### PR TITLE
[manager] make CacheReclaimer deletion asynchronous and prevent over-eviction

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [模块架构与关联关系](design/module_architecture.md) - 各模块职责、依赖方向、控制流与数据流，附 Mermaid 图
 - [基本概念](design/basic_concepts.md) - Storage、Instance Group、Instance、Block、CacheLocation 等核心概念
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
+- [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
 
 ### 开发文档
 - [开发指南](develop/README.md) - 开发者入门指南和开发环境配置

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,9 @@ Example:
 
 ## KVCacheManager Server Config
 
-KVCM server可识别的配置参数列表如下。可通过配置文件、启动参数--env、系统环境变量进行配置：
+KVCM server可识别的配置参数列表如下。可通过配置文件、启动参数--env、系统环境变量进行配置。
+CacheReclaimer 异步删除相关参数的生命周期语义见
+[CacheReclaimer 异步删除与过度逐出优化设计](design/cache_reclaimer_async_delete.md)。
 
 ```TEXT
 ## 参数配置方式有3种，相同配置按照从前往后的覆盖关系（后覆盖前）
@@ -76,6 +78,18 @@ kvcm.service.enable_debug_service=false
 
 # 指定KVCache Manager初始配置JSON文件路径
 kvcm.startup_config=package/etc/default_startup_config.json
+
+# CacheReclaimer 删除 Future 在 delay 结束后可继续抵扣水位的最长时间；到期只关闭 credit，
+# 不取消底层删除。默认 60000ms。
+kvcm.cache_reclaimer.inflight_delete_timeout_ms=60000
+
+# 单个 Instance Group × BaseStorageType 的未完成 Location 数和 bytes 上限。
+kvcm.cache_reclaimer.pending_location_limit_per_group_type=100000
+kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
+
+# 进程级未完成删除请求数和 bytes 上限。Future 终态前始终占用配额，credit 到期不返还。
+kvcm.cache_reclaimer.pending_delete_handler_limit=1024
+kvcm.cache_reclaimer.pending_bytes_limit=274877906944
 
 # 可选值有dummy，local，logging，kmonitor；若不配置，默认启用logging
 kvcm.metrics.reporter_type

--- a/docs/design/cache_reclaimer_async_delete.md
+++ b/docs/design/cache_reclaimer_async_delete.md
@@ -1,0 +1,427 @@
+# CacheReclaimer 异步删除与过度逐出优化设计
+
+| 项目 | 内容 |
+|---|---|
+| 状态 | V1 已实现，包含 `CacheMetaDelRequest` 异步接口；未来扩展未纳入 |
+| 更新时间 | 2026-07-17 |
+| 涉及模块 | `manager`、`meta`、`metrics`、`service` |
+| 关联需求 | [CacheReclaimer 过度逐出优化](https://project.aone.alibaba-inc.com/v2/project/2137612/req/74289896)、[Reclaimer 删除请求提交异步化改造](https://project.aone.alibaba-inc.com/v2/project/2137612/req/80484236) |
+| 历史参考 | [PR #161](https://github.com/alibaba/tair-kvcache/pull/161) |
+
+本文档描述当前 V1 的行为契约和设计边界。历史实现与 PR 仅作为背景，实际行为以本文档及主干代码为准。
+
+## 1. 背景
+
+改造前，一次 Reclaimer 删除包含以下步骤：
+
+1. 采样并选择待逐出的 block 和 Location。
+2. `SchedulePlanExecutor::Submit` 同步读取 Location 元数据。
+3. 同步 CAS，将 Location 更新为 `CLS_DELETING`，并等待 `MetaIndexer::Sync`。
+4. 等待 `delay_before_delete_ms`。
+5. 异步执行存储删除和 Location 元数据删除。
+6. Reclaimer 轮询 Future，处理最终结果。
+
+原有流程有两个直接问题：
+
+- Get、CAS 和 Sync 可能访问远端 Redis，会阻塞 Reclaimer cron 线程。
+- 延迟删除期间正式 usage 和 key count 尚未下降，Reclaimer 会继续选择其他 victim，造成过度逐出。
+
+提交异步化后还会增加一个窗口：请求已经进入 Executor，但 CAS 尚未完成，元数据仍是
+`CLS_SERVING`，同一 Location 可能被下一轮再次选择。
+
+`delay_before_delete_ms` 是类似租约的安全窗口，用于让已经拿到 URI 的 client 完成读写。本设计保留该
+语义，不缩短等待时间。
+
+## 2. 设计范围
+
+### 2.1 V1 目标
+
+V1 只实现以下六项能力：
+
+1. **端到端异步提交**：Get、CAS、Sync 和物理删除在 Executor 中执行，Reclaimer 立即拿到最终 Future。
+2. **Pending Location 去重**：本地记录已经接受但尚未完成的 Location，封住“入队到 CAS”窗口。
+3. **in-flight 水位 credit**：按 Instance Group 和 Storage Type 记录已提交删除 bytes，并保守记录预计完全删除的 key 数。
+4. **Future 生命周期与 credit deadline**：Future 终态后释放临时状态；长期未完成时停止抵扣水位，但继续保留 pending。
+5. **有界反压**：限制 pending Location、bytes 和请求数量，防止 Executor 或后端异常时无限提交。
+6. **无进展退避**：水位超限但没有实际接受删除请求时，ReclaimCron 必须休眠，不能零间隔空转。
+
+所有本地标识和计数都保持严格的 Instance 隔离。
+
+在上述六项 Reclaimer 能力之外，`SchedulePlanExecutor` 同步补齐
+`CacheMetaDelRequest` 的端到端异步提交接口。该接口与 Reclaimer 使用的
+`CacheLocationDelRequest` 复用相同的 Admission、延迟物理删除和 Future 收敛链路，但本次不迁移
+`ReclaimerTaskSupervisor`、`RemoveCache` 或 `TrimCache` 等现有同步调用方。
+
+### 2.2 V1 非目标
+
+以下能力不进入 V1，实现方向见第 11 节：
+
+1. 卡死任务的自动元数据复核和 pending 自恢复。
+2. CAS 后失败的回滚、重试或完整删除状态机。
+3. 按 Storage Type 拆分请求、线程池或物理执行资源的严格故障隔离。
+4. leader/instance generation、主备切换时的任务取消和跨 epoch drain。
+5. 持久化删除任务和跨进程 exactly-once。
+6. StorageBackend 底层 I/O 的强制 timeout 和取消。
+7. 多层存储迁移能力，包括 migration、copy 和 drain 语义。
+8. LRU/LFU/TTL victim 排序算法调整。
+
+文中的正式 usage 是 `MetaIndexer` 维护的逻辑用量，不代表存储后端实时磁盘占用。
+
+## 3. V1 总体方案
+
+```mermaid
+flowchart LR
+    R[CacheReclaimer] -->|SubmitAsync| E[SchedulePlanExecutor]
+    E --> M[Get / CAS DELETING / Sync]
+    M -->|delay after Sync| D[Physical Delete]
+    D --> C[CAD Location / Update Usage]
+    C -->|one end-to-end Future| R
+    R --> P[Pending Location / in-flight credit]
+```
+
+一次删除在业务上仍是一个统一任务，只有一个最终 Future。Admission 和 Physical Delete 是 Executor
+内部的两个步骤，V1 不在 Reclaimer 中引入显式状态机。
+
+## 4. V1 详细设计
+
+### 4.1 端到端异步提交
+
+新增显式异步接口，保留现有同步 `Submit` 兼容其他调用方：
+
+```cpp
+struct AsyncDeleteSubmitResult {
+    bool accepted;
+    std::future<PlanExecuteResult> future;
+};
+
+AsyncDeleteSubmitResult
+SchedulePlanExecutor::SubmitAsync(const CacheLocationDelRequest &request);
+
+AsyncDeleteSubmitResult
+SchedulePlanExecutor::SubmitAsync(const CacheMetaDelRequest &request);
+```
+
+执行流程如下：
+
+1. 创建共享 promise 和最终 Future。
+2. 将 Get、CAS 和 Sync 放入 Executor 队列，成功入队后立即返回 `accepted=true`。
+3. 只把实际 CAS 成功的 Location 放入物理删除任务。
+4. 从 Sync 成功时刻开始计算 `delay_before_delete_ms`。
+5. 延迟到期后执行物理删除和最终 CAD。
+6. 任一步骤成功、失败或抛出异常，都通过统一完成函数设置最终 promise。
+
+统一完成函数必须保证 exactly-once，避免异常逃出 worker 后留下永远不 ready 的 Future。延迟等待使用
+定时队列，不占用 worker。Admission 和 Physical Delete 共用现有 Executor 并发，V1 不拆分线程池。
+
+首次入队失败返回 `accepted=false` 和无效 Future，Reclaimer 不建立任何 pending、credit 或
+`DeleteHandler`。现有 `SubmitNonBlocking` 不满足这一契约，因为它不会向调用方返回内部 Future。
+
+#### 4.1.1 两类请求的选择语义
+
+两类异步请求只在 Location selection 阶段分叉：
+
+- `CacheLocationDelRequest` 只选择请求中明确指定的 `location_id`。
+- `CacheMetaDelRequest` 选择请求中各 block 的全部有效 Location。
+
+两类请求都跳过不存在或已经处于 `CLS_DELETING` 的 Location。已进入 `CLS_DELETING` 表示删除意图
+已经建立，再次提交时必须视为幂等 no-op，不能重复安排物理删除。这个语义与历史同步
+`Submit(const CacheMetaDelRequest &)` 可能重新处理 `CLS_DELETING` 的行为不同；本次只约束新增异步
+接口，不借此重构或改变旧同步接口。
+
+#### 4.1.2 公共 Admission 流程
+
+两类 Prepare 只负责请求校验、读取元数据和生成 CAS plan，后续步骤必须共用同一实现：
+
+```text
+PrepareDeleteTask(Meta / Location)
+    -> select locations and build CAS plan
+    -> BatchCASLocationStatus
+    -> FillActualTask
+    -> MetaIndexer::Sync
+    -> LocationDelAdmissionResult
+```
+
+公共 CAS/Fill/Sync 函数复用 Prepare 阶段已经取得的 `MetaIndexer`，不得为执行公共尾部再次查询
+Indexer。只有实际 CAS 成功的 Location 才进入 `actual_task`；没有可删除 Location 时，Admission
+直接以成功完成 Future，不提交空的物理删除任务。
+
+Admission runner 接收 prepare callback，并统一负责：
+
+1. 捕获 Prepare、CAS、Fill 和 Sync 的所有异常。
+2. 根据 `LocationDelAdmissionResult` 判断直接完成或二次提交物理删除任务。
+3. 从 Sync 成功后开始定时延迟，并通过现有定时队列等待。
+4. 为物理删除任务注册 Executor shutdown cancel callback。
+5. 处理二次入队失败、物理删除异常和 Executor 关闭。
+6. 所有路径只通过共享的 `PromiseCompletion` 收敛端到端 Future。
+
+不能为 Meta 和 Location 分别复制二次 `SubmitRaw`、cancel callback 或异常收敛逻辑；这些路径是
+exactly-once 契约的一部分，必须保持单一实现。首次 Admission 已成功入队、但尚未执行时，如果
+Executor 停止并清理队列，其 cancel callback 必须把最终 Future 收敛为明确失败。
+
+#### 4.1.3 调用方边界
+
+新增 `SubmitAsync(const CacheMetaDelRequest &)` 只补齐 Executor 的异步能力和两类删除请求的接口
+对称性。本次不把 `ReclaimerTaskSupervisor`、`CacheManager::RemoveCache` 或
+`CacheManager::TrimCache` 切换到该接口，因此不能据此认为这些调用链的元数据同步阻塞已经解除。
+
+调用方迁移需要另外评估 Supervisor 队列的有界准入、并发量和任务生命周期，避免把原有同步节流
+转换为无界 Future 堆积，不属于本次改动范围。
+
+### 4.2 Pending Location 去重
+
+本地唯一标识必须包含 `instance_id`：
+
+```cpp
+struct PendingLocationKey {
+    std::string instance_id;
+    int64_t block_key;
+    std::string location_id;
+};
+```
+
+`FilterLocID` 在原有状态判断之外排除 `pending_locations`。不能只使用 block key 或 location id，
+否则会影响其他 Instance。
+
+提交顺序固定为：
+
+1. 过滤已有 pending 和达到硬上限的 Location。
+2. 生成非空删除请求并计算 credit。
+3. 调用 `SubmitAsync`。
+4. 仅当 `accepted=true` 时，立即写入 pending、credit 和 `DeleteHandler`。
+5. `accepted=false` 时不修改任何本地计数。
+
+这些操作都由 Reclaimer cron 线程串行完成，因此下一轮 Reclaim 不会插入 accepted 与本地记账之间。
+
+### 4.3 in-flight 水位 credit
+
+扩展现有 `DeleteHandler`，不新增 operation 对象或状态枚举。其逻辑字段包括：
+
+```cpp
+struct DeleteHandler {
+    std::shared_ptr<RequestContext> request_context;
+    std::string instance_id;
+    std::string instance_group;
+
+    std::vector<PendingLocationKey> pending_locations;
+    BytesByStorageType bytes_by_type;
+    uint64_t predicted_deleted_keys;
+
+    std::chrono::steady_clock::time_point submitted_at;
+    std::chrono::steady_clock::time_point credit_deadline;
+    bool credit_enabled;
+
+    std::future<PlanExecuteResult> future;
+};
+```
+
+bytes 必须与正式 storage usage 使用相同口径：遍历 Location 的 `location_specs`，解析合法 URI 的
+`size`，并按 `ToBaseType(location.type())` 聚合；`VCNS_HF3FS` 必须归一到 `HF3FS`。无法得到
+size 的 Location 按 0 bytes 记账，但仍加入 pending 并受数量上限保护。
+
+只有本次请求覆盖某个 block 的全部有效 Location 时，才增加一个 `predicted_deleted_keys`。V1 不跨
+多个 `DeleteHandler` 合并推断，允许保守少计。
+
+水位判断改为：
+
+```text
+effective_group_bytes =
+    saturating_sub(official_group_bytes, credited_group_bytes)
+
+effective_type_bytes[type] =
+    saturating_sub(official_type_bytes[type], credited_type_bytes[type])
+
+effective_key_count =
+    saturating_sub(official_key_count, predicted_deleted_keys)
+```
+
+credit 在请求被 Executor 接受后立即生效，覆盖元数据排队和延迟删除阶段。所有减法使用饱和减法。
+
+同一 Group 一轮内每成功提交一个请求，都要用最新 credit 重新判断水位；水位满足后立即停止该
+Group 的后续提交。batch 粒度允许最多一个 batch 的自然 overshoot。
+
+### 4.4 Future 生命周期与 credit deadline
+
+`ReclaimCron` 每轮必须先调用 `HandleDelRes`，再读取正式 usage：
+
+1. Future ready 时，无论成功、部分成功还是明确失败，都释放 credit、pending 和硬上限配额。
+2. deadline 到期但 Future 未 ready 时，关闭 credit，但保留 pending 和硬上限配额。
+3. 完成旧任务处理后，读取正式 usage 并进行新一轮判断。
+
+这一顺序避免物理删除已经降低正式 usage、旧 credit 却仍然存在造成双重扣减。
+
+credit deadline 定义为：
+
+```text
+credit_deadline =
+    submitted_at + delay_before_delete_ms + inflight_delete_timeout_ms
+```
+
+deadline 到期但 Future 尚未 ready 时：
+
+- 将 `credit_enabled` 置为 false，立即停止抵扣 bytes 和 predicted keys。
+- 保留 pending Location 和硬上限配额，防止重复提交及任务数量继续放大。
+- 记录 timeout 指标和告警。
+- Future 后续真正 ready 时再释放全部本地状态。
+
+invalid、broken 或 deferred Future 按 outcome unknown 处理：立即关闭 credit，保留 pending 和配额
+并告警。V1 不在 Reclaimer cron 线程同步查询元数据，也不自动释放这类 pending。
+
+`inflight_delete_timeout_ms` 只控制水位 credit，不会中止底层 I/O。
+
+### 4.5 有界反压
+
+V1 只维护两层上限：
+
+1. 每个 `Instance Group × BaseStorageType` 的 pending Location 数和 pending bytes 上限。
+2. 进程级 pending `DeleteHandler` 数和 pending bytes 上限。
+
+某个 Type 达到上限时，只停止该 Group 中该 Type 的新删除准入；进程级上限触发时停止全部新提交。
+一个请求包含多个 Type 时，对达到上限的 Type 进行裁剪，并基于最终请求重新计算 bytes 和
+predicted keys。
+
+所有未完成 `DeleteHandler` 都占用上限，与 `credit_enabled` 无关。credit 到期不能返还配额；只有
+Future 终态才能正常释放。无法解析 size 的 Location 仍受 Location 数和进程级请求数上限约束。
+
+上限的目标是限制内存、队列和删除意图的增长，不承诺共享 Executor 下的物理执行隔离。卡死任务
+可能长期占用配额，V1 选择告警和安全失败，不做自动元数据复核。
+
+### 4.6 无进展退避
+
+水位超限不等于本轮取得进展。`TryReclaimOnGroup` 区分：
+
+- `made_progress=true`：实际有非空请求被 Executor 接受。
+- `made_progress=false`：候选都已 pending、达到上限、没有候选、请求为空，或 `SubmitAsync` 被拒绝。
+
+只有 `made_progress=true` 才允许快速开始下一轮。水位仍超限但没有实际提交时，ReclaimCron 使用
+正常轮询间隔；如果轮询间隔配置为 0，至少等待 1ms，避免持续采样和空请求提交造成 CPU 空转。
+
+`SubmitDelReq` 同时保护空请求：空请求不得进入 Executor，也不得建立 `DeleteHandler`。
+
+## 5. 并发与数据所有权
+
+pending 集合、`DeleteHandler`、credit 和上限计数只允许由 Reclaimer cron 线程修改，不需要额外
+加锁。
+
+`CacheReclaimer` 的并行 sampling workers 只返回采样结果，禁止直接读写上述状态。这是 V1 必须
+保持的无锁不变式。
+
+## 6. V1 异常语义
+
+| 场景 | V1 行为 |
+|---|---|
+| 首次入队失败 | 不建立 pending/credit，本轮无进展并退避 |
+| Admission 已排队时 Executor 停止 | cancel callback 将端到端 Future 收敛为明确失败 |
+| Future 正常或明确失败 | 释放 pending、credit 和上限配额 |
+| Future 超过 deadline | 关闭 credit，保留 pending 和配额，告警 |
+| invalid/broken/deferred Future | 按 outcome unknown 处理，关闭 credit 并保留 pending |
+| 部分 CAS | 按提交值保守记账，Future 终态或 deadline 时统一处理 |
+| CAS 后、物理删除前失败 | Future 返回失败并告警；V1 不自动回滚或复核元数据 |
+| 进程退出 | 本地状态直接丢弃，不同步等待任务，也不持久化 |
+
+V1 的取舍是：正常路径完整闭环，异常路径优先避免继续扩大删除量；永久 pending 依赖告警和运维
+处置。更完整的自恢复能力放到未来扩展。
+
+## 7. 可观测性
+
+V1 提供以下指标：
+
+| 指标 | 说明 |
+|---|---|
+| pending DeleteHandler/location/bytes | 当前未完成任务及其配额占用 |
+| credited delete bytes by Group/Type | 当前参与水位抵扣的 bytes |
+| predicted deleted key count | 当前 key count credit |
+| oldest pending request age | 识别卡死任务 |
+| credit timeout count | credit 到期次数 |
+| pending limit reject count | 反压触发次数及 Group/Type |
+| duplicate pending location filtered count | pending 去重次数 |
+| reclaim no-progress/backoff count | 水位超限但没有实际提交的次数 |
+| submit/complete/fail count | 删除请求生命周期统计 |
+| executor waiting/executing task count | Executor 排队和执行状态 |
+
+日志和事件至少携带 trace id、instance id、Instance Group、block/location 数量和 bytes。Group/Type
+明细通过 metrics tags 保留，Kmonitor reporter 同时上报进程级聚合值。
+
+## 8. 测试方案
+
+### 8.1 单元测试
+
+1. `SubmitAsync` 在元数据后端变慢时快速返回，Get/CAS/Sync 在 worker 中执行。
+2. `delay_before_delete_ms` 从 Sync 成功后计算，等待期间不占用 worker。
+3. worker 任一步骤失败或抛异常时，最终 Future 只完成一次。
+4. pending Location 在 CAS 前阻止重复选择，不同 Instance 互不影响。
+5. bytes 按 Group/Type 正确记账，`VCNS_HF3FS` 与正式 usage 一样归入 `HF3FS`。
+6. predicted keys 只在请求覆盖全部有效 Location 时增加。
+7. 每轮先回收 Future，不会同时扣减已下降的正式 usage 和旧 credit。
+8. Future 终态释放全部临时状态；deadline/invalid Future 只关闭 credit 并保留 pending。
+9. 饱和减法不会发生 unsigned underflow。
+10. 单个 Group × Type 达到上限时只阻塞该 Type；进程级上限阻止全部新提交。
+11. credit 到期不会释放硬上限配额。
+12. 水位超限但未接受非空请求时返回 no-progress，并触发退避。
+13. 空请求不会进入 Executor 或建立 `DeleteHandler`。
+14. `SubmitAsync(CacheMetaDelRequest)` 快速返回，Get/CAS/Sync 在 worker 中执行，并选择 block 下全部
+    有效 Location。
+15. Meta 异步请求跳过 `CLS_DELETING`，重复提交不会再次安排物理删除。
+16. Admission 已进入队列但尚未执行时停止 Executor，cancel callback 使 Future 以错误终态完成。
+
+### 8.2 集成测试关注点
+
+1. 设置较大的 `delay_before_delete_ms`，验证水位 credit 能阻止连续提交大量删除。
+2. 延迟 Get/CAS/Sync，验证 Reclaimer cron 不被阻塞且同一 Location 不重复提交。
+3. Future 超过 deadline 后，验证 credit 回弹、pending 保留且提交量受硬上限约束。
+4. 某个 Group × Type 达到上限后，验证其他未饱和 Type 在 Executor 可用时仍可提交。
+5. 没有有效 victim、全部 pending 和入队拒绝时，验证 ReclaimCron 不会零间隔空转。
+6. 同一 Group 多 Instance 时，验证一轮内水位满足后停止继续提交。
+
+## 9. 验收标准
+
+1. Reclaimer 删除提交耗时不再包含 Get、CAS 和 Sync 延迟。
+2. 同一个 `PendingLocationKey` 不会被同时提交两次。
+3. 大 `delay_before_delete_ms` 下，删除提交量不会随 ReclaimCron 轮数持续增长。
+4. Future 终态后，pending、credit 和上限配额全部释放。
+5. 超过 deadline 的任务不再抵扣水位，但仍阻止重复提交并占用硬上限。
+6. 未完成请求和删除 bytes 不超过配置上限。
+7. 水位超限但无实际提交时，ReclaimCron 会退避而不是空转。
+8. 现有同步删除调用方保持兼容。
+9. Meta 和 Location 异步请求共用 CAS/Fill/Sync、二次入队、shutdown cancel 和 exactly-once Future
+   收敛逻辑。
+10. 新增 Meta 异步接口不会隐式改变 `RemoveCache`、`TrimCache` 或 `ReclaimerTaskSupervisor` 的调用
+    行为。
+
+## 10. 实现落点与默认参数
+
+主要实现文件：
+
+| 文件 | 职责 |
+|---|---|
+| `manager/schedule_plan_executor.h/.cc` | 异步 Admission、定时等待、物理删除、最终 CAD 和 promise 完成 |
+| `manager/cache_reclaimer.h/.cc` | pending、credit、deadline、反压和 no-progress 退避 |
+| `manager/cache_manager.h/.cc` | 将异步删除配置装配到 Reclaimer |
+| `service/server_config.h/.cc` | 配置注册、默认值和合法性检查 |
+| `service/server.cc` | 从服务配置构造 `CacheReclaimerAsyncDeleteConfig` |
+| `metrics/kmonitor_metrics_reporter.cc` | 生命周期、credit、反压和退避指标上报 |
+
+V1 默认参数：
+
+| 配置 | 默认值 | 说明 |
+|---|---:|---|
+| `inflight_delete_timeout_ms` | 60000 | 删除 delay 之外允许 credit 继续生效的时间 |
+| `pending_location_limit_per_group_type` | 100000 | 单 Group × BaseStorageType 的 pending Location 上限 |
+| `pending_bytes_limit_per_group_type` | 64 GiB | 单 Group × BaseStorageType 的 pending bytes 上限 |
+| `pending_delete_handler_limit` | 1024 | 进程级 pending 请求上限 |
+| `pending_bytes_limit` | 256 GiB | 进程级 pending bytes 上限 |
+
+no-progress 默认复用 `cache_reclaimer_idle_interval_ms`；该值为 0 时使用 1ms 的安全下限。
+
+## 11. 未来扩展工作
+
+以下工作需要在 V1 指标证明有必要后单独设计，不属于当前实现：
+
+1. **异步 reconciliation**：对超时或 invalid Future 批量复核 Location 状态，必须通过 Executor、有界执行，不能在 cron 线程同步访问 Redis。
+2. **CAS 后补偿状态机**：区分 CAS 前失败、CAS 后未入队、物理结果未知等阶段，并设计重试、回滚或 `UNCERTAIN` 处理。
+3. **自动恢复永久 pending**：在 reconciliation 结果可信后安全返还配额，减少人工干预。
+4. **严格的 Storage Type 故障隔离**：按 Type 拆分请求、Future、线程池或队列，避免坏后端占用共享 worker。
+5. **主备切换安全**：为异步任务携带 leader/instance generation，在 Admission 和 Physical 阶段校验，并定义 demotion 时的 drain/cancel。
+6. **持久化任务与跨进程恢复**：进程重启后恢复删除意图和 pending 状态。
+7. **StorageBackend I/O timeout/cancel**：为阻塞的物理删除提供真实中止能力。
+8. **精确部分结果记账**：根据实际 CAS 成功 Location 提前修正 credit，而不是等待最终 Future。
+9. **多层存储迁移协同**：migration、copy 和 drain 语义另行专项处理。

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -4,7 +4,7 @@
 
 > **维护提示**：当模块的职责、依赖方向或调用关系发生变化，或新增/删除模块时，请同步更新本文档与文末的 Mermaid 图，并同步更新 [AGENTS.md](../../AGENTS.md) 中的缩略图。
 
-相关文档：[基本概念](basic_concepts.md)、[高可用与选主机制](ha_leader_elector.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
+相关文档：[基本概念](basic_concepts.md)、[高可用与选主机制](ha_leader_elector.md)、[CacheReclaimer 异步删除设计](cache_reclaimer_async_delete.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
 
 ---
 
@@ -245,7 +245,7 @@ sequenceDiagram
 
 ### 4.5 容量回收（后台异步）
 
-`CacheReclaimer` 依据 Quota 与存储水位选出待逐出的 key，通过 `SchedulePlanExecutor`（后台线程池）异步删除 `data_storage` 中的数据并更新 `meta` 索引；删除不阻塞前台请求。回收动作通过 `event` 上报回收事件。
+`CacheReclaimer` 依据 Quota 与存储水位选出待逐出的 key，并把 Location 删除作为端到端异步任务提交给 `SchedulePlanExecutor`。Executor worker 完成元数据 Get/CAS/Sync；Sync 成功后通过定时队列等待删除 delay（等待不占 worker），随后删除 `data_storage` 数据并 CAD `meta` 索引。Reclaimer 在任务终态前按 Instance Group 与 BaseStorageType 维护 pending Location、删除 bytes credit 和硬配额，用于去重、避免过度逐出及提供有界反压；回收动作通过 `event` 上报。完整生命周期和异常语义见 [CacheReclaimer 异步删除设计](cache_reclaimer_async_delete.md)。
 
 ### 4.6 HA 故障转移
 

--- a/integration_test/reclaimer/reclaiming_test.py
+++ b/integration_test/reclaimer/reclaiming_test.py
@@ -276,6 +276,454 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         # new write should now be accepted
         self._write(16)
 
+    def test_no_over_eviction_with_delay(self):
+        """In-flight byte credit prevents repeated delayed batches."""
+        self._assert_no_over_eviction_with_delay(
+            group_capacity=1024 * 20,
+            type_capacity=1024 * 30,
+            max_key_count=30,
+        )
+
+    def test_no_over_eviction_with_delay_key_count(self):
+        """Predicted-key credit prevents repeated delayed batches."""
+        self._assert_no_over_eviction_with_delay(
+            group_capacity=1024 * 1024,
+            type_capacity=1024 * 1024,
+            max_key_count=20,
+        )
+
+    def test_no_over_eviction_same_group_multiple_instances(self):
+        """A Group-wide credit stops admission before the next instance."""
+        self.worker_manager.stop_worker(0)
+        self.assertTrue(
+            self.worker_manager.start_worker(
+                0, **{"kvcm.cache_reclaimer.del_batch_size": 4}
+            )
+        )
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_client()
+
+        self._admin_client.add_storage({
+            "trace_id": self._trace_id,
+            "storage": self._make_dummy_storage(),
+        })
+        instance_group = self._make_dummy_instance_group()
+        instance_group["quota"]["capacity"] = 1024 * 20
+        instance_group["quota"]["quota_config"] = [
+            {"storage_type": 3, "capacity": 1024 * 30},
+            {"storage_type": 4, "capacity": 1024 * 30},
+        ]
+        instance_group[
+            "cache_config"
+        ][
+            "meta_indexer_config"
+        ][
+            "max_key_count"
+        ] = 16
+        instance_group[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "delay_before_delete_ms"
+        ] = 3000
+        self._admin_client.create_instance_group({
+            "trace_id": self._trace_id,
+            "instance_group": instance_group,
+        })
+
+        instance_ids = ["test_instance_01", "test_instance_02"]
+        for instance_id in instance_ids:
+            self._instance_id = instance_id
+            self._client.register_instance(self._make_dummy_ins_req())
+            for block_key in range(6):
+                self._write(block_key)
+
+        current_version = instance_group["version"]
+        instance_group["version"] = current_version + 1
+        instance_group[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "trigger_strategy"
+        ][
+            "used_percentage"
+        ] = 0.5
+        self._admin_client.update_instance_group({
+            "trace_id": self._trace_id + "_update_ig",
+            "instance_group": instance_group,
+            "current_version": current_version,
+        })
+
+        self._wait_metric_value(
+            "cache_reclaimer.pending_delete_handler_count", 1, timeout_s=5
+        )
+        self._wait_metric_value(
+            "cache_reclaimer.pending_delete_handler_count", 0, timeout_s=10
+        )
+        surviving_blocks = sum(
+            self._count_surviving_blocks(instance_id, range(6))
+            for instance_id in instance_ids
+        )
+        self.assertEqual(
+            self._metric_value("cache_reclaimer.delete_submit_count"),
+            1,
+            "Group credit should prevent admission from the next instance",
+        )
+        self.assertGreaterEqual(
+            surviving_blocks,
+            8,
+            "Group credit should limit delayed reclaim to one four-key batch",
+        )
+        self.assertLess(
+            surviving_blocks,
+            12,
+            "the delayed reclaim batch should still complete",
+        )
+
+    def test_no_progress_uses_polling_backoff(self):
+        """Active writers keep a hot water level from spinning the cron."""
+        self._admin_client.add_storage({
+            "trace_id": self._trace_id,
+            "storage": self._make_dummy_storage(),
+        })
+        instance_group = self._make_dummy_instance_group()
+        instance_group["quota"]["capacity"] = 1024 * 20
+        instance_group["quota"]["quota_config"] = [
+            {"storage_type": 3, "capacity": 1024 * 30},
+            {"storage_type": 4, "capacity": 1024 * 30},
+        ]
+        instance_group[
+            "cache_config"
+        ][
+            "meta_indexer_config"
+        ][
+            "max_key_count"
+        ] = 32
+        self._admin_client.create_instance_group({
+            "trace_id": self._trace_id,
+            "instance_group": instance_group,
+        })
+        self._client.register_instance(self._make_dummy_ins_req())
+
+        for block_key in range(12):
+            self._start_write(block_key)
+
+        current_version = instance_group["version"]
+        instance_group["version"] = current_version + 1
+        instance_group[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "trigger_strategy"
+        ][
+            "used_percentage"
+        ] = 0.1
+        self._admin_client.update_instance_group({
+            "trace_id": self._trace_id + "_update_ig",
+            "instance_group": instance_group,
+            "current_version": current_version,
+        })
+
+        time.sleep(0.8)
+        metrics = self._admin_client.get_metrics({
+            "trace_id": self._trace_id + "_metrics",
+        })["metrics"]
+        backoff_count = max(
+            (
+                int(metric["metric_value"].get("int_value", 0))
+                for metric in metrics
+                if metric["metric_name"] ==
+                "cache_reclaimer.reclaim_no_progress_backoff_count"
+            ),
+            default=0,
+        )
+        self.assertGreater(backoff_count, 0)
+        self.assertLess(
+            backoff_count,
+            20,
+            "no-progress rounds should follow the normal polling interval",
+        )
+
+    def _assert_no_over_eviction_with_delay(
+        self, group_capacity, type_capacity, max_key_count
+    ):
+        """Write 12 blocks, then trigger reclaim with a five-second delay.
+
+        A four-key batch is sufficient to move either configured water level
+        from 60% to 40%. The pending request must therefore credit the water
+        level immediately and prevent a second batch during the delay window.
+        The Future terminal state must release all temporary accounting.
+        """
+        self.worker_manager.stop_worker(0)
+        self.assertTrue(
+            self.worker_manager.start_worker(
+                0, **{"kvcm.cache_reclaimer.del_batch_size": 4}
+            )
+        )
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_client()
+
+        self._admin_client.add_storage({
+            "trace_id": self._trace_id,
+            "storage": self._make_dummy_storage(),
+        })
+
+        instance_group = self._make_dummy_instance_group()
+        instance_group["quota"]["capacity"] = group_capacity
+        instance_group["quota"]["quota_config"] = [
+            {"storage_type": 3, "capacity": type_capacity},
+            {"storage_type": 4, "capacity": type_capacity},
+        ]
+        instance_group[
+            "cache_config"
+        ][
+            "meta_indexer_config"
+        ][
+            "max_key_count"
+        ] = max_key_count
+        instance_group[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "delay_before_delete_ms"
+        ] = 5000
+        self._admin_client.create_instance_group({
+            "trace_id": self._trace_id,
+            "instance_group": instance_group,
+        })
+        self._client.register_instance(self._make_dummy_ins_req())
+
+        for block_key in range(12):
+            self._write(block_key)
+
+        current_version = instance_group["version"]
+        instance_group["version"] = current_version + 1
+        instance_group[
+            "cache_config"
+        ][
+            "reclaim_strategy"
+        ][
+            "trigger_strategy"
+        ][
+            "used_percentage"
+        ] = 0.5
+        self._admin_client.update_instance_group({
+            "trace_id": self._trace_id + "_update_ig",
+            "instance_group": instance_group,
+            "current_version": current_version,
+        })
+
+        self._wait_metric_value(
+            "cache_reclaimer.pending_delete_handler_count", 1
+        )
+        expected_group_type_tags = {
+            "instance_group": self._instance_group_name,
+            "storage_type": "file",
+        }
+        expected_group_tags = {
+            "instance_group": self._instance_group_name,
+        }
+        inflight_metrics = {
+            "delete_submit_count": self._metric_value(
+                "cache_reclaimer.delete_submit_count"
+            ),
+            "pending_delete_handler_count": self._metric_value(
+                "cache_reclaimer.pending_delete_handler_count"
+            ),
+            "pending_location_count": self._metric_value(
+                "cache_reclaimer.pending_location_count"
+            ),
+            "pending_delete_bytes": self._metric_value(
+                "cache_reclaimer.pending_delete_bytes"
+            ),
+            "credited_delete_bytes": self._metric_value(
+                "cache_reclaimer.credited_delete_bytes"
+            ),
+            "predicted_deleted_key_count": self._metric_value(
+                "cache_reclaimer.predicted_deleted_key_count"
+            ),
+        }
+        logging.info("delayed reclaim in-flight metrics: %s", inflight_metrics)
+        self.assertEqual(inflight_metrics["delete_submit_count"], 1)
+        self.assertEqual(inflight_metrics["pending_delete_handler_count"], 1)
+        self.assertEqual(inflight_metrics["pending_location_count"], 4)
+        self.assertEqual(inflight_metrics["pending_delete_bytes"], 4 * 1024)
+        self.assertEqual(inflight_metrics["credited_delete_bytes"], 4 * 1024)
+        self.assertEqual(inflight_metrics["predicted_deleted_key_count"], 4)
+        self.assertEqual(
+            self._metric_value(
+                "cache_reclaimer.pending_location_count",
+                expected_group_type_tags,
+            ),
+            4,
+        )
+        self.assertEqual(
+            self._metric_value(
+                "cache_reclaimer.pending_delete_bytes",
+                expected_group_type_tags,
+            ),
+            4 * 1024,
+        )
+        self.assertEqual(
+            self._metric_value(
+                "cache_reclaimer.credited_delete_bytes",
+                expected_group_type_tags,
+            ),
+            4 * 1024,
+        )
+        self.assertEqual(
+            self._metric_value(
+                "cache_reclaimer.predicted_deleted_key_count",
+                expected_group_tags,
+            ),
+            4,
+        )
+
+        self.assertEqual(
+            self._metric_value("cache_reclaimer.delete_complete_count"),
+            0,
+            "the end-to-end Future must remain pending during the delay",
+        )
+        self.assertEqual(
+            self._count_surviving_blocks(self._instance_id, range(12)),
+            8,
+            "CAS should hide exactly one batch while its Future is pending",
+        )
+
+        self._wait_metric_value(
+            "cache_reclaimer.pending_delete_handler_count", 0, timeout_s=8
+        )
+
+        surviving_blocks = self._count_surviving_blocks(
+            self._instance_id, range(12)
+        )
+
+        logging.info(
+            "delayed reclaim survivors: %d/12 (capacity=%d, max_keys=%d)",
+            surviving_blocks,
+            group_capacity,
+            max_key_count,
+        )
+        self.assertGreaterEqual(
+            surviving_blocks,
+            8,
+            "in-flight credit should limit delayed reclaim to one batch",
+        )
+        self.assertLess(
+            surviving_blocks,
+            12,
+            "the delayed reclaim batch should still complete",
+        )
+        self.assertEqual(
+            self._metric_value("cache_reclaimer.delete_submit_count"),
+            1,
+            "fresh credit should prevent admission of a second batch",
+        )
+        self.assertEqual(
+            self._metric_value("cache_reclaimer.delete_complete_count"), 1
+        )
+        for metric_name in (
+            "pending_delete_handler_count",
+            "pending_location_count",
+            "pending_delete_bytes",
+            "credited_delete_bytes",
+            "predicted_deleted_key_count",
+        ):
+            self.assertEqual(
+                self._metric_value(f"cache_reclaimer.{metric_name}"),
+                0,
+                f"{metric_name} should be released at Future completion",
+            )
+        for metric_name in (
+            "pending_location_count",
+            "pending_delete_bytes",
+            "credited_delete_bytes",
+        ):
+            self.assertEqual(
+                self._metric_value(
+                    f"cache_reclaimer.{metric_name}",
+                    expected_group_type_tags,
+                ),
+                0,
+                f"tagged {metric_name} should be released at Future completion",
+            )
+        self.assertEqual(
+            self._metric_value(
+                "cache_reclaimer.predicted_deleted_key_count",
+                expected_group_tags,
+            ),
+            0,
+        )
+
+    def _wait_metric_value(
+        self, metric_name, expected_value, tags=None, timeout_s=2
+    ):
+        deadline = time.monotonic() + timeout_s
+        last_value = None
+        while time.monotonic() < deadline:
+            last_value = self._metric_value(metric_name, tags)
+            if last_value == expected_value:
+                return
+            time.sleep(0.05)
+        self.fail(
+            f"metric {metric_name} with tags {tags or {}} did not become "
+            f"{expected_value}; last value: {last_value}"
+        )
+
+    def _metric_value(self, metric_name, tags=None):
+        expected_tags = tags or {}
+        metrics = self._admin_client.get_metrics({
+            "trace_id": self._trace_id + "_metrics",
+        })["metrics"]
+        values = []
+        for metric in metrics:
+            if metric.get("metric_name") != metric_name:
+                continue
+            actual_tags = {
+                tag["tag_key"]: tag["tag_value"]
+                for tag in metric.get("metric_tags", [])
+            }
+            if actual_tags != expected_tags:
+                continue
+            metric_value = metric.get("metric_value", {})
+            for value_type in (
+                "int_value",
+                "float_value",
+                "double_value",
+            ):
+                if value_type in metric_value:
+                    values.append(float(metric_value[value_type]))
+                    break
+        self.assertEqual(
+            len(values),
+            1,
+            f"expected one {metric_name} metric with tags {expected_tags}, "
+            f"got {len(values)}",
+        )
+        return values[0]
+
+    def _count_surviving_blocks(self, instance_id, block_keys):
+        surviving_blocks = 0
+        for block_key in block_keys:
+            response = self._client.get_cache_location({
+                "trace_id": f"{self._trace_id}_check_{block_key}",
+                "query_type": "QT_PREFIX_MATCH",
+                "block_keys": [block_key],
+                "instance_id": instance_id,
+                "block_mask": {"offset": 0},
+            }, check_response=False)
+            if response.get("header", {}).get("status", {}).get("code") != "OK":
+                continue
+            if any(response.get("locations", [])):
+                surviving_blocks += 1
+        return surviving_blocks
+
     def test_persist_recover_00(self):
         """Test e2e persist/recover: cache locations and metadata
         survive a normal server restart.

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -157,7 +157,8 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
                         uint64_t cache_reclaimer_key_sampling_size_per_task,
                         uint64_t cache_reclaimer_del_batch_size,
                         uint32_t cache_reclaimer_idle_interval_ms,
-                        uint32_t cache_reclaimer_worker_size) {
+                        uint32_t cache_reclaimer_worker_size,
+                        CacheReclaimerAsyncDeleteConfig cache_reclaimer_async_delete_config) {
     schedule_plan_executor_ = std::make_shared<SchedulePlanExecutor>(schedule_plan_executor_thread_count,
                                                                      meta_indexer_manager_,
                                                                      registry_manager_->data_storage_manager(),
@@ -181,7 +182,8 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
                                                         schedule_plan_executor_,
                                                         metrics_registry_,
                                                         event_manager_,
-                                                        write_location_manager_);
+                                                        write_location_manager_,
+                                                        std::move(cache_reclaimer_async_delete_config));
     if (cache_reclaimer_->Start() != EC_OK) {
         KVCM_LOG_ERROR("CacheManager init failed");
         return false;

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -11,6 +11,7 @@
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
 #include "kv_cache_manager/manager/cache_location_view.h"
+#include "kv_cache_manager/manager/cache_reclaimer.h"
 #include "kv_cache_manager/manager/data_storage_selector.h"
 #include "kv_cache_manager/manager/meta_searcher.h"
 #include "kv_cache_manager/manager/select_location_policy.h"
@@ -70,7 +71,8 @@ public:
               uint64_t cache_reclaimer_key_sampling_size_per_task = 100,
               uint64_t cache_reclaimer_del_batch_size = 100,
               uint32_t cache_reclaimer_idle_interval_ms = 100,
-              uint32_t cache_reclaimer_worker_size = 16);
+              uint32_t cache_reclaimer_worker_size = 16,
+              CacheReclaimerAsyncDeleteConfig cache_reclaimer_async_delete_config = {});
     ErrorCode DoRecover();
     ErrorCode DoRecoverOnce();
     void StartRecoverRetryLoop();

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -8,9 +8,11 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <future>
 #include <iomanip>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <random>
@@ -32,6 +34,7 @@
 #include "kv_cache_manager/config/instance_group_quota.h"
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_uri.h"
 #include "kv_cache_manager/data_storage/storage_config.h"
 #include "kv_cache_manager/event/event_manager.h"
 #include "kv_cache_manager/event/spec_events/cache_reclaim_event.h"
@@ -103,6 +106,13 @@ DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(block_submit_count);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(location_submit_count);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(block_del_count);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(location_del_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(credit_timeout_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(pending_limit_reject_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(duplicate_pending_location_filtered_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_no_progress_backoff_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(delete_submit_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(delete_complete_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(delete_fail_count);
 
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us);
@@ -112,6 +122,12 @@ DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_sample_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_lru_submit_duration_us);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(pending_delete_handler_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(pending_location_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(pending_delete_bytes);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(credited_delete_bytes);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(predicted_deleted_key_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(oldest_pending_request_age_ms);
 
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us);
@@ -198,6 +214,244 @@ void CacheReclaimer::GroupUsageData::AddGroupUsageByType(const DataStorageType &
     grp_storage_usage_by_type_.at(idx) += value;
 }
 
+std::uint64_t CacheReclaimer::SaturatingSub(const std::uint64_t lhs, const std::uint64_t rhs) noexcept {
+    return lhs > rhs ? lhs - rhs : 0;
+}
+
+std::uint64_t CacheReclaimer::SaturatingAdd(const std::uint64_t lhs, const std::uint64_t rhs) noexcept {
+    const auto max = std::numeric_limits<std::uint64_t>::max();
+    return rhs > max - lhs ? max : lhs + rhs;
+}
+
+std::uint64_t CacheReclaimer::GetLocationBytes(const CacheLocation &location) noexcept {
+    std::uint64_t total = 0;
+    for (const auto &location_spec : location.location_specs()) {
+        DataStorageUri uri(location_spec.uri());
+        if (!uri.Valid()) {
+            continue;
+        }
+        std::uint64_t size = 0;
+        uri.GetParamAs<std::uint64_t>("size", size);
+        total = SaturatingAdd(total, size);
+    }
+    return total;
+}
+
+CacheReclaimer::BytesByStorageType
+CacheReclaimer::GetCreditedDeleteBytes(const std::string &instance_group) const noexcept {
+    const auto it = credited_delete_bytes_by_group_.find(instance_group);
+    return it == credited_delete_bytes_by_group_.end() ? BytesByStorageType{} : it->second;
+}
+
+std::uint64_t CacheReclaimer::GetPredictedDeletedKeys(const std::string &instance_group) const noexcept {
+    const auto it = predicted_deleted_keys_by_group_.find(instance_group);
+    return it == predicted_deleted_keys_by_group_.end() ? 0 : it->second;
+}
+
+void CacheReclaimer::AddDeleteHandlerState(const DeleteHandler &handler) noexcept {
+    for (const auto &pending_location : handler.pending_locations_) {
+        const auto [_, inserted] = pending_locations_.insert(pending_location);
+        if (!inserted) {
+            KVCM_LOG_ERROR("duplicate pending location admitted, instance[%s] block[%ld] location[%s]",
+                           pending_location.instance_id.c_str(),
+                           pending_location.block_key,
+                           pending_location.location_id.c_str());
+        }
+    }
+
+    for (std::size_t idx = 0; idx < handler.bytes_by_type_.size(); ++idx) {
+        const auto type = static_cast<DataStorageType>(idx);
+        if (type != DataStorageType::DATA_STORAGE_TYPE_UNKNOWN &&
+            type != DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS && handler.bytes_by_type_[idx] != 0) {
+            auto &credited_bytes = credited_delete_bytes_by_group_[handler.ins_gr_];
+            credited_bytes[idx] = SaturatingAdd(credited_bytes[idx], handler.bytes_by_type_[idx]);
+        }
+        if (handler.location_counts_by_type_[idx] == 0 && handler.bytes_by_type_[idx] == 0) {
+            continue;
+        }
+        auto &pending_quota = pending_quota_by_group_type_[{handler.ins_gr_, type}];
+        pending_quota.location_count =
+            SaturatingAdd(pending_quota.location_count, handler.location_counts_by_type_[idx]);
+        pending_quota.bytes = SaturatingAdd(pending_quota.bytes, handler.bytes_by_type_[idx]);
+    }
+    if (handler.predicted_deleted_keys_ != 0) {
+        auto &predicted_keys = predicted_deleted_keys_by_group_[handler.ins_gr_];
+        predicted_keys = SaturatingAdd(predicted_keys, handler.predicted_deleted_keys_);
+    }
+    pending_delete_handler_count_ = SaturatingAdd(pending_delete_handler_count_, 1);
+    for (const auto bytes : handler.bytes_by_type_) {
+        pending_delete_bytes_ = SaturatingAdd(pending_delete_bytes_, bytes);
+    }
+}
+
+void CacheReclaimer::DisableCredit(DeleteHandler &handler, const char *reason) noexcept {
+    if (!handler.credit_enabled_) {
+        return;
+    }
+
+    auto credited_it = credited_delete_bytes_by_group_.find(handler.ins_gr_);
+    if (credited_it != credited_delete_bytes_by_group_.end()) {
+        bool all_zero = true;
+        for (std::size_t idx = 0; idx < credited_it->second.size(); ++idx) {
+            credited_it->second[idx] = SaturatingSub(credited_it->second[idx], handler.bytes_by_type_[idx]);
+            all_zero = all_zero && credited_it->second[idx] == 0;
+        }
+        if (all_zero) {
+            credited_delete_bytes_by_group_.erase(credited_it);
+        }
+    }
+
+    auto predicted_it = predicted_deleted_keys_by_group_.find(handler.ins_gr_);
+    if (predicted_it != predicted_deleted_keys_by_group_.end()) {
+        predicted_it->second = SaturatingSub(predicted_it->second, handler.predicted_deleted_keys_);
+        if (predicted_it->second == 0) {
+            predicted_deleted_keys_by_group_.erase(predicted_it);
+        }
+    }
+
+    handler.credit_enabled_ = false;
+    if (reason != nullptr) {
+        const auto &request_context = handler.req_ctx_;
+        const std::string &ins_id = handler.ins_id_;
+        const std::string &ins_gr = handler.ins_gr_;
+        LOG_WITH_ID(WARN,
+                    "disable in-flight delete credit, reason: [%s], block count: [%" PRIu64
+                    "], location count: [%" PRIu64 "]",
+                    reason,
+                    handler.blk_count_,
+                    handler.loc_count_);
+    }
+}
+
+void CacheReclaimer::ReleaseDeleteHandlerState(DeleteHandler &handler) noexcept {
+    DisableCredit(handler, nullptr);
+
+    for (const auto &pending_location : handler.pending_locations_) {
+        pending_locations_.erase(pending_location);
+    }
+    for (std::size_t idx = 0; idx < handler.location_counts_by_type_.size(); ++idx) {
+        if (handler.location_counts_by_type_[idx] == 0 && handler.bytes_by_type_[idx] == 0) {
+            continue;
+        }
+        const auto key = GroupStorageTypeKey{handler.ins_gr_, static_cast<DataStorageType>(idx)};
+        auto pending_it = pending_quota_by_group_type_.find(key);
+        if (pending_it == pending_quota_by_group_type_.end()) {
+            continue;
+        }
+        pending_it->second.location_count =
+            SaturatingSub(pending_it->second.location_count, handler.location_counts_by_type_[idx]);
+        pending_it->second.bytes = SaturatingSub(pending_it->second.bytes, handler.bytes_by_type_[idx]);
+        if (pending_it->second.location_count == 0 && pending_it->second.bytes == 0) {
+            pending_quota_by_group_type_.erase(pending_it);
+        }
+    }
+    pending_delete_handler_count_ = SaturatingSub(pending_delete_handler_count_, 1);
+    for (const auto bytes : handler.bytes_by_type_) {
+        pending_delete_bytes_ = SaturatingSub(pending_delete_bytes_, bytes);
+    }
+}
+
+void CacheReclaimer::RecordPendingLimitReject(const std::string &instance_group,
+                                              const std::string &storage_type_scope) noexcept {
+    METRICS_(cache_reclaimer, pending_limit_reject_count) += 1;
+    if (metrics_registry_ == nullptr) {
+        return;
+    }
+    try {
+        metrics_registry_->GetCounter(
+            METRICS_NAME_(cache_reclaimer, pending_limit_reject_count),
+            MetricsTags{{"instance_group", instance_group}, {"storage_type", storage_type_scope}}) += 1;
+    } catch (const std::exception &e) {
+        KVCM_LOG_WARN("record tagged pending-limit metric failed: %s", e.what());
+    } catch (...) { KVCM_LOG_WARN("record tagged pending-limit metric failed with unknown exception"); }
+}
+
+void CacheReclaimer::UpdateAsyncDeleteMetrics() noexcept {
+    std::uint64_t credited_bytes = 0;
+    for (const auto &[_, by_type] : credited_delete_bytes_by_group_) {
+        for (const auto bytes : by_type) {
+            credited_bytes = SaturatingAdd(credited_bytes, bytes);
+        }
+    }
+    std::uint64_t predicted_keys = 0;
+    for (const auto &[_, keys] : predicted_deleted_keys_by_group_) {
+        predicted_keys = SaturatingAdd(predicted_keys, keys);
+    }
+
+    std::uint64_t oldest_age_ms = 0;
+    const auto now = std::chrono::steady_clock::now();
+    for (const auto &handler : delete_handlers_) {
+        const auto age = std::chrono::duration_cast<std::chrono::milliseconds>(now - handler.submitted_at_).count();
+        if (age > 0) {
+            oldest_age_ms = std::max(oldest_age_ms, static_cast<std::uint64_t>(age));
+        }
+    }
+
+    METRICS_(cache_reclaimer, pending_delete_handler_count) = static_cast<double>(pending_delete_handler_count_);
+    METRICS_(cache_reclaimer, pending_location_count) = static_cast<double>(pending_locations_.size());
+    METRICS_(cache_reclaimer, pending_delete_bytes) = static_cast<double>(pending_delete_bytes_);
+    METRICS_(cache_reclaimer, credited_delete_bytes) = static_cast<double>(credited_bytes);
+    METRICS_(cache_reclaimer, predicted_deleted_key_count) = static_cast<double>(predicted_keys);
+    METRICS_(cache_reclaimer, oldest_pending_request_age_ms) = static_cast<double>(oldest_age_ms);
+
+    if (metrics_registry_ == nullptr) {
+        return;
+    }
+
+    std::set<GroupStorageTypeKey> current_group_type_keys;
+    for (const auto &[instance_group, by_type] : credited_delete_bytes_by_group_) {
+        for (std::size_t idx = 0; idx < by_type.size(); ++idx) {
+            if (by_type[idx] != 0) {
+                current_group_type_keys.insert(GroupStorageTypeKey{instance_group, static_cast<DataStorageType>(idx)});
+            }
+        }
+    }
+    for (const auto &[key, quota] : pending_quota_by_group_type_) {
+        if (quota.location_count != 0 || quota.bytes != 0) {
+            current_group_type_keys.insert(key);
+        }
+    }
+
+    auto group_type_keys_to_report = reported_group_type_metric_keys_;
+    group_type_keys_to_report.insert(current_group_type_keys.begin(), current_group_type_keys.end());
+    for (const auto &key : group_type_keys_to_report) {
+        const auto credited_it = credited_delete_bytes_by_group_.find(key.instance_group);
+        const auto type_idx = ToIndex(key.storage_type);
+        const std::uint64_t group_type_credit =
+            credited_it != credited_delete_bytes_by_group_.end() && type_idx < credited_it->second.size()
+                ? credited_it->second[type_idx]
+                : 0;
+        const auto quota_it = pending_quota_by_group_type_.find(key);
+        const PendingQuota quota = quota_it == pending_quota_by_group_type_.end() ? PendingQuota{} : quota_it->second;
+        const MetricsTags tags{{"instance_group", key.instance_group}, {"storage_type", ToString(key.storage_type)}};
+        metrics_registry_->GetGauge(METRICS_NAME_(cache_reclaimer, credited_delete_bytes), tags) =
+            static_cast<double>(group_type_credit);
+        metrics_registry_->GetGauge(METRICS_NAME_(cache_reclaimer, pending_location_count), tags) =
+            static_cast<double>(quota.location_count);
+        metrics_registry_->GetGauge(METRICS_NAME_(cache_reclaimer, pending_delete_bytes), tags) =
+            static_cast<double>(quota.bytes);
+    }
+    reported_group_type_metric_keys_ = std::move(current_group_type_keys);
+
+    std::set<std::string> current_group_keys;
+    for (const auto &[instance_group, keys] : predicted_deleted_keys_by_group_) {
+        if (keys != 0) {
+            current_group_keys.insert(instance_group);
+        }
+    }
+    auto group_keys_to_report = reported_group_metric_keys_;
+    group_keys_to_report.insert(current_group_keys.begin(), current_group_keys.end());
+    for (const auto &instance_group : group_keys_to_report) {
+        const auto predicted_it = predicted_deleted_keys_by_group_.find(instance_group);
+        const std::uint64_t group_predicted_keys =
+            predicted_it == predicted_deleted_keys_by_group_.end() ? 0 : predicted_it->second;
+        metrics_registry_->GetGauge(METRICS_NAME_(cache_reclaimer, predicted_deleted_key_count),
+                                    MetricsTags{{"instance_group", instance_group}}) =
+            static_cast<double>(group_predicted_keys);
+    }
+    reported_group_metric_keys_ = std::move(current_group_keys);
+}
+
 CacheReclaimer::WaterLevelExceed::WaterLevelExceed()
     : general_water_level_exceed_(false), water_level_exceed_by_type_{} {
     water_level_exceed_by_type_.fill(false);
@@ -262,7 +516,8 @@ CacheReclaimer::CacheReclaimer(const std::size_t sampling_size_total,
                                std::shared_ptr<SchedulePlanExecutor> sched_plan_executor,
                                std::shared_ptr<MetricsRegistry> metrics_registry,
                                std::shared_ptr<EventManager> event_manager,
-                               std::shared_ptr<WriteLocationManager> write_location_manager)
+                               std::shared_ptr<WriteLocationManager> write_location_manager,
+                               CacheReclaimerAsyncDeleteConfig async_delete_config)
     : registry_manager_(std::move(registry_manager))
     , meta_indexer_manager_(std::move(meta_indexer_manager))
     , meta_searcher_manager_(std::move(meta_searcher_manager))
@@ -277,6 +532,7 @@ CacheReclaimer::CacheReclaimer(const std::size_t sampling_size_total,
     , batching_size_(batching_size)
     , sleep_interval_ms_(sleep_interval_ms)
     , future_timeout_ms_(kFutureTimeoutMs)
+    , async_delete_config_(std::move(async_delete_config))
     , worker_stop_(false) {
     if (worker_size == 0) {
         worker_size = 1;
@@ -335,6 +591,13 @@ ErrorCode CacheReclaimer::Start() noexcept {
     REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(location_submit_count);
     REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(block_del_count);
     REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(location_del_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(credit_timeout_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(pending_limit_reject_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(duplicate_pending_location_filtered_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(reclaim_no_progress_backoff_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_submit_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_complete_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_fail_count);
 
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us);
@@ -344,6 +607,12 @@ ErrorCode CacheReclaimer::Start() noexcept {
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_submit_duration_us);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(pending_delete_handler_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(pending_location_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(pending_delete_bytes);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(credited_delete_bytes);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(predicted_deleted_key_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(oldest_pending_request_age_ms);
 
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us);
@@ -478,6 +747,16 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
         return nullptr;
     }
 
+    const auto credited_bytes = GetCreditedDeleteBytes(ins_gr);
+    std::uint64_t total_credited_bytes = 0;
+    for (const auto bytes : credited_bytes) {
+        total_credited_bytes = SaturatingAdd(total_credited_bytes, bytes);
+    }
+    const std::uint64_t effective_group_bytes =
+        SaturatingSub(static_cast<std::uint64_t>(data->grp_used_byte_sz_), total_credited_bytes);
+    const std::uint64_t effective_group_keys =
+        SaturatingSub(static_cast<std::uint64_t>(data->grp_used_key_cnt_), GetPredictedDeletedKeys(ins_gr));
+
     // 2. generate the result water level exceeding array
     const double threshold_used_percentage = reclaim_strategy->trigger_strategy().used_percentage();
 
@@ -486,6 +765,15 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
         const auto &type = storage_quota.storage_spec();
         if (type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS) {
             // skip vcns_hf3fs, because it is treated as hf3fs
+            continue;
+        }
+
+        const std::size_t type_idx = ToIndex(ToBaseType(type));
+        const std::uint64_t type_credit = type_idx < credited_bytes.size() ? credited_bytes[type_idx] : 0;
+        const std::uint64_t effective_type_bytes =
+            SaturatingSub(static_cast<std::uint64_t>(data->GetGroupUsageByType(type)), type_credit);
+
+        if (effective_type_bytes == 0) {
             continue;
         }
 
@@ -499,7 +787,7 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
             continue;
         }
         if (const double storage_type_wl =
-                static_cast<double>(data->GetGroupUsageByType(type)) / static_cast<double>(storage_quota.capacity());
+                static_cast<double>(effective_type_bytes) / static_cast<double>(storage_quota.capacity());
             storage_type_wl + kEpsilon > threshold_used_percentage) {
             LOG_WITH_GR(DEBUG,
                         "instance group storage type [%d] capacity quota used percentage [%f] "
@@ -511,53 +799,55 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
         }
     }
 
-    // 2.2. result for the entire instance group
-    if (data->grp_used_key_cnt_ == 0 || data->grp_used_byte_sz_ == 0) {
-        water_level_exceed->SetGeneralWaterLevelExceed(false);
-        return water_level_exceed;
-    }
+    // 2.2. result for the entire instance group. Byte and key-count
+    // credits are independent: credit reducing one dimension to zero
+    // must not suppress the other dimension's water-level check.
 
     // 2.2.1. trigger_strategy:used_percent for instance group quota capacity
-    if (instance_group_quota.capacity() <= 0) {
-        // proceed as group quota capacity is 0
-        LOG_WITH_GR(DEBUG,
-                    "instance group capacity quota used percentage [inf] "
-                    "has reached or exceeded the threshold percentage [%f]",
-                    threshold_used_percentage);
-        water_level_exceed->SetGeneralWaterLevelExceed(true);
-        return water_level_exceed;
-    }
-    if (const double group_used_percentage =
-            static_cast<double>(data->grp_used_byte_sz_) / static_cast<double>(instance_group_quota.capacity());
-        group_used_percentage + kEpsilon > threshold_used_percentage) {
-        LOG_WITH_GR(DEBUG,
-                    "instance group capacity quota used percentage [%f] "
-                    "has reached or exceeded the threshold percentage [%f]",
-                    group_used_percentage,
-                    threshold_used_percentage);
-        water_level_exceed->SetGeneralWaterLevelExceed(true);
-        return water_level_exceed;
+    if (effective_group_bytes > 0) {
+        if (instance_group_quota.capacity() <= 0) {
+            // proceed as group quota capacity is 0
+            LOG_WITH_GR(DEBUG,
+                        "instance group capacity quota used percentage [inf] "
+                        "has reached or exceeded the threshold percentage [%f]",
+                        threshold_used_percentage);
+            water_level_exceed->SetGeneralWaterLevelExceed(true);
+            return water_level_exceed;
+        }
+        if (const double group_used_percentage =
+                static_cast<double>(effective_group_bytes) / static_cast<double>(instance_group_quota.capacity());
+            group_used_percentage + kEpsilon > threshold_used_percentage) {
+            LOG_WITH_GR(DEBUG,
+                        "instance group capacity quota used percentage [%f] "
+                        "has reached or exceeded the threshold percentage [%f]",
+                        group_used_percentage,
+                        threshold_used_percentage);
+            water_level_exceed->SetGeneralWaterLevelExceed(true);
+            return water_level_exceed;
+        }
     }
 
     // 2.2.2. trigger_strategy:used_percent for group key count
-    if (data->grp_max_key_cnt_ == 0) {
-        LOG_WITH_GR(DEBUG,
-                    "instance group total key count used percentage [inf] "
-                    "has reached or exceeded the threshold percentage [%f]",
-                    threshold_used_percentage);
-        water_level_exceed->SetGeneralWaterLevelExceed(true);
-        return water_level_exceed;
-    }
-    if (const double group_used_percentage =
-            static_cast<double>(data->grp_used_key_cnt_) / static_cast<double>(data->grp_max_key_cnt_);
-        group_used_percentage + kEpsilon > threshold_used_percentage) {
-        LOG_WITH_GR(DEBUG,
-                    "instance group total key count used percentage [%f] "
-                    "has reached or exceeded the threshold percentage [%f]",
-                    group_used_percentage,
-                    threshold_used_percentage);
-        water_level_exceed->SetGeneralWaterLevelExceed(true);
-        return water_level_exceed;
+    if (effective_group_keys > 0) {
+        if (data->grp_max_key_cnt_ == 0) {
+            LOG_WITH_GR(DEBUG,
+                        "instance group total key count used percentage [inf] "
+                        "has reached or exceeded the threshold percentage [%f]",
+                        threshold_used_percentage);
+            water_level_exceed->SetGeneralWaterLevelExceed(true);
+            return water_level_exceed;
+        }
+        if (const double group_used_percentage =
+                static_cast<double>(effective_group_keys) / static_cast<double>(data->grp_max_key_cnt_);
+            group_used_percentage + kEpsilon > threshold_used_percentage) {
+            LOG_WITH_GR(DEBUG,
+                        "instance group total key count used percentage [%f] "
+                        "has reached or exceeded the threshold percentage [%f]",
+                        group_used_percentage,
+                        threshold_used_percentage);
+            water_level_exceed->SetGeneralWaterLevelExceed(true);
+            return water_level_exceed;
+        }
     }
 
     // 2.2.3. instance group do not trigger reclaiming
@@ -572,18 +862,18 @@ bool CacheReclaimer::IsTriggerReclaiming(const std::shared_ptr<WaterLevelExceed>
     return true;
 }
 
-void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request_context,
+bool CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request_context,
                                   const InstanceInfoConstPtr &instance_info,
                                   const WaterLevelExceed &water_level_exceed,
                                   const std::int32_t delay_before_delete_ms) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
-        return;
+        return false;
     }
 
     if (instance_info == nullptr) {
         LOG_WITH_TRACE(WARN, "instance is nullptr");
-        return;
+        return false;
     }
 
     const std::string &ins_id = instance_info->instance_id();
@@ -597,7 +887,7 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
     const std::int64_t begin_tp_sample = TimestampUtil::GetSteadyTimeUs();
     if (!DoKeySampling(request_context, instance_info, keys, maps)) {
         LOG_WITH_ID(DEBUG, "key sampling failed");
-        return;
+        return false;
     }
     METRICS_(cache_reclaimer, reclaim_lru_sample_duration_us) =
         static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp_sample);
@@ -615,13 +905,13 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
     AgeStats lru_age_stats;
     if (!MakeBatchByLRU(request_context.get(), instance_info, keys, maps, request.block_keys, lru_age_stats)) {
         LOG_WITH_ID(DEBUG, "make batch failed");
-        return;
+        return false;
     }
     METRICS_(cache_reclaimer, reclaim_lru_batch_duration_us) =
         static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp_batch);
     LOG_WITH_ID(DEBUG, "batch is made with size [%zu]", request.block_keys.size());
     if (request.block_keys.empty()) {
-        return;
+        return false;
     }
     METRICS_(cache_reclaimer, reclaim_batch_lru_age_min_us) = static_cast<double>(lru_age_stats.min_us);
     METRICS_(cache_reclaimer, reclaim_batch_lru_age_max_us) = static_cast<double>(lru_age_stats.max_us);
@@ -633,14 +923,20 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
     //    are submitted to be deleted
     const std::int64_t begin_tp_filter = TimestampUtil::GetSteadyTimeUs();
     AgeStats create_age_stats;
+    BytesByStorageType bytes_by_type{};
+    CountsByStorageType location_counts_by_type{};
+    std::uint64_t predicted_deleted_keys = 0;
     if (!FilterLocID(request_context.get(),
                      instance_info,
                      request.block_keys,
                      water_level_exceed,
                      request.location_ids,
+                     bytes_by_type,
+                     location_counts_by_type,
+                     predicted_deleted_keys,
                      create_age_stats)) {
         LOG_WITH_ID(DEBUG, "filter location ID failed");
-        return;
+        return false;
     }
     METRICS_(cache_reclaimer, reclaim_lru_filter_duration_us) =
         static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp_filter);
@@ -650,39 +946,43 @@ void CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
 
     // 4. submit the final deleting request to the executor
     const std::int64_t begin_tp_submit = TimestampUtil::GetSteadyTimeUs();
-    SubmitDelReq(request_context, instance_info, request);
+    const bool submitted = SubmitDelReq(
+        request_context, instance_info, request, bytes_by_type, location_counts_by_type, predicted_deleted_keys);
     METRICS_(cache_reclaimer, reclaim_lru_submit_duration_us) =
         static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp_submit);
 
-    METRICS_(cache_reclaimer, reclaim_job_count) += 1;
+    if (submitted) {
+        METRICS_(cache_reclaimer, reclaim_job_count) += 1;
+    }
+    return submitted;
 }
 
-void CacheReclaimer::ReclaimByLFU(const std::shared_ptr<RequestContext> &request_context,
+bool CacheReclaimer::ReclaimByLFU(const std::shared_ptr<RequestContext> &request_context,
                                   const InstanceInfoConstPtr &instance_info,
                                   const WaterLevelExceed &water_level_exceed,
                                   const std::int32_t delay_before_delete_ms) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
-        return;
+        return false;
     }
 
     // TODO: impl LFU policy
     LOG_WITH_TRACE(WARN, "LFU reclaim policy not supported yet; fall back to LRU policy");
-    ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms);
+    return ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms);
 }
 
-void CacheReclaimer::ReclaimByTTL(const std::shared_ptr<RequestContext> &request_context,
+bool CacheReclaimer::ReclaimByTTL(const std::shared_ptr<RequestContext> &request_context,
                                   const InstanceInfoConstPtr &instance_info,
                                   const WaterLevelExceed &water_level_exceed,
                                   const std::int32_t delay_before_delete_ms) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
-        return;
+        return false;
     }
 
     // TODO: impl TTL policy
     LOG_WITH_TRACE(WARN, "TTL reclaim policy not supported yet; fall back to LRU policy");
-    ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms);
+    return ReclaimByLRU(request_context, instance_info, water_level_exceed, delay_before_delete_ms);
 }
 
 void CacheReclaimer::ReclaimCron() noexcept {
@@ -703,7 +1003,15 @@ void CacheReclaimer::ReclaimCron() noexcept {
             }
         }
 
+        {
+            const std::int64_t res_begin_tp = TimestampUtil::GetSteadyTimeUs();
+            HandleDelRes();
+            METRICS_(cache_reclaimer, reclaim_res_duration_us) =
+                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - res_begin_tp);
+        }
+
         if (IsPaused()) {
+            sleep_interval_ms = sleep_interval_ms_.load();
             continue;
         }
 
@@ -712,27 +1020,31 @@ void CacheReclaimer::ReclaimCron() noexcept {
         const auto [ec, instance_groups] = registry_manager_->ListInstanceGroup(request_context.get());
         if (ec != ErrorCode::EC_OK) {
             LOG_WITH_TRACE(WARN, "list instance group failed, error code: [%d]", static_cast<std::int32_t>(ec));
+            sleep_interval_ms = sleep_interval_ms_.load();
             continue;
         }
 
-        bool triggered = false;
+        bool made_progress = false;
+        bool needs_no_progress_backoff = false;
         for (const auto &instance_group : instance_groups) {
-            if (TryReclaimOnGroup(request_context, instance_group)) {
-                triggered = true;
-            }
+            const auto result = TryReclaimOnGroup(request_context, instance_group);
+            made_progress = made_progress || result.made_progress;
+            needs_no_progress_backoff =
+                needs_no_progress_backoff || (result.water_level_exceeded && !result.made_progress);
         }
 
-        {
-            const std::int64_t res_begin_tp = TimestampUtil::GetSteadyTimeUs();
-            HandleDelRes();
-            METRICS_(cache_reclaimer, reclaim_res_duration_us) =
-                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - res_begin_tp);
-        }
-
-        if (triggered) {
+        if (made_progress) {
+            UpdateAsyncDeleteMetrics();
             sleep_interval_ms = 0;
         } else {
             sleep_interval_ms = sleep_interval_ms_.load();
+            if (needs_no_progress_backoff) {
+                sleep_interval_ms = std::max<std::uint32_t>(sleep_interval_ms, 1);
+                METRICS_(cache_reclaimer, reclaim_no_progress_backoff_count) += 1;
+                LOG_WITH_TRACE(DEBUG,
+                               "reclaiming water level exceeded without accepted delete request; back off for [%u] ms",
+                               sleep_interval_ms);
+            }
         }
 
         METRICS_(cache_reclaimer, reclaim_cron_duration_us) =
@@ -1001,9 +1313,33 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                                  const std::vector<std::int64_t> &batch,
                                  const WaterLevelExceed &water_level_exceed,
                                  std::vector<std::vector<std::string>> &out_loc_ids,
-                                 AgeStats &out_create_age_stats) const noexcept {
+                                 BytesByStorageType &out_bytes_by_type,
+                                 CountsByStorageType &out_location_counts_by_type,
+                                 std::uint64_t &out_predicted_deleted_keys,
+                                 AgeStats &out_create_age_stats) noexcept {
     const std::string &ins_id = instance_info->instance_id();
     const std::string &ins_gr = instance_info->instance_group_name();
+
+    out_loc_ids.clear();
+    out_bytes_by_type.fill(0);
+    out_location_counts_by_type.fill(0);
+    out_predicted_deleted_keys = 0;
+    out_create_age_stats = AgeStats{};
+
+    if (pending_delete_handler_count_ >= async_delete_config_.pending_delete_handler_limit ||
+        pending_delete_bytes_ >= async_delete_config_.pending_bytes_limit) {
+        RecordPendingLimitReject(ins_gr, "process");
+        LOG_WITH_ID(WARN,
+                    "process pending delete limit reached, handlers: [%" PRIu64 "/%" PRIu64 "], bytes: [%" PRIu64
+                    "/%" PRIu64 "]",
+                    pending_delete_handler_count_,
+                    async_delete_config_.pending_delete_handler_limit,
+                    pending_delete_bytes_,
+                    async_delete_config_.pending_bytes_limit);
+        out_loc_ids.resize(batch.size());
+        out_create_age_stats.Clear();
+        return true;
+    }
 
     const auto meta_searcher = meta_searcher_manager_->GetMetaSearcher(ins_id);
     if (meta_searcher == nullptr) {
@@ -1035,12 +1371,16 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
     const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
     int64_t create_age_sum = 0;
     int64_t create_age_count = 0;
-    for (const auto &loc_map : loc_maps) {
+    std::uint64_t selected_total_bytes = 0;
+    for (std::size_t block_idx = 0; block_idx < loc_maps.size(); ++block_idx) {
+        const auto &loc_map = loc_maps[block_idx];
         std::vector<std::string> loc_id_vec;
+        std::size_t valid_location_count = 0;
         for (const auto &[_, loc_ptr] : loc_map) {
             if (!loc_ptr) {
                 continue;
             }
+            ++valid_location_count;
             const auto &loc = *loc_ptr;
             // a location is eligible for eviction if:
             // 1. it is in CLS_SERVING status, OR
@@ -1050,25 +1390,81 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                                              write_location_manager_ != nullptr &&
                                              !write_location_manager_->HasLocationId(loc.id());
             if (loc.status() == CacheLocationStatus::CLS_SERVING || is_orphaned_writing) {
-                bool selected = false;
+                bool selected_by_water_level = false;
                 if (water_level_exceed.CheckStorageTypeWaterLevelExceed()) {
                     // some storage type water level exceeded; only
                     // collect the location with matched type but
                     // fairness is ignored
                     // TODO (rui): implement the fair eviction
                     if (water_level_exceed.GetWaterLevelExceedByType(loc.type())) {
-                        loc_id_vec.emplace_back(loc.id());
-                        selected = true;
+                        selected_by_water_level = true;
                     }
                 } else {
                     // there's no storage type water level exceeded
                     // and since the reclaiming is triggered, the total
                     // usage water level must be exceeded; ignore the
                     // type detection
-                    loc_id_vec.emplace_back(loc.id());
-                    selected = true;
+                    selected_by_water_level = true;
                 }
-                if (selected && loc.create_time() > 0) {
+                if (!selected_by_water_level) {
+                    continue;
+                }
+
+                const PendingLocationKey pending_key{ins_id, batch[block_idx], loc.id()};
+                if (pending_locations_.find(pending_key) != pending_locations_.end()) {
+                    METRICS_(cache_reclaimer, duplicate_pending_location_filtered_count) += 1;
+                    continue;
+                }
+
+                const DataStorageType base_type = ToBaseType(loc.type());
+                const std::size_t type_idx = ToIndex(base_type);
+                if (type_idx >= out_bytes_by_type.size()) {
+                    LOG_WITH_ID(WARN, "skip location with invalid storage type index: [%zu]", type_idx);
+                    continue;
+                }
+
+                const auto quota_it = pending_quota_by_group_type_.find({ins_gr, base_type});
+                const PendingQuota current_quota =
+                    quota_it == pending_quota_by_group_type_.end() ? PendingQuota{} : quota_it->second;
+                const std::uint64_t location_bytes = GetLocationBytes(loc);
+
+                const bool location_limit_reached =
+                    current_quota.location_count >= async_delete_config_.pending_location_limit_per_group_type ||
+                    out_location_counts_by_type[type_idx] >=
+                        async_delete_config_.pending_location_limit_per_group_type -
+                            std::min(current_quota.location_count,
+                                     async_delete_config_.pending_location_limit_per_group_type);
+                const std::uint64_t current_and_selected_type_bytes =
+                    SaturatingAdd(current_quota.bytes, out_bytes_by_type[type_idx]);
+                const bool type_bytes_limit_reached =
+                    current_and_selected_type_bytes >= async_delete_config_.pending_bytes_limit_per_group_type ||
+                    location_bytes > async_delete_config_.pending_bytes_limit_per_group_type -
+                                         std::min(current_and_selected_type_bytes,
+                                                  async_delete_config_.pending_bytes_limit_per_group_type);
+                const std::uint64_t current_and_selected_process_bytes =
+                    SaturatingAdd(pending_delete_bytes_, selected_total_bytes);
+                const bool process_bytes_limit_reached =
+                    current_and_selected_process_bytes >= async_delete_config_.pending_bytes_limit ||
+                    location_bytes >
+                        async_delete_config_.pending_bytes_limit -
+                            std::min(current_and_selected_process_bytes, async_delete_config_.pending_bytes_limit);
+                if (location_limit_reached || type_bytes_limit_reached || process_bytes_limit_reached) {
+                    RecordPendingLimitReject(ins_gr, ToString(base_type));
+                    LOG_WITH_ID(WARN,
+                                "skip pending-limit location, block: [%ld], location: [%s], storage type: [%d], "
+                                "bytes: [%" PRIu64 "]",
+                                batch[block_idx],
+                                loc.id().c_str(),
+                                static_cast<int>(base_type),
+                                location_bytes);
+                    continue;
+                }
+
+                loc_id_vec.emplace_back(loc.id());
+                out_location_counts_by_type[type_idx] = SaturatingAdd(out_location_counts_by_type[type_idx], 1);
+                out_bytes_by_type[type_idx] = SaturatingAdd(out_bytes_by_type[type_idx], location_bytes);
+                selected_total_bytes = SaturatingAdd(selected_total_bytes, location_bytes);
+                if (loc.create_time() > 0) {
                     const int64_t age = now_us - loc.create_time();
                     out_create_age_stats.min_us = std::min(out_create_age_stats.min_us, age);
                     out_create_age_stats.max_us = std::max(out_create_age_stats.max_us, age);
@@ -1076,6 +1472,9 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                     ++create_age_count;
                 }
             }
+        }
+        if (!loc_id_vec.empty() && loc_id_vec.size() == valid_location_count) {
+            out_predicted_deleted_keys = SaturatingAdd(out_predicted_deleted_keys, 1);
         }
         out_loc_ids.emplace_back(std::move(loc_id_vec));
     }
@@ -1087,47 +1486,144 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
     return true;
 }
 
-void CacheReclaimer::SubmitDelReq(const std::shared_ptr<RequestContext> &request_context,
+bool CacheReclaimer::SubmitDelReq(const std::shared_ptr<RequestContext> &request_context,
                                   const std::shared_ptr<const InstanceInfo> &instance_info,
-                                  const CacheLocationDelRequest &req) noexcept {
+                                  const CacheLocationDelRequest &req,
+                                  const BytesByStorageType &bytes_by_type,
+                                  const CountsByStorageType &location_counts_by_type,
+                                  const std::uint64_t predicted_deleted_keys) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
-        return;
+        return false;
     }
-
-    assert(req.block_keys.size() == req.location_ids.size());
 
     const std::string &ins_id = instance_info->instance_id();
     const std::string &ins_gr = instance_info->instance_group_name();
+    if (req.block_keys.size() != req.location_ids.size()) {
+        LOG_WITH_ID(WARN,
+                    "skip invalid reclaim request: block key count [%zu] != location vector count [%zu]",
+                    req.block_keys.size(),
+                    req.location_ids.size());
+        return false;
+    }
 
     std::uint64_t blk_count = 0;
     std::uint64_t loc_count = 0;
+    CacheLocationDelRequest final_req{ins_id, {}, {}, req.delay};
+    std::vector<PendingLocationKey> pending_locations;
+    std::set<PendingLocationKey> request_pending_locations;
     for (std::size_t i = 0; i != req.block_keys.size(); ++i) {
         if (!req.location_ids[i].empty()) {
-            ++blk_count;
-            loc_count += req.location_ids[i].size();
+            blk_count = SaturatingAdd(blk_count, 1);
+            loc_count = SaturatingAdd(loc_count, req.location_ids[i].size());
+            final_req.block_keys.emplace_back(req.block_keys[i]);
+            final_req.location_ids.emplace_back(req.location_ids[i]);
+            for (const auto &location_id : req.location_ids[i]) {
+                PendingLocationKey pending_location{ins_id, req.block_keys[i], location_id};
+                if (!request_pending_locations.insert(pending_location).second) {
+                    LOG_WITH_ID(WARN,
+                                "skip reclaim request containing duplicate location, block: [%ld], location: [%s]",
+                                req.block_keys[i],
+                                location_id.c_str());
+                    return false;
+                }
+                if (pending_locations_.find(pending_location) != pending_locations_.end()) {
+                    METRICS_(cache_reclaimer, duplicate_pending_location_filtered_count) += 1;
+                    LOG_WITH_ID(WARN,
+                                "skip reclaim request containing pending location, block: [%ld], location: [%s]",
+                                req.block_keys[i],
+                                location_id.c_str());
+                    return false;
+                }
+                pending_locations.emplace_back(std::move(pending_location));
+            }
         }
     }
 
-    auto fut = sched_plan_executor_->Submit(req);
-    delete_handlers_.emplace_front(request_context, ins_id, ins_gr, blk_count, loc_count, std::move(fut));
+    if (blk_count == 0 || loc_count == 0) {
+        LOG_WITH_ID(DEBUG, "skip empty reclaim request");
+        return false;
+    }
+    if (pending_delete_handler_count_ >= async_delete_config_.pending_delete_handler_limit) {
+        RecordPendingLimitReject(ins_gr, "process");
+        LOG_WITH_ID(WARN, "skip reclaim request: process pending handler limit reached");
+        return false;
+    }
+
+    std::uint64_t request_bytes = 0;
+    for (std::size_t idx = 0; idx < bytes_by_type.size(); ++idx) {
+        request_bytes = SaturatingAdd(request_bytes, bytes_by_type[idx]);
+        if (location_counts_by_type[idx] == 0 && bytes_by_type[idx] == 0) {
+            continue;
+        }
+        const auto type = static_cast<DataStorageType>(idx);
+        const auto pending_it = pending_quota_by_group_type_.find({ins_gr, type});
+        const PendingQuota pending_quota =
+            pending_it == pending_quota_by_group_type_.end() ? PendingQuota{} : pending_it->second;
+        if (pending_quota.location_count >= async_delete_config_.pending_location_limit_per_group_type ||
+            location_counts_by_type[idx] > async_delete_config_.pending_location_limit_per_group_type -
+                                               std::min(pending_quota.location_count,
+                                                        async_delete_config_.pending_location_limit_per_group_type) ||
+            pending_quota.bytes >= async_delete_config_.pending_bytes_limit_per_group_type ||
+            bytes_by_type[idx] >
+                async_delete_config_.pending_bytes_limit_per_group_type -
+                    std::min(pending_quota.bytes, async_delete_config_.pending_bytes_limit_per_group_type)) {
+            RecordPendingLimitReject(ins_gr, ToString(type));
+            LOG_WITH_ID(WARN, "skip reclaim request: group/type pending limit reached for type [%zu]", idx);
+            return false;
+        }
+    }
+    if (pending_delete_bytes_ >= async_delete_config_.pending_bytes_limit ||
+        request_bytes > async_delete_config_.pending_bytes_limit -
+                            std::min(pending_delete_bytes_, async_delete_config_.pending_bytes_limit)) {
+        RecordPendingLimitReject(ins_gr, "process");
+        LOG_WITH_ID(WARN, "skip reclaim request: process pending bytes limit reached");
+        return false;
+    }
+
+    auto submit_result = sched_plan_executor_->SubmitAsync(final_req);
+    if (!submit_result.accepted) {
+        LOG_WITH_ID(WARN, "schedule plan executor rejected async reclaim request");
+        return false;
+    }
+
+    const auto submitted_at = std::chrono::steady_clock::now();
+    const auto non_negative_delay = std::max(final_req.delay, std::chrono::microseconds::zero());
+    const auto credit_deadline =
+        submitted_at + non_negative_delay + std::chrono::milliseconds(async_delete_config_.inflight_delete_timeout_ms);
+    delete_handlers_.emplace_front(request_context,
+                                   ins_id,
+                                   ins_gr,
+                                   blk_count,
+                                   loc_count,
+                                   std::move(pending_locations),
+                                   bytes_by_type,
+                                   location_counts_by_type,
+                                   predicted_deleted_keys,
+                                   submitted_at,
+                                   credit_deadline,
+                                   std::move(submit_result.future));
+    AddDeleteHandlerState(delete_handlers_.front());
 
     METRICS_(cache_reclaimer, block_submit_count) += blk_count;
     METRICS_(cache_reclaimer, location_submit_count) += loc_count;
+    METRICS_(cache_reclaimer, delete_submit_count) += 1;
 
-    if (event_manager_ != nullptr && blk_count != 0 && loc_count != 0) {
+    if (event_manager_ != nullptr) {
         auto reclaim_submit_event = std::make_shared<CacheReclaimSubmitEvent>(ins_id);
         reclaim_submit_event->SetEventTriggerTime();
-        reclaim_submit_event->SetAdditionalArgs(req.block_keys, req.location_ids, req.delay.count());
+        reclaim_submit_event->SetAdditionalArgs(final_req.block_keys, final_req.location_ids, final_req.delay.count());
         event_manager_->Publish(reclaim_submit_event);
     }
 
     LOG_WITH_ID(DEBUG,
                 "submit reclaim request to schedule plan executor OK, "
                 "with effective cache block count: [%" PRIu64 "], "
-                "cache location count: [%" PRIu64 "]",
+                "cache location count: [%" PRIu64 "], bytes: [%" PRIu64 "]",
                 blk_count,
-                loc_count);
+                loc_count,
+                request_bytes);
+    return true;
 }
 
 std::shared_ptr<CacheReclaimer::GroupUsageData> CacheReclaimer::GetGroupUsageData(
@@ -1158,16 +1654,13 @@ std::shared_ptr<CacheReclaimer::GroupUsageData> CacheReclaimer::GetGroupUsageDat
         data->grp_max_key_cnt_ += ins_max_key_cnt;
         data->grp_used_byte_sz_ += ins_used_byte_size;
 
-        // calc the usage size of each storage type of this instance
-        auto calc_sz = [&meta_indexer, &data](const DataStorageType &type) -> void {
-            const std::uint64_t sz = meta_indexer->GetStorageUsageByType(type);
-            data->AddGroupUsageByType(type, sz);
-        };
-        calc_sz(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
-        calc_sz(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE);
-        calc_sz(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
-        calc_sz(DataStorageType::DATA_STORAGE_TYPE_NFS);
-        // vcns_hf3fs is merged into hf3fs, no need to calc the size
+        for (std::size_t idx = 1; idx < static_cast<std::size_t>(DataStorageType::COUNT); ++idx) {
+            const auto type = static_cast<DataStorageType>(idx);
+            if (type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS) {
+                continue;
+            }
+            data->AddGroupUsageByType(type, meta_indexer->GetStorageUsageByType(type));
+        }
     }
     return data;
 }
@@ -1181,11 +1674,26 @@ void CacheReclaimer::HandleDelRes() noexcept {
         const std::string &ins_gr = it->ins_gr_;
 
         if (!it->fut_.valid()) {
-            LOG_WITH_ID(WARN, "reclaim request got invalid future");
-            it = delete_handlers_.erase_after(it_pre);
-        } else if (const auto fs = it->fut_.wait_for(std::chrono::seconds::zero()); fs == std::future_status::ready) {
+            if (!it->outcome_unknown_reported_) {
+                LOG_WITH_ID(WARN,
+                            "reclaim request got invalid future; preserve pending locations and hard-limit quota");
+                it->outcome_unknown_reported_ = true;
+            }
+            DisableCredit(*it, "invalid future");
+            ++it_pre;
+            ++it;
+            continue;
+        }
+
+        const auto future_status = it->fut_.wait_for(std::chrono::seconds::zero());
+        if (future_status == std::future_status::ready) {
+            bool terminal = false;
+            ErrorCode result_code = ErrorCode::EC_ERROR;
             try {
-                if (const auto [ec, err_msg] = it->fut_.get(); ec != ErrorCode::EC_OK) {
+                const auto [ec, err_msg] = it->fut_.get();
+                terminal = true;
+                result_code = ec;
+                if (ec != ErrorCode::EC_OK) {
                     LOG_WITH_ID(WARN,
                                 "reclaim request execute failed, error_code: [%d], error message: [%s]",
                                 static_cast<std::int32_t>(ec),
@@ -1201,33 +1709,64 @@ void CacheReclaimer::HandleDelRes() noexcept {
                                 it->loc_count_);
                 }
             } catch (const std::exception &e) {
-                LOG_WITH_ID(WARN, "reclaim request finished with exception: [%s]", e.what());
+                if (!it->outcome_unknown_reported_) {
+                    LOG_WITH_ID(WARN,
+                                "reclaim request future outcome unknown: [%s]; preserve pending locations and quota",
+                                e.what());
+                    it->outcome_unknown_reported_ = true;
+                }
             } catch (...) {
-                // make sure no exception can possibly escape
+                if (!it->outcome_unknown_reported_) {
+                    LOG_WITH_ID(WARN, "reclaim request future outcome unknown; preserve pending locations and quota");
+                    it->outcome_unknown_reported_ = true;
+                }
             }
 
-            // eliminate this handler anyway, by erasing and updating
-            // the iterator ``it''; ``it_pre'' remains unchanged
+            if (!terminal) {
+                DisableCredit(*it, "broken or exceptional future");
+                ++it_pre;
+                ++it;
+                continue;
+            }
+
+            METRICS_(cache_reclaimer, delete_complete_count) += 1;
+            if (result_code != ErrorCode::EC_OK) {
+                METRICS_(cache_reclaimer, delete_fail_count) += 1;
+            }
+            ReleaseDeleteHandlerState(*it);
             it = delete_handlers_.erase_after(it_pre);
-        } else {
-            // handle other std::future_status possible:
-            // - std::future_status:deferred
-            // - std::future_status:timeout
-            ++it_pre, ++it;
+            continue;
         }
+
+        if (future_status == std::future_status::deferred) {
+            if (!it->outcome_unknown_reported_) {
+                LOG_WITH_ID(WARN,
+                            "reclaim request got deferred future; preserve pending locations and hard-limit quota");
+                it->outcome_unknown_reported_ = true;
+            }
+            DisableCredit(*it, "deferred future");
+        } else if (it->credit_enabled_ && std::chrono::steady_clock::now() >= it->credit_deadline_) {
+            METRICS_(cache_reclaimer, credit_timeout_count) += 1;
+            DisableCredit(*it, "credit deadline exceeded");
+        }
+        ++it_pre;
+        ++it;
     }
+    UpdateAsyncDeleteMetrics();
 }
 
-bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request_context,
-                                       const std::shared_ptr<const InstanceGroup> &instance_group) noexcept {
+CacheReclaimer::ReclaimResult
+CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request_context,
+                                  const std::shared_ptr<const InstanceGroup> &instance_group) noexcept {
+    ReclaimResult result;
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
-        return false;
+        return result;
     }
 
     if (instance_group == nullptr) {
         LOG_WITH_TRACE(WARN, "instance group is nullptr");
-        return false;
+        return result;
     }
 
     const std::string &ins_gr = instance_group->name();
@@ -1235,13 +1774,13 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
     const auto cache_config = instance_group->cache_config();
     if (cache_config == nullptr) {
         LOG_WITH_GR(WARN, "cache config is nullptr");
-        return false;
+        return result;
     }
 
     const auto &reclaim_strategy = cache_config->reclaim_strategy();
     if (reclaim_strategy == nullptr) {
         LOG_WITH_GR(WARN, "reclaim strategy is nullptr");
-        return false;
+        return result;
     }
     const std::int32_t delay_before_delete_ms = reclaim_strategy->delay_before_delete_ms();
 
@@ -1249,74 +1788,46 @@ bool CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &re
     const auto [ec, instance_infos] = registry_manager_->ListInstanceInfo(request_context.get(), ins_gr);
     if (ec != ErrorCode::EC_OK) {
         LOG_WITH_GR(WARN, "list instances info failed, error code: [%d]", static_cast<std::int32_t>(ec));
-        return false;
+        return result;
     }
 
-    // do we need to reclaim the storage for this instance group?
-    const std::int64_t quota_begin_tp = TimestampUtil::GetSteadyTimeUs();
-    const auto water_level_exceed =
-        GetWaterLevelExceed(request_context.get(),
-                            ins_gr,
-                            instance_group->quota(), // TODO (rui): validate the quota is valid
-                            reclaim_strategy,
-                            instance_infos);
-    METRICS_(cache_reclaimer, reclaim_quota_duration_us) =
-        static_cast<double>(TimestampUtil::GetSteadyTimeUs() - quota_begin_tp);
+    for (const auto &instance_info : instance_infos) {
+        const std::int64_t quota_begin_tp = TimestampUtil::GetSteadyTimeUs();
+        const auto water_level_exceed = GetWaterLevelExceed(
+            request_context.get(), ins_gr, instance_group->quota(), reclaim_strategy, instance_infos);
+        METRICS_(cache_reclaimer, reclaim_quota_duration_us) =
+            static_cast<double>(TimestampUtil::GetSteadyTimeUs() - quota_begin_tp);
+        if (!IsTriggerReclaiming(water_level_exceed)) {
+            if (!result.water_level_exceeded) {
+                LOG_WITH_GR(DEBUG, "instance group does not trigger reclaiming");
+            } else {
+                LOG_WITH_GR(DEBUG, "instance group water level satisfied by in-flight delete credit");
+            }
+            break;
+        }
 
-    if (!IsTriggerReclaiming(water_level_exceed)) {
-        LOG_WITH_GR(DEBUG, "instance group does not trigger reclaiming");
-        return false;
+        result.water_level_exceeded = true;
+        const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
+        bool submitted = false;
+        switch (reclaim_strategy->reclaim_policy()) {
+        case ReclaimPolicy::POLICY_LFU:
+            submitted = ReclaimByLFU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
+            break;
+        case ReclaimPolicy::POLICY_TTL:
+            submitted = ReclaimByTTL(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
+            break;
+        case ReclaimPolicy::POLICY_UNSPECIFIED:
+        case ReclaimPolicy::POLICY_LRU:
+        default:
+            submitted = ReclaimByLRU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
+            break;
+        }
+        METRICS_(cache_reclaimer, reclaim_job_duration_us) =
+            static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
+        result.made_progress = result.made_progress || submitted;
     }
 
-    LOG_WITH_GR(DEBUG, "instance group trigger reclaiming");
-
-    // run the reclaiming algorithm with the chosen policy
-    switch (reclaim_strategy->reclaim_policy()) {
-    case ReclaimPolicy::POLICY_LRU:
-        LOG_WITH_GR(DEBUG, "start to run the LRU reclaim policy");
-        for (const auto &instance_info : instance_infos) {
-            const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByLRU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
-            METRICS_(cache_reclaimer, reclaim_job_duration_us) =
-                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
-        }
-        break;
-
-    case ReclaimPolicy::POLICY_LFU:
-        LOG_WITH_GR(DEBUG, "start to run the LFU reclaim policy");
-        for (const auto &instance_info : instance_infos) {
-            const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByLFU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
-            METRICS_(cache_reclaimer, reclaim_job_duration_us) =
-                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
-        }
-        break;
-
-    case ReclaimPolicy::POLICY_TTL:
-        LOG_WITH_GR(DEBUG, "start to run the TTL reclaim policy");
-        for (const auto &instance_info : instance_infos) {
-            const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByTTL(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
-            METRICS_(cache_reclaimer, reclaim_job_duration_us) =
-                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
-        }
-        break;
-
-    case ReclaimPolicy::POLICY_UNSPECIFIED: // default to LRU
-        LOG_WITH_GR(DEBUG, "reclaim policy not specified; default to LRU policy");
-        // break; skipped intentionally
-
-    default:
-        for (const auto &instance_info : instance_infos) {
-            const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
-            ReclaimByLRU(request_context, instance_info, *water_level_exceed, delay_before_delete_ms);
-            METRICS_(cache_reclaimer, reclaim_job_duration_us) =
-                static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
-        }
-        break;
-    }
-
-    return true;
+    return result;
 }
 
 CacheReclaimer::DeleteHandler::DeleteHandler(std::shared_ptr<RequestContext> req_ctx,
@@ -1324,12 +1835,26 @@ CacheReclaimer::DeleteHandler::DeleteHandler(std::shared_ptr<RequestContext> req
                                              std::string ins_gr,
                                              const std::uint64_t blk_count,
                                              const std::uint64_t loc_count,
+                                             std::vector<PendingLocationKey> pending_locations,
+                                             BytesByStorageType bytes_by_type,
+                                             CountsByStorageType location_counts_by_type,
+                                             const std::uint64_t predicted_deleted_keys,
+                                             const std::chrono::steady_clock::time_point submitted_at,
+                                             const std::chrono::steady_clock::time_point credit_deadline,
                                              std::future<PlanExecuteResult> fut)
     : req_ctx_(std::move(req_ctx))
     , ins_id_(std::move(ins_id))
     , ins_gr_(std::move(ins_gr))
     , blk_count_(blk_count)
     , loc_count_(loc_count)
+    , pending_locations_(std::move(pending_locations))
+    , bytes_by_type_(std::move(bytes_by_type))
+    , location_counts_by_type_(std::move(location_counts_by_type))
+    , predicted_deleted_keys_(predicted_deleted_keys)
+    , submitted_at_(submitted_at)
+    , credit_deadline_(credit_deadline)
+    , credit_enabled_(true)
+    , outcome_unknown_reported_(false)
     , fut_(std::move(fut)) {}
 
 void CacheReclaimer::WorkerRoutine() {

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -13,8 +13,10 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -45,6 +47,7 @@ private:                                                                        
 #endif
 
 class CacheReclaimStrategy;
+class CacheLocation;
 class EventManager;
 class InstanceGroup;
 class InstanceGroupQuota;
@@ -57,6 +60,14 @@ class SchedulePlanExecutor;
 class WriteLocationManager;
 struct CacheLocationDelRequest;
 struct PlanExecuteResult;
+
+struct CacheReclaimerAsyncDeleteConfig {
+    std::uint64_t inflight_delete_timeout_ms{60000};
+    std::uint64_t pending_location_limit_per_group_type{100000};
+    std::uint64_t pending_bytes_limit_per_group_type{64ULL * 1024 * 1024 * 1024};
+    std::uint64_t pending_delete_handler_limit{1024};
+    std::uint64_t pending_bytes_limit{256ULL * 1024 * 1024 * 1024};
+};
 
 /**
  * @brief Manages cache reclamation operations to free up memory by
@@ -83,6 +94,23 @@ struct PlanExecuteResult;
  */
 class CacheReclaimer {
 public:
+    using BytesByStorageType = std::array<std::uint64_t, static_cast<std::size_t>(DataStorageType::COUNT)>;
+    using CountsByStorageType = std::array<std::uint64_t, static_cast<std::size_t>(DataStorageType::COUNT)>;
+
+    struct PendingLocationKey {
+        std::string instance_id;
+        std::int64_t block_key;
+        std::string location_id;
+
+        bool operator<(const PendingLocationKey &other) const noexcept {
+            return std::tie(instance_id, block_key, location_id) <
+                   std::tie(other.instance_id, other.block_key, other.location_id);
+        }
+        bool operator==(const PendingLocationKey &other) const noexcept {
+            return instance_id == other.instance_id && block_key == other.block_key && location_id == other.location_id;
+        }
+    };
+
     struct AgeStats {
         int64_t min_us = INT64_MAX;
         int64_t max_us = 0;
@@ -130,7 +158,8 @@ public:
                    std::shared_ptr<SchedulePlanExecutor> sched_plan_executor,
                    std::shared_ptr<MetricsRegistry> metrics_registry,
                    std::shared_ptr<EventManager> event_manager,
-                   std::shared_ptr<WriteLocationManager> write_location_manager);
+                   std::shared_ptr<WriteLocationManager> write_location_manager,
+                   CacheReclaimerAsyncDeleteConfig async_delete_config = {});
 
     /**
      * @brief Delete copy constructor
@@ -324,6 +353,8 @@ private:
     // default to kFutureTimeoutMs
     std::atomic<std::uint32_t> future_timeout_ms_;
 
+    const CacheReclaimerAsyncDeleteConfig async_delete_config_;
+
     std::mutex task_queue_mutex_;
     std::condition_variable cv_task_queue_;
     std::deque<std::function<void()>> task_queue_;
@@ -344,6 +375,14 @@ private:
         const std::string ins_gr_;
         const std::uint64_t blk_count_;
         const std::uint64_t loc_count_;
+        const std::vector<PendingLocationKey> pending_locations_;
+        const BytesByStorageType bytes_by_type_;
+        const CountsByStorageType location_counts_by_type_;
+        const std::uint64_t predicted_deleted_keys_;
+        const std::chrono::steady_clock::time_point submitted_at_;
+        const std::chrono::steady_clock::time_point credit_deadline_;
+        bool credit_enabled_;
+        bool outcome_unknown_reported_;
         std::future<PlanExecuteResult> fut_;
 
         DeleteHandler(std::shared_ptr<RequestContext> req_ctx,
@@ -351,9 +390,38 @@ private:
                       std::string ins_gr,
                       std::uint64_t blk_count,
                       std::uint64_t loc_count,
+                      std::vector<PendingLocationKey> pending_locations,
+                      BytesByStorageType bytes_by_type,
+                      CountsByStorageType location_counts_by_type,
+                      std::uint64_t predicted_deleted_keys,
+                      std::chrono::steady_clock::time_point submitted_at,
+                      std::chrono::steady_clock::time_point credit_deadline,
                       std::future<PlanExecuteResult> fut);
     };
     std::forward_list<DeleteHandler> delete_handlers_;
+
+    struct GroupStorageTypeKey {
+        std::string instance_group;
+        DataStorageType storage_type;
+
+        bool operator<(const GroupStorageTypeKey &other) const noexcept {
+            return std::tie(instance_group, storage_type) < std::tie(other.instance_group, other.storage_type);
+        }
+    };
+
+    struct PendingQuota {
+        std::uint64_t location_count{0};
+        std::uint64_t bytes{0};
+    };
+
+    std::set<PendingLocationKey> pending_locations_;
+    std::map<std::string, BytesByStorageType> credited_delete_bytes_by_group_;
+    std::map<std::string, std::uint64_t> predicted_deleted_keys_by_group_;
+    std::map<GroupStorageTypeKey, PendingQuota> pending_quota_by_group_type_;
+    std::uint64_t pending_delete_handler_count_{0};
+    std::uint64_t pending_delete_bytes_{0};
+    std::set<GroupStorageTypeKey> reported_group_type_metric_keys_;
+    std::set<std::string> reported_group_metric_keys_;
 
     // record instance group water level exceed flags
     class WaterLevelExceed {
@@ -432,7 +500,7 @@ private:
      * @param water_level_exceed the detailed trigger result
      * @param delay_before_delete_ms delay milliseconds for executor
      */
-    void ReclaimByLRU(const std::shared_ptr<RequestContext> &request_context,
+    bool ReclaimByLRU(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
                       const WaterLevelExceed &water_level_exceed,
                       std::int32_t delay_before_delete_ms) noexcept;
@@ -449,7 +517,7 @@ private:
      * @param water_level_exceed the detailed trigger result
      * @param delay_before_delete_ms delay milliseconds for executor
      */
-    void ReclaimByLFU(const std::shared_ptr<RequestContext> &request_context,
+    bool ReclaimByLFU(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
                       const WaterLevelExceed &water_level_exceed,
                       std::int32_t delay_before_delete_ms) noexcept;
@@ -465,13 +533,18 @@ private:
      * @param water_level_exceed the detailed trigger result
      * @param delay_before_delete_ms delay milliseconds for executor
      */
-    void ReclaimByTTL(const std::shared_ptr<RequestContext> &request_context,
+    bool ReclaimByTTL(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
                       const WaterLevelExceed &water_level_exceed,
                       std::int32_t delay_before_delete_ms) noexcept;
 
-    bool TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request_context,
-                           const std::shared_ptr<const InstanceGroup> &instance_group) noexcept;
+    struct ReclaimResult {
+        bool water_level_exceeded{false};
+        bool made_progress{false};
+    };
+
+    ReclaimResult TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request_context,
+                                    const std::shared_ptr<const InstanceGroup> &instance_group) noexcept;
 
     void HandleDelRes() noexcept;
 
@@ -504,11 +577,28 @@ private:
                      const std::vector<std::int64_t> &batch,
                      const WaterLevelExceed &water_level_exceed,
                      std::vector<std::vector<std::string>> &out_loc_ids,
-                     AgeStats &out_create_age_stats) const noexcept;
+                     BytesByStorageType &out_bytes_by_type,
+                     CountsByStorageType &out_location_counts_by_type,
+                     std::uint64_t &out_predicted_deleted_keys,
+                     AgeStats &out_create_age_stats) noexcept;
 
-    void SubmitDelReq(const std::shared_ptr<RequestContext> &request_context,
+    bool SubmitDelReq(const std::shared_ptr<RequestContext> &request_context,
                       const std::shared_ptr<const InstanceInfo> &instance_info,
-                      const CacheLocationDelRequest &req) noexcept;
+                      const CacheLocationDelRequest &req,
+                      const BytesByStorageType &bytes_by_type,
+                      const CountsByStorageType &location_counts_by_type,
+                      std::uint64_t predicted_deleted_keys) noexcept;
+
+    static std::uint64_t SaturatingSub(std::uint64_t lhs, std::uint64_t rhs) noexcept;
+    static std::uint64_t SaturatingAdd(std::uint64_t lhs, std::uint64_t rhs) noexcept;
+    static std::uint64_t GetLocationBytes(const CacheLocation &location) noexcept;
+    BytesByStorageType GetCreditedDeleteBytes(const std::string &instance_group) const noexcept;
+    std::uint64_t GetPredictedDeletedKeys(const std::string &instance_group) const noexcept;
+    void AddDeleteHandlerState(const DeleteHandler &handler) noexcept;
+    void DisableCredit(DeleteHandler &handler, const char *reason) noexcept;
+    void ReleaseDeleteHandlerState(DeleteHandler &handler) noexcept;
+    void RecordPendingLimitReject(const std::string &instance_group, const std::string &storage_type_scope) noexcept;
+    void UpdateAsyncDeleteMetrics() noexcept;
 
     struct GroupUsageData;
 
@@ -522,6 +612,13 @@ private:
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(location_submit_count)
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(block_del_count)
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(location_del_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(credit_timeout_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(pending_limit_reject_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(duplicate_pending_location_filtered_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(reclaim_no_progress_backoff_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_submit_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_complete_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_fail_count)
 
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us)
@@ -531,6 +628,12 @@ private:
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_batch_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_filter_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_lru_submit_duration_us)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(pending_delete_handler_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(pending_location_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(pending_delete_bytes)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(credited_delete_bytes)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(predicted_deleted_key_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(oldest_pending_request_age_ms)
 
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us)

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -1,5 +1,7 @@
 #include "kv_cache_manager/manager/schedule_plan_executor.h"
 
+#include <algorithm>
+#include <exception>
 #include <memory>
 #include <unordered_set>
 
@@ -23,6 +25,13 @@ namespace kv_cache_manager {
     REGISTER_METRICS_GAUGE_(metrics_registry_, schedule_plan_executor, name)
 
 namespace {
+PlanExecuteResult MakeErrorResult(ErrorCode error_code, std::string error_message) {
+    return PlanExecuteResult{
+        .status = error_code,
+        .error_message = std::move(error_message),
+    };
+}
+
 template <typename ResultType, typename... Args>
 void HandleErrorPromise(const std::shared_ptr<std::promise<ResultType>> &promise,
                         ErrorCode error_code,
@@ -35,6 +44,31 @@ void HandleErrorPromise(const std::shared_ptr<std::promise<ResultType>> &promise
     });
 }
 } // namespace
+
+struct SchedulePlanExecutor::PromiseCompletion {
+    explicit PromiseCompletion(std::shared_ptr<std::promise<PlanExecuteResult>> promise)
+        : promise_(std::move(promise)) {}
+
+    void Complete(PlanExecuteResult result) noexcept {
+        if (completed_.exchange(true, std::memory_order_acq_rel)) {
+            KVCM_LOG_ERROR("schedule plan executor promise completed more than once");
+            return;
+        }
+        try {
+            promise_->set_value(std::move(result));
+        } catch (const std::exception &e) {
+            KVCM_LOG_ERROR("complete schedule plan executor promise failed: %s", e.what());
+        } catch (...) { KVCM_LOG_ERROR("complete schedule plan executor promise failed with unknown exception"); }
+    }
+
+    void Complete(ErrorCode error_code, const std::string &error_message) noexcept {
+        Complete(MakeErrorResult(error_code, error_message));
+    }
+
+private:
+    std::shared_ptr<std::promise<PlanExecuteResult>> promise_;
+    std::atomic<bool> completed_{false};
+};
 
 DEFINE_METRICS_NAME_FOR_SCHEDULE_PLAN_EXECUTOR(waiting_task_count);
 DEFINE_METRICS_NAME_FOR_SCHEDULE_PLAN_EXECUTOR(executing_task_count);
@@ -60,8 +94,30 @@ SchedulePlanExecutor::SchedulePlanExecutor(unsigned int thread_count,
 }
 void SchedulePlanExecutor::Stop() {
     KVCM_LOG_DEBUG("Stopping SchedulePlanExecutor...");
-    stop_ = true;
+    std::vector<std::function<void()>> cancel_tasks;
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        stop_ = true;
+        cancel_tasks.reserve(tasks_.size());
+        for (const auto &scheduled_task : tasks_) {
+            if (scheduled_task.cancel_task) {
+                cancel_tasks.emplace_back(scheduled_task.cancel_task);
+            }
+        }
+        if (!tasks_.empty()) {
+            METRICS_(schedule_plan_executor, waiting_task_count) -= tasks_.size();
+            tasks_.clear();
+        }
+    }
     condition_.notify_all();
+
+    for (auto &cancel_task : cancel_tasks) {
+        try {
+            cancel_task();
+        } catch (const std::exception &e) {
+            KVCM_LOG_ERROR("cancel schedule plan executor task failed: %s", e.what());
+        } catch (...) { KVCM_LOG_ERROR("cancel schedule plan executor task failed with unknown exception"); }
+    }
 
     for (auto &worker : workers_) {
         if (worker.joinable()) {
@@ -111,30 +167,31 @@ void SchedulePlanExecutor::WorkerRoutine() {
         if (task) {
             METRICS_(schedule_plan_executor, waiting_task_count) -= 1;
             METRICS_(schedule_plan_executor, executing_task_count) += 1;
-            task();
+            try {
+                task();
+            } catch (const std::exception &e) {
+                KVCM_LOG_ERROR("schedule plan executor task threw exception: %s", e.what());
+            } catch (...) { KVCM_LOG_ERROR("schedule plan executor task threw unknown exception"); }
             METRICS_(schedule_plan_executor, executing_task_count) -= 1;
         }
     }
 }
 
-void SchedulePlanExecutor::DoLocationDelTask(const std::shared_ptr<std::promise<PlanExecuteResult>> &promise,
-                                             const CacheLocationDelRequest &task) {
+PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDelRequest &task) {
     PlanExecuteResult result;
     result.status = ErrorCode::EC_OK;
 
     if (task.block_keys.size() != task.location_ids.size()) {
-        HandleErrorPromise(promise,
-                           ErrorCode::EC_BADARGS,
-                           "block_keys size %d != location_ids size %d",
-                           task.block_keys.size(),
-                           task.location_ids.size());
-        return;
+        return MakeErrorResult(ErrorCode::EC_BADARGS,
+                               StringUtil::FormatString("block_keys size %zu != location_ids size %zu",
+                                                        task.block_keys.size(),
+                                                        task.location_ids.size()));
     }
 
     std::shared_ptr<MetaIndexer> indexer = meta_manager_->GetMetaIndexer(task.instance_id);
     if (!indexer) {
-        HandleErrorPromise(promise, ErrorCode::EC_NOENT, "MetaIndexer %s not found", task.instance_id.c_str());
-        return;
+        return MakeErrorResult(ErrorCode::EC_NOENT,
+                               StringUtil::FormatString("MetaIndexer %s not found", task.instance_id.c_str()));
     }
 
     MetaSearcher meta_searcher(indexer);
@@ -143,8 +200,14 @@ void SchedulePlanExecutor::DoLocationDelTask(const std::shared_ptr<std::promise<
     auto ctx = std::make_shared<RequestContext>("schedule_plan_executor_call");
     ErrorCode get_locations_ec = meta_searcher.BatchGetLocation(ctx.get(), task.block_keys, empty_mask, location_maps);
     if (get_locations_ec != ErrorCode::EC_OK) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "Failed to get block locations, ec: %d", get_locations_ec);
-        return;
+        return MakeErrorResult(ErrorCode::EC_ERROR,
+                               StringUtil::FormatString("Failed to get block locations, ec: %d", get_locations_ec));
+    }
+    if (location_maps.size() != task.block_keys.size()) {
+        return MakeErrorResult(ErrorCode::EC_ERROR,
+                               StringUtil::FormatString("block location result size %zu != block_keys size %zu",
+                                                        location_maps.size(),
+                                                        task.block_keys.size()));
     }
 
     std::vector<int64_t> block_keys_to_delete;
@@ -193,7 +256,14 @@ void SchedulePlanExecutor::DoLocationDelTask(const std::shared_ptr<std::promise<
         KVCM_LOG_DEBUG("Deleting %zu entries from storage: %s", storage_uris.size(), storage_unique_name.c_str());
         std::vector<ErrorCode> delete_results =
             data_storage_manager_->Delete(request_context.get(), storage_unique_name, storage_uris, nullptr);
-        for (size_t i = 0; i < delete_results.size(); ++i) {
+        if (delete_results.size() != storage_uris.size()) {
+            result.status = ErrorCode::EC_PARTIAL_OK;
+            result.error_message = StringUtil::FormatString(
+                "storage delete result size %zu != request size %zu", delete_results.size(), storage_uris.size());
+            KVCM_LOG_WARN("%s", result.error_message.c_str());
+        }
+        const auto result_count = std::min(delete_results.size(), storage_uris.size());
+        for (size_t i = 0; i < result_count; ++i) {
             if (delete_results[i] != ErrorCode::EC_OK) {
                 // 这里存储删除报错暂且不管，报个warn表示哪个storageUri删失败了
                 result.status = ErrorCode::EC_PARTIAL_OK;
@@ -211,38 +281,64 @@ void SchedulePlanExecutor::DoLocationDelTask(const std::shared_ptr<std::promise<
         std::vector<std::vector<ErrorCode>> delete_meta_results;
         ErrorCode delete_meta_ec =
             meta_searcher.BatchCADLocationStatus(ctx.get(), block_keys_to_delete, batch_cad_tasks, delete_meta_results);
-        (void)delete_meta_ec; // 忽略返回值
-        for (size_t block_key_idx = 0; block_key_idx < delete_meta_results.size(); ++block_key_idx) {
+        if (delete_meta_ec != ErrorCode::EC_OK || delete_meta_results.size() != batch_cad_tasks.size()) {
+            result.status = ErrorCode::EC_PARTIAL_OK;
+            result.error_message =
+                StringUtil::FormatString("location CAD failed, ec: %d, result size %zu != task size %zu",
+                                         static_cast<int>(delete_meta_ec),
+                                         delete_meta_results.size(),
+                                         batch_cad_tasks.size());
+            KVCM_LOG_WARN("%s", result.error_message.c_str());
+        }
+        const auto block_result_count = std::min(delete_meta_results.size(), batch_cad_tasks.size());
+        for (size_t block_key_idx = 0; block_key_idx < block_result_count; ++block_key_idx) {
             auto &results = delete_meta_results[block_key_idx];
-            for (size_t location_idx = 0; location_idx < results.size(); location_idx++) {
+            if (results.size() != batch_cad_tasks[block_key_idx].size()) {
+                result.status = ErrorCode::EC_PARTIAL_OK;
+                KVCM_LOG_WARN("location CAD result size %zu != task size %zu for block key %ld",
+                              results.size(),
+                              batch_cad_tasks[block_key_idx].size(),
+                              block_keys_to_delete[block_key_idx]);
+            }
+            const auto location_result_count = std::min(results.size(), batch_cad_tasks[block_key_idx].size());
+            for (size_t location_idx = 0; location_idx < location_result_count; location_idx++) {
                 if (results[location_idx] != ErrorCode::EC_OK) {
                     result.status = ErrorCode::EC_PARTIAL_OK;
                     KVCM_LOG_WARN("Failed to CAD meta key %ld, location: %s, error_code: %d",
                                   block_keys_to_delete[block_key_idx],
                                   batch_cad_tasks[block_key_idx][location_idx].location_id.c_str(),
-                                  results[location_idx]);
+                                  static_cast<int>(results[location_idx]));
                 }
             }
         }
     }
     KVCM_LOG_DEBUG("DoDelLocationTask completed successfully for instance_id: %s", task.instance_id.c_str());
 
-    promise->set_value(result);
+    return result;
 }
 
-bool SchedulePlanExecutor::SubmitRaw(const std::function<void()> &task, std::chrono::microseconds delay) {
-    {
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        if (stop_) {
-            return false;
+bool SchedulePlanExecutor::SubmitRaw(const std::function<void()> &task,
+                                     std::chrono::microseconds delay,
+                                     const std::function<void()> &cancel_task) {
+    try {
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            if (stop_) {
+                return false;
+            }
+
+            auto execute_time = std::chrono::steady_clock::now() + delay;
+            uint64_t sequence_id = sequence_counter_.fetch_add(1, std::memory_order_relaxed);
+            tasks_.emplace(ScheduledTask{task, cancel_task, execute_time, sequence_id});
+            METRICS_(schedule_plan_executor, waiting_task_count) += 1;
         }
-
-        auto execute_time = std::chrono::steady_clock::now() + delay;
-        uint64_t sequence_id = sequence_counter_.fetch_add(1, std::memory_order_relaxed);
-        tasks_.emplace(ScheduledTask{task, execute_time, sequence_id});
+    } catch (const std::exception &e) {
+        KVCM_LOG_ERROR("enqueue schedule plan executor task failed: %s", e.what());
+        return false;
+    } catch (...) {
+        KVCM_LOG_ERROR("enqueue schedule plan executor task failed with unknown exception");
+        return false;
     }
-    METRICS_(schedule_plan_executor, waiting_task_count) += 1;
-
     condition_.notify_one();
     return true;
 }
@@ -331,8 +427,19 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheMetaDelRe
     KVCM_LOG_DEBUG("Location statuses updated, submitting task to worker pool with delay: %lld microseconds",
                    static_cast<long long>(task.delay.count()));
 
-    bool submit_result =
-        this->SubmitRaw([this, promise, actual_task]() { DoLocationDelTask(promise, actual_task); }, task.delay);
+    auto execute_task = [this, promise, actual_task]() {
+        try {
+            promise->set_value(DoLocationDelTask(actual_task));
+        } catch (const std::exception &e) {
+            HandleErrorPromise(promise, ErrorCode::EC_ERROR, "location delete task threw exception: %s", e.what());
+        } catch (...) {
+            HandleErrorPromise(promise, ErrorCode::EC_ERROR, "location delete task threw unknown exception");
+        }
+    };
+    auto cancel_task = [promise]() {
+        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before task execution.");
+    };
+    bool submit_result = this->SubmitRaw(execute_task, task.delay, cancel_task);
     if (!submit_result) {
         HandleErrorPromise(promise, ErrorCode::EC_ERROR, "submit task failed");
         return future;
@@ -349,7 +456,7 @@ bool SchedulePlanExecutor::FillActualTask(
 
     if (batch_results.size() != batch_cas_block_keys.size() || batch_results.size() != batch_cas_tasks.size()) {
         error_message = StringUtil::FormatString(
-            "Size mismatch between batch_results(%d), batch_cas_block_keys(%d) and batch_cas_tasks(%d).",
+            "Size mismatch between batch_results(%zu), batch_cas_block_keys(%zu) and batch_cas_tasks(%zu).",
             batch_results.size(),
             batch_cas_block_keys.size(),
             batch_cas_tasks.size());
@@ -359,6 +466,15 @@ bool SchedulePlanExecutor::FillActualTask(
 
     for (size_t key_idx = 0; key_idx < batch_results.size(); key_idx++) {
         auto &results = batch_results[key_idx];
+        if (results.size() != batch_cas_tasks[key_idx].size()) {
+            error_message = StringUtil::FormatString(
+                "Location CAS result size mismatch for block key %ld: results(%zu), tasks(%zu).",
+                batch_cas_block_keys[key_idx],
+                results.size(),
+                batch_cas_tasks[key_idx].size());
+            KVCM_LOG_ERROR("%s", error_message.c_str());
+            return false;
+        }
         std::vector<std::string> location_ids;
         for (size_t location_idx = 0; location_idx < results.size(); location_idx++) {
             if (results[location_idx] != EC_OK) {
@@ -377,23 +493,42 @@ bool SchedulePlanExecutor::FillActualTask(
     }
     return true;
 }
-std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationDelRequest &task) {
-    KVCM_LOG_DEBUG("Submitting location delete task for instance_id: %s, block_keys count: %zu",
-                   task.instance_id.c_str(),
-                   task.block_keys.size());
+SchedulePlanExecutor::LocationDelAdmissionResult
+SchedulePlanExecutor::PrepareDeleteTask(const CacheMetaDelRequest &task) {
+    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, task.delay);
+}
 
-    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
-    std::future<PlanExecuteResult> future = promise->get_future();
+SchedulePlanExecutor::LocationDelAdmissionResult
+SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
+    if (task.block_keys.size() != task.location_ids.size()) {
+        LocationDelAdmissionResult admission_result;
+        admission_result.result = MakeErrorResult(
+            ErrorCode::EC_BADARGS,
+            StringUtil::FormatString(
+                "block_keys size %zu != location_ids size %zu", task.block_keys.size(), task.location_ids.size()));
+        return admission_result;
+    }
+    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, &task.location_ids, task.delay);
+}
+
+SchedulePlanExecutor::LocationDelAdmissionResult
+SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
+                                            const std::vector<int64_t> &block_keys,
+                                            const std::vector<std::vector<std::string>> *target_location_ids,
+                                            std::chrono::microseconds delay) {
+    LocationDelAdmissionResult admission_result;
+    admission_result.actual_task = CacheLocationDelRequest{instance_id, {}, {}, delay};
 
     if (stop_) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped.");
-        return future;
+        admission_result.result = MakeErrorResult(ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped.");
+        return admission_result;
     }
 
-    std::shared_ptr<MetaIndexer> indexer = meta_manager_->GetMetaIndexer(task.instance_id);
+    std::shared_ptr<MetaIndexer> indexer = meta_manager_->GetMetaIndexer(instance_id);
     if (!indexer) {
-        HandleErrorPromise(promise, ErrorCode::EC_NOENT, "MetaIndexer %s not found", task.instance_id.c_str());
-        return future;
+        admission_result.result = MakeErrorResult(
+            ErrorCode::EC_NOENT, StringUtil::FormatString("MetaIndexer %s not found", instance_id.c_str()));
+        return admission_result;
     }
 
     MetaSearcher meta_searcher(indexer);
@@ -401,18 +536,30 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
     BlockMask empty_mask;
     auto request_context = std::make_shared<RequestContext>("schedule_plan_executor_call");
     ErrorCode get_locations_ec =
-        meta_searcher.BatchGetLocation(request_context.get(), task.block_keys, empty_mask, location_maps);
+        meta_searcher.BatchGetLocation(request_context.get(), block_keys, empty_mask, location_maps);
     if (get_locations_ec != ErrorCode::EC_OK) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "Failed to get block locations, ec: %d", get_locations_ec);
-        return future;
+        admission_result.result = MakeErrorResult(
+            ErrorCode::EC_ERROR, StringUtil::FormatString("Failed to get block locations, ec: %d", get_locations_ec));
+        return admission_result;
+    }
+    if (location_maps.size() != block_keys.size()) {
+        admission_result.result = MakeErrorResult(
+            ErrorCode::EC_ERROR,
+            StringUtil::FormatString(
+                "block location result size %zu != block_keys size %zu", location_maps.size(), block_keys.size()));
+        return admission_result;
     }
 
     std::vector<int64_t> batch_cas_block_keys;
     std::vector<std::vector<MetaSearcher::LocationCASTask>> batch_cas_tasks;
-    for (size_t block_key_idx = 0; block_key_idx < task.block_keys.size(); ++block_key_idx) {
-        std::unordered_set<std::string> target_location_ids(task.location_ids[block_key_idx].begin(),
-                                                            task.location_ids[block_key_idx].end());
-        auto block_key = task.block_keys[block_key_idx];
+    // A null target list represents CacheMetaDelRequest and selects every non-deleting location.
+    for (size_t block_key_idx = 0; block_key_idx < block_keys.size(); ++block_key_idx) {
+        std::unordered_set<std::string> target_ids;
+        if (target_location_ids != nullptr) {
+            target_ids.insert((*target_location_ids)[block_key_idx].begin(),
+                              (*target_location_ids)[block_key_idx].end());
+        }
+        auto block_key = block_keys[block_key_idx];
         auto &location_map = location_maps[block_key_idx];
         std::vector<MetaSearcher::LocationCASTask> location_cas_tasks;
         for (const auto &loc_kv : location_map) {
@@ -421,10 +568,10 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
             }
             const auto &location = *loc_kv.second;
             if (location.status() == CacheLocationStatus::CLS_DELETING) {
-                continue; // ignore already deleting
+                continue;
             }
-            if (target_location_ids.find(location.id()) == target_location_ids.end()) {
-                continue; // ignore not target location
+            if (target_location_ids != nullptr && target_ids.find(location.id()) == target_ids.end()) {
+                continue;
             }
             location_cas_tasks.push_back({location.id(), location.status(), CacheLocationStatus::CLS_DELETING});
         }
@@ -435,8 +582,7 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
         batch_cas_tasks.emplace_back(std::move(location_cas_tasks));
     }
     if (batch_cas_block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
-        return future;
+        return admission_result;
     }
 
     std::vector<std::vector<ErrorCode>> batch_results;
@@ -447,36 +593,104 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
     }
 
     std::string error_message;
-    CacheLocationDelRequest actual_task{task.instance_id, {}, {}, task.delay};
-    if (!FillActualTask(batch_cas_block_keys, batch_cas_tasks, batch_results, actual_task, error_message)) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "FillActualTask error: %s", error_message.c_str());
-        return future;
+    if (!FillActualTask(
+            batch_cas_block_keys, batch_cas_tasks, batch_results, admission_result.actual_task, error_message)) {
+        admission_result.result = MakeErrorResult(
+            ErrorCode::EC_ERROR, StringUtil::FormatString("FillActualTask error: %s", error_message.c_str()));
+        return admission_result;
     }
-    if (actual_task.block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
-        return future;
-    }
-
-    // Sync: ensure CAS(→DELETING) is persisted before scheduling Phase 2.
-    if (!indexer->Sync(actual_task.block_keys)) {
-        HandleErrorPromise(promise,
-                           ErrorCode::EC_ERROR,
-                           "Sync failed or timed out for location delete, instance[%s]",
-                           task.instance_id.c_str());
-        return future;
+    if (admission_result.actual_task.block_keys.empty()) {
+        return admission_result;
     }
 
-    KVCM_LOG_DEBUG("Location statuses updated, submitting task to worker pool with delay: %lld microseconds",
-                   static_cast<long long>(task.delay.count()));
-
-    bool submit_result =
-        this->SubmitRaw([this, promise, actual_task]() { DoLocationDelTask(promise, actual_task); }, task.delay);
-    if (!submit_result) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "submit task failed");
-        return future;
+    if (!indexer->Sync(admission_result.actual_task.block_keys)) {
+        admission_result.result =
+            MakeErrorResult(ErrorCode::EC_ERROR,
+                            StringUtil::FormatString("Sync failed or timed out for location delete, instance[%s]",
+                                                     instance_id.c_str()));
+        return admission_result;
     }
 
+    admission_result.needs_physical_delete = true;
+    return admission_result;
+}
+
+void SchedulePlanExecutor::RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,
+                                              std::chrono::microseconds delay,
+                                              const std::function<LocationDelAdmissionResult()> &prepare) {
+    try {
+        auto admission_result = prepare();
+        if (admission_result.result.status != ErrorCode::EC_OK || !admission_result.needs_physical_delete) {
+            completion->Complete(std::move(admission_result.result));
+            return;
+        }
+
+        KVCM_LOG_DEBUG("Location statuses updated, submitting task to worker pool with delay: %lld microseconds",
+                       static_cast<long long>(delay.count()));
+        auto actual_task = std::move(admission_result.actual_task);
+        auto execute_task = [this, completion, actual_task]() {
+            try {
+                completion->Complete(DoLocationDelTask(actual_task));
+            } catch (const std::exception &e) {
+                completion->Complete(ErrorCode::EC_ERROR,
+                                     StringUtil::FormatString("location delete task threw exception: %s", e.what()));
+            } catch (...) { completion->Complete(ErrorCode::EC_ERROR, "location delete task threw unknown exception"); }
+        };
+        auto cancel_task = [completion]() {
+            completion->Complete(ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before physical delete.");
+        };
+        if (!SubmitRaw(execute_task, delay, cancel_task)) {
+            completion->Complete(ErrorCode::EC_ERROR, "submit physical delete task failed");
+        }
+    } catch (const std::exception &e) {
+        completion->Complete(ErrorCode::EC_ERROR,
+                             StringUtil::FormatString("location delete admission threw exception: %s", e.what()));
+    } catch (...) { completion->Complete(ErrorCode::EC_ERROR, "location delete admission threw unknown exception"); }
+}
+
+std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationDelRequest &task) {
+    KVCM_LOG_DEBUG("Submitting location delete task for instance_id: %s, block_keys count: %zu",
+                   task.instance_id.c_str(),
+                   task.block_keys.size());
+
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto future = promise->get_future();
+    auto completion = std::make_shared<PromiseCompletion>(promise);
+    RunDeleteAdmission(completion, task.delay, [this, &task]() { return PrepareDeleteTask(task); });
     return future;
+}
+
+AsyncDeleteSubmitResult SchedulePlanExecutor::SubmitAsync(const CacheMetaDelRequest &task) {
+    KVCM_LOG_DEBUG("Submitting async meta delete task for instance_id: %s, block_keys count: %zu",
+                   task.instance_id.c_str(),
+                   task.block_keys.size());
+    return SubmitDeleteTaskAsync(task.delay, [this, task]() { return PrepareDeleteTask(task); });
+}
+
+AsyncDeleteSubmitResult SchedulePlanExecutor::SubmitAsync(const CacheLocationDelRequest &task) {
+    KVCM_LOG_DEBUG("Submitting async location delete task for instance_id: %s, block_keys count: %zu",
+                   task.instance_id.c_str(),
+                   task.block_keys.size());
+
+    return SubmitDeleteTaskAsync(task.delay, [this, task]() { return PrepareDeleteTask(task); });
+}
+
+AsyncDeleteSubmitResult
+SchedulePlanExecutor::SubmitDeleteTaskAsync(std::chrono::microseconds delay,
+                                            std::function<LocationDelAdmissionResult()> prepare) {
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto future = promise->get_future();
+    auto completion = std::make_shared<PromiseCompletion>(promise);
+    auto admission_task = [this, completion, delay, prepare = std::move(prepare)]() {
+        RunDeleteAdmission(completion, delay, prepare);
+    };
+    auto cancel_task = [completion]() {
+        completion->Complete(ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before delete admission.");
+    };
+    if (!SubmitRaw(admission_task, std::chrono::microseconds::zero(), cancel_task)) {
+        return AsyncDeleteSubmitResult{};
+    }
+    return AsyncDeleteSubmitResult{true, std::move(future)};
 }
 
 bool SchedulePlanExecutor::SubmitNonBlocking(const CacheMetaDelRequest &req) {

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -41,6 +41,11 @@ struct PlanExecuteResult {
     std::string error_message;
 };
 
+struct AsyncDeleteSubmitResult {
+    bool accepted{false};
+    std::future<PlanExecuteResult> future;
+};
+
 struct CacheLocationDelRequest {
     std::string instance_id;
     std::vector<int64_t> block_keys;
@@ -50,6 +55,7 @@ struct CacheLocationDelRequest {
 
 struct ScheduledTask {
     std::function<void()> task;
+    std::function<void()> cancel_task;
     std::chrono::steady_clock::time_point execute_time;
     uint64_t sequence_id;
 
@@ -72,6 +78,8 @@ public:
 
     std::future<PlanExecuteResult> Submit(const CacheMetaDelRequest &task);
     std::future<PlanExecuteResult> Submit(const CacheLocationDelRequest &task);
+    AsyncDeleteSubmitResult SubmitAsync(const CacheMetaDelRequest &task);
+    AsyncDeleteSubmitResult SubmitAsync(const CacheLocationDelRequest &task);
 
     bool SubmitNonBlocking(const CacheMetaDelRequest &req);
     bool SubmitNonBlocking(const CacheLocationDelRequest &req);
@@ -79,6 +87,13 @@ public:
     bool SubmitTask(std::function<void()> task, std::chrono::microseconds delay = std::chrono::microseconds(0));
 
 private:
+    struct PromiseCompletion;
+    struct LocationDelAdmissionResult {
+        PlanExecuteResult result{ErrorCode::EC_OK, ""};
+        CacheLocationDelRequest actual_task;
+        bool needs_physical_delete{false};
+    };
+
     std::shared_ptr<MetaIndexerManager> meta_manager_;
     std::shared_ptr<DataStorageManager> data_storage_manager_;
     std::shared_ptr<MetricsRegistry> metrics_registry_;
@@ -93,14 +108,26 @@ private:
     void WorkerRoutine();
 
     void Stop();
-    bool SubmitRaw(const std::function<void()> &task, std::chrono::microseconds delay);
+    bool SubmitRaw(const std::function<void()> &task,
+                   std::chrono::microseconds delay,
+                   const std::function<void()> &cancel_task = {});
     static bool FillActualTask(const std::vector<int64_t> &batch_cas_block_keys,
                                const std::vector<std::vector<MetaSearcher::LocationCASTask>> &batch_cas_tasks,
                                const std::vector<std::vector<ErrorCode>> &batch_results,
                                CacheLocationDelRequest &actual_task,
                                std::string &error_message);
-    void DoLocationDelTask(const std::shared_ptr<std::promise<PlanExecuteResult>> &promise,
-                           const CacheLocationDelRequest &task);
+    LocationDelAdmissionResult PrepareDeleteTask(const CacheMetaDelRequest &task);
+    LocationDelAdmissionResult PrepareDeleteTask(const CacheLocationDelRequest &task);
+    LocationDelAdmissionResult PrepareDeleteTaskImpl(const std::string &instance_id,
+                                                     const std::vector<int64_t> &block_keys,
+                                                     const std::vector<std::vector<std::string>> *target_location_ids,
+                                                     std::chrono::microseconds delay);
+    void RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,
+                            std::chrono::microseconds delay,
+                            const std::function<LocationDelAdmissionResult()> &prepare);
+    AsyncDeleteSubmitResult SubmitDeleteTaskAsync(std::chrono::microseconds delay,
+                                                  std::function<LocationDelAdmissionResult()> prepare);
+    PlanExecuteResult DoLocationDelTask(const CacheLocationDelRequest &task);
 
     KVCM_GAUGE_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(waiting_task_count)
     KVCM_GAUGE_METRICS_FOR_SCHEDULE_PLAN_EXECUTOR(executing_task_count)

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -37,9 +37,11 @@ cc_test(
     ],
     copts = ["-fno-access-control"],
     data = [],
+    linkstatic = True,
     deps = [
         "//kv_cache_manager/common:unittest",
         "//kv_cache_manager/manager:schedule_plan_executor",
+        "@cpp_stub",
     ],
 )
 

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -47,6 +47,32 @@ bool VecContains(const std::vector<std::int64_t> &vec, const std::int64_t v) {
     return std::any_of(vec.cbegin(), vec.cend(), [v](const std::int64_t &e) { return e == v; });
 }
 
+std::vector<CacheLocationMap>
+MakeServingLocationMaps(const std::size_t count, const DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_NFS) {
+    std::vector<CacheLocationMap> maps;
+    maps.reserve(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        const std::string location_id = "serving_location_" + std::to_string(i);
+        maps.push_back(CacheLocationMap{
+            {location_id,
+             std::make_shared<CacheLocation>(
+                 location_id, CacheLocationStatus::CLS_SERVING, type, 0, std::vector<LocationSpec>{})},
+        });
+    }
+    return maps;
+}
+
+CacheLocationConstPtr MakeCacheLocation(const std::string &location_id,
+                                        const CacheLocationStatus status,
+                                        const DataStorageType type,
+                                        const std::string &uri) {
+    std::vector<LocationSpec> specs;
+    if (!uri.empty()) {
+        specs.emplace_back("test_spec", uri);
+    }
+    return std::make_shared<CacheLocation>(location_id, status, type, specs.size(), std::move(specs));
+}
+
 /* ---------------- RegistryManager_ListInstanceGroup_stub ---------------- */
 
 using ins_group_ptr_vec = std::vector<std::shared_ptr<const InstanceGroup>>;
@@ -167,26 +193,39 @@ RegistryManager_ListInstanceInfo_stub(void *obj, RequestContext *rc, const std::
     return std::make_pair(list_ins_info_result, iv);
 }
 
-/* ---------------- SchedulePlanExecutor_Submit_stub ---------------- */
+/* ---------------- SchedulePlanExecutor_SubmitAsync_stub ---------------- */
 
 std::chrono::milliseconds spe_submit_delay{0};
 PlanExecuteResult del_result;
+bool spe_submit_accepted;
+bool spe_submit_auto_complete;
+bool spe_submit_invalid_future;
 std::vector<CacheLocationDelRequest> submitted_del_requests;
+std::vector<std::shared_ptr<std::promise<PlanExecuteResult>>> submitted_del_promises;
 std::mutex submitted_del_requests_mutex;
-// spe_submit_loc is used to help casting the func addr in the stub def below
-// the using declarations is the same as
-// typedef std::future<PlanExecuteResult> (SchedulePlanExecutor::*spe_submit_loc)(const CacheLocationDelRequest &);
-using spe_submit_loc = std::future<PlanExecuteResult> (SchedulePlanExecutor::*)(const CacheLocationDelRequest &);
+using spe_submit_async_loc = AsyncDeleteSubmitResult (SchedulePlanExecutor::*)(const CacheLocationDelRequest &);
 
-std::future<PlanExecuteResult> SchedulePlanExecutor_Submit_stub(void *obj, const CacheLocationDelRequest &request) {
+AsyncDeleteSubmitResult SchedulePlanExecutor_SubmitAsync_stub(void *obj, const CacheLocationDelRequest &request) {
     const auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
     {
         std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
         submitted_del_requests.emplace_back(request);
+        if (!spe_submit_auto_complete) {
+            submitted_del_promises.emplace_back(promise);
+        }
     }
     std::this_thread::sleep_for(spe_submit_delay);
-    promise->set_value(del_result);
-    return promise->get_future();
+    if (!spe_submit_accepted) {
+        return {};
+    }
+    if (spe_submit_invalid_future) {
+        return AsyncDeleteSubmitResult{true, {}};
+    }
+    auto future = promise->get_future();
+    if (spe_submit_auto_complete) {
+        promise->set_value(del_result);
+    }
+    return AsyncDeleteSubmitResult{true, std::move(future)};
 }
 
 /* ---------------- MetaIndexerManager_GetMetaIndexer_stub ---------------- */
@@ -308,7 +347,8 @@ public:
         // set up stubs
         stub_.set(ADDR(RegistryManager, ListInstanceGroup), RegistryManager_ListInstanceGroup_stub);
         stub_.set(ADDR(RegistryManager, ListInstanceInfo), RegistryManager_ListInstanceInfo_stub);
-        stub_.set(static_cast<spe_submit_loc>(ADDR(SchedulePlanExecutor, Submit)), SchedulePlanExecutor_Submit_stub);
+        stub_.set(static_cast<spe_submit_async_loc>(ADDR(SchedulePlanExecutor, SubmitAsync)),
+                  SchedulePlanExecutor_SubmitAsync_stub);
         stub_.set(ADDR(MetaIndexerManager, GetMetaIndexer), MetaIndexerManager_GetMetaIndexer_stub);
         stub_.set(ADDR(MetaIndexer, GetProperties), MetaIndexer_GetProperties_stub);
         stub_.set(ADDR(MetaIndexer, RandomSample), MetaIndexer_RandomSample_stub);
@@ -331,6 +371,9 @@ public:
         dummy_meta_searcher = std::make_shared<MetaSearcher>(nullptr);
 
         del_result = {ErrorCode::EC_OK, ""};
+        spe_submit_accepted = true;
+        spe_submit_auto_complete = true;
+        spe_submit_invalid_future = false;
         get_result = ErrorCode::EC_OK;
         random_sample_result = ErrorCode::EC_OK;
         sample_reclaim_result = ErrorCode::EC_OK;
@@ -373,6 +416,20 @@ public:
             mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, block_del_count));
         cache_reclaimer_->METRICS_(cache_reclaimer, location_del_count) =
             mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, location_del_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, credit_timeout_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, credit_timeout_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, pending_limit_reject_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, pending_limit_reject_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, duplicate_pending_location_filtered_count) = mr_->GetCounter(
+            SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, duplicate_pending_location_filtered_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, reclaim_no_progress_backoff_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, reclaim_no_progress_backoff_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, delete_submit_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, delete_submit_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, delete_complete_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, delete_complete_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, delete_fail_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, delete_fail_count));
 
         cache_reclaimer_->METRICS_(cache_reclaimer, reclaim_cron_duration_us) =
             mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, reclaim_cron_duration_us));
@@ -386,6 +443,18 @@ public:
             mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, reclaim_lru_filter_duration_us));
         cache_reclaimer_->METRICS_(cache_reclaimer, reclaim_lru_submit_duration_us) =
             mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, reclaim_lru_submit_duration_us));
+        cache_reclaimer_->METRICS_(cache_reclaimer, pending_delete_handler_count) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, pending_delete_handler_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, pending_location_count) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, pending_location_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, pending_delete_bytes) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, pending_delete_bytes));
+        cache_reclaimer_->METRICS_(cache_reclaimer, credited_delete_bytes) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, credited_delete_bytes));
+        cache_reclaimer_->METRICS_(cache_reclaimer, predicted_deleted_key_count) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, predicted_deleted_key_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, oldest_pending_request_age_ms) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, oldest_pending_request_age_ms));
     }
 
     void TearDown() override {
@@ -400,6 +469,7 @@ public:
         {
             std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
             submitted_del_requests.clear();
+            submitted_del_promises.clear();
         }
 
         get_out_properties.clear();
@@ -409,7 +479,7 @@ public:
 
         stub_.reset(ADDR(RegistryManager, ListInstanceGroup));
         stub_.reset(ADDR(RegistryManager, ListInstanceInfo));
-        stub_.reset(static_cast<spe_submit_loc>(ADDR(SchedulePlanExecutor, Submit)));
+        stub_.reset(static_cast<spe_submit_async_loc>(ADDR(SchedulePlanExecutor, SubmitAsync)));
         stub_.reset(ADDR(MetaIndexerManager, GetMetaIndexer));
         stub_.reset(ADDR(MetaIndexer, GetProperties));
         stub_.reset(ADDR(MetaIndexer, RandomSample));
@@ -462,6 +532,22 @@ public:
         return WaitUntil([this] { return HasSubmittedDelRequests(); }, timeout);
     }
 
+    void CompleteSubmittedDelete(const std::size_t index, const PlanExecuteResult &result) {
+        std::shared_ptr<std::promise<PlanExecuteResult>> promise;
+        {
+            std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
+            ASSERT_LT(index, submitted_del_promises.size());
+            promise = submitted_del_promises[index];
+        }
+        promise->set_value(result);
+    }
+
+    void ReplaceReclaimer(const CacheReclaimerAsyncDeleteConfig &config) {
+        cache_reclaimer_->Stop();
+        cache_reclaimer_ =
+            std::make_unique<CacheReclaimer>(10, 100, 10, 10, 16, rm_, mim_, msm_, spe_, mr_, em_, nullptr, config);
+    }
+
     int ListInstanceGroupCallCount() {
         std::lock_guard<std::mutex> lock(list_ins_group_mut);
         return list_ins_group_call_counter;
@@ -482,7 +568,7 @@ public:
 TEST_F(CacheReclaimerTest, TestStartStop) {
     stub_.reset(ADDR(RegistryManager, ListInstanceGroup));
     stub_.reset(ADDR(RegistryManager, ListInstanceInfo));
-    stub_.reset(static_cast<spe_submit_loc>(ADDR(SchedulePlanExecutor, Submit)));
+    stub_.reset(static_cast<spe_submit_async_loc>(ADDR(SchedulePlanExecutor, SubmitAsync)));
     stub_.reset(ADDR(MetaIndexerManager, GetMetaIndexer));
     stub_.reset(ADDR(MetaIndexer, GetProperties));
     stub_.reset(ADDR(MetaIndexer, RandomSample));
@@ -675,8 +761,7 @@ TEST_F(CacheReclaimerTest, TestPauseResume) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 2));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
 
     {
         cache_reclaimer_->Pause();
@@ -1382,10 +1467,11 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
     }
 
     {
-        // instance 0 block byte size = 1024, key count = 0, max key count = 32
-        // instance 1 block byte size = 1024, key count = 0, max key count = 32
+        // instance 0 storage usage = 1024, key count = 0, max key count = 32
+        // instance 1 storage usage = 1024, key count = 0, max key count = 32
         // group quota capacity set to zero
-        // should *not* trigger reclaiming when group_used_byte_size = 0
+        // Byte and key-count water levels are independent, so positive official
+        // storage usage still triggers reclaiming when the key count is zero.
 
         key_count = 0;
         max_key_count = 32;
@@ -1398,7 +1484,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
                                                          instance_infos);
-        ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
+        ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
+        ASSERT_TRUE(wle->GetGeneralWaterLevelExceed());
     }
 
     {
@@ -1431,10 +1518,10 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
     }
 
     {
-        // instance 0 block byte size = 1024, key count = 0, max key count = 32
-        // instance 1 block byte size = 1024, key count = 0, max key count = 32
+        // instance 0 storage usage = 1024, key count = 0, max key count = 32
+        // instance 1 storage usage = 1024, key count = 0, max key count = 32
         // group quota capacity set to -1
-        // should *not* trigger reclaiming when group_used_byte_size = 0
+        // A negative capacity has the same zero-capacity semantics.
 
         key_count = 0;
         max_key_count = 32;
@@ -1447,7 +1534,8 @@ TEST_F(CacheReclaimerTest, TestTriggerReclaiming16) {
                                                          ins_group->quota(),
                                                          ins_group->cache_config()->reclaim_strategy(),
                                                          instance_infos);
-        ASSERT_FALSE(CacheReclaimer::IsTriggerReclaiming(wle));
+        ASSERT_TRUE(CacheReclaimer::IsTriggerReclaiming(wle));
+        ASSERT_TRUE(wle->GetGeneralWaterLevelExceed());
     }
 }
 
@@ -1611,7 +1699,7 @@ TEST_F(CacheReclaimerTest, TestInsufficientSampledKeys) {
     // batching_size default to 100 which is larger than the size of sampled keys (10)
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 100));
-    batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(sample_reclaim_keys.size());
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
     // main thread sleeps for 10ms to ensure the worker thread do
@@ -1684,8 +1772,7 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU00) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 2));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
     ASSERT_TRUE(WaitUntilSubmittedDelRequests());
@@ -1753,8 +1840,7 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU01) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 3));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
     ASSERT_TRUE(WaitUntilSubmittedDelRequests());
@@ -1824,8 +1910,7 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU02) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 3));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
     ASSERT_TRUE(WaitUntilSubmittedDelRequests());
@@ -1958,8 +2043,7 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU04) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
     ASSERT_TRUE(WaitUntilSubmittedDelRequests());
@@ -2171,6 +2255,7 @@ TEST_F(CacheReclaimerTest, TestSchedulePlanExecutorDelFailure) {
     del_result = {ErrorCode::EC_ERROR, "unknown"};
 
     // update the trigger strategy to trigger the reclaiming
+    dummy_meta_indexer->AddStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 4096);
 
     // use instance 0 from setup()
     // construct instance 1
@@ -2183,10 +2268,10 @@ TEST_F(CacheReclaimerTest, TestSchedulePlanExecutorDelFailure) {
     ins_group->quota_.set_capacity(2048);
     instance_groups.emplace_back(ins_group);
 
-    batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests());
     ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
 
     cache_reclaimer_->Stop();
@@ -2377,8 +2462,7 @@ TEST_F(CacheReclaimerTest, TestMultipleInstanceGroups) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 5));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     cache_reclaimer_->SetSleepIntervalMs(request_context_.get(), 0);
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
@@ -2467,7 +2551,7 @@ TEST_F(CacheReclaimerTest, TestKeyCountEdgeCases) {
         ins_group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.01); // 1%
         instance_groups.emplace_back(ins_group);
 
-        batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
+        batch_get_loc_out_maps = MakeServingLocationMaps(sample_reclaim_keys.size());
         ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
@@ -2493,7 +2577,7 @@ TEST_F(CacheReclaimerTest, TestKeyCountEdgeCases) {
         // clear requests from previous test
         ClearSubmittedDelRequests();
 
-        batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
+        batch_get_loc_out_maps = MakeServingLocationMaps(sample_reclaim_keys.size());
         ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
         ASSERT_TRUE(WaitUntilSubmittedDelRequests());
@@ -2519,7 +2603,7 @@ TEST_F(CacheReclaimerTest, TestKeyCountEdgeCases) {
         // clear requests from previous test
         ClearSubmittedDelRequests();
 
-        batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
+        batch_get_loc_out_maps = MakeServingLocationMaps(sample_reclaim_keys.size());
         ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
         ASSERT_TRUE(WaitUntilSubmittedDelRequests());
@@ -2584,8 +2668,7 @@ TEST_F(CacheReclaimerTest, TestCronJobAdaptiveSleepInterval) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     const auto initial_sleep_interval = std::chrono::milliseconds(100);
     cache_reclaimer_->SetSleepIntervalMs(request_context_.get(),
                                          static_cast<std::uint32_t>(initial_sleep_interval.count()));
@@ -2660,8 +2743,7 @@ TEST_F(CacheReclaimerTest, TestCronJobAdaptiveSleepIntervalRecovery) {
 
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
-    batch_get_loc_out_maps =
-        std::vector<CacheLocationMap>(cache_reclaimer_->GetBatchingSize(request_context_.get()), CacheLocationMap{});
+    batch_get_loc_out_maps = MakeServingLocationMaps(cache_reclaimer_->GetBatchingSize(request_context_.get()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
     // worker thread should first sleep for 10ms then do the reclaiming
@@ -2737,8 +2819,19 @@ TEST_F(CacheReclaimerTest, TestHandleDelRes01) {
     auto fut = promise->get_future();
 
     cache_reclaimer_->delete_handlers_.clear();
-    cache_reclaimer_->delete_handlers_.emplace_front(
-        request_context_, "test_instance", "test_instance_group", 2, 3, std::move(fut));
+    const auto now = std::chrono::steady_clock::now();
+    cache_reclaimer_->delete_handlers_.emplace_front(request_context_,
+                                                     "test_instance",
+                                                     "test_instance_group",
+                                                     2,
+                                                     3,
+                                                     std::vector<CacheReclaimer::PendingLocationKey>{},
+                                                     CacheReclaimer::BytesByStorageType{},
+                                                     CacheReclaimer::CountsByStorageType{},
+                                                     0,
+                                                     now,
+                                                     now + std::chrono::hours(1),
+                                                     std::move(fut));
 
     cache_reclaimer_->HandleDelRes();
     ASSERT_FALSE(cache_reclaimer_->delete_handlers_.empty());
@@ -2762,11 +2855,18 @@ TEST_F(CacheReclaimerTest, TestHandleDelRes02) {
         promises.emplace_back(promise);
 
         auto fut = promise->get_future();
+        const auto now = std::chrono::steady_clock::now();
         cache_reclaimer_->delete_handlers_.emplace_front(request_context_,
                                                          "test_instance" + std::to_string(i),
                                                          "test_instance_group" + std::to_string(i),
                                                          0,
                                                          0,
+                                                         std::vector<CacheReclaimer::PendingLocationKey>{},
+                                                         CacheReclaimer::BytesByStorageType{},
+                                                         CacheReclaimer::CountsByStorageType{},
+                                                         0,
+                                                         now,
+                                                         now + std::chrono::hours(1),
                                                          std::move(fut));
     }
 
@@ -2806,15 +2906,27 @@ TEST_F(CacheReclaimerTest, TestHandleDelRes03) {
     auto fut = promise->get_future();
 
     cache_reclaimer_->delete_handlers_.clear();
-    cache_reclaimer_->delete_handlers_.emplace_front(
-        request_context_, "test_instance", "test_instance_group", 0, 0, std::move(fut));
+    const auto now = std::chrono::steady_clock::now();
+    cache_reclaimer_->delete_handlers_.emplace_front(request_context_,
+                                                     "test_instance",
+                                                     "test_instance_group",
+                                                     0,
+                                                     0,
+                                                     std::vector<CacheReclaimer::PendingLocationKey>{},
+                                                     CacheReclaimer::BytesByStorageType{},
+                                                     CacheReclaimer::CountsByStorageType{},
+                                                     0,
+                                                     now,
+                                                     now + std::chrono::hours(1),
+                                                     std::move(fut));
 
     try {
         throw std::runtime_error("test exception");
     } catch (...) { promise->set_exception(std::current_exception()); }
 
     cache_reclaimer_->HandleDelRes();
-    ASSERT_TRUE(cache_reclaimer_->delete_handlers_.empty());
+    ASSERT_FALSE(cache_reclaimer_->delete_handlers_.empty());
+    ASSERT_FALSE(cache_reclaimer_->delete_handlers_.front().credit_enabled_);
 }
 
 TEST_F(CacheReclaimerTest, TestHandleDelRes04) {
@@ -2826,11 +2938,652 @@ TEST_F(CacheReclaimerTest, TestHandleDelRes04) {
     fut.get(); // fut is not valid anymore
 
     cache_reclaimer_->delete_handlers_.clear();
-    cache_reclaimer_->delete_handlers_.emplace_front(
-        request_context_, "test_instance", "test_instance_group", 0, 0, std::move(fut));
+    const auto now = std::chrono::steady_clock::now();
+    cache_reclaimer_->delete_handlers_.emplace_front(request_context_,
+                                                     "test_instance",
+                                                     "test_instance_group",
+                                                     0,
+                                                     0,
+                                                     std::vector<CacheReclaimer::PendingLocationKey>{},
+                                                     CacheReclaimer::BytesByStorageType{},
+                                                     CacheReclaimer::CountsByStorageType{},
+                                                     0,
+                                                     now,
+                                                     now + std::chrono::hours(1),
+                                                     std::move(fut));
 
     cache_reclaimer_->HandleDelRes();
-    ASSERT_TRUE(cache_reclaimer_->delete_handlers_.empty());
+    ASSERT_FALSE(cache_reclaimer_->delete_handlers_.empty());
+    ASSERT_FALSE(cache_reclaimer_->delete_handlers_.front().credit_enabled_);
+}
+
+TEST_F(CacheReclaimerTest, TestAsyncDeleteStateIsInstanceIsolatedAndReleasedOnTerminalFuture) {
+    spe_submit_auto_complete = false;
+    cache_reclaimer_->job_state_flag_ = true;
+
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    const auto nfs_idx = ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    bytes_by_type[nfs_idx] = 100;
+    counts_by_type[nfs_idx] = 1;
+    CacheLocationDelRequest request{
+        .instance_id = "ignored_by_reclaimer",
+        .block_keys = {7},
+        .location_ids = {{"same_location"}},
+    };
+
+    const auto instance_1 = InstanceInfoFactory();
+    ASSERT_TRUE(
+        cache_reclaimer_->SubmitDelReq(request_context_, instance_1, request, bytes_by_type, counts_by_type, 1));
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+    ASSERT_EQ(1, cache_reclaimer_->pending_locations_.size());
+    ASSERT_EQ(100, cache_reclaimer_->credited_delete_bytes_by_group_.at(instance_1->instance_group_name())[nfs_idx]);
+    ASSERT_EQ(1, cache_reclaimer_->predicted_deleted_keys_by_group_.at(instance_1->instance_group_name()));
+    ASSERT_EQ(1, cache_reclaimer_->pending_delete_handler_count_);
+    ASSERT_EQ(100, cache_reclaimer_->pending_delete_bytes_);
+
+    // The same instance/block/location is pending before Executor CAS and must not be submitted again.
+    ASSERT_FALSE(
+        cache_reclaimer_->SubmitDelReq(request_context_, instance_1, request, bytes_by_type, counts_by_type, 1));
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+
+    // The same block/location in another instance remains independent.
+    const auto instance_2 = InstanceInfoFactory();
+    instance_2->set_instance_id("second_instance");
+    ASSERT_TRUE(
+        cache_reclaimer_->SubmitDelReq(request_context_, instance_2, request, bytes_by_type, counts_by_type, 1));
+    ASSERT_EQ(2, SubmittedDelRequestCount());
+    ASSERT_EQ(2, cache_reclaimer_->pending_locations_.size());
+    ASSERT_EQ(200, cache_reclaimer_->credited_delete_bytes_by_group_.at(instance_1->instance_group_name())[nfs_idx]);
+    ASSERT_EQ(2, cache_reclaimer_->pending_delete_handler_count_);
+    // Direct submissions bypass the cron's end-of-batch metrics refresh.
+    cache_reclaimer_->UpdateAsyncDeleteMetrics();
+    const MetricsTags credit_tags{{"instance_group", instance_1->instance_group_name()},
+                                  {"storage_type", ToString(DataStorageType::DATA_STORAGE_TYPE_NFS)}};
+    EXPECT_EQ(
+        200,
+        mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, credited_delete_bytes), credit_tags).Get());
+
+    CompleteSubmittedDelete(0, PlanExecuteResult{ErrorCode::EC_PARTIAL_OK, "partial"});
+    CompleteSubmittedDelete(1, PlanExecuteResult{ErrorCode::EC_ERROR, "failed"});
+    cache_reclaimer_->HandleDelRes();
+
+    EXPECT_TRUE(cache_reclaimer_->delete_handlers_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_locations_.empty());
+    EXPECT_TRUE(cache_reclaimer_->credited_delete_bytes_by_group_.empty());
+    EXPECT_TRUE(cache_reclaimer_->predicted_deleted_keys_by_group_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_quota_by_group_type_.empty());
+    EXPECT_EQ(0, cache_reclaimer_->pending_delete_handler_count_);
+    EXPECT_EQ(0, cache_reclaimer_->pending_delete_bytes_);
+    EXPECT_EQ(
+        0,
+        mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, credited_delete_bytes), credit_tags).Get());
+}
+
+TEST_F(CacheReclaimerTest, TestFilterLocationCreditsNormalizeTypeAndPredictKeysConservatively) {
+    const auto instance = InstanceInfoFactory();
+    batch_get_loc_out_maps = {
+        CacheLocationMap{
+            {"hf3fs",
+             MakeCacheLocation("hf3fs",
+                               CacheLocationStatus::CLS_SERVING,
+                               DataStorageType::DATA_STORAGE_TYPE_HF3FS,
+                               "nfs://store/hf3fs?size=10")},
+            {"vcns",
+             MakeCacheLocation("vcns",
+                               CacheLocationStatus::CLS_SERVING,
+                               DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS,
+                               "nfs://store/vcns?size=20")},
+        },
+        CacheLocationMap{
+            {"unknown_size",
+             MakeCacheLocation("unknown_size",
+                               CacheLocationStatus::CLS_SERVING,
+                               DataStorageType::DATA_STORAGE_TYPE_NFS,
+                               "nfs://store/unknown?size=not-a-number")},
+            {"active_writer",
+             MakeCacheLocation("active_writer",
+                               CacheLocationStatus::CLS_WRITING,
+                               DataStorageType::DATA_STORAGE_TYPE_NFS,
+                               "nfs://store/writing?size=40")},
+        },
+    };
+
+    std::vector<std::vector<std::string>> location_ids;
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    std::uint64_t predicted_keys = 0;
+    CacheReclaimer::AgeStats create_age_stats;
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              instance,
+                                              {10, 11},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+
+    const auto hf3fs_idx = ToIndex(DataStorageType::DATA_STORAGE_TYPE_HF3FS);
+    const auto vcns_idx = ToIndex(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS);
+    const auto nfs_idx = ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    ASSERT_EQ(2, location_ids.size());
+    EXPECT_EQ(2, location_ids[0].size());
+    EXPECT_EQ(1, location_ids[1].size());
+    EXPECT_EQ(30, bytes_by_type[hf3fs_idx]);
+    EXPECT_EQ(2, counts_by_type[hf3fs_idx]);
+    EXPECT_EQ(0, bytes_by_type[vcns_idx]);
+    EXPECT_EQ(0, counts_by_type[vcns_idx]);
+    EXPECT_EQ(0, bytes_by_type[nfs_idx]);
+    EXPECT_EQ(1, counts_by_type[nfs_idx]);
+    EXPECT_EQ(1, predicted_keys);
+
+    // Pending is scoped by instance_id: it is filtered in the same instance but not another one.
+    batch_get_loc_out_maps = {batch_get_loc_out_maps.front()};
+    cache_reclaimer_->pending_locations_.insert({instance->instance_id(), 10, "hf3fs"});
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              instance,
+                                              {10},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+    EXPECT_EQ(1, location_ids.front().size());
+    EXPECT_EQ("vcns", location_ids.front().front());
+    EXPECT_EQ(0, predicted_keys);
+
+    const auto other_instance = InstanceInfoFactory();
+    other_instance->set_instance_id("other_instance");
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              other_instance,
+                                              {10},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+    EXPECT_EQ(2, location_ids.front().size());
+    EXPECT_EQ(1, predicted_keys);
+}
+
+TEST_F(CacheReclaimerTest, TestCreditDeadlineDisablesCreditButKeepsPendingAndHardQuota) {
+    CacheReclaimerAsyncDeleteConfig config;
+    config.inflight_delete_timeout_ms = 1;
+    config.pending_delete_handler_limit = 1;
+    ReplaceReclaimer(config);
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    const auto type_idx = ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    bytes_by_type[type_idx] = 64;
+    counts_by_type[type_idx] = 1;
+    const auto instance = InstanceInfoFactory();
+    CacheLocationDelRequest request{
+        .block_keys = {1},
+        .location_ids = {{"deadline_location"}},
+    };
+    ASSERT_TRUE(cache_reclaimer_->SubmitDelReq(request_context_, instance, request, bytes_by_type, counts_by_type, 1));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    cache_reclaimer_->HandleDelRes();
+    ASSERT_FALSE(cache_reclaimer_->delete_handlers_.empty());
+    EXPECT_FALSE(cache_reclaimer_->delete_handlers_.front().credit_enabled_);
+    EXPECT_TRUE(cache_reclaimer_->credited_delete_bytes_by_group_.empty());
+    EXPECT_TRUE(cache_reclaimer_->predicted_deleted_keys_by_group_.empty());
+    EXPECT_EQ(1, cache_reclaimer_->pending_locations_.size());
+    EXPECT_EQ(1, cache_reclaimer_->pending_delete_handler_count_);
+    EXPECT_EQ(64, cache_reclaimer_->pending_delete_bytes_);
+    EXPECT_EQ(1,
+              cache_reclaimer_->pending_quota_by_group_type_
+                  .at({instance->instance_group_name(), DataStorageType::DATA_STORAGE_TYPE_NFS})
+                  .location_count);
+
+    CacheLocationDelRequest second_request{
+        .block_keys = {2},
+        .location_ids = {{"second_location"}},
+    };
+    EXPECT_FALSE(
+        cache_reclaimer_->SubmitDelReq(request_context_, instance, second_request, bytes_by_type, counts_by_type, 1));
+    EXPECT_EQ(1, SubmittedDelRequestCount());
+
+    CompleteSubmittedDelete(0, PlanExecuteResult{ErrorCode::EC_OK, ""});
+    cache_reclaimer_->HandleDelRes();
+    EXPECT_TRUE(cache_reclaimer_->delete_handlers_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_locations_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_quota_by_group_type_.empty());
+    EXPECT_EQ(0, cache_reclaimer_->pending_delete_handler_count_);
+    EXPECT_EQ(0, cache_reclaimer_->pending_delete_bytes_);
+}
+
+TEST_F(CacheReclaimerTest, TestInvalidFutureDisablesCreditButKeepsPendingAndQuota) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_invalid_future = true;
+
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    const auto type_idx = ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    bytes_by_type[type_idx] = 32;
+    counts_by_type[type_idx] = 1;
+    const auto instance = InstanceInfoFactory();
+    CacheLocationDelRequest request{
+        .block_keys = {2},
+        .location_ids = {{"invalid_future_location"}},
+    };
+    ASSERT_TRUE(cache_reclaimer_->SubmitDelReq(request_context_, instance, request, bytes_by_type, counts_by_type, 1));
+    cache_reclaimer_->HandleDelRes();
+
+    ASSERT_FALSE(cache_reclaimer_->delete_handlers_.empty());
+    EXPECT_FALSE(cache_reclaimer_->delete_handlers_.front().credit_enabled_);
+    EXPECT_TRUE(cache_reclaimer_->credited_delete_bytes_by_group_.empty());
+    EXPECT_EQ(1, cache_reclaimer_->pending_locations_.size());
+    EXPECT_EQ(1, cache_reclaimer_->pending_delete_handler_count_);
+    EXPECT_EQ(32, cache_reclaimer_->pending_delete_bytes_);
+}
+
+TEST_F(CacheReclaimerTest, TestBackpressureCropsOnlySaturatedGroupTypeAndProcessLimitStopsAll) {
+    CacheReclaimerAsyncDeleteConfig config;
+    config.pending_location_limit_per_group_type = 1;
+    config.pending_bytes_limit_per_group_type = 1024;
+    ReplaceReclaimer(config);
+
+    const auto instance = InstanceInfoFactory();
+    cache_reclaimer_->pending_quota_by_group_type_[{instance->instance_group_name(),
+                                                    DataStorageType::DATA_STORAGE_TYPE_HF3FS}] = {1, 1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"hf3fs",
+         MakeCacheLocation("hf3fs",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_HF3FS,
+                           "nfs://store/hf3fs?size=10")},
+        {"nfs",
+         MakeCacheLocation("nfs",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/nfs?size=20")},
+    }};
+
+    std::vector<std::vector<std::string>> location_ids;
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    std::uint64_t predicted_keys = 0;
+    CacheReclaimer::AgeStats create_age_stats;
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              instance,
+                                              {1},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+    ASSERT_EQ(1, location_ids.size());
+    ASSERT_EQ(1, location_ids.front().size());
+    EXPECT_EQ("nfs", location_ids.front().front());
+    EXPECT_EQ(0, bytes_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_HF3FS)]);
+    EXPECT_EQ(20, bytes_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)]);
+    EXPECT_EQ(0, predicted_keys);
+    const MetricsTags hf3fs_limit_tags{{"instance_group", instance->instance_group_name()},
+                                       {"storage_type", ToString(DataStorageType::DATA_STORAGE_TYPE_HF3FS)}};
+    EXPECT_GT(mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, pending_limit_reject_count),
+                              hf3fs_limit_tags)
+                  .Get(),
+              0);
+
+    cache_reclaimer_
+        ->pending_quota_by_group_type_[{instance->instance_group_name(), DataStorageType::DATA_STORAGE_TYPE_HF3FS}] = {
+        0, config.pending_bytes_limit_per_group_type};
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              instance,
+                                              {1},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+    ASSERT_EQ(1, location_ids.front().size());
+    EXPECT_EQ("nfs", location_ids.front().front());
+
+    cache_reclaimer_->pending_delete_handler_count_ = config.pending_delete_handler_limit;
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              instance,
+                                              {1},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+    ASSERT_EQ(1, location_ids.size());
+    EXPECT_TRUE(location_ids.front().empty());
+    EXPECT_EQ(0, create_age_stats.min_us);
+    EXPECT_EQ(0, create_age_stats.max_us);
+    EXPECT_EQ(0, create_age_stats.avg_us);
+
+    cache_reclaimer_->pending_delete_handler_count_ = 0;
+    cache_reclaimer_->pending_delete_bytes_ = config.pending_bytes_limit;
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              instance,
+                                              {1},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+    ASSERT_EQ(1, location_ids.size());
+    EXPECT_TRUE(location_ids.front().empty());
+}
+
+TEST_F(CacheReclaimerTest, TestEmptyAndRejectedRequestsLeaveNoAsyncDeleteState) {
+    cache_reclaimer_->job_state_flag_ = true;
+    const auto instance = InstanceInfoFactory();
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+
+    EXPECT_FALSE(cache_reclaimer_->SubmitDelReq(
+        request_context_, instance, CacheLocationDelRequest{}, bytes_by_type, counts_by_type, 0));
+    EXPECT_EQ(0, SubmittedDelRequestCount());
+    EXPECT_TRUE(cache_reclaimer_->delete_handlers_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_locations_.empty());
+
+    spe_submit_accepted = false;
+    CacheLocationDelRequest request{
+        .block_keys = {1},
+        .location_ids = {{"rejected_location"}},
+    };
+    counts_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)] = 1;
+    EXPECT_FALSE(cache_reclaimer_->SubmitDelReq(request_context_, instance, request, bytes_by_type, counts_by_type, 0));
+    EXPECT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_TRUE(cache_reclaimer_->delete_handlers_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_locations_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_quota_by_group_type_.empty());
+    EXPECT_EQ(0, cache_reclaimer_->pending_delete_handler_count_);
+}
+
+TEST_F(CacheReclaimerTest, TestWaterLevelCreditsUseSaturatingSubtraction) {
+    EXPECT_EQ(0, CacheReclaimer::SaturatingSub(1, 2));
+    EXPECT_EQ(0, CacheReclaimer::SaturatingSub(0, std::numeric_limits<std::uint64_t>::max()));
+    EXPECT_EQ(3, CacheReclaimer::SaturatingSub(5, 2));
+
+    const auto instance_group = InstanceGroupFactory();
+    instance_group->quota_.set_capacity(100);
+    instance_group->quota_.quota_config_.clear();
+    QuotaConfig nfs_quota;
+    nfs_quota.set_storage_type(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    nfs_quota.set_capacity(100);
+    instance_group->quota_.quota_config_.push_back(nfs_quota);
+    instance_group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 90);
+    key_count = 79;
+    max_key_count = 100;
+
+    CacheReclaimer::BytesByStorageType credit{};
+    credit[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)] = 20;
+    cache_reclaimer_->credited_delete_bytes_by_group_[instance_group->name()] = credit;
+    cache_reclaimer_->predicted_deleted_keys_by_group_[instance_group->name()] =
+        std::numeric_limits<std::uint64_t>::max();
+    cache_reclaimer_->job_state_flag_ = true;
+    const auto water_level = cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                                                   instance_group->name(),
+                                                                   instance_group->quota(),
+                                                                   instance_group->cache_config()->reclaim_strategy(),
+                                                                   instance_infos);
+    ASSERT_NE(nullptr, water_level);
+    EXPECT_FALSE(water_level->CheckGroupWaterLevelExceed());
+
+    // A byte credit that saturates effective bytes at zero must not
+    // suppress an independently exceeded key-count water level.
+    credit[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)] = std::numeric_limits<std::uint64_t>::max();
+    cache_reclaimer_->credited_delete_bytes_by_group_[instance_group->name()] = credit;
+    cache_reclaimer_->predicted_deleted_keys_by_group_[instance_group->name()] = 0;
+    key_count = 90;
+    const auto key_water_level =
+        cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                              instance_group->name(),
+                                              instance_group->quota(),
+                                              instance_group->cache_config()->reclaim_strategy(),
+                                              instance_infos);
+    ASSERT_NE(nullptr, key_water_level);
+    EXPECT_TRUE(key_water_level->GetGeneralWaterLevelExceed());
+
+    // The symmetric case must still evaluate byte usage when predicted
+    // key credit saturates the effective key count at zero.
+    credit.fill(0);
+    cache_reclaimer_->credited_delete_bytes_by_group_[instance_group->name()] = credit;
+    cache_reclaimer_->predicted_deleted_keys_by_group_[instance_group->name()] =
+        std::numeric_limits<std::uint64_t>::max();
+    const auto byte_water_level =
+        cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                              instance_group->name(),
+                                              instance_group->quota(),
+                                              instance_group->cache_config()->reclaim_strategy(),
+                                              instance_infos);
+    ASSERT_NE(nullptr, byte_water_level);
+    EXPECT_TRUE(byte_water_level->GetGeneralWaterLevelExceed());
+
+    // A zero-capacity storage type is satisfied once its effective usage
+    // has saturated to zero; otherwise credit could never stop eviction.
+    instance_group->quota_.quota_config_.front().set_capacity(0);
+    credit[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)] = std::numeric_limits<std::uint64_t>::max();
+    cache_reclaimer_->credited_delete_bytes_by_group_[instance_group->name()] = credit;
+    const auto zero_effective_usage =
+        cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                              instance_group->name(),
+                                              instance_group->quota(),
+                                              instance_group->cache_config()->reclaim_strategy(),
+                                              instance_infos);
+    ASSERT_NE(nullptr, zero_effective_usage);
+    EXPECT_FALSE(zero_effective_usage->CheckGroupWaterLevelExceed());
+}
+
+TEST_F(CacheReclaimerTest, TestSameGroupRechecksCreditBeforeSubmittingNextInstance) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"fifty_bytes",
+         MakeCacheLocation("fifty_bytes",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=50")},
+    }};
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 60);
+
+    const auto instance_1 = InstanceInfoFactory();
+    const auto instance_2 = InstanceInfoFactory();
+    instance_2->set_instance_id("same_group_second_instance");
+    instance_infos = {instance_1, instance_2};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    group->cache_config_->reclaim_strategy_->set_delay_before_delete_ms(1000);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    EXPECT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ(instance_1->instance_id(), SubmittedDelRequestsSnapshot().front().instance_id);
+}
+
+TEST_F(CacheReclaimerTest, TestReclaimCronHandlesReadyFutureBeforeReadingOfficialUsage) {
+    sample_reclaim_keys = {1};
+    get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
+    batch_get_loc_out_maps = MakeServingLocationMaps(1);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+    cache_reclaimer_->SetSleepIntervalMs(request_context_.get(), 1);
+
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 100);
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    instance_groups = {group};
+
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    bytes_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)] = 30;
+    counts_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)] = 1;
+    std::promise<PlanExecuteResult> completed_promise;
+    auto completed_future = completed_promise.get_future();
+    completed_promise.set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
+    const auto now = std::chrono::steady_clock::now();
+    cache_reclaimer_->delete_handlers_.emplace_front(
+        request_context_,
+        instance_infos.front()->instance_id(),
+        group->name(),
+        1,
+        1,
+        std::vector<CacheReclaimer::PendingLocationKey>{{instance_infos.front()->instance_id(), 999, "old"}},
+        bytes_by_type,
+        counts_by_type,
+        0,
+        now,
+        now + std::chrono::hours(1),
+        std::move(completed_future));
+    cache_reclaimer_->AddDeleteHandlerState(cache_reclaimer_->delete_handlers_.front());
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests());
+    cache_reclaimer_->Stop();
+    EXPECT_EQ(0, cache_reclaimer_->pending_locations_.count({instance_infos.front()->instance_id(), 999, "old"}));
+    EXPECT_GT(SubmittedDelRequestCount(), 0);
+}
+
+TEST_F(CacheReclaimerTest, TestPausedCronStillReleasesTerminalFutureState) {
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    const auto nfs_idx = ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    bytes_by_type[nfs_idx] = 16;
+    counts_by_type[nfs_idx] = 1;
+
+    std::promise<PlanExecuteResult> promise;
+    auto future = promise.get_future();
+    promise.set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
+    const auto now = std::chrono::steady_clock::now();
+    cache_reclaimer_->delete_handlers_.emplace_front(
+        request_context_,
+        instance_infos.front()->instance_id(),
+        instance_groups.front()->name(),
+        1,
+        1,
+        std::vector<CacheReclaimer::PendingLocationKey>{{instance_infos.front()->instance_id(), 1, "paused"}},
+        bytes_by_type,
+        counts_by_type,
+        1,
+        now,
+        now + std::chrono::hours(1),
+        std::move(future));
+    cache_reclaimer_->AddDeleteHandlerState(cache_reclaimer_->delete_handlers_.front());
+    // Direct state setup bypasses the cron's end-of-batch metrics refresh.
+    cache_reclaimer_->UpdateAsyncDeleteMetrics();
+    ASSERT_EQ(1, cache_reclaimer_->get_cache_reclaimer_pending_delete_handler_count_metrics());
+    cache_reclaimer_->SetSleepIntervalMs(request_context_.get(), 1);
+    cache_reclaimer_->Pause();
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
+    ASSERT_TRUE(WaitUntil(
+        [this] { return cache_reclaimer_->get_cache_reclaimer_pending_delete_handler_count_metrics() == 0; }));
+    cache_reclaimer_->Stop();
+
+    EXPECT_TRUE(cache_reclaimer_->pending_locations_.empty());
+    EXPECT_TRUE(cache_reclaimer_->credited_delete_bytes_by_group_.empty());
+    EXPECT_TRUE(cache_reclaimer_->pending_quota_by_group_type_.empty());
+    EXPECT_EQ(0, cache_reclaimer_->pending_delete_handler_count_);
+    EXPECT_EQ(0, cache_reclaimer_->pending_delete_bytes_);
+}
+
+TEST_F(CacheReclaimerTest, TestReclaimCronBacksOffWhenExecutorRejects) {
+    sample_reclaim_keys = {1};
+    get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
+    batch_get_loc_out_maps = MakeServingLocationMaps(1);
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 100);
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(10);
+    instance_groups = {group};
+    spe_submit_accepted = false;
+    const auto polling_interval = std::chrono::milliseconds(80);
+    cache_reclaimer_->SetSleepIntervalMs(request_context_.get(), static_cast<std::uint32_t>(polling_interval.count()));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests(std::chrono::seconds(1)));
+    const auto submit_count_after_first_round = SubmittedDelRequestCount();
+    const auto list_count_after_first_round = ListInstanceGroupCallCount();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    EXPECT_EQ(submit_count_after_first_round, SubmittedDelRequestCount());
+    EXPECT_EQ(list_count_after_first_round, ListInstanceGroupCallCount());
+    cache_reclaimer_->Stop();
+    EXPECT_GT(cache_reclaimer_->get_cache_reclaimer_reclaim_no_progress_backoff_count_metrics(), 0);
+}
+
+TEST_F(CacheReclaimerTest, TestReclaimCronKeepsPositiveBackoffWhenPollingIntervalIsZero) {
+    sample_reclaim_keys = {1};
+    get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
+    batch_get_loc_out_maps = MakeServingLocationMaps(1);
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 100);
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(10);
+    instance_groups = {group};
+    spe_submit_accepted = false;
+    cache_reclaimer_->SetSleepIntervalMs(request_context_.get(), 0);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
+    ASSERT_TRUE(WaitUntilSubmittedDelRequests(std::chrono::seconds(1)));
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    cache_reclaimer_->Stop();
+
+    EXPECT_LT(ListInstanceGroupCallCount(), 100);
+    EXPECT_GT(cache_reclaimer_->get_cache_reclaimer_reclaim_no_progress_backoff_count_metrics(), 0);
+}
+
+TEST_F(CacheReclaimerTest, TestTryReclaimReportsNoProgressForPendingOrMissingVictim) {
+    cache_reclaimer_->job_state_flag_ = true;
+    sample_reclaim_keys = {1};
+    get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 100);
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(10);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"pending",
+         MakeCacheLocation("pending",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/pending?size=1")},
+    }};
+    cache_reclaimer_->pending_locations_.insert({instance_infos.front()->instance_id(), 1, "pending"});
+    auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_FALSE(result.made_progress);
+    EXPECT_EQ(0, SubmittedDelRequestCount());
+
+    cache_reclaimer_->pending_locations_.clear();
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"deleting",
+         MakeCacheLocation("deleting",
+                           CacheLocationStatus::CLS_DELETING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/deleting?size=1")},
+    }};
+    result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_FALSE(result.made_progress);
+    EXPECT_EQ(0, SubmittedDelRequestCount());
 }
 
 TEST_F(CacheReclaimerTest, TestDoKeySampling) {

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -1,4 +1,7 @@
+#include <atomic>
 #include <filesystem>
+#include <stdexcept>
+#include <thread>
 
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/common/unittest.h"
@@ -11,8 +14,34 @@
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
+#include "stub.h"
 using namespace kv_cache_manager;
 namespace {
+std::atomic<bool> sync_entered{false};
+std::atomic<bool> sync_completed{false};
+std::atomic<bool> release_sync{true};
+std::atomic<std::int64_t> sync_delay_ms{0};
+std::atomic<std::size_t> sync_thread_hash{0};
+
+bool MetaIndexer_Sync_stub(void *obj, const KeyVector &keys) noexcept {
+    (void)obj;
+    (void)keys;
+    sync_thread_hash.store(std::hash<std::thread::id>{}(std::this_thread::get_id()), std::memory_order_relaxed);
+    sync_entered.store(true, std::memory_order_release);
+    while (!release_sync.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(sync_delay_ms.load(std::memory_order_relaxed)));
+    sync_completed.store(true, std::memory_order_release);
+    return true;
+}
+
+std::shared_ptr<MetaIndexer> MetaIndexerManager_GetMetaIndexer_throw_stub(void *obj, const std::string &instance_id) {
+    (void)obj;
+    (void)instance_id;
+    throw std::runtime_error("injected GetMetaIndexer exception");
+}
+
 class SchedulePlanExecutorTestHelper {
 public:
     static LocationSpec CreateLocationSpec(const std::string &name = "", const std::string &uri = "") {
@@ -55,7 +84,7 @@ public:
         return meta_storage_backend_config;
     }
 
-    bool CreateMetaIndexer(const std::string &instance_id, const std::string &storage_type) {
+    ErrorCode CreateMetaIndexer(const std::string &instance_id, const std::string &storage_type) {
         auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();
         auto backend_config = ConstructMetaStorageBackendConfig();
         meta_indexer_config->meta_storage_backend_config_ = backend_config;
@@ -64,7 +93,7 @@ public:
         return meta_manager_->CreateMetaIndexer(instance_id, meta_indexer_config);
     }
 
-    bool CreateDataStorage() {
+    ErrorCode CreateDataStorage() {
         auto nfs_storage_spec = std::make_shared<NfsStorageSpec>();
         nfs_storage_spec->set_root_path("/mnt/nfs");
         nfs_storage_spec->set_key_count_per_file(5);
@@ -723,4 +752,334 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequestWithDelay) {
     ASSERT_GE(execution_duration.count(), delay.count() / 1000 - 100)
         << "Task executed too early, expected delay: " << delay.count() / 1000 - 100
         << "ms, actual execution time: " << execution_duration.count() << "ms";
+}
+
+TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncAdmissionRunsOnWorkerAndReturnsQuickly) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("async_admission_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/async_admission?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {900}, {location}, location_ids));
+    ASSERT_EQ(1, location_ids.size());
+    std::vector<CacheLocationMap> initial_location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {900}, empty_mask, initial_location_maps));
+    ASSERT_EQ(1, initial_location_maps.size());
+    const auto initial_status = initial_location_maps.front().at(location_ids.front())->status();
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    auto release_blocker_future = release_blocker.get_future().share();
+    ASSERT_TRUE(executor.SubmitTask([&blocker_started, release_blocker_future] {
+        blocker_started.set_value();
+        release_blocker_future.wait();
+    }));
+    ASSERT_EQ(std::future_status::ready, blocker_started.get_future().wait_for(std::chrono::seconds(1)));
+
+    CacheLocationDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {900},
+        .location_ids = {{location_ids.front()}},
+    };
+    const auto begin = std::chrono::steady_clock::now();
+    auto submit_result = executor.SubmitAsync(request);
+    const auto submit_cost = std::chrono::steady_clock::now() - begin;
+    ASSERT_TRUE(submit_result.accepted);
+    ASSERT_TRUE(submit_result.future.valid());
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(submit_cost).count(), 100);
+
+    std::vector<CacheLocationMap> location_maps;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {900}, empty_mask, location_maps));
+    ASSERT_EQ(initial_status, location_maps.front().at(location_ids.front())->status());
+
+    release_blocker.set_value();
+    const auto result = submit_result.future.get();
+    EXPECT_TRUE(result.status == ErrorCode::EC_OK || result.status == ErrorCode::EC_PARTIAL_OK) << result.error_message;
+}
+
+TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncMetaSelectsAllLocationsAndSkipsDeleting) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("async_meta_selection_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    std::vector<std::string> location_ids;
+    for (int location_idx = 0; location_idx < 2; ++location_idx) {
+        auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+            DataStorageType::DATA_STORAGE_TYPE_NFS,
+            1,
+            {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc_" + std::to_string(location_idx),
+                                                                "nfs://nfs_01/async_meta_selection_" +
+                                                                    std::to_string(location_idx) + "?size=1")});
+        std::vector<std::string> added_location_ids;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher.BatchAddLocation(request_context.get(), {903}, {location}, added_location_ids));
+        ASSERT_EQ(1, added_location_ids.size());
+        location_ids.push_back(added_location_ids.front());
+    }
+
+    Stub stub;
+    sync_entered.store(false);
+    sync_completed.store(false);
+    release_sync.store(true);
+    sync_delay_ms.store(0);
+    sync_thread_hash.store(0);
+    stub.set(ADDR(MetaIndexer, Sync), MetaIndexer_Sync_stub);
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheMetaDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {903},
+        .delay = std::chrono::seconds(10),
+    };
+    const auto caller_thread_hash = std::hash<std::thread::id>{}(std::this_thread::get_id());
+    auto first_submit_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(first_submit_result.accepted);
+
+    const auto sync_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!sync_completed.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < sync_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(sync_completed.load(std::memory_order_acquire));
+    EXPECT_NE(caller_thread_hash, sync_thread_hash.load(std::memory_order_relaxed));
+    EXPECT_EQ(std::future_status::timeout, first_submit_result.future.wait_for(std::chrono::milliseconds(10)));
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {903}, empty_mask, location_maps));
+    ASSERT_EQ(1, location_maps.size());
+    ASSERT_EQ(2, location_maps.front().size());
+    for (const auto &location_id : location_ids) {
+        ASSERT_EQ(CacheLocationStatus::CLS_DELETING, location_maps.front().at(location_id)->status());
+    }
+
+    sync_entered.store(false, std::memory_order_release);
+    auto second_submit_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(second_submit_result.accepted);
+    ASSERT_EQ(std::future_status::ready, second_submit_result.future.wait_for(std::chrono::seconds(1)));
+    EXPECT_EQ(ErrorCode::EC_OK, second_submit_result.future.get().status);
+    EXPECT_FALSE(sync_entered.load(std::memory_order_acquire));
+
+    executor.Stop();
+    ASSERT_EQ(std::future_status::ready, first_submit_result.future.wait_for(std::chrono::seconds(1)));
+    EXPECT_EQ(ErrorCode::EC_ERROR, first_submit_result.future.get().status);
+    stub.reset(ADDR(MetaIndexer, Sync));
+}
+
+TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncMetaAdmissionCancelledOnStop) {
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    auto release_blocker_future = release_blocker.get_future().share();
+    ASSERT_TRUE(executor.SubmitTask([&blocker_started, release_blocker_future] {
+        blocker_started.set_value();
+        release_blocker_future.wait();
+    }));
+    ASSERT_EQ(std::future_status::ready, blocker_started.get_future().wait_for(std::chrono::seconds(1)));
+
+    const auto submit_begin = std::chrono::steady_clock::now();
+    auto submit_result = executor.SubmitAsync(CacheMetaDelRequest{
+        .instance_id = kTestInstanceName,
+        .block_keys = {904},
+    });
+    const auto submit_cost = std::chrono::steady_clock::now() - submit_begin;
+    ASSERT_TRUE(submit_result.accepted);
+    ASSERT_TRUE(submit_result.future.valid());
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(submit_cost).count(), 100);
+
+    std::thread stop_thread([&executor]() { executor.Stop(); });
+    const auto future_status = submit_result.future.wait_for(std::chrono::seconds(1));
+    release_blocker.set_value();
+    stop_thread.join();
+
+    ASSERT_EQ(std::future_status::ready, future_status);
+    const auto result = submit_result.future.get();
+    EXPECT_EQ(ErrorCode::EC_ERROR, result.status);
+    EXPECT_NE(std::string::npos, result.error_message.find("before delete admission"));
+}
+
+TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncDelayStartsAfterSyncAndDoesNotOccupyWorker) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("async_delay_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/async_delay?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {901}, {location}, location_ids));
+
+    Stub stub;
+    sync_entered.store(false);
+    sync_completed.store(false);
+    release_sync.store(true);
+    sync_delay_ms.store(150);
+    sync_thread_hash.store(0);
+    stub.set(ADDR(MetaIndexer, Sync), MetaIndexer_Sync_stub);
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheLocationDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {901},
+        .location_ids = {{location_ids.front()}},
+        .delay = std::chrono::milliseconds(250),
+    };
+    const auto caller_thread_hash = std::hash<std::thread::id>{}(std::this_thread::get_id());
+    const auto begin = std::chrono::steady_clock::now();
+    auto submit_result = executor.SubmitAsync(request);
+    const auto submit_cost = std::chrono::steady_clock::now() - begin;
+    ASSERT_TRUE(submit_result.accepted);
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(submit_cost).count(), 100);
+
+    const auto sync_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!sync_entered.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < sync_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(sync_entered.load(std::memory_order_acquire));
+    EXPECT_NE(caller_thread_hash, sync_thread_hash.load(std::memory_order_relaxed));
+
+    const auto deleting_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    bool deleting = false;
+    while (std::chrono::steady_clock::now() < deleting_deadline) {
+        std::vector<CacheLocationMap> location_maps;
+        BlockMask empty_mask;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher.BatchGetLocation(request_context.get(), {901}, empty_mask, location_maps));
+        deleting = !location_maps.empty() && !location_maps.front().empty() &&
+                   location_maps.front().at(location_ids.front())->status() == CacheLocationStatus::CLS_DELETING;
+        if (deleting) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(deleting);
+
+    const auto sync_completed_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!sync_completed.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < sync_completed_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(sync_completed.load(std::memory_order_acquire));
+
+    std::promise<void> immediate_task_done;
+    auto immediate_task_future = immediate_task_done.get_future();
+    ASSERT_TRUE(executor.SubmitTask([&immediate_task_done] { immediate_task_done.set_value(); }));
+    EXPECT_EQ(std::future_status::ready, immediate_task_future.wait_for(std::chrono::milliseconds(100)));
+
+    const auto result = submit_result.future.get();
+    const auto elapsed = std::chrono::steady_clock::now() - begin;
+    EXPECT_TRUE(result.status == ErrorCode::EC_OK || result.status == ErrorCode::EC_PARTIAL_OK) << result.error_message;
+    EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 380);
+    stub.reset(ADDR(MetaIndexer, Sync));
+}
+
+TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncCompletesFailureAndExceptionPaths) {
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheLocationDelRequest request{
+        .instance_id = "missing_instance",
+        .block_keys = {1},
+        .location_ids = {{"location"}},
+    };
+
+    auto missing_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(missing_result.accepted);
+    ASSERT_EQ(std::future_status::ready, missing_result.future.wait_for(std::chrono::seconds(1)));
+    EXPECT_EQ(ErrorCode::EC_NOENT, missing_result.future.get().status);
+
+    auto missing_meta_result = executor.SubmitAsync(CacheMetaDelRequest{
+        .instance_id = "missing_instance",
+        .block_keys = {1},
+    });
+    ASSERT_TRUE(missing_meta_result.accepted);
+    ASSERT_EQ(std::future_status::ready, missing_meta_result.future.wait_for(std::chrono::seconds(1)));
+    EXPECT_EQ(ErrorCode::EC_NOENT, missing_meta_result.future.get().status);
+
+    Stub stub;
+    stub.set(ADDR(MetaIndexerManager, GetMetaIndexer), MetaIndexerManager_GetMetaIndexer_throw_stub);
+    auto exception_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(exception_result.accepted);
+    ASSERT_EQ(std::future_status::ready, exception_result.future.wait_for(std::chrono::seconds(1)));
+    const auto result = exception_result.future.get();
+    EXPECT_EQ(ErrorCode::EC_ERROR, result.status);
+    EXPECT_NE(std::string::npos, result.error_message.find("injected GetMetaIndexer exception"));
+
+    auto meta_exception_result = executor.SubmitAsync(CacheMetaDelRequest{
+        .instance_id = "missing_instance",
+        .block_keys = {1},
+    });
+    ASSERT_TRUE(meta_exception_result.accepted);
+    ASSERT_EQ(std::future_status::ready, meta_exception_result.future.wait_for(std::chrono::seconds(1)));
+    const auto meta_result = meta_exception_result.future.get();
+    EXPECT_EQ(ErrorCode::EC_ERROR, meta_result.status);
+    EXPECT_NE(std::string::npos, meta_result.error_message.find("injected GetMetaIndexer exception"));
+    stub.reset(ADDR(MetaIndexerManager, GetMetaIndexer));
+}
+
+TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncSecondEnqueueFailureCompletesFuture) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("async_second_enqueue_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/second_enqueue?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {902}, {location}, location_ids));
+
+    Stub stub;
+    sync_entered.store(false);
+    release_sync.store(false);
+    sync_delay_ms.store(0);
+    stub.set(ADDR(MetaIndexer, Sync), MetaIndexer_Sync_stub);
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheLocationDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {902},
+        .location_ids = {{location_ids.front()}},
+        .delay = std::chrono::milliseconds(10),
+    };
+    auto submit_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(submit_result.accepted);
+
+    const auto sync_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!sync_entered.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < sync_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(sync_entered.load(std::memory_order_acquire));
+    executor.stop_.store(true);
+    executor.condition_.notify_all();
+    release_sync.store(true, std::memory_order_release);
+
+    ASSERT_EQ(std::future_status::ready, submit_result.future.wait_for(std::chrono::seconds(1)));
+    const auto result = submit_result.future.get();
+    EXPECT_EQ(ErrorCode::EC_ERROR, result.status);
+    EXPECT_NE(std::string::npos, result.error_message.find("physical delete task"));
+    executor.Stop();
+    stub.reset(ADDR(MetaIndexer, Sync));
+}
+
+TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncRejectedHasNoFuture) {
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    executor.Stop();
+    const auto location_submit_result = executor.SubmitAsync(CacheLocationDelRequest{});
+    EXPECT_FALSE(location_submit_result.accepted);
+    EXPECT_FALSE(location_submit_result.future.valid());
+    const auto meta_submit_result = executor.SubmitAsync(CacheMetaDelRequest{});
+    EXPECT_FALSE(meta_submit_result.accepted);
+    EXPECT_FALSE(meta_submit_result.future.valid());
 }

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -126,6 +126,13 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_reclaimer, location_submit_count);
     DECLARE_METRICS(cache_reclaimer, block_del_count);
     DECLARE_METRICS(cache_reclaimer, location_del_count);
+    DECLARE_METRICS(cache_reclaimer, credit_timeout_count);
+    DECLARE_METRICS(cache_reclaimer, pending_limit_reject_count);
+    DECLARE_METRICS(cache_reclaimer, duplicate_pending_location_filtered_count);
+    DECLARE_METRICS(cache_reclaimer, reclaim_no_progress_backoff_count);
+    DECLARE_METRICS(cache_reclaimer, delete_submit_count);
+    DECLARE_METRICS(cache_reclaimer, delete_complete_count);
+    DECLARE_METRICS(cache_reclaimer, delete_fail_count);
 
     DECLARE_METRICS(cache_reclaimer, reclaim_cron_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_quota_duration_us);
@@ -135,6 +142,12 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_batch_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_filter_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_lru_submit_duration_us);
+    DECLARE_METRICS(cache_reclaimer, pending_delete_handler_count);
+    DECLARE_METRICS(cache_reclaimer, pending_location_count);
+    DECLARE_METRICS(cache_reclaimer, pending_delete_bytes);
+    DECLARE_METRICS(cache_reclaimer, credited_delete_bytes);
+    DECLARE_METRICS(cache_reclaimer, predicted_deleted_key_count);
+    DECLARE_METRICS(cache_reclaimer, oldest_pending_request_age_ms);
 
     DECLARE_METRICS(cache_reclaimer, reclaim_batch_lru_age_min_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_batch_lru_age_max_us);
@@ -371,6 +384,13 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_reclaimer, location_submit_count);
     REGISTER_GAUGE_METRIC(cache_reclaimer, block_del_count);
     REGISTER_GAUGE_METRIC(cache_reclaimer, location_del_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, credit_timeout_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, pending_limit_reject_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, duplicate_pending_location_filtered_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_no_progress_backoff_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, delete_submit_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, delete_complete_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, delete_fail_count);
 
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_cron_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_quota_duration_us);
@@ -380,6 +400,12 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_batch_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_filter_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_lru_submit_duration_us);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, pending_delete_handler_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, pending_location_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, pending_delete_bytes);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, credited_delete_bytes);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, predicted_deleted_key_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, oldest_pending_request_age_ms);
 
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_lru_age_min_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_lru_age_max_us);
@@ -607,6 +633,13 @@ void KmonitorMetricsReporter::ReportInterval() {
         std::uint64_t loc_submit_count_v;
         std::uint64_t blk_del_count_v;
         std::uint64_t loc_del_count_v;
+        std::uint64_t credit_timeout_count_v;
+        std::uint64_t pending_limit_reject_count_v;
+        std::uint64_t duplicate_pending_location_filtered_count_v;
+        std::uint64_t reclaim_no_progress_backoff_count_v;
+        std::uint64_t delete_submit_count_v;
+        std::uint64_t delete_complete_count_v;
+        std::uint64_t delete_fail_count_v;
 
         double reclaim_cron_duration_us_v;
         double reclaim_quota_duration_us_v;
@@ -616,6 +649,12 @@ void KmonitorMetricsReporter::ReportInterval() {
         double reclaim_lru_batch_duration_us_v;
         double reclaim_lru_filter_duration_us_v;
         double reclaim_lru_submit_duration_us_v;
+        double pending_delete_handler_count_v;
+        double pending_location_count_v;
+        double pending_delete_bytes_v;
+        double credited_delete_bytes_v;
+        double predicted_deleted_key_count_v;
+        double oldest_pending_request_age_ms_v;
 
         double reclaim_batch_lru_age_min_us_v;
         double reclaim_batch_lru_age_max_us_v;
@@ -630,6 +669,16 @@ void KmonitorMetricsReporter::ReportInterval() {
         GET_METRICS_(cr, cache_reclaimer, location_submit_count, loc_submit_count_v);
         GET_METRICS_(cr, cache_reclaimer, block_del_count, blk_del_count_v);
         GET_METRICS_(cr, cache_reclaimer, location_del_count, loc_del_count_v);
+        GET_METRICS_(cr, cache_reclaimer, credit_timeout_count, credit_timeout_count_v);
+        GET_METRICS_(cr, cache_reclaimer, pending_limit_reject_count, pending_limit_reject_count_v);
+        GET_METRICS_(cr,
+                     cache_reclaimer,
+                     duplicate_pending_location_filtered_count,
+                     duplicate_pending_location_filtered_count_v);
+        GET_METRICS_(cr, cache_reclaimer, reclaim_no_progress_backoff_count, reclaim_no_progress_backoff_count_v);
+        GET_METRICS_(cr, cache_reclaimer, delete_submit_count, delete_submit_count_v);
+        GET_METRICS_(cr, cache_reclaimer, delete_complete_count, delete_complete_count_v);
+        GET_METRICS_(cr, cache_reclaimer, delete_fail_count, delete_fail_count_v);
 
         GET_METRICS_(cr, cache_reclaimer, reclaim_cron_duration_us, reclaim_cron_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_quota_duration_us, reclaim_quota_duration_us_v);
@@ -639,6 +688,12 @@ void KmonitorMetricsReporter::ReportInterval() {
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_batch_duration_us, reclaim_lru_batch_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_filter_duration_us, reclaim_lru_filter_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_lru_submit_duration_us, reclaim_lru_submit_duration_us_v);
+        GET_METRICS_(cr, cache_reclaimer, pending_delete_handler_count, pending_delete_handler_count_v);
+        GET_METRICS_(cr, cache_reclaimer, pending_location_count, pending_location_count_v);
+        GET_METRICS_(cr, cache_reclaimer, pending_delete_bytes, pending_delete_bytes_v);
+        GET_METRICS_(cr, cache_reclaimer, credited_delete_bytes, credited_delete_bytes_v);
+        GET_METRICS_(cr, cache_reclaimer, predicted_deleted_key_count, predicted_deleted_key_count_v);
+        GET_METRICS_(cr, cache_reclaimer, oldest_pending_request_age_ms, oldest_pending_request_age_ms_v);
 
         GET_METRICS_(cr, cache_reclaimer, reclaim_batch_lru_age_min_us, reclaim_batch_lru_age_min_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_batch_lru_age_max_us, reclaim_batch_lru_age_max_us_v);
@@ -654,6 +709,17 @@ void KmonitorMetricsReporter::ReportInterval() {
         REPORT_METRICS(cache_reclaimer, location_submit_count, static_cast<double>(loc_submit_count_v));
         REPORT_METRICS(cache_reclaimer, block_del_count, static_cast<double>(blk_del_count_v));
         REPORT_METRICS(cache_reclaimer, location_del_count, static_cast<double>(loc_del_count_v));
+        REPORT_METRICS(cache_reclaimer, credit_timeout_count, static_cast<double>(credit_timeout_count_v));
+        REPORT_METRICS(cache_reclaimer, pending_limit_reject_count, static_cast<double>(pending_limit_reject_count_v));
+        REPORT_METRICS(cache_reclaimer,
+                       duplicate_pending_location_filtered_count,
+                       static_cast<double>(duplicate_pending_location_filtered_count_v));
+        REPORT_METRICS(cache_reclaimer,
+                       reclaim_no_progress_backoff_count,
+                       static_cast<double>(reclaim_no_progress_backoff_count_v));
+        REPORT_METRICS(cache_reclaimer, delete_submit_count, static_cast<double>(delete_submit_count_v));
+        REPORT_METRICS(cache_reclaimer, delete_complete_count, static_cast<double>(delete_complete_count_v));
+        REPORT_METRICS(cache_reclaimer, delete_fail_count, static_cast<double>(delete_fail_count_v));
 
         REPORT_METRICS(cache_reclaimer, reclaim_cron_duration_us, reclaim_cron_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_quota_duration_us, reclaim_quota_duration_us_v);
@@ -663,6 +729,12 @@ void KmonitorMetricsReporter::ReportInterval() {
         REPORT_METRICS(cache_reclaimer, reclaim_lru_batch_duration_us, reclaim_lru_batch_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_lru_filter_duration_us, reclaim_lru_filter_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_lru_submit_duration_us, reclaim_lru_submit_duration_us_v);
+        REPORT_METRICS(cache_reclaimer, pending_delete_handler_count, pending_delete_handler_count_v);
+        REPORT_METRICS(cache_reclaimer, pending_location_count, pending_location_count_v);
+        REPORT_METRICS(cache_reclaimer, pending_delete_bytes, pending_delete_bytes_v);
+        REPORT_METRICS(cache_reclaimer, credited_delete_bytes, credited_delete_bytes_v);
+        REPORT_METRICS(cache_reclaimer, predicted_deleted_key_count, predicted_deleted_key_count_v);
+        REPORT_METRICS(cache_reclaimer, oldest_pending_request_age_ms, oldest_pending_request_age_ms_v);
 
         REPORT_METRICS(cache_reclaimer, reclaim_batch_lru_age_min_us, reclaim_batch_lru_age_min_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_batch_lru_age_max_us, reclaim_batch_lru_age_max_us_v);

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -60,12 +60,20 @@ bool Server::Init(const ServerConfig &config) {
     }
 
     cache_manager_.reset(new CacheManager(metrics_registry_, registry_manager_, metrics_lifecycle_));
+    CacheReclaimerAsyncDeleteConfig async_delete_config;
+    async_delete_config.inflight_delete_timeout_ms = config_.GetCacheReclaimerInflightDeleteTimeoutMs();
+    async_delete_config.pending_location_limit_per_group_type =
+        config_.GetCacheReclaimerPendingLocationLimitPerGroupType();
+    async_delete_config.pending_bytes_limit_per_group_type = config_.GetCacheReclaimerPendingBytesLimitPerGroupType();
+    async_delete_config.pending_delete_handler_limit = config_.GetCacheReclaimerPendingDeleteHandlerLimit();
+    async_delete_config.pending_bytes_limit = config_.GetCacheReclaimerPendingBytesLimit();
     cache_manager_->Init(config_.GetSchedulePlanExecutorThreadCount(),
                          config_.GetCacheReclaimerKeySamplingSizeTotal(),
                          config_.GetCacheReclaimerKeySamplingSizePerTask(),
                          config_.GetCacheReclaimerDelBatchSize(),
                          config_.GetCacheReclaimerIdleIntervalMs(),
-                         config_.GetCacheReclaimerWorkerSize());
+                         config_.GetCacheReclaimerWorkerSize(),
+                         async_delete_config);
     cache_manager_->PauseReclaimer(); // Resume after DoRecover
 
     // Set revisit interval histogram configuration

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -128,7 +128,32 @@ std::unordered_map<std::string, ServerConfig::SettingFunction> ServerConfig::kSe
      [](const std::string &value, ServerConfig *config) {
          config->cache_reclaimer_worker_size_ = std::stol(value);
          return true;
-    }},
+     }},
+    {"kvcm.cache_reclaimer.inflight_delete_timeout_ms",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_reclaimer_inflight_delete_timeout_ms_ = std::stoull(value);
+         return true;
+     }},
+    {"kvcm.cache_reclaimer.pending_location_limit_per_group_type",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_reclaimer_pending_location_limit_per_group_type_ = std::stoull(value);
+         return true;
+     }},
+    {"kvcm.cache_reclaimer.pending_bytes_limit_per_group_type",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_reclaimer_pending_bytes_limit_per_group_type_ = std::stoull(value);
+         return true;
+     }},
+    {"kvcm.cache_reclaimer.pending_delete_handler_limit",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_reclaimer_pending_delete_handler_limit_ = std::stoull(value);
+         return true;
+     }},
+    {"kvcm.cache_reclaimer.pending_bytes_limit",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_reclaimer_pending_bytes_limit_ = std::stoull(value);
+         return true;
+     }},
     {"kvcm.metrics.reporter_type",
      [](const std::string &value, ServerConfig *config) {
          config->metrics_reporter_type_ = value;
@@ -200,6 +225,11 @@ void ServerConfig::UpdateDefaultConfig() {
     cache_reclaimer_del_batch_size_ = 100;
     cache_reclaimer_idle_interval_ms_ = 100;
     cache_reclaimer_worker_size_ = 16;
+    cache_reclaimer_inflight_delete_timeout_ms_ = 60000;
+    cache_reclaimer_pending_location_limit_per_group_type_ = 100000;
+    cache_reclaimer_pending_bytes_limit_per_group_type_ = 64ULL * 1024 * 1024 * 1024;
+    cache_reclaimer_pending_delete_handler_limit_ = 1024;
+    cache_reclaimer_pending_bytes_limit_ = 256ULL * 1024 * 1024 * 1024;
 }
 
 bool ServerConfig::ParseFromFile(const std::string &config_file) {
@@ -308,6 +338,14 @@ bool ServerConfig::Check() {
         if (boundaries.empty()) {
             return false; // ParseRevisitIntervalBuckets already printed the error
         }
+    }
+
+    if (cache_reclaimer_inflight_delete_timeout_ms_ == 0 ||
+        cache_reclaimer_pending_location_limit_per_group_type_ == 0 ||
+        cache_reclaimer_pending_bytes_limit_per_group_type_ == 0 ||
+        cache_reclaimer_pending_delete_handler_limit_ == 0 || cache_reclaimer_pending_bytes_limit_ == 0) {
+        fprintf(stderr, "CacheReclaimer async delete limits and timeout must be greater than zero\n");
+        return false;
     }
 
     return true;

--- a/kv_cache_manager/service/server_config.h
+++ b/kv_cache_manager/service/server_config.h
@@ -38,6 +38,17 @@ public:
     uint64_t GetCacheReclaimerDelBatchSize() { return cache_reclaimer_del_batch_size_; }
     uint32_t GetCacheReclaimerIdleIntervalMs() { return cache_reclaimer_idle_interval_ms_; }
     uint32_t GetCacheReclaimerWorkerSize() { return cache_reclaimer_worker_size_; }
+    uint64_t GetCacheReclaimerInflightDeleteTimeoutMs() const { return cache_reclaimer_inflight_delete_timeout_ms_; }
+    uint64_t GetCacheReclaimerPendingLocationLimitPerGroupType() const {
+        return cache_reclaimer_pending_location_limit_per_group_type_;
+    }
+    uint64_t GetCacheReclaimerPendingBytesLimitPerGroupType() const {
+        return cache_reclaimer_pending_bytes_limit_per_group_type_;
+    }
+    uint64_t GetCacheReclaimerPendingDeleteHandlerLimit() const {
+        return cache_reclaimer_pending_delete_handler_limit_;
+    }
+    uint64_t GetCacheReclaimerPendingBytesLimit() const { return cache_reclaimer_pending_bytes_limit_; }
     const std::string &metrics_reporter_type() { return metrics_reporter_type_; }
     const std::string &metrics_reporter_config() { return metrics_reporter_config_; }
     int64_t metrics_report_interval_ms() { return metrics_report_interval_ms_; }
@@ -83,6 +94,11 @@ private:
     uint64_t cache_reclaimer_del_batch_size_ = 0;
     uint32_t cache_reclaimer_idle_interval_ms_ = 0;
     uint32_t cache_reclaimer_worker_size_ = 0;
+    uint64_t cache_reclaimer_inflight_delete_timeout_ms_ = 0;
+    uint64_t cache_reclaimer_pending_location_limit_per_group_type_ = 0;
+    uint64_t cache_reclaimer_pending_bytes_limit_per_group_type_ = 0;
+    uint64_t cache_reclaimer_pending_delete_handler_limit_ = 0;
+    uint64_t cache_reclaimer_pending_bytes_limit_ = 0;
     std::string metrics_reporter_type_;
     std::string metrics_reporter_config_;
     int64_t metrics_report_interval_ms_ = 0;

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -20,6 +20,11 @@ TEST_F(ServerConfigTest, TestSimple) {
         std::unordered_map<std::string, std::string> environ;
         ASSERT_TRUE(config.Parse("", environ));
         ASSERT_TRUE(config.Check());
+        ASSERT_EQ(60000, config.GetCacheReclaimerInflightDeleteTimeoutMs());
+        ASSERT_EQ(100000, config.GetCacheReclaimerPendingLocationLimitPerGroupType());
+        ASSERT_EQ(64ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimitPerGroupType());
+        ASSERT_EQ(1024, config.GetCacheReclaimerPendingDeleteHandlerLimit());
+        ASSERT_EQ(256ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimit());
     }
     // config_file not exist
     {
@@ -75,6 +80,28 @@ TEST_F(ServerConfigTest, TestSimple) {
         ASSERT_TRUE(config.IsEnableDebugService());
         ASSERT_EQ(3, config.GetLogLevel());
     }
+}
+
+TEST_F(ServerConfigTest, TestCacheReclaimerAsyncDeleteConfig) {
+    ServerConfig config;
+    std::unordered_map<std::string, std::string> environ{
+        {"kvcm.cache_reclaimer.inflight_delete_timeout_ms", "1234"},
+        {"kvcm.cache_reclaimer.pending_location_limit_per_group_type", "11"},
+        {"kvcm.cache_reclaimer.pending_bytes_limit_per_group_type", "22"},
+        {"kvcm.cache_reclaimer.pending_delete_handler_limit", "33"},
+        {"kvcm.cache_reclaimer.pending_bytes_limit", "44"},
+    };
+    ASSERT_TRUE(config.Parse("", environ));
+    ASSERT_TRUE(config.Check());
+    EXPECT_EQ(1234, config.GetCacheReclaimerInflightDeleteTimeoutMs());
+    EXPECT_EQ(11, config.GetCacheReclaimerPendingLocationLimitPerGroupType());
+    EXPECT_EQ(22, config.GetCacheReclaimerPendingBytesLimitPerGroupType());
+    EXPECT_EQ(33, config.GetCacheReclaimerPendingDeleteHandlerLimit());
+    EXPECT_EQ(44, config.GetCacheReclaimerPendingBytesLimit());
+
+    environ["kvcm.cache_reclaimer.pending_delete_handler_limit"] = "0";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_FALSE(config.Check());
 }
 
 TEST_F(ServerConfigTest, TestUnderscoreEnvFallback) {

--- a/package/etc/default_server_config.conf
+++ b/package/etc/default_server_config.conf
@@ -54,6 +54,17 @@ kvcm.service.enable_debug_service=false
 # 异步删除KVCache的后台线程池大小
 kvcm.schedule_plan_executor_thread_count=8
 
+# 删除请求在 delay 结束后允许继续抵扣水位的最长时间；只关闭 credit，不中止底层 I/O
+kvcm.cache_reclaimer.inflight_delete_timeout_ms=60000
+
+# 单个 Instance Group × Storage Type 的 pending Location 数与 bytes 上限
+kvcm.cache_reclaimer.pending_location_limit_per_group_type=100000
+kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
+
+# 进程级 pending 删除请求数与 bytes 上限
+kvcm.cache_reclaimer.pending_delete_handler_limit=1024
+kvcm.cache_reclaimer.pending_bytes_limit=274877906944
+
 # 重访间隔统计的桶边界（秒），逗号分隔，必须严格升序
 # 默认值：1,5,30,60,120,180,300,600,900,1800,3600,21600,86400（13个边界，14个桶含+Inf）
 # 修改后需重启服务生效


### PR DESCRIPTION
## Background

Before this change, CacheReclaimer submitted a Location deletion by synchronously performing metadata Get, CAS, and Sync. These operations may access a remote metadata backend such as Redis, so a slow metadata operation could block the Reclaimer cron thread and delay reclamation work for every Instance Group handled by that loop.

Deletion may also be delayed by `delay_before_delete_ms`. During that interval, official storage usage and key count have not decreased yet, so subsequent cron iterations continue to observe an exceeded watermark and select more victims. The accumulated submissions can evict substantially more cache data than required. Making admission asynchronous also creates an accepted-before-CAS window in which a Location still appears selectable, so in-flight work must be accounted for and deduplicated immediately after acceptance.

## Summary

- Add a true end-to-end asynchronous Location deletion API while preserving the existing synchronous `Submit` interface.
- Move metadata Get/CAS/Sync, delayed physical deletion, and final CAD onto `SchedulePlanExecutor` workers; delayed waits use the timer queue and do not occupy a worker.
- Track instance-scoped pending Locations to close the accepted-before-CAS duplicate-submission window.
- Credit in-flight delete bytes by Instance Group and base storage type, plus conservatively predicted deleted keys, so delayed deletion does not cause repeated over-eviction.
- Add credit deadlines, bounded per-Group/type and process-level backpressure, and no-progress polling backoff.
- Document the lifecycle, failure semantics, configuration defaults, and observability.

## Key behavior

- `SubmitAsync` returns `accepted=false` with no valid Future when the initial enqueue is rejected; Reclaimer state is created only after acceptance.
- Every accepted request has one end-to-end Future. Worker failure, exception, secondary enqueue failure, shutdown cancellation, and normal completion all converge on an exactly-once promise completion path.
- `delay_before_delete_ms` starts after metadata Sync succeeds.
- Pending identity includes `instance_id`, block key, and location id, preserving strict Instance isolation.
- Delete bytes use the same URI-size accounting as official usage, with `VCNS_HF3FS` normalized to `HF3FS`; all effective-watermark subtraction is saturating.
- A credit timeout stops bytes/key-count deduction but intentionally retains pending identity and hard-limit quota until the Future reaches a terminal state.
- A saturated Group/type only blocks that type, while process-level limits stop all new admission.
- Watermark excess without an accepted non-empty request uses the normal polling interval instead of spinning.

## Validation

All compilation and tests were run in a dedicated Linux container.

```text
bazelisk test --jobs=1 --runs_per_test=10 --cache_test_results=no \
  //kv_cache_manager/manager/test:SchedulePlanExecutorTest \
  //kv_cache_manager/manager/test:CacheReclaimerTest \
  //kv_cache_manager/service/test:ServerConfigTest
```

Results:

- `SchedulePlanExecutorTest`: 16 tests, target passed 10/10 runs.
- `CacheReclaimerTest`: 75 tests, target passed 10/10 runs.
- `ServerConfigTest`: 3 tests, target passed 10/10 runs.
- `//kv_cache_manager:kv_cache_manager_bin`: built successfully with `--jobs=1`.
- C/C++ changed-line formatting, Python formatting for the separately exercised integration harness, and `git diff --check`: passed.
