### PR TITLE
[metrics] enhance sanitizing for valid Prometheus identifiers

### DIFF
--- a/kv_cache_manager/metrics/prometheus_exporter.cc
+++ b/kv_cache_manager/metrics/prometheus_exporter.cc
@@ -12,25 +12,35 @@ namespace kv_cache_manager {
 
 namespace {
 
-// Prometheus metric names must match [a-zA-Z_:][a-zA-Z0-9_:]*.
-// Replace every character that is not in that set with '_'.
-std::string SanitizeName(const std::string &prefix, const std::string &raw_name) {
+// Prometheus metric names must match [a-zA-Z_:][a-zA-Z0-9_:]*
+// Prometheus label names must match [a-zA-Z_][a-zA-Z0-9_]*
+// replace every character that is not in that set with '_'
+// and ignore the ':' handling for unity
+std::string SanitizeIdentifier(const std::string &raw) {
     std::string out;
-    out.reserve(prefix.size() + 1 + raw_name.size());
-    out += prefix;
-    out += '_';
-    for (char c : raw_name) {
-        if (c == '.' || c == '-') {
-            out += '_';
-        } else {
+    out.reserve(raw.size());
+    for (char c : raw) {
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
             out += c;
+        } else {
+            out += '_';
         }
     }
     return out;
 }
 
-// Prometheus label values use double-quoted strings.  Backslash,
-// double-quote and newline must be escaped.
+// build a prometheus metric name: prefix + '_' + sanitized(raw_name)
+std::string SanitizeName(const std::string &prefix, const std::string &raw_name) {
+    std::string out;
+    out.reserve(prefix.size() + 1 + raw_name.size());
+    out += prefix;
+    out += '_';
+    out += SanitizeIdentifier(raw_name);
+    return out;
+}
+
+// prometheus label values use double-quoted strings; backslash,
+// double-quote and newline must be escaped
 void EscapeLabelValue(std::ostringstream &ss, const std::string &v) {
     for (char c : v) {
         switch (c) {
@@ -60,7 +70,7 @@ void WriteLabels(std::ostringstream &ss, const MetricsTags &tags) {
             ss << ',';
         }
         first = false;
-        ss << k << "=\"";
+        ss << SanitizeIdentifier(k) << "=\"";
         EscapeLabelValue(ss, v);
         ss << '"';
     }

--- a/kv_cache_manager/metrics/prometheus_exporter.cc
+++ b/kv_cache_manager/metrics/prometheus_exporter.cc
@@ -12,15 +12,27 @@ namespace kv_cache_manager {
 
 namespace {
 
-// Prometheus metric names must match [a-zA-Z_:][a-zA-Z0-9_:]*
-// Prometheus label names must match [a-zA-Z_][a-zA-Z0-9_]*
-// replace every character that is not in that set with '_'
-// and ignore the ':' handling for unity
+// replace characters that are invalid in a prometheus identifier
+// with underscores; keeps only [a-zA-Z0-9_]
+// a leading digit is prefixed with '_' since both metric names and
+// label names require the first character to match [a-zA-Z_]
+//
+// WARN:
+// distinct raw strings that differ only in characters replaced by '_'
+// (e.g. "storage.type" vs "storage_type") will produce the same output
+// callers must avoid tag keys that would collide after sanitization --
+// duplicate label names are invalid in prometheus text format
 std::string SanitizeIdentifier(const std::string &raw) {
     std::string out;
-    out.reserve(raw.size());
-    for (char c : raw) {
-        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+    out.reserve(raw.size() + 1);
+    for (std::size_t i = 0; i < raw.size(); ++i) {
+        char c = raw[i];
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
+            out += c;
+        } else if (c >= '0' && c <= '9') {
+            if (i == 0) {
+                out += '_';
+            }
             out += c;
         } else {
             out += '_';

--- a/kv_cache_manager/metrics/prometheus_exporter.cc
+++ b/kv_cache_manager/metrics/prometheus_exporter.cc
@@ -33,7 +33,7 @@ std::string SanitizeIdentifier(const std::string &raw) {
 std::string SanitizeName(const std::string &prefix, const std::string &raw_name) {
     std::string out;
     out.reserve(prefix.size() + 1 + raw_name.size());
-    out += prefix;
+    out += SanitizeIdentifier(prefix);
     out += '_';
     out += SanitizeIdentifier(raw_name);
     return out;

--- a/kv_cache_manager/metrics/prometheus_exporter.cc
+++ b/kv_cache_manager/metrics/prometheus_exporter.cc
@@ -20,8 +20,10 @@ namespace {
 // WARN:
 // distinct raw strings that differ only in characters replaced by '_'
 // (e.g. "storage.type" vs "storage_type") will produce the same output
-// callers must avoid tag keys that would collide after sanitization --
-// duplicate label names are invalid in prometheus text format
+// callers must avoid collisions after sanitization in all contexts:
+// - metric names: duplicates cause repeated HELP/TYPE lines
+// - label keys: duplicates are invalid in prometheus text format
+// - prefixes: same collision risk as metric names
 std::string SanitizeIdentifier(const std::string &raw) {
     std::string out;
     out.reserve(raw.size() + 1);

--- a/kv_cache_manager/metrics/prometheus_exporter.h
+++ b/kv_cache_manager/metrics/prometheus_exporter.h
@@ -10,10 +10,14 @@ class MetricsRegistry;
 // text exposition format (text/plain; version=0.0.4; charset=utf-8).
 //
 // Naming rules applied during serialization:
-//   - Dots in the internal metric name are replaced with underscores.
+//   - Metric names, label keys and the prefix are sanitized to the
+//     Prometheus identifier charset [a-zA-Z0-9_].  Characters outside
+//     that set are replaced with underscores; a leading digit gets a
+//     '_' prefix.
 //   - A configurable prefix (default "kvcm") is prepended, separated
 //     by an underscore.
-//   - MetricsTags become Prometheus labels.
+//   - MetricsTags become Prometheus labels (keys sanitized, values
+//     escaped per the exposition format).
 //   - CounterValue metrics are emitted with TYPE counter.
 //   - GaugeValue   metrics are emitted with TYPE gauge.
 class PrometheusExporter {

--- a/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
+++ b/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
@@ -149,3 +149,59 @@ TEST_F(PrometheusExporterTest, MultipleMetricFamilies) {
     EXPECT_NE(output.find("# TYPE kvcm_meta_indexer_total_key_count gauge"), std::string::npos);
     EXPECT_NE(output.find("# TYPE kvcm_service_query_counter counter"), std::string::npos);
 }
+
+// -- SanitizeIdentifier specification tests (exercised through Expose) --
+
+TEST_F(PrometheusExporterTest, SpecialCharsInMetricName) {
+    // characters beyond '.' and '-': @, space, colon, slash
+    Gauge g = registry_->GetGauge("ns:group/metric name@v2");
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("kvcm_ns_group_metric_name_v2"), std::string::npos) << "Actual output:\n" << output;
+}
+
+TEST_F(PrometheusExporterTest, AllValidInputUnchanged) {
+    // a name with only [a-zA-Z0-9_] should pass through unchanged
+    Gauge g = registry_->GetGauge("abc_XYZ_012");
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("kvcm_abc_XYZ_012"), std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, ConsecutiveSpecialChars) {
+    Gauge g = registry_->GetGauge("a..b--c");
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("kvcm_a__b__c"), std::string::npos) << "Actual output:\n" << output;
+}
+
+TEST_F(PrometheusExporterTest, LeadingDigitInMetricName) {
+    Gauge g = registry_->GetGauge("3abc");
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    // leading digit gets a '_' prefix: "3abc" -> "_3abc"
+    EXPECT_NE(output.find("kvcm__3abc"), std::string::npos) << "Actual output:\n" << output;
+}
+
+TEST_F(PrometheusExporterTest, LeadingDigitInLabelKey) {
+    MetricsTags tags = {{"1abc", "val"}};
+    Gauge g = registry_->GetGauge("test.leading_digit_label", tags);
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("_1abc=\"val\""), std::string::npos) << "Actual output:\n" << output;
+    // raw key must not appear
+    EXPECT_EQ(output.find("{1abc="), std::string::npos);
+}
+
+TEST_F(PrometheusExporterTest, LeadingDigitInPrefix) {
+    Gauge g = registry_->GetGauge("service.qps");
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_, "9app");
+    EXPECT_NE(output.find("_9app_service_qps"), std::string::npos) << "Actual output:\n" << output;
+}

--- a/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
+++ b/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
@@ -89,6 +89,15 @@ TEST_F(PrometheusExporterTest, CustomPrefix) {
     EXPECT_EQ(output.find("kvcm_"), std::string::npos);
 }
 
+TEST_F(PrometheusExporterTest, PrefixSanitization) {
+    Gauge g = registry_->GetGauge("service.qps");
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_, "my-app.v2");
+    EXPECT_NE(output.find("my_app_v2_service_qps"), std::string::npos) << "Actual output:\n" << output;
+    EXPECT_EQ(output.find("my-app"), std::string::npos);
+}
+
 TEST_F(PrometheusExporterTest, LabelValueEscaping) {
     MetricsTags tags = {{"path", "a\\b\"c\nd"}};
     Gauge g = registry_->GetGauge("test.escape", tags);

--- a/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
+++ b/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
@@ -106,6 +106,20 @@ TEST_F(PrometheusExporterTest, DotAndDashInNames) {
     EXPECT_NE(output.find("kvcm_my_group_some_metric"), std::string::npos);
 }
 
+TEST_F(PrometheusExporterTest, LabelKeySanitization) {
+    MetricsTags tags = {{"storage.type", "hf3fs"}, {"host-name", "node01"}};
+    Gauge g = registry_->GetGauge("test.label_keys", tags);
+    g = 1.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    // dots and dashes in label keys should be replaced with underscores
+    EXPECT_NE(output.find("storage_type=\"hf3fs\""), std::string::npos) << "Actual output:\n" << output;
+    EXPECT_NE(output.find("host_name=\"node01\""), std::string::npos) << "Actual output:\n" << output;
+    // originals should not appear as label keys
+    EXPECT_EQ(output.find("storage.type="), std::string::npos);
+    EXPECT_EQ(output.find("host-name="), std::string::npos);
+}
+
 TEST_F(PrometheusExporterTest, HelpLineContainsOriginalName) {
     Gauge g = registry_->GetGauge("meta_searcher.indexer_get_time_us");
     g = 99.5;

--- a/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
+++ b/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
@@ -159,6 +159,10 @@ TEST_F(PrometheusExporterTest, SpecialCharsInMetricName) {
 
     std::string output = PrometheusExporter::Expose(*registry_);
     EXPECT_NE(output.find("kvcm_ns_group_metric_name_v2"), std::string::npos) << "Actual output:\n" << output;
+    // HELP line must preserve the original raw name (pre-sanitization)
+    EXPECT_NE(output.find("# HELP kvcm_ns_group_metric_name_v2 ns:group/metric name@v2"), std::string::npos)
+        << "Actual output:\n"
+        << output;
 }
 
 TEST_F(PrometheusExporterTest, AllValidInputUnchanged) {


### PR DESCRIPTION
This is a follow-up refinement to #106 .

## Situation for current codebase

Only `.` and `-` are realistic offenders in this codebase.  Metric names
come from `DEFINE_METRICS_NAME_` which produces:

```
    C_identifier "." C_identifier
```

So `.` is the only special character.  Tag keys are hardcoded strings
like `type`, `unique_name`, `instance_group` -- all already valid.  No
dashes or dots appear in any current tag key.

## What does this work do

This work still do a proper allowlist check (`[a-zA-Z0-9_]` pass through,
everything else becomes `_`) rather than a blocklist of `.` and `-`.

Reasons being:

1. The cost is identical -- one pass over the string either way.
2. The comment now matches the implementation (the original comment
   claimed general replacement but only handled two characters).
3. Label keys now go through the same sanitizer, closing the gap between
   the metrics names and label keys.
4. It's defensive against future callers without being speculative
   engineering -- it's the same amount of code.