### PR TITLE
[config_server] add config_server tools for kvcm_ops.

### DIFF
--- a/kv_cache_manager/service/http_service/coro_http_service.cc
+++ b/kv_cache_manager/service/http_service/coro_http_service.cc
@@ -58,6 +58,15 @@ bool CoroHttpService::Start(int32_t port, size_t thread_num) {
     return true;
 }
 
+void CoroHttpService::MergeFrom(const CoroHttpService &other) {
+    for (const auto &[path, handler] : other.get_handlers_) {
+        get_handlers_[path] = handler;
+    }
+    for (const auto &[path, handler] : other.post_handlers_) {
+        post_handlers_[path] = handler;
+    }
+}
+
 void CoroHttpService::Stop() {
     if (server_) {
         server_->stop();

--- a/kv_cache_manager/service/http_service/coro_http_service.h
+++ b/kv_cache_manager/service/http_service/coro_http_service.h
@@ -30,6 +30,8 @@ public:
     bool Start(int32_t port, size_t thread_num = std::thread::hardware_concurrency());
     void Stop();
 
+    void MergeFrom(const CoroHttpService &other);
+
     static std::string GetHttpClientIp(const coro_http::coro_http_connection *http_conn);
 
 protected:

--- a/package/kvcm_ops/BUILD
+++ b/package/kvcm_ops/BUILD
@@ -9,6 +9,7 @@ py_library(
         "kvcm/**/*.py",
         "trace/**/*.py",
         "util/**/*.py",
+        "config_server/**/*.py",
         "*.py",
     ]),
 )

--- a/package/kvcm_ops/__main__.py
+++ b/package/kvcm_ops/__main__.py
@@ -25,13 +25,16 @@ COMMANDS = {
 
     "trace_key": "kvcm_ops.trace.trace_key",
     "trace_uri": "kvcm_ops.trace.trace_uri",
+
+    "config_server": "kvcm_ops.config_server",
 }
 
 HELP_MODULE = [
     "kvcm_ops.kvcm.instance._help",
     "kvcm_ops.kvcm.instance_group._help",
     "kvcm_ops.kvcm.storage._help",
-    "kvcm_ops.trace._help"
+    "kvcm_ops.trace._help",
+    "kvcm_ops.config_server._help",
 ]
 
 def main():
@@ -76,6 +79,12 @@ def main():
   trace:
     trace_key
     trace_uri
+  config_server:           (use: python3 -m kvcm_ops config_server <sub> ...)
+    create-hpnzone         create a new hpnzone
+    delete-hpnzone         delete an existing hpnzone
+    list-hpnzones          list all hpnzones on the server
+    instance_pin            (instance_pin mode)
+    server_capability       (detect server routing mode)
         '''
     )
     parser.add_argument(

--- a/package/kvcm_ops/config_server/README.md
+++ b/package/kvcm_ops/config_server/README.md
@@ -1,0 +1,193 @@
+# kvcm_ops · config_server
+
+`kvcm_ops` 中针对 **ConfigServer** 的运维工具集合。所有 config_server 子命令统一通过 `python3 -m kvcm_ops config_server <subcommand>` 调用。
+
+ConfigServer 使用 **instance_pin** 路由模式（显式映射表：instance → cell URL）。
+
+可通过 `server_capability` 探测当前服务器的路由模式：
+
+```bash
+python3 -m kvcm_ops config_server server_capability --url http://127.0.0.1:9101
+# routing_mode   = INSTANCE_PIN
+# server_version = ...
+```
+
+---
+
+## 安装
+
+`kvcm_ops` 已经随 ConfigServer 内源安装包一起发布（`config_server.tar.gz` 里带 `kvcm_ops-0.1.0-py3-none-any.whl`），
+`start_server.sh` 启动 server 时会自动 `pip install`。如果你想在本地直接跑：
+
+```bash
+pip install kvcm_ops-0.1.0-py3-none-any.whl
+# 或者在仓库内直接 -m
+cd KVCacheManager/github-opensource/package
+python3 -m kvcm_ops config_server --help
+```
+
+之后下文统一用 `python3 -m kvcm_ops config_server <subcommand> ...` 来演示。
+
+所有在线子命令默认连本机 `http://127.0.0.1:9101`，可用 `--url` 指向其它实例。
+
+---
+
+## hpnzone 生命周期管理
+
+```bash
+# 列出所有 hpnzone
+python3 -m kvcm_ops config_server list-hpnzones
+python3 -m kvcm_ops config_server list-hpnzones --url http://10.0.0.1:9101
+
+# 创建 hpnzone
+python3 -m kvcm_ops config_server create-hpnzone --hpnzone prod_zone_a
+
+# 删除 hpnzone（交互确认，--yes 跳过）
+python3 -m kvcm_ops config_server delete-hpnzone --hpnzone prod_zone_a
+python3 -m kvcm_ops config_server delete-hpnzone --hpnzone prod_zone_a --yes
+```
+
+---
+
+## server_capability（探测路由模式）
+
+```bash
+python3 -m kvcm_ops config_server server_capability
+python3 -m kvcm_ops config_server server_capability --url http://10.0.0.1:9101
+python3 -m kvcm_ops config_server server_capability --url http://10.0.0.1:9101 --json
+```
+
+---
+
+## instance_pin 模式
+
+> 概念速查：
+> - **cell**：一个 kvcm 服务发现 URL（一主一备，对外原子）
+> - **group pin**：(hpnzone, instance_group) → cell；动态回退，不物化为 instance pin
+> - **instance pin**：(hpnzone, instance) → cell；最高优先级，持久化
+> - **优先级**：instance pin > group pin > 兜底分配（选最轻 cell 并写入 instance pin）
+
+### instance_pin 工具
+
+```bash
+python3 -m kvcm_ops config_server instance_pin --help
+```
+
+#### Cell 管理
+
+```bash
+# 列出 hpnzone 下所有 cell
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a list-cells
+
+# 注册 cell（幂等）
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-cell --cell-url url://kvcm-cell-0
+
+# 注销 cell（必须先清空该 cell 上的 instance pin 和 group pin）
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    unregister-cell --cell-url url://kvcm-cell-0
+```
+
+#### Group Pin 管理
+
+```bash
+# 列出所有 group pin
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a list-group-pins
+
+# 把 groupA 钉到某 cell
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-group-pin --group groupA --cell-url url://kvcm-cell-1
+
+# 迁移 group pin 到另一 cell（仅影响"未自己 pin"的 instance）
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    reassign-group-pin --group groupA --cell-url url://kvcm-cell-2
+
+# 解除 group pin
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    unregister-group-pin --group groupA
+```
+
+#### Instance 管理
+
+```bash
+# 注册 instance（通过 group pin 或兜底分配自动选 cell）
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-instance --instance model-x:dep-007 --group groupA
+
+# 显式指定 cell
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-instance --instance model-x:dep-007 --group groupA \
+    --pin-url url://kvcm-cell-1
+
+# 查询 instance 当前映射到哪个 cell
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    resolve-instance --instance model-x:dep-007 --group groupA
+
+# 迁移 instance 到另一 cell
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    reassign-instance --instance model-x:dep-007 --cell-url url://kvcm-cell-2
+
+# 解除 instance pin（之后退回 group pin 或兜底分配）
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    unregister-instance --instance model-x:dep-007
+```
+
+#### 通用开关
+
+| 开关 | 作用 |
+|---|---|
+| `--url URL`     | ConfigServer HTTP base，默认 `http://127.0.0.1:9101` |
+| `--hpnzone ID`  | 目标 hpnzone_id，必填 |
+| `--timeout SEC` | HTTP 超时，默认 5s |
+| `--dry-run`     | 只打印请求 body，不发送 |
+| `-v / --verbose`| 打印 HTTP 请求细节 |
+
+---
+
+## 典型工作流
+
+### A. 搭建一个 hpnzone
+
+```bash
+# 0. 创建 hpnzone
+python3 -m kvcm_ops config_server create-hpnzone --hpnzone prod_zone_a
+
+# 1. 注册 cell
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-cell --cell-url url://kvcm-cell-0
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-cell --cell-url url://kvcm-cell-1
+
+# 2. 规划 group pin
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-group-pin --group groupA --cell-url url://kvcm-cell-0
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    register-group-pin --group groupB --cell-url url://kvcm-cell-1
+
+# 3. 验证
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a list-cells
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a list-group-pins
+```
+
+### B. instance_pin 迁移
+
+```bash
+# 查看当前状态
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    resolve-instance --instance model-x:dep-007 --group groupA
+
+# 迁移到另一 cell
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    reassign-instance --instance model-x:dep-007 --cell-url url://kvcm-cell-1
+
+# 验证
+python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \
+    resolve-instance --instance model-x:dep-007 --group groupA
+```
+
+### C. 下线 hpnzone
+
+```bash
+# 需先清空所有 instance pin 和 group pin，再注销所有 cell，最后 delete-hpnzone
+python3 -m kvcm_ops config_server delete-hpnzone --hpnzone prod_zone_a
+```

--- a/package/kvcm_ops/config_server/__main__.py
+++ b/package/kvcm_ops/config_server/__main__.py
@@ -1,0 +1,80 @@
+"""ConfigServer ops sub-dispatcher.
+
+Usage:
+    python3 -m kvcm_ops config_server <subcommand> [args...]
+
+Subcommands:
+    hpnzone management:
+        create-hpnzone      Create a new hpnzone
+        delete-hpnzone      Delete an existing hpnzone
+        list-hpnzones       List all hpnzone_ids on the server
+
+    instance_pin mode:
+        instance_pin         Manage cells, group pins, and instance pins
+
+    common:
+        server_capability    Detect server routing mode
+"""
+
+import argparse
+import subprocess
+import sys
+
+COMMANDS = {
+    "instance_pin": "kvcm_ops.config_server.instance_pin",
+    "server_capability": "kvcm_ops.config_server.server_capability",
+}
+
+HPNZONE_COMMANDS = {
+    "create-hpnzone": "create",
+    "delete-hpnzone": "delete",
+    "list-hpnzones": "list",
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="python3 -m kvcm_ops config_server",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    all_cmds = list(HPNZONE_COMMANDS.keys()) + list(COMMANDS.keys())
+    parser.add_argument(
+        "command",
+        nargs="?",
+        help="subcommand name (see above)",
+    )
+    parser.add_argument(
+        "args",
+        nargs=argparse.REMAINDER,
+        help="arguments passed to the subcommand",
+    )
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        print("\nAvailable subcommands:")
+        for name in all_cmds:
+            print(f"  {name}")
+        return 0
+
+    if args.command in HPNZONE_COMMANDS:
+        action = HPNZONE_COMMANDS[args.command]
+        cmd = [sys.executable, "-m", "kvcm_ops.config_server.hpnzone", action] + args.args
+        return subprocess.call(cmd)
+
+    if args.command in COMMANDS:
+        module = COMMANDS[args.command]
+        cmd = [sys.executable, "-m", module] + args.args
+        return subprocess.call(cmd)
+
+    print(f"Unknown subcommand: {args.command}", file=sys.stderr)
+    print("\nAvailable subcommands:")
+    for name in all_cmds:
+        print(f"  {name}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/package/kvcm_ops/config_server/_help.py
+++ b/package/kvcm_ops/config_server/_help.py
@@ -1,0 +1,42 @@
+HELP_MESSAGE = '''
+config_server module (use: python3 -m kvcm_ops config_server <subcommand> ...):
+
+    === hpnzone lifecycle ===
+
+    List all hpnzones:
+        python3 -m kvcm_ops config_server list-hpnzones
+        python3 -m kvcm_ops config_server list-hpnzones --url http://10.0.0.1:9101
+
+    Create a hpnzone:
+        python3 -m kvcm_ops config_server create-hpnzone --hpnzone prod_zone_a
+
+    Delete a hpnzone:
+        python3 -m kvcm_ops config_server delete-hpnzone --hpnzone prod_zone_a
+        python3 -m kvcm_ops config_server delete-hpnzone --hpnzone prod_zone_a --yes
+
+    === common ===
+
+    Detect server routing mode:
+        python3 -m kvcm_ops config_server server_capability
+        python3 -m kvcm_ops config_server server_capability --url http://10.0.0.1:9101 --json
+
+    === instance_pin mode (cell / group pin / instance pin operations) ===
+
+    cell management:
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a list-cells
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a register-cell --cell-url url://kvcm-cell-0
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a unregister-cell --cell-url url://kvcm-cell-0
+
+    group pin management:
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a list-group-pins
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a register-group-pin --group groupA --cell-url url://kvcm-cell-1
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a reassign-group-pin --group groupA --cell-url url://kvcm-cell-2
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a unregister-group-pin --group groupA
+
+    instance management:
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a register-instance --instance model-x:dep-007 --group groupA
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a register-instance --instance model-x:dep-007 --group groupA --pin-url url://kvcm-cell-1
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a resolve-instance --instance model-x:dep-007 --group groupA
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a reassign-instance --instance model-x:dep-007 --cell-url url://kvcm-cell-2
+        python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a unregister-instance --instance model-x:dep-007
+'''

--- a/package/kvcm_ops/config_server/hpnzone.py
+++ b/package/kvcm_ops/config_server/hpnzone.py
@@ -1,0 +1,182 @@
+"""Unified hpnzone lifecycle management (create / delete / list).
+
+Uses the instance_pin HTTP endpoints:
+
+    POST /instancePin/createHpnzone            (body = {trace_id, hpnzone_id})
+    POST /instancePin/deleteHpnzone            (body = {trace_id, hpnzone_id})
+    POST /instancePin/listHpnzones             (body = {trace_id})
+
+Usage:
+    python3 -m kvcm_ops config_server create-hpnzone --hpnzone prod_zone_a
+    python3 -m kvcm_ops config_server delete-hpnzone --hpnzone prod_zone_a [--yes]
+    python3 -m kvcm_ops config_server list-hpnzones
+"""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from ..kvcm.common.http_helper import http_post_text
+
+DEFAULT_URL = "http://127.0.0.1:9101"
+
+
+def _check_response_header(resp_text: str) -> None:
+    """Raise SystemExit if the JSON response body contains a business error code."""
+    try:
+        obj = json.loads(resp_text)
+    except (json.JSONDecodeError, TypeError):
+        return
+    header = obj.get("header") or {}
+    st = header.get("status") or {}
+    code = st.get("code")
+    if code is None:
+        code = "OK"
+    code_str = code if isinstance(code, str) else str(code)
+    if code_str not in ("OK", "1"):
+        msg = st.get("message", "")
+        raise SystemExit(f"[ERROR] server returned {code_str}: {msg}")
+
+
+def cmd_create(args: argparse.Namespace) -> int:
+    if not args.hpnzone:
+        raise SystemExit("[ERROR] --hpnzone is required for create-hpnzone")
+
+    body = {
+        "trace_id": "kvcm_ops/hpnzone/create",
+        "hpnzone_id": args.hpnzone,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/createHpnzone: {json.dumps(body)}")
+        return 0
+    try:
+        status, resp = http_post_text(
+            args.url, "/instancePin/createHpnzone", body,
+            timeout=args.timeout, verbose=args.verbose,
+        )
+    except requests.RequestException as e:
+        raise SystemExit(f"[ERROR] POST /instancePin/createHpnzone failed: {e}")
+    if status != 200:
+        raise SystemExit(f"[ERROR] POST /instancePin/createHpnzone -> HTTP {status}: {resp}")
+    _check_response_header(resp)
+    print(f"[OK] created hpnzone {args.hpnzone!r}: {resp}")
+
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    if not args.hpnzone:
+        raise SystemExit("[ERROR] --hpnzone is required for delete-hpnzone")
+
+    if not args.yes:
+        try:
+            confirm = input(
+                f"Type the hpnzone_id to confirm deletion ({args.hpnzone!r}): "
+            ).strip()
+        except (EOFError, KeyboardInterrupt):
+            raise SystemExit("\n[ABORT] confirmation cancelled")
+        if confirm != args.hpnzone:
+            raise SystemExit(
+                f"[ABORT] confirmation {confirm!r} does not match {args.hpnzone!r}"
+            )
+
+    if args.dry_run:
+        print(f"[dry-run] would delete hpnzone={args.hpnzone!r} on {args.url}")
+        return 0
+
+    body = {
+        "trace_id": "kvcm_ops/hpnzone/delete",
+        "hpnzone_id": args.hpnzone,
+    }
+    try:
+        status, resp = http_post_text(
+            args.url, "/instancePin/deleteHpnzone", body,
+            timeout=args.timeout, verbose=args.verbose,
+        )
+    except requests.RequestException as e:
+        raise SystemExit(f"[ERROR] POST /instancePin/deleteHpnzone failed: {e}")
+    if status != 200:
+        raise SystemExit(f"[ERROR] POST /instancePin/deleteHpnzone -> HTTP {status}: {resp}")
+    _check_response_header(resp)
+    print(f"[OK] deleted hpnzone {args.hpnzone!r}: {resp}")
+
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    req_body = {"trace_id": "kvcm_ops/hpnzone/list"}
+    try:
+        status, resp = http_post_text(
+            args.url, "/instancePin/listHpnzones", req_body,
+            timeout=args.timeout, verbose=args.verbose,
+        )
+    except requests.RequestException as e:
+        raise SystemExit(f"[ERROR] POST /instancePin/listHpnzones failed: {e}")
+    if status != 200:
+        raise SystemExit(f"[ERROR] POST /instancePin/listHpnzones -> HTTP {status}: {resp}")
+    _check_response_header(resp)
+    try:
+        obj = json.loads(resp)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"[ERROR] server returned invalid JSON: {e}\nbody={resp[:512]}")
+    hpnzones = list(obj.get("hpnzone_ids") or obj.get("hpnzoneIds") or [])
+
+    print(f"total: {len(hpnzones)} hpnzone(s)")
+    for h in hpnzones:
+        print(f"  - {h}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--url", default=argparse.SUPPRESS,
+                        help=f"ConfigServer HTTP base URL, default {DEFAULT_URL}")
+    common.add_argument("--hpnzone", default=argparse.SUPPRESS,
+                        help="target hpnzone_id (required for create/delete)")
+    common.add_argument("--timeout", type=float, default=argparse.SUPPRESS,
+                        help="HTTP timeout in seconds, default 5")
+    common.add_argument("--dry-run", action="store_true", default=argparse.SUPPRESS,
+                        help="print what would be done without sending requests")
+    common.add_argument("--verbose", "-v", action="store_true", default=argparse.SUPPRESS,
+                        help="print HTTP request details")
+
+    p = argparse.ArgumentParser(
+        prog="python3 -m kvcm_ops config_server <hpnzone-cmd>",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--url", default=DEFAULT_URL,
+                   help=f"ConfigServer HTTP base URL, default {DEFAULT_URL}")
+    p.add_argument("--hpnzone", default="",
+                   help="target hpnzone_id (required for create/delete)")
+    p.add_argument("--timeout", type=float, default=5.0,
+                   help="HTTP timeout in seconds, default 5")
+    p.add_argument("--dry-run", action="store_true",
+                   help="print what would be done without sending requests")
+    p.add_argument("--verbose", "-v", action="store_true",
+                   help="print HTTP request details")
+    sub = p.add_subparsers(dest="action", required=True)
+
+    sp_create = sub.add_parser("create", parents=[common], help="create a new hpnzone")
+    sp_create.set_defaults(func=cmd_create)
+
+    sp_delete = sub.add_parser("delete", parents=[common], help="delete an existing hpnzone")
+    sp_delete.add_argument("--yes", "-y", action="store_true",
+                           help="skip the interactive confirmation prompt")
+    sp_delete.set_defaults(func=cmd_delete)
+
+    sp_list = sub.add_parser("list", parents=[common], help="list all hpnzone_ids on the server")
+    sp_list.set_defaults(func=cmd_list)
+
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/package/kvcm_ops/config_server/instance_pin.py
+++ b/package/kvcm_ops/config_server/instance_pin.py
@@ -1,0 +1,387 @@
+"""Manage cells, group pins, and instance pins on a ConfigServer running in instance_pin mode.
+
+In instance_pin mode, routing is an explicit mapping table rather than hash-based:
+    hpnzone -> cells (service discovery URLs) -> instances (pinned to a cell)
+    instance_group -> cell (group-level pin, lower priority than instance pin)
+
+All operations go through the ConfigServer HTTP interface (default port 9101).
+Every subcommand except the listing ones requires --hpnzone.
+
+Subcommands — cell management:
+    list-cells           List all cells registered in a hpnzone
+    register-cell        Register a cell (service discovery URL) in a hpnzone
+    unregister-cell      Unregister a cell (must have no instance pins or group pins)
+
+Subcommands — group pin management:
+    list-group-pins      List all group pins in a hpnzone
+    register-group-pin   Pin an instance_group to a cell
+    reassign-group-pin   Move a group pin to a different cell
+    unregister-group-pin Remove a group pin
+
+Subcommands — instance management:
+    register-instance    Register an instance (optionally pin to a specific cell)
+    resolve-instance     Resolve which cell an instance maps to
+    reassign-instance    Move an instance pin to a different cell
+    unregister-instance  Remove an instance pin
+
+Examples:
+    # List cells in hpnzone "prod_zone_a"
+    python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a list-cells
+
+    # Register a cell
+    python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \\
+        register-cell --cell-url url://kvcm-cell-0
+
+    # Pin group "groupA" to a cell
+    python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \\
+        register-group-pin --group groupA --cell-url url://kvcm-cell-1
+
+    # Register an instance (auto-resolve via group pin / fallback)
+    python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \\
+        register-instance --instance model-x:dep-007 --group groupA
+
+    # Resolve an instance to see which cell it maps to
+    python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \\
+        resolve-instance --instance model-x:dep-007 --group groupA
+
+    # Reassign an instance to a different cell
+    python3 -m kvcm_ops config_server instance_pin --hpnzone prod_zone_a \\
+        reassign-instance --instance model-x:dep-007 --cell-url url://kvcm-cell-2
+"""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from ..kvcm.common.http_helper import http_post_text
+
+DEFAULT_URL = "http://127.0.0.1:9101"
+
+PIN_SOURCE_NAMES = {
+    0: "UNSPECIFIED",
+    1: "INSTANCE_PIN",
+    2: "GROUP_PIN",
+    3: "FALLBACK_NEW",
+    "PIN_SOURCE_UNSPECIFIED": "UNSPECIFIED",
+    "PIN_SOURCE_INSTANCE_PIN": "INSTANCE_PIN",
+    "PIN_SOURCE_GROUP_PIN": "GROUP_PIN",
+    "PIN_SOURCE_FALLBACK_NEW": "FALLBACK_NEW",
+}
+
+
+def require_hpnzone(args: argparse.Namespace) -> str:
+    if not args.hpnzone:
+        raise SystemExit("[ERROR] this subcommand requires the global --hpnzone HPNZONE_ID")
+    return args.hpnzone
+
+
+def _post(url: str, api: str, body: dict, timeout: float, verbose: bool) -> dict:
+    """POST JSON and return parsed response; raise SystemExit on HTTP or JSON errors."""
+    try:
+        status, resp_text = http_post_text(
+            url, api, body, timeout=timeout, verbose=verbose,
+        )
+    except requests.RequestException as e:
+        raise SystemExit(f"[ERROR] POST {url}{api} failed: {e}")
+    if status != 200:
+        raise SystemExit(f"[ERROR] POST {url}{api} -> HTTP {status}: {resp_text[:512]}")
+    try:
+        obj = json.loads(resp_text)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"[ERROR] server returned invalid JSON: {e}\nbody={resp_text[:512]}")
+    header = obj.get("header") or {}
+    st = header.get("status") or {}
+    code = st.get("code")
+    if code is None:
+        code = "OK"
+    code_str = code if isinstance(code, str) else str(code)
+    if code_str not in ("OK", "1"):
+        msg = st.get("message", "")
+        raise SystemExit(f"[ERROR] server returned {code_str}: {msg}")
+    return obj
+
+
+def normalize_source(raw) -> str:
+    if isinstance(raw, int):
+        return PIN_SOURCE_NAMES.get(raw, f"UNKNOWN({raw})")
+    if isinstance(raw, str):
+        return PIN_SOURCE_NAMES.get(raw, raw)
+    return str(raw)
+
+
+# ===== cell subcommands =====
+
+def cmd_list_cells(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {"trace_id": "kvcm_ops/instance_pin/list-cells", "hpnzone_id": hpnzone}
+    result = _post(args.url, "/instancePin/listCells", body, args.timeout, args.verbose)
+    cells = result.get("cells") or []
+    print(f"hpnzone {hpnzone!r}: {len(cells)} cell(s)")
+    for c in cells:
+        cell_url = c.get("cellUrl") or c.get("cell_url", "")
+        pin_count = c.get("instancePinCount") or c.get("instance_pin_count", 0)
+        group_refs = c.get("groupPinBackRefs") or c.get("group_pin_back_refs") or []
+        groups_str = ", ".join(group_refs) if group_refs else "(none)"
+        print(f"  {cell_url}  instances={pin_count}  group_pins=[{groups_str}]")
+    return 0
+
+
+def cmd_register_cell(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/register-cell",
+        "hpnzone_id": hpnzone,
+        "cell_url": args.cell_url,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/registerCell: {json.dumps(body)}")
+        return 0
+    _post(args.url, "/instancePin/registerCell", body, args.timeout, args.verbose)
+    print(f"[OK] registered cell {args.cell_url!r} in hpnzone {hpnzone!r}")
+    return 0
+
+
+def cmd_unregister_cell(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/unregister-cell",
+        "hpnzone_id": hpnzone,
+        "cell_url": args.cell_url,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/unregisterCell: {json.dumps(body)}")
+        return 0
+    _post(args.url, "/instancePin/unregisterCell", body, args.timeout, args.verbose)
+    print(f"[OK] unregistered cell {args.cell_url!r} from hpnzone {hpnzone!r}")
+    return 0
+
+
+# ===== group pin subcommands =====
+
+def cmd_list_group_pins(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {"trace_id": "kvcm_ops/instance_pin/list-group-pins", "hpnzone_id": hpnzone}
+    result = _post(args.url, "/instancePin/listGroupPins", body, args.timeout, args.verbose)
+    pins = result.get("groupPins") or result.get("group_pins") or []
+    print(f"hpnzone {hpnzone!r}: {len(pins)} group pin(s)")
+    for p in pins:
+        group = p.get("instanceGroup") or p.get("instance_group", "")
+        cell = p.get("cellUrl") or p.get("cell_url", "")
+        print(f"  {group} -> {cell}")
+    return 0
+
+
+def cmd_register_group_pin(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/register-group-pin",
+        "hpnzone_id": hpnzone,
+        "instance_group": args.group,
+        "cell_url": args.cell_url,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/registerGroupPin: {json.dumps(body)}")
+        return 0
+    _post(args.url, "/instancePin/registerGroupPin", body, args.timeout, args.verbose)
+    print(f"[OK] pinned group {args.group!r} -> {args.cell_url!r} in hpnzone {hpnzone!r}")
+    return 0
+
+
+def cmd_reassign_group_pin(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/reassign-group-pin",
+        "hpnzone_id": hpnzone,
+        "instance_group": args.group,
+        "new_cell_url": args.cell_url,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/reassignGroupPin: {json.dumps(body)}")
+        return 0
+    _post(args.url, "/instancePin/reassignGroupPin", body, args.timeout, args.verbose)
+    print(f"[OK] reassigned group {args.group!r} -> {args.cell_url!r} in hpnzone {hpnzone!r}")
+    return 0
+
+
+def cmd_unregister_group_pin(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/unregister-group-pin",
+        "hpnzone_id": hpnzone,
+        "instance_group": args.group,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/unregisterGroupPin: {json.dumps(body)}")
+        return 0
+    _post(args.url, "/instancePin/unregisterGroupPin", body, args.timeout, args.verbose)
+    print(f"[OK] unpinned group {args.group!r} in hpnzone {hpnzone!r}")
+    return 0
+
+
+# ===== instance subcommands =====
+
+def cmd_register_instance(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/register-instance",
+        "hpnzone_id": hpnzone,
+        "instance_id": args.instance,
+        "instance_group": args.group or "",
+    }
+    if args.pin_url:
+        body["pin_url"] = args.pin_url
+    if not body["instance_group"] and not args.pin_url:
+        raise SystemExit("[ERROR] --group is required when --pin-url is not specified")
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/registerInstance: {json.dumps(body)}")
+        return 0
+    result = _post(args.url, "/instancePin/registerInstance", body, args.timeout, args.verbose)
+    cell = result.get("cellUrl") or result.get("cell_url", "N/A")
+    source = normalize_source(result.get("source", 0))
+    epoch = result.get("mappingEpoch") or result.get("mapping_epoch", "N/A")
+    print(f"[OK] instance {args.instance!r} -> {cell}")
+    print(f"     source={source}  mapping_epoch={epoch}")
+    return 0
+
+
+def cmd_resolve_instance(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/resolve-instance",
+        "hpnzone_id": hpnzone,
+        "instance_id": args.instance,
+        "instance_group": args.group,
+    }
+    result = _post(args.url, "/instancePin/resolveInstance", body, args.timeout, args.verbose)
+    cell = result.get("cellUrl") or result.get("cell_url", "N/A")
+    source = normalize_source(result.get("source", 0))
+    epoch = result.get("mappingEpoch") or result.get("mapping_epoch", "N/A")
+    print(f"instance {args.instance!r} -> {cell}")
+    print(f"  source={source}  mapping_epoch={epoch}")
+    return 0
+
+
+def cmd_reassign_instance(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/reassign-instance",
+        "hpnzone_id": hpnzone,
+        "instance_id": args.instance,
+        "new_cell_url": args.cell_url,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/reassignInstance: {json.dumps(body)}")
+        return 0
+    _post(args.url, "/instancePin/reassignInstance", body, args.timeout, args.verbose)
+    print(f"[OK] reassigned instance {args.instance!r} -> {args.cell_url!r} in hpnzone {hpnzone!r}")
+    return 0
+
+
+def cmd_unregister_instance(args: argparse.Namespace) -> int:
+    hpnzone = require_hpnzone(args)
+    body = {
+        "trace_id": "kvcm_ops/instance_pin/unregister-instance",
+        "hpnzone_id": hpnzone,
+        "instance_id": args.instance,
+    }
+    if args.dry_run:
+        print(f"[dry-run] would POST /instancePin/unregisterInstance: {json.dumps(body)}")
+        return 0
+    _post(args.url, "/instancePin/unregisterInstance", body, args.timeout, args.verbose)
+    print(f"[OK] unregistered instance {args.instance!r} from hpnzone {hpnzone!r}")
+    return 0
+
+
+# ===== parser =====
+
+def build_parser() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--url", default=argparse.SUPPRESS,
+                        help=f"ConfigServer HTTP base URL, default {DEFAULT_URL}")
+    common.add_argument("--hpnzone", default=argparse.SUPPRESS,
+                        help="target hpnzone_id; required by every subcommand")
+    common.add_argument("--timeout", type=float, default=argparse.SUPPRESS,
+                        help="HTTP timeout in seconds, default 5")
+    common.add_argument("--dry-run", action="store_true", default=argparse.SUPPRESS,
+                        help="print the request body without sending")
+    common.add_argument("--verbose", "-v", action="store_true", default=argparse.SUPPRESS,
+                        help="print HTTP request details")
+
+    p = argparse.ArgumentParser(
+        prog="python3 -m kvcm_ops config_server instance_pin",
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--url", default=DEFAULT_URL,
+                   help=f"ConfigServer HTTP base URL, default {DEFAULT_URL}")
+    p.add_argument("--hpnzone", default="",
+                   help="target hpnzone_id; required by every subcommand")
+    p.add_argument("--timeout", type=float, default=5.0, help="HTTP timeout in seconds, default 5")
+    p.add_argument("--dry-run", action="store_true", help="print the request body without sending")
+    p.add_argument("--verbose", "-v", action="store_true", help="print HTTP request details")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # ----- cell -----
+    sp = sub.add_parser("list-cells", parents=[common], help="list all cells in a hpnzone")
+    sp.set_defaults(func=cmd_list_cells)
+
+    sp = sub.add_parser("register-cell", parents=[common], help="register a cell (service discovery URL)")
+    sp.add_argument("--cell-url", required=True, help="cell service discovery URL")
+    sp.set_defaults(func=cmd_register_cell)
+
+    sp = sub.add_parser("unregister-cell", parents=[common],
+                        help="unregister a cell (fails if it still has instance pins or group pins)")
+    sp.add_argument("--cell-url", required=True, help="cell service discovery URL")
+    sp.set_defaults(func=cmd_unregister_cell)
+
+    # ----- group pin -----
+    sp = sub.add_parser("list-group-pins", parents=[common], help="list all group pins in a hpnzone")
+    sp.set_defaults(func=cmd_list_group_pins)
+
+    sp = sub.add_parser("register-group-pin", parents=[common], help="pin an instance_group to a cell")
+    sp.add_argument("--group", required=True, help="instance_group name")
+    sp.add_argument("--cell-url", required=True, help="target cell URL")
+    sp.set_defaults(func=cmd_register_group_pin)
+
+    sp = sub.add_parser("reassign-group-pin", parents=[common], help="move a group pin to a different cell")
+    sp.add_argument("--group", required=True, help="instance_group name")
+    sp.add_argument("--cell-url", required=True, help="new target cell URL")
+    sp.set_defaults(func=cmd_reassign_group_pin)
+
+    sp = sub.add_parser("unregister-group-pin", parents=[common], help="remove a group pin")
+    sp.add_argument("--group", required=True, help="instance_group name")
+    sp.set_defaults(func=cmd_unregister_group_pin)
+
+    # ----- instance -----
+    sp = sub.add_parser("register-instance", parents=[common],
+                        help="register an instance; resolves to a cell via group pin or fallback")
+    sp.add_argument("--instance", required=True, help="instance_id")
+    sp.add_argument("--group", help="instance_group (required unless --pin-url is set)")
+    sp.add_argument("--pin-url", help="explicit cell URL to pin to (bypasses group pin / fallback)")
+    sp.set_defaults(func=cmd_register_instance)
+
+    sp = sub.add_parser("resolve-instance", parents=[common], help="resolve which cell an instance maps to")
+    sp.add_argument("--instance", required=True, help="instance_id")
+    sp.add_argument("--group", required=True, help="instance_group (needed for group pin fallback)")
+    sp.set_defaults(func=cmd_resolve_instance)
+
+    sp = sub.add_parser("reassign-instance", parents=[common], help="move an instance pin to a different cell")
+    sp.add_argument("--instance", required=True, help="instance_id")
+    sp.add_argument("--cell-url", required=True, help="new target cell URL")
+    sp.set_defaults(func=cmd_reassign_instance)
+
+    sp = sub.add_parser("unregister-instance", parents=[common], help="remove an instance pin")
+    sp.add_argument("--instance", required=True, help="instance_id")
+    sp.set_defaults(func=cmd_unregister_instance)
+
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/package/kvcm_ops/config_server/server_capability.py
+++ b/package/kvcm_ops/config_server/server_capability.py
@@ -1,0 +1,84 @@
+"""Detect the routing mode of a running ConfigServer.
+
+Calls POST /serverCapability/getServerCapability to discover whether the
+server is running in hash_bucket or instance_pin mode.
+
+Usage:
+    python3 -m kvcm_ops config_server server_capability
+    python3 -m kvcm_ops config_server server_capability --url http://10.0.0.1:9101
+    python3 -m kvcm_ops config_server server_capability --url http://10.0.0.1:9101 --json
+"""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from ..kvcm.common.http_helper import http_post_text
+
+DEFAULT_URL = "http://127.0.0.1:9101"
+
+ROUTING_MODE_NAMES = {
+    0: "UNSPECIFIED",
+    1: "HASH_BUCKET",
+    2: "INSTANCE_PIN",
+    "ROUTING_MODE_UNSPECIFIED": "UNSPECIFIED",
+    "ROUTING_MODE_HASH_BUCKET": "HASH_BUCKET",
+    "ROUTING_MODE_INSTANCE_PIN": "INSTANCE_PIN",
+}
+
+
+def detect_mode(url: str, timeout: float, verbose: bool) -> dict:
+    body = {"trace_id": "kvcm_ops/server_capability"}
+    status, resp = http_post_text(
+        url, "/serverCapability/getServerCapability", body,
+        timeout=timeout, verbose=verbose,
+    )
+    if status != 200:
+        raise SystemExit(f"[ERROR] POST /serverCapability/getServerCapability -> HTTP {status}: {resp[:512]}")
+    try:
+        return json.loads(resp)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"[ERROR] server returned invalid JSON: {e}\nbody={resp[:512]}")
+
+
+def normalize_mode(raw) -> str:
+    if isinstance(raw, int):
+        return ROUTING_MODE_NAMES.get(raw, f"UNKNOWN({raw})")
+    if isinstance(raw, str):
+        return ROUTING_MODE_NAMES.get(raw, raw)
+    return str(raw)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="python3 -m kvcm_ops config_server server_capability",
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--url", default=DEFAULT_URL,
+                   help=f"ConfigServer HTTP base URL, default {DEFAULT_URL}")
+    p.add_argument("--timeout", type=float, default=5.0, help="HTTP timeout in seconds, default 5")
+    p.add_argument("--verbose", "-v", action="store_true", help="print HTTP request details")
+    p.add_argument("--json", action="store_true", help="print raw JSON response")
+    args = p.parse_args()
+
+    try:
+        result = detect_mode(args.url, args.timeout, args.verbose)
+    except requests.RequestException as e:
+        raise SystemExit(f"[ERROR] failed to connect to {args.url}: {e}")
+
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    mode_raw = result.get("mode") or result.get("routing_mode", "UNKNOWN")
+    mode = normalize_mode(mode_raw)
+    version = result.get("serverVersion") or result.get("server_version", "N/A")
+    print(f"routing_mode   = {mode}")
+    print(f"server_version = {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/package/kvcm_ops/kvcm/common/http_helper.py
+++ b/package/kvcm_ops/kvcm/common/http_helper.py
@@ -31,5 +31,48 @@ def http_post(host: str, api: str, data: dict, verbose = False) -> dict:
     if response.status_code != 200:
         print(f"error status code : {response.status_code}")
         raise RuntimeError(f"error status code : {response.status_code}")
-    
+
     return json.loads(response.text)
+
+def http_get_text(host: str, api: str, timeout: float = 5.0, verbose: bool = False) -> str:
+    """GET and return the raw response body text; non-200 raises RuntimeError (with body excerpt).
+
+    Unlike http_post, this does not force JSON parsing; the caller decides how to handle the body.
+    """
+    host_url = host + api
+    if verbose:
+        print("===========================================")
+        print(f"GET {host_url}")
+    response = requests.get(host_url, timeout=timeout)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"GET {host_url} -> HTTP {response.status_code}: {response.text[:512]}"
+        )
+    return response.text
+
+
+def http_post_text(host: str, api: str, body, timeout: float = 5.0,
+                   verbose: bool = False) -> tuple[int, str]:
+    """POST and return (status_code, response_text); the caller decides success/failure.
+
+    body can be a dict/list (will be json.dumps'd) or an already-serialized str.
+    Unlike http_post, this does not force status==200 and does not parse JSON ——
+    suitable when the server returns non-JSON text or when error bodies need to be inspected.
+    """
+    host_url = host + api
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    if isinstance(body, (dict, list)):
+        payload = json.dumps(body, ensure_ascii=False)
+    else:
+        payload = body
+    if verbose:
+        print("===========================================")
+        print(f"POST {host_url}")
+        print(payload)
+    response = requests.post(
+        host_url, data=payload.encode("utf-8"), headers=headers, timeout=timeout
+    )
+    return response.status_code, response.text


### PR DESCRIPTION
## Context
KVCM is currently a standalone application; to enable its use in a distributed environment, the `configserver` component is being introduced. Consequently, its associated operations and maintenance tools are being integrated into the `kvcm_ops` module.

Here is the polished English version, formatted specifically for a Pull Request (PR) description. I have adjusted the tone to be more professional and structured it for better readability.

---

## Detail

This PR introduces/updates the `kvcm_ops` toolkit for managing the **ConfigServer Routing Table**. It consists of three subcommands, each designed for specific operational scenarios:

| Subcommand | Mode | Description |
| :--- | :--- | :--- |
| `gen_routing_table` | **Offline** <br>(Local JSON) | **Initial Deployment**: An interactive CLI tool to generate a `routing_table.json` file from scratch. |
| `set_routing_table` | **Online** <br>(HTTP API) | **Runtime Management**: Allows viewing, partially updating, or fully replacing the active routing table via the ConfigServer HTTP API. |
| `decode_routing_table` | **Online/Offline** | **Debugging & Inspection**: Decodes the `compressed_ip_list` from the `GetRoutingTable` RPC response. It converts Base64-encoded data back into a readable `replica × bucket` IP matrix. |
