### PR TITLE
[manager] add precise BatchAddLocation rollback

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1073,10 +1073,17 @@ CacheManager::StartWriteCache(RequestContext *request_context,
         KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, GenWriteLocation);
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, StartWriteCacheInfo, "start write cache failed");
         KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, ManagerBatchAddLocation);
-        ec = meta_searcher->BatchAddLocation(request_context, new_keys, new_locations, location_ids);
+        std::vector<MetaSearcher::AddLocationResult> add_results;
+        ec = meta_searcher->BatchAddLocation(request_context, new_keys, new_locations, add_results);
         KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ManagerBatchAddLocation);
-        // FIXME(rui): PartialOK and return will cause storage leak (not possible to reclaim)
-        //             example case -- indexer reach max key count after partial write
+        if (ec != EC_OK) {
+            RollbackAddLocations(request_context, instance_id, new_keys, new_locations, add_results);
+        } else {
+            location_ids.reserve(add_results.size());
+            for (const auto &add_result : add_results) {
+                location_ids.push_back(add_result.location_id);
+            }
+        }
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, StartWriteCacheInfo, "start write cache failed");
     }
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, PutWriteLocationManager);
@@ -1106,6 +1113,144 @@ CacheManager::StartWriteCache(RequestContext *request_context,
             StartWriteCacheInfo(std::move(write_session_id),
                                 std::move(block_mask),
                                 CacheLocationViewVecWrapper(std::move(new_locations)))};
+}
+
+void CacheManager::RollbackAddLocations(RequestContext *request_context,
+                                        const std::string &instance_id,
+                                        const KeyVector &keys,
+                                        const CacheLocationVector &locations,
+                                        const std::vector<MetaSearcher::AddLocationResult> &add_results) {
+    const std::string &trace_id = request_context->trace_id();
+    if (keys.size() != locations.size() || keys.size() != add_results.size()) {
+        PREFIX_LOG(ERROR,
+                   "rollback add locations size mismatch, keys[%lu], locations[%lu], results[%lu]",
+                   keys.size(),
+                   locations.size(),
+                   add_results.size());
+        return;
+    }
+
+    CacheLocationDelRequest metadata_rollback{.instance_id = instance_id, .delay = std::chrono::seconds(0)};
+    std::map<std::string, std::vector<DataStorageUri>> direct_delete_uris;
+    KeyVector uncertain_keys;
+    std::vector<std::string> uncertain_location_ids;
+    std::vector<size_t> uncertain_indices;
+
+    auto queue_uri_delete = [&](size_t index) {
+        if (!locations[index]) {
+            PREFIX_LOG(WARN, "rollback add location has null location, key[%lu](%lu)", index, keys[index]);
+            return;
+        }
+        for (const auto &spec : locations[index]->location_specs()) {
+            DataStorageUri uri(spec.uri());
+            if (!uri.Valid()) {
+                PREFIX_LOG(WARN,
+                           "rollback add location has invalid uri, key[%lu](%lu), uri[%s]",
+                           index,
+                           keys[index],
+                           spec.uri().c_str());
+                continue;
+            }
+            direct_delete_uris[uri.GetHostName()].push_back(std::move(uri));
+        }
+    };
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const auto &add_result = add_results[i];
+        if (add_result.ec == EC_OK && !add_result.location_id.empty()) {
+            metadata_rollback.block_keys.push_back(keys[i]);
+            metadata_rollback.location_ids.push_back({add_result.location_id});
+            continue;
+        }
+        if (!add_result.location_id.empty()) {
+            // location id 已生成但写结果失败/未知：先做幂等元数据删除，确认无引用后才能删 URI。
+            uncertain_keys.push_back(keys[i]);
+            uncertain_location_ids.push_back(add_result.location_id);
+            uncertain_indices.push_back(i);
+            continue;
+        }
+        queue_uri_delete(i);
+    }
+
+    // 已成功写入元数据的 location 复用标准删除流水线：标记 DELETING、Sync、删 URI、删元数据。
+    if (!metadata_rollback.block_keys.empty()) {
+        reclaimer_task_supervisor_->Submit(trace_id, std::move(metadata_rollback));
+    }
+
+    if (!uncertain_keys.empty()) {
+        MetaSearcher *meta_searcher = meta_searcher_manager_->GetMetaSearcher(instance_id);
+        if (!meta_searcher) {
+            PREFIX_LOG(ERROR, "rollback uncertain add locations failed: meta searcher not found");
+        } else {
+            LocationIdsPerKey location_ids_per_key;
+            location_ids_per_key.reserve(uncertain_location_ids.size());
+            for (const auto &location_id : uncertain_location_ids) {
+                location_ids_per_key.push_back({location_id});
+            }
+            std::vector<std::vector<ErrorCode>> delete_results;
+            meta_searcher->BatchDeleteLocations(request_context,
+                                                uncertain_keys,
+                                                location_ids_per_key,
+                                                delete_results,
+                                                {},
+                                                false /* these failed adds were never included in usage */,
+                                                false /* failed adds were never counted as new keys */);
+            KeyVector deleted_metadata_keys;
+            for (size_t i = 0; i < uncertain_indices.size(); ++i) {
+                if (i < delete_results.size() && delete_results[i].size() == 1 &&
+                    delete_results[i].front() == EC_OK) {
+                    deleted_metadata_keys.push_back(uncertain_keys[i]);
+                }
+            }
+
+            bool metadata_synced = true;
+            if (!deleted_metadata_keys.empty()) {
+                auto meta_indexer = meta_indexer_manager_->GetMetaIndexer(instance_id);
+                metadata_synced = meta_indexer && meta_indexer->Sync(deleted_metadata_keys);
+                if (!metadata_synced) {
+                    PREFIX_LOG(WARN,
+                               "rollback uncertain add locations failed to sync deleted metadata, key_count[%zu]",
+                               deleted_metadata_keys.size());
+                }
+            }
+            for (size_t i = 0; i < uncertain_indices.size(); ++i) {
+                if (i >= delete_results.size() || delete_results[i].size() != 1) {
+                    continue;
+                }
+                const ErrorCode delete_ec = delete_results[i].front();
+                if (delete_ec == EC_NOENT || (delete_ec == EC_OK && metadata_synced)) {
+                    queue_uri_delete(uncertain_indices[i]);
+                }
+            }
+        }
+    }
+
+    auto data_storage_manager = registry_manager_->data_storage_manager();
+    if (!data_storage_manager) {
+        PREFIX_LOG(ERROR, "rollback add locations failed: data storage manager not found");
+        return;
+    }
+    // 明确未写入元数据的项没有 location 可交给删除流水线，直接释放其已分配 URI。
+    for (const auto &[storage_name, uris] : direct_delete_uris) {
+        const auto delete_results = data_storage_manager->Delete(request_context, storage_name, uris, nullptr);
+        if (delete_results.size() != uris.size()) {
+            PREFIX_LOG(WARN,
+                       "rollback data uri result size mismatch, storage[%s], expect[%lu], actual[%lu]",
+                       storage_name.c_str(),
+                       uris.size(),
+                       delete_results.size());
+        }
+        const size_t result_count = std::min(delete_results.size(), uris.size());
+        for (size_t i = 0; i < result_count; ++i) {
+            if (delete_results[i] != EC_OK && delete_results[i] != EC_NOENT) {
+                PREFIX_LOG(WARN,
+                           "rollback data uri failed, storage[%s], uri[%s], ec[%d]",
+                           storage_name.c_str(),
+                           uris[i].ToUriString().c_str(),
+                           delete_results[i]);
+            }
+        }
+    }
 }
 
 ErrorCode

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -267,6 +267,11 @@ private:
                                         const std::string &storage_name,
                                         DataStorageType storage_type,
                                         CacheLocationVector &out_locations);
+    void RollbackAddLocations(RequestContext *request_context,
+                              const std::string &instance_id,
+                              const KeyVector &keys,
+                              const CacheLocationVector &locations,
+                              const std::vector<MetaSearcher::AddLocationResult> &add_results);
     ErrorCode CreateInSingleBatch(RequestContext *request_context,
                                   const std::string &instance_id,
                                   const CacheManager::KeyVector &keys,

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -944,16 +944,18 @@ ErrorCode MetaSearcher::BatchGetLocation(RequestContext *request_context,
 ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
                                          const KeyVector &keys,
                                          const CacheLocationVector &locations,
-                                         std::vector<std::string> &out_location_ids) {
+                                         std::vector<AddLocationResult> &out_results) {
+    out_results.assign(keys.size(), AddLocationResult{});
     if (keys.size() != locations.size()) {
+        for (auto &result : out_results) {
+            result.ec = EC_BADARGS;
+        }
         return EC_BADARGS;
     }
-    out_location_ids.clear();
-    out_location_ids.resize(keys.size());
     std::vector<std::pair<DataStorageType, std::uint64_t>> loc_sz(keys.size());
 
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
-    auto modifier = [&locations, &out_location_ids, &keys, &loc_sz, batch_create_time](
+    auto modifier = [&locations, &out_results, &keys, &loc_sz, batch_create_time](
                         const LocationIdVector &existing_location_ids,
                         ErrorCode get_ec,
                         size_t index,
@@ -996,7 +998,7 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
         }
         loc_sz[index] = std::make_pair(locations[index]->type(), sz);
 
-        out_location_ids[index] = std::move(location_id);
+        out_results[index].location_id = std::move(location_id);
         return {ModifierAction::MA_OK, ErrorCode::EC_OK};
     };
 
@@ -1005,17 +1007,41 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
     auto result = meta_indexer_->ReadModifyWriteBlock(request_context, keys, modifier);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteBlock);
 
+    ErrorCode aggregate_ec = result.ec;
+    if (result.error_codes.size() != keys.size()) {
+        KVCM_LOG_ERROR(
+            "BatchAddLocation result size mismatch, expect: %lu, actual: %lu", keys.size(), result.error_codes.size());
+        for (auto &add_result : out_results) {
+            add_result.ec = ErrorCode::EC_MISMATCH;
+        }
+        aggregate_ec = ErrorCode::EC_MISMATCH;
+    } else {
+        for (std::size_t i = 0; i < keys.size(); ++i) {
+            out_results[i].ec = result.error_codes[i];
+            if (out_results[i].ec == ErrorCode::EC_OK && out_results[i].location_id.empty()) {
+                KVCM_LOG_ERROR("BatchAddLocation returned EC_OK with empty location id, key[%lu](%lu)", i, keys[i]);
+                out_results[i].ec = ErrorCode::EC_MISMATCH;
+                aggregate_ec = ErrorCode::EC_MISMATCH;
+            }
+        }
+    }
+
     // update the usage of each storage type
     for (std::size_t i = 0; i < keys.size(); i++) {
-        if (result.error_codes[i] == ErrorCode::EC_OK) {
+        if (out_results[i].ec == ErrorCode::EC_OK) {
             meta_indexer_->AddStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
         }
     }
 
-    if (result.ec != ErrorCode::EC_OK) {
-        LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
+    if (aggregate_ec != ErrorCode::EC_OK) {
+        std::vector<ErrorCode> per_key_ec;
+        per_key_ec.reserve(out_results.size());
+        for (const auto &add_result : out_results) {
+            per_key_ec.push_back(add_result.ec);
+        }
+        LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", per_key_ec, keys);
     }
-    return result.ec;
+    return aggregate_ec;
 }
 
 ErrorCode
@@ -1801,7 +1827,9 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
                                              const KeyVector &keys,
                                              const LocationIdsPerKey &location_ids_per_key,
                                              std::vector<std::vector<ErrorCode>> &out_per_location_ec,
-                                             const std::vector<std::vector<std::string>> &expected_location_values) {
+                                             const std::vector<std::vector<std::string>> &expected_location_values,
+                                             bool adjust_storage_usage,
+                                             bool adjust_reclaimed_key_count) {
     if (keys.size() != location_ids_per_key.size()) {
         return EC_BADARGS;
     }
@@ -1873,20 +1901,23 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
-    auto result = meta_indexer_->ReadModifyWriteLocation(request_context, keys, location_ids_per_key, modifier);
+    auto result = meta_indexer_->ReadModifyWriteLocation(
+        request_context, keys, location_ids_per_key, modifier, adjust_reclaimed_key_count);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
     out_per_location_ec = std::move(result.per_location_error_codes);
 
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (i >= out_per_location_ec.size()) {
-            continue;
-        }
-        for (size_t k = 0; k < location_ids_per_key[i].size(); ++k) {
-            if (k >= out_per_location_ec[i].size()) {
+    if (adjust_storage_usage) {
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (i >= out_per_location_ec.size()) {
                 continue;
             }
-            if (out_per_location_ec[i][k] == ErrorCode::EC_OK && !location_ids_per_key[i][k].empty()) {
-                meta_indexer_->SubStorageUsageByType(locs_sz[i][k].first, locs_sz[i][k].second);
+            for (size_t k = 0; k < location_ids_per_key[i].size(); ++k) {
+                if (k >= out_per_location_ec[i].size()) {
+                    continue;
+                }
+                if (out_per_location_ec[i][k] == ErrorCode::EC_OK && !location_ids_per_key[i][k].empty()) {
+                    meta_indexer_->SubStorageUsageByType(locs_sz[i][k].first, locs_sz[i][k].second);
+                }
             }
         }
     }

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -93,10 +93,15 @@ public:
                                const KeyVector &keys,
                                const BlockMask &input_mask,
                                std::vector<CacheLocationMap> &out_location_maps);
+    struct AddLocationResult {
+        ErrorCode ec = EC_UNKNOWN;
+        // EC_OK 时是可供业务使用的 location id；失败时若非空，仅可作为回滚定位符。
+        std::string location_id;
+    };
     ErrorCode BatchAddLocation(RequestContext *request_context,
                                const KeyVector &keys,
                                const CacheLocationVector &locations,
-                               std::vector<std::string> &out_location_ids);
+                               std::vector<AddLocationResult> &out_results);
     struct ReplaceLocationSpecsTask {
         std::string location_id;
         DataStorageType type;
@@ -167,7 +172,9 @@ public:
                                    const KeyVector &keys,
                                    const LocationIdsPerKey &location_ids_per_key,
                                    std::vector<std::vector<ErrorCode>> &out_per_location_ec,
-                                   const std::vector<std::vector<std::string>> &expected_location_values = {});
+                                   const std::vector<std::vector<std::string>> &expected_location_values = {},
+                                   bool adjust_storage_usage = true,
+                                   bool adjust_reclaimed_key_count = true);
     using LocationVisitor =
         std::function<void(KeyType block_key, const std::string &location_id, const CacheLocation &location)>;
     ErrorCode VisitAllLocations(RequestContext *request_context, size_t scan_batch_size, LocationVisitor visitor);

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -6,6 +6,7 @@
 #include <limits>
 #include <optional>
 #include <tuple>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -32,6 +33,173 @@ namespace kv_cache_manager {
 namespace {
 constexpr auto kMonitorIdleSleep = std::chrono::milliseconds(50);
 constexpr auto kFutureWaitTime = std::chrono::microseconds(200);
+
+struct AddLocationRollbackItem {
+    int64_t block_key = 0;
+    std::string storage_name;
+    std::vector<DataStorageUri> uris;
+    ErrorCode ec = EC_UNKNOWN;
+    std::string location_id;
+};
+
+// BatchAddLocation 失败后的补偿规则与返回契约一致：
+// - 已知成功项走标准 Location 删除流水线，由流水线回收 usage；
+// - 失败但已生成 ID 的项先幂等删除元数据并 Sync，确认无引用后才删 URI；
+// - 未生成 ID 的项可直接删 URI。
+// 任一元数据状态无法确认时保留 URI，避免制造悬空引用。
+void RollbackAddedLocations(RequestContext *request_context,
+                            const std::string &trace_id,
+                            const std::string &instance_id,
+                            const std::shared_ptr<MetaIndexer> &indexer,
+                            const std::shared_ptr<DataStorageManager> &data_storage_manager,
+                            const std::shared_ptr<SchedulePlanExecutor> &schedule_plan_executor,
+                            const std::vector<AddLocationRollbackItem> &items) {
+    CacheLocationDelRequest known_success_request;
+    known_success_request.instance_id = instance_id;
+
+    KeyVector uncertain_keys;
+    std::vector<std::string> uncertain_location_ids;
+    std::vector<const AddLocationRollbackItem *> uncertain_items;
+    std::unordered_map<std::string, std::vector<DataStorageUri>> direct_delete_uris;
+    auto queue_uri_delete = [&direct_delete_uris](const AddLocationRollbackItem &item) {
+        if (item.uris.empty()) {
+            return;
+        }
+        auto &uris = direct_delete_uris[item.storage_name];
+        uris.insert(uris.end(), item.uris.begin(), item.uris.end());
+    };
+
+    for (const auto &item : items) {
+        if (item.ec == EC_OK && !item.location_id.empty()) {
+            known_success_request.block_keys.push_back(item.block_key);
+            known_success_request.location_ids.push_back({item.location_id});
+        } else if (!item.location_id.empty()) {
+            uncertain_keys.push_back(item.block_key);
+            uncertain_location_ids.push_back(item.location_id);
+            uncertain_items.push_back(&item);
+        } else {
+            queue_uri_delete(item);
+        }
+    }
+
+    if (!known_success_request.block_keys.empty() &&
+        (!schedule_plan_executor ||
+         !schedule_plan_executor->SubmitNonBlocking(
+             known_success_request, ScheduleTaskClass::kMigrationContinuation))) {
+        KVCM_LOG_WARN("[%s] rollback known successful migration locations failed to submit delete, instance %s, "
+                      "key_count %zu",
+                      trace_id.c_str(),
+                      instance_id.c_str(),
+                      known_success_request.block_keys.size());
+    }
+
+    if (!uncertain_keys.empty()) {
+        if (!indexer) {
+            KVCM_LOG_WARN("[%s] rollback uncertain migration locations retained URIs: meta indexer missing, "
+                          "instance %s, key_count %zu",
+                          trace_id.c_str(),
+                          instance_id.c_str(),
+                          uncertain_keys.size());
+        } else {
+            MetaSearcher meta_searcher(indexer);
+            LocationIdsPerKey location_ids_per_key;
+            location_ids_per_key.reserve(uncertain_location_ids.size());
+            for (const auto &location_id : uncertain_location_ids) {
+                location_ids_per_key.push_back({location_id});
+            }
+            std::vector<std::vector<ErrorCode>> delete_results;
+            const ErrorCode delete_ec =
+                meta_searcher.BatchDeleteLocations(request_context,
+                                                   uncertain_keys,
+                                                   location_ids_per_key,
+                                                   delete_results,
+                                                   {},
+                                                   false /* failed adds were never included in usage */,
+                                                   false /* failed adds were never counted as new keys */);
+            const size_t invalid_result_count =
+                std::count_if(delete_results.begin(), delete_results.end(), [](const auto &per_location_results) {
+                    return per_location_results.size() != 1;
+                });
+            if (delete_results.size() != uncertain_items.size() || invalid_result_count != 0) {
+                KVCM_LOG_WARN("[%s] rollback uncertain migration metadata returned unexpected result shape, "
+                              "instance %s, expected %zu, got %zu, invalid inner result count %zu, ec %d",
+                              trace_id.c_str(),
+                              instance_id.c_str(),
+                              uncertain_items.size(),
+                              delete_results.size(),
+                              invalid_result_count,
+                              delete_ec);
+            } else {
+                KeyVector sync_keys;
+                for (std::size_t i = 0; i < delete_results.size(); ++i) {
+                    if (delete_results[i].front() == EC_OK) {
+                        sync_keys.push_back(uncertain_keys[i]);
+                    }
+                }
+
+                bool metadata_synced = true;
+                if (!sync_keys.empty()) {
+                    metadata_synced = indexer->Sync(sync_keys);
+                    if (!metadata_synced) {
+                        KVCM_LOG_WARN("[%s] rollback uncertain migration locations failed to sync deleted metadata, "
+                                      "instance %s, key_count %zu",
+                                      trace_id.c_str(),
+                                      instance_id.c_str(),
+                                      sync_keys.size());
+                    }
+                }
+
+                for (std::size_t i = 0; i < delete_results.size(); ++i) {
+                    const ErrorCode per_location_ec = delete_results[i].front();
+                    if (per_location_ec == EC_NOENT || (per_location_ec == EC_OK && metadata_synced)) {
+                        queue_uri_delete(*uncertain_items[i]);
+                    } else if (per_location_ec != EC_OK) {
+                        KVCM_LOG_WARN("[%s] rollback uncertain migration metadata failed, instance %s, block_key %ld, "
+                                      "location_id %s, ec %d",
+                                      trace_id.c_str(),
+                                      instance_id.c_str(),
+                                      uncertain_keys[i],
+                                      uncertain_location_ids[i].c_str(),
+                                      per_location_ec);
+                    }
+                }
+            }
+        }
+    }
+
+    if (direct_delete_uris.empty()) {
+        return;
+    }
+    if (!data_storage_manager) {
+        KVCM_LOG_WARN("[%s] rollback migration URIs failed: data storage manager missing, instance %s",
+                      trace_id.c_str(),
+                      instance_id.c_str());
+        return;
+    }
+    for (const auto &[storage_name, uris] : direct_delete_uris) {
+        const auto delete_results = data_storage_manager->Delete(request_context, storage_name, uris, nullptr);
+        if (delete_results.size() != uris.size()) {
+            KVCM_LOG_WARN("[%s] rollback migration URI result count mismatch, instance %s, storage %s, expected %zu, "
+                          "got %zu",
+                          trace_id.c_str(),
+                          instance_id.c_str(),
+                          storage_name.c_str(),
+                          uris.size(),
+                          delete_results.size());
+        }
+        const std::size_t result_count = std::min(delete_results.size(), uris.size());
+        for (std::size_t i = 0; i < result_count; ++i) {
+            if (delete_results[i] != EC_OK && delete_results[i] != EC_NOENT) {
+                KVCM_LOG_WARN("[%s] rollback migration URI failed, instance %s, storage %s, uri %s, ec %d",
+                              trace_id.c_str(),
+                              instance_id.c_str(),
+                              storage_name.c_str(),
+                              uris[i].ToUriString().c_str(),
+                              delete_results[i]);
+            }
+        }
+    }
+}
 
 std::optional<int64_t> ParsePositiveInt64(const std::string &value) {
     if (value.empty()) {
@@ -402,15 +570,34 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
     for (auto &spec : dst_specs) {
         dst_location->push_location_spec(std::move(spec));
     }
-    std::vector<std::string> out_location_ids;
-    ErrorCode ec =
-        meta_searcher.BatchAddLocation(ctx.get(), {request.block_key}, {dst_location}, out_location_ids);
-    if (ec != EC_OK || out_location_ids.empty() || out_location_ids[0].empty()) {
-        KVCM_LOG_WARN("[%s] BatchAddLocation failed for block_key %ld, ec %d",
+    std::vector<MetaSearcher::AddLocationResult> add_results;
+    ErrorCode ec = meta_searcher.BatchAddLocation(ctx.get(), {request.block_key}, {dst_location}, add_results);
+    if (add_results.size() != 1) {
+        KVCM_LOG_WARN("[%s] BatchAddLocation returned unexpected result count for block_key %ld: expected 1, got %zu; "
+                      "retaining allocated URIs",
                       trace_id.c_str(),
                       request.block_key,
-                      ec);
-        rollback();
+                      add_results.size());
+        return EC_ERROR;
+    }
+    const auto &add_result = add_results.front();
+    if (ec != EC_OK || add_result.ec != EC_OK || add_result.location_id.empty()) {
+        KVCM_LOG_WARN("[%s] BatchAddLocation failed for block_key %ld, aggregate ec %d, item ec %d",
+                      trace_id.c_str(),
+                      request.block_key,
+                      ec,
+                      add_result.ec);
+        RollbackAddedLocations(ctx.get(),
+                               trace_id,
+                               request.instance_id,
+                               indexer,
+                               data_storage_manager_,
+                               schedule_plan_executor_,
+                               {{request.block_key,
+                                 request.dst_storage_name,
+                                 allocated_for_rollback,
+                                 add_result.ec,
+                                 add_result.location_id}});
         return EC_ERROR;
     }
 
@@ -421,7 +608,7 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
     out_ctx.src_create_time = src_create_time; // 记录源 location 的创建时间
     out_ctx.src_storage_name = request.src_storage_name;
     out_ctx.dst_storage_name = request.dst_storage_name;
-    out_ctx.dst_location_id = out_location_ids[0];
+    out_ctx.dst_location_id = add_result.location_id;
     out_ctx.retention = request.retention;
     out_ctx.total_bytes = total_bytes;
     return EC_OK;
@@ -490,8 +677,8 @@ ErrorCode MigrationManager::Submit(const std::string &trace_id, MigrationRequest
     std::vector<DataStorageUri> dst_uris;
     ErrorCode prepare_ec = PrepareCopyTask(trace_id, request, ctx, src_uris, dst_uris);
     if (prepare_ec != EC_OK) {
-        // PrepareCopyTask 已回滚其成功分配的 URI；若 BatchAddLocation 部分成功留下 WRITING，
-        // 释放 reservation 后它会成为无 copy 在跑的真实 orphan，由 Reclaimer 安全清理。
+        // PrepareCopyTask 已按逐 key AddLocation 结果回滚目标元数据和 URI；补偿状态无法确认时
+        // 会保守保留 URI，由残留 WRITING 元数据的孤儿清理路径继续收敛。
         release_preparing();
         return prepare_ec;
     }
@@ -855,7 +1042,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
     }
 
     // 收集成功 Create 的 block → batch AddLocation
-    // add_items[k] 显式对应 add_block_keys[k]/add_locations[k]，并用于接回 location_ids[k]。
+    // add_items[k] 显式对应 add_block_keys[k]/add_locations[k]，并用于接回 add_results[k]。
     std::vector<BatchCopyItem *> add_items;
     std::vector<int64_t> add_block_keys;
     CacheLocationVector add_locations;
@@ -886,41 +1073,47 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
     // ---- phase 2+3: batch AddLocation + bind preparing reservations + executor Submit ----
     if (!add_block_keys.empty()) {
         MetaSearcher meta_searcher(indexer);
-        std::vector<std::string> location_ids;
+        std::vector<MetaSearcher::AddLocationResult> add_results;
         ErrorCode add_ec =
-            meta_searcher.BatchAddLocation(batch_ctx.get(), add_block_keys, add_locations, location_ids);
-        if (add_ec != EC_OK) {
-            // FIXME: 与正常写路径（cache_manager.cc:858）相同的已知局限——BatchAddLocation 部分成功时
-            // 无法精确识别哪些 block 的 meta 已写入，可能留下孤儿 CLS_WRITING location，由 reclaimer
-            // 孤儿检测被动清理。Delete 所有已分配 URI 作为 best-effort 回滚。
+            meta_searcher.BatchAddLocation(batch_ctx.get(), add_block_keys, add_locations, add_results);
+        if (add_results.size() != add_items.size()) {
+            KVCM_LOG_WARN("[%s] BatchAddLocation returned unexpected result count for migration batch: expected %zu, "
+                          "got %zu, aggregate ec %d; retaining allocated URIs",
+                          trace_id.c_str(),
+                          add_items.size(),
+                          add_results.size(),
+                          add_ec);
             for (auto *item : add_items) {
-                if (!item->dst_uris.empty()) {
-                    data_storage_manager_->Delete(
-                        batch_ctx.get(), item->request.dst_storage_name, item->dst_uris, nullptr);
-                }
-                item->MarkFailed(EC_ERROR);
+                item->MarkFailed(EC_MISMATCH);
             }
-            // 部分成功但未返回 id 的 WRITING 会在释放后成为真实 orphan；此时没有 copy 被提交。
             release_all_preparing();
             return collect_results();
+        }
+        if (add_ec != EC_OK) {
+            KVCM_LOG_WARN("[%s] BatchAddLocation partially failed for migration batch, aggregate ec %d",
+                          trace_id.c_str(),
+                          add_ec);
         }
 
         // ---- phase 3a: 先为整个批次绑定 location_id，再做任何逐项 mark 查询/submit ----
         // BatchAddLocation 一次公开全部 WRITING；若仍在逐项循环里绑定，后半批会继续暴露宽泛窗口。
         std::vector<BatchCopyItem *> bind_items;
         bind_items.reserve(add_items.size());
+        std::vector<AddLocationRollbackItem> rollback_items;
+        std::vector<BatchCopyItem *> rollback_add_items;
         for (std::size_t k = 0; k < add_items.size(); ++k) {
             auto &item = *add_items[k];
-            if (!item.eligible || k >= location_ids.size() || location_ids[k].empty()) {
-                // 无法识别目标 location id，不能提交 copy。URI 先 best-effort 删除；若 meta 已部分写入，
-                // reservation 释放后由 Reclaimer 清理残留 WRITING metadata。
-                if (!item.dst_uris.empty()) {
-                    data_storage_manager_->Delete(
-                        batch_ctx.get(), item.request.dst_storage_name, item.dst_uris, nullptr);
-                    item.dst_uris.clear();
-                }
-                item.MarkFailed(EC_ERROR);
-                release_preparing(item);
+            const auto &add_result = add_results[k];
+            if (!item.eligible || add_result.ec != EC_OK || add_result.location_id.empty()) {
+                const ErrorCode item_ec = add_result.ec == EC_OK ? EC_MISMATCH : add_result.ec;
+                rollback_items.push_back({item.request.block_key,
+                                          item.request.dst_storage_name,
+                                          item.dst_uris,
+                                          item_ec,
+                                          add_result.location_id});
+                item.dst_uris.clear();
+                item.MarkFailed(item_ec);
+                rollback_add_items.push_back(&item);
                 continue;
             }
             auto &req = item.request;
@@ -932,10 +1125,22 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             ctx.src_create_time = req.src_create_time;
             ctx.src_storage_name = req.src_storage_name;
             ctx.dst_storage_name = req.dst_storage_name;
-            ctx.dst_location_id = location_ids[k];
+            ctx.dst_location_id = add_result.location_id;
             ctx.retention = req.retention;
             ctx.total_bytes = item.total_bytes;
             bind_items.push_back(&item);
+        }
+        if (!rollback_items.empty()) {
+            RollbackAddedLocations(batch_ctx.get(),
+                                   trace_id,
+                                   first_req.instance_id,
+                                   indexer,
+                                   data_storage_manager_,
+                                   schedule_plan_executor_,
+                                   rollback_items);
+            for (auto *item : rollback_add_items) {
+                release_preparing(*item);
+            }
         }
         {
             std::lock_guard<std::mutex> lock(task_mutex_);

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -6,6 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <set>
+#include <shared_mutex>
 #include <thread>
 #include <tuple>
 
@@ -34,6 +36,7 @@
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 #include "kv_cache_manager/meta/meta_local_backend.h"
+#include "kv_cache_manager/meta/utils.h"
 #include "kv_cache_manager/metrics/metrics_collector.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "stub.h"
@@ -45,6 +48,23 @@ static const std::string default_storage_configs(
 } // namespace
 
 namespace kv_cache_manager {
+
+namespace {
+ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
+                                  RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const CacheLocationVector &locations,
+                                  std::vector<std::string> &out_location_ids) {
+    std::vector<MetaSearcher::AddLocationResult> results;
+    const ErrorCode ec = meta_searcher->BatchAddLocation(request_context, keys, locations, results);
+    out_location_ids.clear();
+    out_location_ids.reserve(results.size());
+    for (const auto &result : results) {
+        out_location_ids.push_back(result.location_id);
+    }
+    return ec;
+}
+} // namespace
 
 namespace mark_query_read_error_stub {
 ErrorCode ReadError_stub(void * /*obj*/,
@@ -274,6 +294,49 @@ private:
     bool release_location_read_ = false;
     std::optional<int64_t> fail_key_on_next_upsert_;
     size_t sync_call_count_ = 0;
+};
+
+class DeleteRecordingBackend : public DataStorageBackend {
+public:
+    explicit DeleteRecordingBackend(std::shared_ptr<DataStorageBackend> delegate)
+        : DataStorageBackend(delegate->metrics_registry_), delegate_(std::move(delegate)) {
+        SetOpen(delegate_->IsOpen());
+        SetAvailable(true);
+    }
+
+    DataStorageType GetType() override { return delegate_->GetType(); }
+    bool Available() override { return delegate_->Available(); }
+    double GetStorageUsageRatio(const std::string &trace_id) const override {
+        return delegate_->GetStorageUsageRatio(trace_id);
+    }
+    const StorageConfig &GetStorageConfig() override { return delegate_->GetStorageConfig(); }
+    ErrorCode DoOpen(const StorageConfig &config, const std::string &trace_id) override {
+        return delegate_->DoOpen(config, trace_id);
+    }
+    ErrorCode Close() override { return delegate_->Close(); }
+    std::vector<std::pair<ErrorCode, DataStorageUri>> Create(const std::vector<std::string> &keys,
+                                                             size_t size_per_key,
+                                                             const std::string &trace_id,
+                                                             std::function<void()> cb) override {
+        return delegate_->Create(keys, size_per_key, trace_id, std::move(cb));
+    }
+    std::vector<ErrorCode>
+    Delete(const std::vector<DataStorageUri> &uris, const std::string &trace_id, std::function<void()> cb) override {
+        deleted_uri_count_.fetch_add(uris.size(), std::memory_order_relaxed);
+        return delegate_->Delete(uris, trace_id, std::move(cb));
+    }
+    std::vector<bool> Exist(const std::vector<DataStorageUri> &uris) override { return delegate_->Exist(uris); }
+    std::vector<bool> MightExist(const std::vector<DataStorageUri> &uris) override {
+        return delegate_->MightExist(uris);
+    }
+    std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &uris) override { return delegate_->Lock(uris); }
+    std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &uris) override { return delegate_->UnLock(uris); }
+
+    size_t DeletedUriCount() const { return deleted_uri_count_.load(std::memory_order_relaxed); }
+
+private:
+    std::shared_ptr<DataStorageBackend> delegate_;
+    std::atomic<size_t> deleted_uri_count_{0};
 };
 
 class CacheManagerTest : public TESTBASE {
@@ -826,6 +889,67 @@ TEST_F(CacheManagerTest, TestStartWriteCache) {
             // ASSERT_EQ(expected, location_specs[j].location());
         }
     }
+}
+
+TEST_F(CacheManagerTest, TestStartWriteCacheRollsBackPartialBatchAdd) {
+    auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    ASSERT_EQ(expected,
+              cache_manager_->RegisterInstance(request_context_.get(),
+                                               "default",
+                                               "test_instance",
+                                               64,
+                                               createLocationSpecInfos(),
+                                               createModelDeployment(),
+                                               std::vector<LocationSpecGroup>()));
+
+    auto meta_indexer = cache_manager_->meta_indexer_manager_->GetMetaIndexer("test_instance");
+    ASSERT_TRUE(meta_indexer);
+    meta_indexer->batch_key_size_ = 1;
+    meta_indexer->max_key_count_ = 1;
+
+    auto data_storage_manager = registry_manager_->data_storage_manager();
+    ASSERT_TRUE(data_storage_manager);
+    auto original_backend = data_storage_manager->GetDataStorageBackend("nfs_01");
+    ASSERT_TRUE(original_backend);
+    auto recording_backend = std::make_shared<DeleteRecordingBackend>(original_backend);
+    {
+        std::unique_lock<std::shared_mutex> lock(data_storage_manager->rw_lock_);
+        data_storage_manager->storage_map_["nfs_01"] = recording_backend;
+    }
+
+    std::vector<int64_t> keys{1001, 1002};
+    while (GetShardIndex(keys[0], meta_indexer->mutex_shard_mask_) ==
+           GetShardIndex(keys[1], meta_indexer->mutex_shard_mask_)) {
+        ++keys[1];
+    }
+    auto [ec, start_write_cache_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 1000);
+    EXPECT_EQ(EC_PARTIAL_OK, ec);
+    EXPECT_TRUE(start_write_cache_info.locations().cache_locations_view().empty());
+
+    MetaSearcher *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_TRUE(meta_searcher);
+    std::vector<CacheLocationMap> location_maps;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    bool rollback_completed = false;
+    do {
+        location_maps.clear();
+        BlockMask empty_mask;
+        const ErrorCode get_ec =
+            meta_searcher->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps);
+        const bool metadata_removed = get_ec == EC_OK && location_maps.size() == keys.size() &&
+                                      std::all_of(location_maps.begin(),
+                                                  location_maps.end(),
+                                                  [](const auto &locations) { return locations.empty(); });
+        rollback_completed = metadata_removed && meta_indexer->GetStorageUsage() == 0 &&
+                             recording_backend->DeletedUriCount() >= keys.size() * createLocationSpecInfos().size();
+        if (!rollback_completed) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    } while (!rollback_completed && std::chrono::steady_clock::now() < deadline);
+
+    EXPECT_TRUE(rollback_completed);
+    EXPECT_EQ(keys.size() * createLocationSpecInfos().size(), recording_backend->DeletedUriCount());
 }
 
 TEST_F(CacheManagerTest, TestStartWriteDuplicateCache) {
@@ -6891,7 +7015,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkPropagation) {
                                             1,
                                             std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot/blk1?size=1")});
         std::vector<std::string> ids;
-        ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {loc}, ids));
+        ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {loc}, ids));
     }
     cache_manager_->migration_manager()->MarkForTieredWrite("placeholder_id", {1}, "cold_01");
 
@@ -6939,7 +7063,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheFallsBackToOrdinaryPolicyOnMarkRead
         1,
         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/mark_read_error?size=1")});
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {hot_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {hot_loc}, ids));
     ASSERT_EQ(1u, ids.size());
     std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
         {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
@@ -6985,7 +7109,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheInvalidTieredTargetUsesOrdinaryPoli
         1,
         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/invalid_target?size=1")});
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {hot_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {hot_loc}, ids));
     ASSERT_EQ(1u, ids.size());
     std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
         {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
@@ -7034,7 +7158,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheUnavailableTieredTargetUsesOrdinary
         1,
         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/unavailable_target?size=1")});
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {hot_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {hot_loc}, ids));
     std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
         {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
     std::vector<std::vector<ErrorCode>> cas_results;
@@ -7114,7 +7238,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaFallsBackOnMarkReadEr
     };
     for (const auto &uri : {"dummy://hot_01/mark_read_error_a?size=1", "dummy://hot_02/mark_read_error_b?size=1"}) {
         std::vector<std::string> ids;
-        ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {make_hot_loc(uri)}, ids));
+        ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {make_hot_loc(uri)}, ids));
         ASSERT_EQ(1u, ids.size());
         std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
             {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
@@ -7160,7 +7284,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaInvalidTieredTargetUs
         auto loc = std::make_shared<CacheLocation>(
             DataStorageType::DATA_STORAGE_TYPE_DUMMY, 1, std::vector<LocationSpec>{LocationSpec("tp0", uri)});
         std::vector<std::string> ids;
-        ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {block_key}, {loc}, ids));
+        ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {block_key}, {loc}, ids));
         ASSERT_EQ(1u, ids.size());
         std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
             {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
@@ -7216,7 +7340,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheSkipsTieredMarkWhenMigrationDisable
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/blk1?size=1")});
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {hot_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {hot_loc}, ids));
     ASSERT_EQ(EC_OK, cache_manager_->migration_manager()->MarkForTieredWrite("tiered_disabled", {1}, "cold_01"));
 
     CacheManager::KeyVector new_keys;
@@ -7267,7 +7391,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkSkipsExistingTarget) {
                                                            LocationSpec("tp3", "dummy://cold_01/blk2/tp3?size=1"),
                                                        });
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1, 2}, {writing_loc, serving_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1, 2}, {writing_loc, serving_loc}, ids));
     ASSERT_EQ(2u, ids.size());
     std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
         {MetaSearcher::LocationCASTask{ids[1], CLS_WRITING, CLS_SERVING}}};
@@ -7320,7 +7444,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredStaleTargetTriggersRewrite) {
                                                         LocationSpec("tp3", "dummy://cold_01/blk1/tp3?size=1"),
                                                     });
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {cold_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {cold_loc}, ids));
     ASSERT_EQ(1u, ids.size());
     std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
         {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
@@ -7377,7 +7501,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaUsesTieredMarkTarget)
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/blk1?size=1")});
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {hot_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {hot_loc}, ids));
     cache_manager_->migration_manager()->MarkForTieredWrite("min_replica_tiered", {1}, "cold_01");
 
     CacheManager::KeyVector new_keys;
@@ -7420,8 +7544,8 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaHonorsTieredMarkWhenR
     };
     std::vector<std::string> ids;
     ASSERT_EQ(EC_OK,
-              meta_searcher->BatchAddLocation(
-                  request_context_.get(), {1}, {make_hot_loc("dummy://hot_01/blk1_a?size=1")}, ids));
+              BatchAddLocationForTest(
+                  meta_searcher, request_context_.get(), {1}, {make_hot_loc("dummy://hot_01/blk1_a?size=1")}, ids));
     ASSERT_EQ(1u, ids.size());
     std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
         {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
@@ -7430,8 +7554,8 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaHonorsTieredMarkWhenR
 
     ids.clear();
     ASSERT_EQ(EC_OK,
-              meta_searcher->BatchAddLocation(
-                  request_context_.get(), {1}, {make_hot_loc("dummy://hot_02/blk1_b?size=1")}, ids));
+              BatchAddLocationForTest(
+                  meta_searcher, request_context_.get(), {1}, {make_hot_loc("dummy://hot_02/blk1_b?size=1")}, ids));
     ASSERT_EQ(1u, ids.size());
     cas_tasks = {{MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
     cas_results.clear();
@@ -7491,7 +7615,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkChecksSpecGroupOnTarget) 
                                                            LocationSpec("tp1_F0", "dummy://cold_01/blk1/tp1_F0?size=1"),
                                                        });
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {cold_f0_loc}, ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {cold_f0_loc}, ids));
     ASSERT_EQ(1u, ids.size());
     cache_manager_->migration_manager()->MarkForTieredWrite("tiered_spec_group", {1}, "cold_01");
 
@@ -7631,11 +7755,11 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheClearsTieredMark) {
     ASSERT_TRUE(meta_searcher);
     std::vector<std::string> source_ids;
     {
-        auto loc =
-            std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-                                            1,
-                                            std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot/blk1?size=1")});
-        ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {loc}, source_ids));
+        auto loc = std::make_shared<CacheLocation>(
+            DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+            1,
+            std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot/blk1?size=1")});
+        ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {loc}, source_ids));
     }
     ASSERT_EQ(1u, source_ids.size());
     cache_manager_->migration_manager()->MarkForTieredWrite("placeholder_id", {1}, "cold_01");
@@ -7646,7 +7770,7 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheClearsTieredMark) {
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://cold_01/blk1?size=1")});
     std::vector<std::string> target_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {target_loc}, target_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {target_loc}, target_ids));
     ASSERT_EQ(1u, target_ids.size());
 
     auto info = std::make_unique<WriteLocationManager::WriteLocationInfo>();
@@ -7685,7 +7809,7 @@ TEST_F(CacheManagerTest, TestAdminMarkUsesMatchingStrategyTimeout) {
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/blk1?size=1")});
     std::vector<std::string> source_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {source_loc}, source_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {source_loc}, source_ids));
     std::vector<std::vector<MetaSearcher::LocationUpdateTask>> status_tasks = {
         {{source_ids[0], CacheLocationStatus::CLS_SERVING}}};
     std::vector<std::vector<ErrorCode>> status_results;
@@ -7739,7 +7863,7 @@ TEST_F(CacheManagerTest, TestAdminMarkAllowsUnmatchedTargetWithDefaultTimeout) {
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/blk1?size=1")});
     std::vector<std::string> source_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {source_loc}, source_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {source_loc}, source_ids));
     ASSERT_EQ(1u, source_ids.size());
     std::vector<std::vector<MetaSearcher::LocationUpdateTask>> status_tasks = {
         {{source_ids[0], CacheLocationStatus::CLS_SERVING}}};
@@ -7802,7 +7926,7 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheFullBlockPolicyKeepsPartialMark) {
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot_01/blk1?size=1")});
     std::vector<std::string> hot_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {hot_loc}, hot_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {hot_loc}, hot_ids));
     cache_manager_->migration_manager()->MarkForTieredWrite("full_policy_instance", {1}, "cold_01");
     ASSERT_TRUE(cache_manager_->migration_manager()->IsMarkedForTieredWrite("full_policy_instance", 1));
 
@@ -7811,7 +7935,7 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheFullBlockPolicyKeepsPartialMark) {
         1,
         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://cold_01/blk1/tp0?size=1")});
     std::vector<std::string> partial_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {partial_cold_loc}, partial_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {partial_cold_loc}, partial_ids));
     auto partial_info = std::make_unique<WriteLocationManager::WriteLocationInfo>();
     partial_info->keys = {1};
     partial_info->location_ids = {partial_ids[0]};
@@ -7832,7 +7956,7 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheFullBlockPolicyKeepsPartialMark) {
                                             LocationSpec("tp3", "dummy://cold_01/blk1/tp3?size=1"),
                                         });
     std::vector<std::string> remaining_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {remaining_cold_loc}, remaining_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {remaining_cold_loc}, remaining_ids));
     auto remaining_info = std::make_unique<WriteLocationManager::WriteLocationInfo>();
     remaining_info->keys = {1};
     remaining_info->location_ids = {remaining_ids[0]};
@@ -7866,7 +7990,7 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheSkipsTieredMarkWhenMigrationDisable
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot/blk1?size=1")});
     std::vector<std::string> hot_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {hot_loc}, hot_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {hot_loc}, hot_ids));
 
     // 通过 admin 旁路直接打标（该 group 无策略）。
     cache_manager_->migration_manager()->MarkForTieredWrite("tiered_disabled_finish", {1}, "cold_01");
@@ -7879,7 +8003,7 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheSkipsTieredMarkWhenMigrationDisable
                                         1,
                                         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://cold_01/blk1?size=1")});
     std::vector<std::string> target_ids;
-    ASSERT_EQ(EC_OK, meta_searcher->BatchAddLocation(request_context_.get(), {1}, {target_loc}, target_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {target_loc}, target_ids));
     ASSERT_EQ(1u, target_ids.size());
 
     auto info = std::make_unique<WriteLocationManager::WriteLocationInfo>();

--- a/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
@@ -33,6 +33,21 @@ SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
                                            const std::vector<std::vector<std::string>> &,
                                            const std::vector<std::vector<std::string>> &,
                                            bool) -> void {};
+
+ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
+                                  RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const CacheLocationVector &locations,
+                                  std::vector<std::string> &out_location_ids) {
+    std::vector<MetaSearcher::AddLocationResult> results;
+    const ErrorCode ec = meta_searcher->BatchAddLocation(request_context, keys, locations, results);
+    out_location_ids.clear();
+    out_location_ids.reserve(results.size());
+    for (const auto &result : results) {
+        out_location_ids.push_back(result.location_id);
+    }
+    return ec;
+}
 } // namespace
 
 class MetaSearcherRealServiceTest : public TESTBASE {
@@ -94,7 +109,8 @@ TEST_F(MetaSearcherRealServiceTest, TestBatchAddAndGetLocation) {
 
     // 调用BatchAddLocation
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
 
     // 验证结果
     EXPECT_EQ(ec, ErrorCode::EC_OK);
@@ -132,7 +148,8 @@ TEST_F(MetaSearcherRealServiceTest, TestBatchUpdateLocationStatus) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -193,7 +210,8 @@ TEST_F(MetaSearcherRealServiceTest, TestPrefixMatchWithServingStatus) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -251,7 +269,8 @@ TEST_F(MetaSearcherRealServiceTest, TestConcurrentOperations) {
 
             // 添加位置信息
             std::vector<std::string> out_location_ids;
-            ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+            ErrorCode ec = BatchAddLocationForTest(
+                meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
             ASSERT_EQ(ec, ErrorCode::EC_OK);
             ASSERT_EQ(out_location_ids.size(), 3);
 
@@ -310,7 +329,8 @@ TEST_F(MetaSearcherRealServiceTest, TestBatchVsSequentialPerformance) {
 
     // 批量添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
 
     // 将所有位置更新为SERVING状态

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -14,6 +14,7 @@
 #include "kv_cache_manager/manager/meta_searcher.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/meta/meta_local_backend.h"
+#include "kv_cache_manager/meta/utils.h"
 
 using namespace kv_cache_manager;
 
@@ -67,6 +68,42 @@ public:
 private:
     std::optional<KeyType> failed_key_;
 };
+
+class CommitThenFailUpsertBackend : public MetaLocalBackend {
+public:
+    void SetFailUpsert(bool fail_upsert) { fail_upsert_ = fail_upsert; }
+
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override {
+        auto results = MetaLocalBackend::Upsert(request_context, keys, locations, properties);
+        if (fail_upsert_) {
+            for (auto &result : results) {
+                result = EC_ERROR;
+            }
+        }
+        return results;
+    }
+
+private:
+    bool fail_upsert_ = false;
+};
+
+ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
+                                  RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const CacheLocationVector &locations,
+                                  std::vector<std::string> &out_location_ids) {
+    std::vector<MetaSearcher::AddLocationResult> results;
+    const ErrorCode ec = meta_searcher->BatchAddLocation(request_context, keys, locations, results);
+    out_location_ids.clear();
+    out_location_ids.reserve(results.size());
+    for (const auto &result : results) {
+        out_location_ids.push_back(result.location_id);
+    }
+    return ec;
+}
 } // namespace
 
 class MetaSearcherTest : public TESTBASE {
@@ -123,6 +160,18 @@ public:
         return backend_raw;
     }
 
+    CommitThenFailUpsertBackend *ReplaceWithCommitThenFailUpsertBackend() {
+        auto backend_config = ConstructMetaStorageBackendConfig();
+        auto backend = std::make_unique<CommitThenFailUpsertBackend>();
+        EXPECT_EQ(EC_OK, backend->Init("test", backend_config));
+        EXPECT_EQ(EC_OK, backend->Open());
+        auto backend_raw = backend.get();
+        meta_indexer_->backend_manager_->persistent_backend_->Close();
+        meta_indexer_->backend_manager_->persistent_backend_ = std::move(backend);
+        meta_indexer_->backend_manager_->cache_backend_.reset();
+        return backend_raw;
+    }
+
     std::shared_ptr<MetaIndexer> meta_indexer_;
     std::shared_ptr<MetaSearcher> meta_searcher_;
     std::shared_ptr<RequestContext> request_context_;
@@ -145,12 +194,16 @@ TEST_F(MetaSearcherTest, TestBatchAddLocation) {
     CacheLocationVector locations = {location1, location2, location3};
 
     // 调用BatchAddLocation
-    std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    std::vector<MetaSearcher::AddLocationResult> add_results;
+    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, add_results);
 
     // 验证结果
     EXPECT_EQ(ec, ErrorCode::EC_OK);
-    EXPECT_EQ(out_location_ids.size(), 3);
+    ASSERT_EQ(add_results.size(), keys.size());
+    for (const auto &result : add_results) {
+        EXPECT_EQ(result.ec, ErrorCode::EC_OK);
+        EXPECT_FALSE(result.location_id.empty());
+    }
 
     // 验证添加的位置信息可以被检索到
     std::vector<CacheLocationMap> out_location_maps;
@@ -160,10 +213,55 @@ TEST_F(MetaSearcherTest, TestBatchAddLocation) {
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_maps.size(), 3);
 
-    for (const auto &location_map : out_location_maps) {
+    for (size_t i = 0; i < out_location_maps.size(); ++i) {
+        const auto &location_map = out_location_maps[i];
         EXPECT_FALSE(location_map.empty());
         // 每个map应该只有一个location（我们刚添加的）
         EXPECT_EQ(location_map.size(), 1);
+        EXPECT_NE(location_map.find(add_results[i].location_id), location_map.end());
+    }
+}
+
+TEST_F(MetaSearcherTest, TestBatchAddLocationReturnsAlignedPartialResults) {
+    meta_indexer_->batch_key_size_ = 1;
+    meta_indexer_->max_key_count_ = 1;
+
+    MetaSearcher::KeyVector keys = {1001, 1002};
+    while (GetShardIndex(keys[0], meta_indexer_->mutex_shard_mask_) ==
+           GetShardIndex(keys[1], meta_indexer_->mutex_shard_mask_)) {
+        ++keys[1];
+    }
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+    CacheLocationVector locations = {location, location};
+
+    std::vector<MetaSearcher::AddLocationResult> add_results;
+    const ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, add_results);
+
+    EXPECT_EQ(ec, ErrorCode::EC_PARTIAL_OK);
+    ASSERT_EQ(add_results.size(), keys.size());
+    size_t success_count = 0;
+    size_t failure_count = 0;
+    for (const auto &result : add_results) {
+        // 两个 modifier 都已生成 id；失败项的 id 只能用于回滚定位。
+        EXPECT_FALSE(result.location_id.empty());
+        if (result.ec == ErrorCode::EC_OK) {
+            ++success_count;
+        } else {
+            EXPECT_EQ(result.ec, ErrorCode::EC_NOSPC);
+            ++failure_count;
+        }
+    }
+    EXPECT_EQ(success_count, 1);
+    EXPECT_EQ(failure_count, 1);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    ASSERT_EQ(location_maps.size(), keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool persisted = location_maps[i].find(add_results[i].location_id) != location_maps[i].end();
+        EXPECT_EQ(persisted, add_results[i].ec == ErrorCode::EC_OK);
     }
 }
 
@@ -192,7 +290,8 @@ TEST_F(MetaSearcherTest, TestBatchAddLocation2) {
 
     // 调用BatchAddLocation
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
 
     // 验证结果
     EXPECT_EQ(ec, ErrorCode::EC_OK);
@@ -985,7 +1084,8 @@ TEST_F(MetaSearcherTest, TestPrefixMatch) {
     CacheLocationVector locations = {location1, location2, location3};
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -1083,7 +1183,8 @@ TEST_F(MetaSearcherTest, TestBatchGet) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -1153,7 +1254,8 @@ TEST_F(MetaSearcherTest, TestBatchUpdateLocationStatus) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -1278,9 +1380,12 @@ TEST_F(MetaSearcherTest, TestBlockKeyWithMultipleLocations) {
     // 分别调用三次BatchAddLocation，为同一个key添加三个不同的location
     std::vector<std::string> out_location_ids1, out_location_ids2, out_location_ids3;
 
-    ErrorCode ec1 = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations1, out_location_ids1);
-    ErrorCode ec2 = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations2, out_location_ids2);
-    ErrorCode ec3 = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations3, out_location_ids3);
+    ErrorCode ec1 =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations1, out_location_ids1);
+    ErrorCode ec2 =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations2, out_location_ids2);
+    ErrorCode ec3 =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations3, out_location_ids3);
 
     // 验证结果
     EXPECT_EQ(ec1, ErrorCode::EC_OK);
@@ -1324,6 +1429,193 @@ TEST_F(MetaSearcherTest, TestBlockKeyWithMultipleLocations) {
     EXPECT_EQ(retrieved_location3.location_specs().size(), 1);
 }
 
+TEST_F(MetaSearcherTest, TestBatchDeleteLocations) {
+    // 首先添加一些测试数据
+    MetaSearcher::KeyVector keys = {5000, 6000, 7000};
+
+    // 创建CacheLocation对象
+    auto location_specs = MetaSearcherTestHelper::CreateDefaultLocationSpecs();
+    CacheLocationConstPtr location1 =
+        MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, location_specs);
+    CacheLocationConstPtr location2 =
+        MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, location_specs);
+    CacheLocationConstPtr location3 =
+        MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, location_specs);
+
+    CacheLocationVector locations = {location1, location2, location3};
+
+    // 添加位置信息
+    std::vector<std::string> out_location_ids;
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
+    EXPECT_EQ(ec, ErrorCode::EC_OK);
+    EXPECT_EQ(out_location_ids.size(), 3);
+
+    // 验证添加的位置信息可以被检索到
+    std::vector<CacheLocationMap> out_location_maps;
+    BlockMask mask; // 空mask，不跳过任何元素
+
+    ec = meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, out_location_maps);
+    EXPECT_EQ(ec, ErrorCode::EC_OK);
+    EXPECT_EQ(out_location_maps.size(), 3);
+
+    for (const auto &location_map : out_location_maps) {
+        EXPECT_FALSE(location_map.empty());
+        // 每个map应该只有一个location（我们刚添加的）
+        EXPECT_EQ(location_map.size(), 1);
+    }
+
+    // 准备删除数据 - 删除前两个location
+    LocationIdsPerKey delete_location_ids = {{out_location_ids[0]}, {out_location_ids[1]}, {"non_existent_id"}};
+    MetaSearcher::KeyVector delete_keys = {5000, 6000, 7000}; // 对应的keys
+
+    // 调用BatchDeleteLocations
+    std::vector<std::vector<ErrorCode>> delete_results;
+    ec = meta_searcher_->BatchDeleteLocations(request_context_.get(), delete_keys, delete_location_ids, delete_results);
+
+    // 验证结果
+    EXPECT_EQ(ec, ErrorCode::EC_OK);
+    EXPECT_EQ(delete_results.size(), 3);
+    ASSERT_EQ(delete_results[0].size(), 1);
+    ASSERT_EQ(delete_results[1].size(), 1);
+    ASSERT_EQ(delete_results[2].size(), 1);
+    EXPECT_EQ(delete_results[0][0], ErrorCode::EC_OK);    // 成功删除第一个
+    EXPECT_EQ(delete_results[1][0], ErrorCode::EC_OK);    // 成功删除第二个
+    EXPECT_EQ(delete_results[2][0], ErrorCode::EC_NOENT); // 删除不存在的location应返回EC_NOENT
+
+    // 验证删除后的状态
+    out_location_maps.clear();
+    ec = meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, out_location_maps);
+    EXPECT_EQ(ec, ErrorCode::EC_OK);
+    EXPECT_EQ(out_location_maps.size(), 3);
+
+    // 第一个key应该没有location了
+    EXPECT_TRUE(out_location_maps[0].empty());
+
+    // 第二个key应该没有location了
+    EXPECT_TRUE(out_location_maps[1].empty());
+
+    // 第三个key应该还有location
+    EXPECT_FALSE(out_location_maps[2].empty());
+    EXPECT_EQ(out_location_maps[2].size(), 1);
+
+    // 验证第三个location仍然存在且信息正确
+    auto it = out_location_maps[2].find(out_location_ids[2]);
+    EXPECT_NE(it, out_location_maps[2].end());
+
+    if (it != out_location_maps[2].end()) {
+        const auto &location = *it->second;
+        EXPECT_EQ(location.id(), out_location_ids[2]);
+        EXPECT_EQ(location.status(), CLS_WRITING);
+        EXPECT_EQ(location.type(), locations[2]->type());
+    }
+
+    // 测试错误情况：key和location_id数量不匹配
+    MetaSearcher::KeyVector mismatched_keys = {5000, 6000}; // 只有两个
+    LocationIdsPerKey mismatched_location_ids = {
+        {out_location_ids[0]}, {out_location_ids[1]}, {out_location_ids[2]}}; // 三个
+
+    ec = meta_searcher_->BatchDeleteLocations(
+        request_context_.get(), mismatched_keys, mismatched_location_ids, delete_results);
+    EXPECT_EQ(ec, ErrorCode::EC_BADARGS);
+}
+
+TEST_F(MetaSearcherTest, TestBatchDeleteLocationsTracksStorageUsage) {
+    // 首先添加一些测试数据
+    MetaSearcher::KeyVector keys = {5000, 6000, 7000};
+
+    // 创建CacheLocation对象
+    std::vector<LocationSpec> specs1(
+        1, MetaSearcherTestHelper::CreateLocationSpec("nfs", "file:///tmp/test1/test.txt?offset=1&length=2&size=3"));
+    CacheLocationConstPtr location1 =
+        MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_NFS, 1, specs1);
+
+    std::vector<LocationSpec> specs2(
+        1, MetaSearcherTestHelper::CreateLocationSpec("hf3fs", "hf3fs:///tmp/test1/test.txt?offset=1&length=2&size=4"));
+    CacheLocationConstPtr location2 =
+        MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 2, specs2);
+
+    std::vector<LocationSpec> specs3(2,
+                                     MetaSearcherTestHelper::CreateLocationSpec(
+                                         "mooncake", "mooncake:///tmp/test1/test.txt?offset=1&length=2&size=5"));
+    CacheLocationConstPtr location3 =
+        MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 3, specs3);
+
+    CacheLocationVector locations = {location1, location2, location3};
+
+    // 添加位置信息
+    std::vector<std::string> out_location_ids;
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
+    EXPECT_EQ(ec, ErrorCode::EC_OK);
+    EXPECT_EQ(out_location_ids.size(), 3);
+
+    // 准备删除数据 - 删除前两个location
+    LocationIdsPerKey delete_location_ids = {{out_location_ids[0]}, {out_location_ids[1]}, {"non_existent_id"}};
+    MetaSearcher::KeyVector delete_keys = {5000, 6000, 7000}; // 对应的keys
+
+    // 调用BatchDeleteLocations
+    std::vector<std::vector<ErrorCode>> delete_results;
+    ec = meta_searcher_->BatchDeleteLocations(request_context_.get(), delete_keys, delete_location_ids, delete_results);
+
+    // 验证结果
+    EXPECT_EQ(0, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS));
+    EXPECT_EQ(0, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_HF3FS));
+    EXPECT_EQ(10, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE));
+}
+
+TEST_F(MetaSearcherTest, TestBatchDeleteLocationsCanPreserveKeyCountForUncertainAddRollback) {
+    auto backend = ReplaceWithCommitThenFailUpsertBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType existing_key = 7100;
+    const KeyType uncertain_key = 7200;
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+
+    std::vector<MetaSearcher::AddLocationResult> existing_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {existing_key}, {location}, existing_results));
+    ASSERT_EQ(1u, existing_results.size());
+    ASSERT_EQ(EC_OK, existing_results[0].ec);
+    ASSERT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    backend->SetFailUpsert(true);
+    std::vector<MetaSearcher::AddLocationResult> uncertain_results;
+    ASSERT_EQ(EC_ERROR,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {uncertain_key}, {location}, uncertain_results));
+    ASSERT_EQ(1u, uncertain_results.size());
+    ASSERT_EQ(EC_ERROR, uncertain_results[0].ec);
+    ASSERT_FALSE(uncertain_results[0].location_id.empty());
+    ASSERT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {uncertain_key}, mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_EQ(1u, location_maps[0].count(uncertain_results[0].location_id));
+
+    std::vector<std::vector<ErrorCode>> delete_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(),
+                                                   {uncertain_key},
+                                                   {{uncertain_results[0].location_id}},
+                                                   delete_results,
+                                                   {},
+                                                   false,
+                                                   false));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
+    EXPECT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    location_maps.clear();
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchGetLocation(request_context_.get(), {existing_key, uncertain_key}, mask, location_maps));
+    ASSERT_EQ(2u, location_maps.size());
+    EXPECT_EQ(1u, location_maps[0].count(existing_results[0].location_id));
+    EXPECT_TRUE(location_maps[1].empty());
+}
+
 TEST_F(MetaSearcherTest, TestBatchVsSequentialPerformance) {
     const size_t num_keys = 100;
     MetaSearcher::KeyVector keys;
@@ -1339,7 +1631,8 @@ TEST_F(MetaSearcherTest, TestBatchVsSequentialPerformance) {
     }
 
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
 
     std::vector<CacheLocationStatus> statuses(out_location_ids.size(), CacheLocationStatus::CLS_SERVING);
@@ -1405,7 +1698,8 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatus) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -1502,7 +1796,8 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusChecksExactLocationValue) {
         DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
     CacheLocationVector locations = {location};
     std::vector<std::string> location_ids;
-    ASSERT_EQ(EC_OK, meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, location_ids));
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, location_ids));
     ASSERT_EQ(1u, location_ids.size());
 
     std::vector<std::vector<MetaSearcher::LocationCASTask>> mismatch_tasks = {{
@@ -1542,7 +1837,8 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatus) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -1640,7 +1936,8 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatus2) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 3);
 
@@ -1692,7 +1989,8 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusMultipleTasksPerKey) {
 
     // 添加位置信息
     std::vector<std::string> out_location_ids;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations, out_location_ids);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, out_location_ids);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids.size(), 1);
 
@@ -1700,7 +1998,7 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusMultipleTasksPerKey) {
     CacheLocationConstPtr location2 =
         MetaSearcherTestHelper::CreateCacheLocation(DataStorageType::DATA_STORAGE_TYPE_HF3FS, 1, location_specs);
     std::vector<std::string> out_location_ids2;
-    ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, {location2}, out_location_ids2);
+    ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, {location2}, out_location_ids2);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids2.size(), 1);
 
@@ -1759,14 +2057,15 @@ TEST_F(MetaSearcherTest, TestBatchCADLocationStatusMultipleTasksPerKey) {
     // 添加第一个位置信息
     CacheLocationVector locations1 = {location1};
     std::vector<std::string> out_location_ids1;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations1, out_location_ids1);
+    ErrorCode ec =
+        BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations1, out_location_ids1);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids1.size(), 1);
 
     // 添加第二个位置到同一个key
     CacheLocationVector locations2 = {location2};
     std::vector<std::string> out_location_ids2;
-    ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations2, out_location_ids2);
+    ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations2, out_location_ids2);
     EXPECT_EQ(ec, ErrorCode::EC_OK);
     EXPECT_EQ(out_location_ids2.size(), 1);
 
@@ -1898,14 +2197,14 @@ TEST_F(MetaSearcherTest, TestPrefixMatchMergesSpecsByStorageType) {
     // Add location A to all keys
     CacheLocationVector locations_a = {loc_a, loc_a, loc_a};
     std::vector<std::string> out_ids_a;
-    ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations_a, out_ids_a);
+    ErrorCode ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations_a, out_ids_a);
     ASSERT_EQ(ec, ErrorCode::EC_OK);
     ASSERT_EQ(out_ids_a.size(), 3);
 
     // Add location B to all keys
     CacheLocationVector locations_b = {loc_b, loc_b, loc_b};
     std::vector<std::string> out_ids_b;
-    ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locations_b, out_ids_b);
+    ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations_b, out_ids_b);
     ASSERT_EQ(ec, ErrorCode::EC_OK);
     ASSERT_EQ(out_ids_b.size(), 3);
 
@@ -1961,7 +2260,7 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
     {
         CacheLocationVector locs = {loc_a, loc_c};
         std::vector<std::string> out_ids;
-        ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), keys, locs, out_ids);
+        ErrorCode ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locs, out_ids);
         ASSERT_EQ(ec, ErrorCode::EC_OK);
 
         std::vector<std::vector<MetaSearcher::LocationUpdateTask>> tasks;
@@ -1978,7 +2277,7 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
         MetaSearcher::KeyVector key_60000 = {60000};
         CacheLocationVector locs = {loc_b};
         std::vector<std::string> out_ids;
-        ErrorCode ec = meta_searcher_->BatchAddLocation(request_context_.get(), key_60000, locs, out_ids);
+        ErrorCode ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), key_60000, locs, out_ids);
         ASSERT_EQ(ec, ErrorCode::EC_OK);
 
         std::vector<std::vector<MetaSearcher::LocationUpdateTask>> tasks;
@@ -2090,7 +2389,7 @@ protected:
                 1,
                 {MetaSearcherTestHelper::CreateLocationSpec("tp0", "tair://host_t:6379/tp0")});
             std::vector<std::string> out_ids;
-            ec = meta_searcher_->BatchAddLocation(request_context_.get(), {key}, {tair_loc}, out_ids);
+            ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), {key}, {tair_loc}, out_ids);
             ASSERT_EQ(ec, ErrorCode::EC_OK);
             std::vector<std::vector<MetaSearcher::LocationUpdateTask>> tasks = {{{out_ids[0], CLS_SERVING}}};
             std::vector<std::vector<ErrorCode>> results;

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -29,6 +29,23 @@
 
 using namespace kv_cache_manager;
 
+namespace {
+ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
+                                  RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const CacheLocationVector &locations,
+                                  std::vector<std::string> &out_location_ids) {
+    std::vector<MetaSearcher::AddLocationResult> results;
+    const ErrorCode ec = meta_searcher->BatchAddLocation(request_context, keys, locations, results);
+    out_location_ids.clear();
+    out_location_ids.reserve(results.size());
+    for (const auto &result : results) {
+        out_location_ids.push_back(result.location_id);
+    }
+    return ec;
+}
+} // namespace
+
 // ---- orphan cleanup 测试用 DataStorageManager::Create/Delete 存根 ----
 // 复现"异构 size spec 分散到多个 create_group、某 group 失败使 block ineligible、
 // 后处理 group 已成功分配的 URI 被跳过 → rollback 漏删 → orphan"的场景。
@@ -188,6 +205,8 @@ bool g_cancel_first_reservation_on_create = false;
 std::optional<ErrorCode> g_cancel_result;
 int g_create_calls = 0;
 std::vector<std::size_t> g_create_key_counts;
+std::vector<DataStorageUri> g_deleted_uris;
+std::vector<std::shared_ptr<std::promise<PlanExecuteResult>>> g_pending_copy_promises;
 
 void Reset() {
     g_manager = nullptr;
@@ -198,6 +217,8 @@ void Reset() {
     g_cancel_result.reset();
     g_create_calls = 0;
     g_create_key_counts.clear();
+    g_deleted_uris.clear();
+    g_pending_copy_promises.clear();
 }
 
 std::vector<std::pair<ErrorCode, DataStorageUri>> Create_stub(void * /*obj*/,
@@ -231,6 +252,15 @@ std::vector<std::pair<ErrorCode, DataStorageUri>> Create_stub(void * /*obj*/,
     return results;
 }
 
+std::vector<ErrorCode> Delete_stub(void * /*obj*/,
+                                   RequestContext * /*rc*/,
+                                   const std::string & /*name*/,
+                                   const std::vector<DataStorageUri> &uris,
+                                   std::function<void()> /*cb*/) {
+    g_deleted_uris.insert(g_deleted_uris.end(), uris.begin(), uris.end());
+    return std::vector<ErrorCode>(uris.size(), EC_OK);
+}
+
 MetaIndexer::Result ReadModifyWriteBlockFail_stub(void * /*obj*/,
                                                   RequestContext * /*rc*/,
                                                   const KeyVector &keys,
@@ -244,6 +274,13 @@ using CopySubmitLocation = std::future<PlanExecuteResult> (SchedulePlanExecutor:
 
 std::future<PlanExecuteResult> CopySubmitInvalid_stub(void * /*obj*/, const CacheLocationCopyRequest & /*request*/) {
     return {};
+}
+
+std::future<PlanExecuteResult> CopySubmitPending_stub(void * /*obj*/, const CacheLocationCopyRequest & /*request*/) {
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto future = promise->get_future();
+    g_pending_copy_promises.push_back(std::move(promise));
+    return future;
 }
 } // namespace preparing_reservation_stub
 
@@ -395,7 +432,8 @@ public:
             loc->set_create_time(create_time);
         }
         std::vector<std::string> ids;
-        EXPECT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(rc.get(), {block_key}, {loc}, ids));
+        EXPECT_EQ(
+            ErrorCode::EC_OK, BatchAddLocationForTest(&meta_searcher, rc.get(), {block_key}, {loc}, ids));
         EXPECT_EQ(1u, ids.size());
         // BatchAddLocation 写入 CLS_WRITING，CAS 到 SERVING 模拟一个已就绪的源副本。
         std::vector<std::vector<MetaSearcher::LocationCASTask>> cas{
@@ -1794,8 +1832,7 @@ TEST_F(MigrationManagerTest, TestBatchReservesAllBeforeCreateAndDeduplicates) {
     ASSERT_FALSE(mgr.GetActiveTaskDstLocation(kInstance, 811).empty());
 }
 
-// batch AddLocation 失败时，所有尚未运行的 reservation 必须释放；此后即使 meta 曾部分
-// 成功，残留 WRITING 也只是无 copy 在跑的真正 orphan。
+// batch AddLocation 失败时，目标 URI 必须按逐 key 结果回滚，所有尚未运行的 reservation 必须释放。
 TEST_F(MigrationManagerTest, TestBatchAddLocationFailureReleasesPreparingReservations) {
     ASSERT_TRUE(CreateMetaIndexer(kInstance));
     ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "reserve_add_fail_hot/"));
@@ -1826,6 +1863,63 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationFailureReleasesPreparingReserva
     ASSERT_FALSE(mgr.HasMigrationTask(kInstance, block_key));
     ASSERT_EQ(0u, mgr.ActiveTaskCount());
     ASSERT_EQ(1u, LocationCount(block_key));
+}
+
+// batch AddLocation 部分成功时，成功项继续进入 copy，失败项按其 rollback-only ID 精确清理；
+// 不能再把整个 batch 一并判失败或删除成功项的 URI。
+TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCopyAndRollsBackFailedItem) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "reserve_partial_add_hot/"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "reserve_partial_add_cold/"));
+
+    auto indexer = meta_manager_->GetMetaIndexer(kInstance);
+    ASSERT_NE(nullptr, indexer);
+    indexer->batch_key_size_ = 1;
+    indexer->max_key_count_ = 1;
+
+    const std::vector<int64_t> block_keys{814, 815};
+    auto make_request = [&](int64_t block_key) {
+        MigrationManager::MigrationRequest req;
+        req.instance_group_name = "group_a";
+        req.instance_id = kInstance;
+        req.block_key = block_key;
+        req.src_location_id = "src_" + std::to_string(block_key);
+        req.src_storage_name = "hot_01";
+        req.dst_storage_name = "cold_01";
+        req.src_specs = {
+            LocationSpec("TP0", "dummy://hot_01/src_" + std::to_string(block_key) + "?size=4")};
+        return req;
+    };
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    mgr.DebugEnableCopySubmissionsForTest();
+    preparing_reservation_stub::Reset();
+    preparing_reservation_stub::g_manager = &mgr;
+    preparing_reservation_stub::g_expected_reservations = {{kInstance, block_keys[0]}, {kInstance, block_keys[1]}};
+    Stub stub;
+    stub.set(ADDR(DataStorageManager, Create), preparing_reservation_stub::Create_stub);
+    stub.set(ADDR(DataStorageManager, Delete), preparing_reservation_stub::Delete_stub);
+    stub.set(static_cast<preparing_reservation_stub::CopySubmitLocation>(ADDR(SchedulePlanExecutor, Submit)),
+             preparing_reservation_stub::CopySubmitPending_stub);
+
+    const auto results =
+        mgr.BatchSubmit("batch_add_location_partial", {make_request(block_keys[0]), make_request(block_keys[1])});
+    ASSERT_EQ(2u, results.size());
+    ASSERT_TRUE((results[0] == EC_OK && results[1] == EC_NOSPC) ||
+                (results[1] == EC_OK && results[0] == EC_NOSPC));
+
+    const std::size_t success_index = results[0] == EC_OK ? 0 : 1;
+    const std::size_t failed_index = 1 - success_index;
+    EXPECT_TRUE(mgr.HasMigrationTask(kInstance, block_keys[success_index]));
+    EXPECT_FALSE(mgr.HasMigrationTask(kInstance, block_keys[failed_index]));
+    EXPECT_EQ(1u, mgr.ActiveTaskCount());
+    EXPECT_EQ(1u, preparing_reservation_stub::g_pending_copy_promises.size());
+    EXPECT_EQ(1u, LocationCount(block_keys[success_index]));
+    EXPECT_EQ(0u, LocationCount(block_keys[failed_index]));
+    ASSERT_EQ(1u, preparing_reservation_stub::g_deleted_uris.size());
+    EXPECT_NE(std::string::npos,
+              preparing_reservation_stub::g_deleted_uris.front().ToUriString().find(
+                  StringUtil::Uint64ToHex(block_keys[failed_index])));
 }
 
 // 真批量路径在 Create 阶段收到取消后，同样不能覆盖取消态或提交 copy。

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -66,6 +66,21 @@ public:
         return {spec};
     }
 };
+
+ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
+                                  RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const CacheLocationVector &locations,
+                                  std::vector<std::string> &out_location_ids) {
+    std::vector<MetaSearcher::AddLocationResult> results;
+    const ErrorCode ec = meta_searcher->BatchAddLocation(request_context, keys, locations, results);
+    out_location_ids.clear();
+    out_location_ids.reserve(results.size());
+    for (const auto &result : results) {
+        out_location_ids.push_back(result.location_id);
+    }
+    return ec;
+}
 } // namespace
 class SchedulePlanExecutorTest : public TESTBASE {
 public:
@@ -160,9 +175,10 @@ TEST_F(SchedulePlanExecutorTest, TestSubmit) {
         // 添加location
         std::vector<std::string> location_ids1, location_ids2;
         ASSERT_EQ(ErrorCode::EC_OK,
-                  meta_searcher.BatchAddLocation(request_context.get(), {i * 2}, {location1}, location_ids1));
-        ASSERT_EQ(ErrorCode::EC_OK,
-                  meta_searcher.BatchAddLocation(request_context.get(), {i * 2 + 1}, {location2}, location_ids2));
+                  BatchAddLocationForTest(&meta_searcher, request_context.get(), {i * 2}, {location1}, location_ids1));
+        ASSERT_EQ(
+            ErrorCode::EC_OK,
+            BatchAddLocationForTest(&meta_searcher, request_context.get(), {i * 2 + 1}, {location2}, location_ids2));
 
         // 验证数据已添加
         std::vector<CacheLocationMap> location_maps;
@@ -260,7 +276,7 @@ TEST_F(SchedulePlanExecutorTest, TestSetStatusToDeleting) {
     // 添加location
     std::vector<std::string> location_ids;
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {200}, {new_location}, location_ids));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {200}, {new_location}, location_ids));
 
     // 验证数据已添加
     std::vector<CacheLocationMap> location_maps;
@@ -325,11 +341,11 @@ TEST_F(SchedulePlanExecutorTest, TestMultipleLocationsPerBlockKey) {
     // 分别添加location到同一个block_key
     std::vector<std::string> location_ids1, location_ids2, location_ids3;
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {400}, {location1}, location_ids1));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {400}, {location1}, location_ids1));
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {400}, {location2}, location_ids2));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {400}, {location2}, location_ids2));
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {400}, {location3}, location_ids3));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {400}, {location3}, location_ids3));
 
     // 验证数据已添加
     std::vector<CacheLocationMap> location_maps;
@@ -396,7 +412,8 @@ TEST_F(SchedulePlanExecutorTest, TestStorageDelete) {
 
     // 添加location
     std::vector<std::string> location_ids;
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {300}, {location}, location_ids));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {300}, {location}, location_ids));
 
     // 验证数据已添加
     std::vector<CacheLocationMap> location_maps;
@@ -449,7 +466,8 @@ TEST_F(SchedulePlanExecutorTest, TestDelayExecution) {
 
     // 添加location
     std::vector<std::string> location_ids;
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {500}, {location}, location_ids));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {500}, {location}, location_ids));
 
     // 验证数据已添加
     std::vector<CacheLocationMap> location_maps;
@@ -521,7 +539,7 @@ TEST_F(SchedulePlanExecutorTest, TestMultipleDelayedTasksExecutionOrder) {
         // 添加location
         std::vector<std::string> location_ids;
         ASSERT_EQ(ErrorCode::EC_OK,
-                  meta_searcher.BatchAddLocation(request_context.get(), {600 + i}, {location}, location_ids));
+                  BatchAddLocationForTest(&meta_searcher, request_context.get(), {600 + i}, {location}, location_ids));
 
         // 验证数据已添加
         std::vector<CacheLocationMap> location_maps;
@@ -609,11 +627,11 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequest) {
     // 分别添加location到同一个block_key
     std::vector<std::string> location_ids1, location_ids2, location_ids3;
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {700}, {location1}, location_ids1));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {700}, {location1}, location_ids1));
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {700}, {location2}, location_ids2));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {700}, {location2}, location_ids2));
     ASSERT_EQ(ErrorCode::EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {700}, {location3}, location_ids3));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {700}, {location3}, location_ids3));
 
     // 验证数据已添加
     std::vector<CacheLocationMap> location_maps;
@@ -764,7 +782,7 @@ TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBack
             "tp0", "event_report://external_cache/cache/block701?s_version=11111111111111111111111111111111")});
     std::vector<std::string> location_ids;
     ASSERT_EQ(EC_OK,
-              meta_searcher.BatchAddLocation(request_context.get(), {block_key}, {location}, location_ids));
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {location}, location_ids));
     ASSERT_EQ(1u, location_ids.size());
 
     SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
@@ -789,8 +807,8 @@ TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBack
     std::vector<std::string> control_location_ids;
     ASSERT_EQ(
         EC_OK,
-        meta_searcher.BatchAddLocation(
-            request_context.get(), {control_block_key}, {location}, control_location_ids));
+        BatchAddLocationForTest(
+            &meta_searcher, request_context.get(), {control_block_key}, {location}, control_location_ids));
     ASSERT_EQ(1u, control_location_ids.size());
     CacheLocationDelRequest control_request{
         .instance_id = kTestInstanceName,
@@ -843,7 +861,8 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequestWithDelay) {
 
     // 添加location
     std::vector<std::string> location_ids;
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {800}, {location}, location_ids));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {800}, {location}, location_ids));
 
     // 验证数据已添加
     std::vector<CacheLocationMap> location_maps;
@@ -904,7 +923,8 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncAdmissionRunsOnWorkerAndReturnsQ
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/async_admission?size=1")});
     std::vector<std::string> location_ids;
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {900}, {location}, location_ids));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {900}, {location}, location_ids));
     ASSERT_EQ(1, location_ids.size());
     std::vector<CacheLocationMap> initial_location_maps;
     BlockMask empty_mask;
@@ -960,8 +980,9 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncMetaSelectsAllLocationsAndSkipsD
                                                                 "nfs://nfs_01/async_meta_selection_" +
                                                                     std::to_string(location_idx) + "?size=1")});
         std::vector<std::string> added_location_ids;
-        ASSERT_EQ(ErrorCode::EC_OK,
-                  meta_searcher.BatchAddLocation(request_context.get(), {903}, {location}, added_location_ids));
+        ASSERT_EQ(
+            ErrorCode::EC_OK,
+            BatchAddLocationForTest(&meta_searcher, request_context.get(), {903}, {location}, added_location_ids));
         ASSERT_EQ(1, added_location_ids.size());
         location_ids.push_back(added_location_ids.front());
     }
@@ -1058,7 +1079,8 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncDelayStartsAfterSyncAndDoesNotOc
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/async_delay?size=1")});
     std::vector<std::string> location_ids;
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {901}, {location}, location_ids));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {901}, {location}, location_ids));
 
     Stub stub;
     sync_entered.store(false);
@@ -1177,7 +1199,8 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncSecondEnqueueFailureCompletesFut
         1,
         {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/second_enqueue?size=1")});
     std::vector<std::string> location_ids;
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchAddLocation(request_context.get(), {902}, {location}, location_ids));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {902}, {location}, location_ids));
 
     Stub stub;
     sync_entered.store(false);

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -409,6 +409,19 @@ MetaIndexer::Result MetaIndexer::ReadModifyWriteBlock(RequestContext *request_co
         std::vector<ErrorCode> get_ecs =
             backend_manager_->GetLocationIds(ephemeral_request_context.get(), batch_keys, batch_location_ids);
         stats.get_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin_get;
+        if (get_ecs.size() != batch_keys.size() || batch_location_ids.size() != batch_keys.size()) {
+            PREFIX_INDEXER_LOG(ERROR,
+                               "ReadModifyWrite GetLocationIds result size mismatch, keys[%lu], ecs[%lu], ids[%lu]",
+                               batch_keys.size(),
+                               get_ecs.size(),
+                               batch_location_ids.size());
+            for (const int32_t global_idx : batch.batch_indexs) {
+                result.error_codes[global_idx] = EC_MISMATCH;
+            }
+            error_count += static_cast<int32_t>(batch.batch_indexs.size());
+            result.ec = EC_MISMATCH;
+            continue;
+        }
 
         // 2. Modify -> bucket each key into upsert_batch / delete_batch.
         BatchMetaData upsert_batch;
@@ -466,7 +479,8 @@ MetaIndexer::Result MetaIndexer::ReadModifyWriteBlock(RequestContext *request_co
 MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext *request_context,
                                                                  const KeyVector &keys,
                                                                  const LocationIdsPerKey &location_ids,
-                                                                 const LocationModifierFunc &modifier) noexcept {
+                                                                 const LocationModifierFunc &modifier,
+                                                                 bool adjust_reclaimed_key_count) noexcept {
     const auto &trace_id = request_context->trace_id();
     if (keys.empty()) {
         return LocationResult(EC_OK);
@@ -596,7 +610,7 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
             }
         }
         error_count += upsert_errs + delete_errs;
-        AdjustKeyCountMeta(put_success_count - delete_success_count);
+        AdjustKeyCountMeta(put_success_count - (adjust_reclaimed_key_count ? delete_success_count : 0));
     }
 
     EmitRmwMetrics(request_context->metrics_collector(), stats, keys.size());
@@ -942,12 +956,48 @@ int32_t MetaIndexer::ProcessErrorCodes(const std::string &trace_id,
                                        const KeyVector &keys,
                                        const std::string &op_name,
                                        Result &result) const noexcept {
-    assert(indexs.size() == error_codes.size() || indexs.empty());
+    const size_t expected_count = indexs.empty() ? keys.size() : indexs.size();
+    if (error_codes.size() != expected_count) {
+        PREFIX_INDEXER_LOG(ERROR,
+                           "meta indexer %s result size mismatch, expect[%lu], actual[%lu]",
+                           op_name.c_str(),
+                           expected_count,
+                           error_codes.size());
+        int32_t mismatch_count = 0;
+        for (size_t i = 0; i < expected_count; ++i) {
+            const int32_t index = indexs.empty() ? static_cast<int32_t>(i) : indexs[i];
+            if (index < 0 || static_cast<size_t>(index) >= result.error_codes.size()) {
+                PREFIX_INDEXER_LOG(ERROR,
+                                   "meta indexer %s result index out of range, index[%d], result size[%lu]",
+                                   op_name.c_str(),
+                                   index,
+                                   result.error_codes.size());
+                continue;
+            }
+            result.error_codes[index] = EC_MISMATCH;
+            ++mismatch_count;
+        }
+        result.ec = EC_MISMATCH;
+        return mismatch_count;
+    }
+
     int32_t error_count = 0;
-    for (int32_t i = 0; i < error_codes.size(); ++i) {
-        int32_t index = i;
+    for (size_t i = 0; i < error_codes.size(); ++i) {
+        int32_t index = static_cast<int32_t>(i);
         if (!indexs.empty()) {
             index = indexs[i];
+        }
+        if (index < 0 || static_cast<size_t>(index) >= result.error_codes.size() ||
+            static_cast<size_t>(index) >= keys.size()) {
+            PREFIX_INDEXER_LOG(ERROR,
+                               "meta indexer %s result index out of range, index[%d], keys[%lu], result[%lu]",
+                               op_name.c_str(),
+                               index,
+                               keys.size(),
+                               result.error_codes.size());
+            result.ec = EC_MISMATCH;
+            ++error_count;
+            continue;
         }
         if (error_codes[i] != EC_OK) {
             if (error_codes[i] != EC_NOENT) {
@@ -966,6 +1016,9 @@ void MetaIndexer::ProcessErrorResult(const std::string &trace_id,
                                      const int32_t error_count,
                                      const int32_t key_count,
                                      Result &result) const noexcept {
+    if (result.ec != EC_OK) {
+        return;
+    }
     if (error_count == key_count) {
         result.ec = EC_ERROR;
         PREFIX_INDEXER_LOG(DEBUG, "all keys %s failed, key count[%d]", op_name.c_str(), key_count);

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -74,7 +74,8 @@ public:
     LocationResult ReadModifyWriteLocation(RequestContext *request_context,
                                            const KeyVector &keys,
                                            const LocationIdsPerKey &location_ids,
-                                           const LocationModifierFunc &modifier) noexcept;
+                                           const LocationModifierFunc &modifier,
+                                           bool adjust_reclaimed_key_count = true) noexcept;
 
     // ---------- READ ----------
     Result Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept;

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -100,6 +100,22 @@ TEST_F(MetaIndexerTest, TestInit) {
     ASSERT_EQ(EC_CONFIG_ERROR, InitIndexer(configStr));
 }
 
+TEST_F(MetaIndexerTest, TestProcessErrorCodesRejectsAbnormalResultCount) {
+    const KeyVector keys = {11, 22, 33};
+
+    MetaIndexer::Result short_result(keys.size());
+    EXPECT_EQ(3, meta_indexer_->ProcessErrorCodes("trace", {EC_OK}, {}, keys, "test_short_result", short_result));
+    EXPECT_EQ(EC_MISMATCH, short_result.ec);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH, EC_MISMATCH, EC_MISMATCH}), short_result.error_codes);
+
+    MetaIndexer::Result long_result(keys.size());
+    EXPECT_EQ(3,
+              meta_indexer_->ProcessErrorCodes(
+                  "trace", {EC_OK, EC_OK, EC_OK, EC_OK}, {}, keys, "test_long_result", long_result));
+    EXPECT_EQ(EC_MISMATCH, long_result.ec);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH, EC_MISMATCH, EC_MISMATCH}), long_result.error_codes);
+}
+
 // Verifies the invariants of MakeBatches() that callers rely on, regardless
 // of the exact shard distribution (which is now hash-driven and therefore
 // not deterministic across keys):

--- a/kv_cache_manager/service/test/admin_service_impl_test.cc
+++ b/kv_cache_manager/service/test/admin_service_impl_test.cc
@@ -30,6 +30,23 @@
 
 using namespace kv_cache_manager;
 
+namespace {
+ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
+                                  RequestContext *request_context,
+                                  const KeyVector &keys,
+                                  const CacheLocationVector &locations,
+                                  std::vector<std::string> &out_location_ids) {
+    std::vector<MetaSearcher::AddLocationResult> results;
+    const ErrorCode ec = meta_searcher->BatchAddLocation(request_context, keys, locations, results);
+    out_location_ids.clear();
+    out_location_ids.reserve(results.size());
+    for (const auto &result : results) {
+        out_location_ids.push_back(result.location_id);
+    }
+    return ec;
+}
+} // namespace
+
 class AdminServiceImplTest : public TESTBASE {
 public:
     void SetUp() override {
@@ -131,7 +148,7 @@ public:
         auto loc = std::make_shared<CacheLocation>(
             DataStorageType::DATA_STORAGE_TYPE_DUMMY, 1, std::vector<LocationSpec>{LocationSpec("tp0", uri)});
         std::vector<std::string> ids;
-        ASSERT_EQ(EC_OK, meta_searcher.BatchAddLocation(rc.get(), {block_key}, {loc}, ids));
+        ASSERT_EQ(EC_OK, BatchAddLocationForTest(&meta_searcher, rc.get(), {block_key}, {loc}, ids));
         ASSERT_EQ(1u, ids.size());
         std::vector<std::vector<MetaSearcher::LocationCASTask>> cas{
             {MetaSearcher::LocationCASTask{ids[0], CLS_WRITING, CLS_SERVING}}};
@@ -152,7 +169,7 @@ public:
         auto loc = std::make_shared<CacheLocation>(
             DataStorageType::DATA_STORAGE_TYPE_DUMMY, 1, std::vector<LocationSpec>{LocationSpec("tp0", uri)});
         std::vector<std::string> ids;
-        ASSERT_EQ(EC_OK, meta_searcher.BatchAddLocation(rc.get(), {block_key}, {loc}, ids));
+        ASSERT_EQ(EC_OK, BatchAddLocationForTest(&meta_searcher, rc.get(), {block_key}, {loc}, ids));
         ASSERT_EQ(1u, ids.size());
         if (status == CLS_SERVING) {
             std::vector<std::vector<MetaSearcher::LocationCASTask>> cas{


### PR DESCRIPTION
## Background

`BatchAddLocation` previously returned only an aggregate `ErrorCode` plus location IDs. On a partial write, callers could not distinguish successfully persisted locations from IDs that were generated only as rollback locators. `StartWriteCache` therefore returned on `EC_PARTIAL_OK` without a write session while leaving metadata and allocated storage URIs behind.

## Summary

- return an index-aligned `AddLocationResult { ec, location_id }` for every input key
- treat a non-empty ID on a failed item as rollback-only and normalize malformed success results to `EC_MISMATCH`
- harden `MetaIndexer` against short, long, or otherwise misaligned backend result arrays
- make `StartWriteCache` expose all-or-nothing results: establish a write session only when the full batch succeeds, otherwise compensate each key by its precise result
- reuse the standard deletion pipeline for known successful metadata, delete uncertain metadata idempotently before releasing its URI, and directly release URIs that never received a location ID
- keep storage usage accounting balanced, including an opt-out for failed adds that were never charged
- adapt the migration paths merged in #209: single-item prepare requires one successful result with an ID, while batch migration keeps successful items copying and rolls back only failed items before releasing their preparing reservations

## Safety and scope

- callers never receive a partial writable location set or session
- uncertain metadata is synced before its URI is deleted; on ambiguity the rollback retains the URI rather than creating a dangling metadata reference
- known successful locations enter the existing `DELETING` pipeline before physical cleanup
- this is compensating rollback, not a cross-key transaction; physical cleanup may complete after the API returns
- existing `BatchDeleteLocation` callers retain their current usage-accounting behavior through the default argument

## Testing

Built and tested in an isolated Linux environment after rebasing onto the #209 merge:

- `MetaSearcherTest`
- `meta_indexer_test`
- `CacheManagerTest`
- `MigrationManagerTest`
- `SchedulePlanExecutorTest`
- `CacheReclaimerTest`
- `AdminServiceImplTest`

All 7 test targets passed with uncached test results. `MetaSearcherRedisTest` also built successfully; runtime was not executed because it requires the manual Redis environment. Local and remote source hashes matched for all 13 changed files, and `git diff --check` passed.
