### PR TITLE
[connector/sglang] support sdk_backend_configs pass-through via extra_config

### DIFF
--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -132,7 +132,7 @@ class HiCacheKVCM(HiCacheStorage):
         self.write_iov_block_size = self.extra_config.get("write_iov_block_size", 0)
         self.iov_size = self.location_spec_size * 1024
 
-        sdk_backend_configs = []
+        sdk_backend_configs = list(self.extra_config.get("sdk_backend_configs", []))
 
         hf3fs_configs = self.parse_hf3fs_configs(self.storage_configs)
         sdk_backend_configs.extend(hf3fs_configs)


### PR DESCRIPTION
## Summary
- Allow users to specify initial `sdk_backend_configs` via `--hicache-storage-backend-extra-config`, enabling pass-through of SDK backend configurations (e.g. `pace`, `mooncake`) without code changes.
- User-provided configs are prepended, then `hf3fs` configs parsed from `storage_configs` are appended as before.
- When `sdk_backend_configs` is not set in `extra_config`, behavior is identical to before (defaults to empty list).

## Changes
- `kv_cache_manager/py_connector/sglang/connector.py`: Changed `sdk_backend_configs = []` to `sdk_backend_configs = list(self.extra_config.get("sdk_backend_configs", []))`.

## Usage Example
```bash
EXTRA_CONFIG='{
    ...
    "sdk_backend_configs": [
        {"type": "xxxx", "xxxxxx": "xxxxxxx"}
    ]
}'
python -m sglang.launch_server ... --hicache-storage-backend-extra-config "$EXTRA_CONFIG"
```

## Test plan
- [x] Verify that without `sdk_backend_configs` in extra_config, behavior is unchanged
- [x] Verify that with `sdk_backend_configs` set, user configs are correctly passed through to TransferClient
- [x] Verify hf3fs configs from storage_configs are still appended after user configs