### PR TITLE
[hisim] Support general requests and add a dataset argument to the runner.

### DIFF
--- a/hisim/README.md
+++ b/hisim/README.md
@@ -70,7 +70,6 @@ python3 -m hisim.simulation.sglang.launch_server \
 > **Notes**:
 > - Parameters prefixed with `--sim-` are simulation-specific; others are passed to the SGLang framework.
 > - Use `--sim-config-path` to specify the simulation configuration file.
-> - `--skip-server-warmup` is required because the simulator only accepts specific request formats.
 > - In pure CPU simulation environments, you may need to install the CPU-compatible version of vLLM (a dependency of SGLang CPU mode) and set the following environment variables:
 >   ```bash
 >   export SGLANG_USE_CPU_ENGINE=1
@@ -80,7 +79,7 @@ python3 -m hisim.simulation.sglang.launch_server \
 
 #### Run the Simulation Benchmark
 
-Open a new terminal and run the benchmark client. **Important**: Use `--bench-mode simulation` and **do not** use `--warmup-request`.
+Open a new terminal and run the benchmark client. **Important**: Use `--bench-mode simulation` and set `--warmup-request=0`.
 
 - **Replay from user dataset** (`user_replay_requests.jsonl`):
   ```bash

--- a/hisim/README_zh.md
+++ b/hisim/README_zh.md
@@ -55,13 +55,12 @@ pip install .
 ``` bash
 python3 -m hisim.simulation.sglang.launch_server \
   --model-path "Qwen/Qwen3-32B-FP8" \
-  --sim-config-path test/assets/mock/config.json \
-  --skip-server-warmup
+  --sim-config-path test/assets/mock/config.json
 ```
 
 > **Notes**:
 > - 详细参数参考[详细参数与环境变量设置说明](#mock-simulation推理仿真)。
-> - 命令行参数中，`sim` 开头的参数为仿真参数，其他参数为服务框架（SGLang）的参数，通过指定 `--sim-config-path` 设置仿真配置，仿真过程中，只能接受特定的请求，因此需要 `--skip-server-warmup` 避免出现异常。
+> - 命令行参数中，`sim` 开头的参数为仿真参数，其他参数为服务框架（SGLang）的参数，通过指定 `--sim-config-path` 设置仿真配置。
 > - 如果在纯CPU仿真环境中，可能需要安装vllm(sglang cpu版本依赖)，同时需要指定环境变量
 >   ``` bash
 >   export SGLANG_USE_CPU_ENGINE=1
@@ -71,7 +70,7 @@ python3 -m hisim.simulation.sglang.launch_server \
 
 #### 劫持仿真压测
 
-压测时需要指定 `--bench-mode simulation`，同时不支持 `--warmup-request`。新建终端作为发送端，运行以下命令
+压测时需要指定 `--bench-mode simulation`，warmup-request 也会当仿真的请求，请设置（`--warmup-request=0`）。新建终端作为发送端，运行以下命令
 
 - **基于用户数据集重放**
 ``` bash

--- a/hisim/src/hisim/dataset/__init__.py
+++ b/hisim/src/hisim/dataset/__init__.py
@@ -1,6 +1,6 @@
 from transformers import PreTrainedTokenizer
 
-from hisim.dataset.base_dataset import BaseDataset, GenericRequest
+from hisim.dataset.base_dataset import BaseDataset, GenericRequest, SimpleDataset
 from hisim.dataset.random import (
     RandomDataset,
     RandomIDsDataset,
@@ -44,6 +44,7 @@ def get_dataset(
 
 __all__ = (
     "BaseDataset",
+    "SimpleDataset",
     "GenericRequest",
     "get_dataset",
 )

--- a/hisim/src/hisim/dataset/base_dataset.py
+++ b/hisim/src/hisim/dataset/base_dataset.py
@@ -42,3 +42,29 @@ class BaseDataset:
             return self._name
         else:
             return self.__class__.__name__
+
+
+class SimpleDataset(BaseDataset):
+    def __init__(
+        self, tokenizer=None, args=None, reqs: list[GenericRequest] | None = None
+    ):
+        super().__init__(tokenizer, args)
+        self.data: list[GenericRequest] = []
+        if reqs is not None:
+            self.data.extend(reqs)
+
+    def add_request(self, req: GenericRequest):
+        self.data.append(req)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            return [self[i] for i in range(start, stop, step)]
+
+        if index >= len(self):
+            raise IndexError
+
+        return self.data[index]
+
+    def __len__(self):
+        return len(self.data)

--- a/hisim/src/hisim/simulation/bench_serving.py
+++ b/hisim/src/hisim/simulation/bench_serving.py
@@ -924,6 +924,8 @@ class BenchmarkMetrics:
     concurrency: float
     max_output_tokens_per_s: float = 0.0
     max_concurrent_requests: int = 0
+    mean_queue_ms: float = 0.0
+    prefix_cache_reused_ratio: float = 0.0
 
 
 SHAREGPT_URL = "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
@@ -1758,6 +1760,7 @@ async def get_request(
     request_rate: float,
     use_trace_timestamps: bool = False,
     slowdown_factor: float = 1.0,
+    timestamp_scale_s: float = 1000,  # 1000: ms -> s
 ) -> AsyncGenerator[DatasetRow, None]:
     if use_trace_timestamps:
         print(
@@ -1767,15 +1770,16 @@ async def get_request(
         input_requests.sort(key=lambda r: r.timestamp)
 
         start_time = time.perf_counter()
-        trace_start_time_ms = input_requests[0].timestamp if input_requests else 0
+        trace_start_time = input_requests[0].timestamp if input_requests else 0
 
         for request in input_requests:
-            trace_time_s = (request.timestamp - trace_start_time_ms) / 1000.0
+            trace_time_s = (request.timestamp - trace_start_time) / timestamp_scale_s
             target_arrival_time = start_time + (trace_time_s * slowdown_factor)
             # Hisim: simulation arguments
             request.simulation.update(
                 {
-                    "created_time": request.timestamp - trace_start_time_ms,
+                    "created_time": (request.timestamp - trace_start_time)
+                    / timestamp_scale_s,
                     "total_request": len(input_requests),
                 }
             )
@@ -2166,7 +2170,9 @@ async def benchmark(
         )
         pbar_total *= args.mooncake_num_rounds
     elif backend == "sglang" and args.dataset_name == "hisim-collection":
-        request_generator = get_request(input_requests, -1, use_trace_timestamps=True)
+        request_generator = get_request(
+            input_requests, -1, use_trace_timestamps=True, timestamp_scale_s=1
+        )
     else:
         request_generator = get_request(input_requests, request_rate)
 
@@ -2408,6 +2414,7 @@ async def benchmark(
             "median_ttft_ms": metrics.median_ttft_ms,
             "std_ttft_ms": metrics.std_ttft_ms,
             "p99_ttft_ms": metrics.p99_ttft_ms,
+            "mean_queue_ms": metrics.mean_queue_ms,
             "mean_tpot_ms": metrics.mean_tpot_ms,
             "median_tpot_ms": metrics.median_tpot_ms,
             "std_tpot_ms": metrics.std_tpot_ms,
@@ -2421,6 +2428,7 @@ async def benchmark(
             "accept_length": accept_length,
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
             "max_concurrent_requests": metrics.max_concurrent_requests,
+            "prefix_cache_reused_ratio": metrics.prefix_cache_reused_ratio,
         }
     else:
         print(f"Error running benchmark for request rate: {request_rate}")

--- a/hisim/src/hisim/simulation/sglang/sglang_bench.py
+++ b/hisim/src/hisim/simulation/sglang/sglang_bench.py
@@ -2,7 +2,7 @@ from dataclasses import asdict
 import asyncio
 import json
 import os
-from typing import Iterator
+from typing import Iterator, Optional
 import numpy as np
 import torch
 
@@ -60,6 +60,8 @@ class SGLangBenchmarkRunner(BaseBenchmarkRunner):
         self.server_args = server_args
         self.engine = Engine(**asdict(server_args))
 
+        self._tokenizer: AutoTokenizer = None
+
     def flush_cache(self):
         self.engine.flush_cache()
 
@@ -70,6 +72,7 @@ class SGLangBenchmarkRunner(BaseBenchmarkRunner):
         self,
         dataset: BaseDataset,
         ignore_timestamp: bool = False,
+        with_queue_start: bool = False,
         request_rate: float = float("inf"),
     ) -> Iterator[tuple[GenericRequest, dict]]:
         yield_delay = 0
@@ -84,15 +87,31 @@ class SGLangBenchmarkRunner(BaseBenchmarkRunner):
                 "total_request": len(dataset),  # include the warmup requests.
                 "created_time": created_time,
             }
+            if with_queue_start:
+                simulation_params["queue_start"] = req.custom_params.get("queue_start")
+
             yield (req, simulation_params)
 
     async def async_benchmark(
-        self, benchmark_config: BenchmarkConfig, dataset_args: DatasetArgs
+        self,
+        benchmark_config: BenchmarkConfig,
+        dataset: Optional[BaseDataset] = None,
+        dataset_args: Optional[DatasetArgs] = None,
     ):
-        dataset = get_dataset(
-            dataset_args,
-            tokenizer=AutoTokenizer.from_pretrained(self.server_args.model_path),
-        )
+        if (dataset is None) == (dataset_args is None):
+            raise ValueError(
+                "Exactly one of `dataset` or `dataset_args` must be provided."
+            )
+
+        if dataset is None and dataset_args is not None:
+            if self._tokenizer is None:
+                self._tokenizer = AutoTokenizer.from_pretrained(
+                    self.server_args.model_path
+                )
+            dataset = get_dataset(
+                dataset_args,
+                tokenizer=self._tokenizer,
+            )
 
         await self.engine.tokenizer_manager.start_profile(profile_prefix="reset")
 
@@ -106,6 +125,7 @@ class SGLangBenchmarkRunner(BaseBenchmarkRunner):
         for req, simulation_params in self.get_request(
             dataset,
             ignore_timestamp=benchmark_config.ignore_request_timestamp,
+            with_queue_start=benchmark_config.with_queue_start,
             request_rate=benchmark_config.request_rate,
         ):
             task = asyncio.create_task(
@@ -143,10 +163,11 @@ class SGLangBenchmarkRunner(BaseBenchmarkRunner):
     def benchmark(
         self,
         benchmark_config: BenchmarkConfig,
-        dataset_args: DatasetArgs,
+        dataset: Optional[BaseDataset] = None,
+        dataset_args: Optional[DatasetArgs] = None,
     ):
         return self.engine.loop.run_until_complete(
-            self.async_benchmark(benchmark_config, dataset_args)
+            self.async_benchmark(benchmark_config, dataset, dataset_args)
         )
 
     def get_iteration_stats(self) -> list[dict]:

--- a/hisim/src/hisim/simulation/sglang/sglang_hook.py
+++ b/hisim/src/hisim/simulation/sglang/sglang_hook.py
@@ -612,8 +612,15 @@ class C_SchedulerHook(BaseHook):
                                 extra_requests.append(req)
 
                         # Add requests to future queue
-                        for idx, req in enumerate(gen_requests):
-                            sim_params = req.sampling_params.custom_params["simulation"]
+                        for req in gen_requests:
+                            sim_params = None
+                            if req.sampling_params.custom_params is not None:
+                                sim_params = req.sampling_params.custom_params.get("simulation")
+                            if sim_params is None:
+                                # There are some warm-up requests when starting the server without --skip-server-warmup.
+                                extra_requests.append(req)
+                                logger.warning("Failed to extract the simulation parameters required for simulation from the request. Ignore this warning if the request is a warm-up request.")
+                                continue
                             C_SchedulerHook.FUTURE_QUEUE.append(
                                 (
                                     sim_params["created_time"],

--- a/hisim/src/hisim/simulation/sglang/sglang_hook.py
+++ b/hisim/src/hisim/simulation/sglang/sglang_hook.py
@@ -65,7 +65,14 @@ class C_TokenizerManagerHook(BaseHook):
 
         # When running with blocking mode, send the created time to schedule.
         def wrapped_send_one_request(self, obj, tokenized_obj, created_time):
-            setattr(tokenized_obj, "created_time", created_time)
+            if obj.__class__.__name__ == "GenerateReqInput":
+                if (
+                    tokenized_obj.sampling_params.custom_params is not None
+                    and "simulation" in tokenized_obj.sampling_params.custom_params
+                ):
+                    tokenized_obj.sampling_params.custom_params["simulation"][
+                        "server_created_time"
+                    ] = created_time
             return original_send_one_request(self, obj, tokenized_obj, created_time)
 
         target._send_one_request = wrapped_send_one_request
@@ -594,73 +601,66 @@ class C_SchedulerHook(BaseHook):
             if C_SchedulerHook.SIM_MODE == MockSimulationMode.BLOCKING:
                 recv_reqs.extend(original_recv_requests(self, *args, **kwargs))
             elif C_SchedulerHook.SIM_MODE == MockSimulationMode.OFFLINE:
-                total_request = -1
-
-                # Initialized
+                # Initializing
                 if not C_SchedulerHook.OFFLINE_RECV_ALL_REQUEST:
-                    while True:
-                        gen_requests = []
-                        extra_requests = []
-                        time.sleep(0.001)  # waiting requests
+                    gen_requests = []
+                    extra_requests = []
+                    time.sleep(0.05)  # waiting requests
 
-                        reqs = original_recv_requests(self, *args, **kwargs)
+                    reqs = original_recv_requests(self, *args, **kwargs)
 
-                        for req in reqs:
-                            if req.__class__.__name__ == "TokenizedGenerateReqInput":
-                                gen_requests.append(req)
-                            else:
-                                extra_requests.append(req)
+                    for req in reqs:
+                        if req.__class__.__name__ == "TokenizedGenerateReqInput":
+                            gen_requests.append(req)
+                        else:
+                            # Such as: /profile_start, /flush_cache, etc.
+                            extra_requests.append(req)
 
-                        # Add requests to future queue
-                        for req in gen_requests:
-                            sim_params = None
-                            if req.sampling_params.custom_params is not None:
-                                sim_params = req.sampling_params.custom_params.get("simulation")
-                            if sim_params is None:
-                                # There are some warm-up requests when starting the server without --skip-server-warmup.
-                                extra_requests.append(req)
-                                logger.warning("Failed to extract the simulation parameters required for simulation from the request. Ignore this warning if the request is a warm-up request.")
-                                continue
-                            C_SchedulerHook.FUTURE_QUEUE.append(
-                                (
-                                    sim_params["created_time"],
-                                    time.time_ns(),  # The request is not comparable, so add the salt to avoid comparison.
-                                    req,
-                                )
-                            )
-
-                        # Update the total number of requests
-                        if (
-                            total_request == -1
-                            and len(C_SchedulerHook.FUTURE_QUEUE) != 0
-                        ):
-                            _, _, gen_req = C_SchedulerHook.FUTURE_QUEUE[-1]
-                            total_request = gen_req.sampling_params.custom_params[
+                    # Add requests to future queue
+                    for req in gen_requests:
+                        sim_params = None
+                        if req.sampling_params.custom_params is not None:
+                            sim_params = req.sampling_params.custom_params.get(
                                 "simulation"
-                            ]["total_request"]
-                            logger.info(
-                                f"Offline simulation mode enabled. {total_request} requests expected."
                             )
+                        if sim_params is None:
+                            # There are some warm-up requests when starting the server without --skip-server-warmup.
+                            extra_requests.append(req)
+                            logger.warning(
+                                "Failed to extract the simulation parameters required for simulation from the request. Ignore this warning if the request is a warm-up request."
+                            )
+                            continue
+                        C_SchedulerHook.FUTURE_QUEUE.append(
+                            (
+                                sim_params["created_time"],
+                                time.time_ns(),  # The request is not comparable, so add the salt to avoid comparison.
+                                req,
+                            )
+                        )
 
-                        if len(extra_requests) != 0:
-                            # Schedule the extra requests immediately.
-                            return extra_requests
+                    if len(C_SchedulerHook.FUTURE_QUEUE) != 0:
+                        _, _, gen_req = C_SchedulerHook.FUTURE_QUEUE[-1]
+                        total_request = gen_req.sampling_params.custom_params[
+                            "simulation"
+                        ]["total_request"]
 
                         if len(C_SchedulerHook.FUTURE_QUEUE) == total_request:
+                            C_SchedulerHook.OFFLINE_RECV_ALL_REQUEST = True
+                            heapq.heapify(C_SchedulerHook.FUTURE_QUEUE)
                             logger.info(
                                 "All requests received. Starting simulation now."
                             )
-                            break
+                        else:
+                            logger.info(
+                                f"Offline simulation mode enabled. {total_request} requests expected in total. Received {len(C_SchedulerHook.FUTURE_QUEUE)} requests so far."
+                            )
+
+                    if len(extra_requests) != 0:
+                        # Schedule the extra requests immediately.
+                        return extra_requests
                 else:
                     # Extra requests include: flush request, abort request, etc.
                     recv_reqs.extend(original_recv_requests(self, *args, **kwargs))
-
-                if (
-                    not C_SchedulerHook.OFFLINE_RECV_ALL_REQUEST
-                    and len(C_SchedulerHook.FUTURE_QUEUE) == total_request
-                ):
-                    C_SchedulerHook.OFFLINE_RECV_ALL_REQUEST = True
-                    heapq.heapify(C_SchedulerHook.FUTURE_QUEUE)
 
                 # Process the arrived requests only after all requests have been added to the future queue
                 current_timestamp = StateManager.get_global_clock()
@@ -684,16 +684,18 @@ class C_SchedulerHook(BaseHook):
                     req_stats.rid = req.rid
                     req_stats.input_length = len(req.input_ids)
                     req_stats.output_length = req.sampling_params.max_new_tokens
+                    simulation_args = req.sampling_params.custom_params["simulation"]
                     if C_SchedulerHook.SIM_MODE == MockSimulationMode.BLOCKING:
-                        if not hasattr(req, "created_time"):
-                            logger.warning("Request's created time is missing.")
-                        req_stats.created_time = getattr(req, "created_time", now)
+                        if "server_created_time" not in simulation_args:
+                            logger.warning(
+                                "The request's creation time is missing, which may cause the TTFT to be inaccurate."
+                            )
+                        req_stats.created_time = simulation_args.get(
+                            "server_created_time", now
+                        )
                         req_stats.last_event_time = req_stats.created_time
                         req_stats.queue_start = now
                     elif C_SchedulerHook.SIM_MODE == MockSimulationMode.OFFLINE:
-                        simulation_args = req.sampling_params.custom_params[
-                            "simulation"
-                        ]
                         req_stats.created_time = simulation_args["created_time"]
                         req_stats.last_event_time = req_stats.created_time
                         req_stats.queue_start = StateManager.get_global_clock()

--- a/hisim/src/hisim/simulation/sglang/sglang_hook.py
+++ b/hisim/src/hisim/simulation/sglang/sglang_hook.py
@@ -630,9 +630,15 @@ class C_SchedulerHook(BaseHook):
                                 "Failed to extract the simulation parameters required for simulation from the request. Ignore this warning if the request is a warm-up request."
                             )
                             continue
+                        if sim_params.get("queue_start"):
+                            logger.debug(
+                                "Add request to waiting queue with custom queue start timestamp."
+                            )
+
                         C_SchedulerHook.FUTURE_QUEUE.append(
                             (
-                                sim_params["created_time"],
+                                sim_params.get("queue_start")
+                                or sim_params["created_time"],
                                 time.time_ns(),  # The request is not comparable, so add the salt to avoid comparison.
                                 req,
                             )
@@ -668,8 +674,8 @@ class C_SchedulerHook(BaseHook):
                     C_SchedulerHook.OFFLINE_RECV_ALL_REQUEST
                     and len(C_SchedulerHook.FUTURE_QUEUE) > 0
                 ):
-                    created_time, _, req = C_SchedulerHook.FUTURE_QUEUE[0]
-                    if created_time > current_timestamp:
+                    enqueue_time, _, req = C_SchedulerHook.FUTURE_QUEUE[0]
+                    if enqueue_time > current_timestamp + 6e-3:
                         break
                     recv_reqs.append(req)
                     heapq.heappop(C_SchedulerHook.FUTURE_QUEUE)
@@ -698,6 +704,9 @@ class C_SchedulerHook(BaseHook):
                     elif C_SchedulerHook.SIM_MODE == MockSimulationMode.OFFLINE:
                         req_stats.created_time = simulation_args["created_time"]
                         req_stats.last_event_time = req_stats.created_time
+                        queue_start = simulation_args["queue_start"]
+                        if queue_start is not None:
+                            StateManager.set_global_clock(queue_start)
                         req_stats.queue_start = StateManager.get_global_clock()
 
             if recv_reqs and C_SchedulerHook.LAST_CPU_TS == 0:

--- a/hisim/src/hisim/simulation/sglang/sglang_hook.py
+++ b/hisim/src/hisim/simulation/sglang/sglang_hook.py
@@ -675,7 +675,7 @@ class C_SchedulerHook(BaseHook):
                     and len(C_SchedulerHook.FUTURE_QUEUE) > 0
                 ):
                     enqueue_time, _, req = C_SchedulerHook.FUTURE_QUEUE[0]
-                    if enqueue_time > current_timestamp + 6e-3:
+                    if enqueue_time > current_timestamp:
                         break
                     recv_reqs.append(req)
                     heapq.heappop(C_SchedulerHook.FUTURE_QUEUE)
@@ -704,6 +704,7 @@ class C_SchedulerHook(BaseHook):
                     elif C_SchedulerHook.SIM_MODE == MockSimulationMode.OFFLINE:
                         req_stats.created_time = simulation_args["created_time"]
                         req_stats.last_event_time = req_stats.created_time
+                        # Align with the real queue start timestamp if queue_start is not None. For debugging only.
                         queue_start = simulation_args["queue_start"]
                         if queue_start is not None:
                             StateManager.set_global_clock(queue_start)

--- a/hisim/src/hisim/simulation/utils.py
+++ b/hisim/src/hisim/simulation/utils.py
@@ -61,11 +61,13 @@ def calc_metrics(requests: list[RequestStats]) -> dict:
     completed = 0
     total_reused_tokens = 0
     total_disk_hit_tokens = 0
+    queue_durs = []
     for req in requests:
         if not req.is_complete():
             continue
         completed += 1
         ttfts.append(req.gen_token_latencies[0])
+        queue_durs.append(req.queue_end - req.queue_start)
         if len(req.gen_token_latencies) > 1:
             # output length > 1
             tpots.append(np.mean(req.gen_token_latencies[1:]))
@@ -98,6 +100,7 @@ def calc_metrics(requests: list[RequestStats]) -> dict:
         "p90_ttft_ms": np.percentile(ttfts or 0, 90) * 1000,
         "p95_ttft_ms": np.percentile(ttfts or 0, 95) * 1000,
         "p99_ttft_ms": np.percentile(ttfts or 0, 99) * 1000,
+        "mean_queue_ms": np.mean(queue_durs or 0) * 1000,
         "mean_tpot_ms": np.mean(tpots or 0) * 1000,
         "median_tpot_ms": np.median(tpots or 0) * 1000,
         "std_tpot_ms": np.std(tpots or 0) * 1000,


### PR DESCRIPTION
## 主要改动点
* 仿真时允许请求不携带 `simulation` 参数，避免 `warmup` 请求推理异常。
* 请求参数中新增 `queue_start`，用于完美回放场景的压测。
* 新增 `SimpleDataset ` 数据集，允许用户自定义构建数据，同时在 Runner 中增加 `dataset` 参数，提升使用的灵活性。

## Main Changes
* During simulation, requests are allowed to omit the `simulation` parameter to prevent inference issues for `warmup` requests.
* Add `queue_start` to request parameters for perfect replay–style load testing.
* Add the `SimpleDataset` dataset to allow users to build custom data, and add a `dataset` argument to the Runner to improve flexibility.