### PR TITLE
[client] set transfer client default timeouts to 15s

### DIFF
--- a/kv_cache_manager/client/src/internal/config/sdk_config.h
+++ b/kv_cache_manager/client/src/internal/config/sdk_config.h
@@ -29,8 +29,8 @@ public:
     void set_get_timeout_ms(int timeout_ms) { get_timeout_ms_ = timeout_ms; }
 
 private:
-    int put_timeout_ms_{2000};
-    int get_timeout_ms_{2000};
+    int put_timeout_ms_{15000};
+    int get_timeout_ms_{15000};
 };
 
 class SdkBackendConfig : public Jsonizable {

--- a/kv_cache_manager/client/src/internal/config/test/sdk_config_test.cc
+++ b/kv_cache_manager/client/src/internal/config/test/sdk_config_test.cc
@@ -126,6 +126,14 @@ TEST_F(SdkBackendConfigTest, TestDuplicatedSdkConfig) {
     ASSERT_EQ(8, std::dynamic_pointer_cast<MooncakeSdkConfig>(mooncake_config)->put_replica_num());
 }
 
+TEST_F(SdkBackendConfigTest, TestSdkTimeoutConfigDefault) {
+    SdkTimeoutConfig timeout_config;
+
+    ASSERT_EQ(15000, timeout_config.get_timeout_ms());
+    ASSERT_EQ(15000, timeout_config.put_timeout_ms());
+    ASSERT_TRUE(timeout_config.Validate());
+}
+
 // Test cases for operator== functions
 TEST_F(SdkBackendConfigTest, TestSdkTimeoutConfigEquality) {
     SdkTimeoutConfig config1;

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -190,8 +190,8 @@ class HiCacheKVCM(HiCacheStorage):
         # sdk
         self.sdk_thread_num = self.extra_config.get("sdk_thread_num", 4)
         self.sdk_queue_size = self.extra_config.get("sdk_queue_size", 1000)
-        self.sdk_get_timeout_ms = self.extra_config.get("sdk_get_timeout_ms", 5000)
-        self.sdk_put_timeout_ms = self.extra_config.get("sdk_put_timeout_ms", 10000)
+        self.sdk_get_timeout_ms = self.extra_config.get("sdk_get_timeout_ms", 15000)
+        self.sdk_put_timeout_ms = self.extra_config.get("sdk_put_timeout_ms", 15000)
 
         self.read_iov_block_size = self.extra_config.get("read_iov_block_size", 0)
         self.write_iov_block_size = self.extra_config.get("write_iov_block_size", 0)

--- a/kv_cache_manager/py_connector/trtllm/connector.py
+++ b/kv_cache_manager/py_connector/trtllm/connector.py
@@ -80,8 +80,8 @@ def init_kvcm_transfer_client(llm_args, kvcm_config, extra_config):
     # sdk
     sdk_thread_num = kvcm_config.get("sdk_thread_num", 4)
     sdk_queue_size = kvcm_config.get("sdk_queue_size", 1000)
-    sdk_get_timeout_ms = kvcm_config.get("sdk_get_timeout_ms", 5000)
-    sdk_put_timeout_ms = kvcm_config.get("sdk_put_timeout_ms", 10000)
+    sdk_get_timeout_ms = kvcm_config.get("sdk_get_timeout_ms", 15000)
+    sdk_put_timeout_ms = kvcm_config.get("sdk_put_timeout_ms", 15000)
 
     # data transfer setup
     # TODO: sdk_config

--- a/kv_cache_manager/py_connector/vllm/config.py
+++ b/kv_cache_manager/py_connector/vllm/config.py
@@ -13,8 +13,8 @@ class TairKvCacheConnectorExtraConfig:
         self.write_timeout_seconds: int = extra_config.get("write_timeout_seconds", 30)
         self.sdk_thread_num = extra_config.get("sdk_thread_num", 32)
         self.sdk_queue_size = extra_config.get("sdk_queue_size", 1000)
-        self.sdk_get_timeout_ms = extra_config.get("sdk_get_timeout_ms", 5000)
-        self.sdk_put_timeout_ms = extra_config.get("sdk_put_timeout_ms", 10000)
+        self.sdk_get_timeout_ms = extra_config.get("sdk_get_timeout_ms", 15000)
+        self.sdk_put_timeout_ms = extra_config.get("sdk_put_timeout_ms", 15000)
 
         self.read_iov_block_size = extra_config.get("read_iov_block_size", 0)
         self.write_iov_block_size = extra_config.get("write_iov_block_size", 0)


### PR DESCRIPTION
## What changed

- Set the C++ TransferClient SDK default get/put timeouts to 15000ms.
- Align vLLM, SGLang, and TRT-LLM connector default `sdk_get_timeout_ms` / `sdk_put_timeout_ms` values to 15000ms.
- Add a config unit test covering the SDK timeout defaults.

## Why

The previous Transfer client defaults were inconsistent across layers: the C++ SDK defaulted to 2000ms while Python connectors overrode defaults with 5000ms reads and 10000ms writes. The default read and write transfer timeouts should both be 15 seconds.

## Impact

Users who do not explicitly set Transfer client SDK timeouts now get a 15s default for both read/load and write/save operations. Explicit timeout configuration still takes precedence.

## Validation

- `bazel test //kv_cache_manager/client/src/internal/config/test:SdkConfigTest`
- `bazel test //kv_cache_manager/client/test:TransferClientTest`
- `python3 -m py_compile kv_cache_manager/py_connector/vllm/config.py kv_cache_manager/py_connector/sglang/connector.py kv_cache_manager/py_connector/trtllm/connector.py`
- `git diff --check`