### PR TITLE
[metrics] Add GetCacheLocation block-level hit rate counters

### DIFF
--- a/docs/prometheus-en_US.md
+++ b/docs/prometheus-en_US.md
@@ -24,8 +24,12 @@ Then query metrics with PromQL:
 # Service QPS (rate over 1 minute)
 rate(kvcm_service_query_counter[1m])
 
-# Cache hit ratio
+# Search cache hit ratio
 kvcm_meta_indexer_search_cache_hit_ratio
+
+# GetCacheLocation block-level hit rate (5-minute window)
+rate(kvcm_manager_get_cache_location_hit_block_counter[5m])
+  / rate(kvcm_manager_get_cache_location_query_block_counter[5m])
 
 # Storage usage per backend
 kvcm_data_storage_storage_usage_ratio
@@ -125,6 +129,8 @@ every `kvcm.metrics.report_interval_ms`, default 20s).
 | `service.request_queue_size` | gauge | Request queue size |
 | `manager.request_key_count` | gauge | Keys per request |
 | `manager.prefix_match_len` | gauge | Prefix match length |
+| `manager.get_cache_location_query_block_counter` | counter | Total blocks queried via GetCacheLocation (cumulative) |
+| `manager.get_cache_location_hit_block_counter` | counter | Total blocks hit via GetCacheLocation (cumulative) |
 | `manager.prefix_match_time_us` | gauge | Prefix match latency (us) |
 | `meta_indexer.search_cache_hit_ratio` | gauge | Search cache hit ratio |
 | `data_storage.create_keys_counter` | counter | Total created keys |

--- a/docs/prometheus-zh_CN.md
+++ b/docs/prometheus-zh_CN.md
@@ -23,8 +23,12 @@ scrape_configs:
 # 服务 QPS（1 分钟速率）
 rate(kvcm_service_query_counter[1m])
 
-# 缓存命中率
+# 搜索缓存命中率
 kvcm_meta_indexer_search_cache_hit_ratio
+
+# GetCacheLocation Block 级命中率（5 分钟窗口）
+rate(kvcm_manager_get_cache_location_hit_block_counter[5m])
+  / rate(kvcm_manager_get_cache_location_query_block_counter[5m])
 
 # 每个后端的存储使用率
 kvcm_data_storage_storage_usage_ratio
@@ -122,6 +126,8 @@ kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="store_02"} 0.3
 | `service.request_queue_size` | gauge | 请求队列大小 |
 | `manager.request_key_count` | gauge | 每次请求的 key 数量 |
 | `manager.prefix_match_len` | gauge | 前缀匹配长度 |
+| `manager.get_cache_location_query_block_counter` | counter | GetCacheLocation 查询的 Block 总数（累计） |
+| `manager.get_cache_location_hit_block_counter` | counter | GetCacheLocation 命中的 Block 总数（累计） |
 | `manager.prefix_match_time_us` | gauge | 前缀匹配延迟（微秒） |
 | `meta_indexer.search_cache_hit_ratio` | gauge | 搜索缓存命中率 |
 | `data_storage.create_keys_counter` | counter | 已创建 key 总数 |

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -378,6 +378,27 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
                                    cache_locations);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ManagerPrefixMatch);
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, prefix_match_len, cache_locations.size());
+    // accumulate hit/query block counters for hit-rate monitoring
+    if (service_metrics_collector) {
+        size_t query_count = query_keys.size();
+        size_t hit_count = 0;
+        if (query_type == QueryType::QT_PREFIX_MATCH) {
+            // PrefixMatch only returns matched blocks; size() == hit count
+            hit_count = cache_locations.size();
+        } else {
+            // BatchGet / ReverseRollSW pad misses with empty CacheLocation
+            for (const auto &loc : cache_locations) {
+                if (loc && !loc->id().empty()) {
+                    ++hit_count;
+                }
+            }
+        }
+        Counter query_counter, hit_counter;
+        COPY_METRICS_(service_metrics_collector, manager, get_cache_location_query_block_counter, query_counter);
+        COPY_METRICS_(service_metrics_collector, manager, get_cache_location_hit_block_counter, hit_counter);
+        query_counter += query_count;
+        hit_counter += hit_count;
+    }
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, CacheLocationViewVecWrapper, "get cache location failed");
     FilterLocationSpecByName(cache_locations, location_spec_names);
 
@@ -1141,7 +1162,9 @@ bool ParseInt64(const std::string &s, int64_t &out) {
         }
         out = v;
         return true;
-    } catch (...) { return false; }
+    } catch (...) {
+        return false;
+    }
 }
 
 std::shared_ptr<VineyardBackend> LookupVineyardBackend(const std::shared_ptr<RegistryManager> &registry_manager,

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -378,7 +378,8 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
                                    cache_locations);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ManagerPrefixMatch);
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, prefix_match_len, cache_locations.size());
-    // accumulate hit/query block counters for hit-rate monitoring
+    RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, CacheLocationViewVecWrapper, "get cache location failed");
+    // accumulate hit/query block counters for hit-rate monitoring (only on success)
     if (service_metrics_collector) {
         size_t query_count = query_keys.size();
         size_t hit_count = 0;
@@ -399,7 +400,6 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
         query_counter += query_count;
         hit_counter += hit_count;
     }
-    RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, CacheLocationViewVecWrapper, "get cache location failed");
     FilterLocationSpecByName(cache_locations, location_spec_names);
 
     auto cache_get_event = std::make_shared<CacheGetEvent>(instance_id);

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -22,6 +22,7 @@
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
+#include "kv_cache_manager/metrics/metrics_collector.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
 namespace {
@@ -101,7 +102,8 @@ public:
     void TearDown() override {}
 
     std::unique_ptr<CacheManager> createCacheManager() {
-        std::shared_ptr<MetricsRegistry> metrics_registry = std::make_shared<MetricsRegistry>();
+        metrics_registry_ = std::make_shared<MetricsRegistry>();
+        std::shared_ptr<MetricsRegistry> &metrics_registry = metrics_registry_;
         registry_manager_ = std::make_shared<RegistryManager>("", metrics_registry);
         std::shared_ptr<InstanceGroup> instance_group = std::make_shared<InstanceGroup>();
         auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();
@@ -173,6 +175,7 @@ public:
     std::unique_ptr<CacheManager> cache_manager_;
     std::shared_ptr<RegistryManager> registry_manager_;
     std::shared_ptr<RequestContext> request_context_;
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
 };
 
 TEST_F(CacheManagerTest, TestRegisterInstance) {
@@ -607,6 +610,72 @@ TEST_F(CacheManagerTest, TestGetCacheLocationPrefixMatch) {
             ASSERT_EQ(3, cache_location_view.location_specs().size());
         }
     }
+}
+
+TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters) {
+    auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    ASSERT_EQ(expected,
+              cache_manager_->RegisterInstance(request_context_.get(),
+                                               "default",
+                                               "test_instance",
+                                               64,
+                                               createLocationSpecInfos(),
+                                               createModelDeployment(),
+                                               std::vector<LocationSpecGroup>()));
+
+    // Write blocks {1, 2, 3}
+    std::vector<int64_t> write_keys{1, 2, 3};
+    auto [ec1, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", write_keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, ec1);
+    BlockMask finish_mask = static_cast<size_t>(3); // all 3 blocks succeeded (offset semantics)
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), finish_mask));
+
+    // Create a RequestContext with a ServiceMetricsCollector so counters get incremented
+    auto svc_collector = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
+    ASSERT_TRUE(svc_collector->Init());
+    auto metrics_ctx = std::make_unique<RequestContext>("hit_rate_test", svc_collector);
+
+    // Query 1: PrefixMatch with keys {1, 2, 4} → hits {1, 2}, miss at 4
+    {
+        std::vector<int64_t> query_keys{1, 2, 4};
+        BlockMask block_mask = static_cast<size_t>(0);
+        auto [ec, result] = cache_manager_->GetCacheLocation(metrics_ctx.get(),
+                                                             "test_instance",
+                                                             CacheManager::QueryType::QT_PREFIX_MATCH,
+                                                             query_keys,
+                                                             {},
+                                                             block_mask,
+                                                             0,
+                                                             {});
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(2u, result.cache_locations_view().size()); // 2 hits
+    }
+
+    // Query 2: PrefixMatch with keys {1, 2, 3} → all 3 hit
+    {
+        std::vector<int64_t> query_keys{1, 2, 3};
+        BlockMask block_mask = static_cast<size_t>(0);
+        auto [ec, result] = cache_manager_->GetCacheLocation(metrics_ctx.get(),
+                                                             "test_instance",
+                                                             CacheManager::QueryType::QT_PREFIX_MATCH,
+                                                             query_keys,
+                                                             {},
+                                                             block_mask,
+                                                             0,
+                                                             {});
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(3u, result.cache_locations_view().size()); // 3 hits
+    }
+
+    // Verify cumulative counters: query 3+3=6, hit 2+3=5
+    Counter query_counter, hit_counter;
+    COPY_METRICS_(svc_collector.get(), manager, get_cache_location_query_block_counter, query_counter);
+    COPY_METRICS_(svc_collector.get(), manager, get_cache_location_hit_block_counter, hit_counter);
+    EXPECT_EQ(6u, query_counter.Get());
+    EXPECT_EQ(5u, hit_counter.Get());
 }
 
 TEST_F(CacheManagerTest, TestGetCacheLocationBatchGet) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -678,6 +678,80 @@ TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters) {
     EXPECT_EQ(5u, hit_counter.Get());
 }
 
+TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters_BatchGet) {
+    auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    ASSERT_EQ(expected,
+              cache_manager_->RegisterInstance(request_context_.get(),
+                                               "default",
+                                               "test_instance",
+                                               64,
+                                               createLocationSpecInfos(),
+                                               createModelDeployment(),
+                                               std::vector<LocationSpecGroup>()));
+
+    // Write blocks {1, 2, 3}
+    std::vector<int64_t> write_keys{1, 2, 3};
+    auto [ec1, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", write_keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, ec1);
+    BlockMask finish_mask = static_cast<size_t>(3);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), finish_mask));
+
+    auto svc_collector = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
+    ASSERT_TRUE(svc_collector->Init());
+    auto metrics_ctx = std::make_unique<RequestContext>("batch_get_hit_rate_test", svc_collector);
+
+    // BatchGet query: keys {1, 2, 99} → 2 hits (1,2), 1 miss (99)
+    {
+        std::vector<int64_t> query_keys{1, 2, 99};
+        BlockMask block_mask = static_cast<size_t>(0);
+        auto [ec, result] = cache_manager_->GetCacheLocation(metrics_ctx.get(),
+                                                             "test_instance",
+                                                             CacheManager::QueryType::QT_BATCH_GET,
+                                                             query_keys,
+                                                             {},
+                                                             block_mask,
+                                                             0,
+                                                             {});
+        ASSERT_EQ(EC_OK, ec);
+        // BatchGet returns all keys; hits have non-empty id, misses have empty id
+        ASSERT_EQ(3u, result.cache_locations_view().size());
+    }
+
+    Counter query_counter, hit_counter;
+    COPY_METRICS_(svc_collector.get(), manager, get_cache_location_query_block_counter, query_counter);
+    COPY_METRICS_(svc_collector.get(), manager, get_cache_location_hit_block_counter, hit_counter);
+    EXPECT_EQ(3u, query_counter.Get());
+    EXPECT_EQ(2u, hit_counter.Get());
+}
+
+TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters_ErrorPath) {
+    auto svc_collector = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
+    ASSERT_TRUE(svc_collector->Init());
+    auto metrics_ctx = std::make_unique<RequestContext>("error_path_test", svc_collector);
+
+    // Query non-existent instance → should fail and NOT increment counters
+    std::vector<int64_t> query_keys{1, 2, 3};
+    BlockMask block_mask = static_cast<size_t>(0);
+    auto [ec, result] = cache_manager_->GetCacheLocation(metrics_ctx.get(),
+                                                         "nonexistent_instance",
+                                                         CacheManager::QueryType::QT_PREFIX_MATCH,
+                                                         query_keys,
+                                                         {},
+                                                         block_mask,
+                                                         0,
+                                                         {});
+    EXPECT_NE(EC_OK, ec);
+
+    Counter query_counter, hit_counter;
+    COPY_METRICS_(svc_collector.get(), manager, get_cache_location_query_block_counter, query_counter);
+    COPY_METRICS_(svc_collector.get(), manager, get_cache_location_hit_block_counter, hit_counter);
+    EXPECT_EQ(0u, query_counter.Get());
+    EXPECT_EQ(0u, hit_counter.Get());
+}
+
 TEST_F(CacheManagerTest, TestGetCacheLocationBatchGet) {
     auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
     ASSERT_EQ(expected,

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -294,6 +294,9 @@ bool KmonitorMetricsReporter::InitMetrics() {
     // manager metrics
     REGISTER_GAUGE_METRIC(manager, request_key_count);
     REGISTER_GAUGE_METRIC(manager, prefix_match_len);
+    // Workaround: KMonitor only supports QPS and GAUGE metric types (no COUNTER).
+    // These are semantically cumulative counters; registered as GAUGE to match
+    // existing codebase convention (e.g. cache_reclaimer counters).
     REGISTER_GAUGE_METRIC(manager, get_cache_location_query_block_counter);
     REGISTER_GAUGE_METRIC(manager, get_cache_location_hit_block_counter);
     REGISTER_GAUGE_METRIC(manager, prefix_match_time_us);

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -53,6 +53,8 @@ struct KmonitorMetricsReporter::Context {
     // manager metrics metrics
     DECLARE_METRICS(manager, request_key_count);
     DECLARE_METRICS(manager, prefix_match_len);
+    DECLARE_METRICS(manager, get_cache_location_query_block_counter);
+    DECLARE_METRICS(manager, get_cache_location_hit_block_counter);
     DECLARE_METRICS(manager, prefix_match_time_us);
     DECLARE_METRICS(manager, lock_write_location_retry_times);
     DECLARE_METRICS(manager, write_cache_io_cost_us);
@@ -292,6 +294,8 @@ bool KmonitorMetricsReporter::InitMetrics() {
     // manager metrics
     REGISTER_GAUGE_METRIC(manager, request_key_count);
     REGISTER_GAUGE_METRIC(manager, prefix_match_len);
+    REGISTER_GAUGE_METRIC(manager, get_cache_location_query_block_counter);
+    REGISTER_GAUGE_METRIC(manager, get_cache_location_hit_block_counter);
     REGISTER_GAUGE_METRIC(manager, prefix_match_time_us);
     REGISTER_GAUGE_METRIC(manager, lock_write_location_retry_times);
     REGISTER_GAUGE_METRIC(manager, write_cache_io_cost_us);
@@ -460,6 +464,8 @@ void KmonitorMetricsReporter::ReportPerQuery(MetricsCollector *collector) {
         // manager metrics
         REPORT_COLLECTED_METRICS(manager, request_key_count);
         REPORT_COLLECTED_METRICS(manager, prefix_match_len);
+        REPORT_COLLECTED_METRICS(manager, get_cache_location_query_block_counter);
+        REPORT_COLLECTED_METRICS(manager, get_cache_location_hit_block_counter);
         REPORT_COLLECTED_METRICS(manager, prefix_match_time_us);
         REPORT_COLLECTED_METRICS(manager, lock_write_location_retry_times);
         REPORT_COLLECTED_METRICS(manager, write_cache_io_cost_us);

--- a/kv_cache_manager/metrics/metrics_collector.cc
+++ b/kv_cache_manager/metrics/metrics_collector.cc
@@ -52,11 +52,15 @@ DEFINE_METRICS_NAME_FOR_SERVICE(request_queue_size);
 
 // manager metrics
 #define DEFINE_METRICS_NAME_FOR_MANAGER(name) DEFINE_METRICS_NAME_(ServiceMetricsCollector, manager, name)
+#define REGISTER_COUNTER_METRICS_FOR_MANAGER(name)                                                                     \
+    REGISTER_METRICS_W_TAGS_COUNTER_(metrics_registry_, manager, name, metrics_tags_)
 #define REGISTER_GAUGE_METRICS_FOR_MANAGER(name)                                                                       \
     REGISTER_METRICS_W_TAGS_GAUGE_(metrics_registry_, manager, name, metrics_tags_)
 
 DEFINE_METRICS_NAME_FOR_MANAGER(request_key_count);
 DEFINE_METRICS_NAME_FOR_MANAGER(prefix_match_len);
+DEFINE_METRICS_NAME_FOR_MANAGER(get_cache_location_query_block_counter);
+DEFINE_METRICS_NAME_FOR_MANAGER(get_cache_location_hit_block_counter);
 DEFINE_METRICS_NAME_FOR_MANAGER(prefix_match_time_us);
 DEFINE_METRICS_NAME_FOR_MANAGER(lock_write_location_retry_times);
 DEFINE_METRICS_NAME_FOR_MANAGER(write_cache_io_cost_us);
@@ -130,6 +134,8 @@ bool ServiceMetricsCollector::Init() {
     // manager metrics
     REGISTER_GAUGE_METRICS_FOR_MANAGER(request_key_count);
     REGISTER_GAUGE_METRICS_FOR_MANAGER(prefix_match_len);
+    REGISTER_COUNTER_METRICS_FOR_MANAGER(get_cache_location_query_block_counter);
+    REGISTER_COUNTER_METRICS_FOR_MANAGER(get_cache_location_hit_block_counter);
     REGISTER_GAUGE_METRICS_FOR_MANAGER(prefix_match_time_us);
     REGISTER_GAUGE_METRICS_FOR_MANAGER(lock_write_location_retry_times);
     REGISTER_GAUGE_METRICS_FOR_MANAGER(write_cache_io_cost_us);

--- a/kv_cache_manager/metrics/metrics_collector.h
+++ b/kv_cache_manager/metrics/metrics_collector.h
@@ -262,6 +262,8 @@ class ServiceMetricsCollector final : public MetricsCollector {
     // manager metrics
     KVCM_GAUGE_METRICS(manager, request_key_count)
     KVCM_GAUGE_METRICS(manager, prefix_match_len)
+    KVCM_COUNTER_METRICS(manager, get_cache_location_query_block_counter)
+    KVCM_COUNTER_METRICS(manager, get_cache_location_hit_block_counter)
     KVCM_CHRONO_METRICS(manager, prefix_match_time_us, ManagerPrefixMatch)
     KVCM_GAUGE_METRICS(manager, lock_write_location_retry_times)
     KVCM_GAUGE_METRICS(manager, write_cache_io_cost_us)

--- a/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
@@ -168,12 +168,12 @@ TEST_F(LocalMetricsReporterTest, TestReportPerQuery02) {
     ServiceMetricsCollector collector(metrics_registry_);
     collector.Init();
 
-    EXPECT_EQ(3 + 5 + 10 + 5 + 25, metrics_registry_->GetSize());
+    EXPECT_EQ(3 + 5 + 12 + 5 + 25, metrics_registry_->GetSize());
 
     {
         reporter_->ReportPerQuery(&collector);
 
-        EXPECT_EQ(3 + 5 + 10 + 5 + 25, metrics_registry_->GetSize());
+        EXPECT_EQ(3 + 5 + 12 + 5 + 25, metrics_registry_->GetSize());
 
         std::uint64_t v;
         GET_METRICS_(&collector, service, query_counter, v);
@@ -190,7 +190,7 @@ TEST_F(LocalMetricsReporterTest, TestReportPerQuery02) {
 
         reporter_->ReportPerQuery(&collector);
 
-        EXPECT_EQ(3 + 5 + 10 + 5 + 25, metrics_registry_->GetSize());
+        EXPECT_EQ(3 + 5 + 12 + 5 + 25, metrics_registry_->GetSize());
 
         std::uint64_t v;
         GET_METRICS_(&collector, service, query_counter, v);

--- a/kv_cache_manager/metrics/test/metrics_collector_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_collector_test.cc
@@ -149,6 +149,8 @@ TEST_F(MetricsCollectorTest, ManagerMetricsTest) {
 
     EXPECT_DOUBLE_EQ(GET(p, manager, request_key_count), 0.);
     EXPECT_DOUBLE_EQ(GET(p, manager, prefix_match_len), 0.);
+    EXPECT_EQ(GET(p, manager, get_cache_location_query_block_counter), 0u);
+    EXPECT_EQ(GET(p, manager, get_cache_location_hit_block_counter), 0u);
     EXPECT_DOUBLE_EQ(GET(p, manager, prefix_match_time_us), 0.);
     EXPECT_DOUBLE_EQ(GET(p, manager, lock_write_location_retry_times), 0.);
     EXPECT_DOUBLE_EQ(GET(p, manager, write_cache_io_cost_us), 0.);
@@ -165,6 +167,16 @@ TEST_F(MetricsCollectorTest, ManagerMetricsTest) {
     EXPECT_DOUBLE_EQ(GET(p, manager, prefix_match_len), 10.);
     EXPECT_DOUBLE_EQ(GET(p, manager, lock_write_location_retry_times), 5.);
     EXPECT_DOUBLE_EQ(GET(p, manager, write_cache_io_cost_us), 2000.);
+
+    // Test counter accumulation (counter members are public, direct += works)
+    p->manager_get_cache_location_query_block_counter_metrics_ += 100;
+    p->manager_get_cache_location_hit_block_counter_metrics_ += 60;
+    EXPECT_EQ(GET(p, manager, get_cache_location_query_block_counter), 100u);
+    EXPECT_EQ(GET(p, manager, get_cache_location_hit_block_counter), 60u);
+    p->manager_get_cache_location_query_block_counter_metrics_ += 50;
+    p->manager_get_cache_location_hit_block_counter_metrics_ += 30;
+    EXPECT_EQ(GET(p, manager, get_cache_location_query_block_counter), 150u);
+    EXPECT_EQ(GET(p, manager, get_cache_location_hit_block_counter), 90u);
 
     // Test time measurement
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, ManagerPrefixMatch);


### PR DESCRIPTION
## Summary

Add two cumulative Counter metrics to monitor KVCache block-level hit rate via Prometheus:

- `manager.get_cache_location_query_block_counter` — total blocks queried
- `manager.get_cache_location_hit_block_counter` — total blocks hit

Hit rate in Grafana:
```promql
sum(rate(kvcm_manager_get_cache_location_hit_block_counter[1m]))
  / sum(rate(kvcm_manager_get_cache_location_query_block_counter[1m]))
```

## Motivation

The existing `meta_indexer.search_cache_hit_ratio` only reflects the internal MetaSearchCache hit rate, not the actual block-level cache hit rate seen by inference engines. Operators had to manually compute `prefix_match_len / request_key_count` from per-request Gauges, which is cumbersome in Grafana. These new cumulative Counters enable straightforward `rate()` based dashboards.

## Changes

| File | Description |
|---|---|
| `metrics_collector.h/cc` | Declare and register 2 Counter metrics |
| `cache_manager.cc` | Accumulate counters in `GetCacheLocation()` return path (after error check) |
| `kmonitor_metrics_reporter.cc` | Sync register for KMonitor pipeline |
| `prometheus-zh_CN.md` | Document new metrics with PromQL example |
| `metrics_collector_test.cc` | Counter init and accumulation UT |
| `cache_manager_test.cc` | PrefixMatch + BatchGet + error path UT |

**7 files, +206 lines**

## Hit Counting Logic

| QueryType | Hit Detection |
|---|---|
| `QT_PREFIX_MATCH` | `cache_locations.size()` (only matched blocks returned) |
| `QT_BATCH_GET` / `QT_REVERSE_ROLL_SW_MATCH` | Count locations with non-empty `id()` (misses padded with empty CacheLocation) |

Counters are only incremented on successful queries (`ec == EC_OK`).

## Testing

**Unit tests**: MetricsCollectorTest + CacheManagerTest (PrefixMatch, BatchGet, error path) — all passed.

**Integration test**: Full stack verification with KVCM + Prometheus + Grafana.

![Grafana Dashboard](https://github.com/lpdink/tair-kvcache/blob/feature_cache_hit_test/feature_test/grafana_cache_hit.jpg?raw=true)

Test report, reproduction guide, and docker-compose setup:
https://github.com/lpdink/tair-kvcache/blob/feature_cache_hit_test/feature_test/README.md

Could you please kindly review this PR?  @wangxiyu191 