### PR TITLE
[metrics] introducing Prometheus metrics endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,9 @@
 
 ### 模块文档
 - [优化器文档](optimizer.md) - 缓存优化策略和算法说明
-- [Prometheus Metrics (English)](prometheus-en_US.md) - Prometheus metrics endpoint documentation
-- [Prometheus Metrics (中文)](prometheus-zh_CN.md) - Prometheus 指标端点文档
+- Prometheus Metrics
+  - [English](prometheus-en_US.md) - Prometheus metrics endpoint documentation
+  - [中文](prometheus-zh_CN.md) - Prometheus 指标端点文档
 
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@
 
 ### 模块文档
 - [优化器文档](optimizer.md) - 缓存优化策略和算法说明
+- [Prometheus Metrics (English)](prometheus-en_US.md) - Prometheus metrics endpoint documentation
+- [Prometheus Metrics (中文)](prometheus-zh_CN.md) - Prometheus 指标端点文档
 
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,12 @@ kvcm.metrics.reporter_config
 # 若启用的metrics reporter有周期性report任务，指定该任务的唤醒间隔；默认20000
 kvcm.metrics.report_interval_ms
 
+# 是否开启Prometheus metrics端点（GET /metrics），默认true
+kvcm.metrics.enable_prometheus=true
+
+# Prometheus metrics名称前缀，默认kvcm
+kvcm.metrics.prometheus_prefix=kvcm
+
 # log event publisher的初始化配置值，暂未启用
 kvcm.event.event_publishers_configs
 ```

--- a/docs/prometheus-en_US.md
+++ b/docs/prometheus-en_US.md
@@ -1,0 +1,153 @@
+# Prometheus Metrics Endpoint
+
+KVCacheManager exposes a Prometheus-compatible metrics scrape endpoint
+at `GET /metrics` on the Admin HTTP service port (default 6492).
+
+## Quick Start
+
+With default settings, the endpoint is enabled automatically. Point
+your Prometheus instance at the Admin HTTP port:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: kvcache_manager
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["<host>:6492"]
+```
+
+Then query metrics with PromQL:
+
+```promql
+# Service QPS (rate over 1 minute)
+rate(kvcm_service_query_counter[1m])
+
+# Cache hit ratio
+kvcm_meta_indexer_search_cache_hit_ratio
+
+# Storage usage per backend
+kvcm_data_storage_storage_usage_ratio
+```
+
+## Configuration
+
+Two config keys control the Prometheus endpoint:
+
+| Key | Default | Description |
+|---|---|---|
+| `kvcm.metrics.enable_prometheus` | `true` | Enable/disable the `GET /metrics` endpoint |
+| `kvcm.metrics.prometheus_prefix` | `kvcm` | Prefix prepended to all metric names |
+
+Set via config file, `--env` flag, or environment variable:
+
+```bash
+# Disable the endpoint
+kv_cache_manager_bin -e 'kvcm.metrics.enable_prometheus=false'
+
+# Change the metric name prefix
+kv_cache_manager_bin -e 'kvcm.metrics.prometheus_prefix=myapp'
+```
+
+## Output Format
+
+The endpoint outputs the Prometheus text exposition format
+(`text/plain; version=0.0.4; charset=utf-8`).
+
+Internal metric names (dotted, e.g. `service.query_counter`) are
+translated to Prometheus-compatible names by replacing dots with
+underscores and prepending the configured prefix:
+
+```
+service.query_counter  ->  kvcm_service_query_counter
+meta_indexer.total_key_count  ->  kvcm_meta_indexer_total_key_count
+```
+
+`CounterValue` metrics are emitted as `# TYPE ... counter`.
+`GaugeValue` metrics are emitted as `# TYPE ... gauge`.
+
+`MetricsTags` (key-value pairs) are emitted as Prometheus labels:
+
+```
+kvcm_data_storage_storage_usage_ratio{type="hf3fs",unique_name="nfs_01"} 0.75
+kvcm_cache_manager_group_usage_ratio{instance_group="default"} 0.42
+```
+
+## Example Output
+
+```
+# HELP kvcm_service_query_counter service.query_counter
+# TYPE kvcm_service_query_counter counter
+kvcm_service_query_counter 12345
+# HELP kvcm_service_query_rt_us service.query_rt_us
+# TYPE kvcm_service_query_rt_us gauge
+kvcm_service_query_rt_us 523.5
+# HELP kvcm_meta_indexer_total_key_count meta_indexer.total_key_count
+# TYPE kvcm_meta_indexer_total_key_count gauge
+kvcm_meta_indexer_total_key_count 42000
+# HELP kvcm_data_storage_storage_usage_ratio data_storage.storage_usage_ratio
+# TYPE kvcm_data_storage_storage_usage_ratio gauge
+kvcm_data_storage_storage_usage_ratio{type="hf3fs",unique_name="store_01"} 0.6
+kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="store_02"} 0.3
+```
+
+## Available Metrics
+
+The endpoint exposes all metrics registered in the shared
+`MetricsRegistry`. These include both per-query metrics (accumulated
+counters and latest-value gauges) and interval metrics (refreshed
+every `kvcm.metrics.report_interval_ms`, default 20s).
+
+### Per-Query Metrics
+
+| Metric | Type | Description |
+|---|---|---|
+| `service.query_counter` | counter | Total query count |
+| `service.error_counter` | counter | Total error count |
+| `service.query_rt_us` | gauge | Last query response time (us) |
+| `service.request_queue_size` | gauge | Request queue size |
+| `manager.request_key_count` | gauge | Keys per request |
+| `manager.prefix_match_len` | gauge | Prefix match length |
+| `manager.prefix_match_time_us` | gauge | Prefix match latency (us) |
+| `meta_indexer.search_cache_hit_ratio` | gauge | Search cache hit ratio |
+| `data_storage.create_keys_counter` | counter | Total created keys |
+
+### Interval Metrics
+
+| Metric | Type | Description |
+|---|---|---|
+| `meta_indexer.total_key_count` | gauge | Total keys across all indexers |
+| `meta_indexer.total_cache_usage` | gauge | Total cache usage bytes |
+| `data_storage.healthy_status` | gauge | Storage backend health (1/0) |
+| `data_storage.storage_usage_ratio` | gauge | Storage usage ratio |
+| `cache_manager.write_location_expire_size` | gauge | Expired write locations |
+| `cache_manager_group.usage_ratio` | gauge | Group capacity usage ratio |
+| `cache_manager_instance.key_count` | gauge | Per-instance key count |
+| `cache_manager_instance.byte_size` | gauge | Per-instance byte size |
+
+The full list depends on the active `MetricsReporter` type. The
+`kmonitor` reporter populates the most complete set of metrics.
+
+## Architecture
+
+The Prometheus endpoint is implemented as a lightweight serializer
+(`PrometheusExporter`) that reads the existing `MetricsRegistry` at
+scrape time. It does not use any external Prometheus client library.
+
+```
+Prometheus  --GET /metrics-->  AdminServiceHttp
+                                  |
+                                  v
+                           PrometheusExporter::Expose()
+                                  |
+                                  v
+                           MetricsRegistry::GetAllMetrics()
+                                  |
+                                  v
+                           text/plain response
+```
+
+The endpoint is orthogonal to the `MetricsReporter` pipeline. Any
+reporter type (`kmonitor`, `local`, `logging`, `dummy`) populates
+the same `MetricsRegistry`, and the Prometheus endpoint reads from it.

--- a/docs/prometheus-zh_CN.md
+++ b/docs/prometheus-zh_CN.md
@@ -1,0 +1,150 @@
+# Prometheus Metrics 端点
+
+KVCacheManager 在 Admin HTTP 服务端口（默认 6492）上提供了兼容 Prometheus
+的指标抓取端点 `GET /metrics`。
+
+## 快速开始
+
+默认配置下该端点自动启用。将 Prometheus 实例指向 Admin HTTP 端口即可：
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: kvcache_manager
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["<host>:6492"]
+```
+
+然后使用 PromQL 查询指标：
+
+```promql
+# 服务 QPS（1 分钟速率）
+rate(kvcm_service_query_counter[1m])
+
+# 缓存命中率
+kvcm_meta_indexer_search_cache_hit_ratio
+
+# 每个后端的存储使用率
+kvcm_data_storage_storage_usage_ratio
+```
+
+## 配置
+
+以下两个配置项控制 Prometheus 端点：
+
+| 配置项 | 默认值 | 说明 |
+|---|---|---|
+| `kvcm.metrics.enable_prometheus` | `true` | 启用/禁用 `GET /metrics` 端点 |
+| `kvcm.metrics.prometheus_prefix` | `kvcm` | 所有指标名称的前缀 |
+
+可通过配置文件、`--env` 启动参数或环境变量进行设置：
+
+```bash
+# 禁用端点
+kv_cache_manager_bin -e 'kvcm.metrics.enable_prometheus=false'
+
+# 修改指标名称前缀
+kv_cache_manager_bin -e 'kvcm.metrics.prometheus_prefix=myapp'
+```
+
+## 输出格式
+
+端点输出 Prometheus 文本展示格式
+（`text/plain; version=0.0.4; charset=utf-8`）。
+
+内部指标名称（点分隔，如 `service.query_counter`）会被转换为
+Prometheus 兼容的名称——将点替换为下划线，并添加配置的前缀：
+
+```
+service.query_counter  ->  kvcm_service_query_counter
+meta_indexer.total_key_count  ->  kvcm_meta_indexer_total_key_count
+```
+
+`CounterValue` 类型的指标以 `# TYPE ... counter` 输出。
+`GaugeValue` 类型的指标以 `# TYPE ... gauge` 输出。
+
+`MetricsTags`（键值对）以 Prometheus 标签形式输出：
+
+```
+kvcm_data_storage_storage_usage_ratio{type="hf3fs",unique_name="nfs_01"} 0.75
+kvcm_cache_manager_group_usage_ratio{instance_group="default"} 0.42
+```
+
+## 输出示例
+
+```
+# HELP kvcm_service_query_counter service.query_counter
+# TYPE kvcm_service_query_counter counter
+kvcm_service_query_counter 12345
+# HELP kvcm_service_query_rt_us service.query_rt_us
+# TYPE kvcm_service_query_rt_us gauge
+kvcm_service_query_rt_us 523.5
+# HELP kvcm_meta_indexer_total_key_count meta_indexer.total_key_count
+# TYPE kvcm_meta_indexer_total_key_count gauge
+kvcm_meta_indexer_total_key_count 42000
+# HELP kvcm_data_storage_storage_usage_ratio data_storage.storage_usage_ratio
+# TYPE kvcm_data_storage_storage_usage_ratio gauge
+kvcm_data_storage_storage_usage_ratio{type="hf3fs",unique_name="store_01"} 0.6
+kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="store_02"} 0.3
+```
+
+## 可用指标
+
+该端点导出 `MetricsRegistry` 中注册的所有指标，包括逐请求指标（累积
+计数器和最新值仪表）以及周期性指标（每 `kvcm.metrics.report_interval_ms`
+刷新一次，默认 20 秒）。
+
+### 逐请求指标
+
+| 指标 | 类型 | 说明 |
+|---|---|---|
+| `service.query_counter` | counter | 总查询次数 |
+| `service.error_counter` | counter | 总错误次数 |
+| `service.query_rt_us` | gauge | 最近一次查询响应时间（微秒） |
+| `service.request_queue_size` | gauge | 请求队列大小 |
+| `manager.request_key_count` | gauge | 每次请求的 key 数量 |
+| `manager.prefix_match_len` | gauge | 前缀匹配长度 |
+| `manager.prefix_match_time_us` | gauge | 前缀匹配延迟（微秒） |
+| `meta_indexer.search_cache_hit_ratio` | gauge | 搜索缓存命中率 |
+| `data_storage.create_keys_counter` | counter | 已创建 key 总数 |
+
+### 周期性指标
+
+| 指标 | 类型 | 说明 |
+|---|---|---|
+| `meta_indexer.total_key_count` | gauge | 所有索引器的 key 总数 |
+| `meta_indexer.total_cache_usage` | gauge | 缓存使用总量（字节） |
+| `data_storage.healthy_status` | gauge | 存储后端健康状态（1/0） |
+| `data_storage.storage_usage_ratio` | gauge | 存储使用率 |
+| `cache_manager.write_location_expire_size` | gauge | 已过期的写入位置数量 |
+| `cache_manager_group.usage_ratio` | gauge | 实例组容量使用率 |
+| `cache_manager_instance.key_count` | gauge | 单实例 key 数量 |
+| `cache_manager_instance.byte_size` | gauge | 单实例字节大小 |
+
+完整指标列表取决于当前使用的 `MetricsReporter` 类型。`kmonitor`
+类型的 reporter 会填充最完整的指标集。
+
+## 架构
+
+Prometheus 端点通过一个轻量级序列化器（`PrometheusExporter`）实现，
+在抓取时读取已有的 `MetricsRegistry`。不依赖任何外部 Prometheus
+客户端库。
+
+```
+Prometheus  --GET /metrics-->  AdminServiceHttp
+                                  |
+                                  v
+                           PrometheusExporter::Expose()
+                                  |
+                                  v
+                           MetricsRegistry::GetAllMetrics()
+                                  |
+                                  v
+                           text/plain 响应
+```
+
+该端点与 `MetricsReporter` 管线正交。任何 reporter 类型（`kmonitor`、
+`local`、`logging`、`dummy`）都向同一个 `MetricsRegistry` 写入数据，
+Prometheus 端点从中读取。

--- a/kv_cache_manager/metrics/BUILD
+++ b/kv_cache_manager/metrics/BUILD
@@ -52,6 +52,19 @@ cc_library(
 )
 
 cc_library(
+    name = "prometheus_exporter",
+    srcs = [
+        "prometheus_exporter.cc",
+    ],
+    hdrs = [
+        "prometheus_exporter.h",
+    ],
+    deps = [
+        ":metrics_registry",
+    ],
+)
+
+cc_library(
     name = "metrics_reporter_factory",
     srcs = [
         "metrics_reporter_factory.cc",

--- a/kv_cache_manager/metrics/prometheus_exporter.cc
+++ b/kv_cache_manager/metrics/prometheus_exporter.cc
@@ -1,0 +1,115 @@
+#include "kv_cache_manager/metrics/prometheus_exporter.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <sstream>
+#include <variant>
+#include <vector>
+
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+// Prometheus metric names must match [a-zA-Z_:][a-zA-Z0-9_:]*.
+// Replace every character that is not in that set with '_'.
+std::string SanitizeName(const std::string &prefix, const std::string &raw_name) {
+    std::string out;
+    out.reserve(prefix.size() + 1 + raw_name.size());
+    out += prefix;
+    out += '_';
+    for (char c : raw_name) {
+        if (c == '.' || c == '-') {
+            out += '_';
+        } else {
+            out += c;
+        }
+    }
+    return out;
+}
+
+// Prometheus label values use double-quoted strings.  Backslash,
+// double-quote and newline must be escaped.
+void EscapeLabelValue(std::ostringstream &ss, const std::string &v) {
+    for (char c : v) {
+        switch (c) {
+        case '\\':
+            ss << "\\\\";
+            break;
+        case '"':
+            ss << "\\\"";
+            break;
+        case '\n':
+            ss << "\\n";
+            break;
+        default:
+            ss << c;
+        }
+    }
+}
+
+void WriteLabels(std::ostringstream &ss, const MetricsTags &tags) {
+    if (tags.empty()) {
+        return;
+    }
+    ss << '{';
+    bool first = true;
+    for (const auto &[k, v] : tags) {
+        if (!first) {
+            ss << ',';
+        }
+        first = false;
+        ss << k << "=\"";
+        EscapeLabelValue(ss, v);
+        ss << '"';
+    }
+    ss << '}';
+}
+
+} // namespace
+
+std::string PrometheusExporter::Expose(MetricsRegistry &registry, const std::string &prefix) {
+    std::vector<MetricsRegistry::metrics_tuple_t> all_metrics;
+    registry.GetAllMetrics(all_metrics);
+
+    // Group metrics by name so we can emit TYPE / HELP lines once per
+    // metric family.
+    //
+    // GetAllMetrics returns entries ordered by name (the underlying
+    // map is std::map<string, ...>), so consecutive entries with the
+    // same name belong to the same family.
+    std::ostringstream ss;
+
+    std::string prev_name;
+    for (const auto &[name, tags, val] : all_metrics) {
+        std::string prom_name = SanitizeName(prefix, name);
+
+        if (name != prev_name) {
+            const char *type_str = "untyped";
+            if (std::holds_alternative<CounterValue>(*val)) {
+                type_str = "counter";
+            } else if (std::holds_alternative<GaugeValue>(*val)) {
+                type_str = "gauge";
+            }
+            ss << "# HELP " << prom_name << ' ' << name << '\n';
+            ss << "# TYPE " << prom_name << ' ' << type_str << '\n';
+            prev_name = name;
+        }
+
+        ss << prom_name;
+        WriteLabels(ss, tags);
+
+        if (std::holds_alternative<CounterValue>(*val)) {
+            ss << ' ' << std::get<CounterValue>(*val).load(std::memory_order_relaxed);
+        } else if (std::holds_alternative<GaugeValue>(*val)) {
+            double gv = std::get<GaugeValue>(*val).load(std::memory_order_relaxed);
+            ss << ' ' << gv;
+        }
+        ss << '\n';
+    }
+
+    return ss.str();
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/prometheus_exporter.cc
+++ b/kv_cache_manager/metrics/prometheus_exporter.cc
@@ -1,8 +1,8 @@
 #include "kv_cache_manager/metrics/prometheus_exporter.h"
 
-#include <algorithm>
-#include <cstdint>
+#include <cmath>
 #include <sstream>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -104,7 +104,13 @@ std::string PrometheusExporter::Expose(MetricsRegistry &registry, const std::str
             ss << ' ' << std::get<CounterValue>(*val).load(std::memory_order_relaxed);
         } else if (std::holds_alternative<GaugeValue>(*val)) {
             double gv = std::get<GaugeValue>(*val).load(std::memory_order_relaxed);
-            ss << ' ' << gv;
+            if (std::isnan(gv)) {
+                ss << " NaN";
+            } else if (std::isinf(gv)) {
+                ss << ' ' << (gv > 0 ? "+Inf" : "-Inf");
+            } else {
+                ss << ' ' << gv;
+            }
         }
         ss << '\n';
     }

--- a/kv_cache_manager/metrics/prometheus_exporter.h
+++ b/kv_cache_manager/metrics/prometheus_exporter.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+namespace kv_cache_manager {
+
+class MetricsRegistry;
+
+// Serializes all metrics held in a MetricsRegistry into the Prometheus
+// text exposition format (text/plain; version=0.0.4; charset=utf-8).
+//
+// Naming rules applied during serialization:
+//   - Dots in the internal metric name are replaced with underscores.
+//   - A configurable prefix (default "kvcm") is prepended, separated
+//     by an underscore.
+//   - MetricsTags become Prometheus labels.
+//   - CounterValue metrics are emitted with TYPE counter.
+//   - GaugeValue   metrics are emitted with TYPE gauge.
+class PrometheusExporter {
+public:
+    // Serialize all metrics in |registry| to Prometheus text format.
+    // |prefix| is prepended to every metric name (e.g. "kvcm").
+    static std::string Expose(MetricsRegistry &registry, const std::string &prefix = "kvcm");
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/test/BUILD
+++ b/kv_cache_manager/metrics/test/BUILD
@@ -97,6 +97,20 @@ cc_test(
 )
 
 cc_test(
+    name = "PrometheusExporterTest",
+    srcs = [
+        "prometheus_exporter_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/metrics:prometheus_exporter",
+    ],
+)
+
+cc_test(
     name = "MetricsRegistryTest",
     srcs = [
         "metrics_registry_test.cc",

--- a/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
+++ b/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
@@ -1,0 +1,128 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/metrics/prometheus_exporter.h"
+
+using namespace kv_cache_manager;
+
+class PrometheusExporterTest : public TESTBASE {
+public:
+    void SetUp() override { registry_ = std::make_shared<MetricsRegistry>(); }
+    void TearDown() override {}
+
+    std::shared_ptr<MetricsRegistry> registry_;
+};
+
+TEST_F(PrometheusExporterTest, EmptyRegistry) {
+    std::string output = PrometheusExporter::Expose(*registry_);
+    ASSERT_TRUE(output.empty());
+}
+
+TEST_F(PrometheusExporterTest, SingleCounter) {
+    Counter c = registry_->GetCounter("service.query_counter");
+    ++c;
+    ++c;
+    ++c;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("# HELP kvcm_service_query_counter"), std::string::npos);
+    EXPECT_NE(output.find("# TYPE kvcm_service_query_counter counter"), std::string::npos);
+    EXPECT_NE(output.find("kvcm_service_query_counter 3"), std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, SingleGauge) {
+    Gauge g = registry_->GetGauge("meta_indexer.total_key_count");
+    g = 42000.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("# HELP kvcm_meta_indexer_total_key_count"), std::string::npos);
+    EXPECT_NE(output.find("# TYPE kvcm_meta_indexer_total_key_count gauge"), std::string::npos);
+    EXPECT_NE(output.find("kvcm_meta_indexer_total_key_count 42000"), std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, MetricsWithTags) {
+    MetricsTags tags = {{"instance_group", "group_a"}, {"type", "hf3fs"}};
+    Gauge g = registry_->GetGauge("data_storage.storage_usage_ratio", tags);
+    g = 0.75;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    // Labels should appear in sorted order (std::map order)
+    EXPECT_NE(output.find("kvcm_data_storage_storage_usage_ratio"
+                          "{instance_group=\"group_a\",type=\"hf3fs\"} 0.75"),
+              std::string::npos)
+        << "Actual output:\n"
+        << output;
+}
+
+TEST_F(PrometheusExporterTest, MultipleTagSets) {
+    MetricsTags tags_a = {{"instance_group", "group_a"}};
+    MetricsTags tags_b = {{"instance_group", "group_b"}};
+
+    Gauge ga = registry_->GetGauge("cache_manager_group.usage_ratio", tags_a);
+    Gauge gb = registry_->GetGauge("cache_manager_group.usage_ratio", tags_b);
+    ga = 0.5;
+    gb = 0.8;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+
+    // TYPE line should appear only once
+    size_t first = output.find("# TYPE kvcm_cache_manager_group_usage_ratio");
+    ASSERT_NE(first, std::string::npos);
+    size_t second = output.find("# TYPE kvcm_cache_manager_group_usage_ratio", first + 1);
+    EXPECT_EQ(second, std::string::npos) << "TYPE line appears more than once";
+
+    // Both label sets should be present
+    EXPECT_NE(output.find("{instance_group=\"group_a\"}"), std::string::npos);
+    EXPECT_NE(output.find("{instance_group=\"group_b\"}"), std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, CustomPrefix) {
+    Counter c = registry_->GetCounter("service.query_counter");
+    ++c;
+
+    std::string output = PrometheusExporter::Expose(*registry_, "myapp");
+    EXPECT_NE(output.find("myapp_service_query_counter"), std::string::npos);
+    EXPECT_EQ(output.find("kvcm_"), std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, LabelValueEscaping) {
+    MetricsTags tags = {{"path", "a\\b\"c\nd"}};
+    Gauge g = registry_->GetGauge("test.escape", tags);
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("path=\"a\\\\b\\\"c\\nd\""), std::string::npos) << "Actual output:\n" << output;
+}
+
+TEST_F(PrometheusExporterTest, DotAndDashInNames) {
+    Gauge g = registry_->GetGauge("my-group.some-metric");
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("kvcm_my_group_some_metric"), std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, HelpLineContainsOriginalName) {
+    Gauge g = registry_->GetGauge("meta_searcher.indexer_get_time_us");
+    g = 99.5;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("# HELP kvcm_meta_searcher_indexer_get_time_us "
+                          "meta_searcher.indexer_get_time_us"),
+              std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, MultipleMetricFamilies) {
+    Counter c = registry_->GetCounter("service.query_counter");
+    Gauge g = registry_->GetGauge("meta_indexer.total_key_count");
+    ++c;
+    g = 100.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("# TYPE kvcm_meta_indexer_total_key_count gauge"), std::string::npos);
+    EXPECT_NE(output.find("# TYPE kvcm_service_query_counter counter"), std::string::npos);
+}

--- a/kv_cache_manager/service/http_service/BUILD
+++ b/kv_cache_manager/service/http_service/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "//kv_cache_manager/config",
         "//kv_cache_manager/data_storage",
         "//kv_cache_manager/data_storage:common_define",
+        "//kv_cache_manager/metrics:prometheus_exporter",
         "//kv_cache_manager/protocol/protobuf:service_cc_proto",
         "//kv_cache_manager/service:admin_service_impl",
         "//kv_cache_manager/service:debug_service_impl",

--- a/kv_cache_manager/service/http_service/admin_service_http.cc
+++ b/kv_cache_manager/service/http_service/admin_service_http.cc
@@ -7,6 +7,7 @@
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/metrics/prometheus_exporter.h"
 #include "kv_cache_manager/protocol/protobuf/admin_service.pb.h"
 #include "kv_cache_manager/service/admin_service_impl.h"
 #include "kv_cache_manager/service/util/common.h"
@@ -16,6 +17,15 @@ namespace kv_cache_manager {
 AdminServiceHttp::AdminServiceHttp(std::shared_ptr<MetricsRegistry> metrics_registry,
                                    std::shared_ptr<AdminServiceImpl> admin_service_impl)
     : metrics_registry_(std::move(metrics_registry)), admin_service_impl_(std::move(admin_service_impl)) {}
+
+AdminServiceHttp::AdminServiceHttp(std::shared_ptr<MetricsRegistry> metrics_registry,
+                                   std::shared_ptr<AdminServiceImpl> admin_service_impl,
+                                   bool enable_prometheus,
+                                   const std::string &prometheus_prefix)
+    : metrics_registry_(std::move(metrics_registry)),
+      admin_service_impl_(std::move(admin_service_impl)),
+      enable_prometheus_(enable_prometheus),
+      prometheus_prefix_(prometheus_prefix) {}
 
 void AdminServiceHttp::Init() {
     // for storage APIs
@@ -106,6 +116,18 @@ void AdminServiceHttp::RegisterHandler() {
 
     // Metrics API
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, getMetrics, GetMetrics, GetMetrics, GetMetrics);
+
+    // Prometheus metrics endpoint (GET /metrics)
+    if (enable_prometheus_ && metrics_registry_) {
+        RegisterGetHandler("/metrics",
+                           [this](coro_http::coro_http_request &req,
+                                  coro_http::coro_http_response &res) -> async_simple::coro::Lazy<void> {
+                               std::string body = PrometheusExporter::Expose(*metrics_registry_, prometheus_prefix_);
+                               res.add_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+                               res.set_status_and_content(coro_http::status_type::ok, std::move(body));
+                               co_return;
+                           });
+    }
 
     // High Availability APIs
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, checkHealth, CheckHealth, CheckHealth, CheckHealth);

--- a/kv_cache_manager/service/http_service/admin_service_http.h
+++ b/kv_cache_manager/service/http_service/admin_service_http.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "kv_cache_manager/metrics/metrics_collector.h"
 #include "kv_cache_manager/protocol/protobuf/admin_service.pb.h"
@@ -15,6 +16,10 @@ class AdminServiceHttp : public CoroHttpService {
 public:
     AdminServiceHttp(std::shared_ptr<MetricsRegistry> metrics_registry,
                      std::shared_ptr<AdminServiceImpl> admin_service_impl);
+    AdminServiceHttp(std::shared_ptr<MetricsRegistry> metrics_registry,
+                     std::shared_ptr<AdminServiceImpl> admin_service_impl,
+                     bool enable_prometheus,
+                     const std::string &prometheus_prefix);
 
     void Init() override;
     void RegisterHandler() override;
@@ -115,6 +120,8 @@ public:
 private:
     std::shared_ptr<MetricsRegistry> metrics_registry_;
     std::shared_ptr<AdminServiceImpl> admin_service_impl_;
+    bool enable_prometheus_ = true;
+    std::string prometheus_prefix_ = "kvcm";
 
     // for storage APIs
     KVCM_DECLARE_METRICS_COLLECTOR_(AddStorage);

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -223,7 +223,8 @@ bool Server::StartHttpServer() {
     int32_t admin_http_port = config_.GetServiceAdminHttpPort();
 
     meta_http_service_ = std::make_shared<MetaServiceHttp>(metrics_registry_, meta_impl_, registry_manager_);
-    admin_http_service_ = std::make_shared<AdminServiceHttp>(metrics_registry_, admin_impl_);
+    admin_http_service_ = std::make_shared<AdminServiceHttp>(
+        metrics_registry_, admin_impl_, config_.enable_prometheus(), config_.prometheus_prefix());
     debug_http_service_ = std::make_shared<DebugServiceHttp>(metrics_registry_, debug_impl_);
 
     meta_http_service_->Init();

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -141,6 +141,16 @@ std::unordered_map<std::string, ServerConfig::SettingFunction> ServerConfig::kSe
      [](const std::string &value, ServerConfig *config) {
          config->custom_info_ = value;
          return true;
+     }},
+    {"kvcm.metrics.enable_prometheus",
+     [](const std::string &value, ServerConfig *config) {
+         config->enable_prometheus_ = value == "true";
+         return true;
+     }},
+    {"kvcm.metrics.prometheus_prefix",
+     [](const std::string &value, ServerConfig *config) {
+         config->prometheus_prefix_ = value;
+         return true;
      }}};
 
 bool ServerConfig::Parse(const std::string &config_file, const EnvironMap &environ) {

--- a/kv_cache_manager/service/server_config.h
+++ b/kv_cache_manager/service/server_config.h
@@ -40,6 +40,8 @@ public:
     const std::string &metrics_reporter_type() { return metrics_reporter_type_; }
     const std::string &metrics_reporter_config() { return metrics_reporter_config_; }
     int64_t metrics_report_interval_ms() { return metrics_report_interval_ms_; }
+    bool enable_prometheus() const { return enable_prometheus_; }
+    const std::string &prometheus_prefix() const { return prometheus_prefix_; }
     const std::string &event_publishers_configs() { return event_publishers_configs_; }
     const std::string &GetAdvertisedHost() const { return advertised_host_; }
     const std::string &GetCustomInfo() const { return custom_info_; }
@@ -73,6 +75,8 @@ private:
     std::string metrics_reporter_type_;
     std::string metrics_reporter_config_;
     int64_t metrics_report_interval_ms_ = 0;
+    bool enable_prometheus_ = true;
+    std::string prometheus_prefix_ = "kvcm";
     std::string event_publishers_configs_;
     std::string advertised_host_;
     std::string custom_info_;


### PR DESCRIPTION
# Prometheus Pull Endpoint

## Approach: Self-contained, no new library dependency

Instead of adding `prometheus-cpp` as an external dependency (which
brings `civetweb`, `curl`, and transitive dep management headaches),
implement a lightweight Prometheus text exposition formatter that reads
directly from the existing `MetricsRegistry`. The format (OpenMetrics /
Prometheus text exposition: https://prometheus.io/docs/instrumenting/exposition_formats/)
is simple enough to serialize ourselves.

This is consistent with how `LoggingMetricsReporter` already iterates
`GetAllMetrics()` and formats text output. The Prometheus format is
equally straightforward.

## Components

### 1. `PrometheusExporter` — new class

A stateless utility class that serializes a `MetricsRegistry` snapshot
into Prometheus text exposition format
(`text/plain; version=0.0.4; charset=utf-8`).

```cpp
class PrometheusExporter {
public:
    // Serialize all metrics in the registry to Prometheus text format.
    // - Dots in metric names are replaced with underscores (Prometheus
    //   naming convention).
    // - MetricsTags become Prometheus labels.
    // - CounterValue -> rendered as untyped (or counter) metric.
    // - GaugeValue   -> rendered as gauge metric.
    static std::string Expose(MetricsRegistry &registry);
};
```

Naming translation: The existing metric names use the `group.name` dot
convention (e.g., `service.query_rt_us`, `meta_indexer.total_key_count`).
Prometheus metric names must match `[a-zA-Z_:][a-zA-Z0-9_:]*`, so dots
are replaced with underscores. A configurable prefix (default: `kvcm_`)
is prepended.

Output example:

```
# HELP kvcm_service_query_rt_us service.query_rt_us
# TYPE kvcm_service_query_rt_us gauge
kvcm_service_query_rt_us{instance_group="default"} 1234.0
# HELP kvcm_meta_indexer_total_key_count meta_indexer.total_key_count
# TYPE kvcm_meta_indexer_total_key_count gauge
kvcm_meta_indexer_total_key_count 42000
```

For `CounterValue` metrics, the `TYPE` is emitted as `counter`; for
`GaugeValue`, as `gauge`.

### 2. `GET /metrics` HTTP endpoint — on the Admin HTTP service

Register a `GET /metrics` handler on the Admin HTTP service (port
`6492`, configurable). This follows Prometheus convention for scrape
targets:

```cpp
// In AdminServiceHttp::RegisterHandler():
RegisterGetHandler("/metrics", [this](auto &req, auto &resp) {
    std::string body = PrometheusExporter::Expose(*metrics_registry_);
    resp.set_status_and_content(
        cinatra::status_type::ok,
        std::move(body),
        cinatra::req_content_type::text);
    // Content-Type: text/plain; version=0.0.4; charset=utf-8
});
```

The handler calls `PrometheusExporter::Expose()` which internally calls
`MetricsRegistry::GetAllMetrics()` at scrape time, guaranteeing the
latest values.

Since `ReportInterval()` runs every 20s and updates interval metrics
(data storage health, key counts, etc.) into the same `MetricsRegistry`,
the scrape endpoint naturally picks up both:

- Per-query accumulated metrics (counters like `service.query_counter`,
  `service.error_counter`)
- Interval metrics (gauges like `meta_indexer.total_key_count`,
  `data_storage.storage_usage_ratio`, `cache_reclaimer.*`)

No changes needed to `MetricsReporter` or `MetricsCollector`. The
exporter reads from the registry that all reporters already populate.

### 3. Configuration

Add a config flag to enable/disable the Prometheus endpoint:

| Config Key                       | Default  | Description                    |
|----------------------------------|----------|--------------------------------|
| `kvcm.metrics.enable_prometheus` | `true`   | Enable `GET /metrics` endpoint |
| `kvcm.metrics.prometheus_prefix` | `"kvcm"` | Metric name prefix             |

When disabled, the `GET /metrics` handler is simply not registered.
