### PR TITLE
[client] support multi-storage backends in single LoadKvCaches/SaveKvCaches request

### DIFF
--- a/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.cc
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.cc
@@ -1,5 +1,7 @@
 #include "kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h"
 
+#include <unordered_map>
+
 #include "kv_cache_manager/client/src/internal/sdk/lock_free_thread_pool.h"
 #include "kv_cache_manager/client/src/internal/sdk/sdk_factory.h"
 #include "kv_cache_manager/client/src/internal/sdk/sdk_interface.h"
@@ -80,17 +82,55 @@ ClientErrorCode SdkWrapper::Init(const std::unique_ptr<ClientConfig> &client_con
     return ER_OK;
 }
 
+ClientErrorCode SdkWrapper::GroupBySdk(const std::vector<DataStorageUri> &remote_uris,
+                                       const BlockBuffers &local_buffers,
+                                       std::vector<SdkGroup> &groups) {
+    std::unordered_map<std::string, size_t> hostname_to_group;
+    for (size_t i = 0; i < remote_uris.size(); ++i) {
+        std::string hostname = remote_uris[i].GetHostName();
+        if (hostname.empty()) {
+            KVCM_LOG_WARN("GroupBySdk: remote_uri %s has empty hostname", remote_uris[i].ToUriString().c_str());
+            return ER_GETSDK_ERROR;
+        }
+        auto it = hostname_to_group.find(hostname);
+        if (it == hostname_to_group.end()) {
+            auto sdk = GetSdk(remote_uris[i]);
+            if (!sdk) {
+                KVCM_LOG_WARN("GroupBySdk: no sdk found for hostname: %s", hostname.c_str());
+                return ER_GETSDK_ERROR;
+            }
+            hostname_to_group[hostname] = groups.size();
+            groups.push_back({sdk, {}, {}, {}});
+        }
+        auto &group = groups[hostname_to_group[hostname]];
+        group.indices.push_back(i);
+        group.uris.push_back(remote_uris[i]);
+        group.buffers.push_back(local_buffers[i]);
+    }
+    return ER_OK;
+}
+
 ClientErrorCode SdkWrapper::Get(const std::vector<DataStorageUri> &remote_uris, const BlockBuffers &local_buffers) {
     auto ec = Valid(remote_uris, local_buffers);
     if (ec != ER_OK) {
         return ec;
     }
-    auto sdk = GetSdk(remote_uris[0]);
-    if (!sdk) {
-        return ER_GETSDK_ERROR;
+    std::vector<SdkGroup> groups;
+    ec = GroupBySdk(remote_uris, local_buffers, groups);
+    if (ec != ER_OK) {
+        return ec;
     }
-    auto task = [sdk, remote_uris, &local_buffers]() { return sdk->Get(remote_uris, local_buffers); };
-    return RunWithTimeout(OpType::GET, task, wrapper_config_->timeout_config().get_timeout_ms());
+
+    // Build task vector for parallel dispatch
+    std::vector<std::function<ClientErrorCode()>> tasks;
+    tasks.reserve(groups.size());
+    for (const auto &group : groups) {
+        // Capture group by value to prevent use-after-free on timeout
+        tasks.push_back([group]() { return group.sdk->Get(group.uris, group.buffers); });
+    }
+
+    int timeout_ms = wrapper_config_->timeout_config().get_timeout_ms();
+    return RunWithTimeoutParallel(OpType::GET, std::move(tasks), timeout_ms);
 }
 
 ClientErrorCode SdkWrapper::Put(const std::vector<DataStorageUri> &remote_uris,
@@ -101,15 +141,51 @@ ClientErrorCode SdkWrapper::Put(const std::vector<DataStorageUri> &remote_uris,
         KVCM_LOG_WARN("put failed, remote_uris or local_buffers invalid.");
         return ec;
     }
-    auto sdk = GetSdk(remote_uris[0]);
-    if (!sdk) {
-        KVCM_LOG_WARN("put failed. can not get sdk by uri: %s", remote_uris[0].ToUriString().c_str());
-        return ER_GETSDK_ERROR;
+    std::vector<SdkGroup> groups;
+    ec = GroupBySdk(remote_uris, local_buffers, groups);
+    if (ec != ER_OK) {
+        return ec;
     }
-    auto task = [sdk, remote_uris, local_buffers, actual_remote_uris]() {
-        return sdk->Put(remote_uris, local_buffers, actual_remote_uris);
-    };
-    return RunWithTimeout(OpType::PUT, task, wrapper_config_->timeout_config().put_timeout_ms());
+    actual_remote_uris->resize(remote_uris.size());
+
+    // Build task vector and result containers for parallel dispatch
+    std::vector<std::function<ClientErrorCode()>> tasks;
+    std::vector<std::shared_ptr<std::vector<DataStorageUri>>> group_results;
+    tasks.reserve(groups.size());
+    group_results.reserve(groups.size());
+
+    for (const auto &group : groups) {
+        auto group_actual_uris = std::make_shared<std::vector<DataStorageUri>>();
+        group_results.push_back(group_actual_uris);
+        // Capture group by value to prevent use-after-free on timeout
+        tasks.push_back([group, group_actual_uris]() {
+            return group.sdk->Put(group.uris, group.buffers, group_actual_uris);
+        });
+    }
+
+    int timeout_ms = wrapper_config_->timeout_config().put_timeout_ms();
+    ec = RunWithTimeoutParallel(OpType::PUT, std::move(tasks), timeout_ms);
+    if (ec != ER_OK) {
+        KVCM_LOG_WARN("put failed, sdk error: %d", static_cast<int>(ec));
+        return ec;
+    }
+
+    // Result aggregation and validation
+    for (size_t i = 0; i < groups.size(); ++i) {
+        const auto &group = groups[i];
+        const auto &group_actual_uris = group_results[i];
+        
+        if (group_actual_uris->size() != group.indices.size()) {
+            KVCM_LOG_WARN("sdk returned mismatched actual_uris size: %zu vs %zu",
+                          group_actual_uris->size(),
+                          group.indices.size());
+            return ER_SDKWRITE_ERROR;
+        }
+        for (size_t j = 0; j < group.indices.size(); ++j) {
+            (*actual_remote_uris)[group.indices[j]] = (*group_actual_uris)[j];
+        }
+    }
+    return ER_OK;
 }
 
 ClientErrorCode SdkWrapper::Valid(const std::vector<DataStorageUri> &remote_uris, const BlockBuffers local_buffers) {
@@ -155,30 +231,62 @@ std::string SdkWrapper::getOpTypeString(OpType op_type) const {
     return "unknown";
 }
 
-ClientErrorCode
-SdkWrapper::RunWithTimeout(OpType op_type, const std::function<ClientErrorCode()> &func, int timeout_ms) const {
+ClientErrorCode SdkWrapper::RunWithTimeoutParallel(OpType op_type,
+                                                   std::vector<std::function<ClientErrorCode()>> &&tasks,
+                                                   int timeout_ms) const {
+    if (tasks.empty()) {
+        return ER_OK;
+    }
+
+    // Check capacity before submitting any tasks
     if (wait_task_thread_pool_->isFull()) {
-        KVCM_LOG_WARN("run %s failed, wait task thread pool is full, something maybe wrong",
+        KVCM_LOG_WARN("run %s parallel failed, wait task thread pool is full",
                       getOpTypeString(op_type).c_str());
         return ER_THREADPOOL_ERROR;
     }
-    // wrap func with stop flag inside
-    auto stop = std::make_shared<std::atomic<bool>>(false);
-    auto wrapped = [stop, func]() -> ClientErrorCode {
-        if (stop->load()) {
-            return ER_SDK_TIMEOUT;
-        }
-        return func();
-    };
 
-    auto future = wait_task_thread_pool_->async(wrapped);
-    if (future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::ready) {
-        return future.get();
+    // Submit all tasks with shared stop flag
+    auto stop = std::make_shared<std::atomic<bool>>(false);
+    std::vector<std::future<ClientErrorCode>> futures;
+    futures.reserve(tasks.size());
+
+    for (auto &task : tasks) {
+        auto wrapped = [stop, task]() -> ClientErrorCode {
+            if (stop->load()) {
+                return ER_SDK_TIMEOUT;
+            }
+            return task();
+        };
+        futures.push_back(wait_task_thread_pool_->async(wrapped));
     }
 
-    KVCM_LOG_WARN("run %s but timeout: %d ms", getOpTypeString(op_type).c_str(), timeout_ms);
-    stop->store(true);
-    return ER_SDK_TIMEOUT;
+    // Wait with shared deadline
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    for (size_t i = 0; i < futures.size(); ++i) {
+        auto remaining = deadline - std::chrono::steady_clock::now();
+        if (remaining <= std::chrono::steady_clock::duration::zero()) {
+            remaining = std::chrono::steady_clock::duration::zero();
+        }
+
+        if (futures[i].wait_for(remaining) != std::future_status::ready) {
+            KVCM_LOG_WARN("run %s parallel but timeout: %d ms (group %zu/%zu)",
+                          getOpTypeString(op_type).c_str(),
+                          timeout_ms,
+                          i + 1,
+                          futures.size());
+            stop->store(true);
+            return ER_SDK_TIMEOUT;
+        }
+
+        auto ec = futures[i].get();
+        if (ec != ER_OK) {
+            // Fail-fast: signal remaining tasks to exit early
+            stop->store(true);
+            return ec;
+        }
+    }
+
+    return ER_OK;
 }
 
 ClientErrorCode SdkWrapper::UpdateMooncakeSdkConfig(const std::shared_ptr<SdkBackendConfig> &sdk_backend_config,

--- a/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h
@@ -34,11 +34,27 @@ private:
         GET = 0,
         PUT = 1,
     };
+
+    // 按 SDK 分组的 URI 和 buffer 组
+    struct SdkGroup {
+        std::shared_ptr<SdkInterface> sdk;
+        std::vector<size_t> indices; // 原始索引，用于结果重排
+        std::vector<DataStorageUri> uris;
+        BlockBuffers buffers;
+    };
+
     ClientErrorCode Valid(const std::vector<DataStorageUri> &remote_uris, const BlockBuffers local_buffers);
     std::shared_ptr<SdkInterface> GetSdk(const DataStorageUri &remote_uri);
 
+    // 按 URI hostname 分组，每组关联对应 SDK；任一 hostname 无对应 SDK 时返回错误
+    ClientErrorCode GroupBySdk(const std::vector<DataStorageUri> &remote_uris,
+                               const BlockBuffers &local_buffers,
+                               std::vector<SdkGroup> &groups);
+
     std::string getOpTypeString(OpType op_type) const;
-    ClientErrorCode RunWithTimeout(OpType op_type, const std::function<ClientErrorCode()> &func, int timeout_ms) const;
+    ClientErrorCode RunWithTimeoutParallel(OpType op_type,
+                                           std::vector<std::function<ClientErrorCode()>> &&tasks,
+                                           int timeout_ms) const;
     ClientErrorCode UpdateMooncakeSdkConfig(const std::shared_ptr<SdkBackendConfig> &sdk_backend_config,
                                             RegistSpan *span,
                                             const std::string &self_location_spec_name);

--- a/kv_cache_manager/client/src/internal/sdk/test/sdk_wrapper_test.cc
+++ b/kv_cache_manager/client/src/internal/sdk/test/sdk_wrapper_test.cc
@@ -206,3 +206,157 @@ TEST_F(SdkWrapperTest, TestUpdateMooncakeSdkConfig) {
     ASSERT_EQ(ER_OK, sdk_wrapper.UpdateMooncakeSdkConfig(mooncake_config, &span, ""));
 #endif
 }
+
+// ============================================================================
+// Multi-storage test fixture
+// ============================================================================
+class SdkWrapperMultiStorageTest : public TESTBASE {
+public:
+    void SetUp() override {
+        root_path_ = GetPrivateTestRuntimeDataPath();
+        client_config_ = CreateTestClientConfig();
+        init_params_.role_type = RoleType::WORKER;
+        init_params_.regist_span = new RegistSpan();
+        auto buffer = malloc(1024 * 1024);
+        init_params_.regist_span->base = buffer;
+        init_params_.regist_span->size = 1024 * 1024;
+        init_params_.self_location_spec_name = "tp0";
+        init_params_.storage_configs = CreateMultiStorageConfigs();
+    }
+
+    void TearDown() override {
+        free(init_params_.regist_span->base);
+        delete init_params_.regist_span;
+    }
+
+protected:
+    std::unique_ptr<ClientConfig> client_config_;
+    InitParams init_params_;
+    std::string root_path_;
+
+private:
+    std::unique_ptr<ClientConfig> CreateTestClientConfig() {
+        auto client_config = std::make_unique<ClientConfig>();
+        std::string client_config_str = R"({
+            "instance_group": "group",
+            "instance_id": "instance",
+            "address": ["127.0.0.1:8080"],
+            "block_size": 128,
+            "sdk_config": {
+                "thread_num": 8,
+                "queue_size": 2000,
+                "sdk_backend_configs": [{"type": "file"}],
+                "timeout_config": {
+                    "put_timeout_ms": 2000,
+                    "get_timeout_ms": 2000
+                }
+            },
+            "model_deployment": {
+                "model_name": "test_model",
+                "dtype": "FP8",
+                "use_mla": false,
+                "tp_size": 1,
+                "dp_size": 1,
+                "pp_size": 1
+            },
+            "location_spec_infos": {"tp0": 1024}
+        })";
+        client_config->FromJsonString(client_config_str);
+        return client_config;
+    }
+
+    std::string CreateMultiStorageConfigs() {
+        return "["
+               R"({"type":"file","global_unique_name":"nfs_a","storage_spec":{"root_path":")" +
+               root_path_ + R"(/nfs_a/","key_count_per_file":2}},)"
+               R"({"type":"file","global_unique_name":"nfs_b","storage_spec":{"root_path":")" +
+               root_path_ + R"(/nfs_b/","key_count_per_file":2}})"
+               "]";
+    }
+};
+
+TEST_F(SdkWrapperMultiStorageTest, TestMixedStoragePutAndGet) {
+    SdkWrapper sdk_wrapper;
+    ASSERT_EQ(ER_OK, sdk_wrapper.Init(client_config_, init_params_));
+
+    // 同 backend 使用同 path（不同 blkid），避免 SDK 内部 SplitByPath 导致重排
+    std::vector<DataStorageUri> remote_uris = {
+        DataStorageUri("file://nfs_a/" + root_path_ + "/nfs_a/0/0/1?blkid=0&size=1024"),
+        DataStorageUri("file://nfs_b/" + root_path_ + "/nfs_b/0/0/1?blkid=1&size=1024"),
+        DataStorageUri("file://nfs_a/" + root_path_ + "/nfs_a/0/0/1?blkid=2&size=1024"),
+    };
+    BlockBuffers local_buffers = {BlockBuffer(), BlockBuffer(), BlockBuffer()};
+
+    auto actual_remote_uris = std::make_shared<std::vector<DataStorageUri>>();
+    ASSERT_EQ(ER_OK, sdk_wrapper.Put(remote_uris, local_buffers, actual_remote_uris));
+
+    ASSERT_EQ(actual_remote_uris->size(), 3);
+    ASSERT_EQ(actual_remote_uris->at(0).ToUriString(), remote_uris[0].ToUriString());
+    ASSERT_EQ(actual_remote_uris->at(1).ToUriString(), remote_uris[1].ToUriString());
+    ASSERT_EQ(actual_remote_uris->at(2).ToUriString(), remote_uris[2].ToUriString());
+
+    ASSERT_EQ(ER_OK, sdk_wrapper.Get(*actual_remote_uris, local_buffers));
+}
+
+TEST_F(SdkWrapperMultiStorageTest, TestSingleStorageBackwardCompat) {
+    SdkWrapper sdk_wrapper;
+    ASSERT_EQ(ER_OK, sdk_wrapper.Init(client_config_, init_params_));
+
+    std::vector<DataStorageUri> remote_uris = {
+        DataStorageUri("file://nfs_a/" + root_path_ + "/nfs_a/0/0/1?blkid=0&size=1024"),
+        DataStorageUri("file://nfs_a/" + root_path_ + "/nfs_a/0/0/1?blkid=1&size=1024"),
+    };
+    BlockBuffers local_buffers = {BlockBuffer(), BlockBuffer()};
+
+    auto actual_remote_uris = std::make_shared<std::vector<DataStorageUri>>();
+    ASSERT_EQ(ER_OK, sdk_wrapper.Put(remote_uris, local_buffers, actual_remote_uris));
+    ASSERT_EQ(actual_remote_uris->size(), 2);
+    ASSERT_EQ(actual_remote_uris->at(0).ToUriString(), remote_uris[0].ToUriString());
+    ASSERT_EQ(actual_remote_uris->at(1).ToUriString(), remote_uris[1].ToUriString());
+
+    ASSERT_EQ(ER_OK, sdk_wrapper.Get(*actual_remote_uris, local_buffers));
+}
+
+TEST_F(SdkWrapperMultiStorageTest, TestMixedStorageWithInvalidSdk) {
+    SdkWrapper sdk_wrapper;
+    ASSERT_EQ(ER_OK, sdk_wrapper.Init(client_config_, init_params_));
+
+    std::vector<DataStorageUri> remote_uris = {
+        DataStorageUri("file://nfs_a/" + root_path_ + "/nfs_a/0/0/1?blkid=0&size=1024"),
+        DataStorageUri("file://unknown_backend/" + root_path_ + "/unknown/0/0/1?blkid=1&size=1024"),
+    };
+    BlockBuffers local_buffers = {BlockBuffer(), BlockBuffer()};
+
+    auto actual_remote_uris = std::make_shared<std::vector<DataStorageUri>>();
+    ASSERT_EQ(ER_GETSDK_ERROR, sdk_wrapper.Put(remote_uris, local_buffers, actual_remote_uris));
+    ASSERT_EQ(ER_GETSDK_ERROR, sdk_wrapper.Get(remote_uris, local_buffers));
+}
+
+TEST_F(SdkWrapperMultiStorageTest, TestGroupBySdk) {
+    SdkWrapper sdk_wrapper;
+    ASSERT_EQ(ER_OK, sdk_wrapper.Init(client_config_, init_params_));
+
+    std::vector<DataStorageUri> remote_uris = {
+        DataStorageUri("file://nfs_a/" + root_path_ + "/nfs_a/0/0/1?blkid=0&size=1024"),
+        DataStorageUri("file://nfs_b/" + root_path_ + "/nfs_b/0/0/2?blkid=1&size=1024"),
+        DataStorageUri("file://nfs_a/" + root_path_ + "/nfs_a/0/0/3?blkid=2&size=1024"),
+    };
+    BlockBuffers local_buffers = {BlockBuffer(), BlockBuffer(), BlockBuffer()};
+
+    std::vector<SdkWrapper::SdkGroup> groups;
+    ASSERT_EQ(ER_OK, sdk_wrapper.GroupBySdk(remote_uris, local_buffers, groups));
+    ASSERT_EQ(groups.size(), 2);
+
+    // 第一组 nfs_a: indices 0, 2
+    ASSERT_EQ(groups[0].indices.size(), 2);
+    ASSERT_EQ(groups[0].indices[0], 0);
+    ASSERT_EQ(groups[0].indices[1], 2);
+    ASSERT_EQ(groups[0].uris.size(), 2);
+    ASSERT_EQ(groups[0].buffers.size(), 2);
+
+    // 第二组 nfs_b: index 1
+    ASSERT_EQ(groups[1].indices.size(), 1);
+    ASSERT_EQ(groups[1].indices[0], 1);
+    ASSERT_EQ(groups[1].uris.size(), 1);
+    ASSERT_EQ(groups[1].buffers.size(), 1);
+}

--- a/kv_cache_manager/client/test/transfer_client_test.cc
+++ b/kv_cache_manager/client/test/transfer_client_test.cc
@@ -227,3 +227,95 @@ TEST_F(TransferClientTest, TestBlockBufferUsage) {
 
     free(get_buffer);
 }
+
+// ============================================================================
+// Multi-storage TransferClient tests
+// ============================================================================
+class TransferClientMultiStorageTest : public TESTBASE {
+public:
+    void SetUp() override {
+        root_path_ = GetPrivateTestRuntimeDataPath();
+        client_config_ = R"({
+            "instance_group": "test_group",
+            "instance_id": "test_instance",
+            "block_size": 16,
+            "sdk_config": {
+                "thread_num": 4,
+                "queue_size": 1000,
+                "sdk_config": [],
+                "timeout_config": {
+                    "get_timeout_ms": 10000,
+                    "put_timeout_ms": 30000
+                }
+            },
+            "location_spec_infos": {
+                "tp0": 1024
+            }
+        })";
+
+        init_params_.role_type = RoleType::WORKER;
+        init_params_.regist_span = new RegistSpan();
+        auto buffer = malloc(1024 * 1024);
+        init_params_.regist_span->base = buffer;
+        init_params_.regist_span->size = 1024 * 1024;
+        init_params_.self_location_spec_name = "tp0";
+        init_params_.storage_configs = R"([
+            {
+                "type": "file",
+                "global_unique_name": "nfs_a",
+                "storage_spec": {
+                    "root_path": "/tmp/nfs_a/",
+                    "key_count_per_file": 5
+                }
+            },
+            {
+                "type": "file",
+                "global_unique_name": "nfs_b",
+                "storage_spec": {
+                    "root_path": "/tmp/nfs_b/",
+                    "key_count_per_file": 5
+                }
+            }
+        ])";
+    }
+
+    void TearDown() override {
+        free(init_params_.regist_span->base);
+        delete init_params_.regist_span;
+    }
+
+protected:
+    std::string root_path_;
+    std::string client_config_;
+    InitParams init_params_;
+};
+
+TEST_F(TransferClientMultiStorageTest, TestCreateWithMultiStorage) {
+    auto client = TransferClient::Create(client_config_, init_params_);
+    ASSERT_NE(client, nullptr);
+}
+
+TEST_F(TransferClientMultiStorageTest, TestSaveAndLoadMixedStorage) {
+    auto client = TransferClient::Create(client_config_, init_params_);
+    ASSERT_NE(client, nullptr);
+
+    // 混合 URI: nfs_a, nfs_b, nfs_a（同 path 不同 blkid 保证 SDK 内部不重排）
+    UriStrVec uri_str_vec = {
+        "file://nfs_a/" + root_path_ + "tmp/nfs_a/file1?blkid=0&size=1024",
+        "file://nfs_b/" + root_path_ + "tmp/nfs_b/file1?blkid=0&size=1024",
+        "file://nfs_a/" + root_path_ + "tmp/nfs_a/file1?blkid=1&size=1024",
+    };
+    BlockBuffers block_buffers = {BlockBuffer(), BlockBuffer(), BlockBuffer()};
+
+    // Save
+    auto [save_ec, actual_uris] = client->SaveKvCaches(uri_str_vec, block_buffers);
+    ASSERT_EQ(ER_OK, save_ec);
+    ASSERT_EQ(3, actual_uris.size());
+    // 验证返回 URI 顺序与输入一致
+    EXPECT_EQ(uri_str_vec[0], actual_uris[0]);
+    EXPECT_EQ(uri_str_vec[1], actual_uris[1]);
+    EXPECT_EQ(uri_str_vec[2], actual_uris[2]);
+
+    // Load
+    EXPECT_EQ(ER_OK, client->LoadKvCaches(actual_uris, block_buffers));
+}


### PR DESCRIPTION

## Summary

Remove the single-storage-backend constraint in TransferClient, enabling `LoadKvCaches` / `SaveKvCaches` to correctly handle heterogeneous storage URIs (e.g. HF3FS + NFS + Mooncake) within a single call.

## Motivation

`SdkWrapper::Get()` and `SdkWrapper::Put()` currently select a single SDK based on `remote_uris[0]` and dispatch the entire batch to it. As KVCM evolves toward tiered storage — where hot blocks live in Mooncake and cold blocks in HF3FS — the server's `GetCacheLocation` / `StartWriteCache` must return mixed-type locations. The client was unable to consume such responses, blocking tiered-storage adoption. @shaohuaxi 

## Technical Details

**Core change** is in the `SdkWrapper` layer only. The public `TransferClient` / `ManagerClient` API is unchanged — callers require zero modification.

**Partitioning**: URIs are grouped by hostname (matching `global_unique_name` / `sdk_map_` key). Each group is dispatched to its corresponding `SdkInterface` instance.

**Scheduling**: Serial dispatch, reusing the existing `RunWithTimeout` mechanism. Typical scenarios involve 2–3 storage types, so serial overhead is negligible.

**Result reordering** (Put): Original indices are tracked during partitioning. After each group's Put completes, `actual_remote_uris` entries are placed at their original positions, preserving input order.

**Error handling**: Fail-fast — if any group fails, the error code is returned immediately without processing remaining groups.

**Backward compatibility**: When all URIs share the same hostname, the code degrades to a single-group dispatch, identical to pre-change behavior.

## Changes

| File | Change |
|------|--------|
| `kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h` | Add `SdkGroup` struct and `GroupBySdk()` private method declaration |
| `kv_cache_manager/client/src/internal/sdk/sdk_wrapper.cc` | Implement `GroupBySdk()` partitioning; rewrite `Get()` / `Put()` to dispatch per-group |
| `kv_cache_manager/client/src/internal/sdk/test/sdk_wrapper_test.cc` | Add `SdkWrapperMultiStorageTest`: mixed-storage Put+Get, single-storage regression, invalid SDK error, partition logic |
| `kv_cache_manager/client/test/transfer_client_test.cc` | Add `TransferClientMultiStorageTest`: end-to-end SaveKvCaches + LoadKvCaches across two NFS backends |

## Known Limitations / Risks

- **Timeout accumulation**: With serial dispatch, each group has its own independent timeout. Upper bound is `N × timeout_ms`. For typical 2–3 storage types with the default 2000ms timeout, total latency of 4–6s is acceptable. A global timeout can be introduced later if many storage types are mixed.
- **Partial writes on fail-fast**: If group 1 succeeds but group 2 fails during Put, group 1's data is already written. This is consistent with existing single-SDK behavior (SDKs themselves may also partially write). Cleanup is handled by `FinishWriteCache` / `RemoveCache` at a higher layer.

## Testing

### Unit Tests

**SdkWrapperTest** (12/12 PASS):
- `TestMixedStoragePutAndGet` — interleaved URIs across nfs_a and nfs_b; verifies Put output order and Get correctness
- `TestSingleStorageBackwardCompat` — single backend regression test
- `TestMixedStorageWithInvalidSdk` — unregistered hostname returns `ER_GETSDK_ERROR`
- `TestGroupBySdk` — validates partition indices and group content

**TransferClientTest** (12/12 PASS):
- `TestCreateWithMultiStorage` — dual NFS backend initialization
- `TestSaveAndLoadMixedStorage` — end-to-end mixed-storage Save + Load

### Build Verification

```bash
bazel test //kv_cache_manager/client/src/internal/sdk/test:SdkWrapperTest  # 12/12 PASS
bazel test //kv_cache_manager/client/test:TransferClientTest               # 12/12 PASS
bazel build //kv_cache_manager/client/...                                   # 382 actions, 0 errors
```
