### PR TITLE
[service] support underscore env keys & revert start_server.sh workar…

### DIFF
--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/service/server_config.h"
 
+#include <algorithm>
 #include <fstream>
 #include <stdio.h>
 
@@ -8,6 +9,7 @@
 
 namespace kv_cache_manager {
 
+// clang-format off
 std::unordered_map<std::string, ServerConfig::SettingFunction> ServerConfig::kSettingsMap = {
     {"kvcm.registry_storage.uri",
      [](const std::string &value, ServerConfig *config) {
@@ -152,6 +154,7 @@ std::unordered_map<std::string, ServerConfig::SettingFunction> ServerConfig::kSe
          config->prometheus_prefix_ = value;
          return true;
      }}};
+// clang-format on
 
 bool ServerConfig::Parse(const std::string &config_file, const EnvironMap &environ) {
     // 1. 默认配置
@@ -258,8 +261,18 @@ bool ServerConfig::ParseFromEnviron(const EnvironMap &environ) {
 void ServerConfig::UpdateEnviron(EnvironMap &environ) {
     // TODO 环境变量和原始ENV的覆盖关系
     // 系统环境变量具有最高优先级，覆盖了传入的environ中的同名配置项
+    // 优先查带 `.` 的 key（如 kvcm.registry_storage.uri），查不到再尝试将 `.`
+    // 替换为 `_` 后查（如 kvcm_registry_storage_uri），兼容 bash 等不支持
+    // 变量名包含 `.` 的场景。
     for (const auto &[key, _] : kSettingsMap) {
         std::string value = EnvUtil::GetEnv(key, "");
+        if (value.empty()) {
+            std::string underscore_key = key;
+            std::replace(underscore_key.begin(), underscore_key.end(), '.', '_');
+            if (underscore_key != key) {
+                value = EnvUtil::GetEnv(underscore_key, "");
+            }
+        }
         if (!value.empty()) {
             environ[key] = value;
         }

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -76,3 +76,27 @@ TEST_F(ServerConfigTest, TestSimple) {
         ASSERT_EQ(3, config.GetLogLevel());
     }
 }
+
+TEST_F(ServerConfigTest, TestUnderscoreEnvFallback) {
+    // 仅设置下划线版本，验证 fallback 生效
+    {
+        ServerConfig config;
+        std::unordered_map<std::string, std::string> environ;
+        ScopedEnv env1("kvcm_registry_storage_uri", "redis://127.0.0.1:6379?auth=abc");
+        ScopedEnv env2("kvcm_service_rpc_port", "7381");
+        ASSERT_TRUE(config.Parse("", environ));
+        ASSERT_TRUE(config.Check());
+        ASSERT_EQ("redis://127.0.0.1:6379?auth=abc", config.GetRegistryStorageUri());
+        ASSERT_EQ(7381, config.GetServiceRpcPort());
+    }
+    // 同时设置 dotted 和 underscore 版本，验证 dotted 优先
+    {
+        ServerConfig config;
+        std::unordered_map<std::string, std::string> environ;
+        ScopedEnv env1("kvcm.registry_storage.uri", "redis://dotted-wins");
+        ScopedEnv env2("kvcm_registry_storage_uri", "redis://underscore-loses");
+        ASSERT_TRUE(config.Parse("", environ));
+        ASSERT_TRUE(config.Check());
+        ASSERT_EQ("redis://dotted-wins", config.GetRegistryStorageUri());
+    }
+}

--- a/package/script/start_server.sh
+++ b/package/script/start_server.sh
@@ -14,11 +14,7 @@ BINARY=$BINARY_PATH/kv_cache_manager_bin
 
 function start_server() {
     echo "start server at: "$BINARY
-    local env_args=()
-    while IFS='=' read -r key value; do
-        env_args+=(-e "${key}=${value}")
-    done < <(env | grep '^kvcm\.')
-    exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "$@" "${env_args[@]}"
+    exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "$@"
 }
 
 function main() {

--- a/package/script/start_server.sh
+++ b/package/script/start_server.sh
@@ -12,13 +12,17 @@ DEFAULT_SERVER_CONFIG=$CONFIG_PATH/default_server_config.conf
 DEFAULT_LOGGER_CONFIG=$CONFIG_PATH/default_logger_config.conf
 BINARY=$BINARY_PATH/kv_cache_manager_bin
 
+function install_kvcm_ops() {
+    python3 -m pip install "$KVCM_OPS_WHEEL_PATH"
+}
+
 function start_server() {
     echo "start server at: "$BINARY
     exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "$@"
 }
 
 function main() {
-    python3 -m pip install "$KVCM_OPS_WHEEL_PATH"
+    install_kvcm_ops
     start_server "$@"
 }
 


### PR DESCRIPTION
…ound

Bash drops env vars whose names contain '.' (kvcm.foo.bar) on exec, so the binary cannot read them via getenv.

Instead of extracting them in start_server.sh and forwarding as -e args (which had CLI-override-precedence regression), handle it in the binary: in UpdateEnviron, if the dotted key is not found in the environment, fall back to looking up its underscore-translated form (kvcm.foo.bar -> kvcm_foo_bar). Dotted form still wins when both exist.

This restores start_server.sh to its original form and lets users set env vars with underscores in any standard way (k8s, shell, docker -e).