### PR TITLE
[coordination] use client pool for redis backend

### DIFF
--- a/kv_cache_manager/config/BUILD
+++ b/kv_cache_manager/config/BUILD
@@ -91,6 +91,7 @@ cc_library(
     ],
     deps = [
         "//kv_cache_manager/common",
+        "//kv_cache_manager/common:client_pool",
         "//kv_cache_manager/common:redis_client_ext",
         "//kv_cache_manager/common:standard_uri",
     ],

--- a/kv_cache_manager/config/coordination_redis_backend.cc
+++ b/kv_cache_manager/config/coordination_redis_backend.cc
@@ -15,30 +15,71 @@ CoordinationRedisBackend::CoordinationRedisBackend() = default;
 
 CoordinationRedisBackend::~CoordinationRedisBackend() = default;
 
+std::shared_ptr<RedisClientExt> CoordinationRedisBackend::CreateRedisClient(const StandardUri &storage_uri) const {
+    return std::make_shared<RedisClientExt>(storage_uri);
+}
+
 ErrorCode CoordinationRedisBackend::Init(const StandardUri &standard_uri) noexcept {
+    constexpr int32_t DEFAULT_CLIENT_MAX_POOL_SIZE = 4;
+    constexpr int32_t DEFAULT_CLIENT_MIN_POOL_SIZE = 1;
+
     // 验证URI协议
     if (standard_uri.GetProtocol() != "redis") {
         KVCM_LOG_ERROR("Invalid protocol for Redis lock backend: %s", standard_uri.GetProtocol().c_str());
         return EC_BADARGS;
     }
 
-    if (initialized_) {
+    if (initialized_.load(std::memory_order_acquire)) {
         KVCM_LOG_WARN("Redis lock backend already initialized");
         return EC_OK;
     }
 
-    // 创建Redis客户端
-    try {
-        redis_client_ = std::make_unique<RedisClientExt>(standard_uri);
-    } catch (const std::exception &e) {
-        KVCM_LOG_ERROR("Failed to create Redis client: %s", e.what());
-        return EC_ERROR;
+    storage_uri_ = standard_uri;
+
+    timeout_ms_ = 1000;
+    int64_t tmp_timeout_ms = 0;
+    storage_uri_.GetParamAs("timeout_ms", tmp_timeout_ms);
+    if (tmp_timeout_ms > 0) {
+        timeout_ms_ = tmp_timeout_ms;
     }
 
-    // 打开Redis连接
-    if (!redis_client_->Open()) {
-        KVCM_LOG_ERROR("Failed to open Redis connection");
-        redis_client_.reset();
+    int32_t client_max_pool_size = DEFAULT_CLIENT_MAX_POOL_SIZE;
+    int32_t client_min_pool_size = DEFAULT_CLIENT_MIN_POOL_SIZE;
+    int64_t tmp_client_max_pool_size = 0;
+    storage_uri_.GetParamAs("client_max_pool_size", tmp_client_max_pool_size);
+    if (tmp_client_max_pool_size > 0) {
+        client_max_pool_size = static_cast<int32_t>(tmp_client_max_pool_size);
+    }
+    int64_t tmp_client_min_pool_size = 0;
+    storage_uri_.GetParamAs("client_min_pool_size", tmp_client_min_pool_size);
+    if (tmp_client_min_pool_size > 0) {
+        client_min_pool_size = static_cast<int32_t>(tmp_client_min_pool_size);
+    }
+    if (client_max_pool_size <= 0) {
+        client_max_pool_size = DEFAULT_CLIENT_MAX_POOL_SIZE;
+    }
+    if (client_min_pool_size < 0) {
+        client_min_pool_size = DEFAULT_CLIENT_MIN_POOL_SIZE;
+    }
+    if (client_min_pool_size > client_max_pool_size) {
+        KVCM_LOG_WARN("coordination redis client_min_pool_size[%d] > client_max_pool_size[%d], clamp min to max",
+                      client_min_pool_size,
+                      client_max_pool_size);
+        client_min_pool_size = client_max_pool_size;
+    }
+
+    auto client_pool = std::make_shared<RedisClientPool>(
+        [this]() -> std::shared_ptr<RedisClientExt> {
+            auto client = CreateRedisClient(storage_uri_);
+            if (!client || !client->Open()) {
+                return nullptr;
+            }
+            return client;
+        },
+        client_min_pool_size,
+        client_max_pool_size);
+    if (!client_pool->Initialize()) {
+        KVCM_LOG_ERROR("Failed to initialize coordination redis client pool");
         return EC_IO_ERROR;
     }
 
@@ -47,28 +88,44 @@ ErrorCode CoordinationRedisBackend::Init(const StandardUri &standard_uri) noexce
     lock_key_prefix_ = base_prefix + "lock:";
     kv_key_prefix_ = base_prefix + "kv:";
 
-    initialized_ = true;
+    auto handle = client_pool->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_LOG_ERROR("Failed to acquire coordination redis client for script loading");
+        return EC_TIMEOUT;
+    }
+
+    std::string try_lock_sha1;
+    std::string renew_lock_sha1;
+    std::string unlock_sha1;
 
     // 初始化时加载所有Lua脚本
-    ErrorCode ec = redis_client_->LoadScript(LUA_TRY_LOCK, try_lock_sha1_);
+    ErrorCode ec = handle->LoadScript(LUA_TRY_LOCK, try_lock_sha1);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to load TryLock script: ec=%d", ec);
         return ec;
     }
 
-    ec = redis_client_->LoadScript(LUA_RENEW_LOCK, renew_lock_sha1_);
+    ec = handle->LoadScript(LUA_RENEW_LOCK, renew_lock_sha1);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to load RenewLock script: ec=%d", ec);
         return ec;
     }
 
-    ec = redis_client_->LoadScript(LUA_UNLOCK, unlock_sha1_);
+    ec = handle->LoadScript(LUA_UNLOCK, unlock_sha1);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to load Unlock script: ec=%d", ec);
         return ec;
     }
 
-    KVCM_LOG_INFO("Redis lock backend initialized successfully with script caching");
+    try_lock_sha1_ = try_lock_sha1;
+    renew_lock_sha1_ = renew_lock_sha1;
+    unlock_sha1_ = unlock_sha1;
+    client_pool_ = client_pool;
+    initialized_.store(true, std::memory_order_release);
+
+    KVCM_LOG_INFO("Redis lock backend initialized successfully with script caching, client pool min[%d], max[%d]",
+                  client_min_pool_size,
+                  client_max_pool_size);
     return EC_OK;
 }
 
@@ -76,9 +133,26 @@ std::string CoordinationRedisBackend::GetRedisLockKey(const std::string &lock_ke
     return lock_key_prefix_ + lock_key;
 }
 
+CoordinationRedisBackend::RedisClientHandle CoordinationRedisBackend::AcquireClient() {
+    if (!client_pool_) {
+        return RedisClientHandle(nullptr, nullptr);
+    }
+    return client_pool_->AcquireClient(timeout_ms_);
+}
+
+std::string CoordinationRedisBackend::GetCachedScriptSha1(const std::string &cached_sha1) const {
+    std::lock_guard<std::mutex> lock(script_sha_mutex_);
+    return cached_sha1;
+}
+
+void CoordinationRedisBackend::UpdateCachedScriptSha1(std::string &cached_sha1, const std::string &new_sha1) {
+    std::lock_guard<std::mutex> lock(script_sha_mutex_);
+    cached_sha1 = new_sha1;
+}
+
 ErrorCode
 CoordinationRedisBackend::TryLock(const std::string &lock_key, const std::string &lock_value, int64_t ttl_ms) {
-    if (!initialized_) {
+    if (!initialized_.load(std::memory_order_acquire)) {
         KVCM_LOG_ERROR("Redis lock backend not initialized");
         return EC_ERROR;
     }
@@ -95,11 +169,19 @@ CoordinationRedisBackend::TryLock(const std::string &lock_key, const std::string
     std::vector<std::string> keys = {redis_key};
     std::vector<std::string> args = {lock_value, std::to_string(ttl_ms)};
 
-    ErrorCode ec = redis_client_->ExecuteScriptWithFallback(LUA_TRY_LOCK, keys, args, try_lock_sha1_, result);
+    auto handle = AcquireClient();
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(10, "try lock fail, fail to acquire coordination redis client");
+        return EC_TIMEOUT;
+    }
+
+    std::string script_sha1 = GetCachedScriptSha1(try_lock_sha1_);
+    ErrorCode ec = handle->ExecuteScriptWithFallback(LUA_TRY_LOCK, keys, args, script_sha1, result);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to execute TryLock Lua script: ec=%d", ec);
         return ec;
     }
+    UpdateCachedScriptSha1(try_lock_sha1_, script_sha1);
 
     // 解析Lua脚本结果
     if (result == "1") {
@@ -117,7 +199,7 @@ CoordinationRedisBackend::TryLock(const std::string &lock_key, const std::string
 
 ErrorCode
 CoordinationRedisBackend::RenewLock(const std::string &lock_key, const std::string &lock_value, int64_t ttl_ms) {
-    if (!initialized_) {
+    if (!initialized_.load(std::memory_order_acquire)) {
         KVCM_LOG_ERROR("Redis lock backend not initialized");
         return EC_ERROR;
     }
@@ -134,11 +216,19 @@ CoordinationRedisBackend::RenewLock(const std::string &lock_key, const std::stri
     std::vector<std::string> keys = {redis_key};
     std::vector<std::string> args = {lock_value, std::to_string(ttl_ms)};
 
-    ErrorCode ec = redis_client_->ExecuteScriptWithFallback(LUA_RENEW_LOCK, keys, args, renew_lock_sha1_, result);
+    auto handle = AcquireClient();
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(10, "renew lock fail, fail to acquire coordination redis client");
+        return EC_TIMEOUT;
+    }
+
+    std::string script_sha1 = GetCachedScriptSha1(renew_lock_sha1_);
+    ErrorCode ec = handle->ExecuteScriptWithFallback(LUA_RENEW_LOCK, keys, args, script_sha1, result);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to execute RenewLock Lua script: ec=%d", ec);
         return ec;
     }
+    UpdateCachedScriptSha1(renew_lock_sha1_, script_sha1);
 
     // 解析Lua脚本结果
     if (result == "1") {
@@ -158,7 +248,7 @@ CoordinationRedisBackend::RenewLock(const std::string &lock_key, const std::stri
 }
 
 ErrorCode CoordinationRedisBackend::Unlock(const std::string &lock_key, const std::string &lock_value) {
-    if (!initialized_) {
+    if (!initialized_.load(std::memory_order_acquire)) {
         KVCM_LOG_ERROR("Redis lock backend not initialized");
         return EC_ERROR;
     }
@@ -175,11 +265,19 @@ ErrorCode CoordinationRedisBackend::Unlock(const std::string &lock_key, const st
     std::vector<std::string> keys = {redis_key};
     std::vector<std::string> args = {lock_value};
 
-    ErrorCode ec = redis_client_->ExecuteScriptWithFallback(LUA_UNLOCK, keys, args, unlock_sha1_, result);
+    auto handle = AcquireClient();
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(10, "unlock fail, fail to acquire coordination redis client");
+        return EC_TIMEOUT;
+    }
+
+    std::string script_sha1 = GetCachedScriptSha1(unlock_sha1_);
+    ErrorCode ec = handle->ExecuteScriptWithFallback(LUA_UNLOCK, keys, args, script_sha1, result);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to execute Unlock Lua script: ec=%d", ec);
         return ec;
     }
+    UpdateCachedScriptSha1(unlock_sha1_, script_sha1);
 
     // 解析Lua脚本结果
     if (result == "1") {
@@ -199,9 +297,9 @@ ErrorCode CoordinationRedisBackend::Unlock(const std::string &lock_key, const st
 }
 
 ErrorCode CoordinationRedisBackend::GetLockHolder(const std::string &lock_key,
-                                                     std::string &out_current_value,
-                                                     int64_t &out_expire_time_ms) {
-    if (!initialized_) {
+                                                  std::string &out_current_value,
+                                                  int64_t &out_expire_time_ms) {
+    if (!initialized_.load(std::memory_order_acquire)) {
         KVCM_LOG_ERROR("Redis lock backend not initialized");
         return EC_ERROR;
     }
@@ -213,8 +311,14 @@ ErrorCode CoordinationRedisBackend::GetLockHolder(const std::string &lock_key,
 
     std::string redis_key = GetRedisLockKey(lock_key);
 
+    auto handle = AcquireClient();
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(10, "get lock holder fail, fail to acquire coordination redis client");
+        return EC_TIMEOUT;
+    }
+
     // 获取当前锁的值
-    ErrorCode ec = redis_client_->Get(redis_key, out_current_value);
+    ErrorCode ec = handle->Get(redis_key, out_current_value);
     if (ec == EC_NOENT) {
         // 锁不存在
         out_current_value.clear();
@@ -227,7 +331,7 @@ ErrorCode CoordinationRedisBackend::GetLockHolder(const std::string &lock_key,
 
     // 获取锁的剩余过期时间
     int64_t remaining_ttl_ms = 0;
-    ec = redis_client_->Pttl(redis_key, remaining_ttl_ms);
+    ec = handle->Pttl(redis_key, remaining_ttl_ms);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to get lock TTL: ec=%d", ec);
         return ec;
@@ -242,18 +346,17 @@ ErrorCode CoordinationRedisBackend::GetLockHolder(const std::string &lock_key,
 
     // 将剩余 TTL 转换为 system_clock 绝对时间戳
     out_expire_time_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count() + remaining_ttl_ms;
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count() +
+        remaining_ttl_ms;
 
     return EC_OK;
 }
 
-std::string CoordinationRedisBackend::GetRedisKVKey(const std::string &key) const {
-    return kv_key_prefix_ + key;
-}
+std::string CoordinationRedisBackend::GetRedisKVKey(const std::string &key) const { return kv_key_prefix_ + key; }
 
 ErrorCode CoordinationRedisBackend::SetValue(const std::string &key, const std::string &value) {
-    if (!initialized_) {
+    if (!initialized_.load(std::memory_order_acquire)) {
         KVCM_LOG_ERROR("Redis coordination backend not initialized");
         return EC_ERROR;
     }
@@ -263,7 +366,13 @@ ErrorCode CoordinationRedisBackend::SetValue(const std::string &key, const std::
     }
 
     std::string redis_key = GetRedisKVKey(key);
-    ErrorCode ec = redis_client_->Set(redis_key, value);
+    auto handle = AcquireClient();
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(10, "set value fail, fail to acquire coordination redis client");
+        return EC_TIMEOUT;
+    }
+
+    ErrorCode ec = handle->Set(redis_key, value);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("Failed to set value for key %s: ec=%d", key.c_str(), ec);
         return ec;
@@ -272,7 +381,7 @@ ErrorCode CoordinationRedisBackend::SetValue(const std::string &key, const std::
 }
 
 ErrorCode CoordinationRedisBackend::GetValue(const std::string &key, std::string &out_value) {
-    if (!initialized_) {
+    if (!initialized_.load(std::memory_order_acquire)) {
         KVCM_LOG_ERROR("Redis coordination backend not initialized");
         return EC_ERROR;
     }
@@ -282,7 +391,13 @@ ErrorCode CoordinationRedisBackend::GetValue(const std::string &key, std::string
     }
 
     std::string redis_key = GetRedisKVKey(key);
-    ErrorCode ec = redis_client_->Get(redis_key, out_value);
+    auto handle = AcquireClient();
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(10, "get value fail, fail to acquire coordination redis client");
+        return EC_TIMEOUT;
+    }
+
+    ErrorCode ec = handle->Get(redis_key, out_value);
     if (ec == EC_NOENT) {
         return EC_NOENT;
     }

--- a/kv_cache_manager/config/coordination_redis_backend.h
+++ b/kv_cache_manager/config/coordination_redis_backend.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 
+#include "kv_cache_manager/common/client_pool.h"
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/common/redis_client_ext.h"
 #include "kv_cache_manager/common/standard_uri.h"
@@ -15,13 +18,11 @@ public:
     CoordinationRedisBackend();
     ~CoordinationRedisBackend() override;
 
-    // 禁止拷贝和赋值
+    // 禁止拷贝、赋值和移动
     CoordinationRedisBackend(const CoordinationRedisBackend &) = delete;
     CoordinationRedisBackend &operator=(const CoordinationRedisBackend &) = delete;
-
-    // 允许移动
-    CoordinationRedisBackend(CoordinationRedisBackend &&) = default;
-    CoordinationRedisBackend &operator=(CoordinationRedisBackend &&) = default;
+    CoordinationRedisBackend(CoordinationRedisBackend &&) = delete;
+    CoordinationRedisBackend &operator=(CoordinationRedisBackend &&) = delete;
 
 public:
     ErrorCode Init(const StandardUri &standard_uri) noexcept override;
@@ -33,12 +34,22 @@ public:
     ErrorCode SetValue(const std::string &key, const std::string &value) override;
     ErrorCode GetValue(const std::string &key, std::string &out_value) override;
 
+protected:
+    virtual std::shared_ptr<RedisClientExt> CreateRedisClient(const StandardUri &storage_uri) const;
+
 private:
+    using RedisClientPool = DynamicClientPool<RedisClientExt>;
+    using RedisClientHandle = RedisClientPool::ClientHandle;
+
     // 生成Redis锁键名
     std::string GetRedisLockKey(const std::string &lock_key) const;
 
     // 生成Redis KV键名
     std::string GetRedisKVKey(const std::string &key) const;
+
+    RedisClientHandle AcquireClient();
+    std::string GetCachedScriptSha1(const std::string &cached_sha1) const;
+    void UpdateCachedScriptSha1(std::string &cached_sha1, const std::string &new_sha1);
 
     // Lua脚本：尝试获取锁（原子操作）
     static constexpr const char *LUA_TRY_LOCK = R"(
@@ -115,12 +126,15 @@ private:
     )";
 
 private:
-    std::unique_ptr<RedisClientExt> redis_client_;
+    std::shared_ptr<RedisClientPool> client_pool_;
+    StandardUri storage_uri_;
     std::string lock_key_prefix_;
     std::string kv_key_prefix_;
-    bool initialized_{false};
+    int64_t timeout_ms_{1000};
+    std::atomic<bool> initialized_{false};
 
     // Lua脚本的SHA1缓存
+    mutable std::mutex script_sha_mutex_;
     std::string try_lock_sha1_;
     std::string renew_lock_sha1_;
     std::string unlock_sha1_;

--- a/kv_cache_manager/config/test/BUILD
+++ b/kv_cache_manager/config/test/BUILD
@@ -101,6 +101,21 @@ cc_test(
 )
 
 cc_test(
+    name = "coordination_redis_backend_unit_test",
+    srcs = [
+        "coordination_redis_backend_unit_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:redis_client_ext",
+        "//kv_cache_manager/common:standard_uri",
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/config:coordination_backend",
+    ],
+)
+
+cc_test(
     name = "coordination_file_backend_test",
     srcs = [
         "coordination_file_backend_test.cc",

--- a/kv_cache_manager/config/test/coordination_backend_test_base.h
+++ b/kv_cache_manager/config/test/coordination_backend_test_base.h
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <functional>
@@ -5,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <thread>
+#include <vector>
 
 #include "kv_cache_manager/common/standard_uri.h"
 #include "kv_cache_manager/common/unittest.h"
@@ -19,8 +21,7 @@ struct CoordinationBackendTestConfig {
     std::function<void(CoordinationBackendTest *test_base)> tear_down_;
 };
 
-class CoordinationBackendTest : public TESTBASE,
-                                   public testing::WithParamInterface<CoordinationBackendTestConfig> {
+class CoordinationBackendTest : public TESTBASE, public testing::WithParamInterface<CoordinationBackendTestConfig> {
 protected:
     void SetUp() override {
         GetParam().set_up_(this);
@@ -428,6 +429,36 @@ TEST_P(CoordinationBackendTest, TestSetGetMultipleKeys) {
 
     EXPECT_EQ(EC_OK, backend_->GetValue("key3", out));
     EXPECT_EQ("val3", out);
+}
+
+TEST_P(CoordinationBackendTest, TestConcurrentGetValue) {
+    const std::string key = "concurrent_get_value_key";
+    const std::string value = R"({"node_id":"node-1","host":"127.0.0.1","meta_rpc_port":8080})";
+    ASSERT_EQ(EC_OK, backend_->SetValue(key, value));
+
+    std::atomic<int> error_count{0};
+    std::vector<std::thread> threads;
+    constexpr int32_t THREAD_NUM = 8;
+    constexpr int32_t ITERATION_NUM = 50;
+    threads.reserve(THREAD_NUM);
+
+    for (int32_t i = 0; i < THREAD_NUM; ++i) {
+        threads.emplace_back([&]() {
+            for (int32_t j = 0; j < ITERATION_NUM; ++j) {
+                std::string out_value;
+                ErrorCode ec = backend_->GetValue(key, out_value);
+                if (ec != EC_OK || out_value != value) {
+                    error_count.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+
+    for (auto &thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(0, error_count.load(std::memory_order_relaxed));
 }
 
 // 测试 SetValue 空值

--- a/kv_cache_manager/config/test/coordination_redis_backend_unit_test.cc
+++ b/kv_cache_manager/config/test/coordination_redis_backend_unit_test.cc
@@ -1,0 +1,141 @@
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "kv_cache_manager/common/redis_client_ext.h"
+#include "kv_cache_manager/common/standard_uri.h"
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/coordination_redis_backend.h"
+
+namespace kv_cache_manager {
+namespace {
+
+struct RedisClientConcurrencyState {
+    std::atomic<int32_t> concurrent_pipeline_count{0};
+};
+
+class TrackingRedisClient : public RedisClientExt {
+public:
+    TrackingRedisClient(const StandardUri &storage_uri, std::shared_ptr<RedisClientConcurrencyState> state)
+        : RedisClientExt(storage_uri), state_(std::move(state)) {}
+
+protected:
+    bool IsContextOk() const override { return true; }
+    bool Reconnect() override { return true; }
+
+    std::vector<ReplyUPtr> TryExecPipeline(const std::vector<CmdArgs> &cmds) override {
+        int32_t active_count = active_pipeline_count_.fetch_add(1, std::memory_order_acq_rel) + 1;
+        if (active_count > 1) {
+            state_->concurrent_pipeline_count.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+        std::vector<ReplyUPtr> replies;
+        replies.reserve(cmds.size());
+        for (const auto &cmd : cmds) {
+            replies.emplace_back(MakeReply(cmd));
+        }
+
+        active_pipeline_count_.fetch_sub(1, std::memory_order_acq_rel);
+        return replies;
+    }
+
+private:
+    static ReplyUPtr MakeFakeReply(int type, const std::string &str) {
+        redisReply *r = (redisReply *)malloc(sizeof(redisReply));
+        memset(r, 0, sizeof(redisReply));
+        r->type = type;
+        if (type == REDIS_REPLY_STRING || type == REDIS_REPLY_STATUS || type == REDIS_REPLY_ERROR || !str.empty()) {
+            r->str = strdup(str.c_str());
+            r->len = str.size();
+        }
+        return ReplyUPtr(r, freeReplyObject);
+    }
+
+    static ReplyUPtr MakeFakeReplyInteger(const int64_t integer) {
+        redisReply *r = (redisReply *)malloc(sizeof(redisReply));
+        memset(r, 0, sizeof(redisReply));
+        r->type = REDIS_REPLY_INTEGER;
+        r->integer = integer;
+        return ReplyUPtr(r, freeReplyObject);
+    }
+
+    ReplyUPtr MakeReply(const CmdArgs &cmd) {
+        if (cmd.empty()) {
+            return MakeFakeReply(REDIS_REPLY_ERROR, "empty command");
+        }
+        if (cmd[0] == "SCRIPT") {
+            return MakeFakeReply(REDIS_REPLY_STRING, "fake_script_sha1");
+        }
+        if (cmd[0] == "EVALSHA" || cmd[0] == "EVAL") {
+            return MakeFakeReplyInteger(1);
+        }
+        if (cmd[0] == "GET") {
+            return MakeFakeReply(REDIS_REPLY_STRING, "node_info_json");
+        }
+        if (cmd[0] == "PTTL") {
+            return MakeFakeReplyInteger(1000);
+        }
+        if (cmd[0] == "SET") {
+            return MakeFakeReply(REDIS_REPLY_STATUS, "OK");
+        }
+        return MakeFakeReplyInteger(1);
+    }
+
+private:
+    std::shared_ptr<RedisClientConcurrencyState> state_;
+    std::atomic<int32_t> active_pipeline_count_{0};
+};
+
+class TestCoordinationRedisBackend : public CoordinationRedisBackend {
+public:
+    explicit TestCoordinationRedisBackend(std::shared_ptr<RedisClientConcurrencyState> state)
+        : state_(std::move(state)) {}
+
+protected:
+    std::shared_ptr<RedisClientExt> CreateRedisClient(const StandardUri &storage_uri) const override {
+        return std::make_shared<TrackingRedisClient>(storage_uri, state_);
+    }
+
+private:
+    std::shared_ptr<RedisClientConcurrencyState> state_;
+};
+
+TEST(CoordinationRedisBackendUnitTest, PoolSerializesDifferentApisOnSameClient) {
+    auto state = std::make_shared<RedisClientConcurrencyState>();
+    TestCoordinationRedisBackend backend(state);
+    StandardUri uri = StandardUri::FromUri("redis://localhost:6379?client_min_pool_size=1&client_max_pool_size=1");
+    ASSERT_EQ(EC_OK, backend.Init(uri));
+
+    std::atomic<bool> go{false};
+    std::thread renew_thread([&]() {
+        while (!go.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        EXPECT_EQ(EC_OK, backend.RenewLock("leader_lock", "node_1", 1000));
+    });
+    std::thread get_thread([&]() {
+        while (!go.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        std::string value;
+        EXPECT_EQ(EC_OK, backend.GetValue("_TAIR_KVCM_NODE_INFO_node_1", value));
+        EXPECT_EQ("node_info_json", value);
+    });
+
+    go.store(true, std::memory_order_release);
+    renew_thread.join();
+    get_thread.join();
+
+    EXPECT_EQ(0, state->concurrent_pipeline_count.load(std::memory_order_relaxed));
+}
+
+} // namespace
+} // namespace kv_cache_manager


### PR DESCRIPTION
## Summary
- Use `DynamicClientPool<RedisClientExt>` in `CoordinationRedisBackend` so concurrent backend calls do not share one Redis client/context.
- Protect cached Lua script SHA updates and keep public Redis operations borrowing a pool client per call.
- Add a unit test with an injected fake Redis client to verify different APIs serialize access when the pool has a single client.

## Root Cause
`RedisClientExt` wraps a Redis client/context that is not safe for concurrent multi-threaded command execution. Sharing one client across foreground/background calls could interleave different Redis commands and corrupt responses.

## Validation
- `bazelisk test --disk_cache= //kv_cache_manager/config/test:coordination_redis_backend_unit_test`
- `bazelisk build --disk_cache= //kv_cache_manager/config:coordination_backend //kv_cache_manager/config/test:coordination_redis_backend_test //kv_cache_manager/config/test:coordination_file_backend_test //kv_cache_manager/config/test:coordination_memory_backend_test //kv_cache_manager/config/test:leader_elector_test`

Note: `--disk_cache=` was used because the shared Bazel disk cache contained depfiles from a different container toolchain.