### PR TITLE
[meta] MetaLocalBackend::ListKeys support cursor based multi-turn scan

### DIFF
--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/meta/meta_local_backend.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 
@@ -331,30 +332,49 @@ ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
     out_next_cursor.clear();
     out_keys.clear();
 
-    int64_t start_index = 0;
-    if (cursor != SCAN_BASE_CURSOR) {
-        if (!StringUtil::StrToInt64(cursor.c_str(), start_index)) {
-            KVCM_LOG_ERROR("list keys fail, cannot convert cursor[%s] to start index", cursor.c_str());
-            return EC_BADARGS;
-        }
-    }
-
-    int64_t current_index = 0;
-    int64_t end_index = start_index + limit;
-    bool reached_limit = false;
+    // Collect all keys and sort them for deterministic ordering
+    std::vector<KeyType> all_keys;
     table_.ForEachKV([&](const KeyType &key, const FieldMap &) {
-        if (current_index >= end_index) {
-            reached_limit = true;
-            return false;
-        }
-        if (current_index >= start_index) {
-            out_keys.emplace_back(key);
-        }
-        ++current_index;
+        all_keys.emplace_back(key);
         return true;
     });
+    std::sort(all_keys.begin(), all_keys.end());
 
-    out_next_cursor = reached_limit ? std::to_string(current_index) : SCAN_BASE_CURSOR;
+    if (all_keys.empty() || limit <= 0) {
+        out_next_cursor = SCAN_BASE_CURSOR;
+        return EC_OK;
+    }
+
+    // Parse cursor to find starting position
+    // Cursor format: string representation of the last key returned
+    // SCAN_BASE_CURSOR ("0") means start from beginning
+    size_t start_index = 0;
+    if (cursor != SCAN_BASE_CURSOR) {
+        KeyType cursor_key = 0;
+        if (!StringUtil::StrToInt64(cursor.c_str(), cursor_key)) {
+            KVCM_LOG_ERROR("list keys fail, cannot convert cursor[%s] to key", cursor.c_str());
+            return EC_BADARGS;
+        }
+        // Find the position after the cursor key
+        // Use upper_bound to find the first key greater than cursor_key
+        auto it = std::upper_bound(all_keys.begin(), all_keys.end(), cursor_key);
+        start_index = std::distance(all_keys.begin(), it);
+    }
+
+    // Collect keys starting from start_index
+    size_t end_index = std::min(start_index + static_cast<size_t>(limit), all_keys.size());
+    for (size_t i = start_index; i < end_index; ++i) {
+        out_keys.emplace_back(all_keys[i]);
+    }
+
+    // Set next cursor
+    if (end_index < all_keys.size()) {
+        // More keys to scan, use last returned key as cursor
+        out_next_cursor = std::to_string(all_keys[end_index - 1]);
+    } else {
+        // Reached the end
+        out_next_cursor = SCAN_BASE_CURSOR;
+    }
     return EC_OK;
 }
 

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -355,8 +355,9 @@ ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
     out_keys.clear();
 
     if (limit <= 0) {
-        out_next_cursor = SCAN_BASE_CURSOR;
-        return EC_OK;
+        // align to the behavior of Redis SCAN where COUNT must > 0
+        // do not update the out_next_cursor
+        return EC_BADARGS;
     }
 
     std::lock_guard<std::mutex> guard(mutex_);

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -37,12 +37,14 @@ ErrorCode MetaLocalBackend::Init(const std::string &instance_id,
 }
 
 ErrorCode MetaLocalBackend::Open() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
     table_.Clear();
+    sorted_keys_cache_.clear();
+    cache_dirty_ = true;
+
     if (!enable_persistence_) {
         return EC_OK;
     }
-
-    std::lock_guard<std::mutex> guard(mutex_);
     std::error_code ec;
     bool exists = std::filesystem::exists(path_, ec);
     if (ec) {
@@ -124,6 +126,7 @@ ErrorCode MetaLocalBackend::PutForOneKey(const KeyType &key, const FieldMap &fie
     // PersistToPath will traverse all keys, we should lock the mutex when multi-threads put/update/delete one key
     std::lock_guard<std::mutex> guard(mutex_);
     table_.Upsert(key, field_map);
+    cache_dirty_ = true;
     return PersistToPath();
 }
 
@@ -153,6 +156,7 @@ ErrorCode MetaLocalBackend::UpdateFieldsForOneKey(const KeyType &key, const Fiel
         KVCM_LOG_WARN("update fields fail, cannot find key[%ld]", key);
         return EC_NOENT;
     }
+    // key set is unchanged; cache_dirty_ stays as-is
     return PersistToPath();
 }
 
@@ -181,6 +185,7 @@ ErrorCode MetaLocalBackend::UpsertForOneKey(const KeyType &key, const FieldMap &
     if (!found) {
         table_.Upsert(key, field_map);
     }
+    cache_dirty_ = true;
     return PersistToPath();
 }
 
@@ -229,7 +234,9 @@ ErrorCode MetaLocalBackend::IncrFieldsForOneKey(const KeyType &key,
         KVCM_LOG_WARN("incr fields fail, cannot find key[%ld]", key);
         return EC_NOENT;
     }
-    if (ec != EC_OK) return ec;
+    if (ec != EC_OK)
+        return ec;
+    // key set is unchanged; cache_dirty_ stays as-is
     return PersistToPath();
 }
 
@@ -250,6 +257,7 @@ ErrorCode MetaLocalBackend::DeleteForOneKey(const KeyType &key) {
         return EC_NOENT;
     }
     table_.Erase(key);
+    cache_dirty_ = true;
     return PersistToPath();
 }
 
@@ -325,6 +333,20 @@ ErrorCode MetaLocalBackend::ExistsForOneKey(const KeyType &key, bool &out_is_exi
     return EC_OK;
 }
 
+void MetaLocalBackend::RebuildSortedCacheUnderLock() {
+    if (!cache_dirty_) {
+        return;
+    }
+
+    sorted_keys_cache_.clear();
+    table_.ForEachKV([&](const KeyType &key, const FieldMap &) {
+        sorted_keys_cache_.emplace_back(key);
+        return true;
+    });
+    std::sort(sorted_keys_cache_.begin(), sorted_keys_cache_.end());
+    cache_dirty_ = false;
+}
+
 ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
                                      const int64_t limit,
                                      std::string &out_next_cursor,
@@ -332,21 +354,21 @@ ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
     out_next_cursor.clear();
     out_keys.clear();
 
-    // Collect all keys and sort them for deterministic ordering
-    std::vector<KeyType> all_keys;
-    table_.ForEachKV([&](const KeyType &key, const FieldMap &) {
-        all_keys.emplace_back(key);
-        return true;
-    });
-    std::sort(all_keys.begin(), all_keys.end());
-
-    if (all_keys.empty() || limit <= 0) {
+    if (limit <= 0) {
         out_next_cursor = SCAN_BASE_CURSOR;
         return EC_OK;
     }
 
-    // Parse cursor to find starting position
-    // Cursor format: string representation of the last key returned
+    std::lock_guard<std::mutex> guard(mutex_);
+    RebuildSortedCacheUnderLock();
+
+    if (sorted_keys_cache_.empty()) {
+        out_next_cursor = SCAN_BASE_CURSOR;
+        return EC_OK;
+    }
+
+    // parse cursor to find starting position
+    // cursor format: string representation of the last key returned
     // SCAN_BASE_CURSOR ("0") means start from beginning
     size_t start_index = 0;
     if (cursor != SCAN_BASE_CURSOR) {
@@ -355,24 +377,21 @@ ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
             KVCM_LOG_ERROR("list keys fail, cannot convert cursor[%s] to key", cursor.c_str());
             return EC_BADARGS;
         }
-        // Find the position after the cursor key
-        // Use upper_bound to find the first key greater than cursor_key
-        auto it = std::upper_bound(all_keys.begin(), all_keys.end(), cursor_key);
-        start_index = std::distance(all_keys.begin(), it);
+        // find the position after the cursor key
+        auto it = std::upper_bound(sorted_keys_cache_.begin(), sorted_keys_cache_.end(), cursor_key);
+        start_index = std::distance(sorted_keys_cache_.begin(), it);
     }
 
-    // Collect keys starting from start_index
-    size_t end_index = std::min(start_index + static_cast<size_t>(limit), all_keys.size());
+    // collect keys starting from start_index
+    size_t end_index = std::min(start_index + static_cast<size_t>(limit), sorted_keys_cache_.size());
     for (size_t i = start_index; i < end_index; ++i) {
-        out_keys.emplace_back(all_keys[i]);
+        out_keys.emplace_back(sorted_keys_cache_[i]);
     }
 
-    // Set next cursor
-    if (end_index < all_keys.size()) {
-        // More keys to scan, use last returned key as cursor
-        out_next_cursor = std::to_string(all_keys[end_index - 1]);
+    // set next cursor: use the last returned key, or base cursor when exhausted
+    if (end_index < sorted_keys_cache_.size()) {
+        out_next_cursor = std::to_string(sorted_keys_cache_[end_index - 1]);
     } else {
-        // Reached the end
         out_next_cursor = SCAN_BASE_CURSOR;
     }
     return EC_OK;

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -54,10 +54,19 @@ private:
     ErrorCode GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map);
     ErrorCode ExistsForOneKey(const KeyType &key, bool &out_is_exist);
 
+    // rebuilds sorted_keys_cache_ from table_
+    // caller must hold mutex_
+    void RebuildSortedCacheUnderLock();
+
 private:
     std::mutex mutex_;
     std::string path_;
     ConcurrentHashMap<KeyType, FieldMap> table_;
     bool enable_persistence_ = false;
+
+    // sorted_keys_cache_ and cache_dirty_ are protected by mutex_
+    std::vector<KeyType> sorted_keys_cache_;
+    bool cache_dirty_ = true;
 };
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -333,9 +333,12 @@ TEST_F(MetaLocalBackendTest, TestListKeys) {
     // invalid cursor
     AssertListKeys(meta_storage_backend_.get(), "invalid_cursor", /*limit*/ 1, EC_BADARGS, "", {1, 2, 3});
 
-    // list no key, limit = 0
+    // invalid limit
     std::string next_cursor;
-    AssertListKeysByStep(meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 0, EC_OK, {1, 2, 3}, next_cursor);
+    AssertListKeysByStep(
+        meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 0, EC_BADARGS, {1, 2, 3}, next_cursor);
+    AssertListKeysByStep(
+        meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ -1, EC_BADARGS, {1, 2, 3}, next_cursor);
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -353,6 +353,47 @@ TEST_F(MetaLocalBackendTest, TestRecover) {
     }
 }
 
+TEST_F(MetaLocalBackendTest, TestListKeysCacheBehavior) {
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    // Add initial keys
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}),
+              meta_storage_backend_->Put({1, 3, 5}, {{{"f1", "v1"}}, {{"f1", "v3"}}, {{"f1", "v5"}}}));
+
+    // First scan should trigger cache rebuild
+    std::string cursor = SCAN_BASE_CURSOR;
+    std::string next_cursor;
+    std::vector<KeyType> keys;
+    ErrorCode ec = meta_storage_backend_->ListKeys(cursor, 2, next_cursor, keys);
+    ASSERT_EQ(EC_OK, ec);
+    ASSERT_EQ(2, keys.size());
+    ASSERT_EQ(1, keys[0]);
+    ASSERT_EQ(3, keys[1]);
+    ASSERT_NE(SCAN_BASE_CURSOR, next_cursor); // Should have continuation
+
+    // Second scan should use cached data
+    cursor = next_cursor;
+    ec = meta_storage_backend_->ListKeys(cursor, 2, next_cursor, keys);
+    ASSERT_EQ(EC_OK, ec);
+    ASSERT_EQ(1, keys.size());
+    ASSERT_EQ(5, keys[0]);
+    ASSERT_EQ(SCAN_BASE_CURSOR, next_cursor); // Should be done
+
+    // Add a new key - should invalidate cache
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({2}, {{{"f1", "v2"}}}));
+
+    // Next scan should see the new key and trigger rebuild
+    cursor = SCAN_BASE_CURSOR;
+    ec = meta_storage_backend_->ListKeys(cursor, 10, next_cursor, keys);
+    ASSERT_EQ(EC_OK, ec);
+    ASSERT_EQ(4, keys.size());
+    ASSERT_EQ((std::vector<KeyType>{1, 2, 3, 5}), keys); // Should be sorted
+    ASSERT_EQ(SCAN_BASE_CURSOR, next_cursor);
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestRecoverBinarySafe) {
     for (int32_t i = 0; i < 10; ++i) {
         ConstructMetaStorageBackend(); // new meta storage backend

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -286,11 +286,23 @@ TEST_F(MetaLocalBackendTest, TestListKeys) {
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
 
-    // list keys by step
+    // list keys by step with cursor-based scanning
     std::string current_cursor = SCAN_BASE_CURSOR;
-    for (std::string next_cursor; current_cursor != SCAN_BASE_CURSOR; current_cursor = next_cursor) {
-        AssertListKeysByStep(meta_storage_backend_.get(), current_cursor, /*limit*/ 1, EC_OK, {1, 2, 3}, next_cursor);
-    }
+    std::set<KeyType> collected_keys;
+    int loop_count = 0;
+    const int max_loops = 10; // prevent infinite loop
+    do {
+        std::string next_cursor;
+        std::vector<KeyType> keys;
+        ErrorCode ec = meta_storage_backend_->ListKeys(current_cursor, /*limit*/ 1, next_cursor, keys);
+        ASSERT_EQ(EC_OK, ec);
+        for (const auto &key : keys) {
+            collected_keys.insert(key);
+        }
+        current_cursor = next_cursor;
+        ASSERT_LT(++loop_count, max_loops) << "ListKeys loop exceeded maximum iterations";
+    } while (current_cursor != SCAN_BASE_CURSOR);
+    ASSERT_EQ((std::set<KeyType>{1, 2, 3}), collected_keys);
 
     // list all keys
     AssertListKeys(meta_storage_backend_.get(),

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -1,5 +1,6 @@
 #include <filesystem>
 
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
@@ -286,22 +287,39 @@ TEST_F(MetaLocalBackendTest, TestListKeys) {
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
 
-    // list keys by step with cursor-based scanning
+    // list keys by step with cursor-based scanning, limit=1 over 3 keys
+    // Expected: exactly 3 iterations (one key per page), cursors form a
+    // strictly increasing sequence, and the full key set is covered.
+    const int64_t scan_limit = 1;
+    const int key_count = 3;
+    const int max_loops = key_count + 1; // ceil(key_count / scan_limit) + 1
     std::string current_cursor = SCAN_BASE_CURSOR;
     std::set<KeyType> collected_keys;
     int loop_count = 0;
-    const int max_loops = 10; // prevent infinite loop
+    KeyType prev_cursor_val = std::numeric_limits<KeyType>::min();
     do {
         std::string next_cursor;
         std::vector<KeyType> keys;
-        ErrorCode ec = meta_storage_backend_->ListKeys(current_cursor, /*limit*/ 1, next_cursor, keys);
+        ErrorCode ec = meta_storage_backend_->ListKeys(current_cursor, scan_limit, next_cursor, keys);
         ASSERT_EQ(EC_OK, ec);
+        // Each page must return exactly scan_limit keys (except possibly the last)
+        ASSERT_GE(scan_limit, static_cast<int64_t>(keys.size())) << "page exceeded limit";
+        ASSERT_EQ(scan_limit, static_cast<int64_t>(keys.size())) << "expected exactly one key per page";
         for (const auto &key : keys) {
             collected_keys.insert(key);
+        }
+        // Cursor must advance strictly forward (i.e. new cursor > previous cursor)
+        // when there are more pages remaining.
+        if (next_cursor != SCAN_BASE_CURSOR) {
+            KeyType next_cursor_val = 0;
+            ASSERT_TRUE(StringUtil::StrToInt64(next_cursor.c_str(), next_cursor_val));
+            ASSERT_GT(next_cursor_val, prev_cursor_val) << "cursor did not advance";
+            prev_cursor_val = next_cursor_val;
         }
         current_cursor = next_cursor;
         ASSERT_LT(++loop_count, max_loops) << "ListKeys loop exceeded maximum iterations";
     } while (current_cursor != SCAN_BASE_CURSOR);
+    ASSERT_EQ(key_count, loop_count) << "expected exactly key_count iterations with limit=1";
     ASSERT_EQ((std::set<KeyType>{1, 2, 3}), collected_keys);
 
     // list all keys


### PR DESCRIPTION
The original ListKeys implementation used an index-based cursor approach which ad several problems:

1. Non-deterministic iteration order: unordered_map doesn't guarantee consistent iteration order.
2. Unreliable cursor: If keys are added/deleted between scan calls, or if rehashing occurs, the index-based approach would miss or duplicate keys.
3. The test had a bug: The loop condition current_cursor != SCAN_BASE_CURSOR was false from the start, so the multi-turn scan was never actually tested.

This patch replaced the index-based cursor with a key-based cursor approach:
1. Collect and sort keys: All keys are collected into a sorted vector for deterministic ordering.
2. Use key as cursor: The cursor is the string representation of the last returned key.
3. Binary search for position: Use std::upper_bound to efficiently find the starting position.
4. Return next cursor: The next cursor is the last returned key, or "0" (SCAN_BASE_CURSOR) when done.

Also fixed the test to properly verify multi-turn cursor-based scanning:
- Changed from a for loop with incorrect condition to a do-while loop.
- Added proper collection of all keys across multiple turns.
- Added iteration count limit to prevent infinite loops.
- Verified that all keys are collected after multiple scan turns.