### PR TITLE
[ci] add lucky-zzz as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @charpty @oldsharp @PerryZZ @wangxiyu191 @xiqi-lq
+* @charpty @oldsharp @PerryZZ @wangxiyu191 @xiqi-lq @lucky-zzz
 
 /.github/CODEOWNERS @charpty @oldsharp @PerryZZ @wangxiyu191 @xiqi-lq
 


### PR DESCRIPTION
## What changed

- Add `@lucky-zzz` to the repository-wide ownership rule in `.github/CODEOWNERS`.

## Why

Ensure `@lucky-zzz` is automatically requested for review on pull requests covered by the global CODEOWNERS rule.

## Impact

This changes review assignment metadata only; runtime behavior is unaffected.

## Validation

- `git diff --check`
- Confirmed the PR contains only the `.github/CODEOWNERS` update