### PR TITLE
[cicd] use pull_request_target to support fork PRs

### DIFF
--- a/.github/workflows/qoder-code-review.yml
+++ b/.github/workflows/qoder-code-review.yml
@@ -1,7 +1,7 @@
 name: Qoder Auto Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, unlabeled ]
     branches: [ "main" ]
   issue_comment:
@@ -23,8 +23,8 @@ jobs:
     # 4. Manual workflow dispatch
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.action != 'unlabeled') ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'ai reviewed') ||
+      (github.event_name == 'pull_request_target' && github.event.action != 'unlabeled') ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'ai reviewed') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@tair-ci review') &&
@@ -38,7 +38,7 @@ jobs:
       - name: Determine PR number
         id: pr-info
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "number=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -5,7 +5,7 @@ permissions:
 on:
   push:
     branches: [ "main" ]
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
   workflow_dispatch:
     inputs:
@@ -22,7 +22,7 @@ on:
         default: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.runs-on || 'ubuntu-latest' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     strategy:
@@ -58,8 +58,6 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -5,7 +5,7 @@ permissions:
 on:
   push:
     branches: [ "main" ]
-  pull_request:
+  pull_request_target:
     branches: [ "main" ]
   workflow_dispatch:
     inputs:
@@ -21,8 +21,8 @@ on:
         type: boolean
         default: false
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runs-on || 'ubuntu-latest' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.runs-on || 'ubuntu-latest' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 jobs:
   test:
     strategy:
@@ -58,6 +58,8 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true


### PR DESCRIPTION
## Summary
- Switch `pull_request` to `pull_request_target` in `test-opensrc.yml` and `qoder-code-review.yml` so that workflows trigger correctly for PRs from external forks.
- `pull_request` event uses the workflow file from the fork (which may not exist) and restricts secrets/token permissions, causing both CI and Qoder review to silently skip fork PRs.
- Also fix concurrency group (use PR number instead of `github.ref` to avoid all fork PRs sharing the same group) and checkout ref (explicitly use PR head SHA for `pull_request_target`).

## Test plan
- [ ] Merge to main, then open a PR from an external fork targeting main
- [ ] Verify test-opensrc workflow triggers and runs tests correctly
- [ ] Verify Qoder Auto Code Review workflow triggers and posts review comments
- [ ] Verify internal PRs still trigger both workflows as before