### PR TITLE
[protocol] clarify EventReport storage usage

### DIFF
--- a/integration_test/meta_service/test_report_event.py
+++ b/integration_test/meta_service/test_report_event.py
@@ -11,7 +11,7 @@ Usage:
     #        --env kvcm.service.admin_http_port=56040 \
     #        --env kvcm.service.enable_debug_service=false
     # 2. Run this script:
-    python test_vineyard_report_event.py \
+    python3 integration_test/meta_service/test_report_event.py \
         --host localhost --http_port 56020 --admin_http_port 56040 \
         --instance_id event_report_cluster_0
 """

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -131,7 +131,8 @@ message StorageConfig {
         EventReportStorageSpec event_report = 14;
     }
     bool check_storage_available_when_open = 8;
-    // 仅供响应中使用，标识存储类型；请求时类型由 oneof 字段决定。
+    // 响应中用于标识存储类型；请求中通常由 oneof storage_spec 确定类型。
+    // 配置 EventReport storage 时必须显式指定 ST_EVENT_REPORT_L1P5 或 ST_EVENT_REPORT_L2。
     StorageType storage_type = 11;
 }
 


### PR DESCRIPTION
## Summary

- clarify that `StorageConfig.storage_type` identifies the type in responses and is required for EventReport storage configuration requests
- fix the `test_report_event.py` Usage example so it invokes the current script with its supported arguments

## Why

The comments and copy-paste example were left stale after EventReport support landed, which could mislead maintainers or run the wrong integration script.

## Impact

Documentation and executable examples now match the existing request parsing and runtime behavior. No protocol field numbers or runtime semantics change.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 integration_test/meta_service/test_report_event.py --help`
- verified the repository no longer references `test_vineyard_report_event.py` outside vendored/build content