### PR TITLE
[py_connector/manager] support hybrid attention models (mamba/gdn/linear) with stride-aware kv cache transfer

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -633,11 +633,6 @@ CacheManager::StartWriteCache(RequestContext *request_context,
     SPAN_TRACER(request_context);
     const std::string &trace_id = request_context->trace_id();
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
-    if (!location_spec_group_names.empty()) {
-        auto check_ec =
-            CheckLocationSpecGroupNames(request_context, instance_id, keys.size(), location_spec_group_names);
-        RETURN_IF_EC_NOT_OK_WITH_TYPE(check_ec, StartWriteCacheInfo);
-    }
     auto [ec, meta_searcher] = CheckInputAndGetMetaSearcher(request_context, instance_id, keys, tokens);
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, StartWriteCacheInfo, "start write cache failed");
     CacheLocationVector new_locations;
@@ -677,6 +672,17 @@ CacheManager::StartWriteCache(RequestContext *request_context,
     }
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ManagerFilterWriteCache);
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, filter_ec, StartWriteCacheInfo, "filter write cache failed");
+
+    // Validate location_spec_group_names size matches query_keys size (not keys size).
+    // This must happen AFTER key generation because:
+    // - If keys is empty, query_keys is generated from token_ids via GenKeyVector
+    // - location_spec_group_names.size() must match the ACTUAL number of keys used (query_keys.size())
+    // - Validating against keys.size() would fail when keys is empty (normal token_ids mode)
+    if (!location_spec_group_names.empty()) {
+        auto check_ec =
+            CheckLocationSpecGroupNames(request_context, instance_id, query_keys.size(), location_spec_group_names);
+        RETURN_IF_EC_NOT_OK_WITH_TYPE(check_ec, StartWriteCacheInfo);
+    }
 
     std::vector<std::string> location_ids;
     std::string write_session_id = StringUtil::GenerateRandomString(32);

--- a/kv_cache_manager/py_connector/common/types.py
+++ b/kv_cache_manager/py_connector/common/types.py
@@ -1,8 +1,23 @@
 from enum import Enum
-from typing import Tuple, Dict, Optional, Any
+from typing import Tuple, Dict, Optional, Any, List
 
 import attrs
 import torch
+
+
+@attrs.define(frozen=True)
+class HybridCacheInfo:
+    """Info for non-attention (mamba/gdn/linear) layers in a hybrid model."""
+    layer_names: List[str]
+    # (num_hybrid_layers, ) int64 tensor of base ptrs on CPU (for offset computation)
+    ptr_tensor_cpu: torch.Tensor
+    # List of raw byte-view tensors on GPU: each is (num_blocks, page_size_bytes) uint8
+    # These are views into the hybrid state tensors' untyped_storage
+    block_view_tensors: List[torch.Tensor]
+    # byte size per block per layer (all hybrid layers share the same page_size_bytes)
+    page_size_bytes: int
+    # number of hybrid layers
+    layer_num: int
 
 
 @attrs.define(frozen=True)
@@ -20,3 +35,9 @@ class KVCacheInfo:
     per_token_per_layer_dim_size: int
     device: torch.device
     dtype: torch.dtype
+    # Hybrid (mamba/gdn/linear) layer info, None for pure attention models
+    hybrid_info: Optional[HybridCacheInfo] = None
+    # Stride parameters for strided memory layout (0 = contiguous/flat indexing)
+    kv_stride: int = 0  # stride between K and V (for V pointers)
+    block_stride: int = 0  # stride between blocks
+    local_block_size: int = 0  # actual block size in tensor (0 = use manager block size)

--- a/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
@@ -42,8 +42,15 @@ def kv_cache_batch_gather_kernel(
         NUM_KVCACHE_PTRS: tl.constexpr,  # num_layers * kv_count
         BLOCK_SIZE: tl.constexpr,  # 隐藏维度分块大小
         DTYPE: tl.constexpr = tl.float16,
+        kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
+        block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
+        local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
 ):
     NUM_DIMS_PER_BLOCK = NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
+    
+    # Determine if using strided layout
+    USE_STRIDED: tl.constexpr = (block_stride != 0)
+    EFFECTIVE_LOCAL_BLOCK_SIZE: tl.constexpr = local_block_size if local_block_size > 0 else NUM_TOKENS_PER_BLOCK
 
     pid = tl.program_id(0)
     grid_size = tl.num_programs(0)  # 实际grid大小 (如3)
@@ -65,6 +72,9 @@ def kv_cache_batch_gather_kernel(
         for ptr_idx in tl.range(NUM_KVCACHE_PTRS):
             # 3.1 加载当前层的KV缓存基地址
             kvcache_ptr = tl.load(kv_cache_ptrs_ptr + ptr_idx).to(tl.pointer_type(DTYPE))
+            
+            # Determine if this is a V pointer (odd index)
+            is_v_ptr = ptr_idx % 2
 
             # 3.2 计算当前层在dst中的基础偏移
             layer_offset = block_offset + ptr_idx * NUM_DIMS_PER_BLOCK
@@ -90,7 +100,17 @@ def kv_cache_batch_gather_kernel(
 
                 # 从HBM的KV缓存加载数据
                 # 计算源指针: [BLOCK_SIZE]
-                src_ptrs = kvcache_ptr + global_token_idx * NUM_DIMS_PER_TOKEN + dim_idx_in_token
+                if USE_STRIDED:
+                    # Strided layout: convert flat token index to strided offset
+                    kv_block_idx = global_token_idx // EFFECTIVE_LOCAL_BLOCK_SIZE
+                    token_in_kv_block = global_token_idx % EFFECTIVE_LOCAL_BLOCK_SIZE
+                    strided_offset = kv_block_idx * block_stride + token_in_kv_block * NUM_DIMS_PER_TOKEN
+                    # Add kv_stride for V pointers
+                    strided_offset = strided_offset + is_v_ptr * kv_stride
+                    src_ptrs = kvcache_ptr + strided_offset + dim_idx_in_token
+                else:
+                    # Contiguous layout: flat indexing
+                    src_ptrs = kvcache_ptr + global_token_idx * NUM_DIMS_PER_TOKEN + dim_idx_in_token
                 load_mask = mask & token_gather_mask
                 data = tl.load(src_ptrs, mask=load_mask, other=0.0)
                 # 大块连续写入 host memory (PCIe优化)
@@ -107,7 +127,10 @@ def batch_gather_kv_caches(
         dst_block_indices: List[int],  # List of dst block indices
         num_tokens_per_block: int,
         dim_size_per_token_per_layer: int,
-        sm_count: int = 3
+        sm_count: int = 3,
+        kv_stride: int = 0,  # stride between K and V (for V pointers)
+        block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
+        local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
 ):
     # 配置参数
     total_blocks = len(dst_block_indices)
@@ -132,6 +155,9 @@ def batch_gather_kv_caches(
         BLOCK_SIZE=2048,
         DTYPE=pytorch_dtype_to_triton_dtype(dst_tensor.dtype),
         num_warps=32,
+        kv_stride=kv_stride,
+        block_stride=block_stride,
+        local_block_size=local_block_size if local_block_size > 0 else num_tokens_per_block,
     )
     # TODO autotune num_warps and BLOCK_SIZE
 
@@ -148,8 +174,15 @@ def kv_cache_batch_scatter_kernel(
         NUM_KVCACHE_PTRS: tl.constexpr,  # num_layers * kv_count
         BLOCK_SIZE: tl.constexpr,  # 隐藏维度分块大小
         DTYPE: tl.constexpr = tl.float16,
+        kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
+        block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
+        local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
 ):
     NUM_DIMS_PER_BLOCK = NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
+    
+    # Determine if using strided layout
+    USE_STRIDED: tl.constexpr = (block_stride != 0)
+    EFFECTIVE_LOCAL_BLOCK_SIZE: tl.constexpr = local_block_size if local_block_size > 0 else NUM_TOKENS_PER_BLOCK
 
     pid = tl.program_id(0)
     grid_size = tl.num_programs(0)  # 实际grid大小 (如3)
@@ -171,6 +204,9 @@ def kv_cache_batch_scatter_kernel(
         for ptr_idx in range(NUM_KVCACHE_PTRS):
             # 3.1 加载当前层的KV缓存基地址
             kvcache_ptr = tl.load(kv_cache_ptrs_ptr + ptr_idx).to(tl.pointer_type(DTYPE))
+            
+            # Determine if this is a V pointer (odd index)
+            is_v_ptr = ptr_idx % 2
 
             # 3.2 计算当前层在src中的基础偏移
             layer_offset = block_offset + ptr_idx * NUM_DIMS_PER_BLOCK
@@ -201,7 +237,17 @@ def kv_cache_batch_scatter_kernel(
 
                 # 向HBM的KV缓存写入数据
                 # 计算目的指针: [BLOCK_SIZE]
-                dst_ptrs = kvcache_ptr + global_token_idx * NUM_DIMS_PER_TOKEN + dim_idx_in_token
+                if USE_STRIDED:
+                    # Strided layout: convert flat token index to strided offset
+                    kv_block_idx = global_token_idx // EFFECTIVE_LOCAL_BLOCK_SIZE
+                    token_in_kv_block = global_token_idx % EFFECTIVE_LOCAL_BLOCK_SIZE
+                    strided_offset = kv_block_idx * block_stride + token_in_kv_block * NUM_DIMS_PER_TOKEN
+                    # Add kv_stride for V pointers
+                    strided_offset = strided_offset + is_v_ptr * kv_stride
+                    dst_ptrs = kvcache_ptr + strided_offset + dim_idx_in_token
+                else:
+                    # Contiguous layout: flat indexing
+                    dst_ptrs = kvcache_ptr + global_token_idx * NUM_DIMS_PER_TOKEN + dim_idx_in_token
                 tl.store(dst_ptrs, data, mask=load_mask)
 
 
@@ -214,7 +260,10 @@ def batch_scatter_kv_caches(
         src_block_indices: List[int],  # List of src block indices
         num_tokens_per_block: int,
         dim_size_per_token_per_layer: int,
-        sm_count: int = 3
+        sm_count: int = 3,
+        kv_stride: int = 0,  # stride between K and V (for V pointers)
+        block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
+        local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
 ):
     # 配置参数
     total_blocks = len(src_block_indices)
@@ -245,4 +294,7 @@ def batch_scatter_kv_caches(
         BLOCK_SIZE=2048,
         DTYPE=pytorch_dtype_to_triton_dtype(src_tensor.dtype),
         num_warps=32,
+        kv_stride=kv_stride,
+        block_stride=block_stride,
+        local_block_size=local_block_size if local_block_size > 0 else num_tokens_per_block,
     )

--- a/kv_cache_manager/py_connector/kernel/gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/gather_scatter_helper.py
@@ -17,6 +17,9 @@ def kv_cache_scatter_kernel(
         hidden_size,  # hidden dimension size
         total_token_in_kvcache,  # sequence length in KV cache
         num_layers,  # number of layers
+        kv_stride,  # stride between K and V sections (in elements)
+        block_stride,  # stride between blocks (in elements)
+        local_block_size,  # tokens per block
         BLOCK_SIZE: tl.constexpr,
 ):
     # Get the current program's layer index and token position
@@ -41,9 +44,14 @@ def kv_cache_scatter_kernel(
     source_offset_k = (layer_idx * num_tokens_in_block * 2 + 0 * num_tokens_in_block + token_pos) * hidden_size
     source_offset_v = (1 * num_tokens_in_block + layer_idx * num_tokens_in_block * 2 + token_pos) * hidden_size
 
-    # Calculate target offsets (for both K and V)
-    target_offset_k = (0 * total_token_in_kvcache + token_idx) * hidden_size
-    target_offset_v = (1 * total_token_in_kvcache + token_idx) * hidden_size
+    # Calculate target offsets using stride-based addressing
+    # For contiguous layout: kv_stride = total_tokens * hidden_size, block_stride = block_size * hidden_size
+    # For strided layout: kv_stride and block_stride from tensor strides
+    block_idx = token_idx // local_block_size
+    token_in_block = token_idx % local_block_size
+    target_offset_k = block_idx * block_stride + token_in_block * hidden_size
+    target_offset_v = kv_stride + block_idx * block_stride + token_in_block * hidden_size
+    
     # Copy data in blocks
     for i in range(0, hidden_size, BLOCK_SIZE):
         offset = i + tl.arange(0, BLOCK_SIZE)
@@ -68,6 +76,9 @@ def kv_cache_gather_kernel(
         hidden_size,  # hidden dimension size
         total_token_in_kvcache,  # sequence length in KV cache
         num_layers,  # number of layers
+        kv_stride,  # stride between K and V sections (in elements)
+        block_stride,  # stride between blocks (in elements)
+        local_block_size,  # tokens per block
         BLOCK_SIZE: tl.constexpr,
 ):
     # Get the current program's layer index and token position
@@ -92,9 +103,12 @@ def kv_cache_gather_kernel(
     dst_offset_k = (layer_idx * num_tokens_in_block * 2 + 0 * num_tokens_in_block + token_pos) * hidden_size
     dst_offset_v = (layer_idx * num_tokens_in_block * 2 + 1 * num_tokens_in_block + token_pos) * hidden_size
 
-    # Calculate kvcache offsets (for both K and V)
-    kvcache_offset_k = (0 * total_token_in_kvcache + token_idx) * hidden_size
-    kvcache_offset_v = (1 * total_token_in_kvcache + token_idx) * hidden_size
+    # Calculate kvcache offsets using stride-based addressing
+    block_idx = token_idx // local_block_size
+    token_in_block = token_idx % local_block_size
+    kvcache_offset_k = block_idx * block_stride + token_in_block * hidden_size
+    kvcache_offset_v = kv_stride + block_idx * block_stride + token_in_block * hidden_size
+    
     # Copy data in blocks
     for i in range(0, hidden_size, BLOCK_SIZE):
         offset = i + tl.arange(0, BLOCK_SIZE)

--- a/kv_cache_manager/py_connector/vllm/data_transfer.py
+++ b/kv_cache_manager/py_connector/vllm/data_transfer.py
@@ -157,6 +157,9 @@ class DataTransferManager:
                     copy_buffer_indices,
                     self._manager_block_size,
                     self._kvcache_info.per_token_per_layer_dim_size,
+                    kv_stride=self._kvcache_info.kv_stride,
+                    block_stride=self._kvcache_info.block_stride,
+                    local_block_size=self._kvcache_info.local_block_size,
                 )
 
                 copy_done_event = self._device_mod.Event()
@@ -171,26 +174,41 @@ class DataTransferManager:
         self._copy_buffer_allocator.free_buffer(copy_buffer_indices)
         multi_result.submit_result(task_idx, [transfer_result] * len(remote_uris))
 
-    def create_load_done_callback(self, req_id, tp_rank, epoch, local_block_ids):
-        """创建加载完成回调函数
+    def create_load_done_callback(self, req_id, tp_rank, epoch, local_block_ids,
+                                  attn_block_count=0, hybrid_block_count=0):
+        """Create load done callback.
 
         Args:
-            req_id: 请求ID
+            req_id: Request ID
             tp_rank: TP rank
-            epoch
-            local_block_ids: 本地块ID列表
-
-        Returns:
-            回调函数
+            epoch: Current epoch
+            local_block_ids: Local block ID list (length = attn_block_count)
+            attn_block_count: Number of attention blocks (for AND-merge with hybrid)
+            hybrid_block_count: Number of hybrid blocks (0 for pure attention)
         """
         def generate_message(task_results):
-            failed_block_idxs = []
-            idx = 0
+            # Flatten all task results into a single list
+            all_successes = []
             for task_result in task_results:
                 for block_result in task_result:
-                    if block_result != kvcm_py_client.ClientErrorCode.ER_OK:
-                        failed_block_idxs.append(local_block_ids[idx])
-                    idx += 1
+                    all_successes.append(block_result == kvcm_py_client.ClientErrorCode.ER_OK)
+
+            if hybrid_block_count > 0 and attn_block_count > 0:
+                # AND-merge: block i is fully loaded only if both attention and hybrid succeed
+                attn_successes = all_successes[:attn_block_count]
+                hybrid_successes = all_successes[attn_block_count:]
+                assert len(hybrid_successes) == attn_block_count, \
+                    f"hybrid_block_count ({len(hybrid_successes)}) != attn_block_count ({attn_block_count})"
+                merged_successes = [
+                    attn_successes[i] and hybrid_successes[i]
+                    for i in range(attn_block_count)
+                ]
+            else:
+                merged_successes = all_successes
+
+            failed_block_idxs = [
+                local_block_ids[i] for i, ok in enumerate(merged_successes) if not ok
+            ]
 
             msg = CoordinateMessage(
                 time.time(),
@@ -224,6 +242,9 @@ class DataTransferManager:
                 copy_buffer_indices,
                 self._manager_block_size,
                 self._kvcache_info.per_token_per_layer_dim_size,
+                kv_stride=self._kvcache_info.kv_stride,
+                block_stride=self._kvcache_info.block_stride,
+                local_block_size=self._kvcache_info.local_block_size,
             )
             copy_done_event = self._device_mod.Event()
             copy_done_event.record(self._save_stream)
@@ -257,29 +278,40 @@ class DataTransferManager:
         # TODO: submit uri when enable local alloc
         multi_result.submit_result(task_idx, [transfer_result[0]] * len(remote_uris))
 
-    def create_save_done_callback(self, req_id, tp_rank, write_session_id):
+    def create_save_done_callback(self, req_id, tp_rank, write_session_id,
+                                  attn_block_count=0, hybrid_block_count=0):
         """创建保存完成回调函数
         
         Args:
             req_id: 请求ID
             tp_rank: TP rank
             write_session_id: 写入会话ID
+            attn_block_count: attention层的block数量（用于AND-merge hybrid结果）
+            hybrid_block_count: hybrid层的block数量（0表示纯attention模型）
             
         Returns:
             回调函数
         """
         def generate_message(task_results):
-            is_successes = []
-            # TODO: report uri when enable local alloc
-            # remote_uris = []
+            # Flatten all task results into a single list
+            all_successes = []
             for task_result in task_results:
                 for block_result in task_result:
-                    if block_result != kvcm_py_client.ClientErrorCode.ER_OK:
-                        is_successes.append(False)
-                        # remote_uris.append(None)
-                    else:
-                        is_successes.append(True)
-                        # remote_uris.extend(future_result[1])
+                    all_successes.append(block_result == kvcm_py_client.ClientErrorCode.ER_OK)
+
+            if hybrid_block_count > 0 and attn_block_count > 0:
+                # AND-merge: attention[i] AND hybrid[i] → block i is fully saved
+                attn_successes = all_successes[:attn_block_count]
+                hybrid_successes = all_successes[attn_block_count:]
+                assert len(hybrid_successes) == attn_block_count, \
+                    f"hybrid_block_count ({len(hybrid_successes)}) != attn_block_count ({attn_block_count})"
+                is_successes = [
+                    attn_successes[i] and hybrid_successes[i]
+                    for i in range(attn_block_count)
+                ]
+            else:
+                # Pure attention (or pure hybrid) — no merge needed
+                is_successes = all_successes
 
             msg = CoordinateMessage(
                 time.time(),
@@ -290,3 +322,119 @@ class DataTransferManager:
             self._coordinator_client.send(CoordinateMsgSerializer.dumps(msg))
 
         return generate_message
+
+    # ==============================
+    # Hybrid (mamba/gdn/linear) layer transfer methods
+    # ==============================
+
+    def _get_hybrid_block_byte_size(self) -> int:
+        """Total bytes per block across all hybrid layers."""
+        info = self._kvcache_info.hybrid_info
+        return info.page_size_bytes * info.layer_num
+
+    def hybrid_load_task(self, multi_result: MultiResult, task_idx, remote_uris, block_indices):
+        """Load hybrid state for a batch of blocks (opaque byte-level memcpy).
+
+        Args:
+            multi_result: 多任务结果管理器
+            task_idx: 任务索引
+            remote_uris: 远程URI列表 (hybrid spec的URI)
+            block_indices: 每个block的local block id列表
+        """
+        info = self._kvcache_info.hybrid_info
+        per_block_bytes = self._get_hybrid_block_byte_size()
+        device = self._kvcache_info.device
+
+        # Allocate pinned CPU buffer for this batch (faster GPU↔CPU transfer)
+        cpu_buffer = torch.empty(len(remote_uris) * per_block_bytes, dtype=torch.uint8,
+                                 device="cpu", pin_memory=True)
+
+        buffers = []
+        for i in range(len(remote_uris)):
+            offset = i * per_block_bytes
+            buf = kvcm_py_client.BlockBuffer()
+            iov = kvcm_py_client.Iov()
+            iov.type = kvcm_py_client.MemoryType.CPU
+            iov.base = cpu_buffer.data_ptr() + offset
+            iov.size = per_block_bytes
+            iov.ignore = False
+            buf.iovs = [iov]
+            buffers.append(buf)
+
+        transfer_result = self._transfer_client.LoadKvCaches(remote_uris, buffers)
+
+        if transfer_result == kvcm_py_client.ClientErrorCode.ER_OK:
+            # Scatter from CPU buffer to GPU hybrid state (block-level memcpy via tensor indexing)
+            with self._device_mod.stream(self._load_stream):
+                gpu_buffer = cpu_buffer.to(device, non_blocking=True)
+                for i, block_idx in enumerate(block_indices):
+                    for layer_idx in range(info.layer_num):
+                        src_offset = (i * info.layer_num + layer_idx) * info.page_size_bytes
+                        src_slice = gpu_buffer[src_offset:src_offset + info.page_size_bytes]
+                        info.block_view_tensors[layer_idx][block_idx].copy_(src_slice)
+
+                copy_done_event = self._device_mod.Event()
+                copy_done_event.record(self._load_stream)
+            copy_done_event.synchronize()
+        else:
+            logger.warning("hybrid load task failed, remote_uris:%s, transfer_result:%s",
+                           remote_uris, transfer_result)
+
+        multi_result.submit_result(task_idx, [transfer_result] * len(remote_uris))
+
+    def hybrid_save_task(self, multi_result: MultiResult, task_idx, remote_uris, block_indices,
+                         kvcache_ready_event):
+        """Save hybrid state for a batch of blocks (opaque byte-level memcpy).
+
+        Args:
+            multi_result: 多任务结果管理器
+            task_idx: 任务索引
+            remote_uris: 远程URI列表 (hybrid spec的URI)
+            block_indices: 每个block的local block id列表
+            kvcache_ready_event: KV缓存就绪事件
+        """
+        info = self._kvcache_info.hybrid_info
+        per_block_bytes = self._get_hybrid_block_byte_size()
+        device = self._kvcache_info.device
+
+        # Gather from GPU hybrid state to GPU buffer (block-level memcpy via tensor indexing)
+        with self._device_mod.stream(self._save_stream):
+            kvcache_ready_event.wait()
+
+            gpu_buffer = torch.empty(len(block_indices) * per_block_bytes, dtype=torch.uint8, device=device)
+            for i, block_idx in enumerate(block_indices):
+                for layer_idx in range(info.layer_num):
+                    src_slice = info.block_view_tensors[layer_idx][block_idx]
+                    dst_offset = (i * info.layer_num + layer_idx) * info.page_size_bytes
+                    gpu_buffer[dst_offset:dst_offset + info.page_size_bytes].copy_(src_slice)
+
+            copy_done_event = self._device_mod.Event()
+            copy_done_event.record(self._save_stream)
+
+        copy_done_event.synchronize()
+
+        # Use pinned memory for efficient D2H transfer
+        cpu_buffer = torch.empty(len(block_indices) * per_block_bytes, dtype=torch.uint8,
+                                 device="cpu", pin_memory=True)
+        cpu_buffer.copy_(gpu_buffer, non_blocking=True)
+        self._device_mod.current_stream().synchronize()
+
+        buffers = []
+        for i in range(len(remote_uris)):
+            offset = i * per_block_bytes
+            buf = kvcm_py_client.BlockBuffer()
+            iov = kvcm_py_client.Iov()
+            iov.type = kvcm_py_client.MemoryType.CPU
+            iov.base = cpu_buffer.data_ptr() + offset
+            iov.size = per_block_bytes
+            iov.ignore = False
+            buf.iovs = [iov]
+            buffers.append(buf)
+
+        transfer_result = self._transfer_client.SaveKvCaches(remote_uris, buffers)
+
+        if transfer_result[0] != kvcm_py_client.ClientErrorCode.ER_OK:
+            logger.warning("hybrid save task failed, remote_uris:%s, transfer_result:%s",
+                           remote_uris, transfer_result)
+
+        multi_result.submit_result(task_idx, [transfer_result[0]] * len(remote_uris))

--- a/kv_cache_manager/py_connector/vllm/v1_connector.py
+++ b/kv_cache_manager/py_connector/vllm/v1_connector.py
@@ -20,15 +20,21 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 
 try:
     # vllm >= v0.11.1
     from vllm.utils.torch_utils import get_kv_cache_torch_dtype
     from vllm.utils.network_utils import get_ip
+    from vllm.v1.kv_cache_interface import MambaSpec, FullAttentionSpec
+    _HAS_MAMBA_SPEC = True
 except ImportError:
     # vllm <= v0.11.0
     from vllm.utils import get_kv_cache_torch_dtype, get_ip
+    _HAS_MAMBA_SPEC = False
+    MambaSpec = None
+    FullAttentionSpec = None
 
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
@@ -39,7 +45,7 @@ from kv_cache_manager.py_connector.common.tp_coordinator import CoordinateMsgSer
 from kv_cache_manager.py_connector.common.logger import logger, configure_log_level
 from kv_cache_manager.py_connector.common._version_info import FULL_VERSION, GIT_COMMIT, BUILD_TIME
 
-from kv_cache_manager.py_connector.common.types import KVCacheInfo
+from kv_cache_manager.py_connector.common.types import KVCacheInfo, HybridCacheInfo
 from kv_cache_manager.py_connector.kernel.gather_scatter_helper import CopyBufferAllocator
 from kv_cache_manager.py_connector.vllm.metadata import SaveRequest, LoadRequest, FinishRequest, ReqStateToWorker, \
     TairKvCacheConnectorMetadata
@@ -105,10 +111,70 @@ class TransferTaskArgs:
     remote_uris: List[str] = field(default_factory=list)
 
 
-class TairKvCacheConnector(KVConnectorBase_V1):
+class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Called when a request has finished all kv cache groups.
+
+        For hybrid models, block_ids is a tuple where each element corresponds
+        to a kv_cache_group (e.g. block_ids[0] = attention blocks, block_ids[1] = hybrid blocks).
+        In mamba_cache_mode="all", all groups share the same block_ids.
+
+        We delegate to request_finished which handles saving progress tracking.
+        """
+        # For hybrid models with mamba_cache_mode="all", all groups share block_ids.
+        # We use block_ids[0] (attention group) since the saving logic is block-level.
+        if len(block_ids) == 0:
+            return False, None
+        delay_free, extra_info = self.request_finished(request, block_ids[0])
+        return delay_free, extra_info
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+        """
+        Specify the required KV cache layout for this connector.
+        
+        We don't enforce a specific KV cache layout. vLLM will use the default
+        layout determined by the attention backend (typically NHD for FlashAttention).
+        """
+        return None
+
     def _tp_rank_to_spec_name(self, tp_rank: int) -> str:
         """Convert TP rank to location spec name."""
         return f"tp{tp_rank}"
+
+    def _tp_rank_to_hybrid_spec_name(self, tp_rank: int) -> str:
+        """Convert TP rank to hybrid (mamba/gdn) location spec name."""
+        return f"tp{tp_rank}_hybrid"
+
+    def _detect_hybrid_layers(self, kv_cache_config) -> tuple[bool, list, int]:
+        """Detect hybrid (non-attention) layer groups from kv_cache_config.
+
+        Returns:
+            (has_hybrid, hybrid_layer_names, hybrid_page_size_bytes)
+        """
+        if not _HAS_MAMBA_SPEC or kv_cache_config is None:
+            return False, [], 0
+
+        hybrid_layer_names = []
+        hybrid_page_size_bytes = 0
+        for group in kv_cache_config.kv_cache_groups:
+            spec = group.kv_cache_spec
+            if isinstance(spec, MambaSpec):
+                hybrid_layer_names.extend(group.layer_names)
+                if hybrid_page_size_bytes == 0:
+                    hybrid_page_size_bytes = spec.page_size_bytes
+                else:
+                    assert spec.page_size_bytes == hybrid_page_size_bytes, \
+                        f"All MambaSpec groups must have the same page_size_bytes, " \
+                        f"got {spec.page_size_bytes} vs {hybrid_page_size_bytes}"
+
+        has_hybrid = len(hybrid_layer_names) > 0
+        return has_hybrid, hybrid_layer_names, hybrid_page_size_bytes
 
     def __init__(self,
                  vllm_config: "VllmConfig",
@@ -132,6 +198,11 @@ class TairKvCacheConnector(KVConnectorBase_V1):
         configure_log_level(self._extra_config.log_level)
 
         self._kv_caches: Optional[dict[str, torch.Tensor]] = None
+        # Scheduler's logical block size — used to index local_block_ids.
+        # Must NOT be overwritten by register_kv_caches.
+        self._vllm_block_size = vllm_config.cache_config.block_size
+        # Kernel's physical block size — may be overwritten by register_kv_caches
+        # to tensor.shape[2] for hybrid models where cache_config.block_size != kernel_block_size.
         self._local_block_size = vllm_config.cache_config.block_size
 
         model_config = vllm_config.model_config
@@ -152,6 +223,13 @@ class TairKvCacheConnector(KVConnectorBase_V1):
         per_manager_location_spec_shape = [num_layer, 1 if self._use_mla else 2, manager_block_size,
                                            per_tp_rank_kv_head_num,
                                            head_size]
+
+        # Detect hybrid (mamba/gdn/linear) layers from kv_cache_config
+        self._has_hybrid, self._hybrid_layer_names, self._hybrid_page_size_bytes = \
+            self._detect_hybrid_layers(kv_cache_config)
+        if self._has_hybrid:
+            logger.warning("Hybrid model detected: %d hybrid layers, page_size_bytes=%d",
+                           len(self._hybrid_layer_names), self._hybrid_page_size_bytes)
 
         assert vllm_config.parallel_config.pipeline_parallel_size == 1
         deployment = {
@@ -189,17 +267,44 @@ class TairKvCacheConnector(KVConnectorBase_V1):
         self._host_ip = get_ip()
         port = self._extra_config.coordinator_base_port
 
-        register_response = self._manager_client.register_instance({
+        # Build location_spec_infos and location_spec_groups
+        location_spec_infos = [{
+            "name": self._tp_rank_to_spec_name(rank),
+            "size": math.prod(per_manager_location_spec_shape) * kv_dtype.itemsize
+        } for rank in range(self._tp_size)]
+
+        location_spec_groups = []
+
+        if self._has_hybrid:
+            # Add hybrid spec infos for each tp rank.
+            # Size must cover ALL hybrid layers packed into one buffer per block,
+            # matching what hybrid_save_task actually sends.
+            hybrid_total_bytes = self._hybrid_page_size_bytes * len(self._hybrid_layer_names)
+            for rank in range(self._tp_size):
+                location_spec_infos.append({
+                    "name": self._tp_rank_to_hybrid_spec_name(rank),
+                    "size": hybrid_total_bytes
+                })
+            # Define spec groups for hybrid attention
+            all_attn_specs = [self._tp_rank_to_spec_name(r) for r in range(self._tp_size)]
+            all_hybrid_specs = [self._tp_rank_to_hybrid_spec_name(r) for r in range(self._tp_size)]
+            location_spec_groups = [
+                {"name": "Full", "spec_names": all_attn_specs},
+                {"name": "FullAndHybrid", "spec_names": all_attn_specs + all_hybrid_specs},
+            ]
+
+        register_request = {
             "trace_id": "trace_trace",
             "instance_group": self._extra_config.instance_group,
             "instance_id": self._extra_config.instance_id,
             "model_deployment": deployment,
             "block_size": manager_block_size,
-            "location_spec_infos": [{
-                "name": self._tp_rank_to_spec_name(rank),
-                "size": math.prod(per_manager_location_spec_shape) * kv_dtype.itemsize
-            } for rank in range(self._tp_size)],
-        })
+            "location_spec_infos": location_spec_infos,
+        }
+        if location_spec_groups:
+            register_request["location_spec_groups"] = location_spec_groups
+
+        register_response = self._manager_client.register_instance(register_request)
         # TODO: check conflict and update
         self._iov_size = math.prod(
             per_manager_location_spec_shape) * kv_dtype.itemsize * self._extra_config.hf3fs_concurrent_io_block_count
@@ -265,6 +370,10 @@ class TairKvCacheConnector(KVConnectorBase_V1):
                     self._location_spec_name: math.prod(per_manager_location_spec_shape) * kv_dtype.itemsize,
                 },
             }
+            if self._has_hybrid:
+                self._hybrid_location_spec_name = self._tp_rank_to_hybrid_spec_name(self._tp_rank)
+                transfer_client_json["location_spec_infos"][self._hybrid_location_spec_name] = \
+                    self._hybrid_page_size_bytes * len(self._hybrid_layer_names)
             self._transfer_client_config = json.dumps(transfer_client_json)
 
             self._init_params = kvcm_py_client.InitParams()
@@ -323,16 +432,41 @@ class TairKvCacheConnector(KVConnectorBase_V1):
     # ==============================
 
     def generate_blocks_idx(self, manager_block_idxes, local_block_ids):
+        """Map manager block indices to flat token indices in the KV cache tensor.
+
+        Three-tier block hierarchy:
+          Manager block  : _manager_block_size (e.g. 528) — KVCM server's unit
+          vLLM logical   : _vllm_block_size   (e.g. 528) — scheduler's allocation unit
+          Kernel physical: _local_block_size   (e.g. 16)  — tensor's storage unit
+
+        ratio = _vllm_block_size // _local_block_size (e.g. 33)
+        Each logical block occupies `ratio` consecutive physical blocks in the tensor.
+        """
+        ratio = self._vllm_block_size // self._local_block_size
         blocks_idx = []
         for manager_block_idx in manager_block_idxes:
-            # get kvcache index list
             block_idx = []
             for i in range(self._manager_block_size):
                 now_token_idx = manager_block_idx * self._manager_block_size + i
-                assert now_token_idx // self._local_block_size < len(local_block_ids)
-                local_block_id = local_block_ids[now_token_idx // self._local_block_size]
-                token_offset = now_token_idx % self._local_block_size
-                block_idx.append(local_block_id * self._local_block_size + token_offset)
+
+                # 1. Logical block index (into local_block_ids)
+                logical_block_idx = now_token_idx // self._vllm_block_size
+                assert logical_block_idx < len(local_block_ids), (
+                    f"logical_block_idx={logical_block_idx} out of range "
+                    f"(len={len(local_block_ids)}, ratio={ratio}, "
+                    f"vllm_bs={self._vllm_block_size}, local_bs={self._local_block_size})"
+                )
+                local_block_id = local_block_ids[logical_block_idx]
+
+                # 2. Token offset within the logical block
+                token_within_logical = now_token_idx % self._vllm_block_size
+
+                # 3. Physical block in tensor
+                physical_block = local_block_id * ratio + token_within_logical // self._local_block_size
+
+                # 4. Flat token index for gather/scatter kernel
+                token_within_physical = token_within_logical % self._local_block_size
+                block_idx.append(physical_block * self._local_block_size + token_within_physical)
             blocks_idx.append(block_idx)
         return blocks_idx
 
@@ -375,13 +509,74 @@ class TairKvCacheConnector(KVConnectorBase_V1):
             logger.warning("finish_write_cache failed, write_session_id: %s, error: %s", write_session_id, e)
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        _, first_layer_kvcache = next(iter(kv_caches.items()))
         self._kv_caches = kv_caches
+
+        # Separate attention layers (Tensor) from hybrid layers (list[Tensor])
+        attn_layer_names = []
+        hybrid_layer_names_in_kv = []
+        for name, cache in kv_caches.items():
+            if isinstance(cache, list):
+                hybrid_layer_names_in_kv.append(name)
+            else:
+                attn_layer_names.append(name)
+
+        # Find first attention layer as reference
+        first_attn_kvcache = None
+        for name in attn_layer_names:
+            first_attn_kvcache = kv_caches[name]
+            break
+
+        if first_attn_kvcache is not None:
+            self._register_attention_kv_caches(first_attn_kvcache, attn_layer_names)
+        else:
+            raise RuntimeError(
+                "Pure Mamba/GDN models are not supported; "
+                "at least one Attention layer is required in kv_caches")
+
+        # Register hybrid layers if present
+        if self._has_hybrid and hybrid_layer_names_in_kv:
+            self._register_hybrid_kv_caches(hybrid_layer_names_in_kv)
+        elif hybrid_layer_names_in_kv:
+            logger.warning("Hybrid layers found in kv_caches but _has_hybrid is False, "
+                           "hybrid layers will not be transferred")
+
+        # Safety: if _has_hybrid is True, hybrid_info must have been set
+        if self._has_hybrid:
+            assert getattr(self, '_hybrid_info', None) is not None, \
+                "_has_hybrid is True but hybrid_info was not set; " \
+                "kv_caches may not contain the expected hybrid layers"
+
+        # Finalize: build KVCacheInfo and DataTransferManager
+        self._finalize_kv_cache_registration()
+
+    def _register_attention_kv_caches(self, first_layer_kvcache, attn_layer_names):
+        """Register attention layer KV caches (existing logic)."""
         # TODO: support MLA
 
-        assert self._local_block_size == first_layer_kvcache.shape[2], "kv cache shape error"
-        for layer_name, kvcache in kv_caches.items():
-            assert kvcache.is_contiguous(), "kv cache must be contiguous"
+        # For hybrid models, the kernel block size (tensor shape[2]) may differ
+        # from the scheduler's block size (vllm config). Update _local_block_size
+        # to match the tensor's actual block size.
+        self._local_block_size = first_layer_kvcache.shape[2]
+        
+        # Compute stride parameters for strided memory layout
+        # For contiguous layout: kv_stride=0, block_stride=0 (use flat indexing)
+        # For strided layout: compute from tensor strides
+        if first_layer_kvcache.is_contiguous():
+            self._kv_stride = 0
+            self._block_stride = 0
+        else:
+            # Strided layout: [2, num_blocks, block_size, num_heads, head_dim]
+            # stride[0] = distance between K and V
+            # stride[1] = distance between blocks
+            self._kv_stride = first_layer_kvcache.stride(0)
+            self._block_stride = first_layer_kvcache.stride(1)
+            logger.info(f"Strided KV cache layout: kv_stride={self._kv_stride}, block_stride={self._block_stride}")
+        
+        for name in attn_layer_names:
+            kvcache = self._kv_caches[name]
+            # Hybrid models may have strided tensors; skip contiguous check for them
+            if not self._has_hybrid:
+                assert kvcache.is_contiguous(), "kv cache must be contiguous"
 
         # torch.Size([2, block_num, block_size, kv_head_num, kv_dim])
         # 2 -> key, value
@@ -405,25 +600,25 @@ class TairKvCacheConnector(KVConnectorBase_V1):
                first_layer_kvcache[0][0][0].data_ptr(), "kv cache shape error"
         assert self._per_manager_location_spec_layer_byte_size == 2 * self._manager_block_size * self._per_layer_token_key_byte_size
 
-        self._per_manager_location_spec_shape = [len(self._kv_caches)] + self._per_manager_location_spec_layer_shape
+        self._per_manager_location_spec_shape = [len(attn_layer_names)] + self._per_manager_location_spec_layer_shape
         self._per_manager_location_spec_byte_size = math.prod(
             self._per_manager_location_spec_shape) * self._dtype.itemsize
 
         self._kvcache_ptr_tensor_cpu = torch.tensor(
-            [self._kv_caches[name].data_ptr() for name in self._kv_caches],
+            [self._kv_caches[name].data_ptr() for name in attn_layer_names],
             dtype=torch.int64,
             device="cpu"
         )
         self._kvcache_ptr_tensor_gpu = self._kvcache_ptr_tensor_cpu.to(self._device)
         if self._use_mla:
             self._all_kvcache_ptr_tensor_cpu = torch.tensor(
-                [self._kv_caches[name].data_ptr() for name in self._kv_caches],
+                [self._kv_caches[name].data_ptr() for name in attn_layer_names],
                 dtype=torch.int64,
                 device="cpu"
             )
         else:
             kvcache_ptrs = []
-            for name in self._kv_caches:
+            for name in attn_layer_names:
                 kvcache_ptrs.append(self._kv_caches[name][0].data_ptr())
                 kvcache_ptrs.append(self._kv_caches[name][1].data_ptr())
             self._all_kvcache_ptr_tensor_cpu = torch.tensor(
@@ -433,6 +628,62 @@ class TairKvCacheConnector(KVConnectorBase_V1):
             )
         self._all_kvcache_ptr_tensor_gpu = self._all_kvcache_ptr_tensor_cpu.to(self._device)
 
+        self._copy_buffer_allocator = CopyBufferAllocator(torch.device("cpu"), self._dtype,
+                                                          self._per_manager_location_spec_shape, 1024)
+
+    def _register_hybrid_kv_caches(self, hybrid_layer_names):
+        """Register hybrid (mamba/gdn/linear) layer state caches.
+
+        For each hybrid layer, kv_caches[name] is a list[Tensor] (e.g. [conv_state, ssm_state]).
+        All state tensors share the same underlying untyped_storage (guaranteed by vllm).
+        We reconstruct a (num_blocks, page_size_bytes) byte view for opaque block transfer.
+        """
+        device = self._device
+        block_view_tensors = []
+        ptr_list = []
+
+        for name in hybrid_layer_names:
+            state_tensors = self._kv_caches[name]
+            assert isinstance(state_tensors, list) and len(state_tensors) > 0, \
+                f"Hybrid layer {name} should be a non-empty list of tensors"
+
+            # Assert all state tensors share the same untyped_storage (contiguity guarantee)
+            base_storage = state_tensors[0].untyped_storage()
+            for i, st in enumerate(state_tensors[1:], 1):
+                assert st.untyped_storage().data_ptr() == base_storage.data_ptr(), \
+                    f"Hybrid layer {name}: state tensor [{i}] does not share storage with [0]"
+
+            # Build (num_blocks, page_size_bytes) uint8 view from the shared storage
+            num_blocks = state_tensors[0].shape[0]
+            byte_view = torch.tensor([], dtype=torch.uint8, device=device).set_(base_storage)
+            total_bytes = base_storage.nbytes()
+            assert total_bytes >= num_blocks * self._hybrid_page_size_bytes, \
+                f"Hybrid layer {name}: storage size {total_bytes} < {num_blocks} * {self._hybrid_page_size_bytes}"
+            byte_view = byte_view[:num_blocks * self._hybrid_page_size_bytes].view(
+                num_blocks, self._hybrid_page_size_bytes)
+            block_view_tensors.append(byte_view)
+            ptr_list.append(base_storage.data_ptr())
+
+        ptr_tensor_cpu = torch.tensor(ptr_list, dtype=torch.int64, device="cpu")
+
+        self._hybrid_info = HybridCacheInfo(
+            layer_names=hybrid_layer_names,
+            ptr_tensor_cpu=ptr_tensor_cpu,
+            block_view_tensors=block_view_tensors,
+            page_size_bytes=self._hybrid_page_size_bytes,
+            layer_num=len(hybrid_layer_names),
+        )
+
+        logger.warning("Registered hybrid layers: %s, page_size_bytes=%d, layer_num=%d",
+                       hybrid_layer_names, self._hybrid_page_size_bytes, len(hybrid_layer_names))
+
+    def _finalize_kv_cache_registration(self):
+        """Finalize KV cache registration after both attention and hybrid layers are registered.
+
+        Called at the end of register_kv_caches to build KVCacheInfo and DataTransferManager.
+        """
+        hybrid_info = getattr(self, '_hybrid_info', None) if self._has_hybrid else None
+
         self._kvcache_info = KVCacheInfo(
             self._tp_rank,
             self._tp_size,
@@ -440,18 +691,20 @@ class TairKvCacheConnector(KVConnectorBase_V1):
             self._kvcache_ptr_tensor_cpu,
             self._kvcache_ptr_tensor_gpu,
             self._all_kvcache_ptr_tensor_gpu,
-            len(self._kv_caches),
+            len([n for n in self._kv_caches if isinstance(self._kv_caches[n], torch.Tensor)]),
             self._local_token_num,
             tuple(self._per_manager_location_spec_shape),
             self._per_manager_location_spec_byte_size,
             self._per_layer_token_key_dim_size,
             self._device,
-            self._dtype
+            self._dtype,
+            hybrid_info,
+            self._kv_stride,
+            self._block_stride,
+            self._local_block_size,
         )
-        self._copy_buffer_allocator = CopyBufferAllocator(torch.device("cpu"), self._dtype,
-                                                          self._per_manager_location_spec_shape, 1024)
 
-        # 初始化DataTransferManager实例
+        # Initialize DataTransferManager
         self._data_transfer = DataTransferManager(
             self._kvcache_info,
             self._manager_block_size,
@@ -461,8 +714,8 @@ class TairKvCacheConnector(KVConnectorBase_V1):
             self._extra_config,
         )
 
-        logger.warning("register_kv_caches, _per_manager_location_spec_layer_shape: %s",
-                       self._per_manager_location_spec_layer_shape)
+        logger.warning("register_kv_caches, _per_manager_location_spec_layer_shape: %s, has_hybrid: %s",
+                       self._per_manager_location_spec_layer_shape, self._has_hybrid)
 
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
@@ -472,19 +725,40 @@ class TairKvCacheConnector(KVConnectorBase_V1):
             if len(load_req.need_load_locations) == 0:
                 continue
 
+            # --- Attention layer load (existing path) ---
             block_token_indices = self.generate_blocks_idx(load_req.manager_block_idxes, load_req.local_block_ids)
             all_remote_uris = self.get_self_uris(load_req.need_load_locations)
 
             per_task_size = self._extra_config.block_per_load_task
-            task_num = math.ceil(len(block_token_indices) / per_task_size)
+
+            # --- Hybrid layer load setup ---
+            hybrid_uris = []
+            hybrid_block_indices = []
+            if self._has_hybrid:
+                hybrid_uris = self.get_self_hybrid_uris(load_req.need_load_locations)
+                if len(hybrid_uris) > 0:
+                    hybrid_block_indices = self.generate_hybrid_block_indices(
+                        load_req.manager_block_idxes, load_req.local_block_ids)
+                    assert len(hybrid_uris) == len(hybrid_block_indices), \
+                        f"hybrid_uris ({len(hybrid_uris)}) != hybrid_block_indices ({len(hybrid_block_indices)}), " \
+                        f"locations may have mixed Full/FullAndHybrid groups"
+
+            # Total tasks = attention tasks + hybrid tasks (merged into one MultiResult)
+            attn_task_num = math.ceil(len(block_token_indices) / per_task_size)
+            hybrid_task_num = math.ceil(len(hybrid_uris) / per_task_size) if hybrid_uris else 0
+            total_task_num = attn_task_num + hybrid_task_num
+
             done_callback = self._data_transfer.create_load_done_callback(
                 load_req.req_id,
                 self._kvcache_info.tp_rank,
                 meta.epoch,
-                copy.copy(load_req.local_block_ids)
+                copy.copy(load_req.local_block_ids),
+                attn_block_count=len(block_token_indices),
+                hybrid_block_count=len(hybrid_uris)
             )
-            multi_result = MultiResult(task_num, done_callback)
+            multi_result = MultiResult(total_task_num, done_callback)
 
+            # Submit attention tasks
             task_idx = 0
             for i in range(0, len(block_token_indices), per_task_size):
                 end_idx = min(len(block_token_indices), i + per_task_size)
@@ -492,6 +766,16 @@ class TairKvCacheConnector(KVConnectorBase_V1):
                 task_block_token_indices = block_token_indices[i:end_idx]
                 self._data_transfer.submit_task(self._data_transfer.load_task, multi_result, task_idx, task_remote_uris,
                                                 task_block_token_indices)
+                task_idx += 1
+
+            # Submit hybrid tasks (continuing with same multi_result)
+            for i in range(0, len(hybrid_uris), per_task_size):
+                end_idx = min(len(hybrid_uris), i + per_task_size)
+                h_task_uris = hybrid_uris[i:end_idx]
+                h_task_blocks = hybrid_block_indices[i:end_idx]
+                self._data_transfer.submit_task(
+                    self._data_transfer.hybrid_load_task,
+                    multi_result, task_idx, h_task_uris, h_task_blocks)
                 task_idx += 1
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -515,19 +799,40 @@ class TairKvCacheConnector(KVConnectorBase_V1):
         for req_save in meta.to_save_requests:
             req = self._alive_requests[req_save.req_id]
 
+            # --- Attention layer save (existing path) ---
             # get idx
             blocks_idx = self.generate_blocks_idx(req_save.manager_block_idxes, req.local_block_ids)
             all_remote_uris = self.get_self_uris(req_save.target_locations)
 
             per_task_size = self._extra_config.block_per_save_task
-            task_num = math.ceil(len(blocks_idx) / per_task_size)
+
+            # --- Hybrid layer save setup ---
+            hybrid_uris = []
+            hybrid_block_indices = []
+            if self._has_hybrid:
+                hybrid_uris = self.get_self_hybrid_uris(req_save.target_locations)
+                if len(hybrid_uris) > 0:
+                    hybrid_block_indices = self.generate_hybrid_block_indices(
+                        req_save.manager_block_idxes, req.local_block_ids)
+                    assert len(hybrid_uris) == len(hybrid_block_indices), \
+                        f"hybrid_uris ({len(hybrid_uris)}) != hybrid_block_indices ({len(hybrid_block_indices)}), " \
+                        f"locations may have mixed Full/FullAndHybrid groups"
+
+            # Total tasks = attention tasks + hybrid tasks (merged into one MultiResult)
+            attn_task_num = math.ceil(len(blocks_idx) / per_task_size)
+            hybrid_task_num = math.ceil(len(hybrid_uris) / per_task_size) if hybrid_uris else 0
+            total_task_num = attn_task_num + hybrid_task_num
+
             done_callback = self._data_transfer.create_save_done_callback(
                 req.req_id,
                 self._kvcache_info.tp_rank,
-                req_save.write_session_id
+                req_save.write_session_id,
+                attn_block_count=len(blocks_idx),
+                hybrid_block_count=len(hybrid_uris)
             )
-            multi_result = MultiResult(task_num, done_callback)
+            multi_result = MultiResult(total_task_num, done_callback)
 
+            # Submit attention tasks
             task_idx = 0
             for i in range(0, len(blocks_idx), per_task_size):
                 end_idx = min(len(blocks_idx), i + per_task_size)
@@ -537,6 +842,18 @@ class TairKvCacheConnector(KVConnectorBase_V1):
                                                 task_block_token_indices,
                                                 kvcache_ready_event)
                 task_idx += 1
+
+            # Submit hybrid tasks (continuing with same multi_result)
+            for i in range(0, len(hybrid_uris), per_task_size):
+                end_idx = min(len(hybrid_uris), i + per_task_size)
+                h_task_uris = hybrid_uris[i:end_idx]
+                h_task_blocks = hybrid_block_indices[i:end_idx]
+                self._data_transfer.submit_task(
+                    self._data_transfer.hybrid_save_task,
+                    multi_result, task_idx, h_task_uris, h_task_blocks,
+                    kvcache_ready_event)
+                task_idx += 1
+
             if self._tp_rank == 0:
                 req.scheduled_saving_count += 1
 
@@ -548,6 +865,38 @@ class TairKvCacheConnector(KVConnectorBase_V1):
                 if self._tp_rank_to_spec_name(self._kvcache_info.tp_rank) == location_spec["name"]:
                     all_remote_uris.append(location_spec["uri"])
         return all_remote_uris
+
+    def get_self_hybrid_uris(self, locations):
+        """Extract hybrid spec URIs for this rank."""
+        if not self._has_hybrid:
+            return []
+        hybrid_spec_name = self._tp_rank_to_hybrid_spec_name(self._kvcache_info.tp_rank)
+        all_remote_uris = []
+        for location in locations:
+            for location_spec in location.get("location_specs", []):
+                if hybrid_spec_name == location_spec["name"]:
+                    all_remote_uris.append(location_spec["uri"])
+        return all_remote_uris
+
+    def generate_hybrid_block_indices(self, manager_block_idxes, local_block_ids):
+        """Generate local block IDs for hybrid (per-block) transfer.
+
+        Unlike attention's generate_blocks_idx which produces per-token indices,
+        hybrid state is per-block, so we only need one local block ID per manager block.
+
+        Hybrid state tensors are indexed by logical block IDs (scheduler's allocation unit),
+        so we use _vllm_block_size (not _local_block_size) for the lookup.
+        """
+        block_indices = []
+        for manager_block_idx in manager_block_idxes:
+            now_token_idx = manager_block_idx * self._manager_block_size
+            logical_block_idx = now_token_idx // self._vllm_block_size
+            assert logical_block_idx < len(local_block_ids), (
+                f"hybrid block index {logical_block_idx} out of range "
+                f"(len={len(local_block_ids)}, vllm_bs={self._vllm_block_size})"
+            )
+            block_indices.append(local_block_ids[logical_block_idx])
+        return block_indices
 
     def get_finished(
             self, finished_req_ids: set[str]
@@ -777,6 +1126,14 @@ class TairKvCacheConnector(KVConnectorBase_V1):
             "token_ids": token_ids,
             "write_timeout_seconds": 30
         }
+        # Fill location_spec_group_names for hybrid attention models
+        if self._has_hybrid:
+            # In mamba_cache_mode="all", every block has both attention and hybrid state
+            request["location_spec_group_names"] = ["FullAndHybrid"] * target_save_num
+            # Keep block_keys=[] to let server generate hash-based keys from token_ids.
+            # This ensures write and query use the same hash function.
+            # NOTE: Server must apply key generation BEFORE validating keys.size() == group_names.size().
+            # See server-side fix in commit 71205d0 (CacheManager::StartWriteCache).
         logger.debug("start_write_cache req: %s", request)
         try:
             response = self._manager_client.start_write_cache(request)


### PR DESCRIPTION
## Summary

support hybrid attention models (mamba/gdn/linear) in vllm connector with stride-aware kv cache transfer, and fix server-side key validation for token_ids mode

## Motivation

hybrid models like qwen3.5-4b combine attention layers with non-attention layers (mamba, gdn, linear). the existing connector only supported pure attention models. this pr extends the connector to handle hybrid architectures by:

- tracking hybrid layer state separately from attention kv cache
- supporting strided memory layouts (vllm uses strided tensors for hybrid models)
- implementing byte-level transfer for hybrid state (opaque memcpy instead of token-level gather/scatter)
- registering separate `location_spec_groups` (Full / FullAndHybrid) to distinguish cache entries

additionally, the server-side `StartWriteCache` had a key validation ordering bug: it validated `location_spec_group_names.size() == keys.size()` BEFORE generating keys from `token_ids`. when `keys` is empty (normal token_ids mode), the validation would incorrectly reject the request. this is fixed by moving the validation AFTER key generation, using `query_keys.size()` instead.

## Usage

hybrid models are automatically detected via `MambaSpec` in `kv_cache_config`. no configuration changes needed — just use a hybrid model and the connector will:

1. register hybrid layer info alongside attention kv cache
2. save/load hybrid state in parallel with attention kv cache
3. merge success callbacks (attention AND hybrid must both succeed)

verified on qwen3.5-4b (24 hybrid layers + attention):

```python
from vllm import LLM, SamplingParams

connector_config = {
    "kv_connector": "TairKvCacheConnector",
    "kv_role": "kv_both",
    "kv_connector_module_path": "kv_cache_manager.py_connector.vllm.v1_connector",
    "kv_connector_extra_config": { ... }
}

llm = LLM(
    model="Qwen/Qwen3.5-4B",  # hybrid model
    kv_transfer_config=connector_config,
)

# first request: cold path, triggers save
outputs = llm.generate(["long prompt ..."], SamplingParams(max_tokens=64))

# second request: hot path, cache hit
outputs = llm.generate(["long prompt ..."], SamplingParams(max_tokens=64))
```

## Changes

| file | change |
|------|--------|
| `cache_manager.cc` | move `CheckLocationSpecGroupNames` after key generation, use `query_keys.size()` |
| `types.py` | add `HybridCacheInfo` dataclass for non-attention layer state |
| `v1_connector.py` | detect hybrid layers, register hybrid specs, implement hybrid load/save orchestration |
| `data_transfer.py` | implement `hybrid_load_task` / `hybrid_save_task` for byte-level state transfer, add AND-merge success callbacks |
| `batch_gather_scatter_helper.py` | add stride parameters (`kv_stride`, `block_stride`, `local_block_size`) for strided memory layouts |
| `gather_scatter_helper.py` | compute strided offsets for attention kv cache when using strided tensors |

## Known limitations / Risks

- **only tested on qwen3.5-4b** — other hybrid models (e.g. jamba, zamba) may have different state layouts
- **stride support assumes uniform block size** — hybrid layers are assumed to use the same `local_block_size` as attention layers
- **no support for pure mamba models** — at least one attention layer is required (raises `RuntimeError` otherwise)
## Testing

**smoke testing only** — deterministic token-by-token assertions are not viable for cross-engine validation.

we encountered fundamental difficulties with deterministic assertions in integration tests: vllm's flash attention kernel tiling strategy depends on sequence length, causing floating-point accumulation order differences between cold path (full prefill) and hot path (prefix cache hit). when cumulative error is large enough, `argmax` results diverge.

deterministic token-by-token assertions are unreliable for cross-inference-engine validation (even inference engines don't guarantee cross-version output consistency). we proceeded with merging the code after smoke testing, and will adopt more specific validation approaches in the future:

- **prefill-stage tensor cosine similarity** — compare attention outputs before decoding
- **error injection sensitivity testing** — corrupt cached blocks and verify degradation patterns
- **semantic similarity metrics** — prefix match ratio, trigram overlap, length ratio (currently used in smoke tests)

current results on qwen3.5-4b show cache writes and hits are working correctly (verified via prometheus metrics: `StartWriteCache`, `GetCacheLocation`, `key_count`). generated outputs are semantically coherent between cold and hot paths.

integration test infrastructure is not included in this pr (kept out of repo per project policy). we will develop better testing approaches in follow-up work.
