### PR TITLE
[reclaimer] stabilize cache reclaimer async assertions

### DIFF
--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -172,6 +172,7 @@ RegistryManager_ListInstanceInfo_stub(void *obj, RequestContext *rc, const std::
 std::chrono::milliseconds spe_submit_delay{0};
 PlanExecuteResult del_result;
 std::vector<CacheLocationDelRequest> submitted_del_requests;
+std::mutex submitted_del_requests_mutex;
 // spe_submit_loc is used to help casting the func addr in the stub def below
 // the using declarations is the same as
 // typedef std::future<PlanExecuteResult> (SchedulePlanExecutor::*spe_submit_loc)(const CacheLocationDelRequest &);
@@ -179,7 +180,10 @@ using spe_submit_loc = std::future<PlanExecuteResult> (SchedulePlanExecutor::*)(
 
 std::future<PlanExecuteResult> SchedulePlanExecutor_Submit_stub(void *obj, const CacheLocationDelRequest &request) {
     const auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
-    submitted_del_requests.emplace_back(request);
+    {
+        std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+        submitted_del_requests.emplace_back(request);
+    }
     std::this_thread::sleep_for(spe_submit_delay);
     promise->set_value(del_result);
     return promise->get_future();
@@ -393,7 +397,10 @@ public:
         dummy_meta_indexer.reset();
         dummy_meta_searcher.reset();
 
-        submitted_del_requests.clear();
+        {
+            std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+            submitted_del_requests.clear();
+        }
 
         get_out_properties.clear();
         random_sample_keys.clear();
@@ -412,6 +419,52 @@ public:
         stub_.reset(ADDR(MetaIndexer, PersistMetaData));
         stub_.reset(ADDR(MetaSearcherManager, GetMetaSearcher));
         stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    }
+
+    template <typename Predicate>
+    bool WaitUntil(Predicate predicate, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000)) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (predicate()) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return predicate();
+    }
+
+    std::vector<CacheLocationDelRequest> SubmittedDelRequestsSnapshot() {
+        std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+        return submitted_del_requests;
+    }
+
+    void ClearSubmittedDelRequests() {
+        std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+        submitted_del_requests.clear();
+    }
+
+    bool HasSubmittedDelRequests() {
+        std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+        return !submitted_del_requests.empty();
+    }
+
+    bool HasNoSubmittedDelRequests() {
+        std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+        return submitted_del_requests.empty();
+    }
+
+    std::size_t SubmittedDelRequestCount() {
+        std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+        return submitted_del_requests.size();
+    }
+
+    bool WaitUntilSubmittedDelRequests(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000)) {
+        return WaitUntil([this] { return HasSubmittedDelRequests(); }, timeout);
+    }
+
+    int ListInstanceGroupCallCount() {
+        std::lock_guard<std::mutex> lock(list_ins_group_mut);
+        return list_ins_group_call_counter;
     }
 
     Stub stub_;
@@ -632,7 +685,7 @@ TEST_F(CacheReclaimerTest, TestPauseResume) {
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
         ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
         ASSERT_TRUE(cache_reclaimer_->IsPaused());  // the worker thread is in paused state
-        ASSERT_TRUE(submitted_del_requests.empty());
+        ASSERT_TRUE(HasNoSubmittedDelRequests());
     }
 
     {
@@ -640,9 +693,10 @@ TEST_F(CacheReclaimerTest, TestPauseResume) {
         ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
         ASSERT_FALSE(cache_reclaimer_->IsPaused()); // the worker thread is not in paused state
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(16));
-        ASSERT_FALSE(submitted_del_requests.empty());
-        const auto &req = submitted_del_requests.back();
+        ASSERT_TRUE(WaitUntilSubmittedDelRequests());
+        const auto requests = SubmittedDelRequestsSnapshot();
+        ASSERT_FALSE(requests.empty());
+        const auto &req = requests.back();
         ASSERT_EQ(2, req.block_keys.size());
         ASSERT_TRUE(VecContains(req.block_keys, 0));
         ASSERT_TRUE(VecContains(req.block_keys, 1));
@@ -1563,13 +1617,14 @@ TEST_F(CacheReclaimerTest, TestInsufficientSampledKeys) {
     // main thread sleeps for 10ms to ensure the worker thread do
     // reclaiming at least once (not 100% but should have reasonable
     // high probability)
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests());
     ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
     cache_reclaimer_->Stop();
     // all blocks should be submitted when sampled keys are insufficient
-    ASSERT_FALSE(submitted_del_requests.empty());
-    const auto &req = submitted_del_requests.back();
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_FALSE(requests.empty());
+    const auto &req = requests.back();
     ASSERT_EQ(10, req.block_keys.size());
     for (std::int64_t i = 0; i != 10; ++i) {
         ASSERT_TRUE(VecContains(req.block_keys, i));
@@ -1633,13 +1688,14 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU00) {
         std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests());
     ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
     cache_reclaimer_->Stop();
 
-    ASSERT_FALSE(submitted_del_requests.empty());
-    const auto &req = submitted_del_requests.back();
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_FALSE(requests.empty());
+    const auto &req = requests.back();
     ASSERT_EQ(2, req.block_keys.size());
     ASSERT_TRUE(VecContains(req.block_keys, 0));
     ASSERT_TRUE(VecContains(req.block_keys, 1));
@@ -1701,13 +1757,14 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU01) {
         std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests());
     ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
     cache_reclaimer_->Stop();
 
-    ASSERT_FALSE(submitted_del_requests.empty());
-    const auto &req = submitted_del_requests.back();
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_FALSE(requests.empty());
+    const auto &req = requests.back();
     ASSERT_EQ(3, req.block_keys.size());
     // the 3 keys with minimal time point should be included
     ASSERT_TRUE(VecContains(req.block_keys, 1)); // time point -> 2
@@ -1771,13 +1828,14 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU02) {
         std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests());
     ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
     cache_reclaimer_->Stop();
 
-    ASSERT_FALSE(submitted_del_requests.empty());
-    const auto &req = submitted_del_requests.back();
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_FALSE(requests.empty());
+    const auto &req = requests.back();
     ASSERT_EQ(3, req.block_keys.size());
     // the 3 keys with minimal time point should be included
     ASSERT_TRUE(VecContains(req.block_keys, 9)); // time point -> 2
@@ -1845,7 +1903,7 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU03) {
 
     cache_reclaimer_->Stop();
 
-    ASSERT_TRUE(submitted_del_requests.empty());
+    ASSERT_TRUE(HasNoSubmittedDelRequests());
 }
 
 TEST_F(CacheReclaimerTest, TestReclaimByLRU04) {
@@ -1904,13 +1962,14 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU04) {
         std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests());
     ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
     cache_reclaimer_->Stop();
 
-    ASSERT_FALSE(submitted_del_requests.empty());
-    const auto &req = submitted_del_requests.back();
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_FALSE(requests.empty());
+    const auto &req = requests.back();
     ASSERT_EQ(1, req.block_keys.size());
     // the 1 keys with minimal time point should be included
     ASSERT_TRUE(VecContains(req.block_keys, 9)); // time point -> 2
@@ -1945,7 +2004,7 @@ TEST_F(CacheReclaimerTest, TestMetaIndexerGetPropertiesFailure) {
     cache_reclaimer_->Stop();
 
     // no deletion requests should be submitted when GetProperties fails
-    ASSERT_TRUE(submitted_del_requests.empty());
+    ASSERT_TRUE(HasNoSubmittedDelRequests());
 }
 
 TEST_F(CacheReclaimerTest, TestMetaIndexerSampleReclaimFailure) {
@@ -1974,7 +2033,7 @@ TEST_F(CacheReclaimerTest, TestMetaIndexerSampleReclaimFailure) {
     cache_reclaimer_->Stop();
 
     // no deletion requests should be submitted when SampleReclaim fails
-    ASSERT_TRUE(submitted_del_requests.empty());
+    ASSERT_TRUE(HasNoSubmittedDelRequests());
 }
 
 TEST_F(CacheReclaimerTest, TestMetaIndexerSampleKeys00) {
@@ -2008,7 +2067,7 @@ TEST_F(CacheReclaimerTest, TestMetaIndexerSampleKeys00) {
     cache_reclaimer_->Stop();
 
     // no deletion requests should be submitted
-    ASSERT_TRUE(submitted_del_requests.empty());
+    ASSERT_TRUE(HasNoSubmittedDelRequests());
 }
 
 TEST_F(CacheReclaimerTest, TestMetaIndexerSampleKeys01) {
@@ -2069,7 +2128,7 @@ TEST_F(CacheReclaimerTest, TestMetaIndexerSampleKeys01) {
     cache_reclaimer_->Stop();
 
     // no deletion requests should be submitted
-    ASSERT_TRUE(submitted_del_requests.empty());
+    ASSERT_TRUE(HasNoSubmittedDelRequests());
 }
 
 TEST_F(CacheReclaimerTest, TestSchedulePlanExecutorDelFailure) {
@@ -2181,7 +2240,7 @@ TEST_F(CacheReclaimerTest, TestEmptyInstanceGroups) {
     cache_reclaimer_->Stop();
 
     // no deletion requests should be submitted when there are no instance groups
-    ASSERT_TRUE(submitted_del_requests.empty());
+    ASSERT_TRUE(HasNoSubmittedDelRequests());
 }
 
 TEST_F(CacheReclaimerTest, TestEmptyInstanceInfos) {
@@ -2245,7 +2304,7 @@ TEST_F(CacheReclaimerTest, TestEmptyInstanceInfos) {
     cache_reclaimer_->Stop();
 
     // no deletion requests should be submitted when there are no instance infos
-    ASSERT_TRUE(submitted_del_requests.empty());
+    ASSERT_TRUE(HasNoSubmittedDelRequests());
 }
 
 TEST_F(CacheReclaimerTest, TestMultipleInstanceGroups) {
@@ -2320,21 +2379,31 @@ TEST_F(CacheReclaimerTest, TestMultipleInstanceGroups) {
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 5));
     batch_get_loc_out_maps =
         std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    cache_reclaimer_->SetSleepIntervalMs(request_context_.get(), 0);
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
     ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
+    ASSERT_TRUE(WaitUntil([this] {
+        bool found_instance_1 = false;
+        bool found_instance_2 = false;
+        for (const auto &req : SubmittedDelRequestsSnapshot()) {
+            found_instance_1 = found_instance_1 || req.instance_id == "test_instance_id_1";
+            found_instance_2 = found_instance_2 || req.instance_id == "test_instance_id_2";
+        }
+        return found_instance_1 && found_instance_2;
+    }));
 
     cache_reclaimer_->Stop();
 
     // deletion requests should be submitted for both instance groups
-    ASSERT_FALSE(submitted_del_requests.empty());
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_FALSE(requests.empty());
 
     // check that we have requests for both instances
     bool found_instance_1 = false;
     bool found_instance_2 = false;
 
-    for (const auto &req : submitted_del_requests) {
+    for (const auto &req : requests) {
         if (req.instance_id == "test_instance_id_1") {
             found_instance_1 = true;
         } else if (req.instance_id == "test_instance_id_2") {
@@ -2407,7 +2476,7 @@ TEST_F(CacheReclaimerTest, TestKeyCountEdgeCases) {
         cache_reclaimer_->Stop();
 
         // with zero key count, the percentage usage would be 0%, so no reclaiming should happen
-        ASSERT_TRUE(submitted_del_requests.empty());
+        ASSERT_TRUE(HasNoSubmittedDelRequests());
     }
 
     {
@@ -2422,18 +2491,18 @@ TEST_F(CacheReclaimerTest, TestKeyCountEdgeCases) {
         instance_groups.emplace_back(ins_group);
 
         // clear requests from previous test
-        submitted_del_requests.clear();
+        ClearSubmittedDelRequests();
 
         batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
         ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(16));
+        ASSERT_TRUE(WaitUntilSubmittedDelRequests());
         ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
         cache_reclaimer_->Stop();
 
         // with 100% key usage and trigger at 90%, reclaiming should happen
-        ASSERT_FALSE(submitted_del_requests.empty());
+        ASSERT_TRUE(HasSubmittedDelRequests());
     }
 
     {
@@ -2448,18 +2517,18 @@ TEST_F(CacheReclaimerTest, TestKeyCountEdgeCases) {
         instance_groups.emplace_back(ins_group);
 
         // clear requests from previous test
-        submitted_del_requests.clear();
+        ClearSubmittedDelRequests();
 
         batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
         ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(16));
+        ASSERT_TRUE(WaitUntilSubmittedDelRequests());
         ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
         cache_reclaimer_->Stop();
 
         // group max key count is zero, reclaiming should happen
-        ASSERT_FALSE(submitted_del_requests.empty());
+        ASSERT_TRUE(HasSubmittedDelRequests());
     }
 }
 
@@ -2517,66 +2586,24 @@ TEST_F(CacheReclaimerTest, TestCronJobAdaptiveSleepInterval) {
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
     batch_get_loc_out_maps =
         std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    const auto initial_sleep_interval = std::chrono::milliseconds(100);
+    cache_reclaimer_->SetSleepIntervalMs(request_context_.get(),
+                                         static_cast<std::uint32_t>(initial_sleep_interval.count()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-    // worker thread should first sleep for 10ms then do the reclaiming
-    // multiple times with 0 sleep interval in between.
-    // here we set the wait time to be 16ms to verify the worker thread
-    // sleep interval is set to 0, or the reclaiming round would
-    // otherwise equal to 1 (see below for explanation).
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    // The worker should first sleep for initial_sleep_interval, do one
+    // reclaiming round, then reduce its sleep interval to 0 and immediately
+    // enter following rounds. Use a two-phase wait so the test does not depend
+    // on absolute scheduler timing, while still requiring the second round to
+    // arrive before the original sleep interval would have elapsed again.
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests(initial_sleep_interval + std::chrono::milliseconds(1000)));
+    ASSERT_TRUE(WaitUntil(
+        [this] { return ListInstanceGroupCallCount() > 1 && SubmittedDelRequestCount() > 1; },
+        initial_sleep_interval / 2));
     cache_reclaimer_->Stop(); // join the worker thread
 
-    // the worker thread is synchronised by join(),
-    // so the count should be 1+1 if sleep interval reduction is not
-    // working:
-    //
-    //    [start]
-    //       |
-    //       |
-    //   sleep 10ms
-    //       |
-    //       |
-    //       V
-    // [1st triggered]
-    //       |
-    //       |
-    // sleep 6ms (stopping requested by main thread)
-    //       |
-    //       |
-    // working thread signaled and wake up immediately
-    //       |
-    //       |
-    //       V
-    //    [finish]
-    //
-    // but when the sleep interval reduction is working as expected,
-    // what's going on would be:
-    //
-    //    [start]
-    //       |
-    //       |
-    //   sleep 10ms
-    //       |
-    //       |
-    //       V
-    // [1st triggered]
-    // <sleep interval becomes 0>
-    //       |
-    //       |
-    // [2nd triggered]
-    // [3rd triggered]
-    // [   ......    ]
-    // [nth triggered]
-    //       |
-    //       |
-    //  (stopping requested)
-    //       |
-    //       |
-    //       V
-    //    [finish]
-    ASSERT_LT(1, list_ins_group_call_counter);
-    ASSERT_LT(1, submitted_del_requests.size());
+    ASSERT_LT(1, ListInstanceGroupCallCount());
+    ASSERT_LT(1, SubmittedDelRequestCount());
 }
 
 TEST_F(CacheReclaimerTest, TestCronJobAdaptiveSleepIntervalRecovery) {
@@ -3346,8 +3373,9 @@ TEST_F(CacheReclaimerTest, TestPerf) {
         }
     }
 
-    ASSERT_FALSE(submitted_del_requests.empty());
-    const auto &req = submitted_del_requests.back();
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_FALSE(requests.empty());
+    const auto &req = requests.back();
     ASSERT_EQ(batching_sz, req.block_keys.size());
 
     std::uint64_t reclaim_cron_count_v;


### PR DESCRIPTION
## Summary

Fix flaky `CacheReclaimerTest` assertions that read `submitted_del_requests` while the cache reclaimer worker thread writes to it asynchronously.

## Root Cause

The test stub records submitted delete requests from a worker thread, while test assertions previously read and cleared the same vector directly. Several positive assertions also relied on a fixed 16 ms sleep before checking for a submitted request. On slower or noisier runners, the worker had not always reached the submit path yet, which caused intermittent empty-vector assertions in LRU/key-count cases.

## Changes

- Protect `submitted_del_requests` with a mutex in the submit stub and test cleanup.
- Add fixture helpers for locked snapshots, clears, counts, and wait-until-submitted checks.
- Replace fixed-sleep positive assertions with explicit waits for a submitted delete request.
- Keep negative assertions locked so they no longer race with the worker thread.

## Validation

- `bazelisk test //kv_cache_manager/manager/test:CacheReclaimerTest --test_output=errors --cache_test_results=no`
- Targeted flaky cases were also run 20 times locally on the same patch before splitting this PR branch.
- The same fix was validated in Aliyun runner workflow run `28162271240`: `unit_test`, `integration_test`, and `client_test` all passed.