### PR TITLE
[py_connector] complete manager reporting and query APIs

### DIFF
--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -65,7 +65,7 @@ client 覆盖元数据面与数据面两条链路，其对应关系如下（管�
 **元数据面到 KVCM 有两条等价通路**，最终都落到服务端同一套 `*ServiceImpl`（`grpc_service`/`http_service` 只是传输适配层）：
 
 1. **C++ `MetaClient`（gRPC）**：走 `internal/stub:grpc_stub`，供 C++ 侧与经 pybind 的引擎使用。
-2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 访问 KVCM 的 `/api/*` 端点（`getCacheLocation`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`registerInstance`/`removeCache`/`reportEvent`/`trimCache`/`getClusterInfo`），并自带 Leader 发现（`/api/getClusterInfo` → `leader_endpoint.meta_http_port`）与 `SERVER_NOT_LEADER` 重试。不同连接器按需选用其一。
+2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 覆盖 MetaService 的全部 `/api/*` 端点（`registerInstance`/`getInstanceInfo`/`getCacheMeta`/`getCacheLocation`/`getCacheLocationLen`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`removeCache`/`trimCache`/`getClusterInfo`/`reportEvent`），并自带 Leader 发现（`/api/getClusterInfo` → `leader_endpoint.meta_http_port`）与 `SERVER_NOT_LEADER` 重试。不同连接器按需选用其一。
 
 数据面则统一走 C++ `TransferClient`（经 pybind），与元数据面选哪条通路无关。
 

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -65,7 +65,7 @@ client 覆盖元数据面与数据面两条链路，其对应关系如下（管�
 **元数据面到 KVCM 有两条等价通路**，最终都落到服务端同一套 `*ServiceImpl`（`grpc_service`/`http_service` 只是传输适配层）：
 
 1. **C++ `MetaClient`（gRPC）**：走 `internal/stub:grpc_stub`，供 C++ 侧与经 pybind 的引擎使用。
-2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 访问 KVCM 的 `/api/*` 端点（`getCacheLocation`/`startWriteCache`/`finishWriteCache`/`registerInstance`/`removeCache`/`trimCache`/`getClusterInfo`），并自带 Leader 发现（`/api/getClusterInfo` → `leader_endpoint.meta_http_port`）与 `SERVER_NOT_LEADER` 重试。不同连接器按需选用其一。
+2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 访问 KVCM 的 `/api/*` 端点（`getCacheLocation`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`registerInstance`/`removeCache`/`reportEvent`/`trimCache`/`getClusterInfo`），并自带 Leader 发现（`/api/getClusterInfo` → `leader_endpoint.meta_http_port`）与 `SERVER_NOT_LEADER` 重试。不同连接器按需选用其一。
 
 数据面则统一走 C++ `TransferClient`（经 pybind），与元数据面选哪条通路无关。
 

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -201,9 +201,17 @@ class KvCacheManagerClient:
         """Get information about a registered instance"""
         return self._make_api_request('/api/getInstanceInfo', data, check_response)
 
+    def get_cache_meta(self, data, check_response=True):
+        """Get cache metadata for specified block keys"""
+        return self._make_api_request('/api/getCacheMeta', data, check_response)
+
     def get_cache_location(self, data, check_response=True):
         """Get cache location for specified block keys"""
         return self._make_api_request('/api/getCacheLocation', data, check_response)
+
+    def get_cache_location_len(self, data, check_response=True):
+        """Get the number of cache locations matching the specified block keys"""
+        return self._make_api_request('/api/getCacheLocationLen', data, check_response)
 
     def get_cache_locations_by_backend(self, data, check_response=True):
         """Get cache locations selected independently for each storage backend."""

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -205,6 +205,10 @@ class KvCacheManagerClient:
         """Get cache location for specified block keys"""
         return self._make_api_request('/api/getCacheLocation', data, check_response)
 
+    def get_cache_locations_by_backend(self, data, check_response=True):
+        """Get cache locations selected independently for each storage backend."""
+        return self._make_api_request('/api/getCacheLocationsByBackend', data, check_response)
+
     def start_write_cache(self, data, check_response=True):
         """Start writing cache data"""
         return self._make_api_request('/api/startWriteCache', data, check_response)
@@ -216,6 +220,10 @@ class KvCacheManagerClient:
     def remove_cache(self, data, check_response=True):
         """Remove cache data for specified block keys"""
         return self._make_api_request('/api/removeCache', data, check_response)
+
+    def report_event(self, data, check_response=True):
+        """Report node, cache block, host-down, or heartbeat events."""
+        return self._make_api_request('/api/reportEvent', data, check_response)
 
     def trim_cache(self, data, check_response=True):
         """Trim cache data based on specified strategy"""

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -523,6 +523,70 @@ class TestGetClusterInfoPublicApi(unittest.TestCase):
             client.close()
 
 
+class TestReportingApis(unittest.TestCase):
+    """Tests for the event reporting and backend-aware query APIs."""
+
+    @patch.object(KvCacheManagerClient, "_make_api_request")
+    def test_report_event_forwards_request(self, mock_make_api_request):
+        """report_event() should forward the request to reportEvent unchanged."""
+        mock_make_api_request.return_value = _ok_response_json()
+        client = KvCacheManagerClient("http://10.0.0.1:8080")
+        request = {
+            "trace_id": "report-1",
+            "instance_id": "instance-1",
+            "host_ip_port": "10.0.0.2:9600",
+            "storage_type": "ST_VINEYARD",
+            "events": [
+                {
+                    "event_type": "EVENT_HEARTBEAT",
+                    "heartbeat": {"system_status": {"version": "v6d_1.0"}},
+                }
+            ],
+        }
+
+        try:
+            result = client.report_event(request, check_response=False)
+        finally:
+            client.close()
+
+        self.assertEqual(result["header"]["status"]["code"], "OK")
+        mock_make_api_request.assert_called_once_with(
+            "/api/reportEvent", request, False
+        )
+
+    @patch.object(KvCacheManagerClient, "_make_api_request")
+    def test_get_cache_locations_by_backend_forwards_request(
+        self, mock_make_api_request
+    ):
+        """Backend-aware lookup should use getCacheLocationsByBackend."""
+        mock_make_api_request.return_value = _ok_response_json(
+            {"key_locations": []}
+        )
+        client = KvCacheManagerClient("http://10.0.0.1:8080")
+        request = {
+            "trace_id": "lookup-1",
+            "instance_id": "instance-1",
+            "query_type": "QT_BATCH_GET",
+            "block_keys": [123],
+            "backend_selectors": [
+                {
+                    "backend_type": "ST_VINEYARD",
+                    "strategy": "LSS_V6D_PREFIX",
+                }
+            ],
+        }
+
+        try:
+            result = client.get_cache_locations_by_backend(request)
+        finally:
+            client.close()
+
+        self.assertEqual(result["key_locations"], [])
+        mock_make_api_request.assert_called_once_with(
+            "/api/getCacheLocationsByBackend", request, True
+        )
+
+
 class TestNormalApiStillWorks(unittest.TestCase):
     """Regression tests: normal API calls should still work unchanged."""
 

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -523,14 +523,15 @@ class TestGetClusterInfoPublicApi(unittest.TestCase):
             client.close()
 
 
-class TestReportingApis(unittest.TestCase):
-    """Tests for the event reporting and backend-aware query APIs."""
+class TestMetaServiceApiWrappers(unittest.TestCase):
+    """Tests for MetaService API wrappers not covered by integration-style tests."""
 
     @patch.object(KvCacheManagerClient, "_make_api_request")
     def test_report_event_forwards_request(self, mock_make_api_request):
         """report_event() should forward the request to reportEvent unchanged."""
         mock_make_api_request.return_value = _ok_response_json()
         client = KvCacheManagerClient("http://10.0.0.1:8080")
+        self.addCleanup(client.close)
         request = {
             "trace_id": "report-1",
             "instance_id": "instance-1",
@@ -544,11 +545,7 @@ class TestReportingApis(unittest.TestCase):
             ],
         }
 
-        try:
-            result = client.report_event(request, check_response=False)
-        finally:
-            client.close()
-
+        result = client.report_event(request, check_response=False)
         self.assertEqual(result["header"]["status"]["code"], "OK")
         mock_make_api_request.assert_called_once_with(
             "/api/reportEvent", request, False
@@ -563,6 +560,7 @@ class TestReportingApis(unittest.TestCase):
             {"key_locations": []}
         )
         client = KvCacheManagerClient("http://10.0.0.1:8080")
+        self.addCleanup(client.close)
         request = {
             "trace_id": "lookup-1",
             "instance_id": "instance-1",
@@ -576,14 +574,53 @@ class TestReportingApis(unittest.TestCase):
             ],
         }
 
-        try:
-            result = client.get_cache_locations_by_backend(request)
-        finally:
-            client.close()
-
+        result = client.get_cache_locations_by_backend(request)
         self.assertEqual(result["key_locations"], [])
         mock_make_api_request.assert_called_once_with(
             "/api/getCacheLocationsByBackend", request, True
+        )
+
+    @patch.object(KvCacheManagerClient, "_make_api_request")
+    def test_get_cache_meta_forwards_request(self, mock_make_api_request):
+        """get_cache_meta() should forward metadata queries unchanged."""
+        mock_make_api_request.return_value = _ok_response_json(
+            {"locations": [], "metas": []}
+        )
+        client = KvCacheManagerClient("http://10.0.0.1:8080")
+        self.addCleanup(client.close)
+        request = {
+            "trace_id": "meta-1",
+            "instance_id": "instance-1",
+            "block_keys": [123],
+            "detail_level": 1,
+        }
+
+        result = client.get_cache_meta(request)
+        self.assertEqual(result["locations"], [])
+        self.assertEqual(result["metas"], [])
+        mock_make_api_request.assert_called_once_with(
+            "/api/getCacheMeta", request, True
+        )
+
+    @patch.object(KvCacheManagerClient, "_make_api_request")
+    def test_get_cache_location_len_forwards_request(self, mock_make_api_request):
+        """get_cache_location_len() should use getCacheLocationLen."""
+        mock_make_api_request.return_value = _ok_response_json(
+            {"cache_location_len": 2}
+        )
+        client = KvCacheManagerClient("http://10.0.0.1:8080")
+        self.addCleanup(client.close)
+        request = {
+            "trace_id": "location-len-1",
+            "instance_id": "instance-1",
+            "query_type": "QT_BATCH_GET",
+            "block_keys": [123, 456],
+        }
+
+        result = client.get_cache_location_len(request, check_response=False)
+        self.assertEqual(result["cache_location_len"], 2)
+        mock_make_api_request.assert_called_once_with(
+            "/api/getCacheLocationLen", request, False
         )
 
 


### PR DESCRIPTION
## Summary

- add `report_event()` for node, cache block, host-down, and heartbeat events
- add `get_cache_locations_by_backend()` for backend-aware cache location queries
- add the previously omitted `get_cache_meta()` wrapper
- add `get_cache_location_len()` after rebasing onto the latest `main`
- cover all 12 MetaService HTTP endpoints in the Python client documentation
- add focused unit coverage and align client cleanup with the existing test lifecycle

## Motivation

The HTTP Manager Python client did not expose several MetaService APIs needed by Python integrations. These wrappers preserve the existing raw request/response contract and response validation behavior while completing the Python client surface for every MetaService HTTP endpoint.

## Validation

- `python3 -m unittest kv_cache_manager.py_connector.test.test_manager_client` (28 tests)
- `python3 -m py_compile kv_cache_manager/py_connector/common/manager_client.py kv_cache_manager/py_connector/test/test_manager_client.py`
- `bazelisk build --config=client //kv_cache_manager/py_connector/common:common`
- `git diff --check`