### PR TITLE
[meta] using CacheLocationConstPtr to avoid deep copy

### DIFF
--- a/integration_test/reclaimer/multi_location_test.py
+++ b/integration_test/reclaimer/multi_location_test.py
@@ -128,13 +128,38 @@ class MultiLocationTest(abc.ABC, TestBase, unittest.TestCase):
         # Delete all GroupA location files
         self._delete_cache_locations(locs_a, list(range(len(locs_a))))
 
-        # Wait for async prune to detect and clean stale locations
-        time.sleep(2)
+        # Poll until tp0 is fully pruned (query triggers lazy detection).
+        # Each query submits async prune requests; retry to wait for them
+        # to take effect in the meta indexer.
+        max_attempts = 5
+        for attempt in range(max_attempts):
+            resp = self._prefix_query(block_keys)
+            if len(resp["locations"]) != 3:
+                if attempt < max_attempts - 1:
+                    time.sleep(2)
+                    continue
+                self.fail(
+                    f"blocks should still be queryable via GroupB location, "
+                    f"got {len(resp['locations'])} after {max_attempts} attempts")
 
-        # Query: trigger prune detection via SelectForMatch
-        resp = self._prefix_query(block_keys)
-        self.assertEqual(len(resp["locations"]), 3,
-                         "blocks should still be queryable via GroupB location")
+            all_specs = set()
+            for loc in resp["locations"]:
+                for s in loc["location_specs"]:
+                    all_specs.add(s["name"])
+
+            if "tp0" not in all_specs:
+                # tp0 fully pruned — success
+                break
+
+            if attempt < max_attempts - 1:
+                logging.info(
+                    "attempt %d: tp0 still present, waiting for async "
+                    "prune to complete...", attempt + 1)
+                time.sleep(2)
+            else:
+                self.fail(
+                    f"tp0 specs still present after {max_attempts} attempts; "
+                    f"async prune did not complete in time")
 
         # Verify only tp1 specs remain (tp0 was pruned)
         for loc in resp["locations"]:

--- a/kv_cache_manager/manager/cache_location_view.cc
+++ b/kv_cache_manager/manager/cache_location_view.cc
@@ -40,8 +40,9 @@ CacheLocationViewVecWrapper::CacheLocationViewVecWrapper(CacheLocationVector &&r
     if (size) {
         CacheLocationTransformer transformer;
         cache_locations_view_.reserve(size);
-        for (const auto &cache_location : raw_cache_locations_) {
-            cache_locations_view_.push_back(transformer(cache_location));
+        for (const auto &loc_ptr : raw_cache_locations_) {
+            assert(loc_ptr);
+            cache_locations_view_.push_back(transformer(*loc_ptr));
         }
     }
 }

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -294,16 +294,15 @@ std::pair<ErrorCode, CacheMetaVecWrapper> CacheManager::GetCacheMeta(RequestCont
     std::map<std::string, std::string> meta;
     for (CacheLocationMap &location_map : location_maps) {
         auto iter = location_map.begin();
-        if (iter != location_map.end()) {
-            auto nh = location_map.extract(iter);
-            cache_locations.push_back(std::move(nh.mapped()));
-            meta["id"] = cache_locations.back().id();
+        if (iter != location_map.end() && iter->second) {
+            cache_locations.push_back(iter->second);
+            meta["id"] = cache_locations.back()->id();
         } else {
-            CacheLocation cache_location;
-            cache_location.set_status(CacheLocationStatus::CLS_NOT_FOUND);
-            cache_locations.push_back(std::move(cache_location));
+            auto not_found_loc = std::make_shared<CacheLocation>();
+            not_found_loc->set_status(CacheLocationStatus::CLS_NOT_FOUND);
+            cache_locations.push_back(std::move(not_found_loc));
         }
-        meta["status"] = CacheLocation::CacheLocationStatusToString(cache_locations.back().status());
+        meta["status"] = CacheLocation::CacheLocationStatusToString(cache_locations.back()->status());
         metas.push_back(Jsonizable::ToJsonString(meta));
     }
 
@@ -418,9 +417,12 @@ std::pair<ErrorCode, int64_t> CacheManager::GetCacheLocationLen(RequestContext *
     switch (query_type) {
     case QueryType::QT_BATCH_GET:
     case QueryType::QT_REVERSE_ROLL_SW_MATCH: {
-        for (const auto &location : cache_locations) {
+        for (const auto &loc_ptr : cache_locations) {
+            if (!loc_ptr) {
+                continue;
+            }
             bool has_valid_uri = false;
-            for (const auto &spec : location.location_specs()) {
+            for (const auto &spec : loc_ptr->location_specs()) {
                 if (!spec.uri().empty()) {
                     has_valid_uri = true;
                     break;
@@ -729,15 +731,21 @@ void CacheManager::FilterLocationSpecByName(CacheLocationVector &locations,
     }
 
     const std::unordered_set<std::string> names_set(location_spec_names.begin(), location_spec_names.end());
-    for (auto &location : locations) {
+    for (auto &loc_ptr : locations) {
+        if (!loc_ptr) {
+            continue;
+        }
         std::vector<LocationSpec> new_specs;
-        for (auto &spec : location.location_specs()) {
+        for (const auto &spec : loc_ptr->location_specs()) {
             if (names_set.count(spec.name()) == 0) {
                 continue;
             }
             new_specs.push_back(spec);
         }
-        location.set_location_specs(std::move(new_specs));
+        // COW: copy, modify, replace
+        auto new_loc = std::make_shared<CacheLocation>(*loc_ptr);
+        new_loc->set_location_specs(std::move(new_specs));
+        loc_ptr = std::move(new_loc);
     }
 }
 
@@ -1088,15 +1096,15 @@ ErrorCode CacheManager::GenWriteLocation(RequestContext *request_context,
     }
 
     for (const auto &uris : key_to_uris) {
-        CacheLocation cache_location;
-        cache_location.set_type(select_result.type);
+        auto cache_location = std::make_shared<CacheLocation>();
+        cache_location->set_type(select_result.type);
         for (const auto &[data_storage_uri_idx, location_spec_info] : uris) {
             LocationSpec location_spec;
             location_spec.set_name(location_spec_info->name());
             location_spec.set_uri(allocated_uris[data_storage_uri_idx].ToUriString());
-            cache_location.push_location_spec(std::move(location_spec));
+            cache_location->push_location_spec(std::move(location_spec));
         }
-        cache_location.set_spec_size(uris.size());
+        cache_location->set_spec_size(uris.size());
         new_locations.push_back(std::move(cache_location));
     }
     return EC_OK;
@@ -1225,12 +1233,15 @@ ErrorCode CacheManager::GetCacheLocationByQueryType(MetaSearcher *meta_searcher,
             request_context->error_tracer()->AddErrorMsg("instance not found");
             RETURN_IF_EC_NOT_OK_WITH_LOG(WARN, EC_INSTANCE_NOT_EXIST, "instance not found");
         }
-        for (auto &location : cache_locations) {
-            if (location.spec_size() == 0) {
-                location.set_spec_size(instance_info->location_spec_infos().size());
+        for (auto &loc_ptr : cache_locations) {
+            if (!loc_ptr || loc_ptr->spec_size() == 0) {
+                // COW: create or copy, then modify
+                auto new_loc = loc_ptr ? std::make_shared<CacheLocation>(*loc_ptr) : std::make_shared<CacheLocation>();
+                new_loc->set_spec_size(instance_info->location_spec_infos().size());
                 for (auto &spec_info : instance_info->location_spec_infos()) {
-                    location.push_location_spec(LocationSpec(spec_info.name(), ""));
+                    new_loc->push_location_spec(LocationSpec(spec_info.name(), ""));
                 }
+                loc_ptr = std::move(new_loc);
             }
         }
     }

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -707,7 +707,7 @@ ErrorCode CacheManager::TrimCache(RequestContext *request_context,
         CacheMetaDelRequest request;
         request.instance_id = instance_id;
 
-        if (const auto ec = meta_indexer->Scan(cursor, limit, next_cursor, request.block_keys);
+        if (const ErrorCode ec = meta_indexer->Scan(request_context, cursor, limit, next_cursor, request.block_keys);
             ec != ErrorCode::EC_OK) {
             // TODO (rui): cache reclaimer should reclaim the dangling blocks
             RETURN_IF_EC_NOT_OK_WITH_LOG(WARN, ec, "trim cache failed");

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -952,7 +952,11 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
     out_loc_ids.reserve(loc_maps.size());
     for (const auto &loc_map : loc_maps) {
         std::vector<std::string> loc_id_vec;
-        for (const auto &[_, loc] : loc_map) {
+        for (const auto &[_, loc_ptr] : loc_map) {
+            if (!loc_ptr) {
+                continue;
+            }
+            const auto &loc = *loc_ptr;
             // a location is eligible for eviction if:
             // 1. it is in CLS_SERVING status, OR
             // 2. it is in CLS_WRITING status but its write session is

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -32,65 +32,68 @@ void LogErrorCodes(const std::string &operation_name,
     }
 }
 
-CacheLocation SelectAndMergeForMatch(SelectLocationPolicy *policy,
-                                     CacheLocationMap &location_map,
-                                     CheckLocDataExistFunc check_loc_data_exist,
-                                     std::vector<std::string> &out_prune_loc_ids) {
+CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
+                                             CacheLocationMap &location_map,
+                                             CheckLocDataExistFunc check_loc_data_exist,
+                                             std::vector<std::string> &out_prune_loc_ids) {
     // Filter valid locations into a shared map.
     CacheLocationMap valid_map;
-    for (auto &[id, loc] : location_map) {
-        if (loc.status() != CacheLocationStatus::CLS_SERVING) {
+    for (auto &[id, loc_ptr] : location_map) {
+        if (!loc_ptr) {
             continue;
         }
-        if (check_loc_data_exist && !check_loc_data_exist(loc)) {
+        if (loc_ptr->status() != CacheLocationStatus::CLS_SERVING) {
+            continue;
+        }
+        if (check_loc_data_exist && !check_loc_data_exist(*loc_ptr)) {
             out_prune_loc_ids.push_back(id);
             continue;
         }
-        valid_map.try_emplace(id, loc);
+        valid_map.try_emplace(id, loc_ptr);
     }
     if (valid_map.empty()) {
-        return {};
+        return std::make_shared<CacheLocation>();
     }
 
     // Use the policy to select one winning location, which determines the
     // target storage backend instance.
     std::vector<std::string> unused_prune_ids;
-    CacheLocation *winner = policy->SelectForMatch(valid_map, nullptr, unused_prune_ids);
+    CacheLocationConstPtr winner = policy->SelectForMatch(valid_map, nullptr, unused_prune_ids);
     if (!winner || winner->location_specs().empty()) {
-        return {};
+        return std::make_shared<CacheLocation>();
     }
 
     // Collect all specs from every valid location that belongs to the same
     // storage backend as the winner, dedup by spec name.
     std::map<std::string, LocationSpec> merged_specs;
-    for (auto &[id, loc] : valid_map) {
-        if (!policy->IsSameDataStorage(loc, *winner)) {
+    for (const auto &[id, loc_ptr] : valid_map) {
+        if (!loc_ptr || !policy->IsSameDataStorage(*loc_ptr, *winner)) {
             continue;
         }
-        for (const auto &spec : loc.location_specs()) {
+        for (const auto &spec : loc_ptr->location_specs()) {
             merged_specs.try_emplace(spec.name(), spec);
         }
     }
 
     if (merged_specs.empty()) {
-        return {};
+        return std::make_shared<CacheLocation>();
     }
 
     // NOTE: this is an aggregated view merging
     // specs from multiple locations, not a real stored entity. Downstream
     // CacheLocationView / proto serialization never accesses id either.
     std::string representative_id = winner->id() + "merged";
-    CacheLocation result;
-    result.set_id(std::move(representative_id));
-    result.set_status(CacheLocationStatus::CLS_SERVING);
-    result.set_type(winner->type());
+    auto result = std::make_shared<CacheLocation>();
+    result->set_id(std::move(representative_id));
+    result->set_status(CacheLocationStatus::CLS_SERVING);
+    result->set_type(winner->type());
     std::vector<LocationSpec> specs;
     specs.reserve(merged_specs.size());
     for (auto &[name, spec] : merged_specs) {
         specs.push_back(std::move(spec));
     }
-    result.set_spec_size(specs.size());
-    result.set_location_specs(std::move(specs));
+    result->set_spec_size(specs.size());
+    result->set_location_specs(std::move(specs));
     return result;
 }
 
@@ -156,12 +159,13 @@ ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_cont
             break;
         }
         std::vector<std::string> prune_loc_ids;
-        CacheLocation merged = SelectAndMergeForMatch(policy, location_map, check_loc_data_exist_func_, prune_loc_ids);
+        CacheLocationConstPtr merged =
+            SelectAndMergeForMatch(policy, location_map, check_loc_data_exist_func_, prune_loc_ids);
         if (!prune_loc_ids.empty()) {
             prune_keys.emplace_back(keys[i]);
             prune_loc_ids_vec.emplace_back(prune_loc_ids);
         }
-        if (merged.location_specs().empty()) {
+        if (merged->location_specs().empty()) {
             KVCM_LOG_DEBUG("prefix match end because keys[%lu] no serving location", i);
             break;
         }
@@ -237,7 +241,7 @@ ErrorCode MetaSearcher::BatchGetBestLocation(RequestContext *request_context,
     std::vector<std::vector<std::string>> prune_loc_ids_vec;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (result.error_codes[i] == ErrorCode::EC_NOENT) {
-            out_locations.push_back({});
+            out_locations.push_back(std::make_shared<CacheLocation>());
             continue;
         }
         if (result.error_codes[i] != ErrorCode::EC_OK) {
@@ -247,17 +251,18 @@ ErrorCode MetaSearcher::BatchGetBestLocation(RequestContext *request_context,
 
         auto &location_map = location_maps[i];
         if (location_map.empty()) {
-            out_locations.push_back({});
+            out_locations.push_back(std::make_shared<CacheLocation>());
             continue;
         }
         std::vector<std::string> prune_loc_ids;
-        CacheLocation merged = SelectAndMergeForMatch(policy, location_map, check_loc_data_exist_func_, prune_loc_ids);
+        CacheLocationConstPtr merged =
+            SelectAndMergeForMatch(policy, location_map, check_loc_data_exist_func_, prune_loc_ids);
         if (!prune_loc_ids.empty()) {
             prune_keys.emplace_back(keys[i]);
             prune_loc_ids_vec.emplace_back(prune_loc_ids);
         }
-        if (merged.location_specs().empty()) {
-            out_locations.push_back({});
+        if (merged->location_specs().empty()) {
+            out_locations.push_back(std::make_shared<CacheLocation>());
             continue;
         }
         out_locations.push_back(std::move(merged));
@@ -281,14 +286,18 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
     assert(sw_size > 0);
     // TODO: error handle
     out_locations.clear();
-    out_locations.assign(keys.size(), {});
+    out_locations.clear();
+    out_locations.reserve(keys.size());
+    for (size_t idx = 0; idx < keys.size(); ++idx) {
+        out_locations.push_back(std::make_shared<CacheLocation>());
+    }
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
     CacheLocationMapVector location_maps;
     auto result = meta_indexer_->GetLocations(request_context, keys, location_maps);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     bool is_match = false;
-    std::vector<CacheLocation> temp_sw_locations;
+    CacheLocationVector temp_sw_locations;
     temp_sw_locations.reserve(sw_size);
     KeyVector prune_keys;
     std::vector<std::vector<std::string>> prune_loc_ids_vec;
@@ -313,13 +322,13 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
                 break;
             }
             std::vector<std::string> prune_loc_ids;
-            CacheLocation merged =
+            CacheLocationConstPtr merged =
                 SelectAndMergeForMatch(policy, location_map, check_loc_data_exist_func_, prune_loc_ids);
             if (!prune_loc_ids.empty()) {
                 prune_keys.emplace_back(keys[base + offset]);
                 prune_loc_ids_vec.emplace_back(prune_loc_ids);
             }
-            if (merged.location_specs().empty()) {
+            if (!merged || merged->location_specs().empty()) {
                 temp_sw_locations.clear();
                 base -= sw_size - offset;
                 is_match = false;
@@ -407,21 +416,21 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
         } while (existing_id_set.count(location_id) > 0);
 
         // build the new CacheLocation with status = CLS_WRITING
-        CacheLocation new_loc = locations[index];
-        new_loc.set_id(location_id);
-        new_loc.set_status(CLS_WRITING);
+        auto new_loc = std::make_shared<CacheLocation>(*locations[index]);
+        new_loc->set_id(location_id);
+        new_loc->set_status(CLS_WRITING);
         out_new_locations[location_id] = std::move(new_loc);
 
         // compute storage size for usage tracking
         std::uint64_t sz = 0;
-        for (const auto &loc_spec : locations[index].location_specs()) {
+        for (const auto &loc_spec : locations[index]->location_specs()) {
             if (DataStorageUri ds_uri(loc_spec.uri()); ds_uri.Valid()) {
                 std::uint64_t spec_sz;
                 ds_uri.GetParamAs<std::uint64_t>("size", spec_sz);
                 sz += spec_sz;
             }
         }
-        loc_sz[index] = std::make_pair(locations[index].type(), sz);
+        loc_sz[index] = std::make_pair(locations[index]->type(), sz);
 
         out_location_ids[index] = std::move(location_id);
         return {ModifierAction::MA_OK, ErrorCode::EC_OK};
@@ -478,7 +487,6 @@ ErrorCode MetaSearcher::BatchUpdateLocationStatus(RequestContext *request_contex
         for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
             const ErrorCode ec = get_ecs[loc_index];
             const std::string &loc_id = loc_ids[loc_index];
-            CacheLocation &loc = locs[loc_index];
             if (ec != ErrorCode::EC_OK) {
                 modifier_ecs[loc_index] = ec;
                 if (ec != ErrorCode::EC_NOENT) {
@@ -491,7 +499,10 @@ ErrorCode MetaSearcher::BatchUpdateLocationStatus(RequestContext *request_contex
                 continue;
             }
             updated = true;
-            loc.set_status(batch_tasks[key_index][loc_index].new_status);
+            // COW: copy the location, modify the copy, replace the pointer
+            auto new_loc = std::make_shared<CacheLocation>(*locs[loc_index]);
+            new_loc->set_status(batch_tasks[key_index][loc_index].new_status);
+            locs[loc_index] = std::move(new_loc);
         }
         if (!updated) {
             // do not need to update status, skip and return ok
@@ -545,7 +556,6 @@ ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
         for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
             const ErrorCode ec = get_ecs[loc_index];
             const std::string &loc_id = loc_ids[loc_index];
-            CacheLocation &loc = locs[loc_index];
             if (ec != ErrorCode::EC_OK) {
                 modifier_ecs[loc_index] = ec;
                 if (ec != ErrorCode::EC_NOENT) {
@@ -558,11 +568,14 @@ ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
                 continue;
             }
             const auto &task = batch_tasks[key_index][loc_index];
-            if (loc.status() != task.old_status) {
+            if (locs[loc_index]->status() != task.old_status) {
                 modifier_ecs[loc_index] = ErrorCode::EC_MISMATCH;
             } else {
                 updated = true;
-                loc.set_status(task.new_status);
+                // COW: copy the location, modify the copy, replace the pointer
+                auto new_loc = std::make_shared<CacheLocation>(*locs[loc_index]);
+                new_loc->set_status(task.new_status);
+                locs[loc_index] = std::move(new_loc);
             }
         }
         if (!updated) {
@@ -619,7 +632,6 @@ ErrorCode MetaSearcher::BatchCADLocationStatus(RequestContext *request_context,
         for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
             const ErrorCode ec = get_ecs[loc_index];
             const std::string &loc_id = loc_ids[loc_index];
-            CacheLocation &loc = locs[loc_index];
             if (ec != ErrorCode::EC_OK) {
                 modifier_ecs[loc_index] = ec;
                 if (ec != ErrorCode::EC_NOENT) {
@@ -631,21 +643,21 @@ ErrorCode MetaSearcher::BatchCADLocationStatus(RequestContext *request_context,
                 }
                 continue;
             }
-            if (loc.status() != batch_tasks[key_index][loc_index].expect_status) {
+            if (!locs[loc_index] || locs[loc_index]->status() != batch_tasks[key_index][loc_index].expect_status) {
                 modifier_ecs[loc_index] = ErrorCode::EC_MISMATCH;
                 continue;
             }
             updated = true;
             // compute storage size before deletion for usage tracking
             std::uint64_t sz = 0;
-            for (const auto &loc_spec : loc.location_specs()) {
+            for (const auto &loc_spec : locs[loc_index]->location_specs()) {
                 if (DataStorageUri ds_uri(loc_spec.uri()); ds_uri.Valid()) {
                     std::uint64_t spec_sz = 0;
                     ds_uri.GetParamAs<std::uint64_t>("size", spec_sz);
                     sz += spec_sz;
                 }
             }
-            locs_sz[key_index][loc_index] = std::make_pair(loc.type(), sz);
+            locs_sz[key_index][loc_index] = std::make_pair(locs[loc_index]->type(), sz);
         }
         if (!updated) {
             // do not need to update status, skip and return ok
@@ -706,7 +718,6 @@ ErrorCode MetaSearcher::BatchDeleteLocation(RequestContext *request_context,
         for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
             const ErrorCode ec = get_ecs[loc_index];
             const std::string &loc_id = loc_ids[loc_index];
-            CacheLocation &loc = locs[loc_index];
             if (ec != ErrorCode::EC_OK) {
                 modifier_ecs[loc_index] = ec;
                 if (ec != ErrorCode::EC_NOENT) {
@@ -718,16 +729,20 @@ ErrorCode MetaSearcher::BatchDeleteLocation(RequestContext *request_context,
                 }
                 continue;
             }
+            if (!locs[loc_index]) {
+                modifier_ecs[loc_index] = ErrorCode::EC_NOENT;
+                continue;
+            }
             updated = true;
             std::uint64_t sz = 0;
-            for (const auto &loc_spec : loc.location_specs()) {
+            for (const auto &loc_spec : locs[loc_index]->location_specs()) {
                 if (DataStorageUri ds_uri(loc_spec.uri()); ds_uri.Valid()) {
                     std::uint64_t spec_sz = 0;
                     ds_uri.GetParamAs<std::uint64_t>("size", spec_sz);
                     sz += spec_sz;
                 }
             }
-            loc_sz[key_index] = std::make_pair(loc.type(), sz);
+            loc_sz[key_index] = std::make_pair(locs[loc_index]->type(), sz);
         }
         if (!updated) {
             // do not need to update status, skip and return ok

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -137,7 +137,7 @@ ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_cont
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
-    LocationMapVector location_maps;
+    CacheLocationMapVector location_maps;
     auto result = meta_indexer_->GetLocations(request_context, keys, location_maps);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
 
@@ -230,7 +230,7 @@ ErrorCode MetaSearcher::BatchGetBestLocation(RequestContext *request_context,
     out_locations.reserve(keys.size());
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
-    LocationMapVector location_maps;
+    CacheLocationMapVector location_maps;
     auto result = meta_indexer_->GetLocations(request_context, keys, location_maps);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     KeyVector prune_keys;
@@ -284,7 +284,7 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
     out_locations.assign(keys.size(), {});
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
-    LocationMapVector location_maps;
+    CacheLocationMapVector location_maps;
     auto result = meta_indexer_->GetLocations(request_context, keys, location_maps);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     bool is_match = false;
@@ -381,11 +381,12 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
     out_location_ids.resize(keys.size());
     std::vector<std::pair<DataStorageType, std::uint64_t>> loc_sz(keys.size());
 
-    auto modifier = [&locations, &out_location_ids, &keys, &loc_sz](const LocationIdVector &existing_location_ids,
-                                                                    ErrorCode get_ec,
-                                                                    size_t index,
-                                                                    PropertyMap &upsert_property_map,
-                                                                    LocationMap &out_new_locations) -> ModifierResult {
+    auto modifier =
+        [&locations, &out_location_ids, &keys, &loc_sz](const LocationIdVector &existing_location_ids,
+                                                        ErrorCode get_ec,
+                                                        size_t index,
+                                                        PropertyMap &upsert_property_map,
+                                                        CacheLocationMap &out_new_locations) -> ModifierResult {
         if (get_ec != ErrorCode::EC_OK && get_ec != ErrorCode::EC_NOENT) {
             KVCM_LOG_WARN("load location failed, key[%lu](%lu) return %d", index, keys[index], get_ec);
             return {ModifierAction::MA_FAIL, get_ec};

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -161,13 +161,13 @@ void SchedulePlanExecutor::DoLocationDelTask(const std::shared_ptr<std::promise<
 
         for (auto &location_id : need_delete_location_ids) {
             auto iter = location_map.find(location_id);
-            if (iter == location_map.end()) {
+            if (iter == location_map.end() || !iter->second) {
                 continue;
             }
-            if (iter->second.status() != CacheLocationStatus::CLS_DELETING) {
+            if (iter->second->status() != CacheLocationStatus::CLS_DELETING) {
                 continue;
             }
-            for (const auto &loc_spec : iter->second.location_specs()) {
+            for (const auto &loc_spec : iter->second->location_specs()) {
                 DataStorageUri uri(loc_spec.uri());
                 if (uri.Valid()) {
                     std::string storage_unique_name = uri.GetHostName();
@@ -284,7 +284,10 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheMetaDelRe
     for (size_t block_key_idx = 0; block_key_idx < task.block_keys.size(); ++block_key_idx) {
         std::vector<MetaSearcher::LocationCASTask> cas_tasks;
         for (const auto &loc_kv : location_maps[block_key_idx]) {
-            cas_tasks.push_back({loc_kv.first, loc_kv.second.status(), CLS_DELETING});
+            if (!loc_kv.second) {
+                continue;
+            }
+            cas_tasks.push_back({loc_kv.first, loc_kv.second->status(), CLS_DELETING});
         }
         if (cas_tasks.empty()) {
             continue;
@@ -402,7 +405,10 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
         auto &location_map = location_maps[block_key_idx];
         std::vector<MetaSearcher::LocationCASTask> location_cas_tasks;
         for (const auto &loc_kv : location_map) {
-            const auto &location = loc_kv.second;
+            if (!loc_kv.second) {
+                continue;
+            }
+            const auto &location = *loc_kv.second;
             if (location.status() == CacheLocationStatus::CLS_DELETING) {
                 continue; // ignore already deleting
             }

--- a/kv_cache_manager/manager/select_location_policy.cc
+++ b/kv_cache_manager/manager/select_location_policy.cc
@@ -40,29 +40,32 @@ std::string_view ExtractHostName(std::string_view uri) {
 
 namespace kv_cache_manager {
 
-CacheLocation *WeightSLPolicy::SelectForMatch(CacheLocationMap &location_map,
-                                              CheckLocDataExistFunc check_loc_data_exist,
-                                              std::vector<std::string> &out_prune_loc_ids) const {
+CacheLocationConstPtr WeightSLPolicy::SelectForMatch(CacheLocationMap &location_map,
+                                                     CheckLocDataExistFunc check_loc_data_exist,
+                                                     std::vector<std::string> &out_prune_loc_ids) const {
     thread_local std::mt19937 rng(std::random_device{}());
-    std::vector<CacheLocation *> serving_locations;
+    std::vector<CacheLocationConstPtr> serving_locations;
     std::vector<uint32_t> weights;
     serving_locations.reserve(location_map.size());
     weights.reserve(location_map.size());
     out_prune_loc_ids.clear();
-    for (auto &kv : location_map) {
-        if (kv.second.status() == CacheLocationStatus::CLS_SERVING) {
-            if (check_loc_data_exist && !check_loc_data_exist(kv.second)) {
+    for (const auto &kv : location_map) {
+        if (!kv.second) {
+            continue;
+        }
+        if (kv.second->status() == CacheLocationStatus::CLS_SERVING) {
+            if (check_loc_data_exist && !check_loc_data_exist(*kv.second)) {
                 out_prune_loc_ids.emplace_back(kv.first);
                 continue;
             }
             if (int32_t weight = GetWeight(kv); weight > 0) {
-                serving_locations.push_back(&kv.second);
+                serving_locations.push_back(kv.second);
                 weights.push_back(weight);
             }
         }
     }
     if (serving_locations.empty() || weights.empty()) {
-        return nullptr;
+        return std::make_shared<CacheLocation>();
     }
     std::discrete_distribution<uint32_t> dist(weights.begin(), weights.end());
     return serving_locations[dist(rng)];
@@ -73,10 +76,13 @@ bool WeightSLPolicy::ExistsForWrite(const CacheLocationMap &location_map,
                                     std::vector<std::string> &out_prune_loc_ids) const {
     bool exists = false;
     out_prune_loc_ids.clear();
-    for (auto &kv : location_map) {
-        if (kv.second.status() != CacheLocationStatus::CLS_NOT_FOUND) {
-            if (kv.second.status() == CacheLocationStatus::CLS_SERVING && check_loc_data_exist &&
-                !check_loc_data_exist(kv.second)) {
+    for (const auto &kv : location_map) {
+        if (!kv.second) {
+            continue;
+        }
+        if (kv.second->status() != CacheLocationStatus::CLS_NOT_FOUND) {
+            if (kv.second->status() == CacheLocationStatus::CLS_SERVING && check_loc_data_exist &&
+                !check_loc_data_exist(*kv.second)) {
                 out_prune_loc_ids.emplace_back(kv.first);
                 continue;
             }
@@ -101,12 +107,15 @@ bool WeightSLPolicy::ExistsForWrite(const CacheLocationMap &location_map,
     // building a hash set — avoids heap allocation and string copies.
     bool exists = false;
     out_prune_loc_ids.clear();
-    for (auto &kv : location_map) {
-        if (kv.second.status() == CacheLocationStatus::CLS_NOT_FOUND) {
+    for (const auto &kv : location_map) {
+        if (!kv.second) {
             continue;
         }
-        if (kv.second.status() == CacheLocationStatus::CLS_SERVING && check_loc_data_exist &&
-            !check_loc_data_exist(kv.second)) {
+        if (kv.second->status() == CacheLocationStatus::CLS_NOT_FOUND) {
+            continue;
+        }
+        if (kv.second->status() == CacheLocationStatus::CLS_SERVING && check_loc_data_exist &&
+            !check_loc_data_exist(*kv.second)) {
             out_prune_loc_ids.emplace_back(kv.first);
             continue;
         }
@@ -116,7 +125,7 @@ bool WeightSLPolicy::ExistsForWrite(const CacheLocationMap &location_map,
         if (GetWeight(kv) <= 0) {
             continue;
         }
-        const auto &loc_specs = kv.second.location_specs();
+        const auto &loc_specs = kv.second->location_specs();
         bool covers_all = std::all_of(
             requested_spec_names.begin(), requested_spec_names.end(), [&loc_specs](const std::string &name) {
                 return std::any_of(
@@ -130,7 +139,10 @@ bool WeightSLPolicy::ExistsForWrite(const CacheLocationMap &location_map,
 }
 
 uint32_t StaticWeightSLPolicy::GetWeight(CacheLocationMap::const_reference kv) const {
-    DataStorageType type = kv.second.type();
+    if (!kv.second) {
+        return 0;
+    }
+    DataStorageType type = kv.second->type();
     uint32_t weight = StorageTypeWeights::DEFAULT;
     // 如果枚举值对应数组索引可用，就直接取
     if (static_cast<size_t>(type) < std::size(storage_weights_)) {
@@ -140,8 +152,11 @@ uint32_t StaticWeightSLPolicy::GetWeight(CacheLocationMap::const_reference kv) c
 }
 
 uint32_t NamedStorageWeightedSLPolicy::GetWeight(CacheLocationMap::const_reference kv) const {
+    if (!kv.second || kv.second->location_specs().empty()) {
+        return 0;
+    }
     // all location_specs in location have the same host name
-    std::string_view host_name = ExtractHostName(kv.second.location_specs().front().uri());
+    std::string_view host_name = ExtractHostName(kv.second->location_specs().front().uri());
     if (auto iter = weight_map_.find(host_name); iter != weight_map_.end()) {
         return iter->second;
     }

--- a/kv_cache_manager/manager/select_location_policy.h
+++ b/kv_cache_manager/manager/select_location_policy.h
@@ -15,9 +15,9 @@ using CheckLocDataExistFunc = std::function<bool(const CacheLocation &loc)>;
 class SelectLocationPolicy {
 public:
     // for match : select best location
-    virtual CacheLocation *SelectForMatch(CacheLocationMap &location_map,
-                                          CheckLocDataExistFunc check_loc_data_exist,
-                                          std::vector<std::string> &out_prune_loc_ids) const = 0;
+    virtual CacheLocationConstPtr SelectForMatch(CacheLocationMap &location_map,
+                                                 CheckLocDataExistFunc check_loc_data_exist,
+                                                 std::vector<std::string> &out_prune_loc_ids) const = 0;
 
     // for write : return true if exists means that not need write again
     virtual bool ExistsForWrite(const CacheLocationMap &location_map,
@@ -39,9 +39,9 @@ public:
 
 class WeightSLPolicy : public SelectLocationPolicy {
 public:
-    CacheLocation *SelectForMatch(CacheLocationMap &location_map,
-                                  CheckLocDataExistFunc check_loc_data_exist,
-                                  std::vector<std::string> &out_prune_loc_ids) const override;
+    CacheLocationConstPtr SelectForMatch(CacheLocationMap &location_map,
+                                         CheckLocDataExistFunc check_loc_data_exist,
+                                         std::vector<std::string> &out_prune_loc_ids) const override;
     bool ExistsForWrite(const CacheLocationMap &location_map,
                         CheckLocDataExistFunc check_loc_data_exist,
                         std::vector<std::string> &out_prune_loc_ids) const override;

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -222,10 +222,8 @@ std::chrono::milliseconds mi_randsample_delay{0};
 ErrorCode random_sample_result;
 KeyVector random_sample_keys;
 
-ErrorCode MetaIndexer_RandomSample_stub(void *obj,
-                                        RequestContext *rc,
-                                        const std::size_t c,
-                                        KeyVector &out_keys) noexcept {
+ErrorCode
+MetaIndexer_RandomSample_stub(void *obj, RequestContext *rc, const std::size_t c, KeyVector &out_keys) noexcept {
     if (random_sample_result == ErrorCode::EC_OK) {
         if (c == random_sample_keys.size()) {
             out_keys = random_sample_keys;
@@ -246,10 +244,8 @@ std::chrono::milliseconds mi_sample_reclaim_delay{0};
 ErrorCode sample_reclaim_result;
 KeyVector sample_reclaim_keys;
 
-ErrorCode MetaIndexer_SampleReclaimKeys_stub(void *obj,
-                                             RequestContext *rc,
-                                             const std::int64_t c,
-                                             KeyVector &out_keys) noexcept {
+ErrorCode
+MetaIndexer_SampleReclaimKeys_stub(void *obj, RequestContext *rc, const std::int64_t c, KeyVector &out_keys) noexcept {
     if (sample_reclaim_result == ErrorCode::EC_OK) {
         if (c == static_cast<std::int64_t>(sample_reclaim_keys.size())) {
             out_keys = sample_reclaim_keys;
@@ -3115,9 +3111,12 @@ TEST_F(CacheReclaimerTest, TestPerf) {
 
     batch_get_loc_out_maps = std::vector<CacheLocationMap>(
         batching_sz,
-        CacheLocationMap{
-            {"foo",
-             CacheLocation{"foo", CacheLocationStatus::CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_NFS, 8, {}}}});
+        CacheLocationMap{{"foo",
+                          std::make_shared<CacheLocation>("foo",
+                                                          CacheLocationStatus::CLS_SERVING,
+                                                          DataStorageType::DATA_STORAGE_TYPE_NFS,
+                                                          8,
+                                                          std::vector<LocationSpec>{})}});
 
     cache_reclaimer_->job_state_flag_ = true;
 

--- a/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
@@ -81,12 +81,12 @@ TEST_F(MetaSearcherRealServiceTest, TestBatchAddAndGetLocation) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherRedisTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
-        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
-        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 = MetaSearcherRedisTestHelper::CreateCacheLocation(
-        DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
+    auto location1 = std::make_shared<const CacheLocation>(
+        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs));
+    auto location2 = std::make_shared<const CacheLocation>(
+        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs));
+    auto location3 = std::make_shared<const CacheLocation>(MetaSearcherRedisTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs));
 
     CacheLocationVector locations = {location1, location2, location3};
 
@@ -119,12 +119,12 @@ TEST_F(MetaSearcherRealServiceTest, TestBatchUpdateLocationStatus) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherRedisTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
-        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
-        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 = MetaSearcherRedisTestHelper::CreateCacheLocation(
-        DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
+    auto location1 = std::make_shared<const CacheLocation>(
+        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs));
+    auto location2 = std::make_shared<const CacheLocation>(
+        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs));
+    auto location3 = std::make_shared<const CacheLocation>(MetaSearcherRedisTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs));
 
     CacheLocationVector locations = {location1, location2, location3};
 
@@ -169,8 +169,7 @@ TEST_F(MetaSearcherRealServiceTest, TestBatchUpdateLocationStatus) {
         EXPECT_NE(it, location_map.end());
 
         if (it != location_map.end()) {
-            const CacheLocation &location = it->second;
-            EXPECT_EQ(location.status(), new_statuses[i]); // 状态应已更新
+            EXPECT_EQ(it->second->status(), new_statuses[i]); // 状态应已更新
         }
     }
 }
@@ -181,12 +180,12 @@ TEST_F(MetaSearcherRealServiceTest, TestPrefixMatchWithServingStatus) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherRedisTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
-        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
-        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 = MetaSearcherRedisTestHelper::CreateCacheLocation(
-        DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
+    auto location1 = std::make_shared<const CacheLocation>(
+        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs));
+    auto location2 = std::make_shared<const CacheLocation>(
+        MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs));
+    auto location3 = std::make_shared<const CacheLocation>(MetaSearcherRedisTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs));
 
     CacheLocationVector locations = {location1, location2, location3};
 
@@ -224,7 +223,7 @@ TEST_F(MetaSearcherRealServiceTest, TestPrefixMatchWithServingStatus) {
 
     // 验证返回的 locations（PrefixMatch 合并视图的 id 无单一元数据语义，不测 id）
     for (size_t i = 0; i < out_locations.size(); i++) {
-        EXPECT_EQ(out_locations[i].status(), CLS_SERVING);
+        EXPECT_EQ(out_locations[i]->status(), CLS_SERVING);
     }
 }
 
@@ -239,12 +238,12 @@ TEST_F(MetaSearcherRealServiceTest, TestConcurrentOperations) {
 
             // 创建CacheLocation对象
             auto location_specs = MetaSearcherRedisTestHelper::CreateDefaultLocationSpecs();
-            CacheLocation location1 = MetaSearcherRedisTestHelper::CreateCacheLocation(
-                DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-            CacheLocation location2 = MetaSearcherRedisTestHelper::CreateCacheLocation(
-                DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-            CacheLocation location3 = MetaSearcherRedisTestHelper::CreateCacheLocation(
-                DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
+            auto location1 = std::make_shared<const CacheLocation>(MetaSearcherRedisTestHelper::CreateCacheLocation(
+                DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs));
+            auto location2 = std::make_shared<const CacheLocation>(MetaSearcherRedisTestHelper::CreateCacheLocation(
+                DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs));
+            auto location3 = std::make_shared<const CacheLocation>(MetaSearcherRedisTestHelper::CreateCacheLocation(
+                DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs));
 
             CacheLocationVector locations = {location1, location2, location3};
 
@@ -302,8 +301,8 @@ TEST_F(MetaSearcherRealServiceTest, TestBatchVsSequentialPerformance) {
         keys.push_back(10000 + i);
 
         auto location_specs = MetaSearcherRedisTestHelper::CreateDefaultLocationSpecs();
-        CacheLocation location =
-            MetaSearcherRedisTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
+        auto location = std::make_shared<const CacheLocation>(MetaSearcherRedisTestHelper::CreateCacheLocation(
+            DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs));
         locations.push_back(location);
     }
 

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -18,10 +18,10 @@ public:
         return spec;
     }
 
-    static CacheLocation CreateCacheLocation(DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_NFS,
-                                             size_t spec_size = 1,
-                                             const std::vector<LocationSpec> &specs = {}) {
-        return CacheLocation(type, spec_size, specs);
+    static CacheLocationConstPtr CreateCacheLocation(DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_NFS,
+                                                     size_t spec_size = 1,
+                                                     const std::vector<LocationSpec> &specs = {}) {
+        return std::make_shared<CacheLocation>(type, spec_size, specs);
     }
 
     static std::vector<LocationSpec> CreateDefaultLocationSpecs() {
@@ -89,11 +89,11 @@ TEST_F(MetaSearcherTest, TestBatchAddLocation) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -128,18 +128,18 @@ TEST_F(MetaSearcherTest, TestBatchAddLocation2) {
     // 创建CacheLocation对象
     std::vector<LocationSpec> specs1(
         1, MetaSearcherTestHelper::CreateLocationSpec("nfs", "file:///tmp/test1/test.txt?offset=1&length=2&size=3"));
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs1);
 
     std::vector<LocationSpec> specs2(
         1, MetaSearcherTestHelper::CreateLocationSpec("hf3fs", "hf3fs:///tmp/test1/test.txt?offset=1&length=2&size=4"));
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, specs2);
 
     std::vector<LocationSpec> specs3(2,
                                      MetaSearcherTestHelper::CreateLocationSpec(
                                          "mooncake", "mooncake:///tmp/test1/test.txt?offset=1&length=2&size=5"));
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, specs3);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -177,11 +177,11 @@ TEST_F(MetaSearcherTest, TestPrefixMatch) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -243,7 +243,7 @@ TEST_F(MetaSearcherTest, TestPrefixMatch) {
 
         // 验证返回的 locations（合并视图的 id 无单一元数据语义；type 为策略 winner 的后端类型）
         for (size_t i = 0; i < out_locations.size(); i++) {
-            EXPECT_EQ(out_locations[i].status(), CLS_SERVING);
+            EXPECT_EQ(out_locations[i]->status(), CLS_SERVING);
         }
     }
 
@@ -263,7 +263,7 @@ TEST_F(MetaSearcherTest, TestPrefixMatch) {
 
         // 验证返回的 locations（合并视图的 id 无单一元数据语义）
         for (size_t i = 0; i < out_locations.size(); i++) {
-            EXPECT_EQ(out_locations[i].status(), CLS_SERVING);
+            EXPECT_EQ(out_locations[i]->status(), CLS_SERVING);
         }
     }
 }
@@ -274,11 +274,11 @@ TEST_F(MetaSearcherTest, TestBatchGet) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -310,10 +310,10 @@ TEST_F(MetaSearcherTest, TestBatchGet) {
         EXPECT_NE(it, location_map.end());
 
         if (it != location_map.end()) {
-            const CacheLocation &location = it->second;
+            const auto &location = *it->second;
             EXPECT_EQ(location.id(), out_location_ids[i]);
             EXPECT_EQ(location.status(), CLS_WRITING);
-            EXPECT_EQ(location.type(), locations[i].type());
+            EXPECT_EQ(location.type(), locations[i]->type());
         }
     }
 
@@ -344,11 +344,11 @@ TEST_F(MetaSearcherTest, TestBatchUpdateLocationStatus) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -377,10 +377,10 @@ TEST_F(MetaSearcherTest, TestBatchUpdateLocationStatus) {
         EXPECT_NE(it, location_map.end());
 
         if (it != location_map.end()) {
-            const CacheLocation &location = it->second;
+            const auto &location = *it->second;
             EXPECT_EQ(location.id(), out_location_ids[i]);
             EXPECT_EQ(location.status(), CLS_WRITING); // 初始状态应为CLS_WRITING
-            EXPECT_EQ(location.type(), locations[i].type());
+            EXPECT_EQ(location.type(), locations[i]->type());
         }
     }
 
@@ -416,10 +416,10 @@ TEST_F(MetaSearcherTest, TestBatchUpdateLocationStatus) {
         EXPECT_NE(it, location_map.end());
 
         if (it != location_map.end()) {
-            const CacheLocation &location = it->second;
+            const auto &location = *it->second;
             EXPECT_EQ(location.id(), out_location_ids[i]);
             EXPECT_EQ(location.status(), new_statuses[i]); // 状态应已更新
-            EXPECT_EQ(location.type(), locations[i].type());
+            EXPECT_EQ(location.type(), locations[i]->type());
         }
     }
 
@@ -465,11 +465,11 @@ TEST_F(MetaSearcherTest, TestBlockKeyWithMultipleLocations) {
     std::vector<LocationSpec> location_specs2 = {MetaSearcherTestHelper::CreateLocationSpec("tp1", "uri2")};
     std::vector<LocationSpec> location_specs3 = {MetaSearcherTestHelper::CreateLocationSpec("tp2", "uri3")};
 
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs1);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs2);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs3);
 
     // 将三个location添加到同一个key
@@ -510,17 +510,17 @@ TEST_F(MetaSearcherTest, TestBlockKeyWithMultipleLocations) {
     EXPECT_NE(location_map.find(out_location_ids3[0]), location_map.end());
 
     // 验证每个location的信息
-    const CacheLocation &retrieved_location1 = location_map.at(out_location_ids1[0]);
+    const auto &retrieved_location1 = *location_map.at(out_location_ids1[0]);
     EXPECT_EQ(retrieved_location1.type(), DataStorageType::DATA_STORAGE_TYPE_NFS);
     EXPECT_EQ(retrieved_location1.spec_size(), 1);
     EXPECT_EQ(retrieved_location1.location_specs().size(), 1);
 
-    const CacheLocation &retrieved_location2 = location_map.at(out_location_ids2[0]);
+    const auto &retrieved_location2 = *location_map.at(out_location_ids2[0]);
     EXPECT_EQ(retrieved_location2.type(), DataStorageType::DATA_STORAGE_TYPE_HF3FS);
     EXPECT_EQ(retrieved_location2.spec_size(), 2);
     EXPECT_EQ(retrieved_location2.location_specs().size(), 1);
 
-    const CacheLocation &retrieved_location3 = location_map.at(out_location_ids3[0]);
+    const auto &retrieved_location3 = *location_map.at(out_location_ids3[0]);
     EXPECT_EQ(retrieved_location3.type(), DataStorageType::DATA_STORAGE_TYPE_MOONCAKE);
     EXPECT_EQ(retrieved_location3.spec_size(), 3);
     EXPECT_EQ(retrieved_location3.location_specs().size(), 1);
@@ -532,11 +532,11 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocation) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -597,10 +597,10 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocation) {
     EXPECT_NE(it, out_location_maps[2].end());
 
     if (it != out_location_maps[2].end()) {
-        const CacheLocation &location = it->second;
+        const auto &location = *it->second;
         EXPECT_EQ(location.id(), out_location_ids[2]);
         EXPECT_EQ(location.status(), CLS_WRITING);
-        EXPECT_EQ(location.type(), locations[2].type());
+        EXPECT_EQ(location.type(), locations[2]->type());
     }
 
     // 测试错误情况：key和location_id数量不匹配
@@ -620,18 +620,18 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocation2) {
     // 创建CacheLocation对象
     std::vector<LocationSpec> specs1(
         1, MetaSearcherTestHelper::CreateLocationSpec("nfs", "file:///tmp/test1/test.txt?offset=1&length=2&size=3"));
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs1);
 
     std::vector<LocationSpec> specs2(
         1, MetaSearcherTestHelper::CreateLocationSpec("hf3fs", "hf3fs:///tmp/test1/test.txt?offset=1&length=2&size=4"));
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, specs2);
 
     std::vector<LocationSpec> specs3(2,
                                      MetaSearcherTestHelper::CreateLocationSpec(
                                          "mooncake", "mooncake:///tmp/test1/test.txt?offset=1&length=2&size=5"));
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, specs3);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -665,7 +665,7 @@ TEST_F(MetaSearcherTest, TestBatchVsSequentialPerformance) {
         keys.push_back(10000 + i);
 
         auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-        CacheLocation location =
+        CacheLocationConstPtr location =
             MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
         locations.push_back(location);
     }
@@ -726,11 +726,11 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatus) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -759,7 +759,7 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatus) {
         EXPECT_NE(it, location_map.end());
 
         if (it != location_map.end()) {
-            const CacheLocation &location = it->second;
+            const auto &location = *it->second;
             EXPECT_EQ(location.id(), out_location_ids[i]);
             EXPECT_EQ(location.status(), CLS_WRITING); // 初始状态应为CLS_WRITING
         }
@@ -801,10 +801,10 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatus) {
         EXPECT_NE(it, location_map.end());
 
         if (it != location_map.end()) {
-            const CacheLocation &location = it->second;
+            const auto &location = *it->second;
             EXPECT_EQ(location.id(), out_location_ids[i]);
             EXPECT_EQ(location.status(), CLS_SERVING); // 状态应已更新为SERVING
-            EXPECT_EQ(location.type(), locations[i].type());
+            EXPECT_EQ(location.type(), locations[i]->type());
         }
     }
 
@@ -834,11 +834,11 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatus) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -925,18 +925,18 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatus2) {
     // 创建CacheLocation对象
     std::vector<LocationSpec> specs1(
         1, MetaSearcherTestHelper::CreateLocationSpec("nfs", "file:///tmp/test1/test.txt?offset=1&length=2&size=3"));
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs1);
 
     std::vector<LocationSpec> specs2(
         1, MetaSearcherTestHelper::CreateLocationSpec("hf3fs", "hf3fs:///tmp/test1/test.txt?offset=1&length=2&size=4"));
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, specs2);
 
     std::vector<LocationSpec> specs3(2,
                                      MetaSearcherTestHelper::CreateLocationSpec(
                                          "mooncake", "mooncake:///tmp/test1/test.txt?offset=1&length=2&size=5"));
-    CacheLocation location3 =
+    CacheLocationConstPtr location3 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, specs3);
 
     CacheLocationVector locations = {location1, location2, location3};
@@ -988,7 +988,7 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusMultipleTasksPerKey) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
 
     CacheLocationVector locations = {location1};
@@ -1000,7 +1000,7 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusMultipleTasksPerKey) {
     EXPECT_EQ(out_location_ids.size(), 1);
 
     // 添加第二个位置到同一个key
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 1, location_specs);
     std::vector<std::string> out_location_ids2;
     ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, {location2}, out_location_ids2);
@@ -1044,8 +1044,8 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusMultipleTasksPerKey) {
     auto it2 = out_location_maps[0].find(out_location_ids2[0]);
     EXPECT_NE(it1, out_location_maps[0].end());
     EXPECT_NE(it2, out_location_maps[0].end());
-    EXPECT_EQ(it1->second.status(), CLS_SERVING);
-    EXPECT_EQ(it2->second.status(), CLS_DELETING);
+    EXPECT_EQ(it1->second->status(), CLS_SERVING);
+    EXPECT_EQ(it2->second->status(), CLS_DELETING);
 }
 
 TEST_F(MetaSearcherTest, TestBatchCADLocationStatusMultipleTasksPerKey) {
@@ -1054,9 +1054,9 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatusMultipleTasksPerKey) {
 
     // 创建CacheLocation对象
     auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
-    CacheLocation location1 =
+    CacheLocationConstPtr location1 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
-    CacheLocation location2 =
+    CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 1, location_specs);
 
     // 添加第一个位置信息
@@ -1084,7 +1084,7 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatusMultipleTasksPerKey) {
     EXPECT_EQ(out_location_maps.size(), 1);
     EXPECT_EQ(out_location_maps[0].size(), 2); // 应该有两个位置
     for (const auto &loc_pair : out_location_maps[0]) {
-        EXPECT_EQ(loc_pair.second.status(), CLS_WRITING);
+        EXPECT_EQ(loc_pair.second->status(), CLS_WRITING);
     }
 
     // 将第一个位置的状态都更新为DELETING
@@ -1114,8 +1114,8 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatusMultipleTasksPerKey) {
     auto it2 = out_location_maps[0].find(out_location_ids[1]);
     EXPECT_NE(it1, out_location_maps[0].end());
     EXPECT_NE(it2, out_location_maps[0].end());
-    EXPECT_EQ(it1->second.status(), CLS_DELETING);
-    EXPECT_EQ(it2->second.status(), CLS_WRITING);
+    EXPECT_EQ(it1->second->status(), CLS_DELETING);
+    EXPECT_EQ(it2->second->status(), CLS_WRITING);
 
     // CAD任务：删除状态为DELETING的两个位置
     std::vector<std::vector<MetaSearcher::LocationCADTask>> batch_tasks;
@@ -1190,12 +1190,12 @@ TEST_F(MetaSearcherTest, TestPrefixMatchMergesSpecsByStorageType) {
 
     // Location A: NFS with spec "tp0"
     std::vector<LocationSpec> specs_a = {MetaSearcherTestHelper::CreateLocationSpec("tp0", "nfs:///a/tp0")};
-    CacheLocation loc_a =
+    CacheLocationConstPtr loc_a =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs_a);
 
     // Location B: NFS with spec "tp1" (same storage type, different spec)
     std::vector<LocationSpec> specs_b = {MetaSearcherTestHelper::CreateLocationSpec("tp1", "nfs:///b/tp1")};
-    CacheLocation loc_b =
+    CacheLocationConstPtr loc_b =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs_b);
 
     // Add location A to all keys
@@ -1234,11 +1234,11 @@ TEST_F(MetaSearcherTest, TestPrefixMatchMergesSpecsByStorageType) {
     for (size_t i = 0; i < out_locations.size(); ++i) {
         const auto &loc = out_locations[i];
         // Both locations are NFS, so specs from both should be merged
-        ASSERT_EQ(loc.location_specs().size(), 2) << "key index " << i << " should have 2 specs merged from same type";
-        EXPECT_EQ(loc.spec_size(), loc.location_specs().size())
+        ASSERT_EQ(loc->location_specs().size(), 2) << "key index " << i << " should have 2 specs merged from same type";
+        EXPECT_EQ(loc->spec_size(), loc->location_specs().size())
             << "spec_size must equal location_specs count after merge";
-        EXPECT_EQ(loc.type(), DataStorageType::DATA_STORAGE_TYPE_NFS);
-        for (const auto &spec : loc.location_specs()) {
+        EXPECT_EQ(loc->type(), DataStorageType::DATA_STORAGE_TYPE_NFS);
+        for (const auto &spec : loc->location_specs()) {
             EXPECT_FALSE(spec.uri().empty());
         }
     }
@@ -1250,14 +1250,14 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
     // Key 60000: add 2 locations with different specs but SAME storage type (NFS)
     std::vector<LocationSpec> specs_a = {MetaSearcherTestHelper::CreateLocationSpec("tp0", "nfs:///a/tp0")};
     std::vector<LocationSpec> specs_b = {MetaSearcherTestHelper::CreateLocationSpec("tp1", "nfs:///b/tp1")};
-    CacheLocation loc_a =
+    CacheLocationConstPtr loc_a =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs_a);
-    CacheLocation loc_b =
+    CacheLocationConstPtr loc_b =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs_b);
 
     // Key 60001: add only 1 location
     std::vector<LocationSpec> specs_c = {MetaSearcherTestHelper::CreateLocationSpec("tp0", "mooncake:///c/tp0")};
-    CacheLocation loc_c =
+    CacheLocationConstPtr loc_c =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 1, specs_c);
 
     // Add loc_a to key 60000, loc_c to key 60001
@@ -1300,19 +1300,19 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
     // Key 60000: both locations are NFS, specs should be merged → 2 specs
     {
         const auto &loc = out_locations[0];
-        ASSERT_EQ(loc.location_specs().size(), 2);
-        EXPECT_EQ(loc.spec_size(), loc.location_specs().size())
+        ASSERT_EQ(loc->location_specs().size(), 2);
+        EXPECT_EQ(loc->spec_size(), loc->location_specs().size())
             << "spec_size must equal location_specs count after merge";
-        EXPECT_EQ(loc.type(), DataStorageType::DATA_STORAGE_TYPE_NFS);
+        EXPECT_EQ(loc->type(), DataStorageType::DATA_STORAGE_TYPE_NFS);
     }
 
     // Key 60001: single location → 1 spec
     {
         const auto &loc = out_locations[1];
-        ASSERT_EQ(loc.location_specs().size(), 1);
-        EXPECT_EQ(loc.spec_size(), loc.location_specs().size())
+        ASSERT_EQ(loc->location_specs().size(), 1);
+        EXPECT_EQ(loc->spec_size(), loc->location_specs().size())
             << "spec_size must equal location_specs count for single location";
-        EXPECT_EQ(loc.location_specs()[0].name(), "tp0");
-        EXPECT_EQ(loc.type(), DataStorageType::DATA_STORAGE_TYPE_MOONCAKE);
+        EXPECT_EQ(loc->location_specs()[0].name(), "tp0");
+        EXPECT_EQ(loc->type(), DataStorageType::DATA_STORAGE_TYPE_MOONCAKE);
     }
 }

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -20,10 +20,10 @@ public:
         return spec;
     }
 
-    static CacheLocation CreateCacheLocation(DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_NFS,
-                                             size_t spec_size = 1,
-                                             const std::vector<LocationSpec> &specs = {}) {
-        return CacheLocation(type, spec_size, specs);
+    static CacheLocationConstPtr CreateCacheLocation(DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_NFS,
+                                                     size_t spec_size = 1,
+                                                     const std::vector<LocationSpec> &specs = {}) {
+        return std::make_shared<CacheLocation>(type, spec_size, specs);
     }
 
     static std::vector<LocationSpec> CreateDefaultLocationSpecs() {
@@ -94,11 +94,11 @@ TEST_F(SchedulePlanExecutorTest, TestSubmit) {
         MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
 
         // 创建CacheLocation对象
-        CacheLocation location1 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        CacheLocationConstPtr location1 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
             DataStorageType::DATA_STORAGE_TYPE_NFS,
             1,
             {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0", "nfs://nfs_01/block" + std::to_string(i * 2))});
-        CacheLocation location2 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        CacheLocationConstPtr location2 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
             DataStorageType::DATA_STORAGE_TYPE_NFS,
             1,
             {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0",
@@ -199,7 +199,7 @@ TEST_F(SchedulePlanExecutorTest, TestSetStatusToDeleting) {
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
 
     // 创建CacheLocation对象
-    CacheLocation new_location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr new_location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/block200")});
@@ -233,7 +233,7 @@ TEST_F(SchedulePlanExecutorTest, TestSetStatusToDeleting) {
 
     for (const auto &location_map : location_maps) {
         for (const auto &loc_kv : location_map) {
-            const auto &location = loc_kv.second;
+            const auto &location = *loc_kv.second;
             ASSERT_EQ(CacheLocationStatus::CLS_DELETING, location.status())
                 << "Location status should be CLS_DELETING after Submit";
         }
@@ -256,15 +256,15 @@ TEST_F(SchedulePlanExecutorTest, TestMultipleLocationsPerBlockKey) {
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
 
     // 创建多个CacheLocation对象
-    CacheLocation location1 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location1 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0", "nfs://nfs_01/block1")});
-    CacheLocation location2 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location2 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0", "nfs://nfs_01/block2")});
-    CacheLocation location3 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location3 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0", "nfs://nfs_01/block3")});
@@ -307,7 +307,7 @@ TEST_F(SchedulePlanExecutorTest, TestMultipleLocationsPerBlockKey) {
 
     // 检查所有location的状态是否都更新为DELETING
     for (const auto &loc_kv : location_maps[0]) {
-        const auto &location = loc_kv.second;
+        const auto &location = *loc_kv.second;
         KVCM_LOG_INFO("Location ID: %s, Status: %d", loc_kv.first.c_str(), location.status());
         ASSERT_EQ(CacheLocationStatus::CLS_DELETING, location.status())
             << "Location status should be CLS_DELETING after Submit";
@@ -336,7 +336,7 @@ TEST_F(SchedulePlanExecutorTest, TestStorageDelete) {
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
 
     // 创建CacheLocation对象
-    CacheLocation location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/test_block_for_storage_delete")});
@@ -389,7 +389,7 @@ TEST_F(SchedulePlanExecutorTest, TestDelayExecution) {
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
 
     // 创建CacheLocation对象
-    CacheLocation location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/test_block_for_delay")});
@@ -459,7 +459,7 @@ TEST_F(SchedulePlanExecutorTest, TestMultipleDelayedTasksExecutionOrder) {
 
     for (int i = 0; i < 3; i++) {
         // 创建CacheLocation对象
-        CacheLocation location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        CacheLocationConstPtr location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
             DataStorageType::DATA_STORAGE_TYPE_NFS,
             1,
             {SchedulePlanExecutorTestHelper::CreateLocationSpec(
@@ -540,15 +540,15 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequest) {
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
 
     // 创建多个CacheLocation对象
-    CacheLocation location1 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location1 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0", "nfs://nfs_01/block100")});
-    CacheLocation location2 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location2 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0", "nfs://nfs_01/block101")});
-    CacheLocation location3 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location3 = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("TP0", "nfs://nfs_01/block102")});
@@ -601,7 +601,7 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequest) {
     // 检查被标记为删除的location的状态是否都更新为DELETING
     int deleting_count = 0;
     for (const auto &loc_kv : location_maps[0]) {
-        const auto &location = loc_kv.second;
+        const auto &location = *loc_kv.second;
         if (loc_kv.first == original_location_ids[0] || loc_kv.first == original_location_ids[1]) {
             // 这两个应该被标记为DELETING
             ASSERT_EQ(CacheLocationStatus::CLS_DELETING, location.status())
@@ -668,7 +668,7 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequestWithDelay) {
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
 
     // 创建CacheLocation对象
-    CacheLocation location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+    CacheLocationConstPtr location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
         DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/test_block_for_location_delay")});

--- a/kv_cache_manager/manager/test/selection_location_policy_test.cc
+++ b/kv_cache_manager/manager/test/selection_location_policy_test.cc
@@ -31,15 +31,14 @@ public:
         return location_map;
     }
 
-    CacheLocation GenFakeLocation(const std::string &id, const FakeLocationMeta &meta) const {
-
+    CacheLocationConstPtr GenFakeLocation(const std::string &id, const FakeLocationMeta &meta) const {
         std::string uri = ToString(meta.type) + "://" + meta.unique_name + "/" + id;
-        CacheLocation location;
-        location.set_id(id);
-        location.set_status(meta.status);
-        location.set_type(meta.type);
-        location.set_spec_size(1000);
-        location.set_location_specs({LocationSpec("tp0", uri)});
+        auto location = std::make_shared<CacheLocation>();
+        location->set_id(id);
+        location->set_status(meta.status);
+        location->set_type(meta.type);
+        location->set_spec_size(1000);
+        location->set_location_specs({LocationSpec("tp0", uri)});
         return location;
     }
 
@@ -50,18 +49,18 @@ public:
         std::vector<std::string> spec_names;
     };
 
-    CacheLocation GenFakeLocationWithSpecs(const std::string &id, const FakeLocationMetaWithSpecs &meta) const {
-        CacheLocation location;
-        location.set_id(id);
-        location.set_status(meta.status);
-        location.set_type(meta.type);
-        location.set_spec_size(meta.spec_names.size());
+    CacheLocationConstPtr GenFakeLocationWithSpecs(const std::string &id, const FakeLocationMetaWithSpecs &meta) const {
+        auto location = std::make_shared<CacheLocation>();
+        location->set_id(id);
+        location->set_status(meta.status);
+        location->set_type(meta.type);
+        location->set_spec_size(meta.spec_names.size());
         std::vector<LocationSpec> specs;
         for (const auto &name : meta.spec_names) {
             std::string uri = ToString(meta.type) + "://" + meta.unique_name + "/" + id + "/" + name;
             specs.emplace_back(name, uri);
         }
-        location.set_location_specs(std::move(specs));
+        location->set_location_specs(std::move(specs));
         return location;
     }
 
@@ -81,7 +80,8 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatch) {
         auto location_map = GenLocationMap(
             {{CLS_SERVING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_MEMPOOL, D_3FS, D_NFS));
         }
     }
@@ -89,7 +89,8 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatch) {
         auto location_map = GenLocationMap(
             {{CLS_WRITING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
         }
     }
@@ -99,7 +100,8 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatch) {
                                             {CLS_SERVING, D_3FS, "3fs_02"},
                                             {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(),
                         AnyOf(HasSubstr("3fs_01"), HasSubstr("3fs_02"), HasSubstr("nfs_01")));
@@ -115,11 +117,11 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatchWithStale
         auto location_map = GenLocationMap({{CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         ASSERT_EQ(prune_loc_ids.size(), 2u);
         for (const auto &id : prune_loc_ids) {
-            ASSERT_EQ(location_map.at(id).status(), CLS_SERVING);
+            ASSERT_EQ(location_map.at(id)->status(), CLS_SERVING);
         }
     }
     // (b) mix of stale and valid CLS_SERVING ->
@@ -133,11 +135,11 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatchWithStale
         };
         for (int i = 0; i < 100; ++i) {
             std::vector<std::string> prune_loc_ids;
-            CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-            ASSERT_NE(location, nullptr);
+            CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+            ASSERT_FALSE(location->location_specs().empty());
             ASSERT_THAT(location->type(), AnyOf(D_NFS, D_MEMPOOL));
             ASSERT_EQ(prune_loc_ids.size(), 1u);
-            ASSERT_EQ(location_map.at(prune_loc_ids[0]).type(), D_3FS);
+            ASSERT_EQ(location_map.at(prune_loc_ids[0])->type(), D_3FS);
         }
     }
     // (c) non-CLS_SERVING entries are ignored entirely ->
@@ -147,11 +149,11 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatchWithStale
             {{CLS_WRITING, D_3FS, "3fs_01"}, {CLS_NOT_FOUND, D_NFS, "nfs_01"}, {CLS_SERVING, D_MEMPOOL, "pace_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
         // only the CLS_SERVING entry is checked; it is stale and pruned
-        ASSERT_EQ(location, nullptr);
+        ASSERT_TRUE(location->location_specs().empty());
         ASSERT_EQ(prune_loc_ids.size(), 1u);
-        ASSERT_EQ(location_map.at(prune_loc_ids[0]).status(), CLS_SERVING);
+        ASSERT_EQ(location_map.at(prune_loc_ids[0])->status(), CLS_SERVING);
     }
     // (d) single stale CLS_SERVING entry ->
     //     pruned, returns nullptr
@@ -159,8 +161,8 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicySelectForMatchWithStale
         auto location_map = GenLocationMap({{CLS_SERVING, D_3FS, "3fs_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         ASSERT_EQ(prune_loc_ids.size(), 1u);
     }
 }
@@ -246,7 +248,7 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicyExistsForWriteWithStale
         ASSERT_TRUE(policy.ExistsForWrite(location_map, stale_check, prune_loc_ids));
         ASSERT_EQ(prune_loc_ids.size(), 2u);
         for (const auto &id : prune_loc_ids) {
-            ASSERT_EQ(location_map.at(id).status(), CLS_SERVING);
+            ASSERT_EQ(location_map.at(id)->status(), CLS_SERVING);
         }
     }
     // (f) mix of stale and valid CLS_SERVING ->
@@ -259,7 +261,7 @@ TEST_F(SelectLocationPolicyTest, TestStaticWeightSLPolicyExistsForWriteWithStale
         std::vector<std::string> prune_loc_ids;
         ASSERT_TRUE(policy.ExistsForWrite(location_map, stale_check, prune_loc_ids));
         ASSERT_EQ(prune_loc_ids.size(), 1u);
-        ASSERT_EQ(location_map.at(prune_loc_ids[0]).type(), D_3FS);
+        ASSERT_EQ(location_map.at(prune_loc_ids[0])->type(), D_3FS);
     }
 }
 
@@ -275,7 +277,8 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatch) {
         auto location_map = GenLocationMap(
             {{CLS_SERVING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_MEMPOOL, D_3FS));
         }
     }
@@ -285,7 +288,8 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatch) {
                                             {CLS_SERVING, D_MOONCAKE, "mooncake_01"},
                                             {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_MOONCAKE));
         }
     }
@@ -297,7 +301,8 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatch) {
                                             {CLS_SERVING, D_NFS, "nfs_01"},
                                             {CLS_SERVING, D_NFS, "nfs_02"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_MOONCAKE));
             ASSERT_THAT(location->location_specs().front().uri(),
                         AnyOf(HasSubstr("3fs_01"), HasSubstr("mooncake_01"), HasSubstr("mooncake_02")));
@@ -319,8 +324,8 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatchWithStal
         auto location_map = GenLocationMap({{CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_MOONCAKE, "mooncake_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         ASSERT_EQ(prune_loc_ids.size(), 2u);
     }
     // (b) mix of stale and valid ->
@@ -335,11 +340,11 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatchWithStal
         };
         for (int i = 0; i < 100; ++i) {
             std::vector<std::string> prune_loc_ids;
-            CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-            ASSERT_NE(location, nullptr);
+            CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+            ASSERT_FALSE(location->location_specs().empty());
             ASSERT_THAT(location->type(), AnyOf(D_MOONCAKE, D_MEMPOOL));
             ASSERT_EQ(prune_loc_ids.size(), 1u);
-            ASSERT_EQ(location_map.at(prune_loc_ids[0]).type(), D_3FS);
+            ASSERT_EQ(location_map.at(prune_loc_ids[0])->type(), D_3FS);
         }
     }
     // (c) non-CLS_SERVING entries are ignored entirely ->
@@ -348,11 +353,11 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatchWithStal
         auto location_map = GenLocationMap({{CLS_WRITING, D_3FS, "3fs_01"}, {CLS_SERVING, D_MOONCAKE, "mooncake_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         // only the CLS_SERVING mooncake entry is pruned
         ASSERT_EQ(prune_loc_ids.size(), 1u);
-        ASSERT_EQ(location_map.at(prune_loc_ids[0]).status(), CLS_SERVING);
+        ASSERT_EQ(location_map.at(prune_loc_ids[0])->status(), CLS_SERVING);
     }
     // (d) stale CLS_SERVING entry with weight 0 (nfs) ->
     //     still pruned
@@ -360,8 +365,8 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicySelectForMatchWithStal
         auto location_map = GenLocationMap({{CLS_SERVING, D_NFS, "nfs_01"}, {CLS_SERVING, D_3FS, "3fs_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         // both are CLS_SERVING and stale, both pruned (weight check
         // happens after the stale-data check)
         ASSERT_EQ(prune_loc_ids.size(), 2u);
@@ -454,7 +459,7 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicyExistsForWriteWithStal
         ASSERT_TRUE(policy.ExistsForWrite(location_map, stale_check, prune_loc_ids));
         ASSERT_EQ(prune_loc_ids.size(), 2u);
         for (const auto &id : prune_loc_ids) {
-            ASSERT_EQ(location_map.at(id).status(), CLS_SERVING);
+            ASSERT_EQ(location_map.at(id)->status(), CLS_SERVING);
         }
     }
     // (e) mix of stale and valid CLS_SERVING ->
@@ -467,7 +472,7 @@ TEST_F(SelectLocationPolicyTest, TestDynamicWeightSLPolicyExistsForWriteWithStal
         std::vector<std::string> prune_loc_ids;
         ASSERT_TRUE(policy.ExistsForWrite(location_map, stale_check, prune_loc_ids));
         ASSERT_EQ(prune_loc_ids.size(), 1u);
-        ASSERT_EQ(location_map.at(prune_loc_ids[0]).type(), D_3FS);
+        ASSERT_EQ(location_map.at(prune_loc_ids[0])->type(), D_3FS);
     }
 }
 
@@ -477,7 +482,8 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatch)
         auto location_map = GenLocationMap(
             {{CLS_SERVING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_MEMPOOL, D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(),
                         AnyOf(HasSubstr("pace_01"), HasSubstr("3fs_01"), HasSubstr("nfs_01")));
@@ -487,7 +493,8 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatch)
         auto location_map = GenLocationMap(
             {{CLS_WRITING, D_MEMPOOL, "pace_01"}, {CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(), AnyOf(HasSubstr("3fs_01"), HasSubstr("nfs_01")));
         }
@@ -498,7 +505,8 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatch)
                                             {CLS_SERVING, D_3FS, "3fs_02"},
                                             {CLS_SERVING, D_NFS, "nfs_01"}});
         for (int i = 0; i < 100; ++i) {
-            CacheLocation *location = policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
+            CacheLocationConstPtr location =
+                policy.SelectForMatch(location_map, dummy_check_loc_data_exist, dummy_loc_ids);
             ASSERT_THAT(location->type(), AnyOf(D_3FS, D_NFS));
             ASSERT_THAT(location->location_specs().front().uri(), AnyOf(HasSubstr("3fs_01"), HasSubstr("nfs_01")));
         }
@@ -513,8 +521,8 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatchW
         auto location_map = GenLocationMap({{CLS_SERVING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         ASSERT_EQ(prune_loc_ids.size(), 2u);
     }
     // (b) mix of stale and valid ->
@@ -528,11 +536,11 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatchW
         };
         for (int i = 0; i < 100; ++i) {
             std::vector<std::string> prune_loc_ids;
-            CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-            ASSERT_NE(location, nullptr);
+            CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+            ASSERT_FALSE(location->location_specs().empty());
             ASSERT_THAT(location->type(), AnyOf(D_NFS, D_MEMPOOL));
             ASSERT_EQ(prune_loc_ids.size(), 1u);
-            ASSERT_EQ(location_map.at(prune_loc_ids[0]).type(), D_3FS);
+            ASSERT_EQ(location_map.at(prune_loc_ids[0])->type(), D_3FS);
         }
     }
     // (c) non-CLS_SERVING entries ignored ->
@@ -541,11 +549,11 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatchW
         auto location_map = GenLocationMap({{CLS_WRITING, D_3FS, "3fs_01"}, {CLS_SERVING, D_NFS, "nfs_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         // only the CLS_SERVING nfs entry is pruned
         ASSERT_EQ(prune_loc_ids.size(), 1u);
-        ASSERT_EQ(location_map.at(prune_loc_ids[0]).status(), CLS_SERVING);
+        ASSERT_EQ(location_map.at(prune_loc_ids[0])->status(), CLS_SERVING);
     }
     // (d) stale entry with weight 0 (3fs_02) ->
     //     still pruned (stale-data check runs before the weight check)
@@ -553,8 +561,8 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicySelectForMatchW
         auto location_map = GenLocationMap({{CLS_SERVING, D_3FS, "3fs_02"}, {CLS_SERVING, D_3FS, "3fs_01"}});
         auto stale_check = [](const CacheLocation &) -> bool { return false; };
         std::vector<std::string> prune_loc_ids;
-        CacheLocation *location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
-        ASSERT_EQ(location, nullptr);
+        CacheLocationConstPtr location = policy.SelectForMatch(location_map, stale_check, prune_loc_ids);
+        ASSERT_TRUE(location->location_specs().empty());
         ASSERT_EQ(prune_loc_ids.size(), 2u);
     }
 }
@@ -641,7 +649,7 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicyExistsForWriteW
         ASSERT_TRUE(policy.ExistsForWrite(location_map, stale_check, prune_loc_ids));
         ASSERT_EQ(prune_loc_ids.size(), 2u);
         for (const auto &id : prune_loc_ids) {
-            ASSERT_EQ(location_map.at(id).status(), CLS_SERVING);
+            ASSERT_EQ(location_map.at(id)->status(), CLS_SERVING);
         }
     }
     // (f) mix of stale and valid CLS_SERVING ->
@@ -654,7 +662,7 @@ TEST_F(SelectLocationPolicyTest, TestNamedStorageWeightedSLPolicyExistsForWriteW
         std::vector<std::string> prune_loc_ids;
         ASSERT_TRUE(policy.ExistsForWrite(location_map, stale_check, prune_loc_ids));
         ASSERT_EQ(prune_loc_ids.size(), 1u);
-        ASSERT_EQ(location_map.at(prune_loc_ids[0]).type(), D_3FS);
+        ASSERT_EQ(location_map.at(prune_loc_ids[0])->type(), D_3FS);
     }
 }
 

--- a/kv_cache_manager/meta/cache_location.h
+++ b/kv_cache_manager/meta/cache_location.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -144,8 +145,9 @@ private:
     std::vector<LocationSpec> location_specs_;
 };
 
-using CacheLocationVector = std::vector<CacheLocation>;
-using CacheLocationMap = std::unordered_map<std::string, CacheLocation>;
+using CacheLocationConstPtr = std::shared_ptr<const CacheLocation>;
+using CacheLocationVector = std::vector<CacheLocationConstPtr>;
+using CacheLocationMap = std::unordered_map<std::string, CacheLocationConstPtr>;
 using CacheLocationMapVector = std::vector<CacheLocationMap>;
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/cache_location.h
+++ b/kv_cache_manager/meta/cache_location.h
@@ -128,6 +128,13 @@ public:
     [[nodiscard]] CacheLocationStatus status() const { return status_; }
     [[nodiscard]] DataStorageType type() const { return type_; }
     [[nodiscard]] size_t spec_size() const { return spec_size_; }
+    [[nodiscard]] size_t EstimateMemUsage() const {
+        size_t usage = sizeof(CacheLocation) + id_.size();
+        for (const auto &spec : location_specs_) {
+            usage += sizeof(LocationSpec) + spec.name().size() + spec.uri().size();
+        }
+        return usage;
+    }
 
 private:
     std::string id_;
@@ -139,5 +146,6 @@ private:
 
 using CacheLocationVector = std::vector<CacheLocation>;
 using CacheLocationMap = std::unordered_map<std::string, CacheLocation>;
+using CacheLocationMapVector = std::vector<CacheLocationMap>;
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_cache_base_backend.h
+++ b/kv_cache_manager/meta/meta_cache_base_backend.h
@@ -12,35 +12,68 @@ class MetaCacheBaseBackend : public MetaStorageBackend {
 public:
     ~MetaCacheBaseBackend() override = default;
 
+    // Bring base-class write overloads into scope (without previous_error_codes).
     using MetaStorageBackend::Delete;
-    using MetaStorageBackend::DeleteFields;
+    using MetaStorageBackend::DeleteLocations;
     using MetaStorageBackend::Put;
-    using MetaStorageBackend::UpdateFields;
+    using MetaStorageBackend::Update;
     using MetaStorageBackend::Upsert;
 
-    virtual std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
-
-    // Conditional write: only processes keys where previous_error_codes[i] == EC_OK.
-    // For skipped keys, the returned error code is copied from previous_error_codes.
-    virtual std::vector<ErrorCode> Put(const KeyTypeVec &keys,
-                                       const FieldMapVec &field_maps,
-                                       const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-    virtual std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys,
-                                               const FieldMapVec &field_maps,
-                                               const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-    virtual std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys,
-                                                const FieldMapVec &field_maps,
-                                                const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-    virtual std::vector<ErrorCode> Upsert(const KeyTypeVec &keys,
-                                          const FieldMapVec &field_maps,
-                                          const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-    virtual std::vector<ErrorCode> Delete(const KeyTypeVec &keys,
-                                          const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-    virtual std::vector<ErrorCode> DeleteFields(const KeyTypeVec &keys,
-                                                const std::vector<std::vector<std::string>> &field_names_vec,
-                                                const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
-
     virtual size_t GetMemUsage() const noexcept = 0;
+
+    // 写入 locations + properties，仅当 key 在 cache 中不存在时才写入。
+    // 若 key 已存在，返回 EC_OK 且不修改已有数据（幂等）。
+    // @param request_context    请求上下文；可为 nullptr
+    // @param keys               待写入的 key 列表
+    // @param locations          每个 key 的 CacheLocationMap
+    // @param properties         每个 key 的 PropertyMap
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    写入成功或 key 已存在（均视为成功）
+    //   - EC_ERROR: 写入失败
+    virtual std::vector<ErrorCode> PutIfAbsent(RequestContext *request_context,
+                                               const KeyTypeVec &keys,
+                                               const CacheLocationMapVector &locations,
+                                               const PropertyMapVector &properties) noexcept = 0;
+
+    // =====================================================================
+    // Overloaded writes with previous_error_codes
+    // =====================================================================
+    // For each key:
+    //   - If previous_error_codes[i] != EC_OK → skip, return previous_error_codes[i]
+    //   - Otherwise → perform the write normally
+
+    virtual std::vector<ErrorCode> Put(RequestContext *request_context,
+                                       const KeyTypeVec &keys,
+                                       const CacheLocationMapVector &locations,
+                                       const PropertyMapVector &properties,
+                                       const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
+
+    virtual std::vector<ErrorCode> PutIfAbsent(RequestContext *request_context,
+                                               const KeyTypeVec &keys,
+                                               const CacheLocationMapVector &locations,
+                                               const PropertyMapVector &properties,
+                                               const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
+
+    virtual std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          const CacheLocationMapVector &locations,
+                                          const PropertyMapVector &properties,
+                                          const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
+
+    virtual std::vector<ErrorCode> Update(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          const CacheLocationMapVector &locations,
+                                          const PropertyMapVector &properties,
+                                          const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
+
+    virtual std::vector<ErrorCode> Delete(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
+
+    virtual std::vector<ErrorCode> DeleteLocations(RequestContext *request_context,
+                                                   const KeyTypeVec &keys,
+                                                   const LocationIdsPerKey &location_ids,
+                                                   const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -106,8 +106,8 @@ ErrorCode MetaDummyBackend::Open() noexcept {
         for (auto &[field_name, field_value] : parsed_v) {
             if (field_name.rfind(LOCATION_PREFIX, 0) == 0) {
                 std::string loc_id = field_name.substr(LOCATION_PREFIX.size());
-                CacheLocation loc;
-                if (loc.FromJsonString(field_value)) {
+                auto loc = std::make_shared<CacheLocation>();
+                if (loc->FromJsonString(field_value)) {
                     item.locations[loc_id] = std::move(loc);
                 }
             } else {
@@ -136,8 +136,8 @@ ErrorCode MetaDummyBackend::PersistToPath() {
     // block data: serialize each DummyItem as a FieldMap with locations serialized as JSON values
     table_.ForEachKV([&](const KeyType &key, const DummyItem &item) {
         FieldMap serialized;
-        for (const auto &[loc_id, loc] : item.locations) {
-            serialized[LOCATION_PREFIX + loc_id] = loc.ToJsonString();
+        for (const auto &[loc_id, loc_ptr] : item.locations) {
+            serialized[LOCATION_PREFIX + loc_id] = loc_ptr ? loc_ptr->ToJsonString() : "";
         }
         for (const auto &[prop_name, prop_value] : item.properties) {
             serialized[prop_name] = prop_value;

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -96,13 +96,25 @@ ErrorCode MetaDummyBackend::Open() noexcept {
             continue;
         }
 
-        // parse block data
+        // parse block data: reconstruct DummyItem from serialized FieldMap
         KeyType key;
         if (!StringUtil::StrToInt64(k.c_str(), key)) {
             KVCM_LOG_ERROR("parse key to int64_t failed, path: [%s], raw key string: [%s]", path_.c_str(), k.c_str());
             return ErrorCode::EC_ERROR;
         }
-        table_.Emplace(key, std::move(parsed_v));
+        DummyItem item;
+        for (auto &[field_name, field_value] : parsed_v) {
+            if (field_name.rfind(LOCATION_PREFIX, 0) == 0) {
+                std::string loc_id = field_name.substr(LOCATION_PREFIX.size());
+                CacheLocation loc;
+                if (loc.FromJsonString(field_value)) {
+                    item.locations[loc_id] = std::move(loc);
+                }
+            } else {
+                item.properties[field_name] = std::move(field_value);
+            }
+        }
+        table_.Emplace(key, std::move(item));
     }
 
     return ErrorCode::EC_OK;
@@ -121,9 +133,16 @@ ErrorCode MetaDummyBackend::PersistToPath() {
 
     std::map<std::string, std::string> persist_table;
 
-    // block data
-    table_.ForEachKV([&](const KeyType &key, const FieldMap &field_map) {
-        persist_table[std::to_string(key)] = Jsonizable::ToJsonString(field_map);
+    // block data: serialize each DummyItem as a FieldMap with locations serialized as JSON values
+    table_.ForEachKV([&](const KeyType &key, const DummyItem &item) {
+        FieldMap serialized;
+        for (const auto &[loc_id, loc] : item.locations) {
+            serialized[LOCATION_PREFIX + loc_id] = loc.ToJsonString();
+        }
+        for (const auto &[prop_name, prop_value] : item.properties) {
+            serialized[prop_name] = prop_value;
+        }
+        persist_table[std::to_string(key)] = Jsonizable::ToJsonString(serialized);
         return true;
     });
 
@@ -142,319 +161,271 @@ ErrorCode MetaDummyBackend::PersistToPath() {
     return ErrorCode::EC_OK;
 }
 
-std::vector<ErrorCode> MetaDummyBackend::Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
-    if (keys.size() != field_maps.size()) {
-        KVCM_LOG_ERROR("put failed, keys.size: [%zu] != field_maps.size: [%zu]", keys.size(), field_maps.size());
-        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
-    }
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
 
-    std::vector<ErrorCode> ec_vec;
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        ec_vec.emplace_back(PutForOneKey(keys[i], field_maps[i]));
-        if (ec_vec.back() != ErrorCode::EC_OK) {
-            KVCM_LOG_WARN("put failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          keys[i],
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-    }
-    return ec_vec;
-}
-
-ErrorCode MetaDummyBackend::PutForOneKey(const KeyType &key, const FieldMap &field_map) {
+std::vector<ErrorCode> MetaDummyBackend::Put(RequestContext * /*request_context*/,
+                                             const KeyTypeVec &keys,
+                                             const CacheLocationMapVector &locations,
+                                             const PropertyMapVector &properties) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
     std::lock_guard<std::mutex> guard(mutex_);
-    FieldMap enriched_map = field_map;
-    enriched_map[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
-    table_.Upsert(key, std::move(enriched_map));
-    return PersistToPath();
+    for (size_t i = 0; i < keys.size(); ++i) {
+        DummyItem item;
+        item.locations = locations[i];
+        item.properties = properties[i];
+        item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+        table_.Upsert(keys[i], std::move(item));
+    }
+    PersistToPath();
+    return results;
 }
 
-std::vector<ErrorCode> MetaDummyBackend::UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
-    if (keys.size() != field_maps.size()) {
-        KVCM_LOG_ERROR("update fields failed, keys.size[%zu] != field_maps.size[%zu]", keys.size(), field_maps.size());
-        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
-    }
-    std::vector<ErrorCode> ec_vec;
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        ec_vec.emplace_back(UpdateFieldsForOneKey(keys[i], field_maps[i]));
-        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
-            KVCM_LOG_WARN("update fields failed, key: [%" PRIi64 "], ec:[%" PRIi32 "]",
-                          keys[i],
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-    }
-    return ec_vec;
-}
-
-ErrorCode MetaDummyBackend::UpdateFieldsForOneKey(const KeyType &key, const FieldMap &field_map) {
+std::vector<ErrorCode> MetaDummyBackend::Upsert(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
     std::lock_guard<std::mutex> guard(mutex_);
-    const bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
-        for (const auto &[field_name, field_value] : field_map) {
-            existing_map[field_name] = field_value;
-        }
-        existing_map[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
-    });
-    if (!found) {
-        KVCM_LOG_WARN("update fields failed due to key cannot be found, key: [%" PRIi64 "]", key);
-        return ErrorCode::EC_NOENT;
-    }
-    return PersistToPath();
-}
-
-std::vector<ErrorCode> MetaDummyBackend::Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
-    if (keys.size() != field_maps.size()) {
-        KVCM_LOG_ERROR("upsert failed, keys.size: [%zu] != field_maps.size: [%zu]", keys.size(), field_maps.size());
-        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
-    }
-
-    std::vector<ErrorCode> ec_vec;
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        ec_vec.emplace_back(UpsertForOneKey(keys[i], field_maps[i]));
-        if (ec_vec.back() != ErrorCode::EC_OK) {
-            KVCM_LOG_WARN("upsert failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]", keys[i], ec_vec.back());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = table_.FindAndModify(keys[i], [&](DummyItem &existing) {
+            for (const auto &[loc_id, loc] : locations[i]) {
+                existing.locations[loc_id] = loc;
+            }
+            for (const auto &[prop_name, prop_value] : properties[i]) {
+                existing.properties[prop_name] = prop_value;
+            }
+            existing.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+        });
+        if (!found) {
+            DummyItem item;
+            item.locations = locations[i];
+            item.properties = properties[i];
+            item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            table_.Upsert(keys[i], std::move(item));
         }
     }
-    return ec_vec;
+    PersistToPath();
+    return results;
 }
 
-ErrorCode MetaDummyBackend::UpsertForOneKey(const KeyType &key, const FieldMap &field_map) {
+std::vector<ErrorCode> MetaDummyBackend::Update(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
     std::lock_guard<std::mutex> guard(mutex_);
-    const std::string current_time_str = std::to_string(TimestampUtil::GetCurrentTimeUs());
-    const bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
-        for (const auto &[field_name, field_value] : field_map) {
-            existing_map[field_name] = field_value;
-        }
-        existing_map[PROPERTY_LRU_TIME] = current_time_str;
-    });
-    if (!found) {
-        FieldMap enriched_map = field_map;
-        enriched_map[PROPERTY_LRU_TIME] = current_time_str;
-        table_.Upsert(key, std::move(enriched_map));
-    }
-    return PersistToPath();
-}
-
-std::vector<ErrorCode> MetaDummyBackend::Delete(const KeyTypeVec &keys) noexcept {
-    std::vector<ErrorCode> ec_vec;
-    for (const KeyType &key : keys) {
-        ec_vec.emplace_back(DeleteForOneKey(key));
-        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
-            KVCM_LOG_WARN("delete failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          key,
-                          static_cast<std::int32_t>(ec_vec.back()));
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = table_.FindAndModify(keys[i], [&](DummyItem &existing) {
+            for (const auto &[loc_id, loc] : locations[i]) {
+                existing.locations[loc_id] = loc;
+            }
+            for (const auto &[prop_name, prop_value] : properties[i]) {
+                existing.properties[prop_name] = prop_value;
+            }
+            existing.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+        });
+        if (!found) {
+            results[i] = EC_NOENT;
         }
     }
-    return ec_vec;
+    PersistToPath();
+    return results;
 }
 
-ErrorCode MetaDummyBackend::DeleteForOneKey(const KeyType &key) {
+std::vector<ErrorCode> MetaDummyBackend::Delete(RequestContext * /*request_context*/, const KeyTypeVec &keys) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
     std::lock_guard<std::mutex> guard(mutex_);
-    if (!table_.Contains(key)) {
-        return ErrorCode::EC_NOENT;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (!table_.Contains(keys[i])) {
+            results[i] = EC_NOENT;
+        } else {
+            table_.Erase(keys[i]);
+        }
     }
-    table_.Erase(key);
-    return PersistToPath();
+    PersistToPath();
+    return results;
 }
 
-std::vector<ErrorCode>
-MetaDummyBackend::DeleteFields(const KeyTypeVec &keys,
-                               const std::vector<std::vector<std::string>> &field_names_vec) noexcept {
-    if (keys.size() != field_names_vec.size()) {
-        KVCM_LOG_ERROR("delete fields failed, keys.size: [%zu] != field_names_vec.size: [%zu]",
-                       keys.size(),
-                       field_names_vec.size());
-        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
-    }
-    std::vector<ErrorCode> ec_vec;
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        if (field_names_vec[i].empty()) {
-            ec_vec.emplace_back(ErrorCode::EC_OK); // Nothing to delete — idempotent success.
+std::vector<ErrorCode> MetaDummyBackend::DeleteLocations(RequestContext * /*request_context*/,
+                                                         const KeyTypeVec &keys,
+                                                         const LocationIdsPerKey &location_ids) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    std::lock_guard<std::mutex> guard(mutex_);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (location_ids[i].empty()) {
             continue;
         }
-        ec_vec.emplace_back(DeleteFieldsForOneKey(keys[i], field_names_vec[i]));
-        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
-            KVCM_LOG_WARN("delete fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          keys[i],
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-    }
-    return ec_vec;
-}
-
-ErrorCode MetaDummyBackend::DeleteFieldsForOneKey(const KeyType &key, const std::vector<std::string> &field_names) {
-    std::lock_guard<std::mutex> guard(mutex_);
-    const bool found = table_.FindAndModify(key, [&](FieldMap &existing_map) {
-        for (const auto &field_name : field_names) {
-            existing_map.erase(field_name);
-        }
-    });
-    if (!found) {
-        return ErrorCode::EC_NOENT;
-    }
-    return PersistToPath();
-}
-
-std::vector<ErrorCode> MetaDummyBackend::Get(const KeyTypeVec &keys,
-                                             const std::vector<std::string> &field_names,
-                                             FieldMapVec &out_field_maps) noexcept {
-    std::vector<ErrorCode> ec_vec;
-    out_field_maps = FieldMapVec(keys.size());
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        ec_vec.emplace_back(GetForOneKey(keys[i], field_names, out_field_maps[i]));
-        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
-            KVCM_LOG_WARN("get failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          keys[i],
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-    }
-    return ec_vec;
-}
-
-std::vector<ErrorCode> MetaDummyBackend::Get(const KeyTypeVec &keys,
-                                             const std::vector<std::vector<std::string>> &field_names_vec,
-                                             FieldMapVec &out_field_maps) noexcept {
-    out_field_maps = FieldMapVec(keys.size());
-    if (keys.size() != field_names_vec.size()) {
-        KVCM_LOG_ERROR(
-            "get failed, keys.size: [%zu] != field_names_vec.size: [%zu]", keys.size(), field_names_vec.size());
-        return std::vector<ErrorCode>(keys.size(), ErrorCode::EC_BADARGS);
-    }
-    std::vector<ErrorCode> ec_vec;
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        ec_vec.emplace_back(GetForOneKey(keys[i], field_names_vec[i], out_field_maps[i]));
-        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
-            KVCM_LOG_WARN("get failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          keys[i],
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-    }
-    return ec_vec;
-}
-
-ErrorCode MetaDummyBackend::GetForOneKey(const KeyType &key,
-                                         const std::vector<std::string> &field_names,
-                                         FieldMap &out_field_map) {
-    out_field_map.clear();
-    const bool found = table_.FindAndApply(key, [&](const FieldMap &field_table) {
-        for (const auto &field_name : field_names) {
-            const auto field_iter = field_table.find(field_name);
-            if (field_iter != field_table.end()) {
-                out_field_map[field_name] = field_iter->second;
+        const bool found = table_.FindAndModify(keys[i], [&](DummyItem &existing) {
+            for (const auto &loc_id : location_ids[i]) {
+                existing.locations.erase(loc_id);
             }
-        }
-    });
-    if (!found) {
-        return ErrorCode::EC_NOENT;
-    }
-    // Update last access time after reading the stored value
-    table_.FindAndModify(key, [](FieldMap &field_table) {
-        field_table[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
-    });
-    return ErrorCode::EC_OK;
-}
-
-std::vector<ErrorCode> MetaDummyBackend::GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept {
-    std::vector<ErrorCode> ec_vec;
-    out_field_maps = FieldMapVec(keys.size());
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        ec_vec.emplace_back(GetAllFieldsForOneKey(keys[i], out_field_maps[i]));
-        if (ec_vec.back() != ErrorCode::EC_OK && ec_vec.back() != ErrorCode::EC_NOENT) {
-            KVCM_LOG_WARN("get all fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          keys[i],
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-    }
-    return ec_vec;
-}
-
-ErrorCode MetaDummyBackend::GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map) {
-    out_field_map.clear();
-    if (!table_.Get(key, out_field_map)) {
-        return ErrorCode::EC_NOENT;
-    }
-    // Update last access time in the stored map after copying the old value
-    table_.FindAndModify(key, [](FieldMap &field_table) {
-        field_table[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
-    });
-    return ErrorCode::EC_OK;
-}
-
-std::vector<ErrorCode> MetaDummyBackend::Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept {
-    out_is_exist_vec.clear();
-    out_is_exist_vec.reserve(keys.size());
-    std::vector<ErrorCode> ec_vec;
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        bool is_exist = false;
-        ec_vec.emplace_back(ExistsForOneKey(keys[i], is_exist));
-        if (ec_vec.back() != ErrorCode::EC_OK) {
-            KVCM_LOG_WARN("get all fields failed, key: [%" PRIi64 "], error code: [%" PRIi32 "]",
-                          keys[i],
-                          static_cast<std::int32_t>(ec_vec.back()));
-        }
-        out_is_exist_vec.emplace_back(is_exist);
-    }
-    return ec_vec;
-}
-
-ErrorCode MetaDummyBackend::ExistsForOneKey(const KeyType &key, bool &out_is_exist) {
-    out_is_exist = (table_.Count(key) > 0);
-    if (out_is_exist) {
-        table_.FindAndModify(key, [](FieldMap &field_table) {
-            field_table[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
         });
+        if (!found) {
+            results[i] = EC_NOENT;
+        }
     }
-    return ErrorCode::EC_OK;
+    PersistToPath();
+    return results;
 }
 
-std::vector<ErrorCode> MetaDummyBackend::ExistsFieldWithPrefix(const KeyTypeVec &keys,
-                                                               const std::string &field_prefix,
-                                                               std::vector<bool> &out_exists_vec) noexcept {
-    out_exists_vec.resize(keys.size(), false);
-    std::vector<ErrorCode> ec_vec(keys.size(), ErrorCode::EC_OK);
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        const bool found = table_.FindAndApply(keys[i], [&](const FieldMap &field_table) {
-            for (const auto &[field_name, field_value] : field_table) {
-                if (field_name.size() >= field_prefix.size() &&
-                    field_name.compare(0, field_prefix.size(), field_prefix) == 0 && !field_value.empty()) {
-                    // Skip tombstones (empty value) — they are not valid locations.
-                    out_exists_vec[i] = true;
-                    return;
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+std::vector<ErrorCode> MetaDummyBackend::Get(RequestContext * /*request_context*/,
+                                             const KeyTypeVec &keys,
+                                             CacheLocationMapVector &out_locations,
+                                             PropertyMapVector &out_properties) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_locations.resize(keys.size());
+    out_properties.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = table_.FindAndApply(keys[i], [&](const DummyItem &item) {
+            out_locations[i] = item.locations;
+            out_properties[i] = item.properties;
+        });
+        if (!found) {
+            results[i] = EC_NOENT;
+        } else {
+            table_.FindAndModify(keys[i], [](DummyItem &item) {
+                item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            });
+        }
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaDummyBackend::GetLocations(RequestContext * /*request_context*/,
+                                                      const KeyTypeVec &keys,
+                                                      CacheLocationMapVector &out_locations) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_locations.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found =
+            table_.FindAndApply(keys[i], [&](const DummyItem &item) { out_locations[i] = item.locations; });
+        if (!found) {
+            results[i] = EC_NOENT;
+        } else {
+            table_.FindAndModify(keys[i], [](DummyItem &item) {
+                item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            });
+        }
+    }
+    return results;
+}
+
+std::vector<std::vector<ErrorCode>> MetaDummyBackend::GetLocations(RequestContext * /*request_context*/,
+                                                                   const KeyTypeVec &keys,
+                                                                   const LocationIdsPerKey &location_ids,
+                                                                   LocationsPerKey &out_locations) noexcept {
+    std::vector<std::vector<ErrorCode>> results(keys.size());
+    out_locations.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i].resize(location_ids[i].size(), EC_NOENT);
+        out_locations[i].resize(location_ids[i].size());
+        const bool found = table_.FindAndApply(keys[i], [&](const DummyItem &item) {
+            for (size_t j = 0; j < location_ids[i].size(); ++j) {
+                auto it = item.locations.find(location_ids[i][j]);
+                if (it != item.locations.end()) {
+                    out_locations[i][j] = it->second;
+                    results[i][j] = EC_OK;
                 }
             }
         });
         if (!found) {
-            ec_vec[i] = ErrorCode::EC_NOENT;
+            // All remain EC_NOENT (key not found).
+        } else {
+            table_.FindAndModify(keys[i], [](DummyItem &item) {
+                item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            });
         }
     }
-    return ec_vec;
+    return results;
 }
 
-std::vector<ErrorCode>
-MetaDummyBackend::GetFieldNamesWithPrefix(const KeyTypeVec &keys,
-                                          const std::string &field_prefix,
-                                          std::vector<std::vector<std::string>> &out_field_names_vec) noexcept {
-    out_field_names_vec.resize(keys.size());
-    std::vector<ErrorCode> ec_vec(keys.size(), ErrorCode::EC_OK);
-    for (std::size_t i = 0; i != keys.size(); ++i) {
-        const bool found = table_.FindAndApply(keys[i], [&](const FieldMap &field_table) {
-            for (auto it = field_table.lower_bound(field_prefix); it != field_table.end(); ++it) {
-                if (it->first.size() < field_prefix.size() ||
-                    it->first.compare(0, field_prefix.size(), field_prefix) != 0) {
-                    break;
-                }
-                // Skip tombstones (empty value) — they are not valid locations.
-                if (!it->second.empty()) {
-                    out_field_names_vec[i].emplace_back(it->first);
+std::vector<ErrorCode> MetaDummyBackend::GetLocationIds(RequestContext * /*request_context*/,
+                                                        const KeyTypeVec &keys,
+                                                        LocationIdsPerKey &out_location_ids) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_location_ids.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = table_.FindAndApply(keys[i], [&](const DummyItem &item) {
+            for (const auto &[loc_id, loc] : item.locations) {
+                out_location_ids[i].push_back(loc_id);
+            }
+        });
+        if (!found) {
+            results[i] = EC_NOENT;
+        }
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaDummyBackend::ExistsLocation(RequestContext * /*request_context*/,
+                                                        const KeyTypeVec &keys,
+                                                        std::vector<bool> &out_exists) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_exists.resize(keys.size(), false);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found =
+            table_.FindAndApply(keys[i], [&](const DummyItem &item) { out_exists[i] = !item.locations.empty(); });
+        if (!found) {
+            results[i] = EC_NOENT;
+        }
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaDummyBackend::GetProperties(RequestContext * /*request_context*/,
+                                                       const KeyTypeVec &keys,
+                                                       const std::vector<std::string> &field_names,
+                                                       PropertyMapVector &out_properties) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_properties.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = table_.FindAndApply(keys[i], [&](const DummyItem &item) {
+            for (const auto &field_name : field_names) {
+                auto it = item.properties.find(field_name);
+                if (it != item.properties.end()) {
+                    out_properties[i][field_name] = it->second;
                 }
             }
         });
         if (!found) {
-            ec_vec[i] = ErrorCode::EC_NOENT;
+            results[i] = EC_NOENT;
+        } else {
+            table_.FindAndModify(keys[i], [](DummyItem &item) {
+                item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            });
         }
     }
-    return ec_vec;
+    return results;
 }
 
-ErrorCode MetaDummyBackend::ListKeys(const std::string &cursor,
+// ---------------------------------------------------------------------------
+// Key-level operations
+// ---------------------------------------------------------------------------
+
+std::vector<ErrorCode> MetaDummyBackend::Exists(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                std::vector<bool> &out_is_exist_vec) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_is_exist_vec.resize(keys.size(), false);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        out_is_exist_vec[i] = table_.Contains(keys[i]);
+        if (out_is_exist_vec[i]) {
+            table_.FindAndModify(keys[i], [](DummyItem &item) {
+                item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            });
+        }
+    }
+    return results;
+}
+
+ErrorCode MetaDummyBackend::ListKeys(RequestContext * /*request_context*/,
+                                     const std::string &cursor,
                                      const std::int64_t limit,
                                      std::string &out_next_cursor,
                                      KeyTypeVec &out_keys) noexcept {
@@ -472,7 +443,7 @@ ErrorCode MetaDummyBackend::ListKeys(const std::string &cursor,
     std::int64_t current_index = 0;
     const std::int64_t end_index = start_index + limit;
     bool reached_limit = false;
-    table_.ForEachKV([&](const KeyType &key, const FieldMap &) {
+    table_.ForEachKV([&](const KeyType &key, const DummyItem &) {
         if (current_index >= end_index) {
             reached_limit = true;
             return false;
@@ -488,10 +459,12 @@ ErrorCode MetaDummyBackend::ListKeys(const std::string &cursor,
     return ErrorCode::EC_OK;
 }
 
-ErrorCode MetaDummyBackend::RandomSample(const std::int64_t count, KeyTypeVec &out_keys) noexcept {
+ErrorCode MetaDummyBackend::RandomSample(RequestContext * /*request_context*/,
+                                         const std::int64_t count,
+                                         KeyTypeVec &out_keys) noexcept {
     out_keys.clear();
-    table_.ForEachKV([&](const KeyType &key, const FieldMap &map) {
-        if (out_keys.size() >= count) {
+    table_.ForEachKV([&](const KeyType &key, const DummyItem &) {
+        if (static_cast<std::int64_t>(out_keys.size()) >= count) {
             return false;
         }
         out_keys.emplace_back(key);
@@ -500,9 +473,15 @@ ErrorCode MetaDummyBackend::RandomSample(const std::int64_t count, KeyTypeVec &o
     return ErrorCode::EC_OK;
 }
 
-ErrorCode MetaDummyBackend::SampleReclaimKeys(const std::int64_t count, KeyTypeVec &out_keys) noexcept {
-    return RandomSample(count, out_keys);
+ErrorCode MetaDummyBackend::SampleReclaimKeys(RequestContext *request_context,
+                                              const std::int64_t count,
+                                              KeyTypeVec &out_keys) noexcept {
+    return RandomSample(request_context, count, out_keys);
 }
+
+// ---------------------------------------------------------------------------
+// Metadata operations
+// ---------------------------------------------------------------------------
 
 ErrorCode MetaDummyBackend::PutMetaData(const FieldMap &field_map) noexcept {
     std::lock_guard<std::mutex> guard(mutex_);

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -12,6 +11,12 @@
 #include "kv_cache_manager/meta/meta_storage_backend.h"
 
 namespace kv_cache_manager {
+
+// Per-key storage item for dummy backend.
+struct DummyItem {
+    CacheLocationMap locations;
+    PropertyMap properties;
+};
 
 /*
  * MetaDummyBackend is a meta storage backend implementation with
@@ -34,58 +39,83 @@ public:
     ErrorCode Open() noexcept override;
     ErrorCode Close() noexcept override;
 
-    // write
-    std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
-    std::vector<ErrorCode> DeleteFields(const KeyTypeVec &keys,
-                                        const std::vector<std::vector<std::string>> &field_names_vec) noexcept override;
+    // =====================================================================
+    // Write APIs
+    // =====================================================================
 
-    // read
-    std::vector<ErrorCode> Get(const KeyTypeVec &keys,
-                               const std::vector<std::string> &field_names,
-                               FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> Get(const KeyTypeVec &keys,
-                               const std::vector<std::vector<std::string>> &field_names_vec,
-                               FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept override;
-    std::vector<ErrorCode> ExistsFieldWithPrefix(const KeyTypeVec &keys,
-                                                 const std::string &field_prefix,
-                                                 std::vector<bool> &out_exists_vec) noexcept override;
-    std::vector<ErrorCode>
-    GetFieldNamesWithPrefix(const KeyTypeVec &keys,
-                            const std::string &field_prefix,
-                            std::vector<std::vector<std::string>> &out_field_names_vec) noexcept override;
-    ErrorCode ListKeys(const std::string &cursor,
+    std::vector<ErrorCode> Put(RequestContext *request_context,
+                               const KeyTypeVec &keys,
+                               const CacheLocationMapVector &locations,
+                               const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Update(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyTypeVec &keys) noexcept override;
+    std::vector<ErrorCode> DeleteLocations(RequestContext *request_context,
+                                           const KeyTypeVec &keys,
+                                           const LocationIdsPerKey &location_ids) noexcept override;
+
+    // =====================================================================
+    // Read APIs
+    // =====================================================================
+
+    std::vector<ErrorCode> Get(RequestContext *request_context,
+                               const KeyTypeVec &keys,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties) noexcept override;
+    std::vector<ErrorCode> GetLocations(RequestContext *request_context,
+                                        const KeyTypeVec &keys,
+                                        CacheLocationMapVector &out_locations) noexcept override;
+    std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
+                                                     const KeyTypeVec &keys,
+                                                     const LocationIdsPerKey &location_ids,
+                                                     LocationsPerKey &out_locations) noexcept override;
+    std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          LocationIdsPerKey &out_location_ids) noexcept override;
+    std::vector<ErrorCode> ExistsLocation(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          std::vector<bool> &out_exists) noexcept override;
+    std::vector<ErrorCode> GetProperties(RequestContext *request_context,
+                                         const KeyTypeVec &keys,
+                                         const std::vector<std::string> &field_names,
+                                         PropertyMapVector &out_properties) noexcept override;
+
+    // =====================================================================
+    // Key-level APIs
+    // =====================================================================
+
+    std::vector<ErrorCode> Exists(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  std::vector<bool> &out_is_exist_vec) noexcept override;
+    ErrorCode ListKeys(RequestContext *request_context,
+                       const std::string &cursor,
                        std::int64_t limit,
                        std::string &out_next_cursor,
                        KeyTypeVec &out_keys) noexcept override;
-    ErrorCode RandomSample(std::int64_t count, KeyTypeVec &out_keys) noexcept override;
-    ErrorCode SampleReclaimKeys(std::int64_t count, KeyTypeVec &out_keys) noexcept override;
+    ErrorCode RandomSample(RequestContext *request_context, std::int64_t count, KeyTypeVec &out_keys) noexcept override;
+    ErrorCode
+    SampleReclaimKeys(RequestContext *request_context, std::int64_t count, KeyTypeVec &out_keys) noexcept override;
 
-    // meta data
+    // =====================================================================
+    // Metadata APIs
+    // =====================================================================
+
     ErrorCode PutMetaData(const FieldMap &field_map) noexcept override;
     ErrorCode GetMetaData(FieldMap &out_field_map) noexcept override;
 
 private:
     ErrorCode PersistToPath();
 
-    ErrorCode PutForOneKey(const KeyType &key, const FieldMap &field_map);
-    ErrorCode UpdateFieldsForOneKey(const KeyType &key, const FieldMap &field_map);
-    ErrorCode UpsertForOneKey(const KeyType &key, const FieldMap &field_map);
-    ErrorCode DeleteForOneKey(const KeyType &key);
-    ErrorCode DeleteFieldsForOneKey(const KeyType &key, const std::vector<std::string> &field_names);
-
-    ErrorCode GetForOneKey(const KeyType &key, const std::vector<std::string> &field_names, FieldMap &out_field_map);
-    ErrorCode GetAllFieldsForOneKey(const KeyType &key, FieldMap &out_field_map);
-    ErrorCode ExistsForOneKey(const KeyType &key, bool &out_is_exist);
-
     std::mutex mutex_;
-    ConcurrentHashMap<KeyType, FieldMap> table_; // block data
-    FieldMap metadata_;                          // metadata
-    std::string path_;                           // persistence local filesystem path
+    ConcurrentHashMap<KeyType, DummyItem> table_;
+    FieldMap metadata_;
+    std::string path_;
     bool enable_persistence_ = false;
 };
 

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -521,9 +521,9 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                         continue;
                     }
                     const LocationId &loc_id = loc_ids[loc_index];
-                    CacheLocation &working_loc = loc_values[loc_index];
-                    assert(loc_id == working_loc.id());
-                    upsert_loc_map.emplace(loc_id, std::move(working_loc));
+                    const CacheLocationConstPtr &working_loc = loc_values[loc_index];
+                    assert(working_loc && loc_id == working_loc->id());
+                    upsert_loc_map.emplace(loc_id, working_loc);
                     upsert_location_indexs[global_idx].emplace_back(loc_index);
                 }
                 if (!upsert_loc_map.empty() || !upsert_property_map.empty()) {

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -131,7 +131,7 @@ ErrorCode MetaIndexer::Init(const std::string &instance_id, const std::shared_pt
 
 MetaIndexer::Result MetaIndexer::Put(RequestContext *request_context,
                                      const KeyVector &keys,
-                                     LocationMapVector &location_maps,
+                                     CacheLocationMapVector &location_maps,
                                      PropertyMapVector &properties) noexcept {
     if (keys.size() == 0) {
         return Result(EC_OK);
@@ -182,7 +182,7 @@ MetaIndexer::Result MetaIndexer::Put(RequestContext *request_context,
 
 MetaIndexer::Result MetaIndexer::Update(RequestContext *request_context,
                                         const KeyVector &keys,
-                                        LocationMapVector &location_maps,
+                                        CacheLocationMapVector &location_maps,
                                         PropertyMapVector &properties) noexcept {
     if (keys.size() == 0) {
         return Result(EC_OK);
@@ -230,7 +230,7 @@ MetaIndexer::Result MetaIndexer::Delete(RequestContext *request_context, const K
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
     const auto &trace_id = request_context->trace_id();
     static LocationIdsPerKey empty_location_ids;
-    static LocationMapVector empty_locations;
+    static CacheLocationMapVector empty_locations;
     static PropertyMapVector empty_properties;
     std::vector<BatchMetaData> batches = MakeBatches(keys, empty_location_ids, empty_locations, empty_properties);
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_batch_num, batches.size());
@@ -239,7 +239,7 @@ MetaIndexer::Result MetaIndexer::Delete(RequestContext *request_context, const K
     int64_t lock_wait_time_us = 0;
     for (auto &batch : batches) {
         ScopedBatchLock lock(*this, batch.batch_shard_indexs, &lock_wait_time_us);
-        auto error_codes = backend_manager_->Delete(batch.batch_keys);
+        std::vector<ErrorCode> error_codes = backend_manager_->Delete(request_context, batch.batch_keys);
         error_count += ProcessErrorCodes(trace_id, error_codes, batch.batch_indexs, keys, kDeleteMetaOperation, result);
     }
     AdjustKeyCountMeta(error_count - keys.size());
@@ -296,6 +296,7 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwUpsert(const std::string &tra
 }
 
 std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwDelete(const std::string &trace_id,
+                                                          RequestContext *request_context,
                                                           const BatchMetaData &delete_batch,
                                                           const KeyVector &all_keys,
                                                           RmwStats &stats,
@@ -309,10 +310,10 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwDelete(const std::string &tra
     std::vector<ErrorCode> delete_ecs;
     int32_t reclaimed_count = 0;
     if (delete_batch.batch_location_ids.empty()) {
-        delete_ecs = backend_manager_->Delete(delete_batch.batch_keys);
+        delete_ecs = backend_manager_->Delete(request_context, delete_batch.batch_keys);
     } else {
-        delete_ecs =
-            backend_manager_->Delete(delete_batch.batch_keys, delete_batch.batch_location_ids, reclaimed_count);
+        delete_ecs = backend_manager_->Delete(
+            request_context, delete_batch.batch_keys, delete_batch.batch_location_ids, reclaimed_count);
     }
     stats.delete_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin;
 
@@ -370,7 +371,7 @@ MetaIndexer::Result MetaIndexer::ReadModifyWriteBlock(RequestContext *request_co
         std::make_shared<RequestContext>("read_modify_write_block", ephemeral_metrics_collector);
 
     static LocationIdsPerKey empty_location_ids;
-    static LocationMapVector empty_locations;
+    static CacheLocationMapVector empty_locations;
     static PropertyMapVector empty_properties;
     std::vector<BatchMetaData> batches = MakeBatches(keys, empty_location_ids, empty_locations, empty_properties);
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_batch_num, batches.size());
@@ -385,7 +386,8 @@ MetaIndexer::Result MetaIndexer::ReadModifyWriteBlock(RequestContext *request_co
         const auto &batch_keys = batch.batch_keys;
         LocationIdsPerKey batch_location_ids;
         const int64_t begin_get = TimestampUtil::GetCurrentTimeUs();
-        std::vector<ErrorCode> get_ecs = backend_manager_->GetLocationIds(batch_keys, batch_location_ids);
+        std::vector<ErrorCode> get_ecs =
+            backend_manager_->GetLocationIds(ephemeral_request_context.get(), batch_keys, batch_location_ids);
         stats.get_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin_get;
 
         // 2. Modify -> bucket each key into upsert_batch / delete_batch.
@@ -399,7 +401,7 @@ MetaIndexer::Result MetaIndexer::ReadModifyWriteBlock(RequestContext *request_co
             const ErrorCode get_ec = get_ecs[i];
             const int32_t global_idx = batch.batch_indexs[i];
             PropertyMap upsert_property_map;
-            LocationMap out_new_locations;
+            CacheLocationMap out_new_locations;
             const auto [action, modifier_ec] = modifier(
                 existing_location_ids, get_ec, static_cast<size_t>(global_idx), upsert_property_map, out_new_locations);
             if (action == MA_OK) {
@@ -430,7 +432,8 @@ MetaIndexer::Result MetaIndexer::ReadModifyWriteBlock(RequestContext *request_co
         // 3. Dispatch upsert and delete sub-batches.
         const auto [upsert_errs, put_success_count] = ExecuteRmwUpsert(
             trace_id, ephemeral_request_context.get(), upsert_batch, put_global_indexs, keys, stats, result);
-        const auto [delete_errs, delete_success_count] = ExecuteRmwDelete(trace_id, delete_batch, keys, stats, result);
+        const auto [delete_errs, delete_success_count] =
+            ExecuteRmwDelete(trace_id, ephemeral_request_context.get(), delete_batch, keys, stats, result);
         error_count += upsert_errs + delete_errs;
         AdjustKeyCountMeta(put_success_count - delete_success_count);
     }
@@ -465,7 +468,7 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
     auto ephemeral_request_context =
         std::make_shared<RequestContext>("read_modify_write_location", ephemeral_metrics_collector);
 
-    static LocationMapVector empty_locations;
+    static CacheLocationMapVector empty_locations;
     static PropertyMapVector empty_properties;
     std::vector<BatchMetaData> batches = MakeBatches(keys, location_ids, empty_locations, empty_properties);
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_batch_num, batches.size());
@@ -511,7 +514,7 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                 action = MA_FAIL;
             }
             if (action == MA_OK) {
-                LocationMap upsert_loc_map;
+                CacheLocationMap upsert_loc_map;
                 for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
                     if (modifier_ecs[loc_index] != EC_OK) {
                         location_result.per_location_error_codes[global_idx][loc_index] = modifier_ecs[loc_index];
@@ -564,7 +567,7 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
             }
         }
         const auto [delete_errs, delete_success_count] =
-            ExecuteRmwDelete(trace_id, delete_batch, keys, stats, rmw_result);
+            ExecuteRmwDelete(trace_id, ephemeral_request_context.get(), delete_batch, keys, stats, rmw_result);
         for (const auto &global_index : delete_batch.batch_indexs) {
             for (const auto &location_index : delete_location_indexs[global_index]) {
                 location_result.per_location_error_codes[global_index][location_index] =
@@ -591,7 +594,7 @@ MetaIndexer::Result
 MetaIndexer::Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept {
     const auto &trace_id = request_context->trace_id();
     out_exists.reserve(keys.size());
-    auto error_codes = backend_manager_->Exists(keys, out_exists);
+    std::vector<ErrorCode> error_codes = backend_manager_->Exists(request_context, keys, out_exists);
 
     Result result(keys.size());
     int32_t error_count = ProcessErrorCodes(trace_id, error_codes, {}, keys, kExistMetaOperation, result);
@@ -601,7 +604,7 @@ MetaIndexer::Exist(RequestContext *request_context, const KeyVector &keys, std::
 
 MetaIndexer::Result MetaIndexer::Get(RequestContext *request_context,
                                      const KeyVector &keys,
-                                     LocationMapVector &out_location_maps,
+                                     CacheLocationMapVector &out_location_maps,
                                      PropertyMapVector &out_properties) noexcept {
     if (keys.empty()) {
         out_location_maps.clear();
@@ -612,54 +615,20 @@ MetaIndexer::Result MetaIndexer::Get(RequestContext *request_context,
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
     const auto &trace_id = request_context->trace_id();
 
-    out_location_maps.assign(keys.size(), LocationMap{});
-    out_properties.assign(keys.size(), PropertyMap{});
-
-    FieldMapVec field_maps;
     int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
-    auto error_codes = backend_manager_->GetAllFields(keys, field_maps);
+    auto error_codes = backend_manager_->Get(request_context, keys, out_location_maps, out_properties);
     KVCM_METRICS_COLLECTOR_SET_METRICS(
         service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
 
     Result result(keys.size());
-    int32_t error_count = 0;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (error_codes[i] != EC_OK) {
-            if (error_codes[i] != EC_NOENT) {
-                PREFIX_INDEXER_LOG(ERROR, "meta indexer get failed, key[%ld] ec[%d]", keys[i], error_codes[i]);
-            }
-            result.error_codes[i] = error_codes[i];
-            ++error_count;
-            continue;
-        }
-        for (auto &kv : field_maps[i]) {
-            if (kv.first.rfind(LOCATION_PREFIX, 0) == 0) {
-                if (kv.second.empty()) {
-                    continue;
-                }
-                CacheLocation location;
-                if (!location.FromJsonString(kv.second)) {
-                    PREFIX_INDEXER_LOG(
-                        ERROR, "deserialize CacheLocation failed, key[%ld] field[%s]", keys[i], kv.first.c_str());
-                    result.error_codes[i] = EC_CORRUPTION;
-                    ++error_count;
-                    out_location_maps[i].clear();
-                    out_properties[i].clear();
-                    break;
-                }
-                out_location_maps[i].emplace(location.id(), std::move(location));
-            } else {
-                out_properties[i].emplace(kv.first, std::move(kv.second));
-            }
-        }
-    }
+    int32_t error_count = ProcessErrorCodes(trace_id, error_codes, {}, keys, kGetMetaOperation, result);
     ProcessErrorResult(trace_id, kGetMetaOperation, error_count, keys.size(), result);
     return result;
 }
 
 MetaIndexer::Result MetaIndexer::GetLocations(RequestContext *request_context,
                                               const KeyVector &keys,
-                                              LocationMapVector &out_location_maps) noexcept {
+                                              CacheLocationMapVector &out_location_maps) noexcept {
     if (keys.empty()) {
         out_location_maps.clear();
         return Result(EC_OK);
@@ -738,7 +707,7 @@ MetaIndexer::Result MetaIndexer::GetProperties(RequestContext *request_context,
     const auto &trace_id = request_context->trace_id();
     out_properties.reserve(keys.size());
     int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
-    auto error_codes = backend_manager_->Get(keys, property_names, out_properties);
+    auto error_codes = backend_manager_->GetProperties(request_context, keys, property_names, out_properties);
     KVCM_METRICS_COLLECTOR_SET_METRICS(
         service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
     Result result(keys.size());
@@ -747,12 +716,13 @@ MetaIndexer::Result MetaIndexer::GetProperties(RequestContext *request_context,
     return result;
 }
 
-ErrorCode MetaIndexer::Scan(const std::string &cursor,
+ErrorCode MetaIndexer::Scan(RequestContext *request_context,
+                            const std::string &cursor,
                             const size_t limit,
                             std::string &out_next_cursor,
                             KeyVector &out_keys) noexcept {
     out_keys.reserve(limit);
-    auto ec = backend_manager_->ListKeys(cursor, limit, out_next_cursor, out_keys);
+    ErrorCode ec = backend_manager_->ListKeys(request_context, cursor, limit, out_next_cursor, out_keys);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR(
             "instance[%s] meta indexer scan failed, cursor[%s] limit[%lu] next cursor[%s] scan key size[%lu]",
@@ -770,7 +740,7 @@ MetaIndexer::RandomSample(RequestContext *request_context, const size_t count, K
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     out_keys.reserve(count);
     int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
-    auto ec = backend_manager_->RandomSample(count, out_keys);
+    ErrorCode ec = backend_manager_->RandomSample(request_context, count, out_keys);
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector,
                                        meta_indexer,
                                        rand_io_time_us,
@@ -789,7 +759,7 @@ ErrorCode MetaIndexer::SampleReclaimKeys(RequestContext *request_context,
                                          KeyVector &out_keys) const noexcept {
     out_keys.clear();
     out_keys.reserve(count);
-    auto ec = backend_manager_->SampleReclaimKeys(count, out_keys);
+    ErrorCode ec = backend_manager_->SampleReclaimKeys(request_context, count, out_keys);
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("instance[%s] meta indexer sample reclaim keys failed, count[%lu] sample key size[%lu]",
                        instance_id_.c_str(),
@@ -825,7 +795,7 @@ std::uint64_t MetaIndexer::SubStorageUsageByType(const DataStorageType &type, co
 
 std::vector<BatchMetaData> MetaIndexer::MakeBatches(const KeyVector &keys,
                                                     const LocationIdsPerKey &location_ids,
-                                                    LocationMapVector &locations,
+                                                    CacheLocationMapVector &locations,
                                                     PropertyMapVector &properties) const noexcept {
     std::vector<BatchMetaData> result;
 
@@ -879,7 +849,7 @@ std::vector<BatchMetaData> MetaIndexer::MakeBatches(const KeyVector &keys,
 
 ErrorCode MetaIndexer::RecoverMetaData() noexcept {
     PropertyMap metadata_map;
-    auto ec = backend_manager_->GetMetaData(metadata_map);
+    ErrorCode ec = backend_manager_->GetMetaData(metadata_map);
     if (ec == EC_NOENT) {
         KVCM_LOG_INFO("there is no metadata key in storage backend, no need to recover metadata");
         return ec;
@@ -917,7 +887,7 @@ void MetaIndexer::PersistMetaData() noexcept {
         std::map<std::string, std::string> metadata_map;
         metadata_map[METADATA_PROPERTY_KEY_COUNT] = std::to_string(key_count_);
         metadata_map[METADATA_PROPERTY_STORAGE_USAGE_DATA] = storage_usage_data_.Serialize();
-        auto ec = backend_manager_->PutMetaData(metadata_map);
+        ErrorCode ec = backend_manager_->PutMetaData(metadata_map);
         if (ec != EC_OK) {
             KVCM_LOG_WARN("meta indexer persist metadata failed, ec[%d]", ec);
         }
@@ -925,8 +895,6 @@ void MetaIndexer::PersistMetaData() noexcept {
     }
 }
 
-// 如果key重复，put时key count将重复计算，将比真实值偏大
-// KV Cache场景key是累积hash的计算值，同一个请求中不会存在重复值
 void MetaIndexer::AdjustKeyCountMeta(const int32_t delta) noexcept {
     if (delta >= 0) {
         key_count_ += delta;

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -59,11 +59,11 @@ public:
     // ---------- WRITE ----------
     Result Put(RequestContext *request_context,
                const KeyVector &keys,
-               LocationMapVector &location_maps,
+               CacheLocationMapVector &location_maps,
                PropertyMapVector &properties) noexcept;
     Result Update(RequestContext *request_context,
                   const KeyVector &keys,
-                  LocationMapVector &location_maps,
+                  CacheLocationMapVector &location_maps,
                   PropertyMapVector &properties) noexcept;
     Result Delete(RequestContext *request_context, const KeyVector &keys) noexcept;
     // Block-level RMW: modifier sees only existing location id list per key.
@@ -80,10 +80,11 @@ public:
     Result Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept;
     Result Get(RequestContext *request_context,
                const KeyVector &keys,
-               LocationMapVector &out_location_maps,
+               CacheLocationMapVector &out_location_maps,
                PropertyMapVector &out_properties) noexcept;
-    Result
-    GetLocations(RequestContext *request_context, const KeyVector &keys, LocationMapVector &out_location_maps) noexcept;
+    Result GetLocations(RequestContext *request_context,
+                        const KeyVector &keys,
+                        CacheLocationMapVector &out_location_maps) noexcept;
     LocationResult GetLocations(RequestContext *request_context,
                                 const KeyVector &keys,
                                 const LocationIdsPerKey &location_ids,
@@ -92,8 +93,11 @@ public:
                          const KeyVector &keys,
                          const std::vector<std::string> &property_names,
                          PropertyMapVector &out_properties) noexcept;
-    ErrorCode
-    Scan(const std::string &cursor, const size_t limit, std::string &out_next_cursor, KeyVector &out_keys) noexcept;
+    ErrorCode Scan(RequestContext *request_context,
+                   const std::string &cursor,
+                   const size_t limit,
+                   std::string &out_next_cursor,
+                   KeyVector &out_keys) noexcept;
     ErrorCode RandomSample(RequestContext *request_context, const size_t count, KeyVector &out_keys) const noexcept;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyVector &out_keys) const noexcept;
@@ -116,7 +120,7 @@ private:
 private:
     std::vector<BatchMetaData> MakeBatches(const KeyVector &keys,
                                            const LocationIdsPerKey &location_ids,
-                                           LocationMapVector &locations,
+                                           CacheLocationMapVector &locations,
                                            PropertyMapVector &properties) const noexcept;
 
     ErrorCode RecoverMetaData() noexcept;
@@ -155,6 +159,7 @@ private:
                                                  Result &result) noexcept;
     // Returns {error_count, delete_success_count}.
     std::pair<int32_t, int32_t> ExecuteRmwDelete(const std::string &trace_id,
+                                                 RequestContext *request_context,
                                                  const BatchMetaData &delete_batch,
                                                  const KeyVector &all_keys,
                                                  RmwStats &stats,

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -162,15 +162,17 @@ ErrorCode MetaLocalBackend::UpdateInPlace(const std::string &key_str,
     {
         std::unique_lock lock(existing->GetMutex());
         auto &existing_locations = existing->GetMutableLocations();
-        for (const auto &[loc_id, loc] : locations) {
+        for (const auto &[loc_id, loc_ptr] : locations) {
             auto it = existing_locations.find(loc_id);
             if (it != existing_locations.end()) {
-                ssize_t old_usage = static_cast<ssize_t>(it->second.EstimateMemUsage());
-                it->second = loc;
-                charge_delta += static_cast<ssize_t>(loc.EstimateMemUsage()) - old_usage;
+                ssize_t old_usage = it->second ? static_cast<ssize_t>(it->second->EstimateMemUsage()) : 0;
+                it->second = loc_ptr;
+                ssize_t new_usage = loc_ptr ? static_cast<ssize_t>(loc_ptr->EstimateMemUsage()) : 0;
+                charge_delta += new_usage - old_usage;
             } else {
-                charge_delta += static_cast<ssize_t>(sizeof(void *) * 4 + loc_id.size() + loc.EstimateMemUsage());
-                existing_locations[loc_id] = loc;
+                ssize_t new_usage = loc_ptr ? static_cast<ssize_t>(loc_ptr->EstimateMemUsage()) : 0;
+                charge_delta += static_cast<ssize_t>(sizeof(void *) * 4 + loc_id.size()) + new_usage;
+                existing_locations[loc_id] = loc_ptr;
             }
         }
         auto &existing_properties = existing->GetMutableProperties();
@@ -241,8 +243,8 @@ ErrorCode MetaLocalBackend::DeleteLocationsForOneKey(KeyType key, const std::vec
         for (const auto &loc_id : location_ids) {
             auto it = locs.find(loc_id);
             if (it != locs.end()) {
-                charge_delta -=
-                    static_cast<ssize_t>(sizeof(void *) * 4 + it->first.size() + it->second.EstimateMemUsage());
+                ssize_t loc_usage = it->second ? static_cast<ssize_t>(it->second->EstimateMemUsage()) : 0;
+                charge_delta -= static_cast<ssize_t>(sizeof(void *) * 4 + it->first.size()) + loc_usage;
                 locs.erase(it);
             }
         }

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -114,16 +114,15 @@ ErrorCode MetaLocalBackend::Close() noexcept {
 // Private helpers
 // ---------------------------------------------------------------------------
 
-ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, const FieldMap &fields) {
-    MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
+ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str,
+                                            const CacheLocationMap &locations,
+                                            const PropertyMap &properties) {
+    MetaMemCacheItem *item = MetaMemCacheItem::Create(locations, properties);
     item->TouchAccessTime();
     size_t charge = item->Size();
     // We must pass &handle (not nullptr) so that when strict_capacity_limit
     // is enabled and capacity is exceeded, Insert returns EC_NOSPC instead
     // of silently discarding the entry with EC_OK.
-    // On success the handle holds a reference that pins the entry out of
-    // the LRU list (preventing eviction), so we Release it immediately to
-    // let the entry become evictable again.
     Cache::Handle *handle = nullptr;
     ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge, &handle);
     if (ret != EC_OK) {
@@ -134,26 +133,12 @@ ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, const Fi
     return ret;
 }
 
-ErrorCode MetaLocalBackend::CreateAndInsert(const std::string &key_str, FieldMap &&fields) {
-    MetaMemCacheItem *item = MetaMemCacheItem::Create(std::move(fields));
+ErrorCode MetaLocalBackend::CreateAndInsertIfAbsent(const std::string &key_str,
+                                                    const CacheLocationMap &locations,
+                                                    const PropertyMap &properties) {
+    MetaMemCacheItem *item = MetaMemCacheItem::Create(locations, properties);
     item->TouchAccessTime();
     size_t charge = item->Size();
-    // See the const-ref overload above for why we pass &handle.
-    Cache::Handle *handle = nullptr;
-    ErrorCode ret = cache_->Insert(key_str, item, cache_item_helper_.get(), charge, &handle);
-    if (ret != EC_OK) {
-        MetaMemCacheItem::Deleter(item, nullptr);
-    } else if (handle) {
-        cache_->Release(handle);
-    }
-    return ret;
-}
-
-ErrorCode MetaLocalBackend::CreateAndInsertIfAbsent(const std::string &key_str, const FieldMap &fields) {
-    MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
-    item->TouchAccessTime();
-    size_t charge = item->Size();
-    // See CreateAndInsert above for why we pass &handle.
     Cache::Handle *handle = nullptr;
     ErrorCode ret = cache_->InsertIfAbsent(key_str, item, cache_item_helper_.get(), charge, &handle);
     if (ret != EC_OK && ret != EC_EXIST) {
@@ -164,7 +149,9 @@ ErrorCode MetaLocalBackend::CreateAndInsertIfAbsent(const std::string &key_str, 
     return ret;
 }
 
-ErrorCode MetaLocalBackend::UpdateFieldsInPlace(const std::string &key_str, const FieldMap &updates) {
+ErrorCode MetaLocalBackend::UpdateInPlace(const std::string &key_str,
+                                          const CacheLocationMap &locations,
+                                          const PropertyMap &properties) {
     Cache::Handle *handle = cache_->Lookup(key_str);
     if (!handle) {
         return EC_NOENT;
@@ -174,17 +161,27 @@ ErrorCode MetaLocalBackend::UpdateFieldsInPlace(const std::string &key_str, cons
     ssize_t charge_delta = 0;
     {
         std::unique_lock lock(existing->GetMutex());
-        auto &fields = existing->GetMutableFields();
-        for (const auto &[field_name, field_value] : updates) {
-            auto it = fields.find(field_name);
-            if (it != fields.end()) {
-                // Existing field: delta is difference in value length.
-                charge_delta += static_cast<ssize_t>(field_value.size()) - static_cast<ssize_t>(it->second.size());
-                it->second = field_value;
+        auto &existing_locations = existing->GetMutableLocations();
+        for (const auto &[loc_id, loc] : locations) {
+            auto it = existing_locations.find(loc_id);
+            if (it != existing_locations.end()) {
+                ssize_t old_usage = static_cast<ssize_t>(it->second.EstimateMemUsage());
+                it->second = loc;
+                charge_delta += static_cast<ssize_t>(loc.EstimateMemUsage()) - old_usage;
             } else {
-                // New field: add full entry overhead.
-                charge_delta += static_cast<ssize_t>(field_name.size() + field_value.size() + sizeof(void *) * 4);
-                fields[field_name] = field_value;
+                charge_delta += static_cast<ssize_t>(sizeof(void *) * 4 + loc_id.size() + loc.EstimateMemUsage());
+                existing_locations[loc_id] = loc;
+            }
+        }
+        auto &existing_properties = existing->GetMutableProperties();
+        for (const auto &[prop_name, prop_value] : properties) {
+            auto it = existing_properties.find(prop_name);
+            if (it != existing_properties.end()) {
+                charge_delta += static_cast<ssize_t>(prop_value.size()) - static_cast<ssize_t>(it->second.size());
+                it->second = prop_value;
+            } else {
+                charge_delta += static_cast<ssize_t>(sizeof(void *) * 4 + prop_name.size() + prop_value.size());
+                existing_properties[prop_name] = prop_value;
             }
         }
     }
@@ -199,13 +196,23 @@ ErrorCode MetaLocalBackend::UpdateFieldsInPlace(const std::string &key_str, cons
 // Per-key helpers
 // ---------------------------------------------------------------------------
 
-ErrorCode MetaLocalBackend::UpsertForOneKey(KeyType key, const FieldMap &field_map) {
+ErrorCode
+MetaLocalBackend::UpsertForOneKey(KeyType key, const CacheLocationMap &locations, const PropertyMap &properties) {
     std::string key_str = std::to_string(key);
-    if (UpdateFieldsInPlace(key_str, field_map) == EC_OK) {
+    ErrorCode update_ec = UpdateInPlace(key_str, locations, properties);
+    if (update_ec != EC_OK && update_ec != EC_NOENT) {
+        KVCM_LOG_ERROR("local backend fail to update key[%ld] in upsert, ec[%d]", key, update_ec);
+        return update_ec;
+    }
+    if (update_ec == EC_OK) {
         return EC_OK;
     }
-    FieldMap fields = field_map;
-    return CreateAndInsert(key_str, std::move(fields));
+    ErrorCode insert_ec = CreateAndInsert(key_str, locations, properties);
+    if (insert_ec != EC_OK) {
+        KVCM_LOG_ERROR("local backend fail to insert key[%ld] in upsert, ec[%d]", key, insert_ec);
+        return insert_ec;
+    }
+    return EC_OK;
 }
 
 ErrorCode MetaLocalBackend::DeleteForOneKey(KeyType key) {
@@ -219,7 +226,7 @@ ErrorCode MetaLocalBackend::DeleteForOneKey(KeyType key) {
     return EC_OK;
 }
 
-ErrorCode MetaLocalBackend::DeleteFieldsForOneKey(KeyType key, const std::vector<std::string> &field_names) {
+ErrorCode MetaLocalBackend::DeleteLocationsForOneKey(KeyType key, const std::vector<LocationId> &location_ids) {
     std::string key_str = std::to_string(key);
     Cache::Handle *handle = cache_->Lookup(key_str);
     if (!handle) {
@@ -230,12 +237,13 @@ ErrorCode MetaLocalBackend::DeleteFieldsForOneKey(KeyType key, const std::vector
     ssize_t charge_delta = 0;
     {
         std::unique_lock lock(item->GetMutex());
-        auto &fields = item->GetMutableFields();
-        for (const auto &field_name : field_names) {
-            auto it = fields.find(field_name);
-            if (it != fields.end()) {
-                charge_delta -= static_cast<ssize_t>(it->first.size() + it->second.size() + sizeof(void *) * 4);
-                fields.erase(it);
+        auto &locs = item->GetMutableLocations();
+        for (const auto &loc_id : location_ids) {
+            auto it = locs.find(loc_id);
+            if (it != locs.end()) {
+                charge_delta -=
+                    static_cast<ssize_t>(sizeof(void *) * 4 + it->first.size() + it->second.EstimateMemUsage());
+                locs.erase(it);
             }
         }
     }
@@ -246,119 +254,55 @@ ErrorCode MetaLocalBackend::DeleteFieldsForOneKey(KeyType key, const std::vector
     return EC_OK;
 }
 
-ErrorCode
-MetaLocalBackend::GetForOneKey(KeyType key, const std::vector<std::string> &field_names, FieldMap &out_field_map) {
-    out_field_map.clear();
-
-    std::string key_str = std::to_string(key);
-    Cache::Handle *handle = cache_->Lookup(key_str);
-    if (!handle) {
-        return EC_NOENT;
-    }
-
-    auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
-    int64_t stored_time = item->GetLastAccessTime();
-    item->TouchAccessTime();
-    {
-        std::shared_lock lock(item->GetMutex());
-        const auto &fields = item->GetFields();
-        for (const auto &field_name : field_names) {
-            if (field_name == PROPERTY_LRU_TIME) {
-                out_field_map[PROPERTY_LRU_TIME] = std::to_string(stored_time);
-                continue;
-            }
-            auto it = fields.find(field_name);
-            if (it != fields.end()) {
-                out_field_map[field_name] = it->second;
-            }
-        }
-    }
-    cache_->Release(handle);
-    return EC_OK;
-}
-
 // ---------------------------------------------------------------------------
-// Write operations
+// Write operations (unconditional)
 // ---------------------------------------------------------------------------
 
-std::vector<ErrorCode> MetaLocalBackend::Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::Put(RequestContext * /*request_context*/,
+                                             const KeyTypeVec &keys,
+                                             const CacheLocationMapVector &locations,
+                                             const PropertyMapVector &properties) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = CreateAndInsert(std::to_string(keys[i]), field_maps[i]);
+        results[i] = CreateAndInsert(std::to_string(keys[i]), locations[i], properties[i]);
     }
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::Put(const KeyTypeVec &keys,
-                                             const FieldMapVec &field_maps,
-                                             const std::vector<ErrorCode> &previous_error_codes) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::PutIfAbsent(RequestContext * /*request_context*/,
+                                                     const KeyTypeVec &keys,
+                                                     const CacheLocationMapVector &locations,
+                                                     const PropertyMapVector &properties) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = (previous_error_codes[i] == EC_OK) ? CreateAndInsert(std::to_string(keys[i]), field_maps[i])
-                                                        : previous_error_codes[i];
+        results[i] = CreateAndInsertIfAbsent(std::to_string(keys[i]), locations[i], properties[i]);
     }
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::PutIfAbsent(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::Upsert(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = CreateAndInsertIfAbsent(std::to_string(keys[i]), field_maps[i]);
+        results[i] = UpsertForOneKey(keys[i], locations[i], properties[i]);
     }
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::PutIfAbsent(const KeyTypeVec &keys,
-                                                     const FieldMapVec &field_maps,
-                                                     const std::vector<ErrorCode> &previous_error_codes) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::Update(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = (previous_error_codes[i] == EC_OK)
-                         ? CreateAndInsertIfAbsent(std::to_string(keys[i]), field_maps[i])
-                         : previous_error_codes[i];
+        results[i] = UpdateInPlace(std::to_string(keys[i]), locations[i], properties[i]);
     }
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = UpdateFieldsInPlace(std::to_string(keys[i]), field_maps[i]);
-    }
-    return results;
-}
-
-std::vector<ErrorCode> MetaLocalBackend::UpdateFields(const KeyTypeVec &keys,
-                                                      const FieldMapVec &field_maps,
-                                                      const std::vector<ErrorCode> &previous_error_codes) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = (previous_error_codes[i] == EC_OK) ? UpdateFieldsInPlace(std::to_string(keys[i]), field_maps[i])
-                                                        : previous_error_codes[i];
-    }
-    return results;
-}
-
-std::vector<ErrorCode> MetaLocalBackend::Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = UpsertForOneKey(keys[i], field_maps[i]);
-    }
-    return results;
-}
-
-std::vector<ErrorCode> MetaLocalBackend::Upsert(const KeyTypeVec &keys,
-                                                const FieldMapVec &field_maps,
-                                                const std::vector<ErrorCode> &previous_error_codes) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] =
-            (previous_error_codes[i] == EC_OK) ? UpsertForOneKey(keys[i], field_maps[i]) : previous_error_codes[i];
-    }
-    return results;
-}
-
-std::vector<ErrorCode> MetaLocalBackend::Delete(const KeyTypeVec &keys) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::Delete(RequestContext * /*request_context*/, const KeyTypeVec &keys) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
         results[i] = DeleteForOneKey(keys[i]);
@@ -366,7 +310,80 @@ std::vector<ErrorCode> MetaLocalBackend::Delete(const KeyTypeVec &keys) noexcept
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::Delete(const KeyTypeVec &keys,
+std::vector<ErrorCode> MetaLocalBackend::DeleteLocations(RequestContext * /*request_context*/,
+                                                         const KeyTypeVec &keys,
+                                                         const LocationIdsPerKey &location_ids) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (location_ids[i].empty()) {
+            continue;
+        }
+        results[i] = DeleteLocationsForOneKey(keys[i], location_ids[i]);
+    }
+    return results;
+}
+
+// ---------------------------------------------------------------------------
+// Write operations (PutIfAbsent + conditional with previous_error_codes)
+// ---------------------------------------------------------------------------
+
+std::vector<ErrorCode> MetaLocalBackend::Put(RequestContext *request_context,
+                                             const KeyTypeVec &keys,
+                                             const CacheLocationMapVector &locations,
+                                             const PropertyMapVector &properties,
+                                             const std::vector<ErrorCode> &previous_error_codes) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = (previous_error_codes[i] == EC_OK)
+                         ? CreateAndInsert(std::to_string(keys[i]), locations[i], properties[i])
+                         : previous_error_codes[i];
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::PutIfAbsent(RequestContext *request_context,
+                                                     const KeyTypeVec &keys,
+                                                     const CacheLocationMapVector &locations,
+                                                     const PropertyMapVector &properties,
+                                                     const std::vector<ErrorCode> &previous_error_codes) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = (previous_error_codes[i] == EC_OK)
+                         ? CreateAndInsertIfAbsent(std::to_string(keys[i]), locations[i], properties[i])
+                         : previous_error_codes[i];
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::Upsert(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties,
+                                                const std::vector<ErrorCode> &previous_error_codes) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = (previous_error_codes[i] == EC_OK) ? UpsertForOneKey(keys[i], locations[i], properties[i])
+                                                        : previous_error_codes[i];
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::Update(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties,
+                                                const std::vector<ErrorCode> &previous_error_codes) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = (previous_error_codes[i] == EC_OK)
+                         ? UpdateInPlace(std::to_string(keys[i]), locations[i], properties[i])
+                         : previous_error_codes[i];
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::Delete(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
                                                 const std::vector<ErrorCode> &previous_error_codes) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -375,29 +392,17 @@ std::vector<ErrorCode> MetaLocalBackend::Delete(const KeyTypeVec &keys,
     return results;
 }
 
-std::vector<ErrorCode>
-MetaLocalBackend::DeleteFields(const KeyTypeVec &keys,
-                               const std::vector<std::vector<std::string>> &field_names_vec) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::DeleteLocations(RequestContext *request_context,
+                                                         const KeyTypeVec &keys,
+                                                         const LocationIdsPerKey &location_ids,
+                                                         const std::vector<ErrorCode> &previous_error_codes) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (field_names_vec[i].empty()) {
-            continue; // Nothing to delete — idempotent success.
-        }
-        results[i] = DeleteFieldsForOneKey(keys[i], field_names_vec[i]);
-    }
-    return results;
-}
-
-std::vector<ErrorCode> MetaLocalBackend::DeleteFields(const KeyTypeVec &keys,
-                                                      const std::vector<std::vector<std::string>> &field_names_vec,
-                                                      const std::vector<ErrorCode> &previous_error_codes) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (field_names_vec[i].empty()) {
+        if (location_ids[i].empty()) {
             results[i] = previous_error_codes[i];
-            continue; // Nothing to delete — idempotent success (propagate previous ec).
+            continue;
         }
-        results[i] = (previous_error_codes[i] == EC_OK) ? DeleteFieldsForOneKey(keys[i], field_names_vec[i])
+        results[i] = (previous_error_codes[i] == EC_OK) ? DeleteLocationsForOneKey(keys[i], location_ids[i])
                                                         : previous_error_codes[i];
     }
     return results;
@@ -407,84 +412,165 @@ std::vector<ErrorCode> MetaLocalBackend::DeleteFields(const KeyTypeVec &keys,
 // Read operations
 // ---------------------------------------------------------------------------
 
-std::vector<ErrorCode> MetaLocalBackend::Get(const KeyTypeVec &keys,
-                                             const std::vector<std::string> &field_names,
-                                             FieldMapVec &out_field_maps) noexcept {
+ErrorCode MetaLocalBackend::GetForOneKey(KeyType key,
+                                         const std::vector<std::string> *field_names,
+                                         CacheLocationMap *out_location_map,
+                                         PropertyMap *out_property_map,
+                                         std::vector<LocationId> *out_location_ids) {
+    std::string key_str = std::to_string(key);
+    Cache::Handle *handle = cache_->Lookup(key_str);
+    if (!handle) {
+        return EC_NOENT;
+    }
+    auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
+    int64_t stored_time = item->GetLastAccessTime();
+    item->TouchAccessTime();
+    {
+        std::shared_lock lock(item->GetMutex());
+        if (out_location_map || out_location_ids) {
+            const auto &locs = item->GetLocations();
+            if (out_location_map) {
+                *out_location_map = locs;
+            }
+            if (out_location_ids) {
+                out_location_ids->reserve(locs.size());
+                for (const auto &[loc_id, _] : locs) {
+                    out_location_ids->push_back(loc_id);
+                }
+            }
+        }
+        if (out_property_map) {
+            if (field_names) {
+                const auto &props = item->GetProperties();
+                for (const auto &field_name : *field_names) {
+                    if (field_name == PROPERTY_LRU_TIME) {
+                        (*out_property_map)[PROPERTY_LRU_TIME] = std::to_string(stored_time);
+                        continue;
+                    }
+                    auto it = props.find(field_name);
+                    if (it != props.end()) {
+                        (*out_property_map)[field_name] = it->second;
+                    }
+                }
+            } else {
+                *out_property_map = item->GetProperties();
+                (*out_property_map)[PROPERTY_LRU_TIME] = std::to_string(stored_time);
+            }
+        }
+    }
+    cache_->Release(handle);
+    return EC_OK;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::Get(RequestContext * /*request_context*/,
+                                             const KeyTypeVec &keys,
+                                             CacheLocationMapVector &out_locations,
+                                             PropertyMapVector &out_properties) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
-    out_field_maps.resize(keys.size());
+    out_locations.resize(keys.size());
+    out_properties.resize(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = GetForOneKey(keys[i], field_names, out_field_maps[i]);
+        results[i] = GetForOneKey(keys[i], nullptr, &out_locations[i], &out_properties[i], nullptr);
     }
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::Get(const KeyTypeVec &keys,
-                                             const std::vector<std::vector<std::string>> &field_names_vec,
-                                             FieldMapVec &out_field_maps) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::GetLocations(RequestContext * /*request_context*/,
+                                                      const KeyTypeVec &keys,
+                                                      CacheLocationMapVector &out_locations) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
-    out_field_maps.resize(keys.size());
+    out_locations.resize(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = GetForOneKey(keys[i], field_names_vec[i], out_field_maps[i]);
+        results[i] = GetForOneKey(keys[i], nullptr, &out_locations[i], nullptr, nullptr);
     }
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    out_field_maps.resize(keys.size());
+std::vector<std::vector<ErrorCode>> MetaLocalBackend::GetLocations(RequestContext * /*request_context*/,
+                                                                   const KeyTypeVec &keys,
+                                                                   const LocationIdsPerKey &location_ids,
+                                                                   LocationsPerKey &out_locations) noexcept {
+    assert(keys.size() == location_ids.size());
+    std::vector<std::vector<ErrorCode>> results(keys.size());
+    out_locations.resize(keys.size());
 
     for (size_t i = 0; i < keys.size(); ++i) {
+        out_locations[i].resize(location_ids[i].size());
+
         std::string key_str = std::to_string(keys[i]);
-
         Cache::Handle *handle = cache_->Lookup(key_str);
         if (!handle) {
-            results[i] = EC_NOENT;
+            results[i].assign(location_ids[i].size(), EC_NOENT);
             continue;
         }
-
         auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
-        int64_t stored_time = item->GetLastAccessTime();
         item->TouchAccessTime();
+        results[i].resize(location_ids[i].size());
         {
             std::shared_lock lock(item->GetMutex());
-            out_field_maps[i] = item->GetFields();
+            const auto &locs = item->GetLocations();
+            for (size_t j = 0; j < location_ids[i].size(); ++j) {
+                auto it = locs.find(location_ids[i][j]);
+                if (it != locs.end()) {
+                    out_locations[i][j] = it->second;
+                    results[i][j] = EC_OK;
+                } else {
+                    results[i][j] = EC_NOENT;
+                }
+            }
         }
-        out_field_maps[i][PROPERTY_LRU_TIME] = std::to_string(stored_time);
         cache_->Release(handle);
-        results[i] = EC_OK;
     }
-
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::GetLocationIds(RequestContext * /*request_context*/,
+                                                        const KeyTypeVec &keys,
+                                                        LocationIdsPerKey &out_location_ids) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_location_ids.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = GetForOneKey(keys[i], nullptr, nullptr, nullptr, &out_location_ids[i]);
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::GetProperties(RequestContext * /*request_context*/,
+                                                       const KeyTypeVec &keys,
+                                                       const std::vector<std::string> &field_names,
+                                                       PropertyMapVector &out_properties) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_properties.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = GetForOneKey(keys[i], &field_names, nullptr, &out_properties[i], nullptr);
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::Exists(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                std::vector<bool> &out_is_exist_vec) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     out_is_exist_vec.resize(keys.size(), false);
 
     for (size_t i = 0; i < keys.size(); ++i) {
         std::string key_str = std::to_string(keys[i]);
-
         Cache::Handle *handle = cache_->Lookup(key_str);
         out_is_exist_vec[i] = (handle != nullptr);
-
         if (handle) {
             auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
             item->TouchAccessTime();
             cache_->Release(handle);
         }
-
-        results[i] = EC_OK;
     }
-
     return results;
 }
 
-std::vector<ErrorCode> MetaLocalBackend::ExistsFieldWithPrefix(const KeyTypeVec &keys,
-                                                               const std::string &field_prefix,
-                                                               std::vector<bool> &out_exists_vec) noexcept {
+std::vector<ErrorCode> MetaLocalBackend::ExistsLocation(RequestContext * /*request_context*/,
+                                                        const KeyTypeVec &keys,
+                                                        std::vector<bool> &out_exists) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
-    out_exists_vec.resize(keys.size(), false);
-
+    out_exists.resize(keys.size(), false);
     for (size_t i = 0; i < keys.size(); ++i) {
         std::string key_str = std::to_string(keys[i]);
         Cache::Handle *handle = cache_->Lookup(key_str);
@@ -492,68 +578,19 @@ std::vector<ErrorCode> MetaLocalBackend::ExistsFieldWithPrefix(const KeyTypeVec 
             results[i] = EC_NOENT;
             continue;
         }
-
         auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
         item->TouchAccessTime();
         {
             std::shared_lock lock(item->GetMutex());
-            const auto &fields = item->GetFields();
-            for (auto it = fields.lower_bound(field_prefix); it != fields.end(); ++it) {
-                if (it->first.size() < field_prefix.size() ||
-                    it->first.compare(0, field_prefix.size(), field_prefix) != 0) {
-                    break;
-                }
-                // Skip tombstones (empty value) — they are not valid locations.
-                if (!it->second.empty()) {
-                    out_exists_vec[i] = true;
-                    break;
-                }
-            }
+            out_exists[i] = !item->GetLocations().empty();
         }
         cache_->Release(handle);
     }
-
     return results;
 }
 
-std::vector<ErrorCode>
-MetaLocalBackend::GetFieldNamesWithPrefix(const KeyTypeVec &keys,
-                                          const std::string &field_prefix,
-                                          std::vector<std::vector<std::string>> &out_field_names_vec) noexcept {
-    std::vector<ErrorCode> results(keys.size(), EC_OK);
-    out_field_names_vec.resize(keys.size());
-
-    for (size_t i = 0; i < keys.size(); ++i) {
-        std::string key_str = std::to_string(keys[i]);
-        Cache::Handle *handle = cache_->Lookup(key_str);
-        if (!handle) {
-            results[i] = EC_NOENT;
-            continue;
-        }
-
-        auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
-        item->TouchAccessTime();
-        {
-            std::shared_lock lock(item->GetMutex());
-            const auto &fields = item->GetFields();
-            for (auto it = fields.lower_bound(field_prefix); it != fields.end(); ++it) {
-                if (it->first.size() < field_prefix.size() ||
-                    it->first.compare(0, field_prefix.size(), field_prefix) != 0) {
-                    break;
-                }
-                // Skip tombstones (empty value) — they are not valid locations.
-                if (!it->second.empty()) {
-                    out_field_names_vec[i].emplace_back(it->first);
-                }
-            }
-        }
-        cache_->Release(handle);
-    }
-
-    return results;
-}
-
-ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
+ErrorCode MetaLocalBackend::ListKeys(RequestContext * /*request_context*/,
+                                     const std::string &cursor,
                                      const int64_t limit,
                                      std::string &out_next_cursor,
                                      std::vector<KeyType> &out_keys) noexcept {
@@ -593,7 +630,9 @@ ErrorCode MetaLocalBackend::ListKeys(const std::string &cursor,
     return EC_OK;
 }
 
-ErrorCode MetaLocalBackend::RandomSample(const int64_t count, std::vector<KeyType> &out_keys) noexcept {
+ErrorCode MetaLocalBackend::RandomSample(RequestContext * /*request_context*/,
+                                         const int64_t count,
+                                         std::vector<KeyType> &out_keys) noexcept {
     if (!cache_) {
         KVCM_LOG_ERROR("local backend not inited");
         return EC_ERROR;
@@ -616,7 +655,9 @@ ErrorCode MetaLocalBackend::RandomSample(const int64_t count, std::vector<KeyTyp
     return EC_OK;
 }
 
-ErrorCode MetaLocalBackend::SampleReclaimKeys(const int64_t count, std::vector<KeyType> &out_keys) noexcept {
+ErrorCode MetaLocalBackend::SampleReclaimKeys(RequestContext * /*request_context*/,
+                                              const int64_t count,
+                                              std::vector<KeyType> &out_keys) noexcept {
     out_keys.clear();
     if (!cache_) {
         KVCM_LOG_ERROR("local backend not inited");

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -25,8 +25,9 @@ struct MetaMemCacheItem {
     size_t Size() const {
         size_t total = sizeof(MetaMemCacheItem);
         for (const auto &[location_id, location] : locations_) {
-            // unordered_map node overhead + key string heap + CacheLocation footprint
-            total += sizeof(void *) * 4 + location_id.size() + location.EstimateMemUsage();
+            // unordered_map node overhead + key string heap + shared_ptr overhead + CacheLocation footprint
+            total += sizeof(void *) * 4 + location_id.size() + sizeof(CacheLocationConstPtr) +
+                     (location ? location->EstimateMemUsage() : 0);
         }
         for (const auto &[prop_name, prop_value] : properties_) {
             total += sizeof(void *) * 4 + prop_name.size() + prop_value.size();

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -20,40 +20,47 @@
 namespace kv_cache_manager {
 
 struct MetaMemCacheItem {
-    using FieldMap = MetaCacheBaseBackend::FieldMap;
-
     // Estimates total memory footprint including the heap memory owned by
-    // FieldMap entries, used as the "charge" for LRU cache eviction accounting.
+    // CacheLocationMap and PropertyMap entries, used as the "charge" for LRU cache eviction accounting.
     size_t Size() const {
         size_t total = sizeof(MetaMemCacheItem);
-        for (const auto &[field_name, field_value] : fields_) {
-            // Each map entry: key string heap + value string heap + tree-node overhead
-            total += field_name.size() + field_value.size() + sizeof(void *) * 4;
+        for (const auto &[location_id, location] : locations_) {
+            // unordered_map node overhead + key string heap + CacheLocation footprint
+            total += sizeof(void *) * 4 + location_id.size() + location.EstimateMemUsage();
+        }
+        for (const auto &[prop_name, prop_value] : properties_) {
+            total += sizeof(void *) * 4 + prop_name.size() + prop_value.size();
         }
         return total;
     }
-    const FieldMap &GetFields() const { return fields_; }
-    FieldMap &GetMutableFields() { return fields_; }
+
+    const CacheLocationMap &GetLocations() const { return locations_; }
+    CacheLocationMap &GetMutableLocations() { return locations_; }
+    const PropertyMap &GetProperties() const { return properties_; }
+    PropertyMap &GetMutableProperties() { return properties_; }
     std::shared_mutex &GetMutex() const { return mutex_; }
 
     int64_t GetLastAccessTime() const { return last_access_time_.load(std::memory_order_relaxed); }
     void TouchAccessTime() { last_access_time_.store(TimestampUtil::GetCurrentTimeUs(), std::memory_order_relaxed); }
 
-    static MetaMemCacheItem *Create(const FieldMap &fields) {
+    static MetaMemCacheItem *Create(const CacheLocationMap &locations, const PropertyMap &properties) {
         auto *item = new MetaMemCacheItem();
-        item->fields_ = fields;
+        item->locations_ = locations;
+        item->properties_ = properties;
         return item;
     }
-    static MetaMemCacheItem *Create(FieldMap &&fields) {
+    static MetaMemCacheItem *Create(CacheLocationMap &&locations, PropertyMap &&properties) {
         auto *item = new MetaMemCacheItem();
-        item->fields_ = std::move(fields);
+        item->locations_ = std::move(locations);
+        item->properties_ = std::move(properties);
         return item;
     }
     static void Deleter(void *value, MemoryAllocator * /*allocator*/) { delete static_cast<MetaMemCacheItem *>(value); }
 
 private:
     mutable std::shared_mutex mutex_;
-    FieldMap fields_;
+    CacheLocationMap locations_;
+    PropertyMap properties_;
     std::atomic<int64_t> last_access_time_{0};
 };
 
@@ -70,56 +77,92 @@ public:
     ErrorCode Close() noexcept override;
 
     // write
-    std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
-    std::vector<ErrorCode> DeleteFields(const KeyTypeVec &keys,
-                                        const std::vector<std::vector<std::string>> &field_names_vec) noexcept override;
+    std::vector<ErrorCode> Put(RequestContext *request_context,
+                               const KeyTypeVec &keys,
+                               const CacheLocationMapVector &locations,
+                               const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> PutIfAbsent(RequestContext *request_context,
+                                       const KeyTypeVec &keys,
+                                       const CacheLocationMapVector &locations,
+                                       const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Update(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyTypeVec &keys) noexcept override;
+    std::vector<ErrorCode> DeleteLocations(RequestContext *request_context,
+                                           const KeyTypeVec &keys,
+                                           const LocationIdsPerKey &location_ids) noexcept override;
 
     // Conditional write: only processes keys where previous_error_codes[i] == EC_OK.
-    std::vector<ErrorCode> Put(const KeyTypeVec &keys,
-                               const FieldMapVec &field_maps,
+    std::vector<ErrorCode> Put(RequestContext *request_context,
+                               const KeyTypeVec &keys,
+                               const CacheLocationMapVector &locations,
+                               const PropertyMapVector &properties,
                                const std::vector<ErrorCode> &previous_error_codes) noexcept override;
-    std::vector<ErrorCode> PutIfAbsent(const KeyTypeVec &keys,
-                                       const FieldMapVec &field_maps,
+    std::vector<ErrorCode> PutIfAbsent(RequestContext *request_context,
+                                       const KeyTypeVec &keys,
+                                       const CacheLocationMapVector &locations,
+                                       const PropertyMapVector &properties,
                                        const std::vector<ErrorCode> &previous_error_codes) noexcept override;
-    std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys,
-                                        const FieldMapVec &field_maps,
-                                        const std::vector<ErrorCode> &previous_error_codes) noexcept override;
-    std::vector<ErrorCode> Upsert(const KeyTypeVec &keys,
-                                  const FieldMapVec &field_maps,
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties,
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
-    std::vector<ErrorCode> Delete(const KeyTypeVec &keys,
+    std::vector<ErrorCode> Update(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties,
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
-    // Adjusts the LRU charge to reflect the size change.
-    std::vector<ErrorCode> DeleteFields(const KeyTypeVec &keys,
-                                        const std::vector<std::vector<std::string>> &field_names_vec,
-                                        const std::vector<ErrorCode> &previous_error_codes) noexcept override;
+    std::vector<ErrorCode> Delete(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const std::vector<ErrorCode> &previous_error_codes) noexcept override;
+    std::vector<ErrorCode> DeleteLocations(RequestContext *request_context,
+                                           const KeyTypeVec &keys,
+                                           const LocationIdsPerKey &location_ids,
+                                           const std::vector<ErrorCode> &previous_error_codes) noexcept override;
 
     // read
-    std::vector<ErrorCode> Get(const KeyTypeVec &keys,
-                               const std::vector<std::string> &field_names,
-                               FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> Get(const KeyTypeVec &keys,
-                               const std::vector<std::vector<std::string>> &field_names_vec,
-                               FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept override;
-    std::vector<ErrorCode> ExistsFieldWithPrefix(const KeyTypeVec &keys,
-                                                 const std::string &field_prefix,
-                                                 std::vector<bool> &out_exists_vec) noexcept override;
-    std::vector<ErrorCode>
-    GetFieldNamesWithPrefix(const KeyTypeVec &keys,
-                            const std::string &field_prefix,
-                            std::vector<std::vector<std::string>> &out_field_names_vec) noexcept override;
-    ErrorCode ListKeys(const std::string &cursor,
+    std::vector<ErrorCode> Get(RequestContext *request_context,
+                               const KeyTypeVec &keys,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties) noexcept override;
+    std::vector<ErrorCode> GetLocations(RequestContext *request_context,
+                                        const KeyTypeVec &keys,
+                                        CacheLocationMapVector &out_locations) noexcept override;
+    std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
+                                                     const KeyTypeVec &keys,
+                                                     const LocationIdsPerKey &location_ids,
+                                                     LocationsPerKey &out_locations) noexcept override;
+    std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          LocationIdsPerKey &out_location_ids) noexcept override;
+    std::vector<ErrorCode> GetProperties(RequestContext *request_context,
+                                         const KeyTypeVec &keys,
+                                         const std::vector<std::string> &field_names,
+                                         PropertyMapVector &out_properties) noexcept override;
+    std::vector<ErrorCode> Exists(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  std::vector<bool> &out_is_exist_vec) noexcept override;
+    std::vector<ErrorCode> ExistsLocation(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          std::vector<bool> &out_exists) noexcept override;
+    ErrorCode ListKeys(RequestContext *request_context,
+                       const std::string &cursor,
                        const int64_t limit,
                        std::string &out_next_cursor,
                        std::vector<KeyType> &out_keys) noexcept override;
-    ErrorCode RandomSample(const int64_t count, std::vector<KeyType> &out_keys) noexcept override;
-    ErrorCode SampleReclaimKeys(const int64_t count, std::vector<KeyType> &out_keys) noexcept override;
+    ErrorCode RandomSample(RequestContext *request_context,
+                           const int64_t count,
+                           std::vector<KeyType> &out_keys) noexcept override;
+    ErrorCode SampleReclaimKeys(RequestContext *request_context,
+                                const int64_t count,
+                                std::vector<KeyType> &out_keys) noexcept override;
 
     // meta data
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
@@ -128,39 +171,35 @@ public:
     size_t GetMemUsage() const noexcept override;
 
 private:
-    // Collects up to `count` oldest keys from the given shard, parses them to
-    // KeyType and appends to `out_keys`. Returns the number of keys collected.
     size_t CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys);
-
-    // Per-key helpers used by both unconditional and conditional write methods.
-    ErrorCode UpsertForOneKey(KeyType key, const FieldMap &field_map);
+    ErrorCode
+    CreateAndInsert(const std::string &key_str, const CacheLocationMap &locations, const PropertyMap &properties);
+    ErrorCode CreateAndInsertIfAbsent(const std::string &key_str,
+                                      const CacheLocationMap &locations,
+                                      const PropertyMap &properties);
+    ErrorCode
+    UpdateInPlace(const std::string &key_str, const CacheLocationMap &locations, const PropertyMap &properties);
+    ErrorCode UpsertForOneKey(KeyType key, const CacheLocationMap &locations, const PropertyMap &properties);
     ErrorCode DeleteForOneKey(KeyType key);
-    ErrorCode DeleteFieldsForOneKey(KeyType key, const std::vector<std::string> &field_names);
-    ErrorCode GetForOneKey(KeyType key, const std::vector<std::string> &field_names, FieldMap &out_field_map);
-
-    // Creates a MetaMemCacheItem from the given fields and inserts it into
-    // cache_ via Insert().  On failure the item is deleted and the error code
-    // is returned.
-    ErrorCode CreateAndInsert(const std::string &key_str, const FieldMap &fields);
-    ErrorCode CreateAndInsert(const std::string &key_str, FieldMap &&fields);
-
-    // Creates a MetaMemCacheItem and inserts it into cache_ via InsertIfAbsent().
-    ErrorCode CreateAndInsertIfAbsent(const std::string &key_str, const FieldMap &fields);
-
-    // Looks up an existing cache item and merges `updates` into its fields
-    // in place. Adjusts the LRU charge to reflect the size change.
-    // Returns EC_OK on success, EC_NOENT if key not found.
-    ErrorCode UpdateFieldsInPlace(const std::string &key_str, const FieldMap &updates);
+    ErrorCode DeleteLocationsForOneKey(KeyType key, const std::vector<LocationId> &location_ids);
+    // Unified read helper. Fetches data from cache for a single key.
+    // Pass nullptr for any output you don't need.
+    // - field_names: if non-null, only these properties are returned; otherwise all properties
+    // - out_location_map: if non-null, copies the full CacheLocationMap
+    // - out_property_map: if non-null, copies properties
+    // - out_location_ids: if non-null, collects all location ids from the key
+    // Returns EC_OK if key found, EC_NOENT otherwise.
+    ErrorCode GetForOneKey(KeyType key,
+                           const std::vector<std::string> *field_names,
+                           CacheLocationMap *out_location_map,
+                           PropertyMap *out_property_map,
+                           std::vector<LocationId> *out_location_ids);
 
     std::shared_ptr<Cache::CacheItemHelper> cache_item_helper_;
     std::shared_ptr<Cache> cache_;
+    std::unique_ptr<std::atomic<int64_t>[]> shard_oldest_access_time_;
     uint32_t shard_mask_ = 0;
     size_t sample_times_ = 0;
-
-    // Per-shard approximate oldest access time, updated via tail-change callback
-    // from the LRU cache. Used by SampleReclaimKeys to select the oldest shards
-    // without acquiring any shard locks.
-    std::unique_ptr<std::atomic<int64_t>[]> shard_oldest_access_time_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_redis_backend.cc
@@ -142,8 +142,8 @@ ErrorCode MetaRedisBackend::Close() noexcept {
 
 FieldMap MetaRedisBackend::SerializeToFieldMap(const CacheLocationMap &locations, const PropertyMap &properties) {
     FieldMap field_map;
-    for (const auto &[loc_id, loc] : locations) {
-        field_map[LOCATION_PREFIX + loc_id] = loc.ToJsonString();
+    for (const auto &[loc_id, loc_ptr] : locations) {
+        field_map[LOCATION_PREFIX + loc_id] = loc_ptr ? loc_ptr->ToJsonString() : "";
     }
     for (const auto &[key, value] : properties) {
         field_map[key] = value;
@@ -156,12 +156,12 @@ ErrorCode MetaRedisBackend::DeserializeFieldMap(const FieldMap &field_map,
                                                 PropertyMap &out_properties) {
     for (const auto &[field_name, field_value] : field_map) {
         if (field_name.rfind(LOCATION_PREFIX, 0) == 0) {
-            if (field_value.empty()) {
-                continue;
-            }
             std::string loc_id = field_name.substr(LOCATION_PREFIX.size());
-            CacheLocation location;
-            if (!location.FromJsonString(field_value)) {
+            auto location = std::make_shared<CacheLocation>();
+            if (field_value.empty()) {
+                // Empty value: deserialization failed but location id still exists.
+                location->set_id(loc_id);
+            } else if (!location->FromJsonString(field_value)) {
                 return EC_CORRUPTION;
             }
             out_locations[loc_id] = std::move(location);
@@ -177,12 +177,12 @@ ErrorCode MetaRedisBackend::DeserializeLocations(const FieldMap &field_map, Cach
         if (field_name.rfind(LOCATION_PREFIX, 0) != 0) {
             continue;
         }
-        if (field_value.empty()) {
-            continue;
-        }
         std::string loc_id = field_name.substr(LOCATION_PREFIX.size());
-        CacheLocation location;
-        if (!location.FromJsonString(field_value)) {
+        auto location = std::make_shared<CacheLocation>();
+        if (field_value.empty()) {
+            // Empty value: deserialization failed but location id still exists.
+            location->set_id(loc_id);
+        } else if (!location->FromJsonString(field_value)) {
             return EC_CORRUPTION;
         }
         out_locations[loc_id] = std::move(location);
@@ -417,8 +417,8 @@ std::vector<std::vector<ErrorCode>> MetaRedisBackend::GetLocations(RequestContex
                 results[i][j] = EC_NOENT;
                 continue;
             }
-            CacheLocation location;
-            if (!location.FromJsonString(it->second)) {
+            auto location = std::make_shared<CacheLocation>();
+            if (!location->FromJsonString(it->second)) {
                 results[i][j] = EC_CORRUPTION;
                 continue;
             }

--- a/kv_cache_manager/meta/meta_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_redis_backend.cc
@@ -1,9 +1,12 @@
 #include "kv_cache_manager/meta/meta_redis_backend.h"
 
 #include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
+#include "kv_cache_manager/metrics/metrics_collector.h"
 
 namespace kv_cache_manager {
 
@@ -133,7 +136,86 @@ ErrorCode MetaRedisBackend::Close() noexcept {
     return EC_OK;
 }
 
-std::vector<ErrorCode> MetaRedisBackend::Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
+
+FieldMap MetaRedisBackend::SerializeToFieldMap(const CacheLocationMap &locations, const PropertyMap &properties) {
+    FieldMap field_map;
+    for (const auto &[loc_id, loc] : locations) {
+        field_map[LOCATION_PREFIX + loc_id] = loc.ToJsonString();
+    }
+    for (const auto &[key, value] : properties) {
+        field_map[key] = value;
+    }
+    return field_map;
+}
+
+ErrorCode MetaRedisBackend::DeserializeFieldMap(const FieldMap &field_map,
+                                                CacheLocationMap &out_locations,
+                                                PropertyMap &out_properties) {
+    for (const auto &[field_name, field_value] : field_map) {
+        if (field_name.rfind(LOCATION_PREFIX, 0) == 0) {
+            if (field_value.empty()) {
+                continue;
+            }
+            std::string loc_id = field_name.substr(LOCATION_PREFIX.size());
+            CacheLocation location;
+            if (!location.FromJsonString(field_value)) {
+                return EC_CORRUPTION;
+            }
+            out_locations[loc_id] = std::move(location);
+        } else {
+            out_properties[field_name] = field_value;
+        }
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaRedisBackend::DeserializeLocations(const FieldMap &field_map, CacheLocationMap &out_locations) {
+    for (const auto &[field_name, field_value] : field_map) {
+        if (field_name.rfind(LOCATION_PREFIX, 0) != 0) {
+            continue;
+        }
+        if (field_value.empty()) {
+            continue;
+        }
+        std::string loc_id = field_name.substr(LOCATION_PREFIX.size());
+        CacheLocation location;
+        if (!location.FromJsonString(field_value)) {
+            return EC_CORRUPTION;
+        }
+        out_locations[loc_id] = std::move(location);
+    }
+    return EC_OK;
+}
+
+void MetaRedisBackend::ExtractLocationIds(const FieldMap &field_map, std::vector<LocationId> &out_location_ids) {
+    for (const auto &[field_name, field_value] : field_map) {
+        if (field_name.rfind(LOCATION_PREFIX, 0) == 0) {
+            out_location_ids.push_back(field_name.substr(LOCATION_PREFIX.size()));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+std::vector<ErrorCode> MetaRedisBackend::Put(RequestContext *request_context,
+                                             const KeyTypeVec &keys,
+                                             const CacheLocationMapVector &locations,
+                                             const PropertyMapVector &properties) noexcept {
+    const int64_t serde_begin = TimestampUtil::GetCurrentTimeUs();
+    FieldMapVec field_maps(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        field_maps[i] = SerializeToFieldMap(locations[i], properties[i]);
+    }
+    const int64_t serde_us = TimestampUtil::GetCurrentTimeUs() - serde_begin;
+    auto *service_metrics_collector =
+        request_context ? dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector()) : nullptr;
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_searcher, index_serialize_time_us, serde_us);
+
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(10, "put fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
@@ -143,17 +225,20 @@ std::vector<ErrorCode> MetaRedisBackend::Put(const KeyTypeVec &keys, const Field
     return handle->Set(full_keys, field_maps);
 }
 
-std::vector<ErrorCode> MetaRedisBackend::UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
-    auto handle = client_pool_->AcquireClient(timeout_ms_);
-    if (!handle) {
-        KVCM_INTERVAL_LOG_WARN(10, "update fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
-        return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
+std::vector<ErrorCode> MetaRedisBackend::Upsert(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties) noexcept {
+    const int64_t serde_begin = TimestampUtil::GetCurrentTimeUs();
+    FieldMapVec field_maps(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        field_maps[i] = SerializeToFieldMap(locations[i], properties[i]);
     }
-    std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
-    return handle->Update(full_keys, field_maps);
-}
+    const int64_t serde_us = TimestampUtil::GetCurrentTimeUs() - serde_begin;
+    auto *service_metrics_collector =
+        request_context ? dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector()) : nullptr;
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_searcher, index_serialize_time_us, serde_us);
 
-std::vector<ErrorCode> MetaRedisBackend::Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(10, "upsert fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
@@ -163,7 +248,30 @@ std::vector<ErrorCode> MetaRedisBackend::Upsert(const KeyTypeVec &keys, const Fi
     return handle->Upsert(full_keys, field_maps);
 }
 
-std::vector<ErrorCode> MetaRedisBackend::Delete(const KeyTypeVec &keys) noexcept {
+std::vector<ErrorCode> MetaRedisBackend::Update(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties) noexcept {
+    const int64_t serde_begin = TimestampUtil::GetCurrentTimeUs();
+    FieldMapVec field_maps(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        field_maps[i] = SerializeToFieldMap(locations[i], properties[i]);
+    }
+    const int64_t serde_us = TimestampUtil::GetCurrentTimeUs() - serde_begin;
+    auto *service_metrics_collector =
+        request_context ? dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector()) : nullptr;
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_searcher, index_serialize_time_us, serde_us);
+
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(10, "update fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
+    }
+    std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
+    return handle->Update(full_keys, field_maps);
+}
+
+std::vector<ErrorCode> MetaRedisBackend::Delete(RequestContext * /*request_context*/, const KeyTypeVec &keys) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(10, "delete fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
@@ -173,55 +281,218 @@ std::vector<ErrorCode> MetaRedisBackend::Delete(const KeyTypeVec &keys) noexcept
     return handle->Delete(full_keys);
 }
 
-std::vector<ErrorCode>
-MetaRedisBackend::DeleteFields(const KeyTypeVec &keys,
-                               const std::vector<std::vector<std::string>> &field_names_vec) noexcept {
+std::vector<ErrorCode> MetaRedisBackend::DeleteLocations(RequestContext * /*request_context*/,
+                                                         const KeyTypeVec &keys,
+                                                         const LocationIdsPerKey &location_ids) noexcept {
+    // Convert location ids to field names with LOCATION_PREFIX for Redis DeleteFields.
+    std::vector<std::vector<std::string>> field_names_vec(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        field_names_vec[i].reserve(location_ids[i].size());
+        for (const auto &loc_id : location_ids[i]) {
+            field_names_vec[i].push_back(LOCATION_PREFIX + loc_id);
+        }
+    }
+
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(
-            10, "delete fields fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+            10, "delete locations fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
         return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
     }
     std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
     return handle->DeleteFields(full_keys, field_names_vec);
 }
 
-std::vector<ErrorCode> MetaRedisBackend::Get(const KeyTypeVec &keys,
-                                             const std::vector<std::string> &field_names,
-                                             FieldMapVec &out_field_maps) noexcept {
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+std::vector<ErrorCode> MetaRedisBackend::Get(RequestContext *request_context,
+                                             const KeyTypeVec &keys,
+                                             CacheLocationMapVector &out_locations,
+                                             PropertyMapVector &out_properties) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(10, "get fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
         return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
     }
     std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
-    return handle->Get(full_keys, field_names, out_field_maps);
-}
+    FieldMapVec field_maps;
+    std::vector<ErrorCode> results = handle->GetAllFields(full_keys, field_maps);
 
-std::vector<ErrorCode> MetaRedisBackend::Get(const KeyTypeVec &keys,
-                                             const std::vector<std::vector<std::string>> &field_names_vec,
-                                             FieldMapVec &out_field_maps) noexcept {
-    auto handle = client_pool_->AcquireClient(timeout_ms_);
-    if (!handle) {
-        KVCM_INTERVAL_LOG_WARN(10, "get fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
-        return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
+    const int64_t serde_begin = TimestampUtil::GetCurrentTimeUs();
+    out_locations.resize(keys.size());
+    out_properties.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (results[i] != EC_OK) {
+            continue;
+        }
+        ErrorCode ec = DeserializeFieldMap(field_maps[i], out_locations[i], out_properties[i]);
+        if (ec != EC_OK) {
+            KVCM_LOG_ERROR("get deserialize failed, key[%ld], instance[%s]", keys[i], instance_id_.c_str());
+            results[i] = ec;
+        }
     }
-    std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
-    return handle->Get(full_keys, field_names_vec, out_field_maps);
+    const int64_t serde_us = TimestampUtil::GetCurrentTimeUs() - serde_begin;
+    auto *service_metrics_collector =
+        request_context ? dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector()) : nullptr;
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_searcher, index_deserialize_time_us, serde_us);
+    return results;
 }
 
-std::vector<ErrorCode> MetaRedisBackend::GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept {
+std::vector<ErrorCode> MetaRedisBackend::GetLocations(RequestContext *request_context,
+                                                      const KeyTypeVec &keys,
+                                                      CacheLocationMapVector &out_locations) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(
-            10, "get all fields fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+            10, "get locations fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
         return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
     }
     std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
-    return handle->GetAllFields(full_keys, out_field_maps);
+    FieldMapVec field_maps;
+    std::vector<ErrorCode> results = handle->GetAllFields(full_keys, field_maps);
+
+    const int64_t serde_begin = TimestampUtil::GetCurrentTimeUs();
+    out_locations.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (results[i] != EC_OK) {
+            continue;
+        }
+        ErrorCode ec = DeserializeLocations(field_maps[i], out_locations[i]);
+        if (ec != EC_OK) {
+            KVCM_LOG_ERROR("get locations deserialize failed, key[%ld], instance[%s]", keys[i], instance_id_.c_str());
+            results[i] = ec;
+        }
+    }
+    const int64_t serde_us = TimestampUtil::GetCurrentTimeUs() - serde_begin;
+    auto *service_metrics_collector =
+        request_context ? dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector()) : nullptr;
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_searcher, index_deserialize_time_us, serde_us);
+    return results;
 }
 
-std::vector<ErrorCode> MetaRedisBackend::Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept {
+std::vector<std::vector<ErrorCode>> MetaRedisBackend::GetLocations(RequestContext *request_context,
+                                                                   const KeyTypeVec &keys,
+                                                                   const LocationIdsPerKey &location_ids,
+                                                                   LocationsPerKey &out_locations) noexcept {
+    assert(keys.size() == location_ids.size());
+
+    // Build per-key field names to fetch only requested locations.
+    std::vector<std::vector<std::string>> field_names_vec(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        field_names_vec[i].reserve(location_ids[i].size());
+        for (const auto &loc_id : location_ids[i]) {
+            field_names_vec[i].push_back(LOCATION_PREFIX + loc_id);
+        }
+    }
+
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "get locations by id fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        std::vector<std::vector<ErrorCode>> results(keys.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            results[i].assign(location_ids[i].size(), EC_TIMEOUT);
+        }
+        return results;
+    }
+    std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
+    FieldMapVec field_maps;
+    std::vector<ErrorCode> key_results = handle->Get(full_keys, field_names_vec, field_maps);
+
+    const int64_t serde_begin = TimestampUtil::GetCurrentTimeUs();
+    std::vector<std::vector<ErrorCode>> results(keys.size());
+    out_locations.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        out_locations[i].resize(location_ids[i].size());
+        if (key_results[i] != EC_OK) {
+            results[i].assign(location_ids[i].size(), key_results[i]);
+            continue;
+        }
+        results[i].resize(location_ids[i].size());
+        for (size_t j = 0; j < location_ids[i].size(); ++j) {
+            auto it = field_maps[i].find(field_names_vec[i][j]);
+            if (it == field_maps[i].end() || it->second.empty()) {
+                results[i][j] = EC_NOENT;
+                continue;
+            }
+            CacheLocation location;
+            if (!location.FromJsonString(it->second)) {
+                results[i][j] = EC_CORRUPTION;
+                continue;
+            }
+            out_locations[i][j] = std::move(location);
+            results[i][j] = EC_OK;
+        }
+    }
+    const int64_t serde_us = TimestampUtil::GetCurrentTimeUs() - serde_begin;
+    auto *service_metrics_collector =
+        request_context ? dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector()) : nullptr;
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_searcher, index_deserialize_time_us, serde_us);
+    return results;
+}
+
+std::vector<ErrorCode> MetaRedisBackend::GetLocationIds(RequestContext * /*request_context*/,
+                                                        const KeyTypeVec &keys,
+                                                        LocationIdsPerKey &out_location_ids) noexcept {
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "get location ids fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
+    }
+    std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
+    std::vector<std::vector<std::string>> raw_field_names_vec;
+    std::vector<ErrorCode> results = handle->GetFieldNamesWithPrefix(full_keys, LOCATION_PREFIX, raw_field_names_vec);
+
+    out_location_ids.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (results[i] != EC_OK) {
+            continue;
+        }
+        out_location_ids[i].reserve(raw_field_names_vec[i].size());
+        for (const auto &field_name : raw_field_names_vec[i]) {
+            if (field_name.size() > LOCATION_PREFIX.size() && field_name.rfind(LOCATION_PREFIX, 0) == 0) {
+                out_location_ids[i].push_back(field_name.substr(LOCATION_PREFIX.size()));
+            }
+        }
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaRedisBackend::GetProperties(RequestContext * /*request_context*/,
+                                                       const KeyTypeVec &keys,
+                                                       const std::vector<std::string> &field_names,
+                                                       PropertyMapVector &out_properties) noexcept {
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "get properties fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
+    }
+    std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
+    FieldMapVec field_maps;
+    std::vector<ErrorCode> results = handle->Get(full_keys, field_names, field_maps);
+
+    out_properties.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (results[i] != EC_OK) {
+            continue;
+        }
+        // Properties are stored as plain fields (no LOCATION_PREFIX).
+        out_properties[i] = std::move(field_maps[i]);
+    }
+    return results;
+}
+
+// ---------------------------------------------------------------------------
+// Key-level operations
+// ---------------------------------------------------------------------------
+
+std::vector<ErrorCode> MetaRedisBackend::Exists(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                std::vector<bool> &out_is_exist_vec) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(10, "exists fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
@@ -231,39 +502,25 @@ std::vector<ErrorCode> MetaRedisBackend::Exists(const KeyTypeVec &keys, std::vec
     return handle->Exists(full_keys, out_is_exist_vec);
 }
 
-std::vector<ErrorCode> MetaRedisBackend::ExistsFieldWithPrefix(const KeyTypeVec &keys,
-                                                               const std::string &field_prefix,
-                                                               std::vector<bool> &out_exists_vec) noexcept {
+std::vector<ErrorCode> MetaRedisBackend::ExistsLocation(RequestContext * /*request_context*/,
+                                                        const KeyTypeVec &keys,
+                                                        std::vector<bool> &out_exists) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(
-            10, "exists field with prefix fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+            10, "exists location fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
         return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
     }
     std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
-    return handle->ExistsFieldWithPrefix(full_keys, field_prefix, out_exists_vec);
+    return handle->ExistsFieldWithPrefix(full_keys, LOCATION_PREFIX, out_exists);
 }
 
-std::vector<ErrorCode>
-MetaRedisBackend::GetFieldNamesWithPrefix(const KeyTypeVec &keys,
-                                          const std::string &field_prefix,
-                                          std::vector<std::vector<std::string>> &out_field_names_vec) noexcept {
-    auto handle = client_pool_->AcquireClient(timeout_ms_);
-    if (!handle) {
-        KVCM_INTERVAL_LOG_WARN(
-            10, "list field names with prefix fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
-        return std::vector<ErrorCode>(keys.size(), EC_TIMEOUT);
-    }
-    std::vector<std::string> full_keys = AppendPrefixToKeys(keys);
-    return handle->GetFieldNamesWithPrefix(full_keys, field_prefix, out_field_names_vec);
-}
-
-ErrorCode MetaRedisBackend::ListKeys(const std::string &cursor,
+ErrorCode MetaRedisBackend::ListKeys(RequestContext * /*request_context*/,
+                                     const std::string &cursor,
                                      const int64_t limit,
                                      std::string &out_next_cursor,
-                                     std::vector<KeyType> &out_keys) noexcept {
+                                     KeyTypeVec &out_keys) noexcept {
     out_keys.clear();
-
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(10, "list keys fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
@@ -283,9 +540,10 @@ ErrorCode MetaRedisBackend::ListKeys(const std::string &cursor,
     return EC_OK;
 }
 
-ErrorCode MetaRedisBackend::RandomSample(const int64_t count, std::vector<KeyType> &out_keys) noexcept {
+ErrorCode MetaRedisBackend::RandomSample(RequestContext * /*request_context*/,
+                                         const int64_t count,
+                                         KeyTypeVec &out_keys) noexcept {
     out_keys.clear();
-
     auto handle = client_pool_->AcquireClient(timeout_ms_);
     if (!handle) {
         KVCM_INTERVAL_LOG_WARN(10, "random fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
@@ -305,10 +563,15 @@ ErrorCode MetaRedisBackend::RandomSample(const int64_t count, std::vector<KeyTyp
     return EC_OK;
 }
 
-ErrorCode MetaRedisBackend::SampleReclaimKeys(const int64_t count, std::vector<KeyType> &out_keys) noexcept {
-    // For Redis backend, RandomSample already uses Redis RAND command which is efficient
-    return RandomSample(count, out_keys);
+ErrorCode MetaRedisBackend::SampleReclaimKeys(RequestContext * /*request_context*/,
+                                              const int64_t count,
+                                              KeyTypeVec &out_keys) noexcept {
+    return RandomSample(nullptr, count, out_keys);
 }
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
 
 ErrorCode MetaRedisBackend::PutMetaData(const FieldMap &field_map) noexcept {
     auto handle = client_pool_->AcquireClient(timeout_ms_);

--- a/kv_cache_manager/meta/meta_redis_backend.h
+++ b/kv_cache_manager/meta/meta_redis_backend.h
@@ -29,44 +29,82 @@ public:
     ErrorCode Open() noexcept override;
     ErrorCode Close() noexcept override;
 
-    // write
-    std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept override;
-    std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept override;
-    std::vector<ErrorCode> DeleteFields(const KeyTypeVec &keys,
-                                        const std::vector<std::vector<std::string>> &field_names_vec) noexcept override;
+    // ----- Write APIs -----
+    std::vector<ErrorCode> Put(RequestContext *request_context,
+                               const KeyTypeVec &keys,
+                               const CacheLocationMapVector &locations,
+                               const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Update(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyTypeVec &keys) noexcept override;
+    std::vector<ErrorCode> DeleteLocations(RequestContext *request_context,
+                                           const KeyTypeVec &keys,
+                                           const LocationIdsPerKey &location_ids) noexcept override;
 
-    // read
-    std::vector<ErrorCode> Get(const KeyTypeVec &keys,
-                               const std::vector<std::string> &field_names,
-                               FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> Get(const KeyTypeVec &keys,
-                               const std::vector<std::vector<std::string>> &field_names_vec,
-                               FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept override;
-    std::vector<ErrorCode> Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept override;
-    std::vector<ErrorCode> ExistsFieldWithPrefix(const KeyTypeVec &keys,
-                                                 const std::string &field_prefix,
-                                                 std::vector<bool> &out_exists_vec) noexcept override;
-    std::vector<ErrorCode>
-    GetFieldNamesWithPrefix(const KeyTypeVec &keys,
-                            const std::string &field_prefix,
-                            std::vector<std::vector<std::string>> &out_field_names_vec) noexcept override;
-    ErrorCode ListKeys(const std::string &cursor,
+    // ----- Read APIs -----
+    std::vector<ErrorCode> Get(RequestContext *request_context,
+                               const KeyTypeVec &keys,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties) noexcept override;
+    std::vector<ErrorCode> GetLocations(RequestContext *request_context,
+                                        const KeyTypeVec &keys,
+                                        CacheLocationMapVector &out_locations) noexcept override;
+    std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
+                                                     const KeyTypeVec &keys,
+                                                     const LocationIdsPerKey &location_ids,
+                                                     LocationsPerKey &out_locations) noexcept override;
+    std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          LocationIdsPerKey &out_location_ids) noexcept override;
+    std::vector<ErrorCode> GetProperties(RequestContext *request_context,
+                                         const KeyTypeVec &keys,
+                                         const std::vector<std::string> &field_names,
+                                         PropertyMapVector &out_properties) noexcept override;
+    std::vector<ErrorCode> Exists(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  std::vector<bool> &out_is_exist_vec) noexcept override;
+    std::vector<ErrorCode> ExistsLocation(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          std::vector<bool> &out_exists) noexcept override;
+    ErrorCode ListKeys(RequestContext *request_context,
+                       const std::string &cursor,
                        const int64_t limit,
                        std::string &out_next_cursor,
-                       std::vector<KeyType> &out_keys) noexcept override;
-    ErrorCode RandomSample(const int64_t count, std::vector<KeyType> &out_keys) noexcept override;
-    ErrorCode SampleReclaimKeys(const int64_t count, std::vector<KeyType> &out_keys) noexcept override;
+                       KeyTypeVec &out_keys) noexcept override;
+    ErrorCode
+    RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
+    ErrorCode
+    SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
 
-    // meta data
+    // ----- Metadata APIs -----
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
 
 private:
+    // ----- Key helpers -----
     std::vector<std::string> AppendPrefixToKeys(const KeyTypeVec &keys) const;
     bool StripPrefixInKeys(const std::vector<std::string> &keys_with_prefix, std::vector<KeyType> &out_keys) const;
+
+    // ----- Serialization helpers -----
+    // Serialize CacheLocationMap + PropertyMap into a single FieldMap for Redis storage.
+    static FieldMap SerializeToFieldMap(const CacheLocationMap &locations, const PropertyMap &properties);
+
+    // Deserialize a FieldMap from Redis into CacheLocationMap + PropertyMap.
+    // Returns EC_OK on success, EC_CORRUPTION if any location JSON is invalid.
+    static ErrorCode
+    DeserializeFieldMap(const FieldMap &field_map, CacheLocationMap &out_locations, PropertyMap &out_properties);
+
+    // Deserialize a FieldMap into CacheLocationMap only (ignores properties).
+    static ErrorCode DeserializeLocations(const FieldMap &field_map, CacheLocationMap &out_locations);
+
+    // Extract location ids from field names that start with LOCATION_PREFIX.
+    static void ExtractLocationIds(const FieldMap &field_map, std::vector<LocationId> &out_location_ids);
 
     // virtual for test
     virtual std::shared_ptr<RedisClient> CreateRedisClient() const;

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -10,12 +10,14 @@
 
 namespace kv_cache_manager {
 class MetaStorageBackendConfig;
+class RequestContext;
 
 // MetaStorageBackend — MetaIndexer 后端存储抽象基类
 //
 // 数据模型：
-//   每个 key (int64_t) 对应一个 hash 结构，内含多个 field→value 映射。
-//   field 用于存储 location（前缀 "__loc__"）和 property。
+//   每个 key (int64_t) 对应一组 CacheLocation（按 location_id 索引）和
+//   一组 property（string→string KV 对）。
+//   后端自行决定内部存储格式：Local 后端直接存结构体，Redis 后端存 JSON string。
 
 class MetaStorageBackend {
 public:
@@ -47,149 +49,201 @@ public:
     // Write APIs
     // =====================================================================
 
-    // 创建 key 并写入所有 field。若 key 已存在，行为等同于全量覆盖。
-    // @param keys        待写入的 key 列表
-    // @param field_maps  每个 key 对应的 field→value 映射，大小必须等于 keys.size()
+    // 整 key 覆盖写入 locations + properties。若 key 已存在则全量替换
+    // @param request_context  请求上下文，用于 metrics 上报；可为 nullptr
+    // @param keys             待写入的 key 列表
+    // @param locations        每个 key 对应的 CacheLocationMap，大小必须等于 keys.size()；
+    //                         可以为空 map 表示该 key 无 location
+    // @param properties       每个 key 对应的 PropertyMap，大小必须等于 keys.size()；
+    //                         可以为空 map 表示该 key 无 property
     // @return 每个 key 的错误码：
     //   - EC_OK:    写入成功
     //   - EC_ERROR: 写入失败（网络/IO 错误等）
-    virtual std::vector<ErrorCode> Put(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
+    virtual std::vector<ErrorCode> Put(RequestContext *request_context,
+                                       const KeyTypeVec &keys,
+                                       const CacheLocationMapVector &locations,
+                                       const PropertyMapVector &properties) noexcept = 0;
 
-    // 更新已存在 key 的部分 field。不会创建新 key。
-    // @param keys        待更新的 key 列表
-    // @param field_maps  每个 key 要更新的 field→value，大小必须等于 keys.size()
+    // 若 key 存在则合并 不存在则创建 key 并写入。
+    // @param request_context  请求上下文；可为 nullptr
+    // @param keys             待操作的 key 列表
+    // @param locations        每个 key 要合并的 CacheLocationMap，大小必须等于 keys.size()；
+    //                         空 map 表示不更新该 key 的 location
+    // @param properties       每个 key 要合并的 PropertyMap，大小必须等于 keys.size()；
+    //                         空 map 表示不更新该 key 的 property
+    // @return 每个 key 的错误码：
+    //   - EC_OK:    操作成功（无论是新建还是合并）
+    //   - EC_ERROR: 操作失败
+    virtual std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          const CacheLocationMapVector &locations,
+                                          const PropertyMapVector &properties) noexcept = 0;
+
+    // 增量更新：仅更新传入的 locations 和 properties 字段，不影响 key 中其他已有字段。
+    // @param request_context  请求上下文；可为 nullptr
+    // @param keys             待更新的 key 列表
+    // @param locations        每个 key 要更新的 CacheLocationMap，大小必须等于 keys.size()；
+    //                         空 map 表示不更新该 key 的 location
+    // @param properties       每个 key 要更新的 PropertyMap，大小必须等于 keys.size()；
+    //                         空 map 表示不更新该 key 的 property
     // @return 每个 key 的错误码：
     //   - EC_OK:    更新成功
-    //   - EC_NOENT: key 不存在（仅 Local/Dummy 后端；Redis HMSET 对不存在的 key 会隐式创建）
+    //   - EC_NOENT: key 不存在
     //   - EC_ERROR: 更新失败
-    virtual std::vector<ErrorCode> UpdateFields(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
+    virtual std::vector<ErrorCode> Update(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          const CacheLocationMapVector &locations,
+                                          const PropertyMapVector &properties) noexcept = 0;
 
-    // 若 key 存在则更新 field，不存在则创建 key 并写入。语义 = Put + UpdateFields 的合体。
-    // @param keys        待操作的 key 列表
-    // @param field_maps  每个 key 对应的 field→value，大小必须等于 keys.size()
-    // @return 每个 key 的错误码：
-    //   - EC_OK:    操作成功（无论是新建还是更新）
-    //   - EC_ERROR: 操作失败
-    virtual std::vector<ErrorCode> Upsert(const KeyTypeVec &keys, const FieldMapVec &field_maps) noexcept = 0;
-
-    // 删除整个 key 及其所有 field。
+    // 删除整个 key 及其所有 locations 和 properties。
+    // @param request_context  请求上下文；可为 nullptr
     // @param keys  待删除的 key 列表
     // @return 每个 key 的错误码：
     //   - EC_OK:    删除成功（key 确实存在并被删除）
-    //   - EC_NOENT: key 不存在（Local/Dummy 后端）；Redis DEL 返回 0
+    //   - EC_NOENT: key 不存在
     //   - EC_ERROR: 删除失败
-    virtual std::vector<ErrorCode> Delete(const KeyTypeVec &keys) noexcept = 0;
+    virtual std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyTypeVec &keys) noexcept = 0;
 
-    // 删除 key 中的指定 field（部分删除）。幂等语义：删除不存在的 field 视为成功。
+    // 删除指定 key 下的指定 location。幂等语义：删除不存在的 location 视为成功。
+    // 不影响 key 中的 properties 和其他 location。
+    // @param request_context  请求上下文；可为 nullptr
     // @param keys             待操作的 key 列表
-    // @param field_names_vec  每个 key 要删除的 field name 列表，大小必须等于 keys.size()
-    //                         若 field_names_vec[i] 为空，该 key 跳过操作（no-op，返回 EC_OK）
+    // @param location_ids     每个 key 要删除的 location id 列表，大小必须等于 keys.size()；
+    //                         若 location_ids[i] 为空，该 key 为 no-op（返回 EC_OK）
     // @return 每个 key 的错误码：
-    //   - EC_OK:    删除成功（包括 field 原本就不存在的情况，以及 field_names 为空的 no-op）
-    //   - EC_NOENT: key 本身不存在（仅当 field_names 非空时；Local/Dummy 后端）
+    //   - EC_OK:    删除成功（含 no-op 和 location 原本不存在的情况）
+    //   - EC_NOENT: key 本身不存在
     //   - EC_ERROR: 操作失败
-    virtual std::vector<ErrorCode>
-    DeleteFields(const KeyTypeVec &keys, const std::vector<std::vector<std::string>> &field_names_vec) noexcept = 0;
+    virtual std::vector<ErrorCode> DeleteLocations(RequestContext *request_context,
+                                                   const KeyTypeVec &keys,
+                                                   const LocationIdsPerKey &location_ids) noexcept = 0;
 
     // =====================================================================
     // Read APIs
     // =====================================================================
 
-    // 按统一的 field name 列表，批量获取多个 key 的指定 field。
-    // @param keys           待查询的 key 列表
-    // @param field_names    所有 key 共用的 field name 列表（不能为空）
-    // @param out_field_maps [out] 每个 key 的结果 map，大小等于 keys.size()。
-    //                       仅包含存在且 value 非空的 field。
+    // 读取 key 的完整元数据（locations + properties 一起返回）。
+    // @param request_context   请求上下文；可为 nullptr
+    // @param keys              待查询的 key 列表
+    // @param out_locations     [out] 每个 key 的 CacheLocationMap，大小等于 keys.size()
+    // @param out_properties    [out] 每个 key 的 PropertyMap，大小等于 keys.size()
     // @return 每个 key 的错误码：
-    //   - EC_OK:    key 存在（out_field_maps[i] 可能为空——表示请求的 field 都不存在）
-    //   - EC_NOENT: key 不存在
-    //              注意：Redis 后端当所有 field 返回 nil 时统一返回 EC_NOENT。
-    //   - EC_BADARGS: field_names 为空
-    //   - EC_ERROR: 查询失败
-    virtual std::vector<ErrorCode>
-    Get(const KeyTypeVec &keys, const std::vector<std::string> &field_names, FieldMapVec &out_field_maps) noexcept = 0;
+    //   - EC_OK:        key 存在
+    //   - EC_NOENT:     key 不存在
+    //   - EC_CORRUPTION: location 数据损坏（反序列化失败）
+    //   - EC_ERROR:     查询失败
+    virtual std::vector<ErrorCode> Get(RequestContext *request_context,
+                                       const KeyTypeVec &keys,
+                                       CacheLocationMapVector &out_locations,
+                                       PropertyMapVector &out_properties) noexcept = 0;
 
-    // 按每个 key 独立的 field name 列表，批量获取 field。
+    // 读取 key 的全量 CacheLocationMap（所有 location）。
+    // @param request_context   请求上下文；可为 nullptr
+    // @param keys              待查询的 key 列表
+    // @param out_locations     [out] 每个 key 的 CacheLocationMap，大小等于 keys.size()。
+    //                          key 存在但无 location 时为空 map。
+    // @return 每个 key 的错误码：
+    //   - EC_OK:        key 存在（out_locations[i] 可能为空 map）
+    //   - EC_NOENT:     key 不存在
+    //   - EC_CORRUPTION: location 数据损坏（反序列化失败，仅 Redis 后端）
+    //   - EC_ERROR:     查询失败
+    virtual std::vector<ErrorCode> GetLocations(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
+                                                CacheLocationMapVector &out_locations) noexcept = 0;
+
+    // 读取指定 location id 对应的 CacheLocation。
+    // @param request_context  请求上下文；可为 nullptr
     // @param keys             待查询的 key 列表
-    // @param field_names_vec  每个 key 对应的 field name 列表，大小必须等于 keys.size()
-    //                         每个子列表不能为空（空列表返回 EC_BADARGS）
-    // @param out_field_maps   [out] 每个 key 的结果 map。仅含存在且 value 非空的 field。
-    // @return 每个 key 的错误码：
-    //   - EC_OK:     key 存在（out_field_maps[i] 可能为空——表示请求的 field 都不存在）
-    //   - EC_NOENT:  key 不存在
-    //              注意：Redis 后端当所有 field 返回 nil 时统一返回 EC_NOENT。
-    //   - EC_BADARGS: field_names_vec[i] 为空
-    //   - EC_ERROR:  查询失败
-    virtual std::vector<ErrorCode> Get(const KeyTypeVec &keys,
-                                       const std::vector<std::vector<std::string>> &field_names_vec,
-                                       FieldMapVec &out_field_maps) noexcept = 0;
+    // @param location_ids     每个 key 要查询的 location id 列表，大小必须等于 keys.size()
+    // @param out_locations    [out] 每个 key 的 CacheLocation 列表，out_locations[i] 大小
+    //                         等于 location_ids[i].size()。未找到的 location 为默认构造。
+    // @return 二维错误码，results[i][j] 对应 keys[i] 的 location_ids[i][j]：
+    //   - EC_OK:         location 存在
+    //   - EC_NOENT:      key 不存在或该 location 不存在
+    //   - EC_CORRUPTION: location 数据损坏（反序列化失败）
+    //   - EC_ERROR:      查询失败
+    virtual std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
+                                                             const KeyTypeVec &keys,
+                                                             const LocationIdsPerKey &location_ids,
+                                                             LocationsPerKey &out_locations) noexcept = 0;
 
-    // 获取 key 的所有 field（含 tombstone 空 value）。
-    // 注意：此接口不过滤 tombstone，调用方需自行判断空 value。
-    // @param keys           待查询的 key 列表
-    // @param out_field_maps [out] 每个 key 的完整 field map（包含空 value 的 field）
+    // 仅获取 key 的 location id 列表（不读取 location body）。
+    // @param request_context    请求上下文；可为 nullptr
+    // @param keys               待查询的 key 列表
+    // @param out_location_ids   [out] 每个 key 的 location id 列表，大小等于 keys.size()。
+    //                           key 存在但无 location 时为空 vector。
     // @return 每个 key 的错误码：
-    //   - EC_OK:    key 存在（即使所有 field value 为空）
+    //   - EC_OK:    key 存在
     //   - EC_NOENT: key 不存在
     //   - EC_ERROR: 查询失败
-    virtual std::vector<ErrorCode> GetAllFields(const KeyTypeVec &keys, FieldMapVec &out_field_maps) noexcept = 0;
+    virtual std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
+                                                  const KeyTypeVec &keys,
+                                                  LocationIdsPerKey &out_location_ids) noexcept = 0;
 
-    // 获取 key 中以指定前缀开头的 field name 列表。跳过 value 为空的 tombstone field。
-    // @param keys                 待查询的 key 列表
-    // @param field_prefix         field name 前缀（如 "__loc__"）
-    // @param out_field_names_vec  [out] 每个 key 匹配的 field name 列表（仅含 value 非空的）
+    // 读取指定字段名的 properties。
+    // @param request_context  请求上下文；可为 nullptr
+    // @param keys             待查询的 key 列表
+    // @param field_names      要读取的 property 字段名列表（所有 key 使用同一组字段名）
+    // @param out_properties   [out] 每个 key 的 PropertyMap（仅包含请求的字段），
+    //                         大小等于 keys.size()。字段不存在时不出现在 map 中。
     // @return 每个 key 的错误码：
-    //   - EC_OK:    key 存在（结果可能为空——key 存在但无匹配的非空 field）
+    //   - EC_OK:    key 存在
     //   - EC_NOENT: key 不存在
     //   - EC_ERROR: 查询失败
-    virtual std::vector<ErrorCode>
-    GetFieldNamesWithPrefix(const KeyTypeVec &keys,
-                            const std::string &field_prefix,
-                            std::vector<std::vector<std::string>> &out_field_names_vec) noexcept = 0;
+    virtual std::vector<ErrorCode> GetProperties(RequestContext *request_context,
+                                                 const KeyTypeVec &keys,
+                                                 const std::vector<std::string> &field_names,
+                                                 PropertyMapVector &out_properties) noexcept = 0;
 
     // 检查 key 是否存在。
+    // @param request_context   请求上下文；可为 nullptr
     // @param keys              待查询的 key 列表
     // @param out_is_exist_vec  [out] 每个 key 是否存在，大小等于 keys.size()
     // @return 每个 key 的错误码：
     //   - EC_OK:    查询成功（out_is_exist_vec[i] 反映结果）
     //   - EC_ERROR: 查询失败
-    virtual std::vector<ErrorCode> Exists(const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept = 0;
+    virtual std::vector<ErrorCode>
+    Exists(RequestContext *request_context, const KeyTypeVec &keys, std::vector<bool> &out_is_exist_vec) noexcept = 0;
 
-    // 检查 key 中是否存在以指定前缀开头且 value 非空的 field。
-    // 空 value (tombstone) 不被视为有效存在。
-    // @param keys            待查询的 key 列表
-    // @param field_prefix    field name 前缀
-    // @param out_exists_vec  [out] 每个 key 是否有匹配的非空 field
+    // 判断 key 是否存在至少一个有效 location。
+    // @param request_context  请求上下文；可为 nullptr
+    // @param keys             待查询的 key 列表
+    // @param out_exists       [out] 每个 key 是否拥有至少一个 location，大小等于 keys.size()
     // @return 每个 key 的错误码：
-    //   - EC_OK:    key 存在（out_exists_vec[i] 反映结果，可能为 false）
-    //   - EC_NOENT: key 不存在
+    //   - EC_OK:    查询成功（out_exists[i] 反映结果）
+    //   - EC_NOENT: key 不存在（out_exists[i] 为 false）
     //   - EC_ERROR: 查询失败
-    virtual std::vector<ErrorCode> ExistsFieldWithPrefix(const KeyTypeVec &keys,
-                                                         const std::string &field_prefix,
-                                                         std::vector<bool> &out_exists_vec) noexcept = 0;
+    virtual std::vector<ErrorCode>
+    ExistsLocation(RequestContext *request_context, const KeyTypeVec &keys, std::vector<bool> &out_exists) noexcept = 0;
 
     // 基于 cursor 分页扫描所有 key。
+    // @param request_context 请求上下文；可为 nullptr
     // @param cursor          游标（首次传 SCAN_BASE_CURSOR = "0"）
     // @param limit           本次最多返回的 key 数量（hint，实际可能多于或少于此值）
     // @param out_next_cursor [out] 下一次扫描的 cursor；等于 SCAN_BASE_CURSOR 时表示扫描结束
     // @param out_keys        [out] 本次扫描到的 key 列表
     // @return EC_OK 成功；EC_BADARGS cursor 非法；EC_ERROR 扫描失败
-    virtual ErrorCode ListKeys(const std::string &cursor,
+    virtual ErrorCode ListKeys(RequestContext *request_context,
+                               const std::string &cursor,
                                const int64_t limit,
                                std::string &out_next_cursor,
                                KeyTypeVec &out_keys) noexcept = 0;
 
     // 随机采样 key。
+    // @param request_context 请求上下文；可为 nullptr
     // @param count    期望采样数量
     // @param out_keys [out] 采样结果（实际数量可能小于 count）
     // @return EC_OK 成功；EC_ERROR 采样失败
-    virtual ErrorCode RandomSample(const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
+    virtual ErrorCode
+    RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
 
     // 采样适合回收的 key（通常按 LRU 或 access time 排序）。
+    // @param request_context 请求上下文；可为 nullptr
     // @param count    期望采样数量
     // @param out_keys [out] 采样结果
     // @return EC_OK 成功；EC_ERROR 采样失败
-    virtual ErrorCode SampleReclaimKeys(const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
+    virtual ErrorCode
+    SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
 
     // =====================================================================
     // Metadata APIs — 用于持久化 MetaIndexer 自身的元信息（key_count、storage_usage 等）

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -561,10 +561,10 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(RequestContext 
                                                                  const KeyVector &keys,
                                                                  LocationIdsPerKey &out_location_ids) noexcept {
     if (!cache_backend_) {
-        return persistent_backend_->GetLocationIds(nullptr, keys, out_location_ids);
+        return persistent_backend_->GetLocationIds(request_context, keys, out_location_ids);
     }
 
-    std::vector<ErrorCode> results = cache_backend_->GetLocationIds(nullptr, keys, out_location_ids);
+    std::vector<ErrorCode> results = cache_backend_->GetLocationIds(request_context, keys, out_location_ids);
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
@@ -576,7 +576,7 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(RequestContext 
 
     LocationIdsPerKey persistent_location_ids;
     std::vector<ErrorCode> persistent_results =
-        persistent_backend_->GetLocationIds(nullptr, missing_keys, persistent_location_ids);
+        persistent_backend_->GetLocationIds(request_context, missing_keys, persistent_location_ids);
     if (missing_keys.size() != persistent_location_ids.size()) {
         KVCM_LOG_ERROR("persistent_location_ids size[%lu] mismatch keys's[%lu]",
                        persistent_location_ids.size(),

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -11,7 +11,6 @@
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_storage_backend_factory.h"
-#include "kv_cache_manager/metrics/metrics_collector.h"
 
 namespace kv_cache_manager {
 
@@ -19,28 +18,18 @@ namespace {
 constexpr int64_t kRecoverScanBatchSize = 1000;
 constexpr int kRecoverMaxConsecutiveFailures = 3;
 
-void SetIndexSerializeTimeUs(RequestContext *request_context, int64_t delta_us) noexcept {
-    if (request_context == nullptr || delta_us <= 0) {
-        return;
+// Collects keys where results[i] == EC_NOENT. Returns {missing_keys, missing_indices}.
+std::pair<KeyTypeVec, std::vector<size_t>> CollectMissingKeys(const KeyVector &keys,
+                                                              const std::vector<ErrorCode> &results) {
+    KeyTypeVec missing_keys;
+    std::vector<size_t> missing_indices;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (results[i] == EC_NOENT) {
+            missing_keys.push_back(keys[i]);
+            missing_indices.push_back(i);
+        }
     }
-    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
-    if (service_metrics_collector == nullptr) {
-        return;
-    }
-    KVCM_METRICS_COLLECTOR_SET_METRICS(
-        service_metrics_collector, meta_searcher, index_serialize_time_us, static_cast<double>(delta_us));
-}
-
-void SetIndexDeserializeTimeUs(RequestContext *request_context, int64_t delta_us) noexcept {
-    if (request_context == nullptr || delta_us <= 0) {
-        return;
-    }
-    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
-    if (service_metrics_collector == nullptr) {
-        return;
-    }
-    KVCM_METRICS_COLLECTOR_SET_METRICS(
-        service_metrics_collector, meta_searcher, index_deserialize_time_us, static_cast<double>(delta_us));
+    return {std::move(missing_keys), std::move(missing_indices)};
 }
 } // namespace
 
@@ -187,7 +176,8 @@ void MetaStorageBackendManager::AsyncRecoverTask() noexcept {
 
         scanned_keys.clear();
         field_maps.clear();
-        ErrorCode scan_ec = persistent_backend_->ListKeys(cursor, kRecoverScanBatchSize, next_cursor, scanned_keys);
+        ErrorCode scan_ec =
+            persistent_backend_->ListKeys(nullptr, cursor, kRecoverScanBatchSize, next_cursor, scanned_keys);
         if (scan_ec != EC_OK) {
             ++consecutive_failures;
             KVCM_LOG_ERROR("async recover scan failed, instance[%s] cursor[%s] ec[%d] attempt[%d/%d]",
@@ -205,18 +195,21 @@ void MetaStorageBackendManager::AsyncRecoverTask() noexcept {
             }
             continue;
         }
-        consecutive_failures = 0;
 
-        if (!scanned_keys.empty()) {
-            std::vector<ErrorCode> get_error_codes = persistent_backend_->GetAllFields(scanned_keys, field_maps);
-            for (size_t i = 0; i < scanned_keys.size(); ++i) {
-                if (get_error_codes[i] != EC_OK && get_error_codes[i] != EC_NOENT) {
-                    KVCM_LOG_WARN("async recover key[%ld] get failed ec[%d]", scanned_keys[i], get_error_codes[i]);
-                }
-            }
-            total_backfilled_keys += BackfillKeysToCache(scanned_keys, field_maps, get_error_codes);
-        }
+        consecutive_failures = 0;
         cursor = next_cursor;
+        if (scanned_keys.empty()) {
+            continue;
+        }
+        CacheLocationMapVector locations;
+        PropertyMapVector properties;
+        std::vector<ErrorCode> get_error_codes = persistent_backend_->Get(nullptr, scanned_keys, locations, properties);
+        for (size_t i = 0; i < scanned_keys.size(); ++i) {
+            if (get_error_codes[i] != EC_OK && get_error_codes[i] != EC_NOENT) {
+                KVCM_LOG_WARN("async recover key[%ld] get failed ec[%d]", scanned_keys[i], get_error_codes[i]);
+            }
+        }
+        total_backfilled_keys += BackfillKeysToCache(scanned_keys, locations, properties, get_error_codes);
     } while (cursor != SCAN_BASE_CURSOR);
 
     if (consecutive_failures == 0) {
@@ -235,12 +228,12 @@ void MetaStorageBackendManager::AsyncRecoverTask() noexcept {
     }
 }
 
-void MetaStorageBackendManager::EnsureKeyInCache(const KeyTypeVec &keys) noexcept {
+void MetaStorageBackendManager::EnsureKeyInCache(RequestContext *request_context, const KeyTypeVec &keys) noexcept {
     if (keys.empty()) {
         return;
     }
     std::vector<bool> exists_vec;
-    std::vector<ErrorCode> exists_results = cache_backend_->Exists(keys, exists_vec);
+    std::vector<ErrorCode> exists_results = cache_backend_->Exists(request_context, keys, exists_vec);
     KeyTypeVec missing_keys;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (exists_results[i] != EC_OK || !exists_vec[i]) {
@@ -251,125 +244,107 @@ void MetaStorageBackendManager::EnsureKeyInCache(const KeyTypeVec &keys) noexcep
         return;
     }
 
-    FieldMapVec field_maps;
-    std::vector<ErrorCode> get_results = persistent_backend_->GetAllFields(missing_keys, field_maps);
-    std::vector<ErrorCode> put_results = cache_backend_->Put(missing_keys, field_maps, get_results);
+    CacheLocationMapVector locations;
+    PropertyMapVector properties;
+    std::vector<ErrorCode> get_results = persistent_backend_->Get(request_context, missing_keys, locations, properties);
+    std::vector<ErrorCode> put_results =
+        cache_backend_->Put(request_context, missing_keys, locations, properties, get_results);
     for (size_t i = 0; i < missing_keys.size(); ++i) {
-        if (put_results[i] != EC_OK && put_results[i] != EC_NOENT) {
+        if (put_results[i] != EC_OK && get_results[i] == EC_OK) {
             KVCM_LOG_WARN("ensure key[%ld] in cache failed, ec[%d]", missing_keys[i], put_results[i]);
         }
     }
 }
 
 int64_t MetaStorageBackendManager::BackfillKeysToCache(const KeyTypeVec &keys,
-                                                       const FieldMapVec &field_maps,
+                                                       const CacheLocationMapVector &locations,
+                                                       const PropertyMapVector &properties,
                                                        const std::vector<ErrorCode> &get_error_codes) noexcept {
     std::lock_guard<std::mutex> lock(deleted_keys_mutex_);
 
+    // Merge get errors and deleted-key tombstones into a single error vector.
     assert(get_error_codes.size() == keys.size());
-    std::vector<ErrorCode> previous_error_codes(keys.size());
-    int64_t eligible_count = 0;
+    int64_t valid_count = 0;
+    std::vector<ErrorCode> merged_error_codes = get_error_codes;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (deleted_keys_.count(keys[i]) > 0) {
-            previous_error_codes[i] = EC_NOENT;
-        } else {
-            previous_error_codes[i] = get_error_codes[i];
-            eligible_count += (previous_error_codes[i] == EC_OK);
+        if (merged_error_codes[i] == EC_OK && deleted_keys_.count(keys[i]) > 0) {
+            merged_error_codes[i] = EC_NOENT;
         }
+        valid_count += (merged_error_codes[i] == EC_OK);
     }
-    if (eligible_count == 0) {
+    if (valid_count == 0) {
         return 0;
     }
 
-    std::vector<ErrorCode> put_results = cache_backend_->PutIfAbsent(keys, field_maps, previous_error_codes);
+    std::vector<ErrorCode> put_results =
+        cache_backend_->PutIfAbsent(nullptr, keys, locations, properties, merged_error_codes);
     int64_t backfilled_count = 0;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (put_results[i] == EC_OK) {
             ++backfilled_count;
-        } else if (put_results[i] != EC_NOENT) {
+        } else if (merged_error_codes[i] == EC_OK && put_results[i] != EC_NOENT) {
             KVCM_LOG_WARN("backfill PutIfAbsent failed key[%ld] ec[%d]", keys[i], put_results[i]);
         }
     }
     return backfilled_count;
 }
 
-std::string MetaStorageBackendManager::MakeLocationFieldName(const std::string &location_id) noexcept {
-    return LOCATION_PREFIX + location_id;
-}
-
-PropertyMapVector &MetaStorageBackendManager::BuildEffectiveFieldMaps(RequestContext *request_context,
-                                                                      BatchMetaData &batch) const noexcept {
-    const size_t key_count = batch.batch_keys.size();
-
-    // When the caller only supplied locations, grow it here to hold the upcoming location fields.
-    if (batch.batch_properties.empty()) {
-        batch.batch_properties.resize(key_count);
-    }
-    assert(batch.batch_properties.size() == key_count);
-
-    if (batch.batch_locations.empty()) {
-        return batch.batch_properties;
-    }
-
-    assert(batch.batch_locations.size() == key_count);
-    const int64_t begin_us = TimestampUtil::GetCurrentTimeUs();
-    for (size_t i = 0; i < key_count; ++i) {
-        for (const auto &loc_kv : batch.batch_locations[i]) {
-            const CacheLocation &location = loc_kv.second;
-            batch.batch_properties[i][MakeLocationFieldName(location.id())] = location.ToJsonString();
-        }
-    }
-    SetIndexSerializeTimeUs(request_context, TimestampUtil::GetCurrentTimeUs() - begin_us);
-    return batch.batch_properties;
-}
-
 std::vector<ErrorCode> MetaStorageBackendManager::Put(RequestContext *request_context, BatchMetaData &batch) noexcept {
-    const auto &keys = batch.batch_keys;
-    PropertyMapVector &effective = BuildEffectiveFieldMaps(request_context, batch);
-    std::vector<ErrorCode> persistent_results = persistent_backend_->Put(keys, effective);
+    const KeyVector &keys = batch.batch_keys;
+    batch.EnsureLocationsAndPropertiesResized();
+    CacheLocationMapVector &locations = batch.batch_locations;
+    PropertyMapVector &properties = batch.batch_properties;
+    std::vector<ErrorCode> persistent_results = persistent_backend_->Put(request_context, keys, locations, properties);
     if (!cache_backend_) {
         return persistent_results;
     }
-    return cache_backend_->Put(keys, effective, persistent_results);
+    return cache_backend_->Put(request_context, keys, locations, properties, persistent_results);
 }
 
 std::vector<ErrorCode> MetaStorageBackendManager::UpdateFields(RequestContext *request_context,
                                                                BatchMetaData &batch) noexcept {
-    const auto &keys = batch.batch_keys;
-    PropertyMapVector &effective = BuildEffectiveFieldMaps(request_context, batch);
+    const KeyVector &keys = batch.batch_keys;
+    batch.EnsureLocationsAndPropertiesResized();
+    CacheLocationMapVector &locations = batch.batch_locations;
+    PropertyMapVector &properties = batch.batch_properties;
 
     // Partial-update during Recover: hydrate cache from persistent first so
     // the conditional mirror write below has the full pre-restart field set
     // to update against (and async backfill cannot later overwrite us).
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
-        EnsureKeyInCache(keys);
+        EnsureKeyInCache(request_context, keys);
     }
-    std::vector<ErrorCode> persistent_results = persistent_backend_->UpdateFields(keys, effective);
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->Update(request_context, keys, locations, properties);
     if (!cache_backend_) {
         return persistent_results;
     }
-    return cache_backend_->UpdateFields(keys, effective, persistent_results);
+    return cache_backend_->Update(request_context, keys, locations, properties, persistent_results);
 }
 
 std::vector<ErrorCode> MetaStorageBackendManager::Upsert(RequestContext *request_context,
                                                          BatchMetaData &batch) noexcept {
-    const auto &keys = batch.batch_keys;
-    PropertyMapVector &effective = BuildEffectiveFieldMaps(request_context, batch);
+    const KeyVector &keys = batch.batch_keys;
+    batch.EnsureLocationsAndPropertiesResized();
+    CacheLocationMapVector &locations = batch.batch_locations;
+    PropertyMapVector &properties = batch.batch_properties;
 
     // See UpdateFields(): Upsert may also touch only a subset of fields, so
     // the same Recover-time hydration is needed.
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
-        EnsureKeyInCache(keys);
+        EnsureKeyInCache(request_context, keys);
     }
-    std::vector<ErrorCode> persistent_results = persistent_backend_->Upsert(keys, effective);
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->Upsert(request_context, keys, locations, properties);
     if (!cache_backend_) {
         return persistent_results;
     }
-    return cache_backend_->Upsert(keys, effective, persistent_results);
+    return cache_backend_->Upsert(request_context, keys, locations, properties, persistent_results);
 }
 
-std::vector<ErrorCode> MetaStorageBackendManager::Delete(const KeyVector &keys) noexcept {
-    std::vector<ErrorCode> persistent_results = persistent_backend_->Delete(keys);
+std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request_context,
+                                                         const KeyVector &keys) noexcept {
+    std::vector<ErrorCode> persistent_results = persistent_backend_->Delete(request_context, keys);
     if (!cache_backend_) {
         return persistent_results;
     }
@@ -380,10 +355,11 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(const KeyVector &keys) 
             deleted_keys_.insert(key);
         }
     }
-    return cache_backend_->Delete(keys, persistent_results);
+    return cache_backend_->Delete(request_context, keys, persistent_results);
 }
 
-std::vector<ErrorCode> MetaStorageBackendManager::Delete(const KeyVector &keys,
+std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request_context,
+                                                         const KeyVector &keys,
                                                          const LocationIdsPerKey &location_ids,
                                                          int32_t &out_reclaimed_count) noexcept {
     out_reclaimed_count = 0;
@@ -396,35 +372,24 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(const KeyVector &keys,
     // the conditional mirror write below has the full pre-restart field set
     // to delete against (and async backfill cannot later overwrite us).
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
-        EnsureKeyInCache(keys);
+        EnsureKeyInCache(request_context, keys);
     }
 
-    std::vector<std::vector<std::string>> field_names_vec(keys.size());
-    bool any_field_to_delete = false;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        field_names_vec[i].reserve(location_ids[i].size());
-        for (const auto &id : location_ids[i]) {
-            field_names_vec[i].emplace_back(MakeLocationFieldName(id));
-        }
-        any_field_to_delete = any_field_to_delete || !field_names_vec[i].empty();
-    }
-    if (!any_field_to_delete) {
-        return std::vector<ErrorCode>(keys.size(), EC_OK);
-    }
-
-    std::vector<ErrorCode> persistent_results = persistent_backend_->DeleteFields(keys, field_names_vec);
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->DeleteLocations(request_context, keys, location_ids);
     std::vector<ErrorCode> results;
     if (!cache_backend_) {
         results = std::move(persistent_results);
     } else {
-        results = cache_backend_->DeleteFields(keys, field_names_vec, persistent_results);
+        results = cache_backend_->DeleteLocations(request_context, keys, location_ids, persistent_results);
     }
 
-    out_reclaimed_count = MaybeReclaimEmptyKeys(keys, results);
+    out_reclaimed_count = MaybeReclaimEmptyKeys(request_context, keys, results);
     return results;
 }
 
-int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(const KeyVector &keys,
+int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(RequestContext *request_context,
+                                                         const KeyVector &keys,
                                                          const std::vector<ErrorCode> &delete_results) noexcept {
     KeyVector candidate_keys;
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -439,9 +404,9 @@ int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(const KeyVector &keys,
     std::vector<bool> has_locations;
     std::vector<ErrorCode> exists_ecs;
     if (cache_backend_) {
-        exists_ecs = cache_backend_->ExistsFieldWithPrefix(candidate_keys, LOCATION_PREFIX, has_locations);
+        exists_ecs = cache_backend_->ExistsLocation(request_context, candidate_keys, has_locations);
     } else {
-        exists_ecs = persistent_backend_->ExistsFieldWithPrefix(candidate_keys, LOCATION_PREFIX, has_locations);
+        exists_ecs = persistent_backend_->ExistsLocation(request_context, candidate_keys, has_locations);
     }
 
     KeyVector reclaimed_keys;
@@ -454,7 +419,7 @@ int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(const KeyVector &keys,
         return 0;
     }
 
-    std::vector<ErrorCode> whole_ecs = Delete(reclaimed_keys);
+    std::vector<ErrorCode> whole_ecs = Delete(request_context, reclaimed_keys);
     int32_t reclaimed = 0;
     for (const ErrorCode ec : whole_ecs) {
         if (ec == EC_OK || ec == EC_NOENT) {
@@ -464,36 +429,32 @@ int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(const KeyVector &keys,
     return reclaimed;
 }
 
-std::vector<ErrorCode> MetaStorageBackendManager::Get(const KeyVector &keys,
-                                                      const std::vector<std::string> &field_names,
-                                                      FieldMapVec &out_field_maps) noexcept {
+std::vector<ErrorCode> MetaStorageBackendManager::Get(RequestContext *request_context,
+                                                      const KeyVector &keys,
+                                                      CacheLocationMapVector &out_locations,
+                                                      PropertyMapVector &out_properties) noexcept {
     if (!cache_backend_) {
-        return persistent_backend_->Get(keys, field_names, out_field_maps);
+        return persistent_backend_->Get(request_context, keys, out_locations, out_properties);
     }
 
-    std::vector<ErrorCode> results = cache_backend_->Get(keys, field_names, out_field_maps);
+    std::vector<ErrorCode> results = cache_backend_->Get(request_context, keys, out_locations, out_properties);
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
 
-    KeyTypeVec missing_keys;
-    std::vector<size_t> missing_indices;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (results[i] == EC_NOENT) {
-            missing_keys.push_back(keys[i]);
-            missing_indices.push_back(i);
-        }
-    }
+    auto [missing_keys, missing_indices] = CollectMissingKeys(keys, results);
     if (missing_keys.empty()) {
         return results;
     }
 
-    FieldMapVec persistent_field_maps;
+    CacheLocationMapVector persistent_locations;
+    PropertyMapVector persistent_properties;
     std::vector<ErrorCode> persistent_results =
-        persistent_backend_->Get(missing_keys, field_names, persistent_field_maps);
-    if (missing_keys.size() != persistent_field_maps.size()) {
-        KVCM_LOG_ERROR("persistent_field_maps size[%lu] mismatch missing_keys's[%lu]",
-                       persistent_field_maps.size(),
+        persistent_backend_->Get(request_context, missing_keys, persistent_locations, persistent_properties);
+    if (missing_keys.size() != persistent_locations.size() || missing_keys.size() != persistent_properties.size()) {
+        KVCM_LOG_ERROR("persistent Get size mismatch: locations[%lu] properties[%lu] vs keys[%lu]",
+                       persistent_locations.size(),
+                       persistent_properties.size(),
                        missing_keys.size());
         for (size_t i = 0; i < missing_keys.size(); ++i) {
             results[missing_indices[i]] = EC_ERROR;
@@ -503,129 +464,49 @@ std::vector<ErrorCode> MetaStorageBackendManager::Get(const KeyVector &keys,
     for (size_t i = 0; i < missing_keys.size(); ++i) {
         const size_t original_idx = missing_indices[i];
         results[original_idx] = persistent_results[i];
-        out_field_maps[original_idx] = std::move(persistent_field_maps[i]);
-    }
-    return results;
-}
-
-std::vector<ErrorCode> MetaStorageBackendManager::Get(const KeyVector &keys,
-                                                      const std::vector<std::vector<std::string>> &field_names_vec,
-                                                      FieldMapVec &out_field_maps) noexcept {
-    if (!cache_backend_) {
-        return persistent_backend_->Get(keys, field_names_vec, out_field_maps);
-    }
-
-    std::vector<ErrorCode> results = cache_backend_->Get(keys, field_names_vec, out_field_maps);
-    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
-        return results;
-    }
-
-    KeyTypeVec missing_keys;
-    std::vector<std::vector<std::string>> missing_field_names;
-    std::vector<size_t> missing_indices;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (results[i] == EC_NOENT) {
-            missing_keys.push_back(keys[i]);
-            missing_field_names.push_back(field_names_vec[i]);
-            missing_indices.push_back(i);
+        if (persistent_results[i] == EC_OK) {
+            out_locations[original_idx] = std::move(persistent_locations[i]);
+            out_properties[original_idx] = std::move(persistent_properties[i]);
         }
-    }
-    if (missing_keys.empty()) {
-        return results;
-    }
-
-    FieldMapVec persistent_field_maps;
-    std::vector<ErrorCode> persistent_results =
-        persistent_backend_->Get(missing_keys, missing_field_names, persistent_field_maps);
-    if (missing_keys.size() != persistent_field_maps.size()) {
-        KVCM_LOG_ERROR("persistent_field_maps size[%lu] mismatch missing_keys's[%lu]",
-                       persistent_field_maps.size(),
-                       missing_keys.size());
-        for (size_t i = 0; i < missing_keys.size(); ++i) {
-            results[missing_indices[i]] = EC_ERROR;
-        }
-        return results;
-    }
-    for (size_t i = 0; i < missing_keys.size(); ++i) {
-        const size_t original_idx = missing_indices[i];
-        results[original_idx] = persistent_results[i];
-        out_field_maps[original_idx] = std::move(persistent_field_maps[i]);
-    }
-    return results;
-}
-
-std::vector<ErrorCode> MetaStorageBackendManager::GetAllFields(const KeyVector &keys,
-                                                               FieldMapVec &out_field_maps) noexcept {
-    if (!cache_backend_) {
-        return persistent_backend_->GetAllFields(keys, out_field_maps);
-    }
-
-    std::vector<ErrorCode> results = cache_backend_->GetAllFields(keys, out_field_maps);
-    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
-        return results;
-    }
-
-    KeyTypeVec missing_keys;
-    std::vector<size_t> missing_indices;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (results[i] == EC_NOENT) {
-            missing_keys.push_back(keys[i]);
-            missing_indices.push_back(i);
-        }
-    }
-    if (missing_keys.empty()) {
-        return results;
-    }
-
-    FieldMapVec persistent_field_maps;
-    std::vector<ErrorCode> persistent_results = persistent_backend_->GetAllFields(missing_keys, persistent_field_maps);
-    if (missing_keys.size() != persistent_field_maps.size()) {
-        KVCM_LOG_ERROR("persistent_field_maps size[%lu] mismatch missing_keys's[%lu]",
-                       persistent_field_maps.size(),
-                       missing_keys.size());
-        for (size_t i = 0; i < missing_keys.size(); ++i) {
-            results[missing_indices[i]] = EC_ERROR;
-        }
-        return results;
-    }
-    for (size_t i = 0; i < missing_keys.size(); ++i) {
-        const size_t original_idx = missing_indices[i];
-        results[original_idx] = persistent_results[i];
-        out_field_maps[original_idx] = std::move(persistent_field_maps[i]);
     }
     return results;
 }
 
 std::vector<ErrorCode> MetaStorageBackendManager::GetLocations(RequestContext *request_context,
                                                                const KeyVector &keys,
-                                                               LocationMapVector &out_location_maps) noexcept {
-    FieldMapVec field_maps;
-    std::vector<ErrorCode> results = GetAllFields(keys, field_maps);
+                                                               CacheLocationMapVector &out_location_maps) noexcept {
+    if (!cache_backend_) {
+        return persistent_backend_->GetLocations(request_context, keys, out_location_maps);
+    }
 
-    out_location_maps.clear();
-    out_location_maps.resize(keys.size());
-    const int64_t begin_us = TimestampUtil::GetCurrentTimeUs();
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (results[i] != EC_OK) {
-            continue;
+    std::vector<ErrorCode> results = cache_backend_->GetLocations(request_context, keys, out_location_maps);
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        return results;
+    }
+
+    auto [missing_keys, missing_indices] = CollectMissingKeys(keys, results);
+    if (missing_keys.empty()) {
+        return results;
+    }
+
+    CacheLocationMapVector persistent_locations;
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->GetLocations(request_context, missing_keys, persistent_locations);
+    if (missing_keys.size() != persistent_locations.size()) {
+        KVCM_LOG_ERROR(
+            "persistent_locations size[%lu] mismatch keys's[%lu]", persistent_locations.size(), missing_keys.size());
+        for (size_t i = 0; i < missing_keys.size(); ++i) {
+            results[missing_indices[i]] = EC_ERROR;
         }
-        for (const auto &field_kv : field_maps[i]) {
-            const std::string &field_name = field_kv.first;
-            const std::string &field_value = field_kv.second;
-            if (field_name.compare(0, LOCATION_PREFIX.size(), LOCATION_PREFIX) != 0 || field_value.empty()) {
-                continue;
-            }
-            CacheLocation location;
-            if (!location.FromJsonString(field_value)) {
-                KVCM_LOG_ERROR("deserialize CacheLocation failed, key[%ld] field[%s]", keys[i], field_name.c_str());
-                results[i] = EC_CORRUPTION;
-                out_location_maps[i].clear();
-                break;
-            }
-            out_location_maps[i].emplace(location.id(), std::move(location));
+        return results;
+    }
+    for (size_t i = 0; i < missing_keys.size(); ++i) {
+        const size_t original_idx = missing_indices[i];
+        results[original_idx] = persistent_results[i];
+        if (persistent_results[i] == EC_OK) {
+            out_location_maps[original_idx] = std::move(persistent_locations[i]);
         }
     }
-    SetIndexDeserializeTimeUs(request_context, TimestampUtil::GetCurrentTimeUs() - begin_us);
     return results;
 }
 
@@ -633,128 +514,134 @@ std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(Requ
                                                                             const KeyVector &keys,
                                                                             const LocationIdsPerKey &location_ids,
                                                                             LocationsPerKey &out_locations) noexcept {
-    assert(keys.size() == location_ids.size());
-    std::vector<std::vector<ErrorCode>> results(keys.size());
-    out_locations.clear();
-    out_locations.resize(keys.size());
-    if (keys.empty()) {
+    if (!cache_backend_) {
+        return persistent_backend_->GetLocations(request_context, keys, location_ids, out_locations);
+    }
+
+    std::vector<std::vector<ErrorCode>> results =
+        cache_backend_->GetLocations(request_context, keys, location_ids, out_locations);
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
 
-    // Build per-key field name vectors from location ids.
-    std::vector<std::vector<std::string>> field_names_vec(keys.size());
+    KeyTypeVec missing_keys;
+    std::vector<size_t> missing_indices;
+    LocationIdsPerKey missing_location_ids;
     for (size_t i = 0; i < keys.size(); ++i) {
-        field_names_vec[i].reserve(location_ids[i].size());
-        for (const auto &id : location_ids[i]) {
-            field_names_vec[i].emplace_back(MakeLocationFieldName(id));
+        if (!results[i].empty() && results[i][0] == EC_NOENT) {
+            missing_keys.push_back(keys[i]);
+            missing_indices.push_back(i);
+            missing_location_ids.push_back(location_ids[i]);
         }
     }
-
-    // Delegate to the per-key field names Get which already handles
-    // cache-first with persistent Recover fallback.
-    FieldMapVec field_maps;
-    std::vector<ErrorCode> get_results = Get(keys, field_names_vec, field_maps);
-
-    // Deserialize the returned field values into CacheLocations.
-    const int64_t begin_us = TimestampUtil::GetCurrentTimeUs();
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (get_results[i] != EC_OK) {
-            results[i].assign(location_ids[i].size(), get_results[i]);
-            continue;
-        }
-        results[i].assign(location_ids[i].size(), EC_OK);
-        out_locations[i].resize(location_ids[i].size());
-        const auto &fields = field_maps[i];
-        for (size_t j = 0; j < location_ids[i].size(); ++j) {
-            const std::string &field_name = field_names_vec[i][j];
-            auto it = fields.find(field_name);
-            // Empty value is a tombstone left by historical Delete(batch, location_ids)
-            // writes that overwrote the field with "" instead of deleting it.
-            if (it == fields.end() || it->second.empty()) {
-                results[i][j] = EC_NOENT;
-                continue;
-            }
-            CacheLocation location;
-            if (!location.FromJsonString(it->second)) {
-                KVCM_LOG_ERROR(
-                    "deserialize CacheLocation failed, key[%ld] location_id[%s]", keys[i], location_ids[i][j].c_str());
-                results[i][j] = EC_CORRUPTION;
-                continue;
-            }
-            out_locations[i][j] = std::move(location);
-        }
+    if (missing_keys.empty()) {
+        return results;
     }
-    SetIndexDeserializeTimeUs(request_context, TimestampUtil::GetCurrentTimeUs() - begin_us);
+
+    LocationsPerKey persistent_locations;
+    std::vector<std::vector<ErrorCode>> persistent_results =
+        persistent_backend_->GetLocations(request_context, missing_keys, missing_location_ids, persistent_locations);
+    if (missing_keys.size() != persistent_results.size()) {
+        KVCM_LOG_ERROR(
+            "persistent results size[%lu] mismatch keys's[%lu]", persistent_results.size(), missing_keys.size());
+        for (size_t i = 0; i < missing_keys.size(); ++i) {
+            results[missing_indices[i]].assign(location_ids[missing_indices[i]].size(), EC_ERROR);
+        }
+        return results;
+    }
+    for (size_t i = 0; i < missing_keys.size(); ++i) {
+        const size_t original_idx = missing_indices[i];
+        results[original_idx] = std::move(persistent_results[i]);
+        out_locations[original_idx] = std::move(persistent_locations[i]);
+    }
     return results;
 }
 
-std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(const KeyVector &keys,
+std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(RequestContext *request_context,
+                                                                 const KeyVector &keys,
                                                                  LocationIdsPerKey &out_location_ids) noexcept {
-    out_location_ids.clear();
-    if (keys.empty()) {
-        return {};
+    if (!cache_backend_) {
+        return persistent_backend_->GetLocationIds(nullptr, keys, out_location_ids);
     }
 
-    std::vector<std::vector<std::string>> field_names_vec;
-    std::vector<ErrorCode> results;
-    if (cache_backend_) {
-        results = cache_backend_->GetFieldNamesWithPrefix(keys, LOCATION_PREFIX, field_names_vec);
-        if (recover_state_.load(std::memory_order_acquire) != RecoverState::kRunning) {
-            KeyTypeVec missing_keys;
-            std::vector<size_t> missing_indices;
-            for (size_t i = 0; i < keys.size(); ++i) {
-                if (results[i] == EC_NOENT) {
-                    missing_keys.push_back(keys[i]);
-                    missing_indices.push_back(i);
-                }
-            }
-            if (!missing_keys.empty()) {
-                std::vector<std::vector<std::string>> persistent_field_names;
-                std::vector<ErrorCode> persistent_results =
-                    persistent_backend_->GetFieldNamesWithPrefix(missing_keys, LOCATION_PREFIX, persistent_field_names);
-                if (missing_keys.size() != persistent_field_names.size()) {
-                    KVCM_LOG_ERROR("persistent_field_names size[%lu] mismatch missing_keys's[%lu]",
-                                   persistent_field_names.size(),
-                                   missing_keys.size());
-                    for (size_t i = 0; i < missing_keys.size(); ++i) {
-                        results[missing_indices[i]] = EC_ERROR;
-                    }
-                    return results;
-                }
-                for (size_t i = 0; i < missing_keys.size(); ++i) {
-                    const size_t original_idx = missing_indices[i];
-                    results[original_idx] = persistent_results[i];
-                    field_names_vec[original_idx] = std::move(persistent_field_names[i]);
-                }
-            }
-        }
-    } else {
-        results = persistent_backend_->GetFieldNamesWithPrefix(keys, LOCATION_PREFIX, field_names_vec);
+    std::vector<ErrorCode> results = cache_backend_->GetLocationIds(nullptr, keys, out_location_ids);
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        return results;
     }
 
-    // Strip LOCATION_PREFIX from field names to produce location ids.
-    out_location_ids.resize(keys.size());
-    const size_t prefix_len = LOCATION_PREFIX.size();
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (results[i] != EC_OK || field_names_vec[i].empty()) {
-            continue;
+    auto [missing_keys, missing_indices] = CollectMissingKeys(keys, results);
+    if (missing_keys.empty()) {
+        return results;
+    }
+
+    LocationIdsPerKey persistent_location_ids;
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->GetLocationIds(nullptr, missing_keys, persistent_location_ids);
+    if (missing_keys.size() != persistent_location_ids.size()) {
+        KVCM_LOG_ERROR("persistent_location_ids size[%lu] mismatch keys's[%lu]",
+                       persistent_location_ids.size(),
+                       missing_keys.size());
+        for (size_t i = 0; i < missing_keys.size(); ++i) {
+            results[missing_indices[i]] = EC_ERROR;
         }
-        out_location_ids[i].reserve(field_names_vec[i].size());
-        for (auto &field_name : field_names_vec[i]) {
-            if (field_name.size() > prefix_len) {
-                out_location_ids[i].emplace_back(field_name.substr(prefix_len));
-            }
+        return results;
+    }
+    for (size_t i = 0; i < missing_keys.size(); ++i) {
+        const size_t original_idx = missing_indices[i];
+        results[original_idx] = persistent_results[i];
+        if (persistent_results[i] == EC_OK) {
+            out_location_ids[original_idx] = std::move(persistent_location_ids[i]);
         }
     }
     return results;
 }
 
-std::vector<ErrorCode> MetaStorageBackendManager::Exists(const KeyVector &keys,
+std::vector<ErrorCode> MetaStorageBackendManager::GetProperties(RequestContext *request_context,
+                                                                const KeyVector &keys,
+                                                                const std::vector<std::string> &field_names,
+                                                                PropertyMapVector &out_properties) noexcept {
+    if (!cache_backend_) {
+        return persistent_backend_->GetProperties(request_context, keys, field_names, out_properties);
+    }
+
+    std::vector<ErrorCode> results = cache_backend_->GetProperties(request_context, keys, field_names, out_properties);
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        return results;
+    }
+
+    auto [missing_keys, missing_indices] = CollectMissingKeys(keys, results);
+    if (missing_keys.empty()) {
+        return results;
+    }
+
+    PropertyMapVector persistent_properties;
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->GetProperties(request_context, missing_keys, field_names, persistent_properties);
+    if (missing_keys.size() != persistent_properties.size()) {
+        KVCM_LOG_ERROR(
+            "persistent_properties size[%lu] mismatch keys's[%lu]", persistent_properties.size(), missing_keys.size());
+        for (size_t i = 0; i < missing_keys.size(); ++i) {
+            results[missing_indices[i]] = EC_ERROR;
+        }
+        return results;
+    }
+    for (size_t i = 0; i < missing_keys.size(); ++i) {
+        const size_t original_idx = missing_indices[i];
+        results[original_idx] = persistent_results[i];
+        if (persistent_results[i] == EC_OK) {
+            out_properties[original_idx] = std::move(persistent_properties[i]);
+        }
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaStorageBackendManager::Exists(RequestContext *request_context,
+                                                         const KeyVector &keys,
                                                          std::vector<bool> &out_is_exist_vec) noexcept {
     if (!cache_backend_) {
-        return persistent_backend_->Exists(keys, out_is_exist_vec);
+        return persistent_backend_->Exists(request_context, keys, out_is_exist_vec);
     }
-    std::vector<ErrorCode> results = cache_backend_->Exists(keys, out_is_exist_vec);
+    std::vector<ErrorCode> results = cache_backend_->Exists(request_context, keys, out_is_exist_vec);
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
@@ -772,7 +659,8 @@ std::vector<ErrorCode> MetaStorageBackendManager::Exists(const KeyVector &keys,
     }
 
     std::vector<bool> persistent_exists;
-    std::vector<ErrorCode> persistent_results = persistent_backend_->Exists(missing_keys, persistent_exists);
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->Exists(request_context, missing_keys, persistent_exists);
     if (missing_keys.size() != persistent_exists.size()) {
         KVCM_LOG_ERROR(
             "persistent_exists size[%lu] mismatch missing_keys's[%lu]", persistent_exists.size(), missing_keys.size());
@@ -789,24 +677,29 @@ std::vector<ErrorCode> MetaStorageBackendManager::Exists(const KeyVector &keys,
     return results;
 }
 
-ErrorCode MetaStorageBackendManager::ListKeys(const std::string &cursor,
+ErrorCode MetaStorageBackendManager::ListKeys(RequestContext *request_context,
+                                              const std::string &cursor,
                                               const int64_t limit,
                                               std::string &out_next_cursor,
                                               KeyTypeVec &out_keys) noexcept {
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
-        return cache_backend_->ListKeys(cursor, limit, out_next_cursor, out_keys);
+        return cache_backend_->ListKeys(request_context, cursor, limit, out_next_cursor, out_keys);
     }
-    return persistent_backend_->ListKeys(cursor, limit, out_next_cursor, out_keys);
+    return persistent_backend_->ListKeys(request_context, cursor, limit, out_next_cursor, out_keys);
 }
 
-ErrorCode MetaStorageBackendManager::RandomSample(const int64_t count, KeyTypeVec &out_keys) noexcept {
+ErrorCode MetaStorageBackendManager::RandomSample(RequestContext *request_context,
+                                                  const int64_t count,
+                                                  KeyTypeVec &out_keys) noexcept {
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
-        return cache_backend_->RandomSample(count, out_keys);
+        return cache_backend_->RandomSample(request_context, count, out_keys);
     }
-    return persistent_backend_->RandomSample(count, out_keys);
+    return persistent_backend_->RandomSample(request_context, count, out_keys);
 }
 
-ErrorCode MetaStorageBackendManager::SampleReclaimKeys(const int64_t count, KeyTypeVec &out_keys) noexcept {
+ErrorCode MetaStorageBackendManager::SampleReclaimKeys(RequestContext *request_context,
+                                                       const int64_t count,
+                                                       KeyTypeVec &out_keys) noexcept {
     if (count <= 0) {
         return EC_OK;
     }
@@ -814,9 +707,9 @@ ErrorCode MetaStorageBackendManager::SampleReclaimKeys(const int64_t count, KeyT
     // so we still go to persistent to avoid biased reclamation. In single-
     // backend mode (no cache) we always go to persistent.
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
-        return cache_backend_->SampleReclaimKeys(count, out_keys);
+        return cache_backend_->SampleReclaimKeys(request_context, count, out_keys);
     }
-    return persistent_backend_->SampleReclaimKeys(count, out_keys);
+    return persistent_backend_->SampleReclaimKeys(request_context, count, out_keys);
 }
 
 ErrorCode MetaStorageBackendManager::PutMetaData(const FieldMap &field_maps) noexcept {

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -44,41 +44,45 @@ public:
     RecoverState GetRecoverState() const noexcept { return recover_state_.load(std::memory_order_acquire); }
 
     // ----- Write APIs -----
-    // Put / UpdateFields / Upsert merge CacheLocations into batch.batch_properties in place.
     std::vector<ErrorCode> Put(RequestContext *request_context, BatchMetaData &batch) noexcept;
     std::vector<ErrorCode> UpdateFields(RequestContext *request_context, BatchMetaData &batch) noexcept;
     std::vector<ErrorCode> Upsert(RequestContext *request_context, BatchMetaData &batch) noexcept;
-
-    // Delete entire block keys.
-    std::vector<ErrorCode> Delete(const KeyVector &keys) noexcept;
-
-    // Delete specific location fields within each key.
-    std::vector<ErrorCode>
-    Delete(const KeyVector &keys, const LocationIdsPerKey &location_ids, int32_t &out_reclaimed_count) noexcept;
+    std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyVector &keys) noexcept;
+    std::vector<ErrorCode> Delete(RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const LocationIdsPerKey &location_ids,
+                                  int32_t &out_reclaimed_count) noexcept;
 
     // ----- Read APIs -----
-    std::vector<ErrorCode>
-    Get(const KeyVector &keys, const std::vector<std::string> &field_names, FieldMapVec &out_field_maps) noexcept;
-    std::vector<ErrorCode> Get(const KeyVector &keys,
-                               const std::vector<std::vector<std::string>> &field_names_vec,
-                               FieldMapVec &out_field_maps) noexcept;
-    std::vector<ErrorCode> GetAllFields(const KeyVector &keys, FieldMapVec &out_field_maps) noexcept;
-    std::vector<ErrorCode>
-    GetLocations(RequestContext *request_context, const KeyVector &keys, LocationMapVector &out_location_maps) noexcept;
+    std::vector<ErrorCode> Get(RequestContext *request_context,
+                               const KeyVector &keys,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties) noexcept;
+    std::vector<ErrorCode> GetLocations(RequestContext *request_context,
+                                        const KeyVector &keys,
+                                        CacheLocationMapVector &out_location_maps) noexcept;
     std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
                                                      const KeyVector &keys,
                                                      const LocationIdsPerKey &location_ids,
                                                      LocationsPerKey &out_locations) noexcept;
-    std::vector<ErrorCode> GetLocationIds(const KeyVector &keys, LocationIdsPerKey &out_location_ids) noexcept;
-    std::vector<ErrorCode> Exists(const KeyVector &keys, std::vector<bool> &out_is_exist_vec) noexcept;
+    std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
+                                          const KeyVector &keys,
+                                          LocationIdsPerKey &out_location_ids) noexcept;
+    std::vector<ErrorCode> GetProperties(RequestContext *request_context,
+                                         const KeyVector &keys,
+                                         const std::vector<std::string> &field_names,
+                                         PropertyMapVector &out_properties) noexcept;
+    std::vector<ErrorCode>
+    Exists(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_is_exist_vec) noexcept;
 
     // ----- Cross-batch APIs (no shard locks) -----
-    ErrorCode ListKeys(const std::string &cursor,
+    ErrorCode ListKeys(RequestContext *request_context,
+                       const std::string &cursor,
                        const int64_t limit,
                        std::string &out_next_cursor,
                        KeyTypeVec &out_keys) noexcept;
-    ErrorCode RandomSample(const int64_t count, KeyTypeVec &out_keys) noexcept;
-    ErrorCode SampleReclaimKeys(const int64_t count, KeyTypeVec &out_keys) noexcept;
+    ErrorCode RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept;
+    ErrorCode SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept;
 
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept;
@@ -88,16 +92,15 @@ public:
 private:
     void AsyncRecoverTask() noexcept;
     int64_t BackfillKeysToCache(const KeyTypeVec &keys,
-                                const FieldMapVec &field_maps,
+                                const CacheLocationMapVector &locations,
+                                const PropertyMapVector &properties,
                                 const std::vector<ErrorCode> &get_error_codes) noexcept;
     // Hydrate missing keys from persistent into cache during Recover.
-    void EnsureKeyInCache(const KeyTypeVec &keys) noexcept;
-    // Merge CacheLocations into batch.batch_properties in place. Accumulates
-    // serialization latency onto `request_context` when non-null.
-    PropertyMapVector &BuildEffectiveFieldMaps(RequestContext *request_context, BatchMetaData &batch) const noexcept;
-    static std::string MakeLocationFieldName(const std::string &location_id) noexcept;
+    void EnsureKeyInCache(RequestContext *request_context, const KeyTypeVec &keys) noexcept;
     // Delete keys that have no remaining location fields. Returns reclaimed count.
-    int32_t MaybeReclaimEmptyKeys(const KeyVector &keys, const std::vector<ErrorCode> &delete_results) noexcept;
+    int32_t MaybeReclaimEmptyKeys(RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const std::vector<ErrorCode> &delete_results) noexcept;
 
     std::string instance_id_;
     std::unique_ptr<MetaStorageBackend> persistent_backend_;

--- a/kv_cache_manager/meta/test/BUILD
+++ b/kv_cache_manager/meta/test/BUILD
@@ -64,6 +64,7 @@ cc_library(
     ],
     copts = ["-fno-access-control"],
     deps = [
+        "//kv_cache_manager/meta:meta_cache_base_backend",
         "//kv_cache_manager/meta:meta_storage_backend",
         "//kv_cache_manager/meta:meta_redis_backend",
         "@com_google_googletest//:gtest",

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -55,19 +55,19 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(), {1, 2}, {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->UpdateFields({1, 2}, {{{"f2", "v1-2"}}, {{"f2", "v2-2"}}}));
+              UpdateWithFieldMaps(meta_storage_backend_.get(), {1, 2}, {{{"f2", "v1-2"}}, {{"f2", "v2-2"}}}));
 
     AssertExists(meta_storage_backend_.get(),
                  {1, 2, 3},
                  {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
                  /*is_exist*/ {true, true, false});
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
     AssertListKeys(
         meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, ErrorCode::EC_OK, SCAN_BASE_CURSOR, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
@@ -80,22 +80,22 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
                  (std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
                  /*is_exist*/ {true, true, false});
 
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}), meta_storage_backend_->Delete({1}));
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}), meta_storage_backend_->Delete({1}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}), meta_storage_backend_->Delete(nullptr, {1}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}), meta_storage_backend_->Delete(nullptr, {1}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(), {3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->UpdateFields({2}, {{{"f1", "v2-1-1"}}}));
+              UpdateWithFieldMaps(meta_storage_backend_.get(), {2}, {{{"f1", "v2-1-1"}}}));
 
     AssertExists(meta_storage_backend_.get(),
                  {1, 2, 3},
                  {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
                  /*is_exist*/ {false, true, true});
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2, 3},
-              {"f1", "f2"},
-              {ErrorCode::EC_NOENT, ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{}, {{"f1", "v2-1-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}});
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2, 3},
+                        {"f1", "f2"},
+                        {ErrorCode::EC_NOENT, ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{}, {{"f1", "v2-1-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}});
     AssertListKeys(
         meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, ErrorCode::EC_OK, SCAN_BASE_CURSOR, {2, 3});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {2, 3});
@@ -114,20 +114,23 @@ TEST_F(MetaDummyBackendTest, TestPut) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
 
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}})); // cover old value
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2", "f3"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+    ASSERT_EQ(
+        (std::vector<ErrorCode>{ErrorCode::EC_OK}),
+        PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}})); // cover old value
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2", "f3"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
@@ -137,25 +140,28 @@ TEST_F(MetaDummyBackendTest, TestUpdateFields) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->UpdateFields(
-                  {1, 2}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2-1"}}})); // merge old value
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2", "f3"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2-1"}}});
+              UpdateWithFieldMaps(meta_storage_backend_.get(),
+                                  {1, 2},
+                                  {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2-1"}}})); // merge old value
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2", "f3"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2-1"}}});
 
     // can not update key that dont exist
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT}),
-              meta_storage_backend_->UpdateFields({3}, {{{"f1", "v3-1"}}}));
+              UpdateWithFieldMaps(meta_storage_backend_.get(), {3}, {{{"f1", "v3-1"}}}));
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
@@ -165,17 +171,20 @@ TEST_F(MetaDummyBackendTest, TestUpsert) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
     // update or insert
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Upsert(
-                  {1, 2, 3}, {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2-1"}}, {{"f3", "v3-1"}}}));
-    AssertGet(
+              UpsertWithFieldMaps(meta_storage_backend_.get(),
+                                  {1, 2, 3},
+                                  {{{"f1", "v1-1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2-1"}}, {{"f3", "v3-1"}}}));
+    AssertGetProperties(
         meta_storage_backend_.get(),
         {1, 2, 3},
         {"f1", "f2", "f3"},
@@ -191,12 +200,14 @@ TEST_F(MetaDummyBackendTest, TestDelete) {
 
     ASSERT_EQ(
         (std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
-        meta_storage_backend_->Put(
+        PutWithFieldMaps(
+            meta_storage_backend_.get(),
             {1, 2, 3},
             {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}, {"f2", "v3-2"}}}));
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}), meta_storage_backend_->Delete({1, 3}));
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Delete(nullptr, {1, 3}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_NOENT, ErrorCode::EC_NOENT}),
-              meta_storage_backend_->Delete({1, 3}));
+              meta_storage_backend_->Delete(nullptr, {1, 3}));
     AssertExists(meta_storage_backend_.get(),
                  {1, 2, 3},
                  {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
@@ -210,20 +221,22 @@ TEST_F(MetaDummyBackendTest, TestGet) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}); // part fields
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}); // all fields
-    AssertGet(
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}); // part fields
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}); // all fields
+    AssertGetProperties(
         meta_storage_backend_.get(), {1, 2}, {}, {ErrorCode::EC_OK, ErrorCode::EC_OK}, FieldMapVec(2)); // no fields
-    AssertGet(meta_storage_backend_.get(), {3}, {"f1", "f2"}, {ErrorCode::EC_NOENT}, {{}});             // key not exist
+    AssertGetProperties(meta_storage_backend_.get(), {3}, {"f1", "f2"}, {ErrorCode::EC_NOENT}, {{}});   // key not exist
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
@@ -233,7 +246,9 @@ TEST_F(MetaDummyBackendTest, TestGetAll) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
     AssertGetAllFields(meta_storage_backend_.get(),
                        {1, 2},
                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
@@ -248,7 +263,9 @@ TEST_F(MetaDummyBackendTest, TestExists) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
     AssertExists(meta_storage_backend_.get(),
                  {1, 2, 3},
                  {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK},
@@ -262,11 +279,11 @@ TEST_F(MetaDummyBackendTest, TestListKeys) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(), {2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(), {3}, {{{"f1", "v3-1"}, {"f2", "v3-2"}}}));
 
     // list keys by step
     std::string current_cursor = SCAN_BASE_CURSOR;
@@ -299,9 +316,9 @@ TEST_F(MetaDummyBackendTest, TestRandomSample) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{"f1", "v1-1"}, {"f2", "v1-2"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(), {2}, {{{"f1", "v2-1"}, {"f2", "v2-2"}}}));
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 0, ErrorCode::EC_OK, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 2, ErrorCode::EC_OK, {1, 2});
@@ -319,12 +336,12 @@ TEST_F(MetaDummyBackendTest, TestRecover) {
         {
             std::string keyStr = std::to_string(i);
             ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-                      meta_storage_backend_->Put({i}, {{{"f" + keyStr, "v" + keyStr}}}));
+                      PutWithFieldMaps(meta_storage_backend_.get(), {i}, {{{"f" + keyStr, "v" + keyStr}}}));
         }
 
         for (std::int32_t j = 0; j <= i; ++j) {
             std::string keyStr = std::to_string(j);
-            AssertGet(
+            AssertGetProperties(
                 meta_storage_backend_.get(), {j}, {"f" + keyStr}, {ErrorCode::EC_OK}, {{{"f" + keyStr, "v" + keyStr}}});
         }
 
@@ -341,130 +358,76 @@ TEST_F(MetaDummyBackendTest, TestRecoverBinarySafe) {
         {
             std::string keyStr = std::to_string(i);
             ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-                      meta_storage_backend_->Put({i}, {{{"f " + keyStr, "v " + keyStr}}}));
+                      PutWithFieldMaps(meta_storage_backend_.get(), {i}, {{{"f " + keyStr, "v " + keyStr}}}));
         }
 
         for (std::int32_t j = 0; j <= i; ++j) {
             std::string keyStr = std::to_string(j);
-            AssertGet(meta_storage_backend_.get(),
-                      {j},
-                      {"f " + keyStr},
-                      {ErrorCode::EC_OK},
-                      {{{"f " + keyStr, "v " + keyStr}}});
+            AssertGetProperties(meta_storage_backend_.get(),
+                                {j},
+                                {"f " + keyStr},
+                                {ErrorCode::EC_OK},
+                                {{{"f " + keyStr, "v " + keyStr}}});
         }
 
         ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
     }
 }
 
-TEST_F(MetaDummyBackendTest, TestDeleteFields) {
+TEST_F(MetaDummyBackendTest, TestDeleteLocations) {
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_storage_backend_->Init("test_instance_delete_fields", meta_storage_backend_config_));
+              meta_storage_backend_->Init("test_instance_delete_locations", meta_storage_backend_config_));
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
+    // Seed: key 1 has two locations + one property; key 2 has one location + one property.
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put(
-                  {1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{LOCATION_PREFIX + "a", "la"}, {LOCATION_PREFIX + "b", "lb"}, {"p0", "v0"}},
+                                {{LOCATION_PREFIX + "c", "lc"}, {"p0", "v0"}}}));
 
-    // key 1: delete one of three fields; key 2: delete all listed fields;
-    // key 3: not exist -> EC_NOENT.
-    AssertDeleteFields(meta_storage_backend_.get(),
-                       {1, 2, 3},
-                       {{"f1"}, {"f1", "f2"}, {"f1"}},
-                       {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_NOENT});
+    // key 1: delete one of two locations; key 2: delete its only location;
+    // key 3: does not exist -> EC_NOENT.
+    AssertDeleteLocations(meta_storage_backend_.get(),
+                          {1, 2, 3},
+                          {{"a"}, {"c"}, {"anything"}},
+                          {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_NOENT});
 
-    // Surviving fields are intact; deleted fields are absent.
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {"f1", "f2", "f3"},
-              {ErrorCode::EC_OK, ErrorCode::EC_OK},
-              {{{"f2", "v1-2"}, {"f3", "v1-3"}}, {}});
+    // Deleting a non-existent location on an existing key still returns EC_OK.
+    AssertDeleteLocations(meta_storage_backend_.get(), {1}, {{"not_exist_loc"}}, {ErrorCode::EC_OK});
 
-    // Deleting a non-existent field on an existing key still returns EC_OK.
-    AssertDeleteFields(meta_storage_backend_.get(), {1}, {{"not_exist_field"}}, {ErrorCode::EC_OK});
+    // Empty location id list on an existing key is a no-op (EC_OK).
+    AssertDeleteLocations(meta_storage_backend_.get(), {2}, {{}}, {ErrorCode::EC_OK});
 
-    // Empty field list on an existing key is a no-op (EC_OK), original fields kept.
-    AssertDeleteFields(meta_storage_backend_.get(), {1}, {{}}, {ErrorCode::EC_OK});
-    AssertGet(meta_storage_backend_.get(), {1}, {"f2", "f3"}, {ErrorCode::EC_OK}, {{{"f2", "v1-2"}, {"f3", "v1-3"}}});
+    // Properties survive location deletion.
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {"p0"},
+                        {ErrorCode::EC_OK, ErrorCode::EC_OK},
+                        {{{"p0", "v0"}}, {{"p0", "v0"}}});
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
 
-TEST_F(MetaDummyBackendTest, TestExistsFieldWithPrefix) {
+TEST_F(MetaDummyBackendTest, TestExistsLocation) {
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_storage_backend_->Init("test_instance_exists_prefix", meta_storage_backend_config_));
+              meta_storage_backend_->Init("test_instance_exists_location", meta_storage_backend_config_));
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
 
-    // key 1: has LOCATION_PREFIX field; key 2: has only normal fields; key 3: not exist.
+    // key 1: has location; key 2: has only properties; key 3: not exist.
     ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{LOCATION_PREFIX + "a", "la"}, {"p0", "v0"}}, {{"p0", "v0"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{LOCATION_PREFIX + "a", "la"}, {"p0", "v0"}}, {{"p0", "v0"}}}));
 
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(),
-                                {1, 2, 3},
-                                LOCATION_PREFIX,
-                                {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_NOENT},
-                                {true, false, false});
+    AssertExistsLocation(meta_storage_backend_.get(),
+                         {1, 2, 3},
+                         {ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_NOENT},
+                         {true, false, false});
 
-    // After removing the only LOCATION_PREFIX field from key 1, prefix check is false.
-    AssertDeleteFields(meta_storage_backend_.get(), {1}, {{LOCATION_PREFIX + "a"}}, {ErrorCode::EC_OK});
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(), {1}, LOCATION_PREFIX, {ErrorCode::EC_OK}, {false});
-
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
-}
-
-// Tombstone: a location field with empty value should not be treated as valid.
-TEST_F(MetaDummyBackendTest, TestTombstoneNotTreatedAsValidLocation) {
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_tombstone", meta_storage_backend_config_));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
-
-    // Put key 1 with a real location and a tombstone (empty value) location.
-    ASSERT_EQ(
-        (std::vector<ErrorCode>{ErrorCode::EC_OK}),
-        meta_storage_backend_->Put({1}, {{{LOCATION_PREFIX + "real", "valid_data"}, {LOCATION_PREFIX + "tomb", ""}}}));
-
-    // ExistsFieldWithPrefix should return true (real location exists).
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(), {1}, LOCATION_PREFIX, {ErrorCode::EC_OK}, {true});
-
-    // GetFieldNamesWithPrefix should only return the non-tombstone field.
-    std::vector<std::vector<std::string>> field_names_vec;
-    auto ecs = meta_storage_backend_->GetFieldNamesWithPrefix({1}, LOCATION_PREFIX, field_names_vec);
-    ASSERT_EQ(ErrorCode::EC_OK, ecs[0]);
-    ASSERT_EQ(1u, field_names_vec[0].size());
-    EXPECT_EQ(LOCATION_PREFIX + "real", field_names_vec[0][0]);
-
-    // Now update the real location to empty (tombstone it).
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
-              meta_storage_backend_->UpdateFields({1}, {{{LOCATION_PREFIX + "real", ""}}}));
-
-    // Both locations are now tombstones — should report no valid locations.
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(), {1}, LOCATION_PREFIX, {ErrorCode::EC_OK}, {false});
-    field_names_vec.clear();
-    ecs = meta_storage_backend_->GetFieldNamesWithPrefix({1}, LOCATION_PREFIX, field_names_vec);
-    ASSERT_EQ(ErrorCode::EC_OK, ecs[0]);
-    EXPECT_TRUE(field_names_vec[0].empty());
-
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
-}
-
-TEST_F(MetaDummyBackendTest, TestGetPerKeyFields) {
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
-
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
-              meta_storage_backend_->Put(
-                  {1, 2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
-
-    // Each key queries a different subset; key 3 does not exist; key 2 asks for
-    // a missing field "f3" which is silently dropped from the returned map.
-    FieldMapVec field_maps;
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_NOENT}),
-              meta_storage_backend_->Get(
-                  {1, 2, 3}, std::vector<std::vector<std::string>>{{"f1", "f3"}, {"f2", "f3"}, {"f1"}}, field_maps));
-    ASSERT_EQ((FieldMapVec{{{"f1", "v1-1"}, {"f3", "v1-3"}}, {{"f2", "v2-2"}}, {}}), field_maps);
-
-    // Size mismatch between keys and field_names_vec -> EC_BADARGS per key.
-    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_BADARGS, ErrorCode::EC_BADARGS}),
-              meta_storage_backend_->Get({1, 2}, std::vector<std::vector<std::string>>{{"f1"}}, field_maps));
+    // After removing the only location from key 1, ExistsLocation is false.
+    AssertDeleteLocations(meta_storage_backend_.get(), {1}, {{"a"}}, {ErrorCode::EC_OK});
+    AssertExistsLocation(meta_storage_backend_.get(), {1}, {ErrorCode::EC_OK}, {false});
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_indexer_redis_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_redis_test.cc
@@ -83,7 +83,7 @@ TEST_F(MetaIndexerRedisTest, TestRedisSimple) {
     const int32_t key_count = 3;
     MakeKVData(/*start*/ 0, /*end*/ 3, data);
     // Snapshot the expected location payload before Put potentially moves inputs.
-    LocationMapVector expect_locations;
+    CacheLocationMapVector expect_locations;
     expect_locations.reserve(data.location_maps.size());
     for (const auto &location_map : data.location_maps) {
         expect_locations.emplace_back(location_map);

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -123,7 +123,7 @@ TEST_F(MetaIndexerTest, TestMakeBatches) {
 
     KeyVector keys = {0, 1, 2, 3, 4, 8, 9, 80, 800};
     LocationIdsPerKey empty_location_ids;
-    LocationMapVector empty_locations;
+    CacheLocationMapVector empty_locations;
     PropertyMapVector empty_properties;
     auto batches = meta_indexer_->MakeBatches(keys, empty_location_ids, empty_locations, empty_properties);
 
@@ -176,7 +176,7 @@ TEST_F(MetaIndexerTest, TestMakeBatches2) {
                                     {{"uri", "35"}},
                                     {{"uri", "64"}}};
     LocationIdsPerKey empty_location_ids;
-    LocationMapVector empty_locations;
+    CacheLocationMapVector empty_locations;
     auto batches = meta_indexer_->MakeBatches(keys, empty_location_ids, empty_locations, properties);
 
     std::vector<int32_t> covered_indexs;

--- a/kv_cache_manager/meta/test/meta_indexer_test_base.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test_base.cc
@@ -13,17 +13,17 @@
 
 namespace kv_cache_manager {
 
-CacheLocation MetaIndexerTestBase::MakeLocation(const std::string &id, const std::string &uri) {
+CacheLocationConstPtr MetaIndexerTestBase::MakeLocation(const std::string &id, const std::string &uri) {
     // Build a minimal one-spec CacheLocation; uri field carries the payload the
     // tests compare against after a round-trip through the backend.
-    CacheLocation location;
-    location.set_id(id);
-    location.set_status(CacheLocationStatus::CLS_SERVING);
-    location.set_type(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
-    location.set_spec_size(1);
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id(id);
+    location->set_status(CacheLocationStatus::CLS_SERVING);
+    location->set_type(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
+    location->set_spec_size(1);
     std::vector<LocationSpec> specs;
     specs.emplace_back(/*name*/ "default", uri);
-    location.set_location_specs(std::move(specs));
+    location->set_location_specs(std::move(specs));
     return location;
 }
 
@@ -92,10 +92,10 @@ void MetaIndexerTestBase::AssertGet(const KeyVector &keys,
             ASSERT_TRUE(it != actual_map.end()) << "key=" << keys[i] << " location_id=" << kv.first;
             // Compare on the round-trippable projection (id/uri) instead of the
             // full object to avoid coupling to every CacheLocation field.
-            ASSERT_EQ(kv.second.id(), it->second.id());
-            ASSERT_EQ(kv.second.location_specs().size(), it->second.location_specs().size());
-            if (!kv.second.location_specs().empty()) {
-                ASSERT_EQ(kv.second.location_specs().front().uri(), it->second.location_specs().front().uri());
+            ASSERT_EQ(kv.second->id(), it->second->id());
+            ASSERT_EQ(kv.second->location_specs().size(), it->second->location_specs().size());
+            if (!kv.second->location_specs().empty()) {
+                ASSERT_EQ(kv.second->location_specs().front().uri(), it->second->location_specs().front().uri());
             }
         }
     }
@@ -119,7 +119,7 @@ void MetaIndexerTestBase::AssertGet(const KeyVector &keys,
         for (const auto &kv : expect_loc) {
             auto it = actual_loc.find(kv.first);
             ASSERT_TRUE(it != actual_loc.end()) << "key=" << keys[i] << " location_id=" << kv.first;
-            ASSERT_EQ(kv.second.id(), it->second.id());
+            ASSERT_EQ(kv.second->id(), it->second->id());
         }
         for (const auto &prop : expect_properties[i]) {
             ASSERT_EQ(prop.second, out_properties[i][prop.first]) << "key=" << keys[i] << " prop=" << prop.first;

--- a/kv_cache_manager/meta/test/meta_indexer_test_base.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test_base.cc
@@ -34,7 +34,7 @@ void MetaIndexerTestBase::MakeKVData(const int64_t start, const int64_t end, KVD
     for (int64_t i = start; i < end; ++i) {
         data.keys.push_back(i);
         const std::string loc_id = "loc_" + std::to_string(i);
-        LocationMap loc_map;
+        CacheLocationMap loc_map;
         loc_map.emplace(loc_id, MakeLocation(loc_id, "uri_" + std::to_string(i)));
         data.location_maps.push_back(std::move(loc_map));
 
@@ -62,7 +62,7 @@ void MetaIndexerTestBase::MakeRandomKVData(const int64_t count,
         }
         data.keys.push_back(key);
         const std::string loc_id = "loc_" + std::to_string(key);
-        LocationMap loc_map;
+        CacheLocationMap loc_map;
         loc_map.emplace(loc_id, MakeLocation(loc_id, "uri_" + std::to_string(key)));
         data.location_maps.push_back(std::move(loc_map));
 
@@ -74,9 +74,9 @@ void MetaIndexerTestBase::MakeRandomKVData(const int64_t count,
 }
 
 void MetaIndexerTestBase::AssertGet(const KeyVector &keys,
-                                    const LocationMapVector &expect_location_maps,
+                                    const CacheLocationMapVector &expect_location_maps,
                                     const Result &expect_result) {
-    LocationMapVector out_locations;
+    CacheLocationMapVector out_locations;
     PropertyMapVector out_properties;
     auto result = meta_indexer_->Get(request_context_.get(), keys, out_locations, out_properties);
     ASSERT_EQ(expect_result.ec, result.ec);
@@ -102,10 +102,10 @@ void MetaIndexerTestBase::AssertGet(const KeyVector &keys,
 }
 
 void MetaIndexerTestBase::AssertGet(const KeyVector &keys,
-                                    const LocationMapVector &expect_location_maps,
+                                    const CacheLocationMapVector &expect_location_maps,
                                     const PropertyMapVector &expect_properties,
                                     const Result &expect_result) {
-    LocationMapVector out_locations;
+    CacheLocationMapVector out_locations;
     PropertyMapVector out_properties;
     auto result = meta_indexer_->Get(request_context_.get(), keys, out_locations, out_properties);
     ASSERT_EQ(expect_result.ec, result.ec);
@@ -154,7 +154,7 @@ void MetaIndexerTestBase::DoPutTest() {
     ASSERT_EQ(0, meta_indexer_->GetKeyCount());
     auto expect_result = Result(key_count);
     // Snapshot expected payload before the Put call moves the inputs.
-    LocationMapVector expect_locations;
+    CacheLocationMapVector expect_locations;
     expect_locations.reserve(key_count);
     for (const auto &m : data.location_maps) {
         expect_locations.emplace_back(m);
@@ -190,7 +190,7 @@ void MetaIndexerTestBase::DoUpdateTest() {
         m["p0"] = m["p0"] + "_new";
     }
     PropertyMapVector keep_properties = update_data.properties;
-    LocationMapVector keep_locations;
+    CacheLocationMapVector keep_locations;
     for (const auto &m : update_data.location_maps) {
         keep_locations.emplace_back(m);
     }
@@ -269,7 +269,7 @@ void MetaIndexerTestBase::DoDeleteAndExistTest() {
     ASSERT_EQ(EC_OK, result.ec);
     ASSERT_EQ((std::vector<bool>{false, false, true}), is_exists);
 
-    LocationMapVector expect_locations(key_count);
+    CacheLocationMapVector expect_locations(key_count);
     expect_locations[2].emplace("loc_2", MakeLocation("loc_2", "uri_2"));
     PropertyMapVector expect_properties(key_count);
     expect_properties[2] = {{"p0", "p0_2"}, {"p1", "p1_2"}};
@@ -300,7 +300,7 @@ void MetaIndexerTestBase::DoScanAndSampleReclaimKeysTest() {
     while (try_count-- && scan_count > 0) {
         std::string next_cursor;
         KeyVector out_keys;
-        ASSERT_EQ(EC_OK, meta_indexer_->Scan(cursor, /*limit*/ 50, next_cursor, out_keys));
+        ASSERT_EQ(EC_OK, meta_indexer_->Scan(nullptr, cursor, /*limit*/ 50, next_cursor, out_keys));
         cursor = next_cursor;
         scan_count -= out_keys.size();
         keys.insert(keys.end(), out_keys.begin(), out_keys.end());
@@ -340,7 +340,7 @@ void MetaIndexerTestBase::DoReadModifyWriteBlockTest() {
                               ErrorCode get_ec,
                               size_t /*key_index*/,
                               PropertyMap &upsert_property_map,
-                              LocationMap &out_new_locations) -> ModifierResult {
+                              CacheLocationMap &out_new_locations) -> ModifierResult {
         if (get_ec != EC_OK && get_ec != EC_NOENT) {
             return {MA_FAIL, get_ec};
         }
@@ -356,7 +356,7 @@ void MetaIndexerTestBase::DoReadModifyWriteBlockTest() {
                                       ErrorCode get_ec,
                                       size_t,
                                       PropertyMap &,
-                                      LocationMap &) -> ModifierResult {
+                                      CacheLocationMap &) -> ModifierResult {
         if (get_ec == EC_NOENT || (get_ec == EC_OK && existing_location_ids.empty())) {
             return {MA_SKIP, EC_OK};
         }
@@ -370,7 +370,7 @@ void MetaIndexerTestBase::DoReadModifyWriteBlockTest() {
                                      ErrorCode get_ec,
                                      size_t,
                                      PropertyMap &,
-                                     LocationMap &) -> ModifierResult {
+                                     CacheLocationMap &) -> ModifierResult {
         if (get_ec == EC_NOENT || (get_ec == EC_OK && existing_location_ids.empty())) {
             return {MA_FAIL, EC_NOENT};
         }
@@ -416,7 +416,7 @@ void MetaIndexerTestBase::DoReadModifyWriteBlockTest() {
 void MetaIndexerTestBase::DoReadModifyWriteLocationTest() {
     // Seed two keys, each with two locations (loc_a/loc_b).
     KeyVector keys = {0, 1};
-    LocationMapVector seed_locations(keys.size());
+    CacheLocationMapVector seed_locations(keys.size());
     PropertyMapVector seed_properties(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         seed_locations[i].emplace("loc_a", MakeLocation("loc_a", "uri_a_" + std::to_string(keys[i])));
@@ -448,7 +448,7 @@ void MetaIndexerTestBase::DoReadModifyWriteLocationTest() {
     for (const auto &per_key : loc_result.per_location_error_codes) {
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), per_key);
     }
-    LocationMapVector expect_locations(keys.size());
+    CacheLocationMapVector expect_locations(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         expect_locations[i].emplace("loc_a", MakeLocation("loc_a", "rmw_loc_a"));
         expect_locations[i].emplace("loc_b", MakeLocation("loc_b", "uri_b_" + std::to_string(keys[i])));
@@ -527,7 +527,7 @@ void MetaIndexerTestBase::DoMultiThreadTest() {
                               ErrorCode get_ec,
                               size_t /*key_index*/,
                               PropertyMap &upsert_property_map,
-                              LocationMap &out_new_locations) -> ModifierResult {
+                              CacheLocationMap &out_new_locations) -> ModifierResult {
         if (get_ec != EC_OK && get_ec != EC_NOENT) {
             return {MA_FAIL, get_ec};
         }

--- a/kv_cache_manager/meta/test/meta_indexer_test_base.h
+++ b/kv_cache_manager/meta/test/meta_indexer_test_base.h
@@ -36,7 +36,7 @@ protected:
 
     // Build a single-location CacheLocation with the given id/uri, using the
     // same schema as MakeKVData so producers/consumers stay in lockstep.
-    static CacheLocation MakeLocation(const std::string &id, const std::string &uri);
+    static CacheLocationConstPtr MakeLocation(const std::string &id, const std::string &uri);
 
     // Assertions over MetaIndexer::Get(LocationMapVector, PropertyMapVector)
     // (the new whole-block read path).

--- a/kv_cache_manager/meta/test/meta_indexer_test_base.h
+++ b/kv_cache_manager/meta/test/meta_indexer_test_base.h
@@ -22,7 +22,7 @@ protected:
     // describes key_i's locations + block-level properties.
     struct KVData {
         KeyVector keys;
-        LocationMapVector location_maps;
+        CacheLocationMapVector location_maps;
         PropertyMapVector properties;
     };
 
@@ -40,11 +40,10 @@ protected:
 
     // Assertions over MetaIndexer::Get(LocationMapVector, PropertyMapVector)
     // (the new whole-block read path).
+    void
+    AssertGet(const KeyVector &keys, const CacheLocationMapVector &expect_location_maps, const Result &expect_result);
     void AssertGet(const KeyVector &keys,
-                   const LocationMapVector &expect_location_maps,
-                   const Result &expect_result);
-    void AssertGet(const KeyVector &keys,
-                   const LocationMapVector &expect_location_maps,
+                   const CacheLocationMapVector &expect_location_maps,
                    const PropertyMapVector &expect_properties,
                    const Result &expect_result);
     void AssertGetProperties(const KeyVector &keys,

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -782,17 +782,16 @@ TEST_F(MetaLocalBackendTest, TestDeleteFields) {
 
     // key 1: delete one of two location fields; key 2: delete its only
     // location field; key 3: does not exist -> EC_NOENT.
-    AssertDeleteLocations(meta_storage_backend_.get(),
-                          {1, 2, 3},
-                          {{LOCATION_PREFIX + "a"}, {LOCATION_PREFIX + "c"}, {"anything"}},
-                          {EC_OK, EC_OK, EC_NOENT});
+    // DeleteLocations takes location ids without LOCATION_PREFIX.
+    AssertDeleteLocations(
+        meta_storage_backend_.get(), {1, 2, 3}, {{"a"}, {"c"}, {"anything"}}, {EC_OK, EC_OK, EC_NOENT});
 
-    // Non-deleted fields survive.
+    // Non-deleted properties survive; verify via GetProperties (properties only).
     AssertGetProperties(meta_storage_backend_.get(),
                         {1, 2},
-                        {LOCATION_PREFIX + "a", LOCATION_PREFIX + "b", PROPERTY_URI},
+                        {PROPERTY_URI},
                         {EC_OK, EC_OK},
-                        {{{LOCATION_PREFIX + "b", "lb"}, {PROPERTY_URI, "u1"}}, {{PROPERTY_URI, "u2"}}});
+                        {{{PROPERTY_URI, "u1"}}, {{PROPERTY_URI, "u2"}}});
 
     // Deleting a non-existent field on an existing key still returns EC_OK.
     AssertDeleteLocations(meta_storage_backend_.get(), {1}, {{"not_exist_field"}}, {EC_OK});
@@ -837,22 +836,26 @@ TEST_F(MetaLocalBackendTest, TestTombstoneNotTreatedAsValidLocation) {
     // ExistsLocation should return true (real location exists).
     AssertExistsLocation(meta_storage_backend_.get(), {1}, {EC_OK}, {true});
 
-    // GetLocationIds should only return the non-tombstone location.
+    // GetLocationIds returns ALL location ids including tombstones (empty value
+    // means deserialization failed but the location id still exists).
     LocationIdsPerKey location_ids_vec;
     auto ecs = meta_storage_backend_->GetLocationIds(nullptr, {1}, location_ids_vec);
     ASSERT_EQ(EC_OK, ecs[0]);
-    ASSERT_EQ(1u, location_ids_vec[0].size());
-    EXPECT_EQ("real", location_ids_vec[0][0]);
+    ASSERT_EQ(2u, location_ids_vec[0].size());
+    std::set<std::string> ids(location_ids_vec[0].begin(), location_ids_vec[0].end());
+    EXPECT_TRUE(ids.count("real"));
+    EXPECT_TRUE(ids.count("tomb"));
 
     // Now delete the real location so only the tombstone remains.
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->DeleteLocations(nullptr, {1}, {{"real"}}));
 
-    // The only valid location was removed — should report no valid locations.
-    AssertExistsLocation(meta_storage_backend_.get(), {1}, {EC_OK}, {false});
+    // Tombstone location id still exists — ExistsLocation should still be true.
+    AssertExistsLocation(meta_storage_backend_.get(), {1}, {EC_OK}, {true});
     location_ids_vec.clear();
     ecs = meta_storage_backend_->GetLocationIds(nullptr, {1}, location_ids_vec);
     ASSERT_EQ(EC_OK, ecs[0]);
-    EXPECT_TRUE(location_ids_vec[0].empty());
+    ASSERT_EQ(1u, location_ids_vec[0].size());
+    EXPECT_EQ("tomb", location_ids_vec[0][0]);
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -1048,20 +1051,25 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
     size_t usage_after_shrink = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_shrink) - static_cast<ssize_t>(usage_after_add), expected_delta_shrink);
 
-    // --- Upsert: add another new field (key exists, goes through UpdateFieldsInPlace) ---
-    std::string field_name_b = "field_b";
-    std::string field_value_b(512, 'y');
-    ssize_t expected_delta_upsert = static_cast<ssize_t>(field_name_b.size() + field_value_b.size() + kMapNodeOverhead);
+    // --- Upsert: add a location (key exists, goes through UpdateFieldsInPlace) ---
+    // Use a location field so that DeleteLocations can remove it.
+    std::string loc_id_b = "loc_b";
+    std::string loc_value_b(512, 'y'); // non-JSON value, stored as-is
+    std::string field_name_b_full = LOCATION_PREFIX + loc_id_b;
+    // SplitFieldMaps creates a CacheLocation with id=loc_id_b and no specs.
+    // EstimateMemUsage = sizeof(CacheLocation) + loc_id_b.size()
+    // MetaMemCacheItem::Size location overhead = sizeof(void*)*4 + loc_id.size() + EstimateMemUsage
+    size_t loc_mem_usage = sizeof(CacheLocation) + loc_id_b.size();
+    ssize_t expected_delta_upsert = static_cast<ssize_t>(kMapNodeOverhead + loc_id_b.size() + loc_mem_usage);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              UpsertWithFieldMaps(backend.get(), {1}, {{{field_name_b, field_value_b}}}));
+              UpsertWithFieldMaps(backend.get(), {1}, {{{field_name_b_full, loc_value_b}}}));
     size_t usage_after_upsert = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_upsert - usage_after_shrink), expected_delta_upsert);
 
-    // --- DeleteFields: remove field_b ---
-    // Expected delta: -(field_name.size() + field_value.size() + kMapNodeOverhead)
-    ssize_t expected_delta_delete =
-        -static_cast<ssize_t>(field_name_b.size() + field_value_b.size() + kMapNodeOverhead);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->DeleteLocations(nullptr, {1}, {{field_name_b}}));
+    // --- DeleteLocations: remove loc_b ---
+    // Expected delta: -(sizeof(void*)*4 + loc_id.size() + EstimateMemUsage)
+    ssize_t expected_delta_delete = -expected_delta_upsert;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->DeleteLocations(nullptr, {1}, {{loc_id_b}}));
     size_t usage_after_delete = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_delete) - static_cast<ssize_t>(usage_after_upsert),
               expected_delta_delete);

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -50,15 +50,16 @@ TEST_F(MetaLocalBackendTest, TestSimple) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     // Put two entries with uri field
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}}));
-    // UpdateFields to add hit_count
     ASSERT_EQ(
         (std::vector<ErrorCode>{EC_OK, EC_OK}),
-        meta_storage_backend_->UpdateFields({1, 2}, {{{PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_HIT_COUNT, "200"}}}));
+        PutWithFieldMaps(meta_storage_backend_.get(), {1, 2}, {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}}));
+    // UpdateFields to add hit_count
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              UpdateWithFieldMaps(
+                  meta_storage_backend_.get(), {1, 2}, {{{PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_HIT_COUNT, "200"}}}));
 
     AssertExists(meta_storage_backend_.get(), {1, 2, 3}, {EC_OK, EC_OK, EC_OK}, /*is_exist*/ {true, true, false});
-    AssertGet(
+    AssertGetProperties(
         meta_storage_backend_.get(),
         {1, 2},
         {PROPERTY_URI, PROPERTY_HIT_COUNT},
@@ -67,21 +68,22 @@ TEST_F(MetaLocalBackendTest, TestSimple) {
     AssertListKeys(meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, EC_OK, SCAN_BASE_CURSOR, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, EC_OK, {1, 2});
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete({1}));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT}), meta_storage_backend_->Delete({1}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete(nullptr, {1}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT}), meta_storage_backend_->Delete(nullptr, {1}));
+    ASSERT_EQ(
+        (std::vector<ErrorCode>{EC_OK}),
+        PutWithFieldMaps(meta_storage_backend_.get(), {3}, {{{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->Put({3}, {{{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}}));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->UpdateFields({2}, {{{PROPERTY_URI, "uri2-updated"}}}));
+              UpdateWithFieldMaps(meta_storage_backend_.get(), {2}, {{{PROPERTY_URI, "uri2-updated"}}}));
 
     AssertExists(meta_storage_backend_.get(), {1, 2, 3}, {EC_OK, EC_OK, EC_OK}, /*is_exist*/ {false, true, true});
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2, 3},
-              {PROPERTY_URI, PROPERTY_HIT_COUNT},
-              {EC_NOENT, EC_OK, EC_OK},
-              {{},
-               {{PROPERTY_URI, "uri2-updated"}, {PROPERTY_HIT_COUNT, "200"}},
-               {{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}});
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2, 3},
+                        {PROPERTY_URI, PROPERTY_HIT_COUNT},
+                        {EC_NOENT, EC_OK, EC_OK},
+                        {{},
+                         {{PROPERTY_URI, "uri2-updated"}, {PROPERTY_HIT_COUNT, "200"}},
+                         {{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}});
     AssertListKeys(meta_storage_backend_.get(), SCAN_BASE_CURSOR, /*limit*/ 3, EC_OK, SCAN_BASE_CURSOR, {2, 3});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, EC_OK, {2, 3});
 
@@ -109,8 +111,8 @@ TEST_F(MetaLocalBackendTest, TestParseStorageUri) {
     ASSERT_EQ(50, backend->sample_times_);
 
     // Verify the backend is functional with custom parameters
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
-    AssertGet(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), PutWithFieldMaps(backend.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
+    AssertGetProperties(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
 
     ASSERT_EQ(EC_OK, backend->Close());
 }
@@ -128,8 +130,8 @@ TEST_F(MetaLocalBackendTest, TestParseStorageUriEmpty) {
     ASSERT_EQ(expected_shard_mask, backend->shard_mask_);
     ASSERT_EQ(META_LOCAL_BACKEND_DEFAULT_SAMPLE_TIMES, backend->sample_times_);
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
-    AssertGet(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), PutWithFieldMaps(backend.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
+    AssertGetProperties(backend.get(), {1}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "uri1"}}});
 
     ASSERT_EQ(EC_OK, backend->Close());
 }
@@ -148,10 +150,11 @@ TEST_F(MetaLocalBackendTest, TestPut) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
-    AssertGet(
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
+    AssertGetProperties(
         meta_storage_backend_.get(),
         {1, 2},
         {PROPERTY_URI, PROPERTY_HIT_COUNT},
@@ -159,12 +162,13 @@ TEST_F(MetaLocalBackendTest, TestPut) {
         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     // Put again to overwrite
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1-new"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {PROPERTY_URI},
-              {EC_OK, EC_OK},
-              {{{PROPERTY_URI, "uri1-new"}}, {{PROPERTY_URI, "uri2"}}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1-new"}}}));
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {PROPERTY_URI},
+                        {EC_OK, EC_OK},
+                        {{{PROPERTY_URI, "uri1-new"}}, {{PROPERTY_URI, "uri2"}}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -174,23 +178,26 @@ TEST_F(MetaLocalBackendTest, TestUpdateFields) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
 
     // Update uri only, lru_time should be preserved
-    ASSERT_EQ(
-        (std::vector<ErrorCode>{EC_OK, EC_OK}),
-        meta_storage_backend_->UpdateFields({1, 2}, {{{PROPERTY_URI, "uri1-updated"}}, {{PROPERTY_HIT_COUNT, "250"}}}));
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {PROPERTY_URI, PROPERTY_HIT_COUNT},
-              {EC_OK, EC_OK},
-              {{{PROPERTY_URI, "uri1-updated"}, {PROPERTY_HIT_COUNT, "100"}},
-               {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "250"}}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              UpdateWithFieldMaps(meta_storage_backend_.get(),
+                                  {1, 2},
+                                  {{{PROPERTY_URI, "uri1-updated"}}, {{PROPERTY_HIT_COUNT, "250"}}}));
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {PROPERTY_URI, PROPERTY_HIT_COUNT},
+                        {EC_OK, EC_OK},
+                        {{{PROPERTY_URI, "uri1-updated"}, {PROPERTY_HIT_COUNT, "100"}},
+                         {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "250"}}});
 
     // Cannot update key that does not exist
-    ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT}), meta_storage_backend_->UpdateFields({3}, {{{PROPERTY_URI, "uri3"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT}),
+              UpdateWithFieldMaps(meta_storage_backend_.get(), {3}, {{{PROPERTY_URI, "uri3"}}}));
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -200,23 +207,25 @@ TEST_F(MetaLocalBackendTest, TestUpsert) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
 
     // Upsert: update existing, insert new
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}),
-              meta_storage_backend_->Upsert(
+              UpsertWithFieldMaps(
+                  meta_storage_backend_.get(),
                   {1, 2, 3},
                   {{{PROPERTY_URI, "uri1-upserted"}}, {{PROPERTY_HIT_COUNT, "250"}}, {{PROPERTY_URI, "uri3-new"}}}));
     // Verify existing keys preserve unmodified fields
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2, 3},
-              {PROPERTY_URI, PROPERTY_HIT_COUNT},
-              {EC_OK, EC_OK, EC_OK},
-              {{{PROPERTY_URI, "uri1-upserted"}, {PROPERTY_HIT_COUNT, "100"}},
-               {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "250"}},
-               {{PROPERTY_URI, "uri3-new"}}});
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2, 3},
+                        {PROPERTY_URI, PROPERTY_HIT_COUNT},
+                        {EC_OK, EC_OK, EC_OK},
+                        {{{PROPERTY_URI, "uri1-upserted"}, {PROPERTY_HIT_COUNT, "100"}},
+                         {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "250"}},
+                         {{PROPERTY_URI, "uri3-new"}}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -226,10 +235,11 @@ TEST_F(MetaLocalBackendTest, TestDelete) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}),
-              meta_storage_backend_->Put(
-                  {1, 2, 3}, {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}, {{PROPERTY_URI, "uri3"}}}));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), meta_storage_backend_->Delete({1, 3}));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT, EC_NOENT}), meta_storage_backend_->Delete({1, 3}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2, 3},
+                               {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}, {{PROPERTY_URI, "uri3"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), meta_storage_backend_->Delete(nullptr, {1, 3}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT, EC_NOENT}), meta_storage_backend_->Delete(nullptr, {1, 3}));
     AssertExists(meta_storage_backend_.get(), {1, 2, 3}, {EC_OK, EC_OK, EC_OK}, /*is_exist*/ {false, true, false});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
@@ -240,19 +250,20 @@ TEST_F(MetaLocalBackendTest, TestGet) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
 
     // Get single field
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {PROPERTY_URI},
-              {EC_OK, EC_OK},
-              {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}});
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {PROPERTY_URI},
+                        {EC_OK, EC_OK},
+                        {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}});
 
     // Get all supported fields
-    AssertGet(
+    AssertGetProperties(
         meta_storage_backend_.get(),
         {1, 2},
         {PROPERTY_URI, PROPERTY_HIT_COUNT},
@@ -260,13 +271,13 @@ TEST_F(MetaLocalBackendTest, TestGet) {
         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}, {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     // Get no fields
-    AssertGet(meta_storage_backend_.get(), {1, 2}, {}, {EC_OK, EC_OK}, FieldMapVec(2));
+    AssertGetProperties(meta_storage_backend_.get(), {1, 2}, {}, {EC_OK, EC_OK}, FieldMapVec(2));
 
     // Get non-existent key returns empty values
-    AssertGet(meta_storage_backend_.get(), {3}, {PROPERTY_URI, PROPERTY_HIT_COUNT}, {EC_NOENT}, {{}});
+    AssertGetProperties(meta_storage_backend_.get(), {3}, {PROPERTY_URI, PROPERTY_HIT_COUNT}, {EC_NOENT}, {{}});
 
     // Get unsupported field returns empty string
-    AssertGet(meta_storage_backend_.get(), {1}, {"unsupported_field"}, {EC_OK}, {{}});
+    AssertGetProperties(meta_storage_backend_.get(), {1}, {"unsupported_field"}, {EC_OK}, {{}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -276,9 +287,10 @@ TEST_F(MetaLocalBackendTest, TestGetAll) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
     // GetAllFields returns all stored fields plus a dynamically generated PROPERTY_LRU_TIME.
     // AssertGetAllFields skips PROPERTY_LRU_TIME value comparison (only checks existence).
     AssertGetAllFields(meta_storage_backend_.get(),
@@ -295,8 +307,9 @@ TEST_F(MetaLocalBackendTest, TestExists) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2}, {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}}));
+    ASSERT_EQ(
+        (std::vector<ErrorCode>{EC_OK, EC_OK}),
+        PutWithFieldMaps(meta_storage_backend_.get(), {1, 2}, {{{PROPERTY_URI, "uri1"}}, {{PROPERTY_URI, "uri2"}}}));
     AssertExists(meta_storage_backend_.get(), {1, 2, 3}, {EC_OK, EC_OK, EC_OK}, /*is_exist*/ {true, true, false});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
@@ -306,9 +319,12 @@ TEST_F(MetaLocalBackendTest, TestListKeys) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({2}, {{{PROPERTY_URI, "uri2"}}}));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({3}, {{{PROPERTY_URI, "uri3"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {2}, {{{PROPERTY_URI, "uri2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {3}, {{{PROPERTY_URI, "uri3"}}}));
 
     // List all keys
     AssertListKeys(meta_storage_backend_.get(),
@@ -325,8 +341,10 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeys) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({2}, {{{PROPERTY_URI, "uri2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {2}, {{{PROPERTY_URI, "uri2"}}}));
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 0, EC_OK, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, EC_OK, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 2, EC_OK, {1, 2});
@@ -336,35 +354,37 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeys) {
 }
 
 TEST_F(MetaLocalBackendTest, TestMetaMemCacheItemFieldMap) {
-    // Verify MetaMemCacheItem stores all fields in a single FieldMap
-    MetaMemCacheItem::FieldMap fields = {{PROPERTY_URI, "test://some/long/uri/path/for/testing"},
-                                         {PROPERTY_HIT_COUNT, "1234567890"}};
+    // Verify MetaMemCacheItem stores locations and properties separately.
+    CacheLocationMap locations;
+    PropertyMap properties = {{PROPERTY_URI, "test://some/long/uri/path/for/testing"},
+                              {PROPERTY_HIT_COUNT, "1234567890"}};
 
-    MetaMemCacheItem *item = MetaMemCacheItem::Create(fields);
+    MetaMemCacheItem *item = MetaMemCacheItem::Create(locations, properties);
     ASSERT_NE(nullptr, item);
-    ASSERT_EQ("test://some/long/uri/path/for/testing", item->GetFields().at(PROPERTY_URI));
-    ASSERT_EQ("1234567890", item->GetFields().at(PROPERTY_HIT_COUNT));
-    ASSERT_EQ(2u, item->GetFields().size());
+    ASSERT_EQ("test://some/long/uri/path/for/testing", item->GetProperties().at(PROPERTY_URI));
+    ASSERT_EQ("1234567890", item->GetProperties().at(PROPERTY_HIT_COUNT));
+    ASSERT_EQ(2u, item->GetProperties().size());
+    ASSERT_TRUE(item->GetLocations().empty());
     // Size should be at least sizeof(MetaMemCacheItem) plus string heap overhead
     ASSERT_GE(item->Size(), sizeof(MetaMemCacheItem));
 
     MetaMemCacheItem::Deleter(item, nullptr);
 
     // Test with empty fields
-    MetaMemCacheItem *empty_item = MetaMemCacheItem::Create({});
+    MetaMemCacheItem *empty_item = MetaMemCacheItem::Create({}, {});
     ASSERT_NE(nullptr, empty_item);
-    ASSERT_TRUE(empty_item->GetFields().empty());
+    ASSERT_TRUE(empty_item->GetProperties().empty());
+    ASSERT_TRUE(empty_item->GetLocations().empty());
     ASSERT_EQ(sizeof(MetaMemCacheItem), empty_item->Size());
 
     MetaMemCacheItem::Deleter(empty_item, nullptr);
 
-    // Test with extra custom fields
-    MetaMemCacheItem::FieldMap custom_fields = {
-        {PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}, {"custom_key", "custom_value"}};
-    MetaMemCacheItem *custom_item = MetaMemCacheItem::Create(custom_fields);
+    // Test with extra custom properties
+    PropertyMap custom_props = {{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}, {"custom_key", "custom_value"}};
+    MetaMemCacheItem *custom_item = MetaMemCacheItem::Create({}, custom_props);
     ASSERT_NE(nullptr, custom_item);
-    ASSERT_EQ(3u, custom_item->GetFields().size());
-    ASSERT_EQ("custom_value", custom_item->GetFields().at("custom_key"));
+    ASSERT_EQ(3u, custom_item->GetProperties().size());
+    ASSERT_EQ("custom_value", custom_item->GetProperties().at("custom_key"));
 
     MetaMemCacheItem::Deleter(custom_item, nullptr);
 }
@@ -375,23 +395,24 @@ TEST_F(MetaLocalBackendTest, TestRandomSample) {
 
     // No entries inserted, should return empty
     std::vector<MetaStorageBackend::KeyType> oldest_keys;
-    ErrorCode ret = meta_storage_backend_->RandomSample(5, oldest_keys);
+    ErrorCode ret = meta_storage_backend_->RandomSample(nullptr, 5, oldest_keys);
     ASSERT_EQ(EC_OK, ret);
     ASSERT_TRUE(oldest_keys.empty());
 
     // count = 0 should return OK with no keys
-    ret = meta_storage_backend_->RandomSample(0, oldest_keys);
+    ret = meta_storage_backend_->RandomSample(nullptr, 0, oldest_keys);
     ASSERT_EQ(EC_OK, ret);
     ASSERT_TRUE(oldest_keys.empty());
 
     // Insert multiple entries
     for (int64_t i = 1; i <= 20; ++i) {
         std::string uri = "uri" + std::to_string(i);
-        ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({i}, {{{PROPERTY_URI, uri}}}));
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+                  PutWithFieldMaps(meta_storage_backend_.get(), {i}, {{{PROPERTY_URI, uri}}}));
     }
 
     // RandomSample should return some keys
-    ret = meta_storage_backend_->RandomSample(5, oldest_keys);
+    ret = meta_storage_backend_->RandomSample(nullptr, 5, oldest_keys);
     ASSERT_EQ(EC_OK, ret);
     // The returned keys should be a subset of inserted keys
     for (const auto &key : oldest_keys) {
@@ -408,17 +429,17 @@ TEST_F(MetaLocalBackendTest, TestRandomSampleAfterDelete) {
     // Insert entries
     for (int64_t i = 1; i <= 10; ++i) {
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-                  meta_storage_backend_->Put({i}, {{{PROPERTY_URI, "uri" + std::to_string(i)}}}));
+                  PutWithFieldMaps(meta_storage_backend_.get(), {i}, {{{PROPERTY_URI, "uri" + std::to_string(i)}}}));
     }
 
     // Delete some entries
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), meta_storage_backend_->Delete({1, 3, 5}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), meta_storage_backend_->Delete(nullptr, {1, 3, 5}));
 
     // RandomSample should not return deleted keys
     std::set<int64_t> remaining_keys = {2, 4, 6, 7, 8, 9, 10};
 
     std::vector<MetaStorageBackend::KeyType> oldest_keys;
-    ErrorCode ret = meta_storage_backend_->RandomSample(10, oldest_keys);
+    ErrorCode ret = meta_storage_backend_->RandomSample(nullptr, 10, oldest_keys);
     ASSERT_EQ(EC_OK, ret);
     for (const auto &key : oldest_keys) {
         ASSERT_TRUE(remaining_keys.count(key) > 0) << "Deleted key " << key << " should not appear in oldest keys";
@@ -449,13 +470,14 @@ TEST_F(MetaLocalBackendTest, TestPutIfAbsent) {
 
     // Insert new keys should succeed
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              local_backend->PutIfAbsent({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}},
-                                         {EC_OK, EC_OK}));
+              PutIfAbsentWithFieldMaps(local_backend,
+                                       {1, 2},
+                                       {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                        {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}},
+                                       {EC_OK, EC_OK}));
 
     // Verify inserted data
-    AssertGet(
+    AssertGetProperties(
         meta_storage_backend_.get(),
         {1, 2},
         {PROPERTY_URI, PROPERTY_HIT_COUNT},
@@ -464,13 +486,14 @@ TEST_F(MetaLocalBackendTest, TestPutIfAbsent) {
 
     // Insert again with same keys should return EC_EXIST and not overwrite
     ASSERT_EQ((std::vector<ErrorCode>{EC_EXIST, EC_EXIST}),
-              local_backend->PutIfAbsent({1, 2},
-                                         {{{PROPERTY_URI, "uri1-new"}, {PROPERTY_HIT_COUNT, "999"}},
-                                          {{PROPERTY_URI, "uri2-new"}, {PROPERTY_HIT_COUNT, "888"}}},
-                                         {EC_OK, EC_OK}));
+              PutIfAbsentWithFieldMaps(local_backend,
+                                       {1, 2},
+                                       {{{PROPERTY_URI, "uri1-new"}, {PROPERTY_HIT_COUNT, "999"}},
+                                        {{PROPERTY_URI, "uri2-new"}, {PROPERTY_HIT_COUNT, "888"}}},
+                                       {EC_OK, EC_OK}));
 
     // Verify original data is unchanged
-    AssertGet(
+    AssertGetProperties(
         meta_storage_backend_.get(),
         {1, 2},
         {PROPERTY_URI, PROPERTY_HIT_COUNT},
@@ -479,13 +502,14 @@ TEST_F(MetaLocalBackendTest, TestPutIfAbsent) {
 
     // Mixed: one existing key and one new key
     ASSERT_EQ((std::vector<ErrorCode>{EC_EXIST, EC_OK}),
-              local_backend->PutIfAbsent(
+              PutIfAbsentWithFieldMaps(
+                  local_backend,
                   {1, 3},
                   {{{PROPERTY_URI, "uri1-again"}}, {{PROPERTY_URI, "uri3"}, {PROPERTY_HIT_COUNT, "300"}}},
                   {EC_OK, EC_OK}));
 
     // Verify key 1 unchanged, key 3 inserted
-    AssertGet(
+    AssertGetProperties(
         meta_storage_backend_.get(),
         {1, 3},
         {PROPERTY_URI, PROPERTY_HIT_COUNT},
@@ -503,22 +527,24 @@ TEST_F(MetaLocalBackendTest, TestPutIfAbsentThenDelete) {
 
     // Insert a key
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              local_backend->PutIfAbsent({1}, {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}}, {EC_OK, EC_OK}));
+              PutIfAbsentWithFieldMaps(
+                  local_backend, {1}, {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}}}, {EC_OK, EC_OK}));
 
     // Delete the key
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete({1}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete(nullptr, {1}));
 
     // PutIfAbsent should succeed again after deletion
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              local_backend->PutIfAbsent(
-                  {1}, {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_HIT_COUNT, "200"}}}, {EC_OK, EC_OK}));
+    ASSERT_EQ(
+        (std::vector<ErrorCode>{EC_OK}),
+        PutIfAbsentWithFieldMaps(
+            local_backend, {1}, {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_HIT_COUNT, "200"}}}, {EC_OK, EC_OK}));
 
     // Verify the reinserted data
-    AssertGet(meta_storage_backend_.get(),
-              {1},
-              {PROPERTY_URI, PROPERTY_HIT_COUNT},
-              {EC_OK},
-              {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_HIT_COUNT, "200"}}});
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1},
+                        {PROPERTY_URI, PROPERTY_HIT_COUNT},
+                        {EC_OK},
+                        {{{PROPERTY_URI, "uri1-reinserted"}, {PROPERTY_HIT_COUNT, "200"}}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -536,13 +562,15 @@ TEST_F(MetaLocalBackendTest, TestLruTimeUpdatedByReadWriteOps) {
     // Helper lambda: get LRU time for a key via Get.
     auto getLruTime = [&](int64_t key) -> int64_t {
         FieldMapVec out;
-        auto ec = meta_storage_backend_->Get({key}, std::vector<std::string>{PROPERTY_LRU_TIME}, out);
+        auto ec =
+            meta_storage_backend_->GetProperties(nullptr, {key}, std::vector<std::string>{PROPERTY_LRU_TIME}, out);
         EXPECT_EQ((std::vector<ErrorCode>{EC_OK}), ec);
         return std::stoll(out[0][PROPERTY_LRU_TIME]);
     };
 
     // --- Put ---
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
     int64_t lru_after_put = getLruTime(1);
     ASSERT_GT(lru_after_put, 0);
 
@@ -554,22 +582,26 @@ TEST_F(MetaLocalBackendTest, TestLruTimeUpdatedByReadWriteOps) {
     usleep(1000);
     FieldMapVec all_out;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->Get({1}, std::vector<std::string>{PROPERTY_URI}, all_out));
+              meta_storage_backend_->GetProperties(nullptr, {1}, std::vector<std::string>{PROPERTY_URI}, all_out));
     ASSERT_EQ("uri1", all_out[0][PROPERTY_URI]);
     int64_t lru_after_get = getLruTime(1);
     ASSERT_GE(lru_after_get - lru_after_put, kMinTimeDiffUs) << "Get should update LRU time by >= 1000us";
 
     // --- GetAllFields updates LRU time ---
     usleep(1000);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->GetAllFields({1}, all_out));
-    ASSERT_EQ("uri1", all_out[0][PROPERTY_URI]);
+    {
+        CacheLocationMapVector out_locs;
+        PropertyMapVector out_props;
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Get(nullptr, {1}, out_locs, out_props));
+        ASSERT_EQ("uri1", out_props[0][PROPERTY_URI]);
+    }
     int64_t lru_after_getall = getLruTime(1);
     ASSERT_GE(lru_after_getall - lru_after_get, kMinTimeDiffUs) << "GetAllFields should update LRU time by >= 1000us";
 
     // --- Exists updates LRU time ---
     usleep(1000);
     std::vector<bool> exist_vec;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Exists({1}, exist_vec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Exists(nullptr, {1}, exist_vec));
     ASSERT_TRUE(exist_vec[0]);
     int64_t lru_after_exists = getLruTime(1);
     ASSERT_GE(lru_after_exists - lru_after_getall, kMinTimeDiffUs) << "Exists should update LRU time by >= 1000us";
@@ -577,20 +609,22 @@ TEST_F(MetaLocalBackendTest, TestLruTimeUpdatedByReadWriteOps) {
     // --- UpdateFields updates LRU time ---
     usleep(1000);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->UpdateFields({1}, {{{PROPERTY_URI, "uri1-updated"}}}));
+              UpdateWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1-updated"}}}));
     int64_t lru_after_update = getLruTime(1);
     ASSERT_GE(lru_after_update - lru_after_exists, kMinTimeDiffUs)
         << "UpdateFields should update LRU time by >= 1000us";
 
     // --- Upsert updates LRU time ---
     usleep(1000);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Upsert({1}, {{{PROPERTY_URI, "uri1-upserted"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              UpsertWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1-upserted"}}}));
     int64_t lru_after_upsert = getLruTime(1);
     ASSERT_GE(lru_after_upsert - lru_after_update, kMinTimeDiffUs) << "Upsert should update LRU time by >= 1000us";
 
     // --- PutIfAbsent on new key ---
     usleep(1000);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), local_backend->PutIfAbsent({2}, {{{PROPERTY_URI, "uri2"}}}, {EC_OK}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutIfAbsentWithFieldMaps(local_backend, {2}, {{{PROPERTY_URI, "uri2"}}}, {EC_OK}));
     int64_t lru_key2 = getLruTime(2);
     ASSERT_GT(lru_key2, 0) << "PutIfAbsent should set LRU time on new key";
 
@@ -610,7 +644,8 @@ TEST_F(MetaLocalBackendTest, TestShardOldestAccessTimeEmptyToNonEmpty) {
     ASSERT_EQ(INT64_MAX, local_backend->shard_oldest_access_time_[1].load(std::memory_order_relaxed));
 
     // Insert a key.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({100}, {{{PROPERTY_URI, "uri100"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {100}, {{{PROPERTY_URI, "uri100"}}}));
 
     // At least one shard should now have a non-INT64_MAX timestamp.
     bool any_updated = (local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed) < INT64_MAX) ||
@@ -629,11 +664,12 @@ TEST_F(MetaLocalBackendTest, TestShardOldestAccessTimeNonEmptyToEmpty) {
     MetaLocalBackend *local_backend = GetLocalBackend();
 
     // Insert one key.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
     ASSERT_LT(local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed), INT64_MAX);
 
     // Delete the key — shard becomes empty, timestamp should go back to INT64_MAX.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete({1}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete(nullptr, {1}));
     ASSERT_EQ(INT64_MAX, local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed));
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
@@ -650,7 +686,7 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeysSelectsOldestShard) {
     // Insert keys into both shards.
     for (int64_t i = 1; i <= 100; ++i) {
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-                  meta_storage_backend_->Put({i}, {{{PROPERTY_URI, "uri" + std::to_string(i)}}}));
+                  PutWithFieldMaps(meta_storage_backend_.get(), {i}, {{{PROPERTY_URI, "uri" + std::to_string(i)}}}));
     }
 
     // Both shards should have entries now.
@@ -662,17 +698,17 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeysSelectsOldestShard) {
     // Sleep and then access all keys via Get to make them "newer".
     for (int64_t i = 1; i <= 50; ++i) {
         FieldMapVec out;
-        meta_storage_backend_->Get({i}, std::vector<std::string>{PROPERTY_URI}, out);
+        meta_storage_backend_->GetProperties(nullptr, {i}, std::vector<std::string>{PROPERTY_URI}, out);
     }
     usleep(1000);
     for (int64_t i = 51; i <= 100; ++i) {
         FieldMapVec out;
-        meta_storage_backend_->Get({i}, std::vector<std::string>{PROPERTY_URI}, out);
+        meta_storage_backend_->GetProperties(nullptr, {i}, std::vector<std::string>{PROPERTY_URI}, out);
     }
 
     // Now SampleReclaimKeys should return keys.
     std::vector<MetaStorageBackend::KeyType> reclaim_keys;
-    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(10, reclaim_keys));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(nullptr, 10, reclaim_keys));
     ASSERT_FALSE(reclaim_keys.empty()) << "SampleReclaimKeys should return some keys";
 
     // All returned keys should be valid (subset of inserted keys).
@@ -690,7 +726,7 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeysEmptyCache) {
 
     // SampleReclaimKeys on empty cache should return OK with no keys.
     std::vector<MetaStorageBackend::KeyType> reclaim_keys;
-    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(10, reclaim_keys));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(nullptr, 10, reclaim_keys));
     ASSERT_TRUE(reclaim_keys.empty());
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
@@ -705,25 +741,27 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeysAfterDeleteUpdatesTimestamp) {
     MetaLocalBackend *local_backend = GetLocalBackend();
 
     // Insert two keys with a time gap.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({1}, {{{PROPERTY_URI, "uri1"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
     usleep(1000);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({2}, {{{PROPERTY_URI, "uri2"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {2}, {{{PROPERTY_URI, "uri2"}}}));
 
     int64_t ts_before_delete = local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed);
 
     // Sample should return key 1 (oldest in LRU).
     std::vector<MetaStorageBackend::KeyType> reclaim_keys;
-    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(1, reclaim_keys));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(nullptr, 1, reclaim_keys));
     ASSERT_EQ(1u, reclaim_keys.size());
     ASSERT_EQ(1, reclaim_keys[0]);
 
     // Delete the sampled key.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete(reclaim_keys));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Delete(nullptr, reclaim_keys));
 
     // After deletion, the shard's oldest timestamp should have changed.
     int64_t ts_after_delete = local_backend->shard_oldest_access_time_[0].load(std::memory_order_relaxed);
     ASSERT_GE(ts_after_delete, ts_before_delete) << "After deleting the oldest key, shard timestamp should advance";
-    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(1, reclaim_keys));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->SampleReclaimKeys(nullptr, 1, reclaim_keys));
     ASSERT_EQ(1u, reclaim_keys.size());
     ASSERT_EQ(2, reclaim_keys[0]);
 
@@ -737,31 +775,31 @@ TEST_F(MetaLocalBackendTest, TestDeleteFields) {
     // Seed two keys: one with multiple location-prefixed fields, another with
     // a single location field plus a normal field.
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put(
-                  {1, 2},
-                  {{{LOCATION_PREFIX + "a", "la"}, {LOCATION_PREFIX + "b", "lb"}, {PROPERTY_URI, "u1"}},
-                   {{LOCATION_PREFIX + "c", "lc"}, {PROPERTY_URI, "u2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{LOCATION_PREFIX + "a", "la"}, {LOCATION_PREFIX + "b", "lb"}, {PROPERTY_URI, "u1"}},
+                                {{LOCATION_PREFIX + "c", "lc"}, {PROPERTY_URI, "u2"}}}));
 
     // key 1: delete one of two location fields; key 2: delete its only
     // location field; key 3: does not exist -> EC_NOENT.
-    AssertDeleteFields(meta_storage_backend_.get(),
-                       {1, 2, 3},
-                       {{LOCATION_PREFIX + "a"}, {LOCATION_PREFIX + "c"}, {"anything"}},
-                       {EC_OK, EC_OK, EC_NOENT});
+    AssertDeleteLocations(meta_storage_backend_.get(),
+                          {1, 2, 3},
+                          {{LOCATION_PREFIX + "a"}, {LOCATION_PREFIX + "c"}, {"anything"}},
+                          {EC_OK, EC_OK, EC_NOENT});
 
     // Non-deleted fields survive.
-    AssertGet(meta_storage_backend_.get(),
-              {1, 2},
-              {LOCATION_PREFIX + "a", LOCATION_PREFIX + "b", PROPERTY_URI},
-              {EC_OK, EC_OK},
-              {{{LOCATION_PREFIX + "b", "lb"}, {PROPERTY_URI, "u1"}}, {{PROPERTY_URI, "u2"}}});
+    AssertGetProperties(meta_storage_backend_.get(),
+                        {1, 2},
+                        {LOCATION_PREFIX + "a", LOCATION_PREFIX + "b", PROPERTY_URI},
+                        {EC_OK, EC_OK},
+                        {{{LOCATION_PREFIX + "b", "lb"}, {PROPERTY_URI, "u1"}}, {{PROPERTY_URI, "u2"}}});
 
     // Deleting a non-existent field on an existing key still returns EC_OK.
-    AssertDeleteFields(meta_storage_backend_.get(), {1}, {{"not_exist_field"}}, {EC_OK});
+    AssertDeleteLocations(meta_storage_backend_.get(), {1}, {{"not_exist_field"}}, {EC_OK});
 
     // Empty field list on an existing key is a no-op (EC_OK).
-    AssertDeleteFields(meta_storage_backend_.get(), {2}, {{}}, {EC_OK});
-    AssertGet(meta_storage_backend_.get(), {2}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "u2"}}});
+    AssertDeleteLocations(meta_storage_backend_.get(), {2}, {{}}, {EC_OK});
+    AssertGetProperties(meta_storage_backend_.get(), {2}, {PROPERTY_URI}, {EC_OK}, {{{PROPERTY_URI, "u2"}}});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -772,15 +810,15 @@ TEST_F(MetaLocalBackendTest, TestExistsFieldWithPrefix) {
 
     // key 1: has LOCATION_PREFIX field; key 2: only normal fields; key 3: not exist.
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put(
-                  {1, 2}, {{{LOCATION_PREFIX + "a", "la"}, {PROPERTY_URI, "u1"}}, {{PROPERTY_URI, "u2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{LOCATION_PREFIX + "a", "la"}, {PROPERTY_URI, "u1"}}, {{PROPERTY_URI, "u2"}}}));
 
-    AssertExistsFieldWithPrefix(
-        meta_storage_backend_.get(), {1, 2, 3}, LOCATION_PREFIX, {EC_OK, EC_OK, EC_NOENT}, {true, false, false});
+    AssertExistsLocation(meta_storage_backend_.get(), {1, 2, 3}, {EC_OK, EC_OK, EC_NOENT}, {true, false, false});
 
-    // After removing the only LOCATION_PREFIX field from key 1, prefix check is false.
-    AssertDeleteFields(meta_storage_backend_.get(), {1}, {{LOCATION_PREFIX + "a"}}, {EC_OK});
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(), {1}, LOCATION_PREFIX, {EC_OK}, {false});
+    // After removing the only location from key 1, location check is false.
+    AssertDeleteLocations(meta_storage_backend_.get(), {1}, {{"a"}}, {EC_OK});
+    AssertExistsLocation(meta_storage_backend_.get(), {1}, {EC_OK}, {false});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -791,30 +829,30 @@ TEST_F(MetaLocalBackendTest, TestTombstoneNotTreatedAsValidLocation) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     // Put key 1 with a real location and a tombstone (empty value) location.
-    ASSERT_EQ(
-        (std::vector<ErrorCode>{EC_OK}),
-        meta_storage_backend_->Put({1}, {{{LOCATION_PREFIX + "real", "valid_data"}, {LOCATION_PREFIX + "tomb", ""}}}));
-
-    // ExistsFieldWithPrefix should return true (real location exists).
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(), {1}, LOCATION_PREFIX, {EC_OK}, {true});
-
-    // GetFieldNamesWithPrefix should only return the non-tombstone field.
-    std::vector<std::vector<std::string>> field_names_vec;
-    auto ecs = meta_storage_backend_->GetFieldNamesWithPrefix({1}, LOCATION_PREFIX, field_names_vec);
-    ASSERT_EQ(EC_OK, ecs[0]);
-    ASSERT_EQ(1u, field_names_vec[0].size());
-    EXPECT_EQ(LOCATION_PREFIX + "real", field_names_vec[0][0]);
-
-    // Now update the real location to empty (tombstone it).
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->UpdateFields({1}, {{{LOCATION_PREFIX + "real", ""}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1},
+                               {{{LOCATION_PREFIX + "real", "valid_data"}, {LOCATION_PREFIX + "tomb", ""}}}));
 
-    // Both locations are now tombstones — should report no valid locations.
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(), {1}, LOCATION_PREFIX, {EC_OK}, {false});
-    field_names_vec.clear();
-    ecs = meta_storage_backend_->GetFieldNamesWithPrefix({1}, LOCATION_PREFIX, field_names_vec);
+    // ExistsLocation should return true (real location exists).
+    AssertExistsLocation(meta_storage_backend_.get(), {1}, {EC_OK}, {true});
+
+    // GetLocationIds should only return the non-tombstone location.
+    LocationIdsPerKey location_ids_vec;
+    auto ecs = meta_storage_backend_->GetLocationIds(nullptr, {1}, location_ids_vec);
     ASSERT_EQ(EC_OK, ecs[0]);
-    EXPECT_TRUE(field_names_vec[0].empty());
+    ASSERT_EQ(1u, location_ids_vec[0].size());
+    EXPECT_EQ("real", location_ids_vec[0][0]);
+
+    // Now delete the real location so only the tombstone remains.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->DeleteLocations(nullptr, {1}, {{"real"}}));
+
+    // The only valid location was removed — should report no valid locations.
+    AssertExistsLocation(meta_storage_backend_.get(), {1}, {EC_OK}, {false});
+    location_ids_vec.clear();
+    ecs = meta_storage_backend_->GetLocationIds(nullptr, {1}, location_ids_vec);
+    ASSERT_EQ(EC_OK, ecs[0]);
+    EXPECT_TRUE(location_ids_vec[0].empty());
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -824,23 +862,31 @@ TEST_F(MetaLocalBackendTest, TestGetPerKeyFields) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
-                                          {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{PROPERTY_URI, "uri1"}, {PROPERTY_HIT_COUNT, "100"}},
+                                {{PROPERTY_URI, "uri2"}, {PROPERTY_HIT_COUNT, "200"}}}));
 
-    // Each key queries a different subset; key 3 does not exist.
-    FieldMapVec field_maps;
+    // Each key queries a specific property subset; key 3 does not exist.
+    // Note: the new API uses a uniform field_names for all keys, so we test
+    // each subset separately.
+    PropertyMapVector props_uri;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}),
-              meta_storage_backend_->Get(
-                  {1, 2, 3},
-                  std::vector<std::vector<std::string>>{{PROPERTY_URI}, {PROPERTY_HIT_COUNT}, {PROPERTY_URI}},
-                  field_maps));
-    ASSERT_EQ((FieldMapVec{{{PROPERTY_URI, "uri1"}}, {{PROPERTY_HIT_COUNT, "200"}}, {}}), field_maps);
+              meta_storage_backend_->GetProperties(nullptr, {1, 2, 3}, {PROPERTY_URI}, props_uri));
+    ASSERT_EQ("uri1", props_uri[0][PROPERTY_URI]);
+    ASSERT_EQ("uri2", props_uri[1][PROPERTY_URI]);
+    ASSERT_TRUE(props_uri[2].empty());
 
-    // Empty field list on existing key returns EC_OK with empty FieldMap.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              meta_storage_backend_->Get({1}, std::vector<std::vector<std::string>>{{}}, field_maps));
-    ASSERT_EQ((FieldMapVec{{}}), field_maps);
+    PropertyMapVector props_hit;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              meta_storage_backend_->GetProperties(nullptr, {1, 2}, {PROPERTY_HIT_COUNT}, props_hit));
+    ASSERT_EQ("100", props_hit[0][PROPERTY_HIT_COUNT]);
+    ASSERT_EQ("200", props_hit[1][PROPERTY_HIT_COUNT]);
+
+    // Empty field list on existing key returns EC_OK with empty PropertyMap.
+    PropertyMapVector props_empty;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->GetProperties(nullptr, {1}, {}, props_empty));
+    ASSERT_TRUE(props_empty[0].empty());
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -852,18 +898,20 @@ TEST_F(MetaLocalBackendTest, TestConditionalDeleteFields) {
     MetaLocalBackend *local_backend = GetLocalBackend();
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_storage_backend_->Put({1, 2},
-                                         {{{LOCATION_PREFIX + "a", "la"}, {PROPERTY_URI, "u1"}},
-                                          {{LOCATION_PREFIX + "b", "lb"}, {PROPERTY_URI, "u2"}}}));
+              PutWithFieldMaps(meta_storage_backend_.get(),
+                               {1, 2},
+                               {{{LOCATION_PREFIX + "a", "la"}, {PROPERTY_URI, "u1"}},
+                                {{LOCATION_PREFIX + "b", "lb"}, {PROPERTY_URI, "u2"}}}));
 
     // previous_error_codes[0]=EC_OK -> actually delete; [1]=EC_EXIST -> passthrough untouched.
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_EXIST}),
-              local_backend->DeleteFields({1, 2},
-                                          {{LOCATION_PREFIX + "a"}, {LOCATION_PREFIX + "b"}},
-                                          /*previous_error_codes*/ {EC_OK, EC_EXIST}));
+              local_backend->DeleteLocations(nullptr,
+                                             {1, 2},
+                                             {{"a"}, {"b"}},
+                                             /*previous_error_codes*/ {EC_OK, EC_EXIST}));
 
-    // Key 1's LOCATION_PREFIX field was removed, key 2's remains intact.
-    AssertExistsFieldWithPrefix(meta_storage_backend_.get(), {1, 2}, LOCATION_PREFIX, {EC_OK, EC_OK}, {false, true});
+    // Key 1's location was removed, key 2's remains intact.
+    AssertExistsLocation(meta_storage_backend_.get(), {1, 2}, {EC_OK, EC_OK}, {false, true});
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
@@ -881,7 +929,8 @@ TEST_F(MetaLocalBackendTest, TestConcurrentReadWrite) {
     constexpr int kNumReaders = 6;
 
     // Seed an initial entry so readers/writers always have something to operate on.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_storage_backend_->Put({kTestKey}, {{{PROPERTY_URI, "initial"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {kTestKey}, {{{PROPERTY_URI, "initial"}}}));
 
     std::atomic<bool> stop{false};
     std::atomic<int> write_count{0};
@@ -892,11 +941,12 @@ TEST_F(MetaLocalBackendTest, TestConcurrentReadWrite) {
             std::string field_name = LOCATION_PREFIX + "w" + std::to_string(writer_id) + "_" + std::to_string(i);
             std::string field_value = "value_" + std::to_string(i);
 
-            auto update_ec = meta_storage_backend_->UpdateFields({kTestKey}, {{{field_name, field_value}}});
+            auto update_ec =
+                UpdateWithFieldMaps(meta_storage_backend_.get(), {kTestKey}, {{{field_name, field_value}}});
             ASSERT_EQ(1u, update_ec.size());
             ASSERT_EQ(EC_OK, update_ec[0]);
 
-            auto delete_ec = meta_storage_backend_->DeleteFields({kTestKey}, {{field_name}});
+            auto delete_ec = meta_storage_backend_->DeleteLocations(nullptr, {kTestKey}, {{field_name}});
             ASSERT_EQ(1u, delete_ec.size());
             ASSERT_EQ(EC_OK, delete_ec[0]);
 
@@ -904,33 +954,33 @@ TEST_F(MetaLocalBackendTest, TestConcurrentReadWrite) {
         }
     };
 
-    // Reader threads: exercise Get, GetAllFields, ExistsFieldWithPrefix, GetFieldNamesWithPrefix.
+    // Reader threads: exercise GetProperties, Get, ExistsLocation, GetLocationIds.
     auto reader_fn = [&](int /*reader_id*/) {
         for (int i = 0; i < kIterations && !stop.load(std::memory_order_relaxed); ++i) {
-            // Get with specific field names
-            FieldMapVec field_maps;
-            auto get_ec = meta_storage_backend_->Get({kTestKey}, {PROPERTY_URI}, field_maps);
+            // GetProperties with specific field names
+            PropertyMapVector prop_maps;
+            auto get_ec = meta_storage_backend_->GetProperties(nullptr, {kTestKey}, {PROPERTY_URI}, prop_maps);
             ASSERT_EQ(1u, get_ec.size());
             ASSERT_EQ(EC_OK, get_ec[0]);
 
-            // GetAllFields
-            FieldMapVec all_maps;
-            auto all_ec = meta_storage_backend_->GetAllFields({kTestKey}, all_maps);
+            // Get (full locations + properties)
+            CacheLocationMapVector out_locs;
+            PropertyMapVector out_props;
+            auto all_ec = meta_storage_backend_->Get(nullptr, {kTestKey}, out_locs, out_props);
             ASSERT_EQ(1u, all_ec.size());
             ASSERT_EQ(EC_OK, all_ec[0]);
 
-            // ExistsFieldWithPrefix
+            // ExistsLocation
             std::vector<bool> exists_vec;
-            auto exists_ec = meta_storage_backend_->ExistsFieldWithPrefix({kTestKey}, LOCATION_PREFIX, exists_vec);
+            auto exists_ec = meta_storage_backend_->ExistsLocation(nullptr, {kTestKey}, exists_vec);
             ASSERT_EQ(1u, exists_ec.size());
             ASSERT_EQ(EC_OK, exists_ec[0]);
 
-            // GetFieldNamesWithPrefix
-            std::vector<std::vector<std::string>> names_vec;
-            auto get_field_names_ec =
-                meta_storage_backend_->GetFieldNamesWithPrefix({kTestKey}, LOCATION_PREFIX, names_vec);
-            ASSERT_EQ(1u, get_field_names_ec.size());
-            ASSERT_EQ(EC_OK, get_field_names_ec[0]);
+            // GetLocationIds
+            LocationIdsPerKey loc_ids;
+            auto get_loc_ids_ec = meta_storage_backend_->GetLocationIds(nullptr, {kTestKey}, loc_ids);
+            ASSERT_EQ(1u, get_loc_ids_ec.size());
+            ASSERT_EQ(EC_OK, get_loc_ids_ec[0]);
         }
     };
 
@@ -951,8 +1001,8 @@ TEST_F(MetaLocalBackendTest, TestConcurrentReadWrite) {
     ASSERT_EQ(kNumWriters * kIterations, write_count.load());
 
     // The initial PROPERTY_URI field should still be intact.
-    FieldMapVec final_maps;
-    auto final_ec = meta_storage_backend_->Get({kTestKey}, {PROPERTY_URI}, final_maps);
+    PropertyMapVector final_maps;
+    auto final_ec = meta_storage_backend_->GetProperties(nullptr, {kTestKey}, {PROPERTY_URI}, final_maps);
     ASSERT_EQ(EC_OK, final_ec[0]);
     ASSERT_EQ("initial", final_maps[0][PROPERTY_URI]);
 
@@ -975,7 +1025,7 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
     constexpr size_t kMapNodeOverhead = sizeof(void *) * 4;
 
     // Insert a key with a small field.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "v"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), PutWithFieldMaps(backend.get(), {1}, {{{PROPERTY_URI, "v"}}}));
     size_t usage_after_put = backend->GetMemUsage();
 
     // --- UpdateFields: add a new field ---
@@ -983,7 +1033,8 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
     std::string field_name_a = "field_a";
     std::string field_value_a(1024, 'x');
     ssize_t expected_delta_add = static_cast<ssize_t>(field_name_a.size() + field_value_a.size() + kMapNodeOverhead);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->UpdateFields({1}, {{{field_name_a, field_value_a}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              UpdateWithFieldMaps(backend.get(), {1}, {{{field_name_a, field_value_a}}}));
     size_t usage_after_add = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_add - usage_after_put), expected_delta_add);
 
@@ -992,7 +1043,8 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
     std::string field_value_a_short = "short";
     ssize_t expected_delta_shrink =
         static_cast<ssize_t>(field_value_a_short.size()) - static_cast<ssize_t>(field_value_a.size());
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->UpdateFields({1}, {{{field_name_a, field_value_a_short}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              UpdateWithFieldMaps(backend.get(), {1}, {{{field_name_a, field_value_a_short}}}));
     size_t usage_after_shrink = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_shrink) - static_cast<ssize_t>(usage_after_add), expected_delta_shrink);
 
@@ -1000,7 +1052,8 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
     std::string field_name_b = "field_b";
     std::string field_value_b(512, 'y');
     ssize_t expected_delta_upsert = static_cast<ssize_t>(field_name_b.size() + field_value_b.size() + kMapNodeOverhead);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Upsert({1}, {{{field_name_b, field_value_b}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              UpsertWithFieldMaps(backend.get(), {1}, {{{field_name_b, field_value_b}}}));
     size_t usage_after_upsert = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_upsert - usage_after_shrink), expected_delta_upsert);
 
@@ -1008,7 +1061,7 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
     // Expected delta: -(field_name.size() + field_value.size() + kMapNodeOverhead)
     ssize_t expected_delta_delete =
         -static_cast<ssize_t>(field_name_b.size() + field_value_b.size() + kMapNodeOverhead);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->DeleteFields({1}, {{field_name_b}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->DeleteLocations(nullptr, {1}, {{field_name_b}}));
     size_t usage_after_delete = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_delete) - static_cast<ssize_t>(usage_after_upsert),
               expected_delta_delete);
@@ -1021,7 +1074,7 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
 
     // Verify the remaining data is intact.
     FieldMapVec out;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Get({1}, {PROPERTY_URI, field_name_a}, out));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->GetProperties(nullptr, {1}, {PROPERTY_URI, field_name_a}, out));
     ASSERT_EQ("v", out[0][PROPERTY_URI]);
     ASSERT_EQ(field_value_a_short, out[0][field_name_a]);
 
@@ -1043,25 +1096,25 @@ TEST_F(MetaLocalBackendTest, TestStrictCapacityInsertFails) {
     const size_t capacity = backend->cache_->GetCapacity(); // 1 MB
 
     // Insert a small entry first to verify basic functionality.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->Put({1}, {{{PROPERTY_URI, "small"}}}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), PutWithFieldMaps(backend.get(), {1}, {{{PROPERTY_URI, "small"}}}));
 
     // Try to insert an entry whose charge exceeds the entire capacity.
     std::string huge_value(capacity + 1, 'A');
-    auto results = backend->Put({2}, {{{PROPERTY_URI, huge_value}}});
+    auto results = PutWithFieldMaps(backend.get(), {2}, {{{PROPERTY_URI, huge_value}}});
     ASSERT_EQ(EC_NOSPC, results[0]);
 
     // The small entry should still be readable
     FieldMapVec out;
-    auto get_ec = backend->Get({1}, {PROPERTY_URI}, out);
+    auto get_ec = backend->GetProperties(nullptr, {1}, {PROPERTY_URI}, out);
     ASSERT_TRUE(EC_OK == get_ec[0]);
 
     FieldMapVec out2;
-    auto get_ec2 = backend->Get({2}, {PROPERTY_URI}, out2);
+    auto get_ec2 = backend->GetProperties(nullptr, {2}, {PROPERTY_URI}, out2);
     ASSERT_EQ(EC_NOENT, get_ec2[0]);
 
     // A reasonably-sized entry should succeed after the failed attempt.
     std::string normal_value(1024, 'B');
-    auto retry = backend->Put({3}, {{{PROPERTY_URI, normal_value}}});
+    auto retry = PutWithFieldMaps(backend.get(), {3}, {{{PROPERTY_URI, normal_value}}});
     ASSERT_EQ(EC_OK, retry[0]);
 
     ASSERT_EQ(EC_OK, backend->Close());

--- a/kv_cache_manager/meta/test/meta_redis_backend_real_service_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_real_service_test.cc
@@ -93,7 +93,8 @@ TEST_F(MetaRedisBackendRealServiceTest, TestMultiThreadSimple) {
     std::atomic<int> put_index = 0;
     auto put_task = [&, this]() {
         int i = put_index++;
-        auto ec_per_key = meta_redis_backend_->Put(keys_vec[i], field_maps_vec[i]);
+        auto ec_per_key = meta_redis_backend_->Put(
+            nullptr, keys_vec[i], CacheLocationMapVector(keys_vec[i].size()), field_maps_vec[i]);
         ASSERT_EQ(std::vector<ErrorCode>(keys_vec[i].size(), EC_OK), ec_per_key);
     };
     std::vector<std::thread> put_threads;
@@ -109,7 +110,8 @@ TEST_F(MetaRedisBackendRealServiceTest, TestMultiThreadSimple) {
     auto get_task = [&, this]() {
         int i = get_index++;
         FieldMapVec out_field_map;
-        auto ec_per_key = meta_redis_backend_->Get(keys_vec[i], std::vector<std::string>{"f1", "f2"}, out_field_map);
+        auto ec_per_key = meta_redis_backend_->GetProperties(
+            nullptr, keys_vec[i], std::vector<std::string>{"f1", "f2"}, out_field_map);
         ASSERT_EQ(std::vector<ErrorCode>(keys_vec[i].size(), EC_OK), ec_per_key);
         ASSERT_EQ(field_maps_vec[i], out_field_map);
     };
@@ -141,7 +143,7 @@ TEST_F(MetaRedisBackendRealServiceTest, TestConcurrentMixedOperations) {
     for (int i = 0; i < COUNT; ++i) {
         keys_vec.emplace_back(KeyTypeVec{MyKey(i), MyKey(i + 1000)});
         field_maps_vec.emplace_back(FieldMapVec{MyMap(i), MyMap(i + 1000)});
-        auto ec_per_key = meta_redis_backend_->Delete(keys_vec.back());
+        auto ec_per_key = meta_redis_backend_->Delete(nullptr, keys_vec.back());
         for (const auto &ec : ec_per_key) {
             ASSERT_TRUE(ec == EC_OK || ec == EC_NOENT);
         }
@@ -158,14 +160,14 @@ TEST_F(MetaRedisBackendRealServiceTest, TestConcurrentMixedOperations) {
         switch (op_id % 4) {
         case 0: // PUT
         {
-            auto ec_per_key = meta_redis_backend_->Put(keys, field_maps);
+            auto ec_per_key = meta_redis_backend_->Put(nullptr, keys, CacheLocationMapVector(keys.size()), field_maps);
             ASSERT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), ec_per_key);
         } break;
         case 1: // GET
         {
             FieldMapVec out_field_maps;
             std::vector<std::string> field_names = {"name", "value", "updated", "ts"};
-            auto ec_per_key = meta_redis_backend_->Get(keys, field_names, out_field_maps);
+            auto ec_per_key = meta_redis_backend_->GetProperties(nullptr, keys, field_names, out_field_maps);
             ASSERT_EQ(keys.size(), ec_per_key.size());
             ASSERT_EQ(keys.size(), out_field_maps.size());
             for (int i = 0; i < ec_per_key.size(); ++i) {
@@ -193,7 +195,8 @@ TEST_F(MetaRedisBackendRealServiceTest, TestConcurrentMixedOperations) {
         {
             FieldMap update_map = {{"updated", "true"}, {"ts", "1234"}};
             FieldMapVec update_maps(keys.size(), update_map);
-            auto ec_per_key = meta_redis_backend_->UpdateFields(keys, update_maps);
+            auto ec_per_key =
+                meta_redis_backend_->Update(nullptr, keys, CacheLocationMapVector(keys.size()), update_maps);
             ASSERT_EQ(keys.size(), ec_per_key.size());
             for (auto ec : ec_per_key) {
                 ASSERT_TRUE(ec == EC_OK || ec == EC_NOENT) << ec;
@@ -202,7 +205,7 @@ TEST_F(MetaRedisBackendRealServiceTest, TestConcurrentMixedOperations) {
         case 3: // EXISTS
         {
             std::vector<bool> out_is_exist_vec;
-            auto ec_per_key = meta_redis_backend_->Exists(keys, out_is_exist_vec);
+            auto ec_per_key = meta_redis_backend_->Exists(nullptr, keys, out_is_exist_vec);
             ASSERT_EQ(keys.size(), out_is_exist_vec.size());
             ASSERT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), ec_per_key);
         } break;
@@ -234,7 +237,7 @@ TEST_F(MetaRedisBackendRealServiceTest, TestConcurrentListAndRandomOperations) {
     for (int i = 0; i < COUNT; ++i) {
         KeyTypeVec keys = {MyKey(i), MyKey(i + COUNT)};
         FieldMapVec field_maps = {MyMap(i), MyMap(i + COUNT)};
-        auto ec_per_key = meta_redis_backend_->Put(keys, field_maps);
+        auto ec_per_key = meta_redis_backend_->Put(nullptr, keys, CacheLocationMapVector(keys.size()), field_maps);
         ASSERT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), ec_per_key);
     }
 
@@ -244,14 +247,14 @@ TEST_F(MetaRedisBackendRealServiceTest, TestConcurrentListAndRandomOperations) {
         if (op_id % 2 == 0) {
             std::string next_cursor;
             KeyTypeVec out_keys;
-            ErrorCode ec = meta_redis_backend_->ListKeys(SCAN_BASE_CURSOR, 10, next_cursor, out_keys);
+            ErrorCode ec = meta_redis_backend_->ListKeys(nullptr, SCAN_BASE_CURSOR, 10, next_cursor, out_keys);
             ASSERT_EQ(EC_OK, ec);
             for (const KeyType &key : out_keys) {
                 ASSERT_TRUE(key >= 0 && key <= COUNT * 2);
             }
         } else {
             std::vector<KeyType> out_keys;
-            ErrorCode ec = meta_redis_backend_->SampleReclaimKeys(5, out_keys);
+            ErrorCode ec = meta_redis_backend_->SampleReclaimKeys(nullptr, 5, out_keys);
             ASSERT_EQ(EC_OK, ec);
             for (const KeyType &key : out_keys) {
                 ASSERT_TRUE(key >= 0 && key <= COUNT * 2);
@@ -292,7 +295,8 @@ TEST_F(MetaRedisBackendRealServiceTest, TestScanUntilBaseCursor) {
 
     // Put all keys
     for (int i = 0; i < COUNT; ++i) {
-        auto ec_per_key = meta_redis_backend_->Put(keys_vec[i], field_maps_vec[i]);
+        auto ec_per_key = meta_redis_backend_->Put(
+            nullptr, keys_vec[i], CacheLocationMapVector(keys_vec[i].size()), field_maps_vec[i]);
         ASSERT_EQ(std::vector<ErrorCode>(keys_vec[i].size(), EC_OK), ec_per_key);
     }
 
@@ -305,7 +309,7 @@ TEST_F(MetaRedisBackendRealServiceTest, TestScanUntilBaseCursor) {
 
     do {
         KeyTypeVec batch_keys;
-        auto ec = meta_redis_backend_->ListKeys(current_cursor, /*limit*/ 50, next_cursor, batch_keys);
+        auto ec = meta_redis_backend_->ListKeys(nullptr, current_cursor, /*limit*/ 50, next_cursor, batch_keys);
         ASSERT_EQ(EC_OK, ec);
 
         // Check that batch_keys doesn't contain any keys that are already in all_listed_keys
@@ -339,7 +343,7 @@ TEST_F(MetaRedisBackendRealServiceTest, TestScanUntilBaseCursor) {
 
     // Clean up: delete all keys
     for (int i = 0; i < COUNT; ++i) {
-        auto ec_per_key = meta_redis_backend_->Delete(keys_vec[i]);
+        auto ec_per_key = meta_redis_backend_->Delete(nullptr, keys_vec[i]);
         ASSERT_EQ(std::vector<ErrorCode>(keys_vec[i].size(), EC_OK), ec_per_key);
     }
 
@@ -368,7 +372,8 @@ TEST_F(MetaRedisBackendRealServiceTest, TestMultiOpen) {
     std::atomic<int> put_index = 0;
     auto put_task = [&, this]() {
         int i = put_index++;
-        auto ec_per_key = meta_redis_backend_->Put(keys_vec[i], field_maps_vec[i]);
+        auto ec_per_key = meta_redis_backend_->Put(
+            nullptr, keys_vec[i], CacheLocationMapVector(keys_vec[i].size()), field_maps_vec[i]);
         ASSERT_EQ(std::vector<ErrorCode>(keys_vec[i].size(), EC_OK), ec_per_key);
     };
     std::vector<std::thread> put_threads;
@@ -396,7 +401,8 @@ TEST_F(MetaRedisBackendRealServiceTest, TestMultiOpen) {
     auto get_task = [&, this]() {
         int i = get_index++;
         FieldMapVec out_field_map;
-        auto ec_per_key = meta_redis_backend_->Get(keys_vec[i], std::vector<std::string>{"f1", "f2"}, out_field_map);
+        auto ec_per_key = meta_redis_backend_->GetProperties(
+            nullptr, keys_vec[i], std::vector<std::string>{"f1", "f2"}, out_field_map);
         ASSERT_EQ(std::vector<ErrorCode>(keys_vec[i].size(), EC_OK), ec_per_key);
         ASSERT_EQ(field_maps_vec[i], out_field_map);
     };
@@ -418,117 +424,6 @@ TEST_F(MetaRedisBackendRealServiceTest, TestMultiOpen) {
         thread.join();
     }
 
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
-}
-
-TEST_F(MetaRedisBackendRealServiceTest, TestDeleteFields) {
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("test_delete_fields", meta_storage_backend_config_));
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
-
-    constexpr KeyType kKey1 = 9001;
-    constexpr KeyType kKey2 = 9002;
-    constexpr KeyType kKeyMissing = 9003;
-
-    // Clean residual data from previous runs to make the test idempotent.
-    meta_redis_backend_->Delete({kKey1, kKey2, kKeyMissing});
-
-    // Seed two keys: kKey1 has 3 fields, kKey2 has 1 field.
-    ASSERT_EQ(
-        (std::vector<ErrorCode>{EC_OK, EC_OK}),
-        meta_redis_backend_->Put({kKey1, kKey2}, {{{"f1", "v1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}}}));
-
-    // kKey1: delete two existing fields (EC_OK);
-    // kKey2: delete a missing field — HDEL is idempotent (EC_OK);
-    // kKeyMissing: key does not exist — HDEL is idempotent (EC_OK).
-    auto ec_vec =
-        meta_redis_backend_->DeleteFields({kKey1, kKey2, kKeyMissing}, {{"f1", "f2"}, {"missing_field"}, {"anything"}});
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), ec_vec);
-
-    // kKey1 should retain only f3; kKey2 should still have its original field.
-    FieldMapVec field_maps;
-    auto get_ec = meta_redis_backend_->Get({kKey1, kKey2}, std::vector<std::string>{"f1", "f2", "f3"}, field_maps);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), get_ec);
-    ASSERT_EQ(1u, field_maps[0].size());
-    ASSERT_EQ("v1-3", field_maps[0]["f3"]);
-    ASSERT_EQ("v2-1", field_maps[1]["f1"]);
-
-    // Cleanup.
-    meta_redis_backend_->Delete({kKey1, kKey2});
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
-}
-
-TEST_F(MetaRedisBackendRealServiceTest, TestExistsFieldWithPrefix) {
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("test_exists_field_with_prefix", meta_storage_backend_config_));
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
-
-    constexpr KeyType kKeyWithPrefix = 9101;
-    constexpr KeyType kKeyWithoutPrefix = 9102;
-    constexpr KeyType kKeyMissing = 9103;
-
-    meta_redis_backend_->Delete({kKeyWithPrefix, kKeyWithoutPrefix, kKeyMissing});
-
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_redis_backend_->Put(
-                  {kKeyWithPrefix, kKeyWithoutPrefix},
-                  {{{LOCATION_PREFIX + "a", "la"}, {LOCATION_PREFIX + "b", "lb"}, {"p0", "v0"}}, {{"p0", "v0"}}}));
-
-    // ExistsFieldWithPrefix now uses EXISTS to detect missing keys.
-    // kKeyMissing does not exist → EC_NOENT; the other two exist → EC_OK.
-    std::vector<bool> exists_vec;
-    auto ec_vec = meta_redis_backend_->ExistsFieldWithPrefix(
-        {kKeyWithPrefix, kKeyWithoutPrefix, kKeyMissing}, LOCATION_PREFIX, exists_vec);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}), ec_vec);
-    ASSERT_EQ((std::vector<bool>{true, false, false}), exists_vec);
-
-    // Removing one of the two LOCATION_PREFIX fields: the remaining one still
-    // satisfies the prefix check.
-    auto del_ec = meta_redis_backend_->DeleteFields({kKeyWithPrefix}, {{LOCATION_PREFIX + "a"}});
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), del_ec);
-    ec_vec = meta_redis_backend_->ExistsFieldWithPrefix({kKeyWithPrefix}, LOCATION_PREFIX, exists_vec);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), ec_vec);
-    ASSERT_EQ((std::vector<bool>{true}), exists_vec);
-
-    // Removing the remaining LOCATION_PREFIX field: now the prefix check is false.
-    del_ec = meta_redis_backend_->DeleteFields({kKeyWithPrefix}, {{LOCATION_PREFIX + "b"}});
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), del_ec);
-    ec_vec = meta_redis_backend_->ExistsFieldWithPrefix({kKeyWithPrefix}, LOCATION_PREFIX, exists_vec);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), ec_vec);
-    ASSERT_EQ((std::vector<bool>{false}), exists_vec);
-
-    // Cleanup.
-    meta_redis_backend_->Delete({kKeyWithPrefix, kKeyWithoutPrefix});
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
-}
-
-TEST_F(MetaRedisBackendRealServiceTest, TestGet) {
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("test_get_per_key_fields", meta_storage_backend_config_));
-    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
-
-    constexpr KeyType kKey1 = 9201;
-    constexpr KeyType kKey2 = 9202;
-    constexpr KeyType kKeyMissing = 9203;
-
-    meta_redis_backend_->Delete({kKey1, kKey2, kKeyMissing});
-
-    ASSERT_EQ(
-        (std::vector<ErrorCode>{EC_OK, EC_OK}),
-        meta_redis_backend_->Put({kKey1, kKey2},
-                                 {{{"f1", "v1-1"}, {"f2", "v1-2"}, {"f3", "v1-3"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}}));
-
-    // kKey1 asks {f1, f3}; kKey2 asks {f2, f3} (f3 missing -> dropped);
-    // kKeyMissing does not exist -> EC_NOENT.
-    FieldMapVec field_maps;
-    auto ec_vec = meta_redis_backend_->Get({kKey1, kKey2, kKeyMissing},
-                                           std::vector<std::vector<std::string>>{{"f1", "f3"}, {"f2", "f3"}, {"f1"}},
-                                           field_maps);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}), ec_vec);
-    ASSERT_EQ(3u, field_maps.size());
-    ASSERT_EQ((FieldMap{{"f1", "v1-1"}, {"f3", "v1-3"}}), field_maps[0]);
-    ASSERT_EQ((FieldMap{{"f2", "v2-2"}}), field_maps[1]);
-    ASSERT_TRUE(field_maps[2].empty());
-
-    // Cleanup.
-    meta_redis_backend_->Delete({kKey1, kKey2});
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
 

--- a/kv_cache_manager/meta/test/meta_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_test.cc
@@ -383,11 +383,13 @@ TEST_F(MetaRedisBackendTest, TestDeleteFields) {
         std::vector<ReplyUPtr> replies;
         replies.emplace_back(MakeFakeReplyInteger(2));
         replies.emplace_back(MakeFakeReplyInteger(0));
-        EXPECT_CALL(
-            *mock_redis_client,
-            TryExecPipeline(ElementsAre(
-                ElementsAre(StrEq("HDEL"), StrEq("kvcache:instance_instance_0:cache_1"), StrEq("f1"), StrEq("f2")),
-                ElementsAre(StrEq("HDEL"), StrEq("kvcache:instance_instance_0:cache_2"), StrEq("f3")))))
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(
+                        ElementsAre(StrEq("HDEL"),
+                                    StrEq("kvcache:instance_instance_0:cache_1"),
+                                    StrEq("__loc__f1"),
+                                    StrEq("__loc__f2")),
+                        ElementsAre(StrEq("HDEL"), StrEq("kvcache:instance_instance_0:cache_2"), StrEq("__loc__f3")))))
             .WillOnce(Return(ByMove(std::move(replies))));
         return mock_redis_client;
     }));
@@ -555,24 +557,29 @@ TEST_F(MetaRedisBackendTest, TestGet) {
         EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
         EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
 
-        // key 1 asks {f1} -> "v1-1"; key 2 asks {f2, f3} -> "v2-2", null (f3 missing).
-        std::vector<ReplyUPtr> replies;
-        replies.emplace_back(MakeFakeReplyArrayString({"v1-1"}));
-        replies.emplace_back(MakeFakeReplyArrayString({"v2-2", std::nullopt}));
-        EXPECT_CALL(
-            *mock_redis_client,
-            TryExecPipeline(ElementsAre(
-                ElementsAre(StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_1"), StrEq("f1")),
-                ElementsAre(StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_2"), StrEq("f2"), StrEq("f3")))))
-            .WillOnce(Return(ByMove(std::move(replies))));
+        // Each GetProperties call creates a separate pipeline request.
+        // Call 1: key 1 asks {f1} -> "v1-1"
+        std::vector<ReplyUPtr> replies1;
+        replies1.emplace_back(MakeFakeReplyArrayString({"v1-1"}));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(
+                        ElementsAre(StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_1"), StrEq("f1")))))
+            .WillOnce(Return(ByMove(std::move(replies1))));
+
+        // Call 2: key 2 asks {f2, f3} -> "v2-2", null (f3 missing)
+        std::vector<ReplyUPtr> replies2;
+        replies2.emplace_back(MakeFakeReplyArrayString({"v2-2", std::nullopt}));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(ElementsAre(
+                        StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_2"), StrEq("f2"), StrEq("f3")))))
+            .WillOnce(Return(ByMove(std::move(replies2))));
         return mock_redis_client;
     }));
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
-    // Note: the new API uses a uniform field_names for all keys via GetProperties.
-    // Test key 1 with f1, key 2 with f2.
+    // Each GetProperties call sends a separate pipeline to Redis.
     PropertyMapVector props1;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_redis_backend_->GetProperties(nullptr, {1}, {"f1"}, props1));
     ASSERT_EQ("v1-1", props1[0]["f1"]);

--- a/kv_cache_manager/meta/test/meta_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_test.cc
@@ -252,16 +252,17 @@ TEST_F(MetaRedisBackendTest, TestSimple) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_redis_backend_->Put({1, 2}, {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}));
+              PutWithFieldMaps(meta_redis_backend_.get(), {1, 2}, {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}),
-              meta_redis_backend_->UpdateFields({1, 2, 3}, {{{"f2", "v1-2"}}, {{"f2", "v2-2"}}, {{"f3", "v3-2"}}}));
+              UpdateWithFieldMaps(
+                  meta_redis_backend_.get(), {1, 2, 3}, {{{"f2", "v1-2"}}, {{"f2", "v2-2"}}, {{"f3", "v3-2"}}}));
 
     AssertExists(meta_redis_backend_.get(), {1, 2, 4}, {EC_OK, EC_OK, EC_OK}, /*is_exist*/ {true, true, false});
-    AssertGet(meta_redis_backend_.get(),
-              {1, 2},
-              {"f1", "f2"},
-              {EC_OK, EC_OK},
-              {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+    AssertGetProperties(meta_redis_backend_.get(),
+                        {1, 2},
+                        {"f1", "f2"},
+                        {EC_OK, EC_OK},
+                        {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
     AssertGetAllFields(meta_redis_backend_.get(),
                        {1, 2},
                        {EC_OK, EC_OK},
@@ -272,12 +273,12 @@ TEST_F(MetaRedisBackendTest, TestSimple) {
 
     // test upsert
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
-              meta_redis_backend_->Upsert({2, 3}, {{{"f1", "v2-1-2"}}, {{"f1", "v3-1"}}}));
-    AssertGet(meta_redis_backend_.get(),
-              {2, 3},
-              {"f1", "f2"},
-              {EC_OK, EC_OK},
-              {{{"f1", "v2-1-2"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}}});
+              UpsertWithFieldMaps(meta_redis_backend_.get(), {2, 3}, {{{"f1", "v2-1-2"}}, {{"f1", "v3-1"}}}));
+    AssertGetProperties(meta_redis_backend_.get(),
+                        {2, 3},
+                        {"f1", "f2"},
+                        {EC_OK, EC_OK},
+                        {{{"f1", "v2-1-2"}, {"f2", "v2-2"}}, {{"f1", "v3-1"}}});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
@@ -294,28 +295,32 @@ TEST_F(MetaRedisBackendTest, TestRedisError) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
     ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}),
-              meta_redis_backend_->Put({1, 2}, {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}));
+              PutWithFieldMaps(meta_redis_backend_.get(), {1, 2}, {{{"f1", "v1-1"}}, {{"f1", "v2-1"}}}));
     ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR, EC_ERROR}),
-              meta_redis_backend_->UpdateFields({1, 2, 3}, {{{"f2", "v1-2"}}, {{"f2", "v2-2"}}, {{"f3", "v3-2"}}}));
+              UpdateWithFieldMaps(
+                  meta_redis_backend_.get(), {1, 2, 3}, {{{"f2", "v1-2"}}, {{"f2", "v2-2"}}, {{"f3", "v3-2"}}}));
 
     std::vector<bool> is_exist_vec;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), meta_redis_backend_->Exists({1, 2}, is_exist_vec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), meta_redis_backend_->Exists(nullptr, {1, 2}, is_exist_vec));
     ASSERT_EQ(std::vector<bool>(2, false), is_exist_vec);
 
-    FieldMapVec field_maps;
+    PropertyMapVector prop_maps;
     ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}),
-              meta_redis_backend_->Get({1, 2}, std::vector<std::string>{"f1", "f2"}, field_maps));
-    ASSERT_EQ(std::vector<FieldMap>(2), field_maps);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), meta_redis_backend_->GetAllFields({1, 2}, field_maps));
-    ASSERT_EQ(std::vector<FieldMap>(2), field_maps);
+              meta_redis_backend_->GetProperties(nullptr, {1, 2}, std::vector<std::string>{"f1", "f2"}, prop_maps));
+    ASSERT_EQ(PropertyMapVector(2), prop_maps);
+    CacheLocationMapVector out_locs;
+    PropertyMapVector out_props;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}),
+              meta_redis_backend_->Get(nullptr, {1, 2}, out_locs, out_props));
+    ASSERT_EQ(PropertyMapVector(2), out_props);
 
     std::string next_cursor;
     KeyTypeVec keys;
-    ASSERT_EQ(EC_ERROR, meta_redis_backend_->ListKeys(SCAN_BASE_CURSOR, /*limit*/ 5, next_cursor, keys));
+    ASSERT_EQ(EC_ERROR, meta_redis_backend_->ListKeys(nullptr, SCAN_BASE_CURSOR, /*limit*/ 5, next_cursor, keys));
     ASSERT_TRUE(next_cursor.empty());
     ASSERT_TRUE(keys.empty());
 
-    ASSERT_EQ(EC_ERROR, meta_redis_backend_->SampleReclaimKeys(/*count*/ 5, keys));
+    ASSERT_EQ(EC_ERROR, meta_redis_backend_->SampleReclaimKeys(nullptr, /*count*/ 5, keys));
     ASSERT_TRUE(keys.empty());
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
@@ -350,11 +355,11 @@ TEST_F(MetaRedisBackendTest, TestMultiThreadSimple) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
     auto get_task = [this]() {
-        AssertGet(meta_redis_backend_.get(),
-                  {1, 2},
-                  {"f1", "f2"},
-                  {EC_OK, EC_OK},
-                  {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
+        AssertGetProperties(meta_redis_backend_.get(),
+                            {1, 2},
+                            {"f1", "f2"},
+                            {EC_OK, EC_OK},
+                            {{{"f1", "v1-1"}, {"f2", "v1-2"}}, {{"f1", "v2-1"}, {"f2", "v2-2"}}});
     };
     std::vector<std::thread> threads;
     for (int i = 0; i < 10; ++i) {
@@ -391,10 +396,10 @@ TEST_F(MetaRedisBackendTest, TestDeleteFields) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
     // HDEL returning 0 (no field actually removed) is now idempotent EC_OK.
-    AssertDeleteFields(meta_redis_backend_.get(),
-                       {1, 2},
-                       /*field_names_vec*/ {{"f1", "f2"}, {"f3"}},
-                       {EC_OK, EC_OK});
+    AssertDeleteLocations(meta_redis_backend_.get(),
+                          {1, 2},
+                          /*location_ids*/ {{"f1", "f2"}, {"f3"}},
+                          {EC_OK, EC_OK});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
@@ -442,7 +447,7 @@ TEST_F(MetaRedisBackendTest, TestExistsFieldWithPrefix) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
-    AssertExistsFieldWithPrefix(meta_redis_backend_.get(), {1, 2}, LOCATION_PREFIX, {EC_OK, EC_OK}, {true, false});
+    AssertExistsLocation(meta_redis_backend_.get(), {1, 2}, {EC_OK, EC_OK}, {true, false});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
@@ -475,7 +480,7 @@ TEST_F(MetaRedisBackendTest, TestExistsFieldWithPrefixIgnoresTombstone) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
-    AssertExistsFieldWithPrefix(meta_redis_backend_.get(), {1, 2}, LOCATION_PREFIX, {EC_OK, EC_OK}, {false, true});
+    AssertExistsLocation(meta_redis_backend_.get(), {1, 2}, {EC_OK, EC_OK}, {false, true});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
@@ -517,7 +522,7 @@ TEST_F(MetaRedisBackendTest, TestExistsFieldWithPrefixKeyNotExist) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
-    AssertExistsFieldWithPrefix(meta_redis_backend_.get(), {1, 2}, LOCATION_PREFIX, {EC_OK, EC_NOENT}, {true, false});
+    AssertExistsLocation(meta_redis_backend_.get(), {1, 2}, {EC_OK, EC_NOENT}, {true, false});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
@@ -538,7 +543,7 @@ TEST_F(MetaRedisBackendTest, TestDeleteFieldsEmptyFieldList) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
-    AssertDeleteFields(meta_redis_backend_.get(), {1, 2}, {{}, {}}, {EC_OK, EC_OK});
+    AssertDeleteLocations(meta_redis_backend_.get(), {1, 2}, {{}, {}}, {EC_OK, EC_OK});
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
@@ -566,11 +571,15 @@ TEST_F(MetaRedisBackendTest, TestGet) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
 
-    FieldMapVec field_maps;
-    ASSERT_EQ(
-        (std::vector<ErrorCode>{EC_OK, EC_OK}),
-        meta_redis_backend_->Get({1, 2}, std::vector<std::vector<std::string>>{{"f1"}, {"f2", "f3"}}, field_maps));
-    ASSERT_EQ((FieldMapVec{{{"f1", "v1-1"}}, {{"f2", "v2-2"}}}), field_maps);
+    // Note: the new API uses a uniform field_names for all keys via GetProperties.
+    // Test key 1 with f1, key 2 with f2.
+    PropertyMapVector props1;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_redis_backend_->GetProperties(nullptr, {1}, {"f1"}, props1));
+    ASSERT_EQ("v1-1", props1[0]["f1"]);
+    PropertyMapVector props2;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), meta_redis_backend_->GetProperties(nullptr, {2}, {"f2", "f3"}, props2));
+    ASSERT_EQ("v2-2", props2[0]["f2"]);
+    ASSERT_TRUE(props2[0].find("f3") == props2[0].end());
 
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_real_redis_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_real_redis_test.cc
@@ -40,15 +40,15 @@ public:
         return config;
     }
 
-    static CacheLocation MakeLocation(const std::string &id, const std::string &uri) {
-        CacheLocation loc;
-        loc.set_id(id);
-        loc.set_status(CacheLocationStatus::CLS_SERVING);
-        loc.set_type(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
-        loc.set_spec_size(1);
+    static CacheLocationConstPtr MakeLocation(const std::string &id, const std::string &uri) {
+        auto loc = std::make_shared<CacheLocation>();
+        loc->set_id(id);
+        loc->set_status(CacheLocationStatus::CLS_SERVING);
+        loc->set_type(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
+        loc->set_spec_size(1);
         std::vector<LocationSpec> specs;
         specs.emplace_back("default", uri);
-        loc.set_location_specs(std::move(specs));
+        loc->set_location_specs(std::move(specs));
         return loc;
     }
 
@@ -81,9 +81,10 @@ public:
             batch.batch_properties.resize(batch.batch_keys.size());
         }
         for (size_t i = 0; i < batch.batch_keys.size(); ++i) {
-            for (const auto &loc_kv : batch.batch_locations[i]) {
-                const CacheLocation &location = loc_kv.second;
-                batch.batch_properties[i][LOCATION_PREFIX + location.id()] = location.ToJsonString();
+            for (const auto &[loc_id, loc_ptr] : batch.batch_locations[i]) {
+                if (!loc_ptr)
+                    continue;
+                batch.batch_properties[i][LOCATION_PREFIX + loc_ptr->id()] = loc_ptr->ToJsonString();
             }
         }
     }
@@ -119,13 +120,13 @@ TEST_F(MetaStorageBackendManagerRealRedisTest, TestDualBackendPutAndGet) {
     auto batch = MakeBatch(keys);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Put(request_context_.get(), batch));
 
-    LocationMapVector out_locations;
+    CacheLocationMapVector out_locations;
     auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), get_ecs);
     for (size_t i = 0; i < keys.size(); ++i) {
         const std::string loc_id = "loc_" + std::to_string(keys[i]);
         ASSERT_EQ(1u, out_locations[i].size());
-        ASSERT_EQ("uri_" + std::to_string(keys[i]), out_locations[i].at(loc_id).location_specs().front().uri());
+        ASSERT_EQ("uri_" + std::to_string(keys[i]), out_locations[i].at(loc_id)->location_specs().front().uri());
     }
 
     Cleanup(mgr, keys);
@@ -180,9 +181,9 @@ TEST_F(MetaStorageBackendManagerRealRedisTest, TestSingleBackendCrud) {
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(keys, exists_vec));
     ASSERT_EQ((std::vector<bool>{true, true}), exists_vec);
 
-    LocationMapVector out_locs;
+    CacheLocationMapVector out_locs;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.GetLocations(request_context_.get(), keys, out_locs));
-    ASSERT_EQ("uri_20001", out_locs[0].at("loc_20001").location_specs().front().uri());
+    ASSERT_EQ("uri_20001", out_locs[0].at("loc_20001")->location_specs().front().uri());
 
     // Delete the only location of each key -> MaybeReclaimEmptyKeys walks
     // through persistent (redis) to discover keys with no remaining locations.
@@ -247,7 +248,7 @@ TEST_F(MetaStorageBackendManagerRealRedisTest, TestRecoverReadFallbackToPersiste
     auto per_ecs = mgr.GetLocations(request_context_.get(), KeyVector{30001, 30002}, ids, per_key_locs);
     ASSERT_EQ(EC_OK, per_ecs[0][0]);
     ASSERT_EQ(EC_OK, per_ecs[1][0]);
-    ASSERT_EQ("uri_30002", per_key_locs[1][0].location_specs().front().uri());
+    ASSERT_EQ("uri_30002", per_key_locs[1][0]->location_specs().front().uri());
 
     Cleanup(mgr, KeyVector{30001, 30002});
     ASSERT_EQ(EC_OK, mgr.Close());
@@ -363,8 +364,8 @@ TEST_F(MetaStorageBackendManagerRealRedisTest, TestGetLocationsPerLocationIdSema
     ASSERT_EQ(2u, ecs.size());
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT}), ecs[0]);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT}), ecs[1]);
-    ASSERT_EQ("uri_60005", out_locs[0][0].location_specs().front().uri());
-    ASSERT_EQ("uri_60006", out_locs[1][0].location_specs().front().uri());
+    ASSERT_EQ("uri_60005", out_locs[0][0]->location_specs().front().uri());
+    ASSERT_EQ("uri_60006", out_locs[1][0]->location_specs().front().uri());
 
     Cleanup(mgr, keys);
     ASSERT_EQ(EC_OK, mgr.Close());

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_real_redis_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_real_redis_test.cc
@@ -100,7 +100,7 @@ public:
 
     // Best-effort Delete; swallow NOENT so repeated runs against the same
     // redis instance stay idempotent even when a previous run aborted midway.
-    static void Cleanup(MetaStorageBackendManager &mgr, const KeyVector &keys) { mgr.Delete(keys); }
+    static void Cleanup(MetaStorageBackendManager &mgr, const KeyVector &keys) { mgr.Delete(nullptr, keys); }
 
 protected:
     std::shared_ptr<RequestContext> request_context_;
@@ -188,7 +188,7 @@ TEST_F(MetaStorageBackendManagerRealRedisTest, TestSingleBackendCrud) {
     // through persistent (redis) to discover keys with no remaining locations.
     LocationIdsPerKey loc_ids = {{"loc_20001"}, {"loc_20002"}};
     int32_t reclaimed = 0;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Delete(keys, loc_ids, reclaimed));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Delete(nullptr, keys, loc_ids, reclaimed));
     ASSERT_EQ(2, reclaimed);
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(keys, exists_vec));
@@ -272,7 +272,7 @@ TEST_F(MetaStorageBackendManagerRealRedisTest, TestRecoverWriteDualWriteAndDelet
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
 
     // Delete in Recover -> tombstone recorded.
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Delete(keys));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Delete(nullptr, keys));
     {
         std::lock_guard<std::mutex> lock(mgr.deleted_keys_mutex_);
         ASSERT_EQ(1u, mgr.deleted_keys_.count(40042));

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -42,15 +42,15 @@ public:
 
     // Construct a single-location CacheLocation with id/uri wired up so the
     // round-trip through JSON can be asserted.
-    static CacheLocation MakeLocation(const std::string &id, const std::string &uri) {
-        CacheLocation loc;
-        loc.set_id(id);
-        loc.set_status(CacheLocationStatus::CLS_SERVING);
-        loc.set_type(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
-        loc.set_spec_size(1);
+    static CacheLocationConstPtr MakeLocation(const std::string &id, const std::string &uri) {
+        auto loc = std::make_shared<CacheLocation>();
+        loc->set_id(id);
+        loc->set_status(CacheLocationStatus::CLS_SERVING);
+        loc->set_type(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
+        loc->set_spec_size(1);
         std::vector<LocationSpec> specs;
         specs.emplace_back("default", uri);
-        loc.set_location_specs(std::move(specs));
+        loc->set_location_specs(std::move(specs));
         return loc;
     }
 
@@ -85,9 +85,10 @@ public:
             batch.batch_properties.resize(batch.batch_keys.size());
         }
         for (size_t i = 0; i < batch.batch_keys.size(); ++i) {
-            for (const auto &loc_kv : batch.batch_locations[i]) {
-                const CacheLocation &location = loc_kv.second;
-                batch.batch_properties[i][LOCATION_PREFIX + location.id()] = location.ToJsonString();
+            for (const auto &[loc_id, loc_ptr] : batch.batch_locations[i]) {
+                if (!loc_ptr)
+                    continue;
+                batch.batch_properties[i][LOCATION_PREFIX + loc_ptr->id()] = loc_ptr->ToJsonString();
             }
         }
     }
@@ -160,12 +161,14 @@ TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {
     auto put_ecs = mgr.Put(request_context_.get(), batch);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), put_ecs);
 
-    // BuildEffectiveFieldMaps should have serialized every location into
-    // batch.batch_properties under the LOCATION_PREFIX + id field name.
+    // New API stores locations separately from properties — verify locations
+    // are populated in batch_locations (already set by MakeBatch) and that the
+    // Put call did not corrupt them.
     for (size_t i = 0; i < keys.size(); ++i) {
-        const std::string expected_field = LOCATION_PREFIX + "loc_" + std::to_string(keys[i]);
-        ASSERT_TRUE(batch.batch_properties[i].count(expected_field) > 0)
-            << "location field missing for key=" << keys[i];
+        const std::string loc_id = "loc_" + std::to_string(keys[i]);
+        ASSERT_EQ(1u, batch.batch_locations[i].size());
+        ASSERT_TRUE(batch.batch_locations[i].count(loc_id) > 0)
+            << "location missing in batch_locations for key=" << keys[i];
     }
 
     // GetLocations must deserialize back into the same (id, uri) pairs.
@@ -178,7 +181,7 @@ TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {
         ASSERT_EQ(1u, out_locations[i].size());
         auto it = out_locations[i].find(loc_id);
         ASSERT_TRUE(it != out_locations[i].end());
-        ASSERT_EQ("uri_" + std::to_string(keys[i]), it->second.location_specs().front().uri());
+        ASSERT_EQ("uri_" + std::to_string(keys[i]), it->second->location_specs().front().uri());
     }
 
     // Block-level properties should be preserved alongside the location fields.
@@ -336,7 +339,7 @@ TEST_F(MetaStorageBackendManagerTest, TestSingleBackendCrud) {
 
     CacheLocationMapVector out_locs;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.GetLocations(request_context_.get(), keys, out_locs));
-    ASSERT_EQ("uri_1", out_locs[0].at("loc_1").location_specs().front().uri());
+    ASSERT_EQ("uri_1", out_locs[0].at("loc_1")->location_specs().front().uri());
 
     // Delete location field -> reclaim path resolves emptiness via persistent.
     LocationIdsPerKey loc_ids = {{"loc_1"}, {"loc_2"}};
@@ -397,7 +400,7 @@ TEST_F(MetaStorageBackendManagerTest, TestRecoverReadFallbackToPersistent) {
     CacheLocationMapVector locs;
     auto loc_ecs = mgr.GetLocations(request_context_.get(), KeyVector{1, 2}, locs);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), loc_ecs);
-    ASSERT_EQ("uri_2", locs[1].at("loc_2").location_specs().front().uri());
+    ASSERT_EQ("uri_2", locs[1].at("loc_2")->location_specs().front().uri());
 
     // Targeted GetLocations(keys, location_ids) also falls back on miss.
     LocationIdsPerKey ids = {{"loc_1"}, {"loc_2"}};
@@ -405,7 +408,7 @@ TEST_F(MetaStorageBackendManagerTest, TestRecoverReadFallbackToPersistent) {
     auto per_ecs = mgr.GetLocations(request_context_.get(), KeyVector{1, 2}, ids, per_key_locs);
     ASSERT_EQ(EC_OK, per_ecs[0][0]);
     ASSERT_EQ(EC_OK, per_ecs[1][0]);
-    ASSERT_EQ("uri_2", per_key_locs[1][0].location_specs().front().uri());
+    ASSERT_EQ("uri_2", per_key_locs[1][0]->location_specs().front().uri());
 
     ASSERT_EQ(EC_OK, mgr.Close());
 }
@@ -525,8 +528,8 @@ TEST_F(MetaStorageBackendManagerTest, TestGetLocationsPerLocationIdSemantics) {
     ASSERT_EQ(2u, ecs.size());
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT}), ecs[0]);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT}), ecs[1]);
-    ASSERT_EQ("uri_5", out_locs[0][0].location_specs().front().uri());
-    ASSERT_EQ("uri_6", out_locs[1][0].location_specs().front().uri());
+    ASSERT_EQ("uri_5", out_locs[0][0]->location_specs().front().uri());
+    ASSERT_EQ("uri_6", out_locs[1][0]->location_specs().front().uri());
 
     ASSERT_EQ(EC_OK, mgr.Close());
 }

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -76,7 +76,7 @@ public:
     // bypass the manager and write straight to persistent_backend_. Without
     // this merge the persistent side would only carry block-level properties
     // and later GetLocations fallbacks would find no location fields -> the
-    // caller's map::at on the returned LocationMapVector would throw.
+    // caller's map::at on the returned CacheLocationMapVector would throw.
     static void SerializeLocationsIntoProperties(BatchMetaData &batch) {
         if (batch.batch_locations.empty()) {
             return;
@@ -169,7 +169,7 @@ TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {
     }
 
     // GetLocations must deserialize back into the same (id, uri) pairs.
-    LocationMapVector out_locations;
+    CacheLocationMapVector out_locations;
     auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), get_ecs);
     ASSERT_EQ(keys.size(), out_locations.size());
@@ -182,8 +182,8 @@ TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {
     }
 
     // Block-level properties should be preserved alongside the location fields.
-    FieldMapVec field_maps;
-    auto field_ecs = mgr.Get(keys, {"p0"}, field_maps);
+    PropertyMapVector field_maps;
+    auto field_ecs = mgr.GetProperties(nullptr, keys, {"p0"}, field_maps);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), field_ecs);
     for (size_t i = 0; i < keys.size(); ++i) {
         ASSERT_EQ("p0_" + std::to_string(keys[i]), field_maps[i].at("p0"));
@@ -210,13 +210,13 @@ TEST_F(MetaStorageBackendManagerTest, TestDeleteLocationFieldsReclaimsEmptyKeys)
     // reclaimed by MaybeReclaimEmptyKeys.
     LocationIdsPerKey location_ids = {{"loc_10"}, {"loc_20"}};
     int32_t reclaimed = 0;
-    auto del_ecs = mgr.Delete(keys, location_ids, reclaimed);
+    auto del_ecs = mgr.Delete(nullptr, keys, location_ids, reclaimed);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), del_ecs);
     ASSERT_EQ(2, reclaimed);
 
     // After reclaim both keys must be gone.
     std::vector<bool> exists_vec;
-    auto exists_ecs = mgr.Exists(keys, exists_vec);
+    auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), exists_ecs);
     ASSERT_EQ((std::vector<bool>{false, false}), exists_vec);
 
@@ -243,7 +243,7 @@ TEST_F(MetaStorageBackendManagerTest, TestListKeysAndRandomSample) {
     for (int i = 0; i < 20 && seen.size() < keys.size(); ++i) {
         std::string next;
         KeyTypeVec out;
-        ASSERT_EQ(EC_OK, mgr.ListKeys(cursor, /*limit*/ 50, next, out));
+        ASSERT_EQ(EC_OK, mgr.ListKeys(nullptr, cursor, /*limit*/ 50, next, out));
         for (auto k : out) {
             seen.insert(k);
         }
@@ -258,7 +258,7 @@ TEST_F(MetaStorageBackendManagerTest, TestListKeysAndRandomSample) {
 
     // RandomSample should return at most `count` keys from the set above.
     KeyTypeVec sampled;
-    ASSERT_EQ(EC_OK, mgr.RandomSample(/*count*/ 1, sampled));
+    ASSERT_EQ(EC_OK, mgr.RandomSample(nullptr, /*count*/ 1, sampled));
     ASSERT_LE(sampled.size(), 1u);
 
     ASSERT_EQ(EC_OK, mgr.Close());
@@ -326,25 +326,25 @@ TEST_F(MetaStorageBackendManagerTest, TestSingleBackendCrud) {
     auto batch = MakeBatch(keys);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Put(request_context_.get(), batch));
 
-    FieldMapVec field_maps;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Get(keys, {"p0"}, field_maps));
+    PropertyMapVector field_maps;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.GetProperties(nullptr, keys, {"p0"}, field_maps));
     ASSERT_EQ("p0_1", field_maps[0].at("p0"));
 
     std::vector<bool> exists_vec;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(keys, exists_vec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(nullptr, keys, exists_vec));
     ASSERT_EQ((std::vector<bool>{true, true}), exists_vec);
 
-    LocationMapVector out_locs;
+    CacheLocationMapVector out_locs;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.GetLocations(request_context_.get(), keys, out_locs));
     ASSERT_EQ("uri_1", out_locs[0].at("loc_1").location_specs().front().uri());
 
     // Delete location field -> reclaim path resolves emptiness via persistent.
     LocationIdsPerKey loc_ids = {{"loc_1"}, {"loc_2"}};
     int32_t reclaimed = 0;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Delete(keys, loc_ids, reclaimed));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Delete(nullptr, keys, loc_ids, reclaimed));
     ASSERT_EQ(2, reclaimed);
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(keys, exists_vec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(nullptr, keys, exists_vec));
     ASSERT_EQ((std::vector<bool>{false, false}), exists_vec);
 
     ASSERT_EQ(EC_OK, mgr.Close());
@@ -374,26 +374,27 @@ TEST_F(MetaStorageBackendManagerTest, TestRecoverReadFallbackToPersistent) {
     auto extra_batch = MakeBatch(extra);
     SerializeLocationsIntoProperties(extra_batch);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              mgr.persistent_backend_->Put(extra_batch.batch_keys, extra_batch.batch_properties));
+              mgr.persistent_backend_->Put(
+                  nullptr, extra_batch.batch_keys, extra_batch.batch_locations, extra_batch.batch_properties));
 
     // Flip back to Recover to force the local-miss -> persistent-fallback path.
     mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover, std::memory_order_release);
 
     KeyVector keys = {1, 2, 3};
-    FieldMapVec fms;
-    auto ecs = mgr.Get(keys, {"p0"}, fms);
+    PropertyMapVector fms;
+    auto ecs = mgr.GetProperties(nullptr, keys, {"p0"}, fms);
     ASSERT_EQ(EC_OK, ecs[0]);
     ASSERT_EQ(EC_OK, ecs[1]);
     ASSERT_EQ("p0_1", fms[0].at("p0"));
     ASSERT_EQ("p0_2", fms[1].at("p0"));
 
     std::vector<bool> exists_vec;
-    auto exists_ecs = mgr.Exists(keys, exists_vec);
+    auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
     ASSERT_EQ(EC_OK, exists_ecs[0]);
     ASSERT_EQ(EC_OK, exists_ecs[1]);
     ASSERT_EQ((std::vector<bool>{true, true, false}), exists_vec);
 
-    LocationMapVector locs;
+    CacheLocationMapVector locs;
     auto loc_ecs = mgr.GetLocations(request_context_.get(), KeyVector{1, 2}, locs);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), loc_ecs);
     ASSERT_EQ("uri_2", locs[1].at("loc_2").location_specs().front().uri());
@@ -428,19 +429,20 @@ TEST_F(MetaStorageBackendManagerTest, TestRecoverWriteDualWriteAndDeleteTombston
     auto batch = MakeBatch(keys);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
 
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Delete(keys));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Delete(nullptr, keys));
     {
         std::lock_guard<std::mutex> lock(mgr.deleted_keys_mutex_);
         ASSERT_EQ(1u, mgr.deleted_keys_.count(42));
     }
 
-    // Simulate a late backfill racing after Delete: BackfillKeysToLocal must
+    // Simulate a late backfill racing after Delete: BackfillKeysToCache must
     // see the tombstone and refuse to reinsert the key into local.
-    FieldMapVec stale_fms(1);
-    stale_fms[0]["p0"] = "stale";
-    ASSERT_EQ(0, mgr.BackfillKeysToCache(keys, stale_fms, {EC_OK}));
+    CacheLocationMapVector stale_locs(1);
+    PropertyMapVector stale_props(1);
+    stale_props[0]["p0"] = "stale";
+    ASSERT_EQ(0, mgr.BackfillKeysToCache(keys, stale_locs, stale_props, {EC_OK}));
     std::vector<bool> exists_vec;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(keys, exists_vec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, keys, exists_vec));
     ASSERT_FALSE(exists_vec[0]);
 
     // UpdateFields under Recover hydrates missing keys via EnsureKeyInLocal
@@ -449,8 +451,9 @@ TEST_F(MetaStorageBackendManagerTest, TestRecoverWriteDualWriteAndDeleteTombston
     KeyVector k7 = {7};
     auto batch7 = MakeBatch(k7);
     SerializeLocationsIntoProperties(batch7);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              mgr.persistent_backend_->Put(batch7.batch_keys, batch7.batch_properties));
+    ASSERT_EQ(
+        (std::vector<ErrorCode>{EC_OK}),
+        mgr.persistent_backend_->Put(nullptr, batch7.batch_keys, batch7.batch_locations, batch7.batch_properties));
 
     BatchMetaData update_batch;
     update_batch.batch_keys = k7;
@@ -458,8 +461,8 @@ TEST_F(MetaStorageBackendManagerTest, TestRecoverWriteDualWriteAndDeleteTombston
     update_batch.batch_properties[0]["p0"] = "p0_7_updated";
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.UpdateFields(request_context_.get(), update_batch));
 
-    FieldMapVec fms;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Get(k7, {"p0"}, fms));
+    PropertyMapVector fms;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.GetProperties(nullptr, k7, {"p0"}, fms));
     ASSERT_EQ("p0_7_updated", fms[0].at("p0"));
 
     ASSERT_EQ(EC_OK, mgr.Close());
@@ -484,14 +487,15 @@ TEST_F(MetaStorageBackendManagerTest, TestRunningReadLocalOnly) {
     // not know about it; in Running state reads must not see it.
     KeyVector k2 = {2};
     auto b2 = MakeBatch(k2);
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.persistent_backend_->Put(b2.batch_keys, b2.batch_properties));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.persistent_backend_->Put(nullptr, b2.batch_keys, b2.batch_locations, b2.batch_properties));
 
     std::vector<bool> exists_vec;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(KeyVector{1, 2}, exists_vec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Exists(nullptr, KeyVector{1, 2}, exists_vec));
     ASSERT_EQ((std::vector<bool>{true, false}), exists_vec);
 
-    FieldMapVec fms;
-    auto ecs = mgr.Get(KeyVector{2}, {"p0"}, fms);
+    PropertyMapVector fms;
+    auto ecs = mgr.GetProperties(nullptr, KeyVector{2}, {"p0"}, fms);
     // Local miss: EC_OK with empty map OR EC_NOENT, both must not leak the
     // persistent-only entry.
     ASSERT_TRUE(ecs[0] == EC_NOENT || (ecs[0] == EC_OK && fms[0].empty()));
@@ -538,7 +542,7 @@ TEST_F(MetaStorageBackendManagerTest, TestEmptyInputsAreNoOp) {
     WaitRunning(mgr);
 
     int32_t reclaimed = -1;
-    auto del_ecs = mgr.Delete(/*keys*/ {}, /*location_ids*/ {}, reclaimed);
+    auto del_ecs = mgr.Delete(nullptr, /*keys*/ {}, /*location_ids*/ {}, reclaimed);
     ASSERT_TRUE(del_ecs.empty());
     ASSERT_EQ(0, reclaimed);
 
@@ -566,24 +570,22 @@ TEST_F(MetaStorageBackendManagerTest, TestGetLocationIdsIgnoresTombstone) {
 
     // Verify GetLocationIds returns the real location.
     LocationIdsPerKey loc_ids;
-    auto ecs = mgr.GetLocationIds(keys, loc_ids);
+    auto ecs = mgr.GetLocationIds(nullptr, keys, loc_ids);
     ASSERT_EQ(EC_OK, ecs[0]);
     ASSERT_EQ(1u, loc_ids[0].size());
     EXPECT_EQ("loc_10", loc_ids[0][0]);
 
-    // Now overwrite the location field with an empty value (tombstone) via
-    // UpdateFields on the persistent backend directly, then invalidate cache.
-    FieldMapVec tombstone_fields = {{{LOCATION_PREFIX + "loc_10", ""}}};
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.persistent_backend_->UpdateFields(keys, tombstone_fields));
+    // Now delete the location via DeleteLocations on both backends directly.
+    LocationIdsPerKey del_loc_ids = {{"loc_10"}};
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.persistent_backend_->DeleteLocations(nullptr, keys, del_loc_ids));
     if (mgr.cache_backend_) {
-        FieldMapVec cache_tomb = {{{LOCATION_PREFIX + "loc_10", ""}}};
-        mgr.cache_backend_->UpdateFields(keys, cache_tomb);
+        mgr.cache_backend_->DeleteLocations(nullptr, keys, del_loc_ids);
     }
 
     // GetLocationIds should now return EC_OK with empty location ids
     // (key still exists but has no valid non-tombstone locations).
     loc_ids.clear();
-    ecs = mgr.GetLocationIds(keys, loc_ids);
+    ecs = mgr.GetLocationIds(nullptr, keys, loc_ids);
     ASSERT_EQ(EC_OK, ecs[0]);
     EXPECT_TRUE(loc_ids[0].empty());
 
@@ -608,13 +610,13 @@ TEST_F(MetaStorageBackendManagerTest, TestDeleteEmptyLocationIdsIsNoOp) {
     // Delete with empty location_ids should be a no-op → EC_OK, 0 reclaimed.
     int32_t reclaimed = -1;
     LocationIdsPerKey empty_ids = {{}};
-    auto del_ecs = mgr.Delete(keys, empty_ids, reclaimed);
+    auto del_ecs = mgr.Delete(nullptr, keys, empty_ids, reclaimed);
     ASSERT_EQ(EC_OK, del_ecs[0]);
     ASSERT_EQ(0, reclaimed);
 
     // The original location should still exist.
     LocationIdsPerKey loc_ids;
-    auto get_ecs = mgr.GetLocationIds(keys, loc_ids);
+    auto get_ecs = mgr.GetLocationIds(nullptr, keys, loc_ids);
     ASSERT_EQ(EC_OK, get_ecs[0]);
     ASSERT_EQ(1u, loc_ids[0].size());
     EXPECT_EQ("loc_20", loc_ids[0][0]);
@@ -640,13 +642,13 @@ TEST_F(MetaStorageBackendManagerTest, TestMaybeReclaimEmptyKeysAfterLastLocation
     // Delete that location → the key should be auto-reclaimed.
     int32_t reclaimed = 0;
     LocationIdsPerKey ids = {{"loc_30"}};
-    auto del_ecs = mgr.Delete(keys, ids, reclaimed);
+    auto del_ecs = mgr.Delete(nullptr, keys, ids, reclaimed);
     ASSERT_EQ(EC_OK, del_ecs[0]);
     EXPECT_EQ(1, reclaimed);
 
     // The key should no longer exist.
     std::vector<bool> exists_vec;
-    auto exists_ecs = mgr.Exists(keys, exists_vec);
+    auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
     ASSERT_EQ(EC_OK, exists_ecs[0]);
     EXPECT_FALSE(exists_vec[0]);
 
@@ -685,7 +687,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyMultiLocationGradualDeletion) 
 
     // Verify each key now has 3 locations.
     {
-        LocationMapVector out_locations;
+        CacheLocationMapVector out_locations;
         auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
         for (size_t i = 0; i < keys.size(); ++i) {
             ASSERT_EQ(EC_OK, get_ecs[i]) << "key=" << keys[i];
@@ -701,18 +703,18 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyMultiLocationGradualDeletion) 
             {"loc_60"},
         };
         int32_t reclaimed = -1;
-        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        auto del_ecs = mgr.Delete(nullptr, keys, del_ids, reclaimed);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
         EXPECT_EQ(0, reclaimed) << "keys still have 2 locations each, none should be reclaimed";
 
         // All keys should still exist.
         std::vector<bool> exists_vec;
-        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
         ASSERT_EQ((std::vector<bool>{true, true, true}), exists_vec);
 
         // Each key should have exactly 2 remaining locations.
-        LocationMapVector out_locations;
+        CacheLocationMapVector out_locations;
         auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
         for (size_t i = 0; i < keys.size(); ++i) {
             ASSERT_EQ(EC_OK, get_ecs[i]);
@@ -728,18 +730,18 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyMultiLocationGradualDeletion) 
             {"loc_60_b"},
         };
         int32_t reclaimed = -1;
-        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        auto del_ecs = mgr.Delete(nullptr, keys, del_ids, reclaimed);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
         EXPECT_EQ(0, reclaimed) << "keys still have 1 location each, none should be reclaimed";
 
         // All keys should still exist.
         std::vector<bool> exists_vec;
-        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
         ASSERT_EQ((std::vector<bool>{true, true, true}), exists_vec);
 
         // Each key should have exactly 1 remaining location.
-        LocationMapVector out_locations;
+        CacheLocationMapVector out_locations;
         auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
         for (size_t i = 0; i < keys.size(); ++i) {
             ASSERT_EQ(EC_OK, get_ecs[i]);
@@ -758,13 +760,13 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyMultiLocationGradualDeletion) 
             {"loc_60_c"},
         };
         int32_t reclaimed = -1;
-        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        auto del_ecs = mgr.Delete(nullptr, keys, del_ids, reclaimed);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
         EXPECT_EQ(3, reclaimed) << "all 3 keys should be reclaimed after last location deleted";
 
         // All keys should be gone.
         std::vector<bool> exists_vec;
-        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
         ASSERT_EQ((std::vector<bool>{false, false, false}), exists_vec);
     }
@@ -808,7 +810,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyPartialReclamation) {
 
     // Verify initial state: key70=2, key80=3, key90=1
     {
-        LocationMapVector out_locations;
+        CacheLocationMapVector out_locations;
         auto get_ecs = mgr.GetLocations(request_context_.get(), keys, out_locations);
         ASSERT_EQ(EC_OK, get_ecs[0]);
         ASSERT_EQ(EC_OK, get_ecs[1]);
@@ -827,7 +829,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyPartialReclamation) {
             {"loc_90"},                         // key90: only 1 deleted → reclaimed
         };
         int32_t reclaimed = -1;
-        auto del_ecs = mgr.Delete(keys, del_ids, reclaimed);
+        auto del_ecs = mgr.Delete(nullptr, keys, del_ids, reclaimed);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), del_ecs);
         EXPECT_EQ(2, reclaimed) << "key80 and key90 should be reclaimed";
     }
@@ -835,7 +837,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyPartialReclamation) {
     // Verify: key70 still exists with 1 location, key80 and key90 are gone.
     {
         std::vector<bool> exists_vec;
-        auto exists_ecs = mgr.Exists(keys, exists_vec);
+        auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
         ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), exists_ecs);
         EXPECT_TRUE(exists_vec[0]) << "key70 should still exist";
         EXPECT_FALSE(exists_vec[1]) << "key80 should be reclaimed";
@@ -844,7 +846,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMultiKeyPartialReclamation) {
 
     // key70 should have exactly 1 remaining location.
     {
-        LocationMapVector out_locations;
+        CacheLocationMapVector out_locations;
         auto get_ecs = mgr.GetLocations(request_context_.get(), {70}, out_locations);
         ASSERT_EQ(EC_OK, get_ecs[0]);
         ASSERT_EQ(1u, out_locations[0].size());

--- a/kv_cache_manager/meta/test/meta_storage_backend_test_base.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_test_base.cc
@@ -18,17 +18,17 @@ void MetaStorageBackendTestBase::SplitFieldMaps(const FieldMapVec &field_maps,
         for (const auto &[name, value] : field_maps[i]) {
             if (name.rfind(LOCATION_PREFIX, 0) == 0) {
                 std::string loc_id = name.substr(LOCATION_PREFIX.size());
-                CacheLocation loc;
-                loc.set_id(loc_id);
+                auto loc = std::make_shared<CacheLocation>();
+                loc->set_id(loc_id);
                 // Store raw value in a location_spec uri so round-trip tests
                 // that compare serialised JSON can still work. For empty value
                 // (tombstone), leave the location default-constructed (no specs).
                 if (!value.empty()) {
-                    loc.FromJsonString(value);
+                    loc->FromJsonString(value);
                     // If FromJsonString failed (value was not valid JSON),
                     // fall back to storing raw value.
-                    if (loc.id().empty()) {
-                        loc.set_id(loc_id);
+                    if (loc->id().empty()) {
+                        loc->set_id(loc_id);
                     }
                 }
                 out_locations[i][loc_id] = std::move(loc);
@@ -120,8 +120,8 @@ void MetaStorageBackendTestBase::AssertGetAllFields(MetaStorageBackend *meta_sto
     for (size_t i = 0; i < keys.size(); ++i) {
         const KeyType &key = keys[i];
         FieldMap merged;
-        for (const auto &[loc_id, loc] : out_locations[i]) {
-            merged[LOCATION_PREFIX + loc_id] = loc.ToJsonString();
+        for (const auto &[loc_id, loc_ptr] : out_locations[i]) {
+            merged[LOCATION_PREFIX + loc_id] = loc_ptr ? loc_ptr->ToJsonString() : "";
         }
         for (const auto &[prop_name, prop_value] : out_properties[i]) {
             merged[prop_name] = prop_value;

--- a/kv_cache_manager/meta/test/meta_storage_backend_test_base.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_test_base.cc
@@ -1,59 +1,141 @@
 #include "kv_cache_manager/meta/test/meta_storage_backend_test_base.h"
 
+#include "kv_cache_manager/meta/cache_location.h"
 #include "kv_cache_manager/meta/common.h"
-#include "kv_cache_manager/meta/meta_redis_backend.h"
+
 namespace kv_cache_manager {
-void MetaStorageBackendTestBase::AssertGet(MetaStorageBackend *meta_storage_backend,
-                                           const KeyTypeVec &keys,
-                                           const std::vector<std::string> &field_names,
-                                           const std::vector<ErrorCode> expected_ec_vec,
-                                           const FieldMapVec &expected_field_maps) {
+
+// ---------------------------------------------------------------------------
+// Compatibility wrappers
+// ---------------------------------------------------------------------------
+
+void MetaStorageBackendTestBase::SplitFieldMaps(const FieldMapVec &field_maps,
+                                                CacheLocationMapVector &out_locations,
+                                                PropertyMapVector &out_properties) {
+    out_locations.resize(field_maps.size());
+    out_properties.resize(field_maps.size());
+    for (size_t i = 0; i < field_maps.size(); ++i) {
+        for (const auto &[name, value] : field_maps[i]) {
+            if (name.rfind(LOCATION_PREFIX, 0) == 0) {
+                std::string loc_id = name.substr(LOCATION_PREFIX.size());
+                CacheLocation loc;
+                loc.set_id(loc_id);
+                // Store raw value in a location_spec uri so round-trip tests
+                // that compare serialised JSON can still work. For empty value
+                // (tombstone), leave the location default-constructed (no specs).
+                if (!value.empty()) {
+                    loc.FromJsonString(value);
+                    // If FromJsonString failed (value was not valid JSON),
+                    // fall back to storing raw value.
+                    if (loc.id().empty()) {
+                        loc.set_id(loc_id);
+                    }
+                }
+                out_locations[i][loc_id] = std::move(loc);
+            } else {
+                out_properties[i][name] = value;
+            }
+        }
+    }
+}
+
+std::vector<ErrorCode> MetaStorageBackendTestBase::PutWithFieldMaps(MetaStorageBackend *backend,
+                                                                    const KeyTypeVec &keys,
+                                                                    const FieldMapVec &field_maps) {
+    CacheLocationMapVector locations;
+    PropertyMapVector properties;
+    SplitFieldMaps(field_maps, locations, properties);
+    return backend->Put(nullptr, keys, locations, properties);
+}
+
+std::vector<ErrorCode> MetaStorageBackendTestBase::UpsertWithFieldMaps(MetaStorageBackend *backend,
+                                                                       const KeyTypeVec &keys,
+                                                                       const FieldMapVec &field_maps) {
+    CacheLocationMapVector locations;
+    PropertyMapVector properties;
+    SplitFieldMaps(field_maps, locations, properties);
+    return backend->Upsert(nullptr, keys, locations, properties);
+}
+
+std::vector<ErrorCode> MetaStorageBackendTestBase::UpdateWithFieldMaps(MetaStorageBackend *backend,
+                                                                       const KeyTypeVec &keys,
+                                                                       const FieldMapVec &field_maps) {
+    CacheLocationMapVector locations;
+    PropertyMapVector properties;
+    SplitFieldMaps(field_maps, locations, properties);
+    return backend->Update(nullptr, keys, locations, properties);
+}
+
+std::vector<ErrorCode>
+MetaStorageBackendTestBase::PutIfAbsentWithFieldMaps(MetaCacheBaseBackend *backend,
+                                                     const KeyTypeVec &keys,
+                                                     const FieldMapVec &field_maps,
+                                                     const std::vector<ErrorCode> &previous_error_codes) {
+    CacheLocationMapVector locations;
+    PropertyMapVector properties;
+    SplitFieldMaps(field_maps, locations, properties);
+    return backend->PutIfAbsent(nullptr, keys, locations, properties, previous_error_codes);
+}
+
+void MetaStorageBackendTestBase::AssertGetProperties(MetaStorageBackend *meta_storage_backend,
+                                                     const KeyTypeVec &keys,
+                                                     const std::vector<std::string> &field_names,
+                                                     const std::vector<ErrorCode> &expected_ec_vec,
+                                                     const PropertyMapVector &expected_properties) {
     ASSERT_TRUE(meta_storage_backend);
-    FieldMapVec field_maps;
-    std::vector<ErrorCode> ec_vec = meta_storage_backend->Get(keys, field_names, field_maps);
+    PropertyMapVector out_properties;
+    std::vector<ErrorCode> ec_vec = meta_storage_backend->GetProperties(nullptr, keys, field_names, out_properties);
     ASSERT_EQ(keys.size(), expected_ec_vec.size());
     ASSERT_EQ(expected_ec_vec, ec_vec);
-    ASSERT_EQ(keys.size(), field_maps.size());
-    ASSERT_EQ(expected_field_maps.size(), field_maps.size());
-    for (int i = 0; i < keys.size(); ++i) {
+    ASSERT_EQ(keys.size(), out_properties.size());
+    ASSERT_EQ(expected_properties.size(), out_properties.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
         const KeyType &key = keys[i];
-        const FieldMap &field_map = field_maps[i];
-        const FieldMap &expected_field_map = expected_field_maps[i];
-        ASSERT_EQ(expected_field_map.size(), field_map.size()) << key;
-        for (const auto &[expected_field_name, expected_field_value] : expected_field_map) {
-            const auto iter = field_map.find(expected_field_name);
-            ASSERT_TRUE(iter != field_map.end()) << key << " " << expected_field_name;
-            ASSERT_EQ(expected_field_value, iter->second) << key << " " << expected_field_name;
+        const PropertyMap &actual = out_properties[i];
+        const PropertyMap &expected = expected_properties[i];
+        ASSERT_EQ(expected.size(), actual.size()) << key;
+        for (const auto &[name, value] : expected) {
+            const auto iter = actual.find(name);
+            ASSERT_TRUE(iter != actual.end()) << key << " " << name;
+            ASSERT_EQ(value, iter->second) << key << " " << name;
         }
     }
 }
 
 void MetaStorageBackendTestBase::AssertGetAllFields(MetaStorageBackend *meta_storage_backend,
                                                     const KeyTypeVec &keys,
-                                                    const std::vector<ErrorCode> expected_ec_vec,
+                                                    const std::vector<ErrorCode> &expected_ec_vec,
                                                     const FieldMapVec &expected_field_maps) {
     ASSERT_TRUE(meta_storage_backend);
-    FieldMapVec field_maps;
-    std::vector<ErrorCode> ec_vec = meta_storage_backend->GetAllFields(keys, field_maps);
+    CacheLocationMapVector out_locations;
+    PropertyMapVector out_properties;
+    std::vector<ErrorCode> ec_vec = meta_storage_backend->Get(nullptr, keys, out_locations, out_properties);
     ASSERT_EQ(keys.size(), expected_ec_vec.size());
     ASSERT_EQ(expected_ec_vec, ec_vec);
-    ASSERT_EQ(keys.size(), field_maps.size());
-    ASSERT_EQ(expected_field_maps.size(), field_maps.size());
-    for (int i = 0; i < keys.size(); ++i) {
+    ASSERT_EQ(keys.size(), out_locations.size());
+    ASSERT_EQ(keys.size(), out_properties.size());
+    ASSERT_EQ(expected_field_maps.size(), out_locations.size());
+
+    // Merge locations + properties back into a FieldMap for comparison.
+    for (size_t i = 0; i < keys.size(); ++i) {
         const KeyType &key = keys[i];
-        const FieldMap &field_map = field_maps[i];
+        FieldMap merged;
+        for (const auto &[loc_id, loc] : out_locations[i]) {
+            merged[LOCATION_PREFIX + loc_id] = loc.ToJsonString();
+        }
+        for (const auto &[prop_name, prop_value] : out_properties[i]) {
+            merged[prop_name] = prop_value;
+        }
         const FieldMap &expected_field_map = expected_field_maps[i];
         // Count actual fields excluding PROPERTY_LRU_TIME (dynamically filled by local backend).
-        size_t actual_count_without_lru = field_map.size();
-        if (field_map.count(PROPERTY_LRU_TIME) && !expected_field_map.count(PROPERTY_LRU_TIME)) {
+        size_t actual_count_without_lru = merged.size();
+        if (merged.count(PROPERTY_LRU_TIME) && !expected_field_map.count(PROPERTY_LRU_TIME)) {
             --actual_count_without_lru;
         }
         ASSERT_EQ(expected_field_map.size(), actual_count_without_lru) << key;
-        // Verify all expected fields are present with correct values.
-        // PROPERTY_LRU_TIME is dynamically filled, so only check existence.
         for (const auto &[expected_field_name, expected_field_value] : expected_field_map) {
-            const auto iter = field_map.find(expected_field_name);
-            ASSERT_TRUE(iter != field_map.end()) << key << " " << expected_field_name;
+            const auto iter = merged.find(expected_field_name);
+            ASSERT_TRUE(iter != merged.end()) << key << " " << expected_field_name;
             if (expected_field_name == PROPERTY_LRU_TIME) {
                 ASSERT_FALSE(iter->second.empty()) << key << " " << expected_field_name << " should not be empty";
             } else {
@@ -65,20 +147,18 @@ void MetaStorageBackendTestBase::AssertGetAllFields(MetaStorageBackend *meta_sto
 
 void MetaStorageBackendTestBase::AssertExists(MetaStorageBackend *meta_storage_backend,
                                               const KeyTypeVec &keys,
-                                              const std::vector<ErrorCode> expected_ec_vec,
+                                              const std::vector<ErrorCode> &expected_ec_vec,
                                               const std::vector<bool> &expected_is_exist_vec) {
     ASSERT_TRUE(meta_storage_backend);
     std::vector<bool> is_exist_vec;
-    std::vector<ErrorCode> ec_vec = meta_storage_backend->Exists(keys, is_exist_vec);
+    std::vector<ErrorCode> ec_vec = meta_storage_backend->Exists(nullptr, keys, is_exist_vec);
     ASSERT_EQ(keys.size(), expected_ec_vec.size());
     ASSERT_EQ(expected_ec_vec, ec_vec);
     ASSERT_EQ(keys.size(), is_exist_vec.size());
     ASSERT_EQ(expected_is_exist_vec.size(), is_exist_vec.size());
-    for (int i = 0; i < keys.size(); ++i) {
+    for (size_t i = 0; i < keys.size(); ++i) {
         const KeyType &key = keys[i];
-        const bool is_exist = is_exist_vec[i];
-        const bool expected_is_exist = expected_is_exist_vec[i];
-        ASSERT_EQ(expected_is_exist, is_exist) << "key is: " << key;
+        ASSERT_EQ(expected_is_exist_vec[i], is_exist_vec[i]) << "key is: " << key;
     }
 }
 
@@ -91,14 +171,13 @@ void MetaStorageBackendTestBase::AssertListKeys(MetaStorageBackend *meta_storage
     ASSERT_TRUE(meta_storage_backend);
     std::string next_cursor;
     std::vector<KeyType> keys;
-    ErrorCode ec = meta_storage_backend->ListKeys(cursor, limit, next_cursor, keys);
+    ErrorCode ec = meta_storage_backend->ListKeys(nullptr, cursor, limit, next_cursor, keys);
     ASSERT_EQ(expected_ec, ec);
     if (ec == EC_OK) {
         ASSERT_EQ(expected_next_cursor, next_cursor);
-        ASSERT_EQ(std::min((size_t)limit, expected_keys.size()), keys.size());
+        ASSERT_EQ(std::min(static_cast<size_t>(limit), expected_keys.size()), keys.size());
         for (const auto &key : keys) {
-            const auto iter = expected_keys.find(key);
-            ASSERT_TRUE(iter != expected_keys.end()) << key;
+            ASSERT_TRUE(expected_keys.count(key)) << key;
         }
     } else {
         ASSERT_EQ("", next_cursor);
@@ -114,13 +193,12 @@ void MetaStorageBackendTestBase::AssertListKeysByStep(MetaStorageBackend *meta_s
                                                       std::string &out_next_cursor) {
     ASSERT_TRUE(meta_storage_backend);
     std::vector<KeyType> keys;
-    ErrorCode ec = meta_storage_backend->ListKeys(cursor, limit, out_next_cursor, keys);
+    ErrorCode ec = meta_storage_backend->ListKeys(nullptr, cursor, limit, out_next_cursor, keys);
     ASSERT_EQ(expected_ec, ec);
     if (ec == EC_OK) {
-        ASSERT_EQ(std::min((size_t)limit, expected_keys.size()), keys.size());
+        ASSERT_EQ(std::min(static_cast<size_t>(limit), expected_keys.size()), keys.size());
         for (const auto &key : keys) {
-            const auto iter = expected_keys.find(key);
-            ASSERT_TRUE(iter != expected_keys.end()) << key;
+            ASSERT_TRUE(expected_keys.count(key)) << key;
         }
     } else {
         ASSERT_EQ("", out_next_cursor);
@@ -134,31 +212,29 @@ void MetaStorageBackendTestBase::AssertSampleReclaimKeys(MetaStorageBackend *met
                                                          const std::set<KeyType> &expected_keys) {
     ASSERT_TRUE(meta_storage_backend);
     std::vector<KeyType> keys;
-    ErrorCode ec = meta_storage_backend->SampleReclaimKeys(count, keys);
+    ErrorCode ec = meta_storage_backend->SampleReclaimKeys(nullptr, count, keys);
     ASSERT_EQ(expected_ec, ec);
     for (const auto &key : keys) {
-        const auto iter = expected_keys.find(key);
-        ASSERT_TRUE(iter != expected_keys.end()) << key;
+        ASSERT_TRUE(expected_keys.count(key)) << key;
     }
 }
 
-void MetaStorageBackendTestBase::AssertDeleteFields(MetaStorageBackend *meta_storage_backend,
-                                                    const KeyTypeVec &keys,
-                                                    const std::vector<std::vector<std::string>> &field_names_vec,
-                                                    const std::vector<ErrorCode> &expected_ec_vec) {
+void MetaStorageBackendTestBase::AssertDeleteLocations(MetaStorageBackend *meta_storage_backend,
+                                                       const KeyTypeVec &keys,
+                                                       const LocationIdsPerKey &location_ids,
+                                                       const std::vector<ErrorCode> &expected_ec_vec) {
     ASSERT_TRUE(meta_storage_backend);
-    std::vector<ErrorCode> ec_vec = meta_storage_backend->DeleteFields(keys, field_names_vec);
+    std::vector<ErrorCode> ec_vec = meta_storage_backend->DeleteLocations(nullptr, keys, location_ids);
     ASSERT_EQ(expected_ec_vec, ec_vec);
 }
 
-void MetaStorageBackendTestBase::AssertExistsFieldWithPrefix(MetaStorageBackend *meta_storage_backend,
-                                                             const KeyTypeVec &keys,
-                                                             const std::string &field_prefix,
-                                                             const std::vector<ErrorCode> &expected_ec_vec,
-                                                             const std::vector<bool> &expected_exists_vec) {
+void MetaStorageBackendTestBase::AssertExistsLocation(MetaStorageBackend *meta_storage_backend,
+                                                      const KeyTypeVec &keys,
+                                                      const std::vector<ErrorCode> &expected_ec_vec,
+                                                      const std::vector<bool> &expected_exists_vec) {
     ASSERT_TRUE(meta_storage_backend);
     std::vector<bool> exists_vec;
-    std::vector<ErrorCode> ec_vec = meta_storage_backend->ExistsFieldWithPrefix(keys, field_prefix, exists_vec);
+    std::vector<ErrorCode> ec_vec = meta_storage_backend->ExistsLocation(nullptr, keys, exists_vec);
     ASSERT_EQ(expected_ec_vec, ec_vec);
     ASSERT_EQ(expected_exists_vec, exists_vec);
 }

--- a/kv_cache_manager/meta/test/meta_storage_backend_test_base.h
+++ b/kv_cache_manager/meta/test/meta_storage_backend_test_base.h
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "kv_cache_manager/meta/cache_location.h"
+#include "kv_cache_manager/meta/meta_cache_base_backend.h"
 #include "kv_cache_manager/meta/meta_storage_backend.h"
 
 namespace kv_cache_manager {
@@ -11,47 +13,70 @@ protected:
     using KeyTypeVec = MetaStorageBackend::KeyTypeVec;
     using FieldMap = MetaStorageBackend::FieldMap;
     using FieldMapVec = MetaStorageBackend::FieldMapVec;
+    // PropertyMap / PropertyMapVector are defined in types.h, not inside MetaStorageBackend.
+    using PropertyMap = kv_cache_manager::PropertyMap;
+    using PropertyMapVector = kv_cache_manager::PropertyMapVector;
 
-    static void AssertGet(MetaStorageBackend *meta_storage_backend,
-                          const MetaStorageBackend::KeyTypeVec &keys,
-                          const std::vector<std::string> &field_names,
-                          const std::vector<ErrorCode> expected_ec_vec,
-                          const MetaStorageBackend::FieldMapVec &expected_field_maps);
+    // ---- Compatibility wrappers ----
+    // Split a legacy FieldMapVec into CacheLocationMapVector + PropertyMapVector.
+    // Fields starting with LOCATION_PREFIX are treated as locations (value = raw string
+    // stored as-is in a minimal CacheLocation), others go to properties.
+    static void SplitFieldMaps(const FieldMapVec &field_maps,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties);
+    // Legacy-compatible Put/Upsert/Update that accept FieldMapVec.
+    static std::vector<ErrorCode>
+    PutWithFieldMaps(MetaStorageBackend *backend, const KeyTypeVec &keys, const FieldMapVec &field_maps);
+    static std::vector<ErrorCode>
+    UpsertWithFieldMaps(MetaStorageBackend *backend, const KeyTypeVec &keys, const FieldMapVec &field_maps);
+    static std::vector<ErrorCode>
+    UpdateWithFieldMaps(MetaStorageBackend *backend, const KeyTypeVec &keys, const FieldMapVec &field_maps);
+    // Legacy-compatible PutIfAbsent that accepts FieldMapVec (for MetaLocalBackend / MetaCacheBaseBackend).
+    static std::vector<ErrorCode> PutIfAbsentWithFieldMaps(MetaCacheBaseBackend *backend,
+                                                           const KeyTypeVec &keys,
+                                                           const FieldMapVec &field_maps,
+                                                           const std::vector<ErrorCode> &previous_error_codes);
+
+    // ---- Assert helpers ----
+    // Calls GetProperties(nullptr, ...) and asserts the returned per-key PropertyMap.
+    static void AssertGetProperties(MetaStorageBackend *meta_storage_backend,
+                                    const KeyTypeVec &keys,
+                                    const std::vector<std::string> &field_names,
+                                    const std::vector<ErrorCode> &expected_ec_vec,
+                                    const PropertyMapVector &expected_properties);
+    // Calls Get(nullptr, ...) to retrieve locations + properties, then merges
+    // them into a FieldMap (location serialised via ToJsonString) for comparison.
     static void AssertGetAllFields(MetaStorageBackend *meta_storage_backend,
-                                   const MetaStorageBackend::KeyTypeVec &keys,
-                                   const std::vector<ErrorCode> expected_ec_vec,
-                                   const MetaStorageBackend::FieldMapVec &expected_field_maps);
+                                   const KeyTypeVec &keys,
+                                   const std::vector<ErrorCode> &expected_ec_vec,
+                                   const FieldMapVec &expected_field_maps);
     static void AssertExists(MetaStorageBackend *meta_storage_backend,
-                             const MetaStorageBackend::KeyTypeVec &keys,
-                             const std::vector<ErrorCode> expected_ec_vec,
+                             const KeyTypeVec &keys,
+                             const std::vector<ErrorCode> &expected_ec_vec,
                              const std::vector<bool> &expected_is_exist_vec);
     static void AssertListKeys(MetaStorageBackend *meta_storage_backend,
                                const std::string &cursor,
                                const int64_t limit,
                                const ErrorCode expected_ec,
                                const std::string &expected_next_cursor,
-                               const std::set<MetaStorageBackend::KeyType> &expected_keys);
+                               const std::set<KeyType> &expected_keys);
     static void AssertListKeysByStep(MetaStorageBackend *meta_storage_backend,
                                      const std::string &cursor,
                                      const int64_t limit,
                                      const ErrorCode expected_ec,
-                                     const std::set<MetaStorageBackend::KeyType> &expected_keys,
+                                     const std::set<KeyType> &expected_keys,
                                      std::string &out_next_cursor);
     static void AssertSampleReclaimKeys(MetaStorageBackend *meta_storage_backend,
                                         const int64_t count,
                                         const ErrorCode expected_ec,
-                                        const std::set<MetaStorageBackend::KeyType> &expected_keys);
-    // Invokes DeleteFields() and asserts the returned per-key ErrorCode vector.
-    static void AssertDeleteFields(MetaStorageBackend *meta_storage_backend,
-                                   const MetaStorageBackend::KeyTypeVec &keys,
-                                   const std::vector<std::vector<std::string>> &field_names_vec,
-                                   const std::vector<ErrorCode> &expected_ec_vec);
-    // Invokes ExistsFieldWithPrefix() and asserts both ErrorCode vector and the
-    // out_exists_vec (true if any field under `field_prefix` is present).
-    static void AssertExistsFieldWithPrefix(MetaStorageBackend *meta_storage_backend,
-                                            const MetaStorageBackend::KeyTypeVec &keys,
-                                            const std::string &field_prefix,
-                                            const std::vector<ErrorCode> &expected_ec_vec,
-                                            const std::vector<bool> &expected_exists_vec);
+                                        const std::set<KeyType> &expected_keys);
+    static void AssertDeleteLocations(MetaStorageBackend *meta_storage_backend,
+                                      const KeyTypeVec &keys,
+                                      const LocationIdsPerKey &location_ids,
+                                      const std::vector<ErrorCode> &expected_ec_vec);
+    static void AssertExistsLocation(MetaStorageBackend *meta_storage_backend,
+                                     const KeyTypeVec &keys,
+                                     const std::vector<ErrorCode> &expected_ec_vec,
+                                     const std::vector<bool> &expected_exists_vec);
 };
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/types.h
+++ b/kv_cache_manager/meta/types.h
@@ -45,8 +45,6 @@ using PropertyMapVector = std::vector<PropertyMap>;
 // ---------- Location primitives ----------
 using LocationId = std::string;
 using LocationIdVector = std::vector<LocationId>;
-using LocationMap = std::unordered_map<LocationId, CacheLocation>;
-using LocationMapVector = std::vector<LocationMap>;
 using LocationIdsPerKey = std::vector<LocationIdVector>;
 using LocationsPerKey = std::vector<CacheLocationVector>;
 
@@ -63,14 +61,14 @@ using LocationModifierResult = std::pair<ModifierAction, std::vector<ErrorCode>>
 
 // Lightweight block-level modifier: only sees the existing location id list
 // (no location values are deserialized). The modifier can produce new
-// CacheLocations to be written via the output LocationMap.
+// CacheLocations to be written via the output CacheLocationMap.
 using BlockIdsOnlyModifierFunc = std::function<ModifierResult(const LocationIdVector & /*existing_location_ids*/,
                                                               ErrorCode /*get_ec*/,
                                                               size_t /*key_index*/,
                                                               PropertyMap & /*upsert_property_map*/,
-                                                              LocationMap & /*out_new_locations*/)>;
+                                                              CacheLocationMap & /*out_new_locations*/)>;
 
-// Note: an earlier `BlockModifierFunc` variant (sees the entire LocationMap
+// Note: an earlier `BlockModifierFunc` variant (sees the entire CacheLocationMap
 // of one block_key) was removed because nothing in the codebase ever used
 // it. If a future caller really needs the deserialized map, it should fetch
 // it via MetaIndexer::GetLocations and then drive ReadModifyWriteLocation.
@@ -90,9 +88,19 @@ struct BatchMetaData {
     std::vector<int32_t> batch_shard_indexs; // shard mutex indices in this batch
     std::vector<int32_t> batch_indexs;       // raw index in the original KeyVector
     KeyVector batch_keys;                    // keys in this batch
-    LocationMapVector batch_locations;       // optional per-key CacheLocations
+    CacheLocationMapVector batch_locations;  // optional per-key CacheLocations
     LocationIdsPerKey batch_location_ids;    // optional per-key location ids
     PropertyMapVector batch_properties;      // optional per-key properties
+
+    // Ensure batch_locations and batch_properties are sized to match batch_keys.
+    void EnsureLocationsAndPropertiesResized() {
+        if (batch_locations.empty()) {
+            batch_locations.resize(batch_keys.size());
+        }
+        if (batch_properties.empty()) {
+            batch_properties.resize(batch_keys.size());
+        }
+    }
 };
 
 } // namespace kv_cache_manager


### PR DESCRIPTION
### 改动概述

**Commit 1: `[meta] support CacheLocation mem store`**

重构 Meta 存储层接口，统一 `MetaStorageBackend` 的读写 API，引入 `CacheLocationMap`/`CacheLocationVector`/`LocationsPerKey` 等类型定义，为后续 per-location shared_ptr 方案打基础。涉及 `MetaLocalBackend`、`MetaRedisBackend`、`MetaDummyBackend`、`MetaStorageBackendManager`、`MetaIndexer` 全链路适配。

**Commit 2: `[meta] using CacheLocationConstPtr to avoid deep copy`**

核心优化——将 `CacheLocationMap` 和 `CacheLocationVector` 的元素从值语义改为 `shared_ptr<const CacheLocation>`：

- **类型变更**：`CacheLocationConstPtr = shared_ptr<const CacheLocation>`
- **读路径**：拷贝 map 时只增加引用计数（~atomic increment），不再深拷贝 `CacheLocation` 本体
- **写路径**：采用 COW（Copy-On-Write）—— modifier 中 `make_shared` 拷贝后修改，再替换指针
- **`SelectForMatch`**：返回值从裸指针 `CacheLocation*` 改为 `CacheLocationConstPtr`，语义更安全
- **空位置表示**：统一使用 `make_shared<CacheLocation>()` 默认构造，不再使用 `nullptr`

### 性能收益

- `GetForOneKey` 中 map 拷贝从 **O(N × sizeof(CacheLocation))** 降为 **O(N × sizeof(shared_ptr))**
- `FilterWriteCache` 热路径延迟大幅降低
- 减少高并发场景下的堆分配和 page fault