### PR TITLE
[meta] validate MetaIndexer metadata persistence & recovery

### DIFF
--- a/integration_test/reclaimer/reclaiming_test.py
+++ b/integration_test/reclaimer/reclaiming_test.py
@@ -161,6 +161,294 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         # now the writing of key=16 should success
         self._write(16)
 
+    def test_persist_recover_00(self):
+        """Test e2e persist/recover: cache locations and metadata
+        survive a normal server restart.
+
+        The meta indexer is configured with the dummy backend with
+        filesystem persistence enabled so that
+
+        1. cache locations are always flushed to disk, and
+        2. metadata like key_count and storage usage accounting data are
+           flushed to disk *before* every metadata READ.
+
+        After a controlled server restart the instance group is
+        re-registered (which reinitialise the MetaIndexer from the
+        persisted file), and the test verifies:
+
+        1. All block meta written before the restart are still
+           addressable.
+        2. key_count was recovered (not reset to zero), so the capacity
+           limit is enforced correctly.
+        """
+        add_storage_req = {
+            "trace_id": self._trace_id,
+            "storage": self._make_dummy_storage(),
+        }
+        self._admin_client.add_storage(add_storage_req)
+
+        # add instance group
+        # start with the reclaiming trigger would not happen
+        ig = self._make_dummy_instance_group()
+        create_ig_req = {
+            "trace_id": self._trace_id,
+            "instance_group": ig,
+        }
+        self._admin_client.create_instance_group(create_ig_req)
+
+        # register instance
+        reg_ins_data_req = self._make_dummy_ins_req()
+        self._client.register_instance(reg_ins_data_req)
+
+        # write 8 blocks (half of max_key_count=16)
+        write_count = 8
+        for i in range(write_count):
+            self._write(i)
+
+        # --- restart ---
+        self.worker_manager.stop_worker(0)
+        self.assertTrue(self.worker_manager.start_worker(0))
+
+        # reconnect clients: update_ports() assigns fresh ports on every
+        # start
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_client()
+
+        # the registry is in-memory only, so re-add the storage and
+        # instance group after restart
+        # crucially the same storage_uri is used so that
+        # MetaIndexer.Init -> RecoverMetaData will reload key_count and
+        # storage_usage_data from the persisted file
+        self._admin_client.add_storage(add_storage_req)
+        create_ig_req["trace_id"] = self._trace_id + "_restart"
+        self._admin_client.create_instance_group(create_ig_req)
+        self._client.register_instance(reg_ins_data_req)
+
+        # 1. verify that all blocks written before the restart are still
+        #    addressable (cache locations was persisted and recovered)
+        for i in range(write_count):
+            get_location_req = {
+                "trace_id": f"{self._trace_id}_verify_{i}",
+                "query_type": "QT_PREFIX_MATCH",
+                "block_keys": [i],
+                "instance_id": self._instance_id,
+                "block_mask": {"offset": 0},
+            }
+            resp = self._client.get_cache_location(get_location_req)
+            self.assertGreater(
+                len(resp["locations"]),
+                0,
+                f"block {i} should be accessible after restart",
+            )
+
+        # 2. verify key_count was recovered (not reset to zero)
+        #    write the remaining 8 blocks (keys 8-15) to reach
+        #    max_key_count=16
+        for i in range(write_count, 16):
+            self._write(i)
+        # key_count is now:
+        # 8 (recovered) + 8 (just written) = 16 = max_key_count
+        # so the next write must be rejected
+        self._start_write_expect_fail(16)
+
+    def test_persist_recover_01(self):
+        """Test e2e persist/recover: storage usage data survives a
+        normal server restart.
+
+        After writing all 16 blocks (filling key_count to
+        max_key_count=16), each block contributes 1024 bytes to
+        StorageUsageData for the NFS storage type.  StorageUsageData is
+        persisted to the dummy backend together with key_count.
+
+        After a controlled server restart the instance group is
+        re-registered, which reloads StorageUsageData from the persisted
+        file.  The test verifies recovery by observing the reclaimer's
+        byte-usage trigger:
+
+        * If StorageUsageData IS recovered (grp_used_byte_sz_ > 0):
+          the group byte-usage ratio is 0.5 which exceeds the 0.1
+          threshold → the reclaimer fires → some blocks are freed → a
+          new write succeeds.
+
+        * If StorageUsageData is NOT recovered (grp_used_byte_sz_ == 0):
+          cache_reclaimer.cc line 480 returns early with water-level
+          = false even though key_count was recovered; the reclaimer
+          does NOT trigger → the write still fails.
+        """
+        add_storage_req = {
+            "trace_id": self._trace_id,
+            "storage": self._make_dummy_storage(),
+        }
+        self._admin_client.add_storage(add_storage_req)
+
+        # add instance group
+        # start with the reclaiming trigger would not happen
+        ig = self._make_dummy_instance_group()
+        create_ig_req = {
+            "trace_id": self._trace_id,
+            "instance_group": ig,
+        }
+        self._admin_client.create_instance_group(create_ig_req)
+
+        # register instance
+        reg_ins_data_req = self._make_dummy_ins_req()
+        self._client.register_instance(reg_ins_data_req)
+
+        # write all 16 blocks to fill key_count to max_key_count=16
+        # each block also adds 1024 bytes to StorageUsageData (NFS type)
+        for i in range(16):
+            self._write(i)
+
+        # key_count is now at max; the next write must be rejected
+        self._start_write_expect_fail(16)
+
+        # --- restart ---
+        self.worker_manager.stop_worker(0)
+        self.assertTrue(self.worker_manager.start_worker(0))
+
+        # reconnect clients after restart
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_client()
+
+        # re-register storage and instance group using the same storage_uri
+        # so that MetaIndexer.Init -> RecoverMetaData reloads both key_count
+        # and storage_usage_data from the persisted file
+        self._admin_client.add_storage(add_storage_req)
+        create_ig_req["trace_id"] = self._trace_id + "_restart"
+        self._admin_client.create_instance_group(create_ig_req)
+        self._client.register_instance(reg_ins_data_req)
+
+        # key_count is recovered to 16 = max, so write must still fail
+        self._start_write_expect_fail(16)
+
+        # lower the reclaim trigger so the reclaimer fires ONLY if
+        # storage_usage_data was recovered:
+        #   not recovered → grp_used_byte_sz_ == 0 → trigger checker
+        #                   early-return false → reclaimer does NOT run
+        #                   → write fails
+        #   recovered     → grp_used_byte_sz_ == 16 * 1024 = 16384 bytes
+        #                   group ratio = 16384 / 32768 = 0.5 > 0.1
+        #                   → reclaimer fires → blocks freed → write
+        #                   succeeds
+        curr_ver = ig["version"]
+        ig["version"] = curr_ver + 1
+        ig[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "trigger_strategy"
+        ][
+            "used_percentage"
+        ] = 0.1
+        update_ig_req = {
+            "trace_id": self._trace_id + "_update_ig",
+            "instance_group": ig,
+            "current_version": curr_ver,
+        }
+        self._admin_client.update_instance_group(update_ig_req)
+
+        # 2 seconds is enough for the background reclaimer to run
+        time.sleep(2)
+
+        # write should succeed only if reclaiming happened, which
+        # requires storage_usage_data to have survived the restart
+        self._write(16)
+
+    def test_persist_recover_02(self):
+        """Test metadata persistence-recovery backward compatibility
+        handling.
+
+        Scenario
+        --------
+        1. Setup: Fill test_instance_01 with 16 blocks but do not
+           trigger reclaiming.
+        2. Restart the server with intentionally crafted version 0
+           metadata file, that is, only key_count is included.
+        3. Re-register test_instance_01, lower the threshold for
+           test_group_01; make the reclaimer fires.
+        4. Assert: a new write to test_instance_01 should success, which
+           means the reclaiming worked as expected, thus the backward
+           compatibility is properly handled.
+        """
+        # add storage
+        add_storage_req = {
+            "trace_id": self._trace_id,
+            "storage": self._make_dummy_storage(),
+        }
+        self._admin_client.add_storage(add_storage_req)
+
+        # add instance group; reclaim trigger is intentionally too high
+        # to fire at this point
+        ig = self._make_dummy_instance_group()
+        create_ig_req = {
+            "trace_id": self._trace_id,
+            "instance_group": ig,
+        }
+        self._admin_client.create_instance_group(create_ig_req)
+
+        # register test_instance_01
+        reg_ins_01_req = self._make_dummy_ins_req()
+        self._client.register_instance(reg_ins_01_req)
+
+        # write 16 keys into test_instance_01
+        for i in range(16):
+            self._write(i)
+
+        # storage quota is full
+        self._start_write_expect_fail(16)
+
+        # restart the server
+        self.worker_manager.stop_worker(0)
+        meta_storage_backend_config = ig[
+            "cache_config"
+        ][
+            "meta_indexer_config"
+        ][
+            "meta_storage_backend_config"
+        ]
+        self._make_v0_persist_data(meta_storage_backend_config)
+        self.assertTrue(self.worker_manager.start_worker(0))
+
+        # reconnect clients: update_ports() assigns fresh ports on every
+        # start
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_client()
+
+        # re-add the storage and instance group after restart
+        # re-register test_instance_01 to bring the recovered indexer
+        # back online
+        self._admin_client.add_storage(add_storage_req)
+        create_ig_req["trace_id"] = self._trace_id + "_restart"
+        self._admin_client.create_instance_group(create_ig_req)
+        self._client.register_instance(reg_ins_01_req)
+
+        # fire the reclaimer for test_group_01
+        curr_ver = ig["version"]
+        ig["version"] = curr_ver + 1
+        ig[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "trigger_strategy"
+        ][
+            "used_percentage"
+        ] = 0.1
+        self._admin_client.update_instance_group({
+            "trace_id": self._trace_id + "_update_ig",
+            "instance_group": ig,
+            "current_version": curr_ver,
+        })
+
+        time.sleep(2)
+
+        # this write can succeed only when v0 meta is properly handled
+        self._write(16)
+
     def _get_manager_client(self):
         self._admin_http_port = self.worker_manager.get_worker(
             0).env.admin_http_port
@@ -276,7 +564,7 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         return {
             "global_unique_name": self._storage_name,
             "nfs": {
-                "root_path": f"/tmp/{self._storage_name}",
+                "root_path": f"{self.get_workdir()}/{self._storage_name}/",
             }
         }
 
@@ -312,13 +600,14 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
                     "max_key_count": 16,  # start with 16 max key
                     "mutex_shard_num": 16,
                     "meta_storage_backend_config": {
-                        "storage_type": "local",
-                        "storage_uri": "",  # disable persistence
+                        "storage_type": "dummy",
+                        "storage_uri": f"file://{self.get_workdir()}/meta_storage_{self._instance_group_name}",
                     },
                     "meta_cache_policy_config": {
                         "capacity": 1024 * 1024 * 1024,
                         "type": "LRU",
-                    }
+                    },
+                    "persist_metadata_interval_time_ms": 0,
                 }
             },
             "user_data": "user-defined info",
@@ -349,6 +638,34 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             "dp_size": 1,
             "pp_size": 1,
         }
+
+    def _make_v0_persist_data(self, meta_storage_backend_conf):
+        if meta_storage_backend_conf["storage_type"] == "dummy":
+            # rewrite the persisted metadata file
+            import json
+            d = {}
+
+            persist_path = meta_storage_backend_conf["storage_uri"]
+            persist_path = persist_path.removeprefix("file://")
+            persist_path = "_".join((persist_path, self._instance_id,))
+
+            with open(persist_path, 'r') as f:
+                meta_key = "__metadata__"
+                key = "__storage_usage_data__"
+                d = json.load(f)
+                d1 = json.loads(d[meta_key])
+                if key in d1:
+                    del d1[key]
+                d[meta_key] = json.dumps(d1)
+
+            with open(persist_path, 'w') as f:
+                json.dump(d, f)
+
+        elif meta_storage_backend_conf["storage_type"] == "local":
+            pass
+        elif meta_storage_backend_conf["storage_type"] == "redis":
+            # TODO
+            pass
 
 
 if __name__ == "__main__":

--- a/kv_cache_manager/config/meta_indexer_config.h
+++ b/kv_cache_manager/config/meta_indexer_config.h
@@ -34,6 +34,7 @@ public:
         : max_key_count_(max_key_count)
         , mutex_shard_num_(mutex_shard_num)
         , batch_key_size_(batch_key_size)
+        , persist_metadata_interval_time_ms_(kDefaultPersistMetaDataIntervalTimeMs)
         , meta_storage_backend_config_(meta_storage_backend_config)
         , meta_cache_policy_config_(meta_cache_policy_config) {}
 
@@ -83,6 +84,7 @@ public:
         Put(writer, "max_key_count", max_key_count_);
         Put(writer, "mutex_shard_num", mutex_shard_num_);
         Put(writer, "batch_key_size", batch_key_size_);
+        Put(writer, "persist_metadata_interval_time_ms", persist_metadata_interval_time_ms_);
         Put(writer, "meta_storage_backend_config", meta_storage_backend_config_);
         Put(writer, "meta_cache_policy_config", meta_cache_policy_config_);
     }

--- a/kv_cache_manager/meta/BUILD
+++ b/kv_cache_manager/meta/BUILD
@@ -36,6 +36,7 @@ cc_library(
         ":common",
         ":meta_search_cache",
         ":meta_cached_backend",
+        ":meta_dummy_backend",
         ":meta_local_backend",
         ":meta_redis_backend",
         ":meta_storage_backend",
@@ -85,6 +86,23 @@ cc_library(
 )
 
 cc_library(
+    name = "meta_dummy_backend",
+    srcs = [
+        "meta_dummy_backend.cc",
+    ],
+    hdrs = [
+        "meta_dummy_backend.h",
+    ],
+    deps = [
+        ":common",
+        ":meta_storage_backend",
+        "//kv_cache_manager/common:concurrent_hash_map",
+        "//kv_cache_manager/common:standard_uri",
+        "//kv_cache_manager/common:string_util",
+    ],
+)
+
+cc_library(
     name = "meta_local_base_backend",
     srcs = [
     ],
@@ -108,7 +126,6 @@ cc_library(
         ":common",
         ":meta_local_base_backend",
         ":meta_search_cache",
-        "//kv_cache_manager/common:concurrent_hash_map",
         "//kv_cache_manager/common:lru_cache",
         "//kv_cache_manager/common:standard_uri",
         "//kv_cache_manager/common:string_util",

--- a/kv_cache_manager/meta/common.h
+++ b/kv_cache_manager/meta/common.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 namespace kv_cache_manager {
+static const std::string META_DUMMY_BACKEND_TYPE_STR = "dummy";
 static const std::string META_LOCAL_BACKEND_TYPE_STR = "local";
 static const std::string META_REDIS_BACKEND_TYPE_STR = "redis";
 static const std::string META_CACHED_BACKEND_TYPE_STR = "cached";

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -1,0 +1,446 @@
+#include "kv_cache_manager/meta/meta_dummy_backend.h"
+
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/jsonizable.h"
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/standard_uri.h"
+#include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/config/meta_storage_backend_config.h"
+#include "kv_cache_manager/meta/common.h"
+
+namespace kv_cache_manager {
+
+// special key used in the persistence file to identify the metadata
+// entry, non-numeric so it is guaranteed never to collide with any
+// numeric cache key
+static constexpr const char *kMetadataFileKey = "__metadata__";
+
+std::string MetaDummyBackend::GetStorageType() noexcept { return META_DUMMY_BACKEND_TYPE_STR; }
+
+ErrorCode MetaDummyBackend::Init(const std::string &instance_id,
+                                 const std::shared_ptr<MetaStorageBackendConfig> &config) noexcept {
+    if (instance_id.empty()) {
+        KVCM_LOG_ERROR("init fail, instance_id is empty");
+        return ErrorCode::EC_BADARGS;
+    }
+    if (!config) {
+        KVCM_LOG_ERROR("init fail, config is nullptr");
+        return ErrorCode::EC_BADARGS;
+    }
+    if (const std::string storage_uri_str = config->GetStorageUri(); storage_uri_str.empty()) {
+        enable_persistence_ = false;
+    } else {
+        const StandardUri storage_uri = StandardUri::FromUri(storage_uri_str);
+        enable_persistence_ = true;
+        path_ = storage_uri.GetPath() + "_" + instance_id;
+    }
+    return ErrorCode::EC_OK;
+}
+
+ErrorCode MetaDummyBackend::Open() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+
+    table_.Clear();
+    metadata_.clear();
+    if (!enable_persistence_) {
+        return ErrorCode::EC_OK;
+    }
+
+    std::error_code ec;
+    bool exists = std::filesystem::exists(path_, ec);
+    if (ec) {
+        KVCM_LOG_ERROR("file existed, err msg: [%s], path: [%s]", ec.message().c_str(), path_.c_str());
+        return ErrorCode::EC_IO_ERROR;
+    }
+    if (!exists) {
+        return ErrorCode::EC_OK;
+    }
+
+    std::ifstream ifs(path_);
+    if (!ifs.is_open()) {
+        KVCM_LOG_ERROR("fail to open file, path: [%s]", path_.c_str());
+        return ErrorCode::EC_IO_ERROR;
+    }
+
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    std::map<std::string, std::string> parsed;
+    if (!Jsonizable::FromJsonString(content, parsed)) {
+        KVCM_LOG_ERROR("parse top-level json failed, path: [%s], raw content: [%s]", path_.c_str(), content.c_str());
+        return ErrorCode::EC_ERROR;
+    }
+    for (auto &[k, v] : parsed) {
+        FieldMap parsed_v;
+        if (!Jsonizable::FromJsonString(v, parsed_v)) {
+            KVCM_LOG_ERROR("parse field_map json failed, path: [%s], raw content: [%s]", path_.c_str(), v.c_str());
+            return ErrorCode::EC_ERROR;
+        }
+
+        // parse metadata
+        if (k == kMetadataFileKey) {
+            metadata_ = std::move(parsed_v);
+            continue;
+        }
+
+        // parse block data
+        KeyType key;
+        if (!StringUtil::StrToInt64(k.c_str(), key)) {
+            KVCM_LOG_ERROR("parse key to int64_t failed, path: [%s], raw key string: [%s]", path_.c_str(), k.c_str());
+            return ErrorCode::EC_ERROR;
+        }
+        table_.Emplace(key, std::move(parsed_v));
+    }
+
+    return ErrorCode::EC_OK;
+}
+
+ErrorCode MetaDummyBackend::Close() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return ErrorCode::EC_OK;
+}
+
+// should be used with protection of mutex
+ErrorCode MetaDummyBackend::PersistToPath() {
+    if (!enable_persistence_) {
+        return ErrorCode::EC_OK;
+    }
+
+    std::map<std::string, std::string> persist_table;
+
+    // block data
+    table_.ForEachKV([&](const KeyType &key, const FieldMap &field_map) {
+        persist_table[std::to_string(key)] = Jsonizable::ToJsonString(field_map);
+        return true;
+    });
+
+    // metadata
+    if (!metadata_.empty()) {
+        persist_table[kMetadataFileKey] = Jsonizable::ToJsonString(metadata_);
+    }
+
+    const std::string json_content = Jsonizable::ToJsonString(persist_table);
+    std::ofstream ofs(path_);
+    if (!ofs.is_open()) {
+        KVCM_LOG_ERROR("cannot open file for write, path: [%s]", path_.c_str());
+        return ErrorCode::EC_IO_ERROR;
+    }
+    ofs << json_content;
+    return ErrorCode::EC_OK;
+}
+
+std::vector<ErrorCode> MetaDummyBackend::Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
+    if (keys.size() != field_maps.size()) {
+        KVCM_LOG_ERROR("put failed, keys.size: [%zu] != field_maps.size: [%zu]", keys.size(), field_maps.size());
+        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
+    }
+
+    std::vector<ErrorCode> ec_vec;
+    for (std::size_t i = 0; i != keys.size(); ++i) {
+        ec_vec.emplace_back(PutForOneKey(keys[i], field_maps[i]));
+        if (ec_vec.back() != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("put failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
+                          keys[i],
+                          static_cast<std::int32_t>(ec_vec.back()));
+        }
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::PutForOneKey(const KeyType &key, const FieldMap &field_map) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    table_.Upsert(key, field_map);
+    return PersistToPath();
+}
+
+std::vector<ErrorCode> MetaDummyBackend::UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
+    if (keys.size() != field_maps.size()) {
+        KVCM_LOG_ERROR("update fields failed, keys.size[%zu] != field_maps.size[%zu]", keys.size(), field_maps.size());
+        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
+    }
+    std::vector<ErrorCode> ec_vec;
+    for (std::size_t i = 0; i != keys.size(); ++i) {
+        ec_vec.emplace_back(UpdateFieldsForOneKey(keys[i], field_maps[i]));
+        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
+            KVCM_LOG_WARN("update fields failed, key: [%" PRIi64 "], ec:[%" PRIi32 "]",
+                          keys[i],
+                          static_cast<std::int32_t>(ec_vec.back()));
+        }
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::UpdateFieldsForOneKey(const KeyType &key, const FieldMap &field_map) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    const bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
+        for (const auto &[field_name, field_value] : field_map) {
+            existing_map[field_name] = field_value;
+        }
+    });
+    if (!found) {
+        KVCM_LOG_WARN("update fields failed due to key cannot be found, key: [%" PRIi64 "]", key);
+        return ErrorCode::EC_NOENT;
+    }
+    return PersistToPath();
+}
+
+std::vector<ErrorCode> MetaDummyBackend::Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
+    if (keys.size() != field_maps.size()) {
+        KVCM_LOG_ERROR("upsert failed, keys.size: [%zu] != field_maps.size: [%zu]", keys.size(), field_maps.size());
+        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
+    }
+
+    std::vector<ErrorCode> ec_vec;
+    for (std::size_t i = 0; i != keys.size(); ++i) {
+        ec_vec.emplace_back(UpsertForOneKey(keys[i], field_maps[i]));
+        if (ec_vec.back() != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("upsert failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]", keys[i], ec_vec.back());
+        }
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::UpsertForOneKey(const KeyType &key, const FieldMap &field_map) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    const bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
+        for (const auto &[field_name, field_value] : field_map) {
+            existing_map[field_name] = field_value;
+        }
+    });
+    if (!found) {
+        table_.Upsert(key, field_map);
+    }
+    return PersistToPath();
+}
+
+std::vector<ErrorCode> MetaDummyBackend::IncrFields(const KeyTypeVec &keys,
+                                                    const std::map<std::string, std::int64_t> &field_amounts) noexcept {
+    std::vector<ErrorCode> ec_vec;
+    for (const KeyType &key : keys) {
+        ec_vec.emplace_back(IncrFieldsForOneKey(key, field_amounts));
+        if (ec_vec.back() != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("incr fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
+                          key,
+                          static_cast<std::int32_t>(ec_vec.back()));
+        }
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::IncrFieldsForOneKey(const KeyType &key,
+                                                const std::map<std::string, std::int64_t> &field_amounts) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    ErrorCode ec = ErrorCode::EC_OK;
+    const bool found = table_.FindAndModify(key, [&](FieldMap &field_map) {
+        std::map<std::string, std::string> new_field_map;
+        for (const auto &[field_name, amount] : field_amounts) {
+            const auto field_iter = field_map.find(field_name);
+            if (field_iter == field_map.end()) {
+                KVCM_LOG_ERROR("incr fields failed due to field cannot be found, field: [%s], key: [%" PRIi64 "]",
+                               field_name.c_str(),
+                               key);
+                ec = ErrorCode::EC_BADARGS;
+                return;
+            }
+            const auto &old_field_value = field_iter->second;
+            std::int64_t old_field_value_num = 0;
+            if (!StringUtil::StrToInt64(old_field_value.c_str(), old_field_value_num)) {
+                KVCM_LOG_ERROR("incr fields failed due to value cannot be interpreted to int64_t, "
+                               "field: [%s], value: [%s], key: [%" PRIi64 "]",
+                               field_name.c_str(),
+                               old_field_value.c_str(),
+                               key);
+                ec = ErrorCode::EC_BADARGS;
+                return;
+            }
+            new_field_map[field_name] = std::to_string(old_field_value_num + amount);
+        }
+        for (const auto &[field_name, new_field_value] : new_field_map) {
+            field_map[field_name] = new_field_value;
+        }
+    });
+    if (!found) {
+        KVCM_LOG_WARN("incr fields failed due to key cannot be found, key: [%" PRIi64 "]", key);
+        return ErrorCode::EC_NOENT;
+    }
+    if (ec != ErrorCode::EC_OK) {
+        return ec;
+    }
+    return PersistToPath();
+}
+
+std::vector<ErrorCode> MetaDummyBackend::Delete(const KeyTypeVec &keys) noexcept {
+    std::vector<ErrorCode> ec_vec;
+    for (const KeyType &key : keys) {
+        ec_vec.emplace_back(DeleteForOneKey(key));
+        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
+            KVCM_LOG_WARN("delete failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
+                          key,
+                          static_cast<std::int32_t>(ec_vec.back()));
+        }
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::DeleteForOneKey(const KeyType &key) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (!table_.Contains(key)) {
+        return ErrorCode::EC_NOENT;
+    }
+    table_.Erase(key);
+    return PersistToPath();
+}
+
+std::vector<ErrorCode> MetaDummyBackend::Get(const KeyTypeVec &keys,
+                                             const std::vector<std::string> &field_names,
+                                             FieldMapVec &out_field_maps) noexcept {
+    std::vector<ErrorCode> ec_vec;
+    out_field_maps = FieldMapVec(keys.size());
+    for (std::size_t i = 0; i != keys.size(); ++i) {
+        ec_vec.emplace_back(GetForOneKey(keys[i], field_names, out_field_maps[i]));
+        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
+            KVCM_LOG_WARN("get failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
+                          keys[i],
+                          static_cast<std::int32_t>(ec_vec.back()));
+        }
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::GetForOneKey(const KeyType &key,
+                                         const std::vector<std::string> &field_names,
+                                         FieldMap &out_field_map) const {
+    out_field_map.clear();
+    const bool found = table_.FindAndApply(key, [&](const FieldMap &field_table) {
+        for (const auto &field_name : field_names) {
+            const auto field_iter = field_table.find(field_name);
+            out_field_map[field_name] = (field_iter == field_table.end() ? "" : field_iter->second);
+        }
+    });
+    if (!found) {
+        for (const auto &field_name : field_names) {
+            out_field_map[field_name] = "";
+        }
+    }
+    return ErrorCode::EC_OK;
+}
+
+std::vector<ErrorCode> MetaDummyBackend::GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept {
+    std::vector<ErrorCode> ec_vec;
+    out_field_maps = FieldMapVec(keys.size());
+    for (std::size_t i = 0; i != keys.size(); ++i) {
+        ec_vec.emplace_back(GetAllFieldsForOneKey(keys[i], out_field_maps[i]));
+        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
+            KVCM_LOG_WARN("get all fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
+                          keys[i],
+                          static_cast<std::int32_t>(ec_vec.back()));
+        }
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) const {
+    out_field_map.clear();
+    if (!table_.Get(key, out_field_map)) {
+        return ErrorCode::EC_NOENT;
+    }
+    return out_field_map.empty() ? ErrorCode::EC_NOENT : ErrorCode::EC_OK;
+}
+
+std::vector<ErrorCode> MetaDummyBackend::Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept {
+    out_is_exist_vec.clear();
+    out_is_exist_vec.reserve(keys.size());
+    std::vector<ErrorCode> ec_vec;
+    for (std::size_t i = 0; i != keys.size(); ++i) {
+        bool is_exist = false;
+        ec_vec.emplace_back(ExistsForOneKey(keys[i], is_exist));
+        if (ec_vec.back() != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("get all fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
+                          keys[i],
+                          static_cast<std::int32_t>(ec_vec.back()));
+        }
+        out_is_exist_vec.emplace_back(is_exist);
+    }
+    return ec_vec;
+}
+
+ErrorCode MetaDummyBackend::ExistsForOneKey(const KeyType &key, bool &out_is_exist) const {
+    out_is_exist = (table_.Count(key) > 0);
+    return ErrorCode::EC_OK;
+}
+
+ErrorCode MetaDummyBackend::ListKeys(const std::string &cursor,
+                                     const std::int64_t limit,
+                                     std::string &out_next_cursor,
+                                     KeyTypeVec &out_keys) noexcept {
+    out_next_cursor.clear();
+    out_keys.clear();
+
+    std::int64_t start_index = 0;
+    if (cursor != SCAN_BASE_CURSOR) {
+        if (!StringUtil::StrToInt64(cursor.c_str(), start_index)) {
+            KVCM_LOG_ERROR("list keys fail, cannot convert cursor[%s] to start index", cursor.c_str());
+            return ErrorCode::EC_BADARGS;
+        }
+    }
+
+    std::int64_t current_index = 0;
+    const std::int64_t end_index = start_index + limit;
+    bool reached_limit = false;
+    table_.ForEachKV([&](const KeyType &key, const FieldMap &) {
+        if (current_index >= end_index) {
+            reached_limit = true;
+            return false;
+        }
+        if (current_index >= start_index) {
+            out_keys.emplace_back(key);
+        }
+        ++current_index;
+        return true;
+    });
+
+    out_next_cursor = reached_limit ? std::to_string(current_index) : SCAN_BASE_CURSOR;
+    return ErrorCode::EC_OK;
+}
+
+ErrorCode MetaDummyBackend::RandomSample(const std::int64_t count, KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    table_.ForEachKV([&](const KeyType &key, const FieldMap &map) {
+        if (out_keys.size() >= count) {
+            return false;
+        }
+        out_keys.emplace_back(key);
+        return true;
+    });
+    return ErrorCode::EC_OK;
+}
+
+ErrorCode MetaDummyBackend::SampleReclaimKeys(const std::int64_t count, KeyTypeVec &out_keys) noexcept {
+    return RandomSample(count, out_keys);
+}
+
+ErrorCode MetaDummyBackend::PutMetaData(const FieldMap &field_map) noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    metadata_ = field_map;
+    return PersistToPath();
+}
+
+ErrorCode MetaDummyBackend::GetMetaData(FieldMap &out_field_map) noexcept {
+    out_field_map.clear();
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (metadata_.empty()) {
+        return ErrorCode::EC_NOENT;
+    }
+    out_field_map = metadata_;
+    return ErrorCode::EC_OK;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include "kv_cache_manager/common/jsonizable.h"
@@ -59,7 +60,10 @@ ErrorCode MetaDummyBackend::Open() noexcept {
     std::error_code ec;
     bool exists = std::filesystem::exists(path_, ec);
     if (ec) {
-        KVCM_LOG_ERROR("file existed, err msg: [%s], path: [%s]", ec.message().c_str(), path_.c_str());
+        KVCM_LOG_ERROR("std::filesystem::exists call failed, err code: [%d], err msg: [%s], path: [%s]",
+                       ec.value(),
+                       ec.message().c_str(),
+                       path_.c_str());
         return ErrorCode::EC_IO_ERROR;
     }
     if (!exists) {
@@ -68,7 +72,7 @@ ErrorCode MetaDummyBackend::Open() noexcept {
 
     std::ifstream ifs(path_);
     if (!ifs.is_open()) {
-        KVCM_LOG_ERROR("fail to open file, path: [%s]", path_.c_str());
+        KVCM_LOG_ERROR("file open failed, path: [%s]", path_.c_str());
         return ErrorCode::EC_IO_ERROR;
     }
 

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/concurrent_hash_map.h"
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/meta/meta_storage_backend.h"
+
+namespace kv_cache_manager {
+
+/*
+ * MetaDummyBackend is a meta storage backend implementation with
+ * in-memory data store, and optional local filesystem persistence
+ * capability, whose *sole* purpose is for testing & validating.
+ *
+ * WARNING:
+ * THIS IS A TEST FACILITY WITHOUT ANY FUNCTIONALITY COMPLETENESS
+ * WARRANTY; DO NOT EVER USE IT UNDER ANY PRODUCTION CIRCUMSTANCE.
+ */
+class MetaDummyBackend : public MetaStorageBackend {
+public:
+    MetaDummyBackend() = default;
+    ~MetaDummyBackend() override = default;
+
+    std::string GetStorageType() noexcept override;
+
+    ErrorCode Init(const std::string &instance_id,
+                   const std::shared_ptr<MetaStorageBackendConfig> &config) noexcept override;
+    ErrorCode Open() noexcept override;
+    ErrorCode Close() noexcept override;
+
+    // write
+    std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
+    std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
+    std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
+    std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
+                                      const std::map<std::string, std::int64_t> &field_amounts) noexcept override;
+    std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
+
+    // read
+    std::vector<ErrorCode> Get(const KeyTypeVec &keys,
+                               const std::vector<std::string> &field_names,
+                               FieldMapVec &out_field_maps) noexcept override;
+    std::vector<ErrorCode> GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept override;
+    std::vector<ErrorCode> Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept override;
+    ErrorCode ListKeys(const std::string &cursor,
+                       std::int64_t limit,
+                       std::string &out_next_cursor,
+                       KeyTypeVec &out_keys) noexcept override;
+    ErrorCode RandomSample(std::int64_t count, KeyTypeVec &out_keys) noexcept override;
+    ErrorCode SampleReclaimKeys(std::int64_t count, KeyTypeVec &out_keys) noexcept override;
+
+    // meta data
+    ErrorCode PutMetaData(const FieldMap &field_map) noexcept override;
+    ErrorCode GetMetaData(FieldMap &out_field_map) noexcept override;
+
+private:
+    ErrorCode PersistToPath();
+
+    ErrorCode PutForOneKey(const KeyType &key, const FieldMap &field_map);
+    ErrorCode UpdateFieldsForOneKey(const KeyType &key, const FieldMap &field_map);
+    ErrorCode UpsertForOneKey(const KeyType &key, const FieldMap &field_map);
+    ErrorCode IncrFieldsForOneKey(const KeyType &key, const std::map<std::string, std::int64_t> &field_amounts);
+    ErrorCode DeleteForOneKey(const KeyType &key);
+
+    ErrorCode
+    GetForOneKey(const KeyType &key, const std::vector<std::string> &field_names, FieldMap &out_field_map) const;
+    ErrorCode GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) const;
+    ErrorCode ExistsForOneKey(const KeyType &key, bool &out_is_exist) const;
+
+    std::mutex mutex_;
+    ConcurrentHashMap<KeyType, FieldMap> table_; // block data
+    FieldMap metadata_;                          // metadata
+    std::string path_;                           // persistence local filesystem path
+    bool enable_persistence_ = false;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -205,6 +205,13 @@ ErrorCode MetaIndexer::StorageUsageData::Deserialize(const std::string &str) noe
     return ErrorCode::EC_OK;
 }
 
+MetaIndexer::~MetaIndexer() {
+    // try to persist metadata when quit gracefully
+    if (storage_) {
+        PersistMetaData();
+    }
+}
+
 ErrorCode MetaIndexer::Init(const std::string &instance_id, const std::shared_ptr<MetaIndexerConfig> &config) noexcept {
     if (!config || !config->GetMetaStorageBackendConfig()) {
         KVCM_LOG_ERROR("instance[%s] meta indexer init failed, config is invalid", instance_id.c_str());

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -55,7 +55,7 @@ public:
 public:
     /// @brief Initialize the meta indexer.
     MetaIndexer() = default;
-    ~MetaIndexer() = default;
+    ~MetaIndexer();
 
     ErrorCode Init(const std::string &instance_id, const std::shared_ptr<MetaIndexerConfig> &config) noexcept;
 

--- a/kv_cache_manager/meta/meta_storage_backend_factory.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_factory.cc
@@ -4,6 +4,7 @@
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_cached_backend.h"
+#include "kv_cache_manager/meta/meta_dummy_backend.h"
 #include "kv_cache_manager/meta/meta_local_backend.h"
 #include "kv_cache_manager/meta/meta_redis_backend.h"
 
@@ -19,6 +20,8 @@ MetaStorageBackendFactory::CreateAndInitStorageBackend(const std::string &instan
         storage_backend = std::make_unique<MetaLocalBackend>();
     } else if (config->GetStorageType() == META_CACHED_BACKEND_TYPE_STR) {
         storage_backend = std::make_unique<MetaCachedBackend>();
+    } else if (config->GetStorageType() == META_DUMMY_BACKEND_TYPE_STR) {
+        storage_backend = std::make_unique<MetaDummyBackend>();
     } else {
         KVCM_LOG_ERROR("meta storage backend create failed, unknown meta storage type[%s]",
                        config->GetStorageType().c_str());

--- a/kv_cache_manager/meta/test/BUILD
+++ b/kv_cache_manager/meta/test/BUILD
@@ -71,6 +71,20 @@ cc_library(
 )
 
 cc_test(
+    name = "meta_dummy_backend_test",
+    srcs = [
+        "meta_dummy_backend_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        ":meta_storage_backend_testlib",
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/meta:meta_dummy_backend",
+    ],
+)
+
+cc_test(
     name = "meta_local_backend_test",
     srcs = [
         "meta_local_backend_test.cc",

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -70,7 +70,7 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
     AssertListKeys(
         meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, ErrorCode::EC_OK, SCAN_BASE_CURSOR, {1, 2});
-    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
+    AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
 
     ConstructMetaStorageBackend(); // recover
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
@@ -98,7 +98,7 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
               {{{"f1", ""}, {"f2", ""}}, {{"f1", "v2-1-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}});
     AssertListKeys(
         meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, ErrorCode::EC_OK, SCAN_BASE_CURSOR, {2, 3});
-    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {2, 3});
+    AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {2, 3});
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
@@ -350,10 +350,10 @@ TEST_F(MetaDummyBackendTest, TestRandomSample) {
               meta_storage_backend_->Put({1}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
               meta_storage_backend_->Put({2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
-    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 0, ErrorCode::EC_OK, {1, 2});
-    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
-    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 2, ErrorCode::EC_OK, {1, 2});
-    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 3, ErrorCode::EC_OK, {1, 2});
+    AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 0, ErrorCode::EC_OK, {1, 2});
+    AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
+    AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 2, ErrorCode::EC_OK, {1, 2});
+    AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 3, ErrorCode::EC_OK, {1, 2});
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -1,0 +1,406 @@
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/meta_storage_backend_config.h"
+#include "kv_cache_manager/meta/common.h"
+#include "kv_cache_manager/meta/meta_dummy_backend.h"
+#include "kv_cache_manager/meta/test/meta_storage_backend_test_base.h"
+
+using namespace kv_cache_manager;
+
+class MetaDummyBackendTest : public MetaStorageBackendTestBase, public TESTBASE {
+public:
+    void SetUp() override;
+    void TearDown() override;
+    void ConstructMetaStorageBackend();
+    void ConstructMetaStorageBackendConfig();
+
+private:
+    std::shared_ptr<MetaStorageBackend> meta_storage_backend_;
+    std::shared_ptr<MetaStorageBackendConfig> meta_storage_backend_config_;
+};
+
+void MetaDummyBackendTest::SetUp() {
+    ConstructMetaStorageBackend();
+    ConstructMetaStorageBackendConfig();
+}
+
+void MetaDummyBackendTest::TearDown() {}
+
+void MetaDummyBackendTest::ConstructMetaStorageBackend() {
+    meta_storage_backend_ = std::make_shared<MetaDummyBackend>();
+}
+
+void MetaDummyBackendTest::ConstructMetaStorageBackendConfig() {
+    meta_storage_backend_config_ = std::make_shared<MetaStorageBackendConfig>();
+
+    const std::string local_path = GetPrivateTestRuntimeDataPath() + "_meta_dummy_backend_file1";
+    std::error_code ec;
+    const bool exists = std::filesystem::exists(local_path, ec);
+    ASSERT_FALSE(ec) << local_path; // false means correct
+    if (exists) {
+        std::remove(local_path.c_str());
+    }
+    meta_storage_backend_config_->SetStorageUri("file://" + local_path);
+}
+
+TEST_F(MetaDummyBackendTest, TestSimple) {
+    ASSERT_EQ(META_DUMMY_BACKEND_TYPE_STR, meta_storage_backend_->GetStorageType());
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->UpdateFields({1, 2}, {{{"f2", "v1-2"}}, {{"f2", "v2-2"}}}));
+
+    AssertExists(meta_storage_backend_.get(),
+                 {1, 2, 3},
+                 {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
+                 /*is_exist*/ {true, true, false});
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1", "f2"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+    AssertListKeys(
+        meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, ErrorCode::EC_OK, SCAN_BASE_CURSOR, {1, 2});
+    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
+
+    ConstructMetaStorageBackend(); // recover
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+    AssertExists(meta_storage_backend_.get(),
+                 {1, 2, 3},
+                 (std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
+                 /*is_exist*/ {true, true, false});
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}), meta_storage_backend_->Delete({1}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}), meta_storage_backend_->Delete({1}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->UpdateFields({2}, {{{"f1", "v2-1-1"}}}));
+
+    AssertExists(meta_storage_backend_.get(),
+                 {1, 2, 3},
+                 {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
+                 /*is_exist*/ {false, true, true});
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2, 3},
+              {"f1", "f2"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", ""}, {"f2", ""}}, {{"f1", "v2-1-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}});
+    AssertListKeys(
+        meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, ErrorCode::EC_OK, SCAN_BASE_CURSOR, {2, 3});
+    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {2, 3});
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestInit) {
+    // invalid config
+    ASSERT_NE(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));
+    ASSERT_NE(ErrorCode::EC_OK, meta_storage_backend_->Init(/*instance_id*/ "", meta_storage_backend_config_));
+}
+
+TEST_F(MetaDummyBackendTest, TestPut) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1", "f2"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}})); // cover old value
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1", "f2", "f3"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1-1"}, {"f2", ""}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}, {"f3", ""}}});
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestUpdateFields) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1", "f2"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->UpdateFields(
+                  {1, 2}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2-1"}}})); // merge old value
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1", "f2", "f3"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2-1"}, {"f3", ""}}});
+
+    // can not update key that dont exist
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}),
+              meta_storage_backend_->UpdateFields({3}, {{{"f1", "v3-1"}}}));
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestUpsert) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1", "f2"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+    // update or insert
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Upsert(
+                  {1, 2, 3}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2-1"}}, {{"f3", "v3-1"}}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2, 3},
+              {"f1", "f2", "f3"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}},
+               {{"f1", "v2-1"}, {"f2", "v2-2-1"}, {"f3", ""}},
+               {{"f1", ""}, {"f2", ""}, {"f3", "v3-1"}}});
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestIncrFields) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put(
+                  {1, 2}, {{{"hit_count", "10"}, {"weight", "100"}}, {{"hit_count", "20"}, {"weight", "200"}}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"hit_count", "weight"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"hit_count", "10"}, {"weight", "100"}}, {{"hit_count", "20"}, {"weight", "200"}}});
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->IncrFields({1, 2}, {{"hit_count", /*amount*/ 2}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"hit_count", "weight"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"hit_count", "12"}, {"weight", "100"}}, {{"hit_count", "22"}, {"weight", "200"}}});
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->IncrFields({1, 2}, {{"weight", /*amount*/ 3}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"hit_count", "weight"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"hit_count", "12"}, {"weight", "103"}}, {{"hit_count", "22"}, {"weight", "203"}}});
+
+    // can not update key that dont exist
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}),
+              meta_storage_backend_->IncrFields({3}, {{"hit_count", /*amount*/ 2}}));
+
+    // can not update field that is not num
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}), meta_storage_backend_->Put({4}, {{{"f1", "v1"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_BADARGS}),
+              meta_storage_backend_->IncrFields({4}, {{"f1", /*amount*/ 2}}));
+    // can not update field that is not exist
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_BADARGS}),
+              meta_storage_backend_->IncrFields({4}, {{"f2", /*amount*/ 2}}));
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestDelete) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ(
+        (std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
+        meta_storage_backend_->Put(
+            {1, 2, 3},
+            {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}), meta_storage_backend_->Delete({1, 3}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT, ErrorCode::EC_NOENT}),
+              meta_storage_backend_->Delete({1, 3}));
+    AssertExists(meta_storage_backend_.get(),
+                 {1, 2, 3},
+                 {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
+                 /*is_exist*/ {false, true, false});
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestGet) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}); // part fields
+    AssertGet(meta_storage_backend_.get(),
+              {1, 2},
+              {"f1", "f2"},
+              {ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}); // all fields
+    AssertGet(
+        meta_storage_backend_.get(), {1, 2}, {}, {ErrorCode::EC_OK, ErrorCode::EC_OK}, FieldMapVec(2)); // no fields
+    AssertGet(meta_storage_backend_.get(),
+              {3},
+              {"f1", "f2"},
+              {ErrorCode::EC_OK},
+              {{{"f1", ""}, {"f2", ""}}}); // key not exist
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestGetAll) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGetAllFields(meta_storage_backend_.get(),
+                       {1, 2},
+                       {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                       {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+    AssertGetAllFields(meta_storage_backend_.get(), {3}, {ErrorCode::EC_NOENT}, FieldMapVec(1)); // no entry
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestExists) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertExists(meta_storage_backend_.get(),
+                 {1, 2, 3},
+                 {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
+                 /*is_exist*/ {true, true, false});
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestListKeys) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
+
+    // list keys by step
+    std::string current_cursor = SCAN_BASE_CURSOR;
+    for (std::string next_cursor; current_cursor != SCAN_BASE_CURSOR; current_cursor = next_cursor) {
+        AssertListKeysByStep(
+            meta_storage_backend_.get(), current_cursor, /*limit*/ 1, ErrorCode::EC_OK, {1, 2, 3}, next_cursor);
+    }
+
+    // list all keys
+    AssertListKeys(meta_storage_backend_.get(),
+                   SCAN_BASE_CURSOR,
+                   /*limit*/ std::numeric_limits<std::int64_t>::max(),
+                   ErrorCode::EC_OK,
+                   SCAN_BASE_CURSOR,
+                   {1, 2, 3});
+
+    // invalid cursor
+    AssertListKeys(meta_storage_backend_.get(), "invalid_cursor", /*limit*/ 1, ErrorCode::EC_BADARGS, "", {1, 2, 3});
+
+    // list no key, limit = 0
+    std::string next_cursor;
+    AssertListKeysByStep(
+        meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 0, ErrorCode::EC_OK, {1, 2, 3}, next_cursor);
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestRandomSample) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({1}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put({2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 0, ErrorCode::EC_OK, {1, 2});
+    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
+    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 2, ErrorCode::EC_OK, {1, 2});
+    AssertRandomSample(meta_storage_backend_.get(), /*count*/ 3, ErrorCode::EC_OK, {1, 2});
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaDummyBackendTest, TestRecover) {
+    for (std::int32_t i = 0; i != 10; ++i) {
+        ConstructMetaStorageBackend(); // new meta storage backend
+        ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
+        ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+        {
+            std::string keyStr = std::to_string(i);
+            ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+                      meta_storage_backend_->Put({i}, {{{"f" + keyStr, "v" + keyStr}}}));
+        }
+
+        for (std::int32_t j = 0; j <= i; ++j) {
+            std::string keyStr = std::to_string(j);
+            AssertGet(
+                meta_storage_backend_.get(), {j}, {"f" + keyStr}, {ErrorCode::EC_OK}, {{{"f" + keyStr, "v" + keyStr}}});
+        }
+
+        ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+    }
+}
+
+TEST_F(MetaDummyBackendTest, TestRecoverBinarySafe) {
+    for (std::int32_t i = 0; i != 10; ++i) {
+        ConstructMetaStorageBackend(); // new meta storage backend
+        ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test instance 0", meta_storage_backend_config_));
+        ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+        {
+            std::string keyStr = std::to_string(i);
+            ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+                      meta_storage_backend_->Put({i}, {{{"f " + keyStr, "v " + keyStr}}}));
+        }
+
+        for (std::int32_t j = 0; j <= i; ++j) {
+            std::string keyStr = std::to_string(j);
+            AssertGet(meta_storage_backend_.get(),
+                      {j},
+                      {"f " + keyStr},
+                      {ErrorCode::EC_OK},
+                      {{{"f " + keyStr, "v " + keyStr}}});
+        }
+
+        ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+    }
+}

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -236,33 +236,49 @@ TEST_F(MetaIndexerTest, TestMultiThread) {
 }
 
 TEST_F(MetaIndexerTest, TestMetadataPersistAndRecover) {
-    GTEST_SKIP() << "Skipping for local backend not support recover";
-
-    std::string configStr = R"({
+    const std::string configStr = R"({
         "max_key_count" : 100,
         "mutex_shard_num" : 8,
         "persist_metadata_interval_time_ms" : 0,
-        "meta_storage_backend_config" : { "storage_type" : "local" },
+        "meta_storage_backend_config" : { "storage_type" : "dummy" },
         "meta_cache_policy_config" : { "capacity" : 0 }
     })";
+    const auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();
+    meta_indexer_config->FromJsonString(configStr);
+    const std::string path = GetPrivateTestRuntimeDataPath() + "meta_dummy_backend_file";
+    meta_indexer_config->meta_storage_backend_config_->SetStorageUri("file://" + path);
 
-    ASSERT_EQ(EC_OK, InitIndexer(configStr));
+    // verify fresh init behavior
+    {
+        meta_indexer_ = std::make_shared<MetaIndexer>();
+        ASSERT_EQ(ErrorCode::EC_OK, meta_indexer_->Init(/* instance_id */ "test_instance_01", meta_indexer_config));
 
+        ASSERT_EQ(MetaIndexer::InstanceVersion::VERSION_1, meta_indexer_->GetVersion());
+        ASSERT_EQ(0, meta_indexer_->GetKeyCount());
+        for (auto &v : meta_indexer_->storage_usage_data_.storage_usage_by_type_) {
+            ASSERT_EQ(0, v.load());
+        }
+    }
+
+    // persist
     meta_indexer_->key_count_.store(3);
-
     const std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500};
     ASSERT_EQ(expected_usage_vec.size(), meta_indexer_->storage_usage_data_.storage_usage_by_type_.size());
     for (std::size_t i = 0; i != meta_indexer_->storage_usage_data_.storage_usage_by_type_.size(); ++i) {
         meta_indexer_->storage_usage_data_.storage_usage_by_type_.at(i).store(expected_usage_vec.at(i));
     }
-
     meta_indexer_->PersistMetaData();
 
-    meta_indexer_ = std::make_shared<MetaIndexer>();
-    ASSERT_EQ(EC_OK, InitIndexer(configStr));
-    ASSERT_EQ(3, meta_indexer_->GetKeyCount());
-    for (std::size_t i = 0; i != meta_indexer_->storage_usage_data_.storage_usage_by_type_.size(); ++i) {
-        ASSERT_EQ(expected_usage_vec.at(i), meta_indexer_->storage_usage_data_.storage_usage_by_type_.at(i).load());
+    // verify recovery behavior
+    {
+        meta_indexer_ = std::make_shared<MetaIndexer>();
+        ASSERT_EQ(ErrorCode::EC_OK, meta_indexer_->Init(/* instance_id */ "test_instance_01", meta_indexer_config));
+
+        ASSERT_EQ(MetaIndexer::InstanceVersion::VERSION_1, meta_indexer_->GetVersion());
+        ASSERT_EQ(3, meta_indexer_->GetKeyCount());
+        for (std::size_t i = 0; i != meta_indexer_->storage_usage_data_.storage_usage_by_type_.size(); ++i) {
+            ASSERT_EQ(expected_usage_vec.at(i), meta_indexer_->storage_usage_data_.storage_usage_by_type_.at(i).load());
+        }
     }
 }
 

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package kv_cache_manager.proto.admin;
 
+import "google/protobuf/wrappers.proto";
+
 option cc_generic_services = false;
 
 enum ErrorCode {
@@ -199,6 +201,10 @@ message MetaIndexerConfig {
     int64 batch_key_size = 3;
     MetaStorageBackendConfig meta_storage_backend_config = 4;
     MetaCachePolicyConfig meta_cache_policy_config = 5;
+    // google.protobuf.Int64Value as a wrapper for tracking presence of
+    // scalar fields in older proto3 versions (v3.12.0, before which
+    // the "optional" keyword is not available)
+    google.protobuf.Int64Value persist_metadata_interval_time_ms = 6;
 }
 
 message SystemStorageConfig {

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -156,6 +156,8 @@ void ProtoConvert::CacheConfigToProto(const CacheConfig &cache_config_info,
         meta_indexer_config->set_max_key_count(origin_meta_indexer_config->GetMaxKeyCount());
         meta_indexer_config->set_mutex_shard_num(origin_meta_indexer_config->GetMutexShardNum());
         meta_indexer_config->set_batch_key_size(origin_meta_indexer_config->GetBatchKeySize());
+        meta_indexer_config->mutable_persist_metadata_interval_time_ms()->set_value(
+            origin_meta_indexer_config->GetPersistMetaDataIntervalTimeMs());
 
         // 转换meta_storage_backend_config
         auto origin_meta_storage_backend_config = origin_meta_indexer_config->GetMetaStorageBackendConfig();
@@ -207,6 +209,10 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
     meta_indexer_config->SetMaxKeyCount(proto_cache_config->meta_indexer_config().max_key_count());
     meta_indexer_config->SetMutexShardNum(proto_cache_config->meta_indexer_config().mutex_shard_num());
     meta_indexer_config->SetBatchKeySize(proto_cache_config->meta_indexer_config().batch_key_size());
+    if (proto_cache_config->meta_indexer_config().has_persist_metadata_interval_time_ms()) {
+        meta_indexer_config->SetPersistMetaDataIntervalTimeMs(
+            proto_cache_config->meta_indexer_config().persist_metadata_interval_time_ms().value());
+    }
 
     // 转换meta_storage_backend_config
     auto meta_storage_backend_config = std::make_shared<MetaStorageBackendConfig>();


### PR DESCRIPTION
* [meta] introducing `MetaDummyBackend` for testing purpose
```
/*
 * MetaDummyBackend is a meta storage backend implementation with
 * in-memory data store, and optional local filesystem persistence
 * capability, whose *sole* purpose is for testing & validating.
 *
 * WARNING:
 * THIS IS A TEST FACILITY WITHOUT ANY FUNCTIONALITY COMPLETENESS
 * WARRANTY; DO NOT EVER USE IT UNDER ANY PRODUCTION CIRCUMSTANCE.
 */
```
* [meta] [test] enable & update `MetaIndexer` persistence & recovery test case
* [proto] add the missing `persist_metadata_interval_time_ms` field
  * so the `MetaIndexer`'s metadata persistence interval can be adjusted via API calls
  * being used in the test set introduced by this pull request
* [test] add reclaiming test cases
  * validate `MetaIndexer` metadata persistence & recovery behavior #77 
  * validate `MetaIndexer` metadata persistence & recovery backward compatibility:
    v0 and v1 behavior validation #103 
  * switch meta storage backend: local -> dummy