### PR TITLE
[manager] implement fair eviction across instances

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
 - [后台扫描 GC](design/cache_garbage_collector.md) - 基于 authoritative cursor 的后台全量巡检；V1 清理长期 orphan WRITING 和普通 SERVING storage-missing，并提供无副作用读取、精确值条件 CAS 与 HA 生命周期
+- [CacheReclaimer 跨 Instance 公平逐出](design/cache_reclaimer_instance_fairness.md) - 按 Instance 用量分配采样与逐出预算，并与异步 credit 协同
 
 ### 开发文档
 - [开发指南](develop/README.md) - 开发者入门指南和开发环境配置

--- a/docs/api/admin_service.md
+++ b/docs/api/admin_service.md
@@ -142,7 +142,8 @@ curl -g -vvv -X POST http://localhost:6492/api/createInstanceGroup \
                 },
                 "trigger_period_seconds": 60,
                 "reclaim_step_size": 1073741824,
-                "reclaim_step_percentage": 10
+                "reclaim_step_percentage": 10,
+                "instance_reclaim_budget_policy": "USAGE_PROPORTIONAL"
             },
             "data_storage_strategy": "CPS_PREFER_3FS",
             "meta_indexer_config": {
@@ -193,7 +194,8 @@ curl -g -vvv -X POST http://localhost:6492/api/createInstanceGroup \
                 "trigger_period_seconds": 60,
                 "reclaim_step_size": 1073741824,
                 "reclaim_step_percentage": 10,
-                "delay_before_delete_ms": 1000
+                "delay_before_delete_ms": 1000,
+                "instance_reclaim_budget_policy": "USAGE_PROPORTIONAL"
             },
             "data_storage_strategy": "CPS_PREFER_3FS",
             "meta_indexer_config": {
@@ -249,7 +251,8 @@ curl -g -vvv -X POST http://localhost:6492/api/updateInstanceGroup \
                 "trigger_period_seconds": 60,
                 "reclaim_step_size": 1073741824,
                 "reclaim_step_percentage": 10,
-                "delay_before_delete_ms": 1000
+                "delay_before_delete_ms": 1000,
+                "instance_reclaim_budget_policy": "USAGE_PROPORTIONAL"
             },
             "data_storage_strategy": "CPS_PREFER_3FS",
             "meta_indexer_config": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,7 +247,8 @@ timeout，因此不会使用配置数组顺序作为隐式优先级。
                 "trigger_strategy": {
                     "used_percentage": 0.8 # 控制数据用量水位，当用量达到或超过quota * percentage时将触发回收（逐出）
                 },
-                "delay_before_delete_ms": 1000 # 控制从提交删除请求到实际执行删除动作的间隔，类似于租约概念
+                "delay_before_delete_ms": 1000, # 控制从提交删除请求到实际执行删除动作的间隔，类似于租约概念
+                "instance_reclaim_budget_policy": 0 # 0=USAGE_PROPORTIONAL（默认，按用量分配）；1=FIXED_PER_INSTANCE（旧的固定 per-instance 行为）
             },
             # cache_prefer_strategy与storage candidates一起控制storage backend选择策略，可选值如下：
             # enum class CachePreferStrategy {
@@ -288,6 +289,12 @@ timeout，因此不会使用配置数组顺序作为隐式优先级。
     }
 }
 ```
+
+`instance_reclaim_budget_policy=USAGE_PROPORTIONAL`（内部持久化值为 `0`）时，Reclaimer 按各
+Instance 在当前超水位维度上的用量计算预算份额。
+服务级 `key_sampling_size_total` 和 `del_batch_size` 仍是单个 Instance 一次请求的 sample/batch
+上限，不会因 Group 内 Instance 数量或用量倾斜而放大；超出上限的理论份额留给后续 reclaim 轮次。
+设为 `FIXED_PER_INSTANCE`（内部持久化值为 `1`）时，完整使用旧的固定 per-instance 预算和遍历顺序。
 
 TairMempool DRAM 使用 `pace`（proto `ST_TAIRMEMPOOL`），LocalSSD 使用
 `pace_ssd`（proto `ST_TAIRMEMPOOL_SSD`，同时要求 `media_type=5`）。两类 storage

--- a/docs/design/cache_reclaimer_instance_fairness.md
+++ b/docs/design/cache_reclaimer_instance_fairness.md
@@ -1,0 +1,219 @@
+# CacheReclaimer 跨 Instance 预算分配设计
+
+| 项目 | 内容 |
+|---|---|
+| 状态 | 已实现，待合入 |
+| 更新时间 | 2026-09-01 |
+| 涉及模块 | `manager`、`meta`、`config`、`metrics`、`service`、`protocol`、`kvcm_ops` |
+| 关联能力 | Instance Group 水位回收、异步删除、分层存储迁移 |
+
+本文档描述 CacheReclaimer 当前的跨 Instance 预算分配行为。异步删除的 pending、credit、Future 和反压语义见
+[CacheReclaimer 异步删除设计](cache_reclaimer_async_delete.md)，模块职责与分层迁移顺序见
+[模块架构与关联关系](module_architecture.md)。
+
+## 1. 背景与目标
+
+CacheReclaimer 以 Instance Group 为水位和配额边界。Group 总 bytes、总 key count 或某个 Storage Type 的
+bytes 超过阈值后，Reclaimer 在各 Instance 内采样 key、读取 LRU 属性，并提交异步删除请求。
+
+如果每个 Instance 都使用相同的采样量和逐出上限，小 Instance 可能与大 Instance 承担相同的回收量；固定遍历
+顺序还会决定异步 credit 满足水位前由谁先承担逐出。当前默认策略因此按本轮超水位维度上的实际用量，为各
+Instance 分配采样和逐出预算，并让用量更大的 Instance 优先执行。
+
+本设计遵守以下边界：
+
+1. 只在同一个 Instance 内采样、排序和删除，不跨 Instance 复用或比较 key。
+2. 调整的是预算分配，不改变 LRU 候选、Location 过滤、删除请求和异步生命周期。
+3. 继续以 Group/Type 水位恢复为停止条件，不要求完整执行理论计划。
+4. 不为低用量 Instance 提供最低保有容量，也不保证单轮实际删除量严格等于用量比例。
+
+## 2. 配置与兼容模式
+
+`CacheReclaimStrategy.instance_reclaim_budget_policy` 选择跨 Instance 的预算策略：
+
+| 值 | Admin API | 行为 |
+|---|---|---|
+| `0` | `USAGE_PROPORTIONAL` | 默认。按当前超水位维度上的 per-instance 用量分配 Group 预算 |
+| `1` | `FIXED_PER_INSTANCE` | 兼容模式。按注册表顺序遍历，每个 Instance 使用固定配置预算 |
+
+内部持久化 JSON 使用整数，Admin protobuf/JSON 和 `kvcm_ops` 使用枚举名。旧配置缺少该字段时按
+`USAGE_PROPORTIONAL` 处理；配置加载会拒绝未知枚举值。运行期若遇到未知值，Reclaimer 记录告警并保守回退到
+默认的用量比例策略。
+
+预算使用以下进程级参数：
+
+- `key_sampling_size_total`：单个有效 Instance 的基准采样量 `S_cfg`；
+- `del_batch_size`：单个有效 Instance 的基准逐出上限 `B_cfg`；
+- `key_sampling_size_per_task`：单个采样任务的大小；
+- sampling worker 数和 future timeout：约束并行采样波次及共享截止时间。
+
+`FIXED_PER_INSTANCE` 完整复用原有执行路径，不做采样量归一化、Group 预算构造、用量排序或公平模式的单项
+裁剪。切换策略只影响下一轮规划；已有 pending、credit 和删除 Future 不会被清空或重建。
+
+## 3. 水位信号与权重维度
+
+`GetWaterLevelExceed` 使用正式 usage 减去有效的 Group/Type credit，分别计算三类信号：
+
+- `storage_type_exceeded[type]`：某个 Storage Type 的 bytes 超水位；
+- `group_bytes_exceeded`：Group 总 bytes 超水位；
+- `group_keys_exceeded`：Group 总 key count 超水位。
+
+计划只使用本轮实际需要回收的维度，优先级为：
+
+1. 任意 Storage Type 超水位：按每个 Instance 在所有超水位、且可由通用 Reclaimer 删除的 Storage Type 上的
+   bytes 之和加权；
+2. 否则 Group bytes 超水位：按每个 Instance 的可回收 storage usage bytes 加权；
+3. 否则 Group key count 超水位：按每个 Instance 的 used key count 加权；
+4. 都未超水位：不生成计划。
+
+该优先级保证权重和本轮 Location 过滤范围一致。例如 NFS 超水位时，不会用 Instance 的总 bytes 为仅针对 NFS
+的回收分配责任。Group bytes 和 key count 同时超限时优先使用 bytes；仅 key count 超限时固定使用 key count。
+
+EventReport Location 由独立链路管理，不进入通用 Reclaimer 的 bytes 权重；`VCNS_HF3FS` 与 HF3FS 共用统计槽，
+计算时跳过别名以避免重复计数。当前权重为 0、缺少 Instance 信息或缺少 MetaIndexer 的 Instance 不进入有效计划。
+
+## 4. Group 预算与整数分配
+
+设有效 Instance 数为 `N`。用量比例策略保留固定策略的理论总量：
+
+```text
+B_group = B_cfg * N
+S_group = max(S_cfg, B_cfg) * N
+```
+
+`S_cfg < B_cfg` 时先把本轮采样基准归一化为 `B_cfg`，保证每个计划项的采样量不小于逐出量。任一配置为 0 时
+不生成计划。Group 预算只检查整数乘法溢出，不受单次请求上限约束。
+
+### 4.1 最大余数分配
+
+batch 预算按权重占比分配。每个 Instance 先取得向下取整的整数份额，再把剩余名额依次给小数余数最大的
+Instance；余数相同时按 `instance_id` 排序，结果可复现。权重求和及乘法使用无符号 128 位整数，避免大容量
+Group 的 64 位溢出和浮点误差。
+
+采样预算分两步分配：先让每个获得 batch 的 Instance 得到等量采样名额，再把 `S_group - B_group` 的额外采样
+预算按相同权重分配给这些 Instance。由此保持 `sample_i >= batch_i`，且 batch 为 0 的 Instance 不产生无效采样。
+
+分配不会强制“非零权重至少一个 batch”。极小 Instance 因整数取整得到 0 时，本轮不处理，避免其每轮固定失血。
+
+### 4.2 单 Instance 上限
+
+Group 预算分配完成后，每个计划项分别受单 Instance 配置值和 `kSizeLimit - 1` 限制。Group 总预算可以大于
+`kSizeLimit`，因此 Instance 数较多不会导致整组计划失败。
+
+采样预算被硬上限裁剪时，batch 同步按配置的 `S_cfg:B_cfg` 比例收缩，避免采样放大倍数退化。若一个已经分配
+到非零 batch 的极小计划项因整数比例再次向下取整为 0，则保留 1 个 batch，避免裁剪造成永久无进展；这不会为
+原始 batch 为 0 的 Instance 新增最低份额。裁掉的预算不在同轮转移给其他 Instance。
+
+计划项最终按以下顺序执行：
+
+1. 权重降序；
+2. batch 降序；
+3. `instance_id` 升序；
+4. 原注册表顺序。
+
+## 5. 采样与逐出执行
+
+每个计划项仍在自己的 Instance 内执行：
+
+```text
+随机采样 sample_i 个 key
+  -> 批量读取 LRU 属性
+  -> 在该 Instance 内按 LRU 选择最多 batch_i 个 key
+  -> 按当前超水位维度过滤可删除 Location
+  -> 提交异步删除请求
+```
+
+这里的“按 LRU”用于从随机候选中选择较老的 victim，不是从全量 key 中直接取全局最老项。不同 Instance 的 LRU
+时间不参与统一排序。
+
+公平预算可能集中到大 Instance。为避免一次提交超过 sampling worker 数，采样按
+`key_sampling_size_per_task` 拆分为有界波次：每个波次最多占用当前可用 worker，完成后再提交下一波。所有波次
+共享同一 deadline；任一任务失败、超时、Reclaimer 暂停或 worker pool 已饱和时，本计划项整体失败，不提交部分
+采样结果。
+
+## 6. 异步 credit 与提前停止
+
+公平计划每轮只构造一次。执行每个计划项前，Reclaimer 都重新读取正式 Group/Type usage，并减去最新 credit：
+
+```text
+effective_group_usage = official_group_usage - credited_group_usage
+effective_type_usage  = official_type_usage  - credited_type_usage
+```
+
+当前请求被 Executor 接受后，pending Location、credited bytes、predicted deleted keys、DeleteHandler 和 Future 按既有
+异步删除流程立即建立。Reclaimer 随后再次判断水位：
+
+- 水位已经恢复：结束本 Group，不再为剩余 Instance 采样；
+- 水位仍超限且触发维度未变化：继续下一个计划项；
+- 请求为空或未被接受：不产生 credit，继续尝试后续计划项；
+- 触发维度或超水位 Storage Type 集合变化：停止旧计划，由下一轮按新范围重新规划。
+
+因此 `B_group`、`S_group` 以及各 Instance 预算都是上限，不是必须完成的工作量。用量较大的 Instance 先执行，其
+accepted 请求可能已经覆盖全部水位缺口，使后续 Instance 不再承担本轮逐出。这一行为保留了异步 credit 对过度
+逐出的保护。
+
+当前 credit 仍按 Group/Type 维护，不拆分为 per-instance credit。计划权重读取当轮正式 per-instance usage；实际
+删除因候选不足、Location 过滤、提交拒绝或异步失败产生的偏差，由后续轮次重新读取 usage 后修正。
+
+## 7. 与分层存储迁移的协同
+
+同一 cron round 内，Reclaim 准入先于 Migration 准备。删除请求 accepted 后会同步登记
+`pending_locations_`，随后构造的 Migration Job 快照排除这些 Location，避免同一 Location 同时进入删除和 Copy。
+
+这一顺序只保证准入互斥，不等待物理删除完成。若水位只达到 migration threshold、尚未达到 reclaim threshold，
+Migration 仍可独立触发。公平预算不改变 Migration strategy、Copy 并发、reservation 生命周期或共享 Executor 的
+任务优先级。
+
+## 8. 边界与近似
+
+当前实现存在以下有意边界：
+
+1. bytes 权重最终分配的是 key 数预算。Instance 间平均 KV 大小差异较大时，实际删除 bytes 比例会偏离计划比例；
+2. 不提供 per-instance 最低容量或保底份额，极小权重可以因取整在某轮获得 0 batch；
+3. 不跨 Instance 合并候选，不实现严格全局 LRU；
+4. 候选不足、过滤或提交失败后不在同轮重新分配预算；
+5. Group/Type credit 防止整体过度逐出，但不精确描述每个 Instance 的在途删除量；
+6. LFU 和 TTL 在公平路径中仍回退为当前的 LRU 实现。
+
+这些边界不改变 Instance 隔离、Location 状态机及异步删除的安全约束。
+
+## 9. 可观测性
+
+公平路径提供以下指标：
+
+| 指标 | 含义 |
+|---|---|
+| `fair_plan_count` | 成功生成的计划数 |
+| `fair_planned_batch_count` / `fair_planned_sample_count` | 计划逐出和采样总量 |
+| `fair_effective_instance_count` / `fair_planned_instance_count` | 有效权重 Instance 数和最终计划项数 |
+| `fair_sampled_instance_count` / `fair_submitted_instance_count` | 实际进入采样和成功提交的 Instance 数 |
+| `fair_zero_weight_skip_count` | 因当前权重为 0 而跳过的 Instance 数 |
+| `fair_item_capped_count` | 预算被裁剪后仍保留的计划项数 |
+| `fair_plan_truncated_count` / `fair_plan_truncated_instance_count` | 水位恢复或范围变化造成的计划截断次数和剩余项数 |
+| `fair_sampling_size_normalized_count` | 因 `S_cfg < B_cfg` 执行采样量归一化的次数 |
+
+DEBUG 日志记录权重维度、Group 理论预算、各计划项的原始/最终预算和提前停止原因。结合计划、采样和提交三组
+Instance 数，可以区分预算取整、采样失败、提交拒绝和 credit 提前满足水位等情况。
+
+## 10. 发布与回退
+
+缺少策略字段的配置默认进入 `USAGE_PROPORTIONAL`。发布后重点观察计划量、实际采样/提交 Instance 数、计划截断
+和无进展退避，确认预算分配及 credit 提前停止符合预期。
+
+需要回退预算行为时，将策略改为 `FIXED_PER_INSTANCE`；下一轮开始按固定 per-instance 预算和原注册表顺序执行。
+切换不会取消、重置或重复提交已经在途的删除请求，异步 credit 和 pending Location 继续按原生命周期收敛。
+
+## 11. 自动化验证
+
+当前自动化测试覆盖以下行为：
+
+- 最大余数分配的确定性、128 位大数计算、Group 预算溢出和单 Instance 上限；
+- bytes、key count、Storage Type 权重以及多维度同时超限的优先级；
+- 采样与 batch 联动、`S_cfg < B_cfg` 归一化、极小份额取整和裁剪比例保护；
+- 异步 credit 满足水位后的提前停止、继续执行、触发范围变化和提交失败；
+- 有界采样波次的成功、失败、超时、暂停和 worker 饱和；
+- 两种预算策略、缺省值、配置/Proto 转换和运行期切换；
+- Reclaim pending Location 与同轮 Migration 快照的互斥。
+
+`kvcm_ops` 单测覆盖枚举参数解析、JSON round-trip、缺省值和 create/update payload。通用 Reclaimer 冒烟测试用于
+验证整体回收链路，但不作为跨 Instance 公平分配的专项覆盖依据。

--- a/integration_test/admin_service/admin_interface_cases.py
+++ b/integration_test/admin_service/admin_interface_cases.py
@@ -187,6 +187,7 @@ class AdminServiceTestBase(abc.ABC, TestBase, unittest.TestCase):
                     "trigger_period_seconds": 60,
                     "reclaim_step_size": 512 * 1024 * 1024,
                     "reclaim_step_percentage": 5,
+                    "instance_reclaim_budget_policy": "USAGE_PROPORTIONAL",
                 },
                 "data_storage_strategy": 2,  # CPS_PREFER_3FS
                 "meta_indexer_config": {

--- a/kv_cache_manager/config/cache_reclaim_strategy.cc
+++ b/kv_cache_manager/config/cache_reclaim_strategy.cc
@@ -12,6 +12,10 @@ bool CacheReclaimStrategy::FromRapidValue(const rapidjson::Value &rapid_value) {
     KVCM_JSON_GET_MACRO(rapid_value, "reclaim_step_size", reclaim_step_size_);
     KVCM_JSON_GET_MACRO(rapid_value, "reclaim_step_percentage", reclaim_step_percentage_);
     KVCM_JSON_GET_MACRO(rapid_value, "delay_before_delete_ms", delay_before_delete_ms_);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "instance_reclaim_budget_policy",
+                                instance_reclaim_budget_policy_,
+                                InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL);
     return true;
 }
 
@@ -23,6 +27,7 @@ void CacheReclaimStrategy::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuff
     Put(writer, "reclaim_step_size", reclaim_step_size_);
     Put(writer, "reclaim_step_percentage", reclaim_step_percentage_);
     Put(writer, "delay_before_delete_ms", delay_before_delete_ms_);
+    Put(writer, "instance_reclaim_budget_policy", instance_reclaim_budget_policy_);
 }
 
 bool CacheReclaimStrategy::ValidateRequiredFields(std::string &invalid_fields) const {
@@ -31,6 +36,11 @@ bool CacheReclaimStrategy::ValidateRequiredFields(std::string &invalid_fields) c
     if (storage_unique_name_.empty()) {
         valid = false;
         local_invalid_fields += "{storage_unique_name}";
+    }
+    if (instance_reclaim_budget_policy_ != InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL &&
+        instance_reclaim_budget_policy_ != InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE) {
+        valid = false;
+        local_invalid_fields += "{instance_reclaim_budget_policy}";
     }
     if (!valid) {
         invalid_fields += "{CacheReclaimStrategy: " + local_invalid_fields + "}";

--- a/kv_cache_manager/config/cache_reclaim_strategy.h
+++ b/kv_cache_manager/config/cache_reclaim_strategy.h
@@ -18,26 +18,34 @@ enum class ReclaimPolicy {
     POLICY_TTL = 3,
 };
 
+enum class InstanceReclaimBudgetPolicy {
+    USAGE_PROPORTIONAL = 0,
+    FIXED_PER_INSTANCE = 1,
+};
+
 /**
  * Cache整理策略相关的配置，包括淘汰策略
  */
 class CacheReclaimStrategy : public Jsonizable {
 public:
     CacheReclaimStrategy() = default;
-    CacheReclaimStrategy(const std::string &storage_unique_name,
-                         ReclaimPolicy reclaim_policy,
-                         const TriggerStrategy &trigger_strategy,
-                         int32_t trigger_period_seconds,
-                         int32_t reclaim_step_size,
-                         int32_t reclaim_step_percentage,
-                         int32_t delay_before_delete_ms = 0)
+    CacheReclaimStrategy(
+        const std::string &storage_unique_name,
+        ReclaimPolicy reclaim_policy,
+        const TriggerStrategy &trigger_strategy,
+        int32_t trigger_period_seconds,
+        int32_t reclaim_step_size,
+        int32_t reclaim_step_percentage,
+        int32_t delay_before_delete_ms = 0,
+        InstanceReclaimBudgetPolicy instance_reclaim_budget_policy = InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL)
         : storage_unique_name_(storage_unique_name)
         , reclaim_policy_(reclaim_policy)
         , trigger_strategy_(trigger_strategy)
         , trigger_period_seconds_(trigger_period_seconds)
         , reclaim_step_size_(reclaim_step_size)
         , reclaim_step_percentage_(reclaim_step_percentage)
-        , delay_before_delete_ms_(delay_before_delete_ms) {}
+        , delay_before_delete_ms_(delay_before_delete_ms)
+        , instance_reclaim_budget_policy_(instance_reclaim_budget_policy) {}
 
     ~CacheReclaimStrategy() override;
 
@@ -52,6 +60,7 @@ public:
     int32_t reclaim_step_size() const { return reclaim_step_size_; }
     int32_t reclaim_step_percentage() const { return reclaim_step_percentage_; }
     int32_t delay_before_delete_ms() const { return delay_before_delete_ms_; }
+    InstanceReclaimBudgetPolicy instance_reclaim_budget_policy() const { return instance_reclaim_budget_policy_; }
 
     // Setters
     void set_storage_unique_name(const std::string &storage_unique_name) { storage_unique_name_ = storage_unique_name; }
@@ -66,6 +75,9 @@ public:
     }
     void set_delay_before_delete_ms(int32_t delay_before_delete_ms) {
         delay_before_delete_ms_ = delay_before_delete_ms;
+    }
+    void set_instance_reclaim_budget_policy(InstanceReclaimBudgetPolicy instance_reclaim_budget_policy) {
+        instance_reclaim_budget_policy_ = instance_reclaim_budget_policy;
     }
 
 public:
@@ -82,6 +94,7 @@ private:
     int32_t reclaim_step_size_;
     int32_t reclaim_step_percentage_;
     int32_t delay_before_delete_ms_;
+    InstanceReclaimBudgetPolicy instance_reclaim_budget_policy_{InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL};
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/config/test/instance_group_test.cc
+++ b/kv_cache_manager/config/test/instance_group_test.cc
@@ -294,4 +294,51 @@ TEST_F(InstanceGroupTest, LegacyTairMempoolProtoWithoutStorageTypeRemainsDramTyp
     EXPECT_EQ(kTairMemPoolMediaTypeSsd, restored_spec->media_type());
 }
 
+TEST_F(InstanceGroupTest, CacheReclaimBudgetPolicyProtoRoundTripPreservesFixedPerInstance) {
+    CacheConfig original;
+    auto reclaim_strategy = std::make_shared<CacheReclaimStrategy>();
+    reclaim_strategy->set_instance_reclaim_budget_policy(InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE);
+    original.set_reclaim_strategy(reclaim_strategy);
+
+    proto::admin::CacheConfig proto_config;
+    ProtoConvert::CacheConfigToProto(original, &proto_config);
+    EXPECT_EQ(proto::admin::FIXED_PER_INSTANCE, proto_config.reclaim_strategy().instance_reclaim_budget_policy());
+
+    CacheConfig restored;
+    ProtoConvert::CacheConfigFromProto(&proto_config, restored);
+    ASSERT_NE(nullptr, restored.reclaim_strategy());
+    EXPECT_EQ(InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE,
+              restored.reclaim_strategy()->instance_reclaim_budget_policy());
+}
+
+TEST_F(InstanceGroupTest, CacheReclaimBudgetPolicyProtoDefaultsToUsageProportional) {
+    proto::admin::CacheConfig proto_config;
+    proto_config.mutable_reclaim_strategy();
+
+    CacheConfig restored;
+    ProtoConvert::CacheConfigFromProto(&proto_config, restored);
+    ASSERT_NE(nullptr, restored.reclaim_strategy());
+    EXPECT_EQ(InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL,
+              restored.reclaim_strategy()->instance_reclaim_budget_policy());
+}
+
+TEST_F(InstanceGroupTest, CacheReclaimBudgetPolicyJsonDefaultsToUsageProportionalAndAcceptsFixedPerInstance) {
+    CacheReclaimStrategy reclaim_strategy;
+    ASSERT_TRUE(reclaim_strategy.FromJsonString("{}"));
+    EXPECT_EQ(InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL, reclaim_strategy.instance_reclaim_budget_policy());
+
+    ASSERT_TRUE(reclaim_strategy.FromJsonString(R"({"instance_reclaim_budget_policy": 1})"));
+    EXPECT_EQ(InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE, reclaim_strategy.instance_reclaim_budget_policy());
+}
+
+TEST_F(InstanceGroupTest, CacheReclaimBudgetPolicyValidationRejectsUnknownValue) {
+    CacheReclaimStrategy reclaim_strategy;
+    reclaim_strategy.set_storage_unique_name("nfs_01");
+    reclaim_strategy.set_instance_reclaim_budget_policy(static_cast<InstanceReclaimBudgetPolicy>(999));
+
+    std::string invalid_fields;
+    EXPECT_FALSE(reclaim_strategy.ValidateRequiredFields(invalid_fields));
+    EXPECT_NE(std::string::npos, invalid_fields.find("instance_reclaim_budget_policy"));
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -121,6 +121,14 @@ DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(delete_complete_count);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(delete_fail_count);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(migration_copy_submitted_total);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(migration_mark_submitted_total);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_plan_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_planned_batch_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_planned_sample_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_zero_weight_skip_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_plan_truncated_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_plan_truncated_instance_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_item_capped_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_sampling_size_normalized_count);
 
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us);
@@ -136,6 +144,10 @@ DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(pending_delete_bytes);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(credited_delete_bytes);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(predicted_deleted_key_count);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(oldest_pending_request_age_ms);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_effective_instance_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_planned_instance_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_sampled_instance_count);
+DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(fair_submitted_instance_count);
 
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us);
 DEFINE_METRICS_NAME_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us);
@@ -464,12 +476,20 @@ void CacheReclaimer::UpdateAsyncDeleteMetrics() noexcept {
 }
 
 CacheReclaimer::WaterLevelExceed::WaterLevelExceed()
-    : general_water_level_exceed_(false), water_level_exceed_by_type_{} {
+    : group_bytes_water_level_exceed_(false), group_keys_water_level_exceed_(false), water_level_exceed_by_type_{} {
     water_level_exceed_by_type_.fill(false);
 }
 
 bool CacheReclaimer::WaterLevelExceed::GetGeneralWaterLevelExceed() const noexcept {
-    return general_water_level_exceed_;
+    return group_bytes_water_level_exceed_ || group_keys_water_level_exceed_;
+}
+
+bool CacheReclaimer::WaterLevelExceed::GetGroupBytesWaterLevelExceed() const noexcept {
+    return group_bytes_water_level_exceed_;
+}
+
+bool CacheReclaimer::WaterLevelExceed::GetGroupKeysWaterLevelExceed() const noexcept {
+    return group_keys_water_level_exceed_;
 }
 
 bool CacheReclaimer::WaterLevelExceed::GetWaterLevelExceedByType(const DataStorageType &type) const noexcept {
@@ -483,8 +503,12 @@ bool CacheReclaimer::WaterLevelExceed::GetWaterLevelExceedByType(const DataStora
     return water_level_exceed_by_type_.at(idx);
 }
 
-void CacheReclaimer::WaterLevelExceed::SetGeneralWaterLevelExceed(const bool value) noexcept {
-    general_water_level_exceed_ = value;
+void CacheReclaimer::WaterLevelExceed::SetGroupBytesWaterLevelExceed(const bool value) noexcept {
+    group_bytes_water_level_exceed_ = value;
+}
+
+void CacheReclaimer::WaterLevelExceed::SetGroupKeysWaterLevelExceed(const bool value) noexcept {
+    group_keys_water_level_exceed_ = value;
 }
 
 void CacheReclaimer::WaterLevelExceed::SetWaterLevelExceedByType(const DataStorageType &type,
@@ -500,7 +524,7 @@ void CacheReclaimer::WaterLevelExceed::SetWaterLevelExceedByType(const DataStora
 }
 
 bool CacheReclaimer::WaterLevelExceed::CheckGroupWaterLevelExceed() const noexcept {
-    return general_water_level_exceed_ || CheckStorageTypeWaterLevelExceed();
+    return GetGeneralWaterLevelExceed() || CheckStorageTypeWaterLevelExceed();
 }
 
 bool CacheReclaimer::WaterLevelExceed::CheckStorageTypeWaterLevelExceed() const noexcept {
@@ -613,6 +637,14 @@ ErrorCode CacheReclaimer::Start() noexcept {
     REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_fail_count);
     REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(migration_copy_submitted_total);
     REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(migration_mark_submitted_total);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_plan_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_planned_batch_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_planned_sample_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_zero_weight_skip_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_plan_truncated_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_plan_truncated_instance_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_item_capped_count);
+    REGISTER_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_sampling_size_normalized_count);
 
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us);
@@ -628,6 +660,10 @@ ErrorCode CacheReclaimer::Start() noexcept {
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(credited_delete_bytes);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(predicted_deleted_key_count);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(oldest_pending_request_age_ms);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_effective_instance_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_planned_instance_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_sampled_instance_count);
+    REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_submitted_instance_count);
 
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us);
     REGISTER_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us);
@@ -830,19 +866,16 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
                         "instance group capacity quota used percentage [inf] "
                         "has reached or exceeded the threshold percentage [%f]",
                         threshold_used_percentage);
-            water_level_exceed->SetGeneralWaterLevelExceed(true);
-            return water_level_exceed;
-        }
-        if (const double group_used_percentage =
-                static_cast<double>(effective_group_bytes) / static_cast<double>(instance_group_quota.capacity());
-            group_used_percentage + kEpsilon > threshold_used_percentage) {
+            water_level_exceed->SetGroupBytesWaterLevelExceed(true);
+        } else if (const double group_used_percentage = static_cast<double>(effective_group_bytes) /
+                                                        static_cast<double>(instance_group_quota.capacity());
+                   group_used_percentage + kEpsilon > threshold_used_percentage) {
             LOG_WITH_GR(DEBUG,
                         "instance group capacity quota used percentage [%f] "
                         "has reached or exceeded the threshold percentage [%f]",
                         group_used_percentage,
                         threshold_used_percentage);
-            water_level_exceed->SetGeneralWaterLevelExceed(true);
-            return water_level_exceed;
+            water_level_exceed->SetGroupBytesWaterLevelExceed(true);
         }
     }
 
@@ -853,24 +886,19 @@ CacheReclaimer::GetWaterLevelExceed(const RequestContext *request_context,
                         "instance group total key count used percentage [inf] "
                         "has reached or exceeded the threshold percentage [%f]",
                         threshold_used_percentage);
-            water_level_exceed->SetGeneralWaterLevelExceed(true);
-            return water_level_exceed;
-        }
-        if (const double group_used_percentage =
-                static_cast<double>(effective_group_keys) / static_cast<double>(data->grp_max_key_cnt_);
-            group_used_percentage + kEpsilon > threshold_used_percentage) {
+            water_level_exceed->SetGroupKeysWaterLevelExceed(true);
+        } else if (const double group_used_percentage =
+                       static_cast<double>(effective_group_keys) / static_cast<double>(data->grp_max_key_cnt_);
+                   group_used_percentage + kEpsilon > threshold_used_percentage) {
             LOG_WITH_GR(DEBUG,
                         "instance group total key count used percentage [%f] "
                         "has reached or exceeded the threshold percentage [%f]",
                         group_used_percentage,
                         threshold_used_percentage);
-            water_level_exceed->SetGeneralWaterLevelExceed(true);
-            return water_level_exceed;
+            water_level_exceed->SetGroupKeysWaterLevelExceed(true);
         }
     }
 
-    // 2.2.3. instance group do not trigger reclaiming
-    water_level_exceed->SetGeneralWaterLevelExceed(false);
     return water_level_exceed;
 }
 
@@ -885,6 +913,26 @@ bool CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
                                   const InstanceInfoConstPtr &instance_info,
                                   const WaterLevelExceed &water_level_exceed,
                                   const std::int32_t delay_before_delete_ms) noexcept {
+    return ReclaimByLRUImpl(request_context, instance_info, water_level_exceed, delay_before_delete_ms, false, 0, 0);
+}
+
+bool CacheReclaimer::ReclaimByLRUWithBudget(const std::shared_ptr<RequestContext> &request_context,
+                                            const InstanceInfoConstPtr &instance_info,
+                                            const WaterLevelExceed &water_level_exceed,
+                                            const std::int32_t delay_before_delete_ms,
+                                            const std::size_t sampling_size,
+                                            const std::size_t batching_size) noexcept {
+    return ReclaimByLRUImpl(
+        request_context, instance_info, water_level_exceed, delay_before_delete_ms, true, sampling_size, batching_size);
+}
+
+bool CacheReclaimer::ReclaimByLRUImpl(const std::shared_ptr<RequestContext> &request_context,
+                                      const InstanceInfoConstPtr &instance_info,
+                                      const WaterLevelExceed &water_level_exceed,
+                                      const std::int32_t delay_before_delete_ms,
+                                      const bool use_fair_budget,
+                                      const std::size_t sampling_size,
+                                      const std::size_t batching_size) noexcept {
     if (!IsRunning() || IsPaused()) {
         // fast exiting in the middle of one job round
         return false;
@@ -904,7 +952,10 @@ bool CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
     // 1. get the sampled block keys and the LRU timestamp info from
     // the meta indexer
     const std::int64_t begin_tp_sample = TimestampUtil::GetSteadyTimeUs();
-    if (!DoKeySampling(request_context, instance_info, keys, maps)) {
+    const bool sampled = use_fair_budget
+                             ? DoKeySamplingWithSize(request_context, instance_info, sampling_size, true, keys, maps)
+                             : DoKeySampling(request_context, instance_info, keys, maps);
+    if (!sampled) {
         LOG_WITH_ID(DEBUG, "key sampling failed");
         return false;
     }
@@ -922,7 +973,12 @@ bool CacheReclaimer::ReclaimByLRU(const std::shared_ptr<RequestContext> &request
     // 2. constitute the batch based on the LRU timestamp info
     const std::int64_t begin_tp_batch = TimestampUtil::GetSteadyTimeUs();
     AgeStats lru_age_stats;
-    if (!MakeBatchByLRU(request_context.get(), instance_info, keys, maps, request.block_keys, lru_age_stats)) {
+    const bool batch_made =
+        use_fair_budget
+            ? MakeBatchByLRUWithSize(
+                  request_context.get(), instance_info, keys, maps, batching_size, request.block_keys, lru_age_stats)
+            : MakeBatchByLRU(request_context.get(), instance_info, keys, maps, request.block_keys, lru_age_stats);
+    if (!batch_made) {
         LOG_WITH_ID(DEBUG, "make batch failed");
         return false;
     }
@@ -1076,6 +1132,15 @@ bool CacheReclaimer::DoKeySampling(const std::shared_ptr<RequestContext> &reques
                                    const std::shared_ptr<const InstanceInfo> &instance_info,
                                    std::vector<std::int64_t> &out_keys,
                                    std::vector<std::map<std::string, std::string>> &out_maps) noexcept {
+    return DoKeySamplingWithSize(request_context, instance_info, 0, false, out_keys, out_maps);
+}
+
+bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext> &request_context,
+                                           const std::shared_ptr<const InstanceInfo> &instance_info,
+                                           const std::size_t total_sampling_size,
+                                           const bool bounded_waves,
+                                           std::vector<std::int64_t> &out_keys,
+                                           std::vector<std::map<std::string, std::string>> &out_maps) noexcept {
     const std::string &ins_id = instance_info->instance_id();
     const std::string &ins_gr = instance_info->instance_group_name();
 
@@ -1085,7 +1150,7 @@ bool CacheReclaimer::DoKeySampling(const std::shared_ptr<RequestContext> &reques
         return false;
     }
 
-    const std::size_t total_sampling_sz = sampling_size_.load();
+    const std::size_t total_sampling_sz = bounded_waves ? total_sampling_size : sampling_size_.load();
     std::size_t sampling_sz_per_task = sampling_size_per_task_.load();
     if (total_sampling_sz == 0) {
         KVCM_LOG_ERROR("sampling size == 0");
@@ -1096,11 +1161,11 @@ bool CacheReclaimer::DoKeySampling(const std::shared_ptr<RequestContext> &reques
     }
 
     auto cancelled = std::make_shared<std::atomic<bool>>(false);
-    auto sample = [request_context, ins_id, ins_gr, meta_indexer, cancelled](
+    auto sample = [this, request_context, ins_id, ins_gr, meta_indexer, cancelled, bounded_waves](
                       std::size_t sampling_sz,
                       std::vector<std::int64_t> &keys,
                       std::vector<std::map<std::string, std::string>> &maps) -> ErrorCode {
-        if (cancelled->load(std::memory_order_relaxed)) {
+        if (cancelled->load(std::memory_order_relaxed) || (bounded_waves && (!IsRunning() || IsPaused()))) {
             return ErrorCode::EC_ERROR;
         }
         if (const auto ec = meta_indexer->SampleReclaimKeys(request_context.get(), sampling_sz, keys);
@@ -1116,7 +1181,7 @@ bool CacheReclaimer::DoKeySampling(const std::shared_ptr<RequestContext> &reques
             LOG_WITH_ID(DEBUG, "random sample key size mismatch, expect: [%zu], got: [%zu]", sampling_sz, keys.size());
         }
 
-        if (cancelled->load(std::memory_order_relaxed)) {
+        if (cancelled->load(std::memory_order_relaxed) || (bounded_waves && (!IsRunning() || IsPaused()))) {
             return ErrorCode::EC_ERROR;
         }
         if (const auto res = meta_indexer->GetProperties(request_context.get(), keys, {PROPERTY_LRU_TIME}, maps);
@@ -1140,8 +1205,94 @@ bool CacheReclaimer::DoKeySampling(const std::shared_ptr<RequestContext> &reques
     out_maps.clear();
     out_maps.reserve(total_sampling_sz);
     const std::size_t worker_sz = (total_sampling_sz + sampling_sz_per_task - 1) / sampling_sz_per_task;
-    if (worker_sz == 1) {
+    if (worker_sz == 1 && !bounded_waves) {
         return sample(total_sampling_sz, out_keys, out_maps) == ErrorCode::EC_OK;
+    }
+
+    if (bounded_waves) {
+        std::vector<std::int64_t> sampled_keys;
+        sampled_keys.reserve(total_sampling_sz);
+        std::vector<std::map<std::string, std::string>> sampled_maps;
+        sampled_maps.reserve(total_sampling_sz);
+
+        std::size_t sampling_sz_todo = total_sampling_sz;
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(future_timeout_ms_.load());
+        while (sampling_sz_todo > 0) {
+            const std::size_t in_flight = in_flight_sampling_tasks_.load();
+            if (in_flight >= workers_.size()) {
+                LOG_WITH_ID(WARN,
+                            "skipping fair key sampling wave: [%zu] tasks still in-flight, worker pool saturated",
+                            in_flight);
+                cancelled->store(true, std::memory_order_relaxed);
+                return false;
+            }
+
+            const std::size_t available_workers = workers_.size() - in_flight;
+            const std::size_t remaining_task_count = (sampling_sz_todo - 1) / sampling_sz_per_task + 1;
+            const std::size_t wave_task_count = std::min(remaining_task_count, available_workers);
+            std::vector<std::future<KeySamplingResult>> futures;
+            futures.reserve(wave_task_count);
+            for (std::size_t i = 0; i != wave_task_count; ++i) {
+                const std::size_t sampling_sz = std::min(sampling_sz_per_task, sampling_sz_todo);
+                auto promise = std::make_shared<std::promise<KeySamplingResult>>();
+                futures.emplace_back(promise->get_future());
+                in_flight_sampling_tasks_.fetch_add(1);
+                SubmitTask([this, sample, sampling_sz, promise]() {
+                    std::vector<std::int64_t> keys;
+                    std::vector<std::map<std::string, std::string>> maps;
+                    const auto ec = sample(sampling_sz, keys, maps);
+                    in_flight_sampling_tasks_.fetch_sub(1);
+                    if (ec != ErrorCode::EC_OK) {
+                        promise->set_value({ec, nullptr, nullptr});
+                    } else {
+                        promise->set_value(
+                            {ErrorCode::EC_OK,
+                             std::make_shared<std::vector<std::int64_t>>(std::move(keys)),
+                             std::make_shared<std::vector<std::map<std::string, std::string>>>(std::move(maps))});
+                    }
+                });
+                sampling_sz_todo -= sampling_sz;
+            }
+
+            bool wave_succeeded = true;
+            for (auto &future : futures) {
+                if (!future.valid()) {
+                    wave_succeeded = false;
+                    cancelled->store(true, std::memory_order_relaxed);
+                    break;
+                }
+                const auto remaining = deadline - std::chrono::steady_clock::now();
+                if (remaining <= std::chrono::milliseconds::zero() ||
+                    future.wait_for(remaining) != std::future_status::ready) {
+                    LOG_WITH_ID(WARN, "fair key sampling wave timed out, shared deadline exceeded");
+                    wave_succeeded = false;
+                    cancelled->store(true, std::memory_order_relaxed);
+                    break;
+                }
+                auto key_sampling_result = future.get();
+                if (key_sampling_result.ec != ErrorCode::EC_OK) {
+                    wave_succeeded = false;
+                    cancelled->store(true, std::memory_order_relaxed);
+                    break;
+                }
+                sampled_keys.insert(sampled_keys.end(),
+                                    std::make_move_iterator(key_sampling_result.keys->begin()),
+                                    std::make_move_iterator(key_sampling_result.keys->end()));
+                sampled_maps.insert(sampled_maps.end(),
+                                    std::make_move_iterator(key_sampling_result.maps->begin()),
+                                    std::make_move_iterator(key_sampling_result.maps->end()));
+            }
+            if (!wave_succeeded) {
+                cancelled->store(true, std::memory_order_relaxed);
+                out_keys.clear();
+                out_maps.clear();
+                return false;
+            }
+        }
+
+        out_keys = std::move(sampled_keys);
+        out_maps = std::move(sampled_maps);
+        return true;
     }
 
     // guard: skip submitting new tasks if too many prior tasks are still
@@ -1222,6 +1373,17 @@ bool CacheReclaimer::MakeBatchByLRU(const RequestContext *request_context,
                                     std::vector<std::int64_t> &out_batch,
                                     AgeStats &out_lru_age_stats) const noexcept {
     const std::size_t batching_size = batching_size_.load();
+    return MakeBatchByLRUWithSize(
+        request_context, instance_info, sampled_keys, property_maps, batching_size, out_batch, out_lru_age_stats);
+}
+
+bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_context,
+                                            const std::shared_ptr<const InstanceInfo> &instance_info,
+                                            const std::vector<std::int64_t> &sampled_keys,
+                                            const std::vector<std::map<std::string, std::string>> &property_maps,
+                                            const std::size_t batching_size,
+                                            std::vector<std::int64_t> &out_batch,
+                                            AgeStats &out_lru_age_stats) const noexcept {
     if (batching_size == 0) {
         out_batch.clear();
         out_lru_age_stats.Clear();
@@ -1414,27 +1576,29 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                                                      const std::string &location_id) -> bool {
         return pending_locations_.find(PendingLocationKey{ins_id, block_key, location_id}) != pending_locations_.end();
     };
-    const auto cold_locations_cover_specs = [&is_pending_location, &loc_on_cold_storage](
-                                                 const std::int64_t block_key,
-                                                 const CacheLocationMap &loc_map,
-                                                 const CacheLocation &source_loc) -> bool {
+    const auto cold_locations_cover_specs =
+        [&is_pending_location, &loc_on_cold_storage](
+            const std::int64_t block_key, const CacheLocationMap &loc_map, const CacheLocation &source_loc) -> bool {
         if (source_loc.location_specs().empty()) {
             return false;
         }
         for (const auto &source_spec : source_loc.location_specs()) {
-            const bool covered = std::any_of(loc_map.begin(), loc_map.end(), [&is_pending_location, &loc_on_cold_storage, block_key, &source_spec](const auto &entry) {
-                const auto &loc_ptr = entry.second;
-                if (!loc_ptr || loc_ptr->status() != CacheLocationStatus::CLS_SERVING ||
-                    IsEventReportStorageType(loc_ptr->type()) || is_pending_location(block_key, loc_ptr->id()) ||
-                    !loc_on_cold_storage(*loc_ptr)) {
-                    return false;
-                }
-                return std::any_of(loc_ptr->location_specs().begin(),
-                                   loc_ptr->location_specs().end(),
-                                   [&source_spec](const auto &cold_spec) {
-                                       return cold_spec.name() == source_spec.name();
-                                   });
-            });
+            const bool covered =
+                std::any_of(loc_map.begin(),
+                            loc_map.end(),
+                            [&is_pending_location, &loc_on_cold_storage, block_key, &source_spec](const auto &entry) {
+                                const auto &loc_ptr = entry.second;
+                                if (!loc_ptr || loc_ptr->status() != CacheLocationStatus::CLS_SERVING ||
+                                    IsEventReportStorageType(loc_ptr->type()) ||
+                                    is_pending_location(block_key, loc_ptr->id()) || !loc_on_cold_storage(*loc_ptr)) {
+                                    return false;
+                                }
+                                return std::any_of(loc_ptr->location_specs().begin(),
+                                                   loc_ptr->location_specs().end(),
+                                                   [&source_spec](const auto &cold_spec) {
+                                                       return cold_spec.name() == source_spec.name();
+                                                   });
+                            });
             if (!covered) {
                 return false;
             }
@@ -1471,10 +1635,9 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                 const bool is_active_copy_target =
                     loc.status() == CacheLocationStatus::CLS_WRITING && migration_manager_ != nullptr &&
                     migration_manager_->HasActiveCopyTargetLocation(ins_id, block_key, loc.id());
-                const bool is_orphaned_writing = loc.status() == CacheLocationStatus::CLS_WRITING &&
-                                                 write_location_manager_ != nullptr &&
-                                                 !write_location_manager_->HasLocationId(loc.id()) &&
-                                                 !is_active_copy_target;
+                const bool is_orphaned_writing =
+                    loc.status() == CacheLocationStatus::CLS_WRITING && write_location_manager_ != nullptr &&
+                    !write_location_manager_->HasLocationId(loc.id()) && !is_active_copy_target;
                 if (loc.status() != CacheLocationStatus::CLS_SERVING && !is_orphaned_writing) {
                     continue;
                 }
@@ -1515,10 +1678,9 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
             const bool is_active_copy_target =
                 loc.status() == CacheLocationStatus::CLS_WRITING && migration_manager_ != nullptr &&
                 migration_manager_->HasActiveCopyTargetLocation(ins_id, block_key, loc.id());
-            const bool is_orphaned_writing = loc.status() == CacheLocationStatus::CLS_WRITING &&
-                                             write_location_manager_ != nullptr &&
-                                             !write_location_manager_->HasLocationId(loc.id()) &&
-                                             !is_active_copy_target;
+            const bool is_orphaned_writing =
+                loc.status() == CacheLocationStatus::CLS_WRITING && write_location_manager_ != nullptr &&
+                !write_location_manager_->HasLocationId(loc.id()) && !is_active_copy_target;
             if (loc.status() == CacheLocationStatus::CLS_SERVING || is_orphaned_writing) {
                 bool selected_by_water_level = false;
                 if (in_storage_type_eviction_zone) {
@@ -1579,13 +1741,14 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                             std::min(current_and_selected_process_bytes, async_delete_config_.pending_bytes_limit);
                 if (location_limit_reached || type_bytes_limit_reached || process_bytes_limit_reached) {
                     RecordPendingLimitReject(ins_gr, ToString(base_type));
-                    LOG_WITH_ID(WARN,
-                                "skip pending-limit location, block: [%ld], location: [%s], storage type: [%d], "
-                                "bytes: [%" PRIu64 "]",
-                                batch[block_idx],
-                                loc.id().c_str(),
-                                static_cast<int>(base_type),
-                                location_bytes);
+                    INTERVAL_LOG_WITH_ID(WARN,
+                                         10000,
+                                         "skip pending-limit location, block: [%ld], location: [%s], storage type: "
+                                         "[%d], bytes: [%" PRIu64 "]",
+                                         batch[block_idx],
+                                         loc.id().c_str(),
+                                         static_cast<int>(base_type),
+                                         location_bytes);
                     continue;
                 }
 
@@ -1615,9 +1778,10 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
     return true;
 }
 
-void CacheReclaimer::TryMigrateOnGroup(const std::shared_ptr<RequestContext> &request_context,
-                                       const std::shared_ptr<const InstanceGroup> &instance_group,
-                                       const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept {
+void CacheReclaimer::TryMigrateOnGroup(
+    const std::shared_ptr<RequestContext> &request_context,
+    const std::shared_ptr<const InstanceGroup> &instance_group,
+    const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept {
     if (!IsRunning() || IsPaused()) {
         return;
     }
@@ -1768,8 +1932,7 @@ bool CacheReclaimer::BuildMigrationCandidateBatch(const std::shared_ptr<RequestC
 }
 
 std::vector<std::vector<std::string>>
-CacheReclaimer::SnapshotPendingLocations(const std::string &instance_id,
-                                         const std::vector<std::int64_t> &batch) const {
+CacheReclaimer::SnapshotPendingLocations(const std::string &instance_id, const std::vector<std::int64_t> &batch) const {
     std::vector<std::vector<std::string>> snapshot(batch.size());
     for (std::size_t block_idx = 0; block_idx < batch.size(); ++block_idx) {
         const auto block_key = batch[block_idx];
@@ -2107,6 +2270,321 @@ void CacheReclaimer::HandleDelRes() noexcept {
     UpdateAsyncDeleteMetrics();
 }
 
+const char *CacheReclaimer::FairWeightDimensionName(const FairWeightDimension dimension) noexcept {
+    switch (dimension) {
+    case FairWeightDimension::STORAGE_TYPE_BYTES:
+        return "storage_type_bytes";
+    case FairWeightDimension::GROUP_BYTES:
+        return "group_bytes";
+    case FairWeightDimension::GROUP_KEYS:
+        return "group_keys";
+    case FairWeightDimension::NONE:
+    default:
+        return "none";
+    }
+}
+
+bool CacheReclaimer::AllocateFairBudget(const std::size_t total_budget,
+                                        const std::vector<std::uint64_t> &weights,
+                                        const std::vector<std::string> &instance_ids,
+                                        std::vector<std::size_t> &out_allocations) noexcept {
+    out_allocations.clear();
+    if (weights.size() != instance_ids.size()) {
+        return false;
+    }
+    out_allocations.resize(weights.size(), 0);
+    if (total_budget == 0) {
+        return true;
+    }
+
+    using uint128_t = unsigned __int128;
+    constexpr uint128_t kUint128Max = ~static_cast<uint128_t>(0);
+    uint128_t total_weight = 0;
+    for (const std::uint64_t weight : weights) {
+        if (total_weight > kUint128Max - static_cast<uint128_t>(weight)) {
+            return false;
+        }
+        total_weight += static_cast<uint128_t>(weight);
+    }
+    if (total_weight == 0) {
+        return false;
+    }
+
+    struct RemainderEntry {
+        std::size_t index;
+        uint128_t remainder;
+    };
+    std::vector<RemainderEntry> remainders;
+    remainders.reserve(weights.size());
+    std::size_t allocated = 0;
+    for (std::size_t i = 0; i != weights.size(); ++i) {
+        if (weights[i] == 0) {
+            continue;
+        }
+        const uint128_t numerator = static_cast<uint128_t>(total_budget) * static_cast<uint128_t>(weights[i]);
+        const uint128_t quotient = numerator / total_weight;
+        if (quotient > static_cast<uint128_t>(std::numeric_limits<std::size_t>::max())) {
+            return false;
+        }
+        const std::size_t allocation = static_cast<std::size_t>(quotient);
+        if (allocation > total_budget - allocated) {
+            return false;
+        }
+        out_allocations[i] = allocation;
+        allocated += allocation;
+        remainders.push_back({i, numerator % total_weight});
+    }
+
+    const std::size_t unallocated = total_budget - allocated;
+    if (unallocated > remainders.size()) {
+        return false;
+    }
+    std::sort(remainders.begin(), remainders.end(), [&instance_ids](const auto &lhs, const auto &rhs) {
+        if (lhs.remainder != rhs.remainder) {
+            return lhs.remainder > rhs.remainder;
+        }
+        if (instance_ids[lhs.index] != instance_ids[rhs.index]) {
+            return instance_ids[lhs.index] < instance_ids[rhs.index];
+        }
+        return lhs.index < rhs.index;
+    });
+    for (std::size_t i = 0; i != unallocated; ++i) {
+        ++out_allocations[remainders[i].index];
+    }
+    return true;
+}
+
+bool CacheReclaimer::BuildFairReclaimPlan(const RequestContext *request_context,
+                                          const WaterLevelExceed &water_level_exceed,
+                                          const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos,
+                                          const std::size_t configured_sampling_size,
+                                          const std::size_t configured_batch_size,
+                                          FairReclaimPlan &out_plan) const noexcept {
+    out_plan = FairReclaimPlan{};
+    out_plan.configured_sampling_size = configured_sampling_size;
+    out_plan.configured_batch_size = configured_batch_size;
+    out_plan.normalized_sampling_size = configured_sampling_size;
+
+    if (configured_sampling_size == 0 || configured_batch_size == 0) {
+        LOG_WITH_TRACE(WARN,
+                       "skip fair reclaim plan because configured sampling size [%zu] or batching size [%zu] is zero",
+                       configured_sampling_size,
+                       configured_batch_size);
+        return false;
+    }
+    if (configured_sampling_size < configured_batch_size) {
+        out_plan.normalized_sampling_size = configured_batch_size;
+        out_plan.sampling_size_normalized = true;
+        KVCM_INTERVAL_LOG_WARN(10,
+                               "trace_id [%s] | normalize fair sampling size from [%zu] to batching size [%zu]",
+                               request_context->trace_id().c_str(),
+                               configured_sampling_size,
+                               configured_batch_size);
+    }
+
+    if (water_level_exceed.CheckStorageTypeWaterLevelExceed()) {
+        out_plan.weight_dimension = FairWeightDimension::STORAGE_TYPE_BYTES;
+    } else if (water_level_exceed.GetGroupBytesWaterLevelExceed()) {
+        out_plan.weight_dimension = FairWeightDimension::GROUP_BYTES;
+    } else if (water_level_exceed.GetGroupKeysWaterLevelExceed()) {
+        out_plan.weight_dimension = FairWeightDimension::GROUP_KEYS;
+    } else {
+        return false;
+    }
+
+    out_plan.items.reserve(instance_infos.size());
+    for (std::size_t i = 0; i != instance_infos.size(); ++i) {
+        const auto &instance_info = instance_infos[i];
+        if (instance_info == nullptr) {
+            LOG_WITH_TRACE(WARN, "skip nullptr instance when building fair reclaim plan");
+            continue;
+        }
+
+        const std::string &ins_id = instance_info->instance_id();
+        const std::string &ins_gr = instance_info->instance_group_name();
+        const auto meta_indexer = meta_indexer_manager_->GetMetaIndexer(ins_id);
+        if (meta_indexer == nullptr) {
+            LOG_WITH_ID(WARN, "skip instance without meta indexer when building fair reclaim plan");
+            continue;
+        }
+
+        std::uint64_t weight = 0;
+        switch (out_plan.weight_dimension) {
+        case FairWeightDimension::STORAGE_TYPE_BYTES:
+            for (std::size_t type_index = 1; type_index < static_cast<std::size_t>(DataStorageType::COUNT);
+                 ++type_index) {
+                const auto type = static_cast<DataStorageType>(type_index);
+                if (type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS || IsEventReportStorageType(type) ||
+                    !water_level_exceed.GetWaterLevelExceedByType(type)) {
+                    continue;
+                }
+                weight = SaturatingAdd(weight, meta_indexer->GetStorageUsageByType(type));
+            }
+            break;
+        case FairWeightDimension::GROUP_BYTES:
+            // EventReport bytes remain part of the official group watermark, but their
+            // reporter-owned locations cannot be deleted by the generic Reclaimer. Keep
+            // the trigger unchanged while assigning fair responsibility only by bytes
+            // that this path can actually reclaim. VCNS_HF3FS aliases the HF3FS slot and
+            // must be skipped to avoid double counting.
+            for (std::size_t type_index = 1; type_index < static_cast<std::size_t>(DataStorageType::COUNT);
+                 ++type_index) {
+                const auto type = static_cast<DataStorageType>(type_index);
+                if (type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS || IsEventReportStorageType(type)) {
+                    continue;
+                }
+                weight = SaturatingAdd(weight, meta_indexer->GetStorageUsageByType(type));
+            }
+            break;
+        case FairWeightDimension::GROUP_KEYS:
+            weight = static_cast<std::uint64_t>(meta_indexer->GetKeyCount());
+            break;
+        case FairWeightDimension::NONE:
+        default:
+            break;
+        }
+
+        if (weight == 0) {
+            ++out_plan.zero_weight_instance_count;
+            continue;
+        }
+        out_plan.items.push_back({instance_info, ins_id, weight, 0, 0, 0, 0, i});
+    }
+
+    out_plan.effective_instance_count = out_plan.items.size();
+    if (out_plan.effective_instance_count == 0) {
+        LOG_WITH_TRACE(WARN,
+                       "water level exceeded but all instances have zero weight for fair dimension [%s]",
+                       FairWeightDimensionName(out_plan.weight_dimension));
+        return false;
+    }
+
+    const auto checked_multiply = [](const std::size_t lhs, const std::size_t rhs, std::size_t &out) {
+        if (lhs != 0 && rhs > std::numeric_limits<std::size_t>::max() / lhs) {
+            return false;
+        }
+        out = lhs * rhs;
+        return true;
+    };
+    if (!checked_multiply(configured_batch_size, out_plan.effective_instance_count, out_plan.group_batch_size) ||
+        !checked_multiply(
+            out_plan.normalized_sampling_size, out_plan.effective_instance_count, out_plan.group_sampling_size)) {
+        LOG_WITH_TRACE(ERROR,
+                       "fair reclaim Group budget overflow, batch [%zu], sampling [%zu], instance count [%zu]",
+                       configured_batch_size,
+                       out_plan.normalized_sampling_size,
+                       out_plan.effective_instance_count);
+        return false;
+    }
+
+    std::vector<std::uint64_t> weights;
+    std::vector<std::string> instance_ids;
+    weights.reserve(out_plan.items.size());
+    instance_ids.reserve(out_plan.items.size());
+    for (const auto &item : out_plan.items) {
+        weights.push_back(item.weight);
+        instance_ids.push_back(item.instance_id);
+    }
+
+    std::vector<std::size_t> batch_allocations;
+    if (!AllocateFairBudget(out_plan.group_batch_size, weights, instance_ids, batch_allocations)) {
+        LOG_WITH_TRACE(ERROR, "allocate fair batch budget failed");
+        return false;
+    }
+    for (std::size_t i = 0; i != out_plan.items.size(); ++i) {
+        out_plan.items[i].raw_batch_size = batch_allocations[i];
+        out_plan.items[i].raw_sampling_size = batch_allocations[i];
+    }
+
+    const std::size_t extra_sampling_budget = out_plan.group_sampling_size - out_plan.group_batch_size;
+    std::vector<std::size_t> sampling_item_indexes;
+    std::vector<std::uint64_t> sampling_weights;
+    std::vector<std::string> sampling_instance_ids;
+    for (std::size_t i = 0; i != out_plan.items.size(); ++i) {
+        if (out_plan.items[i].raw_batch_size == 0) {
+            continue;
+        }
+        sampling_item_indexes.push_back(i);
+        sampling_weights.push_back(out_plan.items[i].weight);
+        sampling_instance_ids.push_back(out_plan.items[i].instance_id);
+    }
+
+    std::vector<std::size_t> extra_sampling_allocations;
+    if (!AllocateFairBudget(
+            extra_sampling_budget, sampling_weights, sampling_instance_ids, extra_sampling_allocations)) {
+        LOG_WITH_TRACE(ERROR, "allocate fair extra sampling budget failed");
+        return false;
+    }
+    for (std::size_t i = 0; i != sampling_item_indexes.size(); ++i) {
+        auto &item = out_plan.items[sampling_item_indexes[i]];
+        if (extra_sampling_allocations[i] > std::numeric_limits<std::size_t>::max() - item.raw_sampling_size) {
+            LOG_WITH_TRACE(ERROR, "fair sampling item budget overflow");
+            return false;
+        }
+        item.raw_sampling_size += extra_sampling_allocations[i];
+    }
+
+    constexpr std::size_t kPerInstanceHardLimit = kSizeLimit - 1;
+    const std::size_t per_instance_batch_limit = std::min(configured_batch_size, kPerInstanceHardLimit);
+    const std::size_t per_instance_sampling_limit = std::min(out_plan.normalized_sampling_size, kPerInstanceHardLimit);
+    using uint128_t = unsigned __int128;
+    for (auto &item : out_plan.items) {
+        item.sampling_size = std::min(item.raw_sampling_size, per_instance_sampling_limit);
+        item.batch_size = std::min(item.raw_batch_size, per_instance_batch_limit);
+        const bool sampling_size_capped = item.sampling_size != item.raw_sampling_size;
+
+        // Preserve the configured sampling amplification after clipping.
+        // Otherwise sampling can hit its limit before batching and gradually
+        // degrade into selecting every sampled key instead of the oldest subset.
+        if (sampling_size_capped && out_plan.normalized_sampling_size > configured_batch_size) {
+            uint128_t max_batch_for_sampling = static_cast<uint128_t>(item.sampling_size) *
+                                               static_cast<uint128_t>(configured_batch_size) /
+                                               static_cast<uint128_t>(out_plan.normalized_sampling_size);
+            // Ratios above the hard sampling limit cannot be preserved exactly.
+            // Do not turn an already allocated nonzero batch into permanent
+            // no-progress; this does not grant a minimum to raw zero allocations.
+            if (max_batch_for_sampling == 0 && item.batch_size > 0) {
+                max_batch_for_sampling = 1;
+            }
+            item.batch_size = std::min(item.batch_size, static_cast<std::size_t>(max_batch_for_sampling));
+        }
+        const bool item_capped = item.batch_size != item.raw_batch_size || sampling_size_capped;
+        if (item.batch_size == 0) {
+            if (item_capped) {
+                LOG_WITH_TRACE(DEBUG,
+                               "drop fair plan item [%s] because capped batch size is zero, raw batch/sample "
+                               "[%zu/%zu], capped sample [%zu]",
+                               item.instance_id.c_str(),
+                               item.raw_batch_size,
+                               item.raw_sampling_size,
+                               item.sampling_size);
+            }
+            item.sampling_size = 0;
+            continue;
+        }
+        if (item_capped) {
+            ++out_plan.capped_item_count;
+        }
+    }
+    out_plan.items.erase(std::remove_if(out_plan.items.begin(),
+                                        out_plan.items.end(),
+                                        [](const FairReclaimPlanItem &item) { return item.batch_size == 0; }),
+                         out_plan.items.end());
+    std::sort(out_plan.items.begin(), out_plan.items.end(), [](const auto &lhs, const auto &rhs) {
+        if (lhs.weight != rhs.weight) {
+            return lhs.weight > rhs.weight;
+        }
+        if (lhs.batch_size != rhs.batch_size) {
+            return lhs.batch_size > rhs.batch_size;
+        }
+        if (lhs.instance_id != rhs.instance_id) {
+            return lhs.instance_id < rhs.instance_id;
+        }
+        return lhs.original_index < rhs.original_index;
+    });
+    return true;
+}
+
 CacheReclaimer::ReclaimResult
 CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request_context,
                                   const std::shared_ptr<const InstanceGroup> &instance_group) noexcept {
@@ -2122,7 +2600,6 @@ CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request
     }
 
     const std::string &ins_gr = instance_group->name();
-
     const auto cache_config = instance_group->cache_config();
     if (cache_config == nullptr) {
         LOG_WITH_GR(WARN, "cache config is nullptr");
@@ -2134,15 +2611,47 @@ CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request
         LOG_WITH_GR(WARN, "reclaim strategy is nullptr");
         return result;
     }
-    const std::int32_t delay_before_delete_ms = reclaim_strategy->delay_before_delete_ms();
 
-    // retrieve all the instances in this group
+    // Retrieve the list before branching, as in the legacy path. The budget
+    // policy only changes planning and execution after this point.
     const auto [ec, instance_infos] = registry_manager_->ListInstanceInfo(request_context.get(), ins_gr);
     if (ec != ErrorCode::EC_OK) {
         LOG_WITH_GR(WARN, "list instances info failed, error code: [%d]", static_cast<std::int32_t>(ec));
         return result;
     }
 
+    const auto budget_policy = reclaim_strategy->instance_reclaim_budget_policy();
+    if (budget_policy == InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE) {
+        result = TryReclaimOnGroupLegacy(request_context, instance_group, reclaim_strategy, instance_infos);
+    } else {
+        if (budget_policy != InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL) {
+            LOG_WITH_GR(WARN,
+                        "unknown instance reclaim budget policy: [%d], falling back to usage-proportional",
+                        static_cast<std::int32_t>(budget_policy));
+        }
+        result = TryReclaimOnGroupFair(request_context, instance_group, reclaim_strategy, instance_infos);
+    }
+
+    // Reclaim admission precedes migration preparation in the same cron round. An accepted
+    // delete is synchronously recorded in pending_locations_, so the migration job snapshot
+    // excludes that exact location before asynchronous Create/Copy starts. This only orders
+    // admission; it does not wait for physical deletion. Migration still runs independently
+    // when its lower watermark is reached before the reclaim threshold.
+    if (migration_manager_ != nullptr && !cache_config->migration_strategies().empty()) {
+        TryMigrateOnGroup(request_context, instance_group, instance_infos);
+    }
+
+    return result;
+}
+
+CacheReclaimer::ReclaimResult CacheReclaimer::TryReclaimOnGroupLegacy(
+    const std::shared_ptr<RequestContext> &request_context,
+    const std::shared_ptr<const InstanceGroup> &instance_group,
+    const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
+    const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept {
+    ReclaimResult result;
+    const std::string &ins_gr = instance_group->name();
+    const std::int32_t delay_before_delete_ms = reclaim_strategy->delay_before_delete_ms();
     for (const auto &instance_info : instance_infos) {
         const std::int64_t quota_begin_tp = TimestampUtil::GetSteadyTimeUs();
         const auto water_level_exceed = GetWaterLevelExceed(
@@ -2178,16 +2687,210 @@ CacheReclaimer::TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request
             static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
         result.made_progress = result.made_progress || submitted;
     }
+    return result;
+}
 
-    // Reclaim admission precedes migration preparation in the same cron round. An accepted
-    // delete is synchronously recorded in pending_locations_, so the migration job snapshot
-    // excludes that exact location before asynchronous Create/Copy starts. This only orders
-    // admission; it does not wait for physical deletion. Migration still runs independently
-    // when its lower watermark is reached before the reclaim threshold.
-    if (migration_manager_ != nullptr && !cache_config->migration_strategies().empty()) {
-        TryMigrateOnGroup(request_context, instance_group, instance_infos);
+CacheReclaimer::ReclaimResult
+CacheReclaimer::TryReclaimOnGroupFair(const std::shared_ptr<RequestContext> &request_context,
+                                      const std::shared_ptr<const InstanceGroup> &instance_group,
+                                      const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
+                                      const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept {
+    ReclaimResult result;
+    const std::string &ins_gr = instance_group->name();
+    const std::int32_t delay_before_delete_ms = reclaim_strategy->delay_before_delete_ms();
+    METRICS_(cache_reclaimer, fair_effective_instance_count) = 0;
+    METRICS_(cache_reclaimer, fair_planned_instance_count) = 0;
+    METRICS_(cache_reclaimer, fair_sampled_instance_count) = 0;
+    METRICS_(cache_reclaimer, fair_submitted_instance_count) = 0;
+
+    const auto read_water_level = [&]() {
+        const std::int64_t quota_begin_tp = TimestampUtil::GetSteadyTimeUs();
+        auto water_level = GetWaterLevelExceed(
+            request_context.get(), ins_gr, instance_group->quota(), reclaim_strategy, instance_infos);
+        METRICS_(cache_reclaimer, reclaim_quota_duration_us) =
+            static_cast<double>(TimestampUtil::GetSteadyTimeUs() - quota_begin_tp);
+        return water_level;
+    };
+
+    const auto log_water_level_unavailable = [&]() {
+        if (!IsRunning() || IsPaused()) {
+            LOG_WITH_GR(DEBUG, "fair plan stopped because reclaimer is stopping or paused");
+        } else {
+            LOG_WITH_GR(WARN, "fair plan stopped because water level could not be read");
+        }
+    };
+
+    const auto initial_water_level = read_water_level();
+    if (initial_water_level == nullptr) {
+        log_water_level_unavailable();
+        return result;
+    }
+    if (!IsTriggerReclaiming(initial_water_level)) {
+        LOG_WITH_GR(DEBUG, "instance group does not trigger reclaiming");
+        return result;
+    }
+    result.water_level_exceeded = true;
+
+    FairReclaimPlan plan;
+    const std::size_t configured_sampling_size = sampling_size_.load();
+    const std::size_t configured_batch_size = batching_size_.load();
+    const bool plan_built = BuildFairReclaimPlan(request_context.get(),
+                                                 *initial_water_level,
+                                                 instance_infos,
+                                                 configured_sampling_size,
+                                                 configured_batch_size,
+                                                 plan);
+    METRICS_(cache_reclaimer, fair_zero_weight_skip_count) += plan.zero_weight_instance_count;
+    if (plan.sampling_size_normalized) {
+        METRICS_(cache_reclaimer, fair_sampling_size_normalized_count) += 1;
+    }
+    METRICS_(cache_reclaimer, fair_effective_instance_count) = static_cast<double>(plan.effective_instance_count);
+    if (!plan_built) {
+        return result;
     }
 
+    std::uint64_t planned_batch_count = 0;
+    std::uint64_t planned_sample_count = 0;
+    const std::uint64_t capped_item_count = static_cast<std::uint64_t>(plan.capped_item_count);
+    for (const auto &item : plan.items) {
+        planned_batch_count = SaturatingAdd(planned_batch_count, item.batch_size);
+        planned_sample_count = SaturatingAdd(planned_sample_count, item.sampling_size);
+        LOG_WITH_GR(DEBUG,
+                    "fair plan item instance [%s], weight [%" PRIu64 "], raw batch [%zu], raw sample [%zu], "
+                    "batch [%zu], sample [%zu]",
+                    item.instance_id.c_str(),
+                    item.weight,
+                    item.raw_batch_size,
+                    item.raw_sampling_size,
+                    item.batch_size,
+                    item.sampling_size);
+    }
+    METRICS_(cache_reclaimer, fair_plan_count) += 1;
+    METRICS_(cache_reclaimer, fair_planned_batch_count) += planned_batch_count;
+    METRICS_(cache_reclaimer, fair_planned_sample_count) += planned_sample_count;
+    METRICS_(cache_reclaimer, fair_item_capped_count) += capped_item_count;
+    METRICS_(cache_reclaimer, fair_planned_instance_count) = static_cast<double>(plan.items.size());
+
+    LOG_WITH_GR(DEBUG,
+                "fair plan dimension [%s], group bytes exceeded [%d], group keys exceeded [%d], "
+                "type exceeded [%d], configured batch/sample [%zu/%zu], normalized sample [%zu], "
+                "group batch/sample [%zu/%zu], effective/planned instances [%zu/%zu]",
+                FairWeightDimensionName(plan.weight_dimension),
+                initial_water_level->GetGroupBytesWaterLevelExceed(),
+                initial_water_level->GetGroupKeysWaterLevelExceed(),
+                initial_water_level->CheckStorageTypeWaterLevelExceed(),
+                plan.configured_batch_size,
+                plan.configured_sampling_size,
+                plan.normalized_sampling_size,
+                plan.group_batch_size,
+                plan.group_sampling_size,
+                plan.effective_instance_count,
+                plan.items.size());
+
+    const auto plan_scope_still_active = [&](const WaterLevelExceed &current_water_level) {
+        switch (plan.weight_dimension) {
+        case FairWeightDimension::STORAGE_TYPE_BYTES:
+            for (std::size_t type_index = 1; type_index < static_cast<std::size_t>(DataStorageType::COUNT);
+                 ++type_index) {
+                const auto type = static_cast<DataStorageType>(type_index);
+                if (type == DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS) {
+                    continue;
+                }
+                if (initial_water_level->GetWaterLevelExceedByType(type) !=
+                    current_water_level.GetWaterLevelExceedByType(type)) {
+                    return false;
+                }
+            }
+            return current_water_level.CheckStorageTypeWaterLevelExceed();
+        case FairWeightDimension::GROUP_BYTES:
+            return !current_water_level.CheckStorageTypeWaterLevelExceed() &&
+                   current_water_level.GetGroupBytesWaterLevelExceed();
+        case FairWeightDimension::GROUP_KEYS:
+            return !current_water_level.CheckStorageTypeWaterLevelExceed() &&
+                   !current_water_level.GetGroupBytesWaterLevelExceed() &&
+                   current_water_level.GetGroupKeysWaterLevelExceed();
+        case FairWeightDimension::NONE:
+        default:
+            return false;
+        }
+    };
+
+    std::size_t sampled_instance_count = 0;
+    std::size_t submitted_instance_count = 0;
+    std::shared_ptr<WaterLevelExceed> water_level_before_next_item;
+    for (std::size_t i = 0; i != plan.items.size(); ++i) {
+        auto water_level_exceed =
+            water_level_before_next_item != nullptr ? std::move(water_level_before_next_item) : read_water_level();
+        if (water_level_exceed == nullptr) {
+            log_water_level_unavailable();
+            break;
+        }
+        if (!IsTriggerReclaiming(water_level_exceed) || !plan_scope_still_active(*water_level_exceed)) {
+            const std::size_t remaining = plan.items.size() - i;
+            METRICS_(cache_reclaimer, fair_plan_truncated_count) += 1;
+            METRICS_(cache_reclaimer, fair_plan_truncated_instance_count) += remaining;
+            LOG_WITH_GR(DEBUG,
+                        "fair plan stopped before instance [%s], water level satisfied or trigger scope "
+                        "changed, remaining items [%zu]",
+                        plan.items[i].instance_id.c_str(),
+                        remaining);
+            break;
+        }
+
+        const auto &item = plan.items[i];
+        ++sampled_instance_count;
+        const std::int64_t begin_tp = TimestampUtil::GetSteadyTimeUs();
+        switch (reclaim_strategy->reclaim_policy()) {
+        case ReclaimPolicy::POLICY_LFU:
+            LOG_WITH_TRACE(WARN, "LFU reclaim policy not supported yet; fall back to fair LRU policy");
+            break;
+        case ReclaimPolicy::POLICY_TTL:
+            LOG_WITH_TRACE(WARN, "TTL reclaim policy not supported yet; fall back to fair LRU policy");
+            break;
+        case ReclaimPolicy::POLICY_UNSPECIFIED:
+        case ReclaimPolicy::POLICY_LRU:
+        default:
+            break;
+        }
+        const bool submitted = ReclaimByLRUWithBudget(request_context,
+                                                      item.instance_info,
+                                                      *initial_water_level,
+                                                      delay_before_delete_ms,
+                                                      item.sampling_size,
+                                                      item.batch_size);
+        METRICS_(cache_reclaimer, reclaim_job_duration_us) =
+            static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp);
+        result.made_progress = result.made_progress || submitted;
+        if (!submitted) {
+            continue;
+        }
+
+        ++submitted_instance_count;
+        if (i + 1 == plan.items.size()) {
+            continue;
+        }
+        water_level_before_next_item = read_water_level();
+        if (water_level_before_next_item == nullptr) {
+            log_water_level_unavailable();
+            break;
+        }
+        if (!IsTriggerReclaiming(water_level_before_next_item) ||
+            !plan_scope_still_active(*water_level_before_next_item)) {
+            const std::size_t remaining = plan.items.size() - i - 1;
+            METRICS_(cache_reclaimer, fair_plan_truncated_count) += 1;
+            METRICS_(cache_reclaimer, fair_plan_truncated_instance_count) += remaining;
+            LOG_WITH_GR(DEBUG,
+                        "fair plan stopped after accepted instance [%s], credit satisfied water level or "
+                        "trigger scope changed, "
+                        "remaining items [%zu]",
+                        item.instance_id.c_str(),
+                        remaining);
+            break;
+        }
+    }
+
+    METRICS_(cache_reclaimer, fair_sampled_instance_count) = static_cast<double>(sampled_instance_count);
+    METRICS_(cache_reclaimer, fair_submitted_instance_count) = static_cast<double>(submitted_instance_count);
     return result;
 }
 

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -436,16 +436,22 @@ private:
         ~WaterLevelExceed() = default;
 
         [[nodiscard]] bool GetGeneralWaterLevelExceed() const noexcept;
+        [[nodiscard]] bool GetGroupBytesWaterLevelExceed() const noexcept;
+        [[nodiscard]] bool GetGroupKeysWaterLevelExceed() const noexcept;
         [[nodiscard]] bool GetWaterLevelExceedByType(const DataStorageType &type) const noexcept;
-        void SetGeneralWaterLevelExceed(bool value) noexcept;
+        void SetGroupBytesWaterLevelExceed(bool value) noexcept;
+        void SetGroupKeysWaterLevelExceed(bool value) noexcept;
         void SetWaterLevelExceedByType(const DataStorageType &type, bool value) noexcept;
 
         [[nodiscard]] bool CheckGroupWaterLevelExceed() const noexcept;       // general or any storage type exceed
         [[nodiscard]] bool CheckStorageTypeWaterLevelExceed() const noexcept; // any single storage type exceed
 
     private:
-        // group general water level exceed flag
-        bool general_water_level_exceed_;
+        // Group byte usage and key count are independent trigger
+        // dimensions. GetGeneralWaterLevelExceed() remains as the
+        // compatibility view of their logical OR.
+        bool group_bytes_water_level_exceed_;
+        bool group_keys_water_level_exceed_;
 
         using array_t_ = std::array<bool, static_cast<std::size_t>(DataStorageType::COUNT)>;
         using size_t_ = array_t_::size_type;
@@ -462,6 +468,38 @@ private:
         // slot 8: DATA_STORAGE_TYPE_EVENT_REPORT_L2 exceed flag
         // slot 9: DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD exceed flag
         array_t_ water_level_exceed_by_type_;
+    };
+
+    enum class FairWeightDimension {
+        NONE,
+        STORAGE_TYPE_BYTES,
+        GROUP_BYTES,
+        GROUP_KEYS,
+    };
+
+    struct FairReclaimPlanItem {
+        std::shared_ptr<const InstanceInfo> instance_info;
+        std::string instance_id;
+        std::uint64_t weight{0};
+        std::size_t raw_batch_size{0};
+        std::size_t raw_sampling_size{0};
+        std::size_t batch_size{0};
+        std::size_t sampling_size{0};
+        std::size_t original_index{0};
+    };
+
+    struct FairReclaimPlan {
+        FairWeightDimension weight_dimension{FairWeightDimension::NONE};
+        std::size_t configured_batch_size{0};
+        std::size_t configured_sampling_size{0};
+        std::size_t normalized_sampling_size{0};
+        std::size_t group_batch_size{0};
+        std::size_t group_sampling_size{0};
+        std::size_t effective_instance_count{0};
+        std::size_t zero_weight_instance_count{0};
+        std::size_t capped_item_count{0};
+        bool sampling_size_normalized{false};
+        std::vector<FairReclaimPlanItem> items;
     };
 
     /**
@@ -514,6 +552,21 @@ private:
                       const WaterLevelExceed &water_level_exceed,
                       std::int32_t delay_before_delete_ms) noexcept;
 
+    bool ReclaimByLRUWithBudget(const std::shared_ptr<RequestContext> &request_context,
+                                const std::shared_ptr<const InstanceInfo> &instance_info,
+                                const WaterLevelExceed &water_level_exceed,
+                                std::int32_t delay_before_delete_ms,
+                                std::size_t sampling_size,
+                                std::size_t batching_size) noexcept;
+
+    bool ReclaimByLRUImpl(const std::shared_ptr<RequestContext> &request_context,
+                          const std::shared_ptr<const InstanceInfo> &instance_info,
+                          const WaterLevelExceed &water_level_exceed,
+                          std::int32_t delay_before_delete_ms,
+                          bool use_fair_budget,
+                          std::size_t sampling_size,
+                          std::size_t batching_size) noexcept;
+
     /**
      * @brief Reclaim cache entries using LFU (Least Frequently Used)
      * strategy
@@ -555,6 +608,32 @@ private:
     ReclaimResult TryReclaimOnGroup(const std::shared_ptr<RequestContext> &request_context,
                                     const std::shared_ptr<const InstanceGroup> &instance_group) noexcept;
 
+    ReclaimResult
+    TryReclaimOnGroupLegacy(const std::shared_ptr<RequestContext> &request_context,
+                            const std::shared_ptr<const InstanceGroup> &instance_group,
+                            const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
+                            const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept;
+
+    ReclaimResult
+    TryReclaimOnGroupFair(const std::shared_ptr<RequestContext> &request_context,
+                          const std::shared_ptr<const InstanceGroup> &instance_group,
+                          const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy,
+                          const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos) noexcept;
+
+    [[nodiscard]] bool BuildFairReclaimPlan(const RequestContext *request_context,
+                                            const WaterLevelExceed &water_level_exceed,
+                                            const std::vector<std::shared_ptr<const InstanceInfo>> &instance_infos,
+                                            std::size_t configured_sampling_size,
+                                            std::size_t configured_batch_size,
+                                            FairReclaimPlan &out_plan) const noexcept;
+
+    [[nodiscard]] static bool AllocateFairBudget(std::size_t total_budget,
+                                                 const std::vector<std::uint64_t> &weights,
+                                                 const std::vector<std::string> &instance_ids,
+                                                 std::vector<std::size_t> &out_allocations) noexcept;
+
+    [[nodiscard]] static const char *FairWeightDimensionName(FairWeightDimension dimension) noexcept;
+
     void HandleDelRes() noexcept;
 
     /**
@@ -574,6 +653,13 @@ private:
                        std::vector<std::int64_t> &out_keys,
                        std::vector<std::map<std::string, std::string>> &out_maps) noexcept;
 
+    bool DoKeySamplingWithSize(const std::shared_ptr<RequestContext> &request_context,
+                               const std::shared_ptr<const InstanceInfo> &instance_info,
+                               std::size_t total_sampling_size,
+                               bool bounded_waves,
+                               std::vector<std::int64_t> &out_keys,
+                               std::vector<std::map<std::string, std::string>> &out_maps) noexcept;
+
     bool MakeBatchByLRU(const RequestContext *request_context,
                         const std::shared_ptr<const InstanceInfo> &instance_info,
                         const std::vector<std::int64_t> &sampled_keys,
@@ -581,12 +667,20 @@ private:
                         std::vector<std::int64_t> &out_batch,
                         AgeStats &out_lru_age_stats) const noexcept;
 
+    bool MakeBatchByLRUWithSize(const RequestContext *request_context,
+                                const std::shared_ptr<const InstanceInfo> &instance_info,
+                                const std::vector<std::int64_t> &sampled_keys,
+                                const std::vector<std::map<std::string, std::string>> &property_maps,
+                                std::size_t batching_size,
+                                std::vector<std::int64_t> &out_batch,
+                                AgeStats &out_lru_age_stats) const noexcept;
+
     bool BuildMigrationCandidateBatch(const std::shared_ptr<RequestContext> &request_context,
                                       const std::shared_ptr<const InstanceInfo> &instance_info,
                                       std::vector<std::int64_t> &out_batch) noexcept;
 
-    std::vector<std::vector<std::string>>
-    SnapshotPendingLocations(const std::string &instance_id, const std::vector<std::int64_t> &batch) const;
+    std::vector<std::vector<std::string>> SnapshotPendingLocations(const std::string &instance_id,
+                                                                   const std::vector<std::int64_t> &batch) const;
 
     bool SubmitMigrationPrepareJob(const std::shared_ptr<RequestContext> &request_context,
                                    const std::shared_ptr<const InstanceInfo> &instance_info,
@@ -649,6 +743,14 @@ private:
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(delete_fail_count)
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(migration_copy_submitted_total)
     KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(migration_mark_submitted_total)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_plan_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_planned_batch_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_planned_sample_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_zero_weight_skip_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_plan_truncated_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_plan_truncated_instance_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_item_capped_count)
+    KVCM_COUNTER_METRICS_FOR_CACHE_RECLAIMER(fair_sampling_size_normalized_count)
 
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_cron_duration_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_quota_duration_us)
@@ -664,6 +766,10 @@ private:
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(credited_delete_bytes)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(predicted_deleted_key_count)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(oldest_pending_request_age_ms)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_effective_instance_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_planned_instance_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_sampled_instance_count)
+    KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(fair_submitted_instance_count)
 
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_min_us)
     KVCM_GAUGE_METRICS_FOR_CACHE_RECLAIMER(reclaim_batch_lru_age_max_us)

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -4,11 +4,15 @@
 #include <condition_variable>
 #include <cstddef>
 #include <exception>
+#include <functional>
 #include <future>
 #include <limits>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -252,6 +256,8 @@ PlanExecuteResult del_result;
 bool spe_submit_accepted;
 bool spe_submit_auto_complete;
 bool spe_submit_invalid_future;
+std::map<std::string, bool> spe_submit_accepted_by_instance;
+std::function<void(const CacheLocationDelRequest &)> spe_submit_accepted_callback;
 std::vector<CacheLocationDelRequest> submitted_del_requests;
 std::vector<std::shared_ptr<std::promise<PlanExecuteResult>>> submitted_del_promises;
 std::mutex submitted_del_requests_mutex;
@@ -259,16 +265,26 @@ using spe_submit_async_loc = AsyncDeleteSubmitResult (SchedulePlanExecutor::*)(c
 
 AsyncDeleteSubmitResult SchedulePlanExecutor_SubmitAsync_stub(void *obj, const CacheLocationDelRequest &request) {
     const auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    bool accepted = spe_submit_accepted;
+    std::function<void(const CacheLocationDelRequest &)> accepted_callback;
     {
         std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
         submitted_del_requests.emplace_back(request);
-        if (!spe_submit_auto_complete) {
+        const auto accepted_it = spe_submit_accepted_by_instance.find(request.instance_id);
+        if (accepted_it != spe_submit_accepted_by_instance.end()) {
+            accepted = accepted_it->second;
+        }
+        accepted_callback = spe_submit_accepted_callback;
+        if (accepted && !spe_submit_auto_complete) {
             submitted_del_promises.emplace_back(promise);
         }
     }
     std::this_thread::sleep_for(spe_submit_delay);
-    if (!spe_submit_accepted) {
+    if (!accepted) {
         return {};
+    }
+    if (accepted_callback) {
+        accepted_callback(request);
     }
     if (spe_submit_invalid_future) {
         return AsyncDeleteSubmitResult{true, {}};
@@ -284,8 +300,14 @@ AsyncDeleteSubmitResult SchedulePlanExecutor_SubmitAsync_stub(void *obj, const C
 
 // the dummy meta_indexer that the meta_indexer_manager would return
 std::shared_ptr<MetaIndexer> dummy_meta_indexer;
+std::map<std::string, std::shared_ptr<MetaIndexer>> meta_indexers_by_instance;
+std::map<const void *, std::string> instance_id_by_meta_indexer;
 
 std::shared_ptr<MetaIndexer> MetaIndexerManager_GetMetaIndexer_stub(void *obj, const std::string &i) {
+    const auto it = meta_indexers_by_instance.find(i);
+    if (it != meta_indexers_by_instance.end()) {
+        return it->second;
+    }
     return dummy_meta_indexer;
 }
 
@@ -344,13 +366,32 @@ MetaIndexer_RandomSample_stub(void *obj, RequestContext *rc, const std::size_t c
 
 std::chrono::milliseconds mi_sample_reclaim_delay{0};
 ErrorCode sample_reclaim_result;
+std::vector<ErrorCode> sample_reclaim_results;
+std::vector<std::chrono::milliseconds> mi_sample_reclaim_delays;
+std::size_t sample_reclaim_call_count;
 KeyVector sample_reclaim_keys;
 int sample_reclaim_call_counter;
+std::mutex sample_reclaim_requests_mutex;
+std::vector<std::pair<std::string, std::int64_t>> sample_reclaim_requests;
 
 ErrorCode
 MetaIndexer_SampleReclaimKeys_stub(void *obj, RequestContext *rc, const std::int64_t c, KeyVector &out_keys) noexcept {
     ++sample_reclaim_call_counter;
-    if (sample_reclaim_result == ErrorCode::EC_OK) {
+    ErrorCode result = sample_reclaim_result;
+    std::chrono::milliseconds delay = mi_sample_reclaim_delay;
+    {
+        std::lock_guard<std::mutex> lock(sample_reclaim_requests_mutex);
+        const auto it = instance_id_by_meta_indexer.find(obj);
+        sample_reclaim_requests.emplace_back(it == instance_id_by_meta_indexer.end() ? std::string{} : it->second, c);
+        const std::size_t call_index = sample_reclaim_call_count++;
+        if (call_index < sample_reclaim_results.size()) {
+            result = sample_reclaim_results[call_index];
+        }
+        if (call_index < mi_sample_reclaim_delays.size()) {
+            delay = mi_sample_reclaim_delays[call_index];
+        }
+    }
+    if (result == ErrorCode::EC_OK) {
         if (c == static_cast<std::int64_t>(sample_reclaim_keys.size())) {
             out_keys = sample_reclaim_keys;
         } else if (c == 11) {
@@ -360,16 +401,20 @@ MetaIndexer_SampleReclaimKeys_stub(void *obj, RequestContext *rc, const std::int
             out_keys = KeyVector(c);
         }
     }
-    std::this_thread::sleep_for(mi_sample_reclaim_delay);
-    return sample_reclaim_result;
+    std::this_thread::sleep_for(delay);
+    return result;
 }
 
 /* ---------------- MetaIndexer KeyCount stubs ---------------- */
 
 std::size_t key_count;
 std::size_t max_key_count;
+std::map<const void *, std::size_t> key_count_by_meta_indexer;
 
-size_t MetaIndexer_GetKeyCount_stub(void *obj) noexcept { return key_count; }
+size_t MetaIndexer_GetKeyCount_stub(void *obj) noexcept {
+    const auto it = key_count_by_meta_indexer.find(obj);
+    return it == key_count_by_meta_indexer.end() ? key_count : it->second;
+}
 
 size_t MetaIndexer_GetMaxKeyCount_stub(void *obj) noexcept { return max_key_count; }
 
@@ -437,6 +482,16 @@ public:
         list_ins_info_result = ErrorCode::EC_OK;
         instance_infos.emplace_back(InstanceInfoFactory());
 
+        meta_indexers_by_instance.clear();
+        instance_id_by_meta_indexer.clear();
+        key_count_by_meta_indexer.clear();
+        {
+            std::lock_guard<std::mutex> lock(sample_reclaim_requests_mutex);
+            sample_reclaim_requests.clear();
+            sample_reclaim_results.clear();
+            mi_sample_reclaim_delays.clear();
+            sample_reclaim_call_count = 0;
+        }
         dummy_meta_indexer = std::make_shared<MetaIndexer>();
         dummy_meta_searcher = std::make_shared<MetaSearcher>(nullptr);
 
@@ -450,6 +505,8 @@ public:
         captured_copy_trace.clear();
         captured_mark_keys.clear();
         captured_mark_target.clear();
+        spe_submit_accepted_by_instance.clear();
+        spe_submit_accepted_callback = {};
         get_result = ErrorCode::EC_OK;
         random_sample_result = ErrorCode::EC_OK;
         sample_reclaim_result = ErrorCode::EC_OK;
@@ -513,6 +570,22 @@ public:
             mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, migration_copy_submitted_total));
         cache_reclaimer_->METRICS_(cache_reclaimer, migration_mark_submitted_total) =
             mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, migration_mark_submitted_total));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_plan_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_plan_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_planned_batch_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_planned_batch_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_planned_sample_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_planned_sample_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_zero_weight_skip_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_zero_weight_skip_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_plan_truncated_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_plan_truncated_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_plan_truncated_instance_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_plan_truncated_instance_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_item_capped_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_item_capped_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_sampling_size_normalized_count) =
+            mr_->GetCounter(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_sampling_size_normalized_count));
 
         cache_reclaimer_->METRICS_(cache_reclaimer, reclaim_cron_duration_us) =
             mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, reclaim_cron_duration_us));
@@ -538,6 +611,14 @@ public:
             mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, predicted_deleted_key_count));
         cache_reclaimer_->METRICS_(cache_reclaimer, oldest_pending_request_age_ms) =
             mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, oldest_pending_request_age_ms));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_effective_instance_count) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_effective_instance_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_planned_instance_count) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_planned_instance_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_sampled_instance_count) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_sampled_instance_count));
+        cache_reclaimer_->METRICS_(cache_reclaimer, fair_submitted_instance_count) =
+            mr_->GetGauge(SCOPED_METRICS_NAME_(CacheReclaimer, cache_reclaimer, fair_submitted_instance_count));
     }
 
     void TearDown() override {
@@ -547,6 +628,9 @@ public:
         instance_groups.clear();
         instance_infos.clear();
 
+        meta_indexers_by_instance.clear();
+        instance_id_by_meta_indexer.clear();
+        key_count_by_meta_indexer.clear();
         dummy_meta_indexer.reset();
         dummy_meta_searcher.reset();
 
@@ -554,6 +638,8 @@ public:
             std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
             submitted_del_requests.clear();
             submitted_del_promises.clear();
+            spe_submit_accepted_by_instance.clear();
+            spe_submit_accepted_callback = {};
         }
         captured_copy_reqs.clear();
         captured_copy_req_batches.clear();
@@ -568,6 +654,13 @@ public:
         batch_get_loc_out_maps.clear();
         sample_reclaim_call_counter = 0;
         batch_get_loc_call_counter = 0;
+        {
+            std::lock_guard<std::mutex> lock(sample_reclaim_requests_mutex);
+            sample_reclaim_requests.clear();
+            sample_reclaim_results.clear();
+            mi_sample_reclaim_delays.clear();
+            sample_reclaim_call_count = 0;
+        }
 
         stub_.reset(ADDR(RegistryManager, ListInstanceGroup));
         stub_.reset(ADDR(RegistryManager, ListInstanceInfo));
@@ -646,6 +739,31 @@ public:
     std::size_t SubmittedDelRequestCount() {
         std::lock_guard<std::mutex> lock(submitted_del_requests_mutex);
         return submitted_del_requests.size();
+    }
+
+    std::vector<std::pair<std::string, std::int64_t>> SampleReclaimRequestsSnapshot() {
+        std::lock_guard<std::mutex> lock(sample_reclaim_requests_mutex);
+        return sample_reclaim_requests;
+    }
+
+    void ClearSampleReclaimRequests() {
+        std::lock_guard<std::mutex> lock(sample_reclaim_requests_mutex);
+        sample_reclaim_requests.clear();
+        sample_reclaim_call_count = 0;
+    }
+
+    std::shared_ptr<MetaIndexer>
+    AddMetaIndexerForInstance(const std::string &instance_id,
+                              const std::uint64_t nfs_usage,
+                              const std::optional<std::size_t> instance_key_count = std::nullopt) {
+        auto meta_indexer = std::make_shared<MetaIndexer>();
+        meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, nfs_usage);
+        meta_indexers_by_instance[instance_id] = meta_indexer;
+        instance_id_by_meta_indexer[meta_indexer.get()] = instance_id;
+        if (instance_key_count.has_value()) {
+            key_count_by_meta_indexer[meta_indexer.get()] = *instance_key_count;
+        }
+        return meta_indexer;
     }
 
     bool WaitUntilSubmittedDelRequests(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000)) {
@@ -1714,16 +1832,14 @@ TEST_F(CacheReclaimerTest, TestEventReportUsageDoesNotTriggerStorageTypeWaterLev
     max_key_count = 100;
 
     cache_reclaimer_->job_state_flag_ = true;
-    const auto water_level = cache_reclaimer_->GetWaterLevelExceed(
-        request_context_.get(),
-        instance_group->name(),
-        instance_group->quota(),
-        instance_group->cache_config()->reclaim_strategy(),
-        instance_infos);
+    const auto water_level = cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                                                   instance_group->name(),
+                                                                   instance_group->quota(),
+                                                                   instance_group->cache_config()->reclaim_strategy(),
+                                                                   instance_infos);
     ASSERT_NE(nullptr, water_level);
     EXPECT_TRUE(water_level->GetGeneralWaterLevelExceed());
-    EXPECT_FALSE(
-        water_level->GetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5));
+    EXPECT_FALSE(water_level->GetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5));
     EXPECT_FALSE(water_level->GetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
 }
 
@@ -1803,9 +1919,12 @@ TEST_F(CacheReclaimerTest, TestInsufficientSampledKeys) {
     ins_group->quota_.set_capacity(2048);
     instance_groups.emplace_back(ins_group);
 
-    // batching_size default to 100 which is larger than the size of sampled keys (10)
+    // Fair mode normalizes sampling_size from 10 to batching_size 100.
+    // Use 11-key sampling tasks so the stub returns only the 10 available
+    // keys for each full task, exercising the insufficient-sample path.
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), sample_reclaim_keys.size()));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 100));
+    cache_reclaimer_->sampling_size_per_task_.store(11);
     batch_get_loc_out_maps = MakeServingLocationMaps(sample_reclaim_keys.size());
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
 
@@ -2787,9 +2906,8 @@ TEST_F(CacheReclaimerTest, TestCronJobAdaptiveSleepInterval) {
     // on absolute scheduler timing, while still requiring the second round to
     // arrive before the original sleep interval would have elapsed again.
     ASSERT_TRUE(WaitUntilSubmittedDelRequests(initial_sleep_interval + std::chrono::milliseconds(1000)));
-    ASSERT_TRUE(WaitUntil(
-        [this] { return ListInstanceGroupCallCount() > 1 && SubmittedDelRequestCount() > 1; },
-        initial_sleep_interval / 2));
+    ASSERT_TRUE(WaitUntil([this] { return ListInstanceGroupCallCount() > 1 && SubmittedDelRequestCount() > 1; },
+                          initial_sleep_interval / 2));
     cache_reclaimer_->Stop(); // join the worker thread
 
     ASSERT_LT(1, ListInstanceGroupCallCount());
@@ -3246,7 +3364,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocationExcludesEventReportStorage) {
     };
 
     CacheReclaimer::WaterLevelExceed water_level;
-    water_level.SetGeneralWaterLevelExceed(true);
+    water_level.SetGroupBytesWaterLevelExceed(true);
     std::vector<std::vector<std::string>> location_ids;
     CacheReclaimer::BytesByStorageType bytes_by_type{};
     CacheReclaimer::CountsByStorageType counts_by_type{};
@@ -3472,6 +3590,388 @@ TEST_F(CacheReclaimerTest, TestEmptyAndRejectedRequestsLeaveNoAsyncDeleteState) 
     EXPECT_EQ(0, cache_reclaimer_->pending_delete_handler_count_);
 }
 
+TEST_F(CacheReclaimerTest, TestAllocateFairBudgetUsesDeterministicLargestRemainder) {
+    std::vector<std::size_t> allocations;
+    ASSERT_TRUE(CacheReclaimer::AllocateFairBudget(200, {80, 20}, {"large", "small"}, allocations));
+    EXPECT_EQ((std::vector<std::size_t>{160, 40}), allocations);
+
+    // All three raw shares are 1 1/3. The extra slot goes to the
+    // lexicographically smallest instance_id, independent of input order.
+    ASSERT_TRUE(CacheReclaimer::AllocateFairBudget(4, {1, 1, 1}, {"c", "a", "b"}, allocations));
+    EXPECT_EQ((std::vector<std::size_t>{1, 2, 1}), allocations);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanAllocatesGroupBudgetByUsage) {
+    const auto large = InstanceInfoFactory();
+    large->set_instance_id("large");
+    const auto small = InstanceInfoFactory();
+    small->set_instance_id("small");
+    AddMetaIndexerForInstance(large->instance_id(), 80);
+    AddMetaIndexerForInstance(small->instance_id(), 20);
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetGroupBytesWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(
+        cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, {large, small}, 1000, 100, plan));
+
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::GROUP_BYTES, plan.weight_dimension);
+    EXPECT_EQ(2, plan.effective_instance_count);
+    EXPECT_EQ(200, plan.group_batch_size);
+    EXPECT_EQ(2000, plan.group_sampling_size);
+    ASSERT_EQ(2, plan.items.size());
+    EXPECT_EQ("large", plan.items[0].instance_id);
+    EXPECT_EQ(160, plan.items[0].raw_batch_size);
+    EXPECT_EQ(1600, plan.items[0].raw_sampling_size);
+    EXPECT_EQ(100, plan.items[0].batch_size);
+    EXPECT_EQ(1000, plan.items[0].sampling_size);
+    EXPECT_EQ("small", plan.items[1].instance_id);
+    EXPECT_EQ(40, plan.items[1].raw_batch_size);
+    EXPECT_EQ(400, plan.items[1].raw_sampling_size);
+    EXPECT_EQ(40, plan.items[1].batch_size);
+    EXPECT_EQ(400, plan.items[1].sampling_size);
+    EXPECT_EQ(1, plan.capped_item_count);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanDoesNotPropagateSamplingRoundingIntoBatch) {
+    const auto dominant = InstanceInfoFactory();
+    dominant->set_instance_id("dominant");
+    const auto small_a = InstanceInfoFactory();
+    small_a->set_instance_id("small_a");
+    const auto small_b = InstanceInfoFactory();
+    small_b->set_instance_id("small_b");
+    AddMetaIndexerForInstance(dominant->instance_id(), 1000);
+    AddMetaIndexerForInstance(small_a->instance_id(), 3);
+    AddMetaIndexerForInstance(small_b->instance_id(), 3);
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetGroupBytesWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {dominant, small_a, small_b}, 1000, 100, plan));
+
+    ASSERT_EQ(3, plan.items.size());
+    EXPECT_EQ("dominant", plan.items[0].instance_id);
+    EXPECT_EQ(298, plan.items[0].raw_batch_size);
+    EXPECT_EQ(2982, plan.items[0].raw_sampling_size);
+    EXPECT_EQ(100, plan.items[0].batch_size);
+    EXPECT_EQ(1000, plan.items[0].sampling_size);
+    EXPECT_EQ("small_a", plan.items[1].instance_id);
+    EXPECT_EQ(1, plan.items[1].raw_batch_size);
+    EXPECT_EQ(9, plan.items[1].raw_sampling_size);
+    EXPECT_EQ(1, plan.items[1].batch_size);
+    EXPECT_EQ(9, plan.items[1].sampling_size);
+    EXPECT_EQ("small_b", plan.items[2].instance_id);
+    EXPECT_EQ(1, plan.items[2].batch_size);
+    EXPECT_EQ(9, plan.items[2].sampling_size);
+    EXPECT_EQ(1, plan.capped_item_count);
+
+    const auto equal_dominant = InstanceInfoFactory();
+    equal_dominant->set_instance_id("equal_dominant");
+    AddMetaIndexerForInstance(equal_dominant->instance_id(), 500);
+    std::vector<std::shared_ptr<const InstanceInfo>> equal_tiny_instances;
+    equal_tiny_instances.reserve(4);
+    for (const std::string instance_id : {"tiny_a", "tiny_b", "tiny_c", "tiny_d"}) {
+        auto instance = InstanceInfoFactory();
+        instance->set_instance_id(instance_id);
+        AddMetaIndexerForInstance(instance_id, 2);
+        equal_tiny_instances.push_back(std::move(instance));
+    }
+    std::vector<std::shared_ptr<const InstanceInfo>> equal_instances{equal_dominant};
+    equal_instances.insert(equal_instances.end(), equal_tiny_instances.begin(), equal_tiny_instances.end());
+    ASSERT_TRUE(
+        cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, equal_instances, 1000, 100, plan));
+
+    ASSERT_EQ(5, plan.items.size());
+    EXPECT_EQ("tiny_a", plan.items[1].instance_id);
+    EXPECT_EQ(2, plan.items[1].batch_size);
+    EXPECT_EQ(20, plan.items[1].sampling_size);
+    EXPECT_EQ("tiny_d", plan.items[4].instance_id);
+    EXPECT_EQ(2, plan.items[4].batch_size);
+    EXPECT_EQ(19, plan.items[4].sampling_size);
+    EXPECT_EQ(1, plan.capped_item_count);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanAppliesRatioGuardOnlyWhenHardSampleCapClips) {
+    const auto first = InstanceInfoFactory();
+    first->set_instance_id("first");
+    const auto second = InstanceInfoFactory();
+    second->set_instance_id("second");
+    AddMetaIndexerForInstance(first->instance_id(), 1);
+    AddMetaIndexerForInstance(second->instance_id(), 1);
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetGroupBytesWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {first, second}, 100000, 100, plan));
+
+    ASSERT_EQ(2, plan.items.size());
+    for (const auto &item : plan.items) {
+        EXPECT_EQ(100, item.raw_batch_size);
+        EXPECT_EQ(100000, item.raw_sampling_size);
+        EXPECT_EQ(65, item.batch_size);
+        EXPECT_EQ(CacheReclaimer::kSizeLimit - 1, item.sampling_size);
+    }
+    EXPECT_EQ(2, plan.capped_item_count);
+
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {first}, CacheReclaimer::kSizeLimit, 1, plan));
+    ASSERT_EQ(1, plan.items.size());
+    EXPECT_EQ(1, plan.items.front().raw_batch_size);
+    EXPECT_EQ(CacheReclaimer::kSizeLimit, plan.items.front().raw_sampling_size);
+    EXPECT_EQ(1, plan.items.front().batch_size);
+    EXPECT_EQ(CacheReclaimer::kSizeLimit - 1, plan.items.front().sampling_size);
+    EXPECT_EQ(1, plan.capped_item_count);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanExcludesEventReportAndSumsReclaimableByteWeights) {
+    const auto mixed = InstanceInfoFactory();
+    mixed->set_instance_id("mixed");
+    const auto ordinary = InstanceInfoFactory();
+    ordinary->set_instance_id("ordinary");
+    const auto reporter_only = InstanceInfoFactory();
+    reporter_only->set_instance_id("reporter_only");
+
+    auto mixed_indexer = AddMetaIndexerForInstance(mixed->instance_id(), 60);
+    AddMetaIndexerForInstance(ordinary->instance_id(), 20);
+    auto reporter_indexer = AddMetaIndexerForInstance(reporter_only->instance_id(), 0);
+    mixed_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 20);
+    mixed_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5, 1000);
+    reporter_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, 10000);
+
+    CacheReclaimer::WaterLevelExceed group_water_level;
+    group_water_level.SetGroupBytesWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), group_water_level, {reporter_only, ordinary, mixed}, 1000, 100, plan));
+
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::GROUP_BYTES, plan.weight_dimension);
+    EXPECT_EQ(2, plan.effective_instance_count);
+    EXPECT_EQ(1, plan.zero_weight_instance_count);
+    ASSERT_EQ(2, plan.items.size());
+    EXPECT_EQ("mixed", plan.items[0].instance_id);
+    EXPECT_EQ(80, plan.items[0].weight);
+    EXPECT_EQ(160, plan.items[0].raw_batch_size);
+    EXPECT_EQ("ordinary", plan.items[1].instance_id);
+    EXPECT_EQ(20, plan.items[1].weight);
+    EXPECT_EQ(40, plan.items[1].raw_batch_size);
+
+    CacheReclaimer::WaterLevelExceed multi_type_water_level;
+    multi_type_water_level.SetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_NFS, true);
+    multi_type_water_level.SetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, true);
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), multi_type_water_level, {reporter_only, ordinary, mixed}, 1000, 100, plan));
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::STORAGE_TYPE_BYTES, plan.weight_dimension);
+    EXPECT_EQ(2, plan.effective_instance_count);
+    EXPECT_EQ(1, plan.zero_weight_instance_count);
+    ASSERT_EQ(2, plan.items.size());
+    EXPECT_EQ("mixed", plan.items[0].instance_id);
+    EXPECT_EQ(80, plan.items[0].weight);
+    EXPECT_EQ("ordinary", plan.items[1].instance_id);
+    EXPECT_EQ(20, plan.items[1].weight);
+
+    CacheReclaimer::WaterLevelExceed reporter_type_water_level;
+    reporter_type_water_level.SetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5, true);
+    EXPECT_FALSE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), reporter_type_water_level, {reporter_only, mixed}, 1000, 100, plan));
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::STORAGE_TYPE_BYTES, plan.weight_dimension);
+    EXPECT_EQ(2, plan.zero_weight_instance_count);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanUsesPerInstanceKeyCountWeight) {
+    const auto key_heavy = InstanceInfoFactory();
+    key_heavy->set_instance_id("key_heavy");
+    const auto byte_heavy = InstanceInfoFactory();
+    byte_heavy->set_instance_id("byte_heavy");
+    AddMetaIndexerForInstance(key_heavy->instance_id(), 20, 80);
+    AddMetaIndexerForInstance(byte_heavy->instance_id(), 80, 20);
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetGroupKeysWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {byte_heavy, key_heavy}, 1000, 100, plan));
+
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::GROUP_KEYS, plan.weight_dimension);
+    ASSERT_EQ(2, plan.items.size());
+    EXPECT_EQ("key_heavy", plan.items[0].instance_id);
+    EXPECT_EQ(80, plan.items[0].weight);
+    EXPECT_EQ(160, plan.items[0].raw_batch_size);
+    EXPECT_EQ(1600, plan.items[0].raw_sampling_size);
+    EXPECT_EQ("byte_heavy", plan.items[1].instance_id);
+    EXPECT_EQ(20, plan.items[1].weight);
+    EXPECT_EQ(40, plan.items[1].raw_batch_size);
+    EXPECT_EQ(400, plan.items[1].raw_sampling_size);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanHonorsWeightDimensionPriority) {
+    const auto nfs_heavy = InstanceInfoFactory();
+    nfs_heavy->set_instance_id("nfs_heavy");
+    const auto total_bytes_heavy = InstanceInfoFactory();
+    total_bytes_heavy->set_instance_id("total_bytes_heavy");
+    AddMetaIndexerForInstance(nfs_heavy->instance_id(), 80, 100);
+    auto total_bytes_indexer = AddMetaIndexerForInstance(total_bytes_heavy->instance_id(), 20, 1);
+    total_bytes_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 180);
+
+    CacheReclaimer::WaterLevelExceed all_dimensions;
+    all_dimensions.SetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_NFS, true);
+    all_dimensions.SetGroupBytesWaterLevelExceed(true);
+    all_dimensions.SetGroupKeysWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), all_dimensions, {total_bytes_heavy, nfs_heavy}, 100, 10, plan));
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::STORAGE_TYPE_BYTES, plan.weight_dimension);
+    ASSERT_EQ(2, plan.items.size());
+    EXPECT_EQ("nfs_heavy", plan.items[0].instance_id);
+    EXPECT_EQ(80, plan.items[0].weight);
+    EXPECT_EQ("total_bytes_heavy", plan.items[1].instance_id);
+    EXPECT_EQ(20, plan.items[1].weight);
+
+    CacheReclaimer::WaterLevelExceed group_dimensions;
+    group_dimensions.SetGroupBytesWaterLevelExceed(true);
+    group_dimensions.SetGroupKeysWaterLevelExceed(true);
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), group_dimensions, {nfs_heavy, total_bytes_heavy}, 100, 10, plan));
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::GROUP_BYTES, plan.weight_dimension);
+    ASSERT_EQ(2, plan.items.size());
+    EXPECT_EQ("total_bytes_heavy", plan.items[0].instance_id);
+    EXPECT_EQ(200, plan.items[0].weight);
+    EXPECT_EQ("nfs_heavy", plan.items[1].instance_id);
+    EXPECT_EQ(80, plan.items[1].weight);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanUsesExceededStorageTypeAndSkipsZeroWeight) {
+    const auto large_nfs = InstanceInfoFactory();
+    large_nfs->set_instance_id("large_nfs");
+    const auto small_nfs = InstanceInfoFactory();
+    small_nfs->set_instance_id("small_nfs");
+    const auto mooncake_only = InstanceInfoFactory();
+    mooncake_only->set_instance_id("mooncake_only");
+
+    auto large_indexer = AddMetaIndexerForInstance(large_nfs->instance_id(), 80);
+    auto small_indexer = AddMetaIndexerForInstance(small_nfs->instance_id(), 20);
+    auto mooncake_indexer = AddMetaIndexerForInstance(mooncake_only->instance_id(), 0);
+    large_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 1);
+    small_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 1000);
+    mooncake_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE, 10000);
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_NFS, true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {small_nfs, mooncake_only, large_nfs}, 1000, 100, plan));
+
+    EXPECT_EQ(CacheReclaimer::FairWeightDimension::STORAGE_TYPE_BYTES, plan.weight_dimension);
+    EXPECT_EQ(2, plan.effective_instance_count);
+    EXPECT_EQ(1, plan.zero_weight_instance_count);
+    ASSERT_EQ(2, plan.items.size());
+    EXPECT_EQ("large_nfs", plan.items[0].instance_id);
+    EXPECT_EQ(80, plan.items[0].weight);
+    EXPECT_EQ("small_nfs", plan.items[1].instance_id);
+    EXPECT_EQ(20, plan.items[1].weight);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanAllowsLargeGroupBudgetAndKeepsConfiguredRequestLimits) {
+    std::vector<std::shared_ptr<const InstanceInfo>> many_instances;
+    many_instances.reserve(66);
+    for (std::size_t i = 0; i != 66; ++i) {
+        auto instance = InstanceInfoFactory();
+        instance->set_instance_id("instance_" + std::to_string(i));
+        AddMetaIndexerForInstance(instance->instance_id(), 1);
+        many_instances.push_back(instance);
+    }
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetGroupBytesWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(
+        cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, many_instances, 1000, 100, plan));
+    EXPECT_EQ(66000, plan.group_sampling_size);
+    EXPECT_EQ(6600, plan.group_batch_size);
+    ASSERT_EQ(66, plan.items.size());
+    for (const auto &item : plan.items) {
+        EXPECT_EQ(1000, item.sampling_size);
+        EXPECT_EQ(100, item.batch_size);
+    }
+
+    meta_indexers_by_instance[many_instances.front()->instance_id()]->SetStorageUsageByType(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, std::numeric_limits<std::uint64_t>::max());
+    ASSERT_TRUE(
+        cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, many_instances, 1000, 100, plan));
+    ASSERT_EQ(1, plan.items.size());
+    EXPECT_EQ("instance_0", plan.items.front().instance_id);
+    EXPECT_GT(plan.items.front().raw_batch_size, 100);
+    EXPECT_GT(plan.items.front().raw_sampling_size, 1000);
+    EXPECT_EQ(100, plan.items.front().batch_size);
+    EXPECT_EQ(1000, plan.items.front().sampling_size);
+    EXPECT_EQ(10, plan.items.front().sampling_size / plan.items.front().batch_size);
+    EXPECT_EQ(1, plan.capped_item_count);
+
+    const auto dominant = InstanceInfoFactory();
+    dominant->set_instance_id("dominant");
+    const auto tiny = InstanceInfoFactory();
+    tiny->set_instance_id("tiny");
+    AddMetaIndexerForInstance(dominant->instance_id(), std::numeric_limits<std::uint64_t>::max());
+    AddMetaIndexerForInstance(tiny->instance_id(), 1);
+    ASSERT_TRUE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {dominant, tiny}, 65535, 100, plan));
+    ASSERT_EQ(1, plan.items.size());
+    EXPECT_GT(plan.items.front().raw_sampling_size, CacheReclaimer::kSizeLimit - 1);
+    EXPECT_EQ(100, plan.items.front().batch_size);
+    EXPECT_EQ(CacheReclaimer::kSizeLimit - 1, plan.items.front().sampling_size);
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanNormalizesSamplingAndDoesNotForceMinimumBatch) {
+    const auto dominant = InstanceInfoFactory();
+    dominant->set_instance_id("dominant");
+    const auto tiny = InstanceInfoFactory();
+    tiny->set_instance_id("tiny");
+    AddMetaIndexerForInstance(dominant->instance_id(), 1000);
+    AddMetaIndexerForInstance(tiny->instance_id(), 1);
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetGroupBytesWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    ASSERT_TRUE(
+        cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, {dominant, tiny}, 1, 1, plan));
+    EXPECT_EQ(2, plan.effective_instance_count);
+    ASSERT_EQ(1, plan.items.size());
+    EXPECT_EQ("dominant", plan.items.front().instance_id);
+    EXPECT_EQ(2, plan.items.front().raw_batch_size);
+    EXPECT_EQ(1, plan.items.front().batch_size);
+
+    ASSERT_TRUE(
+        cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, {dominant, tiny}, 100, 500, plan));
+    EXPECT_TRUE(plan.sampling_size_normalized);
+    EXPECT_EQ(500, plan.normalized_sampling_size);
+    EXPECT_EQ(plan.group_batch_size, plan.group_sampling_size);
+    for (const auto &item : plan.items) {
+        EXPECT_GE(item.sampling_size, item.batch_size);
+    }
+}
+
+TEST_F(CacheReclaimerTest, TestBuildFairPlanRejectsZeroAndOverflowingGroupBudgets) {
+    const auto first = InstanceInfoFactory();
+    first->set_instance_id("first");
+    AddMetaIndexerForInstance(first->instance_id(), 1);
+
+    CacheReclaimer::WaterLevelExceed water_level;
+    water_level.SetGroupBytesWaterLevelExceed(true);
+    CacheReclaimer::FairReclaimPlan plan;
+    EXPECT_FALSE(cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, {first}, 0, 1, plan));
+    EXPECT_FALSE(cache_reclaimer_->BuildFairReclaimPlan(request_context_.get(), water_level, {first}, 1, 0, plan));
+
+    const auto second = InstanceInfoFactory();
+    second->set_instance_id("second");
+    AddMetaIndexerForInstance(second->instance_id(), 1);
+    constexpr std::size_t kMaxSize = std::numeric_limits<std::size_t>::max();
+    EXPECT_FALSE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {first, second}, kMaxSize, kMaxSize, plan));
+    EXPECT_FALSE(cache_reclaimer_->BuildFairReclaimPlan(
+        request_context_.get(), water_level, {first, second}, kMaxSize, 1, plan));
+}
+
 TEST_F(CacheReclaimerTest, TestWaterLevelCreditsUseSaturatingSubtraction) {
     EXPECT_EQ(0, CacheReclaimer::SaturatingSub(1, 2));
     EXPECT_EQ(0, CacheReclaimer::SaturatingSub(0, std::numeric_limits<std::uint64_t>::max()));
@@ -3517,6 +4017,8 @@ TEST_F(CacheReclaimerTest, TestWaterLevelCreditsUseSaturatingSubtraction) {
                                               instance_infos);
     ASSERT_NE(nullptr, key_water_level);
     EXPECT_TRUE(key_water_level->GetGeneralWaterLevelExceed());
+    EXPECT_FALSE(key_water_level->GetGroupBytesWaterLevelExceed());
+    EXPECT_TRUE(key_water_level->GetGroupKeysWaterLevelExceed());
 
     // The symmetric case must still evaluate byte usage when predicted
     // key credit saturates the effective key count at zero.
@@ -3532,6 +4034,8 @@ TEST_F(CacheReclaimerTest, TestWaterLevelCreditsUseSaturatingSubtraction) {
                                               instance_infos);
     ASSERT_NE(nullptr, byte_water_level);
     EXPECT_TRUE(byte_water_level->GetGeneralWaterLevelExceed());
+    EXPECT_TRUE(byte_water_level->GetGroupBytesWaterLevelExceed());
+    EXPECT_FALSE(byte_water_level->GetGroupKeysWaterLevelExceed());
 
     // A zero-capacity storage type is satisfied once its effective usage
     // has saturated to zero; otherwise credit could never stop eviction.
@@ -3571,6 +4075,8 @@ TEST_F(CacheReclaimerTest, TestSameGroupRechecksCreditBeforeSubmittingNextInstan
     group->quota_.set_capacity(100);
     group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
     group->cache_config_->reclaim_strategy_->set_delay_before_delete_ms(1000);
+    group->cache_config_->reclaim_strategy_->set_instance_reclaim_budget_policy(
+        InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE);
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
     ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
 
@@ -3579,6 +4085,578 @@ TEST_F(CacheReclaimerTest, TestSameGroupRechecksCreditBeforeSubmittingNextInstan
     EXPECT_TRUE(result.made_progress);
     EXPECT_EQ(1, SubmittedDelRequestCount());
     EXPECT_EQ(instance_1->instance_id(), SubmittedDelRequestsSnapshot().front().instance_id);
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimUsesWeightedBudgetAndStopsAfterAcceptedCredit) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    get_out_properties.clear();
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"thirty_bytes",
+         MakeCacheLocation("thirty_bytes",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=30")},
+    }};
+
+    const auto small = InstanceInfoFactory();
+    small->set_instance_id("small");
+    const auto large = InstanceInfoFactory();
+    large->set_instance_id("large");
+    AddMetaIndexerForInstance(small->instance_id(), 20);
+    AddMetaIndexerForInstance(large->instance_id(), 80);
+    // Deliberately put the small Instance first; fair execution must
+    // reorder by contribution.
+    instance_infos = {small, large};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 100));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 10));
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ("large", SubmittedDelRequestsSnapshot().front().instance_id);
+
+    std::int64_t large_sampling_count = 0;
+    std::int64_t small_sampling_count = 0;
+    for (const auto &[instance_id, sampling_count] : SampleReclaimRequestsSnapshot()) {
+        if (instance_id == "large") {
+            large_sampling_count += sampling_count;
+        } else if (instance_id == "small") {
+            small_sampling_count += sampling_count;
+        }
+    }
+    EXPECT_EQ(100, large_sampling_count);
+    EXPECT_EQ(0, small_sampling_count);
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_count_metrics());
+    EXPECT_EQ(2, cache_reclaimer_->get_cache_reclaimer_fair_effective_instance_count_metrics());
+    EXPECT_EQ(2, cache_reclaimer_->get_cache_reclaimer_fair_planned_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_sampled_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_submitted_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_instance_count_metrics());
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimContinuesUntilAcceptedCreditRestoresWaterLevel) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"six_bytes",
+         MakeCacheLocation("six_bytes",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=6")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    const auto instance_c = InstanceInfoFactory();
+    instance_c->set_instance_id("c");
+    AddMetaIndexerForInstance(instance_a->instance_id(), 30);
+    AddMetaIndexerForInstance(instance_b->instance_id(), 30);
+    AddMetaIndexerForInstance(instance_c->instance_id(), 30);
+    instance_infos = {instance_c, instance_b, instance_a};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 100));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 10));
+    cache_reclaimer_->sampling_size_per_task_.store(11);
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_EQ(2, requests.size());
+    EXPECT_EQ("a", requests[0].instance_id);
+    EXPECT_EQ("b", requests[1].instance_id);
+
+    std::map<std::string, std::int64_t> sampled_by_instance;
+    for (const auto &[instance_id, sampling_count] : SampleReclaimRequestsSnapshot()) {
+        sampled_by_instance[instance_id] += sampling_count;
+    }
+    EXPECT_EQ(100, sampled_by_instance["a"]);
+    EXPECT_EQ(100, sampled_by_instance["b"]);
+    EXPECT_EQ(0, sampled_by_instance["c"]);
+    EXPECT_EQ(2, cache_reclaimer_->get_cache_reclaimer_fair_sampled_instance_count_metrics());
+    EXPECT_EQ(2, cache_reclaimer_->get_cache_reclaimer_fair_submitted_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_instance_count_metrics());
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimStopsWhenTriggerScopeChanges) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"twenty_one_bytes",
+         MakeCacheLocation("twenty_one_bytes",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=21")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    AddMetaIndexerForInstance(instance_a->instance_id(), 50);
+    AddMetaIndexerForInstance(instance_b->instance_id(), 50);
+    instance_infos = {instance_b, instance_a};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(50);
+    group->quota_.quota_config_.clear();
+    QuotaConfig nfs_quota;
+    nfs_quota.set_storage_type(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    nfs_quota.set_capacity(100);
+    group->quota_.quota_config_.push_back(nfs_quota);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ("a", SubmittedDelRequestsSnapshot().front().instance_id);
+
+    const auto current_water_level = cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                                                           group->name(),
+                                                                           group->quota(),
+                                                                           group->cache_config()->reclaim_strategy(),
+                                                                           instance_infos);
+    ASSERT_NE(nullptr, current_water_level);
+    EXPECT_TRUE(current_water_level->GetGroupBytesWaterLevelExceed());
+    EXPECT_FALSE(current_water_level->CheckStorageTypeWaterLevelExceed());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_sampled_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_count_metrics());
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimStopsWhenStorageTypeBecomesExceeded) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"one_byte",
+         MakeCacheLocation("one_byte",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=1")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    const auto indexer_a = AddMetaIndexerForInstance(instance_a->instance_id(), 50);
+    const auto indexer_b = AddMetaIndexerForInstance(instance_b->instance_id(), 50);
+    instance_infos = {instance_b, instance_a};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->quota_.set_quota_config({QuotaConfig(1000, DataStorageType::DATA_STORAGE_TYPE_NFS)});
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    spe_submit_accepted_callback = [indexer_a, indexer_b](const CacheLocationDelRequest &) {
+        indexer_a->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 500);
+        indexer_b->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 500);
+    };
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ("a", SubmittedDelRequestsSnapshot().front().instance_id);
+
+    const auto current_water_level = cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                                                           group->name(),
+                                                                           group->quota(),
+                                                                           group->cache_config()->reclaim_strategy(),
+                                                                           instance_infos);
+    ASSERT_NE(nullptr, current_water_level);
+    EXPECT_TRUE(current_water_level->GetGroupBytesWaterLevelExceed());
+    EXPECT_TRUE(current_water_level->GetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_NFS));
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_sampled_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_count_metrics());
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimStopsWhenGroupBytesBecomesExceededDuringKeyCountPlan) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"one_byte",
+         MakeCacheLocation("one_byte",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=1")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    const auto indexer_a = AddMetaIndexerForInstance(instance_a->instance_id(), 1, 90);
+    const auto indexer_b = AddMetaIndexerForInstance(instance_b->instance_id(), 1, 90);
+    instance_infos = {instance_b, instance_a};
+    max_key_count = 100;
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(1000);
+    group->quota_.set_quota_config({QuotaConfig(10000, DataStorageType::DATA_STORAGE_TYPE_NFS)});
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    spe_submit_accepted_callback = [indexer_a, indexer_b](const CacheLocationDelRequest &) {
+        indexer_a->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 500);
+        indexer_b->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 500);
+    };
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ("a", SubmittedDelRequestsSnapshot().front().instance_id);
+
+    const auto current_water_level = cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                                                           group->name(),
+                                                                           group->quota(),
+                                                                           group->cache_config()->reclaim_strategy(),
+                                                                           instance_infos);
+    ASSERT_NE(nullptr, current_water_level);
+    EXPECT_TRUE(current_water_level->GetGroupKeysWaterLevelExceed());
+    EXPECT_TRUE(current_water_level->GetGroupBytesWaterLevelExceed());
+    EXPECT_FALSE(current_water_level->CheckStorageTypeWaterLevelExceed());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_sampled_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_count_metrics());
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimPauseDoesNotReportWaterLevelTruncation) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"one_byte",
+         MakeCacheLocation("one_byte",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=1")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    AddMetaIndexerForInstance(instance_a->instance_id(), 50);
+    AddMetaIndexerForInstance(instance_b->instance_id(), 50);
+    instance_infos = {instance_b, instance_a};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(10);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+    spe_submit_accepted_callback = [this](const CacheLocationDelRequest &) { cache_reclaimer_->Pause(); };
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    EXPECT_TRUE(cache_reclaimer_->IsPaused());
+    EXPECT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_sampled_instance_count_metrics());
+    EXPECT_EQ(0, cache_reclaimer_->get_cache_reclaimer_fair_plan_truncated_count_metrics());
+}
+
+TEST_F(CacheReclaimerTest, TestFairUnsupportedPoliciesFallBackToLRU) {
+    cache_reclaimer_->job_state_flag_ = true;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"one_byte",
+         MakeCacheLocation("one_byte",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=1")},
+    }};
+    AddMetaIndexerForInstance(instance_infos.front()->instance_id(), 100);
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(10);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    for (const auto policy : {ReclaimPolicy::POLICY_LFU, ReclaimPolicy::POLICY_TTL}) {
+        group->cache_config_->reclaim_strategy_->set_reclaim_policy(policy);
+        const std::size_t submitted_before = SubmittedDelRequestCount();
+        const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+        EXPECT_TRUE(result.water_level_exceeded);
+        EXPECT_TRUE(result.made_progress);
+        EXPECT_EQ(submitted_before + 1, SubmittedDelRequestCount());
+        cache_reclaimer_->HandleDelRes();
+    }
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimContinuesAfterRejectedSubmission) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    spe_submit_accepted_by_instance["a"] = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"fifty_bytes",
+         MakeCacheLocation("fifty_bytes",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=50")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    AddMetaIndexerForInstance(instance_a->instance_id(), 60);
+    AddMetaIndexerForInstance(instance_b->instance_id(), 60);
+    instance_infos = {instance_b, instance_a};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    const auto requests = SubmittedDelRequestsSnapshot();
+    ASSERT_EQ(2, requests.size());
+    EXPECT_EQ("a", requests[0].instance_id);
+    EXPECT_EQ("b", requests[1].instance_id);
+    EXPECT_EQ(2, cache_reclaimer_->get_cache_reclaimer_fair_sampled_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_submitted_instance_count_metrics());
+    EXPECT_EQ(1, cache_reclaimer_->pending_delete_handler_count_);
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimContinuesAfterSamplingFailure) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_results = {ErrorCode::EC_ERROR, ErrorCode::EC_OK};
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"fifty_bytes",
+         MakeCacheLocation("fifty_bytes",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=50")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    AddMetaIndexerForInstance(instance_a->instance_id(), 60);
+    AddMetaIndexerForInstance(instance_b->instance_id(), 60);
+    instance_infos = {instance_b, instance_a};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    const auto sampled = SampleReclaimRequestsSnapshot();
+    ASSERT_EQ(2, sampled.size());
+    EXPECT_EQ("a", sampled[0].first);
+    EXPECT_EQ("b", sampled[1].first);
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ("b", SubmittedDelRequestsSnapshot().front().instance_id);
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimSnapshotsRuntimeBudgetForCurrentPlan) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"one_byte",
+         MakeCacheLocation("one_byte",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=1")},
+    }};
+
+    const auto instance_a = InstanceInfoFactory();
+    instance_a->set_instance_id("a");
+    const auto instance_b = InstanceInfoFactory();
+    instance_b->set_instance_id("b");
+    AddMetaIndexerForInstance(instance_a->instance_id(), 50);
+    AddMetaIndexerForInstance(instance_b->instance_id(), 50);
+    instance_infos = {instance_b, instance_a};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(10);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 10));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    ErrorCode sampling_update_result = ErrorCode::EC_ERROR;
+    ErrorCode batching_update_result = ErrorCode::EC_ERROR;
+    std::size_t accepted_count = 0;
+    spe_submit_accepted_callback = [&](const CacheLocationDelRequest &) {
+        if (accepted_count++ == 0) {
+            sampling_update_result = cache_reclaimer_->SetSamplingSize(request_context_.get(), 100);
+            batching_update_result = cache_reclaimer_->SetBatchingSize(request_context_.get(), 10);
+        }
+    };
+
+    const auto first_result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(first_result.made_progress);
+    EXPECT_EQ(ErrorCode::EC_OK, sampling_update_result);
+    EXPECT_EQ(ErrorCode::EC_OK, batching_update_result);
+    std::map<std::string, std::int64_t> first_round_sampling;
+    for (const auto &[instance_id, sampling_count] : SampleReclaimRequestsSnapshot()) {
+        first_round_sampling[instance_id] += sampling_count;
+    }
+    EXPECT_EQ(10, first_round_sampling["a"]);
+    EXPECT_EQ(10, first_round_sampling["b"]);
+
+    spe_submit_accepted_callback = {};
+    ClearSampleReclaimRequests();
+    const auto second_result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(second_result.water_level_exceeded);
+    std::map<std::string, std::int64_t> second_round_sampling;
+    for (const auto &[instance_id, sampling_count] : SampleReclaimRequestsSnapshot()) {
+        second_round_sampling[instance_id] += sampling_count;
+    }
+    EXPECT_EQ(100, second_round_sampling["a"]);
+    EXPECT_EQ(100, second_round_sampling["b"]);
+}
+
+TEST_F(CacheReclaimerTest, TestBudgetPolicySwitchAppliesNextRoundAndPreservesInFlightState) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    sample_reclaim_keys = {1};
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"one_byte",
+         MakeCacheLocation("one_byte",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=1")},
+    }};
+
+    const auto small = InstanceInfoFactory();
+    small->set_instance_id("small");
+    const auto large = InstanceInfoFactory();
+    large->set_instance_id("large");
+    AddMetaIndexerForInstance(small->instance_id(), 20);
+    AddMetaIndexerForInstance(large->instance_id(), 80);
+    instance_infos = {small, large};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(10);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 100));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 10));
+
+    const auto reclaim_strategy = group->cache_config()->reclaim_strategy();
+    spe_submit_accepted_callback = [reclaim_strategy](const CacheLocationDelRequest &request) {
+        if (request.instance_id == "large") {
+            reclaim_strategy->set_instance_reclaim_budget_policy(InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE);
+        }
+    };
+
+    const auto first_result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(first_result.made_progress);
+    EXPECT_EQ(InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE, reclaim_strategy->instance_reclaim_budget_policy());
+    const auto first_requests = SubmittedDelRequestsSnapshot();
+    ASSERT_EQ(2, first_requests.size());
+    EXPECT_EQ("large", first_requests[0].instance_id);
+    EXPECT_EQ("small", first_requests[1].instance_id);
+    std::map<std::string, std::int64_t> fair_sampling;
+    for (const auto &[instance_id, sampling_count] : SampleReclaimRequestsSnapshot()) {
+        fair_sampling[instance_id] += sampling_count;
+    }
+    EXPECT_EQ(100, fair_sampling["large"]);
+    EXPECT_EQ(40, fair_sampling["small"]);
+
+    const std::uint64_t delete_handler_count = cache_reclaimer_->pending_delete_handler_count_;
+    const std::size_t pending_location_count = cache_reclaimer_->pending_locations_.size();
+    const auto credited_bytes = cache_reclaimer_->credited_delete_bytes_by_group_;
+    const auto predicted_keys = cache_reclaimer_->predicted_deleted_keys_by_group_;
+
+    spe_submit_accepted_callback = {};
+    ClearSampleReclaimRequests();
+    const auto second_result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(second_result.water_level_exceeded);
+    const auto legacy_sampling = SampleReclaimRequestsSnapshot();
+    ASSERT_EQ(2, legacy_sampling.size());
+    EXPECT_EQ(std::make_pair(std::string{"small"}, std::int64_t{100}), legacy_sampling[0]);
+    EXPECT_EQ(std::make_pair(std::string{"large"}, std::int64_t{100}), legacy_sampling[1]);
+    EXPECT_EQ(1, cache_reclaimer_->get_cache_reclaimer_fair_plan_count_metrics());
+    EXPECT_EQ(delete_handler_count, cache_reclaimer_->pending_delete_handler_count_);
+    EXPECT_EQ(pending_location_count, cache_reclaimer_->pending_locations_.size());
+    EXPECT_EQ(credited_bytes, cache_reclaimer_->credited_delete_bytes_by_group_);
+    EXPECT_EQ(predicted_keys, cache_reclaimer_->predicted_deleted_keys_by_group_);
+}
+
+TEST_F(CacheReclaimerTest, TestFixedPerInstanceBudgetPolicyUsesLegacyOrderAndBudget) {
+    cache_reclaimer_->job_state_flag_ = true;
+    spe_submit_auto_complete = false;
+    get_out_properties.clear();
+    batch_get_loc_out_maps = {CacheLocationMap{
+        {"thirty_bytes",
+         MakeCacheLocation("thirty_bytes",
+                           CacheLocationStatus::CLS_SERVING,
+                           DataStorageType::DATA_STORAGE_TYPE_NFS,
+                           "nfs://store/key?size=30")},
+    }};
+
+    const auto small = InstanceInfoFactory();
+    small->set_instance_id("small");
+    const auto large = InstanceInfoFactory();
+    large->set_instance_id("large");
+    AddMetaIndexerForInstance(small->instance_id(), 20);
+    AddMetaIndexerForInstance(large->instance_id(), 80);
+    instance_infos = {small, large};
+
+    const auto group = InstanceGroupFactory();
+    group->quota_.set_capacity(100);
+    group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    group->cache_config_->reclaim_strategy_->set_instance_reclaim_budget_policy(
+        InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE);
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 100));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 10));
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, group);
+    EXPECT_TRUE(result.water_level_exceeded);
+    EXPECT_TRUE(result.made_progress);
+    ASSERT_EQ(1, SubmittedDelRequestCount());
+    EXPECT_EQ("small", SubmittedDelRequestsSnapshot().front().instance_id);
+
+    std::int64_t small_sampling_count = 0;
+    std::int64_t large_sampling_count = 0;
+    for (const auto &[instance_id, sampling_count] : SampleReclaimRequestsSnapshot()) {
+        if (instance_id == "small") {
+            small_sampling_count += sampling_count;
+        } else if (instance_id == "large") {
+            large_sampling_count += sampling_count;
+        }
+    }
+    EXPECT_EQ(100, small_sampling_count);
+    EXPECT_EQ(0, large_sampling_count);
+    EXPECT_EQ(0, cache_reclaimer_->get_cache_reclaimer_fair_plan_count_metrics());
 }
 
 TEST_F(CacheReclaimerTest, TestReclaimCronHandlesReadyFutureBeforeReadingOfficialUsage) {
@@ -3890,6 +4968,82 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
     }
 }
 
+TEST_F(CacheReclaimerTest, TestFairKeySamplingSubmitsBoundedWaves) {
+    cache_reclaimer_->Stop();
+    cache_reclaimer_ = std::make_unique<CacheReclaimer>(5, 1, 1, 10, 2, rm_, mim_, msm_, spe_, mr_, em_, nullptr);
+    cache_reclaimer_->job_state_flag_ = true;
+    sample_reclaim_keys = {1};
+    get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
+    mi_sample_reclaim_delay = std::chrono::milliseconds(300);
+
+    std::vector<std::int64_t> keys;
+    std::vector<std::map<std::string, std::string>> maps;
+    auto sampling_future = std::async(std::launch::async, [&] {
+        return cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 5, true, keys, maps);
+    });
+
+    // Before the first tasks can finish, only one wave (two tasks) may
+    // be admitted. An unbounded submission would report five in-flight
+    // tasks and leave three queued.
+    EXPECT_TRUE(WaitUntil(
+        [this] {
+            std::lock_guard<std::mutex> lock(cache_reclaimer_->task_queue_mutex_);
+            return cache_reclaimer_->in_flight_sampling_tasks_.load() == 2 && cache_reclaimer_->task_queue_.empty();
+        },
+        std::chrono::milliseconds(200)));
+    EXPECT_TRUE(sampling_future.get());
+    EXPECT_EQ(5, keys.size());
+    EXPECT_EQ(5, maps.size());
+}
+
+TEST_F(CacheReclaimerTest, TestFairKeySamplingFailureClearsPartialWaveResults) {
+    cache_reclaimer_->Stop();
+    cache_reclaimer_ = std::make_unique<CacheReclaimer>(5, 1, 1, 10, 2, rm_, mim_, msm_, spe_, mr_, em_, nullptr);
+    cache_reclaimer_->job_state_flag_ = true;
+    sample_reclaim_keys = {1};
+    sample_reclaim_results = {
+        ErrorCode::EC_OK,
+        ErrorCode::EC_OK,
+        ErrorCode::EC_ERROR,
+        ErrorCode::EC_OK,
+    };
+
+    std::vector<std::int64_t> keys = {999};
+    std::vector<std::map<std::string, std::string>> maps = {{{"stale", "value"}}};
+    EXPECT_FALSE(
+        cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 5, true, keys, maps));
+    EXPECT_TRUE(keys.empty());
+    EXPECT_TRUE(maps.empty());
+    EXPECT_EQ(4, SampleReclaimRequestsSnapshot().size());
+    EXPECT_EQ(0, cache_reclaimer_->in_flight_sampling_tasks_.load());
+}
+
+TEST_F(CacheReclaimerTest, TestFairKeySamplingTimeoutClearsPartialWaveResults) {
+    cache_reclaimer_->Stop();
+    cache_reclaimer_ = std::make_unique<CacheReclaimer>(2, 1, 1, 10, 1, rm_, mim_, msm_, spe_, mr_, em_, nullptr);
+    cache_reclaimer_->job_state_flag_ = true;
+    cache_reclaimer_->future_timeout_ms_.store(50);
+    sample_reclaim_keys = {1};
+    mi_sample_reclaim_delays = {
+        std::chrono::milliseconds{0},
+        std::chrono::milliseconds{500},
+    };
+
+    std::vector<std::int64_t> keys = {999};
+    std::vector<std::map<std::string, std::string>> maps = {{{"stale", "value"}}};
+    const auto begin = std::chrono::steady_clock::now();
+    EXPECT_FALSE(
+        cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 2, true, keys, maps));
+    const auto elapsed = std::chrono::steady_clock::now() - begin;
+    EXPECT_LT(elapsed, std::chrono::milliseconds{300});
+    EXPECT_TRUE(keys.empty());
+    EXPECT_TRUE(maps.empty());
+    EXPECT_EQ(2, SampleReclaimRequestsSnapshot().size());
+
+    ASSERT_TRUE(WaitUntil([this] { return cache_reclaimer_->in_flight_sampling_tasks_.load() == 0; },
+                          std::chrono::milliseconds{1000}));
+}
+
 TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_SampleReclaimKeysHangs) {
     // when SampleReclaimKeys blocks longer than the future timeout,
     // DoKeySampling should return false instead of blocking forever
@@ -4128,8 +5282,8 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
-        ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+        ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
+            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(9, batch.size());
         // keys 1..10 unique, lru_times 0..9; tp=0 excluded from stats, tp=1..9 included (9 entries)
         // ages: now_us-1, now_us-2, ..., now_us-9 → min=now_us-9, max=now_us-1, diff=8
@@ -4184,8 +5338,8 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
-        ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+        ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
+            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(1, batch.size());
         // all keys are 1 (only 1 unique key), first occurrence has tp=0 → excluded
         // age_count=0 → Clear() called → all stats zeroed
@@ -4237,8 +5391,8 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
         std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
-        ASSERT_TRUE(
-            cache_reclaimer_->MakeBatchByLRU(request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+        ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
+            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
         ASSERT_EQ(2, batch.size());
         // keys={1*7,2,1,1}, tp={9*7,10,9,9}; sorted → key=1(tp=9) then key=2(tp=10)
         // ages: now_us-9 and now_us-10 → min=now_us-10, max=now_us-9, diff=1
@@ -4262,12 +5416,12 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotSkipActiveMigrationTask) {
 
     auto make_serving_map = [](const std::string &loc_id) {
         CacheLocationMap m;
-        auto loc = std::make_shared<CacheLocation>(
-            loc_id,
-            CacheLocationStatus::CLS_SERVING,
-            DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-            1,
-            std::vector<LocationSpec>{LocationSpec("TP0", "dummy://d/" + loc_id)});
+        auto loc =
+            std::make_shared<CacheLocation>(loc_id,
+                                            CacheLocationStatus::CLS_SERVING,
+                                            DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                            1,
+                                            std::vector<LocationSpec>{LocationSpec("TP0", "dummy://d/" + loc_id)});
         m.emplace(loc_id, loc);
         return m;
     };
@@ -4278,7 +5432,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotSkipActiveMigrationTask) {
         batch_get_loc_result = ErrorCode::EC_OK;
 
         CacheReclaimer::WaterLevelExceed wl;
-        wl.SetGeneralWaterLevelExceed(true);
+        wl.SetGroupBytesWaterLevelExceed(true);
         ASSERT_FALSE(wl.CheckStorageTypeWaterLevelExceed());
 
         std::vector<std::vector<std::string>> out;
@@ -4313,21 +5467,20 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotSkipActiveMigrationTask) {
 
 TEST_F(CacheReclaimerTest, TestFilterLocIDSkipsActiveWritingLocations) {
     auto write_location_manager = std::make_shared<WriteLocationManager>();
-    cache_reclaimer_ = std::make_unique<CacheReclaimer>(
-        10,
-        100,
-        1,
-        10,
-        16,
-        rm_,
-        mim_,
-        msm_,
-        spe_,
-        mr_,
-        em_,
-        write_location_manager,
-        CacheReclaimerAsyncDeleteConfig{},
-        mm_);
+    cache_reclaimer_ = std::make_unique<CacheReclaimer>(10,
+                                                        100,
+                                                        1,
+                                                        10,
+                                                        16,
+                                                        rm_,
+                                                        mim_,
+                                                        msm_,
+                                                        spe_,
+                                                        mr_,
+                                                        em_,
+                                                        write_location_manager,
+                                                        CacheReclaimerAsyncDeleteConfig{},
+                                                        mm_);
 
     const auto ins_info = InstanceInfoFactory();
     mm_->DebugInsertActiveCopyTask(ins_info->instance_id(), 42, "migration_writing");
@@ -4340,20 +5493,17 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDSkipsActiveWritingLocations) {
         std::lock_guard<std::mutex> lock(mm_->task_mutex_);
         ASSERT_TRUE(mm_->ReservePreparingTaskLocked(preparing_req));
     }
-    write_location_manager->Put("write_session",
-                                {44},
-                                {"client_writing"},
-                                60,
-                                [](std::unique_ptr<WriteLocationManager::WriteLocationInfo>) {});
+    write_location_manager->Put(
+        "write_session", {44}, {"client_writing"}, 60, [](std::unique_ptr<WriteLocationManager::WriteLocationInfo>) {});
 
     auto make_writing_map = [](const std::string &loc_id) {
         CacheLocationMap m;
-        auto loc = std::make_shared<CacheLocation>(
-            loc_id,
-            CacheLocationStatus::CLS_WRITING,
-            DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-            1,
-            std::vector<LocationSpec>{LocationSpec("TP0", "dummy://d/" + loc_id)});
+        auto loc =
+            std::make_shared<CacheLocation>(loc_id,
+                                            CacheLocationStatus::CLS_WRITING,
+                                            DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                            1,
+                                            std::vector<LocationSpec>{LocationSpec("TP0", "dummy://d/" + loc_id)});
         m.emplace(loc_id, loc);
         return m;
     };
@@ -4365,7 +5515,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDSkipsActiveWritingLocations) {
     batch_get_loc_result = ErrorCode::EC_OK;
 
     CacheReclaimer::WaterLevelExceed wl;
-    wl.SetGeneralWaterLevelExceed(true);
+    wl.SetGroupBytesWaterLevelExceed(true);
 
     std::vector<std::vector<std::string>> out;
     CacheReclaimer::AgeStats age_stats;
@@ -4423,7 +5573,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDKeepColdEvictHot) {
     batch_get_loc_result = ErrorCode::EC_OK;
 
     CacheReclaimer::WaterLevelExceed wl;
-    wl.SetGeneralWaterLevelExceed(true); // 总水位超限分支
+    wl.SetGroupBytesWaterLevelExceed(true); // 总水位超限分支
     ASSERT_FALSE(wl.CheckStorageTypeWaterLevelExceed());
 
     std::vector<std::vector<std::string>> out;
@@ -4484,7 +5634,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDPendingColdDoesNotCompleteCoverage) {
     cache_reclaimer_->pending_locations_.insert({ins_info->instance_id(), block_key, "cold_pending"});
 
     CacheReclaimer::WaterLevelExceed water_level;
-    water_level.SetGeneralWaterLevelExceed(true);
+    water_level.SetGroupBytesWaterLevelExceed(true);
     std::vector<std::vector<std::string>> location_ids;
     CacheReclaimer::AgeStats age_stats;
     ASSERT_TRUE(FilterLocations(ins_info, {block_key}, water_level, location_ids, age_stats));
@@ -4510,15 +5660,14 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotEvictHotWhenColdSpecsIncomplete
     stub_.set(ADDR(RegistryManager, GetInstanceGroup), RegistryManager_GetInstanceGroup_cold_stub);
 
     const auto ins_info = InstanceInfoFactory();
-    auto hot_loc = std::make_shared<CacheLocation>(
-        "hot_full",
-        CacheLocationStatus::CLS_SERVING,
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-        2,
-        std::vector<LocationSpec>{
-            LocationSpec("TP0", "dummy://hot_01/hot_full/tp0"),
-            LocationSpec("TP1", "dummy://hot_01/hot_full/tp1"),
-        });
+    auto hot_loc = std::make_shared<CacheLocation>("hot_full",
+                                                   CacheLocationStatus::CLS_SERVING,
+                                                   DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                                   2,
+                                                   std::vector<LocationSpec>{
+                                                       LocationSpec("TP0", "dummy://hot_01/hot_full/tp0"),
+                                                       LocationSpec("TP1", "dummy://hot_01/hot_full/tp1"),
+                                                   });
     auto partial_cold_loc = std::make_shared<CacheLocation>(
         "cold_partial",
         CacheLocationStatus::CLS_SERVING,
@@ -4543,7 +5692,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotEvictHotWhenColdSpecsIncomplete
     batch_get_loc_result = ErrorCode::EC_OK;
 
     CacheReclaimer::WaterLevelExceed wl;
-    wl.SetGeneralWaterLevelExceed(true);
+    wl.SetGroupBytesWaterLevelExceed(true);
 
     std::vector<std::vector<std::string>> out;
     CacheReclaimer::AgeStats age_stats;
@@ -4557,21 +5706,20 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotEvictHotWhenColdSpecsIncomplete
 
 TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotPreserveColdOrphanWriting) {
     auto write_location_manager = std::make_shared<WriteLocationManager>();
-    cache_reclaimer_ = std::make_unique<CacheReclaimer>(
-        10,
-        100,
-        1,
-        10,
-        16,
-        rm_,
-        mim_,
-        msm_,
-        spe_,
-        mr_,
-        em_,
-        write_location_manager,
-        CacheReclaimerAsyncDeleteConfig{},
-        mm_);
+    cache_reclaimer_ = std::make_unique<CacheReclaimer>(10,
+                                                        100,
+                                                        1,
+                                                        10,
+                                                        16,
+                                                        rm_,
+                                                        mim_,
+                                                        msm_,
+                                                        spe_,
+                                                        mr_,
+                                                        em_,
+                                                        write_location_manager,
+                                                        CacheReclaimerAsyncDeleteConfig{},
+                                                        mm_);
 
     auto ig = InstanceGroupFactory();
     {
@@ -4602,7 +5750,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDDoesNotPreserveColdOrphanWriting) {
     batch_get_loc_result = ErrorCode::EC_OK;
 
     CacheReclaimer::WaterLevelExceed wl;
-    wl.SetGeneralWaterLevelExceed(true);
+    wl.SetGroupBytesWaterLevelExceed(true);
 
     std::vector<std::vector<std::string>> out;
     CacheReclaimer::AgeStats age_stats;
@@ -4751,10 +5899,8 @@ bool MigrationManager_SubmitAsyncMigrationPrepare_stub(void *obj, MigrationManag
     return true;
 }
 
-static MigrationStrategy MakeStrategy(const std::string &src,
-                                      const std::string &dst,
-                                      bool copy_enabled,
-                                      bool mark_enabled) {
+static MigrationStrategy
+MakeStrategy(const std::string &src, const std::string &dst, bool copy_enabled, bool mark_enabled) {
     MigrationStrategy strategy;
     strategy.set_source_storage_name(src);
     strategy.set_target_storage_name(dst);
@@ -4901,6 +6047,7 @@ TEST_F(CacheReclaimerTest, TestReclaimAdmissionExcludesVictimFromSameRoundMigrat
     auto instance_group = InstanceGroupFactory();
     auto config = std::make_shared<CacheConfig>();
     config->set_reclaim_strategy(instance_group->cache_config()->reclaim_strategy());
+    config->reclaim_strategy()->set_instance_reclaim_budget_policy(InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL);
     config->set_meta_indexer_config(instance_group->cache_config()->meta_indexer_config());
     config->set_migration_copy_max_concurrency(1);
     const auto strategy = MakeStrategy("hot_01", "cold_01", /*copy*/ true, /*mark*/ false);
@@ -4938,6 +6085,53 @@ TEST_F(CacheReclaimerTest, TestReclaimAdmissionExcludesVictimFromSameRoundMigrat
     EXPECT_EQ((std::vector<std::int64_t>{10}), captured_async_prepare_keys);
     ASSERT_EQ(1u, captured_async_prepare_pending_locations.size());
     EXPECT_EQ((std::vector<std::string>{"src_10"}), captured_async_prepare_pending_locations.front());
+
+    stub_.reset(ADDR(MigrationManager, SubmitAsyncMigrationPrepare));
+}
+
+TEST_F(CacheReclaimerTest, TestFairReclaimStillRunsMigrationBelowReclaimThreshold) {
+    stub_.set(ADDR(MigrationManager, SubmitAsyncMigrationPrepare), MigrationManager_SubmitAsyncMigrationPrepare_stub);
+    cache_reclaimer_->job_state_flag_ = true;
+    captured_async_prepare_keys.clear();
+    captured_async_prepare_pending_locations.clear();
+
+    const auto ins_info = InstanceInfoFactory();
+    instance_infos = {ins_info};
+    auto instance_group = InstanceGroupFactory();
+    auto config = std::make_shared<CacheConfig>();
+    config->set_reclaim_strategy(instance_group->cache_config()->reclaim_strategy());
+    config->reclaim_strategy()->set_instance_reclaim_budget_policy(InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL);
+    config->set_meta_indexer_config(instance_group->cache_config()->meta_indexer_config());
+    config->set_migration_copy_max_concurrency(1);
+    const auto strategy = MakeStrategy("hot_01", "cold_01", /*copy*/ true, /*mark*/ false);
+    config->set_migration_strategies({std::make_shared<MigrationStrategy>(strategy)});
+    instance_group->set_cache_config(config);
+
+    QuotaConfig quota_config;
+    quota_config.set_capacity(100);
+    quota_config.set_storage_type(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    InstanceGroupQuota quota;
+    quota.set_capacity(100);
+    quota.set_quota_config({quota_config});
+    instance_group->set_quota(quota);
+    EnableAsyncMigration(instance_group, ins_info);
+
+    // 60% is above the migration threshold (50%) but below the
+    // reclaim threshold (80%).
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS, 60);
+    sample_reclaim_keys = {10};
+    get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetSamplingSize(request_context_.get(), 1));
+    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
+
+    const auto result = cache_reclaimer_->TryReclaimOnGroup(request_context_, instance_group);
+
+    EXPECT_FALSE(result.water_level_exceeded);
+    EXPECT_FALSE(result.made_progress);
+    EXPECT_EQ(0, SubmittedDelRequestCount());
+    EXPECT_EQ((std::vector<std::int64_t>{10}), captured_async_prepare_keys);
+    ASSERT_EQ(1u, captured_async_prepare_pending_locations.size());
+    EXPECT_TRUE(captured_async_prepare_pending_locations.front().empty());
 
     stub_.reset(ADDR(MigrationManager, SubmitAsyncMigrationPrepare));
 }
@@ -5049,8 +6243,8 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareRejectsAmbiguousRoute) {
     config->set_meta_indexer_config(instance_group->cache_config()->meta_indexer_config());
     config->set_migration_copy_max_concurrency(1);
     // Direct mutation deliberately bypasses config validation to cover recovered legacy data.
-    config->set_migration_strategies({std::make_shared<MigrationStrategy>(copy_strategy),
-                                      std::make_shared<MigrationStrategy>(mark_strategy)});
+    config->set_migration_strategies(
+        {std::make_shared<MigrationStrategy>(copy_strategy), std::make_shared<MigrationStrategy>(mark_strategy)});
     instance_group->set_cache_config(config);
     EnableAsyncMigration(instance_group, ins_info);
 
@@ -5107,8 +6301,8 @@ TEST_F(CacheReclaimerTest, TestMigrationManagerStopWaitsForRunningAsyncPrepare) 
     bool read_started = false;
     {
         std::unique_lock<std::mutex> lock(async_prepare_read_mutex);
-        read_started = async_prepare_read_cv.wait_for(
-            lock, std::chrono::seconds(3), []() { return async_prepare_read_started; });
+        read_started =
+            async_prepare_read_cv.wait_for(lock, std::chrono::seconds(3), []() { return async_prepare_read_started; });
     }
 
     std::future<void> stop_future;
@@ -5248,8 +6442,7 @@ TEST_F(CacheReclaimerTest, TestExecutorStopCancelsQueuedAsyncMigrationPrepare) {
         release_blocker = true;
     }
     cv.notify_all();
-    const bool stop_completed =
-        stop_future.wait_for(std::chrono::seconds(3)) == std::future_status::ready;
+    const bool stop_completed = stop_future.wait_for(std::chrono::seconds(3)) == std::future_status::ready;
 
     EXPECT_TRUE(started);
     EXPECT_TRUE(accepted);
@@ -5329,19 +6522,16 @@ TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupAccountsForPendingPrepareAcrossT
     }
 
     cache_reclaimer_->TryMigrateOnGroup(request_context_, instance_group, {first_instance});
-    const auto pending_after_first_tick =
-        mm_->PendingAsyncMigrationPrepareCountForGroup(instance_group->name());
+    const auto pending_after_first_tick = mm_->PendingAsyncMigrationPrepareCountForGroup(instance_group->name());
 
     sample_reclaim_call_counter = 0;
     cache_reclaimer_->TryMigrateOnGroup(request_context_, instance_group, {second_instance, third_instance});
-    const auto pending_after_second_tick =
-        mm_->PendingAsyncMigrationPrepareCountForGroup(instance_group->name());
+    const auto pending_after_second_tick = mm_->PendingAsyncMigrationPrepareCountForGroup(instance_group->name());
     const auto sampled_on_second_tick = sample_reclaim_call_counter;
 
     sample_reclaim_call_counter = 0;
     cache_reclaimer_->TryMigrateOnGroup(request_context_, instance_group, {third_instance});
-    const auto pending_after_full_tick =
-        mm_->PendingAsyncMigrationPrepareCountForGroup(instance_group->name());
+    const auto pending_after_full_tick = mm_->PendingAsyncMigrationPrepareCountForGroup(instance_group->name());
     const auto sampled_when_full = sample_reclaim_call_counter;
 
     {
@@ -5354,8 +6544,7 @@ TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupAccountsForPendingPrepareAcrossT
     EXPECT_TRUE(started);
     EXPECT_EQ(1u, pending_after_first_tick);
     EXPECT_EQ(2u, pending_after_second_tick);
-    EXPECT_EQ(1, sampled_on_second_tick)
-        << "only one remaining copy slot may enqueue one instance prepare job";
+    EXPECT_EQ(1, sampled_on_second_tick) << "only one remaining copy slot may enqueue one instance prepare job";
     EXPECT_EQ(2u, pending_after_full_tick);
     EXPECT_EQ(0, sampled_when_full) << "a full pending budget must prune before candidate sampling";
     EXPECT_TRUE(became_idle);
@@ -5673,27 +6862,26 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDMultiColdUnionCoversHot) {
     stub_.set(ADDR(RegistryManager, GetInstanceGroup), RegistryManager_GetInstanceGroup_cold_stub);
     const auto ins_info = InstanceInfoFactory();
 
-    auto hot_loc = std::make_shared<CacheLocation>(
-        "hot_full",
-        CacheLocationStatus::CLS_SERVING,
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-        2,
-        std::vector<LocationSpec>{
-            LocationSpec("TP0", "dummy://hot_01/hot_full/tp0"),
-            LocationSpec("TP1", "dummy://hot_01/hot_full/tp1"),
-        });
-    auto cold_a = std::make_shared<CacheLocation>(
-        "cold_a",
-        CacheLocationStatus::CLS_SERVING,
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-        1,
-        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold_01/cold_a/tp0")});
-    auto cold_b = std::make_shared<CacheLocation>(
-        "cold_b",
-        CacheLocationStatus::CLS_SERVING,
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-        1,
-        std::vector<LocationSpec>{LocationSpec("TP1", "dummy://cold_01/cold_b/tp1")});
+    auto hot_loc = std::make_shared<CacheLocation>("hot_full",
+                                                   CacheLocationStatus::CLS_SERVING,
+                                                   DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                                   2,
+                                                   std::vector<LocationSpec>{
+                                                       LocationSpec("TP0", "dummy://hot_01/hot_full/tp0"),
+                                                       LocationSpec("TP1", "dummy://hot_01/hot_full/tp1"),
+                                                   });
+    auto cold_a =
+        std::make_shared<CacheLocation>("cold_a",
+                                        CacheLocationStatus::CLS_SERVING,
+                                        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                        1,
+                                        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold_01/cold_a/tp0")});
+    auto cold_b =
+        std::make_shared<CacheLocation>("cold_b",
+                                        CacheLocationStatus::CLS_SERVING,
+                                        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                        1,
+                                        std::vector<LocationSpec>{LocationSpec("TP1", "dummy://cold_01/cold_b/tp1")});
 
     CacheLocationMap loc_map;
     loc_map.emplace("hot_full", hot_loc);
@@ -5703,7 +6891,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDMultiColdUnionCoversHot) {
     batch_get_loc_result = ErrorCode::EC_OK;
 
     CacheReclaimer::WaterLevelExceed wl;
-    wl.SetGeneralWaterLevelExceed(true);
+    wl.SetGroupBytesWaterLevelExceed(true);
 
     std::vector<std::vector<std::string>> out;
     CacheReclaimer::AgeStats age_stats;
@@ -5775,18 +6963,18 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDWritingColdDoesNotProtectHot) {
     const auto ins_info = InstanceInfoFactory();
 
     // hot: SERVING, cold: WRITING(迁移中半成品)
-    auto hot_loc = std::make_shared<CacheLocation>(
-        "hot_a",
-        CacheLocationStatus::CLS_SERVING,
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-        1,
-        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://hot_01/hot_a")});
-    auto cold_writing = std::make_shared<CacheLocation>(
-        "cold_w",
-        CacheLocationStatus::CLS_WRITING,
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-        1,
-        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold_01/cold_w")});
+    auto hot_loc =
+        std::make_shared<CacheLocation>("hot_a",
+                                        CacheLocationStatus::CLS_SERVING,
+                                        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                        1,
+                                        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://hot_01/hot_a")});
+    auto cold_writing =
+        std::make_shared<CacheLocation>("cold_w",
+                                        CacheLocationStatus::CLS_WRITING,
+                                        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                        1,
+                                        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold_01/cold_w")});
 
     CacheLocationMap loc_map;
     loc_map.emplace("hot_a", hot_loc);
@@ -5795,7 +6983,7 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDWritingColdDoesNotProtectHot) {
     batch_get_loc_result = ErrorCode::EC_OK;
 
     CacheReclaimer::WaterLevelExceed wl;
-    wl.SetGeneralWaterLevelExceed(true);
+    wl.SetGroupBytesWaterLevelExceed(true);
 
     std::vector<std::vector<std::string>> out;
     CacheReclaimer::AgeStats age_stats;

--- a/kv_cache_manager/manager/test/startup_config_loader_test.cc
+++ b/kv_cache_manager/manager/test/startup_config_loader_test.cc
@@ -78,6 +78,7 @@ TEST_F(StartupConfigLoaderTest, TestStartupConfigJsonize) {
     ASSERT_EQ(reclaim1.reclaim_step_size(), reclaim2.reclaim_step_size());
     ASSERT_EQ(reclaim1.reclaim_step_percentage(), reclaim2.reclaim_step_percentage());
     ASSERT_EQ(reclaim1.delay_before_delete_ms(), reclaim2.delay_before_delete_ms());
+    ASSERT_EQ(reclaim1.instance_reclaim_budget_policy(), reclaim2.instance_reclaim_budget_policy());
 
     // Compare TriggerStrategy
     const TriggerStrategy &trigger1 = reclaim1.trigger_strategy();
@@ -131,6 +132,8 @@ TEST_F(StartupConfigLoaderTest, TestLoad) {
         auto [ec, ig] = registry_manager->GetInstanceGroup(request_context1, "default");
         ASSERT_EQ(ErrorCode::EC_OK, ec);
         ASSERT_TRUE(ig);
+        ASSERT_EQ(InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL,
+                  ig->cache_config()->reclaim_strategy()->instance_reclaim_budget_policy());
         auto [ec2, config_vec] = registry_manager->ListStorage(request_context2);
         ASSERT_EQ(ErrorCode::EC_OK, ec2);
         ASSERT_EQ(1, config_vec.size());
@@ -148,6 +151,8 @@ TEST_F(StartupConfigLoaderTest, TestLoad) {
         auto [ec, ig] = registry_manager->GetInstanceGroup(request_context1, "default");
         ASSERT_EQ(ErrorCode::EC_OK, ec);
         ASSERT_TRUE(ig);
+        ASSERT_EQ(InstanceReclaimBudgetPolicy::USAGE_PROPORTIONAL,
+                  ig->cache_config()->reclaim_strategy()->instance_reclaim_budget_policy());
         auto [ec2, config_vec] = registry_manager->ListStorage(request_context2);
         ASSERT_EQ(ErrorCode::EC_OK, ec2);
         ASSERT_EQ(1, config_vec.size());
@@ -189,6 +194,7 @@ InstanceGroup StartupConfigLoaderTest::MakeInstanceGroup() {
     reclaim_strategy->set_reclaim_step_size(1073741824); // 1GB
     reclaim_strategy->set_reclaim_step_percentage(10);
     reclaim_strategy->set_delay_before_delete_ms(1000);
+    reclaim_strategy->set_instance_reclaim_budget_policy(InstanceReclaimBudgetPolicy::FIXED_PER_INSTANCE);
 
     // Create meta storage backend config
     auto meta_storage_backend_config = std::make_shared<MetaStorageBackendConfig>();

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -137,6 +137,14 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_reclaimer, delete_submit_count);
     DECLARE_METRICS(cache_reclaimer, delete_complete_count);
     DECLARE_METRICS(cache_reclaimer, delete_fail_count);
+    DECLARE_METRICS(cache_reclaimer, fair_plan_count);
+    DECLARE_METRICS(cache_reclaimer, fair_planned_batch_count);
+    DECLARE_METRICS(cache_reclaimer, fair_planned_sample_count);
+    DECLARE_METRICS(cache_reclaimer, fair_zero_weight_skip_count);
+    DECLARE_METRICS(cache_reclaimer, fair_plan_truncated_count);
+    DECLARE_METRICS(cache_reclaimer, fair_plan_truncated_instance_count);
+    DECLARE_METRICS(cache_reclaimer, fair_item_capped_count);
+    DECLARE_METRICS(cache_reclaimer, fair_sampling_size_normalized_count);
 
     DECLARE_METRICS(cache_reclaimer, reclaim_cron_duration_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_quota_duration_us);
@@ -152,6 +160,10 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_reclaimer, credited_delete_bytes);
     DECLARE_METRICS(cache_reclaimer, predicted_deleted_key_count);
     DECLARE_METRICS(cache_reclaimer, oldest_pending_request_age_ms);
+    DECLARE_METRICS(cache_reclaimer, fair_effective_instance_count);
+    DECLARE_METRICS(cache_reclaimer, fair_planned_instance_count);
+    DECLARE_METRICS(cache_reclaimer, fair_sampled_instance_count);
+    DECLARE_METRICS(cache_reclaimer, fair_submitted_instance_count);
 
     DECLARE_METRICS(cache_reclaimer, reclaim_batch_lru_age_min_us);
     DECLARE_METRICS(cache_reclaimer, reclaim_batch_lru_age_max_us);
@@ -408,6 +420,14 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_reclaimer, delete_submit_count);
     REGISTER_GAUGE_METRIC(cache_reclaimer, delete_complete_count);
     REGISTER_GAUGE_METRIC(cache_reclaimer, delete_fail_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_plan_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_planned_batch_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_planned_sample_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_zero_weight_skip_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_plan_truncated_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_plan_truncated_instance_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_item_capped_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_sampling_size_normalized_count);
 
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_cron_duration_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_quota_duration_us);
@@ -423,6 +443,10 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_reclaimer, credited_delete_bytes);
     REGISTER_GAUGE_METRIC(cache_reclaimer, predicted_deleted_key_count);
     REGISTER_GAUGE_METRIC(cache_reclaimer, oldest_pending_request_age_ms);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_effective_instance_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_planned_instance_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_sampled_instance_count);
+    REGISTER_GAUGE_METRIC(cache_reclaimer, fair_submitted_instance_count);
 
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_lru_age_min_us);
     REGISTER_GAUGE_METRIC(cache_reclaimer, reclaim_batch_lru_age_max_us);
@@ -715,6 +739,14 @@ void KmonitorMetricsReporter::ReportInterval() {
         std::uint64_t delete_submit_count_v;
         std::uint64_t delete_complete_count_v;
         std::uint64_t delete_fail_count_v;
+        std::uint64_t fair_plan_count_v;
+        std::uint64_t fair_planned_batch_count_v;
+        std::uint64_t fair_planned_sample_count_v;
+        std::uint64_t fair_zero_weight_skip_count_v;
+        std::uint64_t fair_plan_truncated_count_v;
+        std::uint64_t fair_plan_truncated_instance_count_v;
+        std::uint64_t fair_item_capped_count_v;
+        std::uint64_t fair_sampling_size_normalized_count_v;
 
         double reclaim_cron_duration_us_v;
         double reclaim_quota_duration_us_v;
@@ -730,6 +762,10 @@ void KmonitorMetricsReporter::ReportInterval() {
         double credited_delete_bytes_v;
         double predicted_deleted_key_count_v;
         double oldest_pending_request_age_ms_v;
+        double fair_effective_instance_count_v;
+        double fair_planned_instance_count_v;
+        double fair_sampled_instance_count_v;
+        double fair_submitted_instance_count_v;
 
         double reclaim_batch_lru_age_min_us_v;
         double reclaim_batch_lru_age_max_us_v;
@@ -754,6 +790,14 @@ void KmonitorMetricsReporter::ReportInterval() {
         GET_METRICS_(cr, cache_reclaimer, delete_submit_count, delete_submit_count_v);
         GET_METRICS_(cr, cache_reclaimer, delete_complete_count, delete_complete_count_v);
         GET_METRICS_(cr, cache_reclaimer, delete_fail_count, delete_fail_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_plan_count, fair_plan_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_planned_batch_count, fair_planned_batch_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_planned_sample_count, fair_planned_sample_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_zero_weight_skip_count, fair_zero_weight_skip_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_plan_truncated_count, fair_plan_truncated_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_plan_truncated_instance_count, fair_plan_truncated_instance_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_item_capped_count, fair_item_capped_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_sampling_size_normalized_count, fair_sampling_size_normalized_count_v);
 
         GET_METRICS_(cr, cache_reclaimer, reclaim_cron_duration_us, reclaim_cron_duration_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_quota_duration_us, reclaim_quota_duration_us_v);
@@ -769,6 +813,10 @@ void KmonitorMetricsReporter::ReportInterval() {
         GET_METRICS_(cr, cache_reclaimer, credited_delete_bytes, credited_delete_bytes_v);
         GET_METRICS_(cr, cache_reclaimer, predicted_deleted_key_count, predicted_deleted_key_count_v);
         GET_METRICS_(cr, cache_reclaimer, oldest_pending_request_age_ms, oldest_pending_request_age_ms_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_effective_instance_count, fair_effective_instance_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_planned_instance_count, fair_planned_instance_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_sampled_instance_count, fair_sampled_instance_count_v);
+        GET_METRICS_(cr, cache_reclaimer, fair_submitted_instance_count, fair_submitted_instance_count_v);
 
         GET_METRICS_(cr, cache_reclaimer, reclaim_batch_lru_age_min_us, reclaim_batch_lru_age_min_us_v);
         GET_METRICS_(cr, cache_reclaimer, reclaim_batch_lru_age_max_us, reclaim_batch_lru_age_max_us_v);
@@ -795,6 +843,19 @@ void KmonitorMetricsReporter::ReportInterval() {
         REPORT_METRICS(cache_reclaimer, delete_submit_count, static_cast<double>(delete_submit_count_v));
         REPORT_METRICS(cache_reclaimer, delete_complete_count, static_cast<double>(delete_complete_count_v));
         REPORT_METRICS(cache_reclaimer, delete_fail_count, static_cast<double>(delete_fail_count_v));
+        REPORT_METRICS(cache_reclaimer, fair_plan_count, static_cast<double>(fair_plan_count_v));
+        REPORT_METRICS(cache_reclaimer, fair_planned_batch_count, static_cast<double>(fair_planned_batch_count_v));
+        REPORT_METRICS(cache_reclaimer, fair_planned_sample_count, static_cast<double>(fair_planned_sample_count_v));
+        REPORT_METRICS(
+            cache_reclaimer, fair_zero_weight_skip_count, static_cast<double>(fair_zero_weight_skip_count_v));
+        REPORT_METRICS(cache_reclaimer, fair_plan_truncated_count, static_cast<double>(fair_plan_truncated_count_v));
+        REPORT_METRICS(cache_reclaimer,
+                       fair_plan_truncated_instance_count,
+                       static_cast<double>(fair_plan_truncated_instance_count_v));
+        REPORT_METRICS(cache_reclaimer, fair_item_capped_count, static_cast<double>(fair_item_capped_count_v));
+        REPORT_METRICS(cache_reclaimer,
+                       fair_sampling_size_normalized_count,
+                       static_cast<double>(fair_sampling_size_normalized_count_v));
 
         REPORT_METRICS(cache_reclaimer, reclaim_cron_duration_us, reclaim_cron_duration_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_quota_duration_us, reclaim_quota_duration_us_v);
@@ -810,6 +871,10 @@ void KmonitorMetricsReporter::ReportInterval() {
         REPORT_METRICS(cache_reclaimer, credited_delete_bytes, credited_delete_bytes_v);
         REPORT_METRICS(cache_reclaimer, predicted_deleted_key_count, predicted_deleted_key_count_v);
         REPORT_METRICS(cache_reclaimer, oldest_pending_request_age_ms, oldest_pending_request_age_ms_v);
+        REPORT_METRICS(cache_reclaimer, fair_effective_instance_count, fair_effective_instance_count_v);
+        REPORT_METRICS(cache_reclaimer, fair_planned_instance_count, fair_planned_instance_count_v);
+        REPORT_METRICS(cache_reclaimer, fair_sampled_instance_count, fair_sampled_instance_count_v);
+        REPORT_METRICS(cache_reclaimer, fair_submitted_instance_count, fair_submitted_instance_count_v);
 
         REPORT_METRICS(cache_reclaimer, reclaim_batch_lru_age_min_us, reclaim_batch_lru_age_min_us_v);
         REPORT_METRICS(cache_reclaimer, reclaim_batch_lru_age_max_us, reclaim_batch_lru_age_max_us_v);

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -191,6 +191,11 @@ enum ReclaimPolicy {
     POLICY_TTL = 3;
 }
 
+enum InstanceReclaimBudgetPolicy {
+    USAGE_PROPORTIONAL = 0;
+    FIXED_PER_INSTANCE = 1;
+}
+
 message QuotaConfig {
     StorageType storage_type = 1;
     int64 capacity = 2;
@@ -209,6 +214,7 @@ message CacheReclaimStrategy {
     int32 reclaim_step_size = 5;       // 每次回收的步长绝对值,如100GiB
     int32 reclaim_step_percentage = 6; // 每次回收的步长相对比例,如回收5%的数据量
     int32 delay_before_delete_ms = 7; // Location设置为Deleting状态后等待多少毫秒再调用Storage删除
+    InstanceReclaimBudgetPolicy instance_reclaim_budget_policy = 8;
 }
 
 // ===== 多层存储迁移（Tiered Storage Migration）配置 =====

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -216,6 +216,8 @@ void ProtoConvert::CacheConfigToProto(const CacheConfig &cache_config_info,
     reclaim_strategy->set_reclaim_step_size(cache_config_info.reclaim_strategy()->reclaim_step_size());
     reclaim_strategy->set_reclaim_step_percentage(cache_config_info.reclaim_strategy()->reclaim_step_percentage());
     reclaim_strategy->set_delay_before_delete_ms(cache_config_info.reclaim_strategy()->delay_before_delete_ms());
+    reclaim_strategy->set_instance_reclaim_budget_policy(static_cast<proto::admin::InstanceReclaimBudgetPolicy>(
+        cache_config_info.reclaim_strategy()->instance_reclaim_budget_policy()));
 
     // 转换data_storage_strategy (cache_prefer_strategy)
     proto_cache_config->set_data_storage_strategy(
@@ -291,6 +293,8 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
     reclaim_strategy->set_reclaim_step_size(proto_cache_config->reclaim_strategy().reclaim_step_size());
     reclaim_strategy->set_reclaim_step_percentage(proto_cache_config->reclaim_strategy().reclaim_step_percentage());
     reclaim_strategy->set_delay_before_delete_ms(proto_cache_config->reclaim_strategy().delay_before_delete_ms());
+    reclaim_strategy->set_instance_reclaim_budget_policy(static_cast<InstanceReclaimBudgetPolicy>(
+        proto_cache_config->reclaim_strategy().instance_reclaim_budget_policy()));
 
     cache_config_info.set_reclaim_strategy(reclaim_strategy);
 

--- a/package/kvcm_ops/BUILD
+++ b/package/kvcm_ops/BUILD
@@ -35,3 +35,9 @@ py_test(
     srcs = ["test/instance_group_revisit_buckets_test.py"],
     deps = [":kvcm_ops_lib"],
 )
+
+py_test(
+    name = "instance_group_fairness_test",
+    srcs = ["test/instance_group_fairness_test.py"],
+    deps = [":kvcm_ops_lib"],
+)

--- a/package/kvcm_ops/kvcm/instance_group/create_instance_group.py
+++ b/package/kvcm_ops/kvcm/instance_group/create_instance_group.py
@@ -72,7 +72,8 @@ def create_instance_group(args) -> InstanceGroup:
     instance_group_quota = InstanceGroupQuota(args.quota_capacity, args.quota_configs)
     reclaim_strategy = ReclaimStrategy(storage_unique_name=args.storage_candidates[0],
                                        reclaim_policy=args.reclaim_policy,
-                                       trigger_used_percentage=args.reclaim_used_percentage)
+                                       trigger_used_percentage=args.reclaim_used_percentage,
+                                       instance_reclaim_budget_policy=args.instance_reclaim_budget_policy)
     meta_cache_policy_config = MetaCachePolicyConfig(capacity=args.search_cache_capacity,
                                                      cache_shard_bits=args.search_cache_shard_bits)
     meta_indexer_config = MetaIndexerConfig(max_key_count=args.max_key_count,

--- a/package/kvcm_ops/kvcm/instance_group/update_instance_group.py
+++ b/package/kvcm_ops/kvcm/instance_group/update_instance_group.py
@@ -37,6 +37,9 @@ def main():
         current._cache_config._reclaim_strategy._reclaim_policy = args.reclaim_policy
     if hasattr(args, "reclaim_used_percentage"):
         current._cache_config._reclaim_strategy._trigger_used_percentage = args.reclaim_used_percentage
+    if hasattr(args, "instance_reclaim_budget_policy"):
+        current._cache_config._reclaim_strategy._instance_reclaim_budget_policy = \
+            args.instance_reclaim_budget_policy
     if hasattr(args, "data_storage_strategy"):
         current._cache_config._data_storage_strategy = args.data_storage_strategy
     if hasattr(args, "max_key_count"):

--- a/package/kvcm_ops/kvcm/instance_group/util.py
+++ b/package/kvcm_ops/kvcm/instance_group/util.py
@@ -102,7 +102,8 @@ class ReclaimStrategy(JsonData):
                  trigger_period_seconds: int = 0,
                  reclaim_step_size: int = 0,
                  reclaim_step_percentage: float = 0.0,
-                 delay_before_delete_ms: int = 1000
+                 delay_before_delete_ms: int = 1000,
+                 instance_reclaim_budget_policy: str = "USAGE_PROPORTIONAL",
                  ):
         self._storage_unique_name = storage_unique_name
         self._reclaim_policy = reclaim_policy
@@ -112,6 +113,7 @@ class ReclaimStrategy(JsonData):
         self._reclaim_step_size = reclaim_step_size
         self._reclaim_step_percentage = reclaim_step_percentage
         self._delay_before_delete_ms = delay_before_delete_ms
+        self._instance_reclaim_budget_policy = instance_reclaim_budget_policy
         self.check()
 
     def to_json_data(self) -> dict:
@@ -125,7 +127,8 @@ class ReclaimStrategy(JsonData):
             "trigger_period_seconds": self._trigger_period_seconds,
             "reclaim_step_size": self._reclaim_step_size,
             "reclaim_step_percentage": self._reclaim_step_percentage,
-            "delay_before_delete_ms": self._delay_before_delete_ms
+            "delay_before_delete_ms": self._delay_before_delete_ms,
+            "instance_reclaim_budget_policy": self._instance_reclaim_budget_policy,
         }
 
     def check(self) -> bool:
@@ -133,6 +136,12 @@ class ReclaimStrategy(JsonData):
         if _reclaim_policy not in ["POLICY_LRU", "POLICY_LFU", "POLICY_TTL"]:
             raise RuntimeError(f"reclaim_policy {_reclaim_policy} invalid, support POLICY_LRU|POLICY_LFU|POLICY_TTL")
         self._reclaim_policy = _reclaim_policy
+        if not isinstance(self._instance_reclaim_budget_policy, str):
+            raise RuntimeError("instance_reclaim_budget_policy must be a string")
+        self._instance_reclaim_budget_policy = self._instance_reclaim_budget_policy.strip().upper()
+        if self._instance_reclaim_budget_policy not in ("USAGE_PROPORTIONAL", "FIXED_PER_INSTANCE"):
+            raise RuntimeError(
+                "instance_reclaim_budget_policy must be USAGE_PROPORTIONAL or FIXED_PER_INSTANCE")
         return True
 
     @classmethod
@@ -155,6 +164,9 @@ class ReclaimStrategy(JsonData):
             reclaim_step_percentage = float(json_data["reclaim_step_percentage"])
         if JsonData.expect_exist("delay_before_delete_ms", json_data, (str, int)):
             delay_before_delete_ms = int(json_data["delay_before_delete_ms"])
+        instance_reclaim_budget_policy = "USAGE_PROPORTIONAL"
+        if JsonData.maybe_exist("instance_reclaim_budget_policy", json_data, str):
+            instance_reclaim_budget_policy = json_data["instance_reclaim_budget_policy"]
         return cls(
             storage_unique_name,
             reclaim_policy,
@@ -163,7 +175,18 @@ class ReclaimStrategy(JsonData):
             trigger_period_seconds,
             reclaim_step_size,
             reclaim_step_percentage,
-            delay_before_delete_ms)
+            delay_before_delete_ms,
+            instance_reclaim_budget_policy)
+
+
+def instance_reclaim_budget_policy_value(value: str) -> str:
+    if not isinstance(value, str):
+        raise argparse.ArgumentTypeError("instance_reclaim_budget_policy must be a string")
+    normalized = value.strip().upper()
+    if normalized in ("USAGE_PROPORTIONAL", "FIXED_PER_INSTANCE"):
+        return normalized
+    raise argparse.ArgumentTypeError(
+        "instance_reclaim_budget_policy must be USAGE_PROPORTIONAL or FIXED_PER_INSTANCE")
 
 
 class MetaStorageBackendConfig(JsonData):
@@ -533,6 +556,16 @@ def parse_instance_group_args(is_create: bool):
         type=float,
         default=0.8 if is_create else argparse.SUPPRESS,
         help="reclaim_used_percentage"
+    )
+
+    parser.add_argument(
+        "--instance_reclaim_budget_policy",
+        type=instance_reclaim_budget_policy_value,
+        default="USAGE_PROPORTIONAL" if is_create else argparse.SUPPRESS,
+        help=(
+            "cross-instance reclaim budget policy: USAGE_PROPORTIONAL or FIXED_PER_INSTANCE. "
+            "On update, omit to keep the server-side value"
+        )
     )
 
     parser.add_argument(

--- a/package/kvcm_ops/test/instance_group_fairness_test.py
+++ b/package/kvcm_ops/test/instance_group_fairness_test.py
@@ -1,0 +1,138 @@
+import argparse
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+# Bazel keeps sources under package/kvcm_ops while the wheel exposes kvcm_ops
+# as a top-level namespace package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from kvcm_ops.kvcm.instance_group import update_instance_group
+from kvcm_ops.kvcm.instance_group.util import (
+    CacheConfig,
+    InstanceGroup,
+    InstanceGroupQuota,
+    ReclaimStrategy,
+    StorageQuota,
+    instance_reclaim_budget_policy_value,
+    parse_instance_group_args,
+)
+
+
+def _make_instance_group(instance_reclaim_budget_policy="USAGE_PROPORTIONAL"):
+    quota = InstanceGroupQuota(1000, [StorageQuota("ST_NFS", 100)])
+    reclaim_strategy = ReclaimStrategy(
+        storage_unique_name="nfs_01",
+        instance_reclaim_budget_policy=instance_reclaim_budget_policy,
+    )
+    return InstanceGroup(
+        name="g1",
+        storage_candidates=["nfs_01"],
+        instance_group_quota=quota,
+        quota_group_name="default_quota_group",
+        cache_config=CacheConfig(reclaim_strategy=reclaim_strategy),
+    )
+
+
+class ReclaimStrategyBudgetPolicyTest(unittest.TestCase):
+    def test_defaults_to_usage_proportional(self):
+        self.assertEqual(
+            "USAGE_PROPORTIONAL",
+            ReclaimStrategy().to_json_data()["instance_reclaim_budget_policy"])
+
+    def test_json_round_trip_preserves_fixed_per_instance(self):
+        data = ReclaimStrategy(instance_reclaim_budget_policy="FIXED_PER_INSTANCE").to_json_data()
+        restored = ReclaimStrategy.from_json_data(data)
+        self.assertEqual(
+            "FIXED_PER_INSTANCE",
+            restored.to_json_data()["instance_reclaim_budget_policy"])
+
+    def test_missing_json_field_defaults_to_usage_proportional(self):
+        data = ReclaimStrategy(instance_reclaim_budget_policy="FIXED_PER_INSTANCE").to_json_data()
+        del data["instance_reclaim_budget_policy"]
+        restored = ReclaimStrategy.from_json_data(data)
+        self.assertEqual(
+            "USAGE_PROPORTIONAL",
+            restored.to_json_data()["instance_reclaim_budget_policy"])
+
+    def test_unknown_policy_is_rejected(self):
+        data = ReclaimStrategy().to_json_data()
+        data["instance_reclaim_budget_policy"] = "UNKNOWN"
+        with self.assertRaises(RuntimeError):
+            ReclaimStrategy.from_json_data(data)
+
+
+class BudgetPolicyValueTest(unittest.TestCase):
+    def test_valid_values(self):
+        for value, expected in (
+                ("usage_proportional", "USAGE_PROPORTIONAL"),
+                ("USAGE_PROPORTIONAL", "USAGE_PROPORTIONAL"),
+                ("fixed_per_instance", "FIXED_PER_INSTANCE"),
+                ("FIXED_PER_INSTANCE", "FIXED_PER_INSTANCE")):
+            with self.subTest(value=value):
+                self.assertEqual(expected, instance_reclaim_budget_policy_value(value))
+
+    def test_invalid_value(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            instance_reclaim_budget_policy_value("yes")
+
+
+class ParseInstanceGroupArgsTest(unittest.TestCase):
+    def _parse(self, is_create, *extra_args):
+        argv = ["prog", "--name", "g1"]
+        if is_create:
+            argv += ["--storage_candidates", "nfs_01"]
+        argv += list(extra_args)
+        with patch("sys.argv", argv):
+            return parse_instance_group_args(is_create=is_create)
+
+    def test_create_defaults_to_usage_proportional(self):
+        self.assertEqual("USAGE_PROPORTIONAL", self._parse(True).instance_reclaim_budget_policy)
+
+    def test_create_accepts_fixed_per_instance(self):
+        self.assertEqual(
+            "FIXED_PER_INSTANCE",
+            self._parse(True, "--instance_reclaim_budget_policy", "fixed_per_instance")
+            .instance_reclaim_budget_policy)
+
+    def test_update_omitted_keeps_no_attribute(self):
+        self.assertFalse(hasattr(self._parse(False), "instance_reclaim_budget_policy"))
+
+    def test_update_accepts_explicit_value(self):
+        self.assertEqual(
+            "USAGE_PROPORTIONAL",
+            self._parse(False, "--instance_reclaim_budget_policy", "usage_proportional")
+            .instance_reclaim_budget_policy)
+
+
+class UpdateInstanceGroupTest(unittest.TestCase):
+    def _run_update(self, server_policy, *extra_args):
+        instance_group = _make_instance_group(server_policy).to_json_data()
+        with patch("sys.argv", ["prog", "--name", "g1", *extra_args]), \
+             patch.object(update_instance_group, "http_post") as mock_http_post:
+            mock_http_post.side_effect = [
+                {"header": {"status": {"code": "OK"}}, "instance_group": instance_group},
+                {"header": {"status": {"code": "OK"}}},
+            ]
+            update_instance_group.main()
+            request = mock_http_post.call_args_list[1].args[2]
+            return request["instance_group"]["cache_config"]["reclaim_strategy"][
+                "instance_reclaim_budget_policy"]
+
+    def test_omitted_preserves_fixed_per_instance_from_server(self):
+        self.assertEqual(
+            "FIXED_PER_INSTANCE",
+            self._run_update("FIXED_PER_INSTANCE", "--user_data", "changed"))
+
+    def test_explicit_value_overrides_server_value(self):
+        self.assertEqual(
+            "USAGE_PROPORTIONAL",
+            self._run_update(
+                "FIXED_PER_INSTANCE",
+                "--instance_reclaim_budget_policy",
+                "USAGE_PROPORTIONAL"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- distribute each group reclaim round sampling and eviction budgets across instances according to the active water-level dimension
- use deterministic integer allocation, bounded sampling waves, and current async credit checks to avoid group over-eviction
- preserve legacy behavior behind enable_instance_fairness and keep multi-tier migration admission ordered after reclaim admission
- add metrics, configuration/proto plumbing, design documentation, and regression coverage for allocation, water-level priority, credit, sampling, and migration interactions

## Testing

- //kv_cache_manager/manager/test:CacheReclaimerTest
- //kv_cache_manager/config/test:instance_group_test
- //kv_cache_manager/manager/test:StartupConfigLoaderTest
- //kv_cache_manager:kv_cache_manager_bin
- tiered-storage reclaimer smoke tests: 5 passed