### PR TITLE
[connector] best-effort write when prefix blocks need writing for sglang

### DIFF
--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -96,6 +96,10 @@ class HiCacheKVCM(HiCacheStorage):
         # manager
         self.block_size = self.mem_pool_host.page_size
 
+        # Detect extra pools early — _tp_rank_to_spec_name depends on these.
+        self.has_mamba = PoolName.MAMBA in self.registered_pools
+        self.has_indexer = PoolName.INDEXER in self.registered_pools
+
         self.location_spec_size = kv_pool.get_size_per_token() * self.block_size
         self.location_spec_infos = [{
             "name": self._tp_rank_to_spec_name(rank),
@@ -107,7 +111,6 @@ class HiCacheKVCM(HiCacheStorage):
         self.location_spec_groups = [{"name": self._get_kv_spec_group(), "spec_names": kv_spec_names}]
 
         # Mamba/Linear specs
-        self.has_mamba = PoolName.MAMBA in self.registered_pools
         if self.has_mamba:
             mamba_pool = self.registered_pools[PoolName.MAMBA]
             self.mamba_spec_size = mamba_pool.get_size_per_token()
@@ -123,7 +126,6 @@ class HiCacheKVCM(HiCacheStorage):
             })
 
         # Indexer specs (NSA/DSA)
-        self.has_indexer = PoolName.INDEXER in self.registered_pools
         if self.has_indexer:
             indexer_pool = self.registered_pools[PoolName.INDEXER]
             self.indexer_spec_size = indexer_pool.get_size_per_token() * self.block_size

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -98,7 +98,7 @@ class HiCacheKVCM(HiCacheStorage):
 
         # Detect extra pools early — _tp_rank_to_spec_name depends on these.
         self.has_mamba = PoolName.MAMBA in self.registered_pools
-        self.has_indexer = PoolName.INDEXER in self.registered_pools
+        self.has_indexer = getattr(PoolName, "INDEXER", None) is not None and PoolName.INDEXER in self.registered_pools
 
         self.location_spec_size = kv_pool.get_size_per_token() * self.block_size
         self.location_spec_infos = [{
@@ -441,6 +441,7 @@ class HiCacheKVCM(HiCacheStorage):
         # Prepare keys
         block_keys, len_prefix, len_new = self._prepare_block_keys(keys, extra_info)
         local_len_new = len_new      # Preserve local key count for return value
+        input_hash = hash(tuple(block_keys))  # Hash of full block_keys for cross-rank consistency check
 
         # Start write cache
         if self.tp_rank == 0:
@@ -464,20 +465,31 @@ class HiCacheKVCM(HiCacheStorage):
 
             if self.tp_world_size > 1:
                 torch.distributed.broadcast_object_list(
-                    [result, len_prefix, len_new], src=0, group=self.storage_tp_group
+                    [result, len_prefix, len_new, input_hash], src=0, group=self.storage_tp_group
                 )
         else:
-            recv = [None, None, None]
+            recv = [None, None, None, None]
             torch.distributed.broadcast_object_list(
                 recv, src=0, group=self.storage_tp_group
             )
-            result, len_prefix, len_new = recv
+            result, len_prefix, len_new, input_hash = recv
 
         logger.debug(f"start_write_cache {result=}")
 
         # All ranks now share rank 0's len_prefix/len_new so that
         # _parse_block_mask produces the same save_indices everywhere,
         # preventing control-flow divergence (and NCCL hangs).
+        # We also compare a hash of the full block_keys list: if a non-rank-0
+        # rank's local block_keys differ from rank 0's, writing would corrupt
+        # storage. The rank still participates in all_reduce with all-zero
+        # flags so NCCL doesn't hang.
+        skip_transfer = False
+        local_hash = hash(tuple(block_keys))
+        if local_hash != input_hash:
+            logger.warning(f"_batch_set: local block_keys hash ({local_hash}) != "
+                           f"rank 0 hash ({input_hash}), inputs diverged across TP ranks. "
+                           f"local_block_keys={block_keys}")
+            skip_transfer = True
 
         if result is None:
             return [False] * local_len_new

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -440,8 +440,9 @@ class HiCacheKVCM(HiCacheStorage):
 
         # Prepare keys
         block_keys, len_prefix, len_new = self._prepare_block_keys(keys, extra_info)
-        local_len_new = len_new      # Preserve local key count for return value
-        input_hash = hash(tuple(block_keys))  # Hash of full block_keys for cross-rank consistency check
+        local_len_new = len_new        # Preserve local key count for return value
+        local_len_prefix = len_prefix  # Preserve for divergence check
+        input_hash = hash((len_prefix, len_new, *block_keys))  # Hash covers prefix/new boundary + all keys
 
         # Start write cache
         if self.tp_rank == 0:
@@ -484,7 +485,7 @@ class HiCacheKVCM(HiCacheStorage):
         # storage. The rank still participates in all_reduce with all-zero
         # flags so NCCL doesn't hang.
         skip_transfer = False
-        local_hash = hash(tuple(block_keys))
+        local_hash = hash((local_len_prefix, local_len_new, *block_keys))
         if local_hash != input_hash:
             logger.warning(f"_batch_set: local block_keys hash ({local_hash}) != "
                            f"rank 0 hash ({input_hash}), inputs diverged across TP ranks. "
@@ -537,7 +538,7 @@ class HiCacheKVCM(HiCacheStorage):
                     )
                 except Exception as e:
                     logger.error(f"finish_write_cache failed: {e}")
-            return [True] * local_len_new
+            return [False] * local_len_new if skip_transfer else [True] * local_len_new
 
         assert unmatched + prefix_write_count == len(locations)
 
@@ -629,6 +630,10 @@ class HiCacheKVCM(HiCacheStorage):
         # Use local_len_new so the return length matches the caller's input.
         # - keys not in save_indices → True (assumed cached / no-op)
         # - keys in save_indices → per-block success from all_reduce
+        # When input diverged (skip_transfer), nothing was written and the
+        # local keys don't match rank 0's — return all False.
+        if skip_transfer:
+            return [False] * local_len_new
         block_flag_map = {save_indices[j]: new_block_success[j] for j in range(unmatched)}
         result_list = [
             block_flag_map.get(i, True)

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -440,6 +440,7 @@ class HiCacheKVCM(HiCacheStorage):
 
         # Prepare keys
         block_keys, len_prefix, len_new = self._prepare_block_keys(keys, extra_info)
+        local_len_new = len_new      # Preserve local key count for return value
 
         # Start write cache
         if self.tp_rank == 0:
@@ -463,19 +464,23 @@ class HiCacheKVCM(HiCacheStorage):
 
             if self.tp_world_size > 1:
                 torch.distributed.broadcast_object_list(
-                    [result], src=0, group=self.storage_tp_group
+                    [result, len_prefix, len_new], src=0, group=self.storage_tp_group
                 )
         else:
-            recv = [None]
+            recv = [None, None, None]
             torch.distributed.broadcast_object_list(
                 recv, src=0, group=self.storage_tp_group
             )
-            result = recv[0]
+            result, len_prefix, len_new = recv
 
         logger.debug(f"start_write_cache {result=}")
 
+        # All ranks now share rank 0's len_prefix/len_new so that
+        # _parse_block_mask produces the same save_indices everywhere,
+        # preventing control-flow divergence (and NCCL hangs).
+
         if result is None:
-            return [False] * len_new
+            return [False] * local_len_new
 
         locations = result["locations"]
         write_session_id = result["write_session_id"]
@@ -501,7 +506,7 @@ class HiCacheKVCM(HiCacheStorage):
                     )
                 except Exception as e:
                     logger.error(f"finish_write_cache failed: {e}")
-            return [False] * len_new
+            return [False] * local_len_new
 
         save_indices, prefix_write_count = parsed
         unmatched = len(save_indices)
@@ -520,51 +525,79 @@ class HiCacheKVCM(HiCacheStorage):
                     )
                 except Exception as e:
                     logger.error(f"finish_write_cache failed: {e}")
-            return [True] * len_new
+            return [True] * local_len_new
 
         assert unmatched + prefix_write_count == len(locations)
 
         # Data transfer preparation and execution.
         # Skip prefix locations — sglang cannot write prefix blocks.
+        # Best-effort: each rank writes only the blocks it has local data for.
+        # A per-block flag vector is all_reduced (MIN) so only blocks written
+        # by ALL ranks are considered successful.
         # Wrapped in try-except so that every rank always reaches the
         # all_reduce below, preventing cross-rank NCCL/gloo hangs.
         new_locations = locations[prefix_write_count:]
-        try:
-            buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
-            buffer_ptrs = [buffer_ptr for i, buffer_ptr in enumerate(buffer_ptrs) if (i // self.kv_factor) in save_indices]
-            buffer_sizes = [buffer_size for i, buffer_size in enumerate(
-                buffer_sizes) if (i // self.kv_factor) in save_indices]
+        per_block_flags = torch.zeros(unmatched, dtype=torch.int)
+        if skip_transfer:
+            # This rank's block_keys diverged from rank 0 — writing would
+            # corrupt storage. Keep per_block_flags as all-zero and still
+            # participate in all_reduce below.
+            logger.warning("_batch_set: skipping data transfer on this rank due to input divergence")
+        else:
+            try:
+                buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
+                local_block_count = len(buffer_ptrs) // self.kv_factor
 
-            # Extract URIs and prepare buffers
-            uris = self._extract_uris(new_locations)
-            buffers = self._prepare_buffers(buffer_ptrs, buffer_sizes)
-            assert len(uris) == len(buffers)
-            # Perform data transfer
-            start_time = time.perf_counter()
-            result = self.transfer_client.SaveKvCaches(uris, buffers)
-            end_time = time.perf_counter()
-            self.backup_pgs.append(unmatched)
-            self.backup_bandwidth.append(unmatched * self.location_spec_size / (1 << 30) / (end_time - start_time))
-            logger.debug(f"SaveKvCaches {result=}")
+                # Determine which save_indices have local data available
+                valid_save_mask = [(idx < local_block_count) for idx in save_indices]
+                valid_save_set = set(idx for idx, valid in zip(save_indices, valid_save_mask) if valid)
+                num_valid = sum(valid_save_mask)
 
-            flag = (result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
-            if not flag:
-                logger.error(f"SaveKvCaches error: {result}")
-        except Exception as e:
-            logger.error(f"Data transfer (SaveKvCaches) failed: {e}")
-            flag = False
+                if num_valid > 0:
+                    buffer_ptrs = [ptr for i, ptr in enumerate(buffer_ptrs)
+                                   if (i // self.kv_factor) in valid_save_set]
+                    buffer_sizes = [sz for i, sz in enumerate(buffer_sizes)
+                                    if (i // self.kv_factor) in valid_save_set]
 
-        # Finish write cache
+                    # Extract URIs only for blocks with local data
+                    valid_locations = [loc for loc, valid in zip(new_locations, valid_save_mask) if valid]
+                    uris = self._extract_uris(valid_locations)
+                    buffers = self._prepare_buffers(buffer_ptrs, buffer_sizes)
+                    assert len(uris) == len(buffers)
+
+                    # Perform data transfer
+                    start_time = time.perf_counter()
+                    result = self.transfer_client.SaveKvCaches(uris, buffers)
+                    end_time = time.perf_counter()
+                    self.backup_pgs.append(num_valid)
+                    self.backup_bandwidth.append(num_valid * self.location_spec_size / (1 << 30) / (end_time - start_time))
+                    logger.debug(f"SaveKvCaches {result=}")
+
+                    transfer_ok = (result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
+                    if not transfer_ok:
+                        logger.error(f"SaveKvCaches error: {result}")
+                else:
+                    transfer_ok = True  # nothing to write on this rank
+
+                # Mark blocks this rank successfully wrote
+                for j, valid in enumerate(valid_save_mask):
+                    if valid and transfer_ok:
+                        per_block_flags[j] = 1
+
+            except Exception as e:
+                logger.error(f"Data transfer (SaveKvCaches) failed: {e}")
+                # per_block_flags remains all zeros
+
+        # Per-block all_reduce: only blocks ALL ranks wrote are marked success
         if self.tp_world_size > 1:
-            flag_tensor = torch.tensor(flag, dtype=torch.int)
             torch.distributed.all_reduce(
-                flag_tensor,
+                per_block_flags,
                 op=torch.distributed.ReduceOp.MIN,
                 group=self.storage_tp_group,
             )
-            flag = bool(flag_tensor.item())
 
-        finish_mask = [False] * prefix_write_count + [flag] * unmatched
+        new_block_success = [bool(per_block_flags[j]) for j in range(unmatched)]
+        finish_mask = [False] * prefix_write_count + new_block_success
         if self.tp_rank == 0:
             try:
                 self._manager_client.finish_write_cache(
@@ -577,19 +610,17 @@ class HiCacheKVCM(HiCacheStorage):
                 )
             except Exception as e:
                 logger.error(f"finish_write_cache failed: {e}")
-                # This sets flag = False on rank 0 only; other ranks
-                # still have the post-all_reduce value (True if data
-                # transfer succeeded). See the NOTE at the top of
-                # _batch_set for why we accept this inconsistency.
-                flag = False
+                # Mark all as failed on rank 0 for the return value.
+                new_block_success = [False] * unmatched
 
-        # Build result list: 1:1 positional mapping with input keys
-        # - keys not in save_indices → True
-        # - keys in save_indices → flag (True if save succeeded)
-        save_indices_set = set(save_indices)
+        # Build result list: 1:1 positional mapping with input keys.
+        # Use local_len_new so the return length matches the caller's input.
+        # - keys not in save_indices → True (assumed cached / no-op)
+        # - keys in save_indices → per-block success from all_reduce
+        block_flag_map = {save_indices[j]: new_block_success[j] for j in range(unmatched)}
         result_list = [
-            flag if i in save_indices_set else True
-            for i in range(len_new)
+            block_flag_map.get(i, True)
+            for i in range(local_len_new)
         ]
         return result_list
 

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -478,12 +478,12 @@ class HiCacheKVCM(HiCacheStorage):
         locations = result["locations"]
         write_session_id = result["write_session_id"]
         block_mask = result["block_mask"]
-        save_indices = self._parse_block_mask(block_mask, len_prefix, len_new)
+        parsed = self._parse_block_mask(block_mask, len_prefix, len_new)
 
         finish_trace_id = f"finish-{trace_id}"
 
-        # None means inconsistent manager state — treat as write failure.
-        if save_indices is None:
+        # None means truly broken manager data — treat as write failure.
+        if parsed is None:
             logger.warning(f"_batch_set: inconsistent block_mask from manager, "
                            f"aborting write session {write_session_id}")
             if self.tp_rank == 0:
@@ -501,6 +501,7 @@ class HiCacheKVCM(HiCacheStorage):
                     logger.error(f"finish_write_cache failed: {e}")
             return [False] * len_new
 
+        save_indices, prefix_write_count = parsed
         unmatched = len(save_indices)
 
         # Early return if all new blocks are already cached.
@@ -519,11 +520,13 @@ class HiCacheKVCM(HiCacheStorage):
                     logger.error(f"finish_write_cache failed: {e}")
             return [True] * len_new
 
-        assert unmatched == len(locations)
+        assert unmatched + prefix_write_count == len(locations)
 
         # Data transfer preparation and execution.
+        # Skip prefix locations — sglang cannot write prefix blocks.
         # Wrapped in try-except so that every rank always reaches the
         # all_reduce below, preventing cross-rank NCCL/gloo hangs.
+        new_locations = locations[prefix_write_count:]
         try:
             buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
             buffer_ptrs = [buffer_ptr for i, buffer_ptr in enumerate(buffer_ptrs) if (i // self.kv_factor) in save_indices]
@@ -531,7 +534,7 @@ class HiCacheKVCM(HiCacheStorage):
                 buffer_sizes) if (i // self.kv_factor) in save_indices]
 
             # Extract URIs and prepare buffers
-            uris = self._extract_uris(locations)
+            uris = self._extract_uris(new_locations)
             buffers = self._prepare_buffers(buffer_ptrs, buffer_sizes)
             assert len(uris) == len(buffers)
             # Perform data transfer
@@ -559,7 +562,7 @@ class HiCacheKVCM(HiCacheStorage):
             )
             flag = bool(flag_tensor.item())
 
-        finish_mask = [flag] * unmatched
+        finish_mask = [False] * prefix_write_count + [flag] * unmatched
         if self.tp_rank == 0:
             try:
                 self._manager_client.finish_write_cache(
@@ -660,9 +663,9 @@ class HiCacheKVCM(HiCacheStorage):
                 block_mask = write_result["block_mask"]
                 finish_trace_id = f"finish-v2-{trace_id}"
 
-                save_indices = self._parse_block_mask(block_mask, 0, len(keys))
+                parsed = self._parse_block_mask(block_mask, 0, len(keys))
 
-                if save_indices is None:
+                if parsed is None:
                     logger.warning(f"batch_set_v2: inconsistent block_mask from manager, "
                                    f"aborting write session {write_session_id}")
                     if self.tp_rank == 0:
@@ -678,6 +681,7 @@ class HiCacheKVCM(HiCacheStorage):
                     results[transfer.name] = [False] * len(keys)
                     continue
 
+                save_indices, _prefix_write_count = parsed
                 unmatched = len(save_indices)
 
                 if unmatched == 0:
@@ -923,24 +927,31 @@ class HiCacheKVCM(HiCacheStorage):
             buffers.append(buffer)
         return buffers
 
-    def _parse_block_mask(self, block_mask: dict, len_prefix: int, len_new: int) -> Optional[List[int]]:
+    def _parse_block_mask(self, block_mask: dict, len_prefix: int, len_new: int) -> Optional[tuple[List[int], int]]:
         """Parse block_mask from manager to determine which new-block indices need writing.
 
         Returns:
-            List[int]: indices (relative to new blocks) that need writing.
-                       Empty list means all new blocks are already cached.
-            None: manager returned an inconsistent state; caller should treat
-                  as a write failure (safe fallback).
+            tuple[List[int], int]:
+                - save_indices: indices (relative to new blocks) that need writing.
+                  Empty list means all new blocks are already cached.
+                - prefix_write_count: number of prefix blocks the manager wants
+                  written that we cannot fulfil (best-effort skip).
+            None: manager returned truly broken data (e.g. incomplete bool_masks);
+                  caller should treat as a total write failure.
         """
         save_indices = []
+        prefix_write_count = 0
         if "offset" in block_mask:
             offset = block_mask["offset"]
             if offset < len_prefix:
-                # Inconsistent: offset behind prefix boundary.
+                # Best-effort: prefix blocks [offset, len_prefix) can't be written
+                # by sglang (no data available), but new blocks can still proceed.
                 logger.warning(f"_parse_block_mask: offset {offset} < len_prefix {len_prefix}, "
-                               "treating as inconsistent state")
-                return None
-            save_indices.extend(range(offset, len_prefix + len_new))
+                               "prefix blocks will be skipped (best-effort)")
+                prefix_write_count = len_prefix - offset
+                save_indices.extend(range(len_prefix, len_prefix + len_new))
+            else:
+                save_indices.extend(range(offset, len_prefix + len_new))
         else:
             # False: need to store
             bool_masks = block_mask.get("bool_masks", {}).get("values", [])
@@ -949,15 +960,14 @@ class HiCacheKVCM(HiCacheStorage):
                 logger.warning(f"_parse_block_mask: bool_masks length {len(bool_masks)} < "
                                f"expected {len_prefix + len_new}, treating as inconsistent state")
                 return None
-            if not all(bool_masks[:len_prefix]):
-                # Inconsistent: prefix blocks not fully cached.
-                logger.warning("_parse_block_mask: prefix blocks not fully cached in bool_masks, "
-                               "treating as inconsistent state")
-                return None
+            prefix_write_count = sum(1 for v in bool_masks[:len_prefix] if not v)
+            if prefix_write_count > 0:
+                logger.warning(f"_parse_block_mask: {prefix_write_count} prefix blocks "
+                               "not cached in bool_masks, will be skipped (best-effort)")
             max_index = max([i for i, x in enumerate(bool_masks) if not x], default=-1)
             save_indices.extend([i for i in range(len_prefix, max_index + 1) if not bool_masks[i]])
         save_indices = [(i - len_prefix) for i in save_indices if i >= len_prefix]
-        return save_indices
+        return save_indices, prefix_write_count
 
     def _extract_single_spec_uri(self, location, spec_name: str):
         """Extract the URI for a named spec from a single location dict."""

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -700,7 +700,7 @@ class HiCacheKVCM(HiCacheStorage):
                     results[transfer.name] = [True] * len(keys)
                     continue
 
-                assert len(save_indices) == len(locations)
+                assert len(save_indices) + _prefix_write_count == len(locations)
 
                 # Data transfer preparation and execution.
                 # Wrapped in try-except so that every rank always reaches the

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -441,8 +441,7 @@ class HiCacheKVCM(HiCacheStorage):
         # Prepare keys
         block_keys, len_prefix, len_new = self._prepare_block_keys(keys, extra_info)
         local_len_new = len_new        # Preserve local key count for return value
-        local_len_prefix = len_prefix  # Preserve for divergence check
-        input_hash = hash((len_prefix, len_new, *block_keys))  # Hash covers prefix/new boundary + all keys
+        local_hash = hash((len_prefix, len_new, *block_keys))  # Hash covers prefix/new boundary + all keys
 
         # Start write cache
         if self.tp_rank == 0:
@@ -466,14 +465,14 @@ class HiCacheKVCM(HiCacheStorage):
 
             if self.tp_world_size > 1:
                 torch.distributed.broadcast_object_list(
-                    [result, len_prefix, len_new, input_hash], src=0, group=self.storage_tp_group
+                    [result, len_prefix, len_new, local_hash], src=0, group=self.storage_tp_group
                 )
         else:
             recv = [None, None, None, None]
             torch.distributed.broadcast_object_list(
                 recv, src=0, group=self.storage_tp_group
             )
-            result, len_prefix, len_new, input_hash = recv
+            result, len_prefix, len_new, rank0_hash = recv
 
         logger.debug(f"start_write_cache {result=}")
 
@@ -485,10 +484,9 @@ class HiCacheKVCM(HiCacheStorage):
         # storage. The rank still participates in all_reduce with all-zero
         # flags so NCCL doesn't hang.
         skip_transfer = False
-        local_hash = hash((local_len_prefix, local_len_new, *block_keys))
-        if local_hash != input_hash:
+        if self.tp_rank != 0 and local_hash != rank0_hash:
             logger.warning(f"_batch_set: local block_keys hash ({local_hash}) != "
-                           f"rank 0 hash ({input_hash}), inputs diverged across TP ranks. "
+                           f"rank 0 hash ({rank0_hash}), inputs diverged across TP ranks. "
                            f"local_block_keys={block_keys}")
             skip_transfer = True
 

--- a/kv_cache_manager/py_connector/sglang/test.py
+++ b/kv_cache_manager/py_connector/sglang/test.py
@@ -674,6 +674,37 @@ def _multi_rank_worker(rank, world_size, init_port):
     torch.distributed.barrier()
     logger.info(f"[Rank {rank}] MR-7 PASSED: prefix best-effort multi-rank")
 
+    # ------------------------------------------------------------------
+    # MR-8: Input divergence across ranks → both return all False
+    #   Rank 0 uses block hashes [30..33], rank 1 uses a completely
+    #   different set of hashes.  The broadcast delivers rank 0's hash;
+    #   rank 1 detects the mismatch (skip_transfer=True) and contributes
+    #   all-zero per-block flags.  After all_reduce(MIN), all flags are
+    #   zero on every rank → both return [False, False, False].
+    # ------------------------------------------------------------------
+    if rank == 0:
+        h8 = mr_hashes[30:33]
+    else:
+        # Generate hashes from a different token range so they differ
+        diverge_ids = list(range(90000, 90000 + 3 * page_size))
+        h8 = []
+        _h = None
+        for i in range(0, len(diverge_ids), page_size):
+            _h = get_hash_str(diverge_ids[i:i + page_size], _h)
+            h8.append(_h)
+
+    idx8 = mr_indices[30 * page_size:33 * page_size]  # 3 blocks
+
+    torch.distributed.barrier()
+    result = storage_backend.batch_set_v1(h8, torch.tensor(idx8))
+
+    assert len(result) == 3, f"MR-8 rank {rank}: expected 3 results, got {len(result)}"
+    assert all(r is False for r in result), \
+        f"MR-8 rank {rank}: expected all False (input diverged), got {result}"
+
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-8 PASSED: input divergence → all False")
+
     if debug_client:
         debug_client.close()
     logger.info(f"[Rank {rank}] All multi-rank tests passed!")

--- a/kv_cache_manager/py_connector/sglang/test.py
+++ b/kv_cache_manager/py_connector/sglang/test.py
@@ -612,6 +612,68 @@ def _multi_rank_worker(rank, world_size, init_port):
     torch.distributed.barrier()
     logger.info(f"[Rank {rank}] MR-5 PASSED: recovery")
 
+    # ------------------------------------------------------------------
+    # MR-6: Per-block best-effort across ranks
+    #   Rank 0 passes 5 blocks of host_indices, rank 1 passes only 3.
+    #   Both ranks pass the same 5 keys. Rank 1's get_page_buffer_meta
+    #   returns fewer entries → local_block_count=3 → only blocks [0,1,2]
+    #   written by rank 1. After all_reduce(MIN), blocks [3,4] are marked
+    #   failed on ALL ranks. Verifies no hang and correct per-block result.
+    # ------------------------------------------------------------------
+    h6 = mr_hashes[25:30]
+    if rank == 0:
+        idx6 = mr_indices[25 * page_size:30 * page_size]  # 5 blocks
+    else:
+        idx6 = mr_indices[25 * page_size:28 * page_size]  # 3 blocks
+
+    torch.distributed.barrier()
+    result = storage_backend.batch_set_v1(h6, torch.tensor(idx6))
+
+    # Both ranks should get [True, True, True, False, False]:
+    # blocks 0-2 succeeded on all ranks, blocks 3-4 only rank 0 had data
+    assert len(result) == 5, f"MR-6 rank {rank}: expected 5 results, got {len(result)}"
+    assert result[:3] == [True, True, True], \
+        f"MR-6 rank {rank}: first 3 blocks should be True, got {result[:3]}"
+    assert result[3:] == [False, False], \
+        f"MR-6 rank {rank}: last 2 blocks should be False, got {result[3:]}"
+
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-6 PASSED: per-block best-effort")
+
+    # ------------------------------------------------------------------
+    # MR-7: Prefix best-effort across ranks
+    #   Uses prefix_keys that were NEVER written → manager returns offset=0
+    #   which is < len_prefix → triggers prefix best-effort path.
+    #   Rank 0 passes full host_indices for new blocks (3 blocks).
+    #   Rank 1 passes fewer host_indices (2 blocks).
+    #   After all_reduce(MIN): blocks [0,1] succeed, block [2] fails.
+    #   Verifies prefix best-effort + per-block MIN in multi-rank.
+    # ------------------------------------------------------------------
+    prefix_keys_7 = mr_hashes[5:8]    # 3 blocks never written → not in cache
+    h7 = mr_hashes[8:11]              # 3 new blocks
+
+    if rank == 0:
+        idx7 = mr_indices[8 * page_size:11 * page_size]   # 3 blocks of data
+    else:
+        idx7 = mr_indices[8 * page_size:10 * page_size]   # 2 blocks of data
+
+    extra_info_7 = HiCacheStorageExtraInfo(prefix_keys=prefix_keys_7)
+
+    torch.distributed.barrier()
+    result = storage_backend.batch_set_v1(h7, torch.tensor(idx7), extra_info_7)
+
+    # Both ranks: len_prefix=3, offset=0 → prefix_write_count=3, save_indices=[0,1,2]
+    # Rank 0 writes blocks [0,1,2]; Rank 1 writes blocks [0,1] only.
+    # all_reduce(MIN) → [1,1,0]. Result for new keys: [True, True, False]
+    assert len(result) == 3, f"MR-7 rank {rank}: expected 3 results, got {len(result)}"
+    assert result[:2] == [True, True], \
+        f"MR-7 rank {rank}: first 2 blocks should be True, got {result[:2]}"
+    assert result[2] == False, \
+        f"MR-7 rank {rank}: last block should be False, got {result[2]}"
+
+    torch.distributed.barrier()
+    logger.info(f"[Rank {rank}] MR-7 PASSED: prefix best-effort multi-rank")
+
     if debug_client:
         debug_client.close()
     logger.info(f"[Rank {rank}] All multi-rank tests passed!")

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -630,5 +630,140 @@ class TestBatchSetReturnValue(unittest.TestCase):
         self.assertEqual(result, [False, False, False])
 
 
+class TestSkipTransfer(unittest.TestCase):
+    """Verify _batch_set returns all False when input diverges across TP ranks.
+
+    These tests simulate a non-rank-0 worker whose local block_keys differ
+    from rank 0's.  The broadcast delivers rank 0's result + hash, and the
+    hash mismatch sets skip_transfer = True.
+    """
+
+    @staticmethod
+    def _make_rank1_connector():
+        """Build a rank-1 connector (tp_world_size=2)."""
+        c = _build_connector(tp_rank=1, tp_world_size=2)
+        c.storage_tp_group = MagicMock()
+        return c
+
+    @staticmethod
+    def _broadcast_side_effect(result, len_prefix, len_new, input_hash):
+        """Return a side_effect that fills the recv list with rank 0's data."""
+        def _side_effect(tensor_list, src, group):
+            tensor_list[0] = result
+            tensor_list[1] = len_prefix
+            tensor_list[2] = len_new
+            tensor_list[3] = input_hash
+        return _side_effect
+
+    @staticmethod
+    def _rank0_hash(keys_raw, len_prefix, len_new):
+        """Compute the hash rank 0 would broadcast for the given raw keys."""
+        c_tmp = _build_connector()
+        int_keys = [c_tmp._sha256_to_int64(k) for k in keys_raw]
+        return hash((len_prefix, len_new, *int_keys))
+
+    # ── Case 19: skip_transfer + unmatched == 0 → all False ──────────
+    def test_skip_transfer_all_cached(self):
+        """Input diverges but all blocks cached (unmatched==0) → all False."""
+        c = self._make_rank1_connector()
+
+        # Rank 1's local keys (different from rank 0's)
+        local_keys = ["local_k0", "local_k1", "local_k2"]
+
+        # Rank 0 had different keys, all cached
+        rank0_len_prefix, rank0_len_new = 0, 3
+        rank0_hash = self._rank0_hash(
+            ["rank0_k0", "rank0_k1", "rank0_k2"],
+            rank0_len_prefix, rank0_len_new,
+        )
+        rank0_result = {
+            "locations": [],
+            "write_session_id": "ws-19",
+            "block_mask": {"offset": 3},  # all cached
+        }
+
+        bcast = self._broadcast_side_effect(
+            rank0_result, rank0_len_prefix, rank0_len_new, rank0_hash,
+        )
+        with patch("torch.distributed.broadcast_object_list", side_effect=bcast):
+            result = c._batch_set(local_keys, torch.zeros(3), trace_id="t19")
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result, [False, False, False])
+
+    # ── Case 20: skip_transfer + unmatched > 0 → all False ───────────
+    def test_skip_transfer_partial_write(self):
+        """Input diverges, some blocks need writing → all False."""
+        c = self._make_rank1_connector()
+
+        local_keys = ["local_k0", "local_k1", "local_k2", "local_k3"]
+
+        # Rank 0 had different keys, first 2 cached, last 2 need writing
+        rank0_len_prefix, rank0_len_new = 0, 4
+        rank0_hash = self._rank0_hash(
+            ["rank0_k0", "rank0_k1", "rank0_k2", "rank0_k3"],
+            rank0_len_prefix, rank0_len_new,
+        )
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(2)
+        ]
+        rank0_result = {
+            "locations": locations,
+            "write_session_id": "ws-20",
+            "block_mask": {"offset": 2},  # indices [2,3] need writing
+        }
+
+        bcast = self._broadcast_side_effect(
+            rank0_result, rank0_len_prefix, rank0_len_new, rank0_hash,
+        )
+
+        # all_reduce is a no-op (keeps all-zero flags)
+        with patch("torch.distributed.broadcast_object_list", side_effect=bcast), \
+             patch("torch.distributed.all_reduce"):
+            result = c._batch_set(local_keys, torch.zeros(4), trace_id="t20")
+
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result, [False, False, False, False])
+
+    # ── Case 21: skip_transfer + prefix + unmatched > 0 → all False ──
+    def test_skip_transfer_with_prefix(self):
+        """Input diverges (including prefix), blocks need writing → all False."""
+        c = self._make_rank1_connector()
+
+        local_keys = ["local_k3", "local_k4", "local_k5"]
+        local_extra = MagicMock()
+        local_extra.prefix_keys = ["local_p0", "local_p1", "local_p2"]
+
+        # Rank 0 had different prefix+keys
+        rank0_len_prefix, rank0_len_new = 3, 3
+        rank0_hash = self._rank0_hash(
+            ["rank0_p0", "rank0_p1", "rank0_p2", "rank0_k3", "rank0_k4", "rank0_k5"],
+            rank0_len_prefix, rank0_len_new,
+        )
+        # offset=1 < len_prefix=3 → prefix best-effort path, all 5 blocks in locations
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(5)
+        ]
+        rank0_result = {
+            "locations": locations,
+            "write_session_id": "ws-21",
+            "block_mask": {"offset": 1},
+        }
+
+        bcast = self._broadcast_side_effect(
+            rank0_result, rank0_len_prefix, rank0_len_new, rank0_hash,
+        )
+
+        with patch("torch.distributed.broadcast_object_list", side_effect=bcast), \
+             patch("torch.distributed.all_reduce"):
+            result = c._batch_set(local_keys, torch.zeros(3), trace_id="t21",
+                                  extra_info=local_extra)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result, [False, False, False])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -477,7 +477,149 @@ class TestBatchSetReturnValue(unittest.TestCase):
         self.assertEqual(len(result), len(keys))
         self.assertEqual(result, [False, False])
 
-    # ── Case 15: batch_set_v1 exception returns all False ─────────────
+    # ── Case 15: per-block best-effort with partial local data ─────────
+    def test_per_block_best_effort_partial_local_data(self):
+        """When local rank has fewer blocks than save_indices expects,
+        only blocks with local data are written; others return False."""
+        keys = ["k0", "k1", "k2", "k3", "k4"]
+
+        # All 5 keys need writing (offset=0), 5 locations
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(5)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-15",
+            "block_mask": {"offset": 0},
+        }
+        c = _build_connector()
+        c._manager_client.start_write_cache.return_value = result_from_manager
+
+        # Only 3 blocks worth of buffer data (kv_factor=2, so 6 entries)
+        # This simulates a rank that has fewer local blocks available.
+        # local_block_count = 6 // 2 = 3, so only save_indices [0,1,2] are valid.
+        c.mem_pool_host.get_page_buffer_meta.return_value = (
+            list(range(6)),           # 6 ptrs → 3 blocks
+            [c.location_spec_size] * 6,
+        )
+
+        # SaveKvCaches succeeds for the 3 valid blocks
+        c.transfer_client.SaveKvCaches.return_value = (
+            _mock_kvcm.ClientErrorCode.ER_OK,
+        )
+
+        result = c._batch_set(keys, torch.zeros(5), trace_id="t15")
+
+        self.assertEqual(len(result), len(keys))
+        # Blocks 0,1,2 have local data → True; blocks 3,4 do not → False
+        self.assertEqual(result, [True, True, True, False, False])
+
+        # Verify SaveKvCaches was called with only 3 URIs (valid blocks)
+        save_call_args = c.transfer_client.SaveKvCaches.call_args[0]
+        uris_arg = save_call_args[0]
+        self.assertEqual(len(uris_arg), 3)
+
+        # Verify finish_write_cache mask reflects per-block success
+        call_args = c._manager_client.finish_write_cache.call_args[0][0]
+        finish_mask = call_args["success_blocks"]["bool_masks"]["values"]
+        self.assertEqual(finish_mask, [True, True, True, False, False])
+
+    # ── Case 16: per-block best-effort, transfer fails for valid blocks ─
+    def test_per_block_best_effort_transfer_fails(self):
+        """When local rank has partial data but transfer fails, all return False."""
+        keys = ["k0", "k1", "k2", "k3"]
+
+        # All 4 keys need writing (offset=0)
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(4)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-16",
+            "block_mask": {"offset": 0},
+        }
+        c = _build_connector()
+        c._manager_client.start_write_cache.return_value = result_from_manager
+
+        # Only 2 blocks of local data (kv_factor=2, so 4 entries)
+        # local_block_count = 4 // 2 = 2, save_indices [0,1] valid, [2,3] invalid
+        c.mem_pool_host.get_page_buffer_meta.return_value = (
+            list(range(4)),
+            [c.location_spec_size] * 4,
+        )
+
+        # SaveKvCaches FAILS
+        c.transfer_client.SaveKvCaches.return_value = (999,)
+
+        result = c._batch_set(keys, torch.zeros(4), trace_id="t16")
+
+        self.assertEqual(len(result), len(keys))
+        # Blocks 0,1 had local data but transfer failed → False
+        # Blocks 2,3 had no local data → False
+        self.assertEqual(result, [False, False, False, False])
+
+        # Verify finish_write_cache: all False
+        call_args = c._manager_client.finish_write_cache.call_args[0][0]
+        finish_mask = call_args["success_blocks"]["bool_masks"]["values"]
+        self.assertEqual(finish_mask, [False, False, False, False])
+
+    # ── Case 17: per-block best-effort with prefix + partial local data ─
+    def test_per_block_best_effort_prefix_plus_partial(self):
+        """Prefix blocks skipped AND local rank has partial data for new blocks."""
+        keys = ["k2", "k3", "k4", "k5"]
+
+        # prefix_keys = ["p0", "p1"], len_prefix=2
+        # offset=1 → blocks [1..5] need writing:
+        #   p1 (prefix, can't write) + k2, k3, k4, k5 (new, can write)
+        # prefix_write_count=1, save_indices=[0,1,2,3]
+        # locations: 5 entries (1 prefix + 4 new)
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(5)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-17",
+            "block_mask": {"offset": 1},
+        }
+        c = _build_connector()
+        c._manager_client.start_write_cache.return_value = result_from_manager
+
+        # Only 2 blocks of local data (kv_factor=2, so 4 entries)
+        # local_block_count = 4 // 2 = 2
+        # save_indices = [0,1,2,3], valid: [0<2, 1<2, 2<2, 3<2] = [T, T, F, F]
+        c.mem_pool_host.get_page_buffer_meta.return_value = (
+            list(range(4)),
+            [c.location_spec_size] * 4,
+        )
+
+        # SaveKvCaches succeeds for the 2 valid blocks
+        c.transfer_client.SaveKvCaches.return_value = (
+            _mock_kvcm.ClientErrorCode.ER_OK,
+        )
+
+        extra_info = MagicMock()
+        extra_info.prefix_keys = ["p0", "p1"]
+
+        result = c._batch_set(keys, torch.zeros(4), trace_id="t17",
+                              extra_info=extra_info)
+
+        self.assertEqual(len(result), len(keys))
+        # k2(idx0): local data + success → True
+        # k3(idx1): local data + success → True
+        # k4(idx2): no local data → False
+        # k5(idx3): no local data → False
+        self.assertEqual(result, [True, True, False, False])
+
+        # Verify finish_write_cache: prefix=False, block0=True, block1=True,
+        # block2=False, block3=False
+        call_args = c._manager_client.finish_write_cache.call_args[0][0]
+        finish_mask = call_args["success_blocks"]["bool_masks"]["values"]
+        self.assertEqual(finish_mask, [False, True, True, False, False])
+
+    # ── Case 18: batch_set_v1 exception returns all False ─────────────
     def test_batch_set_v1_exception(self):
         """batch_set_v1 catches exceptions and returns all False."""
         c = _build_connector()

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -20,6 +20,12 @@ _mock_kvcm.ClientErrorCode.ER_OK = 0
 _mock_pybind.kvcm_py_client = _mock_kvcm
 sys.modules["kv_cache_manager.client.pybind"] = _mock_pybind
 
+_mock_version = types.ModuleType("kv_cache_manager.py_connector.common._version_info")
+_mock_version.FULL_VERSION = "0.0.0-test"
+_mock_version.GIT_COMMIT = "test"
+_mock_version.BUILD_TIME = "test"
+sys.modules.setdefault("kv_cache_manager.py_connector.common._version_info", _mock_version)
+
 from kv_cache_manager.py_connector.sglang.connector import HiCacheKVCM  # noqa: E402
 
 
@@ -45,6 +51,9 @@ def _build_connector(*, tp_rank=0, tp_world_size=1, kv_factor=2,
     obj._manager_client = MagicMock()
     obj.transfer_client = MagicMock()
     obj.mem_pool_host = MagicMock()
+    obj.has_mamba = False
+    obj.has_indexer = False
+    obj.registered_pools = {}
     return obj
 
 
@@ -275,19 +284,27 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # index 4 → write failed (False)
         self.assertEqual(result, [False, True, False, True, False])
 
-    # ── Case 9: inconsistent offset (offset < len_prefix) → all False ─
-    def test_inconsistent_offset_returns_all_false(self):
-        """When offset < len_prefix, manager state is inconsistent → all False."""
+    # ── Case 9: offset behind prefix → best-effort write succeeds ───
+    def test_offset_behind_prefix_best_effort_success(self):
+        """When offset < len_prefix, skip prefix blocks and write new blocks."""
         keys = ["k3", "k4", "k5"]
 
         # prefix_keys = ["p0", "p1", "p2"], len_prefix=3
-        # offset=1 < len_prefix=3 → inconsistent
+        # offset=1 → blocks [1..5] need writing:
+        #   p1, p2 (prefix, can't write) + k3, k4, k5 (new, can write)
+        # prefix_write_count=2, save_indices=[0,1,2]
+        # locations: 5 entries (2 prefix + 3 new)
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(5)
+        ]
         result_from_manager = {
-            "locations": [],
+            "locations": locations,
             "write_session_id": "ws-9",
             "block_mask": {"offset": 1},
         }
-        c = self._setup_connector(start_write_result=result_from_manager)
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=True)
 
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1", "p2"]
@@ -296,21 +313,107 @@ class TestBatchSetReturnValue(unittest.TestCase):
                               extra_info=extra_info)
 
         self.assertEqual(len(result), len(keys))
+        # All new blocks written successfully
+        self.assertEqual(result, [True, True, True])
+
+        # Verify finish_write_cache was called with prefix blocks marked as failed
+        call_args = c._manager_client.finish_write_cache.call_args[0][0]
+        finish_mask = call_args["success_blocks"]["bool_masks"]["values"]
+        # First 2 entries (prefix) = False, last 3 (new) = True
+        self.assertEqual(finish_mask, [False, False, True, True, True])
+
+    # ── Case 10: offset behind prefix → best-effort write fails ───
+    def test_offset_behind_prefix_best_effort_failure(self):
+        """When offset < len_prefix, skip prefix; new blocks fail → all False."""
+        keys = ["k3", "k4", "k5"]
+
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(5)
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-10",
+            "block_mask": {"offset": 1},
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=False)
+
+        extra_info = MagicMock()
+        extra_info.prefix_keys = ["p0", "p1", "p2"]
+
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t10",
+                              extra_info=extra_info)
+
+        self.assertEqual(len(result), len(keys))
+        # New blocks write failed
         self.assertEqual(result, [False, False, False])
 
-    # ── Case 10: inconsistent bool_masks (prefix not cached) → all False
-    def test_inconsistent_bool_masks_returns_all_false(self):
-        """When prefix blocks not fully cached in bool_masks → all False."""
+        # Verify finish_write_cache: prefix=False, new=False
+        call_args = c._manager_client.finish_write_cache.call_args[0][0]
+        finish_mask = call_args["success_blocks"]["bool_masks"]["values"]
+        self.assertEqual(finish_mask, [False, False, False, False, False])
+
+    # ── Case 11: bool_masks prefix not cached → best-effort succeeds ─
+    def test_bool_masks_prefix_not_cached_best_effort(self):
+        """When prefix blocks not fully cached in bool_masks, write new blocks."""
         keys = ["k2", "k3", "k4"]
 
         # prefix_keys = ["p0", "p1"], len_prefix=2
-        # bool_masks[:2] = [True, False] → not all True → inconsistent
+        # bool_masks: [True, False, False, True, False]
+        #   p0:True p1:False(prefix,skip) k2:False(write) k3:True(cached) k4:False(write)
+        # prefix_write_count=1, save_indices=[0,2] (k2 and k4)
+        # locations: 3 entries (1 prefix + 2 new)
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
+            for i in range(3)
+        ]
         result_from_manager = {
-            "locations": [],
-            "write_session_id": "ws-10",
+            "locations": locations,
+            "write_session_id": "ws-11",
             "block_mask": {
                 "bool_masks": {
                     "values": [True, False, False, True, False]
+                }
+            },
+        }
+        c = self._setup_connector(start_write_result=result_from_manager,
+                                  save_ok=True)
+
+        extra_info = MagicMock()
+        extra_info.prefix_keys = ["p0", "p1"]
+
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t11",
+                              extra_info=extra_info)
+
+        self.assertEqual(len(result), len(keys))
+        # k2: write succeeded, k3: cached, k4: write succeeded
+        self.assertEqual(result, [True, True, True])
+
+        # Verify finish_write_cache: prefix p1=False, k2=True, k4=True
+        call_args = c._manager_client.finish_write_cache.call_args[0][0]
+        finish_mask = call_args["success_blocks"]["bool_masks"]["values"]
+        self.assertEqual(finish_mask, [False, True, True])
+
+    # ── Case 12: all new cached but prefix needs write → all True ────
+    def test_all_new_cached_but_prefix_needs_write(self):
+        """All new blocks cached, only prefix needs writing → return all True."""
+        keys = ["k2", "k3"]
+
+        # prefix_keys = ["p0", "p1"], len_prefix=2
+        # bool_masks: [True, False, True, True]
+        #   p0:True p1:False(prefix,skip) k2:True(cached) k3:True(cached)
+        # prefix_write_count=1, save_indices=[] (all new cached)
+        # locations: 1 entry (for p1 only)
+        locations = [
+            {"location_specs": [{"name": "tp_0", "uri": "uri_0"}]}
+        ]
+        result_from_manager = {
+            "locations": locations,
+            "write_session_id": "ws-12",
+            "block_mask": {
+                "bool_masks": {
+                    "values": [True, False, True, True]
                 }
             },
         }
@@ -319,13 +422,19 @@ class TestBatchSetReturnValue(unittest.TestCase):
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1"]
 
-        result = c._batch_set(keys, torch.zeros(3), trace_id="t10",
+        result = c._batch_set(keys, torch.zeros(2), trace_id="t12",
                               extra_info=extra_info)
 
         self.assertEqual(len(result), len(keys))
-        self.assertEqual(result, [False, False, False])
+        # All new blocks are cached → True
+        self.assertEqual(result, [True, True])
 
-    # ── Case 11: incomplete bool_masks (shorter than expected) → all False
+        # Verify finish_write_cache marks prefix location as failed
+        call_args = c._manager_client.finish_write_cache.call_args[0][0]
+        finish_mask = call_args["success_blocks"]["bool_masks"]["values"]
+        self.assertEqual(finish_mask, [False])
+
+    # ── Case 13: incomplete bool_masks (shorter than expected) → all False
     def test_incomplete_bool_masks_returns_all_false(self):
         """When bool_masks is shorter than len_prefix + len_new → all False."""
         keys = ["k0", "k1", "k2"]
@@ -333,7 +442,7 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # 3 keys, no prefix → expected bool_masks length = 3, but only 1 given
         result_from_manager = {
             "locations": [],
-            "write_session_id": "ws-11",
+            "write_session_id": "ws-13",
             "block_mask": {
                 "bool_masks": {
                     "values": [True]
@@ -342,19 +451,19 @@ class TestBatchSetReturnValue(unittest.TestCase):
         }
         c = self._setup_connector(start_write_result=result_from_manager)
 
-        result = c._batch_set(keys, torch.zeros(3), trace_id="t11")
+        result = c._batch_set(keys, torch.zeros(3), trace_id="t13")
 
         self.assertEqual(len(result), len(keys))
         self.assertEqual(result, [False, False, False])
 
-    # ── Case 12: empty bool_masks → all False ────────────────────────
+    # ── Case 14: empty bool_masks → all False ────────────────────────
     def test_empty_bool_masks_returns_all_false(self):
         """When bool_masks is empty → all False (all([]) would be True)."""
         keys = ["k0", "k1"]
 
         result_from_manager = {
             "locations": [],
-            "write_session_id": "ws-12",
+            "write_session_id": "ws-14",
             "block_mask": {
                 "bool_masks": {
                     "values": []
@@ -363,12 +472,12 @@ class TestBatchSetReturnValue(unittest.TestCase):
         }
         c = self._setup_connector(start_write_result=result_from_manager)
 
-        result = c._batch_set(keys, torch.zeros(2), trace_id="t12")
+        result = c._batch_set(keys, torch.zeros(2), trace_id="t14")
 
         self.assertEqual(len(result), len(keys))
         self.assertEqual(result, [False, False])
 
-    # ── Case 13: batch_set_v1 exception returns all False ─────────────
+    # ── Case 15: batch_set_v1 exception returns all False ─────────────
     def test_batch_set_v1_exception(self):
         """batch_set_v1 catches exceptions and returns all False."""
         c = _build_connector()


### PR DESCRIPTION
## Summary
- 当 Manager 的 `block_mask` 表明某些 prefix blocks 未被缓存需要写入时，sglang 因为没有 prefix blocks 的数据无法满足。之前 `_parse_block_mask` 直接返回 `None`，导致整个 batch 全部返回 `[False]*len_new`，所有 new blocks 都不写了。
- 现在改为 best-effort：跳过无法写入的 prefix locations，仍然写入能写的 new blocks，在 `finish_write_cache` 中将 prefix blocks 标记为失败。返回值正确反映 new blocks 的实际写入结果。
- 更新测试用例覆盖 offset 和 bool_masks 两种 prefix 降级场景，并修复测试 mock 缺少的 `has_mamba`/`has_indexer`/`_version_info` 属性。

## Test plan
- [x] 15 个单元测试全部通过（`python3 -m unittest kv_cache_manager.py_connector.test.test_batch_set_return -v`）
- [ ] 集成环境验证 prefix 降级场景下 new blocks 正常写入

	🤖 Generated with [Qoder][https://qoder.com]