### PR TITLE
feat: publish v6d heartbeat system_status as Prometheus gauges

### DIFF
--- a/kv_cache_manager/data_storage/test/vineyard_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/vineyard_backend_test.cc
@@ -344,3 +344,77 @@ TEST_F(VineyardBackendTest, OnHeartbeatPublishesMetricsGauges) {
 
     ASSERT_EQ(EC_OK, backend.Close());
 }
+
+TEST_F(VineyardBackendTest, SetNodeUnavailableZerosGauges) {
+    VineyardBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 50), "trace"));
+
+    ASSERT_EQ(EC_OK, backend.RegisterNode("10.0.0.30:9600", {"mem"}));
+    ASSERT_EQ(EC_OK, backend.RegisterNode("10.0.0.31:9600", {"mem"}));
+
+    backend.OnHeartbeat("10.0.0.30:9600", {{"hit_rate", "0.90"}, {"mem_used", "8192"}});
+    backend.OnHeartbeat("10.0.0.31:9600", {{"hit_rate", "0.80"}, {"mem_used", "4096"}});
+
+    MetricsTags tags_30 = {{"instance_id", "v6d_cluster_test"}, {"host", "10.0.0.30:9600"}};
+    MetricsTags tags_31 = {{"instance_id", "v6d_cluster_test"}, {"host", "10.0.0.31:9600"}};
+
+    auto hr_data = metrics_registry_->GetMetricsData("v6d.hit_rate");
+    ASSERT_NE(hr_data, nullptr);
+    ASSERT_DOUBLE_EQ(0.90, hr_data->GetOrCreateGauge(tags_30).Get());
+    ASSERT_DOUBLE_EQ(0.80, hr_data->GetOrCreateGauge(tags_31).Get());
+
+    backend.SetNodeUnavailable("10.0.0.30:9600");
+
+    // node 30's gauges should be zeroed
+    ASSERT_DOUBLE_EQ(0.0, hr_data->GetOrCreateGauge(tags_30).Get());
+    auto mu_data = metrics_registry_->GetMetricsData("v6d.mem_used");
+    ASSERT_DOUBLE_EQ(0.0, mu_data->GetOrCreateGauge(tags_30).Get());
+
+    // node 31's gauges should be untouched
+    ASSERT_DOUBLE_EQ(0.80, hr_data->GetOrCreateGauge(tags_31).Get());
+    ASSERT_DOUBLE_EQ(4096, mu_data->GetOrCreateGauge(tags_31).Get());
+
+    // calling SetNodeUnavailable again should be a no-op (already unavailable)
+    backend.SetNodeUnavailable("10.0.0.30:9600");
+    ASSERT_DOUBLE_EQ(0.0, hr_data->GetOrCreateGauge(tags_30).Get());
+
+    ASSERT_EQ(EC_OK, backend.Close());
+}
+
+TEST_F(VineyardBackendTest, UnregisterNodeCleansUpGauges) {
+    VineyardBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 50), "trace"));
+
+    ASSERT_EQ(EC_OK, backend.RegisterNode("10.0.0.20:9600", {"mem"}));
+    ASSERT_EQ(EC_OK, backend.RegisterNode("10.0.0.21:9600", {"mem"}));
+
+    backend.OnHeartbeat("10.0.0.20:9600", {{"hit_rate", "0.75"}, {"mem_used", "4096"}});
+    backend.OnHeartbeat("10.0.0.21:9600", {{"hit_rate", "0.60"}, {"mem_used", "2048"}});
+
+    MetricsTags tags_20 = {{"instance_id", "v6d_cluster_test"}, {"host", "10.0.0.20:9600"}};
+    MetricsTags tags_21 = {{"instance_id", "v6d_cluster_test"}, {"host", "10.0.0.21:9600"}};
+
+    auto hr_data = metrics_registry_->GetMetricsData("v6d.hit_rate");
+    ASSERT_NE(hr_data, nullptr);
+    ASSERT_DOUBLE_EQ(0.75, hr_data->GetOrCreateGauge(tags_20).Get());
+    ASSERT_DOUBLE_EQ(0.60, hr_data->GetOrCreateGauge(tags_21).Get());
+
+    ASSERT_EQ(EC_OK, backend.UnregisterNode("10.0.0.20:9600"));
+
+    // node 20's gauges should be removed
+    auto hr_values = hr_data->GetMetricsValues();
+    for (const auto &[tags, val] : hr_values) {
+        ASSERT_NE(tags, tags_20) << "node 20 gauge should have been removed";
+    }
+    auto mu_data = metrics_registry_->GetMetricsData("v6d.mem_used");
+    auto mu_values = mu_data->GetMetricsValues();
+    for (const auto &[tags, val] : mu_values) {
+        ASSERT_NE(tags, tags_20) << "node 20 gauge should have been removed";
+    }
+
+    // node 21's gauges should still be present
+    ASSERT_DOUBLE_EQ(0.60, hr_data->GetOrCreateGauge(tags_21).Get());
+    ASSERT_DOUBLE_EQ(2048, mu_data->GetOrCreateGauge(tags_21).Get());
+
+    ASSERT_EQ(EC_OK, backend.Close());
+}

--- a/kv_cache_manager/data_storage/test/vineyard_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/vineyard_backend_test.cc
@@ -297,3 +297,50 @@ TEST_F(VineyardBackendTest, LivenessLoopPassesGenerationToCallback) {
 
     ASSERT_EQ(EC_OK, backend.Close());
 }
+
+// OnHeartbeat publishes numeric system_status as prometheus gauges
+TEST_F(VineyardBackendTest, OnHeartbeatPublishesMetricsGauges) {
+    VineyardBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 50), "trace"));
+    ASSERT_EQ(EC_OK, backend.RegisterNode("10.0.0.10:9600", {"mem"}));
+
+    // Round 1: send initial metrics
+    backend.OnHeartbeat("10.0.0.10:9600", {
+        {"hit_rate", "0.85"},
+        {"active_leases", "5"},
+        {"non_numeric_field", "BOTH_OK"},
+    });
+
+    // Verify numeric gauges registered
+    auto hit_rate_data = metrics_registry_->GetMetricsData("v6d.hit_rate");
+    ASSERT_NE(hit_rate_data, nullptr);
+    MetricsTags expected_tags = {{"instance_id", "v6d_cluster_test"}, {"host", "10.0.0.10:9600"}};
+    auto gauge = hit_rate_data->GetOrCreateGauge(expected_tags);
+    ASSERT_DOUBLE_EQ(0.85, gauge.Get());
+
+    auto leases_data = metrics_registry_->GetMetricsData("v6d.active_leases");
+    ASSERT_NE(leases_data, nullptr);
+    auto leases_gauge = leases_data->GetOrCreateGauge(expected_tags);
+    ASSERT_DOUBLE_EQ(5.0, leases_gauge.Get());
+
+    // Verify non-numeric field NOT registered
+    auto non_numeric = metrics_registry_->GetMetricsData("v6d.non_numeric_field");
+    ASSERT_EQ(non_numeric, nullptr);
+
+    // Round 2: dynamically add a new metric
+    backend.OnHeartbeat("10.0.0.10:9600", {
+        {"hit_rate", "0.90"},
+        {"brand_new_metric", "42"},
+    });
+
+    // New metric should appear
+    auto new_data = metrics_registry_->GetMetricsData("v6d.brand_new_metric");
+    ASSERT_NE(new_data, nullptr);
+    auto new_gauge = new_data->GetOrCreateGauge(expected_tags);
+    ASSERT_DOUBLE_EQ(42.0, new_gauge.Get());
+
+    // Existing metric should be updated
+    ASSERT_DOUBLE_EQ(0.90, gauge.Get());
+
+    ASSERT_EQ(EC_OK, backend.Close());
+}

--- a/kv_cache_manager/data_storage/vineyard_backend.cc
+++ b/kv_cache_manager/data_storage/vineyard_backend.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/data_storage/vineyard_backend.h"
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -104,6 +105,7 @@ ErrorCode VineyardBackend::RegisterNode(const std::string &host_ip_port, const s
         info.last_heartbeat_ms.store(now_ms, std::memory_order_relaxed);
         info.available.store(true, std::memory_order_relaxed);
         info.unavailable_since_ms.store(0, std::memory_order_relaxed);
+        info.metrics_tags = {{"instance_id", spec_.cluster_name()}, {"host", host_ip_port}};
         KVCM_LOG_INFO("VineyardBackend: node [%s] already registered, mediums=%zu (refreshed heartbeat, gen=%lu)",
                       host_ip_port.c_str(),
                       info.mediums.size(),
@@ -116,6 +118,7 @@ ErrorCode VineyardBackend::RegisterNode(const std::string &host_ip_port, const s
     info->available.store(true, std::memory_order_relaxed);
     info->unavailable_since_ms.store(0, std::memory_order_relaxed);
     info->mediums = mediums;
+    info->metrics_tags = {{"instance_id", spec_.cluster_name()}, {"host", host_ip_port}};
     nodes_[host_ip_port] = std::move(info);
 
     KVCM_LOG_INFO("VineyardBackend: node [%s] registered in cluster [%s], mediums=%zu, gen=%lu",
@@ -157,6 +160,21 @@ void VineyardBackend::OnHeartbeat(const std::string &host_ip_port,
         KVCM_LOG_INFO("VineyardBackend: node [%s] recovered from unavailable", host_ip_port.c_str());
     }
     info.last_system_status = system_status;
+
+    // Publish numeric system_status entries as prometheus gauges.
+    if (metrics_registry_) {
+        const auto &tags = info.metrics_tags;
+        for (const auto &kv : system_status) {
+            const auto &s = kv.second;
+            if (s.empty()) continue;
+            double val = 0;
+            auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), val);
+            if (ec == std::errc{} && ptr == s.data() + s.size()) {
+                auto gauge = metrics_registry_->GetGauge("v6d." + kv.first, tags);
+                gauge = val;
+            }
+        }
+    }
 }
 
 void VineyardBackend::SetNodeUnavailable(const std::string &host_ip_port) {

--- a/kv_cache_manager/data_storage/vineyard_backend.cc
+++ b/kv_cache_manager/data_storage/vineyard_backend.cc
@@ -136,6 +136,15 @@ ErrorCode VineyardBackend::UnregisterNode(const std::string &host_ip_port) {
         KVCM_LOG_WARN("VineyardBackend: node [%s] not found for unregister", host_ip_port.c_str());
         return EC_NOENT;
     }
+    if (metrics_registry_) {
+        auto &info = *it->second;
+        for (const auto &kv : info.last_system_status) {
+            auto data = metrics_registry_->GetMetricsData("v6d." + kv.first);
+            if (data) {
+                data->RemoveByTags(info.metrics_tags);
+            }
+        }
+    }
     nodes_.erase(it);
     KVCM_LOG_INFO("VineyardBackend: node [%s] unregistered from cluster [%s]",
                   host_ip_port.c_str(),
@@ -187,6 +196,20 @@ void VineyardBackend::SetNodeUnavailable(const std::string &host_ip_port) {
     bool prev = info.available.exchange(false, std::memory_order_relaxed);
     if (prev) {
         info.unavailable_since_ms.store(NowMillis(), std::memory_order_relaxed);
+        ZeroNodeGauges(info);
+    }
+}
+
+void VineyardBackend::ZeroNodeGauges(const NodeInfo &info) {
+    if (!metrics_registry_) {
+        return;
+    }
+    for (const auto &kv : info.last_system_status) {
+        auto data = metrics_registry_->GetMetricsData("v6d." + kv.first);
+        if (data) {
+            auto gauge = data->GetOrCreateGauge(info.metrics_tags);
+            gauge = 0.0;
+        }
     }
 }
 
@@ -247,6 +270,7 @@ void VineyardBackend::LivenessCheckerLoop() {
                     KVCM_LOG_WARN("VineyardBackend: node [%s] timed out (no hb for %ldms), marked unavailable",
                                   kv.first.c_str(),
                                   now_ms - last_hb);
+                    ZeroNodeGauges(info);
                 }
                 int64_t unavailable_since = info.unavailable_since_ms.load(std::memory_order_relaxed);
                 if (unavailable_since > 0 && now_ms - unavailable_since >= cleanup_grace_ms_) {

--- a/kv_cache_manager/data_storage/vineyard_backend.h
+++ b/kv_cache_manager/data_storage/vineyard_backend.h
@@ -95,6 +95,8 @@ private:
     int64_t cleanup_grace_ms_ = VineyardStorageSpec::kDefaultCleanupGraceMs;
     int64_t liveness_check_interval_ms_ = VineyardStorageSpec::kDefaultLivenessCheckIntervalMs;
 
+    void ZeroNodeGauges(const NodeInfo &info);
+
     mutable std::mutex cleanup_cb_mutex_;
     CleanupCallback cleanup_callback_;
     std::atomic<bool> cleanup_cb_set_{false};

--- a/kv_cache_manager/data_storage/vineyard_backend.h
+++ b/kv_cache_manager/data_storage/vineyard_backend.h
@@ -78,6 +78,7 @@ private:
 
         std::vector<std::string> mediums;
         std::map<std::string, std::string> last_system_status;
+        MetricsTags metrics_tags;
     };
 
     VineyardStorageSpec spec_;

--- a/kv_cache_manager/metrics/metrics_registry.cc
+++ b/kv_cache_manager/metrics/metrics_registry.cc
@@ -229,6 +229,11 @@ Gauge MetricsData::GetOrCreateGauge(const MetricsTags &tags) {
     return Gauge{it->second};
 }
 
+bool MetricsData::RemoveByTags(const MetricsTags &tags) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return metrics_data_.erase(tags) > 0;
+}
+
 /* ---------------------------- Registry ---------------------------- */
 
 std::size_t MetricsRegistry::GetSize() noexcept {

--- a/kv_cache_manager/metrics/metrics_registry.h
+++ b/kv_cache_manager/metrics/metrics_registry.h
@@ -201,6 +201,7 @@ public:
 
     Counter GetOrCreateCounter(const MetricsTags &tags);
     Gauge GetOrCreateGauge(const MetricsTags &tags);
+    bool RemoveByTags(const MetricsTags &tags);
 
 private:
     std::mutex mutex_;

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -104,6 +104,9 @@ message NfsStorageSpec {
 
 message VineyardStorageSpec {
     string cluster_name = 1;
+    int64 heartbeat_timeout_ms = 2;
+    int64 cleanup_grace_ms = 3;
+    int64 liveness_check_interval_ms = 4;
 }
 
 message StorageConfig {

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -63,6 +63,9 @@ void ProtoConvert::StorageConfigToProto(const StorageConfig &storage_config,
         const auto &vineyard_storage = *std::dynamic_pointer_cast<VineyardStorageSpec>(storage_config.storage_spec());
         auto *vineyard = proto_storage_config->mutable_vineyard();
         vineyard->set_cluster_name(vineyard_storage.cluster_name());
+        vineyard->set_heartbeat_timeout_ms(vineyard_storage.heartbeat_timeout_ms());
+        vineyard->set_cleanup_grace_ms(vineyard_storage.cleanup_grace_ms());
+        vineyard->set_liveness_check_interval_ms(vineyard_storage.liveness_check_interval_ms());
     }
 }
 
@@ -136,7 +139,11 @@ void ProtoConvert::StorageFromProto(const proto::admin::StorageConfig *proto_sto
     }
     case proto::admin::StorageConfig::kVineyard: {
         VineyardStorageSpec spec;
-        spec.set_cluster_name(proto_storage_config->vineyard().cluster_name());
+        const auto &v = proto_storage_config->vineyard();
+        spec.set_cluster_name(v.cluster_name());
+        if (v.heartbeat_timeout_ms() > 0) spec.set_heartbeat_timeout_ms(v.heartbeat_timeout_ms());
+        if (v.cleanup_grace_ms() > 0) spec.set_cleanup_grace_ms(v.cleanup_grace_ms());
+        if (v.liveness_check_interval_ms() > 0) spec.set_liveness_check_interval_ms(v.liveness_check_interval_ms());
         storage_config.set_storage_spec(std::make_shared<VineyardStorageSpec>(spec));
         storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_VINEYARD);
         break;


### PR DESCRIPTION
OnHeartbeat now iterates system_status map and dynamically registers numeric values as Prometheus gauges with instance_id + host tags. Tags are cached per node at RegisterNode time. Parsing uses std::from_chars (zero-exception, non-numeric values safely skipped). New v6d metrics appear in /metrics without KVCM restart.