### PR TITLE
fix libibverbs and librdmacm search path and refine docker build related docs

### DIFF
--- a/3rdparty/mooncake/mooncake.BUILD
+++ b/3rdparty/mooncake/mooncake.BUILD
@@ -175,6 +175,7 @@ cc_library(
     }),
     linkopts = [
         "-L/usr/local/lib64/",
+        "-L/usr/lib64/",
         "-libverbs",
         "-lrdmacm",
     ] + select({

--- a/3rdparty/tair_mempool/tair_mempool.BUILD
+++ b/3rdparty/tair_mempool/tair_mempool.BUILD
@@ -74,6 +74,7 @@ cc_library(
     name = "tair_mempool",
     linkopts = [
         "-L/usr/local/lib64/",
+        "-L/usr/lib64/",
         "-libverbs",
         "-lrdmacm",
     ] + select({

--- a/open_source/docker/README.md
+++ b/open_source/docker/README.md
@@ -1,20 +1,23 @@
-# Docker 镜像构建说明
+# Docker镜像构建说明
 
-## 开发镜像 (Dockerfile.dev)
+## 开发镜像（Dockerfile.dev）
 
-开发镜像用于构建和开发环境。
+开发镜像用于Tair KVCache Manager的构建和开发环境。
 
 ### 构建命令
+
 ```bash
 # 构建开发镜像
 docker build -f Dockerfile.dev -t kv_cache_manager_dev:latest .
 ```
 
+### 基于已有推理引擎开发镜像构建通用开发镜像（Manager+Connector）
 
-### 基于已有推理引擎开发镜像构建通用开发镜像(Manager+Connector)
-参考open_source/docker/Dockerfile.dev补充相关依赖即可。具体请结合推理引擎镜像的实际情况
+通用开发镜像用于推理引擎（vllm/sglang） + Tair KVCache Manager + Tair KVCache Manager Connector的构建和开发环境。
+参考 `open_source/docker/Dockerfile.dev` 补充相关依赖即可。
+具体请结合推理引擎镜像的实际情况。
 
-<details> 
+<details>
 
 <summary>示例Dockerfile</summary>
 
@@ -40,7 +43,7 @@ RUN apt-get update && \
     # RDMA相关依赖
     librdmacm-dev libibverbs-dev libnuma-dev \
     # 构建工具
-    cpio patchelf libaio-dev pigz \
+    cpio rpm2cpio patchelf libaio-dev pigz \
     # Python开发环境（Ubuntu 22.04默认使用Python 3.10）
     python3 python3-pip python3-dev \
     # 代码格式化工具
@@ -58,7 +61,7 @@ RUN apt-get update && \
 #     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 # 配置Python包源并安装Python工具
-RUN pip3 config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple && \
+RUN pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/ && \
     pip3 install autopep8
 
 # 安装Bazelisk和Buildifier
@@ -69,10 +72,12 @@ RUN wget "$BAZELISK_URL" -O /usr/local/bin/bazelisk && chmod a+x /usr/local/bin/
 # 如果是sglang容器，需要移除冲突的jsoncpp库
 # RUN apt-get remove -y libjsoncpp-dev
 ```
+
 </details>
 
 如果只需要在现有Ubuntu推理容器中补充依赖，可以使用以下命令：
-<details> 
+
+<details>
 
 <summary>快速依赖补充脚本</summary>
 
@@ -81,22 +86,23 @@ RUN wget "$BAZELISK_URL" -O /usr/local/bin/bazelisk && chmod a+x /usr/local/bin/
 apt-get update && \
 apt-get install -y --no-install-recommends \
     librdmacm-dev libibverbs-dev libnuma-dev \
-    cpio patchelf libaio-dev pigz \
+    cpio rpm2cpio patchelf libaio-dev pigz \
     python3 python3-pip python3-dev \
     clang-format libicu-dev
 
 # 安装Python工具和Bazel
-pip3 config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple && \
-pip3 install autopep8 && \
-wget "https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64" -O /usr/local/bin/bazelisk && \
-chmod a+x /usr/local/bin/bazelisk && \
-BAZELISK_BASE_URL=https://mirrors.huaweicloud.com/bazel/ USE_BAZEL_VERSION=6.4.0 bazelisk && \
-wget "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-linux-amd64" -O /usr/local/bin/buildifier && \
-chmod a+x /usr/local/bin/buildifier
+pip3 config set global.index-url https://mirrors.aliyun.com/pypi/simple/ && \
+    pip3 install autopep8 && \
+    wget "https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64" -O /usr/local/bin/bazelisk && \
+    chmod a+x /usr/local/bin/bazelisk && \
+    BAZELISK_BASE_URL=https://mirrors.huaweicloud.com/bazel/ USE_BAZEL_VERSION=6.4.0 bazelisk && \
+    wget "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-linux-amd64" -O /usr/local/bin/buildifier && \
+    chmod a+x /usr/local/bin/buildifier
 
 #（仅sglang需要执行下一条）
 apt-get remove -y libjsoncpp-dev # sglang容器内jsoncpp的和KVCM自带的有冲突
 ```
+
 </details>
 
 ## 生产镜像 (Dockerfile.prod)
@@ -117,35 +123,41 @@ docker build -f Dockerfile.prod \
 ```
 
 ### 运行容器
+
 ```bash
 # 运行生产容器
 docker run -d --name kv_cache_manager \
-  -p 6381:6381 -p 6382:6382 -p 6491:6491 -p 6492:6492 \  
-  kv_cache_manager_prod:latest
+    -p 6381:6381 -p 6382:6382 -p 6491:6491 -p 6492:6492 \
+    kv_cache_manager_prod:latest
 
 # 设置启动参数。可配置参数请参考docs/configuration.md
 docker run -d --name kv_cache_manager \
-  -p 3000:3000 -p 6382:6382 -p 6491:6491 -p 6492:6492 \
-  -e kvcm.service.rpc_port=3000 \
-  kv_cache_manager_prod:latest
+    -p 3000:3000 -p 6382:6382 -p 6491:6491 -p 6492:6492 \
+    -e kvcm.service.rpc_port=3000 \
+    kv_cache_manager_prod:latest
 ```
+
 注意对于NFS和HF3FS等KVCache存储后端，可能需要将文件系统中的相关目录挂载到容器中。
 具体请参照存储后端配置要求。
 
 ### 默认端口说明
+
 - 6381: MetaService gRPC 端口
 - 6491: AdminService gRPC 端口
 - 6382: MetaService HTTP 端口
-- 6492: AdminService HTTP 端口  
+- 6492: AdminService HTTP 端口
 
+## 推理容器（Dockerfile.vllm/sglang）
 
-## 推理容器 (Dockerfile.vllm&sglang)
 推理容器镜像用于部署推理服务。
+
 ### 构建命令
+
 基于已有推理容器镜像，构造包含Tair KVCache Manager Connector的推理容器镜像。
+
 ```bash
 # 需要先构建wheel包，建议使用上述基于推理引擎开发镜像构建的通用开发镜像作为构建环境。
-bazelisk build //kv_cache_manager/py_connector/vllm:kvcm_vllm_connector_wheel --config=client_with_cuda
+bazelisk build //kv_cache_manager/py_connector/vllm:kvcm_vllm_connector_wheel
 # 如果需要指定编译器和CUDA架构要求等可以添加相关编译参数
 # --action_env=CC=gcc-11 --action_env=CXX=g++-11 --@rules_cuda//cuda:archs="compute_75:sm_75;compute_80:sm_80;compute_86:sm_86;compute_89:sm_89;compute_90:sm_90,compute_90"
 cp bazel-bin/kv_cache_manager/py_connector/vllm/*.whl ./


### PR DESCRIPTION
```
    [build] fix libibverbs and librdmacm search path
    
    This issue happens during linking stage on some ubuntu env.

    [doc] refine docker build related README.md
    
    A side-note about the PyPI mirror URL update:
    The tsinghua source would cause a package install issue on Ubuntu env.
    Switching to the aliyun source resolves the issue.
```