### PR TITLE
[common] fix TOCTOU race in DynamicClientPool::AcquireClient

### DIFF
--- a/kv_cache_manager/common/client_pool.h
+++ b/kv_cache_manager/common/client_pool.h
@@ -10,6 +10,8 @@
 #include <thread>
 #include <vector>
 
+#include "kv_cache_manager/common/logger.h"
+
 namespace kv_cache_manager {
 
 template <typename ClientType>
@@ -148,18 +150,19 @@ public:
         }
         if (client == nullptr) {
             if (static_cast<int32_t>(this->pool_state_->AllClientSize()) < max_pool_size_) {
-                {
-                    std::unique_lock lock(acq_mux_);
-                    // double check
-                    if (static_cast<int32_t>(this->pool_state_->AllClientSize()) < max_pool_size_) {
-                        auto temp_client = this->cb_();
-                        if (temp_client != nullptr) {
-                            this->pool_state_->ReleaseClient(temp_client, true);
-                        }
+                std::unique_lock lock(acq_mux_);
+                // double check
+                if (static_cast<int32_t>(this->pool_state_->AllClientSize()) < max_pool_size_) {
+                    auto temp_client = this->cb_();
+                    if (temp_client != nullptr) {
+                        this->pool_state_->ReleaseClient(temp_client, true);
+                    } else {
+                        KVCM_LOG_WARN("DynamicClientPool: failed to create new client, current pool size: %zu",
+                                      this->pool_state_->AllClientSize());
                     }
                 }
-                client = this->pool_state_->AcquireClient(timeout_ms);
             }
+            client = this->pool_state_->AcquireClient(timeout_ms);
         }
 
         return typename Base::ClientHandle(this->pool_state_, std::move(client));


### PR DESCRIPTION
修复 DynamicClientPool::AcquireClient 中的 TOCTOU 竞态问题，并增加连接创建失败日志

【问题】
DynamicClientPool::AcquireClient 存在 TOCTOU（检查时/使用时）竞态窗口：当池从未满切换到已满的瞬间（即 FreeClientSize() 读取与后续 AllClientSize() 检查之间），当前线程可能跳过等待和扩容两个分支，直接返回空 handle。对于 coordination 场景，这会导致锁续约出现虚假的 EC_TIMEOUT，引发短暂的 leadership 翻转。

【修复】
将 pool_state_->AcquireClient(timeout_ms) 调用提到 if/else 分支外部，确保所有未走快速路径的线程都会正确阻塞等待可用 client 归还。
当 client factory 回调返回 nullptr 时新增 KVCM_LOG_WARN 日志输出，使连接创建失败可观测，避免静默超时难以排查。