### PR TITLE
[metrics] unify metric labels and skip untouched series

### DIFF
--- a/docs/prometheus-en_US.md
+++ b/docs/prometheus-en_US.md
@@ -74,6 +74,22 @@ kvcm_data_storage_storage_usage_ratio{type="hf3fs",unique_name="nfs_01"} 0.75
 kvcm_cache_manager_group_usage_ratio{instance_group="default"} 0.42
 ```
 
+### Label Conventions
+
+To allow PromQL `join` / aggregation across the `data_storage.*`
+metric family, every per-instance `data_storage.*` series uses the
+same two labels:
+
+- `type`: backend type, e.g. `hf3fs`, `nfs`, `pace`, `tair_mempool`.
+- `unique_name`: the backend instance's `global_unique_name`.
+
+```
+kvcm_data_storage_create_counter{type="nfs",unique_name="nfs_01"} 100
+kvcm_data_storage_create_keys_counter{type="nfs",unique_name="nfs_01"} 12800
+kvcm_data_storage_healthy_status{type="nfs",unique_name="nfs_01"} 1
+kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="nfs_01"} 0.6
+```
+
 ## Example Output
 
 ```

--- a/docs/prometheus-en_US.md
+++ b/docs/prometheus-en_US.md
@@ -145,6 +145,34 @@ every `kvcm.metrics.report_interval_ms`, default 20s).
 The full list depends on the active `MetricsReporter` type. The
 `kmonitor` reporter populates the most complete set of metrics.
 
+## Mapping to KMonitor Metrics
+
+KVCacheManager simultaneously exports metrics via KMonitor and via
+the Prometheus `/metrics` endpoint. The two pipelines write to
+different metric stores, so a few KMonitor metric names are not
+emitted by Prometheus *under the same name* — most commonly the
+`*.qps` family, which is materialized server-side by KMonitor's QPS
+reducer. Use `rate(<counter>[Xm])` in PromQL instead.
+
+### QPS-style metrics
+
+| KMonitor metric | Prometheus equivalent |
+|---|---|
+| `service.qps` | `rate(kvcm_service_query_counter[1m])` |
+| `service.error_qps` | `rate(kvcm_service_error_counter[1m])` |
+| `data_storage.create_qps` | `rate(kvcm_data_storage_create_counter[1m])` |
+| `data_storage.create_keys_qps` | `rate(kvcm_data_storage_create_keys_counter[1m])` |
+
+The Prometheus side stores the underlying *counter* (monotonically
+increasing). KMonitor's `*.qps` value is computed by the agent at
+report time. Both views describe the same event stream — pick `rate`
+on the counter when querying Prometheus.
+
+Note that `data_storage.create_keys_qps` is also exported as a Prom
+gauge with the latest *batch size* (not a per-second rate). Prefer
+`rate(kvcm_data_storage_create_keys_counter[1m])` for the per-second
+view, and the gauge only for "the most recent batch size" diagnostics.
+
 ## Architecture
 
 The Prometheus endpoint is implemented as a lightweight serializer

--- a/docs/prometheus-zh_CN.md
+++ b/docs/prometheus-zh_CN.md
@@ -72,6 +72,22 @@ kvcm_data_storage_storage_usage_ratio{type="hf3fs",unique_name="nfs_01"} 0.75
 kvcm_cache_manager_group_usage_ratio{instance_group="default"} 0.42
 ```
 
+### Label 规范
+
+为了让 `data_storage.*` 系列指标能在 PromQL 中互相 `join` /
+聚合，所有按存储实例维度的 `data_storage.*` 序列统一使用两个
+label：
+
+- `type`：后端类型，例如 `hf3fs`、`nfs`、`pace`、`tair_mempool`。
+- `unique_name`：后端实例的 `global_unique_name`。
+
+```
+kvcm_data_storage_create_counter{type="nfs",unique_name="nfs_01"} 100
+kvcm_data_storage_create_keys_counter{type="nfs",unique_name="nfs_01"} 12800
+kvcm_data_storage_healthy_status{type="nfs",unique_name="nfs_01"} 1
+kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="nfs_01"} 0.6
+```
+
 ## 输出示例
 
 ```

--- a/docs/prometheus-zh_CN.md
+++ b/docs/prometheus-zh_CN.md
@@ -142,6 +142,32 @@ kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="store_02"} 0.3
 完整指标列表取决于当前使用的 `MetricsReporter` 类型。`kmonitor`
 类型的 reporter 会填充最完整的指标集。
 
+## 与 KMonitor 指标对照
+
+KVCacheManager 同时通过 KMonitor 与 Prometheus `/metrics` 端点导出
+指标。两条管线写入不同的存储，因此部分 KMonitor 指标名在
+Prometheus 侧并不以**同名**输出 —— 最常见的是 `*.qps` 一族，由
+KMonitor agent 在上报时计算。Prometheus 侧请用 PromQL
+`rate(<counter>[Xm])` 等价获取。
+
+### QPS 类指标
+
+| KMonitor 指标 | Prometheus 等价 |
+|---|---|
+| `service.qps` | `rate(kvcm_service_query_counter[1m])` |
+| `service.error_qps` | `rate(kvcm_service_error_counter[1m])` |
+| `data_storage.create_qps` | `rate(kvcm_data_storage_create_counter[1m])` |
+| `data_storage.create_keys_qps` | `rate(kvcm_data_storage_create_keys_counter[1m])` |
+
+Prometheus 侧存储的是底层 *counter*（单调递增），KMonitor 的
+`*.qps` 值由 agent 在上报时计算。两种视图反映的是同一事件流，
+查询 Prometheus 时直接用 counter + `rate` 即可。
+
+注：`data_storage.create_keys_qps` 在 Prom 侧也会以 gauge 形式
+导出"最近一次批次大小"（不是每秒速率）。每秒速率请使用
+`rate(kvcm_data_storage_create_keys_counter[1m])`，gauge 仅作
+"最近一次批次大小"诊断用。
+
 ## 架构
 
 Prometheus 端点通过一个轻量级序列化器（`PrometheusExporter`）实现，

--- a/kv_cache_manager/data_storage/data_storage_backend.h
+++ b/kv_cache_manager/data_storage/data_storage_backend.h
@@ -33,7 +33,8 @@ public:
     virtual ErrorCode Open(const StorageConfig &config, const std::string &trace_id) {
         config_ = config;
         metrics_collector_ = std::make_shared<DataStorageMetricsCollector>(
-            metrics_registry_, MetricsTags{{ToString(config.type()), config.global_unique_name()}});
+            metrics_registry_,
+            MetricsTags{{"type", ToString(config.type())}, {"unique_name", config.global_unique_name()}});
         if (!metrics_collector_->Init()) {
             metrics_collector_ = nullptr;
         }

--- a/kv_cache_manager/data_storage/test/dummy_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/dummy_backend_test.cc
@@ -297,6 +297,26 @@ TEST_F(DummyBackendTest, TestLockAndUnLockReturnOk) {
     }
 }
 
+TEST_F(DummyBackendTest, TestMetricsCollectorTagsAfterOpen) {
+    DummyBackend backend(metrics_registry_);
+    auto config = MakeConfig(test_root_);
+    ASSERT_EQ(EC_OK, backend.Open(config, "trace_1"));
+
+    auto collector = backend.GetMetricsCollector();
+    ASSERT_NE(nullptr, collector);
+
+    const auto &tags = collector->GetMetricsTags();
+    ASSERT_EQ(2u, tags.size());
+
+    auto type_it = tags.find("type");
+    ASSERT_NE(tags.end(), type_it);
+    EXPECT_EQ(ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY), type_it->second);
+
+    auto unique_it = tags.find("unique_name");
+    ASSERT_NE(tags.end(), unique_it);
+    EXPECT_EQ("test_dummy", unique_it->second);
+}
+
 TEST_F(DummyBackendTest, TestCreateThenExistRoundTrip) {
     // end-to-end: Create produces URIs, then Exist and MightExist
     // confirm the files were NOT actually written (Create does not

--- a/kv_cache_manager/metrics/logging_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/logging_metrics_reporter.cc
@@ -36,10 +36,10 @@ void LoggingMetricsReporter::ReportPerQuery(MetricsCollector *collector) {
         ss << "]:";
 
         // value
-        if (std::holds_alternative<CounterValue>(*val)) {
-            ss << std::get<CounterValue>(*val).load();
-        } else if (std::holds_alternative<GaugeValue>(*val)) {
-            ss << std::get<GaugeValue>(*val).load();
+        if (std::holds_alternative<CounterValue>(val->value)) {
+            ss << std::get<CounterValue>(val->value).load();
+        } else if (std::holds_alternative<GaugeValue>(val->value)) {
+            ss << std::get<GaugeValue>(val->value).load();
         } else {
             ss << "<unknown_value_type>";
         }
@@ -48,7 +48,7 @@ void LoggingMetricsReporter::ReportPerQuery(MetricsCollector *collector) {
     }
 
     // TODO 要使用专门的logger防止截断
-     KVCM_METRICS_LOG(ss.str());
+    KVCM_METRICS_LOG(ss.str());
 }
 
 void LoggingMetricsReporter::ReportInterval() {
@@ -75,10 +75,10 @@ void LoggingMetricsReporter::ReportInterval() {
         ss << "]:";
 
         // value
-        if (std::holds_alternative<CounterValue>(*val)) {
-                ss << std::get<CounterValue>(*val).load();
-        } else if (std::holds_alternative<GaugeValue>(*val)) {
-                ss << std::get<GaugeValue>(*val).load();
+        if (std::holds_alternative<CounterValue>(val->value)) {
+            ss << std::get<CounterValue>(val->value).load();
+        } else if (std::holds_alternative<GaugeValue>(val->value)) {
+            ss << std::get<GaugeValue>(val->value).load();
         } else {
             ss << "<unknown_value_type>";
         }

--- a/kv_cache_manager/metrics/metrics_registry.cc
+++ b/kv_cache_manager/metrics/metrics_registry.cc
@@ -27,12 +27,18 @@ MetricsValueWrapper::MetricsValueWrapper(std::shared_ptr<MetricsValue> v) noexce
 
 std::shared_ptr<MetricsValue> MetricsValueWrapper::GetRaw() const noexcept { return value_; }
 
+void MetricsValueWrapper::MarkTouched() noexcept {
+    if (value_ != nullptr) {
+        value_->touched.store(true, std::memory_order_relaxed);
+    }
+}
+
 /* ---------------------------- Counter ----------------------------- */
 
 Counter::Counter() noexcept : MetricsValueWrapper(nullptr) {}
 
 Counter::Counter(std::shared_ptr<MetricsValue> v) : MetricsValueWrapper(std::move(v)) {
-    if (!std::holds_alternative<CounterValue>(*value_)) {
+    if (!std::holds_alternative<CounterValue>(value_->value)) {
         value_.reset();
         throw std::runtime_error{"mismatched metrics value type (expecting CounterValue)"};
     }
@@ -42,21 +48,26 @@ std::uint64_t Counter::Get() const {
     if (value_ == nullptr) {
         return 0;
     }
-    return std::get<CounterValue>(*value_).load(std::memory_order_acquire);
+    return std::get<CounterValue>(value_->value).load(std::memory_order_acquire);
 }
 
 void Counter::Reset() const {
     if (value_ == nullptr) {
         return;
     }
-    std::get<CounterValue>(*value_).store(0, std::memory_order_release);
+    // Reset is intentionally not marking the value as touched: a
+    // counter that was touched then explicitly reset to zero is
+    // still a deliberately-observable series and should keep
+    // appearing in /metrics.
+    std::get<CounterValue>(value_->value).store(0, std::memory_order_release);
 }
 
 Counter &Counter::operator++() {
     if (value_ == nullptr) {
         return *this;
     }
-    std::get<CounterValue>(*value_).fetch_add(1, std::memory_order_acq_rel);
+    std::get<CounterValue>(value_->value).fetch_add(1, std::memory_order_acq_rel);
+    MarkTouched();
     return *this;
 }
 
@@ -64,7 +75,8 @@ Counter &Counter::operator--() {
     if (value_ == nullptr) {
         return *this;
     }
-    std::get<CounterValue>(*value_).fetch_sub(1, std::memory_order_acq_rel);
+    std::get<CounterValue>(value_->value).fetch_sub(1, std::memory_order_acq_rel);
+    MarkTouched();
     return *this;
 }
 
@@ -84,7 +96,8 @@ Counter &Counter::operator+=(const std::uint64_t v) {
     if (value_ == nullptr) {
         return *this;
     }
-    std::get<CounterValue>(*value_).fetch_add(v, std::memory_order_acq_rel);
+    std::get<CounterValue>(value_->value).fetch_add(v, std::memory_order_acq_rel);
+    MarkTouched();
     return *this;
 }
 
@@ -92,7 +105,8 @@ Counter &Counter::operator-=(const std::uint64_t v) {
     if (value_ == nullptr) {
         return *this;
     }
-    std::get<CounterValue>(*value_).fetch_sub(v, std::memory_order_acq_rel);
+    std::get<CounterValue>(value_->value).fetch_sub(v, std::memory_order_acq_rel);
+    MarkTouched();
     return *this;
 }
 
@@ -101,7 +115,7 @@ Counter &Counter::operator-=(const std::uint64_t v) {
 Gauge::Gauge() noexcept : MetricsValueWrapper(nullptr) {}
 
 Gauge::Gauge(std::shared_ptr<MetricsValue> v) : MetricsValueWrapper(std::move(v)) {
-    if (!std::holds_alternative<GaugeValue>(*value_)) {
+    if (!std::holds_alternative<GaugeValue>(value_->value)) {
         value_.reset();
         throw std::runtime_error{"mismatched metrics value type (expecting GaugeValue)"};
     }
@@ -111,18 +125,20 @@ double Gauge::Get() const {
     if (value_ == nullptr) {
         return 0.;
     }
-    return std::get<GaugeValue>(*value_).load();
+    return std::get<GaugeValue>(value_->value).load();
 }
 
 double Gauge::Steal() {
+    // Steal is a read-and-invalidate — the gauge was already
+    // touched by the original writer.
     if (value_ == nullptr) {
         return std::numeric_limits<double>::quiet_NaN();
     }
     double old_v;
     double invalid_v = std::numeric_limits<double>::quiet_NaN();
     do {
-        old_v = std::get<GaugeValue>(*value_).load(std::memory_order_relaxed);
-    } while (!std::get<GaugeValue>(*value_).compare_exchange_weak(old_v, invalid_v, std::memory_order_relaxed));
+        old_v = std::get<GaugeValue>(value_->value).load(std::memory_order_relaxed);
+    } while (!std::get<GaugeValue>(value_->value).compare_exchange_weak(old_v, invalid_v, std::memory_order_relaxed));
     return old_v;
 }
 
@@ -130,7 +146,8 @@ Gauge &Gauge::operator=(const double v) {
     if (value_ == nullptr) {
         return *this;
     }
-    std::get<GaugeValue>(*value_).store(v);
+    std::get<GaugeValue>(value_->value).store(v);
+    MarkTouched();
     return *this;
 }
 
@@ -140,9 +157,10 @@ Gauge &Gauge::operator+=(const double v) {
     }
     double old_v, new_v;
     do {
-        old_v = std::get<GaugeValue>(*value_).load();
+        old_v = std::get<GaugeValue>(value_->value).load();
         new_v = old_v + v;
-    } while (!std::get<GaugeValue>(*value_).compare_exchange_weak(old_v, new_v));
+    } while (!std::get<GaugeValue>(value_->value).compare_exchange_weak(old_v, new_v));
+    MarkTouched();
     return *this;
 }
 
@@ -152,9 +170,10 @@ Gauge &Gauge::operator-=(const double v) {
     }
     double old_v, new_v;
     do {
-        old_v = std::get<GaugeValue>(*value_).load();
+        old_v = std::get<GaugeValue>(value_->value).load();
         new_v = old_v - v;
-    } while (!std::get<GaugeValue>(*value_).compare_exchange_weak(old_v, new_v));
+    } while (!std::get<GaugeValue>(value_->value).compare_exchange_weak(old_v, new_v));
+    MarkTouched();
     return *this;
 }
 
@@ -191,7 +210,7 @@ Counter MetricsData::GetOrCreateCounter(const MetricsTags &tags) {
         it = metrics_data_.emplace(tags, MakeCounterValue()).first;
     } else if (it->second == nullptr) {
         it->second = MakeCounterValue();
-    } else if (!std::holds_alternative<CounterValue>(*it->second)) {
+    } else if (!std::holds_alternative<CounterValue>(it->second->value)) {
         throw std::runtime_error{"a metrics value holds a type other than CounterValue already exists"};
     }
     return Counter{it->second};
@@ -204,7 +223,7 @@ Gauge MetricsData::GetOrCreateGauge(const MetricsTags &tags) {
         it = metrics_data_.emplace(tags, MakeGaugeValue()).first;
     } else if (it->second == nullptr) {
         it->second = MakeGaugeValue();
-    } else if (!std::holds_alternative<GaugeValue>(*it->second)) {
+    } else if (!std::holds_alternative<GaugeValue>(it->second->value)) {
         throw std::runtime_error{"a metrics value holds a type other than GaugeValue already exists"};
     }
     return Gauge{it->second};

--- a/kv_cache_manager/metrics/metrics_registry.h
+++ b/kv_cache_manager/metrics/metrics_registry.h
@@ -97,7 +97,26 @@ namespace kv_cache_manager {
 
 using CounterValue = std::atomic<std::uint64_t>;
 using GaugeValue = std::atomic<double>;
-using MetricsValue = std::variant<CounterValue, GaugeValue>;
+using MetricsValueVariant = std::variant<CounterValue, GaugeValue>;
+
+// MetricsValue holds both the underlying value and a "touched" flag
+// used by PrometheusExporter to drop never-written series — e.g. the
+// (manager.batch_add_location_time_us, api_name=GetCacheMeta) tuple
+// is registered for every Service collector but never written, and
+// would otherwise inflate Prometheus cardinality.
+//
+// The flag is set by every write path on Counter/Gauge (operator=,
+// operator+=, operator++, etc.) and stays set; Reset() does not
+// clear it because resetting a previously-active counter to zero is
+// still a deliberately observable state.
+struct MetricsValue {
+    MetricsValueVariant value;
+    std::atomic<bool> touched{false};
+
+    template <typename T, typename U>
+    MetricsValue(std::in_place_type_t<T> tag, U init) noexcept : value(tag, init) {}
+};
+
 using MetricsTags = std::map<std::string, std::string>;
 
 class MetricsValueWrapper {
@@ -114,6 +133,8 @@ protected:
 
     MetricsValueWrapper &operator=(const MetricsValueWrapper &) = default;
     MetricsValueWrapper &operator=(MetricsValueWrapper &&) = default;
+
+    void MarkTouched() noexcept;
 
     std::shared_ptr<MetricsValue> value_;
 };

--- a/kv_cache_manager/metrics/prometheus_exporter.cc
+++ b/kv_cache_manager/metrics/prometheus_exporter.cc
@@ -103,31 +103,50 @@ std::string PrometheusExporter::Expose(MetricsRegistry &registry, const std::str
     // GetAllMetrics returns entries ordered by name (the underlying
     // map is std::map<string, ...>), so consecutive entries with the
     // same name belong to the same family.
+    //
+    // Untouched series are skipped: the Service collector registers
+    // every (manager.*, meta_searcher.*, meta_indexer.*) series for
+    // every api_name, but most combinations are never written. Without
+    // filtering, /metrics is dominated by zero-valued series that
+    // mostly inflate Prometheus cardinality. A series becomes touched
+    // the first time any write path on Counter/Gauge runs against it.
+    // If every series in a family is untouched, the # HELP / # TYPE
+    // header is omitted as well.
     std::ostringstream ss;
 
     std::string prev_name;
+    bool family_header_written = false;
     for (const auto &[name, tags, val] : all_metrics) {
+        if (val == nullptr || !val->touched.load(std::memory_order_relaxed)) {
+            continue;
+        }
+
         std::string prom_name = SanitizeName(prefix, name);
 
         if (name != prev_name) {
+            family_header_written = false;
+            prev_name = name;
+        }
+
+        if (!family_header_written) {
             const char *type_str = "untyped";
-            if (std::holds_alternative<CounterValue>(*val)) {
+            if (std::holds_alternative<CounterValue>(val->value)) {
                 type_str = "counter";
-            } else if (std::holds_alternative<GaugeValue>(*val)) {
+            } else if (std::holds_alternative<GaugeValue>(val->value)) {
                 type_str = "gauge";
             }
             ss << "# HELP " << prom_name << ' ' << name << '\n';
             ss << "# TYPE " << prom_name << ' ' << type_str << '\n';
-            prev_name = name;
+            family_header_written = true;
         }
 
         ss << prom_name;
         WriteLabels(ss, tags);
 
-        if (std::holds_alternative<CounterValue>(*val)) {
-            ss << ' ' << std::get<CounterValue>(*val).load(std::memory_order_relaxed);
-        } else if (std::holds_alternative<GaugeValue>(*val)) {
-            double gv = std::get<GaugeValue>(*val).load(std::memory_order_relaxed);
+        if (std::holds_alternative<CounterValue>(val->value)) {
+            ss << ' ' << std::get<CounterValue>(val->value).load(std::memory_order_relaxed);
+        } else if (std::holds_alternative<GaugeValue>(val->value)) {
+            double gv = std::get<GaugeValue>(val->value).load(std::memory_order_relaxed);
             if (std::isnan(gv)) {
                 ss << " NaN";
             } else if (std::isinf(gv)) {

--- a/kv_cache_manager/metrics/test/metrics_registry_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_registry_test.cc
@@ -26,16 +26,16 @@ bool VecContains(const std::vector<MetricsRegistry::metrics_tuple_t> &vec, const
         const auto &[name_e, tags_e, val_e] = e;
         const auto &[name_v, tags_v, val_v] = v;
 
-        if (name_e != name_v || tags_e != tags_v || val_e->index() != val_v->index()) {
+        if (name_e != name_v || tags_e != tags_v || val_e->value.index() != val_v->value.index()) {
             return false;
         }
 
-        if (std::holds_alternative<CounterValue>(*val_e)) {
-            return std::get<CounterValue>(*val_e).load() == std::get<CounterValue>(*val_v).load();
+        if (std::holds_alternative<CounterValue>(val_e->value)) {
+            return std::get<CounterValue>(val_e->value).load() == std::get<CounterValue>(val_v->value).load();
         }
 
-        if (std::holds_alternative<GaugeValue>(*val_e)) {
-            return AlmostEqual(std::get<GaugeValue>(*val_e).load(), std::get<GaugeValue>(*val_v).load());
+        if (std::holds_alternative<GaugeValue>(val_e->value)) {
+            return AlmostEqual(std::get<GaugeValue>(val_e->value).load(), std::get<GaugeValue>(val_v->value).load());
         }
 
         return false;
@@ -375,7 +375,7 @@ TEST_F(MetricsRegistryTest, TestMetricsDataGetOrCreate) {
 
 TEST_F(MetricsRegistryTest, TestMetricsRegistryGetCounter) {
     auto c = registry_->GetCounter("foo.bar");
-    ASSERT_TRUE(std::holds_alternative<CounterValue>(*c.GetRaw()));
+    ASSERT_TRUE(std::holds_alternative<CounterValue>(c.GetRaw()->value));
     ASSERT_EQ(0, c.Get());
     ++c;
     ASSERT_EQ(1, c.Get());
@@ -397,7 +397,7 @@ TEST_F(MetricsRegistryTest, TestMetricsRegistryGetCounter) {
 
 TEST_F(MetricsRegistryTest, TestMetricsRegistryGetCounterWithTags) {
     auto c = registry_->GetCounter("foo.bar", {{"foo", "bar"}});
-    ASSERT_TRUE(std::holds_alternative<CounterValue>(*c.GetRaw()));
+    ASSERT_TRUE(std::holds_alternative<CounterValue>(c.GetRaw()->value));
     ASSERT_EQ(0, c.Get());
     ++c;
     ASSERT_EQ(1, c.Get());
@@ -422,7 +422,7 @@ TEST_F(MetricsRegistryTest, TestMetricsRegistryGetCounterWithTags) {
 
 TEST_F(MetricsRegistryTest, TestMetricsRegistryGetGauge) {
     auto c = registry_->GetGauge("foo.bar");
-    ASSERT_TRUE(std::holds_alternative<GaugeValue>(*c.GetRaw()));
+    ASSERT_TRUE(std::holds_alternative<GaugeValue>(c.GetRaw()->value));
     ASSERT_DOUBLE_EQ(0., c.Get());
     c += 8.;
     ASSERT_DOUBLE_EQ(8., c.Get());
@@ -444,7 +444,7 @@ TEST_F(MetricsRegistryTest, TestMetricsRegistryGetGauge) {
 
 TEST_F(MetricsRegistryTest, TestMetricsRegistryGetGaugeWithTags) {
     auto c = registry_->GetGauge("foo.bar", {{"foo", "bar"}});
-    ASSERT_TRUE(std::holds_alternative<GaugeValue>(*c.GetRaw()));
+    ASSERT_TRUE(std::holds_alternative<GaugeValue>(c.GetRaw()->value));
     ASSERT_DOUBLE_EQ(0., c.Get());
     c += 8.;
     ASSERT_DOUBLE_EQ(8., c.Get());
@@ -471,11 +471,11 @@ TEST_F(MetricsRegistryTest, TestMetricsRegistryAdaptiveGet) {
     // adaptive get should not be supported
 
     auto counter = registry_->GetCounter("foo.bar");
-    ASSERT_TRUE(std::holds_alternative<CounterValue>(*counter.GetRaw()));
+    ASSERT_TRUE(std::holds_alternative<CounterValue>(counter.GetRaw()->value));
     ASSERT_THROW(registry_->GetGauge("foo.bar"), std::runtime_error);
 
     auto gauge = registry_->GetGauge("foo2.bar2");
-    ASSERT_TRUE(std::holds_alternative<GaugeValue>(*gauge.GetRaw()));
+    ASSERT_TRUE(std::holds_alternative<GaugeValue>(gauge.GetRaw()->value));
     ASSERT_THROW(registry_->GetCounter("foo2.bar2"), std::runtime_error);
 }
 

--- a/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
+++ b/kv_cache_manager/metrics/test/prometheus_exporter_test.cc
@@ -209,3 +209,63 @@ TEST_F(PrometheusExporterTest, LeadingDigitInPrefix) {
     std::string output = PrometheusExporter::Expose(*registry_, "9app");
     EXPECT_NE(output.find("_9app_service_qps"), std::string::npos) << "Actual output:\n" << output;
 }
+
+// Untouched series (registered but never written) must not appear in
+// the output, and a metric family with no touched series must not
+// emit its # HELP / # TYPE header either.
+TEST_F(PrometheusExporterTest, RegisteredCounterNeverWrittenIsSkipped) {
+    Counter c = registry_->GetCounter("service.query_counter");
+    (void)c;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_TRUE(output.empty()) << "Actual output:\n" << output;
+}
+
+TEST_F(PrometheusExporterTest, RegisteredGaugeNeverWrittenIsSkipped) {
+    Gauge g = registry_->GetGauge("data_storage.healthy_status");
+    (void)g;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_TRUE(output.empty()) << "Actual output:\n" << output;
+}
+
+TEST_F(PrometheusExporterTest, OnlyTouchedSeriesAppearInFamily) {
+    MetricsTags tags_a = {{"api_name", "GetCacheLocation"}};
+    MetricsTags tags_b = {{"api_name", "StartWriteCache"}};
+
+    Gauge ga = registry_->GetGauge("manager.batch_add_location_time_us", tags_a);
+    Gauge gb = registry_->GetGauge("manager.batch_add_location_time_us", tags_b);
+
+    // only the StartWriteCache series is actually written
+    gb = 42.0;
+    (void)ga;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+
+    EXPECT_NE(output.find("# TYPE kvcm_manager_batch_add_location_time_us gauge"), std::string::npos);
+    EXPECT_NE(output.find("api_name=\"StartWriteCache\"} 42"), std::string::npos);
+    EXPECT_EQ(output.find("api_name=\"GetCacheLocation\""), std::string::npos)
+        << "Untouched series should not appear:\n"
+        << output;
+}
+
+// Writing zero is still an explicit observation — the series must
+// stay visible.
+TEST_F(PrometheusExporterTest, GaugeExplicitlySetToZeroAppears) {
+    Gauge g = registry_->GetGauge("data_storage.healthy_status");
+    g = 0.0;
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("kvcm_data_storage_healthy_status 0"), std::string::npos)
+        << "Actual output:\n"
+        << output;
+}
+
+TEST_F(PrometheusExporterTest, CounterIncrementedThenResetAppears) {
+    Counter c = registry_->GetCounter("service.query_counter");
+    ++c;
+    c.Reset();
+
+    std::string output = PrometheusExporter::Expose(*registry_);
+    EXPECT_NE(output.find("kvcm_service_query_counter 0"), std::string::npos) << "Actual output:\n" << output;
+}

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -787,11 +787,11 @@ void AdminServiceImpl::GetMetrics(RequestContext *request_context,
         }
 
         // value
-        if (std::holds_alternative<CounterValue>(*val)) {
+        if (std::holds_alternative<CounterValue>(val->value)) {
             pb_data->mutable_metric_value()->set_int_value(
-                static_cast<std::int64_t>(std::get<CounterValue>(*val).load()));
-        } else if (std::holds_alternative<GaugeValue>(*val)) {
-            pb_data->mutable_metric_value()->set_float_value(std::get<GaugeValue>(*val).load());
+                static_cast<std::int64_t>(std::get<CounterValue>(val->value).load()));
+        } else if (std::holds_alternative<GaugeValue>(val->value)) {
+            pb_data->mutable_metric_value()->set_float_value(std::get<GaugeValue>(val->value).load());
         }
     }
 


### PR DESCRIPTION
1. Unify per-instance data_storage.* metric labels to named keys (type, unique_name) instead of positional values, enabling PromQL joins across the metric family.
2. Document the KMonitor ↔ Prometheus metric name mapping in both EN/CN docs.
3. Add a "touched" flag to MetricsValue so PrometheusExporter skips never-written series, reducing cardinality bloat.