### PR TITLE
Add ReportEvent block snapshot reconciliation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ### 设计文档
 - [模块架构与关联关系](design/module_architecture.md) - 各模块职责、依赖方向、控制流与数据流，附 Mermaid 图
 - [基本概念](design/basic_concepts.md) - Storage、Instance Group、Instance、Block、CacheLocation 等核心概念
+- [ReportEvent 元数据一致性与 Location 索引设计](design/report_event_metadata_consistency.md) - Subscriber 上报、CacheMeta 持久化、location 反向索引与不一致处理
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 
 ### 开发文档

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -111,10 +111,17 @@ engine-specific cache signals into block-level events:
   `EVENT_BLOCK_DELETE`, and full-clear snapshots.
 
 `storage_type` identifies the storage/cache system, such as Vineyard/V6D.
-`location` identifies one diffable location namespace under the reporting host.
-Use `location.labels` when one host has multiple independent cache groups, such
-as vLLM `dp_rank` or `group_idx`. `specs` describes the concrete address of the
-block in that namespace.
+`medium` identifies one diffable cache namespace under the reporting host.
+`specs` describes the concrete address of the block in that namespace.
+Subscribers should encode component identity in `LocationSpec.name`, for
+example `full_attention:group=0:tp=0` or `mamba_state:group=1`. KVCM currently
+stores and matches only full-attention specs; mamba-state specs are accepted but
+ignored until fine-grained hybrid-cache matching is implemented. Legacy spec
+names such as `tp0` are treated as full-attention for compatibility.
+For `EVENT_BLOCK_SNAPSHOT`, the diff scope is the reporter `host_ip_port` plus
+`medium` after mamba-state specs are filtered. If an engine has multiple
+full-attention groups for one block, report them as multiple `LocationSpec`
+entries on the same `BlockSnapshotItem`.
 
 ```bash
 curl -g -vvv -X POST http://localhost:6382/api/reportEvent \
@@ -135,19 +142,13 @@ curl -g -vvv -X POST http://localhost:6382/api/reportEvent \
       {
         "event_type": "EVENT_BLOCK_SNAPSHOT",
         "block_snapshot": {
-          "location": {
-            "medium": "gpu",
-            "labels": {
-              "dp_rank": "0",
-              "group_idx": "1"
-            }
-          },
+          "medium": "gpu",
           "blocks": [
             {
               "block_key": "123",
               "specs": [
                 {
-                  "name": "tp0",
+                  "name": "full_attention:group=0:tp=0",
                   "uri": "vineyard://192.168.2.1/gpu/123?size=4096"
                 }
               ]

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -101,6 +101,64 @@ curl -g -vvv -X POST http://localhost:6382/api/removeCache \
 }'
 ```
 
+## Report Event
+
+`reportEvent` is the cache-subscriber ingestion API. A subscriber normalizes
+engine-specific cache signals into block-level events:
+
+- RTP-LLM subscriber: report full host/location snapshots with `EVENT_BLOCK_SNAPSHOT`.
+- vLLM subscriber: map KV events to ordered `EVENT_BLOCK_ADD`,
+  `EVENT_BLOCK_DELETE`, and full-clear snapshots.
+
+`storage_type` identifies the storage/cache system, such as Vineyard/V6D.
+`location` identifies one diffable location namespace under the reporting host.
+Use `location.labels` when one host has multiple independent cache groups, such
+as vLLM `dp_rank` or `group_idx`. `specs` describes the concrete address of the
+block in that namespace.
+
+```bash
+curl -g -vvv -X POST http://localhost:6382/api/reportEvent \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "trace_id": "trace_id_131",
+    "instance_id": "test_instance",
+    "host_ip_port": "192.168.2.1:8080",
+    "storage_type": "ST_VINEYARD",
+    "events": [
+      {
+        "event_type": "EVENT_NODE_REGISTER",
+        "node_register": {
+          "mediums": ["gpu"]
+        }
+      },
+      {
+        "event_type": "EVENT_BLOCK_SNAPSHOT",
+        "block_snapshot": {
+          "location": {
+            "medium": "gpu",
+            "labels": {
+              "dp_rank": "0",
+              "group_idx": "1"
+            }
+          },
+          "blocks": [
+            {
+              "block_key": "123",
+              "specs": [
+                {
+                  "name": "tp0",
+                  "uri": "vineyard://192.168.2.1/gpu/123?size=4096"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+}'
+```
+
 ## Trim Cache
 ```bash
 curl -g -vvv -X POST http://localhost:6382/api/trimCache \

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -121,7 +121,10 @@ names such as `tp0` are treated as full-attention for compatibility.
 For `EVENT_BLOCK_SNAPSHOT`, the diff scope is the reporter `host_ip_port` plus
 `medium` after mamba-state specs are filtered. If an engine has multiple
 full-attention groups for one block, report them as multiple `LocationSpec`
-entries on the same `BlockSnapshotItem`.
+entries on the same `BlockSnapshotItem`. Snapshot reconciliation verifies
+existing CacheMeta candidates against full-attention specs before deleting
+blocks, so mamba-state-only metadata is not removed by the current full-attention
+matching path.
 
 ```bash
 curl -g -vvv -X POST http://localhost:6382/api/reportEvent \

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -4,7 +4,7 @@
 
 > **维护提示**：当模块的职责、依赖方向或调用关系发生变化，或新增/删除模块时，请同步更新本文档与文末的 Mermaid 图，并同步更新 [AGENTS.md](../../AGENTS.md) 中的缩略图。
 
-相关文档：[基本概念](basic_concepts.md)、[高可用与选主机制](ha_leader_elector.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
+相关文档：[基本概念](basic_concepts.md)、[ReportEvent 元数据一致性与 Location 索引设计](report_event_metadata_consistency.md)、[高可用与选主机制](ha_leader_elector.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
 
 ---
 

--- a/docs/design/report_event_metadata_consistency.md
+++ b/docs/design/report_event_metadata_consistency.md
@@ -1,0 +1,277 @@
+# ReportEvent 元数据一致性与 Location 索引设计
+
+## 1. 背景
+
+`ReportEvent` 用于接收外部 subscriber 上报的 KVCache 事件。KVCM 不主动连接所有推理 Worker，而是由 RTP-LLM、vLLM、V6D 等侧的 subscriber 将本地 cache 变化归一化成 block 级事件，上报给 KVCM。
+
+其中 `EVENT_BLOCK_SNAPSHOT` 是一个按 location 做全量对账的事件：subscriber 上报某个 `host_ip_port + medium` 当前完整拥有的 block 集合，KVCM 需要和自己已有的元数据做 diff，补齐新增 block，并删除已经不在该 location 上的 block。
+
+如果每次 snapshot diff 都从 Redis 全量扫描所有 CacheMeta，再筛选目标 location，会带来几个问题：
+
+- 请求路径延迟不可控，block 数量增长后会直接影响 subscriber 上报。
+- `SCAN` 不是一致性快照，并发写入/删除时可能重复或遗漏。
+- 多 KVCM 进程各自扫描重建内存索引，浪费 Redis 和 KVCM 资源。
+- 依赖 meta backend 支持全量 scan，不利于抽象和后续替换 backend。
+
+因此 snapshot diff 需要一份可持久化、跨 KVCM 共享的 `location_id -> block_key` 二级索引。同时，二级索引不能成为新的事实来源，读链路必须显式处理索引与 CacheMeta 不一致的情况。
+
+## 2. 目标与非目标
+
+### 目标
+
+- `ReportEvent` 写入的 block cache 信息仍然存入普通 CacheMeta，和现有查询链路复用同一份元数据。
+- 为 `EVENT_BLOCK_SNAPSHOT` 提供持久化的 location 反向索引，避免请求路径全库扫描。
+- 读链路容忍索引和 CacheMeta 的短暂不一致，不因索引脏数据误删或误命中。
+- 写链路通过顺序设计，让新写入尽量只产生 over-index，不产生新的 under-index。
+- 支持 RTP-LLM full snapshot 和 vLLM KV events 两类 subscriber。
+
+### 非目标
+
+- 不让 KVCM 主动拉取所有 Worker 的 cache 状态。
+- 不把 location 反向索引暴露成用户查询接口。
+- 当前不实现 mamba-state 的精细匹配。接口接收相关 `LocationSpec.name`，但存储和匹配仍只处理 full-attention。
+- 不要求所有 meta backend 一开始都支持原子多 key 事务；Redis 后端优先实现强一些的一致性语义，其他 backend 可以先实现同接口的最佳努力版本。
+
+## 3. 核心概念
+
+### CacheMeta
+
+CacheMeta 是唯一事实来源，结构仍然是：
+
+```text
+instance_id + block_key -> CacheLocationMap
+```
+
+每个 `CacheLocation` 包含：
+
+- `location_id`
+- `storage_type`
+- `status`
+- `LocationSpec[]`
+
+`GetCacheMeta` / `GetCacheLocation` 等查询接口只信任 CacheMeta，不直接使用 location 反向索引。
+
+### Location
+
+`ReportEvent` 的 diff scope 是一个 location。location 由 event backend 根据 `host_ip_port + medium` 构造，例如 V6D 可构造为：
+
+```text
+kvs#v6d#{medium}#{host_ip_port}
+```
+
+`storage_type` 表示大的存储系统，比如 Vineyard/V6D；`medium` 表示该 host 下可独立 diff 的位置，比如 `gpu`、`mem`、`disk`。更细粒度的 full-attention group、TP、mamba-state 等信息放在 `LocationSpec.name` 中。
+
+### Location 反向索引
+
+二级索引用于加速 snapshot diff：
+
+```text
+instance_id + location_id -> set(block_key)
+```
+
+它是 CacheMeta 的派生索引，不是事实来源。索引允许短暂 over-index：索引里有某个 block_key，但 CacheMeta 中没有对应 location。读链路会过滤这类脏数据，并异步或顺手修复索引。
+
+索引不应产生新的 under-index：CacheMeta 中已有某个 location，但索引缺少该 block_key。under-index 会导致 snapshot diff 找不到应删除的旧 block，读路径无法在不扫描全量 CacheMeta 的情况下完全发现它。因此写路径要通过顺序和失败处理避免新 under-index。
+
+## 4. 持久化模型
+
+建议在 meta 层增加独立抽象，例如：
+
+```cpp
+class LocationKeyIndexBackend {
+public:
+    virtual ErrorCode AddKeys(RequestContext*, const std::string& location_id,
+                              const KeyVector& keys) = 0;
+    virtual ErrorCode RemoveKeys(RequestContext*, const std::string& location_id,
+                                 const KeyVector& keys) = 0;
+    virtual ErrorCode GetKeys(RequestContext*, const std::string& location_id,
+                              KeyVector& out_keys) = 0;
+};
+```
+
+也可以把这组接口挂到 `MetaStorageBackend` 上，前提是不要把索引逻辑散落在 `CacheManager`。`CacheManager` 只表达业务语义：上报 add/delete/snapshot；`MetaSearcher` 负责 CacheMeta 与二级索引的一致性维护。
+
+Redis 后端可以使用 set 存储：
+
+```text
+{meta_prefix}:locidx:{hash(location_id)}:{shard_id} -> SET(block_key)
+```
+
+是否分 shard 由单 location 的 block 数决定。初版可以先用单 set，但接口要保留 shard 能力，避免后续改调用层。
+
+## 5. 写路径设计
+
+### 5.1 Add / Upsert
+
+Add 或 upsert 某个 `block_key -> location_id` 时，顺序应为：
+
+1. 先把 `block_key` 加入 location 反向索引。
+2. 再写入或更新 CacheMeta。
+3. 如果索引写失败，则不写 CacheMeta，并返回该 item 失败。
+4. 如果索引写成功但 CacheMeta 写失败，允许留下 over-index。
+
+这样最坏情况是索引里多了一个 key。后续 snapshot 读索引时会 BatchGet CacheMeta 过滤，发现该 key 并没有对应 location 后可以清理索引。更重要的是，成功写入 CacheMeta 的 location 基本不会缺少反向索引。
+
+### 5.2 Delete
+
+Delete 某个 `block_key -> location_id` 时，顺序应为：
+
+1. 先从 CacheMeta 删除该 location。
+2. 再从 location 反向索引删除该 `block_key`。
+3. CacheMeta 删除失败则返回失败，不删除索引。
+4. CacheMeta 确认删除成功后，再删除索引；如果索引删除失败，允许留下 over-index。
+5. 如果 CacheMeta 返回 `EC_NOENT`，请求热路径不急于删除索引，避免和并发 add-before-meta 形成竞态。此时留下的 over-index 由读路径过滤，后续离线 repair 处理。
+
+这个顺序同样保证失败后最多是 over-index，而不是 CacheMeta 仍有 location 但索引已经丢失。
+
+### 5.3 RemoveCache / HostDown / Reclaimer
+
+所有会删除 CacheMeta 的路径都必须维护 location 反向索引，包括：
+
+- `ReportEvent(EVENT_BLOCK_DELETE)`
+- `ReportEvent(EVENT_BLOCK_SNAPSHOT)` diff 出来的删除
+- `HOST_DOWN` 触发的 host location 清理
+- `RemoveCache`
+- reclaimer 删除
+
+这些路径如果能在删除前读到旧 `CacheLocationMap`，应先记录要删除的 `location_id` 列表，再按“先删 CacheMeta，后删索引”的顺序执行。
+
+### 5.4 Snapshot
+
+`EVENT_BLOCK_SNAPSHOT` 的单 location 对账流程：
+
+1. 读取该 location 的反向索引，得到 candidate keys。
+2. 对 candidate keys 做 `BatchGetLocation`。
+3. 只保留 CacheMeta 中仍然包含该 `location_id` 且状态可服务的 keys，得到 `existing_keys`。
+4. 对于索引有但 CacheMeta 不再包含该 location 的 keys，记录为 stale index；热路径只过滤，不立即删除索引。
+5. 从上报 payload 得到 `reported_keys`。
+6. `to_add = reported_keys - existing_keys`。
+7. `to_delete = existing_keys - reported_keys`。
+8. 对 `to_add` 走 Add / Upsert 顺序。
+9. 对 `to_delete` 走 Delete 顺序。
+
+重要约束：snapshot 只能删除 `existing_keys - reported_keys`，不能删除“索引中存在但 CacheMeta 未确认存在”的 key，也不能根据索引直接判断某个 key 有效。
+
+## 6. 读路径不一致处理
+
+### 6.1 Snapshot Diff 读索引
+
+索引读取结果必须经过 CacheMeta 二次确认。伪代码：
+
+```text
+candidate_keys = LocationIndex.GetKeys(location_id)
+location_maps = BatchGetLocation(candidate_keys)
+
+existing_keys = {}
+stale_index_keys = {}
+
+for key, location_map in zip(candidate_keys, location_maps):
+    if location_map contains location_id and location is serving/full-attention:
+        existing_keys.add(key)
+    else:
+        stale_index_keys.add(key)
+
+record stale_index_keys for metrics / delayed repair
+```
+
+这样 over-index 不会造成误删，也不会让不存在的 cache 被当成命中。不要在这个同步读路径里立刻删除 stale index，因为 add 写路径是先写 index 再写 CacheMeta；如果此时把刚写入的 index 当作 stale 删除，后续 CacheMeta 写成功后反而会制造 under-index。
+
+### 6.2 正常 Cache 查询
+
+`GetCacheMeta` / `GetCacheLocation` 不读 location 反向索引，仍从 CacheMeta 读取 block 对应的 `CacheLocationMap`，并按现有规则过滤：
+
+- instance 隔离
+- `CacheLocationStatus`
+- `DataStorageType`
+- `LocationSpec.name`
+- full-attention / mamba-state 兼容策略
+
+因此索引 over-index 不影响正常 cache 命中。
+
+### 6.3 Under-index 的处理
+
+under-index 是需要重点避免的状态。因为如果 CacheMeta 中存在 `location_id`，但 location 索引缺少该 key，则 snapshot diff 无法发现这个旧 key，自然也无法在该 key 未上报时删除它。
+
+设计上应把 under-index 作为异常状态处理：
+
+- 新写路径通过 add-before-meta、delete-after-meta 避免产生新的 under-index。
+- Redis 后端可以用 Lua 或 pipeline + 幂等重试进一步收敛失败窗口。
+- 启动时不在请求路径全量扫描重建索引。
+- 提供低优先级 repair job 或运维工具，对历史数据和异常状态做离线校验：扫描 CacheMeta，重建/补齐 location 索引，并输出修复指标。
+- 对 snapshot diff 暴露指标：candidate 数、stale index 数、reported 数、add 数、delete 数、repair 失败数。如果 stale index 或 repair 失败持续升高，应告警。
+
+换句话说：读路径要容忍 over-index；under-index 不能靠普通读路径完全修复，只能靠写路径不制造、离线 repair 兜底。
+
+## 7. RTP-LLM 与 vLLM 接入
+
+### RTP-LLM
+
+RTP-LLM subscriber 可以继续使用现有本地 cache 状态采集方式，但对 KVCM 上报时应转换为：
+
+- `EVENT_NODE_REGISTER`：注册 host 和可上报 medium。
+- `EVENT_HEARTBEAT`：汇报活性和观测指标。
+- `EVENT_BLOCK_SNAPSHOT`：按 `host_ip_port + medium` 汇报该 location 的完整 block 集合。
+
+RTP-LLM 的 full snapshot 是 authoritative input，但 KVCM 仍只删除 CacheMeta 二次确认后存在于该 location 的 keys。
+
+### vLLM
+
+vLLM KV events 可以转换为：
+
+- block 创建或变为可服务：`EVENT_BLOCK_ADD`
+- block 删除：`EVENT_BLOCK_DELETE`
+- worker 清空或重建本地 cache：空或完整 `EVENT_BLOCK_SNAPSHOT`
+
+vLLM 上报的 group id、attention 类型、TP 等信息放入 `LocationSpec.name`。当前 KVCM 存储和匹配 full-attention；mamba-state spec 可以上报，但会被过滤掉，后续再扩展精细匹配。
+
+### V6D / 本地显存混合位置
+
+`storage_type` 仍表示大的存储系统，例如 Vineyard/V6D；`medium` 表示该系统下的 diff location，例如 `mem` 或 `disk`；`LocationSpec.uri` 表示具体地址。推理引擎内部显存和外部 V6D 内存/磁盘可以作为不同 `storage_type + medium + uri` 组合表达，不需要在 request 级别再引入更细的存储层级。
+
+## 8. 多 KVCM 与失败语义
+
+多 KVCM 进程共享 Redis 后端时，location 反向索引也必须共享同一 namespace，与 CacheMeta 使用同样的 instance 隔离和 prefix 规则。
+
+所有索引操作都应幂等：
+
+- 重复 Add：结果不变。
+- 重复 Delete：结果不变。
+- 重复 Snapshot：最终收敛到上报集合。
+
+失败时的语义：
+
+- Add 索引失败：不写 CacheMeta，item 返回失败。
+- Add CacheMeta 失败：item 返回失败，可能留下 over-index。
+- Delete CacheMeta 返回 `EC_NOENT`：业务删除可视为幂等成功，但热路径不删除索引，避免误清理并发 add-before-meta 的 index。
+- Delete 索引失败：item 可以返回成功或部分成功，取决于调用方是否要求强一致；但必须打指标，因为它会留下可修复的 over-index。
+- Snapshot 中发现 stale index：不影响 snapshot 主流程，打指标并交给延迟 repair。
+
+## 9. 测试要求
+
+单元测试需要覆盖：
+
+- Add 成功后 CacheMeta 与 location index 都可见。
+- Add 索引失败时不写 CacheMeta。
+- Add CacheMeta 失败时留下 over-index，snapshot 读路径能过滤。
+- Delete 成功后 CacheMeta 和 index 都删除。
+- Delete 索引失败留下 over-index，snapshot 读路径能过滤。
+- Snapshot 只删除 CacheMeta 二次确认存在的 keys。
+- Snapshot 对 stale index 不误删。
+- mamba-state specs 被接收但不进入当前 full-attention 存储和匹配。
+- RTP-LLM full snapshot 与 vLLM add/delete/snapshot 混合事件顺序保持。
+
+集成测试需要覆盖：
+
+- Redis meta backend 下 `ReportEvent` 写入后重启 KVCM，location index 仍可用于 snapshot diff。
+- 多 KVCM 进程共享同一 Redis index 时，A 写入、B snapshot 能正确 diff。
+- 构造 over-index 后，snapshot 不误删，并能清理 stale index。
+- 历史无 index 数据通过 repair job 补齐后，snapshot 不需要请求路径 scan。
+
+## 10. 演进步骤
+
+1. 在 meta 层增加 location index backend 抽象和 Redis 实现。
+2. 将 `MetaSearcher` 的内存 `location_key_index_` 改为持久化 index 读写，并保留小范围内存缓存仅做性能优化，不能作为事实来源。
+3. 调整 `BatchUpsertLocations` 和所有删除 location 的路径，按 add-before-meta、delete-after-meta 顺序维护 index。
+4. 重写 `EVENT_BLOCK_SNAPSHOT` diff：读持久化 index，BatchGet CacheMeta 二次确认，过滤并修复 stale index。
+5. 增加指标和日志，观察 over-index 修复量、索引操作失败量、snapshot diff 数量。
+6. 增加离线 repair 工具，用于老数据迁移和异常状态修复；请求路径不做全量 scan。

--- a/docs/design/report_event_metadata_consistency.md
+++ b/docs/design/report_event_metadata_consistency.md
@@ -69,13 +69,15 @@ kvs#v6d#{medium}#{host_ip_port}
 instance_id + location_id -> set(block_key)
 ```
 
-它是 CacheMeta 的派生索引，不是事实来源。索引允许短暂 over-index：索引里有某个 block_key，但 CacheMeta 中没有对应 location。读链路会过滤这类脏数据，并异步或顺手修复索引。
+它是 CacheMeta 的派生索引，不是事实来源。索引允许短暂 over-index：索引里有某个 block_key，但 CacheMeta 中没有对应 location。读链路会过滤这类脏数据，后续由延迟/离线 repair 清理索引。
 
 索引不应产生新的 under-index：CacheMeta 中已有某个 location，但索引缺少该 block_key。under-index 会导致 snapshot diff 找不到应删除的旧 block，读路径无法在不扫描全量 CacheMeta 的情况下完全发现它。因此写路径要通过顺序和失败处理避免新 under-index。
 
 ## 4. 持久化模型
 
-建议在 meta 层增加独立抽象，例如：
+location 反向索引属于 meta 层能力，调用入口挂在 `MetaStorageBackend` / `MetaIndexer` / `MetaSearcher` 这一层，避免把索引逻辑散落在 `CacheManager`。`CacheManager` 只表达业务语义：上报 add/delete/snapshot；`MetaSearcher` 负责 CacheMeta 与二级索引的一致性维护。
+
+抽象接口等价于：
 
 ```cpp
 class LocationKeyIndexBackend {
@@ -89,15 +91,13 @@ public:
 };
 ```
 
-也可以把这组接口挂到 `MetaStorageBackend` 上，前提是不要把索引逻辑散落在 `CacheManager`。`CacheManager` 只表达业务语义：上报 add/delete/snapshot；`MetaSearcher` 负责 CacheMeta 与二级索引的一致性维护。
-
-Redis 后端可以使用 set 存储：
+Redis / AsyncRedis 后端使用 set 存储并与 CacheMeta 共用 instance namespace：
 
 ```text
 {meta_prefix}:locidx:{hash(location_id)}:{shard_id} -> SET(block_key)
 ```
 
-是否分 shard 由单 location 的 block 数决定。初版可以先用单 set，但接口要保留 shard 能力，避免后续改调用层。
+当前实现先使用单 set，接口保留了后续分 shard 的空间，避免单 location block 数过大时改调用层。Local 后端的 location index 是内存态；Dummy 后端持久化 CacheMeta，并在重新 `Open()` 时从 CacheMeta 重建 location index，因此它可以覆盖本地持久化重启场景，但不是独立持久索引。Redis 后端的 set 才是多 KVCM 共享场景下的持久索引来源。
 
 ## 5. 写路径设计
 
@@ -110,7 +110,7 @@ Add 或 upsert 某个 `block_key -> location_id` 时，顺序应为：
 3. 如果索引写失败，则不写 CacheMeta，并返回该 item 失败。
 4. 如果索引写成功但 CacheMeta 写失败，允许留下 over-index。
 
-这样最坏情况是索引里多了一个 key。后续 snapshot 读索引时会 BatchGet CacheMeta 过滤，发现该 key 并没有对应 location 后可以清理索引。更重要的是，成功写入 CacheMeta 的 location 基本不会缺少反向索引。
+这样最坏情况是索引里多了一个 key。后续 snapshot 读索引时会 BatchGet CacheMeta 过滤，发现该 key 并没有对应 location 后记录为 stale，交给延迟/离线 repair 清理。更重要的是，成功写入 CacheMeta 的 location 基本不会缺少反向索引。
 
 ### 5.2 Delete
 
@@ -198,7 +198,7 @@ under-index 是需要重点避免的状态。因为如果 CacheMeta 中存在 `l
 - Redis 后端可以用 Lua 或 pipeline + 幂等重试进一步收敛失败窗口。
 - 启动时不在请求路径全量扫描重建索引。
 - 提供低优先级 repair job 或运维工具，对历史数据和异常状态做离线校验：扫描 CacheMeta，重建/补齐 location 索引，并输出修复指标。
-- 对 snapshot diff 暴露指标：candidate 数、stale index 数、reported 数、add 数、delete 数、repair 失败数。如果 stale index 或 repair 失败持续升高，应告警。
+- 对 snapshot diff 暴露指标：candidate 数、stale index 数、reported 数、add 数、delete 数；离线 repair 暴露独立修复量和失败数。如果 stale index 或 repair 失败持续升高，应告警。
 
 换句话说：读路径要容忍 over-index；under-index 不能靠普通读路径完全修复，只能靠写路径不制造、离线 repair 兜底。
 
@@ -264,7 +264,7 @@ vLLM 上报的 group id、attention 类型、TP 等信息放入 `LocationSpec.na
 
 - Redis meta backend 下 `ReportEvent` 写入后重启 KVCM，location index 仍可用于 snapshot diff。
 - 多 KVCM 进程共享同一 Redis index 时，A 写入、B snapshot 能正确 diff。
-- 构造 over-index 后，snapshot 不误删，并能清理 stale index。
+- 构造 over-index 后，snapshot 不误删；stale index 清理由延迟/离线 repair 覆盖。
 - 历史无 index 数据通过 repair job 补齐后，snapshot 不需要请求路径 scan。
 
 ## 10. 演进步骤
@@ -272,6 +272,6 @@ vLLM 上报的 group id、attention 类型、TP 等信息放入 `LocationSpec.na
 1. 在 meta 层增加 location index backend 抽象和 Redis 实现。
 2. 将 `MetaSearcher` 的内存 `location_key_index_` 改为持久化 index 读写，并保留小范围内存缓存仅做性能优化，不能作为事实来源。
 3. 调整 `BatchUpsertLocations` 和所有删除 location 的路径，按 add-before-meta、delete-after-meta 顺序维护 index。
-4. 重写 `EVENT_BLOCK_SNAPSHOT` diff：读持久化 index，BatchGet CacheMeta 二次确认，过滤并修复 stale index。
+4. 重写 `EVENT_BLOCK_SNAPSHOT` diff：读持久化 index，BatchGet CacheMeta 二次确认，请求热路径只过滤 stale index。
 5. 增加指标和日志，观察 over-index 修复量、索引操作失败量、snapshot diff 数量。
 6. 增加离线 repair 工具，用于老数据迁移和异常状态修复；请求路径不做全量 scan。

--- a/integration_test/meta_service/test_vineyard_report_event.py
+++ b/integration_test/meta_service/test_vineyard_report_event.py
@@ -160,6 +160,27 @@ def _ev_block_delete(block_key, medium):
     }
 
 
+def _ev_block_snapshot(medium, blocks):
+    """Build a block_snapshot event.
+
+    Args:
+        blocks: list of (block_key, specs) tuples.
+    """
+    return {
+        "event_type": "EVENT_BLOCK_SNAPSHOT",
+        "block_snapshot": {
+            "medium": medium,
+            "blocks": [
+                {
+                    "block_key": str(block_key),
+                    "specs": specs,
+                }
+                for block_key, specs in blocks
+            ],
+        },
+    }
+
+
 def _ev_host_down():
     return {"event_type": "EVENT_HOST_DOWN", "host_down": {}}
 
@@ -614,6 +635,52 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
         locations2 = resp2.get("locations", [])
         self.assertEqual(len(locations2), 0,
                          "Expected no write locations since 2 replicas already exist")
+
+    # 16. BLOCK_SNAPSHOT reconciles the full block set for one host/medium
+    def test_16_block_snapshot_diff(self):
+        host = "192.168.1.240:8080"
+        medium = "mem"
+        key_deleted = 8101
+        key_kept = 8102
+        key_added = 8103
+        uri_deleted = _build_vineyard_uri(host, medium, {"obj_id": "deleted"})
+        uri_kept = _build_vineyard_uri(host, medium, {"obj_id": "kept"})
+        uri_added = _build_vineyard_uri(host, medium, {"obj_id": "added"})
+
+        def has_uri(block_key, expected_uri):
+            resp = self.client.get_cache_location({
+                "trace_id": f"t16_query_{block_key}",
+                "instance_id": self.instance_id,
+                "query_type": "QT_BATCH_GET",
+                "block_keys": [block_key],
+                "block_mask": {"offset": 0},
+            })
+            for loc in resp.get("locations", []):
+                for spec in loc.get("location_specs", []):
+                    if spec.get("uri") == expected_uri:
+                        return True
+            return False
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (key_deleted, _make_single_spec("spec_4096", uri_deleted)),
+                (key_kept, _make_single_spec("spec_4096", uri_kept)),
+            ]),
+        ], trace_id="t16_snapshot_a"))
+        self.assertTrue(has_uri(key_kept, uri_kept))
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_snapshot(medium, [
+                (key_kept, _make_single_spec("spec_4096", uri_kept)),
+                (key_added, _make_single_spec("spec_4096", uri_added)),
+            ]),
+        ], trace_id="t16_snapshot_b"))
+
+        self.assertFalse(has_uri(key_deleted, uri_deleted),
+                         "Second full snapshot should delete blocks missing from the same host/medium")
+        self.assertTrue(has_uri(key_kept, uri_kept))
+        self.assertTrue(has_uri(key_added, uri_added))
 
     # 16a. Heartbeat timeout -> location filtered out, then recovery on heartbeat resume.
     def test_16a_heartbeat_timeout_then_recovery(self):

--- a/integration_test/meta_service/test_vineyard_report_event.py
+++ b/integration_test/meta_service/test_vineyard_report_event.py
@@ -150,12 +150,13 @@ def _make_single_spec(name, uri):
     return [{"name": name, "uri": uri}]
 
 
-def _ev_block_delete(block_key, medium):
+def _ev_block_delete(block_key, medium, spec_names=None):
     return {
         "event_type": "EVENT_BLOCK_DELETE",
         "block_delete": {
             "block_key": str(block_key),
             "medium": medium,
+            "spec_names": list(spec_names or []),
         },
     }
 
@@ -760,6 +761,160 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
         self._assert_uri_absent(key_mem_deleted, uri_mem_deleted, "t16d_query_mem_deleted")
         self._assert_uri_present(key_mem_kept, uri_mem_kept, "t16d_query_mem_kept")
         self._assert_uri_present(key_disk_kept, uri_disk_kept, "t16d_query_disk_kept")
+
+    # 16e. Mamba-only reports are accepted but ignored for current full-attention matching.
+    def test_16e_mamba_only_report_does_not_delete_full_attention(self):
+        host = "192.168.1.244:8080"
+        medium = "gpu"
+        full_key = 8131
+        mamba_key = 8132
+        full_uri = _build_vineyard_uri(host, medium, {"obj_id": "full"})
+        mamba_uri = _build_vineyard_uri(host, medium, {"obj_id": "mamba"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_add(
+                full_key,
+                medium,
+                _make_single_spec("full_attention:group=0:tp=0", full_uri),
+            ),
+        ], trace_id="t16e_full_add"))
+        self._assert_uri_present(full_key, full_uri, "t16e_query_full_before")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_snapshot(medium, [
+                (mamba_key, _make_single_spec("mamba_state:group=1", mamba_uri)),
+            ]),
+            _ev_block_delete(full_key, medium, ["mamba_state:group=1"]),
+        ], trace_id="t16e_mamba_only"))
+
+        self._assert_uri_present(full_key, full_uri, "t16e_query_full_after")
+        self._assert_uri_absent(mamba_key, mamba_uri, "t16e_query_mamba_after")
+
+    # 16f. Snapshot is an ordering barrier inside one ReportEvent request.
+    def test_16f_snapshot_ordering_barrier_inside_batch(self):
+        host = "192.168.1.245:8080"
+        medium = "mem"
+        key_add_after_snapshot = 8141
+        key_add_before_snapshot = 8142
+        uri_after = _build_vineyard_uri(host, medium, {"obj_id": "after"})
+        uri_before = _build_vineyard_uri(host, medium, {"obj_id": "before"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, []),
+            _ev_block_add(
+                key_add_after_snapshot,
+                medium,
+                _make_single_spec("tp0", uri_after),
+            ),
+        ], trace_id="t16f_snapshot_then_add"))
+        self._assert_uri_present(key_add_after_snapshot, uri_after, "t16f_query_after_present")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_add(
+                key_add_before_snapshot,
+                medium,
+                _make_single_spec("tp0", uri_before),
+            ),
+            _ev_block_snapshot(medium, []),
+        ], trace_id="t16f_add_then_snapshot"))
+        self._assert_uri_absent(key_add_after_snapshot, uri_after, "t16f_query_after_deleted")
+        self._assert_uri_absent(key_add_before_snapshot, uri_before, "t16f_query_before_deleted")
+
+    # 16g. Per-item failures do not drop other valid mutations in the same batch.
+    def test_16g_partial_block_add_failure_keeps_valid_adds(self):
+        host = "192.168.1.246:8080"
+        medium = "mem"
+        key_a = 8151
+        key_b = 8152
+        uri_a = _build_vineyard_uri(host, medium, {"obj_id": "valid_a"})
+        uri_b = _build_vineyard_uri(host, medium, {"obj_id": "valid_b"})
+        invalid_uri = _build_vineyard_uri(host, medium, {"obj_id": "invalid"})
+
+        body = self.client.report_event(
+            _make_request(self.instance_id, host, [
+                _ev_node_register([medium]),
+                _ev_block_add(key_a, medium, _make_single_spec("tp0", uri_a)),
+                {
+                    "event_type": "EVENT_BLOCK_ADD",
+                    "block_add": {
+                        "block_key": "not-an-int64",
+                        "medium": medium,
+                        "specs": _make_single_spec("tp0", invalid_uri),
+                    },
+                },
+                _ev_block_add(key_b, medium, _make_single_spec("tp0", uri_b)),
+            ], trace_id="t16g_partial_add"),
+            check_ok=False,
+        )
+        item_results = body.get("item_results", [])
+        self.assertGreaterEqual(len(item_results), 4, json.dumps(body, ensure_ascii=False))
+        self.assertNotIn(item_results[2], ("OK", 1, "1"), json.dumps(body, ensure_ascii=False))
+
+        self._assert_uri_present(key_a, uri_a, "t16g_query_valid_a")
+        self._assert_uri_present(key_b, uri_b, "t16g_query_valid_b")
+
+    # 16h. Snapshot diff is scoped by host even when the same block exists on another host.
+    def test_16h_snapshot_same_block_other_host_survives(self):
+        host_a = "192.168.1.247:8080"
+        host_b = "192.168.1.248:8080"
+        medium = "mem"
+        block_key = 8161
+        uri_a = _build_vineyard_uri(host_a, medium, {"obj_id": "same_block_a"})
+        uri_b = _build_vineyard_uri(host_b, medium, {"obj_id": "same_block_b"})
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (block_key, _make_single_spec("host_a_full", uri_a)),
+            ]),
+        ], trace_id="t16h_snapshot_host_a"))
+        self.client.report_event(_make_request(self.instance_id, host_b, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (block_key, _make_single_spec("host_b_full", uri_b)),
+            ]),
+        ], trace_id="t16h_snapshot_host_b"))
+        self._assert_uri_present(block_key, uri_a, "t16h_query_a_before")
+        self._assert_uri_present(block_key, uri_b, "t16h_query_b_before")
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_block_snapshot(medium, []),
+        ], trace_id="t16h_snapshot_host_a_empty"))
+
+        self._assert_uri_absent(block_key, uri_a, "t16h_query_a_after")
+        self._assert_uri_present(block_key, uri_b, "t16h_query_b_after")
+
+    # 16i. Mixed full-attention and mamba specs store/match only full-attention today.
+    def test_16i_full_attention_and_mamba_mixed_report(self):
+        host = "192.168.1.249:8080"
+        medium = "gpu"
+        block_key = 8171
+        full_uri = _build_vineyard_uri(host, medium, {"obj_id": "full"})
+        mamba_uri = _build_vineyard_uri(host, medium, {"obj_id": "mamba"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (block_key, [
+                    {"name": "full_attention:group=0:tp=0", "uri": full_uri},
+                    {"name": "mamba_state:group=1", "uri": mamba_uri},
+                ]),
+            ]),
+        ], trace_id="t16i_mixed_snapshot"))
+        self._assert_uri_present(block_key, full_uri, "t16i_query_full_after_snapshot")
+        self._assert_uri_absent(block_key, mamba_uri, "t16i_query_mamba_after_snapshot")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_delete(block_key, medium, ["mamba_state:group=1"]),
+        ], trace_id="t16i_mamba_delete"))
+        self._assert_uri_present(block_key, full_uri, "t16i_query_full_after_mamba_delete")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_delete(block_key, medium, ["full_attention:group=0:tp=0"]),
+        ], trace_id="t16i_full_delete"))
+        self._assert_uri_absent(block_key, full_uri, "t16i_query_full_after_full_delete")
 
     # 16a. Heartbeat timeout -> location filtered out, then recovery on heartbeat resume.
     def test_16a_heartbeat_timeout_then_recovery(self):

--- a/integration_test/meta_service/test_vineyard_report_event.py
+++ b/integration_test/meta_service/test_vineyard_report_event.py
@@ -319,6 +319,33 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
     def tearDownClass(cls):
         cls.client.close()
 
+    def _query_specs(self, block_key, trace_id):
+        resp = self.client.get_cache_location({
+            "trace_id": trace_id,
+            "instance_id": self.instance_id,
+            "query_type": "QT_BATCH_GET",
+            "block_keys": [block_key],
+            "block_mask": {"offset": 0},
+        })
+        specs = []
+        for loc in resp.get("locations", []):
+            specs.extend(loc.get("location_specs", []))
+        return specs
+
+    def _assert_uri_present(self, block_key, expected_uri, trace_id):
+        specs = self._query_specs(block_key, trace_id)
+        self.assertTrue(
+            any(spec.get("uri") == expected_uri for spec in specs),
+            f"Expected uri={expected_uri} for block={block_key}, specs={specs}",
+        )
+
+    def _assert_uri_absent(self, block_key, unexpected_uri, trace_id):
+        specs = self._query_specs(block_key, trace_id)
+        self.assertFalse(
+            any(spec.get("uri") == unexpected_uri for spec in specs),
+            f"Unexpected uri={unexpected_uri} for block={block_key}, specs={specs}",
+        )
+
     # 1. NODE_REGISTER (with mediums)
     def test_01_node_register(self):
         body = self.client.report_event(
@@ -647,20 +674,6 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
         uri_kept = _build_vineyard_uri(host, medium, {"obj_id": "kept"})
         uri_added = _build_vineyard_uri(host, medium, {"obj_id": "added"})
 
-        def has_uri(block_key, expected_uri):
-            resp = self.client.get_cache_location({
-                "trace_id": f"t16_query_{block_key}",
-                "instance_id": self.instance_id,
-                "query_type": "QT_BATCH_GET",
-                "block_keys": [block_key],
-                "block_mask": {"offset": 0},
-            })
-            for loc in resp.get("locations", []):
-                for spec in loc.get("location_specs", []):
-                    if spec.get("uri") == expected_uri:
-                        return True
-            return False
-
         self.client.report_event(_make_request(self.instance_id, host, [
             _ev_node_register([medium]),
             _ev_block_snapshot(medium, [
@@ -668,7 +681,7 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
                 (key_kept, _make_single_spec("spec_4096", uri_kept)),
             ]),
         ], trace_id="t16_snapshot_a"))
-        self.assertTrue(has_uri(key_kept, uri_kept))
+        self._assert_uri_present(key_kept, uri_kept, "t16_query_kept_a")
 
         self.client.report_event(_make_request(self.instance_id, host, [
             _ev_block_snapshot(medium, [
@@ -677,10 +690,76 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
             ]),
         ], trace_id="t16_snapshot_b"))
 
-        self.assertFalse(has_uri(key_deleted, uri_deleted),
-                         "Second full snapshot should delete blocks missing from the same host/medium")
-        self.assertTrue(has_uri(key_kept, uri_kept))
-        self.assertTrue(has_uri(key_added, uri_added))
+        self._assert_uri_absent(key_deleted, uri_deleted, "t16_query_deleted_b")
+        self._assert_uri_present(key_kept, uri_kept, "t16_query_kept_b")
+        self._assert_uri_present(key_added, uri_added, "t16_query_added_b")
+
+    # 16c. Snapshot diff is scoped by host: same medium on another host survives.
+    def test_16c_block_snapshot_diff_is_host_scoped(self):
+        host_a = "192.168.1.241:8080"
+        host_b = "192.168.1.242:8080"
+        medium = "mem"
+        key_a_deleted = 8111
+        key_a_kept = 8112
+        key_b_kept = 8113
+        uri_a_deleted = _build_vineyard_uri(host_a, medium, {"obj_id": "a_deleted"})
+        uri_a_kept = _build_vineyard_uri(host_a, medium, {"obj_id": "a_kept"})
+        uri_b_kept = _build_vineyard_uri(host_b, medium, {"obj_id": "b_kept"})
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (key_a_deleted, _make_single_spec("host_a_deleted", uri_a_deleted)),
+                (key_a_kept, _make_single_spec("host_a_kept", uri_a_kept)),
+            ]),
+        ], trace_id="t16c_snapshot_host_a_initial"))
+        self.client.report_event(_make_request(self.instance_id, host_b, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (key_b_kept, _make_single_spec("host_b_kept", uri_b_kept)),
+            ]),
+        ], trace_id="t16c_snapshot_host_b_initial"))
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_block_snapshot(medium, [
+                (key_a_kept, _make_single_spec("host_a_kept", uri_a_kept)),
+            ]),
+        ], trace_id="t16c_snapshot_host_a_reconcile"))
+
+        self._assert_uri_absent(key_a_deleted, uri_a_deleted, "t16c_query_a_deleted")
+        self._assert_uri_present(key_a_kept, uri_a_kept, "t16c_query_a_kept")
+        self._assert_uri_present(key_b_kept, uri_b_kept, "t16c_query_b_kept")
+
+    # 16d. Snapshot diff is scoped by medium: another tier on the same host survives.
+    def test_16d_block_snapshot_diff_is_medium_scoped(self):
+        host = "192.168.1.243:8080"
+        key_mem_deleted = 8121
+        key_mem_kept = 8122
+        key_disk_kept = 8123
+        uri_mem_deleted = _build_vineyard_uri(host, "mem", {"obj_id": "mem_deleted"})
+        uri_mem_kept = _build_vineyard_uri(host, "mem", {"obj_id": "mem_kept"})
+        uri_disk_kept = _build_vineyard_uri(host, "disk", {"obj_id": "disk_kept"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register(["mem", "disk"]),
+            _ev_block_snapshot("mem", [
+                (key_mem_deleted, _make_single_spec("mem_deleted", uri_mem_deleted)),
+                (key_mem_kept, _make_single_spec("mem_kept", uri_mem_kept)),
+            ]),
+            _ev_block_snapshot("disk", [
+                (key_disk_kept, _make_single_spec("disk_kept", uri_disk_kept)),
+            ]),
+        ], trace_id="t16d_snapshot_initial"))
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_snapshot("mem", [
+                (key_mem_kept, _make_single_spec("mem_kept", uri_mem_kept)),
+            ]),
+        ], trace_id="t16d_snapshot_mem_reconcile"))
+
+        self._assert_uri_absent(key_mem_deleted, uri_mem_deleted, "t16d_query_mem_deleted")
+        self._assert_uri_present(key_mem_kept, uri_mem_kept, "t16d_query_mem_kept")
+        self._assert_uri_present(key_disk_kept, uri_disk_kept, "t16d_query_disk_kept")
 
     # 16a. Heartbeat timeout -> location filtered out, then recovery on heartbeat resume.
     def test_16a_heartbeat_timeout_then_recovery(self):

--- a/kv_cache_manager/common/redis_client.cc
+++ b/kv_cache_manager/common/redis_client.cc
@@ -333,6 +333,44 @@ void RedisClient::BuildHashDeleteCmds(const std::vector<std::string> &keys,
     }
 }
 
+void RedisClient::BuildSetAddCmds(const std::vector<std::string> &keys,
+                                  const std::vector<std::vector<std::string>> &members_vec,
+                                  std::vector<CmdArgs> &out_cmds) {
+    assert(keys.size() == members_vec.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (members_vec[i].empty()) {
+            continue;
+        }
+        CmdArgs sadd_cmd;
+        sadd_cmd.reserve(members_vec[i].size() + 2);
+        sadd_cmd.emplace_back("SADD");
+        sadd_cmd.emplace_back(keys[i]);
+        for (const auto &member : members_vec[i]) {
+            sadd_cmd.emplace_back(member);
+        }
+        out_cmds.emplace_back(std::move(sadd_cmd));
+    }
+}
+
+void RedisClient::BuildSetRemoveCmds(const std::vector<std::string> &keys,
+                                     const std::vector<std::vector<std::string>> &members_vec,
+                                     std::vector<CmdArgs> &out_cmds) {
+    assert(keys.size() == members_vec.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (members_vec[i].empty()) {
+            continue;
+        }
+        CmdArgs srem_cmd;
+        srem_cmd.reserve(members_vec[i].size() + 2);
+        srem_cmd.emplace_back("SREM");
+        srem_cmd.emplace_back(keys[i]);
+        for (const auto &member : members_vec[i]) {
+            srem_cmd.emplace_back(member);
+        }
+        out_cmds.emplace_back(std::move(srem_cmd));
+    }
+}
+
 // cover old key-fields
 std::vector<ErrorCode> RedisClient::Set(const std::vector<std::string> &keys,
                                         const std::vector<std::map<std::string, std::string>> &field_maps) {
@@ -545,6 +583,122 @@ std::vector<ErrorCode> RedisClient::DeleteFields(const std::vector<std::string> 
         }
     }
     return ec_per_key;
+}
+
+std::vector<ErrorCode> RedisClient::SAdd(const std::vector<std::string> &keys,
+                                         const std::vector<std::vector<std::string>> &members_vec) {
+    if (keys.size() != members_vec.size()) {
+        KVCM_REDIS_LOG_ERROR("redis sadd fail, keys.size[%lu] != members_vec.size[%lu]",
+                             keys.size(),
+                             members_vec.size());
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
+
+    std::vector<size_t> original_indexes;
+    std::vector<ErrorCode> ec_per_key(keys.size(), EC_OK);
+    original_indexes.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (!members_vec[i].empty()) {
+            original_indexes.emplace_back(i);
+        }
+    }
+
+    std::vector<CmdArgs> sadd_cmds;
+    sadd_cmds.reserve(original_indexes.size());
+    BuildSetAddCmds(keys, members_vec, sadd_cmds);
+    if (sadd_cmds.empty()) {
+        return ec_per_key;
+    }
+
+    std::vector<ReplyUPtr> sadd_replies = CommandPipeline(sadd_cmds);
+    if (sadd_cmds.size() != sadd_replies.size()) {
+        KVCM_REDIS_LOG_ERROR("redis sadd fail, pipeline sadd_cmds.size[%lu] != replies.size[%lu]",
+                             sadd_cmds.size(),
+                             sadd_replies.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+    assert(original_indexes.size() == sadd_replies.size());
+    for (size_t i = 0; i < original_indexes.size(); ++i) {
+        const size_t original_idx = original_indexes[i];
+        const ReplyUPtr &reply = sadd_replies[i];
+        if (!IsReplyOk(reply.get()) || !CheckReplyInteger(reply.get())) {
+            KVCM_REDIS_LOG_ERROR("redis sadd fail, key[%s]", keys[original_idx].c_str());
+            ec_per_key[original_idx] = EC_ERROR;
+        }
+    }
+    return ec_per_key;
+}
+
+std::vector<ErrorCode> RedisClient::SRem(const std::vector<std::string> &keys,
+                                         const std::vector<std::vector<std::string>> &members_vec) {
+    if (keys.size() != members_vec.size()) {
+        KVCM_REDIS_LOG_ERROR("redis srem fail, keys.size[%lu] != members_vec.size[%lu]",
+                             keys.size(),
+                             members_vec.size());
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
+
+    std::vector<size_t> original_indexes;
+    std::vector<ErrorCode> ec_per_key(keys.size(), EC_OK);
+    original_indexes.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (!members_vec[i].empty()) {
+            original_indexes.emplace_back(i);
+        }
+    }
+
+    std::vector<CmdArgs> srem_cmds;
+    srem_cmds.reserve(original_indexes.size());
+    BuildSetRemoveCmds(keys, members_vec, srem_cmds);
+    if (srem_cmds.empty()) {
+        return ec_per_key;
+    }
+
+    std::vector<ReplyUPtr> srem_replies = CommandPipeline(srem_cmds);
+    if (srem_cmds.size() != srem_replies.size()) {
+        KVCM_REDIS_LOG_ERROR("redis srem fail, pipeline srem_cmds.size[%lu] != replies.size[%lu]",
+                             srem_cmds.size(),
+                             srem_replies.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+    assert(original_indexes.size() == srem_replies.size());
+    for (size_t i = 0; i < original_indexes.size(); ++i) {
+        const size_t original_idx = original_indexes[i];
+        const ReplyUPtr &reply = srem_replies[i];
+        if (!IsReplyOk(reply.get()) || !CheckReplyInteger(reply.get())) {
+            KVCM_REDIS_LOG_ERROR("redis srem fail, key[%s]", keys[original_idx].c_str());
+            ec_per_key[original_idx] = EC_ERROR;
+        }
+    }
+    return ec_per_key;
+}
+
+ErrorCode RedisClient::SMembers(const std::string &key, std::vector<std::string> &out_members) {
+    out_members.clear();
+    std::vector<CmdArgs> cmds{{"SMEMBERS", key}};
+    std::vector<ReplyUPtr> replies = CommandPipeline(cmds);
+    if (replies.size() != 1) {
+        KVCM_REDIS_LOG_ERROR("redis smembers fail, pipeline replies.size[%lu]", replies.size());
+        return EC_ERROR;
+    }
+    const ReplyUPtr &reply = replies[0];
+    if (!IsReplyOk(reply.get()) || !CheckReplyArray(reply.get())) {
+        KVCM_REDIS_LOG_ERROR("redis smembers fail, key[%s]", key.c_str());
+        return EC_ERROR;
+    }
+    out_members.reserve(reply->elements);
+    for (size_t i = 0; i < reply->elements; ++i) {
+        const redisReply *element = reply->element[i];
+        if (!element || element->type != REDIS_REPLY_STRING) {
+            KVCM_REDIS_LOG_ERROR("redis smembers fail, key[%s] unexpected element type[%d]",
+                                 key.c_str(),
+                                 element ? element->type : -1);
+            out_members.clear();
+            return EC_ERROR;
+        }
+        out_members.emplace_back(element->str, element->len);
+    }
+    return EC_OK;
 }
 
 std::vector<ErrorCode> RedisClient::Get(const std::vector<std::string> &keys,

--- a/kv_cache_manager/common/redis_client.h
+++ b/kv_cache_manager/common/redis_client.h
@@ -32,6 +32,11 @@ public:
     std::vector<ErrorCode> Delete(const std::vector<std::string> &keys);
     std::vector<ErrorCode> DeleteFields(const std::vector<std::string> &keys,
                                         const std::vector<std::vector<std::string>> &field_names_vec);
+    std::vector<ErrorCode> SAdd(const std::vector<std::string> &keys,
+                                const std::vector<std::vector<std::string>> &members_vec);
+    std::vector<ErrorCode> SRem(const std::vector<std::string> &keys,
+                                const std::vector<std::vector<std::string>> &members_vec);
+    ErrorCode SMembers(const std::string &key, std::vector<std::string> &out_members);
     std::vector<ErrorCode> Get(const std::vector<std::string> &keys,
                                const std::vector<std::string> &field_names,
                                std::vector<std::map<std::string, std::string>> &out_field_maps);
@@ -84,6 +89,14 @@ public:
     static void BuildHashDeleteCmds(const std::vector<std::string> &keys,
                                     const std::vector<std::vector<std::string>> &field_names_vec,
                                     std::vector<CmdArgs> &out_cmds);
+
+    // SADD/SREM per key. Skips keys with empty member lists.
+    static void BuildSetAddCmds(const std::vector<std::string> &keys,
+                                const std::vector<std::vector<std::string>> &members_vec,
+                                std::vector<CmdArgs> &out_cmds);
+    static void BuildSetRemoveCmds(const std::vector<std::string> &keys,
+                                   const std::vector<std::vector<std::string>> &members_vec,
+                                   std::vector<CmdArgs> &out_cmds);
 
 protected:
 

--- a/kv_cache_manager/common/test/loop_thread_test.cc
+++ b/kv_cache_manager/common/test/loop_thread_test.cc
@@ -37,6 +37,7 @@ TEST_F(LoopThreadTest, TestCreateAndStop) {
 
     loop_thread->Stop();
 
+    count_before_stop = count.load();
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     int count_after_stop = count.load();
     EXPECT_EQ(count_before_stop, count_after_stop);

--- a/kv_cache_manager/common/test/redis_client_test.cc
+++ b/kv_cache_manager/common/test/redis_client_test.cc
@@ -903,6 +903,88 @@ TEST_F(RedisClientTest, TestBuildHashDeleteCmdsEmpty) {
     ASSERT_TRUE(cmds.empty());
 }
 
+TEST_F(RedisClientTest, TestSetIndexCommands) {
+    EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+    std::vector<ReplyUPtr> sadd_replies;
+    sadd_replies.emplace_back(MakeFakeReplyInteger(2));
+    sadd_replies.emplace_back(MakeFakeReplyInteger(1));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"), StrEq("idx_a"), StrEq("11"), StrEq("12")),
+                                            ElementsAre(StrEq("SADD"), StrEq("idx_c"), StrEq("13")))))
+        .WillOnce(Return(ByMove(std::move(sadd_replies))));
+    auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b", "idx_c"}, {{"11", "12"}, {}, {"13"}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), sadd_ecs);
+
+    std::vector<ReplyUPtr> srem_replies;
+    srem_replies.emplace_back(MakeFakeReplyInteger(1));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"), StrEq("idx_a"), StrEq("11")))))
+        .WillOnce(Return(ByMove(std::move(srem_replies))));
+    auto srem_ecs = redis_client_->SRem({"idx_a", "idx_b"}, {{"11"}, {}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), srem_ecs);
+
+    std::vector<ReplyUPtr> smembers_replies;
+    smembers_replies.emplace_back(MakeFakeReplyArrayString({"11", "12"}));
+    EXPECT_CALL(*redis_client_, TryExecPipeline(ElementsAre(ElementsAre(StrEq("SMEMBERS"), StrEq("idx_a")))))
+        .WillOnce(Return(ByMove(std::move(smembers_replies))));
+    std::vector<std::string> members;
+    ASSERT_EQ(EC_OK, redis_client_->SMembers("idx_a", members));
+    ASSERT_EQ((std::vector<std::string>{"11", "12"}), members);
+}
+
+TEST_F(RedisClientTest, TestSetIndexCommandErrors) {
+    EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+    ASSERT_EQ((std::vector<ErrorCode>{EC_BADARGS}), redis_client_->SAdd({"idx_a"}, {}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_BADARGS}), redis_client_->SRem({"idx_a"}, {}));
+
+    std::vector<ReplyUPtr> sadd_replies;
+    sadd_replies.emplace_back(MakeFakeReplyInteger(-1));
+    sadd_replies.emplace_back(MakeFakeReplyInteger(1));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"), StrEq("idx_a"), StrEq("11")),
+                                            ElementsAre(StrEq("SADD"), StrEq("idx_c"), StrEq("13")))))
+        .WillOnce(Return(ByMove(std::move(sadd_replies))));
+    auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b", "idx_c"}, {{"11"}, {}, {"13"}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_OK, EC_OK}), sadd_ecs);
+
+    std::vector<ReplyUPtr> srem_replies;
+    srem_replies.emplace_back(MakeFakeReplyInteger(1));
+    srem_replies.emplace_back(MakeFakeReply(REDIS_REPLY_ERROR, "ERR"));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"), StrEq("idx_a"), StrEq("11")),
+                                            ElementsAre(StrEq("SREM"), StrEq("idx_c"), StrEq("13")))))
+        .WillOnce(Return(ByMove(std::move(srem_replies))));
+    auto srem_ecs = redis_client_->SRem({"idx_a", "idx_b", "idx_c"}, {{"11"}, {}, {"13"}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_ERROR}), srem_ecs);
+
+    std::vector<ReplyUPtr> smembers_replies;
+    smembers_replies.emplace_back(MakeFakeReplyArrayString({"11", std::nullopt}));
+    EXPECT_CALL(*redis_client_, TryExecPipeline(ElementsAre(ElementsAre(StrEq("SMEMBERS"), StrEq("idx_a")))))
+        .WillOnce(Return(ByMove(std::move(smembers_replies))));
+    std::vector<std::string> members;
+    ASSERT_EQ(EC_ERROR, redis_client_->SMembers("idx_a", members));
+    ASSERT_TRUE(members.empty());
+}
+
+TEST_F(RedisClientTest, TestBuildSetIndexCmds) {
+    std::vector<std::string> keys = {"idx_a", "idx_b", "idx_c"};
+    std::vector<std::vector<std::string>> members = {{"11", "12"}, {}, {"13"}};
+
+    std::vector<CmdArgs> sadd_cmds;
+    RedisClient::BuildSetAddCmds(keys, members, sadd_cmds);
+    ASSERT_EQ(2, sadd_cmds.size());
+    ASSERT_EQ(CmdArgs({"SADD", "idx_a", "11", "12"}), sadd_cmds[0]);
+    ASSERT_EQ(CmdArgs({"SADD", "idx_c", "13"}), sadd_cmds[1]);
+
+    std::vector<CmdArgs> srem_cmds;
+    RedisClient::BuildSetRemoveCmds(keys, members, srem_cmds);
+    ASSERT_EQ(2, srem_cmds.size());
+    ASSERT_EQ(CmdArgs({"SREM", "idx_a", "11", "12"}), srem_cmds[0]);
+    ASSERT_EQ(CmdArgs({"SREM", "idx_c", "13"}), srem_cmds[1]);
+}
+
 TEST_F(RedisClientTest, TestBuildCmdsAppendToExisting) {
     std::vector<CmdArgs> cmds;
     cmds.push_back({"EXISTING_CMD"});

--- a/kv_cache_manager/common/test/redis_client_test.cc
+++ b/kv_cache_manager/common/test/redis_client_test.cc
@@ -968,6 +968,50 @@ TEST_F(RedisClientTest, TestSetIndexCommandErrors) {
     ASSERT_TRUE(members.empty());
 }
 
+TEST_F(RedisClientTest, TestSetIndexCommandsNoopAndPipelineShapeErrors) {
+    {
+        EXPECT_CALL(*redis_client_, TryExecPipeline(_)).Times(0);
+
+        auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b"}, {{}, {}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), sadd_ecs);
+
+        auto srem_ecs = redis_client_->SRem({"idx_a", "idx_b"}, {{}, {}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), srem_ecs);
+    }
+    {
+        EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> sadd_replies;
+        sadd_replies.emplace_back(MakeFakeReplyInteger(1));
+        EXPECT_CALL(*redis_client_,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"), StrEq("idx_a"), StrEq("11")),
+                                                ElementsAre(StrEq("SADD"), StrEq("idx_b"), StrEq("12")))))
+            .WillOnce(Return(ByMove(std::move(sadd_replies))));
+        auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b"}, {{"11"}, {"12"}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), sadd_ecs);
+    }
+    {
+        EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> srem_replies;
+        EXPECT_CALL(*redis_client_,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"), StrEq("idx_a"), StrEq("11")))))
+            .WillOnce(Return(ByMove(std::move(srem_replies))));
+        auto srem_ecs = redis_client_->SRem({"idx_a"}, {{"11"}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR}), srem_ecs);
+    }
+    {
+        EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> smembers_replies;
+        EXPECT_CALL(*redis_client_, TryExecPipeline(ElementsAre(ElementsAre(StrEq("SMEMBERS"), StrEq("idx_a")))))
+            .WillOnce(Return(ByMove(std::move(smembers_replies))));
+        std::vector<std::string> members = {"stale"};
+        ASSERT_EQ(EC_ERROR, redis_client_->SMembers("idx_a", members));
+        ASSERT_TRUE(members.empty());
+    }
+}
+
 TEST_F(RedisClientTest, TestBuildSetIndexCmds) {
     std::vector<std::string> keys = {"idx_a", "idx_b", "idx_c"};
     std::vector<std::vector<std::string>> members = {{"11", "12"}, {}, {"13"}};
@@ -991,11 +1035,15 @@ TEST_F(RedisClientTest, TestBuildCmdsAppendToExisting) {
 
     RedisClient::BuildDeleteCmds({"k1"}, cmds);
     RedisClient::BuildHashSetCmds({"k2"}, {{{"f", "v"}}}, cmds);
+    RedisClient::BuildSetAddCmds({"idx"}, {{"11", "12"}}, cmds);
+    RedisClient::BuildSetRemoveCmds({"idx"}, {{"11"}}, cmds);
 
-    ASSERT_EQ(3, cmds.size());
+    ASSERT_EQ(5, cmds.size());
     ASSERT_EQ("EXISTING_CMD", cmds[0][0]);
     ASSERT_EQ("DEL", cmds[1][0]);
     ASSERT_EQ("HSET", cmds[2][0]);
+    ASSERT_EQ(CmdArgs({"SADD", "idx", "11", "12"}), cmds[3]);
+    ASSERT_EQ(CmdArgs({"SREM", "idx", "11"}), cmds[4]);
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "kv_cache_manager/common/env_util.h"
 #include "kv_cache_manager/common/jsonizable.h"
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
@@ -1530,8 +1529,14 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         std::string location_id;
         int event_index;
     };
+    struct SnapshotEntry {
+        std::string location_id;
+        std::map<int64_t, std::vector<LocationSpec>> blocks;
+        int event_index;
+    };
     std::map<int64_t, std::vector<BlockAddEntry>> block_to_add;
     std::map<int64_t, std::vector<BlockDelEntry>> block_to_del;
+    std::vector<SnapshotEntry> snapshots;
 
     for (int i = 0; i < events_size; ++i) {
         const auto &item = request->events(i);
@@ -1618,6 +1623,51 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
             block_to_del[block_key].push_back(
                 BlockDelEntry{event_backend->BuildLocationId(p.medium(), host_ip_port), i});
+            break;
+        }
+        case proto::meta::EVENT_BLOCK_SNAPSHOT: {
+            if (!item.has_block_snapshot()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            const auto &p = item.block_snapshot();
+            if (p.medium().empty()) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty medium", trace_id.c_str());
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            SnapshotEntry snapshot;
+            snapshot.location_id = event_backend->BuildLocationId(p.medium(), host_ip_port);
+            snapshot.event_index = i;
+            bool valid_snapshot = true;
+            for (const auto &block : p.blocks()) {
+                int64_t block_key = 0;
+                if (!ParseInt64(block.block_key(), block_key)) {
+                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: invalid block_key [%s]",
+                                  trace_id.c_str(),
+                                  block.block_key().c_str());
+                    valid_snapshot = false;
+                    break;
+                }
+                if (block.specs_size() == 0) {
+                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty specs for block_key [%ld]",
+                                  trace_id.c_str(),
+                                  block_key);
+                    valid_snapshot = false;
+                    break;
+                }
+                auto &specs = snapshot.blocks[block_key];
+                specs.clear();
+                specs.reserve(block.specs_size());
+                for (const auto &s : block.specs()) {
+                    specs.emplace_back(s.name(), s.uri());
+                }
+            }
+            if (!valid_snapshot) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            snapshots.emplace_back(std::move(snapshot));
             break;
         }
         default:
@@ -1760,6 +1810,105 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
             KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
             KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
+        }
+    }
+
+    if (!snapshots.empty()) {
+        for (const auto &snapshot : snapshots) {
+            if (per_item_ec[snapshot.event_index] != EC_OK) {
+                continue;
+            }
+
+            KeyVector existing_keys;
+            auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
+            if (list_ec != EC_OK) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
+                              trace_id.c_str(),
+                              snapshot.location_id.c_str(),
+                              static_cast<int32_t>(list_ec));
+                per_item_ec[snapshot.event_index] = list_ec;
+                continue;
+            }
+
+            std::unordered_set<int64_t> existing_key_set(existing_keys.begin(), existing_keys.end());
+            std::unordered_set<int64_t> reported_key_set;
+            reported_key_set.reserve(snapshot.blocks.size());
+            for (const auto &block : snapshot.blocks) {
+                reported_key_set.insert(block.first);
+            }
+
+            KeyVector add_keys;
+            std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+            for (const auto &block : snapshot.blocks) {
+                if (existing_key_set.find(block.first) != existing_key_set.end()) {
+                    continue;
+                }
+                add_keys.push_back(block.first);
+                upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
+                    MetaSearcher::UpsertLocation{
+                        snapshot.location_id,
+                        event_backend->GetStorageType(),
+                        CacheLocationStatus::CLS_SERVING,
+                        block.second,
+                    },
+                });
+            }
+
+            if (!add_keys.empty()) {
+                std::vector<ErrorCode> per_key_ec;
+                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, add_keys, upserts, per_key_ec);
+                if (add_ec != EC_OK) {
+                    per_item_ec[snapshot.event_index] = add_ec;
+                } else {
+                    for (const auto &key_ec : per_key_ec) {
+                        if (key_ec != EC_OK) {
+                            per_item_ec[snapshot.event_index] = key_ec;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            KeyVector del_keys;
+            LocationIdsPerKey del_location_ids;
+            for (const auto &existing_key : existing_keys) {
+                if (reported_key_set.find(existing_key) != reported_key_set.end()) {
+                    continue;
+                }
+                del_keys.push_back(existing_key);
+                del_location_ids.push_back(LocationIdVector{snapshot.location_id});
+            }
+
+            if (!del_keys.empty()) {
+                std::vector<std::vector<ErrorCode>> per_location_ec;
+                auto del_ec =
+                    meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
+                if (del_ec != EC_OK) {
+                    per_item_ec[snapshot.event_index] = del_ec;
+                } else {
+                    for (const auto &location_ecs : per_location_ec) {
+                        for (const auto &loc_ec : location_ecs) {
+                            if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                                per_item_ec[snapshot.event_index] = loc_ec;
+                                break;
+                            }
+                        }
+                        if (per_item_ec[snapshot.event_index] != EC_OK) {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (per_item_ec[snapshot.event_index] == EC_OK) {
+                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], add[%zu], "
+                              "delete[%zu]",
+                              trace_id.c_str(),
+                              snapshot.location_id.c_str(),
+                              snapshot.blocks.size(),
+                              add_keys.size(),
+                              del_keys.size());
+            }
         }
     }
 
@@ -2077,6 +2226,7 @@ void CacheManager::StopRecoverRetryLoop() {
         recover_retry_thread_.join();
     }
 }
+
 void CacheManager::ClearEventCleanupCallbacks() {
     if (!registry_manager_ || !registry_manager_->data_storage_manager()) {
         return;

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1426,7 +1426,9 @@ LookupEventReportingBackend(const std::shared_ptr<RegistryManager> &registry_man
     return backend;
 }
 
-bool ParseInt64(const std::string &s, int64_t &out) {
+} // namespace
+
+bool CacheManager::ParseInt64(const std::string &s, int64_t &out) {
     try {
         size_t consumed = 0;
         int64_t v = std::stoll(s, &consumed);
@@ -1438,46 +1440,47 @@ bool ParseInt64(const std::string &s, int64_t &out) {
     } catch (...) { return false; }
 }
 
-std::string EscapeLocationScopeToken(const std::string &s) {
-    std::string out;
-    out.reserve(s.size());
-    for (char ch : s) {
-        if (ch == '\\' || ch == ';' || ch == '=') {
-            out.push_back('\\');
+bool CacheManager::HasPrefix(const std::string &s, const std::string &prefix) {
+    return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+bool CacheManager::IsMambaLocationSpecName(const std::string &name) {
+    return name == "mamba" || HasPrefix(name, "mamba:") || HasPrefix(name, "mamba/") ||
+           HasPrefix(name, "mamba_") || name == "mamba_state" || HasPrefix(name, "mamba_state:") ||
+           HasPrefix(name, "mamba_state/") || HasPrefix(name, "mamba_state_");
+}
+
+bool CacheManager::IsFullAttentionLocationSpecName(const std::string &name) {
+    // Legacy reporters use names like "tp0"; treat unknown names as full
+    // attention unless they explicitly opt into the mamba-state namespace.
+    return !IsMambaLocationSpecName(name);
+}
+
+bool CacheManager::ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names) {
+    if (spec_names.empty()) {
+        return true;
+    }
+    for (const auto &name : spec_names) {
+        if (IsFullAttentionLocationSpecName(name)) {
+            return true;
         }
-        out.push_back(ch);
     }
-    return out;
+    return false;
 }
 
-std::string ResolveMedium(const std::string &legacy_medium, const proto::meta::LocationScope &scope) {
-    return scope.medium().empty() ? legacy_medium : scope.medium();
-}
-
-std::string BuildScopedMedium(const std::string &medium, const proto::meta::LocationScope &scope) {
-    if (scope.labels().empty()) {
-        return medium;
-    }
-    std::map<std::string, std::string> sorted_labels;
-    for (const auto &kv : scope.labels()) {
-        if (!kv.first.empty()) {
-            sorted_labels[kv.first] = kv.second;
+std::vector<LocationSpec> CacheManager::BuildFullAttentionSpecs(
+    const google::protobuf::RepeatedPtrField<proto::meta::LocationSpec> &proto_specs) {
+    std::vector<LocationSpec> specs;
+    specs.reserve(proto_specs.size());
+    for (const auto &s : proto_specs) {
+        if (IsFullAttentionLocationSpecName(s.name())) {
+            specs.emplace_back(s.name(), s.uri());
         }
     }
-    if (sorted_labels.empty()) {
-        return medium;
-    }
-    std::string scoped_medium = medium;
-    for (const auto &kv : sorted_labels) {
-        scoped_medium.push_back(';');
-        scoped_medium.append(EscapeLocationScopeToken(kv.first));
-        scoped_medium.push_back('=');
-        scoped_medium.append(EscapeLocationScopeToken(kv.second));
-    }
-    return scoped_medium;
+    return specs;
 }
 
-bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs) {
+bool CacheManager::SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs) {
     if (lhs.size() != rhs.size()) {
         return false;
     }
@@ -1489,18 +1492,18 @@ bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<L
     return true;
 }
 
-bool CacheLocationEquals(const CacheLocationConstPtr &loc,
-                         DataStorageType type,
-                         CacheLocationStatus status,
-                         const std::vector<LocationSpec> &specs) {
+bool CacheManager::CacheLocationEquals(const CacheLocationConstPtr &loc,
+                                       DataStorageType type,
+                                       CacheLocationStatus status,
+                                       const std::vector<LocationSpec> &specs) {
     return loc && loc->type() == type && loc->status() == status && SameLocationSpecs(loc->location_specs(), specs);
 }
 
-bool ExistingLocationEquals(const CacheLocationMap *existing_map,
-                            const std::string &location_id,
-                            DataStorageType type,
-                            CacheLocationStatus status,
-                            const std::vector<LocationSpec> &specs) {
+bool CacheManager::ExistingLocationEquals(const CacheLocationMap *existing_map,
+                                          const std::string &location_id,
+                                          DataStorageType type,
+                                          CacheLocationStatus status,
+                                          const std::vector<LocationSpec> &specs) {
     if (!existing_map) {
         return false;
     }
@@ -1508,7 +1511,7 @@ bool ExistingLocationEquals(const CacheLocationMap *existing_map,
     return iter != existing_map->end() && CacheLocationEquals(iter->second, type, status, specs);
 }
 
-proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec) {
+proto::meta::ErrorCode CacheManager::ToProtoErrorCode(ErrorCode ec) {
     if (ec == EC_OK) {
         return proto::meta::OK;
     }
@@ -1524,7 +1527,547 @@ proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec) {
     return proto::meta::INTERNAL_ERROR;
 }
 
-} // namespace
+ServiceMetricsCollector *CacheManager::FindReportEventSubCollector(RequestContext *request_context,
+                                                                   const std::string &api_name) {
+    for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
+        auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
+        if (smc) {
+            const auto &tags = smc->GetMetricsTags();
+            auto it = tags.find("api_name");
+            if (it != tags.end() && it->second == api_name) {
+                return smc;
+            }
+        }
+    }
+    return nullptr;
+}
+
+void CacheManager::SetReportEventItemEcIfOk(ReportEventState *state, int event_index, ErrorCode ec) {
+    if (state && event_index >= 0 && event_index < static_cast<int>(state->per_item_ec.size()) &&
+        state->per_item_ec[event_index] == EC_OK) {
+        state->per_item_ec[event_index] = ec;
+    }
+}
+
+bool CacheManager::BuildReportEventLocationId(const std::string &trace_id,
+                                              EventReportingBackend *event_backend,
+                                              const std::string &host_ip_port,
+                                              const std::string &medium,
+                                              const char *event_name,
+                                              int event_index,
+                                              ReportEventState *state,
+                                              std::string &out_location_id) const {
+    if (medium.empty()) {
+        KVCM_LOG_WARN("trace_id [%s] | %s: empty medium", trace_id.c_str(), event_name);
+        SetReportEventItemEcIfOk(state, event_index, EC_BADARGS);
+        return false;
+    }
+    out_location_id = event_backend->BuildLocationId(medium, host_ip_port);
+    return true;
+}
+
+void CacheManager::FlushReportEventAdds(RequestContext *request_context,
+                                        MetaSearcher *meta_searcher,
+                                        EventReportingBackend *event_backend,
+                                        ReportEventState *state) const {
+    if (!state || state->pending_adds.empty()) {
+        return;
+    }
+    KeyVector add_keys_aggr;
+    std::vector<const std::vector<ReportEventBlockAddEntry> *> add_entries_aggr;
+    add_keys_aggr.reserve(state->pending_adds.size());
+    add_entries_aggr.reserve(state->pending_adds.size());
+    for (const auto &kv : state->pending_adds) {
+        add_keys_aggr.push_back(kv.first);
+        add_entries_aggr.push_back(&kv.second);
+    }
+
+    std::vector<CacheLocationMap> existing_location_maps;
+    BlockMask bm = static_cast<size_t>(0);
+    auto get_ec = meta_searcher->BatchGetLocation(request_context, add_keys_aggr, bm, existing_location_maps);
+    if (get_ec != EC_OK) {
+        for (const auto *entries : add_entries_aggr) {
+            for (const auto &entry : *entries) {
+                SetReportEventItemEcIfOk(state, entry.event_index, get_ec);
+            }
+        }
+        state->pending_adds.clear();
+        return;
+    }
+
+    struct PendingAddLocation {
+        std::vector<LocationSpec> specs;
+        std::vector<int> event_indices;
+    };
+    KeyVector filtered_keys;
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+    std::vector<std::vector<std::vector<int>>> upsert_event_indices;
+    for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
+        const auto &entries = *add_entries_aggr[i];
+        std::map<std::string, PendingAddLocation> final_entries_by_location;
+        for (const auto &entry : entries) {
+            auto &pending = final_entries_by_location[entry.location_id];
+            pending.specs = entry.specs;
+            pending.event_indices.push_back(entry.event_index);
+        }
+
+        std::vector<MetaSearcher::UpsertLocation> per_key_upserts;
+        std::vector<std::vector<int>> per_key_event_indices;
+        const CacheLocationMap *existing_map =
+            (i < existing_location_maps.size()) ? &existing_location_maps[i] : nullptr;
+        for (const auto &kv : final_entries_by_location) {
+            const auto &location_id = kv.first;
+            const auto &pending = kv.second;
+            if (ExistingLocationEquals(existing_map,
+                                       location_id,
+                                       event_backend->GetStorageType(),
+                                       CacheLocationStatus::CLS_SERVING,
+                                       pending.specs)) {
+                continue;
+            }
+            per_key_upserts.push_back(MetaSearcher::UpsertLocation{
+                location_id,
+                event_backend->GetStorageType(),
+                CacheLocationStatus::CLS_SERVING,
+                pending.specs,
+            });
+            per_key_event_indices.push_back(pending.event_indices);
+        }
+        if (!per_key_upserts.empty()) {
+            filtered_keys.push_back(add_keys_aggr[i]);
+            upserts.push_back(std::move(per_key_upserts));
+            upsert_event_indices.push_back(std::move(per_key_event_indices));
+        }
+    }
+
+    if (!filtered_keys.empty()) {
+        std::vector<ErrorCode> per_key_ec;
+        auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
+
+        for (size_t k = 0; k < filtered_keys.size(); ++k) {
+            ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
+            if (key_ec == EC_OK) {
+                continue;
+            }
+            for (const auto &event_indices : upsert_event_indices[k]) {
+                for (const auto event_index : event_indices) {
+                    SetReportEventItemEcIfOk(state, event_index, key_ec);
+                }
+            }
+        }
+        if (auto *add_mc = FindReportEventSubCollector(request_context, "EventBlockAdd")) {
+            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, filtered_keys.size());
+            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, filtered_keys.size());
+        }
+    }
+    state->pending_adds.clear();
+}
+
+void CacheManager::FlushReportEventDeletes(RequestContext *request_context,
+                                           MetaSearcher *meta_searcher,
+                                           ReportEventState *state) const {
+    if (!state || state->pending_dels.empty()) {
+        return;
+    }
+    KeyVector del_keys_aggr;
+    std::vector<const std::vector<ReportEventBlockDelEntry> *> del_entries_aggr;
+    del_keys_aggr.reserve(state->pending_dels.size());
+    del_entries_aggr.reserve(state->pending_dels.size());
+    for (const auto &kv : state->pending_dels) {
+        del_keys_aggr.push_back(kv.first);
+        del_entries_aggr.push_back(&kv.second);
+    }
+
+    struct PendingDelLocation {
+        std::vector<int> event_indices;
+    };
+    LocationIdsPerKey del_location_ids(del_keys_aggr.size());
+    std::vector<std::vector<std::vector<int>>> del_event_indices(del_keys_aggr.size());
+    for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
+        std::map<std::string, PendingDelLocation> final_entries_by_location;
+        for (const auto &entry : *del_entries_aggr[i]) {
+            final_entries_by_location[entry.location_id].event_indices.push_back(entry.event_index);
+        }
+        del_location_ids[i].reserve(final_entries_by_location.size());
+        del_event_indices[i].reserve(final_entries_by_location.size());
+        for (const auto &kv : final_entries_by_location) {
+            del_location_ids[i].push_back(kv.first);
+            del_event_indices[i].push_back(kv.second.event_indices);
+        }
+    }
+
+    std::vector<std::vector<ErrorCode>> per_location_ec;
+    auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
+
+    for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
+        if (del_ec != EC_OK || k >= per_location_ec.size()) {
+            ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
+            for (const auto &event_indices : del_event_indices[k]) {
+                for (const auto event_index : event_indices) {
+                    SetReportEventItemEcIfOk(state, event_index, key_ec);
+                }
+            }
+            continue;
+        }
+        for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
+            ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
+            if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
+                continue;
+            }
+            for (const auto event_index : del_event_indices[k][loc_index]) {
+                SetReportEventItemEcIfOk(state, event_index, loc_ec);
+            }
+        }
+    }
+    if (auto *del_mc = FindReportEventSubCollector(request_context, "EventBlockDelete")) {
+        KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
+        KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
+    }
+    state->pending_dels.clear();
+}
+
+void CacheManager::FlushReportEventPending(RequestContext *request_context,
+                                           MetaSearcher *meta_searcher,
+                                           EventReportingBackend *event_backend,
+                                           ReportEventState *state) const {
+    if (!state) {
+        return;
+    }
+    if (state->pending_kind == ReportEventPendingMutationKind::ADD) {
+        FlushReportEventAdds(request_context, meta_searcher, event_backend, state);
+    } else if (state->pending_kind == ReportEventPendingMutationKind::DELETE) {
+        FlushReportEventDeletes(request_context, meta_searcher, state);
+    }
+    state->pending_kind = ReportEventPendingMutationKind::NONE;
+}
+
+void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
+                                            MetaSearcher *meta_searcher,
+                                            EventReportingBackend *event_backend,
+                                            const ReportEventSnapshotEntry &snapshot,
+                                            ReportEventState *state) const {
+    if (!state || state->per_item_ec[snapshot.event_index] != EC_OK) {
+        return;
+    }
+
+    const std::string &trace_id = request_context->trace_id();
+    KeyVector existing_keys;
+    auto list_ec = meta_searcher->GetKeysByLocationIndex(request_context, snapshot.location_id, existing_keys);
+    if (list_ec != EC_OK) {
+        KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
+                      trace_id.c_str(),
+                      snapshot.location_id.c_str(),
+                      static_cast<int32_t>(list_ec));
+        state->per_item_ec[snapshot.event_index] = list_ec;
+        return;
+    }
+
+    std::unordered_set<int64_t> reported_key_set;
+    reported_key_set.reserve(snapshot.blocks.size());
+    KeyVector reported_keys;
+    reported_keys.reserve(snapshot.blocks.size());
+    for (const auto &block : snapshot.blocks) {
+        reported_key_set.insert(block.first);
+        reported_keys.push_back(block.first);
+    }
+
+    std::vector<CacheLocationMap> existing_reported_maps;
+    if (!reported_keys.empty()) {
+        BlockMask bm = static_cast<size_t>(0);
+        auto get_ec = meta_searcher->BatchGetLocation(request_context, reported_keys, bm, existing_reported_maps);
+        if (get_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = get_ec;
+            return;
+        }
+    }
+
+    KeyVector upsert_keys;
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+    size_t block_index = 0;
+    for (const auto &block : snapshot.blocks) {
+        const CacheLocationMap *existing_map =
+            (block_index < existing_reported_maps.size()) ? &existing_reported_maps[block_index] : nullptr;
+        ++block_index;
+        if (ExistingLocationEquals(existing_map,
+                                   snapshot.location_id,
+                                   event_backend->GetStorageType(),
+                                   CacheLocationStatus::CLS_SERVING,
+                                   block.second)) {
+            continue;
+        }
+        upsert_keys.push_back(block.first);
+        upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
+            MetaSearcher::UpsertLocation{
+                snapshot.location_id,
+                event_backend->GetStorageType(),
+                CacheLocationStatus::CLS_SERVING,
+                block.second,
+            },
+        });
+    }
+
+    if (!upsert_keys.empty()) {
+        std::vector<ErrorCode> per_key_ec;
+        auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
+        if (add_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = add_ec;
+        } else {
+            for (const auto &key_ec : per_key_ec) {
+                if (key_ec != EC_OK) {
+                    state->per_item_ec[snapshot.event_index] = key_ec;
+                    break;
+                }
+            }
+        }
+    }
+    if (state->per_item_ec[snapshot.event_index] != EC_OK) {
+        return;
+    }
+
+    KeyVector del_keys;
+    LocationIdsPerKey del_location_ids;
+    for (const auto &existing_key : existing_keys) {
+        if (reported_key_set.find(existing_key) != reported_key_set.end()) {
+            continue;
+        }
+        del_keys.push_back(existing_key);
+        del_location_ids.push_back(LocationIdVector{snapshot.location_id});
+    }
+
+    if (!del_keys.empty()) {
+        std::vector<std::vector<ErrorCode>> per_location_ec;
+        auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
+        if (del_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = del_ec;
+        } else {
+            for (const auto &location_ecs : per_location_ec) {
+                for (const auto &loc_ec : location_ecs) {
+                    if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                        state->per_item_ec[snapshot.event_index] = loc_ec;
+                        break;
+                    }
+                }
+                if (state->per_item_ec[snapshot.event_index] != EC_OK) {
+                    break;
+                }
+            }
+        }
+    }
+
+    if (state->per_item_ec[snapshot.event_index] == EC_OK) {
+        KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
+                      "delete[%zu]",
+                      trace_id.c_str(),
+                      snapshot.location_id.c_str(),
+                      snapshot.blocks.size(),
+                      upsert_keys.size(),
+                      del_keys.size());
+    }
+}
+
+void CacheManager::ProcessReportEventItem(RequestContext *request_context,
+                                          const proto::meta::EventItem &item,
+                                          int event_index,
+                                          const std::string &instance_id,
+                                          const std::string &host_ip_port,
+                                          DataStorageType requested_type,
+                                          MetaSearcher *meta_searcher,
+                                          EventReportingBackend *event_backend,
+                                          ReportEventState *state) {
+    const std::string &trace_id = request_context->trace_id();
+    switch (item.event_type()) {
+    case proto::meta::EVENT_NODE_REGISTER: {
+        if (!item.has_node_register()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::vector<std::string> register_mediums;
+        for (const auto &m : item.node_register().mediums()) {
+            if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
+                register_mediums.push_back(m);
+            }
+        }
+        auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
+        if (ec != EC_OK) {
+            state->per_item_ec[event_index] = ec;
+        } else {
+            KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
+                          trace_id.c_str(),
+                          host_ip_port.c_str(),
+                          register_mediums.size(),
+                          instance_id.c_str());
+        }
+        break;
+    }
+    case proto::meta::EVENT_HEARTBEAT: {
+        if (!item.has_heartbeat()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::map<std::string, std::string> heartbeat_status;
+        for (const auto &kv : item.heartbeat().system_status()) {
+            heartbeat_status[kv.first] = kv.second;
+        }
+        state->per_item_ec[event_index] = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
+        break;
+    }
+    case proto::meta::EVENT_HOST_DOWN: {
+        FlushReportEventPending(request_context, meta_searcher, event_backend, state);
+        event_backend->SetNodeUnavailable(instance_id, host_ip_port);
+        uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
+        assert(schedule_plan_executor_);
+        schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
+            this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
+        });
+        event_backend->UnregisterNode(instance_id, host_ip_port);
+        KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
+                      trace_id.c_str(),
+                      host_ip_port.c_str(),
+                      gen_at_trigger);
+        break;
+    }
+    case proto::meta::EVENT_BLOCK_ADD: {
+        if (!item.has_block_add()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        const auto &p = item.block_add();
+        int64_t block_key = 0;
+        if (!ParseInt64(p.block_key(), block_key)) {
+            KVCM_LOG_WARN(
+                "trace_id [%s] | EVENT_BLOCK_ADD: invalid block_key [%s]", trace_id.c_str(), p.block_key().c_str());
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        if (p.specs_size() == 0) {
+            KVCM_LOG_WARN(
+                "trace_id [%s] | EVENT_BLOCK_ADD: empty specs for block_key [%ld]", trace_id.c_str(), block_key);
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::string location_id;
+        if (!BuildReportEventLocationId(
+                trace_id, event_backend, host_ip_port, p.medium(), "EVENT_BLOCK_ADD", event_index, state, location_id)) {
+            break;
+        }
+        std::vector<LocationSpec> entry_specs = BuildFullAttentionSpecs(p.specs());
+        if (entry_specs.empty()) {
+            KVCM_LOG_DEBUG("trace_id [%s] | EVENT_BLOCK_ADD: skip non-full-attention specs for block_key [%ld]",
+                           trace_id.c_str(),
+                           block_key);
+            break;
+        }
+        if (state->pending_kind == ReportEventPendingMutationKind::DELETE) {
+            FlushReportEventDeletes(request_context, meta_searcher, state);
+        }
+        state->pending_kind = ReportEventPendingMutationKind::ADD;
+        state->pending_adds[block_key].push_back(
+            ReportEventBlockAddEntry{std::move(location_id), std::move(entry_specs), event_index});
+        break;
+    }
+    case proto::meta::EVENT_BLOCK_DELETE: {
+        if (!item.has_block_delete()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        const auto &p = item.block_delete();
+        int64_t block_key = 0;
+        if (!ParseInt64(p.block_key(), block_key)) {
+            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_DELETE: invalid block_key [%s]",
+                          trace_id.c_str(),
+                          p.block_key().c_str());
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::string location_id;
+        if (!BuildReportEventLocationId(trace_id,
+                                        event_backend,
+                                        host_ip_port,
+                                        p.medium(),
+                                        "EVENT_BLOCK_DELETE",
+                                        event_index,
+                                        state,
+                                        location_id)) {
+            break;
+        }
+        if (!ContainsFullAttentionSpecName(p.spec_names())) {
+            KVCM_LOG_DEBUG("trace_id [%s] | EVENT_BLOCK_DELETE: skip non-full-attention spec_names for block_key "
+                           "[%ld]",
+                           trace_id.c_str(),
+                           block_key);
+            break;
+        }
+        if (state->pending_kind == ReportEventPendingMutationKind::ADD) {
+            FlushReportEventAdds(request_context, meta_searcher, event_backend, state);
+        }
+        state->pending_kind = ReportEventPendingMutationKind::DELETE;
+        state->pending_dels[block_key].push_back(ReportEventBlockDelEntry{std::move(location_id), event_index});
+        break;
+    }
+    case proto::meta::EVENT_BLOCK_SNAPSHOT: {
+        FlushReportEventPending(request_context, meta_searcher, event_backend, state);
+        if (!item.has_block_snapshot()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        const auto &p = item.block_snapshot();
+        ReportEventSnapshotEntry snapshot;
+        if (!BuildReportEventLocationId(trace_id,
+                                        event_backend,
+                                        host_ip_port,
+                                        p.medium(),
+                                        "EVENT_BLOCK_SNAPSHOT",
+                                        event_index,
+                                        state,
+                                        snapshot.location_id)) {
+            break;
+        }
+        snapshot.event_index = event_index;
+        bool valid_snapshot = true;
+        bool has_filtered_block = false;
+        for (const auto &block : p.blocks()) {
+            int64_t block_key = 0;
+            if (!ParseInt64(block.block_key(), block_key)) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: invalid block_key [%s]",
+                              trace_id.c_str(),
+                              block.block_key().c_str());
+                valid_snapshot = false;
+                break;
+            }
+            if (block.specs_size() == 0) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty specs for block_key [%ld]",
+                              trace_id.c_str(),
+                              block_key);
+                valid_snapshot = false;
+                break;
+            }
+            auto specs = BuildFullAttentionSpecs(block.specs());
+            if (!specs.empty()) {
+                has_filtered_block = true;
+                snapshot.blocks[block_key] = std::move(specs);
+            }
+        }
+        if (!valid_snapshot) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        if (p.blocks_size() > 0 && !has_filtered_block) {
+            KVCM_LOG_DEBUG("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: skip non-full-attention snapshot",
+                           trace_id.c_str());
+            break;
+        }
+        ApplyReportEventSnapshot(request_context, meta_searcher, event_backend, snapshot, state);
+        break;
+    }
+    default:
+        KVCM_LOG_WARN("trace_id [%s] | ReportEvent: unknown event_type %d at index %d (ignored)",
+                      trace_id.c_str(),
+                      static_cast<int>(item.event_type()),
+                      event_index);
+        state->per_item_ec[event_index] = EC_BADARGS;
+        break;
+    }
+}
 
 ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                                     const proto::meta::ReportEventRequest *request,
@@ -1598,536 +2141,30 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         return EC_INSTANCE_NOT_EXIST;
     }
 
-    const int events_size = request->events_size();
-    std::vector<ErrorCode> per_item_ec(events_size, EC_OK);
-
-    struct BlockAddEntry {
-        std::string location_id;
-        std::vector<LocationSpec> specs;
-        int event_index;
-    };
-    struct BlockDelEntry {
-        std::string location_id;
-        int event_index;
-    };
-    struct SnapshotEntry {
-        std::string location_id;
-        std::map<int64_t, std::vector<LocationSpec>> blocks;
-        int event_index;
-    };
-    struct PendingAddLocation {
-        std::vector<LocationSpec> specs;
-        std::vector<int> event_indices;
-    };
-    struct PendingDelLocation {
-        std::vector<int> event_indices;
-    };
-    std::map<int64_t, std::vector<BlockAddEntry>> pending_adds;
-    std::map<int64_t, std::vector<BlockDelEntry>> pending_dels;
-    enum class PendingMutationKind { NONE, ADD, DELETE };
-    PendingMutationKind pending_kind = PendingMutationKind::NONE;
-
-    auto find_sub_collector = [&request_context](const std::string &api_name) -> ServiceMetricsCollector * {
-        for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
-            auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
-            if (smc) {
-                const auto &tags = smc->GetMetricsTags();
-                auto it = tags.find("api_name");
-                if (it != tags.end() && it->second == api_name) {
-                    return smc;
-                }
-            }
-        }
-        return nullptr;
-    };
-
-    auto set_item_ec_if_ok = [&per_item_ec](int event_index, ErrorCode ec) {
-        if (event_index >= 0 && event_index < static_cast<int>(per_item_ec.size()) && per_item_ec[event_index] == EC_OK) {
-            per_item_ec[event_index] = ec;
-        }
-    };
-
-    proto::meta::LocationScope empty_scope;
-    auto build_location_id = [&](const std::string &legacy_medium,
-                                 const proto::meta::LocationScope &scope,
-                                 const char *event_name,
-                                 int event_index,
-                                 std::string &out_location_id) -> bool {
-        std::string medium = ResolveMedium(legacy_medium, scope);
-        if (medium.empty()) {
-            KVCM_LOG_WARN("trace_id [%s] | %s: empty medium", trace_id.c_str(), event_name);
-            set_item_ec_if_ok(event_index, EC_BADARGS);
-            return false;
-        }
-        out_location_id = event_backend->BuildLocationId(BuildScopedMedium(medium, scope), host_ip_port);
-        return true;
-    };
-
-    auto flush_adds = [&]() {
-        if (pending_adds.empty()) {
-            return;
-        }
-        KeyVector add_keys_aggr;
-        std::vector<const std::vector<BlockAddEntry> *> add_entries_aggr;
-        add_keys_aggr.reserve(pending_adds.size());
-        add_entries_aggr.reserve(pending_adds.size());
-        for (const auto &kv : pending_adds) {
-            add_keys_aggr.push_back(kv.first);
-            add_entries_aggr.push_back(&kv.second);
-        }
-
-        std::vector<CacheLocationMap> existing_location_maps;
-        BlockMask bm = static_cast<size_t>(0);
-        auto get_ec = meta_searcher->BatchGetLocation(request_context, add_keys_aggr, bm, existing_location_maps);
-        if (get_ec != EC_OK) {
-            for (const auto *entries : add_entries_aggr) {
-                for (const auto &entry : *entries) {
-                    set_item_ec_if_ok(entry.event_index, get_ec);
-                }
-            }
-            pending_adds.clear();
-            return;
-        }
-
-        KeyVector filtered_keys;
-        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
-        std::vector<std::vector<std::vector<int>>> upsert_event_indices;
-        for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
-            const auto &entries = *add_entries_aggr[i];
-            std::map<std::string, PendingAddLocation> final_entries_by_location;
-            for (const auto &entry : entries) {
-                auto &pending = final_entries_by_location[entry.location_id];
-                pending.specs = entry.specs;
-                pending.event_indices.push_back(entry.event_index);
-            }
-
-            std::vector<MetaSearcher::UpsertLocation> per_key_upserts;
-            std::vector<std::vector<int>> per_key_event_indices;
-            const CacheLocationMap *existing_map =
-                (i < existing_location_maps.size()) ? &existing_location_maps[i] : nullptr;
-            for (const auto &kv : final_entries_by_location) {
-                const auto &location_id = kv.first;
-                const auto &pending = kv.second;
-                if (ExistingLocationEquals(existing_map,
-                                           location_id,
-                                           event_backend->GetStorageType(),
-                                           CacheLocationStatus::CLS_SERVING,
-                                           pending.specs)) {
-                    continue;
-                }
-                per_key_upserts.push_back(MetaSearcher::UpsertLocation{
-                    location_id,
-                    event_backend->GetStorageType(),
-                    CacheLocationStatus::CLS_SERVING,
-                    pending.specs,
-                });
-                per_key_event_indices.push_back(pending.event_indices);
-            }
-            if (!per_key_upserts.empty()) {
-                filtered_keys.push_back(add_keys_aggr[i]);
-                upserts.push_back(std::move(per_key_upserts));
-                upsert_event_indices.push_back(std::move(per_key_event_indices));
-            }
-        }
-
-        if (!filtered_keys.empty()) {
-            std::vector<ErrorCode> per_key_ec;
-            auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
-
-            for (size_t k = 0; k < filtered_keys.size(); ++k) {
-                ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
-                if (key_ec == EC_OK) {
-                    continue;
-                }
-                for (const auto &event_indices : upsert_event_indices[k]) {
-                    for (const auto event_index : event_indices) {
-                        set_item_ec_if_ok(event_index, key_ec);
-                    }
-                }
-            }
-            if (auto *add_mc = find_sub_collector("EventBlockAdd")) {
-                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, filtered_keys.size());
-                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, filtered_keys.size());
-            }
-        }
-        pending_adds.clear();
-    };
-
-    auto flush_dels = [&]() {
-        if (pending_dels.empty()) {
-            return;
-        }
-        KeyVector del_keys_aggr;
-        std::vector<const std::vector<BlockDelEntry> *> del_entries_aggr;
-        del_keys_aggr.reserve(pending_dels.size());
-        del_entries_aggr.reserve(pending_dels.size());
-        for (const auto &kv : pending_dels) {
-            del_keys_aggr.push_back(kv.first);
-            del_entries_aggr.push_back(&kv.second);
-        }
-
-        LocationIdsPerKey del_location_ids(del_keys_aggr.size());
-        std::vector<std::vector<std::vector<int>>> del_event_indices(del_keys_aggr.size());
-        for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
-            std::map<std::string, PendingDelLocation> final_entries_by_location;
-            for (const auto &entry : *del_entries_aggr[i]) {
-                final_entries_by_location[entry.location_id].event_indices.push_back(entry.event_index);
-            }
-            del_location_ids[i].reserve(final_entries_by_location.size());
-            del_event_indices[i].reserve(final_entries_by_location.size());
-            for (const auto &kv : final_entries_by_location) {
-                del_location_ids[i].push_back(kv.first);
-                del_event_indices[i].push_back(kv.second.event_indices);
-            }
-        }
-
-        std::vector<std::vector<ErrorCode>> per_location_ec;
-        auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
-
-        for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
-            if (del_ec != EC_OK || k >= per_location_ec.size()) {
-                ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
-                for (const auto &event_indices : del_event_indices[k]) {
-                    for (const auto event_index : event_indices) {
-                        set_item_ec_if_ok(event_index, key_ec);
-                    }
-                }
-                continue;
-            }
-            for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
-                ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
-                if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
-                    continue;
-                }
-                for (const auto event_index : del_event_indices[k][loc_index]) {
-                    set_item_ec_if_ok(event_index, loc_ec);
-                }
-            }
-        }
-        if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
-        }
-        pending_dels.clear();
-    };
-
-    auto flush_pending = [&]() {
-        if (pending_kind == PendingMutationKind::ADD) {
-            flush_adds();
-        } else if (pending_kind == PendingMutationKind::DELETE) {
-            flush_dels();
-        }
-        pending_kind = PendingMutationKind::NONE;
-    };
-
-    auto apply_snapshot = [&](const SnapshotEntry &snapshot) {
-        if (per_item_ec[snapshot.event_index] != EC_OK) {
-            return;
-        }
-
-        KeyVector existing_keys;
-        auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
-        if (list_ec != EC_OK) {
-            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
-                          trace_id.c_str(),
-                          snapshot.location_id.c_str(),
-                          static_cast<int32_t>(list_ec));
-            per_item_ec[snapshot.event_index] = list_ec;
-            return;
-        }
-
-        std::unordered_set<int64_t> reported_key_set;
-        reported_key_set.reserve(snapshot.blocks.size());
-        KeyVector reported_keys;
-        reported_keys.reserve(snapshot.blocks.size());
-        for (const auto &block : snapshot.blocks) {
-            reported_key_set.insert(block.first);
-            reported_keys.push_back(block.first);
-        }
-
-        std::vector<CacheLocationMap> existing_reported_maps;
-        if (!reported_keys.empty()) {
-            BlockMask bm = static_cast<size_t>(0);
-            auto get_ec = meta_searcher->BatchGetLocation(request_context, reported_keys, bm, existing_reported_maps);
-            if (get_ec != EC_OK) {
-                per_item_ec[snapshot.event_index] = get_ec;
-                return;
-            }
-        }
-
-        KeyVector upsert_keys;
-        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
-        size_t block_index = 0;
-        for (const auto &block : snapshot.blocks) {
-            const CacheLocationMap *existing_map =
-                (block_index < existing_reported_maps.size()) ? &existing_reported_maps[block_index] : nullptr;
-            ++block_index;
-            if (ExistingLocationEquals(existing_map,
-                                       snapshot.location_id,
-                                       event_backend->GetStorageType(),
-                                       CacheLocationStatus::CLS_SERVING,
-                                       block.second)) {
-                continue;
-            }
-            upsert_keys.push_back(block.first);
-            upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
-                MetaSearcher::UpsertLocation{
-                    snapshot.location_id,
-                    event_backend->GetStorageType(),
-                    CacheLocationStatus::CLS_SERVING,
-                    block.second,
-                },
-            });
-        }
-
-        if (!upsert_keys.empty()) {
-            std::vector<ErrorCode> per_key_ec;
-            auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
-            if (add_ec != EC_OK) {
-                per_item_ec[snapshot.event_index] = add_ec;
-            } else {
-                for (const auto &key_ec : per_key_ec) {
-                    if (key_ec != EC_OK) {
-                        per_item_ec[snapshot.event_index] = key_ec;
-                        break;
-                    }
-                }
-            }
-        }
-        if (per_item_ec[snapshot.event_index] != EC_OK) {
-            return;
-        }
-
-        KeyVector del_keys;
-        LocationIdsPerKey del_location_ids;
-        for (const auto &existing_key : existing_keys) {
-            if (reported_key_set.find(existing_key) != reported_key_set.end()) {
-                continue;
-            }
-            del_keys.push_back(existing_key);
-            del_location_ids.push_back(LocationIdVector{snapshot.location_id});
-        }
-
-        if (!del_keys.empty()) {
-            std::vector<std::vector<ErrorCode>> per_location_ec;
-            auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
-            if (del_ec != EC_OK) {
-                per_item_ec[snapshot.event_index] = del_ec;
-            } else {
-                for (const auto &location_ecs : per_location_ec) {
-                    for (const auto &loc_ec : location_ecs) {
-                        if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
-                            per_item_ec[snapshot.event_index] = loc_ec;
-                            break;
-                        }
-                    }
-                    if (per_item_ec[snapshot.event_index] != EC_OK) {
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (per_item_ec[snapshot.event_index] == EC_OK) {
-            KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
-                          "delete[%zu]",
-                          trace_id.c_str(),
-                          snapshot.location_id.c_str(),
-                          snapshot.blocks.size(),
-                          upsert_keys.size(),
-                          del_keys.size());
-        }
-    };
-
-    for (int i = 0; i < events_size; ++i) {
-        const auto &item = request->events(i);
-        switch (item.event_type()) {
-        case proto::meta::EVENT_NODE_REGISTER: {
-            if (!item.has_node_register()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::vector<std::string> register_mediums;
-            for (const auto &m : item.node_register().mediums()) {
-                if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
-                    register_mediums.push_back(m);
-                }
-            }
-            auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
-            if (ec != EC_OK) {
-                per_item_ec[i] = ec;
-            } else {
-                KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
-                              trace_id.c_str(),
-                              host_ip_port.c_str(),
-                              register_mediums.size(),
-                              instance_id.c_str());
-            }
-            break;
-        }
-        case proto::meta::EVENT_HEARTBEAT: {
-            if (!item.has_heartbeat()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::map<std::string, std::string> heartbeat_status;
-            for (const auto &kv : item.heartbeat().system_status()) {
-                heartbeat_status[kv.first] = kv.second;
-            }
-            per_item_ec[i] = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
-            break;
-        }
-        case proto::meta::EVENT_HOST_DOWN: {
-            flush_pending();
-            event_backend->SetNodeUnavailable(instance_id, host_ip_port);
-            uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
-            assert(schedule_plan_executor_);
-            schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
-                this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
-            });
-            event_backend->UnregisterNode(instance_id, host_ip_port);
-            KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
-                          trace_id.c_str(),
-                          host_ip_port.c_str(),
-                          gen_at_trigger);
-            break;
-        }
-        case proto::meta::EVENT_BLOCK_ADD: {
-            if (!item.has_block_add()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            const auto &p = item.block_add();
-            int64_t block_key = 0;
-            if (!ParseInt64(p.block_key(), block_key)) {
-                KVCM_LOG_WARN(
-                    "trace_id [%s] | EVENT_BLOCK_ADD: invalid block_key [%s]", trace_id.c_str(), p.block_key().c_str());
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            if (p.specs_size() == 0) {
-                KVCM_LOG_WARN(
-                    "trace_id [%s] | EVENT_BLOCK_ADD: empty specs for block_key [%ld]", trace_id.c_str(), block_key);
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::string location_id;
-            if (!build_location_id(p.medium(),
-                                   p.has_location() ? p.location() : empty_scope,
-                                   "EVENT_BLOCK_ADD",
-                                   i,
-                                   location_id)) {
-                break;
-            }
-            if (pending_kind == PendingMutationKind::DELETE) {
-                flush_dels();
-            }
-            pending_kind = PendingMutationKind::ADD;
-            std::vector<LocationSpec> entry_specs;
-            entry_specs.reserve(p.specs_size());
-            for (const auto &s : p.specs()) {
-                entry_specs.emplace_back(s.name(), s.uri());
-            }
-            pending_adds[block_key].push_back(BlockAddEntry{std::move(location_id), std::move(entry_specs), i});
-            break;
-        }
-        case proto::meta::EVENT_BLOCK_DELETE: {
-            if (!item.has_block_delete()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            const auto &p = item.block_delete();
-            int64_t block_key = 0;
-            if (!ParseInt64(p.block_key(), block_key)) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_DELETE: invalid block_key [%s]",
-                              trace_id.c_str(),
-                              p.block_key().c_str());
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::string location_id;
-            if (!build_location_id(p.medium(),
-                                   p.has_location() ? p.location() : empty_scope,
-                                   "EVENT_BLOCK_DELETE",
-                                   i,
-                                   location_id)) {
-                break;
-            }
-            if (pending_kind == PendingMutationKind::ADD) {
-                flush_adds();
-            }
-            pending_kind = PendingMutationKind::DELETE;
-            pending_dels[block_key].push_back(BlockDelEntry{std::move(location_id), i});
-            break;
-        }
-        case proto::meta::EVENT_BLOCK_SNAPSHOT: {
-            flush_pending();
-            if (!item.has_block_snapshot()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            const auto &p = item.block_snapshot();
-            SnapshotEntry snapshot;
-            if (!build_location_id(p.medium(),
-                                   p.has_location() ? p.location() : empty_scope,
-                                   "EVENT_BLOCK_SNAPSHOT",
-                                   i,
-                                   snapshot.location_id)) {
-                break;
-            }
-            snapshot.event_index = i;
-            bool valid_snapshot = true;
-            for (const auto &block : p.blocks()) {
-                int64_t block_key = 0;
-                if (!ParseInt64(block.block_key(), block_key)) {
-                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: invalid block_key [%s]",
-                                  trace_id.c_str(),
-                                  block.block_key().c_str());
-                    valid_snapshot = false;
-                    break;
-                }
-                if (block.specs_size() == 0) {
-                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty specs for block_key [%ld]",
-                                  trace_id.c_str(),
-                                  block_key);
-                    valid_snapshot = false;
-                    break;
-                }
-                auto &specs = snapshot.blocks[block_key];
-                specs.clear();
-                specs.reserve(block.specs_size());
-                for (const auto &s : block.specs()) {
-                    specs.emplace_back(s.name(), s.uri());
-                }
-            }
-            if (!valid_snapshot) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            apply_snapshot(snapshot);
-            break;
-        }
-        default:
-            KVCM_LOG_WARN("trace_id [%s] | ReportEvent: unknown event_type %d at index %d (ignored)",
-                          trace_id.c_str(),
-                          static_cast<int>(item.event_type()),
-                          i);
-            per_item_ec[i] = EC_BADARGS;
-            break;
-        }
+    ReportEventState state(request->events_size());
+    for (int i = 0; i < request->events_size(); ++i) {
+        ProcessReportEventItem(request_context,
+                               request->events(i),
+                               i,
+                               instance_id,
+                               host_ip_port,
+                               requested_type,
+                               meta_searcher,
+                               event_backend,
+                               &state);
     }
 
-    flush_pending();
+    FlushReportEventPending(request_context, meta_searcher, event_backend, &state);
 
     bool any_failure = false;
-    for (auto ec : per_item_ec) {
+    for (auto ec : state.per_item_ec) {
         if (ec != EC_OK) {
             any_failure = true;
             break;
         }
     }
     if (any_failure) {
-        for (auto ec : per_item_ec) {
+        for (auto ec : state.per_item_ec) {
             response->add_item_results(ToProtoErrorCode(ec));
         }
         response_status->set_code(proto::meta::INTERNAL_ERROR);

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -4,6 +4,7 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -1437,6 +1438,92 @@ bool ParseInt64(const std::string &s, int64_t &out) {
     } catch (...) { return false; }
 }
 
+std::string EscapeLocationScopeToken(const std::string &s) {
+    std::string out;
+    out.reserve(s.size());
+    for (char ch : s) {
+        if (ch == '\\' || ch == ';' || ch == '=') {
+            out.push_back('\\');
+        }
+        out.push_back(ch);
+    }
+    return out;
+}
+
+std::string ResolveMedium(const std::string &legacy_medium, const proto::meta::LocationScope &scope) {
+    return scope.medium().empty() ? legacy_medium : scope.medium();
+}
+
+std::string BuildScopedMedium(const std::string &medium, const proto::meta::LocationScope &scope) {
+    if (scope.labels().empty()) {
+        return medium;
+    }
+    std::map<std::string, std::string> sorted_labels;
+    for (const auto &kv : scope.labels()) {
+        if (!kv.first.empty()) {
+            sorted_labels[kv.first] = kv.second;
+        }
+    }
+    if (sorted_labels.empty()) {
+        return medium;
+    }
+    std::string scoped_medium = medium;
+    for (const auto &kv : sorted_labels) {
+        scoped_medium.push_back(';');
+        scoped_medium.append(EscapeLocationScopeToken(kv.first));
+        scoped_medium.push_back('=');
+        scoped_medium.append(EscapeLocationScopeToken(kv.second));
+    }
+    return scoped_medium;
+}
+
+bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i].name() != rhs[i].name() || lhs[i].uri() != rhs[i].uri()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CacheLocationEquals(const CacheLocationConstPtr &loc,
+                         DataStorageType type,
+                         CacheLocationStatus status,
+                         const std::vector<LocationSpec> &specs) {
+    return loc && loc->type() == type && loc->status() == status && SameLocationSpecs(loc->location_specs(), specs);
+}
+
+bool ExistingLocationEquals(const CacheLocationMap *existing_map,
+                            const std::string &location_id,
+                            DataStorageType type,
+                            CacheLocationStatus status,
+                            const std::vector<LocationSpec> &specs) {
+    if (!existing_map) {
+        return false;
+    }
+    auto iter = existing_map->find(location_id);
+    return iter != existing_map->end() && CacheLocationEquals(iter->second, type, status, specs);
+}
+
+proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec) {
+    if (ec == EC_OK) {
+        return proto::meta::OK;
+    }
+    if (ec == EC_BADARGS) {
+        return proto::meta::INVALID_ARGUMENT;
+    }
+    if (ec == EC_INSTANCE_NOT_EXIST) {
+        return proto::meta::INSTANCE_NOT_EXIST;
+    }
+    if (ec == EC_NODE_NOT_REGISTERED) {
+        return proto::meta::NODE_NOT_REGISTERED;
+    }
+    return proto::meta::INTERNAL_ERROR;
+}
+
 } // namespace
 
 ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
@@ -1514,12 +1601,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     const int events_size = request->events_size();
     std::vector<ErrorCode> per_item_ec(events_size, EC_OK);
 
-    bool has_register = false;
-    bool has_heartbeat = false;
-    bool has_host_down = false;
-    std::vector<std::string> register_mediums;
-    std::map<std::string, std::string> heartbeat_status;
-
     struct BlockAddEntry {
         std::string location_id;
         std::vector<LocationSpec> specs;
@@ -1534,36 +1615,381 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         std::map<int64_t, std::vector<LocationSpec>> blocks;
         int event_index;
     };
-    std::map<int64_t, std::vector<BlockAddEntry>> block_to_add;
-    std::map<int64_t, std::vector<BlockDelEntry>> block_to_del;
-    std::vector<SnapshotEntry> snapshots;
+    struct PendingAddLocation {
+        std::vector<LocationSpec> specs;
+        std::vector<int> event_indices;
+    };
+    struct PendingDelLocation {
+        std::vector<int> event_indices;
+    };
+    std::map<int64_t, std::vector<BlockAddEntry>> pending_adds;
+    std::map<int64_t, std::vector<BlockDelEntry>> pending_dels;
+    enum class PendingMutationKind { NONE, ADD, DELETE };
+    PendingMutationKind pending_kind = PendingMutationKind::NONE;
+
+    auto find_sub_collector = [&request_context](const std::string &api_name) -> ServiceMetricsCollector * {
+        for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
+            auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
+            if (smc) {
+                const auto &tags = smc->GetMetricsTags();
+                auto it = tags.find("api_name");
+                if (it != tags.end() && it->second == api_name) {
+                    return smc;
+                }
+            }
+        }
+        return nullptr;
+    };
+
+    auto set_item_ec_if_ok = [&per_item_ec](int event_index, ErrorCode ec) {
+        if (event_index >= 0 && event_index < static_cast<int>(per_item_ec.size()) && per_item_ec[event_index] == EC_OK) {
+            per_item_ec[event_index] = ec;
+        }
+    };
+
+    proto::meta::LocationScope empty_scope;
+    auto build_location_id = [&](const std::string &legacy_medium,
+                                 const proto::meta::LocationScope &scope,
+                                 const char *event_name,
+                                 int event_index,
+                                 std::string &out_location_id) -> bool {
+        std::string medium = ResolveMedium(legacy_medium, scope);
+        if (medium.empty()) {
+            KVCM_LOG_WARN("trace_id [%s] | %s: empty medium", trace_id.c_str(), event_name);
+            set_item_ec_if_ok(event_index, EC_BADARGS);
+            return false;
+        }
+        out_location_id = event_backend->BuildLocationId(BuildScopedMedium(medium, scope), host_ip_port);
+        return true;
+    };
+
+    auto flush_adds = [&]() {
+        if (pending_adds.empty()) {
+            return;
+        }
+        KeyVector add_keys_aggr;
+        std::vector<const std::vector<BlockAddEntry> *> add_entries_aggr;
+        add_keys_aggr.reserve(pending_adds.size());
+        add_entries_aggr.reserve(pending_adds.size());
+        for (const auto &kv : pending_adds) {
+            add_keys_aggr.push_back(kv.first);
+            add_entries_aggr.push_back(&kv.second);
+        }
+
+        std::vector<CacheLocationMap> existing_location_maps;
+        BlockMask bm = static_cast<size_t>(0);
+        auto get_ec = meta_searcher->BatchGetLocation(request_context, add_keys_aggr, bm, existing_location_maps);
+        if (get_ec != EC_OK) {
+            for (const auto *entries : add_entries_aggr) {
+                for (const auto &entry : *entries) {
+                    set_item_ec_if_ok(entry.event_index, get_ec);
+                }
+            }
+            pending_adds.clear();
+            return;
+        }
+
+        KeyVector filtered_keys;
+        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+        std::vector<std::vector<std::vector<int>>> upsert_event_indices;
+        for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
+            const auto &entries = *add_entries_aggr[i];
+            std::map<std::string, PendingAddLocation> final_entries_by_location;
+            for (const auto &entry : entries) {
+                auto &pending = final_entries_by_location[entry.location_id];
+                pending.specs = entry.specs;
+                pending.event_indices.push_back(entry.event_index);
+            }
+
+            std::vector<MetaSearcher::UpsertLocation> per_key_upserts;
+            std::vector<std::vector<int>> per_key_event_indices;
+            const CacheLocationMap *existing_map =
+                (i < existing_location_maps.size()) ? &existing_location_maps[i] : nullptr;
+            for (const auto &kv : final_entries_by_location) {
+                const auto &location_id = kv.first;
+                const auto &pending = kv.second;
+                if (ExistingLocationEquals(existing_map,
+                                           location_id,
+                                           event_backend->GetStorageType(),
+                                           CacheLocationStatus::CLS_SERVING,
+                                           pending.specs)) {
+                    continue;
+                }
+                per_key_upserts.push_back(MetaSearcher::UpsertLocation{
+                    location_id,
+                    event_backend->GetStorageType(),
+                    CacheLocationStatus::CLS_SERVING,
+                    pending.specs,
+                });
+                per_key_event_indices.push_back(pending.event_indices);
+            }
+            if (!per_key_upserts.empty()) {
+                filtered_keys.push_back(add_keys_aggr[i]);
+                upserts.push_back(std::move(per_key_upserts));
+                upsert_event_indices.push_back(std::move(per_key_event_indices));
+            }
+        }
+
+        if (!filtered_keys.empty()) {
+            std::vector<ErrorCode> per_key_ec;
+            auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
+
+            for (size_t k = 0; k < filtered_keys.size(); ++k) {
+                ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
+                if (key_ec == EC_OK) {
+                    continue;
+                }
+                for (const auto &event_indices : upsert_event_indices[k]) {
+                    for (const auto event_index : event_indices) {
+                        set_item_ec_if_ok(event_index, key_ec);
+                    }
+                }
+            }
+            if (auto *add_mc = find_sub_collector("EventBlockAdd")) {
+                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, filtered_keys.size());
+                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, filtered_keys.size());
+            }
+        }
+        pending_adds.clear();
+    };
+
+    auto flush_dels = [&]() {
+        if (pending_dels.empty()) {
+            return;
+        }
+        KeyVector del_keys_aggr;
+        std::vector<const std::vector<BlockDelEntry> *> del_entries_aggr;
+        del_keys_aggr.reserve(pending_dels.size());
+        del_entries_aggr.reserve(pending_dels.size());
+        for (const auto &kv : pending_dels) {
+            del_keys_aggr.push_back(kv.first);
+            del_entries_aggr.push_back(&kv.second);
+        }
+
+        LocationIdsPerKey del_location_ids(del_keys_aggr.size());
+        std::vector<std::vector<std::vector<int>>> del_event_indices(del_keys_aggr.size());
+        for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
+            std::map<std::string, PendingDelLocation> final_entries_by_location;
+            for (const auto &entry : *del_entries_aggr[i]) {
+                final_entries_by_location[entry.location_id].event_indices.push_back(entry.event_index);
+            }
+            del_location_ids[i].reserve(final_entries_by_location.size());
+            del_event_indices[i].reserve(final_entries_by_location.size());
+            for (const auto &kv : final_entries_by_location) {
+                del_location_ids[i].push_back(kv.first);
+                del_event_indices[i].push_back(kv.second.event_indices);
+            }
+        }
+
+        std::vector<std::vector<ErrorCode>> per_location_ec;
+        auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
+
+        for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
+            if (del_ec != EC_OK || k >= per_location_ec.size()) {
+                ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
+                for (const auto &event_indices : del_event_indices[k]) {
+                    for (const auto event_index : event_indices) {
+                        set_item_ec_if_ok(event_index, key_ec);
+                    }
+                }
+                continue;
+            }
+            for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
+                ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
+                if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
+                    continue;
+                }
+                for (const auto event_index : del_event_indices[k][loc_index]) {
+                    set_item_ec_if_ok(event_index, loc_ec);
+                }
+            }
+        }
+        if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
+            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
+            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
+        }
+        pending_dels.clear();
+    };
+
+    auto flush_pending = [&]() {
+        if (pending_kind == PendingMutationKind::ADD) {
+            flush_adds();
+        } else if (pending_kind == PendingMutationKind::DELETE) {
+            flush_dels();
+        }
+        pending_kind = PendingMutationKind::NONE;
+    };
+
+    auto apply_snapshot = [&](const SnapshotEntry &snapshot) {
+        if (per_item_ec[snapshot.event_index] != EC_OK) {
+            return;
+        }
+
+        KeyVector existing_keys;
+        auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
+        if (list_ec != EC_OK) {
+            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
+                          trace_id.c_str(),
+                          snapshot.location_id.c_str(),
+                          static_cast<int32_t>(list_ec));
+            per_item_ec[snapshot.event_index] = list_ec;
+            return;
+        }
+
+        std::unordered_set<int64_t> reported_key_set;
+        reported_key_set.reserve(snapshot.blocks.size());
+        KeyVector reported_keys;
+        reported_keys.reserve(snapshot.blocks.size());
+        for (const auto &block : snapshot.blocks) {
+            reported_key_set.insert(block.first);
+            reported_keys.push_back(block.first);
+        }
+
+        std::vector<CacheLocationMap> existing_reported_maps;
+        if (!reported_keys.empty()) {
+            BlockMask bm = static_cast<size_t>(0);
+            auto get_ec = meta_searcher->BatchGetLocation(request_context, reported_keys, bm, existing_reported_maps);
+            if (get_ec != EC_OK) {
+                per_item_ec[snapshot.event_index] = get_ec;
+                return;
+            }
+        }
+
+        KeyVector upsert_keys;
+        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+        size_t block_index = 0;
+        for (const auto &block : snapshot.blocks) {
+            const CacheLocationMap *existing_map =
+                (block_index < existing_reported_maps.size()) ? &existing_reported_maps[block_index] : nullptr;
+            ++block_index;
+            if (ExistingLocationEquals(existing_map,
+                                       snapshot.location_id,
+                                       event_backend->GetStorageType(),
+                                       CacheLocationStatus::CLS_SERVING,
+                                       block.second)) {
+                continue;
+            }
+            upsert_keys.push_back(block.first);
+            upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
+                MetaSearcher::UpsertLocation{
+                    snapshot.location_id,
+                    event_backend->GetStorageType(),
+                    CacheLocationStatus::CLS_SERVING,
+                    block.second,
+                },
+            });
+        }
+
+        if (!upsert_keys.empty()) {
+            std::vector<ErrorCode> per_key_ec;
+            auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
+            if (add_ec != EC_OK) {
+                per_item_ec[snapshot.event_index] = add_ec;
+            } else {
+                for (const auto &key_ec : per_key_ec) {
+                    if (key_ec != EC_OK) {
+                        per_item_ec[snapshot.event_index] = key_ec;
+                        break;
+                    }
+                }
+            }
+        }
+        if (per_item_ec[snapshot.event_index] != EC_OK) {
+            return;
+        }
+
+        KeyVector del_keys;
+        LocationIdsPerKey del_location_ids;
+        for (const auto &existing_key : existing_keys) {
+            if (reported_key_set.find(existing_key) != reported_key_set.end()) {
+                continue;
+            }
+            del_keys.push_back(existing_key);
+            del_location_ids.push_back(LocationIdVector{snapshot.location_id});
+        }
+
+        if (!del_keys.empty()) {
+            std::vector<std::vector<ErrorCode>> per_location_ec;
+            auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
+            if (del_ec != EC_OK) {
+                per_item_ec[snapshot.event_index] = del_ec;
+            } else {
+                for (const auto &location_ecs : per_location_ec) {
+                    for (const auto &loc_ec : location_ecs) {
+                        if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                            per_item_ec[snapshot.event_index] = loc_ec;
+                            break;
+                        }
+                    }
+                    if (per_item_ec[snapshot.event_index] != EC_OK) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (per_item_ec[snapshot.event_index] == EC_OK) {
+            KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
+                          "delete[%zu]",
+                          trace_id.c_str(),
+                          snapshot.location_id.c_str(),
+                          snapshot.blocks.size(),
+                          upsert_keys.size(),
+                          del_keys.size());
+        }
+    };
 
     for (int i = 0; i < events_size; ++i) {
         const auto &item = request->events(i);
         switch (item.event_type()) {
         case proto::meta::EVENT_NODE_REGISTER: {
-            has_register = true;
-            if (item.has_node_register()) {
-                for (const auto &m : item.node_register().mediums()) {
-                    if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
-                        register_mediums.push_back(m);
-                    }
+            if (!item.has_node_register()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            std::vector<std::string> register_mediums;
+            for (const auto &m : item.node_register().mediums()) {
+                if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
+                    register_mediums.push_back(m);
                 }
+            }
+            auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
+            if (ec != EC_OK) {
+                per_item_ec[i] = ec;
+            } else {
+                KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
+                              trace_id.c_str(),
+                              host_ip_port.c_str(),
+                              register_mediums.size(),
+                              instance_id.c_str());
             }
             break;
         }
         case proto::meta::EVENT_HEARTBEAT: {
-            has_heartbeat = true;
-            if (item.has_heartbeat()) {
-                heartbeat_status.clear();
-                for (const auto &kv : item.heartbeat().system_status()) {
-                    heartbeat_status[kv.first] = kv.second;
-                }
+            if (!item.has_heartbeat()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
             }
+            std::map<std::string, std::string> heartbeat_status;
+            for (const auto &kv : item.heartbeat().system_status()) {
+                heartbeat_status[kv.first] = kv.second;
+            }
+            per_item_ec[i] = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
             break;
         }
         case proto::meta::EVENT_HOST_DOWN: {
-            has_host_down = true;
+            flush_pending();
+            event_backend->SetNodeUnavailable(instance_id, host_ip_port);
+            uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
+            assert(schedule_plan_executor_);
+            schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
+                this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
+            });
+            event_backend->UnregisterNode(instance_id, host_ip_port);
+            KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
+                          trace_id.c_str(),
+                          host_ip_port.c_str(),
+                          gen_at_trigger);
             break;
         }
         case proto::meta::EVENT_BLOCK_ADD: {
@@ -1579,25 +2005,30 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            if (p.medium().empty()) {
-                KVCM_LOG_WARN(
-                    "trace_id [%s] | EVENT_BLOCK_ADD: empty medium for block_key [%ld]", trace_id.c_str(), block_key);
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
             if (p.specs_size() == 0) {
                 KVCM_LOG_WARN(
                     "trace_id [%s] | EVENT_BLOCK_ADD: empty specs for block_key [%ld]", trace_id.c_str(), block_key);
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            std::string location_id = event_backend->BuildLocationId(p.medium(), host_ip_port);
+            std::string location_id;
+            if (!build_location_id(p.medium(),
+                                   p.has_location() ? p.location() : empty_scope,
+                                   "EVENT_BLOCK_ADD",
+                                   i,
+                                   location_id)) {
+                break;
+            }
+            if (pending_kind == PendingMutationKind::DELETE) {
+                flush_dels();
+            }
+            pending_kind = PendingMutationKind::ADD;
             std::vector<LocationSpec> entry_specs;
             entry_specs.reserve(p.specs_size());
             for (const auto &s : p.specs()) {
                 entry_specs.emplace_back(s.name(), s.uri());
             }
-            block_to_add[block_key].push_back(BlockAddEntry{std::move(location_id), std::move(entry_specs), i});
+            pending_adds[block_key].push_back(BlockAddEntry{std::move(location_id), std::move(entry_specs), i});
             break;
         }
         case proto::meta::EVENT_BLOCK_DELETE: {
@@ -1614,30 +2045,36 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            if (p.medium().empty()) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_DELETE: empty medium for block_key [%ld]",
-                              trace_id.c_str(),
-                              block_key);
-                per_item_ec[i] = EC_BADARGS;
+            std::string location_id;
+            if (!build_location_id(p.medium(),
+                                   p.has_location() ? p.location() : empty_scope,
+                                   "EVENT_BLOCK_DELETE",
+                                   i,
+                                   location_id)) {
                 break;
             }
-            block_to_del[block_key].push_back(
-                BlockDelEntry{event_backend->BuildLocationId(p.medium(), host_ip_port), i});
+            if (pending_kind == PendingMutationKind::ADD) {
+                flush_adds();
+            }
+            pending_kind = PendingMutationKind::DELETE;
+            pending_dels[block_key].push_back(BlockDelEntry{std::move(location_id), i});
             break;
         }
         case proto::meta::EVENT_BLOCK_SNAPSHOT: {
+            flush_pending();
             if (!item.has_block_snapshot()) {
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
             const auto &p = item.block_snapshot();
-            if (p.medium().empty()) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty medium", trace_id.c_str());
-                per_item_ec[i] = EC_BADARGS;
+            SnapshotEntry snapshot;
+            if (!build_location_id(p.medium(),
+                                   p.has_location() ? p.location() : empty_scope,
+                                   "EVENT_BLOCK_SNAPSHOT",
+                                   i,
+                                   snapshot.location_id)) {
                 break;
             }
-            SnapshotEntry snapshot;
-            snapshot.location_id = event_backend->BuildLocationId(p.medium(), host_ip_port);
             snapshot.event_index = i;
             bool valid_snapshot = true;
             for (const auto &block : p.blocks()) {
@@ -1667,7 +2104,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            snapshots.emplace_back(std::move(snapshot));
+            apply_snapshot(snapshot);
             break;
         }
         default:
@@ -1680,247 +2117,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
-    if (has_register) {
-        auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
-        if (ec != EC_OK) {
-            for (int i = 0; i < events_size; ++i) {
-                if (request->events(i).event_type() == proto::meta::EVENT_NODE_REGISTER) {
-                    per_item_ec[i] = ec;
-                }
-            }
-        } else {
-            KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
-                          trace_id.c_str(),
-                          host_ip_port.c_str(),
-                          register_mediums.size(),
-                          instance_id.c_str());
-        }
-    }
-
-    if (has_heartbeat) {
-        auto hb_ec = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
-        if (hb_ec != EC_OK) {
-            for (int i = 0; i < events_size; ++i) {
-                if (request->events(i).event_type() == proto::meta::EVENT_HEARTBEAT) {
-                    per_item_ec[i] = hb_ec;
-                }
-            }
-        }
-    }
-
-    auto find_sub_collector = [&request_context](const std::string &api_name) -> ServiceMetricsCollector * {
-        for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
-            auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
-            if (smc) {
-                const auto &tags = smc->GetMetricsTags();
-                auto it = tags.find("api_name");
-                if (it != tags.end() && it->second == api_name) {
-                    return smc;
-                }
-            }
-        }
-        return nullptr;
-    };
-
-    if (!block_to_add.empty()) {
-        KeyVector add_keys_aggr;
-        std::vector<const std::vector<BlockAddEntry> *> add_entries_aggr;
-        add_keys_aggr.reserve(block_to_add.size());
-        add_entries_aggr.reserve(block_to_add.size());
-        for (const auto &kv : block_to_add) {
-            add_keys_aggr.push_back(kv.first);
-            add_entries_aggr.push_back(&kv.second);
-        }
-
-        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts(add_keys_aggr.size());
-        for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
-            const auto &entries = *add_entries_aggr[i];
-            upserts[i].reserve(entries.size());
-            for (const auto &entry : entries) {
-                upserts[i].push_back(MetaSearcher::UpsertLocation{
-                    entry.location_id,
-                    event_backend->GetStorageType(),
-                    CacheLocationStatus::CLS_SERVING,
-                    entry.specs,
-                });
-            }
-        }
-
-        std::vector<ErrorCode> per_key_ec;
-        meta_searcher->BatchUpsertLocations(request_context, add_keys_aggr, upserts, per_key_ec);
-
-        for (size_t k = 0; k < add_keys_aggr.size(); ++k) {
-            ErrorCode key_ec = (k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR;
-            if (key_ec == EC_OK) {
-                continue;
-            }
-            for (const auto &entry : *add_entries_aggr[k]) {
-                if (per_item_ec[entry.event_index] == EC_OK) {
-                    per_item_ec[entry.event_index] = key_ec;
-                }
-            }
-        }
-        if (auto *add_mc = find_sub_collector("EventBlockAdd")) {
-            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, add_keys_aggr.size());
-            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, add_keys_aggr.size());
-        }
-    }
-
-    if (!block_to_del.empty()) {
-        KeyVector del_keys_aggr;
-        std::vector<const std::vector<BlockDelEntry> *> del_entries_aggr;
-        del_keys_aggr.reserve(block_to_del.size());
-        del_entries_aggr.reserve(block_to_del.size());
-        for (const auto &kv : block_to_del) {
-            del_keys_aggr.push_back(kv.first);
-            del_entries_aggr.push_back(&kv.second);
-        }
-
-        LocationIdsPerKey del_location_ids(del_keys_aggr.size());
-        for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
-            for (const auto &entry : *del_entries_aggr[i]) {
-                del_location_ids[i].push_back(entry.location_id);
-            }
-        }
-
-        std::vector<std::vector<ErrorCode>> per_location_ec;
-        meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
-
-        for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
-            ErrorCode key_ec = EC_OK;
-            if (k < per_location_ec.size()) {
-                for (const auto &loc_ec : per_location_ec[k]) {
-                    if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
-                        key_ec = loc_ec;
-                        break;
-                    }
-                }
-            } else {
-                key_ec = EC_ERROR;
-            }
-            if (key_ec == EC_OK) {
-                continue;
-            }
-            for (const auto &entry : *del_entries_aggr[k]) {
-                if (per_item_ec[entry.event_index] == EC_OK) {
-                    per_item_ec[entry.event_index] = key_ec;
-                }
-            }
-        }
-        if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
-        }
-    }
-
-    if (!snapshots.empty()) {
-        for (const auto &snapshot : snapshots) {
-            if (per_item_ec[snapshot.event_index] != EC_OK) {
-                continue;
-            }
-
-            KeyVector existing_keys;
-            auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
-            if (list_ec != EC_OK) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
-                              trace_id.c_str(),
-                              snapshot.location_id.c_str(),
-                              static_cast<int32_t>(list_ec));
-                per_item_ec[snapshot.event_index] = list_ec;
-                continue;
-            }
-
-            std::unordered_set<int64_t> reported_key_set;
-            reported_key_set.reserve(snapshot.blocks.size());
-            for (const auto &block : snapshot.blocks) {
-                reported_key_set.insert(block.first);
-            }
-
-            KeyVector upsert_keys;
-            std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
-            for (const auto &block : snapshot.blocks) {
-                upsert_keys.push_back(block.first);
-                upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
-                    MetaSearcher::UpsertLocation{
-                        snapshot.location_id,
-                        event_backend->GetStorageType(),
-                        CacheLocationStatus::CLS_SERVING,
-                        block.second,
-                    },
-                });
-            }
-
-            if (!upsert_keys.empty()) {
-                std::vector<ErrorCode> per_key_ec;
-                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
-                if (add_ec != EC_OK) {
-                    per_item_ec[snapshot.event_index] = add_ec;
-                } else {
-                    for (const auto &key_ec : per_key_ec) {
-                        if (key_ec != EC_OK) {
-                            per_item_ec[snapshot.event_index] = key_ec;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            KeyVector del_keys;
-            LocationIdsPerKey del_location_ids;
-            for (const auto &existing_key : existing_keys) {
-                if (reported_key_set.find(existing_key) != reported_key_set.end()) {
-                    continue;
-                }
-                del_keys.push_back(existing_key);
-                del_location_ids.push_back(LocationIdVector{snapshot.location_id});
-            }
-
-            if (!del_keys.empty()) {
-                std::vector<std::vector<ErrorCode>> per_location_ec;
-                auto del_ec =
-                    meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
-                if (del_ec != EC_OK) {
-                    per_item_ec[snapshot.event_index] = del_ec;
-                } else {
-                    for (const auto &location_ecs : per_location_ec) {
-                        for (const auto &loc_ec : location_ecs) {
-                            if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
-                                per_item_ec[snapshot.event_index] = loc_ec;
-                                break;
-                            }
-                        }
-                        if (per_item_ec[snapshot.event_index] != EC_OK) {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (per_item_ec[snapshot.event_index] == EC_OK) {
-                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
-                              "delete[%zu]",
-                              trace_id.c_str(),
-                              snapshot.location_id.c_str(),
-                              snapshot.blocks.size(),
-                              upsert_keys.size(),
-                              del_keys.size());
-            }
-        }
-    }
-
-    if (has_host_down) {
-        event_backend->SetNodeUnavailable(instance_id, host_ip_port);
-        uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
-        assert(schedule_plan_executor_);
-        schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
-            this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
-        });
-        event_backend->UnregisterNode(instance_id, host_ip_port);
-        KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
-                      trace_id.c_str(),
-                      host_ip_port.c_str(),
-                      gen_at_trigger);
-    }
+    flush_pending();
 
     bool any_failure = false;
     for (auto ec : per_item_ec) {
@@ -1931,17 +2128,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     }
     if (any_failure) {
         for (auto ec : per_item_ec) {
-            proto::meta::ErrorCode mapped = proto::meta::OK;
-            if (ec == EC_OK) {
-                mapped = proto::meta::OK;
-            } else if (ec == EC_BADARGS) {
-                mapped = proto::meta::INVALID_ARGUMENT;
-            } else if (ec == EC_INSTANCE_NOT_EXIST) {
-                mapped = proto::meta::INSTANCE_NOT_EXIST;
-            } else {
-                mapped = proto::meta::INTERNAL_ERROR;
-            }
-            response->add_item_results(mapped);
+            response->add_item_results(ToProtoErrorCode(ec));
         }
         response_status->set_code(proto::meta::INTERNAL_ERROR);
         response_status->set_message("ReportEvent partially failed; see item_results");

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1830,20 +1830,16 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 continue;
             }
 
-            std::unordered_set<int64_t> existing_key_set(existing_keys.begin(), existing_keys.end());
             std::unordered_set<int64_t> reported_key_set;
             reported_key_set.reserve(snapshot.blocks.size());
             for (const auto &block : snapshot.blocks) {
                 reported_key_set.insert(block.first);
             }
 
-            KeyVector add_keys;
+            KeyVector upsert_keys;
             std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
             for (const auto &block : snapshot.blocks) {
-                if (existing_key_set.find(block.first) != existing_key_set.end()) {
-                    continue;
-                }
-                add_keys.push_back(block.first);
+                upsert_keys.push_back(block.first);
                 upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
                     MetaSearcher::UpsertLocation{
                         snapshot.location_id,
@@ -1854,9 +1850,9 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 });
             }
 
-            if (!add_keys.empty()) {
+            if (!upsert_keys.empty()) {
                 std::vector<ErrorCode> per_key_ec;
-                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, add_keys, upserts, per_key_ec);
+                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
                 if (add_ec != EC_OK) {
                     per_item_ec[snapshot.event_index] = add_ec;
                 } else {
@@ -1901,12 +1897,12 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
 
             if (per_item_ec[snapshot.event_index] == EC_OK) {
-                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], add[%zu], "
+                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
                               "delete[%zu]",
                               trace_id.c_str(),
                               snapshot.location_id.c_str(),
                               snapshot.blocks.size(),
-                              add_keys.size(),
+                              upsert_keys.size(),
                               del_keys.size());
             }
         }

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1751,8 +1751,8 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
     }
 
     const std::string &trace_id = request_context->trace_id();
-    KeyVector existing_keys;
-    auto list_ec = meta_searcher->GetKeysByLocationIndex(request_context, snapshot.location_id, existing_keys);
+    KeyVector indexed_keys;
+    auto list_ec = meta_searcher->GetKeysByLocationIndex(request_context, snapshot.location_id, indexed_keys);
     if (list_ec != EC_OK) {
         KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
                       trace_id.c_str(),
@@ -1760,6 +1760,35 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
                       static_cast<int32_t>(list_ec));
         state->per_item_ec[snapshot.event_index] = list_ec;
         return;
+    }
+
+    KeyVector existing_keys;
+    size_t stale_index_key_count = 0;
+    if (!indexed_keys.empty()) {
+        std::vector<CacheLocationMap> indexed_location_maps;
+        BlockMask bm = static_cast<size_t>(0);
+        auto get_ec = meta_searcher->BatchGetLocation(request_context, indexed_keys, bm, indexed_location_maps);
+        if (get_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = get_ec;
+            return;
+        }
+        existing_keys.reserve(indexed_keys.size());
+        for (size_t i = 0; i < indexed_keys.size(); ++i) {
+            const CacheLocationMap *location_map =
+                (i < indexed_location_maps.size()) ? &indexed_location_maps[i] : nullptr;
+            if (!location_map) {
+                ++stale_index_key_count;
+                continue;
+            }
+            auto iter = location_map->find(snapshot.location_id);
+            if (iter != location_map->end() && iter->second &&
+                iter->second->type() == event_backend->GetStorageType() &&
+                iter->second->status() == CacheLocationStatus::CLS_SERVING) {
+                existing_keys.push_back(indexed_keys[i]);
+            } else {
+                ++stale_index_key_count;
+            }
+        }
     }
 
     std::unordered_set<int64_t> reported_key_set;
@@ -1856,12 +1885,13 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
 
     if (state->per_item_ec[snapshot.event_index] == EC_OK) {
         KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
-                      "delete[%zu]",
+                      "delete[%zu], stale_index[%zu]",
                       trace_id.c_str(),
                       snapshot.location_id.c_str(),
                       snapshot.blocks.size(),
                       upsert_keys.size(),
-                      del_keys.size());
+                      del_keys.size(),
+                      stale_index_key_count);
     }
 }
 

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1456,6 +1456,15 @@ bool CacheManager::IsFullAttentionLocationSpecName(const std::string &name) {
     return !IsMambaLocationSpecName(name);
 }
 
+bool CacheManager::ContainsFullAttentionLocationSpec(const std::vector<LocationSpec> &specs) {
+    for (const auto &spec : specs) {
+        if (IsFullAttentionLocationSpecName(spec.name())) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool CacheManager::ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names) {
     if (spec_names.empty()) {
         return true;
@@ -1547,6 +1556,51 @@ void CacheManager::SetReportEventItemEcIfOk(ReportEventState *state, int event_i
         state->per_item_ec[event_index] == EC_OK) {
         state->per_item_ec[event_index] = ec;
     }
+}
+
+bool CacheManager::HasReportEventKeyFailure(const std::vector<ErrorCode> &per_key_ec) {
+    return std::any_of(per_key_ec.begin(), per_key_ec.end(), [](ErrorCode ec) { return ec != EC_OK; });
+}
+
+bool CacheManager::HasReportEventHardLocationFailure(const std::vector<std::vector<ErrorCode>> &per_location_ec) {
+    for (const auto &location_ecs : per_location_ec) {
+        for (const auto loc_ec : location_ecs) {
+            if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+ErrorCode CacheManager::ResolveReportEventKeyError(ErrorCode aggregate_ec,
+                                                   bool has_specific_key_failure,
+                                                   const std::vector<ErrorCode> &per_key_ec,
+                                                   size_t key_index) {
+    if (key_index >= per_key_ec.size()) {
+        return aggregate_ec != EC_OK ? aggregate_ec : EC_ERROR;
+    }
+    ErrorCode key_ec = per_key_ec[key_index];
+    if (key_ec == EC_OK && aggregate_ec != EC_OK && !has_specific_key_failure) {
+        key_ec = aggregate_ec;
+    }
+    return key_ec;
+}
+
+ErrorCode CacheManager::ResolveReportEventLocationError(
+    ErrorCode aggregate_ec,
+    bool has_specific_hard_location_failure,
+    const std::vector<std::vector<ErrorCode>> &per_location_ec,
+    size_t key_index,
+    size_t location_index) {
+    if (key_index >= per_location_ec.size() || location_index >= per_location_ec[key_index].size()) {
+        return aggregate_ec != EC_OK ? aggregate_ec : EC_ERROR;
+    }
+    ErrorCode loc_ec = per_location_ec[key_index][location_index];
+    if (loc_ec == EC_OK && aggregate_ec != EC_OK && !has_specific_hard_location_failure) {
+        loc_ec = aggregate_ec;
+    }
+    return loc_ec;
 }
 
 bool CacheManager::BuildReportEventLocationId(const std::string &trace_id,
@@ -1643,9 +1697,10 @@ void CacheManager::FlushReportEventAdds(RequestContext *request_context,
     if (!filtered_keys.empty()) {
         std::vector<ErrorCode> per_key_ec;
         auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
+        const bool has_specific_key_failure = HasReportEventKeyFailure(per_key_ec);
 
         for (size_t k = 0; k < filtered_keys.size(); ++k) {
-            ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
+            ErrorCode key_ec = ResolveReportEventKeyError(upsert_ec, has_specific_key_failure, per_key_ec, k);
             if (key_ec == EC_OK) {
                 continue;
             }
@@ -1698,9 +1753,10 @@ void CacheManager::FlushReportEventDeletes(RequestContext *request_context,
 
     std::vector<std::vector<ErrorCode>> per_location_ec;
     auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
+    const bool has_specific_hard_location_failure = HasReportEventHardLocationFailure(per_location_ec);
 
     for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
-        if (del_ec != EC_OK || k >= per_location_ec.size()) {
+        if (k >= per_location_ec.size()) {
             ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
             for (const auto &event_indices : del_event_indices[k]) {
                 for (const auto event_index : event_indices) {
@@ -1710,7 +1766,8 @@ void CacheManager::FlushReportEventDeletes(RequestContext *request_context,
             continue;
         }
         for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
-            ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
+            ErrorCode loc_ec = ResolveReportEventLocationError(
+                del_ec, has_specific_hard_location_failure, per_location_ec, k, loc_index);
             if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
                 continue;
             }
@@ -1783,7 +1840,8 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
             auto iter = location_map->find(snapshot.location_id);
             if (iter != location_map->end() && iter->second &&
                 iter->second->type() == event_backend->GetStorageType() &&
-                iter->second->status() == CacheLocationStatus::CLS_SERVING) {
+                iter->second->status() == CacheLocationStatus::CLS_SERVING &&
+                ContainsFullAttentionLocationSpec(iter->second->location_specs())) {
                 existing_keys.push_back(indexed_keys[i]);
             } else {
                 ++stale_index_key_count;

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -209,6 +209,7 @@ private:
     static bool HasPrefix(const std::string &s, const std::string &prefix);
     static bool IsMambaLocationSpecName(const std::string &name);
     static bool IsFullAttentionLocationSpecName(const std::string &name);
+    static bool ContainsFullAttentionLocationSpec(const std::vector<LocationSpec> &specs);
     static bool ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names);
     static std::vector<LocationSpec> BuildFullAttentionSpecs(
         const google::protobuf::RepeatedPtrField<proto::meta::LocationSpec> &proto_specs);
@@ -227,6 +228,18 @@ private:
     static ServiceMetricsCollector *FindReportEventSubCollector(RequestContext *request_context,
                                                                 const std::string &api_name);
     static void SetReportEventItemEcIfOk(ReportEventState *state, int event_index, ErrorCode ec);
+    static bool HasReportEventKeyFailure(const std::vector<ErrorCode> &per_key_ec);
+    static bool HasReportEventHardLocationFailure(const std::vector<std::vector<ErrorCode>> &per_location_ec);
+    static ErrorCode ResolveReportEventKeyError(ErrorCode aggregate_ec,
+                                                bool has_specific_key_failure,
+                                                const std::vector<ErrorCode> &per_key_ec,
+                                                size_t key_index);
+    static ErrorCode ResolveReportEventLocationError(
+        ErrorCode aggregate_ec,
+        bool has_specific_hard_location_failure,
+        const std::vector<std::vector<ErrorCode>> &per_location_ec,
+        size_t key_index,
+        size_t location_index);
 
     bool BuildReportEventLocationId(const std::string &trace_id,
                                     EventReportingBackend *event_backend,

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <thread>
@@ -29,6 +30,8 @@ class ReclaimerTaskSupervisor;
 class StartupConfigLoader;
 class EventManager;
 class CacheManagerMetricsRecorder;
+class EventReportingBackend;
+class ServiceMetricsCollector;
 struct MetricsLifecycle;
 constexpr unsigned int DEFAULT_SCHEDULE_PLAN_EXECUTOR_THREAD_COUNT = 2;
 
@@ -180,6 +183,85 @@ public:
     void SetRevisitHistogramConfig(const std::vector<double> &boundaries);
 
 private:
+    struct ReportEventBlockAddEntry {
+        std::string location_id;
+        std::vector<LocationSpec> specs;
+        int event_index = 0;
+    };
+    struct ReportEventBlockDelEntry {
+        std::string location_id;
+        int event_index = 0;
+    };
+    struct ReportEventSnapshotEntry {
+        std::string location_id;
+        std::map<int64_t, std::vector<LocationSpec>> blocks;
+        int event_index = 0;
+    };
+    enum class ReportEventPendingMutationKind { NONE, ADD, DELETE };
+    struct ReportEventState {
+        explicit ReportEventState(size_t event_count) : per_item_ec(event_count, EC_OK) {}
+        std::vector<ErrorCode> per_item_ec;
+        std::map<int64_t, std::vector<ReportEventBlockAddEntry>> pending_adds;
+        std::map<int64_t, std::vector<ReportEventBlockDelEntry>> pending_dels;
+        ReportEventPendingMutationKind pending_kind = ReportEventPendingMutationKind::NONE;
+    };
+
+    static bool HasPrefix(const std::string &s, const std::string &prefix);
+    static bool IsMambaLocationSpecName(const std::string &name);
+    static bool IsFullAttentionLocationSpecName(const std::string &name);
+    static bool ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names);
+    static std::vector<LocationSpec> BuildFullAttentionSpecs(
+        const google::protobuf::RepeatedPtrField<proto::meta::LocationSpec> &proto_specs);
+    static bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs);
+    static bool CacheLocationEquals(const CacheLocationConstPtr &loc,
+                                    DataStorageType type,
+                                    CacheLocationStatus status,
+                                    const std::vector<LocationSpec> &specs);
+    static bool ExistingLocationEquals(const CacheLocationMap *existing_map,
+                                       const std::string &location_id,
+                                       DataStorageType type,
+                                       CacheLocationStatus status,
+                                       const std::vector<LocationSpec> &specs);
+    static bool ParseInt64(const std::string &s, int64_t &out);
+    static proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec);
+    static ServiceMetricsCollector *FindReportEventSubCollector(RequestContext *request_context,
+                                                                const std::string &api_name);
+    static void SetReportEventItemEcIfOk(ReportEventState *state, int event_index, ErrorCode ec);
+
+    bool BuildReportEventLocationId(const std::string &trace_id,
+                                    EventReportingBackend *event_backend,
+                                    const std::string &host_ip_port,
+                                    const std::string &medium,
+                                    const char *event_name,
+                                    int event_index,
+                                    ReportEventState *state,
+                                    std::string &out_location_id) const;
+    void FlushReportEventAdds(RequestContext *request_context,
+                              MetaSearcher *meta_searcher,
+                              EventReportingBackend *event_backend,
+                              ReportEventState *state) const;
+    void FlushReportEventDeletes(RequestContext *request_context,
+                                 MetaSearcher *meta_searcher,
+                                 ReportEventState *state) const;
+    void FlushReportEventPending(RequestContext *request_context,
+                                 MetaSearcher *meta_searcher,
+                                 EventReportingBackend *event_backend,
+                                 ReportEventState *state) const;
+    void ApplyReportEventSnapshot(RequestContext *request_context,
+                                  MetaSearcher *meta_searcher,
+                                  EventReportingBackend *event_backend,
+                                  const ReportEventSnapshotEntry &snapshot,
+                                  ReportEventState *state) const;
+    void ProcessReportEventItem(RequestContext *request_context,
+                                const proto::meta::EventItem &item,
+                                int event_index,
+                                const std::string &instance_id,
+                                const std::string &host_ip_port,
+                                DataStorageType requested_type,
+                                MetaSearcher *meta_searcher,
+                                EventReportingBackend *event_backend,
+                                ReportEventState *state);
+
     ErrorCode FilterWriteCache(RequestContext *request_context,
                                const std::string &instance_id,
                                MetaSearcher *meta_searcher,

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <map>
-#include <mutex>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -36,7 +35,11 @@ void LogErrorCodes(const std::string &operation_name,
 }
 
 bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
-    return ec == ErrorCode::EC_OK || ec == ErrorCode::EC_NOENT;
+    // Remove the index only after CacheMeta confirms the location was deleted.
+    // If we remove on EC_NOENT, a concurrent add-before-meta write can be
+    // observed as over-index and then turned into under-index when its later
+    // CacheMeta write succeeds.
+    return ec == ErrorCode::EC_OK;
 }
 
 std::uint64_t LocationSpecSize(const std::vector<LocationSpec> &specs) {
@@ -230,28 +233,51 @@ MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
 
 MetaSearcher::~MetaSearcher() = default;
 
-void MetaSearcher::AddKeysToLocationIndex(const KeyVector &keys,
+void MetaSearcher::AddKeysToLocationIndex(RequestContext *request_context,
+                                          const KeyVector &keys,
                                           const LocationIdsPerKey &location_ids_per_key,
-                                          const std::vector<ErrorCode> &per_key_ec) {
-    if (keys.size() != location_ids_per_key.size()) {
+                                          std::vector<ErrorCode> *per_key_ec) {
+    if (keys.size() != location_ids_per_key.size() || !per_key_ec || per_key_ec->size() != keys.size()) {
         return;
     }
 
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    std::unordered_map<std::string, KeyVector> keys_by_location;
+    std::unordered_map<std::string, std::vector<size_t>> key_indices_by_location;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (i >= per_key_ec.size() || per_key_ec[i] != ErrorCode::EC_OK) {
+        if ((*per_key_ec)[i] != ErrorCode::EC_OK) {
             continue;
         }
+        std::unordered_set<std::string> seen_location_ids;
         for (const auto &location_id : location_ids_per_key[i]) {
-            if (location_id.empty()) {
+            if (location_id.empty() || !seen_location_ids.insert(location_id).second) {
                 continue;
             }
-            location_key_index_[location_id].insert(keys[i]);
+            keys_by_location[location_id].push_back(keys[i]);
+            key_indices_by_location[location_id].push_back(i);
+        }
+    }
+
+    for (const auto &kv : keys_by_location) {
+        const std::string &location_id = kv.first;
+        const KeyVector &location_keys = kv.second;
+        ErrorCode ec = meta_indexer_->AddKeysToLocationIndex(request_context, location_id, location_keys);
+        if (ec == ErrorCode::EC_OK) {
+            continue;
+        }
+        KVCM_LOG_WARN("add location index failed, location_id[%s], keys[%zu], ec[%d]",
+                      location_id.c_str(),
+                      location_keys.size(),
+                      ec);
+        for (const auto key_index : key_indices_by_location[location_id]) {
+            if ((*per_key_ec)[key_index] == ErrorCode::EC_OK) {
+                (*per_key_ec)[key_index] = ec;
+            }
         }
     }
 }
 
 void MetaSearcher::RemoveKeysFromLocationIndex(
+    RequestContext *request_context,
     const KeyVector &keys,
     const LocationIdsPerKey &location_ids_per_key,
     const std::vector<std::vector<ErrorCode>> &per_location_ec) {
@@ -259,7 +285,9 @@ void MetaSearcher::RemoveKeysFromLocationIndex(
         return;
     }
 
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    std::unordered_map<std::string, KeyVector> keys_by_location;
+    KeyVector keys_to_sync;
+    std::unordered_set<KeyType> seen_keys_to_sync;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (i >= per_location_ec.size()) {
             continue;
@@ -272,84 +300,30 @@ void MetaSearcher::RemoveKeysFromLocationIndex(
             if (location_id.empty()) {
                 continue;
             }
-            auto iter = location_key_index_.find(location_id);
-            if (iter == location_key_index_.end()) {
-                continue;
-            }
-            iter->second.erase(keys[i]);
-            if (iter->second.empty()) {
-                location_key_index_.erase(iter);
+            keys_by_location[location_id].push_back(keys[i]);
+            if (seen_keys_to_sync.insert(keys[i]).second) {
+                keys_to_sync.push_back(keys[i]);
             }
         }
     }
-}
-
-void MetaSearcher::SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const {
-    out_keys.clear();
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-    auto iter = location_key_index_.find(location_id);
-    if (iter == location_key_index_.end()) {
+    if (keys_by_location.empty()) {
         return;
     }
-    out_keys.reserve(iter->second.size());
-    for (const auto &key : iter->second) {
-        out_keys.push_back(key);
-    }
-    std::sort(out_keys.begin(), out_keys.end());
-}
 
-ErrorCode MetaSearcher::RebuildLocationKeyIndex(RequestContext *request_context,
-                                                const std::string &location_id,
-                                                size_t scan_batch_size) {
-    if (location_id.empty() || scan_batch_size == 0) {
-        return EC_BADARGS;
+    if (!meta_indexer_->Sync(keys_to_sync)) {
+        KVCM_LOG_WARN("skip location index removal because meta sync failed, keys[%zu]", keys_to_sync.size());
+        return;
     }
 
-    {
-        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-        if (rebuilt_location_key_index_.find(location_id) != rebuilt_location_key_index_.end()) {
-            return EC_OK;
+    for (const auto &kv : keys_by_location) {
+        ErrorCode ec = meta_indexer_->RemoveKeysFromLocationIndex(request_context, kv.first, kv.second);
+        if (ec != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("remove location index failed, location_id[%s], keys[%zu], ec[%d]",
+                          kv.first.c_str(),
+                          kv.second.size(),
+                          ec);
         }
     }
-
-    std::unordered_set<KeyType> rebuilt_keys;
-    std::string cursor = "0";
-    do {
-        std::string next_cursor;
-        KeyVector scanned_keys;
-        ErrorCode scan_ec = meta_indexer_->Scan(request_context, cursor, scan_batch_size, next_cursor, scanned_keys);
-        if (scan_ec != EC_OK) {
-            return scan_ec;
-        }
-
-        if (!scanned_keys.empty()) {
-            std::vector<CacheLocationMap> location_maps;
-            BlockMask empty_mask = static_cast<size_t>(0);
-            ErrorCode get_ec = BatchGetLocation(request_context, scanned_keys, empty_mask, location_maps);
-            if (get_ec != EC_OK) {
-                return get_ec;
-            }
-            for (size_t i = 0; i < scanned_keys.size() && i < location_maps.size(); ++i) {
-                if (location_maps[i].find(location_id) != location_maps[i].end()) {
-                    rebuilt_keys.insert(scanned_keys[i]);
-                }
-            }
-        }
-
-        cursor = std::move(next_cursor);
-    } while (!cursor.empty() && cursor != "0");
-
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-    auto current_iter = location_key_index_.find(location_id);
-    if (current_iter != location_key_index_.end()) {
-        rebuilt_keys.insert(current_iter->second.begin(), current_iter->second.end());
-    }
-    location_key_index_[location_id] = std::move(rebuilt_keys);
-    rebuilt_location_key_index_.insert(location_id);
-    if (location_key_index_[location_id].empty()) {
-        location_key_index_.erase(location_id);
-    }
-    return EC_OK;
 }
 
 ErrorCode MetaSearcher::GetKeysByLocationIndex(RequestContext *request_context,
@@ -358,21 +332,7 @@ ErrorCode MetaSearcher::GetKeysByLocationIndex(RequestContext *request_context,
     if (location_id.empty()) {
         return EC_BADARGS;
     }
-
-    bool needs_rebuild = false;
-    {
-        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-        needs_rebuild = rebuilt_location_key_index_.find(location_id) == rebuilt_location_key_index_.end();
-    }
-    if (needs_rebuild) {
-        ErrorCode rebuild_ec = RebuildLocationKeyIndex(request_context, location_id);
-        if (rebuild_ec != EC_OK) {
-            return rebuild_ec;
-        }
-    }
-
-    SnapshotLocationKeyIndex(location_id, out_keys);
-    return EC_OK;
+    return meta_indexer_->GetKeysByLocationIndex(request_context, location_id, out_keys);
 }
 
 std::string MetaSearcher::BatchErrorCodeToStr(const std::vector<std::vector<ErrorCode>> &batch_results) {
@@ -878,7 +838,8 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
     for (size_t i = 0; i < keys.size(); ++i) {
         location_ids_per_key[i].push_back(out_location_ids[i]);
     }
-    AddKeysToLocationIndex(keys, location_ids_per_key, result.error_codes);
+    auto index_ecs = result.error_codes;
+    AddKeysToLocationIndex(request_context, keys, location_ids_per_key, &index_ecs);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -903,6 +864,19 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
     if (existing_ec != ErrorCode::EC_OK) {
         return existing_ec;
     }
+    LocationIdsPerKey location_ids_per_key(keys.size());
+    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        std::unordered_set<std::string> seen_location_ids;
+        location_ids_per_key[i].reserve(new_locations_per_key[i].size());
+        for (const auto &entry : new_locations_per_key[i]) {
+            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
+                continue;
+            }
+            location_ids_per_key[i].push_back(entry.location_id);
+        }
+    }
+    AddKeysToLocationIndex(request_context, keys, location_ids_per_key, &out_per_key_ec);
+
     for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
         if (i >= existing_location_maps.size()) {
             continue;
@@ -922,12 +896,18 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
 
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
 
-    auto modifier = [&new_locations_per_key, &keys, &loc_sz, batch_create_time](
+    auto modifier = [&new_locations_per_key, &keys, &loc_sz, &out_per_key_ec, batch_create_time](
                         const LocationIdVector & /*existing_ids*/,
                         ErrorCode get_ec,
                         size_t index,
                         PropertyMap & /*upsert_property_map*/,
                         CacheLocationMap &out_new_locations) -> ModifierResult {
+        if (index >= out_per_key_ec.size()) {
+            return {ModifierAction::MA_FAIL, ErrorCode::EC_ERROR};
+        }
+        if (out_per_key_ec[index] != ErrorCode::EC_OK) {
+            return {ModifierAction::MA_FAIL, out_per_key_ec[index]};
+        }
         if (get_ec != ErrorCode::EC_OK && get_ec != ErrorCode::EC_NOENT) {
             KVCM_LOG_WARN("load location failed, key[%lu](%lu) return %d", index, keys[index], get_ec);
             return {ModifierAction::MA_FAIL, get_ec};
@@ -977,18 +957,6 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             }
         }
     }
-    LocationIdsPerKey location_ids_per_key(keys.size());
-    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
-        std::unordered_set<std::string> seen_location_ids;
-        location_ids_per_key[i].reserve(new_locations_per_key[i].size());
-        for (const auto &entry : new_locations_per_key[i]) {
-            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
-                continue;
-            }
-            location_ids_per_key[i].push_back(entry.location_id);
-        }
-    }
-    AddKeysToLocationIndex(keys, location_ids_per_key, out_per_key_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -1222,7 +1190,7 @@ ErrorCode MetaSearcher::BatchCADLocationStatus(RequestContext *request_context,
             }
         }
     }
-    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_batch_results);
+    RemoveKeysFromLocationIndex(request_context, keys, location_ids_per_key, out_batch_results);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1316,7 +1284,7 @@ ErrorCode MetaSearcher::BatchDeleteLocation(RequestContext *request_context,
     for (size_t i = 0; i < keys.size(); ++i) {
         per_location_ec[i].push_back(results[i]);
     }
-    RemoveKeysFromLocationIndex(keys, location_ids_per_key, per_location_ec);
+    RemoveKeysFromLocationIndex(request_context, keys, location_ids_per_key, per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1397,7 +1365,7 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
             }
         }
     }
-    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_per_location_ec);
+    RemoveKeysFromLocationIndex(request_context, keys, location_ids_per_key, out_per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -284,22 +284,94 @@ void MetaSearcher::RemoveKeysFromLocationIndex(
     }
 }
 
-ErrorCode MetaSearcher::GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const {
-    if (location_id.empty()) {
-        return EC_BADARGS;
-    }
-
+void MetaSearcher::SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const {
     out_keys.clear();
     std::lock_guard<std::mutex> lock(location_key_index_mutex_);
     auto iter = location_key_index_.find(location_id);
     if (iter == location_key_index_.end()) {
-        return EC_OK;
+        return;
     }
     out_keys.reserve(iter->second.size());
     for (const auto &key : iter->second) {
         out_keys.push_back(key);
     }
     std::sort(out_keys.begin(), out_keys.end());
+}
+
+ErrorCode MetaSearcher::RebuildLocationKeyIndex(RequestContext *request_context,
+                                                const std::string &location_id,
+                                                size_t scan_batch_size) {
+    if (location_id.empty() || scan_batch_size == 0) {
+        return EC_BADARGS;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+        if (rebuilt_location_key_index_.find(location_id) != rebuilt_location_key_index_.end()) {
+            return EC_OK;
+        }
+    }
+
+    std::unordered_set<KeyType> rebuilt_keys;
+    std::string cursor = "0";
+    do {
+        std::string next_cursor;
+        KeyVector scanned_keys;
+        ErrorCode scan_ec = meta_indexer_->Scan(request_context, cursor, scan_batch_size, next_cursor, scanned_keys);
+        if (scan_ec != EC_OK) {
+            return scan_ec;
+        }
+
+        if (!scanned_keys.empty()) {
+            std::vector<CacheLocationMap> location_maps;
+            BlockMask empty_mask = static_cast<size_t>(0);
+            ErrorCode get_ec = BatchGetLocation(request_context, scanned_keys, empty_mask, location_maps);
+            if (get_ec != EC_OK) {
+                return get_ec;
+            }
+            for (size_t i = 0; i < scanned_keys.size() && i < location_maps.size(); ++i) {
+                if (location_maps[i].find(location_id) != location_maps[i].end()) {
+                    rebuilt_keys.insert(scanned_keys[i]);
+                }
+            }
+        }
+
+        cursor = std::move(next_cursor);
+    } while (!cursor.empty() && cursor != "0");
+
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto current_iter = location_key_index_.find(location_id);
+    if (current_iter != location_key_index_.end()) {
+        rebuilt_keys.insert(current_iter->second.begin(), current_iter->second.end());
+    }
+    location_key_index_[location_id] = std::move(rebuilt_keys);
+    rebuilt_location_key_index_.insert(location_id);
+    if (location_key_index_[location_id].empty()) {
+        location_key_index_.erase(location_id);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaSearcher::GetKeysByLocationIndex(RequestContext *request_context,
+                                               const std::string &location_id,
+                                               KeyVector &out_keys) {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+
+    bool needs_rebuild = false;
+    {
+        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+        needs_rebuild = rebuilt_location_key_index_.find(location_id) == rebuilt_location_key_index_.end();
+    }
+    if (needs_rebuild) {
+        ErrorCode rebuild_ec = RebuildLocationKeyIndex(request_context, location_id);
+        if (rebuild_ec != EC_OK) {
+            return rebuild_ec;
+        }
+    }
+
+    SnapshotLocationKeyIndex(location_id, out_keys);
     return EC_OK;
 }
 

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -39,6 +39,22 @@ bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
     return ec == ErrorCode::EC_OK || ec == ErrorCode::EC_NOENT;
 }
 
+std::uint64_t LocationSpecSize(const std::vector<LocationSpec> &specs) {
+    std::uint64_t size = 0;
+    for (const auto &loc_spec : specs) {
+        if (DataStorageUri ds_uri(loc_spec.uri()); ds_uri.Valid()) {
+            std::uint64_t spec_size = 0;
+            ds_uri.GetParamAs<std::uint64_t>("size", spec_size);
+            size += spec_size;
+        }
+    }
+    return size;
+}
+
+std::uint64_t CacheLocationSize(const CacheLocationConstPtr &loc) {
+    return loc ? LocationSpecSize(loc->location_specs()) : 0;
+}
+
 CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
                                              CacheLocationMap &location_map,
                                              CheckLocDataExistFunc check_loc_data_exist,
@@ -808,6 +824,30 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
     out_per_key_ec.assign(keys.size(), ErrorCode::EC_OK);
 
     std::vector<std::pair<DataStorageType, std::uint64_t>> loc_sz(keys.size());
+    std::vector<std::map<DataStorageType, std::uint64_t>> replaced_loc_sz(keys.size());
+    std::vector<CacheLocationMap> existing_location_maps;
+    BlockMask empty_mask = static_cast<size_t>(0);
+    auto existing_ec = BatchGetLocation(request_context, keys, empty_mask, existing_location_maps);
+    if (existing_ec != ErrorCode::EC_OK) {
+        return existing_ec;
+    }
+    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        if (i >= existing_location_maps.size()) {
+            continue;
+        }
+        std::unordered_set<std::string> seen_location_ids;
+        for (const auto &entry : new_locations_per_key[i]) {
+            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
+                continue;
+            }
+            auto existing_iter = existing_location_maps[i].find(entry.location_id);
+            if (existing_iter == existing_location_maps[i].end() || !existing_iter->second) {
+                continue;
+            }
+            replaced_loc_sz[i][existing_iter->second->type()] += CacheLocationSize(existing_iter->second);
+        }
+    }
+
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
 
     auto modifier = [&new_locations_per_key, &keys, &loc_sz, batch_create_time](
@@ -822,7 +862,15 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
         }
         std::uint64_t key_total_sz = 0;
         DataStorageType key_type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        for (const auto &entry : new_locations_per_key[index]) {
+        std::map<std::string, size_t> final_entry_index_by_location;
+        for (size_t entry_index = 0; entry_index < new_locations_per_key[index].size(); ++entry_index) {
+            const auto &entry = new_locations_per_key[index][entry_index];
+            if (!entry.location_id.empty()) {
+                final_entry_index_by_location[entry.location_id] = entry_index;
+            }
+        }
+        for (const auto &kv : final_entry_index_by_location) {
+            const auto &entry = new_locations_per_key[index][kv.second];
             CacheLocation loc;
             loc.set_id(entry.location_id);
             loc.set_type(entry.type);
@@ -831,12 +879,8 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             loc.set_create_time(batch_create_time);
             for (const auto &ls : entry.specs) {
                 loc.push_location_spec(LocationSpec(ls.name(), ls.uri()));
-                if (DataStorageUri ds_uri(ls.uri()); ds_uri.Valid()) {
-                    std::uint64_t spec_sz = 0;
-                    ds_uri.GetParamAs<std::uint64_t>("size", spec_sz);
-                    key_total_sz += spec_sz;
-                }
             }
+            key_total_sz += LocationSpecSize(entry.specs);
             out_new_locations[entry.location_id] = std::make_shared<const CacheLocation>(std::move(loc));
             if (key_type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN) {
                 key_type = entry.type;
@@ -856,12 +900,19 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
         out_per_key_ec[i] = key_ec;
         if (key_ec == ErrorCode::EC_OK) {
             meta_indexer_->AddStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
+            for (const auto &replaced : replaced_loc_sz[i]) {
+                meta_indexer_->SubStorageUsageByType(replaced.first, replaced.second);
+            }
         }
     }
     LocationIdsPerKey location_ids_per_key(keys.size());
     for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        std::unordered_set<std::string> seen_location_ids;
         location_ids_per_key[i].reserve(new_locations_per_key[i].size());
         for (const auto &entry : new_locations_per_key[i]) {
+            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
+                continue;
+            }
             location_ids_per_key[i].push_back(entry.location_id);
         }
     }

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <map>
+#include <mutex>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "kv_cache_manager/common/logger.h"
@@ -31,6 +33,10 @@ void LogErrorCodes(const std::string &operation_name,
             KVCM_LOG_WARN("%s failed, keys[%lu](%lu) return %d", operation_name.c_str(), i, keys[i], error_codes[i]);
         }
     }
+}
+
+bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
+    return ec == ErrorCode::EC_OK || ec == ErrorCode::EC_NOENT;
 }
 
 CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
@@ -207,6 +213,79 @@ MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
     , submit_del_req_func_(submit_del_req) {}
 
 MetaSearcher::~MetaSearcher() = default;
+
+void MetaSearcher::AddKeysToLocationIndex(const KeyVector &keys,
+                                          const LocationIdsPerKey &location_ids_per_key,
+                                          const std::vector<ErrorCode> &per_key_ec) {
+    if (keys.size() != location_ids_per_key.size()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (i >= per_key_ec.size() || per_key_ec[i] != ErrorCode::EC_OK) {
+            continue;
+        }
+        for (const auto &location_id : location_ids_per_key[i]) {
+            if (location_id.empty()) {
+                continue;
+            }
+            location_key_index_[location_id].insert(keys[i]);
+        }
+    }
+}
+
+void MetaSearcher::RemoveKeysFromLocationIndex(
+    const KeyVector &keys,
+    const LocationIdsPerKey &location_ids_per_key,
+    const std::vector<std::vector<ErrorCode>> &per_location_ec) {
+    if (keys.size() != location_ids_per_key.size()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (i >= per_location_ec.size()) {
+            continue;
+        }
+        for (size_t j = 0; j < location_ids_per_key[i].size(); ++j) {
+            if (j >= per_location_ec[i].size() || !ShouldRemoveLocationIndexEntry(per_location_ec[i][j])) {
+                continue;
+            }
+            const auto &location_id = location_ids_per_key[i][j];
+            if (location_id.empty()) {
+                continue;
+            }
+            auto iter = location_key_index_.find(location_id);
+            if (iter == location_key_index_.end()) {
+                continue;
+            }
+            iter->second.erase(keys[i]);
+            if (iter->second.empty()) {
+                location_key_index_.erase(iter);
+            }
+        }
+    }
+}
+
+ErrorCode MetaSearcher::GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+
+    out_keys.clear();
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    out_keys.reserve(iter->second.size());
+    for (const auto &key : iter->second) {
+        out_keys.push_back(key);
+    }
+    std::sort(out_keys.begin(), out_keys.end());
+    return EC_OK;
+}
 
 std::string MetaSearcher::BatchErrorCodeToStr(const std::vector<std::vector<ErrorCode>> &batch_results) {
     std::stringstream result_stream;
@@ -707,6 +786,11 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
             meta_indexer_->AddStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
         }
     }
+    LocationIdsPerKey location_ids_per_key(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        location_ids_per_key[i].push_back(out_location_ids[i]);
+    }
+    AddKeysToLocationIndex(keys, location_ids_per_key, result.error_codes);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -774,6 +858,14 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             meta_indexer_->AddStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
         }
     }
+    LocationIdsPerKey location_ids_per_key(keys.size());
+    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        location_ids_per_key[i].reserve(new_locations_per_key[i].size());
+        for (const auto &entry : new_locations_per_key[i]) {
+            location_ids_per_key[i].push_back(entry.location_id);
+        }
+    }
+    AddKeysToLocationIndex(keys, location_ids_per_key, out_per_key_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -1007,6 +1099,7 @@ ErrorCode MetaSearcher::BatchCADLocationStatus(RequestContext *request_context,
             }
         }
     }
+    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_batch_results);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1096,6 +1189,11 @@ ErrorCode MetaSearcher::BatchDeleteLocation(RequestContext *request_context,
             meta_indexer_->SubStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
         }
     }
+    std::vector<std::vector<ErrorCode>> per_location_ec(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        per_location_ec[i].push_back(results[i]);
+    }
+    RemoveKeysFromLocationIndex(keys, location_ids_per_key, per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1176,6 +1274,7 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
             }
         }
     }
+    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -34,14 +34,6 @@ void LogErrorCodes(const std::string &operation_name,
     }
 }
 
-bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
-    // Remove the index only after CacheMeta confirms the location was deleted.
-    // If we remove on EC_NOENT, a concurrent add-before-meta write can be
-    // observed as over-index and then turned into under-index when its later
-    // CacheMeta write succeeds.
-    return ec == ErrorCode::EC_OK;
-}
-
 std::uint64_t LocationSpecSize(const std::vector<LocationSpec> &specs) {
     std::uint64_t size = 0;
     for (const auto &loc_spec : specs) {
@@ -232,6 +224,14 @@ MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
     , submit_del_req_func_(submit_del_req) {}
 
 MetaSearcher::~MetaSearcher() = default;
+
+bool MetaSearcher::ShouldRemoveLocationIndexEntry(ErrorCode ec) {
+    // Remove the index only after CacheMeta confirms the location was deleted.
+    // If we remove on EC_NOENT, a concurrent add-before-meta write can be
+    // observed as over-index and then turned into under-index when its later
+    // CacheMeta write succeeds.
+    return ec == ErrorCode::EC_OK;
+}
 
 void MetaSearcher::AddKeysToLocationIndex(RequestContext *request_context,
                                           const KeyVector &keys,
@@ -875,6 +875,10 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             location_ids_per_key[i].push_back(entry.location_id);
         }
     }
+    // ReportEvent snapshot diff cannot discover under-index without scanning all
+    // CacheMeta. Add the derived index before writing CacheMeta, so failures can
+    // only leave over-index, which snapshot verification filters and delayed
+    // repair can later clean up.
     AddKeysToLocationIndex(request_context, keys, location_ids_per_key, &out_per_key_ec);
 
     for (size_t i = 0; i < new_locations_per_key.size(); ++i) {

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -3,10 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -145,23 +142,18 @@ private:
                                           const KeyVector &keys,
                                           CacheLocationVector &out_locations,
                                           SelectLocationPolicy *policy) const;
-    void AddKeysToLocationIndex(const KeyVector &keys,
+    void AddKeysToLocationIndex(RequestContext *request_context,
+                                const KeyVector &keys,
                                 const LocationIdsPerKey &location_ids_per_key,
-                                const std::vector<ErrorCode> &per_key_ec);
-    void RemoveKeysFromLocationIndex(const KeyVector &keys,
+                                std::vector<ErrorCode> *per_key_ec);
+    void RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                     const KeyVector &keys,
                                      const LocationIdsPerKey &location_ids_per_key,
                                      const std::vector<std::vector<ErrorCode>> &per_location_ec);
-    ErrorCode RebuildLocationKeyIndex(RequestContext *request_context,
-                                      const std::string &location_id,
-                                      size_t scan_batch_size = 1000);
-    void SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const;
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;
     SubmitDelReqFunc submit_del_req_func_;
-    mutable std::mutex location_key_index_mutex_;
-    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
-    std::unordered_set<std::string> rebuilt_location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -3,7 +3,10 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -121,6 +124,7 @@ public:
                                      DataStorageType storage_type,
                                      size_t scan_batch_size = 1000,
                                      std::function<bool()> should_abort = nullptr);
+    ErrorCode GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const;
 
 private:
     struct StorageTypeWeights {
@@ -139,10 +143,18 @@ private:
                                           const KeyVector &keys,
                                           CacheLocationVector &out_locations,
                                           SelectLocationPolicy *policy) const;
+    void AddKeysToLocationIndex(const KeyVector &keys,
+                                const LocationIdsPerKey &location_ids_per_key,
+                                const std::vector<ErrorCode> &per_key_ec);
+    void RemoveKeysFromLocationIndex(const KeyVector &keys,
+                                     const LocationIdsPerKey &location_ids_per_key,
+                                     const std::vector<std::vector<ErrorCode>> &per_location_ec);
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;
     SubmitDelReqFunc submit_del_req_func_;
+    mutable std::mutex location_key_index_mutex_;
+    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -150,6 +150,7 @@ private:
                                      const KeyVector &keys,
                                      const LocationIdsPerKey &location_ids_per_key,
                                      const std::vector<std::vector<ErrorCode>> &per_location_ec);
+    static bool ShouldRemoveLocationIndexEntry(ErrorCode ec);
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -124,7 +124,9 @@ public:
                                      DataStorageType storage_type,
                                      size_t scan_batch_size = 1000,
                                      std::function<bool()> should_abort = nullptr);
-    ErrorCode GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                      const std::string &location_id,
+                                      KeyVector &out_keys);
 
 private:
     struct StorageTypeWeights {
@@ -149,12 +151,17 @@ private:
     void RemoveKeysFromLocationIndex(const KeyVector &keys,
                                      const LocationIdsPerKey &location_ids_per_key,
                                      const std::vector<std::vector<ErrorCode>> &per_location_ec);
+    ErrorCode RebuildLocationKeyIndex(RequestContext *request_context,
+                                      const std::string &location_id,
+                                      size_t scan_batch_size = 1000);
+    void SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const;
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;
     SubmitDelReqFunc submit_del_req_func_;
     mutable std::mutex location_key_index_mutex_;
     std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
+    std::unordered_set<std::string> rebuilt_location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -260,6 +260,33 @@ public:
         return location_map.find(location_id) != location_map.end();
     }
 
+    std::string GetFirstSpecUri(int64_t key, const std::string &location_id) {
+        auto location_map = GetLocationMapForKey(key);
+        auto iter = location_map.find(location_id);
+        if (iter == location_map.end() || !iter->second || iter->second->location_specs().empty()) {
+            return "";
+        }
+        return iter->second->location_specs().front().uri();
+    }
+
+    std::string GetFirstQueriedSpecUri(int64_t key) {
+        BlockMask bm = static_cast<size_t>(0);
+        auto [ec, locations] = cache_manager_->GetCacheLocation(request_context_.get(),
+                                                                "test_instance",
+                                                                CacheManager::QueryType::QT_BATCH_GET,
+                                                                {key},
+                                                                {},
+                                                                bm,
+                                                                0,
+                                                                {});
+        EXPECT_EQ(EC_OK, ec);
+        const auto &views = locations.cache_locations_view();
+        if (views.empty() || views.front().location_specs().empty()) {
+            return "";
+        }
+        return views.front().location_specs().front().uri();
+    }
+
     std::unique_ptr<CacheManager> cache_manager_;
     std::shared_ptr<RegistryManager> registry_manager_;
     std::shared_ptr<RequestContext> request_context_;
@@ -3034,6 +3061,78 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDiffsHostLocation) {
     ReportBlockSnapshot(host, "mem", {400, 500});
     EXPECT_FALSE(HasLocation(300, location_id));
     EXPECT_TRUE(HasLocation(400, location_id));
+    EXPECT_TRUE(HasLocation(500, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotVisibleThroughCacheQuery) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true);
+    EXPECT_EQ("vineyard://" + host + "/mem/300", GetFirstQueriedSpecUri(300));
+    EXPECT_EQ("vineyard://" + host + "/mem/400", GetFirstQueriedSpecUri(400));
+
+    ReportBlockSnapshot(host, "mem", {400, 500});
+    EXPECT_EQ("", GetFirstQueriedSpecUri(300));
+    EXPECT_EQ("vineyard://" + host + "/mem/400", GetFirstQueriedSpecUri(400));
+    EXPECT_EQ("vineyard://" + host + "/mem/500", GetFirstQueriedSpecUri(500));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotRefreshesExistingSpecs) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300}, true);
+    ASSERT_EQ("vineyard://" + host + "/mem/300", GetFirstSpecUri(300, location_id));
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    auto *ev = req.add_events();
+    ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *snapshot = ev->mutable_block_snapshot();
+    snapshot->set_medium("mem");
+    auto *block = snapshot->add_blocks();
+    block->set_block_key("300");
+    auto *spec = block->add_specs();
+    spec->set_name("tp0");
+    spec->set_uri("vineyard://" + host + "/mem/300-updated");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_EQ("vineyard://" + host + "/mem/300-updated", GetFirstSpecUri(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotConvergesWithMultipleSnapshotsInOneRequest) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true);
+    ASSERT_TRUE(HasLocation(300, location_id));
+    ASSERT_TRUE(HasLocation(400, location_id));
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddBlockSnapshotEvent(&req, host, "mem", {300, 500});
+    AddBlockSnapshotEvent(&req, host, "mem", {500});
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(400, location_id));
     EXPECT_TRUE(HasLocation(500, location_id));
 }
 

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -3293,6 +3293,62 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {
     EXPECT_TRUE(HasLocation(500, ssd_loc));
 }
 
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotSameBlockOtherHostSurvives) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host_a = "192.168.2.1:8080";
+    const std::string host_b = "192.168.2.2:8080";
+    const std::string loc_a = ExpectedReportEventLocationId(host_a, "mem");
+    const std::string loc_b = ExpectedReportEventLocationId(host_b, "mem");
+
+    ReportBlockSnapshot(host_a, "mem", {300}, true);
+    ReportBlockSnapshot(host_b, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, loc_a));
+    ASSERT_TRUE(HasLocation(300, loc_b));
+
+    ReportBlockSnapshot(host_a, "mem", {});
+    EXPECT_FALSE(HasLocation(300, loc_a));
+    EXPECT_TRUE(HasLocation(300, loc_b));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotReplacesMismatchedReportedLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> mismatched_locations = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_NFS,
+          CLS_SERVING,
+          {LocationSpec("tp0", "file:///tmp/not-vineyard?size=10")}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher->BatchUpsertLocations(request_context_.get(), {300}, mismatched_locations, per_key_ec));
+    ASSERT_EQ(1, per_key_ec.size());
+    ASSERT_EQ(EC_OK, per_key_ec[0]);
+    ASSERT_TRUE(HasLocation(300, location_id));
+    ASSERT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, GetLocationMapForKey(300).at(location_id)->type());
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddBlockSnapshotEvent(&req, host, "mem", {300}, 20, "-reported");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    ASSERT_TRUE(HasLocation(300, location_id));
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_VINEYARD, GetLocationMapForKey(300).at(location_id)->type());
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 20, "-reported"), GetFirstSpecUri(300, location_id));
+}
+
 TEST_F(CacheManagerTest, TestReportEventPreservesDeleteThenAddOrder) {
     RegisterDefaultInstanceForReportEvent();
     SetupVineyardEventReportingBackend();
@@ -3428,6 +3484,82 @@ TEST_F(CacheManagerTest, TestReportEventSkipsMambaStateSpecNames) {
     EXPECT_TRUE(HasLocation(300, location_id));
     EXPECT_FALSE(HasLocation(400, location_id));
     EXPECT_FALSE(HasLocation(401, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventSnapshotDoesNotDeleteMambaOnlyExistingLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
+
+    auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> mamba_locations = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+          CLS_SERVING,
+          {LocationSpec("mamba_state:group=1", ReportEventUri(host, "gpu", 300, 0, "-mamba"))}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher->BatchUpsertLocations(request_context_.get(), {300}, mamba_locations, per_key_ec));
+    ASSERT_EQ(1, per_key_ec.size());
+    ASSERT_EQ(EC_OK, per_key_ec[0]);
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    ReportBlockSnapshot(host, "gpu", {}, true);
+    EXPECT_TRUE(HasLocation(300, location_id));
+
+    auto indexed_keys = GetLocationIndexKeys(location_id);
+    EXPECT_NE(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 300));
+}
+
+TEST_F(CacheManagerTest, TestReportEventDeleteSpecNamesRequireFullAttention) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"gpu"});
+        AddBlockAddEvent(&req, host, "gpu", 300, 0, "", "full_attention:group=0:tp=0");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockDeleteEvent(&req, "gpu", 300, {"mamba_state:group=1"});
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_TRUE(HasLocation(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockDeleteEvent(&req, "gpu", 300, {"mamba_state:group=1", "full_attention:group=0:tp=0"});
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_FALSE(HasLocation(300, location_id));
 }
 
 TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
@@ -3620,6 +3752,44 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotPartialFailureKeepsValidSna
     EXPECT_EQ(proto::meta::OK, resp.item_results(1));
     EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
     EXPECT_TRUE(HasLocation(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventPartialBlockAddFailureKeepsValidAdds) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"mem"});
+    AddBlockAddEvent(&req, host, "mem", 300);
+
+    auto *invalid_key = req.add_events();
+    invalid_key->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+    auto *invalid_add = invalid_key->mutable_block_add();
+    invalid_add->set_block_key("bad-key");
+    invalid_add->set_medium("mem");
+    auto *invalid_spec = invalid_add->add_specs();
+    invalid_spec->set_name("tp0");
+    invalid_spec->set_uri(ReportEventUri(host, "mem", 301));
+
+    AddBlockAddEvent(&req, host, "mem", 302);
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, resp.header().status().code());
+    ASSERT_EQ(4, resp.item_results_size());
+    EXPECT_EQ(proto::meta::OK, resp.item_results(0));
+    EXPECT_EQ(proto::meta::OK, resp.item_results(1));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
+    EXPECT_EQ(proto::meta::OK, resp.item_results(3));
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(301, location_id));
+    EXPECT_TRUE(HasLocation(302, location_id));
 }
 
 TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -173,6 +173,93 @@ public:
         }
     }
 
+    void RegisterDefaultInstanceForReportEvent() {
+        auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+        ASSERT_EQ(expected_reg,
+                  cache_manager_->RegisterInstance(request_context_.get(),
+                                                   "default",
+                                                   "test_instance",
+                                                   64,
+                                                   createLocationSpecInfos(),
+                                                   createModelDeployment(),
+                                                   std::vector<LocationSpecGroup>()));
+    }
+
+    void SetupVineyardEventReportingBackend(const std::string &storage_name = "vineyard_default") {
+        auto vineyard_backend = std::make_shared<VineyardBackend>(metrics_registry_);
+        StorageConfig v6d_config;
+        v6d_config.set_global_unique_name(storage_name);
+        v6d_config.set_type(DataStorageType::DATA_STORAGE_TYPE_VINEYARD);
+        v6d_config.set_storage_spec(std::make_shared<VineyardStorageSpec>());
+        ASSERT_EQ(EC_OK, vineyard_backend->Open(v6d_config, "test_trace"));
+
+        auto dsm = registry_manager_->data_storage_manager_;
+        dsm->storage_map_[storage_name] = vineyard_backend;
+        registry_manager_->instance_group_configs_["default"]->set_event_reporting_storage_candidates({storage_name});
+    }
+
+    void AddNodeRegisterEvent(proto::meta::ReportEventRequest *req, const std::vector<std::string> &mediums) {
+        auto *reg = req->add_events();
+        reg->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+        for (const auto &medium : mediums) {
+            reg->mutable_node_register()->add_mediums(medium);
+        }
+    }
+
+    void AddBlockSnapshotEvent(proto::meta::ReportEventRequest *req,
+                               const std::string &host,
+                               const std::string &medium,
+                               const std::vector<int64_t> &keys) {
+        auto *ev = req->add_events();
+        ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+        auto *snapshot = ev->mutable_block_snapshot();
+        snapshot->set_medium(medium);
+        for (auto key : keys) {
+            auto *block = snapshot->add_blocks();
+            block->set_block_key(std::to_string(key));
+            auto *spec = block->add_specs();
+            spec->set_name("tp0");
+            spec->set_uri("vineyard://" + host + "/" + medium + "/" + std::to_string(key));
+        }
+    }
+
+    proto::meta::ReportEventResponse ReportBlockSnapshot(const std::string &host,
+                                                         const std::string &medium,
+                                                         const std::vector<int64_t> &keys,
+                                                         bool register_node = false,
+                                                         const std::vector<std::string> &register_mediums = {}) {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        if (register_node) {
+            AddNodeRegisterEvent(&req, register_mediums.empty() ? std::vector<std::string>{medium} : register_mediums);
+        }
+        AddBlockSnapshotEvent(&req, host, medium, keys);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+        return resp;
+    }
+
+    CacheLocationMap GetLocationMapForKey(int64_t key) {
+        auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+        EXPECT_NE(nullptr, meta_searcher);
+        if (!meta_searcher) {
+            return {};
+        }
+        std::vector<CacheLocationMap> maps;
+        BlockMask bm = static_cast<size_t>(0);
+        EXPECT_EQ(EC_OK, meta_searcher->BatchGetLocation(request_context_.get(), {key}, bm, maps));
+        return maps.empty() ? CacheLocationMap{} : maps[0];
+    }
+
+    bool HasLocation(int64_t key, const std::string &location_id) {
+        auto location_map = GetLocationMapForKey(key);
+        return location_map.find(location_id) != location_map.end();
+    }
+
     std::unique_ptr<CacheManager> cache_manager_;
     std::shared_ptr<RegistryManager> registry_manager_;
     std::shared_ptr<RequestContext> request_context_;
@@ -2931,6 +3018,134 @@ TEST_F(CacheManagerTest, InvalidateInstanceMetricsInvokesCallback) {
 //   peer_A: {300,400,600}      → 3 keys
 //   peer_B: {300,400,500,600}  → 4 keys (winner)
 //   peer_C: {300}              → 1 key
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDiffsHostLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true);
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_TRUE(HasLocation(400, location_id));
+    EXPECT_FALSE(HasLocation(500, location_id));
+
+    ReportBlockSnapshot(host, "mem", {400, 500});
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_TRUE(HasLocation(400, location_id));
+    EXPECT_TRUE(HasLocation(500, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotEmptySnapshotDeletesOnlyTargetLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host_a = "192.168.2.1:8080";
+    const std::string host_b = "192.168.2.2:8080";
+    const std::string loc_a = "kvs#v6d#mem#" + host_a;
+    const std::string loc_b = "kvs#v6d#mem#" + host_b;
+
+    ReportBlockSnapshot(host_a, "mem", {300, 400}, true);
+    ReportBlockSnapshot(host_b, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, loc_a));
+    ASSERT_TRUE(HasLocation(300, loc_b));
+    ASSERT_TRUE(HasLocation(400, loc_a));
+
+    ReportBlockSnapshot(host_a, "mem", {});
+    EXPECT_FALSE(HasLocation(300, loc_a));
+    EXPECT_FALSE(HasLocation(400, loc_a));
+    EXPECT_TRUE(HasLocation(300, loc_b));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string mem_loc = "kvs#v6d#mem#" + host;
+    const std::string ssd_loc = "kvs#v6d#ssd#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true, {"mem", "ssd"});
+    ReportBlockSnapshot(host, "ssd", {300, 500});
+    ASSERT_TRUE(HasLocation(300, mem_loc));
+    ASSERT_TRUE(HasLocation(400, mem_loc));
+    ASSERT_TRUE(HasLocation(300, ssd_loc));
+    ASSERT_TRUE(HasLocation(500, ssd_loc));
+
+    ReportBlockSnapshot(host, "mem", {300});
+    EXPECT_TRUE(HasLocation(300, mem_loc));
+    EXPECT_FALSE(HasLocation(400, mem_loc));
+    EXPECT_TRUE(HasLocation(300, ssd_loc));
+    EXPECT_TRUE(HasLocation(500, ssd_loc));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotRejectsInvalidSnapshot) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"mem"});
+
+    auto *invalid_key = req.add_events();
+    invalid_key->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *invalid_snapshot = invalid_key->mutable_block_snapshot();
+    invalid_snapshot->set_medium("mem");
+    auto *invalid_block = invalid_snapshot->add_blocks();
+    invalid_block->set_block_key("not-an-int64");
+    invalid_block->add_specs()->set_name("tp0");
+
+    auto *empty_specs = req.add_events();
+    empty_specs->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *empty_specs_snapshot = empty_specs->mutable_block_snapshot();
+    empty_specs_snapshot->set_medium("mem");
+    empty_specs_snapshot->add_blocks()->set_block_key("301");
+
+    auto *missing_payload = req.add_events();
+    missing_payload->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, resp.header().status().code());
+    ASSERT_EQ(4, resp.item_results_size());
+    EXPECT_EQ(proto::meta::OK, resp.item_results(0));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(1));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(3));
+    EXPECT_FALSE(HasLocation(301, "kvs#v6d#mem#" + host));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotPartialFailureKeepsValidSnapshot) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"mem"});
+    AddBlockSnapshotEvent(&req, host, "mem", {300});
+
+    auto *invalid = req.add_events();
+    invalid->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    invalid->mutable_block_snapshot()->set_medium("");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, resp.header().status().code());
+    ASSERT_EQ(3, resp.item_results_size());
+    EXPECT_EQ(proto::meta::OK, resp.item_results(0));
+    EXPECT_EQ(proto::meta::OK, resp.item_results(1));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
+    EXPECT_TRUE(HasLocation(300, location_id));
+}
 
 TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -1,7 +1,12 @@
 #include <chrono>
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include "kv_cache_manager/common/jsonizable.h"
 #include "kv_cache_manager/common/request_context.h"
@@ -206,20 +211,92 @@ public:
         }
     }
 
+    using LocationScopeLabels = std::vector<std::pair<std::string, std::string>>;
+
+    void SetLocationScope(proto::meta::LocationScope *scope,
+                          const std::string &medium,
+                          const LocationScopeLabels &labels) {
+        scope->set_medium(medium);
+        for (const auto &label : labels) {
+            (*scope->mutable_labels())[label.first] = label.second;
+        }
+    }
+
+    std::string ExpectedReportEventLocationId(const std::string &host,
+                                              const std::string &medium,
+                                              const LocationScopeLabels &labels = {}) {
+        std::string location_id = "kvs#v6d#" + medium;
+        std::map<std::string, std::string> sorted_labels;
+        for (const auto &label : labels) {
+            sorted_labels[label.first] = label.second;
+        }
+        for (const auto &label : sorted_labels) {
+            location_id += ";" + label.first + "=" + label.second;
+        }
+        return location_id + "#" + host;
+    }
+
+    std::string ReportEventUri(const std::string &host,
+                               const std::string &medium,
+                               int64_t key,
+                               uint64_t size = 0,
+                               const std::string &suffix = "") {
+        std::string uri = "vineyard://" + host + "/" + medium + "/" + std::to_string(key) + suffix;
+        if (size > 0) {
+            uri += "?size=" + std::to_string(size);
+        }
+        return uri;
+    }
+
+    void AddBlockAddEvent(proto::meta::ReportEventRequest *req,
+                          const std::string &host,
+                          const std::string &medium,
+                          int64_t key,
+                          uint64_t size = 0,
+                          const LocationScopeLabels &labels = {},
+                          const std::string &suffix = "") {
+        auto *ev = req->add_events();
+        ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+        auto *add = ev->mutable_block_add();
+        add->set_block_key(std::to_string(key));
+        SetLocationScope(add->mutable_location(), medium, labels);
+        auto *spec = add->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
+    }
+
+    void AddBlockDeleteEvent(proto::meta::ReportEventRequest *req,
+                             const std::string &medium,
+                             int64_t key,
+                             const LocationScopeLabels &labels = {}) {
+        auto *ev = req->add_events();
+        ev->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+        auto *del = ev->mutable_block_delete();
+        del->set_block_key(std::to_string(key));
+        SetLocationScope(del->mutable_location(), medium, labels);
+    }
+
     void AddBlockSnapshotEvent(proto::meta::ReportEventRequest *req,
                                const std::string &host,
                                const std::string &medium,
-                               const std::vector<int64_t> &keys) {
+                               const std::vector<int64_t> &keys,
+                               const LocationScopeLabels &labels = {},
+                               uint64_t size = 0,
+                               const std::string &suffix = "") {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
         auto *snapshot = ev->mutable_block_snapshot();
-        snapshot->set_medium(medium);
+        if (labels.empty()) {
+            snapshot->set_medium(medium);
+        } else {
+            SetLocationScope(snapshot->mutable_location(), medium, labels);
+        }
         for (auto key : keys) {
             auto *block = snapshot->add_blocks();
             block->set_block_key(std::to_string(key));
             auto *spec = block->add_specs();
             spec->set_name("tp0");
-            spec->set_uri("vineyard://" + host + "/" + medium + "/" + std::to_string(key));
+            spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
         }
     }
 
@@ -285,6 +362,12 @@ public:
             return "";
         }
         return views.front().location_specs().front().uri();
+    }
+
+    uint64_t GetStorageUsageByType(DataStorageType type) {
+        auto meta_indexer = cache_manager_->meta_indexer_manager()->GetMetaIndexer("test_instance");
+        EXPECT_NE(nullptr, meta_indexer);
+        return meta_indexer ? meta_indexer->GetStorageUsageByType(type) : 0;
     }
 
     std::unique_ptr<CacheManager> cache_manager_;
@@ -3177,6 +3260,241 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {
     EXPECT_FALSE(HasLocation(400, mem_loc));
     EXPECT_TRUE(HasLocation(300, ssd_loc));
     EXPECT_TRUE(HasLocation(500, ssd_loc));
+}
+
+TEST_F(CacheManagerTest, TestReportEventPreservesDeleteThenAddOrder) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    ReportBlockSnapshot(host, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddBlockDeleteEvent(&req, "mem", 300);
+    AddBlockAddEvent(&req, host, "mem", 300, 0, {}, "-recreated");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 0, "-recreated"), GetFirstSpecUri(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventSnapshotIsOrderingBarrier) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"mem"});
+        AddBlockSnapshotEvent(&req, host, "mem", {});
+        AddBlockAddEvent(&req, host, "mem", 300);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+        EXPECT_TRUE(HasLocation(300, location_id));
+    }
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockAddEvent(&req, host, "mem", 400);
+        AddBlockSnapshotEvent(&req, host, "mem", {});
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+        EXPECT_FALSE(HasLocation(300, location_id));
+        EXPECT_FALSE(HasLocation(400, location_id));
+    }
+}
+
+TEST_F(CacheManagerTest, TestReportEventLocationScopeSeparatesVllmGroups) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const LocationScopeLabels group0 = {{"group_idx", "0"}, {"dp_rank", "0"}};
+    const LocationScopeLabels group1 = {{"group_idx", "1"}, {"dp_rank", "0"}};
+    const std::string group0_loc = ExpectedReportEventLocationId(host, "gpu", group0);
+    const std::string group1_loc = ExpectedReportEventLocationId(host, "gpu", group1);
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"gpu"});
+        AddBlockSnapshotEvent(&req, host, "gpu", {300, 400}, group0);
+        AddBlockSnapshotEvent(&req, host, "gpu", {300}, group1);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    ASSERT_TRUE(HasLocation(300, group0_loc));
+    ASSERT_TRUE(HasLocation(400, group0_loc));
+    ASSERT_TRUE(HasLocation(300, group1_loc));
+
+    ReportBlockSnapshot(host, "gpu", {400}, false, {});
+    EXPECT_TRUE(HasLocation(300, group0_loc));
+    EXPECT_TRUE(HasLocation(400, group0_loc));
+    EXPECT_TRUE(HasLocation(300, group1_loc));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockSnapshotEvent(&req, host, "gpu", {400}, group0);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_FALSE(HasLocation(300, group0_loc));
+    EXPECT_TRUE(HasLocation(400, group0_loc));
+    EXPECT_TRUE(HasLocation(300, group1_loc));
+}
+
+TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+    const auto storage_type = DataStorageType::DATA_STORAGE_TYPE_VINEYARD;
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"mem"});
+        AddBlockAddEvent(&req, host, "mem", 300, 10, {}, "-old");
+        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(20, GetStorageUsageByType(storage_type));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 20, "-new"), GetFirstSpecUri(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(20, GetStorageUsageByType(storage_type));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockAddEvent(&req, host, "mem", 300, 35, {}, "-updated");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(35, GetStorageUsageByType(storage_type));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 35, "-updated"), GetFirstSpecUri(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 35, "-updated");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(35, GetStorageUsageByType(storage_type));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 50, "-snapshot");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(50, GetStorageUsageByType(storage_type));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 50, "-snapshot"), GetFirstSpecUri(300, location_id));
+
+    ReportBlockSnapshot(host, "mem", {});
+    EXPECT_EQ(0, GetStorageUsageByType(storage_type));
+    EXPECT_FALSE(HasLocation(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventDuplicateDeleteIsIdempotentForUsage) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+    const auto storage_type = DataStorageType::DATA_STORAGE_TYPE_VINEYARD;
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"mem"});
+        AddBlockAddEvent(&req, host, "mem", 300, 20);
+        AddBlockAddEvent(&req, host, "mem", 301, 20);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    ASSERT_EQ(40, GetStorageUsageByType(storage_type));
+    ASSERT_TRUE(HasLocation(300, location_id));
+    ASSERT_TRUE(HasLocation(301, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockDeleteEvent(&req, "mem", 300);
+        AddBlockDeleteEvent(&req, "mem", 300);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(20, GetStorageUsageByType(storage_type));
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_TRUE(HasLocation(301, location_id));
 }
 
 TEST_F(CacheManagerTest, TestReportEventBlockSnapshotRejectsInvalidSnapshot) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -211,29 +211,8 @@ public:
         }
     }
 
-    using LocationScopeLabels = std::vector<std::pair<std::string, std::string>>;
-
-    void SetLocationScope(proto::meta::LocationScope *scope,
-                          const std::string &medium,
-                          const LocationScopeLabels &labels) {
-        scope->set_medium(medium);
-        for (const auto &label : labels) {
-            (*scope->mutable_labels())[label.first] = label.second;
-        }
-    }
-
-    std::string ExpectedReportEventLocationId(const std::string &host,
-                                              const std::string &medium,
-                                              const LocationScopeLabels &labels = {}) {
-        std::string location_id = "kvs#v6d#" + medium;
-        std::map<std::string, std::string> sorted_labels;
-        for (const auto &label : labels) {
-            sorted_labels[label.first] = label.second;
-        }
-        for (const auto &label : sorted_labels) {
-            location_id += ";" + label.first + "=" + label.second;
-        }
-        return location_id + "#" + host;
+    std::string ExpectedReportEventLocationId(const std::string &host, const std::string &medium) {
+        return "kvs#v6d#" + medium + "#" + host;
     }
 
     std::string ReportEventUri(const std::string &host,
@@ -253,49 +232,48 @@ public:
                           const std::string &medium,
                           int64_t key,
                           uint64_t size = 0,
-                          const LocationScopeLabels &labels = {},
-                          const std::string &suffix = "") {
+                          const std::string &suffix = "",
+                          const std::string &spec_name = "tp0") {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
         auto *add = ev->mutable_block_add();
         add->set_block_key(std::to_string(key));
-        SetLocationScope(add->mutable_location(), medium, labels);
+        add->set_medium(medium);
         auto *spec = add->add_specs();
-        spec->set_name("tp0");
+        spec->set_name(spec_name);
         spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
     }
 
     void AddBlockDeleteEvent(proto::meta::ReportEventRequest *req,
                              const std::string &medium,
                              int64_t key,
-                             const LocationScopeLabels &labels = {}) {
+                             const std::vector<std::string> &spec_names = {}) {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
         auto *del = ev->mutable_block_delete();
         del->set_block_key(std::to_string(key));
-        SetLocationScope(del->mutable_location(), medium, labels);
+        del->set_medium(medium);
+        for (const auto &spec_name : spec_names) {
+            del->add_spec_names(spec_name);
+        }
     }
 
     void AddBlockSnapshotEvent(proto::meta::ReportEventRequest *req,
                                const std::string &host,
                                const std::string &medium,
                                const std::vector<int64_t> &keys,
-                               const LocationScopeLabels &labels = {},
                                uint64_t size = 0,
-                               const std::string &suffix = "") {
+                               const std::string &suffix = "",
+                               const std::string &spec_name = "tp0") {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
         auto *snapshot = ev->mutable_block_snapshot();
-        if (labels.empty()) {
-            snapshot->set_medium(medium);
-        } else {
-            SetLocationScope(snapshot->mutable_location(), medium, labels);
-        }
+        snapshot->set_medium(medium);
         for (auto key : keys) {
             auto *block = snapshot->add_blocks();
             block->set_block_key(std::to_string(key));
             auto *spec = block->add_specs();
-            spec->set_name("tp0");
+            spec->set_name(spec_name);
             spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
         }
     }
@@ -3277,7 +3255,7 @@ TEST_F(CacheManagerTest, TestReportEventPreservesDeleteThenAddOrder) {
     req.set_host_ip_port(host);
     req.set_storage_type(proto::meta::ST_VINEYARD);
     AddBlockDeleteEvent(&req, "mem", 300);
-    AddBlockAddEvent(&req, host, "mem", 300, 0, {}, "-recreated");
+    AddBlockAddEvent(&req, host, "mem", 300, 0, "-recreated");
 
     proto::meta::ReportEventResponse resp;
     EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3324,15 +3302,48 @@ TEST_F(CacheManagerTest, TestReportEventSnapshotIsOrderingBarrier) {
     }
 }
 
-TEST_F(CacheManagerTest, TestReportEventLocationScopeSeparatesVllmGroups) {
+TEST_F(CacheManagerTest, TestReportEventLocationSpecNameKeepsFullAttentionSpecs) {
     RegisterDefaultInstanceForReportEvent();
     SetupVineyardEventReportingBackend();
 
     const std::string host = "192.168.2.1:8080";
-    const LocationScopeLabels group0 = {{"group_idx", "0"}, {"dp_rank", "0"}};
-    const LocationScopeLabels group1 = {{"group_idx", "1"}, {"dp_rank", "0"}};
-    const std::string group0_loc = ExpectedReportEventLocationId(host, "gpu", group0);
-    const std::string group1_loc = ExpectedReportEventLocationId(host, "gpu", group1);
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"gpu"});
+    auto *mixed_ev = req.add_events();
+    mixed_ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *mixed_snapshot = mixed_ev->mutable_block_snapshot();
+    mixed_snapshot->set_medium("gpu");
+    auto *mixed_block = mixed_snapshot->add_blocks();
+    mixed_block->set_block_key("300");
+    auto *full_spec = mixed_block->add_specs();
+    full_spec->set_name("full_attention:group=0:tp=0");
+    full_spec->set_uri(ReportEventUri(host, "gpu", 300));
+    auto *mamba_spec = mixed_block->add_specs();
+    mamba_spec->set_name("mamba_state:group=1");
+    mamba_spec->set_uri(ReportEventUri(host, "gpu", 300, 0, "-mamba"));
+    AddBlockSnapshotEvent(&req, host, "gpu", {400}, 0, "", "mamba_state:group=1");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(400, location_id));
+    const auto &specs = GetLocationMapForKey(300).at(location_id)->location_specs();
+    ASSERT_EQ(1, specs.size());
+    EXPECT_EQ("full_attention:group=0:tp=0", specs[0].name());
+}
+
+TEST_F(CacheManagerTest, TestReportEventSkipsMambaStateSpecNames) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
 
     {
         proto::meta::ReportEventRequest req;
@@ -3340,36 +3351,30 @@ TEST_F(CacheManagerTest, TestReportEventLocationScopeSeparatesVllmGroups) {
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
         AddNodeRegisterEvent(&req, {"gpu"});
-        AddBlockSnapshotEvent(&req, host, "gpu", {300, 400}, group0);
-        AddBlockSnapshotEvent(&req, host, "gpu", {300}, group1);
+        AddBlockAddEvent(&req, host, "gpu", 300, 0, "", "full_attention:group=0:tp=0");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
         EXPECT_EQ(proto::meta::OK, resp.header().status().code());
     }
-    ASSERT_TRUE(HasLocation(300, group0_loc));
-    ASSERT_TRUE(HasLocation(400, group0_loc));
-    ASSERT_TRUE(HasLocation(300, group1_loc));
-
-    ReportBlockSnapshot(host, "gpu", {400}, false, {});
-    EXPECT_TRUE(HasLocation(300, group0_loc));
-    EXPECT_TRUE(HasLocation(400, group0_loc));
-    EXPECT_TRUE(HasLocation(300, group1_loc));
+    ASSERT_TRUE(HasLocation(300, location_id));
 
     {
         proto::meta::ReportEventRequest req;
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockSnapshotEvent(&req, host, "gpu", {400}, group0);
+        AddBlockSnapshotEvent(&req, host, "gpu", {400}, 0, "", "mamba_state:group=1");
+        AddBlockAddEvent(&req, host, "gpu", 401, 0, "", "mamba_state:group=1");
+        AddBlockDeleteEvent(&req, "gpu", 300, {"mamba_state:group=1"});
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
         EXPECT_EQ(proto::meta::OK, resp.header().status().code());
     }
-    EXPECT_FALSE(HasLocation(300, group0_loc));
-    EXPECT_TRUE(HasLocation(400, group0_loc));
-    EXPECT_TRUE(HasLocation(300, group1_loc));
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(400, location_id));
+    EXPECT_FALSE(HasLocation(401, location_id));
 }
 
 TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
@@ -3386,8 +3391,8 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
         AddNodeRegisterEvent(&req, {"mem"});
-        AddBlockAddEvent(&req, host, "mem", 300, 10, {}, "-old");
-        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+        AddBlockAddEvent(&req, host, "mem", 300, 10, "-old");
+        AddBlockAddEvent(&req, host, "mem", 300, 20, "-new");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3401,7 +3406,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+        AddBlockAddEvent(&req, host, "mem", 300, 20, "-new");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3414,7 +3419,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockAddEvent(&req, host, "mem", 300, 35, {}, "-updated");
+        AddBlockAddEvent(&req, host, "mem", 300, 35, "-updated");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3428,7 +3433,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 35, "-updated");
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, 35, "-updated");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3441,7 +3446,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 50, "-snapshot");
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, 50, "-snapshot");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <map>
@@ -313,6 +314,17 @@ public:
     bool HasLocation(int64_t key, const std::string &location_id) {
         auto location_map = GetLocationMapForKey(key);
         return location_map.find(location_id) != location_map.end();
+    }
+
+    MetaSearcher::KeyVector GetLocationIndexKeys(const std::string &location_id) {
+        auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+        EXPECT_NE(nullptr, meta_searcher);
+        MetaSearcher::KeyVector keys;
+        if (!meta_searcher) {
+            return keys;
+        }
+        EXPECT_EQ(EC_OK, meta_searcher->GetKeysByLocationIndex(request_context_.get(), location_id, keys));
+        return keys;
     }
 
     std::string GetFirstSpecUri(int64_t key, const std::string &location_id) {
@@ -3216,6 +3228,47 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotEmptySnapshotDeletesOnlyTar
     EXPECT_FALSE(HasLocation(300, loc_a));
     EXPECT_FALSE(HasLocation(400, loc_a));
     EXPECT_TRUE(HasLocation(300, loc_b));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotFiltersStaleLocationIndex) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    ReportBlockSnapshot(host, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    auto meta_indexer = cache_manager_->meta_indexer_manager()->GetMetaIndexer("test_instance");
+    ASSERT_NE(nullptr, meta_indexer);
+    ASSERT_EQ(EC_OK, meta_indexer->AddKeysToLocationIndex(request_context_.get(), location_id, {777}));
+    EXPECT_FALSE(HasLocation(777, location_id));
+
+    auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> mismatched_locations = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_NFS,
+          CLS_SERVING,
+          {LocationSpec("tp0", "file:///tmp/not-vineyard")}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher->BatchUpsertLocations(request_context_.get(), {778}, mismatched_locations, per_key_ec));
+    ASSERT_EQ(1, per_key_ec.size());
+    ASSERT_EQ(EC_OK, per_key_ec[0]);
+    ASSERT_TRUE(HasLocation(778, location_id));
+
+    ReportBlockSnapshot(host, "mem", {});
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(777, location_id));
+    EXPECT_TRUE(HasLocation(778, location_id));
+
+    auto indexed_keys = GetLocationIndexKeys(location_id);
+    EXPECT_EQ(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 300));
+    EXPECT_NE(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 777));
+    EXPECT_NE(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 778));
 }
 
 TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -121,6 +121,69 @@ TEST_F(MetaSearcherTest, TestBatchAddLocation) {
     }
 }
 
+TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    const std::string loc_b = "kvs#v6d#mem#host_b:8080";
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts = {
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/11")}},
+            {loc_b, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://b/11")}},
+        },
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/12")}},
+        },
+        {
+            {loc_b, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://b/13")}},
+        },
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchUpsertLocations(request_context_.get(), {11, 12, 13}, upserts, per_key_ec));
+    ASSERT_EQ(3, per_key_ec.size());
+    EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[0]);
+    EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[1]);
+    EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[2]);
+
+    MetaSearcher::KeyVector indexed_keys;
+    EXPECT_EQ(ErrorCode::EC_BADARGS, meta_searcher_->GetKeysByLocationIndex("", indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{11, 12}), indexed_keys);
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
+
+    LocationIdsPerKey delete_loc_a = {{loc_a}, {loc_a}, {loc_a}};
+    std::vector<std::vector<ErrorCode>> delete_ecs;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(), {11, 12, 13}, delete_loc_a, delete_ecs));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    EXPECT_TRUE(indexed_keys.empty());
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
+
+    std::vector<std::vector<MetaSearcher::LocationCADTask>> cad_tasks = {{{loc_b, CLS_SERVING}}};
+    std::vector<std::vector<ErrorCode>> cad_ecs;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchCADLocationStatus(request_context_.get(), {11}, cad_tasks, cad_ecs));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{13}), indexed_keys);
+
+    std::vector<ErrorCode> delete_results;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchDeleteLocation(request_context_.get(), {13}, {loc_b}, delete_results));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_TRUE(indexed_keys.empty());
+
+    auto generated_loc = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, {LocationSpec("nfs", "file:///tmp/generated?size=1")});
+    std::vector<std::string> generated_ids;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {14}, {generated_loc}, generated_ids));
+    ASSERT_EQ(1, generated_ids.size());
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(generated_ids[0], indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{14}), indexed_keys);
+}
+
 TEST_F(MetaSearcherTest, TestBatchAddLocation2) {
     // 准备测试数据
     MetaSearcher::KeyVector keys = {1, 2, 3};

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -185,7 +185,7 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
     EXPECT_EQ((MetaSearcher::KeyVector{14}), indexed_keys);
 }
 
-TEST_F(MetaSearcherTest, TestLocationKeyIndexRebuildsFromMetaIndexer) {
+TEST_F(MetaSearcherTest, TestLocationKeyIndexPersistsAcrossSearcherInstances) {
     const std::string loc_a = "kvs#v6d#mem#host_a:8080";
     const std::string loc_b = "kvs#v6d#mem#host_b:8080";
 

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -146,32 +146,32 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
     EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[2]);
 
     MetaSearcher::KeyVector indexed_keys;
-    EXPECT_EQ(ErrorCode::EC_BADARGS, meta_searcher_->GetKeysByLocationIndex("", indexed_keys));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    EXPECT_EQ(ErrorCode::EC_BADARGS, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), "", indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{11, 12}), indexed_keys);
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
 
     LocationIdsPerKey delete_loc_a = {{loc_a}, {loc_a}, {loc_a}};
     std::vector<std::vector<ErrorCode>> delete_ecs;
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchDeleteLocations(request_context_.get(), {11, 12, 13}, delete_loc_a, delete_ecs));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
     EXPECT_TRUE(indexed_keys.empty());
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
 
     std::vector<std::vector<MetaSearcher::LocationCADTask>> cad_tasks = {{{loc_b, CLS_SERVING}}};
     std::vector<std::vector<ErrorCode>> cad_ecs;
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchCADLocationStatus(request_context_.get(), {11}, cad_tasks, cad_ecs));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{13}), indexed_keys);
 
     std::vector<ErrorCode> delete_results;
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchDeleteLocation(request_context_.get(), {13}, {loc_b}, delete_results));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_TRUE(indexed_keys.empty());
 
     auto generated_loc = MetaSearcherTestHelper::CreateCacheLocation(
@@ -180,8 +180,43 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchAddLocation(request_context_.get(), {14}, {generated_loc}, generated_ids));
     ASSERT_EQ(1, generated_ids.size());
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(generated_ids[0], indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->GetKeysByLocationIndex(request_context_.get(), generated_ids[0], indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{14}), indexed_keys);
+}
+
+TEST_F(MetaSearcherTest, TestLocationKeyIndexRebuildsFromMetaIndexer) {
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    const std::string loc_b = "kvs#v6d#mem#host_b:8080";
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts = {
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/21")}},
+            {loc_b, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://b/21")}},
+        },
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/22")}},
+        },
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchUpsertLocations(request_context_.get(), {21, 22}, upserts, per_key_ec));
+
+    auto rebuilt_searcher =
+        std::make_shared<MetaSearcher>(meta_indexer_, dummy_check_loc_data_exist, dummy_submit_del_req);
+    MetaSearcher::KeyVector indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              rebuilt_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{21, 22}), indexed_keys);
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> new_upserts = {
+        {{loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/23")}}},
+    };
+    ASSERT_EQ(ErrorCode::EC_OK,
+              rebuilt_searcher->BatchUpsertLocations(request_context_.get(), {23}, new_upserts, per_key_ec));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              rebuilt_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{21, 22, 23}), indexed_keys);
 }
 
 TEST_F(MetaSearcherTest, TestBatchAddLocation2) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -46,9 +46,10 @@ public:
 
     void TearDown() override {}
 
-    std::shared_ptr<MetaStorageBackendConfig> ConstructMetaStorageBackendConfig() {
+    std::shared_ptr<MetaStorageBackendConfig> ConstructMetaStorageBackendConfig(
+        const std::string &path_suffix = "meta_local_backend_file_1") {
         auto meta_storage_backend_config = std::make_shared<MetaStorageBackendConfig>();
-        std::string local_path = GetPrivateTestRuntimeDataPath() + "meta_local_backend_file_1";
+        std::string local_path = GetPrivateTestRuntimeDataPath() + path_suffix;
         meta_storage_backend_config->SetStorageUri("file://" + local_path);
         std::error_code ec;
         bool exists = std::filesystem::exists(local_path, ec);
@@ -59,12 +60,14 @@ public:
         return meta_storage_backend_config;
     }
 
-    std::shared_ptr<MetaIndexer> CreateMetaIndexer() {
+    std::shared_ptr<MetaIndexer> CreateMetaIndexer(size_t max_key_count = 10000,
+                                                   int32_t mutex_shard_num = 32,
+                                                   const std::string &path_suffix = "meta_local_backend_file_1") {
         auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();
-        auto backend_config = ConstructMetaStorageBackendConfig();
+        auto backend_config = ConstructMetaStorageBackendConfig(path_suffix);
         meta_indexer_config->SetMetaStorageBackendConfig(backend_config);
-        meta_indexer_config->SetMutexShardNum(32);
-        meta_indexer_config->SetMaxKeyCount(10000);
+        meta_indexer_config->SetMutexShardNum(mutex_shard_num);
+        meta_indexer_config->SetMaxKeyCount(max_key_count);
         auto indexer = std::make_shared<MetaIndexer>();
         auto metaCachePolicyConfig = std::make_shared<MetaCachePolicyConfig>();
         metaCachePolicyConfig->SetCapacity(0);
@@ -217,6 +220,57 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexPersistsAcrossSearcherInstances) {
     ASSERT_EQ(ErrorCode::EC_OK,
               rebuilt_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{21, 22, 23}), indexed_keys);
+}
+
+TEST_F(MetaSearcherTest, TestDeleteNoentKeepsLocationIndex) {
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    ASSERT_EQ(ErrorCode::EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), loc_a, {901}));
+
+    LocationIdsPerKey delete_loc_a = {{loc_a}};
+    std::vector<std::vector<ErrorCode>> delete_ecs;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(), {901}, delete_loc_a, delete_ecs));
+    ASSERT_EQ(1, delete_ecs.size());
+    ASSERT_EQ(1, delete_ecs[0].size());
+    EXPECT_EQ(ErrorCode::EC_NOENT, delete_ecs[0][0]);
+
+    MetaSearcher::KeyVector indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{901}), indexed_keys);
+}
+
+TEST_F(MetaSearcherTest, TestBatchUpsertLeavesOverIndexWhenMetaWriteFails) {
+    auto limited_indexer = CreateMetaIndexer(/*max_key_count=*/1,
+                                             /*mutex_shard_num=*/1,
+                                             "meta_local_backend_limited_capacity");
+    ASSERT_NE(nullptr, limited_indexer);
+    auto limited_searcher =
+        std::make_shared<MetaSearcher>(limited_indexer, dummy_check_loc_data_exist, dummy_submit_del_req);
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts = {
+        {{loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/31")}}},
+        {{loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/32")}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    EXPECT_EQ(ErrorCode::EC_ERROR,
+              limited_searcher->BatchUpsertLocations(request_context_.get(), {31, 32}, upserts, per_key_ec));
+    ASSERT_EQ(2, per_key_ec.size());
+    EXPECT_EQ(ErrorCode::EC_NOSPC, per_key_ec[0]);
+    EXPECT_EQ(ErrorCode::EC_NOSPC, per_key_ec[1]);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask = static_cast<size_t>(0);
+    ASSERT_EQ(ErrorCode::EC_OK,
+              limited_searcher->BatchGetLocation(request_context_.get(), {31, 32}, mask, location_maps));
+    ASSERT_EQ(2, location_maps.size());
+    EXPECT_TRUE(location_maps[0].empty());
+    EXPECT_TRUE(location_maps[1].empty());
+
+    MetaSearcher::KeyVector indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              limited_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{31, 32}), indexed_keys);
 }
 
 TEST_F(MetaSearcherTest, TestBatchAddLocation2) {

--- a/kv_cache_manager/meta/meta_async_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_async_redis_backend.cc
@@ -9,6 +9,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/cache_location.h"
@@ -39,6 +40,7 @@ ErrorCode MetaAsyncRedisBackend::Init(const std::string &instance_id,
     instance_id_ = instance_id;
     cache_key_prefix_ = "kvcache:instance_" + instance_id_ + ":cache_";
     metadata_key_ = "kvcache:instance_" + instance_id_ + ":metadata";
+    location_index_key_prefix_ = "kvcache:instance_" + instance_id_ + ":locidx_";
 
     if (!config) {
         KVCM_LOG_ERROR("fail to init meta async redis backend, invalid nullptr config");
@@ -626,6 +628,94 @@ ErrorCode MetaAsyncRedisBackend::GetMetaData(FieldMap &out_field_map) noexcept {
         out_field_map = std::move(maps[0]);
     }
     return error_codes[0];
+}
+
+ErrorCode MetaAsyncRedisBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = read_client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "async redis add location index fail, fail to acquire client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SAdd({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaAsyncRedisBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                             const std::string &location_id,
+                                                             const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = read_client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "async redis remove location index fail, fail to acquire client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SRem({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaAsyncRedisBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    auto handle = read_client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "async redis get location index fail, fail to acquire client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    auto ec = handle->SMembers(location_index_key_prefix_ + location_id, members);
+    if (ec != EC_OK) {
+        return ec;
+    }
+    out_keys.reserve(members.size());
+    for (const auto &member : members) {
+        KeyType key = 0;
+        if (!StringUtil::StrToInt64(member.c_str(), key)) {
+            KVCM_LOG_WARN("async redis location index has invalid key member[%s], instance[%s], location_id[%s]",
+                          member.c_str(),
+                          instance_id_.c_str(),
+                          location_id.c_str());
+            out_keys.clear();
+            return EC_CORRUPTION;
+        }
+        out_keys.emplace_back(key);
+    }
+    return EC_OK;
 }
 
 // ==================== Sync ====================

--- a/kv_cache_manager/meta/meta_async_redis_backend.h
+++ b/kv_cache_manager/meta/meta_async_redis_backend.h
@@ -77,6 +77,15 @@ public:
     // ----- MetaData (sync passthrough) -----
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
     // ----- Sync -----
     bool Sync(const KeyTypeVec &keys) noexcept override;
@@ -104,6 +113,7 @@ private:
     std::string instance_id_;
     std::string cache_key_prefix_;
     std::string metadata_key_;
+    std::string location_index_key_prefix_;
     int64_t timeout_ms_ = 2000;
 
     // Async config

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/meta/meta_dummy_backend.h"
 
 #include <cinttypes>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -54,6 +55,7 @@ ErrorCode MetaDummyBackend::Open() noexcept {
 
     table_.Clear();
     metadata_.clear();
+    location_key_index_.clear();
     if (!enable_persistence_) {
         return ErrorCode::EC_OK;
     }
@@ -109,6 +111,9 @@ ErrorCode MetaDummyBackend::Open() noexcept {
                 auto loc = std::make_shared<CacheLocation>();
                 if (loc->FromJsonString(field_value)) {
                     item.locations[loc_id] = std::move(loc);
+                    if (!loc_id.empty()) {
+                        location_key_index_[loc_id].insert(key);
+                    }
                 }
             } else {
                 item.properties[field_name] = std::move(field_value);
@@ -473,6 +478,66 @@ ErrorCode MetaDummyBackend::GetMetaData(FieldMap &out_field_map) noexcept {
     }
     out_field_map = metadata_;
     return ErrorCode::EC_OK;
+}
+
+ErrorCode MetaDummyBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto &indexed_keys = location_key_index_[location_id];
+    for (const auto &key : keys) {
+        indexed_keys.insert(key);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaDummyBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    for (const auto &key : keys) {
+        iter->second.erase(key);
+    }
+    if (iter->second.empty()) {
+        location_key_index_.erase(iter);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaDummyBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    out_keys.reserve(iter->second.size());
+    for (const auto &key : iter->second) {
+        out_keys.push_back(key);
+    }
+    std::sort(out_keys.begin(), out_keys.end());
+    return EC_OK;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/concurrent_hash_map.h"
@@ -104,6 +106,15 @@ public:
 
     ErrorCode PutMetaData(const FieldMap &field_map) noexcept override;
     ErrorCode GetMetaData(FieldMap &out_field_map) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
 private:
     ErrorCode PersistToPath();
@@ -111,6 +122,7 @@ private:
     std::mutex mutex_;
     ConcurrentHashMap<KeyType, DummyItem> table_;
     FieldMap metadata_;
+    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
     std::string path_;
     bool enable_persistence_ = false;
 };

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -790,6 +790,45 @@ ErrorCode MetaIndexer::SampleReclaimKeys(RequestContext *request_context,
     return ec;
 }
 
+ErrorCode MetaIndexer::AddKeysToLocationIndex(RequestContext *request_context,
+                                              const std::string &location_id,
+                                              const KeyVector &keys) noexcept {
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    return backend_manager_->AddKeysToLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaIndexer::RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                                   const std::string &location_id,
+                                                   const KeyVector &keys) noexcept {
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    return backend_manager_->RemoveKeysFromLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaIndexer::GetKeysByLocationIndex(RequestContext *request_context,
+                                              const std::string &location_id,
+                                              KeyVector &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    auto ec = backend_manager_->GetKeysByLocationIndex(request_context, location_id, out_keys);
+    if (ec == EC_OK) {
+        std::sort(out_keys.begin(), out_keys.end());
+        out_keys.erase(std::unique(out_keys.begin(), out_keys.end()), out_keys.end());
+    }
+    return ec;
+}
+
 size_t MetaIndexer::GetKeyCount() const noexcept { return key_count_.load(); }
 
 size_t MetaIndexer::GetMaxKeyCount() const noexcept { return max_key_count_; }

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -101,6 +101,15 @@ public:
     ErrorCode RandomSample(RequestContext *request_context, const size_t count, KeyVector &out_keys) const noexcept;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyVector &out_keys) const noexcept;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyVector &keys) noexcept;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyVector &keys) noexcept;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyVector &out_keys) noexcept;
 
     void PersistMetaData() noexcept;
     size_t GetKeyCount() const noexcept;

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -106,6 +106,10 @@ ErrorCode MetaLocalBackend::Close() noexcept {
     }
     cache_.reset();
     cache_item_helper_.reset();
+    {
+        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+        location_key_index_.clear();
+    }
     KVCM_LOG_INFO("local backend close ok");
     return EC_OK;
 }
@@ -665,6 +669,66 @@ ErrorCode MetaLocalBackend::SampleReclaimKeys(RequestContext * /*request_context
 ErrorCode MetaLocalBackend::PutMetaData(const FieldMap & /*field_maps*/) noexcept { return EC_OK; }
 
 ErrorCode MetaLocalBackend::GetMetaData(FieldMap & /*field_maps*/) noexcept { return EC_NOENT; }
+
+ErrorCode MetaLocalBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto &indexed_keys = location_key_index_[location_id];
+    for (const auto &key : keys) {
+        indexed_keys.insert(key);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaLocalBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    for (const auto &key : keys) {
+        iter->second.erase(key);
+    }
+    if (iter->second.empty()) {
+        location_key_index_.erase(iter);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaLocalBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    out_keys.reserve(iter->second.size());
+    for (const auto &key : iter->second) {
+        out_keys.push_back(key);
+    }
+    std::sort(out_keys.begin(), out_keys.end());
+    return EC_OK;
+}
 
 size_t MetaLocalBackend::GetMemUsage() const noexcept { return cache_->GetUsage(); }
 

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -4,10 +4,13 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/cache/advanced_cache.h"
@@ -167,6 +170,15 @@ public:
     // meta data
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
     size_t GetMemUsage() const noexcept override;
     int64_t GetOldestAccessTime() const noexcept override;
@@ -209,6 +221,8 @@ private:
     uint32_t shard_mask_ = 0;
     size_t sample_times_ = 0;
     std::shared_ptr<RevisitIntervalHistogram> revisit_histogram_;
+    mutable std::mutex location_key_index_mutex_;
+    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_redis_backend.cc
@@ -2,6 +2,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
@@ -27,6 +28,7 @@ ErrorCode MetaRedisBackend::Init(const std::string &instance_id,
     instance_id_ = instance_id;
     cache_key_prefix_ = "kvcache:instance_" + instance_id_ + ":cache_";
     metadata_key_ = "kvcache:instance_" + instance_id_ + ":metadata";
+    location_index_key_prefix_ = "kvcache:instance_" + instance_id_ + ":locidx_";
 
     if (!config) {
         KVCM_LOG_ERROR("fail to init meta redis backend, invalid nullptr config");
@@ -479,6 +481,94 @@ ErrorCode MetaRedisBackend::GetMetaData(FieldMap &out_field_map) noexcept {
         out_field_map = std::move(maps[0]);
     }
     return error_codes[0];
+}
+
+ErrorCode MetaRedisBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "add location index fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SAdd({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaRedisBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "remove location index fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SRem({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaRedisBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "get location index fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    auto ec = handle->SMembers(location_index_key_prefix_ + location_id, members);
+    if (ec != EC_OK) {
+        return ec;
+    }
+    out_keys.reserve(members.size());
+    for (const auto &member : members) {
+        KeyType key = 0;
+        if (!StringUtil::StrToInt64(member.c_str(), key)) {
+            KVCM_LOG_WARN("location index has invalid key member[%s], instance[%s], location_id[%s]",
+                          member.c_str(),
+                          instance_id_.c_str(),
+                          location_id.c_str());
+            out_keys.clear();
+            return EC_CORRUPTION;
+        }
+        out_keys.emplace_back(key);
+    }
+    return EC_OK;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_redis_backend.h
+++ b/kv_cache_manager/meta/meta_redis_backend.h
@@ -81,6 +81,15 @@ public:
     // ----- Metadata APIs -----
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
 private:
     // virtual for test
@@ -92,6 +101,7 @@ private:
     std::string instance_id_;
     std::string cache_key_prefix_;
     std::string metadata_key_;
+    std::string location_index_key_prefix_;
     int64_t timeout_ms_ = 1000;
 };
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -244,6 +244,34 @@ public:
     // @return EC_OK 成功；EC_NOENT 无元数据；EC_ERROR 读取失败
     virtual ErrorCode GetMetaData(FieldMap &field_maps) noexcept = 0;
 
+    // =====================================================================
+    // Location Index APIs — derived secondary index for snapshot diff
+    // =====================================================================
+
+    // Add keys to the persistent secondary index:
+    //   location_id -> set(block_key)
+    // This index is not the source of truth. CacheMeta remains authoritative.
+    virtual ErrorCode AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                             const std::string & /*location_id*/,
+                                             const KeyTypeVec & /*keys*/) noexcept {
+        return EC_UNIMPLEMENTED;
+    }
+
+    // Remove keys from the persistent secondary index. Idempotent.
+    virtual ErrorCode RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                  const std::string & /*location_id*/,
+                                                  const KeyTypeVec & /*keys*/) noexcept {
+        return EC_UNIMPLEMENTED;
+    }
+
+    // Read candidate block keys from the persistent secondary index.
+    // Callers must verify every candidate against CacheMeta before using it.
+    virtual ErrorCode GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                             const std::string & /*location_id*/,
+                                             KeyTypeVec & /*out_keys*/) noexcept {
+        return EC_UNIMPLEMENTED;
+    }
+
     // Synchronously flush pending writes for the given keys.
     // Returns true if all writes persisted successfully, false on failure/timeout.
     // Default: no-op (sync backends have no pending writes).

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -728,6 +728,34 @@ ErrorCode MetaStorageBackendManager::GetMetaData(FieldMap &field_maps) noexcept 
     return persistent_backend_->GetMetaData(field_maps);
 }
 
+ErrorCode MetaStorageBackendManager::AddKeysToLocationIndex(RequestContext *request_context,
+                                                            const std::string &location_id,
+                                                            const KeyVector &keys) noexcept {
+    if (!persistent_backend_) {
+        return EC_ERROR;
+    }
+    return persistent_backend_->AddKeysToLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaStorageBackendManager::RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                                                 const std::string &location_id,
+                                                                 const KeyVector &keys) noexcept {
+    if (!persistent_backend_) {
+        return EC_ERROR;
+    }
+    return persistent_backend_->RemoveKeysFromLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaStorageBackendManager::GetKeysByLocationIndex(RequestContext *request_context,
+                                                            const std::string &location_id,
+                                                            KeyVector &out_keys) noexcept {
+    out_keys.clear();
+    if (!persistent_backend_) {
+        return EC_ERROR;
+    }
+    return persistent_backend_->GetKeysByLocationIndex(request_context, location_id, out_keys);
+}
+
 bool MetaStorageBackendManager::Sync(const KeyVector &keys) noexcept {
     if (!persistent_backend_) {
         return true;

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -87,6 +87,16 @@ public:
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept;
 
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyVector &keys) noexcept;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyVector &keys) noexcept;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyVector &out_keys) noexcept;
+
     // Synchronously flush pending writes for the given keys to persistent storage.
     // Returns true on success, false on failure/timeout.
     bool Sync(const KeyVector &keys) noexcept;

--- a/kv_cache_manager/meta/test/meta_async_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_async_redis_backend_test.cc
@@ -1,4 +1,6 @@
 #include <atomic>
+#include <map>
+#include <set>
 #include <thread>
 
 #include "kv_cache_manager/common/redis_client.h"
@@ -194,6 +196,76 @@ TEST_F(MetaAsyncRedisBackendTest, TestDeleteLocations) {
     auto results = backend_->DeleteLocations(nullptr, keys, location_ids);
     ASSERT_EQ(1, results.size());
     ASSERT_EQ(EC_OK, results[0]);
+}
+
+TEST_F(MetaAsyncRedisBackendTest, TestLocationIndexPassthrough) {
+    config_->SetStorageUri("redis://user:pass@host:6379/?async_queue_count=1&async_max_batch=64&async_wait_us=1000"
+                           "&async_max_size=1000&async_drain_ms=2000&client_min_pool_size=1&client_max_pool_size=1");
+    std::map<std::string, std::set<std::string>> redis_sets;
+    EXPECT_CALL(*backend_, CreateRedisClient()).WillRepeatedly(Invoke([this, &redis_sets]() {
+        StandardUri empty_uri;
+        auto mock = std::make_shared<::testing::NiceMock<MockRedisClient>>(empty_uri);
+        ON_CALL(*mock, IsContextOk()).WillByDefault(Return(true));
+        ON_CALL(*mock, Reconnect()).WillByDefault(Return(true));
+        ON_CALL(*mock, TryExecPipeline(_)).WillByDefault(Invoke([this, &redis_sets](const std::vector<CmdArgs> &cmds) {
+            std::vector<ReplyUPtr> replies;
+            replies.reserve(cmds.size());
+            for (const auto &cmd : cmds) {
+                if (cmd.size() >= 3 && cmd[0] == "SADD") {
+                    auto &members = redis_sets[cmd[1]];
+                    int64_t added = 0;
+                    for (size_t i = 2; i < cmd.size(); ++i) {
+                        added += members.insert(cmd[i]).second ? 1 : 0;
+                    }
+                    replies.emplace_back(MakeFakeReplyInteger(added));
+                } else if (cmd.size() >= 3 && cmd[0] == "SREM") {
+                    auto &members = redis_sets[cmd[1]];
+                    int64_t removed = 0;
+                    for (size_t i = 2; i < cmd.size(); ++i) {
+                        removed += members.erase(cmd[i]);
+                    }
+                    replies.emplace_back(MakeFakeReplyInteger(removed));
+                } else if (cmd.size() == 2 && cmd[0] == "SMEMBERS") {
+                    std::vector<std::optional<std::string>> members;
+                    for (const auto &member : redis_sets[cmd[1]]) {
+                        members.emplace_back(member);
+                    }
+                    replies.emplace_back(MakeFakeReplyArrayString(members));
+                } else {
+                    replies.emplace_back(MakeFakeReplyInteger(1));
+                }
+            }
+            return replies;
+        }));
+        return mock;
+    }));
+
+    ASSERT_EQ(EC_OK, backend_->Init("test_instance", config_));
+    ASSERT_EQ(EC_OK, backend_->Open());
+
+    KeyTypeVec out_keys = {999};
+    EXPECT_EQ(EC_BADARGS, backend_->AddKeysToLocationIndex(nullptr, "", {}));
+    EXPECT_EQ(EC_BADARGS, backend_->RemoveKeysFromLocationIndex(nullptr, "", {}));
+    EXPECT_EQ(EC_BADARGS, backend_->AddKeysToLocationIndex(nullptr, "", {1}));
+    EXPECT_EQ(EC_BADARGS, backend_->RemoveKeysFromLocationIndex(nullptr, "", {1}));
+    EXPECT_EQ(EC_BADARGS, backend_->GetKeysByLocationIndex(nullptr, "", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, backend_->AddKeysToLocationIndex(nullptr, "loc_a", {3, 1, 3}));
+    ASSERT_EQ(EC_OK, backend_->AddKeysToLocationIndex(nullptr, "loc_b", {2}));
+    ASSERT_EQ(EC_OK, backend_->GetKeysByLocationIndex(nullptr, "loc_a", out_keys));
+    EXPECT_EQ((KeyTypeVec{1, 3}), out_keys);
+    ASSERT_EQ(EC_OK, backend_->GetKeysByLocationIndex(nullptr, "loc_b", out_keys));
+    EXPECT_EQ((KeyTypeVec{2}), out_keys);
+
+    ASSERT_EQ(EC_OK, backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {1, 404}));
+    ASSERT_EQ(EC_OK, backend_->GetKeysByLocationIndex(nullptr, "loc_a", out_keys));
+    EXPECT_EQ((KeyTypeVec{3}), out_keys);
+
+    redis_sets["kvcache:instance_test_instance:locidx_loc_bad"].insert("not-int64");
+    out_keys = {999};
+    EXPECT_EQ(EC_CORRUPTION, backend_->GetKeysByLocationIndex(nullptr, "loc_bad", out_keys));
+    EXPECT_TRUE(out_keys.empty());
 }
 
 TEST_F(MetaAsyncRedisBackendTest, TestWriteEmptyKeys) {

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -103,6 +103,60 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaDummyBackendTest, TestLocationIndexRebuildsFromPersistentCacheMeta) {
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_storage_backend_->Init("test_instance_location_index_rebuild", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    const std::string loc_b = "kvs#v6d#mem#host_b:8080";
+
+    CacheLocationMapVector locations(2);
+    locations[0][loc_a] = std::make_shared<CacheLocation>(loc_a,
+                                                          CLS_SERVING,
+                                                          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+                                                          1,
+                                                          std::vector<LocationSpec>{
+                                                              LocationSpec("tp0", "v6d://host_a:8080/11")});
+    locations[0][loc_b] = std::make_shared<CacheLocation>(loc_b,
+                                                          CLS_SERVING,
+                                                          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+                                                          1,
+                                                          std::vector<LocationSpec>{
+                                                              LocationSpec("tp0", "v6d://host_b:8080/11")});
+    locations[1][loc_a] = std::make_shared<CacheLocation>(loc_a,
+                                                          CLS_SERVING,
+                                                          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+                                                          1,
+                                                          std::vector<LocationSpec>{
+                                                              LocationSpec("tp0", "v6d://host_a:8080/12")});
+    PropertyMapVector properties(2);
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put(nullptr, {11, 12}, locations, properties));
+
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_storage_backend_->AddKeysToLocationIndex(nullptr, loc_a, {11, 12, 999}));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->AddKeysToLocationIndex(nullptr, loc_b, {11}));
+
+    MetaStorageBackend::KeyTypeVec indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, loc_a, indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11, 12, 999}), indexed_keys);
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+
+    ConstructMetaStorageBackend();
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_storage_backend_->Init("test_instance_location_index_rebuild", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, loc_a, indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11, 12}), indexed_keys);
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, loc_b, indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11}), indexed_keys);
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaDummyBackendTest, TestInit) {
     // invalid config
     ASSERT_NE(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -201,6 +201,43 @@ TEST_F(MetaIndexerTest, TestMakeBatches2) {
     ASSERT_EQ(expected_indexs, covered_indexs);
 }
 
+TEST_F(MetaIndexerTest, TestLocationIndexWrapper) {
+    std::string configStr = R"({
+        "max_key_count" : 100,
+        "mutex_shard_num" : 8,
+        "batch_key_size" : 2,
+        "meta_storage_backend_config" : { "storage_type" : "local" },
+        "meta_cache_policy_config" : { "capacity" : 0 }
+    })";
+    ASSERT_EQ(EC_OK, InitIndexer(configStr));
+
+    KeyVector keys = {3, 1, 3, 2};
+    KeyVector out_keys = {999};
+
+    EXPECT_EQ(EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "", {}));
+    EXPECT_EQ(EC_OK, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "", {}));
+    EXPECT_EQ(EC_BADARGS, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "loc_a", keys));
+    ASSERT_EQ(EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "loc_b", {5}));
+
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{1, 2, 3}), out_keys);
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_b", out_keys));
+    EXPECT_EQ((KeyVector{5}), out_keys);
+
+    EXPECT_EQ(EC_OK, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {2, 999}));
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{1, 3}), out_keys);
+
+    EXPECT_EQ(EC_OK, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {1, 3}));
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+}
+
 TEST_F(MetaIndexerTest, TestLocalSimple) {
     std::string configStr = R"({
         "max_key_count" : 100,

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -90,6 +90,34 @@ TEST_F(MetaLocalBackendTest, TestSimple) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaLocalBackendTest, TestLocationIndex) {
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_location_index", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    MetaStorageBackend::KeyTypeVec indexed_keys;
+    ASSERT_EQ(EC_BADARGS, meta_storage_backend_->AddKeysToLocationIndex(nullptr, "", {1}));
+    ASSERT_EQ(EC_BADARGS, meta_storage_backend_->RemoveKeysFromLocationIndex(nullptr, "", {1}));
+    ASSERT_EQ(EC_BADARGS, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "", indexed_keys));
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->AddKeysToLocationIndex(nullptr, "loc_a", {3, 1, 1}));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->AddKeysToLocationIndex(nullptr, "loc_b", {2}));
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_a", indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{1, 3}), indexed_keys);
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_b", indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{2}), indexed_keys);
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {1, 100}));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_a", indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{3}), indexed_keys);
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {3}));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_a", indexed_keys));
+    ASSERT_TRUE(indexed_keys.empty());
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestInit) {
     // invalid config
     ASSERT_EQ(EC_BADARGS, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));

--- a/kv_cache_manager/meta/test/meta_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <thread>
 
 #include "kv_cache_manager/common/redis_client.h"
@@ -133,6 +134,56 @@ TEST_F(MetaRedisBackendTest, TestOpenAndClose) {
         ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
         ASSERT_EQ(EC_ERROR, meta_redis_backend_->Open());
     }
+}
+
+TEST_F(MetaRedisBackendTest, TestLocationIndex) {
+    EXPECT_CALL(*meta_redis_backend_, CreateRedisClient()).WillRepeatedly(Invoke([]() {
+        StandardUri empty_storage_uri;
+        auto mock_redis_client = std::make_unique<MockRedisClient>(empty_storage_uri);
+        EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> sadd_replies;
+        sadd_replies.emplace_back(MakeFakeReplyInteger(2));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"),
+                                                            StrEq("kvcache:instance_instance_0:locidx_loc_a"),
+                                                            StrEq("11"),
+                                                            StrEq("12")))))
+            .WillOnce(Return(ByMove(std::move(sadd_replies))));
+
+        std::vector<ReplyUPtr> smembers_replies;
+        smembers_replies.emplace_back(MakeFakeReplyArrayString({"12", "11"}));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(
+                        ElementsAre(StrEq("SMEMBERS"), StrEq("kvcache:instance_instance_0:locidx_loc_a")))))
+            .WillOnce(Return(ByMove(std::move(smembers_replies))));
+
+        std::vector<ReplyUPtr> srem_replies;
+        srem_replies.emplace_back(MakeFakeReplyInteger(1));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"),
+                                                            StrEq("kvcache:instance_instance_0:locidx_loc_a"),
+                                                            StrEq("11")))))
+            .WillOnce(Return(ByMove(std::move(srem_replies))));
+        return mock_redis_client;
+    }));
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
+
+    ASSERT_EQ(EC_BADARGS,
+              meta_redis_backend_->AddKeysToLocationIndex(nullptr, "", MetaStorageBackend::KeyTypeVec{11}));
+    ASSERT_EQ(EC_OK,
+              meta_redis_backend_->AddKeysToLocationIndex(nullptr, "loc_a", MetaStorageBackend::KeyTypeVec{11, 12}));
+
+    MetaStorageBackend::KeyTypeVec keys;
+    ASSERT_EQ(EC_OK, meta_redis_backend_->GetKeysByLocationIndex(nullptr, "loc_a", keys));
+    std::sort(keys.begin(), keys.end());
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11, 12}), keys);
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {11}));
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
 
 TEST_F(MetaRedisBackendTest, TestSimple) {

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -146,6 +146,57 @@ TEST_F(MetaStorageBackendManagerTest, TestInitDualBackend) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
+TEST_F(MetaStorageBackendManagerTest, TestLocationIndexSingleBackendRoundTrip) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_locidx_single";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_locidx_single", MakeSingleConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+
+    KeyVector out_keys = {999};
+    EXPECT_EQ(EC_OK, mgr.AddKeysToLocationIndex(request_context_.get(), "loc_a", {3, 1, 1}));
+    EXPECT_EQ(EC_OK, mgr.AddKeysToLocationIndex(request_context_.get(), "loc_b", {2}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{1, 3}), out_keys);
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_b", out_keys));
+    EXPECT_EQ((KeyVector{2}), out_keys);
+
+    EXPECT_EQ(EC_OK, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {1, 404}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{3}), out_keys);
+
+    EXPECT_EQ(EC_OK, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {3}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestLocationIndexDualBackendRoundTrip) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_locidx_dual";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_locidx_dual", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    KeyVector out_keys = {999};
+    EXPECT_EQ(EC_BADARGS, mgr.AddKeysToLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, mgr.GetKeysByLocationIndex(request_context_.get(), "", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, mgr.AddKeysToLocationIndex(request_context_.get(), "loc_a", {10, 20, 10}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{10, 20}), out_keys);
+
+    ASSERT_EQ(EC_OK, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {10}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{20}), out_keys);
+
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
 // --- Put/Get: CacheLocation serialization round-trip --------------------------
 
 TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -55,28 +55,39 @@ enum ReportEventType {
     EVENT_BLOCK_DELETE = 3;  // V6D deleted a block locally
     EVENT_HOST_DOWN = 4;     // V6D node is going down (graceful or detected)
     EVENT_HEARTBEAT = 5;     // V6D periodic heartbeat
+    EVENT_BLOCK_SNAPSHOT = 6; // Reporter sends the full block set for one host/medium
 }
 
-message NodeRegisterParams {
+message NodeRegisterEventParams {
     repeated string mediums = 1; // mediums supported by the node, e.g. ["mem","disk"]
 }
 
-message BlockAddParams {
+message BlockAddEventParams {
     string block_key = 1; // int64 as string
     string uri = 2;       // deprecated, use specs instead
     string medium = 3;    // e.g. "mem"/"disk"/"ssd"/"hbm"
     repeated LocationSpec specs = 4;
 }
 
-message BlockDeleteParams {
+message BlockDeleteEventParams {
     string block_key = 1;
     string medium = 2;
 }
 
-message HostDownParams {
+message BlockSnapshotItem {
+    string block_key = 1;
+    repeated LocationSpec specs = 2;
 }
 
-message HeartbeatParams {
+message BlockSnapshotEventParams {
+    string medium = 1;
+    repeated BlockSnapshotItem blocks = 2;
+}
+
+message HostDownEventParams {
+}
+
+message HeartbeatEventParams {
     // KVCM only refreshes last_heartbeat; system_status is opaque observability data
     map<string, string> system_status = 1;
 }
@@ -84,11 +95,12 @@ message HeartbeatParams {
 message EventItem {
     ReportEventType event_type = 1;
     oneof event_params {
-        NodeRegisterParams node_register = 2;
-        BlockAddParams block_add = 3;
-        BlockDeleteParams block_delete = 4;
-        HostDownParams host_down = 5;
-        HeartbeatParams heartbeat = 6;
+        NodeRegisterEventParams node_register = 2;
+        BlockAddEventParams block_add = 3;
+        BlockDeleteEventParams block_delete = 4;
+        HostDownEventParams host_down = 5;
+        HeartbeatEventParams heartbeat = 6;
+        BlockSnapshotEventParams block_snapshot = 7;
     }
 }
 

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -51,9 +51,11 @@ enum StorageType {
 // ReportEvent is the ingestion API used by cache subscribers. A subscriber
 // normalizes engine-specific cache signals (for example RTP-LLM full cache
 // snapshots or vLLM KV events) into block-level mutations on one storage
-// system. `storage_type` names that large storage/cache system; LocationScope
-// identifies one diffable location namespace inside it; LocationSpec describes
-// where the block lives within that namespace.
+// system. `storage_type` names that large storage/cache system; `medium`
+// identifies one diffable cache namespace under the reporter host; LocationSpec
+// describes where each cache component of the block lives. KVCM currently
+// matches only full-attention specs and ignores mamba-state specs by
+// LocationSpec.name.
 
 enum ReportEventType {
     EVENT_UNSPECIFIED = 0;
@@ -65,13 +67,6 @@ enum ReportEventType {
     EVENT_BLOCK_SNAPSHOT = 6; // Reporter sends the full block set for one host/medium
 }
 
-message LocationScope {
-    string medium = 1; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
-    // Optional identity dimensions within a medium, e.g. {"dp_rank":"0", "group_idx":"1"}.
-    // KVCM sorts these labels and folds them into the location id.
-    map<string, string> labels = 2;
-}
-
 message NodeRegisterEventParams {
     repeated string mediums = 1; // mediums supported by the node, e.g. ["mem","disk"]
 }
@@ -79,15 +74,16 @@ message NodeRegisterEventParams {
 message BlockAddEventParams {
     string block_key = 1; // int64 as string
     string uri = 2;       // deprecated, use specs instead
-    string medium = 3;    // deprecated compatibility field; use location.medium instead
+    string medium = 3;    // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
     repeated LocationSpec specs = 4;
-    LocationScope location = 5;
 }
 
 message BlockDeleteEventParams {
     string block_key = 1;
-    string medium = 2; // deprecated compatibility field; use location.medium instead
-    LocationScope location = 3;
+    string medium = 2; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
+    // Optional. When set, KVCM applies the delete only if these component names
+    // contain a full-attention spec; mamba-state-only deletes are ignored.
+    repeated string spec_names = 3;
 }
 
 message BlockSnapshotItem {
@@ -96,9 +92,8 @@ message BlockSnapshotItem {
 }
 
 message BlockSnapshotEventParams {
-    string medium = 1; // deprecated compatibility field; use location.medium instead
+    string medium = 1; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
     repeated BlockSnapshotItem blocks = 2;
-    LocationScope location = 3;
 }
 
 message HostDownEventParams {

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -46,16 +46,30 @@ enum StorageType {
     ST_VINEYARD = 7;
 }
 
-// ---- V6D event reporting ----
+// ---- Cache event reporting ----
+//
+// ReportEvent is the ingestion API used by cache subscribers. A subscriber
+// normalizes engine-specific cache signals (for example RTP-LLM full cache
+// snapshots or vLLM KV events) into block-level mutations on one storage
+// system. `storage_type` names that large storage/cache system; LocationScope
+// identifies one diffable location namespace inside it; LocationSpec describes
+// where the block lives within that namespace.
 
 enum ReportEventType {
     EVENT_UNSPECIFIED = 0;
-    EVENT_NODE_REGISTER = 1; // V6D node starts up and registers with KVCM
-    EVENT_BLOCK_ADD = 2;     // V6D stored a new block locally
-    EVENT_BLOCK_DELETE = 3;  // V6D deleted a block locally
-    EVENT_HOST_DOWN = 4;     // V6D node is going down (graceful or detected)
-    EVENT_HEARTBEAT = 5;     // V6D periodic heartbeat
+    EVENT_NODE_REGISTER = 1; // Reporter node starts up and registers with KVCM
+    EVENT_BLOCK_ADD = 2;     // Reporter stored a block in one location
+    EVENT_BLOCK_DELETE = 3;  // Reporter removed a block from one location
+    EVENT_HOST_DOWN = 4;     // Reporter node is going down (graceful or detected)
+    EVENT_HEARTBEAT = 5;     // Reporter periodic heartbeat
     EVENT_BLOCK_SNAPSHOT = 6; // Reporter sends the full block set for one host/medium
+}
+
+message LocationScope {
+    string medium = 1; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
+    // Optional identity dimensions within a medium, e.g. {"dp_rank":"0", "group_idx":"1"}.
+    // KVCM sorts these labels and folds them into the location id.
+    map<string, string> labels = 2;
 }
 
 message NodeRegisterEventParams {
@@ -65,13 +79,15 @@ message NodeRegisterEventParams {
 message BlockAddEventParams {
     string block_key = 1; // int64 as string
     string uri = 2;       // deprecated, use specs instead
-    string medium = 3;    // e.g. "mem"/"disk"/"ssd"/"hbm"
+    string medium = 3;    // deprecated compatibility field; use location.medium instead
     repeated LocationSpec specs = 4;
+    LocationScope location = 5;
 }
 
 message BlockDeleteEventParams {
     string block_key = 1;
-    string medium = 2;
+    string medium = 2; // deprecated compatibility field; use location.medium instead
+    LocationScope location = 3;
 }
 
 message BlockSnapshotItem {
@@ -80,8 +96,9 @@ message BlockSnapshotItem {
 }
 
 message BlockSnapshotEventParams {
-    string medium = 1;
+    string medium = 1; // deprecated compatibility field; use location.medium instead
     repeated BlockSnapshotItem blocks = 2;
+    LocationScope location = 3;
 }
 
 message HostDownEventParams {
@@ -109,7 +126,7 @@ message ReportEventRequest {
     string instance_id = 2;
     string host_ip_port = 3;
     repeated EventItem events = 4;
-    StorageType storage_type = 5; // required: declares the reporter's storage type
+    StorageType storage_type = 5; // required: declares the reporter's storage/cache system
 }
 
 message ReportEventResponse {


### PR DESCRIPTION
## Summary
- Add `EVENT_BLOCK_SNAPSHOT` to `ReportEvent` so external subscribers can report a full block set for one host/medium.
- Rename report-event proto payload messages to the `XXXEventParams` form to avoid generic `XXXParams` names in `meta_service.proto`.
- Reconcile full snapshots in KVCM by diffing reported keys against an indexed key set for the target location: upsert missing keys and delete stale locations.
- Add coverage for the location reverse index plus snapshot diffing, empty snapshots, host/medium isolation, invalid snapshot payloads, and partial-failure behavior.

## Design Notes
KVCM no longer connects to every worker. A subscriber/reporting component can live with RTP-LLM, consume worker-local/cache-status data, and report full snapshots to KVCM. KVCM treats the snapshot as the authoritative full state for `(instance_id, host_ip_port, medium)` and only mutates the corresponding location id.

Snapshot reconciliation no longer scans Redis/meta keys on every full report. `MetaSearcher` now maintains a `location_id -> block_key set` reverse index from the location mutation paths (`BatchAddLocation`, `BatchUpsertLocations`, `BatchCADLocationStatus`, `BatchDeleteLocation(s)`), and `EVENT_BLOCK_SNAPSHOT` reads that index through `GetKeysByLocationIndex` before computing add/delete sets. The backend key metadata remains the source of truth; the index is the serving-side lookup path for snapshot diff.

## Validation
- Local: `git diff --check HEAD^`
- Remote `11.122.133.161`, `screen -x qisa`, window 1: `bazel test //kv_cache_manager/manager/test:MetaSearcherTest //kv_cache_manager/manager/test:CacheManagerTest //kv_cache_manager/config/test:instance_group_test`
- Result on `6d3145a`: `Executed 3 out of 3 tests: 3 tests pass` (`KVCM_TEST_EXIT:0`)