### PR TITLE
[connector] align MLA storage spec to rank0 and skip TP sync paths

### DIFF
--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -125,7 +125,8 @@ class HiCacheKVCM(HiCacheStorage):
                 name = self._tp_rank_to_linear_spec_name(rank)
                 self.location_spec_infos.append({"name": name, "size": self.mamba_spec_size})
                 linear_spec_names.append(name)
-            self.mamba_location_spec_name = self._tp_rank_to_linear_spec_name(self.tp_rank)
+            mamba_spec_rank = 0 if self.is_mla_model else self.tp_rank
+            self.mamba_location_spec_name = self._tp_rank_to_linear_spec_name(mamba_spec_rank)
             self.location_spec_groups.append({
                 "name": self._get_extra_pool_spec_group(PoolName.MAMBA),
                 "spec_names": linear_spec_names,
@@ -140,7 +141,8 @@ class HiCacheKVCM(HiCacheStorage):
                 name = self._tp_rank_to_indexer_spec_name(rank)
                 self.location_spec_infos.append({"name": name, "size": self.indexer_spec_size})
                 indexer_spec_names.append(name)
-            self.indexer_location_spec_name = self._tp_rank_to_indexer_spec_name(self.tp_rank)
+            indexer_spec_rank = 0 if self.is_mla_model else self.tp_rank
+            self.indexer_location_spec_name = self._tp_rank_to_indexer_spec_name(indexer_spec_rank)
             self.location_spec_groups.append({
                 "name": self._get_extra_pool_spec_group(PoolName.INDEXER),
                 "spec_names": indexer_spec_names,
@@ -171,7 +173,9 @@ class HiCacheKVCM(HiCacheStorage):
         self.storage_configs = register_response["storage_configs"]
 
         # data transfer setup
-        self.location_spec_name = self._tp_rank_to_spec_name(self.tp_rank)
+        # MLA: only rank 0 writes, so all ranks use rank 0's spec for read/write
+        kv_spec_rank = 0 if self.is_mla_model else self.tp_rank
+        self.location_spec_name = self._tp_rank_to_spec_name(kv_spec_rank)
 
         self.write_timeout_seconds = self.extra_config.get("write_timeout_seconds", 30)
 
@@ -469,11 +473,11 @@ class HiCacheKVCM(HiCacheStorage):
                 logger.error(f"start_write_cache failed: {e}")
                 result = None
 
-            if self.tp_world_size > 1:
+            if self.tp_world_size > 1 and not self.is_mla_model:
                 torch.distributed.broadcast_object_list(
                     [result, len_prefix, len_new, local_hash], src=0, group=self.storage_tp_group
                 )
-        else:
+        elif not self.is_mla_model:
             recv = [None, None, None, None]
             torch.distributed.broadcast_object_list(
                 recv, src=0, group=self.storage_tp_group
@@ -606,7 +610,7 @@ class HiCacheKVCM(HiCacheStorage):
                 # per_block_flags remains all zeros
 
         # Per-block all_reduce: only blocks ALL ranks wrote are marked success
-        if self.tp_world_size > 1:
+        if self.tp_world_size > 1 and not self.is_mla_model:
             torch.distributed.all_reduce(
                 per_block_flags,
                 op=torch.distributed.ReduceOp.MIN,
@@ -698,11 +702,11 @@ class HiCacheKVCM(HiCacheStorage):
                     except Exception as e:
                         logger.error(f"start_write_cache failed on rank 0: {trace_id=} {e=}")
                         write_result = None
-                    if self.tp_world_size > 1:
+                    if self.tp_world_size > 1 and not self.is_mla_model:
                         torch.distributed.broadcast_object_list(
                             [write_result], src=0, group=self.storage_tp_group
                         )
-                else:
+                elif not self.is_mla_model:
                     recv = [None]
                     torch.distributed.broadcast_object_list(
                         recv, src=0, group=self.storage_tp_group
@@ -789,7 +793,7 @@ class HiCacheKVCM(HiCacheStorage):
                     logger.error(f"Data transfer v2 (SaveKvCaches) failed: {transfer.name} {e}")
                     flag = False
 
-                if self.tp_world_size > 1:
+                if self.tp_world_size > 1 and not self.is_mla_model:
                     flag_tensor = torch.tensor(flag, dtype=torch.int)
                     torch.distributed.all_reduce(
                         flag_tensor,

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -112,9 +112,10 @@ class HiCacheKVCM(HiCacheStorage):
             "size": self.location_spec_size,
         } for rank in range(self.tp_size)]
 
-        # LocationSpecGroup: KV specs only
+        # LocationSpecGroup: KV specs always prepared, but only sent when
+        # extra pools exist (backward compat with older managers).
         kv_spec_names = [self._tp_rank_to_spec_name(rank) for rank in range(self.tp_size)]
-        self.location_spec_groups = [{"name": self._get_kv_spec_group(), "spec_names": kv_spec_names}]
+        self.location_spec_groups = []
 
         # Mamba/Linear specs
         if self.has_mamba:
@@ -148,6 +149,12 @@ class HiCacheKVCM(HiCacheStorage):
                 "spec_names": indexer_spec_names,
             })
 
+        if self.location_spec_groups:
+            self.location_spec_groups.insert(0, {
+                "name": self._get_kv_spec_group(),
+                "spec_names": kv_spec_names,
+            })
+
         self.deployment = {
             "model_name": self.model_name,
             "tp_size": self.tp_size,
@@ -164,8 +171,9 @@ class HiCacheKVCM(HiCacheStorage):
             "model_deployment": self.deployment,
             "block_size": self.block_size,
             "location_spec_infos": self.location_spec_infos,
-            "location_spec_groups": self.location_spec_groups,
         }
+        if self.location_spec_groups:
+            register_request["location_spec_groups"] = self.location_spec_groups
         # TODO: check conflict and update
         register_response = self._manager_client.register_instance(register_request)
         logger.debug(f"register_instance {register_response=}")

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -477,7 +477,11 @@ class HiCacheKVCM(HiCacheStorage):
                 torch.distributed.broadcast_object_list(
                     [result, len_prefix, len_new, local_hash], src=0, group=self.storage_tp_group
                 )
-        elif not self.is_mla_model:
+        elif self.is_mla_model:
+            logger.warning(f"_batch_set called on non-rank-0 (tp_rank={self.tp_rank}) "
+                           f"for MLA model; only rank 0 should write. Returning all False.")
+            return [False] * len_new
+        else:
             recv = [None, None, None, None]
             torch.distributed.broadcast_object_list(
                 recv, src=0, group=self.storage_tp_group
@@ -706,7 +710,12 @@ class HiCacheKVCM(HiCacheStorage):
                         torch.distributed.broadcast_object_list(
                             [write_result], src=0, group=self.storage_tp_group
                         )
-                elif not self.is_mla_model:
+                elif self.is_mla_model:
+                    logger.warning(f"batch_set_v2 called on non-rank-0 (tp_rank={self.tp_rank}) "
+                                   f"for MLA model; only rank 0 should write. Returning all False.")
+                    results[transfer.name] = [False] * len(keys)
+                    continue
+                else:
                     recv = [None]
                     torch.distributed.broadcast_object_list(
                         recv, src=0, group=self.storage_tp_group

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -36,7 +36,8 @@ def _make_obj(cls):
 
 def _build_connector(*, tp_rank=0, tp_world_size=1, kv_factor=2,
                      instance_id="test", location_spec_name="tp_0",
-                     location_spec_size=4096, write_timeout_seconds=30):
+                     location_spec_size=4096, write_timeout_seconds=30,
+                     is_mla_model=False):
     """Build a HiCacheKVCM with attributes set manually (bypass __init__)."""
     obj = _make_obj(HiCacheKVCM)
     obj.tp_rank = tp_rank
@@ -46,6 +47,7 @@ def _build_connector(*, tp_rank=0, tp_world_size=1, kv_factor=2,
     obj.location_spec_name = location_spec_name
     obj.location_spec_size = location_spec_size
     obj.write_timeout_seconds = write_timeout_seconds
+    obj.is_mla_model = is_mla_model
     obj.backup_pgs = []
     obj.backup_bandwidth = []
     obj._manager_client = MagicMock()
@@ -763,6 +765,95 @@ class TestSkipTransfer(unittest.TestCase):
 
         self.assertEqual(len(result), 3)
         self.assertEqual(result, [False, False, False])
+
+
+class TestMLASkipTPSync(unittest.TestCase):
+    """Verify MLA models skip broadcast/all_reduce in _batch_set.
+
+    MLA models set is_mla_model=True. In sglang only rank 0 writes
+    (backup_skip), so the connector skips TP synchronisation to avoid hangs.
+    """
+
+    def _make_mla_rank0(self):
+        """MLA connector at rank 0 in a 2-rank setup."""
+        c = _build_connector(
+            tp_rank=0, tp_world_size=2, kv_factor=1,
+            location_spec_name="tp_0_full", is_mla_model=True,
+        )
+        c.storage_tp_group = MagicMock()
+        return c
+
+    def _setup_write(self, c, num_keys=3, save_ok=True):
+        locations = [
+            {"location_specs": [{"name": "tp_0_full", "uri": f"uri_{i}"}]}
+            for i in range(num_keys)
+        ]
+        c._manager_client.start_write_cache.return_value = {
+            "locations": locations,
+            "write_session_id": "ws-mla",
+            "block_mask": {"offset": 0},
+        }
+        c.mem_pool_host.get_page_buffer_meta.return_value = (
+            list(range(num_keys * c.kv_factor)),
+            [c.location_spec_size] * (num_keys * c.kv_factor),
+        )
+        err = _mock_kvcm.ClientErrorCode.ER_OK if save_ok else 999
+        c.transfer_client.SaveKvCaches.return_value = (err,)
+
+    # ── MLA-1: rank 0 writes succeed without broadcast/all_reduce ─────
+    def test_mla_rank0_no_broadcast(self):
+        """MLA rank 0 writes successfully; broadcast is never called."""
+        c = self._make_mla_rank0()
+        self._setup_write(c)
+
+        with patch("torch.distributed.broadcast_object_list") as mock_bcast, \
+             patch("torch.distributed.all_reduce") as mock_allreduce:
+            result = c._batch_set(["k0", "k1", "k2"], torch.zeros(3), trace_id="mla1")
+
+        self.assertEqual(result, [True, True, True])
+        mock_bcast.assert_not_called()
+        mock_allreduce.assert_not_called()
+
+    # ── MLA-2: rank 0 write fails, still no broadcast ────────────────
+    def test_mla_rank0_failure_no_broadcast(self):
+        """MLA rank 0 write fails; broadcast/all_reduce still not called."""
+        c = self._make_mla_rank0()
+        self._setup_write(c, save_ok=False)
+
+        with patch("torch.distributed.broadcast_object_list") as mock_bcast, \
+             patch("torch.distributed.all_reduce") as mock_allreduce:
+            result = c._batch_set(["k0", "k1", "k2"], torch.zeros(3), trace_id="mla2")
+
+        self.assertEqual(result, [False, False, False])
+        mock_bcast.assert_not_called()
+        mock_allreduce.assert_not_called()
+
+    # ── MLA-3: rank 0 start_write_cache fails, no broadcast ──────────
+    def test_mla_rank0_start_write_fails_no_broadcast(self):
+        """MLA rank 0: start_write_cache throws; no broadcast, returns all False."""
+        c = self._make_mla_rank0()
+        c._manager_client.start_write_cache.side_effect = RuntimeError("boom")
+
+        with patch("torch.distributed.broadcast_object_list") as mock_bcast:
+            result = c.batch_set_v1(["k0", "k1"], torch.zeros(2))
+
+        self.assertEqual(result, [False, False])
+        mock_bcast.assert_not_called()
+
+    # ── MLA-4: kv_factor=1 produces correct number of IOVs ───────────
+    def test_mla_kv_factor_1(self):
+        """MLA uses kv_factor=1: each page has 1 IOV (not 2 like MHA)."""
+        c = self._make_mla_rank0()
+        self._setup_write(c, num_keys=4)
+
+        with patch("torch.distributed.broadcast_object_list"), \
+             patch("torch.distributed.all_reduce"):
+            c._batch_set(["k0", "k1", "k2", "k3"], torch.zeros(4), trace_id="mla4")
+
+        # SaveKvCaches should be called with 4 URIs (1 per page, not 8)
+        save_args = c.transfer_client.SaveKvCaches.call_args[0]
+        self.assertEqual(len(save_args[0]), 4)  # uris
+        self.assertEqual(len(save_args[1]), 4)  # buffers
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Modified the HiCacheKVCM class to ensure that when using the MLA model, all ranks utilize rank 0 for location specifications. This change affects the determination of mamba and indexer location spec names, as well as the handling of data transfer operations across multiple ranks, improving consistency and correctness in distributed scenarios.