### PR TITLE
[manager] add background cache garbage collector

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [ReportEvent 增量上报与权威快照设计](design/report_event_snapshot_uri_version.md) - 增量/快照协同、提交屏障、故障恢复、性能取舍与 Subscriber 集成
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
+- [后台扫描 GC](design/cache_garbage_collector.md) - 基于 authoritative cursor 的后台全量巡检；V1 清理长期 orphan WRITING 和普通 SERVING storage-missing，并提供无副作用读取、精确值条件 CAS 与 HA 生命周期
 
 ### 开发文档
 - [开发指南](develop/README.md) - 开发者入门指南和开发环境配置

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,20 @@ kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
 kvcm.cache_reclaimer.pending_delete_handler_limit=1024
 kvcm.cache_reclaimer.pending_bytes_limit=274877906944
 
+# leader 后台 metadata GC，默认关闭。V1 处理超过 grace 的 CLS_WRITING，
+# 以及 MightExist 明确 missing 的普通 CLS_SERVING Location（EventReport 除外）。
+kvcm.cache_gc.enabled=false
+# active round 的 tick 间隔；每个 tick 最多推进一个 backend batch。
+kvcm.cache_gc.scan_interval_ms=1000
+# 一个 full round 完成后的 cooldown，默认 24 小时。
+kvcm.cache_gc.round_pause_ms=86400000
+# backend key 数 hint，同时限制单次删除请求的 Location target 数。
+kvcm.cache_gc.scan_batch_size=256
+# orphan WRITING grace，最小 1 小时（3600000ms），默认 24 小时。
+kvcm.cache_gc.orphan_writing_grace_period_ms=86400000
+# GC 在途删除请求硬上限；默认 2。一个慢请求只占一个槽位，全部槽位占满后暂停扫描。
+kvcm.cache_gc.max_inflight_delete_requests=2
+
 # 可选值有dummy，local，logging，kmonitor；若不配置或配置为空，默认使用local
 kvcm.metrics.reporter_type=local
 

--- a/docs/design/cache_garbage_collector.md
+++ b/docs/design/cache_garbage_collector.md
@@ -1,0 +1,615 @@
+# Cache Garbage Collector 后台扫描 GC 设计
+
+| 项目 | 内容 |
+|---|---|
+| 状态 | V1 已实现并完成相关单测、E2E 与性能冒烟；基线已包含异步删除（#234）、分层存储迁移（#209）和精确值条件删除（#233） |
+| 更新时间 | 2026-07-30 |
+| 涉及模块 | `manager`、`meta`、`data_storage`、`config`、`metrics`、`service` |
+| 历史参考 | [PR #184](https://github.com/alibaba/tair-kvcache/pull/184) |
+
+本文档定义 Cache Garbage Collector（以下简称 GC）V1 的行为契约和实现边界。PR #184 仅作为历史实现参考；最终行为以本文档和实现为准。
+
+## 1. 背景
+
+### 1.1 为什么需要后台 GC
+
+KVCM 中 Cache Location 的正常生命周期为：
+
+```text
+CLS_WRITING -> CLS_SERVING -> CLS_DELETING -> metadata removed
+```
+
+当前异常 metadata 主要依赖两类被动触发器清理：
+
+1. 容量达到水位后，由 Reclaimer 采样逐出；
+2. key 再次被访问时，通过 `MightExist()` 等检查机会式清理。
+
+如果容量没有达到水位，异常 key 此后也不再被访问，metadata 就可能长期残留。本需求建立一个只在 leader 运行的后台 GC，使长期 WRITING 和存储已明确丢失的普通 SERVING Location 能够主动收敛，并为后续 TTL 等场景提供统一的后台执行入口。
+
+当前 metadata backend 没有按 Location 状态或创建时间查询的索引。V1 不在写入热路径维护新索引，而是按 cursor 分批扫描 authoritative metadata。cursor 只把一次全量扫描摊到多个 tick；一个完整 round 仍会读取全部 Block 和 Location metadata，成本约为 `O(keyspace + location metadata)`。
+
+V1 采用“以固定间隔扫完一轮，再长时间休眠”的简单策略。默认 WRITING grace 和 round cooldown 都是 24 小时，避免小 keyspace 被持续重复扫描。若 active round 的开销仍不可接受，再根据性能数据引入动态 pacing 或到期索引。
+
+### 1.2 当前已知的异常状态
+
+#### 长期 CLS_WRITING
+
+`StartWriteCache` 会把 `CLS_WRITING` Location 写入 metadata，并把 `write_session_id` 保存在当前 leader 的内存中。服务端把 write session timeout 限制为最多 1800 秒；健康 leader 会在 client `FinishWriteCache` 或 timeout callback 中完成状态流转或清理。
+
+如果持有 session 和 timer 的进程在完成前退出，例如 `StartWriteCache` 后发生主备切换，新 leader 无法恢复旧进程内存中的 session：
+
+1. 旧 `write_session_id` 无法继续 Finish；
+2. metadata 可能长期停留在 `CLS_WRITING`；
+3. 后续写入可能因已有 WRITING Location 而被阻塞；
+4. 若没有水位逐出和业务访问，该对象无法自行收敛。
+
+#### 数据已丢失的普通 CLS_SERVING
+
+`CLS_SERVING` 只表示 metadata 已完成写入结算，不保证 URI 对应的物理数据仍然存在。例如 TairMempool 节点退出后，若该 Block 没有再次被访问且容量未触发逐出，失效 metadata 会一直保留。
+
+在线查询已经通过低成本 `MightExist()` 机会式过滤这类 Location。GC V1 复用同一 backend 能力做后台探测：仅当普通 storage 的某个 spec 被明确判定为 missing 时，才把整个 Location 作为候选；backend 不支持低成本探测、返回 unknown、结果 shape 异常或调用失败时均不删除。EventReport 有独立的版本和所有权语义，不进入本规则。
+
+#### 长期 CLS_DELETING
+
+正常删除需要完成状态 CAS、Sync、物理数据删除和最终 metadata CAD。链路中断可能留下长期 `CLS_DELETING`，但仅凭状态和持续时间无法区分：
+
+- 数据尚未释放，可以重试；
+- 数据已经释放，只缺最终 CAD；
+- URI 空间已经被其他数据复用。
+
+后两种情况下盲目重试物理删除可能造成 UAF。安全恢复依赖 storage URI version/epoch 和后端原子校验，因此长期 DELETING 是已知场景，但不进入 V1。
+
+### 1.3 V1 取舍
+
+V1 处理两类可保守判定的垃圾：超过 grace 且不属于活跃 Migration Copy 目标的 `CLS_WRITING`，以及至少一个 spec 被 `MightExist()` 明确判定为 missing 的普通 `CLS_SERVING`。两类候选复用同一最小闭环：
+
+```text
+leader LoopThread
+  -> authoritative batch scan
+  -> 固定 WRITING 判定 / 批量 MightExist 探测
+  -> 携带扫描快照的条件删除
+  -> 复用 SchedulePlanExecutor::SubmitAsync
+  -> 记录结果
+```
+
+V1 不提前抽象通用 Rule Engine、Candidate Source、Action Dispatcher 或 Admission Controller。两个固定判定仍内聚在 GC 内；扩展点只保留在组件边界上：MetaIndexer 提供无副作用维护扫描，DataStorage 提供低成本保守探测，Executor 提供精确值条件删除。后续规则继续增加时再提取共同接口。
+
+现有 `WriteLocationManager` 的 location ID 隔离问题，以及 Reclaimer 与 `FinishWriteCache` 的结算窗口，是独立的既存正确性问题。它们应单独修复和回归，不作为 GC V1 的依赖，也不在本 PR 顺手改造。
+
+## 2. 设计范围
+
+### 2.1 V1 目标
+
+V1 实现以下六项能力：
+
+1. **低频全量巡检**：按 Instance 和 cursor 分批读取 authoritative metadata；每个 tick 最多推进一个 batch，完成一轮后进入 cooldown。
+2. **无副作用读取**：GC 扫描不能更新 LRU/access time、hit count、revisit histogram，也不能改变 online hot cache。
+3. **保守识别长期 WRITING**：只处理状态、创建时间和标识均明确有效，年龄达到 grace，且不属于活跃 Migration Copy 目标的 Location；异常时间、读取错误或活跃迁移一律跳过。
+4. **保守识别普通 SERVING 失效**：按 storage 批量调用低成本 `MightExist()`；任一 spec 明确 missing 时整个 Location 失效，unsupported/unknown/错误均跳过，EventReport 明确排除。
+5. **异步精确条件删除**：请求携带扫描时的完整 Location 序列化值；Executor worker 重新读取 metadata，只有对象仍与快照完全一致时才执行当前状态到 `CLS_DELETING` 的 CAS。
+6. **有界异步反压和 leader 生命周期**：使用小型在途窗口并行消费 Executor 能力，每个 tick 最多提交一个请求，达到窗口上限后停止扫描；GC 只在 leader recovery 完成后运行，降级时在 metadata cleanup 前停止并 join。
+
+所有扫描、判定和提交均保持严格的 `instance_id` 隔离。
+
+### 2.2 V1 非目标
+
+以下能力不进入 V1：
+
+1. 通用 Rule/Candidate/Action 框架和动态规则注册。
+2. WRITING deadline ZSET、TTL expiry index、CDC 或其他增量候选源。
+3. 动态 pacing、adaptive backoff、每轮预算、跨 Instance 公平调度。
+4. 动态或大规模并发窗口、多维 bytes/Group 配额、Future deadline 和持久化任务。
+5. `WriteLocationManager` 三元组索引、settling guard，以及 Reclaimer/Finish 竞态修复。
+6. `CLS_DELETING` 自动恢复和 storage version/epoch。
+7. EventReport reconciliation、Block TTL 和闲置 Instance 清理。
+8. 查询链路 fast-submit 重构。
+9. GC lease/generation、跨进程 cursor 或 pending 恢复。
+10. data storage I/O timeout/cancel 和 CAS 后补偿状态机。
+11. dry-run、动态配置热更新和按 Group/Instance 单独启停。
+12. 不改变 #234 的异步删除结果契约：继续复用 accepted、端到端 Future、`PlanExecuteResult`、`EC_PARTIAL_OK` 和 promise exactly-once 完成语义。
+13. 不改变 #209 的迁移状态机、Copy 调度和 reservation 生命周期；GC 只消费其活跃目标查询接口。
+
+### 2.3 依赖与交付边界
+
+GC 的 `LoopThread` 回调会同步调用 Registry、maintenance scan 和 DataStorage `MightExist()` 探测，并复用这些组件现有的 timeout 和 retry 语义。公共 Redis command timeout 不是 GC V1 合入或生产启用的硬前置；CacheReclaimer 和其他 metadata 调用方也依赖同一套基础设施。
+
+GC 新增的风险暴露点是：demotion 必须在 cleanup 前 `Join()`，因此慢或失联的 metadata/DataStorage 探测可能延长降级时间。GC 默认关闭，生产上线时应灰度开启并监控扫描错误、共享 Executor/存储后端负载与降级时延；若确认底层调用缺少有限返回上界，应作为公共基础设施问题独立治理。GC V1 不自行重构 Redis 建连、认证、重连、timeout/cancel、连接池或 data storage I/O 语义。
+
+当前基线已包含 #234 的异步删除能力和 #233 的 `expected_location_values` 精确值条件删除。GC 直接复用二者：首次入队 accepted、端到端 Future、Get/CAS/Sync、delay、二次入队、物理删除和 promise 收敛均沿用现有实现。GC 请求额外声明 `authoritative_read`：`PrepareDeleteTaskImpl` 从 persistent source of truth 重新读取扫描目标，条件 CAS 在 shard lock 内先用完整 persistent key 刷新可能缺失或陈旧的 hot cache，再按 expected value 原子复核。普通删除请求不启用该选项，现有同步/异步兼容语义不变。
+
+当前基线也已包含 #209 的分层存储迁移。Migration Copy 会创建合法的 `CLS_WRITING` 目标，并用 `MigrationManager` 活跃任务 reservation 覆盖 Prepare、Copy 和收尾窗口。GC 复用 `HasActiveCopyTargetLocation(instance_id, block_key, location_id)` 排除这些目标；任务结束后若仍留下 WRITING，后续 round 才按普通 orphan 收敛。GC 删除沿用 `kReclaim` 任务类别，不占 migration worker budget，也不修改迁移的队列优先级和并发限制。
+
+## 3. 总体设计
+
+### 3.1 组件与调用链
+
+```mermaid
+flowchart LR
+    L[Leader lifecycle] --> G[CacheGarbageCollector]
+    G --> R[Registry snapshot]
+    R --> M[ScanLocationsForMaintenance]
+    M --> W[Old WRITING predicate]
+    X[MigrationManager active target guard] --> W
+    M --> S[Ordinary SERVING candidates]
+    S --> D[DataStorageManager MightExist batches]
+    W --> E[SchedulePlanExecutor exact-value SubmitAsync]
+    D --> E
+    E --> F[Bounded Future window]
+    F --> G
+```
+
+| 组件 | V1 职责 |
+|---|---|
+| `CacheGarbageCollector` | 复用公共 `LoopThread` 做单线程调度，维护 round/cursor、固定判定、有界 Future 轮询和 pending target 去重 |
+| `RegistryManager` | 在每轮开始时提供 Instance Group/Instance 快照 |
+| `MetaIndexer` | 从 authoritative backend 返回一个无副作用的 metadata batch |
+| `MigrationManager` | 识别仍属于活跃 Copy 的 WRITING 目标，防止被当作 orphan |
+| `DataStorageManager` | 按 storage 合并普通 SERVING 的 URI，并通过 `MightExist()` 做低成本保守探测 |
+| `SchedulePlanExecutor` | accepted 准入、worker 内重新读取、精确值条件 CAS、Sync、物理删除、最终 CAD 和端到端 Future |
+| `Server/CacheManager` | 在 leader recovery/demotion 和进程析构时管理 GC 生命周期 |
+
+GC 只访问 data storage 的低成本 `MightExist()` 探测接口，不执行物理删除，也不自行实现 Location 删除状态机。
+
+GC 的扫描协调不放入 `SchedulePlanExecutor`。Executor 是 Reclaimer、GC 等调用方共享的删除执行资源；把可能受 Redis SCAN/Get 延迟影响的完整扫描循环放入其中，会占用删除 worker，并把巡检速度与删除吞吐耦合。若扫描任务在 Executor worker 内提交删除后等待 Future，单 worker 配置下还会形成队内自依赖。
+
+因此 V1 只为扫描协调保留一个轻量串行循环，并复用 `common::LoopThread`，不自行实现线程、定时等待和条件变量。GC 找到候选后立即调用 `SchedulePlanExecutor::SubmitAsync()`；Get/CAS/Sync、delay、物理删除和最终 CAD 仍全部由 Executor 执行。
+
+### 3.2 最小运行状态
+
+GC 调度循环只保存：
+
+```cpp
+struct ScanState {
+    std::vector<InstanceScanEntry> instances;
+    size_t instance_index = 0;
+    std::string cursor = SCAN_BASE_CURSOR;
+    uint64_t round_id = 0;
+    std::optional<std::chrono::steady_clock::time_point> next_round_at;
+};
+
+struct InflightDelete {
+    uint64_t round_id = 0;
+    std::string instance_id;
+    size_t target_count = 0;
+    std::chrono::steady_clock::time_point submitted_at;
+    std::vector<PendingLocationKey> pending_locations;
+    std::future<PlanExecuteResult> future;
+};
+
+std::vector<InflightDelete> inflight_deletes;
+std::set<PendingLocationKey> pending_locations;
+```
+
+`PendingLocationKey` 至少包含 `(instance_id, block_key, location_id)`。在途窗口和 pending 集合只由 `LoopThread` 回调访问，其规模分别受 `max_inflight_delete_requests` 和 `max_inflight_delete_requests * scan_batch_size` 约束。跨线程只保留 GC stop 标志和一个 `LoopThread` handle，不维护自建 condition variable 或通用 task table。
+
+每次 leader recovery 后重新开始一个 round；降级、重启或重新成为 leader 时不恢复旧 cursor。重复覆盖由条件 CAS 保证安全。
+
+### 3.3 LoopThread 回调
+
+`LoopThread` 使用 strict interval，在上一次回调结束后至少等待 `scan_interval_ms`，因此慢调用返回后不会追赶错过的 tick。每个回调按以下顺序执行：
+
+1. 若收到 stop 请求，立即退出；若持有未完成 Future，只丢弃本地 handle 和 pending，不取消或等待底层 Executor 任务。已接受任务在 leader cleanup 期间按 best-effort 语义继续执行。
+2. 非阻塞轮询全部在途 Future：ready/exception/invalid 均记录结果、释放其 pending target 并移出窗口；未 ready 的任务继续占用槽位。
+3. 若在途请求数已达到 `max_inflight_delete_requests`，本 tick 结束，不继续扫描。
+4. 若仍处于 round cooldown，本 tick 结束。
+5. 若没有本轮快照，从 Registry 获取 Group/Instance 列表，按 `(instance_group, instance_id)` 排序；失败时按普通 tick 间隔重试。
+6. 对当前 Instance 调用一次 `ScanLocationsForMaintenance(cursor, scan_batch_size)`。
+7. 保存 next cursor，遍历返回的 Location：筛选长期 WRITING 并排除活跃 Migration Copy 目标；对普通 SERVING 的合法 URI 按 `(storage unique name, storage type)` 聚合，每次最多取 512 个 URI 调用 `MightExist()`；每个探测分块前后检查 stop，EventReport 和不确定结果跳过。
+8. 删除 target 按 `(block_key, location_id)` 去重，最多保留 `scan_batch_size` 个。请求为空时不调用 Executor。
+9. 非空请求携带每个 target 在扫描时的 `expected_location_values`，调用 `SubmitAsync()`：
+   - `accepted=true` 且 Future valid：保存 Future，并为最终请求建立 pending target；
+   - `accepted=false`：不建立 Future 或 pending，记录 `submit_rejected`；
+   - accepted/Future 契约不一致：记录 `submit_contract`，不建立本地状态；
+   - 调用抛异常：记录 `submit_exception`，不建立本地状态。
+10. 当前 Instance cursor 回到 base 后推进到下一个 Instance；全部 Instance 完成后结束 round，并设置 `next_round_at = now + round_pause_ms`。
+11. tick 结束后至少等待 `scan_interval_ms`。慢调用返回后不追赶错过的 tick。
+
+窗口默认包含 2 个请求。一个慢或卡住的物理删除只占用一个槽位，其他槽位仍可继续扫描和提交；只有全部槽位被占用时才暂停扫描。这为当前无容量上限的 Executor 队列提供了 GC 调用方侧的硬反压，同时利用 #234 已提供的 worker 并发。每个 tick 仍最多提交一个请求，不会形成突发灌入。`inflight_delete_count` 和 `inflight_delete_age_ms` 分别表示当前在途请求数和最老任务年龄。
+
+cursor 在 SubmitAsync 前已经推进。rejected、抛异常或 accepted/Future 契约错误时不回滚 cursor，也不保存该批候选；对象仍保留在 authoritative metadata，等待后续 full round 重新发现。这样避免为 V1 引入额外 retry queue。
+
+同一 batch 中超过 target 上限的候选不会保存在额外 pending 表中；它们仍留在 authoritative metadata，等待后续 round 再次发现。这会牺牲极端场景的收敛速度，但保持 V1 状态简单。
+
+### 3.4 全量扫描语义和成本
+
+一个 round 只在开始时获取一次 Registry 快照，然后依次把每个 Instance 的 cursor 推进到 base。快照之后新增或删除的 Instance 允许本轮不可见或返回 Indexer 不存在，下一轮重新获取快照后收敛。
+
+Redis SCAN 和本地 backend cursor 不提供并发 exactly-once：
+
+- 同一 key 在一轮中可能重复；
+- 并发删除或索引移动可能使本轮漏过 key；
+- 并发新增 key 可能到下一轮才被看到。
+
+V1 只要求重复处理安全，并由后续 round 重新覆盖。扫描发现不是删除授权；最终是否删除由 Executor 对完整 Location 快照的条件 CAS 决定。
+
+设某 Instance 有 `N` 个 Block、平均每个 Block 有 `L` 个 Location，则一轮判定成本约为 `O(N + N*L)`。`scan_batch_size` 是 backend hint，不保证 Local backend 的单 shard 返回量严格受限。
+
+设 active round 耗时为 `S`、cooldown 为 `P`，正常候选的最坏发现时间约为：
+
+```text
+candidate eligibility delay + S + P
+```
+
+WRITING 的 eligibility delay 是 grace；普通 SERVING storage-missing 一旦进入扫描即具备资格。默认 WRITING grace 和 `P` 都为 24 小时，因此该能力定位为最终收敛，不提供分钟级 SLA。SCAN 并发遗漏、target 裁剪、backend/探测错误和全部在途槽位卡住都可能继续延长时间。
+
+## 4. 详细设计
+
+### 4.1 无副作用 authoritative scan
+
+GC 不能直接复用在线 `GetLocations()`：
+
+- Local/Dummy backend 的读取会更新 LRU 或 revisit 统计；
+- dual-backend Running 状态下，现有 `ListKeys()` 可能扫描可淘汰的 hot cache，而不是完整 persistent metadata。
+
+V1 对 GC 暴露一个合并的维护接口，避免 GC 自己拼接 List 和 Get：
+
+```cpp
+struct MaintenanceScanBatch {
+    std::string next_cursor;
+    KeyVector keys;
+    CacheLocationMapVector locations;
+    std::vector<ErrorCode> location_results;
+};
+
+ErrorCode MetaIndexer::ScanLocationsForMaintenance(
+    RequestContext *request_context,
+    const std::string &cursor,
+    size_t limit,
+    MaintenanceScanBatch &out) noexcept;
+```
+
+接口契约：
+
+1. key 和 Location 都读取 authoritative backend；dual-backend 时不能只看 hot cache。
+2. 读取不更新 access/LRU/revisit，也不向 hot cache 回填。
+3. `keys`、`locations` 和 `location_results` 必须按下标对齐；shape 不一致视为整批错误，不做删除。
+4. Scan 级错误时不推进 cursor；单 key 已不存在或读取失败时跳过该 key，cursor 正常推进，由下一轮再覆盖。
+5. `limit` 只作为 backend hint；调用方不能假设实际数量一定不超过该值。
+
+实现上，该契约下沉到 backend 的合并扫描接口。Redis/AsyncRedis 组合 authoritative `SCAN` 和只读反序列化；Local/Dummy 在底层容器中直接复制 Location，不调用在线 `Lookup/Touch`。backend manager 在 dual-backend 模式下强制选择 persistent backend，在线读取接口保持不变。
+
+### 4.2 长期 orphan WRITING 判定
+
+Location 同时满足以下条件才进入请求：
+
+1. `status == CLS_WRITING`；
+2. `instance_id`、`block_key` 和 `location_id` 均有效；
+3. `create_time` 可解析，且不晚于当前时间；
+4. `now - create_time >= orphan_writing_grace_period`。
+5. `MigrationManager::HasActiveCopyTargetLocation(instance_id, block_key, location_id) == false`。
+
+任一条件不确定都 fail-closed 跳过，不尝试删除。V1 不逐 Location 记录拒绝原因，避免全量扫描制造高基数指标和日志；只对 batch shape、backend 读取等操作异常计数。
+
+`create_time` 使用现有微秒时间戳。实现先判断 `now_us >= create_time`，再用有符号或检查过的 duration 计算 age，不能用无符号减法掩盖时钟回拨。
+
+V1 不查询 `WriteLocationManager`。理由是：
+
+- 服务端 write session 硬上限为 30 分钟；
+- grace 最小为 1 小时，在 write session 硬上限之外保留 30 分钟安全余量；生产默认仍为 24 小时；
+- 在健康进程中，超过 session 上限的 WRITING 已不再是合法活跃写入；
+- HA 后旧 session 本来也不在新 leader 的内存中；
+- 扫描后的并发 Finish 由最终条件 CAS 保护。
+
+上述推论只适用于 client write session。#209 的 Migration Copy 也会创建 `CLS_WRITING`，其合法生命周期不受 30 分钟 write-session 上限约束，因此必须额外查询活跃 Copy reservation。该查询按 `(instance_id, block_key, location_id)` 隔离；Prepare 尚未绑定 location ID 时，#209 已定义为临时保护该 block 的 WRITING 目标。GC 不复制这套状态，只消费查询结果。
+
+1 小时下限用于覆盖 write-session timeout 轮询、正常调度抖动和 AsyncRedis 的正常异步刷写窗口；若 metadata 异步写入超过 30 分钟仍未收敛，视为公共 backend 一致性故障，GC V1 不增加专用 `Sync/fence`。24 小时默认值不是为了容纳合法慢写，而是第一版自动删除路径的保守爆炸半径，为监控和人工干预留出更充足时间。
+
+`create_time` 和 GC 的 `now` 可能来自不同机器的 wall clock。V1 假设集群 NTP 正常，秒级偏差相对至少 1 小时的 grace 可接受；时间回拨或未来时间一律跳过。若后续需要消除该假设，应让创建和判断使用同一个 authoritative time source。
+
+### 4.3 普通 SERVING 的 storage-missing 判定
+
+GC 只探测 `status == CLS_SERVING` 且 storage type 已知的普通 Location，明确排除 EventReport。每个 scan batch 内先解析 Location spec URI，再按 `(storage unique name, storage type)` 聚合。调用前确认该 storage 仍已注册且 backend type 与 Location 一致；随后按最多 512 个 URI 分块调用 `MightExist()`，限制一次调用和 `DataStorageManager` 共享锁的持有范围。一个 Location 的多个 spec 可以分布在不同分块，结果按原下标映射回 Location。
+
+`MightExist()` 的契约是低延迟且允许 false positive：backend 无法低成本或确定判断时返回 `true`，`false` 必须表示明确 missing。GC 的判定为：
+
+- 任一可解析 spec 返回 `false`：整个 Location 失效；
+- 全部返回 `true`：保留；其中可以包含 backend 的 unknown/unsupported；
+- URI 无法解析、storage 不存在、结果长度不匹配或调用抛异常：该部分视为 unknown，不单独授权删除；若同一 Location 的其他 spec 被明确判定 missing，仍可判为失效；
+- 没有任何可探测 spec：跳过。
+
+storage 未注册记录 `might_exist_storage_not_found`，backend type 不一致记录 `might_exist_storage_type_mismatch`；两者均视为 unknown，不调用探测。结果长度必须与当前分块的输入 URI 数完全一致，否则该分块结果不可关联，记录 `might_exist_shape` 并丢弃；其他分块和 storage 继续。调用异常记录 `might_exist_exception`，不影响同 batch 的其他 storage。GC 不逐 URI 输出正常 missing 日志，避免全量扫描制造日志压力。
+
+该规则删除整个 Location，而不是只删 missing spec。原因是一个 Location 的 specs 共同描述同一份可用缓存，任一必需 spec 丢失后该 Location 已无法完整服务；Executor 仍会 best effort 删除其余 URI，再完成 metadata CAD。NFS/HF3FS 等未覆写 `MightExist()` 的 backend 默认返回全 `true`，因此不会因为 GC 引入同步 I/O 或误删；具备低成本明确判定能力的 backend 才实际启用该规则。
+
+storage-missing 往往由节点批量退出触发，可能在短时间产生大量物理删除。任务会进入与 Reclaimer 共享的 Executor；如果后端 `Delete()` 缺少 I/O timeout，大量慢删除可能占用共享 worker，并通过 `DataStorageManager` 锁竞争延长 storage cleanup。V1 不能改为 metadata-only：同一 Location 的其他 spec 可能仍存在，需要 best effort 释放。上线需按 Instance/Group 灰度，重点监控在途任务年龄、Executor/存储后端负载和 demotion 时延；物理 I/O timeout/cancel 与独立执行隔离仍是后续公共治理项。
+
+### 4.4 精确值条件化 Location 删除
+
+扫描结果只负责发现，不能直接授权删除。当前基线的 `CacheLocationDelRequest` 已提供与 `location_ids` 平行的可选快照值：
+
+```cpp
+struct CacheLocationDelRequest {
+    std::string instance_id;
+    std::vector<int64_t> block_keys;
+    std::vector<std::vector<std::string>> location_ids;
+    std::chrono::microseconds delay{std::chrono::seconds(0)};
+    std::vector<std::vector<std::string>> expected_location_values;
+    bool metadata_only{false};
+    bool authoritative_read{false};
+};
+```
+
+GC 对 WRITING 和 SERVING 两类 target 都设置扫描时的 `CacheLocation::ToJsonString()`，普通 storage 删除保持 `metadata_only=false`，并设置 `authoritative_read=true`。Executor 对每个 target：
+
+1. 从 persistent backend 重新读取当前 Location，不以 dual-backend 的 hot-cache 命中为删除前提；
+2. Location 不存在，或完整序列化值与扫描快照不一致时跳过；
+3. 条件 CAS 持有 MetaIndexer shard lock 后，从 persistent backend 重新读取完整 key 并刷新 hot cache，避免 cache miss/stale 令 target 永久 no-op，也避免只回填单个 Location 隐藏同 Block 的其他字段；
+4. 构造“当前状态和完整 expected value -> `CLS_DELETING`”的条件 CAS；
+5. 只把 CAS 成功的精确子集交给现有 Sync、物理删除和 metadata CAD。
+
+如果并发 `FinishWriteCache` 已把 WRITING 改为 SERVING，或 SERVING 的 URI、create time 等字段被刷新，完整值比较会失败；如果 Reclaimer 同时提交同一 target，也只有一个 CAS winner。精确值条件比单独的 `expected_status` 更强，并允许一个请求同时包含 WRITING 与 SERVING 候选。
+
+未设置 `expected_location_values`、未启用 `authoritative_read` 的现有调用方保持当前行为。authoritative read 只在候选 admission/CAS 阶段触碰被选中的完整 key；全量 scan 本身仍不回填 hot cache。V1 不新增 GC 专用删除状态机，也不改变物理删除和最终 CAD 的顺序。
+
+#234 的 `SubmitAsync()` 首次入队成功后立即返回；Get/CAS/Sync、delay 和物理删除都在 Executor 中完成。精确值筛选和 CAS 已由 #233 落在共享 `PrepareDeleteTaskImpl`/MetaSearcher RMW 中，同步与异步入口复用同一 admission 语义。
+
+### 4.5 有界 Future 窗口、pending 去重和结果
+
+GC 同一时刻最多持有 `max_inflight_delete_requests` 个已接受请求的 `std::future<PlanExecuteResult>`：
+
+- `SubmitAsync()` 只有返回 `accepted=true` 且 valid Future 时才保存 Future，并建立最终请求对应的 pending target；
+- `accepted=false`、invalid Future、accepted/Future 契约不一致或抛异常均不建立 Future、pending 或其他本地状态；
+- 每个 tick 先非阻塞轮询全部 Future，终态或异常只释放该任务的槽位和 pending；
+- 未 ready 的 Future 继续占用槽位，但只在窗口全部占满时停止后续 Scan 和 Submit；
+- pending key 包含 `instance_id`，相同 block/location 在不同 Instance 中互不影响；
+- 空请求不进入 Executor。
+
+pending 集合不承担删除授权，只用于覆盖请求 accepted 到 Executor CAS 之间的窗口，以及 Redis SCAN 可能在同一 round 重复返回 key 的情况。最终并发安全仍由 Executor 的完整 expected value 条件 CAS 保证。窗口和单请求 target 上限共同限定 pending 集合大小，不新增 bytes credit、deadline 或跨进程恢复。
+
+V1 沿用现有 `PlanExecuteResult` 语义，不新增 PARTIAL 或 per-target result：
+
+- `EC_OK`：任务按现有 Executor 语义完成，也可能表示 target 已不存在或条件不匹配而 no-op；
+- `EC_PARTIAL_OK`：物理删除或 metadata CAD 仅部分成功，是明确终态；记录结果并释放对应槽位；
+- 其他 ErrorCode：删除链路明确失败，记录 `delete_result_count{status}`，并输出包含 round、Instance、target 数和错误信息的 warning；
+- Future exception/invalid：Executor contract error。
+
+GC 不因单次失败停止后续 round，也不自动重试同一请求。仍满足 WRITING 或 storage-missing 判定的对象由后续 full scan 再次发现；已经进入 DELETING 的失败对象留给未来 DELETING reconciliation 处理。
+
+## 5. 生命周期与并发
+
+### 5.1 启动和重复调用
+
+- `enabled=false`：不创建 GC `LoopThread`。
+- `enabled=true`：只构造 GC；首次 leader recovery 成功后调用 `Start()`。
+- `Start()` 在 `LoopThread` 已运行时幂等；线程已 join 后再次调用会创建新的 `LoopThread`、清空旧 cursor，并从新 round 开始。
+- `RequestStop()` 和 `Join()` 均幂等。
+- `enabled=true` 时配置非法或构造依赖缺失，服务初始化失败，不静默降级为 disabled；`enabled=false` 时不校验未使用的 GC 运行参数。
+- leader promotion 时线程创建失败，`Start()` 返回错误，本轮不 Resume Reclaimer、也不开放 leader-only 请求。
+- 某个 Instance 的 Indexer 尚未 recover 时，本轮跳过并告警，由下一轮覆盖，不让整个服务退出。
+
+### 5.2 Leader recovery 和 demotion
+
+升主顺序：
+
+```text
+RegistryManager::DoRecover()
+  -> CacheManager::DoRecover()
+  -> CacheGarbageCollector::Start()
+  -> Reclaimer.Resume()
+  -> MigrationManager.Start()
+  -> enable leader-only requests
+```
+
+降级采用“先发停止信号，后 join”的顺序：
+
+```text
+GC.RequestStop() + Reclaimer.Pause()
+  -> DisableLeaderOnlyRequests()
+  -> WaitForAllLeaderOnlyRequestsToComplete()
+  -> GC.Join()
+  -> MigrationManager.Stop()
+  -> CacheManager::DoCleanup()
+  -> RegistryManager::DoCleanup()
+```
+
+`RequestStop()` 只设置 GC stop 标志，并调用 `LoopThread::RunOnce()` 唤醒可能处于 tick/cooldown 等待的循环；回调看到 stop 后立即返回。该操作不 join，不能在关闭 leader 请求之前阻塞。`Join()` 随后调用 `LoopThread::Stop()` 完成 join，且必须位于 MigrationManager Stop 和 CacheManager/Registry cleanup 之前，保证 GC 不再读取活跃 Copy reservation 或其他依赖。V1 不修改公共 `LoopThread` 接口。
+
+`LoopThread` 回调在每次 Registry、Scan、DataStorage 探测分块和 SubmitAsync 前检查 stop，并在每个 `MightExist()` 分块返回后再次检查。已经进入的 Registry/Scan/MightExist 同步调用不能强制取消，`Join()` 会沿用底层现有 timeout/retry 语义，慢调用可能相应延长 demotion。Executor admission 已异步化，不阻塞 GC 的 `Join()`；GC 在 stop 时只丢弃本地 Future handle 和 pending 集合，不等待端到端删除 Future。`Join()` 只保证扫描回调不再访问 Registry、MetaIndexerManager、DataStorageManager 等依赖，不为物理删除建立 drain 屏障。
+
+降级时若 GC 已提交删除，只丢弃本地 Future handle，不取消 Executor 中的任务。该任务与 Reclaimer 已提交任务使用相同的 best-effort detach 语义：cleanup 前完成则正常收敛；若已完成进入 `CLS_DELETING` 的 CAS，但后续重新获取 MetaIndexer、访问 DataStorage 或执行 metadata CAD 时依赖已被 cleanup，则 Future 可能以错误终态结束并留下长期 `CLS_DELETING`。V1 优先保证物理删除不会阻塞 leader demotion，不引入统一 Executor drain、任务资源 lease、跨 leader generation 或 DELETING 补偿；这些能力作为独立生命周期治理工作处理。
+
+### 5.3 进程停止和析构
+
+`CacheManager` 析构时首先停止并 join GC，再拆除 Registry、MetaIndexer、Executor、metrics 等 GC 依赖。当前未引入 GC 时的 WLM/Reclaimer shared ownership 顺序不是既存 UAF；本设计不借 GC PR 重排无关组件。
+
+Stop 通过 GC stop flag、`LoopThread::RunOnce()` 和最终 `LoopThread::Stop()` 打断 tick sleep 与 round cooldown。若回调正在 Registry/metadata/DataStorage 同步调用中，`Stop()` 需要等待当前调用按底层现有 timeout/retry 语义返回；返回后不会继续下一个探测分块。若底层缺少有限返回上界，进程停止或 demotion 可能被延长。
+
+## 6. 异常处理
+
+| 场景 | V1 行为 |
+|---|---|
+| Registry snapshot 失败 | 丢弃不完整快照，普通 tick 后重试 |
+| Instance/Indexer 不存在 | 跳过当前 Instance，下一轮重新发现 |
+| Scan 失败 | 不推进 cursor，普通 tick 后重试 |
+| key 在 SCAN 后被并发删除（`EC_NOENT`） | 正常跳过，不计入 operation error |
+| 单 key Location 读取失败 | 跳过该 key、记录 `scan_key` error，下一轮覆盖 |
+| batch shape 不一致 | 整批拒绝，不提交 |
+| Location 字段或时间非法 | fail-closed 跳过 |
+| Location 是活跃 Migration Copy 目标 | 正常跳过；任务释放 reservation 后，若仍为 WRITING 则由后续 round 重新判断 |
+| EventReport SERVING | 不进入普通 storage-missing 规则，由独立 reconciliation 需求处理 |
+| URI 无法解析或无可探测 spec | 视为 unknown，单独不授权删除 |
+| storage 未注册 | 视为 unknown，不调用探测，记录 `might_exist_storage_not_found` |
+| backend type 与 Location 不一致 | 视为 unknown，不调用探测，记录 `might_exist_storage_type_mismatch` |
+| `MightExist()` 返回长度不一致 | 丢弃当前 URI 分块结果，记录 `might_exist_shape`；其他分块继续 |
+| `MightExist()` 抛异常 | 当前及后续分块视为 unknown，记录 `might_exist_exception`；已完成分块的明确结果保留，其他 storage 继续 |
+| 空候选 | 不调用 Executor |
+| SubmitAsync rejected | 记录 `submit_rejected` error，不占槽位、不建立 pending；cursor 不回滚，后续 round 重新发现 |
+| SubmitAsync 直接抛异常 | 记录 `submit_exception` error，不占槽位、不建立 pending；cursor 不回滚 |
+| accepted/Future 不一致 | 记录 `submit_contract` error，不占槽位、不建立 pending；cursor 不回滚 |
+| 条件不匹配或 CAS loser | 合法 no-op，不告警为数据错误 |
+| Future 返回错误 | 释放对应槽位和 pending、记录结果，后续 round 继续 |
+| Future 长期未完成 | 保留其槽位和 pending、持续上报最老 age；其他槽位仍可推进，V1 不超时释放 |
+| stop 期间存在 Future | 丢弃本地 handle 和 pending，不取消或等待底层任务；任务 best effort 继续，CAS 后失败可能留下 `CLS_DELETING` |
+
+所有错误路径都必须经过 `scan_interval_ms` 或 cooldown，不能形成零间隔重试。
+
+## 7. 可观测性
+
+V1 只保留能回答“是否在扫描、发现了什么、删除是否卡住”的核心指标：
+
+| 指标 | 类型 | 说明 |
+|---|---|---|
+| `cache_gc.scan_round_count` | Counter | 完整 round 完成次数 |
+| `cache_gc.scan_key_count` | Counter | 扫描 Block 数 |
+| `cache_gc.candidate_count{reason}` | Counter | 候选数；V1 reason 为 `orphan_writing` 或 `storage_missing` |
+| `cache_gc.delete_target_count` | Counter | 实际提交的 Location 数 |
+| `cache_gc.delete_result_count{status}` | Counter | Future 终态 |
+| `cache_gc.operation_error_count{stage}` | Counter | Registry/scan/submit/future 等异常；并发 `EC_NOENT`、条件不匹配和 CAS loser 不计入 |
+| `cache_gc.inflight_delete_count` | Gauge | 当前在途删除请求数 |
+| `cache_gc.inflight_delete_age_ms` | Gauge | 最老在途 Future 的年龄，无任务时为 0 |
+| `cache_gc.round_duration_ms` | Gauge | 最近一个 active round 耗时 |
+
+round 和结果日志包含 `round_id`、`instance_id`、target 数、result；扫描错误日志额外包含 cursor 和 error stage。正常逐 key 扫描不打 INFO，block/location 明细只在诊断级日志中输出，避免 GC 自身制造日志压力。
+
+上述固定指标和带 `reason/status/stage` 标签的指标族同时进入本地 registry、Prometheus 和 KMonitor；KMonitor 周期上报直接遍历 registry 中已 touched 的 series，避免另维护一份易遗漏的标签枚举。
+
+## 8. 测试方案
+
+### 8.1 单元测试
+
+1. disabled 不创建 `LoopThread`；Start/RequestStop/Join 重复调用安全，重新 Start 从 base cursor 开始。
+2. 每个 tick 最多调用一次 Scan；cursor、Instance 推进和 round cooldown 正确。
+3. Registry/Scan 失败按普通间隔重试，不推进错误 cursor，也不零间隔空转。
+4. maintenance scan 在 dual-backend 下读取 persistent metadata，不依赖 hot cache；Running 状态下即使候选 key 已从 hot cache 淘汰，Executor 仍会 authoritative re-read、刷新完整 key 并完成条件删除。
+5. Local/Dummy maintenance scan 不改变 LRU/access/revisit，也不回填 hot cache。
+6. 只有状态为 WRITING、字段有效且年龄达到 grace 的 Location 成为 orphan 候选；未来时间、解析失败和边界值 fail-closed。
+7. grace 配置不得小于 1 小时，默认值为 24 小时。
+8. 普通 SERVING 按 storage 批量探测，任一 spec 明确 missing 时选择整个 Location；全 true、无可探测 URI、storage 缺失/type 不符、shape 错误和异常均 fail-closed，EventReport 不进入该规则；单次探测不超过 512 URI。
+9. 请求保持 Instance 隔离，按 `(block_key, location_id)` 去重并受 batch target 上限约束；空请求不调用 Executor。
+10. GC 请求携带与 target 平行的完整序列化 Location；请求排队后 Finish、URI 刷新、DELETING 或 NOENT 均因 expected value 不匹配而不做物理删除。
+11. #209 活跃 Copy reservation 对应的 WRITING 目标不会成为候选；相同 location ID 在其他 Instance/Block 中不被误保护。
+12. GC 与另一个删除者同时提交同一 target 时只有一个 CAS winner。
+13. 有界窗口未满时一个慢 Future 不阻止其他 batch 提交，窗口占满后停止 Scan；Future 终态只释放自己的槽位和 pending，随后恢复扫描。
+14. RequestStop 能打断 sleep/cooldown，并在当前 DataStorage 探测分块返回后停止后续分块；活跃 maintenance scan 或探测返回前 Join 必须等待，未完成删除 Future 不参与 GC drain 并按 best-effort detach；CacheManager cleanup 会先停止 GC 扫描线程。
+15. 未设置 `expected_location_values`、未启用 `authoritative_read` 的现有 Executor 调用方行为不变。
+16. 并发删除导致的 `EC_NOENT` 不增加 operation error；SubmitAsync 直接抛异常归入 `submit_exception` 而不是 `tick_exception`。
+17. accepted 到 CAS 期间同一 Instance 的相同 target 被 pending 过滤；不同 Instance 的相同 block/location 不互相抑制；rejected、invalid 和空请求不留下 pending。
+
+测试使用注入时钟或回填旧 `create_time`，不通过放宽生产 grace 下限制造并发窗口。
+
+### 8.2 集成测试
+
+集成测试覆盖以下组合和场景：
+
+1. KVCM + Dummy metadata + NFS data storage：模拟进程重启后 session 丢失，回填超过 grace 的 WRITING，确认删除链路完成 metadata 清理，Block 可再次写入。
+2. 同一 Group 多 Instance 中，未到 grace 的 WRITING 不删除，只有过期 Instance 被处理。
+3. cached metadata 模式下通过 persistent backend 发现并清理 orphan；persistent-only/no-backfill 和 LRU 不变由 backend component test 单独验证。
+4. GC 开启期间执行真实 leader demotion，确认进程健康进入 standby，cleanup 完成后 scan round 不再增长。
+5. KVCM + Dummy metadata + Dummy data storage：完成 SERVING 后移除物理文件，不发起 Get，确认后台 `MightExist()` 发现并清理 metadata，Block 可再次写入。
+
+并发 Finish、真实 Executor backlog、慢 admission 和 Join 等需要精确控制时序的场景在 C++ component test 中验证，避免依赖不稳定的 wall-clock 或外部故障注入。
+
+NFS 只用于验证物理删除控制链路；Dummy 持久化文件用于构造和验证 metadata 最终清理。
+
+### 8.3 性能测试方法
+
+采用 matched A/B 和分层负载验证：
+
+1. 固定 binary、资源配额、keyspace、请求序列、目标 QPS、运行时长和随机种子，对比 GC disabled、GC enabled 但处于 cooldown，以及 GC enabled 且 active scan 三种场景；轮换执行顺序并重复运行，降低缓存预热和系统抖动影响。
+2. 分别构造无垃圾、少量/大量 orphan WRITING 和普通 SERVING，区分纯扫描、`MightExist()` 探测、候选判定和实际删除成本；对具备真实低成本探测的 backend 单独统计探测开销。
+3. 逐级扩大 keyspace，并组合不同 `scan_batch_size`、`scan_interval_ms`，观察 active round 的扫描吞吐和在线请求退化趋势。
+4. 让慢物理删除分别占用一个和全部在途槽位，验证部分槽位被占用时仍可推进、窗口满时停止扫描的反压行为。
+
+比较在线 Get/StartWrite/FinishWrite P50/P95/P99、Redis QPS/CPU/网络流量、KVCM CPU/RSS、active round 时长、每秒扫描 key 数和垃圾收敛时间，同时确认业务请求无新增失败、active-scan 场景确实产生扫描量。测试结果用于判断默认 batch/interval 是否可接受，以及 V2 是否需要动态 pacing、减少 metadata 读取量或引入索引化候选源。
+
+## 9. 验收标准
+
+1. disabled、standby 和 leader recovery 完成前不扫描、不提交。
+2. GC 能从 authoritative backend 完成全量 round，且扫描不改变业务访问统计。
+3. grace 最小 1 小时、默认 24 小时，在 30 分钟 write session 上限之外保留安全余量；判定异常时 fail-closed。
+4. 只有长期且不属于活跃 Migration Copy 的 WRITING，或被 backend 明确判定至少一个 spec missing 的普通 SERVING 进入删除请求；EventReport 和不确定探测结果不会被该规则删除。
+5. 并发 Finish、Location 刷新、Reclaimer 或重复 SCAN 由完整 expected Location value 的条件 CAS 安全仲裁。
+6. 在途删除请求不超过配置上限；单个慢任务不会暂停整个 GC，全部槽位占满时形成硬反压，空请求和错误不会形成提交风暴或 CPU 空转。
+7. 每轮完成后至少等待 `round_pause_ms`，不会持续重复全扫。
+8. demotion 时先停止新 leader 请求，再在 cleanup 前完成 GC 扫描线程 join；慢 maintenance metadata/DataStorage 探测可以延长 join。已接受的物理删除不参与 GC drain，但仍可能因共享 worker 或 DataStorageManager 锁竞争间接延长后续 cleanup。
+9. 未设置 `expected_location_values` 的现有 Executor 调用方保持兼容。
+10. 通用规则框架、索引化扫描、DELETING、EventReport reconciliation、TTL、闲置 Instance 和 Reclaimer/Finish 修复均未被隐式实现。
+
+## 10. 实现落点与配置
+
+### 10.1 主要修改文件
+
+| 文件 | 职责 |
+|---|---|
+| `kv_cache_manager/manager/cache_garbage_collector.h/.cc` | 复用 `common::LoopThread`，维护 round/cursor、固定 WRITING 判定、普通 SERVING 批量探测、Migration 活跃目标过滤、有界 Future/pending 和两阶段停止 |
+| `kv_cache_manager/manager/schedule_plan_executor.*` | 复用 #234 异步链路和 #233 的精确条件删除；为 maintenance 请求增加显式 authoritative admission 选项 |
+| `kv_cache_manager/manager/cache_manager.h/.cc` | 注入 Registry、MetaIndexer、DataStorage、Executor 等依赖，并管理 leader 启停和析构 |
+| `kv_cache_manager/meta/meta_indexer.h/.cc` | 合并的 maintenance scan、persistent re-read 与 shard-lock 内 cache refresh 接口 |
+| `kv_cache_manager/meta/meta_storage_backend*.h/.cc` | authoritative List/no-touch Location 读取，以及候选 key 的完整 persistent-to-cache refresh |
+| `kv_cache_manager/metrics/kmonitor_metrics_reporter.cc` | 注册并周期上报 GC 固定指标及带标签指标族 |
+| `kv_cache_manager/service/server_config.h/.cc` | GC 配置解析和校验 |
+| `kv_cache_manager/service/server.cc` | leader recovery/demotion 接线 |
+| `package/etc/default_server_config.conf`、`docs/configuration.md`、相关 BUILD | 配置、文档和构建目标 |
+| 对应 `manager/meta/service` 测试 | 第 8 章单元与集成测试 |
+
+V1 不修改 `write_location_manager.*`、`cache_reclaimer.*` 或 `migration_manager.*` 的状态机，也不新增 rule/source/admission/task-tracker 文件。
+
+公共 Redis command timeout 不作为 GC V1 的前置 PR；若现网验证确认 Redis 命令缺少有限返回上界，再由独立基础设施 PR 修改 `common/redis_client.*` 及相关测试，不混入 GC 主体 PR。
+
+### 10.2 V1 配置
+
+| 配置 | 默认值 | 说明 |
+|---|---:|---|
+| `kvcm.cache_gc.enabled` | `false` | 默认关闭，灰度开启 |
+| `kvcm.cache_gc.scan_interval_ms` | 1000 | 相邻 tick 的最小间隔 |
+| `kvcm.cache_gc.round_pause_ms` | 86400000 | 完成一个 full round 后的 cooldown |
+| `kvcm.cache_gc.scan_batch_size` | 256 | backend key 数 hint，同时作为单请求 target 上限 |
+| `kvcm.cache_gc.orphan_writing_grace_period_ms` | 86400000 | WRITING 自动清理 grace，必须不小于 3600000 ms |
+| `kvcm.cache_gc.max_inflight_delete_requests` | 2 | GC 在途删除请求硬上限，必须大于 0；每个请求最多包含 `scan_batch_size` 个 target |
+
+配置通过一个内聚的 `CacheGarbageCollector::Config` 传入。时间、batch 和在途请求上限必须为正，毫秒到内部 duration 的转换需要检查溢出。1 小时 grace 下限基于当前 1800 秒 write session 上限；若后续修改该协议上限，必须同步重新评估 GC grace 下限。
+
+## 11. 后续演进
+
+以下能力均不属于 V1，只有在真实场景或性能数据出现后再设计。
+
+### 11.1 扫描资源治理
+
+若 active full round 对 Redis 或在线延迟影响明显，可以增加：
+
+- 根据 keyspace 和目标 round 时长计算 inter-batch pacing；
+- scan budget、adaptive backoff 和大 Instance 公平调度；
+- 可中断的 Local shard cursor；
+- 动态并发窗口、bytes/Group 配额、deadline 和长期卡住告警。
+
+扩大并发窗口前必须结合共享 Executor worker/队列负载和线上指标评估；V1 的固定小窗口不承诺物理执行隔离。
+
+### 11.2 Candidate Source 和 Rule
+
+继续接入更多复杂垃圾类型时，再从当前两个固定判定中提取：
+
+- `FullMetadataScanSource` 或到期索引等 Candidate Source；
+- 只负责判定和前置条件的 Rule；
+- Location/Block target；
+- 复用同一生命周期和预算的 Dispatcher。
+
+WRITING 可增加按 `create_time` 排序的 ZSET，只查询到期 Location；TTL 可增加 expiry index。索引只负责发现候选，删除前仍要读取 authoritative metadata 并条件复核。双写原子性、状态出口清理、历史 backfill 和多 backend 兼容必须先解决。
+
+### 11.3 Probe 协议演进和 TTL
+
+V1 沿用 `MightExist()` 的保守布尔契约：`false` 是明确 MISSING，`true` 同时承载 AVAILABLE 与 UNKNOWN。若后续需要区分探测未就绪、超时和真实存在，可升级为显式三态 `AVAILABLE/MISSING/UNKNOWN`，但不能把 UNKNOWN 当作删除授权。
+
+Block TTL 需要先定义 TTL 写入、刷新、authoritative `expire_at`、并发写入竞争和条件 Block 删除。扫描不能刷新 TTL。
+
+### 11.4 长期 DELETING
+
+长期 DELETING 的安全恢复依赖 storage backend 校验 URI version/epoch，确认当前对象仍是 metadata 记录的同一代后才能重试释放。KVCM 单侧记录 epoch 不足以防止 URI 被复用。
+
+### 11.5 独立需求
+
+以下问题单独设计和交付：
+
+1. `WriteLocationManager` 使用 `(instance_id, block_key, location_id)` 索引，并关闭 Reclaimer/Finish settling race；
+2. 查询链路发现无效 Location 后的快速删除提交：复用 accepted 和端到端 Future，且不在查询线程同步执行 admission；
+3. 连续 N 周无流量的闲置 Instance 回收；
+4. GC task 持久化、lease/generation 和跨进程恢复；
+5. data storage I/O timeout/cancel；
+6. authoritative time source；
+7. EventReport snapshot/event 的后台 reconciliation；其 metadata-only、版本和所有权语义不能复用普通 storage 的物理删除规则。
+
+### 11.6 建议交付顺序
+
+1. **GC V1 PR**：本文定义的 full scan、固定 WRITING 与普通 SERVING storage-missing 判定、精确值条件删除、有界 Future/pending、leader 生命周期、指标和测试。
+2. **公共基础设施跟进（按需）**：若现网验证确认 Redis 命令缺少有限返回上界，再独立补齐 connect/auth/command/reconnect timeout 和坏连接淘汰。
+3. **独立正确性 PR**：WriteLocationManager Instance 隔离和 Reclaimer/Finish settling race。
+4. **后续 PR**：根据性能和业务优先级分别接入 pacing/index、显式三态 probe、TTL、EventReport 和 DELETING reconciliation。

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -4,7 +4,7 @@
 
 > **维护提示**：当模块的职责、依赖方向或调用关系发生变化，或新增/删除模块时，请同步更新本文档与文末的 Mermaid 图，并同步更新 [AGENTS.md](../../AGENTS.md) 中的缩略图。
 
-相关文档：[基本概念](basic_concepts.md)、[ReportEvent Snapshot URI 版本方案](report_event_snapshot_uri_version.md)、[高可用与选主机制](ha_leader_elector.md)、[CacheReclaimer 异步删除设计](cache_reclaimer_async_delete.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
+相关文档：[基本概念](basic_concepts.md)、[ReportEvent Snapshot URI 版本方案](report_event_snapshot_uri_version.md)、[高可用与选主机制](ha_leader_elector.md)、[CacheReclaimer 异步删除设计](cache_reclaimer_async_delete.md)、[后台扫描 GC 设计](cache_garbage_collector.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
 
 ---
 
@@ -32,7 +32,7 @@ KVCache Manager 采用中心化部署，负责 KVCache 的全局元数据管理�
 |---|---|---|
 | **入口** | `main.cpp` | 构造 `CommandLine` 并运行，唯一依赖 `service`。 |
 | **service** | `service/` | 接入层。`Server` 在启动时创建并串联几乎所有组件（整个服务的装配入口）；`*ServiceImpl`（meta/admin/debug）实现与传输无关的业务入口，`grpc_service/`、`http_service/` 是对应传输适配层，`util/` 负责 proto↔领域对象转换、调用守卫与访问日志。 |
-| **manager** | `manager/` | 编排层与业务核心。`CacheManager` 是中心门面，对外提供注册实例、查询/写入/删除 Cache、上报事件、容量回收与分层迁移等能力，并协调 `MetaSearcher`、`WriteLocationManager`、`DataStorageSelector`、`CacheReclaimer`、`MigrationManager`、`SchedulePlanExecutor` 等子组件。 |
+| **manager** | `manager/` | 编排层与业务核心。`CacheManager` 是中心门面，对外提供注册实例、查询/写入/删除 Cache、上报事件、容量回收、后台 GC 与分层迁移等能力，并协调 `MetaSearcher`、`WriteLocationManager`、`DataStorageSelector`、`CacheReclaimer`、`CacheGarbageCollector`、`MigrationManager`、`SchedulePlanExecutor` 等子组件。 |
 | **meta** | `meta/` | 元数据平面。`MetaIndexerManager` 按 `instance_id` 管理 `MetaIndexer`，维护 cache key → `CacheLocation` 的索引；元数据后端可插拔；`meta_search_cache` 做查询缓存。`CacheLocation` 是被广泛共享的核心类型。 |
 | **config** | `config/` | 配置模型 + 注册表 + HA 协调层。定义各类配置对象；`RegistryManager` 持久化实例注册信息；`CoordinationBackend` + `LeaderElector` 提供一主多备的分布式选主。 |
 | **data_storage** | `data_storage/` | 可插拔的 KVCache 数据存储后端。`DataStorageManager` 管理后端集合，`DataStorageBackend` 抽象存储介质，`DataStorageUri` 统一位置描述。 |
@@ -298,9 +298,13 @@ flowchart LR
     reclaim_task --> storage
 ```
 
-### 4.7 HA 故障转移
+### 4.7 后台 metadata GC
 
-`LeaderElector`（config）基于 `CoordinationBackend`（memory/file/redis）的分布式锁选主。`Server` 在成为 Leader 时调用 `CacheManager::DoRecover` 恢复状态，降级时调用 `DoCleanup` 清理运行时状态（正在进行的写入按失败处理）。Python `KvCacheManagerClient` 使用服务发现 URL 时，会在每次 Leader 刷新前重新选择一个 Manager 发现端点，避免把 Leader 查询入口固定在单个节点上。
+`CacheGarbageCollector` 只在 Leader 上运行，复用公共 `LoopThread`，按 Registry 快照和 backend cursor 串行扫描 authoritative metadata；扫描协调不占用共享的删除 worker。维护扫描不更新在线 LRU/revisit，也不向 local hot cache 回填。V1 识别超过 grace、且不属于活跃 Migration Copy 目标的 `CLS_WRITING`，并对普通 `CLS_SERVING` Location 按 storage 批量调用低成本 `MightExist()`，任一 spec 明确 missing 时选择整个 Location；EventReport 和探测不确定项均跳过。两类候选都通过 `SchedulePlanExecutor::SubmitAsync` 提交扫描时的完整序列化 Location，由 Executor worker 重新读取并以精确值条件 CAS 仲裁并发 Finish、Location 刷新和 Reclaimer。GC 使用固定小窗口管理在途 Future，并以 Instance-aware pending target 覆盖 accepted 到 CAS 的重复窗口；每 tick 最多提交一个请求，窗口满后停止扫描，完整 round 后进入长 cooldown。详细边界见 [后台扫描 GC 设计](cache_garbage_collector.md)。
+
+### 4.8 HA 故障转移
+
+`LeaderElector`（config）基于 `CoordinationBackend`（memory/file/redis）的分布式锁选主。`Server` 在成为 Leader 时调用 `CacheManager::DoRecover` 恢复状态，随后启动 GC、恢复 Reclaimer、启动 MigrationManager 并开放 leader-only 请求。降级时先通知 GC/Reclaimer 停止新工作并关闭、排空 leader-only 请求，再 join GC、停止 MigrationManager，最后调用 `DoCleanup` 清理运行时状态（正在进行的写入按失败处理）。Python `KvCacheManagerClient` 使用服务发现 URL 时，会在每次 Leader 刷新前重新选择一个 Manager 发现端点，避免把 Leader 查询入口固定在单个节点上。
 
 ---
 

--- a/integration_test/cache_garbage_collector/BUILD
+++ b/integration_test/cache_garbage_collector/BUILD
@@ -1,0 +1,15 @@
+package(default_visibility = ["//integration_test/cache_garbage_collector:__subpackages__"])
+
+py_test(
+    name = "cache_garbage_collector_test",
+    srcs = ["cache_garbage_collector_test.py"],
+    data = [
+        "//kv_cache_manager:kv_cache_manager_bin",
+    ],
+    tags = ["no-remote-exec"],
+    deps = [
+        "//integration_test/admin_service:http_interface_test",
+        "//integration_test/meta_service:http_interface_test",
+        "//integration_test/testlib:test_base",
+    ],
+)

--- a/integration_test/cache_garbage_collector/cache_garbage_collector_test.py
+++ b/integration_test/cache_garbage_collector/cache_garbage_collector_test.py
@@ -1,0 +1,442 @@
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+import os
+import time
+import unittest
+from urllib.parse import urlparse
+
+from integration_test.admin_service.http_interface_test import (
+    AdminServiceHttpClient,
+)
+from integration_test.meta_service.http_interface_test import (
+    MetaServiceHttpClient,
+)
+from integration_test.testlib.test_base import TestBase
+
+
+class CacheGarbageCollectorTest(TestBase, unittest.TestCase):
+    """End-to-end coverage for background Location collection."""
+
+    _GRACE_MS = 3_600_000
+
+    def setUp(self):
+        self.init_default()
+        self._admin_client, self._client = self._get_manager_clients()
+        self._trace_id = "cache_gc_e2e"
+        self._storage_name = "cache_gc_nfs"
+        self._group_name = "cache_gc_group"
+        self._block_key = 101
+
+    def tearDown(self):
+        self._admin_client.close()
+        self._client.close()
+        self.cleanup()
+
+    def test_orphan_writing_is_collected_after_restart(self):
+        """Only the expired orphan is deleted after write sessions are lost."""
+        self._create_topology()
+
+        instance_ids = ("cache_gc_instance_a", "cache_gc_instance_b")
+        for instance_id in instance_ids:
+            self._register_instance(instance_id)
+            response = self._start_write(instance_id, self._block_key)
+            self.assertTrue(response.get("locations"))
+
+        # Restart loses both in-memory write sessions. Backdate only instance A
+        # in the authoritative dummy file so instance B remains inside grace.
+        self.worker_manager.stop_worker(0)
+        self._backdate_persisted_writing(instance_ids[0], self._block_key)
+        self.assertTrue(
+            self.worker_manager.start_worker(
+                0,
+                **{
+                    "kvcm.cache_gc.enabled": "true",
+                    "kvcm.cache_gc.scan_interval_ms": 25,
+                    "kvcm.cache_gc.round_pause_ms": 100,
+                    "kvcm.cache_gc.scan_batch_size": 8,
+                    "kvcm.cache_gc.orphan_writing_grace_period_ms": self._GRACE_MS,
+                    "kvcm.cache_gc.max_inflight_delete_requests": 2,
+                },
+            )
+        )
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_clients()
+
+        self._create_topology()
+        for instance_id in instance_ids:
+            self._register_instance(instance_id)
+
+        self._wait_metric_at_least(
+            "cache_gc.delete_result_count",
+            1,
+            tags={"status": "0"},
+            timeout_s=10,
+        )
+
+        # The expired location in A was removed, so the same block can receive
+        # a fresh location. B has the same block key but a young WRITING
+        # location and therefore remains blocked.
+        expired_response = self._start_write(instance_ids[0], self._block_key)
+        self.assertTrue(
+            expired_response.get("locations"),
+            "expired orphan WRITING should be removed and become writable",
+        )
+        young_response = self._start_write(instance_ids[1], self._block_key)
+        self.assertFalse(
+            young_response.get("locations"),
+            "young WRITING in another instance must not be collected",
+        )
+        self.assertEqual(
+            1,
+            self._metric_value("cache_gc.delete_target_count"),
+            "only the expired instance should enter the delete request",
+        )
+
+        # Exercise the real leader-demotion wiring while GC is enabled. The
+        # worker must remain healthy as a standby and completed rounds must stop
+        # advancing after GC has been joined and metadata cleanup has run.
+        self._admin_client.update_leader_elector_config(
+            {
+                "trace_id": f"{self._trace_id}_demote_config",
+                "campaign_delay_time_ms": 100_000,
+            }
+        )
+        self._admin_client.leader_demote(
+            {"trace_id": f"{self._trace_id}_demote"}
+        )
+        self._wait_until_standby()
+        rounds_after_demote = self._metric_value("cache_gc.scan_round_count")
+        time.sleep(0.3)
+        self.assertEqual(
+            rounds_after_demote,
+            self._metric_value("cache_gc.scan_round_count"),
+            "GC rounds must stop after leader demotion",
+        )
+
+    def test_cached_metadata_gc_uses_persistent_backend(self):
+        """Dual-backend GC finds and removes an orphan through persistent metadata."""
+        self._create_topology(meta_storage_type="cached")
+        instance_id = "cache_gc_cached_instance"
+        self._register_instance(instance_id)
+        response = self._start_write(instance_id, self._block_key)
+        self.assertTrue(response.get("locations"))
+
+        self.worker_manager.stop_worker(0)
+        self._backdate_persisted_writing(instance_id, self._block_key)
+        self.assertTrue(
+            self.worker_manager.start_worker(
+                0,
+                **{
+                    "kvcm.cache_gc.enabled": "true",
+                    "kvcm.cache_gc.scan_interval_ms": 25,
+                    "kvcm.cache_gc.round_pause_ms": 100,
+                    "kvcm.cache_gc.scan_batch_size": 8,
+                    "kvcm.cache_gc.orphan_writing_grace_period_ms": self._GRACE_MS,
+                    "kvcm.cache_gc.max_inflight_delete_requests": 2,
+                },
+            )
+        )
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_clients()
+
+        self._create_topology(meta_storage_type="cached")
+        self._register_instance(instance_id)
+        self._wait_metric_at_least(
+            "cache_gc.delete_result_count",
+            1,
+            tags={"status": "0"},
+            timeout_s=10,
+        )
+
+        rewritten = self._start_write(instance_id, self._block_key)
+        self.assertTrue(
+            rewritten.get("locations"),
+            "persistent orphan should be collected in cached metadata mode",
+        )
+
+    def test_missing_serving_data_is_collected_without_query(self):
+        """A missing ordinary SERVING Location is found by the background probe."""
+        self.worker_manager.stop_worker(0)
+        self.assertTrue(
+            self.worker_manager.start_worker(
+                0,
+                **{
+                    "kvcm.cache_gc.enabled": "true",
+                    "kvcm.cache_gc.scan_interval_ms": 25,
+                    "kvcm.cache_gc.round_pause_ms": 100,
+                    "kvcm.cache_gc.scan_batch_size": 8,
+                    "kvcm.cache_gc.orphan_writing_grace_period_ms": self._GRACE_MS,
+                    "kvcm.cache_gc.max_inflight_delete_requests": 2,
+                },
+            )
+        )
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_clients()
+
+        self._create_topology(data_storage_type="dummy")
+        instance_id = "cache_gc_serving_instance"
+        self._register_instance(instance_id)
+        response = self._start_write(instance_id, self._block_key)
+        locations = response.get("locations", [])
+        self.assertEqual(1, len(locations))
+        self._touch_location_files(locations)
+        self._finish_write(
+            instance_id,
+            response["write_session_id"],
+            len(locations),
+        )
+        self._remove_location_files(locations)
+
+        # Do not issue GetCacheLocation: cleanup must be driven by GC rather
+        # than the existing query-path MightExist pruning.
+        self._wait_metric_at_least(
+            "cache_gc.candidate_count",
+            1,
+            tags={"reason": "storage_missing"},
+            timeout_s=10,
+        )
+        self._wait_metric_at_least(
+            "cache_gc.delete_result_count",
+            1,
+            tags={"status": "0"},
+            timeout_s=10,
+        )
+        self.assertEqual(1, self._metric_value("cache_gc.delete_target_count"))
+
+        rewritten = self._start_write(instance_id, self._block_key)
+        self.assertTrue(
+            rewritten.get("locations"),
+            "missing SERVING metadata should be removed and become writable",
+        )
+
+    def _create_topology(
+        self, meta_storage_type="dummy", data_storage_type="nfs"
+    ):
+        metadata_uri = (
+            f"file://{self.get_workdir()}/cache_gc_metadata"
+        )
+        if meta_storage_type == "cached":
+            metadata_uri += "?persistent_type=dummy&cache_type=local"
+        storage_spec = {
+            "root_path": os.path.join(
+                self.get_workdir(), self._storage_name
+            )
+            + "/",
+        }
+        storage_type_id = 4
+        if data_storage_type == "dummy":
+            storage_spec["key_count_per_file"] = 1
+            storage_type_id = 6
+        self._admin_client.add_storage(
+            {
+                "trace_id": self._trace_id,
+                "storage": {
+                    "global_unique_name": self._storage_name,
+                    data_storage_type: storage_spec,
+                },
+            }
+        )
+        self._admin_client.create_instance_group(
+            {
+                "trace_id": self._trace_id,
+                "instance_group": {
+                    "name": self._group_name,
+                    "storage_candidates": [self._storage_name],
+                    "global_quota_group_name": "cache_gc_quota",
+                    "max_instance_count": 8,
+                    "quota": {
+                        "capacity": 1024 * 1024,
+                        "quota_config": [
+                            {
+                                "storage_type": storage_type_id,
+                                "capacity": 1024 * 1024,
+                            }
+                        ],
+                    },
+                    "cache_config": {
+                        "reclaim_strategy": {
+                            "storage_unique_name": self._storage_name,
+                            "reclaim_policy": 1,
+                            "trigger_strategy": {"used_percentage": 2.0},
+                            "delay_before_delete_ms": 0,
+                        },
+                        "data_storage_strategy": 2,
+                        "meta_indexer_config": {
+                            "max_key_count": 128,
+                            "mutex_shard_num": 16,
+                            "meta_storage_backend_config": {
+                                "storage_type": meta_storage_type,
+                                "storage_uri": metadata_uri,
+                            },
+                            "meta_cache_policy_config": {
+                                "capacity": 1024 * 1024,
+                                "type": "LRU",
+                            },
+                            "persist_metadata_interval_time_ms": 0,
+                        },
+                    },
+                    "version": 1,
+                },
+            }
+        )
+
+    def _register_instance(self, instance_id):
+        self._client.register_instance(
+            {
+                "trace_id": f"{self._trace_id}_{instance_id}",
+                "instance_group": self._group_name,
+                "instance_id": instance_id,
+                "block_size": 128,
+                "model_deployment": {
+                    "model_name": "cache_gc_model",
+                    "dtype": "FP8",
+                    "use_mla": False,
+                    "tp_size": 1,
+                    "dp_size": 1,
+                    "pp_size": 1,
+                },
+                "location_spec_infos": [{"name": "tp0", "size": 1024}],
+            }
+        )
+
+    def _start_write(self, instance_id, block_key):
+        return self._client.start_write_cache(
+            {
+                "trace_id": f"{self._trace_id}_{instance_id}_{block_key}",
+                "instance_id": instance_id,
+                "block_keys": [block_key],
+                "token_ids": [block_key + 100],
+                "write_timeout_seconds": 1800,
+            }
+        )
+
+    def _finish_write(self, instance_id, write_session_id, location_count):
+        return self._client.finish_write_cache(
+            {
+                "trace_id": f"{self._trace_id}_{instance_id}_finish",
+                "instance_id": instance_id,
+                "write_session_id": write_session_id,
+                "success_blocks": {
+                    "bool_masks": {"values": [True] * location_count},
+                },
+            }
+        )
+
+    @staticmethod
+    def _touch_location_files(locations):
+        for location in locations:
+            for spec in location.get("location_specs", []):
+                path = urlparse(spec["uri"]).path
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "a", encoding="utf-8"):
+                    pass
+
+    @staticmethod
+    def _remove_location_files(locations):
+        for location in locations:
+            for spec in location.get("location_specs", []):
+                path = urlparse(spec["uri"]).path
+                if os.path.exists(path):
+                    os.remove(path)
+
+    def _backdate_persisted_writing(self, instance_id, block_key):
+        path = os.path.join(
+            self.get_workdir(), f"cache_gc_metadata_{instance_id}"
+        )
+        self.assertTrue(os.path.exists(path), f"metadata file missing: {path}")
+        with open(path, "r", encoding="utf-8") as source:
+            persisted = json.load(source)
+
+        fields = json.loads(persisted[str(block_key)])
+        location_fields = [
+            name for name in fields if name.startswith("L#")
+        ]
+        self.assertEqual(1, len(location_fields))
+        location = json.loads(fields[location_fields[0]])
+        self.assertEqual(2, location["status"])
+        location["create_time"] = int(time.time() * 1_000_000) - (
+            self._GRACE_MS + 60_000
+        ) * 1000
+        fields[location_fields[0]] = json.dumps(
+            location, separators=(",", ":")
+        )
+        persisted[str(block_key)] = json.dumps(
+            fields, separators=(",", ":")
+        )
+        with open(path, "w", encoding="utf-8") as destination:
+            json.dump(persisted, destination, separators=(",", ":"))
+
+    def _get_manager_clients(self):
+        worker = self.worker_manager.get_worker(0)
+        return (
+            AdminServiceHttpClient(
+                f"http://localhost:{worker.env.admin_http_port}"
+            ),
+            MetaServiceHttpClient(f"http://localhost:{worker.env.http_port}"),
+        )
+
+    def _wait_metric_at_least(
+        self, metric_name, expected, tags=None, timeout_s=5
+    ):
+        deadline = time.monotonic() + timeout_s
+        last_value = None
+        while time.monotonic() < deadline:
+            last_value = self._metric_value(metric_name, tags)
+            if last_value is not None and last_value >= expected:
+                return
+            time.sleep(0.05)
+        self.fail(
+            f"{metric_name} with tags {tags or {}} did not reach "
+            f"{expected}; last value: {last_value}"
+        )
+
+    def _wait_until_standby(self, timeout_s=5):
+        deadline = time.monotonic() + timeout_s
+        last_response = None
+        while time.monotonic() < deadline:
+            last_response = self._admin_client.check_health(
+                {"trace_id": f"{self._trace_id}_standby"},
+                check_response=False,
+            )
+            if not last_response.get("is_leader", True):
+                return
+            time.sleep(0.05)
+        self.fail(f"worker did not finish leader demotion: {last_response}")
+
+    def _metric_value(self, metric_name, tags=None):
+        expected_tags = tags or {}
+        metrics = self._admin_client.get_metrics(
+            {"trace_id": f"{self._trace_id}_metrics"}
+        )["metrics"]
+        values = []
+        for metric in metrics:
+            if metric.get("metric_name") != metric_name:
+                continue
+            actual_tags = {
+                tag["tag_key"]: tag["tag_value"]
+                for tag in metric.get("metric_tags", [])
+            }
+            if actual_tags != expected_tags:
+                continue
+            metric_value = metric.get("metric_value", {})
+            for value_type in ("int_value", "float_value", "double_value"):
+                if value_type in metric_value:
+                    values.append(float(metric_value[value_type]))
+                    break
+        if not values:
+            return None
+        self.assertEqual(
+            1,
+            len(values),
+            f"expected one {metric_name} with tags {expected_tags}",
+        )
+        return values[0]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/manager/BUILD
+++ b/kv_cache_manager/manager/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "cache_manager.h",
     ],
     deps = [
+        ":cache_garbage_collector",
         ":cache_location_view",
         ":cache_manager_metrics_recorder",
         ":cache_reclaimer",
@@ -32,6 +33,25 @@ cc_library(
         "//kv_cache_manager/event:event_publisher",
         "//kv_cache_manager/metrics:metrics_collector",
         "//kv_cache_manager/metrics:metrics_lifecycle",
+        "//kv_cache_manager/metrics:metrics_registry",
+    ],
+)
+
+cc_library(
+    name = "cache_garbage_collector",
+    srcs = ["cache_garbage_collector.cc"],
+    hdrs = ["cache_garbage_collector.h"],
+    deps = [
+        ":migration_manager",
+        ":schedule_plan_executor",
+        "//kv_cache_manager/common",
+        "//kv_cache_manager/common:loop_thread",
+        "//kv_cache_manager/common:timestamp_util",
+        "//kv_cache_manager/config",
+        "//kv_cache_manager/data_storage",
+        "//kv_cache_manager/meta",
+        "//kv_cache_manager/meta:cache_location",
+        "//kv_cache_manager/meta:types",
         "//kv_cache_manager/metrics:metrics_registry",
     ],
 )
@@ -180,4 +200,3 @@ cc_library(
         "//kv_cache_manager/metrics:metrics_lifecycle",
     ],
 )
-

--- a/kv_cache_manager/manager/cache_garbage_collector.cc
+++ b/kv_cache_manager/manager/cache_garbage_collector.cc
@@ -1,0 +1,781 @@
+#include "kv_cache_manager/manager/cache_garbage_collector.h"
+
+#include <algorithm>
+#include <chrono>
+#include <exception>
+#include <limits>
+#include <map>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/timestamp_util.h"
+#include "kv_cache_manager/config/instance_group.h"
+#include "kv_cache_manager/config/instance_info.h"
+#include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
+#include "kv_cache_manager/manager/migration_manager.h"
+#include "kv_cache_manager/meta/cache_location.h"
+#include "kv_cache_manager/meta/common.h"
+#include "kv_cache_manager/meta/meta_indexer.h"
+#include "kv_cache_manager/meta/meta_indexer_manager.h"
+#include "kv_cache_manager/meta/types.h"
+
+namespace kv_cache_manager {
+
+#define DEFINE_METRICS_NAME_FOR_CACHE_GC(name) DEFINE_METRICS_NAME_(CacheGarbageCollector, cache_gc, name)
+#define REGISTER_COUNTER_METRICS_FOR_CACHE_GC(name) REGISTER_METRICS_COUNTER_(metrics_registry_, cache_gc, name)
+#define REGISTER_GAUGE_METRICS_FOR_CACHE_GC(name) REGISTER_METRICS_GAUGE_(metrics_registry_, cache_gc, name)
+
+DEFINE_METRICS_NAME_FOR_CACHE_GC(scan_round_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(scan_key_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(candidate_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(delete_target_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(inflight_delete_count);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(inflight_delete_age_ms);
+DEFINE_METRICS_NAME_FOR_CACHE_GC(round_duration_ms);
+
+namespace {
+
+constexpr const char *kDeleteResultMetricName = "cache_gc.delete_result_count";
+constexpr const char *kOperationErrorMetricName = "cache_gc.operation_error_count";
+constexpr const char *kOrphanWritingReason = "orphan_writing";
+constexpr const char *kStorageMissingReason = "storage_missing";
+// DataStorageManager keeps a shared registry lock while invoking MightExist().
+constexpr size_t kMightExistProbeBatchSize = 512;
+
+using CandidateKey = std::pair<KeyType, std::string>;
+using StorageProbeKey = std::tuple<std::string, DataStorageType>;
+
+enum class CandidateReason {
+    kOrphanWriting,
+    kStorageMissing,
+};
+
+struct DeleteCandidate {
+    std::string expected_location_value;
+    CandidateReason reason{CandidateReason::kOrphanWriting};
+};
+
+struct ServingProbe {
+    CandidateKey key;
+    CacheLocationConstPtr location;
+    bool storage_missing{false};
+};
+
+struct StorageProbeBatch {
+    std::vector<DataStorageUri> uris;
+    // Parallel to uris; multiple specs can refer to the same Location.
+    std::vector<size_t> serving_probe_indexes;
+};
+
+} // namespace
+
+CacheGarbageCollector::CacheGarbageCollector(Config config,
+                                             std::shared_ptr<RegistryManager> registry_manager,
+                                             std::shared_ptr<MetaIndexerManager> meta_indexer_manager,
+                                             std::shared_ptr<DataStorageManager> data_storage_manager,
+                                             std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor,
+                                             std::shared_ptr<MetricsRegistry> metrics_registry,
+                                             std::shared_ptr<MigrationManager> migration_manager)
+    : config_(std::move(config))
+    , registry_manager_(std::move(registry_manager))
+    , meta_indexer_manager_(std::move(meta_indexer_manager))
+    , data_storage_manager_(std::move(data_storage_manager))
+    , schedule_plan_executor_(std::move(schedule_plan_executor))
+    , metrics_registry_(std::move(metrics_registry))
+    , migration_manager_(std::move(migration_manager))
+    , cursor_(SCAN_BASE_CURSOR) {}
+
+CacheGarbageCollector::~CacheGarbageCollector() { Stop(); }
+
+ErrorCode CacheGarbageCollector::Validate() const noexcept {
+    if (!config_.enabled) {
+        return EC_OK;
+    }
+    if (!registry_manager_ || !meta_indexer_manager_ || !data_storage_manager_ || !schedule_plan_executor_ ||
+        !metrics_registry_ || !migration_manager_) {
+        KVCM_LOG_ERROR("cache gc enabled with missing dependency");
+        return EC_CONFIG_ERROR;
+    }
+    if (config_.scan_interval_ms <= 0 || config_.round_pause_ms <= 0 || config_.scan_batch_size == 0 ||
+        config_.max_inflight_delete_requests == 0 ||
+        config_.orphan_writing_grace_period_ms < kMinCacheGcOrphanWritingGracePeriodMs) {
+        KVCM_LOG_ERROR("invalid cache gc config, scan_interval_ms[%ld], round_pause_ms[%ld], scan_batch_size[%zu], "
+                       "max_inflight_delete_requests[%zu], orphan_writing_grace_period_ms[%ld], grace must be at "
+                       "least[%ld]",
+                       config_.scan_interval_ms,
+                       config_.round_pause_ms,
+                       config_.scan_batch_size,
+                       config_.max_inflight_delete_requests,
+                       config_.orphan_writing_grace_period_ms,
+                       kMinCacheGcOrphanWritingGracePeriodMs);
+        return EC_CONFIG_ERROR;
+    }
+    if (config_.scan_batch_size > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+        KVCM_LOG_ERROR("invalid cache gc scan_batch_size[%zu]", config_.scan_batch_size);
+        return EC_CONFIG_ERROR;
+    }
+    const auto max_steady_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(Clock::duration::max()).count() / 2;
+    if (config_.scan_interval_ms > max_steady_ms || config_.round_pause_ms > max_steady_ms) {
+        KVCM_LOG_ERROR("cache gc duration config overflows steady clock");
+        return EC_CONFIG_ERROR;
+    }
+    return EC_OK;
+}
+
+void CacheGarbageCollector::RegisterMetrics() {
+    REGISTER_COUNTER_METRICS_FOR_CACHE_GC(scan_round_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_GC(scan_key_count);
+    METRICS_(cache_gc, candidate_count) = metrics_registry_->GetCounter(METRICS_NAME_(cache_gc, candidate_count),
+                                                                        MetricsTags{{"reason", kOrphanWritingReason}});
+    REGISTER_COUNTER_METRICS_FOR_CACHE_GC(delete_target_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_GC(inflight_delete_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_GC(inflight_delete_age_ms);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_GC(round_duration_ms);
+}
+
+ErrorCode CacheGarbageCollector::Start() noexcept {
+    if (!config_.enabled) {
+        return EC_OK;
+    }
+    if (Validate() != EC_OK) {
+        return EC_CONFIG_ERROR;
+    }
+
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (running_) {
+        return EC_OK;
+    }
+
+    try {
+        RegisterMetrics();
+        ResetWorkerState();
+        stop_requested_.store(false, std::memory_order_release);
+        worker_ = LoopThread::CreateLoopThread(
+            [this]() { RunOneTick(); }, config_.scan_interval_ms * 1000, "CacheGarbageCollector", true);
+        if (!worker_) {
+            stop_requested_.store(true, std::memory_order_release);
+            KVCM_LOG_ERROR("start cache gc worker failed: LoopThread creation returned null");
+            return EC_ERROR;
+        }
+        running_ = true;
+    } catch (const std::exception &e) {
+        worker_.reset();
+        running_ = false;
+        stop_requested_.store(true, std::memory_order_release);
+        KVCM_LOG_ERROR("start cache gc worker failed: %s", e.what());
+        return EC_ERROR;
+    } catch (...) {
+        worker_.reset();
+        running_ = false;
+        stop_requested_.store(true, std::memory_order_release);
+        KVCM_LOG_ERROR("start cache gc worker failed with unknown exception");
+        return EC_ERROR;
+    }
+    KVCM_LOG_INFO("cache gc worker started");
+    return EC_OK;
+}
+
+void CacheGarbageCollector::RequestStop() noexcept {
+    stop_requested_.store(true, std::memory_order_release);
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (worker_) {
+        // Wake a long tick/cooldown wait without joining here. RunOneTick observes
+        // stop_requested_ and returns without touching GC dependencies.
+        worker_->RunOnce();
+    }
+}
+
+void CacheGarbageCollector::Join() noexcept {
+    stop_requested_.store(true, std::memory_order_release);
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (worker_) {
+        worker_->Stop();
+        worker_.reset();
+    }
+    // Match CacheReclaimer's demotion policy: accepted deletes continue best effort in the Executor, while GC never
+    // waits for their end-to-end Futures. Clearing these observer handles neither cancels the tasks nor keeps their
+    // MetaIndexer/DataStorage dependencies alive across leader cleanup; a post-CAS failure may remain CLS_DELETING.
+    inflight_deletes_.clear();
+    pending_locations_.clear();
+    METRICS_(cache_gc, inflight_delete_count) = 0;
+    METRICS_(cache_gc, inflight_delete_age_ms) = 0;
+    running_ = false;
+}
+
+void CacheGarbageCollector::Stop() noexcept {
+    RequestStop();
+    Join();
+}
+
+bool CacheGarbageCollector::IsRunning() const noexcept {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return running_;
+}
+
+void CacheGarbageCollector::ResetWorkerState() noexcept {
+    instances_.clear();
+    instance_index_ = 0;
+    cursor_ = SCAN_BASE_CURSOR;
+    round_active_ = false;
+    next_round_at_.reset();
+    round_context_.reset();
+    inflight_deletes_.clear();
+    pending_locations_.clear();
+    METRICS_(cache_gc, inflight_delete_count) = 0;
+    METRICS_(cache_gc, inflight_delete_age_ms) = 0;
+    METRICS_(cache_gc, round_duration_ms) = 0;
+}
+
+void CacheGarbageCollector::RunOneTick() noexcept {
+    try {
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return;
+        }
+        PollInflightDeletes();
+        if (inflight_deletes_.size() >= config_.max_inflight_delete_requests) {
+            return;
+        }
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        const auto now = Clock::now();
+        if (next_round_at_.has_value() && now < next_round_at_.value()) {
+            return;
+        }
+        if (!round_active_ && !BeginRound()) {
+            return;
+        }
+        if (!round_active_) {
+            return;
+        }
+        if (instance_index_ >= instances_.size()) {
+            CompleteRound();
+            return;
+        }
+
+        const InstanceScanEntry entry = instances_[instance_index_];
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return;
+        }
+        auto indexer = meta_indexer_manager_->GetMetaIndexer(entry.instance_id);
+        if (!indexer) {
+            RecordOperationError("indexer_missing");
+            KVCM_LOG_WARN("cache gc round[%lu] skip missing indexer, group[%s] instance[%s]",
+                          round_id_,
+                          entry.instance_group.c_str(),
+                          entry.instance_id.c_str());
+            AdvanceInstance();
+            return;
+        }
+
+        MaintenanceScanBatch batch;
+        const std::string scan_cursor = cursor_;
+        ErrorCode ec =
+            indexer->ScanLocationsForMaintenance(round_context_.get(), scan_cursor, config_.scan_batch_size, batch);
+        if (ec != EC_OK) {
+            RecordOperationError("scan");
+            KVCM_LOG_WARN("cache gc round[%lu] scan failed, group[%s] instance[%s] cursor[%s] ec[%d]",
+                          round_id_,
+                          entry.instance_group.c_str(),
+                          entry.instance_id.c_str(),
+                          scan_cursor.c_str(),
+                          static_cast<int>(ec));
+            return;
+        }
+
+        METRICS_(cache_gc, scan_key_count) += batch.keys.size();
+        cursor_ = batch.next_cursor;
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return;
+        }
+        CacheLocationDelRequest request =
+            BuildDeleteRequest(entry.instance_id, batch, TimestampUtil::GetCurrentTimeUs());
+
+        if (cursor_ == SCAN_BASE_CURSOR) {
+            AdvanceInstance();
+        }
+
+        if (request.block_keys.empty() || stop_requested_.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        const size_t target_count = [&request]() {
+            size_t count = 0;
+            for (const auto &ids : request.location_ids) {
+                count += ids.size();
+            }
+            return count;
+        }();
+
+        AsyncDeleteSubmitResult submit_result;
+        try {
+            submit_result = schedule_plan_executor_->SubmitAsync(request);
+        } catch (const std::exception &e) {
+            RecordOperationError("submit_exception");
+            KVCM_LOG_ERROR("cache gc SubmitAsync threw, instance[%s] error[%s]", entry.instance_id.c_str(), e.what());
+            return;
+        } catch (...) {
+            RecordOperationError("submit_exception");
+            KVCM_LOG_ERROR("cache gc SubmitAsync threw unknown exception, instance[%s]", entry.instance_id.c_str());
+            return;
+        }
+        if (!submit_result.accepted) {
+            if (submit_result.future.valid()) {
+                RecordOperationError("submit_contract");
+                KVCM_LOG_ERROR("cache gc SubmitAsync rejected with a valid Future, instance[%s]",
+                               entry.instance_id.c_str());
+            } else {
+                RecordOperationError("submit_rejected");
+            }
+            return;
+        }
+        if (!submit_result.future.valid()) {
+            RecordOperationError("submit_contract");
+            KVCM_LOG_ERROR("cache gc SubmitAsync accepted with an invalid Future, instance[%s]",
+                           entry.instance_id.c_str());
+            return;
+        }
+
+        std::vector<PendingLocationKey> request_pending_locations;
+        try {
+            request_pending_locations.reserve(target_count);
+            for (size_t block_index = 0; block_index < request.block_keys.size(); ++block_index) {
+                for (const auto &location_id : request.location_ids[block_index]) {
+                    PendingLocationKey key{entry.instance_id, request.block_keys[block_index], location_id};
+                    request_pending_locations.emplace_back(key);
+                    if (pending_locations_.insert(key).second) {
+                        continue;
+                    }
+                    // BuildDeleteRequest de-duplicates and filters pending targets, and this callback is
+                    // single-threaded. Reaching here is an invariant violation; keep the existing owner while the
+                    // Executor's conditional CAS remains the final deletion-safety barrier.
+                    request_pending_locations.pop_back();
+                    RecordOperationError("pending_contract");
+                    KVCM_LOG_ERROR("cache gc accepted duplicate pending target, instance[%s] block[%ld] location[%s]",
+                                   entry.instance_id.c_str(),
+                                   request.block_keys[block_index],
+                                   location_id.c_str());
+                }
+            }
+            inflight_deletes_.emplace_back(InflightDelete{
+                .round_id = round_id_,
+                .instance_id = entry.instance_id,
+                .target_count = target_count,
+                .submitted_at = Clock::now(),
+                .pending_locations = request_pending_locations,
+                .future = std::move(submit_result.future),
+            });
+        } catch (...) {
+            for (const auto &pending_location : request_pending_locations) {
+                pending_locations_.erase(pending_location);
+            }
+            throw;
+        }
+        METRICS_(cache_gc, delete_target_count) += target_count;
+        UpdateInflightDeleteMetrics();
+    } catch (const std::exception &e) {
+        RecordOperationError("tick_exception");
+        KVCM_LOG_ERROR("cache gc tick threw exception: %s", e.what());
+    } catch (...) {
+        RecordOperationError("tick_exception");
+        KVCM_LOG_ERROR("cache gc tick threw unknown exception");
+    }
+}
+
+void CacheGarbageCollector::PollInflightDeletes() noexcept {
+    auto it = inflight_deletes_.begin();
+    while (it != inflight_deletes_.end()) {
+        if (!it->future.valid()) {
+            RecordOperationError("future_invalid");
+            RecordDeleteResult("invalid");
+            KVCM_LOG_ERROR("cache gc stored invalid Future, round[%lu] instance[%s] targets[%zu]",
+                           it->round_id,
+                           it->instance_id.c_str(),
+                           it->target_count);
+            ReleasePendingLocations(*it);
+            it = inflight_deletes_.erase(it);
+            continue;
+        }
+
+        const uint64_t round_id = it->round_id;
+        const std::string instance_id = it->instance_id;
+        const size_t target_count = it->target_count;
+        try {
+            if (it->future.wait_for(std::chrono::microseconds::zero()) != std::future_status::ready) {
+                ++it;
+                continue;
+            }
+            const PlanExecuteResult result = it->future.get();
+            RecordDeleteResult(std::to_string(static_cast<int>(result.status)));
+            if (result.status == EC_OK) {
+                KVCM_LOG_DEBUG("cache gc delete completed, round[%lu] instance[%s] targets[%zu]",
+                               round_id,
+                               instance_id.c_str(),
+                               target_count);
+            } else {
+                KVCM_LOG_WARN(
+                    "cache gc delete completed with status[%d], round[%lu] instance[%s] targets[%zu] error[%s]",
+                    static_cast<int>(result.status),
+                    round_id,
+                    instance_id.c_str(),
+                    target_count,
+                    result.error_message.c_str());
+            }
+        } catch (const std::exception &e) {
+            RecordOperationError("future_get");
+            RecordDeleteResult("exception");
+            KVCM_LOG_ERROR("cache gc Future get failed, round[%lu] instance[%s] targets[%zu] error[%s]",
+                           round_id,
+                           instance_id.c_str(),
+                           target_count,
+                           e.what());
+        } catch (...) {
+            RecordOperationError("future_get");
+            RecordDeleteResult("exception");
+            KVCM_LOG_ERROR("cache gc Future get failed with unknown exception, round[%lu] instance[%s] targets[%zu]",
+                           round_id,
+                           instance_id.c_str(),
+                           target_count);
+        }
+        ReleasePendingLocations(*it);
+        it = inflight_deletes_.erase(it);
+    }
+    UpdateInflightDeleteMetrics();
+}
+
+void CacheGarbageCollector::UpdateInflightDeleteMetrics() noexcept {
+    METRICS_(cache_gc, inflight_delete_count) = static_cast<double>(inflight_deletes_.size());
+    int64_t oldest_age_ms = 0;
+    const auto now = Clock::now();
+    for (const auto &inflight : inflight_deletes_) {
+        const auto age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - inflight.submitted_at).count();
+        oldest_age_ms = std::max<int64_t>(oldest_age_ms, age_ms);
+    }
+    METRICS_(cache_gc, inflight_delete_age_ms) = static_cast<double>(oldest_age_ms);
+}
+
+void CacheGarbageCollector::ReleasePendingLocations(const InflightDelete &inflight) noexcept {
+    for (const auto &pending_location : inflight.pending_locations) {
+        pending_locations_.erase(pending_location);
+    }
+}
+
+bool CacheGarbageCollector::BeginRound() {
+    const uint64_t next_round_id = round_id_ + 1;
+    auto context = std::make_shared<RequestContext>("cache_gc_round_" + std::to_string(next_round_id));
+    auto [group_ec, groups] = registry_manager_->ListInstanceGroup(context.get());
+    if (group_ec != EC_OK) {
+        RecordOperationError("list_groups");
+        KVCM_LOG_WARN("cache gc list instance groups failed, ec[%d]", static_cast<int>(group_ec));
+        return false;
+    }
+
+    std::vector<InstanceScanEntry> snapshot;
+    for (const auto &group : groups) {
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return false;
+        }
+        if (!group || group->name().empty()) {
+            RecordOperationError("registry_snapshot");
+            KVCM_LOG_WARN("cache gc encountered invalid instance group in snapshot");
+            return false;
+        }
+        auto [instance_ec, instances] = registry_manager_->ListInstanceInfo(context.get(), group->name());
+        if (instance_ec != EC_OK) {
+            RecordOperationError("list_instances");
+            KVCM_LOG_WARN("cache gc list instances failed, group[%s] ec[%d]",
+                          group->name().c_str(),
+                          static_cast<int>(instance_ec));
+            return false;
+        }
+        for (const auto &instance : instances) {
+            if (!instance || instance->instance_id().empty()) {
+                RecordOperationError("registry_snapshot");
+                KVCM_LOG_WARN("cache gc encountered invalid instance in group[%s]", group->name().c_str());
+                return false;
+            }
+            snapshot.push_back({group->name(), instance->instance_id()});
+        }
+    }
+
+    std::sort(snapshot.begin(), snapshot.end());
+    snapshot.erase(std::unique(snapshot.begin(), snapshot.end()), snapshot.end());
+    instances_ = std::move(snapshot);
+    instance_index_ = 0;
+    cursor_ = SCAN_BASE_CURSOR;
+    round_id_ = next_round_id;
+    round_active_ = true;
+    round_started_at_ = Clock::now();
+    next_round_at_.reset();
+    round_context_ = std::move(context);
+    KVCM_LOG_INFO("cache gc round[%lu] started with[%zu] instances", round_id_, instances_.size());
+    return true;
+}
+
+void CacheGarbageCollector::CompleteRound() noexcept {
+    const auto now = Clock::now();
+    const auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - round_started_at_).count();
+    METRICS_(cache_gc, round_duration_ms) = static_cast<double>(std::max<int64_t>(0, duration_ms));
+    ++METRICS_(cache_gc, scan_round_count);
+    KVCM_LOG_INFO(
+        "cache gc round[%lu] completed, instances[%zu] duration_ms[%ld]", round_id_, instances_.size(), duration_ms);
+
+    instances_.clear();
+    instance_index_ = 0;
+    cursor_ = SCAN_BASE_CURSOR;
+    round_active_ = false;
+    round_context_.reset();
+    next_round_at_ = now + std::chrono::milliseconds(config_.round_pause_ms);
+}
+
+void CacheGarbageCollector::AdvanceInstance() noexcept {
+    ++instance_index_;
+    cursor_ = SCAN_BASE_CURSOR;
+    if (instance_index_ >= instances_.size()) {
+        CompleteRound();
+    }
+}
+
+CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::string &instance_id,
+                                                                  const MaintenanceScanBatch &batch,
+                                                                  const int64_t now_us) {
+    CacheLocationDelRequest request;
+    request.instance_id = instance_id;
+    request.authoritative_read = true;
+
+    if (instance_id.empty() || batch.keys.size() != batch.locations.size() ||
+        batch.keys.size() != batch.location_results.size()) {
+        RecordOperationError("scan_shape");
+        return request;
+    }
+
+    std::map<CandidateKey, DeleteCandidate> candidates;
+    std::vector<ServingProbe> serving_probes;
+    std::map<StorageProbeKey, StorageProbeBatch> storage_probe_batches;
+    for (size_t i = 0; i < batch.keys.size(); ++i) {
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return request;
+        }
+        if (batch.location_results[i] != EC_OK) {
+            if (batch.location_results[i] != EC_NOENT) {
+                RecordOperationError("scan_key");
+            }
+            continue;
+        }
+        for (const auto &[location_id, location] : batch.locations[i]) {
+            if (!location || location_id.empty() || location->id().empty() || location_id != location->id()) {
+                continue;
+            }
+
+            const CandidateKey candidate_key{batch.keys[i], location_id};
+            if (IsOrphanWriting(location_id, *location, now_us)) {
+                if (migration_manager_ &&
+                    migration_manager_->HasActiveCopyTargetLocation(instance_id, batch.keys[i], location_id)) {
+                    continue;
+                }
+                candidates.emplace(candidate_key,
+                                   DeleteCandidate{location->ToJsonString(), CandidateReason::kOrphanWriting});
+                continue;
+            }
+
+            const auto storage_type = location->type();
+            if (location->status() != CLS_SERVING || storage_type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN ||
+                ToIndex(storage_type) >= ToIndex(DataStorageType::COUNT) || IsEventReportStorageType(storage_type) ||
+                location->location_specs().empty()) {
+                continue;
+            }
+
+            std::vector<std::pair<std::string, DataStorageUri>> parsed_uris;
+            parsed_uris.reserve(location->location_specs().size());
+            for (const auto &spec : location->location_specs()) {
+                DataStorageUri uri(spec.uri());
+                if (uri.Valid() && !uri.GetHostName().empty()) {
+                    parsed_uris.emplace_back(uri.GetHostName(), std::move(uri));
+                }
+            }
+            if (parsed_uris.empty()) {
+                continue;
+            }
+
+            const size_t serving_probe_index = serving_probes.size();
+            serving_probes.push_back({candidate_key, location, false});
+            for (auto &[storage_name, uri] : parsed_uris) {
+                auto &probe_batch = storage_probe_batches[{storage_name, storage_type}];
+                probe_batch.uris.emplace_back(std::move(uri));
+                probe_batch.serving_probe_indexes.push_back(serving_probe_index);
+            }
+        }
+    }
+
+    for (const auto &[storage_key, probe_batch] : storage_probe_batches) {
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return request;
+        }
+        const auto &[storage_name, expected_storage_type] = storage_key;
+        try {
+            auto storage_backend = data_storage_manager_->GetDataStorageBackend(storage_name);
+            if (!storage_backend) {
+                RecordOperationError("might_exist_storage_not_found");
+                continue;
+            }
+            const DataStorageType actual_storage_type = storage_backend->GetType();
+            if (actual_storage_type != expected_storage_type) {
+                RecordOperationError("might_exist_storage_type_mismatch");
+                KVCM_LOG_WARN("cache gc storage type mismatch, round[%lu] instance[%s] storage[%s] expected[%d] "
+                              "actual[%d]",
+                              round_id_,
+                              instance_id.c_str(),
+                              storage_name.c_str(),
+                              static_cast<int>(expected_storage_type),
+                              static_cast<int>(actual_storage_type));
+                continue;
+            }
+
+            for (size_t offset = 0; offset < probe_batch.uris.size(); offset += kMightExistProbeBatchSize) {
+                if (stop_requested_.load(std::memory_order_acquire)) {
+                    return request;
+                }
+                const size_t end = std::min(offset + kMightExistProbeBatchSize, probe_batch.uris.size());
+                const std::vector<DataStorageUri> uris(probe_batch.uris.begin() + offset,
+                                                       probe_batch.uris.begin() + end);
+                const std::vector<bool> might_exist =
+                    data_storage_manager_->Exist(storage_name, uris, /*fastpath=*/true);
+                if (stop_requested_.load(std::memory_order_acquire)) {
+                    return request;
+                }
+                if (might_exist.size() != uris.size()) {
+                    RecordOperationError("might_exist_shape");
+                    KVCM_LOG_WARN("cache gc MightExist result shape mismatch, round[%lu] instance[%s] storage[%s] "
+                                  "offset[%zu] uris[%zu] results[%zu]",
+                                  round_id_,
+                                  instance_id.c_str(),
+                                  storage_name.c_str(),
+                                  offset,
+                                  uris.size(),
+                                  might_exist.size());
+                    continue;
+                }
+                for (size_t i = 0; i < might_exist.size(); ++i) {
+                    if (!might_exist[i]) {
+                        serving_probes[probe_batch.serving_probe_indexes[offset + i]].storage_missing = true;
+                    }
+                }
+            }
+        } catch (const std::exception &e) {
+            RecordOperationError("might_exist_exception");
+            KVCM_LOG_WARN("cache gc MightExist threw, round[%lu] instance[%s] storage[%s] error[%s]",
+                          round_id_,
+                          instance_id.c_str(),
+                          storage_name.c_str(),
+                          e.what());
+        } catch (...) {
+            RecordOperationError("might_exist_exception");
+            KVCM_LOG_WARN("cache gc MightExist threw unknown exception, round[%lu] instance[%s] storage[%s]",
+                          round_id_,
+                          instance_id.c_str(),
+                          storage_name.c_str());
+        }
+    }
+
+    for (auto &probe : serving_probes) {
+        if (probe.storage_missing) {
+            candidates.emplace(std::move(probe.key),
+                               DeleteCandidate{probe.location->ToJsonString(), CandidateReason::kStorageMissing});
+        }
+    }
+
+    size_t orphan_writing_count = 0;
+    size_t storage_missing_count = 0;
+    for (const auto &[candidate_key, candidate] : candidates) {
+        (void)candidate_key;
+        if (candidate.reason == CandidateReason::kOrphanWriting) {
+            ++orphan_writing_count;
+        } else {
+            ++storage_missing_count;
+        }
+    }
+    RecordCandidateCount(kOrphanWritingReason, orphan_writing_count);
+    RecordCandidateCount(kStorageMissingReason, storage_missing_count);
+
+    struct RequestTargets {
+        std::vector<std::string> location_ids;
+        std::vector<std::string> expected_location_values;
+    };
+    std::map<KeyType, RequestTargets> targets;
+    size_t selected = 0;
+    for (const auto &[candidate_key, candidate] : candidates) {
+        const auto &[block_key, location_id] = candidate_key;
+        if (pending_locations_.find(PendingLocationKey{instance_id, block_key, location_id}) !=
+            pending_locations_.end()) {
+            continue;
+        }
+        if (selected >= config_.scan_batch_size) {
+            break;
+        }
+        auto &block_targets = targets[block_key];
+        block_targets.location_ids.push_back(location_id);
+        block_targets.expected_location_values.push_back(candidate.expected_location_value);
+        ++selected;
+    }
+    request.block_keys.reserve(targets.size());
+    request.location_ids.reserve(targets.size());
+    request.expected_location_values.reserve(targets.size());
+    for (auto &[block_key, block_targets] : targets) {
+        request.block_keys.push_back(block_key);
+        request.location_ids.emplace_back(std::move(block_targets.location_ids));
+        request.expected_location_values.emplace_back(std::move(block_targets.expected_location_values));
+    }
+    return request;
+}
+
+bool CacheGarbageCollector::IsOrphanWriting(const std::string &map_location_id,
+                                            const CacheLocation &location,
+                                            const int64_t now_us) const noexcept {
+    if (map_location_id.empty() || location.id().empty() || map_location_id != location.id() ||
+        location.status() != CLS_WRITING || location.create_time() <= 0 || now_us < location.create_time()) {
+        return false;
+    }
+    const int64_t age_us = now_us - location.create_time();
+    return age_us / 1000 >= config_.orphan_writing_grace_period_ms;
+}
+
+void CacheGarbageCollector::RecordCandidateCount(const std::string &reason, const size_t count) noexcept {
+    if (count == 0) {
+        return;
+    }
+    try {
+        if (metrics_registry_) {
+            auto counter = metrics_registry_->GetCounter(METRICS_NAME_(cache_gc, candidate_count),
+                                                         MetricsTags{{"reason", reason}});
+            counter += count;
+        }
+    } catch (...) { KVCM_LOG_ERROR("cache gc failed to record candidate metric"); }
+}
+
+void CacheGarbageCollector::RecordOperationError(const std::string &stage) noexcept {
+    try {
+        if (metrics_registry_) {
+            auto counter = metrics_registry_->GetCounter(kOperationErrorMetricName, MetricsTags{{"stage", stage}});
+            ++counter;
+        }
+    } catch (...) { KVCM_LOG_ERROR("cache gc failed to record operation error metric"); }
+}
+
+void CacheGarbageCollector::RecordDeleteResult(const std::string &status) noexcept {
+    try {
+        if (metrics_registry_) {
+            auto counter = metrics_registry_->GetCounter(kDeleteResultMetricName, MetricsTags{{"status", status}});
+            ++counter;
+        }
+    } catch (...) { KVCM_LOG_ERROR("cache gc failed to record delete result metric"); }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_garbage_collector.h
+++ b/kv_cache_manager/manager/cache_garbage_collector.h
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/loop_thread.h"
+#include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+namespace kv_cache_manager {
+
+inline constexpr int64_t kMinCacheGcOrphanWritingGracePeriodMs = 60LL * 60 * 1000;
+
+#ifndef KVCM_COUNTER_METRICS_FOR_CACHE_GC
+#define KVCM_COUNTER_METRICS_FOR_CACHE_GC(name)                                                                        \
+public:                                                                                                                \
+    DECLARE_METRICS_NAME_(cache_gc, name);                                                                             \
+    DEFINE_GET_METRICS_COUNTER_(cache_gc, name)                                                                        \
+                                                                                                                       \
+private:                                                                                                               \
+    DECLARE_METRICS_COUNTER_(cache_gc, name);
+#endif
+
+#ifndef KVCM_GAUGE_METRICS_FOR_CACHE_GC
+#define KVCM_GAUGE_METRICS_FOR_CACHE_GC(name)                                                                          \
+public:                                                                                                                \
+    DECLARE_METRICS_NAME_(cache_gc, name);                                                                             \
+    DEFINE_GET_METRICS_GAUGE_(cache_gc, name)                                                                          \
+                                                                                                                       \
+private:                                                                                                               \
+    DECLARE_METRICS_GAUGE_(cache_gc, name);
+#endif
+
+class CacheLocation;
+class DataStorageManager;
+class MetaIndexerManager;
+class MigrationManager;
+class RegistryManager;
+class RequestContext;
+struct MaintenanceScanBatch;
+
+class CacheGarbageCollector {
+public:
+    struct Config {
+        bool enabled{false};
+        int64_t scan_interval_ms{1000};
+        int64_t round_pause_ms{24LL * 60 * 60 * 1000};
+        size_t scan_batch_size{256};
+        int64_t orphan_writing_grace_period_ms{24LL * 60 * 60 * 1000};
+        size_t max_inflight_delete_requests{2};
+    };
+
+    CacheGarbageCollector() = delete;
+    CacheGarbageCollector(Config config,
+                          std::shared_ptr<RegistryManager> registry_manager,
+                          std::shared_ptr<MetaIndexerManager> meta_indexer_manager,
+                          std::shared_ptr<DataStorageManager> data_storage_manager,
+                          std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor,
+                          std::shared_ptr<MetricsRegistry> metrics_registry,
+                          std::shared_ptr<MigrationManager> migration_manager);
+    ~CacheGarbageCollector();
+
+    CacheGarbageCollector(const CacheGarbageCollector &) = delete;
+    CacheGarbageCollector(CacheGarbageCollector &&) = delete;
+    CacheGarbageCollector &operator=(const CacheGarbageCollector &) = delete;
+    CacheGarbageCollector &operator=(CacheGarbageCollector &&) = delete;
+
+    [[nodiscard]] ErrorCode Validate() const noexcept;
+    [[nodiscard]] ErrorCode Start() noexcept;
+    void RequestStop() noexcept;
+    void Join() noexcept;
+    void Stop() noexcept;
+    [[nodiscard]] bool IsRunning() const noexcept;
+    [[nodiscard]] bool IsEnabled() const noexcept { return config_.enabled; }
+
+private:
+    using Clock = std::chrono::steady_clock;
+
+    struct InstanceScanEntry {
+        std::string instance_group;
+        std::string instance_id;
+
+        bool operator<(const InstanceScanEntry &other) const {
+            return std::tie(instance_group, instance_id) < std::tie(other.instance_group, other.instance_id);
+        }
+        bool operator==(const InstanceScanEntry &other) const {
+            return instance_group == other.instance_group && instance_id == other.instance_id;
+        }
+    };
+
+    struct PendingLocationKey {
+        std::string instance_id;
+        int64_t block_key{0};
+        std::string location_id;
+
+        bool operator<(const PendingLocationKey &other) const noexcept {
+            return std::tie(instance_id, block_key, location_id) <
+                   std::tie(other.instance_id, other.block_key, other.location_id);
+        }
+    };
+
+    struct InflightDelete {
+        uint64_t round_id{0};
+        std::string instance_id;
+        size_t target_count{0};
+        Clock::time_point submitted_at;
+        std::vector<PendingLocationKey> pending_locations;
+        std::future<PlanExecuteResult> future;
+    };
+
+    void RunOneTick() noexcept;
+    void PollInflightDeletes() noexcept;
+    void UpdateInflightDeleteMetrics() noexcept;
+    void ReleasePendingLocations(const InflightDelete &inflight) noexcept;
+    bool BeginRound();
+    void CompleteRound() noexcept;
+    void AdvanceInstance() noexcept;
+    CacheLocationDelRequest
+    BuildDeleteRequest(const std::string &instance_id, const MaintenanceScanBatch &batch, int64_t now_us);
+    bool
+    IsOrphanWriting(const std::string &map_location_id, const CacheLocation &location, int64_t now_us) const noexcept;
+    void ResetWorkerState() noexcept;
+    void RegisterMetrics();
+    void RecordCandidateCount(const std::string &reason, size_t count) noexcept;
+    void RecordOperationError(const std::string &stage) noexcept;
+    void RecordDeleteResult(const std::string &status) noexcept;
+
+    const Config config_;
+    const std::shared_ptr<RegistryManager> registry_manager_;
+    const std::shared_ptr<MetaIndexerManager> meta_indexer_manager_;
+    const std::shared_ptr<DataStorageManager> data_storage_manager_;
+    const std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor_;
+    const std::shared_ptr<MetricsRegistry> metrics_registry_;
+    const std::shared_ptr<MigrationManager> migration_manager_;
+
+    mutable std::mutex lifecycle_mutex_;
+    std::shared_ptr<LoopThread> worker_;
+    std::atomic<bool> stop_requested_{true};
+    bool running_{false};
+
+    // Worker-thread-only state.
+    std::vector<InstanceScanEntry> instances_;
+    size_t instance_index_{0};
+    std::string cursor_;
+    uint64_t round_id_{0};
+    bool round_active_{false};
+    Clock::time_point round_started_at_;
+    std::optional<Clock::time_point> next_round_at_;
+    std::shared_ptr<RequestContext> round_context_;
+    std::vector<InflightDelete> inflight_deletes_;
+    std::set<PendingLocationKey> pending_locations_;
+
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(scan_round_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(scan_key_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(candidate_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_GC(delete_target_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_GC(inflight_delete_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_GC(inflight_delete_age_ms)
+    KVCM_GAUGE_METRICS_FOR_CACHE_GC(round_duration_ms)
+};
+
+#undef KVCM_COUNTER_METRICS_FOR_CACHE_GC
+#undef KVCM_GAUGE_METRICS_FOR_CACHE_GC
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -412,6 +412,10 @@ CacheManager::CacheManager(std::shared_ptr<MetricsRegistry> metrics_registry,
           meta_indexer_manager_, write_location_manager_, registry_manager_, metrics_lifecycle_)) {}
 
 CacheManager::~CacheManager() {
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->Stop();
+        cache_garbage_collector_.reset();
+    }
     ClearEventCleanupCallbacks();
     StopRecoverRetryLoop();
     if (write_location_manager_) {
@@ -435,7 +439,8 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
                         uint32_t cache_reclaimer_idle_interval_ms,
                         uint32_t cache_reclaimer_worker_size,
                         CacheReclaimerAsyncDeleteConfig cache_reclaimer_async_delete_config,
-                        uint32_t schedule_plan_migration_worker_budget) {
+                        uint32_t schedule_plan_migration_worker_budget,
+                        CacheGarbageCollector::Config cache_gc_config) {
     if (schedule_plan_executor_thread_count <= 1 || schedule_plan_migration_worker_budget == 0 ||
         schedule_plan_migration_worker_budget >= static_cast<uint32_t>(schedule_plan_executor_thread_count)) {
         KVCM_LOG_ERROR("invalid schedule executor budget: worker_count=%d migration_worker_budget=%u",
@@ -466,6 +471,18 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
     // Invariant: migration_manager_ is always constructed here. Feature enablement is a per
     // instance-group property (IsTieredMigrationEnabled), never expressed via pointer nullness.
     assert(migration_manager_ != nullptr);
+
+    cache_garbage_collector_ = std::make_shared<CacheGarbageCollector>(std::move(cache_gc_config),
+                                                                       registry_manager_,
+                                                                       meta_indexer_manager_,
+                                                                       registry_manager_->data_storage_manager(),
+                                                                       schedule_plan_executor_,
+                                                                       metrics_registry_,
+                                                                       migration_manager_);
+    if (cache_garbage_collector_->Validate() != EC_OK) {
+        KVCM_LOG_ERROR("CacheManager init failed: invalid CacheGarbageCollector config");
+        return false;
+    }
 
     cache_reclaimer_ = std::make_shared<CacheReclaimer>(cache_reclaimer_key_sampling_size_total,
                                                         cache_reclaimer_key_sampling_size_per_task,
@@ -1554,6 +1571,22 @@ CacheManager::MigrateCacheResult CacheManager::MigrateCache(RequestContext *requ
     result.rejected = domain.rejected;
     result.message = domain.message;
     return result;
+}
+
+ErrorCode CacheManager::StartCacheGarbageCollector() {
+    return cache_garbage_collector_ ? cache_garbage_collector_->Start() : EC_ERROR;
+}
+
+void CacheManager::RequestStopCacheGarbageCollector() {
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->RequestStop();
+    }
+}
+
+void CacheManager::JoinCacheGarbageCollector() {
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->Join();
+    }
 }
 
 void CacheManager::FilterLocationSpecByName(CacheLocationVector &locations,
@@ -3672,6 +3705,9 @@ void CacheManager::ClearEventCleanupCallbacks() {
 }
 
 ErrorCode CacheManager::DoCleanup() {
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->Stop();
+    }
     ClearEventCleanupCallbacks();
     StopRecoverRetryLoop();
     // aborting write session need meta indexer

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -14,6 +14,7 @@
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
 #include "kv_cache_manager/data_storage/snapshot_uri_utils.h"
+#include "kv_cache_manager/manager/cache_garbage_collector.h"
 #include "kv_cache_manager/manager/cache_location_view.h"
 #include "kv_cache_manager/manager/cache_reclaimer.h"
 #include "kv_cache_manager/manager/data_storage_selector.h"
@@ -88,7 +89,8 @@ public:
               uint32_t cache_reclaimer_idle_interval_ms = 100,
               uint32_t cache_reclaimer_worker_size = 16,
               CacheReclaimerAsyncDeleteConfig cache_reclaimer_async_delete_config = {},
-              uint32_t schedule_plan_migration_worker_budget = DEFAULT_SCHEDULE_PLAN_MIGRATION_WORKER_BUDGET);
+              uint32_t schedule_plan_migration_worker_budget = DEFAULT_SCHEDULE_PLAN_MIGRATION_WORKER_BUDGET,
+              CacheGarbageCollector::Config cache_gc_config = {});
     ErrorCode DoRecover();
     ErrorCode DoRecoverOnce();
     void StartRecoverRetryLoop();
@@ -213,6 +215,9 @@ public:
 
     void PauseReclaimer();
     void ResumeReclaimer();
+    ErrorCode StartCacheGarbageCollector();
+    void RequestStopCacheGarbageCollector();
+    void JoinCacheGarbageCollector();
 
     // 多层存储迁移控制面随 leader 生命周期启停（OnBecomeLeader/OnNoLongerLeader）。
     void StartMigrationManager();
@@ -221,6 +226,7 @@ public:
     std::shared_ptr<MetaIndexerManager> meta_indexer_manager() { return meta_indexer_manager_; }
     std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor() { return schedule_plan_executor_; }
     std::shared_ptr<CacheReclaimer> cache_reclaimer() { return cache_reclaimer_; }
+    std::shared_ptr<CacheGarbageCollector> cache_garbage_collector() { return cache_garbage_collector_; }
     std::shared_ptr<EventManager> event_manager() { return event_manager_; }
     std::shared_ptr<CacheManagerMetricsRecorder> metrics_recorder() { return metrics_recorder_; }
     std::shared_ptr<MigrationManager> migration_manager() { return migration_manager_; }
@@ -370,6 +376,8 @@ private:
     std::shared_ptr<RegistryManager> registry_manager_;
     // 无需清理 - 让遗留的Plan自行跑完
     std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor_;
+    // leader demotion 和析构时先停止 GC 线程；已接受的删除任务由 Executor best effort 继续执行
+    std::shared_ptr<CacheGarbageCollector> cache_garbage_collector_;
     // 无需清理 - 仅需要暂停
     std::shared_ptr<CacheReclaimer> cache_reclaimer_;
     // 无需清理 - 随 leader 生命周期 Start/Stop；活跃任务在切主时由 Reclaimer 孤儿检测兜底

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -1660,7 +1660,8 @@ ErrorCode MetaSearcher::BatchUpdateLocationStatus(RequestContext *request_contex
 ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
                                                const KeyVector &keys,
                                                const std::vector<std::vector<LocationCASTask>> &batch_tasks,
-                                               std::vector<std::vector<ErrorCode>> &out_batch_results) {
+                                               std::vector<std::vector<ErrorCode>> &out_batch_results,
+                                               bool refresh_cache_from_persistent) {
 
     if (keys.size() != batch_tasks.size()) {
         return EC_BADARGS;
@@ -1723,7 +1724,8 @@ ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
-    auto result = meta_indexer_->ReadModifyWriteLocation(request_context, keys, location_ids_per_key, modifier);
+    auto result = meta_indexer_->ReadModifyWriteLocation(
+        request_context, keys, location_ids_per_key, modifier, true, refresh_cache_from_persistent);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
     out_batch_results = std::move(result.per_location_error_codes);
 

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -159,7 +159,8 @@ public:
     ErrorCode BatchCASLocationStatus(RequestContext *request_context,
                                      const KeyVector &keys,
                                      const std::vector<std::vector<LocationCASTask>> &batch_tasks,
-                                     std::vector<std::vector<ErrorCode>> &out_batch_results);
+                                     std::vector<std::vector<ErrorCode>> &out_batch_results,
+                                     bool refresh_cache_from_persistent = false);
     struct LocationCADTask {
         std::string location_id;
         CacheLocationStatus expect_status;

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -434,7 +434,7 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheMetaDelRe
 }
 
 std::future<PlanExecuteResult> SchedulePlanExecutor::SubmitMetaDelete(const CacheMetaDelRequest &task,
-                                                                     ScheduleTaskClass task_class) {
+                                                                      ScheduleTaskClass task_class) {
     KVCM_LOG_DEBUG("Submitting meta delete task for instance_id: %s, block_keys count: %zu",
                    task.instance_id.c_str(),
                    task.block_keys.size());
@@ -586,18 +586,16 @@ bool SchedulePlanExecutor::FillActualTask(
 }
 SchedulePlanExecutor::LocationDelAdmissionResult
 SchedulePlanExecutor::PrepareDeleteTask(const CacheMetaDelRequest &task) {
-    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay);
+    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false);
 }
 
 SchedulePlanExecutor::LocationDelAdmissionResult
 SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
     if (task.block_keys.size() != task.location_ids.size() ||
-        (!task.expected_location_values.empty() &&
-         task.block_keys.size() != task.expected_location_values.size())) {
+        (!task.expected_location_values.empty() && task.block_keys.size() != task.expected_location_values.size())) {
         LocationDelAdmissionResult admission_result;
         admission_result.result = MakeErrorResult(
-            ErrorCode::EC_BADARGS,
-            "block_keys, location_ids and expected_location_values sizes do not match");
+            ErrorCode::EC_BADARGS, "block_keys, location_ids and expected_location_values sizes do not match");
         return admission_result;
     }
     if (!task.expected_location_values.empty()) {
@@ -614,8 +612,12 @@ SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
     }
     const auto *expected_location_values =
         task.expected_location_values.empty() ? nullptr : &task.expected_location_values;
-    auto result = PrepareDeleteTaskImpl(
-        task.instance_id, task.block_keys, &task.location_ids, expected_location_values, task.delay);
+    auto result = PrepareDeleteTaskImpl(task.instance_id,
+                                        task.block_keys,
+                                        &task.location_ids,
+                                        expected_location_values,
+                                        task.delay,
+                                        task.authoritative_read);
     result.actual_task.metadata_only = task.metadata_only;
     return result;
 }
@@ -625,7 +627,8 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                                             const std::vector<int64_t> &block_keys,
                                             const std::vector<std::vector<std::string>> *target_location_ids,
                                             const std::vector<std::vector<std::string>> *expected_location_values,
-                                            std::chrono::microseconds delay) {
+                                            std::chrono::microseconds delay,
+                                            bool authoritative_read) {
     LocationDelAdmissionResult admission_result;
     admission_result.actual_task = CacheLocationDelRequest{instance_id, {}, {}, delay};
 
@@ -644,8 +647,22 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
     std::vector<CacheLocationMap> location_maps;
     BlockMask empty_mask;
     auto request_context = std::make_shared<RequestContext>("schedule_plan_executor_call");
-    ErrorCode get_locations_ec =
-        meta_searcher.BatchGetLocation(request_context.get(), block_keys, empty_mask, location_maps);
+    ErrorCode get_locations_ec = ErrorCode::EC_OK;
+    if (authoritative_read) {
+        const auto get_result = indexer->GetLocationsFromPersistent(request_context.get(), block_keys, location_maps);
+        if (get_result.error_codes.size() != block_keys.size()) {
+            get_locations_ec = ErrorCode::EC_ERROR;
+        } else {
+            for (const ErrorCode ec : get_result.error_codes) {
+                if (ec != ErrorCode::EC_OK && ec != ErrorCode::EC_NOENT) {
+                    get_locations_ec = ErrorCode::EC_ERROR;
+                    break;
+                }
+            }
+        }
+    } else {
+        get_locations_ec = meta_searcher.BatchGetLocation(request_context.get(), block_keys, empty_mask, location_maps);
+    }
     if (get_locations_ec != ErrorCode::EC_OK) {
         admission_result.result = MakeErrorResult(
             ErrorCode::EC_ERROR, StringUtil::FormatString("Failed to get block locations, ec: %d", get_locations_ec));
@@ -714,7 +731,7 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
 
     std::vector<std::vector<ErrorCode>> batch_results;
     ErrorCode update_ec = meta_searcher.BatchCASLocationStatus(
-        request_context.get(), batch_cas_block_keys, batch_cas_tasks, batch_results);
+        request_context.get(), batch_cas_block_keys, batch_cas_tasks, batch_results, authoritative_read);
     if (update_ec != ErrorCode::EC_OK) {
         KVCM_LOG_DEBUG("Location status BatchCASLocationStatus not ok, ec: %d", update_ec);
     }
@@ -780,8 +797,8 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationD
     return SubmitLocationDelete(task, ScheduleTaskClass::kSystem);
 }
 
-std::future<PlanExecuteResult>
-SchedulePlanExecutor::SubmitLocationDelete(const CacheLocationDelRequest &task, ScheduleTaskClass task_class) {
+std::future<PlanExecuteResult> SchedulePlanExecutor::SubmitLocationDelete(const CacheLocationDelRequest &task,
+                                                                          ScheduleTaskClass task_class) {
     KVCM_LOG_DEBUG("Submitting location delete task for instance_id: %s, block_keys count: %zu",
                    task.instance_id.c_str(),
                    task.block_keys.size());
@@ -789,7 +806,8 @@ SchedulePlanExecutor::SubmitLocationDelete(const CacheLocationDelRequest &task, 
     auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
     auto future = promise->get_future();
     auto completion = std::make_shared<PromiseCompletion>(promise);
-    RunDeleteAdmission(completion, task.delay, [this, &task]() { return PrepareDeleteTask(task); }, task_class);
+    RunDeleteAdmission(
+        completion, task.delay, [this, &task]() { return PrepareDeleteTask(task); }, task_class);
     return future;
 }
 
@@ -820,10 +838,7 @@ SchedulePlanExecutor::SubmitDeleteTaskAsync(std::chrono::microseconds delay,
     auto cancel_task = [completion]() {
         completion->Complete(ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before delete admission.");
     };
-    if (!SubmitRaw(admission_task,
-                   std::chrono::microseconds::zero(),
-                   cancel_task,
-                   ScheduleTaskClass::kReclaim)) {
+    if (!SubmitRaw(admission_task, std::chrono::microseconds::zero(), cancel_task, ScheduleTaskClass::kReclaim)) {
         return AsyncDeleteSubmitResult{};
     }
     return AsyncDeleteSubmitResult{true, std::move(future)};
@@ -927,8 +942,8 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationC
     auto cancel_task = [promise]() {
         HandleErrorPromise(promise, ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before copy task execution.");
     };
-    bool submit_result = this->SubmitRaw(
-        execute_task, task.delay, cancel_task, ScheduleTaskClass::kMigrationContinuation);
+    bool submit_result =
+        this->SubmitRaw(execute_task, task.delay, cancel_task, ScheduleTaskClass::kMigrationContinuation);
     if (!submit_result) {
         HandleErrorPromise(promise, ErrorCode::EC_ERROR, "submit copy task failed");
         return future;

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -61,6 +61,9 @@ struct CacheLocationDelRequest {
     // Event-report metadata describes externally owned cache. Its reconciliation
     // cleanup must remove only KVCM metadata and never call the URI backend.
     bool metadata_only{false};
+    // Maintenance scans observe the persistent source of truth. Revalidate
+    // admission there and refresh candidate keys into the hot cache before CAS.
+    bool authoritative_read{false};
 };
 
 // 单个 block 的跨存储复制请求。URI 由上层（MigrationManager）解析与预分配后传入；
@@ -116,8 +119,7 @@ public:
     AsyncDeleteSubmitResult SubmitAsync(const CacheMetaDelRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const CacheLocationDelRequest &task);
 
-    bool SubmitNonBlocking(const CacheMetaDelRequest &req,
-                           ScheduleTaskClass task_class = ScheduleTaskClass::kSystem);
+    bool SubmitNonBlocking(const CacheMetaDelRequest &req, ScheduleTaskClass task_class = ScheduleTaskClass::kSystem);
     bool SubmitNonBlocking(const CacheLocationDelRequest &req,
                            ScheduleTaskClass task_class = ScheduleTaskClass::kSystem);
 
@@ -166,12 +168,13 @@ private:
                                std::string &error_message);
     LocationDelAdmissionResult PrepareDeleteTask(const CacheMetaDelRequest &task);
     LocationDelAdmissionResult PrepareDeleteTask(const CacheLocationDelRequest &task);
-    LocationDelAdmissionResult PrepareDeleteTaskImpl(const std::string &instance_id,
-                                                     const std::vector<int64_t> &block_keys,
-                                                     const std::vector<std::vector<std::string>> *target_location_ids,
-                                                     const std::vector<std::vector<std::string>>
-                                                         *expected_location_values,
-                                                     std::chrono::microseconds delay);
+    LocationDelAdmissionResult
+    PrepareDeleteTaskImpl(const std::string &instance_id,
+                          const std::vector<int64_t> &block_keys,
+                          const std::vector<std::vector<std::string>> *target_location_ids,
+                          const std::vector<std::vector<std::string>> *expected_location_values,
+                          std::chrono::microseconds delay,
+                          bool authoritative_read = false);
     void RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,
                             std::chrono::microseconds delay,
                             const std::function<LocationDelAdmissionResult()> &prepare,

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -17,6 +17,22 @@ cc_test(
 )
 
 cc_test(
+    name = "CacheGarbageCollectorTest",
+    srcs = [
+        "cache_garbage_collector_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    linkstatic = True,
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/manager:cache_garbage_collector",
+        "//kv_cache_manager/manager:migration_manager",
+        "@cpp_stub",
+    ],
+)
+
+cc_test(
     name = "DataStorageSelectorTest",
     srcs = [
         "data_storage_selector_test.cc",

--- a/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
+++ b/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
@@ -1,0 +1,1145 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <map>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/timestamp_util.h"
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/instance_group.h"
+#include "kv_cache_manager/config/instance_info.h"
+#include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/manager/cache_garbage_collector.h"
+#include "kv_cache_manager/manager/meta_searcher.h"
+#include "kv_cache_manager/manager/migration_manager.h"
+#include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/meta/cache_location.h"
+#include "kv_cache_manager/meta/common.h"
+#include "kv_cache_manager/meta/meta_indexer.h"
+#include "kv_cache_manager/meta/meta_indexer_manager.h"
+#include "kv_cache_manager/meta/types.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "stub.h"
+
+namespace kv_cache_manager {
+namespace {
+
+using InstanceGroups = std::vector<std::shared_ptr<const InstanceGroup>>;
+using InstanceInfos = std::vector<std::shared_ptr<const InstanceInfo>>;
+using SubmitAsyncLocation = AsyncDeleteSubmitResult (SchedulePlanExecutor::*)(const CacheLocationDelRequest &);
+
+struct ScanResponse {
+    ErrorCode ec{EC_OK};
+    MaintenanceScanBatch batch;
+};
+
+struct MightExistCall {
+    std::string storage_name;
+    std::vector<DataStorageUri> uris;
+    bool fastpath{false};
+};
+
+enum class SubmitMode {
+    kReadyOk,
+    kReadyPartial,
+    kPending,
+    kRejected,
+    kAcceptedInvalid,
+    kFutureException,
+    kThrow,
+};
+
+class ProbeTestBackend : public DataStorageBackend {
+public:
+    explicit ProbeTestBackend(DataStorageType type) : DataStorageBackend(nullptr), type_(type) {}
+
+    DataStorageType GetType() override { return type_; }
+    bool Available() override { return true; }
+    double GetStorageUsageRatio(const std::string &) const override { return 0.0; }
+    ErrorCode DoOpen(const StorageConfig &, const std::string &) override { return EC_OK; }
+    ErrorCode Close() override { return EC_OK; }
+    std::vector<std::pair<ErrorCode, DataStorageUri>>
+    Create(const std::vector<std::string> &keys, size_t, const std::string &, std::function<void()>) override {
+        return std::vector<std::pair<ErrorCode, DataStorageUri>>(keys.size(), {EC_OK, DataStorageUri{}});
+    }
+    std::vector<ErrorCode>
+    Delete(const std::vector<DataStorageUri> &uris, const std::string &, std::function<void()>) override {
+        return std::vector<ErrorCode>(uris.size(), EC_OK);
+    }
+    std::vector<bool> Exist(const std::vector<DataStorageUri> &uris) override {
+        return std::vector<bool>(uris.size(), true);
+    }
+    std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &uris) override {
+        return std::vector<ErrorCode>(uris.size(), EC_OK);
+    }
+    std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &uris) override {
+        return std::vector<ErrorCode>(uris.size(), EC_OK);
+    }
+
+private:
+    DataStorageType type_;
+};
+
+ErrorCode list_groups_ec = EC_OK;
+InstanceGroups instance_groups;
+std::map<std::string, std::pair<ErrorCode, InstanceInfos>> instances_by_group;
+std::map<std::string, std::vector<ScanResponse>> scan_responses;
+std::map<std::string, size_t> scan_positions;
+std::vector<std::pair<std::string, std::string>> scan_calls;
+std::set<std::string> missing_indexers;
+std::string active_instance_id;
+std::shared_ptr<MetaIndexer> dummy_indexer;
+std::vector<CacheLocationDelRequest> submitted_requests;
+SubmitMode submit_mode = SubmitMode::kReadyOk;
+std::shared_ptr<std::promise<PlanExecuteResult>> pending_delete_promise;
+std::vector<std::shared_ptr<std::promise<PlanExecuteResult>>> pending_delete_promises;
+size_t list_groups_call_count = 0;
+std::atomic<size_t> scan_call_count{0};
+std::atomic<bool> block_scan{false};
+std::atomic<bool> scan_block_entered{false};
+std::atomic<bool> release_scan{true};
+std::vector<MightExistCall> might_exist_calls;
+std::map<std::string, bool> might_exist_by_uri;
+std::map<std::string, std::vector<bool>> might_exist_result_overrides;
+std::set<std::string> might_exist_throw_storages;
+std::set<std::string> missing_probe_storages;
+std::map<std::string, DataStorageType> probe_storage_type_overrides;
+std::atomic<bool> block_might_exist{false};
+std::atomic<bool> might_exist_block_entered{false};
+std::atomic<bool> release_might_exist{true};
+
+std::pair<ErrorCode, InstanceGroups> ListInstanceGroupStub(void *, RequestContext *) {
+    ++list_groups_call_count;
+    return {list_groups_ec, instance_groups};
+}
+
+std::pair<ErrorCode, InstanceInfos> ListInstanceInfoStub(void *, RequestContext *, const std::string &instance_group) {
+    const auto it = instances_by_group.find(instance_group);
+    if (it == instances_by_group.end()) {
+        return {EC_OK, {}};
+    }
+    return it->second;
+}
+
+std::shared_ptr<MetaIndexer> GetMetaIndexerStub(void *, const std::string &instance_id) {
+    active_instance_id = instance_id;
+    if (missing_indexers.count(instance_id) > 0) {
+        return nullptr;
+    }
+    return dummy_indexer;
+}
+
+std::shared_ptr<DataStorageBackend> GetDataStorageBackendStub(void *, const std::string &storage_name) {
+    if (missing_probe_storages.count(storage_name) > 0) {
+        return nullptr;
+    }
+    const auto it = probe_storage_type_overrides.find(storage_name);
+    const auto type = it == probe_storage_type_overrides.end() ? DataStorageType::DATA_STORAGE_TYPE_DUMMY : it->second;
+    return std::make_shared<ProbeTestBackend>(type);
+}
+
+ErrorCode ScanLocationsForMaintenanceStub(
+    void *, RequestContext *, const std::string &cursor, size_t, MaintenanceScanBatch &out) noexcept {
+    scan_calls.emplace_back(active_instance_id, cursor);
+    scan_call_count.fetch_add(1, std::memory_order_release);
+    if (block_scan.load(std::memory_order_acquire)) {
+        scan_block_entered.store(true, std::memory_order_release);
+        while (!release_scan.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+    auto &position = scan_positions[active_instance_id];
+    const auto responses_it = scan_responses.find(active_instance_id);
+    if (responses_it == scan_responses.end() || position >= responses_it->second.size()) {
+        out.Clear();
+        out.next_cursor = SCAN_BASE_CURSOR;
+        return EC_OK;
+    }
+    const ScanResponse &response = responses_it->second[position++];
+    if (response.ec != EC_OK) {
+        out.Clear();
+        return response.ec;
+    }
+    out = response.batch;
+    return EC_OK;
+}
+
+AsyncDeleteSubmitResult SubmitAsyncStub(void *, const CacheLocationDelRequest &request) {
+    submitted_requests.push_back(request);
+    if (submit_mode == SubmitMode::kThrow) {
+        throw std::runtime_error("injected SubmitAsync exception");
+    }
+    if (submit_mode == SubmitMode::kRejected) {
+        return {};
+    }
+    if (submit_mode == SubmitMode::kAcceptedInvalid) {
+        return {true, {}};
+    }
+
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto future = promise->get_future();
+    if (submit_mode == SubmitMode::kPending) {
+        pending_delete_promise = promise;
+        pending_delete_promises.push_back(promise);
+    } else if (submit_mode == SubmitMode::kFutureException) {
+        promise->set_exception(std::make_exception_ptr(std::runtime_error("injected Future exception")));
+    } else if (submit_mode == SubmitMode::kReadyPartial) {
+        promise->set_value({EC_PARTIAL_OK, "injected partial"});
+    } else {
+        promise->set_value({EC_OK, ""});
+    }
+    return {true, std::move(future)};
+}
+
+MetaIndexer::Result
+GetLocationsFromPersistentErrorStub(void *, RequestContext *, const KeyVector &, CacheLocationMapVector &) noexcept {
+    return MetaIndexer::Result(EC_ERROR);
+}
+
+std::vector<bool>
+DataStorageExistStub(void *, const std::string &storage_name, const std::vector<DataStorageUri> &uris, bool fastpath) {
+    might_exist_calls.push_back({storage_name, uris, fastpath});
+    if (block_might_exist.load(std::memory_order_acquire)) {
+        might_exist_block_entered.store(true, std::memory_order_release);
+        while (!release_might_exist.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+    if (might_exist_throw_storages.count(storage_name) > 0) {
+        throw std::runtime_error("injected MightExist exception");
+    }
+    if (const auto override_it = might_exist_result_overrides.find(storage_name);
+        override_it != might_exist_result_overrides.end()) {
+        return override_it->second;
+    }
+    std::vector<bool> result;
+    result.reserve(uris.size());
+    for (const auto &uri : uris) {
+        const auto it = might_exist_by_uri.find(uri.ToUriString());
+        result.push_back(it == might_exist_by_uri.end() || it->second);
+    }
+    return result;
+}
+
+std::shared_ptr<CacheLocation> MakeLocation(const std::string &id, CacheLocationStatus status, int64_t create_time_us) {
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id(id);
+    location->set_status(status);
+    location->set_create_time(create_time_us);
+    return location;
+}
+
+std::shared_ptr<CacheLocation> MakeStoredLocation(const std::string &id,
+                                                  CacheLocationStatus status,
+                                                  DataStorageType type,
+                                                  const std::vector<std::string> &uris) {
+    auto location = MakeLocation(id, status, TimestampUtil::GetCurrentTimeUs());
+    location->set_type(type);
+    location->set_spec_size(uris.size());
+    std::vector<LocationSpec> specs;
+    specs.reserve(uris.size());
+    for (size_t i = 0; i < uris.size(); ++i) {
+        specs.emplace_back("spec_" + std::to_string(i), uris[i]);
+    }
+    location->set_location_specs(std::move(specs));
+    return location;
+}
+
+MaintenanceScanBatch MakeBatch(const std::string &next_cursor,
+                               const KeyVector &keys,
+                               CacheLocationMapVector locations,
+                               std::vector<ErrorCode> results = {}) {
+    MaintenanceScanBatch batch;
+    batch.next_cursor = next_cursor;
+    batch.keys = keys;
+    batch.locations = std::move(locations);
+    batch.location_results = results.empty() ? std::vector<ErrorCode>(batch.keys.size(), EC_OK) : std::move(results);
+    return batch;
+}
+
+} // namespace
+
+class CacheGarbageCollectorTest : public TESTBASE {
+public:
+    void SetUp() override {
+        stub_.set(ADDR(RegistryManager, ListInstanceGroup), ListInstanceGroupStub);
+        stub_.set(ADDR(RegistryManager, ListInstanceInfo), ListInstanceInfoStub);
+        stub_.set(ADDR(MetaIndexerManager, GetMetaIndexer), GetMetaIndexerStub);
+        stub_.set(ADDR(MetaIndexer, ScanLocationsForMaintenance), ScanLocationsForMaintenanceStub);
+        stub_.set(ADDR(DataStorageManager, GetDataStorageBackend), GetDataStorageBackendStub);
+        stub_.set(ADDR(DataStorageManager, Exist), DataStorageExistStub);
+        stub_.set(static_cast<SubmitAsyncLocation>(ADDR(SchedulePlanExecutor, SubmitAsync)), SubmitAsyncStub);
+
+        metrics_registry_ = std::make_shared<MetricsRegistry>();
+        registry_manager_ = std::make_shared<RegistryManager>("", metrics_registry_);
+        meta_indexer_manager_ = std::make_shared<MetaIndexerManager>();
+        data_storage_manager_ = std::make_shared<DataStorageManager>(metrics_registry_);
+        executor_ =
+            std::make_shared<SchedulePlanExecutor>(1, meta_indexer_manager_, data_storage_manager_, metrics_registry_);
+        migration_manager_ = std::make_shared<MigrationManager>(
+            executor_, meta_indexer_manager_, data_storage_manager_, metrics_registry_);
+        dummy_indexer = std::make_shared<MetaIndexer>();
+
+        list_groups_ec = EC_OK;
+        instance_groups.clear();
+        instances_by_group.clear();
+        scan_responses.clear();
+        scan_positions.clear();
+        scan_calls.clear();
+        missing_indexers.clear();
+        active_instance_id.clear();
+        submitted_requests.clear();
+        submit_mode = SubmitMode::kReadyOk;
+        pending_delete_promise.reset();
+        pending_delete_promises.clear();
+        list_groups_call_count = 0;
+        scan_call_count.store(0, std::memory_order_relaxed);
+        block_scan.store(false, std::memory_order_relaxed);
+        scan_block_entered.store(false, std::memory_order_relaxed);
+        release_scan.store(true, std::memory_order_relaxed);
+        might_exist_calls.clear();
+        might_exist_by_uri.clear();
+        might_exist_result_overrides.clear();
+        might_exist_throw_storages.clear();
+        missing_probe_storages.clear();
+        probe_storage_type_overrides.clear();
+        block_might_exist.store(false, std::memory_order_relaxed);
+        might_exist_block_entered.store(false, std::memory_order_relaxed);
+        release_might_exist.store(true, std::memory_order_relaxed);
+        AddInstance("group_a", "instance_a");
+    }
+
+    void TearDown() override {
+        release_scan.store(true, std::memory_order_release);
+        release_might_exist.store(true, std::memory_order_release);
+        migration_manager_.reset();
+        executor_.reset();
+        dummy_indexer.reset();
+        pending_delete_promise.reset();
+        pending_delete_promises.clear();
+    }
+
+    void AddInstance(const std::string &group_name, const std::string &instance_id) {
+        auto group_it = std::find_if(instance_groups.begin(), instance_groups.end(), [&](const auto &group) {
+            return group && group->name() == group_name;
+        });
+        if (group_it == instance_groups.end()) {
+            auto group = std::make_shared<InstanceGroup>();
+            group->set_name(group_name);
+            instance_groups.push_back(group);
+        }
+        auto instance = std::make_shared<InstanceInfo>();
+        instance->set_instance_group_name(group_name);
+        instance->set_instance_id(instance_id);
+        instances_by_group[group_name].first = EC_OK;
+        instances_by_group[group_name].second.push_back(instance);
+    }
+
+    CacheGarbageCollector::Config DefaultConfig() const {
+        CacheGarbageCollector::Config config;
+        config.enabled = true;
+        config.scan_interval_ms = 1000;
+        config.round_pause_ms = 1000;
+        config.scan_batch_size = 2;
+        config.orphan_writing_grace_period_ms = kMinCacheGcOrphanWritingGracePeriodMs;
+        return config;
+    }
+
+    std::unique_ptr<CacheGarbageCollector> MakeGc(const CacheGarbageCollector::Config &config) {
+        return std::make_unique<CacheGarbageCollector>(config,
+                                                       registry_manager_,
+                                                       meta_indexer_manager_,
+                                                       data_storage_manager_,
+                                                       executor_,
+                                                       metrics_registry_,
+                                                       migration_manager_);
+    }
+
+    void PrepareForSingleStep(CacheGarbageCollector &gc) {
+        gc.RegisterMetrics();
+        gc.ResetWorkerState();
+        gc.stop_requested_.store(false);
+    }
+
+    bool WaitForScanCallCount(size_t expected) const {
+        for (size_t i = 0; i < 100; ++i) {
+            if (scan_call_count.load(std::memory_order_acquire) >= expected) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return false;
+    }
+
+    int64_t OldCreateTimeUs(const CacheGarbageCollector::Config &config, int64_t extra_us = 0) const {
+        return TimestampUtil::GetCurrentTimeUs() - config.orphan_writing_grace_period_ms * 1000 - extra_us;
+    }
+
+protected:
+    Stub stub_;
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::shared_ptr<RegistryManager> registry_manager_;
+    std::shared_ptr<MetaIndexerManager> meta_indexer_manager_;
+    std::shared_ptr<DataStorageManager> data_storage_manager_;
+    std::shared_ptr<SchedulePlanExecutor> executor_;
+    std::shared_ptr<MigrationManager> migration_manager_;
+};
+
+TEST_F(CacheGarbageCollectorTest, ConfigAndRestartableLifecycle) {
+    auto disabled_config = DefaultConfig();
+    disabled_config.enabled = false;
+    auto disabled_gc = MakeGc(disabled_config);
+    EXPECT_EQ(EC_OK, disabled_gc->Start());
+    EXPECT_FALSE(disabled_gc->IsRunning());
+
+    auto invalid_config = DefaultConfig();
+    invalid_config.orphan_writing_grace_period_ms = kMinCacheGcOrphanWritingGracePeriodMs - 1;
+    auto invalid_gc = MakeGc(invalid_config);
+    EXPECT_EQ(EC_CONFIG_ERROR, invalid_gc->Validate());
+
+    invalid_config = DefaultConfig();
+    invalid_config.max_inflight_delete_requests = 0;
+    invalid_gc = MakeGc(invalid_config);
+    EXPECT_EQ(EC_CONFIG_ERROR, invalid_gc->Validate());
+
+    auto gc = MakeGc(DefaultConfig());
+    ASSERT_EQ(EC_OK, gc->Start());
+    EXPECT_TRUE(gc->IsRunning());
+    EXPECT_EQ(EC_OK, gc->Start());
+    gc->RequestStop();
+    gc->RequestStop();
+    gc->Join();
+    gc->Join();
+    EXPECT_FALSE(gc->IsRunning());
+
+    ASSERT_EQ(EC_OK, gc->Start());
+    EXPECT_TRUE(gc->IsRunning());
+    gc->Stop();
+    EXPECT_FALSE(gc->IsRunning());
+}
+
+TEST_F(CacheGarbageCollectorTest, RestartBeginsScanningFromBaseCursor) {
+    auto config = DefaultConfig();
+    config.scan_interval_ms = 60000;
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch("cursor_after_first_start", {}, {})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+
+    auto gc = MakeGc(config);
+    ASSERT_EQ(EC_OK, gc->Start());
+    ASSERT_TRUE(WaitForScanCallCount(1));
+    gc->Stop();
+
+    ASSERT_EQ(EC_OK, gc->Start());
+    ASSERT_TRUE(WaitForScanCallCount(2));
+    gc->Stop();
+
+    ASSERT_EQ(2, scan_calls.size());
+    EXPECT_EQ(SCAN_BASE_CURSOR, scan_calls[0].second);
+    EXPECT_EQ(SCAN_BASE_CURSOR, scan_calls[1].second);
+}
+
+TEST_F(CacheGarbageCollectorTest, FixedPredicateIsFailClosedAndRequestIsBounded) {
+    auto config = DefaultConfig();
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    const int64_t grace_us = config.orphan_writing_grace_period_ms * 1000;
+    CacheLocationMap first_locations;
+    first_locations["old"] = MakeLocation("old", CLS_WRITING, now_us - grace_us);
+    first_locations["young"] = MakeLocation("young", CLS_WRITING, now_us - grace_us + 1);
+    first_locations["serving"] = MakeLocation("serving", CLS_SERVING, now_us - grace_us - 1);
+    first_locations["future"] = MakeLocation("future", CLS_WRITING, now_us + 1);
+    first_locations["zero"] = MakeLocation("zero", CLS_WRITING, 0);
+    first_locations["map_id"] = MakeLocation("different_id", CLS_WRITING, now_us - grace_us - 1);
+    CacheLocationMap second_locations;
+    second_locations["another"] = MakeLocation("another", CLS_WRITING, now_us - grace_us - 1);
+    CacheLocationMap third_locations;
+    third_locations["third"] = MakeLocation("third", CLS_WRITING, now_us - grace_us - 1);
+    CacheLocationMap duplicate_locations;
+    duplicate_locations["old"] = MakeLocation("old", CLS_WRITING, now_us - grace_us - 1);
+
+    const auto batch = MakeBatch(
+        SCAN_BASE_CURSOR, {10, 20, 30, 10}, {first_locations, second_locations, third_locations, duplicate_locations});
+    const CacheLocationDelRequest request = gc->BuildDeleteRequest("instance_a", batch, now_us);
+    ASSERT_EQ(2, request.block_keys.size());
+    EXPECT_EQ((KeyVector{10, 20}), request.block_keys);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"old"}, {"another"}}), request.location_ids);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{first_locations.at("old")->ToJsonString()},
+                                                     {second_locations.at("another")->ToJsonString()}}),
+              request.expected_location_values);
+    EXPECT_TRUE(request.authoritative_read);
+    EXPECT_EQ(3, gc->get_cache_gc_candidate_count_metrics());
+
+    MaintenanceScanBatch broken_batch = batch;
+    broken_batch.location_results.pop_back();
+    EXPECT_TRUE(gc->BuildDeleteRequest("instance_a", broken_batch, now_us).block_keys.empty());
+    EXPECT_TRUE(gc->BuildDeleteRequest("", batch, now_us).block_keys.empty());
+}
+
+TEST_F(CacheGarbageCollectorTest, ServingMissingSpecIsBatchedAndSubmittedWithExactSnapshot) {
+    auto config = DefaultConfig();
+    config.scan_batch_size = 10;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    const std::string missing_a_uri = "dummy://storage_a/missing_a?size=1";
+    const std::string existing_a_uri = "dummy://storage_a/existing_a?size=1";
+    const std::string existing_b_uri = "dummy://storage_a/existing_b?size=1";
+    const std::string missing_b_uri = "dummy://storage_b/missing_b?size=1";
+    might_exist_by_uri[missing_a_uri] = false;
+    might_exist_by_uri[missing_b_uri] = false;
+
+    CacheLocationMap first_locations;
+    first_locations["old_writing"] = MakeLocation("old_writing", CLS_WRITING, OldCreateTimeUs(config, /*extra_us=*/1));
+    first_locations["serving_missing"] = MakeStoredLocation(
+        "serving_missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_a_uri, existing_a_uri});
+    first_locations["serving_existing"] =
+        MakeStoredLocation("serving_existing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {existing_b_uri});
+    first_locations["event_report_missing"] = MakeStoredLocation("event_report_missing",
+                                                                 CLS_SERVING,
+                                                                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5,
+                                                                 {"event_report://event_storage/missing"});
+    first_locations["unknown_type"] = MakeStoredLocation(
+        "unknown_type", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_UNKNOWN, {"dummy://unknown_storage/missing"});
+    first_locations["malformed_uri"] =
+        MakeStoredLocation("malformed_uri", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {"not-a-uri"});
+
+    CacheLocationMap second_locations;
+    second_locations["second_missing"] =
+        MakeStoredLocation("second_missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_b_uri});
+
+    const auto batch = MakeBatch(SCAN_BASE_CURSOR, {10, 20}, {first_locations, second_locations});
+    const CacheLocationDelRequest request =
+        gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs());
+
+    EXPECT_EQ((KeyVector{10, 20}), request.block_keys);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"old_writing", "serving_missing"}, {"second_missing"}}),
+              request.location_ids);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{first_locations.at("old_writing")->ToJsonString(),
+                                                      first_locations.at("serving_missing")->ToJsonString()},
+                                                     {second_locations.at("second_missing")->ToJsonString()}}),
+              request.expected_location_values);
+
+    ASSERT_EQ(2, might_exist_calls.size());
+    const auto storage_a_call =
+        std::find_if(might_exist_calls.begin(), might_exist_calls.end(), [](const MightExistCall &call) {
+            return call.storage_name == "storage_a";
+        });
+    const auto storage_b_call =
+        std::find_if(might_exist_calls.begin(), might_exist_calls.end(), [](const MightExistCall &call) {
+            return call.storage_name == "storage_b";
+        });
+    ASSERT_NE(might_exist_calls.end(), storage_a_call);
+    ASSERT_NE(might_exist_calls.end(), storage_b_call);
+    EXPECT_TRUE(storage_a_call->fastpath);
+    EXPECT_TRUE(storage_b_call->fastpath);
+    EXPECT_EQ(3, storage_a_call->uris.size());
+    EXPECT_EQ(1, storage_b_call->uris.size());
+
+    EXPECT_EQ(1, gc->get_cache_gc_candidate_count_metrics());
+    EXPECT_EQ(
+        2, metrics_registry_->GetCounter("cache_gc.candidate_count", MetricsTags{{"reason", "storage_missing"}}).Get());
+}
+
+TEST_F(CacheGarbageCollectorTest, ServingProbeErrorsAreUnknownButOtherDefinitiveMissingStillWins) {
+    auto config = DefaultConfig();
+    config.scan_batch_size = 10;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    might_exist_result_overrides["shape_storage"] = {};
+    might_exist_throw_storages.insert("throw_storage");
+    might_exist_by_uri["dummy://missing_storage/missing?size=1"] = false;
+
+    CacheLocationMap locations;
+    locations["shape_only"] = MakeStoredLocation(
+        "shape_only", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {"dummy://shape_storage/value?size=1"});
+    locations["throw_only"] = MakeStoredLocation(
+        "throw_only", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {"dummy://throw_storage/value?size=1"});
+    locations["missing_and_unknown"] =
+        MakeStoredLocation("missing_and_unknown",
+                           CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                           {"dummy://shape_storage/unknown?size=1", "dummy://missing_storage/missing?size=1"});
+
+    const CacheLocationDelRequest request = gc->BuildDeleteRequest(
+        "instance_a", MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}), TimestampUtil::GetCurrentTimeUs());
+
+    EXPECT_EQ((KeyVector{10}), request.block_keys);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"missing_and_unknown"}}), request.location_ids);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{locations.at("missing_and_unknown")->ToJsonString()}}),
+              request.expected_location_values);
+    EXPECT_EQ(
+        1,
+        metrics_registry_->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "might_exist_shape"}})
+            .Get());
+    EXPECT_EQ(
+        1,
+        metrics_registry_->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "might_exist_exception"}})
+            .Get());
+}
+
+TEST_F(CacheGarbageCollectorTest, ServingProbeBatchesBoundEachMightExistCall) {
+    auto config = DefaultConfig();
+    config.scan_batch_size = 1;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    std::vector<std::string> uris;
+    uris.reserve(513);
+    for (size_t i = 0; i < 513; ++i) {
+        uris.push_back("dummy://storage_a/object_" + std::to_string(i) + "?size=1");
+    }
+    CacheLocationMap locations;
+    locations["serving"] = MakeStoredLocation("serving", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, uris);
+
+    const CacheLocationDelRequest request = gc->BuildDeleteRequest(
+        "instance_a", MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}), TimestampUtil::GetCurrentTimeUs());
+
+    EXPECT_TRUE(request.block_keys.empty());
+    ASSERT_EQ(2, might_exist_calls.size());
+    EXPECT_EQ(512, might_exist_calls[0].uris.size());
+    EXPECT_EQ(1, might_exist_calls[1].uris.size());
+}
+
+TEST_F(CacheGarbageCollectorTest, StopAfterActiveProbeSkipsRemainingMightExistBatches) {
+    auto config = DefaultConfig();
+    config.scan_interval_ms = 60000;
+
+    std::vector<std::string> uris;
+    uris.reserve(513);
+    for (size_t i = 0; i < 513; ++i) {
+        uris.push_back("dummy://storage_a/object_" + std::to_string(i) + "?size=1");
+    }
+    CacheLocationMap locations;
+    locations["serving"] = MakeStoredLocation("serving", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, uris);
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {10}, {locations})}};
+    block_might_exist.store(true, std::memory_order_release);
+    release_might_exist.store(false, std::memory_order_release);
+
+    auto gc = MakeGc(config);
+    ASSERT_EQ(EC_OK, gc->Start());
+    for (size_t i = 0; i < 100 && !might_exist_block_entered.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    if (!might_exist_block_entered.load(std::memory_order_acquire)) {
+        release_might_exist.store(true, std::memory_order_release);
+        gc->Stop();
+        FAIL() << "MightExist probe did not start";
+    }
+
+    gc->RequestStop();
+    release_might_exist.store(true, std::memory_order_release);
+    gc->Join();
+
+    ASSERT_EQ(1, might_exist_calls.size());
+    EXPECT_EQ(512, might_exist_calls.front().uris.size());
+    EXPECT_TRUE(submitted_requests.empty());
+}
+
+TEST_F(CacheGarbageCollectorTest, MissingOrMismatchedStorageIsUnknownAndClassifiedSeparately) {
+    auto config = DefaultConfig();
+    config.scan_batch_size = 10;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    missing_probe_storages.insert("unregistered_storage");
+    probe_storage_type_overrides["wrong_type_storage"] = DataStorageType::DATA_STORAGE_TYPE_NFS;
+    const std::string missing_uri = "dummy://healthy_storage/missing?size=1";
+    might_exist_by_uri[missing_uri] = false;
+
+    CacheLocationMap locations;
+    locations["unregistered"] = MakeStoredLocation("unregistered",
+                                                   CLS_SERVING,
+                                                   DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                                   {"dummy://unregistered_storage/value?size=1"});
+    locations["wrong_type"] = MakeStoredLocation("wrong_type",
+                                                 CLS_SERVING,
+                                                 DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                                 {"dummy://wrong_type_storage/value?size=1"});
+    locations["definitive_missing"] =
+        MakeStoredLocation("definitive_missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_uri});
+
+    const CacheLocationDelRequest request = gc->BuildDeleteRequest(
+        "instance_a", MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}), TimestampUtil::GetCurrentTimeUs());
+
+    EXPECT_EQ((KeyVector{10}), request.block_keys);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"definitive_missing"}}), request.location_ids);
+    ASSERT_EQ(1, might_exist_calls.size());
+    EXPECT_EQ("healthy_storage", might_exist_calls.front().storage_name);
+    EXPECT_EQ(
+        1,
+        metrics_registry_
+            ->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "might_exist_storage_not_found"}})
+            .Get());
+    EXPECT_EQ(
+        1,
+        metrics_registry_
+            ->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "might_exist_storage_type_mismatch"}})
+            .Get());
+}
+
+TEST_F(CacheGarbageCollectorTest, ActiveMigrationCopyTargetIsNotCollected) {
+    auto config = DefaultConfig();
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    MigrationManager::CopyTaskContext task;
+    task.instance_group_name = "group_a";
+    task.instance_id = "instance_a";
+    task.block_key = 10;
+    task.dst_location_id = "migration_target";
+    task.state = MigrationManager::CopyTaskState::kRunning;
+    migration_manager_->active_tasks_by_instance_["instance_a"].emplace(task.block_key, task);
+
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    CacheLocationMap migration_locations;
+    migration_locations["migration_target"] =
+        MakeLocation("migration_target", CLS_WRITING, now_us - config.orphan_writing_grace_period_ms * 1000 - 1);
+    CacheLocationMap orphan_locations;
+    orphan_locations["migration_target"] =
+        MakeLocation("migration_target", CLS_WRITING, now_us - config.orphan_writing_grace_period_ms * 1000 - 1);
+
+    const auto batch = MakeBatch(SCAN_BASE_CURSOR, {10, 20}, {migration_locations, orphan_locations});
+    const CacheLocationDelRequest same_instance_request = gc->BuildDeleteRequest("instance_a", batch, now_us);
+    const CacheLocationDelRequest other_instance_request =
+        gc->BuildDeleteRequest("instance_b", MakeBatch(SCAN_BASE_CURSOR, {10}, {migration_locations}), now_us);
+
+    EXPECT_EQ((KeyVector{20}), same_instance_request.block_keys);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"migration_target"}}), same_instance_request.location_ids);
+    EXPECT_EQ((KeyVector{10}), other_instance_request.block_keys);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"migration_target"}}), other_instance_request.location_ids);
+    EXPECT_EQ(2, gc->get_cache_gc_candidate_count_metrics());
+}
+
+TEST_F(CacheGarbageCollectorTest, MissingScannedKeyIsNotCountedAsOperationError) {
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+
+    const auto batch =
+        MakeBatch(SCAN_BASE_CURSOR, {1, 2}, {CacheLocationMap{}, CacheLocationMap{}}, {EC_NOENT, EC_ERROR});
+    EXPECT_TRUE(gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
+
+    EXPECT_EQ(
+        1, metrics_registry_->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "scan_key"}}).Get());
+}
+
+TEST_F(CacheGarbageCollectorTest, TickScansOneBatchAndSubmitsConditionalAsyncDelete) {
+    auto config = DefaultConfig();
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["loc"] = MakeLocation("loc", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {100}, {locations})}};
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    gc->RunOneTick();
+
+    ASSERT_EQ(1, scan_calls.size());
+    EXPECT_EQ(std::make_pair(std::string("instance_a"), SCAN_BASE_CURSOR), scan_calls.front());
+    ASSERT_EQ(1, submitted_requests.size());
+    EXPECT_EQ("instance_a", submitted_requests.front().instance_id);
+    EXPECT_EQ((KeyVector{100}), submitted_requests.front().block_keys);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"loc"}}), submitted_requests.front().location_ids);
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{locations.at("loc")->ToJsonString()}}),
+              submitted_requests.front().expected_location_values);
+    EXPECT_TRUE(submitted_requests.front().authoritative_read);
+    EXPECT_EQ(1, gc->inflight_deletes_.size());
+    EXPECT_EQ(1, gc->pending_locations_.size());
+}
+
+TEST_F(CacheGarbageCollectorTest, ScanFailureRetriesSameCursorWithoutBusyLoop) {
+    scan_responses["instance_a"] = {
+        {EC_ERROR, {}},
+        {EC_OK, MakeBatch("next", {}, {})},
+    };
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+
+    gc->RunOneTick();
+    ASSERT_EQ(1, scan_calls.size());
+    EXPECT_EQ(SCAN_BASE_CURSOR, gc->cursor_);
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+
+    gc->RunOneTick();
+    ASSERT_EQ(2, scan_calls.size());
+    EXPECT_EQ(SCAN_BASE_CURSOR, scan_calls[0].second);
+    EXPECT_EQ(SCAN_BASE_CURSOR, scan_calls[1].second);
+    EXPECT_EQ("next", gc->cursor_);
+}
+
+TEST_F(CacheGarbageCollectorTest, RegistryFailureDiscardsIncompleteSnapshot) {
+    AddInstance("group_b", "instance_b");
+    instances_by_group["group_b"].first = EC_ERROR;
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+
+    gc->RunOneTick();
+    EXPECT_FALSE(gc->round_active_);
+    EXPECT_TRUE(gc->instances_.empty());
+    EXPECT_TRUE(scan_calls.empty());
+
+    instances_by_group["group_b"].first = EC_OK;
+    gc->RunOneTick();
+    EXPECT_TRUE(gc->round_active_);
+    ASSERT_EQ(2, gc->instances_.size());
+    ASSERT_EQ(1, scan_calls.size());
+    EXPECT_EQ("instance_a", scan_calls.front().first);
+}
+
+TEST_F(CacheGarbageCollectorTest, InflightLimitBlocksScanAndReadyFutureResumes) {
+    auto config = DefaultConfig();
+    config.max_inflight_delete_requests = 1;
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap first_locations;
+    first_locations["loc_1"] = MakeLocation("loc_1", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch("next", {1}, {first_locations})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+    submit_mode = SubmitMode::kPending;
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    gc->RunOneTick();
+    ASSERT_EQ(1, scan_calls.size());
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+
+    gc->RunOneTick();
+    EXPECT_EQ(1, scan_calls.size());
+    ASSERT_TRUE(pending_delete_promise);
+    pending_delete_promise->set_value({EC_OK, ""});
+
+    gc->RunOneTick();
+    EXPECT_EQ(2, scan_calls.size());
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    EXPECT_EQ(1, gc->get_cache_gc_scan_round_count_metrics());
+}
+
+TEST_F(CacheGarbageCollectorTest, BoundedInflightWindowProgressesAroundOneStuckDelete) {
+    auto config = DefaultConfig();
+    config.max_inflight_delete_requests = 2;
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap first_locations;
+    first_locations["loc_1"] = MakeLocation("loc_1", CLS_WRITING, old_time);
+    CacheLocationMap second_locations;
+    second_locations["loc_2"] = MakeLocation("loc_2", CLS_WRITING, old_time);
+    CacheLocationMap third_locations;
+    third_locations["loc_3"] = MakeLocation("loc_3", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch("cursor_2", {1}, {first_locations})},
+        {EC_OK, MakeBatch("cursor_3", {2}, {second_locations})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {3}, {third_locations})},
+    };
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    submit_mode = SubmitMode::kPending;
+    gc->RunOneTick();
+    ASSERT_EQ(1, pending_delete_promises.size());
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+
+    submit_mode = SubmitMode::kReadyOk;
+    gc->RunOneTick();
+    ASSERT_EQ(2, gc->inflight_deletes_.size());
+    EXPECT_EQ(2, scan_calls.size());
+
+    gc->RunOneTick();
+    EXPECT_EQ(3, scan_calls.size());
+    EXPECT_EQ(3, submitted_requests.size());
+    EXPECT_EQ(2, gc->inflight_deletes_.size());
+    EXPECT_EQ(2, gc->pending_locations_.size());
+    EXPECT_EQ(2, gc->get_cache_gc_inflight_delete_count_metrics());
+
+    pending_delete_promises.front()->set_value({EC_OK, ""});
+    gc->RunOneTick();
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    EXPECT_EQ(0, gc->get_cache_gc_inflight_delete_count_metrics());
+    EXPECT_EQ(1, gc->get_cache_gc_scan_round_count_metrics());
+}
+
+TEST_F(CacheGarbageCollectorTest, PendingTargetDeduplicatesBeforeCasAndKeepsInstanceIsolation) {
+    auto config = DefaultConfig();
+    config.max_inflight_delete_requests = 2;
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["same_location"] = MakeLocation("same_location", CLS_WRITING, old_time);
+    const auto batch = MakeBatch("next", {9}, {locations});
+    scan_responses["instance_a"] = {
+        {EC_OK, batch},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {9}, {locations})},
+    };
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    submit_mode = SubmitMode::kPending;
+    gc->RunOneTick();
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+    ASSERT_EQ(1, gc->pending_locations_.size());
+
+    gc->RunOneTick();
+    EXPECT_EQ(2, scan_calls.size());
+    EXPECT_EQ(1, submitted_requests.size());
+    EXPECT_EQ(1, gc->inflight_deletes_.size());
+
+    EXPECT_TRUE(gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
+    EXPECT_FALSE(gc->BuildDeleteRequest("instance_b", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
+
+    pending_delete_promises.front()->set_value({EC_OK, ""});
+    gc->PollInflightDeletes();
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    EXPECT_FALSE(gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
+}
+
+TEST_F(CacheGarbageCollectorTest, PendingTargetRemainsDeduplicatedAcrossRoundBoundary) {
+    auto config = DefaultConfig();
+    config.max_inflight_delete_requests = 2;
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["same_location"] = MakeLocation("same_location", CLS_WRITING, old_time);
+    const auto batch = MakeBatch(SCAN_BASE_CURSOR, {9}, {locations});
+    scan_responses["instance_a"] = {{EC_OK, batch}, {EC_OK, batch}};
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    submit_mode = SubmitMode::kPending;
+    gc->RunOneTick();
+    ASSERT_FALSE(gc->round_active_);
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+    ASSERT_EQ(1, gc->pending_locations_.size());
+    ASSERT_EQ(1, submitted_requests.size());
+
+    gc->next_round_at_ = CacheGarbageCollector::Clock::now();
+    gc->RunOneTick();
+    EXPECT_EQ(2, scan_calls.size());
+    EXPECT_EQ(1, submitted_requests.size());
+    EXPECT_EQ(1, gc->inflight_deletes_.size());
+    EXPECT_EQ(1, gc->pending_locations_.size());
+
+    pending_delete_promises.front()->set_value({EC_OK, ""});
+}
+
+TEST_F(CacheGarbageCollectorTest, RealExecutorBacklogDoesNotBlockGcSubmitAndStopsFurtherScan) {
+    auto config = DefaultConfig();
+    config.max_inflight_delete_requests = 1;
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["loc_1"] = MakeLocation("loc_1", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch("next", {1}, {locations})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+
+    stub_.reset(static_cast<SubmitAsyncLocation>(ADDR(SchedulePlanExecutor, SubmitAsync)));
+    stub_.set(ADDR(MetaIndexer, GetLocationsFromPersistent), GetLocationsFromPersistentErrorStub);
+
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    const auto release_future = release_blocker.get_future().share();
+    ASSERT_TRUE(executor_->SubmitTask([&blocker_started, release_future]() {
+        blocker_started.set_value();
+        release_future.wait_for(std::chrono::seconds(2));
+    }));
+    ASSERT_EQ(std::future_status::ready, blocker_started.get_future().wait_for(std::chrono::seconds(1)));
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    const auto begin = std::chrono::steady_clock::now();
+    gc->RunOneTick();
+    const auto submit_cost = std::chrono::steady_clock::now() - begin;
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(submit_cost).count(), 100);
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+    ASSERT_EQ(1, scan_calls.size());
+
+    gc->RunOneTick();
+    EXPECT_EQ(1, scan_calls.size());
+
+    release_blocker.set_value();
+    ASSERT_EQ(std::future_status::ready, gc->inflight_deletes_.front().future.wait_for(std::chrono::seconds(1)));
+    gc->RunOneTick();
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_EQ(2, scan_calls.size());
+}
+
+TEST_F(CacheGarbageCollectorTest, RejectedAndBrokenSubmissionsDoNotOccupySlot) {
+    auto config = DefaultConfig();
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["loc"] = MakeLocation("loc", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch("next", {1}, {locations})}};
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    submit_mode = SubmitMode::kRejected;
+    gc->RunOneTick();
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+
+    scan_responses["instance_a"].push_back({EC_OK, MakeBatch("last", {2}, {locations})});
+    submit_mode = SubmitMode::kAcceptedInvalid;
+    gc->RunOneTick();
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+
+    scan_responses["instance_a"].push_back({EC_OK, MakeBatch(SCAN_BASE_CURSOR, {3}, {locations})});
+    submit_mode = SubmitMode::kThrow;
+    gc->RunOneTick();
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    EXPECT_EQ(3, submitted_requests.size());
+    EXPECT_EQ(
+        1,
+        metrics_registry_->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "submit_exception"}})
+            .Get());
+    EXPECT_EQ(0,
+              metrics_registry_->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "tick_exception"}})
+                  .Get());
+}
+
+TEST_F(CacheGarbageCollectorTest, FuturePartialAndExceptionAreTerminal) {
+    auto config = DefaultConfig();
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["loc"] = MakeLocation("loc", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch("next", {1}, {locations})},
+        {EC_OK, MakeBatch("last", {2}, {locations})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    submit_mode = SubmitMode::kReadyPartial;
+    gc->RunOneTick();
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+    submit_mode = SubmitMode::kFutureException;
+    gc->RunOneTick();
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+    gc->RunOneTick();
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    EXPECT_EQ(3, scan_calls.size());
+}
+
+TEST_F(CacheGarbageCollectorTest, SnapshotPreservesInstanceIsolationAndCooldown) {
+    AddInstance("group_a", "instance_b");
+    auto config = DefaultConfig();
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["same_location"] = MakeLocation("same_location", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {9}, {locations})}};
+    scan_responses["instance_b"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {9}, {locations})}};
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    gc->RunOneTick();
+    gc->RunOneTick();
+    gc->RunOneTick();
+    ASSERT_EQ(2, submitted_requests.size());
+    EXPECT_EQ("instance_a", submitted_requests[0].instance_id);
+    EXPECT_EQ("instance_b", submitted_requests[1].instance_id);
+    EXPECT_EQ(1, gc->get_cache_gc_scan_round_count_metrics());
+
+    const size_t snapshot_count = list_groups_call_count;
+    gc->RunOneTick();
+    EXPECT_EQ(snapshot_count, list_groups_call_count);
+}
+
+TEST_F(CacheGarbageCollectorTest, MissingIndexerAdvancesAndEmptyRequestIsNotSubmitted) {
+    AddInstance("group_a", "instance_b");
+    missing_indexers.insert("instance_a");
+    scan_responses["instance_b"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {1}, {CacheLocationMap{}})}};
+
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+    gc->RunOneTick();
+    EXPECT_TRUE(scan_calls.empty());
+    gc->RunOneTick();
+    EXPECT_EQ(1, scan_calls.size());
+    EXPECT_TRUE(submitted_requests.empty());
+    EXPECT_EQ(1, gc->get_cache_gc_scan_round_count_metrics());
+}
+
+TEST_F(CacheGarbageCollectorTest, StopInterruptsLongTickWait) {
+    auto config = DefaultConfig();
+    config.scan_interval_ms = 60000;
+    auto gc = MakeGc(config);
+    ASSERT_EQ(EC_OK, gc->Start());
+    const auto begin = std::chrono::steady_clock::now();
+    gc->RequestStop();
+    gc->Join();
+    const auto elapsed = std::chrono::steady_clock::now() - begin;
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), 1);
+}
+
+TEST_F(CacheGarbageCollectorTest, JoinDetachesPendingDeleteWithoutWaitingForFuture) {
+    auto config = DefaultConfig();
+    const int64_t old_time = OldCreateTimeUs(config, 1);
+    CacheLocationMap locations;
+    locations["loc_1"] = MakeLocation("loc_1", CLS_WRITING, old_time);
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {1}, {locations})}};
+    submit_mode = SubmitMode::kPending;
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    gc->RunOneTick();
+    ASSERT_EQ(1, gc->inflight_deletes_.size());
+    ASSERT_EQ(1, gc->pending_locations_.size());
+    ASSERT_TRUE(pending_delete_promise);
+
+    const auto begin = std::chrono::steady_clock::now();
+    gc->Join();
+    const auto elapsed = std::chrono::steady_clock::now() - begin;
+
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), 1);
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    EXPECT_EQ(0, gc->get_cache_gc_inflight_delete_count_metrics());
+    pending_delete_promise->set_value({EC_OK, ""});
+}
+
+TEST_F(CacheGarbageCollectorTest, JoinWaitsForActiveMaintenanceScan) {
+    auto config = DefaultConfig();
+    config.scan_interval_ms = 60000;
+    block_scan.store(true, std::memory_order_release);
+    release_scan.store(false, std::memory_order_release);
+
+    auto gc = MakeGc(config);
+    ASSERT_EQ(EC_OK, gc->Start());
+    for (size_t i = 0; i < 100 && !scan_block_entered.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    if (!scan_block_entered.load(std::memory_order_acquire)) {
+        release_scan.store(true, std::memory_order_release);
+        gc->Stop();
+        FAIL() << "maintenance scan did not start";
+    }
+
+    auto join_future = std::async(std::launch::async, [&gc]() {
+        gc->RequestStop();
+        gc->Join();
+    });
+    EXPECT_EQ(std::future_status::timeout, join_future.wait_for(std::chrono::milliseconds(50)));
+
+    release_scan.store(true, std::memory_order_release);
+    ASSERT_EQ(std::future_status::ready, join_future.wait_for(std::chrono::seconds(1)));
+    join_future.get();
+    EXPECT_FALSE(gc->IsRunning());
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -860,6 +860,30 @@ TEST_F(CacheManagerTest, TestCleanup) {
     ASSERT_EQ("test_instance", meta_indexer->instance_id_);
 }
 
+TEST_F(CacheManagerTest, TestCleanupStopsActiveCacheGarbageCollector) {
+    CacheGarbageCollector::Config config;
+    config.enabled = true;
+    config.scan_interval_ms = 60000;
+    config.round_pause_ms = 60000;
+    config.scan_batch_size = 1;
+    config.orphan_writing_grace_period_ms = kMinCacheGcOrphanWritingGracePeriodMs;
+
+    auto collector = std::make_shared<CacheGarbageCollector>(config,
+                                                             cache_manager_->registry_manager_,
+                                                             cache_manager_->meta_indexer_manager_,
+                                                             cache_manager_->registry_manager_->data_storage_manager(),
+                                                             cache_manager_->schedule_plan_executor_,
+                                                             cache_manager_->metrics_registry_,
+                                                             cache_manager_->migration_manager_);
+    cache_manager_->cache_garbage_collector_ = collector;
+    ASSERT_EQ(EC_OK, cache_manager_->StartCacheGarbageCollector());
+    ASSERT_TRUE(collector->IsRunning());
+
+    ASSERT_EQ(EC_OK, cache_manager_->DoCleanup());
+    EXPECT_FALSE(collector->IsRunning());
+    EXPECT_EQ(nullptr, cache_manager_->meta_indexer_manager_->GetMetaIndexer("test_instance"));
+}
+
 TEST_F(CacheManagerTest, TestStartWriteCache) {
     auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
     ASSERT_EQ(expected,

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -114,6 +114,29 @@ public:
         return meta_manager_->CreateMetaIndexer(instance_id, meta_indexer_config);
     }
 
+    ErrorCode CreateCachedMetaIndexer(const std::string &instance_id, const std::string &path) {
+        std::filesystem::remove(path);
+        auto backend_config = std::make_shared<MetaStorageBackendConfig>();
+        backend_config->SetStorageType(META_CACHED_BACKEND_TYPE_STR);
+        backend_config->SetStorageUri("file://" + path + "?persistent_type=dummy&cache_type=local");
+        auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();
+        meta_indexer_config->meta_storage_backend_config_ = std::move(backend_config);
+        meta_indexer_config->mutex_shard_num_ = 32;
+        meta_indexer_config->max_key_count_ = 10000;
+        return meta_manager_->CreateMetaIndexer(instance_id, meta_indexer_config);
+    }
+
+    static void WaitForCachedMetaIndexerRunning(const std::shared_ptr<MetaIndexer> &indexer) {
+        ASSERT_TRUE(indexer);
+        for (int i = 0; i < 100; ++i) {
+            if (indexer->backend_manager_->GetRecoverState() == MetaStorageBackendManager::RecoverState::kRunning) {
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        FAIL() << "cached metadata recovery did not finish in time";
+    }
+
     ErrorCode CreateDataStorage() {
         auto nfs_storage_spec = std::make_shared<NfsStorageSpec>();
         nfs_storage_spec->set_root_path("/mnt/nfs");
@@ -769,8 +792,7 @@ TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBack
     };
 
     std::atomic<size_t> delete_calls{0};
-    data_storage_manager_->storage_map_["external_cache"] =
-        std::make_shared<CountingDeleteBackend>(delete_calls);
+    data_storage_manager_->storage_map_["external_cache"] = std::make_shared<CountingDeleteBackend>(delete_calls);
 
     auto request_context = std::make_shared<RequestContext>("metadata_only_delete");
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
@@ -798,17 +820,15 @@ TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBack
 
     std::vector<CacheLocationMap> location_maps;
     BlockMask empty_mask;
-    ASSERT_EQ(EC_OK,
-              meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
     ASSERT_EQ(1u, location_maps.size());
     EXPECT_TRUE(location_maps.front().empty());
 
     const int64_t control_block_key = 702;
     std::vector<std::string> control_location_ids;
-    ASSERT_EQ(
-        EC_OK,
-        BatchAddLocationForTest(
-            &meta_searcher, request_context.get(), {control_block_key}, {location}, control_location_ids));
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(
+                  &meta_searcher, request_context.get(), {control_block_key}, {location}, control_location_ids));
     ASSERT_EQ(1u, control_location_ids.size());
     CacheLocationDelRequest control_request{
         .instance_id = kTestInstanceName,
@@ -1319,7 +1339,10 @@ TEST_F(SchedulePlanExecutorTest, TestCopyTaskShortResultVector) {
     // 注入一个 Copy 返回短 vector 的 mock 后端（覆盖真实 dummy backend）。
     class ShortCopyBackend : public DataStorageBackend {
     public:
-        ShortCopyBackend() : DataStorageBackend(nullptr) { SetOpen(true); SetAvailable(true); }
+        ShortCopyBackend() : DataStorageBackend(nullptr) {
+            SetOpen(true);
+            SetAvailable(true);
+        }
         DataStorageType GetType() override { return DataStorageType::DATA_STORAGE_TYPE_DUMMY; }
         bool Available() override { return true; }
         double GetStorageUsageRatio(const std::string &) const override { return 0.0; }
@@ -1327,12 +1350,22 @@ TEST_F(SchedulePlanExecutorTest, TestCopyTaskShortResultVector) {
         ErrorCode DoOpen(const StorageConfig &, const std::string &) override { return EC_OK; }
         ErrorCode Close() override { return EC_OK; }
         std::vector<std::pair<ErrorCode, DataStorageUri>>
-        Create(const std::vector<std::string> &, size_t, const std::string &, std::function<void()>) override { return {}; }
+        Create(const std::vector<std::string> &, size_t, const std::string &, std::function<void()>) override {
+            return {};
+        }
         std::vector<ErrorCode>
-        Delete(const std::vector<DataStorageUri> &, const std::string &, std::function<void()>) override { return {}; }
-        std::vector<bool> Exist(const std::vector<DataStorageUri> &u) override { return std::vector<bool>(u.size(), true); }
-        std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &u) override { return std::vector<ErrorCode>(u.size(), EC_OK); }
-        std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &u) override { return std::vector<ErrorCode>(u.size(), EC_OK); }
+        Delete(const std::vector<DataStorageUri> &, const std::string &, std::function<void()>) override {
+            return {};
+        }
+        std::vector<bool> Exist(const std::vector<DataStorageUri> &u) override {
+            return std::vector<bool>(u.size(), true);
+        }
+        std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &u) override {
+            return std::vector<ErrorCode>(u.size(), EC_OK);
+        }
+        std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &u) override {
+            return std::vector<ErrorCode>(u.size(), EC_OK);
+        }
         std::vector<ErrorCode> Copy(const std::vector<DataStorageUri> &src,
                                     const std::vector<DataStorageUri> &,
                                     const std::string &) override {
@@ -1429,8 +1462,8 @@ TEST_F(SchedulePlanExecutorTest, TestMigrationBudgetLeavesWorkerForReclaim) {
     std::promise<void> reclaim_ran;
     auto reclaim_future = reclaim_ran.get_future();
     const bool reclaim_accepted = executor.SubmitTask(ScheduleTaskClass::kReclaim, [&]() { reclaim_ran.set_value(); });
-    const bool reclaim_completed = reclaim_accepted &&
-                                   reclaim_future.wait_for(std::chrono::seconds(3)) == std::future_status::ready;
+    const bool reclaim_completed =
+        reclaim_accepted && reclaim_future.wait_for(std::chrono::seconds(3)) == std::future_status::ready;
 
     {
         std::lock_guard<std::mutex> lock(mutex);
@@ -1474,17 +1507,15 @@ TEST_F(SchedulePlanExecutorTest, TestMigrationBudgetClampAppliesAcrossPrepareAnd
             cv.notify_all();
         };
 
-        const bool prepare_accepted =
-            executor->SubmitTask(ScheduleTaskClass::kMigrationPrepare, migration_task);
+        const bool prepare_accepted = executor->SubmitTask(ScheduleTaskClass::kMigrationPrepare, migration_task);
         const bool continuation_accepted =
             executor->SubmitTask(ScheduleTaskClass::kMigrationContinuation, migration_task);
 
         bool expected_concurrency_reached = false;
         {
             std::unique_lock<std::mutex> lock(mutex);
-            expected_concurrency_reached = cv.wait_for(lock, std::chrono::seconds(3), [&]() {
-                return running_migrations == expected_running;
-            });
+            expected_concurrency_reached =
+                cv.wait_for(lock, std::chrono::seconds(3), [&]() { return running_migrations == expected_running; });
         }
 
         // With a clamped budget of one, the second worker must remain available for reclaim
@@ -1495,8 +1526,8 @@ TEST_F(SchedulePlanExecutorTest, TestMigrationBudgetClampAppliesAcrossPrepareAnd
             auto reclaim_future = reclaim_ran.get_future();
             const bool reclaim_accepted =
                 executor->SubmitTask(ScheduleTaskClass::kReclaim, [&]() { reclaim_ran.set_value(); });
-            reclaim_completed = reclaim_accepted &&
-                                reclaim_future.wait_for(std::chrono::seconds(3)) == std::future_status::ready;
+            reclaim_completed =
+                reclaim_accepted && reclaim_future.wait_for(std::chrono::seconds(3)) == std::future_status::ready;
         }
 
         {
@@ -1507,9 +1538,7 @@ TEST_F(SchedulePlanExecutorTest, TestMigrationBudgetClampAppliesAcrossPrepareAnd
         bool all_completed = false;
         {
             std::unique_lock<std::mutex> lock(mutex);
-            all_completed = cv.wait_for(lock, std::chrono::seconds(3), [&]() {
-                return completed_migrations == 2;
-            });
+            all_completed = cv.wait_for(lock, std::chrono::seconds(3), [&]() { return completed_migrations == 2; });
         }
 
         EXPECT_TRUE(prepare_accepted);
@@ -1587,4 +1616,121 @@ TEST_F(SchedulePlanExecutorTest, TestMigrationExceptionReleasesBudget) {
     ASSERT_TRUE(executor.SubmitTask(ScheduleTaskClass::kMigrationPrepare, [&]() { second_ran.set_value(); }));
 
     EXPECT_EQ(std::future_status::ready, second_future.wait_for(std::chrono::seconds(3)));
+}
+
+TEST_F(SchedulePlanExecutorTest, TestLocationRefreshWinsBeforeConditionalAsyncAdmission) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("finish_before_gc_admission_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc",
+                                                            "nfs://nfs_01/finish_before_gc_admission?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {912}, {location}, location_ids));
+    ASSERT_EQ(1, location_ids.size());
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {912}, empty_mask, location_maps));
+    ASSERT_EQ(1, location_maps.size());
+    ASSERT_EQ(1, location_maps.front().size());
+    const std::string expected_location_value = location_maps.front().at(location_ids.front())->ToJsonString();
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    const auto release_future = release_blocker.get_future().share();
+    ASSERT_TRUE(executor.SubmitTask([&blocker_started, release_future]() {
+        blocker_started.set_value();
+        release_future.wait_for(std::chrono::seconds(2));
+    }));
+    ASSERT_EQ(std::future_status::ready, blocker_started.get_future().wait_for(std::chrono::seconds(1)));
+
+    CacheLocationDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {912},
+        .location_ids = {{location_ids.front()}},
+        .expected_location_values = {{expected_location_value}},
+    };
+    auto submit_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(submit_result.accepted);
+    ASSERT_TRUE(submit_result.future.valid());
+
+    std::vector<std::vector<ErrorCode>> update_results;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchUpdateLocationStatus(request_context.get(),
+                                                      {912},
+                                                      {{{location_ids.front(), CacheLocationStatus::CLS_SERVING}}},
+                                                      update_results));
+
+    release_blocker.set_value();
+    const auto result = submit_result.future.get();
+    EXPECT_EQ(ErrorCode::EC_OK, result.status) << result.error_message;
+
+    location_maps.clear();
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {912}, empty_mask, location_maps));
+    ASSERT_EQ(1, location_maps.size());
+    ASSERT_EQ(1, location_maps.front().size());
+    EXPECT_EQ(CacheLocationStatus::CLS_SERVING, location_maps.front().at(location_ids.front())->status());
+}
+
+TEST_F(SchedulePlanExecutorTest, TestAuthoritativeAdmissionRefreshesCachedMetadataBeforeConditionalDelete) {
+    const std::string instance_id = "cached_authoritative_delete";
+    const std::string persistent_path = GetPrivateTestRuntimeDataPath() + "schedule_plan_executor_cached_authoritative";
+    ASSERT_EQ(EC_OK, CreateCachedMetaIndexer(instance_id, persistent_path));
+    const auto indexer = meta_manager_->GetMetaIndexer(instance_id);
+    WaitForCachedMetaIndexerRunning(indexer);
+
+    auto request_context = std::make_shared<RequestContext>("cached_authoritative_delete_test");
+    MetaSearcher meta_searcher(indexer);
+    const int64_t block_key = 913;
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("default",
+                                                            "nfs://nfs_01/cached_authoritative_delete?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {location}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    const std::string expected_value = location_maps.front().at(location_ids.front())->ToJsonString();
+
+    // Simulate a Running dual-backend instance whose authoritative metadata
+    // still contains the key after the local hot-cache entry was evicted.
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), indexer->backend_manager_->cache_backend_->Delete(nullptr, {block_key}));
+    location_maps.clear();
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_TRUE(location_maps.front().empty());
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheLocationDelRequest request{
+        .instance_id = instance_id,
+        .block_keys = {block_key},
+        .location_ids = {{location_ids.front()}},
+        .expected_location_values = {{expected_value}},
+        .metadata_only = true,
+        .authoritative_read = true,
+    };
+    const PlanExecuteResult result = executor.Submit(request).get();
+    ASSERT_EQ(EC_OK, result.status) << result.error_message;
+
+    CacheLocationMapVector persistent_locations;
+    const auto persistent_results =
+        indexer->backend_manager_->GetLocationsFromPersistent(request_context.get(), {block_key}, persistent_locations);
+    ASSERT_EQ(1u, persistent_results.size());
+    ASSERT_EQ(1u, persistent_locations.size());
+    EXPECT_TRUE(persistent_results.front() == EC_NOENT || persistent_locations.front().empty());
 }

--- a/kv_cache_manager/meta/meta_async_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_async_redis_backend.cc
@@ -568,6 +568,33 @@ ErrorCode MetaAsyncRedisBackend::ListKeys(RequestContext * /*request_context*/,
     return EC_OK;
 }
 
+ErrorCode MetaAsyncRedisBackend::ScanLocationsForMaintenance(RequestContext *request_context,
+                                                             const std::string &cursor,
+                                                             const int64_t limit,
+                                                             MaintenanceScanBatch &out) noexcept {
+    MaintenanceScanBatch batch;
+    ErrorCode ec = ListKeys(request_context, cursor, limit, batch.next_cursor, batch.keys);
+    if (ec != EC_OK) {
+        out.Clear();
+        return ec;
+    }
+    if (!batch.keys.empty()) {
+        batch.location_results = GetLocations(request_context, batch.keys, batch.locations);
+    }
+    if (batch.locations.size() != batch.keys.size() || batch.location_results.size() != batch.keys.size()) {
+        KVCM_LOG_ERROR(
+            "async redis maintenance scan shape mismatch, instance[%s] keys[%zu] locations[%zu] results[%zu]",
+            instance_id_.c_str(),
+            batch.keys.size(),
+            batch.locations.size(),
+            batch.location_results.size());
+        out.Clear();
+        return EC_ERROR;
+    }
+    out = std::move(batch);
+    return EC_OK;
+}
+
 ErrorCode MetaAsyncRedisBackend::RandomSample(RequestContext * /*request_context*/,
                                               const int64_t count,
                                               KeyTypeVec &out_keys) noexcept {

--- a/kv_cache_manager/meta/meta_async_redis_backend.h
+++ b/kv_cache_manager/meta/meta_async_redis_backend.h
@@ -69,6 +69,10 @@ public:
                        const int64_t limit,
                        std::string &out_next_cursor,
                        KeyTypeVec &out_keys) noexcept override;
+    ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
+                                          const std::string &cursor,
+                                          int64_t limit,
+                                          MaintenanceScanBatch &out) noexcept override;
     ErrorCode
     RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
     ErrorCode

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -435,6 +435,30 @@ ErrorCode MetaDummyBackend::ListKeys(RequestContext * /*request_context*/,
     return ErrorCode::EC_OK;
 }
 
+ErrorCode MetaDummyBackend::ScanLocationsForMaintenance(RequestContext *request_context,
+                                                        const std::string &cursor,
+                                                        const int64_t limit,
+                                                        MaintenanceScanBatch &out) noexcept {
+    MaintenanceScanBatch batch;
+    ErrorCode ec = ListKeys(request_context, cursor, limit, batch.next_cursor, batch.keys);
+    if (ec != EC_OK) {
+        out.Clear();
+        return ec;
+    }
+
+    batch.locations.resize(batch.keys.size());
+    batch.location_results.resize(batch.keys.size(), EC_OK);
+    for (size_t i = 0; i < batch.keys.size(); ++i) {
+        const bool found =
+            table_.FindAndApply(batch.keys[i], [&](const DummyItem &item) { batch.locations[i] = item.locations; });
+        if (!found) {
+            batch.location_results[i] = EC_NOENT;
+        }
+    }
+    out = std::move(batch);
+    return EC_OK;
+}
+
 ErrorCode MetaDummyBackend::RandomSample(RequestContext * /*request_context*/,
                                          const std::int64_t count,
                                          KeyTypeVec &out_keys) noexcept {

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -94,6 +94,10 @@ public:
                        std::int64_t limit,
                        std::string &out_next_cursor,
                        KeyTypeVec &out_keys) noexcept override;
+    ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
+                                          const std::string &cursor,
+                                          int64_t limit,
+                                          MaintenanceScanBatch &out) noexcept override;
     ErrorCode RandomSample(RequestContext *request_context, std::int64_t count, KeyTypeVec &out_keys) noexcept override;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, std::int64_t count, KeyTypeVec &out_keys) noexcept override;

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -4,6 +4,7 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <set>
 #include <string>
 #include <vector>
@@ -480,7 +481,8 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                                                                  const KeyVector &keys,
                                                                  const LocationIdsPerKey &location_ids,
                                                                  const LocationModifierFunc &modifier,
-                                                                 bool adjust_reclaimed_key_count) noexcept {
+                                                                 bool adjust_reclaimed_key_count,
+                                                                 bool refresh_cache_from_persistent) noexcept {
     const auto &trace_id = request_context->trace_id();
     if (keys.empty()) {
         return LocationResult(EC_OK);
@@ -518,9 +520,42 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         const auto &batch_keys = batch.batch_keys;
         LocationsPerKey batch_locations_per_key;
         const int64_t begin_get = TimestampUtil::GetCurrentTimeUs();
+        std::vector<ErrorCode> refresh_results;
+        if (refresh_cache_from_persistent) {
+            // Maintenance candidates originate from the persistent scan. Under
+            // the same shard lock as the CAS, replace a missing or stale hot
+            // cache entry with the complete source-of-truth key first.
+            refresh_results = backend_manager_->RefreshCacheFromPersistent(ephemeral_request_context.get(), batch_keys);
+        }
         std::vector<std::vector<ErrorCode>> get_ecs_per_key = backend_manager_->GetLocations(
             ephemeral_request_context.get(), batch_keys, batch.batch_location_ids, batch_locations_per_key);
         stats.get_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin_get;
+        if (get_ecs_per_key.size() != batch_keys.size() || batch_locations_per_key.size() != batch_keys.size() ||
+            (refresh_cache_from_persistent && refresh_results.size() != batch_keys.size())) {
+            PREFIX_INDEXER_LOG(ERROR,
+                               "ReadModifyWriteLocation read shape mismatch, keys[%lu] ecs[%lu] locations[%lu] "
+                               "refresh[%lu]",
+                               batch_keys.size(),
+                               get_ecs_per_key.size(),
+                               batch_locations_per_key.size(),
+                               refresh_results.size());
+            for (const int32_t global_idx : batch.batch_indexs) {
+                location_result.per_location_error_codes[global_idx].assign(location_ids[global_idx].size(), EC_ERROR);
+            }
+            error_count += static_cast<int32_t>(batch.batch_indexs.size());
+            continue;
+        }
+        for (size_t i = 0; i < batch_keys.size(); ++i) {
+            const size_t location_count = batch.batch_location_ids[i].size();
+            if (get_ecs_per_key[i].size() != location_count || batch_locations_per_key[i].size() != location_count) {
+                get_ecs_per_key[i].assign(location_count, EC_ERROR);
+                batch_locations_per_key[i].assign(location_count, nullptr);
+            }
+            if (refresh_cache_from_persistent && refresh_results[i] != EC_OK) {
+                get_ecs_per_key[i].assign(location_count, refresh_results[i]);
+                batch_locations_per_key[i].assign(location_count, nullptr);
+            }
+        }
         int64_t v = 0;
         auto *ephemeral_service_metrics_collector =
             dynamic_cast<ServiceMetricsCollector *>(ephemeral_request_context->metrics_collector());
@@ -683,6 +718,28 @@ MetaIndexer::Result MetaIndexer::GetLocations(RequestContext *request_context,
     return result;
 }
 
+MetaIndexer::Result MetaIndexer::GetLocationsFromPersistent(RequestContext *request_context,
+                                                            const KeyVector &keys,
+                                                            CacheLocationMapVector &out_location_maps) noexcept {
+    if (keys.empty()) {
+        out_location_maps.clear();
+        return Result(EC_OK);
+    }
+    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
+    const auto &trace_id = request_context->trace_id();
+
+    const int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
+    auto error_codes = backend_manager_->GetLocationsFromPersistent(request_context, keys, out_location_maps);
+    KVCM_METRICS_COLLECTOR_SET_METRICS(
+        service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
+
+    Result result(keys.size());
+    const int32_t error_count = ProcessErrorCodes(trace_id, error_codes, {}, keys, kGetMetaOperation, result);
+    ProcessErrorResult(trace_id, kGetMetaOperation, error_count, keys.size(), result);
+    return result;
+}
+
 MetaIndexer::LocationResult MetaIndexer::GetLocations(RequestContext *request_context,
                                                       const KeyVector &keys,
                                                       const LocationIdsPerKey &location_ids,
@@ -766,6 +823,30 @@ ErrorCode MetaIndexer::Scan(RequestContext *request_context,
             limit,
             out_next_cursor.c_str(),
             out_keys.size());
+    }
+    return ec;
+}
+
+ErrorCode MetaIndexer::ScanLocationsForMaintenance(RequestContext *request_context,
+                                                   const std::string &cursor,
+                                                   const size_t limit,
+                                                   MaintenanceScanBatch &out) noexcept {
+    out.Clear();
+    if (limit == 0 || limit > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+        KVCM_LOG_ERROR("instance[%s] maintenance scan invalid limit[%zu], cursor[%s]",
+                       instance_id_.c_str(),
+                       limit,
+                       cursor.c_str());
+        return EC_BADARGS;
+    }
+    ErrorCode ec =
+        backend_manager_->ScanLocationsForMaintenance(request_context, cursor, static_cast<int64_t>(limit), out);
+    if (ec != EC_OK) {
+        KVCM_LOG_ERROR("instance[%s] maintenance scan failed, cursor[%s] limit[%zu] ec[%d]",
+                       instance_id_.c_str(),
+                       cursor.c_str(),
+                       limit,
+                       ec);
     }
     return ec;
 }

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -75,7 +75,8 @@ public:
                                            const KeyVector &keys,
                                            const LocationIdsPerKey &location_ids,
                                            const LocationModifierFunc &modifier,
-                                           bool adjust_reclaimed_key_count = true) noexcept;
+                                           bool adjust_reclaimed_key_count = true,
+                                           bool refresh_cache_from_persistent = false) noexcept;
 
     // ---------- READ ----------
     Result Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept;
@@ -86,6 +87,11 @@ public:
     Result GetLocations(RequestContext *request_context,
                         const KeyVector &keys,
                         CacheLocationMapVector &out_location_maps) noexcept;
+    // Source-of-truth read used by maintenance admission. It never backfills
+    // or touches the optional hot-cache backend.
+    Result GetLocationsFromPersistent(RequestContext *request_context,
+                                      const KeyVector &keys,
+                                      CacheLocationMapVector &out_location_maps) noexcept;
     LocationResult GetLocations(RequestContext *request_context,
                                 const KeyVector &keys,
                                 const LocationIdsPerKey &location_ids,
@@ -99,6 +105,10 @@ public:
                    const size_t limit,
                    std::string &out_next_cursor,
                    KeyVector &out_keys) noexcept;
+    ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
+                                          const std::string &cursor,
+                                          size_t limit,
+                                          MaintenanceScanBatch &out) noexcept;
     ErrorCode RandomSample(RequestContext *request_context, const size_t count, KeyVector &out_keys) const noexcept;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyVector &out_keys) const noexcept;

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -597,6 +597,51 @@ ErrorCode MetaLocalBackend::ListKeys(RequestContext * /*request_context*/,
     return EC_OK;
 }
 
+ErrorCode MetaLocalBackend::ScanLocationsForMaintenance(RequestContext * /*request_context*/,
+                                                        const std::string &cursor,
+                                                        const int64_t limit,
+                                                        MaintenanceScanBatch &out) noexcept {
+    out.Clear();
+
+    int64_t start_shard = 0;
+    if (!StringUtil::StrToInt64(cursor.c_str(), start_shard) || start_shard < 0 || start_shard > shard_mask_) {
+        return EC_BADARGS;
+    }
+
+    const uint32_t num_shards = shard_mask_ + 1;
+    int64_t collected = 0;
+    for (uint32_t shard_id = static_cast<uint32_t>(start_shard); shard_id < num_shards; ++shard_id) {
+        cache_->ApplyToSingleShard(shard_id,
+                                   [&](const std::string_view &key,
+                                       Cache::ObjectPtr value,
+                                       size_t /*charge*/,
+                                       const Cache::CacheItemHelper * /*helper*/) {
+                                       if (key.size() != sizeof(KeyType) || value == nullptr) {
+                                           return;
+                                       }
+                                       const auto *item = static_cast<const MetaMemCacheItem *>(value);
+                                       CacheLocationMap locations;
+                                       {
+                                           std::shared_lock lock(item->GetMutex());
+                                           locations = item->GetLocations();
+                                       }
+                                       out.keys.push_back(ViewToKey(key));
+                                       out.locations.emplace_back(std::move(locations));
+                                       out.location_results.push_back(EC_OK);
+                                       ++collected;
+                                   });
+
+        if (collected >= limit) {
+            const uint32_t next_shard = shard_id + 1;
+            out.next_cursor = (next_shard >= num_shards) ? SCAN_BASE_CURSOR : std::to_string(next_shard);
+            return EC_OK;
+        }
+    }
+
+    out.next_cursor = SCAN_BASE_CURSOR;
+    return EC_OK;
+}
+
 ErrorCode MetaLocalBackend::RandomSample(RequestContext * /*request_context*/,
                                          const int64_t count,
                                          std::vector<KeyType> &out_keys) noexcept {

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -157,6 +157,10 @@ public:
                        const int64_t limit,
                        std::string &out_next_cursor,
                        std::vector<KeyType> &out_keys) noexcept override;
+    ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
+                                          const std::string &cursor,
+                                          int64_t limit,
+                                          MaintenanceScanBatch &out) noexcept override;
     ErrorCode RandomSample(RequestContext *request_context,
                            const int64_t count,
                            std::vector<KeyType> &out_keys) noexcept override;

--- a/kv_cache_manager/meta/meta_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_redis_backend.cc
@@ -420,6 +420,32 @@ ErrorCode MetaRedisBackend::ListKeys(RequestContext * /*request_context*/,
     return EC_OK;
 }
 
+ErrorCode MetaRedisBackend::ScanLocationsForMaintenance(RequestContext *request_context,
+                                                        const std::string &cursor,
+                                                        const int64_t limit,
+                                                        MaintenanceScanBatch &out) noexcept {
+    MaintenanceScanBatch batch;
+    ErrorCode ec = ListKeys(request_context, cursor, limit, batch.next_cursor, batch.keys);
+    if (ec != EC_OK) {
+        out.Clear();
+        return ec;
+    }
+    if (!batch.keys.empty()) {
+        batch.location_results = GetLocations(request_context, batch.keys, batch.locations);
+    }
+    if (batch.locations.size() != batch.keys.size() || batch.location_results.size() != batch.keys.size()) {
+        KVCM_LOG_ERROR("maintenance scan result shape mismatch, instance[%s] keys[%zu] locations[%zu] results[%zu]",
+                       instance_id_.c_str(),
+                       batch.keys.size(),
+                       batch.locations.size(),
+                       batch.location_results.size());
+        out.Clear();
+        return EC_ERROR;
+    }
+    out = std::move(batch);
+    return EC_OK;
+}
+
 ErrorCode MetaRedisBackend::RandomSample(RequestContext * /*request_context*/,
                                          const int64_t count,
                                          KeyTypeVec &out_keys) noexcept {

--- a/kv_cache_manager/meta/meta_redis_backend.h
+++ b/kv_cache_manager/meta/meta_redis_backend.h
@@ -73,6 +73,10 @@ public:
                        const int64_t limit,
                        std::string &out_next_cursor,
                        KeyTypeVec &out_keys) noexcept override;
+    ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
+                                          const std::string &cursor,
+                                          int64_t limit,
+                                          MaintenanceScanBatch &out) noexcept override;
     ErrorCode
     RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
     ErrorCode

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -214,6 +214,20 @@ public:
                                std::string &out_next_cursor,
                                KeyTypeVec &out_keys) noexcept = 0;
 
+    // Scan keys and their full CacheLocationMap for background maintenance.
+    // Unlike the online ListKeys/GetLocations path, this operation must not
+    // update access/LRU/revisit state or populate another cache tier.
+    //
+    // `limit` is a batch-size hint, matching ListKeys/Redis SCAN semantics;
+    // a backend may return more or fewer keys while advancing its cursor.
+    //
+    // `out` is only valid when EC_OK is returned. On success, out.keys,
+    // out.locations and out.location_results must have identical sizes.
+    virtual ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
+                                                  const std::string &cursor,
+                                                  int64_t limit,
+                                                  MaintenanceScanBatch &out) noexcept = 0;
+
     // 随机采样 key。
     // @param request_context 请求上下文；可为 nullptr
     // @param count    期望采样数量

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -518,6 +518,81 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocations(RequestContext *r
     return results;
 }
 
+std::vector<ErrorCode> MetaStorageBackendManager::GetLocationsFromPersistent(
+    RequestContext *request_context, const KeyVector &keys, CacheLocationMapVector &out_location_maps) noexcept {
+    out_location_maps.clear();
+    if (keys.empty()) {
+        return {};
+    }
+    if (!persistent_backend_) {
+        KVCM_LOG_ERROR("persistent GetLocations failed, backend is null, instance[%s]", instance_id_.c_str());
+        out_location_maps.resize(keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+    std::vector<ErrorCode> results = persistent_backend_->GetLocations(request_context, keys, out_location_maps);
+    if (results.size() != keys.size() || out_location_maps.size() != keys.size()) {
+        KVCM_LOG_ERROR("persistent GetLocations shape mismatch, instance[%s] keys[%zu] results[%zu] locations[%zu]",
+                       instance_id_.c_str(),
+                       keys.size(),
+                       results.size(),
+                       out_location_maps.size());
+        out_location_maps.resize(keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaStorageBackendManager::RefreshCacheFromPersistent(RequestContext *request_context,
+                                                                             const KeyVector &keys) noexcept {
+    if (keys.empty()) {
+        return {};
+    }
+    if (!cache_backend_) {
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+    CacheLocationMapVector locations;
+    PropertyMapVector properties;
+    std::vector<ErrorCode> persistent_results = persistent_backend_->Get(request_context, keys, locations, properties);
+    if (persistent_results.size() != keys.size() || locations.size() != keys.size() ||
+        properties.size() != keys.size()) {
+        KVCM_LOG_ERROR("persistent refresh shape mismatch, instance[%s] keys[%zu] results[%zu] locations[%zu] "
+                       "properties[%zu]",
+                       instance_id_.c_str(),
+                       keys.size(),
+                       persistent_results.size(),
+                       locations.size(),
+                       properties.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+
+    std::vector<ErrorCode> results = persistent_results;
+    const std::vector<ErrorCode> put_results =
+        cache_backend_->Put(request_context, keys, locations, properties, persistent_results);
+    if (put_results.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache refresh Put shape mismatch, instance[%s] keys[%zu] results[%zu]",
+                       instance_id_.c_str(),
+                       keys.size(),
+                       put_results.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+
+    KeyVector missing_keys;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (persistent_results[i] == EC_OK) {
+            results[i] = put_results[i];
+        } else if (persistent_results[i] == EC_NOENT) {
+            // Do not let a stale hot-cache entry resurrect metadata that has
+            // already disappeared from the source of truth.
+            missing_keys.push_back(keys[i]);
+        }
+    }
+    if (!missing_keys.empty()) {
+        (void)cache_backend_->Delete(request_context, missing_keys);
+    }
+    return results;
+}
+
 std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(RequestContext *request_context,
                                                                             const KeyVector &keys,
                                                                             const LocationIdsPerKey &location_ids,
@@ -694,6 +769,36 @@ ErrorCode MetaStorageBackendManager::ListKeys(RequestContext *request_context,
         return cache_backend_->ListKeys(request_context, cursor, limit, out_next_cursor, out_keys);
     }
     return persistent_backend_->ListKeys(request_context, cursor, limit, out_next_cursor, out_keys);
+}
+
+ErrorCode MetaStorageBackendManager::ScanLocationsForMaintenance(RequestContext *request_context,
+                                                                 const std::string &cursor,
+                                                                 const int64_t limit,
+                                                                 MaintenanceScanBatch &out) noexcept {
+    out.Clear();
+    if (!persistent_backend_) {
+        KVCM_LOG_ERROR("maintenance scan failed, persistent backend is null, instance[%s]", instance_id_.c_str());
+        return EC_ERROR;
+    }
+
+    MaintenanceScanBatch batch;
+    ErrorCode ec = persistent_backend_->ScanLocationsForMaintenance(request_context, cursor, limit, batch);
+    if (ec != EC_OK) {
+        return ec;
+    }
+    if (batch.next_cursor.empty() || batch.keys.size() != batch.locations.size() ||
+        batch.keys.size() != batch.location_results.size()) {
+        KVCM_LOG_ERROR(
+            "maintenance scan result invalid, instance[%s] cursor_empty[%d] keys[%zu] locations[%zu] results[%zu]",
+            instance_id_.c_str(),
+            batch.next_cursor.empty(),
+            batch.keys.size(),
+            batch.locations.size(),
+            batch.location_results.size());
+        return EC_ERROR;
+    }
+    out = std::move(batch);
+    return EC_OK;
 }
 
 ErrorCode MetaStorageBackendManager::RandomSample(RequestContext *request_context,

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -61,6 +61,11 @@ public:
     std::vector<ErrorCode> GetLocations(RequestContext *request_context,
                                         const KeyVector &keys,
                                         CacheLocationMapVector &out_location_maps) noexcept;
+    // Read the source-of-truth backend directly without touching the hot cache.
+    // Maintenance admission uses this to revalidate a persistent scan result.
+    std::vector<ErrorCode> GetLocationsFromPersistent(RequestContext *request_context,
+                                                      const KeyVector &keys,
+                                                      CacheLocationMapVector &out_location_maps) noexcept;
     std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
                                                      const KeyVector &keys,
                                                      const LocationIdsPerKey &location_ids,
@@ -75,12 +80,21 @@ public:
     std::vector<ErrorCode>
     Exists(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_is_exist_vec) noexcept;
 
+    // Refresh complete keys from persistent storage into the hot cache before
+    // a maintenance RMW. The caller must hold the corresponding shard locks.
+    // In single-backend mode this is a no-op.
+    std::vector<ErrorCode> RefreshCacheFromPersistent(RequestContext *request_context, const KeyVector &keys) noexcept;
+
     // ----- Cross-batch APIs (no shard locks) -----
     ErrorCode ListKeys(RequestContext *request_context,
                        const std::string &cursor,
                        const int64_t limit,
                        std::string &out_next_cursor,
                        KeyTypeVec &out_keys) noexcept;
+    ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
+                                          const std::string &cursor,
+                                          int64_t limit,
+                                          MaintenanceScanBatch &out) noexcept;
     ErrorCode RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept;
     ErrorCode SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept;
 

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -280,6 +280,38 @@ TEST_F(MetaDummyBackendTest, TestListKeys) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaDummyBackendTest, TestMaintenanceScanReturnsLocationsWithoutTouchingLru) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_maintenance_scan", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id("loc_1");
+    location->set_status(CacheLocationStatus::CLS_WRITING);
+    CacheLocationMapVector locations(1);
+    locations[0].emplace(location->id(), location);
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put(nullptr, {1}, locations, PropertyMapVector(1)));
+
+    auto *backend = static_cast<MetaDummyBackend *>(meta_storage_backend_.get());
+    int64_t lru_before = 0;
+    ASSERT_TRUE(backend->table_.FindAndApply(
+        1, [&lru_before](const DummyItem &item) { lru_before = std::stoll(item.properties.at(PROPERTY_LRU_TIME)); }));
+
+    MaintenanceScanBatch batch;
+    ASSERT_EQ(ErrorCode::EC_OK, backend->ScanLocationsForMaintenance(nullptr, SCAN_BASE_CURSOR, /*limit*/ 1, batch));
+    ASSERT_EQ(SCAN_BASE_CURSOR, batch.next_cursor);
+    ASSERT_EQ((KeyVector{1}), batch.keys);
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}), batch.location_results);
+    ASSERT_EQ(1, batch.locations.size());
+    ASSERT_TRUE(batch.locations[0].count("loc_1") > 0);
+
+    int64_t lru_after = 0;
+    ASSERT_TRUE(backend->table_.FindAndApply(
+        1, [&lru_after](const DummyItem &item) { lru_after = std::stoll(item.properties.at(PROPERTY_LRU_TIME)); }));
+    EXPECT_EQ(lru_before, lru_after);
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaDummyBackendTest, TestRandomSample) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -308,6 +308,43 @@ TEST_F(MetaLocalBackendTest, TestListKeys) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaLocalBackendTest, TestMaintenanceScanReturnsLocationsWithoutTouchingLru) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_maintenance_scan", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id("loc_1");
+    location->set_status(CacheLocationStatus::CLS_WRITING);
+    CacheLocationMapVector locations(1);
+    locations[0].emplace(location->id(), location);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              meta_storage_backend_->Put(nullptr, {1}, locations, PropertyMapVector(1)));
+
+    auto *backend = GetLocalBackend();
+    auto get_last_access_time = [backend]() {
+        int64_t last_access_time = -1;
+        backend->cache_->ApplyToSingleShard(
+            0, [&last_access_time](std::string_view, Cache::ObjectPtr value, size_t, const Cache::CacheItemHelper *) {
+                last_access_time = static_cast<MetaMemCacheItem *>(value)->GetLastAccessTime();
+            });
+        return last_access_time;
+    };
+    const int64_t lru_before = get_last_access_time();
+    ASSERT_GT(lru_before, 0);
+
+    MaintenanceScanBatch batch;
+    ASSERT_EQ(EC_OK, backend->ScanLocationsForMaintenance(nullptr, SCAN_BASE_CURSOR, /*limit*/ 1, batch));
+    ASSERT_EQ(SCAN_BASE_CURSOR, batch.next_cursor);
+    ASSERT_EQ((KeyVector{1}), batch.keys);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), batch.location_results);
+    ASSERT_EQ(1, batch.locations.size());
+    ASSERT_TRUE(batch.locations[0].count("loc_1") > 0);
+    EXPECT_EQ(lru_before, get_last_access_time());
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestSampleReclaimKeys) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -267,6 +267,50 @@ TEST_F(MetaStorageBackendManagerTest, TestListKeysAndRandomSample) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesPersistentWithoutCacheBackfill) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_scan";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    auto batch = MakeBatch({777});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.persistent_backend_->Put(nullptr, batch.batch_keys, batch.batch_locations, batch.batch_properties));
+
+    std::vector<bool> cache_exists;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
+    ASSERT_EQ((std::vector<bool>{false}), cache_exists);
+
+    MaintenanceScanBatch scan_batch;
+    ASSERT_EQ(EC_OK, mgr.ScanLocationsForMaintenance(nullptr, SCAN_BASE_CURSOR, 10, scan_batch));
+    ASSERT_EQ((KeyVector{777}), scan_batch.keys);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), scan_batch.location_results);
+    ASSERT_EQ(1, scan_batch.locations.size());
+    ASSERT_TRUE(scan_batch.locations[0].count("loc_777") > 0);
+
+    cache_exists.clear();
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
+    EXPECT_EQ((std::vector<bool>{false}), cache_exists);
+
+    CacheLocationMapVector authoritative_locations;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.GetLocationsFromPersistent(nullptr, {777}, authoritative_locations));
+    ASSERT_EQ(1u, authoritative_locations.size());
+    ASSERT_TRUE(authoritative_locations.front().count("loc_777") > 0);
+
+    // An authoritative read remains side-effect free. Maintenance admission
+    // explicitly refreshes only accepted candidate keys before its RMW.
+    cache_exists.clear();
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
+    EXPECT_EQ((std::vector<bool>{false}), cache_exists);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.RefreshCacheFromPersistent(nullptr, {777}));
+    cache_exists.clear();
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
+    EXPECT_EQ((std::vector<bool>{true}), cache_exists);
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
 // --- PutMetaData / GetMetaData always routed to persistent --------------------
 
 TEST_F(MetaStorageBackendManagerTest, TestPutGetMetaData) {

--- a/kv_cache_manager/meta/types.h
+++ b/kv_cache_manager/meta/types.h
@@ -48,6 +48,23 @@ using LocationIdVector = std::vector<LocationId>;
 using LocationIdsPerKey = std::vector<LocationIdVector>;
 using LocationsPerKey = std::vector<CacheLocationVector>;
 
+// A maintenance scan reads keys and their locations from the authoritative
+// backend without updating online access/LRU state. The three vectors are
+// always index-aligned when the scan succeeds.
+struct MaintenanceScanBatch {
+    std::string next_cursor;
+    KeyVector keys;
+    CacheLocationMapVector locations;
+    std::vector<ErrorCode> location_results;
+
+    void Clear() {
+        next_cursor.clear();
+        keys.clear();
+        locations.clear();
+        location_results.clear();
+    }
+};
+
 // ---------- Read-Modify-Write helpers ----------
 // Action codes shared by both block-level and location-level RMW modifiers.
 enum ModifierAction {

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -160,6 +160,17 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_reclaimer, reclaim_batch_create_age_max_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_batch_create_age_avg_us);
 
+    // cache garbage collector metrics
+    DECLARE_METRICS(cache_gc, scan_round_count);
+    DECLARE_METRICS(cache_gc, scan_key_count);
+    DECLARE_METRICS(cache_gc, candidate_count);
+    DECLARE_METRICS(cache_gc, delete_target_count);
+    DECLARE_METRICS(cache_gc, delete_result_count);
+    DECLARE_METRICS(cache_gc, operation_error_count);
+    DECLARE_METRICS(cache_gc, inflight_delete_count);
+    DECLARE_METRICS(cache_gc, inflight_delete_age_ms);
+    DECLARE_METRICS(cache_gc, round_duration_ms);
+
     // cache manager
     DECLARE_METRICS(cache_manager, write_location_expire_size);
     DECLARE_METRICS(cache_manager_group, usage_ratio);
@@ -420,6 +431,19 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_create_age_min_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_create_age_max_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_create_age_avg_us);
+
+    // Cache GC counters are registered as gauges, matching the existing
+    // cumulative counter convention used for CacheReclaimer. Tagged series
+    // share one KMonitor metric and are distinguished at report time.
+    REGISTER_GAUGE_METRIC(cache_gc, scan_round_count);
+    REGISTER_GAUGE_METRIC(cache_gc, scan_key_count);
+    REGISTER_GAUGE_METRIC(cache_gc, candidate_count);
+    REGISTER_GAUGE_METRIC(cache_gc, delete_target_count);
+    REGISTER_GAUGE_METRIC(cache_gc, delete_result_count);
+    REGISTER_GAUGE_METRIC(cache_gc, operation_error_count);
+    REGISTER_GAUGE_METRIC(cache_gc, inflight_delete_count);
+    REGISTER_GAUGE_METRIC(cache_gc, inflight_delete_age_ms);
+    REGISTER_GAUGE_METRIC(cache_gc, round_duration_ms);
 
     // cache manager
     REGISTER_GAUGE_METRIC(cache_manager, write_location_expire_size);
@@ -757,6 +781,45 @@ void KmonitorMetricsReporter::ReportInterval() {
         REPORT_METRICS(cache_reclaimer, reclaim_batch_create_age_min_us, reclaim_batch_create_age_min_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_batch_create_age_max_us, reclaim_batch_create_age_max_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_batch_create_age_avg_us, reclaim_batch_create_age_avg_us_v);
+    } while (false);
+
+    do {
+        // Cache GC owns both untagged metrics and bounded tagged families
+        // (candidate reason, delete status and error stage). Read the registry
+        // snapshot so KMonitor preserves the same labels as Prometheus/local
+        // reporting instead of maintaining a second hard-coded tag list.
+        if (!metrics_registry_) {
+            break;
+        }
+        const auto report_registry_metric = [this](kmonitor::MutableMetric *metric, const std::string &name) {
+            const auto data = metrics_registry_->GetMetricsData(name);
+            if (!metric || !data) {
+                return;
+            }
+            for (const auto &[base_tags, value] : data->GetMetricsValues()) {
+                if (!value || !value->touched.load(std::memory_order_relaxed)) {
+                    continue;
+                }
+                double sample = 0.0;
+                if (std::holds_alternative<CounterValue>(value->value)) {
+                    sample = static_cast<double>(std::get<CounterValue>(value->value).load(std::memory_order_relaxed));
+                } else {
+                    sample = std::get<GaugeValue>(value->value).load(std::memory_order_relaxed);
+                }
+                const kmonitor::MetricsTags tags = ctx_->GetKmonitorTags(base_tags);
+                metric->Report(&tags, sample);
+            }
+        };
+
+        report_registry_metric(ctx_->cache_gc_scan_round_count_metrics.get(), "cache_gc.scan_round_count");
+        report_registry_metric(ctx_->cache_gc_scan_key_count_metrics.get(), "cache_gc.scan_key_count");
+        report_registry_metric(ctx_->cache_gc_candidate_count_metrics.get(), "cache_gc.candidate_count");
+        report_registry_metric(ctx_->cache_gc_delete_target_count_metrics.get(), "cache_gc.delete_target_count");
+        report_registry_metric(ctx_->cache_gc_delete_result_count_metrics.get(), "cache_gc.delete_result_count");
+        report_registry_metric(ctx_->cache_gc_operation_error_count_metrics.get(), "cache_gc.operation_error_count");
+        report_registry_metric(ctx_->cache_gc_inflight_delete_count_metrics.get(), "cache_gc.inflight_delete_count");
+        report_registry_metric(ctx_->cache_gc_inflight_delete_age_ms_metrics.get(), "cache_gc.inflight_delete_age_ms");
+        report_registry_metric(ctx_->cache_gc_round_duration_ms_metrics.get(), "cache_gc.round_duration_ms");
     } while (false);
 
     do {

--- a/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
@@ -104,6 +104,15 @@ TEST_F(KmonitorMetricsReporterTest, TestReportPerQuery) {
 
 TEST_F(KmonitorMetricsReporterTest, TestReportInterval) {
     {
+        metrics_registry_->GetCounter("cache_gc.scan_round_count") += 1;
+        metrics_registry_->GetCounter("cache_gc.candidate_count", {{"reason", "storage_missing"}}) += 2;
+        metrics_registry_->GetCounter("cache_gc.delete_result_count", {{"status", "0"}}) += 1;
+        metrics_registry_->GetCounter("cache_gc.operation_error_count", {{"stage", "scan"}}) += 1;
+        metrics_registry_->GetGauge("cache_gc.inflight_delete_count") = 2;
+        EXPECT_NO_FATAL_FAILURE(reporter_->ReportInterval());
+    }
+
+    {
         // simulate the uninitialised case 1
         reporter_->cache_manager_ = nullptr;
         reporter_->metrics_registry_ = std::make_shared<MetricsRegistry>();

--- a/kv_cache_manager/service/BUILD
+++ b/kv_cache_manager/service/BUILD
@@ -30,6 +30,7 @@ cc_library(
         "//kv_cache_manager/config:coordination_backend",
         "//kv_cache_manager/config:leader_elector_base",
         "//kv_cache_manager/event:event_publisher",
+        "//kv_cache_manager/manager:cache_garbage_collector",
         "//kv_cache_manager/manager:cache_location_view",
         "//kv_cache_manager/manager:cache_manager",
         "//kv_cache_manager/manager:write_location_manager",

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -67,6 +67,13 @@ bool Server::Init(const ServerConfig &config) {
     async_delete_config.pending_bytes_limit_per_group_type = config_.GetCacheReclaimerPendingBytesLimitPerGroupType();
     async_delete_config.pending_delete_handler_limit = config_.GetCacheReclaimerPendingDeleteHandlerLimit();
     async_delete_config.pending_bytes_limit = config_.GetCacheReclaimerPendingBytesLimit();
+    CacheGarbageCollector::Config cache_gc_config;
+    cache_gc_config.enabled = config_.IsCacheGcEnabled();
+    cache_gc_config.scan_interval_ms = config_.GetCacheGcScanIntervalMs();
+    cache_gc_config.round_pause_ms = config_.GetCacheGcRoundPauseMs();
+    cache_gc_config.scan_batch_size = static_cast<size_t>(config_.GetCacheGcScanBatchSize());
+    cache_gc_config.orphan_writing_grace_period_ms = config_.GetCacheGcOrphanWritingGracePeriodMs();
+    cache_gc_config.max_inflight_delete_requests = static_cast<size_t>(config_.GetCacheGcMaxInflightDeleteRequests());
     if (!cache_manager_->Init(config_.GetSchedulePlanExecutorThreadCount(),
                               config_.GetCacheReclaimerKeySamplingSizeTotal(),
                               config_.GetCacheReclaimerKeySamplingSizePerTask(),
@@ -74,7 +81,8 @@ bool Server::Init(const ServerConfig &config) {
                               config_.GetCacheReclaimerIdleIntervalMs(),
                               config_.GetCacheReclaimerWorkerSize(),
                               async_delete_config,
-                              config_.GetSchedulePlanMigrationWorkerBudget())) {
+                              config_.GetSchedulePlanMigrationWorkerBudget(),
+                              cache_gc_config)) {
         KVCM_LOG_ERROR("cache manager init failed");
         return false;
     }
@@ -124,6 +132,11 @@ void Server::OnBecomeLeader() {
         KVCM_LOG_ERROR("cache_manager recover failed");
         return;
     }
+    ec = cache_manager_->StartCacheGarbageCollector();
+    if (ec != EC_OK) {
+        KVCM_LOG_ERROR("cache garbage collector start failed, ec[%d]", static_cast<int>(ec));
+        return;
+    }
     cache_manager_->ResumeReclaimer();
     cache_manager_->StartMigrationManager();
 
@@ -134,6 +147,7 @@ void Server::OnBecomeLeader() {
 
 void Server::OnNoLongerLeader() {
     KVCM_LOG_INFO("Server demoted to standby, starting cleanup...");
+    cache_manager_->RequestStopCacheGarbageCollector();
     cache_manager_->PauseReclaimer();
 
     meta_impl_->DisableLeaderOnlyRequests();
@@ -142,8 +156,9 @@ void Server::OnNoLongerLeader() {
     meta_impl_->WaitForAllLeaderOnlyRequestsToComplete();
     admin_impl_->WaitForAllLeaderOnlyRequestsToComplete();
 
-    // Stop migration after leader-only requests drain, so MigrateCache cannot submit
-    // new copy tasks after the migration monitor has stopped.
+    cache_manager_->JoinCacheGarbageCollector();
+    // Stop migration after leader-only requests drain and after GC has stopped consulting
+    // active Copy reservations.
     cache_manager_->StopMigrationManager();
 
     ErrorCode ec = cache_manager_->DoCleanup();

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/service/server_config.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <limits>
 #include <sstream>
@@ -8,6 +9,7 @@
 
 #include "kv_cache_manager/common/env_util.h"
 #include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/manager/cache_garbage_collector.h"
 #include "kv_cache_manager/metrics/metrics_reporter_factory.h"
 
 namespace kv_cache_manager {
@@ -170,6 +172,36 @@ std::unordered_map<std::string, ServerConfig::SettingFunction> ServerConfig::kSe
          config->cache_reclaimer_pending_bytes_limit_ = std::stoull(value);
          return true;
      }},
+    {"kvcm.cache_gc.enabled",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_enabled_ = value == "true";
+         return value == "true" || value == "false";
+     }},
+    {"kvcm.cache_gc.scan_interval_ms",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_scan_interval_ms_ = std::stoll(value);
+         return true;
+     }},
+    {"kvcm.cache_gc.round_pause_ms",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_round_pause_ms_ = std::stoll(value);
+         return true;
+     }},
+    {"kvcm.cache_gc.scan_batch_size",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_scan_batch_size_ = std::stoull(value);
+         return true;
+     }},
+    {"kvcm.cache_gc.orphan_writing_grace_period_ms",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_orphan_writing_grace_period_ms_ = std::stoll(value);
+         return true;
+     }},
+    {"kvcm.cache_gc.max_inflight_delete_requests",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_max_inflight_delete_requests_ = std::stoull(value);
+         return true;
+     }},
     {"kvcm.metrics.reporter_type",
      [](const std::string &value, ServerConfig *config) {
          config->metrics_reporter_type_ = value;
@@ -249,6 +281,12 @@ void ServerConfig::UpdateDefaultConfig() {
     cache_reclaimer_pending_bytes_limit_per_group_type_ = 64ULL * 1024 * 1024 * 1024;
     cache_reclaimer_pending_delete_handler_limit_ = 1024;
     cache_reclaimer_pending_bytes_limit_ = 256ULL * 1024 * 1024 * 1024;
+    cache_gc_enabled_ = false;
+    cache_gc_scan_interval_ms_ = 1000;
+    cache_gc_round_pause_ms_ = 24LL * 60 * 60 * 1000;
+    cache_gc_scan_batch_size_ = 256;
+    cache_gc_orphan_writing_grace_period_ms_ = 24LL * 60 * 60 * 1000;
+    cache_gc_max_inflight_delete_requests_ = 2;
 }
 
 bool ServerConfig::ParseFromFile(const std::string &config_file) {
@@ -317,10 +355,14 @@ bool ServerConfig::ParseFromEnviron(const EnvironMap &environ) {
             fprintf(stderr, "Unknown config key %s\n", key.c_str());
             continue;
         }
-        if (!setting_it->second(val, this)) {
+        try {
+            if (!setting_it->second(val, this)) {
+                fprintf(stderr, "Invalid value for config: %s = %s\n", key.c_str(), val.c_str());
+                success = false;
+            }
+        } catch (...) {
             fprintf(stderr, "Invalid value for config: %s = %s\n", key.c_str(), val.c_str());
             success = false;
-            continue;
         }
     }
     return success;
@@ -379,6 +421,19 @@ bool ServerConfig::Check() {
         schedule_plan_migration_worker_budget_ >= static_cast<uint32_t>(schedule_plan_executor_thread_count_)) {
         fprintf(stderr,
                 "SchedulePlanExecutor requires thread_count > 1 and 0 < migration_worker_budget < thread_count\n");
+        return false;
+    }
+
+    if (cache_gc_enabled_ &&
+        (cache_gc_scan_interval_ms_ <= 0 || cache_gc_round_pause_ms_ <= 0 || cache_gc_scan_batch_size_ == 0 ||
+         cache_gc_scan_batch_size_ > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+         cache_gc_max_inflight_delete_requests_ == 0 ||
+         cache_gc_max_inflight_delete_requests_ > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+         cache_gc_orphan_writing_grace_period_ms_ < kMinCacheGcOrphanWritingGracePeriodMs)) {
+        fprintf(stderr,
+                "Cache GC intervals, batch size and max in-flight requests must be greater than zero, and orphan "
+                "WRITING grace must be at least %ldms\n",
+                kMinCacheGcOrphanWritingGracePeriodMs);
         return false;
     }
 

--- a/kv_cache_manager/service/server_config.h
+++ b/kv_cache_manager/service/server_config.h
@@ -50,6 +50,12 @@ public:
         return cache_reclaimer_pending_delete_handler_limit_;
     }
     uint64_t GetCacheReclaimerPendingBytesLimit() const { return cache_reclaimer_pending_bytes_limit_; }
+    bool IsCacheGcEnabled() const { return cache_gc_enabled_; }
+    int64_t GetCacheGcScanIntervalMs() const { return cache_gc_scan_interval_ms_; }
+    int64_t GetCacheGcRoundPauseMs() const { return cache_gc_round_pause_ms_; }
+    uint64_t GetCacheGcScanBatchSize() const { return cache_gc_scan_batch_size_; }
+    int64_t GetCacheGcOrphanWritingGracePeriodMs() const { return cache_gc_orphan_writing_grace_period_ms_; }
+    uint64_t GetCacheGcMaxInflightDeleteRequests() const { return cache_gc_max_inflight_delete_requests_; }
     const std::string &metrics_reporter_type() { return metrics_reporter_type_; }
     const std::string &metrics_reporter_config() { return metrics_reporter_config_; }
     int64_t metrics_report_interval_ms() { return metrics_report_interval_ms_; }
@@ -101,6 +107,12 @@ private:
     uint64_t cache_reclaimer_pending_bytes_limit_per_group_type_ = 0;
     uint64_t cache_reclaimer_pending_delete_handler_limit_ = 0;
     uint64_t cache_reclaimer_pending_bytes_limit_ = 0;
+    bool cache_gc_enabled_ = false;
+    int64_t cache_gc_scan_interval_ms_ = 0;
+    int64_t cache_gc_round_pause_ms_ = 0;
+    uint64_t cache_gc_scan_batch_size_ = 0;
+    int64_t cache_gc_orphan_writing_grace_period_ms_ = 0;
+    uint64_t cache_gc_max_inflight_delete_requests_ = 0;
     std::string metrics_reporter_type_ = "local";
     std::string metrics_reporter_config_;
     int64_t metrics_report_interval_ms_ = 0;

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -27,6 +27,11 @@ TEST_F(ServerConfigTest, TestSimple) {
         ASSERT_EQ(64ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimitPerGroupType());
         ASSERT_EQ(1024, config.GetCacheReclaimerPendingDeleteHandlerLimit());
         ASSERT_EQ(256ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimit());
+        ASSERT_FALSE(config.IsCacheGcEnabled());
+        ASSERT_EQ(1000, config.GetCacheGcScanIntervalMs());
+        ASSERT_EQ(86400000, config.GetCacheGcRoundPauseMs());
+        ASSERT_EQ(256, config.GetCacheGcScanBatchSize());
+        ASSERT_EQ(86400000, config.GetCacheGcOrphanWritingGracePeriodMs());
     }
     // config_file not exist
     {
@@ -185,6 +190,57 @@ TEST_F(ServerConfigTest, TestCacheReclaimerAsyncDeleteConfig) {
     environ["kvcm.cache_reclaimer.pending_delete_handler_limit"] = "0";
     ASSERT_TRUE(config.Parse("", environ));
     EXPECT_FALSE(config.Check());
+}
+
+TEST_F(ServerConfigTest, TestCacheGcConfig) {
+    ServerConfig config;
+    std::unordered_map<std::string, std::string> environ{
+        {"kvcm.cache_gc.enabled", "true"},
+        {"kvcm.cache_gc.scan_interval_ms", "123"},
+        {"kvcm.cache_gc.round_pause_ms", "456"},
+        {"kvcm.cache_gc.scan_batch_size", "7"},
+        {"kvcm.cache_gc.orphan_writing_grace_period_ms", "3600000"},
+        {"kvcm.cache_gc.max_inflight_delete_requests", "3"},
+    };
+    ASSERT_TRUE(config.Parse("", environ));
+    ASSERT_TRUE(config.Check());
+    EXPECT_TRUE(config.IsCacheGcEnabled());
+    EXPECT_EQ(123, config.GetCacheGcScanIntervalMs());
+    EXPECT_EQ(456, config.GetCacheGcRoundPauseMs());
+    EXPECT_EQ(7, config.GetCacheGcScanBatchSize());
+    EXPECT_EQ(3600000, config.GetCacheGcOrphanWritingGracePeriodMs());
+    EXPECT_EQ(3, config.GetCacheGcMaxInflightDeleteRequests());
+
+    environ["kvcm.cache_gc.orphan_writing_grace_period_ms"] = "3599999";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_FALSE(config.Check());
+
+    environ["kvcm.cache_gc.orphan_writing_grace_period_ms"] = "3600000";
+    environ["kvcm.cache_gc.scan_batch_size"] = "0";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_FALSE(config.Check());
+
+    environ["kvcm.cache_gc.scan_batch_size"] = "9223372036854775808";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_FALSE(config.Check());
+
+    environ["kvcm.cache_gc.scan_batch_size"] = "7";
+    environ["kvcm.cache_gc.max_inflight_delete_requests"] = "0";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_FALSE(config.Check());
+
+    environ["kvcm.cache_gc.enabled"] = "false";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_TRUE(config.Check());
+}
+
+TEST_F(ServerConfigTest, TestMalformedNumericEnvironmentValueReturnsParseError) {
+    ServerConfig config;
+    std::unordered_map<std::string, std::string> environ{
+        {"kvcm.cache_gc.scan_interval_ms", "not-a-number"},
+    };
+
+    EXPECT_FALSE(config.Parse("", environ));
 }
 
 TEST_F(ServerConfigTest, TestUnderscoreEnvFallback) {

--- a/package/etc/default_server_config.conf
+++ b/package/etc/default_server_config.conf
@@ -83,6 +83,20 @@ kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
 kvcm.cache_reclaimer.pending_delete_handler_limit=1024
 kvcm.cache_reclaimer.pending_bytes_limit=274877906944
 
+# 后台 metadata GC 默认关闭；只在 leader 上运行。处理长期 WRITING，
+# 以及 MightExist 明确 missing 的普通 SERVING Location（EventReport 除外）
+kvcm.cache_gc.enabled=false
+# active round 每个 tick 最多扫描一个 batch
+kvcm.cache_gc.scan_interval_ms=1000
+# 完成一轮全量扫描后的休眠时间，默认 24 小时
+kvcm.cache_gc.round_pause_ms=86400000
+# backend 扫描 batch hint，同时限制单次提交的 Location 数
+kvcm.cache_gc.scan_batch_size=256
+# 自动清理 CLS_WRITING 的 grace，最小 1 小时（3600000ms），默认 24 小时
+kvcm.cache_gc.orphan_writing_grace_period_ms=86400000
+# GC 在途删除请求硬上限；默认 2
+kvcm.cache_gc.max_inflight_delete_requests=2
+
 # 重访间隔统计的桶边界（秒），逗号分隔，必须严格升序
 # 默认值：1,5,30,60,120,180,300,600,900,1800,3600,21600,86400（13个边界，14个桶含+Inf）
 # 修改后需重启服务生效


### PR DESCRIPTION
## Background

KVCM currently removes invalid cache metadata mainly when capacity-driven Reclaimer eviction runs or when the same key is accessed again. If a leader exits after `StartWriteCache` has persisted a `CLS_WRITING` location but before `FinishWriteCache` or the session-timeout cleanup completes, the in-memory write session and timer are lost while the metadata remains. When the cache is not full and that key is never read again, the stale location cannot self-heal and may permanently block later writes to the block; this PR adds a low-frequency background path to make such metadata converge.

## Summary

- add a leader-only `CacheGarbageCollector` that incrementally scans authoritative metadata without updating LRU/access statistics or backfilling the hot metadata cache
- collect long-lived `CLS_WRITING` locations after a conservative grace period, with a fixed `WRITING -> DELETING` conditional admission check
- reuse the asynchronous delete pipeline introduced by #234, with bounded GC-side in-flight requests, pending-location deduplication, lifecycle wiring, metrics, and configuration
- document the V1 contract and add deterministic unit tests plus Dummy/NFS process-level E2E coverage

## Safety and scope

- scan results are discovery-only; the Executor re-reads metadata and conditionally admits only locations that are still `CLS_WRITING`
- metadata parse/read failures, malformed or young locations, and concurrent state changes all fail closed
- the grace period defaults to 24 hours and cannot be configured below 1 hour, leaving a conservative margin beyond the 30-minute write-session limit
- V1 only enables orphan-WRITING collection; stale `CLS_DELETING` reconciliation, storage version/epoch handling, TTL expiry, idle-Instance cleanup, and WriteLocationManager/Reclaimer settling fixes remain out of scope

Architecture reference: this PR follows the high-level shape proposed in #184—a standalone `CacheGarbageCollector`, periodic per-Instance cursor scanning, and cleanup through `SchedulePlanExecutor`—while narrowing V1 to orphan WRITING and revising the authoritative-scan, conditional async deletion, bounded in-flight tracking, and leader-lifecycle contracts.

## Testing

All KVCM builds and tests below ran in an isolated Linux container with Dummy metadata and NFS data storage where applicable.

- `CacheGarbageCollectorTest`, `SchedulePlanExecutorTest`, `CacheManagerTest`, and `ServerConfigTest` passed
- Local, Dummy, and dual-backend metadata maintenance-scan component tests passed
- `//integration_test/cache_garbage_collector:cache_garbage_collector_test` passed, covering restart recovery, Instance isolation, persistent-backend scan, and leader demotion
- matched directional performance screen passed 9/9 runs at approximately 800 QPS with zero StartWrite/FinishWrite failures; active-scan runs each scanned 6400 keys and produced zero delete targets
- `clang-format --dry-run --Werror`, `autopep8 --diff`, and `git diff --check` passed
