### PR TITLE
[config] rename instance query_type to default_query_type

### DIFF
--- a/docs/BREAK_CHANGE.md
+++ b/docs/BREAK_CHANGE.md
@@ -20,7 +20,7 @@ PR #249 将 Vineyard 专用事件上报泛化为 `EventReportBackend`，并区�
 
 - Storage 的规范类型从 `vineyard` 改为 `event_report_l1p5` 或 `event_report_l2`，storage spec 也从 Vineyard 命名切换为 EventReport 命名。
 - Instance Group 的候选字段从 `event_reporting_storage_candidates` 改为 `event_report_storage_candidates`。
-- Instance/Client 配置新增 `query_type`，用于 GetHostCacheState 请求未指定 QueryType 时的默认查询方式。
+- Instance/Client 配置的实例级默认字段最终统一为 `default_query_type`，用于 GetHostCacheState 请求未指定 QueryType 时的默认查询方式。PR #249 初版使用的 `query_type` 已在后续 review 中纠偏，详见下方不兼容变更。
 
 #### CacheLocation 元数据
 
@@ -51,3 +51,22 @@ PR #249 将 Vineyard 专用事件上报泛化为 `EventReportBackend`，并区�
 ### 回滚说明
 
 回滚到旧 Vineyard 版本同样需要停写并清理 PR #249 生成的 `kvs#event_report_l1p5#...`/`kvs#event_report_l2#...` location，恢复旧 storage/Instance Group 配置，再由旧 reporter 重建元数据。禁止在保留新 EventReport 状态的情况下直接替换为旧二进制。
+
+## Instance 默认查询类型重命名
+
+Introduced by: PR #249 review follow-up
+
+PR #249 review 进一步确认，Instance 注册信息中的 `query_type` 表示请求未显式指定查询类型时使用的 instance 级默认值，而不是某次请求实际采用的查询类型。因此，该字段在 InstanceInfo、注册协议、Registry JSON 和 Client 配置中统一重命名为 `default_query_type`。
+
+### 不兼容内容
+
+- Meta/Admin protobuf 的 `InstanceInfo.query_type` 与 `RegisterInstanceRequest.query_type` 重命名为 `default_query_type`。字段类型和编号 `8` 保持不变，因此 protobuf 二进制 wire 数据兼容，但生成代码的 getter/setter 与源码 API 不兼容，调用方必须重新生成并编译。
+- HTTP/protobuf JSON、Registry 持久化 JSON 和 Client JSON 配置仅接受、序列化 `default_query_type`，不兼容读取旧 `query_type` key。旧配置中的值会回落为 `QT_UNSPECIFIED`。
+- 请求级 `GetHostCacheStateRequest.query_type` 及其他查询、事件和 trace 中的 `query_type` 不变。显式的请求级 `query_type` 始终优先；只有请求值为 `QT_UNSPECIFIED` 时才使用 `InstanceInfo.default_query_type`。
+
+### 升级要求
+
+1. 将 Registry 快照、Client 配置和 RegisterInstance HTTP JSON 中的实例级 `query_type` 改为 `default_query_type`。
+2. 使用新 proto 重新生成并编译所有 Meta/Admin gRPC 与 SDK 调用方，将实例注册和 InstanceInfo accessor 切换为新名称。
+3. 在同一升级窗口更新 KVCM 与注册调用方。混合版本虽然可传输字段号 `8` 的 protobuf 二进制数据，但 Registry/HTTP JSON 与生成源码 API 不构成受支持的混合版本契约。
+4. 升级后检查 GetInstanceInfo/Registry 回显中的 `default_query_type`；未配置时应为 `QT_UNSPECIFIED`，显式请求级 `query_type` 的行为不变。

--- a/docs/api/admin_service.md
+++ b/docs/api/admin_service.md
@@ -357,13 +357,13 @@ curl -g -vvv -X POST http://localhost:6492/api/registerInstance \
         "user_data": "user_data"
     },
     "block_size": 128,
-    "query_type": "QT_PREFIX_MATCH",
+    "default_query_type": "QT_PREFIX_MATCH",
     "location_spec_infos": [
         {"name": "tp0", "size": 1024}
     ]
 }'
 ```
-`query_type` is optional. When `GetHostCacheState` does not set `query_type`, the service uses this registered value.
+`default_query_type` is optional. When `GetHostCacheState` does not set request-level `query_type`, the service uses this registered value.
 
 ## Remove Instance
 ```bash

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -21,13 +21,13 @@ curl -g -vvv -X POST http://localhost:6382/api/registerInstance \
         "user_data": "custom_user_data"
     },
     "block_size": 8,
-    "query_type": "QT_PREFIX_MATCH",
+    "default_query_type": "QT_PREFIX_MATCH",
     "location_spec_infos": [
         {"name": "tp0", "size": 4096000}
     ]
 }'
 ```
-`query_type` is optional. When `GetHostCacheState` does not set `query_type`, the service uses this registered value.
+`default_query_type` is optional. When `GetHostCacheState` does not set request-level `query_type`, the service uses this registered value.
 
 ## Get Instance Info
 ```bash

--- a/integration_test/meta_service/meta_interface_cases.py
+++ b/integration_test/meta_service/meta_interface_cases.py
@@ -276,6 +276,7 @@ class MetaServiceTestBase(abc.ABC, TestBase, unittest.TestCase):
             "instance_group": "default",
             "instance_id": self._instance_id,
             "block_size": 128,
+            "default_query_type": "QT_PREFIX_MATCH_WITH_MAMBA",
             "model_deployment": self._get_test_model_deployment(),
             "location_spec_infos": [
                 {"name": "tp0", "size": 1024},
@@ -297,6 +298,8 @@ class MetaServiceTestBase(abc.ABC, TestBase, unittest.TestCase):
         self.assertIn('instance_group', response_data)
         self.assertIn('instance_info', response_data)
         self.assertEqual(response_data['instance_group'], "default")
+        self.assertEqual(response_data['instance_info']['default_query_type'],
+                         "QT_PREFIX_MATCH_WITH_MAMBA")
 
         # Verify model deployment data matches what we registered
         expected_deployment = self._get_test_model_deployment()

--- a/integration_test/meta_service/test_report_event.py
+++ b/integration_test/meta_service/test_report_event.py
@@ -906,7 +906,7 @@ class EventReportFunctionalTest(unittest.TestCase):
             "instance_group": self.INSTANCE_GROUP_NAME,
             "instance_id": instance_id,
             "block_size": 128,
-            "query_type": "QT_PREFIX_MATCH",
+            "default_query_type": "QT_PREFIX_MATCH",
             "model_deployment": {
                 "model_name": "test_er_model",
                 "dtype": "FP8",

--- a/kv_cache_manager/client/src/internal/config/client_config.cc
+++ b/kv_cache_manager/client/src/internal/config/client_config.cc
@@ -14,7 +14,7 @@ bool ClientConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
     KVCM_JSON_GET_MACRO(rapid_value, "sdk_config", sdk_wrapper_config_);
     KVCM_JSON_GET_MACRO(rapid_value, "model_deployment", model_deployment_);
     KVCM_JSON_GET_MACRO(rapid_value, "location_spec_groups", location_spec_groups_);
-    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "query_type", query_type_, static_cast<int32_t>(0));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "default_query_type", default_query_type_, static_cast<int32_t>(0));
     return Check();
 }
 void ClientConfig::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
@@ -27,7 +27,7 @@ void ClientConfig::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &wri
     Put(writer, "sdk_config", sdk_wrapper_config_);
     Put(writer, "model_deployment", model_deployment_);
     Put(writer, "location_spec_groups", location_spec_groups_);
-    Put(writer, "query_type", query_type_);
+    Put(writer, "default_query_type", default_query_type_);
 }
 
 bool ClientConfig::operator==(const ClientConfig &other) const {
@@ -42,7 +42,7 @@ bool ClientConfig::operator==(const ClientConfig &other) const {
     return block_size_ == other.block_size_ && instance_group_ == other.instance_group_ &&
            instance_id_ == other.instance_id_ && location_spec_infos_ == other.location_spec_infos_ &&
            addresses_ == other.addresses_ && sdk_configs_equal && model_deployment_ == other.model_deployment_ &&
-           location_spec_groups_ == other.location_spec_groups_ && query_type_ == other.query_type_;
+           location_spec_groups_ == other.location_spec_groups_ && default_query_type_ == other.default_query_type_;
 }
 
 bool ClientConfig::Check() const {
@@ -74,9 +74,9 @@ bool ClientConfig::Check() const {
             }
         }
     }
-    if (query_type_ < static_cast<int32_t>(QueryType::QT_UNSPECIFIED) ||
-        query_type_ > static_cast<int32_t>(QueryType::QT_PREFIX_MATCH_WITH_MAMBA)) {
-        KVCM_LOG_ERROR("query_type [%d] is invalid", query_type_);
+    if (default_query_type_ < static_cast<int32_t>(QueryType::QT_UNSPECIFIED) ||
+        default_query_type_ > static_cast<int32_t>(QueryType::QT_PREFIX_MATCH_WITH_MAMBA)) {
+        KVCM_LOG_ERROR("default_query_type [%d] is invalid", default_query_type_);
         return false;
     }
     return true;

--- a/kv_cache_manager/client/src/internal/config/client_config.h
+++ b/kv_cache_manager/client/src/internal/config/client_config.h
@@ -29,7 +29,7 @@ public:
     std::shared_ptr<SdkWrapperConfig> sdk_wrapper_config() const { return sdk_wrapper_config_; }
     const ModelDeployment &model_deployment() const { return model_deployment_; }
     const LocationSpecGroups &location_spec_groups() const { return location_spec_groups_; }
-    QueryType query_type() const { return static_cast<QueryType>(query_type_); }
+    QueryType default_query_type() const { return static_cast<QueryType>(default_query_type_); }
 
 private:
     bool Check() const;
@@ -44,7 +44,7 @@ private:
     std::shared_ptr<SdkWrapperConfig> sdk_wrapper_config_;
     ModelDeployment model_deployment_;
     LocationSpecGroups location_spec_groups_;
-    int32_t query_type_{0};
+    int32_t default_query_type_{0};
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/client/src/internal/config/test/client_config_test.cc
+++ b/kv_cache_manager/client/src/internal/config/test/client_config_test.cc
@@ -15,10 +15,24 @@ TEST_F(ClientConfigTest, TestClientConfigSuccess) {
     std::string file_content = getFileContent("client_config_success.json");
     ASSERT_FALSE(file_content.empty());
     ASSERT_TRUE(client_config.FromJsonString(file_content));
-    ASSERT_EQ(QueryType::QT_UNSPECIFIED, client_config.query_type());
+    ASSERT_EQ(QueryType::QT_UNSPECIFIED, client_config.default_query_type());
 }
 
-TEST_F(ClientConfigTest, TestClientConfigQueryType) {
+TEST_F(ClientConfigTest, TestClientConfigDefaultQueryType) {
+    ClientConfig client_config;
+    std::string file_content = getFileContent("client_config_success.json");
+    ASSERT_FALSE(file_content.empty());
+    const std::string location_spec_infos_field = R"(    "location_spec_infos": {)";
+    const auto pos = file_content.find(location_spec_infos_field);
+    ASSERT_NE(std::string::npos, pos);
+    file_content.insert(pos, R"(    "default_query_type": 4,
+)");
+    ASSERT_TRUE(client_config.FromJsonString(file_content));
+    ASSERT_EQ(QueryType::QT_PREFIX_MATCH_WITH_MAMBA, client_config.default_query_type());
+    ASSERT_NE(std::string::npos, client_config.ToJsonString().find("\"default_query_type\":4"));
+}
+
+TEST_F(ClientConfigTest, TestClientConfigLegacyQueryTypeIsIgnored) {
     ClientConfig client_config;
     std::string file_content = getFileContent("client_config_success.json");
     ASSERT_FALSE(file_content.empty());
@@ -28,7 +42,8 @@ TEST_F(ClientConfigTest, TestClientConfigQueryType) {
     file_content.insert(pos, R"(    "query_type": 4,
 )");
     ASSERT_TRUE(client_config.FromJsonString(file_content));
-    ASSERT_EQ(QueryType::QT_PREFIX_MATCH_WITH_MAMBA, client_config.query_type());
+    ASSERT_EQ(QueryType::QT_UNSPECIFIED, client_config.default_query_type());
+    ASSERT_EQ(std::string::npos, client_config.ToJsonString().find("\"query_type\""));
 }
 
 TEST_F(ClientConfigTest, TestClientConfigTairMemPoolSuccess) {

--- a/kv_cache_manager/client/src/internal/stub/grpc_stub.cc
+++ b/kv_cache_manager/client/src/internal/stub/grpc_stub.cc
@@ -251,13 +251,13 @@ std::pair<ClientErrorCode, std::string> GrpcStub::RegisterInstance(const std::st
                                                                    const LocationSpecInfoMap &location_spec_infos,
                                                                    const ModelDeployment &model_deployment,
                                                                    const LocationSpecGroups &location_spec_groups,
-                                                                   QueryType query_type) {
+                                                                   QueryType default_query_type) {
     auto stub = GET_AND_CHECK_STUB_WITH_TYPE();
     proto::meta::RegisterInstanceRequest request;
     SetCommonInfo(request, trace_id, instance_id);
     request.set_instance_group(instance_group);
     request.set_block_size(block_size);
-    request.set_query_type(static_cast<proto::meta::QueryType>(query_type));
+    request.set_default_query_type(static_cast<proto::meta::QueryType>(default_query_type));
     std::vector<LocationSpecInfo> info_vec;
     info_vec.reserve(location_spec_infos.size());
     std::for_each(location_spec_infos.begin(), location_spec_infos.end(), [&info_vec](const auto &info_pair) {

--- a/kv_cache_manager/client/src/internal/stub/grpc_stub.h
+++ b/kv_cache_manager/client/src/internal/stub/grpc_stub.h
@@ -23,7 +23,8 @@ public:
                                                              const LocationSpecInfoMap &location_spec_infos,
                                                              const ModelDeployment &model_deployment,
                                                              const LocationSpecGroups &location_spec_groups,
-                                                             QueryType query_type = QueryType::QT_UNSPECIFIED) override;
+                                                             QueryType default_query_type =
+                                                                 QueryType::QT_UNSPECIFIED) override;
 
     std::pair<ClientErrorCode, InstanceInfo> GetInstanceInfo(const std::string &trace_id,
                                                              const std::string &instance_id) override;

--- a/kv_cache_manager/client/src/internal/stub/stub.h
+++ b/kv_cache_manager/client/src/internal/stub/stub.h
@@ -28,7 +28,7 @@ public:
                      const LocationSpecInfoMap &location_spec_infos,
                      const ModelDeployment &model_deployment,
                      const LocationSpecGroups &location_spec_groups,
-                     QueryType query_type = QueryType::QT_UNSPECIFIED) = 0;
+                     QueryType default_query_type = QueryType::QT_UNSPECIFIED) = 0;
     virtual std::pair<ClientErrorCode, InstanceInfo> GetInstanceInfo(const std::string &trace_id,
                                                                      const std::string &instance_id) = 0;
 

--- a/kv_cache_manager/client/src/internal/stub/test/grpc_stub_test.cc
+++ b/kv_cache_manager/client/src/internal/stub/test/grpc_stub_test.cc
@@ -298,7 +298,7 @@ TEST_F(GrpcStubTest, TestRegisterInstance) {
 
     auto [ec, instance_info] = stub_->GetInstanceInfo("trace4", "instance3");
     ASSERT_EQ(ER_OK, ec);
-    ASSERT_EQ(static_cast<int32_t>(QueryType::QT_PREFIX_MATCH_WITH_MAMBA), instance_info.query_type());
+    ASSERT_EQ(static_cast<int32_t>(QueryType::QT_PREFIX_MATCH_WITH_MAMBA), instance_info.default_query_type());
 }
 
 TEST_F(GrpcStubTest, TestStartWriteCache) {

--- a/kv_cache_manager/client/src/meta_client_impl.cc
+++ b/kv_cache_manager/client/src/meta_client_impl.cc
@@ -235,7 +235,7 @@ ClientErrorCode MetaClientImpl::Connect(const std::string &address) {
                                                             client_config->location_spec_infos(),
                                                             client_config->model_deployment(),
                                                             client_config->location_spec_groups(),
-                                                            client_config->query_type());
+                                                            client_config->default_query_type());
     if (reg_ec == ER_OK) {
         storage_config_ = storage_config;
     }

--- a/kv_cache_manager/client/test/meta_client_test.cc
+++ b/kv_cache_manager/client/test/meta_client_test.cc
@@ -35,7 +35,8 @@ public:
             },
             "location_spec_groups": {
                 "group0": ["tp0"]
-            }
+            },
+            "default_query_type": 4
         })";
         init_params_.role_type = RoleType::HYBRID;
     }
@@ -70,7 +71,7 @@ public:
                  const LocationSpecInfoMap &location_spec_infos,
                  const ModelDeployment &model_deployment,
                  const LocationSpecGroups &location_spec_groups,
-                 QueryType query_type),
+                 QueryType default_query_type),
                 (override));
 
     MOCK_METHOD((std::pair<ClientErrorCode, InstanceInfo>),
@@ -161,7 +162,7 @@ TEST_F(MetaClientTest, TestCreateSimple) {
                                  ::testing::_,
                                  ::testing::_,
                                  ::testing::_,
-                                 ::testing::_))
+                                 QueryType::QT_PREFIX_MATCH_WITH_MAMBA))
         .Times(1)
         .WillOnce(::testing::Return(std::make_pair(ER_OK, std::string("{fake_storage_config}"))));
     auto ec = client->Init(client_config_, init_params_);

--- a/kv_cache_manager/config/instance_info.cc
+++ b/kv_cache_manager/config/instance_info.cc
@@ -13,7 +13,7 @@ bool InstanceInfo::FromRapidValue(const rapidjson::Value &rapid_value) {
     KVCM_JSON_GET_MACRO(rapid_value, "model_deployment", model_deployment_);
     KVCM_JSON_GET_DEFAULT_MACRO(
         rapid_value, "location_spec_groups", location_spec_groups_, std::vector<LocationSpecGroup>());
-    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "query_type", query_type_, static_cast<int32_t>(0));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "default_query_type", default_query_type_, static_cast<int32_t>(0));
     SortLocationSpecGroups();
     return true;
 }
@@ -26,7 +26,7 @@ void InstanceInfo::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &wri
     Put(writer, "location_spec_infos", location_spec_infos_);
     Put(writer, "model_deployment", model_deployment_);
     Put(writer, "location_spec_groups", location_spec_groups_);
-    Put(writer, "query_type", query_type_);
+    Put(writer, "default_query_type", default_query_type_);
 }
 
 std::string InstanceInfo::ToString() const { return Jsonizable::ToJsonString(); }

--- a/kv_cache_manager/config/instance_info.h
+++ b/kv_cache_manager/config/instance_info.h
@@ -123,7 +123,7 @@ public:
                  const std::vector<LocationSpecInfo> &location_spec_infos,
                  const ModelDeployment &model_deployment,
                  const std::vector<LocationSpecGroup> &location_spec_groups = {},
-                 int32_t query_type = 0)
+                 int32_t default_query_type = 0)
         : quota_group_name_(quota_group_name)
         , instance_group_name_(instance_group_name)
         , instance_id_(instance_id)
@@ -131,7 +131,7 @@ public:
         , location_spec_infos_(location_spec_infos)
         , model_deployment_(model_deployment)
         , location_spec_groups_(location_spec_groups)
-        , query_type_(query_type) {
+        , default_query_type_(default_query_type) {
         SortLocationSpecGroups();
     };
     ~InstanceInfo() override;
@@ -148,7 +148,7 @@ public:
     const std::vector<LocationSpecInfo> &location_spec_infos() const { return location_spec_infos_; }
     const ModelDeployment &model_deployment() const { return model_deployment_; }
     const std::vector<LocationSpecGroup> &location_spec_groups() const { return location_spec_groups_; }
-    int32_t query_type() const { return query_type_; }
+    int32_t default_query_type() const { return default_query_type_; }
     void set_quota_group_name(const std::string &quota_group_name) { quota_group_name_ = quota_group_name; }
     void set_instance_group_name(const std::string &instance_group_name) { instance_group_name_ = instance_group_name; }
     void set_instance_id(const std::string &instance_id) { instance_id_ = instance_id; }
@@ -161,14 +161,14 @@ public:
         location_spec_groups_ = location_spec_groups;
         SortLocationSpecGroups();
     }
-    void set_query_type(int32_t query_type) { query_type_ = query_type; }
+    void set_default_query_type(int32_t default_query_type) { default_query_type_ = default_query_type; }
     // Returns field names that differ from the given values.
     // Returns empty vector if all fields match.
     [[nodiscard]] std::vector<std::string> MismatchFields(int32_t block_size,
                                                           const std::vector<LocationSpecInfo> &location_spec_infos,
                                                           const ModelDeployment &model_deployment,
                                                           const std::vector<LocationSpecGroup> &location_spec_groups,
-                                                          int32_t query_type = 0) const {
+                                                          int32_t default_query_type = 0) const {
         std::vector<std::string> mismatched;
         if (block_size_ != block_size) {
             mismatched.emplace_back("block_size");
@@ -186,8 +186,8 @@ public:
         if (location_spec_groups_ != sorted_location_spec_groups) {
             mismatched.emplace_back("location_spec_groups");
         }
-        if (query_type_ != query_type) {
-            mismatched.emplace_back("query_type");
+        if (default_query_type_ != default_query_type) {
+            mismatched.emplace_back("default_query_type");
         }
         return mismatched;
     }
@@ -203,7 +203,7 @@ private:
     std::vector<LocationSpecInfo> location_spec_infos_;
     ModelDeployment model_deployment_;
     std::vector<LocationSpecGroup> location_spec_groups_;
-    int32_t query_type_{0};
+    int32_t default_query_type_{0};
 };
 
 using InstanceInfoConstPtr = std::shared_ptr<const InstanceInfo>;

--- a/kv_cache_manager/config/registry_manager.cc
+++ b/kv_cache_manager/config/registry_manager.cc
@@ -276,7 +276,7 @@ ErrorCode RegistryManager::RegisterInstance(RequestContext *request_context,
                                             const std::vector<LocationSpecInfo> &location_spec_infos,
                                             const ModelDeployment &model_deployment,
                                             const std::vector<LocationSpecGroup> &location_spec_groups,
-                                            int32_t query_type) {
+                                            int32_t default_query_type) {
     const auto &trace_id = request_context->trace_id();
     std::unique_lock<std::shared_mutex> lock(mutex_);
     auto instance_group_iter = instance_group_configs_.find(instance_group);
@@ -290,7 +290,7 @@ ErrorCode RegistryManager::RegisterInstance(RequestContext *request_context,
     if (it != instance_infos_.end()) {
         const auto &existing = it->second;
         auto mismatched = existing->MismatchFields(
-            block_size, location_spec_infos, model_deployment, location_spec_groups, query_type);
+            block_size, location_spec_infos, model_deployment, location_spec_groups, default_query_type);
         if (!mismatched.empty()) {
             auto mismatched_str = StringUtil::Join(mismatched, ", ");
             request_context->error_tracer()->AddErrorMsg(
@@ -310,7 +310,7 @@ ErrorCode RegistryManager::RegisterInstance(RequestContext *request_context,
                                                         location_spec_infos,
                                                         model_deployment,
                                                         location_spec_groups,
-                                                        query_type);
+                                                        default_query_type);
     // save the instance info to storage backend in such a way that one key corresponds to one instance
     auto ec = LoadAndSave(instance_id, instance_id, instance_info.get());
     if (ec != EC_OK) {

--- a/kv_cache_manager/config/registry_manager.h
+++ b/kv_cache_manager/config/registry_manager.h
@@ -63,7 +63,7 @@ public:
                                const std::vector<LocationSpecInfo> &location_spec_infos,
                                const ModelDeployment &model_deployment,
                                const std::vector<LocationSpecGroup> &location_spec_groups = {},
-                               int32_t query_type = 0);
+                               int32_t default_query_type = 0);
 
     ErrorCode
     RemoveInstance(RequestContext *request_context, const std::string &instance_group, const std::string &instance_id);

--- a/kv_cache_manager/config/test/instance_info_test.cc
+++ b/kv_cache_manager/config/test/instance_info_test.cc
@@ -121,21 +121,21 @@ TEST_F(InstanceInfoTest, TestMismatchFieldsIgnoresLocationSpecGroupOrder) {
     EXPECT_EQ("location_spec_groups", mismatched[0]);
 }
 
-TEST_F(InstanceInfoTest, TestQueryTypeSerializeAndMismatch) {
+TEST_F(InstanceInfoTest, TestDefaultQueryTypeSerializeAndMismatch) {
     constexpr int32_t kBlockSize = 64;
     constexpr int32_t kQueryType = 4;
     InstanceInfo instance_info("quota_group", "instance_group", "instance_id", kBlockSize, {}, {}, {}, kQueryType);
 
-    EXPECT_EQ(kQueryType, instance_info.query_type());
+    EXPECT_EQ(kQueryType, instance_info.default_query_type());
     EXPECT_TRUE(instance_info.MismatchFields(kBlockSize, {}, {}, {}, kQueryType).empty());
 
     auto mismatched = instance_info.MismatchFields(kBlockSize, {}, {}, {}, 2);
     ASSERT_EQ(1, mismatched.size());
-    EXPECT_EQ("query_type", mismatched[0]);
+    EXPECT_EQ("default_query_type", mismatched[0]);
 
     InstanceInfo parsed;
     ASSERT_TRUE(parsed.FromJsonString(instance_info.ToJsonString()));
-    EXPECT_EQ(kQueryType, parsed.query_type());
+    EXPECT_EQ(kQueryType, parsed.default_query_type());
 }
 
 TEST_F(InstanceInfoTest, TestToStringProducesJsonObject) {
@@ -150,20 +150,34 @@ TEST_F(InstanceInfoTest, TestToStringProducesJsonObject) {
     EXPECT_EQ("instance_group", parsed.instance_group_name());
     EXPECT_EQ("instance_id", parsed.instance_id());
     EXPECT_EQ(64, parsed.block_size());
-    EXPECT_EQ(4, parsed.query_type());
+    EXPECT_EQ(4, parsed.default_query_type());
 }
 
-TEST_F(InstanceInfoTest, TestQueryTypeDefaultsToUnspecifiedForOldJson) {
+TEST_F(InstanceInfoTest, TestDefaultQueryTypeDefaultsToUnspecifiedWhenMissing) {
     InstanceInfo instance_info("quota_group", "instance_group", "instance_id", 64, {}, {}, {}, 4);
     std::string json = instance_info.ToJsonString();
-    const std::string query_type_field = ",\"query_type\":4";
-    const auto pos = json.find(query_type_field);
+    const std::string default_query_type_field = ",\"default_query_type\":4";
+    const auto pos = json.find(default_query_type_field);
     ASSERT_NE(std::string::npos, pos);
-    json.erase(pos, query_type_field.size());
+    json.erase(pos, default_query_type_field.size());
 
     InstanceInfo parsed;
     ASSERT_TRUE(parsed.FromJsonString(json));
-    EXPECT_EQ(0, parsed.query_type());
+    EXPECT_EQ(0, parsed.default_query_type());
+}
+
+TEST_F(InstanceInfoTest, TestLegacyQueryTypeJsonKeyIsIgnored) {
+    InstanceInfo instance_info("quota_group", "instance_group", "instance_id", 64, {}, {}, {}, 4);
+    std::string json = instance_info.ToJsonString();
+    const std::string default_query_type_key = "\"default_query_type\"";
+    const auto pos = json.find(default_query_type_key);
+    ASSERT_NE(std::string::npos, pos);
+    json.replace(pos, default_query_type_key.size(), "\"query_type\"");
+
+    InstanceInfo parsed;
+    ASSERT_TRUE(parsed.FromJsonString(json));
+    EXPECT_EQ(0, parsed.default_query_type());
+    EXPECT_EQ(std::string::npos, parsed.ToJsonString().find("\"query_type\""));
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -454,14 +454,17 @@ CacheManager::RegisterInstance(RequestContext *request_context,
                                const std::vector<LocationSpecInfo> &location_spec_infos,
                                const ModelDeployment &model_deployment,
                                const std::vector<LocationSpecGroup> &location_spec_groups,
-                               QueryType query_type) {
+                               QueryType default_query_type) {
     SPAN_TRACER(request_context);
     // TODO : not thread safe now
     const auto &trace_id = request_context->trace_id();
     auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);
     if (instance_info) {
-        auto mismatched = instance_info->MismatchFields(
-            block_size, location_spec_infos, model_deployment, location_spec_groups, static_cast<int32_t>(query_type));
+        auto mismatched = instance_info->MismatchFields(block_size,
+                                                        location_spec_infos,
+                                                        model_deployment,
+                                                        location_spec_groups,
+                                                        static_cast<int32_t>(default_query_type));
         if (!mismatched.empty()) {
             auto mismatched_str = StringUtil::Join(mismatched, ", ");
             request_context->error_tracer()->AddErrorMsg(
@@ -483,7 +486,7 @@ CacheManager::RegisterInstance(RequestContext *request_context,
                                                   location_spec_infos,
                                                   model_deployment,
                                                   location_spec_groups,
-                                                  static_cast<int32_t>(query_type));
+                                                  static_cast<int32_t>(default_query_type));
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, std::string, "register instance failed with errorcode: %d", ec);
     ec = TryCreateMetaSearcher(request_context, instance_id);
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, std::string, "register instance failed with errorcode: %d", ec);
@@ -2824,7 +2827,7 @@ ErrorCode CacheManager::DoRecoverOnce() {
                                                       instance_info->location_spec_infos(),
                                                       instance_info->model_deployment(),
                                                       instance_info->location_spec_groups(),
-                                                      static_cast<QueryType>(instance_info->query_type()));
+                                                      static_cast<QueryType>(instance_info->default_query_type()));
             if (ec3 != EC_OK) {
                 KVCM_LOG_WARN("CacheManager RegisterInstance failed when recover, skip. ec[%d] instance_group "
                               "name[%s] instance_id[%s]",
@@ -3081,7 +3084,7 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
             RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
                 WARN, EC_INSTANCE_NOT_EXIST, std::vector<HostCacheMatch>, "instance not found");
         }
-        query_type = static_cast<QueryType>(instance_info->query_type());
+        query_type = static_cast<QueryType>(instance_info->default_query_type());
         if (query_type == QueryType::QT_UNSPECIFIED) {
             RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, EC_ERROR, std::vector<HostCacheMatch>, "unknown query type");
         }

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -109,7 +109,7 @@ public:
                                                        const std::vector<LocationSpecInfo> &location_spec_infos,
                                                        const ModelDeployment &model_deployment,
                                                        const std::vector<LocationSpecGroup> &location_spec_groups,
-                                                       QueryType query_type = QueryType::QT_UNSPECIFIED);
+                                                       QueryType default_query_type = QueryType::QT_UNSPECIFIED);
 
     ErrorCode
     RemoveInstance(RequestContext *request_context, const std::string &instance_group, const std::string &instance_id);

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -2967,8 +2967,8 @@ TEST_F(CacheManagerTest, TestDoRecoverAfterCleanup) {
     ASSERT_EQ("test_instance", meta_searcher->meta_indexer_->instance_id_);
 }
 
-TEST_F(CacheManagerTest, TestDoRecoverPreservesRegisteredQueryType) {
-    registry_manager_->instance_infos_["test_instance"]->set_query_type(
+TEST_F(CacheManagerTest, TestDoRecoverPreservesRegisteredDefaultQueryType) {
+    registry_manager_->instance_infos_["test_instance"]->set_default_query_type(
         static_cast<int32_t>(CacheManager::QueryType::QT_PREFIX_MATCH));
 
     ASSERT_EQ(EC_OK, cache_manager_->DoCleanup());
@@ -4060,7 +4060,7 @@ TEST_F(CacheManagerTest, TestGetHostCacheState) {
         EXPECT_EQ(1, find_prefix(hosts, "10.0.0.3:8080"));
     }
 
-    // --- Test 1b: unspecified query type falls back to RegisterInstance.query_type ---
+    // --- Test 1b: unspecified query type falls back to RegisterInstance.default_query_type ---
     {
         CacheManager::KeyVector keys = {100, 200, 300, 400, 500};
         auto [ec, hosts] = cache_manager_->GetHostCacheState(
@@ -4303,6 +4303,15 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
         EXPECT_EQ(-1, find_prefix(matches, host_d));
     };
     expect_mamba_matches(hosts);
+
+    // An explicit request query type takes precedence over the registered default.
+    auto [explicit_ec, explicit_hosts] = cache_manager_->GetHostCacheState(
+        request_context_.get(), instance_id, CacheManager::QueryType::QT_PREFIX_MATCH, keys);
+    ASSERT_EQ(EC_OK, explicit_ec);
+    EXPECT_EQ(4, find_prefix(explicit_hosts, host_a));
+    EXPECT_EQ(4, find_prefix(explicit_hosts, host_b));
+    EXPECT_EQ(2, find_prefix(explicit_hosts, host_c));
+    EXPECT_EQ(-1, find_prefix(explicit_hosts, host_d));
 
     auto [fallback_ec, fallback_hosts] = cache_manager_->GetHostCacheState(
         request_context_.get(), instance_id, CacheManager::QueryType::QT_UNSPECIFIED, keys);

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -456,7 +456,7 @@ message InstanceInfo {
     repeated LocationSpecInfo location_spec_infos = 5; // 一个location内的所有spec，StartWriteCache时会按照这个进行分配
     ModelDeployment model_deployment = 6;
     repeated LocationSpecGroup location_spec_groups = 7; // 一个group包含多个spec name。用于简化StartWriteCache时指定可以提供哪些location spec。
-    QueryType query_type = 8;                            
+    QueryType default_query_type = 8; // 请求未显式指定 query_type 时使用的 instance 级默认值
 }
 
 message RegisterInstanceRequest {
@@ -467,7 +467,7 @@ message RegisterInstanceRequest {
     repeated LocationSpecInfo location_spec_infos = 5; // 一个location内的所有spec，StartWriteCache时会按照这个进行分配
     ModelDeployment model_deployment = 6;
     repeated LocationSpecGroup location_spec_groups = 7; // 一个group包含多个spec name。用于简化StartWriteCache时指定可以提供哪些location spec。
-    QueryType query_type = 8;                           
+    QueryType default_query_type = 8; // 请求未显式指定 query_type 时使用的 instance 级默认值
 }
 
 message RemoveInstanceRequest {

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -176,7 +176,7 @@ message InstanceInfo {
     repeated LocationSpecInfo location_spec_infos = 5; // 一个location内的所有spec，StartWriteCache时会按照这个进行分配
     ModelDeployment model_deployment = 6;
     repeated LocationSpecGroup location_spec_groups = 7; // 一个group包含多个spec name。用于简化StartWriteCache时指定可以提供哪些location spec。
-    QueryType query_type = 8;
+    QueryType default_query_type = 8; // 请求未显式指定 query_type 时使用的 instance 级默认值
 }
 
 message LocalStorageSpec {}
@@ -257,7 +257,7 @@ message RegisterInstanceRequest {
     repeated LocationSpecInfo location_spec_infos = 5; // 一个location内的所有spec，StartWriteCache时会按照这个进行分配
     ModelDeployment model_deployment = 6;
     repeated LocationSpecGroup location_spec_groups = 7; // 一个group包含多个spec name。用于简化StartWriteCache时指定可以提供哪些location spec。
-    QueryType query_type = 8;
+    QueryType default_query_type = 8; // 请求未显式指定 query_type 时使用的 instance 级默认值
 }
 
 message RegisterInstanceResponse {

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -636,7 +636,8 @@ void AdminServiceImpl::RegisterInstance(RequestContext *request_context,
                                                          location_spec_infos,
                                                          model_deployment_req,
                                                          location_spec_groups,
-                                                         static_cast<CacheManager::QueryType>(request->query_type()));
+                                                         static_cast<CacheManager::QueryType>(
+                                                             request->default_query_type()));
     if (ec_info != EC_OK) {
         status->set_code(ToAdminPbError(ec_info));
         request_context->set_status_code(status->code());

--- a/kv_cache_manager/service/meta_service_impl.cc
+++ b/kv_cache_manager/service/meta_service_impl.cc
@@ -329,7 +329,7 @@ void MetaServiceImpl::RegisterInstance(RequestContext *request_context,
                                          location_spec_infos,
                                          model_deployment_req,
                                          location_spec_groups,
-                                         static_cast<CacheManager::QueryType>(request->query_type()));
+                                         static_cast<CacheManager::QueryType>(request->default_query_type()));
 
     if (ec_info != EC_OK) {
         status->set_code(ToMetaPbError(ec_info));

--- a/kv_cache_manager/service/util/manager_message_proto_util.h
+++ b/kv_cache_manager/service/util/manager_message_proto_util.h
@@ -379,9 +379,11 @@ ProtoConvert::InstanceInfoToProto(const InstanceInfo &instance_info, T *proto_in
                               proto_instance_info->mutable_location_spec_groups());
 
     if constexpr (std::is_same_v<T, proto::meta::InstanceInfo>) {
-        proto_instance_info->set_query_type(static_cast<proto::meta::QueryType>(instance_info.query_type()));
+        proto_instance_info->set_default_query_type(
+            static_cast<proto::meta::QueryType>(instance_info.default_query_type()));
     } else {
-        proto_instance_info->set_query_type(static_cast<proto::admin::QueryType>(instance_info.query_type()));
+        proto_instance_info->set_default_query_type(
+            static_cast<proto::admin::QueryType>(instance_info.default_query_type()));
     }
 }
 
@@ -407,7 +409,7 @@ ProtoConvert::InstanceInfoFromProto(const T *proto_instance_info, InstanceInfo &
     LocationSpecGroupsFromProto(proto_instance_info->location_spec_groups(), location_spec_groups);
     instance_info.set_location_spec_groups(location_spec_groups);
 
-    instance_info.set_query_type(static_cast<int32_t>(proto_instance_info->query_type()));
+    instance_info.set_default_query_type(static_cast<int32_t>(proto_instance_info->default_query_type()));
 }
 
 template <typename T>


### PR DESCRIPTION
## Summary

- Rename the instance-level fallback query type from `query_type` to `default_query_type` across Meta/Admin protobuf APIs, C++ configuration and registration paths, Registry and client JSON, SDK plumbing, documentation, and tests.
- Preserve request-level `query_type` semantics: an explicit request value wins, while `QT_UNSPECIFIED` falls back to the instance default.
- Keep protobuf field number 8 for wire compatibility and document the intentional JSON/generated-API breaking change introduced as a follow-up to #249 review.

## Impact

Registry snapshots, HTTP JSON, and client configuration must use `default_query_type`; generated protobuf/SDK consumers must regenerate and recompile. Legacy JSON keys are intentionally not read.

## Validation

- 5/5 affected C++ targeted tests passed.
- Meta and Admin HTTP/gRPC integration targets passed (4/4).
- `//kv_cache_manager/...` regression passed: 102 passed, 1 skipped, 0 failed.
- `git diff --check` and instance-level old-name semantic audit passed.