### PR TITLE
fix: eliminate data race on GrpcStub::next_stub_

### DIFF
--- a/kv_cache_manager/client/src/internal/stub/grpc_stub.cc
+++ b/kv_cache_manager/client/src/internal/stub/grpc_stub.cc
@@ -487,7 +487,7 @@ std::shared_ptr<proto::meta::MetaService::Stub> GrpcStub::GetStub() const {
     if (stubs_.empty()) {
         return nullptr;
     }
-    size_t current_stub = (next_stub_++) % stubs_.size();
+    size_t current_stub = next_stub_.fetch_add(1, std::memory_order_relaxed) % stubs_.size();
     return stubs_[current_stub];
 }
 

--- a/kv_cache_manager/client/src/internal/stub/grpc_stub.h
+++ b/kv_cache_manager/client/src/internal/stub/grpc_stub.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <deque>
 #include <shared_mutex>
 
@@ -82,7 +83,7 @@ private:
     mutable std::shared_mutex stubs_mutex_;
     // TODO : add stub proxy to manage stub
     std::deque<std::shared_ptr<proto::meta::MetaService::Stub>> stubs_;
-    mutable size_t next_stub_ = 0;
+    mutable std::atomic<size_t> next_stub_{0};
 };
 
 } // namespace kv_cache_manager


### PR DESCRIPTION
## Summary

- Fix undefined behavior: `next_stub_` (plain `size_t`) was incremented under `shared_lock` by multiple threads concurrently
- Change to `std::atomic<size_t>` with `fetch_add(1, memory_order_relaxed)`

## Changes

| Changed | Not changed |
|---------|-------------|
| `grpc_stub.h`: add `#include <atomic>`, type → `std::atomic<size_t>` | `RemoveAllConnections` does not reset counter (not a correctness issue) |
| `grpc_stub.cc`: `++` → `fetch_add(relaxed)` | No concurrent test added (separate follow-up) |

## Why relaxed ordering is sufficient

`next_stub_` is only used for round-robin stub selection, no ordering dependencies. `stubs_` access is protected by `shared_lock(stubs_mutex_)` which provides necessary happens-before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)