### PR TITLE
[cicd] delete old disk cache before rebuild new one

### DIFF
--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -97,10 +97,13 @@ jobs:
           curl -sL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_${ARCH}.tar.gz" | tar xz --strip-components=1 -C /usr/local
           # Delete old disk cache so setup-bazel post action can save the new one.
           # GitHub Actions cache is immutable - same key cannot be overwritten.
-          # Match by our disk-cache name to avoid depending on setup-bazel's internal key format.
+          # Match by our disk-cache name and runner arch to avoid depending on
+          # setup-bazel's internal key format, while not deleting other arches' caches.
+          RUNNER_ARCH_LOWER=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
           DISK_CACHE_NAME="disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}"
           gh cache list --repo ${{ github.repository }} --json id,key --limit 100 | \
-            jq -r --arg name "$DISK_CACHE_NAME" '.[] | select(.key | contains($name)) | .key' | \
+            jq -r --arg arch "$RUNNER_ARCH_LOWER" --arg name "$DISK_CACHE_NAME" \
+              '.[] | select((.key | contains($arch)) and (.key | contains($name))) | .key' | \
             xargs -I {} gh cache delete "{}" --repo ${{ github.repository }} || true
       - name: detect_crashes
         if: failure()

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -97,10 +97,10 @@ jobs:
           curl -sL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_${ARCH}.tar.gz" | tar xz --strip-components=1 -C /usr/local
           # Delete old disk cache so setup-bazel post action can save the new one.
           # GitHub Actions cache is immutable - same key cannot be overwritten.
-          RUNNER_ARCH_LOWER=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
-          CACHE_KEY="setup-bazel-1-linux-${RUNNER_ARCH_LOWER}-disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}"
-          gh cache list --repo ${{ github.repository }} --key "${CACHE_KEY}" --json id,key | \
-            jq -r '.[].key' | \
+          # Match by our disk-cache name to avoid depending on setup-bazel's internal key format.
+          DISK_CACHE_NAME="disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}"
+          gh cache list --repo ${{ github.repository }} --json id,key --limit 100 | \
+            jq -r --arg name "$DISK_CACHE_NAME" '.[] | select(.key | contains($name)) | .key' | \
             xargs -I {} gh cache delete "{}" --repo ${{ github.repository }} || true
       - name: detect_crashes
         if: failure()

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -97,7 +97,9 @@ jobs:
           curl -sL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_${ARCH}.tar.gz" | tar xz --strip-components=1 -C /usr/local
           # Delete old disk cache so setup-bazel post action can save the new one.
           # GitHub Actions cache is immutable - same key cannot be overwritten.
-          gh cache list --repo ${{ github.repository }} --key "setup-bazel-1-linux-x64-disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}" --json id,key | \
+          RUNNER_ARCH_LOWER=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+          CACHE_KEY="setup-bazel-1-linux-${RUNNER_ARCH_LOWER}-disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}"
+          gh cache list --repo ${{ github.repository }} --key "${CACHE_KEY}" --json id,key | \
             jq -r '.[].key' | \
             xargs -I {} gh cache delete "{}" --repo ${{ github.repository }} || true
       - name: detect_crashes

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -103,8 +103,8 @@ jobs:
           DISK_CACHE_NAME="disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}"
           gh cache list --repo ${{ github.repository }} --json id,key --limit 100 | \
             jq -r --arg arch "$RUNNER_ARCH_LOWER" --arg name "$DISK_CACHE_NAME" \
-              '.[] | select((.key | contains($arch)) and (.key | contains($name))) | .key' | \
-            xargs -I {} gh cache delete "{}" --repo ${{ github.repository }} || true
+              '.[] | select((.key | contains($arch)) and (.key | contains($name))) | .id' | \
+            xargs -I {} gh cache delete {} --repo ${{ github.repository }} || true
       - name: detect_crashes
         if: failure()
         run: |

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -1,6 +1,7 @@
 name: test-opensrc
 permissions:
   contents: read
+  actions: write
 on:
   push:
     branches: [ "main" ]
@@ -83,6 +84,22 @@ jobs:
           set -e
           ulimit -c unlimited
           bazelisk test ${{ matrix.test_target }} ${{ matrix.test_args }} --cache_test_results=no --test_output=errors
+      - name: delete_old_disk_cache
+        if: ${{ inputs.rebuildDiskCache || false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -x
+          # Install gh and jq (not pre-installed in the container image)
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -sLo /usr/local/bin/jq "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-${ARCH}" && chmod +x /usr/local/bin/jq
+          GH_VER=2.89.0
+          curl -sL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_${ARCH}.tar.gz" | tar xz --strip-components=1 -C /usr/local
+          # Delete old disk cache so setup-bazel post action can save the new one.
+          # GitHub Actions cache is immutable - same key cannot be overwritten.
+          gh cache list --repo ${{ github.repository }} --key "setup-bazel-1-linux-x64-disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}" --json id,key | \
+            jq -r '.[].key' | \
+            xargs -I {} gh cache delete "{}" --repo ${{ github.repository }} || true
       - name: detect_crashes
         if: failure()
         run: |


### PR DESCRIPTION
## Summary
- GitHub Actions cache is immutable — the same key cannot be overwritten. When `rebuildDiskCache=true`, the `setup-bazel` post action always failed to save the new disk cache because the old cache with the same key still existed.
- Fix by adding a `delete_old_disk_cache` step after `bazel_test` succeeds that uses `gh cache delete` to remove the old cache, so the post action can save the new one.
- Installs `gh` (v2.89.0) and `jq` (v1.8.1) as standalone binaries since the container image does not include them. Supports both amd64 and arm64.
- Adds `actions: write` permission required for cache deletion.

## Test plan
- [x] Triggered workflow with `rebuildDiskCache=true` on the `fix-rebuild-disk-cache` branch: https://github.com/alibaba/tair-kvcache/actions/runs/23600006970
- [x] Verify `delete_old_disk_cache` step installs `gh`/`jq` and deletes old cache successfully
- [x] Verify `setup-bazel` post action saves the new cache successfully