### PR TITLE
[client] fix hf3fs mempool missing string include

### DIFF
--- a/kv_cache_manager/client/src/internal/sdk/hf3fs_mempool.h
+++ b/kv_cache_manager/client/src/internal/sdk/hf3fs_mempool.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <map>
 #include <shared_mutex>
-
+#include <string>
 namespace kv_cache_manager {
 
 class Hf3fsMempool final {


### PR DESCRIPTION
Build fails with GCC 13.3.0 due to missing #include <string> in hf3fs_mempool.h. Older GCC versions implicitly pulled in <string> through other headers, but GCC 13.3.0 enforces stricter header dependencies, causing compilation errors.
