### PR TITLE
[manager] add ListInstanceGroup admin API

### DIFF
--- a/docs/api/admin_service.md
+++ b/docs/api/admin_service.md
@@ -294,13 +294,23 @@ curl -g -vvv -X POST http://localhost:6492/api/getInstanceGroup \
 }'
 ```
 
+## List Instance Group
+```bash
+curl -g -vvv -X POST http://localhost:6492/api/listInstanceGroup \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "trace_id": "trace_id_211"
+}'
+```
+
 ## Get Cache Meta
 ```bash
 curl -g -vvv -X POST http://localhost:6492/api/getCacheMeta \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
   -d '{
-    "trace_id": "trace_id_211",
+    "trace_id": "trace_id_212",
     "instance_id": "instance1",
     "block_keys": [123],
     "token_ids": [456],

--- a/integration_test/admin_service/admin_interface_cases.py
+++ b/integration_test/admin_service/admin_interface_cases.py
@@ -62,6 +62,10 @@ class AdminServiceClientBase(abc.ABC):
         return {}
 
     @abc.abstractmethod
+    def list_instance_group(self, data, check_response=True) -> Dict:
+        return {}
+
+    @abc.abstractmethod
     def get_cache_meta(self, data, check_response=True) -> Dict:
         return {}
 
@@ -254,11 +258,18 @@ class AdminServiceTestBase(abc.ABC, TestBase, unittest.TestCase):
         found = any(s["global_unique_name"] == add_req["storage"]["global_unique_name"] for s in list_resp["storage"])
         self.assertTrue(found, "not found storage after added.")
 
-    def test_create_update_get_remove_instance_group(self):
+    def test_create_update_get_list_remove_instance_group(self):
         ig = self.make_sample_instance_group()
         create_req = {"trace_id": self._trace_id, "instance_group": ig}
         create_resp = self._client.create_instance_group(create_req)
         self.assertEqual(create_resp["header"]["status"]["code"], "OK")
+
+        list_resp = self._client.list_instance_group({"trace_id": self._trace_id})
+        self.assertEqual(list_resp["header"]["status"]["code"], "OK")
+        self.assertIn("instance_group", list_resp)
+        self.assertTrue(
+            any(instance_group["name"] == ig["name"] for instance_group in list_resp["instance_group"]),
+            "not found instance group after created.")
 
         # Update some field
         ig_updated = ig.copy()
@@ -272,6 +283,12 @@ class AdminServiceTestBase(abc.ABC, TestBase, unittest.TestCase):
         get_resp = self._client.get_instance_group(get_req)
         self.assertEqual(get_resp["header"]["status"]["code"], "OK")
         self.assertEqual(get_resp["instance_group"]["user_data"], "updated_data")
+
+        list_resp = self._client.list_instance_group({"trace_id": self._trace_id})
+        self.assertEqual(list_resp["header"]["status"]["code"], "OK")
+        listed_groups = {instance_group["name"]: instance_group for instance_group in list_resp["instance_group"]}
+        self.assertIn(ig["name"], listed_groups)
+        self.assertEqual(listed_groups[ig["name"]]["user_data"], "updated_data")
 
         remove_req = {"trace_id": self._trace_id, "name": ig["name"]}
         remove_resp = self._client.remove_instance_group(remove_req)

--- a/integration_test/admin_service/grpc_interface_test.py
+++ b/integration_test/admin_service/grpc_interface_test.py
@@ -12,6 +12,7 @@ from kv_cache_manager.protocol.protobuf.admin_service_pb2 import (
     UpdateInstanceGroupRequest,
     RemoveInstanceGroupRequest,
     GetInstanceGroupRequest,
+    ListInstanceGroupRequest,
     GetCacheMetaRequest,
     RemoveCacheRequest,
     RegisterInstanceRequest,
@@ -145,6 +146,17 @@ class AdminServiceGrpcClient(cases.AdminServiceClientBase):
             if not header or header['status']['code'] != "OK":
                 msg = header['status']['message'] if header else "no header"
                 raise AssertionError(f"get_instance_group failed: {msg}")
+        return response_dict
+
+    def list_instance_group(self, data, check_response=True):
+        request = self._convert_dict_to_proto(ListInstanceGroupRequest, data)
+        response = self._stub.ListInstanceGroup(request, timeout=self._timeout)
+        response_dict = self._convert_proto_to_dict(response)
+        if check_response:
+            header = response_dict.get('header')
+            if not header or header['status']['code'] != "OK":
+                msg = header['status']['message'] if header else "no header"
+                raise AssertionError(f"list_instance_group failed: {msg}")
         return response_dict
 
     def get_cache_meta(self, data, check_response=True):

--- a/integration_test/admin_service/http_interface_test.py
+++ b/integration_test/admin_service/http_interface_test.py
@@ -66,6 +66,9 @@ class AdminServiceHttpClient(cases.AdminServiceClientBase):
     def get_instance_group(self, data, check_response=True):
         return self._make_api_request('/api/getInstanceGroup', data, check_response)
 
+    def list_instance_group(self, data, check_response=True):
+        return self._make_api_request('/api/listInstanceGroup', data, check_response)
+
     def get_cache_meta(self, data, check_response=True):
         return self._make_api_request('/api/getCacheMeta', data, check_response)
 

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -268,6 +268,13 @@ message GetInstanceGroupResponse {
     InstanceGroup instance_group = 2;
 }
 
+message ListInstanceGroupRequest { string trace_id = 1; }
+
+message ListInstanceGroupResponse {
+    CommonResponseHeader header = 1;
+    repeated InstanceGroup instance_group = 2;
+}
+
 message BoolMasksType { repeated bool values = 1; }
 message BlockMask {
     oneof info {
@@ -515,6 +522,7 @@ service AdminService {
     rpc UpdateInstanceGroup(UpdateInstanceGroupRequest) returns (CommonResponse);
     rpc RemoveInstanceGroup(RemoveInstanceGroupRequest) returns (CommonResponse);
     rpc GetInstanceGroup(GetInstanceGroupRequest) returns (GetInstanceGroupResponse);
+    rpc ListInstanceGroup(ListInstanceGroupRequest) returns (ListInstanceGroupResponse);
     // 增删改查单条CacheMeta信息,暂时与meta_service保持一致
     rpc GetCacheMeta(GetCacheMetaRequest) returns (GetCacheMetaResponse);
     // 删除指定key的cache,用于修复用户反馈的单query异常,暂时与meta_service保持一致

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -370,6 +370,34 @@ void AdminServiceImpl::GetInstanceGroup(RequestContext *request_context,
     }
 }
 
+void AdminServiceImpl::ListInstanceGroup(RequestContext *request_context,
+                                         const proto::admin::ListInstanceGroupRequest *request,
+                                         proto::admin::ListInstanceGroupResponse *response) {
+    API_CALL_GUARD("ListInstanceGroup", true);
+    auto *header = response->mutable_header();
+    auto *status = header->mutable_status();
+
+    auto list_instance_group = registry_manager_->ListInstanceGroup(request_context);
+    ErrorCode ec_info = list_instance_group.first;
+    const auto &instance_groups = list_instance_group.second;
+    if (ec_info != EC_OK) {
+        status->set_code(ToAdminPbError(ec_info));
+        request_context->set_status_code(status->code());
+        status->set_message("Failed to list instance group");
+        KVCM_LOG_ERROR("[traceId: %s] ListInstanceGroup failed", request->trace_id().c_str());
+        return;
+    }
+
+    for (const auto &instance_group : instance_groups) {
+        auto *instance_group_config = response->add_instance_group();
+        ProtoConvert::InstanceGroupToProto(*instance_group, instance_group_config);
+    }
+    status->set_code(proto::admin::OK);
+    request_context->set_status_code(status->code());
+    status->set_message("Instance group listed successfully");
+    KVCM_LOG_INFO("[traceId: %s] ListInstanceGroup succeeded", request->trace_id().c_str());
+}
+
 // Cache相关接口实现
 void AdminServiceImpl::GetCacheMeta(RequestContext *request_context,
                                     const proto::admin::GetCacheMetaRequest *request,

--- a/kv_cache_manager/service/admin_service_impl.h
+++ b/kv_cache_manager/service/admin_service_impl.h
@@ -55,6 +55,9 @@ public:
     void GetInstanceGroup(RequestContext *request_context,
                           const proto::admin::GetInstanceGroupRequest *request,
                           proto::admin::GetInstanceGroupResponse *response);
+    void ListInstanceGroup(RequestContext *request_context,
+                           const proto::admin::ListInstanceGroupRequest *request,
+                           proto::admin::ListInstanceGroupResponse *response);
 
     void GetCacheMeta(RequestContext *request_context,
                       const proto::admin::GetCacheMetaRequest *request,

--- a/kv_cache_manager/service/grpc_service/admin_service_grpc.cc
+++ b/kv_cache_manager/service/grpc_service/admin_service_grpc.cc
@@ -30,6 +30,7 @@ void AdminServiceGRpc::Init() {
     MAKE_SERVICE_METRICS_COLLECTOR(UpdateInstanceGroup);
     MAKE_SERVICE_METRICS_COLLECTOR(RemoveInstanceGroup);
     MAKE_SERVICE_METRICS_COLLECTOR(GetInstanceGroup);
+    MAKE_SERVICE_METRICS_COLLECTOR(ListInstanceGroup);
 
     // for cache APIs
     MAKE_SERVICE_METRICS_COLLECTOR(GetCacheMeta);
@@ -141,6 +142,14 @@ grpc::Status AdminServiceGRpc::GetInstanceGroup(grpc::ServerContext *context,
                                                 proto::admin::GetInstanceGroupResponse *response) {
     API_CONTEXT_INIT_GRPC(GetInstanceGroup)
     admin_service_impl_->GetInstanceGroup(request_context, request, response);
+    return grpc::Status::OK;
+}
+
+grpc::Status AdminServiceGRpc::ListInstanceGroup(grpc::ServerContext *context,
+                                                 const proto::admin::ListInstanceGroupRequest *request,
+                                                 proto::admin::ListInstanceGroupResponse *response) {
+    API_CONTEXT_INIT_GRPC(ListInstanceGroup)
+    admin_service_impl_->ListInstanceGroup(request_context, request, response);
     return grpc::Status::OK;
 }
 

--- a/kv_cache_manager/service/grpc_service/admin_service_grpc.h
+++ b/kv_cache_manager/service/grpc_service/admin_service_grpc.h
@@ -49,6 +49,9 @@ public:
     grpc::Status GetInstanceGroup(grpc::ServerContext *context,
                                   const proto::admin::GetInstanceGroupRequest *request,
                                   proto::admin::GetInstanceGroupResponse *response) override;
+    grpc::Status ListInstanceGroup(grpc::ServerContext *context,
+                                   const proto::admin::ListInstanceGroupRequest *request,
+                                   proto::admin::ListInstanceGroupResponse *response) override;
     grpc::Status GetCacheMeta(grpc::ServerContext *context,
                               const proto::admin::GetCacheMetaRequest *request,
                               proto::admin::GetCacheMetaResponse *response) override;
@@ -123,6 +126,7 @@ private:
     KVCM_DECLARE_METRICS_COLLECTOR_(UpdateInstanceGroup);
     KVCM_DECLARE_METRICS_COLLECTOR_(RemoveInstanceGroup);
     KVCM_DECLARE_METRICS_COLLECTOR_(GetInstanceGroup);
+    KVCM_DECLARE_METRICS_COLLECTOR_(ListInstanceGroup);
 
     // for cache APIs
     KVCM_DECLARE_METRICS_COLLECTOR_(GetCacheMeta);

--- a/kv_cache_manager/service/http_service/admin_service_http.cc
+++ b/kv_cache_manager/service/http_service/admin_service_http.cc
@@ -41,6 +41,7 @@ void AdminServiceHttp::Init() {
     MAKE_SERVICE_METRICS_COLLECTOR(UpdateInstanceGroup);
     MAKE_SERVICE_METRICS_COLLECTOR(RemoveInstanceGroup);
     MAKE_SERVICE_METRICS_COLLECTOR(GetInstanceGroup);
+    MAKE_SERVICE_METRICS_COLLECTOR(ListInstanceGroup);
 
     // for cache APIs
     MAKE_SERVICE_METRICS_COLLECTOR(GetCacheMeta);
@@ -93,6 +94,8 @@ void AdminServiceHttp::RegisterHandler() {
         Post, removeInstanceGroup, RemoveInstanceGroup, Common, RemoveInstanceGroup);
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(
         Post, getInstanceGroup, GetInstanceGroup, GetInstanceGroup, GetInstanceGroup);
+    REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(
+        Post, listInstanceGroup, ListInstanceGroup, ListInstanceGroup, ListInstanceGroup);
 
     // Cache APIs
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, getCacheMeta, GetCacheMeta, GetCacheMeta, GetCacheMeta);
@@ -236,6 +239,14 @@ void AdminServiceHttp::GetInstanceGroup(coro_http::coro_http_connection *http_co
     API_CONTEXT_INIT_HTTP(GetInstanceGroup)
     KVCM_LOG_INFO("[traceId: %s] GetInstanceGroup [%s] called.", request->trace_id().c_str(), request->name().c_str());
     admin_service_impl_->GetInstanceGroup(request_context, request, response);
+}
+
+void AdminServiceHttp::ListInstanceGroup(coro_http::coro_http_connection *http_conn,
+                                         proto::admin::ListInstanceGroupRequest *request,
+                                         proto::admin::ListInstanceGroupResponse *response) {
+    API_CONTEXT_INIT_HTTP(ListInstanceGroup)
+    KVCM_LOG_INFO("[traceId: %s] ListInstanceGroup called.", request->trace_id().c_str());
+    admin_service_impl_->ListInstanceGroup(request_context, request, response);
 }
 
 void AdminServiceHttp::GetCacheMeta(coro_http::coro_http_connection *http_conn,

--- a/kv_cache_manager/service/http_service/admin_service_http.h
+++ b/kv_cache_manager/service/http_service/admin_service_http.h
@@ -55,6 +55,9 @@ public:
     void GetInstanceGroup(coro_http::coro_http_connection *http_conn,
                           proto::admin::GetInstanceGroupRequest *request,
                           proto::admin::GetInstanceGroupResponse *response);
+    void ListInstanceGroup(coro_http::coro_http_connection *http_conn,
+                           proto::admin::ListInstanceGroupRequest *request,
+                           proto::admin::ListInstanceGroupResponse *response);
 
     void GetCacheMeta(coro_http::coro_http_connection *http_conn,
                       proto::admin::GetCacheMetaRequest *request,
@@ -136,6 +139,7 @@ private:
     KVCM_DECLARE_METRICS_COLLECTOR_(UpdateInstanceGroup);
     KVCM_DECLARE_METRICS_COLLECTOR_(RemoveInstanceGroup);
     KVCM_DECLARE_METRICS_COLLECTOR_(GetInstanceGroup);
+    KVCM_DECLARE_METRICS_COLLECTOR_(ListInstanceGroup);
 
     // for cache APIs
     KVCM_DECLARE_METRICS_COLLECTOR_(GetCacheMeta);

--- a/package/kvcm_ops/__main__.py
+++ b/package/kvcm_ops/__main__.py
@@ -11,6 +11,7 @@ COMMANDS = {
     "remove_instance": "kvcm_ops.kvcm.instance.remove_instance",
 
     "get_instance_group": "kvcm_ops.kvcm.instance_group.get_instance_group",
+    "list_instance_group": "kvcm_ops.kvcm.instance_group.list_instance_group",
     "create_instance_group": "kvcm_ops.kvcm.instance_group.create_instance_group",
     "update_instance_group": "kvcm_ops.kvcm.instance_group.update_instance_group",
     "remove_instance_group": "kvcm_ops.kvcm.instance_group.remove_instance_group",
@@ -61,6 +62,7 @@ def main():
     remove_instance
   instance_group:
     get_instance_group
+    list_instance_group
     create_instance_group
     update_instance_group
     remove_instance_group

--- a/package/kvcm_ops/kvcm/instance_group/_help.py
+++ b/package/kvcm_ops/kvcm/instance_group/_help.py
@@ -4,6 +4,10 @@ instance_group module:
         python3 -m kvcm_ops get_instance_group --help
         python3 -m kvcm_ops get_instance_group -n default
         python3 -m kvcm_ops get_instance_group -H http://localhost:56040 -n default
+    list instance_group info:
+        python3 -m kvcm_ops list_instance_group --help
+        python3 -m kvcm_ops list_instance_group
+        python3 -m kvcm_ops list_instance_group -H http://localhost:56040
     create new instance_group:
         python3 -m kvcm_ops create_instance_group --help
         python3 -m kvcm_ops create_instance_group -n test_group -s nfs_01

--- a/package/kvcm_ops/kvcm/instance_group/list_instance_group.py
+++ b/package/kvcm_ops/kvcm/instance_group/list_instance_group.py
@@ -1,0 +1,37 @@
+import argparse
+from ..common.http_helper import *
+from ..common.common_args import *
+from ...util.json_helper import *
+
+'''
+curl -g -vvv -X POST http://localhost:56040/api/listInstanceGroup \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "trace_id": "default_trace_id"
+}'
+'''
+
+def parse_args():
+    common_parser = create_common_parser()
+    parser = argparse.ArgumentParser(
+        prog="python3 script.kvcm.instance_group.list_instance_group",
+        description="kvcm: list_instance_group.",
+        parents=[common_parser],
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    data = {
+        "trace_id": args.trace_id
+    }
+    result = http_post(args.host, "/api/listInstanceGroup", data, args.verbose)
+    pretty_print_json(result)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cli_py/admin_service_client.py
+++ b/tools/cli_py/admin_service_client.py
@@ -20,6 +20,8 @@ from kv_cache_manager.protocol.protobuf.admin_service_pb2 import (
     UpdateStorageRequest,
     ListStorageRequest,
     ListStorageResponse,
+    ListInstanceGroupRequest,
+    ListInstanceGroupResponse,
 )
 
 from kv_cache_manager.protocol.protobuf.admin_service_pb2_grpc import AdminServiceStub
@@ -63,4 +65,12 @@ class AdminServiceClient(object):
             request = ListStorageRequest(trace_id="trace-123456")
         response = stub.ListStorage(request)
         print("[ListStorageReponse]:", str(response))
+        return response
+
+    def list_instance_group(self, request: Optional[ListInstanceGroupRequest] = None) -> ListInstanceGroupResponse:
+        stub = AdminServiceStub(self._channel)
+        if request is None:
+            request = ListInstanceGroupRequest(trace_id="trace-123456")
+        response = stub.ListInstanceGroup(request)
+        print("[ListInstanceGroupReponse]:", str(response))
         return response


### PR DESCRIPTION
### Motivation
- Provide an Admin API to enumerate all configured InstanceGroups so management tools can discover and inspect instance-group configuration and metadata.

### Description
- Added new protobuf messages and RPC: `ListInstanceGroupRequest`, `ListInstanceGroupResponse` and `rpc ListInstanceGroup(...)` in `admin_service.proto`.
- Implemented `AdminServiceImpl::ListInstanceGroup` which calls `RegistryManager::ListInstanceGroup` and converts results to proto with `ProtoConvert::InstanceGroupToProto` (see `service/admin_service_impl.cc` / `service/admin_service_impl.h`).
- Wired the API into gRPC and HTTP layers by adding a gRPC method and HTTP handler, registering metrics collectors, and exposing `/api/listInstanceGroup` (see `service/grpc_service/*` and `service/http_service/*`).
- Extended integration test clients and test cases to exercise listing (gRPC and HTTP clients, and test `test_create_update_get_list_remove_instance_group`) under `integration_test/admin_service/*`.

### Testing
- Built protobuf/python artifacts with `bazel build //kv_cache_manager/protocol/protobuf:admin_service_py_proto //kv_cache_manager/protocol/protobuf:admin_service_cc` which succeeded.
- Ran Python syntax checks with `python3 -m py_compile integration_test/admin_service/*.py` and `git diff --check` which succeeded.
- Built the admin service implementation with `bazel build //kv_cache_manager/service:admin_service_impl` which succeeded.
- Attempted to run the integration test target `bazel test //integration_test/admin_service:grpc_interface_test --test_filter=AdminServiceGrpcTest.test_create_update_get_list_remove_instance_group` but the run did not complete because an external `boringssl` compilation failed under strict GCC warnings (`-Werror=dangling-pointer`) in the test environment; this is unrelated to the new API implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035adaa7fc832cabbd2d63608dcd97)