### PR TITLE
[manager] fair eviction across instances within an instance group

### DIFF
--- a/kv_cache_manager/config/cache_reclaim_strategy.cc
+++ b/kv_cache_manager/config/cache_reclaim_strategy.cc
@@ -12,6 +12,7 @@ bool CacheReclaimStrategy::FromRapidValue(const rapidjson::Value &rapid_value) {
     KVCM_JSON_GET_MACRO(rapid_value, "reclaim_step_size", reclaim_step_size_);
     KVCM_JSON_GET_MACRO(rapid_value, "reclaim_step_percentage", reclaim_step_percentage_);
     KVCM_JSON_GET_MACRO(rapid_value, "delay_before_delete_ms", delay_before_delete_ms_);
+    KVCM_JSON_GET_MACRO(rapid_value, "enable_instance_fairness", enable_instance_fairness_);
     return true;
 }
 
@@ -23,6 +24,7 @@ void CacheReclaimStrategy::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuff
     Put(writer, "reclaim_step_size", reclaim_step_size_);
     Put(writer, "reclaim_step_percentage", reclaim_step_percentage_);
     Put(writer, "delay_before_delete_ms", delay_before_delete_ms_);
+    Put(writer, "enable_instance_fairness", enable_instance_fairness_);
 }
 
 bool CacheReclaimStrategy::ValidateRequiredFields(std::string &invalid_fields) const {

--- a/kv_cache_manager/config/cache_reclaim_strategy.h
+++ b/kv_cache_manager/config/cache_reclaim_strategy.h
@@ -30,14 +30,16 @@ public:
                          int32_t trigger_period_seconds,
                          int32_t reclaim_step_size,
                          int32_t reclaim_step_percentage,
-                         int32_t delay_before_delete_ms = 0)
+                         int32_t delay_before_delete_ms = 0,
+                         bool enable_instance_fairness = true)
         : storage_unique_name_(storage_unique_name)
         , reclaim_policy_(reclaim_policy)
         , trigger_strategy_(trigger_strategy)
         , trigger_period_seconds_(trigger_period_seconds)
         , reclaim_step_size_(reclaim_step_size)
         , reclaim_step_percentage_(reclaim_step_percentage)
-        , delay_before_delete_ms_(delay_before_delete_ms) {}
+        , delay_before_delete_ms_(delay_before_delete_ms)
+        , enable_instance_fairness_(enable_instance_fairness) {}
 
     ~CacheReclaimStrategy() override;
 
@@ -52,6 +54,7 @@ public:
     int32_t reclaim_step_size() const { return reclaim_step_size_; }
     int32_t reclaim_step_percentage() const { return reclaim_step_percentage_; }
     int32_t delay_before_delete_ms() const { return delay_before_delete_ms_; }
+    bool enable_instance_fairness() const { return enable_instance_fairness_; }
 
     // Setters
     void set_storage_unique_name(const std::string &storage_unique_name) { storage_unique_name_ = storage_unique_name; }
@@ -66,6 +69,9 @@ public:
     }
     void set_delay_before_delete_ms(int32_t delay_before_delete_ms) {
         delay_before_delete_ms_ = delay_before_delete_ms;
+    }
+    void set_enable_instance_fairness(bool enable_instance_fairness) {
+        enable_instance_fairness_ = enable_instance_fairness;
     }
 
 public:
@@ -82,6 +88,7 @@ private:
     int32_t reclaim_step_size_;
     int32_t reclaim_step_percentage_;
     int32_t delay_before_delete_ms_;
+    bool enable_instance_fairness_ = true;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -144,31 +144,7 @@ inline std::string CacheReclaimer::GenTraceID() {
 }
 
 // instance group key & storage usage data
-struct CacheReclaimer::GroupUsageData {
-    std::size_t grp_used_key_cnt_;
-    std::size_t grp_max_key_cnt_;
-    std::size_t grp_used_byte_sz_;
-
-    GroupUsageData();
-    ~GroupUsageData() = default;
-
-    [[nodiscard]] std::size_t GetGroupUsageByType(const DataStorageType &type) const noexcept;
-    void AddGroupUsageByType(const DataStorageType &type, std::size_t value) noexcept;
-
-private:
-    using array_t_ = std::array<std::size_t, static_cast<std::size_t>(DataStorageType::COUNT)>;
-    using size_t_ = array_t_::size_type;
-
-    // group storage usage data array aggregated by storage type
-    // slot 0: DATA_STORAGE_TYPE_UNKNOWN **UNUSED**
-    // slot 1: DATA_STORAGE_TYPE_HF3FS usage data
-    // slot 2: DATA_STORAGE_TYPE_MOONCAKE usage data
-    // slot 3: DATA_STORAGE_TYPE_TAIR_MEMPOOL usage data
-    // slot 4: DATA_STORAGE_TYPE_NFS usage data
-    // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
-    // slot 6: DATA_STORAGE_TYPE_DUMMY usage data (testing only)
-    array_t_ grp_storage_usage_by_type_;
-};
+// (definition moved to cache_reclaimer.h so tests can construct one)
 
 CacheReclaimer::GroupUsageData::GroupUsageData()
     : grp_used_key_cnt_(0), grp_max_key_cnt_(0), grp_used_byte_sz_(0), grp_storage_usage_by_type_{} {
@@ -176,7 +152,7 @@ CacheReclaimer::GroupUsageData::GroupUsageData()
 }
 
 std::size_t CacheReclaimer::GroupUsageData::GetGroupUsageByType(const DataStorageType &type) const noexcept {
-    const size_t_ idx = ToIndex(ToBaseType(type));
+    const std::size_t idx = ToIndex(ToBaseType(type));
     if (idx >= grp_storage_usage_by_type_.size()) {
         KVCM_LOG_WARN("data storage type to index out of range, array size: [%zu], type as index: [%zu]",
                       grp_storage_usage_by_type_.size(),
@@ -188,7 +164,7 @@ std::size_t CacheReclaimer::GroupUsageData::GetGroupUsageByType(const DataStorag
 
 void CacheReclaimer::GroupUsageData::AddGroupUsageByType(const DataStorageType &type,
                                                          const std::size_t value) noexcept {
-    const size_t_ idx = ToIndex(ToBaseType(type));
+    const std::size_t idx = ToIndex(ToBaseType(type));
     if (idx >= grp_storage_usage_by_type_.size()) {
         KVCM_LOG_WARN("data storage type to index out of range, array size: [%zu], type as index: [%zu]",
                       grp_storage_usage_by_type_.size(),
@@ -452,7 +428,7 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
                                     const std::string &ins_gr,
                                     const InstanceGroupQuota &instance_group_quota,
                                     const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
-                                    const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept {
+                                    const GroupUsageData &group_usage_data) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
         return nullptr;
@@ -469,13 +445,7 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
     //       2. storage type usage and capacity quota for this group
 
     const auto water_level_exceed = std::make_shared<WaterLevelExceed>();
-
-    // 1. calculate the key count and used byte size of this group
-    const auto data = GetGroupUsageData(request_context, instance_infos);
-    if (data == nullptr) {
-        LOG_WITH_GR(ERROR, "group usage data is nullptr");
-        return nullptr;
-    }
+    const GroupUsageData *data = &group_usage_data;
 
     // 2. generate the result water level exceeding array
     const double threshold_used_percentage = reclaim_strategy->trigger_strategy().used_percentage();
@@ -574,7 +544,8 @@ bool CacheReclaimer::IsTriggerReclaiming(const std::shared_ptr<WaterLevelExceed>
 void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request_context,
                                   const InstanceInfoConstPtr &instance_info,
                                   const WaterLevelExceed &water_level_exceed,
-                                  const std::int32_t delay_before_delete_ms) noexcept {
+                                  const std::int32_t delay_before_delete_ms,
+                                  const std::size_t batch_size_override) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
         return;
@@ -612,7 +583,13 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
     // 2. constitute the batch based on the LRU timestamp info
     const std::int64_t begin_tp_batch = TimestampUtil::GetSteadyTimeUs();
     AgeStats lru_age_stats;
-    if (!MakeBatchByLRU(request_context.get(), instance_info, keys, maps, request.block_keys, lru_age_stats)) {
+    if (!MakeBatchByLRU(request_context.get(),
+                        instance_info,
+                        keys,
+                        maps,
+                        request.block_keys,
+                        lru_age_stats,
+                        batch_size_override)) {
         LOG_WITH_ID(DEBUG, "make batch failed");
         return;
     }
@@ -659,7 +636,8 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
 void CacheReclaimer::ReclaimByLFU(const std::shared_ptr<RequestContext> &request_context,
                                   const InstanceInfoConstPtr &instance_info,
                                   const WaterLevelExceed &water_level_exceed,
-                                  const std::int32_t delay_before_delete_ms) noexcept {
+                                  const std::int32_t delay_before_delete_ms,
+                                  const std::size_t batch_size_override) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
         return;
@@ -667,13 +645,14 @@ void CacheReclaimer::ReclaimByLFU(const std::shared_ptr<RequestContext> &request
 
     // TODO: impl LFU policy
     LOG_WITH_TRACE(WARN, "LFU reclaim policy not supported yet; fall back to LRU policy");
-    ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms);
+    ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms, batch_size_override);
 }
 
 void CacheReclaimer::ReclaimByTTL(const std::shared_ptr<RequestContext> &request_context,
                                   const InstanceInfoConstPtr &instance_info,
                                   const WaterLevelExceed &water_level_exceed,
-                                  const std::int32_t delay_before_delete_ms) noexcept {
+                                  const std::int32_t delay_before_delete_ms,
+                                  const std::size_t batch_size_override) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
         return;
@@ -681,7 +660,7 @@ void CacheReclaimer::ReclaimByTTL(const std::shared_ptr<RequestContext> &request
 
     // TODO: impl TTL policy
     LOG_WITH_TRACE(WARN, "TTL reclaim policy not supported yet; fall back to LRU policy");
-    ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms);
+    ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms, batch_size_override);
 }
 
 void CacheReclaimer::ReclaimCron() noexcept {
@@ -859,8 +838,9 @@ bool CacheReclaimer::MakeBatchByLRU(const RequestContext *request_context,
                                     const std::vector<std::int64_t> &sampled_keys,
                                     const std::vector<std::map<std::string, std::string>> &property_maps,
                                     std::vector<std::int64_t> &out_batch,
-                                    AgeStats &out_lru_age_stats) const noexcept {
-    const std::size_t batching_size = batching_size_.load();
+                                    AgeStats &out_lru_age_stats,
+                                    std::size_t batch_size_override) const noexcept {
+    const std::size_t batching_size = batch_size_override > 0 ? batch_size_override : batching_size_.load();
     if (batching_size == 0) {
         out_batch.clear();
         out_lru_age_stats.Clear();
@@ -1023,9 +1003,9 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                 bool selected = false;
                 if (water_level_exceed.CheckStorageTypeWaterLevelExceed()) {
                     // some storage type water level exceeded; only
-                    // collect the location with matched type but
-                    // fairness is ignored
-                    // TODO (rui): implement the fair eviction
+                    // collect the location with matched type
+                    // per-instance fairness is enforced upstream by
+                    // ComputeInstanceReclaimPlan
                     if (water_level_exceed.GetWaterLevelExceedByType(loc.type())) {
                         loc_id_vec.emplace_back(loc.id());
                         selected = true;
@@ -1104,6 +1084,7 @@ std::shared_ptr<CacheReclaimer::GroupUsageData> CacheReclaimer::GetGroupUsageDat
     const RequestContext *request_context,
     const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) const noexcept {
     const auto data = std::make_shared<GroupUsageData>();
+    data->per_instance_.reserve(instance_infos.size());
     for (const auto &instance_info : instance_infos) {
         if (instance_info == nullptr) {
             LOG_WITH_TRACE(WARN, "instance is nullptr");
@@ -1128,18 +1109,133 @@ std::shared_ptr<CacheReclaimer::GroupUsageData> CacheReclaimer::GetGroupUsageDat
         data->grp_max_key_cnt_ += ins_max_key_cnt;
         data->grp_used_byte_sz_ += ins_used_byte_size;
 
+        GroupUsageData::InstanceUsage ins_usage;
+        ins_usage.instance_info = instance_info;
+        ins_usage.used_key_cnt = ins_used_key_cnt;
+        ins_usage.max_key_cnt = ins_max_key_cnt;
+        ins_usage.used_byte_sz = ins_used_byte_size;
+
         // calc the usage size of each storage type of this instance
-        auto calc_sz = [&meta_indexer, &data](const DataStorageType &type) -> void {
+        auto calc_sz = [&meta_indexer, &data, &ins_usage](const DataStorageType &type) -> void {
             const std::uint64_t sz = meta_indexer->GetStorageUsageByType(type);
             data->AddGroupUsageByType(type, sz);
+            const auto idx = static_cast<std::size_t>(ToIndex(ToBaseType(type)));
+            if (idx < ins_usage.used_byte_sz_by_type.size()) {
+                ins_usage.used_byte_sz_by_type[idx] += sz;
+            }
         };
         calc_sz(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
         calc_sz(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE);
         calc_sz(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
         calc_sz(DataStorageType::DATA_STORAGE_TYPE_NFS);
         // vcns_hf3fs is merged into hf3fs, no need to calc the size
+
+        data->per_instance_.emplace_back(std::move(ins_usage));
     }
     return data;
+}
+
+std::vector<CacheReclaimer::InstanceReclaimPlan> CacheReclaimer::ComputeInstanceReclaimPlan(
+    const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
+    const GroupUsageData &group_usage_data,
+    const WaterLevelExceed &water_level_exceed,
+    const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) const noexcept {
+    const std::size_t batching_size = batching_size_.load();
+    std::vector<InstanceReclaimPlan> plan;
+    plan.reserve(instance_infos.size());
+
+    // build a fast lookup from instance_id to per-instance usage so the
+    // returned plan preserves the caller's instance_infos ordering even
+    // when GetGroupUsageData skipped null/missing meta indexers
+    std::map<std::string, const GroupUsageData::InstanceUsage *> usage_by_id;
+    for (const auto &usage : group_usage_data.per_instance_) {
+        if (usage.instance_info != nullptr) {
+            usage_by_id.emplace(usage.instance_info->instance_id(), &usage);
+        }
+    }
+
+    // legacy behavior: every instance receives the atomic batching size
+    if (reclaim_strategy == nullptr || !reclaim_strategy->enable_instance_fairness()) {
+        for (const auto &instance_info : instance_infos) {
+            plan.push_back({instance_info, batching_size});
+        }
+        return plan;
+    }
+
+    // pick the weight source based on which watermark dimension is
+    // exceeded; per-storage-type exceed uses the matching type's
+    // bytes (summed across exceeded types) so eviction concentrates on
+    // the instances responsible for that type's pressure
+    const bool only_type_exceed =
+        !water_level_exceed.GetGeneralWaterLevelExceed() && water_level_exceed.CheckStorageTypeWaterLevelExceed();
+
+    auto weight_of = [&](const GroupUsageData::InstanceUsage &usage) -> std::size_t {
+        if (only_type_exceed) {
+            std::size_t w = 0;
+            for (std::size_t idx = 0; idx < usage.used_byte_sz_by_type.size(); ++idx) {
+                const auto type = static_cast<DataStorageType>(idx);
+                if (water_level_exceed.GetWaterLevelExceedByType(type)) {
+                    w += usage.used_byte_sz_by_type[idx];
+                }
+            }
+            return w;
+        }
+        // general exceed: prefer absolute byte usage; if bytes are not
+        // tracked (all zero) fall back to key count so the planner is
+        // still meaningful for key-count-driven watermarks
+        return usage.used_byte_sz > 0 ? usage.used_byte_sz : usage.used_key_cnt;
+    };
+
+    // first pass: compute weights per instance_info
+    std::vector<std::size_t> weights(instance_infos.size(), 0);
+    long double sum_w = 0;
+    for (std::size_t i = 0; i < instance_infos.size(); ++i) {
+        const auto &instance_info = instance_infos[i];
+        if (instance_info == nullptr) {
+            continue;
+        }
+        const auto it = usage_by_id.find(instance_info->instance_id());
+        if (it == usage_by_id.end() || it->second == nullptr) {
+            continue;
+        }
+        const std::size_t w = weight_of(*it->second);
+        weights[i] = w;
+        sum_w += static_cast<long double>(w);
+    }
+
+    // degenerate case: no usage data available; fall back to legacy
+    // uniform plan so the reclaimer still makes forward progress
+    if (sum_w <= 0) {
+        for (const auto &instance_info : instance_infos) {
+            plan.push_back({instance_info, batching_size});
+        }
+        return plan;
+    }
+
+    const std::size_t global_budget = batching_size * instance_infos.size();
+    constexpr std::size_t kBatchCap = kSizeLimit - 1;
+
+    for (std::size_t i = 0; i < instance_infos.size(); ++i) {
+        const auto &instance_info = instance_infos[i];
+        const std::size_t w = weights[i];
+        if (instance_info == nullptr || w == 0) {
+            // skip instances with zero contribution; nothing to evict
+            plan.push_back({instance_info, 0});
+            continue;
+        }
+        const long double share =
+            static_cast<long double>(global_budget) * static_cast<long double>(w) / sum_w;
+        std::size_t batch = static_cast<std::size_t>(share + 0.5L);
+        if (batch == 0) {
+            // floor at 1 so a non-zero contributor still makes progress
+            batch = 1;
+        }
+        if (batch > kBatchCap) {
+            batch = kBatchCap;
+        }
+        plan.push_back({instance_info, batch});
+    }
+    return plan;
 }
 
 void CacheReclaimer::HandleDelRes() noexcept {
@@ -1224,12 +1320,17 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
 
     // do we need to reclaim the storage for this instance group?
     const std::int64_t quota_begin_tp = TimestampUtil::GetSteadyTimeUs();
+    const auto group_usage_data = GetGroupUsageData(request_context.get(), instance_infos);
+    if (group_usage_data == nullptr) {
+        LOG_WITH_GR(ERROR, "group usage data is nullptr");
+        return false;
+    }
     const auto water_level_exceed =
         GetWaterLevelExceed(request_context.get(),
                             ins_gr,
                             instance_group->quota(), // TODO (rui): validate the quota is valid
                             reclaim_strategy,
-                            instance_infos);
+                            *group_usage_data);
     METRICS_(cache_reclaimer, reclaim_quota_duration_us) =
         static_cast<double>(TimestampUtil::GetSteadyTimeUs() - quota_begin_tp);
 
@@ -1240,13 +1341,26 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
 
     LOG_WITH_GR(DEBUG, "instance group trigger reclaiming");
 
+    // build the per-instance reclaim plan; with fairness enabled this
+    // biases eviction toward the heaviest contributors and skips
+    // instances whose contribution is zero
+    const auto reclaim_plan =
+        ComputeInstanceReclaimPlan(reclaim_strategy, *group_usage_data, *water_level_exceed, instance_infos);
+
     // run the reclaiming algorithm with the chosen policy
     switch (reclaim_strategy->reclaim_policy()) {
     case ReclaimPolicy::POLICY_LRU:
         LOG_WITH_GR(DEBUG, "start to run the LRU reclaim policy");
-        for (const auto &instance_info : instance_infos) {
+        for (const auto &entry : reclaim_plan) {
+            if (entry.instance_info == nullptr || entry.batch_size == 0) {
+                continue;
+            }
             const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByLRU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
+            ReclaimByLRU(request_context,
+                         entry.instance_info,
+                         *water_level_exceed,
+                         delay_before_delete_ms,
+                         entry.batch_size);
             METRICS_(cache_reclaimer, reclaim_job_duration_us) =
                 static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
         }
@@ -1254,9 +1368,16 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
 
     case ReclaimPolicy::POLICY_LFU:
         LOG_WITH_GR(DEBUG, "start to run the LFU reclaim policy");
-        for (const auto &instance_info : instance_infos) {
+        for (const auto &entry : reclaim_plan) {
+            if (entry.instance_info == nullptr || entry.batch_size == 0) {
+                continue;
+            }
             const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByLFU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
+            ReclaimByLFU(request_context,
+                         entry.instance_info,
+                         *water_level_exceed,
+                         delay_before_delete_ms,
+                         entry.batch_size);
             METRICS_(cache_reclaimer, reclaim_job_duration_us) =
                 static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
         }
@@ -1264,9 +1385,16 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
 
     case ReclaimPolicy::POLICY_TTL:
         LOG_WITH_GR(DEBUG, "start to run the TTL reclaim policy");
-        for (const auto &instance_info : instance_infos) {
+        for (const auto &entry : reclaim_plan) {
+            if (entry.instance_info == nullptr || entry.batch_size == 0) {
+                continue;
+            }
             const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByTTL(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
+            ReclaimByTTL(request_context,
+                         entry.instance_info,
+                         *water_level_exceed,
+                         delay_before_delete_ms,
+                         entry.batch_size);
             METRICS_(cache_reclaimer, reclaim_job_duration_us) =
                 static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
         }
@@ -1277,9 +1405,16 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
         // break; skipped intentionally
 
     default:
-        for (const auto &instance_info : instance_infos) {
+        for (const auto &entry : reclaim_plan) {
+            if (entry.instance_info == nullptr || entry.batch_size == 0) {
+                continue;
+            }
             const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByLRU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
+            ReclaimByLRU(request_context,
+                         entry.instance_info,
+                         *water_level_exceed,
+                         delay_before_delete_ms,
+                         entry.batch_size);
             METRICS_(cache_reclaimer, reclaim_job_duration_us) =
                 static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
         }

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -377,6 +377,40 @@ private:
         array_t_ water_level_exceed_by_type_;
     };
 
+    // instance group key & storage usage data, with a per-instance
+    // breakdown so ComputeInstanceReclaimPlan can weight eviction by
+    // absolute usage without doing a second MetaIndexer pass
+    struct GroupUsageData {
+        struct InstanceUsage {
+            std::shared_ptr<const InstanceInfo> instance_info;
+            std::size_t used_key_cnt = 0;
+            std::size_t max_key_cnt = 0;
+            std::size_t used_byte_sz = 0;
+            std::array<std::size_t, static_cast<std::size_t>(DataStorageType::COUNT)> used_byte_sz_by_type{};
+        };
+
+        std::size_t grp_used_key_cnt_;
+        std::size_t grp_max_key_cnt_;
+        std::size_t grp_used_byte_sz_;
+        std::vector<InstanceUsage> per_instance_;
+
+        GroupUsageData();
+        ~GroupUsageData() = default;
+
+        [[nodiscard]] std::size_t GetGroupUsageByType(const DataStorageType &type) const noexcept;
+        void AddGroupUsageByType(const DataStorageType &type, std::size_t value) noexcept;
+
+        // group storage usage data array aggregated by storage type
+        // slot 0: DATA_STORAGE_TYPE_UNKNOWN **UNUSED**
+        // slot 1: DATA_STORAGE_TYPE_HF3FS usage data
+        // slot 2: DATA_STORAGE_TYPE_MOONCAKE usage data
+        // slot 3: DATA_STORAGE_TYPE_TAIR_MEMPOOL usage data
+        // slot 4: DATA_STORAGE_TYPE_NFS usage data
+        // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
+        // slot 6: DATA_STORAGE_TYPE_DUMMY usage data (testing only)
+        std::array<std::size_t, static_cast<std::size_t>(DataStorageType::COUNT)> grp_storage_usage_by_type_;
+    };
+
     /**
      * @brief Calculate the group's WaterLevelExceed data
      *
@@ -384,7 +418,7 @@ private:
      * @param instance_group_name Name of the instance group to check
      * @param instance_group_quota Quota info for the instance group
      * @param reclaim_strategy Strategy to use for reclamation decisions
-     * @param instance_infos Vector of instance information
+     * @param group_usage_data Pre-computed group usage data
      * @return shared pointer to the result WaterLevelExceed data
      */
     [[nodiscard]] std::shared_ptr<WaterLevelExceed>
@@ -392,7 +426,7 @@ private:
                         const std::string &instance_group_name,
                         const InstanceGroupQuota &instance_group_quota,
                         const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
-                        const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept;
+                        const GroupUsageData &group_usage_data) noexcept;
 
     /**
      * @brief Determine if a reclamation should be triggered for an
@@ -425,7 +459,8 @@ private:
     void ReclaimByLRU(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
                       const WaterLevelExceed &water_level_exceed,
-                      std::int32_t delay_before_delete_ms) noexcept;
+                      std::int32_t delay_before_delete_ms,
+                      std::size_t batch_size_override = 0) noexcept;
 
     /**
      * @brief Reclaim cache entries using LFU (Least Frequently Used)
@@ -438,11 +473,14 @@ private:
      * @param instance_info Instance information to process
      * @param water_level_exceed the detailed trigger result
      * @param delay_before_delete_ms delay milliseconds for executor
+     * @param batch_size_override per-instance batch size (0 means use
+     * the atomic batching_size_); set by the fair-eviction planner
      */
     void ReclaimByLFU(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
                       const WaterLevelExceed &water_level_exceed,
-                      std::int32_t delay_before_delete_ms) noexcept;
+                      std::int32_t delay_before_delete_ms,
+                      std::size_t batch_size_override = 0) noexcept;
 
     /**
      * @brief Reclaim cache entries using TTL (Time To Live) strategy
@@ -454,11 +492,14 @@ private:
      * @param instance_info Instance information to process
      * @param water_level_exceed the detailed trigger result
      * @param delay_before_delete_ms delay milliseconds for executor
+     * @param batch_size_override per-instance batch size (0 means use
+     * the atomic batching_size_); set by the fair-eviction planner
      */
     void ReclaimByTTL(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
                       const WaterLevelExceed &water_level_exceed,
-                      std::int32_t delay_before_delete_ms) noexcept;
+                      std::int32_t delay_before_delete_ms,
+                      std::size_t batch_size_override = 0) noexcept;
 
     bool TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request_context,
                            const std::shared_ptr<const InstanceGroup> &instance_group) noexcept;
@@ -487,7 +528,8 @@ private:
                         const std::vector<std::int64_t> &sampled_keys,
                         const std::vector<std::map<std::string, std::string>> &property_maps,
                         std::vector<std::int64_t> &out_batch,
-                        AgeStats &out_lru_age_stats) const noexcept;
+                        AgeStats &out_lru_age_stats,
+                        std::size_t batch_size_override = 0) const noexcept;
 
     bool FilterLocID(RequestContext *request_context,
                      const std::shared_ptr<const InstanceInfo> &instance_info,
@@ -500,11 +542,33 @@ private:
                       const std::shared_ptr<const InstanceInfo> &instance_info,
                       const CacheLocationDelRequest &req) noexcept;
 
-    struct GroupUsageData;
-
     [[nodiscard]] std::shared_ptr<GroupUsageData>
     GetGroupUsageData(const RequestContext *request_context,
                       const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) const noexcept;
+
+    // per-instance batch plan returned by ComputeInstanceReclaimPlan
+    struct InstanceReclaimPlan {
+        std::shared_ptr<const InstanceInfo> instance_info;
+        std::size_t batch_size = 0; // 0 means skip this instance
+    };
+
+    /**
+     * @brief Build a per-instance reclaim plan that biases eviction
+     * toward instances contributing more to the over-watermark state
+     *
+     * When fairness is disabled in the strategy, returns one plan per
+     * instance with batch_size = batching_size_ (legacy behavior).
+     * When enabled, allocates a global budget of batching_size_ * N
+     * keys across instances proportionally to their absolute usage.
+     * Instances with zero usage are skipped; non-zero contributors are
+     * floored at one batch.
+     */
+    [[nodiscard]] std::vector<InstanceReclaimPlan>
+    ComputeInstanceReclaimPlan(const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
+                               const GroupUsageData &group_usage_data,
+                               const WaterLevelExceed &water_level_exceed,
+                               const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos)
+        const noexcept;
 
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(reclaim_cron_count)
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(reclaim_job_count)

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -904,7 +904,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming00) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -925,7 +926,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming01) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -946,7 +948,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming02) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -970,7 +973,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming03) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -995,7 +999,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming04) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
     ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
     ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1023,7 +1028,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming05) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -1043,7 +1049,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming06) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
     ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
     ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1078,7 +1085,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming07) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -1113,7 +1121,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming08) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
     ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
     ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1148,7 +1157,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming09) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -1175,7 +1185,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming10) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
     ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
     ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1210,7 +1221,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming11) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
     ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
     ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1235,7 +1247,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming15) {
                                                      ins_group->name(),
                                                      ins_group->quota(),
                                                      ins_group->cache_config()->reclaim_strategy(),
-                                                     instance_infos);
+                                                     *cache_reclaimer_->GetGroupUsageData(
+                                                         request_context_.get(), instance_infos));
     ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
 }
 
@@ -1266,7 +1279,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
         ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
         ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1294,7 +1308,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
     }
 
@@ -1314,7 +1329,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
         ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
         ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1343,7 +1359,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
     }
 
@@ -1363,7 +1380,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
         ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
         ASSERT_FALSE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1392,7 +1410,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
     }
 }
@@ -1429,7 +1448,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming17) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
         ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
         ASSERT_TRUE(wle->CheckStorageTypeWaterLevelExceed());
@@ -1461,7 +1481,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming17) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
     }
 
@@ -1490,7 +1511,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming17) {
                                                          ins_group->name(),
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
-                                                         instance_infos);
+                                                         *cache_reclaimer_->GetGroupUsageData(
+                                                             request_context_.get(), instance_infos));
         ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
         ASSERT_TRUE(wle->CheckGroupWaterLevelExceed());
         ASSERT_TRUE(wle->CheckStorageTypeWaterLevelExceed());
@@ -3201,4 +3223,198 @@ TEST_F(CacheReclaimerTest, TestPerf) {
     KVCM_LOG_INFO("run time: 60 sec, reclaim job qps: [%f], loc del qps: [%f]",
                   static_cast<double>(reclaim_job_count_v) / 60.0,
                   static_cast<double>(loc_submit_count_v) / 60.0);
+}
+
+namespace {
+
+std::shared_ptr<InstanceInfo> MakeInstance(const std::string &id) {
+    auto info = InstanceInfoFactory();
+    info->set_instance_id(id);
+    return info;
+}
+
+// build a GroupUsageData entry for one instance keyed by id; the
+// instance_info is referenced from instance_infos so the planner's
+// id-based lookup works on it
+CacheReclaimer::GroupUsageData::InstanceUsage
+MakeUsage(const std::shared_ptr<const InstanceInfo> &info,
+          std::size_t used_bytes,
+          std::size_t used_keys,
+          DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_NFS) {
+    CacheReclaimer::GroupUsageData::InstanceUsage u;
+    u.instance_info = info;
+    u.used_byte_sz = used_bytes;
+    u.used_key_cnt = used_keys;
+    u.max_key_cnt = 0;
+    if (used_bytes > 0 && static_cast<std::size_t>(type) < u.used_byte_sz_by_type.size()) {
+        u.used_byte_sz_by_type[static_cast<std::size_t>(type)] = used_bytes;
+    }
+    return u;
+}
+
+} // namespace
+
+TEST_F(CacheReclaimerTest, ComputeInstanceReclaimPlan_FairnessSkipsZeroUsage) {
+    // a non-zero contributor must always get a batch; a zero-usage
+    // instance must be skipped entirely
+    auto a = MakeInstance("inst_a");
+    auto b = MakeInstance("inst_b");
+
+    CacheReclaimer::GroupUsageData usage;
+    usage.per_instance_.push_back(MakeUsage(a, 9ULL << 30, 1024));
+    usage.per_instance_.push_back(MakeUsage(b, 0, 0));
+
+    CacheReclaimer::WaterLevelExceed wle;
+    wle.SetGeneralWaterLevelExceed(true);
+
+    const auto strategy = std::make_shared<CacheReclaimStrategy>();
+    strategy->set_enable_instance_fairness(true);
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 4));
+    const auto plan = cache_reclaimer_->ComputeInstanceReclaimPlan(
+        strategy, usage, wle, std::vector<std::shared_ptr<const InstanceInfo>>{a, b});
+
+    ASSERT_EQ(2u, plan.size());
+    EXPECT_EQ("inst_a", plan[0].instance_info->instance_id());
+    EXPECT_GT(plan[0].batch_size, 0u);
+    EXPECT_EQ("inst_b", plan[1].instance_info->instance_id());
+    EXPECT_EQ(0u, plan[1].batch_size);
+}
+
+TEST_F(CacheReclaimerTest, ComputeInstanceReclaimPlan_FairnessProportionalBatchSize) {
+    // the batch sizes for two non-zero contributors should be
+    // proportional to their absolute byte usage
+    auto a = MakeInstance("inst_a");
+    auto b = MakeInstance("inst_b");
+
+    CacheReclaimer::GroupUsageData usage;
+    usage.per_instance_.push_back(MakeUsage(a, 7ULL << 30, 7000));
+    usage.per_instance_.push_back(MakeUsage(b, 2ULL << 30, 2000));
+
+    CacheReclaimer::WaterLevelExceed wle;
+    wle.SetGeneralWaterLevelExceed(true);
+
+    const auto strategy = std::make_shared<CacheReclaimStrategy>();
+    strategy->set_enable_instance_fairness(true);
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 100));
+    const auto plan = cache_reclaimer_->ComputeInstanceReclaimPlan(
+        strategy, usage, wle, std::vector<std::shared_ptr<const InstanceInfo>>{a, b});
+
+    ASSERT_EQ(2u, plan.size());
+    // global_budget = 100 * 2 = 200, ratio 7:2 -> ~155.6 / ~44.4
+    EXPECT_NEAR(static_cast<double>(plan[0].batch_size), 155.6, 1.5);
+    EXPECT_NEAR(static_cast<double>(plan[1].batch_size), 44.4, 1.5);
+    // total stays close to the global budget (within rounding)
+    EXPECT_LE(plan[0].batch_size + plan[1].batch_size, 201u);
+    EXPECT_GE(plan[0].batch_size + plan[1].batch_size, 199u);
+}
+
+TEST_F(CacheReclaimerTest, ComputeInstanceReclaimPlan_FairnessOnlyTypeExceeded) {
+    // when only one storage type is over-watermark, weight by that
+    // type's per-instance bytes -- a heavy instance on a non-exceeded
+    // type must not be charged
+    auto a = MakeInstance("inst_a");
+    auto b = MakeInstance("inst_b");
+
+    CacheReclaimer::GroupUsageData usage;
+    // a is heavy on the *exceeded* NFS type
+    usage.per_instance_.push_back(MakeUsage(a, 4ULL << 30, 100, DataStorageType::DATA_STORAGE_TYPE_NFS));
+    // b is heavy on a *non-exceeded* type (mooncake) only; its NFS
+    // bytes are zero
+    auto b_usage = MakeUsage(b, 0, 100);
+    b_usage.used_byte_sz = 8ULL << 30;
+    b_usage.used_byte_sz_by_type[static_cast<std::size_t>(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE)] = 8ULL << 30;
+    usage.per_instance_.push_back(b_usage);
+
+    CacheReclaimer::WaterLevelExceed wle;
+    // general not exceeded -- only the NFS type
+    wle.SetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_NFS, true);
+
+    const auto strategy = std::make_shared<CacheReclaimStrategy>();
+    strategy->set_enable_instance_fairness(true);
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 8));
+    const auto plan = cache_reclaimer_->ComputeInstanceReclaimPlan(
+        strategy, usage, wle, std::vector<std::shared_ptr<const InstanceInfo>>{a, b});
+
+    ASSERT_EQ(2u, plan.size());
+    EXPECT_GT(plan[0].batch_size, 0u);
+    EXPECT_EQ(0u, plan[1].batch_size);
+}
+
+TEST_F(CacheReclaimerTest, ComputeInstanceReclaimPlan_FairnessDisabledMatchesLegacy) {
+    // with the fairness flag off, every instance gets the legacy
+    // uniform per-instance batch -- regardless of usage skew
+    auto a = MakeInstance("inst_a");
+    auto b = MakeInstance("inst_b");
+
+    CacheReclaimer::GroupUsageData usage;
+    usage.per_instance_.push_back(MakeUsage(a, 9ULL << 30, 9000));
+    usage.per_instance_.push_back(MakeUsage(b, 0, 0));
+
+    CacheReclaimer::WaterLevelExceed wle;
+    wle.SetGeneralWaterLevelExceed(true);
+
+    const auto strategy = std::make_shared<CacheReclaimStrategy>();
+    strategy->set_enable_instance_fairness(false);
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 7));
+    const auto plan = cache_reclaimer_->ComputeInstanceReclaimPlan(
+        strategy, usage, wle, std::vector<std::shared_ptr<const InstanceInfo>>{a, b});
+
+    ASSERT_EQ(2u, plan.size());
+    EXPECT_EQ(7u, plan[0].batch_size);
+    EXPECT_EQ(7u, plan[1].batch_size);
+}
+
+TEST_F(CacheReclaimerTest, ComputeInstanceReclaimPlan_FairnessFloorAtOneForNonZero) {
+    // non-zero contributor must always receive at least one batch
+    // even when its proportional share rounds to zero
+    auto a = MakeInstance("inst_a");
+    auto b = MakeInstance("inst_b");
+
+    CacheReclaimer::GroupUsageData usage;
+    usage.per_instance_.push_back(MakeUsage(a, 1ULL << 40, 1000)); // dominant
+    usage.per_instance_.push_back(MakeUsage(b, 1, 1));             // tiny
+
+    CacheReclaimer::WaterLevelExceed wle;
+    wle.SetGeneralWaterLevelExceed(true);
+
+    const auto strategy = std::make_shared<CacheReclaimStrategy>();
+    strategy->set_enable_instance_fairness(true);
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 2));
+    const auto plan = cache_reclaimer_->ComputeInstanceReclaimPlan(
+        strategy, usage, wle, std::vector<std::shared_ptr<const InstanceInfo>>{a, b});
+
+    ASSERT_EQ(2u, plan.size());
+    EXPECT_GE(plan[0].batch_size, 1u);
+    // tiny but non-zero contributor must still make progress
+    EXPECT_EQ(1u, plan[1].batch_size);
+}
+
+TEST_F(CacheReclaimerTest, ComputeInstanceReclaimPlan_FairnessZeroSumFallsBack) {
+    // when no instance has any usage data, the planner falls back to
+    // the legacy uniform plan rather than producing all zeros
+    auto a = MakeInstance("inst_a");
+    auto b = MakeInstance("inst_b");
+
+    CacheReclaimer::GroupUsageData usage;
+    usage.per_instance_.push_back(MakeUsage(a, 0, 0));
+    usage.per_instance_.push_back(MakeUsage(b, 0, 0));
+
+    CacheReclaimer::WaterLevelExceed wle;
+    wle.SetGeneralWaterLevelExceed(true);
+
+    const auto strategy = std::make_shared<CacheReclaimStrategy>();
+    strategy->set_enable_instance_fairness(true);
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 5));
+    const auto plan = cache_reclaimer_->ComputeInstanceReclaimPlan(
+        strategy, usage, wle, std::vector<std::shared_ptr<const InstanceInfo>>{a, b});
+
+    ASSERT_EQ(2u, plan.size());
+    EXPECT_EQ(5u, plan[0].batch_size);
+    EXPECT_EQ(5u, plan[1].batch_size);
 }

--- a/kv_cache_manager/manager/test/startup_config_loader_test.cc
+++ b/kv_cache_manager/manager/test/startup_config_loader_test.cc
@@ -78,6 +78,7 @@ TEST_F(StartupConfigLoaderTest, TestStartupConfigJsonize) {
     ASSERT_EQ(reclaim1.reclaim_step_size(), reclaim2.reclaim_step_size());
     ASSERT_EQ(reclaim1.reclaim_step_percentage(), reclaim2.reclaim_step_percentage());
     ASSERT_EQ(reclaim1.delay_before_delete_ms(), reclaim2.delay_before_delete_ms());
+    ASSERT_EQ(reclaim1.enable_instance_fairness(), reclaim2.enable_instance_fairness());
 
     // Compare TriggerStrategy
     const TriggerStrategy &trigger1 = reclaim1.trigger_strategy();
@@ -189,6 +190,7 @@ InstanceGroup StartupConfigLoaderTest::MakeInstanceGroup() {
     reclaim_strategy->set_reclaim_step_size(1073741824); // 1GB
     reclaim_strategy->set_reclaim_step_percentage(10);
     reclaim_strategy->set_delay_before_delete_ms(1000);
+    reclaim_strategy->set_enable_instance_fairness(false);
 
     // Create meta storage backend config
     auto meta_storage_backend_config = std::make_shared<MetaStorageBackendConfig>();

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -186,6 +186,9 @@ message CacheReclaimStrategy {
     int32 reclaim_step_size = 5;       // 每次回收的步长绝对值,如100GiB
     int32 reclaim_step_percentage = 6; // 每次回收的步长相对比例,如回收5%的数据量
     int32 delay_before_delete_ms = 7; // Location设置为Deleting状态后等待多少毫秒再调用Storage删除
+    // when true (default), distribute eviction across instances by
+    // absolute usage so heavy contributors are evicted more
+    bool enable_instance_fairness = 8;
 }
 
 enum CachePreferStrategy {

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -166,6 +166,8 @@ void ProtoConvert::CacheConfigToProto(const CacheConfig &cache_config_info,
     reclaim_strategy->set_reclaim_step_size(cache_config_info.reclaim_strategy()->reclaim_step_size());
     reclaim_strategy->set_reclaim_step_percentage(cache_config_info.reclaim_strategy()->reclaim_step_percentage());
     reclaim_strategy->set_delay_before_delete_ms(cache_config_info.reclaim_strategy()->delay_before_delete_ms());
+    reclaim_strategy->set_enable_instance_fairness(
+        cache_config_info.reclaim_strategy()->enable_instance_fairness());
 
     // 转换data_storage_strategy (cache_prefer_strategy)
     proto_cache_config->set_data_storage_strategy(
@@ -219,6 +221,8 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
     reclaim_strategy->set_reclaim_step_size(proto_cache_config->reclaim_strategy().reclaim_step_size());
     reclaim_strategy->set_reclaim_step_percentage(proto_cache_config->reclaim_strategy().reclaim_step_percentage());
     reclaim_strategy->set_delay_before_delete_ms(proto_cache_config->reclaim_strategy().delay_before_delete_ms());
+    reclaim_strategy->set_enable_instance_fairness(
+        proto_cache_config->reclaim_strategy().enable_instance_fairness());
 
     cache_config_info.set_reclaim_strategy(reclaim_strategy);
 


### PR DESCRIPTION
# Fair Eviction Across Instances Within an Instance Group

## Context

`CacheReclaimer` currently runs a per-group cron: when an
`InstanceGroup` exceeds its watermark (`used_percentage` of
`InstanceGroupQuota`), it iterates **every** instance in the group
and evicts up to a fixed `batching_size_` keys per instance per round
(`cache_reclaimer.cc:1247-1252`). All instances are treated equally
regardless of how much each one is using.

This is unfair when usage is skewed: an instance using <1% of the
group budget can have its hot blocks evicted at the same rate as an
instance using >90%. The aggressor effectively penalises the victim.

**Goal**: when a group is over-watermark, bias eviction toward the
instances that contribute the most absolute usage to the over-watermark
state. Heaviest contributors are evicted with the largest per-round
batch; instances with zero usage are skipped.

## Design Summary

Pure-absolute-usage proportional batching:

- Keep `batching_size_` as the per-instance average; redistribute
  it across instances of the group weighted by absolute usage
- Global per-round budget = `batching_size_ * N` (`N` = instance count)
  — preserves current throughput
- Per-instance batch = `round(global_budget * used_i / sum(used))`,
  floored to 1 if `used_i > 0`, capped at `kSizeLimit - 1`
- Instances with `used_i == 0` are skipped entirely (no work to do)
- Per-storage-type watermark: when only a storage type is exceeded,
  weight by that type's per-instance usage; when both general and a
  type are exceeded, take the per-instance max of the two weights

Behavior is gated by a new `CacheReclaimStrategy.enable_instance_fairness`
flag, defaulting to **true** (opt-out). When false, all instances
receive `batching_size_` (legacy round-robin).