### PR TITLE
Isolate Redis coordination keys by cluster

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,8 +35,8 @@ KVCM server可识别的配置参数列表如下。可通过配置文件、启动
 # 指定系统Registry自身数据存储位置
 # kvcm.registry_storage.uri=redis://127.0.0.1:6379?auth=123456
 
-# 指定协调后端服务的URI（用于多节点选主、节点信息存储等）
-# kvcm.coordination.uri=redis://127.0.0.1:6379?auth=123456
+# 指定协调后端服务的URI（用于多节点选主、节点信息存储等）。Redis选主key按cluster_name隔离。
+# kvcm.coordination.uri=redis://127.0.0.1:6379?auth=123456&cluster_name=kvcm_app_0
 # 旧配置 kvcm.distributed_lock.uri 仍可使用（向后兼容），但新配置优先
 
 # 指定选主时当前节点使用的node_id（如果不指定会自动生成）

--- a/docs/design/ha_leader_elector.md
+++ b/docs/design/ha_leader_elector.md
@@ -251,11 +251,13 @@ kvcm.leader_elector.loop_interval_ms=100
 **多节点 HA（Redis，生产）：**
 
 ```
-kvcm.coordination.uri=redis://your_password@redis-host:6379?timeout_ms=5000&retry_count=3
+kvcm.coordination.uri=redis://your_password@redis-host:6379?timeout_ms=5000&retry_count=3&cluster_name=kvcm_app_0
 kvcm.leader_elector.lease_ms=10000
 kvcm.leader_elector.loop_interval_ms=100
 kvcm.service.advertised_host=10.0.0.1
 ```
+
+Redis选主key通过`cluster_name`区分：`kvcm_<cluster_name>_lock:`/`kvcm_<cluster_name>_kv:`。
 
 ## 7. 故障场景分析
 

--- a/integration_test/redis_coordination/BUILD
+++ b/integration_test/redis_coordination/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//integration_test/redis_coordination:__subpackages__"])
+
+py_test(
+    name = "redis_cluster_isolation_test",
+    srcs = ["redis_cluster_isolation_test.py"],
+    data = [
+        "//kv_cache_manager:kv_cache_manager_bin",
+    ],
+    tags = [
+        "manual",
+        "no-remote-exec",
+        "redis",
+    ],
+    deps = [
+        "//integration_test/testlib:test_base",
+    ],
+)

--- a/integration_test/redis_coordination/redis_cluster_isolation_test.py
+++ b/integration_test/redis_coordination/redis_cluster_isolation_test.py
@@ -1,0 +1,439 @@
+import json
+import logging
+import os
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+from integration_test.testlib.redis_server import RedisServer
+from integration_test.testlib.test_base import TestBase
+
+
+class KVCMHttpClient(object):
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    def close(self):
+        pass
+
+    def _post(self, endpoint, data, check_response=True):
+        body = json.dumps(data).encode()
+        request = urllib.request.Request(
+            self.base_url + endpoint,
+            data=body,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                response_data = json.loads(response.read().decode())
+        except urllib.error.HTTPError as e:
+            raise AssertionError(f"Request to {endpoint} failed with status code {e.code}") from e
+        except urllib.error.URLError as e:
+            raise AssertionError(f"Request to {endpoint} failed: {e}") from e
+
+        if check_response:
+            status = response_data.get("header", {}).get("status", {})
+            if status.get("code") != "OK":
+                raise AssertionError(f"Request to {endpoint} failed: {status.get('message')}")
+        return response_data
+
+    def check_health(self, data, check_response=True):
+        return self._post("/api/checkHealth", data, check_response)
+
+    def get_manager_cluster_info(self, data, check_response=True):
+        return self._post("/api/getManagerClusterInfo", data, check_response)
+
+    def leader_demote(self, data, check_response=True):
+        return self._post("/api/leaderDemote", data, check_response)
+
+    def update_leader_elector_config(self, data, check_response=True):
+        return self._post("/api/updateLeaderElectorConfig", data, check_response)
+
+    def get_instance_group(self, data, check_response=True):
+        return self._post("/api/getInstanceGroup", data, check_response)
+
+    def create_instance_group(self, data, check_response=True):
+        return self._post("/api/createInstanceGroup", data, check_response)
+
+    def register_instance(self, data, check_response=True):
+        return self._post("/api/registerInstance", data, check_response)
+
+    def start_write_cache(self, data, check_response=True):
+        return self._post("/api/startWriteCache", data, check_response)
+
+    def finish_write_cache(self, data, check_response=True):
+        return self._post("/api/finishWriteCache", data, check_response)
+
+    def get_cache_location(self, data, check_response=True):
+        return self._post("/api/getCacheLocation", data, check_response)
+
+
+class RedisClusterIsolationTest(TestBase, unittest.TestCase):
+    CLUSTER_A = "redis_it_cluster_a"
+    CLUSTER_B = "redis_it_cluster_b"
+    CLUSTERS = (CLUSTER_A, CLUSTER_B)
+    CLUSTER_WORKERS = {
+        CLUSTER_A: (0, 1),
+        CLUSTER_B: (2, 3),
+    }
+
+    def setUp(self):
+        logging.basicConfig(level=logging.INFO)
+        self.clean_workdir()
+        self._redis = RedisServer(self.get_workdir())
+        self.addCleanup(self._redis.stop)
+        self._redis.start()
+        self.prepare_test_resource(4, work_dir=self.get_workdir())
+        self.addCleanup(self.stop_worker)
+        self._startup_configs = self._write_startup_configs()
+        self.start_worker()
+
+    def start_worker(self, **kwargs):
+        for cluster in self.CLUSTERS:
+            for node_idx, worker_id in enumerate(self.CLUSTER_WORKERS[cluster]):
+                worker_kwargs = dict(kwargs)
+                worker_kwargs.update({
+                    "kvcm.registry_storage.uri": self._shell_arg(self._cluster_redis_uri(cluster)),
+                    "kvcm.coordination.uri": self._shell_arg(self._cluster_redis_uri(cluster)),
+                    "kvcm.leader_elector.node_id": f"{cluster}_node_{node_idx}",
+                    "kvcm.leader_elector.lease_ms": 5000,
+                    "kvcm.leader_elector.loop_interval_ms": 100,
+                    "kvcm.service.advertised_host": "127.0.0.1",
+                    "kvcm.service.custom_info": f"{cluster}-worker-{node_idx}",
+                    "kvcm.startup_config": self._shell_arg(self._startup_configs[cluster]),
+                })
+                self.assertTrue(self.worker_manager.start_worker(worker_id, **worker_kwargs))
+
+    def test_two_clusters_share_one_redis_and_stay_isolated(self):
+        admin_clients = {i: self._admin_client(i) for i in range(4)}
+        meta_clients = {i: self._meta_client(i) for i in range(4)}
+        for client in list(admin_clients.values()) + list(meta_clients.values()):
+            self.addCleanup(client.close)
+
+        leaders = {}
+        for cluster in self.CLUSTERS:
+            leaders[cluster] = self._wait_for_cluster_leader(cluster, admin_clients)
+            self._assert_cluster_info(cluster, leaders[cluster], admin_clients)
+
+        written_instances = []
+        for cluster in self.CLUSTERS:
+            leader_id = leaders[cluster]
+            admin_client = admin_clients[leader_id]
+            meta_client = meta_clients[leader_id]
+
+            self._wait_for_instance_group(admin_client, self._group_name(cluster, 0))
+            self._create_instance_group(admin_client, cluster, 1)
+
+            for group_idx in (0, 1):
+                instance_id = self._instance_id(cluster, group_idx)
+                self._write_cache_meta(meta_client, instance_id, self._group_name(cluster, group_idx), group_idx)
+                written_instances.append(instance_id)
+
+        self._assert_redis_key_isolation(written_instances)
+
+    def test_leader_demote_only_affects_its_cluster(self):
+        admin_clients = {i: self._admin_client(i) for i in range(4)}
+        for client in admin_clients.values():
+            self.addCleanup(client.close)
+
+        leader_a = self._wait_for_cluster_leader(self.CLUSTER_A, admin_clients)
+        leader_b = self._wait_for_cluster_leader(self.CLUSTER_B, admin_clients)
+        follower_a = self._other_worker(self.CLUSTER_A, leader_a)
+
+        update_resp = admin_clients[leader_a].update_leader_elector_config({
+            "trace_id": "trace_demote_cluster_a_config",
+            "campaign_delay_time_ms": 10000,
+        })
+        self.assertEqual(update_resp["header"]["status"]["code"], "OK")
+
+        demote_resp = admin_clients[leader_a].leader_demote({
+            "trace_id": "trace_demote_cluster_a",
+        })
+        self.assertEqual(demote_resp["header"]["status"]["code"], "OK")
+
+        self._wait_for_cluster_leader(self.CLUSTER_A, admin_clients, expected_leader=follower_a)
+        self._assert_cluster_leader(self.CLUSTER_B, leader_b, admin_clients)
+
+        self.assertEqual(
+            self._node_id(self.CLUSTER_A, follower_a),
+            self._redis.command("GET", f"kvcm_{self.CLUSTER_A}_lock:_TAIR_KVCM_LEADER_KEY"),
+        )
+        self.assertEqual(
+            self._node_id(self.CLUSTER_B, leader_b),
+            self._redis.command("GET", f"kvcm_{self.CLUSTER_B}_lock:_TAIR_KVCM_LEADER_KEY"),
+        )
+
+    def _write_startup_configs(self):
+        result = {}
+        for cluster in self.CLUSTERS:
+            path = os.path.join(self.workdir, f"{cluster}_startup.json")
+            with open(path, "w") as f:
+                json.dump({
+                    "storage_config": self._storage_config(cluster),
+                    "instance_group": self._instance_group(cluster, 0),
+                }, f)
+            result[cluster] = path
+        return result
+
+    def _storage_config(self, cluster):
+        return {
+            "type": "file",
+            "global_unique_name": self._storage_name(cluster),
+            "storage_spec": {
+                "root_path": os.path.join(self.workdir, cluster, "nfs") + "/",
+                "key_count_per_file": 8,
+            },
+        }
+
+    def _instance_group(self, cluster, group_idx, for_admin=False):
+        return {
+            "name": self._group_name(cluster, group_idx),
+            "storage_candidates": [self._storage_name(cluster)],
+            "global_quota_group_name": f"{cluster}_quota_group",
+            "max_instance_count": 10,
+            "quota": {
+                "capacity": 30000000000,
+                "quota_config": [
+                    {
+                        "storage_type": 4 if for_admin else "file",
+                        "capacity": 30000000000,
+                    },
+                ],
+            },
+            "cache_config": {
+                "reclaim_strategy": {
+                    "storage_unique_name": self._storage_name(cluster),
+                    "reclaim_policy": 1,
+                    "trigger_strategy": {
+                        "used_percentage": 0.8,
+                    },
+                    "delay_before_delete_ms": 1000,
+                },
+                "data_storage_strategy" if for_admin else "cache_prefer_strategy": 2,
+                "meta_indexer_config": {
+                    "max_key_count": 1000000,
+                    "mutex_shard_num": 16,
+                    "batch_key_size": 16,
+                    "meta_storage_backend_config": {
+                        "storage_type": "redis",
+                        "storage_uri": self._redis.uri,
+                    },
+                    "meta_cache_policy_config": {
+                        "type": "LRU",
+                        "capacity": 10000,
+                        "cache_shard_bits": 0,
+                        "high_pri_pool_ratio": 0.0,
+                    },
+                },
+            },
+            "user_data": f"{cluster}-group-{group_idx}",
+            "version": 1,
+        }
+
+    def _create_instance_group(self, admin_client, cluster, group_idx):
+        resp = admin_client.create_instance_group({
+            "trace_id": f"trace_create_{cluster}_{group_idx}",
+            "instance_group": self._instance_group(cluster, group_idx, for_admin=True),
+        })
+        self.assertEqual(resp["header"]["status"]["code"], "OK")
+
+    def _write_cache_meta(self, meta_client, instance_id, instance_group, group_idx):
+        block_base = 100000 + group_idx * 1000 + (0 if self.CLUSTER_A in instance_id else 10000)
+        block_keys = [block_base, block_base + 1]
+        token_ids = [block_base + 10, block_base + 11]
+
+        register_resp = meta_client.register_instance({
+            "trace_id": f"trace_register_{instance_id}",
+            "instance_group": instance_group,
+            "instance_id": instance_id,
+            "block_size": 128,
+            "model_deployment": {
+                "model_name": f"{instance_id}_model",
+                "dtype": "FP16",
+                "use_mla": False,
+                "tp_size": 1,
+                "dp_size": 1,
+                "pp_size": 1,
+            },
+            "location_spec_infos": [
+                {
+                    "name": "tp0",
+                    "size": 1024,
+                },
+            ],
+        })
+        self.assertEqual(register_resp["header"]["status"]["code"], "OK")
+
+        start_resp = meta_client.start_write_cache({
+            "trace_id": f"trace_start_{instance_id}",
+            "instance_id": instance_id,
+            "block_keys": block_keys,
+            "token_ids": token_ids,
+            "write_timeout_seconds": 30,
+        })
+        self.assertIn("write_session_id", start_resp)
+        self.assertEqual(2, len(start_resp["locations"]))
+
+        finish_resp = meta_client.finish_write_cache({
+            "trace_id": f"trace_finish_{instance_id}",
+            "instance_id": instance_id,
+            "write_session_id": start_resp["write_session_id"],
+            "success_blocks": {
+                "bool_masks": {
+                    "values": [True, True],
+                },
+            },
+        })
+        self.assertEqual(finish_resp["header"]["status"]["code"], "OK")
+
+        location_resp = meta_client.get_cache_location({
+            "trace_id": f"trace_location_{instance_id}",
+            "query_type": "QT_PREFIX_MATCH",
+            "block_keys": block_keys,
+            "instance_id": instance_id,
+            "block_mask": {
+                "offset": 0,
+            },
+        })
+        self.assertEqual(2, len(location_resp["locations"]))
+
+    def _wait_for_cluster_leader(self, cluster, admin_clients, timeout=30, expected_leader=None):
+        worker_ids = self.CLUSTER_WORKERS[cluster]
+        deadline = time.time() + timeout
+        last_states = {}
+        while time.time() < deadline:
+            leaders = []
+            for worker_id in worker_ids:
+                try:
+                    resp = admin_clients[worker_id].check_health({
+                        "trace_id": f"trace_wait_{cluster}_{worker_id}_{int(time.time())}",
+                    }, check_response=False)
+                    last_states[worker_id] = resp
+                    if (resp.get("header", {}).get("status", {}).get("code") == "OK"
+                            and resp.get("is_health") is True
+                            and resp.get("is_leader") is True):
+                        leaders.append(worker_id)
+                except Exception as e:
+                    last_states[worker_id] = str(e)
+            if len(leaders) == 1 and (expected_leader is None or leaders[0] == expected_leader):
+                return leaders[0]
+            time.sleep(0.5)
+        self.fail(f"cluster {cluster} did not settle to exactly one leader, last states: {last_states}")
+
+    def _wait_for_instance_group(self, admin_client, group_name, timeout=30):
+        deadline = time.time() + timeout
+        last_resp = None
+        while time.time() < deadline:
+            last_resp = admin_client.get_instance_group({
+                "trace_id": f"trace_wait_group_{group_name}_{int(time.time())}",
+                "name": group_name,
+            }, check_response=False)
+            if last_resp.get("header", {}).get("status", {}).get("code") == "OK":
+                return
+            time.sleep(0.5)
+        self.fail(f"instance group {group_name} was not loaded, last response: {last_resp}")
+
+    def _assert_cluster_info(self, cluster, leader_id, admin_clients):
+        leader_client = admin_clients[leader_id]
+        cluster_resp = leader_client.get_manager_cluster_info({
+            "trace_id": f"trace_cluster_info_{cluster}",
+        })
+        self.assertEqual(cluster_resp["leader_node_id"], cluster_resp["self_node_id"])
+        leader_ep = cluster_resp["leader_endpoint"]
+        node_idx = self.CLUSTER_WORKERS[cluster].index(leader_id)
+        self.assertEqual(leader_ep["node_id"], f"{cluster}_node_{node_idx}")
+        self.assertEqual(leader_ep["host"], "127.0.0.1")
+        self.assertEqual(leader_ep["custom_info"], f"{cluster}-worker-{node_idx}")
+
+        follower_id = next(worker_id for worker_id in self.CLUSTER_WORKERS[cluster] if worker_id != leader_id)
+        follower_resp = admin_clients[follower_id].get_manager_cluster_info({
+            "trace_id": f"trace_follower_cluster_info_{cluster}",
+        })
+        self.assertEqual(follower_resp["leader_node_id"], cluster_resp["leader_node_id"])
+        self.assertEqual(follower_resp["leader_endpoint"]["admin_http_port"], leader_ep["admin_http_port"])
+
+    def _assert_cluster_leader(self, cluster, expected_leader_id, admin_clients):
+        for worker_id in self.CLUSTER_WORKERS[cluster]:
+            resp = admin_clients[worker_id].get_manager_cluster_info({
+                "trace_id": f"trace_assert_leader_{cluster}_{worker_id}",
+            })
+            self.assertEqual(resp["leader_node_id"], self._node_id(cluster, expected_leader_id))
+            self.assertEqual(resp["leader_endpoint"]["admin_http_port"],
+                             self.worker_manager.get_worker(expected_leader_id).env.admin_http_port)
+
+    def _assert_redis_key_isolation(self, written_instances):
+        all_keys = set(self._redis.keys("*"))
+        self.assertNotIn("kvcm_lock:_TAIR_KVCM_LEADER_KEY", all_keys)
+
+        for cluster in self.CLUSTERS:
+            registry_prefix = f"kvcache_registry:{cluster}:"
+            self.assertIn(registry_prefix + "storage", all_keys)
+            self.assertIn(registry_prefix + "instance_group", all_keys)
+            self.assertIn(registry_prefix + "instance", all_keys)
+            self.assertIn(f"kvcm_{cluster}_lock:_TAIR_KVCM_LEADER_KEY", all_keys)
+            self.assertEqual(2, len(self._redis.keys(f"kvcm_{cluster}_kv:_TAIR_KVCM_NODE_INFO_*")))
+
+            group_fields = self._redis.hgetall(registry_prefix + "instance_group")
+            self.assertEqual({
+                self._group_name(cluster, 0),
+                self._group_name(cluster, 1),
+            }, set(group_fields.keys()))
+
+            instance_fields = self._redis.hgetall(registry_prefix + "instance")
+            expected_instances = {
+                self._instance_id(cluster, 0),
+                self._instance_id(cluster, 1),
+            }
+            self.assertTrue(expected_instances.issubset(set(instance_fields.keys())))
+
+        for instance_id in written_instances:
+            cache_keys = self._redis.keys(f"kvcache:instance_{instance_id}:cache_*")
+            self.assertGreaterEqual(len(cache_keys), 2)
+
+        a_groups = self._redis.hgetall(f"kvcache_registry:{self.CLUSTER_A}:instance_group")
+        b_groups = self._redis.hgetall(f"kvcache_registry:{self.CLUSTER_B}:instance_group")
+        self.assertTrue(all(name.startswith(self.CLUSTER_A) for name in a_groups.keys()))
+        self.assertTrue(all(name.startswith(self.CLUSTER_B) for name in b_groups.keys()))
+
+    def _admin_client(self, worker_id):
+        worker = self.worker_manager.get_worker(worker_id)
+        return KVCMHttpClient(f"http://localhost:{worker.env.admin_http_port}")
+
+    def _meta_client(self, worker_id):
+        worker = self.worker_manager.get_worker(worker_id)
+        return KVCMHttpClient(f"http://localhost:{worker.env.http_port}")
+
+    def _cluster_redis_uri(self, cluster):
+        return f"{self._redis.uri}?cluster_name={cluster}"
+
+    def _node_id(self, cluster, worker_id):
+        node_idx = self.CLUSTER_WORKERS[cluster].index(worker_id)
+        return f"{cluster}_node_{node_idx}"
+
+    def _other_worker(self, cluster, worker_id):
+        return next(candidate for candidate in self.CLUSTER_WORKERS[cluster] if candidate != worker_id)
+
+    @staticmethod
+    def _shell_arg(value):
+        return "'" + str(value).replace("'", "'\\''") + "'"
+
+    @staticmethod
+    def _storage_name(cluster):
+        return f"{cluster}_nfs"
+
+    @staticmethod
+    def _group_name(cluster, group_idx):
+        return f"{cluster}_group_{group_idx}"
+
+    @staticmethod
+    def _instance_id(cluster, group_idx):
+        return f"{cluster}_group_{group_idx}_instance"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration_test/testlib/BUILD
+++ b/integration_test/testlib/BUILD
@@ -6,6 +6,7 @@ py_library(
         "__init__.py",
         "module_base.py",
         "ranged_port_util.py",
+        "redis_server.py",
         "test_base.py",
         "worker.py",
         "worker_manager.py",

--- a/integration_test/testlib/redis_server.py
+++ b/integration_test/testlib/redis_server.py
@@ -1,0 +1,129 @@
+import os
+import shutil
+import socket
+import subprocess
+import time
+
+
+class RedisServer(object):
+    def __init__(self, workdir):
+        self.workdir = workdir
+        self.port_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.port_socket.bind(("127.0.0.1", 0))
+        self.port = self.port_socket.getsockname()[1]
+        self.process = None
+        self.stdout = None
+        self.stderr = None
+
+    @property
+    def uri(self):
+        return f"redis://127.0.0.1:{self.port}/"
+
+    def start(self):
+        redis_server = os.environ.get("REDIS_SERVER_BIN") or shutil.which("redis-server")
+        if redis_server is None:
+            raise RuntimeError("redis-server is required for this integration test; set REDIS_SERVER_BIN or PATH")
+
+        redis_dir = os.path.join(self.workdir, "redis")
+        os.makedirs(redis_dir, exist_ok=True)
+        conf_path = os.path.join(redis_dir, "redis.conf")
+        with open(conf_path, "w") as f:
+            f.write("\n".join([
+                f"port {self.port}",
+                "bind 127.0.0.1",
+                "protected-mode no",
+                "save \"\"",
+                "appendonly no",
+                "daemonize no",
+                f"dir {redis_dir}",
+                "loglevel warning",
+                "",
+            ]))
+
+        self.port_socket.close()
+        self.port_socket = None
+        self.stdout = open(os.path.join(redis_dir, "stdout"), "w")
+        self.stderr = open(os.path.join(redis_dir, "stderr"), "w")
+        self.process = subprocess.Popen([redis_server, conf_path], stdout=self.stdout, stderr=self.stderr)
+        self._wait_until_ready()
+        self.command("FLUSHALL")
+
+    def stop(self):
+        if self.process is not None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+            self.process = None
+        if self.stdout is not None:
+            self.stdout.close()
+            self.stdout = None
+        if self.stderr is not None:
+            self.stderr.close()
+            self.stderr = None
+        if self.port_socket is not None:
+            self.port_socket.close()
+            self.port_socket = None
+
+    def _wait_until_ready(self):
+        deadline = time.time() + 10
+        last_error = None
+        while time.time() < deadline:
+            try:
+                if self.command("PING") == "PONG":
+                    return
+            except Exception as e:
+                last_error = e
+                time.sleep(0.1)
+        raise RuntimeError(f"redis-server did not become ready: {last_error}")
+
+    def command(self, *args):
+        with socket.create_connection(("127.0.0.1", self.port), timeout=2) as sock:
+            payload = self._encode(args)
+            sock.sendall(payload)
+            reader = sock.makefile("rb")
+            return self._read_reply(reader)
+
+    def keys(self, pattern):
+        result = self.command("KEYS", pattern)
+        return sorted(result or [])
+
+    def hgetall(self, key):
+        result = self.command("HGETALL", key)
+        if not result:
+            return {}
+        return dict(zip(result[0::2], result[1::2]))
+
+    @staticmethod
+    def _encode(args):
+        parts = [f"*{len(args)}\r\n".encode()]
+        for arg in args:
+            value = str(arg).encode()
+            parts.append(f"${len(value)}\r\n".encode())
+            parts.append(value)
+            parts.append(b"\r\n")
+        return b"".join(parts)
+
+    def _read_reply(self, reader):
+        prefix = reader.read(1)
+        if prefix == b"+":
+            return reader.readline().rstrip(b"\r\n").decode()
+        if prefix == b"-":
+            raise RuntimeError(reader.readline().rstrip(b"\r\n").decode())
+        if prefix == b":":
+            return int(reader.readline().rstrip(b"\r\n"))
+        if prefix == b"$":
+            length = int(reader.readline().rstrip(b"\r\n"))
+            if length < 0:
+                return None
+            data = reader.read(length)
+            reader.read(2)
+            return data.decode()
+        if prefix == b"*":
+            length = int(reader.readline().rstrip(b"\r\n"))
+            if length < 0:
+                return None
+            return [self._read_reply(reader) for _ in range(length)]
+        raise RuntimeError(f"unknown redis reply prefix: {prefix!r}")

--- a/kv_cache_manager/config/coordination_redis_backend.cc
+++ b/kv_cache_manager/config/coordination_redis_backend.cc
@@ -85,6 +85,8 @@ ErrorCode CoordinationRedisBackend::Init(const StandardUri &standard_uri) noexce
 
     // 从URI参数中获取cluster_name，用于多KVCM实例共享同一Redis时的key隔离
     std::string cluster_name = standard_uri.GetParam("cluster_name");
+    // TODO: 下次做带迁移方案的Redis key重构时，改成 kvcm_lock:<cluster_name>: / kvcm_kv:<cluster_name>: 格式。
+    // 目前保留 kvcm_<cluster_name>_lock: / kvcm_<cluster_name>_kv:，避免升级时读写到新key空间。
     std::string base_prefix = "kvcm_";
     if (!cluster_name.empty()) {
         base_prefix += cluster_name + "_";

--- a/kv_cache_manager/config/test/BUILD
+++ b/kv_cache_manager/config/test/BUILD
@@ -116,6 +116,20 @@ cc_test(
 )
 
 cc_test(
+    name = "coordination_redis_backend_prefix_test",
+    srcs = [
+        "coordination_redis_backend_prefix_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:standard_uri",
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/config:coordination_backend",
+    ],
+)
+
+cc_test(
     name = "coordination_redis_backend_unit_test",
     srcs = [
         "coordination_redis_backend_unit_test.cc",

--- a/kv_cache_manager/config/test/coordination_redis_backend_prefix_test.cc
+++ b/kv_cache_manager/config/test/coordination_redis_backend_prefix_test.cc
@@ -1,0 +1,144 @@
+#include "kv_cache_manager/config/coordination_redis_backend.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/redis_client_ext.h"
+#include "kv_cache_manager/common/standard_uri.h"
+#include "kv_cache_manager/common/unittest.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+StandardUri RedisUriWithParams(const std::string &params) {
+    return StandardUri::FromUri("redis://localhost:6379/?" + params);
+}
+
+class PrefixRedisClient : public RedisClientExt {
+public:
+    using RedisClientExt::RedisClientExt;
+
+protected:
+    bool IsContextOk() const override { return true; }
+    bool Reconnect() override { return true; }
+
+    std::vector<ReplyUPtr> TryExecPipeline(const std::vector<CmdArgs> &cmds) override {
+        std::vector<ReplyUPtr> replies;
+        replies.reserve(cmds.size());
+        for (const auto &cmd : cmds) {
+            if (cmd.size() >= 2 && cmd[0] == "SCRIPT" && cmd[1] == "LOAD") {
+                replies.emplace_back(MakeStringReply("fake_script_sha1"));
+            } else {
+                replies.emplace_back(MakeStringReply("OK"));
+            }
+        }
+        return replies;
+    }
+
+private:
+    static ReplyUPtr MakeStringReply(const std::string &value) {
+        auto *reply = static_cast<redisReply *>(std::malloc(sizeof(redisReply)));
+        std::memset(reply, 0, sizeof(redisReply));
+        reply->type = REDIS_REPLY_STRING;
+        reply->len = value.size();
+        reply->str = static_cast<char *>(std::malloc(value.size() + 1));
+        std::memcpy(reply->str, value.data(), value.size());
+        reply->str[value.size()] = '\0';
+        return ReplyUPtr(reply, freeReplyObject);
+    }
+};
+
+class TestCoordinationRedisBackend : public CoordinationRedisBackend {
+protected:
+    std::shared_ptr<RedisClientExt> CreateRedisClient(const StandardUri &storage_uri) const override {
+        return std::make_shared<PrefixRedisClient>(storage_uri);
+    }
+};
+
+ErrorCode InitBackend(CoordinationRedisBackend &backend, const StandardUri &uri) { return backend.Init(uri); }
+
+} // namespace
+
+TEST(CoordinationRedisBackendPrefixTest, InitUsesLegacyPrefixWhenClusterNameIsMissing) {
+    TestCoordinationRedisBackend backend;
+    ASSERT_EQ(EC_OK, InitBackend(backend, RedisUriWithParams("timeout_ms=1000")));
+
+    EXPECT_EQ("kvcm_lock:leader", backend.GetRedisLockKey("leader"));
+    EXPECT_EQ("kvcm_kv:node_endpoint", backend.GetRedisKVKey("node_endpoint"));
+}
+
+TEST(CoordinationRedisBackendPrefixTest, InitUsesLegacyPrefixWhenClusterNameIsEmpty) {
+    TestCoordinationRedisBackend backend;
+    ASSERT_EQ(EC_OK, InitBackend(backend, RedisUriWithParams("cluster_name=")));
+
+    EXPECT_EQ("kvcm_lock:leader", backend.GetRedisLockKey("leader"));
+    EXPECT_EQ("kvcm_kv:node_endpoint", backend.GetRedisKVKey("node_endpoint"));
+}
+
+TEST(CoordinationRedisBackendPrefixTest, InitScopesGeneratedKeysByClusterName) {
+    TestCoordinationRedisBackend backend;
+    ASSERT_EQ(EC_OK, InitBackend(backend, RedisUriWithParams("cluster_name=test_cluster")));
+
+    EXPECT_EQ("kvcm_test_cluster_lock:leader", backend.GetRedisLockKey("leader"));
+    EXPECT_EQ("kvcm_test_cluster_kv:node_endpoint/127.0.0.1:6381",
+              backend.GetRedisKVKey("node_endpoint/127.0.0.1:6381"));
+}
+
+TEST(CoordinationRedisBackendPrefixTest, OtherRedisParamsDoNotAffectClusterScope) {
+    TestCoordinationRedisBackend backend;
+    ASSERT_EQ(EC_OK,
+              InitBackend(backend, RedisUriWithParams("timeout_ms=1000&retry_count=3&db=2&cluster_name=test_cluster")));
+
+    EXPECT_EQ("kvcm_test_cluster_lock:leader", backend.GetRedisLockKey("leader"));
+    EXPECT_EQ("kvcm_test_cluster_kv:leader", backend.GetRedisKVKey("leader"));
+}
+
+TEST(CoordinationRedisBackendPrefixTest, LockAndKVKeysAreSeparatedWithinSameCluster) {
+    TestCoordinationRedisBackend backend;
+    ASSERT_EQ(EC_OK, InitBackend(backend, RedisUriWithParams("cluster_name=test_cluster")));
+
+    EXPECT_NE(backend.GetRedisLockKey("leader"), backend.GetRedisKVKey("leader"));
+    EXPECT_EQ("kvcm_test_cluster_lock:leader", backend.GetRedisLockKey("leader"));
+    EXPECT_EQ("kvcm_test_cluster_kv:leader", backend.GetRedisKVKey("leader"));
+}
+
+TEST(CoordinationRedisBackendPrefixTest, LogicalKeysAreAppendedWithoutMutation) {
+    TestCoordinationRedisBackend backend;
+    ASSERT_EQ(EC_OK, InitBackend(backend, RedisUriWithParams("cluster_name=test_cluster")));
+
+    EXPECT_EQ("kvcm_test_cluster_lock:model/a/b:0", backend.GetRedisLockKey("model/a/b:0"));
+    EXPECT_EQ("kvcm_test_cluster_kv:node_endpoint/10.0.0.1:6381",
+              backend.GetRedisKVKey("node_endpoint/10.0.0.1:6381"));
+}
+
+TEST(CoordinationRedisBackendPrefixTest, DifferentClustersGenerateDifferentRedisKeysForSameLogicalKey) {
+    TestCoordinationRedisBackend first;
+    TestCoordinationRedisBackend second;
+    ASSERT_EQ(EC_OK, InitBackend(first, RedisUriWithParams("cluster_name=cluster_a")));
+    ASSERT_EQ(EC_OK, InitBackend(second, RedisUriWithParams("cluster_name=cluster_b")));
+
+    EXPECT_NE(first.GetRedisLockKey("leader"), second.GetRedisLockKey("leader"));
+    EXPECT_NE(first.GetRedisKVKey("node_endpoint"), second.GetRedisKVKey("node_endpoint"));
+    EXPECT_EQ("kvcm_cluster_a_lock:leader", first.GetRedisLockKey("leader"));
+    EXPECT_EQ("kvcm_cluster_b_lock:leader", second.GetRedisLockKey("leader"));
+}
+
+TEST(CoordinationRedisBackendPrefixTest, SameClusterNameGeneratesSameScopeAcrossDifferentRedisUris) {
+    TestCoordinationRedisBackend first;
+    TestCoordinationRedisBackend second;
+    StandardUri first_uri = StandardUri::FromUri(
+        "redis://user:pwd@redis-a:6379/?timeout_ms=1000&cluster_name=test_cluster");
+    StandardUri second_uri = StandardUri::FromUri(
+        "redis://redis-b:6380/?db=3&retry_count=5&cluster_name=test_cluster");
+    ASSERT_EQ(EC_OK, InitBackend(first, first_uri));
+    ASSERT_EQ(EC_OK, InitBackend(second, second_uri));
+
+    EXPECT_EQ(first.GetRedisLockKey("leader"), second.GetRedisLockKey("leader"));
+    EXPECT_EQ(first.GetRedisKVKey("node_endpoint"), second.GetRedisKVKey("node_endpoint"));
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -54,7 +54,10 @@ bool Server::Init(const ServerConfig &config) {
 
     auto registry_storage_uri = config_.GetRegistryStorageUri();
     registry_manager_.reset(new RegistryManager(registry_storage_uri, metrics_registry_));
-    registry_manager_->Init();
+    if (!registry_manager_->Init()) {
+        KVCM_LOG_ERROR("registry manager init failed");
+        return false;
+    }
 
     cache_manager_.reset(new CacheManager(metrics_registry_, registry_manager_, metrics_lifecycle_));
     cache_manager_->Init(config_.GetSchedulePlanExecutorThreadCount(),

--- a/package/etc/default_server_config.conf
+++ b/package/etc/default_server_config.conf
@@ -13,8 +13,9 @@
 # 指定本系统自身的数据存储位置
 # kvcm.registry_storage.uri=redis://127.0.0.1:6379?auth=123456
 
-# 指定分布式锁服务的URI。仅单节点的部署模式下可以不设置或置空。
-# kvcm.distributed_lock.uri=redis://127.0.0.1:6379?auth=123456
+# 指定协调后端服务的URI（用于多节点选主、节点信息存储等）。Redis选主key按cluster_name隔离。
+# kvcm.coordination.uri=redis://127.0.0.1:6379?auth=123456&cluster_name=kvcm_app_0
+# 旧配置 kvcm.distributed_lock.uri 仍可使用（向后兼容），但新配置优先
 
 # 指定选主时当前节点使用的node_id（如果不指定会自动生成）
 # kvcm.leader_elector.node_id=node_0


### PR DESCRIPTION
## Summary

This PR isolates Redis keys used by distributed leader election so multiple KVCacheManager clusters can share one large Redis instance without election key collisions. Registry storage behavior is left unchanged.

Changes:
- Namespace Redis coordination lock/KV keys by `cluster_name`.
- Keep legacy coordination key prefixes when `cluster_name` is not configured, while logging a warning.
- Fail server startup when registry initialization fails.
- Add unit coverage for coordination Redis key generation and edge cases.
- Add manual real-Redis integration coverage that starts four KVCM workers as two clusters, elects one leader per cluster, creates two instance_groups per cluster, writes registry entries, writes CacheMeta, verifies Redis key isolation, and verifies demoting one cluster's leader does not disturb the other cluster.

## Key layout

- Leader lock: `kvcm_<cluster_name>_lock:<lock_key>`
- Coordination KV: `kvcm_<cluster_name>_kv:<key>`

Registry keys already include cluster identity through the existing registry backend layout; this PR does not change registry key format.

## Validation

Local:

```bash
python3 -m py_compile integration_test/testlib/redis_server.py integration_test/redis_coordination/redis_cluster_isolation_test.py
git diff --check
```

On `11.122.133.161`, `screen -x qisa`, window 2, at commit `ee78cb4`:

```bash
bazelisk test --config=debug --config=asan --test_output=errors \
  --test_env ASAN_OPTIONS=detect_odr_violation=0 \
  --test_env PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
  //integration_test/redis_coordination:redis_cluster_isolation_test \
  //kv_cache_manager/config/test:coordination_redis_backend_prefix_test
```

Result:

```text
//integration_test/redis_coordination:redis_cluster_isolation_test       PASSED in 21.6s
//kv_cache_manager/config/test:coordination_redis_backend_prefix_test    PASSED in 0.0s

Executed 2 out of 2 tests: 2 tests pass.
```
