### PR TITLE
[meta] handle instance storage usage data backward compatibility

### DIFF
--- a/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
+++ b/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
@@ -97,11 +97,20 @@ void CacheManagerMetricsRecorder::RecorderLoop() {
                 }
                 meta_indexer->PersistMetaData();
                 const std::size_t key_cnt = meta_indexer->GetKeyCount();
-                std::size_t byte_size_per_key = 0;
-                for (auto &location_spec_info : instance_info->location_spec_infos()) {
-                    byte_size_per_key += location_spec_info.size();
+                std::size_t byte_size = 0;
+                if (meta_indexer->GetVersion() == MetaIndexer::InstanceVersion::VERSION_0) {
+                    std::size_t byte_size_per_key = 0;
+                    for (auto &location_spec_info : instance_info->location_spec_infos()) {
+                        byte_size_per_key += location_spec_info.size();
+                    }
+                    byte_size = byte_size_per_key * key_cnt;
+                } else if (meta_indexer->GetVersion() == MetaIndexer::InstanceVersion::VERSION_1) {
+                    byte_size = meta_indexer->GetStorageUsage();
+                } else {
+                    KVCM_LOG_WARN("unknown meta_indexer version: [%" PRIu8 "]",
+                                  static_cast<std::uint8_t>(meta_indexer->GetVersion()));
+                    continue;
                 }
-                const std::size_t byte_size = byte_size_per_key * key_cnt;
                 group_byte_size += byte_size;
                 group_instance_id_metric_map[instance_group_name][instance_id] = InstanceMetric({key_cnt, byte_size});
             }

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -1024,7 +1024,22 @@ std::shared_ptr<CacheReclaimer::GroupUsageData> CacheReclaimer::GetGroupUsageDat
         meta_indexer->PersistMetaData();
         const std::size_t ins_used_key_cnt = meta_indexer->GetKeyCount();
         const std::size_t ins_max_key_cnt = meta_indexer->GetMaxKeyCount();
-        const std::size_t ins_used_byte_size = meta_indexer->GetStorageUsage();
+
+        std::size_t ins_used_byte_size = 0;
+        if (meta_indexer->GetVersion() == MetaIndexer::InstanceVersion::VERSION_0) {
+            std::size_t byte_size_per_key = 0;
+            for (auto &location_spec_info : instance_info->location_spec_infos()) {
+                byte_size_per_key += location_spec_info.size();
+            }
+            ins_used_byte_size = byte_size_per_key * ins_used_key_cnt;
+        } else if (meta_indexer->GetVersion() == MetaIndexer::InstanceVersion::VERSION_1) {
+            ins_used_byte_size = meta_indexer->GetStorageUsage();
+        } else {
+            LOG_WITH_ID(WARN,
+                        "unknown meta_indexer version: [%" PRIu8 "]",
+                        static_cast<std::uint8_t>(meta_indexer->GetVersion()));
+            continue;
+        }
 
         data->grp_used_key_cnt_ += ins_used_key_cnt;
         data->grp_max_key_cnt_ += ins_max_key_cnt;

--- a/kv_cache_manager/manager/data_storage_selector.cc
+++ b/kv_cache_manager/manager/data_storage_selector.cc
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cinttypes>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -365,7 +366,23 @@ std::size_t DataStorageSelector::CalcGroupUsedSize(
         }
 
         meta_indexer->PersistMetaData();
-        group_used_byte_size += meta_indexer->GetStorageUsage();
+        if (meta_indexer->GetVersion() == MetaIndexer::InstanceVersion::VERSION_0) {
+            const std::size_t ins_used_key_cnt = meta_indexer->GetKeyCount();
+
+            std::size_t byte_size_per_key = 0;
+            for (auto &location_spec_info : instance_info->location_spec_infos()) {
+                byte_size_per_key += location_spec_info.size();
+            }
+            const std::size_t ins_used_byte_size = byte_size_per_key * ins_used_key_cnt;
+
+            group_used_byte_size += ins_used_byte_size;
+        } else if (meta_indexer->GetVersion() == MetaIndexer::InstanceVersion::VERSION_1) {
+            group_used_byte_size += meta_indexer->GetStorageUsage();
+        } else {
+            PREFIX_LOG(WARN,
+                       "unknown meta_indexer version: [%" PRIu8 "]",
+                       static_cast<std::uint8_t>(meta_indexer->GetVersion()));
+        }
     }
 
     return group_used_byte_size;

--- a/kv_cache_manager/manager/data_storage_selector.cc
+++ b/kv_cache_manager/manager/data_storage_selector.cc
@@ -382,6 +382,7 @@ std::size_t DataStorageSelector::CalcGroupUsedSize(
             PREFIX_LOG(WARN,
                        "unknown meta_indexer version: [%" PRIu8 "]",
                        static_cast<std::uint8_t>(meta_indexer->GetVersion()));
+            continue; // in case of more logic added below this
         }
     }
 

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/meta/meta_indexer.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <set>
@@ -259,14 +260,18 @@ ErrorCode MetaIndexer::Init(const std::string &instance_id, const std::shared_pt
     }
     KVCM_LOG_INFO(
         "instance[%s] meta indexer init success, storage backend type[%s], mutex shard num[%lu], max key count[%lu], "
-        "batch key size[%lu], search cache size[%lu], key_count[%lu]",
+        "batch key size[%lu], search cache size[%lu], key_count[%lu], persist_metadata_interval_time_ms[%zu], "
+        "storage usage data[%s], instance version[%" PRIu8 "]",
         instance_id_.c_str(),
         storage_->GetStorageType().c_str(),
         mutex_shard_num_,
         max_key_count_,
         batch_key_size_,
         config->GetMetaCachePolicyConfig()->GetCapacity(),
-        key_count_.load());
+        key_count_.load(),
+        persist_metadata_interval_time_ms_,
+        version_ == InstanceVersion::VERSION_1 ? storage_usage_data_.ToJsonString().c_str() : "N/A",
+        static_cast<std::uint8_t>(version_));
     return EC_OK;
 }
 
@@ -739,6 +744,8 @@ std::uint64_t MetaIndexer::SubStorageUsageByType(const DataStorageType &type, co
     return storage_usage_data_.SubStorageUsageByType(type, value);
 }
 
+MetaIndexer::InstanceVersion MetaIndexer::GetVersion() const noexcept { return version_; }
+
 // Combining batch size and lock granularity size to assemble batch data
 void MetaIndexer::MakeBatches(const KeyVector &keys,
                               PropertyMapVector &properties,
@@ -791,12 +798,17 @@ ErrorCode MetaIndexer::RecoverMetaData() noexcept {
     auto ec = storage_->GetMetaData(metadata_map);
     if (ec == EC_NOENT) {
         KVCM_LOG_INFO("there is no metadata key in storage backend, no need to recover metadata");
+        // no metadata to recover (new instance or persistence turned
+        // off), safe to set to the newest version
+        // version_ remains InstanceVersion::VERSION_1
         return ec;
     }
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("meta indexer read metadata from storage backend failed, ec[%d]", ec);
         return ec;
     }
+
+    // METADATA_PROPERTY_KEY_COUNT *must* always be presented
     std::string key_count_str = metadata_map[METADATA_PROPERTY_KEY_COUNT];
     int64_t key_count;
     bool is_valid = StringUtil::StrToInt64(key_count_str.c_str(), key_count);
@@ -807,12 +819,16 @@ ErrorCode MetaIndexer::RecoverMetaData() noexcept {
     }
     key_count_ = key_count;
 
+    // METADATA_PROPERTY_STORAGE_USAGE_DATA decides the behavior version
     if (const auto it = metadata_map.find(METADATA_PROPERTY_STORAGE_USAGE_DATA); it != metadata_map.end()) {
         if (storage_usage_data_.Deserialize(it->second) != EC_OK) {
-            KVCM_LOG_WARN("meta indexer deserialize storage usage data failed, resetting to zero, str: [%s]",
-                          it->second.c_str());
-            storage_usage_data_.Reset();
+            KVCM_LOG_ERROR("meta indexer deserialize storage usage data failed, str: [%s]", it->second.c_str());
+            return EC_ERROR;
         }
+        // version_ remains InstanceVersion::VERSION_1
+    } else {
+        // METADATA_PROPERTY_STORAGE_USAGE_DATA do not exist
+        version_ = InstanceVersion::VERSION_0;
     }
 
     return EC_OK;
@@ -824,7 +840,9 @@ void MetaIndexer::PersistMetaData() noexcept {
     if (current_time >= last_persist_metadata_time_ + persist_metadata_interval_time_ms_) {
         std::map<std::string, std::string> metadata_map;
         metadata_map[METADATA_PROPERTY_KEY_COUNT] = std::to_string(key_count_);
-        metadata_map[METADATA_PROPERTY_STORAGE_USAGE_DATA] = storage_usage_data_.Serialize();
+        if (version_ == InstanceVersion::VERSION_1) {
+            metadata_map[METADATA_PROPERTY_STORAGE_USAGE_DATA] = storage_usage_data_.Serialize();
+        }
         auto ec = storage_->PutMetaData(metadata_map);
         if (ec != EC_OK) {
             KVCM_LOG_ERROR("meta indexer persist metadata failed, ec[%d]", ec);

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -96,11 +96,38 @@ public:
     size_t GetCacheUsage() const noexcept;
 
     // storage usage interfaces
+    //
+    // notes about backward compatibility:
+    //
+    // GetStorageUsage() is accurate for hybrid model arch, and should
+    // only be used under InstanceVersion::VERSION_1
+    //
+    // similar logic for Get/Add/Sub-StorageUsageByType() are already
+    // being used under InstanceVersion::VERSION_0; however they are
+    // only accurate under InstanceVersion::VERSION_1
+    //
+    // see also notes for instance behavior version
     [[nodiscard]] std::uint64_t GetStorageUsage() const noexcept;
     [[nodiscard]] std::uint64_t GetStorageUsageByType(const DataStorageType &type) const noexcept;
     void SetStorageUsageByType(const DataStorageType &type, std::uint64_t value) noexcept;
     std::uint64_t AddStorageUsageByType(const DataStorageType &type, std::uint64_t value) noexcept;
     std::uint64_t SubStorageUsageByType(const DataStorageType &type, std::uint64_t value) noexcept;
+
+    // instance behavior version
+    enum class InstanceVersion : std::uint8_t {
+        // version 0: metadata persisted = [
+        //     METADATA_PROPERTY_KEY_COUNT,
+        // ]
+        VERSION_0 = 0,
+
+        // version 1: metadata persisted = [
+        //     METADATA_PROPERTY_KEY_COUNT,
+        //     METADATA_PROPERTY_STORAGE_USAGE_DATA,
+        // ]
+        VERSION_1 = 1,
+    };
+
+    [[nodiscard]] InstanceVersion GetVersion() const noexcept;
 
 private:
     class ScopedBatchLock;
@@ -179,6 +206,7 @@ private:
     size_t batch_key_size_ = MetaIndexerConfig::kDefaultBatchKeySize;
     std::string instance_id_;
     StorageUsageData storage_usage_data_;
+    InstanceVersion version_ = InstanceVersion::VERSION_1;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
@@ -321,6 +321,7 @@ TEST_F(LocalMetricsReporterTest, TestReportIntervalCacheManagerMetrics) {
               cache_manager_->meta_indexer_manager_->CreateMetaIndexer("test_instance_id", meta_indexer_config));
     auto meta_indexer = cache_manager_->meta_indexer_manager_->GetMetaIndexer("test_instance_id");
     meta_indexer->key_count_.store(5);
+    meta_indexer->AddStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 1024 * 5);
     cache_manager_->metrics_recorder_->Start();
     std::this_thread::sleep_for(std::chrono::seconds(6));
     EXPECT_NO_FATAL_FAILURE(reporter_->ReportInterval());


### PR DESCRIPTION
**1. Introducing instance version to handle storage usage data backward compatibility**
Implements a backward compatibility mechanism for instance storage usage accounting by introducing the `InstanceVersion` enum to distinguish between legacy instances (`VERSION_0`) and new instances with accurate storage tracking (`VERSION_1`). This is a follow-up (or, fix-up) work for, and *must* be deployed together with, #77 .
* **version 0**: legacy instances, storage usage calculated by `block_size * key_count`; metadata persisted:
  * `METADATA_PROPERTY_KEY_COUNT`
* **version 1**: new instances with accurate storage usage tracking; metadata persisted:
  * `METADATA_PROPERTY_KEY_COUNT`
  * `METADATA_PROPERTY_STORAGE_USAGE_DATA`

**2. `CacheManagerMetricsRecorder` add support for accurate usage data calculation**