### PR TITLE
[service/config/integration_test] enhance error handling and logging in meta and admin services

### DIFF
--- a/integration_test/admin_service/admin_interface_cases.py
+++ b/integration_test/admin_service/admin_interface_cases.py
@@ -410,6 +410,77 @@ class AdminServiceTestBase(abc.ABC, TestBase, unittest.TestCase):
         # 如果更新成功，新的延迟应该生效；否则保持原样
         # 我们只是记录而不做硬性断言，因为更新可能需要特定权限
         logging.info(f"Original delay: {original_delay}, current delay: {get_resp2['campaign_delay_time_ms']}")
+    def test_register_and_remove_instance_error_details(self):
+        """Verify error details for various register/remove instance error scenarios."""
+        # --- Part 1: invalid block_size ---
+        ig = self.make_sample_instance_group()
+        create_req = {"trace_id": self._trace_id, "instance_group": ig}
+        self._client.create_instance_group(create_req)
+
+        reg_req = self.make_sample_register_instance_request()
+        reg_req["block_size"] = 0
+        resp = self._client.register_instance(reg_req, check_response=False)
+        status = resp["header"]["status"]
+        self.assertEqual(status["code"], "INVALID_ARGUMENT",
+                         f"Expected INVALID_ARGUMENT for block_size=0, got {status['code']}: {status.get('message', '')}")
+        self.assertIn("block_size", status.get("message", "").lower(),
+                       "Error message should mention block_size")
+
+        # --- Part 2: group not found ---
+        non_existent_group = "totally_nonexistent_admin_group"
+        reg_req = self.make_sample_register_instance_request()
+        reg_req["instance_group"] = non_existent_group
+        reg_req["instance_id"] = "instance_no_group_admin"
+        resp = self._client.register_instance(reg_req, check_response=False)
+        status = resp["header"]["status"]
+        self.assertNotEqual(status["code"], "OK",
+                            "Registering with non-existent group should fail")
+        msg = status.get("message", "")
+        self.assertIn(non_existent_group, msg,
+                       f"Error message should contain group name '{non_existent_group}', got: {msg}")
+
+        # --- Part 3: duplicate with different model_deployment ---
+        reg_req = self.make_sample_register_instance_request()
+        self._client.register_instance(reg_req)
+
+        dup_req = self.make_sample_register_instance_request()
+        dup_req["model_deployment"]["model_name"] = "completely_different_model"
+        resp = self._client.register_instance(dup_req, check_response=False)
+        status = resp["header"]["status"]
+        self.assertEqual(status["code"], "DUPLICATE_ENTITY",
+                         f"Expected DUPLICATE_ENTITY, got {status['code']}: {status.get('message', '')}")
+        msg = status.get("message", "")
+        self.assertIn(reg_req["instance_id"], msg,
+                       f"Error message should contain instance_id, got: {msg}")
+        self.assertIn("model_deployment", msg,
+                       f"Error message should mention mismatched field 'model_deployment', got: {msg}")
+
+        # --- Part 4: duplicate with different block_size ---
+        dup_req = self.make_sample_register_instance_request()
+        dup_req["block_size"] = 256
+        resp = self._client.register_instance(dup_req, check_response=False)
+        status = resp["header"]["status"]
+        self.assertEqual(status["code"], "DUPLICATE_ENTITY",
+                         f"Expected DUPLICATE_ENTITY, got {status['code']}: {status.get('message', '')}")
+        msg = status.get("message", "")
+        self.assertIn("block_size", msg,
+                       f"Error message should mention mismatched field 'block_size', got: {msg}")
+
+        # --- Part 5: remove non-existent instance ---
+        remove_req = {
+            "trace_id": self._trace_id,
+            "instance_id": "nonexistent_instance_for_remove"
+        }
+        resp = self._client.remove_instance(remove_req, check_response=False)
+        status = resp["header"]["status"]
+        self.assertNotEqual(status["code"], "OK",
+                            "Removing non-existent instance should fail")
+        self.assertNotEqual(status["code"], "INTERNAL_ERROR",
+                            f"Expected a specific error code (not INTERNAL_ERROR) for non-existent instance, got: {status}")
+        msg = status.get("message", "")
+        self.assertIn("nonexistent_instance_for_remove", msg,
+                       f"Error message should contain the instance_id, got: {msg}")
+
     def test_leader_demote(self):
         """测试 LeaderDemote 接口"""
         req = {"trace_id": self._trace_id}

--- a/integration_test/client_test/client_test_base.h
+++ b/integration_test/client_test/client_test_base.h
@@ -96,6 +96,86 @@ protected:
         return client;
     }
 
+    // Create a client with a custom instance_group for error-path testing
+    std::string createClientConfigWithGroup(const std::string &instance_id,
+                                            const std::string &instance_group,
+                                            int block_size = 128) const {
+        std::array<char, 2048> buffer;
+        int n = std::snprintf(buffer.data(),
+                              buffer.size(),
+                              R"({
+"instance_group": "%s",
+"instance_id": "%s",
+"address": [
+    "127.0.0.1:%d"
+],
+"block_size": %d,
+"location_spec_infos":{
+    "tp0": 1024,
+    "tp1": 1024
+},
+"meta_channel_config": {
+    "call_timeout": 1000
+},
+"sdk_config": {},
+"model_deployment": {
+    "model_name": "test_model",
+    "dtype": "FP8",
+    "use_mla": false,
+    "tp_size": 2,
+    "dp_size": 1,
+    "pp_size": 1,
+    "pp_infos": [
+        "layer0"
+    ]
+}
+})",
+                              instance_group.c_str(),
+                              instance_id.c_str(),
+                              controller_.rpc_port(),
+                              block_size);
+        return std::string(buffer.data(), n);
+    }
+
+    // Create a client with a different model_name (for duplicate-with-diff-config testing)
+    std::string createClientConfigWithModel(const std::string &instance_id,
+                                            const std::string &model_name) const {
+        std::array<char, 2048> buffer;
+        int n = std::snprintf(buffer.data(),
+                              buffer.size(),
+                              R"({
+"instance_group": "default",
+"instance_id": "%s",
+"address": [
+    "127.0.0.1:%d"
+],
+"block_size": 128,
+"location_spec_infos":{
+    "tp0": 1024,
+    "tp1": 1024
+},
+"meta_channel_config": {
+    "call_timeout": 1000
+},
+"sdk_config": {},
+"model_deployment": {
+    "model_name": "%s",
+    "dtype": "FP8",
+    "use_mla": false,
+    "tp_size": 2,
+    "dp_size": 1,
+    "pp_size": 1,
+    "pp_infos": [
+        "layer0"
+    ]
+}
+})",
+                              instance_id.c_str(),
+                              controller_.rpc_port(),
+                              model_name.c_str());
+        return std::string(buffer.data(), n);
+    }
+
     template <typename ClientType>
     void TestStartWrite(const std::string &prefix, const ClientPtr<ClientType> &client) {
         {

--- a/integration_test/client_test/manager_client_test.cc
+++ b/integration_test/client_test/manager_client_test.cc
@@ -135,3 +135,38 @@ TEST_F(ManagerClientTest, TestSaveAndLoad) {
         // ASSERT_TRUE(read_result.first);
     }
 }
+
+// --- Error detail tests for the latest commit ---
+
+TEST_F(ManagerClientTest, TestRegisterInstanceErrorDetails) {
+    auto prefix = GetCurrentTestName();
+
+    // Part 1: duplicate instance with different model_deployment
+    {
+        std::string instance_id = prefix + "_dup_instance";
+
+        // First registration with model "test_model"
+        {
+            auto config = createClientConfigWithModel(instance_id, "test_model");
+            auto client = ManagerClient::Create(config, init_params_);
+            ASSERT_NE(nullptr, client.get());
+        }
+
+        // Second registration with a different model name
+        {
+            auto config = createClientConfigWithModel(instance_id, "different_model");
+            auto client = ManagerClient::Create(config, init_params_);
+            EXPECT_EQ(nullptr, client.get())
+                << "Re-registration with different model should fail during client creation";
+        }
+    }
+
+    // Part 2: non-existent instance_group
+    {
+        std::string instance_id = prefix + "_nogroup_instance";
+        auto config = createClientConfigWithGroup(instance_id, "nonexistent_group_xyz");
+        auto client = ManagerClient::Create(config, init_params_);
+        EXPECT_EQ(nullptr, client.get())
+            << "Registration with non-existent group should fail during client creation";
+    }
+}

--- a/integration_test/meta_service/meta_interface_cases.py
+++ b/integration_test/meta_service/meta_interface_cases.py
@@ -418,3 +418,117 @@ class MetaServiceTestBase(abc.ABC, TestBase, unittest.TestCase):
         self.assertIsInstance(locations, list)
         self.assertEqual(0, len(locations))
         # With all blocks masked out, we should get an empty list or locations with no valid specs
+
+    def test_register_instance_error_details(self):
+        """Verify error details for various register instance error scenarios."""
+        # --- Part 1: invalid block_size (zero) ---
+        register_data = {
+            "trace_id": self._trace_id,
+            "instance_group": "default",
+            "instance_id": "instance_bad_block_size",
+            "block_size": 0,
+            "model_deployment": self._get_test_model_deployment(),
+            "location_spec_infos": [
+                {"name": "tp0", "size": 1024},
+            ]
+        }
+        response_data = self._client.register_instance(register_data, check_response=False)
+        status = response_data['header']['status']
+        self.assertEqual(status['code'], "INVALID_ARGUMENT",
+                         f"Expected INVALID_ARGUMENT for block_size=0, got {status['code']}: {status.get('message', '')}")
+        self.assertIn("block_size", status.get('message', '').lower(),
+                       "Error message should mention block_size")
+
+        # --- Part 2: invalid block_size (negative) ---
+        register_data = {
+            "trace_id": self._trace_id,
+            "instance_group": "default",
+            "instance_id": "instance_neg_block_size",
+            "block_size": -1,
+            "model_deployment": self._get_test_model_deployment(),
+            "location_spec_infos": [
+                {"name": "tp0", "size": 1024},
+            ]
+        }
+        response_data = self._client.register_instance(register_data, check_response=False)
+        status = response_data['header']['status']
+        self.assertEqual(status['code'], "INVALID_ARGUMENT",
+                         f"Expected INVALID_ARGUMENT for block_size=-1, got {status['code']}: {status.get('message', '')}")
+
+        # --- Part 3: group not found ---
+        non_existent_group = "absolutely_nonexistent_group_xyz"
+        register_data = {
+            "trace_id": self._trace_id,
+            "instance_group": non_existent_group,
+            "instance_id": "instance_no_group",
+            "block_size": 128,
+            "model_deployment": self._get_test_model_deployment(),
+            "location_spec_infos": [
+                {"name": "tp0", "size": 1024},
+            ]
+        }
+        response_data = self._client.register_instance(register_data, check_response=False)
+        status = response_data['header']['status']
+        self.assertNotEqual(status['code'], "OK",
+                            "Registering with non-existent group should fail")
+        msg = status.get('message', '')
+        self.assertIn(non_existent_group, msg,
+                       f"Error message should contain the group name '{non_existent_group}', got: {msg}")
+
+        # --- Part 4: duplicate with different model_deployment ---
+        register_data = {
+            "trace_id": self._trace_id,
+            "instance_group": "default",
+            "instance_id": "instance_dup_test",
+            "block_size": 128,
+            "model_deployment": self._get_test_model_deployment(),
+            "location_spec_infos": [
+                {"name": "tp0", "size": 1024},
+            ]
+        }
+        self._client.register_instance(register_data)
+
+        modified_deployment = self._get_test_model_deployment()
+        modified_deployment["model_name"] = "completely_different_model"
+        dup_data = {
+            "trace_id": self._trace_id,
+            "instance_group": "default",
+            "instance_id": "instance_dup_test",
+            "block_size": 128,
+            "model_deployment": modified_deployment,
+            "location_spec_infos": [
+                {"name": "tp0", "size": 1024},
+            ]
+        }
+        response_data = self._client.register_instance(dup_data, check_response=False)
+        status = response_data['header']['status']
+        self.assertEqual(status['code'], "DUPLICATE_ENTITY",
+                         f"Expected DUPLICATE_ENTITY, got {status['code']}: {status.get('message', '')}")
+        msg = status.get('message', '')
+        self.assertIn("instance_dup_test", msg,
+                       f"Error message should contain instance_id, got: {msg}")
+        self.assertIn("model_deployment", msg,
+                       f"Error message should mention mismatched field 'model_deployment', got: {msg}")
+
+        # --- Part 5: duplicate with different block_size ---
+        register_data = {
+            "trace_id": self._trace_id,
+            "instance_group": "default",
+            "instance_id": "instance_blk_mismatch",
+            "block_size": 128,
+            "model_deployment": self._get_test_model_deployment(),
+            "location_spec_infos": [
+                {"name": "tp0", "size": 1024},
+            ]
+        }
+        self._client.register_instance(register_data)
+
+        dup_data = register_data.copy()
+        dup_data["block_size"] = 256
+        response_data = self._client.register_instance(dup_data, check_response=False)
+        status = response_data['header']['status']
+        self.assertEqual(status['code'], "DUPLICATE_ENTITY",
+                         f"Expected DUPLICATE_ENTITY, got {status['code']}: {status.get('message', '')}")
+        msg = status.get('message', '')
+        self.assertIn("block_size", msg,
+                       f"Error message should mention mismatched field 'block_size', got: {msg}")

--- a/kv_cache_manager/common/error_code.h
+++ b/kv_cache_manager/common/error_code.h
@@ -29,8 +29,7 @@ enum [[nodiscard]] ErrorCode : int32_t{
     EC_KVCM_MAX,
 };
 
-// Convert internal ErrorCode to protobuf ErrorCode (works with proto::meta::ErrorCode,
-// proto::admin::ErrorCode, etc. since all proto ErrorCode enums share the same enum values).
+// Convert internal ErrorCode to protobuf proto::meta::ErrorCode or proto::admin::ErrorCode.
 template <typename PbErrorCode>
 inline PbErrorCode ToPbError(ErrorCode internal_error) {
     static const std::unordered_map<ErrorCode, PbErrorCode> error_map{

--- a/kv_cache_manager/common/error_code.h
+++ b/kv_cache_manager/common/error_code.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 namespace kv_cache_manager {
 
 // TODO 完善错误码，可以表示各个组件的各个细节错误，全局一套
@@ -26,5 +28,27 @@ enum [[nodiscard]] ErrorCode : int32_t{
     EC_UNKNOWN = 127,
     EC_KVCM_MAX,
 };
+
+// Convert internal ErrorCode to protobuf ErrorCode (works with proto::meta::ErrorCode,
+// proto::admin::ErrorCode, etc. since all proto ErrorCode enums share the same enum values).
+template <typename PbErrorCode>
+inline PbErrorCode ToPbError(ErrorCode internal_error) {
+    static const std::unordered_map<ErrorCode, PbErrorCode> error_map{
+        {EC_UNIMPLEMENTED, PbErrorCode::UNSUPPORTED},
+        {EC_BADARGS, PbErrorCode::INVALID_ARGUMENT},
+        {EC_DUPLICATE_ENTITY, PbErrorCode::DUPLICATE_ENTITY},
+        {EC_EXIST, PbErrorCode::DUPLICATE_ENTITY},
+        {EC_INSTANCE_NOT_EXIST, PbErrorCode::INSTANCE_NOT_EXIST},
+        {EC_NOENT, PbErrorCode::INSTANCE_NOT_EXIST},
+        {EC_SERVICE_NOT_LEADER, PbErrorCode::SERVER_NOT_LEADER},
+        {EC_IO_ERROR, PbErrorCode::IO_ERROR},
+        {EC_OUT_OF_LIMIT, PbErrorCode::REACH_MAX_ENTITY_CAPACITY},
+        {EC_UNKNOWN, PbErrorCode::UNKNOWN_ERROR},
+    };
+    if (auto iter = error_map.find(internal_error); iter != error_map.end()) {
+        return iter->second;
+    }
+    return PbErrorCode::INTERNAL_ERROR;
+}
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/config/instance_info.h
+++ b/kv_cache_manager/config/instance_info.h
@@ -159,6 +159,28 @@ public:
         SortLocationSpecGroups();
     }
 
+    // Returns field names that differ from the given values.
+    // Returns empty vector if all fields match.
+    [[nodiscard]] std::vector<std::string> MismatchFields(int32_t block_size,
+                                            const std::vector<LocationSpecInfo> &location_spec_infos,
+                                            const ModelDeployment &model_deployment,
+                                            const std::vector<LocationSpecGroup> &location_spec_groups) const {
+        std::vector<std::string> mismatched;
+        if (block_size_ != block_size) {
+            mismatched.emplace_back("block_size");
+        }
+        if (location_spec_infos_ != location_spec_infos) {
+            mismatched.emplace_back("location_spec_infos");
+        }
+        if (model_deployment_ != model_deployment) {
+            mismatched.emplace_back("model_deployment");
+        }
+        if (location_spec_groups_ != location_spec_groups) {
+            mismatched.emplace_back("location_spec_groups");
+        }
+        return mismatched;
+    }
+
 private:
     void SortLocationSpecGroups();
 

--- a/kv_cache_manager/config/registry_manager.cc
+++ b/kv_cache_manager/config/registry_manager.cc
@@ -5,6 +5,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/config/account.h"
 #include "kv_cache_manager/config/instance_group.h"
 #include "kv_cache_manager/config/instance_info.h"
@@ -301,17 +302,24 @@ ErrorCode RegistryManager::RegisterInstance(RequestContext *request_context,
     std::unique_lock<std::shared_mutex> lock(mutex_);
     auto instance_group_iter = instance_group_configs_.find(instance_group);
     if (instance_group_iter == instance_group_configs_.end()) {
+        request_context->error_tracer()->AddErrorMsg("register instance failed: instance group '" + instance_group +
+                                                     "' not found");
         RETURN_IF_EC_NOT_OK_WITH_LOG_I(
             WARN, EC_NOENT, "register instance failed: instance group not found: %s", instance_group.c_str());
     }
     auto it = instance_infos_.find(instance_id);
     if (it != instance_infos_.end()) {
-        auto exist_instance_info = it->second;
-        if (exist_instance_info->block_size() != block_size ||
-            exist_instance_info->location_spec_infos() != location_spec_infos ||
-            exist_instance_info->model_deployment() != model_deployment ||
-            exist_instance_info->location_spec_groups() != location_spec_groups) {
-            RETURN_IF_EC_NOT_OK_WITH_LOG_I(WARN, EC_DUPLICATE_ENTITY, "register instance failed: duplicate instance");
+        const auto &existing = it->second;
+        auto mismatched = existing->MismatchFields(block_size, location_spec_infos, model_deployment, location_spec_groups);
+        if (!mismatched.empty()) {
+            auto mismatched_str = StringUtil::Join(mismatched, ", ");
+            request_context->error_tracer()->AddErrorMsg(
+                "register instance failed: instance_id '" + instance_id +
+                "' already exists with different configuration, mismatched fields: [" + mismatched_str + "]");
+            RETURN_IF_EC_NOT_OK_WITH_LOG_I(WARN,
+                                           EC_DUPLICATE_ENTITY,
+                                           "register instance failed: duplicate instance, mismatched fields: [%s]",
+                                           mismatched_str.c_str());
         }
         return EC_OK;
     }
@@ -324,9 +332,17 @@ ErrorCode RegistryManager::RegisterInstance(RequestContext *request_context,
                                                         location_spec_groups);
     // save the instance info to storage backend in such a way that one key corresponds to one instance
     auto ec = LoadAndSave(instance_id, instance_id, instance_info.get());
+    if (ec != EC_OK) {
+        request_context->error_tracer()->AddErrorMsg(
+            "register instance failed: failed to persist instance info to storage backend");
+    }
     RETURN_IF_EC_NOT_OK_WITH_LOG_I(WARN, ec, "load and save instance info failed");
     // save the instance_id as value to instance key for recover
     ec = LoadAndSave(kRegistryInstanceKey, instance_id, nullptr);
+    if (ec != EC_OK) {
+        request_context->error_tracer()->AddErrorMsg(
+            "register instance failed: failed to persist instance id to storage backend");
+    }
     RETURN_IF_EC_NOT_OK_WITH_LOG_I(WARN, ec, "load and save instance id failed");
     // TODO: add quota_group_name
     instance_infos_[instance_id] = instance_info;

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -197,11 +197,13 @@ CacheManager::RegisterInstance(RequestContext *request_context,
     const auto &trace_id = request_context->trace_id();
     auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);
     if (instance_info) {
-        if (instance_info->block_size() != block_size || instance_info->location_spec_infos() != location_spec_infos ||
-            instance_info->model_deployment() != model_deployment ||
-            instance_info->location_spec_groups() != location_spec_groups) {
-            PREFIX_LOG(WARN, "register instance failed: duplicate instance");
-            request_context->error_tracer()->AddErrorMsg("register instance failed: duplicate instance");
+        auto mismatched = instance_info->MismatchFields(block_size, location_spec_infos, model_deployment, location_spec_groups);
+        if (!mismatched.empty()) {
+            auto mismatched_str = StringUtil::Join(mismatched, ", ");
+            request_context->error_tracer()->AddErrorMsg(
+                "register instance failed: instance_id '" + instance_id +
+                "' already exists with different configuration, mismatched fields: [" + mismatched_str + "]");
+            PREFIX_LOG(WARN, "register instance failed: duplicate instance, mismatched fields: [%s]", mismatched_str.c_str());
             return {EC_DUPLICATE_ENTITY, {}};
         }
         auto ec = TryCreateMetaSearcher(request_context, instance_id);

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -63,6 +63,12 @@
         return;                                                                                                        \
     } while (0)
 
+namespace {
+kv_cache_manager::proto::admin::ErrorCode ToAdminPbError(kv_cache_manager::ErrorCode ec) {
+    return kv_cache_manager::ToPbError<kv_cache_manager::proto::admin::ErrorCode>(ec);
+}
+} // anonymous namespace
+
 namespace kv_cache_manager {
 
 AdminServiceImpl::AdminServiceImpl(std::shared_ptr<CacheManager> cache_manager,
@@ -466,6 +472,10 @@ void AdminServiceImpl::RegisterInstance(RequestContext *request_context,
     if (request->instance_id().empty()) {
         CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("RegisterInstance", "instance_id", true);
     }
+    if (request->block_size() <= 0) {
+        CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("RegisterInstance", "block_size (must be > 0)", true);
+        return;
+    }
     if (!request->has_model_deployment()) {
         CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("RegisterInstance", "model_deployment", true);
     }
@@ -501,16 +511,25 @@ void AdminServiceImpl::RegisterInstance(RequestContext *request_context,
                                                          model_deployment_req,
                                                          location_spec_groups);
     if (ec_info != EC_OK) {
-        status->set_code(proto::admin::INTERNAL_ERROR);
+        status->set_code(ToAdminPbError(ec_info));
         request_context->set_status_code(status->code());
-        status->set_message("Failed to register instance");
-        KVCM_LOG_ERROR("[traceId: %s] RegisterInstance failed", request->trace_id().c_str());
+        status->set_message("Failed to register instance, instance_group: " + request->instance_group() +
+                            ", instance_id: " + request->instance_id() +
+                            ", error: " + request_context->error_tracer()->ToJsonString());
+        KVCM_LOG_ERROR("[traceId: %s] RegisterInstance failed, instance_group: %s, instance_id: %s, ec: %d",
+                       request->trace_id().c_str(),
+                       request->instance_group().c_str(),
+                       request->instance_id().c_str(),
+                       ec_info);
         return;
     } else {
         status->set_code(proto::admin::OK);
         request_context->set_status_code(status->code());
         status->set_message("Instance registered successfully");
-        KVCM_LOG_INFO("[traceId: %s] RegisterInstance succeeded", request->trace_id().c_str());
+        KVCM_LOG_INFO("[traceId: %s] RegisterInstance succeeded, instance_group: %s, instance_id: %s",
+                      request->trace_id().c_str(),
+                      request->instance_group().c_str(),
+                      request->instance_id().c_str());
     }
 };
 
@@ -527,10 +546,14 @@ void AdminServiceImpl::RemoveInstance(RequestContext *request_context,
     ErrorCode ec_info =
         cache_manager_->RemoveInstance(request_context, request->instance_group(), request->instance_id());
     if (ec_info != EC_OK) {
-        status->set_code(proto::admin::INTERNAL_ERROR);
+        status->set_code(ToAdminPbError(ec_info));
         request_context->set_status_code(status->code());
-        status->set_message("Failed to remove instance");
-        KVCM_LOG_ERROR("[traceId: %s] RemoveInstance failed", request->trace_id().c_str());
+        status->set_message("Failed to remove instance, instance_id: " + request->instance_id() +
+                            ", error: " + request_context->error_tracer()->ToJsonString());
+        KVCM_LOG_ERROR("[traceId: %s] RemoveInstance failed, instance_id: %s, ec: %d",
+                       request->trace_id().c_str(),
+                       request->instance_id().c_str(),
+                       ec_info);
         return;
     } else {
         status->set_code(proto::admin::OK);

--- a/kv_cache_manager/service/meta_service_impl.cc
+++ b/kv_cache_manager/service/meta_service_impl.cc
@@ -90,24 +90,13 @@
         }                                                                                                              \
     } while (0)
 
-namespace kv_cache_manager {
-
 namespace {
-
-inline proto::meta::ErrorCode ToPbError(ErrorCode internal_error) {
-    static const std::unordered_map<ErrorCode, proto::meta::ErrorCode> error_map{
-        {EC_UNIMPLEMENTED, proto::meta::UNSUPPORTED},
-        {EC_BADARGS, proto::meta::INVALID_ARGUMENT},
-        {EC_DUPLICATE_ENTITY, proto::meta::DUPLICATE_ENTITY},
-        {EC_INSTANCE_NOT_EXIST, proto::meta::INSTANCE_NOT_EXIST},
-        {EC_SERVICE_NOT_LEADER, proto::meta::SERVER_NOT_LEADER}};
-    if (auto iter = error_map.find(internal_error); iter != error_map.end()) {
-        return iter->second;
-    }
-    return proto::meta::INTERNAL_ERROR;
+kv_cache_manager::proto::meta::ErrorCode ToMetaPbError(kv_cache_manager::ErrorCode ec) {
+    return kv_cache_manager::ToPbError<kv_cache_manager::proto::meta::ErrorCode>(ec);
 }
+} // anonymous namespace
 
-} // namespace
+namespace kv_cache_manager {
 
 MetaServiceImpl::MetaServiceImpl(std::shared_ptr<CacheManager> cache_manager,
                                  std::shared_ptr<MetricsReporter> metrics_reporter)
@@ -120,6 +109,9 @@ void MetaServiceImpl::RegisterInstance(RequestContext *request_context,
     API_CALL_GUARD("RegisterInstance", true);
     auto *header = response->mutable_header();
     auto *status = header->mutable_status();
+    CHECK_FAULT_INJECTION("RegisterInstance");
+
+    // 参数验证
     std::string invalid_fields = "missing or invalid fields: ";
     if (request->instance_group().empty()) {
         CHECK_REQUIRED_FIELDS_VALIDATION("RegisterInstance", "instance_group", true);
@@ -131,7 +123,11 @@ void MetaServiceImpl::RegisterInstance(RequestContext *request_context,
         SET_SPAN_TRACER_STR_IN_HEADER(request_context);
         return;
     }
-    // 参数验证
+    if (request->block_size() <= 0) {
+        CHECK_REQUIRED_FIELDS_VALIDATION("RegisterInstance", "block_size (must be > 0)", true);
+        SET_SPAN_TRACER_STR_IN_HEADER(request_context);
+        return;
+    }
     if (!request->has_model_deployment()) {
         CHECK_REQUIRED_FIELDS_VALIDATION("RegisterInstance", "model_deployment", true);
         SET_SPAN_TRACER_STR_IN_HEADER(request_context);
@@ -146,7 +142,7 @@ void MetaServiceImpl::RegisterInstance(RequestContext *request_context,
         return;
     }
 
-    if (request->location_spec_infos().size() == 0) {
+    if (request->location_spec_infos().empty()) {
         CHECK_REQUIRED_FIELDS_VALIDATION("RegisterInstance", "location_spec_infos", true);
         SET_SPAN_TRACER_STR_IN_HEADER(request_context);
         return;
@@ -178,10 +174,16 @@ void MetaServiceImpl::RegisterInstance(RequestContext *request_context,
                                                                        location_spec_groups);
 
     if (ec_info != EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         request_context->set_status_code(status->code());
-        status->set_message("Failed to register instance : " + request_context->error_tracer()->ToJsonString());
-        KVCM_LOG_ERROR("[traceId: %s] RegisterInstance failed", request->trace_id().c_str());
+        status->set_message("Failed to register instance, instance_group: " + request->instance_group() +
+                            ", instance_id: " + request->instance_id() +
+                            ", error: " + request_context->error_tracer()->ToJsonString());
+        KVCM_LOG_ERROR("[traceId: %s] RegisterInstance failed, instance_group: %s, instance_id: %s, ec: %d",
+                       request->trace_id().c_str(),
+                       request->instance_group().c_str(),
+                       request->instance_id().c_str(),
+                       ec_info);
     } else {
         status->set_code(proto::meta::OK);
         request_context->set_status_code(status->code());
@@ -212,7 +214,7 @@ void MetaServiceImpl::GetInstanceInfo(RequestContext *request_context,
     std::shared_ptr<const InstanceInfo> instance_info_ptr = get_instance_info.second;
 
     if (ec_info == ErrorCode::EC_INSTANCE_NOT_EXIST) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         status->set_message(request_context->error_tracer()->ToJsonString());
         request_context->set_status_code(status->code());
         KVCM_LOG_INFO(
@@ -221,7 +223,7 @@ void MetaServiceImpl::GetInstanceInfo(RequestContext *request_context,
         return;
     }
     if (ec_info != ErrorCode::EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         status->set_message(request_context->error_tracer()->ToJsonString());
         request_context->set_status_code(status->code());
         KVCM_LOG_ERROR("[traceId: %s] GetInstanceInfo failed", request->trace_id().c_str());
@@ -279,7 +281,7 @@ void MetaServiceImpl::GetCacheLocation(RequestContext *request_context,
     CacheLocationViewVecWrapper cache_location_view_vec_wrapper(std::move(get_cache_meta.second));
     CacheLocationViewVec cache_locations_res = cache_location_view_vec_wrapper.cache_locations_view();
     if (ec_info != EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         request_context->set_status_code(status->code());
         status->set_message("Failed to get cache locations : " + request_context->error_tracer()->ToJsonString());
         KVCM_LOG_ERROR("[traceId: %s] GetCacheLocation failed, ec: %d", request->trace_id().c_str(), ec_info);
@@ -332,7 +334,7 @@ void MetaServiceImpl::GetCacheMeta(RequestContext *request_context,
     std::vector<std::string> metas_res = cache_meta_vec_wrapper.metas();
 
     if (ec_info != EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         request_context->set_status_code(status->code());
         status->set_message("Failed to get cache metadata : " + request_context->error_tracer()->ToJsonString());
         KVCM_LOG_ERROR("[traceId: %s] GetCacheMeta failed", request->trace_id().c_str());
@@ -395,7 +397,7 @@ void MetaServiceImpl::StartWriteCache(RequestContext *request_context,
     CacheLocationViewVecWrapper cache_locations_res(std::move(start_write_cache.second.locations_mut()));
 
     if (ec_info != EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         request_context->set_status_code(status->code());
         status->set_message("Failed to start write cache : " + request_context->error_tracer()->ToJsonString());
         KVCM_LOG_ERROR("[traceId: %s] StartWriteCache failed", request->trace_id().c_str());
@@ -450,7 +452,7 @@ void MetaServiceImpl::FinishWriteCache(RequestContext *request_context,
         request_context, request->instance_id(), request->write_session_id(), success_blocks_req);
 
     if (ec_info != EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         request_context->set_status_code(status->code());
         status->set_message("Failed to finish write cache : " + request_context->error_tracer()->ToJsonString());
         KVCM_LOG_ERROR("[traceId: %s] FinishWriteCache failed", request->trace_id().c_str());
@@ -493,7 +495,7 @@ void MetaServiceImpl::RemoveCache(RequestContext *request_context,
                                     std::vector<int64_t>(request->token_ids().begin(), request->token_ids().end()),
                                     block_mask_req);
     if (ec_info != EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         request_context->set_status_code(status->code());
         status->set_message("Failed to remove cache : " + request_context->error_tracer()->ToJsonString());
         KVCM_LOG_ERROR("[traceId: %s] RemoveCache failed", request->trace_id().c_str());
@@ -532,7 +534,7 @@ void MetaServiceImpl::TrimCache(RequestContext *request_context,
                                                   request->begin_timestamp(),
                                                   request->end_timestamp());
     if (ec_info != EC_OK) {
-        status->set_code(ToPbError(ec_info));
+        status->set_code(ToMetaPbError(ec_info));
         request_context->set_status_code(status->code());
         status->set_message("Failed to trim cache : " + request_context->error_tracer()->ToJsonString());
         KVCM_LOG_ERROR("[traceId: %s] TrimCache failed", request->trace_id().c_str());


### PR DESCRIPTION
# 主要变更内容

1. 错误码转换统一抽象（error_code.h）
新增模板函数 ToPbError<PbErrorCode>，统一内部 ErrorCode 到各 proto 错误码的映射，覆盖 EC_BADARGS、EC_DUPLICATE_ENTITY、EC_NOENT、EC_IO_ERROR 等，未显式映射的统一落到 INTERNAL_ERROR。
2. 实例配置差异检测（instance_info.h）
新增 MismatchFields(...) 方法，逐字段比较已注册的 InstanceInfo 与入参，返回不匹配字段名列表。配合 RegistryManager / CacheManager 在重复注册时输出如 "mismatched fields: [model_deployment]" 的可读错误信息。
3. Meta/Admin Service 错误处理增强
引入 ToMetaPbError / ToAdminPbError 辅助函数替换旧的本地实现
RegisterInstance 新增 block_size <= 0 参数校验
错误 message 中统一包含 instance_group、instance_id 以及 error_tracer 的 JSON 序列化内容，提升可观测性
RemoveInstance 失败时返回更精确的错误码（如 INSTANCE_NOT_EXIST 而非笼统的 INTERNAL_ERROR）
4. 测试覆盖度
Meta/Admin Python 集成测试：覆盖 block_size 非法、group 不存在、配置不一致等多个错误路径
C++ 客户端单测：验证重复注册和使用不存在 group 时客户端行为符合预期

# Main Changes

1. Unified Error Code Conversion (error_code.h)
Added a template function ToPbError<PbErrorCode> to centralize the mapping from internal ErrorCode to each proto-layer error code. It covers EC_BADARGS, EC_DUPLICATE_ENTITY, EC_NOENT, EC_IO_ERROR, EC_OUT_OF_LIMIT, EC_UNKNOWN, etc. Any unmapped error code falls back to INTERNAL_ERROR.
2. Instance Configuration Mismatch Detection (instance_info.h)
Added a MismatchFields(...) method to compare the registered InstanceInfo against incoming parameters field by field, returning a list of mismatched field names. Used in RegistryManager and CacheManager to produce human-readable error messages like "mismatched fields: [model_deployment]" when duplicate registration with conflicting config is detected.
3. Enhanced Error Handling in Meta/Admin Services
Introduced ToMetaPbError / ToAdminPbError helper functions to replace local implementations
Added block_size <= 0 parameter validation in RegisterInstance
Error messages now uniformly include instance_group, instance_id, and the JSON-serialized error_tracer content for better observability
RemoveInstance now returns a more precise error code (e.g., INSTANCE_NOT_EXIST instead of a generic INTERNAL_ERROR)
4. Test Coverage
Meta/Admin Python Integration Tests: Cover multiple error paths including invalid block_size, non-existent group, and configuration mismatch
C++ Client Unit Tests: Verify that the client behaves correctly when duplicate registration or non-existent group is used