### PR TITLE
fix: implement real health check, fix last_loop_time_ data race

### DIFF
--- a/kv_cache_manager/config/leader_elector.cc
+++ b/kv_cache_manager/config/leader_elector.cc
@@ -105,10 +105,11 @@ bool LeaderElector::WorkLoop() {
 
 void LeaderElector::DoWorkLoop(int64_t current_time) {
     int64_t begin_time = TimestampUtil::GetCurrentTimeUs();
-    if (begin_time - last_loop_time_ < 0 || (begin_time - last_loop_time_ > loop_interval_us_ * 2)) {
-        KVCM_LOG_WARN("LeaderElector workloop begin timeout, current[%ld] last[%ld]", begin_time, last_loop_time_);
+    int64_t prev_loop_time = last_loop_time_.load(std::memory_order_relaxed);
+    if (begin_time - prev_loop_time < 0 || (begin_time - prev_loop_time > loop_interval_us_ * 2)) {
+        KVCM_LOG_WARN("LeaderElector workloop begin timeout, current[%ld] last[%ld]", begin_time, prev_loop_time);
     }
-    last_loop_time_ = begin_time;
+    last_loop_time_.store(begin_time, std::memory_order_relaxed);
 
     if (!lock_acquired_.load()) {
         CampaignLeader(current_time);
@@ -534,7 +535,9 @@ void LeaderElector::SetForbidCampaignLeaderTimeMs(int64_t forbid_time) { forbid_
 
 int64_t LeaderElector::GetForbidCampaignLeaderTimeMs() const { return forbid_campaign_time_ms_; }
 
-int64_t LeaderElector::GetLastLoopTimeUs() const { return last_loop_time_; }
+int64_t LeaderElector::GetLastLoopTimeUs() const { return last_loop_time_.load(std::memory_order_relaxed); }
+
+int64_t LeaderElector::GetLoopIntervalUs() const { return loop_interval_us_; }
 
 std::string LeaderElector::GetLeaderNodeID() const {
     std::unique_lock guard(current_lock_holder_mutex_);

--- a/kv_cache_manager/config/leader_elector.h
+++ b/kv_cache_manager/config/leader_elector.h
@@ -80,6 +80,7 @@ public:
     void SetForbidCampaignLeaderTimeMs(int64_t forbid_time);
     int64_t GetForbidCampaignLeaderTimeMs() const;
     int64_t GetLastLoopTimeUs() const;
+    int64_t GetLoopIntervalUs() const;
     static const char *RoleStateToString(const RoleState state);
 
 private:
@@ -137,7 +138,7 @@ private:
     std::unique_ptr<std::thread> state_transition_thread_; // 状态转换线程
 
     std::atomic<bool> stop_flag_{false};
-    int64_t last_loop_time_ = -1;
+    std::atomic<int64_t> last_loop_time_{-1};
 
     // === 回调函数 ===
     HandlerFuncType become_leader_handler_;

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/service/admin_service_impl.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -846,8 +847,22 @@ void AdminServiceImpl::CheckHealth(RequestContext *request_context,
     }
 
     response->set_is_leader(leader_elector_->IsLeader());
-    response->set_is_health(true); // TODO: 实现健康检查逻辑，如IOHang探测、elector长时间不loop等
-    response->set_elector_last_loop_time_ms(leader_elector_->GetLastLoopTimeUs() / 1000);
+    int64_t last_loop_us = leader_elector_->GetLastLoopTimeUs();
+    response->set_elector_last_loop_time_ms(last_loop_us / 1000);
+
+    bool is_healthy = true;
+    if (last_loop_us > 0) {
+        int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+        int64_t staleness_threshold_us = std::max(leader_elector_->GetLoopIntervalUs() * 100,
+                                                  static_cast<int64_t>(2000000));
+        if (now_us - last_loop_us > staleness_threshold_us) {
+            is_healthy = false;
+            KVCM_LOG_WARN("[traceId: %s] CheckHealth: elector loop stale, last_loop=%ldus ago, threshold=%ldus",
+                          request->trace_id().c_str(), now_us - last_loop_us, staleness_threshold_us);
+        }
+    }
+
+    response->set_is_health(is_healthy);
 
     status->set_code(proto::admin::OK);
     request_context->set_status_code(status->code());


### PR DESCRIPTION
## Summary

- `CheckHealth` previously always returned `is_health=true` (stub)
- Now detects elector loop staleness: >2s without update → unhealthy
- Fixes pre-existing data race: `last_loop_time_` was plain `int64_t` written by WorkLoop thread, read by RPC threads

## Changes

| File | Change | Why |
|------|--------|-----|
| `leader_elector.h` | `last_loop_time_` → `std::atomic<int64_t>`, add `GetLoopIntervalUs()` | Fix data race; health check needs interval for threshold |
| `leader_elector.cc` | All `last_loop_time_` access → atomic load/store | Match atomic type |
| `admin_service_impl.cc` | Replace `set_is_health(true)` with staleness detection | LB/K8s probe can detect failures |

## Threshold design

`max(loop_interval * 100, 2_000_000us)` = at least 2 seconds. Avoids NTP slew and scheduling jitter false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)