### PR TITLE
[script] preserve CLI -e override precedence

### DIFF
--- a/package/script/start_server.sh
+++ b/package/script/start_server.sh
@@ -18,7 +18,7 @@ function start_server() {
     while IFS='=' read -r key value; do
         env_args+=(-e "${key}=${value}")
     done < <(env | grep '^kvcm\.')
-    exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "${env_args[@]}" "$@"
+    exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "$@" "${env_args[@]}"
 }
 
 function main() {


### PR DESCRIPTION
CommandArgs::ParseCmdLine uses environ_.insert(), which is first-occurrence-wins. Place caller's "$@" before injected env_args so explicit -e CLI overrides take precedence over inherited env vars.