### PR TITLE
[manager] disable indefinite location deleting retry

### DIFF
--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -1081,7 +1081,7 @@ void CacheReclaimer::HandleDelRes() noexcept {
             it = delete_handlers_.erase_after(it_pre);
         } else if (const auto fs = it->fut_.wait_for(std::chrono::seconds::zero()); fs == std::future_status::ready) {
             try {
-                if (const auto [ec, err_msg, _] = it->fut_.get(); ec != ErrorCode::EC_OK) {
+                if (const auto [ec, err_msg] = it->fut_.get(); ec != ErrorCode::EC_OK) {
                     LOG_WITH_ID(WARN,
                                 "reclaim request execute failed, error_code: [%d], error message: [%s]",
                                 static_cast<std::int32_t>(ec),

--- a/kv_cache_manager/manager/reclaimer_task_supervisor.cc
+++ b/kv_cache_manager/manager/reclaimer_task_supervisor.cc
@@ -69,26 +69,11 @@ void ReclaimerTaskSupervisor::WorkLoop() {
             auto status = cell->result.wait_for(kDefaultFutureWaitTime);
             if (status == std::future_status::ready) {
                 auto del_result = cell->result.get();
-                if (del_result.status != ErrorCode::EC_OK) {
-                    // retry
-                    CacheLocationDelRequest request;
-                    request.instance_id = cell->instance_id;
-                    request.delay = std::chrono::seconds(0);
-                    for (const auto &meta : del_result.fail_metas) {
-                        request.block_keys.push_back(meta.block_key);
-                        request.location_ids.push_back(meta.location_ids);
-                    }
-                    cell->result = schedule_plan_executor_->Submit(request);
-                    if (cell->result.valid()) {
-                        cell_queue_.Push(cell);
-                    }
-                } else {
-                    KVCM_LOG_INFO("delete task finish : instance_id[%s] trace_id [%s] ec[%d] message[%s]",
-                                  cell->instance_id.c_str(),
-                                  cell->trace_id.c_str(),
-                                  del_result.status,
-                                  del_result.error_message.c_str());
-                }
+                KVCM_LOG_INFO("delete task finish : instance_id[%s] trace_id [%s] ec[%d] message[%s]",
+                              cell->instance_id.c_str(),
+                              cell->trace_id.c_str(),
+                              del_result.status,
+                              del_result.error_message.c_str());
             } else {
                 cell_queue_.Push(cell);
             }

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -32,7 +32,6 @@ void HandleErrorPromise(const std::shared_ptr<std::promise<ResultType>> &promise
     promise->set_value(ResultType{
         .status = error_code,
         .error_message = std::move(error_message),
-        .fail_metas = {},
     });
 }
 } // namespace
@@ -211,26 +210,16 @@ void SchedulePlanExecutor::DoLocationDelTask(const std::shared_ptr<std::promise<
         ErrorCode delete_meta_ec =
             meta_searcher.BatchCADLocationStatus(ctx.get(), block_keys_to_delete, batch_cad_tasks, delete_meta_results);
         (void)delete_meta_ec; // 忽略返回值
-        std::vector<ErrorCode> status_vec;
-        std::vector<std::string> location_ids;
         for (size_t block_key_idx = 0; block_key_idx < delete_meta_results.size(); ++block_key_idx) {
             auto &results = delete_meta_results[block_key_idx];
             for (size_t location_idx = 0; location_idx < results.size(); location_idx++) {
                 if (results[location_idx] != ErrorCode::EC_OK) {
-                    status_vec.push_back(results[location_idx]);
-                    location_ids.push_back(batch_cad_tasks[block_key_idx][location_idx].location_id);
                     result.status = ErrorCode::EC_PARTIAL_OK;
                     KVCM_LOG_WARN("Failed to CAD meta key %ld, location: %s, error_code: %d",
                                   block_keys_to_delete[block_key_idx],
                                   batch_cad_tasks[block_key_idx][location_idx].location_id.c_str(),
                                   results[location_idx]);
                 }
-            }
-            if (!status_vec.empty()) {
-                result.fail_metas.push_back(PlanExecuteResultFailMeta{
-                    block_keys_to_delete[block_key_idx], std::move(status_vec), std::move(location_ids)});
-                status_vec.clear();
-                location_ids.clear();
             }
         }
     }
@@ -303,7 +292,7 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheMetaDelRe
     }
 
     if (batch_cas_block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, "", {}});
+        promise->set_value({ErrorCode::EC_OK, ""});
         return future;
     }
 
@@ -321,7 +310,7 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheMetaDelRe
         return future;
     }
     if (actual_task.block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, "", {}});
+        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
         return future;
     }
     KVCM_LOG_DEBUG("Location statuses updated, submitting task to worker pool with delay: %lld microseconds",
@@ -427,7 +416,7 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
         batch_cas_tasks.emplace_back(std::move(location_cas_tasks));
     }
     if (batch_cas_block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, "", {}});
+        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
         return future;
     }
 
@@ -445,7 +434,7 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
         return future;
     }
     if (actual_task.block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, "", {}});
+        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
         return future;
     }
 

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -36,16 +36,9 @@ struct CacheMetaDelRequest {
     std::chrono::microseconds delay{std::chrono::seconds(0)};
 };
 
-struct PlanExecuteResultFailMeta {
-    int64_t block_key;
-    std::vector<ErrorCode> status_vec;
-    std::vector<std::string> location_ids;
-};
-
 struct PlanExecuteResult {
     ErrorCode status;
     std::string error_message;
-    std::vector<PlanExecuteResultFailMeta> fail_metas;
 };
 
 struct CacheLocationDelRequest {


### PR DESCRIPTION
This reverts #68.

#68 was a temporary solution for the Redis meta backend r/w failure,
and actually had no effect because the CLS_DELETING status was ignored
when the retry requests were submitted to the schedule plan executor.

And there's no significant benefit in migrating to a bounded retry at
this moment. So revert it.