### PR TITLE
[meta] lru cache support inner last access time field

### DIFF
--- a/kv_cache_manager/common/cache/advanced_cache.h
+++ b/kv_cache_manager/common/cache/advanced_cache.h
@@ -415,12 +415,22 @@ public: // functions
             void(const std::string_view &key, ObjectPtr obj, size_t charge, const CacheItemHelper *helper)> &callback,
         const ApplyToAllEntriesOptions &opts) = 0;
 
+    // Callback invoked (while holding the shard mutex) whenever the LRU tail
+    // of a shard changes. Parameters: (shard_id, tail_value_ptr).
+    // tail_value_ptr is nullptr when the shard becomes empty.
+    using TailChangeCallback = std::function<void(uint32_t shard_id, ObjectPtr tail_value)>;
+
+    // Register a callback that is invoked whenever the LRU tail of any shard
+    // changes. The callback is called inside the shard lock, so it must be
+    // very lightweight (e.g. a single atomic store).
+    // Default implementation is a no-op (not supported).
+    virtual void SetTailChangeCallback(TailChangeCallback /*callback*/) {}
+
     // Returns up to `count` oldest (least recently used) keys from the
     // specified shard. Returns the number of keys actually collected.
     // Default implementation returns 0 (not supported).
-    virtual size_t GetOldestKeysInShard(uint32_t /*shard_id*/,
-                                        size_t /*count*/,
-                                        std::vector<std::string> & /*out_keys*/) {
+    virtual size_t
+    GetOldestKeysInShard(uint32_t /*shard_id*/, size_t /*count*/, std::vector<std::string> & /*out_keys*/) {
         return 0;
     }
 
@@ -431,9 +441,9 @@ public: // functions
     // Default implementation is a no-op (not supported).
     virtual void ApplyToSingleShard(
         uint32_t /*shard_id*/,
-        const std::function<
-            void(const std::string_view &key, ObjectPtr obj, size_t charge, const CacheItemHelper *helper)>
-            & /*callback*/) {}
+        const std::function<void(
+            const std::string_view &key, ObjectPtr obj, size_t charge, const CacheItemHelper *helper)> & /*callback*/) {
+    }
 
     // Insert a mapping from key->object only if the key does not already exist.
     // Returns EC_OK on successful insertion, EC_EXIST if the key is already
@@ -680,8 +690,8 @@ public:
     void ApplyToSingleShard(
         uint32_t shard_id,
         const std::function<
-            void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)>
-            &callback) override {
+            void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)> &callback)
+        override {
         target_->ApplyToSingleShard(shard_id, callback);
     }
 

--- a/kv_cache_manager/common/cache/lru_cache.cc
+++ b/kv_cache_manager/common/cache/lru_cache.cc
@@ -87,7 +87,7 @@ void LRUHandleTable::Resize() {
 
     uint32_t old_length = uint32_t{1} << length_bits_;
     int new_length_bits = length_bits_ + 1;
-    std::unique_ptr<LRUHandle *[]> new_list{new LRUHandle *[size_t{1} << new_length_bits] {}};
+    std::unique_ptr<LRUHandle *[]> new_list { new LRUHandle *[size_t{1} << new_length_bits] {} };
     [[maybe_unused]] uint32_t count = 0;
     for (uint32_t i = 0; i < old_length; i++) {
         LRUHandle *h = list_[i];
@@ -225,6 +225,7 @@ double LRUCacheShard::GetLowPriPoolRatio() {
 void LRUCacheShard::LRU_Remove(LRUHandle *e) {
     assert(e->next != nullptr);
     assert(e->prev != nullptr);
+    bool was_tail = (lru_.next == e);
     if (lru_low_pri_ == e) {
         lru_low_pri_ = e->prev;
     }
@@ -244,11 +245,15 @@ void LRUCacheShard::LRU_Remove(LRUHandle *e) {
         assert(low_pri_pool_usage_ >= e->total_charge);
         low_pri_pool_usage_ -= e->total_charge;
     }
+    if (was_tail) {
+        NotifyTailChange();
+    }
 }
 
 void LRUCacheShard::LRU_Insert(LRUHandle *e) {
     assert(e->next == nullptr);
     assert(e->prev == nullptr);
+    LRUHandle *old_tail = lru_.next;
     if (high_pri_pool_ratio_ > 0 && (e->IsHighPri() || e->HasHit())) {
         // Inset "e" to head of LRU list.
         e->next = &lru_;
@@ -285,6 +290,9 @@ void LRUCacheShard::LRU_Insert(LRUHandle *e) {
         lru_bottom_pri_ = e;
     }
     lru_usage_ += e->total_charge;
+    if (lru_.next != old_tail) {
+        NotifyTailChange();
+    }
 }
 
 void LRUCacheShard::MaintainPoolSize() {
@@ -358,8 +366,8 @@ void LRUCacheShard::SetStrictCapacityLimit(bool strict_capacity_limit) {
     strict_capacity_limit_ = strict_capacity_limit;
 }
 
-ErrorCode LRUCacheShard::DoInsertItemUnsafe(LRUHandle *e, LRUHandle **handle,
-                                      autovector<LRUHandle *> *last_reference_list) {
+ErrorCode
+LRUCacheShard::DoInsertItemUnsafe(LRUHandle *e, LRUHandle **handle, autovector<LRUHandle *> *last_reference_list) {
     // Free the space following strict LRU policy until enough space
     // is freed or the lru list is empty.
     EvictFromLRU(e->total_charge, last_reference_list);
@@ -679,6 +687,28 @@ size_t LRUCacheShard::GetOldestKeys(size_t count, std::vector<std::string> &out_
     return collected;
 }
 
+void LRUCacheShard::SetTailChangeCallback(uint32_t shard_id, const Cache::TailChangeCallback &callback) {
+    std::lock_guard<std::mutex> l(mutex_);
+    shard_id_ = shard_id;
+    tail_change_callback_ = callback;
+    // Notify immediately with current tail state so the caller gets the
+    // initial value.
+    NotifyTailChange();
+}
+
+void LRUCacheShard::NotifyTailChange() {
+    if (!tail_change_callback_) {
+        return;
+    }
+    LRUHandle *tail = lru_.next;
+    if (tail == &lru_) {
+        // LRU list is empty.
+        tail_change_callback_(shard_id_, nullptr);
+    } else {
+        tail_change_callback_(shard_id_, tail->value);
+    }
+}
+
 void LRUCacheShard::AppendPrintableOptions(std::string &str) const {
     const int kBufferSize = 200;
     char buffer[kBufferSize];
@@ -739,14 +769,19 @@ size_t LRUCache::TEST_GetLRUSize() {
 
 double LRUCache::GetHighPriPoolRatio() { return GetShard(0).GetHighPriPoolRatio(); }
 
-size_t LRUCache::GetOldestKeysInShard(uint32_t shard_id,
-                                       size_t count,
-                                       std::vector<std::string> &out_keys) {
+size_t LRUCache::GetOldestKeysInShard(uint32_t shard_id, size_t count, std::vector<std::string> &out_keys) {
     uint32_t num_shards = GetNumShards();
     if (shard_id >= num_shards || count == 0) {
         return 0;
     }
     return GetShard(shard_id).GetOldestKeys(count, out_keys);
+}
+
+void LRUCache::SetTailChangeCallback(TailChangeCallback callback) {
+    uint32_t num_shards = GetNumShards();
+    for (uint32_t i = 0; i < num_shards; ++i) {
+        GetShard(i).SetTailChangeCallback(i, callback);
+    }
 }
 
 } // namespace lru_cache

--- a/kv_cache_manager/common/cache/lru_cache.h
+++ b/kv_cache_manager/common/cache/lru_cache.h
@@ -367,6 +367,10 @@ public: // other function definitions
     // Returns the number of keys actually collected.
     size_t GetOldestKeys(size_t count, std::vector<std::string> &out_keys);
 
+    // Set the shard id and tail-change callback for this shard.
+    // The callback is invoked inside the shard mutex whenever the LRU tail changes.
+    void SetTailChangeCallback(uint32_t shard_id, const Cache::TailChangeCallback &callback);
+
 private:
     friend class LRUCache;
     // Insert an item into the hash table and, if handle is null, insert into
@@ -468,6 +472,14 @@ private:
 
     // A reference to Cache::eviction_callback_
     const Cache::EvictionCallback &eviction_callback_;
+
+    // Tail-change notification support.
+    uint32_t shard_id_{0};
+    Cache::TailChangeCallback tail_change_callback_;
+
+    // Must be called while holding mutex_. Invokes tail_change_callback_ with
+    // the current tail value (nullptr if the LRU list is empty).
+    void NotifyTailChange();
 };
 
 class LRUCache
@@ -494,9 +506,10 @@ public:
     double GetHighPriPoolRatio();
 
     // Returns up to `count` oldest keys from the specified shard.
-    size_t GetOldestKeysInShard(uint32_t shard_id,
-                                size_t count,
-                                std::vector<std::string> &out_keys) override;
+    size_t GetOldestKeysInShard(uint32_t shard_id, size_t count, std::vector<std::string> &out_keys) override;
+
+    // Register a callback invoked whenever the LRU tail of any shard changes.
+    void SetTailChangeCallback(TailChangeCallback callback) override;
 };
 
 } // namespace lru_cache

--- a/kv_cache_manager/common/redis_client.cc
+++ b/kv_cache_manager/common/redis_client.cc
@@ -473,9 +473,19 @@ std::vector<ErrorCode> RedisClient::Get(const std::vector<std::string> &keys,
                 hasError = true;
                 break;
             }
-            out_field_map.emplace(field_name, std::move(field_value));
+            // Skip nil values: treat them as non-existent fields
+            if (!field_value.empty()) {
+                out_field_map.emplace(field_name, std::move(field_value));
+            }
         }
-        ec_per_key.emplace_back(hasError ? EC_ERROR : EC_OK);
+        if (hasError) {
+            ec_per_key.emplace_back(EC_ERROR);
+        } else if (out_field_map.empty()) {
+            // All fields are nil: key does not exist or has no matching fields
+            ec_per_key.emplace_back(EC_NOENT);
+        } else {
+            ec_per_key.emplace_back(EC_OK);
+        }
     }
     return ec_per_key;
 }

--- a/kv_cache_manager/common/test/redis_client_real_service_test.cc
+++ b/kv_cache_manager/common/test/redis_client_real_service_test.cc
@@ -144,13 +144,10 @@ TEST_F(RedisClientRealServiceTest, TestNotExistKey) {
     // get
     std::vector<std::string> all_keys{key1, key2, key3, key4};
     std::vector<std::map<std::string, std::string>> expected_field_maps = field_maps;
-    expected_field_maps[0]["f3"] = "";
-    expected_field_maps[1]["f3"] = "";
-    expected_field_maps.emplace_back(
-        std::map<std::string, std::string>{{"f1", ""}, {"f2", ""}, {"f3", ""}}); // not exist
-    expected_field_maps.emplace_back(
-        std::map<std::string, std::string>{{"f1", ""}, {"f2", ""}, {"f3", ""}}); // not exist
-    std::vector<ErrorCode> expected_ec_per_key = {EC_OK, EC_OK, EC_OK, EC_OK};
+    // f3 does not exist for key1 and key2, so it is skipped
+    expected_field_maps.emplace_back(std::map<std::string, std::string>{}); // key3 not exist
+    expected_field_maps.emplace_back(std::map<std::string, std::string>{}); // key4 not exist
+    std::vector<ErrorCode> expected_ec_per_key = {EC_OK, EC_OK, EC_NOENT, EC_NOENT};
     std::vector<std::map<std::string, std::string>> out_field_maps;
     ec_per_key = redis_client_->Get(all_keys, /*field_names*/ {"f1", "f2", "f3"}, out_field_maps);
     ASSERT_EQ(expected_ec_per_key, ec_per_key);

--- a/kv_cache_manager/common/test/redis_client_test.cc
+++ b/kv_cache_manager/common/test/redis_client_test.cc
@@ -338,9 +338,8 @@ TEST_F(RedisClientTest, TestGet) {
 
         std::vector<std::string> keys{"key1", "key2"};
         std::vector<std::map<std::string, std::string>> field_maps;
-        std::vector<std::map<std::string, std::string>> expected_field_maps{{{"f1", ""}, {"f2", ""}},
-                                                                            {{"f1", ""}, {"f2", "v2-2-0"}}};
-        std::vector<ErrorCode> expected_ec_per_key{EC_OK, EC_OK};
+        std::vector<std::map<std::string, std::string>> expected_field_maps{{}, {{"f2", "v2-2-0"}}};
+        std::vector<ErrorCode> expected_ec_per_key{EC_NOENT, EC_OK};
         auto ec_per_key = redis_client_->Get(keys, /*field_names*/ {"f1", "f2"}, field_maps);
         ASSERT_EQ(expected_ec_per_key, ec_per_key);
         ASSERT_EQ(expected_field_maps, field_maps);
@@ -357,9 +356,8 @@ TEST_F(RedisClientTest, TestGet) {
 
         std::vector<std::string> keys{"key1", "key2"};
         std::vector<std::map<std::string, std::string>> field_maps;
-        std::vector<std::map<std::string, std::string>> expected_field_maps{{{"f1", ""}, {"f2", ""}},
-                                                                            {{"f1", ""}, {"f2", ""}}};
-        std::vector<ErrorCode> expected_ec_per_key{EC_OK, EC_OK};
+        std::vector<std::map<std::string, std::string>> expected_field_maps{{}, {}};
+        std::vector<ErrorCode> expected_ec_per_key{EC_NOENT, EC_NOENT};
         auto ec_per_key = redis_client_->Get(keys, /*field_names*/ {"f1", "f2"}, field_maps);
         ASSERT_EQ(expected_ec_per_key, ec_per_key);
         ASSERT_EQ(expected_field_maps, field_maps);

--- a/kv_cache_manager/meta/meta_cached_backend.cc
+++ b/kv_cache_manager/meta/meta_cached_backend.cc
@@ -305,15 +305,6 @@ std::vector<ErrorCode> MetaCachedBackend::Upsert(const KeyTypeVec &keys, const F
     return local_backend_->Upsert(keys, field_maps, persistent_results);
 }
 
-std::vector<ErrorCode> MetaCachedBackend::IncrFields(const KeyTypeVec &keys,
-                                                     const std::map<std::string, int64_t> &field_amounts) noexcept {
-    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
-        EnsureKeyInLocal(keys);
-    }
-    std::vector<ErrorCode> persistent_results = persistent_backend_->IncrFields(keys, field_amounts);
-    return local_backend_->IncrFields(keys, field_amounts, persistent_results);
-}
-
 std::vector<ErrorCode> MetaCachedBackend::Delete(const KeyTypeVec &keys) noexcept {
     std::vector<ErrorCode> persistent_results = persistent_backend_->Delete(keys);
 
@@ -451,16 +442,7 @@ ErrorCode MetaCachedBackend::SampleReclaimKeys(const int64_t count, std::vector<
 }
 
 ErrorCode MetaCachedBackend::PutMetaData(const FieldMap &field_maps) noexcept {
-    ErrorCode persistent_ec = persistent_backend_->PutMetaData(field_maps);
-    if (persistent_ec != EC_OK) {
-        return persistent_ec;
-    }
-    ErrorCode cache_ec = local_backend_->PutMetaData(field_maps);
-    if (cache_ec != EC_OK) {
-        KVCM_LOG_ERROR("meta cached backend: cache PutMetaData failed ec[%d], persistent succeeded", cache_ec);
-        return cache_ec;
-    }
-    return EC_OK;
+    return persistent_backend_->PutMetaData(field_maps);
 }
 
 ErrorCode MetaCachedBackend::GetMetaData(FieldMap &field_maps) noexcept {

--- a/kv_cache_manager/meta/meta_cached_backend.h
+++ b/kv_cache_manager/meta/meta_cached_backend.h
@@ -38,8 +38,6 @@ public:
     std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
-                                      const std::map<std::string, int64_t> &field_amounts) noexcept override;
     std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
 
     // read

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -16,6 +16,7 @@
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/standard_uri.h"
 #include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
 
@@ -161,7 +162,9 @@ std::vector<ErrorCode> MetaDummyBackend::Put(const KeyTypeVec &keys, const Field
 
 ErrorCode MetaDummyBackend::PutForOneKey(const KeyType &key, const FieldMap &field_map) {
     std::lock_guard<std::mutex> guard(mutex_);
-    table_.Upsert(key, field_map);
+    FieldMap enriched_map = field_map;
+    enriched_map[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+    table_.Upsert(key, std::move(enriched_map));
     return PersistToPath();
 }
 
@@ -188,6 +191,7 @@ ErrorCode MetaDummyBackend::UpdateFieldsForOneKey(const KeyType &key, const Fiel
         for (const auto &[field_name, field_value] : field_map) {
             existing_map[field_name] = field_value;
         }
+        existing_map[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
     });
     if (!found) {
         KVCM_LOG_WARN("update fields failed due to key cannot be found, key: [%" PRIi64 "]", key);
@@ -214,69 +218,17 @@ std::vector<ErrorCode> MetaDummyBackend::Upsert(const KeyTypeVec &keys, const Fi
 
 ErrorCode MetaDummyBackend::UpsertForOneKey(const KeyType &key, const FieldMap &field_map) {
     std::lock_guard<std::mutex> guard(mutex_);
+    const std::string current_time_str = std::to_string(TimestampUtil::GetCurrentTimeUs());
     const bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
         for (const auto &[field_name, field_value] : field_map) {
             existing_map[field_name] = field_value;
         }
+        existing_map[PROPERTY_LRU_TIME] = current_time_str;
     });
     if (!found) {
-        table_.Upsert(key, field_map);
-    }
-    return PersistToPath();
-}
-
-std::vector<ErrorCode> MetaDummyBackend::IncrFields(const KeyTypeVec &keys,
-                                                    const std::map<std::string, std::int64_t> &field_amounts) noexcept {
-    std::vector<ErrorCode> ec_vec;
-    for (const KeyType &key : keys) {
-        ec_vec.emplace_back(IncrFieldsForOneKey(key, field_amounts));
-        if (ec_vec.back() != ErrorCode::EC_OK) {
-            KVCM_LOG_WARN("incr fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          key,
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-    }
-    return ec_vec;
-}
-
-ErrorCode MetaDummyBackend::IncrFieldsForOneKey(const KeyType &key,
-                                                const std::map<std::string, std::int64_t> &field_amounts) {
-    std::lock_guard<std::mutex> guard(mutex_);
-    ErrorCode ec = ErrorCode::EC_OK;
-    const bool found = table_.FindAndModify(key, [&](FieldMap &field_map) {
-        std::map<std::string, std::string> new_field_map;
-        for (const auto &[field_name, amount] : field_amounts) {
-            const auto field_iter = field_map.find(field_name);
-            if (field_iter == field_map.end()) {
-                KVCM_LOG_ERROR("incr fields failed due to field cannot be found, field: [%s], key: [%" PRIi64 "]",
-                               field_name.c_str(),
-                               key);
-                ec = ErrorCode::EC_BADARGS;
-                return;
-            }
-            const auto &old_field_value = field_iter->second;
-            std::int64_t old_field_value_num = 0;
-            if (!StringUtil::StrToInt64(old_field_value.c_str(), old_field_value_num)) {
-                KVCM_LOG_ERROR("incr fields failed due to value cannot be interpreted to int64_t, "
-                               "field: [%s], value: [%s], key: [%" PRIi64 "]",
-                               field_name.c_str(),
-                               old_field_value.c_str(),
-                               key);
-                ec = ErrorCode::EC_BADARGS;
-                return;
-            }
-            new_field_map[field_name] = std::to_string(old_field_value_num + amount);
-        }
-        for (const auto &[field_name, new_field_value] : new_field_map) {
-            field_map[field_name] = new_field_value;
-        }
-    });
-    if (!found) {
-        KVCM_LOG_WARN("incr fields failed due to key cannot be found, key: [%" PRIi64 "]", key);
-        return ErrorCode::EC_NOENT;
-    }
-    if (ec != ErrorCode::EC_OK) {
-        return ec;
+        FieldMap enriched_map = field_map;
+        enriched_map[PROPERTY_LRU_TIME] = current_time_str;
+        table_.Upsert(key, std::move(enriched_map));
     }
     return PersistToPath();
 }
@@ -321,19 +273,23 @@ std::vector<ErrorCode> MetaDummyBackend::Get(const KeyTypeVec &keys,
 
 ErrorCode MetaDummyBackend::GetForOneKey(const KeyType &key,
                                          const std::vector<std::string> &field_names,
-                                         FieldMap &out_field_map) const {
+                                         FieldMap &out_field_map) {
     out_field_map.clear();
     const bool found = table_.FindAndApply(key, [&](const FieldMap &field_table) {
         for (const auto &field_name : field_names) {
             const auto field_iter = field_table.find(field_name);
-            out_field_map[field_name] = (field_iter == field_table.end() ? "" : field_iter->second);
+            if (field_iter != field_table.end()) {
+                out_field_map[field_name] = field_iter->second;
+            }
         }
     });
     if (!found) {
-        for (const auto &field_name : field_names) {
-            out_field_map[field_name] = "";
-        }
+        return ErrorCode::EC_NOENT;
     }
+    // Update last access time after reading the stored value
+    table_.FindAndModify(key, [](FieldMap &field_table) {
+        field_table[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+    });
     return ErrorCode::EC_OK;
 }
 
@@ -351,12 +307,19 @@ std::vector<ErrorCode> MetaDummyBackend::GetAllFields(const KeyTypeVec &keys, Fi
     return ec_vec;
 }
 
-ErrorCode MetaDummyBackend::GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) const {
+ErrorCode MetaDummyBackend::GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) {
     out_field_map.clear();
     if (!table_.Get(key, out_field_map)) {
         return ErrorCode::EC_NOENT;
     }
-    return out_field_map.empty() ? ErrorCode::EC_NOENT : ErrorCode::EC_OK;
+    if (out_field_map.empty()) {
+        return ErrorCode::EC_NOENT;
+    }
+    // Update last access time in the stored map after copying the old value
+    table_.FindAndModify(key, [](FieldMap &field_table) {
+        field_table[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+    });
+    return ErrorCode::EC_OK;
 }
 
 std::vector<ErrorCode> MetaDummyBackend::Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept {
@@ -376,8 +339,13 @@ std::vector<ErrorCode> MetaDummyBackend::Exists(const KeyTypeVec &keys, std::vec
     return ec_vec;
 }
 
-ErrorCode MetaDummyBackend::ExistsForOneKey(const KeyType &key, bool &out_is_exist) const {
+ErrorCode MetaDummyBackend::ExistsForOneKey(const KeyType &key, bool &out_is_exist) {
     out_is_exist = (table_.Count(key) > 0);
+    if (out_is_exist) {
+        table_.FindAndModify(key, [](FieldMap &field_table) {
+            field_table[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+        });
+    }
     return ErrorCode::EC_OK;
 }
 

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -38,8 +38,6 @@ public:
     std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
-                                      const std::map<std::string, std::int64_t> &field_amounts) noexcept override;
     std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
 
     // read
@@ -65,13 +63,11 @@ private:
     ErrorCode PutForOneKey(const KeyType &key, const FieldMap &field_map);
     ErrorCode UpdateFieldsForOneKey(const KeyType &key, const FieldMap &field_map);
     ErrorCode UpsertForOneKey(const KeyType &key, const FieldMap &field_map);
-    ErrorCode IncrFieldsForOneKey(const KeyType &key, const std::map<std::string, std::int64_t> &field_amounts);
     ErrorCode DeleteForOneKey(const KeyType &key);
 
-    ErrorCode
-    GetForOneKey(const KeyType &key, const std::vector<std::string> &field_names, FieldMap &out_field_map) const;
-    ErrorCode GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) const;
-    ErrorCode ExistsForOneKey(const KeyType &key, bool &out_is_exist) const;
+    ErrorCode GetForOneKey(const KeyType &key, const std::vector<std::string> &field_names, FieldMap &out_field_map);
+    ErrorCode GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map);
+    ErrorCode ExistsForOneKey(const KeyType &key, bool &out_is_exist);
 
     std::mutex mutex_;
     ConcurrentHashMap<KeyType, FieldMap> table_; // block data

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -309,11 +309,9 @@ MetaIndexer::Result MetaIndexer::Put(RequestContext *request_context,
     }
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
-    std::string ts_str = std::to_string(TimestampUtil::GetCurrentTimeUs());
     for (int32_t i = 0; i < keys.size(); ++i) {
         PropertyMap &map = properties[i];
         map[PROPERTY_URI] = std::move(uris[i]);
-        map[PROPERTY_LRU_TIME] = ts_str;
     }
 
     BatchMetaData batch_datas;
@@ -350,12 +348,6 @@ MetaIndexer::Update(RequestContext *request_context, const KeyVector &keys, Prop
     }
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
-    std::string ts_str = std::to_string(TimestampUtil::GetCurrentTimeUs());
-    for (int32_t i = 0; i < keys.size(); ++i) {
-        PropertyMap &map = properties[i];
-        map[PROPERTY_LRU_TIME] = ts_str;
-    }
-
     BatchMetaData batch_datas;
     MakeBatches(keys, properties, batch_datas);
     KVCM_METRICS_COLLECTOR_SET_METRICS(
@@ -394,11 +386,9 @@ MetaIndexer::Result MetaIndexer::Update(RequestContext *request_context,
     }
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
-    std::string ts_str = std::to_string(TimestampUtil::GetCurrentTimeUs());
     for (int32_t i = 0; i < keys.size(); ++i) {
         PropertyMap &map = properties[i];
         map[PROPERTY_URI] = std::move(uris[i]);
-        map[PROPERTY_LRU_TIME] = ts_str;
     }
 
     BatchMetaData batch_datas;
@@ -430,7 +420,6 @@ MetaIndexer::Result MetaIndexer::ReadModifyWrite(RequestContext *request_context
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
     const auto &trace_id = request_context->trace_id();
-    std::string ts_str = std::to_string(TimestampUtil::GetCurrentTimeUs());
     BatchMetaData batch_datas;
     PropertyMapVector empty_properties;
     MakeBatches(keys, empty_properties, batch_datas);
@@ -485,7 +474,6 @@ MetaIndexer::Result MetaIndexer::ReadModifyWrite(RequestContext *request_context
                 continue;
             }
             map[PROPERTY_URI] = std::move(uris[j]);
-            map[PROPERTY_LRU_TIME] = ts_str;
             if (get_ec == EC_OK || get_ec == EC_NOENT) {
                 upsert_keys.push_back(keys[idx]);
                 upsert_indexs.push_back(idx);
@@ -709,8 +697,10 @@ MetaIndexer::RandomSample(RequestContext *request_context, const size_t count, K
     return ec;
 }
 
-ErrorCode
-MetaIndexer::SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyVector &out_keys) const noexcept {
+ErrorCode MetaIndexer::SampleReclaimKeys(RequestContext *request_context,
+                                         const int64_t count,
+                                         KeyVector &out_keys) const noexcept {
+    out_keys.clear();
     out_keys.reserve(count);
     auto ec = storage_->SampleReclaimKeys(count, out_keys);
     if (ec != EC_OK) {
@@ -852,7 +842,7 @@ void MetaIndexer::PersistMetaData() noexcept {
         }
         auto ec = storage_->PutMetaData(metadata_map);
         if (ec != EC_OK) {
-            KVCM_LOG_ERROR("meta indexer persist metadata failed, ec[%d]", ec);
+            KVCM_LOG_WARN("meta indexer persist metadata failed, ec[%d]", ec);
         }
         last_persist_metadata_time_ = current_time;
     }

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -1,5 +1,7 @@
 #include "kv_cache_manager/meta/meta_local_backend.h"
 
+#include <algorithm>
+#include <climits>
 #include <random>
 #include <utility>
 
@@ -43,7 +45,7 @@ ErrorCode MetaLocalBackend::Init(const std::string &instance_id,
     }
     if (capacity <= 0 || num_shard_bits < 0 || sample_times_ <= 0) {
         KVCM_LOG_ERROR(
-            "invalid local backend parameters, capacity[%lu] num_shard_bits[%d] sample_times[%ld], storage uri[%s]",
+            "invalid local backend parameters, capacity[%lu] num_shard_bits[%d] sample_times[%zu], storage uri[%s]",
             capacity,
             num_shard_bits,
             sample_times_,
@@ -60,7 +62,25 @@ ErrorCode MetaLocalBackend::Init(const std::string &instance_id,
     cache_item_helper_ = std::make_shared<Cache::CacheItemHelper>();
     cache_item_helper_->del_cb = MetaMemCacheItem::Deleter;
 
-    KVCM_LOG_INFO("local backend init ok, instance[%s] capacity[%lu] num_shard_bits[%d] sample_times[%ld]",
+    // Initialize per-shard oldest access time tracking.
+    size_t num_shards = shard_mask_ + 1;
+    shard_oldest_access_time_ = std::make_unique<std::atomic<int64_t>[]>(num_shards);
+    for (size_t i = 0; i < num_shards; ++i) {
+        shard_oldest_access_time_[i].store(INT64_MAX, std::memory_order_relaxed);
+    }
+    // Register tail-change callback: whenever a shard's LRU tail changes,
+    // read the tail item's last_access_time and store it in the atomic array.
+    cache_->SetTailChangeCallback([this](uint32_t shard_id, Cache::ObjectPtr tail_value) {
+        if (tail_value == nullptr) {
+            shard_oldest_access_time_[shard_id].store(INT64_MAX, std::memory_order_relaxed);
+        } else {
+            auto *item = static_cast<MetaMemCacheItem *>(tail_value);
+            int64_t access_time = item->last_access_time_.load(std::memory_order_relaxed);
+            shard_oldest_access_time_[shard_id].store(access_time, std::memory_order_relaxed);
+        }
+    });
+
+    KVCM_LOG_INFO("local backend init ok, instance[%s] capacity[%lu] num_shard_bits[%d] sample_times[%zu]",
                   instance_id.c_str(),
                   capacity,
                   num_shard_bits,
@@ -77,6 +97,9 @@ ErrorCode MetaLocalBackend::Open() noexcept {
 }
 
 ErrorCode MetaLocalBackend::Close() noexcept {
+    if (cache_) {
+        cache_->SetTailChangeCallback(nullptr);
+    }
     cache_.reset();
     cache_item_helper_.reset();
     return EC_OK;
@@ -88,6 +111,7 @@ ErrorCode MetaLocalBackend::Close() noexcept {
 
 ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, const FieldMap &fields) {
     MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
+    item->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
     size_t charge = item->Size();
     ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge);
     if (ret != EC_OK) {
@@ -98,6 +122,7 @@ ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, const Fi
 
 ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, FieldMap &&fields) {
     MetaMemCacheItem *item = MetaMemCacheItem::Create(std::move(fields));
+    item->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
     size_t charge = item->Size();
     ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge);
     if (ret != EC_OK) {
@@ -108,6 +133,7 @@ ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, FieldMap
 
 ErrorCode MetaLocalBackend::CreateAndInsertIfAbsent(const std::string &key_str, const FieldMap &fields) {
     MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
+    item->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
     size_t charge = item->Size();
     ErrorCode ret = cache_->InsertIfAbsent(key_str, item, cache_item_helper_.get(), charge);
     if (ret != EC_OK && ret != EC_EXIST) {
@@ -122,6 +148,7 @@ bool MetaLocalBackend::LookupFields(const std::string &key_str, FieldMap &out_fi
         return false;
     }
     auto *existing = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
+    existing->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
     out_fields = existing->GetFields();
     cache_->Release(handle);
     return true;
@@ -136,6 +163,7 @@ ErrorCode MetaLocalBackend::UpdateFieldsInPlace(const std::string &key_str, cons
     // item cannot be evicted or freed by another thread.  The FieldMap itself
     // is not involved in any LRU list or hash table operations.
     auto *existing = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
+    existing->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
     for (const auto &[key, value] : updates) {
         existing->GetMutableFields()[key] = value;
     }
@@ -190,6 +218,26 @@ std::vector<ErrorCode> MetaLocalBackend::Put(const KeyTypeVec &keys,
     return results;
 }
 
+std::vector<ErrorCode> MetaLocalBackend::PutIfAbsent(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = CreateAndInsertIfAbsent(std::to_string(keys[i]), field_maps[i]);
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::PutIfAbsent(const KeyTypeVec &keys,
+                                                     const FieldMapVec &field_maps,
+                                                     const std::vector<ErrorCode> &previous_error_codes) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = (previous_error_codes[i] == EC_OK)
+                         ? CreateAndInsertIfAbsent(std::to_string(keys[i]), field_maps[i])
+                         : previous_error_codes[i];
+    }
+    return results;
+}
+
 std::vector<ErrorCode> MetaLocalBackend::UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -226,17 +274,6 @@ std::vector<ErrorCode> MetaLocalBackend::Upsert(const KeyTypeVec &keys,
             (previous_error_codes[i] == EC_OK) ? UpsertForOneKey(keys[i], field_maps[i]) : previous_error_codes[i];
     }
     return results;
-}
-
-std::vector<ErrorCode> MetaLocalBackend::IncrFields(const KeyTypeVec &keys,
-                                                    const std::map<std::string, int64_t> &field_amounts) noexcept {
-    return std::vector<ErrorCode>(keys.size(), EC_UNIMPLEMENTED);
-}
-
-std::vector<ErrorCode> MetaLocalBackend::IncrFields(const KeyTypeVec &keys,
-                                                    const std::map<std::string, int64_t> &field_amounts,
-                                                    const std::vector<ErrorCode> &previous_error_codes) noexcept {
-    return std::vector<ErrorCode>(keys.size(), EC_UNIMPLEMENTED);
 }
 
 std::vector<ErrorCode> MetaLocalBackend::Delete(const KeyTypeVec &keys) noexcept {
@@ -276,9 +313,15 @@ std::vector<ErrorCode> MetaLocalBackend::Get(const KeyTypeVec &keys,
         }
 
         auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
+        int64_t stored_time = item->last_access_time_.load(std::memory_order_relaxed);
+        item->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
         const auto &fields = item->GetFields();
         FieldMap &out_field_map = out_field_maps[i];
         for (const auto &field_name : field_names) {
+            if (field_name == PROPERTY_LRU_TIME) {
+                out_field_map[PROPERTY_LRU_TIME] = std::to_string(stored_time);
+                continue;
+            }
             auto it = fields.find(field_name);
             if (it != fields.end()) {
                 out_field_map[field_name] = it->second;
@@ -305,7 +348,10 @@ std::vector<ErrorCode> MetaLocalBackend::GetAllFields(const KeyTypeVec &keys, Fi
         }
 
         auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
+        int64_t stored_time = item->last_access_time_.load(std::memory_order_relaxed);
+        item->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
         out_field_maps[i] = item->GetFields();
+        out_field_maps[i][PROPERTY_LRU_TIME] = std::to_string(stored_time);
         cache_->Release(handle);
         results[i] = EC_OK;
     }
@@ -324,6 +370,8 @@ std::vector<ErrorCode> MetaLocalBackend::Exists(const KeyTypeVec &keys, std::vec
         out_is_exist_vec[i] = (handle != nullptr);
 
         if (handle) {
+            auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
+            item->last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed);
             cache_->Release(handle);
         }
 
@@ -374,90 +422,80 @@ ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
 }
 
 ErrorCode MetaLocalBackend::RandomSample(const int64_t count, std::vector<KeyType> &out_keys) noexcept {
-    if (!cache_ || count <= 0) {
+    if (!cache_) {
+        KVCM_LOG_ERROR("local backend not inited");
+        return EC_ERROR;
+    }
+    if (count <= 0) {
         return EC_OK;
-    }
-
-    return GetOldestKeysFromRandomShard(static_cast<size_t>(count), out_keys);
-}
-
-ErrorCode MetaLocalBackend::SampleReclaimKeys(const int64_t count, std::vector<KeyType> &out_keys) noexcept {
-    // Validate input parameters
-    if (!cache_ || count <= 0) {
-        return EC_OK;
-    }
-
-    int64_t remaining = count;
-    int64_t batch_size = count / std::min(sample_times_, count);
-    // Loop until we have collected enough keys or no more keys available
-    while (remaining > 0) {
-        // Calculate batch size for this iteration using member variable sample_times
-        batch_size = std::min(batch_size, remaining);
-
-        // Get oldest keys from a random shard
-        int64_t last_size = out_keys.size();
-        ErrorCode ec = GetOldestKeysFromRandomShard(static_cast<size_t>(batch_size), out_keys);
-        if (ec != EC_OK) {
-            return ec;
-        }
-
-        // Add collected keys to output
-        int64_t current_sample_size = out_keys.size() - last_size;
-        remaining -= current_sample_size;
-
-        // If no keys were collected in this iteration, break to avoid infinite loop
-        if (current_sample_size == 0) {
-            break;
-        }
-    }
-
-    return EC_OK;
-}
-
-ErrorCode MetaLocalBackend::PutMetaData(const FieldMap & /*field_maps*/) noexcept { return EC_OK; }
-
-ErrorCode MetaLocalBackend::GetMetaData(FieldMap & /*field_maps*/) noexcept { return EC_NOENT; }
-
-std::vector<ErrorCode> MetaLocalBackend::PutIfAbsent(const KeyTypeVec &keys,
-                                                     const FieldMapVec &field_maps,
-                                                     const std::vector<ErrorCode> &previous_error_codes) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = (previous_error_codes[i] == EC_OK)
-                         ? CreateAndInsertIfAbsent(std::to_string(keys[i]), field_maps[i])
-                         : previous_error_codes[i];
-    }
-    return results;
-}
-
-ErrorCode MetaLocalBackend::GetOldestKeysFromRandomShard(size_t count, std::vector<KeyType> &out_keys) {
-    if (!cache_ || count == 0) {
-        return EC_BADARGS;
     }
 
     static thread_local std::mt19937 rng(std::random_device{}());
     std::uniform_int_distribution<uint32_t> dist(0, shard_mask_);
     uint32_t shard_id = dist(rng);
-
-    std::vector<std::string> string_keys;
-    string_keys.reserve(count);
     uint32_t shard_collect_count = 0;
     size_t key_collect_count = 0;
     while (key_collect_count < count && shard_collect_count <= shard_mask_) {
-        string_keys.clear();
-        cache_->GetOldestKeysInShard(shard_id, count - key_collect_count, string_keys);
-        KeyType parsed_key = 0;
-        for (const auto &key_str : string_keys) {
-            if (StringUtil::StrToInt64(key_str.c_str(), parsed_key)) {
-                out_keys.push_back(parsed_key);
-            }
-        }
-        key_collect_count += string_keys.size();
+        key_collect_count += CollectOldestKeysFromShard(shard_id, count - key_collect_count, out_keys);
         ++shard_collect_count;
         shard_id = (shard_id + 1) & shard_mask_;
     }
 
     return EC_OK;
+}
+
+ErrorCode MetaLocalBackend::SampleReclaimKeys(const int64_t count, std::vector<KeyType> &out_keys) noexcept {
+    out_keys.clear();
+    if (!cache_) {
+        KVCM_LOG_ERROR("local backend not inited");
+        return EC_ERROR;
+    }
+    if (count <= 0) {
+        return EC_OK;
+    }
+
+    size_t num_shards = shard_mask_ + 1;
+    size_t num_rounds = std::min(sample_times_, num_shards);
+    num_rounds = std::min(num_rounds, static_cast<size_t>(count));
+    int64_t per_round_count = (count + num_rounds - 1) / num_rounds;
+    std::vector<std::pair<int64_t, uint32_t>> shard_times;
+    shard_times.reserve(num_shards);
+    for (uint32_t s = 0; s < num_shards; ++s) {
+        int64_t access_time = shard_oldest_access_time_[s].load(std::memory_order_relaxed);
+        if (access_time < INT64_MAX) {
+            shard_times.emplace_back(access_time, s);
+        }
+    }
+    if (shard_times.empty()) {
+        return EC_OK;
+    }
+
+    size_t select_count = std::min(num_rounds, shard_times.size());
+    std::partial_sort(shard_times.begin(), shard_times.begin() + select_count, shard_times.end());
+    int64_t remaining = count;
+    for (size_t i = 0; i < select_count && remaining > 0; ++i) {
+        size_t batch = static_cast<size_t>(std::min(per_round_count, remaining));
+        size_t collected = CollectOldestKeysFromShard(shard_times[i].second, batch, out_keys);
+        remaining -= static_cast<int64_t>(collected);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaLocalBackend::PutMetaData(const FieldMap & /*field_maps*/) noexcept { return EC_UNIMPLEMENTED; }
+
+ErrorCode MetaLocalBackend::GetMetaData(FieldMap & /*field_maps*/) noexcept { return EC_NOENT; }
+
+size_t MetaLocalBackend::CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys) {
+    std::vector<std::string> string_keys;
+    string_keys.reserve(count);
+    cache_->GetOldestKeysInShard(shard_id, count, string_keys);
+    KeyType parsed_key = 0;
+    for (const auto &key_str : string_keys) {
+        if (StringUtil::StrToInt64(key_str.c_str(), parsed_key)) {
+            out_keys.push_back(parsed_key);
+        }
+    }
+    return string_keys.size();
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <random>
@@ -21,6 +22,7 @@ struct MetaMemCacheItem {
     using FieldMap = MetaLocalBaseBackend::FieldMap;
 
     FieldMap fields_;
+    std::atomic<int64_t> last_access_time_{0};
 
     // Estimates total memory footprint including the heap memory owned by
     // FieldMap entries, used as the "charge" for LRU cache eviction accounting.
@@ -49,9 +51,7 @@ struct MetaMemCacheItem {
         return item;
     }
 
-    static void Deleter(void *value, MemoryAllocator * /*allocator*/) {
-        delete static_cast<MetaMemCacheItem *>(value);
-    }
+    static void Deleter(void *value, MemoryAllocator * /*allocator*/) { delete static_cast<MetaMemCacheItem *>(value); }
 };
 
 class MetaLocalBackend : public MetaLocalBaseBackend {
@@ -68,30 +68,26 @@ public:
 
     // write
     std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
+    std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
-                                      const std::map<std::string, int64_t> &field_amounts) noexcept override;
     std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
 
     // Conditional write: only processes keys where previous_error_codes[i] == EC_OK.
     std::vector<ErrorCode> Put(const KeyTypeVec &keys,
                                const FieldMapVec &field_maps,
                                const std::vector<ErrorCode> &previous_error_codes) noexcept override;
+    std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys,
+                                       const FieldMapVec &field_maps,
+                                       const std::vector<ErrorCode> &previous_error_codes) noexcept override;
     std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys,
                                         const FieldMapVec &field_maps,
                                         const std::vector<ErrorCode> &previous_error_codes) noexcept override;
     std::vector<ErrorCode> Upsert(const KeyTypeVec &keys,
                                   const FieldMapVec &field_maps,
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
-    std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
-                                      const std::map<std::string, int64_t> &field_amounts,
-                                      const std::vector<ErrorCode> &previous_error_codes) noexcept override;
     std::vector<ErrorCode> Delete(const KeyTypeVec &keys,
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
-    std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys,
-                                       const FieldMapVec &field_maps,
-                                       const std::vector<ErrorCode> &previous_error_codes) noexcept override;
 
     // read
     std::vector<ErrorCode> Get(const KeyTypeVec &keys,
@@ -110,10 +106,11 @@ public:
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
 
-    // Returns up to `count` oldest keys from a randomly chosen shard.
-    ErrorCode GetOldestKeysFromRandomShard(size_t count, std::vector<KeyType> &out_keys);
-
 private:
+    // Collects up to `count` oldest keys from the given shard, parses them to
+    // KeyType and appends to `out_keys`. Returns the number of keys collected.
+    size_t CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys);
+
     // Per-key write helpers used by both unconditional and conditional write methods.
     ErrorCode UpsertForOneKey(KeyType key, const FieldMap &field_map);
     ErrorCode DeleteForOneKey(KeyType key);
@@ -139,7 +136,12 @@ private:
     std::shared_ptr<Cache::CacheItemHelper> cache_item_helper_;
     std::shared_ptr<Cache> cache_;
     uint32_t shard_mask_ = 0;
-    int64_t sample_times_ = 0;
+    size_t sample_times_ = 0;
+
+    // Per-shard approximate oldest access time, updated via tail-change callback
+    // from the LRU cache. Used by SampleReclaimKeys to select the oldest shards
+    // without acquiring any shard locks.
+    std::unique_ptr<std::atomic<int64_t>[]> shard_oldest_access_time_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_local_base_backend.h
+++ b/kv_cache_manager/meta/meta_local_base_backend.h
@@ -13,30 +13,28 @@ public:
     ~MetaLocalBaseBackend() override = default;
 
     using MetaStorageBackend::Delete;
-    using MetaStorageBackend::IncrFields;
     using MetaStorageBackend::Put;
     using MetaStorageBackend::UpdateFields;
     using MetaStorageBackend::Upsert;
+
+    virtual std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
 
     // Conditional write: only processes keys where previous_error_codes[i] == EC_OK.
     // For skipped keys, the returned error code is copied from previous_error_codes.
     virtual std::vector<ErrorCode> Put(const KeyTypeVec &keys,
                                        const FieldMapVec &field_maps,
                                        const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
+    virtual std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys,
+                                               const FieldMapVec &field_maps,
+                                               const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
     virtual std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys,
                                                 const FieldMapVec &field_maps,
                                                 const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
     virtual std::vector<ErrorCode> Upsert(const KeyTypeVec &keys,
                                           const FieldMapVec &field_maps,
                                           const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-    virtual std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
-                                              const std::map<std::string, int64_t> &field_amounts,
-                                              const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
     virtual std::vector<ErrorCode> Delete(const KeyTypeVec &keys,
                                           const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-    virtual std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys,
-                                               const FieldMapVec &field_maps,
-                                               const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_redis_backend.cc
@@ -160,11 +160,6 @@ std::vector<ErrorCode> MetaRedisBackend::Upsert(const KeyTypeVec &keys, const Fi
     return handle->Upsert(full_keys, field_maps);
 }
 
-std::vector<ErrorCode> MetaRedisBackend::IncrFields(const KeyTypeVec &keys,
-                                                    const std::map<std::string, int64_t> &field_amounts) noexcept {
-    return std::vector<ErrorCode>(keys.size(), EC_UNIMPLEMENTED);
-}
-
 std::vector<ErrorCode> MetaRedisBackend::Delete(const KeyTypeVec &keys) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {

--- a/kv_cache_manager/meta/meta_redis_backend.h
+++ b/kv_cache_manager/meta/meta_redis_backend.h
@@ -33,8 +33,6 @@ public:
     std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
     std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
-                                      const std::map<std::string, int64_t> &field_amounts) noexcept override;
     std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
 
     // read

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -32,8 +32,6 @@ public:
     virtual std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
     virtual std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
     virtual std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
-    virtual std::vector<ErrorCode> IncrFields(const KeyTypeVec &keys,
-                                              const std::map<std::string, int64_t> &field_amounts) noexcept = 0;
     virtual std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept = 0;
 
     // read

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -94,8 +94,8 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
     AssertGet(meta_storage_backend_.get(),
               {1, 2, 3},
               {"f1", "f2"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", ""}, {"f2", ""}}, {{"f1", "v2-1-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}});
+              {ErrorCode::EC_NOENT, ErrorCode::EC_OK, ErrorCode::EC_OK},
+              {{}, {{"f1", "v2-1-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}});
     AssertListKeys(
         meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, ErrorCode::EC_OK, SCAN_BASE_CURSOR, {2, 3});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {2, 3});
@@ -127,7 +127,7 @@ TEST_F(MetaDummyBackendTest, TestPut) {
               {1, 2},
               {"f1", "f2", "f3"},
               {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1-1"}, {"f2", ""}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}, {"f3", ""}}});
+              {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
@@ -151,7 +151,7 @@ TEST_F(MetaDummyBackendTest, TestUpdateFields) {
               {1, 2},
               {"f1", "f2", "f3"},
               {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2-1"}, {"f3", ""}}});
+              {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2-1"}}});
 
     // can not update key that dont exist
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}),
@@ -175,56 +175,12 @@ TEST_F(MetaDummyBackendTest, TestUpsert) {
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
               meta_storage_backend_->Upsert(
                   {1, 2, 3}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2-1"}}, {{"f3", "v3-1"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2, 3},
-              {"f1", "f2", "f3"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}},
-               {{"f1", "v2-1"}, {"f2", "v2-2-1"}, {"f3", ""}},
-               {{"f1", ""}, {"f2", ""}, {"f3", "v3-1"}}});
-
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
-}
-
-TEST_F(MetaDummyBackendTest, TestIncrFields) {
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
-
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put(
-                  {1, 2}, {{{"hit_count", "10"}, {"weight", "100"}}, {{"hit_count", "20"}, {"weight", "200"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"hit_count", "weight"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"hit_count", "10"}, {"weight", "100"}}, {{"hit_count", "20"}, {"weight", "200"}}});
-
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->IncrFields({1, 2}, {{"hit_count", /*amount*/ 2}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"hit_count", "weight"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"hit_count", "12"}, {"weight", "100"}}, {{"hit_count", "22"}, {"weight", "200"}}});
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->IncrFields({1, 2}, {{"weight", /*amount*/ 3}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"hit_count", "weight"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"hit_count", "12"}, {"weight", "103"}}, {{"hit_count", "22"}, {"weight", "203"}}});
-
-    // can not update key that dont exist
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}),
-              meta_storage_backend_->IncrFields({3}, {{"hit_count", /*amount*/ 2}}));
-
-    // can not update field that is not num
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}), meta_storage_backend_->Put({4}, {{{"f1", "v1"}}}));
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_BADARGS}),
-              meta_storage_backend_->IncrFields({4}, {{"f1", /*amount*/ 2}}));
-    // can not update field that is not exist
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_BADARGS}),
-              meta_storage_backend_->IncrFields({4}, {{"f2", /*amount*/ 2}}));
+    AssertGet(
+        meta_storage_backend_.get(),
+        {1, 2, 3},
+        {"f1", "f2", "f3"},
+        {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
+        {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2-1"}}, {{"f3", "v3-1"}}});
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
@@ -267,11 +223,7 @@ TEST_F(MetaDummyBackendTest, TestGet) {
               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}); // all fields
     AssertGet(
         meta_storage_backend_.get(), {1, 2}, {}, {ErrorCode::EC_OK, ErrorCode::EC_OK}, FieldMapVec(2)); // no fields
-    AssertGet(meta_storage_backend_.get(),
-              {3},
-              {"f1", "f2"},
-              {ErrorCode::EC_OK},
-              {{{"f1", ""}, {"f2", ""}}}); // key not exist
+    AssertGet(meta_storage_backend_.get(), {3}, {"f1", "f2"}, {ErrorCode::EC_NOENT}, {{}});             // key not exist
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_indexer_redis_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_redis_test.cc
@@ -79,7 +79,7 @@ TEST_F(MetaIndexerRedisTest, TestRedisSimple) {
     ASSERT_EQ(META_REDIS_BACKEND_TYPE_STR, meta_indexer_->storage_->GetStorageType());
     ASSERT_TRUE(meta_indexer_->cache_);
     ASSERT_EQ(1024, meta_indexer_->cache_->cache_size_);
-    DoSimpleTest(true);
+    DoSimpleTest();
 
     // test redis recover
     ASSERT_EQ(0, meta_indexer_->GetKeyCount());

--- a/kv_cache_manager/meta/test/meta_indexer_test_base.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test_base.cc
@@ -207,7 +207,7 @@ void MetaIndexerTestBase::DoUpdateTest() {
     ASSERT_EQ(0, meta_indexer_->GetKeyCount());
 }
 
-void MetaIndexerTestBase::DoDeleteAndExistTest(bool is_redis_test) {
+void MetaIndexerTestBase::DoDeleteAndExistTest() {
     KVData data;
     int32_t key_count = 3;
     MakeKVData(/*start*/ 0, /*end*/ 3, data);
@@ -248,10 +248,6 @@ void MetaIndexerTestBase::DoDeleteAndExistTest(bool is_redis_test) {
     AssertGet(data.keys, expect_uris, expect_get_result);
     AssertSearchCacheGet(data.keys, expect_uris, expect_get_result.error_codes);
     AssertGet(data.keys, expect_uris, expect_maps, expect_get_result);
-    if (is_redis_test) {
-        // redis backend can not determine whether keys exist when get some fields
-        expect_get_result = Result(key_count);
-    }
     AssertGetProperties(data.keys, {"p0"}, expect_p0_maps, expect_get_result);
     AssertGetProperties(data.keys, {"p1"}, expect_p1_maps, expect_get_result);
 
@@ -309,10 +305,10 @@ void MetaIndexerTestBase::DoScanAndSampleReclaimKeysTest() {
     ASSERT_EQ(0, meta_indexer_->GetKeyCount());
 }
 
-void MetaIndexerTestBase::DoSimpleTest(bool is_redis_test) {
+void MetaIndexerTestBase::DoSimpleTest() {
     DoPutTest();
     DoUpdateTest();
-    DoDeleteAndExistTest(is_redis_test);
+    DoDeleteAndExistTest();
     DoScanAndSampleReclaimKeysTest();
     DoReadModifyWriteTest();
 }

--- a/kv_cache_manager/meta/test/meta_indexer_test_base.h
+++ b/kv_cache_manager/meta/test/meta_indexer_test_base.h
@@ -36,13 +36,13 @@ protected:
     void AssertReadModifyWrite(const KeyVector &keys,
                                const MetaIndexer::ModifierFunc &modifier,
                                const Result &expect_result);
-    void DoSimpleTest(bool is_redis_test = false);
+    void DoSimpleTest();
     void DoMultiThreadTest();
 
 private:
     void DoPutTest();
     void DoUpdateTest();
-    void DoDeleteAndExistTest(bool is_redis_test);
+    void DoDeleteAndExistTest();
     void DoScanAndSampleReclaimKeysTest();
     void DoReadModifyWriteTest();
 

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -36,15 +36,6 @@ void MetaLocalBackendTest::ConstructMetaStorageBackend() {
 
 void MetaLocalBackendTest::ConstructMetaStorageBackendConfig() {
     meta_storage_backend_config_ = std::make_shared<MetaStorageBackendConfig>();
-
-    std::string local_path = GetPrivateTestRuntimeDataPath() + "_meta_local_backend_file1";
-    std::error_code ec;
-    bool exists = std::filesystem::exists(local_path, ec);
-    ASSERT_FALSE(ec) << local_path; // false means correct
-    if (exists) {
-        std::remove(local_path.c_str());
-    }
-    meta_storage_backend_config_->SetStorageUri("file://" + local_path);
 }
 
 std::string MetaLocalBackendTest::ExpectedStorageType() const { return META_LOCAL_BACKEND_TYPE_STR; }
@@ -58,36 +49,36 @@ TEST_F(MetaLocalBackendTest, TestSimple) {
     // Put two entries with uri field
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
               meta_storage_backend_->Put({1, 2}, {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}}));
-    // UpdateFields to add lru_time
+    // UpdateFields to add hit_count
     ASSERT_EQ(
         (std::vector<ErrorCode>{EC_OK, EC_OK}),
-        meta_storage_backend_->UpdateFields({1, 2}, {{{PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_LRU_TIME, "200"}}}));
+        meta_storage_backend_->UpdateFields({1, 2}, {{{PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_HIT_COUNT, "200"}}}));
 
     AssertExists(meta_storage_backend_.get(), {1, 2, 3}, {EC_OK, EC_OK, EC_OK}, /*is_exist*/ {true, true, false});
     AssertGet(
         meta_storage_backend_.get(),
         {1, 2},
-        {PROPERTY_URI, PROPERTY_LRU_TIME},
+        {PROPERTY_URI, PROPERTY_HIT_COUNT},
         {EC_OK, EC_OK},
-        {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}});
+        {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}});
     AssertListKeys(meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, EC_OK, SCAN_BASE_CURSOR, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, EC_OK, {1, 2});
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete({1}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT}), meta_storage_backend_->Delete({1}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->Put({3}, {{{PROPERTY_URI, "uri3"}, {PROPERTY_LRU_TIME, "300"}}}));
+              meta_storage_backend_->Put({3}, {{{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
               meta_storage_backend_->UpdateFields({2}, {{{PROPERTY_URI, "uri2-updated"}}}));
 
     AssertExists(meta_storage_backend_.get(), {1, 2, 3}, {EC_OK, EC_OK, EC_OK}, /*is_exist*/ {false, true, true});
     AssertGet(meta_storage_backend_.get(),
               {1, 2, 3},
-              {PROPERTY_URI, PROPERTY_LRU_TIME},
+              {PROPERTY_URI, PROPERTY_HIT_COUNT},
               {EC_NOENT, EC_OK, EC_OK},
               {{},
-               {{PROPERTY_URI, "uri2-updated"}, {PROPERTY_LRU_TIME, "200"}},
-               {{PROPERTY_URI, "uri3"}, {PROPERTY_LRU_TIME, "300"}}});
+               {{PROPERTY_URI, "uri2-updated"}, {PROPERTY_HIT_COUNT, "200"}},
+               {{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}});
     AssertListKeys(meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, EC_OK, SCAN_BASE_CURSOR, {2, 3});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, EC_OK, {2, 3});
 
@@ -101,20 +92,68 @@ TEST_F(MetaLocalBackendTest, TestInit) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
 }
 
+TEST_F(MetaLocalBackendTest, TestParseStorageUri) {
+    // URI with all parameters specified
+    auto config = std::make_shared<MetaStorageBackendConfig>();
+    config->SetStorageUri("local://?capacity=1024&num_shard_bits=4&sample_times=50");
+
+    auto backend = std::make_shared<MetaLocalBackend>();
+    ASSERT_EQ(EC_OK, backend->Init("test_instance_uri_all", config));
+    ASSERT_EQ(EC_OK, backend->Open());
+    ASSERT_EQ(1024 * 1024 * 1024, backend->cache_->GetCapacity());
+    uint32_t expected_shard_mask = (1 << 4) - 1;
+    ASSERT_EQ(expected_shard_mask, backend->shard_mask_);
+    ASSERT_EQ(50, backend->sample_times_);
+
+    // Verify the backend is functional with custom parameters
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    AssertGet(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
+
+    ASSERT_EQ(EC_OK, backend->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestParseStorageUriEmpty) {
+    // Empty URI should use all default values
+    auto config = std::make_shared<MetaStorageBackendConfig>();
+    config->SetStorageUri("");
+
+    auto backend = std::make_shared<MetaLocalBackend>();
+    ASSERT_EQ(EC_OK, backend->Init("test_instance_uri_empty", config));
+    ASSERT_EQ(EC_OK, backend->Open());
+    ASSERT_EQ(META_LOCAL_BACKEND_DEFAULT_CAPACITY * 1024 * 1024, backend->cache_->GetCapacity());
+    uint32_t expected_shard_mask = (1 << META_LOCAL_BACKEND_DEFAULT_NUM_SHARD_BITS) - 1;
+    ASSERT_EQ(expected_shard_mask, backend->shard_mask_);
+    ASSERT_EQ(META_LOCAL_BACKEND_DEFAULT_SAMPLE_TIMES, backend->sample_times_);
+
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    AssertGet(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
+
+    ASSERT_EQ(EC_OK, backend->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestParseStorageUriInvalidFormat) {
+    // Invalid URI format (no protocol) should fall back to defaults
+    auto config = std::make_shared<MetaStorageBackendConfig>();
+    config->SetStorageUri("not_a_valid_uri");
+
+    auto backend = std::make_shared<MetaLocalBackend>();
+    ASSERT_EQ(EC_BADARGS, backend->Init("test_instance_uri_invalid", config));
+}
+
 TEST_F(MetaLocalBackendTest, TestPut) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
               meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}}));
+                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
     AssertGet(
         meta_storage_backend_.get(),
         {1, 2},
-        {PROPERTY_URI, PROPERTY_LRU_TIME},
+        {PROPERTY_URI, PROPERTY_HIT_COUNT},
         {EC_OK, EC_OK},
-        {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}});
+        {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     // Put again to overwrite
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1-new"}}}));
@@ -133,19 +172,19 @@ TEST_F(MetaLocalBackendTest, TestUpdateFields) {
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
               meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}}));
+                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
 
     // Update uri only, lru_time should be preserved
     ASSERT_EQ(
         (std::vector<ErrorCode>{EC_OK, EC_OK}),
-        meta_storage_backend_->UpdateFields({1, 2}, {{{PROPERTY_URI, "uri1-updated"}}, {{PROPERTY_LRU_TIME, "250"}}}));
+        meta_storage_backend_->UpdateFields({1, 2}, {{{PROPERTY_URI, "uri1-updated"}}, {{PROPERTY_HIT_COUNT, "250"}}}));
     AssertGet(meta_storage_backend_.get(),
               {1, 2},
-              {PROPERTY_URI, PROPERTY_LRU_TIME},
+              {PROPERTY_URI, PROPERTY_HIT_COUNT},
               {EC_OK, EC_OK},
-              {{{PROPERTY_URI, "uri1-updated"}, {PROPERTY_LRU_TIME, "100"}},
-               {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "250"}}});
+              {{{PROPERTY_URI, "uri1-updated"}, {PROPERTY_HIT_COUNT, "100"}},
+               {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "250"}}});
 
     // Cannot update key that does not exist
     ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT}), meta_storage_backend_->UpdateFields({3}, {{{PROPERTY_URI, "uri3"}}}));
@@ -159,37 +198,22 @@ TEST_F(MetaLocalBackendTest, TestUpsert) {
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
               meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}}));
+                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
 
     // Upsert: update existing, insert new
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}),
               meta_storage_backend_->Upsert(
                   {1, 2, 3},
-                  {{{PROPERTY_URI, "uri1-upserted"}}, {{PROPERTY_LRU_TIME, "250"}}, {{PROPERTY_URI, "uri3-new"}}}));
+                  {{{PROPERTY_URI, "uri1-upserted"}}, {{PROPERTY_HIT_COUNT, "250"}}, {{PROPERTY_URI, "uri3-new"}}}));
     // Verify existing keys preserve unmodified fields
     AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {PROPERTY_URI, PROPERTY_LRU_TIME},
-              {EC_OK, EC_OK},
-              {{{PROPERTY_URI, "uri1-upserted"}, {PROPERTY_LRU_TIME, "100"}},
-               {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "250"}}});
-
-    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
-}
-
-TEST_F(MetaLocalBackendTest, TestIncrFields) {
-    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
-    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
-
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}}));
-
-    // Increment lru_time
-    ASSERT_EQ((std::vector<ErrorCode>{EC_UNIMPLEMENTED, EC_UNIMPLEMENTED}),
-              meta_storage_backend_->IncrFields({1, 2}, {{PROPERTY_LRU_TIME, 50}}));
+              {1, 2, 3},
+              {PROPERTY_URI, PROPERTY_HIT_COUNT},
+              {EC_OK, EC_OK, EC_OK},
+              {{{PROPERTY_URI, "uri1-upserted"}, {PROPERTY_HIT_COUNT, "100"}},
+               {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "250"}},
+               {{PROPERTY_URI, "uri3-new"}}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -214,8 +238,8 @@ TEST_F(MetaLocalBackendTest, TestGet) {
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
               meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}}));
+                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
 
     // Get single field
     AssertGet(meta_storage_backend_.get(),
@@ -228,15 +252,15 @@ TEST_F(MetaLocalBackendTest, TestGet) {
     AssertGet(
         meta_storage_backend_.get(),
         {1, 2},
-        {PROPERTY_URI, PROPERTY_LRU_TIME},
+        {PROPERTY_URI, PROPERTY_HIT_COUNT},
         {EC_OK, EC_OK},
-        {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}});
+        {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     // Get no fields
     AssertGet(meta_storage_backend_.get(), {1, 2}, {}, {EC_OK, EC_OK}, FieldMapVec(2));
 
     // Get non-existent key returns empty values
-    AssertGet(meta_storage_backend_.get(), {3}, {PROPERTY_URI, PROPERTY_LRU_TIME}, {EC_NOENT}, {{}});
+    AssertGet(meta_storage_backend_.get(), {3}, {PROPERTY_URI, PROPERTY_HIT_COUNT}, {EC_NOENT}, {{}});
 
     // Get unsupported field returns empty string
     AssertGet(meta_storage_backend_.get(), {1}, {"unsupported_field"}, {EC_OK}, {{}});
@@ -250,13 +274,15 @@ TEST_F(MetaLocalBackendTest, TestGetAll) {
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
               meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}}));
-    AssertGetAllFields(
-        meta_storage_backend_.get(),
-        {1, 2},
-        {EC_OK, EC_OK},
-        {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}});
+                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
+    // GetAllFields returns all stored fields plus a dynamically generated PROPERTY_LRU_TIME.
+    // AssertGetAllFields skips PROPERTY_LRU_TIME value comparison (only checks existence).
+    AssertGetAllFields(meta_storage_backend_.get(),
+                       {1, 2},
+                       {EC_OK, EC_OK},
+                       {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}, {PROPERTY_LRU_TIME, ""}},
+                        {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}, {PROPERTY_LRU_TIME, ""}}});
     AssertGetAllFields(meta_storage_backend_.get(), {3}, {EC_NOENT}, FieldMapVec(1)); // no entry
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
@@ -309,12 +335,12 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeys) {
 TEST_F(MetaLocalBackendTest, TestMetaMemCacheItemFieldMap) {
     // Verify MetaMemCacheItem stores all fields in a single FieldMap
     MetaMemCacheItem::FieldMap fields = {{PROPERTY_URI, "test://some/long/uri/path/for/testing"},
-                                         {PROPERTY_LRU_TIME, "1234567890"}};
+                                         {PROPERTY_HIT_COUNT, "1234567890"}};
 
     MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
     ASSERT_NE(nullptr, item);
     ASSERT_EQ("test://some/long/uri/path/for/testing", item->GetFields().at(PROPERTY_URI));
-    ASSERT_EQ("1234567890", item->GetFields().at(PROPERTY_LRU_TIME));
+    ASSERT_EQ("1234567890", item->GetFields().at(PROPERTY_HIT_COUNT));
     ASSERT_EQ(2u, item->GetFields().size());
     // Size should be at least sizeof(MetaMemCacheItem) plus string heap overhead
     ASSERT_GE(item->Size(), sizeof(MetaMemCacheItem));
@@ -331,7 +357,7 @@ TEST_F(MetaLocalBackendTest, TestMetaMemCacheItemFieldMap) {
 
     // Test with extra custom fields
     MetaMemCacheItem::FieldMap custom_fields = {
-        {PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}, {"custom_key", "custom_value"}};
+        {PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}, {"custom_key", "custom_value"}};
     MetaMemCacheItem *custom_item = MetaMemCacheItem::Create(custom_fields);
     ASSERT_NE(nullptr, custom_item);
     ASSERT_EQ(3u, custom_item->GetFields().size());
@@ -340,20 +366,20 @@ TEST_F(MetaLocalBackendTest, TestMetaMemCacheItemFieldMap) {
     MetaMemCacheItem::Deleter(custom_item, nullptr);
 }
 
-TEST_F(MetaLocalBackendTest, TestGetOldestKeysFromRandomShard) {
+TEST_F(MetaLocalBackendTest, TestRandomSample) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     // No entries inserted, should return empty
-    MetaLocalBackend *local_backend = GetLocalBackend();
     std::vector<MetaStorageBackend::KeyType> oldest_keys;
-    ErrorCode ret = local_backend->GetOldestKeysFromRandomShard(5, oldest_keys);
+    ErrorCode ret = meta_storage_backend_->RandomSample(5, oldest_keys);
     ASSERT_EQ(EC_OK, ret);
     ASSERT_TRUE(oldest_keys.empty());
 
-    // count = 0 should return EC_BADARGS
-    ret = local_backend->GetOldestKeysFromRandomShard(0, oldest_keys);
-    ASSERT_EQ(EC_BADARGS, ret);
+    // count = 0 should return OK with no keys
+    ret = meta_storage_backend_->RandomSample(0, oldest_keys);
+    ASSERT_EQ(EC_OK, ret);
+    ASSERT_TRUE(oldest_keys.empty());
 
     // Insert multiple entries
     for (int64_t i = 1; i <= 20; ++i) {
@@ -361,22 +387,18 @@ TEST_F(MetaLocalBackendTest, TestGetOldestKeysFromRandomShard) {
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({i}, {{{PROPERTY_URI, uri}}}));
     }
 
-    // GetOldestKeysFromRandomShard should return some keys
-    ret = local_backend->GetOldestKeysFromRandomShard(5, oldest_keys);
+    // RandomSample should return some keys
+    ret = meta_storage_backend_->RandomSample(5, oldest_keys);
     ASSERT_EQ(EC_OK, ret);
     // The returned keys should be a subset of inserted keys
-    std::set<int64_t> all_keys;
-    for (int64_t i = 1; i <= 20; ++i) {
-        all_keys.insert(i);
-    }
     for (const auto &key : oldest_keys) {
-        ASSERT_TRUE(all_keys.count(key) > 0) << "Unexpected key: " << key;
+        ASSERT_TRUE(1 <= key && key <= 20) << "Unexpected key: " << key;
     }
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
-TEST_F(MetaLocalBackendTest, TestGetOldestKeysAfterDelete) {
+TEST_F(MetaLocalBackendTest, TestRandomSampleAfterDelete) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
@@ -389,47 +411,15 @@ TEST_F(MetaLocalBackendTest, TestGetOldestKeysAfterDelete) {
     // Delete some entries
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), meta_storage_backend_->Delete({1, 3, 5}));
 
-    // GetOldestKeysFromRandomShard should not return deleted keys
-    MetaLocalBackend *local_backend = GetLocalBackend();
-    std::set<int64_t> deleted_keys = {1, 3, 5};
+    // RandomSample should not return deleted keys
     std::set<int64_t> remaining_keys = {2, 4, 6, 7, 8, 9, 10};
 
-    // Run multiple times to cover different random shards
     std::vector<MetaStorageBackend::KeyType> oldest_keys;
-    ErrorCode ret = local_backend->GetOldestKeysFromRandomShard(10, oldest_keys);
+    ErrorCode ret = meta_storage_backend_->RandomSample(10, oldest_keys);
     ASSERT_EQ(EC_OK, ret);
     for (const auto &key : oldest_keys) {
         ASSERT_TRUE(remaining_keys.count(key) > 0) << "Deleted key " << key << " should not appear in oldest keys";
     }
-
-    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
-}
-
-TEST_F(MetaLocalBackendTest, TestUpsertMergesFields) {
-    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
-    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
-
-    // Put initial entry
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "original_uri"}, {PROPERTY_LRU_TIME, "100"}}}));
-
-    // Upsert with only uri change - lru_time should be preserved
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Upsert({1}, {{{PROPERTY_URI, "updated_uri"}}}));
-
-    FieldMapVec out_field_maps;
-    auto results = meta_storage_backend_->Get({1}, {PROPERTY_URI, PROPERTY_LRU_TIME}, out_field_maps);
-    ASSERT_EQ(EC_OK, results[0]);
-    ASSERT_EQ("updated_uri", out_field_maps[0][PROPERTY_URI]);
-    ASSERT_EQ("100", out_field_maps[0][PROPERTY_LRU_TIME]);
-
-    // Upsert with only lru_time change - uri should be preserved
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Upsert({1}, {{{PROPERTY_LRU_TIME, "999"}}}));
-
-    FieldMapVec out_field_maps2;
-    results = meta_storage_backend_->Get({1}, {PROPERTY_URI, PROPERTY_LRU_TIME}, out_field_maps2);
-    ASSERT_EQ(EC_OK, results[0]);
-    ASSERT_EQ("updated_uri", out_field_maps2[0][PROPERTY_URI]);
-    ASSERT_EQ("999", out_field_maps2[0][PROPERTY_LRU_TIME]);
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -440,7 +430,7 @@ TEST_F(MetaLocalBackendTest, TestPutMetaDataAndGetMetaData) {
 
     FieldMap field_maps;
     field_maps["key1"] = "value1";
-    ASSERT_EQ(EC_OK, meta_storage_backend_->PutMetaData(field_maps));
+    ASSERT_EQ(EC_UNIMPLEMENTED, meta_storage_backend_->PutMetaData(field_maps));
 
     FieldMap out_field_maps;
     ASSERT_EQ(EC_NOENT, meta_storage_backend_->GetMetaData(out_field_maps));
@@ -457,47 +447,47 @@ TEST_F(MetaLocalBackendTest, TestPutIfAbsent) {
     // Insert new keys should succeed
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
               local_backend->PutIfAbsent({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}},
+                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}},
                                          {EC_OK, EC_OK}));
 
     // Verify inserted data
     AssertGet(
         meta_storage_backend_.get(),
         {1, 2},
-        {PROPERTY_URI, PROPERTY_LRU_TIME},
+        {PROPERTY_URI, PROPERTY_HIT_COUNT},
         {EC_OK, EC_OK},
-        {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}});
+        {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     // Insert again with same keys should return EC_EXIST and not overwrite
     ASSERT_EQ((std::vector<ErrorCode>{EC_EXIST, EC_EXIST}),
               local_backend->PutIfAbsent({1, 2},
-                                         {{{PROPERTY_URI, "uri1-new"}, {PROPERTY_LRU_TIME, "999"}},
-                                          {{PROPERTY_URI, "uri2-new"}, {PROPERTY_LRU_TIME, "888"}}},
+                                         {{{PROPERTY_URI, "uri1-new"}, {PROPERTY_HIT_COUNT, "999"}},
+                                          {{PROPERTY_URI, "uri2-new"}, {PROPERTY_HIT_COUNT, "888"}}},
                                          {EC_OK, EC_OK}));
 
     // Verify original data is unchanged
     AssertGet(
         meta_storage_backend_.get(),
         {1, 2},
-        {PROPERTY_URI, PROPERTY_LRU_TIME},
+        {PROPERTY_URI, PROPERTY_HIT_COUNT},
         {EC_OK, EC_OK},
-        {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_LRU_TIME, "200"}}});
+        {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     // Mixed: one existing key and one new key
     ASSERT_EQ((std::vector<ErrorCode>{EC_EXIST, EC_OK}),
               local_backend->PutIfAbsent(
                   {1, 3},
-                  {{{PROPERTY_URI, "uri1-again"}}, {{PROPERTY_URI, "uri3"}, {PROPERTY_LRU_TIME, "300"}}},
+                  {{{PROPERTY_URI, "uri1-again"}}, {{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}},
                   {EC_OK, EC_OK}));
 
     // Verify key 1 unchanged, key 3 inserted
     AssertGet(
         meta_storage_backend_.get(),
         {1, 3},
-        {PROPERTY_URI, PROPERTY_LRU_TIME},
+        {PROPERTY_URI, PROPERTY_HIT_COUNT},
         {EC_OK, EC_OK},
-        {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}, {{PROPERTY_URI, "uri3"}, {PROPERTY_LRU_TIME, "300"}}});
+        {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -510,7 +500,7 @@ TEST_F(MetaLocalBackendTest, TestPutIfAbsentThenDelete) {
 
     // Insert a key
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              local_backend->PutIfAbsent({1}, {{{PROPERTY_URI, "uri1"}, {PROPERTY_LRU_TIME, "100"}}}, {EC_OK, EC_OK}));
+              local_backend->PutIfAbsent({1}, {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}}, {EC_OK, EC_OK}));
 
     // Delete the key
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete({1}));
@@ -518,66 +508,222 @@ TEST_F(MetaLocalBackendTest, TestPutIfAbsentThenDelete) {
     // PutIfAbsent should succeed again after deletion
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
               local_backend->PutIfAbsent(
-                  {1}, {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_LRU_TIME, "200"}}}, {EC_OK, EC_OK}));
+                  {1}, {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_HIT_COUNT, "200"}}}, {EC_OK, EC_OK}));
 
     // Verify the reinserted data
     AssertGet(meta_storage_backend_.get(),
               {1},
-              {PROPERTY_URI, PROPERTY_LRU_TIME},
+              {PROPERTY_URI, PROPERTY_HIT_COUNT},
               {EC_OK},
-              {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_LRU_TIME, "200"}}});
+              {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
-// ==================== storage_uri parsing tests ====================
+TEST_F(MetaLocalBackendTest, TestLruTimeUpdatedByReadWriteOps) {
+    // Verify that PROPERTY_LRU_TIME (backed by last_access_time_) is updated
+    // by all read/write operations: Get, GetAllFields, Exists, UpdateFields,
+    // Upsert, and PutIfAbsent.
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_lru_time_ops", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
-TEST_F(MetaLocalBackendTest, TestParseStorageUri) {
-    // URI with all parameters specified
-    auto config = std::make_shared<MetaStorageBackendConfig>();
-    config->SetStorageUri("local://?capacity=1024&num_shard_bits=4&sample_times=50");
+    MetaLocalBackend *local_backend = GetLocalBackend();
 
-    auto backend = std::make_shared<MetaLocalBackend>();
-    ASSERT_EQ(EC_OK, backend->Init("test_instance_uri_all", config));
-    ASSERT_EQ(EC_OK, backend->Open());
-    ASSERT_EQ(1024 * 1024 * 1024, backend->cache_->GetCapacity());
-    uint32_t expected_shard_mask = (1 << 4) - 1;
-    ASSERT_EQ(expected_shard_mask, backend->shard_mask_);
-    ASSERT_EQ(50, backend->sample_times_);
+    // Helper lambda: get LRU time for a key via Get.
+    auto getLruTime = [&](int64_t key) -> int64_t {
+        FieldMapVec out;
+        auto ec = meta_storage_backend_->Get({key}, {PROPERTY_LRU_TIME}, out);
+        EXPECT_EQ((std::vector<ErrorCode>{EC_OK}), ec);
+        return std::stoll(out[0][PROPERTY_LRU_TIME]);
+    };
 
-    // Verify the backend is functional with custom parameters
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
-    AssertGet(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
+    // --- Put ---
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    int64_t lru_after_put = getLruTime(1);
+    ASSERT_GT(lru_after_put, 0);
 
-    ASSERT_EQ(EC_OK, backend->Close());
+    // Each operation sleeps 1ms (1000us) before running, so the LRU time
+    // difference between consecutive operations should be at least 1000us.
+    constexpr int64_t kMinTimeDiffUs = 1000;
+
+    // --- Get updates LRU time ---
+    usleep(1000);
+    FieldMapVec all_out;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Get({1}, {PROPERTY_URI}, all_out));
+    ASSERT_EQ("uri1", all_out[0][PROPERTY_URI]);
+    int64_t lru_after_get = getLruTime(1);
+    ASSERT_GE(lru_after_get - lru_after_put, kMinTimeDiffUs) << "Get should update LRU time by >= 1000us";
+
+    // --- GetAllFields updates LRU time ---
+    usleep(1000);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->GetAllFields({1}, all_out));
+    ASSERT_EQ("uri1", all_out[0][PROPERTY_URI]);
+    int64_t lru_after_getall = getLruTime(1);
+    ASSERT_GE(lru_after_getall - lru_after_get, kMinTimeDiffUs) << "GetAllFields should update LRU time by >= 1000us";
+
+    // --- Exists updates LRU time ---
+    usleep(1000);
+    std::vector<bool> exist_vec;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Exists({1}, exist_vec));
+    ASSERT_TRUE(exist_vec[0]);
+    int64_t lru_after_exists = getLruTime(1);
+    ASSERT_GE(lru_after_exists - lru_after_getall, kMinTimeDiffUs) << "Exists should update LRU time by >= 1000us";
+
+    // --- UpdateFields updates LRU time ---
+    usleep(1000);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              meta_storage_backend_->UpdateFields({1}, {{{PROPERTY_URI, "uri1-updated"}}}));
+    int64_t lru_after_update = getLruTime(1);
+    ASSERT_GE(lru_after_update - lru_after_exists, kMinTimeDiffUs)
+        << "UpdateFields should update LRU time by >= 1000us";
+
+    // --- Upsert updates LRU time ---
+    usleep(1000);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Upsert({1}, {{{PROPERTY_URI, "uri1-upserted"}}}));
+    int64_t lru_after_upsert = getLruTime(1);
+    ASSERT_GE(lru_after_upsert - lru_after_update, kMinTimeDiffUs) << "Upsert should update LRU time by >= 1000us";
+
+    // --- PutIfAbsent on new key ---
+    usleep(1000);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), local_backend->PutIfAbsent({2}, {{{PROPERTY_URI, "uri2"}}}, {EC_OK}));
+    int64_t lru_key2 = getLruTime(2);
+    ASSERT_GT(lru_key2, 0) << "PutIfAbsent should set LRU time on new key";
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
-TEST_F(MetaLocalBackendTest, TestParseStorageUriEmpty) {
-    // Empty URI should use all default values
-    auto config = std::make_shared<MetaStorageBackendConfig>();
-    config->SetStorageUri("");
+TEST_F(MetaLocalBackendTest, TestShardOldestAccessTimeEmptyToNonEmpty) {
+    // Use 2 shards (num_shard_bits=1) to test 0→1 boundary.
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=1&sample_times=2");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_0to1", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
-    auto backend = std::make_shared<MetaLocalBackend>();
-    ASSERT_EQ(EC_OK, backend->Init("test_instance_uri_empty", config));
-    ASSERT_EQ(EC_OK, backend->Open());
-    ASSERT_EQ(META_LOCAL_BACKEND_DEFAULT_CAPACITY * 1024 * 1024, backend->cache_->GetCapacity());
-    uint32_t expected_shard_mask = (1 << META_LOCAL_BACKEND_DEFAULT_NUM_SHARD_BITS) - 1;
-    ASSERT_EQ(expected_shard_mask, backend->shard_mask_);
-    ASSERT_EQ(META_LOCAL_BACKEND_DEFAULT_SAMPLE_TIMES, backend->sample_times_);
+    MetaLocalBackend *local_backend = GetLocalBackend();
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
-    AssertGet(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
+    // Initially both shards should have INT64_MAX (empty).
+    ASSERT_EQ(INT64_MAX, local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed));
+    ASSERT_EQ(INT64_MAX, local_backend->shard_oldest_access_time_[1].load(std::memory_order_relaxed));
 
-    ASSERT_EQ(EC_OK, backend->Close());
+    // Insert a key.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({100}, {{{PROPERTY_URI, "uri100"}}}));
+
+    // At least one shard should now have a non-INT64_MAX timestamp.
+    bool any_updated = (local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed) < INT64_MAX) ||
+                       (local_backend->shard_oldest_access_time_[1].load(std::memory_order_relaxed) < INT64_MAX);
+    ASSERT_TRUE(any_updated) << "Inserting into an empty shard should trigger tail-change callback";
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
-TEST_F(MetaLocalBackendTest, TestParseStorageUriInvalidFormat) {
-    // Invalid URI format (no protocol) should fall back to defaults
-    auto config = std::make_shared<MetaStorageBackendConfig>();
-    config->SetStorageUri("not_a_valid_uri");
+TEST_F(MetaLocalBackendTest, TestShardOldestAccessTimeNonEmptyToEmpty) {
+    // Use 1 shard (num_shard_bits=0) to test 1→0 boundary.
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_1to0", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
-    auto backend = std::make_shared<MetaLocalBackend>();
-    ASSERT_EQ(EC_BADARGS, backend->Init("test_instance_uri_invalid", config));
+    MetaLocalBackend *local_backend = GetLocalBackend();
+
+    // Insert one key.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    ASSERT_LT(local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed), INT64_MAX);
+
+    // Delete the key — shard becomes empty, timestamp should go back to INT64_MAX.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete({1}));
+    ASSERT_EQ(INT64_MAX, local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed));
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestSampleReclaimKeysSelectsOldestShard) {
+    // Use 2 shards (num_shard_bits=1), sample_times=2 so we can observe shard selection.
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=1&sample_times=2");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_oldest_shard", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    MetaLocalBackend *local_backend = GetLocalBackend();
+
+    // Insert keys into both shards.
+    for (int64_t i = 1; i <= 100; ++i) {
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+                  meta_storage_backend_->Put({i}, {{{PROPERTY_URI, "uri" + std::to_string(i)}}}));
+    }
+
+    // Both shards should have entries now.
+    int64_t ts0 = local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed);
+    int64_t ts1 = local_backend->shard_oldest_access_time_[1].load(std::memory_order_relaxed);
+    ASSERT_LT(ts0, INT64_MAX) << "Shard 0 should have entries";
+    ASSERT_LT(ts1, INT64_MAX) << "Shard 1 should have entries";
+
+    // Sleep and then access all keys via Get to make them "newer".
+    for (int64_t i = 1; i <= 50; ++i) {
+        FieldMapVec out;
+        meta_storage_backend_->Get({i}, {PROPERTY_URI}, out);
+    }
+    usleep(1000);
+    for (int64_t i = 51; i <= 100; ++i) {
+        FieldMapVec out;
+        meta_storage_backend_->Get({i}, {PROPERTY_URI}, out);
+    }
+
+    // Now SampleReclaimKeys should return keys.
+    std::vector<MetaStorageBackend::KeyType> reclaim_keys;
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(10, reclaim_keys));
+    ASSERT_FALSE(reclaim_keys.empty()) << "SampleReclaimKeys should return some keys";
+
+    // All returned keys should be valid (subset of inserted keys).
+    for (const auto &key : reclaim_keys) {
+        ASSERT_TRUE(1 <= key && key <= 50) << "Unexpected key: " << key;
+    }
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestSampleReclaimKeysEmptyCache) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=2&sample_times=4");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_empty_sample", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    // SampleReclaimKeys on empty cache should return OK with no keys.
+    std::vector<MetaStorageBackend::KeyType> reclaim_keys;
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(10, reclaim_keys));
+    ASSERT_TRUE(reclaim_keys.empty());
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestSampleReclaimKeysAfterDeleteUpdatesTimestamp) {
+    // Use 1 shard for simplicity.
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_delete_ts", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    MetaLocalBackend *local_backend = GetLocalBackend();
+
+    // Insert two keys with a time gap.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    usleep(1000);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({2}, {{{PROPERTY_URI, "uri2"}}}));
+
+    int64_t ts_before_delete = local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed);
+
+    // Sample should return key 1 (oldest in LRU).
+    std::vector<MetaStorageBackend::KeyType> reclaim_keys;
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(1, reclaim_keys));
+    ASSERT_EQ(1u, reclaim_keys.size());
+    ASSERT_EQ(1, reclaim_keys[0]);
+
+    // Delete the sampled key.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete(reclaim_keys));
+
+    // After deletion, the shard's oldest timestamp should have changed.
+    int64_t ts_after_delete = local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed);
+    ASSERT_GE(ts_after_delete, ts_before_delete) << "After deleting the oldest key, shard timestamp should advance";
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(1, reclaim_keys));
+    ASSERT_EQ(1u, reclaim_keys.size());
+    ASSERT_EQ(2, reclaim_keys[0]);
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/test/meta_redis_backend_real_service_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_real_service_test.cc
@@ -170,18 +170,22 @@ TEST_F(MetaRedisBackendRealServiceTest, TestConcurrentMixedOperations) {
             ASSERT_EQ(keys.size(), out_field_maps.size());
             for (int i = 0; i < ec_per_key.size(); ++i) {
                 auto ec = ec_per_key[i];
-                ASSERT_TRUE(ec == EC_OK) << ec;
-                if (!out_field_maps[i]["name"].empty()) {
-                    ASSERT_EQ(field_maps[i]["name"], out_field_maps[i]["name"]);
-                    ASSERT_EQ(field_maps[i]["value"], out_field_maps[i]["value"]);
-                    ASSERT_TRUE(out_field_maps[i]["updated"] == "true" || out_field_maps[i]["updated"] == "false");
-                    bool is_updated = out_field_maps[i]["updated"] == "true";
-                    ASSERT_EQ(is_updated ? std::string("1234") : std::string(), out_field_maps[i]["ts"]);
+                ASSERT_TRUE(ec == EC_OK || ec == EC_NOENT) << ec;
+                if (ec == EC_OK) {
+                    auto nameIt = out_field_maps[i].find("name");
+                    if (nameIt != out_field_maps[i].end() && !nameIt->second.empty()) {
+                        ASSERT_EQ(field_maps[i]["name"], out_field_maps[i]["name"]);
+                        ASSERT_EQ(field_maps[i]["value"], out_field_maps[i]["value"]);
+                        auto updatedIt = out_field_maps[i].find("updated");
+                        ASSERT_TRUE(updatedIt != out_field_maps[i].end());
+                        ASSERT_TRUE(updatedIt->second == "true" || updatedIt->second == "false");
+                        bool is_updated = updatedIt->second == "true";
+                        auto tsIt = out_field_maps[i].find("ts");
+                        ASSERT_EQ(is_updated ? std::string("1234") : std::string(),
+                                  tsIt != out_field_maps[i].end() ? tsIt->second : std::string());
+                    }
                 } else {
-                    ASSERT_EQ(std::string(), out_field_maps[i]["name"]);
-                    ASSERT_EQ(std::string(), out_field_maps[i]["value"]);
-                    ASSERT_EQ(std::string(), out_field_maps[i]["updated"]);
-                    ASSERT_EQ(std::string(), out_field_maps[i]["ts"]);
+                    ASSERT_TRUE(out_field_maps[i].empty());
                 }
             }
         } break;

--- a/kv_cache_manager/meta/test/meta_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_test.cc
@@ -277,7 +277,7 @@ TEST_F(MetaRedisBackendTest, TestSimple) {
               {2, 3},
               {"f1", "f2"},
               {EC_OK, EC_OK},
-              {{{"f1", "v2-1-2"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", ""}}});
+              {{{"f1", "v2-1-2"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}}});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_storage_backend_test_base.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_test_base.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/meta/test/meta_storage_backend_test_base.h"
 
+#include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_redis_backend.h"
 namespace kv_cache_manager {
 void MetaStorageBackendTestBase::AssertGet(MetaStorageBackend *meta_storage_backend,
@@ -42,11 +43,22 @@ void MetaStorageBackendTestBase::AssertGetAllFields(MetaStorageBackend *meta_sto
         const KeyType &key = keys[i];
         const FieldMap &field_map = field_maps[i];
         const FieldMap &expected_field_map = expected_field_maps[i];
-        ASSERT_EQ(expected_field_map.size(), field_map.size()) << key;
+        // Count actual fields excluding PROPERTY_LRU_TIME (dynamically filled by local backend).
+        size_t actual_count_without_lru = field_map.size();
+        if (field_map.count(PROPERTY_LRU_TIME) && !expected_field_map.count(PROPERTY_LRU_TIME)) {
+            --actual_count_without_lru;
+        }
+        ASSERT_EQ(expected_field_map.size(), actual_count_without_lru) << key;
+        // Verify all expected fields are present with correct values.
+        // PROPERTY_LRU_TIME is dynamically filled, so only check existence.
         for (const auto &[expected_field_name, expected_field_value] : expected_field_map) {
             const auto iter = field_map.find(expected_field_name);
             ASSERT_TRUE(iter != field_map.end()) << key << " " << expected_field_name;
-            ASSERT_EQ(expected_field_value, iter->second) << key << " " << expected_field_name;
+            if (expected_field_name == PROPERTY_LRU_TIME) {
+                ASSERT_FALSE(iter->second.empty()) << key << " " << expected_field_name << " should not be empty";
+            } else {
+                ASSERT_EQ(expected_field_value, iter->second) << key << " " << expected_field_name;
+            }
         }
     }
 }


### PR DESCRIPTION
```markdown
## `[meta] lru cache support inner last access time field`

Move `PROPERTY_LRU_TIME` ownership from `MetaIndexer` to individual meta storage backends, so each backend maintains and dynamically fills the last-access timestamp on read.

- **`MetaLocalBackend`**: Add atomic `last_access_time_` per cache item; all read/write ops update the timestamp; `Get`/`GetAllFields` return the pre-update value as `PROPERTY_LRU_TIME`
- **`MetaDummyBackend`**: Maintain `PROPERTY_LRU_TIME` directly in the field map; all read/write ops update it accordingly
- **`MetaIndexer`**: Remove 4 places that wrote `PROPERTY_LRU_TIME` into field maps (Put/Update/Upsert/ModifyByUri)
- **LRU Cache**: Add `TailChangeCallback` mechanism; `LRU_Remove`/`LRU_Insert` detect tail-node changes and notify via callback
- **`SampleReclaimKeys`**: Replace random shard selection with oldest-tail-first strategy using a per-shard `shard_oldest_access_time_` atomic array, reducing lock contention
- **Remove `IncrFields`**: Delete the `IncrFields` interface from all meta backends
```