### PR TITLE
[manager] add create and lru age time metrics

### DIFF
--- a/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
+++ b/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
@@ -1,7 +1,10 @@
 #include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
 
+#include <climits>
+
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/instance_group.h"
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/registry_manager.h"
@@ -99,7 +102,13 @@ void CacheManagerMetricsRecorder::RecorderLoop() {
                 const std::size_t key_cnt = meta_indexer->GetKeyCount();
                 const std::size_t byte_size = meta_indexer->GetStorageUsage();
                 group_byte_size += byte_size;
-                group_instance_id_metric_map[instance_group_name][instance_id] = InstanceMetric({key_cnt, byte_size});
+                const int64_t oldest_access_time = meta_indexer->GetOldestAccessTime();
+                int64_t max_lru_age_us = 0;
+                if (oldest_access_time < INT64_MAX) {
+                    max_lru_age_us = TimestampUtil::GetCurrentTimeUs() - oldest_access_time;
+                }
+                group_instance_id_metric_map[instance_group_name][instance_id] =
+                    InstanceMetric({key_cnt, byte_size, max_lru_age_us});
             }
             int64_t capacity = instance_group->quota().capacity();
             group_usage_ratio_map[instance_group_name] =

--- a/kv_cache_manager/manager/cache_manager_metrics_recorder.h
+++ b/kv_cache_manager/manager/cache_manager_metrics_recorder.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -22,6 +23,7 @@ public:
     struct InstanceMetric {
         size_t key_count = 0;
         size_t byte_size = 0;
+        int64_t max_lru_age_us = 0;
     };
     using GroupUsageRatioMap = std::map<std::string, double>;
     using GroupInstanceIdMetricMap = std::map<std::string, std::unordered_map<std::string, InstanceMetric>>;

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -113,6 +113,19 @@ DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_submit_duration_us);
 
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_avg_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_min_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_max_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_avg_us);
+
+void CacheReclaimer::AgeStats::Clear() {
+    min_us = 0;
+    max_us = 0;
+    avg_us = 0;
+}
+
 const std::string CacheReclaimer::kTraceIDPrefix{"cache_reclaimer_internal_trace_"};
 
 inline std::string CacheReclaimer::GenTraceID() {
@@ -330,6 +343,13 @@ ErrorCode CacheReclaimer::Start() noexcept {
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_submit_duration_us);
+
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_avg_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_min_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_max_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_avg_us);
 
     {
         std::unique_lock<std::mutex> lock(job_state_mutex_);
@@ -591,7 +611,8 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
 
     // 2. constitute the batch based on the LRU timestamp info
     const std::int64_t begin_tp_batch = TimestampUtil::GetSteadyTimeUs();
-    if (!MakeBatchByLRU(request_context.get(), instance_info, keys, maps, request.block_keys)) {
+    AgeStats lru_age_stats;
+    if (!MakeBatchByLRU(request_context.get(), instance_info, keys, maps, request.block_keys, lru_age_stats)) {
         LOG_WITH_ID(DEBUG, "make batch failed");
         return;
     }
@@ -601,19 +622,30 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
     if (request.block_keys.empty()) {
         return;
     }
+    METRICS_(cache_reclaimer, reclaim_batch_lru_age_min_us) = static_cast<double>(lru_age_stats.min_us);
+    METRICS_(cache_reclaimer, reclaim_batch_lru_age_max_us) = static_cast<double>(lru_age_stats.max_us);
+    METRICS_(cache_reclaimer, reclaim_batch_lru_age_avg_us) = static_cast<double>(lru_age_stats.avg_us);
 
     // 3. inspect the cache location status for every blocks so that:
     //    a) cache locations in CLS_SERVING status
     //    b) cache locations in CLS_WRITING status *and* is orphaned
     //    are submitted to be deleted
     const std::int64_t begin_tp_filter = TimestampUtil::GetSteadyTimeUs();
-    if (!FilterLocID(
-            request_context.get(), instance_info, request.block_keys, water_level_exceed, request.location_ids)) {
+    AgeStats create_age_stats;
+    if (!FilterLocID(request_context.get(),
+                     instance_info,
+                     request.block_keys,
+                     water_level_exceed,
+                     request.location_ids,
+                     create_age_stats)) {
         LOG_WITH_ID(DEBUG, "filter location ID failed");
         return;
     }
     METRICS_(cache_reclaimer, reclaim_lru_filter_duration_us) =
         static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp_filter);
+    METRICS_(cache_reclaimer, reclaim_batch_create_age_min_us) = static_cast<double>(create_age_stats.min_us);
+    METRICS_(cache_reclaimer, reclaim_batch_create_age_max_us) = static_cast<double>(create_age_stats.max_us);
+    METRICS_(cache_reclaimer, reclaim_batch_create_age_avg_us) = static_cast<double>(create_age_stats.avg_us);
 
     // 4. submit the final deleting request to the executor
     const std::int64_t begin_tp_submit = TimestampUtil::GetSteadyTimeUs();
@@ -731,9 +763,7 @@ bool CacheReclaimer::DoKeySampling(RequestContext *request_context,
         sampling_sz_per_task = total_sampling_sz;
     }
 
-    const std::size_t batching_size = batching_size_.load();
-    bool need_get_properties = total_sampling_sz > batching_size;
-    auto sample = [request_context, &ins_id, &ins_gr, &meta_indexer, &need_get_properties](
+    auto sample = [request_context, &ins_id, &ins_gr, &meta_indexer](
                       std::size_t sampling_sz,
                       std::vector<std::int64_t> &keys,
                       std::vector<std::map<std::string, std::string>> &maps) -> ErrorCode {
@@ -749,19 +779,19 @@ bool CacheReclaimer::DoKeySampling(RequestContext *request_context,
         if (keys.size() != sampling_sz) {
             LOG_WITH_ID(DEBUG, "random sample key size mismatch, expect: [%zu], got: [%zu]", sampling_sz, keys.size());
         }
-        if (!need_get_properties) {
-            return ErrorCode::EC_OK;
-        }
 
         if (const auto res = meta_indexer->GetProperties(request_context, keys, {PROPERTY_LRU_TIME}, maps);
             res.ec != ErrorCode::EC_OK) {
-            LOG_WITH_ID(WARN, "get properties failed, error code: [%d]", static_cast<std::int32_t>(res.ec));
-            return res.ec;
-        }
-        if (keys.size() != maps.size()) {
+            LOG_WITH_ID(WARN,
+                        "get properties failed, error code: [%d], proceed with empty lru_time",
+                        static_cast<std::int32_t>(res.ec));
+            maps.clear();
+            maps.resize(keys.size());
+        } else if (keys.size() != maps.size()) {
             LOG_WITH_ID(
                 WARN, "num of sampled keys [%zu] and property maps [%zu] do not match", keys.size(), maps.size());
-            return ErrorCode::EC_MISMATCH;
+            maps.clear();
+            maps.resize(keys.size());
         }
         return ErrorCode::EC_OK;
     };
@@ -828,15 +858,12 @@ bool CacheReclaimer::MakeBatchByLRU(const RequestContext *request_context,
                                     const std::shared_ptr<const InstanceInfo> &instance_info,
                                     const std::vector<std::int64_t> &sampled_keys,
                                     const std::vector<std::map<std::string, std::string>> &property_maps,
-                                    std::vector<std::int64_t> &out_batch) const noexcept {
+                                    std::vector<std::int64_t> &out_batch,
+                                    AgeStats &out_lru_age_stats) const noexcept {
     const std::size_t batching_size = batching_size_.load();
     if (batching_size == 0) {
         out_batch.clear();
-        return true;
-    }
-    if (sampled_keys.size() <= batching_size) {
-        std::unordered_set<std::int64_t> deduped_batch(sampled_keys.begin(), sampled_keys.end());
-        out_batch.assign(deduped_batch.begin(), deduped_batch.end());
+        out_lru_age_stats.Clear();
         return true;
     }
 
@@ -872,45 +899,69 @@ bool CacheReclaimer::MakeBatchByLRU(const RequestContext *request_context,
         key_tp_vec.emplace_back(k, lru_ts);
     }
 
-    std::sort(key_tp_vec.begin(),
-              key_tp_vec.end(),
-              [](const std::pair<std::int64_t, std::int64_t> &a,
-                 const std::pair<std::int64_t, std::int64_t> &b) -> bool { return a.second < b.second; });
+    if (sampled_keys.size() > batching_size) {
+        std::sort(key_tp_vec.begin(),
+                  key_tp_vec.end(),
+                  [](const std::pair<std::int64_t, std::int64_t> &a,
+                     const std::pair<std::int64_t, std::int64_t> &b) -> bool { return a.second < b.second; });
+    }
 
     // constitute the batch to be submitted for deleting
     // the first N timestamp would be picked out
+    const std::size_t effective_batch_size = std::min(batching_size, sampled_keys.size());
     std::unordered_set<std::int64_t> deduped_batch;
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    int64_t age_sum = 0;
+    int64_t age_count = 0;
     for (const auto &[key, tp] : key_tp_vec) {
         if (auto [_, r] = deduped_batch.insert(key); r) {
-            if (deduped_batch.size() == batching_size) {
-                // the batch is successfully constituted
-                out_batch.assign(deduped_batch.begin(), deduped_batch.end());
-                return true;
+            if (tp > 0) {
+                const int64_t age = now_us - tp;
+                out_lru_age_stats.min_us = std::min(out_lru_age_stats.min_us, age);
+                out_lru_age_stats.max_us = std::max(out_lru_age_stats.max_us, age);
+                age_sum += age;
+                ++age_count;
+            }
+            if (deduped_batch.size() == effective_batch_size) {
+                break;
             }
         }
     }
 
-    if (deduped_batch.size() != sampled_keys.size()) {
-        // sampled_keys contains duplicated keys, log the event
-        LOG_WITH_ID(DEBUG,
-                    "shortened batch size (likely duplicated keys sampled), final batch size: [%zu], "
-                    "sampled keys size: [%zu], intended batching size: [%zu]",
-                    deduped_batch.size(),
-                    sampled_keys.size(),
-                    batching_size);
-    } else {
-        // the batch size is equal to the size of sampled keys;
-        // * possibility 1: not enough keys sampled
-        // * possibility 2: sampling_size_ < batching_size_
-        LOG_WITH_ID(DEBUG,
-                    "shortened batch size, final batch size: [%zu], "
-                    "sampled keys size: [%zu], intended batching size: [%zu]",
-                    deduped_batch.size(),
-                    sampled_keys.size(),
-                    batching_size);
+    if (deduped_batch.empty()) {
+        out_batch.clear();
+        out_lru_age_stats.Clear();
+        return true;
     }
 
-    // permit a no-full-sized batch
+    if (age_count > 0) {
+        out_lru_age_stats.avg_us = age_sum / age_count;
+    } else {
+        out_lru_age_stats.Clear();
+    }
+
+    if (deduped_batch.size() < batching_size) {
+        if (deduped_batch.size() != sampled_keys.size()) {
+            // sampled_keys contains duplicated keys, log the event
+            LOG_WITH_ID(DEBUG,
+                        "shortened batch size (likely duplicated keys sampled), final batch size: [%zu], "
+                        "sampled keys size: [%zu], intended batching size: [%zu]",
+                        deduped_batch.size(),
+                        sampled_keys.size(),
+                        batching_size);
+        } else {
+            // the batch size is equal to the size of sampled keys;
+            // * possibility 1: not enough keys sampled
+            // * possibility 2: sampling_size_ < batching_size_
+            LOG_WITH_ID(DEBUG,
+                        "shortened batch size, final batch size: [%zu], "
+                        "sampled keys size: [%zu], intended batching size: [%zu]",
+                        deduped_batch.size(),
+                        sampled_keys.size(),
+                        batching_size);
+        }
+    }
+
     out_batch.assign(deduped_batch.begin(), deduped_batch.end());
     return true;
 }
@@ -919,7 +970,8 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                                  const std::shared_ptr<const InstanceInfo> &instance_info,
                                  const std::vector<std::int64_t> &batch,
                                  const WaterLevelExceed &water_level_exceed,
-                                 std::vector<std::vector<std::string>> &out_loc_ids) const noexcept {
+                                 std::vector<std::vector<std::string>> &out_loc_ids,
+                                 AgeStats &out_create_age_stats) const noexcept {
     const std::string &ins_id = instance_info->instance_id();
     const std::string &ins_gr = instance_info->instance_group_name();
 
@@ -950,6 +1002,9 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
     // inspect the cache location status of each block and get the
     // filtered location ID vecs
     out_loc_ids.reserve(loc_maps.size());
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    int64_t create_age_sum = 0;
+    int64_t create_age_count = 0;
     for (const auto &loc_map : loc_maps) {
         std::vector<std::string> loc_id_vec;
         for (const auto &[_, loc_ptr] : loc_map) {
@@ -965,6 +1020,7 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                                              write_location_manager_ != nullptr &&
                                              !write_location_manager_->HasLocationId(loc.id());
             if (loc.status() == CacheLocationStatus::CLS_SERVING || is_orphaned_writing) {
+                bool selected = false;
                 if (water_level_exceed.CheckStorageTypeWaterLevelExceed()) {
                     // some storage type water level exceeded; only
                     // collect the location with matched type but
@@ -972,6 +1028,7 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                     // TODO (rui): implement the fair eviction
                     if (water_level_exceed.GetWaterLevelExceedByType(loc.type())) {
                         loc_id_vec.emplace_back(loc.id());
+                        selected = true;
                     }
                 } else {
                     // there's no storage type water level exceeded
@@ -979,11 +1036,24 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                     // usage water level must be exceeded; ignore the
                     // type detection
                     loc_id_vec.emplace_back(loc.id());
+                    selected = true;
+                }
+                if (selected && loc.create_time() > 0) {
+                    const int64_t age = now_us - loc.create_time();
+                    out_create_age_stats.min_us = std::min(out_create_age_stats.min_us, age);
+                    out_create_age_stats.max_us = std::max(out_create_age_stats.max_us, age);
+                    create_age_sum += age;
+                    ++create_age_count;
                 }
             }
         }
         out_loc_ids.emplace_back(std::move(loc_id_vec));
     }
+    if (create_age_count == 0) {
+        out_create_age_stats.Clear();
+        return true;
+    }
+    out_create_age_stats.avg_us = create_age_sum / create_age_count;
     return true;
 }
 

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <atomic>
+#include <climits>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -82,6 +83,13 @@ struct PlanExecuteResult;
  */
 class CacheReclaimer {
 public:
+    struct AgeStats {
+        int64_t min_us = INT64_MAX;
+        int64_t max_us = 0;
+        int64_t avg_us = 0;
+        void Clear();
+    };
+
     /**
      * @brief Delete default constructor
      */
@@ -478,13 +486,15 @@ private:
                         const std::shared_ptr<const InstanceInfo> &instance_info,
                         const std::vector<std::int64_t> &sampled_keys,
                         const std::vector<std::map<std::string, std::string>> &property_maps,
-                        std::vector<std::int64_t> &out_batch) const noexcept;
+                        std::vector<std::int64_t> &out_batch,
+                        AgeStats &out_lru_age_stats) const noexcept;
 
     bool FilterLocID(RequestContext *request_context,
                      const std::shared_ptr<const InstanceInfo> &instance_info,
                      const std::vector<std::int64_t> &batch,
                      const WaterLevelExceed &water_level_exceed,
-                     std::vector<std::vector<std::string>> &out_loc_ids) const noexcept;
+                     std::vector<std::vector<std::string>> &out_loc_ids,
+                     AgeStats &out_create_age_stats) const noexcept;
 
     void SubmitDelReq(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
@@ -511,6 +521,13 @@ private:
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_submit_duration_us)
+
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_avg_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_min_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_max_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_create_age_avg_us)
 };
 
 #undef KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -8,6 +8,7 @@
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/metrics/metrics_collector.h"
 
@@ -390,8 +391,9 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
     out_location_ids.resize(keys.size());
     std::vector<std::pair<DataStorageType, std::uint64_t>> loc_sz(keys.size());
 
+    const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
     auto modifier =
-        [&locations, &out_location_ids, &keys, &loc_sz](const LocationIdVector &existing_location_ids,
+        [&locations, &out_location_ids, &keys, &loc_sz, batch_create_time](const LocationIdVector &existing_location_ids,
                                                         ErrorCode get_ec,
                                                         size_t index,
                                                         PropertyMap &upsert_property_map,
@@ -419,6 +421,7 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
         auto new_loc = std::make_shared<CacheLocation>(*locations[index]);
         new_loc->set_id(location_id);
         new_loc->set_status(CLS_WRITING);
+        new_loc->set_create_time(batch_create_time);
         out_new_locations[location_id] = std::move(new_loc);
 
         // compute storage size for usage tracking

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -2924,8 +2924,7 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
         std::vector<std::map<std::string, std::string>> maps;
         ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_.get(), instance_infos.front(), keys, maps));
         ASSERT_EQ(1, keys.size());
-        // sampling_size_ <= delete_batch_size, will not get properties
-        ASSERT_EQ(0, maps.size());
+        ASSERT_EQ(1, maps.size());
     }
 
     {
@@ -2988,9 +2987,18 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::int64_t> keys(sample_reclaim_keys);
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
+        CacheReclaimer::AgeStats lru_age_stats;
         ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch));
+            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(9, batch.size());
+        // keys 1..10 unique, lru_times 0..9; tp=0 excluded from stats, tp=1..9 included (9 entries)
+        // ages: now_us-1, now_us-2, ..., now_us-9 → min=now_us-9, max=now_us-1, diff=8
+        EXPECT_GT(lru_age_stats.min_us, 0);
+        EXPECT_GT(lru_age_stats.max_us, 0);
+        EXPECT_GT(lru_age_stats.avg_us, 0);
+        EXPECT_LE(lru_age_stats.min_us, lru_age_stats.avg_us);
+        EXPECT_LE(lru_age_stats.avg_us, lru_age_stats.max_us);
+        EXPECT_EQ(lru_age_stats.max_us - lru_age_stats.min_us, 8);
     }
 
     {
@@ -3035,9 +3043,15 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::int64_t> keys(sample_reclaim_keys);
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
+        CacheReclaimer::AgeStats lru_age_stats;
         ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch));
+            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(1, batch.size());
+        // all keys are 1 (only 1 unique key), first occurrence has tp=0 → excluded
+        // age_count=0 → Clear() called → all stats zeroed
+        EXPECT_EQ(lru_age_stats.min_us, 0);
+        EXPECT_EQ(lru_age_stats.max_us, 0);
+        EXPECT_EQ(lru_age_stats.avg_us, 0);
     }
 
     {
@@ -3082,9 +3096,18 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::int64_t> keys(sample_reclaim_keys);
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
+        CacheReclaimer::AgeStats lru_age_stats;
         ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch));
+            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(2, batch.size());
+        // keys={1*7,2,1,1}, tp={9*7,10,9,9}; sorted → key=1(tp=9) then key=2(tp=10)
+        // ages: now_us-9 and now_us-10 → min=now_us-10, max=now_us-9, diff=1
+        EXPECT_GT(lru_age_stats.min_us, 0);
+        EXPECT_GT(lru_age_stats.max_us, 0);
+        EXPECT_GT(lru_age_stats.avg_us, 0);
+        EXPECT_LE(lru_age_stats.min_us, lru_age_stats.avg_us);
+        EXPECT_LE(lru_age_stats.avg_us, lru_age_stats.max_us);
+        EXPECT_EQ(lru_age_stats.max_us - lru_age_stats.min_us, 1);
     }
 }
 

--- a/kv_cache_manager/meta/cache_location.h
+++ b/kv_cache_manager/meta/cache_location.h
@@ -105,6 +105,7 @@ public:
         Put(writer, "status", status_);
         Put(writer, "type", type_);
         Put(writer, "spec_size", spec_size_);
+        Put(writer, "create_time", create_time_);
         Put(writer, "location_specs", location_specs_);
     }
 
@@ -113,6 +114,7 @@ public:
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "status", status_, CacheLocationStatus::CLS_NOT_FOUND);
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "type", type_, DataStorageType::DATA_STORAGE_TYPE_UNKNOWN);
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "spec_size", spec_size_, size_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "create_time", create_time_, int64_t{0});
         KVCM_JSON_GET_MACRO(rapid_value, "location_specs", location_specs_);
         return true;
     }
@@ -121,6 +123,7 @@ public:
     void set_type(DataStorageType type) { type_ = type; }
     void set_id(const std::string &id) { id_ = id; }
     void set_spec_size(size_t spec_size) { spec_size_ = spec_size; }
+    void set_create_time(int64_t create_time) { create_time_ = create_time; }
     void push_location_spec(LocationSpec &&location_spec) { location_specs_.push_back(std::move(location_spec)); }
     void set_location_specs(std::vector<LocationSpec> &&location_specs) { location_specs_ = location_specs; }
 
@@ -129,6 +132,7 @@ public:
     [[nodiscard]] CacheLocationStatus status() const { return status_; }
     [[nodiscard]] DataStorageType type() const { return type_; }
     [[nodiscard]] size_t spec_size() const { return spec_size_; }
+    [[nodiscard]] int64_t create_time() const { return create_time_; }
     [[nodiscard]] size_t EstimateMemUsage() const {
         size_t usage = sizeof(CacheLocation) + id_.size();
         for (const auto &spec : location_specs_) {
@@ -142,6 +146,7 @@ private:
     CacheLocationStatus status_ = CacheLocationStatus::CLS_NEW;
     DataStorageType type_ = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
     size_t spec_size_ = 0;
+    int64_t create_time_ = 0;
     std::vector<LocationSpec> location_specs_;
 };
 

--- a/kv_cache_manager/meta/meta_cache_base_backend.h
+++ b/kv_cache_manager/meta/meta_cache_base_backend.h
@@ -20,6 +20,7 @@ public:
     using MetaStorageBackend::Upsert;
 
     virtual size_t GetMemUsage() const noexcept = 0;
+    virtual int64_t GetOldestAccessTime() const noexcept = 0;
 
     // 写入 locations + properties，仅当 key 在 cache 中不存在时才写入。
     // 若 key 已存在，返回 EC_OK 且不修改已有数据（幂等）。

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -775,6 +775,8 @@ size_t MetaIndexer::GetMaxKeyCount() const noexcept { return max_key_count_; }
 
 size_t MetaIndexer::GetMemUsage() const noexcept { return backend_manager_->GetMemUsage(); }
 
+int64_t MetaIndexer::GetOldestAccessTime() const noexcept { return backend_manager_->GetOldestAccessTime(); }
+
 std::uint64_t MetaIndexer::GetStorageUsage() const noexcept { return storage_usage_data_.GetStorageUsage(); }
 
 std::uint64_t MetaIndexer::GetStorageUsageByType(const DataStorageType &type) const noexcept {

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -106,6 +106,7 @@ public:
     size_t GetKeyCount() const noexcept;
     size_t GetMaxKeyCount() const noexcept;
     size_t GetMemUsage() const noexcept;
+    int64_t GetOldestAccessTime() const noexcept;
 
     // storage usage interfaces
     [[nodiscard]] std::uint64_t GetStorageUsage() const noexcept;

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -703,6 +703,15 @@ ErrorCode MetaLocalBackend::GetMetaData(FieldMap & /*field_maps*/) noexcept { re
 
 size_t MetaLocalBackend::GetMemUsage() const noexcept { return cache_->GetUsage(); }
 
+int64_t MetaLocalBackend::GetOldestAccessTime() const noexcept {
+    int64_t oldest = INT64_MAX;
+    size_t num_shards = shard_mask_ + 1;
+    for (size_t s = 0; s < num_shards; ++s) {
+        oldest = std::min(oldest, shard_oldest_access_time_[s].load(std::memory_order_relaxed));
+    }
+    return oldest;
+}
+
 size_t MetaLocalBackend::CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys) {
     std::vector<std::string> string_keys;
     string_keys.reserve(count);

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -170,6 +170,7 @@ public:
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
 
     size_t GetMemUsage() const noexcept override;
+    int64_t GetOldestAccessTime() const noexcept override;
 
 private:
     size_t CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys);

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/meta/meta_storage_backend_manager.h"
 
 #include <cassert>
+#include <climits>
 #include <utility>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -725,6 +726,13 @@ size_t MetaStorageBackendManager::GetMemUsage() const noexcept {
         return cache_backend_->GetMemUsage();
     }
     return 0;
+}
+
+int64_t MetaStorageBackendManager::GetOldestAccessTime() const noexcept {
+    if (cache_backend_) {
+        return cache_backend_->GetOldestAccessTime();
+    }
+    return INT64_MAX;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -88,6 +88,7 @@ public:
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept;
 
     size_t GetMemUsage() const noexcept;
+    int64_t GetOldestAccessTime() const noexcept;
 
 private:
     void AsyncRecoverTask() noexcept;

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -128,11 +128,19 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_filter_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_submit_duration_us);
 
+    DECLARE_METRICS(cache_reclaimer, reclaim_batch_lru_age_min_us);
+    DECLARE_METRICS(cache_reclaimer, reclaim_batch_lru_age_max_us);
+    DECLARE_METRICS(cache_reclaimer, reclaim_batch_lru_age_avg_us);
+    DECLARE_METRICS(cache_reclaimer, reclaim_batch_create_age_min_us);
+    DECLARE_METRICS(cache_reclaimer, reclaim_batch_create_age_max_us);
+    DECLARE_METRICS(cache_reclaimer, reclaim_batch_create_age_avg_us);
+
     // cache manager
     DECLARE_METRICS(cache_manager, write_location_expire_size);
     DECLARE_METRICS(cache_manager_group, usage_ratio);
     DECLARE_METRICS(cache_manager_instance, key_count);
     DECLARE_METRICS(cache_manager_instance, byte_size);
+    DECLARE_METRICS(cache_manager_instance, max_lru_age_us);
 
     struct MapHashFunc {
         size_t operator()(const std::map<std::string, std::string> &m) const noexcept {
@@ -349,11 +357,19 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_filter_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_submit_duration_us);
 
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_lru_age_min_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_lru_age_max_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_lru_age_avg_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_create_age_min_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_create_age_max_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_create_age_avg_us);
+
     // cache manager
     REGISTER_GAUGE_METRIC(cache_manager, write_location_expire_size);
     REGISTER_GAUGE_METRIC(cache_manager_group, usage_ratio);
     REGISTER_GAUGE_METRIC(cache_manager_instance, key_count);
     REGISTER_GAUGE_METRIC(cache_manager_instance, byte_size);
+    REGISTER_GAUGE_METRIC(cache_manager_instance, max_lru_age_us);
 
     return true;
 }
@@ -559,6 +575,13 @@ void KmonitorMetricsReporter::ReportInterval() {
         double reclaim_lru_filter_duration_us_v;
         double reclaim_lru_submit_duration_us_v;
 
+        double reclaim_batch_lru_age_min_us_v;
+        double reclaim_batch_lru_age_max_us_v;
+        double reclaim_batch_lru_age_avg_us_v;
+        double reclaim_batch_create_age_min_us_v;
+        double reclaim_batch_create_age_max_us_v;
+        double reclaim_batch_create_age_avg_us_v;
+
         GET_METRICS_(cr, cache_reclaimer, reclaim_cron_count, reclaim_cron_count_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_job_count, reclaim_job_count_v);
         GET_METRICS_(cr, cache_reclaimer, block_submit_count, blk_submit_count_v);
@@ -574,6 +597,13 @@ void KmonitorMetricsReporter::ReportInterval() {
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_batch_duration_us, reclaim_lru_batch_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_filter_duration_us, reclaim_lru_filter_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_submit_duration_us, reclaim_lru_submit_duration_us_v);
+
+        GET_METRICS_(cr, cache_reclaimer, reclaim_batch_lru_age_min_us, reclaim_batch_lru_age_min_us_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_batch_lru_age_max_us, reclaim_batch_lru_age_max_us_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_batch_lru_age_avg_us, reclaim_batch_lru_age_avg_us_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_batch_create_age_min_us, reclaim_batch_create_age_min_us_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_batch_create_age_max_us, reclaim_batch_create_age_max_us_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_batch_create_age_avg_us, reclaim_batch_create_age_avg_us_v);
 
         const kmonitor::MetricsTags tags;
         REPORT_METRICS(cache_reclaimer, reclaim_cron_count, static_cast<double>(reclaim_cron_count_v));
@@ -591,6 +621,13 @@ void KmonitorMetricsReporter::ReportInterval() {
         REPORT_METRICS(cache_reclaimer, reclaim_lru_batch_duration_us, reclaim_lru_batch_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_lru_filter_duration_us, reclaim_lru_filter_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_lru_submit_duration_us, reclaim_lru_submit_duration_us_v);
+
+        REPORT_METRICS(cache_reclaimer, reclaim_batch_lru_age_min_us, reclaim_batch_lru_age_min_us_v);
+        REPORT_METRICS(cache_reclaimer, reclaim_batch_lru_age_max_us, reclaim_batch_lru_age_max_us_v);
+        REPORT_METRICS(cache_reclaimer, reclaim_batch_lru_age_avg_us, reclaim_batch_lru_age_avg_us_v);
+        REPORT_METRICS(cache_reclaimer, reclaim_batch_create_age_min_us, reclaim_batch_create_age_min_us_v);
+        REPORT_METRICS(cache_reclaimer, reclaim_batch_create_age_max_us, reclaim_batch_create_age_max_us_v);
+        REPORT_METRICS(cache_reclaimer, reclaim_batch_create_age_avg_us, reclaim_batch_create_age_avg_us_v);
     } while (false);
 
     do {
@@ -623,11 +660,13 @@ void KmonitorMetricsReporter::ReportInterval() {
             for (const auto &mc : vec) {
                 if (const auto p = std::dynamic_pointer_cast<CacheManagerInstanceMetricsCollector>(mc); p != nullptr) {
                     const kmonitor::MetricsTags tags = ctx_->GetKmonitorTags(p->GetMetricsTags());
-                    double key_count_v, byte_size_v;
+                    double key_count_v, byte_size_v, max_lru_age_us_v;
                     GET_METRICS_(p, cache_manager_instance, key_count, key_count_v);
                     REPORT_METRICS(cache_manager_instance, key_count, key_count_v);
                     GET_METRICS_(p, cache_manager_instance, byte_size, byte_size_v);
                     REPORT_METRICS(cache_manager_instance, byte_size, byte_size_v);
+                    GET_METRICS_(p, cache_manager_instance, max_lru_age_us, max_lru_age_us_v);
+                    REPORT_METRICS(cache_manager_instance, max_lru_age_us, max_lru_age_us_v);
                 }
             }
         }

--- a/kv_cache_manager/metrics/local_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/local_metrics_reporter.cc
@@ -183,6 +183,7 @@ void LocalMetricsReporter::ReportInterval() {
                                 MetricsTags{{"instance_group", instance_group_name}, {"instance_id", instance_id}});
                     SET_METRICS_(p, cache_manager_instance, key_count, static_cast<double>(instance_metric.key_count));
                     SET_METRICS_(p, cache_manager_instance, byte_size, static_cast<double>(instance_metric.byte_size));
+                    SET_METRICS_(p, cache_manager_instance, max_lru_age_us, static_cast<double>(instance_metric.max_lru_age_us));
                 }
             }
         }

--- a/kv_cache_manager/metrics/metrics_collector.cc
+++ b/kv_cache_manager/metrics/metrics_collector.cc
@@ -304,6 +304,7 @@ bool CacheManagerGroupMetricsCollector::Init() {
 
 DEFINE_METRICS_NAME_FOR_CACHE_MANAGER(CacheManagerInstanceMetricsCollector, cache_manager_instance, key_count);
 DEFINE_METRICS_NAME_FOR_CACHE_MANAGER(CacheManagerInstanceMetricsCollector, cache_manager_instance, byte_size);
+DEFINE_METRICS_NAME_FOR_CACHE_MANAGER(CacheManagerInstanceMetricsCollector, cache_manager_instance, max_lru_age_us);
 
 CacheManagerInstanceMetricsCollector::CacheManagerInstanceMetricsCollector(
     std::shared_ptr<MetricsRegistry> metrics_registry) noexcept
@@ -320,6 +321,7 @@ bool CacheManagerInstanceMetricsCollector::Init() {
 
     REGISTER_GAUGE_METRICS_FOR_CACHE_MANAGER(cache_manager_instance, key_count);
     REGISTER_GAUGE_METRICS_FOR_CACHE_MANAGER(cache_manager_instance, byte_size);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_MANAGER(cache_manager_instance, max_lru_age_us);
 
     return true;
 }

--- a/kv_cache_manager/metrics/metrics_collector.h
+++ b/kv_cache_manager/metrics/metrics_collector.h
@@ -414,6 +414,7 @@ public:
 class CacheManagerInstanceMetricsCollector final : public MetricsCollector {
     KVCM_GAUGE_METRICS(cache_manager_instance, key_count)
     KVCM_GAUGE_METRICS(cache_manager_instance, byte_size)
+    KVCM_GAUGE_METRICS(cache_manager_instance, max_lru_age_us)
 
 public:
     CacheManagerInstanceMetricsCollector() = delete;


### PR DESCRIPTION
- CacheLocation：新增 create_time 字段，记录缓存 location 的创建时间。

- CacheReclaimer：在每次回收批次中计算并上报被淘汰 key 的 LRU age（min/max/avg）和 location 的 create age（min/max/avg），提升淘汰行为的可观测性。

- MetaIndexer：新增 GetOldestAccessTime() 接口，暴露所有缓存 key 中最老的 LRU 时间戳。

- CacheManagerMetricsRecorder：在周期性指标上报中新增 per-instance 的 max_lru_age_us，反映全局最老缓存条目的存活时长。