### PR TITLE
[build] allow stub_source to depend on http_service target

### DIFF
--- a/kv_cache_manager/service/http_service/BUILD
+++ b/kv_cache_manager/service/http_service/BUILD
@@ -1,4 +1,7 @@
-package(default_visibility = ["//kv_cache_manager/service:__subpackages__"])
+package(default_visibility = [
+    "//kv_cache_manager/service:__subpackages__",
+    "//stub_source:__subpackages__",
+])
 
 cc_library(
     name = "http_service",


### PR DESCRIPTION
## Summary
The HTTP service layer in this package — coro_http_service (the base class) together with its derived services (admin_service_http, debug_service_http,
  meta_service_http) and the internal config_server_http under //stub_source/... — must all be packaged into a single cc_library target. Splitting them across multiple
  cc_library targets causes the heavily-templated ylt/coro_http/coro_http_server.hpp header to be instantiated independently in each library. The duplicated
  instantiations, once linked into a binary, produce non-deterministic shutdown crashes (every worker process SIGSEGVs during teardown), because the destruction paths of
  coroutine frames and std::function-erased handlers cross cc_library boundaries where weak-symbol resolution and static destruction order are no longer guaranteed to be
  consistent.

  To preserve the proven-stable single-cc_library layout while still allowing config_server's HTTP service — which the build system sees as
  **//stub_source/config_server/service/http_service** via the internal-source symlink — to depend on this target, the default_visibility is widened to:

```
  package(default_visibility = [
      "//kv_cache_manager/service:__subpackages__",
      "//stub_source:__subpackages__",
  ])
```
