### PR TITLE
[test] add e2e test cases for aggressive location pruning

### DIFF
--- a/integration_test/reclaimer/BUILD
+++ b/integration_test/reclaimer/BUILD
@@ -1,6 +1,20 @@
 package(default_visibility = ["//integration_test/reclaimer:__subpackages__"])
 
 py_test(
+    name = "location_pruning_test",
+    srcs = ["location_pruning_test.py"],
+    tags = ["no-remote-exec"],
+    data = [
+        "//kv_cache_manager:kv_cache_manager_bin",
+    ],
+    deps = [
+        "//integration_test/testlib:test_base",
+        "//integration_test/admin_service:http_interface_test",
+        "//integration_test/meta_service:http_interface_test",
+    ],
+)
+
+py_test(
     name = "reclaiming_test",
     srcs = ["reclaiming_test.py"],
     tags = ["no-remote-exec"],

--- a/integration_test/reclaimer/location_pruning_test.py
+++ b/integration_test/reclaimer/location_pruning_test.py
@@ -1,0 +1,381 @@
+# -*- coding: utf-8 -*-
+
+
+import abc
+import logging
+import os
+import os.path
+import time
+import unittest
+
+from urllib.parse import urlparse
+
+from integration_test.admin_service.http_interface_test import \
+    AdminServiceHttpClient
+from integration_test.meta_service.http_interface_test import \
+    MetaServiceHttpClient
+from integration_test.testlib.test_base import TestBase
+
+
+class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
+    """Various location pruning policy tests"""
+
+    def setUp(self):
+        self.init_default()
+        self._admin_client, self._client = self._get_manager_client()
+        self._trace_id = "loc_pruning_itest_trace_id"
+        self._storage_name = "test_storage_01"
+        self._instance_group_name = "test_group_01"
+        self._instance_id = "test_instance_01"
+        self._model_name = "test_model"
+        self._resp_dict = dict()
+
+    def tearDown(self):
+        self._admin_client.close()
+        self._client.close()
+        self.cleanup()
+
+    def test_aggressive_location_prune_contiguous(self):
+        """Verify aggressive prune on a contiguous suffix.
+
+        When the underlying data for some cache blocks becomes
+        unavailable (MightExist() returns false), the aggressive prune
+        policy should clean ALL invalid locations in a single query or
+        write pass -- rather than only pruning the first invalid one and
+        requiring O(N) round-trips.
+
+        Scenario (prefix = A B C D E, data for B C D E lost):
+        1. Write A B C D E, confirm all 5 queryable.
+        2. Delete the data files backing B C D E.
+        3. Prefix-match query returns only [A].
+           (aggressive: B C D E pruned in one pass)
+        4. Re-write succeeds for all of B C D E in one pass.
+        5. Prefix-match query returns [A B C D E] again.
+        """
+
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance()
+
+        # ---------- step 1: write blocks A B C D E --------------------
+        block_keys = [100, 101, 102, 103, 104]
+        token_ids = [200, 201, 202, 203, 204]
+        locations = self._write_blocks(block_keys, token_ids)
+        self.assertEqual(len(locations), 5,
+                         "initial write should allocate 5 locations")
+
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(
+            len(resp["locations"]), 5,
+            "all 5 blocks should be queryable after initial write")
+
+        # ---------- step 2: simulate data loss for B C D E ------------
+        self._delete_location_files(locations, range(1, 5))
+
+        # ---------- step 3: prefix-match query ------------------------
+        resp = self._prefix_query(block_keys)
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 1,
+                         "only block A should be returned; "
+                         f"got {len(locations)} locations")
+
+        # --------- step 4: wait for the async metadata prune ----------
+        time.sleep(2)
+
+        # --------- step 5: re-write the full chain --------------------
+        # A still valid; B C D E need writing
+        resp = self._start_write_blocks(block_keys, token_ids)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 4,
+                         "re-write should allocate 4 locations for B C D E; "
+                         f"got {len(locations)} locations")
+        self._verify_block_keys(locations,
+                                [block_keys[i] for i in (1, 2, 3, 4,)])
+        self._finish_write_blocks(write_session_id, 4)
+
+        # --------- step 6: verify full recovery -----------------------
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after re-write")
+
+    def test_aggressive_location_prune_non_contiguous(self):
+        """Verify aggressive prune with non-contiguous data loss.
+
+        When stale blocks are interleaved with valid ones (e.g., B and D
+        lost while A, C, E intact), the write path should produce a
+        BlockMaskVector (non-contiguous bitmap) rather than a simple
+        BlockMaskOffset, and allocate locations only for the stale
+        blocks.
+
+        Scenario (prefix = A B C D E, data for B and D lost):
+        1. Write A B C D E, confirm all 5 queryable.
+        2. Delete the data files backing B and D only.
+        3. Prefix-match query returns only [A] (prefix truncated
+           at the first stale block).
+        4. Re-write allocates exactly 2 locations (for B and D).
+        5. Prefix-match query returns [A B C D E] again.
+        """
+
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance()
+
+        # ---------- step 1: write blocks A B C D E --------------------
+        block_keys = [200, 201, 202, 203, 204]
+        token_ids = [300, 301, 302, 303, 304]
+        locations = self._write_blocks(block_keys, token_ids)
+        self.assertEqual(len(locations), 5,
+                         "initial write should allocate 5 locations")
+
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(
+            len(resp["locations"]), 5,
+            "all 5 blocks should be queryable after initial write")
+
+        # ---------- step 2: simulate data loss for B and D ------------
+        self._delete_location_files(locations, [1, 3])
+
+        # ---------- step 3: prefix-match query ------------------------
+        resp = self._prefix_query(block_keys)
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 1,
+                         "only block A should be returned; "
+                         f"got {len(locations)} locations")
+
+        # --------- step 4: wait for the async metadata prune ----------
+        time.sleep(2)
+
+        # --------- step 5: re-write the full chain --------------------
+        # A, C, E still valid; B and D need writing
+        resp = self._start_write_blocks(block_keys, token_ids)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 2,
+                         "re-write should allocate 2 locations for B and D; "
+                         f"got {len(locations)} locations")
+        self._verify_block_keys(locations, [block_keys[i] for i in (1, 3,)])
+        self._finish_write_blocks(write_session_id, 2)
+
+        # --------- step 6: verify full recovery -----------------------
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after re-write")
+
+    def test_aggressive_location_prune_all_missing(self):
+        """Verify aggressive prune when all blocks are missing.
+
+        Scenario (prefix = A B C D E, all data lost):
+        1. Write A B C D E, confirm all 3 queryable.
+        2. Delete data files for all 3 blocks.
+        3. Prefix-match query returns empty result.
+        4. Re-write allocates 3 fresh locations.
+        5. Prefix-match query returns [A B C D E] again.
+        """
+
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance()
+
+        # --------- step 1: write blocks A B C -------------------------
+        block_keys = [300, 301, 302, 303, 304]
+        token_ids = [400, 401, 402, 403, 404]
+        first_locations = self._write_blocks(block_keys, token_ids)
+        self.assertEqual(len(first_locations), 5,
+                         "initial write should allocate 5 locations")
+
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after initial write")
+
+        # --------- step 2: simulate data loss for A B C D E -----------
+        self._delete_location_files(first_locations, range(0, 5))
+
+        # --------- step 3: prefix-match query -------------------------
+        resp = self._prefix_query(block_keys)
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 0,
+                         "no blocks should be returned when all data is lost; "
+                         f"got {len(locations)} locations")
+
+        # --------- step 4: wait for async metadata prune --------------
+        time.sleep(2)
+
+        # --------- step 5: re-write all blocks ------------------------
+        resp = self._start_write_blocks(block_keys, token_ids)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 5,
+                         "re-write should allocate 5 locations for A B C D E; "
+                         f"got {len(locations)} locations")
+        self._verify_block_keys(locations, block_keys)
+        self._finish_write_blocks(write_session_id, 5)
+
+        # --------- step 6: verify full recovery -----------------------
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after re-write")
+
+    def _get_manager_client(self):
+        worker = self.worker_manager.get_worker(0)
+        self._admin_http_port = worker.env.admin_http_port
+        self._admin_http_url = f"http://localhost:{self._admin_http_port}"
+        self._http_port = worker.env.http_port
+        self._http_url = f"http://localhost:{self._http_port}"
+        logging.info(f"admin http url: {self._admin_http_url}, "
+                     f"http url: {self._http_url}")
+        return (
+            AdminServiceHttpClient(self._admin_http_url),
+            MetaServiceHttpClient(self._http_url),
+        )
+
+    def _write_blocks(self, block_keys, token_ids):
+        resp = self._start_write_blocks(block_keys, token_ids)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self._finish_write_blocks(write_session_id, len(locations))
+        return locations
+
+    def _start_write_blocks(self, blk_keys, token_ids):
+        return self._client.start_write_cache({
+            "trace_id": self._trace_id,
+            "instance_id": self._instance_id,
+            "block_keys": blk_keys,
+            "token_ids": token_ids,
+            "write_timeout_seconds": 30,
+        })
+
+    def _finish_write_blocks(self, write_session_id, loc_sz):
+        return self._client.finish_write_cache({
+            "trace_id": self._trace_id,
+            "instance_id": self._instance_id,
+            "write_session_id": write_session_id,
+            "success_blocks": {
+                "bool_masks": {"values": [True] * loc_sz},
+            },
+        })
+
+    def _prefix_query(self, block_keys):
+        return self._client.get_cache_location({
+            "trace_id": self._trace_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_keys": block_keys,
+            "instance_id": self._instance_id,
+            "block_mask": {"offset": 0},
+        })
+
+    def _delete_location_files(self, locations, indices):
+        for i in indices:
+            loc = locations[i]
+            for spec in loc.get("location_specs", []):
+                file_path = urlparse(spec["uri"]).path
+                self.assertTrue(
+                    os.path.exists(file_path),
+                    f"Data file should exist before deletion: "
+                    f"{file_path}")
+                os.remove(file_path)
+
+    def _verify_block_keys(self, locations, block_keys):
+        self.assertEqual(len(locations), len(block_keys))
+        for (loc, key) in zip(locations, block_keys):
+            for spec in loc.get("location_specs", []):
+                file_path = urlparse(spec["uri"]).path
+                self.assertEqual(int(os.path.basename(file_path), base=16), key)
+
+    def _make_dummy_storage(self):
+        # TODO: use dummy storage backend instead of hf3fs
+        hf3fs_mountpoint = f"{self.get_workdir()}/{self._storage_name}/"
+        os.makedirs(hf3fs_mountpoint, exist_ok=True)
+        add_storage_req = {
+            "trace_id": self._trace_id + "-add_storage",
+            "storage": {
+                "global_unique_name": self._storage_name,
+                "threefs": {
+                    "mountpoint": hf3fs_mountpoint,
+                    "root_dir": "data/",
+                    "key_count_per_file": 1,
+                    "touch_file_when_create": True,
+                }
+            },
+        }
+        self._admin_client.add_storage(add_storage_req)
+
+    def _make_dummy_instance_group(self):
+        create_ig_req = {
+            "trace_id": self._trace_id + "-add_instance_group",
+            "instance_group": {
+                "name": self._instance_group_name,
+                "storage_candidates": [
+                    self._storage_name,
+                ],
+                "global_quota_group_name": "quota_group_test",
+                "max_instance_count": 8,
+                "quota": {
+                    "capacity": 1024 * 32,
+                    "quota_config": [
+                        # StorageType.ST_TAIRMEMPOOL=3
+                        {"storage_type": 3, "capacity": 1024 * 16},
+                        # StorageType.ST_NFS=4
+                        {"storage_type": 4, "capacity": 1024 * 16},
+                    ],
+                },
+                "cache_config": {
+                    "reclaim_strategy": {
+                        "storage_unique_name": self._storage_name,
+                        "reclaim_policy": 1,  # POLICY_LRU
+                        "trigger_strategy": {
+                            # make sure not trigger by percentage
+                            "used_percentage": 3.2,
+                        },
+                        "delay_before_delete_ms": 100,
+                    },
+                    "data_storage_strategy": 2,  # CPS_PREFER_3FS
+                    "meta_indexer_config": {
+                        "max_key_count": 16,  # start with 16 max key
+                        "mutex_shard_num": 16,
+                        "meta_storage_backend_config": {
+                            "storage_type": "dummy",
+                            "storage_uri": f"file://{self.get_workdir()}/meta_storage_{self._instance_group_name}",
+                        },
+                        "meta_cache_policy_config": {
+                            "capacity": 1024 * 1024 * 1024,
+                            "type": "LRU",
+                        },
+                        "persist_metadata_interval_time_ms": 0,
+                    }
+                },
+                "user_data": "user-defined info",
+                "version": 1,
+            },
+        }
+        self._admin_client.create_instance_group(create_ig_req)
+
+    def _make_dummy_instance(self):
+        reg_ins_req = {
+            "trace_id": self._trace_id + "-add_instance",
+            "instance_group": self._instance_group_name,
+            "instance_id": self._instance_id,
+            "block_size": 128,
+            "model_deployment": self._make_dummy_model_deployment(),
+            "location_spec_infos": [
+                {
+                    "name": "tp0",
+                    "size": 1024,
+                },
+            ],
+        }
+        self._client.register_instance(reg_ins_req)
+
+    def _make_dummy_model_deployment(self):
+        return {
+            "model_name": self._model_name,
+            "dtype": "FP8",
+            "use_mla": False,
+            "tp_size": 1,
+            "dp_size": 1,
+            "pp_size": 1,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration_test/reclaimer/location_pruning_test.py
+++ b/integration_test/reclaimer/location_pruning_test.py
@@ -283,18 +283,15 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                 self.assertEqual(int(os.path.basename(file_path), base=16), key)
 
     def _make_dummy_storage(self):
-        # TODO: use dummy storage backend instead of hf3fs
-        hf3fs_mountpoint = f"{self.get_workdir()}/{self._storage_name}/"
-        os.makedirs(hf3fs_mountpoint, exist_ok=True)
+        dummy_root_path = f"{self.get_workdir()}/{self._storage_name}/data/"
+        os.makedirs(dummy_root_path, exist_ok=True)
         add_storage_req = {
             "trace_id": self._trace_id + "-add_storage",
             "storage": {
                 "global_unique_name": self._storage_name,
-                "threefs": {
-                    "mountpoint": hf3fs_mountpoint,
-                    "root_dir": "data/",
+                "local": {
+                    "root_path": dummy_root_path,
                     "key_count_per_file": 1,
-                    "touch_file_when_create": True,
                 }
             },
         }

--- a/integration_test/reclaimer/location_pruning_test.py
+++ b/integration_test/reclaimer/location_pruning_test.py
@@ -70,7 +70,7 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
             "all 5 blocks should be queryable after initial write")
 
         # ---------- step 2: simulate data loss for B C D E ------------
-        self._delete_location_files(locations, range(1, 5))
+        LocationPruningTest._delete_cache_locations(locations, range(1, 5))
 
         # ---------- step 3: prefix-match query ------------------------
         resp = self._prefix_query(block_keys)
@@ -92,9 +92,74 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                          f"got {len(locations)} locations")
         self._verify_block_keys(locations,
                                 [block_keys[i] for i in (1, 2, 3, 4,)])
+        # simulate the actual location data write
+        LocationPruningTest._touch_cache_locations(locations)
         self._finish_write_blocks(write_session_id, 4)
 
         # --------- step 6: verify full recovery -----------------------
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after re-write")
+
+    def test_aggressive_location_prune_contiguous_wo_query(self):
+        """Verify aggressive prune on a contiguous suffix with
+        start_write_cache only.
+
+        When the underlying data for some cache blocks becomes
+        unavailable (MightExist() returns false), the aggressive prune
+        policy should clean ALL invalid locations in a single write pass
+        -- rather than only pruning the first invalid one and requiring
+        O(N) round-trips.
+
+        Scenario (prefix = A B C D E, data for B C D E lost):
+        1. Write A B C D E, confirm all 5 queryable.
+        2. Delete the data files backing B C D E.
+        3. Send start_write_cache for B C D E, the server is expected to
+           return all these locations to write, with same path URI (but
+           different location_id).
+        4. The original locations are deleted from the meta indexer,
+           together with the file specified by URI; and since the new
+           locations share the same URIs, they may need to be re-created.
+        5. Prefix-match query returns [A B C D E] again.
+        """
+
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance()
+
+        # ---------- step 1: write blocks A B C D E --------------------
+        block_keys = [100, 101, 102, 103, 104]
+        token_ids = [200, 201, 202, 203, 204]
+        locations = self._write_blocks(block_keys, token_ids)
+        self.assertEqual(len(locations), 5,
+                         "initial write should allocate 5 locations")
+
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(
+            len(resp["locations"]), 5,
+            "all 5 blocks should be queryable after initial write")
+
+        # ---------- step 2: simulate data loss for B C D E ------------
+        LocationPruningTest._delete_cache_locations(locations, range(1, 5))
+
+        # ---------- step 3: re-write the full chain -------------------
+        # A still valid; B C D E need writing
+        resp = self._start_write_blocks(block_keys, token_ids)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 4,
+                         "re-write should allocate 4 locations for B C D E; "
+                         f"got {len(locations)} locations")
+        self._verify_block_keys(locations,
+                                [block_keys[i] for i in (1, 2, 3, 4,)])
+
+        # --------- step 4: wait for the async metadata prune ----------
+        time.sleep(2)
+        # simulate the actual location data write
+        LocationPruningTest._touch_cache_locations(locations)
+        self._finish_write_blocks(write_session_id, len(locations))
+
+        # --------- step 5: verify full recovery -----------------------
         resp = self._prefix_query(block_keys)
         self.assertEqual(len(resp["locations"]), 5,
                          "all 5 blocks should be queryable after re-write")
@@ -103,10 +168,11 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
         """Verify aggressive prune with non-contiguous data loss.
 
         When stale blocks are interleaved with valid ones (e.g., B and D
-        lost while A, C, E intact), the write path should produce a
-        BlockMaskVector (non-contiguous bitmap) rather than a simple
-        BlockMaskOffset, and allocate locations only for the stale
-        blocks.
+        lost while A, C, E intact), the aggressive prune policy should
+        clean ALL invalid locations in a single query or write pass --
+        rather than only pruning the first invalid one and requiring
+        O(N) round-trips, and the write allocate locations only for the
+        stale blocks.
 
         Scenario (prefix = A B C D E, data for B and D lost):
         1. Write A B C D E, confirm all 5 queryable.
@@ -134,7 +200,7 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
             "all 5 blocks should be queryable after initial write")
 
         # ---------- step 2: simulate data loss for B and D ------------
-        self._delete_location_files(locations, [1, 3])
+        LocationPruningTest._delete_cache_locations(locations, [1, 3])
 
         # ---------- step 3: prefix-match query ------------------------
         resp = self._prefix_query(block_keys)
@@ -155,6 +221,8 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                          "re-write should allocate 2 locations for B and D; "
                          f"got {len(locations)} locations")
         self._verify_block_keys(locations, [block_keys[i] for i in (1, 3,)])
+        # simulate the actual location data write
+        LocationPruningTest._touch_cache_locations(locations)
         self._finish_write_blocks(write_session_id, 2)
 
         # --------- step 6: verify full recovery -----------------------
@@ -162,14 +230,82 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
         self.assertEqual(len(resp["locations"]), 5,
                          "all 5 blocks should be queryable after re-write")
 
+    def test_aggressive_location_prune_non_contiguous_wo_query(self):
+        """Verify aggressive prune with non-contiguous data loss with
+        start_write_cache only.
+
+        When stale blocks are interleaved with valid ones (e.g., B and D
+        lost while A, C, E intact), the aggressive prune policy should
+        clean ALL invalid locations in a single write pass -- rather
+        than only pruning the first invalid one and requiring O(N)
+        round-trips, and allocate locations only for the stale blocks.
+
+        Scenario (prefix = A B C D E, data for B and D lost):
+        1. Write A B C D E, confirm all 5 queryable.
+        2. Delete the data files backing B and D only.
+        3. Send start_write_cache for B D, the server is expected to
+           return all these locations to write, with same path URI (but
+           different location_id).
+        4. The original locations are deleted from the meta indexer,
+           together with the file specified by URI; and since the new
+           locations share the same URIs, they may need to be re-created.
+        5. Prefix-match query returns [A B C D E] again.
+        """
+
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance()
+
+        # ---------- step 1: write blocks A B C D E --------------------
+        block_keys = [200, 201, 202, 203, 204]
+        token_ids = [300, 301, 302, 303, 304]
+        locations = self._write_blocks(block_keys, token_ids)
+        self.assertEqual(len(locations), 5,
+                         "initial write should allocate 5 locations")
+
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(
+            len(resp["locations"]), 5,
+            "all 5 blocks should be queryable after initial write")
+
+        # ---------- step 2: simulate data loss for B and D ------------
+        LocationPruningTest._delete_cache_locations(locations, [1, 3])
+
+        # --------- step 3: re-write the full chain --------------------
+        # A, C, E still valid; B and D need writing
+        resp = self._start_write_blocks(block_keys, token_ids)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 2,
+                         "re-write should allocate 2 locations for B and D; "
+                         f"got {len(locations)} locations")
+        self._verify_block_keys(locations, [block_keys[i] for i in (1, 3,)])
+
+        # --------- step 4: wait for the async metadata prune ----------
+        time.sleep(2)
+        # simulate the actual location data write
+        LocationPruningTest._touch_cache_locations(locations)
+        self._finish_write_blocks(write_session_id, len(locations))
+
+        # --------- step 5: verify full recovery -----------------------
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after re-write")
+
     def test_aggressive_location_prune_all_missing(self):
         """Verify aggressive prune when all blocks are missing.
 
+        When the underlying data for all the cache blocks become
+        unavailable (MightExist() returns false), the aggressive prune
+        policy should clean ALL invalid locations in a single query or
+        write pass -- rather than only pruning the first invalid one and
+        requiring O(N) round-trips.
+
         Scenario (prefix = A B C D E, all data lost):
-        1. Write A B C D E, confirm all 3 queryable.
-        2. Delete data files for all 3 blocks.
+        1. Write A B C D E, confirm all 5 queryable.
+        2. Delete data files for all 5 blocks.
         3. Prefix-match query returns empty result.
-        4. Re-write allocates 3 fresh locations.
+        4. Re-write allocates 5 fresh locations.
         5. Prefix-match query returns [A B C D E] again.
         """
 
@@ -180,8 +316,8 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
         # --------- step 1: write blocks A B C -------------------------
         block_keys = [300, 301, 302, 303, 304]
         token_ids = [400, 401, 402, 403, 404]
-        first_locations = self._write_blocks(block_keys, token_ids)
-        self.assertEqual(len(first_locations), 5,
+        locations = self._write_blocks(block_keys, token_ids)
+        self.assertEqual(len(locations), 5,
                          "initial write should allocate 5 locations")
 
         resp = self._prefix_query(block_keys)
@@ -189,7 +325,7 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                          "all 5 blocks should be queryable after initial write")
 
         # --------- step 2: simulate data loss for A B C D E -----------
-        self._delete_location_files(first_locations, range(0, 5))
+        LocationPruningTest._delete_cache_locations(locations, range(0, 5))
 
         # --------- step 3: prefix-match query -------------------------
         resp = self._prefix_query(block_keys)
@@ -209,9 +345,71 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                          "re-write should allocate 5 locations for A B C D E; "
                          f"got {len(locations)} locations")
         self._verify_block_keys(locations, block_keys)
+        # simulate the actual location data write
+        LocationPruningTest._touch_cache_locations(locations)
         self._finish_write_blocks(write_session_id, 5)
 
         # --------- step 6: verify full recovery -----------------------
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after re-write")
+
+    def test_aggressive_location_prune_all_missing_wo_query(self):
+        """Verify aggressive prune when all blocks are missing with
+        start_write_cache only.
+
+        When the underlying data for all the cache blocks become
+        unavailable (MightExist() returns false), the aggressive prune
+        policy should clean ALL invalid locations in a single write pass
+        -- rather than only pruning the first invalid one and requiring
+        O(N) round-trips.
+
+        Scenario (prefix = A B C D E, all data lost):
+        1. Write A B C D E, confirm all 5 queryable.
+        2. Delete data files for all 5 blocks.
+        3. Send start_write_cache for A B C D E, the server is expected
+           to return all these locations to write, with same path URI
+           (but different location_id).
+        4. The original locations are deleted from the meta indexer,
+           together with the file specified by URI; and since the new
+           locations share the same URIs, they may need to be re-created.
+        5. Prefix-match query returns [A B C D E] again.
+        """
+
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance()
+
+        # --------- step 1: write blocks A B C -------------------------
+        block_keys = [300, 301, 302, 303, 304]
+        token_ids = [400, 401, 402, 403, 404]
+        locations = self._write_blocks(block_keys, token_ids)
+        self.assertEqual(len(locations), 5,
+                         "initial write should allocate 5 locations")
+
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 5,
+                         "all 5 blocks should be queryable after initial write")
+
+        # --------- step 2: simulate data loss for A B C D E -----------
+        LocationPruningTest._delete_cache_locations(locations, range(0, 5))
+
+        # --------- step 3: re-write all blocks ------------------------
+        resp = self._start_write_blocks(block_keys, token_ids)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self.assertEqual(len(locations), 5,
+                         "re-write should allocate 5 locations for A B C D E; "
+                         f"got {len(locations)} locations")
+        self._verify_block_keys(locations, block_keys)
+
+        # --------- step 4: wait for async metadata prune --------------
+        time.sleep(2)
+        # simulate the actual location data write
+        LocationPruningTest._touch_cache_locations(locations)
+        self._finish_write_blocks(write_session_id, len(locations))
+
+        # --------- step 5: verify full recovery -----------------------
         resp = self._prefix_query(block_keys)
         self.assertEqual(len(resp["locations"]), 5,
                          "all 5 blocks should be queryable after re-write")
@@ -233,6 +431,9 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
         resp = self._start_write_blocks(block_keys, token_ids)
         write_session_id = resp["write_session_id"]
         locations = resp["locations"]
+
+        LocationPruningTest._touch_cache_locations(locations)
+
         self._finish_write_blocks(write_session_id, len(locations))
         return locations
 
@@ -264,15 +465,35 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
             "block_mask": {"offset": 0},
         })
 
-    def _delete_location_files(self, locations, indices):
+    @staticmethod
+    def _touch_cache_locations(locations):
+        """simulate the cache data write"""
+        for loc in locations:
+            for spec in loc.get("location_specs", []):
+                file_path = urlparse(spec["uri"]).path
+                try:
+                    # the data file can be deleted by a slow pruning
+                    # after being touched here, which is acceptable
+                    # (this is indistinguishable from being reclaimed,
+                    # if the reclaimer were being enabled)
+                    os.utime(file_path)
+                except FileNotFoundError as e:
+                    # if here, there are 2 possibilities:
+                    # 1. initial write; create it
+                    # 2. the data file might have been deleted by
+                    #    the location pruning process; create it again
+                    logging.info(f"FileNotFoundError: {e}, path: {file_path}")
+                    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                    with open(file_path, 'x') as _:
+                        pass
+
+    @staticmethod
+    def _delete_cache_locations(locations, indices):
+        """simulate the cache data lost event"""
         for i in indices:
             loc = locations[i]
             for spec in loc.get("location_specs", []):
                 file_path = urlparse(spec["uri"]).path
-                self.assertTrue(
-                    os.path.exists(file_path),
-                    f"Data file should exist before deletion: "
-                    f"{file_path}")
                 os.remove(file_path)
 
     def _verify_block_keys(self, locations, block_keys):
@@ -284,7 +505,6 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
 
     def _make_dummy_storage(self):
         dummy_root_path = f"{self.get_workdir()}/{self._storage_name}/data/"
-        os.makedirs(dummy_root_path, exist_ok=True)
         add_storage_req = {
             "trace_id": self._trace_id + "-add_storage",
             "storage": {
@@ -310,10 +530,8 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                 "quota": {
                     "capacity": 1024 * 32,
                     "quota_config": [
-                        # StorageType.ST_TAIRMEMPOOL=3
-                        {"storage_type": 3, "capacity": 1024 * 16},
-                        # StorageType.ST_NFS=4
-                        {"storage_type": 4, "capacity": 1024 * 16},
+                        # StorageType.ST_DUMMY=6
+                        {"storage_type": 6, "capacity": 1024 * 32},
                     ],
                 },
                 "cache_config": {
@@ -326,7 +544,7 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                         },
                         "delay_before_delete_ms": 100,
                     },
-                    "data_storage_strategy": 2,  # CPS_PREFER_3FS
+                    "data_storage_strategy": 2,  # TODO: CPS_PREFER_3FS?
                     "meta_indexer_config": {
                         "max_key_count": 16,  # start with 16 max key
                         "mutex_shard_num": 16,

--- a/integration_test/reclaimer/location_pruning_test.py
+++ b/integration_test/reclaimer/location_pruning_test.py
@@ -544,7 +544,7 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
                         },
                         "delay_before_delete_ms": 100,
                     },
-                    "data_storage_strategy": 2,  # TODO: CPS_PREFER_3FS?
+                    "data_storage_strategy": 2,  # CPS_PREFER_3FS
                     "meta_indexer_config": {
                         "max_key_count": 16,  # start with 16 max key
                         "mutex_shard_num": 16,

--- a/integration_test/reclaimer/location_pruning_test.py
+++ b/integration_test/reclaimer/location_pruning_test.py
@@ -509,7 +509,7 @@ class LocationPruningTest(abc.ABC, TestBase, unittest.TestCase):
             "trace_id": self._trace_id + "-add_storage",
             "storage": {
                 "global_unique_name": self._storage_name,
-                "local": {
+                "dummy": {
                     "root_path": dummy_root_path,
                     "key_count_per_file": 1,
                 }

--- a/kv_cache_manager/data_storage/BUILD
+++ b/kv_cache_manager/data_storage/BUILD
@@ -4,6 +4,7 @@ cc_library(
     name = "data_storage",
     srcs = [
         "data_storage_manager.cc",
+        "dummy_backend.cc",
         "hf3fs_backend.cc",
         "mooncake_backend.cc",
         "nfs_backend.cc",
@@ -11,6 +12,7 @@ cc_library(
     hdrs = [
         "data_storage_backend.h",
         "data_storage_manager.h",
+        "dummy_backend.h",
         "hf3fs_backend.h",
         "mooncake_backend.h",
         "nfs_backend.h",

--- a/kv_cache_manager/data_storage/data_storage_manager.cc
+++ b/kv_cache_manager/data_storage/data_storage_manager.cc
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/data_storage/dummy_backend.h"
 #include "kv_cache_manager/data_storage/hf3fs_backend.h"
 #include "kv_cache_manager/data_storage/mooncake_backend.h"
 #include "kv_cache_manager/data_storage/nfs_backend.h"
@@ -169,6 +170,8 @@ std::shared_ptr<DataStorageBackend> DataStorageManager::CreateStorageBackend(con
         return std::make_shared<TairMempoolBackend>(metrics_registry_);
     case DataStorageType::DATA_STORAGE_TYPE_NFS:
         return std::make_shared<NfsBackend>(metrics_registry_);
+    case DataStorageType::DATA_STORAGE_TYPE_DUMMY:
+        return std::make_shared<DummyBackend>(metrics_registry_);
     default:
         return nullptr;
     }

--- a/kv_cache_manager/data_storage/dummy_backend.cc
+++ b/kv_cache_manager/data_storage/dummy_backend.cc
@@ -1,0 +1,182 @@
+#include "kv_cache_manager/data_storage/dummy_backend.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/hash/hash.h"
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/data_storage/data_storage_uri.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+namespace {
+
+bool TouchFile(const std::string &file_path) {
+    const std::filesystem::path path(file_path);
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec) {
+        KVCM_LOG_WARN(
+            "create parent directories failed, path: [%s], msg: [%s]", file_path.c_str(), ec.message().c_str());
+        return false;
+    }
+    std::ofstream ofs(file_path, std::ios::app);
+    if (!ofs) {
+        KVCM_LOG_WARN("open or create file failed, path: [%s]", file_path.c_str());
+        return false;
+    }
+    ofs.close();
+    return true;
+}
+
+} // anonymous namespace
+
+namespace kv_cache_manager {
+
+DummyBackend::DummyBackend(std::shared_ptr<MetricsRegistry> metrics_registry)
+    : DataStorageBackend(std::move(metrics_registry)) {}
+
+DataStorageType DummyBackend::GetType() { return DataStorageType::DATA_STORAGE_TYPE_DUMMY; }
+
+bool DummyBackend::Available() { return IsOpen() && IsAvailable(); }
+
+double DummyBackend::GetStorageUsageRatio(const std::string &trace_id) const { return 0.0; }
+
+ErrorCode DummyBackend::DoOpen(const StorageConfig &storage_config, const std::string &trace_id) {
+    if (const auto cfg = std::dynamic_pointer_cast<DummyStorageSpec>(storage_config.storage_spec())) {
+        spec_ = *cfg;
+    } else {
+        KVCM_LOG_WARN("unexpected config type, storage config: [%s]", storage_config.ToString().c_str());
+        return ErrorCode::EC_ERROR;
+    }
+    if (spec_.root_path().empty()) {
+        KVCM_LOG_WARN("open dummy backend failed, root_path is empty");
+        return ErrorCode::EC_ERROR;
+    }
+    base_path_ = std::filesystem::path(spec_.root_path());
+    std::error_code ec;
+    std::filesystem::create_directories(base_path_, ec);
+    if (ec) {
+        KVCM_LOG_WARN("open dummy backend failed, cannot create root_path [%s], msg: [%s]",
+                      base_path_.string().c_str(),
+                      ec.message().c_str());
+        return ErrorCode::EC_ERROR;
+    }
+    KVCM_LOG_INFO("open dummy backend success, config: [%s]", spec_.ToString().c_str());
+    SetOpen(true);
+    SetAvailable(true);
+    return ErrorCode::EC_OK;
+}
+
+ErrorCode DummyBackend::Close() {
+    KVCM_LOG_INFO("close dummy backend");
+    SetOpen(false);
+    SetAvailable(false);
+    return ErrorCode::EC_OK;
+}
+
+std::vector<std::pair<ErrorCode, DataStorageUri>> DummyBackend::Create(const std::vector<std::string> &keys,
+                                                                       const std::size_t size_per_key,
+                                                                       const std::string &trace_id,
+                                                                       const std::function<void()> cb) {
+    std::vector<std::pair<ErrorCode, DataStorageUri>> results;
+    std::vector<std::vector<std::string>> batches;
+
+    auto batch_size = spec_.key_count_per_file();
+    batch_size = batch_size <= 0 ? 1 : batch_size;
+    using diff_t = std::vector<std::string>::difference_type;
+    for (std::size_t start = 0; start != keys.size(); start += batch_size) {
+        batches.emplace_back(std::next(keys.begin(), static_cast<diff_t>(start)),
+                             std::next(keys.begin(), static_cast<diff_t>(std::min(start + batch_size, keys.size()))));
+    }
+
+    for (auto &batch : batches) {
+        DataStorageUri storage_uri;
+        storage_uri.SetProtocol(ToString(GetType()));
+
+        if (batch.size() > 1) {
+            std::string combine_key = StringUtil::Join(batch, "|");
+            std::string hash_str = StringUtil::Uint64ToHex(Hash64(combine_key.c_str(), combine_key.size(), 42));
+            storage_uri.SetPath(base_path_ / (batch[0] + "_" + hash_str));
+        } else {
+            storage_uri.SetPath(base_path_ / batch[0]);
+        }
+
+        storage_uri.SetParam("size", std::to_string(size_per_key));
+
+        for (std::size_t i = 0; i != batch.size(); ++i) {
+            if (batch_size > 1) {
+                storage_uri.SetParam("blkid", std::to_string(i));
+            }
+            results.emplace_back(ErrorCode::EC_OK, storage_uri);
+            TouchFile(storage_uri.GetPath());
+        }
+    }
+
+    if (cb) {
+        cb();
+    }
+
+    return results;
+}
+
+std::vector<ErrorCode> DummyBackend::Delete(const std::vector<DataStorageUri> &storage_uris,
+                                            const std::string &trace_id,
+                                            const std::function<void()> cb) {
+    std::vector<ErrorCode> results;
+    for (auto &uri : storage_uris) {
+        std::filesystem::path file_path = uri.GetPath();
+        std::error_code ec;
+        const bool removed = std::filesystem::remove(file_path, ec);
+        if (ec) {
+            KVCM_LOG_ERROR(
+                "failed to delete file, path: [%s], msg: [%s]", file_path.string().c_str(), ec.message().c_str());
+            results.push_back(ErrorCode::EC_ERROR);
+            continue;
+        }
+        if (!removed) {
+            KVCM_LOG_WARN("file not exist, path: [%s]", file_path.string().c_str());
+        }
+        results.push_back(ErrorCode::EC_OK);
+    }
+
+    if (cb) {
+        cb();
+    }
+
+    return results;
+}
+
+std::vector<bool> DummyBackend::Exist(const std::vector<DataStorageUri> &storage_uris) {
+    std::vector<bool> results;
+    for (auto &uri : storage_uris) {
+        const bool res = std::filesystem::exists(uri.GetPath());
+        results.push_back(res);
+    }
+    return results;
+}
+
+std::vector<bool> DummyBackend::MightExist(const std::vector<DataStorageUri> &storage_uris) {
+    return Exist(storage_uris);
+}
+
+std::vector<ErrorCode> DummyBackend::Lock(const std::vector<DataStorageUri> &storage_uris) {
+    std::vector<ErrorCode> results(storage_uris.size(), ErrorCode::EC_OK);
+    return results;
+}
+
+std::vector<ErrorCode> DummyBackend::UnLock(const std::vector<DataStorageUri> &storage_uris) {
+    std::vector<ErrorCode> results(storage_uris.size(), ErrorCode::EC_OK);
+    return results;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/dummy_backend.cc
+++ b/kv_cache_manager/data_storage/dummy_backend.cc
@@ -145,6 +145,7 @@ std::vector<bool> DummyBackend::Exist(const std::vector<DataStorageUri> &storage
                            ec.message().c_str(),
                            uri.GetPath().c_str());
             results.push_back(false);
+            continue;
         }
         results.push_back(res);
     }

--- a/kv_cache_manager/data_storage/dummy_backend.cc
+++ b/kv_cache_manager/data_storage/dummy_backend.cc
@@ -18,28 +18,6 @@
 #include "kv_cache_manager/data_storage/data_storage_uri.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
-namespace {
-
-bool TouchFile(const std::string &file_path) {
-    const std::filesystem::path path(file_path);
-    std::error_code ec;
-    std::filesystem::create_directories(path.parent_path(), ec);
-    if (ec) {
-        KVCM_LOG_WARN(
-            "create parent directories failed, path: [%s], msg: [%s]", file_path.c_str(), ec.message().c_str());
-        return false;
-    }
-    std::ofstream ofs(file_path, std::ios::app);
-    if (!ofs) {
-        KVCM_LOG_WARN("open or create file failed, path: [%s]", file_path.c_str());
-        return false;
-    }
-    ofs.close();
-    return true;
-}
-
-} // anonymous namespace
-
 namespace kv_cache_manager {
 
 DummyBackend::DummyBackend(std::shared_ptr<MetricsRegistry> metrics_registry)
@@ -118,7 +96,6 @@ std::vector<std::pair<ErrorCode, DataStorageUri>> DummyBackend::Create(const std
                 storage_uri.SetParam("blkid", std::to_string(i));
             }
             results.emplace_back(ErrorCode::EC_OK, storage_uri);
-            TouchFile(storage_uri.GetPath());
         }
     }
 

--- a/kv_cache_manager/data_storage/dummy_backend.cc
+++ b/kv_cache_manager/data_storage/dummy_backend.cc
@@ -73,7 +73,7 @@ std::vector<std::pair<ErrorCode, DataStorageUri>> DummyBackend::Create(const std
     auto batch_size = spec_.key_count_per_file();
     batch_size = batch_size <= 0 ? 1 : batch_size;
     using diff_t = std::vector<std::string>::difference_type;
-    for (std::size_t start = 0; start != keys.size(); start += batch_size) {
+    for (std::size_t start = 0; start < keys.size(); start += batch_size) {
         batches.emplace_back(std::next(keys.begin(), static_cast<diff_t>(start)),
                              std::next(keys.begin(), static_cast<diff_t>(std::min(start + batch_size, keys.size()))));
     }

--- a/kv_cache_manager/data_storage/dummy_backend.cc
+++ b/kv_cache_manager/data_storage/dummy_backend.cc
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -136,7 +137,15 @@ std::vector<ErrorCode> DummyBackend::Delete(const std::vector<DataStorageUri> &s
 std::vector<bool> DummyBackend::Exist(const std::vector<DataStorageUri> &storage_uris) {
     std::vector<bool> results;
     for (auto &uri : storage_uris) {
-        const bool res = std::filesystem::exists(uri.GetPath());
+        std::error_code ec;
+        const bool res = std::filesystem::exists(uri.GetPath(), ec);
+        if (ec) {
+            KVCM_LOG_ERROR("std::filesystem::exists call failed, err code: [%d], err msg: [%s], path: [%s]",
+                           ec.value(),
+                           ec.message().c_str(),
+                           uri.GetPath().c_str());
+            results.push_back(false);
+        }
         results.push_back(res);
     }
     return results;

--- a/kv_cache_manager/data_storage/dummy_backend.h
+++ b/kv_cache_manager/data_storage/dummy_backend.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/data_storage/data_storage_backend.h"
+#include "kv_cache_manager/data_storage/data_storage_uri.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
+
+namespace kv_cache_manager {
+
+class MetricsRegistry;
+
+class DummyBackend : public DataStorageBackend {
+public:
+    DummyBackend() = delete;
+    explicit DummyBackend(std::shared_ptr<MetricsRegistry> metrics_registry);
+    ~DummyBackend() override = default;
+
+    DataStorageType GetType() override;
+    bool Available() override;
+    [[nodiscard]] double GetStorageUsageRatio(const std::string &trace_id) const override;
+
+    ErrorCode DoOpen(const StorageConfig &storage_config, const std::string &trace_id) override;
+    ErrorCode Close() override;
+
+    std::vector<std::pair<ErrorCode, DataStorageUri>> Create(const std::vector<std::string> &keys,
+                                                             std::size_t size_per_key,
+                                                             const std::string &trace_id,
+                                                             std::function<void()> cb) override;
+    std::vector<ErrorCode> Delete(const std::vector<DataStorageUri> &storage_uris,
+                                  const std::string &trace_id,
+                                  std::function<void()> cb) override;
+    std::vector<bool> Exist(const std::vector<DataStorageUri> &storage_uris) override;
+    std::vector<bool> MightExist(const std::vector<DataStorageUri> &storage_uris) override;
+    std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &storage_uris) override;
+    std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &storage_uris) override;
+
+private:
+    DummyStorageSpec spec_;
+    std::filesystem::path base_path_;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/storage_config.cc
+++ b/kv_cache_manager/data_storage/storage_config.cc
@@ -160,6 +160,8 @@ std::string ToString(const DataStorageType &type) {
         return "pace";
     case DataStorageType::DATA_STORAGE_TYPE_NFS:
         return "file";
+    case DataStorageType::DATA_STORAGE_TYPE_DUMMY:
+        return "dummy";
     default:
         return "unrecognized";
     }
@@ -176,6 +178,8 @@ DataStorageType ToDataStorageType(const std::string &type) {
         return DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL;
     } else if (type == "file") {
         return DataStorageType::DATA_STORAGE_TYPE_NFS;
+    } else if (type == "dummy") {
+        return DataStorageType::DATA_STORAGE_TYPE_DUMMY;
     } else {
         return DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
     }
@@ -271,6 +275,38 @@ void NfsStorageSpec::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &w
     Put(writer, "key_count_per_file", key_count_per_file_);
 }
 
+// DummyStorageSpec
+std::string DummyStorageSpec::ToString() const {
+    std::ostringstream oss;
+    oss << "root_path: " << root_path_;
+    oss << " , key_count_per_file: " << key_count_per_file_;
+    return oss.str();
+}
+
+bool DummyStorageSpec::ValidateRequiredFields(std::string &invalid_fields) const {
+    bool valid = true;
+    std::string local_invalid_fields;
+    if (root_path_.empty()) {
+        valid = false;
+        local_invalid_fields += "{root_path}";
+    }
+    if (!valid) {
+        invalid_fields += "{DummyStorageSpec: " + local_invalid_fields + "}";
+    }
+    return valid;
+}
+
+bool DummyStorageSpec::FromRapidValue(const rapidjson::Value &rapid_value) {
+    KVCM_JSON_GET_MACRO(rapid_value, "root_path", root_path_);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "key_count_per_file", key_count_per_file_, 1);
+    return true;
+}
+
+void DummyStorageSpec::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
+    Put(writer, "root_path", root_path_);
+    Put(writer, "key_count_per_file", key_count_per_file_);
+}
+
 bool StorageConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
     std::string type_str;
     KVCM_JSON_GET_MACRO(rapid_value, "type", type_str);
@@ -295,6 +331,10 @@ bool StorageConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
         storage_spec_ = tmp;
     } else if (type_ == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL) {
         auto tmp = std::make_shared<TairMemPoolStorageSpec>();
+        KVCM_JSON_GET_MACRO(rapid_value, "storage_spec", tmp);
+        storage_spec_ = tmp;
+    } else if (type_ == DataStorageType::DATA_STORAGE_TYPE_DUMMY) {
+        auto tmp = std::make_shared<DummyStorageSpec>();
         KVCM_JSON_GET_MACRO(rapid_value, "storage_spec", tmp);
         storage_spec_ = tmp;
     } else {

--- a/kv_cache_manager/data_storage/storage_config.h
+++ b/kv_cache_manager/data_storage/storage_config.h
@@ -14,6 +14,7 @@ enum class DataStorageType : uint8_t {
     DATA_STORAGE_TYPE_TAIR_MEMPOOL = 3,
     DATA_STORAGE_TYPE_NFS = 4,
     DATA_STORAGE_TYPE_VCNS_HF3FS = 5,
+    DATA_STORAGE_TYPE_DUMMY = 6,
     COUNT, // as sentinel
 };
 
@@ -157,6 +158,23 @@ private:
 };
 
 class NfsStorageSpec : public StorageSpec {
+public:
+    bool FromRapidValue(const rapidjson::Value &rapid_value) override;
+    void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
+    bool ValidateRequiredFields(std::string &invalid_fields) const override;
+
+    std::string ToString() const override;
+    const std::string &root_path() const { return root_path_; }
+    void set_root_path(const std::string &root_path) { root_path_ = root_path; }
+    int32_t key_count_per_file() const { return key_count_per_file_; }
+    void set_key_count_per_file(int32_t value) { key_count_per_file_ = value; }
+
+private:
+    std::string root_path_;
+    int32_t key_count_per_file_ = 0;
+};
+
+class DummyStorageSpec : public StorageSpec {
 public:
     bool FromRapidValue(const rapidjson::Value &rapid_value) override;
     void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;

--- a/kv_cache_manager/data_storage/test/BUILD
+++ b/kv_cache_manager/data_storage/test/BUILD
@@ -40,6 +40,19 @@ cc_test(
 )
 
 cc_test(
+    name = "DummyBackendTest",
+    srcs = [
+        "dummy_backend_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/data_storage",
+    ],
+)
+
+cc_test(
     name = "StorageConfigTest",
     srcs = [
         "storage_config_test.cc",

--- a/kv_cache_manager/data_storage/test/dummy_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/dummy_backend_test.cc
@@ -1,0 +1,324 @@
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/data_storage/dummy_backend.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+using namespace kv_cache_manager;
+
+class DummyBackendTest : public TESTBASE {
+public:
+    void SetUp() override {
+        metrics_registry_ = std::make_shared<MetricsRegistry>();
+        test_root_ = GetPrivateTestRuntimeDataPath() + "dummy_root/";
+    }
+    void TearDown() override {}
+
+    // helper: build a StorageConfig with a DummyStorageSpec
+    StorageConfig MakeConfig(const std::string &root_path, int32_t key_count_per_file = 1) {
+        auto spec = std::make_shared<DummyStorageSpec>();
+        spec->set_root_path(root_path);
+        spec->set_key_count_per_file(key_count_per_file);
+        return StorageConfig(DataStorageType::DATA_STORAGE_TYPE_DUMMY, "test_dummy", spec);
+    }
+
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::string test_root_;
+};
+
+TEST_F(DummyBackendTest, TestGetType) {
+    DummyBackend backend(metrics_registry_);
+    ASSERT_EQ(backend.GetType(), DataStorageType::DATA_STORAGE_TYPE_DUMMY);
+}
+
+TEST_F(DummyBackendTest, TestAvailableBeforeAndAfterOpen) {
+    DummyBackend backend(metrics_registry_);
+    ASSERT_FALSE(backend.Available());
+
+    auto config = MakeConfig(test_root_);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+    ASSERT_TRUE(backend.Available());
+
+    ASSERT_EQ(EC_OK, backend.Close());
+    ASSERT_FALSE(backend.Available());
+}
+
+TEST_F(DummyBackendTest, TestOpenCreatesRootDirectory) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+    ASSERT_TRUE(std::filesystem::is_directory(test_root_));
+}
+
+TEST_F(DummyBackendTest, TestOpenEmptyRootPathFails) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig("");
+    ASSERT_NE(EC_OK, backend.Open(config, "trace_1"));
+    ASSERT_FALSE(backend.Available());
+}
+
+TEST_F(DummyBackendTest, TestOpenWrongSpecTypeFails) {
+    DummyBackend backend(metrics_registry_);
+    // use an NfsStorageSpec instead of DummyStorageSpec
+    auto spec = std::make_shared<NfsStorageSpec>();
+    spec->set_root_path(test_root_);
+    StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_DUMMY, "test_dummy", spec);
+    ASSERT_NE(EC_OK, backend.Open(config, "trace_1"));
+    ASSERT_FALSE(backend.Available());
+}
+
+TEST_F(DummyBackendTest, TestGetStorageUsageRatio) {
+    DummyBackend backend(metrics_registry_);
+    ASSERT_DOUBLE_EQ(0.0, backend.GetStorageUsageRatio("trace_1"));
+}
+
+TEST_F(DummyBackendTest, TestCreateSingleKeyPerFile) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    std::vector<std::string> keys = {"key1", "key2", "key3"};
+    auto results = backend.Create(keys, 128, "trace_2", []() {});
+
+    ASSERT_EQ(results.size(), keys.size());
+    for (auto &[ec, uri] : results) {
+        ASSERT_EQ(ec, EC_OK);
+        EXPECT_EQ(uri.GetProtocol(), "dummy");
+    }
+    // each key maps to its own file path under base_path_
+    EXPECT_NE(std::string::npos, results[0].second.ToUriString().find("key1"));
+    EXPECT_NE(std::string::npos, results[1].second.ToUriString().find("key2"));
+    EXPECT_NE(std::string::npos, results[2].second.ToUriString().find("key3"));
+}
+
+TEST_F(DummyBackendTest, TestCreateMultipleKeysPerFile) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 2);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    std::vector<std::string> keys = {"a", "b", "c"};
+    auto results = backend.Create(keys, 64, "trace_2", []() {});
+
+    ASSERT_EQ(results.size(), keys.size());
+    for (auto &[ec, uri] : results) {
+        ASSERT_EQ(ec, EC_OK);
+    }
+    // first two keys share a batch (should have blkid param)
+    EXPECT_NE(std::string::npos, results[0].second.ToUriString().find("blkid=0"));
+    EXPECT_NE(std::string::npos, results[1].second.ToUriString().find("blkid=1"));
+    // third key is a single-element batch
+    EXPECT_NE(std::string::npos, results[2].second.ToUriString().find("blkid=0"));
+}
+
+TEST_F(DummyBackendTest, TestCreateEmptyKeys) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    bool cb_called = false;
+    auto results = backend.Create({}, 128, "trace_2", [&cb_called]() { cb_called = true; });
+    ASSERT_TRUE(cb_called);
+    ASSERT_TRUE(results.empty());
+}
+
+TEST_F(DummyBackendTest, TestCreateCallbackInvoked) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    bool cb_called = false;
+    backend.Create({"k"}, 64, "trace_2", [&cb_called]() { cb_called = true; });
+    ASSERT_TRUE(cb_called);
+}
+
+TEST_F(DummyBackendTest, TestCreateWithZeroBatchSize) {
+    DummyBackend backend(metrics_registry_);
+    // key_count_per_file = 0 should be treated as 1
+    auto config = MakeConfig(test_root_, 0);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    std::vector<std::string> keys = {"x", "y"};
+    auto results = backend.Create(keys, 32, "trace_2", []() {});
+    ASSERT_EQ(results.size(), keys.size());
+    // with batch_size clamped to 1, no blkid param expected
+    EXPECT_EQ(std::string::npos, results[0].second.ToUriString().find("blkid"));
+    EXPECT_EQ(std::string::npos, results[1].second.ToUriString().find("blkid"));
+}
+
+TEST_F(DummyBackendTest, TestExistAndMightExistOnNonExistentFiles) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    // create URIs pointing to non-existent files
+    DataStorageUri uri1;
+    uri1.SetProtocol("dummy");
+    uri1.SetPath(test_root_ + "no_such_file_1");
+    DataStorageUri uri2;
+    uri2.SetProtocol("dummy");
+    uri2.SetPath(test_root_ + "no_such_file_2");
+    std::vector<DataStorageUri> uris = {uri1, uri2};
+
+    auto exist_res = backend.Exist(uris);
+    ASSERT_EQ(exist_res.size(), 2u);
+    EXPECT_FALSE(exist_res[0]);
+    EXPECT_FALSE(exist_res[1]);
+
+    // MightExist delegates to Exist, so same results
+    auto might_res = backend.MightExist(uris);
+    ASSERT_EQ(might_res.size(), 2u);
+    EXPECT_FALSE(might_res[0]);
+    EXPECT_FALSE(might_res[1]);
+}
+
+TEST_F(DummyBackendTest, TestExistAndMightExistOnExistingFiles) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    // create a file on disk
+    std::string file_path = test_root_ + "existing_file";
+    std::ofstream ofs(file_path);
+    ofs.close();
+    ASSERT_TRUE(std::filesystem::exists(file_path));
+
+    DataStorageUri uri;
+    uri.SetProtocol("dummy");
+    uri.SetPath(file_path);
+    std::vector<DataStorageUri> uris = {uri};
+
+    auto exist_res = backend.Exist(uris);
+    ASSERT_EQ(exist_res.size(), 1u);
+    EXPECT_TRUE(exist_res[0]);
+
+    auto might_res = backend.MightExist(uris);
+    ASSERT_EQ(might_res.size(), 1u);
+    EXPECT_TRUE(might_res[0]);
+}
+
+TEST_F(DummyBackendTest, TestMightExistDelegatesToExist) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    // create one file, leave another missing
+    std::string present = test_root_ + "present";
+    std::ofstream(present).close();
+    std::string absent = test_root_ + "absent";
+
+    DataStorageUri uri_present, uri_absent;
+    uri_present.SetProtocol("dummy");
+    uri_present.SetPath(present);
+    uri_absent.SetProtocol("dummy");
+    uri_absent.SetPath(absent);
+
+    std::vector<DataStorageUri> uris = {uri_present, uri_absent};
+
+    auto exist_res = backend.Exist(uris);
+    auto might_res = backend.MightExist(uris);
+
+    // MightExist must return exactly the same results as Exist
+    ASSERT_EQ(exist_res.size(), might_res.size());
+    for (std::size_t i = 0; i < exist_res.size(); ++i) {
+        EXPECT_EQ(exist_res[i], might_res[i]) << "mismatch at index " << i;
+    }
+}
+
+TEST_F(DummyBackendTest, TestDeleteExistingFiles) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    // create files first
+    std::string f1 = test_root_ + "del_file1";
+    std::string f2 = test_root_ + "del_file2";
+    std::ofstream(f1).close();
+    std::ofstream(f2).close();
+    ASSERT_TRUE(std::filesystem::exists(f1));
+    ASSERT_TRUE(std::filesystem::exists(f2));
+
+    DataStorageUri uri1, uri2;
+    uri1.SetProtocol("dummy");
+    uri1.SetPath(f1);
+    uri2.SetProtocol("dummy");
+    uri2.SetPath(f2);
+
+    bool cb_called = false;
+    auto res = backend.Delete({uri1, uri2}, "trace_2", [&cb_called]() { cb_called = true; });
+    ASSERT_TRUE(cb_called);
+    ASSERT_EQ(res.size(), 2u);
+    EXPECT_EQ(res[0], EC_OK);
+    EXPECT_EQ(res[1], EC_OK);
+
+    // files should be gone
+    EXPECT_FALSE(std::filesystem::exists(f1));
+    EXPECT_FALSE(std::filesystem::exists(f2));
+}
+
+TEST_F(DummyBackendTest, TestDeleteNonExistentFileReturnsOk) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    DataStorageUri uri;
+    uri.SetProtocol("dummy");
+    uri.SetPath(test_root_ + "nonexistent");
+
+    auto res = backend.Delete({uri}, "trace_2", []() {});
+    ASSERT_EQ(res.size(), 1u);
+    EXPECT_EQ(res[0], EC_OK);
+}
+
+TEST_F(DummyBackendTest, TestLockAndUnLockReturnOk) {
+    DummyBackend backend(metrics_registry_);
+
+    DataStorageUri uri1, uri2, uri3;
+    uri1.SetProtocol("dummy");
+    uri1.SetPath("/any/path1");
+    uri2.SetProtocol("dummy");
+    uri2.SetPath("/any/path2");
+    uri3.SetProtocol("dummy");
+    uri3.SetPath("/any/path3");
+    std::vector<DataStorageUri> uris = {uri1, uri2, uri3};
+
+    auto lock_res = backend.Lock(uris);
+    auto unlock_res = backend.UnLock(uris);
+
+    ASSERT_EQ(lock_res.size(), uris.size());
+    ASSERT_EQ(unlock_res.size(), uris.size());
+    for (std::size_t i = 0; i < uris.size(); ++i) {
+        EXPECT_EQ(lock_res[i], EC_OK);
+        EXPECT_EQ(unlock_res[i], EC_OK);
+    }
+}
+
+TEST_F(DummyBackendTest, TestCreateThenExistRoundTrip) {
+    // end-to-end: Create produces URIs, then Exist and MightExist
+    // confirm the files were NOT actually written (Create does not
+    // touch disk in the current implementation -- it only generates
+    // URIs). If the implementation changes to touch disk, update this.
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_, 1);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    std::vector<std::string> keys = {"round_trip_key"};
+    auto create_res = backend.Create(keys, 256, "trace_2", []() {});
+    ASSERT_EQ(create_res.size(), 1u);
+    ASSERT_EQ(create_res[0].first, EC_OK);
+
+    std::vector<DataStorageUri> uris = {create_res[0].second};
+
+    // Create does not write to disk, so the file should not exist
+    auto exist_res = backend.Exist(uris);
+    ASSERT_EQ(exist_res.size(), 1u);
+    EXPECT_FALSE(exist_res[0]);
+
+    auto might_res = backend.MightExist(uris);
+    ASSERT_EQ(might_res.size(), 1u);
+    EXPECT_FALSE(might_res[0]);
+}

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1338,7 +1338,7 @@ std::unique_ptr<SelectLocationPolicy> CacheManager::genSelectLocationPolicy(Requ
         KVCM_INTERVAL_LOG_WARN(10, "all storages are unavailable!");
         return nullptr;
     }
-    std::array<uint32_t, 5> data_storage_counts{0};
+    std::array<uint32_t, static_cast<std::size_t>(DataStorageType::COUNT)> data_storage_counts{};
     bool is_all_type_only_one = true;
     for (const auto &storage : group_storages) {
         size_t idx = static_cast<size_t>(storage->GetType());
@@ -1348,7 +1348,7 @@ std::unique_ptr<SelectLocationPolicy> CacheManager::genSelectLocationPolicy(Requ
         }
     }
     if (is_all_type_only_one) {
-        StaticWeightSLPolicy::WeightArray weight_array{0};
+        StaticWeightSLPolicy::WeightArray weight_array{};
         for (const auto &storage : group_available_storages) {
             size_t idx = static_cast<size_t>(storage->GetType());
             weight_array[idx] = 1;

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1172,6 +1172,11 @@ std::string CacheManager::GetStorageConfigStr(RequestContext *request_context, c
     // TODO : try optimize these copy operation
     std::vector<const StorageConfig *> result;
     for (const auto &config : all_configs) {
+        // dummy backend is server-internal (testing only);
+        // clients have no SDK for it and would fail on init
+        if (config.type() == DataStorageType::DATA_STORAGE_TYPE_DUMMY) {
+            continue;
+        }
         if (storage_candadate_set.find(config.global_unique_name()) != storage_candadate_set.end()) {
             result.push_back(&config);
         }

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -143,6 +143,7 @@ private:
     // slot 3: DATA_STORAGE_TYPE_TAIR_MEMPOOL usage data
     // slot 4: DATA_STORAGE_TYPE_NFS usage data
     // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
+    // slot 6: DATA_STORAGE_TYPE_DUMMY usage data (testing only)
     array_t_ grp_storage_usage_by_type_;
 };
 

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -365,6 +365,7 @@ private:
         // slot 3: DATA_STORAGE_TYPE_TAIR_MEMPOOL exceed flag
         // slot 4: DATA_STORAGE_TYPE_NFS exceed flag
         // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
+        // slot 6: DATA_STORAGE_TYPE_DUMMY exceed flag (testing only)
         array_t_ water_level_exceed_by_type_;
     };
 

--- a/kv_cache_manager/manager/data_storage_selector.cc
+++ b/kv_cache_manager/manager/data_storage_selector.cc
@@ -51,6 +51,7 @@ private:
     // slot 3: DATA_STORAGE_TYPE_TAIR_MEMPOOL availability flag
     // slot 4: DATA_STORAGE_TYPE_NFS exceed availability flag
     // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
+    // slot 6: DATA_STORAGE_TYPE_DUMMY availability flag (testing only)
     array_t_ storage_quota_avail_by_type_;
 };
 
@@ -60,6 +61,7 @@ DataStorageSelector::StorageQuotaAvail::StorageQuotaAvail() : storage_quota_avai
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE)) = true;
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL)) = true;
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)) = true;
+    storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_DUMMY)) = true;
 }
 
 bool DataStorageSelector::StorageQuotaAvail::GetStorageQuotaAvailByType(const DataStorageType &type) const noexcept {

--- a/kv_cache_manager/manager/select_location_policy.h
+++ b/kv_cache_manager/manager/select_location_policy.h
@@ -63,7 +63,7 @@ NamedStorageWeightedSLPolicy : 解析uri, 如果有相同类型的多个存储�
 
 class StaticWeightSLPolicy : public WeightSLPolicy {
 public:
-    using WeightArray = std::array<uint32_t, 5>;
+    using WeightArray = std::array<uint32_t, static_cast<std::size_t>(DataStorageType::COUNT)>;
 
 protected:
     uint32_t GetWeight(CacheLocationMap::const_reference kv) const override;
@@ -78,11 +78,15 @@ protected:
 protected:
     // 直接用一个简单的映射表来选权重(映射表顺序与DataStorageType一样）
     // 代替switch-case
+    // order follows DataStorageType enum values:
+    // UNKNOWN, HF3FS, MOONCAKE, TAIR_MEMPOOL, NFS, VCNS_HF3FS, DUMMY
     inline static WeightArray default_storage_weights_{StorageTypeWeights::DEFAULT,
                                                        StorageTypeWeights::THREEFS,
                                                        StorageTypeWeights::MOONCAKE,
                                                        StorageTypeWeights::TAIR_MEMPOOL,
-                                                       StorageTypeWeights::NFS};
+                                                       StorageTypeWeights::NFS,
+                                                       StorageTypeWeights::THREEFS,
+                                                       StorageTypeWeights::DEFAULT};
 
     WeightArray &storage_weights_ = default_storage_weights_;
 };

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -164,6 +164,7 @@ private:
         // slot 3: DATA_STORAGE_TYPE_TAIR_MEMPOOL usage data
         // slot 4: DATA_STORAGE_TYPE_NFS usage data
         // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
+        // slot 6: DATA_STORAGE_TYPE_DUMMY usage data (testing only)
         array_t_ storage_usage_by_type_;
     };
 

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -262,7 +262,7 @@ TEST_F(MetaIndexerTest, TestMetadataPersistAndRecover) {
 
     // persist
     meta_indexer_->key_count_.store(3);
-    const std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500};
+    const std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600};
     ASSERT_EQ(expected_usage_vec.size(), meta_indexer_->storage_usage_data_.storage_usage_by_type_.size());
     for (std::size_t i = 0; i != meta_indexer_->storage_usage_data_.storage_usage_by_type_.size(); ++i) {
         meta_indexer_->storage_usage_data_.storage_usage_by_type_.at(i).store(expected_usage_vec.at(i));
@@ -299,7 +299,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
         ASSERT_EQ(0, meta_indexer_->GetStorageUsage());
 
         auto type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0};
 
         type = DataStorageType::DATA_STORAGE_TYPE_HF3FS;
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
@@ -340,7 +340,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
     {
         meta_indexer_->storage_usage_data_.Reset();
         auto type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0};
 
         type = DataStorageType::DATA_STORAGE_TYPE_HF3FS;
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
@@ -386,7 +386,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
     // test special case: DATA_STORAGE_TYPE_VCNS_HF3FS behavior as DATA_STORAGE_TYPE_HF3FS
     {
         meta_indexer_->storage_usage_data_.Reset();
-        std::vector<std::uint64_t> expected_usage_vec{0, 128, 0, 0, 0, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 128, 0, 0, 0, 0, 0};
 
         meta_indexer_->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS, 128);
         ASSERT_EQ(128, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS));
@@ -421,7 +421,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
     // Successful round-trip: serialize then deserialize
     {
-        std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500};
+        std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600};
 
         storage_usage_data.Reset();
         for (std::size_t i = 0; i != expected_usage_vec.size(); ++i) {
@@ -429,7 +429,8 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
         }
 
         std::string serialized = storage_usage_data.Serialize();
-        ASSERT_EQ(R"({"unknown":1,"hf3fs":100,"mooncake":200,"pace":300,"file":400,"vcns_hf3fs":500})", serialized);
+        ASSERT_EQ(R"({"unknown":1,"hf3fs":100,"mooncake":200,"pace":300,"file":400,"vcns_hf3fs":500,"dummy":600})",
+                  serialized);
 
         storage_usage_data.Reset();
         ASSERT_EQ(EC_OK, storage_usage_data.Deserialize(serialized));
@@ -440,11 +441,11 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
     // Legal input: keys in different order
     {
-        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6};
+        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7};
         storage_usage_data.Reset();
-        ASSERT_EQ(
-            EC_OK,
-            storage_usage_data.Deserialize(R"({"vcns_hf3fs":6,"file":5,"pace":4,"mooncake":3,"hf3fs":2,"unknown":1})"));
+        ASSERT_EQ(EC_OK,
+                  storage_usage_data.Deserialize(
+                      R"({"dummy":7,"vcns_hf3fs":6,"file":5,"pace":4,"mooncake":3,"hf3fs":2,"unknown":1})"));
         for (std::size_t i = 0; i != storage_usage_data.storage_usage_by_type_.size(); ++i) {
             ASSERT_EQ(expected_usage_vec.at(i), storage_usage_data.storage_usage_by_type_.at(i).load());
         }
@@ -458,15 +459,18 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
         ASSERT_EQ(100, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_HF3FS));
         ASSERT_EQ(200, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE));
         ASSERT_EQ(0, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL));
+        ASSERT_EQ(0, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS));
+        ASSERT_EQ(0, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_DUMMY));
     }
 
     // Legal input: whitespace-padded JSON
     {
-        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6};
+        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7};
         storage_usage_data.Reset();
-        ASSERT_EQ(EC_OK,
-                  storage_usage_data.Deserialize(
-                      "  {\"unknown\":1,\"hf3fs\":2,\"mooncake\":3,\"pace\":4,\"file\":5,\"vcns_hf3fs\":6}  "));
+        ASSERT_EQ(
+            EC_OK,
+            storage_usage_data.Deserialize(
+                "  {\"unknown\":1,\"hf3fs\":2,\"mooncake\":3,\"pace\":4,\"file\":5,\"vcns_hf3fs\":6,\"dummy\":7}  "));
         for (std::size_t i = 0; i != storage_usage_data.storage_usage_by_type_.size(); ++i) {
             ASSERT_EQ(expected_usage_vec.at(i), storage_usage_data.storage_usage_by_type_.at(i).load());
         }

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -42,9 +42,14 @@ enum StorageType {
     ST_TAIRMEMPOOL = 3;
     ST_NFS = 4;
     ST_VCNS_3FS = 5;
+    ST_DUMMY = 6;
 }
 
-message LocalStorageSpec {}
+// for dummy storage backend
+message LocalStorageSpec {
+    string root_path = 1;
+    int32 key_count_per_file = 2;
+}
 
 // 3fs
 message ThreeFSStorageSpec {

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -45,8 +45,9 @@ enum StorageType {
     ST_DUMMY = 6;
 }
 
-// for dummy storage backend
-message LocalStorageSpec {
+message LocalStorageSpec {}
+
+message DummyStorageSpec {
     string root_path = 1;
     int32 key_count_per_file = 2;
 }
@@ -105,6 +106,7 @@ message StorageConfig {
         TairMemPoolStorageSpec tair_mem_pool = 5;
         NfsStorageSpec nfs = 6;
         VcnsThreeFSStorageSpec vcnsthreefs = 7;
+        DummyStorageSpec dummy = 9;
     }
     bool check_storage_available_when_open = 8;
 }

--- a/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
@@ -39,6 +39,7 @@ enum StorageType {
     ST_TAIRMEMPOOL = 3;
     ST_NFS = 4;
     ST_VCNS_3FS = 5;
+    ST_DUMMY = 6;
 }
 
 // 使用URI统一多种存储表示，由client或者connector负责解析

--- a/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
@@ -67,6 +67,11 @@ message InstanceInfo {
 
 message LocalStorageSpec {}
 
+message DummyStorageSpec {
+    string root_path = 1;
+    int32 key_count_per_file = 2;
+}
+
 // 3fs
 message ThreeFSStorageSpec {
     string cluster_name = 1;      // 3fs集群名
@@ -119,6 +124,7 @@ message StorageConfig {
         TairMemPoolStorageSpec tair_mem_pool = 5;
         NfsStorageSpec nfs = 6;
         ThreeFSStorageSpec vcnsthreefs = 7;
+        DummyStorageSpec dummy = 9;
     }
     bool check_storage_available_when_open = 8;
 }

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -94,6 +94,11 @@ message InstanceInfo {
 
 message LocalStorageSpec {}
 
+message DummyStorageSpec {
+    string root_path = 1;
+    int32 key_count_per_file = 2;
+}
+
 // 3fs
 message ThreeFSStorageSpec {
     string cluster_name = 1;      // 3fs集群名
@@ -148,6 +153,7 @@ message StorageConfig {
         TairMemPoolStorageSpec tair_mem_pool = 5;
         NfsStorageSpec nfs = 6;
         ThreeFSStorageSpec vcnsthreefs = 7;
+        DummyStorageSpec dummy = 9;
     }
     bool check_storage_available_when_open = 8;
 }

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -41,6 +41,7 @@ enum StorageType {
     ST_TAIRMEMPOOL = 3;
     ST_NFS = 4;
     ST_VCNS_3FS = 5;
+    ST_DUMMY = 6;
 }
 
 // 使用URI统一多种存储表示，由client或者connector负责解析

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -55,6 +55,11 @@ void ProtoConvert::StorageConfigToProto(const StorageConfig &storage_config,
         auto *nfs = proto_storage_config->mutable_nfs();
         nfs->set_root_path(nfs_storage.root_path());
         nfs->set_key_count_per_file(nfs_storage.key_count_per_file());
+    } else if (type == DataStorageType::DATA_STORAGE_TYPE_DUMMY) {
+        const auto &dummy_storage = *std::dynamic_pointer_cast<DummyStorageSpec>(storage_config.storage_spec());
+        auto *local = proto_storage_config->mutable_local();
+        local->set_root_path(dummy_storage.root_path());
+        local->set_key_count_per_file(dummy_storage.key_count_per_file());
     }
 }
 
@@ -119,10 +124,18 @@ void ProtoConvert::StorageFromProto(const proto::admin::StorageConfig *proto_sto
         storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_NFS);
         break;
     }
+    case proto::admin::StorageConfig::kLocal: {
+        DummyStorageSpec spec;
+        spec.set_root_path(proto_storage_config->local().root_path());
+        spec.set_key_count_per_file(proto_storage_config->local().key_count_per_file());
+        storage_config.set_storage_spec(std::make_shared<DummyStorageSpec>(spec));
+        storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_DUMMY);
+        break;
+    }
     default:
         storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN);
         KVCM_LOG_WARN("Unknown storage type in request proto: storage_type should be : threefs, mooncake, "
-                      "tair_mem_pool or nfs");
+                      "tair_mem_pool, nfs or local");
         break;
     }
 }

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -135,7 +135,7 @@ void ProtoConvert::StorageFromProto(const proto::admin::StorageConfig *proto_sto
     default:
         storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN);
         KVCM_LOG_WARN("Unknown storage type in request proto: storage_type should be : threefs, mooncake, "
-                      "tair_mem_pool, nfs or local");
+                      "tair_mem_pool, nfs or dummy");
         break;
     }
 }

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -57,9 +57,9 @@ void ProtoConvert::StorageConfigToProto(const StorageConfig &storage_config,
         nfs->set_key_count_per_file(nfs_storage.key_count_per_file());
     } else if (type == DataStorageType::DATA_STORAGE_TYPE_DUMMY) {
         const auto &dummy_storage = *std::dynamic_pointer_cast<DummyStorageSpec>(storage_config.storage_spec());
-        auto *local = proto_storage_config->mutable_local();
-        local->set_root_path(dummy_storage.root_path());
-        local->set_key_count_per_file(dummy_storage.key_count_per_file());
+        auto *dummy = proto_storage_config->mutable_dummy();
+        dummy->set_root_path(dummy_storage.root_path());
+        dummy->set_key_count_per_file(dummy_storage.key_count_per_file());
     }
 }
 
@@ -124,10 +124,10 @@ void ProtoConvert::StorageFromProto(const proto::admin::StorageConfig *proto_sto
         storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_NFS);
         break;
     }
-    case proto::admin::StorageConfig::kLocal: {
+    case proto::admin::StorageConfig::kDummy: {
         DummyStorageSpec spec;
-        spec.set_root_path(proto_storage_config->local().root_path());
-        spec.set_key_count_per_file(proto_storage_config->local().key_count_per_file());
+        spec.set_root_path(proto_storage_config->dummy().root_path());
+        spec.set_key_count_per_file(proto_storage_config->dummy().key_count_per_file());
         storage_config.set_storage_spec(std::make_shared<DummyStorageSpec>(spec));
         storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_DUMMY);
         break;

--- a/kv_cache_manager/service/util/manager_message_proto_util.h
+++ b/kv_cache_manager/service/util/manager_message_proto_util.h
@@ -294,6 +294,10 @@ void ProtoConvert::DataStorageTypeToProto(const DataStorageType &data_storage_ty
         *proto_data_storage_type = T::ST_NFS;
         break;
     }
+    case DataStorageType::DATA_STORAGE_TYPE_DUMMY: {
+        *proto_data_storage_type = T::ST_DUMMY;
+        break;
+    }
     default: {
         // Handle unknown storage type case if necessary
         break;
@@ -328,6 +332,10 @@ void ProtoConvert::DataStorageTypeFromProto(const T proto_data_storage_type, Dat
     }
     case T::ST_NFS: {
         data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_NFS;
+        break;
+    }
+    case T::ST_DUMMY: {
+        data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_DUMMY;
         break;
     }
     default: {


### PR DESCRIPTION
## [test] add e2e test cases for aggressive location pruning

This is the follow-up e2e test work to #110 .

## [data_storage] introducing the dummy storage backend

The dummy storage backend is a local filesystem based storage backend
for testing purposes only.

The e2e tests for aggressive location pruning need a storage backend
with `MightExist()` actually implemented, but currently no storage
backend can satisfy the need. This is where the dummy backend comes into
play: it can implement `MightExist()` without worrying about the
read/write path overhead.

Backward-compatibility is naturally handled so no new instance behavior
version needs to be introduced:

```
v0-data: key_count
v1-data: key_count, usage_data[_,]
v2-data: key_count, usage_data[_,dummy]
```

During recovery:

|    | v0-data | v1-data    | v2-data    |
| -- | ------- | ---------- | ---------- |
| v0 | v0,ok   | v0,ok(ignored) | v0,ok(ignored) |
| v1 | v0,ok   | v1,ok      | err,ok     |
| v2 | v0,ok   | v1,ok(dummy=0) | v2,ok  |