### PR TITLE
[event] add transactional engine cache event subscriber

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ flowchart TD
     metrics -. metrics_reporter .-> manager
 
     %% 对外分支与 optimizer
+    cache_event_subscriber["cache_event_subscriber"] --> py_connector
     py_connector["py_connector"] --> client["client SDK"]
     client -.-> config
     optimizer["optimizer（仿真与优化）"] -. cache_location .-> meta

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [基本概念](design/basic_concepts.md) - Storage、Instance Group、Instance、Block、CacheLocation 等核心概念
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
+- [Cache Event Subscriber 设计](design/cache_event_subscriber.md) - RTP/vLLM 全量与增量同步、ACK/cursor 可靠性语义
 
 ### 开发文档
 - [开发指南](develop/README.md) - 开发者入门指南和开发环境配置

--- a/docs/design/cache_event_subscriber.md
+++ b/docs/design/cache_event_subscriber.md
@@ -1,0 +1,65 @@
+# Cache Event Subscriber 设计
+
+## 目标
+
+在不依赖 RTP-LLM #1198、tair-kvcache #241 或 #236 代码的前提下，从 public `main` 实现相同业务能力：将 RTP-LLM/vLLM 的本地 KVCache 状态可靠同步到 KVCM，并同时支持权威全量恢复和低开销增量更新。
+
+## 数据流
+
+```text
+RTP GetCacheStatus v2 / vLLM ZMQ
+  → Source.prepare（不提交 cursor）
+  → 规范化 BlockRecord
+  → KVCM ReportEvent
+  → ACK 成功
+  → Source.commit（提交 generation/cursor/state）
+```
+
+- RTP：changefeed 返回 `generation`、队列 head、明确的分页 `next_cursor`；冷启动、generation 不匹配、history gap 和周期校准返回快照。
+- vLLM：通过 sequence 检测丢包并请求 replay。replay 是有限历史，只有从 sequence 0 完整重放或收到 `AllBlocksCleared` 才能建立权威状态。
+- vLLM publisher 在已提交正游标后重新出现 sequence 0 时视为新 epoch，立即清空旧候选状态并上报权威快照。
+- vLLM 冷启动没有任何 batch 时保持“未就绪”，既不注册节点也不发送 HEARTBEAT；Subscriber 会主动查询 replay，直到 sequence 0 或 `AllBlocksCleared` 建立权威基线，不把空闲误判成引擎故障。
+- vLLM block hash 按低 64 bit 统一映射到 KVCM signed-int64 key；这与 vLLM 的 legacy int event 表示一致。按 engine hash 查询 KVCM 的调用方必须复用同一 codec。
+- KVCM：`EVENT_BLOCK_SNAPSHOT` 表示该 `instance_id + host_ip_port` 的完整集合。服务端同步清理旧位置后写入新集合；空快照表示清空。同一 instance + host 的快照、增量和异步清理通过分片锁串行化；generation 变化或节点已恢复时旧清理立即中止。
+
+## 存储身份
+
+引擎本地 cache 使用独立的 `ST_EVENT_REPORT` 类型和 `event-report://` URI，不复用 `ST_VINEYARD`。该后端只管理节点注册、心跳、generation 和位置元数据，不提供数据读写；实际 KV 数据仍由 RTP-LLM/vLLM 进程持有。这样 KVCM 返回位置时，调用方不会误选 Vineyard connector。
+
+`ST_EVENT_REPORT` 不计入 KVCM 管理的存储容量，也不会进入主动回收请求。其位置只能由引擎事件、权威快照、`HOST_DOWN` 或心跳超时清理，避免 KVCM 调用一个并不拥有引擎显存的 backend 执行 `Delete`。
+
+部署时需创建一个 `event_report` storage，并将其名字放入 instance group 的 `event_reporting_storage_candidates`。现有 Vineyard 配置和位置协议不受影响。
+
+## 一致性语义
+
+1. STORED 只在引擎真实 cache index 写入成功后产生，REMOVED 只在真实删除后产生。
+2. KVCM 只接受已注册且可用节点的缓存变更；节点失活后必须重新注册再重放未确认更新。
+3. Subscriber 同一时刻最多保留一个未确认更新；KVCM 不可用时不继续拉取。
+4. 增量 ADD/DELETE 是幂等的；多批请求中途失败时，可从旧 cursor 重放。
+5. 全量快照是恢复与校准能力，不是稳态传输方式；稳态仅发送变化块。
+6. 所有索引都按 `instance_id` 隔离；不同 DP endpoint 必须全部拉取成功后才提交聚合状态。
+7. KVCM 的 key 域只有 64 bit；vLLM 的完整 digest 会被截断，部署方需接受相应碰撞模型，并以 `instance_id` 做租户/模型隔离。
+8. Source 短暂失败期间暂停 HEARTBEAT；连续失败达到阈值后先上报 `HOST_DOWN` 再退出。RTP Launcher 在可选模式下限频重启 Subscriber，在 required 模式下由 `ProcessManager` 传播失败。
+9. 对无法从 ZMQ 空闲与断连中区分存活状态的引擎，可配置 HTTP health URL；连续探测失败会停止 HEARTBEAT 并触发 Subscriber 下线。
+10. 冷启动先 `prepare` 权威全量，再执行“节点注册 → 快照 ACK → cursor commit → 启动 HEARTBEAT”；首快照失败时立即 `HOST_DOWN` 取消该次注册，并以同一个未提交快照重新注册重试。
+
+小快照通过单个 `EVENT_BLOCK_SNAPSHOT` 替换；超过单请求上限时采用“空快照清理 + 分批 ADD”。后者在传输期间允许短暂的部分可见，但任一批失败都不会提交 source cursor，重试会再次从清理开始，最终收敛且不会产生超大 HTTP 请求。
+
+RTP 配置必须提供与 `dp_size` 等量且互不重复的 endpoint。vLLM 当前明确限制为单 DP；这与其每个 DP rank 使用独立 ZMQ 端口的发布模型一致，禁止在没有多 publisher 聚合器时静默只消费 rank 0。
+
+## 与原 PR 的关键区别
+
+- 基线直接来自两个仓库 public `main`，没有 cherry-pick、commit 依赖或隐藏的 #236 前置条件。
+- 在 main 已有 `EventReportingBackend` 抽象上增加最小 `ST_EVENT_REPORT` 后端，不引入 #236 的大范围 storage 重构。
+- 全量和增量是一个协议的两种模式，而不是两套互相独立的上报链路。
+- RTP 分页区分 queue head 与 next cursor，避免分页时跳过事件。
+- cursor 只在 KVCM ACK 后提交；Manager 故障形成反压，而不是继续堆积无界事件。
+- vLLM 历史不足时显式失败，不把残缺 replay 当作完整缓存状态。
+
+## 验收
+
+- 冷启动空/非空快照、增量新增/删除、分页、generation 变化、history gap 均可收敛。
+- KVCM 请求失败后 cursor 不推进，恢复后重试不丢事件。
+- 空权威快照能清除该 host 的旧位置；其他 host 和其他 instance 不受影响。
+- RTP 多 endpoint 任一失败时不提交任何 endpoint 状态。
+- 主动回收只选择 KVCM 管理的存储位置，不选择 `ST_EVENT_REPORT` 位置。

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -52,6 +52,7 @@ KVCache Manager 采用中心化部署，负责 KVCache 的全局元数据管理�
 |---|---|---|
 | **client** | `client/` | C++/Python 客户端 SDK，是推理引擎与 KVCM 之间的桥梁。对外提供 `ManagerClient`/`RTPLLMClient` 门面，内部由两条链路组成（见下）：**元数据面** `MetaClient`（经 gRPC 桩 `internal/stub` 调用 KVCM 服务）与**数据面** `TransferClient`（经 `internal/sdk` 在推理引擎显存/内存与存储后端之间搬运 KVCache 数据）。面向外部，不被服务端核心调用。 |
 | **py_connector** | `py_connector/` | 推理框架集成（Python）。将 client 接入 vLLM/SGLang/TRT-LLM，含 CUDA kernel 辅助，负责在引擎的推理流程中按正确顺序调用元数据面与数据面接口。此外自带一个纯 Python 的 HTTP 元数据面客户端 `KvCacheManagerClient`（`common/manager_client.py`），可通过统一服务发现 URL 获取 Manager 入口，并作为 C++ `MetaClient` 之外的另一条元数据面通路。位于 Python 侧栈顶。 |
+| **cache_event_subscriber** | `cache_event_subscriber/` | 独立的缓存元数据同步进程。消费 RTP-LLM 的全量/增量 gRPC changefeed 或 vLLM 的 ZMQ 事件流，使用 prepare→KVCM ACK→commit 两阶段推进 cursor，并通过 `py_connector/common/KvCacheManagerClient` 调用 `RegisterInstance`/`ReportEvent`。它不参与推理热路径，位于 Python 侧栈顶。 |
 
 > **三个面的界定**：本文档区分三个面——**元数据面**指 MetaService 的接口（`GetCacheLocation`/`StartWriteCache`/`FinishWriteCache`/`GetCacheMeta`/`RemoveCache`/`RegisterInstance` 等）及 client 侧调用这些接口的逻辑，是推理引擎读写 KVCache 的热路径；**数据面**指 KVCache 数据在引擎显存/内存与存储后端之间的实际搬运（`TransferClient`，不经过 KVCM）；**管控面**仅指 AdminService 的接口（Storage 增删改、Instance Group 管理、账号、配置快照、运维监控、Leader 运维等），供运维/管理工具使用，不在推理引擎的读写热路径上。
 
@@ -97,6 +98,7 @@ service → manager → meta → config → data_storage → common
 ### 3.3 客户端与 Optimizer
 
 - **client** 是独立的对外分支，仅共享 `common`、`config`、`data_storage`、`protocol` 以及 `service/util:manager_message_proto_util`；**py_connector** 通过 pybind 位于 client 之上。核心服务端不依赖 client。运行时，元数据面经 gRPC（C++ `MetaClient`）或 HTTP（py_connector 的 Python `KvCacheManagerClient`）调用 KVCM 服务，数据面经 C++ `TransferClient` 直接读写存储后端——这几条链路是理解端到端流程的关键（见第 4 节）。
+- **cache_event_subscriber** 只依赖 `py_connector/common` 的 Python HTTP 客户端和引擎公开的事件协议；服务端核心不反向依赖 Subscriber。KVCM ACK 前不推进引擎 cursor，Manager 不可用时暂停拉取，从而形成有界反压。
 - **optimizer** 负责 KVCache 访问 trace 的仿真与优化（命中率/容量分析、逐出与容量参数调优）。目前通过 `meta:cache_location` 类型与 `event` 的 optimizer 事件与核心关联；在线化能力正在开发中，后续会与现有 optimizer 合并。
 
 ### 3.4 模块关系图
@@ -129,6 +131,7 @@ flowchart TD
     subgraph clientside["客户端侧（对外分支）"]
         client["client SDK"]
         py_connector["py_connector<br/>vLLM/SGLang/TRT-LLM"]
+        cache_event_subscriber["cache_event_subscriber<br/>RTP/vLLM cache events"]
     end
 
     optimizer["optimizer（仿真与优化）"]
@@ -154,6 +157,7 @@ flowchart TD
     metrics -. metrics_reporter .-> manager
 
     %% 客户端分支
+    cache_event_subscriber --> py_connector
     py_connector --> client
     client --> config
     client --> data_storage
@@ -250,6 +254,10 @@ sequenceDiagram
 ### 4.6 HA 故障转移
 
 `LeaderElector`（config）基于 `CoordinationBackend`（memory/file/redis）的分布式锁选主。`Server` 在成为 Leader 时调用 `CacheManager::DoRecover` 恢复状态，降级时调用 `DoCleanup` 清理运行时状态（正在进行的写入按失败处理）。Python `KvCacheManagerClient` 使用服务发现 URL 时，会在每次 Leader 刷新前重新选择一个 Manager 发现端点，避免把 Leader 查询入口固定在单个节点上。
+
+### 4.7 引擎缓存事件同步
+
+`cache_event_subscriber` 在引擎外部维护已获 KVCM 确认的 cursor 与缓存集合，并通过专用 `ST_EVENT_REPORT` 元数据后端发布 `event-report://` 位置。冷启动、引擎 generation 变化、历史断档和周期校准使用 `EVENT_BLOCK_SNAPSHOT` 权威替换该 host 的全部上报位置；正常运行只发送 `EVENT_BLOCK_ADD`/`EVENT_BLOCK_DELETE`。只有 KVCM 完整 ACK 后才提交 source cursor；请求失败时重试同一更新，不继续消费引擎事件。vLLM replay buffer 不是快照，冷启动只有从 sequence 0 完整重放或收到 `AllBlocksCleared` 才允许建立权威基线；基线建立前不发送 HEARTBEAT。
 
 ---
 

--- a/kv_cache_manager/cache_event_subscriber/BUILD
+++ b/kv_cache_manager/cache_event_subscriber/BUILD
@@ -1,0 +1,13 @@
+load("@rules_python//python:py_library.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "cache_event_subscriber",
+    srcs = glob(["*.py"]),
+    deps = [
+        "//kv_cache_manager/py_connector/common:common",
+        "@pip_cpu//grpcio",
+        "@pip_cpu//protobuf",
+    ],
+)

--- a/kv_cache_manager/cache_event_subscriber/README.md
+++ b/kv_cache_manager/cache_event_subscriber/README.md
@@ -1,0 +1,67 @@
+# KVCM Cache Event Subscriber
+
+独立进程消费 RTP-LLM/vLLM 的 KVCache 事件，并通过 KVCM HTTP `ReportEvent` 同步元数据。设计与一致性语义见 [设计文档](../../docs/design/cache_event_subscriber.md)。
+
+## 运行依赖
+
+- 公共依赖：Python 3.10+、仓库内 `KvCacheManagerClient`、`requests`、`protobuf`、`grpcio`。
+- RTP 路径无需额外包。
+- vLLM 路径额外安装 `requirements-vllm.txt` 中的 `msgspec` 与 `pyzmq`。
+
+Subscriber 需从 tair-kvcache 源码树运行，或将 `kv_cache_manager` Python 包安装/挂载到 RTP 容器；RTP Launcher 只管理命令生命周期，不复制另一仓库的运行时。
+
+KVCM 侧必须先配置专用元数据后端，并绑定到 instance group：
+
+```json
+{
+  "global_unique_name": "engine_cache_events",
+  "event_report": {
+    "heartbeat_timeout_ms": 30000,
+    "cleanup_grace_ms": 300000,
+    "liveness_check_interval_ms": 5000
+  }
+}
+```
+
+对应 instance group 的 `event_reporting_storage_candidates` 需包含 `engine_cache_events`。Subscriber 固定以 `ST_EVENT_REPORT` 上报，并生成 `event-report://<host>/<medium>` 位置；不要配置为 Vineyard storage。
+
+该 storage 只保存引擎缓存的可发现元数据，不属于 KVCM 容量池，也不能放入普通 `storage_candidates`；缓存淘汰由引擎负责，KVCM 仅依据事件、快照和节点失活清理位置。
+
+RTP 示例：
+
+```bash
+python -m kv_cache_manager.cache_event_subscriber \
+  --engine rtp \
+  --manager-uri http://manager:8080 \
+  --instance-group default \
+  --instance-id model-a \
+  --host-ip-port worker-a:9000 \
+  --rtp-endpoints worker-a:9001 \
+  --block-size 64 \
+  --model-name model-a \
+  --cache-group-count 1
+```
+
+vLLM 运行时还需安装 `requirements-vllm.txt`，并配置 publisher 的 PUB 与 replay endpoint。冷启动 replay 已裁剪时 Subscriber 会拒绝上报，必须与引擎共同重启或等到明确的 `AllBlocksCleared`。
+
+RTP 要求 `--rtp-endpoints` 恰好提供 `--dp-size` 个互不重复的 endpoint，只有全部拉取成功才提交聚合状态。当前 vLLM 路径显式限制 `--dp-size=1`，避免多 DP 时静默只消费 rank 0；多 publisher 聚合需后续作为独立能力扩展。
+
+vLLM 示例：
+
+```bash
+python -m kv_cache_manager.cache_event_subscriber \
+  --engine vllm \
+  --manager-uri http://manager:8080 \
+  --instance-group default \
+  --instance-id model-a \
+  --host-ip-port worker-a:9000 \
+  --vllm-pub-endpoint tcp://worker-a:5557 \
+  --vllm-replay-endpoint tcp://worker-a:5558 \
+  --engine-health-url http://worker-a:8000/health \
+  --block-size 16 \
+  --model-name model-a
+```
+
+由 RTP-LLM 托管时，将完整 argv 放入 `KVCM_CACHE_EVENT_SUBSCRIBER_COMMAND`。命令中的 `{rtp_endpoint}` 会在 backend 健康后替换为本机 gRPC endpoint；`KVCM_CACHE_EVENT_SUBSCRIBER_OWNER_RANK` 默认是 `0`，`KVCM_CACHE_EVENT_SUBSCRIBER_REQUIRED=false` 时异常退出会限频重启，设为 `true` 时失败由 RTP `ProcessManager` 向整组进程传播。
+
+Subscriber 只有在 Source 已准备好首个权威快照后才注册节点，并在快照得到 KVCM ACK 后启动 HEARTBEAT。首快照失败会先上报 `HOST_DOWN` 取消该次注册，再用未提交的同一快照重新注册重试。

--- a/kv_cache_manager/cache_event_subscriber/__init__.py
+++ b/kv_cache_manager/cache_event_subscriber/__init__.py
@@ -1,0 +1,6 @@
+"""Reliable cache-event ingestion for RTP-LLM and vLLM."""
+
+from .key_codec import to_signed_i64
+from .models import BlockRecord, EngineUpdate, LocationSpec
+
+__all__ = ["BlockRecord", "EngineUpdate", "LocationSpec", "to_signed_i64"]

--- a/kv_cache_manager/cache_event_subscriber/__main__.py
+++ b/kv_cache_manager/cache_event_subscriber/__main__.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import signal
+
+import requests
+
+from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
+
+from .models import BlockRecord, LocationSpec
+from .reporter import KvcmEventReporter
+from .rtp_source import RtpCacheSource
+from .service import CacheEventSubscriberService
+from .vllm_source import VllmCacheSource
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Report engine KV-cache state to KVCM")
+    parser.add_argument("--engine", choices=("rtp", "vllm"), required=True)
+    parser.add_argument("--manager-uri", required=True)
+    parser.add_argument("--instance-group", required=True)
+    parser.add_argument("--instance-id", required=True)
+    parser.add_argument("--host-ip-port", required=True)
+    parser.add_argument("--block-size", type=int, required=True)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--dtype", default="unknown")
+    parser.add_argument("--tp-size", type=int, default=1)
+    parser.add_argument("--dp-size", type=int, default=1)
+    parser.add_argument("--pp-size", type=int, default=1)
+    parser.add_argument("--cache-group-count", type=int, default=1)
+    parser.add_argument("--bytes-per-group", type=int, default=0)
+    parser.add_argument("--poll-interval", type=float, default=0.1)
+    parser.add_argument("--full-refresh-interval", type=float, default=300.0)
+    parser.add_argument("--heartbeat-interval", type=float, default=10.0)
+    parser.add_argument("--source-failure-threshold", type=int, default=3)
+    parser.add_argument("--manager-request-timeout", type=float, default=1.0)
+    parser.add_argument("--max-events-per-request", type=int, default=4096)
+    parser.add_argument("--source-timeout", type=float, default=1.0)
+    parser.add_argument("--engine-health-url")
+    parser.add_argument("--engine-health-timeout", type=float, default=1.0)
+    parser.add_argument("--engine-health-failure-threshold", type=int, default=3)
+    parser.add_argument("--rtp-endpoints", help="comma-separated host:port endpoints")
+    parser.add_argument("--vllm-pub-endpoint")
+    parser.add_argument("--vllm-replay-endpoint")
+    parser.add_argument("--vllm-topic", default="")
+    return parser
+
+
+def _check_engine_health(url: str, timeout_s: float) -> bool:
+    response = requests.get(url, timeout=timeout_s)
+    response.raise_for_status()
+    return True
+
+
+def _parse_rtp_endpoints(value: str | None, dp_size: int) -> tuple[str, ...]:
+    endpoints = tuple(item.strip() for item in (value or "").split(",") if item.strip())
+    if len(endpoints) != dp_size:
+        raise ValueError(
+            "RTP requires exactly one endpoint per DP rank: "
+            f"expected {dp_size}, got {len(endpoints)}"
+        )
+    if len(set(endpoints)) != len(endpoints):
+        raise ValueError("RTP endpoints must be unique")
+    return endpoints
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    logging.basicConfig(level=logging.INFO)
+    if args.block_size <= 0:
+        raise ValueError("block-size must be positive")
+    if args.tp_size <= 0 or args.dp_size <= 0 or args.pp_size <= 0:
+        raise ValueError("tp-size, dp-size, and pp-size must be positive")
+    if args.cache_group_count <= 0:
+        raise ValueError("cache-group-count must be positive")
+    if args.bytes_per_group < 0:
+        raise ValueError("bytes-per-group must be non-negative")
+    spec_sizes = {
+        f"group_{index}": args.bytes_per_group
+        for index in range(args.cache_group_count)
+    }
+
+    def spec_factory(block: BlockRecord) -> list[LocationSpec]:
+        groups = block.group_ids or (0,)
+        unknown = [group for group in groups if f"group_{group}" not in spec_sizes]
+        if unknown:
+            raise ValueError(f"unregistered cache group ids: {unknown}")
+        return [
+            LocationSpec(
+                f"group_{group}",
+                f"event-report://{args.host_ip_port}/{block.medium}"
+                f"?engine={args.engine}&group_id={group}",
+            )
+            for group in groups
+        ]
+
+    client = KvCacheManagerClient(
+        args.manager_uri,
+        instance_id=args.instance_id,
+        auto_discover_leader=True,
+        request_timeout_seconds=args.manager_request_timeout,
+    )
+    reporter = KvcmEventReporter(
+        client,
+        instance_id=args.instance_id,
+        host_ip_port=args.host_ip_port,
+        spec_factory=spec_factory,
+        max_events_per_request=args.max_events_per_request,
+    )
+
+    if args.engine == "rtp":
+        rtp_endpoints = _parse_rtp_endpoints(args.rtp_endpoints, args.dp_size)
+        source = RtpCacheSource(
+            rtp_endpoints,
+            timeout_s=args.source_timeout,
+            full_refresh_interval_s=args.full_refresh_interval,
+            expected_block_size=args.block_size,
+            cache_group_count=args.cache_group_count,
+        )
+        mediums = ("hbm",)
+    else:
+        if args.dp_size != 1:
+            raise ValueError(
+                "vLLM currently requires dp-size=1; multiple publishers "
+                "must not silently subscribe to rank 0 only"
+            )
+        if not args.vllm_pub_endpoint or not args.vllm_replay_endpoint:
+            raise ValueError("vLLM requires --vllm-pub-endpoint and --vllm-replay-endpoint")
+        source = VllmCacheSource(
+            args.vllm_pub_endpoint,
+            args.vllm_replay_endpoint,
+            topic=args.vllm_topic,
+            replay_timeout_s=args.source_timeout,
+            full_refresh_interval_s=args.full_refresh_interval,
+            expected_block_size=args.block_size,
+            cache_group_count=args.cache_group_count,
+        )
+        mediums = ("hbm", "mem")
+
+    # Validate and construct the engine source before mutating KVCM. Invalid
+    # endpoints, unsupported DP topology, or missing optional dependencies
+    # must not leave behind a partially registered instance.
+    reporter.register_instance(
+        instance_group=args.instance_group,
+        block_size=args.block_size,
+        spec_sizes=spec_sizes,
+        model_name=args.model_name,
+        dtype=args.dtype,
+        tp_size=args.tp_size,
+        dp_size=args.dp_size,
+        pp_size=args.pp_size,
+    )
+
+    service = CacheEventSubscriberService(
+        source,
+        reporter,
+        mediums=mediums,
+        poll_interval_s=args.poll_interval,
+        retry_interval_s=args.poll_interval,
+        heartbeat_interval_s=args.heartbeat_interval,
+        source_failure_threshold=args.source_failure_threshold,
+        health_probe=(
+            (
+                lambda: _check_engine_health(
+                    args.engine_health_url, args.engine_health_timeout
+                )
+            )
+            if args.engine_health_url
+            else None
+        ),
+        health_failure_threshold=args.engine_health_failure_threshold,
+    )
+
+    async def run_service() -> None:
+        loop = asyncio.get_running_loop()
+        for signal_number in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(signal_number, service.stop)
+        await service.run()
+
+    try:
+        asyncio.run(run_service())
+    except KeyboardInterrupt:
+        service.stop()
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/kv_cache_manager/cache_event_subscriber/key_codec.py
+++ b/kv_cache_manager/cache_event_subscriber/key_codec.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+_U64_MASK = (1 << 64) - 1
+_I64_MAX = (1 << 63) - 1
+
+
+def to_signed_i64(value: int | bytes) -> int:
+    """Map engine block hashes onto KVCM's signed int64 key domain.
+
+    Integer and byte hashes preserve their low 64-bit representation. For
+    vLLM this is exactly the representation selected by
+    ``VLLM_KV_EVENTS_USE_INT_BLOCK_HASHES`` and therefore stays stable whether
+    the publisher sends the full digest or its legacy integer form.
+
+    KVCM's metadata key is signed int64, so query-side integrations must use
+    this same codec before calling KVCM with engine-native hashes.
+    """
+
+    if isinstance(value, bytes):
+        if not value:
+            raise ValueError("block key bytes cannot be empty")
+        unsigned = int.from_bytes(value, "big", signed=False) & _U64_MASK
+    elif isinstance(value, int) and not isinstance(value, bool):
+        unsigned = value & _U64_MASK
+    else:
+        raise TypeError(f"unsupported block key type: {type(value).__name__}")
+    return unsigned if unsigned <= _I64_MAX else unsigned - (1 << 64)

--- a/kv_cache_manager/cache_event_subscriber/models.py
+++ b/kv_cache_manager/cache_event_subscriber/models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class SourceNotReady(RuntimeError):
+    """The engine is reachable but has not exposed an authoritative baseline."""
+
+
+@dataclass(frozen=True, order=True)
+class LocationSpec:
+    name: str
+    uri: str
+
+
+@dataclass(frozen=True)
+class BlockRecord:
+    block_key: int
+    medium: str
+    group_ids: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class EngineUpdate:
+    """One source update whose cursor is committed only after KVCM ACKs it."""
+
+    full_snapshot: bool
+    blocks: tuple[BlockRecord, ...] = ()
+    upserts: tuple[BlockRecord, ...] = ()
+    removals: tuple[BlockRecord, ...] = ()
+    commit_token: Any = None
+
+    def __post_init__(self) -> None:
+        if self.full_snapshot and (self.upserts or self.removals):
+            raise ValueError("a full snapshot cannot also contain deltas")
+
+    @property
+    def empty(self) -> bool:
+        return not self.full_snapshot and not self.upserts and not self.removals

--- a/kv_cache_manager/cache_event_subscriber/reporter.py
+++ b/kv_cache_manager/cache_event_subscriber/reporter.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import itertools
+import threading
+import time
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
+
+from .models import BlockRecord, EngineUpdate, LocationSpec
+
+
+class KvcmEventReporter:
+    """Translate normalized engine state into acknowledged KVCM mutations."""
+
+    def __init__(
+        self,
+        manager_client: KvCacheManagerClient,
+        *,
+        instance_id: str,
+        host_ip_port: str,
+        spec_factory: Callable[[BlockRecord], Iterable[LocationSpec]],
+        storage_type: str = "ST_EVENT_REPORT",
+        max_events_per_request: int = 4096,
+    ) -> None:
+        if not instance_id or not host_ip_port:
+            raise ValueError("instance_id and host_ip_port are required")
+        if max_events_per_request <= 0:
+            raise ValueError("max_events_per_request must be positive")
+        self._client = manager_client
+        self._instance_id = instance_id
+        self._host_ip_port = host_ip_port
+        self._spec_factory = spec_factory
+        self._storage_type = storage_type
+        self._max_events = max_events_per_request
+        self._request_lock = threading.Lock()
+
+    def _trace_id(self, operation: str) -> str:
+        return f"cache_subscriber_{operation}_{time.monotonic_ns()}"
+
+    def _request(self, events: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "trace_id": self._trace_id("report"),
+            "instance_id": self._instance_id,
+            "host_ip_port": self._host_ip_port,
+            "storage_type": self._storage_type,
+            "events": events,
+        }
+
+    def register_node(self, mediums: Iterable[str]) -> None:
+        event = {
+            "event_type": "EVENT_NODE_REGISTER",
+            "node_register": {"mediums": sorted(set(mediums))},
+        }
+        self._report([event])
+
+    def register_instance(
+        self,
+        *,
+        instance_group: str,
+        block_size: int,
+        spec_sizes: dict[str, int],
+        model_name: str,
+        dtype: str,
+        tp_size: int = 1,
+        dp_size: int = 1,
+        pp_size: int = 1,
+        use_mla: bool = False,
+        location_spec_groups: list[dict[str, Any]] | None = None,
+    ) -> None:
+        request = {
+            "trace_id": self._trace_id("register_instance"),
+            "instance_group": instance_group,
+            "instance_id": self._instance_id,
+            "block_size": block_size,
+            "location_spec_infos": [
+                {"name": name, "size": size} for name, size in sorted(spec_sizes.items())
+            ],
+            "model_deployment": {
+                "model_name": model_name,
+                "dtype": dtype,
+                "use_mla": use_mla,
+                "tp_size": tp_size,
+                "dp_size": dp_size,
+                "pp_size": pp_size,
+                "lora_name": "",
+                "extra": "",
+                "user_data": "",
+            },
+            "location_spec_groups": location_spec_groups or [],
+        }
+        with self._request_lock:
+            self._client.register_instance(request)
+
+    def heartbeat(self, system_status: dict[str, str] | None = None) -> None:
+        event = {
+            "event_type": "EVENT_HEARTBEAT",
+            "heartbeat": {"system_status": system_status or {}},
+        }
+        self._report([event])
+
+    def host_down(self) -> None:
+        event = {"event_type": "EVENT_HOST_DOWN", "host_down": {}}
+        self._report([event])
+
+    def send(self, update: EngineUpdate) -> None:
+        if update.full_snapshot:
+            if len(update.blocks) > self._max_events:
+                # A single authoritative event is preferable for small
+                # snapshots. Large snapshots use clear-then-upsert chunks to
+                # stay below HTTP/protobuf limits. Retrying the same update
+                # starts with another clear and therefore always converges.
+                self._report(
+                    [
+                        {
+                            "event_type": "EVENT_BLOCK_SNAPSHOT",
+                            "block_snapshot": {"blocks": []},
+                        }
+                    ]
+                )
+                events = [self._upsert_event(block) for block in update.blocks]
+                for chunk in _chunks(events, self._max_events):
+                    self._report(chunk)
+                return
+            blocks = [self._snapshot_block(block) for block in update.blocks]
+            event = {
+                "event_type": "EVENT_BLOCK_SNAPSHOT",
+                "block_snapshot": {"blocks": blocks},
+            }
+            self._report([event])
+            return
+
+        events = [self._upsert_event(block) for block in update.upserts]
+        events.extend(self._remove_event(block) for block in update.removals)
+        for chunk in _chunks(events, self._max_events):
+            self._report(chunk)
+
+    def _report(self, events: list[dict[str, Any]]) -> None:
+        with self._request_lock:
+            self._client.report_event(self._request(events))
+
+    def _specs(self, block: BlockRecord) -> list[dict[str, str]]:
+        specs = [{"name": spec.name, "uri": spec.uri} for spec in self._spec_factory(block)]
+        if not specs:
+            raise ValueError(f"block {block.block_key} has no location specs")
+        return specs
+
+    def _snapshot_block(self, block: BlockRecord) -> dict[str, Any]:
+        return {
+            "block_key": str(block.block_key),
+            "medium": block.medium,
+            "specs": self._specs(block),
+        }
+
+    def _upsert_event(self, block: BlockRecord) -> dict[str, Any]:
+        return {
+            "event_type": "EVENT_BLOCK_ADD",
+            "block_add": self._snapshot_block(block),
+        }
+
+    @staticmethod
+    def _remove_event(block: BlockRecord) -> dict[str, Any]:
+        return {
+            "event_type": "EVENT_BLOCK_DELETE",
+            "block_delete": {
+                "block_key": str(block.block_key),
+                "medium": block.medium,
+            },
+        }
+
+
+def _chunks(items: list[dict[str, Any]], size: int) -> Iterable[list[dict[str, Any]]]:
+    iterator = iter(items)
+    while chunk := list(itertools.islice(iterator, size)):
+        yield chunk

--- a/kv_cache_manager/cache_event_subscriber/requirements-vllm.txt
+++ b/kv_cache_manager/cache_event_subscriber/requirements-vllm.txt
@@ -1,0 +1,2 @@
+msgspec>=0.18
+pyzmq>=25

--- a/kv_cache_manager/cache_event_subscriber/rtp_source.py
+++ b/kv_cache_manager/cache_event_subscriber/rtp_source.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+
+from .models import BlockRecord, EngineUpdate
+
+_RPC_METHOD = "/RpcService/GetCacheStatus"
+_STORED = 0
+_REMOVED = 1
+
+
+class RtpTransport(Protocol):
+    async def call(self, endpoint: str, request: Any, timeout_s: float) -> Any: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass
+class _EndpointState:
+    generation: int
+    cursor: int
+    blocks: dict[int, set[int]]
+
+    def copy(self) -> "_EndpointState":
+        return _EndpointState(
+            generation=self.generation,
+            cursor=self.cursor,
+            blocks={key: set(groups) for key, groups in self.blocks.items()},
+        )
+
+
+@dataclass(frozen=True)
+class _CommitToken:
+    states: tuple[_EndpointState, ...]
+    aggregate: dict[int, frozenset[int]]
+    full_snapshot: bool
+
+
+class RtpCacheSource:
+    """Transactional RTP cache changefeed consumer.
+
+    ``prepare`` reconstructs candidate state without advancing durable cursors.
+    The caller must invoke ``commit`` only after KVCM acknowledges the update.
+    """
+
+    def __init__(
+        self,
+        endpoints: Sequence[str],
+        *,
+        timeout_s: float = 1.0,
+        page_size: int = 4096,
+        max_pages: int = 1024,
+        full_refresh_interval_s: float = 300.0,
+        medium: str = "hbm",
+        expected_block_size: int | None = None,
+        cache_group_count: int = 1,
+        transport: RtpTransport | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not endpoints:
+            raise ValueError("at least one RTP endpoint is required")
+        if len(set(endpoints)) != len(endpoints):
+            raise ValueError("RTP endpoints must be unique")
+        if timeout_s <= 0 or page_size <= 0 or max_pages <= 0:
+            raise ValueError("timeouts and pagination limits must be positive")
+        if cache_group_count <= 0:
+            raise ValueError("cache_group_count must be positive")
+        if expected_block_size is not None and expected_block_size <= 0:
+            raise ValueError("expected_block_size must be positive")
+        self._endpoints = tuple(endpoints)
+        self._timeout_s = timeout_s
+        self._page_size = page_size
+        self._max_pages = max_pages
+        self._full_refresh_interval_s = full_refresh_interval_s
+        self._medium = medium
+        self._expected_block_size = expected_block_size
+        self._cache_group_count = cache_group_count
+        self._clock = clock
+        self._request_type, response_type = _build_message_types()
+        self._transport = transport or _GrpcTransport(response_type)
+        self._states = tuple(_EndpointState(0, -1, {}) for _ in self._endpoints)
+        self._aggregate: dict[int, frozenset[int]] = {}
+        self._initialized = False
+        self._next_full_refresh = 0.0
+        self._pending: _CommitToken | None = None
+
+    async def prepare(self) -> EngineUpdate:
+        if self._pending is not None:
+            raise RuntimeError("previous RTP update has not been committed or aborted")
+        force_snapshot = not self._initialized or self._clock() >= self._next_full_refresh
+        results = await asyncio.gather(
+            *(
+                self._fetch_endpoint(endpoint, state, force_snapshot)
+                for endpoint, state in zip(self._endpoints, self._states, strict=True)
+            )
+        )
+        states = tuple(state for state, _ in results)
+        source_reset = any(reset for _, reset in results)
+        aggregate = _aggregate_states(states)
+        full_snapshot = force_snapshot or source_reset
+        token = _CommitToken(states, aggregate, full_snapshot)
+        self._pending = token
+
+        if full_snapshot:
+            blocks = tuple(
+                BlockRecord(key, self._medium, tuple(sorted(groups)))
+                for key, groups in sorted(aggregate.items())
+            )
+            return EngineUpdate(True, blocks=blocks, commit_token=token)
+
+        changed = {
+            key
+            for key, groups in aggregate.items()
+            if self._aggregate.get(key) != groups
+        }
+        removed = set(self._aggregate) - set(aggregate)
+        return EngineUpdate(
+            False,
+            upserts=tuple(
+                BlockRecord(key, self._medium, tuple(sorted(aggregate[key])))
+                for key in sorted(changed)
+            ),
+            removals=tuple(
+                BlockRecord(key, self._medium, tuple(sorted(self._aggregate[key])))
+                for key in sorted(removed)
+            ),
+            commit_token=token,
+        )
+
+    def commit(self, update: EngineUpdate) -> None:
+        if update.commit_token is not self._pending:
+            raise RuntimeError("RTP update is stale or belongs to another source")
+        token = self._pending
+        assert token is not None
+        self._states = token.states
+        self._aggregate = token.aggregate
+        self._initialized = True
+        if token.full_snapshot:
+            self._next_full_refresh = self._clock() + self._full_refresh_interval_s
+        self._pending = None
+
+    def abort(self, update: EngineUpdate) -> None:
+        if update.commit_token is not self._pending:
+            raise RuntimeError("RTP update is stale or belongs to another source")
+        self._pending = None
+
+    async def close(self) -> None:
+        await self._transport.close()
+
+    async def _fetch_endpoint(
+        self, endpoint: str, committed: _EndpointState, force_snapshot: bool
+    ) -> tuple[_EndpointState, bool]:
+        candidate = committed.copy()
+        reset_seen = False
+        for _ in range(self._max_pages):
+            request = self._request_type(
+                latest_cache_version=candidate.cursor,
+                need_cache_keys=True,
+                need_cache_events=True,
+                max_cache_events=self._page_size,
+                force_cache_event_snapshot=force_snapshot and not reset_seen,
+                cache_event_generation=candidate.generation,
+            )
+            response = await self._transport.call(endpoint, request, self._timeout_s)
+            if self._expected_block_size is not None:
+                observed_block_size = int(getattr(response, "block_size", 0))
+                if observed_block_size != self._expected_block_size:
+                    raise RuntimeError(
+                        "RTP cache block size does not match KVCM registration: "
+                        f"configured={self._expected_block_size}, "
+                        f"observed={observed_block_size}, endpoint={endpoint}"
+                    )
+            protocol = int(getattr(response, "cache_event_protocol_version", 0))
+            if protocol == 0:
+                if self._cache_group_count != 1:
+                    raise RuntimeError(
+                        "legacy RTP cache status has no cache-group identity; "
+                        "cache_group_count must be 1 or RTP cache-event protocol v2 is required"
+                    )
+                legacy_version = int(getattr(response, "version", -1))
+                candidate.blocks = {
+                    int(key): {0}
+                    for key, present in getattr(response, "cache_keys", {}).items()
+                    if present
+                }
+                candidate.cursor = legacy_version
+                candidate.generation = 0
+                # A legacy RTP endpoint only exposes a full key map. Treat it
+                # as authoritative input on every poll, but force an outgoing
+                # full snapshot only for reconciliation or version rollback;
+                # otherwise compute and report the normal aggregate diff.
+                return candidate, force_snapshot or legacy_version < committed.cursor
+
+            generation = int(getattr(response, "cache_event_generation", 0))
+            reset = bool(getattr(response, "cache_event_reset_required", False))
+            if candidate.generation and generation and generation != candidate.generation and not reset:
+                raise RuntimeError(
+                    f"RTP generation changed without snapshot recovery at {endpoint}"
+                )
+            if reset:
+                candidate.blocks = {
+                    int(entry.cache_key): _validated_groups(
+                        entry.group_ids, self._cache_group_count
+                    )
+                    for entry in response.cache_event_snapshot
+                }
+                candidate.cursor = _next_cursor(response, protocol, candidate.cursor)
+                candidate.generation = generation
+                reset_seen = True
+            else:
+                expected = candidate.cursor + 1
+                for event in response.cache_events:
+                    version = int(event.version)
+                    if version != expected:
+                        raise RuntimeError(
+                            f"RTP event gap at {endpoint}: expected={expected}, got={version}"
+                        )
+                    key = int(event.cache_key)
+                    groups = _validated_groups(
+                        event.group_ids, self._cache_group_count
+                    )
+                    if int(event.event_type) == _STORED:
+                        candidate.blocks.setdefault(key, set()).update(groups)
+                    elif int(event.event_type) == _REMOVED:
+                        remaining = candidate.blocks.get(key)
+                        if remaining is not None:
+                            remaining.difference_update(groups)
+                            if not remaining:
+                                candidate.blocks.pop(key, None)
+                    else:
+                        raise RuntimeError(f"unknown RTP cache event type at {endpoint}")
+                    expected += 1
+                candidate.cursor = _next_cursor(response, protocol, candidate.cursor)
+                candidate.generation = generation
+
+            if not bool(getattr(response, "cache_event_has_more", False)):
+                head = int(getattr(response, "cache_event_version", candidate.cursor))
+                if candidate.cursor != head:
+                    raise RuntimeError(
+                        f"RTP page ended before head at {endpoint}: cursor={candidate.cursor}, head={head}"
+                    )
+                return candidate, reset_seen
+            if not response.cache_events or candidate.cursor < 0:
+                raise RuntimeError(f"RTP pagination made no progress at {endpoint}")
+            force_snapshot = False
+        raise RuntimeError(f"RTP pagination exceeded {self._max_pages} pages at {endpoint}")
+
+
+def _next_cursor(response: Any, protocol: int, previous: int) -> int:
+    if protocol >= 2:
+        return int(response.next_cache_event_version)
+    events = getattr(response, "cache_events", ())
+    if events:
+        return int(events[-1].version)
+    if bool(getattr(response, "cache_event_reset_required", False)):
+        return int(response.cache_event_version)
+    return previous
+
+
+def _aggregate_states(states: Sequence[_EndpointState]) -> dict[int, frozenset[int]]:
+    aggregate: dict[int, set[int]] = {}
+    for state in states:
+        for key, groups in state.blocks.items():
+            aggregate.setdefault(key, set()).update(groups)
+    return {key: frozenset(groups) for key, groups in aggregate.items()}
+
+
+def _validated_groups(values: Sequence[int], cache_group_count: int) -> set[int]:
+    groups = {int(group) for group in values}
+    if not groups:
+        raise RuntimeError("RTP cache event has no cache group ids")
+    invalid = sorted(group for group in groups if group < 0 or group >= cache_group_count)
+    if invalid:
+        raise RuntimeError(f"RTP returned unregistered cache group ids: {invalid}")
+    return groups
+
+
+class _GrpcTransport:
+    def __init__(self, response_type: type[Any]) -> None:
+        import grpc
+
+        self._grpc = grpc
+        self._response_type = response_type
+        self._channels: dict[str, Any] = {}
+        self._calls: dict[str, Any] = {}
+
+    async def call(self, endpoint: str, request: Any, timeout_s: float) -> Any:
+        call = self._calls.get(endpoint)
+        if call is None:
+            channel = self._grpc.aio.insecure_channel(
+                endpoint, options=[("grpc.max_receive_message_length", 256 * 1024 * 1024)]
+            )
+            self._channels[endpoint] = channel
+            call = channel.unary_unary(
+                _RPC_METHOD,
+                request_serializer=lambda message: message.SerializeToString(),
+                response_deserializer=self._response_type.FromString,
+            )
+            self._calls[endpoint] = call
+        return await call(request, timeout=timeout_s)
+
+    async def close(self) -> None:
+        await asyncio.gather(*(channel.close() for channel in self._channels.values()))
+        self._channels.clear()
+        self._calls.clear()
+
+
+def _add_field(
+    message: descriptor_pb2.DescriptorProto,
+    name: str,
+    number: int,
+    field_type: int,
+    *,
+    repeated: bool = False,
+    type_name: str = "",
+) -> None:
+    field = message.field.add(name=name, number=number, type=field_type)
+    field.label = (
+        descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED
+        if repeated
+        else descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    )
+    if type_name:
+        field.type_name = type_name
+
+
+def _build_message_types() -> tuple[type[Any], type[Any]]:
+    """Build the stable wire subset so tair-kvcache need not import RTP code."""
+
+    fd = descriptor_pb2.FileDescriptorProto(name="rtp_cache_event_subset.proto", syntax="proto3")
+    request = fd.message_type.add(name="CacheVersionPB")
+    for name, number, field_type in (
+        ("latest_cache_version", 1, descriptor_pb2.FieldDescriptorProto.TYPE_INT64),
+        ("need_cache_keys", 2, descriptor_pb2.FieldDescriptorProto.TYPE_BOOL),
+        ("need_cache_events", 3, descriptor_pb2.FieldDescriptorProto.TYPE_BOOL),
+        ("max_cache_events", 4, descriptor_pb2.FieldDescriptorProto.TYPE_UINT32),
+        ("force_cache_event_snapshot", 5, descriptor_pb2.FieldDescriptorProto.TYPE_BOOL),
+        ("cache_event_generation", 6, descriptor_pb2.FieldDescriptorProto.TYPE_UINT64),
+    ):
+        _add_field(request, name, number, field_type)
+
+    event_enum = fd.enum_type.add(name="CacheEventTypePB")
+    event_enum.value.add(name="CACHE_EVENT_STORED", number=0)
+    event_enum.value.add(name="CACHE_EVENT_REMOVED", number=1)
+    reason_enum = fd.enum_type.add(name="CacheEventSnapshotReasonPB")
+    for number, name in enumerate(
+        (
+            "CACHE_EVENT_SNAPSHOT_NONE",
+            "CACHE_EVENT_SNAPSHOT_FORCED",
+            "CACHE_EVENT_SNAPSHOT_HISTORY_GAP",
+            "CACHE_EVENT_SNAPSHOT_FUTURE_CURSOR",
+            "CACHE_EVENT_SNAPSHOT_GENERATION_MISMATCH",
+            "CACHE_EVENT_SNAPSHOT_INVALID_CURSOR",
+        )
+    ):
+        reason_enum.value.add(name=name, number=number)
+
+    event = fd.message_type.add(name="CacheEventPB")
+    _add_field(event, "version", 1, descriptor_pb2.FieldDescriptorProto.TYPE_INT64)
+    _add_field(
+        event,
+        "event_type",
+        2,
+        descriptor_pb2.FieldDescriptorProto.TYPE_ENUM,
+        type_name=".CacheEventTypePB",
+    )
+    _add_field(event, "cache_key", 3, descriptor_pb2.FieldDescriptorProto.TYPE_INT64)
+    _add_field(event, "group_ids", 4, descriptor_pb2.FieldDescriptorProto.TYPE_INT32, repeated=True)
+
+    snapshot = fd.message_type.add(name="CacheSnapshotEntryPB")
+    _add_field(snapshot, "cache_key", 1, descriptor_pb2.FieldDescriptorProto.TYPE_INT64)
+    _add_field(snapshot, "group_ids", 2, descriptor_pb2.FieldDescriptorProto.TYPE_INT32, repeated=True)
+
+    status = fd.message_type.add(name="CacheStatusPB")
+    cache_map = status.nested_type.add(name="CacheKeysEntry")
+    cache_map.options.map_entry = True
+    _add_field(cache_map, "key", 1, descriptor_pb2.FieldDescriptorProto.TYPE_INT64)
+    _add_field(cache_map, "value", 2, descriptor_pb2.FieldDescriptorProto.TYPE_BOOL)
+    scalar_fields = (
+        ("available_kv_cache", 1, descriptor_pb2.FieldDescriptorProto.TYPE_INT64),
+        ("total_kv_cache", 2, descriptor_pb2.FieldDescriptorProto.TYPE_INT64),
+        ("block_size", 3, descriptor_pb2.FieldDescriptorProto.TYPE_INT64),
+        ("version", 4, descriptor_pb2.FieldDescriptorProto.TYPE_INT64),
+    )
+    for name, number, field_type in scalar_fields:
+        _add_field(status, name, number, field_type)
+    _add_field(
+        status,
+        "cache_keys",
+        5,
+        descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        repeated=True,
+        type_name=".CacheStatusPB.CacheKeysEntry",
+    )
+    for name, number, field_type in (
+        ("cache_event_version", 6, descriptor_pb2.FieldDescriptorProto.TYPE_INT64),
+        ("oldest_cache_event_version", 7, descriptor_pb2.FieldDescriptorProto.TYPE_INT64),
+        ("cache_event_reset_required", 8, descriptor_pb2.FieldDescriptorProto.TYPE_BOOL),
+        ("cache_event_has_more", 9, descriptor_pb2.FieldDescriptorProto.TYPE_BOOL),
+    ):
+        _add_field(status, name, number, field_type)
+    _add_field(
+        status,
+        "cache_events",
+        10,
+        descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        repeated=True,
+        type_name=".CacheEventPB",
+    )
+    _add_field(
+        status,
+        "cache_event_snapshot",
+        11,
+        descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        repeated=True,
+        type_name=".CacheSnapshotEntryPB",
+    )
+    _add_field(status, "cache_event_protocol_version", 12, descriptor_pb2.FieldDescriptorProto.TYPE_UINT32)
+    _add_field(status, "cache_event_generation", 13, descriptor_pb2.FieldDescriptorProto.TYPE_UINT64)
+    _add_field(
+        status,
+        "cache_event_snapshot_reason",
+        14,
+        descriptor_pb2.FieldDescriptorProto.TYPE_ENUM,
+        type_name=".CacheEventSnapshotReasonPB",
+    )
+    _add_field(status, "next_cache_event_version", 15, descriptor_pb2.FieldDescriptorProto.TYPE_INT64)
+
+    pool = descriptor_pool.DescriptorPool()
+    pool.Add(fd)
+    def message_class(name: str) -> type[Any]:
+        descriptor = pool.FindMessageTypeByName(name)
+        if hasattr(message_factory, "GetMessageClass"):
+            return message_factory.GetMessageClass(descriptor)
+        return message_factory.MessageFactory(pool).GetPrototype(descriptor)
+
+    return (
+        message_class("CacheVersionPB"),
+        message_class("CacheStatusPB"),
+    )

--- a/kv_cache_manager/cache_event_subscriber/service.py
+++ b/kv_cache_manager/cache_event_subscriber/service.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Protocol
+
+from .models import EngineUpdate, SourceNotReady
+from .reporter import KvcmEventReporter
+
+
+class TransactionalSource(Protocol):
+    async def prepare(self) -> EngineUpdate: ...
+
+    def commit(self, update: EngineUpdate) -> None: ...
+
+    def abort(self, update: EngineUpdate) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+class CacheEventSubscriberService:
+    """Serialize source reads and KVCM ACKs with bounded backpressure."""
+
+    def __init__(
+        self,
+        source: TransactionalSource,
+        reporter: KvcmEventReporter,
+        *,
+        mediums: tuple[str, ...],
+        poll_interval_s: float = 0.1,
+        retry_interval_s: float = 1.0,
+        heartbeat_interval_s: float = 10.0,
+        source_failure_threshold: int = 3,
+        health_probe: Callable[[], bool] | None = None,
+        health_failure_threshold: int = 3,
+    ) -> None:
+        if poll_interval_s < 0 or retry_interval_s < 0 or heartbeat_interval_s <= 0:
+            raise ValueError(
+                "subscriber intervals must be non-negative and heartbeat positive"
+            )
+        if source_failure_threshold <= 0:
+            raise ValueError("source_failure_threshold must be positive")
+        if health_failure_threshold <= 0:
+            raise ValueError("health_failure_threshold must be positive")
+        self._source = source
+        self._reporter = reporter
+        self._mediums = mediums
+        self._poll_interval_s = poll_interval_s
+        self._retry_interval_s = retry_interval_s
+        self._heartbeat_interval_s = heartbeat_interval_s
+        self._source_failure_threshold = source_failure_threshold
+        self._health_probe = health_probe
+        self._health_failure_threshold = health_failure_threshold
+        self._health_failures = 0
+        self._external_healthy = health_probe is None
+        self._source_healthy = False
+        self._stopping = asyncio.Event()
+
+    async def run(self) -> None:
+        registered = False
+        host_down_reported = False
+        consecutive_source_failures = 0
+        heartbeat: asyncio.Task[None] | None = None
+        try:
+            while not self._stopping.is_set():
+                try:
+                    update = await self._source.prepare()
+                except asyncio.CancelledError:
+                    raise
+                except SourceNotReady:
+                    # An empty, newly started vLLM publisher has no sequence-0
+                    # batch yet. Keep the host unadvertised and retry without
+                    # treating that state as an engine outage.
+                    self._source_healthy = False
+                    consecutive_source_failures = 0
+                    await asyncio.sleep(self._retry_interval_s)
+                    continue
+                except Exception as error:
+                    self._source_healthy = False
+                    consecutive_source_failures += 1
+                    logging.exception("cache-event source read failed; retrying")
+                    if consecutive_source_failures >= self._source_failure_threshold:
+                        if registered:
+                            try:
+                                await asyncio.to_thread(self._reporter.host_down)
+                                host_down_reported = True
+                            except Exception:
+                                logging.exception(
+                                    "KVCM HOST_DOWN report failed after source outage"
+                                )
+                        raise RuntimeError(
+                            "cache-event source exceeded its failure threshold"
+                        ) from error
+                    await asyncio.sleep(self._retry_interval_s)
+                    continue
+                consecutive_source_failures = 0
+                self._source_healthy = True
+                if heartbeat is None and not update.full_snapshot:
+                    self._source.abort(update)
+                    raise RuntimeError(
+                        "the first cache-event source update must be an "
+                        "authoritative full snapshot"
+                    )
+                while not self._stopping.is_set():
+                    if not registered:
+                        try:
+                            await asyncio.to_thread(
+                                self._reporter.register_node, self._mediums
+                            )
+                            registered = True
+                        except Exception:
+                            logging.exception(
+                                "KVCM node registration failed; retrying"
+                            )
+                            await asyncio.sleep(self._retry_interval_s)
+                            continue
+                    try:
+                        if not update.empty:
+                            await asyncio.to_thread(self._reporter.send, update)
+                    except Exception:
+                        logging.exception(
+                            "KVCM cache-event report failed; "
+                            "retrying without advancing source"
+                        )
+                        if heartbeat is None:
+                            # Do not advertise a newly registered node until
+                            # its first authoritative snapshot is visible.
+                            try:
+                                await asyncio.to_thread(self._reporter.host_down)
+                            except Exception:
+                                logging.exception(
+                                    "KVCM HOST_DOWN failed after initial "
+                                    "snapshot rejection"
+                                )
+                            registered = False
+                        else:
+                            await self._reregister_after_failure()
+                        await asyncio.sleep(self._retry_interval_s)
+                        continue
+                    self._source.commit(update)
+                    if heartbeat is None:
+                        heartbeat = asyncio.create_task(
+                            self._heartbeat_loop(), name="kvcm-heartbeat"
+                        )
+                    break
+                if not self._stopping.is_set() and self._poll_interval_s > 0:
+                    await asyncio.sleep(self._poll_interval_s)
+        finally:
+            if heartbeat is not None:
+                heartbeat.cancel()
+                with suppress(asyncio.CancelledError):
+                    await heartbeat
+            if registered and not host_down_reported:
+                try:
+                    await asyncio.to_thread(self._reporter.host_down)
+                except Exception:
+                    logging.exception(
+                        "KVCM HOST_DOWN report failed during subscriber shutdown"
+                    )
+            await self._source.close()
+
+    def stop(self) -> None:
+        self._stopping.set()
+
+    async def _heartbeat_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._heartbeat_interval_s)
+            if self._health_probe is not None:
+                try:
+                    healthy = await asyncio.to_thread(self._health_probe)
+                except Exception:
+                    healthy = False
+                    logging.exception("cache engine health probe failed")
+                self._external_healthy = healthy
+                if not healthy:
+                    self._health_failures += 1
+                    if self._health_failures >= self._health_failure_threshold:
+                        logging.error(
+                            "cache engine health probe exceeded failure threshold"
+                        )
+                        self.stop()
+                    continue
+                self._health_failures = 0
+            if not self._source_healthy or not self._external_healthy:
+                continue
+            try:
+                await asyncio.to_thread(self._reporter.heartbeat)
+            except Exception:
+                logging.exception("KVCM heartbeat failed")
+                await self._reregister_after_failure()
+
+    async def _reregister_after_failure(self) -> None:
+        try:
+            await asyncio.to_thread(self._reporter.register_node, self._mediums)
+        except Exception:
+            logging.exception("KVCM node re-registration failed")

--- a/kv_cache_manager/cache_event_subscriber/test/BUILD
+++ b/kv_cache_manager/cache_event_subscriber/test/BUILD
@@ -1,0 +1,7 @@
+load("@rules_python//python:py_test.bzl", "py_test")
+
+py_test(
+    name = "subscriber_test",
+    srcs = ["test_subscriber.py"],
+    deps = ["//kv_cache_manager/cache_event_subscriber"],
+)

--- a/kv_cache_manager/cache_event_subscriber/test/test_subscriber.py
+++ b/kv_cache_manager/cache_event_subscriber/test/test_subscriber.py
@@ -1,0 +1,699 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from kv_cache_manager.cache_event_subscriber.__main__ import _parse_rtp_endpoints
+from kv_cache_manager.cache_event_subscriber.key_codec import to_signed_i64
+from kv_cache_manager.cache_event_subscriber.models import BlockRecord, EngineUpdate, LocationSpec, SourceNotReady
+from kv_cache_manager.cache_event_subscriber.reporter import KvcmEventReporter
+from kv_cache_manager.cache_event_subscriber.rtp_source import RtpCacheSource
+from kv_cache_manager.cache_event_subscriber.service import CacheEventSubscriberService
+from kv_cache_manager.cache_event_subscriber.vllm_source import VllmCacheSource, VllmHistoryGap
+
+
+def _rtp_response(
+    *,
+    head: int,
+    next_cursor: int,
+    reset: bool = False,
+    more: bool = False,
+    events: list[object] | None = None,
+    snapshot: list[object] | None = None,
+    generation: int = 7,
+    protocol: int = 2,
+    cache_keys: dict[int, bool] | None = None,
+    block_size: int = 64,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        cache_event_protocol_version=protocol,
+        cache_event_generation=generation,
+        cache_event_reset_required=reset,
+        cache_event_has_more=more,
+        cache_event_version=head,
+        next_cache_event_version=next_cursor,
+        cache_events=events or [],
+        cache_event_snapshot=snapshot or [],
+        cache_keys=cache_keys or {},
+        version=head,
+        block_size=block_size,
+    )
+
+
+def _event(version: int, event_type: int, key: int, groups: tuple[int, ...] = (0,)) -> SimpleNamespace:
+    return SimpleNamespace(
+        version=version,
+        event_type=event_type,
+        cache_key=key,
+        group_ids=groups,
+    )
+
+
+class BlockKeyCodecTest(unittest.TestCase):
+    def test_vllm_bytes_and_legacy_integer_have_the_same_key(self) -> None:
+        digest = bytes(range(32))
+        legacy_integer = int.from_bytes(digest, "big") & ((1 << 64) - 1)
+        self.assertEqual(to_signed_i64(legacy_integer), to_signed_i64(digest))
+
+    def test_empty_bytes_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            to_signed_i64(b"")
+
+
+class EndpointConfigTest(unittest.TestCase):
+    def test_rtp_requires_one_unique_endpoint_per_dp_rank(self) -> None:
+        self.assertEqual(
+            ("rank-0:8089", "rank-1:8089"),
+            _parse_rtp_endpoints("rank-0:8089, rank-1:8089", 2),
+        )
+        with self.assertRaisesRegex(ValueError, "expected 2, got 1"):
+            _parse_rtp_endpoints("rank-0:8089", 2)
+        with self.assertRaisesRegex(ValueError, "must be unique"):
+            _parse_rtp_endpoints("rank-0:8089,rank-0:8089", 2)
+
+
+class FakeRtpTransport:
+    def __init__(self, responses: list[object]) -> None:
+        self.responses = responses
+        self.requests: list[object] = []
+
+    async def call(self, endpoint: str, request: object, timeout_s: float) -> object:
+        self.requests.append(request)
+        if not self.responses:
+            raise AssertionError("unexpected RTP request")
+        return self.responses.pop(0)
+
+    async def close(self) -> None:
+        pass
+
+
+class EndpointRtpTransport:
+    def __init__(self, responses: dict[str, list[object | Exception]]) -> None:
+        self.responses = responses
+        self.requests: list[tuple[str, object]] = []
+
+    async def call(self, endpoint: str, request: object, timeout_s: float) -> object:
+        self.requests.append((endpoint, request))
+        response = self.responses[endpoint].pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def close(self) -> None:
+        pass
+
+
+class RtpSourceTest(unittest.IsolatedAsyncioTestCase):
+    async def test_snapshot_then_paginated_delta_uses_explicit_next_cursor(self) -> None:
+        transport = FakeRtpTransport(
+            [
+                _rtp_response(
+                    head=0,
+                    next_cursor=0,
+                    reset=True,
+                    snapshot=[SimpleNamespace(cache_key=1, group_ids=(0,))],
+                ),
+                _rtp_response(
+                    head=2,
+                    next_cursor=1,
+                    more=True,
+                    events=[_event(1, 0, 2)],
+                ),
+                _rtp_response(
+                    head=2,
+                    next_cursor=2,
+                    events=[_event(2, 1, 1)],
+                ),
+            ]
+        )
+        source = RtpCacheSource(["worker:123"], transport=transport)
+
+        initial = await source.prepare()
+        self.assertTrue(initial.full_snapshot)
+        self.assertEqual((BlockRecord(1, "hbm", (0,)),), initial.blocks)
+        source.commit(initial)
+
+        delta = await source.prepare()
+        self.assertFalse(delta.full_snapshot)
+        self.assertEqual((BlockRecord(2, "hbm", (0,)),), delta.upserts)
+        self.assertEqual((BlockRecord(1, "hbm", (0,)),), delta.removals)
+        self.assertEqual(0, transport.requests[1].latest_cache_version)
+        self.assertEqual(1, transport.requests[2].latest_cache_version)
+
+    async def test_abort_does_not_advance_cursor(self) -> None:
+        transport = FakeRtpTransport(
+            [
+                _rtp_response(head=0, next_cursor=0, reset=True, snapshot=[]),
+                _rtp_response(head=1, next_cursor=1, events=[_event(1, 0, 9)]),
+                _rtp_response(head=1, next_cursor=1, events=[_event(1, 0, 9)]),
+            ]
+        )
+        source = RtpCacheSource(["worker:123"], transport=transport)
+        initial = await source.prepare()
+        source.commit(initial)
+        failed = await source.prepare()
+        source.abort(failed)
+        retried = await source.prepare()
+        self.assertEqual(failed.upserts, retried.upserts)
+        self.assertEqual(0, transport.requests[1].latest_cache_version)
+        self.assertEqual(0, transport.requests[2].latest_cache_version)
+
+    async def test_multi_dp_failure_does_not_commit_partial_candidate(self) -> None:
+        rank_0_snapshot = _rtp_response(
+            head=0,
+            next_cursor=0,
+            reset=True,
+            snapshot=[SimpleNamespace(cache_key=1, group_ids=(0,))],
+        )
+        transport = EndpointRtpTransport(
+            {
+                "rank-0:123": [rank_0_snapshot, rank_0_snapshot],
+                "rank-1:123": [
+                    RuntimeError("rank 1 unavailable"),
+                    _rtp_response(
+                        head=0,
+                        next_cursor=0,
+                        reset=True,
+                        snapshot=[SimpleNamespace(cache_key=2, group_ids=(0,))],
+                    ),
+                ],
+            }
+        )
+        source = RtpCacheSource(["rank-0:123", "rank-1:123"], transport=transport)
+
+        with self.assertRaisesRegex(RuntimeError, "rank 1 unavailable"):
+            await source.prepare()
+
+        recovered = await source.prepare()
+        self.assertTrue(recovered.full_snapshot)
+        self.assertEqual(
+            (BlockRecord(1, "hbm", (0,)), BlockRecord(2, "hbm", (0,))),
+            recovered.blocks,
+        )
+        rank_0_requests = [
+            request for endpoint, request in transport.requests if endpoint == "rank-0:123"
+        ]
+        self.assertEqual([-1, -1], [request.latest_cache_version for request in rank_0_requests])
+
+    async def test_snapshot_rejects_unregistered_cache_group(self) -> None:
+        transport = FakeRtpTransport(
+            [
+                _rtp_response(
+                    head=0,
+                    next_cursor=0,
+                    reset=True,
+                    snapshot=[SimpleNamespace(cache_key=1, group_ids=(1,))],
+                )
+            ]
+        )
+        source = RtpCacheSource(
+            ["worker:123"], cache_group_count=1, transport=transport
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "unregistered cache group"):
+            await source.prepare()
+
+    async def test_event_rejects_empty_cache_groups(self) -> None:
+        transport = FakeRtpTransport(
+            [
+                _rtp_response(
+                    head=0,
+                    next_cursor=0,
+                    reset=True,
+                    snapshot=[SimpleNamespace(cache_key=1, group_ids=())],
+                )
+            ]
+        )
+        source = RtpCacheSource(["worker:123"], transport=transport)
+
+        with self.assertRaisesRegex(RuntimeError, "no cache group ids"):
+            await source.prepare()
+
+    async def test_rtp_block_size_must_match_registration(self) -> None:
+        transport = FakeRtpTransport(
+            [_rtp_response(head=0, next_cursor=0, reset=True, block_size=32)]
+        )
+        source = RtpCacheSource(
+            ["worker:123"], expected_block_size=64, transport=transport
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "block size does not match"):
+            await source.prepare()
+
+    async def test_legacy_full_key_map_uses_delta_between_reconciliations(self) -> None:
+        transport = FakeRtpTransport(
+            [
+                _rtp_response(
+                    head=4,
+                    next_cursor=0,
+                    protocol=0,
+                    cache_keys={1: True},
+                ),
+                _rtp_response(
+                    head=5,
+                    next_cursor=0,
+                    protocol=0,
+                    cache_keys={2: True},
+                ),
+            ]
+        )
+        source = RtpCacheSource(["worker:123"], transport=transport)
+
+        initial = await source.prepare()
+        self.assertTrue(initial.full_snapshot)
+        self.assertEqual((BlockRecord(1, "hbm", (0,)),), initial.blocks)
+        source.commit(initial)
+
+        delta = await source.prepare()
+        self.assertFalse(delta.full_snapshot)
+        self.assertEqual((BlockRecord(2, "hbm", (0,)),), delta.upserts)
+        self.assertEqual((BlockRecord(1, "hbm", (0,)),), delta.removals)
+
+    async def test_legacy_full_key_map_rejects_multiple_cache_groups(self) -> None:
+        transport = FakeRtpTransport(
+            [
+                _rtp_response(
+                    head=1,
+                    next_cursor=0,
+                    protocol=0,
+                    cache_keys={1: True},
+                )
+            ]
+        )
+        source = RtpCacheSource(
+            ["worker:123"], cache_group_count=2, transport=transport
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "has no cache-group identity"):
+            await source.prepare()
+
+
+class FakeManagerClient:
+    def __init__(self) -> None:
+        self.reports: list[dict[str, object]] = []
+        self.registrations: list[dict[str, object]] = []
+
+    def report_event(self, request: dict[str, object]) -> None:
+        self.reports.append(request)
+
+    def register_instance(self, request: dict[str, object]) -> None:
+        self.registrations.append(request)
+
+
+class ReporterTest(unittest.TestCase):
+    def test_full_snapshot_is_one_authoritative_event(self) -> None:
+        client = FakeManagerClient()
+        reporter = KvcmEventReporter(
+            client,  # type: ignore[arg-type]
+            instance_id="instance",
+            host_ip_port="host:1",
+            spec_factory=lambda block: [LocationSpec("group_0", "event-report://host:1/hbm")],
+        )
+        reporter.send(EngineUpdate(True, blocks=(BlockRecord(5, "hbm", (0,)),)))
+        events = client.reports[0]["events"]
+        assert isinstance(events, list)
+        self.assertEqual("ST_EVENT_REPORT", client.reports[0]["storage_type"])
+        self.assertEqual("EVENT_BLOCK_SNAPSHOT", events[0]["event_type"])
+        self.assertEqual("5", events[0]["block_snapshot"]["blocks"][0]["block_key"])
+
+    def test_incremental_events_are_chunked(self) -> None:
+        client = FakeManagerClient()
+        reporter = KvcmEventReporter(
+            client,  # type: ignore[arg-type]
+            instance_id="instance",
+            host_ip_port="host:1",
+            max_events_per_request=2,
+            spec_factory=lambda block: [LocationSpec("group_0", "event-report://host:1/hbm")],
+        )
+        reporter.send(
+            EngineUpdate(
+                False,
+                upserts=tuple(BlockRecord(key, "hbm", (0,)) for key in range(3)),
+            )
+        )
+        self.assertEqual(2, len(client.reports))
+
+    def test_large_snapshot_clears_then_upserts_in_chunks(self) -> None:
+        client = FakeManagerClient()
+        reporter = KvcmEventReporter(
+            client,  # type: ignore[arg-type]
+            instance_id="instance",
+            host_ip_port="host:1",
+            max_events_per_request=2,
+            spec_factory=lambda block: [LocationSpec("group_0", "event-report://host:1/hbm")],
+        )
+        reporter.send(
+            EngineUpdate(
+                True,
+                blocks=tuple(BlockRecord(key, "hbm", (0,)) for key in range(3)),
+            )
+        )
+        self.assertEqual(3, len(client.reports))
+        first_events = client.reports[0]["events"]
+        assert isinstance(first_events, list)
+        self.assertEqual([], first_events[0]["block_snapshot"]["blocks"])
+
+
+class FlakySource:
+    def __init__(self) -> None:
+        self.attempts = 0
+        self.closed = False
+        self.initialized = False
+        self.on_commit = lambda: None
+
+    async def prepare(self) -> EngineUpdate:
+        self.attempts += 1
+        if self.attempts == 1:
+            raise RuntimeError("transient source failure")
+        return EngineUpdate(not self.initialized)
+
+    def commit(self, update: EngineUpdate) -> None:
+        self.initialized = True
+        self.on_commit()
+
+    def abort(self, update: EngineUpdate) -> None:
+        pass
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FailingSource(FlakySource):
+    async def prepare(self) -> EngineUpdate:
+        self.attempts += 1
+        raise RuntimeError("persistent source failure")
+
+
+class NotReadySource(FlakySource):
+    async def prepare(self) -> EngineUpdate:
+        self.attempts += 1
+        if self.attempts < 3:
+            raise SourceNotReady("waiting for sequence zero")
+        return EngineUpdate(not self.initialized)
+
+
+class IdleSource(FlakySource):
+    async def prepare(self) -> EngineUpdate:
+        self.attempts += 1
+        return EngineUpdate(not self.initialized)
+
+
+class FakeServiceReporter:
+    def __init__(self) -> None:
+        self.registrations = 0
+        self.host_down_reports = 0
+        self.heartbeats = 0
+        self.updates = 0
+
+    def register_node(self, mediums: tuple[str, ...]) -> None:
+        self.registrations += 1
+
+    def send(self, update: EngineUpdate) -> None:
+        self.updates += 1
+
+    def heartbeat(self) -> None:
+        self.heartbeats += 1
+
+    def host_down(self) -> None:
+        self.host_down_reports += 1
+
+
+class FlakyInitialSnapshotReporter(FakeServiceReporter):
+    def send(self, update: EngineUpdate) -> None:
+        super().send(update)
+        if self.updates == 1:
+            raise RuntimeError("reject first snapshot")
+
+
+class SubscriberServiceTest(unittest.IsolatedAsyncioTestCase):
+    async def test_source_not_ready_does_not_trip_failure_threshold(self) -> None:
+        source = NotReadySource()
+        reporter = FakeServiceReporter()
+        service = CacheEventSubscriberService(
+            source,
+            reporter,  # type: ignore[arg-type]
+            mediums=("hbm",),
+            poll_interval_s=0,
+            retry_interval_s=0,
+            heartbeat_interval_s=60,
+            source_failure_threshold=1,
+        )
+        source.on_commit = service.stop
+
+        await asyncio.wait_for(service.run(), timeout=1)
+
+        self.assertEqual(3, source.attempts)
+        self.assertEqual(1, reporter.registrations)
+        self.assertEqual(1, reporter.updates)
+        self.assertEqual(1, reporter.host_down_reports)
+        self.assertTrue(source.closed)
+
+    async def test_initial_snapshot_failure_unadvertises_before_retry(self) -> None:
+        source = IdleSource()
+        reporter = FlakyInitialSnapshotReporter()
+        service = CacheEventSubscriberService(
+            source,
+            reporter,  # type: ignore[arg-type]
+            mediums=("hbm",),
+            poll_interval_s=0,
+            retry_interval_s=0,
+            heartbeat_interval_s=60,
+        )
+        source.on_commit = service.stop
+
+        await asyncio.wait_for(service.run(), timeout=1)
+
+        self.assertEqual(1, source.attempts)
+        self.assertEqual(2, reporter.registrations)
+        self.assertEqual(2, reporter.updates)
+        # One report removes the rejected bootstrap registration; the second
+        # is the normal graceful shutdown after the committed retry.
+        self.assertEqual(2, reporter.host_down_reports)
+
+    async def test_transient_source_failure_is_retried(self) -> None:
+        source = FlakySource()
+        reporter = FakeServiceReporter()
+        service = CacheEventSubscriberService(
+            source,
+            reporter,  # type: ignore[arg-type]
+            mediums=("hbm",),
+            poll_interval_s=0,
+            retry_interval_s=0,
+            heartbeat_interval_s=60,
+        )
+        source.on_commit = service.stop
+
+        await asyncio.wait_for(service.run(), timeout=1)
+
+        self.assertEqual(2, source.attempts)
+        self.assertEqual(1, reporter.registrations)
+        self.assertEqual(1, reporter.host_down_reports)
+        self.assertTrue(source.closed)
+
+    async def test_persistent_source_failure_reports_down_and_exits(self) -> None:
+        source = FailingSource()
+        reporter = FakeServiceReporter()
+        service = CacheEventSubscriberService(
+            source,
+            reporter,  # type: ignore[arg-type]
+            mediums=("hbm",),
+            poll_interval_s=0,
+            retry_interval_s=0,
+            heartbeat_interval_s=60,
+            source_failure_threshold=2,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "failure threshold"):
+            await service.run()
+
+        self.assertEqual(2, source.attempts)
+        self.assertEqual(0, reporter.registrations)
+        self.assertEqual(0, reporter.host_down_reports)
+        self.assertTrue(source.closed)
+
+    async def test_failed_health_probe_stops_heartbeats_and_exits(self) -> None:
+        source = IdleSource()
+        reporter = FakeServiceReporter()
+        service = CacheEventSubscriberService(
+            source,
+            reporter,  # type: ignore[arg-type]
+            mediums=("hbm",),
+            poll_interval_s=0.001,
+            retry_interval_s=0,
+            heartbeat_interval_s=0.001,
+            health_probe=lambda: False,
+            health_failure_threshold=1,
+        )
+
+        # Health probes run through the default thread executor. Leave enough
+        # headroom for a loaded build host without weakening the service's
+        # millisecond-level failure threshold used by this test.
+        await asyncio.wait_for(service.run(), timeout=5)
+
+        self.assertEqual(0, reporter.heartbeats)
+        self.assertEqual(1, reporter.host_down_reports)
+        self.assertTrue(source.closed)
+
+
+class FakeVllmTransport:
+    def __init__(self, batches: list[list[tuple[int, bytes]]]) -> None:
+        self.batches = batches
+
+    async def next_sequences(self, expected_sequence: int) -> list[tuple[int, bytes]]:
+        return self.batches.pop(0)
+
+    async def close(self) -> None:
+        pass
+
+
+class Batch:
+    def __init__(self, events: list[object]) -> None:
+        self.events = events
+
+
+class BlockStored:
+    def __init__(self, key: int) -> None:
+        self.block_hashes = [key]
+        self.medium = "GPU"
+        self.group_idx = 0
+
+
+class BlockRemoved:
+    def __init__(self, key: int) -> None:
+        self.block_hashes = [key]
+        self.medium = "GPU"
+        self.group_idx = 0
+        self.remaining_copy_counts = [0]
+
+
+class AllBlocksCleared:
+    pass
+
+
+class VllmSourceTest(unittest.IsolatedAsyncioTestCase):
+    async def test_empty_publisher_waits_for_authoritative_baseline(self) -> None:
+        source = VllmCacheSource(
+            "pub",
+            "replay",
+            transport=FakeVllmTransport([[]]),
+            decoder=lambda payload: payload,
+        )
+
+        with self.assertRaises(SourceNotReady):
+            await source.prepare()
+
+    async def test_sequence_zero_builds_snapshot_then_delta(self) -> None:
+        decoded = {b"stored": Batch([BlockStored(11)]), b"removed": Batch([BlockRemoved(11)])}
+        source = VllmCacheSource(
+            "unused",
+            "unused",
+            transport=FakeVllmTransport([[(0, b"stored")], [(1, b"removed")]]),
+            decoder=decoded.__getitem__,
+        )
+        initial = await source.prepare()
+        self.assertTrue(initial.full_snapshot)
+        self.assertEqual((BlockRecord(11, "hbm", (0,)),), initial.blocks)
+        source.commit(initial)
+        delta = await source.prepare()
+        self.assertEqual((BlockRecord(11, "hbm", (0,)),), delta.removals)
+
+    async def test_pruned_cold_history_is_rejected(self) -> None:
+        source = VllmCacheSource(
+            "unused",
+            "unused",
+            transport=FakeVllmTransport([[(5, b"stored")]]),
+            decoder=lambda payload: Batch([BlockStored(11)]),
+        )
+        with self.assertRaises(VllmHistoryGap):
+            await source.prepare()
+
+    async def test_clear_marker_recovers_from_pruned_cold_history(self) -> None:
+        decoded = {
+            b"reset": Batch([AllBlocksCleared(), BlockStored(12)]),
+            b"delta": Batch([BlockStored(13)]),
+        }
+        source = VllmCacheSource(
+            "unused",
+            "unused",
+            transport=FakeVllmTransport([[(5, b"reset")], [(6, b"delta")]]),
+            decoder=decoded.__getitem__,
+        )
+
+        initial = await source.prepare()
+        self.assertTrue(initial.full_snapshot)
+        self.assertEqual((BlockRecord(12, "hbm", (0,)),), initial.blocks)
+        source.commit(initial)
+
+        delta = await source.prepare()
+        self.assertFalse(delta.full_snapshot)
+        self.assertEqual((BlockRecord(13, "hbm", (0,)),), delta.upserts)
+
+    async def test_idle_stream_emits_periodic_full_snapshot(self) -> None:
+        now = [0.0]
+        source = VllmCacheSource(
+            "unused",
+            "unused",
+            transport=FakeVllmTransport([[(0, b"stored")], []]),
+            decoder=lambda payload: Batch([BlockStored(14)]),
+            full_refresh_interval_s=10,
+            clock=lambda: now[0],
+        )
+        initial = await source.prepare()
+        source.commit(initial)
+        now[0] = 11
+
+        refresh = await source.prepare()
+
+        self.assertTrue(refresh.full_snapshot)
+        self.assertEqual((BlockRecord(14, "hbm", (0,)),), refresh.blocks)
+
+    async def test_block_size_mismatch_is_rejected(self) -> None:
+        stored = BlockStored(15)
+        stored.block_size = 32
+        source = VllmCacheSource(
+            "unused",
+            "unused",
+            transport=FakeVllmTransport([[(0, b"stored")]]),
+            decoder=lambda payload: Batch([stored]),
+            expected_block_size=16,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "block size"):
+            await source.prepare()
+
+    async def test_sequence_zero_resets_a_restarted_publisher(self) -> None:
+        decoded = {
+            b"old": Batch([BlockStored(16)]),
+            b"new": Batch([BlockStored(17)]),
+        }
+        source = VllmCacheSource(
+            "unused",
+            "unused",
+            transport=FakeVllmTransport([[(0, b"old")], [(0, b"new")]]),
+            decoder=decoded.__getitem__,
+        )
+        old = await source.prepare()
+        source.commit(old)
+
+        restarted = await source.prepare()
+
+        self.assertTrue(restarted.full_snapshot)
+        self.assertEqual((BlockRecord(17, "hbm", (0,)),), restarted.blocks)
+
+    async def test_removed_copy_counts_must_match_hashes(self) -> None:
+        removed = BlockRemoved(18)
+        removed.block_hashes.append(19)
+        source = VllmCacheSource(
+            "unused",
+            "unused",
+            transport=FakeVllmTransport([[(0, b"reset")]]),
+            decoder=lambda payload: Batch([AllBlocksCleared(), removed]),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "remaining_copy_counts length"):
+            await source.prepare()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/cache_event_subscriber/vllm_source.py
+++ b/kv_cache_manager/cache_event_subscriber/vllm_source.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .key_codec import to_signed_i64
+from .models import BlockRecord, EngineUpdate, SourceNotReady
+
+
+class VllmHistoryGap(RuntimeError):
+    """The bounded vLLM replay buffer cannot reconstruct authoritative state."""
+
+
+class VllmTransport(Protocol):
+    async def next_sequences(self, expected_sequence: int) -> list[tuple[int, bytes]]: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class _CommitToken:
+    cursor: int
+    blocks: dict[tuple[int, str], frozenset[int]]
+    full_snapshot: bool
+
+
+class VllmCacheSource:
+    """Transactional consumer for vLLM's sequenced MsgPack event stream."""
+
+    def __init__(
+        self,
+        pub_endpoint: str,
+        replay_endpoint: str,
+        *,
+        topic: str = "",
+        replay_timeout_s: float = 1.0,
+        full_refresh_interval_s: float = 300.0,
+        expected_block_size: int | None = None,
+        cache_group_count: int = 1,
+        transport: VllmTransport | None = None,
+        decoder: Callable[[bytes], Any] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if expected_block_size is not None and expected_block_size <= 0:
+            raise ValueError("expected_block_size must be positive")
+        if cache_group_count <= 0:
+            raise ValueError("cache_group_count must be positive")
+        self._transport = transport or _ZmqVllmTransport(
+            pub_endpoint, replay_endpoint, topic, replay_timeout_s
+        )
+        self._decoder = decoder or _MsgspecDecoder()
+        self._clock = clock
+        self._full_refresh_interval_s = full_refresh_interval_s
+        self._expected_block_size = expected_block_size
+        self._cache_group_count = cache_group_count
+        self._cursor = -1
+        self._blocks: dict[tuple[int, str], frozenset[int]] = {}
+        self._authoritative = False
+        self._next_full_refresh = 0.0
+        self._pending: _CommitToken | None = None
+
+    async def prepare(self) -> EngineUpdate:
+        if self._pending is not None:
+            raise RuntimeError("previous vLLM update has not been committed or aborted")
+        messages = await self._transport.next_sequences(self._cursor + 1)
+        if not messages:
+            if not self._authoritative:
+                raise SourceNotReady("vLLM has not provided an authoritative baseline")
+            full = self._clock() >= self._next_full_refresh
+            token = _CommitToken(self._cursor, self._blocks, full)
+            self._pending = token
+            if full:
+                return EngineUpdate(True, blocks=_records(self._blocks), commit_token=token)
+            return EngineUpdate(False, commit_token=token)
+        candidate = {key: set(groups) for key, groups in self._blocks.items()}
+        cursor = self._cursor
+        authoritative = self._authoritative
+        clear_seen = False
+        for sequence, payload in messages:
+            batch = self._decoder(payload)
+            has_clear = any(
+                getattr(event, "event_type", type(event).__name__)
+                == "AllBlocksCleared"
+                for event in batch.events
+            )
+            if sequence == 0 and cursor >= 0:
+                # vLLM sequence numbers are process-local. Seeing zero after a
+                # committed positive cursor is an explicit publisher epoch
+                # change, so the old process state must not survive.
+                candidate.clear()
+                authoritative = True
+                clear_seen = True
+                cursor = -1
+            if sequence != cursor + 1:
+                if not has_clear:
+                    raise VllmHistoryGap(
+                        f"vLLM replay gap: expected={cursor + 1}, got={sequence}"
+                    )
+                # AllBlocksCleared is an authoritative reset marker. It makes
+                # events before this sequence irrelevant, so recovery does not
+                # require the pruned replay prefix.
+                candidate.clear()
+                authoritative = True
+                cursor = sequence - 1
+            for event in batch.events:
+                event_name = getattr(event, "event_type", type(event).__name__)
+                if event_name == "AllBlocksCleared":
+                    candidate.clear()
+                    authoritative = True
+                    clear_seen = True
+                elif event_name == "BlockStored":
+                    block_size = getattr(event, "block_size", None)
+                    if (
+                        self._expected_block_size is not None
+                        and block_size is not None
+                        and int(block_size) != self._expected_block_size
+                    ):
+                        raise RuntimeError(
+                            "vLLM cache block size does not match KVCM registration: "
+                            f"configured={self._expected_block_size}, observed={block_size}"
+                        )
+                    medium = _medium(getattr(event, "medium", None))
+                    group = _group(
+                        getattr(event, "group_idx", None), self._cache_group_count
+                    )
+                    for block_hash in event.block_hashes:
+                        candidate.setdefault((to_signed_i64(block_hash), medium), set()).add(group)
+                elif event_name == "BlockRemoved":
+                    medium = _medium(getattr(event, "medium", None))
+                    group = _group(
+                        getattr(event, "group_idx", None), self._cache_group_count
+                    )
+                    counts = getattr(event, "remaining_copy_counts", None)
+                    if counts is not None and len(counts) != len(event.block_hashes):
+                        raise RuntimeError(
+                            "vLLM BlockRemoved remaining_copy_counts length does not "
+                            "match block_hashes"
+                        )
+                    for index, block_hash in enumerate(event.block_hashes):
+                        if counts is not None and index < len(counts) and counts[index] > 0:
+                            continue
+                        key = (to_signed_i64(block_hash), medium)
+                        groups = candidate.get(key)
+                        if groups is not None:
+                            groups.discard(group)
+                            if not groups:
+                                candidate.pop(key, None)
+                else:
+                    raise RuntimeError(f"unknown vLLM cache event: {event_name}")
+            cursor = sequence
+
+        # A sequence-zero replay is the only cold-start proof available from
+        # vLLM unless the stream explicitly resets all blocks.
+        if self._cursor == -1 and messages[0][0] == 0:
+            authoritative = True
+        if not authoritative:
+            raise VllmHistoryGap(
+                "vLLM replay history was pruned before an authoritative baseline"
+            )
+
+        frozen = {key: frozenset(groups) for key, groups in candidate.items()}
+        full = (
+            not self._authoritative
+            or clear_seen
+            or self._clock() >= self._next_full_refresh
+        )
+        token = _CommitToken(cursor, frozen, full)
+        self._pending = token
+        if full:
+            return EngineUpdate(
+                True,
+                blocks=_records(frozen),
+                commit_token=token,
+            )
+
+        changed = {key for key, groups in frozen.items() if self._blocks.get(key) != groups}
+        removed = set(self._blocks) - set(frozen)
+        return EngineUpdate(
+            False,
+            upserts=_records({key: frozen[key] for key in changed}),
+            removals=_records({key: self._blocks[key] for key in removed}),
+            commit_token=token,
+        )
+
+    def commit(self, update: EngineUpdate) -> None:
+        if update.commit_token is not self._pending:
+            raise RuntimeError("vLLM update is stale or belongs to another source")
+        token = self._pending
+        assert token is not None
+        self._cursor = token.cursor
+        self._blocks = token.blocks
+        self._authoritative = True
+        if token.full_snapshot:
+            self._next_full_refresh = self._clock() + self._full_refresh_interval_s
+        self._pending = None
+
+    def abort(self, update: EngineUpdate) -> None:
+        if update.commit_token is not self._pending:
+            raise RuntimeError("vLLM update is stale or belongs to another source")
+        self._pending = None
+
+    async def close(self) -> None:
+        await self._transport.close()
+
+
+def _records(blocks: dict[tuple[int, str], frozenset[int]]) -> tuple[BlockRecord, ...]:
+    return tuple(
+        BlockRecord(key, medium, tuple(sorted(groups)))
+        for (key, medium), groups in sorted(blocks.items())
+    )
+
+
+def _medium(value: str | None) -> str:
+    if value == "CPU":
+        return "mem"
+    if value in (None, "GPU"):
+        return "hbm"
+    raise RuntimeError(f"unsupported vLLM cache medium: {value!r}")
+
+
+def _group(value: int | None, cache_group_count: int) -> int:
+    group = 0 if value is None else int(value)
+    if group < 0 or group >= cache_group_count:
+        raise RuntimeError(f"unregistered vLLM cache group id: {group}")
+    return group
+
+
+class _MsgspecDecoder:
+    def __init__(self) -> None:
+        import msgspec
+
+        self._decoder = msgspec.msgpack.Decoder()
+
+    def __call__(self, payload: bytes) -> Any:
+        raw = self._decoder.decode(payload)
+        if not isinstance(raw, list) or len(raw) < 2 or not isinstance(raw[1], list):
+            raise ValueError("invalid vLLM KVEventBatch payload")
+        return _DecodedBatch([_DecodedEvent(event) for event in raw[1]])
+
+
+class _DecodedBatch:
+    def __init__(self, events: list["_DecodedEvent"]) -> None:
+        self.events = events
+
+
+class _DecodedEvent:
+    def __init__(self, data: Any) -> None:
+        if not isinstance(data, dict):
+            raise ValueError("invalid vLLM cache event payload")
+        event_type = data.get("type")
+        if not isinstance(event_type, str):
+            raise ValueError("vLLM cache event has no type tag")
+        self.event_type = event_type
+        for key, value in data.items():
+            if key != "type" and isinstance(key, str):
+                setattr(self, key, value)
+
+
+class _ZmqVllmTransport:
+    _END = (-1).to_bytes(8, "big", signed=True)
+
+    def __init__(
+        self, pub_endpoint: str, replay_endpoint: str, topic: str, timeout_s: float
+    ) -> None:
+        import zmq
+        import zmq.asyncio
+
+        self._zmq = zmq
+        self._timeout_s = timeout_s
+        context = zmq.asyncio.Context.instance()
+        self._sub = context.socket(zmq.SUB)
+        self._sub.connect(pub_endpoint)
+        self._sub.setsockopt_string(zmq.SUBSCRIBE, topic)
+        self._dealer = context.socket(zmq.DEALER)
+        self._dealer.connect(replay_endpoint)
+
+    async def next_sequences(self, expected_sequence: int) -> list[tuple[int, bytes]]:
+        while True:
+            try:
+                raw_frames = await asyncio.wait_for(
+                    self._sub.recv_multipart(), timeout=self._timeout_s
+                )
+            except asyncio.TimeoutError:
+                # A late subscriber may start after the publisher became
+                # idle. Ask the replay socket directly instead of waiting for
+                # a future live message to reveal the gap.
+                return await self._replay(expected_sequence, None)
+            frames = _payload_frames(raw_frames)
+            if len(frames) != 3 or len(frames[1]) != 8:
+                continue
+            live_sequence = int.from_bytes(frames[1], "big")
+            if live_sequence < expected_sequence:
+                if live_sequence == 0:
+                    return [(live_sequence, frames[2])]
+                continue
+            live = (live_sequence, frames[2])
+            if live_sequence == expected_sequence:
+                return [live]
+            replay = await self._replay(expected_sequence, live_sequence)
+            if not replay or replay[0][0] != expected_sequence:
+                # Let the source inspect the live batch: an AllBlocksCleared
+                # marker is sufficient to recover without the missing prefix.
+                return [live]
+            return replay + [live]
+
+    async def _replay(self, start: int, stop: int | None) -> list[tuple[int, bytes]]:
+        await self._dealer.send_multipart([b"", start.to_bytes(8, "big")])
+        result: list[tuple[int, bytes]] = []
+        while True:
+            frames = _payload_frames(
+                await asyncio.wait_for(
+                    self._dealer.recv_multipart(), timeout=self._timeout_s
+                )
+            )
+            if len(frames) != 3:
+                raise RuntimeError("malformed vLLM replay response")
+            if frames[1] == self._END:
+                return result
+            sequence = int.from_bytes(frames[1], "big")
+            if stop is not None and sequence >= stop:
+                continue
+            result.append((sequence, frames[2]))
+
+    async def close(self) -> None:
+        self._sub.close(linger=0)
+        self._dealer.close(linger=0)
+
+
+def _payload_frames(frames: list[bytes]) -> list[bytes]:
+    # DEALER sockets may retain the empty delimiter sent by vLLM's ROUTER.
+    return frames[1:] if len(frames) == 4 and frames[0] == b"" else frames

--- a/kv_cache_manager/config/BUILD
+++ b/kv_cache_manager/config/BUILD
@@ -52,18 +52,16 @@ cc_library(
 )
 
 cc_library(
-    name = "config",
+    name = "config_types",
     srcs = [
         "cache_config.cc",
         "cache_reclaim_strategy.cc",
         "data_storage_strategy.cc",
         "instance_group.cc",
         "instance_group_quota.cc",
-        "meta_cache_policy_config.cc",
         "meta_indexer_config.cc",
         "meta_storage_backend_config.cc",
         "quota_config.cc",
-        "registry_manager.cc",
         "trigger_strategy.cc",
     ],
     hdrs = [
@@ -73,21 +71,32 @@ cc_library(
         "data_storage_strategy.h",
         "instance_group.h",
         "instance_group_quota.h",
-        "meta_cache_policy_config.h",
         "meta_indexer_config.h",
         "meta_storage_backend_config.h",
         "quota_config.h",
-        "registry_manager.h",
         "trigger_strategy.h",
     ],
     deps = [
+        ":instance_info",
+        ":meta_cache_policy_config",
+        "//kv_cache_manager/common",
+        "//kv_cache_manager/data_storage:common_define",
+    ],
+)
+
+cc_library(
+    name = "config",
+    srcs = ["registry_manager.cc"],
+    hdrs = ["registry_manager.h"],
+    deps = [
+        ":config_types",
         ":instance_info",
         ":registry_backend",
         "//kv_cache_manager/common",
         "//kv_cache_manager/common:concurrent_hash_map",
         "//kv_cache_manager/common:redis_client",
         "//kv_cache_manager/data_storage",
-        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+        "//kv_cache_manager/protocol/protobuf:service_message_cc_proto",
     ],
 )
 

--- a/kv_cache_manager/config/test/BUILD
+++ b/kv_cache_manager/config/test/BUILD
@@ -78,8 +78,9 @@ cc_test(
     data = [],
     deps = [
         "//kv_cache_manager/common:unittest",
-        "//kv_cache_manager/config",
-        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+        "//kv_cache_manager/config:config_types",
+        "//kv_cache_manager/data_storage:common_define",
+        "//kv_cache_manager/protocol/protobuf:service_message_cc_proto",
         "//kv_cache_manager/service/util:manager_message_proto_util",
     ],
 )

--- a/kv_cache_manager/config/test/instance_group_test.cc
+++ b/kv_cache_manager/config/test/instance_group_test.cc
@@ -3,6 +3,7 @@
 #include "kv_cache_manager/config/cache_reclaim_strategy.h"
 #include "kv_cache_manager/config/instance_group.h"
 #include "kv_cache_manager/config/meta_indexer_config.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
 #include "kv_cache_manager/protocol/protobuf/admin_service.pb.h"
 #include "kv_cache_manager/service/util/manager_message_proto_util.h"
 
@@ -191,6 +192,30 @@ TEST_F(InstanceGroupTest, ProtoRoundTripWithoutBuckets) {
     ProtoConvert::InstanceGroupFromProto(&proto_msg, restored);
     EXPECT_TRUE(restored.revisit_interval_buckets_raw().empty());
     EXPECT_TRUE(restored.revisit_interval_buckets().empty());
+}
+
+TEST_F(InstanceGroupTest, EventReportStorageProtoRoundTrip) {
+    auto spec = std::make_shared<EventReportingStorageSpec>();
+    spec->set_heartbeat_timeout_ms(1000);
+    spec->set_cleanup_grace_ms(2000);
+    spec->set_liveness_check_interval_ms(100);
+    StorageConfig original(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, "event_report_01", spec);
+
+    proto::admin::StorageConfig proto_msg;
+    ProtoConvert::StorageConfigToProto(original, &proto_msg);
+    ASSERT_EQ(proto::admin::StorageConfig::kEventReport, proto_msg.storage_spec_case());
+    EXPECT_EQ(1000, proto_msg.event_report().heartbeat_timeout_ms());
+    EXPECT_EQ(2000, proto_msg.event_report().cleanup_grace_ms());
+    EXPECT_EQ(100, proto_msg.event_report().liveness_check_interval_ms());
+
+    StorageConfig restored;
+    ProtoConvert::StorageFromProto(&proto_msg, restored);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, restored.type());
+    auto restored_spec = std::dynamic_pointer_cast<EventReportingStorageSpec>(restored.storage_spec());
+    ASSERT_NE(nullptr, restored_spec);
+    EXPECT_EQ(1000, restored_spec->heartbeat_timeout_ms());
+    EXPECT_EQ(2000, restored_spec->cleanup_grace_ms());
+    EXPECT_EQ(100, restored_spec->liveness_check_interval_ms());
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/BUILD
+++ b/kv_cache_manager/data_storage/BUILD
@@ -8,17 +8,14 @@ cc_library(
         "hf3fs_backend.cc",
         "mooncake_backend.cc",
         "nfs_backend.cc",
-        "vineyard_backend.cc",
     ],
     hdrs = [
         "data_storage_backend.h",
         "data_storage_manager.h",
         "dummy_backend.h",
-        "event_reporting_backend.h",
         "hf3fs_backend.h",
         "mooncake_backend.h",
         "nfs_backend.h",
-        "vineyard_backend.h",
     ],
     deps = [
         # 不一定用
@@ -26,9 +23,28 @@ cc_library(
         "//3rdparty/mooncake:mooncake_client_c",
         "//kv_cache_manager/common/hash",  # for xxph3
         ":common_define",
+        ":event_reporting",
         # Internal implementations
         "//stub_source/kv_cache_manager/data_storage:vcns_hf3fs",
         "//stub_source/kv_cache_manager/data_storage:tair_mempool",
+    ],
+)
+
+cc_library(
+    name = "event_reporting",
+    srcs = [
+        "vineyard_backend.cc",
+    ],
+    hdrs = [
+        "event_report_backend.h",
+        "event_reporting_backend.h",
+        "vineyard_backend.h",
+    ],
+    deps = [
+        ":common_define",
+        "//kv_cache_manager/common:logger",
+        "//kv_cache_manager/metrics:metrics_collector",
+        "//kv_cache_manager/metrics:metrics_registry",
     ],
 )
 

--- a/kv_cache_manager/data_storage/data_storage_manager.cc
+++ b/kv_cache_manager/data_storage/data_storage_manager.cc
@@ -6,6 +6,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/data_storage/dummy_backend.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/data_storage/hf3fs_backend.h"
 #include "kv_cache_manager/data_storage/mooncake_backend.h"
 #include "kv_cache_manager/data_storage/nfs_backend.h"
@@ -175,6 +176,8 @@ std::shared_ptr<DataStorageBackend> DataStorageManager::CreateStorageBackend(con
         return std::make_shared<DummyBackend>(metrics_registry_);
     case DataStorageType::DATA_STORAGE_TYPE_VINEYARD:
         return std::make_shared<VineyardBackend>(metrics_registry_);
+    case DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT:
+        return std::make_shared<EventReportBackend>(metrics_registry_);
     default:
         return nullptr;
     }

--- a/kv_cache_manager/data_storage/event_report_backend.h
+++ b/kv_cache_manager/data_storage/event_report_backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "kv_cache_manager/data_storage/vineyard_backend.h"
+
+namespace kv_cache_manager {
+
+// Metadata-only backend for cache state owned by an inference engine. It
+// deliberately reuses the proven node liveness and generation fencing from
+// VineyardBackend, but exposes a distinct storage type and URI protocol so
+// clients never mistake engine-local blocks for Vineyard objects.
+class EventReportBackend final : public VineyardBackend {
+public:
+    explicit EventReportBackend(std::shared_ptr<MetricsRegistry> metrics_registry)
+        : VineyardBackend(std::move(metrics_registry),
+                          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT,
+                          "event-report",
+                          "kvs#event#",
+                          "event_report.") {}
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/event_reporting_backend.h
+++ b/kv_cache_manager/data_storage/event_reporting_backend.h
@@ -25,6 +25,7 @@ public:
                                   const std::string &host_ip_port,
                                   const std::map<std::string, std::string> &system_status) = 0;
     virtual void SetNodeUnavailable(const std::string &instance_id, const std::string &host_ip_port) = 0;
+    virtual bool IsNodeAvailable(const std::string &instance_id, const std::string &host_ip_port) const = 0;
     virtual uint64_t GetNodeGeneration(const std::string &instance_id, const std::string &host_ip_port) const = 0;
 
     virtual void SetCleanupCallback(CleanupCallback cb) = 0;

--- a/kv_cache_manager/data_storage/storage_config.cc
+++ b/kv_cache_manager/data_storage/storage_config.cc
@@ -163,6 +163,8 @@ std::string ToString(const DataStorageType &type) {
         return "dummy";
     case DataStorageType::DATA_STORAGE_TYPE_VINEYARD:
         return "vineyard";
+    case DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT:
+        return "event_report";
     default:
         return "unrecognized";
     }
@@ -183,6 +185,8 @@ DataStorageType ToDataStorageType(const std::string &type) {
         return DataStorageType::DATA_STORAGE_TYPE_DUMMY;
     } else if (type == "vineyard") {
         return DataStorageType::DATA_STORAGE_TYPE_VINEYARD;
+    } else if (type == "event_report") {
+        return DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT;
     } else {
         return DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
     }
@@ -351,8 +355,9 @@ bool StorageConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
         storage_spec_ = tmp;
     } else if (type_ == DataStorageType::DATA_STORAGE_TYPE_DUMMY) {
         auto tmp = std::make_shared<DummyStorageSpec>();
-    } else if (type_ == DataStorageType::DATA_STORAGE_TYPE_VINEYARD) {
-        auto tmp = std::make_shared<VineyardStorageSpec>();
+    } else if (type_ == DataStorageType::DATA_STORAGE_TYPE_VINEYARD ||
+               type_ == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT) {
+        auto tmp = std::make_shared<EventReportingStorageSpec>();
         KVCM_JSON_GET_MACRO(rapid_value, "storage_spec", tmp);
         storage_spec_ = tmp;
     } else {
@@ -388,8 +393,8 @@ bool StorageConfig::ValidateRequiredFields(std::string &invalid_fields) const {
     return valid;
 }
 
-// VineyardStorageSpec
-bool VineyardStorageSpec::FromRapidValue(const rapidjson::Value &rapid_value) {
+// EventReportingStorageSpec
+bool EventReportingStorageSpec::FromRapidValue(const rapidjson::Value &rapid_value) {
     KVCM_JSON_GET_DEFAULT_MACRO(
         rapid_value, "heartbeat_timeout_ms", heartbeat_timeout_ms_, static_cast<int64_t>(kDefaultHeartbeatTimeoutMs));
     KVCM_JSON_GET_DEFAULT_MACRO(
@@ -401,13 +406,13 @@ bool VineyardStorageSpec::FromRapidValue(const rapidjson::Value &rapid_value) {
     return true;
 }
 
-void VineyardStorageSpec::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
+void EventReportingStorageSpec::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
     Put(writer, "heartbeat_timeout_ms", heartbeat_timeout_ms_);
     Put(writer, "cleanup_grace_ms", cleanup_grace_ms_);
     Put(writer, "liveness_check_interval_ms", liveness_check_interval_ms_);
 }
 
-bool VineyardStorageSpec::ValidateRequiredFields(std::string &invalid_fields) const {
+bool EventReportingStorageSpec::ValidateRequiredFields(std::string &invalid_fields) const {
     bool valid = true;
     std::string local_invalid_fields;
     if (heartbeat_timeout_ms_ <= 0) {
@@ -423,12 +428,12 @@ bool VineyardStorageSpec::ValidateRequiredFields(std::string &invalid_fields) co
         local_invalid_fields += "{liveness_check_interval_ms}";
     }
     if (!valid) {
-        invalid_fields += "{VineyardStorageSpec: " + local_invalid_fields + "}";
+        invalid_fields += "{EventReportingStorageSpec: " + local_invalid_fields + "}";
     }
     return valid;
 }
 
-std::string VineyardStorageSpec::ToString() const {
+std::string EventReportingStorageSpec::ToString() const {
     std::ostringstream oss;
     oss << "heartbeat_timeout_ms: " << heartbeat_timeout_ms_ << ", cleanup_grace_ms: " << cleanup_grace_ms_
         << ", liveness_check_interval_ms: " << liveness_check_interval_ms_;

--- a/kv_cache_manager/data_storage/storage_config.h
+++ b/kv_cache_manager/data_storage/storage_config.h
@@ -17,6 +17,7 @@ enum class DataStorageType : uint8_t {
     DATA_STORAGE_TYPE_VCNS_HF3FS = 5,
     DATA_STORAGE_TYPE_DUMMY = 6,
     DATA_STORAGE_TYPE_VINEYARD = 7,
+    DATA_STORAGE_TYPE_EVENT_REPORT = 8,
     COUNT, // as sentinel, must be last
 };
 
@@ -25,6 +26,14 @@ std::string ToString(const DataStorageType &type);
 DataStorageType ToDataStorageType(const std::string &type);
 
 constexpr std::size_t ToIndex(const DataStorageType &type) noexcept { return static_cast<std::size_t>(type); }
+
+// Event-reporting storage records cache state owned by an inference engine.
+// KVCM may index and query these locations, but it must not allocate or reclaim
+// their capacity as if they were KVCM-managed storage.
+constexpr bool IsEventReportingStorageType(const DataStorageType type) noexcept {
+    return type == DataStorageType::DATA_STORAGE_TYPE_VINEYARD ||
+           type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT;
+}
 
 // help mapping sub storage type to base storage type
 // e.g., VCNS_HF3FS (sub) --> HF3FS (base)
@@ -198,7 +207,7 @@ private:
     int32_t key_count_per_file_ = 0;
 };
 
-class VineyardStorageSpec : public StorageSpec {
+class EventReportingStorageSpec : public StorageSpec {
 public:
     static constexpr int64_t kDefaultHeartbeatTimeoutMs = 30 * 1000;
     static constexpr int64_t kDefaultCleanupGraceMs = 5 * 60 * 1000;
@@ -222,6 +231,10 @@ private:
     int64_t cleanup_grace_ms_ = kDefaultCleanupGraceMs;
     int64_t liveness_check_interval_ms_ = kDefaultLivenessCheckIntervalMs;
 };
+
+// Keep the public Vineyard name source-compatible while sharing the generic
+// liveness configuration with other metadata-only event-reporting backends.
+using VineyardStorageSpec = EventReportingStorageSpec;
 
 class StorageConfig : public Jsonizable {
 public:

--- a/kv_cache_manager/data_storage/test/BUILD
+++ b/kv_cache_manager/data_storage/test/BUILD
@@ -61,7 +61,7 @@ cc_test(
     data = [],
     deps = [
         "//kv_cache_manager/common:unittest",
-        "//kv_cache_manager/data_storage",
+        "//kv_cache_manager/data_storage:common_define",
     ],
 )
 
@@ -78,3 +78,15 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "EventReportBackendTest",
+    srcs = [
+        "event_report_backend_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/data_storage:event_reporting",
+    ],
+)

--- a/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
+++ b/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
@@ -68,3 +68,16 @@ TEST_F(DataStorageManagerTest, TestSimple) {
     data_storage_backends = data_storage_manager.GetAvailableStorages();
     ASSERT_EQ(0, data_storage_backends.size());
 }
+
+TEST_F(DataStorageManagerTest, RegisterEventReportStorage) {
+    DataStorageManager data_storage_manager(metrics_registry_);
+    auto spec = std::make_shared<EventReportingStorageSpec>();
+    StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, "event_report_01", spec);
+    RequestContext request_context("event_report_test");
+
+    ASSERT_EQ(EC_OK, data_storage_manager.RegisterStorage(&request_context, "event_report_01", config));
+    auto backend = data_storage_manager.GetDataStorageBackend("event_report_01");
+    ASSERT_NE(nullptr, backend);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, backend->GetType());
+    EXPECT_EQ(EC_OK, data_storage_manager.UnRegisterStorage("event_report_01"));
+}

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/data_storage/data_storage_uri.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+using namespace kv_cache_manager;
+
+class EventReportBackendTest : public TESTBASE {
+public:
+    void SetUp() override { metrics_registry_ = std::make_shared<MetricsRegistry>(); }
+
+    StorageConfig MakeConfig() {
+        auto spec = std::make_shared<EventReportingStorageSpec>();
+        return StorageConfig(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, "event_report_test", std::move(spec));
+    }
+
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+};
+
+TEST_F(EventReportBackendTest, UsesDistinctMetadataOnlyIdentity) {
+    EventReportBackend backend(metrics_registry_);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, backend.GetType());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, backend.GetStorageType());
+    EXPECT_EQ("event-report", backend.GetProtocol());
+    EXPECT_EQ("kvs#event#hbm#10.0.0.1:8080", backend.BuildLocationId("hbm", "10.0.0.1:8080"));
+
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(), "event_report_test"));
+    ASSERT_EQ(EC_OK, backend.RegisterNode("instance", "10.0.0.1:8080", {"hbm"}));
+    EXPECT_TRUE(backend.IsNodeAvailable("instance", "10.0.0.1:8080"));
+
+    auto exists = backend.MightExist({DataStorageUri("event-report://10.0.0.1:8080/hbm")});
+    ASSERT_EQ(1u, exists.size());
+    EXPECT_TRUE(exists[0]);
+    EXPECT_EQ(EC_OK, backend.UnregisterNode("instance", "10.0.0.1:8080"));
+    EXPECT_FALSE(backend.IsNodeAvailable("instance", "10.0.0.1:8080"));
+    EXPECT_EQ(EC_OK, backend.Close());
+}

--- a/kv_cache_manager/data_storage/test/storage_config_test.cc
+++ b/kv_cache_manager/data_storage/test/storage_config_test.cc
@@ -51,6 +51,26 @@ TEST_F(StorageConfigTest, TestStorageConfigJsonizeNfs) {
     EXPECT_EQ(nfs_spec2.key_count_per_file(), nfs_spec.key_count_per_file());
 }
 
+TEST_F(StorageConfigTest, TestStorageConfigJsonizeEventReport) {
+    auto spec = std::make_shared<EventReportingStorageSpec>();
+    spec->set_heartbeat_timeout_ms(1000);
+    spec->set_cleanup_grace_ms(2000);
+    spec->set_liveness_check_interval_ms(100);
+    StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, "event_report_01", spec);
+
+    const std::string json = config.ToJsonString();
+    EXPECT_NE(json.find("\"type\":\"event_report\""), std::string::npos);
+
+    StorageConfig parsed;
+    ASSERT_TRUE(parsed.FromJsonString(json));
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, parsed.type());
+    auto parsed_spec = std::dynamic_pointer_cast<EventReportingStorageSpec>(parsed.storage_spec());
+    ASSERT_TRUE(parsed_spec);
+    EXPECT_EQ(1000, parsed_spec->heartbeat_timeout_ms());
+    EXPECT_EQ(2000, parsed_spec->cleanup_grace_ms());
+    EXPECT_EQ(100, parsed_spec->liveness_check_interval_ms());
+}
+
 TEST_F(StorageConfigTest, TestTairMemPoolStorageSpecParseNewSchema) {
     // 新版 schema：直接用 service_discovery_url，不带任何老字段。
     const std::string json =
@@ -85,9 +105,8 @@ TEST_F(StorageConfigTest, TestTairMemPoolStorageSpecLegacyEnableFalseDoesNotMigr
 
 TEST_F(StorageConfigTest, TestTairMemPoolStorageSpecNewSchemaTakesPrecedenceOverLegacy) {
     // 同时有 service_discovery_url 与老字段时，以 service_discovery_url 为准。
-    const std::string json =
-        R"({"domain":"pace.meta","timeout":5000,"service_discovery_url":"spectrum://v-yy",)"
-        R"("enable_vipserver":true,"vipserver_domain":"pace.meta.vipserver"})";
+    const std::string json = R"({"domain":"pace.meta","timeout":5000,"service_discovery_url":"spectrum://v-yy",)"
+                             R"("enable_vipserver":true,"vipserver_domain":"pace.meta.vipserver"})";
     TairMemPoolStorageSpec spec;
     ASSERT_TRUE(spec.FromJsonString(json));
     EXPECT_EQ(spec.service_discovery_url(), "spectrum://v-yy");

--- a/kv_cache_manager/data_storage/vineyard_backend.cc
+++ b/kv_cache_manager/data_storage/vineyard_backend.cc
@@ -20,7 +20,19 @@
 namespace kv_cache_manager {
 
 VineyardBackend::VineyardBackend(std::shared_ptr<MetricsRegistry> metrics_registry)
-    : DataStorageBackend(std::move(metrics_registry)) {}
+    : VineyardBackend(
+          std::move(metrics_registry), DataStorageType::DATA_STORAGE_TYPE_VINEYARD, "vineyard", "kvs#v6d#", "v6d.") {}
+
+VineyardBackend::VineyardBackend(std::shared_ptr<MetricsRegistry> metrics_registry,
+                                 DataStorageType storage_type,
+                                 std::string protocol,
+                                 std::string location_id_prefix,
+                                 std::string metrics_prefix)
+    : DataStorageBackend(std::move(metrics_registry))
+    , storage_type_(storage_type)
+    , protocol_(std::move(protocol))
+    , location_id_prefix_(std::move(location_id_prefix))
+    , metrics_prefix_(std::move(metrics_prefix)) {}
 
 VineyardBackend::~VineyardBackend() {
     if (IsOpen()) {
@@ -28,14 +40,14 @@ VineyardBackend::~VineyardBackend() {
     }
 }
 
-DataStorageType VineyardBackend::GetType() { return DataStorageType::DATA_STORAGE_TYPE_VINEYARD; }
+DataStorageType VineyardBackend::GetType() { return storage_type_; }
 
 bool VineyardBackend::Available() { return IsOpen(); }
 
 double VineyardBackend::GetStorageUsageRatio(const std::string & /*trace_id*/) const { return 1.0; }
 
 ErrorCode VineyardBackend::DoOpen(const StorageConfig &config, const std::string &trace_id) {
-    auto spec = std::dynamic_pointer_cast<VineyardStorageSpec>(config.storage_spec());
+    auto spec = std::dynamic_pointer_cast<EventReportingStorageSpec>(config.storage_spec());
     if (!spec) {
         KVCM_LOG_WARN("trace_id [%s] | VineyardBackend::DoOpen: unexpected config type, storage config: [%s]",
                       trace_id.c_str(),
@@ -157,7 +169,7 @@ ErrorCode VineyardBackend::UnregisterNode(const std::string &instance_id, const 
     if (metrics_registry_) {
         auto &info = *it->second;
         for (const auto &kv : info.last_system_status) {
-            auto data = metrics_registry_->GetMetricsData("v6d." + kv.first);
+            auto data = metrics_registry_->GetMetricsData(metrics_prefix_ + kv.first);
             if (data) {
                 data->RemoveByTags(info.metrics_tags);
             }
@@ -214,7 +226,7 @@ ErrorCode VineyardBackend::OnHeartbeat(const std::string &instance_id,
             char *end = nullptr;
             double val = std::strtod(s.c_str(), &end);
             if (end == s.c_str() + s.size()) {
-                REPORT_DYNAMIC_GAUGE_(metrics_registry_, "v6d." + kv.first, tags, val);
+                REPORT_DYNAMIC_GAUGE_(metrics_registry_, metrics_prefix_ + kv.first, tags, val);
             }
         }
     }
@@ -245,7 +257,7 @@ void VineyardBackend::ClearNodeGauges(const NodeInfo &info) {
     }
     std::lock_guard<std::mutex> status_lock(info.status_mutex);
     for (const auto &kv : info.last_system_status) {
-        auto data = metrics_registry_->GetMetricsData("v6d." + kv.first);
+        auto data = metrics_registry_->GetMetricsData(metrics_prefix_ + kv.first);
         if (data) {
             auto gauge = data->GetGauge(info.metrics_tags);
             if (gauge) {
@@ -349,10 +361,11 @@ void VineyardBackend::LivenessCheckerLoop() {
                     cb_copy(entry.instance_id, entry.host, entry.gen);
                 }
                 uint64_t current_gen = GetNodeGeneration(entry.instance_id, entry.host);
-                if (current_gen == entry.gen) {
+                if (current_gen == entry.gen && !IsNodeAvailable(entry.instance_id, entry.host)) {
                     UnregisterNode(entry.instance_id, entry.host);
                 } else {
-                    KVCM_LOG_INFO("VineyardBackend: node [%s] re-registered (gen=%lu -> %lu), skipping unregister",
+                    KVCM_LOG_INFO("VineyardBackend: node [%s] recovered or re-registered "
+                                  "(gen=%lu -> %lu), skipping unregister",
                                   entry.host.c_str(),
                                   entry.gen,
                                   current_gen);
@@ -420,8 +433,8 @@ std::vector<ErrorCode> VineyardBackend::UnLock(const std::vector<DataStorageUri>
 
 std::string VineyardBackend::BuildLocationId(const std::string &medium, const std::string &host_ip_port) const {
     std::string id;
-    id.reserve(8 + medium.size() + 1 + host_ip_port.size());
-    id.append("kvs#v6d#");
+    id.reserve(location_id_prefix_.size() + medium.size() + 1 + host_ip_port.size());
+    id.append(location_id_prefix_);
     id.append(medium);
     id.push_back('#');
     id.append(host_ip_port);
@@ -430,8 +443,8 @@ std::string VineyardBackend::BuildLocationId(const std::string &medium, const st
 
 std::string VineyardBackend::HostSuffix(const std::string &host_ip_port) const { return "#" + host_ip_port; }
 
-DataStorageType VineyardBackend::GetStorageType() const { return DataStorageType::DATA_STORAGE_TYPE_VINEYARD; }
+DataStorageType VineyardBackend::GetStorageType() const { return storage_type_; }
 
-std::string VineyardBackend::GetProtocol() const { return "vineyard"; }
+std::string VineyardBackend::GetProtocol() const { return protocol_; }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/vineyard_backend.h
+++ b/kv_cache_manager/data_storage/vineyard_backend.h
@@ -45,7 +45,7 @@ public:
                           const std::string &host_ip_port,
                           const std::map<std::string, std::string> &system_status) override;
     void SetNodeUnavailable(const std::string &instance_id, const std::string &host_ip_port) override;
-    bool IsNodeAvailable(const std::string &instance_id, const std::string &host_ip_port) const;
+    bool IsNodeAvailable(const std::string &instance_id, const std::string &host_ip_port) const override;
 
     uint64_t GetNodeGeneration(const std::string &instance_id, const std::string &host_ip_port) const override;
 
@@ -68,6 +68,13 @@ public:
     std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &storage_uris) override;
     std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &storage_uris) override;
 
+protected:
+    VineyardBackend(std::shared_ptr<MetricsRegistry> metrics_registry,
+                    DataStorageType storage_type,
+                    std::string protocol,
+                    std::string location_id_prefix,
+                    std::string metrics_prefix);
+
 private:
     void LivenessCheckerLoop();
 
@@ -88,7 +95,11 @@ private:
         MetricsTags metrics_tags;
     };
 
-    VineyardStorageSpec spec_;
+    EventReportingStorageSpec spec_;
+    DataStorageType storage_type_;
+    std::string protocol_;
+    std::string location_id_prefix_;
+    std::string metrics_prefix_;
 
     mutable std::shared_mutex nodes_mutex_;
     // instance_id -> (host_ip_port -> NodeInfo)
@@ -100,9 +111,9 @@ private:
     std::thread liveness_checker_thread_;
     std::atomic<bool> liveness_checker_running_{false};
 
-    int64_t heartbeat_timeout_ms_ = VineyardStorageSpec::kDefaultHeartbeatTimeoutMs;
-    int64_t cleanup_grace_ms_ = VineyardStorageSpec::kDefaultCleanupGraceMs;
-    int64_t liveness_check_interval_ms_ = VineyardStorageSpec::kDefaultLivenessCheckIntervalMs;
+    int64_t heartbeat_timeout_ms_ = EventReportingStorageSpec::kDefaultHeartbeatTimeoutMs;
+    int64_t cleanup_grace_ms_ = EventReportingStorageSpec::kDefaultCleanupGraceMs;
+    int64_t liveness_check_interval_ms_ = EventReportingStorageSpec::kDefaultLivenessCheckIntervalMs;
 
     void ClearNodeGauges(const NodeInfo &info);
 

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1407,7 +1407,9 @@ ErrorCode CacheManager::GenWriteLocation(RequestContext *request_context,
 namespace {
 
 std::shared_ptr<DataStorageBackend>
-LookupEventReportingBackend(const std::shared_ptr<RegistryManager> &registry_manager, const std::string &instance_id) {
+LookupEventReportingBackend(const std::shared_ptr<RegistryManager> &registry_manager,
+                            const std::string &instance_id,
+                            DataStorageType requested_type) {
     if (!registry_manager || !registry_manager->data_storage_manager()) {
         return nullptr;
     }
@@ -1420,12 +1422,14 @@ LookupEventReportingBackend(const std::shared_ptr<RegistryManager> &registry_man
         return nullptr;
     }
     auto dsm = registry_manager->data_storage_manager();
-    const auto &candidate_name = ig->event_reporting_storage_candidates().front();
-    auto backend = dsm->GetDataStorageBackend(candidate_name);
-    if (!backend || !dynamic_cast<EventReportingBackend *>(backend.get())) {
-        return nullptr;
+    for (const auto &candidate_name : ig->event_reporting_storage_candidates()) {
+        auto backend = dsm->GetDataStorageBackend(candidate_name);
+        auto *event_backend = dynamic_cast<EventReportingBackend *>(backend.get());
+        if (event_backend && event_backend->GetStorageType() == requested_type) {
+            return backend;
+        }
     }
-    return backend;
+    return nullptr;
 }
 
 bool ParseInt64(const std::string &s, int64_t &out) {
@@ -1462,6 +1466,11 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         return EC_OK;
     }
 
+    // Snapshot replacement, incremental mutations and asynchronous cleanup
+    // must not interleave for the same engine node. Hash striping keeps the
+    // lock set bounded while allowing unrelated hosts to progress in parallel.
+    std::unique_lock<std::mutex> event_lock(GetEventReportMutex(instance_id, host_ip_port));
+
     DataStorageType requested_type = static_cast<DataStorageType>(request->storage_type());
     if (requested_type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN) {
         KVCM_LOG_WARN("trace_id [%s] | ReportEvent: storage_type is required but not specified", trace_id.c_str());
@@ -1469,8 +1478,16 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         response_status->set_message("storage_type is required");
         return EC_BADARGS;
     }
+    if (!IsEventReportingStorageType(requested_type)) {
+        KVCM_LOG_WARN("trace_id [%s] | ReportEvent: storage_type [%d] is not event-reporting storage",
+                      trace_id.c_str(),
+                      static_cast<int>(requested_type));
+        response_status->set_code(proto::meta::INVALID_ARGUMENT);
+        response_status->set_message("storage_type is not event-reporting storage");
+        return EC_BADARGS;
+    }
 
-    auto event_backend_holder = LookupEventReportingBackend(registry_manager_, instance_id);
+    auto event_backend_holder = LookupEventReportingBackend(registry_manager_, instance_id, requested_type);
     auto *event_backend = dynamic_cast<EventReportingBackend *>(event_backend_holder.get());
     if (!event_backend) {
         KVCM_LOG_WARN("trace_id [%s] | ReportEvent: EventReportingBackend not found for instance [%s] type [%d]",
@@ -1534,6 +1551,8 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     };
     std::map<int64_t, std::vector<BlockAddEntry>> block_to_add;
     std::map<int64_t, std::vector<BlockDelEntry>> block_to_del;
+    std::map<int64_t, std::vector<BlockAddEntry>> snapshot_to_add;
+    int snapshot_event_index = -1;
 
     for (int i = 0; i < events_size; ++i) {
         const auto &item = request->events(i);
@@ -1592,7 +1611,17 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             std::vector<LocationSpec> entry_specs;
             entry_specs.reserve(p.specs_size());
             for (const auto &s : p.specs()) {
+                if (s.name().empty() || s.uri().empty()) {
+                    entry_specs.clear();
+                    break;
+                }
                 entry_specs.emplace_back(s.name(), s.uri());
+            }
+            if (entry_specs.empty()) {
+                KVCM_LOG_WARN(
+                    "trace_id [%s] | EVENT_BLOCK_ADD: invalid specs for block_key [%ld]", trace_id.c_str(), block_key);
+                per_item_ec[i] = EC_BADARGS;
+                break;
             }
             block_to_add[block_key].push_back(BlockAddEntry{std::move(location_id), std::move(entry_specs), i});
             break;
@@ -1622,6 +1651,45 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 BlockDelEntry{event_backend->BuildLocationId(p.medium(), host_ip_port), i});
             break;
         }
+        case proto::meta::EVENT_BLOCK_SNAPSHOT: {
+            if (snapshot_event_index >= 0 || !item.has_block_snapshot()) {
+                per_item_ec[i] = EC_BADARGS;
+                if (snapshot_event_index >= 0) {
+                    per_item_ec[snapshot_event_index] = EC_BADARGS;
+                }
+                break;
+            }
+            snapshot_event_index = i;
+            std::map<int64_t, std::vector<BlockAddEntry>> parsed_snapshot;
+            bool valid_snapshot = true;
+            for (const auto &block : item.block_snapshot().blocks()) {
+                int64_t block_key = 0;
+                if (!ParseInt64(block.block_key(), block_key) || block.medium().empty() || block.specs_size() == 0) {
+                    valid_snapshot = false;
+                    break;
+                }
+                std::vector<LocationSpec> entry_specs;
+                entry_specs.reserve(block.specs_size());
+                for (const auto &spec : block.specs()) {
+                    if (spec.name().empty() || spec.uri().empty()) {
+                        valid_snapshot = false;
+                        break;
+                    }
+                    entry_specs.emplace_back(spec.name(), spec.uri());
+                }
+                if (!valid_snapshot) {
+                    break;
+                }
+                parsed_snapshot[block_key].push_back(BlockAddEntry{
+                    event_backend->BuildLocationId(block.medium(), host_ip_port), std::move(entry_specs), i});
+            }
+            if (!valid_snapshot) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            snapshot_to_add = std::move(parsed_snapshot);
+            break;
+        }
         default:
             KVCM_LOG_WARN("trace_id [%s] | ReportEvent: unknown event_type %d at index %d (ignored)",
                           trace_id.c_str(),
@@ -1630,6 +1698,23 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             per_item_ec[i] = EC_BADARGS;
             break;
         }
+    }
+
+    if (snapshot_event_index >= 0 && (has_host_down || !block_to_add.empty() || !block_to_del.empty())) {
+        KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT cannot be mixed with block mutations or HOST_DOWN",
+                      trace_id.c_str());
+        for (int i = 0; i < events_size; ++i) {
+            const auto event_type = request->events(i).event_type();
+            if (event_type == proto::meta::EVENT_BLOCK_SNAPSHOT || event_type == proto::meta::EVENT_BLOCK_ADD ||
+                event_type == proto::meta::EVENT_BLOCK_DELETE || event_type == proto::meta::EVENT_HOST_DOWN) {
+                per_item_ec[i] = EC_BADARGS;
+            }
+        }
+        // Validation happens before any cache mutation. Do not partially apply
+        // the non-snapshot half of an invalid mixed request.
+        block_to_add.clear();
+        block_to_del.clear();
+        has_host_down = false;
     }
 
     if (has_register) {
@@ -1657,6 +1742,45 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                     per_item_ec[i] = hb_ec;
                 }
             }
+        }
+    }
+
+    if ((!block_to_add.empty() || !block_to_del.empty() || snapshot_event_index >= 0) &&
+        !event_backend->IsNodeAvailable(instance_id, host_ip_port)) {
+        KVCM_LOG_WARN("trace_id [%s] | cache mutation from unregistered or unavailable host [%s]",
+                      trace_id.c_str(),
+                      host_ip_port.c_str());
+        for (int i = 0; i < events_size; ++i) {
+            const auto event_type = request->events(i).event_type();
+            if (event_type == proto::meta::EVENT_BLOCK_SNAPSHOT || event_type == proto::meta::EVENT_BLOCK_ADD ||
+                event_type == proto::meta::EVENT_BLOCK_DELETE) {
+                if (per_item_ec[i] != EC_OK) {
+                    continue;
+                }
+                per_item_ec[i] = EC_NODE_NOT_REGISTERED;
+            }
+        }
+        block_to_add.clear();
+        block_to_del.clear();
+    }
+
+    if (snapshot_event_index >= 0 && per_item_ec[snapshot_event_index] == EC_OK) {
+        const uint64_t snapshot_generation = event_backend->GetNodeGeneration(instance_id, host_ip_port);
+        const std::string host_suffix = event_backend->HostSuffix(host_ip_port);
+        auto abort_if_reregistered = [event_backend_holder, instance_id, host_ip_port, snapshot_generation]() -> bool {
+            auto *backend = dynamic_cast<EventReportingBackend *>(event_backend_holder.get());
+            return backend && backend->GetNodeGeneration(instance_id, host_ip_port) != snapshot_generation;
+        };
+        auto snapshot_ec = meta_searcher->CleanupLocationsByHost(
+            request_context, host_suffix, requested_type, /*scan_batch_size=*/1000, abort_if_reregistered);
+        if (snapshot_ec != EC_OK) {
+            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT cleanup failed for host [%s], ec=%d",
+                          trace_id.c_str(),
+                          host_ip_port.c_str(),
+                          snapshot_ec);
+            per_item_ec[snapshot_event_index] = snapshot_ec;
+        } else {
+            block_to_add = std::move(snapshot_to_add);
         }
     }
 
@@ -1795,6 +1919,8 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 mapped = proto::meta::INVALID_ARGUMENT;
             } else if (ec == EC_INSTANCE_NOT_EXIST) {
                 mapped = proto::meta::INSTANCE_NOT_EXIST;
+            } else if (ec == EC_NODE_NOT_REGISTERED) {
+                mapped = proto::meta::NODE_NOT_REGISTERED;
             } else {
                 mapped = proto::meta::INTERNAL_ERROR;
             }
@@ -1812,7 +1938,8 @@ void CacheManager::CleanupHostLocations(const std::string &instance_id,
                                         const std::string &host_ip_port,
                                         uint64_t cleanup_generation,
                                         DataStorageType storage_type) {
-    auto event_backend_holder = LookupEventReportingBackend(registry_manager_, instance_id);
+    std::unique_lock<std::mutex> event_lock(GetEventReportMutex(instance_id, host_ip_port));
+    auto event_backend_holder = LookupEventReportingBackend(registry_manager_, instance_id, storage_type);
     auto *event_backend = dynamic_cast<EventReportingBackend *>(event_backend_holder.get());
 
     if (event_backend) {
@@ -1824,6 +1951,12 @@ void CacheManager::CleanupHostLocations(const std::string &instance_id,
                           instance_id.c_str(),
                           cleanup_generation,
                           current_gen);
+            return;
+        }
+        if (event_backend->IsNodeAvailable(instance_id, host_ip_port)) {
+            KVCM_LOG_INFO("CleanupHostLocations: skipping cleanup for recovered host [%s] instance [%s]",
+                          host_ip_port.c_str(),
+                          instance_id.c_str());
             return;
         }
     }
@@ -1857,6 +1990,14 @@ void CacheManager::CleanupHostLocations(const std::string &instance_id,
                       host_ip_port.c_str(),
                       instance_id.c_str());
     }
+}
+
+std::mutex &CacheManager::GetEventReportMutex(const std::string &instance_id, const std::string &host_ip_port) {
+    const size_t instance_hash = std::hash<std::string>{}(instance_id);
+    const size_t host_hash = std::hash<std::string>{}(host_ip_port);
+    const size_t shard = (instance_hash ^ (host_hash + 0x9e3779b9U + (instance_hash << 6U) + (instance_hash >> 2U))) %
+                         event_report_mutexes_.size();
+    return event_report_mutexes_[shard];
 }
 
 ErrorCode CacheManager::TryCreateMetaSearcher(RequestContext *request_context, const std::string &instance_id) {
@@ -2210,13 +2351,25 @@ CheckLocDataExistFunc CacheManager::GetCheckLocDataExistFunc(const std::string &
         }
 
         std::string storage_unique_name = storage_uris.front().GetHostName();
-        auto erb_holder = LookupEventReportingBackend(registry_manager_, instance_id);
+        auto erb_holder = LookupEventReportingBackend(registry_manager_, instance_id, loc.type());
         auto *erb = dynamic_cast<EventReportingBackend *>(erb_holder.get());
-        if (erb && loc.type() == erb->GetStorageType()) {
-            auto ig = registry_manager_->GetInstanceGroupConfig(registry_manager_->GetInstanceGroupName(instance_id));
-            if (ig && !ig->event_reporting_storage_candidates().empty()) {
-                storage_unique_name = ig->event_reporting_storage_candidates().front();
+        if (erb && loc.type() == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT) {
+            if (storage_uris.size() != loc.location_specs().size()) {
+                return false;
             }
+            return std::all_of(storage_uris.cbegin(), storage_uris.cend(), [&](const DataStorageUri &uri) {
+                if (uri.GetHostName().empty()) {
+                    return false;
+                }
+                std::string host_ip_port = uri.GetHostName();
+                if (uri.GetPort() > 0) {
+                    host_ip_port += ":" + std::to_string(uri.GetPort());
+                }
+                return erb->IsNodeAvailable(instance_id, host_ip_port);
+            });
+        }
+        if (erb && loc.type() == erb->GetStorageType()) {
+            storage_unique_name = erb_holder->GetStorageConfig().global_unique_name();
         }
         const auto result = registry_manager_->data_storage_manager()->Exist(storage_unique_name, storage_uris, true);
         return std::all_of(result.cbegin(), result.cend(), [](bool v) { return v; });

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -246,6 +248,7 @@ private:
                               const std::string &host_ip_port,
                               uint64_t cleanup_generation,
                               DataStorageType storage_type);
+    std::mutex &GetEventReportMutex(const std::string &instance_id, const std::string &host_ip_port);
     ErrorCode GetCacheLocationByQueryType(MetaSearcher *meta_searcher,
                                           RequestContext *request_context,
                                           const std::string &instance_id,
@@ -310,6 +313,8 @@ private:
     std::shared_ptr<CacheManagerMetricsRecorder> metrics_recorder_;
     // 无需清理
     OnInstanceRemovedFn on_instance_removed_;
+    // 无需清理 - 仅用于串行化同一 instance + host 的快照、增量和清理操作。
+    std::array<std::mutex, 64> event_report_mutexes_;
     // 需要清理 - recover 重试线程相关，在DoCleanup()中StopRecoverRetryLoop()
     std::thread recover_retry_thread_;
     std::atomic<bool> recover_retry_stop_{false};

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -1382,6 +1382,12 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
             }
             ++valid_location_count;
             const auto &loc = *loc_ptr;
+            // Event-reported locations are owned and evicted by the inference
+            // engine. They still count as live replicas when deciding whether
+            // deleting the selected KVCM-managed locations removes the key.
+            if (IsEventReportingStorageType(loc.type())) {
+                continue;
+            }
             // a location is eligible for eviction if:
             // 1. it is in CLS_SERVING status, OR
             // 2. it is in CLS_WRITING status but its write session is
@@ -1656,7 +1662,7 @@ std::shared_ptr<CacheReclaimer::GroupUsageData> CacheReclaimer::GetGroupUsageDat
 
         for (std::size_t idx = 1; idx < static_cast<std::size_t>(DataStorageType::COUNT); ++idx) {
             const auto type = static_cast<DataStorageType>(idx);
-            if (type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS) {
+            if (type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS || IsEventReportingStorageType(type)) {
                 continue;
             }
             data->AddGroupUsageByType(type, meta_indexer->GetStorageUsageByType(type));

--- a/kv_cache_manager/manager/data_storage_selector.cc
+++ b/kv_cache_manager/manager/data_storage_selector.cc
@@ -52,6 +52,8 @@ private:
     // slot 4: DATA_STORAGE_TYPE_NFS exceed availability flag
     // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
     // slot 6: DATA_STORAGE_TYPE_DUMMY availability flag (testing only)
+    // slots 7-8: event-reporting backends are metadata-only and deliberately
+    // remain false so they can never be selected for cache writes.
     array_t_ storage_quota_avail_by_type_;
 };
 

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -47,7 +47,7 @@ CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
             continue;
         }
         if (check_loc_data_exist && !check_loc_data_exist(*loc_ptr)) {
-            if (loc_ptr->type() != DataStorageType::DATA_STORAGE_TYPE_VINEYARD) {
+            if (!IsEventReportingStorageType(loc_ptr->type())) {
                 out_prune_loc_ids.push_back(id);
             }
             continue;
@@ -185,7 +185,7 @@ CacheLocationMap FilterValidLocations(const CacheLocationMap &location_map,
         if (loc->status() != CacheLocationStatus::CLS_SERVING)
             continue;
         if (check_loc_data_exist && !check_loc_data_exist(*loc)) {
-            if (loc->type() != DataStorageType::DATA_STORAGE_TYPE_VINEYARD) {
+            if (!IsEventReportingStorageType(loc->type())) {
                 out_prune_loc_ids.push_back(id);
             }
             continue;
@@ -415,7 +415,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
     for (const auto &selector : selectors) {
         DataStorageType target_type = selector.backend_type;
 
-        if (target_type == DataStorageType::DATA_STORAGE_TYPE_VINEYARD &&
+        if (IsEventReportingStorageType(target_type) &&
             (selector.strategy == LocationSelectStrategy::LSS_V6D_PREFIX ||
              selector.strategy == LocationSelectStrategy::LSS_V6D_COVERAGE)) {
             // --- V6D cross-key selection ---
@@ -436,7 +436,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 std::vector<std::string> vineyard_addrs;
 
                 for (const auto &[id, loc] : vmap) {
-                    if (loc->type() != DataStorageType::DATA_STORAGE_TYPE_VINEYARD)
+                    if (loc->type() != target_type)
                         continue;
                     std::string addr = ExtractPeerAddrFromLocation(*loc);
                     if (addr.empty())
@@ -1200,7 +1200,11 @@ ErrorCode MetaSearcher::CleanupLocationsByHost(RequestContext *request_context,
     do {
         if (should_abort && should_abort()) {
             KVCM_LOG_INFO("CleanupLocationsByHost: aborted by caller (host_suffix=%s)", host_suffix.c_str());
-            return EC_OK;
+            // The caller must not treat an incomplete cleanup as an
+            // authoritative replacement. EC_MISMATCH is retryable by the
+            // cache-event subscriber and also distinguishes this path from a
+            // fully completed no-op cleanup.
+            return EC_MISMATCH;
         }
         std::string next_cursor;
         KeyVector keys;

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -120,6 +120,8 @@ public:
                                      const std::string &host_suffix,
                                      DataStorageType storage_type,
                                      size_t scan_batch_size = 1000,
+                                     // Returns EC_MISMATCH when this predicate
+                                     // interrupts an incomplete cleanup.
                                      std::function<bool()> should_abort = nullptr);
 
 private:

--- a/kv_cache_manager/manager/select_location_policy.cc
+++ b/kv_cache_manager/manager/select_location_policy.cc
@@ -55,7 +55,7 @@ CacheLocationConstPtr WeightSLPolicy::SelectForMatch(CacheLocationMap &location_
         }
         if (kv.second->status() == CacheLocationStatus::CLS_SERVING) {
             if (check_loc_data_exist && !check_loc_data_exist(*kv.second)) {
-                if (kv.second->type() != DataStorageType::DATA_STORAGE_TYPE_VINEYARD) {
+                if (!kv_cache_manager::IsEventReportingStorageType(kv.second->type())) {
                     out_prune_loc_ids.emplace_back(kv.first);
                 }
                 continue;
@@ -85,7 +85,7 @@ bool WeightSLPolicy::ExistsForWrite(const CacheLocationMap &location_map,
         if (kv.second->status() != CacheLocationStatus::CLS_NOT_FOUND) {
             if (kv.second->status() == CacheLocationStatus::CLS_SERVING && check_loc_data_exist &&
                 !check_loc_data_exist(*kv.second)) {
-                if (kv.second->type() != DataStorageType::DATA_STORAGE_TYPE_VINEYARD) {
+                if (!kv_cache_manager::IsEventReportingStorageType(kv.second->type())) {
                     out_prune_loc_ids.emplace_back(kv.first);
                 }
                 continue;
@@ -120,7 +120,7 @@ bool WeightSLPolicy::ExistsForWrite(const CacheLocationMap &location_map,
         }
         if (kv.second->status() == CacheLocationStatus::CLS_SERVING && check_loc_data_exist &&
             !check_loc_data_exist(*kv.second)) {
-            if (kv.second->type() != DataStorageType::DATA_STORAGE_TYPE_VINEYARD) {
+            if (!kv_cache_manager::IsEventReportingStorageType(kv.second->type())) {
                 out_prune_loc_ids.emplace_back(kv.first);
             }
             continue;
@@ -160,7 +160,7 @@ bool WeightSLPolicy::ExistsForWriteWithMinCount(const CacheLocationMap &location
         }
         if (check_loc_data_exist && kv.second->status() == CacheLocationStatus::CLS_SERVING &&
             !check_loc_data_exist(*kv.second)) {
-            if (kv.second->type() != DataStorageType::DATA_STORAGE_TYPE_VINEYARD) {
+            if (!kv_cache_manager::IsEventReportingStorageType(kv.second->type())) {
                 out_prune_loc_ids.emplace_back(kv.first);
             }
             continue;

--- a/kv_cache_manager/manager/select_location_policy.h
+++ b/kv_cache_manager/manager/select_location_policy.h
@@ -80,6 +80,7 @@ protected:
         static constexpr uint32_t DEFAULT = 1;
         static constexpr uint32_t VCNS_HF3FS = THREEFS;
         static constexpr uint32_t VINEYARD = 10;
+        static constexpr uint32_t EVENT_REPORT = 10;
     };
 
 protected:
@@ -93,6 +94,7 @@ protected:
         StorageTypeWeights::VCNS_HF3FS,
         StorageTypeWeights::DEFAULT,
         StorageTypeWeights::VINEYARD,
+        StorageTypeWeights::EVENT_REPORT,
     };
 
     WeightArray &storage_weights_ = default_storage_weights_;

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -11,6 +11,7 @@
 #include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_backend.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/data_storage/vineyard_backend.h"
 #include "kv_cache_manager/event/event_manager.h"
 #include "kv_cache_manager/manager/cache_location_view.h"
@@ -3252,5 +3253,195 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     }
 
     dsm->storage_map_.erase("vineyard_default");
+}
+
+TEST_F(CacheManagerTest, ReportEventSnapshotAuthoritativelyReplacesHostBlocks) {
+    const std::string instance_id = "snapshot_instance";
+    const std::string host = "192.168.10.1:8080";
+    const std::string other_host = "192.168.10.2:8080";
+    auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    ASSERT_EQ(expected_reg,
+              cache_manager_->RegisterInstance(request_context_.get(),
+                                               "default",
+                                               instance_id,
+                                               64,
+                                               createLocationSpecInfos(),
+                                               createModelDeployment(),
+                                               std::vector<LocationSpecGroup>()));
+
+    auto event_report_backend = std::make_shared<EventReportBackend>(cache_manager_->metrics_registry_);
+    StorageConfig config;
+    config.set_global_unique_name("event_report_snapshot");
+    config.set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT);
+    config.set_storage_spec(std::make_shared<EventReportingStorageSpec>());
+    ASSERT_EQ(EC_OK, event_report_backend->Open(config, "snapshot_test"));
+    auto dsm = registry_manager_->data_storage_manager_;
+    dsm->storage_map_["event_report_snapshot"] = event_report_backend;
+    registry_manager_->instance_group_configs_["default"]->set_event_reporting_storage_candidates(
+        {"event_report_snapshot"});
+
+    auto *snapshot_meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher(instance_id);
+    ASSERT_NE(nullptr, snapshot_meta_searcher);
+    EXPECT_EQ(EC_MISMATCH,
+              snapshot_meta_searcher->CleanupLocationsByHost(request_context_.get(),
+                                                             event_report_backend->HostSuffix(host),
+                                                             DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT,
+                                                             1000,
+                                                             [] { return true; }));
+
+    auto add_block = [&](proto::meta::ReportEventRequest &request, int64_t key) {
+        auto *event = request.add_events();
+        event->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+        auto *block = event->mutable_block_add();
+        block->set_block_key(std::to_string(key));
+        block->set_medium("hbm");
+        auto *spec = block->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri("event-report://" + request.host_ip_port() + "/hbm");
+    };
+    auto add_snapshot_block = [&](proto::meta::BlockSnapshotParams *snapshot, int64_t key) {
+        auto *block = snapshot->add_blocks();
+        block->set_block_key(std::to_string(key));
+        block->set_medium("hbm");
+        auto *spec = block->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri("event-report://" + host + "/hbm");
+    };
+
+    proto::meta::ReportEventRequest initial;
+    initial.set_instance_id(instance_id);
+    initial.set_host_ip_port(host);
+    initial.set_storage_type(proto::meta::ST_EVENT_REPORT);
+    auto *register_event = initial.add_events();
+    register_event->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    register_event->mutable_node_register()->add_mediums("hbm");
+    add_block(initial, 1);
+    add_block(initial, 2);
+    proto::meta::ReportEventResponse initial_response;
+    ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &initial, &initial_response));
+
+    proto::meta::ReportEventRequest other_host_request;
+    other_host_request.set_instance_id(instance_id);
+    other_host_request.set_host_ip_port(other_host);
+    other_host_request.set_storage_type(proto::meta::ST_EVENT_REPORT);
+    auto *other_register = other_host_request.add_events();
+    other_register->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    other_register->mutable_node_register()->add_mediums("hbm");
+    add_block(other_host_request, 4);
+    proto::meta::ReportEventResponse other_host_response;
+    ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &other_host_request, &other_host_response));
+
+    proto::meta::ReportEventRequest mixed_request;
+    mixed_request.set_instance_id(instance_id);
+    mixed_request.set_host_ip_port(host);
+    mixed_request.set_storage_type(proto::meta::ST_EVENT_REPORT);
+    auto *mixed_snapshot = mixed_request.add_events();
+    mixed_snapshot->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    add_snapshot_block(mixed_snapshot->mutable_block_snapshot(), 99);
+    add_block(mixed_request, 5);
+    proto::meta::ReportEventResponse mixed_response;
+    EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &mixed_request, &mixed_response));
+
+    BlockMask block_mask = static_cast<size_t>(0);
+    auto [mixed_query_ec, mixed_locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, {5, 99}, {}, block_mask, 0, {});
+    ASSERT_EQ(EC_OK, mixed_query_ec);
+    ASSERT_EQ(2, mixed_locations.cache_locations_view().size());
+    expectEmptySpec(mixed_locations.cache_locations_view()[0].location_specs());
+    expectEmptySpec(mixed_locations.cache_locations_view()[1].location_specs());
+
+    proto::meta::ReportEventRequest snapshot_request;
+    snapshot_request.set_instance_id(instance_id);
+    snapshot_request.set_host_ip_port(host);
+    snapshot_request.set_storage_type(proto::meta::ST_EVENT_REPORT);
+    auto *snapshot_event = snapshot_request.add_events();
+    snapshot_event->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    add_snapshot_block(snapshot_event->mutable_block_snapshot(), 2);
+    add_snapshot_block(snapshot_event->mutable_block_snapshot(), 3);
+    proto::meta::ReportEventResponse snapshot_response;
+    ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &snapshot_request, &snapshot_response));
+
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(request_context_.get(),
+                                                                  instance_id,
+                                                                  CacheManager::QueryType::QT_BATCH_GET,
+                                                                  {1, 2, 3, 4},
+                                                                  {},
+                                                                  block_mask,
+                                                                  0,
+                                                                  {});
+    ASSERT_EQ(EC_OK, query_ec);
+    ASSERT_EQ(4, locations.cache_locations_view().size());
+    expectEmptySpec(locations.cache_locations_view()[0].location_specs());
+    expectNonEmptySpec(locations.cache_locations_view()[1].location_specs());
+    expectNonEmptySpec(locations.cache_locations_view()[2].location_specs());
+    expectNonEmptySpec(locations.cache_locations_view()[3].location_specs());
+
+    proto::meta::ReportEventRequest empty_snapshot_request;
+    empty_snapshot_request.set_instance_id(instance_id);
+    empty_snapshot_request.set_host_ip_port(host);
+    empty_snapshot_request.set_storage_type(proto::meta::ST_EVENT_REPORT);
+    auto *empty_snapshot = empty_snapshot_request.add_events();
+    empty_snapshot->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    empty_snapshot->mutable_block_snapshot();
+    proto::meta::ReportEventResponse empty_snapshot_response;
+    ASSERT_EQ(EC_OK,
+              cache_manager_->ReportEvent(request_context_.get(), &empty_snapshot_request, &empty_snapshot_response));
+
+    auto [empty_query_ec, empty_locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, {2, 3, 4}, {}, block_mask, 0, {});
+    ASSERT_EQ(EC_OK, empty_query_ec);
+    ASSERT_EQ(3, empty_locations.cache_locations_view().size());
+    expectEmptySpec(empty_locations.cache_locations_view()[0].location_specs());
+    expectEmptySpec(empty_locations.cache_locations_view()[1].location_specs());
+    expectNonEmptySpec(empty_locations.cache_locations_view()[2].location_specs());
+
+    proto::meta::ReportEventRequest registered_add_request;
+    registered_add_request.set_instance_id(instance_id);
+    registered_add_request.set_host_ip_port(host);
+    registered_add_request.set_storage_type(proto::meta::ST_EVENT_REPORT);
+    add_block(registered_add_request, 6);
+    proto::meta::ReportEventResponse registered_add_response;
+    ASSERT_EQ(EC_OK,
+              cache_manager_->ReportEvent(request_context_.get(), &registered_add_request, &registered_add_response));
+
+    // A timeout cleanup that was queued just before a heartbeat recovery must
+    // not delete the recovered node's current cache state.
+    cache_manager_->CleanupHostLocations(instance_id,
+                                         host,
+                                         event_report_backend->GetNodeGeneration(instance_id, host),
+                                         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT);
+    auto [recovered_query_ec, recovered_locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, {6}, {}, block_mask, 0, {});
+    ASSERT_EQ(EC_OK, recovered_query_ec);
+    ASSERT_EQ(1, recovered_locations.cache_locations_view().size());
+    expectNonEmptySpec(recovered_locations.cache_locations_view()[0].location_specs());
+
+    ASSERT_EQ(EC_OK, event_report_backend->UnregisterNode(instance_id, host));
+    ASSERT_EQ(EC_OK, event_report_backend->RegisterNode("different_instance", host, {"hbm"}));
+
+    auto [cross_instance_query_ec, cross_instance_locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, {6}, {}, block_mask, 0, {});
+    ASSERT_EQ(EC_OK, cross_instance_query_ec);
+    ASSERT_EQ(1, cross_instance_locations.cache_locations_view().size());
+    expectEmptySpec(cross_instance_locations.cache_locations_view()[0].location_specs());
+
+    proto::meta::ReportEventRequest unregistered_request;
+    unregistered_request.set_instance_id(instance_id);
+    unregistered_request.set_host_ip_port(host);
+    unregistered_request.set_storage_type(proto::meta::ST_EVENT_REPORT);
+    add_block(unregistered_request, 7);
+    proto::meta::ReportEventResponse unregistered_response;
+    EXPECT_EQ(EC_PARTIAL_OK,
+              cache_manager_->ReportEvent(request_context_.get(), &unregistered_request, &unregistered_response));
+
+    auto [unregistered_query_ec, unregistered_locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, {7}, {}, block_mask, 0, {});
+    ASSERT_EQ(EC_OK, unregistered_query_ec);
+    ASSERT_EQ(1, unregistered_locations.cache_locations_view().size());
+    expectEmptySpec(unregistered_locations.cache_locations_view()[0].location_specs());
+
+    ASSERT_EQ(EC_OK, event_report_backend->UnregisterNode("different_instance", host));
+    event_report_backend->Close();
+    dsm->storage_map_.erase("event_report_snapshot");
 }
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -2680,9 +2680,8 @@ TEST_F(CacheReclaimerTest, TestCronJobAdaptiveSleepInterval) {
     // on absolute scheduler timing, while still requiring the second round to
     // arrive before the original sleep interval would have elapsed again.
     ASSERT_TRUE(WaitUntilSubmittedDelRequests(initial_sleep_interval + std::chrono::milliseconds(1000)));
-    ASSERT_TRUE(WaitUntil(
-        [this] { return ListInstanceGroupCallCount() > 1 && SubmittedDelRequestCount() > 1; },
-        initial_sleep_interval / 2));
+    ASSERT_TRUE(WaitUntil([this] { return ListInstanceGroupCallCount() > 1 && SubmittedDelRequestCount() > 1; },
+                          initial_sleep_interval / 2));
     cache_reclaimer_->Stop(); // join the worker thread
 
     ASSERT_LT(1, ListInstanceGroupCallCount());
@@ -3107,6 +3106,56 @@ TEST_F(CacheReclaimerTest, TestFilterLocationCreditsNormalizeTypeAndPredictKeysC
                                               create_age_stats));
     EXPECT_EQ(2, location_ids.front().size());
     EXPECT_EQ(1, predicted_keys);
+}
+
+TEST_F(CacheReclaimerTest, TestFilterLocationNeverReclaimsEventReportedStorage) {
+    const auto instance = InstanceInfoFactory();
+    batch_get_loc_out_maps = {
+        CacheLocationMap{
+            {"event_report",
+             MakeCacheLocation("event_report",
+                               CacheLocationStatus::CLS_SERVING,
+                               DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT,
+                               "event-report://engine-0/gpu?size=64")},
+        },
+        CacheLocationMap{
+            {"event_report",
+             MakeCacheLocation("event_report",
+                               CacheLocationStatus::CLS_SERVING,
+                               DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT,
+                               "event-report://engine-0/gpu?size=64")},
+            {"nfs",
+             MakeCacheLocation("nfs",
+                               CacheLocationStatus::CLS_SERVING,
+                               DataStorageType::DATA_STORAGE_TYPE_NFS,
+                               "nfs://store?size=32")},
+        },
+    };
+
+    std::vector<std::vector<std::string>> location_ids;
+    CacheReclaimer::BytesByStorageType bytes_by_type{};
+    CacheReclaimer::CountsByStorageType counts_by_type{};
+    std::uint64_t predicted_keys = 0;
+    CacheReclaimer::AgeStats create_age_stats;
+    ASSERT_TRUE(cache_reclaimer_->FilterLocID(request_context_.get(),
+                                              instance,
+                                              {10, 11},
+                                              CacheReclaimer::WaterLevelExceed{},
+                                              location_ids,
+                                              bytes_by_type,
+                                              counts_by_type,
+                                              predicted_keys,
+                                              create_age_stats));
+
+    ASSERT_EQ(2, location_ids.size());
+    EXPECT_TRUE(location_ids[0].empty());
+    ASSERT_EQ(1, location_ids[1].size());
+    EXPECT_EQ("nfs", location_ids[1][0]);
+    EXPECT_EQ(32, bytes_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)]);
+    EXPECT_EQ(1, counts_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)]);
+    EXPECT_EQ(0, bytes_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT)]);
+    EXPECT_EQ(0, counts_by_type[ToIndex(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT)]);
+    EXPECT_EQ(0, predicted_keys);
 }
 
 TEST_F(CacheReclaimerTest, TestCreditDeadlineDisablesCreditButKeepsPendingAndHardQuota) {
@@ -3962,8 +4011,8 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
-        ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+        ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
+            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(9, batch.size());
         // keys 1..10 unique, lru_times 0..9; tp=0 excluded from stats, tp=1..9 included (9 entries)
         // ages: now_us-1, now_us-2, ..., now_us-9 → min=now_us-9, max=now_us-1, diff=8
@@ -4018,8 +4067,8 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
-        ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+        ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
+            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(1, batch.size());
         // all keys are 1 (only 1 unique key), first occurrence has tp=0 → excluded
         // age_count=0 → Clear() called → all stats zeroed
@@ -4071,8 +4120,8 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
-        ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+        ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
+            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(2, batch.size());
         // keys={1*7,2,1,1}, tp={9*7,10,9,9}; sorted → key=1(tp=9) then key=2(tp=10)
         // ages: now_us-9 and now_us-10 → min=now_us-10, max=now_us-9, diff=1

--- a/kv_cache_manager/meta/storage_usage_data.cc
+++ b/kv_cache_manager/meta/storage_usage_data.cc
@@ -15,8 +15,9 @@ namespace kv_cache_manager {
 std::uint64_t StorageUsageData::GetStorageUsage() const noexcept {
     std::uint64_t storage_usage = 0;
     for (size_t_ i = 0; i != storage_usage_by_type_.size(); ++i) {
-        if (i == static_cast<size_t_>(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN) ||
-            i == static_cast<size_t_>(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS)) {
+        const auto type = static_cast<DataStorageType>(i);
+        if (type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN ||
+            type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS || IsEventReportingStorageType(type)) {
             continue;
         }
         storage_usage += storage_usage_by_type_.at(i).load();

--- a/kv_cache_manager/meta/storage_usage_data.h
+++ b/kv_cache_manager/meta/storage_usage_data.h
@@ -46,6 +46,8 @@ private:
     // slot 4: DATA_STORAGE_TYPE_NFS usage data
     // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
     // slot 6: DATA_STORAGE_TYPE_DUMMY usage data (testing only)
+    // slot 7: DATA_STORAGE_TYPE_VINEYARD event-reported usage (not capacity-managed)
+    // slot 8: DATA_STORAGE_TYPE_EVENT_REPORT engine cache usage (not capacity-managed)
     array_t_ storage_usage_by_type_;
 };
 

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -262,7 +262,7 @@ TEST_F(MetaIndexerTest, TestMetadataPersistAndRecover) {
 
     // persist
     meta_indexer_->key_count_.store(3);
-    const std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700};
+    const std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700, 800};
     ASSERT_EQ(expected_usage_vec.size(), meta_indexer_->storage_usage_data_.storage_usage_by_type_.size());
     for (std::size_t i = 0; i != meta_indexer_->storage_usage_data_.storage_usage_by_type_.size(); ++i) {
         meta_indexer_->storage_usage_data_.storage_usage_by_type_.at(i).store(expected_usage_vec.at(i));
@@ -298,7 +298,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
         ASSERT_EQ(0, meta_indexer_->GetStorageUsage());
 
         auto type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0, 0};
 
         type = DataStorageType::DATA_STORAGE_TYPE_HF3FS;
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
@@ -339,7 +339,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
     {
         meta_indexer_->storage_usage_data_.Reset();
         auto type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0, 0};
 
         type = DataStorageType::DATA_STORAGE_TYPE_HF3FS;
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
@@ -385,7 +385,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
     // test special case: DATA_STORAGE_TYPE_VCNS_HF3FS behavior as DATA_STORAGE_TYPE_HF3FS
     {
         meta_indexer_->storage_usage_data_.Reset();
-        std::vector<std::uint64_t> expected_usage_vec{0, 128, 0, 0, 0, 0, 0, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 128, 0, 0, 0, 0, 0, 0, 0};
 
         meta_indexer_->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS, 128);
         ASSERT_EQ(128, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS));
@@ -413,6 +413,20 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
             ASSERT_EQ(expected_usage_vec.at(i), meta_indexer_->storage_usage_data_.storage_usage_by_type_.at(i).load());
         }
     }
+
+    // Event-reported cache is owned by the inference engine. Keep its
+    // per-type accounting observable, but exclude it from KVCM-managed
+    // aggregate capacity.
+    {
+        meta_indexer_->storage_usage_data_.Reset();
+        meta_indexer_->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 64);
+        meta_indexer_->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VINEYARD, 128);
+        meta_indexer_->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT, 256);
+
+        ASSERT_EQ(128, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VINEYARD));
+        ASSERT_EQ(256, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT));
+        ASSERT_EQ(64, meta_indexer_->GetStorageUsage());
+    }
 }
 
 TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
@@ -420,7 +434,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
     // Successful round-trip: serialize then deserialize
     {
-        std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700};
+        std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700, 800};
 
         storage_usage_data.Reset();
         for (std::size_t i = 0; i != expected_usage_vec.size(); ++i) {
@@ -429,7 +443,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
         std::string serialized = storage_usage_data.Serialize();
         ASSERT_EQ(
-            R"({"unknown":1,"hf3fs":100,"mooncake":200,"pace":300,"file":400,"vcns_hf3fs":500,"dummy":600,"vineyard":700})",
+            R"({"unknown":1,"hf3fs":100,"mooncake":200,"pace":300,"file":400,"vcns_hf3fs":500,"dummy":600,"vineyard":700,"event_report":800})",
             serialized);
 
         storage_usage_data.Reset();
@@ -441,12 +455,12 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
     // Legal input: keys in different order
     {
-        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8};
+        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8, 9};
         storage_usage_data.Reset();
         ASSERT_EQ(
             EC_OK,
             storage_usage_data.Deserialize(
-                R"({"vineyard":8,"dummy":7,"vcns_hf3fs":6,"file":5,"pace":4,"mooncake":3,"hf3fs":2,"unknown":1})"));
+                R"({"event_report":9,"vineyard":8,"dummy":7,"vcns_hf3fs":6,"file":5,"pace":4,"mooncake":3,"hf3fs":2,"unknown":1})"));
         for (std::size_t i = 0; i != storage_usage_data.storage_usage_by_type_.size(); ++i) {
             ASSERT_EQ(expected_usage_vec.at(i), storage_usage_data.storage_usage_by_type_.at(i).load());
         }
@@ -466,12 +480,13 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
     // Legal input: whitespace-padded JSON
     {
-        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8};
+        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8, 9};
         storage_usage_data.Reset();
         ASSERT_EQ(EC_OK,
                   storage_usage_data.Deserialize("  "
                                                  "{\"unknown\":1,\"hf3fs\":2,\"mooncake\":3,\"pace\":4,\"file\":5,"
-                                                 "\"vcns_hf3fs\":6,\"dummy\":7,\"vineyard\":8}  "));
+                                                 "\"vcns_hf3fs\":6,\"dummy\":7,\"vineyard\":8,"
+                                                 "\"event_report\":9}  "));
         for (std::size_t i = 0; i != storage_usage_data.storage_usage_by_type_.size(); ++i) {
             ASSERT_EQ(expected_usage_vec.at(i), storage_usage_data.storage_usage_by_type_.at(i).load());
         }

--- a/kv_cache_manager/protocol/protobuf/BUILD
+++ b/kv_cache_manager/protocol/protobuf/BUILD
@@ -12,7 +12,7 @@ config_setting(
 )
 
 cc_library(
-    name = "service_cc_proto",
+    name = "service_message_cc_proto",
     srcs = [
         "admin_service.pb.cc",
         "debug_service.pb.cc",
@@ -28,7 +28,15 @@ cc_library(
         "optimizer_service.pb.h",
     ],
     include_prefix = "service/proto",
-    deps = select({
+    deps = [
+        "@com_google_protobuf//:cc_wkt_protos",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_library(
+    name = "service_cc_proto",
+    deps = [":service_message_cc_proto"] + select({
         "client_only_header": [
             ":admin_service_cc_impl_grpc_header_only",
             ":debug_service_cc_impl_grpc_header_only",

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -44,6 +44,7 @@ enum StorageType {
     ST_VCNS_3FS = 5;
     ST_DUMMY = 6;
     ST_VINEYARD = 7;
+    ST_EVENT_REPORT = 8;
 }
 
 message LocalStorageSpec {}
@@ -108,6 +109,12 @@ message VineyardStorageSpec {
     int64 liveness_check_interval_ms = 3;
 }
 
+message EventReportStorageSpec {
+    int64 heartbeat_timeout_ms = 1;
+    int64 cleanup_grace_ms = 2;
+    int64 liveness_check_interval_ms = 3;
+}
+
 message StorageConfig {
     string global_unique_name = 1;
     oneof storage_spec {
@@ -119,6 +126,7 @@ message StorageConfig {
         VcnsThreeFSStorageSpec vcnsthreefs = 7;
         DummyStorageSpec dummy = 9;
         VineyardStorageSpec vineyard = 10;
+        EventReportStorageSpec event_report = 11;
     }
     bool check_storage_available_when_open = 8;
 }

--- a/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
@@ -41,6 +41,7 @@ enum StorageType {
     ST_VCNS_3FS = 5;
     ST_DUMMY = 6;
     ST_VINEYARD = 7;
+    ST_EVENT_REPORT = 8;
 }
 
 // 使用URI统一多种存储表示，由client或者connector负责解析

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -44,17 +44,22 @@ enum StorageType {
     ST_VCNS_3FS = 5;
     ST_DUMMY = 6;
     ST_VINEYARD = 7;
+    ST_EVENT_REPORT = 8;
 }
 
-// ---- V6D event reporting ----
+// ---- Cache event reporting ----
 
 enum ReportEventType {
     EVENT_UNSPECIFIED = 0;
-    EVENT_NODE_REGISTER = 1; // V6D node starts up and registers with KVCM
-    EVENT_BLOCK_ADD = 2;     // V6D stored a new block locally
-    EVENT_BLOCK_DELETE = 3;  // V6D deleted a block locally
-    EVENT_HOST_DOWN = 4;     // V6D node is going down (graceful or detected)
-    EVENT_HEARTBEAT = 5;     // V6D periodic heartbeat
+    EVENT_NODE_REGISTER = 1; // A cache-owning node starts up and registers with KVCM
+    EVENT_BLOCK_ADD = 2;     // The node stored a new block locally
+    EVENT_BLOCK_DELETE = 3;  // The node deleted a local block
+    EVENT_HOST_DOWN = 4;     // The node is going down (graceful or detected)
+    EVENT_HEARTBEAT = 5;     // Node liveness heartbeat
+    // Authoritative replacement of every cache block reported by one host.
+    // A subscriber uses this after startup or when its incremental cursor is
+    // no longer recoverable.
+    EVENT_BLOCK_SNAPSHOT = 6;
 }
 
 message NodeRegisterParams {
@@ -81,6 +86,18 @@ message HeartbeatParams {
     map<string, string> system_status = 1;
 }
 
+message BlockSnapshotItem {
+    string block_key = 1;
+    string medium = 2;
+    repeated LocationSpec specs = 3;
+}
+
+message BlockSnapshotParams {
+    // The complete block set for host_ip_port across all reported mediums.
+    // An empty list authoritatively clears the host.
+    repeated BlockSnapshotItem blocks = 1;
+}
+
 message EventItem {
     ReportEventType event_type = 1;
     oneof event_params {
@@ -89,6 +106,7 @@ message EventItem {
         BlockDeleteParams block_delete = 4;
         HostDownParams host_down = 5;
         HeartbeatParams heartbeat = 6;
+        BlockSnapshotParams block_snapshot = 7;
     }
 }
 

--- a/kv_cache_manager/service/util/BUILD
+++ b/kv_cache_manager/service/util/BUILD
@@ -21,14 +21,13 @@ cc_library(
     srcs = ["manager_message_proto_util.cc"],
     hdrs = ["manager_message_proto_util.h"],
     deps = [
-        ":grpc_wrapper",
         "//kv_cache_manager/common",
-        "//kv_cache_manager/config",
+        "//kv_cache_manager/config:config_types",
         "//kv_cache_manager/config:meta_cache_policy_config",
-        "//kv_cache_manager/data_storage",
+        "//kv_cache_manager/data_storage:common_define",
         "//kv_cache_manager/meta:cache_location",
         "//kv_cache_manager/manager:cache_location_view",
-        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+        "//kv_cache_manager/protocol/protobuf:service_message_cc_proto",
     ],
 )
 

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -65,6 +65,13 @@ void ProtoConvert::StorageConfigToProto(const StorageConfig &storage_config,
         vineyard->set_heartbeat_timeout_ms(vineyard_storage.heartbeat_timeout_ms());
         vineyard->set_cleanup_grace_ms(vineyard_storage.cleanup_grace_ms());
         vineyard->set_liveness_check_interval_ms(vineyard_storage.liveness_check_interval_ms());
+    } else if (type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT) {
+        const auto &event_storage =
+            *std::dynamic_pointer_cast<EventReportingStorageSpec>(storage_config.storage_spec());
+        auto *event_report = proto_storage_config->mutable_event_report();
+        event_report->set_heartbeat_timeout_ms(event_storage.heartbeat_timeout_ms());
+        event_report->set_cleanup_grace_ms(event_storage.cleanup_grace_ms());
+        event_report->set_liveness_check_interval_ms(event_storage.liveness_check_interval_ms());
     }
 }
 
@@ -147,6 +154,19 @@ void ProtoConvert::StorageFromProto(const proto::admin::StorageConfig *proto_sto
             spec.set_liveness_check_interval_ms(v.liveness_check_interval_ms());
         storage_config.set_storage_spec(std::make_shared<VineyardStorageSpec>(spec));
         storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_VINEYARD);
+        break;
+    }
+    case proto::admin::StorageConfig::kEventReport: {
+        EventReportingStorageSpec spec;
+        const auto &event_report = proto_storage_config->event_report();
+        if (event_report.heartbeat_timeout_ms() > 0)
+            spec.set_heartbeat_timeout_ms(event_report.heartbeat_timeout_ms());
+        if (event_report.cleanup_grace_ms() > 0)
+            spec.set_cleanup_grace_ms(event_report.cleanup_grace_ms());
+        if (event_report.liveness_check_interval_ms() > 0)
+            spec.set_liveness_check_interval_ms(event_report.liveness_check_interval_ms());
+        storage_config.set_storage_spec(std::make_shared<EventReportingStorageSpec>(spec));
+        storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT);
         break;
     }
     default:

--- a/kv_cache_manager/service/util/manager_message_proto_util.h
+++ b/kv_cache_manager/service/util/manager_message_proto_util.h
@@ -302,6 +302,10 @@ void ProtoConvert::DataStorageTypeToProto(const DataStorageType &data_storage_ty
         *proto_data_storage_type = T::ST_VINEYARD;
         break;
     }
+    case DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT: {
+        *proto_data_storage_type = T::ST_EVENT_REPORT;
+        break;
+    }
     default: {
         // Handle unknown storage type case if necessary
         break;
@@ -344,6 +348,10 @@ void ProtoConvert::DataStorageTypeFromProto(const T proto_data_storage_type, Dat
     }
     case T::ST_VINEYARD: {
         data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_VINEYARD;
+        break;
+    }
+    case T::ST_EVENT_REPORT: {
+        data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT;
         break;
     }
     default: {


### PR DESCRIPTION

### Summary

This PR adds a standalone subscriber that synchronizes RTP-LLM or vLLM local KV-cache state into KVCM.

- Add a dedicated `ST_EVENT_REPORT` metadata-only storage type.
- Add authoritative per-host cache snapshots and idempotent incremental updates.
- Add RTP-LLM and vLLM source adapters behind one transactional source interface.
- Commit source cursors only after KVCM acknowledges the corresponding update.
- Integrate node registration, heartbeat, generation fencing, and host-down cleanup.
- Exclude engine-owned cache locations from KVCM capacity accounting and active reclaim.

### Data flow

```text
RTP GetCacheStatus v2 / vLLM ZMQ
  -> Source.prepare
  -> normalize BlockRecord
  -> KVCM ReportEvent
  -> KVCM ACK
  -> Source.commit
```

`Source.prepare` creates a candidate state without advancing its committed cursor. A KVCM failure therefore applies backpressure to the source instead of allowing unbounded local event accumulation or acknowledging data that was not persisted.

### Design

#### Dedicated event-report storage

Engine-local GPU cache is represented by a new `ST_EVENT_REPORT = 8` storage type and `event-report://` locations.

This backend owns node liveness and cache-location metadata only. It does not read, write, or delete the actual KV data, which remains owned by RTP-LLM or vLLM.

- Existing Vineyard storage behavior and URI routing remain unchanged.
- Event-report storage is not included in KVCM managed capacity.
- Event-report locations are excluded from active reclaim.
- The storage still participates in replica discovery while its engine node is available.
- Instance groups opt in through `event_reporting_storage_candidates`.

#### Authoritative snapshot semantics

`EVENT_BLOCK_SNAPSHOT` replaces the complete block set for one `instance_id + host_ip_port`. An empty snapshot clears that host without affecting other hosts or instances.

Snapshots, deltas, and asynchronous host cleanup for the same instance and host are serialized by striped mutexes. Generation and availability fences prevent stale timeout cleanup from removing locations after a node has recovered or re-registered.

#### Transactional subscriber

- Cold start first prepares an authoritative source snapshot.
- The subscriber then performs `NODE_REGISTER -> snapshot ACK -> source commit -> HEARTBEAT`.
- If the initial snapshot fails, the subscriber reports `HOST_DOWN`, re-registers, and retries the same uncommitted snapshot.
- KVCM failures do not advance the source cursor.
- Source failures pause heartbeat; repeated failures report `HOST_DOWN` before exit.
- A periodic authoritative refresh reconciles any long-lived drift.

Small snapshots use one replacement request. Large snapshots use an empty replacement followed by chunked `ADD` requests to stay within the request-size limit. A failed transfer is retried from the empty replacement and eventually converges, although the host can be partially visible while chunks are being applied.

#### RTP-LLM source

- Consumes protocol-v2 snapshots and ordered events from every configured DP endpoint.
- Tracks generation and cursor independently per endpoint.
- Commits the aggregate state only after every endpoint succeeds.
- Requires exactly `dp_size` distinct endpoints to avoid silently missing a DP rank.

#### vLLM source

- Consumes sequenced MsgPack/ZMQ cache events and requests bounded replay after a gap.
- Accepts a replay as authoritative only from sequence `0` or after `AllBlocksCleared`.
- Treats a new sequence-0 stream as a publisher epoch reset.
- Remains unregistered and sends no heartbeat until an authoritative baseline exists.
- Maps the low 64 bits of the vLLM hash to KVCM signed `int64`, matching the legacy integer event representation.
- Explicitly supports `dp_size = 1`; multi-publisher aggregation is left for a separate change.

### Configuration

KVCM needs a dedicated event-report storage:

```json
{
  "global_unique_name": "engine_cache_events",
  "event_report": {
    "heartbeat_timeout_ms": 30000,
    "cleanup_grace_ms": 300000,
    "liveness_check_interval_ms": 5000
  }
}
```

The corresponding instance group must include `engine_cache_events` in `event_reporting_storage_candidates`. It must not be added to ordinary `storage_candidates`.

Example RTP subscriber:

```bash
python -m kv_cache_manager.cache_event_subscriber \
  --engine rtp \
  --manager-uri http://manager:8080 \
  --instance-group default \
  --instance-id model-a \
  --host-ip-port worker-a:9000 \
  --rtp-endpoints worker-a:9001 \
  --block-size 64 \
  --model-name model-a \
  --cache-group-count 1
```

The vLLM path additionally requires `msgspec` and `pyzmq`; the RTP path has no source-specific Python dependency.

### Compatibility

- The new protobuf enum value and instance-group candidate field are additive.
- Existing storage candidates and Vineyard nodes keep their current behavior.
- No engine cache is reported unless the dedicated storage and subscriber are explicitly configured.
- Cache metadata remains isolated by `instance_id`.

### Validation

- Subscriber Python tests: 27/27 passed, including startup ordering, retry, pagination, generation reset, vLLM replay, and multi-endpoint failure cases.
- `manager_message_proto_util` builds successfully with the updated protobuf contract.
- `InstanceGroupTest.EventReportStorageProtoRoundTrip`: passed.
- `StorageConfigTest`: passed.
- `EventReportBackendTest`: passed.
- `CacheManagerTest.ReportEventSnapshotAuthoritativelyReplacesHostBlocks`: passed.
- `CacheReclaimerTest.TestFilterLocationNeverReclaimsEventReportedStorage`: passed.
- Event-report `MetaIndexer` filter cases: passed.
- `DataStorageManagerTest.RegisterEventReportStorage`: passed.
- `git diff --check`: passed.

### Known limitations and follow-ups

- [ ] Run a real RTP + Subscriber + KVCM three-process integration test with the companion RTP-LLM PR.
- vLLM currently supports one DP publisher only.
- Chunked large snapshots allow temporary partial visibility during transfer; retry is convergent but not atomically visible.
- KVCM keys are 64-bit, so a wider vLLM digest is intentionally truncated to the signed-`int64` key domain.

### Companion PR

- RTP-LLM: `alibaba/rtp-llm#1214`

