### PR TITLE
[meta] fix meta local backend usage calculation & no need configuring meta_cache_policy_config

### DIFF
--- a/integration_test/reclaimer/BUILD
+++ b/integration_test/reclaimer/BUILD
@@ -27,3 +27,17 @@ py_test(
         "//integration_test/meta_service:http_interface_test",
     ],
 )
+
+py_test(
+    name = "multi_location_test",
+    srcs = ["multi_location_test.py"],
+    tags = ["no-remote-exec"],
+    data = [
+        "//kv_cache_manager:kv_cache_manager_bin",
+    ],
+    deps = [
+        "//integration_test/testlib:test_base",
+        "//integration_test/admin_service:http_interface_test",
+        "//integration_test/meta_service:http_interface_test",
+    ],
+)

--- a/integration_test/reclaimer/multi_location_test.py
+++ b/integration_test/reclaimer/multi_location_test.py
@@ -1,0 +1,366 @@
+    # -*- coding: utf-8 -*-
+
+"""Integration tests for multi-location lifecycle scenarios.
+
+These tests verify that the Meta indexer correctly handles single-key
+with multiple coexisting locations, leveraging the LocationSpecGroup
+mechanism to produce stable multi-location states:
+
+- A key can have multiple locations when written via different spec groups.
+- Query merges specs from all valid locations of the same storage backend.
+- Partial data loss (one location's file deleted) still allows query via
+  the remaining location.
+- Full data loss (all locations' files deleted) breaks prefix match.
+- Rewrite after partial/full loss correctly produces new locations.
+
+This is complementary to location_pruning_test.py which focuses on the
+pruning policy itself. Here we focus on the per-location granularity
+behavior when multiple locations stably coexist for the same key.
+"""
+
+import abc
+import logging
+import os
+import os.path
+import time
+import unittest
+
+from urllib.parse import urlparse
+
+from integration_test.admin_service.http_interface_test import \
+    AdminServiceHttpClient
+from integration_test.meta_service.http_interface_test import \
+    MetaServiceHttpClient
+from integration_test.testlib.test_base import TestBase
+
+
+class MultiLocationTest(abc.ABC, TestBase, unittest.TestCase):
+    """Tests for single-key with multiple locations via LocationSpecGroup."""
+
+    # Two spec groups that partition the location_spec_infos
+    GROUP_A = "GroupA"  # contains spec "tp0"
+    GROUP_B = "GroupB"  # contains spec "tp1"
+
+    def setUp(self):
+        self.init_default()
+        self._admin_client, self._client = self._get_manager_client()
+        self._trace_id = "multi_loc_itest_trace_id"
+        self._storage_name = "test_storage_ml"
+        self._instance_group_name = "test_group_ml"
+        self._instance_id = "test_instance_ml"
+        self._model_name = "test_model_ml"
+
+    def tearDown(self):
+        self._admin_client.close()
+        self._client.close()
+        self.cleanup()
+
+    def test_two_groups_produce_two_locations_per_key(self):
+        """Writing with GroupA then GroupB produces two coexisting locations.
+
+        Scenario:
+        1. Write blocks [A, B, C] with GroupA → each key gets location_1.
+        2. Write blocks [A, B, C] with GroupB → each key gets location_2.
+        3. Query returns all 3 blocks with merged specs (tp0 + tp1).
+
+        This verifies that LocationSpecGroup correctly allows multiple
+        locations to coexist for the same key without triggering prune.
+        """
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance_with_groups()
+
+        block_keys = [500, 501, 502]
+        token_ids = [600, 601, 602]
+
+        # Write with GroupA → location_1 per key (contains tp0)
+        locs_a = self._write_blocks_with_group(block_keys, token_ids,
+                                               self.GROUP_A)
+        self.assertEqual(len(locs_a), 3)
+        for loc in locs_a:
+            spec_names = [s["name"] for s in loc["location_specs"]]
+            self.assertIn("tp0", spec_names)
+            self.assertNotIn("tp1", spec_names)
+
+        # Write with GroupB → location_2 per key (contains tp1)
+        locs_b = self._write_blocks_with_group(block_keys, token_ids,
+                                               self.GROUP_B)
+        self.assertEqual(len(locs_b), 3)
+        for loc in locs_b:
+            spec_names = [s["name"] for s in loc["location_specs"]]
+            self.assertIn("tp1", spec_names)
+            self.assertNotIn("tp0", spec_names)
+
+        # Query: should return all 3 blocks, each with merged specs
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 3,
+                         "all 3 blocks should be queryable")
+        for loc in resp["locations"]:
+            spec_names = [s["name"] for s in loc["location_specs"]]
+            self.assertIn("tp0", spec_names,
+                          "merged result should contain tp0")
+            self.assertIn("tp1", spec_names,
+                          "merged result should contain tp1")
+
+    def test_partial_location_loss_still_queryable(self):
+        """When one location's data is lost, query still works via the other.
+
+        Scenario:
+        1. Write [A, B, C] with GroupA → location_1 (tp0).
+        2. Write [A, B, C] with GroupB → location_2 (tp1).
+        3. Delete location_1's data files (tp0 gone).
+        4. Wait for prune of stale location_1.
+        5. Query still returns all 3 blocks (via location_2, tp1 only).
+        6. The returned specs should only contain tp1.
+        """
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance_with_groups()
+
+        block_keys = [600, 601, 602]
+        token_ids = [700, 701, 702]
+
+        locs_a = self._write_blocks_with_group(block_keys, token_ids,
+                                               self.GROUP_A)
+        locs_b = self._write_blocks_with_group(block_keys, token_ids,
+                                               self.GROUP_B)
+
+        # Delete all GroupA location files
+        self._delete_cache_locations(locs_a, list(range(len(locs_a))))
+
+        # Wait for async prune to detect and clean stale locations
+        time.sleep(2)
+
+        # Query: trigger prune detection via SelectForMatch
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 3,
+                         "blocks should still be queryable via GroupB location")
+
+        # Verify only tp1 specs remain (tp0 was pruned)
+        for loc in resp["locations"]:
+            spec_names = [s["name"] for s in loc["location_specs"]]
+            self.assertIn("tp1", spec_names,
+                          "tp1 should survive since GroupB data is intact")
+
+        # Rewrite with GroupA → should allocate new locations
+        new_locs_a = self._write_blocks_with_group(block_keys, token_ids,
+                                                   self.GROUP_A)
+        self.assertEqual(len(new_locs_a), 3,
+                         "all blocks need new GroupA locations")
+
+        # Query: full coverage restored
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 3)
+        for loc in resp["locations"]:
+            spec_names = [s["name"] for s in loc["location_specs"]]
+            self.assertIn("tp0", spec_names)
+            self.assertIn("tp1", spec_names)
+
+    def test_all_locations_lost_breaks_prefix(self):
+        """When all locations' data is lost, prefix match breaks.
+
+        Scenario:
+        1. Write [A, B, C] with GroupA and GroupB (two locations each).
+        2. Delete ALL data files for block B (both locations).
+        3. Wait for prune.
+        4. Prefix query returns only [A] (prefix breaks at B).
+        """
+        self._make_dummy_storage()
+        self._make_dummy_instance_group()
+        self._make_dummy_instance_with_groups()
+
+        block_keys = [700, 701, 702]
+        token_ids = [800, 801, 802]
+
+        locs_a = self._write_blocks_with_group(block_keys, token_ids,
+                                               self.GROUP_A)
+        locs_b = self._write_blocks_with_group(block_keys, token_ids,
+                                               self.GROUP_B)
+
+        # Delete ALL data for block B (index 1) across both locations
+        self._delete_cache_locations(locs_a, [1])
+        self._delete_cache_locations(locs_b, [1])
+
+        # Wait for prune
+        time.sleep(2)
+
+        # Prefix query should break at B
+        resp = self._prefix_query(block_keys)
+        self.assertEqual(len(resp["locations"]), 1,
+                         "prefix should break at B; only A should match")
+
+    # ===== Helper methods =====
+
+    def _get_manager_client(self):
+        worker = self.worker_manager.get_worker(0)
+        self._admin_http_port = worker.env.admin_http_port
+        self._admin_http_url = f"http://localhost:{self._admin_http_port}"
+        self._http_port = worker.env.http_port
+        self._http_url = f"http://localhost:{self._http_port}"
+        logging.info(f"admin http url: {self._admin_http_url}, "
+                     f"http url: {self._http_url}")
+        return (
+            AdminServiceHttpClient(self._admin_http_url),
+            MetaServiceHttpClient(self._http_url),
+        )
+
+    def _write_blocks_with_group(self, block_keys, token_ids, group_name):
+        """Write blocks with a specific LocationSpecGroup."""
+        resp = self._start_write_blocks(block_keys, token_ids,
+                                        group_name=group_name)
+        write_session_id = resp["write_session_id"]
+        locations = resp["locations"]
+        self._touch_cache_locations(locations)
+        self._finish_write_blocks(write_session_id, len(locations))
+        return locations
+
+    def _start_write_blocks(self, block_keys, token_ids, group_name=None):
+        req = {
+            "trace_id": self._trace_id,
+            "instance_id": self._instance_id,
+            "block_keys": block_keys,
+            "token_ids": token_ids,
+            "write_timeout_seconds": 30,
+        }
+        if group_name:
+            req["location_spec_group_names"] = [group_name] * len(block_keys)
+        return self._client.start_write_cache(req)
+
+    def _finish_write_blocks(self, write_session_id, loc_sz):
+        return self._client.finish_write_cache({
+            "trace_id": self._trace_id,
+            "instance_id": self._instance_id,
+            "write_session_id": write_session_id,
+            "success_blocks": {
+                "bool_masks": {"values": [True] * loc_sz},
+            },
+        })
+
+    def _prefix_query(self, block_keys):
+        return self._client.get_cache_location({
+            "trace_id": self._trace_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_keys": block_keys,
+            "instance_id": self._instance_id,
+            "block_mask": {"offset": 0},
+        })
+
+    @staticmethod
+    def _touch_cache_locations(locations):
+        """Simulate the cache data write by creating data files."""
+        for loc in locations:
+            for spec in loc.get("location_specs", []):
+                file_path = urlparse(spec["uri"]).path
+                try:
+                    os.utime(file_path)
+                except FileNotFoundError:
+                    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                    with open(file_path, 'x') as _:
+                        pass
+
+    @staticmethod
+    def _delete_cache_locations(locations, indices):
+        """Simulate data loss by removing location data files."""
+        for i in indices:
+            loc = locations[i]
+            for spec in loc.get("location_specs", []):
+                file_path = urlparse(spec["uri"]).path
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+
+    def _make_dummy_storage(self):
+        dummy_root_path = f"{self.get_workdir()}/{self._storage_name}/data/"
+        add_storage_req = {
+            "trace_id": self._trace_id + "-add_storage",
+            "storage": {
+                "global_unique_name": self._storage_name,
+                "dummy": {
+                    "root_path": dummy_root_path,
+                    "key_count_per_file": 1,
+                }
+            },
+        }
+        self._admin_client.add_storage(add_storage_req)
+
+    def _make_dummy_instance_group(self):
+        create_ig_req = {
+            "trace_id": self._trace_id + "-add_instance_group",
+            "instance_group": {
+                "name": self._instance_group_name,
+                "storage_candidates": [
+                    self._storage_name,
+                ],
+                "global_quota_group_name": "quota_group_ml",
+                "max_instance_count": 8,
+                "quota": {
+                    "capacity": 1024 * 32,
+                    "quota_config": [
+                        # StorageType.ST_DUMMY=6
+                        {"storage_type": 6, "capacity": 1024 * 32},
+                    ],
+                },
+                "cache_config": {
+                    "reclaim_strategy": {
+                        "storage_unique_name": self._storage_name,
+                        "reclaim_policy": 1,  # POLICY_LRU
+                        "trigger_strategy": {
+                            "used_percentage": 3.2,
+                        },
+                    },
+                    "data_storage_strategy": 2,  # CPS_PREFER_3FS
+                    "meta_indexer_config": {
+                        "max_key_count": 32,
+                        "mutex_shard_num": 16,
+                        "meta_storage_backend_config": {
+                            "storage_type": "dummy",
+                            "storage_uri": (
+                                f"file://{self.get_workdir()}"
+                                f"/meta_storage_{self._instance_group_name}"
+                            ),
+                        },
+                        "persist_metadata_interval_time_ms": 0,
+                    }
+                },
+                "user_data": "multi-location test",
+                "version": 1,
+            },
+        }
+        self._admin_client.create_instance_group(create_ig_req)
+
+    def _make_dummy_instance_with_groups(self):
+        """Register instance with two specs and two groups.
+
+        - tp0 belongs to GroupA
+        - tp1 belongs to GroupB
+        Writing with different groups produces separate locations.
+        """
+        reg_ins_req = {
+            "trace_id": self._trace_id + "-add_instance",
+            "instance_group": self._instance_group_name,
+            "instance_id": self._instance_id,
+            "block_size": 128,
+            "model_deployment": self._make_dummy_model_deployment(),
+            "location_spec_infos": [
+                {"name": "tp0", "size": 1024},
+                {"name": "tp1", "size": 1024},
+            ],
+            "location_spec_groups": [
+                {"name": self.GROUP_A, "spec_names": ["tp0"]},
+                {"name": self.GROUP_B, "spec_names": ["tp1"]},
+            ],
+        }
+        self._client.register_instance(reg_ins_req)
+
+    def _make_dummy_model_deployment(self):
+        return {
+            "model_name": self._model_name,
+            "dtype": "FP8",
+            "use_mla": False,
+            "tp_size": 1,
+            "dp_size": 1,
+            "pp_size": 1,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/common/cache/advanced_cache.h
+++ b/kv_cache_manager/common/cache/advanced_cache.h
@@ -460,6 +460,11 @@ public: // functions
         return EC_UNIMPLEMENTED;
     }
 
+    // Adjust the charge of a referenced handle by `delta` (may be negative).
+    // The caller must hold an external reference (from Lookup) to the handle.
+    // Does NOT trigger eviction even if usage exceeds capacity after adjustment.
+    virtual void AdjustCharge(Handle * /*handle*/, ssize_t /*delta*/) {}
+
     // Apply a callback to a cache handle. The Cache must ensure the lifetime
     // of the key passed to the callback is valid for the duration of the
     // callback. The handle may not belong to the cache, but is guaranteed to

--- a/kv_cache_manager/common/cache/cache.h
+++ b/kv_cache_manager/common/cache/cache.h
@@ -152,6 +152,11 @@ struct ShardedCacheOptions {
     // (default), Insert() never fails.
     bool strict_capacity_limit = false;
 
+    // If true, Insert() will NOT evict existing entries to make room for the
+    // new entry. If capacity is exceeded, Insert() returns EC_NOSPC (requires
+    // strict_capacity_limit to also be true for the error to propagate).
+    bool no_evict_on_insert = false;
+
     // If non-nullptr, RocksDB will use this allocator instead of system
     // allocator when allocating memory for cache blocks.
     //
@@ -200,11 +205,13 @@ struct ShardedCacheOptions {
     ShardedCacheOptions(size_t _capacity,
                         int _num_shard_bits,
                         bool _strict_capacity_limit,
+                        bool _no_evict_on_insert = false,
                         std::shared_ptr<MemoryAllocator> _memory_allocator = nullptr,
                         CacheMetadataChargePolicy _metadata_charge_policy = kDefaultCacheMetadataChargePolicy)
         : capacity(_capacity)
         , num_shard_bits(_num_shard_bits)
         , strict_capacity_limit(_strict_capacity_limit)
+        , no_evict_on_insert(_no_evict_on_insert)
         , memory_allocator(std::move(_memory_allocator))
         , metadata_charge_policy(_metadata_charge_policy) {}
     // Make ShardedCacheOptions polymorphic
@@ -254,13 +261,18 @@ struct LRUCacheOptions : public ShardedCacheOptions {
     LRUCacheOptions(size_t _capacity,
                     int _num_shard_bits,
                     bool _strict_capacity_limit,
+                    bool _no_evict_on_insert,
                     double _high_pri_pool_ratio,
                     std::shared_ptr<MemoryAllocator> _memory_allocator = nullptr,
                     bool _use_adaptive_mutex = kDefaultToAdaptiveMutex,
                     CacheMetadataChargePolicy _metadata_charge_policy = kDefaultCacheMetadataChargePolicy,
                     double _low_pri_pool_ratio = 0.0)
-        : ShardedCacheOptions(
-              _capacity, _num_shard_bits, _strict_capacity_limit, std::move(_memory_allocator), _metadata_charge_policy)
+        : ShardedCacheOptions(_capacity,
+                              _num_shard_bits,
+                              _strict_capacity_limit,
+                              _no_evict_on_insert,
+                              std::move(_memory_allocator),
+                              _metadata_charge_policy)
         , high_pri_pool_ratio(_high_pri_pool_ratio)
         , low_pri_pool_ratio(_low_pri_pool_ratio)
         , use_adaptive_mutex(_use_adaptive_mutex) {}
@@ -278,6 +290,7 @@ inline std::shared_ptr<Cache>
 NewLRUCache(size_t capacity,
             int num_shard_bits = -1,
             bool strict_capacity_limit = false,
+            bool no_evict_on_insert = false,
             double high_pri_pool_ratio = 0.5,
             std::shared_ptr<MemoryAllocator> memory_allocator = nullptr,
             bool use_adaptive_mutex = kDefaultToAdaptiveMutex,
@@ -286,6 +299,7 @@ NewLRUCache(size_t capacity,
     return LRUCacheOptions(capacity,
                            num_shard_bits,
                            strict_capacity_limit,
+                           no_evict_on_insert,
                            high_pri_pool_ratio,
                            memory_allocator,
                            use_adaptive_mutex,
@@ -340,6 +354,7 @@ struct CompressedSecondaryCacheOptions : LRUCacheOptions {
         : LRUCacheOptions(_capacity,
                           _num_shard_bits,
                           _strict_capacity_limit,
+                          /*_no_evict_on_insert=*/false,
                           _high_pri_pool_ratio,
                           std::move(_memory_allocator),
                           _use_adaptive_mutex,
@@ -504,8 +519,12 @@ struct HyperClockCacheOptions : public ShardedCacheOptions {
                            bool _strict_capacity_limit = false,
                            std::shared_ptr<MemoryAllocator> _memory_allocator = nullptr,
                            CacheMetadataChargePolicy _metadata_charge_policy = kDefaultCacheMetadataChargePolicy)
-        : ShardedCacheOptions(
-              _capacity, _num_shard_bits, _strict_capacity_limit, std::move(_memory_allocator), _metadata_charge_policy)
+        : ShardedCacheOptions(_capacity,
+                              _num_shard_bits,
+                              _strict_capacity_limit,
+                              /*_no_evict_on_insert=*/false,
+                              std::move(_memory_allocator),
+                              _metadata_charge_policy)
         , estimated_entry_charge(_estimated_entry_charge) {}
 
     // Construct an instance of HyperClockCache using these options

--- a/kv_cache_manager/common/cache/lru_cache.cc
+++ b/kv_cache_manager/common/cache/lru_cache.cc
@@ -108,6 +108,7 @@ void LRUHandleTable::Resize() {
 
 LRUCacheShard::LRUCacheShard(size_t capacity,
                              bool strict_capacity_limit,
+                             bool no_evict_on_insert,
                              double high_pri_pool_ratio,
                              double low_pri_pool_ratio,
                              bool use_adaptive_mutex,
@@ -120,6 +121,7 @@ LRUCacheShard::LRUCacheShard(size_t capacity,
     , high_pri_pool_usage_(0)
     , low_pri_pool_usage_(0)
     , strict_capacity_limit_(strict_capacity_limit)
+    , no_evict_on_insert_(no_evict_on_insert)
     , high_pri_pool_ratio_(high_pri_pool_ratio)
     , high_pri_pool_capacity_(0)
     , low_pri_pool_ratio_(low_pri_pool_ratio)
@@ -370,7 +372,9 @@ ErrorCode
 LRUCacheShard::DoInsertItemUnsafe(LRUHandle *e, LRUHandle **handle, autovector<LRUHandle *> *last_reference_list) {
     // Free the space following strict LRU policy until enough space
     // is freed or the lru list is empty.
-    EvictFromLRU(e->total_charge, last_reference_list);
+    if (!no_evict_on_insert_) {
+        EvictFromLRU(e->total_charge, last_reference_list);
+    }
 
     if ((usage_ + e->total_charge) > capacity_ && (strict_capacity_limit_ || handle == nullptr)) {
         e->SetInCache(false);
@@ -479,6 +483,22 @@ bool LRUCacheShard::Ref(LRUHandle *e) {
     return true;
 }
 
+void LRUCacheShard::AdjustCharge(LRUHandle *e, ssize_t delta) {
+    std::lock_guard<std::mutex> l(mutex_);
+    assert(e->HasRefs());
+    assert(e->InCache());
+    if (delta > 0) {
+        e->total_charge += static_cast<size_t>(delta);
+        usage_ += static_cast<size_t>(delta);
+    } else if (delta < 0) {
+        size_t decrease = static_cast<size_t>(-delta);
+        decrease = std::min(decrease, e->total_charge);
+        decrease = std::min(decrease, usage_);
+        e->total_charge -= decrease;
+        usage_ -= decrease;
+    }
+}
+
 void LRUCacheShard::SetHighPriorityPoolRatio(double high_pri_pool_ratio) {
     std::lock_guard<std::mutex> l(mutex_);
     high_pri_pool_ratio_ = high_pri_pool_ratio;
@@ -505,8 +525,12 @@ bool LRUCacheShard::Release(LRUHandle *e, bool /*useful*/, bool erase_if_last_re
         was_in_cache = e->InCache();
         if (must_free && was_in_cache) {
             // The item is still in cache, and nobody else holds a reference to it.
-            if (usage_ > capacity_ || erase_if_last_ref) {
-                // The LRU list must be empty since the cache is full.
+            if (erase_if_last_ref || (!no_evict_on_insert_ && usage_ > capacity_)) {
+                // When no_evict_on_insert_ is false: usage > capacity means the
+                // LRU list must be empty (EvictFromLRU drained it on Insert).
+                // When no_evict_on_insert_ is true: skip opportunistic eviction
+                // to avoid silently dropping entries whose charge grew in-place
+                // (via AdjustCharge).
                 assert(lru_.next == &lru_ || erase_if_last_ref);
                 // Take this opportunity and remove the item.
                 table_.Remove(e->key(), e->hash);
@@ -608,7 +632,9 @@ LRUHandle *LRUCacheShard::CreateStandalone(const std::string_view &key,
     {
         std::lock_guard<std::mutex> l(mutex_);
 
-        EvictFromLRU(e->total_charge, &last_reference_list);
+        if (!no_evict_on_insert_) {
+            EvictFromLRU(e->total_charge, &last_reference_list);
+        }
 
         if (strict_capacity_limit_ && (usage_ + e->total_charge) > capacity_) {
             if (allow_uncharged) {
@@ -729,6 +755,7 @@ LRUCache::LRUCache(const LRUCacheOptions &opts) : ShardedCache(opts) {
     InitShards([&](LRUCacheShard *cs) {
         new (cs) LRUCacheShard(per_shard,
                                opts.strict_capacity_limit,
+                               opts.no_evict_on_insert,
                                opts.high_pri_pool_ratio,
                                opts.low_pri_pool_ratio,
                                opts.use_adaptive_mutex,

--- a/kv_cache_manager/common/cache/lru_cache.h
+++ b/kv_cache_manager/common/cache/lru_cache.h
@@ -260,6 +260,7 @@ public:
     // alive in Cache.
     LRUCacheShard(size_t capacity,
                   bool strict_capacity_limit,
+                  bool no_evict_on_insert,
                   double high_pri_pool_ratio,
                   double low_pri_pool_ratio,
                   bool use_adaptive_mutex,
@@ -328,6 +329,11 @@ public: // Function definitions expected as parameter to ShardedCache
     bool Release(LRUHandle *handle, bool useful, bool erase_if_last_ref);
     bool Ref(LRUHandle *handle);
     void Erase(const std::string_view &key, uint32_t hash);
+
+    // Adjust the charge of a referenced handle by `delta` (may be negative).
+    // The caller must hold an external reference to `handle`.
+    // Does NOT trigger eviction even if usage exceeds capacity.
+    void AdjustCharge(LRUHandle *handle, ssize_t delta);
 
     // Although in some platforms the update of size_t is atomic, to make sure
     // GetUsage() and GetPinnedUsage() work correctly under any platform, we'll
@@ -420,6 +426,9 @@ private:
 
     // Whether to reject insertion if cache reaches its full capacity.
     bool strict_capacity_limit_;
+
+    // If true, Insert() skips LRU eviction and fails immediately when full.
+    bool no_evict_on_insert_;
 
     // Ratio of capacity reserved for high priority cache entries.
     double high_pri_pool_ratio_;

--- a/kv_cache_manager/common/cache/sharded_cache.h
+++ b/kv_cache_manager/common/cache/sharded_cache.h
@@ -217,6 +217,11 @@ public:
         GetShard(hash).Erase(key, hash);
     }
 
+    void AdjustCharge(Handle *handle, ssize_t delta) override {
+        auto h = static_cast<HandleImpl *>(handle);
+        GetShard(h->GetHash()).AdjustCharge(h, delta);
+    }
+
     bool Release(Handle *handle, bool useful, bool erase_if_last_ref = false) override {
         auto h = static_cast<HandleImpl *>(handle);
         return GetShard(h->GetHash()).Release(h, useful, erase_if_last_ref);
@@ -263,8 +268,8 @@ public:
 
     void ApplyToSingleShard(
         uint32_t shard_id,
-        const std::function<
-            void(const std::string_view &key, Cache::ObjectPtr obj, size_t charge, const Cache::CacheItemHelper *helper)>
+        const std::function<void(
+            const std::string_view &key, Cache::ObjectPtr obj, size_t charge, const Cache::CacheItemHelper *helper)>
             &callback) override {
         uint32_t num_shards = GetNumShards();
         if (shard_id >= num_shards) {

--- a/kv_cache_manager/common/redis_client.cc
+++ b/kv_cache_manager/common/redis_client.cc
@@ -746,7 +746,15 @@ std::vector<ErrorCode> RedisClient::ExistsFieldWithPrefix(const std::vector<std:
                                                           std::vector<bool> &out_exists_vec) {
     out_exists_vec.assign(keys.size(), false);
 
-    std::vector<ErrorCode> ec_per_key(keys.size(), EC_OK);
+    // First check which keys exist. Non-existent keys get EC_NOENT immediately.
+    std::vector<bool> key_exists_vec;
+    std::vector<ErrorCode> ec_per_key = Exists(keys, key_exists_vec);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (ec_per_key[i] == EC_OK && !key_exists_vec[i]) {
+            ec_per_key[i] = EC_NOENT;
+        }
+    }
+
     const std::string pattern = field_prefix + "*";
     const std::string count_hint = "1000";
     struct PendingKey {
@@ -756,7 +764,9 @@ std::vector<ErrorCode> RedisClient::ExistsFieldWithPrefix(const std::vector<std:
     std::vector<PendingKey> pending;
     pending.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        pending.push_back({i, "0"});
+        if (ec_per_key[i] == EC_OK) {
+            pending.push_back({i, "0"});
+        }
     }
     while (!pending.empty()) {
         std::vector<CmdArgs> hscan_cmds;
@@ -831,7 +841,15 @@ RedisClient::GetFieldNamesWithPrefix(const std::vector<std::string> &keys,
                                      std::vector<std::vector<std::string>> &out_field_names_vec) {
     out_field_names_vec.resize(keys.size());
 
-    std::vector<ErrorCode> ec_per_key(keys.size(), EC_OK);
+    // First check which keys exist. Non-existent keys get EC_NOENT immediately.
+    std::vector<bool> key_exists_vec;
+    std::vector<ErrorCode> ec_per_key = Exists(keys, key_exists_vec);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (ec_per_key[i] == EC_OK && !key_exists_vec[i]) {
+            ec_per_key[i] = EC_NOENT;
+        }
+    }
+
     const std::string pattern = field_prefix + "*";
     const std::string count_hint = "1000";
     struct PendingKey {
@@ -841,7 +859,9 @@ RedisClient::GetFieldNamesWithPrefix(const std::vector<std::string> &keys,
     std::vector<PendingKey> pending;
     pending.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        pending.push_back({i, "0"});
+        if (ec_per_key[i] == EC_OK) {
+            pending.push_back({i, "0"});
+        }
     }
     while (!pending.empty()) {
         std::vector<CmdArgs> hscan_cmds;

--- a/kv_cache_manager/common/test/lru_cache_test.cc
+++ b/kv_cache_manager/common/test/lru_cache_test.cc
@@ -33,6 +33,7 @@ public:
         cache_ = static_cast<LRUCacheShard *>(port::cacheline_aligned_alloc(sizeof(LRUCacheShard)));
         new (cache_) LRUCacheShard(capacity,
                                    /*strict_capacity_limit=*/false,
+                                   /*no_evict_on_insert=*/false,
                                    high_pri_pool_ratio,
                                    low_pri_pool_ratio,
                                    use_adaptive_mutex,

--- a/kv_cache_manager/config/meta_cache_policy_config.h
+++ b/kv_cache_manager/config/meta_cache_policy_config.h
@@ -8,7 +8,7 @@ namespace kv_cache_manager {
 class MetaCachePolicyConfig : public Jsonizable {
 public:
     static constexpr const char *kDefaultCacheType = "lru";
-    static constexpr size_t kDefaultCacheCapacity = 1024; // MB
+    static constexpr size_t kDefaultCacheCapacity = 0; // MB
     static constexpr int32_t kDefaultCacheShardBits = 6;
     static constexpr double kDefaultHighPriPoolRatio = 0.0;
 

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -198,9 +198,11 @@ void SchedulePlanExecutor::DoLocationDelTask(const std::shared_ptr<std::promise<
             if (delete_results[i] != ErrorCode::EC_OK) {
                 // 这里存储删除报错暂且不管，报个warn表示哪个storageUri删失败了
                 result.status = ErrorCode::EC_PARTIAL_OK;
-                KVCM_LOG_WARN("Failed to delete kvcache from storage %s, uri: %s",
+                KVCM_LOG_WARN("storage delete failed, instance[%s] storage[%s] uri[%s] ec[%d]",
+                              task.instance_id.c_str(),
                               storage_unique_name.c_str(),
-                              storage_uris[i].ToUriString().c_str());
+                              storage_uris[i].ToUriString().c_str(),
+                              static_cast<int>(delete_results[i]));
             }
         }
     }

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -266,6 +266,10 @@ MetaDummyBackend::DeleteFields(const KeyTypeVec &keys,
     }
     std::vector<ErrorCode> ec_vec;
     for (std::size_t i = 0; i != keys.size(); ++i) {
+        if (field_names_vec[i].empty()) {
+            ec_vec.emplace_back(ErrorCode::EC_OK); // Nothing to delete — idempotent success.
+            continue;
+        }
         ec_vec.emplace_back(DeleteFieldsForOneKey(keys[i], field_names_vec[i]));
         if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
             KVCM_LOG_WARN("delete fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
@@ -308,13 +312,13 @@ std::vector<ErrorCode> MetaDummyBackend::Get(const KeyTypeVec &keys,
 std::vector<ErrorCode> MetaDummyBackend::Get(const KeyTypeVec &keys,
                                              const std::vector<std::vector<std::string>> &field_names_vec,
                                              FieldMapVec &out_field_maps) noexcept {
+    out_field_maps = FieldMapVec(keys.size());
     if (keys.size() != field_names_vec.size()) {
         KVCM_LOG_ERROR(
             "get failed, keys.size: [%zu] != field_names_vec.size: [%zu]", keys.size(), field_names_vec.size());
         return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
     }
     std::vector<ErrorCode> ec_vec;
-    out_field_maps = FieldMapVec(keys.size());
     for (std::size_t i = 0; i != keys.size(); ++i) {
         ec_vec.emplace_back(GetForOneKey(keys[i], field_names_vec[i], out_field_maps[i]));
         if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
@@ -365,9 +369,6 @@ std::vector<ErrorCode> MetaDummyBackend::GetAllFields(const KeyTypeVec &keys, Fi
 ErrorCode MetaDummyBackend::GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) {
     out_field_map.clear();
     if (!table_.Get(key, out_field_map)) {
-        return ErrorCode::EC_NOENT;
-    }
-    if (out_field_map.empty()) {
         return ErrorCode::EC_NOENT;
     }
     // Update last access time in the stored map after copying the old value

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -117,18 +117,15 @@ ErrorCode MetaIndexer::Init(const std::string &instance_id, const std::shared_pt
         KVCM_LOG_ERROR("instance[%s] recover metadata failed, ec[%d]", instance_id_.c_str(), ec);
         return ec;
     }
-    KVCM_LOG_INFO(
-        "instance[%s] meta indexer init success, mutex shard num[%lu], max key count[%lu], "
-        "batch key size[%lu], search cache size[%lu], key_count[%lu], persist_metadata_interval_time_ms[%zu], "
-        "storage usage data[%s]",
-        instance_id_.c_str(),
-        mutex_shard_num,
-        max_key_count_,
-        batch_key_size_,
-        config->GetMetaCachePolicyConfig()->GetCapacity(),
-        key_count_.load(),
-        persist_metadata_interval_time_ms_,
-        storage_usage_data_.ToJsonString().c_str());
+    KVCM_LOG_INFO("instance[%s] meta indexer init success, mutex shard num[%lu], max key count[%lu], "
+                  "batch key size[%lu], key_count[%lu], persist_metadata_interval_time_ms[%zu], storage usage data[%s]",
+                  instance_id_.c_str(),
+                  mutex_shard_num,
+                  max_key_count_,
+                  batch_key_size_,
+                  key_count_.load(),
+                  persist_metadata_interval_time_ms_,
+                  storage_usage_data_.ToJsonString().c_str());
     return EC_OK;
 }
 

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -54,7 +54,10 @@ ErrorCode MetaLocalBackend::Init(const std::string &instance_id,
     }
 
     shard_mask_ = (1 << num_shard_bits) - 1;
-    cache_ = NewLRUCache(capacity * 1024 * 1024ULL, num_shard_bits);
+    cache_ = NewLRUCache(capacity * 1024 * 1024ULL,
+                         num_shard_bits,
+                         /*strict_capacity_limit=*/true,
+                         /*no_evict_on_insert=*/true);
     if (!cache_) {
         KVCM_LOG_ERROR("fail to create LRUCache");
         return EC_ERROR;
@@ -93,6 +96,7 @@ ErrorCode MetaLocalBackend::Open() noexcept {
         KVCM_LOG_ERROR("Cache is not initialized");
         return EC_ERROR;
     }
+    KVCM_LOG_INFO("local backend open ok");
     return EC_OK;
 }
 
@@ -102,6 +106,7 @@ ErrorCode MetaLocalBackend::Close() noexcept {
     }
     cache_.reset();
     cache_item_helper_.reset();
+    KVCM_LOG_INFO("local backend close ok");
     return EC_OK;
 }
 
@@ -113,9 +118,18 @@ ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, const Fi
     MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
     item->TouchAccessTime();
     size_t charge = item->Size();
-    ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge);
+    // We must pass &handle (not nullptr) so that when strict_capacity_limit
+    // is enabled and capacity is exceeded, Insert returns EC_NOSPC instead
+    // of silently discarding the entry with EC_OK.
+    // On success the handle holds a reference that pins the entry out of
+    // the LRU list (preventing eviction), so we Release it immediately to
+    // let the entry become evictable again.
+    Cache::Handle *handle = nullptr;
+    ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge, &handle);
     if (ret != EC_OK) {
         MetaMemCacheItem::Deleter(item, nullptr);
+    } else if (handle) {
+        cache_->Release(handle);
     }
     return ret;
 }
@@ -124,9 +138,13 @@ ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, FieldMap
     MetaMemCacheItem *item = MetaMemCacheItem::Create(std::move(fields));
     item->TouchAccessTime();
     size_t charge = item->Size();
-    ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge);
+    // See the const-ref overload above for why we pass &handle.
+    Cache::Handle *handle = nullptr;
+    ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge, &handle);
     if (ret != EC_OK) {
         MetaMemCacheItem::Deleter(item, nullptr);
+    } else if (handle) {
+        cache_->Release(handle);
     }
     return ret;
 }
@@ -135,26 +153,15 @@ ErrorCode MetaLocalBackend::CreateAndInsertIfAbsent(const std::string &key_str, 
     MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
     item->TouchAccessTime();
     size_t charge = item->Size();
-    ErrorCode ret = cache_->InsertIfAbsent(key_str, item, cache_item_helper_.get(), charge);
+    // See CreateAndInsert above for why we pass &handle.
+    Cache::Handle *handle = nullptr;
+    ErrorCode ret = cache_->InsertIfAbsent(key_str, item, cache_item_helper_.get(), charge, &handle);
     if (ret != EC_OK && ret != EC_EXIST) {
         MetaMemCacheItem::Deleter(item, nullptr);
+    } else if (handle) {
+        cache_->Release(handle);
     }
     return ret;
-}
-
-bool MetaLocalBackend::LookupFields(const std::string &key_str, FieldMap &out_fields) {
-    Cache::Handle *handle = cache_->Lookup(key_str);
-    if (!handle) {
-        return false;
-    }
-    auto *existing = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
-    existing->TouchAccessTime();
-    {
-        std::shared_lock lock(existing->GetMutex());
-        out_fields = existing->GetFields();
-    }
-    cache_->Release(handle);
-    return true;
 }
 
 ErrorCode MetaLocalBackend::UpdateFieldsInPlace(const std::string &key_str, const FieldMap &updates) {
@@ -164,11 +171,25 @@ ErrorCode MetaLocalBackend::UpdateFieldsInPlace(const std::string &key_str, cons
     }
     auto *existing = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
     existing->TouchAccessTime();
+    ssize_t charge_delta = 0;
     {
         std::unique_lock lock(existing->GetMutex());
-        for (const auto &[key, value] : updates) {
-            existing->GetMutableFields()[key] = value;
+        auto &fields = existing->GetMutableFields();
+        for (const auto &[field_name, field_value] : updates) {
+            auto it = fields.find(field_name);
+            if (it != fields.end()) {
+                // Existing field: delta is difference in value length.
+                charge_delta += static_cast<ssize_t>(field_value.size()) - static_cast<ssize_t>(it->second.size());
+                it->second = field_value;
+            } else {
+                // New field: add full entry overhead.
+                charge_delta += static_cast<ssize_t>(field_name.size() + field_value.size() + sizeof(void *) * 4);
+                fields[field_name] = field_value;
+            }
         }
+    }
+    if (charge_delta != 0) {
+        cache_->AdjustCharge(handle, charge_delta);
     }
     cache_->Release(handle);
     return EC_OK;
@@ -206,11 +227,20 @@ ErrorCode MetaLocalBackend::DeleteFieldsForOneKey(KeyType key, const std::vector
     }
     auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
     item->TouchAccessTime();
+    ssize_t charge_delta = 0;
     {
         std::unique_lock lock(item->GetMutex());
+        auto &fields = item->GetMutableFields();
         for (const auto &field_name : field_names) {
-            item->GetMutableFields().erase(field_name);
+            auto it = fields.find(field_name);
+            if (it != fields.end()) {
+                charge_delta -= static_cast<ssize_t>(it->first.size() + it->second.size() + sizeof(void *) * 4);
+                fields.erase(it);
+            }
         }
+    }
+    if (charge_delta != 0) {
+        cache_->AdjustCharge(handle, charge_delta);
     }
     cache_->Release(handle);
     return EC_OK;
@@ -350,6 +380,9 @@ MetaLocalBackend::DeleteFields(const KeyTypeVec &keys,
                                const std::vector<std::vector<std::string>> &field_names_vec) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
+        if (field_names_vec[i].empty()) {
+            continue; // Nothing to delete — idempotent success.
+        }
         results[i] = DeleteFieldsForOneKey(keys[i], field_names_vec[i]);
     }
     return results;
@@ -360,6 +393,10 @@ std::vector<ErrorCode> MetaLocalBackend::DeleteFields(const KeyTypeVec &keys,
                                                       const std::vector<ErrorCode> &previous_error_codes) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
+        if (field_names_vec[i].empty()) {
+            results[i] = previous_error_codes[i];
+            continue; // Nothing to delete — idempotent success (propagate previous ec).
+        }
         results[i] = (previous_error_codes[i] == EC_OK) ? DeleteFieldsForOneKey(keys[i], field_names_vec[i])
                                                         : previous_error_codes[i];
     }

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -52,9 +52,9 @@ struct MetaMemCacheItem {
     static void Deleter(void *value, MemoryAllocator * /*allocator*/) { delete static_cast<MetaMemCacheItem *>(value); }
 
 private:
+    mutable std::shared_mutex mutex_;
     FieldMap fields_;
     std::atomic<int64_t> last_access_time_{0};
-    mutable std::shared_mutex mutex_;
 };
 
 class MetaLocalBackend : public MetaCacheBaseBackend {
@@ -93,6 +93,7 @@ public:
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
     std::vector<ErrorCode> Delete(const KeyTypeVec &keys,
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
+    // Adjusts the LRU charge to reflect the size change.
     std::vector<ErrorCode> DeleteFields(const KeyTypeVec &keys,
                                         const std::vector<std::vector<std::string>> &field_names_vec,
                                         const std::vector<ErrorCode> &previous_error_codes) noexcept override;
@@ -146,12 +147,8 @@ private:
     // Creates a MetaMemCacheItem and inserts it into cache_ via InsertIfAbsent().
     ErrorCode CreateAndInsertIfAbsent(const std::string &key_str, const FieldMap &fields);
 
-    // Looks up an existing cache item and returns a copy of its fields.
-    // Returns true if the key was found, false otherwise.
-    bool LookupFields(const std::string &key_str, FieldMap &out_fields);
-
     // Looks up an existing cache item and merges `updates` into its fields
-    // in place (the handle prevents eviction during the update).
+    // in place. Adjusts the LRU charge to reflect the size change.
     // Returns EC_OK on success, EC_NOENT if key not found.
     ErrorCode UpdateFieldsInPlace(const std::string &key_str, const FieldMap &updates);
 

--- a/kv_cache_manager/meta/meta_search_cache.cc
+++ b/kv_cache_manager/meta/meta_search_cache.cc
@@ -17,15 +17,17 @@ ErrorCode MetaSearchCache::Init(const std::shared_ptr<MetaCachePolicyConfig> &co
     std::string cache_type = config->GetCachePolicyType();
     StringUtil::ToLower(cache_type);
     if (cache_type != "lru") {
-        KVCM_LOG_ERROR("meta search cache init failed, only support lru, type [%s]",
-                       cache_type.c_str());
+        KVCM_LOG_ERROR("meta search cache init failed, only support lru, type [%s]", cache_type.c_str());
         return EC_ERROR;
     }
     cache_size_ = config->GetCapacity();
     int32_t cache_shard_bits = config->GetCacheShardBits();
     double high_pri_pool_ratio = config->GetHighPriPoolRatio();
-    cache_ =
-        NewLRUCache(cache_size_ * 1024 * 1024, cache_shard_bits, /*strict_capacity_limit*/ true, high_pri_pool_ratio);
+    cache_ = NewLRUCache(cache_size_ * 1024 * 1024,
+                         cache_shard_bits,
+                         /*strict_capacity_limit=*/true,
+                         /*no_evict_on_insert=*/false,
+                         high_pri_pool_ratio);
     if (!cache_) {
         KVCM_LOG_ERROR(
             "create meta search cache failed, cache size [%lu]MB, cache shard bits [%d], high pri pool ratio [%f]",

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -11,60 +11,198 @@
 namespace kv_cache_manager {
 class MetaStorageBackendConfig;
 
-// MetaIndexer 后端存储抽象基类
+// MetaStorageBackend — MetaIndexer 后端存储抽象基类
+//
+// 数据模型：
+//   每个 key (int64_t) 对应一个 hash 结构，内含多个 field→value 映射。
+//   field 用于存储 location（前缀 "__loc__"）和 property。
+
 class MetaStorageBackend {
 public:
-    // The storage primitives (KeyType / KeyTypeVec / FieldMap / FieldMapVec)
-    // are now defined once in kv_cache_manager/meta/types.h. We re-export them
-    // here for the existing call sites that reach for them via this class.
     using KeyType = ::kv_cache_manager::KeyType;
     using KeyTypeVec = ::kv_cache_manager::KeyTypeVec;
     using FieldMap = ::kv_cache_manager::FieldMap;
     using FieldMapVec = ::kv_cache_manager::FieldMapVec;
 
-public:
     virtual ~MetaStorageBackend() = default;
 
     virtual std::string GetStorageType() noexcept = 0;
 
+    // 初始化后端。必须在 Open() 之前调用。
+    // @param instance_id  实例标识，用于 key 前缀隔离
+    // @param config       后端配置（含 storage_uri 等）
+    // @return EC_OK 成功；EC_BADARGS 参数非法；EC_ERROR 内部错误
     virtual ErrorCode Init(const std::string &instance_id,
                            const std::shared_ptr<MetaStorageBackendConfig> &config) noexcept = 0;
+
+    // 打开后端连接/资源。Init 成功后调用。
+    // @return EC_OK 成功；EC_ERROR 连接/资源获取失败
     virtual ErrorCode Open() noexcept = 0;
+
+    // 关闭后端，释放连接和资源。
+    // @return EC_OK 成功；EC_ERROR 关闭时出错
     virtual ErrorCode Close() noexcept = 0;
 
-    // ----- Write -----
+    // =====================================================================
+    // Write APIs
+    // =====================================================================
+
+    // 创建 key 并写入所有 field。若 key 已存在，行为等同于全量覆盖。
+    // @param keys        待写入的 key 列表
+    // @param field_maps  每个 key 对应的 field→value 映射，大小必须等于 keys.size()
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    写入成功
+    //   - EC_ERROR: 写入失败（网络/IO 错误等）
     virtual std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
+
+    // 更新已存在 key 的部分 field。不会创建新 key。
+    // @param keys        待更新的 key 列表
+    // @param field_maps  每个 key 要更新的 field→value，大小必须等于 keys.size()
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    更新成功
+    //   - EC_NOENT: key 不存在（仅 Local/Dummy 后端；Redis HMSET 对不存在的 key 会隐式创建）
+    //   - EC_ERROR: 更新失败
     virtual std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
+
+    // 若 key 存在则更新 field，不存在则创建 key 并写入。语义 = Put + UpdateFields 的合体。
+    // @param keys        待操作的 key 列表
+    // @param field_maps  每个 key 对应的 field→value，大小必须等于 keys.size()
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    操作成功（无论是新建还是更新）
+    //   - EC_ERROR: 操作失败
     virtual std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
+
+    // 删除整个 key 及其所有 field。
+    // @param keys  待删除的 key 列表
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    删除成功（key 确实存在并被删除）
+    //   - EC_NOENT: key 不存在（Local/Dummy 后端）；Redis DEL 返回 0
+    //   - EC_ERROR: 删除失败
     virtual std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept = 0;
 
+    // 删除 key 中的指定 field（部分删除）。幂等语义：删除不存在的 field 视为成功。
+    // @param keys             待操作的 key 列表
+    // @param field_names_vec  每个 key 要删除的 field name 列表，大小必须等于 keys.size()
+    //                         若 field_names_vec[i] 为空，该 key 跳过操作（no-op，返回 EC_OK）
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    删除成功（包括 field 原本就不存在的情况，以及 field_names 为空的 no-op）
+    //   - EC_NOENT: key 本身不存在（仅当 field_names 非空时；Local/Dummy 后端）
+    //   - EC_ERROR: 操作失败
     virtual std::vector<ErrorCode>
     DeleteFields(const KeyTypeVec &keys, const std::vector<std::vector<std::string>> &field_names_vec) noexcept = 0;
 
-    // ----- Read -----
+    // =====================================================================
+    // Read APIs
+    // =====================================================================
+
+    // 按统一的 field name 列表，批量获取多个 key 的指定 field。
+    // @param keys           待查询的 key 列表
+    // @param field_names    所有 key 共用的 field name 列表（不能为空）
+    // @param out_field_maps [out] 每个 key 的结果 map，大小等于 keys.size()。
+    //                       仅包含存在且 value 非空的 field。
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    key 存在（out_field_maps[i] 可能为空——表示请求的 field 都不存在）
+    //   - EC_NOENT: key 不存在
+    //              注意：Redis 后端当所有 field 返回 nil 时统一返回 EC_NOENT。
+    //   - EC_BADARGS: field_names 为空
+    //   - EC_ERROR: 查询失败
     virtual std::vector<ErrorCode>
     Get(const KeyTypeVec &keys, const std::vector<std::string> &field_names, FieldMapVec &out_field_maps) noexcept = 0;
+
+    // 按每个 key 独立的 field name 列表，批量获取 field。
+    // @param keys             待查询的 key 列表
+    // @param field_names_vec  每个 key 对应的 field name 列表，大小必须等于 keys.size()
+    //                         每个子列表不能为空（空列表返回 EC_BADARGS）
+    // @param out_field_maps   [out] 每个 key 的结果 map。仅含存在且 value 非空的 field。
+    // @return 每个 key 的错误码：
+    //   - EC_OK:     key 存在（out_field_maps[i] 可能为空——表示请求的 field 都不存在）
+    //   - EC_NOENT:  key 不存在
+    //              注意：Redis 后端当所有 field 返回 nil 时统一返回 EC_NOENT。
+    //   - EC_BADARGS: field_names_vec[i] 为空
+    //   - EC_ERROR:  查询失败
     virtual std::vector<ErrorCode> Get(const KeyTypeVec &keys,
                                        const std::vector<std::vector<std::string>> &field_names_vec,
                                        FieldMapVec &out_field_maps) noexcept = 0;
+
+    // 获取 key 的所有 field（含 tombstone 空 value）。
+    // 注意：此接口不过滤 tombstone，调用方需自行判断空 value。
+    // @param keys           待查询的 key 列表
+    // @param out_field_maps [out] 每个 key 的完整 field map（包含空 value 的 field）
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    key 存在（即使所有 field value 为空）
+    //   - EC_NOENT: key 不存在
+    //   - EC_ERROR: 查询失败
     virtual std::vector<ErrorCode> GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept = 0;
+
+    // 获取 key 中以指定前缀开头的 field name 列表。跳过 value 为空的 tombstone field。
+    // @param keys                 待查询的 key 列表
+    // @param field_prefix         field name 前缀（如 "__loc__"）
+    // @param out_field_names_vec  [out] 每个 key 匹配的 field name 列表（仅含 value 非空的）
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    key 存在（结果可能为空——key 存在但无匹配的非空 field）
+    //   - EC_NOENT: key 不存在
+    //   - EC_ERROR: 查询失败
     virtual std::vector<ErrorCode>
     GetFieldNamesWithPrefix(const KeyTypeVec &keys,
                             const std::string &field_prefix,
                             std::vector<std::vector<std::string>> &out_field_names_vec) noexcept = 0;
+
+    // 检查 key 是否存在。
+    // @param keys              待查询的 key 列表
+    // @param out_is_exist_vec  [out] 每个 key 是否存在，大小等于 keys.size()
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    查询成功（out_is_exist_vec[i] 反映结果）
+    //   - EC_ERROR: 查询失败
     virtual std::vector<ErrorCode> Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept = 0;
+
+    // 检查 key 中是否存在以指定前缀开头且 value 非空的 field。
+    // 空 value (tombstone) 不被视为有效存在。
+    // @param keys            待查询的 key 列表
+    // @param field_prefix    field name 前缀
+    // @param out_exists_vec  [out] 每个 key 是否有匹配的非空 field
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    key 存在（out_exists_vec[i] 反映结果，可能为 false）
+    //   - EC_NOENT: key 不存在
+    //   - EC_ERROR: 查询失败
     virtual std::vector<ErrorCode> ExistsFieldWithPrefix(const KeyTypeVec &keys,
                                                          const std::string &field_prefix,
                                                          std::vector<bool> &out_exists_vec) noexcept = 0;
+
+    // 基于 cursor 分页扫描所有 key。
+    // @param cursor          游标（首次传 SCAN_BASE_CURSOR = "0"）
+    // @param limit           本次最多返回的 key 数量（hint，实际可能多于或少于此值）
+    // @param out_next_cursor [out] 下一次扫描的 cursor；等于 SCAN_BASE_CURSOR 时表示扫描结束
+    // @param out_keys        [out] 本次扫描到的 key 列表
+    // @return EC_OK 成功；EC_BADARGS cursor 非法；EC_ERROR 扫描失败
     virtual ErrorCode ListKeys(const std::string &cursor,
                                const int64_t limit,
                                std::string &out_next_cursor,
                                KeyTypeVec &out_keys) noexcept = 0;
+
+    // 随机采样 key。
+    // @param count    期望采样数量
+    // @param out_keys [out] 采样结果（实际数量可能小于 count）
+    // @return EC_OK 成功；EC_ERROR 采样失败
     virtual ErrorCode RandomSample(const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
+
+    // 采样适合回收的 key（通常按 LRU 或 access time 排序）。
+    // @param count    期望采样数量
+    // @param out_keys [out] 采样结果
+    // @return EC_OK 成功；EC_ERROR 采样失败
     virtual ErrorCode SampleReclaimKeys(const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
 
-    // meta data
+    // =====================================================================
+    // Metadata APIs — 用于持久化 MetaIndexer 自身的元信息（key_count、storage_usage 等）
+    // =====================================================================
+
+    // 写入/更新 MetaIndexer 元数据。
+    // @param field_maps  要写入的元数据 field→value
+    // @return EC_OK 成功；EC_ERROR 写入失败
     virtual ErrorCode PutMetaData(const FieldMap &field_maps) noexcept = 0;
+
+    // 读取 MetaIndexer 元数据。
+    // @param field_maps [out] 读到的元数据
+    // @return EC_OK 成功；EC_NOENT 无元数据；EC_ERROR 读取失败
     virtual ErrorCode GetMetaData(FieldMap &field_maps) noexcept = 0;
 };
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -479,7 +479,7 @@ std::vector<ErrorCode> MetaStorageBackendManager::Get(const KeyVector &keys,
     KeyTypeVec missing_keys;
     std::vector<size_t> missing_indices;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if ((results[i] == EC_OK && out_field_maps[i].empty()) || results[i] == EC_NOENT) {
+        if (results[i] == EC_NOENT) {
             missing_keys.push_back(keys[i]);
             missing_indices.push_back(i);
         }
@@ -524,7 +524,7 @@ std::vector<ErrorCode> MetaStorageBackendManager::Get(const KeyVector &keys,
     std::vector<std::vector<std::string>> missing_field_names;
     std::vector<size_t> missing_indices;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if ((results[i] == EC_OK && out_field_maps[i].empty()) || results[i] == EC_NOENT) {
+        if (results[i] == EC_NOENT) {
             missing_keys.push_back(keys[i]);
             missing_field_names.push_back(field_names_vec[i]);
             missing_indices.push_back(i);
@@ -568,7 +568,7 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetAllFields(const KeyVector &
     KeyTypeVec missing_keys;
     std::vector<size_t> missing_indices;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if ((results[i] == EC_OK && out_field_maps[i].empty()) || results[i] == EC_NOENT) {
+        if (results[i] == EC_NOENT) {
             missing_keys.push_back(keys[i]);
             missing_indices.push_back(i);
         }
@@ -703,7 +703,7 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(const KeyVector
             KeyTypeVec missing_keys;
             std::vector<size_t> missing_indices;
             for (size_t i = 0; i < keys.size(); ++i) {
-                if ((results[i] == EC_OK && field_names_vec[i].empty()) || results[i] == EC_NOENT) {
+                if (results[i] == EC_NOENT) {
                     missing_keys.push_back(keys[i]);
                     missing_indices.push_back(i);
                 }

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -959,4 +959,112 @@ TEST_F(MetaLocalBackendTest, TestConcurrentReadWrite) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+// ---------------------------------------------------------------------------
+// Test that UpdateFields / Upsert / DeleteFields correctly adjust LRU usage
+// ---------------------------------------------------------------------------
+TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
+    // Use a small capacity (1 MB) with 0 shard bits (single shard) for
+    // deterministic usage tracking.
+    auto config = std::make_shared<MetaStorageBackendConfig>();
+    config->SetStorageUri("local://?capacity=1&num_shard_bits=0");
+    auto backend = std::make_shared<MetaLocalBackend>();
+    ASSERT_EQ(EC_OK, backend->Init("test_charge_adj", config));
+    ASSERT_EQ(EC_OK, backend->Open());
+
+    // Per-field overhead in MetaMemCacheItem::Size(): sizeof(void*) * 4
+    constexpr size_t kMapNodeOverhead = sizeof(void *) * 4;
+
+    // Insert a key with a small field.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "v"}}}));
+    size_t usage_after_put = backend->GetMemUsage();
+
+    // --- UpdateFields: add a new field ---
+    // Expected delta: field_name.size() + field_value.size() + kMapNodeOverhead
+    std::string field_name_a = "field_a";
+    std::string field_value_a(1024, 'x');
+    ssize_t expected_delta_add = static_cast<ssize_t>(field_name_a.size() + field_value_a.size() + kMapNodeOverhead);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->UpdateFields({1}, {{{field_name_a, field_value_a}}}));
+    size_t usage_after_add = backend->GetMemUsage();
+    ASSERT_EQ(static_cast<ssize_t>(usage_after_add - usage_after_put), expected_delta_add);
+
+    // --- UpdateFields: overwrite existing field with shorter value ---
+    // Expected delta: new_value.size() - old_value.size() (name and node overhead unchanged)
+    std::string field_value_a_short = "short";
+    ssize_t expected_delta_shrink =
+        static_cast<ssize_t>(field_value_a_short.size()) - static_cast<ssize_t>(field_value_a.size());
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->UpdateFields({1}, {{{field_name_a, field_value_a_short}}}));
+    size_t usage_after_shrink = backend->GetMemUsage();
+    ASSERT_EQ(static_cast<ssize_t>(usage_after_shrink) - static_cast<ssize_t>(usage_after_add), expected_delta_shrink);
+
+    // --- Upsert: add another new field (key exists, goes through UpdateFieldsInPlace) ---
+    std::string field_name_b = "field_b";
+    std::string field_value_b(512, 'y');
+    ssize_t expected_delta_upsert = static_cast<ssize_t>(field_name_b.size() + field_value_b.size() + kMapNodeOverhead);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Upsert({1}, {{{field_name_b, field_value_b}}}));
+    size_t usage_after_upsert = backend->GetMemUsage();
+    ASSERT_EQ(static_cast<ssize_t>(usage_after_upsert - usage_after_shrink), expected_delta_upsert);
+
+    // --- DeleteFields: remove field_b ---
+    // Expected delta: -(field_name.size() + field_value.size() + kMapNodeOverhead)
+    ssize_t expected_delta_delete =
+        -static_cast<ssize_t>(field_name_b.size() + field_value_b.size() + kMapNodeOverhead);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->DeleteFields({1}, {{field_name_b}}));
+    size_t usage_after_delete = backend->GetMemUsage();
+    ASSERT_EQ(static_cast<ssize_t>(usage_after_delete) - static_cast<ssize_t>(usage_after_upsert),
+              expected_delta_delete);
+
+    // After all adjustments, usage should equal the initial put usage + net delta from field_a shrink.
+    ASSERT_EQ(
+        usage_after_delete,
+        static_cast<size_t>(static_cast<ssize_t>(usage_after_put) +
+                            static_cast<ssize_t>(field_name_a.size() + field_value_a_short.size() + kMapNodeOverhead)));
+
+    // Verify the remaining data is intact.
+    FieldMapVec out;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Get({1}, {PROPERTY_URI, field_name_a}, out));
+    ASSERT_EQ("v", out[0][PROPERTY_URI]);
+    ASSERT_EQ(field_value_a_short, out[0][field_name_a]);
+
+    ASSERT_EQ(EC_OK, backend->Close());
+}
+
+// ---------------------------------------------------------------------------
+// Test that Insert fails with EC_NOSPC when capacity is full
+// (strict_capacity_limit is enabled)
+// ---------------------------------------------------------------------------
+TEST_F(MetaLocalBackendTest, TestStrictCapacityInsertFails) {
+    // Use smallest possible capacity: 1 MB, single shard.
+    auto config = std::make_shared<MetaStorageBackendConfig>();
+    config->SetStorageUri("local://?capacity=1&num_shard_bits=0");
+    auto backend = std::make_shared<MetaLocalBackend>();
+    ASSERT_EQ(EC_OK, backend->Init("test_strict_cap", config));
+    ASSERT_EQ(EC_OK, backend->Open());
+
+    const size_t capacity = backend->cache_->GetCapacity(); // 1 MB
+
+    // Insert a small entry first to verify basic functionality.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "small"}}}));
+
+    // Try to insert an entry whose charge exceeds the entire capacity.
+    std::string huge_value(capacity + 1, 'A');
+    auto results = backend->Put({2}, {{{PROPERTY_URI, huge_value}}});
+    ASSERT_EQ(EC_NOSPC, results[0]);
+
+    // The small entry should still be readable
+    FieldMapVec out;
+    auto get_ec = backend->Get({1}, {PROPERTY_URI}, out);
+    ASSERT_TRUE(EC_OK == get_ec[0]);
+
+    FieldMapVec out2;
+    auto get_ec2 = backend->Get({2}, {PROPERTY_URI}, out2);
+    ASSERT_EQ(EC_NOENT, get_ec2[0]);
+
+    // A reasonably-sized entry should succeed after the failed attempt.
+    std::string normal_value(1024, 'B');
+    auto retry = backend->Put({3}, {{{PROPERTY_URI, normal_value}}});
+    ASSERT_EQ(EC_OK, retry[0]);
+
+    ASSERT_EQ(EC_OK, backend->Close());
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/test/meta_redis_backend_real_service_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_real_service_test.cc
@@ -472,14 +472,12 @@ TEST_F(MetaRedisBackendRealServiceTest, TestExistsFieldWithPrefix) {
                   {kKeyWithPrefix, kKeyWithoutPrefix},
                   {{{LOCATION_PREFIX + "a", "la"}, {LOCATION_PREFIX + "b", "lb"}, {"p0", "v0"}}, {{"p0", "v0"}}}));
 
-    // Note: against a real redis, HSCAN on a non-existent key returns an empty
-    // result with next_cursor=0 instead of an error, so the redis backend
-    // reports EC_OK with `false` for missing keys (rather than EC_NOENT like
-    // the dummy/local backends).
+    // ExistsFieldWithPrefix now uses EXISTS to detect missing keys.
+    // kKeyMissing does not exist → EC_NOENT; the other two exist → EC_OK.
     std::vector<bool> exists_vec;
     auto ec_vec = meta_redis_backend_->ExistsFieldWithPrefix(
         {kKeyWithPrefix, kKeyWithoutPrefix, kKeyMissing}, LOCATION_PREFIX, exists_vec);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), ec_vec);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}), ec_vec);
     ASSERT_EQ((std::vector<bool>{true, false, false}), exists_vec);
 
     // Removing one of the two LOCATION_PREFIX fields: the remaining one still

--- a/kv_cache_manager/meta/test/meta_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_test.cc
@@ -406,8 +406,17 @@ TEST_F(MetaRedisBackendTest, TestExistsFieldWithPrefix) {
         EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
         EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
 
-        // key 1: HSCAN returns one matching field-value pair -> true.
-        // key 2: HSCAN returns empty list with next_cursor=0 -> false.
+        // Step 1: EXISTS check — both keys exist.
+        std::vector<ReplyUPtr> exists_replies;
+        exists_replies.emplace_back(MakeFakeReplyInteger(1));
+        exists_replies.emplace_back(MakeFakeReplyInteger(1));
+        EXPECT_CALL(
+            *mock_redis_client,
+            TryExecPipeline(ElementsAre(ElementsAre(StrEq("EXISTS"), StrEq("kvcache:instance_instance_0:cache_1")),
+                                        ElementsAre(StrEq("EXISTS"), StrEq("kvcache:instance_instance_0:cache_2")))))
+            .WillOnce(Return(ByMove(std::move(exists_replies))));
+
+        // Step 2: HSCAN — key 1 has matching field, key 2 has empty list.
         std::vector<ReplyUPtr> replies;
         replies.emplace_back(MakeFakeReplyScan(/*next_cursor*/ "0", {LOCATION_PREFIX + "a", "la"}));
         replies.emplace_back(MakeFakeReplyScan(/*next_cursor*/ "0", {}));
@@ -446,8 +455,16 @@ TEST_F(MetaRedisBackendTest, TestExistsFieldWithPrefixIgnoresTombstone) {
         EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
         EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
 
-        // key 1: HSCAN returns one field with empty value (tombstone) → false.
-        // key 2: HSCAN returns one field with non-empty value → true.
+        testing::InSequence seq;
+
+        // Step 1: EXISTS check — both keys exist.
+        std::vector<ReplyUPtr> exists_replies;
+        exists_replies.emplace_back(MakeFakeReplyInteger(1));
+        exists_replies.emplace_back(MakeFakeReplyInteger(1));
+        EXPECT_CALL(*mock_redis_client, TryExecPipeline(testing::_))
+            .WillOnce(Return(ByMove(std::move(exists_replies))));
+
+        // Step 2: HSCAN — key 1 has tombstone (empty value), key 2 has valid field.
         std::vector<ReplyUPtr> replies;
         replies.emplace_back(MakeFakeReplyScan("0", {LOCATION_PREFIX + "tomb", ""}));
         replies.emplace_back(MakeFakeReplyScan("0", {LOCATION_PREFIX + "real", "valid"}));
@@ -459,6 +476,48 @@ TEST_F(MetaRedisBackendTest, TestExistsFieldWithPrefixIgnoresTombstone) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
     AssertExistsFieldWithPrefix(meta_redis_backend_.get(), {1, 2}, LOCATION_PREFIX, {EC_OK, EC_OK}, {false, true});
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
+}
+
+// ExistsFieldWithPrefix with a non-existent key should return EC_NOENT.
+TEST_F(MetaRedisBackendTest, TestExistsFieldWithPrefixKeyNotExist) {
+    EXPECT_CALL(*meta_redis_backend_, CreateRedisClient()).WillOnce(Invoke([]() {
+        StandardUri empty_storage_uri;
+        auto mock_redis_client = std::make_unique<MockRedisClient>(empty_storage_uri);
+        EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
+
+        // EXISTS check — key 1 exists, key 2 does not exist.
+        // No HSCAN should be issued for key 2.
+        std::vector<ReplyUPtr> exists_replies;
+        exists_replies.emplace_back(MakeFakeReplyInteger(1));
+        exists_replies.emplace_back(MakeFakeReplyInteger(0));
+        EXPECT_CALL(
+            *mock_redis_client,
+            TryExecPipeline(ElementsAre(ElementsAre(StrEq("EXISTS"), StrEq("kvcache:instance_instance_0:cache_1")),
+                                        ElementsAre(StrEq("EXISTS"), StrEq("kvcache:instance_instance_0:cache_2")))))
+            .WillOnce(Return(ByMove(std::move(exists_replies))));
+
+        // HSCAN only for key 1.
+        std::vector<ReplyUPtr> hscan_replies;
+        hscan_replies.emplace_back(MakeFakeReplyScan("0", {LOCATION_PREFIX + "a", "la"}));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("HSCAN"),
+                                                            StrEq("kvcache:instance_instance_0:cache_1"),
+                                                            StrEq("0"),
+                                                            StrEq("MATCH"),
+                                                            StrEq(LOCATION_PREFIX + "*"),
+                                                            StrEq("COUNT"),
+                                                            StrEq("1000")))))
+            .WillOnce(Return(ByMove(std::move(hscan_replies))));
+        return mock_redis_client;
+    }));
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
+
+    AssertExistsFieldWithPrefix(meta_redis_backend_.get(), {1, 2}, LOCATION_PREFIX, {EC_OK, EC_NOENT}, {true, false});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -653,4 +653,205 @@ TEST_F(MetaStorageBackendManagerTest, TestMaybeReclaimEmptyKeysAfterLastLocation
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
+// --- Multi-key, multi-location: gradual deletion until key reclaimed ----------
+
+TEST_F(MetaStorageBackendManagerTest, TestMultiKeyMultiLocationGradualDeletion) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_multi_loc_gradual";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_multi_loc", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    // Put 3 keys, each with 3 locations in a single batch (Put is overwrite,
+    // so all locations must be in the same batch).
+    KeyVector keys = {40, 50, 60};
+    BatchMetaData batch;
+    batch.batch_keys = keys;
+    batch.batch_indexs = {0, 1, 2};
+    batch.batch_locations.resize(keys.size());
+    batch.batch_properties.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const std::string key_str = std::to_string(keys[i]);
+        const std::string loc_a = "loc_" + key_str;
+        const std::string loc_b = "loc_" + key_str + "_b";
+        const std::string loc_c = "loc_" + key_str + "_c";
+        batch.batch_locations[i].emplace(loc_a, MakeLocation(loc_a, "uri_a_" + key_str));
+        batch.batch_locations[i].emplace(loc_b, MakeLocation(loc_b, "uri_b_" + key_str));
+        batch.batch_locations[i].emplace(loc_c, MakeLocation(loc_c, "uri_c_" + key_str));
+        batch.batch_properties[i]["p0"] = "p0_" + key_str;
+    }
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), mgr.Put(request_context_.get(), batch));
+
+    // Verify each key now has 3 locations.
+    {
+        LocationMapVector out_locations;
+        auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
+        for (size_t i = 0; i < keys.size(); ++i) {
+            ASSERT_EQ(EC_OK, get_ecs[i]) << "key=" << keys[i];
+            ASSERT_EQ(3u, out_locations[i].size()) << "key=" << keys[i] << " should have 3 locations";
+        }
+    }
+
+    // --- Round 1: delete 1 location from each key → keys still alive ---------
+    {
+        LocationIdsPerKey del_ids = {
+            {"loc_40"},
+            {"loc_50"},
+            {"loc_60"},
+        };
+        int32_t reclaimed = -1;
+        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
+        EXPECT_EQ(0, reclaimed) << "keys still have 2 locations each, none should be reclaimed";
+
+        // All keys should still exist.
+        std::vector<bool> exists_vec;
+        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
+        ASSERT_EQ((std::vector<bool>{true, true, true}), exists_vec);
+
+        // Each key should have exactly 2 remaining locations.
+        LocationMapVector out_locations;
+        auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
+        for (size_t i = 0; i < keys.size(); ++i) {
+            ASSERT_EQ(EC_OK, get_ecs[i]);
+            EXPECT_EQ(2u, out_locations[i].size()) << "key=" << keys[i] << " should have 2 locations left";
+        }
+    }
+
+    // --- Round 2: delete another location from each key → keys still alive ---
+    {
+        LocationIdsPerKey del_ids = {
+            {"loc_40_b"},
+            {"loc_50_b"},
+            {"loc_60_b"},
+        };
+        int32_t reclaimed = -1;
+        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
+        EXPECT_EQ(0, reclaimed) << "keys still have 1 location each, none should be reclaimed";
+
+        // All keys should still exist.
+        std::vector<bool> exists_vec;
+        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
+        ASSERT_EQ((std::vector<bool>{true, true, true}), exists_vec);
+
+        // Each key should have exactly 1 remaining location.
+        LocationMapVector out_locations;
+        auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
+        for (size_t i = 0; i < keys.size(); ++i) {
+            ASSERT_EQ(EC_OK, get_ecs[i]);
+            EXPECT_EQ(1u, out_locations[i].size()) << "key=" << keys[i] << " should have 1 location left";
+            // Verify the remaining location is the "_c" one.
+            const std::string expected_id = "loc_" + std::to_string(keys[i]) + "_c";
+            EXPECT_TRUE(out_locations[i].count(expected_id) > 0) << "remaining location should be " << expected_id;
+        }
+    }
+
+    // --- Round 3: delete the last location → all keys should be reclaimed ----
+    {
+        LocationIdsPerKey del_ids = {
+            {"loc_40_c"},
+            {"loc_50_c"},
+            {"loc_60_c"},
+        };
+        int32_t reclaimed = -1;
+        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
+        EXPECT_EQ(3, reclaimed) << "all 3 keys should be reclaimed after last location deleted";
+
+        // All keys should be gone.
+        std::vector<bool> exists_vec;
+        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
+        ASSERT_EQ((std::vector<bool>{false, false, false}), exists_vec);
+    }
+
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+// --- Mixed scenario: some keys reclaimed, some survive -----------------------
+
+TEST_F(MetaStorageBackendManagerTest, TestMultiKeyPartialReclamation) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_partial_reclaim";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_partial", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    // key 70: 2 locations (loc_70, loc_70_b)
+    // key 80: 3 locations (loc_80, loc_80_b, loc_80_c)
+    // key 90: 1 location  (loc_90)
+    // All locations must be in a single Put per key (Put is overwrite).
+    KeyVector keys = {70, 80, 90};
+    BatchMetaData batch;
+    batch.batch_keys = keys;
+    batch.batch_indexs = {0, 1, 2};
+    batch.batch_locations.resize(3);
+    batch.batch_properties.resize(3);
+    // key 70: 2 locations
+    batch.batch_locations[0].emplace("loc_70", MakeLocation("loc_70", "uri_70"));
+    batch.batch_locations[0].emplace("loc_70_b", MakeLocation("loc_70_b", "uri_70_b"));
+    batch.batch_properties[0]["p0"] = "p0_70";
+    // key 80: 3 locations
+    batch.batch_locations[1].emplace("loc_80", MakeLocation("loc_80", "uri_80"));
+    batch.batch_locations[1].emplace("loc_80_b", MakeLocation("loc_80_b", "uri_80_b"));
+    batch.batch_locations[1].emplace("loc_80_c", MakeLocation("loc_80_c", "uri_80_c"));
+    batch.batch_properties[1]["p0"] = "p0_80";
+    // key 90: 1 location
+    batch.batch_locations[2].emplace("loc_90", MakeLocation("loc_90", "uri_90"));
+    batch.batch_properties[2]["p0"] = "p0_90";
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), mgr.Put(request_context_.get(), batch));
+
+    // Verify initial state: key70=2, key80=3, key90=1
+    {
+        LocationMapVector out_locations;
+        auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
+        ASSERT_EQ(EC_OK, get_ecs[0]);
+        ASSERT_EQ(EC_OK, get_ecs[1]);
+        ASSERT_EQ(EC_OK, get_ecs[2]);
+        EXPECT_EQ(2u, out_locations[0].size());
+        EXPECT_EQ(3u, out_locations[1].size());
+        EXPECT_EQ(1u, out_locations[2].size());
+    }
+
+    // Delete: key70 loses 1 of 2, key80 loses all 3, key90 loses its only 1.
+    // Expected: key70 survives, key80 and key90 are reclaimed.
+    {
+        LocationIdsPerKey del_ids = {
+            {"loc_70"},                         // key70: 1 of 2 deleted → survives
+            {"loc_80", "loc_80_b", "loc_80_c"}, // key80: all 3 deleted → reclaimed
+            {"loc_90"},                         // key90: only 1 deleted → reclaimed
+        };
+        int32_t reclaimed = -1;
+        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
+        EXPECT_EQ(2, reclaimed) << "key80 and key90 should be reclaimed";
+    }
+
+    // Verify: key70 still exists with 1 location, key80 and key90 are gone.
+    {
+        std::vector<bool> exists_vec;
+        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
+        EXPECT_TRUE(exists_vec[0]) << "key70 should still exist";
+        EXPECT_FALSE(exists_vec[1]) << "key80 should be reclaimed";
+        EXPECT_FALSE(exists_vec[2]) << "key90 should be reclaimed";
+    }
+
+    // key70 should have exactly 1 remaining location.
+    {
+        LocationMapVector out_locations;
+        auto get_ecs = mgr.GetLocations(request_context_.get(), {70}, out_locations);
+        ASSERT_EQ(EC_OK, get_ecs[0]);
+        ASSERT_EQ(1u, out_locations[0].size());
+        EXPECT_TRUE(out_locations[0].count("loc_70_b") > 0);
+    }
+
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -233,16 +233,16 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
         proto_cache_config->meta_indexer_config().meta_storage_backend_config().storage_uri());
     meta_indexer_config->SetMetaStorageBackendConfig(meta_storage_backend_config);
 
-    // 转换meta_cache_policy_config
-    auto meta_cache_policy_config = std::make_shared<MetaCachePolicyConfig>();
-    meta_cache_policy_config->SetCapacity(
-        proto_cache_config->meta_indexer_config().meta_cache_policy_config().capacity());
-    meta_cache_policy_config->SetType(proto_cache_config->meta_indexer_config().meta_cache_policy_config().type());
-    meta_cache_policy_config->SetCacheShardBits(
-        proto_cache_config->meta_indexer_config().meta_cache_policy_config().cache_shard_bits());
-    meta_cache_policy_config->SetHighPriPoolRatio(
-        proto_cache_config->meta_indexer_config().meta_cache_policy_config().high_pri_pool_ratio());
-    meta_indexer_config->SetMetaCachePolicyConfig(meta_cache_policy_config);
+    // 转换meta_cache_policy_config（仅当 proto 中实际配置了时才填充）
+    const auto &proto_cache_policy = proto_cache_config->meta_indexer_config().meta_cache_policy_config();
+    if (!proto_cache_policy.type().empty()) {
+        auto meta_cache_policy_config = std::make_shared<MetaCachePolicyConfig>();
+        meta_cache_policy_config->SetCapacity(proto_cache_policy.capacity());
+        meta_cache_policy_config->SetType(proto_cache_policy.type());
+        meta_cache_policy_config->SetCacheShardBits(proto_cache_policy.cache_shard_bits());
+        meta_cache_policy_config->SetHighPriPoolRatio(proto_cache_policy.high_pri_pool_ratio());
+        meta_indexer_config->SetMetaCachePolicyConfig(meta_cache_policy_config);
+    }
 
     cache_config_info.set_meta_indexer_config(meta_indexer_config);
 }


### PR DESCRIPTION
**修复 MetaLocalBackend 内存用量计算并简化配置**

1. **修复 usage 计算**：`UpdateFieldsInPlace` 和 `DeleteFieldsForOneKey` 增加 `charge_delta` 追踪，通过 `AdjustCharge` 实时更新 LRU Cache 的内存计量，避免容量统计漂移
2. **修复 Insert 语义**：开启 `strict_capacity_limit` + `no_evict_on_insert`，Insert 时传入 handle 确保容量超限时正确返回 `EC_NOSPC`（而非静默丢弃）
3. **默认不再要求配置 `meta_cache_policy_config`**：将默认 cache capacity 从 1024MB 改为 0（即不启用本地缓存后端），减少部署配置负担
4. **补充 `MetaStorageBackend` 接口文档注释**：为所有读写 API 添加详细的参数说明和错误码语义描述
5. **LRU Cache 能力扩展**：新增 `AdjustCharge`、`strict_capacity_limit`、`no_evict_on_insert` 等选项支撑上述修复
6. **新增 multi-location 集成测试**：验证多 location 共存、部分/全部数据丢失、重写恢复等场景
7. **其他小修**：`DeleteFields` 空列表短路返回；`BackendManager` 测试补充；Redis client 微调