### PR TITLE
[metrics] default metrics reporter to local

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,8 +111,8 @@ kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
 kvcm.cache_reclaimer.pending_delete_handler_limit=1024
 kvcm.cache_reclaimer.pending_bytes_limit=274877906944
 
-# 可选值有dummy，local，logging，kmonitor；若不配置，默认启用logging
-kvcm.metrics.reporter_type
+# 可选值有dummy，local，logging，kmonitor；若不配置或配置为空，默认使用local
+kvcm.metrics.reporter_type=local
 
 # 传递给metrics reporter的配置值
 kvcm.metrics.reporter_config

--- a/kv_cache_manager/config/instance_info.cc
+++ b/kv_cache_manager/config/instance_info.cc
@@ -29,12 +29,7 @@ void InstanceInfo::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &wri
     Put(writer, "query_type", query_type_);
 }
 
-std::string InstanceInfo::ToString() const {
-    rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-    ToRapidWriter(writer);
-    return buffer.GetString();
-}
+std::string InstanceInfo::ToString() const { return Jsonizable::ToJsonString(); }
 
 void InstanceInfo::SortLocationSpecGroups() {
     // to use binary search

--- a/kv_cache_manager/config/test/instance_info_test.cc
+++ b/kv_cache_manager/config/test/instance_info_test.cc
@@ -138,6 +138,21 @@ TEST_F(InstanceInfoTest, TestQueryTypeSerializeAndMismatch) {
     EXPECT_EQ(kQueryType, parsed.query_type());
 }
 
+TEST_F(InstanceInfoTest, TestToStringProducesJsonObject) {
+    InstanceInfo instance_info("quota_group", "instance_group", "instance_id", 64, {}, {}, {}, 4);
+
+    const auto json = instance_info.ToString();
+    EXPECT_EQ(instance_info.ToJsonString(), json);
+
+    InstanceInfo parsed;
+    ASSERT_TRUE(parsed.FromJsonString(json));
+    EXPECT_EQ("quota_group", parsed.quota_group_name());
+    EXPECT_EQ("instance_group", parsed.instance_group_name());
+    EXPECT_EQ("instance_id", parsed.instance_id());
+    EXPECT_EQ(64, parsed.block_size());
+    EXPECT_EQ(4, parsed.query_type());
+}
+
 TEST_F(InstanceInfoTest, TestQueryTypeDefaultsToUnspecifiedForOldJson) {
     InstanceInfo instance_info("quota_group", "instance_group", "instance_id", 64, {}, {}, {}, 4);
     std::string json = instance_info.ToJsonString();

--- a/kv_cache_manager/metrics/metrics_reporter_factory.cc
+++ b/kv_cache_manager/metrics/metrics_reporter_factory.cc
@@ -12,6 +12,40 @@
 
 namespace kv_cache_manager {
 
+namespace {
+
+enum class MetricsReporterType {
+    kDummy,
+    kLocal,
+    kLogging,
+    kKmonitor,
+    kUnsupported,
+};
+
+MetricsReporterType ParseMetricsReporterType(const std::string &type) {
+    if (type.empty() || type == "local") {
+        return MetricsReporterType::kLocal;
+    }
+    if (type == "logging") {
+        return MetricsReporterType::kLogging;
+    }
+    if (type == "dummy") {
+        return MetricsReporterType::kDummy;
+    }
+    if (type == "kmonitor") {
+        return MetricsReporterType::kKmonitor;
+    }
+    return MetricsReporterType::kUnsupported;
+}
+
+} // namespace
+
+bool MetricsReporterFactory::IsSupportedType(const std::string &type) {
+    return ParseMetricsReporterType(type) != MetricsReporterType::kUnsupported;
+}
+
+const char *MetricsReporterFactory::SupportedTypes() { return "dummy, local, logging, kmonitor"; }
+
 bool MetricsReporterFactory::Init(std::shared_ptr<CacheManager> cache_manager,
                                   std::shared_ptr<MetricsRegistry> metrics_registry) {
     cache_manager_ = std::move(cache_manager);
@@ -21,28 +55,31 @@ bool MetricsReporterFactory::Init(std::shared_ptr<CacheManager> cache_manager,
 
 std::shared_ptr<MetricsReporter> MetricsReporterFactory::Create(const std::string &type,
                                                                 const std::string &config) const {
-    KVCM_LOG_INFO("creating metrics reporter with type: %s", type.c_str());
-    if (type == "kmonitor") {
+    const auto reporter_type = ParseMetricsReporterType(type);
+    if (reporter_type == MetricsReporterType::kUnsupported) {
+        KVCM_LOG_ERROR("unsupported metrics reporter type [%s], supported types: %s", type.c_str(), SupportedTypes());
+        return nullptr;
+    }
+
+    KVCM_LOG_INFO("creating metrics reporter with type: %s", type.empty() ? "local (default)" : type.c_str());
+    if (reporter_type == MetricsReporterType::kKmonitor) {
         auto reporter = std::make_shared<KmonitorMetricsReporter>();
         reporter->Init(cache_manager_, metrics_registry_, config);
         return reporter;
-    } else if (type == "local") {
+    } else if (reporter_type == MetricsReporterType::kLocal) {
         auto reporter = std::make_shared<LocalMetricsReporter>();
         reporter->Init(cache_manager_, metrics_registry_, config);
         return reporter;
-    } else if (type == "logging") {
+    } else if (reporter_type == MetricsReporterType::kLogging) {
         auto reporter = std::make_shared<LoggingMetricsReporter>();
         reporter->Init(cache_manager_, metrics_registry_, config);
         return reporter;
-    } else if (type == "dummy") {
+    } else if (reporter_type == MetricsReporterType::kDummy) {
         auto reporter = std::make_shared<DummyMetricsReporter>();
         reporter->Init(cache_manager_, metrics_registry_, config);
         return reporter;
     }
-    KVCM_LOG_INFO("metrics reporter type [%s] invalid, use logging reporter.", type.c_str());
-    auto reporter = std::make_shared<LoggingMetricsReporter>();
-    reporter->Init(cache_manager_, metrics_registry_, config);
-    return reporter;
+    return nullptr;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/metrics_reporter_factory.h
+++ b/kv_cache_manager/metrics/metrics_reporter_factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 namespace kv_cache_manager {
 
@@ -10,6 +11,10 @@ class MetricsReporter;
 
 class MetricsReporterFactory {
 public:
+    // Empty type is valid and resolves to the default local reporter.
+    static bool IsSupportedType(const std::string &type);
+    static const char *SupportedTypes();
+
     bool Init(std::shared_ptr<CacheManager> cache_manager, std::shared_ptr<MetricsRegistry> metrics_registry);
     [[nodiscard]] std::shared_ptr<MetricsReporter> Create(const std::string &type, const std::string &config) const;
 

--- a/kv_cache_manager/metrics/test/metrics_reporter_factory_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_reporter_factory_test.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <typeinfo>
 
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/metrics/dummy_metrics_reporter.h"
@@ -41,9 +42,8 @@ TEST_F(MetricsReporterFactoryTest, TestCreateKmonitorReporter) {
 
 TEST_F(MetricsReporterFactoryTest, TestCreateLocalReporter) {
     auto reporter = factory_->Create("local", "");
-    EXPECT_NE(reporter, nullptr);
-    auto cached_reporter = std::dynamic_pointer_cast<LocalMetricsReporter>(reporter);
-    EXPECT_NE(cached_reporter, nullptr);
+    ASSERT_NE(reporter, nullptr);
+    EXPECT_TRUE(typeid(*reporter) == typeid(LocalMetricsReporter));
 }
 
 TEST_F(MetricsReporterFactoryTest, TestCreateLoggingReporter) {
@@ -54,9 +54,11 @@ TEST_F(MetricsReporterFactoryTest, TestCreateLoggingReporter) {
 }
 
 TEST_F(MetricsReporterFactoryTest, TestCreateDefaultReporter) {
-    auto reporter = factory_->Create("unknown", "");
-    EXPECT_NE(reporter, nullptr);
+    auto reporter = factory_->Create("", "");
+    ASSERT_NE(reporter, nullptr);
+    EXPECT_TRUE(typeid(*reporter) == typeid(LocalMetricsReporter));
+}
 
-    auto default_reporter = std::dynamic_pointer_cast<LoggingMetricsReporter>(reporter);
-    EXPECT_NE(default_reporter, nullptr);
+TEST_F(MetricsReporterFactoryTest, TestCreateUnsupportedReporter) {
+    EXPECT_EQ(nullptr, factory_->Create("unknown", ""));
 }

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -8,6 +8,7 @@
 
 #include "kv_cache_manager/common/env_util.h"
 #include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/metrics/metrics_reporter_factory.h"
 
 namespace kv_cache_manager {
 
@@ -232,6 +233,7 @@ bool ServerConfig::Parse(const std::string &config_file, const EnvironMap &envir
 }
 
 void ServerConfig::UpdateDefaultConfig() {
+    metrics_reporter_type_ = "local";
     metrics_report_interval_ms_ = 20000;
     leader_elector_lease_ms_ = 10000;
     leader_elector_loop_interval_ms_ = 100;
@@ -348,6 +350,14 @@ void ServerConfig::UpdateEnviron(EnvironMap &environ) {
 bool ServerConfig::Check() {
     // registry_storage_uri is optional: when empty, RegistryStorageBackendFactory
     // falls back to local backend. No validation needed for empty value.
+
+    if (!MetricsReporterFactory::IsSupportedType(metrics_reporter_type_)) {
+        fprintf(stderr,
+                "Unsupported kvcm.metrics.reporter_type [%s], supported types: %s\n",
+                metrics_reporter_type_.c_str(),
+                MetricsReporterFactory::SupportedTypes());
+        return false;
+    }
 
     // Validate revisit_interval_buckets if set
     if (!revisit_interval_buckets_.empty()) {

--- a/kv_cache_manager/service/server_config.h
+++ b/kv_cache_manager/service/server_config.h
@@ -101,7 +101,7 @@ private:
     uint64_t cache_reclaimer_pending_bytes_limit_per_group_type_ = 0;
     uint64_t cache_reclaimer_pending_delete_handler_limit_ = 0;
     uint64_t cache_reclaimer_pending_bytes_limit_ = 0;
-    std::string metrics_reporter_type_;
+    std::string metrics_reporter_type_ = "local";
     std::string metrics_reporter_config_;
     int64_t metrics_report_interval_ms_ = 0;
     bool enable_prometheus_ = true;

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -84,6 +84,41 @@ TEST_F(ServerConfigTest, TestSimple) {
     }
 }
 
+TEST_F(ServerConfigTest, TestMetricsReporterType) {
+    {
+        ServerConfig config;
+        EXPECT_EQ("local", config.metrics_reporter_type());
+    }
+    {
+        ServerConfig config;
+        std::unordered_map<std::string, std::string> environ;
+        ASSERT_TRUE(config.Parse("", environ));
+        EXPECT_TRUE(config.Check());
+        EXPECT_EQ("local", config.metrics_reporter_type());
+    }
+    for (const auto &type : {"", "local", "logging"}) {
+        ServerConfig config;
+        std::unordered_map<std::string, std::string> environ{{"kvcm.metrics.reporter_type", type}};
+        ASSERT_TRUE(config.Parse("", environ));
+        EXPECT_TRUE(config.Check()) << "type: " << type;
+        EXPECT_EQ(type, config.metrics_reporter_type());
+    }
+    {
+        ServerConfig config;
+        std::unordered_map<std::string, std::string> environ{{"kvcm.metrics.reporter_type", "logging"}};
+        ASSERT_TRUE(config.Parse("", environ));
+        EXPECT_EQ("logging", config.metrics_reporter_type());
+        ASSERT_TRUE(config.Parse("", {}));
+        EXPECT_EQ("local", config.metrics_reporter_type());
+    }
+    {
+        ServerConfig config;
+        std::unordered_map<std::string, std::string> environ{{"kvcm.metrics.reporter_type", "unknown"}};
+        ASSERT_TRUE(config.Parse("", environ));
+        EXPECT_FALSE(config.Check());
+    }
+}
+
 TEST_F(ServerConfigTest, TestSchedulePlanMigrationWorkerBudget) {
     {
         ServerConfig config;

--- a/package/etc/default_server_config.conf
+++ b/package/etc/default_server_config.conf
@@ -53,7 +53,7 @@ kvcm.service.io_thread_num=0
 # - local: 本地采集指标到MetricsRegistry，支持Prometheus暴露，无per-query日志开销
 # - logging: 在local基础上，每次请求全量dump指标到日志（高QPS下有性能开销）
 # - kmonitor: 接入KMonitor监控平台
-# 不配置时默认使用logging
+# 不配置或配置为空时默认使用local
 kvcm.metrics.reporter_type=local
 
 # 传递给Metrics Reporter的配置值


### PR DESCRIPTION
## Summary

- Make `local` the consistent Metrics Reporter default across package configuration, documentation, `ServerConfig`, and the factory.
- Preserve explicit `dummy`, `local`, `logging`, and `kmonitor` behavior; reject unsupported non-empty types before server resource initialization.
- Fix `InstanceInfo::ToString()` JSON object serialization, uncovered by the full ASAN suite, with a regression test.

## Validation

- Applicable ASAN unit-test targets: 206/206 passed.
- End-to-end scenarios: 29/29 passed, including default local, explicit logging, and unsupported-type startup rejection.
- `git diff --check` and `clang-format --dry-run --Werror` passed.