### PR TITLE
[manager/data_storage] validate and prune invalid metadata during GetCacheLocation()

### DIFF
--- a/kv_cache_manager/data_storage/data_storage_backend.h
+++ b/kv_cache_manager/data_storage/data_storage_backend.h
@@ -49,6 +49,13 @@ public:
     virtual std::vector<ErrorCode>
     Delete(const std::vector<DataStorageUri> &storage_uris, const std::string &trace_id, std::function<void()> cb) = 0;
     virtual std::vector<bool> Exist(const std::vector<DataStorageUri> &storage_uris) = 0;
+    virtual std::vector<bool> MightExist(const std::vector<DataStorageUri> &storage_uris) {
+        // a low-latency version of Exist()
+        // implementation is required to return ASAP;
+        // or it should rather return false-positive result, e.g.,
+        // all true if low-latency can not be guaranteed
+        return std::vector<bool>(storage_uris.size(), true);
+    }
     virtual std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &storage_uris) = 0;
     virtual std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &storage_uris) = 0;
 

--- a/kv_cache_manager/data_storage/data_storage_manager.cc
+++ b/kv_cache_manager/data_storage/data_storage_manager.cc
@@ -225,7 +225,8 @@ std::vector<ErrorCode> DataStorageManager::Delete(RequestContext *request_contex
 }
 
 std::vector<bool> DataStorageManager::Exist(const std::string &unique_name,
-                                            const std::vector<DataStorageUri> &storage_uris) {
+                                            const std::vector<DataStorageUri> &storage_uris,
+                                            bool fastpath) {
     std::shared_lock<std::shared_mutex> lock(rw_lock_);
     auto iter = storage_map_.find(unique_name);
     if (iter == storage_map_.end()) {
@@ -233,7 +234,7 @@ std::vector<bool> DataStorageManager::Exist(const std::string &unique_name,
         return {};
     }
     auto storage_backend = iter->second;
-    return storage_backend->Exist(storage_uris);
+    return fastpath ? storage_backend->MightExist(storage_uris) : storage_backend->Exist(storage_uris);
 }
 
 std::vector<ErrorCode> DataStorageManager::Lock(const std::string &unique_name,

--- a/kv_cache_manager/data_storage/data_storage_manager.h
+++ b/kv_cache_manager/data_storage/data_storage_manager.h
@@ -46,7 +46,8 @@ public:
                                   const std::string &unique_name,
                                   const std::vector<DataStorageUri> &storage_uris,
                                   std::function<void()> cb);
-    std::vector<bool> Exist(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
+    std::vector<bool>
+    Exist(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris, bool fastpath = false);
     std::vector<ErrorCode> Lock(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
     std::vector<ErrorCode> UnLock(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
 

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -2,11 +2,13 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <set>
 #include <string>
 #include <string_view>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "kv_cache_manager/common/env_util.h"
 #include "kv_cache_manager/common/jsonizable.h"
@@ -17,6 +19,7 @@
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/meta_cache_policy_config.h"
 #include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_uri.h"
 #include "kv_cache_manager/event/event_manager.h"
 #include "kv_cache_manager/event/spec_events/optimizer_event.h"
 #include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
@@ -895,7 +898,49 @@ ErrorCode CacheManager::GenWriteLocation(RequestContext *request_context,
 ErrorCode CacheManager::TryCreateMetaSearcher(RequestContext *request_context, const std::string &instance_id) {
     SPAN_TRACER(request_context);
     const std::string &trace_id = request_context->trace_id();
-    MetaSearcher *meta_searcher = meta_searcher_manager_->TryCreateMetaSearcher(request_context, instance_id);
+
+    auto check_loc_data_exist = [this](const CacheLocation &loc) -> bool {
+        if (!registry_manager_ || !registry_manager_->data_storage_manager()) {
+            return true;
+        }
+
+        std::vector<DataStorageUri> storage_uris;
+        for (const auto &spec : loc.location_specs()) {
+            if (const DataStorageUri uri{spec.uri()}; uri.Valid()) {
+                storage_uris.emplace_back(uri);
+            }
+        }
+
+        if (storage_uris.empty()) {
+            // no uri to check
+            return true;
+        }
+
+        // multiple loc_spec in the same location are assumed to be in
+        // the same storage backend
+        const std::string storage_unique_name = storage_uris.front().GetHostName();
+        const auto result = registry_manager_->data_storage_manager()->Exist(storage_unique_name, storage_uris, true);
+        return std::all_of(result.cbegin(), result.cend(), [](const bool v) -> bool { return v; });
+    };
+
+    auto submit_del_req = [this, instance_id](const std::vector<std::int64_t> &blk_keys,
+                                              const std::vector<std::vector<std::string>> &loc_ids) -> void {
+        CacheLocationDelRequest request;
+        request.instance_id = instance_id;
+        request.delay = std::chrono::seconds(0);
+        request.block_keys = blk_keys;
+        request.location_ids = loc_ids;
+        if (schedule_plan_executor_) {
+            if (schedule_plan_executor_->SubmitNonBlocking(request)) {
+                KVCM_LOG_DEBUG("meta data del request submit OK");
+            } else {
+                KVCM_LOG_WARN("meta data del request submit failed");
+            }
+        }
+    };
+
+    MetaSearcher *meta_searcher = meta_searcher_manager_->TryCreateMetaSearcher(
+        request_context, instance_id, check_loc_data_exist, submit_del_req);
     if (!meta_searcher) {
         RETURN_IF_EC_NOT_OK_WITH_LOG(WARN, EC_ERROR, "create meta searcher failed");
     }

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -47,6 +47,13 @@ bool safe_fetch_sub(std::atomic<std::uint64_t> &atom, const std::uint64_t sub_va
 
 MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer) : meta_indexer_(meta_indexer) {}
 
+MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
+                           CheckLocDataExistFunc check_loc_data_exist,
+                           SubmitDelReqFunc submit_del_req)
+    : meta_indexer_(meta_indexer)
+    , check_loc_data_exist_func_(check_loc_data_exist)
+    , submit_del_req_func_(submit_del_req) {}
+
 MetaSearcher::~MetaSearcher() = default;
 
 std::string MetaSearcher::BatchErrorCodeToStr(const std::vector<std::vector<ErrorCode>> &batch_results) {
@@ -84,6 +91,8 @@ ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_cont
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     int64_t index_deserialize_time_us = 0;
 
+    KeyVector prune_keys;
+    std::vector<std::vector<std::string>> prune_loc_ids_vec;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (result.error_codes[i] != ErrorCode::EC_OK) {
             KVCM_LOG_DEBUG("prefix match end because Get keys[%lu](%lu) return %d", i, keys[i], result.error_codes[i]);
@@ -103,7 +112,13 @@ ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_cont
             KVCM_LOG_DEBUG("prefix match end because keys[%lu](%lu) no location", i, keys[i]);
             break;
         }
-        const CacheLocation *best_location = policy->SelectForMatch(location_map);
+        std::vector<std::string> prune_loc_ids;
+        const CacheLocation *best_location =
+            policy->SelectForMatch(location_map, check_loc_data_exist_func_, prune_loc_ids);
+        if (!prune_loc_ids.empty()) {
+            prune_keys.emplace_back(keys[i]);
+            prune_loc_ids_vec.emplace_back(prune_loc_ids);
+        }
         if (best_location == nullptr) {
             KVCM_LOG_DEBUG("prefix match end because keys[%lu] no serving location", i);
             break;
@@ -113,6 +128,10 @@ ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_cont
 
     KVCM_METRICS_COLLECTOR_SET_METRICS(
         service_metrics_collector, meta_searcher, index_deserialize_time_us, index_deserialize_time_us);
+
+    if (!prune_keys.empty() && submit_del_req_func_) {
+        submit_del_req_func_(prune_keys, prune_loc_ids_vec);
+    }
 
     return EC_OK;
 }
@@ -158,6 +177,8 @@ ErrorCode MetaSearcher::BatchGetBestLocation(RequestContext *request_context,
     auto result = meta_indexer_->Get(request_context, keys, uris);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     int64_t index_deserialize_time_us = 0;
+    KeyVector prune_keys;
+    std::vector<std::vector<std::string>> prune_loc_ids_vec;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (result.error_codes[i] == ErrorCode::EC_NOENT) {
             out_locations.push_back({});
@@ -181,7 +202,13 @@ ErrorCode MetaSearcher::BatchGetBestLocation(RequestContext *request_context,
             out_locations.push_back({});
             continue;
         }
-        const CacheLocation *best_location = policy->SelectForMatch(location_map);
+        std::vector<std::string> prune_loc_ids;
+        const CacheLocation *best_location =
+            policy->SelectForMatch(location_map, check_loc_data_exist_func_, prune_loc_ids);
+        if (!prune_loc_ids.empty()) {
+            prune_keys.emplace_back(keys[i]);
+            prune_loc_ids_vec.emplace_back(prune_loc_ids);
+        }
         if (best_location == nullptr) {
             out_locations.push_back({});
             continue;
@@ -190,6 +217,11 @@ ErrorCode MetaSearcher::BatchGetBestLocation(RequestContext *request_context,
     }
     KVCM_METRICS_COLLECTOR_SET_METRICS(
         service_metrics_collector, meta_searcher, index_deserialize_time_us, index_deserialize_time_us);
+
+    if (!prune_keys.empty() && submit_del_req_func_) {
+        submit_del_req_func_(prune_keys, prune_loc_ids_vec);
+    }
+
     return out_locations.size() == keys.size() ? EC_OK : EC_ERROR;
 }
 
@@ -215,6 +247,8 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
     bool is_match = false;
     std::vector<CacheLocation> temp_sw_locations;
     temp_sw_locations.reserve(sw_size);
+    KeyVector prune_keys;
+    std::vector<std::vector<std::string>> prune_loc_ids_vec;
     for (int base = keys.size() - sw_size; base >= 0;) {
         for (int offset = 0; offset < sw_size; ++offset) {
             if (result.error_codes[base + offset] != ErrorCode::EC_OK) {
@@ -245,7 +279,13 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
                 is_match = false;
                 break;
             }
-            CacheLocation *best_location = policy->SelectForMatch(location_map);
+            std::vector<std::string> prune_loc_ids;
+            CacheLocation *best_location =
+                policy->SelectForMatch(location_map, check_loc_data_exist_func_, prune_loc_ids);
+            if (!prune_loc_ids.empty()) {
+                prune_keys.emplace_back(keys[base + offset]);
+                prune_loc_ids_vec.emplace_back(prune_loc_ids);
+            }
             if (best_location == nullptr) {
                 temp_sw_locations.clear();
                 base -= sw_size - offset;
@@ -261,6 +301,11 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
     }
     KVCM_METRICS_COLLECTOR_SET_METRICS(
         service_metrics_collector, meta_searcher, index_deserialize_time_us, index_deserialize_time_us);
+
+    if (!prune_keys.empty() && submit_del_req_func_) {
+        submit_del_req_func_(prune_keys, prune_loc_ids_vec);
+    }
+
     return EC_OK;
 }
 

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -10,6 +10,10 @@
 #include "kv_cache_manager/manager/select_location_policy.h"
 
 namespace kv_cache_manager {
+
+using SubmitDelReqFunc = std::function<void(const std::vector<std::int64_t> &blk_keys,
+                                            const std::vector<std::vector<std::string>> &loc_ids)>;
+
 class MetaIndexer;
 
 class MetaSearcher {
@@ -21,6 +25,9 @@ public:
     static const std::string PROPERTY_PREV_BLOCK_KEY;
 
     explicit MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_manager);
+    MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
+                 CheckLocDataExistFunc check_loc_data_exist,
+                 SubmitDelReqFunc submit_del_req);
     ~MetaSearcher();
 
     static std::string BatchErrorCodeToStr(const std::vector<std::vector<ErrorCode>> &batch_results);
@@ -96,6 +103,8 @@ private:
                                           SelectLocationPolicy *policy) const;
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
+    CheckLocDataExistFunc check_loc_data_exist_func_;
+    SubmitDelReqFunc submit_del_req_func_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/meta_searcher_manager.cc
+++ b/kv_cache_manager/manager/meta_searcher_manager.cc
@@ -18,7 +18,9 @@ MetaSearcherManager::MetaSearcherManager(std::shared_ptr<RegistryManager> regist
 MetaSearcherManager::~MetaSearcherManager() = default;
 
 MetaSearcher *MetaSearcherManager::TryCreateMetaSearcher(RequestContext *request_context,
-                                                         const std::string &instance_id) {
+                                                         const std::string &instance_id,
+                                                         CheckLocDataExistFunc check_loc_data_exist,
+                                                         SubmitDelReqFunc submit_del_req) {
     MetaSearcher *meta_searcher = GetMetaSearcher(instance_id);
     if (meta_searcher) {
         return meta_searcher;
@@ -47,7 +49,9 @@ MetaSearcher *MetaSearcherManager::TryCreateMetaSearcher(RequestContext *request
         ec = meta_indexer_manager_->CreateMetaIndexer(instance_id, cache_config->meta_indexer_config());
         if (ec == ErrorCode::EC_OK) {
             if (auto pair = meta_searcher_map_.emplace(
-                    instance_id, std::make_unique<MetaSearcher>(meta_indexer_manager_->GetMetaIndexer(instance_id)));
+                    instance_id,
+                    std::make_unique<MetaSearcher>(
+                        meta_indexer_manager_->GetMetaIndexer(instance_id), check_loc_data_exist, submit_del_req));
                 pair.second) {
                 return pair.first->second.get();
             }

--- a/kv_cache_manager/manager/meta_searcher_manager.h
+++ b/kv_cache_manager/manager/meta_searcher_manager.h
@@ -17,7 +17,10 @@ public:
     MetaSearcherManager(std::shared_ptr<RegistryManager> registry_manager,
                         std::shared_ptr<MetaIndexerManager> meta_indexer_manager);
     ~MetaSearcherManager();
-    MetaSearcher *TryCreateMetaSearcher(RequestContext *request_context, const std::string &instance_id);
+    MetaSearcher *TryCreateMetaSearcher(RequestContext *request_context,
+                                        const std::string &instance_id,
+                                        CheckLocDataExistFunc check_loc_data_exist,
+                                        SubmitDelReqFunc submit_del_req);
     MetaSearcher *GetMetaSearcher(const std::string &instance_id) const;
     void DoCleanup();
 

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -16,10 +16,10 @@
 
 namespace kv_cache_manager {
 
-#define DEFINE_METRICS_NAME_FOR_SCHEDULE_PLAN_EXECUTOR(name) \
+#define DEFINE_METRICS_NAME_FOR_SCHEDULE_PLAN_EXECUTOR(name)                                                           \
     DEFINE_METRICS_NAME_(SchedulePlanExecutor, schedule_plan_executor, name)
 
-#define REGISTER_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(name) \
+#define REGISTER_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(name)                                                              \
     REGISTER_METRICS_COUNTER_(metrics_registry_, schedule_plan_executor, name)
 
 namespace {
@@ -449,6 +449,14 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
     }
 
     return future;
+}
+
+bool SchedulePlanExecutor::SubmitNonBlocking(const CacheMetaDelRequest &req) {
+    return SubmitRaw([this, req]() { Submit(req); }, std::chrono::microseconds{0});
+}
+
+bool SchedulePlanExecutor::SubmitNonBlocking(const CacheLocationDelRequest &req) {
+    return SubmitRaw([this, req]() { Submit(req); }, std::chrono::microseconds{0});
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -73,6 +73,9 @@ public:
     std::future<PlanExecuteResult> Submit(const CacheMetaDelRequest &task);
     std::future<PlanExecuteResult> Submit(const CacheLocationDelRequest &task);
 
+    bool SubmitNonBlocking(const CacheMetaDelRequest &req);
+    bool SubmitNonBlocking(const CacheLocationDelRequest &req);
+
 private:
     std::shared_ptr<MetaIndexerManager> meta_manager_;
     std::shared_ptr<DataStorageManager> data_storage_manager_;

--- a/kv_cache_manager/manager/select_location_policy.cc
+++ b/kv_cache_manager/manager/select_location_policy.cc
@@ -1,18 +1,26 @@
 #include "select_location_policy.h"
 
 #include <random>
+#include <string>
 #include <vector>
 
 namespace kv_cache_manager {
 
-CacheLocation *WeightSLPolicy::SelectForMatch(CacheLocationMap &location_map) const {
+CacheLocation *WeightSLPolicy::SelectForMatch(CacheLocationMap &location_map,
+                                              CheckLocDataExistFunc check_loc_data_exist,
+                                              std::vector<std::string> &out_prune_loc_ids) const {
     thread_local std::mt19937 rng(std::random_device{}());
     std::vector<CacheLocation *> serving_locations;
     std::vector<uint32_t> weights;
     serving_locations.reserve(location_map.size());
     weights.reserve(location_map.size());
+    out_prune_loc_ids.clear();
     for (auto &kv : location_map) {
         if (kv.second.status() == CacheLocationStatus::CLS_SERVING) {
+            if (check_loc_data_exist && !check_loc_data_exist(kv.second)) {
+                out_prune_loc_ids.emplace_back(kv.first);
+                continue;
+            }
             if (int32_t weight = GetWeight(kv); weight > 0) {
                 serving_locations.push_back(&kv.second);
                 weights.push_back(weight);

--- a/kv_cache_manager/manager/select_location_policy.h
+++ b/kv_cache_manager/manager/select_location_policy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <map>
 #include <string>
 
@@ -8,10 +9,14 @@
 
 namespace kv_cache_manager {
 
+using CheckLocDataExistFunc = std::function<bool(const CacheLocation &loc)>;
+
 class SelectLocationPolicy {
 public:
     // for match : select best location
-    virtual CacheLocation *SelectForMatch(CacheLocationMap &location_map) const = 0;
+    virtual CacheLocation *SelectForMatch(CacheLocationMap &location_map,
+                                          CheckLocDataExistFunc check_loc_data_exist,
+                                          std::vector<std::string> &out_prune_loc_ids) const = 0;
     // for write : return true if exists means that not need write again
     virtual bool ExistsForWrite(const CacheLocationMap &location_map) const = 0;
     virtual ~SelectLocationPolicy() = default;
@@ -19,7 +24,9 @@ public:
 
 class WeightSLPolicy : public SelectLocationPolicy {
 public:
-    CacheLocation *SelectForMatch(CacheLocationMap &location_map) const override;
+    CacheLocation *SelectForMatch(CacheLocationMap &location_map,
+                                  CheckLocDataExistFunc check_loc_data_exist,
+                                  std::vector<std::string> &out_prune_loc_ids) const override;
     bool ExistsForWrite(const CacheLocationMap &location_map) const override;
 
 protected:

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -153,3 +153,18 @@ cc_test(
         "//kv_cache_manager/manager:select_location_policy",
     ],
 )
+
+cc_test(
+    name = "ReclaimerTaskSupervisorTest",
+    srcs = [
+        "reclaimer_task_supervisor_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    linkstatic = True,
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/manager:reclaimer_task_supervisor",
+        "@cpp_stub",
+    ],
+)

--- a/kv_cache_manager/manager/test/meta_searcher_manager_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_manager_test.cc
@@ -14,7 +14,14 @@
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
-namespace kv_cache_manager {
+using namespace kv_cache_manager;
+
+namespace {
+
+CheckLocDataExistFunc dummy_check_loc_data_exist = [](const CacheLocation &) -> bool { return true; };
+SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
+                                           const std::vector<std::vector<std::string>> &) -> void {};
+} // namespace
 
 class MetaSearcherManagerTest : public TESTBASE {
 public:
@@ -51,8 +58,8 @@ TEST_F(MetaSearcherManagerTest, TestMultiThreadCreate) {
     auto thread_fcn = [this, &searcher, &go]() {
         while (!go.load(std::memory_order_relaxed)) {}
         std::shared_ptr<RequestContext> request_context(new RequestContext("test_trace_id"));
-        MetaSearcher *real =
-            this->meta_searcher_manager_->TryCreateMetaSearcher(request_context.get(), "test_instance");
+        MetaSearcher *real = this->meta_searcher_manager_->TryCreateMetaSearcher(
+            request_context.get(), "test_instance", dummy_check_loc_data_exist, dummy_submit_del_req);
         MetaSearcher *expected = nullptr;
         if (!searcher.compare_exchange_strong(expected, real, std::memory_order_acq_rel)) {
             ASSERT_EQ(searcher.load(std::memory_order_relaxed), real);
@@ -77,7 +84,8 @@ TEST_F(MetaSearcherManagerTest, TestMultiThreadCreate) {
 TEST_F(MetaSearcherManagerTest, TestDoCleanup) {
     // 1. 创建 MetaSearcher
     std::shared_ptr<RequestContext> request_context(new RequestContext("test_trace_id"));
-    MetaSearcher *searcher = meta_searcher_manager_->TryCreateMetaSearcher(request_context.get(), "test_instance");
+    MetaSearcher *searcher = meta_searcher_manager_->TryCreateMetaSearcher(
+        request_context.get(), "test_instance", dummy_check_loc_data_exist, dummy_submit_del_req);
     ASSERT_NE(searcher, nullptr);
 
     // 验证可以获取到创建的 MetaSearcher
@@ -98,12 +106,11 @@ TEST_F(MetaSearcherManagerTest, TestDoCleanup) {
     meta_searcher_manager_->meta_indexer_manager_->DoCleanup();
 
     // 6. 重新创建 MetaSearcher
-    MetaSearcher *new_searcher = meta_searcher_manager_->TryCreateMetaSearcher(request_context.get(), "test_instance");
+    MetaSearcher *new_searcher = meta_searcher_manager_->TryCreateMetaSearcher(
+        request_context.get(), "test_instance", dummy_check_loc_data_exist, dummy_submit_del_req);
     ASSERT_NE(new_searcher, nullptr);
 
     // 7. 验证可以获取到新创建的 MetaSearcher
     retrieved_searcher = meta_searcher_manager_->GetMetaSearcher("test_instance");
     ASSERT_EQ(retrieved_searcher, new_searcher);
 }
-
-} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
@@ -27,13 +27,18 @@ public:
         return {spec};
     }
 };
+
+CheckLocDataExistFunc dummy_check_loc_data_exist = [](const CacheLocation &) -> bool { return true; };
+SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
+                                           const std::vector<std::vector<std::string>> &) -> void {};
 } // namespace
 
 class MetaSearcherRealServiceTest : public TESTBASE {
 public:
     void SetUp() override {
         meta_indexer_ = CreateMetaIndexer();
-        meta_searcher_ = std::make_shared<MetaSearcher>(meta_indexer_);
+        meta_searcher_ =
+            std::make_shared<MetaSearcher>(meta_indexer_, dummy_check_loc_data_exist, dummy_submit_del_req);
         request_context_.reset(new RequestContext("fake_trace_id"));
     }
 

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -29,13 +29,18 @@ public:
         return {spec};
     }
 };
+
+CheckLocDataExistFunc dummy_check_loc_data_exist = [](const CacheLocation &) -> bool { return true; };
+SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
+                                           const std::vector<std::vector<std::string>> &) -> void {};
 } // namespace
 
 class MetaSearcherTest : public TESTBASE {
 public:
     void SetUp() override {
         meta_indexer_ = CreateMetaIndexer();
-        meta_searcher_ = std::make_shared<MetaSearcher>(meta_indexer_);
+        meta_searcher_ =
+            std::make_shared<MetaSearcher>(meta_indexer_, dummy_check_loc_data_exist, dummy_submit_del_req);
         request_context_ = std::make_shared<RequestContext>("test_trace_id");
     }
 

--- a/kv_cache_manager/manager/test/reclaimer_task_supervisor_test.cc
+++ b/kv_cache_manager/manager/test/reclaimer_task_supervisor_test.cc
@@ -1,0 +1,102 @@
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/manager/reclaimer_task_supervisor.h"
+#include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/meta/meta_indexer_manager.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "stub.h"
+
+using namespace kv_cache_manager;
+
+namespace {
+
+using spe_submit_blk = std::future<PlanExecuteResult> (SchedulePlanExecutor::*)(const CacheMetaDelRequest &);
+using spe_submit_loc = std::future<PlanExecuteResult> (SchedulePlanExecutor::*)(const CacheLocationDelRequest &);
+
+PlanExecuteResult blk_del_result;
+std::mutex blk_del_reqs_mut;
+std::condition_variable blk_del_reqs_cv; // condition being not empty of submitted_blk_del_reqs
+std::vector<CacheMetaDelRequest> submitted_blk_del_reqs;
+
+std::future<PlanExecuteResult> SchedulePlanExecutor_Submit_blk_stub(void *obj, const CacheMetaDelRequest &req) {
+    const auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    {
+        std::lock_guard<std::mutex> lock{blk_del_reqs_mut};
+        submitted_blk_del_reqs.emplace_back(req);
+        blk_del_reqs_cv.notify_one();
+    }
+    promise->set_value(blk_del_result);
+    return promise->get_future();
+}
+
+PlanExecuteResult loc_del_result;
+std::mutex loc_del_reqs_mut;
+std::condition_variable loc_del_reqs_cv; // condition being not empty of submitted_loc_del_reqs
+std::vector<CacheLocationDelRequest> submitted_loc_del_reqs;
+
+std::future<PlanExecuteResult> SchedulePlanExecutor_Submit_loc_stub(void *obj, const CacheLocationDelRequest &req) {
+    const auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    {
+        std::lock_guard<std::mutex> lock{loc_del_reqs_mut};
+        submitted_loc_del_reqs.emplace_back(req);
+        loc_del_reqs_cv.notify_one();
+    }
+    promise->set_value(loc_del_result);
+    return promise->get_future();
+}
+
+} // namespace
+
+class ReclaimerTaskSupervisorTest : public TESTBASE {
+public:
+    void SetUp() override {
+        stub_.set(static_cast<spe_submit_blk>(ADDR(SchedulePlanExecutor, Submit)),
+                  SchedulePlanExecutor_Submit_blk_stub);
+        stub_.set(static_cast<spe_submit_loc>(ADDR(SchedulePlanExecutor, Submit)),
+                  SchedulePlanExecutor_Submit_loc_stub);
+
+        blk_del_result = {ErrorCode::EC_OK, ""};
+        loc_del_result = {ErrorCode::EC_OK, ""};
+
+        auto mr = std::make_shared<MetricsRegistry>();
+        auto mim = std::make_shared<MetaIndexerManager>();
+        auto dsm = std::make_shared<DataStorageManager>(mr);
+        auto spe = std::make_shared<SchedulePlanExecutor>(0, mim, dsm, mr);
+        task_supervisor_ = std::make_unique<ReclaimerTaskSupervisor>(spe);
+        task_supervisor_->Start();
+    }
+
+    void TearDown() override {
+        submitted_blk_del_reqs.clear();
+        submitted_loc_del_reqs.clear();
+    }
+
+    Stub stub_;
+    std::unique_ptr<ReclaimerTaskSupervisor> task_supervisor_;
+};
+
+TEST_F(ReclaimerTaskSupervisorTest, TestCacheMetaDelRequest) {
+    CacheMetaDelRequest req;
+    task_supervisor_->Submit("foo", std::move(req));
+    {
+        std::unique_lock<std::mutex> lock{blk_del_reqs_mut};
+        blk_del_reqs_cv.wait_for(lock, std::chrono::milliseconds(8000));
+        ASSERT_FALSE(submitted_blk_del_reqs.empty());
+    }
+}
+
+TEST_F(ReclaimerTaskSupervisorTest, TestCacheLocDelRequest) {
+    CacheLocationDelRequest req;
+    task_supervisor_->Submit("foo", std::move(req));
+    {
+        std::unique_lock<std::mutex> lock{loc_del_reqs_mut};
+        loc_del_reqs_cv.wait_for(lock, std::chrono::milliseconds(8000));
+        ASSERT_FALSE(submitted_loc_del_reqs.empty());
+    }
+}

--- a/kv_cache_manager/manager/test/selection_location_policy_test.cc
+++ b/kv_cache_manager/manager/test/selection_location_policy_test.cc
@@ -11,6 +11,9 @@ using namespace kv_cache_manager;
 #define D_MEMPOOL DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL
 #define D_UNKNOWN DataStorageType::DATA_STORAGE_TYPE_UNKNOWN
 
+static CheckLocDataExistFunc dummy_check_loc_data_exist = [](const CacheLocation &) -> bool { return true; };
+static std::vector<std::string> dummy_loc_ids;
+
 class SelectLocationPolicyTest : public TESTBASE {
 public:
     struct FakeLocationMeta {
@@ -47,7 +50,7 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatch) {
         auto location_map = GenLocationMap(
             {{CLS_SERVING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_MEMPOOL, D_3FS, D_NFS));
         }
     }
@@ -55,7 +58,7 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatch) {
         auto location_map = GenLocationMap(
             {{CLS_WRITING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
         }
     }
@@ -65,7 +68,7 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatch) {
                                             {CLS_SERVING, D_3FS, "3fs_02"},
                                             {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(),
                         AnyOf(HasSubstr("3fs_01"), HasSubstr("3fs_02"), HasSubstr("nfs_01")));
@@ -112,7 +115,7 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatch) {
         auto location_map = GenLocationMap(
             {{CLS_SERVING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_MEMPOOL, D_3FS));
         }
     }
@@ -122,7 +125,7 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatch) {
                                             {CLS_SERVING, D_MOONCAKE, "mooncake_01"},
                                             {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_MOONCAKE));
         }
     }
@@ -134,7 +137,7 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatch) {
                                             {CLS_SERVING, D_NFS, "nfs_01"},
                                             {CLS_SERVING, D_NFS, "nfs_02"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_MOONCAKE));
             ASSERT_THAT(location->location_specs().front().uri(),
                         AnyOf(HasSubstr("3fs_01"), HasSubstr("mooncake_01"), HasSubstr("mooncake_02")));
@@ -184,7 +187,7 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatch)
         auto location_map = GenLocationMap(
             {{CLS_SERVING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_MEMPOOL, D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(),
                         AnyOf(HasSubstr("pace_01"), HasSubstr("3fs_01"), HasSubstr("nfs_01")));
@@ -194,7 +197,7 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatch)
         auto location_map = GenLocationMap(
             {{CLS_WRITING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(), AnyOf(HasSubstr("3fs_01"), HasSubstr("nfs_01")));
         }
@@ -205,7 +208,7 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatch)
                                             {CLS_SERVING, D_3FS, "3fs_02"},
                                             {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map);
+            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(), AnyOf(HasSubstr("3fs_01"), HasSubstr("nfs_01")));
         }


### PR DESCRIPTION
Introducing the Exist2() fastpath interface.

Validate the location metadata using Exist2() and eliminate invalid one during GetCacheLocation() call.