### PR TITLE
[config] fix location spec group order mismatch

### DIFF
--- a/kv_cache_manager/config/instance_info.h
+++ b/kv_cache_manager/config/instance_info.h
@@ -161,10 +161,11 @@ public:
 
     // Returns field names that differ from the given values.
     // Returns empty vector if all fields match.
-    [[nodiscard]] std::vector<std::string> MismatchFields(int32_t block_size,
-                                            const std::vector<LocationSpecInfo> &location_spec_infos,
-                                            const ModelDeployment &model_deployment,
-                                            const std::vector<LocationSpecGroup> &location_spec_groups) const {
+    [[nodiscard]] std::vector<std::string>
+    MismatchFields(int32_t block_size,
+                   const std::vector<LocationSpecInfo> &location_spec_infos,
+                   const ModelDeployment &model_deployment,
+                   const std::vector<LocationSpecGroup> &location_spec_groups) const {
         std::vector<std::string> mismatched;
         if (block_size_ != block_size) {
             mismatched.emplace_back("block_size");
@@ -175,7 +176,11 @@ public:
         if (model_deployment_ != model_deployment) {
             mismatched.emplace_back("model_deployment");
         }
-        if (location_spec_groups_ != location_spec_groups) {
+        auto sorted_location_spec_groups = location_spec_groups;
+        std::sort(sorted_location_spec_groups.begin(),
+                  sorted_location_spec_groups.end(),
+                  [](const auto &a, const auto &b) { return a.name() < b.name(); });
+        if (location_spec_groups_ != sorted_location_spec_groups) {
             mismatched.emplace_back("location_spec_groups");
         }
         return mismatched;

--- a/kv_cache_manager/config/test/instance_info_test.cc
+++ b/kv_cache_manager/config/test/instance_info_test.cc
@@ -99,4 +99,26 @@ TEST_F(InstanceInfoTest, TestLocationSpecGroupSort) {
     }
 }
 
+TEST_F(InstanceInfoTest, TestMismatchFieldsIgnoresLocationSpecGroupOrder) {
+    constexpr int32_t kBlockSize = 64;
+    std::vector<LocationSpecGroup> stored_location_spec_groups = {
+        LocationSpecGroup("group_b", {"spec_b", "spec_a"}),
+        LocationSpecGroup("group_a", {"spec_d", "spec_c"}),
+    };
+    InstanceInfo instance_info(
+        "quota_group", "instance_group", "instance_id", kBlockSize, {}, {}, stored_location_spec_groups);
+
+    std::vector<LocationSpecGroup> same_location_spec_groups = {
+        LocationSpecGroup("group_b", {"spec_a", "spec_b"}),
+        LocationSpecGroup("group_a", {"spec_c", "spec_d"}),
+    };
+    auto mismatched = instance_info.MismatchFields(kBlockSize, {}, {}, same_location_spec_groups);
+    EXPECT_TRUE(mismatched.empty());
+
+    same_location_spec_groups[0].set_spec_names({"spec_a", "unexpected_spec"});
+    mismatched = instance_info.MismatchFields(kBlockSize, {}, {}, same_location_spec_groups);
+    ASSERT_EQ(1, mismatched.size());
+    EXPECT_EQ("location_spec_groups", mismatched[0]);
+}
+
 } // namespace kv_cache_manager


### PR DESCRIPTION
## What changed
- Normalize incoming `location_spec_groups` by group name before `InstanceInfo::MismatchFields` compares it with stored instance metadata.
- Add a regression test for same-content location spec groups arriving in a different order.

## Why
`InstanceInfo` stores `location_spec_groups` sorted by name, but register-instance mismatch checks compared the stored vector against the unsorted request vector directly. Two pods with identical groups could be rejected when their request array order differed.

## Impact
Repeated registration for the same `instance_id` now treats `location_spec_groups` as order-insensitive at the group-array level while still detecting real group/spec differences.

## Validation
- `bazel test //kv_cache_manager/config/test:instance_info_test --noremote_accept_cached --disk_cache=`

Note: a normal cached Bazel run first hit stale remote/disk cache metadata from a different GCC toolchain; disabling cache forced a local rebuild and the test passed.