### PR TITLE
[connector] support configuring log level via environment variable and startup parameter

### DIFF
--- a/kv_cache_manager/py_connector/common/logger.py
+++ b/kv_cache_manager/py_connector/common/logger.py
@@ -1,11 +1,49 @@
+import os
 import logging
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
 logger.propagate = False
 handler = logging.StreamHandler()
 handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter("[KVCM] %(levelname)s %(asctime)s [%(filename)s:%(lineno)d] %(message)s", "%m-%d %H:%M:%S")
+formatter = logging.Formatter(
+    "[KVCM] %(levelname)s %(asctime)s [%(filename)s:%(lineno)d] %(message)s",
+    "%m-%d %H:%M:%S")
 handler.setFormatter(formatter)
-
 logger.addHandler(handler)
+
+_DEFAULT_LEVEL = logging.WARNING
+_ENV_VAR = "KVCM_LOG_LEVEL"
+
+
+def set_log_level(level_str: str):
+    """Set KVCM logger level from a string like 'DEBUG', 'INFO', 'WARNING'.
+
+    Falls back to WARNING if the level string is invalid or empty.
+    """
+    if not level_str:
+        logger.setLevel(_DEFAULT_LEVEL)
+        return
+    level = logging.getLevelName(level_str.upper())
+    if not isinstance(level, int):
+        logger.warning("Invalid log level '%s', falling back to WARNING", level_str)
+        level = _DEFAULT_LEVEL
+    logger.setLevel(level)
+
+
+def configure_log_level(param_level: str = ""):
+    """Apply log level with priority: env var > param > default(WARNING).
+
+    Args:
+        param_level: Log level from startup parameter (kv_connector_extra_config).
+    """
+    env_level = os.environ.get(_ENV_VAR)
+    if env_level:
+        set_log_level(env_level)
+    elif param_level:
+        set_log_level(param_level)
+    else:
+        logger.setLevel(_DEFAULT_LEVEL)
+
+
+# Apply environment variable on module load
+configure_log_level()

--- a/kv_cache_manager/py_connector/test/test_logger.py
+++ b/kv_cache_manager/py_connector/test/test_logger.py
@@ -1,0 +1,124 @@
+"""Unit tests for KVCM logger configuration."""
+
+import importlib
+import logging
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestSetLogLevel(unittest.TestCase):
+    """Tests for set_log_level() function."""
+
+    def setUp(self):
+        # Re-import logger module for each test to get fresh state
+        import kv_cache_manager.py_connector.common.logger as logger_mod
+        self.logger_mod = logger_mod
+
+    def test_set_debug_level(self):
+        self.logger_mod.set_log_level("DEBUG")
+        self.assertEqual(self.logger_mod.logger.level, logging.DEBUG)
+
+    def test_set_info_level(self):
+        self.logger_mod.set_log_level("INFO")
+        self.assertEqual(self.logger_mod.logger.level, logging.INFO)
+
+    def test_set_warning_level(self):
+        self.logger_mod.set_log_level("WARNING")
+        self.assertEqual(self.logger_mod.logger.level, logging.WARNING)
+
+    def test_set_error_level(self):
+        self.logger_mod.set_log_level("ERROR")
+        self.assertEqual(self.logger_mod.logger.level, logging.ERROR)
+
+    def test_set_case_insensitive(self):
+        self.logger_mod.set_log_level("debug")
+        self.assertEqual(self.logger_mod.logger.level, logging.DEBUG)
+
+    def test_invalid_level_falls_back_to_warning(self):
+        self.logger_mod.set_log_level("INVALID")
+        self.assertEqual(self.logger_mod.logger.level, logging.WARNING)
+
+    def test_empty_string_falls_back_to_warning(self):
+        self.logger_mod.set_log_level("")
+        self.assertEqual(self.logger_mod.logger.level, logging.WARNING)
+
+    def tearDown(self):
+        self.logger_mod.logger.setLevel(logging.WARNING)
+
+
+class TestEnvironmentVariable(unittest.TestCase):
+    """Tests for KVCM_LOG_LEVEL environment variable."""
+
+    def test_env_var_debug(self):
+        with patch.dict(os.environ, {"KVCM_LOG_LEVEL": "DEBUG"}):
+            import kv_cache_manager.py_connector.common.logger as logger_mod
+            importlib.reload(logger_mod)
+            self.assertEqual(logger_mod.logger.level, logging.DEBUG)
+
+    def test_env_var_info(self):
+        with patch.dict(os.environ, {"KVCM_LOG_LEVEL": "INFO"}):
+            import kv_cache_manager.py_connector.common.logger as logger_mod
+            importlib.reload(logger_mod)
+            self.assertEqual(logger_mod.logger.level, logging.INFO)
+
+    def test_env_var_not_set_defaults_to_warning(self):
+        env = os.environ.copy()
+        env.pop("KVCM_LOG_LEVEL", None)
+        with patch.dict(os.environ, env, clear=True):
+            import kv_cache_manager.py_connector.common.logger as logger_mod
+            importlib.reload(logger_mod)
+            self.assertEqual(logger_mod.logger.level, logging.WARNING)
+
+    def test_env_var_invalid_falls_back_to_warning(self):
+        with patch.dict(os.environ, {"KVCM_LOG_LEVEL": "GARBAGE"}):
+            import kv_cache_manager.py_connector.common.logger as logger_mod
+            importlib.reload(logger_mod)
+            self.assertEqual(logger_mod.logger.level, logging.WARNING)
+
+    def tearDown(self):
+        # Restore default level after env var tests
+        import kv_cache_manager.py_connector.common.logger as logger_mod
+        importlib.reload(logger_mod)
+
+
+class TestConfigureLogLevel(unittest.TestCase):
+    """Tests for configure_log_level() priority logic."""
+
+    def setUp(self):
+        import kv_cache_manager.py_connector.common.logger as logger_mod
+        self.logger_mod = logger_mod
+
+    def test_env_var_takes_priority_over_param(self):
+        with patch.dict(os.environ, {"KVCM_LOG_LEVEL": "DEBUG"}):
+            self.logger_mod.configure_log_level("INFO")
+            self.assertEqual(self.logger_mod.logger.level, logging.DEBUG)
+
+    def test_param_used_when_env_var_not_set(self):
+        env = os.environ.copy()
+        env.pop("KVCM_LOG_LEVEL", None)
+        with patch.dict(os.environ, env, clear=True):
+            self.logger_mod.configure_log_level("INFO")
+            self.assertEqual(self.logger_mod.logger.level, logging.INFO)
+
+    def test_default_when_neither_set(self):
+        env = os.environ.copy()
+        env.pop("KVCM_LOG_LEVEL", None)
+        with patch.dict(os.environ, env, clear=True):
+            self.logger_mod.configure_log_level("")
+            self.assertEqual(self.logger_mod.logger.level, logging.WARNING)
+
+    def test_none_param_treated_as_empty(self):
+        env = os.environ.copy()
+        env.pop("KVCM_LOG_LEVEL", None)
+        with patch.dict(os.environ, env, clear=True):
+            self.logger_mod.configure_log_level(None)
+            self.assertEqual(self.logger_mod.logger.level, logging.WARNING)
+
+    def tearDown(self):
+        import kv_cache_manager.py_connector.common.logger as logger_mod
+        importlib.reload(logger_mod)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/py_connector/vllm/config.py
+++ b/kv_cache_manager/py_connector/vllm/config.py
@@ -33,3 +33,5 @@ class TairKvCacheConnectorExtraConfig:
         self.leader_retry_base_interval_seconds: float = extra_config.get("leader_retry_base_interval_seconds", 0.005)
         self.discovery_refresh_interval_seconds: int = extra_config.get("discovery_refresh_interval_seconds", 30)
         self.min_discover_interval_seconds: int = extra_config.get("min_discover_interval_seconds", 1)
+
+        self.log_level: str = extra_config.get("log_level", "")

--- a/kv_cache_manager/py_connector/vllm/v1_connector.py
+++ b/kv_cache_manager/py_connector/vllm/v1_connector.py
@@ -36,7 +36,7 @@ from vllm.v1.outputs import KVConnectorOutput
 from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
 from kv_cache_manager.py_connector.common.tp_coordinator import CoordinateMsgSerializer, TpCoordinatorServer, \
     TpCoordinatorClient, SendBlockStartEvent, CoordinateMessage, SaveContext
-from kv_cache_manager.py_connector.common.logger import logger
+from kv_cache_manager.py_connector.common.logger import logger, configure_log_level
 from kv_cache_manager.py_connector.common._version_info import FULL_VERSION, GIT_COMMIT, BUILD_TIME
 
 from kv_cache_manager.py_connector.common.types import KVCacheInfo
@@ -127,6 +127,10 @@ class TairKvCacheConnector(KVConnectorBase_V1):
         logger.warning("KVCM vllm connector version: %s (commit: %s, build: %s)", FULL_VERSION, GIT_COMMIT, BUILD_TIME)
 
         self._extra_config = TairKvCacheConnectorExtraConfig(vllm_config.kv_transfer_config.kv_connector_extra_config)
+
+        # Apply log level with priority: env var > startup param > default
+        configure_log_level(self._extra_config.log_level)
+
         self._kv_caches: Optional[dict[str, torch.Tensor]] = None
         self._local_block_size = vllm_config.cache_config.block_size
 


### PR DESCRIPTION
## Summary

Support configuring vllm Connector log level through environment variable `KVCM_LOG_LEVEL` or startup parameter `kv_connector_extra_config["log_level"]`. Previously the log level was hardcoded to `WARNING`, requiring source code changes to debug issues.

## Motivation

When troubleshooting production issues, operators need to temporarily increase log verbosity (e.g., to `DEBUG` or `INFO`). Previously this required modifying `logger.py` and redeploying. This PR enables dynamic log level configuration without code changes.

## Usage

### Option 1: Environment Variable (Recommended)

Set `KVCM_LOG_LEVEL` before starting vllm:

```bash
export KVCM_LOG_LEVEL=DEBUG
python -m vllm.entrypoints.openai.api_server \
    --model Qwen/Qwen2.5-7B \
    --kv-transfer-config '{
        "kv_connector": "kv_cache_manager.py_connector.vllm.v1_connector.TairKvCacheConnector",
        "kv_role": "kv_both",
        "kv_connector_extra_config": {
            "manager_uri": "http://127.0.0.1:6382",
            "instance_id": "my_instance",
            "coordinator_base_port": 12345
        }
    }'
```

Supported values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive).

### Option 2: Startup Parameter

Add `log_level` to `kv_connector_extra_config`:

```bash
python -m vllm.entrypoints.openai.api_server \
    --model Qwen/Qwen2.5-7B \
    --kv-transfer-config '{
        "kv_connector": "kv_cache_manager.py_connector.vllm.v1_connector.TairKvCacheConnector",
        "kv_role": "kv_both",
        "kv_connector_extra_config": {
            "manager_uri": "http://127.0.0.1:6382",
            "instance_id": "my_instance",
            "coordinator_base_port": 12345,
            "log_level": "DEBUG"
        }
    }'
```

### Priority

When both are set, **environment variable takes precedence**:

| `KVCM_LOG_LEVEL` | `kv_connector_extra_config["log_level"]` | Effective Level |
|---|---|---|
| `DEBUG` | `INFO` | `DEBUG` (env var wins) |
| *(not set)* | `INFO` | `INFO` |
| *(not set)* | *(not set)* | `WARNING` (default) |

This follows the [12-Factor App](https://12factor.net/config) convention: environment variables override config files.

## Changes

| Category | Files | Description |
|---|---|---|
| **Logger** | `common/logger.py` | Add `set_log_level()` and `configure_log_level()` functions; auto-apply `KVCM_LOG_LEVEL` on module load |
| **Config** | `vllm/config.py` | Add `log_level` field to `TairKvCacheConnectorExtraConfig` |
| **Connector** | `vllm/v1_connector.py` | Call `configure_log_level()` in `__init__` |
| **Tests** | `test/test_logger.py` | 15 unit tests covering all scenarios |

**4 files, +172 lines**

## Known Limitations

1. **No runtime hot-reload**: Log level changes require restarting vllm. Runtime adjustment via HTTP API is not implemented.

2. **Connector-scoped only**: This only affects the KVCM connector logger (`kv_cache_manager.py_connector.common.logger`). vllm's own logging is controlled by `VLLM_LOGGING_LEVEL` independently.

3. **Invalid values fall back to WARNING**: If an unrecognized level string is provided (e.g., `VERBOSE`), the system logs a warning and uses `WARNING` level.

## Testing

**Unit tests**: 15 test cases covering:
- `set_log_level()` with valid/invalid/empty inputs
- Environment variable `KVCM_LOG_LEVEL` with various levels
- `configure_log_level()` priority logic (env var > param > default)
- Case insensitivity and `None` handling

All tests pass:
```
Ran 15 tests in 0.002s
OK
```

**Full test suite**: All 83 bazel tests pass, no regressions.
