### PR TITLE
[service] tolerate acceptable error in recovery

### DIFF
--- a/integration_test/admin_service/BUILD
+++ b/integration_test/admin_service/BUILD
@@ -43,3 +43,18 @@ py_test(
         "@pip_cpu//protobuf",
     ],
 )
+
+py_test(
+    name = "recover_test",
+    srcs = ["recover_test.py"],
+    data = [
+        "//kv_cache_manager:kv_cache_manager_bin",
+    ],
+    tags = ["no-remote-exec"],
+    deps = [
+        ":http_interface_test",
+        "//integration_test/testlib:test_base",
+        "//integration_test/meta_service:http_interface_test",
+        "@pip_cpu//requests",
+    ],
+)

--- a/integration_test/admin_service/recover_test.py
+++ b/integration_test/admin_service/recover_test.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+
+"""Integration test for server recover fault tolerance.
+
+Scenario:
+1. Start server with local registry persistence enabled.
+2. Add storage, instance group, and register instance_01; write+read a block.
+3. Stop server, corrupt the persisted registry file (only instance_01).
+4. Restart server — it should start successfully despite the corrupted data.
+5. Register a new instance_02; write+read a block on instance_02 (proves service is usable).
+6. Stop server, fix instance_01 in the persisted registry file (preserve instance_02).
+7. Restart server — all data is correct, both instances should work immediately.
+"""
+
+import json
+import logging
+import os
+import unittest
+from typing import Dict
+
+from integration_test.admin_service.http_interface_test import AdminServiceHttpClient
+from integration_test.meta_service.http_interface_test import MetaServiceHttpClient
+from integration_test.testlib.test_base import TestBase
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+class RecoverFaultToleranceTest(TestBase, unittest.TestCase):
+
+    def setUp(self):
+        self.clean_workdir()
+        self.prepare_test_resource(1)
+        self._registry_path = os.path.join(self.get_workdir(), "registry_data.json")
+        self._start_server_with_persistence()
+        self._admin_client, self._meta_client = self._connect_clients()
+        self._trace_id = "recover_itest"
+        self._storage_name = "recover_storage_01"
+        self._instance_group_name = "recover_group_01"
+        self._resp_dict = {}
+
+    def tearDown(self):
+        self._admin_client.close()
+        self._meta_client.close()
+        self.cleanup()
+
+    def _start_server_with_persistence(self, **extra_kwargs):
+        kwargs = {
+            "kvcm.registry_storage.uri": f"local://{self._registry_path}",
+        }
+        kwargs.update(extra_kwargs)
+        self.assertTrue(self.worker_manager.start_all(**kwargs))
+
+    def _restart_server(self, **extra_kwargs):
+        self.worker_manager.stop_worker(0)
+        kwargs = {
+            "kvcm.registry_storage.uri": f"local://{self._registry_path}",
+        }
+        kwargs.update(extra_kwargs)
+        self.assertTrue(self.worker_manager.start_worker(0, **kwargs))
+        self._admin_client.close()
+        self._meta_client.close()
+        self._admin_client, self._meta_client = self._connect_clients()
+
+    def _connect_clients(self):
+        admin_http_port = self.worker_manager.get_worker(0).env.admin_http_port
+        http_port = self.worker_manager.get_worker(0).env.http_port
+        admin_url = f"http://localhost:{admin_http_port}"
+        meta_url = f"http://localhost:{http_port}"
+        logging.info(f"connecting: admin={admin_url}, meta={meta_url}")
+        return AdminServiceHttpClient(admin_url), MetaServiceHttpClient(meta_url)
+
+    def test_recover_with_corrupted_registry(self):
+        """Server tolerates corrupted registry data and recovers when fixed."""
+
+        # --- Step 1: Normal setup ---
+        self._add_storage()
+        self._create_instance_group()
+        self._register_instance("instance_01")
+        self._write_and_read_block("instance_01", block_key=0)
+        logging.info("Step 1 OK: instance_01 write+read succeeded")
+
+        # Save the good registry content
+        self.assertTrue(os.path.exists(self._registry_path),
+                        "registry persistence file should exist")
+        with open(self._registry_path, "r") as f:
+            good_content = f.read()
+        logging.info(f"Good registry content length: {len(good_content)}")
+
+        # --- Step 2: Corrupt the registry file (only instance_01) ---
+        corrupted = json.loads(good_content)
+        for key in list(corrupted.keys()):
+            if "instance_01" in key:
+                corrupted[key] = "THIS_IS_CORRUPTED_DATA"
+        with open(self._registry_path, "w") as f:
+            json.dump(corrupted, f)
+        logging.info("Step 2: Registry file corrupted (instance_01 broken)")
+
+        # --- Step 3: Restart server — should start despite corruption ---
+        self._restart_server()
+        logging.info("Step 3 OK: Server restarted with corrupted registry")
+
+        # --- Step 4: New instance_02 should work fine (registry persists storage/group) ---
+        self._register_instance("instance_02")
+        self._write_and_read_block("instance_02", block_key=100)
+        logging.info("Step 4 OK: instance_02 write+read succeeded on corrupted server")
+
+        # --- Step 5: Fix the registry file (read current file to preserve instance_02) ---
+        self.worker_manager.stop_worker(0)
+        with open(self._registry_path, "r") as f:
+            current_content = json.loads(f.read())
+        # Restore only instance_01 entries from the good content
+        good_data = json.loads(good_content)
+        for key in list(good_data.keys()):
+            if "instance_01" in key:
+                current_content[key] = good_data[key]
+        with open(self._registry_path, "w") as f:
+            json.dump(current_content, f)
+        logging.info("Step 5: Registry file fixed (instance_01 restored, instance_02 preserved)")
+
+        # --- Step 6: Restart — all data is correct, both instances should work immediately ---
+        self._restart_server()
+        logging.info("Step 6: Server restarted with fully correct registry")
+
+        # Both instances should be usable right away
+        self._write_and_read_block("instance_01", block_key=200)
+        logging.info("Step 6 OK: instance_01 write+read succeeded after fix")
+
+        self._write_and_read_block("instance_02", block_key=201)
+        logging.info("Step 6 OK: instance_02 write+read also succeeded")
+
+    # --- Helpers ---
+
+    def _add_storage(self):
+        req = {
+            "trace_id": self._trace_id,
+            "storage": {
+                "global_unique_name": self._storage_name,
+                "nfs": {
+                    "root_path": f"{self.get_workdir()}/{self._storage_name}/",
+                },
+            },
+        }
+        self._admin_client.add_storage(req, check_response=False)
+
+    def _create_instance_group(self):
+        req = {
+            "trace_id": self._trace_id,
+            "instance_group": {
+                "name": self._instance_group_name,
+                "storage_candidates": [self._storage_name],
+                "global_quota_group_name": "quota_group_test",
+                "max_instance_count": 8,
+                "quota": {
+                    "capacity": 1024 * 32,
+                    "quota_config": [
+                        {"storage_type": 4, "capacity": 1024 * 16},
+                    ],
+                },
+                "cache_config": {
+                    "reclaim_strategy": {
+                        "storage_unique_name": self._storage_name,
+                        "reclaim_policy": 1,
+                        "trigger_strategy": {"used_percentage": 3.2},
+                    },
+                    "data_storage_strategy": 2,
+                    "meta_indexer_config": {
+                        "max_key_count": 64,
+                        "mutex_shard_num": 16,
+                        "meta_storage_backend_config": {
+                            "storage_type": "dummy",
+                            "storage_uri": f"file://{self.get_workdir()}/meta_{self._instance_group_name}",
+                        },
+                        "meta_cache_policy_config": {
+                            "capacity": 1024 * 1024 * 1024,
+                            "type": "LRU",
+                        },
+                        "persist_metadata_interval_time_ms": 0,
+                    },
+                },
+                "user_data": "",
+                "version": 1,
+            },
+        }
+        self._admin_client.create_instance_group(req, check_response=False)
+
+    def _register_instance(self, instance_id):
+        req = {
+            "trace_id": f"{self._trace_id}_{instance_id}",
+            "instance_group": self._instance_group_name,
+            "instance_id": instance_id,
+            "block_size": 128,
+            "model_deployment": {
+                "model_name": "test_model",
+                "dtype": "FP8",
+                "use_mla": False,
+                "tp_size": 1,
+                "dp_size": 1,
+                "pp_size": 1,
+            },
+            "location_spec_infos": [{"name": "tp0", "size": 1024}],
+        }
+        self._meta_client.register_instance(req)
+
+    def _write_and_read_block(self, instance_id, block_key):
+        trace_id = f"{self._trace_id}_{instance_id}_blk_{block_key}"
+
+        # start write
+        start_req = {
+            "trace_id": trace_id,
+            "instance_id": instance_id,
+            "block_keys": [block_key],
+            "token_ids": [block_key + 1000],
+            "write_timeout_seconds": 30,
+        }
+        resp = self._meta_client.start_write_cache(start_req)
+        write_session_id = resp["write_session_id"]
+        self.assertIsNotNone(write_session_id)
+        self.assertNotEqual(write_session_id, "")
+
+        # finish write
+        finish_req = {
+            "trace_id": trace_id,
+            "instance_id": instance_id,
+            "write_session_id": write_session_id,
+            "success_blocks": {"bool_masks": {"values": [True]}},
+        }
+        self._meta_client.finish_write_cache(finish_req)
+
+        # read (get cache location)
+        get_req = {
+            "trace_id": trace_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_keys": [block_key],
+            "instance_id": instance_id,
+            "block_mask": {"offset": 0},
+        }
+        resp = self._meta_client.get_cache_location(get_req)
+        self.assertGreater(len(resp["locations"]), 0,
+                           f"block {block_key} should be readable on {instance_id}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/config/registry_local_backend.cc
+++ b/kv_cache_manager/config/registry_local_backend.cc
@@ -55,8 +55,9 @@ ErrorCode RegistryLocalBackend::Recover() {
     for (auto &pair : tmp_table) {
         std::map<std::string, std::string> tmp_field_table;
         if (!Jsonizable::FromJsonString(pair.second, tmp_field_table)) {
-            KVCM_LOG_ERROR("fail to parse field map json, file[%s] content[%s]", path_.c_str(), pair.second.c_str());
-            return EC_ERROR;
+            KVCM_LOG_WARN(
+                "skip unparseable field map json during recover, file[%s] key[%s]", path_.c_str(), pair.first.c_str());
+            continue;
         }
         table_.Emplace(pair.first, std::move(tmp_field_table));
     }

--- a/kv_cache_manager/config/registry_manager.cc
+++ b/kv_cache_manager/config/registry_manager.cc
@@ -125,6 +125,8 @@ RegistryManager::RegistryManager(const std::string &registry_storage_uri,
                                  std::shared_ptr<MetricsRegistry> metrics_registry)
     : registry_storage_uri_(registry_storage_uri), metrics_registry_(std::move(metrics_registry)) {}
 
+RegistryManager::~RegistryManager() { DoCleanup(); }
+
 bool RegistryManager::Init() {
     data_storage_manager_.reset(new DataStorageManager(metrics_registry_));
     storage_ = RegistryStorageBackendFactory::CreateAndInitStorageBackend(registry_storage_uri_);
@@ -203,8 +205,7 @@ ErrorCode RegistryManager::CreateInstanceGroup(RequestContext *request_context, 
     const auto &instance_group_name = instance_group.name();
     std::unique_lock<std::shared_mutex> lock(mutex_);
     if (instance_group_configs_.find(instance_group_name) != instance_group_configs_.end()) {
-        RETURN_IF_EC_NOT_OK_WITH_LOG_G(
-            WARN, EC_EXIST, "create instance group failed: instance group already existed");
+        RETURN_IF_EC_NOT_OK_WITH_LOG_G(WARN, EC_EXIST, "create instance group failed: instance group already existed");
     }
     // save to storage backend
     auto ec = LoadAndSave(kRegistryGroupKey, instance_group_name, &instance_group);
@@ -287,7 +288,8 @@ ErrorCode RegistryManager::RegisterInstance(RequestContext *request_context,
     auto it = instance_infos_.find(instance_id);
     if (it != instance_infos_.end()) {
         const auto &existing = it->second;
-        auto mismatched = existing->MismatchFields(block_size, location_spec_infos, model_deployment, location_spec_groups);
+        auto mismatched =
+            existing->MismatchFields(block_size, location_spec_infos, model_deployment, location_spec_groups);
         if (!mismatched.empty()) {
             auto mismatched_str = StringUtil::Join(mismatched, ", ");
             request_context->error_tracer()->AddErrorMsg(
@@ -495,115 +497,202 @@ ErrorCode RegistryManager::UpdateStorageAvailableStatus(const std::string &globa
     return LoadAndSave(kRegistryStorageKey, global_unique_name, &storage_config);
 }
 
-ErrorCode RegistryManager::DoRecover() {
-    std::unique_lock<std::shared_mutex> lock(mutex_);
-
-    size_t storage_num = 0;
-    size_t not_available_storage_num = 0;
+size_t RegistryManager::RecoverStorageUnsafe() {
+    size_t error_count = 0;
     auto request_context = std::make_shared<RequestContext>("registry_manager_recover_trace");
-    // recover storage
     std::map<std::string, std::string> value_map;
     auto ec = storage_->Load(kRegistryStorageKey, value_map);
     if (ec != EC_OK && ec != EC_NOENT) {
-        KVCM_LOG_ERROR("load registry storage backend failed");
-        return ec;
+        KVCM_LOG_WARN("load registry storage backend failed, will retry later");
+        return 1;
     }
     for (const auto &[id, val] : value_map) {
         StorageConfig storage_config;
         if (!storage_config.FromJsonString(val)) {
-            KVCM_LOG_ERROR("storage config from json string failed, json string[%s]", val.c_str());
-            return EC_CONFIG_ERROR;
+            KVCM_LOG_WARN("storage config from json string failed, skip. json string[%s]", val.c_str());
+            ++error_count;
+            continue;
         }
         auto name = storage_config.global_unique_name();
+        auto existing_backend = data_storage_manager_->GetDataStorageBackend(name);
+        if (existing_backend != nullptr) {
+            if (!storage_config.is_available() && existing_backend->Available()) {
+                ec = data_storage_manager_->DisableStorage(name);
+                if (ec != EC_OK) {
+                    KVCM_LOG_WARN("disable existing storage failed when recover, skip. name[%s]", name.c_str());
+                    ++error_count;
+                }
+            }
+            continue;
+        }
         ec = data_storage_manager_->RegisterStorage(request_context.get(), name, storage_config);
         if (ec != EC_OK) {
-            KVCM_LOG_ERROR(
-                "register storage failed when recover, name[%s], json string[%s]", name.c_str(), val.c_str());
-            return ec;
+            KVCM_LOG_WARN(
+                "register storage failed when recover, skip. name[%s], json string[%s]", name.c_str(), val.c_str());
+            ++error_count;
+            continue;
         }
         if (!storage_config.is_available()) {
             ec = data_storage_manager_->DisableStorage(name);
             if (ec != EC_OK) {
-                KVCM_LOG_ERROR(
-                    "disable storage failed when recover, name[%s], json string[%s]", name.c_str(), val.c_str());
-                return ec;
+                KVCM_LOG_WARN(
+                    "disable storage failed when recover, skip. name[%s], json string[%s]", name.c_str(), val.c_str());
+                ++error_count;
+                continue;
             }
-            ++not_available_storage_num;
         }
-        ++storage_num;
     }
+    return error_count;
+}
 
-    // recover account
-    value_map.clear();
-    ec = storage_->Load(kRegistryAccountKey, value_map);
+size_t RegistryManager::RecoverAccountUnsafe() {
+    size_t error_count = 0;
+    std::map<std::string, std::string> value_map;
+    auto ec = storage_->Load(kRegistryAccountKey, value_map);
     if (ec != EC_OK && ec != EC_NOENT) {
-        KVCM_LOG_ERROR("load registry account failed");
-        return ec;
+        KVCM_LOG_WARN("load registry account failed, will retry later");
+        return 1;
     }
     for (const auto &[id, val] : value_map) {
         auto account = std::make_shared<Account>();
         if (!account->FromJsonString(val)) {
-            KVCM_LOG_ERROR("account from json string failed, json string[%s]", val.c_str());
-            return EC_CONFIG_ERROR;
+            KVCM_LOG_WARN("account from json string failed, skip. json string[%s]", val.c_str());
+            ++error_count;
+            continue;
+        }
+        if (accounts_.find(account->user_name()) != accounts_.end()) {
+            continue;
         }
         accounts_[account->user_name()] = account;
     }
-    // recover instance group
-    value_map.clear();
-    ec = storage_->Load(kRegistryGroupKey, value_map);
+    return error_count;
+}
+
+size_t RegistryManager::RecoverInstanceGroupUnsafe() {
+    size_t error_count = 0;
+    std::map<std::string, std::string> value_map;
+    auto ec = storage_->Load(kRegistryGroupKey, value_map);
     if (ec != EC_OK && ec != EC_NOENT) {
-        KVCM_LOG_ERROR("load registry instance group failed");
-        return ec;
+        KVCM_LOG_WARN("load registry instance group failed, will retry later");
+        return 1;
     }
     for (const auto &[id, val] : value_map) {
         auto instance_group = std::make_shared<InstanceGroup>();
         if (!instance_group->FromJsonString(val)) {
-            KVCM_LOG_ERROR("instance group from json string failed, json string[%s]", val.c_str());
-            return EC_CONFIG_ERROR;
+            KVCM_LOG_WARN("instance group from json string failed, skip. json string[%s]", val.c_str());
+            ++error_count;
+            continue;
+        }
+        if (instance_group_configs_.find(instance_group->name()) != instance_group_configs_.end()) {
+            continue;
         }
         instance_group_configs_[instance_group->name()] = instance_group;
     }
+    return error_count;
+}
 
-    // recover instance info
-    value_map.clear();
-    ec = storage_->Load(kRegistryInstanceKey, value_map);
+size_t RegistryManager::RecoverInstanceInfoUnsafe() {
+    size_t error_count = 0;
+    std::map<std::string, std::string> value_map;
+    auto ec = storage_->Load(kRegistryInstanceKey, value_map);
     if (ec != EC_OK && ec != EC_NOENT) {
-        KVCM_LOG_ERROR("load registry instance group failed");
-        return ec;
+        KVCM_LOG_WARN("load registry instance info failed, will retry later");
+        return 1;
     }
-    std::vector<std::string> instance_ids;
     for (const auto &[id, val] : value_map) {
+        if (instance_infos_.find(id) != instance_infos_.end()) {
+            continue;
+        }
         std::map<std::string, std::string> instance_map;
         ec = storage_->Load(id, instance_map);
         if (ec != EC_OK) {
-            KVCM_LOG_ERROR("load registry instance info failed, instance id[%s]", id.c_str());
-            return ec;
+            KVCM_LOG_WARN("load registry instance info failed, skip. instance id[%s]", id.c_str());
+            ++error_count;
+            continue;
         }
         auto instance_info = std::make_shared<InstanceInfo>();
         if (!instance_info->FromJsonString(instance_map[id])) {
-            KVCM_LOG_ERROR("instance info from json string failed, json string[%s]", instance_map[id].c_str());
-            return EC_CONFIG_ERROR;
+            KVCM_LOG_WARN("instance info from json string failed, skip. json string[%s]", instance_map[id].c_str());
+            ++error_count;
+            continue;
         }
         instance_infos_[id] = instance_info;
     }
-    KVCM_LOG_INFO(
-        "registry manager do recover success, recover storage num[%lu], available storage num[%lu], account num[%lu], "
-        "instance group num[%lu], instance info num[%lu]",
-        storage_num,
-        storage_num - not_available_storage_num,
-        accounts_.size(),
-        instance_group_configs_.size(),
-        instance_infos_.size());
-    return EC_OK;
+    return error_count;
 }
-ErrorCode RegistryManager::DoCleanup() {
+
+ErrorCode RegistryManager::DoRecoverOnce() {
     std::unique_lock<std::shared_mutex> lock(mutex_);
 
+    size_t error_count = 0;
+    error_count += RecoverStorageUnsafe();
+    error_count += RecoverAccountUnsafe();
+    error_count += RecoverInstanceGroupUnsafe();
+    error_count += RecoverInstanceInfoUnsafe();
+
+    KVCM_LOG_INFO("registry manager do recover once done, error_count[%lu], account num[%lu], "
+                  "instance group num[%lu], instance info num[%lu]",
+                  error_count,
+                  accounts_.size(),
+                  instance_group_configs_.size(),
+                  instance_infos_.size());
+    if (error_count == 0) {
+        recover_complete_.store(true);
+    }
+    return error_count > 0 ? EC_ERROR : EC_OK;
+}
+
+bool RegistryManager::IsRecoverComplete() const { return recover_complete_.load(); }
+
+ErrorCode RegistryManager::DoRecover() {
+    auto ec = DoRecoverOnce();
+    if (ec == EC_OK) {
+        return EC_OK;
+    }
+    KVCM_LOG_WARN("registry manager DoRecover partially failed, starting retry loop in background");
+    StartRecoverRetryLoop();
+    return EC_OK;
+}
+
+void RegistryManager::StartRecoverRetryLoop() {
+    StopRecoverRetryLoop();
+    recover_retry_stop_.store(false);
+    recover_retry_thread_ = std::thread([this]() {
+        while (!recover_retry_stop_.load()) {
+            for (int i = 0; i < 100 && !recover_retry_stop_.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            if (recover_retry_stop_.load()) {
+                break;
+            }
+            KVCM_LOG_INFO("registry manager recover retry loop executing...");
+            auto ec = DoRecoverOnce();
+            if (ec == EC_OK) {
+                KVCM_LOG_INFO("registry manager recover retry loop completed successfully, stopping retry");
+                break;
+            }
+        }
+    });
+}
+
+void RegistryManager::StopRecoverRetryLoop() {
+    recover_retry_stop_.store(true);
+    if (recover_retry_thread_.joinable()) {
+        recover_retry_thread_.join();
+    }
+}
+ErrorCode RegistryManager::DoCleanup() {
     KVCM_LOG_INFO("registry manager start cleanup");
 
-    auto ec = data_storage_manager_->DoCleanup();
-    if (ec != EC_OK) {
-        KVCM_LOG_WARN("failed during cleanup data_storage_manager, ec[%d]", ec);
+    StopRecoverRetryLoop(); // need to be outside of lock
+    recover_complete_.store(false);
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    if (data_storage_manager_) {
+        auto ec = data_storage_manager_->DoCleanup();
+        if (ec != EC_OK) {
+            KVCM_LOG_WARN("failed during cleanup data_storage_manager, ec[%d]", ec);
+        }
     }
     // clear config and infos
     instance_group_configs_.clear();

--- a/kv_cache_manager/config/registry_manager.h
+++ b/kv_cache_manager/config/registry_manager.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <shared_mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -29,8 +31,13 @@ class Jsonizable;
 class RegistryManager {
 public:
     RegistryManager(const std::string &registry_uri, std::shared_ptr<MetricsRegistry> metrics_registry);
+    ~RegistryManager();
     bool Init();
     ErrorCode DoRecover();
+    ErrorCode DoRecoverOnce();
+    void StartRecoverRetryLoop();
+    void StopRecoverRetryLoop();
+    bool IsRecoverComplete() const;
     ErrorCode DoCleanup();
 
 public:
@@ -82,6 +89,11 @@ private:
     ErrorCode LoadAndSave(const std::string &key, const std::string &id, const Jsonizable *jsonizable);
     ErrorCode LoadAndDelete(const std::string &key, const std::string &id);
     ErrorCode UpdateStorageAvailableStatus(const std::string &global_unique_name, bool is_available);
+    // return error count (0 means success)
+    size_t RecoverStorageUnsafe();
+    size_t RecoverAccountUnsafe();
+    size_t RecoverInstanceGroupUnsafe();
+    size_t RecoverInstanceInfoUnsafe();
 
 private:
     /***
@@ -108,6 +120,11 @@ private:
     std::unique_ptr<RegistryStorageBackend> storage_;
     // 无需清理 - 不包含数据
     mutable std::shared_mutex mutex_;
+
+    // 需要清理 - recover 重试线程相关，在DoCleanup()中StopRecoverRetryLoop()
+    std::thread recover_retry_thread_;
+    std::atomic<bool> recover_retry_stop_{false};
+    std::atomic<bool> recover_complete_{false};
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/config/test/registry_manager_local_backend_test.cc
+++ b/kv_cache_manager/config/test/registry_manager_local_backend_test.cc
@@ -500,4 +500,191 @@ TEST_F(RegistryManagerLocalBackendTest, TestDoCleanupCompleteness) {
     ASSERT_TRUE(storage_configs_after.empty()) << "data_storage_manager_ should have no storages after cleanup";
 }
 
+TEST_F(RegistryManagerLocalBackendTest, TestDoRecoverOnceIdempotent) {
+    std::string local_path = GetPrivateTestRuntimeDataPath() + "_registry_local_backend_recover_idempotent_test";
+    std::string uri = "local://" + local_path + "?cluster_name=test";
+
+    // Setup initial data
+    {
+        ASSERT_TRUE(InitRegistryManager(uri));
+        AddNfsStorage("storage1", 1);
+        AddNfsStorage("storage2", 2);
+        ASSERT_EQ(EC_OK, registry_manager_->DisableStorage(request_context_.get(), "storage2"));
+        CreateInstanceGroup("group1");
+        RegisterInstance("group1", "instance1");
+        ASSERT_EQ(EC_OK,
+                  registry_manager_->AddAccount(request_context_.get(), "user1", "pwd1", AccountRole::ROLE_USER));
+    }
+
+    // Re-init and call DoRecoverOnce multiple times - should be idempotent
+    {
+        ASSERT_TRUE(InitRegistryManager(uri));
+        ASSERT_EQ(EC_OK, registry_manager_->DoRecoverOnce());
+
+        // Second call should also succeed (skip already-recovered items)
+        ASSERT_EQ(EC_OK, registry_manager_->DoRecoverOnce());
+
+        // Third call
+        ASSERT_EQ(EC_OK, registry_manager_->DoRecoverOnce());
+
+        // Verify data is correct (not duplicated)
+        auto storage1 = registry_manager_->data_storage_manager()->GetDataStorageBackend("storage1");
+        ASSERT_TRUE(storage1);
+        ASSERT_TRUE(storage1->Available());
+
+        auto storage2 = registry_manager_->data_storage_manager()->GetDataStorageBackend("storage2");
+        ASSERT_TRUE(storage2);
+        ASSERT_FALSE(storage2->Available());
+
+        auto [ec_groups, groups] = registry_manager_->ListInstanceGroup(request_context_.get());
+        ASSERT_EQ(EC_OK, ec_groups);
+        ASSERT_EQ(1, groups.size());
+
+        auto instance_info = registry_manager_->GetInstanceInfo(request_context_.get(), "instance1");
+        ASSERT_TRUE(instance_info);
+        ASSERT_EQ("instance1", instance_info->instance_id());
+
+        auto [ec_accounts, accounts] = registry_manager_->ListAccount(request_context_.get());
+        ASSERT_EQ(EC_OK, ec_accounts);
+        ASSERT_EQ(1, accounts.size());
+    }
+}
+
+TEST_F(RegistryManagerLocalBackendTest, TestDoRecoverOncePartialFailure) {
+    std::string local_path = GetPrivateTestRuntimeDataPath() + "_recover_partial_fail_test";
+    std::string uri = "local://" + local_path + "?cluster_name=test";
+
+    // Setup valid data first
+    ASSERT_TRUE(InitRegistryManager(uri));
+    AddNfsStorage("storage1", 1);
+    CreateInstanceGroup("group1");
+    RegisterInstance("group1", "instance1");
+    ASSERT_EQ(EC_OK, registry_manager_->AddAccount(request_context_.get(), "user1", "pwd1", AccountRole::ROLE_USER));
+
+    // Inject invalid entries directly via storage_ backend
+    std::map<std::string, std::string> storage_map;
+    registry_manager_->storage_->Load("storage", storage_map);
+    storage_map["bad_storage"] = "this_is_not_valid_json";
+    registry_manager_->storage_->Save("storage", storage_map);
+
+    std::map<std::string, std::string> account_map;
+    registry_manager_->storage_->Load("account", account_map);
+    account_map["bad_account"] = "invalid_json";
+    registry_manager_->storage_->Save("account", account_map);
+
+    // Re-init from persistent storage containing both valid and invalid entries
+    ASSERT_TRUE(InitRegistryManager(uri));
+    auto ec = registry_manager_->DoRecoverOnce();
+    ASSERT_EQ(EC_ERROR, ec) << "Should report error due to invalid entries";
+
+    // Valid data should still be recovered
+    auto storage1 = registry_manager_->data_storage_manager()->GetDataStorageBackend("storage1");
+    ASSERT_TRUE(storage1) << "Valid storage1 should be recovered";
+    ASSERT_TRUE(storage1->Available());
+
+    auto bad_storage = registry_manager_->data_storage_manager()->GetDataStorageBackend("bad_storage");
+    ASSERT_FALSE(bad_storage) << "Invalid bad_storage should not be recovered";
+
+    auto [ec_groups, groups] = registry_manager_->ListInstanceGroup(request_context_.get());
+    ASSERT_EQ(EC_OK, ec_groups);
+    ASSERT_EQ(1, groups.size());
+
+    auto instance_info = registry_manager_->GetInstanceInfo(request_context_.get(), "instance1");
+    ASSERT_TRUE(instance_info);
+
+    auto [ec_accounts, accounts] = registry_manager_->ListAccount(request_context_.get());
+    ASSERT_EQ(EC_OK, ec_accounts);
+    ASSERT_EQ(1, accounts.size()) << "Valid user1 recovered, bad_account skipped";
+
+    // Call again - idempotent (valid items skipped, bad items still fail)
+    ec = registry_manager_->DoRecoverOnce();
+    ASSERT_EQ(EC_ERROR, ec);
+    storage1 = registry_manager_->data_storage_manager()->GetDataStorageBackend("storage1");
+    ASSERT_TRUE(storage1);
+}
+
+TEST_F(RegistryManagerLocalBackendTest, TestDoRecoverFixedAfterRetry) {
+    std::string local_path = GetPrivateTestRuntimeDataPath() + "_recover_fix_after_retry_test";
+    std::string uri = "local://" + local_path + "?cluster_name=test";
+
+    // Setup valid data
+    ASSERT_TRUE(InitRegistryManager(uri));
+    AddNfsStorage("storage1", 1);
+
+    // Inject invalid entry
+    std::map<std::string, std::string> storage_map;
+    registry_manager_->storage_->Load("storage", storage_map);
+    storage_map["bad_storage"] = "invalid";
+    registry_manager_->storage_->Save("storage", storage_map);
+
+    // Cleanup and recover - partial failure
+    ASSERT_EQ(EC_OK, registry_manager_->DoCleanup());
+    auto ec = registry_manager_->DoRecoverOnce();
+    ASSERT_EQ(EC_ERROR, ec);
+
+    // Fix the bad entry by removing it from backend
+    registry_manager_->storage_->Load("storage", storage_map);
+    storage_map.erase("bad_storage");
+    registry_manager_->storage_->Save("storage", storage_map);
+
+    // Retry should now succeed
+    ec = registry_manager_->DoRecoverOnce();
+    ASSERT_EQ(EC_OK, ec);
+}
+
+TEST_F(RegistryManagerLocalBackendTest, TestDoRecoverStartsRetryOnFailure) {
+    std::string local_path = GetPrivateTestRuntimeDataPath() + "_recover_starts_retry_test";
+    std::string uri = "local://" + local_path + "?cluster_name=test";
+
+    // Setup valid data + inject bad entry
+    ASSERT_TRUE(InitRegistryManager(uri));
+    AddNfsStorage("storage1", 1);
+
+    std::map<std::string, std::string> storage_map;
+    registry_manager_->storage_->Load("storage", storage_map);
+    storage_map["bad_storage"] = "invalid";
+    registry_manager_->storage_->Save("storage", storage_map);
+
+    // Cleanup memory, then DoRecover - should return EC_OK but start retry loop
+    ASSERT_EQ(EC_OK, registry_manager_->DoCleanup());
+    auto ec = registry_manager_->DoRecover();
+    ASSERT_EQ(EC_OK, ec) << "DoRecover tolerates errors and returns OK";
+
+    // Valid storage should still be recovered
+    auto storage1 = registry_manager_->data_storage_manager()->GetDataStorageBackend("storage1");
+    ASSERT_TRUE(storage1);
+
+    // Stop the retry thread
+    registry_manager_->StopRecoverRetryLoop();
+}
+
+TEST_F(RegistryManagerLocalBackendTest, TestRecoverRetryLoopLifecycle) {
+    std::string local_path = GetPrivateTestRuntimeDataPath() + "_recover_retry_lifecycle_test";
+    std::string uri = "local://" + local_path + "?cluster_name=test";
+
+    // StopRecoverRetryLoop should be safe to call even without active thread
+    {
+        ASSERT_TRUE(InitRegistryManager(uri));
+        registry_manager_->StopRecoverRetryLoop();
+        registry_manager_->StopRecoverRetryLoop(); // double-stop should not crash
+    }
+
+    // StartRecoverRetryLoop + StopRecoverRetryLoop lifecycle
+    {
+        ASSERT_TRUE(InitRegistryManager(uri));
+        registry_manager_->StartRecoverRetryLoop();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        registry_manager_->StopRecoverRetryLoop(); // should join within ~100ms
+    }
+
+    // Destructor should properly stop retry thread via DoCleanup
+    {
+        auto rm = std::make_shared<RegistryManager>(uri, std::make_shared<MetricsRegistry>());
+        ASSERT_TRUE(rm->Init());
+        rm->StartRecoverRetryLoop();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        rm.reset(); // destructor -> DoCleanup -> StopRecoverRetryLoop
+    }
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -133,6 +133,7 @@ CacheManager::CacheManager(std::shared_ptr<MetricsRegistry> metrics_registry,
           meta_indexer_manager_, write_location_manager_, registry_manager_)) {}
 
 CacheManager::~CacheManager() {
+    StopRecoverRetryLoop();
     if (write_location_manager_) {
         write_location_manager_->Stop();
         write_location_manager_.reset();
@@ -1237,25 +1238,27 @@ ErrorCode CacheManager::GetCacheLocationByQueryType(MetaSearcher *meta_searcher,
     return ec;
 }
 
-ErrorCode CacheManager::DoRecover() {
+ErrorCode CacheManager::DoRecoverOnce() {
     if (!registry_manager_) {
         KVCM_LOG_ERROR("CacheManager do recover failed, registry_manager is nullptr");
         return EC_ERROR;
     }
+    size_t error_count = 0;
     auto request_context = std::make_shared<RequestContext>("cache_manager_recover_trace");
     auto [ec1, instance_groups] = registry_manager_->ListInstanceGroup(request_context.get());
     if (ec1 != EC_OK) {
-        KVCM_LOG_ERROR("CacheManager ListInstanceGroup failed when recover, ec[%d]", ec1);
-        return ec1;
+        KVCM_LOG_WARN("CacheManager ListInstanceGroup failed when recover, ec[%d], will retry later", ec1);
+        return EC_ERROR;
     }
     for (const auto &instance_group : instance_groups) {
         std::string group_name = instance_group->name();
         auto [ec2, instance_infos] = registry_manager_->ListInstanceInfo(request_context.get(), group_name);
         if (ec2 != EC_OK) {
-            KVCM_LOG_ERROR("CacheManager ListInstanceInfo failed when recover, ec[%d] instance_group name[%s]",
-                           ec2,
-                           group_name.c_str());
-            return ec2;
+            KVCM_LOG_WARN("CacheManager ListInstanceInfo failed when recover, skip. ec[%d] instance_group name[%s]",
+                          ec2,
+                          group_name.c_str());
+            ++error_count;
+            continue;
         }
         for (const auto &instance_info : instance_infos) {
             auto [ec3, config_str] = RegisterInstance(request_context.get(),
@@ -1265,28 +1268,86 @@ ErrorCode CacheManager::DoRecover() {
                                                       instance_info->location_spec_infos(),
                                                       instance_info->model_deployment(),
                                                       instance_info->location_spec_groups());
-            if (ec3 != EC_OK) {
-                KVCM_LOG_ERROR("CacheManager RegisterInstance failed when recover, ec[%d] instance_group "
-                               "name[%s] instance_id[%s]",
-                               ec3,
-                               group_name.c_str(),
-                               instance_info->instance_id().c_str());
-                return ec3;
+            if (ec3 != EC_OK && ec3 != EC_DUPLICATE_ENTITY) {
+                KVCM_LOG_WARN("CacheManager RegisterInstance failed when recover, skip. ec[%d] instance_group "
+                              "name[%s] instance_id[%s]",
+                              ec3,
+                              group_name.c_str(),
+                              instance_info->instance_id().c_str());
+                ++error_count;
+                continue;
             }
             KVCM_LOG_INFO("CacheManager RegisterInstance success when recover, instance_id[%s], storage_config[%s]",
                           instance_info->instance_id().c_str(),
                           config_str.c_str());
         }
     }
+
+    // CacheManager recover is only complete when RegistryManager recover is also complete
+    if (!registry_manager_->IsRecoverComplete()) {
+        KVCM_LOG_WARN("CacheManager recover waiting for RegistryManager recover to complete");
+        ++error_count;
+    }
+
+    KVCM_LOG_INFO("CacheManager do recover once done, error_count[%lu]", error_count);
+    return error_count > 0 ? EC_ERROR : EC_OK;
+}
+
+ErrorCode CacheManager::DoRecover() {
+    auto ec = DoRecoverOnce();
+    if (ec == EC_OK) {
+        return EC_OK;
+    }
+    KVCM_LOG_WARN("CacheManager DoRecover partially failed, starting retry loop in background");
+    StartRecoverRetryLoop();
     return EC_OK;
 }
+
+void CacheManager::StartRecoverRetryLoop() {
+    StopRecoverRetryLoop();
+    recover_retry_stop_.store(false);
+    recover_retry_thread_ = std::thread([this]() {
+        while (!recover_retry_stop_.load()) {
+            for (int i = 0; i < 100 && !recover_retry_stop_.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            if (recover_retry_stop_.load()) {
+                break;
+            }
+            KVCM_LOG_INFO("CacheManager recover retry loop executing...");
+            auto ec = DoRecoverOnce();
+            if (ec == EC_OK) {
+                KVCM_LOG_INFO("CacheManager recover retry loop completed successfully, stopping retry");
+                break;
+            }
+        }
+    });
+}
+
+void CacheManager::StopRecoverRetryLoop() {
+    recover_retry_stop_.store(true);
+    if (recover_retry_thread_.joinable()) {
+        recover_retry_thread_.join();
+    }
+}
 ErrorCode CacheManager::DoCleanup() {
+    StopRecoverRetryLoop();
     // aborting write session need meta indexer
-    write_location_manager_->DoCleanup();
-    meta_searcher_manager_->DoCleanup();
-    meta_indexer_manager_->DoCleanup();
-    metrics_recorder_->DoCleanup();
-    data_storage_selector_->DoCleanup();
+    if (write_location_manager_) {
+        write_location_manager_->DoCleanup();
+    }
+    if (meta_searcher_manager_) {
+        meta_searcher_manager_->DoCleanup();
+    }
+    if (meta_indexer_manager_) {
+        meta_indexer_manager_->DoCleanup();
+    }
+    if (metrics_recorder_) {
+        metrics_recorder_->DoCleanup();
+    }
+    if (data_storage_selector_) {
+        data_storage_selector_->DoCleanup();
+    }
 
     return EC_OK;
 }

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -66,6 +68,9 @@ public:
               uint32_t cache_reclaimer_idle_interval_ms = 100,
               uint32_t cache_reclaimer_worker_size = 16);
     ErrorCode DoRecover();
+    ErrorCode DoRecoverOnce();
+    void StartRecoverRetryLoop();
+    void StopRecoverRetryLoop();
     ErrorCode DoCleanup();
     std::shared_ptr<RegistryManager> GetRegistryManager() { return registry_manager_; }
 
@@ -239,6 +244,10 @@ private:
     std::shared_ptr<EventManager> event_manager_;
     // 需要清理 - 避免有metrics遗留
     std::shared_ptr<CacheManagerMetricsRecorder> metrics_recorder_;
+
+    // 需要清理 - recover 重试线程相关，在DoCleanup()中StopRecoverRetryLoop()
+    std::thread recover_retry_thread_;
+    std::atomic<bool> recover_retry_stop_{false};
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -119,6 +119,8 @@ public:
         registry_manager_->instance_group_configs_["test_group"] = instance_group;
         registry_manager_->instance_infos_["test_instance"] = instance_info;
         registry_manager_->Init();
+        // Mark registry as recovered since data was injected directly (not via backend)
+        registry_manager_->recover_complete_.store(true);
         std::unique_ptr<CacheManager> cache_manager =
             std::make_unique<CacheManager>(metrics_registry, registry_manager_);
 
@@ -2300,6 +2302,88 @@ TEST_F(CacheManagerTest, TestWriteThenReadRoundTripWithSpecGroups) {
                 << "key index " << i << " should have 2 F0 specs after filtering";
         }
     }
+}
+
+TEST_F(CacheManagerTest, TestDoRecoverAfterCleanup) {
+    // Cleanup then recover
+    ASSERT_EQ(EC_OK, cache_manager_->DoCleanup());
+    ASSERT_EQ(EC_OK, cache_manager_->DoRecoverOnce());
+
+    MetaSearcher *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_TRUE(meta_searcher);
+    ASSERT_TRUE(meta_searcher->meta_indexer_);
+    ASSERT_EQ("test_instance", meta_searcher->meta_indexer_->instance_id_);
+
+    // Call again - should be idempotent
+    ASSERT_EQ(EC_OK, cache_manager_->DoRecoverOnce());
+    meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_TRUE(meta_searcher);
+    ASSERT_EQ("test_instance", meta_searcher->meta_indexer_->instance_id_);
+}
+
+TEST_F(CacheManagerTest, TestDoRecoverOnceWithRegistryPartialFailureThenFix) {
+    // Scenario:
+    // 1. RegistryManager has instance_group + test_instance recovered, but a second instance
+    //    "missing_instance" is expected but not in instance_infos_ (simulates partial recover failure)
+    // 2. RegistryManager::IsRecoverComplete() returns false
+    // 3. CacheManager::DoRecoverOnce() succeeds for test_instance but overall returns ERROR
+    // 4. "Fix" RegistryManager by adding missing_instance and marking recover complete
+    // 5. CacheManager::DoRecoverOnce() now succeeds and missing_instance gets its MetaSearcher
+
+    // Cleanup to start fresh
+    ASSERT_EQ(EC_OK, cache_manager_->DoCleanup());
+
+    // Simulate RegistryManager partial failure: recover_complete_ is false
+    // test_instance is already in instance_infos_ (from SetUp), but mark as incomplete
+    registry_manager_->recover_complete_.store(false);
+
+    // CacheManager DoRecoverOnce - should return ERROR because RegistryManager is incomplete
+    auto ec = cache_manager_->DoRecoverOnce();
+    ASSERT_EQ(EC_ERROR, ec);
+
+    // test_instance MetaSearcher should still have been created (partial progress is retained)
+    MetaSearcher *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_TRUE(meta_searcher);
+    ASSERT_EQ("test_instance", meta_searcher->meta_indexer_->instance_id_);
+
+    // "missing_instance" doesn't exist yet - no MetaSearcher
+    meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("missing_instance");
+    ASSERT_FALSE(meta_searcher);
+
+    // Now "fix" RegistryManager: add missing_instance to instance_infos_ and mark complete
+    auto missing_instance_info = std::make_shared<InstanceInfo>(
+        "test_quota_group", "default", "missing_instance", 64, createLocationSpecInfos(), createModelDeployment());
+    registry_manager_->instance_infos_["missing_instance"] = missing_instance_info;
+    registry_manager_->recover_complete_.store(true);
+
+    // CacheManager DoRecoverOnce - should now succeed
+    ec = cache_manager_->DoRecoverOnce();
+    ASSERT_EQ(EC_OK, ec);
+
+    // Both instances should have MetaSearcher
+    meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_TRUE(meta_searcher);
+    ASSERT_EQ("test_instance", meta_searcher->meta_indexer_->instance_id_);
+
+    meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("missing_instance");
+    ASSERT_TRUE(meta_searcher);
+    ASSERT_EQ("missing_instance", meta_searcher->meta_indexer_->instance_id_);
+}
+
+TEST_F(CacheManagerTest, TestRecoverRetryLoopLifecycle) {
+    // StopRecoverRetryLoop should be safe without active thread
+    cache_manager_->StopRecoverRetryLoop();
+    cache_manager_->StopRecoverRetryLoop(); // double-stop should not crash
+
+    // StartRecoverRetryLoop + StopRecoverRetryLoop
+    cache_manager_->StartRecoverRetryLoop();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    cache_manager_->StopRecoverRetryLoop(); // should join within ~100ms
+
+    // DoCleanup should stop retry thread
+    cache_manager_->StartRecoverRetryLoop();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    ASSERT_EQ(EC_OK, cache_manager_->DoCleanup());
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -73,7 +73,6 @@ void Server::OnBecomeLeader() {
     KVCM_LOG_INFO("Server promoted to leader, starting recover...");
     ErrorCode ec = registry_manager_->DoRecover();
     if (ec != EC_OK) {
-        // TODO: 添加异常情况下回滚和重试
         KVCM_LOG_ERROR("registry_manager recover failed");
         return;
     }
@@ -89,7 +88,6 @@ void Server::OnBecomeLeader() {
 
     ec = cache_manager_->DoRecover();
     if (ec != EC_OK) {
-        // TODO: 添加异常情况下回滚和重试
         KVCM_LOG_ERROR("cache_manager recover failed");
         return;
     }


### PR DESCRIPTION
### Recover 容错改造：瞬态错误不阻塞服务启动

**背景**：当前 `RegistryManager::DoRecover` 和 `CacheManager::DoRecover` 遇到任何错误（如 service discovery 暂时不可用、持久化数据部分损坏）会立即终止，导致整个 server 无法启动。

**改动**：

- **RegistryManager**：将 `DoRecover` 核心逻辑拆为 `DoRecoverOnce()`，出错只打 WARN 并跳过，已存在的项幂等跳过；首次同步执行，失败则启后台线程每 10s 重试直到成功；对外暴露 `IsRecoverComplete()` 状态
- **CacheManager**：同样拆分 `DoRecoverOnce()` + 异步重试，额外依赖 `RegistryManager::IsRecoverComplete()` 保证恢复顺序
- **RegistryLocalBackend**：`Recover()` 遇到单条损坏数据跳过而非整体失败
- **析构/Cleanup 安全**：`DoCleanup` 和析构函数增加空指针保护，确保未完整初始化时不 crash

**测试**：
- RegistryManager 单元测试（4 case）：容错跳过、重试成功、线程生命周期
- CacheManager 单元测试（3 case）：Cleanup 后恢复、IsRecoverComplete 联动、重试线程生命周期
- 集成测试 `recover_test.py`：持久化文件损坏→服务可用→修复→完全恢复