### PR TITLE
[common] add CrashHandler with offline stack decoder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@
 - Prometheus Metrics
   - [English](prometheus-en_US.md) - Prometheus metrics endpoint documentation
   - [中文](prometheus-zh_CN.md) - Prometheus 指标端点文档
+- Crash Stack Trace
+  - [English](crash-handler-en_US.md) - Crash signal handler & offline stack decoder
+  - [中文](crash-handler-zh_CN.md) - 崩溃堆栈打印与离线解析
 
 
 ---

--- a/docs/crash-handler-en_US.md
+++ b/docs/crash-handler-en_US.md
@@ -1,0 +1,152 @@
+# Crash Stack Trace
+
+KVCacheManager installs an async-signal-safe crash handler in
+`CommandLine::RegisterSignal` by default. When the process is about to
+be terminated by one of the following signals it dumps a readable stack
+trace **in addition to** the kernel coredump:
+
+`SIGSEGV` / `SIGABRT` / `SIGBUS` / `SIGFPE` / `SIGILL`
+
+The handler does not replace the coredump. After printing, it reraises
+the signal through the previous handler (default → kernel writes a
+coredump; ASAN attached → ASAN takes over). When you have both, the
+text dump is supplementary; when the coredump is lost (ulimit / bad
+`core_pattern`), the text dump is the only clue you have.
+
+## Where The Output Goes
+
+Each crash writes two copies simultaneously:
+
+| Location | Notes |
+|---|---|
+| `stderr` | Always written. Containers / systemd collect it for you |
+| `logs/std_stack_trace.log` | Relative to cwd, the same `logs/` dir as the alog config; `O_APPEND`, multiple crashes accumulate |
+
+If `logs/` cannot be created (permissions, read-only fs) the handler
+gracefully degrades to stderr only — server startup is **not** blocked.
+
+## Sample Output
+
+```
+*** KVCM CrashHandler caught signal 11 (SIGSEGV) at addr 0x..., pid 1234, tid 1234 ***
+version: 0.0.1+20260518.9bfcf9d5 (commit 9bfcf9d5, built 2026-05-18 10:30:09)
+si_code: 1 SEGV_MAPERR (address not mapped)
+time(epoch_sec): 1779085225
+Stack trace (12 frames, demangle with bin/decode_stack_trace.sh):
+#0 ./bin/kv_cache_manager_bin(_ZN3foo3barEv+0x1f)[0x55d...]
+#1 ./bin/kv_cache_manager_bin(_ZN3xyz4baz7processEPv+0x83)[0x55d...]
+...
+*** End of stack trace ***
+```
+
+Field reference:
+
+| Field | Meaning |
+|---|---|
+| `signal N (NAME)` | POSIX signal number and name |
+| `addr` | `siginfo_t::si_addr` — address that triggered the signal (the faulting address for SIGSEGV) |
+| `pid` / `tid` | Process ID / LWP ID of the thread that crashed |
+| `version` | Binary build version and git commit, used to pin code revision after the fact |
+| `si_code` | Refined cause. Common values: `SEGV_MAPERR` (address not mapped), `SEGV_ACCERR` (permission), `BUS_ADRALN` (alignment), `SI_USER`/`SI_TKILL` (user-space raise/tkill), etc. |
+| `time(epoch_sec)` | UNIX epoch second of the crash, useful for correlating with upstream/downstream logs |
+| `#N module(symbol+0xOFF)[0xABS]` | Frame N. `module` is the binary path; `symbol+0xOFF` is the symbol and the in-symbol offset; `[0xABS]` is the runtime virtual address |
+
+## Decoding The Trace: bin/decode_stack_trace.sh
+
+The package ships an offline decoder. It demangles symbols with
+`c++filt` and resolves `file:line` via `addr2line` + `nm` (best-effort):
+
+```bash
+# On the same host as the binary (typical dev workflow)
+bin/decode_stack_trace.sh logs/std_stack_trace.log
+
+# Cross-host: log was produced on host A, binary lives on host B
+bin/decode_stack_trace.sh \
+    -b /opt/kvcm/bin/kv_cache_manager_bin \
+    -l /opt/kvcm/lib \
+    crash.log
+
+# Reads from stdin too
+cat logs/std_stack_trace.log | bin/decode_stack_trace.sh
+```
+
+Decoded output:
+
+```
+Stack trace (12 frames, demangle with bin/decode_stack_trace.sh):
+  #0   kv_cache_manager::foo::bar()  at kv_cache_manager/foo/bar.cc:42  (kv_cache_manager_bin +0x1f)
+  #1   kv_cache_manager::xyz::baz::process(void*)  at kv_cache_manager/xyz/baz.cc:117  (kv_cache_manager_bin +0x83)
+  ...
+```
+
+Flags:
+
+| Flag | Purpose |
+|---|---|
+| `-b BINARY` | Override the main binary path embedded in the trace (cross-host analysis) |
+| `-l LIB_DIR` | Directory to look up `.so` files by basename as a fallback |
+| `-h` | Help |
+
+Dependencies (script degrades gracefully when missing): `c++filt`,
+`addr2line`, `nm`. All present in the default `binutils` / `gcc`
+package on most Linux distros.
+
+## CrashHandler vs Linux Coredump
+
+| | CrashHandler output | Linux coredump |
+|---|---|---|
+| Producer | Current process (`backtrace_symbols_fd`) | Kernel (gated by `ulimit -c` / `core_pattern`) |
+| Format | Text | ELF core file |
+| Size | KB | Process memory size (GB) |
+| Contents | One call stack | All threads' registers, stack, heap, mmap |
+| Tooling | Text utilities + decode_stack_trace.sh | `gdb ./binary core` |
+
+The two are complementary: CrashHandler answers "what's printable,
+greppable, alertable"; the coredump answers "every variable, every
+thread, fully debuggable".
+
+## Stack Overflow Protection For Worker Threads
+
+`sigaltstack` is a **per-thread** attribute: `Install()` only registers
+the alternate signal stack on the calling thread (typically the main
+thread). Threads spawned via `pthread_create` have **no** alt stack by
+default. We register the crash signals with `SA_ONSTACK`, but when the
+delivering thread has no alt stack the kernel falls back to that
+thread's own stack — fine for the vast majority of `SIGSEGV` cases
+(null-pointer dereference, UAF, …), but **broken for worker-thread
+stack overflows**: the handler tries to run on an already-exhausted
+stack and either truncates its output or fails to run at all.
+
+If your worker threads have genuine stack-overflow risk (deep
+recursion, large `alloca`/VLA, …), call
+`CrashHandler::InstallAltStackForCurrentThread()` at the thread entry:
+
+```cpp
+#include "kv_cache_manager/common/crash_handler.h"
+
+std::thread worker([] {
+    kv_cache_manager::CrashHandler::InstallAltStackForCurrentThread();
+    // ... thread body ...
+});
+```
+
+Properties:
+- **Idempotent**: repeated calls don't re-allocate.
+- **Auto-freed**: ~64 KB per thread, registered via a `pthread_key`
+  destructor so it's `free()`d automatically when the thread exits —
+  no manual cleanup.
+- **Fail-safe**: silent no-op on allocation failure; the worker simply
+  loses overflow protection, the thread itself and other crash paths
+  keep working.
+
+Non-overflow crashes do **not** need this API — the worker's own stack
+is intact, the handler runs there fine. Only opt in when you genuinely
+care about stack overflow.
+
+## Configuration
+
+No configuration. Auto-enabled. There is no enable/disable switch by
+design — this is a safety net and should not be turned off. To override
+the output directory you can call `CrashHandler::Install("/your/log/dir")`
+at the call site, but the default (`logs/`) already matches the alog
+config so no change is normally needed.

--- a/docs/crash-handler-zh_CN.md
+++ b/docs/crash-handler-zh_CN.md
@@ -1,0 +1,141 @@
+# Crash Stack Trace
+
+KVCacheManager 在 `CommandLine::RegisterSignal` 中默认安装了一个
+async-signal-safe 的 crash handler，用于在进程被以下信号终止时，
+**在 coredump 之外额外**保留一份可读的堆栈：
+
+`SIGSEGV` / `SIGABRT` / `SIGBUS` / `SIGFPE` / `SIGILL`
+
+handler 不会替代 coredump；它在打完堆栈后把信号 reraise 给原 handler
+（默认 → 内核生成 coredump；ASAN 拉起时 → ASAN 接管）。所以同时拥有
+coredump 时，handler 输出只是辅助；coredump 因 ulimit / `core_pattern`
+丢失时，handler 输出就是唯一线索。
+
+## 输出在哪里
+
+每次崩溃同时写两份：
+
+| 路径 | 备注 |
+|---|---|
+| `stderr` | 始终输出。容器/systemd 会自动收集 |
+| `logs/std_stack_trace.log` | 默认相对 cwd 的 `logs/`，与 alog 配置同目录；`O_APPEND` 追加，多次崩溃叠加 |
+
+`logs/` 目录创建失败（权限、只读 fs）时优雅降级为只写 stderr，**不会**
+阻塞 server 启动。
+
+## 输出样例
+
+```
+*** KVCM CrashHandler caught signal 11 (SIGSEGV) at addr 0x..., pid 1234, tid 1234 ***
+version: 0.0.1+20260518.9bfcf9d5 (commit 9bfcf9d5, built 2026-05-18 10:30:09)
+si_code: 1 SEGV_MAPERR (address not mapped)
+time(epoch_sec): 1779085225
+Stack trace (12 frames, demangle with bin/decode_stack_trace.sh):
+#0 ./bin/kv_cache_manager_bin(_ZN3foo3barEv+0x1f)[0x55d...]
+#1 ./bin/kv_cache_manager_bin(_ZN3xyz4baz7processEPv+0x83)[0x55d...]
+...
+*** End of stack trace ***
+```
+
+字段含义：
+
+| 字段 | 含义 |
+|---|---|
+| `signal N (NAME)` | POSIX 信号编号与名称 |
+| `addr` | `siginfo_t::si_addr` —— 触发信号的访问地址（SIGSEGV 时即非法访问的地址） |
+| `pid` / `tid` | 进程 ID / 触发崩溃线程的 LWP ID |
+| `version` | binary 的编译版本与 git commit，用于事后定位代码版本 |
+| `si_code` | 进一步细化的信号原因。常见取值：`SEGV_MAPERR`（访问未映射地址）、`SEGV_ACCERR`（权限错）、`BUS_ADRALN`（对齐错误）、`SI_USER`/`SI_TKILL`（用户态 raise/tkill）等 |
+| `time(epoch_sec)` | 崩溃时刻 UNIX 时间戳，便于和上下游日志对齐 |
+| `#N module(symbol+0xOFF)[0xABS]` | 第 N 帧。`module` 是二进制路径，`symbol+0xOFF` 是符号名+符号内偏移，`[0xABS]` 是运行时绝对地址 |
+
+## 解析堆栈：bin/decode_stack_trace.sh
+
+打包内置了一个离线解析脚本，用 `c++filt` demangle、`addr2line` 解
+file:line（best-effort）：
+
+```bash
+# 默认从同机的 binary 路径解析（适合开发机）
+bin/decode_stack_trace.sh logs/std_stack_trace.log
+
+# 跨机分析：日志在 A 机产生，binary/动态库在 B 机分析
+bin/decode_stack_trace.sh \
+    -b /opt/kvcm/bin/kv_cache_manager_bin \
+    -l /opt/kvcm/lib \
+    crash.log
+
+# 也可以从 stdin 读
+cat logs/std_stack_trace.log | bin/decode_stack_trace.sh
+```
+
+输出形如：
+
+```
+Stack trace (12 frames, demangle with bin/decode_stack_trace.sh):
+  #0   kv_cache_manager::foo::bar()  at kv_cache_manager/foo/bar.cc:42  (kv_cache_manager_bin +0x1f)
+  #1   kv_cache_manager::xyz::baz::process(void*)  at kv_cache_manager/xyz/baz.cc:117  (kv_cache_manager_bin +0x83)
+  ...
+```
+
+参数：
+
+| 参数 | 用途 |
+|---|---|
+| `-b BINARY` | 指定主 binary 路径，覆盖日志中嵌入的路径（跨机分析常用） |
+| `-l LIB_DIR` | 指定 .so 查找目录，按 basename 兜底 |
+| `-h` | 帮助 |
+
+依赖（不存在则优雅降级，不会失败）：`c++filt`、`addr2line`、`nm`。
+绝大多数 Linux 发行版的 `binutils` / `gcc` 默认包就有。
+
+## 与 coredump 的对比
+
+| | CrashHandler 输出 | Linux coredump |
+|---|---|---|
+| 谁产生 | 当前进程（`backtrace_symbols_fd`） | 内核（受 ulimit -c / core_pattern 控制） |
+| 格式 | 文本 | ELF core file |
+| 容量 | KB 级 | 进程内存大小（GB 级） |
+| 信息 | 一份调用栈 | 全部线程寄存器、栈、堆、mmap | 
+| 工具 | 文本工具 + decode_stack_trace.sh | `gdb ./binary core` |
+
+两者互补：CrashHandler 解决"文本能看到、能 grep、能告警"；coredump
+解决"全栈、所有变量、可调试"。
+
+## Worker 线程的栈溢出保护
+
+`sigaltstack` 是**线程级** attribute：`Install()` 只给调用线程（通常是
+主线程）装了 alternate signal stack。`pthread_create` 出来的 worker
+线程默认**没有** alt stack。SIGSEGV 等 crash signal 注册时带了
+`SA_ONSTACK`，kernel 在投递时如果当前线程没 alt stack 会 fallback
+到当前线程自己的 stack —— 对绝大多数 SIGSEGV（nullptr 解引用、UAF
+等）没影响，**只有 worker 线程发生栈溢出**时这个 fallback 是坏的：
+handler 在已经爆掉的 stack 上跑不起来，堆栈输出会丢失。
+
+如果你的 worker 线程有真正的栈溢出风险（深递归、超大 `alloca`/VLA
+等），在线程入口调一次 `CrashHandler::InstallAltStackForCurrentThread()`：
+
+```cpp
+#include "kv_cache_manager/common/crash_handler.h"
+
+std::thread worker([] {
+    kv_cache_manager::CrashHandler::InstallAltStackForCurrentThread();
+    // ... 业务逻辑 ...
+});
+```
+
+特性：
+- **幂等**：多次调用不会重复分配
+- **自动释放**：每线程 ~64 KB，通过 `pthread_key` destructor 在线程退出时
+  自动 `free`，不需要手动清理
+- **失败 fail-safe**：分配失败时静默返回，worker 失去栈溢出保护，但
+  线程本身和其他场景的 handler 都不受影响
+
+栈溢出之外的崩溃**不需要**这个 API —— worker 自己的 stack 本身没坏，
+handler 在 worker stack 上正常跑。仅在你确实关心栈溢出时再调。
+
+## 配置
+
+无需配置，自动启用。不存在 enable/disable 开关——这是兜底机制，
+不应被关闭。如果对产出文件位置有特殊要求，可在调用处覆盖
+`CrashHandler::Install("/your/log/dir")`，但默认值（`logs/`）已经和
+alog 配置一致，无需额外改动。

--- a/kv_cache_manager/common/BUILD
+++ b/kv_cache_manager/common/BUILD
@@ -86,6 +86,22 @@ cc_library(
 )
 
 cc_library(
+    name = "crash_handler",
+    srcs = [
+        "crash_handler.cc",
+    ],
+    hdrs = [
+        "crash_handler.h",
+    ],
+    linkopts = [
+        "-rdynamic",
+    ],
+    deps = [
+        ":build_version",
+    ],
+)
+
+cc_library(
     name = "jsonizable",
     srcs = [
         "jsonizable.cc",

--- a/kv_cache_manager/common/crash_handler.cc
+++ b/kv_cache_manager/common/crash_handler.cc
@@ -1,0 +1,535 @@
+#include "kv_cache_manager/common/crash_handler.h"
+
+#include <atomic>
+#include <errno.h>
+#include <execinfo.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "kv_cache_manager/common/build_version.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+constexpr int kMaxStackFrames = 128;
+constexpr size_t kAltStackSize = 64 * 1024;
+
+// 默认与 alog 配置（package/etc/default_logger_config.conf）使用同一个 logs/
+// 相对目录，使运维只需要保证 cwd 下有 logs/ 即可同时收集 alog 输出和崩溃栈。
+constexpr const char *kDefaultLogDir = "logs";
+constexpr const char *kCrashLogFileName = "std_stack_trace.log";
+
+constexpr int kCrashSignals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGFPE, SIGILL};
+constexpr size_t kNumSignals = sizeof(kCrashSignals) / sizeof(kCrashSignals[0]);
+
+std::atomic<bool> g_installed{false};
+std::atomic_flag g_in_handler = ATOMIC_FLAG_INIT;
+int g_log_fd = -1;
+char *g_alt_stack = nullptr;
+struct sigaction g_old_actions[kNumSignals];
+
+// 区分两类 handler 重入：
+//   - 跨线程：并发崩溃，g_in_handler 拦住第 N 个，pause 等第一个刷完
+//   - 同线程：user handler 内部又触发了一个 crash signal（典型：abort()
+//     家族 idiom 不 reset disposition 直接 raise(SIGABRT)，因为 SIGABRT
+//     还是我们接管，会再次落进 KvcmCrashSigaction）。这种情况绝不能去
+//     pause —— 第一个"进入者"就是当前线程自己，没有别的线程会刷完，
+//     进程直接 hang 死。
+// 用 thread_local 标记进入态；同线程重入直接走 fail-safe 退出。
+// thread_local 在已 init 完的线程上访问是 TLS slot 直读，async-signal-
+// safe（首次访问可能调 __tls_get_addr，但 handler 装在已运行的线程上，
+// 之前 C++ runtime 至少 access 过 TLS，slot 已经分配）。
+thread_local bool t_in_handler = false;
+
+// Per-thread alt stack 注册管理：用 pthread_key + destructor 保证 worker
+// 线程退出时自动 free 分配的 alt stack，不依赖业务方手动清理。
+pthread_key_t g_alt_stack_key;
+pthread_once_t g_alt_stack_key_once = PTHREAD_ONCE_INIT;
+
+void FreeThreadAltStack(void *p) {
+    if (p != nullptr) {
+        ::free(p);
+    }
+}
+
+void CreateAltStackKey() { ::pthread_key_create(&g_alt_stack_key, FreeThreadAltStack); }
+
+size_t WriteInt(char *buf, int64_t v) {
+    size_t off = 0;
+    uint64_t u;
+    if (v < 0) {
+        buf[off++] = '-';
+        u = static_cast<uint64_t>(-(v + 1)) + 1;
+    } else {
+        u = static_cast<uint64_t>(v);
+    }
+    if (u == 0) {
+        buf[off++] = '0';
+        return off;
+    }
+    char tmp[24];
+    size_t n = 0;
+    while (u > 0 && n < sizeof(tmp)) {
+        tmp[n++] = static_cast<char>('0' + (u % 10));
+        u /= 10;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        buf[off + i] = tmp[n - 1 - i];
+    }
+    return off + n;
+}
+
+size_t WriteUint(char *buf, uint64_t v) {
+    if (v == 0) {
+        buf[0] = '0';
+        return 1;
+    }
+    char tmp[24];
+    size_t n = 0;
+    while (v > 0 && n < sizeof(tmp)) {
+        tmp[n++] = static_cast<char>('0' + (v % 10));
+        v /= 10;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        buf[i] = tmp[n - 1 - i];
+    }
+    return n;
+}
+
+size_t WriteHex(char *buf, uint64_t v) {
+    buf[0] = '0';
+    buf[1] = 'x';
+    if (v == 0) {
+        buf[2] = '0';
+        return 3;
+    }
+    char tmp[16];
+    size_t n = 0;
+    while (v > 0 && n < sizeof(tmp)) {
+        int d = static_cast<int>(v & 0xf);
+        tmp[n++] = static_cast<char>(d < 10 ? '0' + d : 'a' + d - 10);
+        v >>= 4;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        buf[2 + i] = tmp[n - 1 - i];
+    }
+    return n + 2;
+}
+
+void WriteAll(int fd, const char *buf, size_t len) {
+    if (fd < 0) {
+        return;
+    }
+    while (len > 0) {
+        ssize_t n = ::write(fd, buf, len);
+        if (n > 0) {
+            buf += n;
+            len -= static_cast<size_t>(n);
+        } else if (n == -1 && errno == EINTR) {
+            continue;
+        } else {
+            break;
+        }
+    }
+}
+
+void WriteStr(int fd, const char *s) { WriteAll(fd, s, ::strlen(s)); }
+
+const char *SignalName(int sig) {
+    switch (sig) {
+    case SIGSEGV:
+        return "SIGSEGV";
+    case SIGABRT:
+        return "SIGABRT";
+    case SIGBUS:
+        return "SIGBUS";
+    case SIGFPE:
+        return "SIGFPE";
+    case SIGILL:
+        return "SIGILL";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+// 返回 si_code 的文字描述。优先匹配信号特定 code，再匹配通用 code。
+const char *SignalCodeName(int sig, int code) {
+    // 通用 code（kernel/headers 定义）
+    switch (code) {
+    case SI_USER:
+        return "SI_USER";
+    case SI_KERNEL:
+        return "SI_KERNEL";
+    case SI_QUEUE:
+        return "SI_QUEUE";
+    case SI_TIMER:
+        return "SI_TIMER";
+    case SI_MESGQ:
+        return "SI_MESGQ";
+    case SI_ASYNCIO:
+        return "SI_ASYNCIO";
+    case SI_TKILL:
+        return "SI_TKILL";
+    default:
+        break;
+    }
+    if (sig == SIGSEGV) {
+        switch (code) {
+        case SEGV_MAPERR:
+            return "SEGV_MAPERR (address not mapped)";
+        case SEGV_ACCERR:
+            return "SEGV_ACCERR (invalid permissions)";
+#ifdef SEGV_BNDERR
+        case SEGV_BNDERR:
+            return "SEGV_BNDERR (bounds check failed)";
+#endif
+#ifdef SEGV_PKUERR
+        case SEGV_PKUERR:
+            return "SEGV_PKUERR (protection key)";
+#endif
+        default:
+            break;
+        }
+    } else if (sig == SIGBUS) {
+        switch (code) {
+        case BUS_ADRALN:
+            return "BUS_ADRALN (invalid address alignment)";
+        case BUS_ADRERR:
+            return "BUS_ADRERR (non-existent physical address)";
+        case BUS_OBJERR:
+            return "BUS_OBJERR (object-specific hw error)";
+        default:
+            break;
+        }
+    } else if (sig == SIGFPE) {
+        switch (code) {
+        case FPE_INTDIV:
+            return "FPE_INTDIV (integer divide by zero)";
+        case FPE_INTOVF:
+            return "FPE_INTOVF (integer overflow)";
+        case FPE_FLTDIV:
+            return "FPE_FLTDIV (float divide by zero)";
+        case FPE_FLTOVF:
+            return "FPE_FLTOVF (float overflow)";
+        case FPE_FLTUND:
+            return "FPE_FLTUND (float underflow)";
+        case FPE_FLTRES:
+            return "FPE_FLTRES (float inexact result)";
+        case FPE_FLTINV:
+            return "FPE_FLTINV (float invalid op)";
+        case FPE_FLTSUB:
+            return "FPE_FLTSUB (subscript out of range)";
+        default:
+            break;
+        }
+    } else if (sig == SIGILL) {
+        switch (code) {
+        case ILL_ILLOPC:
+            return "ILL_ILLOPC (illegal opcode)";
+        case ILL_ILLOPN:
+            return "ILL_ILLOPN (illegal operand)";
+        case ILL_ILLADR:
+            return "ILL_ILLADR (illegal addressing mode)";
+        case ILL_ILLTRP:
+            return "ILL_ILLTRP (illegal trap)";
+        case ILL_PRVOPC:
+            return "ILL_PRVOPC (privileged opcode)";
+        case ILL_PRVREG:
+            return "ILL_PRVREG (privileged register)";
+        case ILL_COPROC:
+            return "ILL_COPROC (coprocessor error)";
+        case ILL_BADSTK:
+            return "ILL_BADSTK (internal stack error)";
+        default:
+            break;
+        }
+    }
+    return "UNKNOWN_CODE";
+}
+
+// 写入除堆栈外的所有头部字段（signal/version/si_code/time）。
+// frames/depth 由调用方在 handler 入口处一次性捕获，再分别写到 stderr 和
+// log 文件，避免在 handler 内多次调 ::backtrace —— 它会走
+// dl_iterate_phdr 的 glibc 全局锁，重复持有会扩大死锁窗口，且两次调用
+// 在极端优化路径下结果可能不一致。
+void DumpToFd(int fd, int sig, siginfo_t *info, void *const *frames, int depth) {
+    char buf[64];
+    size_t n;
+
+    WriteStr(fd, "*** KVCM CrashHandler caught signal ");
+    n = WriteUint(buf, static_cast<uint64_t>(sig));
+    WriteAll(fd, buf, n);
+    WriteStr(fd, " (");
+    WriteStr(fd, SignalName(sig));
+    WriteStr(fd, ") at addr ");
+    void *addr = info ? info->si_addr : nullptr;
+    n = WriteHex(buf, reinterpret_cast<uint64_t>(addr));
+    WriteAll(fd, buf, n);
+    WriteStr(fd, ", pid ");
+    n = WriteUint(buf, static_cast<uint64_t>(::getpid()));
+    WriteAll(fd, buf, n);
+    WriteStr(fd, ", tid ");
+    n = WriteUint(buf, static_cast<uint64_t>(::syscall(SYS_gettid)));
+    WriteAll(fd, buf, n);
+    WriteStr(fd, " ***\n");
+
+    WriteStr(fd, "version: " KVCM_FULL_VERSION " (commit " KVCM_GIT_COMMIT ", built " KVCM_BUILD_TIME ")\n");
+
+    if (info) {
+        WriteStr(fd, "si_code: ");
+        n = WriteInt(buf, static_cast<int64_t>(info->si_code));
+        WriteAll(fd, buf, n);
+        WriteStr(fd, " ");
+        WriteStr(fd, SignalCodeName(sig, info->si_code));
+        WriteStr(fd, "\n");
+    }
+
+    struct timespec ts;
+    if (::clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+        WriteStr(fd, "time(epoch_sec): ");
+        n = WriteUint(buf, static_cast<uint64_t>(ts.tv_sec));
+        WriteAll(fd, buf, n);
+        WriteStr(fd, "\n");
+    }
+
+    WriteStr(fd, "Stack trace (");
+    n = WriteUint(buf, static_cast<uint64_t>(depth));
+    WriteAll(fd, buf, n);
+    WriteStr(fd, " frames, demangle with bin/decode_stack_trace.sh):\n");
+    // 逐帧调 backtrace_symbols_fd(.., 1, ..)，中间插 "#N " 前缀。
+    // backtrace_symbols_fd 文档保证不调 malloc，async-signal-safe；
+    // size=1 是合法用法（参考 glibc 实现：循环里就是逐帧 dladdr+write）。
+    for (int i = 0; i < depth; ++i) {
+        char prefix[16];
+        size_t plen = 0;
+        prefix[plen++] = '#';
+        plen += WriteUint(prefix + plen, static_cast<uint64_t>(i));
+        prefix[plen++] = ' ';
+        WriteAll(fd, prefix, plen);
+        ::backtrace_symbols_fd(frames + i, 1, fd);
+    }
+    WriteStr(fd, "*** End of stack trace ***\n");
+}
+
+int FindSignalIndex(int sig) {
+    for (size_t i = 0; i < kNumSignals; ++i) {
+        if (kCrashSignals[i] == sig) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+// 调 user 旧 handler / 走 SIG_DFL（让内核默认行为接管 → terminate +
+// coredump）路径前，先解除当前线程对全部 crash signal 的阻塞。POSIX 在
+// handler 执行期间会把 sa_mask 里的信号加进当前线程 signal mask；我们
+// Install() 时把 5 个 crash signal 都加进了 mask。
+//
+// 必须 unblock 全部 5 个、而不是只 unblock 当前 sig —— user handler 可
+// 能用其他 crash signal 终止进程：例如 SIGSEGV handler 内部 abort()（=
+// raise(SIGABRT)），或 sanitizer 在 SIGSEGV handler 里 raise(SIGABRT)
+// 走自己的崩溃报告路径。如果只 unblock 当前 sig，其他 4 个 crash signal
+// 仍被阻塞，raise 只 pending，user handler return 后被 fail-safe _exit
+// 抢先终止，coredump / WIFSIGNALED 状态丢失。其他非 crash signal 的
+// mask 不动。
+void UnblockAllCrashSignalsInThread() {
+    sigset_t unblock;
+    ::sigemptyset(&unblock);
+    for (int s : kCrashSignals) {
+        ::sigaddset(&unblock, s);
+    }
+    ::pthread_sigmask(SIG_UNBLOCK, &unblock, nullptr);
+}
+
+extern "C" void KvcmCrashSigaction(int sig, siginfo_t *info, void *ucontext) {
+    int saved_errno = errno;
+
+    if (t_in_handler) {
+        // 同一线程在 handler 里又触发了 crash signal（user handler 内部
+        // raise 另一个 crash signal 又被我们接管）—— 不能进 pause()，没有
+        // 别的线程来打破等待，进程会 hang。直接走 fail-safe 退出。
+        ::_exit(128 + sig);
+    }
+    if (g_in_handler.test_and_set()) {
+        // 已有另一线程在处理：阻塞当前线程，等第一个线程把堆栈刷完后
+        // 再 raise 让整个进程退出，避免抢着 reraise 把第一个线程的
+        // 输出截断（pause 是 async-signal-safe）。
+        errno = saved_errno;
+        while (true) {
+            ::pause();
+        }
+    }
+    t_in_handler = true;
+
+    // 一次性捕获堆栈，避免在 handler 内重复持 dl_iterate_phdr 的 glibc 全局锁；
+    // 同一份 frames 同步写到 stderr 和 log 文件，保证两边输出严格一致。
+    void *frames[kMaxStackFrames];
+    int depth = ::backtrace(frames, kMaxStackFrames);
+
+    DumpToFd(STDERR_FILENO, sig, info, frames, depth);
+    if (g_log_fd >= 0) {
+        DumpToFd(g_log_fd, sig, info, frames, depth);
+        ::fsync(g_log_fd);
+    }
+
+    // 链式调用旧 handler：
+    //   1) SA_SIGINFO + 用户 handler  → 直接调，透传原始 (sig, info, ucontext)，
+    //      让 ASAN / sanitizer / breakpad 等看到真实崩溃上下文，而不是
+    //      raise(sig) 合成的 SI_TKILL 假上下文。
+    //   2) sa_handler 是 SIG_DFL       → sigaction 还原后 raise，让内核走
+    //      默认行为（生成 coredump）。
+    //   3) sa_handler 是用户 handler   → 直接调（SI_USER 合成上下文，无
+    //      办法回放原始 siginfo，但至少把崩溃通知给上层）。
+    //   4) sa_handler 是 SIG_IGN       → 跳过，走兜底退出，不能让进程
+    //      继续跑（synchronous fault 信号被 ignore 后会反复触发）。
+    //
+    // 所有"会进入 user 代码"的路径（1/2/3 + 末尾 fallback）都先 unblock 全
+    // 部 5 个 crash signal。Install() 的 sa_mask 把它们都阻塞了；user
+    // handler 内部经典 idiom "signal(sig, SIG_DFL); raise(sig);" 走 default
+    // disposition 拿 coredump 要 unblock 当前 sig，而 user handler 也可能
+    // 用其他 crash signal 终止进程（比如内部 abort() = raise(SIGABRT)），
+    // 所以 unblock 整个 set 而不是只 unblock 当前 sig，否则 raise 只 pending、
+    // 被 fail-safe _exit 抢先终止，coredump / WIFSIGNALED 状态丢失（参见
+    // DefaultDispositionCausesSignalTermination /
+    // ChainedUserHandlerCanReachDefaultDisposition /
+    // ChainedHandlerCanTerminateViaDifferentCrashSignal）。
+    // SIG_IGN 不需要 unblock —— 它直接跳到 fail-safe。
+    int idx = FindSignalIndex(sig);
+    if (idx >= 0) {
+        const struct sigaction &old = g_old_actions[idx];
+        errno = saved_errno;
+        if ((old.sa_flags & SA_SIGINFO) != 0 && old.sa_sigaction != nullptr) {
+            UnblockAllCrashSignalsInThread();
+            old.sa_sigaction(sig, info, ucontext);
+        } else if (old.sa_handler == SIG_DFL) {
+            ::sigaction(sig, &old, nullptr);
+            UnblockAllCrashSignalsInThread();
+            ::raise(sig);
+        } else if (old.sa_handler != SIG_IGN && old.sa_handler != nullptr) {
+            UnblockAllCrashSignalsInThread();
+            old.sa_handler(sig);
+        }
+    } else {
+        ::signal(sig, SIG_DFL);
+        errno = saved_errno;
+        UnblockAllCrashSignalsInThread();
+        ::raise(sig);
+    }
+
+    // 兜底：所有路径都没让进程退出（user handler return / SIG_IGN /
+    // raise 被 ignore 等），强制终止。否则 g_in_handler 永久 set，后续
+    // 任何崩溃都会卡死在上面的 pause() loop 里。退出码沿用 shell 惯例
+    // 128 + signo。
+    ::_exit(128 + sig);
+}
+
+} // namespace
+
+void CrashHandler::Install(const std::string &log_dir) {
+    bool expected = false;
+    if (!g_installed.compare_exchange_strong(expected, true)) {
+        return;
+    }
+
+    void *dummy[4];
+    (void)::backtrace(dummy, 4);
+
+    // 给主线程装 alt stack —— 如果别人（ASan/TSan/breakpad 等 crash
+    // reporter，或用户自己）已经装过，跳过：覆盖会让对方在进程退出时
+    // 按它记的旧地址 munmap 我们的 new 内存，触发 sanitizer 内部 CHECK
+    // 失败 abort 进程。逻辑和 InstallAltStackForCurrentThread() 一致。
+    // 保留 g_alt_stack = nullptr 表示我们没有分配，将来若有清理逻辑也
+    // 不会去 delete 一块属于别人的内存。
+    stack_t cur;
+    if (::sigaltstack(nullptr, &cur) != 0 || (cur.ss_flags & SS_DISABLE) != 0) {
+        g_alt_stack = new char[kAltStackSize];
+        stack_t ss;
+        ::memset(&ss, 0, sizeof(ss));
+        ss.ss_sp = g_alt_stack;
+        ss.ss_size = kAltStackSize;
+        ss.ss_flags = 0;
+        ::sigaltstack(&ss, nullptr);
+    }
+
+    // log_dir 为空时使用与 alog 一致的默认目录。stderr 始终打印一份；这里
+    // 额外把 fd 准备好，handler 触发时同时落盘（如果 open 失败会优雅降级
+    // 为只写 stderr）。
+    {
+        std::string dir = log_dir.empty() ? std::string(kDefaultLogDir) : log_dir;
+        if (::mkdir(dir.c_str(), 0755) != 0 && errno != EEXIST) {
+            // mkdir 失败（权限/磁盘等）：保留 g_log_fd = -1，handler 仅写 stderr
+        } else {
+            std::string path = dir;
+            if (path.back() != '/') {
+                path += '/';
+            }
+            path += kCrashLogFileName;
+            g_log_fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);
+        }
+    }
+
+    struct sigaction act;
+    ::memset(&act, 0, sizeof(act));
+    act.sa_sigaction = &KvcmCrashSigaction;
+    ::sigemptyset(&act.sa_mask);
+    for (int s : kCrashSignals) {
+        ::sigaddset(&act.sa_mask, s);
+    }
+    // 不使用 SA_RESETHAND：在多线程场景下，SA_RESETHAND 会在第一个线程进入
+    // handler 时立刻把 SIGSEGV 的进程级 disposition 重置为 SIG_DFL。其他线程
+    // 同期 raise(SIGSEGV) 会让整个进程被默认行为 kill，第一个线程的输出会被
+    // 截断。改为依赖 g_in_handler + pause() 拦住二次进入的线程，让第一个线程
+    // 完整打完后再恢复 oldact 并 reraise。
+    act.sa_flags = SA_SIGINFO | SA_ONSTACK;
+
+    for (size_t i = 0; i < kNumSignals; ++i) {
+        ::sigaction(kCrashSignals[i], &act, &g_old_actions[i]);
+    }
+}
+
+bool CrashHandler::IsInstalled() { return g_installed.load(); }
+
+void CrashHandler::InstallAltStackForCurrentThread() {
+    ::pthread_once(&g_alt_stack_key_once, CreateAltStackKey);
+
+    // 自己之前装过 → 幂等，直接返回。
+    if (::pthread_getspecific(g_alt_stack_key) != nullptr) {
+        return;
+    }
+
+    // 别人已经装了（ASan/TSan 在线程创建时会自动装 SIGSTKSZ*4 大小的；用
+    // 户自己也可能装）→ 不要覆盖。sanitizer 在线程退出时会按自己的地址
+    // munmap，被我们替换后会触发它内部 CHECK 失败把进程 abort，反不如
+    // 当作 no-op，让别人继续管理。
+    stack_t cur;
+    if (::sigaltstack(nullptr, &cur) == 0 && (cur.ss_flags & SS_DISABLE) == 0) {
+        return;
+    }
+
+    void *sp = ::malloc(kAltStackSize);
+    if (sp == nullptr) {
+        return; // 分配失败：worker 失去栈溢出保护，但其他场景的 handler 仍可用
+    }
+    // 用 pthread_setspecific 托管，线程退出时 destructor 自动 free。
+    // 即使后面的 sigaltstack 失败也要登记，避免下次重复分配。
+    ::pthread_setspecific(g_alt_stack_key, sp);
+
+    stack_t ss;
+    ::memset(&ss, 0, sizeof(ss));
+    ss.ss_sp = sp;
+    ss.ss_size = kAltStackSize;
+    ss.ss_flags = 0;
+    ::sigaltstack(&ss, nullptr);
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/common/crash_handler.h
+++ b/kv_cache_manager/common/crash_handler.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+namespace kv_cache_manager {
+
+class CrashHandler {
+public:
+    static void Install(const std::string &log_dir = "");
+
+    static bool IsInstalled();
+
+    // 给当前线程装一个 alternate signal stack，用于 SIGSEGV 等 crash signal
+    // 在线程**栈溢出**时的兜底输出。Install() 只装了主线程，pthread_create
+    // 出来的 worker 线程默认没有 alt stack —— 这些线程发生栈溢出时，handler
+    // 在已经爆掉的 worker stack 上跑不起来，堆栈输出可能丢失或截断。
+    //
+    // 调用约定：在 worker 线程入口（pthread 回调的开头）调一次即可，幂等。
+    // 内存按线程分配（约 64 KB），随线程退出自动释放。栈溢出之外的崩溃
+    // （nullptr 解引用、UAF 等）不需要这个 —— worker stack 本身没坏，
+    // handler 正常跑。仅在线程有强烈的栈溢出担忧时调用。
+    static void InstallAltStackForCurrentThread();
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/common/test/BUILD
+++ b/kv_cache_manager/common/test/BUILD
@@ -27,6 +27,22 @@ cc_test(
 )
 
 cc_test(
+    name = "CrashHandlerTest",
+    srcs = [
+        "crash_handler_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    linkopts = [
+        "-rdynamic",
+    ],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:crash_handler",
+        "//kv_cache_manager/common:unittest",
+    ],
+)
+
+cc_test(
     name = "JsonizableTest",
     srcs = [
         "jsonizable_test.cc",

--- a/kv_cache_manager/common/test/crash_handler_test.cc
+++ b/kv_cache_manager/common/test/crash_handler_test.cc
@@ -1,0 +1,685 @@
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <fcntl.h>
+#include <fstream>
+#include <signal.h>
+#include <sstream>
+#include <string.h>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "kv_cache_manager/common/build_version.h"
+#include "kv_cache_manager/common/crash_handler.h"
+#include "kv_cache_manager/common/unittest.h"
+
+using namespace kv_cache_manager;
+
+namespace {
+
+// 把 child_pipe_write 重定向到 stderr，确保 handler 写 stderr 时被父进程收到
+void RedirectStderrTo(int fd) {
+    dup2(fd, STDERR_FILENO);
+    close(fd);
+}
+
+std::string ReadAllFromFd(int fd) {
+    std::string out;
+    char buf[4096];
+    while (true) {
+        ssize_t n = ::read(fd, buf, sizeof(buf));
+        if (n > 0) {
+            out.append(buf, buf + n);
+        } else if (n == 0) {
+            break;
+        } else if (errno == EINTR) {
+            continue;
+        } else {
+            break;
+        }
+    }
+    return out;
+}
+
+std::string SlurpFile(const std::string &path) {
+    std::ifstream ifs(path);
+    std::stringstream ss;
+    ss << ifs.rdbuf();
+    return ss.str();
+}
+
+struct ChildResult {
+    int wstatus = 0;
+    std::string stderr_output;
+};
+
+// 在子进程跑 body()，把它的 stderr 抓出来；body 中可以触发崩溃
+template <typename F>
+ChildResult RunInChild(F &&body) {
+    int pipefd[2];
+    if (::pipe(pipefd) != 0) {
+        ADD_FAILURE() << "pipe() failed: " << strerror(errno);
+        return {};
+    }
+    pid_t pid = ::fork();
+    if (pid == 0) {
+        ::close(pipefd[0]);
+        RedirectStderrTo(pipefd[1]);
+        body();
+        // body 应该已经触发了崩溃，正常不会到这里
+        _exit(0);
+    }
+    ::close(pipefd[1]);
+    std::string out = ReadAllFromFd(pipefd[0]);
+    ::close(pipefd[0]);
+    int wstatus = 0;
+    ::waitpid(pid, &wstatus, 0);
+    return {wstatus, out};
+}
+
+bool ChildAbnormal(int wstatus) {
+    if (WIFSIGNALED(wstatus)) {
+        return true;
+    }
+    // ASAN 模式下子进程可能 _exit(非 0)
+    if (WIFEXITED(wstatus) && WEXITSTATUS(wstatus) != 0) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+class CrashHandlerTest : public TESTBASE {};
+
+TEST_F(CrashHandlerTest, InstalledFlagBecomesTrue) {
+    auto r = RunInChild([] {
+        if (CrashHandler::IsInstalled()) {
+            _exit(2); // 安装前不应为 true
+        }
+        CrashHandler::Install("");
+        if (!CrashHandler::IsInstalled()) {
+            _exit(3); // 安装后必须为 true
+        }
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFEXITED(r.wstatus)) << "child terminated by signal";
+    ASSERT_EQ(0, WEXITSTATUS(r.wstatus)) << "child exit=" << WEXITSTATUS(r.wstatus);
+}
+
+TEST_F(CrashHandlerTest, HandlesSigsegvWritesToStderr) {
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        // 主动触发：raise(SIGSEGV) 比解引用 nullptr 在 ASAN 下更可控
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus)) << "child exited normally, wstatus=" << r.wstatus;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("KVCM CrashHandler")) << "no header in stderr:\n"
+                                                                            << r.stderr_output;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("SIGSEGV")) << "no SIGSEGV in stderr:\n" << r.stderr_output;
+    // backtrace_symbols_fd 输出形如 "./bin(func+0x..)[0x..]"，至少应包含 "0x"
+    EXPECT_NE(std::string::npos, r.stderr_output.find("0x")) << "no stack frames in stderr:\n" << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, HandlesSigabrt) {
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        ::raise(SIGABRT);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus));
+    EXPECT_NE(std::string::npos, r.stderr_output.find("SIGABRT")) << "stderr:\n" << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, WritesToCrashLogFile) {
+    std::string log_dir = GetPrivateTestRuntimeDataPath();
+    std::string log_path = log_dir + "std_stack_trace.log";
+    ::unlink(log_path.c_str());
+
+    auto r = RunInChild([log_dir] {
+        CrashHandler::Install(log_dir);
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus));
+    struct stat st;
+    ASSERT_EQ(0, ::stat(log_path.c_str(), &st)) << "crash.log not found at " << log_path;
+    ASSERT_GT(st.st_size, 0) << "crash.log is empty";
+    std::string content = SlurpFile(log_path);
+    EXPECT_NE(std::string::npos, content.find("SIGSEGV")) << "log content:\n" << content;
+    EXPECT_NE(std::string::npos, content.find("KVCM CrashHandler")) << "log content:\n" << content;
+}
+
+TEST_F(CrashHandlerTest, NormalSignalsUnaffected) {
+    // SIGINT/SIGTERM 等非 crash 信号不应被 CrashHandler 接管：默认 SIGUSR1 让进程死掉
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        ::signal(SIGUSR1, SIG_DFL);
+        ::raise(SIGUSR1);
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFSIGNALED(r.wstatus));
+    EXPECT_EQ(SIGUSR1, WTERMSIG(r.wstatus));
+    // CrashHandler 不应该被触发
+    EXPECT_EQ(std::string::npos, r.stderr_output.find("KVCM CrashHandler"))
+        << "stderr unexpectedly contains crash header:\n"
+        << r.stderr_output;
+}
+
+class CrashSignalParamTest : public TESTBASE, public ::testing::WithParamInterface<int> {};
+
+TEST_P(CrashSignalParamTest, HandlesSignal) {
+    int sig = GetParam();
+    auto r = RunInChild([sig] {
+        CrashHandler::Install("");
+        ::raise(sig);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus)) << "sig=" << sig << " wstatus=" << r.wstatus;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("KVCM CrashHandler")) << "sig=" << sig << " stderr:\n"
+                                                                            << r.stderr_output;
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCrashSignals,
+                         CrashSignalParamTest,
+                         ::testing::Values(SIGSEGV, SIGABRT, SIGBUS, SIGFPE, SIGILL));
+
+TEST_F(CrashHandlerTest, InstallIsIdempotent) {
+    // 多次 Install 不应崩溃，且仍然生效
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        CrashHandler::Install("");
+        CrashHandler::Install("");
+        if (!CrashHandler::IsInstalled()) {
+            _exit(2);
+        }
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus));
+    EXPECT_NE(std::string::npos, r.stderr_output.find("SIGSEGV")) << "stderr:\n" << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, InstallDoesNotOverwriteExistingAltStack) {
+    // ASan/TSan/breakpad 等在进程启动时会自动给主线程装 alt stack。Install
+    // 必须复用而不是替换，否则对方在退出时按自己记的旧地址 munmap，发现
+    // 地址被换 → sanitizer 内部 CHECK 失败 abort 进程。和
+    // InstallAltStackForCurrentThread() 同款 no-op 策略。
+    auto r = RunInChild([] {
+        stack_t before;
+        if (::sigaltstack(nullptr, &before) != 0) {
+            _exit(10);
+        }
+        if ((before.ss_flags & SS_DISABLE) != 0) {
+            // 没人预装（非 sanitizer 环境）：跳过断言，测试无意义
+            _exit(0);
+        }
+
+        CrashHandler::Install("");
+
+        stack_t after;
+        if (::sigaltstack(nullptr, &after) != 0) {
+            _exit(11);
+        }
+        if (before.ss_sp != after.ss_sp) {
+            _exit(12); // Install 覆盖了
+        }
+        if (before.ss_size != after.ss_size) {
+            _exit(13);
+        }
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFEXITED(r.wstatus)) << "wstatus=" << r.wstatus;
+    EXPECT_EQ(0, WEXITSTATUS(r.wstatus)) << "Install() overwrote pre-existing alt stack, code="
+                                         << WEXITSTATUS(r.wstatus);
+}
+
+TEST_F(CrashHandlerTest, ConcurrentCrashesDoNotDeadlock) {
+    // 多线程同时 raise SEGV，handler 不应死锁；至少一次完整堆栈被打印。
+    // alarm(5) 是兜底：如果未来回归引入死锁，子进程 5 秒后被 SIGALRM 杀掉，
+    // 而不是吃满 bazel test 的 5 分钟超时。
+    auto r = RunInChild([] {
+        ::alarm(5);
+        CrashHandler::Install("");
+        constexpr int kThreads = 8;
+        std::atomic<int> ready{0};
+        std::atomic<bool> go{false};
+        std::vector<std::thread> ts;
+        for (int i = 0; i < kThreads; ++i) {
+            ts.emplace_back([&] {
+                ready.fetch_add(1);
+                while (!go.load()) {
+                    std::this_thread::yield();
+                }
+                ::raise(SIGSEGV);
+            });
+        }
+        while (ready.load() < kThreads) {
+            std::this_thread::yield();
+        }
+        go.store(true);
+        for (auto &t : ts) {
+            t.join();
+        }
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus)) << "wstatus=" << r.wstatus;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("KVCM CrashHandler")) << "stderr:\n" << r.stderr_output;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("End of stack trace"))
+        << "stderr (truncated handler output may indicate deadlock):\n"
+        << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, OutputContainsBuildVersion) {
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_NE(std::string::npos, r.stderr_output.find("version:")) << "stderr:\n" << r.stderr_output;
+    EXPECT_NE(std::string::npos, r.stderr_output.find(KVCM_GIT_COMMIT))
+        << "no git commit in stderr (looking for " << KVCM_GIT_COMMIT << "):\n"
+        << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, SiCodeIsSignedNotHuge) {
+    // SI_TKILL = -6；之前的 bug 是把负数当 uint64_t 打印成 18446744073709551610。
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_EQ(std::string::npos, r.stderr_output.find("18446744073709551")) << "si_code printed as unsigned overflow:\n"
+                                                                            << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, OutputContainsSiCode) {
+    // raise(SIGSEGV) 由 tkill(2) 实现，si_code 是 SI_USER 或 SI_TKILL。
+    // 实际触发的非法访问（kernel 发的）si_code 是 SEGV_MAPERR/SEGV_ACCERR。
+    // 这里只断言"si_code:" 字段存在以及 _USER/_KERNEL/_TKILL 之一出现。
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_NE(std::string::npos, r.stderr_output.find("si_code:")) << "stderr:\n" << r.stderr_output;
+    bool any =
+        r.stderr_output.find("SI_USER") != std::string::npos || r.stderr_output.find("SI_TKILL") != std::string::npos ||
+        r.stderr_output.find("SI_KERNEL") != std::string::npos || r.stderr_output.find("SEGV_") != std::string::npos;
+    EXPECT_TRUE(any) << "no recognizable si_code name in stderr:\n" << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, DefaultInstallWritesToLogsDir) {
+    // 不传 log_dir：应该在子进程 cwd 下创建 logs/std_stack_trace.log，
+    // 与 alog 配置文件 (default_logger_config.conf) 用的相对目录一致。
+    std::string runtime = GetPrivateTestRuntimeDataPath();
+    std::string expected_path = runtime + "logs/std_stack_trace.log";
+    ::unlink(expected_path.c_str());
+
+    auto r = RunInChild([runtime] {
+        // 子进程切到测试 runtime 目录，使 logs/ 落到隔离的位置，避免污染
+        // 外层 bazel test 的工作目录。
+        if (::chdir(runtime.c_str()) != 0) {
+            _exit(2);
+        }
+        CrashHandler::Install(); // 默认参数
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus));
+    struct stat st;
+    ASSERT_EQ(0, ::stat(expected_path.c_str(), &st)) << "expected " << expected_path;
+    ASSERT_GT(st.st_size, 0);
+    std::string content = SlurpFile(expected_path);
+    EXPECT_NE(std::string::npos, content.find("SIGSEGV"));
+    EXPECT_NE(std::string::npos, content.find("KVCM CrashHandler"));
+}
+
+TEST_F(CrashHandlerTest, CrashLogStructuredFields) {
+    std::string log_dir = GetPrivateTestRuntimeDataPath();
+    std::string log_path = log_dir + "std_stack_trace.log";
+    ::unlink(log_path.c_str());
+
+    auto r = RunInChild([log_dir] {
+        CrashHandler::Install(log_dir);
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus));
+    std::string content = SlurpFile(log_path);
+    EXPECT_NE(std::string::npos, content.find("*** KVCM CrashHandler caught signal"));
+    EXPECT_NE(std::string::npos, content.find("SIGSEGV"));
+    EXPECT_NE(std::string::npos, content.find("version:"));
+    EXPECT_NE(std::string::npos, content.find("si_code:"));
+    EXPECT_NE(std::string::npos, content.find("time(epoch_sec):"));
+    EXPECT_NE(std::string::npos, content.find("Stack trace ("));
+    EXPECT_NE(std::string::npos, content.find("*** End of stack trace ***"));
+}
+
+namespace {
+
+// 装在 SIGSEGV 上的 sa_handler：写个标记到 stderr 然后直接 return，
+// 暴露"chained handler 返回"路径，验证 fail-safe 是否兜底退出。
+void UserReturningSegvHandler(int /*sig*/) {
+    const char msg[] = "USER_RETURNING_HANDLER_INVOKED\n";
+    ::write(STDERR_FILENO, msg, sizeof(msg) - 1);
+}
+
+// 装在 SIGSEGV 上的 SA_SIGINFO handler：写标记 + 报告 si_code，验证
+// CrashHandler 通过 sa_sigaction 路径链式调用旧 handler 时，原始
+// siginfo 被透传过去（不是 raise(sig) 合成的 SI_TKILL/SI_USER 假上下文）。
+void UserSigactionSegvHandler(int /*sig*/, siginfo_t *info, void * /*ucontext*/) {
+    const char msg[] = "USER_SIGACTION_HANDLER_INVOKED\n";
+    ::write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    if (info != nullptr) {
+        const char tag[] = "USER_SIGACTION_GOT_SIGINFO\n";
+        ::write(STDERR_FILENO, tag, sizeof(tag) - 1);
+    }
+}
+
+// 经典 idiom：恢复 default 再 raise，期望被 kernel 默认行为杀掉生成
+// coredump。验证 KvcmCrashSigaction 在调 user handler 前 unblock 了 sig
+// —— 否则 raise 只让信号 pending，user handler return 后被 fail-safe
+// _exit 抢先终止，进程以 exit(139) 退出而不是 WIFSIGNALED。
+void UserHandlerChainsToDefault(int sig) {
+    ::signal(sig, SIG_DFL);
+    ::raise(sig);
+    // 不应到达
+}
+
+void UserSigactionChainsToDefault(int sig, siginfo_t * /*info*/, void * /*ucontext*/) {
+    ::signal(sig, SIG_DFL);
+    ::raise(sig);
+}
+
+// SIGSEGV handler 里 abort()（= raise(SIGABRT)），模拟 sanitizer / 通用
+// crash reporter 用另一个 crash signal 终止进程的典型路径。验证
+// KvcmCrashSigaction unblock 的是全部 5 个 crash signal、而不是只解开当前
+// sig —— 否则 SIGABRT 还在 sa_mask 里被阻塞，raise 只 pending，user
+// handler return 后被 fail-safe _exit 抢先终止，子进程不会被 SIGABRT 杀死。
+void UserSegvHandlerRaisesSigabrt(int /*sig*/) {
+    ::signal(SIGABRT, SIG_DFL);
+    ::raise(SIGABRT);
+}
+
+// 故意**不** reset SIGABRT 的 disposition 就 raise —— SIGABRT 仍是
+// KvcmCrashSigaction，会再次落进来。验证同线程重入不死锁：第二次进入
+// 检测到 t_in_handler 直接 fail-safe _exit(128+SIGABRT)，而不是进
+// pause() 等永远不会到来的"第一个线程"。
+void UserSegvHandlerRaisesSigabrtNoReset(int /*sig*/) { ::raise(SIGABRT); }
+
+} // namespace
+
+TEST_F(CrashHandlerTest, DefaultDispositionCausesSignalTermination) {
+    // 装 CrashHandler 前把 SIGSEGV oldact 拉回 SIG_DFL（盖掉 ASan 等
+    // runtime 注册的 handler），让链式调用走到 SIG_DFL 分支。
+    //
+    // 历史 bug：handler 装 sa_mask 时把全部 crash signal 都加进去，导致
+    // 进入 handler 后 sig 被当前线程 mask 阻塞；SIG_DFL 路径裸 raise(sig)
+    // 只能让信号 pending，立刻被后面的 _exit(128+sig) 抢先终止 —— 进程
+    // exit code 是 139，但 WIFSIGNALED 为 false，kernel 也不生成 coredump，
+    // docs 里承诺的"handler 不替代 coredump"实际失效。
+    //
+    // 修复后 SIG_DFL 路径会 pthread_sigmask 解阻塞再 raise，进程真正被
+    // SIGSEGV 杀死，WIFSIGNALED 为 true。
+    auto r = RunInChild([] {
+        ::signal(SIGSEGV, SIG_DFL);
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFSIGNALED(r.wstatus)) << "child exited normally, kernel will not generate coredump. wstatus="
+                                        << r.wstatus;
+    EXPECT_EQ(SIGSEGV, WTERMSIG(r.wstatus));
+}
+
+TEST_F(CrashHandlerTest, FailSafeExitsWhenChainedHandlerReturns) {
+    auto r = RunInChild([] {
+        struct sigaction sa;
+        ::memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = UserReturningSegvHandler;
+        ::sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        ::sigaction(SIGSEGV, &sa, nullptr);
+
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0); // 不应到达：CrashHandler 兜底必须强制退出
+    });
+    ASSERT_TRUE(WIFEXITED(r.wstatus)) << "child killed by signal, wstatus=" << r.wstatus;
+    EXPECT_EQ(128 + SIGSEGV, WEXITSTATUS(r.wstatus))
+        << "fail-safe _exit(128+sig) not taken; chained user handler returned and "
+           "process kept running. wstatus="
+        << r.wstatus;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("USER_RETURNING_HANDLER_INVOKED")) << "old handler not chained:\n"
+                                                                                         << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, OldSigIgnDoesNotDeadlock) {
+    auto r = RunInChild([] {
+        // SIGABRT 是为数不多可以 SIG_IGN 的 crash 信号；之前的实现里
+        // raise(SIGABRT) 会被 ignore 吞掉，进程继续跑，g_in_handler 永
+        // 久 set，下次崩溃就卡 pause()。这里直接验证不会死循环。
+        ::signal(SIGABRT, SIG_IGN);
+        CrashHandler::Install("");
+        ::raise(SIGABRT);
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFEXITED(r.wstatus)) << "child killed by signal, wstatus=" << r.wstatus;
+    EXPECT_EQ(128 + SIGABRT, WEXITSTATUS(r.wstatus));
+}
+
+TEST_F(CrashHandlerTest, ChainedSigactionPathInvoked) {
+    auto r = RunInChild([] {
+        struct sigaction sa;
+        ::memset(&sa, 0, sizeof(sa));
+        sa.sa_sigaction = UserSigactionSegvHandler;
+        ::sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_SIGINFO;
+        ::sigaction(SIGSEGV, &sa, nullptr);
+
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus));
+    // SA_SIGINFO 旧 handler 必须经 sa_sigaction 路径调用（而非 raise 合成）
+    EXPECT_NE(std::string::npos, r.stderr_output.find("USER_SIGACTION_HANDLER_INVOKED"))
+        << "SA_SIGINFO old handler not chained via sa_sigaction:\n"
+        << r.stderr_output;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("USER_SIGACTION_GOT_SIGINFO"))
+        << "siginfo not forwarded to chained handler:\n"
+        << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, ChainedUserHandlerCanReachDefaultDisposition) {
+    // 装一个 user sa_handler，内部跑经典 idiom "signal(sig, SIG_DFL); raise(sig);"
+    // 期望走 default disposition 杀掉进程生成 coredump。验证 KvcmCrashSigaction
+    // 在调 user handler 前已经 unblock 了 sig —— 否则 raise 只让信号 pending，
+    // user handler return 后被 fail-safe _exit(128+sig) 抢先终止，wstatus 是
+    // exit(139) 而非 WIFSIGNALED，kernel 不生成 coredump。
+    auto r = RunInChild([] {
+        struct sigaction sa;
+        ::memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = UserHandlerChainsToDefault;
+        ::sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        ::sigaction(SIGSEGV, &sa, nullptr);
+
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFSIGNALED(r.wstatus)) << "user handler's chain-to-default got swallowed by "
+                                           "fail-safe _exit (sig still blocked?). wstatus="
+                                        << r.wstatus;
+    EXPECT_EQ(SIGSEGV, WTERMSIG(r.wstatus));
+}
+
+TEST_F(CrashHandlerTest, ChainedHandlerCanTerminateViaDifferentCrashSignal) {
+    // SIGSEGV user handler 内部 raise(SIGABRT)（abort 的实质路径）。
+    // KvcmCrashSigaction 必须 unblock 全部 5 个 crash signal，而不是只解开
+    // 当前 sig（SIGSEGV），否则 SIGABRT 还在 sa_mask 里阻塞，raise 只
+    // pending，user handler return 后被 fail-safe _exit(128+SIGSEGV) 抢先
+    // 终止；子进程是 _exit(139) 而不是 WIFSIGNALED == true, WTERMSIG == SIGABRT。
+    auto r = RunInChild([] {
+        struct sigaction sa;
+        ::memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = UserSegvHandlerRaisesSigabrt;
+        ::sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        ::sigaction(SIGSEGV, &sa, nullptr);
+
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFSIGNALED(r.wstatus)) << "child not killed by signal — SIGABRT got swallowed by fail-safe _exit "
+                                           "(other crash signals still blocked by sa_mask?). wstatus="
+                                        << r.wstatus;
+    EXPECT_EQ(SIGABRT, WTERMSIG(r.wstatus));
+}
+
+TEST_F(CrashHandlerTest, ReentrantSameThreadHandlerDoesNotHang) {
+    // SIGSEGV user handler 内部裸 raise(SIGABRT)（不 reset disposition）
+    // 是个常见的 idiom 边角 case：SIGABRT 仍是 KvcmCrashSigaction，会再次
+    // 落进来。修复前 g_in_handler 已 set 第二次进入会进 pause() 死循环，
+    // 进程 hang 死；修复后 thread_local t_in_handler 标记当前线程已在
+    // handler 里，第二次进入直接 _exit(128+SIGABRT) = 134。
+    // alarm(3) 兜底：如果回归 hang 了，3 秒后被 SIGALRM 杀掉，避免吃满
+    // bazel test 的 5 分钟超时。
+    auto r = RunInChild([] {
+        ::alarm(3);
+        struct sigaction sa;
+        ::memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = UserSegvHandlerRaisesSigabrtNoReset;
+        ::sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        ::sigaction(SIGSEGV, &sa, nullptr);
+
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    // 关键：必须不是 SIGALRM 杀的（hang 的话才会走到 SIGALRM 兜底）。
+    if (WIFSIGNALED(r.wstatus)) {
+        ASSERT_NE(SIGALRM, WTERMSIG(r.wstatus))
+            << "handler re-entered itself and hung in pause(); SIGALRM killed the child";
+    }
+    ASSERT_TRUE(WIFEXITED(r.wstatus)) << "wstatus=" << r.wstatus;
+    EXPECT_EQ(128 + SIGABRT, WEXITSTATUS(r.wstatus));
+}
+
+TEST_F(CrashHandlerTest, ChainedSigactionHandlerCanReachDefaultDisposition) {
+    // SA_SIGINFO 路径的对称覆盖：同样的 chain-to-default idiom 装在 sa_sigaction，
+    // 验证 KvcmCrashSigaction 在调 SA_SIGINFO user handler 前也 unblock 了 sig。
+    auto r = RunInChild([] {
+        struct sigaction sa;
+        ::memset(&sa, 0, sizeof(sa));
+        sa.sa_sigaction = UserSigactionChainsToDefault;
+        ::sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_SIGINFO;
+        ::sigaction(SIGSEGV, &sa, nullptr);
+
+        CrashHandler::Install("");
+        ::raise(SIGSEGV);
+        _exit(0);
+    });
+    ASSERT_TRUE(WIFSIGNALED(r.wstatus)) << "SA_SIGINFO user handler's chain-to-default got "
+                                           "swallowed. wstatus="
+                                        << r.wstatus;
+    EXPECT_EQ(SIGSEGV, WTERMSIG(r.wstatus));
+}
+
+TEST_F(CrashHandlerTest, InstallAltStackForCurrentThreadRegistersAltStack) {
+    // worker 线程上调 API 后，sigaltstack 查询应该返回非 disable 的 alt stack。
+    // 用 exit code 编码失败原因：0 = OK，10+ = 各种失败点。
+    auto r = RunInChild([] {
+        int rc = 0;
+        std::thread t([&] {
+            CrashHandler::InstallAltStackForCurrentThread();
+            stack_t cur;
+            if (::sigaltstack(nullptr, &cur) != 0) {
+                rc = 10;
+                return;
+            }
+            if (cur.ss_sp == nullptr) {
+                rc = 11;
+                return;
+            }
+            if (cur.ss_size == 0) {
+                rc = 12;
+                return;
+            }
+            if ((cur.ss_flags & SS_DISABLE) != 0) {
+                rc = 13;
+                return;
+            }
+        });
+        t.join();
+        _exit(rc);
+    });
+    ASSERT_TRUE(WIFEXITED(r.wstatus)) << "child killed by signal, wstatus=" << r.wstatus << " stderr:\n"
+                                      << r.stderr_output;
+    EXPECT_EQ(0, WEXITSTATUS(r.wstatus)) << "alt stack check failed with code " << WEXITSTATUS(r.wstatus)
+                                         << " stderr:\n"
+                                         << r.stderr_output;
+}
+
+TEST_F(CrashHandlerTest, InstallAltStackForCurrentThreadIsIdempotent) {
+    // 多次调用应不会重新分配 alt stack（sp 不变），避免泄漏。
+    auto r = RunInChild([] {
+        int rc = 0;
+        std::thread t([&] {
+            CrashHandler::InstallAltStackForCurrentThread();
+            stack_t first;
+            if (::sigaltstack(nullptr, &first) != 0) {
+                rc = 20;
+                return;
+            }
+            CrashHandler::InstallAltStackForCurrentThread();
+            CrashHandler::InstallAltStackForCurrentThread();
+            stack_t after;
+            if (::sigaltstack(nullptr, &after) != 0) {
+                rc = 21;
+                return;
+            }
+            if (first.ss_sp != after.ss_sp) {
+                rc = 22;
+                return;
+            }
+            if (first.ss_size != after.ss_size) {
+                rc = 23;
+                return;
+            }
+        });
+        t.join();
+        _exit(rc);
+    });
+    ASSERT_TRUE(WIFEXITED(r.wstatus));
+    EXPECT_EQ(0, WEXITSTATUS(r.wstatus)) << "idempotency check failed with code " << WEXITSTATUS(r.wstatus);
+}
+
+TEST_F(CrashHandlerTest, AltStackOnWorkerEnablesCrashHandler) {
+    // 集成场景：worker 线程装好 alt stack 后触发 SIGSEGV，handler 仍能正常
+    // 跑出完整堆栈到 stderr。验证 API 不会破坏链路。
+    auto r = RunInChild([] {
+        CrashHandler::Install("");
+        std::thread t([] {
+            CrashHandler::InstallAltStackForCurrentThread();
+            ::raise(SIGSEGV);
+        });
+        t.join();
+        _exit(0);
+    });
+    EXPECT_TRUE(ChildAbnormal(r.wstatus)) << "wstatus=" << r.wstatus;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("KVCM CrashHandler")) << "handler did not run on worker thread:\n"
+                                                                            << r.stderr_output;
+    EXPECT_NE(std::string::npos, r.stderr_output.find("SIGSEGV")) << r.stderr_output;
+}

--- a/kv_cache_manager/service/BUILD
+++ b/kv_cache_manager/service/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "//kv_cache_manager/common:build_version",
         ":grpc_wrapper",
         "//kv_cache_manager/common",
+        "//kv_cache_manager/common:crash_handler",
         "//kv_cache_manager/common:loop_thread",
         "//kv_cache_manager/config:coordination_backend",
         "//kv_cache_manager/config:leader_elector_base",

--- a/kv_cache_manager/service/command_line.cc
+++ b/kv_cache_manager/service/command_line.cc
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include "kv_cache_manager/common/crash_handler.h"
 #include "kv_cache_manager/service/server.h"
 #include "kv_cache_manager/service/server_config.h"
 namespace kv_cache_manager {
@@ -179,6 +180,7 @@ void CommandLine::UpdateLogLevel(uint32_t log_level) {
 }
 
 void CommandLine::RegisterSignal() {
+    CrashHandler::Install();
     signal(SIGPIPE, SIG_IGN);
     signal(SIGUSR1, __sign_handler__);
     signal(SIGUSR2, __sign_handler__);

--- a/package/BUILD
+++ b/package/BUILD
@@ -32,6 +32,7 @@ bundle_files(
 bundle_files(
     name = "pkg_script",
     srcs = [
+        "//package/script:decode_stack_trace_script",
         "//package/script:start_server_script",
     ],
     prefix = "bin",

--- a/package/rpm/server/BUILD
+++ b/package/rpm/server/BUILD
@@ -49,6 +49,7 @@ pkg_files(
 pkg_files(
     name = "rpm_script",
     srcs = [
+        "//package/script:decode_stack_trace_script",
         "//package/script:start_server_script",
     ],
     attributes = pkg_attributes(

--- a/package/script/BUILD
+++ b/package/script/BUILD
@@ -7,3 +7,11 @@ filegroup(
     ],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "decode_stack_trace_script",
+    srcs = [
+        "decode_stack_trace.sh",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/package/script/decode_stack_trace.sh
+++ b/package/script/decode_stack_trace.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# decode_stack_trace.sh — 把 KVCM CrashHandler 输出的 std_stack_trace.log 中的
+# C++ mangled 符号 demangle，并尽量用 addr2line 解出源码 file:line。
+#
+# 输入格式（每帧一行）：
+#   <path>(SYMBOL+0xOFFSET)[0xABS]    带符号 + 符号内偏移 + 运行时绝对地址
+#   <path>(+0xOFFSET)[0xABS]          仅文件偏移 + 绝对地址（一般是动态库内私有符号）
+#   <path>[0xABS]                     仅绝对地址（main binary 中的 static 符号）
+#
+# 解析策略：
+#   1) demangle：所有 _Z 开头的 mangled 符号统统过 c++filt，能解就解。
+#   2) addr2line（best-effort）：
+#      - 优先用 (SYMBOL+0xOFFSET)：把 SYMBOL 在二进制里的地址（nm 查）加上 OFFSET，
+#        得到 binary 内偏移，喂给 addr2line。这对 PIE 二进制也成立。
+#      - 退化路径：直接拿 [0xABS] 喂 addr2line。对非 PIE 二进制可用，对 PIE 通常会
+#        得到 ??:?，那就跳过。
+#   3) 二进制路径优先用栈帧里写的那个；不可读时回退到 -b/--binary 或 -l/--lib-dir。
+#
+# 这是离线工具，不要求严格性能，逐行处理。
+
+set -uo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [-b BINARY] [-l LIB_DIR] [-h] [LOG_FILE]
+
+Decode a KVCM std_stack_trace.log:
+  - demangle C++ symbols (c++filt)
+  - resolve source file:line (addr2line, best-effort)
+
+Options:
+  -b BINARY     Override main binary path (used when frame's embedded path
+                doesn't exist on this host, e.g. logs collected from another box)
+  -l LIB_DIR    Directory to look up shared libraries by basename when the
+                embedded path can't be opened (fallback before -b)
+  -h            Show this help
+
+Input:
+  LOG_FILE      std_stack_trace.log path; defaults to stdin
+
+Examples:
+  $(basename "$0") logs/std_stack_trace.log
+  $(basename "$0") -b /opt/kvcm/bin/kv_cache_manager_bin std_stack_trace.log
+  cat std_stack_trace.log | $(basename "$0")
+EOF
+}
+
+BINARY_OVERRIDE=""
+LIB_DIR=""
+while getopts ":b:l:h" opt; do
+    case "$opt" in
+        b) BINARY_OVERRIDE="$OPTARG" ;;
+        l) LIB_DIR="$OPTARG" ;;
+        h) usage; exit 0 ;;
+        \?) echo "unknown option: -$OPTARG" >&2; usage >&2; exit 2 ;;
+        :)  echo "option -$OPTARG requires an argument" >&2; exit 2 ;;
+    esac
+done
+shift $((OPTIND - 1))
+LOG_INPUT="${1:-/dev/stdin}"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+if ! have c++filt; then
+    echo "[warn] c++filt not in PATH; symbols will stay mangled" >&2
+fi
+if ! have addr2line; then
+    echo "[warn] addr2line not in PATH; file:line resolution disabled" >&2
+fi
+if ! have nm; then
+    echo "[warn] nm not in PATH; SYMBOL+OFFSET resolution disabled" >&2
+fi
+
+# 给定栈帧路径，返回本机能打开的文件路径（找不到返回空）。
+resolve_binary() {
+    local p="$1"
+    if [[ -r "$p" ]]; then
+        printf '%s' "$p"
+        return 0
+    fi
+    if [[ -n "$LIB_DIR" ]]; then
+        local cand="$LIB_DIR/$(basename "$p")"
+        if [[ -r "$cand" ]]; then
+            printf '%s' "$cand"
+            return 0
+        fi
+    fi
+    if [[ -n "$BINARY_OVERRIDE" && "$(basename "$p")" == "$(basename "$BINARY_OVERRIDE")" ]]; then
+        printf '%s' "$BINARY_OVERRIDE"
+        return 0
+    fi
+    return 1
+}
+
+# 把 c++filt 单次输出 trim 一下；mangled 输入失败时 c++filt 会原样返回。
+demangle() {
+    local s="$1"
+    if [[ -z "$s" ]] || ! have c++filt; then
+        printf '%s' "$s"
+        return
+    fi
+    c++filt -- "$s" 2>/dev/null
+}
+
+# 在 binary 中查 symbol 的地址（十六进制，无 0x 前缀）。找不到返回非 0。
+# 假定 GNU nm 输出格式（"ADDR TYPE SYMBOL"）。BSD nm 列序不同，本脚本
+# 只兼容 Linux/binutils 默认的 GNU nm；macOS/FreeBSD 需自行替换为
+# `nm -P`（POSIX 格式）。
+nm_symbol_addr() {
+    local bin="$1" sym="$2"
+    have nm || return 1
+    nm --defined-only "$bin" 2>/dev/null \
+        | awk -v s="$sym" '$3 == s { print $1; exit }'
+}
+
+# addr2line -fCp 输出形如 "function_name at file:line"。这里只取第一行，
+# 不展开 inline 链。完全没解到（函数和位置都未知）才返回非 0；只有函数没有
+# 位置也算成功（很多动态库函数 stripped 了 debug info 但保留 dynsym）。
+addr2line_at() {
+    local bin="$1" hex="$2"
+    have addr2line || return 1
+    local out
+    out=$(addr2line -e "$bin" -fCp "$hex" 2>/dev/null | head -n 1) || return 1
+    case "$out" in
+        ""|"?? ??:?"|"?? ??:0") return 1 ;;
+    esac
+    printf '%s' "$out"
+}
+
+# 把 addr2line 一行结果拆成 "func" 和 "file:line"。任意一段未解到就置空。
+# 也把 bazel 编译时常见的 /proc/self/cwd/ 前缀去掉，让源码路径相对仓库根。
+split_addr2line() {
+    local out="$1"
+    local func="" loc=""
+    if [[ "$out" == *" at "* ]]; then
+        func="${out% at *}"
+        loc="${out##* at }"
+    else
+        func="$out"
+    fi
+    [[ "$func" == "??" ]] && func=""
+    # 各种"位置无效"的写法都吞掉：
+    #   ""           完全无输出
+    #   ":?" / ":0"  文件名空
+    #   "??:?" 等    addr2line 标准的 unknown 标记
+    case "$loc" in
+        ""|":"*|*"??:"*) loc="" ;;
+    esac
+    loc="${loc#/proc/self/cwd/}"
+    printf '%s\t%s' "$func" "$loc"
+}
+
+# 解一帧并打印；不是栈帧的行原样输出。
+decode_frame() {
+    local line="$1"
+    local path="" sym="" off="" abs=""
+    local frame_no=""
+
+    # 新格式（CrashHandler 直接生成）每帧前面带 "#N "，剥掉再走原解析。
+    # 没有前缀也兼容（旧日志或测试环境）：用脚本本地维护的 FRAME_IDX。
+    local re_idx='^#([0-9]+)[[:space:]]+(.*)$'
+    if [[ "$line" =~ $re_idx ]]; then
+        frame_no="${BASH_REMATCH[1]}"
+        line="${BASH_REMATCH[2]}"
+    fi
+
+    # 把正则放进变量避免 bash 在 [[ =~ ... ]] 内的词法分析问题
+    local re_full='^([^(]+)\(([^+()]+)\+0x([0-9a-fA-F]+)\)\[0x([0-9a-fA-F]+)\]$'
+    local re_off='^([^(]+)\(\+0x([0-9a-fA-F]+)\)\[0x([0-9a-fA-F]+)\]$'
+    local re_abs='^([^[]+)\[0x([0-9a-fA-F]+)\]$'
+
+    if [[ "$line" =~ $re_full ]]; then
+        path="${BASH_REMATCH[1]}"
+        sym="${BASH_REMATCH[2]}"
+        off="${BASH_REMATCH[3]}"
+        abs="${BASH_REMATCH[4]}"
+    elif [[ "$line" =~ $re_off ]]; then
+        path="${BASH_REMATCH[1]}"
+        off="${BASH_REMATCH[2]}"
+        abs="${BASH_REMATCH[3]}"
+    elif [[ "$line" =~ $re_abs ]]; then
+        path="${BASH_REMATCH[1]}"
+        abs="${BASH_REMATCH[2]}"
+    else
+        printf '%s\n' "$line"
+        return
+    fi
+
+    local pretty_sym=""
+    if [[ -n "$sym" ]]; then
+        pretty_sym=$(demangle "$sym")
+    fi
+
+    local resolved_bin=""
+    resolved_bin=$(resolve_binary "$path" || true)
+
+    # 三路尝试 addr2line：
+    #  1. SYMBOL+OFFSET → nm 查 SYMBOL 在 binary 的地址 + OFFSET（PIE 友好）
+    #  2. 直接喂 [0xABS]（对 non-PIE 二进制有效）
+    #  3. 直接喂 0xOFFSET（一般无效，但便宜，兜底）
+    local a2l_out=""
+    if [[ -n "$resolved_bin" ]]; then
+        if [[ -n "$sym" && -n "$off" ]]; then
+            local sym_addr
+            sym_addr=$(nm_symbol_addr "$resolved_bin" "$sym" || true)
+            if [[ -n "$sym_addr" ]]; then
+                local target_hex
+                target_hex=$(printf '0x%x' $((0x$sym_addr + 0x$off)))
+                a2l_out=$(addr2line_at "$resolved_bin" "$target_hex" || true)
+            fi
+        fi
+        if [[ -z "$a2l_out" && -n "$abs" ]]; then
+            a2l_out=$(addr2line_at "$resolved_bin" "0x$abs" || true)
+        fi
+        if [[ -z "$a2l_out" && -n "$off" ]]; then
+            a2l_out=$(addr2line_at "$resolved_bin" "0x$off" || true)
+        fi
+    fi
+
+    local a2l_func="" a2l_source=""
+    if [[ -n "$a2l_out" ]]; then
+        IFS=$'\t' read -r a2l_func a2l_source < <(split_addr2line "$a2l_out")
+    fi
+
+    # 名字优先级：原 SYMBOL（demangled） > addr2line 函数名 > "??"
+    local display_name="${pretty_sym:-${a2l_func:-??}}"
+
+    # 地址段：用相对偏移更短；没有就用绝对地址
+    local addr_part=""
+    if [[ -n "$off" ]]; then
+        addr_part="+0x$off"
+    elif [[ -n "$abs" ]]; then
+        addr_part="[0x$abs]"
+    fi
+
+    local bin_basename
+    bin_basename=$(basename "$path")
+
+    # 序号优先用从输入剥下来的；没有就用脚本本地计数（兼容旧日志）
+    local out_idx="${frame_no:-$FRAME_IDX}"
+
+    if [[ -n "$a2l_source" ]]; then
+        printf '  #%-3d %s  at %s  (%s %s)\n' "$out_idx" "$display_name" "$a2l_source" "$bin_basename" "$addr_part"
+    else
+        printf '  #%-3d %s  (%s %s)\n' "$out_idx" "$display_name" "$bin_basename" "$addr_part"
+    fi
+    FRAME_IDX=$((FRAME_IDX + 1))
+}
+
+FRAME_IDX=0
+
+while IFS= read -r line; do
+    case "$line" in
+        "Stack trace ("*)
+            # 一个新的崩溃栈开始，编号从 0 重新开始
+            FRAME_IDX=0
+            printf '%s\n' "$line"
+            ;;
+        "*** "*|"version:"*|"si_code:"*|"time("*|"")
+            printf '%s\n' "$line"
+            ;;
+        *)
+            decode_frame "$line"
+            ;;
+    esac
+done < "$LOG_INPUT"


### PR DESCRIPTION
Install async-signal-safe handler in CommandLine::RegisterSignal that catches SIGSEGV/SIGABRT/SIGBUS/SIGFPE/SIGILL, dumps signal info, build version, si_code, and a #N-prefixed backtrace to stderr and logs/std_stack_trace.log (same logs/ dir as alog), then chains to the previous handler so ASAN reports and coredumps still work.

Bundle bin/decode_stack_trace.sh alongside start_server.sh as an offline post-processor: c++filt for demangling, addr2line + nm to resolve file:line for both PIE and non-PIE binaries; falls back gracefully when binaries aren't on the host. One frame per line in gdb-style "#N SYMBOL at FILE:LINE (BINARY +0xOFF)".

See docs/crash-handler-zh_CN.md for usage.