### PR TITLE
[metrics] fix prefix_match_len metric counting all returned entries as hits

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -430,7 +430,17 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
                                    query_keys,
                                    cache_locations);
     query_scope = ChronoScopeGuard{};
-    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, prefix_match_len, cache_locations.size());
+    // prefix_match_len: count actual hits (non-empty id), not total returned entries.
+    // BatchGet/ReverseRollSW pad misses with empty CacheLocation objects.
+    {
+        size_t match_len = 0;
+        for (const auto &loc : cache_locations) {
+            if (loc && !loc->id().empty()) {
+                ++match_len;
+            }
+        }
+        KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, prefix_match_len, match_len);
+    }
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, CacheLocationViewVecWrapper, "get cache location failed");
     // accumulate hit/query block counters for hit-rate monitoring (only on success)
     if (service_metrics_collector) {
@@ -526,7 +536,20 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
     ec = meta_searcher->BatchGetBestLocationByBackend(
         request_context, query_keys, locations_per_key, policy.get(), backend_selectors);
     query_scope = ChronoScopeGuard{};
-    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, prefix_match_len, locations_per_key.size());
+    // prefix_match_len: count keys with at least one hit (non-empty id).
+    // Miss keys have empty CacheLocation objects with no id.
+    {
+        size_t match_len = 0;
+        for (const auto &key_locs : locations_per_key) {
+            for (const auto &loc : key_locs) {
+                if (loc && !loc->id().empty()) {
+                    ++match_len;
+                    break;
+                }
+            }
+        }
+        KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, prefix_match_len, match_len);
+    }
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, BatchLocationsView, "batch get multi locations failed");
 
     auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);


### PR DESCRIPTION
## Summary

fix `prefix_match_len` metric to count actual cache hits instead of total returned entries, which became incorrect after multi-spec support was added.

## Motivation

after multi-spec support (`FillEmptyLocationSpecs`), miss entries are padded with empty `CacheLocation` objects (id is empty). the old `prefix_match_len` calculation used `cache_locations.size()` / `locations_per_key.size()`, which counts both hits and misses. this made the metric always equal to request length for `BatchGet` / `ReverseRollSW` queries, breaking cache hit rate observability.

the `hit_count` logic in the same functions already correctly distinguished hits from misses, but `prefix_match_len` did not follow the same pattern.

## Details

this is an internal metrics fix — no API changes, no user-facing behavior changes. monitoring dashboards consuming `prefix_match_len` will now report accurate hit counts:

- **`GetCacheLocation`** (BatchGet / PrefixMatch / ReverseRollSW): counts `CacheLocation` entries with non-empty `id`
- **`GetCacheLocationsByBackend`**: counts keys that have at least one location with non-empty `id`

the fix reuses the same hit-detection logic (`loc && !loc->id().empty()`) already used by `hit_count` calculation.

## Changes

| file | change |
|------|--------|
| `kv_cache_manager/manager/cache_manager.cc` | replace `cache_locations.size()` and `locations_per_key.size()` with actual hit count loops in both `GetCacheLocation` and `GetCacheLocationsByBackend` |

## Known Limitations / Risks

- the `SelectAndMergeForMatch` (PrefixMatch path) also returns empty `CacheLocation` for misses, but the `FillEmptyLocationSpecs` call is skipped for PrefixMatch (`query_type != QT_PREFIX_MATCH` guard at line 1977). so PrefixMatch `prefix_match_len` was already correct before this fix; the fix makes all query types consistently accurate.
- no risk of regression: the fix only changes what number is reported to metrics, not any control flow or data path.

## Testing

- `bazelisk test //kv_cache_manager/...` — 98/98 passed, 1 skipped (GPU-only)
- affected test suites: `CacheManagerTest`, `CacheManagerMetricsRecorderTest`, `MetricsCollectorTest` — all pass