### PR TITLE
[manager] implement proactive GC task

### DIFF
--- a/kv_cache_manager/manager/BUILD
+++ b/kv_cache_manager/manager/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "cache_manager.h",
     ],
     deps = [
+        ":cache_garbage_collector",
         ":cache_location_view",
         ":cache_manager_metrics_recorder",
         ":cache_reclaimer",
@@ -68,6 +69,21 @@ cc_library(
         "//kv_cache_manager/config",
         "//kv_cache_manager/event:event_publisher",
         "//kv_cache_manager/manager:meta_searcher",
+        "//kv_cache_manager/manager:schedule_plan_executor",
+        "//kv_cache_manager/manager:write_location_manager",
+        "//kv_cache_manager/meta",
+        "//kv_cache_manager/metrics:metrics_registry",
+    ],
+)
+
+cc_library(
+    name = "cache_garbage_collector",
+    srcs = ["cache_garbage_collector.cc"],
+    hdrs = ["cache_garbage_collector.h"],
+    deps = [
+        "//kv_cache_manager/common",
+        "//kv_cache_manager/config",
+        "//kv_cache_manager/data_storage",
         "//kv_cache_manager/manager:schedule_plan_executor",
         "//kv_cache_manager/manager:write_location_manager",
         "//kv_cache_manager/meta",

--- a/kv_cache_manager/manager/cache_garbage_collector.cc
+++ b/kv_cache_manager/manager/cache_garbage_collector.cc
@@ -1,0 +1,331 @@
+#include "kv_cache_manager/manager/cache_garbage_collector.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/timestamp_util.h"
+#include "kv_cache_manager/config/instance_group.h"
+#include "kv_cache_manager/config/instance_info.h"
+#include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_uri.h"
+#include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/manager/write_location_manager.h"
+#include "kv_cache_manager/meta/cache_location.h"
+#include "kv_cache_manager/meta/common.h"
+#include "kv_cache_manager/meta/meta_indexer.h"
+#include "kv_cache_manager/meta/meta_indexer_manager.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+namespace kv_cache_manager {
+
+#define DEFINE_METRICS_NAME_FOR_CACHE_GC(name) DEFINE_METRICS_NAME_(CacheGarbageCollector, cache_gc, name)
+
+#define REGISTER_COUNTER_METRICS_FOR_CACHE_GC(name) REGISTER_METRICS_COUNTER_(metrics_registry_, cache_gc, name)
+
+#define REGISTER_GAUGE_METRICS_FOR_CACHE_GC(name) REGISTER_METRICS_GAUGE_(metrics_registry_, cache_gc, name)
+
+DEFINE_METRICS_NAME_FOR_CACHE_GC(scan_round_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(orphaned_writing_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(stale_serving_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(location_submit_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(scan_batch_duration_us);
+
+const std::string CacheGarbageCollector::kTraceIDPrefix{"cache_gc_internal_trace_"};
+
+inline std::string CacheGarbageCollector::GenTraceID() {
+    static std::random_device rd;
+    static std::mt19937_64 rng(rd());
+    static std::uniform_int_distribution<std::uint64_t> dis;
+    const std::uint64_t rand_val = dis(rng);
+    std::stringstream ss;
+    ss << kTraceIDPrefix << std::right << std::setfill('0') << std::setw(16) << std::hex << std::noshowbase << rand_val;
+    return ss.str();
+}
+
+static std::string VineyardStorageNameFromInstance(const std::string &instance_id) { return "v6d_" + instance_id; }
+
+CacheGarbageCollector::CacheGarbageCollector(Config config,
+                                             std::shared_ptr<RegistryManager> registry_manager,
+                                             std::shared_ptr<MetaIndexerManager> meta_indexer_manager,
+                                             std::shared_ptr<SchedulePlanExecutor> sched_plan_executor,
+                                             std::shared_ptr<MetricsRegistry> metrics_registry,
+                                             std::shared_ptr<EventManager> event_manager,
+                                             std::shared_ptr<WriteLocationManager> write_location_manager)
+    : config_(config)
+    , registry_manager_(std::move(registry_manager))
+    , meta_indexer_manager_(std::move(meta_indexer_manager))
+    , sched_plan_executor_(std::move(sched_plan_executor))
+    , metrics_registry_(std::move(metrics_registry))
+    , event_manager_(std::move(event_manager))
+    , write_location_manager_(std::move(write_location_manager)) {}
+
+CacheGarbageCollector::~CacheGarbageCollector() { Stop(); }
+
+ErrorCode CacheGarbageCollector::Start() noexcept {
+    if (!config_.enabled) {
+        KVCM_LOG_INFO("cache garbage collector is disabled");
+        return ErrorCode::EC_OK;
+    }
+    if (registry_manager_ == nullptr) {
+        KVCM_LOG_ERROR("registry manager is nullptr");
+        return ErrorCode::EC_ERROR;
+    }
+    if (meta_indexer_manager_ == nullptr) {
+        KVCM_LOG_ERROR("meta indexer manager is nullptr");
+        return ErrorCode::EC_ERROR;
+    }
+    if (sched_plan_executor_ == nullptr) {
+        KVCM_LOG_ERROR("schedule plan executor is nullptr");
+        return ErrorCode::EC_ERROR;
+    }
+    if (metrics_registry_ == nullptr) {
+        KVCM_LOG_ERROR("metrics registry is nullptr");
+        return ErrorCode::EC_ERROR;
+    }
+
+    REGISTER_COUNTER_METRICS_FOR_CACHE_GC(scan_round_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_GC(orphaned_writing_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_GC(stale_serving_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_GC(location_submit_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_GC(scan_batch_duration_us);
+
+    {
+        std::unique_lock<std::mutex> lock(state_mutex_);
+        if (running_) {
+            KVCM_LOG_ERROR("cache garbage collector is already running");
+            return ErrorCode::EC_EXIST;
+        }
+        running_ = true;
+    }
+
+    gc_thread_ = std::thread([this]() { this->GCScanLoop(); });
+    KVCM_LOG_INFO("cache garbage collector start OK");
+    return ErrorCode::EC_OK;
+}
+
+void CacheGarbageCollector::Stop() noexcept {
+    {
+        std::unique_lock<std::mutex> lock(state_mutex_);
+        if (!running_) {
+            return;
+        }
+        running_ = false;
+        cv_state_.notify_one();
+    }
+    if (gc_thread_.joinable()) {
+        gc_thread_.join();
+    }
+    KVCM_LOG_INFO("cache garbage collector stopped");
+}
+
+bool CacheGarbageCollector::IsRunning() const noexcept {
+    std::unique_lock<std::mutex> lock(const_cast<std::mutex &>(state_mutex_));
+    return running_;
+}
+
+void CacheGarbageCollector::Pause() noexcept { paused_.store(true); }
+
+void CacheGarbageCollector::Resume() noexcept { paused_.store(false); }
+
+bool CacheGarbageCollector::IsPaused() const noexcept { return paused_.load(); }
+
+void CacheGarbageCollector::GCScanLoop() noexcept {
+    while (true) {
+        {
+            std::unique_lock<std::mutex> lock(state_mutex_);
+            cv_state_.wait_for(lock, std::chrono::milliseconds(config_.inter_round_sleep_ms), [this]() {
+                return !running_;
+            });
+            if (!running_) {
+                return;
+            }
+        }
+
+        if (paused_.load()) {
+            continue;
+        }
+
+        auto request_context = std::make_shared<RequestContext>(GenTraceID());
+
+        const auto [ec, instance_groups] = registry_manager_->ListInstanceGroup(request_context.get());
+        if (ec != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("cache gc: list instance group failed, ec: [%d]", static_cast<std::int32_t>(ec));
+            continue;
+        }
+
+        for (const auto &instance_group : instance_groups) {
+            const auto [ec2, instance_infos] =
+                registry_manager_->ListInstanceInfo(request_context.get(), instance_group->name());
+            if (ec2 != ErrorCode::EC_OK) {
+                continue;
+            }
+
+            for (const auto &instance_info : instance_infos) {
+                if (!running_ || paused_.load()) {
+                    break;
+                }
+                const std::string &instance_id = instance_info->instance_id();
+                auto meta_indexer = meta_indexer_manager_->GetMetaIndexer(instance_id);
+                if (!meta_indexer) {
+                    continue;
+                }
+                ScanInstance(request_context.get(), instance_id, meta_indexer);
+            }
+
+            if (!running_) {
+                return;
+            }
+        }
+
+        ++cache_gc_scan_round_count_metrics_;
+    }
+}
+
+void CacheGarbageCollector::ScanInstance(RequestContext *request_context,
+                                         const std::string &instance_id,
+                                         const std::shared_ptr<MetaIndexer> &meta_indexer) noexcept {
+    std::string cursor = SCAN_BASE_CURSOR;
+
+    do {
+        if (!running_ || paused_.load()) {
+            return;
+        }
+
+        const auto batch_start_us = TimestampUtil::GetCurrentTimeUs();
+
+        std::string next_cursor;
+        KeyVector keys;
+        auto ec = meta_indexer->Scan(request_context, cursor, config_.scan_batch_size, next_cursor, keys);
+        if (ec != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("cache gc: scan failed for instance [%s], ec: [%d]",
+                          instance_id.c_str(),
+                          static_cast<std::int32_t>(ec));
+            return;
+        }
+
+        if (keys.empty()) {
+            cursor = next_cursor;
+            continue;
+        }
+
+        CacheLocationMapVector location_maps;
+        auto get_result = meta_indexer->GetLocations(request_context, keys, location_maps);
+
+        std::vector<std::int64_t> del_block_keys;
+        std::vector<std::vector<std::string>> del_location_ids;
+        std::size_t deletion_count = 0;
+
+        for (std::size_t i = 0; i < keys.size() && i < location_maps.size(); ++i) {
+            if (deletion_count >= config_.max_deletions_per_batch) {
+                break;
+            }
+
+            std::vector<std::string> dirty_loc_ids;
+            for (const auto &[loc_id, loc_ptr] : location_maps[i]) {
+                if (!loc_ptr) {
+                    continue;
+                }
+                if (IsOrphanedWriting(*loc_ptr)) {
+                    dirty_loc_ids.push_back(loc_id);
+                    ++cache_gc_orphaned_writing_count_metrics_;
+                } else if (IsStaleServing(instance_id, *loc_ptr)) {
+                    dirty_loc_ids.push_back(loc_id);
+                    ++cache_gc_stale_serving_count_metrics_;
+                }
+            }
+
+            if (!dirty_loc_ids.empty()) {
+                del_block_keys.push_back(keys[i]);
+                deletion_count += dirty_loc_ids.size();
+                del_location_ids.push_back(std::move(dirty_loc_ids));
+            }
+        }
+
+        if (!del_block_keys.empty()) {
+            CacheLocationDelRequest del_request;
+            del_request.instance_id = instance_id;
+            del_request.block_keys = std::move(del_block_keys);
+            del_request.location_ids = std::move(del_location_ids);
+            sched_plan_executor_->SubmitNonBlocking(del_request);
+            cache_gc_location_submit_count_metrics_ += deletion_count;
+        }
+
+        const auto batch_end_us = TimestampUtil::GetCurrentTimeUs();
+        cache_gc_scan_batch_duration_us_metrics_ = static_cast<double>(batch_end_us - batch_start_us);
+
+        cursor = next_cursor;
+
+        // rate limiting sleep between batches
+        if (cursor != SCAN_BASE_CURSOR && config_.inter_batch_sleep_ms > 0) {
+            std::unique_lock<std::mutex> lock(state_mutex_);
+            cv_state_.wait_for(lock, std::chrono::milliseconds(config_.inter_batch_sleep_ms), [this]() {
+                return !running_;
+            });
+            if (!running_) {
+                return;
+            }
+        }
+    } while (cursor != SCAN_BASE_CURSOR);
+}
+
+bool CacheGarbageCollector::IsOrphanedWriting(const CacheLocation &loc) const noexcept {
+    if (loc.status() != CacheLocationStatus::CLS_WRITING) {
+        return false;
+    }
+    if (write_location_manager_ && write_location_manager_->HasLocationId(loc.id())) {
+        return false;
+    }
+    if (loc.create_time() > 0) {
+        const std::int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+        const std::int64_t age_us = now_us - loc.create_time();
+        if (age_us < config_.writing_orphan_grace_period_us) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CacheGarbageCollector::IsStaleServing(const std::string &instance_id, const CacheLocation &loc) const noexcept {
+    if (loc.status() != CacheLocationStatus::CLS_SERVING) {
+        return false;
+    }
+    if (!config_.check_serving_data_exist) {
+        return false;
+    }
+    if (!registry_manager_ || !registry_manager_->data_storage_manager()) {
+        return false;
+    }
+
+    std::vector<DataStorageUri> storage_uris;
+    for (const auto &spec : loc.location_specs()) {
+        if (const DataStorageUri uri{spec.uri()}; uri.Valid()) {
+            storage_uris.emplace_back(uri);
+        }
+    }
+    if (storage_uris.empty()) {
+        return false;
+    }
+
+    std::string storage_unique_name = storage_uris.front().GetHostName();
+    if (storage_uris.front().GetProtocol() == "vineyard") {
+        storage_unique_name = VineyardStorageNameFromInstance(instance_id);
+    }
+    const auto result = registry_manager_->data_storage_manager()->Exist(storage_unique_name, storage_uris, false);
+    return std::any_of(result.cbegin(), result.cend(), [](const bool v) -> bool { return !v; });
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_garbage_collector.h
+++ b/kv_cache_manager/manager/cache_garbage_collector.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+namespace kv_cache_manager {
+
+#ifndef KVCM_COUNTER_METRICS_FOR_CACHE_GC
+#define KVCM_COUNTER_METRICS_FOR_CACHE_GC(name)                                                                        \
+public:                                                                                                                \
+    DECLARE_METRICS_NAME_(cache_gc, name);                                                                             \
+    DEFINE_GET_METRICS_COUNTER_(cache_gc, name)                                                                        \
+                                                                                                                       \
+private:                                                                                                               \
+    DECLARE_METRICS_COUNTER_(cache_gc, name);
+#endif
+
+#ifndef KVCM_GAUGE_METRICS_FOR_CACHE_GC
+#define KVCM_GAUGE_METRICS_FOR_CACHE_GC(name)                                                                          \
+public:                                                                                                                \
+    DECLARE_METRICS_NAME_(cache_gc, name);                                                                             \
+    DEFINE_GET_METRICS_GAUGE_(cache_gc, name)                                                                          \
+                                                                                                                       \
+private:                                                                                                               \
+    DECLARE_METRICS_GAUGE_(cache_gc, name);
+#endif
+
+class CacheLocation;
+class DataStorageManager;
+class EventManager;
+class MetaIndexer;
+class MetaIndexerManager;
+class RegistryManager;
+class RequestContext;
+class SchedulePlanExecutor;
+class WriteLocationManager;
+
+class CacheGarbageCollector {
+public:
+    struct Config {
+        std::size_t scan_batch_size = 256;
+        std::uint32_t inter_batch_sleep_ms = 50;
+        std::uint32_t inter_round_sleep_ms = 60000;
+        std::int64_t writing_orphan_grace_period_us = 600 * 1000000LL;
+        bool check_serving_data_exist = true;
+        std::size_t max_deletions_per_batch = 64;
+        bool enabled = true;
+    };
+
+    CacheGarbageCollector() = delete;
+
+    CacheGarbageCollector(Config config,
+                          std::shared_ptr<RegistryManager> registry_manager,
+                          std::shared_ptr<MetaIndexerManager> meta_indexer_manager,
+                          std::shared_ptr<SchedulePlanExecutor> sched_plan_executor,
+                          std::shared_ptr<MetricsRegistry> metrics_registry,
+                          std::shared_ptr<EventManager> event_manager,
+                          std::shared_ptr<WriteLocationManager> write_location_manager);
+
+    CacheGarbageCollector(const CacheGarbageCollector &) = delete;
+    CacheGarbageCollector(CacheGarbageCollector &&) = delete;
+    CacheGarbageCollector &operator=(const CacheGarbageCollector &) = delete;
+    CacheGarbageCollector &operator=(CacheGarbageCollector &&) = delete;
+
+    ~CacheGarbageCollector();
+
+    ErrorCode Start() noexcept;
+    void Stop() noexcept;
+    [[nodiscard]] bool IsRunning() const noexcept;
+    void Pause() noexcept;
+    void Resume() noexcept;
+    [[nodiscard]] bool IsPaused() const noexcept;
+
+private:
+    static const std::string kTraceIDPrefix;
+    static std::string GenTraceID();
+
+    void GCScanLoop() noexcept;
+    void ScanInstance(RequestContext *request_context,
+                     const std::string &instance_id,
+                     const std::shared_ptr<MetaIndexer> &meta_indexer) noexcept;
+    bool IsOrphanedWriting(const CacheLocation &loc) const noexcept;
+    bool IsStaleServing(const std::string &instance_id, const CacheLocation &loc) const noexcept;
+
+    const Config config_;
+    const std::shared_ptr<RegistryManager> registry_manager_;
+    const std::shared_ptr<MetaIndexerManager> meta_indexer_manager_;
+    const std::shared_ptr<SchedulePlanExecutor> sched_plan_executor_;
+    const std::shared_ptr<MetricsRegistry> metrics_registry_;
+    const std::shared_ptr<EventManager> event_manager_;
+    const std::shared_ptr<WriteLocationManager> write_location_manager_;
+
+    std::thread gc_thread_;
+    std::mutex state_mutex_;
+    std::condition_variable cv_state_;
+    bool running_ = false;
+    std::atomic<bool> paused_{false};
+
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(scan_round_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(orphaned_writing_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(stale_serving_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(location_submit_count)
+
+    KVCM_GAUGE_METRICS_FOR_CACHE_GC(scan_batch_duration_us)
+};
+
+#undef KVCM_COUNTER_METRICS_FOR_CACHE_GC
+#undef KVCM_GAUGE_METRICS_FOR_CACHE_GC
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -26,6 +26,7 @@
 #include "kv_cache_manager/event/event_manager.h"
 #include "kv_cache_manager/event/spec_events/optimizer_event.h"
 #include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
+#include "kv_cache_manager/manager/cache_garbage_collector.h"
 #include "kv_cache_manager/manager/cache_reclaimer.h"
 #include "kv_cache_manager/manager/data_storage_selector.h"
 #include "kv_cache_manager/manager/hash_util.h"
@@ -143,6 +144,10 @@ CacheManager::~CacheManager() {
         write_location_manager_->Stop();
         write_location_manager_.reset();
     }
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->Stop();
+        cache_garbage_collector_.reset();
+    }
     if (cache_reclaimer_) {
         cache_reclaimer_->Stop();
         cache_reclaimer_.reset();
@@ -182,6 +187,16 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
     if (cache_reclaimer_->Start() != EC_OK) {
         KVCM_LOG_ERROR("CacheManager init failed");
         return false;
+    }
+    cache_garbage_collector_ = std::make_shared<CacheGarbageCollector>(CacheGarbageCollector::Config{},
+                                                                       registry_manager_,
+                                                                       meta_indexer_manager_,
+                                                                       schedule_plan_executor_,
+                                                                       metrics_registry_,
+                                                                       event_manager_,
+                                                                       write_location_manager_);
+    if (cache_garbage_collector_->Start() != EC_OK) {
+        KVCM_LOG_WARN("cache garbage collector start failed, continuing without GC");
     }
     reclaimer_task_supervisor_ = std::make_unique<ReclaimerTaskSupervisor>(schedule_plan_executor_);
     reclaimer_task_supervisor_->Start();
@@ -727,8 +742,18 @@ ErrorCode CacheManager::TrimCache(RequestContext *request_context,
 
     return ErrorCode::EC_OK;
 }
-void CacheManager::PauseReclaimer() { cache_reclaimer_->Pause(); }
-void CacheManager::ResumeReclaimer() { cache_reclaimer_->Resume(); }
+void CacheManager::PauseReclaimer() {
+    cache_reclaimer_->Pause();
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->Pause();
+    }
+}
+void CacheManager::ResumeReclaimer() {
+    cache_reclaimer_->Resume();
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->Resume();
+    }
+}
 
 void CacheManager::FilterLocationSpecByName(CacheLocationVector &locations,
                                             const std::vector<std::string> &location_spec_names) {

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -22,6 +22,7 @@ class RegistryManager;
 class MetaSearcherManager;
 class MetaIndexerManager;
 class MetricsRegistry;
+class CacheGarbageCollector;
 class CacheReclaimer;
 class SchedulePlanExecutor;
 class ReclaimerTaskSupervisor;
@@ -246,6 +247,8 @@ private:
     std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor_;
     // 无需清理 - 仅需要暂停
     std::shared_ptr<CacheReclaimer> cache_reclaimer_;
+    // 无需清理 - 仅需要暂停
+    std::shared_ptr<CacheGarbageCollector> cache_garbage_collector_;
     // 无需清理 - SchedulePlanExecutor遗留的Plan会继续跑完
     std::unique_ptr<ReclaimerTaskSupervisor> reclaimer_task_supervisor_;
     // 无需清理 - 不包含运行时状态

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -16,6 +16,21 @@ cc_test(
 )
 
 cc_test(
+    name = "CacheGarbageCollectorTest",
+    srcs = [
+        "cache_garbage_collector_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    linkstatic = True,
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/manager:cache_garbage_collector",
+        "@cpp_stub",
+    ],
+)
+
+cc_test(
     name = "DataStorageSelectorTest",
     srcs = [
         "data_storage_selector_test.cc",

--- a/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
+++ b/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
@@ -1,0 +1,372 @@
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/timestamp_util.h"
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/instance_group.h"
+#include "kv_cache_manager/config/instance_info.h"
+#include "kv_cache_manager/config/model_deployment.h"
+#include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/manager/cache_garbage_collector.h"
+#include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/manager/write_location_manager.h"
+#include "kv_cache_manager/meta/cache_location.h"
+#include "kv_cache_manager/meta/common.h"
+#include "kv_cache_manager/meta/meta_indexer.h"
+#include "kv_cache_manager/meta/meta_indexer_manager.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "stub.h"
+
+using namespace kv_cache_manager;
+
+/* ---------------- RegistryManager stubs ---------------- */
+
+using ins_group_ptr_vec = std::vector<std::shared_ptr<const InstanceGroup>>;
+ins_group_ptr_vec gc_instance_groups;
+
+std::pair<ErrorCode, ins_group_ptr_vec> GC_ListInstanceGroup_stub(void *obj, RequestContext *rc) {
+    return {ErrorCode::EC_OK, gc_instance_groups};
+}
+
+using ins_info_ptr_vec = std::vector<std::shared_ptr<const InstanceInfo>>;
+ins_info_ptr_vec gc_instance_infos;
+
+std::pair<ErrorCode, ins_info_ptr_vec>
+GC_ListInstanceInfo_stub(void *obj, RequestContext *rc, const std::string &ig) {
+    return {ErrorCode::EC_OK, gc_instance_infos};
+}
+
+/* ---------------- MetaIndexerManager stub ---------------- */
+
+std::shared_ptr<MetaIndexer> gc_dummy_meta_indexer;
+
+std::shared_ptr<MetaIndexer> GC_GetMetaIndexer_stub(void *obj, const std::string &i) {
+    return gc_dummy_meta_indexer;
+}
+
+/* ---------------- MetaIndexer::Scan stub ---------------- */
+
+KeyVector gc_scan_keys;
+int gc_scan_call_count;
+
+ErrorCode GC_Scan_stub(void *obj,
+                       RequestContext *rc,
+                       const std::string &cursor,
+                       const std::size_t limit,
+                       std::string &out_next_cursor,
+                       KeyVector &out_keys) noexcept {
+    ++gc_scan_call_count;
+    if (cursor == SCAN_BASE_CURSOR && !gc_scan_keys.empty()) {
+        out_keys = gc_scan_keys;
+        out_next_cursor = SCAN_BASE_CURSOR;
+    } else {
+        out_keys.clear();
+        out_next_cursor = SCAN_BASE_CURSOR;
+    }
+    return ErrorCode::EC_OK;
+}
+
+/* ---------------- MetaIndexer::GetLocations stub ---------------- */
+
+CacheLocationMapVector gc_location_maps;
+
+MetaIndexer::Result GC_GetLocations_stub(void *obj,
+                                         RequestContext *rc,
+                                         const KeyVector &keys,
+                                         CacheLocationMapVector &out_location_maps) noexcept {
+    out_location_maps = gc_location_maps;
+    return MetaIndexer::Result(ErrorCode::EC_OK);
+}
+
+/* ---------------- SchedulePlanExecutor::SubmitNonBlocking stub ---------------- */
+
+using spe_submit_nb_loc = bool (SchedulePlanExecutor::*)(const CacheLocationDelRequest &);
+std::vector<CacheLocationDelRequest> gc_submitted_del_requests;
+
+bool GC_SubmitNonBlocking_stub(void *obj, const CacheLocationDelRequest &request) {
+    gc_submitted_del_requests.push_back(request);
+    return true;
+}
+
+/* ---------------- WriteLocationManager::HasLocationId stub ---------------- */
+
+std::vector<std::string> gc_active_location_ids;
+
+bool GC_HasLocationId_stub(void *obj, const std::string &location_id) {
+    for (const auto &id : gc_active_location_ids) {
+        if (id == location_id) return true;
+    }
+    return false;
+}
+
+/* ---------------- DataStorageManager::Exist stub ---------------- */
+
+std::vector<bool> gc_exist_results;
+
+std::vector<bool>
+GC_DSM_Exist_stub(void *obj, const std::string &name, const std::vector<DataStorageUri> &uris, bool fastpath) {
+    if (!gc_exist_results.empty()) {
+        return gc_exist_results;
+    }
+    return std::vector<bool>(uris.size(), true);
+}
+
+/* ---------------- RegistryManager::data_storage_manager stub ---------------- */
+
+std::shared_ptr<DataStorageManager> gc_dsm;
+
+std::shared_ptr<DataStorageManager> GC_data_storage_manager_stub(void *obj) { return gc_dsm; }
+
+/* ---------------- Test fixture ---------------- */
+
+class CacheGarbageCollectorTest : public TESTBASE {
+public:
+    void SetUp() override {
+        stub_.set(ADDR(RegistryManager, ListInstanceGroup), GC_ListInstanceGroup_stub);
+        stub_.set(ADDR(RegistryManager, ListInstanceInfo), GC_ListInstanceInfo_stub);
+        stub_.set(ADDR(MetaIndexerManager, GetMetaIndexer), GC_GetMetaIndexer_stub);
+        stub_.set(ADDR(MetaIndexer, Scan), GC_Scan_stub);
+        stub_.set(ADDR(WriteLocationManager, HasLocationId), GC_HasLocationId_stub);
+        stub_.set(ADDR(DataStorageManager, Exist), GC_DSM_Exist_stub);
+        stub_.set(ADDR(RegistryManager, data_storage_manager), GC_data_storage_manager_stub);
+
+        // stub the overload: GetLocations(rc, keys, CacheLocationMapVector&)
+        using get_loc_t = MetaIndexer::Result (MetaIndexer::*)(RequestContext *, const KeyVector &,
+                                                               CacheLocationMapVector &) noexcept;
+        stub_.set(static_cast<get_loc_t>(ADDR(MetaIndexer, GetLocations)), GC_GetLocations_stub);
+
+        stub_.set(static_cast<spe_submit_nb_loc>(ADDR(SchedulePlanExecutor, SubmitNonBlocking)),
+                  GC_SubmitNonBlocking_stub);
+
+        auto ig = std::make_shared<InstanceGroup>();
+        ig->set_name("test_group");
+        gc_instance_groups = {ig};
+
+        auto ii = std::make_shared<InstanceInfo>();
+        ii->set_instance_id("test_instance");
+        ii->set_instance_group_name("test_group");
+        gc_instance_infos = {ii};
+
+        gc_dummy_meta_indexer = std::make_shared<MetaIndexer>();
+        gc_scan_keys.clear();
+        gc_scan_call_count = 0;
+        gc_location_maps.clear();
+        gc_submitted_del_requests.clear();
+        gc_active_location_ids.clear();
+        gc_exist_results.clear();
+
+        mr_ = std::make_shared<MetricsRegistry>();
+        rm_ = std::make_shared<RegistryManager>("", mr_);
+        mim_ = std::make_shared<MetaIndexerManager>();
+        gc_dsm = std::make_shared<DataStorageManager>(mr_);
+        spe_ = std::make_shared<SchedulePlanExecutor>(0, mim_, gc_dsm, mr_);
+        wlm_ = std::make_shared<WriteLocationManager>();
+    }
+
+    void TearDown() override {
+        gc_instance_groups.clear();
+        gc_instance_infos.clear();
+        gc_dummy_meta_indexer.reset();
+        gc_scan_keys.clear();
+        gc_location_maps.clear();
+        gc_submitted_del_requests.clear();
+        gc_active_location_ids.clear();
+        gc_exist_results.clear();
+        gc_dsm.reset();
+    }
+
+    std::unique_ptr<CacheGarbageCollector> MakeGC(CacheGarbageCollector::Config config = {}) {
+        config.inter_round_sleep_ms = 10;
+        config.inter_batch_sleep_ms = 0;
+        return std::make_unique<CacheGarbageCollector>(config, rm_, mim_, spe_, mr_, nullptr, wlm_);
+    }
+
+    static CacheLocationConstPtr MakeLocation(const std::string &id,
+                                              CacheLocationStatus status,
+                                              std::int64_t create_time_us = 0) {
+        auto loc = std::make_shared<CacheLocation>();
+        loc->set_id(id);
+        loc->set_status(status);
+        loc->set_create_time(create_time_us);
+        return loc;
+    }
+
+protected:
+    Stub stub_;
+    std::shared_ptr<MetricsRegistry> mr_;
+    std::shared_ptr<RegistryManager> rm_;
+    std::shared_ptr<MetaIndexerManager> mim_;
+    std::shared_ptr<SchedulePlanExecutor> spe_;
+    std::shared_ptr<WriteLocationManager> wlm_;
+};
+
+/* ---------------- Tests ---------------- */
+
+TEST_F(CacheGarbageCollectorTest, StartStopBasic) {
+    auto gc = MakeGC();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    ASSERT_TRUE(gc->IsRunning());
+    gc->Stop();
+    ASSERT_FALSE(gc->IsRunning());
+}
+
+TEST_F(CacheGarbageCollectorTest, DisabledDoesNotStart) {
+    CacheGarbageCollector::Config config;
+    config.enabled = false;
+    auto gc = MakeGC(config);
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    ASSERT_FALSE(gc->IsRunning());
+}
+
+TEST_F(CacheGarbageCollectorTest, DoubleStartReturnsExist) {
+    auto gc = MakeGC();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_EXIST);
+    gc->Stop();
+}
+
+TEST_F(CacheGarbageCollectorTest, DetectsOrphanedWriting) {
+    // orphaned: CLS_WRITING, not in WriteLocationManager, old enough
+    std::int64_t old_time = TimestampUtil::GetCurrentTimeUs() - 700 * 1000000LL;
+    gc_scan_keys = {100};
+    CacheLocationMap loc_map;
+    loc_map["loc_orphan"] = MakeLocation("loc_orphan", CacheLocationStatus::CLS_WRITING, old_time);
+    gc_location_maps = {loc_map};
+
+    auto gc = MakeGC();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    gc->Stop();
+
+    ASSERT_FALSE(gc_submitted_del_requests.empty());
+    ASSERT_EQ(gc_submitted_del_requests[0].block_keys[0], 100);
+    ASSERT_EQ(gc_submitted_del_requests[0].location_ids[0][0], "loc_orphan");
+}
+
+TEST_F(CacheGarbageCollectorTest, GracePeriodProtectsYoungWriting) {
+    // young CLS_WRITING should not be collected
+    std::int64_t recent_time = TimestampUtil::GetCurrentTimeUs() - 10 * 1000000LL;
+    gc_scan_keys = {200};
+    CacheLocationMap loc_map;
+    loc_map["loc_young"] = MakeLocation("loc_young", CacheLocationStatus::CLS_WRITING, recent_time);
+    gc_location_maps = {loc_map};
+
+    auto gc = MakeGC();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    gc->Stop();
+
+    ASSERT_TRUE(gc_submitted_del_requests.empty());
+}
+
+TEST_F(CacheGarbageCollectorTest, ActiveWriteSessionProtected) {
+    // CLS_WRITING but tracked in WriteLocationManager
+    std::int64_t old_time = TimestampUtil::GetCurrentTimeUs() - 700 * 1000000LL;
+    gc_scan_keys = {300};
+    gc_active_location_ids = {"loc_active"};
+    CacheLocationMap loc_map;
+    loc_map["loc_active"] = MakeLocation("loc_active", CacheLocationStatus::CLS_WRITING, old_time);
+    gc_location_maps = {loc_map};
+
+    auto gc = MakeGC();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    gc->Stop();
+
+    ASSERT_TRUE(gc_submitted_del_requests.empty());
+}
+
+TEST_F(CacheGarbageCollectorTest, DetectsStaleServing) {
+    gc_scan_keys = {400};
+    auto loc = std::make_shared<CacheLocation>();
+    loc->set_id("loc_stale");
+    loc->set_status(CacheLocationStatus::CLS_SERVING);
+    loc->push_location_spec(LocationSpec("spec1", "file://storage_01/path/to/data"));
+    CacheLocationMap loc_map;
+    loc_map["loc_stale"] = loc;
+    gc_location_maps = {loc_map};
+
+    // Exist returns false — data is missing
+    gc_exist_results = {false};
+
+    auto gc = MakeGC();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    gc->Stop();
+
+    ASSERT_FALSE(gc_submitted_del_requests.empty());
+    ASSERT_EQ(gc_submitted_del_requests[0].location_ids[0][0], "loc_stale");
+}
+
+TEST_F(CacheGarbageCollectorTest, HealthyServingNotCollected) {
+    gc_scan_keys = {500};
+    auto loc = std::make_shared<CacheLocation>();
+    loc->set_id("loc_healthy");
+    loc->set_status(CacheLocationStatus::CLS_SERVING);
+    loc->push_location_spec(LocationSpec("spec1", "file://storage_01/path/to/data"));
+    CacheLocationMap loc_map;
+    loc_map["loc_healthy"] = loc;
+    gc_location_maps = {loc_map};
+
+    // Exist returns true — data present
+    gc_exist_results = {true};
+
+    auto gc = MakeGC();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    gc->Stop();
+
+    ASSERT_TRUE(gc_submitted_del_requests.empty());
+}
+
+TEST_F(CacheGarbageCollectorTest, PauseStopsScan) {
+    gc_scan_keys = {600};
+    std::int64_t old_time = TimestampUtil::GetCurrentTimeUs() - 700 * 1000000LL;
+    CacheLocationMap loc_map;
+    loc_map["loc_pause"] = MakeLocation("loc_pause", CacheLocationStatus::CLS_WRITING, old_time);
+    gc_location_maps = {loc_map};
+
+    auto gc = MakeGC();
+    gc->Pause();
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+
+    // nothing submitted while paused
+    ASSERT_TRUE(gc_submitted_del_requests.empty());
+
+    gc->Resume();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    gc->Stop();
+
+    ASSERT_FALSE(gc_submitted_del_requests.empty());
+}
+
+TEST_F(CacheGarbageCollectorTest, MaxDeletionsPerBatchRespected) {
+    CacheGarbageCollector::Config config;
+    config.max_deletions_per_batch = 1;
+
+    // provide two keys with dirty locations
+    std::int64_t old_time = TimestampUtil::GetCurrentTimeUs() - 700 * 1000000LL;
+    gc_scan_keys = {700, 701};
+    CacheLocationMap loc_map0;
+    loc_map0["loc_a"] = MakeLocation("loc_a", CacheLocationStatus::CLS_WRITING, old_time);
+    CacheLocationMap loc_map1;
+    loc_map1["loc_b"] = MakeLocation("loc_b", CacheLocationStatus::CLS_WRITING, old_time);
+    gc_location_maps = {loc_map0, loc_map1};
+
+    auto gc = MakeGC(config);
+    ASSERT_EQ(gc->Start(), ErrorCode::EC_OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    gc->Stop();
+
+    // at most 1 deletion per batch submission
+    ASSERT_FALSE(gc_submitted_del_requests.empty());
+    ASSERT_EQ(gc_submitted_del_requests[0].block_keys.size(), 1u);
+}


### PR DESCRIPTION
## Context

KVCM has dirty/invalid metadata in two scenarios:
1. **Orphaned CLS_WRITING**: Client completes `StartWriteCache` but never calls `FinishWriteCache` (process restart, HA failover). Write session is lost, leaving permanent CLS_WRITING locations.
2. **Stale CLS_SERVING**: Storage backend loses data (node failure). CLS_SERVING locations remain but actual data is gone.

Existing passive mechanisms (reclaimer sampling, read-path MightExist check) only partially cover these — the reclaimer only triggers on water-level threshold and only processes sampled keys, while read-path checks only cover accessed keys. A proactive GC task provides systematic, full-coverage cleanup.

---

## Design: `CacheGarbageCollector` Class

### Placement & Threading

- **Separate class** `CacheGarbageCollector` (not embedded in CacheReclaimer)
  - Different concern (correctness vs. capacity), different scan strategy (exhaustive vs. sampled)
- **Dedicated background thread** running `GCScanLoop()`
  - Same lifecycle pattern as `CacheReclaimer` (Start/Stop/Pause/Resume)
  - Uses `cv.wait_for()` for interruptible sleep