### PR TITLE
[py_connector] support service discovery in Python manager client

### DIFF
--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -51,7 +51,7 @@ KVCache Manager 采用中心化部署，负责 KVCache 的全局元数据管理�
 | 模块 | 目录 | 职责 |
 |---|---|---|
 | **client** | `client/` | C++/Python 客户端 SDK，是推理引擎与 KVCM 之间的桥梁。对外提供 `ManagerClient`/`RTPLLMClient` 门面，内部由两条链路组成（见下）：**元数据面** `MetaClient`（经 gRPC 桩 `internal/stub` 调用 KVCM 服务）与**数据面** `TransferClient`（经 `internal/sdk` 在推理引擎显存/内存与存储后端之间搬运 KVCache 数据）。面向外部，不被服务端核心调用。 |
-| **py_connector** | `py_connector/` | 推理框架集成（Python）。将 client 接入 vLLM/SGLang/TRT-LLM，含 CUDA kernel 辅助，负责在引擎的推理流程中按正确顺序调用元数据面与数据面接口。此外自带一个纯 Python 的 HTTP 元数据面客户端 `KvCacheManagerClient`（`common/manager_client.py`），作为 C++ `MetaClient` 之外的另一条元数据面通路。位于 Python 侧栈顶。 |
+| **py_connector** | `py_connector/` | 推理框架集成（Python）。将 client 接入 vLLM/SGLang/TRT-LLM，含 CUDA kernel 辅助，负责在引擎的推理流程中按正确顺序调用元数据面与数据面接口。此外自带一个纯 Python 的 HTTP 元数据面客户端 `KvCacheManagerClient`（`common/manager_client.py`），可通过统一服务发现 URL 获取 Manager 入口，并作为 C++ `MetaClient` 之外的另一条元数据面通路。位于 Python 侧栈顶。 |
 
 > **三个面的界定**：本文档区分三个面——**元数据面**指 MetaService 的接口（`GetCacheLocation`/`StartWriteCache`/`FinishWriteCache`/`GetCacheMeta`/`RemoveCache`/`RegisterInstance` 等）及 client 侧调用这些接口的逻辑，是推理引擎读写 KVCache 的热路径；**数据面**指 KVCache 数据在引擎显存/内存与存储后端之间的实际搬运（`TransferClient`，不经过 KVCM）；**管控面**仅指 AdminService 的接口（Storage 增删改、Instance Group 管理、账号、配置快照、运维监控、Leader 运维等），供运维/管理工具使用，不在推理引擎的读写热路径上。
 
@@ -65,7 +65,7 @@ client 覆盖元数据面与数据面两条链路，其对应关系如下（管�
 **元数据面到 KVCM 有两条等价通路**，最终都落到服务端同一套 `*ServiceImpl`（`grpc_service`/`http_service` 只是传输适配层）：
 
 1. **C++ `MetaClient`（gRPC）**：走 `internal/stub:grpc_stub`，供 C++ 侧与经 pybind 的引擎使用。
-2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 覆盖 MetaService 的全部 `/api/*` 端点（`registerInstance`/`getInstanceInfo`/`getCacheMeta`/`getCacheLocation`/`getCacheLocationLen`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`removeCache`/`trimCache`/`getClusterInfo`/`reportEvent`），并自带 Leader 发现（`/api/getClusterInfo` → `leader_endpoint.meta_http_port`）与 `SERVER_NOT_LEADER` 重试。不同连接器按需选用其一。
+2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 覆盖 MetaService 的全部 `/api/*` 端点（`registerInstance`/`getInstanceInfo`/`getCacheMeta`/`getCacheLocation`/`getCacheLocationLen`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`removeCache`/`trimCache`/`getClusterInfo`/`reportEvent`）。`manager_uri` 可直接使用 HTTP(S) 地址，也可使用通用服务发现 URL；启用 Leader 发现后，客户端以动态发现的 Manager 端点调用 `/api/getClusterInfo`，再根据 `leader_endpoint.meta_http_port` 直连 Leader，并处理 `SERVER_NOT_LEADER` 重试。不同连接器按需选用其一。
 
 数据面则统一走 C++ `TransferClient`（经 pybind），与元数据面选哪条通路无关。
 
@@ -249,7 +249,7 @@ sequenceDiagram
 
 ### 4.6 HA 故障转移
 
-`LeaderElector`（config）基于 `CoordinationBackend`（memory/file/redis）的分布式锁选主。`Server` 在成为 Leader 时调用 `CacheManager::DoRecover` 恢复状态，降级时调用 `DoCleanup` 清理运行时状态（正在进行的写入按失败处理）。
+`LeaderElector`（config）基于 `CoordinationBackend`（memory/file/redis）的分布式锁选主。`Server` 在成为 Leader 时调用 `CacheManager::DoRecover` 恢复状态，降级时调用 `DoCleanup` 清理运行时状态（正在进行的写入按失败处理）。Python `KvCacheManagerClient` 使用服务发现 URL 时，会在每次 Leader 刷新前重新选择一个 Manager 发现端点，避免把 Leader 查询入口固定在单个节点上。
 
 ---
 

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -65,7 +65,7 @@ client 覆盖元数据面与数据面两条链路，其对应关系如下（管�
 **元数据面到 KVCM 有两条等价通路**，最终都落到服务端同一套 `*ServiceImpl`（`grpc_service`/`http_service` 只是传输适配层）：
 
 1. **C++ `MetaClient`（gRPC）**：走 `internal/stub:grpc_stub`，供 C++ 侧与经 pybind 的引擎使用。
-2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 覆盖 MetaService 的全部 `/api/*` 端点（`registerInstance`/`getInstanceInfo`/`getCacheMeta`/`getCacheLocation`/`getCacheLocationLen`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`removeCache`/`trimCache`/`getClusterInfo`/`reportEvent`）。`manager_uri` 可直接使用 HTTP(S) 地址，也可使用通用服务发现 URL；启用 Leader 发现后，客户端以动态发现的 Manager 端点调用 `/api/getClusterInfo`，再根据 `leader_endpoint.meta_http_port` 直连 Leader，并处理 `SERVER_NOT_LEADER` 重试。Leader 查询和普通 API 请求共享可配置的 `request_timeout_seconds`。不同连接器按需选用其一。
+2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 覆盖 MetaService 的全部 `/api/*` 端点（`registerInstance`/`getInstanceInfo`/`getCacheMeta`/`getCacheLocation`/`getCacheLocationLen`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`removeCache`/`trimCache`/`getClusterInfo`/`reportEvent`）。`manager_uri` 可直接使用 HTTP(S) 地址，也可使用通用服务发现 URL；启用 Leader 发现后，客户端以动态发现的 Manager 端点调用 `/api/getClusterInfo`，再根据 `leader_endpoint.meta_http_port` 直连 Leader，并处理 `SERVER_NOT_LEADER` 重试。普通 API 请求使用可配置的 `request_timeout_seconds`（默认 1 秒），Leader 查询保留独立的 5 秒超时。不同连接器按需选用其一。
 
 数据面则统一走 C++ `TransferClient`（经 pybind），与元数据面选哪条通路无关。
 

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -65,7 +65,7 @@ client 覆盖元数据面与数据面两条链路，其对应关系如下（管�
 **元数据面到 KVCM 有两条等价通路**，最终都落到服务端同一套 `*ServiceImpl`（`grpc_service`/`http_service` 只是传输适配层）：
 
 1. **C++ `MetaClient`（gRPC）**：走 `internal/stub:grpc_stub`，供 C++ 侧与经 pybind 的引擎使用。
-2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 覆盖 MetaService 的全部 `/api/*` 端点（`registerInstance`/`getInstanceInfo`/`getCacheMeta`/`getCacheLocation`/`getCacheLocationLen`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`removeCache`/`trimCache`/`getClusterInfo`/`reportEvent`）。`manager_uri` 可直接使用 HTTP(S) 地址，也可使用通用服务发现 URL；启用 Leader 发现后，客户端以动态发现的 Manager 端点调用 `/api/getClusterInfo`，再根据 `leader_endpoint.meta_http_port` 直连 Leader，并处理 `SERVER_NOT_LEADER` 重试。不同连接器按需选用其一。
+2. **Python `KvCacheManagerClient`（HTTP）**：位于 `py_connector/common/manager_client.py`，用 `requests` 覆盖 MetaService 的全部 `/api/*` 端点（`registerInstance`/`getInstanceInfo`/`getCacheMeta`/`getCacheLocation`/`getCacheLocationLen`/`getCacheLocationsByBackend`/`startWriteCache`/`finishWriteCache`/`removeCache`/`trimCache`/`getClusterInfo`/`reportEvent`）。`manager_uri` 可直接使用 HTTP(S) 地址，也可使用通用服务发现 URL；启用 Leader 发现后，客户端以动态发现的 Manager 端点调用 `/api/getClusterInfo`，再根据 `leader_endpoint.meta_http_port` 直连 Leader，并处理 `SERVER_NOT_LEADER` 重试。Leader 查询和普通 API 请求共享可配置的 `request_timeout_seconds`。不同连接器按需选用其一。
 
 数据面则统一走 C++ `TransferClient`（经 pybind），与元数据面选哪条通路无关。
 

--- a/docs/design/service_discovery_framework.md
+++ b/docs/design/service_discovery_framework.md
@@ -484,6 +484,23 @@ if discovery:
         endpoints = sd.get_all_endpoints()
 ```
 
+`KvCacheManagerClient` 也可以直接接收同一格式的服务发现 URL。客户端会先解析
+一个 Manager 端点；启用 Leader 发现后，每次刷新 Leader 都会重新获取一个发现
+端点作为查询入口，避免固定依赖某个 Manager 节点：
+
+```python
+from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
+
+client = KvCacheManagerClient(
+    "static://127.0.0.1:6382,127.0.0.1:6383",
+    instance_id="example-instance",
+    auto_discover_leader=True,
+)
+```
+
+开源构建可直接使用 `static://`；需要内部实现的 scheme 仍由对应的
+`stub_source` 实现提供，通用 Client 不依赖具体服务发现类型。
+
 ### 配置集成示例
 
 在实际项目中，服务发现 URL 通常通过配置文件传入：
@@ -666,4 +683,3 @@ mytype://my-service?param1=value1
 - 非空时，直接把 URL 透传给 `pace_init`，由 `pace_mp` 自身识别 `vipserver://` / `spectrum://` / `static://` 等形式（pace_mp 是内部组件，已与 service_discovery_url 完全兼容）。
 - 为空时使用 `domain` 作为 `pace_init` 的目标。
 - 这样新 client 在面对老 server（`service_discovery_url` 为空）时，行为与历史版本一致。
-

--- a/docs/design/service_discovery_framework.md
+++ b/docs/design/service_discovery_framework.md
@@ -495,8 +495,13 @@ client = KvCacheManagerClient(
     "static://127.0.0.1:6382,127.0.0.1:6383",
     instance_id="example-instance",
     auto_discover_leader=True,
+    request_timeout_seconds=2.0,
 )
 ```
+
+随项目提供的 vLLM、SGLang 和 TensorRT-LLM connector 都会从各自原有的
+extra config 中透传这些 Manager Client 参数，包括
+`request_timeout_seconds`；未配置时默认值为 `1.0` 秒。
 
 开源构建可直接使用 `static://`；需要内部实现的 scheme 仍由对应的
 `stub_source` 实现提供，通用 Client 不依赖具体服务发现类型。

--- a/docs/design/service_discovery_framework.md
+++ b/docs/design/service_discovery_framework.md
@@ -501,7 +501,8 @@ client = KvCacheManagerClient(
 
 随项目提供的 vLLM、SGLang 和 TensorRT-LLM connector 都会从各自原有的
 extra config 中透传这些 Manager Client 参数，包括
-`request_timeout_seconds`；未配置时默认值为 `1.0` 秒。
+`request_timeout_seconds`；未配置时普通 API 请求默认超时为 `1.0` 秒。
+Leader 查询使用独立的 5 秒超时，不受该参数影响。
 
 开源构建可直接使用 `static://`；需要内部实现的 scheme 仍由对应的
 `stub_source` 实现提供，通用 Client 不依赖具体服务发现类型。

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -117,9 +117,8 @@ class KvCacheManagerClient:
                 logger.warning("Initial leader discovery failed, keeping original base_url %s: %s",
                                self.base_url, e)
 
-        # Leader discovery refreshes periodically. Service discovery without
-        # leader discovery is event-driven and only refreshes after transport
-        # failures, so it does not introduce a second refresh lifecycle.
+        # One route-refresh thread serves both modes. Leader discovery wakes
+        # periodically; service-discovery-only mode waits for transport failures.
         if self._auto_discover_leader or self._service_discovery is not None:
             self._refresh_thread = threading.Thread(
                 target=self._route_refresh_loop, daemon=True,
@@ -132,6 +131,7 @@ class KvCacheManagerClient:
 
     @staticmethod
     def _endpoint_url(endpoint: ServiceEndpoint):
+        """Build a Manager URL from the host:port-only HTTP endpoint contract."""
         return f"http://{endpoint.host}"
 
     def _close_service_discovery(self):
@@ -302,6 +302,10 @@ class KvCacheManagerClient:
             try:
                 response = self._make_request('POST', endpoint, data)
             except (requests.ConnectionError, requests.Timeout):
+                # Never retry the current request after a transport failure: without
+                # a response, the client cannot know whether Manager applied it, and
+                # the API set includes non-idempotent writes. Refresh only benefits
+                # subsequent calls.
                 if self._refresh_thread is not None:
                     logger.warning(
                         "Transport request to %s failed, notifying route refresh",

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -71,7 +71,7 @@ class KvCacheManagerClient:
 
         self.base_url = resolved_url.rstrip('/')
 
-        # Leader discovery settings
+        # Manager route settings
         self._instance_id = instance_id
         # Immutable fallback address used when service discovery cannot return a fresh
         # endpoint. For a direct HTTP URL, this remains the stable discovery seed.
@@ -82,21 +82,26 @@ class KvCacheManagerClient:
         self._discovery_refresh_interval = discovery_refresh_interval_seconds
         self._min_discover_interval = min_discover_interval_seconds
 
-        self._leader_lock = threading.Lock()
+        self._route_lock = threading.Lock()
         self._refresh_event = threading.Event()
         self._closed = threading.Event()
-        self._last_discover_time = 0.0  # time.monotonic()
+        self._last_route_refresh_time = 0.0  # time.monotonic()
         self._refresh_thread = None
 
         if self._auto_discover_leader:
             try:
-                self._discover_leader()
+                self._refresh_manager_route()
             except Exception as e:
                 logger.warning("Initial leader discovery failed, keeping original base_url %s: %s",
                                self.base_url, e)
+
+        # Leader discovery refreshes periodically. Service discovery without
+        # leader discovery is event-driven and only refreshes after transport
+        # failures, so it does not introduce a second refresh lifecycle.
+        if self._auto_discover_leader or self._service_discovery is not None:
             self._refresh_thread = threading.Thread(
-                target=self._leader_refresh_loop, daemon=True,
-                name="kvcm-leader-refresh")
+                target=self._route_refresh_loop, daemon=True,
+                name="kvcm-route-refresh")
             self._refresh_thread.start()
 
     @staticmethod
@@ -118,67 +123,79 @@ class KvCacheManagerClient:
         """Extract status code from a standard API response."""
         return response_data.get('header', {}).get('status', {}).get('code')
 
-    def _discover_leader(self):
-        """Query getClusterInfo to discover and switch to the leader node.
-        Returns True if base_url is up-to-date, False on failure.
-        """
+    def _refresh_manager_route(self, force_service_refresh=False):
+        """Refresh the Manager route through service and optional leader discovery."""
         snapshot = self.base_url
-        with self._leader_lock:
+        with self._route_lock:
             # Another thread already updated base_url
             if self.base_url != snapshot:
                 return True
-            return self._do_discover_leader()
 
-    def _do_discover_leader(self):
-        """Actual discovery logic. Must be called under _leader_lock."""
-        url = self._resolve_discovery_url()
+            try:
+                route_url = self._resolve_discovery_url(force_service_refresh)
+                if not self._auto_discover_leader:
+                    if route_url != self.base_url:
+                        logger.info(
+                            "Service discovery refreshed manager route: %s -> %s",
+                            self.base_url,
+                            route_url,
+                        )
+                        self.base_url = route_url
+                    return True
+                return self._do_discover_leader(route_url)
+            finally:
+                self._last_route_refresh_time = time.monotonic()
+
+    def _do_discover_leader(self, url):
+        """Resolve and switch to the leader. Must be called under _route_lock."""
         try:
-            try:
-                resp = requests.post(
-                    url + '/api/getClusterInfo',
-                    json={
-                        "trace_id": f"leader_discovery_{time.monotonic()}",
-                        "instance_id": self._instance_id,
-                    },
-                    headers=self.headers,
-                    timeout=self._request_timeout_seconds,
-                )
-            except Exception as e:
-                logger.warning("Leader discovery request to %s failed: %s", url, e)
-                return False
+            resp = requests.post(
+                url + '/api/getClusterInfo',
+                json={
+                    "trace_id": f"leader_discovery_{time.monotonic()}",
+                    "instance_id": self._instance_id,
+                },
+                headers=self.headers,
+                timeout=self._request_timeout_seconds,
+            )
+        except Exception as e:
+            logger.warning("Leader discovery request to %s failed: %s", url, e)
+            return False
 
-            if resp.status_code != 200:
-                logger.warning("Leader discovery to %s returned status %d", url, resp.status_code)
-                return False
+        if resp.status_code != 200:
+            logger.warning("Leader discovery to %s returned status %d", url, resp.status_code)
+            return False
 
-            try:
-                data = resp.json()
-            except Exception as e:
-                logger.warning("Leader discovery response from %s is not valid JSON: %s", url, e)
-                return False
+        try:
+            data = resp.json()
+        except Exception as e:
+            logger.warning("Leader discovery response from %s is not valid JSON: %s", url, e)
+            return False
 
-            if self._get_status_code(data) != 'OK':
-                msg = data.get('header', {}).get('status', {}).get('message', 'unknown')
-                logger.warning("Leader discovery from %s returned error: %s", url, msg)
-                return False
+        if self._get_status_code(data) != 'OK':
+            msg = data.get('header', {}).get('status', {}).get('message', 'unknown')
+            logger.warning("Leader discovery from %s returned error: %s", url, msg)
+            return False
 
-            leader_ep = data.get('leader_endpoint')
-            if not leader_ep or not leader_ep.get('host') or not leader_ep.get('meta_http_port'):
-                logger.warning("Leader discovery from %s: leader_endpoint missing or incomplete", url)
-                return False
+        leader_ep = data.get('leader_endpoint')
+        if not leader_ep or not leader_ep.get('host') or not leader_ep.get('meta_http_port'):
+            logger.warning("Leader discovery from %s: leader_endpoint missing or incomplete", url)
+            return False
 
-            new_url = f"http://{leader_ep['host']}:{leader_ep['meta_http_port']}"
-            if new_url != self.base_url:
-                logger.info("Leader discovered: switching base_url from %s to %s", self.base_url, new_url)
-                self.base_url = new_url
-            return True
-        finally:
-            self._last_discover_time = time.monotonic()
+        new_url = f"http://{leader_ep['host']}:{leader_ep['meta_http_port']}"
+        if new_url != self.base_url:
+            logger.info("Leader discovered: switching base_url from %s to %s", self.base_url, new_url)
+            self.base_url = new_url
+        return True
 
-    def _resolve_discovery_url(self):
+    def _resolve_discovery_url(self, force_refresh=False):
         """Resolve a fresh leader-discovery seed, falling back to the initial one."""
         if self._service_discovery is not None:
             try:
+                if force_refresh and not self._service_discovery.refresh():
+                    logger.warning(
+                        "Failed to force-refresh manager service discovery; using cached endpoints"
+                    )
                 endpoint = self._service_discovery.get_one_endpoint()
             except Exception as e:
                 logger.warning(
@@ -194,22 +211,31 @@ class KvCacheManagerClient:
                 )
         return self._discovery_url
 
-    def _leader_refresh_loop(self):
-        """Background daemon: periodically refresh leader address, supports urgent wakeup."""
+    def _route_refresh_loop(self):
+        """Background daemon for periodic leader and event-driven route refresh."""
         while not self._closed.is_set():
-            self._refresh_event.wait(timeout=self._discovery_refresh_interval)
+            timeout = (
+                self._discovery_refresh_interval
+                if self._auto_discover_leader
+                else None
+            )
+            refresh_requested = self._refresh_event.wait(timeout=timeout)
             self._refresh_event.clear()
             if self._closed.is_set():
                 break
             # Min interval protection: wait remaining time instead of skipping
-            remaining = self._min_discover_interval - (time.monotonic() - self._last_discover_time)
+            remaining = self._min_discover_interval - (
+                time.monotonic() - self._last_route_refresh_time
+            )
             if remaining > 0:
                 if self._closed.wait(timeout=remaining):
                     break
             try:
-                self._discover_leader()
+                self._refresh_manager_route(
+                    force_service_refresh=refresh_requested,
+                )
             except Exception as e:
-                logger.warning("Background leader refresh failed: %s", e)
+                logger.warning("Background manager route refresh failed: %s", e)
 
     def _make_request(self, method, endpoint, data=None):
         """Helper method to make HTTP requests to the service"""
@@ -253,9 +279,12 @@ class KvCacheManagerClient:
         while True:
             try:
                 response = self._make_request('POST', endpoint, data)
-            except requests.ConnectionError:
-                if self._auto_discover_leader:
-                    logger.warning("Connection to %s failed, notifying background refresh", self.base_url)
+            except (requests.ConnectionError, requests.Timeout):
+                if self._refresh_thread is not None:
+                    logger.warning(
+                        "Transport request to %s failed, notifying route refresh",
+                        self.base_url,
+                    )
                     self._refresh_event.set()
                 raise
 
@@ -272,7 +301,7 @@ class KvCacheManagerClient:
                                    "retrying after %.3fs (retries left: %d)",
                                    endpoint, sleep_time, retries_left)
                     time.sleep(sleep_time)
-                    if self._discover_leader():
+                    if self._refresh_manager_route():
                         continue
                 if retries_left <= 0:
                     logger.error("All leader discovery retries exhausted for %s", endpoint)

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -14,6 +14,8 @@ from kv_cache_manager.py_connector.common.service_discovery_factory import (
     create_service_discovery,
 )
 
+_LEADER_DISCOVERY_TIMEOUT_SECONDS = 5.0
+
 
 class KvCacheManagerClient:
     @classmethod
@@ -48,7 +50,9 @@ class KvCacheManagerClient:
             base_url: Manager HTTP(S) address or a service-discovery URL. When
                 auto_discover_leader is enabled, leader discovery always starts from
                 this entry point instead of the current leader.
-            request_timeout_seconds: Timeout in seconds for Manager HTTP requests.
+            request_timeout_seconds: Timeout in seconds for regular Manager HTTP
+                requests. Defaults to 1 second. Leader discovery keeps its dedicated
+                5-second timeout.
         """
         self._request_timeout_seconds = float(request_timeout_seconds)
         if self._request_timeout_seconds <= 0:
@@ -178,7 +182,7 @@ class KvCacheManagerClient:
                     "instance_id": self._instance_id,
                 },
                 headers=self.headers,
-                timeout=self._request_timeout_seconds,
+                timeout=_LEADER_DISCOVERY_TIMEOUT_SECONDS,
             )
         except Exception as e:
             logger.warning("Leader discovery request to %s failed: %s", url, e)

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -19,13 +19,19 @@ class KvCacheManagerClient:
     def __init__(self, base_url, *, instance_id="", auto_discover_leader=False, leader_retry_count=1,
                  leader_retry_base_interval_seconds=0.005,
                  discovery_refresh_interval_seconds=30,
-                 min_discover_interval_seconds=1):
+                 min_discover_interval_seconds=1,
+                 request_timeout_seconds=1.0):
         """
         Args:
             base_url: Manager HTTP(S) address or a service-discovery URL. When
                 auto_discover_leader is enabled, leader discovery always starts from
                 this entry point instead of the current leader.
+            request_timeout_seconds: Timeout in seconds for Manager HTTP requests.
         """
+        self._request_timeout_seconds = float(request_timeout_seconds)
+        if self._request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be positive")
+
         self.session = requests.Session()
         self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
 
@@ -135,7 +141,7 @@ class KvCacheManagerClient:
                         "instance_id": self._instance_id,
                     },
                     headers=self.headers,
-                    timeout=5,
+                    timeout=self._request_timeout_seconds,
                 )
             except Exception as e:
                 logger.warning("Leader discovery request to %s failed: %s", url, e)
@@ -210,9 +216,19 @@ class KvCacheManagerClient:
         url = self.base_url + endpoint
 
         if method == 'POST':
-            response = self.session.post(url, json=data, headers=self.headers)
+            response = self.session.post(
+                url,
+                json=data,
+                headers=self.headers,
+                timeout=self._request_timeout_seconds,
+            )
         elif method == 'GET':
-            response = self.session.get(url, params=data, headers=self.headers)
+            response = self.session.get(
+                url,
+                params=data,
+                headers=self.headers,
+                timeout=self._request_timeout_seconds,
+            )
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -1,7 +1,7 @@
 import random
 import threading
 import time
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import requests
 
@@ -16,6 +16,28 @@ from kv_cache_manager.py_connector.common.service_discovery_factory import (
 
 
 class KvCacheManagerClient:
+    @classmethod
+    def from_connector_config(
+        cls, config: Mapping[str, Any]
+    ) -> "KvCacheManagerClient":
+        """Create a client from the shared connector configuration surface."""
+        return cls(
+            config["manager_uri"],
+            instance_id=config.get("instance_id", ""),
+            auto_discover_leader=config.get("auto_discover_leader", False),
+            leader_retry_count=config.get("leader_retry_count", 1),
+            leader_retry_base_interval_seconds=config.get(
+                "leader_retry_base_interval_seconds", 0.005
+            ),
+            discovery_refresh_interval_seconds=config.get(
+                "discovery_refresh_interval_seconds", 30
+            ),
+            min_discover_interval_seconds=config.get(
+                "min_discover_interval_seconds", 1
+            ),
+            request_timeout_seconds=config.get("request_timeout_seconds", 1.0),
+        )
+
     def __init__(self, base_url, *, instance_id="", auto_discover_leader=False, leader_retry_count=1,
                  leader_retry_base_interval_seconds=0.005,
                  discovery_refresh_interval_seconds=30,

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -1,11 +1,18 @@
 import random
 import threading
 import time
-from typing import List
+from typing import Optional
 
 import requests
 
 from kv_cache_manager.py_connector.common.logger import logger
+from kv_cache_manager.py_connector.common.service_discovery import (
+    ServiceDiscovery,
+    ServiceEndpoint,
+)
+from kv_cache_manager.py_connector.common.service_discovery_factory import (
+    create_service_discovery,
+)
 
 
 class KvCacheManagerClient:
@@ -15,21 +22,54 @@ class KvCacheManagerClient:
                  min_discover_interval_seconds=1):
         """
         Args:
-            base_url: Manager service address. When auto_discover_leader is enabled, leader
-                discovery will always query this address (not the current leader). It is
-                recommended to use a load-balancer address that fronts all manager nodes.
+            base_url: Manager HTTP(S) address or a service-discovery URL. When
+                auto_discover_leader is enabled, leader discovery always starts from
+                this entry point instead of the current leader.
         """
-        self.base_url = base_url
         self.session = requests.Session()
         self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
 
+        # Resolve service-discovery URLs before issuing any HTTP requests. Keep the
+        # discovery object alive so each leader refresh can start from a fresh endpoint.
+        self._service_discovery: Optional[ServiceDiscovery] = None
+        resolved_url = base_url
+        if not self._is_http_url(base_url):
+            self._service_discovery = create_service_discovery(base_url)
+            if self._service_discovery is None:
+                self.session.close()
+                raise ValueError(
+                    f"failed to create service discovery from manager address {base_url!r}"
+                )
+
+            try:
+                endpoint = self._service_discovery.get_one_endpoint()
+            except Exception as e:
+                self._close_service_discovery()
+                self.session.close()
+                raise RuntimeError(
+                    f"failed to resolve manager endpoints from {base_url!r}"
+                ) from e
+            if endpoint is None:
+                self._close_service_discovery()
+                self.session.close()
+                raise RuntimeError(
+                    f"service discovery returned no manager endpoints for {base_url!r}"
+                )
+
+            resolved_url = self._endpoint_url(endpoint)
+            logger.info(
+                "Service discovery (%s) resolved manager endpoint: %s",
+                self._service_discovery.get_type(),
+                resolved_url,
+            )
+
+        self.base_url = resolved_url.rstrip('/')
+
         # Leader discovery settings
         self._instance_id = instance_id
-        # Immutable seed address used for all discovery requests.
-        # When auto_discover_leader is enabled, getClusterInfo is always sent to this
-        # address rather than the current base_url, so it should be a stable entry point
-        # (e.g. a load-balancer) that can reach any manager node.
-        self._discovery_url = base_url
+        # Immutable fallback address used when service discovery cannot return a fresh
+        # endpoint. For a direct HTTP URL, this remains the stable discovery seed.
+        self._discovery_url = self.base_url
         self._auto_discover_leader = auto_discover_leader
         self._leader_retry_count = leader_retry_count
         self._leader_retry_base_interval = leader_retry_base_interval_seconds
@@ -54,6 +94,20 @@ class KvCacheManagerClient:
             self._refresh_thread.start()
 
     @staticmethod
+    def _is_http_url(url):
+        return url.startswith(('http://', 'https://'))
+
+    @staticmethod
+    def _endpoint_url(endpoint: ServiceEndpoint):
+        return f"http://{endpoint.host}"
+
+    def _close_service_discovery(self):
+        discovery = self._service_discovery
+        self._service_discovery = None
+        if discovery is not None:
+            discovery.close()
+
+    @staticmethod
     def _get_status_code(response_data):
         """Extract status code from a standard API response."""
         return response_data.get('header', {}).get('status', {}).get('code')
@@ -71,7 +125,7 @@ class KvCacheManagerClient:
 
     def _do_discover_leader(self):
         """Actual discovery logic. Must be called under _leader_lock."""
-        url = self._discovery_url
+        url = self._resolve_discovery_url()
         try:
             try:
                 resp = requests.post(
@@ -114,6 +168,25 @@ class KvCacheManagerClient:
             return True
         finally:
             self._last_discover_time = time.monotonic()
+
+    def _resolve_discovery_url(self):
+        """Resolve a fresh leader-discovery seed, falling back to the initial one."""
+        if self._service_discovery is not None:
+            try:
+                endpoint = self._service_discovery.get_one_endpoint()
+            except Exception as e:
+                logger.warning(
+                    "Failed to refresh manager endpoint through service discovery: %s",
+                    e,
+                )
+            else:
+                if endpoint is not None:
+                    return self._endpoint_url(endpoint)
+                logger.warning(
+                    "Service discovery returned no manager endpoints; using %s",
+                    self._discovery_url,
+                )
+        return self._discovery_url
 
     def _leader_refresh_loop(self):
         """Background daemon: periodically refresh leader address, supports urgent wakeup."""
@@ -242,9 +315,10 @@ class KvCacheManagerClient:
         return self._make_api_request('/api/getClusterInfo', data, check_response)
 
     def close(self):
-        """Close the HTTP session and stop background refresh thread"""
+        """Close the HTTP session, discovery client, and background refresh thread."""
         self._closed.set()
         self._refresh_event.set()
         if self._refresh_thread and self._refresh_thread.is_alive():
             self._refresh_thread.join(timeout=5)
         self.session.close()
+        self._close_service_discovery()

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -53,14 +53,8 @@ class HiCacheKVCM(HiCacheStorage):
         self.instance_group = self.extra_config["instance_group"]
         self.instance_id = self.extra_config["instance_id"]
 
-        self._manager_client = KvCacheManagerClient(
-            self.extra_config["manager_uri"],
-            instance_id=self.instance_id,
-            auto_discover_leader=self.extra_config.get("auto_discover_leader", False),
-            leader_retry_count=self.extra_config.get("leader_retry_count", 1),
-            leader_retry_base_interval_seconds=self.extra_config.get("leader_retry_base_interval_seconds", 0.005),
-            discovery_refresh_interval_seconds=self.extra_config.get("discovery_refresh_interval_seconds", 30),
-            min_discover_interval_seconds=self.extra_config.get("min_discover_interval_seconds", 1),
+        self._manager_client = KvCacheManagerClient.from_connector_config(
+            self.extra_config
         )
 
         self.registered_pools = {}

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -211,7 +211,7 @@ class TestRequestTimeout(unittest.TestCase):
         self.assertEqual(client.session.post.call_args.kwargs["timeout"], 1.5)
 
     @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
-    def test_leader_discovery_uses_configured_timeout(self, mock_post):
+    def test_leader_discovery_uses_dedicated_timeout(self, mock_post):
         mock_post.return_value = _make_mock_response(_cluster_info_response())
         client = KvCacheManagerClient(
             "http://10.0.0.1:8080",
@@ -221,7 +221,7 @@ class TestRequestTimeout(unittest.TestCase):
         )
 
         try:
-            self.assertEqual(mock_post.call_args.kwargs["timeout"], 2.5)
+            self.assertEqual(mock_post.call_args.kwargs["timeout"], 5.0)
         finally:
             client.close()
 

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -161,6 +161,50 @@ class TestServiceDiscoveryInit(unittest.TestCase):
         discovery.close.assert_called_once_with()
 
 
+class TestRequestTimeout(unittest.TestCase):
+    """Tests for the configurable Manager HTTP request timeout."""
+
+    def test_non_positive_timeout_is_rejected(self):
+        for timeout in (0, -1):
+            with self.subTest(timeout=timeout):
+                with self.assertRaisesRegex(ValueError, "must be positive"):
+                    KvCacheManagerClient(
+                        "http://10.0.0.1:8080",
+                        request_timeout_seconds=timeout,
+                    )
+
+    def test_api_request_uses_configured_timeout(self):
+        client = KvCacheManagerClient(
+            "http://10.0.0.1:8080",
+            request_timeout_seconds=1.5,
+        )
+        client.session.post = MagicMock(
+            return_value=_make_mock_response(_ok_response_json())
+        )
+
+        try:
+            client.register_instance({"trace_id": "test"})
+        finally:
+            client.close()
+
+        self.assertEqual(client.session.post.call_args.kwargs["timeout"], 1.5)
+
+    @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
+    def test_leader_discovery_uses_configured_timeout(self, mock_post):
+        mock_post.return_value = _make_mock_response(_cluster_info_response())
+        client = KvCacheManagerClient(
+            "http://10.0.0.1:8080",
+            auto_discover_leader=True,
+            discovery_refresh_interval_seconds=60,
+            request_timeout_seconds=2.5,
+        )
+
+        try:
+            self.assertEqual(mock_post.call_args.kwargs["timeout"], 2.5)
+        finally:
+            client.close()
+
+
 class TestLeaderDiscoveryInit(unittest.TestCase):
     """Tests for leader discovery during __init__."""
 

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -564,17 +564,24 @@ class TestConnectionErrorHandling(unittest.TestCase):
                 discovery = client._service_discovery
                 discovery.refresh = MagicMock(wraps=discovery.refresh)
                 client.session.post = MagicMock(side_effect=error)
+                route_refreshed = threading.Event()
+                original_refresh = client._refresh_manager_route
+
+                def refresh_and_signal(*args, **kwargs):
+                    try:
+                        return original_refresh(*args, **kwargs)
+                    finally:
+                        route_refreshed.set()
+
+                client._refresh_manager_route = refresh_and_signal
                 try:
                     with self.assertRaises(type(error)):
                         client.register_instance({"trace_id": "test"})
 
-                    deadline = time.time() + 1
-                    while (
-                        client.base_url != "http://10.0.0.2:8080"
-                        and time.time() < deadline
-                    ):
-                        time.sleep(0.01)
-
+                    self.assertTrue(
+                        route_refreshed.wait(timeout=5),
+                        "route refresh did not finish after the transport failure",
+                    )
                     self.assertEqual(client.base_url, "http://10.0.0.2:8080")
                     discovery.refresh.assert_called_once_with()
                     mock_discovery_post.assert_not_called()

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 import requests
 
 from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
+from kv_cache_manager.py_connector.common.service_discovery import ServiceEndpoint
 
 
 def _ok_response_json(data=None):
@@ -51,6 +52,113 @@ def _make_mock_response(json_data, status_code=200):
     mock_resp.status_code = status_code
     mock_resp.json.return_value = json_data
     return mock_resp
+
+
+class TestServiceDiscoveryInit(unittest.TestCase):
+    """Tests for resolving manager service-discovery URLs."""
+
+    def test_static_url_resolves_before_api_request(self):
+        client = KvCacheManagerClient(
+            "static://10.0.0.1:8080,10.0.0.2:9090",
+            auto_discover_leader=False,
+        )
+        try:
+            self.assertEqual(client.base_url, "http://10.0.0.1:8080")
+            self.assertIsNotNone(client._service_discovery)
+
+            client.session.post = MagicMock(
+                return_value=_make_mock_response(_ok_response_json())
+            )
+            client.register_instance({"trace_id": "test"})
+            client.session.post.assert_called_once()
+            self.assertEqual(
+                client.session.post.call_args[0][0],
+                "http://10.0.0.1:8080/api/registerInstance",
+            )
+        finally:
+            client.close()
+
+    @patch(
+        "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
+    )
+    def test_direct_https_url_bypasses_service_discovery(self, mock_create):
+        client = KvCacheManagerClient("https://manager.example.test:8443/")
+        try:
+            self.assertEqual(client.base_url, "https://manager.example.test:8443")
+            self.assertIsNone(client._service_discovery)
+            mock_create.assert_not_called()
+        finally:
+            client.close()
+
+    @patch(
+        "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
+    )
+    def test_unavailable_discovery_implementation_fails_fast(self, mock_create):
+        mock_create.return_value = None
+        with self.assertRaisesRegex(ValueError, "failed to create service discovery"):
+            KvCacheManagerClient("custom://manager-service")
+
+    @patch(
+        "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
+    )
+    def test_empty_discovery_result_fails_fast_and_closes(self, mock_create):
+        discovery = MagicMock()
+        discovery.get_one_endpoint.return_value = None
+        mock_create.return_value = discovery
+
+        with self.assertRaisesRegex(RuntimeError, "returned no manager endpoints"):
+            KvCacheManagerClient("custom://manager-service")
+
+        discovery.close.assert_called_once_with()
+
+    @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
+    def test_leader_discovery_uses_fresh_service_endpoint(self, mock_post):
+        mock_post.return_value = _make_mock_response(
+            _cluster_info_response("10.0.0.99", 9090)
+        )
+        client = KvCacheManagerClient(
+            "static://10.0.0.1:8080,10.0.0.2:8080",
+            auto_discover_leader=True,
+            discovery_refresh_interval_seconds=60,
+        )
+        try:
+            self.assertEqual(client.base_url, "http://10.0.0.99:9090")
+            self.assertEqual(
+                mock_post.call_args[0][0],
+                "http://10.0.0.2:8080/api/getClusterInfo",
+            )
+
+            mock_post.reset_mock()
+            mock_post.return_value = _make_mock_response(
+                _cluster_info_response("10.0.0.50", 7070)
+            )
+            self.assertTrue(client._discover_leader())
+            self.assertEqual(
+                mock_post.call_args[0][0],
+                "http://10.0.0.1:8080/api/getClusterInfo",
+            )
+            self.assertEqual(client.base_url, "http://10.0.0.50:7070")
+        finally:
+            client.close()
+
+    @patch(
+        "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
+    )
+    def test_close_releases_service_discovery(self, mock_create):
+        discovery = MagicMock()
+        discovery.get_one_endpoint.return_value = ServiceEndpoint(
+            ip="10.0.0.1",
+            port=8080,
+            host="10.0.0.1:8080",
+        )
+        discovery.get_type.return_value = "Test"
+        mock_create.return_value = discovery
+
+        client = KvCacheManagerClient("custom://manager-service")
+        client.close()
+        client.close()
+
+        discovery.close.assert_called_once_with()
 
 
 class TestLeaderDiscoveryInit(unittest.TestCase):

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -173,6 +173,27 @@ class TestRequestTimeout(unittest.TestCase):
                         request_timeout_seconds=timeout,
                     )
 
+    def test_connector_config_forwards_request_timeout(self):
+        client = KvCacheManagerClient.from_connector_config({
+            "manager_uri": "http://10.0.0.1:8080",
+            "instance_id": "connector-instance",
+            "request_timeout_seconds": 3.5,
+        })
+        try:
+            self.assertEqual(client._instance_id, "connector-instance")
+            self.assertEqual(client._request_timeout_seconds, 3.5)
+        finally:
+            client.close()
+
+    def test_connector_config_uses_request_timeout_default(self):
+        client = KvCacheManagerClient.from_connector_config({
+            "manager_uri": "http://10.0.0.1:8080",
+        })
+        try:
+            self.assertEqual(client._request_timeout_seconds, 1.0)
+        finally:
+            client.close()
+
     def test_api_request_uses_configured_timeout(self):
         client = KvCacheManagerClient(
             "http://10.0.0.1:8080",

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -132,7 +132,7 @@ class TestServiceDiscoveryInit(unittest.TestCase):
             mock_post.return_value = _make_mock_response(
                 _cluster_info_response("10.0.0.50", 7070)
             )
-            self.assertTrue(client._discover_leader())
+            self.assertTrue(client._refresh_manager_route())
             self.assertEqual(
                 mock_post.call_args[0][0],
                 "http://10.0.0.1:8080/api/getClusterInfo",
@@ -353,7 +353,7 @@ class TestDiscoveryAlwaysUsesSeedUrl(unittest.TestCase):
         mock_post.side_effect = capture_url
 
         try:
-            result = client._discover_leader()
+            result = client._refresh_manager_route()
             self.assertTrue(result)
             self.assertEqual(client.base_url, "http://10.0.0.50:7070")
             # Only the seed discovery_url should have been called
@@ -453,9 +453,31 @@ class TestServerNotLeaderRetry(unittest.TestCase):
         finally:
             client.close()
 
+    @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
+    def test_not_leader_does_not_rotate_service_endpoint_when_disabled(
+        self,
+        mock_discovery_post,
+    ):
+        client = KvCacheManagerClient(
+            "static://10.0.0.1:8080,10.0.0.2:8080",
+            auto_discover_leader=False,
+            min_discover_interval_seconds=0,
+        )
+        client.session.post = MagicMock(
+            return_value=_make_mock_response(_not_leader_response())
+        )
+
+        try:
+            with self.assertRaises(AssertionError):
+                client.register_instance({"trace_id": "test"})
+            self.assertEqual(client.base_url, "http://10.0.0.1:8080")
+            mock_discovery_post.assert_not_called()
+        finally:
+            client.close()
+
 
 class TestConnectionErrorHandling(unittest.TestCase):
-    """Tests for ConnectionError handling and background refresh wakeup."""
+    """Tests for transport error handling and route refresh wakeup."""
 
     @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
     def test_connection_error_wakes_background_refresh(self, mock_discovery_post):
@@ -503,6 +525,41 @@ class TestConnectionErrorHandling(unittest.TestCase):
         finally:
             client.close()
 
+    @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
+    def test_transport_error_refreshes_service_endpoint_without_leader_discovery(
+        self,
+        mock_discovery_post,
+    ):
+        for error in (
+            requests.ConnectionError("Connection refused"),
+            requests.Timeout("Request timed out"),
+        ):
+            with self.subTest(error=type(error).__name__):
+                client = KvCacheManagerClient(
+                    "static://10.0.0.1:8080,10.0.0.2:8080",
+                    auto_discover_leader=False,
+                    min_discover_interval_seconds=0,
+                )
+                discovery = client._service_discovery
+                discovery.refresh = MagicMock(wraps=discovery.refresh)
+                client.session.post = MagicMock(side_effect=error)
+                try:
+                    with self.assertRaises(type(error)):
+                        client.register_instance({"trace_id": "test"})
+
+                    deadline = time.time() + 1
+                    while (
+                        client.base_url != "http://10.0.0.2:8080"
+                        and time.time() < deadline
+                    ):
+                        time.sleep(0.01)
+
+                    self.assertEqual(client.base_url, "http://10.0.0.2:8080")
+                    discovery.refresh.assert_called_once_with()
+                    mock_discovery_post.assert_not_called()
+                finally:
+                    client.close()
+
 
 class TestBackgroundRefresh(unittest.TestCase):
     """Tests for background leader refresh thread."""
@@ -528,7 +585,7 @@ class TestBackgroundRefresh(unittest.TestCase):
                 _cluster_info_response("10.0.0.2", 9090)
             )
             # Reset last discover time so min interval doesn't block
-            client._last_discover_time = 0
+            client._last_route_refresh_time = 0
 
             # Trigger urgent wakeup
             client._refresh_event.set()
@@ -596,11 +653,11 @@ class TestCloseLifecycle(unittest.TestCase):
 
 
 class TestThreadSafety(unittest.TestCase):
-    """Tests for thread-safe leader discovery dedup."""
+    """Tests for thread-safe Manager route refresh dedup."""
 
     @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
     def test_concurrent_discover_dedup(self, mock_post):
-        """Multiple threads calling _discover_leader should dedup via lock."""
+        """Concurrent Manager route refresh calls should dedup via lock."""
         actual_discover_count = [0]
         original_post = mock_post
 
@@ -622,13 +679,13 @@ class TestThreadSafety(unittest.TestCase):
             actual_discover_count[0] = 0
             client.base_url = "http://10.0.0.1:8080"  # reset to trigger discovery
 
-            # Launch many threads that all call _discover_leader
+            # Launch many threads that all refresh the Manager route.
             threads = []
             results = []
             lock = threading.Lock()
 
             def do_discover():
-                result = client._discover_leader()
+                result = client._refresh_manager_route()
                 with lock:
                     results.append(result)
 
@@ -644,7 +701,7 @@ class TestThreadSafety(unittest.TestCase):
             # All should have succeeded
             self.assertTrue(all(results))
             # But the actual HTTP call should only have happened once (or very few times)
-            # due to the snapshot-check dedup in _discover_leader
+            # due to the snapshot-check dedup in _refresh_manager_route
             self.assertLessEqual(actual_discover_count[0], 2)
         finally:
             client.close()

--- a/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
+++ b/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
@@ -160,6 +160,20 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         self.assertEqual(discovery.custom_port, 12348)
         discovery.close()
 
+    def test_spectrum_body_is_forwarded_to_implementation(self):
+        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
+            discovery = create_service_discovery(
+                "spectrum://virtual-service:opaque-suffix?cache_time=10"
+            )
+
+        self.assertIsNotNone(discovery)
+        self.assertEqual(
+            discovery.virtual_service_id,
+            "virtual-service:opaque-suffix",
+        )
+        self.assertEqual(discovery.custom_port, 0)
+        discovery.close()
+
     def test_spectrum_url_uses_default_port_override(self):
         with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
             discovery = create_service_discovery(

--- a/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
+++ b/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
@@ -1,17 +1,55 @@
 # -*- coding: utf-8 -*-
 """Unit tests for service_discovery_factory.create_service_discovery."""
 
+import sys
 import unittest
+from types import ModuleType
 try:
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 except ImportError:
-    from mock import MagicMock, patch
+    from mock import patch
 
 from kv_cache_manager.py_connector.common.service_discovery_factory import (
     _parse_url,
     _get_int_param,
     create_service_discovery,
 )
+
+
+_SPECTRUM_MODULE = (
+    "stub_source.kv_cache_manager.py_connector.common.spectrum_service_discovery"
+)
+
+
+class _FakeSpectrumServiceDiscovery:
+    """Factory test double that does not depend on an internal implementation."""
+
+    def __init__(
+        self,
+        virtual_service_id,
+        *,
+        cache_ttl=30,
+        refresh_timeout=5,
+        retry_count=0,
+        custom_port=0,
+    ):
+        self.virtual_service_id = virtual_service_id
+        self.cache_ttl = cache_ttl
+        self.refresh_timeout = refresh_timeout
+        self.retry_count = retry_count
+        self.custom_port = custom_port
+
+    def get_type(self):
+        return "Spectrum"
+
+    def close(self):
+        return None
+
+
+def _fake_spectrum_module():
+    module = ModuleType(_SPECTRUM_MODULE)
+    module.SpectrumServiceDiscovery = _FakeSpectrumServiceDiscovery
+    return module
 
 
 class TestParseUrl(unittest.TestCase):
@@ -94,106 +132,42 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         # port 非数字
         self.assertIsNone(create_service_discovery("static://10.0.0.1:abc"))
 
-    @patch(
-        'kv_cache_manager.py_connector.common.spectrum_service_discovery.requests.Session'
-    )
-    def test_spectrum_url_creates_real_instance(self, mock_session_class):
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
+    def test_spectrum_url_passes_config_to_discovery(self):
+        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
+            discovery = create_service_discovery(
+                "spectrum://v-ad2d143d?cache_time=10&retry_time=2&timeout=3000"
+            )
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            'virtual_service_id': 'v-ad2d143d',
-            'instances': [
-                {'ip': '172.1.2.10', 'port': 8080},
-            ],
-        }
-        mock_session.get.return_value = mock_resp
-
-        discovery = create_service_discovery(
-            "spectrum://v-ad2d143d?cache_time=10&retry_time=2&timeout=3000"
-        )
         self.assertIsNotNone(discovery)
         self.assertEqual(discovery.get_type(), 'Spectrum')
-        # URL 中带的运行时配置应当被注入
+        self.assertEqual(discovery.virtual_service_id, 'v-ad2d143d')
         self.assertEqual(discovery.cache_ttl, 10)
         self.assertEqual(discovery.retry_count, 2)
         self.assertEqual(discovery.refresh_timeout, 3)  # 3000 ms → 3 s
-
-        endpoints = discovery.get_all_endpoints()
-        self.assertEqual(len(endpoints), 1)
-        self.assertEqual(endpoints[0].host, '172.1.2.10:8080')
         discovery.close()
 
     def test_spectrum_empty_vsid_returns_none(self):
         # body 为空时 _parse_url 即拒绝
         self.assertIsNone(create_service_discovery("spectrum://"))
 
-    @patch(
-        'kv_cache_manager.py_connector.common.spectrum_service_discovery.requests.Session'
-    )
-    def test_spectrum_url_with_custom_port_overrides_json(self, mock_session_class):
-        """URL 带 port 时所有 endpoint 端口被覆盖。"""
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
+    def test_spectrum_url_passes_custom_port(self):
+        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
+            discovery = create_service_discovery(
+                "spectrum://v-port?cache_time=10&retry_time=2&timeout=3000&port=12348"
+            )
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            'virtual_service_id': 'v-port',
-            'instances': [
-                {'ip': '10.0.0.1', 'port': 8080},
-                {'ip': '10.0.0.2', 'port': 8081},
-            ],
-        }
-        mock_session.get.return_value = mock_resp
-
-        discovery = create_service_discovery(
-            "spectrum://v-port?cache_time=10&retry_time=2&timeout=3000&port=12348"
-        )
         self.assertIsNotNone(discovery)
         self.assertEqual(discovery.custom_port, 12348)
-
-        endpoints = discovery.get_all_endpoints()
-        self.assertEqual(len(endpoints), 2)
-        self.assertEqual(endpoints[0].port, 12348)
-        self.assertEqual(endpoints[0].host, '10.0.0.1:12348')
-        self.assertEqual(endpoints[1].port, 12348)
-        self.assertEqual(endpoints[1].host, '10.0.0.2:12348')
         discovery.close()
 
-    @patch(
-        'kv_cache_manager.py_connector.common.spectrum_service_discovery.requests.Session'
-    )
-    def test_spectrum_url_without_port_uses_json(self, mock_session_class):
-        """URL 不带 port 时使用 JSON 中端口（向后兼容）。"""
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
+    def test_spectrum_url_uses_default_port_override(self):
+        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
+            discovery = create_service_discovery(
+                "spectrum://v-no-port?cache_time=10&retry_time=2&timeout=3000"
+            )
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            'virtual_service_id': 'v-no-port',
-            'instances': [
-                {'ip': '10.0.0.1', 'port': 8080},
-                {'ip': '10.0.0.2', 'port': 9090},
-            ],
-        }
-        mock_session.get.return_value = mock_resp
-
-        discovery = create_service_discovery(
-            "spectrum://v-no-port?cache_time=10&retry_time=2&timeout=3000"
-        )
         self.assertIsNotNone(discovery)
         self.assertEqual(discovery.custom_port, 0)
-
-        endpoints = discovery.get_all_endpoints()
-        self.assertEqual(len(endpoints), 2)
-        self.assertEqual(endpoints[0].port, 8080)
-        self.assertEqual(endpoints[0].host, '10.0.0.1:8080')
-        self.assertEqual(endpoints[1].port, 9090)
-        self.assertEqual(endpoints[1].host, '10.0.0.2:9090')
         discovery.close()
 
 

--- a/kv_cache_manager/py_connector/trtllm/connector.py
+++ b/kv_cache_manager/py_connector/trtllm/connector.py
@@ -52,15 +52,7 @@ def init_kvcm_config():
 
 def init_kvcm_meta_client(llm_args: TorchLlmArgs):
     kvcm_config = init_kvcm_config()
-    manager_client = KvCacheManagerClient(
-        kvcm_config["manager_uri"],
-        instance_id=kvcm_config.get("instance_id", ""),
-        auto_discover_leader=kvcm_config.get("auto_discover_leader", False),
-        leader_retry_count=kvcm_config.get("leader_retry_count", 1),
-        leader_retry_base_interval_seconds=kvcm_config.get("leader_retry_base_interval_seconds", 0.005),
-        discovery_refresh_interval_seconds=kvcm_config.get("discovery_refresh_interval_seconds", 30),
-        min_discover_interval_seconds=kvcm_config.get("min_discover_interval_seconds", 1),
-    )
+    manager_client = KvCacheManagerClient.from_connector_config(kvcm_config)
     logger.info("kvcm manager_client initialized")
     return kvcm_config, manager_client
 

--- a/kv_cache_manager/py_connector/vllm/config.py
+++ b/kv_cache_manager/py_connector/vllm/config.py
@@ -33,5 +33,6 @@ class TairKvCacheConnectorExtraConfig:
         self.leader_retry_base_interval_seconds: float = extra_config.get("leader_retry_base_interval_seconds", 0.005)
         self.discovery_refresh_interval_seconds: int = extra_config.get("discovery_refresh_interval_seconds", 30)
         self.min_discover_interval_seconds: int = extra_config.get("min_discover_interval_seconds", 1)
+        self.request_timeout_seconds: float = extra_config.get("request_timeout_seconds", 1.0)
 
         self.log_level: str = extra_config.get("log_level", "")

--- a/kv_cache_manager/py_connector/vllm/v1_connector.py
+++ b/kv_cache_manager/py_connector/vllm/v1_connector.py
@@ -166,7 +166,7 @@ class TairKvCacheConnector(KVConnectorBase_V1):
         logger.info(deployment)
 
         self._manager_client = KvCacheManagerClient.from_connector_config(
-            connector_extra_config
+            vars(self._extra_config)
         )
         self._manager_block_size = manager_block_size
 

--- a/kv_cache_manager/py_connector/vllm/v1_connector.py
+++ b/kv_cache_manager/py_connector/vllm/v1_connector.py
@@ -126,7 +126,8 @@ class TairKvCacheConnector(KVConnectorBase_V1):
 
         logger.warning("KVCM vllm connector version: %s (commit: %s, build: %s)", FULL_VERSION, GIT_COMMIT, BUILD_TIME)
 
-        self._extra_config = TairKvCacheConnectorExtraConfig(vllm_config.kv_transfer_config.kv_connector_extra_config)
+        connector_extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
+        self._extra_config = TairKvCacheConnectorExtraConfig(connector_extra_config)
 
         # Apply log level with priority: env var > startup param > default
         configure_log_level(self._extra_config.log_level)
@@ -164,14 +165,8 @@ class TairKvCacheConnector(KVConnectorBase_V1):
         }
         logger.info(deployment)
 
-        self._manager_client = KvCacheManagerClient(
-            self._extra_config.manager_uri,
-            instance_id=self._extra_config.instance_id,
-            auto_discover_leader=self._extra_config.auto_discover_leader,
-            leader_retry_count=self._extra_config.leader_retry_count,
-            leader_retry_base_interval_seconds=self._extra_config.leader_retry_base_interval_seconds,
-            discovery_refresh_interval_seconds=self._extra_config.discovery_refresh_interval_seconds,
-            min_discover_interval_seconds=self._extra_config.min_discover_interval_seconds,
+        self._manager_client = KvCacheManagerClient.from_connector_config(
+            connector_extra_config
         )
         self._manager_block_size = manager_block_size
 


### PR DESCRIPTION
## Summary

- add service discovery URL parsing and static endpoint discovery for the Python manager client
- make regular Manager API requests use configurable `request_timeout_seconds` with a new 1-second default
- keep leader discovery on its dedicated 5-second timeout
- refresh discovered manager routes after transport failures without retrying the failed write
- construct the vLLM Manager client from its parsed typed connector config
- document the public service discovery framework and module relationship

## Validation

- `python3 -m unittest kv_cache_manager.py_connector.test.test_manager_client kv_cache_manager.py_connector.test.test_service_discovery_factory`
- `python3 -m py_compile kv_cache_manager/py_connector/common/manager_client.py kv_cache_manager/py_connector/vllm/config.py kv_cache_manager/py_connector/vllm/v1_connector.py kv_cache_manager/py_connector/test/test_manager_client.py`
- `bazelisk build --config=client //kv_cache_manager/py_connector/common:common`