### PR TITLE
[build] speed up Mooncake CI build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -112,6 +112,10 @@ build:release -c opt
 build:release --copt -g --copt -O2
 build:release --strip=never
 
+build:ci_fast --force_pic
+build:ci_fast --per_file_copt=external/mooncake/.*@-g0
+build:ci_fast --per_file_copt=external/mooncake/.*@-O1
+
 # asan
 build:asan --copt -fsanitize=address
 build:asan --copt -DADDRESS_SANITIZER

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -90,7 +90,7 @@ jobs:
           set -x
           set -e
           ulimit -c unlimited
-          bazelisk test ${{ matrix.test_target }} ${{ matrix.test_args }} --cache_test_results=no --test_output=errors
+          bazelisk test ${{ matrix.test_target }} ${{ matrix.test_args }} --config=ci_fast --cache_test_results=no --test_output=errors
       - &delete_old_disk_cache_step
         name: delete_old_disk_cache
         if: ${{ inputs.rebuildDiskCache || false }}


### PR DESCRIPTION
## Summary
- Add a `ci_fast` Bazel config for CI-only Mooncake builds.
- Build Mooncake with `--force_pic`, `-g0`, and `-O1` under `ci_fast`.
- Enable `--config=ci_fast` in the open-source test workflow.

## Why
Mooncake CI rebuild time is dominated by large C++ translation units such as `master_client.cpp` and `real_client.cpp`. `--force_pic` avoids compiling separate PIC and non-PIC variants, while `-g0` and `-O1` reduce compiler work for CI builds without changing the normal local/default build mode.

## Validation
- `bazelisk test --jobs=8 --config=ci_fast --test_output=errors //3rdparty/mooncake:mooncake_client_c_test`  
  Run locally with a repository cache for external archive downloads.


## 优化效果（Boost deps对耗时影响不大，本次未包含）

```text
target: @mooncake//:mooncake_store
jobs: 8
output_user_root: 全新
disk_cache: 显式关闭 --disk_cache=
repository_cache: 开启 ~/.cache/bazel/repository_cache
baseline: clean HEAD ba1bdef，无 ci_fast，无 Boost deps 优化
optimized: 当前改动，Boost deps 收敛 + --config=ci_fast
```

结果：

| 方案 | Elapsed | Execution | Critical Path | master_client.cpp | configured targets | total actions | local actions |
|---|---:|---:|---:|---:|---:|---:|---:|
| baseline | 318.6s | 304.8s | 167.8s | 158.7s | 16872 | 17349 | 593 |
| optimized | 146.2s | 134.0s | 86.8s | 86.5s | 4453 | 2026 | 539 |

结论：

- 总耗时从 `318.6s` 降到 `146.2s`，省 `172s`，约 `2.18x`。
- 真正编译执行阶段从 `304.8s` 降到 `134.0s`，约 `2.27x`。
- critical path 从 `167.8s` 降到 `86.8s`，主要是 `master_client.cpp` 从 `158.7s` 降到 `86.5s`。
- Boost deps 收敛把 configured targets 从 `16872` 降到 `4453`，total actions 从 `17349` 降到 `2026`。
- `force_pic` 确实砍掉了一部分 PIC/non-PIC 重复；baseline 输出有 `.a + .pic.a + .so`，optimized 只有 `.a + .so`。

额外观察：不带 disk cache 时，主收益不是分析时间，而是 `ci_fast` 里的 `-g0` 和 `force_pic`。Boost deps 优化主要减少图规模、internal actions 和输出体积；这次临时输出目录优化前约 `4.3G`，优化后约 `1.4G`。

