### PR TITLE
[Review only] Allow ReportEvent deltas without initial snapshot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 - [Commit 要求](develop/commit_requirements.md) - 提交前检查和 commit message 格式约定
 - [构建版本信息](develop/version_stamping.md) - Version Stamping 机制原理与使用方式
 - [API 文档](api/) - API 接口说明和使用示例
+- [ReportEvent 与查询接口行为](api/report_event.md) - 面向调用方的事件上报、全量对账、查询、错误处理和测试覆盖清单
 
 ### 部署文档
 - [镜像文档](../open_source/docker/README.md) - Docker镜像构建和使用说明

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -105,20 +105,26 @@ curl -g -vvv -X POST http://localhost:6382/api/removeCache \
 
 ## Report Event
 
+完整的调用方接口契约、错误处理、查询可见性和自动化测试矩阵见
+[ReportEvent 与查询接口行为说明](report_event.md)。
+
 `reportEvent` is the cache-subscriber ingestion API. Subscribers use ordered
-incremental events for steady-state traffic and a complete snapshot to build or
+incremental events for steady-state traffic and may use a complete snapshot to
 repair the baseline:
 
-- RTP-LLM subscriber: poll full cache status, establish an initial snapshot,
-  then compute and send local deltas.
+- Realtime-only subscriber: REGISTER and send local deltas directly; no initial
+  snapshot is required.
+- RTP-LLM subscriber: poll full cache status when authoritative reconciliation
+  is needed, then continue sending local deltas.
 - vLLM subscriber: map KV events to ordered `EVENT_BLOCK_ADD`,
   `EVENT_BLOCK_DELETE`, and snapshots after restart, full-clear, or event gaps.
 
 `EVENT_BLOCK_SNAPSHOT` is authoritative for all GPU, CPU, and Disk cache owned
-by one reporter (`instance_id + host_ip_port`). `medium` is specified by each
-block. The request must contain the complete block set and every block's
-complete spec set; it cannot be paginated or mixed with ADD/DELETE in the same
-request. An empty snapshot clears all media owned by that reporter.
+by one reporter (`instance_id + storage_type + host_ip_port`). `medium` is
+specified by each block. The request must contain the complete block set and
+every block's complete spec set; it cannot be paginated or mixed with
+ADD/DELETE in the same request. An empty snapshot clears all media owned by
+that reporter.
 
 KVCM serializes a reporter's full snapshot and incremental mutations. A
 snapshot first closes the reporter's delta write gate, waits for already
@@ -130,14 +136,27 @@ remain independent. A second concurrent snapshot receives
 KVCM keeps the location id stable and appends only its reserved `s_version`
 parameter to each event-report URI. After all metadata writes and `Sync`
 succeed, KVCM publishes the in-memory committed token and returns it as
-`committed_snapshot_version`. Queries accept only URIs matching that token;
-the existing reclaimer asynchronously removes older metadata. KVCM does not
-restore tokens after restart, so each reporter must submit a new complete
-snapshot when `snapshot_required=true`.
+`committed_snapshot_version`. The token is a reconciliation and cleanup
+generation, not a query visibility fence. While a reporter is registered and
+available, queries accept well-formed legacy, old, current and in-flight
+generations. The existing reclaimer asynchronously removes older KVCM metadata
+after a successful snapshot and never sends a physical DELETE to the external
+reporter URI.
 
-Snapshots should be rare: initial baseline, KVCM restart, event gap or explicit
-repair, with an optional very-low-frequency fallback. The 30-second server-side
-minimum interval is a safety limit, not a recommended reporting period.
+After a KVCM restart, REGISTER makes well-formed historical cache metadata
+readable again. The first ADD/DELETE creates a new process-local generation and
+continues normally. `snapshot_required=true` with an empty committed version is
+an advisory, not a delta admission requirement; realtime-only reporters may
+ignore it. A snapshot-capable reporter may reconcile later.
+
+Event-report metadata is a soft cache index. Stale candidates and partial
+snapshot writes may be returned; a failed physical cache read must be treated
+as a normal cache miss. Reporter registration and liveness remain hard
+visibility gates, and malformed URI metadata is rejected.
+
+Snapshots should be rare: event gap, explicit repair, or an optional
+very-low-frequency fallback. The 30-second server-side minimum interval is a
+safety limit, not a recommended reporting period.
 Callers must not set `s_version`. `EVENT_HOST_DOWN` is terminal and must be sent
 as the only event in its request.
 

--- a/docs/api/report_event.md
+++ b/docs/api/report_event.md
@@ -1,0 +1,765 @@
+# ReportEvent 与查询接口行为说明
+
+本文面向推理引擎、Subscriber 和其他 KVCM 调用方，说明 `ReportEvent` 上报之后
+`GetCacheLocation`、`GetCacheLocationsByBackend` 和 `GetHostCacheState` 会看到什么。
+
+本文描述的是调用方可以依赖的接口行为。内部实现和设计取舍见
+[ReportEvent 增量上报与可选全量对账设计](../design/report_event_snapshot_uri_version.md)。
+
+## 1. 调用方先记住这 10 条
+
+1. `EVENT_NODE_REGISTER` 推荐在 reporter 启动时发送，但不是数据上报的硬前置；第一条合法
+   HEARTBEAT、ADD、DELETE 或 SNAPSHOT 可以懒初始化 reporter。
+2. 只支持实时事件的引擎可以一直使用 `ADD/DELETE`，永远不发 snapshot。
+3. 支持全量的引擎应把 snapshot 当作低频纠偏手段，不能分页，也不应高频发送。
+4. 一次 snapshot 是一个 reporter 在一个 storage type 下、跨全部 medium 的完整状态。
+5. 客户端不得在 URI 中填写 `s_version`；KVCM 会自动追加。
+6. `committed_snapshot_version` 是 32 位十六进制 opaque generation，不能按大小比较，也不是查询过滤条件。
+7. `snapshot_required=true` 是“当前 KVCM 进程还没有该 reporter generation”的提示，不会阻止合法增量。
+8. 当前进程尚未收到该 reporter 的任何合法事件，或节点 unavailable 时，查询不会返回该
+   节点的数据；节点存活状态是硬门槛。
+9. snapshot、进程重启和异步清理期间可能短暂返回 stale cache candidate。真实 cache 读取失败必须按 miss 处理。
+10. `ReportEvent` 不是整批事务。出现 `item_results` 时，应按事件下标逐项处理；成功项可能已经生效。
+
+## 2. Reporter 身份与数据粒度
+
+### 2.1 Reporter 身份
+
+一个独立 reporter 由以下三个字段确定：
+
+```text
+instance_id + storage_type + host_ip_port
+```
+
+因此：
+
+- 同一 host 的 `ST_EVENT_REPORT_L1P5` 和 `ST_EVENT_REPORT_L2` 是两个独立 reporter；
+- 同一 host 在两个 instance 中互不影响；
+- 同一 instance 的两个 host 互不影响；
+- snapshot 栅栏、generation、限流和节点生命周期都按上述身份隔离。
+
+`RegisterInstance` 与 `EVENT_NODE_REGISTER` 不是同一层注册：
+
+- `RegisterInstance` 持久化 instance 的静态配置，并在 KVCM 重启时恢复；
+- `EVENT_NODE_REGISTER` 只管理某个 reporter 的进程内 liveness/medium 状态，是可选的启动信号；
+- KVCM 重启不会要求客户端重新 `RegisterInstance`，也不会要求重新发送
+  `EVENT_NODE_REGISTER`；下一条合法 ReportEvent 会补齐运行时 reporter 状态。
+
+### 2.2 Block、medium 与 spec
+
+KVCM 更新的最小逻辑身份是：
+
+```text
+block_key + medium + spec.name
+```
+
+- `medium` 是 block 级属性，例如 `gpu`、`hbm`、`memory`、`disk`；
+- `spec.name` 区分一个 block 内的多个物理组成部分，例如不同 TP、full attention 或 mamba state；
+- 同一 `block_key` 可以同时存在于多个 medium；
+- 同一 `block_key + medium` 可以包含多个不同的 spec name；
+- 同一 `block_key + medium + spec.name` 是集合语义，不是引用计数。
+
+如果引擎内部有多个完全相同的物理 block，它们最终映射到相同
+`block_key + medium + spec.name`，KVCM 无法区分“有 1 份”还是“有 N 份”。调用方应在上报前
+去重；一次 DELETE 会删除这个逻辑 spec。
+
+如果同一个 block 有多个不同 spec，snapshot 时应把它们合并到同一个
+`BlockSnapshotItem.specs` 中，不能把同一 `block_key + medium` 拆成多个 snapshot item。
+
+## 3. 推荐调用时序
+
+### 3.1 纯实时模式
+
+适用于只有增量事件、没有全量能力的推理引擎：
+
+```text
+[可选 REGISTER] -> ADD / DELETE / HEARTBEAT
+                         |
+                         +--> 持续 ADD / DELETE / HEARTBEAT
+```
+
+第一条通过参数校验并获得 delta lease 的 ADD 或 DELETE 会创建当前进程的 generation。
+REGISTER、HEARTBEAT，以及在获得 lease 前就被拒绝的增量不会创建 generation。获得 lease 后
+如果 metadata 写入失败，generation 可能已经建立；它只是内部对账标签，不代表该事件已经写入。
+
+REGISTER 的作用是提前建立节点存活状态、声明 medium，并在同一 KVCM 进程中从 HOST_DOWN/
+grace cleanup 后显式重新启用 reporter。正常数据面不应因为 KVCM 重启而停下来等待再次 REGISTER。
+
+### 3.2 实时 + 低频全量模式
+
+```text
+[可选 REGISTER]
+   |
+   +--> 正常发送 ADD / DELETE / HEARTBEAT
+   |
+   +--> 发现事件断档、显式修复或低频校准
+            |
+            +--> 发送一个完整 SNAPSHOT
+            |
+            +--> 继续发送 ADD / DELETE
+```
+
+Snapshot 不是心跳，不应按秒周期发送。默认最小成功 snapshot 间隔为 30 秒，实际值由
+EventReport storage 的 `snapshot_min_interval_ms` 配置。
+
+### 3.3 进程启动时合并请求
+
+Fresh reporter 可以在一个请求中发送：
+
+```text
+REGISTER -> ADD/DELETE -> HEARTBEAT
+```
+
+也可以发送：
+
+```text
+REGISTER -> SNAPSHOT -> HEARTBEAT
+```
+
+也可以把 ADD/DELETE/SNAPSHOT 放在 REGISTER 前面，合法 mutation 会先懒初始化 reporter，
+后面的 REGISTER 再补充 medium 并刷新 liveness。为了让启动日志和节点观测更清晰，仍推荐
+启动阶段先单独 REGISTER，但正确性不依赖这个顺序。
+
+### 3.4 KVCM 重启
+
+Instance/InstanceGroup 和 cache metadata 会持久化；reporter 节点表、liveness 和 generation
+是进程内状态。KVCM 重启后的行为是：
+
+1. 收到该 reporter 的第一条合法事件前，Redis 中残留的历史 event-report metadata 不可见；
+2. 第一条 HEARTBEAT、ADD、DELETE 或 SNAPSHOT 会自动重建 reporter 节点状态，不要求再次 REGISTER；
+3. 如果第一条只是 HEARTBEAT，响应为 `snapshot_required=true`、
+   `committed_snapshot_version=""`，格式合法的历史 metadata 可以重新成为 cache candidate；
+4. 如果第一条是 ADD/DELETE，它正常成功并建立新 generation；
+5. 该增量只更新明确涉及的 spec，不删除其他历史 block/spec；
+6. snapshot-capable 调用方可以稍后补一次完整 snapshot；
+7. realtime-only 调用方可以继续只发增量。
+
+这保证 Subscriber 不需要感知 KVCM 重启，正常心跳或数据上报会自动恢复链路，但可能重新暴露
+少量历史 cache candidate。
+
+## 4. ReportEvent 公共字段
+
+HTTP 接口为 `POST /api/reportEvent`，gRPC 方法为 `ReportEvent`。
+
+```json
+{
+  "trace_id": "subscriber-20260727-001",
+  "instance_id": "model-a",
+  "host_ip_port": "10.0.0.8:8080",
+  "storage_type": "ST_EVENT_REPORT_L1P5",
+  "events": []
+}
+```
+
+字段要求：
+
+| 字段 | 要求 |
+| --- | --- |
+| `instance_id` | 必填，必须已经通过 `RegisterInstance` 创建 |
+| `host_ip_port` | 必填，必须稳定且与查询侧识别的 worker 地址一致；不能包含 location id 分隔符 `#` |
+| `storage_type` | 非空请求必填，只支持 `ST_EVENT_REPORT_L1P5`、`ST_EVENT_REPORT_L2` |
+| `events` | 有序事件列表；空列表是 no-op success |
+| `trace_id` | 建议每次请求唯一，便于排查 |
+
+每个 `EventItem.event_type` 必须与同一个 item 中实际出现的 `event_params` oneof 字段一致。
+即使 `node_register`、`heartbeat`、`host_down` 的消息内容为空，对应字段本身也必须出现。
+event type 与 payload 缺失或错配时，该 item 返回 `INVALID_ARGUMENT`，不会把错误 payload
+当成目标事件执行。
+
+InstanceGroup 必须把对应 EventReport storage 配置在
+`event_report_storage_candidates` 中，否则返回 `INSTANCE_NOT_EXIST`。
+
+## 5. 各事件行为
+
+### 5.1 EVENT_NODE_REGISTER
+
+```json
+{
+  "event_type": "EVENT_NODE_REGISTER",
+  "node_register": {
+    "mediums": ["gpu", "memory", "disk"]
+  }
+}
+```
+
+行为：
+
+- 建立或刷新该 reporter 的节点状态；
+- 重复 REGISTER 幂等，medium 列表会合并；
+- REGISTER 本身不创建 `committed_snapshot_version`；
+- REGISTER 后可以直接发 ADD/DELETE；
+- KVCM 重启后不必重新 REGISTER；
+- 同一 KVCM 进程内，HOST_DOWN 或超过 grace 被清理会留下 tombstone；此时必须显式
+  REGISTER 才能重新启用同一 reporter identity，避免迟到事件意外复活已下线节点。
+
+### 5.2 EVENT_HEARTBEAT
+
+```json
+{
+  "event_type": "EVENT_HEARTBEAT",
+  "heartbeat": {
+    "system_status": {
+      "engine_version": "v1.2.3",
+      "load": "0.42"
+    }
+  }
+}
+```
+
+行为：
+
+- 只刷新节点存活时间；
+- `system_status` 是观测信息，不参与 cache 正确性判断；
+- fresh reporter 或 KVCM 重启后的第一条 HEARTBEAT 会懒初始化节点，返回 `OK`；
+- 同一进程内已被 HOST_DOWN/grace cleanup tombstone 的 reporter 返回 `NODE_NOT_REGISTERED`；
+- unavailable 但仍处于 grace period 的 reporter 可通过 HEARTBEAT 恢复；
+- HEARTBEAT 不创建或改变 generation。
+
+### 5.3 EVENT_BLOCK_ADD
+
+```json
+{
+  "event_type": "EVENT_BLOCK_ADD",
+  "block_add": {
+    "block_key": "123",
+    "medium": "gpu",
+    "specs": [
+      {
+        "name": "full_attention:group=0:tp=0",
+        "uri": "event_report://10.0.0.8:9600/gpu/123?size=4096"
+      },
+      {
+        "name": "mamba_state:group=0:tp=0",
+        "uri": "event_report://10.0.0.8:9600/gpu/123?size=1024"
+      }
+    ]
+  }
+}
+```
+
+要求：
+
+- `block_key` 必须是可解析的十进制整数文本；
+- `medium` 非空，且不能包含 location id 分隔符 `#`；
+- `specs` 非空；
+- 每个 `spec.name` 非空，且同一事件内不能重复；
+- 每个 URI 必须合法；
+- 客户端 URI 不能带 `s_version`；
+- 旧字段 `block_add.uri` 已废弃，只有 `specs` 生效。
+
+行为：
+
+- 按 spec name merge；
+- 本次未涉及的其他 spec 会保留；
+- 同一逻辑 spec 再次 ADD 会覆盖旧 URI；
+- 首条合法 ADD 可以创建 generation；
+- KVCM 会给每个 URI 追加一个 `s_version`。
+
+### 5.4 EVENT_BLOCK_DELETE
+
+```json
+{
+  "event_type": "EVENT_BLOCK_DELETE",
+  "block_delete": {
+    "block_key": "123",
+    "medium": "gpu",
+    "spec_names": [
+      "full_attention:group=0:tp=0"
+    ]
+  }
+}
+```
+
+要求：
+
+- `block_key`、`medium` 非空且合法；`medium` 不能包含 location id 分隔符 `#`；
+- `spec_names` 非空；
+- spec name 非空且同一事件内不能重复。
+
+行为：
+
+- 只删除指定 `block_key + medium + spec_names`；
+- 同 location 中未指定的 spec 保留；
+- block、medium/location 或 spec 不存在都视为幂等成功，响应仍为 `OK`；
+- 同一请求存在缺失的 `block_key + medium` 时，KVCM 只打一条聚合 warning，
+  记录缺失 target 数量，不逐 block 打日志；
+- 首条合法 DELETE 即使没有实际删到数据，也可以创建 generation。
+
+### 5.5 EVENT_BLOCK_SNAPSHOT
+
+```json
+{
+  "event_type": "EVENT_BLOCK_SNAPSHOT",
+  "block_snapshot": {
+    "blocks": [
+      {
+        "block_key": "123",
+        "medium": "gpu",
+        "specs": [
+          {
+            "name": "full_attention:group=0:tp=0",
+            "uri": "event_report://10.0.0.8:9600/gpu/123?size=4096"
+          },
+          {
+            "name": "mamba_state:group=0:tp=0",
+            "uri": "event_report://10.0.0.8:9600/gpu/123?size=1024"
+          }
+        ]
+      },
+      {
+        "block_key": "456",
+        "medium": "memory",
+        "specs": [
+          {
+            "name": "full_attention:group=0:tp=0",
+            "uri": "event_report://10.0.0.8:9600/memory/456"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Snapshot 的完整性规则：
+
+- `blocks` 是该 reporter 在当前 storage type 下、跨全部 medium 的完整 block 集合；
+- 不能拆成多个 ReportEvent 请求分页；
+- 每个 item 的 specs 是该 `block_key + medium` 的完整 spec 集合；
+- 同一 `block_key + medium` 只能出现一次；
+- 相同 block key 可以出现在不同 medium；
+- `medium` 不能包含 location id 分隔符 `#`；
+- 每个 block 的 specs 必须非空，且 spec name 不能重复；
+- `blocks=[]` 表示该 reporter 当前没有任何 cache，会异步清理其全部旧 location。
+
+Snapshot 的更新语义：
+
+- snapshot 中出现的 `block_key + medium` 会原地替换完整 spec 集合；
+- 已存在 block 中被本次省略的 spec 会被替换掉；
+- 整个 snapshot 中被省略的旧 block 由异步 cleanup 最终删除；
+- 成功后返回新的 generation；
+- 失败时不回滚已经完成的部分 metadata 写入，应完整重试。
+
+### 5.6 EVENT_HOST_DOWN
+
+```json
+{
+  "event_type": "EVENT_HOST_DOWN",
+  "host_down": {}
+}
+```
+
+行为：
+
+- 必须是请求中的唯一事件；
+- 立即把 reporter 标记为不可用并从节点表注销；
+- 查询立即隐藏该 reporter，metadata 异步清理；
+- 重复 HOST_DOWN 幂等；
+- 同一 KVCM 进程内后续重新使用该 reporter identity 时必须先 REGISTER；KVCM 重启会清空
+  进程内 tombstone，下一条合法汇报可以再次懒初始化。
+
+## 6. 请求组合与批处理
+
+| 请求内容 | 行为 |
+| --- | --- |
+| `REGISTER + ADD/DELETE + HEARTBEAT` | 允许；REGISTER 在 mutation 前后都不影响 mutation 正确性 |
+| `REGISTER + SNAPSHOT + HEARTBEAT` | 允许；REGISTER 在 SNAPSHOT 前后都不影响 snapshot 正确性 |
+| 多个 ADD/DELETE | 允许，按请求顺序解释 |
+| SNAPSHOT + ADD/DELETE | 整个请求在写入前返回 `INVALID_ARGUMENT` |
+| 两个 SNAPSHOT | 整个请求在写入前返回 `INVALID_ARGUMENT` |
+| HOST_DOWN + 任意其他事件 | 整个请求在写入前返回 `INVALID_ARGUMENT` |
+| 空 events | no-op success；不查 backend，也不刷新节点或 generation，响应状态字段保持默认值 |
+
+同一请求内，如果相同 `block_key + medium + spec.name` 被多次修改，最后一次操作获胜。例如：
+
+```text
+ADD A -> DELETE A -> ADD A(new URI)
+```
+
+最终保存最后一次 ADD 的 URI。被折叠的事件共享最终 metadata 写入结果。
+
+不同请求之间没有为相同逻辑 spec 提供全局事件序号。调用方必须保证同一 reporter 的相同
+`block_key + medium + spec.name` 按正确顺序送达；并发更新不同 spec name 可以安全 merge。
+
+## 7. Snapshot 与增量并发
+
+同一 reporter 的执行顺序是：
+
+```text
+已经开始的 delta 完成
+        |
+snapshot 关闭新的 delta 入口
+        |
+snapshot replace + Sync + commit/abort
+        |
+等待中的 delta 使用 commit 后的 generation 继续
+```
+
+调用方可依赖：
+
+- snapshot 不会越过已经获得写 lease 的 delta；
+- snapshot 开始后到达的 ADD/DELETE 会在服务端等待，不返回 `DELTA_IN_PROGRESS`；
+- snapshot commit 后，等待中的增量不会再被刚完成的 snapshot 覆盖；
+- snapshot abort 后，等待中的增量继续执行；
+- 第二个并发 snapshot 返回 `SNAPSHOT_IN_PROGRESS`；
+- 不同 host、instance 或 storage type 不共享该写门。
+
+服务端没有为等待 snapshot 的 delta 定义固定等待超时。调用方 HTTP/gRPC timeout 应覆盖可能的
+snapshot 执行时间，并对超时请求做好幂等重试。
+
+## 8. Snapshot 限流
+
+限流维度为：
+
+```text
+instance_id + storage_type + host_ip_port
+```
+
+- 只在成功 snapshot commit 后开始计时；
+- 限流期内返回 `SNAPSHOT_RATE_LIMITED`；
+- `retry_after_ms` 给出当前请求至少还要等待的时间；
+- 失败 snapshot 不启动冷却，可立即完整重试；
+- ADD、DELETE、REGISTER、HEARTBEAT 不受 snapshot 限流影响。
+
+推荐处理：
+
+```text
+SNAPSHOT_RATE_LIMITED -> 等待 retry_after_ms + 少量 jitter -> 重发完整 snapshot
+SNAPSHOT_IN_PROGRESS  -> 退避后重发完整 snapshot
+```
+
+## 9. 响应字段
+
+```json
+{
+  "header": {
+    "status": {
+      "code": "OK",
+      "message": ""
+    },
+    "request_id": "..."
+  },
+  "item_results": [],
+  "committed_snapshot_version": "0123456789abcdef0123456789abcdef",
+  "retry_after_ms": "0",
+  "snapshot_required": false,
+  "extra_info": ""
+}
+```
+
+### 9.1 committed_snapshot_version
+
+- 当前 KVCM 进程中，该 reporter 已发布的 generation；
+- 32 个十六进制字符；
+- opaque、随机、不可排序；
+- 第一条合法 ADD/DELETE 或成功 SNAPSHOT 可创建/更新；
+- 普通增量沿用当前值；
+- REGISTER、HEARTBEAT，以及获得 delta lease 前失败的 mutation 不创建新值；
+- 增量获得 lease 后若 metadata 写入失败，响应仍可能带新建的 generation；是否成功以
+  `header.status`/`item_results` 为准；
+- KVCM 重启或 reporter 注销后为空；
+- 空 events 是不解析 reporter 状态的纯 no-op，因此该响应字段为空；不能用空 events 查询 generation；
+- 仅用于请求关联、日志和 cleanup，不是查询可见性 fence。
+
+客户端不能把“数值更大”解释为“更新”，只能做字符串相等判断。
+
+### 9.2 snapshot_required
+
+`snapshot_required` 等价于“当前进程还没有该 reporter generation”：
+
+| 场景 | 值 |
+| --- | --- |
+| fresh REGISTER 后 | `true` |
+| KVCM 重启后的第一条 HEARTBEAT | `true` |
+| 只有 REGISTER/HEARTBEAT、还没有合法 mutation | `true` |
+| 第一条合法 ADD/DELETE 后 | `false` |
+| 成功 SNAPSHOT 后 | `false` |
+| invalid-only 首批增量 | 仍为 `true` |
+| realtime-only reporter | 可忽略该提示，继续发合法增量 |
+
+空 events 不读取 reporter 状态，`snapshot_required` 保持 proto 默认值 `false`。需要确认当前
+generation 时应查看正常 REGISTER/HEARTBEAT/数据事件的响应，不能发送空 events 探测。
+
+### 9.3 item_results
+
+- 全部事件成功时为空或不出现在 JSON 中；
+- 任一事件失败时，长度与 `events` 完全相同，顺序一一对应；
+- `header.status.code` 是第一个失败项的错误码；
+- `ReportEvent partially failed` 不代表整批回滚；
+- 调用方只重试失败项时，仍要保持原有事件顺序。
+
+例如 fresh reporter 发送 `[ADD, REGISTER, HEARTBEAT]`，三个事件都成功，`item_results` 为空，
+ADD 创建 generation；显式 REGISTER 的先后顺序不会成为数据面的失败原因。若其中某个 item
+参数非法，只有该 item 返回 `INVALID_ARGUMENT`，同批其他合法 item 仍可生效。
+
+### 9.4 retry_after_ms 与 extra_info
+
+- `retry_after_ms` 只在 `SNAPSHOT_RATE_LIMITED` 时有业务含义；
+- proto JSON 的 `uint64` 可能编码成字符串，调用方应同时兼容字符串和数字；
+- `extra_info` 是 InstanceGroup 透传的 opaque JSON，不能用于核心流程判断。
+
+## 10. 错误码与调用方动作
+
+| 错误码 | 含义 | 建议动作 |
+| --- | --- | --- |
+| `OK` | 全部事件成功 | 正常继续 |
+| `INVALID_ARGUMENT` | 请求形状或某事件参数非法 | 不盲重试；修正失败项 |
+| `INSTANCE_NOT_EXIST` | instance、MetaSearcher 或指定 storage type backend 不存在 | 检查 Instance/InstanceGroup/storage 配置 |
+| `NODE_NOT_REGISTERED` | 同一进程内 reporter 已被 HOST_DOWN/grace cleanup tombstone | 确认节点确实重新上线后 REGISTER，再按顺序重试 mutation |
+| `SNAPSHOT_IN_PROGRESS` | 同 reporter 已有 snapshot | 退避后重发完整 snapshot |
+| `SNAPSHOT_RATE_LIMITED` | 距上次成功 snapshot 太近 | 按 `retry_after_ms` 重试完整 snapshot |
+| `SNAPSHOT_REQUIRED` | 等待期间 reporter 被注销/关闭等状态变化 | 重新 REGISTER；realtime-only 可直接重试增量 |
+| `INTERNAL_ERROR` | metadata replace、Sync、commit 等内部失败 | 保留实时链路；完整重试 snapshot 或幂等重试增量 |
+
+## 11. 查询行为
+
+### 11.1 所有查询共享的可见性规则
+
+Event-report location 只有同时满足以下条件才可参与业务查询：
+
+1. location id 能解析出正确的 storage type、medium 和 reporter host；
+2. 当前 KVCM 进程已收到该 reporter 的合法 REGISTER、HEARTBEAT 或数据事件；
+3. reporter 当前 available；
+4. location 至少包含一个 spec；
+5. 每个 URI 语法合法；
+6. URI 如果带 `s_version`，只能出现一次且必须是 32 位十六进制文本。
+
+查询接受：
+
+- 没有 `s_version` 的历史 URI；
+- 旧 generation；
+- 当前 generation；
+- 正在写入的 snapshot generation；
+- 同一 location 内混合的多个合法 generation。
+
+查询不会比较 `s_version` 的大小，也不会要求它等于
+`committed_snapshot_version`。一个 location 中只要有任一 malformed spec，整个 location
+fail closed。
+
+`EventReportBackend::MightExist` 是底层无 instance/location-id 上下文的保守接口，只能对它
+能够反查 owner 的当前 generation 做判断。上述三个公共查询入口使用带 instance 和完整
+location 的查询检查器，不以 `MightExist` 的 token 规则代替本节业务可见性规则。
+
+### 11.2 GetCacheLocation
+
+HTTP 接口为 `POST /api/getCacheLocation`：
+
+```json
+{
+  "trace_id": "query-001",
+  "instance_id": "model-a",
+  "query_type": "QT_BATCH_GET",
+  "block_keys": [123, 456],
+  "block_mask": {
+    "offset": 0
+  }
+}
+```
+
+返回的 EventReport URI 会包含 KVCM 追加的 `s_version`。调用方应把 URI 交给相应 connector
+读取；真实读取失败按普通 cache miss 处理，不能把 metadata 命中当作数据一定存在。
+
+当多个 medium 或多个 backend 返回相同 spec name 时，普通查询可能按选择策略合并/去重。
+需要明确指定 backend 时使用 `GetCacheLocationsByBackend`；需要同时表达多个 cache 组成部分时，
+应使用不同且稳定的 spec name。
+
+### 11.3 GetCacheLocationsByBackend
+
+该接口当前支持 `QT_BATCH_GET`，可通过 `backend_selectors` 明确选择
+`ST_EVENT_REPORT_L1P5`、`ST_EVENT_REPORT_L2` 等 backend，适合验证两种 EventReport storage 的
+隔离状态。
+
+### 11.4 GetHostCacheState
+
+HTTP 接口为 `POST /api/getHostCacheState`：
+
+```json
+{
+  "trace_id": "host-state-001",
+  "instance_id": "model-a",
+  "query_type": "QT_PREFIX_MATCH",
+  "block_cache_keys": [100, 101, 102, 103],
+  "medium": ["gpu", "memory"]
+}
+```
+
+返回：
+
+```json
+{
+  "header": {
+    "status": {
+      "code": "OK"
+    }
+  },
+  "hosts": [
+    {
+      "host_ip_port": "10.0.0.8:8080",
+      "prefix_match_blocks": "3"
+    }
+  ]
+}
+```
+
+规则：
+
+- 输入 block key 的顺序有意义；
+- 每个 host 从第一个 key 开始连续计数，遇到第一个 miss 即停止；
+- 第一个 key 就 miss 的 host 不返回；
+- `medium` 为空表示考虑所有 medium；
+- `medium` 非空时只使用指定 medium；
+- `QT_UNSPECIFIED` 使用 RegisterInstance 时配置的 `default_query_type`；
+- 支持 `QT_PREFIX_MATCH` 和 `QT_PREFIX_MATCH_WITH_MAMBA`，其他类型返回参数错误；
+- 同一个 host 在多个 backend 的有效 cache 会按 host 汇总参与匹配；
+- reporter unavailable 时，该 host 对应的 event-report location 不参与匹配。
+
+`GetHostCacheState` 仍然基于软 cache metadata，因此 `prefix_match_blocks` 也可能是 false positive。
+
+## 12. 节点生命周期与查询
+
+| Reporter 状态 | ReportEvent | 查询 |
+| --- | --- | --- |
+| 当前进程从未见过 | 第一条合法 REGISTER/HEARTBEAT/ADD/DELETE/SNAPSHOT 懒初始化 | 第一条合法事件前不可见，之后按 liveness 可见 |
+| registered + available | 所有合法事件按规则执行 | 可见 |
+| heartbeat timeout、仍在 grace | ADD/DELETE/SNAPSHOT 仍可能被接受；HEARTBEAT 可恢复 | 不可见 |
+| grace 内 HEARTBEAT 恢复 | 保留原 generation 和已写 metadata | 重新可见 |
+| 超过 grace 被 unregister | tombstone 后 mutation 返回 `NODE_NOT_REGISTERED` | 不可见，metadata 异步清理 |
+| HOST_DOWN | 立即 unregister，异步清理 | 立即不可见 |
+| tombstone 后重新 REGISTER | 可继续增量；generation 初始为空 | 未清干净的合法历史 metadata 可能重新可见 |
+| KVCM 重启 | 下一条合法事件自动恢复，不要求 REGISTER | 首条事件前隐藏；之后历史 metadata 可能重新可见 |
+
+调用方不要用 ADD/DELETE 代替 HEARTBEAT：mutation 不刷新 heartbeat。暂时 unavailable 时虽然
+metadata 写入可能成功，但恢复 HEARTBEAT 前查询仍不可见。
+
+## 13. Snapshot 非原子窗口与重试
+
+Snapshot 使用稳定 location 原地更新，不提供原子查询视图：
+
+| 阶段/失败点 | 响应 generation | 查询可能看到什么 | 调用方动作 |
+| --- | --- | --- | --- |
+| 参数校验失败 | 旧值 | 原数据 | 修正请求 |
+| 限流/并发拒绝 | 旧值 | 原数据 | 按错误码退避 |
+| snapshot 写入中 | 旧值 | 新旧合法 candidate | 不做版本大小判断 |
+| 部分 replace 失败 | 旧值 | 已写入的新数据 + 未覆盖的旧数据 | 完整重试 |
+| Sync/commit 失败 | 旧值 | 已写入的新数据可能可见 | 完整重试 |
+| commit 成功、cleanup 未完成 | 新值 | snapshot 遗漏的旧 block 可能短暂可见 | 等待异步收敛 |
+| cleanup 与新写重叠 | 新值 | 新写必须保留 | 无需特殊处理 |
+| KVCM 重启 | 空 | 第一条合法汇报后历史数据可能可见 | 正常继续心跳/增量；可选低频全量 |
+
+Snapshot-capable 调用方的安全重试单位始终是“整个完整 snapshot”，而不是只重试上次失败的
+block 子集。
+
+Snapshot cleanup 只删除 KVCM 中的 event-report metadata，不会向 reporter URI 对应的外部
+cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增量在新 generation 下只刷新
+了其中一个 spec，location 内可能暂时混合当前、旧或无 version 的 legacy spec；只要存在
+当前或 in-flight spec，清理就保留整个 location，避免误删刚成功的增量。旧 sibling spec
+由后续完整 snapshot 替换或回收。
+
+清理扫描耗时通过
+`event_report.snapshot_cleanup_scan_latency_ms{instance_id,host,type}` 暴露。典型场景下，
+1 个 instance、10 个 reporter、每台 5000 个 block，一次单 reporter snapshot 约产生 5000
+次 metadata replace，并以 1000 key 为批次扫描该 instance 约 5 万个 key。10 台同时完整对账
+约有 5 万次 replace、累计约 50 万次 key 检查；具体 Redis 命令数受 backend batching 影响。
+如果扫描延迟或 cleanup backlog 持续升高，应考虑按 reporter 建反向索引，而不是继续扩大
+全 instance 扫描频率。
+
+## 14. 调用方上线检查清单
+
+- [ ] InstanceGroup 配置了正确的 `event_report_storage_candidates`
+- [ ] reporter 自身启动时建议发送 REGISTER；不依赖 KVCM 重启后再次 REGISTER
+- [ ] 正确区分“进程重启后的懒恢复”和“HOST_DOWN/grace tombstone 后显式 REGISTER”
+- [ ] 实时-only 模式不会因 `snapshot_required=true` 停止发送增量
+- [ ] 客户端 URI 不包含 `s_version`
+- [ ] `block_key + medium + spec.name` 在发送前已去重
+- [ ] snapshot 合并同一 block 的全部 specs，且包含全部 medium
+- [ ] snapshot 不分页、不与 ADD/DELETE/HOST_DOWN 混发
+- [ ] 按 `item_results` 下标处理部分失败
+- [ ] 正确处理 `SNAPSHOT_IN_PROGRESS`、`SNAPSHOT_RATE_LIMITED` 和 `retry_after_ms`
+- [ ] HTTP/gRPC timeout 能覆盖 snapshot 栅栏等待，并支持幂等重试
+- [ ] 持续发送 HEARTBEAT，不用数据事件代替 HEARTBEAT
+- [ ] HOST_DOWN 单独发送
+- [ ] GetHostCacheState 使用有序 block keys，并正确处理 prefix 含义
+- [ ] metadata 命中后的物理 cache 读取失败按 miss 处理
+
+## 15. 自动化测试覆盖矩阵
+
+以下矩阵是本文接口契约与自动化测试的对应关系。测试文件：
+
+- Backend UT：`kv_cache_manager/data_storage/test/event_report_backend_test.cc`
+- Manager UT：`kv_cache_manager/manager/test/cache_manager_test.cc`
+- Meta UT：`kv_cache_manager/manager/test/meta_searcher_test.cc`
+- 基础集成：`integration_test/meta_service/test_report_event.py`
+- Snapshot 集成：`integration_test/meta_service/test_report_event_snapshot.py`
+- 重启集成：`integration_test/meta_service/test_report_event_restart.py`
+
+| ID | 用户行为 | 自动化覆盖 |
+| --- | --- | --- |
+| I-01 | instance、host、storage type 隔离 | `ScopesAreIsolatedByInstanceAndReporterHost`；`test_15/16/17_dual_type_*` |
+| I-02 | 同 host 的 L1.5/L2 独立增删和 HOST_DOWN | `TestReportEventL1P5L2BlockAddAreIsolated`；基础集成 `test_15~17` |
+| R-01 | REGISTER 幂等并合并 medium | `RegisterNodeWithMediums`；snapshot 集成 `test_01/02` |
+| R-02 | fresh REGISTER+ADD+HEARTBEAT 同请求 | `TestReportEventRegisterThenFirstDeltaInSameRequest`；snapshot 集成 `test_11_mixed_batch` |
+| R-03 | ADD 排在显式 REGISTER 前仍成功并懒初始化 reporter | `TestReportEventDeltaBeforeExplicitRegisterSucceedsInSameRequest`；snapshot 集成 `test_30_*` |
+| R-04 | REGISTER+SNAPSHOT+HEARTBEAT 同请求 | snapshot 集成 `test_29_*` |
+| R-05 | 空 events 是纯 no-op，响应 generation/snapshot_required/retry 使用默认值 | snapshot 集成 `test_12_empty_batch` |
+| R-06 | 成功、部分失败和 no-op 的响应字段，以及 InstanceGroup extra_info 透传 | snapshot 集成 `test_01/02/03/10/12/13/33` |
+| D-01 | HOST_DOWN/grace tombstone 后 ADD/DELETE 被拒绝，REGISTER 后恢复 | snapshot 集成 `test_16b/26_*` |
+| D-02 | 无 REGISTER、无初始 snapshot 的第一条 ADD 懒初始化、创建 generation 并可查询 | `TestReportEventLazilyRestoresReporterWithoutRegisterOrSnapshot`；snapshot 集成 `test_30_*` |
+| D-03 | 无初始 snapshot 的第一条 DELETE 创建 generation且幂等 | `TestReportEventFirstDeleteWithoutSnapshotCreatesReusableVersion`；snapshot 集成 `test_31_*` |
+| D-04 | invalid-only 首批增量不创建 generation | `TestReportEventInvalidFirstDeltaDoesNotCreateVersionButPartialBatchDoes`；snapshot 集成 `test_26_*` |
+| D-05 | 部分失败批次保留合法项进度和 item_results 顺序 | 同上；snapshot 集成 `test_23_*` |
+| D-06 | 未预注册 reporter 的多线程首批增量只懒建一个节点并发布一个 generation | `ConcurrentFirstDeltasPublishExactlyOneReusableVersion`；snapshot 集成 `test_28_*` |
+| D-07 | ADD 按 spec name merge、保留未触碰 spec | `TestReportEventBlockAddMergesLocationSpecs`；snapshot 集成 `test_05b`、`test_22_*` |
+| D-08 | DELETE 精确删除 spec、missing delete 批量幂等 OK | `TestReportEventBlockDeleteRemovesLocationSpecs`、`TestReportEventMissingBlockDeletesRemainSuccessfulAsOneBatch`；snapshot 集成 `test_06/07` |
+| D-09 | 同请求 ADD/DELETE 最后操作获胜 | `TestReportEventSameRequestDeltaOrderUsesLastOperationPerSpec`；snapshot 集成 `test_25_*` |
+| D-10 | 并发写不同 spec 不互相丢失 | snapshot 集成 `test_24_*` |
+| D-11 | 重复物理逻辑身份是 set 而非 refcount | `TestReportEventRepeatedPhysicalDeltaUsesSetNotReferenceCountSemantics` |
+| D-12 | KVCM 只追加一个合法 s_version，不改变客户端 URI 其他部分 | 基础集成 `_assert_profile_specs_in_locations`；snapshot 集成 `_assert_reporter_scope` |
+| D-13 | 第一条 delta 已创建 generation、metadata 写失败时准确报错，重试复用 generation | `TestReportEventFirstDeltaMetadataFailureReportsFailureAndReusesGeneration` |
+| D-14 | 同一 spec 的折叠事件共享最终 metadata 写入失败结果 | `TestReportEventFoldedDeltaEventsShareFinalWriteFailure` |
+| S-01 | snapshot 跨 medium 完整上报、响应返回 generation | `TestReportEventSnapshotReplacesCompleteSpecSetPerBlock`；snapshot 集成 `test_17/22` |
+| S-02 | 同 block 跨 medium 合法，同 block+medium 重复非法 | `TestReportEventRejectsCanonicalDuplicateSnapshotKeysButAllowsDifferentMedia`；snapshot 集成 `test_27_*` |
+| S-03 | snapshot block 内重复 spec name 被拒绝 | `TestReportEventRejectsDuplicateSpecNamesWithinSnapshotBlock` |
+| S-04 | snapshot 参数错误无写入副作用 | `TestReportEventRejectsDuplicatePhysicalSnapshotItemsWithoutStateChange`；snapshot 集成 `test_19/27` |
+| S-05 | 空 snapshot 清空 reporter | `TestReportEventEmptySnapshotCommitsAndReclaimsPreviousBlocks`；snapshot 集成 `test_17` |
+| S-06 | snapshot 遗漏 block 后 cleanup 最终删除 | `TestReportEventSnapshotCommitReclaimsOnlyStaleReporterLocations`；snapshot 集成 `test_22` |
+| S-07 | snapshot 和 delta 两种先后顺序均收敛 | `TestReportEventDeltaAlreadyAdmittedThenSnapshotWins`、`TestReportEventSnapshotGateThenDeltaInheritsNewTokenAndWins`；snapshot 集成 `test_24` |
+| S-08 | 第二个 snapshot busy，成功后 rate limit 带 retry_after | `ConcurrentSnapshotsHaveExactlyOneWinner`、`SnapshotRateLimitReturnsRetryDelay`；snapshot 集成 `test_18/24` |
+| S-09 | snapshot 部分 replace/Sync 失败后仍可读并可完整重试 | `TestReportEventPartialSnapshotFailureKeepsCacheReadableAndRetryConverges`、`TestReportEventSyncFailureKeepsWrittenCacheReadableAndImmediateRetryConverges` |
+| S-10 | cleanup 与下一轮写入 CAS 竞争不删除新值 | `TestSnapshotCleanupPreservesInFlightStableLocationUntilAbort`、`TestSnapshotCleanupCASPreservesLocationRefreshedAfterScan` |
+| S-11 | snapshot commit 后增量刷新 mixed/legacy location，旧 cleanup 不删除新写 | `TestSnapshotCleanupPreservesPostCommitDeltaOnMixedGenerationLocation`、`TestSnapshotCleanupPreservesCurrentDeltaBesideLegacySpec`；snapshot 集成 `test_32_*` |
+| S-12 | snapshot cleanup 只删 metadata，不调用外部 URI backend | `TestMetadataOnlyLocationDeleteSkipsPhysicalBackend`、`TestCleanupLocationsByPredicateSubmitsExactObservedValue` |
+| S-13 | unavailable reporter 可完成 snapshot，但 HEARTBEAT 恢复前查询保持隐藏 | `TestReportEventSnapshotWhileUnavailableCommitsButStaysHiddenUntilHeartbeat` |
+| Q-01 | legacy/old/current/in-flight/mixed合法 generation 可查询 | `TestGetCheckLocDataExistFuncAcceptsWellFormedGenerationsAndLegacyUris`、`TestGetCheckLocDataExistFuncEventReportUriValidationMatrix` |
+| Q-02 | 空 spec、坏 URI、重复/畸形 s_version 整条 location fail closed | `TestGetCheckLocDataExistFuncEventReportUriValidationMatrix` |
+| Q-03 | malformed location id、错误 storage type、未知 host 不可见 | 同上；`TestGetCheckLocDataExistFunc_MissingEventReportBackendFailsClosed` |
+| Q-04 | 节点 available/unavailable/unregistered 控制真实查询入口 | `TestGetCacheLocationEnforcesReporterLifecycleAndBatchOrdering`；snapshot 集成 `test_16a/16b` |
+| Q-05 | GetHostCacheState 的 prefix、medium、默认 query type | `TestGetHostCacheState`、`TestGetHostCacheStatePrefixMatchWithMamba`；snapshot 集成 `test_16` |
+| Q-06 | 纯增量模式同时通过 GetCacheLocation 和 GetHostCacheState 校验 | snapshot 集成 `test_11/26/28` |
+| Q-07 | GetCacheLocationsByBackend 同样执行 reporter liveness 过滤 | `TestGetCacheLocationsByBackendWithBackendSelectors`；snapshot 集成 `test_16a` |
+| Q-08 | 三个查询入口在 timeout 隐藏和 HEARTBEAT 恢复时结果一致 | snapshot 集成 `test_16a_heartbeat_timeout_then_recovery` |
+| L-01 | 自动 heartbeat timeout 隐藏、grace 内恢复原 generation | `MightExistFollowsAutomaticLivenessAndFullReporterLifecycle`；snapshot 集成 `test_16a` |
+| L-02 | unavailable 期间增量可写但保持不可见，HEARTBEAT 后恢复 | `TestReportEventLazilyRestoresReporterWithoutRegisterOrSnapshot`；snapshot 集成 `test_16a` |
+| L-03 | 超过 grace 后 unregister，旧 cleanup 不伤重新注册数据 | `HeartbeatRecoveryFencesCleanupAlreadySelectedByLivenessLoop`；snapshot 集成 `test_16b` |
+| L-04 | HOST_DOWN 立即隐藏、异步清理、重复调用幂等 | `TestHostDownMakesAlreadyAdmittedDeltaInvisibleWithoutDeadlock`；snapshot 集成 `test_08/09/20` |
+| L-05 | 同 instance 另一 host、同 host 另一 instance 不受 liveness 影响 | `TwoInstancesSameHostIsolated`；snapshot 集成 `test_16a` |
+| L-06 | ADD/DELETE/SNAPSHOT 不刷新 heartbeat，数据事件不能替代 HEARTBEAT | `DataMutationsDoNotRefreshHeartbeat`；snapshot 集成 `test_16b` |
+| P-01 | KVCM 重启前旧数据持久化，首条新汇报前隐藏 | 重启集成 `test_report_event_restart.py --phase prepare/verify` |
+| P-02 | 重启后首条 HEARTBEAT 无需 REGISTER 即恢复历史 candidate，响应提示 snapshot_required | 同上 |
+| P-03 | 重启后首条增量成功并保留未触碰历史数据 | `TestReportEventRestartKeepsHistoricalCacheAndAcceptsDeltaWithoutSnapshot`；重启集成 |
+| P-04 | 重启后可选 snapshot 最终重新收敛 | 重启集成 |
+| C-01 | Close/Unregister/HOST_DOWN 唤醒 snapshot/delta waiter | `CloseUnblocksSnapshotAndDeltaWaiters`、`UnregisterCancelsSnapshotWaitingForActiveDelta`、`TestHostDownCancelsSnapshotAlreadyWritingMetadata` |
+| C-02 | 不同 reporter 的 snapshot 不互相阻塞 | `OtherReporterIsNotBlockedBySnapshot`；snapshot 集成 `test_18` |
+| C-03 | 自动 liveness cleanup 在 snapshot 等待 active delta 时注销并唤醒 waiter | `AutomaticLivenessCleanupCancelsSnapshotWaitingForActiveDelta` |
+| V-01 | reporter host、ADD/DELETE/SNAPSHOT medium 含 `#` 时拒绝且无写入副作用 | `RegisterNodeWithMediums`、`TestReportEventRejectsInvalidRequestsAndMapsItemErrors`；snapshot 集成 `test_19_*` |
+| V-02 | instance/host/storage type/instance backend 的公共字段校验 | `TestReportEventRejectsInvalidRequestsAndMapsItemErrors`；snapshot 集成 `test_14_*` |
+| V-03 | event_type 与 oneof payload 缺失/错配时该 item fail closed；同批其他合法 mutation 可独立懒初始化并生效 | `TestReportEventRejectsMismatchedPayloadsWithoutSideEffects`；snapshot 集成 `test_13/33` |
+| V-04 | ADD 的 key、medium、spec 数量/name/URI/s_version 完整校验且无副作用 | `TestReportEventMutationValidationMatrixHasNoSideEffects`；snapshot 集成 `test_19/33` |
+| V-05 | DELETE 的 key、medium、spec_names 数量/空值/重复完整校验且无副作用 | `TestReportEventMutationValidationMatrixHasNoSideEffects`；snapshot 集成 `test_19/33` |
+| V-06 | SNAPSHOT 的 key、medium、spec、URI、s_version、重复 block 完整校验且无副作用 | `TestReportEventMutationValidationMatrixHasNoSideEffects`；snapshot 集成 `test_19/27/33` |
+| V-07 | snapshot+delta、双 snapshot、HOST_DOWN 混发均在任何副作用前整批拒绝 | `TestReportEventRejectsRequestShapeBeforeAnySideEffect`；snapshot 集成 `test_17/33` |
+| CFG-01 | snapshot interval 默认值、正数校验、负数拒绝、JSON/proto round trip | `TestEventReportStorageSpecSnapshotIntervalDefaultAndValidation`、`TestEventReportStorageSpecJsonRoundTripIncludesSnapshotInterval`、`EventReportStorageSpecProtoRoundTripPreservesSnapshotInterval` |
+| PERF-01 | 100 线程共 1 万 ADD、50 线程共 5000 混合批次均无错误 | `EventReportBenchTest.test_17/18` |
+| PERF-02 | 10 reporter × 每台 5000 blocks 完整 snapshot，并查询每台首/中/末 block | `EventReportBenchTest.test_19_ten_reporters_full_snapshot_capacity` |
+
+上表中的参数解析、故障注入、CAS 竞态等内部边界使用 UT 验证；跨 HTTP 的正常流程、并发流程、
+节点生命周期和 Redis/KVCM 重启使用集成测试验证。

--- a/docs/design/report_event_snapshot_uri_version.md
+++ b/docs/design/report_event_snapshot_uri_version.md
@@ -1,799 +1,447 @@
-# ReportEvent 增量上报与权威快照对账设计
+# ReportEvent 增量汇报与可选全量对账设计
 
-> 状态：实现中。
-> 本文是 ReportEvent snapshot 的目标语义，代码、协议和测试以此为准。
+> 本文描述 ReportEvent 的目标语义。代码、协议和测试应以本文为准。
 
-## 1. 一句话说明
+## 1. 要解决的问题
 
-ReportEvent 使用两条互补链路同步 KV Cache 元数据：
+推理引擎通过 `ReportEvent` 把本地 KV cache 状态汇报给 KVCM。接入方有两类：
 
-- 日常变化走 `EVENT_BLOCK_ADD` / `EVENT_BLOCK_DELETE`；
-- 首次建立基线、KVCM 重启恢复、事件断档和低频兜底校准走 `EVENT_BLOCK_SNAPSHOT`。
+- 只发送实时 `ADD/DELETE`，不具备全量 snapshot 能力；
+- 平时发送实时事件，在事件断档或低频校准时额外发送完整 snapshot。
 
-Snapshot 是一个 reporter 在某一时刻、跨全部介质的完整 cache 事实，不是增量补丁，也不是历史版本存档。
+因此必须满足：
 
-### 1.1 核心设计原则
+1. 即使没有显式 REGISTER、也从未发送过 snapshot，合法 ADD/DELETE 仍能正常工作；
+2. KVCM 重启后不因进程内 version 丢失而隐藏全部历史 cache metadata；
+3. snapshot-capable reporter 仍可用完整全量纠偏并回收旧 metadata；
+4. 当前进程尚未收到 reporter 的任何合法事件，或节点失活时，其 metadata 不能被查询返回。
 
-1. **增量负责效率，快照负责收敛。** ADD/DELETE 优化稳态写放大，snapshot 则是能够覆盖
-   增量历史的权威事实；系统正确性不能永久依赖每一条增量事件都不丢失。
-2. **一台 reporter 一次上报完整事实。** 一个 reporter 统一维护某个 instance 在本机上的
-   GPU、CPU 和 Disk cache；一次 snapshot 必须覆盖这些介质，`medium` 只是 block 属性。
-3. **可见性由提交版本决定，而不是由物理写入完成度决定。** KVCM 先把新版本写入 URI，
-   全部写入成功后才发布 committed token；查询只接受 token 匹配的数据，旧数据或失败
-   写入留下的数据都不可被误认为当前事实。
-4. **逻辑版本与物理位置解耦。** location id 保持稳定，版本只承载可见性，不制造一套
-   新的物理 location identity。这样避免 copy-on-write 的双份位置和两阶段替换，同时
-   明确接受缓存场景下“失败后等待下次 snapshot 收敛”的可用性取舍。
-5. **查询正确性不依赖清理及时性。** 版本过滤先保证旧数据不可见，reclaimer 只负责
-   异步回收空间；清理延迟或 KVCM 在清理中重启都不能重新暴露旧版本。
-6. **重启恢复依赖源端重建事实。** committed token 只保存在内存并通过响应反馈给
-   Subscriber。KVCM 重启后所有 reporter 必须重新提交完整 snapshot，不从残留 metadata
-   猜测或恢复旧的权威状态。
+Event-report metadata 是 cache 索引，不是数据唯一副本。少量 stale candidate 可以接受，实际
+读取 cache 失败时必须按普通 cache miss 处理。
 
-## 2. 要解决的问题
+## 2. 核心结论
 
-只发增量的成本最低，但进程重启、网络中断、事件丢失或 Subscriber 基线损坏后，KVCM 可能长期保留已经不存在的 block。
+### 2.1 增量是主链路
 
-只发全量容易收敛，但高频执行会反复重写所有 block，并放大 Redis 和后台清理负载。
+第一条合法 HEARTBEAT、ADD、DELETE 或 SNAPSHOT 可以懒初始化 reporter 节点状态；第一条
+ADD 或 DELETE 直接建立一个进程内 version，然后执行写入。不要求客户端先 REGISTER，也
+不要求先发送空 snapshot。
 
-因此目标是：
+只支持实时事件的推理引擎可以一直不发送 snapshot。
 
-- 稳态成本与实际变化量成正比；
-- 低频 snapshot 能权威修复增量链路漂移；
-- 未提交版本不能被查询当成当前事实；
-- Subscriber 能明确知道 KVCM 当前 committed version；
-- KVCM 重启后要求全部 reporter 重新上报 snapshot，不恢复旧版本；
-- 旧数据复用既有 reclaimer 删除，不再维护一套 snapshot 专用任务框架。
+显式 REGISTER 仍用于 reporter 自身启动时提前声明 medium 和建立 liveness；同一 KVCM
+进程内发生 HOST_DOWN 或 grace cleanup 后会留下 tombstone，必须由 REGISTER 明确清除，
+防止迟到数据事件复活已下线节点。KVCM 重启会清空该进程内 tombstone。
 
-## 3. 在整体架构中的位置
+这里的 REGISTER 是 `ReportEvent` 内的 `EVENT_NODE_REGISTER`，不是持久化 instance 静态配置
+的 `RegisterInstance`。后者由 RegistryManager 恢复；前者只是 reporter 运行时状态，因此
+可以从下一条 ReportEvent 的 `instance_id + storage_type + host_ip_port` 懒重建。
 
-KVCM 是 KV Cache metadata control plane，不传输真实 KV tensor，也不替代 Master/FlexLB 做最终调度。
+### 2.2 Snapshot 是可选的完整对账
 
-```mermaid
-flowchart LR
-    Engine["RTP-LLM / vLLM / V6D"] --> Adapter["Reporter / Subscriber"]
-    Adapter -->|"ADD / DELETE（高频）"| ReportEvent["KVCM ReportEvent"]
-    Adapter -->|"SNAPSHOT（建基线、重启、断档、低频兜底）"| ReportEvent
-    ReportEvent --> Meta["block -> locations -> specs"]
-    ReportEvent --> Version["EventReportBackend<br/>in-memory committed version"]
-    Meta --> Query["cache-aware query"]
-    Version --> Query
-    ReportEvent --> Reclaimer["既有 Reclaimer Supervisor"]
-    Reclaimer --> Meta
+一个 reporter 的身份是：
+
+```text
+instance_id + storage_type + host_ip_port
 ```
 
-职责边界：
+代码中的 `ReporterSnapshotKey` 只保存 `instance_id + host_ip_port`，因为每个
+`EventReportBackend` 已按 `storage_type` 隔离。
 
-- Engine Adapter 负责获得可信输入；
-- Subscriber 负责事件顺序、源端 watermark、重试、snapshot barrier 和 ACK 后推进本地基线；
-- KVCM 负责版本生成、元数据写入、内存发布点、查询过滤、节点生命周期和旧 metadata 回收；
-- Master/FlexLB 根据 KVCM 的 cache-aware candidates，再结合健康状态和实时负载做最终决策。
+一次 snapshot 是该 reporter 在当前 storage type 下、跨全部 medium 的完整 cache 状态。
+`medium` 是 block 级属性；空 `blocks` 表示该 reporter 当前没有任何 cache。
 
-Engine 的 cache version、event sequence 或 epoch 与本文的 KVCM snapshot version 是不同概念：
+### 2.3 s_version 只用于标记与清理
 
-- source watermark 证明 Engine 快照与后续事件的先后关系；
-- KVCM snapshot version 标识哪一轮 metadata 对账已经提交。
+KVCM 在 reporter 提供的 URI 上只追加：
 
-## 4. 一次全量更新覆盖哪些数据
-
-Snapshot 要表达的是：某个 reporter 此刻为某个 instance 保存的完整 cache 集合。当前部署
-中，一个 Subscriber/reporter 能同时观察本机 GPU、CPU 和 Disk cache，因此这些介质必须
-放在同一次 snapshot 中上报；空 `blocks` 表示该 reporter 的全部 cache 都已经为空。
-
-KVCM 内部用 `(instance_id, reporter host_ip_port)` 找到这名写入者的 committed token、写门
-和限频状态。这只是实现中的查找键，不增加一个需要 Subscriber 理解的 “scope” 协议对象：
-
-- `instance_id` 隔离不同模型实例或 cache namespace；
-- `reporter host_ip_port` 标识实际提交这份完整事实的写入者；
-- `medium` 只描述 block 位于 HBM、DRAM 还是 Disk，保留在 `BlockSnapshotItem` 和 stable
-  location id 中，不参与 token、写门或限频。
-
-由此得到的行为很直接：
-
-- 同一 reporter 的 snapshot 和 ADD/DELETE 串行执行，避免全量基线覆盖并发增量；
-- 不同 instance 或不同 reporter 没有共同写入数据，可以并行；
-- REGISTER 只刷新存活状态，不重置 token；HOST_DOWN、显式注销或 KVCM 重启会使内存
-  token 失效，reporter 必须重新提交完整 snapshot；
-- 同一 reporter 若未来拆成多个独立 cache 进程，必须使用不同的 reporter identity。
-
-`host_ip_port` 必须取自 `ReportEventRequest.host_ip_port`。数据 URI 的 host 可能是实际
-存储服务地址，不能替代 reporter identity。
-
-## 5. Snapshot 协议
-
-### 5.1 Medium 下沉为 block 属性
-
-一个 host snapshot 使用一个 `EVENT_BLOCK_SNAPSHOT` item。外层不再携带 `medium`，每个 block 自己声明 medium：
-
-```protobuf
-message BlockSnapshotItem {
-    string block_key = 1;
-    string medium = 2;
-    repeated LocationSpec specs = 3;
-}
-
-message BlockSnapshotEventParams {
-    repeated BlockSnapshotItem blocks = 1;
-}
+```text
+s_version=<opaque-version>
 ```
 
-该协议仍处于新开发阶段，没有历史兼容负担，因此直接采用最自然的字段顺序，不保留旧外层 medium。Java、C++、HTTP JSON 文档和客户端必须同步更新。
+Version 的用途：
 
-示例：
+- 标记本进程内一段增量或一次 snapshot generation；
+- snapshot 成功后帮助 reclaimer 找出旧 generation；
+- 通过响应、日志和监控对齐一次对账。
+
+Version 不再是查询可见性的硬屏障。查询不会要求：
+
+```text
+uri.s_version == committed_snapshot_version
+```
+
+### 2.4 节点生命周期仍是硬门槛
+
+旧 version、新 version、无 version 的合法 metadata 都可以作为 cache 候选，但 reporter 必须：
+
+- 当前 KVCM 进程已收到合法 REGISTER、HEARTBEAT 或数据事件并建立运行时节点；
+- 当前 available；
+- location id 能解析到该 reporter；
+- storage type 与 backend 一致。
+
+heartbeat timeout、HOST_DOWN、UNREGISTER 后仍按现有生命周期逻辑隐藏或清理该 reporter 的
+metadata。节点清理扫描记录 location 的精确观察值，删除时做 compare-and-delete；旧生命周期
+的 cleanup 即使与重新 REGISTER 后的写入重叠，也不能删除新写入。
+
+## 3. 为什么不再持久化 version
+
+Version 只保存在 `EventReportBackend` 内存，不再写入 MetaIndexer，也不做重启扫描恢复。
+
+原因：
+
+- cache metadata 不是唯一副本；
+- KVCM 重启后保留大部分历史候选，比为了恢复严格 version 而引入 marker、扫描和复杂状态机
+  更符合缓存场景；
+- 第一条新增量可以建立新的进程内 generation；
+- 后续成功 snapshot 仍能把多 generation 状态重新收敛。
+
+代价是 KVCM 重启后可能同时存在旧、新 generation，少量已过期 cache 可能被返回。调用方
+必须把真实 cache 读取失败处理成 miss。
+
+## 4. 接口
+
+### 4.1 ADD
 
 ```json
 {
   "instance_id": "model-a",
-  "host_ip_port": "10.0.0.8:9000",
-  "storage_type": "ST_EVENT_REPORT_L2",
-  "events": [
-    {
-      "event_type": "EVENT_BLOCK_SNAPSHOT",
-      "block_snapshot": {
-        "blocks": [
-          {
-            "block_key": "101",
-            "medium": "hbm",
-            "specs": [
-              {
-                "name": "full_attention",
-                "uri": "rtp-llm://10.0.0.8:9600/hbm/101"
-              }
-            ]
-          },
-          {
-            "block_key": "102",
-            "medium": "mem",
-            "specs": [
-              {
-                "name": "full_attention",
-                "uri": "rtp-llm://10.0.0.8:9600/mem/102"
-              }
-            ]
-          }
-        ]
-      }
+  "host_ip_port": "10.0.0.8:8080",
+  "storage_type": "ST_EVENT_REPORT_L1P5",
+  "events": [{
+    "event_type": "EVENT_BLOCK_ADD",
+    "block_add": {
+      "block_key": "123",
+      "medium": "gpu",
+      "specs": [{
+        "name": "tp0",
+        "uri": "rtp-llm://10.0.0.8:9600/hbm/123"
+      }]
     }
-  ]
+  }]
 }
 ```
 
-### 5.2 完整性语义
+客户端不得携带 `s_version`，由 KVCM 追加。
 
-一次 `EVENT_BLOCK_SNAPSHOT` 是该 reporter 全部 medium 的完整集合：
+### 4.2 DELETE
 
-- 空 `blocks` 表示该 reporter 当前没有任何 cache；
-- 未出现的 medium 表示该 medium 为空；
-- 唯一键是 `(medium, block_key)`，同一组合不能重复；重复判断使用解析后的规范化
-  `int64 block_key`，`1`、`01` 等等价文本不能绕过校验；
-- 每个 block 的 `specs` 是该 location 当前完整的组件集合；
-- medium、spec name 不能为空；
-- 同一 block 内 spec name 不能重复；
-- URI 必须合法，且不能预带 KVCM 保留参数；
-- 一个请求最多有一个 snapshot item；
-- snapshot 不能与 ADD、DELETE、HOST_DOWN 混在同一请求；
-- 同一 snapshot 不能拆成多个普通请求分页提交。
+DELETE 按 `block_key + medium + spec_names` 删除指定 specs，不存在的目标视为幂等成功。
 
-如果单请求无法承载大快照，后续应设计显式 Begin/Page/Commit staging 协议；不能把多个独立 snapshot 当分页。
+### 4.3 SNAPSHOT
 
-非 snapshot 的批量请求是有序事件流。同一请求内如果多个 ADD/DELETE 反复操作同一个
-`(block_key, medium, spec name)`，最终状态以数组中最后一个操作为准；实现可以合并批量
-metadata 写入，但不能把所有 ADD 固定排到所有 DELETE 前面而改变调用方提交的事件顺序。
-
-## 6. Location 与 URI
-
-### 6.1 Stable location id
-
-location 仍按 block 的 medium 区分：
-
-```text
-kvs#<event_report_type>#<medium>#<reporter host_ip_port>
+```json
+{
+  "instance_id": "model-a",
+  "host_ip_port": "10.0.0.8:8080",
+  "storage_type": "ST_EVENT_REPORT_L1P5",
+  "events": [{
+    "event_type": "EVENT_BLOCK_SNAPSHOT",
+    "block_snapshot": {
+      "blocks": [
+        {
+          "block_key": "123",
+          "medium": "gpu",
+          "specs": [{
+            "name": "tp0",
+            "uri": "rtp-llm://10.0.0.8:9600/hbm/123"
+          }]
+        },
+        {
+          "block_key": "456",
+          "medium": "memory",
+          "specs": [{
+            "name": "tp0",
+            "uri": "rtp-llm://10.0.0.8:9600/memory/456"
+          }]
+        }
+      ]
+    }
+  }]
+}
 ```
 
-例如：
+约束：
 
-```text
-kvs#event_report_l2#hbm#10.0.0.8:9000
-kvs#event_report_l2#mem#10.0.0.8:9000
+- 一个请求最多一个 snapshot；
+- snapshot 不能与 ADD、DELETE、HOST_DOWN 混合；
+- 每个 `block_key + medium` 的 specs 必须完整；
+- 同一 medium 不允许重复 block key；
+- 相同 block key 可以出现在不同 medium；
+- snapshot 不能拆成多个普通请求分页。
+
+### 4.4 响应
+
+```proto
+string committed_snapshot_version = 3;
+uint64 retry_after_ms = 4;
+bool snapshot_required = 5;
+string extra_info = 6;
 ```
 
-v1 更新到 v2 时，直接覆盖同一个 block 下该 stable location 的完整 specs。
+`committed_snapshot_version` 是当前进程内 reconciliation generation：
 
-明确删除下面的 copy-on-write 形式：
+- 第一条 ADD/DELETE 可以创建；
+- snapshot 成功后更新；
+- KVCM 刚重启且还没有新 mutation 时为空。
 
-```text
-kvs#<event_report_type>#<medium>#snapshot_v=<version>#<reporter host_ip_port>
-```
+`snapshot_required` 兼容现有响应字段：
 
-实现中不再需要：
+- 当前进程尚无 generation 时为 true；
+- 第一条通过校验并获得写 lease 的增量，或成功 snapshot，建立 generation 后为 false；
+- 它不是增量准入条件；
+- realtime-only 客户端可以忽略；
+- snapshot-capable 客户端可把它当作“方便时补一次全量”的提示。
 
-- versioned location id 的构造和解析；
-- 新旧两代 location 并存；
-- `BatchReplaceLocationSpecs` 的 create/replace 两阶段；
-- 以 location generation 实现可见性切换。
+## 5. 增量处理
 
-Snapshot 写入使用单阶段的“按 stable location 覆盖完整 specs”操作。底层跨 key 仍不是事务，失败语义见第 10 节。
+ADD/DELETE：
 
-### 6.2 URI 只追加 s_version
+1. 校验请求、block、medium、spec name 和 URI；
+2. 若当前进程尚无 reporter 节点则懒初始化；若命中 HOST_DOWN/grace tombstone 则拒绝；
+3. 获取 delta lease；若 snapshot 正在执行则等待其 commit/abort；
+4. 如果尚无 committed generation，在锁内生成一个不可复用的 opaque version；
+5. ADD URI 追加该 `s_version`；
+6. ADD 按 spec name 合并，DELETE 按 spec name 删除；
+7. 请求完成后释放 lease。
 
-KVCM 只在 reporter URI 上追加一个参数：
+`host_ip_port` 和 `medium` 会进入以 `#` 分隔的稳定 location id，因此必须非空且不能包含
+`#`。这项校验在创建节点、解析 ReportEvent 和构造 location id 三层执行，避免写入一个后续
+无法归属到 reporter 的 location。
 
-```text
-s_version=<opaque version>
-```
+Generation 在获得 delta lease 时建立。参数校验、tombstone 等准入失败不会创建 generation；
+获得 lease 后如果 metadata 写入失败，generation 可以保留。这不会伪装事件成功：
+`header.status`/`item_results` 仍返回真实写入结果，generation 只承担后续 URI 标记和对账。
 
-例如：
+同一请求中的增量按请求顺序解释。相同
+`(block_key, medium, spec_name)` 多次出现时，最终操作覆盖前序操作。
 
-```text
-rtp-llm://10.0.0.8:9600/hbm/101?s_version=018f4e3c-7d91-7b12-a3c4-5d6e7f809abc
-```
+当 KVCM 重启后第一条增量使用新 generation 时，同一 location 中未被本次增量触碰的旧 specs
+必须保留，只覆盖本次明确上报的 spec name。否则一次局部 ADD 会误删同 block 的其他 cache
+信息。
 
-instance、reporter 和 medium 已经分别存在于请求上下文、stable location id 和 `BlockSnapshotItem` 中，不需要在每个 spec URI 里重复保存。
+## 6. Snapshot 处理
 
-要求：
+1. 在关闭写门前完成全部校验；
+2. 若当前进程尚无 reporter 节点则懒初始化；若命中 tombstone 则拒绝；
+3. 检查 per-reporter 最小 snapshot 间隔；
+4. `BeginSnapshot` 生成 candidate version，关闭新 delta 入口；
+5. 等待已获得 lease 的 delta 完成；
+6. 为本次全部 URI 追加 candidate `s_version`；
+7. 使用稳定 location id 原地替换完整 specs；
+8. 对本次 block keys 执行 `Sync`；
+9. 更新内存 committed generation并打开写门；
+10. 返回新的 `committed_snapshot_version`；
+11. 异步扫描并回收该 reporter 的旧 generation。
 
-- `s_version` 是 KVCM 保留参数，reporter 输入预带该参数时拒绝；
-- 同一个 location 内的 specs 必须使用相同 `s_version`；
-- 参数缺失、重复、非法或不等于当前 committed version 时 fail closed；
-- reporter 身份与版本校验使用请求 instance 和 stable location id，不从物理 URI host 反推。
+不同 reporter、不同 storage type 可以并行。第二个并发 snapshot 返回
+`SNAPSHOT_IN_PROGRESS`。
 
-版本过滤的主路径放在同时拿得到 `instance_id + location_id + LocationSpec` 的
-MetaSearcher/CacheManager 查询层。`EventReportBackend::MightExist` 只有 URI 输入，不能从
-物理 URI host 猜 reporter；EventReportBackend 因此在内存中维护
-`committed token -> (instance_id, reporter)` 反查关系。`MightExist` 只有在 token 当前已提交、
-所属 reporter 已注册且节点 available 时才返回 true；缺少 token、未知 token、KVCM 重启后
-token 未重建或节点已下线均 fail closed。
+`BeginSnapshot` 在持有节点状态锁时再次确认 reporter 运行时节点仍存在。这样即使请求层检查后并发
+发生 HOST_DOWN/UNREGISTER，也不能重新创建一个脱离节点生命周期的 snapshot state。
 
-## 7. Version 只保存在内存
+Snapshot 期间到达的 ADD/DELETE 会等待。Snapshot 完成后，它们基于新的 generation 继续
+写入，因此不会被刚完成的全量覆盖。
 
-`EventReportBackend` 按 `(instance_id, reporter host_ip_port)` 保存当前 committed version，不再写入 instance metadata。
+## 7. Snapshot 失败
 
-版本仍使用不可复用的 opaque token，推荐 UUIDv7/128-bit：
+Snapshot 使用稳定 location id 原地覆盖，不做 copy-on-write。
 
-- 查询只比较 `s_version == committed version`；
-- Reclaimer 只比较 `s_version != committed version`；
-- Subscriber 不依赖 version 大小排序；
-- KVCM 重启后生成的新 token 不会碰巧复用旧 token。
+如果部分 replace、Sync 或 commit 失败：
 
-不能在重启后从 1 重新计数。否则旧 metadata 中相同数字的 `s_version` 可能被重新激活。随机且不可复用的 token 解决这个问题，同时不需要 committed marker 或 allocated high-water。
+- candidate 不成为 committed generation；
+- snapshot abort，等待中的 delta 继续；
+- 已经写入的部分 metadata 不回滚；
+- 已写入的新候选和未覆盖的旧候选都可能被查询；
+- 不为失败 snapshot 单独启动 cleanup；
+- 客户端可完整重试，后续成功 snapshot 最终收敛。
 
-KVCM 重启后：
+这是有意的缓存可用性取舍。
 
-1. 内存 committed version 为空；
-2. 所有历史 event-report location 暂时不可见；
-3. 所有 reporter 被标记为 `snapshot_required`；
-4. reporter 必须重新发送一份完整 host snapshot；
-5. snapshot 成功后发布新 token，并触发旧数据清理。
-
-系统明确依赖 reporter 在 KVCM 重启后重新汇报，不从 Redis 恢复 snapshot version，也不扫描 block 猜 version。
-
-## 8. Response：明确返回 committed version
-
-`ReportEventResponse` 增加：
-
-```protobuf
-string committed_snapshot_version = 4;
-uint64 retry_after_ms = 5;
-bool snapshot_required = 6;
-```
-
-语义：
-
-- snapshot 成功：返回本次新 token；
-- snapshot 失败或 partial：返回失败前的 committed token；
-- ADD、DELETE、REGISTER、HEARTBEAT：返回该 reporter 当前 committed token；
-- KVCM 启动后尚未收到该 reporter 的完整 snapshot：version 为空且 `snapshot_required=true`；
-- 被频率限制时：同时返回当前 committed token 和建议等待时间。
-
-Subscriber 以响应字段为准，不从 URI、时间戳或本地计数猜测 KVCM 当前版本。
-
-`ReportEvent` 是批量接口，RPC 顶层 `ErrorCode` 只表达整批请求的聚合结果：同一批里既有成功事件又有需要重试的事件时可能返回 `EC_PARTIAL_OK`。Subscriber 不应把顶层 `EC_OK/EC_PARTIAL_OK` 当作 snapshot 是否 commit 的唯一依据；必须同时检查逐 event 结果以及 `committed_snapshot_version`、`snapshot_required`、`retry_after_ms`。特别地，只有返回的 committed token 与本次 snapshot ACK 对齐，才能认为本次 snapshot 已提交。
-
-同一批内对相同 `(block, location, spec name)` 的多次 ADD/DELETE 会按数组顺序折叠为最后一个操作，
-中间状态不会独立持久化。被折叠的原始 events 共享最终 metadata mutation 的逐 event 结果：
-最终写入成功时它们均成功，最终写入失败时它们均失败。不能把前序 event 的成功理解为其中间
-状态曾经对查询可见。
-
-如果 mutation 已提交但 ACK 丢失，单写 Subscriber 重试时可以通过返回的 committed token 与自己的上一次已知 token 对比。即使无法确认，也可以稍后重发完整 snapshot，最终状态仍会收敛。
-
-若运维需要不发 mutation 就读取 version，应在现有 host-state 查询接口中显式返回，而不是扫描 URI。
-
-## 9. 写入与提交流程
-
-```mermaid
-sequenceDiagram
-    participant S as Subscriber
-    participant C as CacheManager
-    participant E as EventReportBackend
-    participant M as Meta Index
-    participant R as Existing Reclaimer
-    participant Q as Query
-
-    S->>C: EVENT_BLOCK_SNAPSHOT(all media)
-    C->>C: 校验完整 host snapshot
-    C->>E: 检查频率并关闭该 reporter 的增量写门
-    E-->>C: 生成 opaque version N
-    C->>M: stable location 原地覆盖，URI s_version=N
-    C->>M: Sync 本次全部 keys
-    C->>E: 发布内存 committed=N
-    C-->>S: committed_snapshot_version=N, snapshot_required=false
-    C->>R: 提交旧 location 删除任务
-    Q->>M: 只返回 URI s_version=N
-```
-
-严格顺序：
-
-1. 完整校验 snapshot；
-2. 检查该 reporter 的最小 snapshot 间隔；
-3. 关闭 `(instance_id, reporter)` 的增量写门，并等待已经进入的增量结束；
-4. 生成不可复用 version N；
-5. 为全部 block 构造带 N 的 URI；
-6. 按 stable location 单阶段覆盖完整 specs；
-7. `Sync` 本次涉及的全部 keys；
-8. 更新内存 committed=N，并清除 `snapshot_required`；
-9. 返回 N；
-10. 扫描旧 location，并把删除请求提交给既有 reclaimer supervisor。
-
-步骤 8 是发布点：
-
-- 之前查询只认可旧 committed；
-- 之后查询只认可 N；
-- 清理只能在 committed=N 成功后启动。
-
-## 10. 原地覆盖与失败语义
-
-本设计不再承诺 copy-on-write 的“失败时旧快照仍完整可读”。
-
-假设当前 committed=C，新 snapshot=N：
-
-- 已覆盖成 N 的 block 在 commit 前会被查询过滤；
-- 尚未覆盖的 block 仍可能以 C 可见；
-- 全部写入和 Sync 成功后才发布 N；
-- N 发布后，本次上报的 N 数据可见；
-- 未上报或失败残留的非 N 数据被过滤，随后由 reclaimer 删除。
-
-失败矩阵：
-
-| 失败位置 | committed 是否变化 | 查询表现 | 后续动作 |
+| 失败点 | committed generation | 查询表现 | 后续 |
 | --- | --- | --- | --- |
-| 校验失败 | 否 | 旧版本不变 | 修正请求 |
-| 频率限制 | 否 | 旧版本不变 | 按 `retry_after_ms` 重试 |
-| version/URI 准备失败 | 否 | 尚未写 metadata | 修正或重试 |
-| 原地覆盖部分失败 | 否 | 已覆盖的 N 不可见，其余 C 可能可见 | 重试完整 snapshot |
-| Sync 失败 | 否 | 同上 | 重试完整 snapshot |
-| 内存发布前进程崩溃 | 否 | 重启后所有旧数据不可见 | reporter 重新上报 |
-| 内存发布后进程崩溃 | 本进程已变，重启后清空 | 重启后所有旧数据不可见 | reporter 重新上报 |
-| ACK 丢失 | 是 | N 已可见 | 查询响应 version 或重发完整 snapshot |
-| 清理中崩溃 | 是 | N 可见，旧数据不可见但占空间 | 下次 snapshot 再触发清理 |
+| 参数校验 | 不变 | 原数据不变 | 修正请求 |
+| 频率限制 | 不变 | 原数据不变 | 按 `retry_after_ms` 重试 |
+| 部分 replace | 不变 | 新旧候选可能共存 | 完整重试 |
+| Sync/commit | 不变 | 已写候选仍可能可见 | 完整重试 |
+| cleanup 中断 | 已更新 | 旧候选继续可见 | 下次 snapshot 再清理 |
 
-安全属性是“未提交 token 不会被当成当前 token”，不是“失败后旧快照始终完整”。
+## 8. 查询规则
 
-Cache 不是唯一副本，短暂的 cache miss 只会退化为重新计算或远端加载，因此该取舍可接受。
+业务查询 event-report location 时：
 
-## 11. 查询规则
+1. 按 instance 和 storage type 找到 `EventReportBackend`；
+2. 从稳定 location id 解析 `medium + host_ip_port`；
+3. reporter 必须已注册且 available；
+4. location 至少包含一个 spec；
+5. 每个 URI 必须合法；
+6. URI 如果有 `s_version`，该值必须唯一且格式合法。
 
-查询 event-report location 时检查：
+查询接受：
 
-1. 查询上下文提供 instance；
-2. stable location id 能否解析出 medium 和 reporter；
-3. URI 的 `s_version` 是否等于该 reporter 的内存 committed token；
-4. reporter 是否已经完成重启后的必需 snapshot；
-5. reporter 节点是否可用。
+- 无 `s_version` 的历史 URI；
+- 旧 generation；
+- 当前 generation；
+- snapshot in-flight generation；
+- 同一 location 内混合的多个合法 generation。
 
-任一条件不满足，该 location 不可见。
+任一 spec malformed 时整个 location fail closed。
 
-兼容规则：
+公共查询路径通过 `CacheManager` 的 location-aware checker 执行上述规则，它同时拥有
+instance、storage type 和稳定 location id 上下文。`EventReportBackend::MightExist` 是底层
+无这些上下文的保守接口，只能验证能够由当前 token 反查 owner 的 URI，不能用它替代公共查询
+的 generation 兼容规则。
 
-- 新部署且尚未启用 snapshot 的 legacy reporter，可以通过显式兼容开关读取无 `s_version` 的历史增量数据；
-- 支持 snapshot 的 reporter 在 committed 为空或 `snapshot_required=true` 时不返回任何旧 location；
-- host 完成 snapshot 后，只接受当前 committed token；
-- snapshot 后的 ADD/DELETE 必须继承当前 committed token；
-- URI 使用未知 token，即使格式合法也不可见。
+## 9. KVCM 重启
 
-查询过滤负责即时正确性；Reclaimer 只负责空间回收。
+进程重启后：
 
-## 12. 全量更新期间阻塞增量
+1. 持久化的 Instance/InstanceGroup 和 cache metadata 恢复，进程内节点表和 committed
+   generation 为空；
+2. 收到 reporter 的第一条合法事件前，历史 metadata 因缺少 liveness 状态而不可见；
+3. 第一条 HEARTBEAT、ADD、DELETE 或 SNAPSHOT 自动重建 reporter，不要求客户端再次 REGISTER；
+4. 如果第一条是 HEARTBEAT，响应 `snapshot_required=true`、
+   `committed_snapshot_version=""`，格式合法的历史 metadata 可以重新查询；
+5. 如果第一条是 ADD/DELETE，它正常成功并创建新 generation；
+6. 该增量只覆盖明确触碰的 spec，不清理其他历史 block；
+7. 后续实时增量继续刷新热点数据；
+8. 若客户端支持 snapshot，可在方便时发送一次完整全量，最终清理旧 generation；
+9. 若客户端只支持实时事件，也可一直运行，允许少量未触碰历史 metadata 保留。
 
-### 12.1 Reporter 写门
+第一条新汇报可能让 Redis 中尚未清理的旧 metadata 再次可见。因此新推理进程复用完全相同
+的 reporter identity 时，建议旧进程发送 HOST_DOWN；同一 KVCM 进程内的 tombstone 会要求
+新进程显式 REGISTER。若 KVCM 也已重启、tombstone 丢失，则依赖 cache miss 容错，并建议
+新进程在具备能力时做一次 snapshot。
 
-同一 `(instance_id, reporter)` 的 snapshot 和 ADD/DELETE 共用一把写门，执行顺序如下：
+## 10. 并发
 
-1. CacheManager 先在内存完成字段校验、重复 block 检查、URI 解析和请求规范化。非法请求
-   不关闭写门，也不影响正常增量；
-2. `BeginSnapshot` 检查限频、生成 candidate token，并立即标记 snapshot in flight，关闭
-   后续增量入口；
-3. 已经取得 lease 的增量继续完成，snapshot 等待 `active_delta_mutations` 降为 0；
-4. 此后到达的 ADD/DELETE 在条件变量上等待，不向 Subscriber 返回 busy 错误；
-5. snapshot 只在写门关闭期间追加 `s_version`、批量覆盖 metadata、`Sync` 并发布 token；
-6. commit 或 abort 都重新打开写门并唤醒等待者。commit 后的增量继承新 token，abort 后的
-   增量继续使用旧 token；
-7. cleanup 扫描和 reclaimer 任务在写门打开后异步执行，绝不能延长阻塞时间。
-
-不同 instance 或 reporter 使用不同写门，可以并行。第二个并发 snapshot 不排队，因为两份
-全量事实没有可靠的先后 watermark；它返回 `SNAPSHOT_IN_PROGRESS`，由 Subscriber 合并或
-稍后重发最新的一份。
-
-写门内路径必须尽可能短，不能执行请求解析、全量 cleanup 扫描、reclaimer 删除、监控上报
-或人为退避。阻塞保证的是同一写入者的全量与增量不会互相覆盖，不是跨 reporter 的全局锁。
-
-### 12.2 仍需区分的错误
-
-协议保留以下 snapshot 专用错误：
-
-```protobuf
-SNAPSHOT_IN_PROGRESS = 11;
-reserved 12; // 曾为 DELTA_IN_PROGRESS；delta 现在等待写门，不再返回 busy
-SNAPSHOT_RATE_LIMITED = 13;
-SNAPSHOT_REQUIRED = 14;
-```
-
-返回规则：
-
-- 第二个 snapshot 与当前 snapshot 冲突时返回 `SNAPSHOT_IN_PROGRESS`；
-- 距离上次成功 snapshot 太近时返回 `SNAPSHOT_RATE_LIMITED` 和 `retry_after_ms`；
-- reporter 尚未 REGISTER 时，HEARTBEAT、snapshot 和 delta 返回 `NODE_NOT_REGISTERED`；
-- “是否注册”和“当前是否可用”是两个状态：snapshot/delta 的准入只要求 reporter 已注册；
-  heartbeat 超时期间即使收到 metadata 更新，查询仍由 liveness 检查保持不可见，后续
-  HEARTBEAT 恢复可用性后才重新可见；
-- KVCM 重启后、reporter 尚未重建基线时，REGISTER/HEARTBEAT 响应携带
-  `snapshot_required=true`，ADD/DELETE 返回 `SNAPSHOT_REQUIRED`；
-- 字段非法返回 `INVALID_ARGUMENT`；存储故障返回 `INTERNAL_ERROR` 或对应 IO 错误。
-
-Subscriber 对 rate limit 按 `retry_after_ms` 等待，对 snapshot required 立即拉取并上报完整
-snapshot，对 invalid argument 不做无限重试。失败重试必须重发完整 snapshot。
-
-## 13. 尽可能少触发 Snapshot
-
-Snapshot 是修复基线的低频手段，不是常规轮询接口。Subscriber 只应在以下情况触发：
-
-1. 首次启动，需要在发送增量前建立完整基线；
-2. KVCM 重启并返回 `snapshot_required=true`；
-3. Subscriber 检测到事件断档、乱序，或已经无法信任本地增量基线；
-4. 运维明确要求进行一次全量纠偏；
-5. 可选的超低频周期兜底，必须带随机抖动，且不应替代事件断档检测。
-
-正常 ADD/DELETE、HEARTBEAT、REGISTER 刷新和每次本地 cache 变化都不能触发 snapshot。
-
-`EventReportBackend` 仍为每个 reporter 维护可配置的最小 snapshot 间隔
-`EventReportStorageSpec.snapshot_min_interval_ms`：
+同一 reporter 共用写门：
 
 ```text
-snapshot_min_interval = 30s  // 默认值，可配置
+已有 delta 获得 lease
+        |
+snapshot 关闭新 delta 入口
+        |
+等待已有 delta 完成
+        |
+snapshot replace + Sync + commit/abort
+        |
+打开入口，等待中的 delta 继续
 ```
 
-语义：
-
-- 首次 snapshot 不受限；
-- 间隔从上一次成功 commit 计算，不从失败尝试计算；
-- 写入或 Sync 失败后允许立即重试；
-- REGISTER/HEARTBEAT/ADD/DELETE 不受 snapshot interval 限制；
-- KVCM 返回剩余 `retry_after_ms`；
-- Subscriber 仍应增加随机抖动，避免多个 host 整点同时上报。
-
-30 秒只是防止 Subscriber bug 或错误配置压垮 Redis 的安全下限，不是建议的 snapshot 周期。
-正常运行时 snapshot 间隔应远大于该值，并优先由异常和恢复事件触发。
-
-频率状态不持久化。KVCM 重启后必须先完成一次重建 snapshot，这次 snapshot 不受重启前的间隔限制；之后重新开始内存计时。
-
-## 14. 清理复用现有 Reclaimer
-
-### 14.1 不新增 snapshot 专用调度器
-
-删除独立的 `ScheduleStaleSnapshotCleanup`、latest-version 合并表和专用退避重试状态。
-
-snapshot commit 成功后：
-
-1. 使用现有 MetaIndexer 分页扫描该 instance 的 block metadata；
-2. 找出属于该 reporter、URI `s_version` 不等于 committed=N 的 location；
-3. 按现有 `CacheLocationDelRequest` 或等价删除请求分批；
-4. 提交给现有 `reclaimer_task_supervisor_->Submit(...)`；
-5. 删除、`EC_NOENT`、容量扣减和实际 metadata mutation 复用现有 reclaimer 路径。
-
-Reclaimer 不解析 token 大小，只比较是否等于当前 committed token。
-
-因为 location id 会被下一轮 snapshot 原地复用，扫描结果不能变成无条件删除。扫描时先
-同时读取 committed 和 in-flight token，当前 in-flight 数据一律不选为清理目标；清理任务
-还会携带扫描时观察到的序列化 location 值。既有 reclaimer 在把 location 从 `SERVING`
-改成 `DELETING` 前做 compare-and-set。若下一轮 snapshot 已经刷新 specs、version 或状态，
-比较失败，本次旧清理跳过该 location。两层保护保证 cleanup 与下一轮 snapshot 重叠时也
-不会按旧的扫描结果删除新版本。
-
-### 14.2 崩溃与重试
-
-- 清理失败不影响查询正确性；
-- 清理过程中 KVCM 崩溃，残留数据继续被 version filter 隐藏；
-- 下一次成功 snapshot 再扫描并提交删除；
-- HOST_DOWN 继续复用现有 host cleanup 与 node generation fencing；
-- 不为 snapshot 另建内存重试队列；
-- 现有 reclaimer 自身已有的任务保障可以复用，但本文不叠加第二套退避。
-
-### 14.3 当前不引入反向索引
-
-第一期不新增持久化 `location_id -> block_key set`，避免引入 Redis 双写一致性和恢复复杂度。
-
-代价是每次 snapshot commit 后清理需要扫描 instance 的 `N` 条 block metadata。扫描是低频后台任务，查询正确性不依赖它。
-
-必须监控扫描耗时、读取量和 backlog；当它持续超过阈值时，再以数据决定是否引入可 rebuild 的反向索引。
-
-### 14.4 只删除 metadata
-
-本 Reclaimer 删除 KVCM 中陈旧的 location/meta 引用。
-
-物理 Cache Store 中 KV tensor 的释放仍由 Engine/Cache Store 生命周期负责。若未来需要 KVCM 主动删除远端物理 cache，应设计独立的鉴权、确认、幂等和重试协议。
-
-## 15. 节点生命周期与恢复
-
-- REGISTER：建立 reporter 和 medium 能力；若该 reporter 尚无本轮 KVCM 进程内 committed token，返回 `snapshot_required=true`；
-- HEARTBEAT：更新可用性，并持续返回当前 `snapshot_required` 状态；
-- SNAPSHOT：成功后发布新 token，设置 `snapshot_required=false`；
-- ADD/DELETE：仅在 `snapshot_required=false` 时接受；
-- HOST_DOWN/UNREGISTER：先让 reporter 对查询不可用，再复用现有 reclaimer 删除全部 location；
-- 快速重新注册使用 node generation 防止旧 HOST_DOWN 任务误删新数据。
-- liveness cleanup 选中 reporter 后、实际扫描前若 HEARTBEAT 在 grace 期内恢复，恢复动作先推进
-  node generation 再返回成功；旧 generation 的 cleanup 和最终 unregister 都必须退出，不能出现
-  “HEARTBEAT 已返回成功，旧任务随后又删除节点”的结果。
-
-KVCM 重启后的恢复协议：
-
-1. EventReportBackend 的 committed token 表为空；
-2. 已恢复或重新注册的所有 reporter 都处于 `snapshot_required=true`；
-3. 查询不返回这些 reporter 的历史 event-report location；
-4. REGISTER/HEARTBEAT 明确通知推理节点或 Subscriber 重新汇报；
-5. ADD/DELETE 返回 `SNAPSHOT_REQUIRED`，避免用增量错误地建立不完整基线；
-6. reporter 拉取全部 medium 的权威集合并发送 snapshot；
-7. snapshot commit 后查询恢复，并复用 reclaimer 清理全部旧 token 数据。
-
-恢复成本不依赖 block scan，也没有 version metadata 的一致性问题。代价是 KVCM 每次重启都会产生一轮全量 snapshot 流量，因此重启和 leader 切换需要做 reporter 抖动与并发限流。
-
-## 16. 性能与容量估算
-
-### 16.1 典型场景
-
-假设：
-
-- 1 个 instance；
-- 10 个 reporter host；
-- 每台 5000 个 block；
-- 每个 block 一个 event-report location、一个 spec；
-- snapshot 最快每 30 秒一次；
-- 每轮 5% block 发生淘汰；
-- metadata scan 每页 256 个 block。
-
-一次“10 台 host 都完成 snapshot”的逻辑工作量：
-
-| 项目 | 数量 |
-| --- | ---: |
-| stable location 覆盖 | 10 × 5000 = 50,000 block writes |
-| committed token 内存发布 | 10 次（无 Redis marker 写） |
-| cleanup 扫描 | 每 host 扫 50,000，合计 500,000 block inspections |
-| scan page 请求 | ceil(50,000 / 256) × 10 ≈ 1,960 次 |
-| 旧 location 删除（按 5%） | 10 × 250 = 2,500 次 |
-
-摊到 30 秒窗口的逻辑平均值：
-
-| 项目 | 平均值 |
-| --- | ---: |
-| block 覆盖 | ≈ 1,667/s |
-| scan page | ≈ 65/s |
-| stale delete | ≈ 83/s |
-
-这些是“逻辑 metadata 操作”，不等于实际 Redis 网络 round trip。批量 HSET、pipeline 和 reclaimer batch 会减少 round trip，但不会减少序列化字节数和 block inspection 数。version 本身不产生 Redis marker 写入。
-
-如果每个 host snapshot 串行写入 5000 blocks 的实测吞吐是 10,000 logical writes/s，则纯写入约 0.5 秒；若后台扫描吞吐是 20,000 blocks/s，则扫描 50,000 blocks 约 2.5 秒。它们只是容量估算基线，最终以压测的 P50/P95/P99 为准。
-
-所有 host 必须加随机抖动。否则 30 秒整点同时到达会形成 50,000 写入和 10 个全量扫描的瞬时尖峰。
-
-KVCM 重启会要求 10 个 host 全部重新 snapshot，相当于至少触发一轮上述 50,000 block writes。启动恢复必须设置最大并发或令 Subscriber 按 `retry_after_ms` 抖动上报，不能让所有 host 同时重建。
-
-### 16.2 监控阈值与反向索引信号
-
-至少监控：
-
-- snapshot block 数、写入耗时、Sync 耗时、commit 耗时；
-- cleanup 扫描 keys、pages、bytes 和耗时；
-- cleanup 删除数量；
-- reclaimer queue wait、执行耗时和 backlog；
-- snapshot rate-limit 次数；
-- Redis QPS、带宽、pipeline 大小和 latency。
-
-以下任一情况持续多个窗口时，应评估引入可 rebuild 的 `location_id -> block_key set`：
-
-- `snapshot_cleanup_scan_latency_p99 > 10s`；
-- 同一 reporter 的上一轮 cleanup 尚未结束，下一轮 snapshot 已到达；
-- cleanup backlog 持续超过正常的低频 snapshot 间隔；
-- cleanup scan 占 Redis 读请求或带宽超过 20%；
-- instance 增长导致 `N / host_blocks` 很大，扫描绝大部分数据都与目标 host 无关。
-
-反向索引是性能优化，不是查询正确性的前提。
-
-## 17. 兼容性与灰度
-
-- stable location id 与历史 ADD/DELETE 一致；
-- URI 只增加 KVCM 生成的 `s_version`；
-- response 新字段对旧 protobuf 客户端向后兼容；
-- Java 与 C++ proto 同步；
-- Snapshot 协议尚未发布，直接调整 item 字段顺序并删除外层 medium，不保留 reserved；
-- `EVENT_BLOCK_DELETE.spec_names` 兼容策略独立评审；
-- legacy 无 snapshot reporter 的兼容读取必须由显式开关控制；
-- 支持 snapshot 的 reporter 在 KVCM 重启后必须重新上报一次。
-
-灰度顺序：
-
-1. 先部署理解 `s_version`、snapshot-required 恢复协议、专用错误码和 response version 的 KVCM；
-2. 再部署能产生单个跨 medium host snapshot 的 Subscriber；
-3. 小流量开启启动 snapshot；
-4. 仅在需要时开启带随机抖动的超低频兜底对账；
-5. 观察 partial、rate-limit、cleanup scan 和 reclaimer backlog。
-
-## 18. 测试计划
-
-### 18.1 单元测试
-
-Reporter 与协议：
-
-- 内部状态按 instance/reporter 隔离，不暴露额外协议对象；
-- 一个 snapshot 同时包含 HBM/Memory/Disk；
-- medium 从 block 读取；
-- item 字段为 block_key=1、medium=2、specs=3，外层 blocks=1；
-- `(medium, block_key)` 重复被拒绝；
-- 不同 host、instance 隔离；
-- 不存在 snapshot version metadata marker。
-
-Location、URI 与 token：
-
-- 两轮 snapshot 的 location id 完全不变；
-- versioned location 构造/解析接口不存在；
-- URI 只追加 `s_version`；
-- reporter 从查询上下文与 stable location id 获取，不依赖物理 URI host；
-- UUID/token 不复用；
-- `s_version` 重复、非法或不匹配时 fail closed；
-- snapshot-required 状态下旧数据全部不可见。
-- 同 token 的 ADD 按 spec name 合并，历史 token 和无 token 的残留 spec 不会混入当前版本；
-- 同一批内同一 spec 的 ADD/DELETE 严格按事件数组顺序收敛，最后一个操作获胜；
-
-提交与恢复：
-
-- URI prepare、overwrite、Sync、内存 publish 各阶段故障注入；
-- 原地覆盖部分失败不推进 committed；
-- 失败后用新 token 完整重试收敛；
-- 响应成功返回新 token，失败返回旧 token；
-- 重启不恢复 token，全部 reporter 进入 snapshot-required；
-- REGISTER/HEARTBEAT 能通知节点重新汇报；
-- 未 REGISTER 与已 REGISTER 但缺 snapshot 分别返回 `NODE_NOT_REGISTERED` 和
-  `SNAPSHOT_REQUIRED`；
-- 已完成 snapshot 后，重复 REGISTER 和 HEARTBEAT 不清空 committed token；
-- 完整 snapshot 前 ADD/DELETE 被拒绝。
-
-并发、错误码和限流：
-
-- snapshot in flight 时，新 delta 阻塞，commit 后继承新 token；
-- snapshot in flight 时，新 delta 阻塞，abort 后继承旧 token；
-- delta 写入已开始后 snapshot 等待其完成，随后完整 snapshot 覆盖该增量；
-- snapshot 部分覆盖失败并 abort 后，新 delta 继续使用旧 token，下一次完整 snapshot 收敛；
-- active delta 未结束时 snapshot 先关闭新 delta 入口，再等待 active delta drain；
-- 第二个并发 snapshot 返回 `SNAPSHOT_IN_PROGRESS`；
-- 成功 snapshot 后 30 秒内返回 `SNAPSHOT_RATE_LIMITED`；
-- 重启后 delta 返回 `SNAPSHOT_REQUIRED`；
-- 失败 snapshot 可立即重试；
-- 不同 instance/reporter 并行；
-- `retry_after_ms` 递减且边界正确。
-- HOST_DOWN 与已进入 metadata 写入的 snapshot/delta 并发时不死锁；节点立即对查询不可见，
-  未完成 snapshot 不能发布 token；
-- backend Close/Unregister 能唤醒等待 delta drain 或 snapshot gate 的 waiter；
-- liveness 已选中 cleanup、回调尚未执行时 HEARTBEAT 恢复会推进 generation，旧 cleanup
-  不能再 unregister 已恢复节点。
-
-Reclaimer：
-
-- commit 后通过现有 supervisor 收到删除任务；
-- 删除旧 token、遗漏 block 和遗漏 medium；
-- 不删除当前 token、其他 host 或 instance；
-- `EC_NOENT` 幂等；
-- 清理中断后查询仍正确；
-- 下一次 snapshot 再触发残留清理；
-- cleanup 扫描后 location 被下一轮 snapshot 原地刷新时，条件删除必须跳过新值；
-- cleanup 提交给现有 reclaimer 时携带扫描时观察到的完整 location 值；
-- cleanup 扫描遇到下一轮 snapshot 的 in-flight token 时不能把它选为旧数据；
-- 不存在 snapshot 专用调度/退避状态。
-
-### 18.2 集成测试
-
-- reporter 一次上报 HBM+Memory，响应返回 committed token；
-- 首次 snapshot、实时 ADD/DELETE/HEARTBEAT、下一轮 snapshot 对账和后续实时增量串成一条完整链路，
-  每个阶段查询结果与 committed token 一致；
-- 6000-block 初始 snapshot 与 ADD/DELETE/HEARTBEAT 并发，竞争 snapshot 返回 busy，metadata mutation
-  在 commit 后继承新 token；16 个并发 ADD 更新同一 stable location 时不丢命名 spec；
-- 查询只看到本次完整 host snapshot；
-- 下一轮遗漏 block/medium 后立即不可见，随后由现有 reclaimer 删除；
-- snapshot 后 ADD/DELETE 继承 token；
-- ADD/DELETE 至少一次重试保持幂等，批内单个非法事件不回滚同批已成功的合法增量；
-- 同一批对同一 spec 执行 DELETE→ADD、ADD→DELETE 和 ADD→DELETE→ADD 时，最终状态分别
-  与最后一个事件一致；
-- 未注册 reporter 的 HEARTBEAT/snapshot/delta 返回 `NODE_NOT_REGISTERED`，注册后但完整
-  snapshot 前的 delta 返回 `SNAPSHOT_REQUIRED`；
-- snapshot 拒绝同 medium 下规范化后重复的 block key，同时允许相同 block key 位于不同 medium；
-- busy、rate-limit、snapshot-required 与 invalid argument 错误可区分；
-- Sync/内存发布前故障后 token 不变化，完整重试恢复；
-- KVCM 重启后旧数据不可见，所有 reporter 被通知重新 snapshot；
-- 自动 heartbeat timeout 通过真实 liveness loop 使当前 token 不可见；grace 内恢复后原 committed
-  token 重新可见，超过 grace 后 REGISTER/HEARTBEAT 不能恢复旧 token，必须提交新 snapshot；
-- 同 instance 两个 host 只过滤超时 host；相同 host 的两个 instance 只过滤超时 instance；
-- batch 查询同时包含当前 token、旧/未知 token、宕机 reporter 和缺失 block 时，返回数量、顺序及
-  每项可见性准确；
-- reporter 完成 snapshot 后查询恢复、旧数据被清理；
-- 清理中 kill KVCM，重启后旧数据仍不可见，下次 snapshot 可清理；
-- 10 host × 5000 blocks 压测记录 Redis ops、commit latency、scan latency 和 backlog；
-- ASAN/TSAN 或等价并发检测覆盖 snapshot/delta/reclaimer。
-
-真实进程重启用例由 `test_report_event_restart.py` 分成两个阶段执行，并为 registry 与
-普通 instance metadata 配置持久化存储（不持久化 snapshot token）：`prepare` 阶段建立
-snapshot 基线，测试驱动在进程外保存响应 token，随后停止并重新启动 KVCM 进程；
-`verify` 阶段复用原 instance，依次验证旧数据不可见、
-REGISTER 要求重建、重建前 delta 返回 `SNAPSHOT_REQUIRED`，以及新 snapshot 提交后查询
-恢复且 token 不复用。该用例必须真正跨越两个 KVCM 进程，不能用同进程内清空对象代替。
-测试驱动会根据 `--meta-storage-uri` 的 scheme 选择 `redis` 或 `local` backend；不能把
-Redis URI 配给 `local` backend，否则重启后 metadata 直接丢失会造成“旧数据不可见”的假阳性。
-
-## 19. 可观测性
-
-建议提供：
-
-- `snapshot_request_total{result}`；
-- `snapshot_block_count{medium}`；
-- `snapshot_write_latency_ms`；
-- `snapshot_sync_latency_ms`；
-- `snapshot_commit_latency_ms`；
-- `snapshot_fence_reject_total{operation,reason}`；
-- `snapshot_rate_limited_total`；
-- `snapshot_required_host_count`；
-- `snapshot_rebuild_total{reason,result}`；
-- `snapshot_stale_location_filtered_total{reason}`；
-- `snapshot_cleanup_scan_keys`；
-- `snapshot_cleanup_scan_pages`；
-- `snapshot_cleanup_scan_bytes`；
-- `snapshot_cleanup_scan_latency_ms`；
-- `snapshot_cleanup_delete_total`；
-- `snapshot_reclaimer_queue_wait_ms`；
-- `snapshot_reclaimer_backlog`。
-
-结构化日志至少包含 instance、reporter、committed token、candidate token、阶段和错误码。不要把 block key、reporter、token 等高基数字段放入常驻 metrics label。
-
-当前实现的 cleanup 任务会输出结构化扫描日志，包含 instance、reporter、committed token、扫描耗时和错误码；监控侧先由该日志提取 `snapshot_cleanup_scan_latency_ms` 与失败率。后续接入原生 metrics registry 时保持相同指标语义，不能把 token 或 reporter 放入 label。
-
-## 20. 正确性约束
-
-实现必须满足：
-
-1. 内部状态只按 instance_id + reporter host_ip_port 隔离，不引入额外协议对象；
-2. 一个 snapshot 覆盖 reporter 的全部 medium；
-3. medium 是 block 属性，不参与 version 和 fence；
-4. location id 不含 version；
-5. URI 只追加 `s_version`，instance/reporter 不在 URI 中重复编码；
-6. committed token 只保存在 EventReportBackend 内存，不写 instance metadata；
-7. token 不复用，未提交 token 永远不会被误激活；
-8. committed 只有在全部写入 Sync 成功后更新；
-9. 响应明确返回 committed token 与 snapshot-required 状态；
-10. KVCM 重启后旧数据不可见，所有 reporter 必须重新 snapshot；
-11. snapshot 先关闭增量写门并等待已有 delta，后续 delta 阻塞到 commit/abort；
-12. 并发 snapshot 返回专用可重试错误，snapshot 受 per-reporter 最小间隔保护；
-13. 旧数据删除复用现有 reclaimer；
-14. cleanup 使用观察值条件删除，不能删除后来写入同一 location id 的新版本；
-15. cleanup 失败不影响查询正确性；
-16. Subscriber 未拿到完整多介质事实时不能发送权威 snapshot。
-
-## 21. 非目标
-
-本文不提供：
-
-- 历史 snapshot 查询或回滚；
-- copy-on-write location；
-- allocated high-water marker；
-- committed version metadata marker；
-- KVCM 重启后直接恢复 event-report 查询；
-- snapshot 专用清理调度器和退避队列；
-- 第一阶段的持久化 location 反向索引；
-- 跨 block 线性一致读；
-- 多写 leader 分布式共识；
-- KVCM 主动删除远端物理 KV tensor。
-
-本设计以“完整 reporter snapshot + stable location + URI `s_version` + in-memory committed token + restart re-report + existing reclaimer”保证最终收敛，并明确接受原地覆盖失败和 KVCM 重启期间的短暂 cache miss。
+保证：
+
+- snapshot 不越过已开始的 delta；
+- snapshot 开始后到达的 delta 不会被本轮 snapshot 覆盖；
+- commit 后等待 delta 使用新 generation；
+- abort 后等待 delta 使用旧 generation；若此前没有旧 generation，则创建一个新 generation；
+- Close、Unregister、HOST_DOWN 唤醒 waiter，不死锁；
+- 旧节点 cleanup 只能删除扫描时看到的原值，不能删除重新 REGISTER 后刷新的稳定 location；
+- 不同 reporter 不共享写门。
+
+## 11. 限流与清理
+
+`EventReportStorageSpec.snapshot_min_interval_ms` 提供 per-reporter 最小 snapshot 间隔，默认
+30 秒。完整维度是：
+
+```text
+instance_id + storage_type + host_ip_port
+```
+
+只对成功 snapshot 开始计时；失败 snapshot 可立即重试；ADD、DELETE、REGISTER、HEARTBEAT
+不受限流影响。
+
+成功 snapshot 后复用现有任务执行器扫描 instance metadata：
+
+- 只处理目标 storage type 和 reporter；
+- event-report URI 描述外部 cache，reclaimer 只删除 KVCM metadata，不调用外部 URI
+  backend 的物理 DELETE；
+- location 内只要包含任一当前 committed generation 就保留；
+- 下一轮 snapshot 已开始时，location 内只要包含任一 in-flight generation 也保留；
+- 完全由旧 generation 或无 version legacy spec 组成的 location 作为 stale；
+- malformed version 的 location 作为 stale；
+- 使用观察值条件删除，避免旧 cleanup 删除刚刷新的新值。
+
+之所以按“任一 spec 匹配就保留”，是因为 delta 按 spec name merge，而 cleanup 只能按稳定
+location 删除。Snapshot commit 后、cleanup 扫描前到达的 delta 可能只把一个 spec 刷到新
+generation，其他 sibling 仍带旧 generation 或无 version 的 legacy URI；此时删除整个
+location 会造成成功增量的 false negative。保留 mixed-generation location 允许少量 stale
+sibling 暂存，后续完整 snapshot 会替换或回收。
+
+Cleanup 只负责最终空间回收，不是查询正确性的前提。扫描耗时记录为
+`event_report.snapshot_cleanup_scan_latency_ms{instance_id,host,type}`。
+
+容量估算：典型的 1 个 instance、10 个 reporter、每台 5000 个 block 场景中，一次单 reporter
+完整 snapshot 约有 5000 次 metadata replace，并以 1000 key 为批次扫描该 instance 约 5 万
+个 key；10 台同时全量约有 5 万次 replace、累计约 50 万次 key 检查。实际 Redis 命令数取决于
+MetaIndexer backend 的 batching。若清理扫描延迟或 backlog 长期超过运行阈值，应引入
+reporter -> location 反向索引，而不是继续提高全量频率。
+
+## 12. 测试要求
+
+### 12.1 单元测试
+
+- fresh reporter 未显式 REGISTER 时，第一条 HEARTBEAT/ADD/DELETE/SNAPSHOT 可懒初始化；
+- 第一条 ADD、第一条 DELETE 都成功并创建 version；
+- HOST_DOWN/grace tombstone 后的迟到事件被拒绝，显式 REGISTER 后恢复；
+- 第一条 delta 后不发送 snapshot，查询可见；
+- 重注册后第一条 delta 创建新 version；
+- 新 generation 的局部 ADD 保留旧 generation 的其他 specs；
+- 健康 reporter 的 old/current/in-flight/unversioned URI 可见；
+- malformed version、空 location fail closed；
+- unavailable/unregistered reporter 不可见，heartbeat 恢复后可见；
+- 旧 lifecycle cleanup 与重新 REGISTER 后的 delta 竞争时，compare-and-delete 保留新值；
+- snapshot 与 delta 两种先后顺序、commit 和 abort 均不死锁；
+- snapshot 部分失败或 Sync 失败后，已写候选仍可见且完整重试收敛；
+- cleanup 与下一轮 snapshot 的 CAS 竞态不删除新值；
+- snapshot commit 后 delta 刷新 mixed-generation location 时，旧 cleanup 不删除新写；
+- snapshot cleanup 只删除 metadata，不调用外部 URI backend；
+- 成功 snapshot 最终清理旧数据，失败 snapshot 不触发专用清理；
+- snapshot 限流、storage type 隔离和 liveness 竞态。
+
+### 12.2 集成测试
+
+- 纯实时模式：不要求 REGISTER，直接 ADD/DELETE/GET，全程无 snapshot；
+- 实时增量与低频 snapshot 混合；
+- 一个 snapshot 同时包含多个 medium；
+- snapshot 遗漏 block 后 reclaimer 最终删除；
+- KVCM 重启后首条新汇报前旧数据不可见；
+- 首条 HEARTBEAT 无需 REGISTER 即恢复旧 metadata；
+- 重启后第一条 delta 成功且不删除未触碰历史 block；
+- realtime-only reporter 不补 snapshot 也能持续 ADD/DELETE；
+- heartbeat timeout、恢复、超过 grace cleanup；
+- 多 reporter、多 instance、多 storage type 隔离；
+- snapshot partial/Sync failure、完整重试；
+- snapshot commit 后立即到达的 delta 在异步 cleanup 后仍可查询；
+- reporter host 或 medium 含 `#` 时 fail closed 且无写入副作用；
+- ASAN/TSAN 或等价并发检测。
+
+## 13. 接受的取舍
+
+本方案优先 cache availability，不提供原子 snapshot 查询视图：
+
+- snapshot 写入期间可能查到新旧 generation；
+- failed snapshot 的部分写入可能被返回；
+- cleanup 完成前，snapshot 遗漏的旧 block 可能短暂返回；
+- KVCM 重启后的第一条合法汇报可能让历史 metadata 重新可见；
+- realtime-only reporter 永远不做 snapshot 时，未触碰的旧数据可能长期存在。
+
+这些都是 cache false positive。实际 cache 读取失败必须按 miss 处理。
+
+本方案不提供 version 持久化、重启扫描恢复、历史 snapshot 查询、跨 reporter 原子快照、
+snapshot 分页或 exactly-once event delivery。
+
+## 14. 总结
+
+```text
+[可选 REGISTER] + realtime ADD/DELETE
+        |
+        +--> 不依赖首次 snapshot
+        |
+        +--> 可选 snapshot 做完整对账
+                  |
+                  +--> 成功：切换 generation + 异步清理
+                  +--> 失败：保留已写候选 + 实时链路继续
+```
+
+Version 用于标记与回收，node liveness 控制硬可见性，snapshot 只负责可选的最终收敛。

--- a/integration_test/meta_service/test_report_event.py
+++ b/integration_test/meta_service/test_report_event.py
@@ -18,11 +18,13 @@ Usage:
 
 import argparse
 import json
+import re
 import sys
 import time
 import statistics
 import unittest
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import parse_qsl, urlsplit
 
 import requests
 
@@ -480,7 +482,34 @@ class EventReportFunctionalTest(unittest.TestCase):
                 specs_by_name,
                 f"Expected {profile_name} spec [{spec_name}], locations={json.dumps(locations, ensure_ascii=False)}",
             )
-            self.assertEqual(specs_by_name[spec_name].get("uri"), uri)
+            actual_uri = specs_by_name[spec_name].get("uri", "")
+            actual = urlsplit(actual_uri)
+            expected = urlsplit(uri)
+            self.assertEqual(
+                (actual.scheme, actual.netloc, actual.path, actual.fragment),
+                (expected.scheme, expected.netloc, expected.path, expected.fragment),
+            )
+
+            actual_params = parse_qsl(actual.query, keep_blank_values=True)
+            expected_params = parse_qsl(expected.query, keep_blank_values=True)
+            versions = [
+                value for key, value in actual_params if key == "s_version"
+            ]
+            self.assertEqual(
+                len(versions),
+                1,
+                f"Expected exactly one s_version in URI: {actual_uri}",
+            )
+            self.assertRegex(versions[0], re.compile(r"^[0-9a-fA-F]{32}$"))
+            self.assertEqual(
+                sorted(
+                    (key, value)
+                    for key, value in actual_params
+                    if key != "s_version"
+                ),
+                sorted(expected_params),
+                f"KVCM changed caller URI parameters: {actual_uri}",
+            )
 
     def _assert_profile_spec_absent(self, block_key, profile_name, spec_name, trace_id, instance_id=None,
                                     timeout_seconds=10.0, interval_seconds=0.2):
@@ -586,7 +615,10 @@ class EventReportFunctionalTest(unittest.TestCase):
     def test_01_node_register(self):
         def run(profile_name):
             body = self._report_node(profile_name, self.HOST, ["mem", "disk", "ssd"], f"t01_{profile_name}")
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertTrue(body.get("snapshot_required"))
+            self.assertEqual(body.get("committed_snapshot_version", ""), "")
         self._for_each_profile(run)
 
     # 2. NODE_REGISTER is idempotent and merges mediums
@@ -595,7 +627,10 @@ class EventReportFunctionalTest(unittest.TestCase):
             host = f"192.168.1.{201 + self.PROFILES[profile_name]['type_value']}:8080"
             self._report_node(profile_name, host, ["mem"], f"t02a_{profile_name}")
             body = self._report_node(profile_name, host, ["mem", "disk"], f"t02b_{profile_name}")
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertTrue(body.get("snapshot_required"))
+            self.assertEqual(body.get("committed_snapshot_version", ""), "")
         self._for_each_profile(run)
 
     # 3. BLOCK_ADD then query: spec name/uri should match what was sent
@@ -632,7 +667,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 ],
                 f"t04_add_{profile_name}",
             )
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
+            self.assertFalse(body.get("snapshot_required"))
             self._assert_profile_specs(
                 block_key,
                 profile_name,
@@ -660,7 +698,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 ],
                 f"t05_add_{profile_name}",
             )
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
+            self.assertFalse(body.get("snapshot_required"))
             self._assert_profile_specs(
                 block_key,
                 profile_name,
@@ -696,7 +737,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 ["drop_spec"],
                 f"t06_del_{profile_name}",
             )
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
+            self.assertFalse(body.get("snapshot_required"))
             self._assert_profile_specs(block_key, profile_name, {"keep_spec": keep_uri}, f"t06_query_{profile_name}")
             self._assert_profile_spec_absent(block_key, profile_name, "drop_spec", f"t06_absent_{profile_name}")
         self._for_each_profile(run)
@@ -713,7 +757,8 @@ class EventReportFunctionalTest(unittest.TestCase):
                 f"t07_{profile_name}",
                 check_ok=False,
             )
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
         self._for_each_profile(run)
 
     # 8. HOST_DOWN cleans up all mediums under the host for each event report type
@@ -738,7 +783,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 ))
             self._report_event(profile_name, down_host, events, f"t08_add_{profile_name}")
             body = self._report_event(profile_name, down_host, [_ev_host_down()], f"t08_down_{profile_name}")
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertTrue(body.get("snapshot_required"))
+            self.assertEqual(body.get("committed_snapshot_version", ""), "")
             self._assert_host_removed_from_cache_locations(
                 block_keys,
                 down_host,
@@ -754,8 +802,10 @@ class EventReportFunctionalTest(unittest.TestCase):
             self._report_node(profile_name, down_host, ["mem"], f"t09_reg_{profile_name}")
             body1 = self._report_event(profile_name, down_host, [_ev_host_down()], f"t09_down1_{profile_name}")
             body2 = self._report_event(profile_name, down_host, [_ev_host_down()], f"t09_down2_{profile_name}")
-            self.assertIn("header", body1)
-            self.assertIn("header", body2)
+            self.assertEqual(body1["header"]["status"]["code"], "OK")
+            self.assertEqual(body2["header"]["status"]["code"], "OK")
+            self.assertEqual(body1.get("item_results", []), [])
+            self.assertEqual(body2.get("item_results", []), [])
         self._for_each_profile(run)
 
     # 10. HEARTBEAT extends liveness; payload is opaque
@@ -767,7 +817,8 @@ class EventReportFunctionalTest(unittest.TestCase):
                 [_ev_heartbeat({"version": "er-0.18", "cpu": "45%"})],
                 f"t10_{profile_name}",
             )
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
         self._for_each_profile(run)
 
     # 11. Mixed batch: register + add + heartbeat in a single RPC
@@ -785,14 +836,21 @@ class EventReportFunctionalTest(unittest.TestCase):
                 _ev_heartbeat({"phase": "boot"}),
             ]
             body = self._report_event(profile_name, host, events, f"t11_{profile_name}")
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
+            self.assertFalse(body.get("snapshot_required"))
         self._for_each_profile(run)
 
     # 12. Empty events array: should be a no-op success
     def test_12_empty_batch(self):
         def run(profile_name):
             body = self._report_event(profile_name, self.HOST, [], f"t12_{profile_name}")
-            self.assertIn("header", body)
+            self.assertEqual(body["header"]["status"]["code"], "OK")
+            self.assertEqual(body.get("item_results", []), [])
+            self.assertEqual(body.get("committed_snapshot_version", ""), "")
+            self.assertFalse(body.get("snapshot_required"))
+            self.assertEqual(body.get("retry_after_ms", "0"), "0")
         self._for_each_profile(run)
 
     # 13. Missing block_add params: server must surface a per-item failure
@@ -805,8 +863,8 @@ class EventReportFunctionalTest(unittest.TestCase):
                 f"t13_{profile_name}",
                 check_ok=False,
             )
-            self.assertIn("header", body)
-            self.assertIn("item_results", body)
+            self.assertEqual(body["header"]["status"]["code"], "INVALID_ARGUMENT")
+            self.assertEqual(body.get("item_results"), ["INVALID_ARGUMENT"])
         self._for_each_profile(run)
 
     # 15. L1.5 and L2 coexist for the same host/key/medium without overwriting each other

--- a/integration_test/meta_service/test_report_event_restart.py
+++ b/integration_test/meta_service/test_report_event_restart.py
@@ -90,39 +90,37 @@ def verify(args, client, checks):
         args.instance_id,
         BLOCK_KEY,
         set(),
-        "restart_verify_old_data_hidden_before_register",
+        "restart_verify_old_data_hidden_before_first_report",
     )
 
-    register = client.report_event(
-        report_event._make_request(
-            args.instance_id,
-            HOST,
-            [report_event._ev_node_register(["mem", "gpu"])],
-            trace_id="restart_verify_register",
-        )
-    )
-    checks.assertTrue(register.get("snapshot_required"))
-    checks.assertEqual(register.get("committed_snapshot_version", ""), "")
-
+    # The subscriber does not restart with KVCM and therefore does not send a
+    # second REGISTER. Its next ordinary heartbeat must lazily rebuild the
+    # reporter's process-local liveness state.
     heartbeat = client.report_event(
         report_event._make_request(
             args.instance_id,
             HOST,
             [report_event._ev_heartbeat({"phase": "after_restart"})],
-            trace_id="restart_verify_heartbeat_before_snapshot",
+            trace_id="restart_verify_first_heartbeat",
         )
     )
     checks.assertTrue(heartbeat.get("snapshot_required"))
     checks.assertEqual(heartbeat.get("committed_snapshot_version", ""), "")
-    report_event._wait_for_block_spec_names(
+    restored_specs = report_event._wait_for_block_spec_names(
         client,
         args.instance_id,
         BLOCK_KEY,
-        set(),
-        "restart_verify_heartbeat_does_not_restore_old_data",
+        {"linear_0"},
+        "restart_verify_heartbeat_reuses_historical_cache",
+    )
+    checks.assertEqual(
+        report_event._snapshot_version_from_uri(
+            checks, restored_specs[0]["uri"]
+        ),
+        previous["version"],
     )
 
-    rejected = client.report_event(
+    accepted = client.report_event(
         report_event._make_request(
             args.instance_id,
             HOST,
@@ -135,11 +133,31 @@ def verify(args, client, checks):
                 ),
             )],
             trace_id="restart_verify_delta_before_snapshot",
-        ),
-        check_ok=False,
+        )
+    )
+    checks.assertEqual(accepted["header"]["status"]["code"], "OK")
+    active_version = accepted["committed_snapshot_version"]
+    checks.assertEqual(len(active_version), 32)
+    checks.assertFalse(accepted.get("snapshot_required"))
+    delta_specs = report_event._wait_for_block_spec_names(
+        client,
+        args.instance_id,
+        BLOCK_KEY + 1,
+        {"gpu_0"},
+        "restart_verify_delta_without_snapshot_visible",
     )
     checks.assertEqual(
-        rejected["header"]["status"]["code"], "SNAPSHOT_REQUIRED"
+        report_event._snapshot_version_from_uri(
+            checks, delta_specs[0]["uri"]
+        ),
+        active_version,
+    )
+    report_event._wait_for_block_spec_names(
+        client,
+        args.instance_id,
+        BLOCK_KEY,
+        {"linear_0"},
+        "restart_verify_delta_keeps_untouched_historical_cache",
     )
 
     after_uri = report_event._build_event_report_uri(
@@ -181,7 +199,8 @@ def verify(args, client, checks):
     )
     print(
         "RESTART_VERIFY_OK "
-        f"old_version={previous['version']} new_version={version}"
+        f"old_version={previous['version']} active_version={active_version} "
+        f"new_version={version}"
     )
 
 
@@ -192,9 +211,18 @@ def main():
     parser.add_argument("--http-port", type=int, required=True)
     parser.add_argument("--admin-http-port", type=int, required=True)
     parser.add_argument("--instance-id", required=True)
-    parser.add_argument("--meta-storage-uri", required=True)
+    parser.add_argument(
+        "--meta-storage-uri",
+        required=True,
+        help="Persistent Redis metadata URI (redis://...) shared across both KVCM processes.",
+    )
     parser.add_argument("--state-file", required=True)
     args = parser.parse_args()
+    if report_event._meta_storage_type(args.meta_storage_uri) != "redis":
+        parser.error(
+            "--meta-storage-uri must use redis://; the local backend is an "
+            "in-process cache and cannot validate process-restart recovery"
+        )
 
     client = configure(args)
     checks = unittest.TestCase()

--- a/integration_test/meta_service/test_report_event_snapshot.py
+++ b/integration_test/meta_service/test_report_event_snapshot.py
@@ -104,6 +104,19 @@ class KVCMClient:
         resp.raise_for_status()
         return resp.json()
 
+    def get_cache_locations_by_backend(self, data, check_response=True):
+        url = f"{self.base_url}/api/getCacheLocationsByBackend"
+        resp = self.session.post(url, json=data)
+        resp.raise_for_status()
+        body = resp.json()
+        if check_response:
+            code = body.get("header", {}).get("status", {}).get("code")
+            assert code == "OK", (
+                "getCacheLocationsByBackend failed: "
+                f"{json.dumps(body, ensure_ascii=False)}"
+            )
+        return body
+
     def start_write_cache_with_min_replica(self, data, check_response=True):
         url = f"{self.base_url}/api/startWriteCache"
         resp = self.session.post(url, json=data)
@@ -223,6 +236,16 @@ def _build_event_report_uri(host_ip_port, medium, params=None):
     return f"{base}?{query}"
 
 
+def _uri_identity_without_snapshot_version(uri):
+    parsed = urlsplit(uri)
+    params = tuple(
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key != "s_version"
+    )
+    return parsed.scheme, parsed.netloc, parsed.path, params
+
+
 def _query_block_specs(client, instance_id, block_key, trace_id):
     """Return the flattened location specs visible for one block."""
     resp = client.get_cache_location({
@@ -239,6 +262,30 @@ def _query_block_specs(client, instance_id, block_key, trace_id):
     return [
         spec
         for location in resp.get("locations", [])
+        for spec in location.get("location_specs", [])
+        if spec.get("uri")
+    ]
+
+
+def _query_block_specs_by_backend(
+    client, instance_id, block_key, storage_type, trace_id
+):
+    """Return visible specs through the backend-selected business query."""
+    resp = client.get_cache_locations_by_backend({
+        "trace_id": trace_id,
+        "instance_id": instance_id,
+        "query_type": "QT_BATCH_GET",
+        "block_keys": [block_key],
+        "block_mask": {"offset": 0},
+        "backend_selectors": [{
+            "backend_type": storage_type,
+            "strategy": "LSS_WEIGHTED_RANDOM",
+        }],
+    })
+    return [
+        spec
+        for key_location in resp.get("key_locations", [])
+        for location in key_location.get("locations", [])
         for spec in location.get("location_specs", [])
         if spec.get("uri")
     ]
@@ -312,6 +359,7 @@ class EventReportFunctionalTest(unittest.TestCase):
     HOST = "192.168.1.200:8080"
     EVENT_REPORT_STORAGE_NAME = "event_report_default"
     INSTANCE_GROUP_NAME = "event_report_test_group"
+    INSTANCE_GROUP_EXTRA_INFO = '{"contract":"report_event"}'
     LIVENESS_STORAGE_NAME = "event_report_liveness"
     LIVENESS_INSTANCE_GROUP_NAME = "event_report_liveness_group"
 
@@ -378,13 +426,19 @@ class EventReportFunctionalTest(unittest.TestCase):
         })
         code = existing.get("header", {}).get("status", {}).get("code")
         if code == "OK":
-            candidates = existing.get("instance_group", {}).get(
+            instance_group = existing.get("instance_group", {})
+            candidates = instance_group.get(
                 "event_report_storage_candidates", []
             )
             if cls.EVENT_REPORT_STORAGE_NAME not in candidates:
                 raise AssertionError(
                     f"InstanceGroup {cls.INSTANCE_GROUP_NAME!r} does not use "
                     f"EventReport storage {cls.EVENT_REPORT_STORAGE_NAME!r}"
+                )
+            if instance_group.get("extra_info", "") != cls.INSTANCE_GROUP_EXTRA_INFO:
+                raise AssertionError(
+                    f"InstanceGroup {cls.INSTANCE_GROUP_NAME!r} has unexpected "
+                    f"extra_info={instance_group.get('extra_info')!r}"
                 )
             print(f"[SETUP] InstanceGroup '{cls.INSTANCE_GROUP_NAME}' reused")
             return
@@ -422,6 +476,7 @@ class EventReportFunctionalTest(unittest.TestCase):
                     },
                 },
                 "event_report_storage_candidates": [cls.EVENT_REPORT_STORAGE_NAME],
+                "extra_info": cls.INSTANCE_GROUP_EXTRA_INFO,
                 "version": 1,
             },
         })
@@ -562,7 +617,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 trace_id="t01",
             )
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        self.assertEqual(body.get("retry_after_ms", "0"), "0")
+        self.assertEqual(body.get("extra_info"), self.INSTANCE_GROUP_EXTRA_INFO)
 
     # 2. NODE_REGISTER is idempotent and merges mediums
     def test_02_node_register_idempotent(self):
@@ -573,7 +631,10 @@ class EventReportFunctionalTest(unittest.TestCase):
         body = self.client.report_event(
             _make_request(self.instance_id, host, [_ev_node_register(["mem", "disk"])], trace_id="t02b")
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        self.assertTrue(body.get("snapshot_required"))
+        self.assertEqual(body.get("committed_snapshot_version", ""), "")
 
     # 3. BLOCK_ADD with single spec
     def test_03_block_add(self):
@@ -585,7 +646,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 trace_id="t03",
             )
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
+        self.assertFalse(body.get("snapshot_required"))
 
     # 4. BLOCK_ADD then query: spec name/uri should match what was sent
     def test_04_block_add_then_query(self):
@@ -650,7 +714,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 trace_id="t05b",
             )
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
+        self.assertFalse(body.get("snapshot_required"))
 
         resp = self.client.get_cache_location({
             "trace_id": "t05_query",
@@ -701,7 +768,10 @@ class EventReportFunctionalTest(unittest.TestCase):
                 trace_id="t05b_add",
             )
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
+        self.assertFalse(body.get("snapshot_required"))
 
         resp = self.client.get_cache_location({
             "trace_id": "t05b_query",
@@ -755,22 +825,28 @@ class EventReportFunctionalTest(unittest.TestCase):
 
     # 7. BLOCK_DELETE on missing key/medium is a no-op (idempotent)
     def test_07_block_delete_nonexistent(self):
+        missing_keys = [99_997, 99_998, 99_999]
         body = self.client.report_event(
             _make_request(
                 self.instance_id, self.HOST,
-                [_ev_block_delete(99999, "mem", ["spec_4096"])],
-                trace_id="t07",
+                [
+                    _ev_block_delete(key, "mem", ["spec_4096"])
+                    for key in missing_keys
+                ],
+                trace_id="t07_three_missing_blocks",
             ),
             check_ok=False,
         )
         self.assertEqual(body["header"]["status"]["code"], "OK")
-        _wait_for_block_spec_names(
-            self.client,
-            self.instance_id,
-            99999,
-            set(),
-            "t07_query_missing",
-        )
+        self.assertEqual(body.get("item_results", []), [])
+        for key in missing_keys:
+            _wait_for_block_spec_names(
+                self.client,
+                self.instance_id,
+                key,
+                set(),
+                f"t07_query_missing_{key}",
+            )
 
     # 8. HOST_DOWN cleans up all mediums under the host
     def test_08_host_down(self):
@@ -850,38 +926,75 @@ class EventReportFunctionalTest(unittest.TestCase):
                 trace_id="t10",
             )
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        self.assertFalse(body.get("snapshot_required"))
 
     # 11. Mixed batch: register + add + heartbeat in a single RPC
     def test_11_mixed_batch(self):
-        host = "192.168.1.230:8080"
-        block_key = 9030
+        host = f"mixed-batch-{time.time_ns()}:8080"
+        block_key = 9_030_000_000 + time.time_ns() % 1_000_000_000
+        reported_uri = _build_event_report_uri(
+            host, "mem", {"source": "first_delta"}
+        )
         events = [
             _ev_node_register(["mem"]),
-            _ev_block_add(block_key, "mem", _make_single_spec("spec_4096", _build_event_report_uri(host, "mem"))),
+            _ev_block_add(
+                block_key,
+                "mem",
+                _make_single_spec("spec_4096", reported_uri),
+            ),
             _ev_heartbeat({"phase": "boot"}),
         ]
-        self.client.report_event(
-            _make_request(self.instance_id, host, events[:1], trace_id="t11_register")
-        )
-        self.client.report_event(
-            _make_request(
-                self.instance_id, host,
-                [_ev_block_snapshot([])],
-                trace_id="t11_initial_snapshot",
-            )
-        )
         body = self.client.report_event(
-            _make_request(self.instance_id, host, events[1:], trace_id="t11")
+            _make_request(self.instance_id, host, events, trace_id="t11")
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        version = body["committed_snapshot_version"]
+        self.assertEqual(len(version), 32)
+        self.assertFalse(body.get("snapshot_required"))
+
+        specs = _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            block_key,
+            {"spec_4096"},
+            "t11_query_first_delta",
+        )
+        _assert_reporter_scope(
+            self,
+            specs[0]["uri"],
+            reported_uri,
+            self.instance_id,
+            host,
+            "mem",
+            version,
+        )
+
+        host_state = self.client.get_host_cache_state({
+            "trace_id": "t11_get_host_cache_state",
+            "instance_id": self.instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [block_key],
+        })
+        matches = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in host_state.get("hosts", [])
+        }
+        self.assertEqual(matches.get(host), 1)
 
     # 12. Empty events array: should be a no-op success
     def test_12_empty_batch(self):
         body = self.client.report_event(
             _make_request(self.instance_id, self.HOST, [], trace_id="t12")
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "OK")
+        self.assertEqual(body.get("item_results", []), [])
+        self.assertEqual(body.get("committed_snapshot_version", ""), "")
+        self.assertFalse(body.get("snapshot_required"))
+        self.assertEqual(body.get("retry_after_ms", "0"), "0")
+        self.assertEqual(body.get("extra_info"), self.INSTANCE_GROUP_EXTRA_INFO)
 
     # 13. Missing block_add params: server must surface a per-item failure
     def test_13_block_add_missing_params(self):
@@ -893,8 +1006,8 @@ class EventReportFunctionalTest(unittest.TestCase):
             ),
             check_ok=False,
         )
-        self.assertIn("header", body)
-        self.assertIn("item_results", body)
+        self.assertEqual(body["header"]["status"]["code"], "INVALID_ARGUMENT")
+        self.assertEqual(body.get("item_results"), ["INVALID_ARGUMENT"])
 
     # 14. Empty top-level host_ip_port: request-level validation must reject
     def test_14_missing_host_ip_port(self):
@@ -908,7 +1021,8 @@ class EventReportFunctionalTest(unittest.TestCase):
             },
             check_ok=False,
         )
-        self.assertIn("header", body)
+        self.assertEqual(body["header"]["status"]["code"], "INVALID_ARGUMENT")
+        self.assertEqual(body.get("item_results", []), [])
 
     # 15. StartWriteCacheWithMinReplica: event report eviction with min_replica_count=2
     def test_15_start_write_cache_with_min_replica(self):
@@ -999,6 +1113,28 @@ class EventReportFunctionalTest(unittest.TestCase):
             _snapshot_version_from_uri(self, target_specs[0]["uri"]),
             committed_token,
         )
+        target_backend_specs = _query_block_specs_by_backend(
+            self.client,
+            instance_id,
+            block_key,
+            "ST_EVENT_REPORT_L2",
+            "t16a_target_backend_positive",
+        )
+        self.assertEqual(
+            {spec.get("name") for spec in target_backend_specs},
+            {"spec_4096"},
+        )
+        target_host_state = self.client.get_host_cache_state({
+            "trace_id": "t16a_target_host_state_positive",
+            "instance_id": instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [block_key],
+        })
+        target_prefixes = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in target_host_state.get("hosts", [])
+        }
+        self.assertEqual(target_prefixes.get(host), 1)
 
         self.client.report_event(
             _make_request(
@@ -1094,6 +1230,32 @@ class EventReportFunctionalTest(unittest.TestCase):
             [],
             "automatic heartbeat timeout must hide the committed location",
         )
+        self.assertEqual(
+            _query_block_specs_by_backend(
+                self.client,
+                instance_id,
+                block_key,
+                "ST_EVENT_REPORT_L2",
+                "t16a_backend_query_hidden",
+            ),
+            [],
+            "backend-selected query must apply the same liveness gate",
+        )
+        hidden_host_state = self.client.get_host_cache_state({
+            "trace_id": "t16a_host_state_hidden",
+            "instance_id": instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [block_key],
+        })
+        hidden_prefixes = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in hidden_host_state.get("hosts", [])
+        }
+        self.assertEqual(
+            hidden_prefixes.get(host, 0),
+            0,
+            "GetHostCacheState must not count an unavailable reporter",
+        )
         _wait_for_block_spec_names(
             self.client,
             instance_id,
@@ -1172,6 +1334,28 @@ class EventReportFunctionalTest(unittest.TestCase):
             _snapshot_version_from_uri(self, recovered_delta_specs[0]["uri"]),
             committed_token,
         )
+        recovered_backend_specs = _query_block_specs_by_backend(
+            self.client,
+            instance_id,
+            block_key,
+            "ST_EVENT_REPORT_L2",
+            "t16a_backend_query_recovered",
+        )
+        self.assertEqual(
+            {spec.get("name") for spec in recovered_backend_specs},
+            {"spec_4096"},
+        )
+        recovered_host_state = self.client.get_host_cache_state({
+            "trace_id": "t16a_host_state_recovered",
+            "instance_id": instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [block_key],
+        })
+        recovered_prefixes = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in recovered_host_state.get("hosts", [])
+        }
+        self.assertEqual(recovered_prefixes.get(host), 1)
 
     # 16b. Heartbeat timeout exceeds cleanup_grace_ms -> CleanupHostLocations triggered.
     def test_16b_heartbeat_exceeds_grace_triggers_cleanup(self):
@@ -1265,8 +1449,9 @@ class EventReportFunctionalTest(unittest.TestCase):
             "t16b_old_data_hidden_after_unregister",
         )
 
-        # Registration and heartbeat only recreate liveness state. They must
-        # not restore a token left in Redis/meta cache from the old lifecycle.
+        # Registration and heartbeat only recreate process-local liveness
+        # state. The old committed generation is not restored, although
+        # already-persisted cache metadata may remain as a soft candidate.
         reregister = self.client.report_event(
             _make_request(
                 instance_id,
@@ -1287,32 +1472,55 @@ class EventReportFunctionalTest(unittest.TestCase):
         )
         self.assertTrue(heartbeat.get("snapshot_required"))
         self.assertEqual(heartbeat.get("committed_snapshot_version", ""), "")
-        _wait_for_block_spec_names(
+        historical_specs = _query_block_specs(
             self.client,
             instance_id,
             block_key,
-            set(),
-            "t16b_register_heartbeat_do_not_restore",
+            "t16b_register_may_reuse_historical_cache",
+        )
+        self.assertIn(
+            {spec.get("name") for spec in historical_specs},
+            (set(), {"before_cleanup"}),
         )
 
-        rejected_delta = self.client.report_event(
+        # Refresh liveness immediately before the delta so the following
+        # assertion changes only the delta/snapshot condition.
+        heartbeat = self.client.report_event(
+            _make_request(
+                instance_id,
+                host,
+                [_ev_heartbeat({"phase": "before_delta_without_snapshot"})],
+                trace_id="t16b_refresh_heartbeat_before_delta",
+            )
+        )
+        self.assertTrue(heartbeat.get("snapshot_required"))
+
+        delta_key = block_key + 3
+        accepted_delta = self.client.report_event(
             _make_request(
                 instance_id,
                 host,
                 [_ev_block_add(
-                    block_key,
+                    delta_key,
                     "mem",
                     _make_single_spec(
                         "delta_without_snapshot",
                         _build_event_report_uri(host, "mem"),
                     ),
                 )],
-                trace_id="t16b_delta_requires_snapshot",
-            ),
-            check_ok=False,
+                trace_id="t16b_delta_without_snapshot",
+            )
         )
         self.assertEqual(
-            rejected_delta["header"]["status"]["code"], "SNAPSHOT_REQUIRED"
+            accepted_delta["header"]["status"]["code"], "OK"
+        )
+        self.assertFalse(accepted_delta.get("snapshot_required"))
+        _wait_for_block_spec_names(
+            self.client,
+            instance_id,
+            delta_key,
+            {"delta_without_snapshot"},
+            "t16b_delta_without_snapshot_visible",
         )
 
         recovered_snapshot = self.client.report_event(
@@ -1349,6 +1557,13 @@ class EventReportFunctionalTest(unittest.TestCase):
             omitted_key,
             set(),
             "t16b_omitted_old_token_remains_hidden",
+        )
+        _wait_for_block_spec_names(
+            self.client,
+            instance_id,
+            delta_key,
+            set(),
+            "t16b_delta_omitted_by_snapshot_is_reclaimed",
         )
 
     # 16. GetHostCacheState — per-host prefix match verification
@@ -1619,13 +1834,12 @@ class EventReportFunctionalTest(unittest.TestCase):
                     ),
                 )],
                 trace_id="t19_delta_before_snapshot",
-            ),
-            check_ok=False,
+            )
         )
-        self.assertEqual(
-            delta["header"]["status"]["code"],
-            "SNAPSHOT_REQUIRED",
-        )
+        self.assertEqual(delta["header"]["status"]["code"], "OK")
+        delta_version = delta["committed_snapshot_version"]
+        self.assertEqual(len(delta_version), 32)
+        self.assertFalse(delta.get("snapshot_required"))
 
         duplicate = self.client.report_event(
             _make_request(
@@ -1646,8 +1860,10 @@ class EventReportFunctionalTest(unittest.TestCase):
             duplicate["header"]["status"]["code"],
             "INVALID_ARGUMENT",
         )
-        self.assertEqual(duplicate.get("committed_snapshot_version", ""), "")
-        self.assertTrue(duplicate.get("snapshot_required"))
+        self.assertEqual(
+            duplicate.get("committed_snapshot_version", ""), delta_version
+        )
+        self.assertFalse(duplicate.get("snapshot_required"))
 
         committed = self.client.report_event(
             _make_request(
@@ -1692,7 +1908,83 @@ class EventReportFunctionalTest(unittest.TestCase):
         self.assertEqual(malformed.get("committed_snapshot_version", ""), "")
         self.assertTrue(malformed.get("snapshot_required"))
 
-    def test_20_host_down_then_reregister_requires_new_snapshot(self):
+        invalid_reporter = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                "192.168.1.245#8080",
+                [_ev_node_register(["mem"])],
+                trace_id="t19_invalid_reporter_delimiter",
+            ),
+            check_ok=False,
+        )
+        self.assertEqual(
+            invalid_reporter["header"]["status"]["code"],
+            "INVALID_ARGUMENT",
+        )
+
+        invalid_medium_delta = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_add(
+                    "9193",
+                    "mem#invalid",
+                    _make_single_spec(
+                        "linear_0", _build_event_report_uri(host, "mem")
+                    ),
+                )],
+                trace_id="t19_invalid_delta_medium_delimiter",
+            ),
+            check_ok=False,
+        )
+        self.assertEqual(
+            invalid_medium_delta["header"]["status"]["code"],
+            "INVALID_ARGUMENT",
+        )
+        self.assertEqual(
+            invalid_medium_delta.get("committed_snapshot_version"),
+            committed["committed_snapshot_version"],
+        )
+        _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            "9193",
+            set(),
+            "t19_invalid_delta_medium_query",
+        )
+
+        invalid_medium_snapshot = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_snapshot([{
+                    "block_key": "9194",
+                    "medium": "mem#invalid",
+                    "specs": _make_single_spec(
+                        "linear_0", _build_event_report_uri(host, "mem")
+                    ),
+                }])],
+                trace_id="t19_invalid_snapshot_medium_delimiter",
+            ),
+            check_ok=False,
+        )
+        self.assertEqual(
+            invalid_medium_snapshot["header"]["status"]["code"],
+            "INVALID_ARGUMENT",
+        )
+        self.assertEqual(
+            invalid_medium_snapshot.get("committed_snapshot_version"),
+            committed["committed_snapshot_version"],
+        )
+        _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            "9194",
+            set(),
+            "t19_invalid_snapshot_medium_query",
+        )
+
+    def test_20_host_down_then_reregister_allows_first_delta(self):
         host = "192.168.1.244:8080"
         register = self.client.report_event(
             _make_request(
@@ -1735,7 +2027,7 @@ class EventReportFunctionalTest(unittest.TestCase):
         self.assertTrue(reregister.get("snapshot_required"))
         self.assertEqual(reregister.get("committed_snapshot_version", ""), "")
 
-        rejected_delta = self.client.report_event(
+        first_delta = self.client.report_event(
             _make_request(
                 self.instance_id,
                 host,
@@ -1746,14 +2038,13 @@ class EventReportFunctionalTest(unittest.TestCase):
                         "linear_0", _build_event_report_uri(host, "mem")
                     ),
                 )],
-                trace_id="t20_delta_before_resnapshot",
-            ),
-            check_ok=False,
+                trace_id="t20_delta_without_resnapshot",
+            )
         )
-        self.assertEqual(
-            rejected_delta["header"]["status"]["code"],
-            "SNAPSHOT_REQUIRED",
-        )
+        self.assertEqual(first_delta["header"]["status"]["code"], "OK")
+        delta_token = first_delta["committed_snapshot_version"]
+        self.assertEqual(len(delta_token), 32)
+        self.assertNotEqual(first_token, delta_token)
 
         second = self.client.report_event(
             _make_request(
@@ -1836,19 +2127,19 @@ class EventReportFunctionalTest(unittest.TestCase):
             duplicate["header"]["status"]["code"], "INVALID_ARGUMENT"
         )
 
-        still_requires_snapshot = self.client.report_event(
+        accepted_delta = self.client.report_event(
             _make_request(
                 self.instance_id,
                 host,
                 [delta],
                 trace_id="t21_delta_after_invalid_requests",
-            ),
-            check_ok=False,
+            )
         )
         self.assertEqual(
-            still_requires_snapshot["header"]["status"]["code"],
-            "SNAPSHOT_REQUIRED",
+            accepted_delta["header"]["status"]["code"],
+            "OK",
         )
+        self.assertEqual(len(accepted_delta["committed_snapshot_version"]), 32)
 
         committed = self.client.report_event(
             _make_request(
@@ -2755,8 +3046,16 @@ class EventReportFunctionalTest(unittest.TestCase):
             version,
         )
 
-    def test_26_unregistered_and_snapshot_required_errors_are_distinct(self):
+    def test_26_unregistered_errors_remain_distinct_from_delta_only_mode(self):
         host = "192.168.1.250:8080"
+        self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_host_down()],
+                trace_id="t26_reset_reporter",
+            )
+        )
         heartbeat = self.client.report_event(
             _make_request(
                 self.instance_id,
@@ -2814,7 +3113,35 @@ class EventReportFunctionalTest(unittest.TestCase):
         )
         self.assertTrue(registered.get("snapshot_required"))
 
-        missing_snapshot = self.client.report_event(
+        invalid_first_delta = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_add(25_000_251, "mem", [])],
+                trace_id="t26_invalid_first_delta",
+            ),
+            check_ok=False,
+        )
+        self.assertEqual(
+            invalid_first_delta["header"]["status"]["code"],
+            "INVALID_ARGUMENT",
+        )
+        self.assertEqual(
+            invalid_first_delta.get("committed_snapshot_version", ""), ""
+        )
+        self.assertTrue(invalid_first_delta.get("snapshot_required"))
+        self.assertEqual(
+            invalid_first_delta.get("item_results"), ["INVALID_ARGUMENT"]
+        )
+        _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            25_000_251,
+            set(),
+            "t26_invalid_first_delta_has_no_side_effect",
+        )
+
+        first_delta = self.client.report_event(
             _make_request(
                 self.instance_id,
                 host,
@@ -2826,12 +3153,58 @@ class EventReportFunctionalTest(unittest.TestCase):
                     ),
                 )],
                 trace_id="t26_registered_without_snapshot",
-            ),
-            check_ok=False,
+            )
+        )
+        self.assertEqual(first_delta["header"]["status"]["code"], "OK")
+        self.assertFalse(first_delta.get("snapshot_required"))
+        delta_version = first_delta["committed_snapshot_version"]
+        self.assertEqual(len(delta_version), 32)
+        _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            25_000_250,
+            {"linear_0"},
+            "t26_delta_without_snapshot_visible",
+        )
+        host_state = self.client.get_host_cache_state({
+            "trace_id": "t26_delta_only_host_state",
+            "instance_id": self.instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [25_000_250],
+        })
+        matches = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in host_state.get("hosts", [])
+        }
+        self.assertEqual(matches.get(host), 1)
+        heartbeat = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_heartbeat({"mode": "delta_only"})],
+                trace_id="t26_delta_only_heartbeat",
+            )
         )
         self.assertEqual(
-            missing_snapshot["header"]["status"]["code"],
-            "SNAPSHOT_REQUIRED",
+            heartbeat.get("committed_snapshot_version"), delta_version
+        )
+        deletion = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_delete(25_000_250, "mem", ["linear_0"])],
+                trace_id="t26_delta_only_delete",
+            )
+        )
+        self.assertEqual(
+            deletion.get("committed_snapshot_version"), delta_version
+        )
+        _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            25_000_250,
+            set(),
+            "t26_delta_only_delete_visible",
         )
 
     def test_27_snapshot_rejects_canonical_duplicate_block_keys(self):
@@ -2923,6 +3296,618 @@ class EventReportFunctionalTest(unittest.TestCase):
                 _snapshot_version_from_uri(self, spec["uri"]), version
             )
 
+    def test_28_concurrent_first_deltas_share_one_generation(self):
+        host = f"first-delta-race-{time.time_ns()}:8080"
+        first_key = 28_000_000_000 + time.time_ns() % 1_000_000_000
+        writer_count = 24
+
+        def send_first_delta(writer):
+            client = KVCMClient(BASE_URL, ADMIN_URL)
+            try:
+                block_key = first_key + writer
+                uri = _build_event_report_uri(
+                    host, "mem", {"writer": str(writer)}
+                )
+                return client.report_event(
+                    _make_request(
+                        self.instance_id,
+                        host,
+                        [_ev_block_add(
+                            block_key,
+                            "mem",
+                            _make_single_spec(f"writer_{writer}", uri),
+                        )],
+                        trace_id=f"t28_delta_{writer}",
+                    )
+                )
+            finally:
+                client.close()
+
+        with ThreadPoolExecutor(max_workers=writer_count) as pool:
+            responses = list(pool.map(send_first_delta, range(writer_count)))
+
+        versions = {
+            response.get("committed_snapshot_version", "")
+            for response in responses
+        }
+        self.assertEqual(len(versions), 1, responses)
+        version = versions.pop()
+        self.assertEqual(len(version), 32)
+        for response in responses:
+            self.assertEqual(
+                response["header"]["status"]["code"], "OK", response
+            )
+            self.assertFalse(response.get("snapshot_required"))
+
+        for writer in range(writer_count):
+            specs = _wait_for_block_spec_names(
+                self.client,
+                self.instance_id,
+                first_key + writer,
+                {f"writer_{writer}"},
+                f"t28_query_{writer}",
+            )
+            self.assertEqual(
+                _snapshot_version_from_uri(self, specs[0]["uri"]), version
+            )
+
+        host_state = self.client.get_host_cache_state({
+            "trace_id": "t28_get_host_cache_state",
+            "instance_id": self.instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [
+                first_key + writer for writer in range(writer_count)
+            ],
+        })
+        matches = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in host_state.get("hosts", [])
+        }
+        self.assertEqual(matches.get(host), writer_count)
+
+    def test_29_register_snapshot_and_heartbeat_in_one_request(self):
+        host = f"snapshot-boot-{time.time_ns()}:8080"
+        block_key = 29_000_000_000 + time.time_ns() % 1_000_000_000
+        reported_uri = _build_event_report_uri(
+            host, "gpu", {"source": "boot_snapshot"}
+        )
+        response = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [
+                    _ev_node_register(["gpu"]),
+                    _ev_block_snapshot([{
+                        "block_key": block_key,
+                        "medium": "gpu",
+                        "specs": _make_single_spec(
+                            "gpu_0", reported_uri
+                        ),
+                    }]),
+                    _ev_heartbeat({"phase": "boot"}),
+                ],
+                trace_id="t29_register_snapshot_heartbeat",
+            )
+        )
+        self.assertEqual(response["header"]["status"]["code"], "OK")
+        self.assertEqual(response.get("item_results", []), [])
+        version = response["committed_snapshot_version"]
+        self.assertEqual(len(version), 32)
+        self.assertFalse(response.get("snapshot_required"))
+        specs = _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            block_key,
+            {"gpu_0"},
+            "t29_query",
+        )
+        _assert_reporter_scope(
+            self,
+            specs[0]["uri"],
+            reported_uri,
+            self.instance_id,
+            host,
+            "gpu",
+            version,
+        )
+
+    def test_30_delta_before_explicit_register_succeeds(self):
+        host = f"wrong-order-{time.time_ns()}:8080"
+        block_key = 30_000_000_000 + time.time_ns() % 1_000_000_000
+        reported_uri = _build_event_report_uri(
+            host, "mem", {"source": "ordered_retry"}
+        )
+        response = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [
+                    _ev_block_add(
+                        block_key,
+                        "mem",
+                        _make_single_spec("linear_0", reported_uri),
+                    ),
+                    _ev_node_register(["mem"]),
+                    _ev_heartbeat({"phase": "boot"}),
+                ],
+                trace_id="t30_delta_before_register",
+            ),
+        )
+        self.assertEqual(response["header"]["status"]["code"], "OK")
+        self.assertEqual(response.get("item_results", []), [])
+        self.assertEqual(len(response["committed_snapshot_version"]), 32)
+        self.assertFalse(response.get("snapshot_required"))
+        _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            block_key,
+            {"linear_0"},
+            "t30_query_without_register",
+        )
+
+    def test_31_first_delete_without_snapshot_creates_reusable_generation(self):
+        host = f"first-delete-{time.time_ns()}:8080"
+        block_key = 31_000_000_000 + time.time_ns() % 1_000_000_000
+        deleted = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_delete(block_key, "mem", ["linear_0"])],
+                trace_id="t31_first_delete",
+            )
+        )
+        version = deleted["committed_snapshot_version"]
+        self.assertEqual(len(version), 32)
+        self.assertFalse(deleted.get("snapshot_required"))
+        _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            block_key,
+            set(),
+            "t31_query_after_missing_delete",
+        )
+
+        empty_host_state = self.client.get_host_cache_state({
+            "trace_id": "t31_empty_host_state",
+            "instance_id": self.instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [block_key],
+        })
+        empty_matches = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in empty_host_state.get("hosts", [])
+        }
+        self.assertNotIn(host, empty_matches)
+
+        reported_uri = _build_event_report_uri(
+            host, "mem", {"source": "after_first_delete"}
+        )
+        added = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_add(
+                    block_key,
+                    "mem",
+                    _make_single_spec("linear_0", reported_uri),
+                )],
+                trace_id="t31_add_after_first_delete",
+            )
+        )
+        self.assertEqual(added["committed_snapshot_version"], version)
+        self.assertFalse(added.get("snapshot_required"))
+        specs = _wait_for_block_spec_names(
+            self.client,
+            self.instance_id,
+            block_key,
+            {"linear_0"},
+            "t31_query_after_add",
+        )
+        _assert_reporter_scope(
+            self,
+            specs[0]["uri"],
+            reported_uri,
+            self.instance_id,
+            host,
+            "mem",
+            version,
+        )
+
+        visible_host_state = self.client.get_host_cache_state({
+            "trace_id": "t31_visible_host_state",
+            "instance_id": self.instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": [block_key],
+        })
+        visible_matches = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in visible_host_state.get("hosts", [])
+        }
+        self.assertEqual(visible_matches.get(host), 1)
+
+    def test_32_post_snapshot_delta_survives_stale_cleanup(self):
+        host = f"post-snapshot-delta-{time.time_ns()}:8080"
+        block_key = 32_000_000_000 + time.time_ns() % 1_000_000_000
+        self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_node_register(["mem"])],
+                trace_id="t32_register",
+            )
+        )
+
+        old_tp0_uri = _build_event_report_uri(
+            host, "mem", {"source": "old_tp0"}
+        )
+        old_tp1_uri = _build_event_report_uri(
+            host, "mem", {"source": "old_tp1"}
+        )
+        baseline = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_snapshot([{
+                    "block_key": block_key,
+                    "medium": "mem",
+                    "specs": [
+                        {"name": "tp0", "uri": old_tp0_uri},
+                        {"name": "tp1", "uri": old_tp1_uri},
+                    ],
+                }])],
+                trace_id="t32_baseline",
+            )
+        )
+        old_version = baseline["committed_snapshot_version"]
+
+        retry_deadline = (
+            time.monotonic() + SNAPSHOT_MIN_INTERVAL_MS / 1000.0 + 1.0
+        )
+        while True:
+            omitted = self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    [_ev_block_snapshot([])],
+                    trace_id="t32_omit_block",
+                ),
+                check_ok=False,
+            )
+            if omitted["header"]["status"]["code"] == "OK":
+                break
+            self.assertEqual(
+                omitted["header"]["status"]["code"],
+                "SNAPSHOT_RATE_LIMITED",
+            )
+            self.assertLess(time.monotonic(), retry_deadline)
+            time.sleep(
+                min(
+                    max(int(omitted.get("retry_after_ms", 1)), 1) / 1000.0,
+                    0.1,
+                )
+            )
+
+        current_version = omitted["committed_snapshot_version"]
+        self.assertNotEqual(old_version, current_version)
+        new_tp0_uri = _build_event_report_uri(
+            host, "mem", {"source": "new_tp0"}
+        )
+        delta = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_add(
+                    block_key,
+                    "mem",
+                    _make_single_spec("tp0", new_tp0_uri),
+                )],
+                trace_id="t32_post_commit_delta",
+            )
+        )
+        self.assertEqual(
+            delta.get("committed_snapshot_version"), current_version
+        )
+
+        # The cleanup may run before or after this delta. The omitted tp1 is
+        # therefore allowed to be already gone or temporarily stale, but the
+        # successful post-commit tp0 write must never be reclaimed with it.
+        deadline = time.monotonic() + 3.0
+        while True:
+            specs = _query_block_specs(
+                self.client,
+                self.instance_id,
+                block_key,
+                "t32_query_after_cleanup",
+            )
+            by_name = {spec["name"]: spec for spec in specs}
+            tp0 = by_name.get("tp0")
+            if (
+                tp0
+                and _uri_identity_without_snapshot_version(tp0["uri"])
+                == _uri_identity_without_snapshot_version(new_tp0_uri)
+            ):
+                break
+            self.assertLess(
+                time.monotonic(),
+                deadline,
+                f"post-snapshot delta disappeared: {specs}",
+            )
+            time.sleep(0.05)
+        self.assertEqual(
+            _snapshot_version_from_uri(self, tp0["uri"]), current_version
+        )
+        stabilization_deadline = time.monotonic() + 1.0
+        while time.monotonic() < stabilization_deadline:
+            specs = _query_block_specs(
+                self.client,
+                self.instance_id,
+                block_key,
+                "t32_query_during_cleanup_window",
+            )
+            by_name = {spec["name"]: spec for spec in specs}
+            tp0 = by_name.get("tp0")
+            self.assertIsNotNone(
+                tp0,
+                f"post-snapshot delta was reclaimed after becoming visible: {specs}",
+            )
+            self.assertEqual(
+                _uri_identity_without_snapshot_version(tp0["uri"]),
+                _uri_identity_without_snapshot_version(new_tp0_uri),
+            )
+            self.assertEqual(
+                _snapshot_version_from_uri(self, tp0["uri"]),
+                current_version,
+            )
+            time.sleep(0.05)
+
+    def test_33_payload_shape_validation_is_fail_closed_without_side_effects(self):
+        host = f"payload-validation-{time.time_ns()}:8080"
+        block_key = 33_000_000_000 + time.time_ns() % 1_000_000_000
+        lazy_restore_key = block_key + 100
+
+        def assert_single_invalid(body):
+            self.assertEqual(
+                body.get("header", {}).get("status", {}).get("code"),
+                "INVALID_ARGUMENT",
+                body,
+            )
+            self.assertEqual(body.get("item_results"), ["INVALID_ARGUMENT"])
+
+        # event_type and its oneof payload must agree. A malformed REGISTER
+        # must not accidentally register the reporter.
+        missing_register_payload = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [{"event_type": "EVENT_NODE_REGISTER"}],
+                trace_id="t33_register_missing_payload",
+            ),
+            check_ok=False,
+        )
+        assert_single_invalid(missing_register_payload)
+        wrong_register_payload = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [{
+                    "event_type": "EVENT_NODE_REGISTER",
+                    "heartbeat": {"system_status": {}},
+                }],
+                trace_id="t33_register_wrong_payload",
+            ),
+            check_ok=False,
+        )
+        assert_single_invalid(wrong_register_payload)
+
+        same_batch_wrong_register = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [
+                    {
+                        "event_type": "EVENT_NODE_REGISTER",
+                        "heartbeat": {"system_status": {}},
+                    },
+                    _ev_block_add(
+                        lazy_restore_key,
+                        "mem",
+                        _make_single_spec(
+                            "valid_after_bad_register",
+                            _build_event_report_uri(host, "mem"),
+                        ),
+                    ),
+                ],
+                trace_id="t33_wrong_register_then_add_same_batch",
+            ),
+            check_ok=False,
+        )
+        self.assertEqual(
+            same_batch_wrong_register["header"]["status"]["code"],
+            "INVALID_ARGUMENT",
+        )
+        self.assertEqual(
+            same_batch_wrong_register.get("item_results"),
+            ["INVALID_ARGUMENT", "OK"],
+        )
+        self.assertFalse(same_batch_wrong_register.get("snapshot_required"))
+        self.assertEqual(
+            {spec.get("name") for spec in _query_block_specs(
+                self.client,
+                self.instance_id,
+                lazy_restore_key,
+                "t33_valid_add_after_wrong_register_visible",
+            )},
+            {"valid_after_bad_register"},
+        )
+
+        registered = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_node_register(["mem"])],
+                trace_id="t33_valid_register",
+            )
+        )
+        self.assertFalse(registered.get("snapshot_required"))
+        self.assertEqual(
+            registered.get("committed_snapshot_version"),
+            same_batch_wrong_register.get("committed_snapshot_version"),
+        )
+
+        missing_heartbeat_payload = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [{"event_type": "EVENT_HEARTBEAT"}],
+                trace_id="t33_heartbeat_missing_payload",
+            ),
+            check_ok=False,
+        )
+        assert_single_invalid(missing_heartbeat_payload)
+
+        baseline_uri = _build_event_report_uri(
+            host, "mem", {"source": "baseline"}
+        )
+        baseline = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_add(
+                    block_key,
+                    "mem",
+                    _make_single_spec("baseline", baseline_uri),
+                )],
+                trace_id="t33_valid_baseline",
+            )
+        )
+        baseline_version = baseline["committed_snapshot_version"]
+        self.assertEqual(len(baseline_version), 32)
+        self.assertEqual(
+            {spec.get("name") for spec in _query_block_specs(
+                self.client,
+                self.instance_id,
+                block_key,
+                "t33_baseline_visible",
+            )},
+            {"baseline"},
+        )
+
+        # A malformed HOST_DOWN must not alter liveness. The request-level
+        # HOST_DOWN exclusivity check must also happen before any event runs.
+        missing_host_down_payload = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [{"event_type": "EVENT_HOST_DOWN"}],
+                trace_id="t33_host_down_missing_payload",
+            ),
+            check_ok=False,
+        )
+        assert_single_invalid(missing_host_down_payload)
+
+        mixed_host_down = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_host_down(), _ev_heartbeat({})],
+                trace_id="t33_host_down_mixed_request",
+            ),
+            check_ok=False,
+        )
+        self.assertEqual(
+            mixed_host_down["header"]["status"]["code"],
+            "INVALID_ARGUMENT",
+        )
+        self.assertEqual(mixed_host_down.get("item_results", []), [])
+        self.assertEqual(
+            {spec.get("name") for spec in _query_block_specs(
+                self.client,
+                self.instance_id,
+                block_key,
+                "t33_still_visible_after_bad_host_down",
+            )},
+            {"baseline"},
+        )
+
+        # Invalid mutation parameters do not advance the generation and do
+        # not modify either the target block or existing metadata.
+        invalid_add_key = block_key + 1
+        client_version_uri = (
+            _build_event_report_uri(host, "mem")
+            + "?s_version="
+            + "a" * 32
+        )
+        invalid_add = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_add(
+                    invalid_add_key,
+                    "mem",
+                    _make_single_spec("client_version", client_version_uri),
+                )],
+                trace_id="t33_add_client_version",
+            ),
+            check_ok=False,
+        )
+        assert_single_invalid(invalid_add)
+        self.assertEqual(
+            invalid_add.get("committed_snapshot_version"),
+            baseline_version,
+        )
+        self.assertEqual(
+            _query_block_specs(
+                self.client,
+                self.instance_id,
+                invalid_add_key,
+                "t33_invalid_add_absent",
+            ),
+            [],
+        )
+
+        invalid_delete = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_delete(block_key, "mem", [])],
+                trace_id="t33_delete_empty_names",
+            ),
+            check_ok=False,
+        )
+        assert_single_invalid(invalid_delete)
+        invalid_snapshot = self.client.report_event(
+            _make_request(
+                self.instance_id,
+                host,
+                [_ev_block_snapshot([{
+                    "block_key": block_key,
+                    "medium": "mem",
+                    "specs": [],
+                }])],
+                trace_id="t33_snapshot_empty_specs",
+            ),
+            check_ok=False,
+        )
+        assert_single_invalid(invalid_snapshot)
+        self.assertEqual(
+            invalid_snapshot.get("committed_snapshot_version"),
+            baseline_version,
+        )
+        remaining = _query_block_specs(
+            self.client,
+            self.instance_id,
+            block_key,
+            "t33_baseline_preserved",
+        )
+        self.assertEqual(
+            {spec.get("name") for spec in remaining},
+            {"baseline"},
+        )
+        self.assertEqual(
+            _snapshot_version_from_uri(self, remaining[0]["uri"]),
+            baseline_version,
+        )
+
 # ---------------------------------------------------------------------------
 # Bench tests
 # ---------------------------------------------------------------------------
@@ -2952,7 +3937,8 @@ class EventReportBenchTest(unittest.TestCase):
 
     @staticmethod
     def _ensure_host_registered(client, instance_id, host):
-        # Register and establish the initial snapshot so deltas are accepted.
+        # The benchmark uses an empty deterministic baseline; production
+        # deltas are accepted immediately after registration.
         client.report_event(
             _make_request(instance_id, host,
                           [_ev_node_register(["mem"])],
@@ -3087,6 +4073,96 @@ class EventReportBenchTest(unittest.TestCase):
             print(f"  Latency avg:   {statistics.mean(latencies):.2f}ms")
         self.assertEqual(len(errors), 0, f"Bench had errors: {errors[:5]}")
 
+    # 19. Typical full-snapshot capacity: 10 reporters x 5000 blocks.
+    def test_19_ten_reporters_full_snapshot_capacity(self):
+        host_count = 10
+        blocks_per_host = 5000
+        snapshot_latencies = []
+
+        for host_index in range(host_count):
+            host = f"192.168.2.{host_index + 1}:8080"
+            base_key = 30_000_000 + host_index * 10_000
+            register = self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    [_ev_node_register(["mem"])],
+                    trace_id=f"bench_snapshot_register_{host_index}",
+                )
+            )
+            self.assertTrue(register.get("snapshot_required"))
+
+            blocks = [
+                {
+                    "block_key": base_key + offset,
+                    "medium": "mem",
+                    "specs": _make_single_spec(
+                        "spec_4096",
+                        _build_event_report_uri(
+                            host,
+                            "mem",
+                            {"block": str(base_key + offset)},
+                        ),
+                    ),
+                }
+                for offset in range(blocks_per_host)
+            ]
+            start = time.monotonic()
+            snapshot = self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    [_ev_block_snapshot(blocks)],
+                    trace_id=f"bench_snapshot_{host_index}",
+                )
+            )
+            snapshot_latencies.append((time.monotonic() - start) * 1000)
+            version = snapshot.get("committed_snapshot_version", "")
+            self.assertEqual(len(version), 32)
+            self.assertFalse(snapshot.get("snapshot_required"))
+
+            # Validate data, not only the ReportEvent status. The first,
+            # middle and last item catch truncation and batching boundaries.
+            for offset in (0, blocks_per_host // 2, blocks_per_host - 1):
+                block_key = base_key + offset
+                specs = _query_block_specs(
+                    self.client,
+                    self.instance_id,
+                    block_key,
+                    f"bench_snapshot_query_{host_index}_{offset}",
+                )
+                self.assertEqual(
+                    {spec.get("name") for spec in specs},
+                    {"spec_4096"},
+                )
+                self.assertEqual(len(specs), 1)
+                _assert_reporter_scope(
+                    self,
+                    specs[0]["uri"],
+                    _build_event_report_uri(
+                        host, "mem", {"block": str(block_key)}
+                    ),
+                    self.instance_id,
+                    host,
+                    "mem",
+                    version,
+                )
+
+        ordered_latencies = sorted(snapshot_latencies)
+        print("\n[BENCH] Full snapshot capacity:")
+        print(
+            f"  Reporters:    {host_count}, "
+            f"blocks/reporter: {blocks_per_host}, "
+            f"total blocks: {host_count * blocks_per_host}"
+        )
+        print(
+            f"  Latency p50: {self._percentile(ordered_latencies, 50):.2f}ms"
+        )
+        print(
+            f"  Latency p99: {self._percentile(ordered_latencies, 99):.2f}ms"
+        )
+        print(f"  Latency max: {max(ordered_latencies):.2f}ms")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Event Report ReportEvent HTTP integration tests")
@@ -3115,7 +4191,10 @@ def main():
     parser.add_argument(
         "--meta-storage-uri",
         default="",
-        help="Persistent local/Redis metadata URI used when creating the test instance group.",
+        help=(
+            "Metadata backend URI used when creating the test instance group. "
+            "Use redis:// for tests that restart the KVCM process."
+        ),
     )
 
     args, _ = parser.parse_known_args()

--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -130,7 +130,10 @@ void EventReportBackend::SetCleanupCallback(CleanupCallback cb) {
 ErrorCode EventReportBackend::RegisterNode(const std::string &instance_id,
                                            const std::string &host_ip_port,
                                            const std::vector<std::string> &mediums) {
-    if (host_ip_port.empty()) {
+    if (instance_id.empty() || !SnapshotUriUtils::IsValidLocationIdComponent(host_ip_port) ||
+        std::any_of(mediums.begin(), mediums.end(), [](const std::string &medium) {
+            return !SnapshotUriUtils::IsValidLocationIdComponent(medium);
+        })) {
         return EC_BADARGS;
     }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
@@ -178,8 +181,65 @@ ErrorCode EventReportBackend::RegisterNode(const std::string &instance_id,
     return EC_OK;
 }
 
+ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_id,
+                                                   const std::string &host_ip_port,
+                                                   const std::vector<std::string> &mediums) {
+    if (instance_id.empty() || !SnapshotUriUtils::IsValidLocationIdComponent(host_ip_port) ||
+        std::any_of(mediums.begin(), mediums.end(), [](const std::string &medium) {
+            return !SnapshotUriUtils::IsValidLocationIdComponent(medium);
+        })) {
+        return EC_BADARGS;
+    }
+
+    {
+        std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+        const auto instance_it = instance_nodes_.find(instance_id);
+        if (instance_it != instance_nodes_.end() &&
+            instance_it->second.find(host_ip_port) != instance_it->second.end()) {
+            // A normal data report must not act as a heartbeat or revive a
+            // node that the liveness loop has marked unavailable.
+            return EC_OK;
+        }
+        const auto generation_it = node_generation_.find(instance_id);
+        if (generation_it != node_generation_.end() && generation_it->second.count(host_ip_port) > 0) {
+            return EC_NODE_NOT_REGISTERED;
+        }
+    }
+
+    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    auto &host_map = instance_nodes_[instance_id];
+    if (host_map.find(host_ip_port) != host_map.end()) {
+        // Another first report won the race while the lock was upgraded.
+        return EC_OK;
+    }
+    const auto generation_it = node_generation_.find(instance_id);
+    if (generation_it != node_generation_.end() && generation_it->second.count(host_ip_port) > 0) {
+        return EC_NODE_NOT_REGISTERED;
+    }
+
+    const uint64_t generation = ++node_generation_[instance_id][host_ip_port];
+    auto info = std::make_unique<NodeInfo>();
+    info->last_heartbeat_ms.store(NowMillis(), std::memory_order_relaxed);
+    info->available.store(true, std::memory_order_relaxed);
+    info->unavailable_since_ms.store(0, std::memory_order_relaxed);
+    info->mediums = mediums;
+    info->instance_id = instance_id;
+    info->metrics_tags = {{"instance_id", instance_id}, {"host", host_ip_port}, {"type", ToString(config_.type())}};
+    host_map[host_ip_port] = std::move(info);
+
+    KVCM_LOG_INFO("EventReportBackend: lazily restored node [%s] in storage [%s] for instance [%s], "
+                  "mediums=%zu, gen=%" PRIu64,
+                  host_ip_port.c_str(),
+                  config_.global_unique_name().c_str(),
+                  instance_id.c_str(),
+                  mediums.size(),
+                  generation);
+    return EC_OK;
+}
+
 ErrorCode EventReportBackend::UnregisterNode(const std::string &instance_id, const std::string &host_ip_port) {
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    node_generation_[instance_id].try_emplace(host_ip_port, 0);
     auto inst_it = instance_nodes_.find(instance_id);
     if (inst_it == instance_nodes_.end()) {
         KVCM_LOG_WARN("EventReportBackend: instance [%s] not found for unregister node [%s]",
@@ -223,22 +283,35 @@ ErrorCode EventReportBackend::UnregisterNode(const std::string &instance_id, con
 ErrorCode EventReportBackend::OnHeartbeat(const std::string &instance_id,
                                           const std::string &host_ip_port,
                                           const std::map<std::string, std::string> &system_status) {
-    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
-    auto inst_it = instance_nodes_.find(instance_id);
-    if (inst_it == instance_nodes_.end()) {
-        KVCM_LOG_WARN("EventReportBackend: heartbeat from unregistered instance [%s] node [%s], "
-                      "returning NODE_NOT_REGISTERED",
-                      instance_id.c_str(),
-                      host_ip_port.c_str());
-        return EC_NODE_NOT_REGISTERED;
+    if (instance_id.empty() || !SnapshotUriUtils::IsValidLocationIdComponent(host_ip_port)) {
+        return EC_BADARGS;
     }
-    auto it = inst_it->second.find(host_ip_port);
-    if (it == inst_it->second.end()) {
-        KVCM_LOG_WARN("EventReportBackend: heartbeat from unregistered node [%s] for instance [%s], "
-                      "returning NODE_NOT_REGISTERED",
+    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    auto &host_map = instance_nodes_[instance_id];
+    auto it = host_map.find(host_ip_port);
+    if (it == host_map.end()) {
+        const auto generation_it = node_generation_.find(instance_id);
+        if (generation_it != node_generation_.end() && generation_it->second.count(host_ip_port) > 0) {
+            KVCM_LOG_WARN("EventReportBackend: heartbeat from tombstoned node [%s] for instance [%s], "
+                          "returning NODE_NOT_REGISTERED",
+                          host_ip_port.c_str(),
+                          instance_id.c_str());
+            return EC_NODE_NOT_REGISTERED;
+        }
+        const uint64_t generation = ++node_generation_[instance_id][host_ip_port];
+        auto new_info = std::make_unique<NodeInfo>();
+        new_info->last_heartbeat_ms.store(NowMillis(), std::memory_order_relaxed);
+        new_info->available.store(true, std::memory_order_relaxed);
+        new_info->unavailable_since_ms.store(0, std::memory_order_relaxed);
+        new_info->instance_id = instance_id;
+        new_info->metrics_tags = {
+            {"instance_id", instance_id}, {"host", host_ip_port}, {"type", ToString(config_.type())}};
+        it = host_map.emplace(host_ip_port, std::move(new_info)).first;
+        KVCM_LOG_INFO("EventReportBackend: heartbeat lazily restored node [%s] for instance [%s] "
+                      "(generation=%" PRIu64 ")",
                       host_ip_port.c_str(),
-                      instance_id.c_str());
-        return EC_NODE_NOT_REGISTERED;
+                      instance_id.c_str(),
+                      generation);
     }
     auto &info = *it->second;
     int64_t now_ms = NowMillis();
@@ -488,6 +561,10 @@ std::vector<ErrorCode> EventReportBackend::UnLock(const std::vector<DataStorageU
 }
 
 std::string EventReportBackend::BuildLocationId(const std::string &medium, const std::string &host_ip_port) const {
+    if (!SnapshotUriUtils::IsValidLocationIdComponent(medium) ||
+        !SnapshotUriUtils::IsValidLocationIdComponent(host_ip_port)) {
+        return {};
+    }
     const std::string type_token = ToString(config_.type());
     std::string result;
     result.reserve(4 + type_token.size() + 1 + medium.size() + 1 + host_ip_port.size());
@@ -521,14 +598,32 @@ ErrorCode EventReportBackend::BeginDeltaMutation(const ReporterSnapshotKey &repo
         auto it = snapshot_versions_.find(reporter_key);
         return it == snapshot_versions_.end() || it->second.in_flight.empty();
     });
-    auto it = snapshot_versions_.find(reporter_key);
-    if (it == snapshot_versions_.end()) {
-        return EC_SNAPSHOT_REQUIRED;
+    auto state_it = snapshot_versions_.find(reporter_key);
+    if (state_it == snapshot_versions_.end() || state_it->second.committed.empty()) {
+        const auto instance_it = instance_nodes_.find(reporter_key.instance_id);
+        if (instance_it == instance_nodes_.end() ||
+            instance_it->second.find(reporter_key.host_ip_port) == instance_it->second.end()) {
+            return EC_SNAPSHOT_REQUIRED;
+        }
+
+        auto token_in_use = [this](const std::string &token) {
+            if (snapshot_token_owners_.count(token) > 0) {
+                return true;
+            }
+            return std::any_of(snapshot_versions_.begin(), snapshot_versions_.end(), [&token](const auto &entry) {
+                return entry.second.in_flight == token;
+            });
+        };
+        std::string candidate;
+        do {
+            candidate = GenerateSnapshotVersionToken();
+        } while (token_in_use(candidate));
+        auto &new_state = snapshot_versions_[reporter_key];
+        new_state.committed = candidate;
+        snapshot_token_owners_[candidate] = reporter_key;
+        state_it = snapshot_versions_.find(reporter_key);
     }
-    auto &state = it->second;
-    if (state.committed.empty()) {
-        return EC_SNAPSHOT_REQUIRED;
-    }
+    auto &state = state_it->second;
     if (state.active_delta_mutations == std::numeric_limits<uint64_t>::max()) {
         return EC_ERROR;
     }
@@ -563,6 +658,11 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
         return EC_BADARGS;
     }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    const auto instance_it = instance_nodes_.find(reporter_key.instance_id);
+    if (instance_it == instance_nodes_.end() ||
+        instance_it->second.find(reporter_key.host_ip_port) == instance_it->second.end()) {
+        return EC_SNAPSHOT_REQUIRED;
+    }
     auto &state = snapshot_versions_[reporter_key];
     if (!state.in_flight.empty()) {
         return EC_SNAPSHOT_IN_PROGRESS;

--- a/kv_cache_manager/data_storage/event_report_backend.h
+++ b/kv_cache_manager/data_storage/event_report_backend.h
@@ -45,6 +45,10 @@ public:
                                   const std::string &trace_id,
                                   std::function<void()> cb) override;
     std::vector<bool> Exist(const std::vector<DataStorageUri> &storage_uris) override;
+    // Conservative context-free storage check. Public cache queries use
+    // CacheManager's location-aware checker because this interface has no
+    // instance id or stable location id with which to validate legacy and
+    // mixed-generation metadata.
     std::vector<bool> MightExist(const std::vector<DataStorageUri> &storage_uris) override;
     std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &storage_uris) override;
     std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &storage_uris) override;
@@ -56,6 +60,13 @@ public:
     ErrorCode RegisterNode(const std::string &instance_id,
                            const std::string &host_ip_port,
                            const std::vector<std::string> &mediums);
+    // Rebuilds a missing process-local reporter entry on the first valid
+    // report from a fresh caller or after KVCM restart. Unlike an explicit
+    // REGISTER, the fast path does not refresh liveness, revive an unavailable
+    // reporter, or clear a same-process unregister tombstone.
+    ErrorCode EnsureNodeRegistered(const std::string &instance_id,
+                                   const std::string &host_ip_port,
+                                   const std::vector<std::string> &mediums);
     ErrorCode UnregisterNode(const std::string &instance_id, const std::string &host_ip_port);
     ErrorCode OnHeartbeat(const std::string &instance_id,
                           const std::string &host_ip_port,
@@ -111,12 +122,15 @@ private:
     mutable std::shared_mutex nodes_mutex_;
     // instance_id -> (host_ip_port -> NodeInfo)
     std::unordered_map<std::string, std::unordered_map<std::string, std::unique_ptr<NodeInfo>>> instance_nodes_;
-    // Persists across unregister/register to fence stale cleanup.
+    // Persists across unregister/register to fence stale cleanup. An entry
+    // without a live instance_nodes_ entry is also the same-process
+    // unregister tombstone. Close() clears both maps, so the first valid
+    // report after process restart can lazily rebuild the node.
     // instance_id -> (host_ip_port -> generation)
     std::unordered_map<std::string, std::unordered_map<std::string, uint64_t>> node_generation_;
     struct SnapshotVersionState {
-        // Process-local reporter state, not a distributed lock. KVCM restart clears
-        // this state and requires the reporter to rebuild it with a full snapshot.
+        // Process-local reporter state, not a distributed lock. KVCM restart
+        // clears this state; the first valid delta or snapshot rebuilds it.
         std::string committed;
         std::string in_flight;
         uint64_t active_delta_mutations = 0;

--- a/kv_cache_manager/data_storage/snapshot_uri_utils.h
+++ b/kv_cache_manager/data_storage/snapshot_uri_utils.h
@@ -38,6 +38,10 @@ class SnapshotUriUtils {
 public:
     inline static constexpr const char *kSnapshotVersionParam = "s_version";
 
+    static bool IsValidLocationIdComponent(const std::string &value) {
+        return !value.empty() && value.find('#') == std::string::npos;
+    }
+
     static size_t CountUriParam(const std::string &uri_text, const std::string &key) {
         const size_t query_begin = uri_text.find('?');
         if (query_begin == std::string::npos) {

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <future>
 #include <gtest/gtest.h>
@@ -37,6 +38,21 @@ public:
 
     std::shared_ptr<MetricsRegistry> metrics_registry_;
 };
+
+ErrorCode BeginSnapshotForRegisteredReporter(EventReportBackend &backend,
+                                             const ReporterSnapshotKey &reporter_key,
+                                             std::string &out_candidate_version,
+                                             uint64_t &out_retry_after_ms) {
+    if (!reporter_key.instance_id.empty() && !reporter_key.host_ip_port.empty() &&
+        !backend.IsNodeRegistered(reporter_key.instance_id, reporter_key.host_ip_port)) {
+        const ErrorCode register_ec =
+            backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"});
+        if (register_ec != EC_OK) {
+            return register_ec;
+        }
+    }
+    return backend.BeginSnapshot(reporter_key, out_candidate_version, out_retry_after_ms);
+}
 
 // (1) GetType / Available / Create-Delete EC_UNIMPLEMENTED / GetStorageUsageRatio=1.0
 TEST_F(EventReportBackendTest, BasicAccessors) {
@@ -84,6 +100,11 @@ TEST_F(EventReportBackendTest, BuildLocationIdIncludesEventReportType) {
     EXPECT_FALSE(l1p5_backend.ParseLocationId(l2_location, medium, host));
     EXPECT_TRUE(l2_backend.ParseLocationId(l2_location, medium, host));
     EXPECT_FALSE(l2_backend.ParseLocationId(l1p5_location, medium, host));
+    EXPECT_TRUE(l1p5_backend.BuildLocationId("mem#bad", "10.0.0.1:8080").empty());
+    EXPECT_TRUE(l1p5_backend.BuildLocationId("mem", "10.0.0.1#8080").empty());
+    EXPECT_FALSE(SnapshotUriUtils::IsValidLocationIdComponent(""));
+    EXPECT_FALSE(SnapshotUriUtils::IsValidLocationIdComponent("mem#bad"));
+    EXPECT_TRUE(SnapshotUriUtils::IsValidLocationIdComponent("hbm-cache"));
 }
 
 TEST_F(EventReportBackendTest, OpenWithWrongSpecTypeFails) {
@@ -119,6 +140,9 @@ TEST_F(EventReportBackendTest, RegisterNodeWithMediums) {
     ASSERT_EQ(EC_OK, backend.Open(MakeConfig(), "trace"));
 
     ASSERT_EQ(EC_BADARGS, backend.RegisterNode("test_inst", "", {"mem"}));
+    ASSERT_EQ(EC_BADARGS, backend.RegisterNode("", "10.0.0.1:8080", {"mem"}));
+    ASSERT_EQ(EC_BADARGS, backend.RegisterNode("test_inst", "10.0.0.1#8080", {"mem"}));
+    ASSERT_EQ(EC_BADARGS, backend.RegisterNode("test_inst", "10.0.0.1:8080", {"mem#bad"}));
     ASSERT_EQ(EC_OK, backend.RegisterNode("test_inst", "10.0.0.1:8080", {"mem", "disk"}));
     ASSERT_TRUE(backend.IsNodeAvailable("test_inst", "10.0.0.1:8080"));
 
@@ -132,11 +156,19 @@ TEST_F(EventReportBackendTest, RegisterNodeWithMediums) {
 
     backend.SetNodeUnavailable("test_inst", "10.0.0.1:8080");
     ASSERT_FALSE(backend.IsNodeAvailable("test_inst", "10.0.0.1:8080"));
+    ASSERT_EQ(EC_OK, backend.EnsureNodeRegistered("test_inst", "10.0.0.1:8080", {"hbm"}));
+    ASSERT_FALSE(backend.IsNodeAvailable("test_inst", "10.0.0.1:8080"));
     ASSERT_EQ(EC_OK, backend.RegisterNode("test_inst", "10.0.0.1:8080", {"mem"}));
     ASSERT_TRUE(backend.IsNodeAvailable("test_inst", "10.0.0.1:8080"));
 
     ASSERT_EQ(EC_OK, backend.UnregisterNode("test_inst", "10.0.0.1:8080"));
     ASSERT_FALSE(backend.IsNodeAvailable("test_inst", "10.0.0.1:8080"));
+    ASSERT_EQ(EC_NODE_NOT_REGISTERED,
+              backend.EnsureNodeRegistered("test_inst", "10.0.0.1:8080", {"mem"}));
+    ASSERT_EQ(EC_NODE_NOT_REGISTERED, backend.OnHeartbeat("test_inst", "10.0.0.1:8080", {}));
+    ASSERT_EQ(EC_OK, backend.RegisterNode("test_inst", "10.0.0.1:8080", {"mem"}));
+    ASSERT_TRUE(backend.IsNodeAvailable("test_inst", "10.0.0.1:8080"));
+    ASSERT_EQ(EC_OK, backend.UnregisterNode("test_inst", "10.0.0.1:8080"));
     ASSERT_EQ(EC_NOENT, backend.UnregisterNode("test_inst", "10.0.0.1:8080"));
     ASSERT_EQ(EC_OK, backend.Close());
 }
@@ -152,7 +184,7 @@ TEST_F(EventReportBackendTest, MightExistTracksRegisteredNodeAvailability) {
     const ReporterSnapshotKey reporter_key{instance_id, available_host};
     std::string committed_token;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, committed_token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, committed_token, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, committed_token));
 
     std::string available_uri_string;
@@ -221,9 +253,44 @@ TEST_F(EventReportBackendTest, OnHeartbeatRefreshesAndRevivesNode) {
         ASSERT_EQ(it->second->unavailable_since_ms.load(), 0);
     }
 
-    ASSERT_EQ(EC_NODE_NOT_REGISTERED, backend.OnHeartbeat("test_inst", "99.99.99.99:8080", {{"x", "y"}}));
-    ASSERT_EQ(backend.instance_nodes_["test_inst"].count("99.99.99.99:8080"), 0u);
+    ASSERT_EQ(EC_OK, backend.OnHeartbeat("test_inst", "99.99.99.99:8080", {{"x", "y"}}));
+    ASSERT_TRUE(backend.IsNodeRegistered("test_inst", "99.99.99.99:8080"));
+    ASSERT_TRUE(backend.IsNodeAvailable("test_inst", "99.99.99.99:8080"));
+    ASSERT_EQ(backend.instance_nodes_["test_inst"]["99.99.99.99:8080"]->last_system_status.at("x"), "y");
 
+    ASSERT_EQ(EC_OK, backend.Close());
+}
+
+TEST_F(EventReportBackendTest, DataMutationsDoNotRefreshHeartbeat) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 50), "trace"));
+    const ReporterSnapshotKey reporter_key{"test_inst", "10.0.0.31:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+
+    int64_t registered_heartbeat_ms = 0;
+    {
+        std::shared_lock<std::shared_mutex> lock(backend.nodes_mutex_);
+        const auto instance_it = backend.instance_nodes_.find(reporter_key.instance_id);
+        ASSERT_NE(backend.instance_nodes_.end(), instance_it);
+        const auto host_it = instance_it->second.find(reporter_key.host_ip_port);
+        ASSERT_NE(instance_it->second.end(), host_it);
+        registered_heartbeat_ms = host_it->second->last_heartbeat_ms.load();
+    }
+
+    std::string delta_version;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, delta_version));
+    backend.EndDeltaMutation(reporter_key);
+
+    std::string snapshot_version;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, snapshot_version, retry_after_ms));
+    backend.AbortSnapshotVersion(reporter_key, snapshot_version);
+
+    {
+        std::shared_lock<std::shared_mutex> lock(backend.nodes_mutex_);
+        const auto &node = backend.instance_nodes_.at(reporter_key.instance_id).at(reporter_key.host_ip_port);
+        EXPECT_EQ(registered_heartbeat_ms, node->last_heartbeat_ms.load());
+    }
     ASSERT_EQ(EC_OK, backend.Close());
 }
 
@@ -308,7 +375,7 @@ TEST_F(EventReportBackendTest, HeartbeatRecoveryFencesCleanupAlreadySelectedByLi
 
     std::string token;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, token, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, token));
     std::string uri;
     ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri("event_report://physical-cache:9600/mem", token, uri));
@@ -619,7 +686,7 @@ TEST_F(EventReportBackendTest, TwoInstancesSameHostIsolated) {
     ASSERT_EQ(EC_OK, backend.Close());
 }
 
-TEST(EventReportBackendSnapshotTest, RequiresSnapshotBeforeAnyDelta) {
+TEST(EventReportBackendSnapshotTest, UnregisteredReporterCannotCreateDeltaVersion) {
     EventReportBackend backend(nullptr);
     const ReporterSnapshotKey scope{"instance-a", "10.0.0.1:8080"};
 
@@ -629,6 +696,58 @@ TEST(EventReportBackendSnapshotTest, RequiresSnapshotBeforeAnyDelta) {
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
 }
 
+TEST(EventReportBackendSnapshotTest, RegisteredReporterFirstDeltaCreatesReusableVersion) {
+    EventReportBackend backend(nullptr);
+    const ReporterSnapshotKey reporter_key{"instance-a", "10.0.0.1:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"hbm"}));
+
+    std::string first;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, first));
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(first));
+    EXPECT_EQ(first, backend.GetSnapshotVersion(reporter_key));
+    backend.EndDeltaMutation(reporter_key);
+
+    std::string second;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, second));
+    EXPECT_EQ(first, second);
+    backend.EndDeltaMutation(reporter_key);
+}
+
+TEST(EventReportBackendSnapshotTest, ConcurrentFirstDeltasPublishExactlyOneReusableVersion) {
+    EventReportBackend backend(nullptr);
+    const ReporterSnapshotKey reporter_key{"instance-a", "10.0.0.2:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"hbm"}));
+
+    constexpr size_t kThreadCount = 32;
+    std::atomic<bool> start{false};
+    std::vector<ErrorCode> ecs(kThreadCount, EC_ERROR);
+    std::vector<std::string> versions(kThreadCount);
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+    for (size_t i = 0; i < kThreadCount; ++i) {
+        threads.emplace_back([&, i] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            ecs[i] = backend.BeginDeltaMutation(reporter_key, versions[i]);
+            if (ecs[i] == EC_OK) {
+                backend.EndDeltaMutation(reporter_key);
+            }
+        });
+    }
+    start.store(true, std::memory_order_release);
+    for (auto &thread : threads) {
+        thread.join();
+    }
+
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(versions.front()));
+    for (size_t i = 0; i < kThreadCount; ++i) {
+        EXPECT_EQ(EC_OK, ecs[i]) << "thread=" << i;
+        EXPECT_EQ(versions.front(), versions[i]) << "thread=" << i;
+    }
+    EXPECT_EQ(versions.front(), backend.GetSnapshotVersion(reporter_key));
+}
+
 TEST(EventReportBackendSnapshotTest, SnapshotCommitPublishesOpaqueToken) {
     EventReportBackend backend(nullptr);
     backend.SetSnapshotMinIntervalMsForTest(0);
@@ -636,7 +755,7 @@ TEST(EventReportBackendSnapshotTest, SnapshotCommitPublishesOpaqueToken) {
 
     std::string candidate;
     uint64_t retry_after_ms = 123;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope, candidate, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, candidate, retry_after_ms));
     EXPECT_EQ(0u, retry_after_ms);
     EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(candidate));
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
@@ -659,7 +778,7 @@ TEST(EventReportBackendSnapshotTest, SnapshotTokensAreNeverReusedAcrossAttempts)
     for (size_t attempt = 0; attempt < 128; ++attempt) {
         std::string candidate;
         uint64_t retry_after_ms = 0;
-        ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms));
+        ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_after_ms));
         ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(candidate));
         EXPECT_TRUE(observed.insert(candidate).second);
         if (attempt % 2 == 0) {
@@ -678,10 +797,12 @@ TEST(EventReportBackendSnapshotTest, SnapshotAndDeltaWaitForEachOther) {
 
     std::string first;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
 
     std::string concurrent_snapshot;
-    EXPECT_EQ(EC_SNAPSHOT_IN_PROGRESS, backend.BeginSnapshot(reporter_key, concurrent_snapshot, retry_after_ms));
+    EXPECT_EQ(EC_SNAPSHOT_IN_PROGRESS,
+              BeginSnapshotForRegisteredReporter(
+                  backend, reporter_key, concurrent_snapshot, retry_after_ms));
 
     std::promise<void> delta_started;
     std::promise<std::pair<ErrorCode, std::string>> delta_result;
@@ -714,7 +835,7 @@ TEST(EventReportBackendSnapshotTest, SnapshotAndDeltaWaitForEachOther) {
         snapshot_started.set_value();
         std::string candidate;
         uint64_t retry_ms = 0;
-        const ErrorCode ec = backend.BeginSnapshot(reporter_key, candidate, retry_ms);
+        const ErrorCode ec = BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_ms);
         snapshot_result.set_value({ec, candidate, retry_ms});
     });
     snapshot_started.get_future().wait();
@@ -740,11 +861,11 @@ TEST(EventReportBackendSnapshotTest, AbortUnblocksWaitingDeltaWithoutPublishingC
 
     std::string first;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first));
 
     std::string candidate;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_after_ms));
     std::string observed_committed;
     std::string observed_in_flight;
     backend.GetSnapshotVersionTokens(reporter_key, observed_committed, observed_in_flight);
@@ -781,7 +902,7 @@ TEST(EventReportBackendSnapshotTest, CommitUnblocksAllWaitingDeltasWithNewToken)
 
     std::string candidate;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_after_ms));
 
     constexpr size_t kWaiterCount = 4;
     std::vector<std::future<std::pair<ErrorCode, std::string>>> futures;
@@ -816,7 +937,7 @@ TEST(EventReportBackendSnapshotTest, SnapshotWaitsUntilEveryAdmittedDeltaDrains)
 
     std::string first;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first));
 
     constexpr size_t kActiveDeltaCount = 3;
@@ -829,7 +950,7 @@ TEST(EventReportBackendSnapshotTest, SnapshotWaitsUntilEveryAdmittedDeltaDrains)
     auto snapshot = std::async(std::launch::async, [&] {
         std::string candidate;
         uint64_t retry_ms = 0;
-        const ErrorCode ec = backend.BeginSnapshot(reporter_key, candidate, retry_ms);
+        const ErrorCode ec = BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_ms);
         return std::make_tuple(ec, candidate, retry_ms);
     });
     EXPECT_EQ(std::future_status::timeout, snapshot.wait_for(20ms));
@@ -863,7 +984,7 @@ TEST(EventReportBackendSnapshotTest, ConcurrentSnapshotsHaveExactlyOneWinner) {
             start_signal.wait();
             std::string candidate;
             uint64_t retry_after_ms = 0;
-            const ErrorCode ec = backend.BeginSnapshot(reporter_key, candidate, retry_after_ms);
+            const ErrorCode ec = BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_after_ms);
             return std::make_pair(ec, candidate);
         }));
     }
@@ -900,7 +1021,7 @@ TEST(EventReportBackendSnapshotTest, UnregisterCancelsSnapshotWaitingForActiveDe
 
     std::string first;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first));
     std::string committed;
     ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, committed));
@@ -908,7 +1029,7 @@ TEST(EventReportBackendSnapshotTest, UnregisterCancelsSnapshotWaitingForActiveDe
     auto snapshot = std::async(std::launch::async, [&] {
         std::string candidate = "stale";
         uint64_t retry_ms = 99;
-        const ErrorCode ec = backend.BeginSnapshot(reporter_key, candidate, retry_ms);
+        const ErrorCode ec = BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_ms);
         return std::make_tuple(ec, candidate, retry_ms);
     });
     EXPECT_EQ(std::future_status::timeout, snapshot.wait_for(20ms));
@@ -922,6 +1043,35 @@ TEST(EventReportBackendSnapshotTest, UnregisterCancelsSnapshotWaitingForActiveDe
     backend.EndDeltaMutation(reporter_key);
 }
 
+TEST_F(EventReportBackendTest, AutomaticLivenessCleanupCancelsSnapshotWaitingForActiveDelta) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 20, /*grace*/ 20, /*tick*/ 5), "liveness_snapshot_wait"));
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    const ReporterSnapshotKey reporter_key{"instance-a", "10.0.0.60:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+
+    std::string committed;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, committed));
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(committed));
+
+    auto snapshot = std::async(std::launch::async, [&] {
+        std::string candidate = "stale";
+        uint64_t retry_after_ms = 99;
+        const ErrorCode ec = backend.BeginSnapshot(reporter_key, candidate, retry_after_ms);
+        return std::make_tuple(ec, candidate, retry_after_ms);
+    });
+    EXPECT_EQ(std::future_status::timeout, snapshot.wait_for(5ms));
+    ASSERT_EQ(std::future_status::ready, snapshot.wait_for(2s));
+    const auto [ec, candidate, retry_after_ms] = snapshot.get();
+    EXPECT_EQ(EC_SNAPSHOT_REQUIRED, ec);
+    EXPECT_TRUE(candidate.empty());
+    EXPECT_EQ(0u, retry_after_ms);
+    EXPECT_FALSE(backend.IsNodeRegistered(reporter_key.instance_id, reporter_key.host_ip_port));
+    EXPECT_TRUE(backend.GetSnapshotVersion(reporter_key).empty());
+
+    ASSERT_EQ(EC_OK, backend.Close());
+}
+
 TEST(EventReportBackendSnapshotTest, UnregisterUnblocksWaitingDeltaAndRequiresNewSnapshot) {
     EventReportBackend backend(nullptr);
     backend.SetSnapshotMinIntervalMsForTest(0);
@@ -932,10 +1082,10 @@ TEST(EventReportBackendSnapshotTest, UnregisterUnblocksWaitingDeltaAndRequiresNe
 
     std::string first;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first));
     std::string second;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, second, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, second, retry_after_ms));
 
     auto delta = std::async(std::launch::async, [&] {
         std::string committed = "stale";
@@ -958,11 +1108,11 @@ TEST(EventReportBackendSnapshotTest, OtherReporterIsNotBlockedBySnapshot) {
     uint64_t retry_after_ms = 0;
 
     std::string token_b;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_b, token_b, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_b, token_b, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_b, token_b));
 
     std::string token_a;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_a, token_a, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_a, token_a, retry_after_ms));
     std::string committed_b;
     EXPECT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_b, committed_b));
     EXPECT_EQ(token_b, committed_b);
@@ -977,17 +1127,19 @@ TEST(EventReportBackendSnapshotTest, AbortNeverPublishesAndWrongTokenCannotCommi
 
     std::string candidate;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope, candidate, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, candidate, retry_after_ms));
     EXPECT_FALSE(backend.CommitSnapshotVersion(scope, std::string(32, 'f')));
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
 
     backend.AbortSnapshotVersion(scope, std::string(32, 'e'));
     std::string still_blocked;
-    EXPECT_EQ(EC_SNAPSHOT_IN_PROGRESS, backend.BeginSnapshot(scope, still_blocked, retry_after_ms));
+    EXPECT_EQ(
+        EC_SNAPSHOT_IN_PROGRESS,
+        BeginSnapshotForRegisteredReporter(backend, scope, still_blocked, retry_after_ms));
 
     backend.AbortSnapshotVersion(scope, candidate);
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
-    EXPECT_EQ(EC_OK, backend.BeginSnapshot(scope, still_blocked, retry_after_ms));
+    EXPECT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, still_blocked, retry_after_ms));
     backend.AbortSnapshotVersion(scope, still_blocked);
 }
 
@@ -998,11 +1150,11 @@ TEST(EventReportBackendSnapshotTest, SnapshotRateLimitReturnsRetryDelay) {
 
     std::string first;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope, first, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, first, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(scope, first));
 
     std::string second;
-    EXPECT_EQ(EC_SNAPSHOT_RATE_LIMITED, backend.BeginSnapshot(scope, second, retry_after_ms));
+    EXPECT_EQ(EC_SNAPSHOT_RATE_LIMITED, BeginSnapshotForRegisteredReporter(backend, scope, second, retry_after_ms));
     EXPECT_GT(retry_after_ms, 0u);
     EXPECT_LE(retry_after_ms, 30'000u);
     EXPECT_TRUE(second.empty());
@@ -1011,13 +1163,13 @@ TEST(EventReportBackendSnapshotTest, SnapshotRateLimitReturnsRetryDelay) {
     std::this_thread::sleep_for(2ms);
     second = "stale";
     retry_after_ms = 0;
-    EXPECT_EQ(EC_SNAPSHOT_RATE_LIMITED, backend.BeginSnapshot(scope, second, retry_after_ms));
+    EXPECT_EQ(EC_SNAPSHOT_RATE_LIMITED, BeginSnapshotForRegisteredReporter(backend, scope, second, retry_after_ms));
     EXPECT_TRUE(second.empty());
     EXPECT_GT(retry_after_ms, 0u);
     EXPECT_LE(retry_after_ms, first_retry_after_ms);
 
     backend.SetSnapshotMinIntervalMsForTest(0);
-    EXPECT_EQ(EC_OK, backend.BeginSnapshot(scope, second, retry_after_ms));
+    EXPECT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, second, retry_after_ms));
     backend.AbortSnapshotVersion(scope, second);
 }
 
@@ -1030,11 +1182,13 @@ TEST_F(EventReportBackendTest, ConfiguredSnapshotRateLimitIsAppliedOnOpen) {
     const ReporterSnapshotKey reporter_key{"instance-a", "10.0.0.1:8080"};
     std::string first;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first));
 
     std::string second = "stale";
-    ASSERT_EQ(EC_SNAPSHOT_RATE_LIMITED, backend.BeginSnapshot(reporter_key, second, retry_after_ms));
+    ASSERT_EQ(
+        EC_SNAPSHOT_RATE_LIMITED,
+        BeginSnapshotForRegisteredReporter(backend, reporter_key, second, retry_after_ms));
     EXPECT_TRUE(second.empty());
     EXPECT_GT(retry_after_ms, 100'000u);
     EXPECT_LE(retry_after_ms, 120'000u);
@@ -1052,9 +1206,9 @@ TEST(EventReportBackendSnapshotTest, ScopesAreIsolatedByInstanceAndReporterHost)
     std::string token_b;
     std::string token_c;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope_a, token_a, retry_after_ms));
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope_b, token_b, retry_after_ms));
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope_c, token_c, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope_a, token_a, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope_b, token_b, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope_c, token_c, retry_after_ms));
     EXPECT_NE(token_a, token_b);
     EXPECT_NE(token_a, token_c);
     EXPECT_NE(token_b, token_c);
@@ -1074,15 +1228,23 @@ TEST(EventReportBackendSnapshotTest, UnregisterForcesFullSnapshotAgain) {
     const std::string host = "10.0.0.1:8080";
     const ReporterSnapshotKey scope{instance_id, host};
 
+    std::string rejected_token;
+    uint64_t retry_after_ms = 0;
+    EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginSnapshot(scope, rejected_token, retry_after_ms));
+    EXPECT_TRUE(rejected_token.empty());
+    EXPECT_EQ(0u, backend.snapshot_versions_.count(scope));
+
     ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, host, {"hbm", "dram"}));
     std::string token;
-    uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope, token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, token, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(scope, token));
     ASSERT_EQ(token, backend.GetSnapshotVersion(scope));
 
     ASSERT_EQ(EC_OK, backend.UnregisterNode(instance_id, host));
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
+    EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginSnapshot(scope, rejected_token, retry_after_ms));
+    EXPECT_TRUE(rejected_token.empty());
+    EXPECT_EQ(0u, backend.snapshot_versions_.count(scope));
     std::string committed;
     EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginDeltaMutation(scope, committed));
 }
@@ -1101,7 +1263,7 @@ TEST(EventReportBackendSnapshotTest, FailedDeltaClearsOutputAndDoesNotCreateACom
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
 }
 
-TEST(EventReportBackendSnapshotTest, UnregisterThenReregisterRequiresNewSnapshot) {
+TEST(EventReportBackendSnapshotTest, UnregisterThenReregisterLetsFirstDeltaCreateNewVersion) {
     EventReportBackend backend(nullptr);
     backend.SetSnapshotMinIntervalMsForTest(0);
     const std::string instance_id = "instance-a";
@@ -1111,18 +1273,20 @@ TEST(EventReportBackendSnapshotTest, UnregisterThenReregisterRequiresNewSnapshot
     ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, host, {"hbm", "dram"}));
     std::string first_token;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope, first_token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, first_token, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(scope, first_token));
 
     ASSERT_EQ(EC_OK, backend.UnregisterNode(instance_id, host));
     ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, host, {"hbm", "dram"}));
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
     std::string committed = "stale-token";
-    EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginDeltaMutation(scope, committed));
-    EXPECT_TRUE(committed.empty());
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(scope, committed));
+    EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(committed));
+    EXPECT_NE(first_token, committed);
+    backend.EndDeltaMutation(scope);
 
     std::string second_token;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(scope, second_token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, scope, second_token, retry_after_ms));
     EXPECT_NE(first_token, second_token);
     EXPECT_TRUE(backend.CommitSnapshotVersion(scope, second_token));
 }
@@ -1151,7 +1315,7 @@ TEST(EventReportBackendSnapshotTest, RegisterAndHeartbeatPreserveCommittedToken)
     ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, host, {"hbm"}));
     std::string token;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, token, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, token));
 
     EXPECT_EQ(EC_OK, backend.RegisterNode(instance_id, host, {"memory"}));
@@ -1171,11 +1335,14 @@ TEST(EventReportBackendSnapshotTest, InvalidInputsDoNotMutateOrReleaseSnapshotSt
 
     std::string candidate = "stale";
     uint64_t retry_after_ms = 99;
-    EXPECT_EQ(EC_BADARGS, backend.BeginSnapshot({"", reporter_key.host_ip_port}, candidate, retry_after_ms));
+    EXPECT_EQ(
+        EC_BADARGS,
+        BeginSnapshotForRegisteredReporter(
+            backend, {"", reporter_key.host_ip_port}, candidate, retry_after_ms));
     EXPECT_TRUE(candidate.empty());
     EXPECT_EQ(0u, retry_after_ms);
 
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_after_ms));
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(candidate));
     EXPECT_FALSE(backend.CommitSnapshotVersion(reporter_key, ""));
     EXPECT_FALSE(backend.CommitSnapshotVersion(reporter_key, std::string(31, 'a')));
@@ -1184,12 +1351,14 @@ TEST(EventReportBackendSnapshotTest, InvalidInputsDoNotMutateOrReleaseSnapshotSt
     backend.AbortSnapshotVersion(reporter_key, std::string(32, 'f'));
     std::string blocked = "stale";
     retry_after_ms = 99;
-    EXPECT_EQ(EC_SNAPSHOT_IN_PROGRESS, backend.BeginSnapshot(reporter_key, blocked, retry_after_ms));
+    EXPECT_EQ(
+        EC_SNAPSHOT_IN_PROGRESS,
+        BeginSnapshotForRegisteredReporter(backend, reporter_key, blocked, retry_after_ms));
     EXPECT_TRUE(blocked.empty());
     EXPECT_EQ(0u, retry_after_ms);
 
     backend.AbortSnapshotVersion(reporter_key, candidate);
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_after_ms));
     backend.AbortSnapshotVersion(reporter_key, candidate);
 }
 
@@ -1247,7 +1416,7 @@ TEST(EventReportBackendSnapshotTest, MightExistRequiresCurrentTokenAndAvailableR
 
     std::string token;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, token, retry_after_ms));
 
     // The URI endpoint may differ from the reporter identity. The opaque
     // token must resolve the owner; URI hostname must not be used for liveness.
@@ -1273,7 +1442,7 @@ TEST(EventReportBackendSnapshotTest, MightExistRequiresCurrentTokenAndAvailableR
     EXPECT_EQ((std::vector<bool>{true}), backend.MightExist({committed_uri}));
 
     std::string replacement_token;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, replacement_token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, replacement_token, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, replacement_token));
     std::string replacement_uri;
     ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(raw_uri, replacement_token, replacement_uri));
@@ -1296,7 +1465,7 @@ TEST_F(EventReportBackendTest, MightExistFollowsAutomaticLivenessAndFullReporter
 
     std::string first_token;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first_token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first_token, retry_after_ms));
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first_token));
     std::string first_uri;
     ASSERT_TRUE(
@@ -1328,11 +1497,13 @@ TEST_F(EventReportBackendTest, MightExistFollowsAutomaticLivenessAndFullReporter
     EXPECT_TRUE(backend.GetSnapshotVersion(reporter_key).empty());
     EXPECT_EQ((std::vector<bool>{false}), backend.MightExist({DataStorageUri(first_uri)}));
     std::string committed = "must-be-cleared";
-    EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginDeltaMutation(reporter_key, committed));
-    EXPECT_TRUE(committed.empty());
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, committed));
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(committed));
+    EXPECT_NE(first_token, committed);
+    backend.EndDeltaMutation(reporter_key);
 
     std::string second_token;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, second_token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, second_token, retry_after_ms));
     ASSERT_NE(first_token, second_token);
     ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, second_token));
     std::string second_uri;
@@ -1355,7 +1526,7 @@ TEST(EventReportBackendSnapshotTest, MightExistBatchPreservesOrderAcrossTokenAnd
     auto commit = [&](const ReporterSnapshotKey &reporter) {
         std::string token;
         uint64_t retry_after_ms = 0;
-        EXPECT_EQ(EC_OK, backend.BeginSnapshot(reporter, token, retry_after_ms));
+        EXPECT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter, token, retry_after_ms));
         EXPECT_TRUE(backend.CommitSnapshotVersion(reporter, token));
         return token;
     };
@@ -1399,7 +1570,7 @@ TEST(EventReportBackendSnapshotTest, MightExistUsesTokenOwnerAcrossInstancesAndP
     auto commit_snapshot = [&](const ReporterSnapshotKey &reporter_key) {
         std::string token;
         uint64_t retry_after_ms = 0;
-        EXPECT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, token, retry_after_ms));
+        EXPECT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, token, retry_after_ms));
         EXPECT_TRUE(backend.CommitSnapshotVersion(reporter_key, token));
         return token;
     };
@@ -1416,7 +1587,7 @@ TEST(EventReportBackendSnapshotTest, MightExistUsesTokenOwnerAcrossInstancesAndP
 
     std::string aborted_token;
     uint64_t retry_after_ms = 0;
-    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_a, aborted_token, retry_after_ms));
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_a, aborted_token, retry_after_ms));
     std::string aborted_uri;
     ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(raw_uri, aborted_token, aborted_uri));
     EXPECT_EQ((std::vector<bool>{true, false}),
@@ -1444,7 +1615,7 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
         std::string token;
         uint64_t retry_after_ms = 0;
-        ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, token, retry_after_ms));
+        ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, token, retry_after_ms));
         ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, token));
         std::string committed;
         ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, committed));
@@ -1452,7 +1623,7 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         auto waiting_snapshot = std::async(std::launch::async, [&] {
             std::string candidate;
             uint64_t retry_ms = 0;
-            return backend.BeginSnapshot(reporter_key, candidate, retry_ms);
+            return BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_ms);
         });
         ASSERT_EQ(std::future_status::timeout, waiting_snapshot.wait_for(20ms));
         ASSERT_EQ(EC_OK, backend.Close());
@@ -1468,10 +1639,10 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
         std::string first;
         uint64_t retry_after_ms = 0;
-        ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, first, retry_after_ms));
+        ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
         ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first));
         std::string second;
-        ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, second, retry_after_ms));
+        ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, second, retry_after_ms));
 
         auto waiting_delta = std::async(std::launch::async, [&] {
             std::string committed;

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1554,7 +1554,7 @@ ErrorCode CacheManager::FilterWriteCache(RequestContext *request_context,
         }
     }
     if (!prune_keys.empty() && submit_del_req) {
-        submit_del_req(prune_keys, prune_loc_ids_vec, {});
+        submit_del_req(prune_keys, prune_loc_ids_vec, {}, false);
     }
 
     // Find the first write and check whether all blocks that need writing form a suffix.
@@ -1712,7 +1712,7 @@ ErrorCode CacheManager::FilterWriteCacheWithMinReplica(RequestContext *request_c
         }
     }
     if (!prune_keys.empty() && submit_del_req) {
-        submit_del_req(prune_keys, prune_loc_ids_vec, {});
+        submit_del_req(prune_keys, prune_loc_ids_vec, {}, false);
     }
 
     size_t first_write_idx = location_maps.size();
@@ -2211,17 +2211,61 @@ bool IsSnapshotLocationStale(const EventReportBackend *event_backend,
     if (location.location_specs().empty()) {
         return true;
     }
-    bool matches_committed = !committed_version.empty();
-    bool matches_in_flight = preserve_in_flight && !in_flight_version.empty();
+    bool contains_committed = false;
+    bool contains_in_flight = false;
     for (const auto &spec : location.location_specs()) {
+        const size_t version_param_count =
+            SnapshotUriUtils::CountUriParam(spec.uri(), SnapshotUriUtils::kSnapshotVersionParam);
+        if (version_param_count == 0) {
+            // Legacy metadata is a stale reconciliation component, but a
+            // current delta spec in the same stable location still protects
+            // the location from coarse-grained cleanup.
+            continue;
+        }
         SnapshotUriInfo info;
-        if (!SnapshotUriUtils::ParseSnapshotUriInfo(spec.uri(), info)) {
+        if (version_param_count != 1 ||
+            !SnapshotUriUtils::ParseSnapshotUriInfo(spec.uri(), info)) {
             return true;
         }
-        matches_committed = matches_committed && info.version == committed_version;
-        matches_in_flight = matches_in_flight && info.version == in_flight_version;
+        contains_committed =
+            contains_committed || (!committed_version.empty() && info.version == committed_version);
+        contains_in_flight = contains_in_flight ||
+                             (preserve_in_flight && !in_flight_version.empty() &&
+                              info.version == in_flight_version);
     }
-    return !matches_committed && !matches_in_flight;
+    // Delta merge is spec-granular and can temporarily leave multiple
+    // generations in one stable location. Cleanup is location-granular, so it
+    // must preserve the whole location when any current/in-flight spec is
+    // present; deleting stale sibling specs is deferred to a later complete
+    // snapshot rather than risking a false negative for a successful delta.
+    return !contains_committed && !contains_in_flight;
+}
+
+bool IsEventReportLocationReadable(const CacheLocation &location) {
+    if (location.location_specs().empty()) {
+        return false;
+    }
+    for (const auto &spec : location.location_specs()) {
+        const DataStorageUri uri(spec.uri());
+        if (!uri.Valid()) {
+            return false;
+        }
+        const size_t version_param_count =
+            SnapshotUriUtils::CountUriParam(spec.uri(), SnapshotUriUtils::kSnapshotVersionParam);
+        if (version_param_count > 1) {
+            return false;
+        }
+        if (version_param_count == 1) {
+            SnapshotUriInfo info;
+            // Count on the raw text first so duplicate parameters remain
+            // observable, then reuse the parsed URI instead of parsing it a
+            // second time on every query.
+            if (!SnapshotUriUtils::ParseSnapshotUriInfo(uri, info)) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 } // namespace
@@ -2235,10 +2279,10 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     const std::string &host_ip_port = request->host_ip_port();
     auto *response_status = response->mutable_header()->mutable_status();
 
-    if (instance_id.empty() || host_ip_port.empty()) {
-        KVCM_LOG_WARN("trace_id [%s] | ReportEvent: empty instance_id or host_ip_port", trace_id.c_str());
+    if (instance_id.empty() || !SnapshotUriUtils::IsValidLocationIdComponent(host_ip_port)) {
+        KVCM_LOG_WARN("trace_id [%s] | ReportEvent: invalid instance_id or host_ip_port", trace_id.c_str());
         response_status->set_code(proto::meta::INVALID_ARGUMENT);
-        response_status->set_message("empty instance_id or host_ip_port");
+        response_status->set_message("invalid instance_id or host_ip_port");
         return EC_BADARGS;
     }
     if (request->events_size() == 0) {
@@ -2348,11 +2392,22 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     std::vector<ErrorCode> per_item_ec(events_size, EC_OK);
     DeltaMutationGuard delta_mutations(event_backend);
 
-    bool has_register = false;
     bool has_heartbeat = false;
     bool has_host_down = false;
     std::vector<std::string> register_mediums;
     std::map<std::string, std::string> heartbeat_status;
+    for (const auto &item : request->events()) {
+        if (item.event_type() != proto::meta::EVENT_NODE_REGISTER || !item.has_node_register()) {
+            continue;
+        }
+        for (const auto &medium : item.node_register().mediums()) {
+            if (std::find(register_mediums.begin(), register_mediums.end(), medium) == register_mediums.end()) {
+                register_mediums.push_back(medium);
+            }
+        }
+    }
+    bool registration_applied = false;
+    ErrorCode register_ec = EC_OK;
 
     struct BlockAddEntry {
         std::string location_id;
@@ -2401,27 +2456,34 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         const auto &item = request->events(i);
         switch (item.event_type()) {
         case proto::meta::EVENT_NODE_REGISTER: {
-            has_register = true;
-            if (item.has_node_register()) {
-                for (const auto &medium : item.node_register().mediums()) {
-                    if (std::find(register_mediums.begin(), register_mediums.end(), medium) == register_mediums.end()) {
-                        register_mediums.push_back(medium);
-                    }
-                }
+            if (!item.has_node_register()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
             }
+            if (!registration_applied) {
+                register_ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
+                registration_applied = true;
+            }
+            per_item_ec[i] = register_ec;
             break;
         }
         case proto::meta::EVENT_HEARTBEAT: {
+            if (!item.has_heartbeat()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
             has_heartbeat = true;
-            if (item.has_heartbeat()) {
-                heartbeat_status.clear();
-                for (const auto &kv : item.heartbeat().system_status()) {
-                    heartbeat_status[kv.first] = kv.second;
-                }
+            heartbeat_status.clear();
+            for (const auto &kv : item.heartbeat().system_status()) {
+                heartbeat_status[kv.first] = kv.second;
             }
             break;
         }
         case proto::meta::EVENT_HOST_DOWN:
+            if (!item.has_host_down()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
             has_host_down = true;
             break;
         case proto::meta::EVENT_BLOCK_ADD: {
@@ -2431,7 +2493,9 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
             const auto &params = item.block_add();
             int64_t block_key = 0;
-            if (!ParseInt64(params.block_key(), block_key) || params.medium().empty() || params.specs_size() == 0) {
+            if (!ParseInt64(params.block_key(), block_key) ||
+                !SnapshotUriUtils::IsValidLocationIdComponent(params.medium()) ||
+                params.specs_size() == 0) {
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
@@ -2451,8 +2515,10 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            if (!has_register && !event_backend->IsNodeRegistered(instance_id, host_ip_port)) {
-                per_item_ec[i] = EC_NODE_NOT_REGISTERED;
+            const ErrorCode ensure_node_ec =
+                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {params.medium()});
+            if (ensure_node_ec != EC_OK) {
+                per_item_ec[i] = ensure_node_ec;
                 break;
             }
 
@@ -2492,7 +2558,8 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
             const auto &params = item.block_delete();
             int64_t block_key = 0;
-            if (!ParseInt64(params.block_key(), block_key) || params.medium().empty() ||
+            if (!ParseInt64(params.block_key(), block_key) ||
+                !SnapshotUriUtils::IsValidLocationIdComponent(params.medium()) ||
                 params.spec_names_size() == 0) {
                 per_item_ec[i] = EC_BADARGS;
                 break;
@@ -2510,8 +2577,10 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            if (!has_register && !event_backend->IsNodeRegistered(instance_id, host_ip_port)) {
-                per_item_ec[i] = EC_NODE_NOT_REGISTERED;
+            const ErrorCode ensure_node_ec =
+                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {params.medium()});
+            if (ensure_node_ec != EC_OK) {
+                per_item_ec[i] = ensure_node_ec;
                 break;
             }
 
@@ -2548,7 +2617,9 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             std::unordered_set<std::string> seen_blocks;
             for (const auto &block : params.blocks()) {
                 int64_t block_key = 0;
-                if (!ParseInt64(block.block_key(), block_key) || block.medium().empty() || block.specs_size() == 0) {
+                if (!ParseInt64(block.block_key(), block_key) ||
+                    !SnapshotUriUtils::IsValidLocationIdComponent(block.medium()) ||
+                    block.specs_size() == 0) {
                     per_item_ec[i] = EC_BADARGS;
                     break;
                 }
@@ -2577,8 +2648,18 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            if (!has_register && !event_backend->IsNodeRegistered(instance_id, host_ip_port)) {
-                per_item_ec[i] = EC_NODE_NOT_REGISTERED;
+            std::vector<std::string> snapshot_mediums;
+            snapshot_mediums.reserve(validated_blocks.size());
+            for (const auto &block : validated_blocks) {
+                if (std::find(snapshot_mediums.begin(), snapshot_mediums.end(), block.medium) ==
+                    snapshot_mediums.end()) {
+                    snapshot_mediums.push_back(block.medium);
+                }
+            }
+            const ErrorCode ensure_node_ec =
+                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, snapshot_mediums);
+            if (ensure_node_ec != EC_OK) {
+                per_item_ec[i] = ensure_node_ec;
                 break;
             }
 
@@ -2650,16 +2731,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
-    if (has_register) {
-        const ErrorCode ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
-        if (ec != EC_OK) {
-            for (int i = 0; i < events_size; ++i) {
-                if (request->events(i).event_type() == proto::meta::EVENT_NODE_REGISTER) {
-                    per_item_ec[i] = ec;
-                }
-            }
-        }
-    }
     if (has_heartbeat) {
         const ErrorCode ec = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
         if (ec != EC_OK) {
@@ -2785,7 +2856,9 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
 
         std::vector<std::vector<ErrorCode>> per_location_ec;
+        std::vector<std::vector<bool>> missing_delete_targets;
         std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks(del_keys_aggr.size());
+        size_t delete_target_count = 0;
         for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
             const auto &entries = del_merged_entries_aggr[i];
             delete_tasks[i].reserve(entries.size());
@@ -2795,8 +2868,10 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                     entry.spec_names,
                 });
             }
+            delete_target_count += delete_tasks[i].size();
         }
-        meta_searcher->BatchDeleteLocationSpecs(request_context, del_keys_aggr, delete_tasks, per_location_ec);
+        meta_searcher->BatchDeleteLocationSpecs(
+            request_context, del_keys_aggr, delete_tasks, per_location_ec, &missing_delete_targets);
 
         for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
             ErrorCode key_ec = EC_OK;
@@ -2820,6 +2895,22 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                     }
                 }
             }
+        }
+        size_t missing_block_count = 0;
+        for (const auto &missing_per_key : missing_delete_targets) {
+            missing_block_count +=
+                static_cast<size_t>(std::count(missing_per_key.begin(), missing_per_key.end(), true));
+        }
+        if (missing_block_count > 0) {
+            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_DELETE: attempted to delete %zu non-existent block(s) "
+                          "(block_key + medium) out of %zu unique target(s); treated as idempotent success, "
+                          "instance [%s], host [%s], storage_type [%s]",
+                          trace_id.c_str(),
+                          missing_block_count,
+                          delete_target_count,
+                          instance_id.c_str(),
+                          host_ip_port.c_str(),
+                          ToString(requested_type).c_str());
         }
         if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
             KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
@@ -3051,6 +3142,17 @@ ErrorCode CacheManager::CleanupStaleSnapshotLocations(const ReporterSnapshotKey 
                   snapshot_version.c_str(),
                   static_cast<int64_t>(elapsed_ms),
                   ec);
+    if (metrics_registry_) {
+        const MetricsTags metrics_tags = {
+            {"instance_id", reporter_key.instance_id},
+            {"host", reporter_key.host_ip_port},
+            {"type", ToString(storage_type)},
+        };
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_,
+                              "event_report.snapshot_cleanup_scan_latency_ms",
+                              metrics_tags,
+                              static_cast<double>(elapsed_ms));
+    }
     return ec;
 }
 
@@ -3410,14 +3512,13 @@ CheckLocDataExistFunc CacheManager::GetCheckLocDataExistFunc(const std::string &
         if (IsEventReportStorageType(loc.type())) {
             auto event_backend_holder = LookupEventReportBackend(registry_manager_, instance_id, loc.type());
             auto *event_backend = dynamic_cast<EventReportBackend *>(event_backend_holder.get());
-            // Event-report metadata has no meaningful physical-backend
-            // fallback. If its typed backend is absent, the process-local
-            // committed token and node liveness cannot be verified, so keep
-            // the location invisible.
+            // Event-report metadata is a soft cache index. Snapshot versions
+            // are used for reconciliation and asynchronous cleanup, not as a
+            // query visibility fence. Node liveness remains mandatory.
             if (!event_backend || loc.type() != event_backend->GetStorageType()) {
                 return false;
             }
-            if (IsSnapshotLocationStale(event_backend, instance_id, loc)) {
+            if (!IsEventReportLocationReadable(loc)) {
                 return false;
             }
             std::string reporter_medium;
@@ -3447,13 +3548,15 @@ CheckLocDataExistFunc CacheManager::GetCheckLocDataExistFunc(const std::string &
 SubmitDelReqFunc CacheManager::GetSubmitDelReqFunc(const std::string &instance_id) const {
     return [this, instance_id](const std::vector<std::int64_t> &blk_keys,
                                const std::vector<std::vector<std::string>> &loc_ids,
-                               const std::vector<std::vector<std::string>> &expected_location_values) -> void {
+                               const std::vector<std::vector<std::string>> &expected_location_values,
+                               bool metadata_only) -> void {
         CacheLocationDelRequest request;
         request.instance_id = instance_id;
         request.delay = std::chrono::seconds(0);
         request.block_keys = blk_keys;
         request.location_ids = loc_ids;
         request.expected_location_values = expected_location_values;
+        request.metadata_only = metadata_only;
         if (reclaimer_task_supervisor_) {
             reclaimer_task_supervisor_->Submit(instance_id, std::move(request));
             KVCM_LOG_DEBUG("meta data del request submitted to reclaimer supervisor");

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/manager/meta_searcher.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <map>
 #include <set>
 #include <sstream>
@@ -110,15 +111,10 @@ ErrorCode MergeLocationSpecsByName(const std::vector<LocationSpec> &old_specs,
 
     std::map<std::string, LocationSpec> merged_specs;
     for (const auto &spec : old_specs) {
-        // Once a reporter has a committed snapshot token, delta writes may
-        // only carry forward specs from that same token.
-        if (has_snapshot_version) {
-            SnapshotUriInfo old_snapshot_info;
-            if (!SnapshotUriUtils::ParseSnapshotUriInfo(spec.uri(), old_snapshot_info) ||
-                old_snapshot_info.version != new_snapshot_info.version) {
-                continue;
-            }
-        }
+        // Snapshot generations are reconciliation/cleanup tags, not a
+        // visibility fence. After a KVCM restart, a new delta may use a fresh
+        // generation while untouched specs still carry an older one. Preserve
+        // those specs and overwrite only names present in this delta.
         merged_specs[spec.name()] = spec;
     }
     for (const auto &spec : new_specs) {
@@ -454,7 +450,7 @@ ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_cont
     }
 
     if (!prune_keys.empty() && submit_del_req_func_) {
-        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {});
+        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {}, false);
     }
 
     return EC_OK;
@@ -532,7 +528,7 @@ ErrorCode MetaSearcher::BatchGetBestLocation(RequestContext *request_context,
     }
 
     if (!prune_keys.empty() && submit_del_req_func_) {
-        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {});
+        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {}, false);
     }
 
     return out_locations.size() == keys.size() ? EC_OK : EC_ERROR;
@@ -692,7 +688,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
     }
 
     if (!prune_keys.empty() && submit_del_req_func_) {
-        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {});
+        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {}, false);
     }
 
     return has_error ? EC_ERROR : EC_OK;
@@ -766,7 +762,7 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
     }
 
     if (!prune_keys.empty() && submit_del_req_func_) {
-        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {});
+        submit_del_req_func_(prune_keys, prune_loc_ids_vec, {}, false);
     }
 
     return EC_OK;
@@ -1371,12 +1367,17 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
 ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context,
                                                  const KeyVector &keys,
                                                  const std::vector<std::vector<DeleteLocationSpecsTask>> &tasks_per_key,
-                                                 std::vector<std::vector<ErrorCode>> &out_batch_results) {
+                                                 std::vector<std::vector<ErrorCode>> &out_batch_results,
+                                                 std::vector<std::vector<bool>> *out_missing_targets) {
     if (keys.size() != tasks_per_key.size()) {
         return EC_BADARGS;
     }
     out_batch_results.clear();
     out_batch_results.resize(keys.size());
+    if (out_missing_targets) {
+        out_missing_targets->clear();
+        out_missing_targets->resize(keys.size());
+    }
 
     // 每个 DeleteLocationSpecsTask 需要独立返回结果；同一个 key 下多个 task
     // 也可能删除同一个 location 的不同 specs，因此先展开成 task 维度执行。
@@ -1384,13 +1385,18 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
     LocationIdsPerKey flat_location_ids;
     std::vector<std::pair<size_t, size_t>> flat_to_original_task_indices;
     std::vector<std::pair<DataStorageType, std::uint64_t>> flat_deleted_specs_size;
+    std::vector<std::uint8_t> flat_missing_targets;
     for (size_t i = 0; i < keys.size(); ++i) {
         out_batch_results[i].assign(tasks_per_key[i].size(), ErrorCode::EC_OK);
+        if (out_missing_targets) {
+            (*out_missing_targets)[i].assign(tasks_per_key[i].size(), false);
+        }
         for (size_t task_index = 0; task_index < tasks_per_key[i].size(); ++task_index) {
             flat_keys.push_back(keys[i]);
             flat_location_ids.push_back({tasks_per_key[i][task_index].location_id});
             flat_to_original_task_indices.push_back({i, task_index});
             flat_deleted_specs_size.emplace_back(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN, 0);
+            flat_missing_targets.push_back(0);
         }
     }
     if (flat_keys.empty()) {
@@ -1399,12 +1405,13 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
 
     // 每条 flat task 独立处理：NOENT 视为幂等成功；spec_names 为空返回 BADARGS；
     // 删除后无剩余 specs 则删除整个 location，否则 COW 更新 location_specs。
-    auto modifier = [&keys, &tasks_per_key, &flat_to_original_task_indices, &flat_deleted_specs_size](
-                        const std::vector<ErrorCode> &get_ecs,
-                        const LocationIdVector &loc_ids,
-                        size_t key_index,
-                        CacheLocationVector &locs,
-                        PropertyMap &upsert_property_map) -> LocationModifierResult {
+    auto modifier =
+        [&keys, &tasks_per_key, &flat_to_original_task_indices, &flat_deleted_specs_size, &flat_missing_targets](
+            const std::vector<ErrorCode> &get_ecs,
+            const LocationIdVector &loc_ids,
+            size_t key_index,
+            CacheLocationVector &locs,
+            PropertyMap &upsert_property_map) -> LocationModifierResult {
         (void)upsert_property_map;
         std::vector<ErrorCode> modifier_ecs(loc_ids.size(), ErrorCode::EC_OK);
         if (loc_ids.size() != 1 || key_index >= flat_to_original_task_indices.size()) {
@@ -1418,6 +1425,9 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
         const std::string &loc_id = loc_ids[0];
 
         if (ec != ErrorCode::EC_OK) {
+            if (ec == ErrorCode::EC_NOENT) {
+                flat_missing_targets[key_index] = 1;
+            }
             modifier_ecs[0] = ec == ErrorCode::EC_NOENT ? ErrorCode::EC_OK : ec;
             if (ec != ErrorCode::EC_NOENT) {
                 KVCM_LOG_WARN("load location failed, key[%lu](%lu), location_id: %s, return %d",
@@ -1430,6 +1440,7 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
         }
 
         if (locs.empty() || !locs[0]) {
+            flat_missing_targets[key_index] = 1;
             modifier_ecs[0] = ErrorCode::EC_OK;
             return {ModifierAction::MA_SKIP, std::move(modifier_ecs)};
         }
@@ -1480,6 +1491,9 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
             ec = result.per_location_error_codes[i][0];
         }
         out_batch_results[original_key_index][original_task_index] = ec;
+        if (out_missing_targets) {
+            (*out_missing_targets)[original_key_index][original_task_index] = flat_missing_targets[i] != 0;
+        }
     }
 
     // 只有实际删除了 specs 且 RMW 成功时，才扣减 storage usage。
@@ -1735,9 +1749,21 @@ ErrorCode MetaSearcher::BatchCADLocationStatus(RequestContext *request_context,
 ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
                                              const KeyVector &keys,
                                              const LocationIdsPerKey &location_ids_per_key,
-                                             std::vector<std::vector<ErrorCode>> &out_per_location_ec) {
+                                             std::vector<std::vector<ErrorCode>> &out_per_location_ec,
+                                             const std::vector<std::vector<std::string>> &expected_location_values) {
     if (keys.size() != location_ids_per_key.size()) {
         return EC_BADARGS;
+    }
+    const bool check_expected_values = !expected_location_values.empty();
+    if (check_expected_values) {
+        if (expected_location_values.size() != location_ids_per_key.size()) {
+            return EC_BADARGS;
+        }
+        for (size_t i = 0; i < location_ids_per_key.size(); ++i) {
+            if (expected_location_values[i].size() != location_ids_per_key[i].size()) {
+                return EC_BADARGS;
+            }
+        }
     }
     out_per_location_ec.clear();
     out_per_location_ec.resize(keys.size());
@@ -1747,11 +1773,12 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
         locs_sz[i].resize(location_ids_per_key[i].size());
     }
 
-    auto modifier = [&keys, &locs_sz](const std::vector<ErrorCode> &get_ecs,
-                                      const LocationIdVector &loc_ids,
-                                      size_t key_index,
-                                      CacheLocationVector &locs,
-                                      PropertyMap & /*upsert_property_map*/) -> LocationModifierResult {
+    auto modifier = [&keys, &locs_sz, &expected_location_values, check_expected_values](
+                        const std::vector<ErrorCode> &get_ecs,
+                        const LocationIdVector &loc_ids,
+                        size_t key_index,
+                        CacheLocationVector &locs,
+                        PropertyMap & /*upsert_property_map*/) -> LocationModifierResult {
         std::vector<ErrorCode> modifier_ecs(loc_ids.size(), ErrorCode::EC_OK);
         bool any_found = false;
         for (size_t k = 0; k < loc_ids.size(); ++k) {
@@ -1767,6 +1794,13 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
                               loc_ids[k].c_str(),
                               ec);
                 modifier_ecs[k] = ec;
+                continue;
+            }
+            if (check_expected_values &&
+                (!locs[k] || locs[k]->ToJsonString() != expected_location_values[key_index][k])) {
+                // The stable location id was refreshed after the cleanup
+                // scan. Treat the old delete request as stale.
+                modifier_ecs[k] = ErrorCode::EC_MISMATCH;
                 continue;
             }
             any_found = true;
@@ -1921,7 +1955,7 @@ ErrorCode MetaSearcher::CleanupLocationsByPredicate(RequestContext *request_cont
                     KVCM_LOG_WARN("CleanupLocationsByPredicate: reclaimer submit callback is unavailable");
                     return EC_ERROR;
                 }
-                submit_del_req_func_(keys, delete_location_ids, expected_location_values);
+                submit_del_req_func_(keys, delete_location_ids, expected_location_values, true);
             }
         }
         cursor = next_cursor;
@@ -1964,6 +1998,7 @@ ErrorCode MetaSearcher::CleanupLocationsByHost(RequestContext *request_context,
                     has_failure = true;
                 }
                 LocationIdsPerKey delete_loc_ids(keys.size());
+                std::vector<std::vector<std::string>> expected_location_values(keys.size());
                 bool has_any_location = false;
                 for (size_t i = 0; i < keys.size(); ++i) {
                     if (get_result.ec == EC_PARTIAL_OK && get_result.error_codes[i] != EC_OK) {
@@ -1975,20 +2010,45 @@ ErrorCode MetaSearcher::CleanupLocationsByHost(RequestContext *request_context,
                         if (loc.type() == storage_type && loc_id.size() >= host_suffix.size() &&
                             loc_id.compare(loc_id.size() - host_suffix.size(), host_suffix.size(), host_suffix) == 0) {
                             delete_loc_ids[i].push_back(loc_id);
+                            expected_location_values[i].push_back(loc.ToJsonString());
                             has_any_location = true;
                         }
                     }
                 }
                 if (has_any_location) {
+                    if (should_abort && should_abort()) {
+                        KVCM_LOG_INFO("CleanupLocationsByHost: aborted before delete (host_suffix=%s)",
+                                      host_suffix.c_str());
+                        return EC_OK;
+                    }
+                    KeyVector delete_keys;
+                    LocationIdsPerKey compact_delete_loc_ids;
+                    std::vector<std::vector<std::string>> compact_expected_location_values;
+                    delete_keys.reserve(keys.size());
+                    compact_delete_loc_ids.reserve(keys.size());
+                    compact_expected_location_values.reserve(keys.size());
+                    for (size_t i = 0; i < keys.size(); ++i) {
+                        if (delete_loc_ids[i].empty()) {
+                            continue;
+                        }
+                        delete_keys.push_back(keys[i]);
+                        compact_delete_loc_ids.push_back(std::move(delete_loc_ids[i]));
+                        compact_expected_location_values.push_back(std::move(expected_location_values[i]));
+                    }
                     std::vector<std::vector<ErrorCode>> per_location_ec;
-                    auto del_ec = BatchDeleteLocations(request_context, keys, delete_loc_ids, per_location_ec);
+                    auto del_ec = BatchDeleteLocations(
+                        request_context,
+                        delete_keys,
+                        compact_delete_loc_ids,
+                        per_location_ec,
+                        compact_expected_location_values);
                     if (del_ec != EC_OK) {
                         KVCM_LOG_WARN("CleanupLocationsByHost: BatchDeleteLocations failed, ec %d", del_ec);
                         has_failure = true;
                     } else {
                         for (size_t i = 0; i < per_location_ec.size(); ++i) {
                             for (const auto &loc_ec : per_location_ec[i]) {
-                                if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                                if (loc_ec != EC_OK && loc_ec != EC_NOENT && loc_ec != EC_MISMATCH) {
                                     KVCM_LOG_WARN(
                                         "CleanupLocationsByHost: delete location failed for key index %zu, ec %d",
                                         i,

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -17,7 +17,10 @@ namespace kv_cache_manager {
 
 using SubmitDelReqFunc = std::function<void(const std::vector<std::int64_t> &blk_keys,
                                             const std::vector<std::vector<std::string>> &loc_ids,
-                                            const std::vector<std::vector<std::string>> &expected_location_values)>;
+                                            const std::vector<std::vector<std::string>> &expected_location_values,
+                                            // Skip physical URI deletion for
+                                            // externally owned metadata.
+                                            bool metadata_only)>;
 
 class MetaIndexer;
 class LocationSpecGroup;
@@ -116,10 +119,14 @@ public:
         std::string location_id;
         std::vector<std::string> spec_names;
     };
+    // Missing block/location targets are idempotent EC_OK. When requested,
+    // out_missing_targets mirrors tasks_per_key and marks those no-op targets;
+    // an existing location with only missing spec_names is not marked.
     ErrorCode BatchDeleteLocationSpecs(RequestContext *request_context,
                                        const KeyVector &keys,
                                        const std::vector<std::vector<DeleteLocationSpecsTask>> &tasks_per_key,
-                                       std::vector<std::vector<ErrorCode>> &out_batch_results);
+                                       std::vector<std::vector<ErrorCode>> &out_batch_results,
+                                       std::vector<std::vector<bool>> *out_missing_targets = nullptr);
     struct LocationUpdateTask {
         std::string location_id;
         CacheLocationStatus new_status;
@@ -152,7 +159,8 @@ public:
     ErrorCode BatchDeleteLocations(RequestContext *request_context,
                                    const KeyVector &keys,
                                    const LocationIdsPerKey &location_ids_per_key,
-                                   std::vector<std::vector<ErrorCode>> &out_per_location_ec);
+                                   std::vector<std::vector<ErrorCode>> &out_per_location_ec,
+                                   const std::vector<std::vector<std::string>> &expected_location_values = {});
     using LocationVisitor =
         std::function<void(KeyType block_key, const std::string &location_id, const CacheLocation &location)>;
     ErrorCode VisitAllLocations(RequestContext *request_context, size_t scan_batch_size, LocationVisitor visitor);

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -305,11 +305,13 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             if (iter->second->status() != CacheLocationStatus::CLS_DELETING) {
                 continue;
             }
-            for (const auto &loc_spec : iter->second->location_specs()) {
-                DataStorageUri uri(loc_spec.uri());
-                if (uri.Valid()) {
-                    std::string storage_unique_name = uri.GetHostName();
-                    delete_uris_by_unique_name[storage_unique_name].emplace_back(uri);
+            if (!task.metadata_only) {
+                for (const auto &loc_spec : iter->second->location_specs()) {
+                    DataStorageUri uri(loc_spec.uri());
+                    if (uri.Valid()) {
+                        std::string storage_unique_name = uri.GetHostName();
+                        delete_uris_by_unique_name[storage_unique_name].emplace_back(uri);
+                    }
                 }
             }
             cad_tasks.push_back({iter->first, CacheLocationStatus::CLS_DELETING});
@@ -612,8 +614,10 @@ SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
     }
     const auto *expected_location_values =
         task.expected_location_values.empty() ? nullptr : &task.expected_location_values;
-    return PrepareDeleteTaskImpl(
+    auto result = PrepareDeleteTaskImpl(
         task.instance_id, task.block_keys, &task.location_ids, expected_location_values, task.delay);
+    result.actual_task.metadata_only = task.metadata_only;
+    return result;
 }
 
 SchedulePlanExecutor::LocationDelAdmissionResult

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -58,6 +58,9 @@ struct CacheLocationDelRequest {
     // Optional serialized values observed by the submitter, parallel to
     // location_ids. A location is reclaimed only if it is still unchanged.
     std::vector<std::vector<std::string>> expected_location_values;
+    // Event-report metadata describes externally owned cache. Its reconciliation
+    // cleanup must remove only KVCM metadata and never call the URI backend.
+    bool metadata_only{false};
 };
 
 // 单个 block 的跨存储复制请求。URI 由上层（MigrationManager）解析与预分配后传入；

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -2599,7 +2599,7 @@ TEST_F(CacheManagerTest, TestHostDownMakesAlreadyAdmittedDeltaInvisibleWithoutDe
     EXPECT_TRUE(QueryEventReportUris({key}).empty());
 }
 
-TEST_F(CacheManagerTest, TestReportEventPartialSnapshotFailureIsFailClosedAndRetryConverges) {
+TEST_F(CacheManagerTest, TestReportEventPartialSnapshotFailureKeepsCacheReadableAndRetryConverges) {
     const std::string host = "192.168.10.3:8080";
     const int64_t key_a = 9420;
     const int64_t key_b = 9421;
@@ -2626,13 +2626,16 @@ TEST_F(CacheManagerTest, TestReportEventPartialSnapshotFailureIsFailClosedAndRet
     ASSERT_EQ(EC_OK, delta_ec);
     EXPECT_EQ(baseline_token, delta_response.committed_snapshot_version());
 
-    // key_a was physically overwritten with an uncommitted token and must be
-    // hidden; a delta admitted after abort inherits the old committed token
-    // and keeps the reporter usable until its full retry.
+    // Event-report metadata is a soft cache index. Both the partially written
+    // snapshot data and the following delta remain useful candidates.
     const auto visible_after_failure = QueryEventReportUris({key_a, key_b});
-    ASSERT_EQ(1u, visible_after_failure.size());
-    EXPECT_NE(std::string::npos, visible_after_failure[0].find("source=delta_after_failed_snapshot"));
-    EXPECT_NE(std::string::npos, visible_after_failure[0].find("s_version=" + baseline_token));
+    ASSERT_EQ(2u, visible_after_failure.size());
+    EXPECT_TRUE(std::any_of(visible_after_failure.begin(), visible_after_failure.end(), [](const std::string &uri) {
+        return uri.find("source=partial_a") != std::string::npos;
+    }));
+    EXPECT_TRUE(std::any_of(visible_after_failure.begin(), visible_after_failure.end(), [](const std::string &uri) {
+        return uri.find("source=delta_after_failed_snapshot") != std::string::npos;
+    }));
 
     const auto [retry_ec, retry_response] = CallReportEvent(
         MakeSnapshotRequest(host, {{key_a, "retry_a"}, {key_b, "retry_b"}}), "partial_full_retry");
@@ -2655,7 +2658,7 @@ TEST_F(CacheManagerTest, TestReportEventPartialSnapshotFailureIsFailClosedAndRet
     EXPECT_EQ((std::set<std::string>{"retry_a", "retry_b"}), retry_sources);
 }
 
-TEST_F(CacheManagerTest, TestReportEventSyncFailureDoesNotPublishAndImmediateFullRetryConverges) {
+TEST_F(CacheManagerTest, TestReportEventSyncFailureKeepsWrittenCacheReadableAndImmediateRetryConverges) {
     const std::string host = "192.168.10.30:8080";
     const int64_t key = 9425;
     auto event_backend = InstallEventReportBackend();
@@ -2675,7 +2678,9 @@ TEST_F(CacheManagerTest, TestReportEventSyncFailureDoesNotPublishAndImmediateFul
     EXPECT_TRUE(failed_response.committed_snapshot_version().empty());
     EXPECT_TRUE(failed_response.snapshot_required());
     EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
-    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+    const auto visible_after_failure = QueryEventReportUris({key});
+    ASSERT_EQ(1u, visible_after_failure.size());
+    EXPECT_NE(std::string::npos, visible_after_failure.front().find("source=sync_failure"));
     ASSERT_EQ(1u, QueryRawEventReportUris(key).size());
 
     // A failed attempt must not start the rate-limit interval.
@@ -2744,8 +2749,40 @@ TEST_F(CacheManagerTest, TestReportEventSameRequestDeltaOrderUsesLastOperationPe
     EXPECT_NE(std::string::npos, visible.front().find("s_version=" + token));
 }
 
-TEST_F(CacheManagerTest, TestReportEventDistinguishesUnregisteredNodeFromMissingSnapshot) {
+TEST_F(CacheManagerTest, TestReportEventFoldedDeltaEventsShareFinalWriteFailure) {
+    const std::string host = "192.168.10.52:8080";
+    const int64_t key = 94'440;
+    auto event_backend = InstallEventReportBackend();
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_NE(nullptr, meta_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    auto request = MakeAddRequest(host, key, "final_add");
+    auto final_add = request.events(0);
+    request.clear_events();
+    auto *absorbed_delete = request.add_events();
+    absorbed_delete->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+    absorbed_delete->mutable_block_delete()->set_block_key(std::to_string(key));
+    absorbed_delete->mutable_block_delete()->set_medium("mem");
+    absorbed_delete->mutable_block_delete()->add_spec_names("tp0");
+    *request.add_events() = final_add;
+
+    meta_backend->FailKeyOnNextUpsert(key);
+    const auto [ec, response] = CallReportEvent(request, "folded_delta_final_write_failure");
+    EXPECT_EQ(EC_PARTIAL_OK, ec);
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, response.header().status().code());
+    ASSERT_EQ(2, response.item_results_size());
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, response.item_results(0));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, response.item_results(1));
+    EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
+    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+}
+
+TEST_F(CacheManagerTest, TestReportEventLazilyRestoresReporterWithoutRegisterOrSnapshot) {
     const std::string host = "192.168.10.32:8080";
+    const std::string snapshot_host = "192.168.10.132:8080";
     auto event_backend = InstallEventReportBackend();
     ASSERT_NE(nullptr, event_backend);
 
@@ -2756,36 +2793,44 @@ TEST_F(CacheManagerTest, TestReportEventDistinguishesUnregisteredNodeFromMissing
     heartbeat.add_events()->set_event_type(proto::meta::EVENT_HEARTBEAT);
     heartbeat.mutable_events(0)->mutable_heartbeat();
     const auto [heartbeat_ec, heartbeat_response] = CallReportEvent(heartbeat, "unregistered_heartbeat");
-    EXPECT_EQ(EC_PARTIAL_OK, heartbeat_ec);
-    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, heartbeat_response.header().status().code());
-    ASSERT_EQ(1, heartbeat_response.item_results_size());
-    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, heartbeat_response.item_results(0));
+    EXPECT_EQ(EC_OK, heartbeat_ec);
+    EXPECT_EQ(proto::meta::OK, heartbeat_response.header().status().code());
+    EXPECT_EQ(0, heartbeat_response.item_results_size());
+    EXPECT_TRUE(heartbeat_response.committed_snapshot_version().empty());
+    EXPECT_TRUE(heartbeat_response.snapshot_required());
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+    EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
 
-    const auto [unregistered_delta_ec, unregistered_delta] =
-        CallReportEvent(MakeAddRequest(host, 9427, "unregistered_delta"), "unregistered_delta");
-    EXPECT_EQ(EC_PARTIAL_OK, unregistered_delta_ec);
-    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, unregistered_delta.header().status().code());
-    EXPECT_TRUE(unregistered_delta.committed_snapshot_version().empty());
-    EXPECT_TRUE(unregistered_delta.snapshot_required());
+    const auto [first_delta_ec, first_delta] =
+        CallReportEvent(MakeAddRequest(host, 9427, "first_delta"), "delta_without_register_or_snapshot");
+    ASSERT_EQ(EC_OK, first_delta_ec);
+    EXPECT_EQ(proto::meta::OK, first_delta.header().status().code());
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(first_delta.committed_snapshot_version()));
+    EXPECT_FALSE(first_delta.snapshot_required());
+    auto visible = QueryEventReportUris({9427});
+    ASSERT_EQ(1u, visible.size());
+    EXPECT_NE(std::string::npos, visible.front().find("source=first_delta"));
+    EXPECT_NE(std::string::npos,
+              visible.front().find("s_version=" + first_delta.committed_snapshot_version()));
 
-    const auto [unregistered_snapshot_ec, unregistered_snapshot] =
-        CallReportEvent(MakeSnapshotRequest(host, {}), "unregistered_snapshot");
-    EXPECT_EQ(EC_PARTIAL_OK, unregistered_snapshot_ec);
-    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, unregistered_snapshot.header().status().code());
-    EXPECT_TRUE(unregistered_snapshot.committed_snapshot_version().empty());
-    EXPECT_TRUE(unregistered_snapshot.snapshot_required());
-
-    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
-    const auto [missing_snapshot_ec, missing_snapshot] =
-        CallReportEvent(MakeAddRequest(host, 9427, "missing_snapshot"), "registered_without_snapshot");
-    EXPECT_EQ(EC_PARTIAL_OK, missing_snapshot_ec);
-    EXPECT_EQ(proto::meta::SNAPSHOT_REQUIRED, missing_snapshot.header().status().code());
-    EXPECT_TRUE(missing_snapshot.committed_snapshot_version().empty());
-    EXPECT_TRUE(missing_snapshot.snapshot_required());
+    const auto [first_snapshot_ec, first_snapshot] =
+        CallReportEvent(MakeSnapshotRequest(snapshot_host, {}), "snapshot_without_register");
+    ASSERT_EQ(EC_OK, first_snapshot_ec);
+    EXPECT_EQ(proto::meta::OK, first_snapshot.header().status().code());
+    EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(first_snapshot.committed_snapshot_version()));
+    EXPECT_FALSE(first_snapshot.snapshot_required());
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", snapshot_host));
+    EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", snapshot_host));
 
     const auto [baseline_ec, baseline] = CallReportEvent(MakeSnapshotRequest(host, {}), "registered_empty_snapshot");
     ASSERT_EQ(EC_OK, baseline_ec);
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(baseline.committed_snapshot_version()));
+    EXPECT_NE(first_delta.committed_snapshot_version(), baseline.committed_snapshot_version());
+    const auto cleanup_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < cleanup_deadline && !QueryEventReportUris({9427}).empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(QueryEventReportUris({9427}).empty());
 
     event_backend->SetNodeUnavailable("test_instance", host);
     const auto [unavailable_delta_ec, unavailable_delta] =
@@ -2795,9 +2840,257 @@ TEST_F(CacheManagerTest, TestReportEventDistinguishesUnregisteredNodeFromMissing
     EXPECT_TRUE(QueryEventReportUris({9427}).empty());
 
     ASSERT_EQ(EC_OK, event_backend->OnHeartbeat("test_instance", host, {}));
-    const auto visible = QueryEventReportUris({9427});
+    visible = QueryEventReportUris({9427});
     ASSERT_EQ(1u, visible.size());
     EXPECT_NE(std::string::npos, visible.front().find("source=registered_but_unavailable"));
+}
+
+TEST_F(CacheManagerTest, TestReportEventSnapshotWhileUnavailableCommitsButStaysHiddenUntilHeartbeat) {
+    const std::string host = "192.168.10.53:8080";
+    const int64_t key = 94'441;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    const auto [baseline_ec, baseline] =
+        CallReportEvent(MakeAddRequest(host, key, "before_unavailable"), "snapshot_unavailable_baseline");
+    ASSERT_EQ(EC_OK, baseline_ec);
+    const std::string baseline_generation = baseline.committed_snapshot_version();
+    ASSERT_EQ(1u, QueryEventReportUris({key}).size());
+
+    event_backend->SetNodeUnavailable("test_instance", host);
+    ASSERT_FALSE(event_backend->IsNodeAvailable("test_instance", host));
+    const auto [snapshot_ec, snapshot] =
+        CallReportEvent(MakeSnapshotRequest(host, {{key, "snapshot_while_unavailable"}}),
+                        "snapshot_while_unavailable");
+    ASSERT_EQ(EC_OK, snapshot_ec);
+    const std::string snapshot_generation = snapshot.committed_snapshot_version();
+    EXPECT_NE(baseline_generation, snapshot_generation);
+    EXPECT_FALSE(snapshot.snapshot_required());
+    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+
+    proto::meta::ReportEventRequest heartbeat;
+    heartbeat.set_instance_id("test_instance");
+    heartbeat.set_host_ip_port(host);
+    heartbeat.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *heartbeat_event = heartbeat.add_events();
+    heartbeat_event->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    heartbeat_event->mutable_heartbeat();
+    const auto [heartbeat_ec, heartbeat_response] =
+        CallReportEvent(heartbeat, "snapshot_unavailable_recovery_heartbeat");
+    ASSERT_EQ(EC_OK, heartbeat_ec);
+    EXPECT_EQ(snapshot_generation, heartbeat_response.committed_snapshot_version());
+
+    const auto visible = QueryEventReportUris({key});
+    ASSERT_EQ(1u, visible.size());
+    EXPECT_NE(std::string::npos, visible.front().find("source=snapshot_while_unavailable"));
+    EXPECT_NE(std::string::npos, visible.front().find("s_version=" + snapshot_generation));
+}
+
+TEST_F(CacheManagerTest, TestReportEventRegisterThenFirstDeltaInSameRequest) {
+    const std::string host = "192.168.10.48:8080";
+    const int64_t key = 94'433;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    auto request = MakeAddRequest(host, key, "same_request_first_delta");
+    const auto add_event = request.events(0);
+    request.clear_events();
+    auto *register_event = request.add_events();
+    register_event->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    register_event->mutable_node_register()->add_mediums("mem");
+    *request.add_events() = add_event;
+    auto *heartbeat_event = request.add_events();
+    heartbeat_event->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    (*heartbeat_event->mutable_heartbeat()->mutable_system_status())["phase"] = "boot";
+
+    const auto [ec, response] = CallReportEvent(request, "register_and_first_delta_same_request");
+    ASSERT_EQ(EC_OK, ec);
+    EXPECT_EQ(proto::meta::OK, response.header().status().code());
+    EXPECT_EQ(0, response.item_results_size());
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
+    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+    EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
+
+    const auto visible = QueryEventReportUris({key});
+    ASSERT_EQ(1u, visible.size());
+    EXPECT_NE(std::string::npos, visible.front().find("source=same_request_first_delta"));
+    EXPECT_NE(std::string::npos,
+              visible.front().find("s_version=" + response.committed_snapshot_version()));
+}
+
+TEST_F(CacheManagerTest, TestReportEventDeltaBeforeExplicitRegisterSucceedsInSameRequest) {
+    const std::string host = "192.168.10.50:8080";
+    const int64_t key = 94'436;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    auto request = MakeAddRequest(host, key, "delta_before_register");
+    auto *register_event = request.add_events();
+    register_event->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    register_event->mutable_node_register()->add_mediums("mem");
+    auto *heartbeat_event = request.add_events();
+    heartbeat_event->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    (*heartbeat_event->mutable_heartbeat()->mutable_system_status())["phase"] = "boot";
+
+    const auto [ec, response] = CallReportEvent(request, "delta_before_register_same_request");
+    ASSERT_EQ(EC_OK, ec);
+    EXPECT_EQ(proto::meta::OK, response.header().status().code());
+    EXPECT_EQ(0, response.item_results_size());
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
+    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+    EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
+    const auto visible = QueryEventReportUris({key});
+    ASSERT_EQ(1u, visible.size());
+    EXPECT_NE(std::string::npos, visible.front().find("source=delta_before_register"));
+    EXPECT_NE(std::string::npos,
+              visible.front().find("s_version=" + response.committed_snapshot_version()));
+}
+
+TEST_F(CacheManagerTest, TestReportEventInvalidFirstDeltaDoesNotCreateVersionButPartialBatchDoes) {
+    const std::string host = "192.168.10.49:8080";
+    const int64_t invalid_key = 94'434;
+    const int64_t valid_key = 94'435;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    auto invalid_request = MakeAddRequest(host, invalid_key, "invalid_without_specs");
+    invalid_request.mutable_events(0)->mutable_block_add()->clear_specs();
+    const auto [invalid_ec, invalid_response] =
+        CallReportEvent(invalid_request, "invalid_first_delta_without_snapshot");
+    ASSERT_EQ(EC_PARTIAL_OK, invalid_ec);
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, invalid_response.header().status().code());
+    ASSERT_EQ(1, invalid_response.item_results_size());
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, invalid_response.item_results(0));
+    EXPECT_TRUE(invalid_response.committed_snapshot_version().empty());
+    EXPECT_TRUE(invalid_response.snapshot_required());
+    EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
+    EXPECT_FALSE(event_backend->IsNodeRegistered("test_instance", host));
+    EXPECT_TRUE(QueryEventReportUris({invalid_key}).empty());
+
+    auto partial_request = invalid_request;
+    *partial_request.add_events() = MakeAddRequest(host, valid_key, "valid_in_partial_first_delta").events(0);
+    const auto [partial_ec, partial_response] =
+        CallReportEvent(partial_request, "partial_first_delta_without_snapshot");
+    ASSERT_EQ(EC_PARTIAL_OK, partial_ec);
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, partial_response.header().status().code());
+    ASSERT_EQ(2, partial_response.item_results_size());
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, partial_response.item_results(0));
+    EXPECT_EQ(proto::meta::OK, partial_response.item_results(1));
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(partial_response.committed_snapshot_version()));
+    EXPECT_FALSE(partial_response.snapshot_required());
+    EXPECT_EQ(partial_response.committed_snapshot_version(),
+              event_backend->GetSnapshotVersion({"test_instance", host}));
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+
+    EXPECT_TRUE(QueryEventReportUris({invalid_key}).empty());
+    const auto visible = QueryEventReportUris({valid_key});
+    ASSERT_EQ(1u, visible.size());
+    EXPECT_NE(std::string::npos, visible.front().find("source=valid_in_partial_first_delta"));
+    EXPECT_NE(std::string::npos,
+              visible.front().find("s_version=" + partial_response.committed_snapshot_version()));
+}
+
+TEST_F(CacheManagerTest, TestReportEventFirstDeleteWithoutSnapshotCreatesReusableVersion) {
+    const std::string host = "192.168.10.46:8080";
+    const int64_t key = 94'430;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    auto delete_request = MakeAddRequest(host, key, "placeholder");
+    delete_request.clear_events();
+    auto *delete_event = delete_request.add_events();
+    delete_event->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+    delete_event->mutable_block_delete()->set_block_key(std::to_string(key));
+    delete_event->mutable_block_delete()->set_medium("mem");
+    delete_event->mutable_block_delete()->add_spec_names("tp0");
+
+    const auto [delete_ec, delete_response] =
+        CallReportEvent(delete_request, "first_delete_without_snapshot");
+    ASSERT_EQ(EC_OK, delete_ec);
+    const std::string version = delete_response.committed_snapshot_version();
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(version));
+    EXPECT_FALSE(delete_response.snapshot_required());
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+
+    const auto [add_ec, add_response] =
+        CallReportEvent(MakeAddRequest(host, key, "after_first_delete"), "delta_after_first_delete");
+    ASSERT_EQ(EC_OK, add_ec);
+    EXPECT_EQ(version, add_response.committed_snapshot_version());
+    const auto visible = QueryEventReportUris({key});
+    ASSERT_EQ(1u, visible.size());
+    EXPECT_NE(std::string::npos, visible.front().find("source=after_first_delete"));
+    EXPECT_NE(std::string::npos, visible.front().find("s_version=" + version));
+}
+
+TEST_F(CacheManagerTest, TestReportEventMissingBlockDeletesRemainSuccessfulAsOneBatch) {
+    const std::string host = "192.168.10.51:8080";
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    auto request = MakeAddRequest(host, 94'437, "placeholder");
+    request.clear_events();
+    for (const int64_t key : {94'437, 94'438, 94'439}) {
+        auto *delete_event = request.add_events();
+        delete_event->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+        delete_event->mutable_block_delete()->set_block_key(std::to_string(key));
+        delete_event->mutable_block_delete()->set_medium("mem");
+        delete_event->mutable_block_delete()->add_spec_names("tp0");
+    }
+
+    const auto [ec, response] = CallReportEvent(request, "missing_block_delete_batch");
+    ASSERT_EQ(EC_OK, ec);
+    EXPECT_EQ(proto::meta::OK, response.header().status().code());
+    EXPECT_EQ(0, response.item_results_size());
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
+    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(QueryEventReportUris({94'437, 94'438, 94'439}).empty());
+}
+
+TEST_F(CacheManagerTest, TestReportEventRestartKeepsHistoricalCacheAndAcceptsDeltaWithoutSnapshot) {
+    const std::string host = "192.168.10.47:8080";
+    const int64_t historical_key = 94'431;
+    const int64_t realtime_key = 94'432;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    const auto [before_ec, before] =
+        CallReportEvent(MakeAddRequest(host, historical_key, "before_restart"), "delta_before_restart");
+    ASSERT_EQ(EC_OK, before_ec);
+    const std::string previous_version = before.committed_snapshot_version();
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(previous_version));
+    ASSERT_EQ(1u, QueryEventReportUris({historical_key}).size());
+
+    const StorageConfig storage_config = event_backend->GetStorageConfig();
+    ASSERT_EQ(EC_OK, event_backend->Close());
+    ASSERT_EQ(EC_OK, event_backend->Open(storage_config, "delta_only_restart"));
+    event_backend->SetSnapshotMinIntervalMsForTest(0);
+    EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
+    EXPECT_TRUE(QueryEventReportUris({historical_key}).empty());
+
+    const auto [delta_ec, delta] =
+        CallReportEvent(MakeAddRequest(host, realtime_key, "after_restart"), "first_delta_after_restart");
+    ASSERT_EQ(EC_OK, delta_ec);
+    EXPECT_EQ(proto::meta::OK, delta.header().status().code());
+    EXPECT_FALSE(delta.snapshot_required());
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(delta.committed_snapshot_version()));
+    EXPECT_NE(previous_version, delta.committed_snapshot_version());
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+    EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
+
+    const auto visible = QueryEventReportUris({historical_key, realtime_key});
+    ASSERT_EQ(2u, visible.size());
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const std::string &uri) {
+        return uri.find("source=before_restart") != std::string::npos;
+    }));
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const std::string &uri) {
+        return uri.find("source=after_restart") != std::string::npos;
+    }));
 }
 
 TEST_F(CacheManagerTest, TestReportEventRejectsCanonicalDuplicateSnapshotKeysButAllowsDifferentMedia) {
@@ -3119,15 +3412,12 @@ TEST_F(CacheManagerTest, TestReportEventSnapshotCommitReclaimsOnlyStaleReporterL
     const std::string host_a_new_token = reconcile.committed_snapshot_version();
     ASSERT_NE(host_a_old_token, host_a_new_token);
 
-    // Query filtering must hide the omitted block immediately, before making
-    // any assumption about asynchronous physical reclamation.
-    EXPECT_TRUE(QueryEventReportUris({stale_key}).empty());
-
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
     while (std::chrono::steady_clock::now() < deadline && !QueryRawEventReportUris(stale_key).empty()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     EXPECT_TRUE(QueryRawEventReportUris(stale_key).empty());
+    EXPECT_TRUE(QueryEventReportUris({stale_key}).empty());
 
     // The same cleanup scan must preserve the reporter's current token and
     // every location belonging to a different reporter.
@@ -3149,6 +3439,131 @@ TEST_F(CacheManagerTest, TestReportEventSnapshotCommitReclaimsOnlyStaleReporterL
     EXPECT_TRUE(QueryRawEventReportUris(stale_key).empty());
     EXPECT_EQ(1u, QueryRawEventReportUris(current_key).size());
     EXPECT_EQ(1u, QueryRawEventReportUris(other_host_key).size());
+}
+
+TEST_F(CacheManagerTest, TestSnapshotCleanupPreservesPostCommitDeltaOnMixedGenerationLocation) {
+    const std::string host = "192.168.10.33:8080";
+    const int64_t key = 9434;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    auto baseline_request = MakeSnapshotRequest(host, {});
+    auto *block = baseline_request.mutable_events(0)->mutable_block_snapshot()->add_blocks();
+    block->set_block_key(std::to_string(key));
+    block->set_medium("mem");
+    auto *tp0 = block->add_specs();
+    tp0->set_name("tp0");
+    tp0->set_uri("event_report://" + host + "/mem?source=old_tp0");
+    auto *tp1 = block->add_specs();
+    tp1->set_name("tp1");
+    tp1->set_uri("event_report://" + host + "/mem?source=old_tp1");
+
+    const auto [baseline_ec, baseline] = CallReportEvent(baseline_request, "mixed_generation_baseline");
+    ASSERT_EQ(EC_OK, baseline_ec);
+    const std::string old_token = baseline.committed_snapshot_version();
+
+    // Publish the next complete generation without touching this block. This
+    // models the interval after commit but before the asynchronous cleanup
+    // scan has reclaimed an omitted location.
+    std::string current_token;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(
+        EC_OK,
+        event_backend->BeginSnapshot({"test_instance", host}, current_token, retry_after_ms));
+    ASSERT_NE(old_token, current_token);
+    ASSERT_TRUE(event_backend->CommitSnapshotVersion({"test_instance", host}, current_token));
+
+    // A post-commit delta refreshes one spec in the stable location. The other
+    // spec legitimately retains its older reconciliation tag.
+    const auto [delta_ec, delta] =
+        CallReportEvent(MakeAddRequest(host, key, "new_tp0"), "mixed_generation_delta");
+    ASSERT_EQ(EC_OK, delta_ec);
+    ASSERT_EQ(current_token, delta.committed_snapshot_version());
+    auto before_cleanup = QueryRawEventReportUris(key);
+    ASSERT_EQ(2u, before_cleanup.size());
+
+    // Cleanup is location-granular. It must not delete the whole location just
+    // because one sibling spec still has the previous generation.
+    ASSERT_EQ(
+        EC_OK,
+        cache_manager_->CleanupStaleSnapshotLocations(
+            {"test_instance", host},
+            current_token,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            event_backend));
+    auto cleanup_latency =
+        metrics_registry_->GetMetricsData("event_report.snapshot_cleanup_scan_latency_ms");
+    ASSERT_NE(nullptr, cleanup_latency);
+    const MetricsTags cleanup_tags = {
+        {"instance_id", "test_instance"},
+        {"host", host},
+        {"type", "event_report_l2"},
+    };
+    EXPECT_GE(cleanup_latency->GetOrCreateGauge(cleanup_tags).Get(), 0.0);
+
+    const auto after_cleanup = QueryRawEventReportUris(key);
+    ASSERT_EQ(2u, after_cleanup.size());
+    EXPECT_EQ(
+        1u,
+        std::count_if(after_cleanup.begin(), after_cleanup.end(), [](const std::string &uri) {
+            return uri.find("source=new_tp0") != std::string::npos;
+        }));
+    EXPECT_EQ(
+        1u,
+        std::count_if(after_cleanup.begin(), after_cleanup.end(), [](const std::string &uri) {
+            return uri.find("source=old_tp1") != std::string::npos;
+        }));
+    EXPECT_EQ(2u, QueryEventReportUris({key}).size());
+}
+
+TEST_F(CacheManagerTest, TestSnapshotCleanupPreservesCurrentDeltaBesideLegacySpec) {
+    const std::string host = "192.168.10.32:8080";
+    const int64_t key = 9433;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    std::string current_token;
+    ASSERT_EQ(
+        EC_OK,
+        event_backend->BeginDeltaMutation({"test_instance", host}, current_token));
+    event_backend->EndDeltaMutation({"test_instance", host});
+
+    std::string current_uri;
+    ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(
+        "event_report://" + host + "/mem?source=current",
+        current_token,
+        current_uri));
+    const std::string legacy_uri =
+        "event_report://" + host + "/mem?source=legacy";
+
+    MetaSearcher *meta_searcher =
+        cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    std::vector<ErrorCode> replace_results;
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher->BatchReplaceLocationSpecs(
+            request_context_.get(),
+            {key},
+            {{{event_backend->BuildLocationId("mem", host),
+               DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+               CacheLocationStatus::CLS_SERVING,
+               {LocationSpec("tp0", current_uri),
+                LocationSpec("tp1", legacy_uri)}}}},
+            replace_results));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), replace_results);
+
+    ASSERT_EQ(
+        EC_OK,
+        cache_manager_->CleanupStaleSnapshotLocations(
+            {"test_instance", host},
+            current_token,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            event_backend));
+    EXPECT_EQ(2u, QueryRawEventReportUris(key).size());
+    EXPECT_EQ(2u, QueryEventReportUris({key}).size());
 }
 
 TEST_F(CacheManagerTest, TestSnapshotCleanupPreservesInFlightStableLocationUntilAbort) {
@@ -3184,7 +3599,9 @@ TEST_F(CacheManagerTest, TestSnapshotCleanupPreservesInFlightStableLocationUntil
                                                        replace_results));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), replace_results);
     ASSERT_EQ(1u, QueryRawEventReportUris(key).size());
-    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+    const auto in_flight_visible = QueryEventReportUris({key});
+    ASSERT_EQ(1u, in_flight_visible.size());
+    EXPECT_NE(std::string::npos, in_flight_visible.front().find("source=in_flight"));
 
     ASSERT_EQ(
         EC_OK,
@@ -3236,7 +3653,9 @@ TEST_F(CacheManagerTest, TestSnapshotCleanupCASPreservesLocationRefreshedAfterSc
         [](const CacheLocation &) { return true; },
         [&](const std::vector<int64_t> &keys,
             const std::vector<std::vector<std::string>> &location_ids,
-            const std::vector<std::vector<std::string>> &expected_values) {
+            const std::vector<std::vector<std::string>> &expected_values,
+            bool metadata_only) {
+            EXPECT_TRUE(metadata_only);
             captured_keys = keys;
             captured_location_ids = location_ids;
             captured_expected_values = expected_values;
@@ -3293,6 +3712,7 @@ TEST_F(CacheManagerTest, TestSnapshotCleanupCASPreservesLocationRefreshedAfterSc
         .location_ids = captured_location_ids,
         .delay = std::chrono::seconds(0),
         .expected_location_values = captured_expected_values,
+        .metadata_only = true,
     };
     const auto cleanup_result = cache_manager_->schedule_plan_executor_->Submit(stale_cleanup_request).get();
     ASSERT_EQ(EC_OK, cleanup_result.status);
@@ -3321,13 +3741,13 @@ TEST_F(CacheManagerTest, TestReportEventEmptySnapshotCommitsAndReclaimsPreviousB
     ASSERT_EQ(EC_OK, empty_ec);
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(empty_snapshot.committed_snapshot_version()));
     EXPECT_NE(baseline.committed_snapshot_version(), empty_snapshot.committed_snapshot_version());
-    EXPECT_TRUE(QueryEventReportUris({key}).empty());
 
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
     while (std::chrono::steady_clock::now() < deadline && !QueryRawEventReportUris(key).empty()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     EXPECT_TRUE(QueryRawEventReportUris(key).empty());
+    EXPECT_TRUE(QueryEventReportUris({key}).empty());
 }
 
 TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_EventReportFallbackLookup) {
@@ -3380,7 +3800,7 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_EventReportFallbackLookup)
     registry_manager_->instance_group_configs_.erase(instance_group);
 }
 
-TEST_F(CacheManagerTest, TestGetCheckLocDataExistFuncRequiresAllSpecsToMatchCurrentReporterToken) {
+TEST_F(CacheManagerTest, TestGetCheckLocDataExistFuncAcceptsWellFormedGenerationsAndLegacyUris) {
     const std::string host = "192.168.10.35:8080";
     auto event_backend = InstallEventReportBackend();
     ASSERT_NE(nullptr, event_backend);
@@ -3406,8 +3826,11 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFuncRequiresAllSpecsToMatchCurr
     EXPECT_TRUE(check(location));
 
     location.set_location_specs({LocationSpec("tp0", current_uri), LocationSpec("tp1", unknown_uri)});
-    EXPECT_FALSE(check(location));
+    EXPECT_TRUE(check(location));
     location.set_location_specs({LocationSpec("tp0", current_uri), LocationSpec("tp1", "event_report://raw/mem")});
+    EXPECT_TRUE(check(location));
+    location.set_location_specs(
+        {LocationSpec("tp0", current_uri), LocationSpec("tp1", "event_report://raw/mem?s_version=bad")});
     EXPECT_FALSE(check(location));
     location.set_location_specs({});
     EXPECT_FALSE(check(location));
@@ -3418,9 +3841,8 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFuncRequiresAllSpecsToMatchCurr
     ASSERT_EQ(EC_OK, event_backend->OnHeartbeat("test_instance", host, {}));
     EXPECT_TRUE(check(location));
 
-    // A token is opaque, but its owner must still match the reporter encoded
-    // by the stable location id. A healthy token belonging to another host or
-    // another instance must fail closed.
+    // The stable location id and liveness identify the reporter. Snapshot
+    // generations do not gate query visibility.
     const std::string other_host = "192.168.10.36:8080";
     ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", other_host, {"mem"}));
     const auto [other_host_ec, other_host_snapshot] =
@@ -3430,7 +3852,7 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFuncRequiresAllSpecsToMatchCurr
     ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(
         "event_report://physical-cache:9600/mem", other_host_snapshot.committed_snapshot_version(), other_host_uri));
     location.set_location_specs({LocationSpec("tp0", other_host_uri)});
-    EXPECT_FALSE(check(location));
+    EXPECT_TRUE(check(location));
 
     const ReporterSnapshotKey other_instance{"other_instance", host};
     ASSERT_EQ(EC_OK, event_backend->RegisterNode(other_instance.instance_id, host, {"mem"}));
@@ -3442,6 +3864,84 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFuncRequiresAllSpecsToMatchCurr
     ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(
         "event_report://physical-cache:9600/mem", other_instance_token, other_instance_uri));
     location.set_location_specs({LocationSpec("tp0", other_instance_uri)});
+    EXPECT_TRUE(check(location));
+}
+
+TEST_F(CacheManagerTest, TestGetCheckLocDataExistFuncEventReportUriValidationMatrix) {
+    const std::string instance_id = "test_instance";
+    const std::string host = "192.168.10.37:8080";
+    const std::string token = "0123456789abcdef0123456789abcdef";
+    const std::string upper_token = "ABCDEF0123456789ABCDEF0123456789";
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode(instance_id, host, {"mem"}));
+
+    CacheLocation location;
+    location.set_id(event_backend->BuildLocationId("mem", host));
+    location.set_status(CLS_SERVING);
+    location.set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+    const auto check = cache_manager_->GetCheckLocDataExistFunc(instance_id);
+
+    struct Case {
+        const char *name;
+        std::vector<std::string> uris;
+        bool readable;
+    };
+    const std::vector<Case> cases{
+        {"empty_specs", {}, false},
+        {"legacy_without_query", {"event_report://physical-cache:9600/mem"}, true},
+        {"legacy_with_other_params", {"event_report://physical-cache:9600/mem?size=4096&offset=0"}, true},
+        {"valid_lowercase_version", {"event_report://physical-cache:9600/mem?s_version=" + token}, true},
+        {"valid_uppercase_version", {"event_report://physical-cache:9600/mem?s_version=" + upper_token}, true},
+        {"near_match_param",
+         {"event_report://physical-cache:9600/mem?xs_version=bad&s_version_suffix=bad"},
+         true},
+        {"empty_version", {"event_report://physical-cache:9600/mem?s_version="}, false},
+        {"version_without_equals", {"event_report://physical-cache:9600/mem?s_version"}, false},
+        {"short_version", {"event_report://physical-cache:9600/mem?s_version=" + std::string(31, 'a')}, false},
+        {"long_version", {"event_report://physical-cache:9600/mem?s_version=" + std::string(33, 'a')}, false},
+        {"non_hex_version",
+         {"event_report://physical-cache:9600/mem?s_version=0123456789abcdef0123456789abcdeg"},
+         false},
+        {"duplicate_same_version",
+         {"event_report://physical-cache:9600/mem?s_version=" + token + "&s_version=" + token},
+         false},
+        {"duplicate_different_version",
+         {"event_report://physical-cache:9600/mem?s_version=" + token + "&s_version=" + upper_token},
+         false},
+        {"invalid_uri", {"not-a-uri"}, false},
+        {"mixed_versioned_and_legacy",
+         {"event_report://physical-cache:9600/mem?s_version=" + token,
+          "event_report://physical-cache:9600/mem?source=legacy"},
+         true},
+        {"mixed_valid_and_malformed",
+         {"event_report://physical-cache:9600/mem?s_version=" + token,
+          "event_report://physical-cache:9600/mem?s_version=bad"},
+         false},
+        {"mixed_valid_and_duplicate",
+         {"event_report://physical-cache:9600/mem?s_version=" + token,
+          "event_report://physical-cache:9600/mem?s_version=" + token + "&s_version=" + token},
+         false},
+    };
+
+    for (const auto &test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        std::vector<LocationSpec> specs;
+        specs.reserve(test_case.uris.size());
+        for (size_t i = 0; i < test_case.uris.size(); ++i) {
+            specs.emplace_back("tp" + std::to_string(i), test_case.uris[i]);
+        }
+        location.set_location_specs(std::move(specs));
+        EXPECT_EQ(test_case.readable, check(location));
+    }
+
+    location.set_location_specs(
+        {LocationSpec("tp0", "event_report://physical-cache:9600/mem?s_version=" + token)});
+    location.set_id("kvs#event_report_l2#mem");
+    EXPECT_FALSE(check(location));
+    location.set_id("kvs#event_report_l1p5#mem#" + host);
+    EXPECT_FALSE(check(location));
+    location.set_id(event_backend->BuildLocationId("mem", "192.168.10.38:8080"));
     EXPECT_FALSE(check(location));
 }
 
@@ -3494,13 +3994,18 @@ TEST_F(CacheManagerTest, TestGetCacheLocationEnforcesReporterLifecycleAndBatchOr
     EXPECT_NE(std::string::npos, visible[0][0].find("s_version=" + first_a_token));
     EXPECT_NE(std::string::npos, visible[2][0].find("s_version=" + first_b_token));
 
-    // A new authoritative snapshot makes the omitted block's old token
-    // invisible immediately, even before its physical cleanup completes.
+    // A successful snapshot eventually reclaims omitted blocks. Until the
+    // asynchronous cleanup completes, old metadata may remain readable.
     const auto [second_a_ec, second_a] =
         CallReportEvent(MakeSnapshotRequest(host_a, {{current_key, "a_second"}}), "query_lifecycle_a_second");
     ASSERT_EQ(EC_OK, second_a_ec);
     const std::string second_a_token = second_a.committed_snapshot_version();
     ASSERT_NE(first_a_token, second_a_token);
+    const auto cleanup_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < cleanup_deadline && !QueryRawEventReportUris(old_key).empty()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(QueryRawEventReportUris(old_key).empty());
     visible = query_visibility({current_key, old_key, down_key, missing_key});
     ASSERT_EQ(4u, visible.size());
     ASSERT_EQ(1u, visible[0].size());
@@ -3523,8 +4028,8 @@ TEST_F(CacheManagerTest, TestGetCacheLocationEnforcesReporterLifecycleAndBatchOr
     ASSERT_EQ(1u, visible[2].size());
     EXPECT_NE(std::string::npos, visible[2][0].find("s_version=" + first_b_token));
 
-    // Once host A is unregistered, neither heartbeat nor registration alone
-    // may resurrect its old token. A new full snapshot is mandatory.
+    // Same-process unregister creates a tombstone: late events cannot revive
+    // the reporter until an explicit REGISTER clears it.
     ASSERT_EQ(EC_OK, event_backend->UnregisterNode("test_instance", host_a));
     visible = query_visibility({current_key, down_key});
     ASSERT_EQ(2u, visible.size());
@@ -3534,12 +4039,18 @@ TEST_F(CacheManagerTest, TestGetCacheLocationEnforcesReporterLifecycleAndBatchOr
     ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host_a, {"mem"}));
     visible = query_visibility({current_key});
     ASSERT_EQ(1u, visible.size());
-    EXPECT_TRUE(visible[0].empty());
+    ASSERT_EQ(1u, visible[0].size());
+    EXPECT_NE(std::string::npos, visible[0][0].find("source=a_second"));
 
     const auto [delta_ec, delta_response] =
-        CallReportEvent(MakeAddRequest(host_a, current_key, "must_be_rejected"), "query_lifecycle_delta_rejected");
-    EXPECT_EQ(EC_PARTIAL_OK, delta_ec);
-    EXPECT_EQ(proto::meta::SNAPSHOT_REQUIRED, delta_response.header().status().code());
+        CallReportEvent(MakeAddRequest(host_a, current_key, "new_lifecycle_delta"), "query_lifecycle_first_delta");
+    ASSERT_EQ(EC_OK, delta_ec);
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(delta_response.committed_snapshot_version()));
+    EXPECT_NE(second_a_token, delta_response.committed_snapshot_version());
+    visible = query_visibility({current_key});
+    ASSERT_EQ(1u, visible.size());
+    ASSERT_EQ(1u, visible[0].size());
+    EXPECT_NE(std::string::npos, visible[0][0].find("source=new_lifecycle_delta"));
     const auto [third_a_ec, third_a] =
         CallReportEvent(MakeSnapshotRequest(host_a, {{current_key, "a_third"}}), "query_lifecycle_a_third");
     ASSERT_EQ(EC_OK, third_a_ec);
@@ -3551,9 +4062,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationEnforcesReporterLifecycleAndBatchOr
 }
 
 TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_EventReportNodeUnavailable) {
-    // Start from a valid committed snapshot. Otherwise an unversioned URI
-    // would be rejected as stale before this test ever reached the node
-    // availability branch.
+    // Start from a known-readable location, then change only node liveness.
     const std::string instance_id = "test_instance";
     const std::string node_host = "192.168.1.200:8080";
     auto event_report_backend = InstallEventReportBackend();
@@ -3608,13 +4117,17 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_EventReportNodeUnregistere
     ASSERT_EQ(EC_OK, event_report_backend->UnregisterNode(instance_id, node_host));
     EXPECT_FALSE(func(loc));
 
-    // Registration alone starts a fresh reporter lifecycle. It must not
-    // resurrect the previous token.
+    // Same-process unregister is tombstoned, so only an explicit REGISTER can
+    // reuse persisted soft cache metadata. The first delta then establishes
+    // a fresh reconciliation generation.
+    ASSERT_EQ(EC_NODE_NOT_REGISTERED, event_report_backend->OnHeartbeat(instance_id, node_host, {}));
     ASSERT_EQ(EC_OK, event_report_backend->RegisterNode(instance_id, node_host, {"mem"}));
-    EXPECT_FALSE(func(loc));
+    EXPECT_TRUE(func(loc));
     std::string committed = "must-be-cleared";
-    EXPECT_EQ(EC_SNAPSHOT_REQUIRED, event_report_backend->BeginDeltaMutation({instance_id, node_host}, committed));
-    EXPECT_TRUE(committed.empty());
+    ASSERT_EQ(EC_OK, event_report_backend->BeginDeltaMutation({instance_id, node_host}, committed));
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(committed));
+    EXPECT_NE(first_token, committed);
+    event_report_backend->EndDeltaMutation({instance_id, node_host});
 
     const auto [second_snapshot_ec, second_snapshot] =
         CallReportEvent(MakeSnapshotRequest(node_host, {}), "reregister_new_snapshot");
@@ -3627,7 +4140,7 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_EventReportNodeUnregistere
     loc.set_location_specs({LocationSpec("tp0", second_uri)});
     EXPECT_TRUE(func(loc));
     loc.set_location_specs({LocationSpec("tp0", first_uri)});
-    EXPECT_FALSE(func(loc));
+    EXPECT_TRUE(func(loc));
 }
 
 TEST_F(CacheManagerTest, TestGetSubmitDelReqFunc_NullExecutor) {
@@ -3637,7 +4150,7 @@ TEST_F(CacheManagerTest, TestGetSubmitDelReqFunc_NullExecutor) {
     cache_manager_->schedule_plan_executor_ = nullptr;
 
     auto func = cache_manager_->GetSubmitDelReqFunc("test_instance");
-    func({1, 2, 3}, {{"loc_a"}, {"loc_b"}, {"loc_c"}}, {});
+    func({1, 2, 3}, {{"loc_a"}, {"loc_b"}, {"loc_c"}}, {}, false);
 
     cache_manager_->schedule_plan_executor_ = saved;
 }
@@ -3686,7 +4199,7 @@ TEST_F(CacheManagerTest, TestGetSubmitDelReqFunc_DeletesLocationMetadata) {
 
     // use GetSubmitDelReqFunc to submit a deletion request
     auto del_func = cache_manager_->GetSubmitDelReqFunc("test_instance");
-    del_func(keys, loc_ids, {});
+    del_func(keys, loc_ids, {}, false);
 
     // wait for the async executor to process the request
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -4434,12 +4947,357 @@ TEST_F(CacheManagerTest, InvalidateInstanceMetricsInvokesCallback) {
     cm->InvalidateInstanceMetrics("");
     ASSERT_EQ(1, call_count);
 }
+
+TEST_F(CacheManagerTest, TestReportEventMutationValidationMatrixHasNoSideEffects) {
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    using ConfigureEvent = std::function<void(proto::meta::EventItem *, int64_t, const std::string &)>;
+    struct TestCase {
+        const char *name;
+        ConfigureEvent configure;
+    };
+    auto configure_valid_add = [](proto::meta::EventItem *event, int64_t key, const std::string &host) {
+        event->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+        auto *params = event->mutable_block_add();
+        params->set_block_key(std::to_string(key));
+        params->set_medium("mem");
+        auto *spec = params->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri("event_report://" + host + "/mem");
+        return params;
+    };
+    auto configure_valid_delete = [](proto::meta::EventItem *event, int64_t key) {
+        event->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+        auto *params = event->mutable_block_delete();
+        params->set_block_key(std::to_string(key));
+        params->set_medium("mem");
+        params->add_spec_names("tp0");
+        return params;
+    };
+    auto configure_valid_snapshot = [](proto::meta::EventItem *event, int64_t key, const std::string &host) {
+        event->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+        auto *block = event->mutable_block_snapshot()->add_blocks();
+        block->set_block_key(std::to_string(key));
+        block->set_medium("mem");
+        auto *spec = block->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri("event_report://" + host + "/mem");
+        return block;
+    };
+
+    const std::vector<TestCase> cases = {
+        {"add_non_numeric_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_block_key("not-a-number");
+         }},
+        {"add_empty_medium",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->clear_medium();
+         }},
+        {"add_medium_with_separator",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_medium("mem#bad");
+         }},
+        {"add_deprecated_uri_without_specs",
+         [](auto *event, int64_t key, const std::string &host) {
+             event->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+             auto *params = event->mutable_block_add();
+             params->set_block_key(std::to_string(key));
+             params->set_medium("mem");
+             params->set_uri("event_report://" + host + "/deprecated");
+         }},
+        {"add_empty_spec_name",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->mutable_specs(0)->clear_name();
+         }},
+        {"add_duplicate_spec_name",
+         [=](auto *event, int64_t key, const std::string &host) {
+             auto *params = configure_valid_add(event, key, host);
+             *params->add_specs() = params->specs(0);
+         }},
+        {"add_invalid_uri",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->mutable_specs(0)->set_uri("not-a-uri");
+         }},
+        {"add_client_snapshot_version",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)
+                 ->mutable_specs(0)
+                 ->set_uri("event_report://" + host + "/mem?s_version=" + std::string(32, 'a'));
+         }},
+        {"delete_non_numeric_key",
+         [=](auto *event, int64_t key, const std::string &) {
+             configure_valid_delete(event, key)->set_block_key("not-a-number");
+         }},
+        {"delete_empty_medium",
+         [=](auto *event, int64_t key, const std::string &) {
+             configure_valid_delete(event, key)->clear_medium();
+         }},
+        {"delete_medium_with_separator",
+         [=](auto *event, int64_t key, const std::string &) {
+             configure_valid_delete(event, key)->set_medium("mem#bad");
+         }},
+        {"delete_empty_spec_names",
+         [=](auto *event, int64_t key, const std::string &) {
+             configure_valid_delete(event, key)->clear_spec_names();
+         }},
+        {"delete_empty_spec_name",
+         [=](auto *event, int64_t key, const std::string &) {
+             configure_valid_delete(event, key)->set_spec_names(0, "");
+         }},
+        {"delete_duplicate_spec_name",
+         [=](auto *event, int64_t key, const std::string &) {
+             configure_valid_delete(event, key)->add_spec_names("tp0");
+         }},
+        {"snapshot_non_numeric_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host)->set_block_key("not-a-number");
+         }},
+        {"snapshot_empty_medium",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host)->clear_medium();
+         }},
+        {"snapshot_medium_with_separator",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host)->set_medium("mem#bad");
+         }},
+        {"snapshot_empty_specs",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host)->clear_specs();
+         }},
+        {"snapshot_empty_spec_name",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host)->mutable_specs(0)->clear_name();
+         }},
+        {"snapshot_duplicate_spec_name",
+         [=](auto *event, int64_t key, const std::string &host) {
+             auto *block = configure_valid_snapshot(event, key, host);
+             *block->add_specs() = block->specs(0);
+         }},
+        {"snapshot_invalid_uri",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host)->mutable_specs(0)->set_uri("not-a-uri");
+         }},
+        {"snapshot_client_snapshot_version",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host)
+                 ->mutable_specs(0)
+                 ->set_uri("event_report://" + host + "/mem?s_version=" + std::string(32, 'a'));
+         }},
+        {"snapshot_duplicate_block_and_medium",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_snapshot(event, key, host);
+             auto *duplicate = event->mutable_block_snapshot()->add_blocks();
+             *duplicate = event->block_snapshot().blocks(0);
+         }},
+    };
+
+    for (size_t index = 0; index < cases.size(); ++index) {
+        const auto &test_case = cases[index];
+        SCOPED_TRACE(test_case.name);
+        const std::string host = "192.168.12." + std::to_string(index + 1) + ":8080";
+        const int64_t key = 95'000 + static_cast<int64_t>(index);
+        ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+        proto::meta::ReportEventRequest request;
+        request.set_instance_id("test_instance");
+        request.set_host_ip_port(host);
+        request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+        test_case.configure(request.add_events(), key, host);
+
+        const auto [ec, response] = CallReportEvent(request, test_case.name);
+        EXPECT_EQ(EC_PARTIAL_OK, ec);
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        ASSERT_EQ(1, response.item_results_size());
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.item_results(0));
+        EXPECT_TRUE(response.committed_snapshot_version().empty());
+        EXPECT_TRUE(response.snapshot_required());
+        EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
+        EXPECT_TRUE(QueryRawEventReportUris(key).empty());
+    }
+}
+
+TEST_F(CacheManagerTest, TestReportEventRejectsMismatchedPayloadsWithoutSideEffects) {
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    using ConfigurePayload = std::function<void(proto::meta::EventItem *)>;
+    struct TestCase {
+        const char *name;
+        proto::meta::ReportEventType event_type;
+        ConfigurePayload configure_payload;
+        bool pre_register;
+    };
+    const std::vector<TestCase> cases = {
+        {"unspecified_without_payload", proto::meta::EVENT_UNSPECIFIED, {}, true},
+        {"register_without_payload", proto::meta::EVENT_NODE_REGISTER, {}, false},
+        {"register_with_heartbeat_payload",
+         proto::meta::EVENT_NODE_REGISTER,
+         [](auto *event) { event->mutable_heartbeat(); },
+         false},
+        {"heartbeat_without_payload", proto::meta::EVENT_HEARTBEAT, {}, true},
+        {"heartbeat_with_register_payload",
+         proto::meta::EVENT_HEARTBEAT,
+         [](auto *event) { event->mutable_node_register()->add_mediums("mem"); },
+         true},
+        {"host_down_without_payload", proto::meta::EVENT_HOST_DOWN, {}, true},
+        {"host_down_with_heartbeat_payload",
+         proto::meta::EVENT_HOST_DOWN,
+         [](auto *event) { event->mutable_heartbeat(); },
+         true},
+        {"add_without_payload", proto::meta::EVENT_BLOCK_ADD, {}, true},
+        {"delete_without_payload", proto::meta::EVENT_BLOCK_DELETE, {}, true},
+        {"snapshot_without_payload", proto::meta::EVENT_BLOCK_SNAPSHOT, {}, true},
+    };
+
+    for (size_t index = 0; index < cases.size(); ++index) {
+        const auto &test_case = cases[index];
+        SCOPED_TRACE(test_case.name);
+        const std::string host = "192.168.11." + std::to_string(index + 1) + ":8080";
+        if (test_case.pre_register) {
+            ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+        }
+
+        proto::meta::ReportEventRequest request;
+        request.set_instance_id("test_instance");
+        request.set_host_ip_port(host);
+        request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+        auto *event = request.add_events();
+        event->set_event_type(test_case.event_type);
+        if (test_case.configure_payload) {
+            test_case.configure_payload(event);
+        }
+
+        const auto [ec, response] = CallReportEvent(request, test_case.name);
+        EXPECT_EQ(EC_PARTIAL_OK, ec);
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        ASSERT_EQ(1, response.item_results_size());
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.item_results(0));
+        EXPECT_TRUE(response.committed_snapshot_version().empty());
+        EXPECT_TRUE(response.snapshot_required());
+        EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
+        EXPECT_EQ(test_case.pre_register, event_backend->IsNodeRegistered("test_instance", host));
+    }
+
+    // A malformed REGISTER is isolated to that item. Registration is not a
+    // data-plane prerequisite, so a later valid mutation still lazily
+    // restores the reporter and is applied.
+    const std::string mixed_host = "192.168.11.200:8080";
+    const int64_t mixed_key = 95'900;
+    proto::meta::ReportEventRequest mixed_request;
+    mixed_request.set_instance_id("test_instance");
+    mixed_request.set_host_ip_port(mixed_host);
+    mixed_request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *bad_register = mixed_request.add_events();
+    bad_register->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    bad_register->mutable_heartbeat();
+    *mixed_request.add_events() = MakeAddRequest(mixed_host, mixed_key, "must_not_write").events(0);
+
+    const auto [mixed_ec, mixed_response] =
+        CallReportEvent(mixed_request, "mismatched_register_then_delta");
+    EXPECT_EQ(EC_PARTIAL_OK, mixed_ec);
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, mixed_response.header().status().code());
+    ASSERT_EQ(2, mixed_response.item_results_size());
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, mixed_response.item_results(0));
+    EXPECT_EQ(proto::meta::OK, mixed_response.item_results(1));
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", mixed_host));
+    EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(
+        event_backend->GetSnapshotVersion({"test_instance", mixed_host})));
+    EXPECT_FALSE(QueryRawEventReportUris(mixed_key).empty());
+}
+
+TEST_F(CacheManagerTest, TestReportEventRejectsRequestShapeBeforeAnySideEffect) {
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    const std::string host = "192.168.13.1:8080";
+    const int64_t key = 96'001;
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    auto expect_request_rejected = [&](proto::meta::ReportEventRequest request, const char *trace_id) {
+        SCOPED_TRACE(trace_id);
+        const auto [ec, response] = CallReportEvent(request, trace_id);
+        EXPECT_EQ(EC_BADARGS, ec);
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        EXPECT_EQ(0, response.item_results_size());
+        EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
+        EXPECT_TRUE(QueryRawEventReportUris(key).empty());
+    };
+
+    auto snapshot_and_delta = MakeSnapshotRequest(host, {{key, "snapshot"}});
+    *snapshot_and_delta.add_events() = MakeAddRequest(host, key, "delta").events(0);
+    expect_request_rejected(std::move(snapshot_and_delta), "snapshot_and_delta");
+
+    auto two_snapshots = MakeSnapshotRequest(host, {});
+    *two_snapshots.add_events() = MakeSnapshotRequest(host, {}).events(0);
+    expect_request_rejected(std::move(two_snapshots), "two_snapshots");
+
+    proto::meta::ReportEventRequest host_down_and_heartbeat;
+    host_down_and_heartbeat.set_instance_id("test_instance");
+    host_down_and_heartbeat.set_host_ip_port(host);
+    host_down_and_heartbeat.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *host_down = host_down_and_heartbeat.add_events();
+    host_down->set_event_type(proto::meta::EVENT_HOST_DOWN);
+    host_down->mutable_host_down();
+    auto *heartbeat = host_down_and_heartbeat.add_events();
+    heartbeat->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    heartbeat->mutable_heartbeat();
+    expect_request_rejected(std::move(host_down_and_heartbeat), "host_down_and_heartbeat");
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+    EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
+}
+
+TEST_F(CacheManagerTest, TestReportEventFirstDeltaMetadataFailureReportsFailureAndReusesGeneration) {
+    const std::string host = "192.168.13.2:8080";
+    const int64_t key = 96'002;
+    auto event_backend = InstallEventReportBackend();
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_NE(nullptr, meta_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    meta_backend->FailKeyOnNextUpsert(key);
+    const auto [failed_ec, failed] =
+        CallReportEvent(MakeAddRequest(host, key, "first_write_fails"), "first_delta_metadata_failure");
+    EXPECT_EQ(EC_PARTIAL_OK, failed_ec);
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, failed.header().status().code());
+    ASSERT_EQ(1, failed.item_results_size());
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, failed.item_results(0));
+    const std::string generation = failed.committed_snapshot_version();
+    EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(generation));
+    EXPECT_FALSE(failed.snapshot_required());
+    EXPECT_EQ(generation, event_backend->GetSnapshotVersion({"test_instance", host}));
+    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+
+    const auto [retry_ec, retry] =
+        CallReportEvent(MakeAddRequest(host, key, "first_write_retry"), "first_delta_metadata_retry");
+    ASSERT_EQ(EC_OK, retry_ec);
+    EXPECT_EQ(generation, retry.committed_snapshot_version());
+    EXPECT_FALSE(retry.snapshot_required());
+    const auto visible = QueryEventReportUris({key});
+    ASSERT_EQ(1u, visible.size());
+    EXPECT_NE(std::string::npos, visible.front().find("source=first_write_retry"));
+    EXPECT_NE(std::string::npos, visible.front().find("s_version=" + generation));
+}
+
 TEST_F(CacheManagerTest, TestReportEventRejectsInvalidRequestsAndMapsItemErrors) {
     auto add_register_event = [](proto::meta::ReportEventRequest &request) {
         auto *event = request.add_events();
         event->set_event_type(proto::meta::EVENT_NODE_REGISTER);
         event->mutable_node_register()->add_mediums("mem");
     };
+
+    {
+        proto::meta::ReportEventRequest request;
+        request.set_host_ip_port("10.0.0.30:8080");
+        request.set_storage_type(proto::meta::ST_EVENT_REPORT_L1P5);
+        add_register_event(request);
+
+        proto::meta::ReportEventResponse response;
+        EXPECT_EQ(EC_BADARGS, cache_manager_->ReportEvent(request_context_.get(), &request, &response));
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        EXPECT_EQ(0, response.item_results_size());
+    }
 
     {
         proto::meta::ReportEventRequest request;
@@ -4490,6 +5348,19 @@ TEST_F(CacheManagerTest, TestReportEventRejectsInvalidRequestsAndMapsItemErrors)
     {
         proto::meta::ReportEventRequest request;
         request.set_instance_id("test_instance");
+        request.set_host_ip_port("10.0.0.30#8080");
+        request.set_storage_type(proto::meta::ST_EVENT_REPORT_L1P5);
+        add_register_event(request);
+
+        proto::meta::ReportEventResponse response;
+        EXPECT_EQ(EC_BADARGS, cache_manager_->ReportEvent(request_context_.get(), &request, &response));
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        EXPECT_FALSE(event_backend->IsNodeRegistered("test_instance", "10.0.0.30#8080"));
+    }
+
+    {
+        proto::meta::ReportEventRequest request;
+        request.set_instance_id("test_instance");
         request.set_host_ip_port("10.0.0.30:8080");
         request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
         add_register_event(request);
@@ -4519,6 +5390,47 @@ TEST_F(CacheManagerTest, TestReportEventRejectsInvalidRequestsAndMapsItemErrors)
         EXPECT_EQ(proto::meta::OK, response.item_results(0));
         EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.item_results(1));
         EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", "10.0.0.30:8080"));
+    }
+
+    {
+        proto::meta::ReportEventRequest request;
+        request.set_instance_id("test_instance");
+        request.set_host_ip_port("10.0.0.30:8080");
+        request.set_storage_type(proto::meta::ST_EVENT_REPORT_L1P5);
+        auto *invalid_add = request.add_events();
+        invalid_add->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+        invalid_add->mutable_block_add()->set_block_key("101");
+        invalid_add->mutable_block_add()->set_medium("mem#invalid");
+        auto *spec = invalid_add->mutable_block_add()->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri("event_report://10.0.0.30:8080/mem");
+
+        proto::meta::ReportEventResponse response;
+        EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &request, &response));
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        EXPECT_TRUE(
+            event_backend->GetSnapshotVersion({"test_instance", "10.0.0.30:8080"}).empty());
+    }
+
+    {
+        proto::meta::ReportEventRequest request;
+        request.set_instance_id("test_instance");
+        request.set_host_ip_port("10.0.0.30:8080");
+        request.set_storage_type(proto::meta::ST_EVENT_REPORT_L1P5);
+        auto *snapshot_event = request.add_events();
+        snapshot_event->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+        auto *block = snapshot_event->mutable_block_snapshot()->add_blocks();
+        block->set_block_key("102");
+        block->set_medium("mem#invalid");
+        auto *spec = block->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri("event_report://10.0.0.30:8080/mem");
+
+        proto::meta::ReportEventResponse response;
+        EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &request, &response));
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        EXPECT_TRUE(
+            event_backend->GetSnapshotVersion({"test_instance", "10.0.0.30:8080"}).empty());
     }
 
     ASSERT_EQ(EC_OK, event_backend->Close());
@@ -5232,6 +6144,51 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         const auto &kl = locs[0].cache_locations_view();
         ASSERT_EQ(1u, kl.size());
         EXPECT_EQ(2u, kl[0].location_specs().size());
+    }
+
+    // --- Test 9: backend-selected queries enforce reporter liveness ---
+    {
+        for (const auto &peer : peer_data) {
+            event_report_backend->SetNodeUnavailable("test_instance", peer.host);
+        }
+        const std::vector<BackendSelector> selectors = {
+            {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+        };
+        BlockMask block_mask = static_cast<size_t>(0);
+        auto [hidden_ec, hidden] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                              "test_instance",
+                                                                              CacheManager::QueryType::QT_BATCH_GET,
+                                                                              all_keys,
+                                                                              {},
+                                                                              block_mask,
+                                                                              0,
+                                                                              {},
+                                                                              selectors);
+        ASSERT_EQ(EC_OK, hidden_ec);
+        ASSERT_EQ(all_keys.size(), hidden.size());
+        for (const auto &location : hidden) {
+            EXPECT_TRUE(location.cache_locations_view().empty());
+        }
+
+        for (const auto &peer : peer_data) {
+            ASSERT_EQ(EC_OK, event_report_backend->OnHeartbeat("test_instance", peer.host, {}));
+        }
+        auto [restored_ec, restored] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                                  "test_instance",
+                                                                                  CacheManager::QueryType::QT_BATCH_GET,
+                                                                                  all_keys,
+                                                                                  {},
+                                                                                  block_mask,
+                                                                                  0,
+                                                                                  {},
+                                                                                  selectors);
+        ASSERT_EQ(EC_OK, restored_ec);
+        ASSERT_EQ(all_keys.size(), restored.size());
+        EXPECT_FALSE(restored[0].cache_locations_view().empty());
+        EXPECT_FALSE(restored[1].cache_locations_view().empty());
+        EXPECT_FALSE(restored[2].cache_locations_view().empty());
+        EXPECT_FALSE(restored[3].cache_locations_view().empty());
+        EXPECT_TRUE(restored[4].cache_locations_view().empty());
     }
 
     dsm->storage_map_.erase("event_report_default");

--- a/kv_cache_manager/manager/test/meta_searcher_manager_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_manager_test.cc
@@ -21,7 +21,8 @@ namespace {
 CheckLocDataExistFunc dummy_check_loc_data_exist = [](const CacheLocation &) -> bool { return true; };
 SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
                                            const std::vector<std::vector<std::string>> &,
-                                           const std::vector<std::vector<std::string>> &) -> void {};
+                                           const std::vector<std::vector<std::string>> &,
+                                           bool) -> void {};
 } // namespace
 
 class MetaSearcherManagerTest : public TESTBASE {

--- a/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_redis_test.cc
@@ -31,7 +31,8 @@ public:
 CheckLocDataExistFunc dummy_check_loc_data_exist = [](const CacheLocation &) -> bool { return true; };
 SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
                                            const std::vector<std::vector<std::string>> &,
-                                           const std::vector<std::vector<std::string>> &) -> void {};
+                                           const std::vector<std::vector<std::string>> &,
+                                           bool) -> void {};
 } // namespace
 
 class MetaSearcherRealServiceTest : public TESTBASE {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -41,7 +41,8 @@ public:
 CheckLocDataExistFunc dummy_check_loc_data_exist = [](const CacheLocation &) -> bool { return true; };
 SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
                                            const std::vector<std::vector<std::string>> &,
-                                           const std::vector<std::vector<std::string>> &) -> void {};
+                                           const std::vector<std::vector<std::string>> &,
+                                           bool) -> void {};
 
 class FaultyGetLocationIdsBackend : public MetaLocalBackend {
 public:
@@ -270,7 +271,7 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsAppendsAndOverwrites) {
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["full_3"]);
 }
 
-TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsKeepsOnlyCurrentSnapshotVersion) {
+TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsPreservesUntouchedSpecsAcrossGenerationChange) {
     const MetaSearcher::KeyVector keys = {10007};
     const std::string location_id = "kvs#event_report_l2#mem#127.0.0.1:8080";
     const std::string version_a = "00112233445566778899aabbccddeeff";
@@ -304,9 +305,14 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsKeepsOnlyCurrentSnapshotVers
     ASSERT_EQ(1u, location_maps.size());
     ASSERT_EQ(1u, location_maps[0].size());
     const auto &after_version_change = location_maps[0].at(location_id)->location_specs();
-    ASSERT_EQ(1u, after_version_change.size());
-    EXPECT_EQ("linear_0", after_version_change[0].name());
-    EXPECT_EQ(uri("new_linear", version_b), after_version_change[0].uri());
+    std::map<std::string, std::string> after_version_change_specs;
+    for (const auto &spec : after_version_change) {
+        after_version_change_specs[spec.name()] = spec.uri();
+    }
+    ASSERT_EQ(3u, after_version_change_specs.size());
+    EXPECT_EQ(uri("new_linear", version_b), after_version_change_specs["linear_0"]);
+    EXPECT_EQ(uri("old_mamba", version_a), after_version_change_specs["mamba_0"]);
+    EXPECT_EQ("event_report://127.0.0.1:8080/mem?source=legacy", after_version_change_specs["legacy"]);
 
     tasks[0][0].specs = {
         LocationSpec("linear_0", uri("newer_linear", version_b)),
@@ -319,9 +325,11 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsKeepsOnlyCurrentSnapshotVers
     for (const auto &spec : location_maps[0].at(location_id)->location_specs()) {
         specs[spec.name()] = spec.uri();
     }
-    ASSERT_EQ(2u, specs.size());
+    ASSERT_EQ(4u, specs.size());
     EXPECT_EQ(uri("newer_linear", version_b), specs["linear_0"]);
     EXPECT_EQ(uri("new_mamba", version_b), specs["mamba_1"]);
+    EXPECT_EQ(uri("old_mamba", version_a), specs["mamba_0"]);
+    EXPECT_EQ("event_report://127.0.0.1:8080/mem?source=legacy", specs["legacy"]);
 }
 
 TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsRejectsMixedOrMalformedSnapshotVersions) {
@@ -568,6 +576,120 @@ TEST_F(MetaSearcherTest, TestMergeAndReplaceLocationSpecsKeepStorageUsageExact) 
     ASSERT_EQ(1u, location_maps.front().size());
     EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, location_maps.front().at(location_id)->type());
 }
+
+TEST_F(MetaSearcherTest, TestConditionalDeleteDoesNotRemoveRefreshedStableLocation) {
+    const MetaSearcher::KeyVector keys = {10008};
+    const std::string location_id = "kvs#event_report_l2#mem#127.0.0.8:8080";
+    std::vector<ErrorCode> per_key_ec;
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks = {{
+        {location_id,
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_SERVING,
+         {LocationSpec("linear_0", "event_report://127.0.0.8:8080/mem?source=old&size=11")}},
+    }};
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchReplaceLocationSpecs(request_context_.get(), keys, replace_tasks, per_key_ec));
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    const std::string stale_expected_value = location_maps[0].at(location_id)->ToJsonString();
+
+    // Simulate a new lifecycle refreshing the stable location id after the
+    // old host-cleanup scan captured its value.
+    replace_tasks[0][0].specs = {
+        LocationSpec("linear_0", "event_report://127.0.0.8:8080/mem?source=new&size=13"),
+    };
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchReplaceLocationSpecs(request_context_.get(), keys, replace_tasks, per_key_ec));
+
+    LocationIdsPerKey location_ids = {{location_id}};
+    std::vector<std::vector<ErrorCode>> delete_results;
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchDeleteLocations(
+            request_context_.get(), keys, location_ids, delete_results, {{stale_expected_value}}));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), delete_results);
+
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    ASSERT_EQ(1u, location_maps[0].count(location_id));
+    EXPECT_NE(std::string::npos,
+              location_maps[0].at(location_id)->location_specs()[0].uri().find("source=new"));
+    EXPECT_EQ(13u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
+
+    const std::string current_expected_value = location_maps[0].at(location_id)->ToJsonString();
+    ASSERT_EQ(
+        EC_BADARGS,
+        meta_searcher_->BatchDeleteLocations(
+            request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}, {}}));
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchDeleteLocations(
+            request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}}));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
+
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    EXPECT_TRUE(location_maps[0].empty());
+    EXPECT_EQ(0u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
+}
+
+TEST_F(MetaSearcherTest, TestCleanupLocationsByHostSkipsKeysWithoutMatchingLocation) {
+    const MetaSearcher::KeyVector keys = {10009, 10010, 10011};
+    const std::string target_suffix = "#127.0.0.9:8080";
+    const std::string target_location = "kvs#event_report_l2#mem" + target_suffix;
+    const std::string other_location = "kvs#event_report_l2#mem#127.0.0.10:8080";
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks = {
+        {{
+            target_location,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("target_0", "event_report://127.0.0.9:8080/mem?size=3")},
+        }},
+        {{
+            other_location,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("other_0", "event_report://127.0.0.10:8080/mem?size=5")},
+        }},
+        {
+            {
+                target_location,
+                DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                CacheLocationStatus::CLS_SERVING,
+                {LocationSpec("target_1", "event_report://127.0.0.9:8080/mem?size=7")},
+            },
+            {
+                other_location,
+                DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                CacheLocationStatus::CLS_SERVING,
+                {LocationSpec("other_1", "event_report://127.0.0.10:8080/mem?size=11")},
+            },
+        },
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchReplaceLocationSpecs(request_context_.get(), keys, replace_tasks, per_key_ec));
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->CleanupLocationsByHost(
+            request_context_.get(),
+            target_suffix,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            /*scan_batch_size=*/1000));
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    ASSERT_EQ(3u, location_maps.size());
+    EXPECT_TRUE(location_maps[0].empty());
+    ASSERT_EQ(1u, location_maps[1].size());
+    EXPECT_EQ(1u, location_maps[1].count(other_location));
+    ASSERT_EQ(1u, location_maps[2].size());
+    EXPECT_EQ(1u, location_maps[2].count(other_location));
+    EXPECT_EQ(16u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
+}
+
 TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsContinuesMergeAfterPartialBlockFailure) {
     auto faulty_backend = ReplaceWithFaultyBackend();
     ASSERT_NE(nullptr, faulty_backend);
@@ -736,16 +858,31 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocationSpecsIsIdempotentForMissingData)
     std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks = {{
         {location_id, {"missing_spec"}},
     }};
+    std::vector<std::vector<bool>> missing_targets;
     ASSERT_EQ(
         EC_OK,
-        meta_searcher_->BatchDeleteLocationSpecs(request_context_.get(), keys, delete_tasks, delete_results));
+        meta_searcher_->BatchDeleteLocationSpecs(
+            request_context_.get(), keys, delete_tasks, delete_results, &missing_targets));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), delete_results[0]);
+    ASSERT_EQ(1u, missing_targets.size());
+    ASSERT_EQ((std::vector<bool>{false}), missing_targets[0]);
 
     delete_tasks = {{{"kvs#event_report_l2#disk#127.0.0.1:8080", {"linear_0"}}}};
     ASSERT_EQ(
         EC_OK,
-        meta_searcher_->BatchDeleteLocationSpecs(request_context_.get(), keys, delete_tasks, delete_results));
+        meta_searcher_->BatchDeleteLocationSpecs(
+            request_context_.get(), keys, delete_tasks, delete_results, &missing_targets));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), delete_results[0]);
+    ASSERT_EQ((std::vector<bool>{true}), missing_targets[0]);
+
+    const MetaSearcher::KeyVector absent_keys = {10080};
+    delete_tasks = {{{location_id, {"linear_0"}}}};
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchDeleteLocationSpecs(
+            request_context_.get(), absent_keys, delete_tasks, delete_results, &missing_targets));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), delete_results[0]);
+    ASSERT_EQ((std::vector<bool>{true}), missing_targets[0]);
 
     std::vector<CacheLocationMap> location_maps;
     BlockMask mask;
@@ -781,9 +918,13 @@ TEST_F(MetaSearcherTest, TestCleanupLocationsByPredicateSubmitsExactObservedValu
     const std::string expected_stale_value = observed_locations[0].at(stale_id)->ToJsonString();
 
     std::vector<std::tuple<int64_t, std::string, std::string>> submitted;
-    SubmitDelReqFunc capture = [&submitted](const std::vector<int64_t> &submitted_keys,
-                                            const std::vector<std::vector<std::string>> &location_ids,
-                                            const std::vector<std::vector<std::string>> &expected_values) {
+    bool submitted_metadata_only = false;
+    SubmitDelReqFunc capture = [&submitted, &submitted_metadata_only](
+                                   const std::vector<int64_t> &submitted_keys,
+                                   const std::vector<std::vector<std::string>> &location_ids,
+                                   const std::vector<std::vector<std::string>> &expected_values,
+                                   bool metadata_only) {
+        submitted_metadata_only = metadata_only;
         for (size_t i = 0; i < submitted_keys.size(); ++i) {
             for (size_t j = 0; j < location_ids[i].size(); ++j) {
                 submitted.emplace_back(submitted_keys[i], location_ids[i][j], expected_values[i][j]);
@@ -805,6 +946,7 @@ TEST_F(MetaSearcherTest, TestCleanupLocationsByPredicateSubmitsExactObservedValu
     EXPECT_EQ(10009, std::get<0>(submitted[0]));
     EXPECT_EQ(stale_id, std::get<1>(submitted[0]));
     EXPECT_EQ(expected_stale_value, std::get<2>(submitted[0]));
+    EXPECT_TRUE(submitted_metadata_only);
 
     bool predicate_called = false;
     ASSERT_EQ(

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -708,6 +708,100 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequest) {
     ASSERT_EQ(untouched_location_status, location_maps[0].at(original_location_ids[2])->status());
 }
 
+TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBackend) {
+    ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+
+    class CountingDeleteBackend : public DataStorageBackend {
+    public:
+        explicit CountingDeleteBackend(std::atomic<size_t> &delete_calls)
+            : DataStorageBackend(nullptr), delete_calls_(delete_calls) {
+            config_.set_type(DataStorageType::DATA_STORAGE_TYPE_DUMMY);
+            config_.set_global_unique_name("external_cache");
+            SetOpen(true);
+            SetAvailable(true);
+        }
+        DataStorageType GetType() override { return DataStorageType::DATA_STORAGE_TYPE_DUMMY; }
+        bool Available() override { return true; }
+        double GetStorageUsageRatio(const std::string &) const override { return 0.0; }
+        const StorageConfig &GetStorageConfig() override { return config_; }
+        ErrorCode DoOpen(const StorageConfig &, const std::string &) override { return EC_OK; }
+        ErrorCode Close() override { return EC_OK; }
+        std::vector<std::pair<ErrorCode, DataStorageUri>>
+        Create(const std::vector<std::string> &, size_t, const std::string &, std::function<void()>) override {
+            return {};
+        }
+        std::vector<ErrorCode>
+        Delete(const std::vector<DataStorageUri> &uris, const std::string &, std::function<void()>) override {
+            ++delete_calls_;
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        std::vector<bool> Exist(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<bool>(uris.size(), true);
+        }
+        std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+
+    private:
+        std::atomic<size_t> &delete_calls_;
+        StorageConfig config_;
+    };
+
+    std::atomic<size_t> delete_calls{0};
+    data_storage_manager_->storage_map_["external_cache"] =
+        std::make_shared<CountingDeleteBackend>(delete_calls);
+
+    auto request_context = std::make_shared<RequestContext>("metadata_only_delete");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    const int64_t block_key = 701;
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec(
+            "tp0", "event_report://external_cache/cache/block701?s_version=11111111111111111111111111111111")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(EC_OK,
+              meta_searcher.BatchAddLocation(request_context.get(), {block_key}, {location}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheLocationDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {block_key},
+        .location_ids = {{location_ids.front()}},
+        .metadata_only = true,
+    };
+    const auto result = executor.Submit(request).get();
+    ASSERT_EQ(EC_OK, result.status);
+    EXPECT_EQ(0u, delete_calls.load());
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    EXPECT_TRUE(location_maps.front().empty());
+
+    const int64_t control_block_key = 702;
+    std::vector<std::string> control_location_ids;
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher.BatchAddLocation(
+            request_context.get(), {control_block_key}, {location}, control_location_ids));
+    ASSERT_EQ(1u, control_location_ids.size());
+    CacheLocationDelRequest control_request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {control_block_key},
+        .location_ids = {{control_location_ids.front()}},
+    };
+    const auto control_result = executor.Submit(control_request).get();
+    ASSERT_EQ(EC_OK, control_result.status);
+    EXPECT_EQ(1u, delete_calls.load());
+}
+
 // 测试CacheLocationDelRequest的Submit方法 - 非存在实例
 TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequestNonExistInstance) {
     CreateMetaIndexer(kTestInstanceName, "local");

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -63,7 +63,11 @@ enum StorageType {
 
 enum ReportEventType {
     EVENT_UNSPECIFIED = 0;
-    EVENT_NODE_REGISTER = 1; // Reporter node starts up and registers with KVCM
+    // Optional startup signal. A fresh reporter, including one observed after
+    // KVCM restart, may also be lazily initialized by its first valid
+    // HEARTBEAT/ADD/DELETE/SNAPSHOT. REGISTER is required to clear a
+    // same-process HOST_DOWN or liveness-cleanup tombstone.
+    EVENT_NODE_REGISTER = 1;
     EVENT_BLOCK_ADD = 2;     // Reporter stored a block in one location
     EVENT_BLOCK_DELETE = 3;  // Reporter removed a block from one location
     EVENT_HOST_DOWN = 4;     // Reporter node is going down (graceful or detected)
@@ -134,13 +138,15 @@ message ReportEventResponse {
     CommonResponseHeader header = 1;
     // Non-empty only when partial failures happen.
     repeated ErrorCode item_results = 2;
-    string extra_info = 3; // opaque JSON passed through from InstanceGroup
-    // Current process-local committed snapshot token for
-    // (instance_id, reporter host_ip_port). Empty means no snapshot has
-    // committed since KVCM started.
-    string committed_snapshot_version = 4;
-    uint64 retry_after_ms = 5;
-    bool snapshot_required = 6;
+    // Current process-local reconciliation/cleanup generation for
+    // (instance_id, storage_type, reporter host_ip_port). The first
+    // ADD/DELETE may create it. It is not a query visibility fence.
+    string committed_snapshot_version = 3;
+    uint64 retry_after_ms = 4;
+    // Advisory: true while this process has no generation yet. ADD/DELETE do
+    // not require an initial snapshot and may create the generation.
+    bool snapshot_required = 5;
+    string extra_info = 6; // opaque JSON passed through from InstanceGroup
 }
 
 // 使用URI统一多种存储表示，由client或者connector负责解析

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -25,12 +25,17 @@ behavior, result interpretation, and how to retain request/response artifacts.
 
 `report_event_load.py` mixes incremental ADD/DELETE events, periodic
 authoritative snapshots, heartbeat events, and standalone reads. It establishes
-the required initial snapshot for every reporter before sending deltas.
+an empty initial test baseline for deterministic shadow-state validation;
+production reporters may send deltas immediately after REGISTER.
 
 Every `ReportEvent` request is followed by `GetHostCacheState` and checked
 against a per-host in-memory authoritative state. Report success, committed
 snapshot token continuity, prefix-match contents, snapshot reconciliation, and
 deleted-key invisibility are therefore validated together.
+
+`s_version` is a reconciliation/cleanup generation, not a strict query fence.
+Production queries may return well-formed older or legacy cache candidates
+until a successful snapshot reclaims them.
 
 Run it with a new instance id. By default the tool rejects a reporter that
 already has a committed snapshot, because its startup empty snapshot would
@@ -63,7 +68,7 @@ python3 tools/scripts/report_event_load.py \
 `--snapshot-interval-sec` is per host and must not be shorter than the
 EventReport backend's configured snapshot rate limit. Setting
 `--snapshot-drop-ratio` above zero deliberately omits a portion of the current
-host state from each full snapshot and verifies those omitted blocks become
-invisible. If the backend responds with `SNAPSHOT_RATE_LIMITED`, the tool uses
+host state from each full snapshot and verifies those omitted blocks are
+eventually removed. If the backend responds with `SNAPSHOT_RATE_LIMITED`, the tool uses
 `retry_after_ms` to stop resubmitting that host until its cooldown expires and
 reports the configured interval as invalid.


### PR DESCRIPTION
## 审查目的

这是基于 PR #233 当前分支创建的独立审查 PR，只包含 commit `1f18460071821a7800de2a6624b420ddd12a9180`，方便逐行查看和评论。本 PR 暂不用于直接合并。

## 改动内容

- REGISTER 后允许在未提交首次 SNAPSHOT 的情况下直接执行 ADD/DELETE。
- 将 `s_version` 从查询强一致屏障调整为 snapshot 对账与旧数据清理 generation；节点注册、存活状态和 storage type 仍是查询硬门槛。
- KVCM 重启后允许合法历史缓存继续作为软候选；`snapshot_required` 只提示客户端尽快补一次全量，不再阻塞增量。
- 修正跨 generation 的增量 spec 合并，避免首次增量误删未触及的历史 spec。
- 加固 reclaimer 的 CAS 删除和 host cleanup 竞态，避免旧清理任务删除已刷新的 location。
- 更新设计文档、API 文档、proto 注释、UT 和集成测试。

## 验证

在开发机 `11.122.133.161` 的 `screen -x qisa` 窗口 2 完成：

- Bazel 编译通过。
- EventReportBackendTest、MetaSearcherTest、CacheManagerTest 全部通过。
- HTTP 集成测试 30/30 通过。
- 真实 Redis + KVCM 整进程重启测试通过。
- Python 脚本语法检查通过。

## 重点审查位置

1. `EventReportBackend::BeginDeltaMutation`
2. `CacheManager::IsEventReportLocationReadable`
3. `MergeLocationSpecsByName`
4. `BatchDeleteLocations` / `CleanupLocationsByHost`
5. 重启、纯增量、snapshot/delta 并发测试语义