### PR TITLE
[manager] keep spec group strings alive in test

### DIFF
--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -4078,6 +4078,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkChecksSpecGroupOnTarget) 
 
     {
         CacheManager::KeyVector new_keys;
+        const std::vector<std::string> location_spec_group_names = {"F0"};
         std::vector<std::string_view> new_sgn;
         BlockMask block_mask;
         std::vector<std::string> new_targets;
@@ -4086,7 +4087,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkChecksSpecGroupOnTarget) 
                                                    meta_searcher,
                                                    {1},
                                                    new_keys,
-                                                   {"F0"},
+                                                   location_spec_group_names,
                                                    new_sgn,
                                                    block_mask,
                                                    1,
@@ -4098,6 +4099,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkChecksSpecGroupOnTarget) 
 
     {
         CacheManager::KeyVector new_keys;
+        const std::vector<std::string> location_spec_group_names = {"L1"};
         std::vector<std::string_view> new_sgn;
         BlockMask block_mask;
         std::vector<std::string> new_targets;
@@ -4106,7 +4108,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkChecksSpecGroupOnTarget) 
                                                    meta_searcher,
                                                    {1},
                                                    new_keys,
-                                                   {"L1"},
+                                                   location_spec_group_names,
                                                    new_sgn,
                                                    block_mask,
                                                    1,


### PR DESCRIPTION
## What changed

- Keep `location_spec_group_names` storage alive for the duration of `TestFilterWriteCacheTieredMarkChecksSpecGroupOnTarget`.
- Avoid constructing temporary `std::vector<std::string>` values whose elements are exposed through `std::string_view`.

## Root cause

`FilterWriteCache` returns `new_location_spec_group_names` as `std::string_view`s into the input `location_spec_group_names`. The test passed `{"L1"}` / `{"F0"}` as temporary vectors and read the returned views after those temporaries were destroyed, causing an ASAN heap-use-after-free. The `{1}` key argument is copied into `new_keys` and is not the dangling storage.

## Impact

This fixes the ASAN failure in `//kv_cache_manager/manager/test:CacheManagerTest` without changing production behavior.

## Validation

- Filtered ASAN test: 10/10 repeated runs passed.
- Full `//kv_cache_manager/manager/test:CacheManagerTest` ASAN target: 10/10 shards passed.

Command:

```bash
bazelisk test --config=debug --config=asan --test_env ASAN_OPTIONS=detect_odr_violation=0 //kv_cache_manager/manager/test:CacheManagerTest --test_output=errors
```