### PR TITLE
[script] fix env vars with dots lost after bash exec

### DIFF
--- a/package/script/start_server.sh
+++ b/package/script/start_server.sh
@@ -14,7 +14,11 @@ BINARY=$BINARY_PATH/kv_cache_manager_bin
 
 function start_server() {
     echo "start server at: "$BINARY
-    exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "$@"
+    local env_args=()
+    while IFS='=' read -r key value; do
+        env_args+=(-e "${key}=${value}")
+    done < <(env | grep '^kvcm\.')
+    exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "${env_args[@]}" "$@"
 }
 
 function main() {


### PR DESCRIPTION
Bash drops environment variables with dots in their names (e.g. kvcm.metrics.enable_prometheus) when exec replaces the process, because bash cannot import them as shell variables.

Extract kvcm.* env vars and pass them as -e arguments to the binary.