### PR TITLE
[cicd] update qoder-review job runner to ubuntu-latest

### DIFF
--- a/.github/workflows/qoder-code-review.yml
+++ b/.github/workflows/qoder-code-review.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   qoder-review:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     # Trigger conditions:
     # 1. PR opened/reopened (ignore synchronize to reduce duplicate reviews)
     # 2. 'ai reviewed' label removed (re-review)


### PR DESCRIPTION
#122 did not resolve the job timeout issue due to:

> If the timeout exceeds the job execution time limit for the runner, the job will be canceled when the execution time limit is met instead.

The `ubuntu-slim` runners have usage limits, including a [runtime limit](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners):

> The job timeout for single-CPU runners is 15 minutes. If a job reaches this limit, the job is terminated and fails.

Update the runner to `ubuntu-latest` to remove this limit.