### PR TITLE
[metrics] add lifecycle management for per-instance metrics cleanup

### DIFF
--- a/kv_cache_manager/data_storage/data_storage_backend.h
+++ b/kv_cache_manager/data_storage/data_storage_backend.h
@@ -38,7 +38,6 @@ public:
         if (!metrics_collector_->Init()) {
             metrics_collector_ = nullptr;
         }
-        // TODO (rui): handle metrics collector unregistration during Close()
         return DoOpen(config, trace_id);
     }
     virtual ErrorCode DoOpen(const StorageConfig &config, const std::string &trace_id) = 0;

--- a/kv_cache_manager/manager/BUILD
+++ b/kv_cache_manager/manager/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "//kv_cache_manager/data_storage",
         "//kv_cache_manager/event:event_publisher",
         "//kv_cache_manager/metrics:metrics_collector",
+        "//kv_cache_manager/metrics:metrics_lifecycle",
         "//kv_cache_manager/metrics:metrics_registry",
     ],
 )
@@ -156,6 +157,7 @@ cc_library(
         ":write_location_manager",
         "//kv_cache_manager/config",
         "//kv_cache_manager/meta:meta_indexer_manager",
+        "//kv_cache_manager/metrics:metrics_lifecycle",
     ],
 )
 

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -39,6 +39,7 @@
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 #include "kv_cache_manager/meta/types.h"
 #include "kv_cache_manager/metrics/metrics_collector.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "kv_cache_manager/protocol/protobuf/meta_service.pb.h"
 
@@ -126,15 +127,17 @@ IsSpecNameInSpecGroup(const std::string &trace_id,
 } // namespace
 
 CacheManager::CacheManager(std::shared_ptr<MetricsRegistry> metrics_registry,
-                           std::shared_ptr<RegistryManager> registry_manager)
+                           std::shared_ptr<RegistryManager> registry_manager,
+                           std::shared_ptr<MetricsLifecycle> metrics_lifecycle)
     : meta_indexer_manager_(std::make_shared<MetaIndexerManager>())
     , write_location_manager_(std::make_shared<WriteLocationManager>())
     , meta_searcher_manager_(std::make_shared<MetaSearcherManager>(registry_manager, meta_indexer_manager_))
     , data_storage_selector_(std::make_unique<DataStorageSelector>(meta_indexer_manager_, registry_manager))
     , metrics_registry_(std::move(metrics_registry))
     , registry_manager_(std::move(registry_manager))
+    , metrics_lifecycle_(metrics_lifecycle ? std::move(metrics_lifecycle) : std::make_shared<MetricsLifecycle>())
     , metrics_recorder_(std::make_shared<CacheManagerMetricsRecorder>(
-          meta_indexer_manager_, write_location_manager_, registry_manager_)) {}
+          meta_indexer_manager_, write_location_manager_, registry_manager_, metrics_lifecycle_)) {}
 
 CacheManager::~CacheManager() {
     ClearVineyardCleanupCallbacks();
@@ -256,10 +259,38 @@ ErrorCode CacheManager::RemoveInstance(RequestContext *request_context,
     auto ec = registry_manager_->RemoveInstance(request_context, instance_group, instance_id);
     RETURN_IF_EC_NOT_OK_WITH_LOG(WARN, ec, "remove instance failed");
 
+    InvalidateInstanceMetrics(instance_id);
+
     ec = TrimCache(request_context, instance_id, proto::meta::TrimStrategy::TS_REMOVE_ALL_CACHE);
     RETURN_IF_EC_NOT_OK_WITH_LOG(WARN, ec, "remove instance failed");
     PREFIX_LOG(INFO, "remove instance OK");
     return ec;
+}
+
+void CacheManager::InvalidateInstanceMetrics(const std::string &instance_id) const {
+    if (instance_id.empty()) {
+        return;
+    }
+
+    // callers must hold a unique lock on metrics_lifecycle_->mut_ while
+    // invoking this, so that no producer (recorder publish span,
+    // reporter ReportInterval, MetaServiceMetricsBase slow path) can
+    // register new instance_id-tagged metrics during the steps below
+
+    // 1) prune the recorder snapshot so the reporter cannot recreate
+    //    entries on its next cycle
+    if (metrics_recorder_) {
+        metrics_recorder_->RemoveInstance(instance_id);
+    }
+    // 2) remove existing metrics entries from the registry
+    if (metrics_registry_) {
+        metrics_registry_->RemoveByTagFilter({{"instance_id", instance_id}});
+    }
+    // 3) evict cached per-instance collectors so subsequent requests
+    //    do not resurrect entries through stale handles
+    if (on_instance_removed_) {
+        on_instance_removed_(instance_id);
+    }
 }
 
 std::pair<ErrorCode, InstanceInfoConstPtr> CacheManager::GetInstanceInfo(RequestContext *request_context,

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
@@ -28,6 +29,7 @@ class ReclaimerTaskSupervisor;
 class StartupConfigLoader;
 class EventManager;
 class CacheManagerMetricsRecorder;
+struct MetricsLifecycle;
 constexpr unsigned int DEFAULT_SCHEDULE_PLAN_EXECUTOR_THREAD_COUNT = 2;
 
 class CacheManager {
@@ -58,7 +60,9 @@ public:
     using UriType = std::string;
     using UriVector = std::vector<UriType>;
 
-    CacheManager(std::shared_ptr<MetricsRegistry> metrics_registry, std::shared_ptr<RegistryManager> registry_manager);
+    CacheManager(std::shared_ptr<MetricsRegistry> metrics_registry,
+                 std::shared_ptr<RegistryManager> registry_manager,
+                 std::shared_ptr<MetricsLifecycle> metrics_lifecycle = nullptr);
     ~CacheManager();
 
     bool Init(int32_t schedule_plan_executor_thread_count = DEFAULT_SCHEDULE_PLAN_EXECUTOR_THREAD_COUNT,
@@ -73,6 +77,14 @@ public:
     void StopRecoverRetryLoop();
     ErrorCode DoCleanup();
     std::shared_ptr<RegistryManager> GetRegistryManager() { return registry_manager_; }
+    [[nodiscard]] std::shared_ptr<MetricsLifecycle> metrics_lifecycle() const { return metrics_lifecycle_; }
+
+    // register a callback invoked after an instance is fully removed;
+    // must be set before serving traffic (not thread-safe for writes)
+    // the callback runs on the RemoveInstance call stack — callees
+    // must not re-enter CacheManager methods
+    using OnInstanceRemovedFn = std::function<void(const std::string &instance_id)>;
+    void SetOnInstanceRemoved(OnInstanceRemovedFn fn) { on_instance_removed_ = std::move(fn); }
 
     std::string GetExtraInfo(RequestContext *request_context, const std::string &instance_id);
 
@@ -251,6 +263,10 @@ private:
     SubmitDelReqFunc GetSubmitDelReqFunc(const std::string &instance_id) const;
     void ClearVineyardCleanupCallbacks();
 
+    // purge metrics registry entries and invoke the removal callback
+    // for a given instance_id
+    void InvalidateInstanceMetrics(const std::string &instance_id) const;
+
 private:
     /***
      * === 成员变量清理说明 ===
@@ -280,9 +296,12 @@ private:
     std::unique_ptr<ReclaimerTaskSupervisor> reclaimer_task_supervisor_;
     // 无需清理 - 不包含运行时状态
     std::shared_ptr<EventManager> event_manager_;
+    // 无需清理
+    std::shared_ptr<MetricsLifecycle> metrics_lifecycle_;
     // 需要清理 - 避免有metrics遗留
     std::shared_ptr<CacheManagerMetricsRecorder> metrics_recorder_;
-
+    // 无需清理
+    OnInstanceRemovedFn on_instance_removed_;
     // 需要清理 - recover 重试线程相关，在DoCleanup()中StopRecoverRetryLoop()
     std::thread recover_retry_thread_;
     std::atomic<bool> recover_retry_stop_{false};

--- a/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
+++ b/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
@@ -11,6 +11,7 @@
 #include "kv_cache_manager/manager/write_location_manager.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
 
 namespace kv_cache_manager {
 
@@ -40,10 +41,12 @@ private:
 
 CacheManagerMetricsRecorder::CacheManagerMetricsRecorder(std::shared_ptr<MetaIndexerManager> meta_indexer_manager,
                                                          std::shared_ptr<WriteLocationManager> write_location_manager,
-                                                         std::shared_ptr<RegistryManager> registry_manager)
+                                                         std::shared_ptr<RegistryManager> registry_manager,
+                                                         std::shared_ptr<MetricsLifecycle> metrics_lifecycle)
     : meta_indexer_manager_(meta_indexer_manager)
     , write_location_manager_(write_location_manager)
-    , registry_manager_(registry_manager) {}
+    , registry_manager_(registry_manager)
+    , metrics_lifecycle_(std::move(metrics_lifecycle)) {}
 
 CacheManagerMetricsRecorder::~CacheManagerMetricsRecorder() { Stop(); }
 
@@ -66,10 +69,33 @@ void CacheManagerMetricsRecorder::DoCleanup() {
     return;
 }
 
+void CacheManagerMetricsRecorder::RemoveInstance(const std::string &instance_id) {
+    std::scoped_lock guard(mutex_);
+    for (auto &[group_name, instance_map] : group_instance_id_metric_map_) {
+        instance_map.erase(instance_id);
+    }
+}
+
+void CacheManagerMetricsRecorder::RemoveGroup(const std::string &group_name) {
+    std::scoped_lock guard(mutex_);
+    group_usage_ratio_map_.erase(group_name);
+    group_instance_id_metric_map_.erase(group_name);
+}
+
 void CacheManagerMetricsRecorder::RecorderLoop() {
     KVCM_LOG_INFO("RecorderLoop started");
     while (!stop_.load(std::memory_order_relaxed)) {
         SleepHelper sleep_helper(stop_mutex_, stop_cv_, stop_);
+
+        // hold a shared lifecycle lock around the entire registry-read
+        // → publish span so an instance/group removal cannot interleave
+        // between sampling the registry and publishing the snapshot
+        // without this, a recorder iteration that read the registry
+        // pre-removal could publish a stale snapshot post-removal that
+        // the reporter would then materialise into the metrics
+        // registry, leaking metrics permanently
+        std::shared_lock<std::shared_mutex> lifecycle_guard(metrics_lifecycle_->mut_);
+
         const auto request_context = std::make_shared<RequestContext>(kTraceId);
         const auto [ec, instance_groups] = registry_manager_->ListInstanceGroup(request_context.get());
         if (ec != ErrorCode::EC_OK) {

--- a/kv_cache_manager/manager/cache_manager_metrics_recorder.h
+++ b/kv_cache_manager/manager/cache_manager_metrics_recorder.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <thread>
 #include <unordered_map>
 
@@ -17,6 +18,7 @@ namespace kv_cache_manager {
 class MetaIndexerManager;
 class WriteLocationManager;
 class RegistryManager;
+struct MetricsLifecycle;
 
 class CacheManagerMetricsRecorder {
 public:
@@ -35,11 +37,14 @@ public:
 
     CacheManagerMetricsRecorder(std::shared_ptr<MetaIndexerManager> meta_indexer_manager,
                                 std::shared_ptr<WriteLocationManager> write_location_manager,
-                                std::shared_ptr<RegistryManager> registry_manager);
+                                std::shared_ptr<RegistryManager> registry_manager,
+                                std::shared_ptr<MetricsLifecycle> metrics_lifecycle);
     ~CacheManagerMetricsRecorder();
     void Start();
     void Stop();
     void DoCleanup();
+    void RemoveInstance(const std::string &instance_id);
+    void RemoveGroup(const std::string &group_name);
     size_t write_location_expire_size() const;
     GroupUsageRatioMap group_usage_ratio_map() const;
     GroupInstanceIdMetricMap group_instance_id_metric_map() const;
@@ -61,6 +66,11 @@ private:
     std::shared_ptr<MetaIndexerManager> meta_indexer_manager_;
     std::shared_ptr<WriteLocationManager> write_location_manager_;
     std::shared_ptr<RegistryManager> registry_manager_;
+    // shared between this recorder, CacheManager, AdminServiceImpl and
+    // the metrics reporters; the recorder loop holds a shared lock
+    // around the registry-read+publish span so removals cannot slip
+    // between sampling and publishing a stale snapshot
+    std::shared_ptr<MetricsLifecycle> metrics_lifecycle_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -196,3 +196,18 @@ cc_test(
         "//kv_cache_manager/manager:write_location_manager",
     ],
 )
+
+cc_test(
+    name = "CacheManagerMetricsRecorderTest",
+    srcs = [
+        "cache_manager_metrics_recorder_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    linkstatic = True,
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/manager:cache_manager_metrics_recorder",
+        "//kv_cache_manager/metrics:metrics_lifecycle",
+    ],
+)

--- a/kv_cache_manager/manager/test/cache_manager_metrics_recorder_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_metrics_recorder_test.cc
@@ -1,0 +1,81 @@
+#include <memory>
+#include <string>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
+
+using namespace kv_cache_manager;
+
+class CacheManagerMetricsRecorderTest : public TESTBASE {
+public:
+    void SetUp() override {
+        auto lifecycle = std::make_shared<MetricsLifecycle>();
+        recorder_ = std::make_shared<CacheManagerMetricsRecorder>(nullptr, nullptr, nullptr, lifecycle);
+    }
+
+    // directly populate the recorder's snapshot maps (via
+    // -fno-access-control) to unit-test the mutator methods without
+    // needing a full RecorderLoop
+    void SeedSnapshot() {
+        recorder_->group_usage_ratio_map_["grp1"] = 0.5;
+        recorder_->group_usage_ratio_map_["grp2"] = 0.3;
+
+        recorder_->group_instance_id_metric_map_["grp1"]["inst1"] = {10, 100};
+        recorder_->group_instance_id_metric_map_["grp1"]["inst2"] = {20, 200};
+        recorder_->group_instance_id_metric_map_["grp2"]["inst3"] = {30, 300};
+        recorder_->group_instance_id_metric_map_["grp2"]["inst1"] = {5, 50};
+    }
+
+    std::shared_ptr<CacheManagerMetricsRecorder> recorder_;
+};
+
+TEST_F(CacheManagerMetricsRecorderTest, RemoveGroupErasesGroupAndItsInstances) {
+    SeedSnapshot();
+
+    recorder_->RemoveGroup("grp1");
+
+    auto ratio_map = recorder_->group_usage_ratio_map();
+    ASSERT_EQ(ratio_map.end(), ratio_map.find("grp1"));
+    ASSERT_NE(ratio_map.end(), ratio_map.find("grp2"));
+
+    auto inst_map = recorder_->group_instance_id_metric_map();
+    ASSERT_EQ(inst_map.end(), inst_map.find("grp1"));
+    ASSERT_NE(inst_map.end(), inst_map.find("grp2"));
+    // grp2 instances untouched
+    ASSERT_EQ(2, inst_map["grp2"].size());
+}
+
+TEST_F(CacheManagerMetricsRecorderTest, RemoveInstanceErasesAcrossAllGroups) {
+    SeedSnapshot();
+
+    // inst1 exists in both grp1 and grp2
+    recorder_->RemoveInstance("inst1");
+
+    auto inst_map = recorder_->group_instance_id_metric_map();
+    // grp1 should only have inst2
+    ASSERT_EQ(1, inst_map["grp1"].size());
+    ASSERT_NE(inst_map["grp1"].end(), inst_map["grp1"].find("inst2"));
+    ASSERT_EQ(inst_map["grp1"].end(), inst_map["grp1"].find("inst1"));
+    // grp2 should only have inst3
+    ASSERT_EQ(1, inst_map["grp2"].size());
+    ASSERT_NE(inst_map["grp2"].end(), inst_map["grp2"].find("inst3"));
+    ASSERT_EQ(inst_map["grp2"].end(), inst_map["grp2"].find("inst1"));
+
+    // group entries themselves remain (not erased)
+    auto ratio_map = recorder_->group_usage_ratio_map();
+    ASSERT_NE(ratio_map.end(), ratio_map.find("grp1"));
+    ASSERT_NE(ratio_map.end(), ratio_map.find("grp2"));
+}
+
+TEST_F(CacheManagerMetricsRecorderTest, RemoveGroupOnAbsentGroupIsNoOp) {
+    SeedSnapshot();
+
+    // removing a non-existent group should not crash or affect others
+    recorder_->RemoveGroup("nonexistent");
+
+    auto ratio_map = recorder_->group_usage_ratio_map();
+    ASSERT_EQ(2, ratio_map.size());
+    auto inst_map = recorder_->group_instance_id_metric_map();
+    ASSERT_EQ(2, inst_map.size());
+}

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -2779,6 +2779,85 @@ TEST_F(CacheManagerTest, TestRecoverRetryLoopLifecycle) {
     ASSERT_EQ(EC_OK, cache_manager_->DoCleanup());
 }
 
+/* ------------ InvalidateInstanceMetrics tests ------------ */
+
+TEST_F(CacheManagerTest, InvalidateInstanceMetricsEmptyIdIsNoOp) {
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto rm_registry = std::make_shared<MetricsRegistry>(); // separate for RM internals
+    auto rm = std::make_shared<RegistryManager>("", rm_registry);
+    rm->Init();
+    auto cm = std::make_unique<CacheManager>(metrics_registry, rm);
+
+    metrics_registry->GetCounter("test.counter", {{"instance_id", "inst1"}});
+    ASSERT_EQ(1, metrics_registry->GetSize());
+
+    // empty id should be a no-op
+    cm->InvalidateInstanceMetrics("");
+    ASSERT_EQ(1, metrics_registry->GetSize());
+}
+
+TEST_F(CacheManagerTest, InvalidateInstanceMetricsNoCallbackDoesNotCrash) {
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto rm_registry = std::make_shared<MetricsRegistry>();
+    auto rm = std::make_shared<RegistryManager>("", rm_registry);
+    rm->Init();
+    auto cm = std::make_unique<CacheManager>(metrics_registry, rm);
+
+    metrics_registry->GetCounter("test.counter", {{"instance_id", "inst1"}});
+    ASSERT_EQ(1, metrics_registry->GetSize());
+
+    // no callback set — should not crash, and still purge registry
+    ASSERT_NO_FATAL_FAILURE(cm->InvalidateInstanceMetrics("inst1"));
+    ASSERT_EQ(0, metrics_registry->GetSize());
+}
+
+TEST_F(CacheManagerTest, InvalidateInstanceMetricsPurgesRegistry) {
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto rm_registry = std::make_shared<MetricsRegistry>();
+    auto rm = std::make_shared<RegistryManager>("", rm_registry);
+    rm->Init();
+    auto cm = std::make_unique<CacheManager>(metrics_registry, rm);
+
+    metrics_registry->GetCounter("m1", {{"instance_id", "inst1"}});
+    metrics_registry->GetGauge("m2", {{"instance_id", "inst1"}, {"extra", "tag"}});
+    metrics_registry->GetCounter("m1", {{"instance_id", "inst2"}});
+    ASSERT_EQ(3, metrics_registry->GetSize());
+
+    cm->InvalidateInstanceMetrics("inst1");
+
+    // only inst2 remains
+    ASSERT_EQ(1, metrics_registry->GetSize());
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    metrics_registry->GetAllMetrics(all);
+    ASSERT_EQ(1, all.size());
+    auto &[name, tags, _] = all[0];
+    ASSERT_EQ("m1", name);
+    ASSERT_EQ("inst2", tags.at("instance_id"));
+}
+
+TEST_F(CacheManagerTest, InvalidateInstanceMetricsInvokesCallback) {
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto rm_registry = std::make_shared<MetricsRegistry>();
+    auto rm = std::make_shared<RegistryManager>("", rm_registry);
+    rm->Init();
+    auto cm = std::make_unique<CacheManager>(metrics_registry, rm);
+
+    std::string received_id;
+    int call_count = 0;
+    cm->SetOnInstanceRemoved([&](const std::string &id) {
+        received_id = id;
+        ++call_count;
+    });
+
+    cm->InvalidateInstanceMetrics("inst42");
+    ASSERT_EQ(1, call_count);
+    ASSERT_EQ("inst42", received_id);
+
+    // empty id should not invoke callback
+    cm->InvalidateInstanceMetrics("");
+    ASSERT_EQ(1, call_count);
+}
+
 // =============================================================
 // GetCacheLocationsByBackend with backend_selectors
 // =============================================================

--- a/kv_cache_manager/metrics/BUILD
+++ b/kv_cache_manager/metrics/BUILD
@@ -11,6 +11,13 @@ cc_library(
 )
 
 cc_library(
+    name = "metrics_lifecycle",
+    hdrs = [
+        "metrics_lifecycle.h",
+    ],
+)
+
+cc_library(
     name = "metrics_collector",
     srcs = [
         "metrics_collector.cc",
@@ -43,6 +50,7 @@ cc_library(
     ],
     deps = [
         ":metrics_registry",
+        ":metrics_lifecycle",
         ":metrics_collector",
         "//kv_cache_manager/common:utils",
         "//kv_cache_manager/common:logger",

--- a/kv_cache_manager/metrics/local_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/local_metrics_reporter.cc
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <shared_mutex>
 #include <utility>
 
 #include "kv_cache_manager/common/common_util.h"
@@ -14,6 +15,7 @@
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 #include "kv_cache_manager/metrics/metrics_collector.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
 namespace kv_cache_manager {
@@ -90,6 +92,12 @@ void LocalMetricsReporter::ReportInterval() {
     if (!cache_manager_) {
         return;
     }
+
+    // hold a shared lifecycle lock across the entire metrics publication
+    // so concurrent RemoveInstance/RemoveInstanceGroup/RemoveStorage
+    // (which hold the lock as a writer) cannot interleave a tag-filter
+    // purge with EmplaceMetricsCollector calls below
+    std::shared_lock<std::shared_mutex> lifecycle_guard(cache_manager_->metrics_lifecycle()->mut_);
 
     do {
         // for data storage metrics

--- a/kv_cache_manager/metrics/metrics_lifecycle.h
+++ b/kv_cache_manager/metrics/metrics_lifecycle.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <shared_mutex>
+
+namespace kv_cache_manager {
+
+// coarse-grained read/write coordination between metrics
+// registration / publication and instance / group / storage lifecycle
+// removal.
+//
+// - sites that register tagged metrics (LocalMetricsReporter,
+//   MetaServiceMetricsBase slow path) and the CacheManagerMetricsRecorder
+//   publish span hold a shared lock around their critical region
+// - lifecycle removal sites (AdminServiceImpl::RemoveInstance,
+//   RemoveInstanceGroup, RemoveStorage) hold a unique lock for the
+//   entire operation
+//
+// removals are very low frequency, so a single coarse-grained
+// shared_mutex is chosen over fine-grained machinery: it eliminates
+// the race interleaving of registration and tag-filter purge without
+// any deferred cleanup or double-purge logic
+struct MetricsLifecycle {
+    mutable std::shared_mutex mut_;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/metrics_registry.cc
+++ b/kv_cache_manager/metrics/metrics_registry.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <cstddef>
@@ -229,6 +230,37 @@ Gauge MetricsData::GetOrCreateGauge(const MetricsTags &tags) {
     return Gauge{it->second};
 }
 
+namespace {
+
+// returns true if tags contains all key-value pairs in filter
+bool TagsMatch(const MetricsTags &tags, const MetricsTags &filter) {
+    return std::all_of(filter.begin(), filter.end(), [&tags](const auto &kv) {
+        auto it = tags.find(kv.first);
+        return it != tags.end() && it->second == kv.second;
+    });
+}
+
+} // anonymous namespace
+
+bool MetricsData::Remove(const MetricsTags &tags) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return metrics_data_.erase(tags) > 0;
+}
+
+std::size_t MetricsData::RemoveByTagFilter(const MetricsTags &filter) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    std::size_t removed = 0;
+    for (auto it = metrics_data_.begin(); it != metrics_data_.end();) {
+        if (TagsMatch(it->first, filter)) {
+            it = metrics_data_.erase(it);
+            ++removed;
+        } else {
+            ++it;
+        }
+    }
+    return removed;
+}
+
 std::optional<Gauge> MetricsData::GetGauge(const MetricsTags &tags) {
     std::lock_guard<std::mutex> guard(mutex_);
     auto it = metrics_data_.find(tags);
@@ -304,6 +336,26 @@ std::shared_ptr<MetricsData> MetricsRegistry::GetOrCreateMetricsData(const std::
         it = metrics_data_map_.emplace(name, std::make_shared<MetricsData>()).first;
     }
     return it->second;
+}
+
+bool MetricsRegistry::Remove(const std::string &name, const MetricsTags &tags) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    const auto it = metrics_data_map_.find(name);
+    if (it == metrics_data_map_.end() || it->second == nullptr) {
+        return false;
+    }
+    return it->second->Remove(tags);
+}
+
+std::size_t MetricsRegistry::RemoveByTagFilter(const MetricsTags &filter) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    std::size_t total = 0;
+    for (auto &[name, data] : metrics_data_map_) {
+        if (data != nullptr) {
+            total += data->RemoveByTagFilter(filter);
+        }
+    }
+    return total;
 }
 
 Counter MetricsRegistry::GetCounter(const std::string &name, const MetricsTags &tags) {

--- a/kv_cache_manager/metrics/metrics_registry.h
+++ b/kv_cache_manager/metrics/metrics_registry.h
@@ -211,6 +211,13 @@ public:
     std::optional<Gauge> GetGauge(const MetricsTags &tags);
     bool RemoveByTags(const MetricsTags &tags);
 
+    // remove a specific entry by exact tags; returns true if erased
+    bool Remove(const MetricsTags &tags);
+
+    // remove all entries whose tags are a superset of filter;
+    // returns number of entries removed
+    std::size_t RemoveByTagFilter(const MetricsTags &filter);
+
 private:
     std::mutex mutex_;
     std::map<MetricsTags, std::shared_ptr<MetricsValue>> metrics_data_;
@@ -235,6 +242,13 @@ public:
 
     Counter GetCounter(const std::string &name, const MetricsTags &tags = {});
     Gauge GetGauge(const std::string &name, const MetricsTags &tags = {});
+
+    // remove a specific metric by name + tags; returns true if erased
+    bool Remove(const std::string &name, const MetricsTags &tags);
+
+    // remove all metrics across all names whose tags match the filter;
+    // returns total number of entries removed
+    std::size_t RemoveByTagFilter(const MetricsTags &filter);
 
     [[nodiscard]] std::shared_ptr<MetricsData> GetMetricsData(const std::string &name) noexcept;
     [[nodiscard]] std::shared_ptr<MetricsData> GetOrCreateMetricsData(const std::string &name) noexcept;

--- a/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
@@ -300,8 +300,11 @@ TEST_F(LocalMetricsReporterTest, TestReportInterval02) {
 TEST_F(LocalMetricsReporterTest, TestReportIntervalCacheManagerMetrics) {
     cache_manager_->meta_indexer_manager_ = std::make_shared<MetaIndexerManager>();
     cache_manager_->write_location_manager_ = std::make_shared<WriteLocationManager>();
-    cache_manager_->metrics_recorder_ = std::make_shared<CacheManagerMetricsRecorder>(
-        cache_manager_->meta_indexer_manager_, cache_manager_->write_location_manager_, registry_manager_);
+    cache_manager_->metrics_recorder_ =
+        std::make_shared<CacheManagerMetricsRecorder>(cache_manager_->meta_indexer_manager_,
+                                                      cache_manager_->write_location_manager_,
+                                                      registry_manager_,
+                                                      cache_manager_->metrics_lifecycle());
 
     RequestContext request_context("test_trace");
     InstanceGroup instance_group;

--- a/kv_cache_manager/metrics/test/metrics_registry_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_registry_test.cc
@@ -697,3 +697,240 @@ TEST_F(MetricsRegistryTest, TestMetricsRegistryMultiThreads) {
 
     t.join();
 }
+
+/* ---------------------- MetricsData::Remove ----------------------- */
+
+TEST_F(MetricsRegistryTest, TestMetricsDataRemoveExact) {
+    auto md = std::make_shared<MetricsData>();
+
+    MetricsTags tags_a{{"instance_id", "inst1"}};
+    MetricsTags tags_b{{"instance_id", "inst2"}};
+    MetricsTags tags_c{{"instance_id", "inst1"}, {"instance_group", "grp1"}};
+
+    md->GetOrCreateCounter(tags_a);
+    md->GetOrCreateGauge(tags_b);
+    md->GetOrCreateCounter(tags_c);
+    ASSERT_EQ(3, md->GetSize());
+
+    // remove non-existent tags returns false
+    ASSERT_FALSE(md->Remove(MetricsTags{{"instance_id", "inst999"}}));
+    ASSERT_EQ(3, md->GetSize());
+
+    // remove exact match
+    ASSERT_TRUE(md->Remove(tags_a));
+    ASSERT_EQ(2, md->GetSize());
+
+    // removing again returns false
+    ASSERT_FALSE(md->Remove(tags_a));
+    ASSERT_EQ(2, md->GetSize());
+
+    // remaining entries unaffected
+    ASSERT_TRUE(md->Remove(tags_b));
+    ASSERT_EQ(1, md->GetSize());
+    ASSERT_TRUE(md->Remove(tags_c));
+    ASSERT_EQ(0, md->GetSize());
+}
+
+TEST_F(MetricsRegistryTest, TestMetricsDataRemoveByTagFilter) {
+    auto md = std::make_shared<MetricsData>();
+
+    MetricsTags tags_a{{"instance_id", "inst1"}, {"instance_group", "grp1"}};
+    MetricsTags tags_b{{"instance_id", "inst2"}, {"instance_group", "grp1"}};
+    MetricsTags tags_c{{"instance_id", "inst1"}, {"instance_group", "grp2"}};
+    MetricsTags tags_d{{"instance_id", "inst3"}, {"instance_group", "grp2"}};
+
+    md->GetOrCreateCounter(tags_a);
+    md->GetOrCreateGauge(tags_b);
+    md->GetOrCreateCounter(tags_c);
+    md->GetOrCreateGauge(tags_d);
+    ASSERT_EQ(4, md->GetSize());
+
+    // filter by instance_id=inst1 should remove tags_a and tags_c
+    ASSERT_EQ(2, md->RemoveByTagFilter({{"instance_id", "inst1"}}));
+    ASSERT_EQ(2, md->GetSize());
+
+    // filter by instance_group=grp1 should remove tags_b only
+    ASSERT_EQ(1, md->RemoveByTagFilter({{"instance_group", "grp1"}}));
+    ASSERT_EQ(1, md->GetSize());
+
+    // filter by non-existent tag should remove nothing
+    ASSERT_EQ(0, md->RemoveByTagFilter({{"instance_id", "inst999"}}));
+    ASSERT_EQ(1, md->GetSize());
+
+    // empty filter matches everything
+    ASSERT_EQ(1, md->RemoveByTagFilter({}));
+    ASSERT_EQ(0, md->GetSize());
+}
+
+TEST_F(MetricsRegistryTest, TestMetricsDataRemoveByTagFilterMultiKey) {
+    auto md = std::make_shared<MetricsData>();
+
+    MetricsTags tags_a{{"instance_id", "inst1"}, {"instance_group", "grp1"}};
+    MetricsTags tags_b{{"instance_id", "inst1"}, {"instance_group", "grp2"}};
+    MetricsTags tags_c{{"instance_id", "inst2"}, {"instance_group", "grp1"}};
+
+    md->GetOrCreateCounter(tags_a);
+    md->GetOrCreateCounter(tags_b);
+    md->GetOrCreateCounter(tags_c);
+    ASSERT_EQ(3, md->GetSize());
+
+    // filter with two keys: only tags_a matches both
+    ASSERT_EQ(1, md->RemoveByTagFilter({{"instance_id", "inst1"}, {"instance_group", "grp1"}}));
+    ASSERT_EQ(2, md->GetSize());
+}
+
+/* -------------------- MetricsRegistry::Remove -------------------- */
+
+TEST_F(MetricsRegistryTest, TestMetricsRegistryRemoveExact) {
+    MetricsTags tags_a{{"instance_id", "inst1"}};
+    MetricsTags tags_b{{"instance_id", "inst2"}};
+
+    auto c1 = registry_->GetCounter("metric1", tags_a);
+    auto c2 = registry_->GetCounter("metric1", tags_b);
+    auto g1 = registry_->GetGauge("metric2", tags_a);
+    ASSERT_EQ(3, registry_->GetSize());
+
+    // remove non-existent name
+    ASSERT_FALSE(registry_->Remove("no_such_metric", tags_a));
+    ASSERT_EQ(3, registry_->GetSize());
+
+    // remove non-existent tags under existing name
+    ASSERT_FALSE(registry_->Remove("metric1", {{"instance_id", "inst999"}}));
+    ASSERT_EQ(3, registry_->GetSize());
+
+    // remove existing entry
+    ASSERT_TRUE(registry_->Remove("metric1", tags_a));
+    ASSERT_EQ(2, registry_->GetSize());
+
+    // the counter handle is still usable (detached)
+    ++c1;
+    ASSERT_EQ(1, c1.Get());
+
+    // metric1 still exists with tags_b
+    ASSERT_NE(nullptr, registry_->GetMetricsData("metric1"));
+
+    // remove last entry under metric1 -> MetricsData remains (empty shell)
+    ASSERT_TRUE(registry_->Remove("metric1", tags_b));
+    ASSERT_EQ(1, registry_->GetSize());
+    // the MetricsData shell persists to avoid orphaning concurrent readers
+    auto md = registry_->GetMetricsData("metric1");
+    ASSERT_NE(nullptr, md);
+    ASSERT_EQ(0, md->GetSize());
+
+    // metric2 still intact
+    ASSERT_TRUE(registry_->Remove("metric2", tags_a));
+    ASSERT_EQ(0, registry_->GetSize());
+}
+
+/* --------------- MetricsRegistry::RemoveByTagFilter -------------- */
+
+TEST_F(MetricsRegistryTest, TestMetricsRegistryRemoveByTagFilter) {
+    MetricsTags tags_inst1_grp1{{"instance_id", "inst1"}, {"instance_group", "grp1"}};
+    MetricsTags tags_inst2_grp1{{"instance_id", "inst2"}, {"instance_group", "grp1"}};
+    MetricsTags tags_inst1_grp2{{"instance_id", "inst1"}, {"instance_group", "grp2"}};
+    MetricsTags tags_inst3_grp2{{"instance_id", "inst3"}, {"instance_group", "grp2"}};
+
+    // spread metrics across multiple names
+    registry_->GetCounter("service.query_counter", tags_inst1_grp1);
+    registry_->GetGauge("service.query_rt_us", tags_inst1_grp1);
+    registry_->GetCounter("service.query_counter", tags_inst2_grp1);
+    registry_->GetGauge("cache_manager_instance.key_count", tags_inst1_grp2);
+    registry_->GetGauge("cache_manager_instance.byte_size", tags_inst3_grp2);
+    ASSERT_EQ(5, registry_->GetSize());
+
+    // remove all metrics for instance_id=inst1 (should remove 3 entries)
+    ASSERT_EQ(3, registry_->RemoveByTagFilter({{"instance_id", "inst1"}}));
+    ASSERT_EQ(2, registry_->GetSize());
+
+    // verify remaining
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    registry_->GetAllMetrics(all);
+    ASSERT_EQ(2, all.size());
+
+    // remove by instance_group=grp2 (should remove 1)
+    ASSERT_EQ(1, registry_->RemoveByTagFilter({{"instance_group", "grp2"}}));
+    ASSERT_EQ(1, registry_->GetSize());
+
+    // remove remaining by instance_group=grp1
+    ASSERT_EQ(1, registry_->RemoveByTagFilter({{"instance_group", "grp1"}}));
+    ASSERT_EQ(0, registry_->GetSize());
+
+    // no-op on empty registry
+    ASSERT_EQ(0, registry_->RemoveByTagFilter({{"instance_id", "inst1"}}));
+}
+
+TEST_F(MetricsRegistryTest, TestMetricsRegistryRemoveByTagFilterKeepsEmptyShell) {
+    MetricsTags tags{{"instance_id", "inst1"}};
+    registry_->GetCounter("metric1", tags);
+    ASSERT_EQ(1, registry_->GetSize());
+    ASSERT_NE(nullptr, registry_->GetMetricsData("metric1"));
+
+    // removing the only entry leaves an empty MetricsData shell
+    // (avoids orphaning concurrent GetCounter/GetGauge callers)
+    registry_->RemoveByTagFilter({{"instance_id", "inst1"}});
+    ASSERT_EQ(0, registry_->GetSize());
+    auto md = registry_->GetMetricsData("metric1");
+    ASSERT_NE(nullptr, md);
+    ASSERT_EQ(0, md->GetSize());
+
+    // GetNames still includes the name (shell is present)
+    auto names = registry_->GetNames();
+    ASSERT_EQ(1, names.size());
+    ASSERT_EQ("metric1", names[0]);
+
+    // re-creating a metric under the same name reuses the shell
+    auto counter = registry_->GetCounter("metric1", tags);
+    ASSERT_EQ(1, registry_->GetSize());
+    ASSERT_EQ(md, registry_->GetMetricsData("metric1"));
+}
+
+TEST_F(MetricsRegistryTest, TestMetricsRegistryRemoveDetachedHandleStillWorks) {
+    MetricsTags tags{{"instance_id", "inst1"}};
+    auto counter = registry_->GetCounter("metric1", tags);
+    ++counter;
+    ASSERT_EQ(1, counter.Get());
+
+    // remove from registry
+    registry_->Remove("metric1", tags);
+
+    // the handle still works (shared_ptr keeps it alive)
+    ++counter;
+    ASSERT_EQ(2, counter.Get());
+
+    // but it's no longer visible in GetAllMetrics
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    registry_->GetAllMetrics(all);
+    ASSERT_TRUE(all.empty());
+}
+
+TEST_F(MetricsRegistryTest, TestMetricsRegistryRemoveByTagFilterMultiThread) {
+    // populate registry with metrics across two instances
+    for (int i = 0; i < 100; ++i) {
+        registry_->GetCounter("counter." + std::to_string(i), {{"instance_id", "inst1"}});
+        registry_->GetGauge("gauge." + std::to_string(i), {{"instance_id", "inst2"}});
+    }
+    ASSERT_EQ(200, registry_->GetSize());
+
+    // concurrently remove inst1 metrics while reading
+    std::thread remover([this]() { registry_->RemoveByTagFilter({{"instance_id", "inst1"}}); });
+
+    std::thread reader([this]() {
+        std::vector<MetricsRegistry::metrics_tuple_t> all;
+        for (int i = 0; i < 50; ++i) {
+            registry_->GetAllMetrics(all);
+            // size should be somewhere between 100 and 200
+            ASSERT_GE(all.size(), 100);
+            ASSERT_LE(all.size(), 200);
+        }
+    });
+
+    remover.join();
+    reader.join();
+
+    // after removal, only inst2 metrics remain
+    ASSERT_EQ(100, registry_->GetSize());
+
+    // clean up
+    ASSERT_EQ(100, registry_->RemoveByTagFilter({{"instance_id", "inst2"}}));
+    ASSERT_EQ(0, registry_->GetSize());
+}

--- a/kv_cache_manager/service/BUILD
+++ b/kv_cache_manager/service/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "//kv_cache_manager/manager:cache_location_view",
         "//kv_cache_manager/manager:cache_manager",
         "//kv_cache_manager/manager:write_location_manager",
+        "//kv_cache_manager/metrics:metrics_lifecycle",
         "//kv_cache_manager/metrics:metrics_registry",
         "//kv_cache_manager/metrics:metrics_reporter",
         "//kv_cache_manager/metrics:metrics_reporter_factory",
@@ -97,6 +98,7 @@ cc_library(
         "//kv_cache_manager/config:leader_elector_base",
         "//kv_cache_manager/data_storage",
         "//kv_cache_manager/manager:cache_manager",
+        "//kv_cache_manager/metrics:metrics_lifecycle",
         "//kv_cache_manager/service/util:manager_message_proto_util",
         "//kv_cache_manager/service/util:proto_message_json_util",
         "//kv_cache_manager/service/util:service_access_log",
@@ -148,6 +150,7 @@ cc_library(
     deps = [
         "//kv_cache_manager/config",
         "//kv_cache_manager/metrics:metrics_collector",
+        "//kv_cache_manager/metrics:metrics_lifecycle",
         "//kv_cache_manager/service/util:common",
     ],
 )

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/service/admin_service_impl.h"
 
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <variant>
@@ -14,6 +15,8 @@
 #include "kv_cache_manager/config/node_endpoint_info.h"
 #include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/manager/cache_manager.h"
+#include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "kv_cache_manager/metrics/metrics_reporter.h"
 #include "kv_cache_manager/protocol/protobuf/admin_service.pb.h"
@@ -178,6 +181,11 @@ void AdminServiceImpl::RemoveStorage(RequestContext *request_context,
     if (request->storage_unique_name().empty()) {
         CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("RemoveStorage", "storage_unique_name", true);
     }
+    // hold the lifecycle lock as a writer so metric-registration sites
+    // (reporter interval loop) cannot re-create storage-tagged entries
+    // concurrently with the purge below
+    std::unique_lock<std::shared_mutex> lifecycle_guard(cache_manager_->metrics_lifecycle()->mut_);
+
     ErrorCode ec_info = registry_manager_->RemoveStorage(request_context, request->storage_unique_name());
     if (ec_info != EC_OK) {
         status->set_code(proto::admin::INTERNAL_ERROR);
@@ -190,6 +198,11 @@ void AdminServiceImpl::RemoveStorage(RequestContext *request_context,
         request_context->set_status_code(status->code());
         status->set_message("Storage removed successfully");
         KVCM_LOG_INFO("[traceId: %s] RemoveStorage succeeded", request->trace_id().c_str());
+
+        // purge storage-tagged metrics from the registry
+        if (metrics_registry_) {
+            metrics_registry_->RemoveByTagFilter({{"unique_name", request->storage_unique_name()}});
+        }
     }
 };
 
@@ -326,6 +339,12 @@ void AdminServiceImpl::RemoveInstanceGroup(RequestContext *request_context,
     if (request->name().empty()) {
         CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("RemoveInstanceGroup", "name", true);
     }
+    // hold the lifecycle lock as a writer so metric-registration sites
+    // (recorder publish, local reporter loops, MetaServiceMetricsBase
+    // slow path) cannot re-create group-tagged entries concurrently
+    // with the purge below
+    std::unique_lock<std::shared_mutex> lifecycle_guard(cache_manager_->metrics_lifecycle()->mut_);
+
     ErrorCode ec_info = registry_manager_->RemoveInstanceGroup(request_context, request->name());
     if (ec_info != EC_OK) {
         status->set_code(proto::admin::INTERNAL_ERROR);
@@ -338,6 +357,23 @@ void AdminServiceImpl::RemoveInstanceGroup(RequestContext *request_context,
         request_context->set_status_code(status->code());
         status->set_message("Instance group removed successfully");
         KVCM_LOG_INFO("[traceId: %s] RemoveInstanceGroup succeeded", request->trace_id().c_str());
+
+        // contract: caller must drain all instances via RemoveInstance
+        // before invoking this
+        //
+        // RemoveInstanceGroup scope is group config+group-tagged
+        // metrics only; per-instance cleanup is not retried here to
+        // avoid racing with concurrent group re-creates
+
+        // prune the recorder snapshot so the reporter cannot recreate
+        // group-tagged entries on its next cycle
+        if (const auto recorder = cache_manager_->metrics_recorder()) {
+            recorder->RemoveGroup(request->name());
+        }
+        // remove group-tagged metrics from the registry
+        if (metrics_registry_) {
+            metrics_registry_->RemoveByTagFilter({{"instance_group", request->name()}});
+        }
     }
 };
 
@@ -574,6 +610,11 @@ void AdminServiceImpl::RemoveInstance(RequestContext *request_context,
     if (request->instance_id().empty()) {
         CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("RemoveInstance", "instance_id", true);
     }
+    // exclude all metrics-registration sites for the duration of the
+    // removal so InvalidateInstanceMetrics' single tag-filter purge
+    // cannot race with concurrent producers; instance removal is low
+    // frequency, so the wide locking range is acceptable
+    std::unique_lock<std::shared_mutex> lifecycle_guard(cache_manager_->metrics_lifecycle()->mut_);
     ErrorCode ec_info =
         cache_manager_->RemoveInstance(request_context, request->instance_group(), request->instance_id());
     if (ec_info != EC_OK) {

--- a/kv_cache_manager/service/grpc_service/meta_service_grpc.cc
+++ b/kv_cache_manager/service/grpc_service/meta_service_grpc.cc
@@ -15,8 +15,9 @@ namespace kv_cache_manager {
 
 MetaServiceGRpc::MetaServiceGRpc(std::shared_ptr<MetricsRegistry> metrics_registry,
                                  std::shared_ptr<MetaServiceImpl> meta_service_impl,
-                                 std::shared_ptr<RegistryManager> registry_manager)
-    : MetaServiceMetricsBase(std::move(metrics_registry), registry_manager)
+                                 std::shared_ptr<RegistryManager> registry_manager,
+                                 std::shared_ptr<MetricsLifecycle> metrics_lifecycle)
+    : MetaServiceMetricsBase(std::move(metrics_registry), registry_manager, std::move(metrics_lifecycle))
     , meta_service_impl_(std::move(meta_service_impl)) {}
 
 void MetaServiceGRpc::Init() { MetaServiceMetricsBase::InitMetrics(); }

--- a/kv_cache_manager/service/grpc_service/meta_service_grpc.h
+++ b/kv_cache_manager/service/grpc_service/meta_service_grpc.h
@@ -12,12 +12,14 @@ namespace kv_cache_manager {
 
 class MetaServiceImpl;
 class MetricsRegistry;
+struct MetricsLifecycle;
 
 class MetaServiceGRpc final : public proto::meta::MetaService::Service, public MetaServiceMetricsBase {
 public:
     MetaServiceGRpc(std::shared_ptr<MetricsRegistry> metrics_registry,
                     std::shared_ptr<MetaServiceImpl> meta_service_impl,
-                    std::shared_ptr<RegistryManager> registry_manager);
+                    std::shared_ptr<RegistryManager> registry_manager,
+                    std::shared_ptr<MetricsLifecycle> metrics_lifecycle = nullptr);
 
     void Init();
 

--- a/kv_cache_manager/service/http_service/meta_service_http.cc
+++ b/kv_cache_manager/service/http_service/meta_service_http.cc
@@ -17,8 +17,9 @@ namespace kv_cache_manager {
 
 MetaServiceHttp::MetaServiceHttp(std::shared_ptr<MetricsRegistry> metrics_registry,
                                  std::shared_ptr<MetaServiceImpl> meta_service_impl,
-                                 std::shared_ptr<RegistryManager> registry_manager)
-    : MetaServiceMetricsBase(std::move(metrics_registry), registry_manager)
+                                 std::shared_ptr<RegistryManager> registry_manager,
+                                 std::shared_ptr<MetricsLifecycle> metrics_lifecycle)
+    : MetaServiceMetricsBase(std::move(metrics_registry), registry_manager, std::move(metrics_lifecycle))
     , meta_service_impl_(std::move(meta_service_impl)) {}
 
 void MetaServiceHttp::Init() { MetaServiceMetricsBase::InitMetrics(); }

--- a/kv_cache_manager/service/http_service/meta_service_http.h
+++ b/kv_cache_manager/service/http_service/meta_service_http.h
@@ -11,12 +11,14 @@ namespace kv_cache_manager {
 
 class MetaServiceImpl;
 class MetricsRegistry;
+struct MetricsLifecycle;
 
 class MetaServiceHttp : public CoroHttpService, public MetaServiceMetricsBase {
 public:
     MetaServiceHttp(std::shared_ptr<MetricsRegistry> metrics_registry,
                     std::shared_ptr<MetaServiceImpl> meta_service_impl,
-                    std::shared_ptr<RegistryManager> registry_manager);
+                    std::shared_ptr<RegistryManager> registry_manager,
+                    std::shared_ptr<MetricsLifecycle> metrics_lifecycle = nullptr);
 
     void Init() override;
     void RegisterHandler() override;

--- a/kv_cache_manager/service/meta_service_metrics_base.cc
+++ b/kv_cache_manager/service/meta_service_metrics_base.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/service/meta_service_metrics_base.h"
 
 #include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
 #include "kv_cache_manager/service/util/common.h"
 
 #ifndef KVCM_DEFINE_METRICS_COLLECTOR_MAP_METHOD_
@@ -15,6 +16,11 @@
             }                                                                                                          \
         }                                                                                                              \
         {                                                                                                              \
+            /* hold a shared lifecycle lock around the slow path so   */                                               \
+            /* the tagged ServiceMetricsCollector below cannot be     */                                               \
+            /* registered concurrently with a unique-locked           */                                               \
+            /* RemoveInstance / RemoveInstanceGroup tag-filter purge. */                                               \
+            std::shared_lock<std::shared_mutex> lifecycle_guard(metrics_lifecycle_->mut_);                             \
             std::scoped_lock write_guard(mutex_##name##_);                                                             \
                                                                                                                        \
             auto iter = KVCM_METRICS_COLLECTOR_MAP_(name).find(instance_id);                                           \
@@ -22,6 +28,10 @@
                 return iter->second;                                                                                   \
             }                                                                                                          \
                                                                                                                        \
+            /* the GetInstanceGroupName check is independently useful: */                                              \
+            /* it prevents creating collectors for instances that were */                                              \
+            /* never registered, so it stays even though the lifecycle */                                              \
+            /* lock alone would already exclude concurrent removals.   */                                              \
             auto instance_group = registry_manager_->GetInstanceGroupName(instance_id);                                \
             if (instance_group.empty()) {                                                                              \
                 return nullptr;                                                                                        \
@@ -43,8 +53,11 @@
 namespace kv_cache_manager {
 
 MetaServiceMetricsBase::MetaServiceMetricsBase(std::shared_ptr<MetricsRegistry> metrics_registry,
-                                               std::shared_ptr<RegistryManager> registry_manager)
-    : metrics_registry_(std::move(metrics_registry)), registry_manager_(registry_manager) {}
+                                               std::shared_ptr<RegistryManager> registry_manager,
+                                               std::shared_ptr<MetricsLifecycle> metrics_lifecycle)
+    : metrics_registry_(std::move(metrics_registry))
+    , registry_manager_(std::move(registry_manager))
+    , metrics_lifecycle_(metrics_lifecycle ? std::move(metrics_lifecycle) : std::make_shared<MetricsLifecycle>()) {}
 
 void MetaServiceMetricsBase::InitMetrics() {
     MAKE_SERVICE_METRICS_COLLECTOR(RegisterInstance);
@@ -52,6 +65,27 @@ void MetaServiceMetricsBase::InitMetrics() {
     MAKE_SERVICE_METRICS_COLLECTOR(GetClusterInfo);
     // GetClusterInfo 的全局 collector 也预置到 MAP 中，以空 instance_id 为 key
     KVCM_METRICS_COLLECTOR_MAP_(GetClusterInfo)[""] = KVCM_METRICS_COLLECTOR_(GetClusterInfo);
+}
+
+void MetaServiceMetricsBase::InvalidateCollectorCache(const std::string &instance_id) {
+    // guard against empty instance_id which would wipe the global
+    // GetClusterInfo collector seeded at the empty-string key
+    if (instance_id.empty()) {
+        return;
+    }
+
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(GetCacheMeta, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(GetCacheLocation, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(GetCacheLocationsByBackend, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(GetCacheLocationLen, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(StartWriteCache, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(FinishWriteCache, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(RemoveCache, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(TrimCache, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(GetClusterInfo, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(ReportEvent, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(EventBlockAdd, instance_id);
+    KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(EventBlockDelete, instance_id);
 }
 
 KVCM_DEFINE_METRICS_COLLECTOR_MAP_METHOD_(GetCacheMeta);

--- a/kv_cache_manager/service/meta_service_metrics_base.h
+++ b/kv_cache_manager/service/meta_service_metrics_base.h
@@ -25,13 +25,27 @@ private:                                                                        
     std::shared_mutex mutex_##name##_
 #endif
 
+#ifndef KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_
+#define KVCM_INVALIDATE_METRICS_COLLECTOR_MAP_(name, instance_id)                                                      \
+    do {                                                                                                               \
+        std::scoped_lock guard(mutex_##name##_);                                                                       \
+        KVCM_METRICS_COLLECTOR_MAP_(name).erase(instance_id);                                                          \
+    } while (0)
+#endif
+
 class RegistryManager;
+struct MetricsLifecycle;
 
 class MetaServiceMetricsBase {
 public:
     explicit MetaServiceMetricsBase(std::shared_ptr<MetricsRegistry> metrics_registry,
-                                    std::shared_ptr<RegistryManager> registry_manager);
+                                    std::shared_ptr<RegistryManager> registry_manager,
+                                    std::shared_ptr<MetricsLifecycle> metrics_lifecycle = nullptr);
     void InitMetrics();
+
+    // evict cached per-instance collectors so that purged registry
+    // entries cannot be resurrected by stale handles
+    void InvalidateCollectorCache(const std::string &instance_id);
 
     KVCM_DECLARE_METRICS_COLLECTOR_MAP_METHOD_(GetCacheMeta);
     KVCM_DECLARE_METRICS_COLLECTOR_MAP_METHOD_(GetCacheLocation);
@@ -66,6 +80,11 @@ protected:
 private:
     std::shared_ptr<MetricsRegistry> metrics_registry_;
     std::shared_ptr<RegistryManager> registry_manager_;
+    // shared coarse-grained lock that excludes RemoveInstance /
+    // RemoveInstanceGroup; held in shared mode while the slow-path
+    // macro creates a new ServiceMetricsCollector so that the new
+    // tagged entry cannot be registered concurrently with a purge
+    std::shared_ptr<MetricsLifecycle> metrics_lifecycle_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -14,6 +14,7 @@
 #include "kv_cache_manager/event/log_event_publisher.h"
 #include "kv_cache_manager/manager/cache_manager.h"
 #include "kv_cache_manager/manager/startup_config_loader.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "kv_cache_manager/metrics/metrics_reporter.h"
 #include "kv_cache_manager/metrics/metrics_reporter_factory.h"
@@ -34,6 +35,10 @@ bool Server::Init(const ServerConfig &config) {
     KVCM_LOG_INFO("begin server init...\n");
 
     metrics_registry_ = std::make_shared<MetricsRegistry>();
+    // single shared lifecycle handle: producers hold it as a reader
+    // around metric registration; AdminServiceImpl::RemoveInstance and
+    // RemoveInstanceGroup hold it as a writer for the entire removal
+    metrics_lifecycle_ = std::make_shared<MetricsLifecycle>();
 
     config_ = config;
 
@@ -45,7 +50,7 @@ bool Server::Init(const ServerConfig &config) {
     registry_manager_.reset(new RegistryManager(registry_storage_uri, metrics_registry_));
     registry_manager_->Init();
 
-    cache_manager_.reset(new CacheManager(metrics_registry_, registry_manager_));
+    cache_manager_.reset(new CacheManager(metrics_registry_, registry_manager_, metrics_lifecycle_));
     cache_manager_->Init(config_.GetSchedulePlanExecutorThreadCount(),
                          config_.GetCacheReclaimerKeySamplingSizeTotal(),
                          config_.GetCacheReclaimerKeySamplingSizePerTask(),
@@ -133,6 +138,24 @@ bool Server::Start() {
         KVCM_LOG_ERROR("init http server failed");
         return false;
     }
+
+    // wire up instance-removal callback: invalidate per-instance
+    // collector caches on both gRPC and HTTP meta services
+    // registered before leader election so no RemoveInstance can arrive
+    // before the callback is in place (API_CALL_GUARD rejects requests
+    // when not leader)
+    std::weak_ptr<MetaServiceGRpc> grpc_weak = meta_service_;
+    std::weak_ptr<MetaServiceHttp> http_weak = meta_http_service_;
+    cache_manager_->SetOnInstanceRemoved(
+        [grpc_weak = std::move(grpc_weak), http_weak = std::move(http_weak)](const std::string &instance_id) {
+            if (const auto grpc = grpc_weak.lock()) {
+                grpc->InvalidateCollectorCache(instance_id);
+            }
+            if (const auto http = http_weak.lock()) {
+                http->InvalidateCollectorCache(instance_id);
+            }
+        });
+
     if (!leader_elector_->Start()) {
         KVCM_LOG_ERROR("leader_elector start failed");
         return false;
@@ -169,7 +192,7 @@ bool Server::StartRpcServer() {
     // grpc::EnableDefaultHealthCheckService(true);
     // grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 
-    meta_service_.reset(new MetaServiceGRpc(metrics_registry_, meta_impl_, registry_manager_));
+    meta_service_.reset(new MetaServiceGRpc(metrics_registry_, meta_impl_, registry_manager_, metrics_lifecycle_));
     admin_service_.reset(new AdminServiceGRpc(metrics_registry_, admin_impl_));
     debug_service_.reset(new DebugServiceGRpc(metrics_registry_, debug_impl_));
 
@@ -227,7 +250,8 @@ bool Server::StartHttpServer() {
                                                               : std::thread::hardware_concurrency();
     KVCM_LOG_INFO("HTTP server io_thread_num=%zu (configured=%d)", io_thread_num, configured_io_thread_num);
 
-    meta_http_service_ = std::make_shared<MetaServiceHttp>(metrics_registry_, meta_impl_, registry_manager_);
+    meta_http_service_ =
+        std::make_shared<MetaServiceHttp>(metrics_registry_, meta_impl_, registry_manager_, metrics_lifecycle_);
     admin_http_service_ = std::make_shared<AdminServiceHttp>(
         metrics_registry_, admin_impl_, config_.enable_prometheus(), config_.prometheus_prefix());
     debug_http_service_ = std::make_shared<DebugServiceHttp>(metrics_registry_, debug_impl_);

--- a/kv_cache_manager/service/server.h
+++ b/kv_cache_manager/service/server.h
@@ -29,6 +29,7 @@ class DebugServiceHttp;
 class MetricsRegistry;
 class MetricsReporter;
 class MetricsReporterFactory;
+struct MetricsLifecycle;
 class LoopThread;
 
 class Server {
@@ -78,6 +79,7 @@ private:
     std::shared_ptr<CacheManager> cache_manager_;
 
     std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::shared_ptr<MetricsLifecycle> metrics_lifecycle_;
     std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory_;
     std::shared_ptr<MetricsReporter> metrics_reporter_;
     std::shared_ptr<LoopThread> metrics_report_thread_;

--- a/kv_cache_manager/service/test/BUILD
+++ b/kv_cache_manager/service/test/BUILD
@@ -1,6 +1,21 @@
 package(default_visibility = ["//visibility:private"])
 
 cc_test(
+    name = "MetaServiceMetricsBaseTest",
+    srcs = [
+        "meta_service_metrics_base_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/config",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/service:meta_service_metrics_base",
+    ],
+)
+
+cc_test(
     name = "CommandLineTest",
     srcs = [
         "command_line_test.cc",
@@ -25,5 +40,39 @@ cc_test(
     deps = [
         "//kv_cache_manager/common:unittest",
         "//kv_cache_manager/service",
+    ],
+)
+
+cc_test(
+    name = "AdminServiceRemoveInstanceGroupTest",
+    srcs = [
+        "admin_service_remove_instance_group_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/config",
+        "//kv_cache_manager/manager:cache_manager",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/service:admin_service_impl",
+    ],
+)
+
+cc_test(
+    name = "AdminServiceRemoveStorageTest",
+    srcs = [
+        "admin_service_remove_storage_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/config",
+        "//kv_cache_manager/data_storage",
+        "//kv_cache_manager/manager:cache_manager",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/metrics:metrics_reporter",
+        "//kv_cache_manager/service:admin_service_impl",
     ],
 )

--- a/kv_cache_manager/service/test/admin_service_remove_instance_group_test.cc
+++ b/kv_cache_manager/service/test/admin_service_remove_instance_group_test.cc
@@ -1,0 +1,138 @@
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/instance_group.h"
+#include "kv_cache_manager/config/instance_info.h"
+#include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/manager/cache_manager.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/service/admin_service_impl.h"
+
+using namespace kv_cache_manager;
+
+class AdminServiceRemoveInstanceGroupTest : public TESTBASE {
+public:
+    void SetUp() override {
+        metrics_registry_ = std::make_shared<MetricsRegistry>();
+        auto rm_registry = std::make_shared<MetricsRegistry>();
+        registry_manager_ = std::make_shared<RegistryManager>("local://", rm_registry);
+        registry_manager_->Init();
+
+        cache_manager_ = std::make_shared<CacheManager>(metrics_registry_, registry_manager_);
+
+        admin_service_ =
+            std::make_unique<AdminServiceImpl>(cache_manager_, nullptr, metrics_registry_, registry_manager_, nullptr);
+        // explicitly enable leader-only requests so this test does not
+        // silently depend on the default in ServiceImplBase
+        admin_service_->EnableLeaderOnlyRequests();
+    }
+
+    void SeedInstanceGroup(const std::string &group_name) {
+        RequestContext rc("seed-" + group_name);
+        InstanceGroup ig;
+        ig.set_name(group_name);
+        auto ec = registry_manager_->CreateInstanceGroup(&rc, ig);
+        ASSERT_EQ(EC_OK, ec);
+    }
+
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::shared_ptr<RegistryManager> registry_manager_;
+    std::shared_ptr<CacheManager> cache_manager_;
+    std::unique_ptr<AdminServiceImpl> admin_service_;
+};
+
+TEST_F(AdminServiceRemoveInstanceGroupTest, PurgesGroupTaggedMetrics) {
+    SeedInstanceGroup("grp1");
+
+    // seed metrics: group-tagged and unrelated
+    metrics_registry_->GetGauge("g1", {{"instance_group", "grp1"}});
+    metrics_registry_->GetGauge("g2", {{"instance_group", "grp1"}});
+    metrics_registry_->GetCounter("m1", {{"instance_id", "other"}});
+    ASSERT_EQ(3, metrics_registry_->GetSize());
+
+    RequestContext rc("test-trace");
+    proto::admin::RemoveInstanceGroupRequest request;
+    request.set_name("grp1");
+    proto::admin::CommonResponse response;
+    admin_service_->RemoveInstanceGroup(&rc, &request, &response);
+
+    ASSERT_EQ(proto::admin::OK, response.header().status().code());
+
+    // group-tagged metrics should be purged; only "other" remains
+    ASSERT_EQ(1, metrics_registry_->GetSize());
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    metrics_registry_->GetAllMetrics(all);
+    ASSERT_EQ(1, all.size());
+    auto &[name, tags, _] = all[0];
+    ASSERT_EQ("other", tags.at("instance_id"));
+}
+
+TEST_F(AdminServiceRemoveInstanceGroupTest, EmptyGroupStillSucceeds) {
+    SeedInstanceGroup("empty_grp");
+
+    // seed metrics: one tagged with the group being removed, one unrelated
+    metrics_registry_->GetGauge("g1", {{"instance_group", "empty_grp"}});
+    metrics_registry_->GetCounter("m1", {{"instance_id", "other"}});
+    ASSERT_EQ(2, metrics_registry_->GetSize());
+
+    RequestContext rc("test-trace");
+    proto::admin::RemoveInstanceGroupRequest request;
+    request.set_name("empty_grp");
+    proto::admin::CommonResponse response;
+    admin_service_->RemoveInstanceGroup(&rc, &request, &response);
+
+    ASSERT_EQ(proto::admin::OK, response.header().status().code());
+    // instance_group-tagged metric should be purged
+    ASSERT_EQ(1, metrics_registry_->GetSize());
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    metrics_registry_->GetAllMetrics(all);
+    ASSERT_EQ(1, all.size());
+    auto &[name, tags, _] = all[0];
+    ASSERT_EQ("other", tags.at("instance_id"));
+}
+
+// documents the contract-violation behavior: caller is responsible
+// for draining instances before removing the group
+TEST_F(AdminServiceRemoveInstanceGroupTest, RemoveInstanceGroupWithRegisteredInstancesLeavesInstancesIntact) {
+    SeedInstanceGroup("grp1");
+
+    // seed an instance directly into the registry (bypasses full
+    // RegisterInstance flow; sufficient to test removal semantics)
+    auto info = std::make_shared<InstanceInfo>();
+    info->set_instance_id("inst1");
+    info->set_instance_group_name("grp1");
+    registry_manager_->instance_infos_["inst1"] = info;
+
+    // seed group-tagged and instance-tagged metrics
+    metrics_registry_->GetGauge("group_metric", {{"instance_group", "grp1"}});
+    metrics_registry_->GetGauge("inst_metric", {{"instance_id", "inst1"}});
+    ASSERT_EQ(2, metrics_registry_->GetSize());
+
+    RequestContext rc("test-trace");
+    proto::admin::RemoveInstanceGroupRequest request;
+    request.set_name("grp1");
+    proto::admin::CommonResponse response;
+    admin_service_->RemoveInstanceGroup(&rc, &request, &response);
+
+    ASSERT_EQ(proto::admin::OK, response.header().status().code());
+
+    // group config is gone
+    RequestContext rc2("verify");
+    auto [ec, _ig] = registry_manager_->GetInstanceGroup(&rc2, "grp1");
+    ASSERT_NE(EC_OK, ec);
+
+    // group-tagged metrics are purged, but instance-tagged metrics remain
+    ASSERT_EQ(1, metrics_registry_->GetSize());
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    metrics_registry_->GetAllMetrics(all);
+    ASSERT_EQ(1, all.size());
+    auto &[name, tags, metric] = all[0];
+    ASSERT_EQ("inst1", tags.at("instance_id"));
+
+    // instance record still present in registry
+    ASSERT_NE(registry_manager_->instance_infos_.end(), registry_manager_->instance_infos_.find("inst1"));
+}

--- a/kv_cache_manager/service/test/admin_service_remove_storage_test.cc
+++ b/kv_cache_manager/service/test/admin_service_remove_storage_test.cc
@@ -1,0 +1,186 @@
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
+#include "kv_cache_manager/manager/cache_manager.h"
+#include "kv_cache_manager/metrics/local_metrics_reporter.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/service/admin_service_impl.h"
+
+using namespace kv_cache_manager;
+
+class AdminServiceRemoveStorageTest : public TESTBASE {
+public:
+    void SetUp() override {
+        metrics_registry_ = std::make_shared<MetricsRegistry>();
+        auto rm_registry = std::make_shared<MetricsRegistry>();
+        registry_manager_ = std::make_shared<RegistryManager>("local://", rm_registry);
+        registry_manager_->Init();
+
+        cache_manager_ = std::make_shared<CacheManager>(metrics_registry_, registry_manager_);
+
+        admin_service_ =
+            std::make_unique<AdminServiceImpl>(cache_manager_, nullptr, metrics_registry_, registry_manager_, nullptr);
+        admin_service_->EnableLeaderOnlyRequests();
+    }
+
+    void SeedStorage(const std::string &unique_name) {
+        auto spec = std::make_shared<DummyStorageSpec>();
+        spec->set_root_path("/tmp/test_" + unique_name);
+        StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_DUMMY, unique_name, spec);
+
+        RequestContext rc("seed-" + unique_name);
+        auto ec = registry_manager_->AddStorage(&rc, config);
+        ASSERT_EQ(EC_OK, ec);
+    }
+
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::shared_ptr<RegistryManager> registry_manager_;
+    std::shared_ptr<CacheManager> cache_manager_;
+    std::unique_ptr<AdminServiceImpl> admin_service_;
+};
+
+TEST_F(AdminServiceRemoveStorageTest, PurgesUniqueNameTaggedMetrics) {
+    SeedStorage("store1");
+
+    // seed metrics: storage-tagged and unrelated
+    metrics_registry_->GetGauge("data_storage.healthy_status", {{"unique_name", "store1"}, {"type", "DUMMY"}});
+    metrics_registry_->GetGauge("data_storage.storage_usage_ratio", {{"unique_name", "store1"}, {"type", "DUMMY"}});
+    metrics_registry_->GetCounter("m1", {{"instance_id", "other"}});
+    ASSERT_EQ(3, metrics_registry_->GetSize());
+
+    RequestContext rc("test-trace");
+    proto::admin::RemoveStorageRequest request;
+    request.set_storage_unique_name("store1");
+    proto::admin::CommonResponse response;
+    admin_service_->RemoveStorage(&rc, &request, &response);
+
+    ASSERT_EQ(proto::admin::OK, response.header().status().code());
+
+    // storage-tagged metrics should be purged; only "other" remains
+    ASSERT_EQ(1, metrics_registry_->GetSize());
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    metrics_registry_->GetAllMetrics(all);
+    ASSERT_EQ(1, all.size());
+    auto &[name, tags, _] = all[0];
+    ASSERT_EQ("other", tags.at("instance_id"));
+}
+
+TEST_F(AdminServiceRemoveStorageTest, RemoveNonexistentStorageReturnsError) {
+    // no storage seeded — removal should fail
+    RequestContext rc("test-trace");
+    proto::admin::RemoveStorageRequest request;
+    request.set_storage_unique_name("nonexistent");
+    proto::admin::CommonResponse response;
+    admin_service_->RemoveStorage(&rc, &request, &response);
+
+    ASSERT_EQ(proto::admin::INTERNAL_ERROR, response.header().status().code());
+}
+
+TEST_F(AdminServiceRemoveStorageTest, PurgesOnlyTargetedStorageMetrics) {
+    SeedStorage("store1");
+    SeedStorage("store2");
+
+    // seed metrics tagged with different storage names
+    metrics_registry_->GetGauge("data_storage.healthy_status", {{"unique_name", "store1"}, {"type", "DUMMY"}});
+    metrics_registry_->GetGauge("data_storage.storage_usage_ratio", {{"unique_name", "store1"}, {"type", "DUMMY"}});
+    metrics_registry_->GetGauge("data_storage.healthy_status", {{"unique_name", "store2"}, {"type", "DUMMY"}});
+    ASSERT_EQ(3, metrics_registry_->GetSize());
+
+    RequestContext rc("test-trace");
+    proto::admin::RemoveStorageRequest request;
+    request.set_storage_unique_name("store1");
+    proto::admin::CommonResponse response;
+    admin_service_->RemoveStorage(&rc, &request, &response);
+
+    ASSERT_EQ(proto::admin::OK, response.header().status().code());
+
+    // only store2 metrics remain
+    ASSERT_EQ(1, metrics_registry_->GetSize());
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    metrics_registry_->GetAllMetrics(all);
+    ASSERT_EQ(1, all.size());
+    auto &[name, tags, _] = all[0];
+    ASSERT_EQ("store2", tags.at("unique_name"));
+}
+
+// race ReportInterval (reader: shared lifecycle lock) against
+// RemoveStorage (writer: unique lifecycle lock) to validate the
+// lifecycle lock under contention; mirrors the pattern used for
+// instance/group removal concurrency tests
+TEST_F(AdminServiceRemoveStorageTest, ConcurrentReportIntervalAndRemoveStorageIsSafe) {
+    constexpr int kStorageCount = 20;
+    std::vector<std::string> storage_names;
+    storage_names.reserve(kStorageCount);
+    for (int i = 0; i < kStorageCount; ++i) {
+        const auto name = "store_race_" + std::to_string(i);
+        SeedStorage(name);
+        storage_names.emplace_back(name);
+    }
+    // a sentinel that must survive the race
+    SeedStorage("store_keeper");
+
+    auto reporter = std::make_unique<LocalMetricsReporter>();
+    ASSERT_TRUE(reporter->Init(cache_manager_, metrics_registry_, ""));
+
+    std::atomic_bool reporter_stop{false};
+
+    // reader: continuously publish metrics through the reporter; this
+    // exercises the shared lifecycle lock around the data storage
+    // section that creates DataStorageIntervalMetricsCollector entries
+    std::thread reader([&]() {
+        while (!reporter_stop.load(std::memory_order_relaxed)) {
+            reporter->ReportInterval();
+        }
+    });
+
+    // writer: remove every targeted storage; each removal acquires the
+    // unique lifecycle lock and runs RemoveByTagFilter
+    std::thread writer([&]() {
+        for (const auto &name : storage_names) {
+            RequestContext rc("race-" + name);
+            proto::admin::RemoveStorageRequest request;
+            request.set_storage_unique_name(name);
+            proto::admin::CommonResponse response;
+            admin_service_->RemoveStorage(&rc, &request, &response);
+            ASSERT_EQ(proto::admin::OK, response.header().status().code());
+        }
+    });
+
+    writer.join();
+    reporter_stop.store(true, std::memory_order_relaxed);
+    reader.join();
+
+    // one final report to flush any pending interval metrics
+    reporter->ReportInterval();
+
+    // none of the removed storages should have any tagged metrics left
+    for (const auto &name : storage_names) {
+        std::vector<MetricsRegistry::metrics_tuple_t> all;
+        metrics_registry_->GetAllMetrics(all);
+        for (const auto &[metric_name, tags, _] : all) {
+            auto it = tags.find("unique_name");
+            ASSERT_TRUE(it == tags.end() || it->second != name)
+                << "leaked metric for removed storage: " << name << " in metric: " << metric_name;
+        }
+    }
+
+    // the sentinel storage's interval metrics should still be present
+    std::vector<MetricsRegistry::metrics_tuple_t> all;
+    metrics_registry_->GetAllMetrics(all);
+    bool keeper_seen = false;
+    for (const auto &[metric_name, tags, _] : all) {
+        auto it = tags.find("unique_name");
+        if (it != tags.end() && it->second == "store_keeper") {
+            keeper_seen = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(keeper_seen);
+}

--- a/kv_cache_manager/service/test/meta_service_metrics_base_test.cc
+++ b/kv_cache_manager/service/test/meta_service_metrics_base_test.cc
@@ -1,0 +1,176 @@
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/instance_info.h"
+#include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/service/meta_service_metrics_base.h"
+
+using namespace kv_cache_manager;
+
+class MetaServiceMetricsBaseTest : public TESTBASE {
+public:
+    void SetUp() override {
+        metrics_registry_ = std::make_shared<MetricsRegistry>();
+        registry_manager_ = std::make_shared<RegistryManager>("local://", metrics_registry_);
+        registry_manager_->Init();
+
+        base_ = std::make_unique<MetaServiceMetricsBase>(metrics_registry_, registry_manager_);
+        base_->InitMetrics();
+    }
+
+    // helper: seed a fake instance into registry_manager_ so that
+    // GetInstanceGroupName returns the group name for the getter
+    void SeedInstance(const std::string &instance_id, const std::string &group_name) {
+        auto info = std::make_shared<InstanceInfo>();
+        info->set_instance_id(instance_id);
+        info->set_instance_group_name(group_name);
+        registry_manager_->instance_infos_[instance_id] = info;
+    }
+
+    void RemoveInstance(const std::string &instance_id) { registry_manager_->instance_infos_.erase(instance_id); }
+
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::shared_ptr<RegistryManager> registry_manager_;
+    std::unique_ptr<MetaServiceMetricsBase> base_;
+};
+
+TEST_F(MetaServiceMetricsBaseTest, InvalidateCollectorCacheEmptyIdIsNoOp) {
+    // the global GetClusterInfo collector is seeded at empty key
+    auto collector = base_->get_metrics_collector_from_map_for_GetClusterInfo("");
+    ASSERT_NE(nullptr, collector);
+
+    base_->InvalidateCollectorCache("");
+
+    // still accessible — empty id guard prevented erasure
+    auto after = base_->get_metrics_collector_from_map_for_GetClusterInfo("");
+    ASSERT_NE(nullptr, after);
+    ASSERT_EQ(collector, after);
+}
+
+TEST_F(MetaServiceMetricsBaseTest, InvalidateCollectorCacheRemovesEntry) {
+    SeedInstance("inst1", "grp1");
+
+    // create collector via getter (slow path)
+    auto collector = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    ASSERT_NE(nullptr, collector);
+
+    // verify cached (fast path returns same pointer)
+    auto cached = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    ASSERT_EQ(collector, cached);
+
+    // invalidate
+    base_->InvalidateCollectorCache("inst1");
+
+    // since instance still exists, getter recreates a new collector
+    auto recreated = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    ASSERT_NE(nullptr, recreated);
+    ASSERT_NE(collector, recreated);
+}
+
+TEST_F(MetaServiceMetricsBaseTest, InvalidateCollectorCacheAllMaps) {
+    SeedInstance("inst1", "grp1");
+
+    // populate collectors in multiple API maps
+    auto c1 = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    auto c2 = base_->get_metrics_collector_from_map_for_GetCacheLocation("inst1");
+    auto c3 = base_->get_metrics_collector_from_map_for_StartWriteCache("inst1");
+    auto c4 = base_->get_metrics_collector_from_map_for_FinishWriteCache("inst1");
+    auto c5 = base_->get_metrics_collector_from_map_for_RemoveCache("inst1");
+    auto c6 = base_->get_metrics_collector_from_map_for_TrimCache("inst1");
+    ASSERT_NE(nullptr, c1);
+    ASSERT_NE(nullptr, c2);
+    ASSERT_NE(nullptr, c3);
+    ASSERT_NE(nullptr, c4);
+    ASSERT_NE(nullptr, c5);
+    ASSERT_NE(nullptr, c6);
+
+    // invalidate
+    base_->InvalidateCollectorCache("inst1");
+
+    // all maps produce new (different) collectors
+    ASSERT_NE(c1, base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1"));
+    ASSERT_NE(c2, base_->get_metrics_collector_from_map_for_GetCacheLocation("inst1"));
+    ASSERT_NE(c3, base_->get_metrics_collector_from_map_for_StartWriteCache("inst1"));
+    ASSERT_NE(c4, base_->get_metrics_collector_from_map_for_FinishWriteCache("inst1"));
+    ASSERT_NE(c5, base_->get_metrics_collector_from_map_for_RemoveCache("inst1"));
+    ASSERT_NE(c6, base_->get_metrics_collector_from_map_for_TrimCache("inst1"));
+}
+
+TEST_F(MetaServiceMetricsBaseTest, InvalidateAfterRemovalPreventsRecreation) {
+    SeedInstance("inst1", "grp1");
+
+    // create collector
+    auto collector = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    ASSERT_NE(nullptr, collector);
+
+    // remove instance from registry
+    RemoveInstance("inst1");
+
+    // invalidate
+    base_->InvalidateCollectorCache("inst1");
+
+    // getter returns nullptr since instance no longer exists
+    auto after = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    ASSERT_EQ(nullptr, after);
+}
+
+TEST_F(MetaServiceMetricsBaseTest, InvalidateDoesNotAffectOtherInstances) {
+    SeedInstance("inst1", "grp1");
+    SeedInstance("inst2", "grp1");
+
+    auto c1 = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    auto c2 = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst2");
+    ASSERT_NE(nullptr, c1);
+    ASSERT_NE(nullptr, c2);
+
+    // invalidate only inst1
+    base_->InvalidateCollectorCache("inst1");
+
+    // inst2 still cached
+    auto c2_after = base_->get_metrics_collector_from_map_for_GetCacheMeta("inst2");
+    ASSERT_EQ(c2, c2_after);
+}
+
+TEST_F(MetaServiceMetricsBaseTest, SlowPathCollectorCreationRacesWithRemoval) {
+    auto lifecycle = std::make_shared<MetricsLifecycle>();
+    auto base = std::make_unique<MetaServiceMetricsBase>(metrics_registry_, registry_manager_, lifecycle);
+    base->InitMetrics();
+
+    SeedInstance("inst1", "grp1");
+
+    constexpr int kIterations = 200;
+
+    // writer: simulates RemoveInstance path — takes unique lock,
+    // invalidates cache, removes metrics by tag filter
+    std::thread writer([&]() {
+        for (int i = 0; i < kIterations; ++i) {
+            std::unique_lock<std::shared_mutex> guard(lifecycle->mut_);
+            base->InvalidateCollectorCache("inst1");
+            metrics_registry_->RemoveByTagFilter({{"instance_id", "inst1"}});
+        }
+    });
+
+    // reader: simulates the slow-path getter which internally takes
+    // shared lock on lifecycle->mu
+    std::thread reader([&]() {
+        for (int i = 0; i < kIterations; ++i) {
+            auto collector = base->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+            // collector may be non-null (created) or null (if the writer
+            // raced and removed the instance from the registry); both are
+            // valid outcomes — we only care about no crashes / no data
+            // races
+            (void)collector;
+        }
+    });
+
+    writer.join();
+    reader.join();
+
+    // instance still seeded, so a final get should succeed
+    auto final_collector = base->get_metrics_collector_from_map_for_GetCacheMeta("inst1");
+    ASSERT_NE(nullptr, final_collector);
+}


### PR DESCRIPTION
## Summary

When an instance, instance group, or data storage backend is removed, its metrics entries and per-instance collector caches were left behind, causing unbounded growth in the `MetricsRegistry` and detached collector handle accumulation.

This PR adds full metrics lifecycle management so that removal of any entity (`RemoveInstance`, `RemoveInstanceGroup`, `RemoveStorage`) atomically purges all associated registry entries and cached collector handles, preventing metric leaks.

## Changes

### Metrics Registry – targeted deletion API
- **`MetricsData::Remove(tags)`** / **`MetricsData::RemoveByTagFilter(filter)`** – erase a single entry by exact tags or bulk-erase all entries whose tags are a superset of a filter.
- **`MetricsRegistry::Remove(name, tags)`** / **`MetricsRegistry::RemoveByTagFilter(filter)`** – top-level wrappers that iterate all metric names.

### CacheManager – instance metrics invalidation
- **`CacheManager::InvalidateInstanceMetrics(instance_id)`** – orchestrates a three-step purge:
  1. Prunes the `CacheManagerMetricsRecorder` snapshot (prevents reporter from re-creating entries).
  2. Calls `RemoveByTagFilter({"instance_id", id})` on the registry.
  3. Invokes the `OnInstanceRemoved` callback to evict cached collector handles.
- **`SetOnInstanceRemoved(fn)`** – registers the callback wired by `Server` at startup.

### MetaServiceMetricsBase – collector cache eviction
- **`InvalidateCollectorCache(instance_id)`** – erases the per-instance `ServiceMetricsCollector` handle from all API method maps (GetCacheMeta, GetCacheLocation, StartWriteCache, etc.) so that purged registry entries cannot be resurrected by stale handles.
- **Slow-path lifecycle guard** – the macro that creates new `ServiceMetricsCollector` instances now holds a `shared_lock` on `MetricsLifecycle`, preventing registration from racing with a concurrent purge.

### MetricsLifecycle – coarse-grained read/write coordination
- New `MetricsLifecycle` struct wrapping a single `std::shared_mutex`.
- **Producers** (recorder publish, reporter `ReportInterval`, `MetaServiceMetricsBase` slow path) hold a **shared lock**.
- **Lifecycle removals** (`AdminServiceImpl::RemoveInstance`, `RemoveInstanceGroup`, `RemoveStorage`) hold a **unique lock** for the entire operation.
- Removals are very low-frequency, so a single coarse-grained lock eliminates the race interleaving without deferred cleanup or double-purge logic.

### Server wiring
- `Server::Init` creates and shares `MetricsLifecycle` with `CacheManager`, `MetaServiceGRpc`, and `MetaServiceHttp`.
- `Server::Start` registers the `OnInstanceRemoved` callback that invalidates both gRPC and HTTP meta service collector caches (via weak_ptr to avoid preventing shutdown).

### AdminServiceImpl – removal paths
- **`RemoveInstance`** – acquires a unique lifecycle lock, calls `CacheManager::RemoveInstance` (which calls `InvalidateInstanceMetrics` internally).
- **`RemoveInstanceGroup`** – acquires a unique lifecycle lock, removes the group config, prunes the recorder snapshot via `RemoveGroup(name)`, then bulk-purges `{"instance_group", name}` tagged metrics.
- **`RemoveStorage`** – acquires a unique lifecycle lock, removes the storage, then bulk-purges `{"unique_name", storage_unique_name}` tagged metrics.

## Design Decisions

### Why `RemoveInstanceGroup` does NOT enumerate and remove per-instance metrics

The same goes for `RemoveInstance`, `RemoveInstanceGroup`, `RemoveStorage`.

The current contract is: **the caller must drain all instances via individual `RemoveInstance` calls before invoking `RemoveInstanceGroup`**. This is an issue, and is intentionally left to a more generic solution for the admin path operations synchronization.The group-removal path only handles its own scope (group config + group-tagged metrics). This avoids a TOCTOU race where a concurrent `RegisterInstance` could insert a new instance between `ListInstanceInfo` and the cleanup loop, causing the newly-created instance to be incorrectly deleted. Keeping the scope narrow makes the operation safe without holding a write lock across an unbounded instance-enumeration loop.

### Why a single coarse-grained `shared_mutex` instead of fine-grained locks

Instance/group/storage removal is a rare administrative operation (seconds or minutes between calls). A single wide lock is simple to reason about and eliminates all race interleavings between tag-filter purge and concurrent registration — no deferred two-generation pending sets, no double-purge passes, no liveness re-checks needed.

## Test Plan

- [x] `metrics_registry_test.cc` – unit tests for `Remove`, `RemoveByTagFilter`, and a multi-threaded stress test (`TestMetricsRegistryRemoveByTagFilterMultiThread`).
- [x] `cache_manager_metrics_recorder_test.cc` – tests for `RemoveGroup`, `RemoveInstance`, cross-group removal, and no-op on absent group.
- [x] `cache_manager_test.cc` – integration test for `InvalidateInstanceMetrics` end-to-end purge flow.
- [x] `meta_service_metrics_base_test.cc` – tests `InvalidateCollectorCache` eviction and `SlowPathCollectorCreationRacesWithRemoval` concurrency test (200 iterations racing reader vs writer).
- [x] `admin_service_remove_instance_group_test.cc` – verifies group-tagged metrics are purged and documents the contract that removing a group with registered instances leaves instance records intact.
- [x] `admin_service_remove_storage_test.cc` – `ConcurrentReportIntervalAndRemoveStorageIsSafe` multi-threaded test racing `ReportInterval` against 20 concurrent `RemoveStorage` calls.
- [x] `local_metrics_reporter_test.cc` – updated to pass `MetricsLifecycle` through construction.