### PR TITLE
[common/config/meta] fix race conditions in ConcurrentHashMap operations

### DIFF
--- a/kv_cache_manager/common/concurrent_hash_map.h
+++ b/kv_cache_manager/common/concurrent_hash_map.h
@@ -171,6 +171,44 @@ public:
         map_.erase(first, last);
     }
 
+    // Atomic upsert: inserts or replaces value under unique_lock.
+    void Upsert(const KeyType &key, const ValueType &value) {
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        map_[key] = value;
+    }
+
+    // Atomic get: copies value to out under shared_lock if key exists.
+    // Returns true if key was found, false otherwise.
+    bool Get(const KeyType &key, ValueType &out) const {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        auto iter = map_.find(key);
+        if (iter == map_.end()) return false;
+        out = iter->second;
+        return true;
+    }
+
+    // Atomic find-and-apply: executes func(const Value&) under shared_lock if key exists.
+    // Returns true if key was found, false otherwise.
+    template <typename Func>
+    bool FindAndApply(const KeyType &key, Func func) const {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        auto iter = map_.find(key);
+        if (iter == map_.end()) return false;
+        func(iter->second);
+        return true;
+    }
+
+    // Atomic find-and-modify: executes func(Value&) under unique_lock if key exists.
+    // Returns true if key was found, false otherwise.
+    template <typename Func>
+    bool FindAndModify(const KeyType &key, Func func) {
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        auto iter = map_.find(key);
+        if (iter == map_.end()) return false;
+        func(iter->second);
+        return true;
+    }
+
     // Lookup
     SizeType Count(const KeyType &key) const {
         std::shared_lock<std::shared_mutex> lock(mutex_);

--- a/kv_cache_manager/config/registry_local_backend.cc
+++ b/kv_cache_manager/config/registry_local_backend.cc
@@ -67,7 +67,6 @@ ErrorCode RegistryLocalBackend::PersistToPath() {
     if (!enable_persistence_) {
         return EC_OK;
     }
-    std::lock_guard<std::mutex> guard(mutex_);
     std::map<std::string, std::string> tmp_table;
     table_.ForEachKV([&](const std::string &key, const std::map<std::string, std::string> &field_map) {
         tmp_table[key] = Jsonizable::ToJsonString(field_map);
@@ -84,25 +83,23 @@ ErrorCode RegistryLocalBackend::PersistToPath() {
 }
 
 ErrorCode RegistryLocalBackend::Load(const std::string &key, std::map<std::string, std::string> &out_value) noexcept {
-    auto iter = table_.Find(key);
-    if (iter == table_.End()) {
+    if (!table_.Get(key, out_value)) {
         return EC_NOENT;
     }
-    out_value = iter->second;
     return EC_OK;
 }
 
 ErrorCode RegistryLocalBackend::Save(const std::string &key, const std::map<std::string, std::string> &value) noexcept {
-    table_[key] = value;
+    std::lock_guard<std::mutex> guard(mutex_);
+    table_.Upsert(key, value);
     return PersistToPath();
 }
 
 ErrorCode RegistryLocalBackend::Delete(const std::string &key) noexcept {
-    auto iter = table_.Find(key);
-    if (iter == table_.End()) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (table_.Erase(key) == 0) {
         return EC_NOENT;
     }
-    table_.Erase(iter);
     return PersistToPath();
 }
 

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -122,7 +122,7 @@ std::vector<ErrorCode> MetaLocalBackend::Put(const KeyTypeVec &keys, const Field
 ErrorCode MetaLocalBackend::PutForOneKey(const KeyType &key, const FieldMap &field_map) {
     // PersistToPath will traverse all keys, we should lock the mutex when multi-threads put/update/delete one key
     std::lock_guard<std::mutex> guard(mutex_);
-    table_[key] = field_map;
+    table_.Upsert(key, field_map);
     return PersistToPath();
 }
 
@@ -143,13 +143,14 @@ std::vector<ErrorCode> MetaLocalBackend::UpdateFields(const KeyTypeVec &keys, co
 
 ErrorCode MetaLocalBackend::UpdateFieldsForOneKey(const KeyType &key, const FieldMap &field_map) {
     std::lock_guard<std::mutex> guard(mutex_);
-    auto iter = table_.Find(key);
-    if (iter == table_.End()) {
+    bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
+        for (const auto &[field_name, field_value] : field_map) {
+            existing_map[field_name] = field_value;
+        }
+    });
+    if (!found) {
         KVCM_LOG_WARN("update fields fail, cannot find key[%ld]", key);
         return EC_NOENT;
-    }
-    for (const auto &[field_name, field_value] : field_map) {
-        (iter->second)[field_name] = field_value;
     }
     return PersistToPath();
 }
@@ -171,15 +172,13 @@ std::vector<ErrorCode> MetaLocalBackend::Upsert(const KeyTypeVec &keys, const Fi
 
 ErrorCode MetaLocalBackend::UpsertForOneKey(const KeyType &key, const FieldMap &field_map) {
     std::lock_guard<std::mutex> guard(mutex_);
-    auto iter = table_.Find(key);
-    if (iter == table_.End()) {
-        // if not exist, then insert
-        table_[key] = field_map;
-        return PersistToPath();
-    }
-    // if exist, then update
-    for (const auto &[field_name, field_value] : field_map) {
-        (iter->second)[field_name] = field_value;
+    bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
+        for (const auto &[field_name, field_value] : field_map) {
+            existing_map[field_name] = field_value;
+        }
+    });
+    if (!found) {
+        table_.Upsert(key, field_map);
     }
     return PersistToPath();
 }
@@ -199,34 +198,37 @@ std::vector<ErrorCode> MetaLocalBackend::IncrFields(const KeyTypeVec &keys,
 ErrorCode MetaLocalBackend::IncrFieldsForOneKey(const KeyType &key,
                                                 const std::map<std::string, int64_t> &field_amounts) {
     std::lock_guard<std::mutex> guard(mutex_);
-    const auto iter = table_.Find(key);
-    if (iter == table_.End()) {
+    ErrorCode ec = EC_OK;
+    bool found = table_.FindAndModify(key, [&](FieldMap &field_map) {
+        std::map<std::string, std::string> new_field_map;
+        for (const auto &[field_name, amount] : field_amounts) {
+            const auto field_iter = field_map.find(field_name);
+            if (field_iter == field_map.end()) {
+                KVCM_LOG_ERROR("incr fields fail, cannot find field[%s] for key[%ld]", field_name.c_str(), key);
+                ec = EC_BADARGS;
+                return;
+            }
+            const auto &old_field_value = field_iter->second;
+            int64_t old_field_value_num = 0;
+            if (!StringUtil::StrToInt64(old_field_value.c_str(), old_field_value_num)) {
+                KVCM_LOG_ERROR("incr fields fail, cannot convert field[%s] value[%s] to int64_t for key[%ld]",
+                               field_name.c_str(),
+                               old_field_value.c_str(),
+                               key);
+                ec = EC_BADARGS;
+                return;
+            }
+            new_field_map[field_name] = std::to_string(old_field_value_num + amount);
+        }
+        for (const auto &[field_name, new_field_value] : new_field_map) {
+            field_map[field_name] = new_field_value;
+        }
+    });
+    if (!found) {
         KVCM_LOG_WARN("incr fields fail, cannot find key[%ld]", key);
         return EC_NOENT;
     }
-
-    auto &field_map = iter->second;
-    std::map<std::string, std::string> new_field_map;
-    for (const auto &[field_name, amount] : field_amounts) {
-        const auto field_iter = field_map.find(field_name);
-        if (field_iter == field_map.end()) {
-            KVCM_LOG_ERROR("incr fields fail, cannot find field[%s] for key[%ld]", field_name.c_str(), key);
-            return EC_BADARGS;
-        }
-        const auto &old_field_value = field_iter->second;
-        int64_t old_field_value_num = 0;
-        if (!StringUtil::StrToInt64(old_field_value.c_str(), old_field_value_num)) {
-            KVCM_LOG_ERROR("incr fields fail, cannot convert field[%s] value[%s] to int64_t for key[%ld]",
-                           field_name.c_str(),
-                           old_field_value.c_str(),
-                           key);
-            return EC_BADARGS;
-        }
-        new_field_map[field_name] = std::to_string(old_field_value_num + amount);
-    }
-    for (const auto &[field_name, new_field_value] : new_field_map) {
-        field_map[field_name] = new_field_value;
-    }
+    if (ec != EC_OK) return ec;
     return PersistToPath();
 }
 
@@ -268,17 +270,16 @@ ErrorCode MetaLocalBackend::GetForOneKey(const KeyType &key,
                                          const std::vector<std::string> &field_names,
                                          FieldMap &out_field_map) {
     out_field_map.clear();
-    const auto iter = table_.Find(key);
-    if (iter == table_.End()) {
+    bool found = table_.FindAndApply(key, [&](const FieldMap &field_table) {
+        for (const std::string &field_name : field_names) {
+            const auto field_iter = field_table.find(field_name);
+            out_field_map[field_name] = (field_iter == field_table.end() ? "" : field_iter->second);
+        }
+    });
+    if (!found) {
         for (const std::string &field_name : field_names) {
             out_field_map[field_name] = "";
         }
-        return EC_OK;
-    }
-    const auto &field_table = iter->second;
-    for (const std::string &field_name : field_names) {
-        const auto field_iter = field_table.find(field_name);
-        out_field_map[field_name] = (field_iter == field_table.end() ? "" : field_iter->second);
     }
     return EC_OK;
 }
@@ -297,12 +298,9 @@ std::vector<ErrorCode> MetaLocalBackend::GetAllFields(const KeyTypeVec &keys, Fi
 
 ErrorCode MetaLocalBackend::GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) {
     out_field_map.clear();
-    const auto iter = table_.Find(key);
-    if (iter == table_.End()) {
+    if (!table_.Get(key, out_field_map)) {
         return EC_NOENT;
     }
-    const auto &field_table = iter->second;
-    out_field_map = field_table;
     return out_field_map.empty() ? EC_NOENT : EC_OK;
 }
 
@@ -333,27 +331,30 @@ ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
     out_next_cursor.clear();
     out_keys.clear();
 
-    int64_t current_index = 0;
-    auto iter = table_.Begin();
+    int64_t start_index = 0;
     if (cursor != SCAN_BASE_CURSOR) {
-        if (!StringUtil::StrToInt64(cursor.c_str(), current_index)) {
+        if (!StringUtil::StrToInt64(cursor.c_str(), start_index)) {
             KVCM_LOG_ERROR("list keys fail, cannot convert cursor[%s] to start index", cursor.c_str());
             return EC_BADARGS;
         }
-        std::advance(iter, current_index);
     }
-    int64_t end_index = current_index + limit;
-    while (iter != table_.End()) {
+
+    int64_t current_index = 0;
+    int64_t end_index = start_index + limit;
+    bool reached_limit = false;
+    table_.ForEachKV([&](const KeyType &key, const FieldMap &) {
         if (current_index >= end_index) {
-            out_next_cursor = std::to_string(current_index);
-            return EC_OK;
+            reached_limit = true;
+            return false;
         }
-        const auto &key = iter->first;
-        out_keys.emplace_back(key);
-        ++iter;
+        if (current_index >= start_index) {
+            out_keys.emplace_back(key);
+        }
         ++current_index;
-    }
-    out_next_cursor = SCAN_BASE_CURSOR;
+        return true;
+    });
+
+    out_next_cursor = reached_limit ? std::to_string(current_index) : SCAN_BASE_CURSOR;
     return EC_OK;
 }
 


### PR DESCRIPTION
修复测试Crash: https://github.com/alibaba/tair-kvcache/pull/52

# 失败的测试
//kv_cache_manager/manager/test:CacheManagerTest (shard 2 of 10) 失败，测试用例为 CacheManagerTest.TestRemoveInstance。
## 根因：Segmentation Fault (SIGSEGV, Signal 11)
测试进程崩溃，产生了 3 个 core dump 文件。根据 GDB backtrace 分析，这是一个并发竞态条件 (race condition) 导致的空指针解引用。

## 崩溃调用栈 (Thread 1 - 主线程)

```plaintext
CacheManagerTest_TestRemoveInstance_Test::TestBody
  -> CacheManager::RemoveInstance          (cache_manager.cc:237)
    -> CacheManager::TrimCache
      -> MetaIndexer::Scan                 (meta_indexer.cc:306)
        -> MetaLocalBackend::ListKeys      (meta_local_backend.cc:343)  <-- 崩溃点
          -> std::advance 在 unordered_map 迭代器上
            -> _Hash_node::_M_next (this=0x0)  <-- 空指针解引用
```
## 并发修改线程 (Thread 24)

```plaintext
SchedulePlanExecutor::WorkerRoutine
  -> SchedulePlanExecutor::DoLocationDelTask
    -> MetaSearcher::BatchCADLocationStatus
      -> MetaIndexer::ReadModifyWrite       <-- 同时在修改同一个 hash map
```

# 原因分析
Thread 1 在调用 MetaLocalBackend::ListKeys 遍历（scan）unordered_map 时，Thread 24 同时在通过 MetaIndexer::ReadModifyWrite 修改同一个 hash map。并发的插入/删除操作导致 hash map 内部链表节点被释放或重排，使得 Thread 1 持有的迭代器失效，最终在 std::advance 推进迭代器时解引用了一个空的 _Hash_node 指针 (this=0x0)，触发了 SIGSEGV。

这是一个典型的 unordered_map 非线程安全 问题 -- 读写操作没有被正确的锁保护。