### PR TITLE
[manager] evict CLS_WRITING location not being tracked

### DIFF
--- a/integration_test/reclaimer/reclaiming_test.py
+++ b/integration_test/reclaimer/reclaiming_test.py
@@ -161,6 +161,121 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         # now the writing of key=16 should success
         self._write(16)
 
+    def test_reclaiming_02(self):
+        """Test that CLS_WRITING keys left over after a server restart
+        should not permanently block reclaimer progress.
+
+        Scenario
+        --------
+        1. Setup: Fill test_instance_01 with 8 start_write_cache calls
+           (keys 0-7) without ever calling finish_write_cache.  The keys
+           are now in CLS_WRITING state and their write sessions exist
+           only in server memory.
+        2. Restart the server immediately.  The meta indexer recovers
+           keys 0-7 from the local-file backend (CLS_WRITING status
+           preserved), but the in-memory write session table is gone.
+        3. Re-register test_instance_01 (loads recovered indexer) and
+           verify finish_write_cache with the pre-restart session IDs
+           must all fail, because the server no longer knows those
+           sessions.
+        4. Write 8 new keys (8-15) into test_instance_01.
+        5. Lower the threshold for test_group_01; make the reclaimer
+           fires.
+        6. Assert: a new write to test_instance_01 (key id = 16) must
+           succeed once the reclaimer has freed a slot.
+        """
+        # add storage
+        add_storage_req = {
+            "trace_id": self._trace_id,
+            "storage": self._make_dummy_storage(),
+        }
+        self._admin_client.add_storage(add_storage_req)
+
+        # add instance group; reclaim trigger is intentionally too high
+        # to fire at this point
+        ig = self._make_dummy_instance_group()
+        create_ig_req = {
+            "trace_id": self._trace_id,
+            "instance_group": ig,
+        }
+        self._admin_client.create_instance_group(create_ig_req)
+
+        # register test_instance_01
+        reg_ins_01_req = self._make_dummy_ins_req()
+        self._client.register_instance(reg_ins_01_req)
+
+        # start writing keys 0-7 into test_instance_01 without finishing
+        # them; the keys are recorded in CLS_WRITING state in the
+        # indexer
+        for i in range(8):
+            self._start_write(i)
+
+        # restart the server immediately before any finish_write_cache
+        # is called; the write session table is lost, but the meta
+        # indexer is flushed to disk (local-file backend) so keys 0-7
+        # survive the restart with CLS_WRITING status
+        self.worker_manager.stop_worker(0)
+        self.assertTrue(
+            self.worker_manager.start_worker(
+                # configure batching_size=8 so the reclaimer always
+                # builds a batch contains test_instance_01's all old
+                # CLS_WRITING keys due to the LRU access time
+                0, **{"kvcm.cache_reclaimer.del_batch_size": 8}
+            )
+        )
+
+        # reconnect clients: update_ports() assigns fresh ports on every
+        # start
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_client()
+
+        # re-add the storage and instance group after restart; the
+        # registry is in-memory only and was lost; using the same
+        # storage_uri causes MetaIndexer to reload keys 0-7 (CLS_WRITING)
+        # from the storage backend
+        # re-register test_instance_01 to bring the recovered indexer
+        # back online
+        self._admin_client.add_storage(add_storage_req)
+        create_ig_req["trace_id"] = self._trace_id + "_restart"
+        self._admin_client.create_instance_group(create_ig_req)
+        self._client.register_instance(reg_ins_01_req)
+
+        # the server lost all write session state on restart, so
+        # finish_write_cache with the pre-restart session IDs must fail
+        for i in range(8):
+            self._finish_write_expect_fail(i)
+
+        # write 8 new keys (8-15) into test_instance_01
+        for i in range(8, 16):
+            self._write(i)
+        # now the quota is full
+        self._start_write_expect_fail(16)
+
+        # fire the reclaimer for test_group_01
+        curr_ver = ig["version"]
+        ig["version"] = curr_ver + 1
+        ig[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "trigger_strategy"
+        ][
+            "used_percentage"
+        ] = 0.1
+        self._admin_client.update_instance_group({
+            "trace_id": self._trace_id + "_update_ig",
+            "instance_group": ig,
+            "current_version": curr_ver,
+        })
+
+        time.sleep(2)
+
+        # the orphaned CLS_WRITING should not stop the evicting
+        # new write should now be accepted
+        self._write(16)
+
     def test_persist_recover_00(self):
         """Test e2e persist/recover: cache locations and metadata
         survive a normal server restart.
@@ -485,6 +600,24 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         resp = self._client.start_write_cache(start_write_req,
                                               check_response=False)
         self.assertNotEqual(resp['header']['status']['code'], "OK")
+
+    def _finish_write_expect_fail(self, blk_key):
+        logging.info(f"finish write expecting failure, block key: {blk_key}")
+        trace_id = f"{self._trace_id}_blk_key_{blk_key}"
+        resp = self._resp_dict[blk_key]
+        finish_write_req = {
+            "trace_id": trace_id,
+            "instance_id": self._instance_id,
+            "write_session_id": resp["write_session_id"],
+            "success_blocks": {
+                "bool_masks": {
+                    "values": [True],
+                }
+            },
+        }
+        resp = self._client.finish_write_cache(finish_write_req,
+                                               check_response=False)
+        self.assertNotEqual(resp["header"]["status"]["code"], "OK")
 
     def _start_write(self, blk_key):
         logging.info(f"start write, block key: {blk_key}")

--- a/kv_cache_manager/manager/BUILD
+++ b/kv_cache_manager/manager/BUILD
@@ -83,6 +83,7 @@ cc_library(
         "//kv_cache_manager/event:event_publisher",
         "//kv_cache_manager/manager:meta_searcher",
         "//kv_cache_manager/manager:schedule_plan_executor",
+        "//kv_cache_manager/manager:write_location_manager",
         "//kv_cache_manager/meta",
         "//kv_cache_manager/metrics:metrics_registry",
     ],

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -171,7 +171,8 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
                                                         meta_searcher_manager_,
                                                         schedule_plan_executor_,
                                                         metrics_registry_,
-                                                        event_manager_);
+                                                        event_manager_,
+                                                        write_location_manager_);
     if (cache_reclaimer_->Start() != EC_OK) {
         KVCM_LOG_ERROR("CacheManager init failed");
         return false;

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -39,6 +39,7 @@
 #include "kv_cache_manager/manager/meta_searcher.h"
 #include "kv_cache_manager/manager/meta_searcher_manager.h"
 #include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/manager/write_location_manager.h"
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
@@ -236,13 +237,15 @@ CacheReclaimer::CacheReclaimer(const std::size_t sampling_size_total,
                                std::shared_ptr<MetaSearcherManager> meta_searcher_manager,
                                std::shared_ptr<SchedulePlanExecutor> sched_plan_executor,
                                std::shared_ptr<MetricsRegistry> metrics_registry,
-                               std::shared_ptr<EventManager> event_manager)
+                               std::shared_ptr<EventManager> event_manager,
+                               std::shared_ptr<WriteLocationManager> write_location_manager)
     : registry_manager_(std::move(registry_manager))
     , meta_indexer_manager_(std::move(meta_indexer_manager))
     , meta_searcher_manager_(std::move(meta_searcher_manager))
     , sched_plan_executor_(std::move(sched_plan_executor))
     , metrics_registry_(std::move(metrics_registry))
     , event_manager_(std::move(event_manager))
+    , write_location_manager_(std::move(write_location_manager))
     , job_state_flag_(false)
     , pause_flag_(false)
     , sampling_size_(sampling_size_total)
@@ -936,8 +939,15 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
     for (const auto &loc_map : loc_maps) {
         std::vector<std::string> loc_id_vec;
         for (const auto &[_, loc] : loc_map) {
-            // pick out only the cache location with "serving" status
-            if (loc.status() == CacheLocationStatus::CLS_SERVING) {
+            // a location is eligible for eviction if:
+            // 1. it is in CLS_SERVING status, OR
+            // 2. it is in CLS_WRITING status but its write session is
+            //    no longer active (orphaned after a server restart)
+            const bool is_orphaned_writing =
+                loc.status() == CacheLocationStatus::CLS_WRITING &&
+                write_location_manager_ != nullptr &&
+                !write_location_manager_->HasLocationId(loc.id());
+            if (loc.status() == CacheLocationStatus::CLS_SERVING || is_orphaned_writing) {
                 if (water_level_exceed.CheckStorageTypeWaterLevelExceed()) {
                     // some storage type water level exceeded; only
                     // collect the location with matched type but

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -591,9 +591,10 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
         return;
     }
 
-    // 3. inspect the cache location status for every blocks so that
-    // only the cache locations with the "CLS_SERVING" status are
-    // submitted to be deleted
+    // 3. inspect the cache location status for every blocks so that:
+    //    a) cache locations in CLS_SERVING status
+    //    b) cache locations in CLS_WRITING status *and* is orphaned
+    //    are submitted to be deleted
     const std::int64_t begin_tp_filter = TimestampUtil::GetSteadyTimeUs();
     if (!FilterLocID(
             request_context.get(), instance_info, request.block_keys, water_level_exceed, request.location_ids)) {

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -53,6 +53,7 @@ class MetaSearcherManager;
 class RegistryManager;
 class RequestContext;
 class SchedulePlanExecutor;
+class WriteLocationManager;
 struct CacheLocationDelRequest;
 struct PlanExecuteResult;
 
@@ -72,8 +73,9 @@ struct PlanExecuteResult;
  *    thresholds
  * 3. Sampling keys from instances and identifying the least valuable
  *    ones
- * 4. Submitting deletion requests for locations in CLS_SERVING status
- *    only for those keys
+ * 4. Submitting deletion requests for locations in CLS_SERVING status,
+ *    or CLS_WRITING locations whose write session is no longer active
+ *    (i.e. orphaned after a server restart)
  *
  * @note This class is not thread-safe and should only be accessed by
  * the cache-manager thread.
@@ -105,6 +107,9 @@ public:
      * for cache-reclaimer related metrics data management
      * @param event_manager Shared pointer to EventManager for event
      * publish
+     * @param write_location_manager Shared pointer to WriteLocationManager
+     * used to detect orphaned CLS_WRITING locations whose write session
+     * is no longer active
      */
     CacheReclaimer(std::size_t sampling_size_total,
                    std::size_t sampling_size_per_task,
@@ -116,7 +121,8 @@ public:
                    std::shared_ptr<MetaSearcherManager> meta_searcher_manager,
                    std::shared_ptr<SchedulePlanExecutor> sched_plan_executor,
                    std::shared_ptr<MetricsRegistry> metrics_registry,
-                   std::shared_ptr<EventManager> event_manager);
+                   std::shared_ptr<EventManager> event_manager,
+                   std::shared_ptr<WriteLocationManager> write_location_manager);
 
     /**
      * @brief Delete copy constructor
@@ -270,6 +276,8 @@ private:
     const std::shared_ptr<MetricsRegistry> metrics_registry_;
     // for event publish
     const std::shared_ptr<EventManager> event_manager_;
+    // to detect orphaned CLS_WRITING locations during reclaiming
+    const std::shared_ptr<WriteLocationManager> write_location_manager_;
 
     // represents the object of the associated working thread
     std::thread reclaimer_;

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -356,7 +356,8 @@ public:
         dsm_ = std::make_shared<DataStorageManager>(mr_);
         spe_ = std::make_shared<SchedulePlanExecutor>(0, mim_, dsm_, mr_);
 
-        cache_reclaimer_ = std::make_unique<CacheReclaimer>(10, 100, 1, 10, 16, rm_, mim_, msm_, spe_, mr_, em_);
+        cache_reclaimer_ =
+            std::make_unique<CacheReclaimer>(10, 100, 1, 10, 16, rm_, mim_, msm_, spe_, mr_, em_, nullptr);
 
         // avoid nullptr issue when testing methods that involve metrics
         // counter but no need to start the working thread
@@ -493,7 +494,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     {
         // test the case that all the dependencies are given as nullptr
         auto cache_reclaimer = std::make_unique<CacheReclaimer>(
-            1000, 100, 100, 100, 16, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+            1000, 100, 100, 100, 16, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
         ASSERT_EQ(ErrorCode::EC_ERROR, cache_reclaimer->Start());
         ASSERT_FALSE(cache_reclaimer->IsRunning());
         ASSERT_FALSE(cache_reclaimer->reclaimer_.joinable());
@@ -502,7 +503,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     {
         // test the case that RegisterManager is nullptr
         auto cache_reclaimer =
-            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, nullptr, mim_, msm_, spe_, mr_, em_);
+            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, nullptr, mim_, msm_, spe_, mr_, em_, nullptr);
         ASSERT_EQ(ErrorCode::EC_ERROR, cache_reclaimer->Start());
         ASSERT_FALSE(cache_reclaimer->IsRunning());
         ASSERT_FALSE(cache_reclaimer->reclaimer_.joinable());
@@ -511,7 +512,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     {
         // test the case that MetaIndexerManager is nullptr
         auto cache_reclaimer =
-            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, nullptr, msm_, spe_, mr_, em_);
+            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, nullptr, msm_, spe_, mr_, em_, nullptr);
         ASSERT_EQ(ErrorCode::EC_ERROR, cache_reclaimer->Start());
         ASSERT_FALSE(cache_reclaimer->IsRunning());
         ASSERT_FALSE(cache_reclaimer->reclaimer_.joinable());
@@ -520,7 +521,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     {
         // test the case that MetaSearcherManager is nullptr
         auto cache_reclaimer =
-            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, nullptr, spe_, mr_, em_);
+            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, nullptr, spe_, mr_, em_, nullptr);
         ASSERT_EQ(ErrorCode::EC_ERROR, cache_reclaimer->Start());
         ASSERT_FALSE(cache_reclaimer->IsRunning());
         ASSERT_FALSE(cache_reclaimer->reclaimer_.joinable());
@@ -529,7 +530,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     {
         // test the case that SchedulePlanExecutor is nullptr
         auto cache_reclaimer =
-            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, msm_, nullptr, mr_, em_);
+            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, msm_, nullptr, mr_, em_, nullptr);
         ASSERT_EQ(ErrorCode::EC_ERROR, cache_reclaimer->Start());
         ASSERT_FALSE(cache_reclaimer->IsRunning());
         ASSERT_FALSE(cache_reclaimer->reclaimer_.joinable());
@@ -538,7 +539,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     {
         // test the case that MetricsRegistry is nullptr
         auto cache_reclaimer =
-            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, msm_, spe_, nullptr, em_);
+            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, msm_, spe_, nullptr, em_, nullptr);
         ASSERT_EQ(ErrorCode::EC_ERROR, cache_reclaimer->Start());
         ASSERT_FALSE(cache_reclaimer->IsRunning());
         ASSERT_FALSE(cache_reclaimer->reclaimer_.joinable());
@@ -547,7 +548,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     {
         // test the case that MetricsRegistry is nullptr
         auto cache_reclaimer =
-            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, msm_, spe_, mr_, nullptr);
+            std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, rm_, mim_, msm_, spe_, mr_, nullptr, nullptr);
         ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer->Start());
         ASSERT_TRUE(cache_reclaimer->IsRunning());
         ASSERT_TRUE(cache_reclaimer->reclaimer_.joinable());
@@ -699,8 +700,8 @@ TEST_F(CacheReclaimerTest, TestDoubleStops) {
 }
 
 TEST_F(CacheReclaimerTest, TestWorkerConfigValues) {
-    cache_reclaimer_ =
-        std::make_unique<CacheReclaimer>(1000, 100, 100, 100, 16, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    cache_reclaimer_ = std::make_unique<CacheReclaimer>(
+        1000, 100, 100, 100, 16, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 
     {
         // default values

--- a/kv_cache_manager/manager/test/write_location_manager_test.cc
+++ b/kv_cache_manager/manager/test/write_location_manager_test.cc
@@ -201,4 +201,52 @@ TEST_F(WriteLocationManagerTest, DoCleanupWithExpiredSessionsTest) {
     ASSERT_EQ(0, manager_.ExpireSize());
 }
 
+TEST_F(WriteLocationManagerTest, HasLocationIdBasicTest) {
+    // empty manager has no location ids
+    ASSERT_FALSE(manager_.HasLocationId("id1"));
+
+    manager_.Put("session_1", {1, 2, 3}, {"id1", "id2", "id3"}, 1000, [](WriteLocationInfoPtr) {});
+    ASSERT_TRUE(manager_.HasLocationId("id1"));
+    ASSERT_TRUE(manager_.HasLocationId("id2"));
+    ASSERT_TRUE(manager_.HasLocationId("id3"));
+    ASSERT_FALSE(manager_.HasLocationId("id4"));
+
+    // after GetAndDelete, location ids are removed from the index
+    WriteLocationManager::WriteLocationInfo info;
+    ASSERT_TRUE(manager_.GetAndDelete("session_1", info));
+    ASSERT_FALSE(manager_.HasLocationId("id1"));
+    ASSERT_FALSE(manager_.HasLocationId("id2"));
+    ASSERT_FALSE(manager_.HasLocationId("id3"));
+}
+
+TEST_F(WriteLocationManagerTest, HasLocationIdSharedAcrossSessionsTest) {
+    // two sessions share the same location_id "shared"
+    manager_.Put("session_1", {1}, {"shared", "only1"}, 1000, [](WriteLocationInfoPtr) {});
+    manager_.Put("session_2", {2}, {"shared", "only2"}, 1000, [](WriteLocationInfoPtr) {});
+
+    ASSERT_TRUE(manager_.HasLocationId("shared"));
+    ASSERT_TRUE(manager_.HasLocationId("only1"));
+    ASSERT_TRUE(manager_.HasLocationId("only2"));
+
+    // remove session_1: "shared" still present via session_2
+    WriteLocationManager::WriteLocationInfo info;
+    ASSERT_TRUE(manager_.GetAndDelete("session_1", info));
+    ASSERT_TRUE(manager_.HasLocationId("shared"));
+    ASSERT_FALSE(manager_.HasLocationId("only1"));
+    ASSERT_TRUE(manager_.HasLocationId("only2"));
+
+    // remove session_2: "shared" now gone
+    ASSERT_TRUE(manager_.GetAndDelete("session_2", info));
+    ASSERT_FALSE(manager_.HasLocationId("shared"));
+    ASSERT_FALSE(manager_.HasLocationId("only2"));
+}
+
+TEST_F(WriteLocationManagerTest, HasLocationIdAfterDoCleanupTest) {
+    manager_.Put("session_1", {1}, {"id1"}, 1000, [](WriteLocationInfoPtr) {});
+    ASSERT_TRUE(manager_.HasLocationId("id1"));
+
+    manager_.DoCleanup();
+    ASSERT_FALSE(manager_.HasLocationId("id1"));
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/write_location_manager.cc
+++ b/kv_cache_manager/manager/write_location_manager.cc
@@ -9,14 +9,14 @@ constexpr int kDefaultExpireLoopSleepTimeUs = 5 * 1000 * 1000; // us
 };
 
 // caller must hold mux_
-void WriteLocationManager::SessionIdMap::AddToLocationIndex(const std::vector<std::string> &location_ids) {
+void WriteLocationManager::SessionIdMap::AddToLocationIndexUnsafe(const std::vector<std::string> &location_ids) {
     for (const auto &id : location_ids) {
         ++location_id_index_[id];
     }
 }
 
 // caller must hold mux_
-void WriteLocationManager::SessionIdMap::RemoveFromLocationIndex(const std::vector<std::string> &location_ids) {
+void WriteLocationManager::SessionIdMap::RemoveFromLocationIndexUnsafe(const std::vector<std::string> &location_ids) {
     for (const auto &id : location_ids) {
         if (auto it = location_id_index_.find(id); it != location_id_index_.end() && --it->second == 0) {
             location_id_index_.erase(it);
@@ -39,7 +39,7 @@ int64_t WriteLocationManager::SessionIdMap::DropByExpirePoint(int64_t cur_point)
     {
         std::unique_lock lock(mux_);
         for (auto it = unit_map_.begin(); (it != unit_map_.end()) && (it->first <= cur_point);) {
-            RemoveFromLocationIndex(it->second->write_location_info.location_ids);
+            RemoveFromLocationIndexUnsafe(it->second->write_location_info.location_ids);
             session_id_map_impl_.erase(it->second->write_session_id);
             prepare_to_expire_units.push_back(it->second);
             it = unit_map_.erase(it);
@@ -87,7 +87,7 @@ void WriteLocationManager::SessionIdMap::Put(ExpireUnitPtr unit) {
     while (unit_map_.find(unit->expire_point) != unit_map_.end()) {
         unit->expire_point++;
     }
-    AddToLocationIndex(unit->write_location_info.location_ids);
+    AddToLocationIndexUnsafe(unit->write_location_info.location_ids);
     unit_map_[unit->expire_point] = unit;
     session_id_map_impl_[unit->write_session_id] = unit->expire_point;
 }
@@ -101,7 +101,7 @@ bool WriteLocationManager::SessionIdMap::GetAndDelete(const std::string &write_s
     }
     auto it_u = unit_map_.find(it_s->second);
     assert(it_u != unit_map_.end());
-    RemoveFromLocationIndex(it_u->second->write_location_info.location_ids);
+    RemoveFromLocationIndexUnsafe(it_u->second->write_location_info.location_ids);
     location_info = std::move(it_u->second->write_location_info);
     unit_map_.erase(it_u);
     session_id_map_impl_.erase(it_s);

--- a/kv_cache_manager/manager/write_location_manager.cc
+++ b/kv_cache_manager/manager/write_location_manager.cc
@@ -1,7 +1,5 @@
 #include "kv_cache_manager/manager/write_location_manager.h"
 
-#include <algorithm>
-
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 namespace kv_cache_manager {
@@ -9,6 +7,22 @@ namespace kv_cache_manager {
 namespace {
 constexpr int kDefaultExpireLoopSleepTimeUs = 5 * 1000 * 1000; // us
 };
+
+// caller must hold mux_
+void WriteLocationManager::SessionIdMap::AddToLocationIndex(const std::vector<std::string> &location_ids) {
+    for (const auto &id : location_ids) {
+        ++location_id_index_[id];
+    }
+}
+
+// caller must hold mux_
+void WriteLocationManager::SessionIdMap::RemoveFromLocationIndex(const std::vector<std::string> &location_ids) {
+    for (const auto &id : location_ids) {
+        if (auto it = location_id_index_.find(id); it != location_id_index_.end() && --it->second == 0) {
+            location_id_index_.erase(it);
+        }
+    }
+}
 
 size_t WriteLocationManager::SessionIdMap::Size() const {
     std::unique_lock lock(mux_);
@@ -25,6 +39,7 @@ int64_t WriteLocationManager::SessionIdMap::DropByExpirePoint(int64_t cur_point)
     {
         std::unique_lock lock(mux_);
         for (auto it = unit_map_.begin(); (it != unit_map_.end()) && (it->first <= cur_point);) {
+            RemoveFromLocationIndex(it->second->write_location_info.location_ids);
             session_id_map_impl_.erase(it->second->write_session_id);
             prepare_to_expire_units.push_back(it->second);
             it = unit_map_.erase(it);
@@ -57,6 +72,7 @@ void WriteLocationManager::SessionIdMap::DropAll() {
             prepare_to_expire_units.push_back(it->second);
             it = unit_map_.erase(it);
         }
+        location_id_index_.clear();
     }
     for (auto &unit : prepare_to_expire_units) {
         KVCM_LOG_DEBUG("Expiring write_session [%s]", unit->write_session_id.c_str());
@@ -71,6 +87,7 @@ void WriteLocationManager::SessionIdMap::Put(ExpireUnitPtr unit) {
     while (unit_map_.find(unit->expire_point) != unit_map_.end()) {
         unit->expire_point++;
     }
+    AddToLocationIndex(unit->write_location_info.location_ids);
     unit_map_[unit->expire_point] = unit;
     session_id_map_impl_[unit->write_session_id] = unit->expire_point;
 }
@@ -84,6 +101,7 @@ bool WriteLocationManager::SessionIdMap::GetAndDelete(const std::string &write_s
     }
     auto it_u = unit_map_.find(it_s->second);
     assert(it_u != unit_map_.end());
+    RemoveFromLocationIndex(it_u->second->write_location_info.location_ids);
     location_info = std::move(it_u->second->write_location_info);
     unit_map_.erase(it_u);
     session_id_map_impl_.erase(it_s);
@@ -180,13 +198,7 @@ bool WriteLocationManager::GetAndDelete(const std::string &write_session_id, Wri
 
 bool WriteLocationManager::SessionIdMap::HasLocationId(const std::string &location_id) const {
     std::unique_lock lock(mux_);
-    for (const auto &[_, unit] : unit_map_) {
-        const auto &ids = unit->write_location_info.location_ids;
-        if (std::find(ids.begin(), ids.end(), location_id) != ids.end()) {
-            return true;
-        }
-    }
-    return false;
+    return location_id_index_.find(location_id) != location_id_index_.end();
 }
 
 bool WriteLocationManager::HasLocationId(const std::string &location_id) const {

--- a/kv_cache_manager/manager/write_location_manager.cc
+++ b/kv_cache_manager/manager/write_location_manager.cc
@@ -1,5 +1,7 @@
 #include "kv_cache_manager/manager/write_location_manager.h"
 
+#include <algorithm>
+
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 namespace kv_cache_manager {
@@ -174,6 +176,21 @@ void WriteLocationManager::Put(const std::string &write_session_id,
 
 bool WriteLocationManager::GetAndDelete(const std::string &write_session_id, WriteLocationInfo &location_info) {
     return session_id_map_.GetAndDelete(write_session_id, location_info);
+}
+
+bool WriteLocationManager::SessionIdMap::HasLocationId(const std::string &location_id) const {
+    std::unique_lock lock(mux_);
+    for (const auto &[_, unit] : unit_map_) {
+        const auto &ids = unit->write_location_info.location_ids;
+        if (std::find(ids.begin(), ids.end(), location_id) != ids.end()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool WriteLocationManager::HasLocationId(const std::string &location_id) const {
+    return session_id_map_.HasLocationId(location_id);
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/write_location_manager.h
+++ b/kv_cache_manager/manager/write_location_manager.h
@@ -32,6 +32,7 @@ public:
              int64_t write_timeout_seconds,
              CallBack callback);
     bool GetAndDelete(const std::string &write_session_id, WriteLocationInfo &location_info);
+    bool HasLocationId(const std::string &location_id) const;
     size_t ExpireSize() const { return session_id_map_.Size(); }
 
 private:
@@ -53,6 +54,7 @@ private:
         void DropAll();
         void Put(ExpireUnitPtr unit);
         bool GetAndDelete(const std::string &write_session_id, WriteLocationInfo &location_info);
+        bool HasLocationId(const std::string &location_id) const;
 
     private:
         mutable std::mutex mux_;

--- a/kv_cache_manager/manager/write_location_manager.h
+++ b/kv_cache_manager/manager/write_location_manager.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <memory>
@@ -57,9 +58,16 @@ private:
         bool HasLocationId(const std::string &location_id) const;
 
     private:
+        void AddToLocationIndex(const std::vector<std::string> &location_ids);
+        void RemoveFromLocationIndex(const std::vector<std::string> &location_ids);
+
         mutable std::mutex mux_;
         std::unordered_map<std::string, int64_t> session_id_map_impl_;
         std::map<int64_t, ExpireUnitPtr> unit_map_;
+
+        // inverted index to enable O(1) HasLocationId lookups:
+        // location_id -> refcount (number of sessions referencing it)
+        std::unordered_map<std::string, std::size_t> location_id_index_;
     };
 
     SessionIdMap session_id_map_;

--- a/kv_cache_manager/manager/write_location_manager.h
+++ b/kv_cache_manager/manager/write_location_manager.h
@@ -58,8 +58,8 @@ private:
         bool HasLocationId(const std::string &location_id) const;
 
     private:
-        void AddToLocationIndex(const std::vector<std::string> &location_ids);
-        void RemoveFromLocationIndex(const std::vector<std::string> &location_ids);
+        void AddToLocationIndexUnsafe(const std::vector<std::string> &location_ids);
+        void RemoveFromLocationIndexUnsafe(const std::vector<std::string> &location_ids);
 
         mutable std::mutex mux_;
         std::unordered_map<std::string, int64_t> session_id_map_impl_;


### PR DESCRIPTION
* [manager] evict `CLS_WRITING` location not being tracked

* [test] validate reclaimer behavior with leaked `CLS_WRITING` location

  Validate `CacheReclaimer` behavior during events like unexpected
  server restart.

  The in-memory only write session ID tracker would be gone after a
  system restart, and the follow-up `FinishWriteCache()` call taken on
  those lost write session IDs could not be processed.  The location
  data do still exist, however, whose status stays at `CLS_WRITING`
  forever.

  The current reclaiming policy does not allow location with status
  being `CLS_WRITING` ever be evicted, which leaves a hole for data
  leakage.