### PR TITLE
[connector] support vcns hf3fs in sglang connector

### DIFF
--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -259,17 +259,19 @@ class HiCacheKVCM(HiCacheStorage):
         hf3fs_configs = []
         storage_configs_json = json.loads(storage_configs)
         for storage_config in storage_configs_json:
-            if storage_config["type"] == "hf3fs" and storage_config["is_available"]:
-                hf3fs_config = {
-                    "type": "hf3fs",
-                    "mountpoint": storage_config["storage_spec"]["mountpoint"],
-                    "root_dir": storage_config["storage_spec"]["root_dir"],
-                    "read_iov_block_size": self.read_iov_block_size,
-                    "read_iov_size": self.iov_size,
-                    "write_iov_block_size": self.write_iov_block_size,
-                    "write_iov_size": self.iov_size,
-                }
-                hf3fs_configs.append(hf3fs_config)
+            storage_type = storage_config["type"]
+            if storage_type not in ("hf3fs", "vcns_hf3fs") or not storage_config.get("is_available", True):
+                continue
+            hf3fs_config = {
+                "type": storage_type,
+                "mountpoint": storage_config["storage_spec"]["mountpoint"],
+                "root_dir": storage_config["storage_spec"]["root_dir"],
+                "read_iov_block_size": self.read_iov_block_size,
+                "read_iov_size": self.iov_size,
+                "write_iov_block_size": self.write_iov_block_size,
+                "write_iov_size": self.iov_size,
+            }
+            hf3fs_configs.append(hf3fs_config)
         return hf3fs_configs
 
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -1,4 +1,5 @@
 """Unit tests for _batch_set return value: 1:1 positional mapping with input keys."""
+import json
 import sys
 import types
 import unittest
@@ -765,6 +766,61 @@ class TestSkipTransfer(unittest.TestCase):
 
         self.assertEqual(len(result), 3)
         self.assertEqual(result, [False, False, False])
+
+
+class TestParseHf3fsConfigs(unittest.TestCase):
+    def test_vcns_hf3fs_uses_storage_spec_and_keeps_type(self):
+        c = _build_connector()
+        c.read_iov_block_size = 0
+        c.write_iov_block_size = 1048576
+        c.iov_size = 4294967296
+
+        storage_configs = json.dumps([
+            {
+                "type": "vcns_hf3fs",
+                "is_available": True,
+                "global_unique_name": "vcns_3fs",
+                "storage_spec": {
+                    "cluster_name": "vcns_3fs",
+                    "mountpoint": "/data/",
+                    "root_dir": "instance-root/",
+                    "key_count_per_file": 8,
+                    "remote_host": "127.0.0.1",
+                    "remote_port": 9081,
+                    "meta_storage_uri": "redis://example",
+                },
+            }
+        ])
+
+        self.assertEqual(c.parse_hf3fs_configs(storage_configs), [{
+            "type": "vcns_hf3fs",
+            "mountpoint": "/data/",
+            "root_dir": "instance-root/",
+            "read_iov_block_size": 0,
+            "read_iov_size": 4294967296,
+            "write_iov_block_size": 1048576,
+            "write_iov_size": 4294967296,
+        }])
+
+    def test_unavailable_vcns_hf3fs_is_ignored(self):
+        c = _build_connector()
+        c.read_iov_block_size = 0
+        c.write_iov_block_size = 0
+        c.iov_size = 1024
+
+        storage_configs = json.dumps([
+            {
+                "type": "vcns_hf3fs",
+                "is_available": False,
+                "global_unique_name": "vcns_3fs",
+                "storage_spec": {
+                    "mountpoint": "/data/",
+                    "root_dir": "instance-root/",
+                },
+            }
+        ])
+
+        self.assertEqual(c.parse_hf3fs_configs(storage_configs), [])
 
 
 class TestMLASkipTPSync(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Teach the sglang connector to generate HF3FS SDK backend config for both `hf3fs` and `vcns_hf3fs` storage configs.
- Preserve the original `vcns_hf3fs` type so the C++ SDK wrapper resolves the matching backend config instead of falling back to the default HF3FS values.
- Add regression coverage for available and unavailable `vcns_hf3fs` storage configs.

## Root Cause

The sglang connector only converted `hf3fs` storage configs into `sdk_backend_configs`. When the manager returned a `vcns_hf3fs` storage config, the C++ SDK wrapper looked up backend config by `vcns_hf3fs` and found only the default `Hf3fsSdkConfig`, which uses `/3fs/stage/3fs/` and `kv_manager/`.

## Validation

- `python3 -m py_compile kv_cache_manager/py_connector/sglang/connector.py kv_cache_manager/py_connector/test/test_batch_set_return.py`
- `git diff --check`
- Ran the new `TestParseHf3fsConfigs` cases with lightweight mocks because this environment does not have `torch` installed.

Full `python3 -m unittest kv_cache_manager.py_connector.test.test_batch_set_return` could not run locally: import fails with `ModuleNotFoundError: No module named 'torch'`.

`bazel build //kv_cache_manager/py_connector/sglang:sglang_connector` was attempted but failed outside this change in `kv_cache_manager/common/logger.cc` due to undeclared GCC system header inclusions (`stdarg.h`, `stddef.h`, `stdint.h`).