### PR TITLE
[metrics] add 2 new duration metrics for CacheReclaimer

### DIFF
--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -92,7 +92,9 @@ DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(block_del_count);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(location_del_count);
 
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_job_duration_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_res_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_sample_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us);
@@ -198,7 +200,9 @@ ErrorCode CacheReclaimer::Start() noexcept {
     REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(location_del_count);
 
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_job_duration_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_res_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_sample_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us);
@@ -567,7 +571,12 @@ void CacheReclaimer::ReclaimCron() noexcept {
             }
         }
 
-        HandleDelRes();
+        {
+            const std::int64_t res_begin_tp = TimestampUtil::GetSteadyTimeUs();
+            HandleDelRes();
+            METRICS_(cache_reclaimer, reclaim_res_duration_us) =
+                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - res_begin_tp);
+        }
 
         if (triggered) {
             sleep_interval_ms = 0;
@@ -1027,13 +1036,20 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
     // do we need to reclaim the storage for this instance group?
     // <total, hf3fs, mooncake, pace, nfs>
     std::array<bool, 5> water_level_exceed_results{false, false, false, false, false};
-    if (!IsTriggerReclaiming(request_context.get(),
-                             ins_gr,
-                             instance_group->quota(), // TODO (rui): validate the quota is valid
-                             reclaim_strategy,
-                             instance_infos,
-                             water_level_exceed_results)) {
-        return false;
+    {
+        const std::int64_t quota_begin_tp = TimestampUtil::GetSteadyTimeUs();
+        if (!IsTriggerReclaiming(request_context.get(),
+                                 ins_gr,
+                                 instance_group->quota(), // TODO (rui): validate the quota is valid
+                                 reclaim_strategy,
+                                 instance_infos,
+                                 water_level_exceed_results)) {
+            METRICS_(cache_reclaimer, reclaim_quota_duration_us) =
+                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - quota_begin_tp);
+            return false;
+        }
+        METRICS_(cache_reclaimer, reclaim_quota_duration_us) =
+            static_cast<double>(TimestampUtil::GetSteadyTimeUs() - quota_begin_tp);
     }
 
     // run the reclaiming algorithm with the chosen policy

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -455,7 +455,9 @@ private:
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(location_del_count)
 
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_job_duration_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_res_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_sample_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us)

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -526,7 +526,7 @@ void KmonitorMetricsReporter::ReportInterval() {
         // note these metrics are reported to the local metrics registry
         // in real-time, but for kmonitor they are reported with time interval
         const auto cr = cache_manager_->cache_reclaimer();
-        if (!cr) {
+        if (!cr || cr->IsPaused() || !cr->IsRunning()) {
             break;
         }
 

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -117,7 +117,9 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_reclaimer, location_del_count);
 
     DECLARE_METRICS(cache_reclaimer, reclaim_cron_duration_us);
+    DECLARE_METRICS(cache_reclaimer, reclaim_quota_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_job_duration_us);
+    DECLARE_METRICS(cache_reclaimer, reclaim_res_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_sample_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_batch_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_filter_duration_us);
@@ -333,7 +335,9 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_reclaimer, location_del_count);
 
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_cron_duration_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_quota_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_job_duration_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_res_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_sample_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_batch_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_filter_duration_us);
@@ -538,7 +542,9 @@ void KmonitorMetricsReporter::ReportInterval() {
         std::uint64_t loc_del_count_v;
 
         double reclaim_cron_duration_us_v;
+        double reclaim_quota_duration_us_v;
         double reclaim_job_duration_us_v;
+        double reclaim_res_duration_us_v;
         double reclaim_lru_sample_duration_us_v;
         double reclaim_lru_batch_duration_us_v;
         double reclaim_lru_filter_duration_us_v;
@@ -552,7 +558,9 @@ void KmonitorMetricsReporter::ReportInterval() {
         GET_METRICS_(cr, cache_reclaimer, location_del_count, loc_del_count_v);
 
         GET_METRICS_(cr, cache_reclaimer, reclaim_cron_duration_us, reclaim_cron_duration_us_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_quota_duration_us, reclaim_quota_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_job_duration_us, reclaim_job_duration_us_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_res_duration_us, reclaim_res_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_sample_duration_us, reclaim_lru_sample_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_batch_duration_us, reclaim_lru_batch_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_filter_duration_us, reclaim_lru_filter_duration_us_v);
@@ -567,7 +575,9 @@ void KmonitorMetricsReporter::ReportInterval() {
         REPORT_METRICS(cache_reclaimer, location_del_count, static_cast<double>(loc_del_count_v));
 
         REPORT_METRICS(cache_reclaimer, reclaim_cron_duration_us, reclaim_cron_duration_us_v);
+        REPORT_METRICS(cache_reclaimer, reclaim_quota_duration_us, reclaim_quota_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_job_duration_us, reclaim_job_duration_us_v);
+        REPORT_METRICS(cache_reclaimer, reclaim_res_duration_us, reclaim_res_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_lru_sample_duration_us, reclaim_lru_sample_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_lru_batch_duration_us, reclaim_lru_batch_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_lru_filter_duration_us, reclaim_lru_filter_duration_us_v);


### PR DESCRIPTION
[metrics] add 2 new duration metrics for CacheReclaimer

* reclaim_quota_duration_us for group reclaiming trigger calculating time
* reclaim_res_duration_us for deleting result handling time

[metrics] better status check for CacheReclaimer metrics report