### PR TITLE
[connector/sglang] fix batch_set return value, improve compatibility

### DIFF
--- a/kv_cache_manager/py_connector/sglang/LOCAL_DEBUG_GUIDE.md
+++ b/kv_cache_manager/py_connector/sglang/LOCAL_DEBUG_GUIDE.md
@@ -1,0 +1,210 @@
+# sglang Connector 本地调试指南
+
+本文档介绍如何在本地环境中构建 KVCM sglang connector，配合真实 sglang 服务进行调试。
+
+## 前置条件
+
+- 已安装 sglang 的 Python venv 环境
+- 可用的模型文件
+- GPU 显存需满足：模型权重 + KV Cache（由 `--mem-fraction-static` 控制）
+- 可用内存需满足：GPU 上 KV Cache 大小 × `--hicache-ratio`
+
+## 1. 构建并安装 wheel 包
+
+在项目主目录下构建 connector wheel：
+
+```bash
+bazel build //kv_cache_manager/py_connector/sglang:kvcm_sglang_connector_wheel
+```
+
+构建产物在 `bazel-bin/kv_cache_manager/py_connector/sglang/` 下。安装到 sglang venv 中：
+
+```bash
+<sglang-venv>/bin/pip install --force-reinstall --no-deps \
+    bazel-bin/kv_cache_manager/py_connector/sglang/kvcm_sglang_connector-*.whl
+```
+
+> **注意**：如果 bazel build 因网络问题失败（如无法拉取 rules_python），
+> 需确保 bazel 缓存可用或网络畅通。
+
+## 2. 启动 KVCM Manager
+
+准备 startup config：
+
+```bash
+mkdir -p /tmp/kvcm_debug/nfs
+
+cat > /tmp/kvcm_debug/startup_config.json << 'EOF'
+{
+  "instance_groups": [
+    {
+      "name": "default",
+      "storage_backend": {
+        "type": "file",
+        "file_root": "/tmp/kvcm_debug/nfs/"
+      }
+    }
+  ]
+}
+EOF
+```
+
+启动 manager（默认监听 6382 端口）：
+
+```bash
+bazel-bin/kv_cache_manager/manager/kv_cache_manager_bin \
+    --startup_config_file=/tmp/kvcm_debug/startup_config.json
+```
+
+验证 manager 就绪：
+
+```bash
+curl -s http://127.0.0.1:6382/health
+# 应返回 "OK"
+```
+
+## 3. 启动 sglang
+
+关键参数说明：
+
+| 参数 | 说明 |
+|------|------|
+| `--mem-fraction-static` | GPU 显存中用于 KV Cache 的比例，需确保模型权重 + KV Cache 不超显存 |
+| `--hicache-ratio` | 主机内存 HiCache 大小 = KV Cache 大小 × ratio |
+| `--page-size 64` | 每个 KV Cache page 的 token 数 |
+| `--enable-cache-report` | 在 Prefill 日志中显示 `#cached-token`，调试时建议开启 |
+| `--hicache-storage-backend dynamic` | 使用动态加载的存储后端 |
+
+启动命令参考：
+
+```bash
+EXTRA_CONFIG='{
+    "backend_name": "kvcm",
+    "module_path": "kv_cache_manager.py_connector.sglang.connector",
+    "class_name": "HiCacheKVCM",
+    "instance_group": "default",
+    "instance_id": "sglang-debug-01",
+    "manager_uri": "http://127.0.0.1:6382",
+    "hicache_storage_pass_prefix_keys": true
+}'
+
+python -m sglang.launch_server \
+    --model-path <模型路径> \
+    --host 127.0.0.1 --port 30000 \
+    --enable-hierarchical-cache \
+    --mem-fraction-static 0.80 \
+    --hicache-ratio 1.2 \
+    --page-size 64 \
+    --enable-cache-report \
+    --hicache-storage-prefetch-policy wait_complete \
+    --hicache-storage-backend dynamic \
+    --hicache-storage-backend-extra-config "$EXTRA_CONFIG"
+```
+
+等待日志出现 `Application startup complete` 后即可发送请求。
+
+> **注意**：`interface_v1` 无需在 `EXTRA_CONFIG` 中手动配置，connector 会在初始化时
+> 自动声明。
+
+## 4. 调试示例
+
+### 4.1 验证 Backup + Prefetch 流程
+
+发送一个足够长的请求（prompt 需超过 1 个 page = 64 tokens），触发 backup 写入 KVCM，
+然后 flush GPU cache 后重复请求，观察是否从 KVCM prefetch 回来。
+
+```bash
+# 1. 发送请求（prompt 需 > 64 tokens 以凑满至少 1 个 page）
+curl -s http://127.0.0.1:30000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "<模型名>",
+        "messages": [
+            {"role": "system", "content": "<长 system prompt, 200+ tokens>"},
+            {"role": "user", "content": "你的问题"}
+        ],
+        "max_tokens": 16
+    }'
+
+# 2. 等待 backup 线程完成写入
+sleep 5
+
+# 3. flush GPU radix cache，确保下次请求不从 GPU/host 内存命中
+curl -s http://127.0.0.1:30000/flush_cache
+
+# 4. 重复相同请求
+curl -s http://127.0.0.1:30000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{...同上...}'
+```
+
+**预期**：第二次请求的 sglang Prefill 日志显示 `#cached-token` > 0。
+
+### 4.2 验证 Partial Write（部分 block 已存在）
+
+当请求 B 与请求 A 共享相同的 prefix 时，B 的 backup 阶段 KVCM 会告知 prefix 对应的
+block 已存在不需要写入，只有新增 block 需要写入。
+
+```bash
+# 1. 清空缓存
+curl -s http://127.0.0.1:30000/flush_cache
+
+# 2. 请求 A：较短问题 + 长 system prompt，建立 prefix cache
+curl ... -d '{"messages": [{"role":"system","content":"<长 prefix>"}, {"role":"user","content":"短问题"}], ...}'
+sleep 5
+
+# 3. flush GPU cache
+curl -s http://127.0.0.1:30000/flush_cache
+
+# 4. 请求 B：同 system prompt + 更长的 user message（触发 partial write）
+curl ... -d '{"messages": [{"role":"system","content":"<同一个长 prefix>"}, {"role":"user","content":"更长的问题..."}], ...}'
+sleep 5
+
+# 5. flush 后重复请求 B，验证 prefetch 能取回全部 page（包括 A 写入的和 B 新写入的）
+curl -s http://127.0.0.1:30000/flush_cache
+curl ... -d '{...同请求 B...}'
+```
+
+**预期**：
+- 请求 B 的 partial write 不报错
+- 重复请求 B 的 Prefill 日志 `#cached-token` 等于全部完整 page 数 × 64
+
+### 4.3 日志检查
+
+调试时关注 sglang server 日志中的关键信息：
+
+```bash
+# 正常的 Prefill 日志，关注 #cached-token 字段
+Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 256, ...
+
+# 以下关键词不应出现，出现则表示有问题
+Exception | NotImplementedError | Error | failed | Write page
+```
+
+## 5. 常见问题
+
+### sglang OOM
+
+`--mem-fraction-static` 设太小导致模型权重 + KV Cache 超过 GPU 显存。增大该值（如 0.8），
+并确保可用内存 >= GPU KV Cache 大小 × `--hicache-ratio`。
+
+### connector import 失败
+
+如果 sglang 启动时报 `Failed to import backend 'kvcm'`，检查 wheel 是否已正确安装：
+
+```bash
+<sglang-venv>/bin/python -c "from kv_cache_manager.py_connector.sglang.connector import HiCacheKVCM; print('OK')"
+```
+
+## 6. 清理
+
+```bash
+# 停止 sglang
+kill $(lsof -ti :30000)
+
+# 停止 KVCM manager
+kill $(lsof -ti :6382)
+
+# 清理调试数据
+rm -rf /tmp/kvcm_debug
+```

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -267,12 +267,10 @@ class HiCacheKVCM(HiCacheStorage):
         write_session_id = result["write_session_id"]
         block_mask = result["block_mask"]
         save_indices = self._parse_block_mask(block_mask, len_prefix, len_new)
-        len_save = max(save_indices, default=-1) + 1
-
         unmatched = len(save_indices)
 
         finish_trace_id = f"finish-{trace_id}"
-        # Early return if no locations
+        # Early return if no locations need writing
         if unmatched == 0:
             if self.tp_rank == 0:
                 self._manager_client.finish_write_cache(
@@ -280,10 +278,10 @@ class HiCacheKVCM(HiCacheStorage):
                         "trace_id": finish_trace_id,
                         "instance_id": self.instance_id,
                         "write_session_id": write_session_id,
-                        "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
+                        "success_blocks": {"bool_masks": {"values": []}},
                     }
                 )
-            return [False] * len(keys)
+            return [True] * len_new
 
         assert unmatched == len(locations)
 
@@ -317,7 +315,6 @@ class HiCacheKVCM(HiCacheStorage):
             flag = bool(flag_tensor.item())
 
         finish_mask = [flag] * unmatched
-        success_mask = finish_mask + [False] * (len_new - len_save)
         if self.tp_rank == 0:
             self._manager_client.finish_write_cache(
                 {
@@ -327,7 +324,16 @@ class HiCacheKVCM(HiCacheStorage):
                     "success_blocks": {"bool_masks": {"values": finish_mask}},
                 }
             )
-        return success_mask
+
+        # Build result list: 1:1 positional mapping with input keys
+        # - keys not in save_indices → True
+        # - keys in save_indices → flag (True if save succeeded)
+        save_indices_set = set(save_indices)
+        result_list = [
+            flag if i in save_indices_set else True
+            for i in range(len_new)
+        ]
+        return result_list
 
     def batch_set_v1(
         self,

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -287,10 +287,27 @@ class HiCacheKVCM(HiCacheStorage):
         write_session_id = result["write_session_id"]
         block_mask = result["block_mask"]
         save_indices = self._parse_block_mask(block_mask, len_prefix, len_new)
-        unmatched = len(save_indices)
 
         finish_trace_id = f"finish-{trace_id}"
-        # Early return if no locations need writing
+
+        # None means inconsistent manager state — treat as write failure.
+        if save_indices is None:
+            logger.warning(f"_batch_set: inconsistent block_mask from manager, "
+                           f"aborting write session {write_session_id}")
+            if self.tp_rank == 0:
+                self._manager_client.finish_write_cache(
+                    {
+                        "trace_id": finish_trace_id,
+                        "instance_id": self.instance_id,
+                        "write_session_id": write_session_id,
+                        "success_blocks": {"bool_masks": {"values": []}},
+                    }
+                )
+            return [False] * len_new
+
+        unmatched = len(save_indices)
+
+        # Early return if all new blocks are already cached.
         if unmatched == 0:
             if self.tp_rank == 0:
                 self._manager_client.finish_write_cache(
@@ -466,18 +483,34 @@ class HiCacheKVCM(HiCacheStorage):
             buffers.append(buffer)
         return buffers
 
-    def _parse_block_mask(self, block_mask: dict, len_prefix: int, len_new: int) -> int:
+    def _parse_block_mask(self, block_mask: dict, len_prefix: int, len_new: int) -> Optional[List[int]]:
+        """Parse block_mask from manager to determine which new-block indices need writing.
+
+        Returns:
+            List[int]: indices (relative to new blocks) that need writing.
+                       Empty list means all new blocks are already cached.
+            None: manager returned an inconsistent state; caller should treat
+                  as a write failure (safe fallback).
+        """
         save_indices = []
         if "offset" in block_mask:
             offset = block_mask["offset"]
-            if offset >= len_prefix:
-                save_indices.extend(range(offset, len_prefix + len_new))
+            if offset < len_prefix:
+                # Inconsistent: offset behind prefix boundary.
+                logger.warning(f"_parse_block_mask: offset {offset} < len_prefix {len_prefix}, "
+                               "treating as inconsistent state")
+                return None
+            save_indices.extend(range(offset, len_prefix + len_new))
         else:
             # False: need to store
             bool_masks = block_mask.get("bool_masks", {}).get("values", [])
-            if all(bool_masks[:len_prefix]):
-                max_index = max([i for i, x in enumerate(bool_masks) if not x], default=-1)
-                save_indices.extend([i for i in range(len_prefix, max_index + 1) if not bool_masks[i]])
+            if not all(bool_masks[:len_prefix]):
+                # Inconsistent: prefix blocks not fully cached.
+                logger.warning("_parse_block_mask: prefix blocks not fully cached in bool_masks, "
+                               "treating as inconsistent state")
+                return None
+            max_index = max([i for i, x in enumerate(bool_masks) if not x], default=-1)
+            save_indices.extend([i for i in range(len_prefix, max_index + 1) if not bool_masks[i]])
         save_indices = [(i - len_prefix) for i in save_indices if i >= len_prefix]
         return save_indices
 

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -56,6 +56,12 @@ class HiCacheKVCM(HiCacheStorage):
         self.prefetch_bandwidth = []
         self.backup_bandwidth = []
 
+        # Declare v1 interface support so that sglang's cache_controller uses
+        # batch_set_v1/batch_get_v1 (zero-copy path) instead of the legacy
+        # batch_set/batch_get. This avoids requiring users to manually add
+        # "interface_v1": 1 in --hicache-storage-backend-extra-config.
+        self.extra_config.setdefault("interface_v1", 1)
+
     def _init_kvcm_client(self):
         # parallelism
         self.tp_rank = self.storage_config.tp_rank

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -13,7 +13,21 @@ from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageExtraInfo,
 )
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
-from sglang.srt.metrics.collector import StorageMetrics
+StorageMetrics = None
+try:
+    from sglang.srt.observability.metrics_collector import StorageMetrics
+except ImportError:
+    pass
+if StorageMetrics is None:
+    try:
+        from sglang.srt.metrics.collector import StorageMetrics
+    except ImportError:
+        raise ImportError(
+            "Cannot import StorageMetrics from sglang. "
+            "Tried sglang.srt.observability.metrics_collector and "
+            "sglang.srt.metrics.collector. "
+            "Please check your sglang version is compatible."
+        )
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.layers.dp_attention import get_attention_tp_group, is_dp_attention_enabled
 

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -295,12 +295,13 @@ class HiCacheKVCM(HiCacheStorage):
             logger.warning(f"_batch_set: inconsistent block_mask from manager, "
                            f"aborting write session {write_session_id}")
             if self.tp_rank == 0:
+                # Mark all locations as failed so manager cleans them up.
                 self._manager_client.finish_write_cache(
                     {
                         "trace_id": finish_trace_id,
                         "instance_id": self.instance_id,
                         "write_session_id": write_session_id,
-                        "success_blocks": {"bool_masks": {"values": []}},
+                        "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
                     }
                 )
             return [False] * len_new
@@ -315,7 +316,7 @@ class HiCacheKVCM(HiCacheStorage):
                         "trace_id": finish_trace_id,
                         "instance_id": self.instance_id,
                         "write_session_id": write_session_id,
-                        "success_blocks": {"bool_masks": {"values": []}},
+                        "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
                     }
                 )
             return [True] * len_new
@@ -504,6 +505,11 @@ class HiCacheKVCM(HiCacheStorage):
         else:
             # False: need to store
             bool_masks = block_mask.get("bool_masks", {}).get("values", [])
+            if len(bool_masks) < len_prefix + len_new:
+                # Incomplete mask data from manager.
+                logger.warning(f"_parse_block_mask: bool_masks length {len(bool_masks)} < "
+                               f"expected {len_prefix + len_new}, treating as inconsistent state")
+                return None
             if not all(bool_masks[:len_prefix]):
                 # Inconsistent: prefix blocks not fully cached.
                 logger.warning("_parse_block_mask: prefix blocks not fully cached in bool_masks, "

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -275,7 +275,57 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # index 4 → write failed (False)
         self.assertEqual(result, [False, True, False, True, False])
 
-    # ── Case 9: batch_set_v1 exception returns all False ─────────────
+    # ── Case 9: inconsistent offset (offset < len_prefix) → all False ─
+    def test_inconsistent_offset_returns_all_false(self):
+        """When offset < len_prefix, manager state is inconsistent → all False."""
+        keys = ["k3", "k4", "k5"]
+
+        # prefix_keys = ["p0", "p1", "p2"], len_prefix=3
+        # offset=1 < len_prefix=3 → inconsistent
+        result_from_manager = {
+            "locations": [],
+            "write_session_id": "ws-9",
+            "block_mask": {"offset": 1},
+        }
+        c = self._setup_connector(start_write_result=result_from_manager)
+
+        extra_info = MagicMock()
+        extra_info.prefix_keys = ["p0", "p1", "p2"]
+
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t9",
+                              extra_info=extra_info)
+
+        self.assertEqual(len(result), len(keys))
+        self.assertEqual(result, [False, False, False])
+
+    # ── Case 10: inconsistent bool_masks (prefix not cached) → all False
+    def test_inconsistent_bool_masks_returns_all_false(self):
+        """When prefix blocks not fully cached in bool_masks → all False."""
+        keys = ["k2", "k3", "k4"]
+
+        # prefix_keys = ["p0", "p1"], len_prefix=2
+        # bool_masks[:2] = [True, False] → not all True → inconsistent
+        result_from_manager = {
+            "locations": [],
+            "write_session_id": "ws-10",
+            "block_mask": {
+                "bool_masks": {
+                    "values": [True, False, False, True, False]
+                }
+            },
+        }
+        c = self._setup_connector(start_write_result=result_from_manager)
+
+        extra_info = MagicMock()
+        extra_info.prefix_keys = ["p0", "p1"]
+
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t10",
+                              extra_info=extra_info)
+
+        self.assertEqual(len(result), len(keys))
+        self.assertEqual(result, [False, False, False])
+
+    # ── Case 11: batch_set_v1 exception returns all False ─────────────
     def test_batch_set_v1_exception(self):
         """batch_set_v1 catches exceptions and returns all False."""
         c = _build_connector()

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -325,7 +325,50 @@ class TestBatchSetReturnValue(unittest.TestCase):
         self.assertEqual(len(result), len(keys))
         self.assertEqual(result, [False, False, False])
 
-    # ── Case 11: batch_set_v1 exception returns all False ─────────────
+    # ── Case 11: incomplete bool_masks (shorter than expected) → all False
+    def test_incomplete_bool_masks_returns_all_false(self):
+        """When bool_masks is shorter than len_prefix + len_new → all False."""
+        keys = ["k0", "k1", "k2"]
+
+        # 3 keys, no prefix → expected bool_masks length = 3, but only 1 given
+        result_from_manager = {
+            "locations": [],
+            "write_session_id": "ws-11",
+            "block_mask": {
+                "bool_masks": {
+                    "values": [True]
+                }
+            },
+        }
+        c = self._setup_connector(start_write_result=result_from_manager)
+
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t11")
+
+        self.assertEqual(len(result), len(keys))
+        self.assertEqual(result, [False, False, False])
+
+    # ── Case 12: empty bool_masks → all False ────────────────────────
+    def test_empty_bool_masks_returns_all_false(self):
+        """When bool_masks is empty → all False (all([]) would be True)."""
+        keys = ["k0", "k1"]
+
+        result_from_manager = {
+            "locations": [],
+            "write_session_id": "ws-12",
+            "block_mask": {
+                "bool_masks": {
+                    "values": []
+                }
+            },
+        }
+        c = self._setup_connector(start_write_result=result_from_manager)
+
+        result = c._batch_set(keys, torch.zeros(2), trace_id="t12")
+
+        self.assertEqual(len(result), len(keys))
+        self.assertEqual(result, [False, False])
+
+    # ── Case 13: batch_set_v1 exception returns all False ─────────────
     def test_batch_set_v1_exception(self):
         """batch_set_v1 catches exceptions and returns all False."""
         c = _build_connector()

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -1,0 +1,290 @@
+"""Unit tests for _batch_set return value: 1:1 positional mapping with input keys."""
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+# ── Mock unavailable modules before importing connector ──────────────
+_mock_metrics = types.ModuleType("sglang.srt.metrics")
+_mock_collector = types.ModuleType("sglang.srt.metrics.collector")
+_mock_collector.StorageMetrics = MagicMock
+_mock_metrics.collector = _mock_collector
+sys.modules.setdefault("sglang.srt.metrics", _mock_metrics)
+sys.modules.setdefault("sglang.srt.metrics.collector", _mock_collector)
+
+_mock_pybind = types.ModuleType("kv_cache_manager.client.pybind")
+_mock_kvcm = MagicMock()
+_mock_kvcm.ClientErrorCode.ER_OK = 0
+_mock_pybind.kvcm_py_client = _mock_kvcm
+sys.modules["kv_cache_manager.client.pybind"] = _mock_pybind
+
+from kv_cache_manager.py_connector.sglang.connector import HiCacheKVCM  # noqa: E402
+
+
+def _make_obj(cls):
+    """Create an instance of cls without calling __init__."""
+    return cls.__new__(cls)
+
+
+def _build_connector(*, tp_rank=0, tp_world_size=1, kv_factor=2,
+                     instance_id="test", location_spec_name="tp_0",
+                     location_spec_size=4096, write_timeout_seconds=30):
+    """Build a HiCacheKVCM with attributes set manually (bypass __init__)."""
+    obj = _make_obj(HiCacheKVCM)
+    obj.tp_rank = tp_rank
+    obj.tp_world_size = tp_world_size
+    obj.kv_factor = kv_factor
+    obj.instance_id = instance_id
+    obj.location_spec_name = location_spec_name
+    obj.location_spec_size = location_spec_size
+    obj.write_timeout_seconds = write_timeout_seconds
+    obj.backup_pgs = []
+    obj.backup_bandwidth = []
+    obj._manager_client = MagicMock()
+    obj.transfer_client = MagicMock()
+    obj.mem_pool_host = MagicMock()
+    return obj
+
+
+class TestBatchSetReturnValue(unittest.TestCase):
+    """Verify _batch_set returns a list aligned 1:1 with input keys."""
+
+    def _setup_connector(self, *, start_write_result, save_ok=True):
+        """Helper: wire up mocks and return the connector."""
+        c = _build_connector()
+
+        c._manager_client.start_write_cache.return_value = start_write_result
+
+        # mem_pool_host stubs – return enough ptrs/sizes
+        n_blocks = 20
+        c.mem_pool_host.get_page_buffer_meta.return_value = (
+            list(range(n_blocks * c.kv_factor)),
+            [c.location_spec_size] * (n_blocks * c.kv_factor),
+        )
+
+        # transfer_client.SaveKvCaches returns (error_code, ...)
+        err_code = _mock_kvcm.ClientErrorCode.ER_OK if save_ok else 999
+        c.transfer_client.SaveKvCaches.return_value = (err_code,)
+
+        return c
+
+    # ── Case 1: all keys already cached (unmatched == 0) ─────────────
+    def test_all_cached_returns_all_true(self):
+        """When startwrite says nothing needs writing, every position is True."""
+        keys = ["k0", "k1", "k2", "k3", "k4"]
+
+        # block_mask offset == len(prefix) + len(keys) → nothing to save
+        result_from_manager = {
+            "locations": [],
+            "write_session_id": "ws-1",
+            "block_mask": {"offset": 5},  # offset == len_prefix(0) + len_new(5)
+        }
+        c = self._setup_connector(start_write_result=result_from_manager)
+
+        result = c._batch_set(keys, torch.zeros(5), trace_id="t1")
+
+        self.assertEqual(len(result), len(keys))
+        self.assertEqual(result, [True, True, True, True, True])
+
+    # ── Case 2: partial write needed, write succeeds ─────────────────
+    def test_partial_write_success(self):
+        """Keys 0,1 already cached; keys 2,3,4 need writing and succeed."""
+        keys = ["k0", "k1", "k2", "k3", "k4"]
+
+        # offset=2 means indices [2,3,4] need saving (relative: [2,3,4])
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(3)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-2",
+            "block_mask": {"offset": 2},  # first 2 (prefix=0, so key 0,1) cached
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=True)
+
+        result = c._batch_set(keys, torch.zeros(5), trace_id="t2")
+
+        self.assertEqual(len(result), len(keys))
+        # key 0,1 → True (no write needed), key 2,3,4 → True (write succeeded)
+        self.assertEqual(result, [True, True, True, True, True])
+
+    # ── Case 3: partial write needed, write fails ────────────────────
+    def test_partial_write_failure(self):
+        """Keys 0,1 already cached; keys 2,3,4 need writing but fail."""
+        keys = ["k0", "k1", "k2", "k3", "k4"]
+
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(3)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-3",
+            "block_mask": {"offset": 2},
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=False)
+
+        result = c._batch_set(keys, torch.zeros(5), trace_id="t3")
+
+        self.assertEqual(len(result), len(keys))
+        # key 0,1 → True (no write needed), key 2,3,4 → False (write failed)
+        self.assertEqual(result, [True, True, False, False, False])
+
+    # ── Case 4: all keys need writing, write succeeds ────────────────
+    def test_all_need_write_success(self):
+        """All keys need writing and succeed."""
+        keys = ["k0", "k1", "k2"]
+
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(3)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-4",
+            "block_mask": {"offset": 0},
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=True)
+
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t4")
+
+        self.assertEqual(len(result), len(keys))
+        self.assertEqual(result, [True, True, True])
+
+    # ── Case 5: all keys need writing, write fails ───────────────────
+    def test_all_need_write_failure(self):
+        """All keys need writing but fail."""
+        keys = ["k0", "k1", "k2"]
+
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(3)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-5",
+            "block_mask": {"offset": 0},
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=False)
+
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t5")
+
+        self.assertEqual(len(result), len(keys))
+        self.assertEqual(result, [False, False, False])
+
+    # ── Case 6: with prefix_keys, partial cached ─────────────────────
+    def test_with_prefix_keys(self):
+        """prefix_keys present; some new keys cached, some need writing."""
+        keys = ["k3", "k4", "k5", "k6"]
+
+        # prefix_keys = ["p0", "p1", "p2"], len_prefix=3
+        # block_mask offset=5 means save from index 5 onward
+        # relative save_indices = [5-3, 6-3] = [2, 3]
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(2)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-6",
+            "block_mask": {"offset": 5},
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=True)
+
+        extra_info = MagicMock()
+        extra_info.prefix_keys = ["p0", "p1", "p2"]
+
+        result = c._batch_set(keys, torch.zeros(4), trace_id="t6",
+                              extra_info=extra_info)
+
+        self.assertEqual(len(result), len(keys))
+        # key 0,1 (k3,k4) → True (no write needed)
+        # key 2,3 (k5,k6) → True (write succeeded)
+        self.assertEqual(result, [True, True, True, True])
+
+    # ── Case 7: bool_masks with non-contiguous save_indices ──────────
+    def test_bool_masks_non_contiguous(self):
+        """bool_masks with gaps: only specific positions need writing."""
+        keys = ["k0", "k1", "k2", "k3", "k4"]
+
+        # bool_masks: True=cached, False=need write
+        # indices [0,1,2,3,4] → masks [False, True, False, True, False]
+        # save_indices (need write): [0, 2, 4]
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(3)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-7",
+            "block_mask": {
+                "bool_masks": {
+                    "values": [False, True, False, True, False]
+                }
+            },
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=True)
+
+        result = c._batch_set(keys, torch.zeros(5), trace_id="t7")
+
+        self.assertEqual(len(result), len(keys))
+        # index 0 → write succeeded (True)
+        # index 1 → cached (True)
+        # index 2 → write succeeded (True)
+        # index 3 → cached (True)
+        # index 4 → write succeeded (True)
+        self.assertEqual(result, [True, True, True, True, True])
+
+    # ── Case 8: bool_masks non-contiguous, write fails ───────────────
+    def test_bool_masks_non_contiguous_failure(self):
+        """bool_masks with gaps, write fails."""
+        keys = ["k0", "k1", "k2", "k3", "k4"]
+
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(3)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-8",
+            "block_mask": {
+                "bool_masks": {
+                    "values": [False, True, False, True, False]
+                }
+            },
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=False)
+
+        result = c._batch_set(keys, torch.zeros(5), trace_id="t8")
+
+        self.assertEqual(len(result), len(keys))
+        # index 0 → write failed (False)
+        # index 1 → cached (True)
+        # index 2 → write failed (False)
+        # index 3 → cached (True)
+        # index 4 → write failed (False)
+        self.assertEqual(result, [False, True, False, True, False])
+
+    # ── Case 9: batch_set_v1 exception returns all False ─────────────
+    def test_batch_set_v1_exception(self):
+        """batch_set_v1 catches exceptions and returns all False."""
+        c = _build_connector()
+        c._manager_client.start_write_cache.side_effect = RuntimeError("boom")
+
+        result = c.batch_set_v1(["k0", "k1", "k2"], torch.zeros(3))
+
+        self.assertEqual(result, [False, False, False])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Fix `_batch_set` return value**: The returned `List[bool]` now maps 1:1 positionally with input keys. Keys that KVCM's `startwrite` indicates already exist in remote storage return `True` instead of `False`, preventing sglang from incorrectly treating partial writes as failures.
- **Support both old and new sglang `StorageMetrics` import path**: `StorageMetrics` was moved from `sglang.srt.metrics.collector` to `sglang.srt.observability.metrics_collector` in newer sglang versions. The connector now tries both paths and raises a clear `ImportError` if neither is available.
- **Auto-declare `interface_v1` support**: The connector sets `interface_v1=1` in `extra_config` during `__init__`, so sglang's `cache_controller` routes to `batch_set_v1`/`batch_get_v1` (zero-copy path) automatically. Users no longer need to manually add `"interface_v1": 1` in `--hicache-storage-backend-extra-config`.
- **Add local debugging guide**: `LOCAL_DEBUG_GUIDE.md` with step-by-step instructions for building the connector wheel, launching KVCM manager + sglang, and verifying backup/prefetch/partial-write flows.

## Test plan

- [x] Unit tests for `_batch_set` return value (8 cases covering all branches)
- [x] E2E: full write + prefetch (verified `#cached-token > 0` in sglang logs)
- [x] E2E: partial write scenario (prefix cached + new blocks written, no errors)
- [x] E2E: sglang logs clean (no `Exception`/`NotImplementedError`/`failed`)

🤖 Generated with [Qoder][https://qoder.com]