### PR TITLE
[cicd] upgrade qodercli version to 0.1.34

### DIFF
--- a/.github/workflows/qoder-code-review.yml
+++ b/.github/workflows/qoder-code-review.yml
@@ -55,6 +55,7 @@ jobs:
         # uses: QoderAI/qoder-action@v0
         uses: QoderAI/qoder-action@0881d27d15a7a93778ebc5c942d11da313ee8b7e
         with:
+          qodercli_version: '0.1.34'
           qoder_personal_access_token: ${{ secrets.QODER_PERSONAL_ACCESS_TOKEN }}
           prompt: |
             /review-pr


### PR DESCRIPTION
## Summary
- 将 `.github/workflows/qoder-code-review.yml` 中 `QoderAI/qoder-action` 的 `qodercli_version` 从默认的 `0.1.18` 升级到 `0.1.34`

## Test plan
- [x] 触发一次 PR review workflow，确认 qodercli 0.1.34 安装成功并正常运行

🤖 Generated with [Qoder][https://qoder.com]