### PR TITLE
[metrics] fix begin_ timestamp race under concurrent writes

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -530,6 +530,7 @@ CacheManager::StartWriteCache(RequestContext *request_context,
                                      new_location_spec_group_names,
                                      block_mask);
     }
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ManagerFilterWriteCache);
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, filter_ec, StartWriteCacheInfo, "filter write cache failed");
 
     std::vector<std::string> location_ids;
@@ -538,7 +539,6 @@ CacheManager::StartWriteCache(RequestContext *request_context,
         // if no new keys, delete this write_session_id as soon as possible
         write_timeout_seconds = 10; // seconds
     } else {
-        KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ManagerFilterWriteCache);
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, StartWriteCacheInfo, "start write cache failed");
         KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, GenWriteLocation);
         ec = GenWriteLocation(request_context, instance_id, new_keys, new_location_spec_group_names, new_locations);

--- a/kv_cache_manager/metrics/metrics_collector.h
+++ b/kv_cache_manager/metrics/metrics_collector.h
@@ -10,6 +10,62 @@
 
 namespace kv_cache_manager {
 
+// RAII guard that records a begin timestamp on construction and writes
+// (now - begin) into the target Gauge on explicit reset (move-assign) or,
+// when auto_finish is true, on destruction.
+//
+// Two usage modes controlled by auto_finish:
+//   - CHRONO_SCOPE (auto_finish=true):  records on destruction (scope guard)
+//   - MARK_BEGIN/END (auto_finish=false): records only via MARK_END (move-assign);
+//     if MARK_END is never reached (early return), destructor is a no-op.
+//
+// Stores begin_us_ per-instance (stack / member), eliminating the
+// multi-thread race that existed when begin_ lived on a shared collector.
+class ChronoScopeGuard {
+public:
+    ChronoScopeGuard() noexcept = default;
+
+    explicit ChronoScopeGuard(Gauge *g, bool auto_finish = true) noexcept
+        : gauge_(g), begin_us_(g ? TimestampUtil::GetCurrentTimeUs() : 0), auto_finish_(auto_finish) {}
+
+    ChronoScopeGuard(const ChronoScopeGuard &) = delete;
+    ChronoScopeGuard &operator=(const ChronoScopeGuard &) = delete;
+
+    ChronoScopeGuard(ChronoScopeGuard &&o) noexcept
+        : gauge_(o.gauge_), begin_us_(o.begin_us_), auto_finish_(o.auto_finish_) {
+        o.gauge_ = nullptr;
+    }
+
+    ChronoScopeGuard &operator=(ChronoScopeGuard &&o) noexcept {
+        if (this != &o) {
+            Finish();
+            gauge_ = o.gauge_;
+            begin_us_ = o.begin_us_;
+            auto_finish_ = o.auto_finish_;
+            o.gauge_ = nullptr;
+        }
+        return *this;
+    }
+
+    ~ChronoScopeGuard() {
+        if (auto_finish_) {
+            Finish();
+        }
+    }
+
+private:
+    void Finish() noexcept {
+        if (gauge_) {
+            *gauge_ = static_cast<double>(TimestampUtil::GetCurrentTimeUs() - begin_us_);
+            gauge_ = nullptr;
+        }
+    }
+
+    Gauge *gauge_ = nullptr;
+    std::int64_t begin_us_ = 0;
+    bool auto_finish_ = false;
+};
+
 /* ---------------------- Generic Help Macros ----------------------- */
 
 #ifndef KVCM_METRICS_COLLECTOR_
@@ -28,24 +84,18 @@ namespace kv_cache_manager {
     } while (0)
 #endif
 
+#ifndef KVCM_METRICS_COLLECTOR_CHRONO_SCOPE
+#define KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(ptr, method) ((ptr) ? (ptr)->Make##method##Scope() : ChronoScopeGuard{})
+#endif
+
 #ifndef KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN
 #define KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(ptr, method)                                                          \
-    do {                                                                                                               \
-        if (!(ptr)) {                                                                                                  \
-            break;                                                                                                     \
-        }                                                                                                              \
-        (ptr)->Mark##method##Begin();                                                                                  \
-    } while (0)
+    auto kvcm_chrono_scope_##method##_ = ((ptr) ? (ptr)->Make##method##Scope(false) : ChronoScopeGuard{})
 #endif
 
 #ifndef KVCM_METRICS_COLLECTOR_CHRONO_MARK_END
 #define KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(ptr, method)                                                            \
-    do {                                                                                                               \
-        if (!(ptr)) {                                                                                                  \
-            break;                                                                                                     \
-        }                                                                                                              \
-        (ptr)->Mark##method##End();                                                                                    \
-    } while (0)
+    kvcm_chrono_scope_##method##_ = ChronoScopeGuard {}
 #endif
 
 #ifndef KVCM_METRICS_COLLECTOR_SET_METRICS
@@ -187,13 +237,9 @@ private:                                                                        
 #define KVCM_CHRONO_METRICS(group, name, method)                                                                       \
     KVCM_GAUGE_METRICS(group, name)                                                                                    \
 public:                                                                                                                \
-    void Mark##method##Begin() { group##_##name##_begin_ = TimestampUtil::GetCurrentTimeUs(); }                        \
-    void Mark##method##End() {                                                                                         \
-        METRICS_(group, name) = static_cast<double>(TimestampUtil::GetCurrentTimeUs() - group##_##name##_begin_);      \
-    }                                                                                                                  \
-                                                                                                                       \
-private:                                                                                                               \
-    std::int64_t group##_##name##_begin_ = 0;
+    ChronoScopeGuard Make##method##Scope(bool auto_finish = true) {                                                    \
+        return ChronoScopeGuard(&METRICS_(group, name), auto_finish);                                                  \
+    }
 #endif
 
 /* ------------------- ServiceMetricsCollector ---------------------- */

--- a/kv_cache_manager/metrics/test/metrics_collector_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_collector_test.cc
@@ -1,5 +1,7 @@
 #include <memory>
+#include <thread>
 #include <unistd.h>
+#include <vector>
 
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/metrics/metrics_collector.h"
@@ -259,4 +261,114 @@ TEST_F(MetricsCollectorTest, MetaIndexerAccumulativeMetricsCollectorTest) {
     SET_METRICS_(p, meta_indexer, total_cache_usage, 456.);
     EXPECT_DOUBLE_EQ(GET(p, meta_indexer, total_key_count), 123.);
     EXPECT_DOUBLE_EQ(GET(p, meta_indexer, total_cache_usage), 456.);
+}
+
+TEST_F(MetricsCollectorTest, ChronoScopeConcurrentTest) {
+    metrics_collector_ = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
+    metrics_collector_->Init();
+
+    auto p = std::dynamic_pointer_cast<ServiceMetricsCollector>(metrics_collector_);
+    ASSERT_NE(nullptr, p);
+
+    constexpr int kThreadCount = 8;
+    constexpr int kIterations = 50;
+    constexpr int kSleepUs = 1000; // 1ms
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        std::vector<std::thread> threads;
+        threads.reserve(kThreadCount);
+        for (int t = 0; t < kThreadCount; ++t) {
+            threads.emplace_back([&p]() {
+                auto scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(p, MetaSearcherIndexerGet);
+                usleep(kSleepUs);
+            });
+        }
+        for (auto &th : threads) {
+            th.join();
+        }
+        EXPECT_GE(GET(p, meta_searcher, indexer_get_time_us), static_cast<double>(kSleepUs));
+    }
+}
+
+TEST_F(MetricsCollectorTest, MarkBeginWithoutMarkEndDoesNotRecord) {
+    metrics_collector_ = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
+    metrics_collector_->Init();
+
+    auto p = std::dynamic_pointer_cast<ServiceMetricsCollector>(metrics_collector_);
+    ASSERT_NE(nullptr, p);
+
+    EXPECT_DOUBLE_EQ(GET(p, manager, batch_get_location_time_us), 0.);
+
+    // MARK_BEGIN without MARK_END: guard destructor should NOT write
+    {
+        KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, ManagerBatchGetLocation);
+        usleep(1000);
+    }
+    EXPECT_DOUBLE_EQ(GET(p, manager, batch_get_location_time_us), 0.);
+
+    // MARK_BEGIN + MARK_END: should record normally
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, ManagerBatchGetLocation);
+    usleep(1000);
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, ManagerBatchGetLocation);
+    EXPECT_GT(GET(p, manager, batch_get_location_time_us), 1000.0);
+}
+
+TEST_F(MetricsCollectorTest, ChronoScopeAutoFinishOnDestruct) {
+    metrics_collector_ = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
+    metrics_collector_->Init();
+
+    auto p = std::dynamic_pointer_cast<ServiceMetricsCollector>(metrics_collector_);
+    ASSERT_NE(nullptr, p);
+
+    EXPECT_DOUBLE_EQ(GET(p, meta_searcher, indexer_get_time_us), 0.);
+
+    // CHRONO_SCOPE without explicit end: guard destructor SHOULD write
+    {
+        auto scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(p, MetaSearcherIndexerGet);
+        usleep(1000);
+    }
+    EXPECT_GT(GET(p, meta_searcher, indexer_get_time_us), 1000.0);
+}
+
+// Verify per-scope isolation with a shared collector, asymmetric sleep,
+// and staggered start.  With the old shared-begin_ member, thread B's
+// MarkBegin() would overwrite thread A's begin_, causing A to compute
+// ~3 ms instead of ~5 ms.  Per-scope begin_us_ on the stack keeps each
+// measurement independent.
+TEST_F(MetricsCollectorTest, ChronoScopeAsymmetricConcurrentTest) {
+    constexpr int kIterations = 20;
+    constexpr int kLongSleepUs = 5000;  // 5 ms – thread A
+    constexpr int kShortSleepUs = 1000; // 1 ms – thread B
+    constexpr int kStaggerUs = 2000;    // 2 ms delay before starting thread B
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        metrics_collector_ = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
+        metrics_collector_->Init();
+        auto p = std::dynamic_pointer_cast<ServiceMetricsCollector>(metrics_collector_);
+        ASSERT_NE(nullptr, p);
+
+        // Thread A: starts immediately, sleeps 5 ms (finishes last → last writer to Gauge)
+        std::thread t_long([&p]() {
+            auto scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(p, MetaSearcherIndexerGet);
+            usleep(kLongSleepUs);
+        });
+
+        // Stagger: wait 2 ms so thread B's MarkBegin timestamp differs from A's
+        usleep(kStaggerUs);
+
+        // Thread B: starts 2 ms later, sleeps 1 ms (finishes at ~3 ms, before A at ~5 ms)
+        std::thread t_short([&p]() {
+            auto scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(p, MetaSearcherIndexerGet);
+            usleep(kShortSleepUs);
+        });
+
+        t_short.join();
+        t_long.join();
+
+        // Thread A finishes last and overwrites the Gauge.
+        // Correct per-scope: Gauge ≈ 5 ms (A's own begin_us_)
+        // Broken shared begin_: Gauge ≈ 3 ms (A would use B's begin_)
+        double val = GET(p, meta_searcher, indexer_get_time_us);
+        EXPECT_GE(val, static_cast<double>(kLongSleepUs - 500));
+    }
 }

--- a/kv_cache_manager/service/util/service_call_guard.cc
+++ b/kv_cache_manager/service/util/service_call_guard.cc
@@ -106,7 +106,7 @@ ServiceCallGuard::ServiceCallGuard(CacheManager *cache_manager,
                                    MetricsReporter *metrics_reporter)
     : cache_manager_(cache_manager), request_context_(request_context), metrics_reporter_(metrics_reporter) {
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
-    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, ServiceQuery);
+    query_scope_ = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(service_metrics_collector, ServiceQuery);
 }
 
 ServiceCallGuard::ServiceCallGuard(CacheManager *cache_manager,
@@ -118,14 +118,17 @@ ServiceCallGuard::ServiceCallGuard(CacheManager *cache_manager,
     , metrics_reporter_(metrics_reporter)
     , response_debug_setter_(std::move(response_debug_setter)) {
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
-    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, ServiceQuery);
+    query_scope_ = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(service_metrics_collector, ServiceQuery);
 }
 
 ServiceCallGuard::~ServiceCallGuard() {
     assert(cache_manager_);
     assert(request_context_);
+    // Member destructors run after this function body, so we explicitly end the
+    // scope here to flush query_rt_us into the Gauge; otherwise the subsequent
+    // ReportPerQuery would read the stale value from the previous request.
+    query_scope_ = ChronoScopeGuard{};
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context_->metrics_collector());
-    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ServiceQuery);
     if (response_debug_setter_) {
         response_debug_setter_();
     }

--- a/kv_cache_manager/service/util/service_call_guard.h
+++ b/kv_cache_manager/service/util/service_call_guard.h
@@ -2,6 +2,8 @@
 
 #include <functional>
 
+#include "kv_cache_manager/metrics/metrics_collector.h"
+
 namespace kv_cache_manager {
 
 class CacheManager;
@@ -24,6 +26,11 @@ private:
     RequestContext *request_context_;
     MetricsReporter *metrics_reporter_;
     std::function<void()> response_debug_setter_;
+    // Records per-request begin timestamp; writes (now - begin) to
+    // service.query_rt_us when the scope ends.  Explicitly reset in
+    // ~ServiceCallGuard() before ReportPerQuery, so declaration order
+    // does not matter.
+    ChronoScopeGuard query_scope_;
 };
 
 } // namespace kv_cache_manager


### PR DESCRIPTION
Fixes a race condition where multiple threads calling MarkxxxBegin() on
a shared MetricsCollector would overwrite each other's begin_ timestamp,
leading to incorrect duration measurements.

The fix introduces a per-call RAII ChronoScopeGuard that captures the
start time on the stack/member, eliminating the shared mutable state.