### PR TITLE
[manager] [metrics] fix Prometheus metric type mismatch

### DIFF
--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -20,7 +20,7 @@ namespace kv_cache_manager {
     DEFINE_METRICS_NAME_(SchedulePlanExecutor, schedule_plan_executor, name)
 
 #define REGISTER_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(name)                                                              \
-    REGISTER_METRICS_COUNTER_(metrics_registry_, schedule_plan_executor, name)
+    REGISTER_METRICS_GAUGE_(metrics_registry_, schedule_plan_executor, name)
 
 namespace {
 template <typename ResultType, typename... Args>
@@ -109,10 +109,10 @@ void SchedulePlanExecutor::WorkerRoutine() {
         }
 
         if (task) {
-            --METRICS_(schedule_plan_executor, waiting_task_count);
-            ++METRICS_(schedule_plan_executor, executing_task_count);
+            METRICS_(schedule_plan_executor, waiting_task_count) -= 1;
+            METRICS_(schedule_plan_executor, executing_task_count) += 1;
             task();
-            --METRICS_(schedule_plan_executor, executing_task_count);
+            METRICS_(schedule_plan_executor, executing_task_count) -= 1;
         }
     }
 }
@@ -241,7 +241,7 @@ bool SchedulePlanExecutor::SubmitRaw(const std::function<void()> &task, std::chr
         uint64_t sequence_id = sequence_counter_.fetch_add(1, std::memory_order_relaxed);
         tasks_.emplace(ScheduledTask{task, execute_time, sequence_id});
     }
-    ++METRICS_(schedule_plan_executor, waiting_task_count);
+    METRICS_(schedule_plan_executor, waiting_task_count) += 1;
 
     condition_.notify_one();
     return true;

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -17,14 +17,14 @@
 
 namespace kv_cache_manager {
 
-#ifndef KVCM_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR
-#define KVCM_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(name)                                                                  \
+#ifndef KVCM_GAUGE_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR
+#define KVCM_GAUGE_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(name)                                                            \
 public:                                                                                                                \
     DECLARE_METRICS_NAME_(schedule_plan_executor, name);                                                               \
-    DEFINE_GET_METRICS_COUNTER_(schedule_plan_executor, name)                                                          \
+    DEFINE_GET_METRICS_GAUGE_(schedule_plan_executor, name)                                                            \
                                                                                                                        \
 private:                                                                                                               \
-    DECLARE_METRICS_COUNTER_(schedule_plan_executor, name);
+    DECLARE_METRICS_GAUGE_(schedule_plan_executor, name);
 #endif
 
 class MetaIndexerManager;
@@ -100,10 +100,10 @@ private:
     void DoLocationDelTask(const std::shared_ptr<std::promise<PlanExecuteResult>> &promise,
                            const CacheLocationDelRequest &task);
 
-    KVCM_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(waiting_task_count)
-    KVCM_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(executing_task_count)
+    KVCM_GAUGE_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(waiting_task_count)
+    KVCM_GAUGE_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(executing_task_count)
 };
 
-#undef KVCM_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR
+#undef KVCM_GAUGE_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -523,15 +523,15 @@ void KmonitorMetricsReporter::ReportInterval() {
             break;
         }
 
-        std::uint64_t w_task_count_v;
-        std::uint64_t e_task_count_v;
+        double w_task_count_v;
+        double e_task_count_v;
 
         GET_METRICS_(spe, schedule_plan_executor, waiting_task_count, w_task_count_v);
         GET_METRICS_(spe, schedule_plan_executor, executing_task_count, e_task_count_v);
 
         const kmonitor::MetricsTags tags;
-        REPORT_METRICS(scheduler_plan_executor, waiting_task_count, static_cast<double>(w_task_count_v));
-        REPORT_METRICS(scheduler_plan_executor, executing_task_count, static_cast<double>(e_task_count_v));
+        REPORT_METRICS(scheduler_plan_executor, waiting_task_count, w_task_count_v);
+        REPORT_METRICS(scheduler_plan_executor, executing_task_count, e_task_count_v);
     } while (false);
 
     do {


### PR DESCRIPTION
## Context

SchedulePlanExecutor exposes two metrics that track current queue state — they go up when work is queued/started and down when work finishes:

- kvcm_schedule_plan_executor_waiting_task_count
- kvcm_schedule_plan_executor_executing_task_count

Semantically these are gauges, but the in-process MetricsRegistry registers them as counter via KVCM_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR.

The Prometheus exporter then emits the wrong # TYPE line because it introspects the variant:

    # TYPE kvcm_schedule_plan_executor_executing_task_count counter  <- WRONG
    # TYPE kvcm_schedule_plan_executor_waiting_task_count counter    <- WRONG

Downstream collectors (e.g. dashscope_turbo_backend_) treat counters as monotonic and clamp scrapes with stored = max(stored, scraped), so the dashboard freezes on the all-time maximum (e.g. 4 / 91) and never decreases when work drains. Fixing the type to gauge is the correct end-to-end fix.

## Verification

- [x] Build:

   ```bash
   bazelisk build //kv_cache_manager:main
   ```

- [x] Run the focused unit tests for the touched code:

   ```bash
   bazelisk test //kv_cache_manager/manager/test:schedule_plan_executor_test \
                 //kv_cache_manager/metrics/test:prometheus_exporter_test
   ```

- [ ] End-to-end: start the server, drive some delete traffic through

   `SchedulePlanExecutor`, then scrape `/metrics` and confirm:

   ```text
   # TYPE kvcm_schedule_plan_executor_waiting_task_count gauge
   # TYPE kvcm_schedule_plan_executor_executing_task_count gauge
   ```

   and that the values rise during load and drop back toward 0 once
   the queue drains (no longer pinned to an all-time max in the
   downstream dashboard).