### PR TITLE
[connector/sglang] fix cross-rank collective hang on manager API failures

### DIFF
--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -256,6 +256,22 @@ class HiCacheKVCM(HiCacheStorage):
         trace_id: str,
         extra_info: Optional[HiCacheStorageExtraInfo] = None,
     ) -> List[bool]:
+        # NOTE on cross-rank consistency:
+        # start_write_cache and SaveKvCaches failures are synchronised
+        # across ranks (via broadcast / all_reduce) so every rank
+        # converges on the same result.
+        #
+        # finish_write_cache is called only on rank 0 *after* the
+        # all_reduce has already completed. If it throws, rank 0
+        # overrides flag to False while other ranks keep flag = True.
+        # Adding a second all_reduce just for this error path would
+        # penalise the hot path for a rare event. The practical
+        # consequence is that rank 1+ callers may believe the write
+        # succeeded, but the manager was never told to commit, so a
+        # subsequent batch_get on those blocks will miss. This is an
+        # accepted inconsistency -- the caller should tolerate cache
+        # misses gracefully.
+
         # Prepare keys
         block_keys, len_prefix, len_new = self._prepare_block_keys(keys, extra_info)
 
@@ -269,7 +285,11 @@ class HiCacheKVCM(HiCacheStorage):
                 "write_timeout_seconds": self.write_timeout_seconds,
             }
             logger.debug(f"start_write_cache {request=}")
-            result = self._manager_client.start_write_cache(request)
+            try:
+                result = self._manager_client.start_write_cache(request)
+            except Exception as e:
+                logger.error(f"start_write_cache failed: {e}")
+                result = None
 
             if self.tp_world_size > 1:
                 torch.distributed.broadcast_object_list(
@@ -283,6 +303,10 @@ class HiCacheKVCM(HiCacheStorage):
             result = recv[0]
 
         logger.debug(f"start_write_cache {result=}")
+
+        if result is None:
+            return [False] * len_new
+
         locations = result["locations"]
         write_session_id = result["write_session_id"]
         block_mask = result["block_mask"]
@@ -296,14 +320,17 @@ class HiCacheKVCM(HiCacheStorage):
                            f"aborting write session {write_session_id}")
             if self.tp_rank == 0:
                 # Mark all locations as failed so manager cleans them up.
-                self._manager_client.finish_write_cache(
-                    {
-                        "trace_id": finish_trace_id,
-                        "instance_id": self.instance_id,
-                        "write_session_id": write_session_id,
-                        "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
-                    }
-                )
+                try:
+                    self._manager_client.finish_write_cache(
+                        {
+                            "trace_id": finish_trace_id,
+                            "instance_id": self.instance_id,
+                            "write_session_id": write_session_id,
+                            "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
+                        }
+                    )
+                except Exception as e:
+                    logger.error(f"finish_write_cache failed: {e}")
             return [False] * len_new
 
         unmatched = len(save_indices)
@@ -311,38 +338,50 @@ class HiCacheKVCM(HiCacheStorage):
         # Early return if all new blocks are already cached.
         if unmatched == 0:
             if self.tp_rank == 0:
-                self._manager_client.finish_write_cache(
-                    {
-                        "trace_id": finish_trace_id,
-                        "instance_id": self.instance_id,
-                        "write_session_id": write_session_id,
-                        "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
-                    }
-                )
+                try:
+                    self._manager_client.finish_write_cache(
+                        {
+                            "trace_id": finish_trace_id,
+                            "instance_id": self.instance_id,
+                            "write_session_id": write_session_id,
+                            "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
+                        }
+                    )
+                except Exception as e:
+                    logger.error(f"finish_write_cache failed: {e}")
             return [True] * len_new
 
         assert unmatched == len(locations)
 
-        # Data transfer preparation
-        buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
-        buffer_ptrs = [buffer_ptr for i, buffer_ptr in enumerate(buffer_ptrs) if (i // self.kv_factor) in save_indices]
-        buffer_sizes = [buffer_size for i, buffer_size in enumerate(
-            buffer_sizes) if (i // self.kv_factor) in save_indices]
+        # Data transfer preparation and execution.
+        # Wrapped in try-except so that every rank always reaches the
+        # all_reduce below, preventing cross-rank NCCL/gloo hangs.
+        try:
+            buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
+            buffer_ptrs = [buffer_ptr for i, buffer_ptr in enumerate(buffer_ptrs) if (i // self.kv_factor) in save_indices]
+            buffer_sizes = [buffer_size for i, buffer_size in enumerate(
+                buffer_sizes) if (i // self.kv_factor) in save_indices]
 
-        # Extract URIs and prepare buffers
-        uris = self._extract_uris(locations)
-        buffers = self._prepare_buffers(buffer_ptrs, buffer_sizes)
-        assert len(uris) == len(buffers)
-        # Perform data transfer
-        start_time = time.perf_counter()
-        result = self.transfer_client.SaveKvCaches(uris, buffers)
-        end_time = time.perf_counter()
-        self.backup_pgs.append(unmatched)
-        self.backup_bandwidth.append(unmatched * self.location_spec_size / (1 << 30) / (end_time - start_time))
-        logger.debug(f"SaveKvCaches {result=}")
+            # Extract URIs and prepare buffers
+            uris = self._extract_uris(locations)
+            buffers = self._prepare_buffers(buffer_ptrs, buffer_sizes)
+            assert len(uris) == len(buffers)
+            # Perform data transfer
+            start_time = time.perf_counter()
+            result = self.transfer_client.SaveKvCaches(uris, buffers)
+            end_time = time.perf_counter()
+            self.backup_pgs.append(unmatched)
+            self.backup_bandwidth.append(unmatched * self.location_spec_size / (1 << 30) / (end_time - start_time))
+            logger.debug(f"SaveKvCaches {result=}")
+
+            flag = (result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
+            if not flag:
+                logger.error(f"SaveKvCaches error: {result}")
+        except Exception as e:
+            logger.error(f"Data transfer (SaveKvCaches) failed: {e}")
+            flag = False
 
         # Finish write cache
-        flag = (result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
         if self.tp_world_size > 1:
             flag_tensor = torch.tensor(flag, dtype=torch.int)
             torch.distributed.all_reduce(
@@ -354,14 +393,22 @@ class HiCacheKVCM(HiCacheStorage):
 
         finish_mask = [flag] * unmatched
         if self.tp_rank == 0:
-            self._manager_client.finish_write_cache(
-                {
-                    "trace_id": finish_trace_id,
-                    "instance_id": self.instance_id,
-                    "write_session_id": write_session_id,
-                    "success_blocks": {"bool_masks": {"values": finish_mask}},
-                }
-            )
+            try:
+                self._manager_client.finish_write_cache(
+                    {
+                        "trace_id": finish_trace_id,
+                        "instance_id": self.instance_id,
+                        "write_session_id": write_session_id,
+                        "success_blocks": {"bool_masks": {"values": finish_mask}},
+                    }
+                )
+            except Exception as e:
+                logger.error(f"finish_write_cache failed: {e}")
+                # This sets flag = False on rank 0 only; other ranks
+                # still have the post-all_reduce value (True if data
+                # transfer succeeded). See the NOTE at the top of
+                # _batch_set for why we accept this inconsistency.
+                flag = False
 
         # Build result list: 1:1 positional mapping with input keys
         # - keys not in save_indices → True

--- a/kv_cache_manager/py_connector/sglang/test.py
+++ b/kv_cache_manager/py_connector/sglang/test.py
@@ -6,7 +6,9 @@ import signal
 import time
 import os
 import atexit
+import requests
 import torch
+import torch.multiprocessing as mp
 from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageConfig,
     HiCacheStorageExtraInfo,
@@ -22,19 +24,6 @@ from kv_cache_manager.py_connector.sglang.connector import HiCacheKVCM
 
 logger = logging.getLogger(__name__)
 
-init_distributed_environment(
-    world_size=1,
-    rank=0,
-    distributed_init_method="tcp://127.0.0.1:23456",
-    local_rank=0,
-    backend="gloo",
-)
-
-initialize_model_parallel(
-    tensor_model_parallel_size=1,
-    pipeline_model_parallel_size=1,
-)
-
 # Configuration
 model_name = "xxx"
 max_total_num_tokens = 8192
@@ -47,7 +36,23 @@ hicache_ratio = 2
 hicache_size = 0
 hicache_mem_layout = "page_first_direct"
 
-manager_uri = "http://127.0.0.1:6382"
+manager_uri = os.environ.get("KVCM_MANAGER_URI", "http://127.0.0.1:6382")
+manager_http_port = int(manager_uri.rsplit(":", 1)[-1])
+debug_uri = os.environ.get("KVCM_DEBUG_URI", f"http://127.0.0.1:{manager_http_port + 3000}")
+
+manager_bin = os.environ.get(
+    "KVCM_MANAGER_BIN",
+    "/home/admin/kv_cache_manager/bin/kv_cache_manager_bin",
+)
+manager_server_conf = os.environ.get(
+    "KVCM_SERVER_CONF",
+    "/home/admin/kv_cache_manager/etc/default_server_config.conf",
+)
+manager_logger_conf = os.environ.get(
+    "KVCM_LOGGER_CONF",
+    "/home/admin/kv_cache_manager/etc/default_logger_config.conf",
+)
+manager_log_dir = os.environ.get("KVCM_LOG_DIR", "/root/KVCacheManager/logs")
 
 # Global process reference
 proc = None
@@ -75,13 +80,14 @@ def _start_manager():
     """Start the KV Cache Manager process."""
     global proc
     # Clean up previous logs
-    subprocess.run("rm -rf /root/KVCacheManager/logs/*", shell=True, check=False)
+    subprocess.run(f"rm -rf {manager_log_dir}/*", shell=True, check=False)
 
-    # Start the manager process
+    # Start the manager process (with debug service enabled for fault injection)
     proc = subprocess.Popen([
-        "/home/admin/kv_cache_manager/bin/kv_cache_manager_bin",
-        "-c", "/home/admin/kv_cache_manager/etc/default_server_config.conf",
-        "-l", "/home/admin/kv_cache_manager/etc/default_logger_config.conf"
+        manager_bin,
+        "-c", manager_server_conf,
+        "-l", manager_logger_conf,
+        "--env", "kvcm.service.enable_debug_service=true",
     ])
 
     # Register cleanup handlers
@@ -117,7 +123,10 @@ def test():
     storage_config = HiCacheStorageConfig(
         tp_rank=0,
         tp_size=1,
+        pp_rank=0,
+        pp_size=1,
         is_mla_model=False,
+        enable_storage_metrics=False,
         is_page_first_layout=True,
         model_name=model_name,
         extra_config={
@@ -128,7 +137,7 @@ def test():
     )
 
     # Initialize storage backend
-    storage_backend = HiCacheKVCM(storage_config)
+    storage_backend = HiCacheKVCM(storage_config, {})
     storage_backend.register_mem_pool_host(mem_pool_host)
 
     # Generate test data
@@ -210,13 +219,472 @@ def test():
         assert torch.mean(tensor_i).item() == bf16_i, f"{torch.mean(tensor_i).item()=} == {bf16_i=}"
         assert torch.std(tensor_i).item() == 0
 
+    return storage_backend
+
+
+class DebugServiceClient:
+    """Client for the KV Cache Manager debug service (fault injection)."""
+
+    def __init__(self, base_url):
+        self.base_url = base_url
+        self.session = requests.Session()
+        self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+
+    def _make_request(self, endpoint, data=None):
+        url = self.base_url + endpoint
+        response = self.session.post(url, json=data, headers=self.headers)
+        response_data = response.json()
+        assert response.status_code == 200, \
+            f"Debug API {endpoint} failed: {response.status_code}"
+        assert response_data.get('header', {}).get('status', {}).get('code') == 'OK', \
+            f"Debug API {endpoint} error: {response_data}"
+        return response_data
+
+    def inject_fault(self, api_name, fault_type="INTERNAL_ERROR",
+                     strategy="ALWAYS", trigger_at_call=None):
+        data = {
+            "api_name": api_name,
+            "fault_type": fault_type,
+            "fault_trigger_strategy": strategy,
+        }
+        if trigger_at_call is not None:
+            data["trigger_at_call"] = trigger_at_call
+        return self._make_request('/api/injectFault', data)
+
+    def remove_fault(self, api_name):
+        return self._make_request('/api/removeFault', {"api_name": api_name})
+
+    def clear_faults(self):
+        return self._make_request('/api/clearFaults', {})
+
+    def close(self):
+        self.session.close()
+
+
+def test_fault_injection(storage_backend):
+    """Test fault injection scenarios to verify error handling.
+
+    These tests verify that when manager APIs fail, the connector
+    returns graceful errors instead of crashing or (in multi-rank
+    scenarios) causing NCCL/gloo hangs due to inconsistent collective
+    operations across ranks.
+    """
+    debug_client = DebugServiceClient(debug_uri)
+
+    # Generate separate test data (uncached blocks) for fault injection tests.
+    fi_token_ids = list(range(5000, 6024))
+    fi_block_hashes = []
+    fi_block_hash = None
+    fi_host_indices = []
+    for i in range(0, 1024, page_size):
+        fi_block_hash = get_hash_str(fi_token_ids[i:i + page_size], fi_block_hash)
+        fi_block_hashes.append(fi_block_hash)
+        fi_host_indices.extend(range(i + 4096, i + 4096 + page_size))
+
+    try:
+        # ----------------------------------------------------------
+        # Test FI-1: StartWriteCache ALWAYS fault
+        #   In multi-rank mode, without the fix, rank 0 would throw
+        #   before broadcast, leaving other ranks hanging forever.
+        # ----------------------------------------------------------
+        logger.info("=== FI-1: StartWriteCache ALWAYS fault ===")
+        debug_client.inject_fault("StartWriteCache")
+
+        hashes = fi_block_hashes[:5]
+        indices = fi_host_indices[:(5 * page_size)]
+        set_result = storage_backend.batch_set_v1(
+            hashes, torch.tensor(indices))
+        assert all(r is False for r in set_result), \
+            f"FI-1 FAILED: expected all False, got {set_result}"
+        logger.info("FI-1 PASSED: StartWriteCache fault → batch_set_v1 returns all False")
+
+        debug_client.remove_fault("StartWriteCache")
+
+        # ----------------------------------------------------------
+        # Test FI-2: GetCacheLocation ALWAYS fault (batch_get_v1)
+        # ----------------------------------------------------------
+        logger.info("=== FI-2: GetCacheLocation ALWAYS fault (batch_get) ===")
+        debug_client.inject_fault("GetCacheLocation")
+
+        get_result = storage_backend.batch_get_v1(
+            hashes, torch.tensor(indices))
+        assert all(r is False for r in get_result), \
+            f"FI-2 FAILED: expected all False, got {get_result}"
+        logger.info("FI-2 PASSED: GetCacheLocation fault → batch_get_v1 returns all False")
+
+        # ----------------------------------------------------------
+        # Test FI-3: GetCacheLocation ALWAYS fault (batch_exists)
+        # ----------------------------------------------------------
+        logger.info("=== FI-3: GetCacheLocation ALWAYS fault (batch_exists) ===")
+        exists_result = storage_backend.batch_exists(hashes)
+        assert exists_result == 0, \
+            f"FI-3 FAILED: expected 0, got {exists_result}"
+        logger.info("FI-3 PASSED: GetCacheLocation fault → batch_exists returns 0")
+
+        debug_client.remove_fault("GetCacheLocation")
+
+        # ----------------------------------------------------------
+        # Test FI-4: FinishWriteCache ALWAYS fault
+        #   In multi-rank mode, without the fix, rank 0 would throw
+        #   after all_reduce, causing inconsistent return values.
+        #   Uses separate block hashes because a failed finish leaves
+        #   a pending write session in the manager, which would
+        #   interfere with subsequent tests on the same keys.
+        # ----------------------------------------------------------
+        logger.info("=== FI-4: FinishWriteCache ALWAYS fault ===")
+        debug_client.inject_fault("FinishWriteCache")
+
+        fi4_hashes = fi_block_hashes[10:15]
+        fi4_indices = fi_host_indices[(10 * page_size):(15 * page_size)]
+        set_result = storage_backend.batch_set_v1(
+            fi4_hashes, torch.tensor(fi4_indices))
+        assert all(r is False for r in set_result), \
+            f"FI-4 FAILED: expected all False, got {set_result}"
+        logger.info("FI-4 PASSED: FinishWriteCache fault → batch_set_v1 returns all False")
+
+        debug_client.remove_fault("FinishWriteCache")
+
+        # ----------------------------------------------------------
+        # Test FI-5: Recovery after clearing all faults
+        #   Verify full get-miss → set → get-hit cycle works after
+        #   faults are removed.
+        # ----------------------------------------------------------
+        logger.info("=== FI-5: Recovery after clearing faults ===")
+        debug_client.clear_faults()
+
+        # The blocks were never successfully written during fault tests,
+        # so batch_exists and batch_get should report miss.
+        exists_result = storage_backend.batch_exists(hashes)
+        assert exists_result == 0, \
+            f"FI-5 FAILED: expected 0 (not cached), got {exists_result}"
+
+        get_result = storage_backend.batch_get_v1(
+            hashes, torch.tensor(indices))
+        assert all(r is False for r in get_result), \
+            f"FI-5 FAILED: expected all False (cache miss), got {get_result}"
+
+        # Now set should succeed.
+        set_result = storage_backend.batch_set_v1(
+            hashes, torch.tensor(indices))
+        assert all(set_result), \
+            f"FI-5 FAILED: expected all True after clearing faults, got {set_result}"
+
+        # After successful set, get should hit.
+        get_result = storage_backend.batch_get_v1(
+            hashes, torch.tensor(indices))
+        assert all(get_result), \
+            f"FI-5 FAILED: expected all True (cache hit), got {get_result}"
+
+        exists_result = storage_backend.batch_exists(hashes)
+        assert exists_result == len(hashes), \
+            f"FI-5 FAILED: expected {len(hashes)}, got {exists_result}"
+        logger.info("FI-5 PASSED: get miss → set → get hit after clearing faults")
+
+        # ----------------------------------------------------------
+        # Test FI-6: StartWriteCache fault with prefix (batch_set_v1)
+        #   Verify fault handling works correctly with extra_info.
+        # ----------------------------------------------------------
+        logger.info("=== FI-6: StartWriteCache fault with prefix ===")
+        debug_client.inject_fault("StartWriteCache")
+
+        prefix_keys = fi_block_hashes[:5]
+        extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
+        suffix_hashes = fi_block_hashes[5:10]
+        suffix_indices = fi_host_indices[(5 * page_size):(10 * page_size)]
+        set_result = storage_backend.batch_set_v1(
+            suffix_hashes, torch.tensor(suffix_indices), extra_info)
+        assert all(r is False for r in set_result), \
+            f"FI-6 FAILED: expected all False, got {set_result}"
+        logger.info("FI-6 PASSED: StartWriteCache fault with prefix → returns all False")
+
+        debug_client.remove_fault("StartWriteCache")
+
+        # ----------------------------------------------------------
+        # Test FI-7: GetCacheLocation fault with prefix (batch_get_v1)
+        # ----------------------------------------------------------
+        logger.info("=== FI-7: GetCacheLocation fault with prefix (batch_get) ===")
+        debug_client.inject_fault("GetCacheLocation")
+
+        get_result = storage_backend.batch_get_v1(
+            suffix_hashes, torch.tensor(suffix_indices), extra_info)
+        assert all(r is False for r in get_result), \
+            f"FI-7 FAILED: expected all False, got {get_result}"
+        logger.info("FI-7 PASSED: GetCacheLocation fault with prefix → returns all False")
+
+        debug_client.remove_fault("GetCacheLocation")
+
+    finally:
+        debug_client.clear_faults()
+        debug_client.close()
+
+
+
+# ---------------------------------------------------------------------------
+# Multi-rank test (mp.spawn)
+# ---------------------------------------------------------------------------
+# Smaller parameters to reduce GPU memory usage (2 workers share one GPU).
+mr_layer_num = 4
+mr_max_total_num_tokens = 2048
+mr_init_port = 23457
+
+
+def _multi_rank_worker(rank, world_size, init_port):
+    """Worker function for multi-rank fault injection tests.
+
+    Each spawned process runs this function with its own rank.
+    Verifies that collective operations (broadcast, all_reduce)
+    remain consistent even when manager API calls fail.
+    """
+    # We only need gloo for the connector's collective operations.
+    # Bypass sglang's initialize_model_parallel entirely because it
+    # creates NCCL communicators which fail when multiple processes
+    # share a single GPU.
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://127.0.0.1:{init_port}",
+        world_size=world_size,
+        rank=rank,
+    )
+
+    # The connector reads get_tp_group().cpu_group to obtain the TP
+    # gloo group.  Patch the global _TP so that get_tp_group() returns
+    # a lightweight object with only the .cpu_group we need.
+    import sglang.srt.distributed.parallel_state as _ps
+
+    class _GlooTPGroup:
+        """Minimal stand-in for GroupCoordinator (gloo only)."""
+        def __init__(self, cpu_group):
+            self.cpu_group = cpu_group
+
+    _ps._TP = _GlooTPGroup(
+        torch.distributed.new_group(list(range(world_size)), backend="gloo")
+    )
+
+    # Create memory pools (smaller than single-rank tests)
+    device_pool = MHATokenToKVPool(
+        size=mr_max_total_num_tokens,
+        page_size=page_size,
+        dtype=kv_cache_dtype,
+        head_num=head_num,
+        head_dim=head_dim,
+        layer_num=mr_layer_num,
+        device=device,
+        enable_memory_saver=False,
+    )
+    mem_pool_host = MHATokenToKVPoolHost(
+        device_pool=device_pool,
+        host_to_device_ratio=hicache_ratio,
+        host_size=hicache_size,
+        page_size=page_size,
+        layout=hicache_mem_layout,
+    )
+
+    storage_config = HiCacheStorageConfig(
+        tp_rank=rank,
+        tp_size=world_size,
+        pp_rank=0,
+        pp_size=1,
+        is_mla_model=False,
+        enable_storage_metrics=False,
+        is_page_first_layout=True,
+        model_name=model_name,
+        extra_config={
+            "manager_uri": manager_uri,
+            "instance_group": "default",
+            "instance_id": "mr_test",
+        },
+    )
+    storage_backend = HiCacheKVCM(storage_config, {})
+    storage_backend.register_mem_pool_host(mem_pool_host)
+
+    # Fill KV buffer with distinguishable data per rank
+    for i in range(mem_pool_host.page_num * mem_pool_host.page_size):
+        p = i // page_size
+        t = i % page_size
+        mem_pool_host.kv_buffer[:, p, :, t] = torch.tensor(
+            i + rank * 100000, dtype=torch.bfloat16
+        )
+
+    # Generate block hashes (different token_ids from single-rank tests)
+    mr_token_ids = list(range(20000, 20000 + mr_max_total_num_tokens))
+    mr_hashes = []
+    mr_hash = None
+    mr_indices = []
+    for i in range(0, mr_max_total_num_tokens, page_size):
+        mr_hash = get_hash_str(mr_token_ids[i:i + page_size], mr_hash)
+        mr_hashes.append(mr_hash)
+        mr_indices.extend(range(i, i + page_size))
+
+    debug_client = DebugServiceClient(debug_uri) if rank == 0 else None
+
+    # ------------------------------------------------------------------
+    # MR-1: Normal multi-rank set
+    # ------------------------------------------------------------------
+    h1 = mr_hashes[:5]
+    idx1 = mr_indices[:5 * page_size]
+    torch.distributed.barrier()
+    result = storage_backend.batch_set_v1(h1, torch.tensor(idx1))
+    assert all(result), f"MR-1 rank {rank}: expected all True, got {result}"
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-1 PASSED: normal set")
+
+    # ------------------------------------------------------------------
+    # MR-2: Normal multi-rank get
+    # ------------------------------------------------------------------
+    torch.distributed.barrier()
+    result = storage_backend.batch_get_v1(h1, torch.tensor(idx1))
+    assert all(result), f"MR-2 rank {rank}: expected all True, got {result}"
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-2 PASSED: normal get")
+
+    # ------------------------------------------------------------------
+    # MR-3: StartWriteCache fault (main bug scenario)
+    #   Without the fix, rank 0 throws before broadcast, rank 1 hangs
+    #   at broadcast_object_list -> gloo timeout.
+    #   With the fix, both ranks return [False] gracefully.
+    # ------------------------------------------------------------------
+    h3 = mr_hashes[5:10]
+    idx3 = mr_indices[5 * page_size:10 * page_size]
+
+    torch.distributed.barrier()
+    if rank == 0:
+        debug_client.inject_fault("StartWriteCache")
+    torch.distributed.barrier()
+
+    result = storage_backend.batch_set_v1(h3, torch.tensor(idx3))
+    assert all(r is False for r in result), \
+        f"MR-3 rank {rank}: expected all False, got {result}"
+
+    torch.distributed.barrier()
+    if rank == 0:
+        debug_client.remove_fault("StartWriteCache")
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-3 PASSED: StartWriteCache fault")
+
+    # ------------------------------------------------------------------
+    # MR-4: FinishWriteCache fault
+    #   After the fix, rank 0 gets [False] (finish failed),
+    #   other ranks may get [True] (data transfer succeeded).
+    #   This is a known inconsistency. We verify no hang occurs.
+    # ------------------------------------------------------------------
+    h4 = mr_hashes[15:20]
+    idx4 = mr_indices[15 * page_size:20 * page_size]
+
+    torch.distributed.barrier()
+    if rank == 0:
+        debug_client.inject_fault("FinishWriteCache")
+    torch.distributed.barrier()
+
+    result = storage_backend.batch_set_v1(h4, torch.tensor(idx4))
+    if rank == 0:
+        assert all(r is False for r in result), \
+            f"MR-4 rank 0: expected all False, got {result}"
+    logger.info(f"[Rank {rank}] MR-4: result = {result}")
+
+    torch.distributed.barrier()
+    if rank == 0:
+        debug_client.remove_fault("FinishWriteCache")
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-4 PASSED: FinishWriteCache fault (no hang)")
+
+    # ------------------------------------------------------------------
+    # MR-5: Recovery after faults
+    #   Clear faults, verify set -> get works on all ranks.
+    # ------------------------------------------------------------------
+    h5 = mr_hashes[20:25]
+    idx5 = mr_indices[20 * page_size:25 * page_size]
+
+    torch.distributed.barrier()
+    if rank == 0:
+        debug_client.clear_faults()
+    torch.distributed.barrier()
+
+    result = storage_backend.batch_set_v1(h5, torch.tensor(idx5))
+    assert all(result), f"MR-5 rank {rank}: set expected all True, got {result}"
+    torch.distributed.barrier()
+
+    result = storage_backend.batch_get_v1(h5, torch.tensor(idx5))
+    assert all(result), f"MR-5 rank {rank}: get expected all True, got {result}"
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-5 PASSED: recovery")
+
+    if debug_client:
+        debug_client.close()
+    logger.info(f"[Rank {rank}] All multi-rank tests passed!")
+
+
+def test_multi_rank(timeout_seconds=120):
+    """Run multi-rank tests with timeout detection for gloo hangs.
+
+    Uses multiprocessing.Process with explicit join(timeout) so that
+    hung child processes can be forcefully killed.
+    """
+    world_size = 2
+    ctx = mp.get_context("spawn")
+    processes = []
+    for rank in range(world_size):
+        p = ctx.Process(
+            target=_multi_rank_worker,
+            args=(rank, world_size, mr_init_port),
+        )
+        p.start()
+        processes.append(p)
+
+    # Wait for all workers to finish within the timeout.
+    deadline = time.monotonic() + timeout_seconds
+    for p in processes:
+        remaining = max(0, deadline - time.monotonic())
+        p.join(timeout=remaining)
+
+    # Check results — kill any survivors and report.
+    hung = [p for p in processes if p.is_alive()]
+    if hung:
+        for p in hung:
+            p.kill()
+        for p in hung:
+            p.join()
+        raise TimeoutError(
+            "Multi-rank test timed out -- likely a gloo hang due to "
+            "inconsistent collective operations across ranks"
+        )
+
+    failed = [p for p in processes if p.exitcode != 0]
+    if failed:
+        codes = {p.pid: p.exitcode for p in failed}
+        raise RuntimeError(f"Multi-rank worker(s) failed: {codes}")
+
 
 if __name__ == "__main__":
     logger.info("Starting KV Cache Manager test")
 
+    # Initialize distributed for single-rank tests
+    init_distributed_environment(
+        world_size=1,
+        rank=0,
+        distributed_init_method="tcp://127.0.0.1:23460",
+        local_rank=0,
+        backend="gloo",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+    )
+
     try:
         _start_manager()
-        test()
+
+        storage_backend = test()
+        logger.info("All basic tests passed!")
+
+        test_fault_injection(storage_backend)
+        logger.info("All fault injection tests passed!")
+
+        # Destroy single-rank process group before spawning multi-rank workers
+        torch.distributed.destroy_process_group()
+
+        test_multi_rank()
+        logger.info("All multi-rank tests passed!")
+
         logger.info("All tests passed successfully!")
     except Exception as e:
         logger.error(f"Test failed with error: {e}")


### PR DESCRIPTION
## Summary

- **Fix cross-rank NCCL/gloo hang**: When manager gRPC APIs (`start_write_cache`, `SaveKvCaches`, `finish_write_cache`) throw exceptions on rank 0, collective operations (broadcast/all_reduce) were skipped, leaving other TP ranks hanging forever. Wrap each API call in try-except to ensure collectives always execute consistently across all ranks.
- **Add fault injection tests (FI-1 ~ FI-7)**: Leverage the manager's debug service to inject faults into `StartWriteCache`, `GetCacheLocation`, `FinishWriteCache` at runtime, verifying the connector returns graceful errors instead of crashing.
- **Add multi-rank tests (MR-1 ~ MR-5)**: Use `torch.multiprocessing.Process` with gloo backend to simulate 2 TP ranks on a single GPU, verifying collective operations remain consistent even under fault injection. Includes process-based timeout detection to catch gloo hangs.

## Test plan

- [x] All basic tests pass (single-rank set/get/exists)
- [x] FI-1 ~ FI-7 fault injection tests pass
- [x] MR-1 ~ MR-5 multi-rank tests pass
- [x] Bug reproduction verified: temporarily reverting the fix causes MR-3 to timeout (detecting the hang), restoring the fix resolves it

	🤖 Generated with [Qoder][https://qoder.com]