### PR TITLE
[subscriber] add KVCache event subscriber

### DIFF
--- a/subscriber/.gitignore
+++ b/subscriber/.gitignore
@@ -1,0 +1,53 @@
+# === Qoder / local agent state ===
+.qoder/
+
+# === 本地环境信息 ===
+env.txt
+
+# === Python & uv ===
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# uv 虚拟环境与锁文件缓存
+.venv/
+.python-version
+
+# 测试与覆盖率
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# mypy / ruff / linting 缓存
+.mypy_cache/
+.ruff_cache/
+.dmypy.json
+
+# Jupyter Notebook
+.ipynb_checkpoints/
+
+# === PyCharm / JetBrains IDE ===
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+
+# === OS ===
+.DS_Store
+Thumbs.db
+
+# === 环境变量与密钥（切勿提交）===
+.env
+.env.*
+!.env.example
+
+*.log

--- a/subscriber/AGENTS.md
+++ b/subscriber/AGENTS.md
@@ -1,0 +1,302 @@
+# AGENTS.md — subscriber
+
+与 vLLM 同机部署的 Python 进程。源码包在仓库根目录下的 `subscriber/`，独立管理依赖，不依赖父项目构建系统。
+
+## 项目概览
+
+subscriber 订阅推理引擎的 KV cache 事件，转发给 KVCM，并与同机 DashServing 绑定健康状态
+（同生同死）。
+
+**技术栈**：Python ≥ 3.11（asyncio 全异步）、ZeroMQ（`pyzmq`）、gRPC（`grpcio` 1.75.1 +
+`protobuf` 3.20.3，pb 手工维护）、`msgspec`（msgpack）、`httpx`、`pyyaml`、dashlog（可选依赖）。
+工具链：`uv` + `ruff` + `mypy --strict` + `pytest`。
+
+## 架构
+
+| 模块 | 职责 |
+|---|---|
+| `subscriber/cli.py`、`main.py` | 入口与 `SubscriberLifecycle`：启动 7 步、serving 监督、关停 6 步 |
+| `subscriber/config.py` | `SubscriberConfig`：字段、CLI 注册、校验、派生属性 |
+| `subscriber/forwarding.py`、`pipeline/` | producer / sender 协程与无状态 per-batch 阶段 |
+| `subscriber/engine/` | 引擎适配层（`AbstractEngineAdapter` + vllm / sglang + gRPC client） |
+| `subscriber/health/` | 引擎存活协调器（epoch 门控）+ DashServing 状态上报 |
+| `subscriber/kvcm/` | KVCM 客户端栈（domain client + HTTP transport + 服务发现） |
+| `subscriber/metrics/` | 指标唯一出口（主路径 telemetry + lifecycle 点事件） |
+| `subscriber/proto/` | `engine_service_rpc` pb 绑定（手工维护，见下文） |
+
+分层依赖方向：`main` → `forwarding` → (`engine`, `health`, `kvcm`, `pipeline`, `metrics`)。
+`engine/` 与 `kvcm/` 互不依赖（`KvCacheDescriptor` 由 `main` 在启动时注入），禁止加反向 import。
+
+**稳态架构文档在 `docs/architecture/`，改架构前先读、改完回来更新**：
+
+| 文档 | 内容 |
+|---|---|
+| [00-overview](docs/architecture/00-overview.md) | 模块划分、启动 / 退出时序、数据流总览、核心不变量 |
+| [01-forwarding-pipeline](docs/architecture/01-forwarding-pipeline.md) | 双 pipeline 数据流、凑批、门控、丢弃语义 |
+| [02-engine-adapter](docs/architecture/02-engine-adapter.md) | adapter 契约、代际语义、vLLM 实现、replay、快照信号 |
+| [03-health-and-liveness](docs/architecture/03-health-and-liveness.md) | epoch、判死、HostDown、同生同死探针 |
+| [04-kvcm-client](docs/architecture/04-kvcm-client.md) | 传输、服务发现、两步注册、心跳、location spec |
+| [05-observability](docs/architecture/05-observability.md) | span 阶段、指标出口、日志、trace id |
+| [06-configuration](docs/architecture/06-configuration.md) | 配置优先级、字段分组、环境变量、校验 |
+
+## 开发命令
+
+所有命令在仓库根目录（`pyproject.toml` 所在目录）下执行，使用 `uv` 管理环境。
+
+```bash
+# 初始化 / 同步依赖
+uv sync --dev
+
+# 运行测试
+uv run pytest
+uv run pytest -v                              # 详细输出
+uv run pytest tests/engine/vllm/test_incremental.py  # 单文件
+
+# Lint（ruff，line-length=88，规则集 E/F/I/UP/B）
+uv run ruff check subscriber/ tests/ harness/
+uv run ruff check --fix subscriber/ tests/ harness/    # 自动修复
+
+# 格式化
+uv run ruff format subscriber/ tests/ harness/
+uv run ruff format --check subscriber/ tests/ harness/ # 仅检查，不修改
+
+# 类型检查（mypy strict）
+uv run mypy subscriber/
+
+# Manifest 驱动的跨仓 harness（原子记录写入已忽略的 harness/records/runs/）
+harness/run_local_checks.sh baseline all
+harness/run_local_checks.sh protocol all
+harness/run_local_checks.sh quality all
+uv run python harness/loop.py review
+
+# 启动进程（SPECTRUM_DEPLOYMENT_NAME、--kvcm-base-url 与 --host-port 为启动必填）
+export SPECTRUM_DEPLOYMENT_NAME=my-deployment
+uv run python -m subscriber --kvcm-base-url grpc://10.0.0.1:6381 --host-port 8080
+
+# 指定参数启动
+SPECTRUM_DEPLOYMENT_NAME=my-deployment uv run python -m subscriber \
+  --kvcm-base-url spectrum://vs-example:6381 \
+  --host-port 8080 \
+  --engine-type vllm
+
+# 使用配置文件（kvcm_base_url 与 host_port 可写在 yaml 中）
+SPECTRUM_DEPLOYMENT_NAME=my-deployment uv run python -m subscriber --config config.yaml
+```
+
+默认 gRPC 时，裸 `host:port`、`grpc://` 和 `http(s)://` 都是直接 channel target；只有
+`static://` / `spectrum://` 会经 service discovery 解析。端口必须为 KVCM `meta_rpc_port`；
+HTTP 回退时才改为 `meta_http_port`。
+
+## 质量门禁（Quality Gates）
+
+- **pre-commit 钩子（本地强制）**：`.pre-commit-config.yaml` 按暂存文件路由执行，通过
+  `uv run pre-commit install` 安装到 `.git/hooks/pre-commit` 后在每次 commit 时强制执行。
+  clone 仓库后必须先执行一次 `uv run pre-commit install`。检查项：
+  - `subscriber/`、`tests/` 或 `harness/` 的 Python 文件暂存时：ruff check、ruff format --check；
+    subscriber/config/toolchain 变更另触发 mypy 与全量 `pytest --cov`
+    （覆盖率门禁 `fail_under = 90`）；
+  - `subscriber/proto/` 文件暂存时额外执行：全部 pb2/pb2_grpc import（protobuf 3.20.3
+    兼容）、authoritative `.proto` / runtime / `.pyi` parity，以及
+    `tests/proto/test_engine_service_rpc.py`、`tests/engine/test_grpc_clients.py` 和
+    KVCM gRPC client 测试；
+  - `docs/metrics.json` 或 metrics 源码/测试变更时执行 metrics catalog parity；
+  - 每次 commit 检查 staged whitespace/conflict marker；修改 hook 配置时先验证配置本身。
+- **pytest（开发中随手跑）**：commit 时 pre-commit 已强制全量测试，
+  开发过程中仍应随手 `uv run pytest` 获得快速反馈（见「约束」一节的
+  「修改后必须通过检查」）。测试未通过的修改视为未完成，不得提交/推送。
+- **AoneCI（MR 触发）**：MR opened 时触发两条模板流水线——「Python单元测试」
+  （Python 3.12，`pip install '.[dev]'` 后跑 pytest，失败钉钉通知）与
+  「代码质量扫描（多语言）」。dev 依赖的唯一权威来源是
+  `[project.optional-dependencies].dev`（uv 的 dev group 引用该 extra），
+  新增 dev 依赖写在 extras 里，否则 CI 装不上。CI 状态用 `a1 ci run get` 查询。
+- **e2e（显式 opt-in）**：`tests/e2e/` 的每个真实运行时用例都用 `pytest.mark.skipif`
+  检查各自前置条件：DashServing 用例要求 `DSV_BINARY`（已构建的 `dashservingd`），KVCM
+  gRPC 用例要求 `KVCM_REAL_GRPC_TARGET`（可选 `KVCM_REAL_ADMIN_HTTP_URL` 做隔离 setup）。
+  默认全部跳过，保证默认 `uv run pytest` 在任何机器上行为一致。
+
+## Git 约定
+
+### 分支命名
+
+- 常规开发：`feat/<description>`，如 `feat/full-kvcache`
+- 缺陷修复：`fix/<description>`，如 `fix/zmq-replay-seq`
+- 个人长期特性分支：`feature/<花名>/<description>`
+- 临时验证：`worktree-<description>`（配合 git worktree，用完删掉）
+
+不要直接在 `master` 上开发；不要 force push `master`。
+
+### Commit Message
+
+沿用仓库历史的 conventional commits：`<type>: <description>`，type ∈
+`feat` / `fix` / `refactor` / `chore` / `docs` / `test` / `perf`。
+
+示例：`feat: add use_eagle_pop and mamba_cache_mode in get_kv_cache_descriptor`、
+`fix: fix zmq replay seq and frame`、`docs: update README/AGENTS.md`
+
+- 一个 commit 只做一件事；重构与行为变更不要混在同一个 commit。
+- **禁止**写入 `Co-Authored-By` 行。
+- 不得使用 `--no-verify` 跳过 pre-commit 钩子；钩子失败要修根因。钩子失败意味着 commit 没有
+  发生，此时**新建 commit**，不要 `--amend`。
+
+### MR / 代码评审
+
+- MR 标题与 commit message 保持一致。
+- MR 描述必须包含：背景与动机、改动点、验证方式（贴 `uv run pytest` / `ruff` / `mypy` 的实际
+  结论）、影响面与回滚方式。
+- **跨仓库改动**（dashllm gRPC server、KVCM 服务端、`.proto` wire schema）必须在描述里列出对
+  应仓库的 MR 链接，并说明上线顺序与兼容窗口。
+
+## 开发流程
+
+按以下 7 步执行。**每完成一个步骤后必须停下来等用户确认，不要自动继续下一步。**
+
+1. **明确需求与范围** — 复述需求、边界、不做什么；不清楚的地方先问，不要猜。
+2. **分析代码** — 先读 `docs/architecture/` 对应文档，再读源码，输出数据流 / 关键调用路径 /
+   受影响的不变量；发现文档与代码不一致，先报告再动手。
+3. **确定方案** — 写入 `docs/specs/YYYY-MM-DD_slug.md`（含方案、被影响的不变量、测试策略、
+   风险），等用户确认后再写代码。
+4. **实施修改** — 从最新 `master` 建分支；测试先行（改行为先改/加测试）；小步提交。
+5. **质量门禁** — `uv run pytest`、`uv run ruff check subscriber/ tests/ harness/`、
+   `uv run mypy subscriber/` 全绿，并把实际输出结论贴出来。不许用「应该没问题」代替执行。
+6. **提交与评审** — commit → push 分支 → 创建 MR，指定评审人。
+7. **回顾与更新** — 检查并更新 `docs/architecture/`、`AGENTS.md`、`README.md`、
+   `docs/metrics.json`；把落地方案与设计文档的差异回写到 spec。
+
+## Protobuf 兼容代码维护
+
+生产环境固定使用 `protobuf==3.20.3`。当前 `grpc-tools` 生成的 Python
+代码会导入 `google.protobuf.runtime_version` / `_builder` 并校验较新的
+protobuf runtime，无法在生产环境加载。因此 `subscriber/proto/` 下的
+Python pb 文件必须 hand-write / 手工维护，**禁止运行
+`grpc_tools.protoc` 后直接提交生成结果**。
+
+`subscriber/proto/engine_service_rpc.proto` 仍是 authoritative wire
+schema。修改 `.proto` 后：
+
+1. 手工同步 `engine_service_rpc_pb2.py` 中的 descriptor
+   message/field/service 定义，继续使用兼容 protobuf 3.20.3 的
+   `descriptor_pb2` / `message_factory` 实现；不得引入
+   `runtime_version` 或 `_builder`。
+2. 手工同步 `engine_service_rpc_pb2.pyi` 的字段、类型和构造函数。
+3. 只有 RPC service、method 或 request/response type 发生变化时，才
+   手工同步 `engine_service_rpc_pb2_grpc.py`；仅新增 message field
+   时该文件不应产生 diff。
+4. 保持 authoritative field number、无 `package` 的 service identity 和
+   完整 RPC path 不变，并增加 descriptor field-number、raw wire parse 和
+   RPC path 测试。
+
+上述 pb 文件均提交到仓库，构建时不会自动生成。修改后至少运行对应
+proto/client 测试和 `uv run mypy subscriber/`，确认 protobuf 3.20.3
+环境可以正常 import。
+
+## 约束
+
+- **asyncio 全异步**：所有 IO 必须使用 `zmq.asyncio.Socket`，禁止在 async 函数中调用同步 ZMQ socket 方法。
+- **引擎适配器隔离**：ZMQ 订阅和 replay 逻辑封装在 `AbstractEngineAdapter` 子类中，`kv_event_loop` 不感知具体引擎实现。
+- **引擎存活探测隔离**：底层连接状态（如 ZMQ socket monitor）由 `AbstractEngineAdapter.watch_liveness()` 暴露为引擎无关事件，判死、epoch、reset 策略集中在 health coordinator。
+- **冷启动 reset 语义**：subscriber 首次连接引擎前不发送 `AllBlocksCleared`；只有曾经进入可发送代际后再断线并达到重试阈值，才发送 reset。
+- **发送门控**：向 kvcm 转发实时或 replay batch 前必须通过 `EngineHealthCoordinator.wait_ready_epoch()` 获取当前可发送 epoch。
+- **分阶段 span 与主路径指标**：adapter 创建并 yield `EngineEventBatch(batches, telemetry, trace_id)`；同一个 `BatchTelemetry` 经 `PipelineContext` 贯穿到 KVCM client。adapter 标记 `decode` / `replay_fetch` / `snapshot_*`，forwarding 标记 `queue_wait` / `engine_gate_wait` / `block_filter`，KVCM client 标记 `expand` / `kvcm_send`。`telemetry.mark("stage")` 只记录内存状态；`count` / `gauge` 可带 `tags`，空标签分别保持 counter 聚合与 gauge 最后值，非空标签保留独立 observation。仅 `MetricsReporter` 后台任务 flush 到 dashlog；`BatchTelemetry` 与 reporter 的观测路径均 best-effort、永不阻断转发主路径。
+- **Metrics 上报规范**：所有指标通过 `subscriber/metrics/` 包（`_base.py` 中的 `_dashlog_counter` / `_dashlog_gauge`）统一出口上报，自动添加 `kvcache_subscriber_` 前缀。维度信息（endpoint、status、reason 等）通过 `tags` 参数传递（对应 Prometheus labels），不要编码进 metric name。dashlog 本地不可编译时所有 report 函数为 no-op（`try: import dashlog / except ImportError` fallback）。新增或修改指标后必须同步更新 `docs/metrics.json` 指标目录。`_dashlog_counter` 按 `DS_EAS_USE_OTEL` 双路径切换（判定规则与 dashlog `EASOTelClient::Enabled()` 一致）：ASI-EAS 部署由 manager 注入该变量，直调 dashlog 原生 `Counter` 走 OTel 增量语义；未设置（PAI-EAS）时走 Gauge 累积绕行，因为 legacy `AddCounters` 在 OTel 关闭时会静默丢数据。
+- **Replay 语义**：检测到 seq gap 时，先聚合 replay batch 一次性 yield，再 yield 当前实时消息。vLLM replay 端会返回所有 `seq >= gap_start_seq` 的缓冲消息（包含触发 gap 的当前实时消息及更新消息），必须过滤只转发缺失区间 `[gap_start_seq, current_seq - 1]`（其余会以实时消息到达，直接转发会重复）；过滤后仍要 drain 到 END marker。replay 成功完成（返回列表，含空列表）后立即把 `_last_seq` 推进到 `current_seq - 1`，与实时消息 decode 成败解耦，避免同一 gap 被重复 replay。replay 中途 abort（超时、异常、帧格式错误、decode 失败）必须调用 `_replace_replay_socket()` 更换 DEALER socket，防止残留帧污染下一次 replay。replay 使用 DEALER socket（非 REQ），避免 async 下严格一问一答的阻塞问题。
+- **配置优先级**：CLI 显式参数 > `--config yaml` 文件 > dataclass 默认值；`kvcm_base_url` 为必填项，
+  可为 CLI / 配置文件 / `KVS_KVCM_ENDPOINT` 环境变量提供（优先级 CLI > YAML > 环境变量），
+  全部为空时在 `validate()` 阶段直接报错。
+- **启动必需的身份环境变量**：`SPECTRUM_DEPLOYMENT_NAME` 必须为非空唯一部署标识；`KvcmClient.start()` 会校验，缺失/空白直接失败（fatal），因为空值会退化为 `_<block_size>` 这类被无关实例共享的 instance_id，破坏"KVCache 仅在同一 instance_id 内复用"的隔离不变量。
+- **Lint/类型检查禁用规则**：禁止通过内联注释（如 `# noqa`、`# type: ignore`）禁用 ruff 或 mypy 检查。自动生成的代码（如 protobuf 生成文件）应在 `pyproject.toml` 或 `ruff.toml` 中通过 `exclude` / `per-file-ignores` 排除整个文件；只有确实无法通过修改代码解决的极少数情况，才允许使用注释禁用，且必须在注释中说明原因。
+- **Docstring 规范**：通用接口/模块定义（后续要实现某个接口的 placeholder）、抽象基类的 public 方法、复杂实现逻辑必须有 docstring，说明契约、默认行为和关键不变量。简单的内部 helper 和自解释代码不需要。
+- **文档落盘目录**：`docs/architecture/` 放**稳态架构文档**（当前代码长什么样，编号命名如
+  `03-health-and-liveness.md`）；`docs/specs/` 放**变更设计文档**（某次改动怎么做，命名
+  `YYYY-MM-DD_slug.md`，如 `2026-07-21_engine-node-metadata-rpc.md`）；`docs/plans/` 放实施计划，
+  `docs/reviews/` 放评审与测试报告。不要在项目根目录或其他位置创建 `specs/` 目录。**改了架构必须
+  回写 `docs/architecture/` 对应文档，不能只留一篇 spec。**
+- **仓库根目录不落运行时日志**：运行时日志不得写入仓库根目录。stdlib 日志后端默认只输出 stderr，需要文件日志时设置 `SUBSCRIBER_LOG_FILE=<path>`（指向仓库外或部署目录）；review / 报告类产物归档到 `docs/reviews/`。
+- **修改后必须通过检查**：所有代码修改完成后，必须确保 `uv run pytest`、`uv run ruff check subscriber/ tests/ harness/` 和 `uv run mypy subscriber/` 全部通过，否则修改视为未完成。四项均由 pre-commit 钩子在 commit 时强制（含全量 pytest --cov）；开发中仍应随手运行以获得快速反馈（见「质量门禁」一节）。
+
+## 代码风格
+
+### 类型与命名
+
+- `mypy --strict`：所有函数（含测试 helper 之外的内部函数）必须有完整注解；异步生成器标注
+  `AsyncGenerator[T, None]`。
+- 文件首行 `from __future__ import annotations`。
+- 模块私有用 `_` 前缀；只在包 `__init__.py` 里 re-export 对外 API。
+- **单位与语义后缀**：秒 `_s`、毫秒 `_ms`、字节 `_bytes`、计数 `_count`、上限 `_maxsize`、
+  间隔 `_interval_s`、超时 `_timeout_s`。新字段沿用既有后缀，不要自造。
+- 不可变优先：跨模块传递的数据载体用 `@dataclass(frozen=True)`（如 `EngineEventBatch`、
+  `MergedBatch`、`KvCacheDescriptor`）；只有需要在 pipeline 中累积状态的才可变
+  （如 `PipelineContext`）。
+
+### 日志
+
+- 结构化调用：`logger.info("message", step="<stage>", tags={...})`。消息本身是固定短语，
+  **不要用 f-string 把变量拼进 message**——变量放 `tags`。
+- debug 级诊断先判 `logger.is_debug_enabled()` 再拼装，避免热路径做无用工作。
+- 高频失败必须限流（首次详细 + 周期汇总），参考 `KvcmDropTracker` 与 state reporter 的写法。
+
+### 异常处理
+
+- 只捕获预期异常类型，禁止裸 `except:`；`asyncio.CancelledError` 必须原样重新抛出。
+- 观测 / 上报路径（metrics、span、日志、best-effort 状态上报）永不向主路径抛异常。
+- 业务不可用与业务拒绝要区分类型（`KvcmUnavailableError` vs `KvcmReportRejectedError`），
+  不要用同一个异常表达「可重试」和「永久失败」。
+- 编程错误不要吞：非预期异常让它冒到 `_serve_until_shutdown`，由生命周期统一处理。
+
+### 测试
+
+- `tests/` 目录结构镜像 `subscriber/`；跨模块行为放顶层（`test_forwarding.py` /
+  `test_main.py`）。
+- 真实 ZMQ socket 用例打 `@pytest.mark.integration`，需要真实 `dashservingd` 的打
+  `@pytest.mark.e2e`（显式 opt-in：设置 `DSV_BINARY` 指向已构建的二进制才运行，
+  否则跳过）。
+- 覆盖率门禁 `fail_under = 90`：只能往上调，不许为了让改动通过而下调。
+
+## Health Integration 开发原则
+
+subscriber 与同机 DashServing "同生同死"：subscriber 未 active 时 DashServing 不导流，subscriber 异常时 DashServing 暴露健康失败。详细 spec 见 `docs/specs/2026-07-22_subscriber-health-dashserving-integration.md`。
+
+**核心不变量（修改代码前必须理解）：**
+
+- **引擎健康只由 `GetWorkerStatus.alive` 驱动**：不用 HTTP `/readiness` 做引擎健康判断，不用 DashServing 探针反馈 engine DEAD。
+- **KVCM 是 lossy 旁路，不是门控（运行期）**：进入 serving 后，KVCM 不可用不阻塞转发、不影响探针、不改变 subscriber 状态。发送失败丢弃并计数，恢复后自动续传。不要为 KVCM 加 generation/snapshot/condition 等复杂机制。**启动期例外（有意设计）**：`_graceful_startup` 第 3 步会等待 KVCM 注册成功（`_wait_kvcm_registered`）才启动 pipeline 并上报 active——启动时需要 KVCM 注册成功才能够启动，避免在从未注册的情况下导流；等待期间 subscriber 保持 starting（readiness 503），并周期性打印 "still waiting for kvcm registration" 警告。不要把这个启动等待当作 bug"修掉"。
+- **seq_id 线性化**：状态上报靠单调递增 seq_id 防乱序。低 seq 的 active 不能复活已接受的 inactive。不要加 session_id 除非需要支持独立重启 subscriber。
+- **HostDown 幂等**：`AllBlocksCleared` 每个 sendable epoch 最多发一次。冷启动失败不发。
+- **同生同死探针语义**：starting → readiness 503 / liveness 200（startup grace）；active → 200/200；inactive/failed/TTL expired → 503/503。
+- **环境变量**：`DS_LLM_LAUNCH_KV_EVENT_SUBSCRIBER=1` 时 DashServing 启用 subscriber 健康检查，否则探针行为不变。
+
+**不要做的事：**
+
+- 不要为引擎重启加 metadata 重新验证（拓扑不变，Pod 替换兜底）
+- 不要轮询 DashServing readiness 来控制转发（`wait_ready_epoch()` 已是正确门控）
+- 不要在 KVCM transport 失败时改 `is_registered`（heartbeat loop 自己管重连）
+- 不要把 learn mode 加回来（已删除）
+- 不要把 transient 启动错误报为 failed（只有 protocol/unsupported 才是 fatal）
+
+## 添加新引擎适配器（参考现有 SGLang 实现）
+
+1. 参考现有 `subscriber/engine/sglang/` 包布局：`adapter.py` 实现 `AbstractEngineAdapter` 并加注册装饰器，`__init__.py` re-export 适配器类：
+
+```python
+# subscriber/engine/<engine>/adapter.py
+from subscriber.engine.base import AbstractEngineAdapter
+
+
+@AbstractEngineAdapter.register("sglang")
+class SGLangAdapter(AbstractEngineAdapter):
+    async def subscribe_kv_events(self): ...  # 实现事件订阅逻辑
+
+    async def watch_liveness(self): ...  # 实现引擎无关存活事件流
+```
+
+完整可运行示例见 `subscriber/engine/sglang/adapter.py`（placeholder 适配器，含全部必须实现的方法）。
+
+2. 启动时传入 `--engine-type sglang`，`AbstractEngineAdapter.create()` 会自动 lazy import 并实例化。
+
+无需修改 `main.py`、`kv_event_loop` 或任何 client 代码。
+
+## Stub 待接入项
+
+| 编号 | 内容 | 文件 | 阶段 |
+|---|---|---|---|
+| S-4 | subscriber 不可用恢复策略：kvcm SDK 心跳、TTL、session/checkpoint | kvcm SDK / kvcm 服务端 / subscriber | DONE（heartbeat + TTL + state reporter 已实现；session/checkpoint 见 TODO(independent-restart)） |
+| S-5 | 多 DP（bootstrap `runtime_topology.data_parallel_size > 1`）事件订阅：当前 adapter 只支持一个 engine-discovered transport，接受 bootstrap 后会 fail closed；rank 1+ 尚未聚合 | subscriber/engine/vllm/adapter.py | TODO（实现 per-rank bootstrap/transport 聚合前不要放开 `data_parallel_size == 1` 校验） |

--- a/subscriber/README.md
+++ b/subscriber/README.md
@@ -1,0 +1,194 @@
+# KVCacheEventSubscriber
+
+A process co-located with an inference engine that subscribes to the engine's KV cache
+events, forwards them to the kvcm service, and ties its health to the co-located
+DashServing instance.
+
+## Modules
+
+| 模块 | 说明 |
+|---|---|
+| `subscriber/cli.py`、`main.py` | 进程入口与生命周期：启动 7 步、serving 监督、关停 6 步 |
+| `subscriber/config.py` | 配置定义、CLI 注册、校验、派生属性 |
+| `subscriber/forwarding.py`、`pipeline/` | 增量 / 快照双 pipeline 的转发链路 |
+| `subscriber/engine/` | 引擎适配层（vLLM / SGLang 实现 + 共用 ZMQ source + gRPC 控制面） |
+| `subscriber/health/` | 引擎存活协调（epoch 门控）+ DashServing 状态上报 |
+| `subscriber/kvcm/` | KVCM 客户端栈（注册、心跳、事件上报、gRPC/HTTP 传输、服务发现） |
+| `subscriber/metrics/` | 指标统一出口（主路径 telemetry + lifecycle 点事件） |
+| `subscriber/proto/` | engine / KVCM pb 绑定（手工维护） |
+
+## Tech Stack
+
+| 类别 | 技术 |
+|---|---|
+| 语言 | Python ≥ 3.11（asyncio 全异步） |
+| 引擎事件通道 | ZeroMQ（`pyzmq`：SUB 实时流 + DEALER replay） |
+| 引擎控制面 | gRPC（`grpcio` 1.75.1 + `protobuf` 3.20.3） |
+| 序列化 | `msgspec`（msgpack） |
+| KVCM | 默认 gRPC/protobuf（`grpcio`），HTTP/JSON（`httpx`）兼容回退 |
+| DashServing | HTTP JSON（`httpx`） |
+| 观测 | dashlog（可选依赖，缺失时降级） |
+| 工具链 | `uv`、`ruff`、`mypy --strict`、`pytest` |
+
+## 设计文档
+
+稳态架构文档在 `docs/architecture/`：
+
+| 文档 | 内容 |
+|---|---|
+| [00-overview](docs/architecture/00-overview.md) | 模块划分、启动 / 退出时序、数据流总览、核心不变量 |
+| [01-forwarding-pipeline](docs/architecture/01-forwarding-pipeline.md) | 双 pipeline 数据流、凑批、门控、丢弃语义 |
+| [02-engine-adapter](docs/architecture/02-engine-adapter.md) | adapter 契约、代际语义、vLLM 实现、replay、快照信号 |
+| [03-health-and-liveness](docs/architecture/03-health-and-liveness.md) | epoch、判死、HostDown、同生同死探针 |
+| [04-kvcm-client](docs/architecture/04-kvcm-client.md) | 传输、服务发现、两步注册、心跳、location spec |
+| [05-observability](docs/architecture/05-observability.md) | span 阶段、指标出口、日志、trace id |
+| [06-configuration](docs/architecture/06-configuration.md) | 配置优先级、字段分组、环境变量、校验 |
+
+变更设计文档在 `docs/specs/`，实施计划在 `docs/plans/`，评审与测试报告在 `docs/reviews/`，
+指标目录在 `docs/metrics.json`。开发约束与流程见 [AGENTS.md](AGENTS.md)。
+
+## Installation
+
+```bash
+uv sync --dev
+uv run pre-commit install   # clone 后必须执行一次
+```
+
+## Running
+
+Required at startup:
+
+- `SPECTRUM_DEPLOYMENT_NAME` — unique deployment identity used to build the
+  KVCM `instance_id`; startup fails if missing or blank.
+- KVCM base URL — via `--kvcm-base-url` or the config file; a blank value is
+  rejected by config validation. Default KVCM protocol is gRPC, so the port
+  must be KVCM `meta_rpc_port`; use `--kvcm-protocol http` with
+  `meta_http_port` for rollback. For gRPC, bare `host:port`, `grpc://`, and
+  `http(s)://` are direct channel targets; `static://` and `spectrum://` are
+  resolved through service discovery.
+- `--host-port` — worker identity port advertised to KVCM as `host_ip_port`;
+  no default value, must match the engine endpoint port that FlexLB discovers
+  via Spectrum (e.g. 8080 on PAI-EAS). Config validation rejects a missing or
+  out-of-range value.
+
+```bash
+# With CLI args
+SPECTRUM_DEPLOYMENT_NAME=my-deployment uv run python -m subscriber \
+  --kvcm-base-url spectrum://vs-example:6381 \
+  --host-port 8080 \
+  --engine-type vllm
+
+# With config file (kvcm_base_url and host_port can be set in the yaml)
+SPECTRUM_DEPLOYMENT_NAME=my-deployment uv run python -m subscriber --config config.yaml
+```
+
+## Development
+
+```bash
+# Run tests
+uv run pytest
+uv run pytest tests/engine/vllm/test_incremental.py   # 单文件
+
+# Lint / format
+uv run ruff check subscriber/ tests/ harness/
+uv run ruff format subscriber/ tests/ harness/
+
+# Type check
+uv run mypy subscriber/
+
+# Manifest-driven cross-repository gates and evolution review
+harness/run_local_checks.sh baseline all
+harness/run_local_checks.sh protocol all
+harness/run_local_checks.sh quality all
+uv run python harness/loop.py review
+```
+
+### Quality Gates
+
+- **pre-commit（本地强制）**：commit 时按暂存文件路由执行——Python/harness 变更触发
+  ruff check / ruff format --check，subscriber/config/toolchain 变更触发 mypy 与全量
+  `pytest --cov`（覆盖率门禁 `fail_under = 90`）；`subscriber/proto/` 文件额外触发
+  全部 pb import、authoritative proto/runtime/pyi parity 与 focused proto/client 测试；
+  metrics catalog 与 staged whitespace/conflict marker 也有独立检查。不得用 `--no-verify`
+  跳过。
+- **pytest（开发中随手跑）**：commit 时 pre-commit 会强制全量测试，
+  开发过程中仍应随手 `uv run pytest` 快速反馈。测试未通过的修改视为未完成。
+- **AoneCI（MR 触发）**：MR opened 时触发「Python单元测试」（`pip install '.[dev]'`
+  后跑 pytest）与「代码质量扫描（多语言）」两条流水线；dev 依赖必须写在
+  `[project.optional-dependencies].dev`，CI 状态用 `a1 ci run get` 查询。
+- **e2e（显式 opt-in）**：`tests/e2e/` 需要设置 `DSV_BINARY` 指向已构建的
+  `dashservingd` 才会运行，默认全部跳过，保证各机器上默认测试行为一致。
+- **harness（跨仓复用）**：`harness/manifest.yaml` 声明 repository/profile/gate，
+  `harness/loop.py` 不经 shell 执行检查并把原子 JSON 证据写入已忽略的
+  `harness/records/runs/`；反馈采用 append-only ledger，`review` 只生成演进建议，
+  不会自动修改 gate 或源码。
+
+## 基于 Agent 的开发流程
+
+以下是本仓库的标准开发流程。**Agent 每完成一步必须停下来等确认，不要自动进入下一步。**
+
+### 1. 明确需求与范围
+
+**Developer:** 描述需求与边界。
+
+**Agent:** 复述需求、列出不做什么、把不清楚的点问出来（不要猜）。
+
+### 2. 分析代码
+
+**Agent:** 先读 `docs/architecture/` 对应文档，再读源码，输出数据流、关键调用路径、受影响的
+不变量；发现文档与代码不一致先报告。
+
+**Developer:** 补充背景与注意事项。
+
+### 3. 确定方案
+
+**Agent:** 输出方案并写入 `docs/specs/YYYY-MM-DD_slug.md`（方案、受影响的不变量、测试策略、
+风险）。
+
+**Developer:** 确认方案，或指出问题让 Agent 修改。
+
+### 4. 实施修改
+
+**Agent:** 从最新 `master` 建分支（`feat/<description>` / `fix/<description>`），测试先行，
+小步提交。
+
+**Developer:** 检查改动是否合理。
+
+### 5. 质量门禁
+
+**Agent:** 跑 `uv run pytest`、`uv run ruff check subscriber/ tests/ harness/`、
+`uv run mypy subscriber/`，贴出实际结论。
+
+**Developer:** 确认全绿。
+
+### 6. 提交与评审
+
+**Agent:** commit → push 分支 → 创建 MR（标题与 commit message 一致，描述含背景、改动点、
+验证方式、影响面与回滚方式；跨仓库改动列出对应 MR 链接）。
+
+**Developer:** 完成代码评审。
+
+### 7. 回顾与更新
+
+**Agent:** 检查并更新 `docs/architecture/`、`AGENTS.md`、`README.md`、`docs/metrics.json`，
+把落地方案与设计文档的差异回写到 spec。
+
+## Protobuf Compatibility Maintenance
+
+Production runs `protobuf==3.20.3`, and code emitted by `grpc_tools.protoc` imports
+`google.protobuf.runtime_version` / `_builder`, which cannot load on that runtime.
+The Python pb files in `subscriber/proto/` (`_pb2.py`, `_pb2_grpc.py`, `_pb2.pyi`) are
+therefore **hand-maintained** — do **not** run `grpc_tools.protoc` and commit its output.
+
+`subscriber/proto/engine_service_rpc.proto` remains the authoritative engine wire
+schema. KVCM meta-service bindings are a hand-maintained subset of KVCM's
+authoritative `meta_service.proto`. After changing either schema, manually sync the
+pb files following the procedure in [AGENTS.md](AGENTS.md) (section "Protobuf
+兼容代码维护"): keep the `descriptor_pb2` / `message_factory` implementation
+compatible with protobuf 3.20.3, never introduce `runtime_version` or `_builder`,
+and only touch `_pb2_grpc.py` when the RPC service/method/request/response types
+change.
+
+The pb files are committed to the repository and are never generated at build time.
+After any change, run the proto/client tests and `uv run mypy subscriber/` to confirm
+they import cleanly under protobuf 3.20.3.

--- a/subscriber/docs/metrics.json
+++ b/subscriber/docs/metrics.json
@@ -1,0 +1,249 @@
+{
+  "prefix": "kvcache_subscriber_",
+  "description": "All metrics emitted by kvcache-event-subscriber. Dual-written via dashlog (Prometheus) and PAI-EAS realtime_metrics (SLS). Tags are Prometheus labels / PAI-EAS tag keys.",
+  "eas_reporting": {
+    "endpoint": "http://localhost:8080/api/builtin/realtime_metrics",
+    "flush_interval_s": 10,
+    "sls_prefix": "custom_kvcache_subscriber_",
+    "counter_semantics": "per-interval delta (reset each flush)",
+    "histogram_semantics": "aggregated into _avg and _max suffixes per flush window"
+  },
+  "sources": {
+    "MetricsReporter": "Async main-path flush. Reads a BatchTelemetry per event; emits per-stage histograms, e2e latency, aggregate counters, and (for dropped batches) a drop-count counter plus partial-stage histograms tagged with drop_reason.",
+    "lifecycle": "Synchronous point-event helpers in subscriber.metrics.lifecycle (report_engine_probe, report_heartbeat, report_shutdown, report_zmq_message, ...). Called directly from health, kvcm, and adapter code paths."
+  },
+  "metrics": [
+    {
+      "name": "kvcache_subscriber_kv_stage_decode_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental | snapshot", "drop_reason": "epoch_changed | send_failed | filtered_empty | engine_not_ready | generation_reset | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Latency of decoding a ZMQ frame into KV events (incremental, vLLM adapter) or msgpack-decoding a fetched snapshot payload (snapshot). Emitted on every submitted telemetry that reached this stage; drop_reason tag is present when the batch was ultimately dropped."
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_replay_fetch_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental", "drop_reason": "epoch_changed | send_failed | engine_not_ready | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Latency of fetching replay batches from the engine after a sequence gap"
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_snapshot_fetch_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "snapshot", "drop_reason": "fetch_failed | generation_reset | empty_snapshot | schema_mismatch | decode_failed | engine_not_ready | epoch_changed | send_failed | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Latency of the gRPC round-trip for a full KV cache snapshot. Emitted on every poll including fetch_failed drops (the stage span is closed before the drop is recorded)."
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_snapshot_build_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "snapshot", "drop_reason": "generation_reset | engine_not_ready | epoch_changed | send_failed | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Latency of building a BlockSnapshot event from a fetched snapshot response. Not emitted on drops that occur before this stage (fetch_failed, empty_snapshot, schema_mismatch, decode_failed, first generation_reset check)."
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_expand_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental | snapshot"},
+      "source": "MetricsReporter",
+      "description": "Latency of expanding KV events or snapshot blocks into the KVCM reportEvent wire payload (serialization). Marked inside report_kv_events and report_snapshot after the expand step completes."
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_queue_wait_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental | snapshot", "drop_reason": "epoch_changed | send_failed | filtered_empty | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Time a batch spends waiting in the internal producer/consumer queue"
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_engine_gate_wait_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental | snapshot", "drop_reason": "epoch_changed | send_failed | filtered_empty | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Time waiting for the engine health coordinator to grant a sendable epoch"
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_block_filter_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental", "drop_reason": "send_failed | filtered_empty | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Time spent filtering redundant block removals before sending"
+    },
+    {
+      "name": "kvcache_subscriber_kv_stage_kvcm_send_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental | snapshot"},
+      "source": "MetricsReporter",
+      "description": "Time spent on the HTTP round-trip to KVCM (POST reportEvent and response handling). Serialization cost is excluded (covered by expand). Only emitted on successful send."
+    },
+    {
+      "name": "kvcache_subscriber_kv_event_e2e_latency_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"pipeline": "incremental | snapshot"},
+      "source": "MetricsReporter",
+      "description": "End-to-end latency from event receipt to the pipeline terminal action (KVCM send for both incremental and snapshot). Only emitted on successful telemetry; dropped batches expose their partial timeline through the individual kv_stage_*_ms histograms with drop_reason tag."
+    },
+    {
+      "name": "kvcache_subscriber_stored_block_hash_count",
+      "type": "counter",
+      "unit": "blocks",
+      "tags": {"pipeline": "incremental"},
+      "source": "MetricsReporter",
+      "description": "Number of block hashes forwarded as BLOCK_ADD events per batch"
+    },
+    {
+      "name": "kvcache_subscriber_removed_block_hash_count",
+      "type": "counter",
+      "unit": "blocks",
+      "tags": {"pipeline": "incremental"},
+      "source": "MetricsReporter",
+      "description": "Number of block hashes forwarded as BLOCK_DELETE events per batch"
+    },
+    {
+      "name": "kvcache_subscriber_snapshot_block_count",
+      "type": "counter",
+      "unit": "blocks",
+      "tags": {"pipeline": "snapshot"},
+      "source": "MetricsReporter",
+      "description": "Blocks contained in full KV cache snapshots forwarded to KVCM per successful send"
+    },
+    {
+      "name": "kvcache_subscriber_zmq_sequence_gap_count",
+      "type": "counter",
+      "unit": "gaps",
+      "tags": {"pipeline": "incremental"},
+      "source": "MetricsReporter",
+      "description": "Sequence gaps detected in the ZMQ pub stream, attributed to the replay batch that exposed the gap"
+    },
+    {
+      "name": "kvcache_subscriber_zmq_missed_message_count",
+      "type": "counter",
+      "unit": "messages",
+      "tags": {"pipeline": "incremental"},
+      "source": "MetricsReporter",
+      "description": "Messages missed across sequence gaps, attributed to the replay batch that exposed the gap"
+    },
+    {
+      "name": "kvcache_subscriber_kv_batch_drop_count",
+      "type": "counter",
+      "unit": "batches",
+      "tags": {"pipeline": "incremental | snapshot", "reason": "epoch_changed | send_failed | filtered_empty | engine_not_ready | fetch_failed | generation_reset | empty_snapshot | schema_mismatch | decode_failed"},
+      "source": "MetricsReporter",
+      "description": "Batches or polls dropped before reaching downstream. Incremental reasons: epoch_changed, send_failed, filtered_empty (all events removed by the block filter; benign no-op, not a failure), engine_not_ready. Snapshot reasons: fetch_failed (gRPC error), generation_reset (poll spanned a reset_generation_state call), empty_snapshot (engine returned no raw snapshot payload), schema_mismatch (msgpack payload failed schema validation), decode_failed (msgpack payload could not be decoded), engine_not_ready, epoch_changed, send_failed. Emitted once per submitted dropped BatchTelemetry."
+    },
+    {
+      "name": "kvcache_subscriber_zmq_received_message_count",
+      "type": "counter",
+      "unit": "messages",
+      "tags": {},
+      "source": "lifecycle",
+      "description": "Total ZMQ pub messages received from the engine. Background throughput counter; not tied to any specific batch."
+    },
+    {
+      "name": "kvcache_subscriber_kvcm_heartbeat_count",
+      "type": "counter",
+      "unit": "heartbeats",
+      "tags": {"status": "success | failure"},
+      "source": "lifecycle",
+      "description": "Heartbeat reports to KVCM (use rate() for heartbeat QPS, group by status)"
+    },
+    {
+      "name": "kvcache_subscriber_kvcm_registration_recovery_count",
+      "type": "counter",
+      "unit": "recoveries",
+      "tags": {},
+      "source": "lifecycle",
+      "description": "Number of times KVCM registration recovered after a failure"
+    },
+    {
+      "name": "kvcache_subscriber_kvcm_registration_transition_count",
+      "type": "counter",
+      "unit": "transitions",
+      "tags": {"from": "registered | unregistered", "to": "registered | unregistered"},
+      "source": "lifecycle",
+      "description": "KVCM registration state transitions"
+    },
+    {
+      "name": "kvcache_subscriber_engine_health_probe_count",
+      "type": "counter",
+      "unit": "probes",
+      "tags": {"result": "alive | dead | timeout | rpc_error"},
+      "source": "lifecycle",
+      "description": "Engine health probe outcomes, labeled by result"
+    },
+    {
+      "name": "kvcache_subscriber_engine_health_probe_latency_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"result": "alive | dead | timeout | rpc_error"},
+      "source": "lifecycle",
+      "description": "Engine health probe latency, labeled by result"
+    },
+    {
+      "name": "kvcache_subscriber_full_snapshot_payload_bytes",
+      "type": "gauge",
+      "unit": "bytes",
+      "tags": {"pipeline": "snapshot", "drop_reason": "generation_reset | empty_snapshot | schema_mismatch | decode_failed | engine_not_ready | epoch_changed | send_failed | (absent on success)"},
+      "source": "MetricsReporter",
+      "description": "Serialized protobuf response size for each full KV cache snapshot fetch that produced a response. Emitted on success and on every post-fetch drop so an empty payload (0 bytes) is observable as a real 0 rather than a missing datapoint. Not emitted on fetch_failed drops (no response object exists)."
+    },
+    {
+      "name": "kvcache_subscriber_engine_health_state_transition_count",
+      "type": "counter",
+      "unit": "transitions",
+      "tags": {"from": "starting | healthy | dead", "to": "starting | healthy | dead"},
+      "source": "lifecycle",
+      "description": "Engine health state machine transitions"
+    },
+    {
+      "name": "kvcache_subscriber_subscriber_phase_transition_count",
+      "type": "counter",
+      "unit": "transitions",
+      "tags": {"from": "starting | active | inactive | failed", "to": "starting | active | inactive | failed"},
+      "source": "lifecycle",
+      "description": "Subscriber phase transitions reported to DashServing"
+    },
+    {
+      "name": "kvcache_subscriber_dashserving_heartbeat_count",
+      "type": "counter",
+      "unit": "heartbeats",
+      "tags": {"status": "success | failure"},
+      "source": "lifecycle",
+      "description": "DashServing state heartbeat outcomes (use rate() for QPS, group by status)"
+    },
+    {
+      "name": "kvcache_subscriber_dashserving_state_report_count",
+      "type": "counter",
+      "unit": "reports",
+      "tags": {"state": "active | inactive | failed", "result": "accepted | error | stale"},
+      "source": "lifecycle",
+      "description": "State report outcomes to DashServing, labeled by state and result"
+    },
+    {
+      "name": "kvcache_subscriber_dashserving_state_report_latency_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "tags": {"state": "active | inactive | failed", "result": "accepted | error | stale"},
+      "source": "lifecycle",
+      "description": "State report latency to DashServing, labeled by state and result"
+    },
+    {
+      "name": "kvcache_subscriber_subscriber_shutdown_count",
+      "type": "counter",
+      "unit": "shutdowns",
+      "tags": {"outcome": "host_down_sent:<reason> | host_down_failed:<reason>"},
+      "source": "lifecycle",
+      "description": "Shutdown/HostDown emission outcomes"
+    }
+  ]
+}

--- a/subscriber/pyproject.toml
+++ b/subscriber/pyproject.toml
@@ -1,0 +1,89 @@
+[project]
+name = "tair-kvcache-subscriber"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "grpcio==1.75.1",
+    "protobuf==3.20.3",
+    "pyzmq>=26",
+    "msgspec>=0.18",
+    "httpx>=0.27",
+    "pyyaml>=6.0",
+]
+
+# Single source for dev deps. AoneCI installs via `pip install '.[dev]'`
+# (extras); uv's dev dependency-group below references this extra.
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "pytest-mock>=3.12",
+    "pytest-cov>=5",
+    "mypy>=2.3.0",
+    "ruff>=0.16.0",
+    "pre-commit>=4.6.0",
+    "types-pyyaml>=6.0",
+    "types-grpcio>=1.0",
+    "types-protobuf>=3.20",
+]
+
+[dependency-groups]
+dev = ["tair-kvcache-subscriber[dev]"]
+
+[project.scripts]
+subscriber = "subscriber.cli:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["subscriber"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+exclude = [
+    "subscriber/proto/*_pb2*.py",
+    "subscriber/proto/*_pb2*.pyi",
+    "benchmark/",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.ruff.lint.per-file-ignores]
+"subscriber/proto/*_pb2*.py" = ["ALL"]
+"subscriber/proto/*_pb2*.pyi" = ["ALL"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+exclude = ["benchmark/"]
+
+[[tool.mypy.overrides]]
+module = ["dashlog"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["subscriber.proto.*"]
+ignore_errors = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+markers = [
+    "integration: real ZMQ socket tests (no mocks)",
+    "e2e: opt-in tests against real DashServing or KVCM runtimes",
+]
+
+# Coverage gate uses two-decimal precision so 89.99% cannot round up and pass.
+# Raise the threshold as coverage improves; never lower it to make a commit pass.
+[tool.coverage.report]
+fail_under = 90
+precision = 2
+
+[tool.uv]
+[[tool.uv.index]]
+url = "https://artlab.alibaba-inc.com/1/pypi/simple"
+default = true

--- a/subscriber/subscriber/__main__.py
+++ b/subscriber/subscriber/__main__.py
@@ -1,0 +1,4 @@
+from subscriber.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/subscriber/subscriber/cli.py
+++ b/subscriber/subscriber/cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from subscriber import logger
+from subscriber.config import SubscriberConfig
+from subscriber.main import run
+
+
+def _build_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="subscriber",
+        description="tair-kvcache subscriber",
+    )
+    parser.set_defaults(command="serve")
+    parser.add_argument(
+        "--config", default=None, metavar="FILE", help="Path to YAML config file"
+    )
+    SubscriberConfig.add_cli_args(parser)
+    sub = parser.add_subparsers(dest="command")
+    serve = sub.add_parser("serve", help="Run the subscriber service")
+    serve.add_argument(
+        "--config",
+        default=argparse.SUPPRESS,
+        metavar="FILE",
+        help="Path to YAML config file",
+    )
+    SubscriberConfig.add_cli_args(serve, default=argparse.SUPPRESS)
+    return parser
+
+
+def cli() -> None:
+    """Entry point for the ``subscriber`` console script."""
+    parser = _build_cli_parser()
+    args = parser.parse_args()
+    config = SubscriberConfig.from_args(args)
+    logger.init("tair-kvcache-subscriber", level=config.log_level)
+    for key in config.unknown_config_keys:
+        logger.warning(
+            "ignoring unknown config file key",
+            step="config",
+            tags={"key": key},
+        )
+    try:
+        asyncio.run(run(config))
+    except Exception as exc:
+        logger.critical(
+            "subscriber exited with fatal error",
+            step="lifecycle",
+            tags={"error": exc.__class__.__name__, "message": str(exc)},
+            exc_info=True,
+        )
+        raise

--- a/subscriber/subscriber/config.py
+++ b/subscriber/subscriber/config.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass, fields
+from dataclasses import field as dataclass_field
+
+import yaml
+
+from subscriber.kvcm.enum import KvcmQueryType, KvcmStorageType
+from subscriber.kvcm.kinds import validate_extra_attention_types
+
+_LOG_LEVELS = ("debug", "info", "warning", "error", "critical")
+_KVCM_PROTOCOLS = ("grpc", "http")
+
+
+def _parse_extra_attention_types(raw: str) -> dict[str, str]:
+    """Parse the CLI JSON object used to extend attention-type mappings."""
+
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(
+            "extra_attention_types must be a JSON object"
+        ) from exc
+    if not isinstance(value, dict) or any(
+        not isinstance(key, str) or not isinstance(category, str)
+        for key, category in value.items()
+    ):
+        raise argparse.ArgumentTypeError(
+            "extra_attention_types must be a JSON object with string keys and values"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class DpEndpoint:
+    rank: int
+    zmq_pub_endpoint: str
+    zmq_replay_endpoint: str
+    zmq_topic: str = ""
+
+
+@dataclass
+class SubscriberConfig:
+    """Runtime configuration for the subscriber process."""
+
+    # ZMQ
+    zmq_replay_timeout_s: float = 1.0
+    zmq_reconnect_ivl_ms: int = 100
+    zmq_reconnect_ivl_max_ms: int = 5000
+    zmq_tcp_keepalive: bool = True
+    zmq_tcp_keepalive_idle_s: int = 30
+    zmq_tcp_keepalive_intvl_s: int = 5
+    zmq_tcp_keepalive_cnt: int = 3
+
+    kv_event_queue_maxsize: int = 4096
+    kv_event_merge_max_report_events: int = 16
+    kv_event_merge_max_queue_items: int = 4
+    snapshot_queue_maxsize: int = 16
+
+    # Engine
+    engine_type: str = "vllm"
+
+    # Engine liveness (gRPC GetWorkerStatus polling).
+    engine_health_interval_s: float = 5.0
+    engine_health_failure_threshold: int = 3
+
+    # Hybrid adapter: full snapshot reconciliation interval
+    engine_snapshot_full_sync_interval_s: float = 30.0
+    engine_kvcache_snapshot_timeout_ms: float = 5000.0
+    engine_kvcache_worker_status_timeout_ms: float = 1000.0
+    engine_kv_event_bootstrap_timeout_ms: float = 1000.0
+    engine_kv_event_bootstrap_max_retries: int = 5
+
+    # Remote worker-status TCP endpoint and same-Pod KV-event control UDS.
+    engine_grpc_endpoint: str = "127.0.0.1:18002"
+    engine_kv_event_control_uds_path: str = "/tmp/dashllm-kv-event-control.sock"
+
+    # Pipeline enable/disable.
+    incremental_kv_event_pipeline_enabled: bool = True
+    snapshot_kv_event_pipeline_enabled: bool = False
+
+    # Worker identity port advertised to KVCM as host_ip_port. Must match the
+    # engine endpoint port that FlexLB discovers via Spectrum. No default;
+    # validate() rejects a missing value at startup.
+    host_port: int | None = None
+
+    # kvcm SDK
+    kvcm_heartbeat_interval_s: float = 5.0
+    kvcm_request_timeout_s: float = 5.0
+    kvcm_query_type: str = KvcmQueryType.QT_PREFIX_MATCH_WITH_MAMBA
+    kvcm_storage_type: str = KvcmStorageType.ST_EVENT_REPORT_L1P5
+    kvcm_base_url: str = ""
+    kvcm_protocol: str = "grpc"
+    kvcm_instance_group: str = ""
+    extra_attention_types: dict[str, str] = dataclass_field(default_factory=dict)
+
+    # Dynamic polling interval (reserved for future adaptive polling).
+    poll_min_interval_s: float = 0.05
+    poll_max_interval_s: float = 0.2
+    poll_initial_interval_s: float = 0.1
+    poll_target_snapshot_size: int = 100
+
+    # Logging
+    log_level: str = "info"
+
+    # Subscriber health integration (DashServing same-host design).
+    subscriber_health_enabled: bool = True
+    subscriber_heartbeat_interval_s: float = 3.0
+    subscriber_state_request_timeout_s: float = 2.0
+    subscriber_shutdown_report_timeout_s: float = 2.0
+
+    # Config-file keys that matched no known field, recorded by ``from_args``
+    # so the CLI entry point can warn about them after logging is initialized.
+    unknown_config_keys: list[str] = dataclass_field(default_factory=list)
+
+    @property
+    def subscriber_state_url(self) -> str:
+        """Derive the DashServing state URL from DSV_CONTROL_PORT."""
+        port = os.environ.get("DSV_CONTROL_PORT", "8601")
+        return f"http://127.0.0.1:{port}/subscriber_state"
+
+    @classmethod
+    def add_cli_args(
+        cls,
+        parser: argparse.ArgumentParser,
+        default: object | str | None = None,
+    ) -> None:
+        """Register CLI overrides without masking YAML or dataclass defaults."""
+
+        parser.add_argument("--zmq-replay-timeout-s", type=float, default=default)
+        parser.add_argument("--kvcm-heartbeat-interval-s", type=float, default=default)
+        parser.add_argument("--kvcm-request-timeout-s", type=float, default=default)
+        parser.add_argument("--kv-event-queue-maxsize", type=int, default=default)
+        parser.add_argument("--snapshot-queue-maxsize", type=int, default=default)
+        parser.add_argument(
+            "--kv-event-merge-max-report-events", type=int, default=default
+        )
+        parser.add_argument(
+            "--kv-event-merge-max-queue-items", type=int, default=default
+        )
+        parser.add_argument("--engine-type", default=default)
+        parser.add_argument(
+            "--log-level",
+            choices=_LOG_LEVELS,
+            default=default,
+        )
+        parser.add_argument("--engine-health-interval-s", type=float, default=default)
+        parser.add_argument(
+            "--engine-health-failure-threshold", type=int, default=default
+        )
+        parser.add_argument(
+            "--engine-kvcache-worker-status-timeout-ms", type=float, default=default
+        )
+        parser.add_argument("--engine-grpc-endpoint", default=default)
+        parser.add_argument("--engine-kv-event-control-uds-path", default=default)
+        parser.add_argument(
+            "--engine-kv-event-bootstrap-max-retries", type=int, default=default
+        )
+        parser.add_argument(
+            "--engine-kv-event-bootstrap-timeout-ms", type=float, default=default
+        )
+        parser.add_argument(
+            "--host-port",
+            type=int,
+            default=default,
+            help="Worker identity port advertised to KVCM as host_ip_port "
+            "(must match the engine endpoint port FlexLB discovers via Spectrum)",
+        )
+        parser.add_argument("--kvcm-query-type", default=default)
+        parser.add_argument("--kvcm-storage-type", default=default)
+        parser.add_argument("--kvcm-base-url", default=default)
+        parser.add_argument(
+            "--kvcm-protocol",
+            choices=_KVCM_PROTOCOLS,
+            default=default,
+        )
+        parser.add_argument("--kvcm-instance-group", default=default)
+        parser.add_argument(
+            "--extra-attention-types",
+            type=_parse_extra_attention_types,
+            default=default,
+        )
+        parser.add_argument("--poll-min-interval-s", type=float, default=default)
+        parser.add_argument("--poll-max-interval-s", type=float, default=default)
+        parser.add_argument("--poll-initial-interval-s", type=float, default=default)
+        parser.add_argument("--poll-target-snapshot-size", type=int, default=default)
+        parser.add_argument(
+            "--engine-snapshot-full-sync-interval-s", type=float, default=default
+        )
+        parser.add_argument(
+            "--engine-kvcache-snapshot-timeout-ms", type=float, default=default
+        )
+        parser.add_argument(
+            "--incremental-kv-event-pipeline-enabled",
+            action=argparse.BooleanOptionalAction,
+            default=default,
+        )
+        parser.add_argument(
+            "--snapshot-kv-event-pipeline-enabled",
+            action=argparse.BooleanOptionalAction,
+            default=default,
+        )
+        parser.add_argument("--zmq-reconnect-ivl-ms", type=int, default=default)
+        parser.add_argument("--zmq-reconnect-ivl-max-ms", type=int, default=default)
+        parser.add_argument(
+            "--zmq-tcp-keepalive",
+            action=argparse.BooleanOptionalAction,
+            default=default,
+        )
+        parser.add_argument("--zmq-tcp-keepalive-idle-s", type=int, default=default)
+        parser.add_argument("--zmq-tcp-keepalive-intvl-s", type=int, default=default)
+        parser.add_argument("--zmq-tcp-keepalive-cnt", type=int, default=default)
+        parser.add_argument(
+            "--subscriber-health-enabled",
+            action=argparse.BooleanOptionalAction,
+            default=default,
+        )
+        parser.add_argument(
+            "--subscriber-heartbeat-interval-s", type=float, default=default
+        )
+        parser.add_argument(
+            "--subscriber-state-request-timeout-s", type=float, default=default
+        )
+        parser.add_argument(
+            "--subscriber-shutdown-report-timeout-s", type=float, default=default
+        )
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> SubscriberConfig:
+        """Build config with priority: CLI > yaml file > dataclass defaults."""
+
+        config = cls()
+        field_names = {f.name for f in fields(cls)}
+
+        if getattr(args, "config", None):
+            with open(args.config, encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            for key, value in data.items():
+                normalized = key.replace("-", "_")
+                if normalized in field_names:
+                    setattr(config, normalized, value)
+                else:
+                    config.unknown_config_keys.append(key)
+
+        for field in fields(cls):
+            dest = field.name
+            cli_val = getattr(args, dest, None)
+            if cli_val is not None:
+                setattr(config, field.name, cli_val)
+
+        config.validate()
+        return config
+
+    def validate(self) -> None:
+        validate_extra_attention_types(self.extra_attention_types)
+        if not isinstance(self.log_level, str):
+            raise ValueError(
+                f"log_level must be one of: {', '.join(sorted(_LOG_LEVELS))}"
+            )
+        self.log_level = self.log_level.lower()
+        if self.log_level not in _LOG_LEVELS:
+            raise ValueError(
+                f"log_level must be one of: {', '.join(sorted(_LOG_LEVELS))}"
+            )
+        if self.engine_health_failure_threshold < 1:
+            raise ValueError("engine_health_failure_threshold must be >= 1")
+        if self.engine_kv_event_bootstrap_max_retries < 1:
+            raise ValueError("engine_kv_event_bootstrap_max_retries must be >= 1")
+        if not self.engine_kv_event_control_uds_path.startswith("/"):
+            raise ValueError("engine_kv_event_control_uds_path must be absolute")
+        if self.kv_event_queue_maxsize < 1:
+            raise ValueError("kv_event_queue_maxsize must be >= 1")
+        if self.snapshot_queue_maxsize < 1:
+            raise ValueError("snapshot_queue_maxsize must be >= 1")
+        if self.kv_event_merge_max_report_events < 1:
+            raise ValueError("kv_event_merge_max_report_events must be >= 1")
+        if self.kv_event_merge_max_queue_items < 1:
+            raise ValueError("kv_event_merge_max_queue_items must be >= 1")
+        if self.host_port is None:
+            raise ValueError("host_port is required; pass --host-port at startup")
+        if not 1 <= self.host_port <= 65535:
+            raise ValueError("host_port must be in [1, 65535]")
+        if not self.kvcm_base_url.strip():
+            self.kvcm_base_url = os.environ.get("KVS_KVCM_ENDPOINT", "")
+            if not self.kvcm_base_url.strip():
+                raise ValueError("kvcm_base_url is required")
+        if not isinstance(self.kvcm_protocol, str):
+            raise ValueError(
+                f"kvcm_protocol must be one of: {', '.join(_KVCM_PROTOCOLS)}"
+            )
+        self.kvcm_protocol = self.kvcm_protocol.lower()
+        if self.kvcm_protocol not in _KVCM_PROTOCOLS:
+            raise ValueError(
+                f"kvcm_protocol must be one of: {', '.join(_KVCM_PROTOCOLS)}"
+            )
+        try:
+            self.kvcm_storage_type = KvcmStorageType(self.kvcm_storage_type)
+        except ValueError as exc:
+            raise ValueError(
+                "kvcm_storage_type must be one of: "
+                f"{', '.join(storage_type.value for storage_type in KvcmStorageType)}"
+            ) from exc
+        if self.kvcm_storage_type == KvcmStorageType.ST_UNSPECIFIED:
+            raise ValueError("kvcm_storage_type must not be ST_UNSPECIFIED")
+        if self.kvcm_heartbeat_interval_s <= 0:
+            raise ValueError("kvcm_heartbeat_interval_s must be > 0")
+        if self.kvcm_request_timeout_s <= 0:
+            raise ValueError("kvcm_request_timeout_s must be > 0")
+        if self.zmq_replay_timeout_s <= 0:
+            raise ValueError("zmq_replay_timeout_s must be > 0")
+        if self.poll_min_interval_s <= 0:
+            raise ValueError("poll_min_interval_s must be > 0")
+        if self.poll_max_interval_s <= self.poll_min_interval_s:
+            raise ValueError("poll_max_interval_s must be > poll_min_interval_s")
+        if self.poll_target_snapshot_size < 1:
+            raise ValueError("poll_target_snapshot_size must be >= 1")
+        if self.engine_snapshot_full_sync_interval_s <= 0:
+            raise ValueError("engine_snapshot_full_sync_interval_s must be > 0")
+        self.poll_initial_interval_s = max(
+            self.poll_min_interval_s,
+            min(self.poll_max_interval_s, self.poll_initial_interval_s),
+        )
+
+        if self.subscriber_health_enabled:
+            self._validate_subscriber_health()
+
+    def _validate_subscriber_health(self) -> None:
+        """Validate subscriber health integration fields when enabled."""
+        for field_name in (
+            "subscriber_heartbeat_interval_s",
+            "subscriber_state_request_timeout_s",
+            "subscriber_shutdown_report_timeout_s",
+        ):
+            if getattr(self, field_name) <= 0:
+                raise ValueError(f"{field_name} must be > 0")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the subscriber command-line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="tair-kvcache subscriber — vLLM KV event forwarder"
+    )
+    parser.add_argument(
+        "--config", default=None, metavar="FILE", help="Path to YAML config file"
+    )
+    SubscriberConfig.add_cli_args(parser)
+    return parser

--- a/subscriber/subscriber/engine/__init__.py
+++ b/subscriber/subscriber/engine/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from subscriber.engine import sglang as _sglang
+from subscriber.engine import vllm as _vllm
+from subscriber.engine.base import AbstractEngineAdapter
+
+__all__ = ["AbstractEngineAdapter"]
+
+_ = (_sglang, _vllm)

--- a/subscriber/subscriber/engine/base.py
+++ b/subscriber/subscriber/engine/base.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypeVar
+
+from subscriber.engine.metadata import KvEventBootstrap
+from subscriber.health.events import LivenessEvent
+from subscriber.metrics import BatchTelemetry
+from subscriber.types import KVEventBatch
+
+if TYPE_CHECKING:
+    from subscriber.config import SubscriberConfig
+
+_AdapterT = TypeVar("_AdapterT", bound="AbstractEngineAdapter")
+
+
+@dataclass(frozen=True)
+class EngineEventBatch:
+    """Engine-agnostic carrier yielded by adapters to the subscriber core.
+
+    Bundles the forwarded KV batches with the :class:`BatchTelemetry` whose
+    origin is the moment the adapter began handling this event. The adapter
+    marks its own internal stages (e.g. ``decode`` for live events,
+    ``replay_fetch`` for replayed events); the subscriber core marks the
+    remaining pipeline stages on the same telemetry so a single span timeline
+    covers receipt through kvcm send, and terminal counters / drop reasons are
+    recorded on the same object before it is submitted to
+    :class:`~subscriber.metrics.MetricsReporter`.
+    """
+
+    batches: list[KVEventBatch]
+    telemetry: BatchTelemetry
+    trace_id: str
+
+
+class AbstractEngineAdapter(ABC):
+    """Interface for engine-specific IO.
+
+    Implementations isolate engine transport details from the subscriber core:
+    KV event subscription, sequence-gap replay, liveness observation, and
+    generation-local reset state all stay behind this interface.
+    """
+
+    _registry: dict[str, Callable[[SubscriberConfig], AbstractEngineAdapter]] = {}
+
+    @classmethod
+    def register(cls, engine_type: str) -> Callable[[type[_AdapterT]], type[_AdapterT]]:
+        """Register an adapter class for lazy construction by engine type."""
+
+        def decorator(adapter_cls: type[_AdapterT]) -> type[_AdapterT]:
+            cls._registry[engine_type] = adapter_cls
+            return adapter_cls
+
+        return decorator
+
+    @classmethod
+    def create(
+        cls, engine_type: str, config: SubscriberConfig
+    ) -> AbstractEngineAdapter:
+        """Create the adapter registered for ``engine_type``.
+
+        Raises:
+            KeyError: If no adapter has been registered for ``engine_type``.
+        """
+
+        if engine_type not in cls._registry:
+            raise KeyError(
+                f"Unknown engine_type {engine_type!r}. "
+                f"Registered: {list(cls._registry)}"
+            )
+        return cls._registry[engine_type](config)
+
+    @abstractmethod
+    def subscribe_kv_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield realtime or replayed KV event batches in forwarding order.
+
+        Each yield is an :class:`EngineEventBatch` whose ``batches`` field is
+        either:
+        - A single-element list: one real-time event batch.
+        - A multi-element list: replayed batches when a sequence gap is detected.
+
+        The carried ``telemetry`` originates when the adapter begins handling the
+        event and has the adapter's internal stage(s) already marked.
+
+        Implementations may aggregate one or more configured DP endpoints into
+        this stream. Transport-specific replay and per-DP sequence tracking stay
+        inside the adapter before yielding batches to the subscriber core.
+        """
+        ...
+
+    @abstractmethod
+    def subscribe_snapshot_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield periodic full snapshots for kvcm reconciliation.
+
+        Each yield is an :class:`EngineEventBatch` containing a single
+        ``BlockSnapshot`` event with the engine's current ``snapshot_version``.
+        The polling interval is adapter-specific (typically minutes).
+
+        The carried ``telemetry`` originates when the adapter begins the poll and
+        has ``snapshot_fetch`` / ``snapshot_build`` stages marked.
+
+        Every concrete adapter must implement this stream, even when its current
+        engine integration intentionally yields no snapshots.
+        """
+        ...
+
+    @abstractmethod
+    def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+        """Yield engine-agnostic liveness events for the health coordinator."""
+        ...
+
+    @abstractmethod
+    def map_medium(self, medium: str | None) -> str:
+        """Translate an engine-native medium string to the kvcm wire value.
+
+        Returns the kvcm-side identifier (e.g. ``"hbm"``, ``"mem"``) for the
+        given engine-specific medium.  Returns ``""`` when *medium* is ``None``
+        or not recognized by this adapter.
+        """
+        ...
+
+    @abstractmethod
+    def supported_mediums(self) -> list[str]:
+        """Return the kvcm wire medium values this adapter can produce."""
+        ...
+
+    @abstractmethod
+    def storage_type(self) -> str:
+        """Return the kvcm storage type identifier for this engine.
+
+        For example, the vLLM adapter returns ``"ST_EVENT_REPORT_L1P5"``.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release adapter-owned asynchronous resources.
+
+        The subscriber calls this once during shutdown. Adapters without
+        external resources may keep the default no-op implementation.
+        """
+        return None
+
+    @abstractmethod
+    def request_immediate_snapshot(self) -> None:
+        """Request the snapshot source to poll immediately.
+
+        Synchronous, event-loop-only signal. Adapters with a snapshot source
+        wake their poller early; adapters without one implement an explicit
+        no-op. Must not perform I/O or await.
+        """
+        ...
+
+    async def reset_generation_state(self) -> None:
+        """Reset adapter-local generation state after an engine restart.
+
+        The health coordinator calls this before opening a new sendable epoch
+        after recovery from DEAD. Adapters should clear sequence tracking and
+        recreate any replay/session state that belongs to the old generation.
+
+        In-flight await contract
+        ------------------------
+        When this method runs, the adapter may still have awaits parked on the
+        previous generation's sockets — for example a live ``recv_multipart``
+        on the SUB socket, or a replay ``send``/``recv`` pair on the DEALER
+        socket. If those awaits returned their results into the new epoch,
+        stale seq/payload from the old engine instance would be yielded with
+        the freshly reset sequence counter and forwarded to kvcm as if it
+        belonged to the new generation.
+
+        Implementations must therefore invalidate any in-flight result whose
+        await spanned the reset. The vLLM adapter does this with a monotonic
+        ``self._generation`` counter: every async helper snapshots the counter
+        before each await and discards the result (returns ``None`` / skips
+        the yield) if the counter has advanced by the time the await resumes.
+        Closing the old sockets with ``linger=0`` inside this method provides
+        a second line of defense by turning parked awaits into exceptions that
+        the helpers already translate into ``None``.
+        """
+        return None
+
+    @abstractmethod
+    async def fetch_kv_event_bootstrap(self) -> KvEventBootstrap:
+        """Fetch and install the authoritative cache/event bootstrap.
+
+        The adapter validates the engine-specific schema and constructs its ZMQ
+        source from the returned engine-owned transport before returning. No
+        configured ZMQ endpoint may override the accepted bootstrap.
+
+        Failures are reported as typed exceptions rather than a nullable return:
+
+        - :class:`MetadataTemporarilyUnavailable`: retryable transport failure
+          or an explicit UNAVAILABLE response, raised after the bounded
+          per-attempt retry policy is exhausted.
+        - :class:`MetadataProtocolError`: a non-retryable response or malformed
+          metadata (invalid status code, wrong field shape, duplicate group
+          ids, or invalid sizes).
+        Every registered adapter must implement this source. Callers register
+        with kvcm only after it resolves successfully.
+        """
+        ...

--- a/subscriber/subscriber/engine/debug.py
+++ b/subscriber/subscriber/engine/debug.py
@@ -1,0 +1,58 @@
+"""Shared debug summaries for normalized KV event batches."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import msgspec
+
+from subscriber.types import BlockRemoved, BlockStored, KVEventBatch, format_block_hash
+
+_MAX_DEBUG_BLOCK_HASHES = 32
+
+
+def _event_for_debug(event: BlockStored | BlockRemoved) -> dict[str, object]:
+    """Copy an event for logging without token IDs or forwarding mutations."""
+
+    event_data = msgspec.structs.asdict(event)
+    event_data.pop("token_ids", None)
+    event_data["block_hashes"] = [
+        format_block_hash(block_hash) for block_hash in event.block_hashes
+    ]
+    if isinstance(event, BlockStored) and event.parent_block_hash is not None:
+        event_data["parent_block_hash"] = format_block_hash(event.parent_block_hash)
+    return event_data
+
+
+def summarize_kv_event_batch_for_debug(batch: KVEventBatch) -> dict[str, object]:
+    """Return bounded, token-free details for a decoded ZMQ batch debug log."""
+
+    event_type_counts = Counter(type(event).__name__ for event in batch.events)
+    stored_blocks: list[dict[str, object]] = []
+    removed_blocks: list[dict[str, object]] = []
+    for event in batch.events:
+        if isinstance(event, BlockStored):
+            if len(stored_blocks) < _MAX_DEBUG_BLOCK_HASHES:
+                stored_blocks.append(_event_for_debug(event))
+        elif isinstance(event, BlockRemoved):
+            if len(removed_blocks) < _MAX_DEBUG_BLOCK_HASHES:
+                removed_blocks.append(_event_for_debug(event))
+    return {
+        "event_count": len(batch.events),
+        "event_types": ",".join(
+            f"{name}:{count}" for name, count in sorted(event_type_counts.items())
+        ),
+        "data_parallel_rank": batch.data_parallel_rank,
+        "stored_block_count": len(stored_blocks),
+        "stored_blocks": stored_blocks,
+        "stored_blocks_truncated": sum(
+            1 for event in batch.events if isinstance(event, BlockStored)
+        )
+        > len(stored_blocks),
+        "removed_block_count": len(removed_blocks),
+        "removed_blocks": removed_blocks,
+        "removed_blocks_truncated": sum(
+            1 for event in batch.events if isinstance(event, BlockRemoved)
+        )
+        > len(removed_blocks),
+    }

--- a/subscriber/subscriber/engine/grpc_options.py
+++ b/subscriber/subscriber/engine/grpc_options.py
@@ -1,0 +1,15 @@
+"""Shared gRPC channel options for DashLLM engine clients."""
+
+from __future__ import annotations
+
+CHANNEL_OPTIONS: list[tuple[str, int]] = [
+    ("grpc.max_receive_message_length", 8 * 1024 * 1024),
+    ("grpc.keepalive_time_ms", 2_000),
+    ("grpc.keepalive_timeout_ms", 10_000),
+    ("grpc.keepalive_permit_without_calls", 1),
+    ("grpc.http2.max_pings_without_data", 0),
+    ("grpc.enable_retries", 0),
+    ("grpc.initial_reconnect_backoff_ms", 100),
+    ("grpc.max_reconnect_backoff_ms", 1_000),
+    ("grpc.tcp_receive_buffer_size", 512 * 1024),
+]

--- a/subscriber/subscriber/engine/interval_adjuster.py
+++ b/subscriber/subscriber/engine/interval_adjuster.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections import deque
+
+
+class DynamicIntervalAdjuster:
+    """Dynamically adjusts a polling interval based on observed diff sizes.
+
+    Uses a rolling window to smooth observations and adjusts the interval
+    toward the target diff size using a dampening factor.
+    """
+
+    WINDOW_SIZE: int = 30
+    DAMPENING_FACTOR: float = 0.3
+    ADJUSTMENT_THRESHOLD: float = 0.1
+    MIN_SAMPLES: int = 3
+
+    def __init__(
+        self,
+        target_diff_size: int,
+        min_interval_s: float,
+        max_interval_s: float,
+        initial_interval_s: float,
+    ) -> None:
+        self._target_diff_size = target_diff_size
+        self._min_interval_s = min_interval_s
+        self._max_interval_s = max_interval_s
+        self._initial_interval_s = initial_interval_s
+        self._current_interval_s = initial_interval_s
+        self._window: deque[int] = deque(maxlen=self.WINDOW_SIZE)
+
+    @property
+    def current_interval_s(self) -> float:
+        return self._current_interval_s
+
+    def update(self, diff_size: int) -> None:
+        self._window.append(diff_size)
+
+        if len(self._window) < self.MIN_SAMPLES:
+            return
+
+        rolling_average = sum(self._window) / len(self._window)
+        deviation = (rolling_average - self._target_diff_size) / self._target_diff_size
+
+        if abs(deviation) < self.ADJUSTMENT_THRESHOLD:
+            return
+
+        if rolling_average > self._target_diff_size:
+            new_interval = self._current_interval_s * (1 - self.DAMPENING_FACTOR)
+        else:
+            new_interval = self._current_interval_s * (1 + self.DAMPENING_FACTOR)
+
+        self._current_interval_s = max(
+            self._min_interval_s, min(self._max_interval_s, new_interval)
+        )
+
+    def reset(self) -> None:
+        """Clear history on engine restart. Reset interval to initial value."""
+        self._window.clear()
+        self._current_interval_s = self._initial_interval_s

--- a/subscriber/subscriber/engine/kv_event_control_client.py
+++ b/subscriber/subscriber/engine/kv_event_control_client.py
@@ -1,0 +1,75 @@
+"""Same-Pod UDS client for DashLLM KV-event bootstrap and snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import grpc
+
+from subscriber.engine.grpc_options import CHANNEL_OPTIONS
+from subscriber.proto import engine_service_rpc_pb2, engine_service_rpc_pb2_grpc
+
+
+class DashllmKvEventControlClient:
+    """Own the local control channel independently from remote worker status."""
+
+    def __init__(self, uds_path: str) -> None:
+        self._target = self._to_uds_target(uds_path)
+        self._channel: grpc.aio.Channel | None = None
+        self._service: engine_service_rpc_pb2_grpc.KvEventControlServiceStub | None = (
+            None
+        )
+
+    @staticmethod
+    def _to_uds_target(path: str) -> str:
+        if path.startswith("unix:"):
+            return path
+        if not path.startswith("/"):
+            raise ValueError("DashLLM KV event control UDS path must be absolute")
+        return f"unix://{path}"
+
+    def _get_service(
+        self,
+    ) -> engine_service_rpc_pb2_grpc.KvEventControlServiceStub:
+        if self._service is None:
+            self._channel = grpc.aio.insecure_channel(
+                self._target, options=CHANNEL_OPTIONS
+            )
+            stub_factory = cast(
+                Callable[
+                    [grpc.aio.Channel],
+                    engine_service_rpc_pb2_grpc.KvEventControlServiceStub,
+                ],
+                engine_service_rpc_pb2_grpc.KvEventControlServiceStub,
+            )
+            self._service = stub_factory(self._channel)
+        return self._service
+
+    async def get_kv_event_bootstrap_info(
+        self, timeout_s: float
+    ) -> engine_service_rpc_pb2.KvEventBootstrapInfoPB:
+        """Fetch engine-owned event transport and cache schema."""
+
+        response = await self._get_service().GetKvEventBootstrapInfo(
+            engine_service_rpc_pb2.KvEventBootstrapInfoRequestPB(),
+            timeout=timeout_s,
+        )
+        return cast(engine_service_rpc_pb2.KvEventBootstrapInfoPB, response)
+
+    async def get_all_kv_cache_blocks(self, timeout_s: float) -> object:
+        """Fetch one versioned full KV cache snapshot."""
+
+        response = await self._get_service().GetAllKvCacheBlocks(
+            engine_service_rpc_pb2.KvCacheBlocksRequestPB(), timeout=timeout_s
+        )
+        return cast(object, response)
+
+    async def close(self) -> None:
+        """Release the local control channel."""
+
+        channel = self._channel
+        self._channel = None
+        self._service = None
+        if channel is not None:
+            await channel.close()

--- a/subscriber/subscriber/engine/metadata.py
+++ b/subscriber/subscriber/engine/metadata.py
@@ -1,0 +1,447 @@
+"""Authoritative KV-event bootstrap and KVCM registration metadata."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from typing import Any, TypeAlias
+
+from subscriber.proto import engine_service_rpc_pb2
+from subscriber.types import KvCacheGroupSpec
+
+SettingScalar: TypeAlias = bool | int | float | str | bytes
+SettingValue: TypeAlias = SettingScalar | tuple[SettingScalar, ...]
+TypedSettings: TypeAlias = tuple[tuple[str, SettingValue], ...]
+
+_SUPPORTED_PROTOCOL_VERSIONS = frozenset({1})
+_SUPPORTED_EVENT_SCHEMA_VERSIONS = frozenset({2})
+_SUPPORTED_SERIALIZATIONS = frozenset({"msgpack-v1"})
+
+
+@dataclass(frozen=True)
+class EventTransport:
+    """Engine-owned ZMQ live/replay transport coordinates."""
+
+    live_endpoint: str
+    topic: str
+    replay_supported: bool
+    replay_endpoint: str
+    serialization: str
+
+
+@dataclass(frozen=True)
+class RuntimeTopology:
+    """Parallel topology for the event publisher represented by this bootstrap."""
+
+    data_parallel_size: int
+    tensor_parallel_size: int
+    pipeline_parallel_size: int
+    data_parallel_rank: int
+    tensor_parallel_rank: int
+    pipeline_parallel_rank: int
+
+
+@dataclass(frozen=True)
+class SnapshotCapability:
+    """Whether the engine exposes full snapshots and versions them."""
+
+    supported: bool
+    versioned: bool
+
+
+@dataclass(frozen=True)
+class CacheGeometry:
+    """Engine-neutral geometry for one independently reported cache component."""
+
+    block_size_tokens: int
+    page_size_tokens: int | None
+    block_count: int | None
+    group_payload_size_bytes: int | None
+    cache_dtype: str
+    element_size_bytes: int | None
+    layer_count: int | None
+    cache_layout: str
+    sliding_window_tokens: int | None
+    checkpoint_alignment_tokens: int | None
+
+
+@dataclass(frozen=True)
+class CacheComponent:
+    """One stable numeric component identity and its cache interpretation.
+
+    The normalized ``component_id`` maps to vLLM event ``group_idx`` or SGLang
+    event ``component_id``; it does not require a shared engine wire field.
+    """
+
+    component_id: int
+    component_kind: str
+    geometry: CacheGeometry
+    compatibility_settings: TypedSettings = ()
+    diagnostic_settings: TypedSettings = ()
+
+
+@dataclass(frozen=True)
+class VllmEventSchema:
+    """vLLM-specific event and cache-compatibility semantics."""
+
+    event_schema_version: int
+    use_eagle_pop: bool
+    mamba_cache_mode: str
+    hash_algorithm: str
+    hash_version: str
+    cache_settings: TypedSettings = ()
+
+
+@dataclass(frozen=True)
+class SglangEventSchema:
+    """SGLang-specific native cache-key and event semantics."""
+
+    event_schema_version: int
+    cache_key_mode: str
+    native_hash_algorithm: str
+    cache_settings: TypedSettings = ()
+
+
+@dataclass(frozen=True)
+class KvEventBootstrap:
+    """Validated immutable contract shared by adapters and KVCM translation."""
+
+    protocol_version: int
+    engine_kind: str
+    event_transport: EventTransport
+    runtime_topology: RuntimeTopology
+    snapshot: SnapshotCapability
+    components: tuple[CacheComponent, ...]
+    compatibility_settings: TypedSettings
+    diagnostic_settings: TypedSettings
+    vllm: VllmEventSchema | None = None
+    sglang: SglangEventSchema | None = None
+
+    def to_log_json(self) -> str:
+        """Serialize the complete accepted bootstrap for one startup info log."""
+
+        return json.dumps(asdict(self), default=_json_default, sort_keys=True)
+
+    def to_kv_cache_descriptor(self) -> KvCacheDescriptor:
+        """Build the existing KVCM-facing descriptor without engine protobufs."""
+
+        groups = tuple(
+            KvCacheGroupSpec(
+                group_idx=component.component_id,
+                kind=component.component_kind,
+                block_size=component.geometry.block_size_tokens,
+                group_payload_size_bytes=(component.geometry.group_payload_size_bytes),
+                sliding_window=component.geometry.sliding_window_tokens,
+            )
+            for component in self.components
+        )
+        return KvCacheDescriptor(
+            groups=groups,
+            use_eagle_pop=self.vllm.use_eagle_pop if self.vllm else False,
+            mamba_cache_mode=self.vllm.mamba_cache_mode if self.vllm else "none",
+        )
+
+
+@dataclass(frozen=True)
+class KvCacheDescriptor:
+    """Immutable result of an authoritative metadata fetch.
+
+    ``groups`` is ordered as returned by the engine; each spec carries its own
+    ``group_idx`` (do not infer the index from tuple position). An empty tuple
+    is a valid success (e.g. a single-group / attention-free model) and must
+    never be represented as ``None``.
+
+    ``use_eagle_pop`` indicates whether the engine pops the last matched
+    FullAttention block during prefix cache lookup (MTP/Eagle correctness).
+    ``mamba_cache_mode`` is the engine's mamba state caching strategy
+    ("none" | "all" | "light" | "light_flex").
+    """
+
+    groups: tuple[KvCacheGroupSpec, ...]
+    use_eagle_pop: bool = False
+    mamba_cache_mode: str = "none"
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, bytes):
+        return {"bytes_hex": value.hex()}
+    raise TypeError(f"cannot serialize {type(value).__name__}")
+
+
+class MetadataFetchError(RuntimeError):
+    """Base error for an authoritative metadata fetch."""
+
+
+class MetadataTemporarilyUnavailable(MetadataFetchError):
+    """Retryable transport failure or explicit UNAVAILABLE response.
+
+    Raised only after the bounded per-attempt retry policy is exhausted. The
+    startup supervisor treats this as a transient condition: the process stays
+    in ``starting`` until the deployment startup/liveness policy replaces it.
+    """
+
+
+class MetadataProtocolError(MetadataFetchError):
+    """Non-retryable response or malformed metadata.
+
+    Covers invalid status codes, wrong field shape, duplicate group ids, and
+    invalid sizes. This is a fatal configuration/protocol error that causes
+    startup ``failed``.
+    """
+
+
+def _optional_int(message: Any, field_name: str) -> int | None:
+    if not message.HasField(field_name):
+        return None
+    return int(getattr(message, field_name).value)
+
+
+def _typed_settings(values: Iterable[Any], *, scope: str) -> TypedSettings:
+    parsed: list[tuple[str, SettingValue]] = []
+    names: set[str] = set()
+    for setting in values:
+        name = str(setting.name)
+        if not name:
+            raise MetadataProtocolError(f"{scope} contains an empty setting name")
+        if name in names:
+            raise MetadataProtocolError(
+                f"{scope} contains duplicate setting name {name!r}"
+            )
+        names.add(name)
+        value_kind = setting.WhichOneof("value")
+        if value_kind is None:
+            raise MetadataProtocolError(f"{scope} setting {name!r} has no typed value")
+        raw_value = getattr(setting, value_kind)
+        if value_kind.endswith("_list"):
+            value: SettingValue = tuple(raw_value.values)
+        else:
+            value = raw_value
+        parsed.append((name, value))
+    return tuple(parsed)
+
+
+def _parse_transport(
+    payload: Any, *, require_incremental_transport: bool
+) -> EventTransport:
+    transport = EventTransport(
+        live_endpoint=str(payload.live_endpoint),
+        topic=str(payload.topic),
+        replay_supported=bool(payload.replay_supported),
+        replay_endpoint=str(payload.replay_endpoint),
+        serialization=str(payload.serialization),
+    )
+    if not require_incremental_transport:
+        return transport
+    if not transport.live_endpoint:
+        raise MetadataProtocolError("event transport is missing live_endpoint")
+    if transport.serialization not in _SUPPORTED_SERIALIZATIONS:
+        raise MetadataProtocolError(
+            f"unsupported event serialization {transport.serialization!r}"
+        )
+    if transport.replay_supported and not transport.replay_endpoint:
+        raise MetadataProtocolError(
+            "event transport declares replay support without replay_endpoint"
+        )
+    if not transport.replay_supported and transport.replay_endpoint:
+        raise MetadataProtocolError(
+            "event transport provides replay_endpoint while replay is unsupported"
+        )
+    return transport
+
+
+def _parse_topology(payload: Any) -> RuntimeTopology:
+    topology = RuntimeTopology(
+        data_parallel_size=int(payload.data_parallel_size),
+        tensor_parallel_size=int(payload.tensor_parallel_size),
+        pipeline_parallel_size=int(payload.pipeline_parallel_size),
+        data_parallel_rank=int(payload.data_parallel_rank),
+        tensor_parallel_rank=int(payload.tensor_parallel_rank),
+        pipeline_parallel_rank=int(payload.pipeline_parallel_rank),
+    )
+    for size_name, rank_name in (
+        ("data_parallel_size", "data_parallel_rank"),
+        ("tensor_parallel_size", "tensor_parallel_rank"),
+        ("pipeline_parallel_size", "pipeline_parallel_rank"),
+    ):
+        size = getattr(topology, size_name)
+        rank = getattr(topology, rank_name)
+        if size < 1:
+            raise MetadataProtocolError(f"runtime topology {size_name} must be >= 1")
+        if rank < 0 or rank >= size:
+            raise MetadataProtocolError(
+                f"runtime topology {rank_name}={rank} is outside {size_name}={size}"
+            )
+    return topology
+
+
+def _parse_geometry(payload: Any, *, component_id: int) -> CacheGeometry:
+    geometry = CacheGeometry(
+        block_size_tokens=int(payload.block_size_tokens),
+        page_size_tokens=_optional_int(payload, "page_size_tokens"),
+        block_count=_optional_int(payload, "block_count"),
+        group_payload_size_bytes=_optional_int(payload, "group_payload_size_bytes"),
+        cache_dtype=str(payload.cache_dtype),
+        element_size_bytes=_optional_int(payload, "element_size_bytes"),
+        layer_count=_optional_int(payload, "layer_count"),
+        cache_layout=str(payload.cache_layout),
+        sliding_window_tokens=_optional_int(payload, "sliding_window_tokens"),
+        checkpoint_alignment_tokens=_optional_int(
+            payload, "checkpoint_alignment_tokens"
+        ),
+    )
+    if geometry.block_size_tokens <= 0:
+        raise MetadataProtocolError(
+            f"component_id {component_id} has invalid block_size_tokens "
+            f"{geometry.block_size_tokens}"
+        )
+    for name in (
+        "page_size_tokens",
+        "block_count",
+        "group_payload_size_bytes",
+        "element_size_bytes",
+        "layer_count",
+        "checkpoint_alignment_tokens",
+    ):
+        value = getattr(geometry, name)
+        if value is not None and value <= 0:
+            raise MetadataProtocolError(
+                f"component_id {component_id} has invalid {name} {value}"
+            )
+    return geometry
+
+
+def _parse_components(payload: Iterable[Any]) -> tuple[CacheComponent, ...]:
+    components: list[CacheComponent] = []
+    seen_ids: set[int] = set()
+    for entry in payload:
+        component_id = int(entry.component_id)
+        if component_id in seen_ids:
+            raise MetadataProtocolError(
+                f"bootstrap contains duplicate component_id {component_id}"
+            )
+        seen_ids.add(component_id)
+        component_kind = str(entry.component_kind)
+        if not component_kind:
+            raise MetadataProtocolError(
+                f"component_id {component_id} has empty component_kind"
+            )
+        components.append(
+            CacheComponent(
+                component_id=component_id,
+                component_kind=component_kind,
+                geometry=_parse_geometry(entry.geometry, component_id=component_id),
+                compatibility_settings=_typed_settings(
+                    entry.compatibility_settings,
+                    scope=f"component_id {component_id} compatibility_settings",
+                ),
+                diagnostic_settings=_typed_settings(
+                    entry.diagnostic_settings,
+                    scope=f"component_id {component_id} diagnostic_settings",
+                ),
+            )
+        )
+    return tuple(components)
+
+
+def _validate_event_schema_version(version: int, *, engine_kind: str) -> None:
+    if version not in _SUPPORTED_EVENT_SCHEMA_VERSIONS:
+        raise MetadataProtocolError(
+            f"unsupported {engine_kind} event_schema_version {version}"
+        )
+
+
+def parse_kv_event_bootstrap(
+    payload: Any,
+    *,
+    expected_engine_kind: str,
+    require_incremental_transport: bool = True,
+) -> KvEventBootstrap:
+    """Validate a protobuf bootstrap response and detach it from protobuf.
+
+    The returned immutable model is the only cache/event metadata passed into
+    adapters and KVCM translation. Unknown semantic versions, contradictory
+    engine schemas and duplicate component IDs fail before any ZMQ socket is
+    opened. Incremental transport completeness is required only when that
+    pipeline is enabled.
+    """
+
+    err_code = int(getattr(payload, "err_code", 0))
+    if err_code != engine_service_rpc_pb2.KV_EVENT_BOOTSTRAP_OK:
+        raise MetadataProtocolError(
+            "DashLLM bootstrap returned error "
+            f"{err_code}: {str(getattr(payload, 'err_msg', ''))}"
+        )
+    protocol_version = int(getattr(payload, "protocol_version", 0))
+    if protocol_version not in _SUPPORTED_PROTOCOL_VERSIONS:
+        raise MetadataProtocolError(
+            f"unsupported KV event bootstrap protocol_version {protocol_version}"
+        )
+    engine_kind = str(getattr(payload, "engine_kind", ""))
+    if engine_kind != expected_engine_kind:
+        raise MetadataProtocolError(
+            f"bootstrap engine_kind {engine_kind!r} does not match configured "
+            f"engine {expected_engine_kind!r}"
+        )
+    schema_kind = payload.WhichOneof("engine_schema")
+    if schema_kind != engine_kind:
+        raise MetadataProtocolError(
+            f"bootstrap engine schema {schema_kind!r} does not match engine_kind "
+            f"{engine_kind!r}"
+        )
+
+    vllm: VllmEventSchema | None = None
+    sglang: SglangEventSchema | None = None
+    if engine_kind == "vllm":
+        schema = payload.vllm
+        _validate_event_schema_version(
+            int(schema.event_schema_version), engine_kind=engine_kind
+        )
+        vllm = VllmEventSchema(
+            event_schema_version=int(schema.event_schema_version),
+            use_eagle_pop=bool(schema.use_eagle_pop),
+            mamba_cache_mode=str(schema.mamba_cache_mode),
+            hash_algorithm=str(schema.hash_algorithm),
+            hash_version=str(schema.hash_version),
+            cache_settings=_typed_settings(
+                schema.cache_settings, scope="vllm.cache_settings"
+            ),
+        )
+    elif engine_kind == "sglang":
+        schema = payload.sglang
+        _validate_event_schema_version(
+            int(schema.event_schema_version), engine_kind=engine_kind
+        )
+        sglang = SglangEventSchema(
+            event_schema_version=int(schema.event_schema_version),
+            cache_key_mode=str(schema.cache_key_mode),
+            native_hash_algorithm=str(schema.native_hash_algorithm),
+            cache_settings=_typed_settings(
+                schema.cache_settings, scope="sglang.cache_settings"
+            ),
+        )
+    else:
+        raise MetadataProtocolError(f"unsupported engine_kind {engine_kind!r}")
+
+    return KvEventBootstrap(
+        protocol_version=protocol_version,
+        engine_kind=engine_kind,
+        event_transport=_parse_transport(
+            payload.event_transport,
+            require_incremental_transport=require_incremental_transport,
+        ),
+        runtime_topology=_parse_topology(payload.runtime_topology),
+        snapshot=SnapshotCapability(
+            supported=bool(payload.snapshot.supported),
+            versioned=bool(payload.snapshot.versioned),
+        ),
+        components=_parse_components(payload.components),
+        compatibility_settings=_typed_settings(
+            payload.compatibility_settings, scope="compatibility_settings"
+        ),
+        diagnostic_settings=_typed_settings(
+            payload.diagnostic_settings, scope="diagnostic_settings"
+        ),
+        vllm=vllm,
+        sglang=sglang,
+    )

--- a/subscriber/subscriber/engine/sglang/__init__.py
+++ b/subscriber/subscriber/engine/sglang/__init__.py
@@ -1,0 +1,3 @@
+from subscriber.engine.sglang.adapter import SGLangAdapter
+
+__all__ = ["SGLangAdapter"]

--- a/subscriber/subscriber/engine/sglang/adapter.py
+++ b/subscriber/subscriber/engine/sglang/adapter.py
@@ -1,0 +1,160 @@
+"""SGLang adapter composed from shared ZMQ transport and gRPC control."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.base import AbstractEngineAdapter, EngineEventBatch
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.metadata import KvEventBootstrap, MetadataProtocolError
+from subscriber.engine.sglang.control import SglangControl
+from subscriber.engine.sglang.incremental import SglangIncrementalSource
+from subscriber.engine.sglang.snapshot import SglangSnapshotSource
+from subscriber.engine.worker_status_client import DashllmWorkerStatusClient
+from subscriber.health.events import LivenessEvent
+
+_KVCM_MEDIUM_MAP = {
+    "GPU": "hbm",
+    "CPU_PINNED": "mem",
+}
+
+
+@AbstractEngineAdapter.register("sglang")
+class SGLangAdapter(AbstractEngineAdapter):
+    """Adapt SGLang KV events and DashLLM control RPCs to subscriber contracts."""
+
+    def __init__(self, config: SubscriberConfig) -> None:
+        self._config = config
+        self._status_client = DashllmWorkerStatusClient(config.engine_grpc_endpoint)
+        self._kv_event_control_client = DashllmKvEventControlClient(
+            config.engine_kv_event_control_uds_path
+        )
+        self._incremental: SglangIncrementalSource | None = None
+        self._snapshot: SglangSnapshotSource | None = None
+        self._control = SglangControl(
+            config, self._status_client, self._kv_event_control_client
+        )
+
+    async def subscribe_kv_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield SGLang live and replay batches in source order."""
+
+        if self._incremental is None:
+            raise RuntimeError("SGLang bootstrap must be fetched before subscription")
+        events = self._incremental.subscribe()
+        try:
+            async for event_batch in events:
+                yield event_batch
+        finally:
+            await events.aclose()
+
+    async def subscribe_snapshot_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield periodic full snapshots for KVCM reconciliation."""
+
+        if self._snapshot is None:
+            raise RuntimeError("SGLang bootstrap must be fetched before subscription")
+        events = self._snapshot.subscribe()
+        try:
+            async for event_batch in events:
+                yield event_batch
+        finally:
+            await events.aclose()
+
+    async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+        """Reuse DashLLM's existing GetWorkerStatus control-plane interface."""
+
+        async for event in self._control.watch_liveness():
+            yield event
+
+    async def fetch_kv_event_bootstrap(self) -> KvEventBootstrap:
+        """Fetch bootstrap and construct component-aware SGLang ZMQ sockets."""
+
+        bootstrap = await self._control.fetch_kv_event_bootstrap()
+        # TODO(multi-dp): discover and aggregate one transport per engine DP rank.
+        if bootstrap.runtime_topology.data_parallel_size != 1:
+            raise MetadataProtocolError(
+                "subscriber currently supports only data_parallel_size=1"
+            )
+        if self._config.snapshot_kv_event_pipeline_enabled:
+            if not bootstrap.snapshot.supported:
+                raise MetadataProtocolError(
+                    "SGLang snapshot transport must be supported"
+                )
+            if not bootstrap.snapshot.versioned:
+                raise MetadataProtocolError(
+                    "SGLang snapshot transport must be versioned"
+                )
+        if (
+            self._config.incremental_kv_event_pipeline_enabled
+            and not bootstrap.event_transport.replay_supported
+        ):
+            raise MetadataProtocolError("SGLang event replay must be supported")
+        component_ids = {
+            component.component_id: component.component_id
+            for component in bootstrap.components
+        }
+        if (
+            self._config.incremental_kv_event_pipeline_enabled
+            and self._incremental is None
+        ):
+            self._incremental = SglangIncrementalSource(
+                self._config,
+                endpoint=DpEndpoint(
+                    rank=bootstrap.runtime_topology.data_parallel_rank,
+                    zmq_pub_endpoint=bootstrap.event_transport.live_endpoint,
+                    zmq_replay_endpoint=bootstrap.event_transport.replay_endpoint,
+                    zmq_topic=bootstrap.event_transport.topic,
+                ),
+                component_group_idxs=component_ids,
+            )
+        if self._config.snapshot_kv_event_pipeline_enabled and self._snapshot is None:
+            self._snapshot = SglangSnapshotSource(
+                self._config,
+                self._kv_event_control_client,
+                component_group_idxs=component_ids,
+            )
+        return bootstrap
+
+    async def close(self) -> None:
+        """Release the shared transport, control helper, and gRPC channel."""
+
+        try:
+            await self._control.close()
+        finally:
+            try:
+                if self._snapshot is not None:
+                    await self._snapshot.close()
+            finally:
+                try:
+                    if self._incremental is not None:
+                        await self._incremental.close()
+                finally:
+                    try:
+                        await self._status_client.close()
+                    finally:
+                        await self._kv_event_control_client.close()
+
+    async def reset_generation_state(self) -> None:
+        """Discard source sequence state after a SGLang generation transition."""
+
+        if self._incremental is not None:
+            await self._incremental.reset_generation_state()
+        if self._snapshot is not None:
+            await self._snapshot.reset_generation_state()
+
+    def request_immediate_snapshot(self) -> None:
+        """Wake the SGLang full-snapshot polling loop after bootstrap."""
+
+        if self._snapshot is not None:
+            self._snapshot.request_immediate_snapshot()
+
+    def map_medium(self, medium: str | None) -> str:
+        if medium is None:
+            return ""
+        return _KVCM_MEDIUM_MAP.get(medium, "")
+
+    def supported_mediums(self) -> list[str]:
+        return list(_KVCM_MEDIUM_MAP.values())
+
+    def storage_type(self) -> str:
+        return self._config.kvcm_storage_type

--- a/subscriber/subscriber/engine/sglang/control.py
+++ b/subscriber/subscriber/engine/sglang/control.py
@@ -1,0 +1,54 @@
+"""SGLang validation for the shared DashLLM KV-event control plane."""
+
+from __future__ import annotations
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.metadata import (
+    KvEventBootstrap,
+    MetadataProtocolError,
+)
+from subscriber.engine.vllm.control import VllmControl
+from subscriber.engine.worker_status_client import DashllmWorkerStatusClient
+from subscriber.kvcm.kinds import validate_extra_attention_types
+
+_SUPPORTED_COMPONENT_KINDS = frozenset({"full_attention", "sliding_window", "mamba"})
+_SUPPORTED_CACHE_KEY_MODES = frozenset({"token", "bigram"})
+
+
+class SglangControl(VllmControl):
+    """Reuse TCP liveness and validate SGLang-specific bootstrap semantics."""
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        status_client: DashllmWorkerStatusClient,
+        kv_event_control_client: DashllmKvEventControlClient,
+    ) -> None:
+        super().__init__(config, status_client, kv_event_control_client)
+        validate_extra_attention_types(config.extra_attention_types)
+        self._supported_component_kinds = _SUPPORTED_COMPONENT_KINDS.union(
+            config.extra_attention_types
+        )
+
+    @property
+    def _engine_kind(self) -> str:
+        return "sglang"
+
+    async def fetch_kv_event_bootstrap(self) -> KvEventBootstrap:
+        bootstrap = await super().fetch_kv_event_bootstrap()
+        schema = bootstrap.sglang
+        if schema is None:
+            raise MetadataProtocolError("SGLang bootstrap is missing its schema")
+        if schema.cache_key_mode not in _SUPPORTED_CACHE_KEY_MODES:
+            raise MetadataProtocolError(
+                "SGLang bootstrap has unsupported cache_key_mode "
+                f"{schema.cache_key_mode!r}"
+            )
+        for component in bootstrap.components:
+            if component.component_kind not in self._supported_component_kinds:
+                raise MetadataProtocolError(
+                    "SGLang bootstrap has unsupported component_kind "
+                    f"{component.component_kind!r}"
+                )
+        return bootstrap

--- a/subscriber/subscriber/engine/sglang/incremental.py
+++ b/subscriber/subscriber/engine/sglang/incremental.py
@@ -1,0 +1,255 @@
+"""SGLang msgpack decoding on the shared ZMQ event transport."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+import msgspec
+
+from subscriber import logger
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.debug import summarize_kv_event_batch_for_debug
+from subscriber.engine.zmq_source import ZmqKvEventSource
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockSnapshot,
+    BlockStored,
+    ExternalBlockHash,
+    KVEventBatch,
+)
+
+
+class _SglangWireEvent(
+    msgspec.Struct,
+    array_like=True,
+    omit_defaults=True,
+    gc=False,
+    tag=True,
+):
+    pass
+
+
+class _SglangWireBlockStored(_SglangWireEvent, tag="BlockStored"):
+    block_hashes: list[ExternalBlockHash]
+    parent_block_hash: ExternalBlockHash | None
+    token_ids: list[int | tuple[int, int]]
+    block_size: int
+    lora_id: int | None
+    component_type: str
+    component_id: int | None = None
+    snapshot_version: int = 0
+    medium: str | None = None
+
+
+class _SglangWireBlockRemoved(_SglangWireEvent, tag="BlockRemoved"):
+    block_hashes: list[ExternalBlockHash]
+    component_type: str
+    component_id: int | None = None
+    snapshot_version: int = 0
+    medium: str | None = None
+
+
+class _SglangWireAllBlocksCleared(_SglangWireEvent, tag="AllBlocksCleared"):
+    pass
+
+
+class _SglangWireBatch(msgspec.Struct, array_like=True, gc=False):
+    ts: float
+    events: list[
+        _SglangWireBlockStored | _SglangWireBlockRemoved | _SglangWireAllBlocksCleared
+    ]
+    attn_dp_rank: int | None = None
+
+
+_SUPPORTED_MEDIA = {"GPU", "CPU_PINNED"}
+_DROP_LOG_INTERVAL_S = 60.0
+
+
+class _DropLogLimiter:
+    """Emit a first detailed drop log and one periodic aggregate per reason."""
+
+    def __init__(self) -> None:
+        self._last_log_s: dict[str, float] = {}
+        self._suppressed_counts: dict[str, int] = {}
+
+    def record(self, reason: str) -> int | None:
+        """Return aggregated count when this drop should be logged."""
+
+        self._suppressed_counts[reason] = self._suppressed_counts.get(reason, 0) + 1
+        now_s = time.monotonic()
+        last_log_s = self._last_log_s.get(reason)
+        if last_log_s is not None and now_s - last_log_s < _DROP_LOG_INTERVAL_S:
+            return None
+        self._last_log_s[reason] = now_s
+        count = self._suppressed_counts[reason]
+        self._suppressed_counts[reason] = 0
+        return count
+
+
+class SglangIncrementalSource(ZmqKvEventSource):
+    """Decode SGLang component events with descriptor-owned component mapping."""
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        *,
+        component_group_idxs: Mapping[int, int],
+        endpoint: DpEndpoint,
+    ) -> None:
+        self._component_group_idxs = dict(component_group_idxs)
+        self._decoder = msgspec.msgpack.Decoder(type=_SglangWireBatch)
+        self._drop_log_limiter = _DropLogLimiter()
+        super().__init__(config, endpoint=endpoint)
+
+    @property
+    def _logger(self) -> Any:
+        return logger
+
+    @property
+    def _engine_label(self) -> str:
+        return "SGLang"
+
+    @property
+    def _connect_log_message(self) -> str:
+        return "connecting SGLang ZMQ sockets"
+
+    @property
+    def _live_message_log_message(self) -> str:
+        return "received SGLang ZMQ live message"
+
+    @property
+    def _decoded_batch_log_message(self) -> str:
+        return "decoded SGLang KV event batch"
+
+    @property
+    def _replay_request_log_message(self) -> str:
+        return "requesting SGLang ZMQ replay"
+
+    @property
+    def _replay_complete_log_message(self) -> str:
+        return "completed SGLang ZMQ replay"
+
+    @property
+    def _reset_log_message(self) -> str:
+        return "reset SGLang ZMQ generation state; sockets recreated"
+
+    def set_component_group_idxs(self, component_group_idxs: Mapping[int, int]) -> None:
+        """Replace the descriptor-derived component map before subscription starts."""
+
+        self._component_group_idxs = dict(component_group_idxs)
+
+    def _summarize_batch(self, batch: KVEventBatch) -> dict[str, object]:
+        return summarize_kv_event_batch_for_debug(batch)
+
+    def _log_event_drop(
+        self,
+        reason: str,
+        message: str,
+        *,
+        step: str,
+        tags: dict[str, object],
+    ) -> None:
+        dropped_count = self._drop_log_limiter.record(reason)
+        if dropped_count is not None:
+            logger.warning(
+                message,
+                step=step,
+                tags={**tags, "reason": reason, "dropped_count": dropped_count},
+            )
+
+    def _decode_payload(
+        self,
+        payload: bytes,
+        *,
+        step: str,
+        tags: dict[str, object],
+    ) -> KVEventBatch | None:
+        try:
+            wire_batch = self._decoder.decode(payload)
+        except (msgspec.DecodeError, msgspec.ValidationError, TypeError) as exc:
+            logger.warning(
+                "failed to decode SGLang KV event msgpack payload",
+                step=step,
+                tags={
+                    **tags,
+                    "error": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+            )
+            return None
+
+        events: list[BlockStored | BlockRemoved | AllBlocksCleared | BlockSnapshot] = []
+        for event in wire_batch.events:
+            if isinstance(event, _SglangWireAllBlocksCleared):
+                events.append(AllBlocksCleared())
+                continue
+            # SGLang publishes component_id. Map that engine-native identity to
+            # the common pipeline group_idx consumed by the KVCM translation.
+            component_id = event.component_id
+            group_idx = (
+                self._component_group_idxs.get(component_id)
+                if component_id is not None
+                else None
+            )
+            if group_idx is None:
+                self._log_event_drop(
+                    "unknown_component_type",
+                    "dropping SGLang KV event with unknown component type",
+                    step=step,
+                    tags={
+                        **tags,
+                        "component_id": event.component_id,
+                        "component_type": event.component_type,
+                    },
+                )
+                continue
+            if event.medium not in _SUPPORTED_MEDIA:
+                self._log_event_drop(
+                    "unsupported_medium",
+                    "dropping SGLang KV event with unsupported medium",
+                    step=step,
+                    tags={**tags, "medium": event.medium},
+                )
+                continue
+            if isinstance(event, _SglangWireBlockStored):
+                token_ids = [
+                    token
+                    for value in event.token_ids
+                    for token in (value if isinstance(value, tuple) else (value,))
+                ]
+                events.append(
+                    BlockStored(
+                        block_hashes=event.block_hashes,
+                        parent_block_hash=event.parent_block_hash,
+                        token_ids=token_ids,
+                        block_size=event.block_size,
+                        lora_id=event.lora_id,
+                        medium=event.medium,
+                        lora_name=None,
+                        group_idx=group_idx,
+                        component_id=event.component_id,
+                        kv_cache_spec_kind=event.component_type,
+                        snapshot_version=event.snapshot_version,
+                    )
+                )
+            else:
+                events.append(
+                    BlockRemoved(
+                        block_hashes=event.block_hashes,
+                        medium=event.medium,
+                        group_idx=group_idx,
+                        component_id=event.component_id,
+                        remaining_copy_counts=None,
+                        snapshot_version=event.snapshot_version,
+                    )
+                )
+        if not events:
+            return None
+        return KVEventBatch(
+            ts=wire_batch.ts,
+            events=events,
+            data_parallel_rank=wire_batch.attn_dp_rank,
+        )

--- a/subscriber/subscriber/engine/sglang/snapshot.py
+++ b/subscriber/subscriber/engine/sglang/snapshot.py
@@ -1,0 +1,42 @@
+"""SGLang decoder for the shared DashLLM gRPC snapshot source."""
+
+from __future__ import annotations
+
+import msgspec
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.snapshot import GrpcSnapshotSource, SnapshotSchemaError
+from subscriber.types import BlockSnapshotItem
+
+
+class SglangSnapshotSource(GrpcSnapshotSource):
+    """Poll SGLang's native-hash, component-indexed HBM snapshot."""
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        grpc_client: DashllmKvEventControlClient,
+        *,
+        component_group_idxs: dict[int, int],
+    ) -> None:
+        self._component_group_idxs = dict(component_group_idxs)
+        super().__init__(config, grpc_client, self._decode_sglang_snapshot)
+
+    def _decode_sglang_snapshot(self, raw_snapshot: bytes) -> list[BlockSnapshotItem]:
+        items = msgspec.msgpack.decode(
+            raw_snapshot,
+            type=list[tuple[int, int]],
+        )
+        decoded = []
+        for block_hash, component_id in items:
+            try:
+                group_idx = self._component_group_idxs[component_id]
+            except KeyError as exc:
+                raise SnapshotSchemaError(
+                    f"snapshot contains undeclared component_id={component_id}"
+                ) from exc
+            decoded.append(
+                BlockSnapshotItem(block_hash=block_hash, group_idx=group_idx)
+            )
+        return decoded

--- a/subscriber/subscriber/engine/snapshot.py
+++ b/subscriber/subscriber/engine/snapshot.py
@@ -1,0 +1,213 @@
+"""Engine-neutral polling lifecycle for full KV cache snapshots."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncGenerator, Callable
+from typing import cast
+
+import grpc
+import msgspec
+
+from subscriber import logger
+from subscriber.config import SubscriberConfig
+from subscriber.engine.base import EngineEventBatch
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.metrics import BatchTelemetry
+from subscriber.proto import engine_service_rpc_pb2
+from subscriber.trace import generate_trace_id
+from subscriber.types import BlockSnapshot, BlockSnapshotItem, KVEventBatch
+
+SnapshotDecoder = Callable[[bytes], list[BlockSnapshotItem]]
+
+
+class SnapshotSchemaError(ValueError):
+    """An engine snapshot payload violates its accepted engine schema."""
+
+
+class GrpcSnapshotSource:
+    """Poll DashLLM's UDS snapshot RPC and apply an engine-specific decoder.
+
+    The gRPC client lifecycle is owned by the composing adapter. Generation
+    tracking discards a response when an engine reset spans the in-flight poll.
+    """
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        grpc_client: DashllmKvEventControlClient,
+        decoder: SnapshotDecoder,
+    ) -> None:
+        self._config = config
+        self._grpc_client = grpc_client
+        self._decoder = decoder
+        self._generation = 0
+        self._snapshot_requested = asyncio.Event()
+        self._signal_warned = False
+
+    def request_immediate_snapshot(self) -> None:
+        """Wake the polling loop; repeated pending signals coalesce."""
+        if self._snapshot_requested.is_set():
+            if not self._signal_warned:
+                logger.warning(
+                    "snapshot signal coalesced: previous signal not yet consumed",
+                    step="grpc_snapshot",
+                )
+                self._signal_warned = True
+        else:
+            self._signal_warned = False
+        if logger.is_debug_enabled():
+            logger.debug("snapshot signal received", step="grpc_snapshot")
+        self._snapshot_requested.set()
+
+    async def _wait_interval(self, interval_s: float) -> None:
+        try:
+            await asyncio.wait_for(self._snapshot_requested.wait(), timeout=interval_s)
+        except TimeoutError:
+            pass
+        self._snapshot_requested.clear()
+        self._signal_warned = False
+
+    @staticmethod
+    def _dropped_batch(telemetry: BatchTelemetry, trace_id: str) -> EngineEventBatch:
+        return EngineEventBatch(batches=[], telemetry=telemetry, trace_id=trace_id)
+
+    async def subscribe(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield decoded snapshots and report every failed/discarded poll."""
+        interval_s = self._config.engine_snapshot_full_sync_interval_s
+        while True:
+            telemetry = BatchTelemetry(pipeline="snapshot")
+            trace_id = generate_trace_id()
+            generation = self._generation
+
+            try:
+                response = cast(
+                    engine_service_rpc_pb2.KvCacheBlockListPB,
+                    await self._grpc_client.get_all_kv_cache_blocks(
+                        timeout_s=(
+                            self._config.engine_kvcache_snapshot_timeout_ms / 1000
+                        ),
+                    ),
+                )
+            except grpc.aio.AioRpcError as exc:
+                telemetry.mark("snapshot_fetch")
+                telemetry.mark_dropped("fetch_failed")
+                logger.warning(
+                    "gRPC snapshot poll failed",
+                    step="grpc_snapshot",
+                    tags={
+                        "code": exc.code().name if exc.code() else "UNKNOWN",
+                        "details": exc.details() or "",
+                        "trace_id": trace_id,
+                    },
+                )
+                yield self._dropped_batch(telemetry, trace_id)
+                await self._wait_interval(interval_s)
+                continue
+            except Exception as exc:
+                telemetry.mark("snapshot_fetch")
+                telemetry.mark_dropped("fetch_failed")
+                logger.warning(
+                    "gRPC snapshot poll unexpected error, will retry",
+                    step="grpc_snapshot",
+                    tags={
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                        "trace_id": trace_id,
+                    },
+                )
+                yield self._dropped_batch(telemetry, trace_id)
+                await self._wait_interval(interval_s)
+                continue
+
+            fetch_ms = telemetry.mark("snapshot_fetch") * 1000
+            payload_bytes = response.ByteSize()
+            telemetry.gauge("full_snapshot_payload_bytes", payload_bytes)
+
+            if generation != self._generation:
+                telemetry.mark_dropped("generation_reset")
+                yield self._dropped_batch(telemetry, trace_id)
+                continue
+
+            if not response.raw_snapshot:
+                telemetry.mark_dropped("empty_snapshot")
+                yield self._dropped_batch(telemetry, trace_id)
+                await self._wait_interval(interval_s)
+                continue
+
+            try:
+                items = self._decoder(response.raw_snapshot)
+            except (msgspec.ValidationError, SnapshotSchemaError) as exc:
+                telemetry.mark_dropped("schema_mismatch")
+                logger.warning(
+                    "snapshot schema mismatch",
+                    step="grpc_snapshot",
+                    tags={
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                        "trace_id": trace_id,
+                    },
+                )
+                yield self._dropped_batch(telemetry, trace_id)
+                await self._wait_interval(interval_s)
+                continue
+            except msgspec.DecodeError as exc:
+                telemetry.mark_dropped("decode_failed")
+                logger.warning(
+                    "snapshot msgpack decode failed",
+                    step="grpc_snapshot",
+                    tags={
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                        "trace_id": trace_id,
+                    },
+                )
+                yield self._dropped_batch(telemetry, trace_id)
+                await self._wait_interval(interval_s)
+                continue
+
+            telemetry.mark("decode")
+            batch = KVEventBatch(
+                ts=time.time(),
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=response.block_size,
+                        items=items,
+                        snapshot_version=response.snapshot_version,
+                    )
+                ],
+            )
+            telemetry.mark("snapshot_build")
+
+            if generation != self._generation:
+                telemetry.mark_dropped("generation_reset")
+                yield self._dropped_batch(telemetry, trace_id)
+                continue
+
+            if logger.is_debug_enabled():
+                logger.debug(
+                    "snapshot poll completed",
+                    step="grpc_snapshot",
+                    tags={
+                        "block_count": len(items),
+                        "snapshot_version": response.snapshot_version,
+                        "payload_bytes": payload_bytes,
+                        "fetch_ms": round(fetch_ms, 2),
+                        "trace_id": trace_id,
+                    },
+                )
+
+            yield EngineEventBatch(
+                batches=[batch], telemetry=telemetry, trace_id=trace_id
+            )
+            await self._wait_interval(interval_s)
+
+    async def reset_generation_state(self) -> None:
+        """Advance generation so an in-flight old-engine result is discarded."""
+        self._generation += 1
+
+    async def close(self) -> None:
+        """No-op; the composing adapter owns the shared gRPC client."""
+        return None

--- a/subscriber/subscriber/engine/vllm/__init__.py
+++ b/subscriber/subscriber/engine/vllm/__init__.py
@@ -1,0 +1,3 @@
+from subscriber.engine.vllm.adapter import VllmAdapter
+
+__all__ = ["VllmAdapter"]

--- a/subscriber/subscriber/engine/vllm/adapter.py
+++ b/subscriber/subscriber/engine/vllm/adapter.py
@@ -1,0 +1,155 @@
+"""vLLM engine adapter — composes incremental ZMQ, gRPC control, and snapshot."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.base import AbstractEngineAdapter, EngineEventBatch
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.metadata import KvEventBootstrap, MetadataProtocolError
+from subscriber.engine.vllm.control import VllmControl
+from subscriber.engine.vllm.incremental import VllmIncrementalSource
+from subscriber.engine.vllm.snapshot import VllmSnapshotSource
+from subscriber.engine.worker_status_client import DashllmWorkerStatusClient
+from subscriber.health.events import LivenessEvent
+
+MEDIUM_VLLM_GPU = "GPU"
+MEDIUM_VLLM_CPU = "CPU"
+
+_KVCM_MEDIUM_MAP = {
+    MEDIUM_VLLM_GPU: "hbm",
+    MEDIUM_VLLM_CPU: "mem",
+}
+
+
+@AbstractEngineAdapter.register("vllm")
+class VllmAdapter(AbstractEngineAdapter):
+    """Public vLLM adapter composed of transport, control, and snapshot."""
+
+    def __init__(self, config: SubscriberConfig) -> None:
+        self._config = config
+        self._status_client = DashllmWorkerStatusClient(config.engine_grpc_endpoint)
+        self._kv_event_control_client = DashllmKvEventControlClient(
+            config.engine_kv_event_control_uds_path
+        )
+        self._control = VllmControl(
+            config, self._status_client, self._kv_event_control_client
+        )
+
+        self._incremental: VllmIncrementalSource | None = None
+        self._snapshot: VllmSnapshotSource | None = None
+
+    async def subscribe_kv_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield vLLM ZMQ batches, keeping replay-before-live ordering."""
+
+        if self._incremental is None:
+            raise RuntimeError("vLLM bootstrap must be fetched before subscription")
+        events = self._incremental.subscribe()
+        try:
+            async for event_batch in events:
+                yield event_batch
+        finally:
+            await events.aclose()
+
+    async def subscribe_snapshot_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield periodic full snapshots for kvcm reconciliation."""
+
+        if self._snapshot is None:
+            raise RuntimeError("vLLM bootstrap must be fetched before subscription")
+        events = self._snapshot.subscribe()
+        try:
+            async for event_batch in events:
+                yield event_batch
+        finally:
+            await events.aclose()
+
+    async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+        """Yield gRPC-based health events from the control helper."""
+
+        async for event in self._control.watch_liveness():
+            yield event
+
+    async def fetch_kv_event_bootstrap(self) -> KvEventBootstrap:
+        """Fetch bootstrap and construct ZMQ sockets from engine metadata."""
+
+        bootstrap = await self._control.fetch_kv_event_bootstrap()
+        # TODO(multi-dp): discover and aggregate one transport per engine DP rank.
+        if bootstrap.runtime_topology.data_parallel_size != 1:
+            raise MetadataProtocolError(
+                "subscriber currently supports only data_parallel_size=1"
+            )
+        if self._config.snapshot_kv_event_pipeline_enabled:
+            if not bootstrap.snapshot.supported:
+                raise MetadataProtocolError("vLLM snapshot transport must be supported")
+            if not bootstrap.snapshot.versioned:
+                raise MetadataProtocolError("vLLM snapshot transport must be versioned")
+        if (
+            self._config.incremental_kv_event_pipeline_enabled
+            and not bootstrap.event_transport.replay_supported
+        ):
+            raise MetadataProtocolError("vLLM event replay must be supported")
+        if (
+            self._config.incremental_kv_event_pipeline_enabled
+            and self._incremental is None
+        ):
+            self._incremental = VllmIncrementalSource(
+                self._config,
+                endpoint=DpEndpoint(
+                    rank=bootstrap.runtime_topology.data_parallel_rank,
+                    zmq_pub_endpoint=bootstrap.event_transport.live_endpoint,
+                    zmq_replay_endpoint=bootstrap.event_transport.replay_endpoint,
+                    zmq_topic=bootstrap.event_transport.topic,
+                ),
+                valid_component_ids={
+                    component.component_id for component in bootstrap.components
+                },
+            )
+        if self._config.snapshot_kv_event_pipeline_enabled and self._snapshot is None:
+            self._snapshot = VllmSnapshotSource(
+                self._config,
+                self._kv_event_control_client,
+            )
+        return bootstrap
+
+    async def close(self) -> None:
+        """Release control, snapshot, transport, and the gRPC client."""
+
+        try:
+            await self._control.close()
+        finally:
+            try:
+                if self._snapshot is not None:
+                    await self._snapshot.close()
+            finally:
+                try:
+                    if self._incremental is not None:
+                        await self._incremental.close()
+                finally:
+                    try:
+                        await self._status_client.close()
+                    finally:
+                        await self._kv_event_control_client.close()
+
+    async def reset_generation_state(self) -> None:
+        """Clear sequence state and snapshot generation after recovery."""
+
+        if self._incremental is not None:
+            await self._incremental.reset_generation_state()
+        if self._snapshot is not None:
+            await self._snapshot.reset_generation_state()
+
+    def request_immediate_snapshot(self) -> None:
+        if self._snapshot is not None:
+            self._snapshot.request_immediate_snapshot()
+
+    def map_medium(self, medium: str | None) -> str:
+        if medium is None:
+            return ""
+        return _KVCM_MEDIUM_MAP.get(medium, "")
+
+    def supported_mediums(self) -> list[str]:
+        return list(_KVCM_MEDIUM_MAP.values())
+
+    def storage_type(self) -> str:
+        return self._config.kvcm_storage_type

--- a/subscriber/subscriber/engine/vllm/control.py
+++ b/subscriber/subscriber/engine/vllm/control.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncGenerator
+
+import grpc.aio
+
+from subscriber import logger
+from subscriber.config import SubscriberConfig
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.metadata import (
+    KvEventBootstrap,
+    MetadataProtocolError,
+    MetadataTemporarilyUnavailable,
+    parse_kv_event_bootstrap,
+)
+from subscriber.engine.worker_status_client import DashllmWorkerStatusClient
+from subscriber.health.events import LivenessEvent
+from subscriber.metrics import report_engine_probe
+from subscriber.proto import engine_service_rpc_pb2
+
+_METADATA_RETRY_BASE_S = 0.5
+_METADATA_RETRY_MAX_S = 30.0
+
+_HEALTH_LOG_SUPPRESS_INTERVAL = 12
+
+
+class VllmControl:
+    """Own vLLM health polling and DashLLM metadata control RPCs."""
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        status_client: DashllmWorkerStatusClient,
+        kv_event_control_client: DashllmKvEventControlClient,
+    ) -> None:
+        self._config = config
+        self._status_client = status_client
+        self._kv_event_control_client = kv_event_control_client
+        self._closed = False
+
+    async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+        """Poll engine liveness via gRPC GetWorkerStatus."""
+
+        was_healthy: bool | None = None
+        consecutive_failures = 0
+
+        while True:
+            probe_started_at = time.monotonic()
+            probe_result = "alive"
+            try:
+                status = await self._status_client.get_worker_status(
+                    self._config.engine_kvcache_worker_status_timeout_ms / 1000
+                )
+                event = (
+                    LivenessEvent.HEALTHY if status.alive else LivenessEvent.UNHEALTHY
+                )
+                probe_result = "alive" if status.alive else "dead"
+                if not status.alive and was_healthy is not False:
+                    logger.warning(
+                        "engine health probe reported not alive",
+                        step="engine_health",
+                        tags={
+                            "target": self._config.engine_grpc_endpoint,
+                        },
+                    )
+            except asyncio.CancelledError:
+                raise
+            except grpc.aio.AioRpcError as exc:
+                event = LivenessEvent.UNHEALTHY
+                code = exc.code()
+                probe_result = (
+                    "timeout"
+                    if code is not None and code.name == "DEADLINE_EXCEEDED"
+                    else "rpc_error"
+                )
+                if was_healthy is not False:
+                    logger.warning(
+                        "engine health probe failed",
+                        step="engine_health",
+                        tags={
+                            "error": type(exc).__name__,
+                            "code": code.name if code is not None else "UNKNOWN",
+                            "details": exc.details(),
+                            "target": self._config.engine_grpc_endpoint,
+                        },
+                    )
+            except Exception as exc:
+                event = LivenessEvent.UNHEALTHY
+                probe_result = "rpc_error"
+                if was_healthy is not False:
+                    logger.warning(
+                        "engine health probe failed unexpectedly",
+                        step="engine_health",
+                        tags={
+                            "error": exc.__class__.__name__,
+                            "message": str(exc),
+                            "target": self._config.engine_grpc_endpoint,
+                        },
+                    )
+
+            report_engine_probe(
+                result=probe_result,
+                latency_ms=(time.monotonic() - probe_started_at) * 1000,
+            )
+
+            is_healthy = event is LivenessEvent.HEALTHY
+
+            if not is_healthy:
+                consecutive_failures += 1
+                if was_healthy is False and (
+                    consecutive_failures % _HEALTH_LOG_SUPPRESS_INTERVAL == 0
+                ):
+                    logger.warning(
+                        "engine still unhealthy",
+                        step="engine_health",
+                        tags={
+                            "consecutive_failures": consecutive_failures,
+                            "target": self._config.engine_grpc_endpoint,
+                        },
+                    )
+            else:
+                if was_healthy is False:
+                    logger.info(
+                        "engine health recovered",
+                        step="engine_health",
+                        tags={
+                            "consecutive_failures_before_recovery": (
+                                consecutive_failures
+                            ),
+                            "target": self._config.engine_grpc_endpoint,
+                        },
+                    )
+                consecutive_failures = 0
+
+            was_healthy = is_healthy
+            yield event
+            await asyncio.sleep(self._config.engine_health_interval_s)
+
+    @property
+    def _engine_kind(self) -> str:
+        return "vllm"
+
+    async def fetch_kv_event_bootstrap(self) -> KvEventBootstrap:
+        """Fetch and validate bootstrap with bounded exponential backoff.
+
+        Retryable failures (transport errors and explicit UNAVAILABLE responses)
+        exhaust the bounded per-attempt retry policy, then raise
+        :class:`MetadataTemporarilyUnavailable`. Non-retryable failures (any
+        other explicit error code, or a malformed response) raise
+        :class:`MetadataProtocolError` immediately. A successful response returns
+        :class:`KvEventBootstrap`; an empty component tuple is valid.
+        """
+
+        max_retries = self._config.engine_kv_event_bootstrap_max_retries
+        delay = _METADATA_RETRY_BASE_S
+        for attempt in range(1, max_retries + 1):
+            try:
+                payload = (
+                    await self._kv_event_control_client.get_kv_event_bootstrap_info(
+                        self._config.engine_kv_event_bootstrap_timeout_ms / 1000
+                    )
+                )
+                if (
+                    payload.err_code
+                    == engine_service_rpc_pb2.KV_EVENT_BOOTSTRAP_UNAVAILABLE
+                ):
+                    raise MetadataTemporarilyUnavailable(
+                        f"DashLLM bootstrap unavailable: {payload.err_msg}"
+                    )
+                metadata = parse_kv_event_bootstrap(
+                    payload,
+                    expected_engine_kind=self._engine_kind,
+                    require_incremental_transport=(
+                        self._config.incremental_kv_event_pipeline_enabled
+                    ),
+                )
+            except asyncio.CancelledError:
+                raise
+            except MetadataProtocolError:
+                logger.warning(
+                    "received non-retryable kv event bootstrap response",
+                    step="kv_metadata",
+                    tags={
+                        "target": self._config.engine_kv_event_control_uds_path,
+                        "attempt": attempt,
+                    },
+                    exc_info=True,
+                )
+                raise
+            except Exception as exc:
+                if attempt >= max_retries:
+                    logger.warning(
+                        "failed to fetch kv event bootstrap; max retries exhausted",
+                        step="kv_metadata",
+                        tags={
+                            "error": type(exc).__name__,
+                            "message": str(exc),
+                            "target": self._config.engine_kv_event_control_uds_path,
+                            "attempts": attempt,
+                            "max_retries": max_retries,
+                        },
+                    )
+                    raise MetadataTemporarilyUnavailable(
+                        f"kv event bootstrap unavailable after "
+                        f"{max_retries} attempts: {exc}"
+                    ) from exc
+                logger.warning(
+                    "failed to fetch kv event bootstrap; retrying",
+                    step="kv_metadata",
+                    tags={
+                        "error": type(exc).__name__,
+                        "message": str(exc),
+                        "target": self._config.engine_kv_event_control_uds_path,
+                        "retry_in_s": delay,
+                        "attempt": attempt,
+                        "max_retries": max_retries,
+                    },
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, _METADATA_RETRY_MAX_S)
+                continue
+            if logger.is_debug_enabled():
+                logger.debug(
+                    "fetched kv event bootstrap",
+                    step="kv_metadata",
+                    tags={
+                        "component_count": len(metadata.components),
+                        "components": [
+                            {
+                                "component_id": component.component_id,
+                                "kind": component.component_kind,
+                                "block_size": (component.geometry.block_size_tokens),
+                            }
+                            for component in metadata.components
+                        ],
+                    },
+                )
+            return metadata
+        raise AssertionError("unreachable")
+
+    async def close(self) -> None:
+        """Mark control as closed. The gRPC client is owned by the adapter."""
+
+        if self._closed:
+            return
+        self._closed = True

--- a/subscriber/subscriber/engine/vllm/incremental.py
+++ b/subscriber/subscriber/engine/vllm/incremental.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any
+
+from subscriber import logger
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.debug import summarize_kv_event_batch_for_debug
+from subscriber.engine.zmq_source import ZmqKvEventSource
+from subscriber.metrics import report_zmq_message
+from subscriber.trace import generate_trace_id
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockSnapshot,
+    BlockStored,
+    KVEventBatch,
+)
+from subscriber.utils.msgpack_helper import KVEventBatchMsgpackHelper
+
+
+class VllmIncrementalSource(ZmqKvEventSource):
+    """Decode vLLM payloads on the shared ZMQ live/replay transport."""
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        *,
+        endpoint: DpEndpoint,
+        valid_component_ids: set[int] | None = None,
+    ) -> None:
+        self._msgpack_helper = KVEventBatchMsgpackHelper()
+        self._valid_component_ids = valid_component_ids
+        super().__init__(config, endpoint=endpoint)
+
+    @property
+    def _logger(self) -> Any:
+        return logger
+
+    @property
+    def _engine_label(self) -> str:
+        return "vLLM"
+
+    @property
+    def _connect_log_message(self) -> str:
+        return "connecting vLLM ZMQ sockets"
+
+    @property
+    def _live_message_log_message(self) -> str:
+        return "received vLLM ZMQ live message"
+
+    @property
+    def _decoded_batch_log_message(self) -> str:
+        return "decoded vLLM KV event batch"
+
+    @property
+    def _replay_request_log_message(self) -> str:
+        return "requesting vLLM ZMQ replay"
+
+    @property
+    def _replay_complete_log_message(self) -> str:
+        return "completed vLLM ZMQ replay"
+
+    @property
+    def _reset_log_message(self) -> str:
+        return "reset vLLM ZMQ generation state; sockets recreated"
+
+    def _new_trace_id(self) -> str:
+        return generate_trace_id()
+
+    def _report_zmq_message(self) -> None:
+        report_zmq_message()
+
+    def _decode_payload(
+        self,
+        payload: bytes,
+        *,
+        step: str,
+        tags: dict[str, object],
+    ) -> KVEventBatch | None:
+        batch = self._msgpack_helper.decode(payload, step=step, tags=tags)
+        if batch is None or self._valid_component_ids is None:
+            return batch
+        filtered_events: list[
+            BlockStored | BlockRemoved | AllBlocksCleared | BlockSnapshot
+        ] = []
+        for event in batch.events:
+            if not isinstance(event, (BlockStored, BlockRemoved)):
+                filtered_events.append(event)
+                continue
+            # vLLM's engine-native event identity is group_idx. Bootstrap uses
+            # the engine-neutral name component_id for that same numeric ID.
+            group_idx = event.group_idx
+            if group_idx is None:
+                logger.warning(
+                    "dropping vLLM KV event without group_idx",
+                    step=step,
+                    tags=tags,
+                )
+                continue
+            if group_idx not in self._valid_component_ids:
+                logger.warning(
+                    "dropping vLLM KV event with unknown group_idx",
+                    step=step,
+                    tags={**tags, "group_idx": group_idx},
+                )
+                continue
+            filtered_events.append(event)
+        if not filtered_events:
+            return None
+        if len(filtered_events) == len(batch.events):
+            return batch
+        return KVEventBatch(
+            ts=batch.ts,
+            events=filtered_events,
+            data_parallel_rank=batch.data_parallel_rank,
+        )
+
+    def _summarize_batch(self, batch: KVEventBatch) -> dict[str, object]:
+        return summarize_kv_event_batch_for_debug(batch)

--- a/subscriber/subscriber/engine/vllm/snapshot.py
+++ b/subscriber/subscriber/engine/vllm/snapshot.py
@@ -1,0 +1,32 @@
+"""vLLM decoder for the shared DashLLM gRPC snapshot source."""
+
+from __future__ import annotations
+
+import msgspec
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.snapshot import GrpcSnapshotSource
+from subscriber.types import BlockSnapshotItem
+
+
+class VllmSnapshotSource(GrpcSnapshotSource):
+    """Poll vLLM's group-indexed HBM snapshot over the shared lifecycle."""
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        grpc_client: DashllmKvEventControlClient,
+    ) -> None:
+        super().__init__(config, grpc_client, self._decode_vllm_snapshot)
+
+    @staticmethod
+    def _decode_vllm_snapshot(raw_snapshot: bytes) -> list[BlockSnapshotItem]:
+        items = msgspec.msgpack.decode(
+            raw_snapshot,
+            type=list[tuple[bytes | int, int, int, int]],
+        )
+        return [
+            BlockSnapshotItem(block_hash=block_hash, group_idx=group_idx)
+            for block_hash, group_idx, _, _ in items
+        ]

--- a/subscriber/subscriber/engine/worker_status_client.py
+++ b/subscriber/subscriber/engine/worker_status_client.py
@@ -1,0 +1,66 @@
+"""Remote TCP client for the FlexLB-compatible DashLLM worker-status RPC."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import grpc
+
+from subscriber.engine.grpc_options import CHANNEL_OPTIONS
+from subscriber.proto import engine_service_rpc_pb2, engine_service_rpc_pb2_grpc
+
+
+class DashllmWorkerStatusClient:
+    """Own the remote status channel and its monotonic request cursors."""
+
+    def __init__(self, target: str) -> None:
+        self._target = target
+        self._channel: grpc.aio.Channel | None = None
+        self._service: engine_service_rpc_pb2_grpc.RpcServiceStub | None = None
+        self._status_version = -1
+        self._latest_cache_version = 0
+        self._latest_finished_version = -1
+
+    def _get_service(self) -> engine_service_rpc_pb2_grpc.RpcServiceStub:
+        if self._service is None:
+            self._channel = grpc.aio.insecure_channel(
+                self._target, options=CHANNEL_OPTIONS
+            )
+            stub_factory = cast(
+                Callable[
+                    [grpc.aio.Channel],
+                    engine_service_rpc_pb2_grpc.RpcServiceStub,
+                ],
+                engine_service_rpc_pb2_grpc.RpcServiceStub,
+            )
+            self._service = stub_factory(self._channel)
+        return self._service
+
+    async def get_worker_status(
+        self, timeout_s: float
+    ) -> engine_service_rpc_pb2.WorkerStatusPB:
+        """Probe liveness and advance the accepted finished cursor."""
+
+        request = engine_service_rpc_pb2.StatusVersionPB(
+            latest_cache_version=self._latest_cache_version,
+            latest_finished_version=self._latest_finished_version,
+        )
+        response = await self._get_service().GetWorkerStatus(request, timeout=timeout_s)
+        typed_response = cast(engine_service_rpc_pb2.WorkerStatusPB, response)
+        if (
+            typed_response.status_version > 0
+            and typed_response.status_version > self._status_version
+        ):
+            self._status_version = typed_response.status_version
+            self._latest_finished_version = typed_response.latest_finished_version
+        return typed_response
+
+    async def close(self) -> None:
+        """Release the remote status channel."""
+
+        channel = self._channel
+        self._channel = None
+        self._service = None
+        if channel is not None:
+            await channel.close()

--- a/subscriber/subscriber/engine/zmq_source.py
+++ b/subscriber/subscriber/engine/zmq_source.py
@@ -1,0 +1,546 @@
+"""Shared ZMQ incremental-event transport for engine adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator, Callable, Mapping
+from typing import Any
+
+import zmq
+import zmq.asyncio
+
+from subscriber import logger
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.base import EngineEventBatch
+from subscriber.metrics import BatchTelemetry, report_zmq_message
+from subscriber.trace import generate_trace_id
+from subscriber.types import KVEventBatch
+
+_END_SEQ = (-1).to_bytes(8, "big", signed=True)
+_RECV_FAILURE_WARN_INTERVAL_S = 5.0
+_RECV_FAILURE_BACKOFF_S = 0.1
+
+
+class _ZmqSequenceGapDiagnostics:
+    """Accumulate best-effort SUB queue observations until a sequence gap."""
+
+    def __init__(
+        self,
+        *,
+        state_reader: Callable[[], Mapping[str, object]],
+    ) -> None:
+        self._state_reader = state_reader
+        self._received_message_bytes = 0
+        self._queue_nonempty_observation_count = 0
+
+    def record_message(
+        self,
+        *,
+        message_bytes: int,
+        queue_nonempty_after_receive: bool,
+    ) -> None:
+        self._received_message_bytes += message_bytes
+        if queue_nonempty_after_receive:
+            self._queue_nonempty_observation_count += 1
+
+    def snapshot_and_reset(self) -> dict[str, object]:
+        tags: dict[str, object] = {}
+        try:
+            tags.update(self._state_reader())
+        except Exception as exc:
+            tags["zmq_queue_state_error"] = type(exc).__name__
+        tags.update(
+            {
+                "zmq_received_message_bytes": self._received_message_bytes,
+                "zmq_queue_nonempty_observation_count": (
+                    self._queue_nonempty_observation_count
+                ),
+            }
+        )
+        self._received_message_bytes = 0
+        self._queue_nonempty_observation_count = 0
+        return tags
+
+
+class ZmqKvEventSource(ABC):
+    """Own the engine-independent ZMQ live/replay state machine.
+
+    Subclasses decode their own msgpack schema while this class keeps the
+    generation-local sequence/replay contract shared by vLLM and SGLang.
+    """
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        *,
+        endpoint: DpEndpoint,
+    ) -> None:
+        self._config = config
+        self._endpoint = endpoint
+        self._ctx = zmq.asyncio.Context.instance()
+        self._last_seq = -1
+        self._generation = 0
+        self._closed = False
+        self._recv_failure_count = 0
+        self._last_recv_warn_s: float | None = None
+        self._logger.info(
+            self._connect_log_message,
+            step="zmq_connect",
+            tags={
+                "pub_endpoint": self._endpoint.zmq_pub_endpoint,
+                "replay_endpoint": self._endpoint.zmq_replay_endpoint,
+                "topic": self._endpoint.zmq_topic,
+                "reconnect_ivl_ms": self._config.zmq_reconnect_ivl_ms,
+                "reconnect_ivl_max_ms": self._config.zmq_reconnect_ivl_max_ms,
+            },
+        )
+        self._sub = self._open_sub_socket()
+        self._dealer = self._open_dealer_socket()
+        self._zmq_gap_diagnostics = _ZmqSequenceGapDiagnostics(
+            state_reader=self._zmq_queue_state,
+        )
+
+    @property
+    def _logger(self) -> Any:
+        return logger
+
+    @property
+    def _engine_label(self) -> str:
+        return "engine"
+
+    @property
+    def _connect_log_message(self) -> str:
+        return "connecting engine ZMQ sockets"
+
+    @property
+    def _live_message_log_message(self) -> str:
+        return "received engine ZMQ live message"
+
+    @property
+    def _decoded_batch_log_message(self) -> str:
+        return "decoded engine KV event batch"
+
+    @property
+    def _replay_request_log_message(self) -> str:
+        return "requesting engine ZMQ replay"
+
+    @property
+    def _replay_complete_log_message(self) -> str:
+        return "completed engine ZMQ replay"
+
+    @property
+    def _reset_log_message(self) -> str:
+        return "reset engine ZMQ generation state; sockets recreated"
+
+    def _new_trace_id(self) -> str:
+        return generate_trace_id()
+
+    def _report_zmq_message(self) -> None:
+        report_zmq_message()
+
+    @abstractmethod
+    def _decode_payload(
+        self,
+        payload: bytes,
+        *,
+        step: str,
+        tags: dict[str, object],
+    ) -> KVEventBatch | None:
+        """Decode one engine payload into the subscriber's internal event batch."""
+
+    def _summarize_batch(self, batch: KVEventBatch) -> dict[str, object]:
+        return {
+            "event_count": len(batch.events),
+            "data_parallel_rank": batch.data_parallel_rank,
+        }
+
+    def _open_sub_socket(self) -> zmq.asyncio.Socket:
+        sub = self._ctx.socket(zmq.SUB)
+        self._configure_sub_socket(sub)
+        sub.connect(self._endpoint.zmq_pub_endpoint)
+        sub.setsockopt_string(zmq.SUBSCRIBE, self._endpoint.zmq_topic)
+        return sub
+
+    def _open_dealer_socket(self) -> zmq.asyncio.Socket:
+        dealer = self._ctx.socket(zmq.DEALER)
+        dealer.connect(self._endpoint.zmq_replay_endpoint)
+        return dealer
+
+    def _replace_replay_socket(
+        self, failed_dealer: zmq.asyncio.Socket, generation: int
+    ) -> None:
+        """Discard a failed replay socket so a stale reply cannot be reused."""
+
+        if generation != self._generation or failed_dealer is not self._dealer:
+            return
+        failed_dealer.close(linger=0)
+        self._dealer = self._open_dealer_socket()
+
+    def _configure_sub_socket(self, sub: zmq.asyncio.Socket) -> None:
+        sub.setsockopt(zmq.RECONNECT_IVL, self._config.zmq_reconnect_ivl_ms)
+        sub.setsockopt(
+            zmq.RECONNECT_IVL_MAX,
+            self._config.zmq_reconnect_ivl_max_ms,
+        )
+        if self._config.zmq_tcp_keepalive:
+            sub.setsockopt(zmq.TCP_KEEPALIVE, 1)
+            sub.setsockopt(
+                zmq.TCP_KEEPALIVE_IDLE,
+                self._config.zmq_tcp_keepalive_idle_s,
+            )
+            sub.setsockopt(
+                zmq.TCP_KEEPALIVE_INTVL,
+                self._config.zmq_tcp_keepalive_intvl_s,
+            )
+            sub.setsockopt(
+                zmq.TCP_KEEPALIVE_CNT,
+                self._config.zmq_tcp_keepalive_cnt,
+            )
+        else:
+            sub.setsockopt(zmq.TCP_KEEPALIVE, 0)
+
+    async def subscribe(self) -> AsyncGenerator[EngineEventBatch, None]:
+        """Yield replayed batches before the live batch that exposed a gap."""
+
+        try:
+            while True:
+                received = await self._recv_live_message()
+                if received is None:
+                    continue
+                seq, payload, trace_id = received
+                generation = self._generation
+
+                if seq > self._last_seq + 1:
+                    missed = seq - self._last_seq - 1
+                    replay_trace_id = self._new_trace_id()
+                    diagnostic_tags = self._zmq_gap_diagnostics.snapshot_and_reset()
+                    self._logger.warning(
+                        "kv event sequence gap detected, triggering replay",
+                        step="zmq_replay",
+                        tags={
+                            "last_seq": self._last_seq,
+                            "current_seq": seq,
+                            "missed": missed,
+                            "trace_id": replay_trace_id,
+                            **diagnostic_tags,
+                        },
+                    )
+                    replay_telemetry = BatchTelemetry(pipeline="incremental")
+                    replay_telemetry.count("zmq_sequence_gap_count", 1)
+                    replay_telemetry.count("zmq_missed_message_count", missed)
+                    replay_batches = await self._replay_missing_batches(
+                        seq, generation, replay_trace_id
+                    )
+                    if generation != self._generation:
+                        continue
+                    if replay_batches is not None:
+                        self._last_seq = seq - 1
+                    if replay_batches:
+                        replay_telemetry.mark("replay_fetch")
+                        yield EngineEventBatch(
+                            replay_batches,
+                            replay_telemetry,
+                            trace_id=replay_trace_id,
+                        )
+                    elif replay_batches == []:
+                        self._logger.warning(
+                            "replay returned no batches, publisher buffer may "
+                            "have been pruned",
+                            step="zmq_replay",
+                            tags={
+                                "gap_start_seq": self._last_seq + 1,
+                                "trace_id": replay_trace_id,
+                            },
+                        )
+
+                telemetry = BatchTelemetry(pipeline="incremental")
+                batch = self._decode_payload(
+                    payload,
+                    step="zmq_subscribe",
+                    tags={"seq": seq, "trace_id": trace_id},
+                )
+                if batch is None:
+                    continue
+                telemetry.mark("decode")
+                if self._logger.is_debug_enabled():
+                    self._logger.debug(
+                        self._decoded_batch_log_message,
+                        step="zmq_subscribe",
+                        tags={
+                            "seq": seq,
+                            "trace_id": trace_id,
+                            **self._summarize_batch(batch),
+                        },
+                    )
+                if generation != self._generation:
+                    continue
+                self._last_seq = seq
+                yield EngineEventBatch([batch], telemetry, trace_id=trace_id)
+        finally:
+            self._sub.close(linger=0)
+            self._dealer.close(linger=0)
+
+    async def _recv_live_message(self) -> tuple[int, bytes, str] | None:
+        generation = self._generation
+        sub = self._sub
+        try:
+            frames = await sub.recv_multipart()
+        except Exception as exc:
+            self._recv_failure_count += 1
+            now_s = time.monotonic()
+            if (
+                self._last_recv_warn_s is None
+                or now_s - self._last_recv_warn_s >= _RECV_FAILURE_WARN_INTERVAL_S
+            ):
+                self._last_recv_warn_s = now_s
+                self._logger.warning(
+                    "failed to receive kv event message",
+                    step="zmq_subscribe",
+                    tags={
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                        "consecutive_failures": self._recv_failure_count,
+                    },
+                )
+            await asyncio.sleep(_RECV_FAILURE_BACKOFF_S)
+            return None
+        if self._recv_failure_count > 0:
+            self._logger.info(
+                "kv event message receive recovered",
+                step="zmq_subscribe",
+                tags={"previous_consecutive_failures": self._recv_failure_count},
+            )
+            self._recv_failure_count = 0
+            self._last_recv_warn_s = None
+        if generation != self._generation:
+            return None
+        self._report_zmq_message()
+        self._zmq_gap_diagnostics.record_message(
+            message_bytes=sum(len(frame) for frame in frames),
+            queue_nonempty_after_receive=self._sub_queue_is_readable(sub),
+        )
+        if len(frames) != 3:
+            self._logger.warning(
+                "dropping malformed kv event message frames",
+                step="zmq_subscribe",
+                tags={"frame_count": len(frames)},
+            )
+            return None
+        topic, seq_bytes, payload = frames
+        if len(seq_bytes) != 8:
+            self._logger.warning(
+                "dropping kv event message with invalid sequence frame",
+                step="zmq_subscribe",
+                tags={"seq_frame_len": len(seq_bytes)},
+            )
+            return None
+        seq = int.from_bytes(seq_bytes, "big")
+        trace_id = self._new_trace_id()
+        if self._logger.is_debug_enabled():
+            self._logger.debug(
+                self._live_message_log_message,
+                step="zmq_subscribe",
+                tags={
+                    "topic": topic.decode(errors="replace"),
+                    "seq": seq,
+                    "payload_bytes": len(payload),
+                    "trace_id": trace_id,
+                },
+            )
+        return seq, payload, trace_id
+
+    def _zmq_queue_state(self) -> dict[str, bool | int]:
+        receive_high_water_mark = self._sub.getsockopt(zmq.RCVHWM)
+        if not isinstance(receive_high_water_mark, int):
+            raise TypeError("ZMQ RCVHWM must be an integer")
+        return {
+            "zmq_sub_readable": self._sub_queue_is_readable(self._sub),
+            "zmq_sub_rcvhwm": receive_high_water_mark,
+            "zmq_exact_queue_depth_available": False,
+        }
+
+    @staticmethod
+    def _sub_queue_is_readable(sub: zmq.asyncio.Socket) -> bool:
+        try:
+            events = sub.getsockopt(zmq.EVENTS)
+            return isinstance(events, int) and bool(events & zmq.POLLIN)
+        except Exception:
+            return False
+
+    async def _replay_missing_batches(
+        self, current_seq: int, generation: int, trace_id: str
+    ) -> list[KVEventBatch] | None:
+        gap_start_seq = self._last_seq + 1
+        if self._logger.is_debug_enabled():
+            self._logger.debug(
+                self._replay_request_log_message,
+                step="zmq_replay",
+                tags={
+                    "gap_start_seq": gap_start_seq,
+                    "current_seq": current_seq,
+                    "trace_id": trace_id,
+                },
+            )
+        dealer = self._dealer
+        try:
+            async with asyncio.timeout(self._config.zmq_replay_timeout_s):
+                await dealer.send_multipart([b"", gap_start_seq.to_bytes(8, "big")])
+        except TimeoutError:
+            self._replace_replay_socket(dealer, generation)
+            self._log_replay_unavailable(
+                gap_start_seq,
+                current_seq,
+                error="TimeoutError",
+                message="replay timed out",
+                trace_id=trace_id,
+            )
+            return None
+        except Exception as exc:
+            self._replace_replay_socket(dealer, generation)
+            self._log_replay_unavailable(
+                gap_start_seq,
+                current_seq,
+                error=exc.__class__.__name__,
+                message=str(exc),
+                trace_id=trace_id,
+            )
+            return None
+        if generation != self._generation:
+            return None
+
+        replay_batches: list[KVEventBatch] = []
+        while True:
+            try:
+                async with asyncio.timeout(self._config.zmq_replay_timeout_s):
+                    frames = await dealer.recv_multipart()
+            except TimeoutError:
+                self._replace_replay_socket(dealer, generation)
+                self._log_replay_unavailable(
+                    gap_start_seq,
+                    current_seq,
+                    error="TimeoutError",
+                    message="replay timed out",
+                    trace_id=trace_id,
+                )
+                return None
+            except Exception as exc:
+                self._replace_replay_socket(dealer, generation)
+                self._log_replay_unavailable(
+                    gap_start_seq,
+                    current_seq,
+                    error=exc.__class__.__name__,
+                    message=str(exc),
+                    trace_id=trace_id,
+                )
+                return None
+            if generation != self._generation:
+                return None
+            if len(frames) == 4:
+                _, _, replay_seq_bytes, replay_payload = frames
+            elif len(frames) == 3:
+                _, replay_seq_bytes, replay_payload = frames
+            else:
+                self._replace_replay_socket(dealer, generation)
+                self._logger.warning(
+                    "dropping malformed kv event replay frames",
+                    step="zmq_replay",
+                    tags={
+                        "gap_start_seq": gap_start_seq,
+                        "current_seq": current_seq,
+                        "frame_count": len(frames),
+                        "trace_id": trace_id,
+                    },
+                )
+                return None
+            if replay_seq_bytes == _END_SEQ:
+                if self._logger.is_debug_enabled():
+                    self._logger.debug(
+                        self._replay_complete_log_message,
+                        step="zmq_replay",
+                        tags={
+                            "gap_start_seq": gap_start_seq,
+                            "current_seq": current_seq,
+                            "batch_count": len(replay_batches),
+                            "trace_id": trace_id,
+                        },
+                    )
+                return replay_batches
+            replay_seq = int.from_bytes(replay_seq_bytes, "big")
+            if replay_seq < gap_start_seq or replay_seq >= current_seq:
+                continue
+            batch = self._decode_payload(
+                replay_payload,
+                step="zmq_replay",
+                tags={
+                    "gap_start_seq": gap_start_seq,
+                    "current_seq": current_seq,
+                    "trace_id": trace_id,
+                },
+            )
+            if batch is None:
+                self._replace_replay_socket(dealer, generation)
+                return None
+            if self._logger.is_debug_enabled():
+                self._logger.debug(
+                    self._decoded_batch_log_message,
+                    step="zmq_replay",
+                    tags={
+                        "gap_start_seq": gap_start_seq,
+                        "current_seq": current_seq,
+                        "replay_seq": replay_seq,
+                        "trace_id": trace_id,
+                        **self._summarize_batch(batch),
+                    },
+                )
+            replay_batches.append(batch)
+
+    def _log_replay_unavailable(
+        self,
+        gap_start_seq: int,
+        current_seq: int,
+        *,
+        error: str,
+        message: str,
+        trace_id: str,
+    ) -> None:
+        self._logger.warning(
+            "kv event replay unavailable; sequence gap remains; forwarding live batch",
+            step="zmq_replay",
+            tags={
+                "gap_start_seq": gap_start_seq,
+                "current_seq": current_seq,
+                "error": error,
+                "message": message,
+                "trace_id": trace_id,
+            },
+        )
+
+    async def close(self) -> None:
+        """Close the current ZMQ sockets once."""
+
+        if self._closed:
+            return
+        self._closed = True
+        self._sub.close(linger=0)
+        self._dealer.close(linger=0)
+
+    async def reset_generation_state(self) -> None:
+        """Invalidate in-flight waits and recreate the ZMQ sockets."""
+
+        self._generation += 1
+        self._last_seq = -1
+        self._sub.close(linger=0)
+        self._dealer.close(linger=0)
+        self._sub = self._open_sub_socket()
+        self._dealer = self._open_dealer_socket()
+        self._logger.info(
+            self._reset_log_message,
+            step="zmq_connect",
+            tags={
+                "generation": self._generation,
+                "pub_endpoint": self._endpoint.zmq_pub_endpoint,
+                "replay_endpoint": self._endpoint.zmq_replay_endpoint,
+            },
+        )

--- a/subscriber/subscriber/forwarding.py
+++ b/subscriber/subscriber/forwarding.py
@@ -1,0 +1,602 @@
+"""Queue, gate, merge, and forward engine KV events to KVCM."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncGenerator, Awaitable, Callable
+
+from subscriber import logger
+from subscriber.engine.base import AbstractEngineAdapter, EngineEventBatch
+from subscriber.health.coordinator import EngineHealthCoordinator
+from subscriber.kvcm.client import KvcmClient
+from subscriber.kvcm.errors import KvcmReportError
+from subscriber.metrics import MetricsReporter
+from subscriber.pipeline.block_filter import filter_block_removals
+from subscriber.pipeline.context import PipelineContext
+from subscriber.pipeline.merge import (
+    MergedBatch,
+    dequeue_merged_batches,
+    log_merge_diagnostics,
+)
+from subscriber.types import BlockRemoved, BlockSnapshot, BlockStored, KVEventBatch
+
+_QUEUE_FULL_WARN_INTERVAL_S = 30.0
+
+
+class KvcmDropTracker:
+    """Rate-limits warnings for KV event batches dropped on KVCM failures.
+
+    The first failure is logged immediately. Subsequent failures accumulate
+    dropped batch/event counts and are summarized every ``summary_every``
+    failures or every ``summary_interval_s`` seconds, whichever comes first.
+    This keeps a sustained KVCM outage from spamming the log while still
+    surfacing the first failure and periodic totals.
+    """
+
+    def __init__(
+        self,
+        *,
+        summary_every: int = 100,
+        summary_interval_s: float = 30.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._summary_every = max(1, summary_every)
+        self._summary_interval_s = summary_interval_s
+        self._clock = clock
+        self._dropped_batch_count = 0
+        self._dropped_event_count = 0
+        self._dropped_since_last_summary = 0
+        self._last_summary_at_s = clock()
+
+    @property
+    def dropped_batch_count(self) -> int:
+        return self._dropped_batch_count
+
+    @property
+    def dropped_event_count(self) -> int:
+        return self._dropped_event_count
+
+    def record_drop(
+        self,
+        *,
+        pipeline: str = "incremental",
+        epoch: int,
+        batch_count: int,
+        event_count: int,
+        error: KvcmReportError,
+        trace_id: str | None = None,
+        merged_trace_ids: list[str] | None = None,
+    ) -> None:
+        """Record one dropped batch and emit a rate-limited warning."""
+
+        self._dropped_batch_count += batch_count
+        self._dropped_event_count += event_count
+        if self._dropped_batch_count == batch_count:
+            # First failure: log immediately with full detail.
+            tags: dict[str, object] = {
+                "pipeline": pipeline,
+                "epoch": epoch,
+                "batch_count": batch_count,
+                "event_count": event_count,
+                "error": error.__class__.__name__,
+                "message": str(error),
+                "reason": error.reason,
+                "dropped_batch_total": self._dropped_batch_count,
+                "dropped_event_total": self._dropped_event_count,
+            }
+            if trace_id is not None:
+                tags["trace_id"] = trace_id
+            if merged_trace_ids is not None:
+                tags["merged_trace_ids"] = merged_trace_ids
+            logger.warning(
+                "failed to send kv event batch to kvcm; dropping batch",
+                step="kvcm_send",
+                tags=tags,
+            )
+            self._last_summary_at_s = self._clock()
+            return
+
+        self._dropped_since_last_summary += batch_count
+        now_s = self._clock()
+        due_by_count = self._dropped_since_last_summary >= self._summary_every
+        due_by_time = (now_s - self._last_summary_at_s) >= self._summary_interval_s
+        if not (due_by_count or due_by_time):
+            return
+        logger.warning(
+            "kvcm send failures continue; dropping batches",
+            step="kvcm_send",
+            tags={
+                "pipeline": pipeline,
+                "epoch": epoch,
+                "error": error.__class__.__name__,
+                "message": str(error),
+                "reason": error.reason,
+                "dropped_batch_since_summary": self._dropped_since_last_summary,
+                "dropped_batch_total": self._dropped_batch_count,
+                "dropped_event_total": self._dropped_event_count,
+            },
+        )
+        self._dropped_since_last_summary = 0
+        self._last_summary_at_s = now_s
+
+
+def _mark_stage(queued_items: list[PipelineContext], stage: str) -> None:
+    for item in queued_items:
+        item.mark(stage)
+
+
+def _trace_tags(queued_items: list[PipelineContext]) -> dict[str, object]:
+    """Build structured-log tags that identify one merged KVCM report."""
+
+    return {
+        "trace_id": queued_items[0].trace_id,
+        "merged_trace_ids": [item.trace_id for item in queued_items],
+    }
+
+
+def _record_merged_request_gauges(
+    merged: MergedBatch,
+    *,
+    send_started_at_s: float,
+) -> None:
+    """Record dimensions once on the telemetry representing one merged request.
+
+    The first queued item owns request-level gauges because all merged items
+    produce one physical KVCM ReportEvent. Per-item latency spans and terminal
+    submission remain owned by their respective ``PipelineContext`` objects.
+    """
+
+    try:
+        telemetry = merged.queued_items[0].telemetry
+        telemetry.gauge("kvcm_merged_queue_item_count", len(merged.queued_items))
+        telemetry.gauge("kvcm_source_batch_count", merged.source_batch_count)
+        telemetry.gauge("kvcm_source_event_count", merged.source_event_count)
+        telemetry.gauge("kvcm_merged_report_event_count", merged.report_event_count)
+        telemetry.gauge("kvcm_queue_size_before_merge", merged.queue_qsize_before_merge)
+        telemetry.gauge("kvcm_queue_size_after_merge", merged.queue_qsize_after_merge)
+        oldest_enqueue_to_send_s = merged.queued_items[
+            0
+        ].telemetry.elapsed_since_checkpoint(
+            "queue_enqueued",
+            at_s=send_started_at_s,
+        )
+        if oldest_enqueue_to_send_s is not None:
+            telemetry.gauge(
+                "kvcm_oldest_enqueue_to_send_ms", oldest_enqueue_to_send_s * 1000
+            )
+        newest_enqueue_to_send_s = merged.queued_items[
+            -1
+        ].telemetry.elapsed_since_checkpoint(
+            "queue_enqueued",
+            at_s=send_started_at_s,
+        )
+        if newest_enqueue_to_send_s is not None:
+            telemetry.gauge(
+                "kvcm_newest_enqueue_to_send_ms", newest_enqueue_to_send_s * 1000
+            )
+    except Exception:
+        pass
+
+
+def _submit_dropped(
+    queued_items: list[PipelineContext],
+    reason: str,
+) -> None:
+    """Mark and submit every queued item as dropped with the given reason."""
+
+    for item in queued_items:
+        item.submit_dropped(reason)
+
+
+async def _notify_metadata_protocol_error(
+    callback: Callable[[], Awaitable[None]] | None,
+) -> None:
+    """Best-effort notify lifecycle of a local descriptor/event mismatch."""
+
+    if callback is None:
+        return
+    try:
+        await callback()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "failed to report metadata protocol failure to DashServing",
+            step="kvcm_send",
+            tags={"error": exc.__class__.__name__, "message": str(exc)},
+            exc_info=True,
+        )
+
+
+def _submit_incremental_success(
+    batches: list[KVEventBatch],
+    merged: MergedBatch,
+) -> None:
+    """Submit telemetries after a successful send.
+
+    Aggregate counters (stored/removed block hash counts) are attributed to the
+    first queued item so each physical block hash is counted once per merged
+    send, matching the pre-refactor behavior. The ``event_expand`` and
+    ``kvcm_send`` stage marks are applied by :meth:`KvcmClient.report_kv_events`
+    directly on each telemetry.
+    """
+
+    stored_block_hash_count = sum(
+        len(event.block_hashes)
+        for batch in batches
+        for event in batch.events
+        if isinstance(event, BlockStored)
+    )
+    removed_block_hash_count = sum(
+        len(event.block_hashes)
+        for batch in batches
+        for event in batch.events
+        if isinstance(event, BlockRemoved)
+    )
+    for index, item in enumerate(merged.queued_items):
+        if index == 0:
+            item.telemetry.count("stored_block_hash_count", stored_block_hash_count)
+            item.telemetry.count("removed_block_hash_count", removed_block_hash_count)
+        item.submit()
+
+
+def _submit_snapshot_success(
+    queued: PipelineContext,
+    batches: list[KVEventBatch],
+) -> None:
+    """Submit snapshot counters after a successful send.
+
+    Snapshot counterpart of :func:`_submit_success`: a snapshot batch is never
+    merged, so the counters are attributed to the single queued item directly.
+    The ``snapshot_build`` and ``kvcm_send`` stage marks are applied by
+    :meth:`KvcmClient.report_snapshot` directly on the telemetry.
+    """
+
+    block_count = 0
+    for batch in batches:
+        for event in batch.events:
+            if isinstance(event, BlockSnapshot):
+                block_count += len(event.items)
+    queued.telemetry.count("snapshot_block_count", block_count)
+    queued.submit()
+
+
+async def _consume_engine_events(
+    events: AsyncGenerator[EngineEventBatch, None],
+    coordinator: EngineHealthCoordinator,
+    queue: asyncio.Queue[PipelineContext],
+    reporter: MetricsReporter,
+    *,
+    pipeline: str,
+) -> None:
+    """Capture, enqueue, and time one engine event stream.
+
+    Adapters may yield an event whose telemetry is already marked dropped
+    (for example, a snapshot poll that failed the gRPC round-trip). Those
+    events are reported through the pipeline's metrics reporter but never
+    enqueued for downstream forwarding — the adapter has already logged the
+    reason.
+
+    Batches captured while the engine is not ready (no sendable epoch) are
+    marked as dropped on their own telemetry and submitted to the reporter
+    here, which fans out the drop-count metric and any partial-stage spans.
+    """
+
+    last_queue_full_warn_s: float | None = None
+    try:
+        async for event in events:
+            if event.telemetry.drop_reason is not None:
+                # Adapter-originated drop: report it and skip enqueue.
+                reporter.submit(event.telemetry)
+                continue
+            epoch_snapshot = coordinator.capture_epoch()
+            if epoch_snapshot is None:
+                event.telemetry.mark_dropped("engine_not_ready")
+                reporter.submit(event.telemetry)
+                logger.warning(
+                    "dropping pipeline batch captured while engine is not ready",
+                    step="engine_event_consume",
+                    tags={"pipeline": pipeline, "trace_id": event.trace_id},
+                )
+                continue
+            queued = PipelineContext(
+                event=event, epoch_snapshot=epoch_snapshot, reporter=reporter
+            )
+            if queue.full():
+                now_s = time.monotonic()
+                if (
+                    last_queue_full_warn_s is None
+                    or now_s - last_queue_full_warn_s >= _QUEUE_FULL_WARN_INTERVAL_S
+                ):
+                    last_queue_full_warn_s = now_s
+                    logger.warning(
+                        "pipeline queue is full; producer blocked until sender drains",
+                        step="engine_event_consume",
+                        tags={
+                            "pipeline": pipeline,
+                            "queue_maxsize": queue.maxsize,
+                            "trace_id": event.trace_id,
+                        },
+                    )
+            await queue.put(queued)
+            queued.telemetry.checkpoint("queue_enqueued")
+    finally:
+        await events.aclose()
+
+
+async def consume_incremental_events(
+    adapter: AbstractEngineAdapter,
+    coordinator: EngineHealthCoordinator,
+    queue: asyncio.Queue[PipelineContext],
+    reporter: MetricsReporter,
+) -> None:
+    """Enqueue incremental batches captured in a ready engine epoch."""
+
+    await _consume_engine_events(
+        adapter.subscribe_kv_events(),
+        coordinator,
+        queue,
+        reporter,
+        pipeline="incremental",
+    )
+
+
+async def consume_snapshot_events(
+    adapter: AbstractEngineAdapter,
+    coordinator: EngineHealthCoordinator,
+    queue: asyncio.Queue[PipelineContext],
+    reporter: MetricsReporter,
+) -> None:
+    """Enqueue snapshot batches independently from the incremental pipeline."""
+
+    await _consume_engine_events(
+        adapter.subscribe_snapshot_events(),
+        coordinator,
+        queue,
+        reporter,
+        pipeline="snapshot",
+    )
+
+
+async def send_snapshot_events(
+    kvcm: KvcmClient,
+    coordinator: EngineHealthCoordinator,
+    queue: asyncio.Queue[PipelineContext],
+    drop_tracker: KvcmDropTracker | None = None,
+    pipeline: str = "snapshot",
+    on_metadata_protocol_error: Callable[[], Awaitable[None]] | None = None,
+) -> None:
+    """Gate and forward queued full snapshots to kvcm in queue order.
+
+    Each queued snapshot batch is sent individually rather than merged: a
+    snapshot is full state, so contiguous batches are independent reports, not
+    deltas to accumulate. Mirrors :func:`send_incremental_events` minus the merging and
+    block-removal filtering that only apply to incremental deltas. Failures are
+    intentionally lossy — a KVCM control-plane error drops the batch through the
+    rate-limited tracker and continues consuming so the bounded producer queue
+    never stalls the engine snapshot poller. KVCM availability is not a
+    forwarding gate input; the KVCM heartbeat loop owns reconnection.
+    ``asyncio.CancelledError`` and any non-:class:`KvcmReportError` exception
+    propagate.
+    """
+
+    tracker = drop_tracker if drop_tracker is not None else KvcmDropTracker()
+    while True:
+        queued_context = await queue.get()
+        try:
+            queued_context.telemetry.mark("queue_wait")
+            epoch = await coordinator.wait_ready_epoch()
+            queued_context.telemetry.mark("engine_gate_wait")
+            if not coordinator.is_epoch_current(queued_context.epoch_snapshot):
+                _submit_dropped([queued_context], "epoch_changed")
+                logger.warning(
+                    "dropping snapshot batch because engine epoch changed before send",
+                    step="kv_event_loop",
+                    tags={
+                        "pipeline": pipeline,
+                        "trace_id": queued_context.trace_id,
+                        "captured_epoch": queued_context.epoch_snapshot,
+                        "current_epoch": epoch,
+                    },
+                )
+                continue
+            batches = queued_context.batches
+            try:
+                await kvcm.report_snapshot(
+                    batches,
+                    epoch,
+                    telemetry=queued_context.telemetry,
+                    trace_id=queued_context.trace_id,
+                )
+            except KvcmReportError as exc:
+                drop_reason = (
+                    "metadata_protocol"
+                    if exc.reason == "metadata_protocol"
+                    else "send_failed"
+                )
+                _submit_dropped([queued_context], drop_reason)
+                tracker.record_drop(
+                    pipeline=pipeline,
+                    epoch=epoch,
+                    batch_count=len(batches),
+                    event_count=sum(len(batch.events) for batch in batches),
+                    error=exc,
+                    trace_id=queued_context.trace_id,
+                    merged_trace_ids=[queued_context.trace_id],
+                )
+                if drop_reason == "metadata_protocol":
+                    await _notify_metadata_protocol_error(on_metadata_protocol_error)
+                continue
+            _submit_snapshot_success(queued_context, batches)
+        finally:
+            queue.task_done()
+
+
+async def _forward_merged_incremental_batches(
+    kvcm: KvcmClient,
+    coordinator: EngineHealthCoordinator,
+    merged: MergedBatch,
+    drop_tracker: KvcmDropTracker,
+    pipeline: str,
+    on_snapshot_required: Callable[[], None] | None = None,
+    on_metadata_protocol_error: Callable[[], Awaitable[None]] | None = None,
+) -> None:
+    _mark_stage(merged.queued_items, "queue_wait")
+    if len(merged.queued_items) > 1:
+        first_trace = merged.queued_items[0].trace_id
+        for item in merged.queued_items[1:]:
+            item.batch_trace_id = first_trace
+    epoch = await coordinator.wait_ready_epoch()
+    _mark_stage(merged.queued_items, "engine_gate_wait")
+    if not coordinator.is_epoch_current(merged.epoch_snapshot):
+        _submit_dropped(merged.queued_items, "epoch_changed")
+        logger.warning(
+            "dropping kv event batch because engine epoch changed before send",
+            step="kv_event_loop",
+            tags={
+                "pipeline": pipeline,
+                **_trace_tags(merged.queued_items),
+                "captured_epoch": merged.epoch_snapshot,
+                "current_epoch": epoch,
+            },
+        )
+        return
+
+    batches = filter_block_removals(merged.batches)
+    _mark_stage(merged.queued_items, "block_filter")
+    if not batches:
+        _submit_dropped(merged.queued_items, "filtered_empty")
+        return
+    send_started_at_s = time.monotonic()
+    _record_merged_request_gauges(merged, send_started_at_s=send_started_at_s)
+    try:
+        log_merge_diagnostics(
+            merged,
+            pipeline=pipeline,
+            send_started_at_s=send_started_at_s,
+        )
+    except Exception as exc:
+        logger.warning(
+            "failed to log kv event batch diagnostics; continuing with send",
+            step="kvcm_send",
+            tags={
+                "pipeline": pipeline,
+                **_trace_tags(merged.queued_items),
+                "error": exc.__class__.__name__,
+                "message": str(exc),
+            },
+            exc_info=True,
+        )
+    try:
+        # TODO(kvcm-protocol): Align an explicit generation/session or ordering
+        # contract with KVCM. The local engine epoch is not carried in the
+        # ReportEvent payload, so an in-flight old-epoch BLOCK_ADD can race with
+        # HOST_DOWN. This release accepts that limitation and does not add a
+        # local send/HostDown lock until the wire-level contract is agreed.
+        snapshot_required = await kvcm.report_kv_events(
+            batches,
+            epoch,
+            telemetries=[item.telemetry for item in merged.queued_items],
+            trace_id=merged.queued_items[0].trace_id,
+        )
+    except KvcmReportError as exc:
+        # Intentionally lossy: a KVCM control-plane failure must not
+        # backpressure or stop engine serving. Drop this batch, record it
+        # through the rate-limited tracker, and continue consuming. KVCM
+        # availability is not a forwarding gate input; the KVCM heartbeat
+        # loop owns reconnection. asyncio.CancelledError and any
+        # non-KvcmReportError (programming) exception propagate.
+        drop_reason = (
+            "metadata_protocol" if exc.reason == "metadata_protocol" else "send_failed"
+        )
+        _submit_dropped(merged.queued_items, drop_reason)
+        drop_tracker.record_drop(
+            pipeline=pipeline,
+            epoch=epoch,
+            batch_count=len(batches),
+            event_count=sum(len(batch.events) for batch in batches),
+            error=exc,
+            trace_id=merged.queued_items[0].trace_id,
+            merged_trace_ids=[item.trace_id for item in merged.queued_items],
+        )
+        if drop_reason == "metadata_protocol":
+            await _notify_metadata_protocol_error(on_metadata_protocol_error)
+        return
+    if snapshot_required and on_snapshot_required is not None:
+        try:
+            on_snapshot_required()
+        except Exception as exc:
+            logger.warning(
+                "failed to request immediate snapshot; "
+                "continuing incremental forwarding",
+                step="snapshot_signal",
+                tags={
+                    "pipeline": pipeline,
+                    **_trace_tags(merged.queued_items),
+                    "error": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+                exc_info=True,
+            )
+    _submit_incremental_success(batches, merged)
+
+
+async def send_incremental_events(
+    kvcm: KvcmClient,
+    coordinator: EngineHealthCoordinator,
+    queue: asyncio.Queue[PipelineContext],
+    max_merged_report_events: int,
+    max_merged_queue_items: int,
+    drop_tracker: KvcmDropTracker | None = None,
+    pipeline: str = "incremental",
+    on_snapshot_required: Callable[[], None] | None = None,
+    on_metadata_protocol_error: Callable[[], Awaitable[None]] | None = None,
+) -> None:
+    """Merge, gate, and forward queued KV batches in queue order."""
+
+    if max_merged_report_events < 1:
+        raise ValueError("max_merged_report_events must be >= 1")
+    if max_merged_queue_items < 1:
+        raise ValueError("max_merged_queue_items must be >= 1")
+
+    tracker = drop_tracker if drop_tracker is not None else KvcmDropTracker()
+    pending: PipelineContext | None = None
+    try:
+        while True:
+            merged, pending = await dequeue_merged_batches(
+                queue,
+                pending,
+                max_merged_report_events,
+                max_merged_queue_items,
+            )
+            try:
+                await _forward_merged_incremental_batches(
+                    kvcm,
+                    coordinator,
+                    merged,
+                    tracker,
+                    pipeline,
+                    on_snapshot_required,
+                    on_metadata_protocol_error,
+                )
+            finally:
+                for _item in merged.queued_items:
+                    queue.task_done()
+    except asyncio.CancelledError:
+        if pending is not None:
+            logger.info(
+                "dropping pending kv event batch because sender stopped",
+                step="kv_event_loop",
+                tags={
+                    "pipeline": pipeline,
+                    "trace_id": pending.trace_id,
+                    "captured_epoch": pending.epoch_snapshot,
+                    "batch_count": len(pending.batches),
+                    "event_count": sum(len(batch.events) for batch in pending.batches),
+                },
+            )
+        raise
+    finally:
+        if pending is not None:
+            queue.task_done()

--- a/subscriber/subscriber/health/__init__.py
+++ b/subscriber/subscriber/health/__init__.py
@@ -1,0 +1,3 @@
+from subscriber.health.events import LivenessEvent
+
+__all__ = ["LivenessEvent"]

--- a/subscriber/subscriber/health/coordinator.py
+++ b/subscriber/subscriber/health/coordinator.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from enum import Enum
+
+from subscriber import logger
+from subscriber.config import SubscriberConfig
+from subscriber.engine.base import AbstractEngineAdapter
+from subscriber.health.events import LivenessEvent
+from subscriber.kvcm.client import KvcmClient
+from subscriber.metrics import report_engine_state_transition, report_shutdown
+from subscriber.types import AllBlocksCleared, KVEventBatch
+
+
+class EngineHealthState(Enum):
+    STARTING = "starting"
+    HEALTHY = "healthy"
+    DEAD = "dead"
+
+
+class EngineHealthCoordinator:
+    """Coordinate engine liveness, send gating, epochs, and reset emission.
+
+    The coordinator is the only component that decides whether KV events may be
+    forwarded to kvcm. It opens epochs on healthy generations, closes the gate
+    on transient unhealthy events, and emits ``AllBlocksCleared`` only after an
+    established generation reaches the configured failure threshold.
+    """
+
+    def __init__(
+        self,
+        adapter: AbstractEngineAdapter,
+        kvcm_client: KvcmClient | None,
+        config: SubscriberConfig,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._adapter = adapter
+        self._kvcm_client = kvcm_client
+        self._threshold = config.engine_health_failure_threshold
+        self._liveness_retry_interval_s = config.engine_health_interval_s
+        self._host_down_timeout_s = config.subscriber_shutdown_report_timeout_s
+        self._clock = clock or time.time
+        self._state = EngineHealthState.STARTING
+        self._epoch = 0
+        self._failure_count = 0
+        self._ready = asyncio.Event()
+        # Guards the HostDown emit flag so concurrent callers (engine DEAD on the
+        # watch loop and graceful shutdown) cannot both pass the check-and-set.
+        self._host_down_lock = asyncio.Lock()
+        # True once AllBlocksCleared has been emitted for the current sendable
+        # epoch; reset by mark_epoch_sendable() when a new epoch opens.
+        self._host_down_sent = False
+        # True once any epoch became sendable. Unlike the gate (_ready), which
+        # closes on unhealthy, this never clears: it is the cold-start guard for
+        # HostDown emission. A generation that never opened has nothing to clear.
+        self._epoch_sendable = False
+
+    def attach_kvcm_client(self, kvcm_client: KvcmClient) -> None:
+        """Attach the KVCM client after construction.
+
+        Must be called before the coordinator can send reset events
+        (i.e. before the first HEALTHY -> DEAD transition).
+        """
+        self._kvcm_client = kvcm_client
+
+    @property
+    def state(self) -> EngineHealthState:
+        """Current coarse liveness state for the engine generation."""
+
+        return self._state
+
+    @property
+    def epoch(self) -> int:
+        """Current send epoch associated with the active engine generation."""
+
+        return self._epoch
+
+    def capture_epoch(self) -> int | None:
+        """Snapshot the current epoch if the gate is open, else None."""
+
+        if self._ready.is_set():
+            return self._epoch
+        return None
+
+    def is_epoch_current(self, snapshot: int) -> bool:
+        """Return True if the snapshot still matches the active epoch."""
+
+        return snapshot == self._epoch
+
+    def mark_epoch_sendable(self, epoch: int) -> None:
+        """Mark ``epoch`` as sendable, arming HostDown emission for it.
+
+        Opening a sendable epoch means KV batches for it may reach kvcm, so a
+        later engine DEAD or graceful shutdown must emit ``AllBlocksCleared``
+        for it exactly once. Stale epochs (older than the current one) are
+        ignored so a delayed call cannot re-arm a superseded generation.
+        """
+
+        if epoch <= 0 or epoch != self._epoch:
+            return
+        self._epoch_sendable = True
+        self._host_down_sent = False
+
+    async def wait_ready_epoch(self) -> int:
+        """Wait until sending is allowed and return the current epoch."""
+
+        await self._ready.wait()
+        return self._epoch
+
+    async def watch_loop(self) -> None:
+        """Consume liveness streams, retrying after unexpected termination."""
+
+        while True:
+            try:
+                async for event in self._adapter.watch_liveness():
+                    await self.handle_liveness_event(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "engine liveness watch failed; treating as unhealthy and retrying",
+                    step="engine_health",
+                    tags={
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                        "retry_in_s": self._liveness_retry_interval_s,
+                    },
+                    exc_info=True,
+                )
+            else:
+                logger.warning(
+                    "engine liveness watch ended unexpectedly; "
+                    "treating as unhealthy and retrying",
+                    step="engine_health",
+                    tags={"retry_in_s": self._liveness_retry_interval_s},
+                )
+            await self.handle_liveness_event(LivenessEvent.UNHEALTHY)
+            await asyncio.sleep(self._liveness_retry_interval_s)
+
+    async def handle_liveness_event(self, event: LivenessEvent) -> None:
+        """Apply one liveness event to the health state machine."""
+
+        if event is LivenessEvent.HEALTHY:
+            await self._on_healthy()
+            return
+        await self._on_unhealthy()
+
+    async def _on_healthy(self) -> None:
+        if self._state is EngineHealthState.STARTING:
+            self._epoch += 1
+            report_engine_state_transition("starting", "healthy")
+            self._state = EngineHealthState.HEALTHY
+            logger.info(
+                "engine healthy; sendable epoch opened",
+                step="engine_health",
+                tags={"from": "starting", "to": "healthy", "epoch": self._epoch},
+            )
+        elif self._state is EngineHealthState.DEAD:
+            try:
+                await self._adapter.reset_generation_state()
+            except Exception as exc:
+                logger.warning(
+                    "failed to reset engine generation state; remaining not ready",
+                    step="engine_health",
+                    tags={
+                        "epoch": self._epoch,
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                    },
+                    exc_info=True,
+                )
+                return
+            self._epoch += 1
+            report_engine_state_transition("dead", "healthy")
+            self._state = EngineHealthState.HEALTHY
+            logger.info(
+                "engine recovered; new sendable epoch opened",
+                step="engine_health",
+                tags={"from": "dead", "to": "healthy", "epoch": self._epoch},
+            )
+        else:
+            # Already HEALTHY: the sendable epoch is unchanged and HostDown
+            # arming must not be reset (aflap must not re-arm a cleared epoch).
+            self._failure_count = 0
+            self._ready.set()
+            return
+        self.mark_epoch_sendable(self._epoch)
+        self._failure_count = 0
+        self._ready.set()
+
+    async def _on_unhealthy(self) -> None:
+        if self._state is EngineHealthState.DEAD:
+            return
+        self._failure_count += 1
+        if self._state is EngineHealthState.STARTING:
+            if self._failure_count % self._threshold == 0:
+                logger.warning(
+                    "engine health still unhealthy during startup",
+                    step="engine_health",
+                    tags={
+                        "state": self._state.value,
+                        "failure_count": self._failure_count,
+                        "failure_threshold": self._threshold,
+                    },
+                )
+            return
+        self._ready.clear()
+        if self._failure_count >= self._threshold:
+            report_engine_state_transition("healthy", "dead")
+            self._state = EngineHealthState.DEAD
+            logger.error(
+                "engine declared dead after consecutive failures; "
+                "forwarding gate closed",
+                step="engine_health",
+                tags={
+                    "from": "healthy",
+                    "to": "dead",
+                    "epoch": self._epoch,
+                    "failure_count": self._failure_count,
+                    "failure_threshold": self._threshold,
+                },
+            )
+            await self.report_host_down("engine_dead")
+
+    async def report_host_down(
+        self, reason: str, timeout_s: float | None = None
+    ) -> None:
+        """Emit ``AllBlocksCleared`` (EVENT_HOST_DOWN) once per sendable epoch.
+
+        Engine DEAD (on the watch loop) and graceful shutdown both call this;
+        the emit flag makes it idempotent so at most one ``AllBlocksCleared``
+        reaches kvcm for a given sendable epoch. No event is emitted when no
+        epoch ever became sendable (cold startup failure) — there is nothing to
+        clear. The send is bounded by ``timeout_s`` (default: the configured
+        shutdown report timeout) and never raises; a failure or timeout is
+        logged and falls back to KVCM heartbeat expiry.
+        """
+
+        if not self._epoch_sendable:
+            # Cold start: no epoch ever became sendable, so no KV batch was
+            # forwardable and there is no generation to clear.
+            return
+        async with self._host_down_lock:
+            if self._host_down_sent:
+                return
+            # Claim emission before the await so a concurrent caller cannot
+            # pass the guard while this send is in flight.
+            self._host_down_sent = True
+            epoch_snapshot = self._epoch
+        if self._kvcm_client is None:
+            logger.warning(
+                "cannot send all blocks cleared; kvcm client not attached",
+                step="engine_health",
+                tags={"epoch": epoch_snapshot, "reason": reason},
+            )
+            return
+        effective_timeout_s = (
+            self._host_down_timeout_s if timeout_s is None else timeout_s
+        )
+        batch = KVEventBatch(ts=self._clock(), events=[AllBlocksCleared()])
+        try:
+            await asyncio.wait_for(
+                self._kvcm_client.report_kv_events(
+                    [batch],
+                    epoch_snapshot,
+                    reregister_after_host_down=False,
+                ),
+                timeout=effective_timeout_s,
+            )
+        except Exception as exc:
+            report_shutdown(outcome=f"host_down_failed:{reason}")
+            logger.warning(
+                "failed to report all blocks cleared to kvcm",
+                step="engine_health",
+                tags={
+                    "epoch": epoch_snapshot,
+                    "reason": reason,
+                    "timeout_s": effective_timeout_s,
+                    "error": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+                exc_info=True,
+            )
+            return
+        report_shutdown(outcome=f"host_down_sent:{reason}")
+        logger.info(
+            "all blocks cleared reported to kvcm",
+            step="engine_health",
+            tags={"epoch": epoch_snapshot, "reason": reason},
+        )

--- a/subscriber/subscriber/health/events.py
+++ b/subscriber/subscriber/health/events.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class LivenessEvent(Enum):
+    """Engine-independent liveness signal consumed by the health coordinator."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"

--- a/subscriber/subscriber/health/state_reporter.py
+++ b/subscriber/subscriber/health/state_reporter.py
@@ -1,0 +1,453 @@
+"""Ordered subscriber-state reporting to DashServing.
+
+``DashservingStateReporter`` owns the subscriber's local phase
+(starting/active/inactive/failed), a strictly monotonic ``seq_id`` allocator,
+and the active-heartbeat task. Every logical report (startup active, each
+heartbeat, terminal failed/inactive) consumes a fresh sequence number under a
+single short-held ``asyncio.Lock``; the lock is released before any HTTP await.
+
+Ordering authority is DashServing's ``seq_id`` comparison, not a network-duration
+local lock: overlapping POSTs are linearized server-side, so a delayed lower-seq
+active cannot resurrect state after a higher-seq inactive.
+
+Unsupported topology (fail-safe, see plan §1.2): sequence-only ordering assumes a
+single reporter per DashServing process lifetime. An independent subscriber
+restart would reset ``seq_id`` to 1 and be rejected as stale by the surviving
+DashServing. That case must add ``session_id + seq_id`` or a persisted monotonic
+counter; until then it is treated as a loud invariant violation, never silent
+success. TODO(independent-restart): add session identity before supporting it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from enum import Enum
+
+import httpx
+
+from subscriber import logger
+from subscriber.config import SubscriberConfig
+from subscriber.metrics import (
+    report_dashserving_heartbeat,
+    report_dashserving_state_report,
+    report_subscriber_phase_transition,
+)
+
+_STEP = "state_report"
+
+# After the first heartbeat failure warning, repeat a summary at most this often.
+_FAILURE_SUMMARY_INTERVAL_S = 30.0
+
+
+class SubscriberPhase(Enum):
+    """Local subscriber phase reported to DashServing."""
+
+    STARTING = "starting"
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    FAILED = "failed"
+
+
+class StateReportError(RuntimeError):
+    """A logical state report was not accepted by DashServing."""
+
+
+class DashservingStateReporter:
+    """Report subscriber phase to DashServing with monotonic sequence ordering.
+
+    The reporter serializes sequence allocation and local phase mutation under one
+    ``asyncio.Lock`` but never holds it across an HTTP call. ``start_heartbeat``
+    creates and stores its own task; ``stop_heartbeat`` cancels and awaits it.
+    Callers must not assign ``_heartbeat_task`` directly.
+    """
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        clock: Callable[[], float] | None = None,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        self._state_url = config.subscriber_state_url
+        self._heartbeat_interval_s = config.subscriber_heartbeat_interval_s
+        self._request_timeout_s = config.subscriber_state_request_timeout_s
+        self._shutdown_timeout_s = config.subscriber_shutdown_report_timeout_s
+
+        self._http_client = http_client or httpx.AsyncClient()
+        self._owns_client = http_client is None
+        self._clock = clock or time.monotonic
+        self._sleep = sleep or asyncio.sleep
+
+        self._lock = asyncio.Lock()
+        self._next_seq_id = 1
+        self._phase = SubscriberPhase.STARTING
+        self._terminal = False
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+        # Heartbeat failure suppression bookkeeping (touched only by the single
+        # heartbeat task / direct calls; not shared across concurrent producers).
+        self._consecutive_failures = 0
+        self._first_failure_at: float | None = None
+        self._last_summary_at: float | None = None
+
+    @property
+    def phase(self) -> SubscriberPhase:
+        """Current local phase."""
+
+        return self._phase
+
+    @property
+    def next_seq_id(self) -> int:
+        """Sequence number that the next logical report will consume."""
+
+        return self._next_seq_id
+
+    async def report_active(self) -> None:
+        """Report ``active`` and await an accepted 2xx acknowledgement.
+
+        Raises ``httpx`` transport errors, ``StateReportError`` for a non-2xx or
+        malformed response, or for a logical rejection (``accepted=false``). A
+        rejection is a failed report, never a silent success, so startup can rely
+        on a clean return as "active confirmed".
+        """
+
+        async with self._lock:
+            if self._terminal:
+                raise StateReportError(
+                    "cannot report active: reporter is terminal "
+                    f"(phase={self._phase.value})"
+                )
+            seq = self._next_seq_id
+            self._next_seq_id += 1
+
+        # The lock is released before the HTTP await; DashServing's seq_id
+        # comparison, not a network-duration lock, linearizes overlapping reports.
+        started_at = time.monotonic()
+        try:
+            ack = await self._post("active", seq, self._request_timeout_s)
+            self._require_accepted(ack, "active", seq)
+        except Exception:
+            self._record_state_report(
+                "active", "error", (time.monotonic() - started_at) * 1000
+            )
+            raise
+        self._record_state_report(
+            "active", "accepted", (time.monotonic() - started_at) * 1000
+        )
+
+        # Transition only on an accepted acknowledgement, and only STARTING->ACTIVE.
+        # A newer terminal transition (inactive/failed) may have landed while this
+        # report was in flight; guarding on STARTING ensures a late accepted ack
+        # never rolls back the local phase.
+        async with self._lock:
+            if self._phase is SubscriberPhase.STARTING:
+                self._phase = SubscriberPhase.ACTIVE
+                report_subscriber_phase_transition("starting", "active")
+                logger.info(
+                    "subscriber phase transition",
+                    step=_STEP,
+                    tags={
+                        "from": SubscriberPhase.STARTING.value,
+                        "to": "active",
+                        "seq_id": seq,
+                    },
+                )
+
+        logger.debug(
+            "state report accepted",
+            step=_STEP,
+            tags={"state": "active", "seq_id": seq, "last_seq_id": ack.last_seq_id},
+        )
+
+    async def report_failed(self, reason: str) -> None:
+        """Report terminal ``failed``; legal only while locally starting.
+
+        Best-effort: a transport failure is logged and swallowed so it cannot mask
+        the original fatal startup error.
+        """
+
+        async with self._lock:
+            if self._phase is not SubscriberPhase.STARTING:
+                raise StateReportError(
+                    "report_failed is only allowed while starting "
+                    f"(phase={self._phase.value})"
+                )
+            seq = self._next_seq_id
+            self._next_seq_id += 1
+            self._phase = SubscriberPhase.FAILED
+            self._terminal = True
+
+        report_subscriber_phase_transition("starting", "failed")
+        logger.info(
+            "subscriber phase transition",
+            step=_STEP,
+            tags={
+                "from": SubscriberPhase.STARTING.value,
+                "to": "failed",
+                "seq_id": seq,
+                "reason": reason,
+            },
+        )
+        await self._best_effort_post("failed", seq, self._request_timeout_s)
+
+    def start_heartbeat(self) -> None:
+        """Create and store the active-heartbeat task; reject a second start.
+
+        Synchronous and atomic within the event loop (no await point), so the
+        ownership check needs no lock. The task is created here; callers never
+        assign ``_heartbeat_task``.
+        """
+
+        if self._heartbeat_task is not None:
+            raise StateReportError("heartbeat already started")
+        if self._terminal:
+            raise StateReportError(
+                "cannot start heartbeat: reporter is terminal "
+                f"(phase={self._phase.value})"
+            )
+        self._heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(), name="subscriber-state-heartbeat"
+        )
+
+    async def stop_heartbeat(self) -> None:
+        """Cancel and await the heartbeat task, if any. Idempotent."""
+
+        async with self._lock:
+            task = self._heartbeat_task
+            self._heartbeat_task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def report_shutdown_inactive(self, reason: str) -> None:
+        """Gracefully report terminal ``inactive`` with a bounded best-effort POST.
+
+        Stops the heartbeat first so no racing active heartbeat can take a higher
+        sequence than this inactive. Makes the reporter terminal; never raises.
+        """
+
+        await self.stop_heartbeat()
+        async with self._lock:
+            if self._terminal:
+                return
+            seq = self._next_seq_id
+            self._next_seq_id += 1
+            previous = self._phase
+            self._phase = SubscriberPhase.INACTIVE
+            self._terminal = True
+
+        report_subscriber_phase_transition(previous.value, "inactive")
+        logger.info(
+            "subscriber phase transition",
+            step=_STEP,
+            tags={
+                "from": previous.value,
+                "to": "inactive",
+                "seq_id": seq,
+                "reason": reason,
+            },
+        )
+        await self._best_effort_post("inactive", seq, self._shutdown_timeout_s)
+
+    async def close(self) -> None:
+        """Stop the heartbeat and release the owned HTTP client. Idempotent."""
+
+        if self._closed:
+            return
+        self._closed = True
+        await self.stop_heartbeat()
+        if self._owns_client:
+            await self._http_client.aclose()
+
+    async def _heartbeat_loop(self) -> None:
+        try:
+            while True:
+                await self._sleep(self._heartbeat_interval_s)
+                await self._send_heartbeat_once()
+        except asyncio.CancelledError:
+            logger.debug("state heartbeat cancelled", step=_STEP, tags={})
+            raise
+
+    async def _send_heartbeat_once(self) -> None:
+        async with self._lock:
+            if self._terminal:
+                return
+            seq = self._next_seq_id
+            self._next_seq_id += 1
+
+        started_at = time.monotonic()
+        try:
+            ack = await self._post("active", seq, self._request_timeout_s)
+            self._require_accepted(ack, "active", seq)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._record_state_report(
+                "active", "error", (time.monotonic() - started_at) * 1000
+            )
+            self._note_heartbeat_failure(
+                error=exc.__class__.__name__, message=str(exc), seq_id=seq
+            )
+            return
+
+        self._record_state_report(
+            "active", "accepted", (time.monotonic() - started_at) * 1000
+        )
+        self._note_heartbeat_success()
+        logger.debug(
+            "state heartbeat accepted",
+            step=_STEP,
+            tags={"state": "active", "seq_id": seq, "last_seq_id": ack.last_seq_id},
+        )
+
+    def _note_heartbeat_failure(self, *, error: str, message: str, seq_id: int) -> None:
+        report_dashserving_heartbeat(success=False)
+        now = self._clock()
+        self._consecutive_failures += 1
+        if self._first_failure_at is None:
+            self._first_failure_at = now
+            self._last_summary_at = now
+            logger.warning(
+                "state heartbeat failed; will retry next interval",
+                step=_STEP,
+                tags={"error": error, "message": message, "seq_id": seq_id},
+            )
+            return
+        assert self._last_summary_at is not None
+        if now - self._last_summary_at >= _FAILURE_SUMMARY_INTERVAL_S:
+            self._last_summary_at = now
+            logger.warning(
+                "state heartbeat still failing",
+                step=_STEP,
+                tags={
+                    "consecutive_failures": self._consecutive_failures,
+                    "for_s": round(now - self._first_failure_at, 3),
+                    "last_error": error,
+                    "last_message": message,
+                },
+            )
+
+    def _note_heartbeat_success(self) -> None:
+        report_dashserving_heartbeat(success=True)
+        if self._consecutive_failures > 0:
+            logger.info(
+                "state heartbeat recovered",
+                step=_STEP,
+                tags={"previous_consecutive_failures": self._consecutive_failures},
+            )
+        self._consecutive_failures = 0
+        self._first_failure_at = None
+        self._last_summary_at = None
+
+    def _record_state_report(self, state: str, result: str, latency_ms: float) -> None:
+        """Best-effort metric recording; never raises."""
+        report_dashserving_state_report(state, result, latency_ms)
+
+    async def _best_effort_post(self, state: str, seq: int, timeout_s: float) -> None:
+        started_at = time.monotonic()
+        try:
+            ack = await self._post(state, seq, timeout_s)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._record_state_report(
+                state, "error", (time.monotonic() - started_at) * 1000
+            )
+            logger.warning(
+                "terminal state report failed; DashServing falls back to TTL",
+                step=_STEP,
+                tags={
+                    "state": state,
+                    "seq_id": seq,
+                    "error": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+            )
+            return
+        if not ack.accepted:
+            self._record_state_report(
+                state, "stale", (time.monotonic() - started_at) * 1000
+            )
+            logger.warning(
+                "terminal state report not accepted",
+                step=_STEP,
+                tags={"state": state, "seq_id": seq, "last_seq_id": ack.last_seq_id},
+            )
+            return
+        self._record_state_report(
+            state, "accepted", (time.monotonic() - started_at) * 1000
+        )
+        logger.debug(
+            "state report accepted",
+            step=_STEP,
+            tags={"state": state, "seq_id": seq, "last_seq_id": ack.last_seq_id},
+        )
+
+    def _require_accepted(self, ack: _Ack, state: str, seq: int) -> None:
+        if ack.accepted:
+            return
+        if ack.last_seq_id > seq:
+            # A higher sequence already won. Under the single-reporter deployment
+            # invariant this is impossible from one process: either an independent
+            # restart reset our counter (unsupported, see module TODO) or sequences
+            # are corrupted. Loud invariant warning, and a failed logical report.
+            logger.warning(
+                "state report rejected: server already advanced past our sequence "
+                "(invariant violation under single-reporter assumption)",
+                step=_STEP,
+                tags={"state": state, "seq_id": seq, "last_seq_id": ack.last_seq_id},
+            )
+        else:
+            logger.warning(
+                "state report rejected as duplicate/stale",
+                step=_STEP,
+                tags={"state": state, "seq_id": seq, "last_seq_id": ack.last_seq_id},
+            )
+        raise StateReportError(
+            f"{state} report seq={seq} not accepted "
+            f"(server last_seq_id={ack.last_seq_id})"
+        )
+
+    async def _post(self, state: str, seq: int, timeout_s: float) -> _Ack:
+        response = await self._http_client.post(
+            self._state_url,
+            json={"state": state, "seq_id": seq},
+            timeout=timeout_s,
+        )
+        response.raise_for_status()
+        return _parse_ack(response)
+
+
+class _Ack:
+    """Validated DashServing acknowledgement for one state report."""
+
+    __slots__ = ("accepted", "last_seq_id")
+
+    def __init__(self, accepted: bool, last_seq_id: int) -> None:
+        self.accepted = accepted
+        self.last_seq_id = last_seq_id
+
+
+def _parse_ack(response: httpx.Response) -> _Ack:
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise StateReportError(f"state ack is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise StateReportError(f"state ack is not a JSON object: {payload!r}")
+    accepted = payload.get("accepted")
+    last_seq_id = payload.get("last_seq_id")
+    if not isinstance(accepted, bool):
+        raise StateReportError(f"state ack 'accepted' is not a bool: {payload!r}")
+    # bool is a subclass of int; reject it explicitly for last_seq_id.
+    if not isinstance(last_seq_id, int) or isinstance(last_seq_id, bool):
+        raise StateReportError(f"state ack 'last_seq_id' is not an int: {payload!r}")
+    return _Ack(accepted, last_seq_id)

--- a/subscriber/subscriber/kvcm/base.py
+++ b/subscriber/subscriber/kvcm/base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class AbstractKvCacheManagerClient(ABC):
+    """Async contract implemented by KVCM manager transports."""
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start the client and any required connection discovery."""
+
+    @abstractmethod
+    async def is_ready(self) -> bool:
+        """Return whether the client currently has a usable endpoint."""
+
+    @abstractmethod
+    async def register_instance(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        """Register this inference instance with KVCM."""
+
+    @abstractmethod
+    async def report_event(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        """Report KVCM lifecycle or block events."""
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Release client resources."""

--- a/subscriber/subscriber/kvcm/client.py
+++ b/subscriber/subscriber/kvcm/client.py
@@ -1,0 +1,1042 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from collections.abc import Callable, Mapping
+from typing import Any, cast
+
+import grpc
+
+from subscriber import logger
+from subscriber.config import SubscriberConfig
+from subscriber.engine.metadata import KvCacheDescriptor, MetadataProtocolError
+from subscriber.kvcm.base import AbstractKvCacheManagerClient
+from subscriber.kvcm.enum import KvcmReportEventType
+from subscriber.kvcm.errors import (
+    KvcmReportError,
+    KvcmReportRejectedError,
+    KvcmResponseRejectedError,
+    KvcmUnavailableError,
+    report_event_transport_diagnostics,
+)
+from subscriber.kvcm.event_payload import (
+    build_merged_snapshot_blocks,
+    expand_report_events,
+    source_counts,
+    split_report_event_requests,
+)
+from subscriber.kvcm.kinds import effective_attention_type_categories
+from subscriber.kvcm.manager_client import HttpKvCacheManagerClient
+from subscriber.metrics import (
+    BatchTelemetry,
+    report_heartbeat,
+    report_registration_recovery,
+    report_registration_transition,
+)
+from subscriber.types import BlockSnapshot, KvCacheGroupSpec, KVEventBatch
+from subscriber.utils.network import resolve_host_ip_port
+
+# Legacy compatibility for fake tests and older HTTP transports. New transports
+# raise KvcmResponseRejectedError for rejected KVCM responses.
+_REPORT_REJECTED_PREFIX = "KVCM /api/reportEvent failed:"
+
+# While unregistered with no available KVCM endpoint, repeat a summary warning
+# at most this often.
+_UNREGISTERED_WARN_INTERVAL_S = 30.0
+_SNAPSHOT_SIGNAL_WARN_INTERVAL_S = 30.0
+
+
+def _report_status_code(response: dict[str, Any]) -> str:
+    status = response.get("header", {}).get("status", {})
+    code = status.get("code") if isinstance(status, dict) else None
+    return code if isinstance(code, str) and code else "UNKNOWN"
+
+
+def _response_retry_count(response: dict[str, Any]) -> int:
+    retry_count = response.get("_subscriber_retry_count")
+    if isinstance(retry_count, int) and not isinstance(retry_count, bool):
+        return max(0, retry_count)
+    return 0
+
+
+def _transport_gauges(
+    *,
+    request_bytes: object,
+    wire_encode_ms: object,
+    grpc_call_ms: object,
+) -> dict[str, float]:
+    """Return valid gRPC ReportEvent diagnostics as metric observations."""
+
+    gauges: dict[str, float] = {}
+    for value, metric_name in (
+        (request_bytes, "kvcm_report_event_request_bytes"),
+        (wire_encode_ms, "kvcm_report_event_wire_encode_ms"),
+        (grpc_call_ms, "kvcm_report_event_grpc_call_ms"),
+    ):
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value >= 0
+        ):
+            gauges[metric_name] = float(value)
+    return gauges
+
+
+def _response_transport_gauges(response: dict[str, Any]) -> dict[str, float]:
+    """Return valid gRPC ReportEvent diagnostics from a transport response."""
+
+    return _transport_gauges(
+        request_bytes=response.get("_subscriber_request_bytes"),
+        wire_encode_ms=response.get("_subscriber_wire_encode_ms"),
+        grpc_call_ms=response.get("_subscriber_grpc_call_ms"),
+    )
+
+
+def _get_engine_config_from_env() -> dict[str, Any]:
+    raw = os.environ.get("DS_LLM_ENGINE_CONFIG", "")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            logger.warning(
+                "DS_LLM_ENGINE_CONFIG must decode to a JSON object",
+                step="kvcm_client_init",
+                tags={"parsed_type": type(parsed).__name__},
+            )
+            return {}
+        return parsed
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "failed to parse DS_LLM_ENGINE_CONFIG",
+            step="kvcm_client_init",
+            exc_info=True,
+        )
+        return {}
+
+
+class KvcmClient:
+    """Async boundary for forwarding KV event batches to kvcm.
+
+    ``on_snapshot_required`` is invoked from the heartbeat loop when a
+    heartbeat response carries ``snapshot_required=True`` — kvcm signals this
+    after a restart that lost its view of this instance's kvcache, so the
+    engine adapter can trigger an immediate full snapshot. The callback must
+    be synchronous and non-blocking (``Event.set()`` plus logging only); its
+    exceptions are swallowed and the signal is retried on the next heartbeat.
+    The incremental-send path handles ``snapshot_required`` separately via the
+    ``report_kv_events`` return value (wired in ``forwarding.py``).
+
+    TODO: Define restart and idempotent-close semantics if a future caller needs
+    to reuse a client after ``close()``. The current lifecycle is one
+    ``start()`` followed by one ``close()``.
+    """
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        *,
+        medium_mapper: Callable[[str | None], str],
+        storage_type: str,
+        supported_mediums: list[str],
+        descriptor: KvCacheDescriptor,
+        manager_client: AbstractKvCacheManagerClient | None = None,
+        on_snapshot_required: Callable[[], None] | None = None,
+    ) -> None:
+        self._config = config
+        self._kind_categories = effective_attention_type_categories(
+            config.extra_attention_types
+        )
+        self._medium_mapper = medium_mapper
+        self._storage_type = storage_type
+        self._supported_mediums = supported_mediums
+        self._descriptor = descriptor
+        self._group_by_idx: dict[int, KvCacheGroupSpec] | None = (
+            {spec.group_idx: spec for spec in descriptor.groups}
+            # An empty metadata tuple is a valid topology; it registers the
+            # same default location spec as the no-metadata path because KVCM
+            # rejects empty location_spec_infos.
+            if descriptor.groups
+            else None
+        )
+        self._manager_client: AbstractKvCacheManagerClient = (
+            manager_client or self._create_manager_client()
+        )
+        self._host_ip_port_value: str | None = None
+        self._spec_cache: dict[tuple[str, int | None], list[dict[str, str]]] = {}
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._engine_config: dict[str, Any] = _get_engine_config_from_env()
+        self._engine_config_fallback_warned = False
+        self._payload_fallback_logged: set[int] = set()
+        self._on_snapshot_required = on_snapshot_required
+        # Dedup latch: True once on_snapshot_required has fired for the
+        # current streak of snapshot_required=True heartbeat responses.
+        # Re-armed when the response stops requesting a snapshot or after a
+        # successful re-registration (see _handle_heartbeat_snapshot_required).
+        self._snapshot_signal_delivered = False
+        self._snapshot_signal_failure_count = 0
+        self._last_snapshot_signal_warn_s = 0.0
+        self._registered = False
+        self._started = False
+
+    # ------------------------------------------------------------------
+    # Registration state
+    # ------------------------------------------------------------------
+
+    def _set_registration_state(self, registered: bool) -> None:
+        """Transition registration state, deduplicating equal values."""
+        if self._registered == registered:
+            return
+        from_state = "registered" if self._registered else "unregistered"
+        to_state = "registered" if registered else "unregistered"
+        self._registered = registered
+        report_registration_transition(from_state, to_state)
+        logger.info(
+            "kvcm registration state changed",
+            step="kvcm_register",
+            tags={"registered": registered},
+        )
+
+    @property
+    def is_registered(self) -> bool:
+        """Whether the client is currently registered with KVCM."""
+        return self._registered
+
+    def _base_url(self) -> str:
+        if not self._config.kvcm_base_url:
+            raise ValueError("kvcm_base_url is required")
+        return self._config.kvcm_base_url
+
+    def _create_manager_client(self) -> AbstractKvCacheManagerClient:
+        if self._config.kvcm_protocol == "http":
+            return HttpKvCacheManagerClient(
+                self._base_url(),
+                request_timeout_seconds=self._config.kvcm_request_timeout_s,
+            )
+        if self._config.kvcm_protocol == "grpc":
+            from subscriber.kvcm.grpc_manager_client import GrpcKvCacheManagerClient
+
+            return GrpcKvCacheManagerClient(
+                self._base_url(),
+                request_timeout_seconds=self._config.kvcm_request_timeout_s,
+            )
+        raise ValueError(f"unsupported kvcm_protocol: {self._config.kvcm_protocol}")
+
+    def _instance_group(self) -> str:
+        return self._config.kvcm_instance_group
+
+    def _instance_id(self) -> str:
+        deployment = self._require_deployment_name()
+        return f"{deployment}_{self._effective_block_size()}"
+
+    @staticmethod
+    def _require_deployment_name() -> str:
+        """Return the unique deployment identity, rejecting a blank value.
+
+        A blank SPECTRUM_DEPLOYMENT_NAME would produce a degenerate
+        instance_id such as ``_16`` shared by every replica missing the
+        variable, breaking the cross-instance KVCache isolation invariant.
+        """
+
+        deployment = os.environ.get("SPECTRUM_DEPLOYMENT_NAME", "").strip()
+        if not deployment:
+            raise ValueError(
+                "SPECTRUM_DEPLOYMENT_NAME must be set to a unique deployment "
+                "identity; a blank value would share one KVCM instance_id "
+                "across unrelated engine instances"
+            )
+        return deployment
+
+    def _host_ip_port(self) -> str:
+        if self._host_ip_port_value is not None:
+            return self._host_ip_port_value
+        raise RuntimeError("kvcm client host identity has not been resolved")
+
+    def _trace_id(self, operation: str) -> str:
+        return f"subscriber_{operation}_{time.monotonic_ns()}"
+
+    @staticmethod
+    def _config_int(cfg: dict[str, Any], key: str, default: int = 1) -> int:
+        raw = cfg.get(key)
+        if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+            return default
+        return raw
+
+    def _effective_block_size(self) -> int:
+        """Return the runtime block size used for KVCM instance identity.
+
+        The engine metadata describes the cache topology that is actually
+        running, which can differ from ``DS_LLM_ENGINE_CONFIG`` after runtime
+        calculation. When groups have different token spans, use their minimum
+        so the one KVCM instance identity is compatible with every group. The
+        environment value is only a fallback for engines without metadata.
+        """
+
+        if self._group_by_idx:
+            block_sizes = {
+                idx: spec.block_size for idx, spec in self._group_by_idx.items()
+            }
+            effective = min(block_sizes.values())
+            if len(set(block_sizes.values())) > 1:
+                logger.warning(
+                    "group metadata contains heterogeneous block_sizes; using min",
+                    step="kvcm_register",
+                    tags={
+                        "block_sizes": block_sizes,
+                        "effective_block_size": effective,
+                    },
+                )
+            return effective
+        block_size = self._config_int(self._engine_config, "block_size")
+        if not self._engine_config_fallback_warned:
+            logger.warning(
+                "kv cache metadata unavailable; using engine config "
+                "block_size fallback",
+                step="kvcm_register",
+                tags={"block_size": block_size},
+            )
+            self._engine_config_fallback_warned = True
+        return block_size
+
+    def _fallback_location_spec_name(self) -> str:
+        return f"vllm_{self._effective_block_size()}"
+
+    @staticmethod
+    def _group_location_spec_name(
+        spec: KvCacheGroupSpec,
+        kind_categories: Mapping[str, str],
+    ) -> str:
+        """Derive one group-aware location-spec name or reject its kind."""
+
+        category = kind_categories.get(spec.kind)
+        if category is None:
+            raise MetadataProtocolError(
+                f"cannot classify component kind {spec.kind!r} for KVCM"
+            )
+        return f"{category}{spec.group_idx}"
+
+    @classmethod
+    def validate_descriptor_location_specs(
+        cls,
+        config: SubscriberConfig,
+        descriptor: KvCacheDescriptor,
+    ) -> None:
+        """Validate bootstrap-derived names without constructing a manager client."""
+
+        kind_categories = effective_attention_type_categories(
+            config.extra_attention_types
+        )
+        for spec in descriptor.groups:
+            cls._group_location_spec_name(spec, kind_categories)
+
+    def _location_spec_name(self, group_idx: int | None = None) -> str:
+        if self._group_by_idx is None:
+            return self._fallback_location_spec_name()
+        if group_idx is None:
+            raise MetadataProtocolError(
+                "event is missing component identity for group-aware KVCM"
+            )
+        spec = self._group_by_idx.get(group_idx)
+        if spec is None:
+            raise MetadataProtocolError(
+                f"group_idx {group_idx} is not present in KV cache bootstrap"
+            )
+        return self._group_location_spec_name(spec, self._kind_categories)
+
+    def _location_specs(
+        self,
+    ) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+        """Build ``location_spec_infos`` and ``location_spec_groups``.
+
+        With group metadata, each group becomes its own location spec named
+        ``{category}{group_idx}`` sized by that group's complete payload bytes,
+        and each spec gets its own single-member location spec group of
+        the same name. Without metadata a single ``default`` group is used,
+        matching pre-hybrid engines.
+        """
+
+        if self._group_by_idx is None:
+            block_size = self._effective_block_size()
+            name = self._location_spec_name()
+            infos: list[dict[str, object]] = [{"name": name, "size": block_size}]
+            groups: list[dict[str, object]] = [
+                {"name": "default", "spec_names": [name]}
+            ]
+            return infos, groups
+
+        infos = []
+        groups = []
+        for group_idx in sorted(self._group_by_idx):
+            spec = self._group_by_idx[group_idx]
+            name = self._location_spec_name(spec.group_idx)
+            payload_size = spec.group_payload_size_bytes
+            if payload_size is None:
+                payload_size = spec.block_size
+                if spec.group_idx not in self._payload_fallback_logged:
+                    self._payload_fallback_logged.add(spec.group_idx)
+                    logger.info(
+                        "Engine component payload size unavailable; using block size",
+                        step="kvcm_register",
+                        tags={
+                            "component_id": spec.group_idx,
+                            "block_size": spec.block_size,
+                        },
+                    )
+            infos.append({"name": name, "size": payload_size})
+            groups.append({"name": name, "spec_names": [name]})
+        return infos, groups
+
+    def validate_location_specs(self) -> None:
+        """Validate bootstrap-derived KVCM specs without starting the client."""
+
+        self._location_specs()
+
+    def _register_instance_request(self) -> dict[str, object]:
+        cfg = self._engine_config
+        block_size = self._effective_block_size()
+        location_spec_infos, location_spec_groups = self._location_specs()
+        tp_size = self._config_int(cfg, "tensor_parallel_size")
+        dp_size = self._config_int(cfg, "data_parallel_size")
+        pp_size = self._config_int(cfg, "pipeline_parallel_size")
+        return {
+            "trace_id": self._trace_id("register_instance"),
+            "instance_group": self._instance_group(),
+            "instance_id": self._instance_id(),
+            "block_size": block_size,
+            "location_spec_infos": location_spec_infos,
+            "model_deployment": {
+                "model_name": "default",
+                "dtype": "bytes",
+                "use_mla": False,
+                "tp_size": tp_size,
+                "dp_size": dp_size,
+                "lora_name": "",
+                "pp_size": pp_size,
+                "extra": "",
+                "user_data": "",
+                "use_eagle_pop": self._descriptor.use_eagle_pop,
+            },
+            "location_spec_groups": location_spec_groups,
+            "default_query_type": self._config.kvcm_query_type,
+        }
+
+    def _node_register_event(self) -> dict[str, object]:
+        return {
+            "event_type": KvcmReportEventType.NODE_REGISTER,
+            "node_register": {"mediums": self._supported_mediums},
+        }
+
+    def _heartbeat_event(self) -> dict[str, object]:
+        return {
+            "event_type": KvcmReportEventType.HEARTBEAT,
+            "heartbeat": {"system_status": {}},
+        }
+
+    def _report_event_request(
+        self,
+        events: list[dict[str, object]],
+        *,
+        operation: str = "report_event",
+        trace_id: str | None = None,
+    ) -> dict[str, object]:
+        return {
+            "trace_id": trace_id if trace_id is not None else self._trace_id(operation),
+            "instance_id": self._instance_id(),
+            "host_ip_port": self._host_ip_port(),
+            "events": events,
+            "storage_type": self._storage_type,
+        }
+
+    def _block_specs(
+        self, medium: str, group_idx: int | None = None
+    ) -> list[dict[str, str]]:
+        key = (medium, group_idx)
+        cached = self._spec_cache.get(key)
+        if cached is not None:
+            return cached
+        spec = [
+            {
+                "name": self._location_spec_name(group_idx),
+                "uri": (
+                    f"{self._config.engine_type}://{self._host_ip_port()}/{medium}"
+                ),
+            }
+        ]
+        self._spec_cache[key] = spec
+        return spec
+
+    def _block_spec_names(self, group_idx: int | None = None) -> list[str]:
+        return [self._location_spec_name(group_idx)]
+
+    def _report_events_for_batches(
+        self, batches: list[KVEventBatch]
+    ) -> list[dict[str, object]]:
+        return expand_report_events(
+            batches,
+            medium_mapper=self._medium_mapper,
+            block_specs=self._block_specs,
+            block_spec_names=self._block_spec_names,
+        )
+
+    @staticmethod
+    def _metadata_protocol_rejection(
+        error: MetadataProtocolError,
+    ) -> KvcmReportRejectedError:
+        """Classify a local descriptor/event mismatch without issuing an RPC."""
+
+        return KvcmReportRejectedError(
+            f"KVCM metadata protocol error: {error}",
+            status_code="METADATA_PROTOCOL",
+            reason="metadata_protocol",
+        )
+
+    async def start(self) -> None:
+        self._require_deployment_name()
+        # host_port is guaranteed non-None by SubscriberConfig.validate().
+        self._host_ip_port_value = await resolve_host_ip_port(
+            cast(int, self._config.host_port)
+        )
+        await self._manager_client.start()
+        self._started = True
+        if await self._manager_is_ready():
+            await self._register_and_report_node()
+        else:
+            logger.warning(
+                "kvcm has no available endpoint; starting in not-ready state",
+                step="kvcm_register",
+            )
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def _manager_is_ready(self) -> bool:
+        if self._manager_client is None:
+            return False
+        return await self._manager_client.is_ready()
+
+    async def _register_instance(self) -> dict[str, object]:
+        if not self._started or self._manager_client is None:
+            raise RuntimeError("kvcm client has not been started")
+        request = self._register_instance_request()
+        if logger.is_debug_enabled():
+            logger.debug(
+                "kvcm register_instance request",
+                step="kvcm_register",
+                tags={"request": request},
+            )
+        await self._manager_client.register_instance(request)
+        return request
+
+    async def _register_and_report_node(self) -> None:
+        """Perform the two-step kvcm registration: the register_instance RPC
+        followed by the NODE_REGISTER event report. Registration state is
+        transitioned via ``_set_registration_state`` only after both steps
+        succeed. Success also re-arms the heartbeat snapshot signal
+        (``_rearm_snapshot_signal``): after re-registration kvcm's view
+        of this instance is fresh, so a previously serviced
+        ``snapshot_required`` must be able to fire again."""
+
+        try:
+            await self._register_instance()
+        except Exception as exc:
+            logger.warning(
+                "kvcm register_instance failed (%s: %s)",
+                type(exc).__name__,
+                exc,
+                step="kvcm_register",
+                tags={"phase": "register_instance"},
+                exc_info=exc,
+            )
+            return
+        try:
+            await self._report_events([self._node_register_event()])
+        except Exception as exc:
+            logger.warning(
+                "kvcm node_register report failed (%s: %s)",
+                type(exc).__name__,
+                exc,
+                step="kvcm_register",
+                tags={"phase": "node_register"},
+                exc_info=exc,
+            )
+            return
+        self._rearm_snapshot_signal()
+        self._set_registration_state(True)
+
+    def _rearm_snapshot_signal(self) -> None:
+        """Reset the snapshot-signal streak state (dedup latch and failure
+        count) so the next ``snapshot_required=True`` response starts a fresh
+        streak with an immediate first-failure warning."""
+        self._snapshot_signal_delivered = False
+        self._snapshot_signal_failure_count = 0
+
+    def _handle_heartbeat_snapshot_required(self, response: dict[str, Any]) -> None:
+        """Fire ``_on_snapshot_required`` at most once per consecutive streak
+        of ``snapshot_required=True`` heartbeat responses.
+
+        The dedup flag (``_snapshot_signal_delivered``) resets when a
+        response no longer requests a snapshot (strict ``is True``; missing or
+        non-bool values count as not requested) and after a successful
+        re-registration (``_register_and_report_node``). If the callback
+        raises, the flag stays unset so the next heartbeat retries; the
+        failure warning is rate-limited. Best-effort: never raises into the
+        heartbeat loop.
+        """
+        if self._on_snapshot_required is None:
+            return
+        if response.get("snapshot_required") is not True:
+            self._rearm_snapshot_signal()
+            return
+        if self._snapshot_signal_delivered:
+            return
+        try:
+            self._on_snapshot_required()
+        except Exception as exc:
+            self._snapshot_signal_failure_count += 1
+            now_s = time.monotonic()
+            if (
+                self._snapshot_signal_failure_count == 1
+                or now_s - self._last_snapshot_signal_warn_s
+                >= _SNAPSHOT_SIGNAL_WARN_INTERVAL_S
+            ):
+                self._last_snapshot_signal_warn_s = now_s
+                logger.warning(
+                    "failed to request immediate snapshot from kvcm heartbeat; "
+                    "continuing heartbeat",
+                    step="snapshot_signal",
+                    tags={
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                        "failure_count": self._snapshot_signal_failure_count,
+                    },
+                    exc_info=exc,
+                )
+            return
+        self._snapshot_signal_failure_count = 0
+        self._snapshot_signal_delivered = True
+
+    async def _heartbeat_loop(self) -> None:
+        not_ready_since_s: float | None = None
+        last_not_ready_warn_s = 0.0
+        while True:
+            await asyncio.sleep(self._config.kvcm_heartbeat_interval_s)
+            if not self._registered:
+                if not await self._manager_is_ready():
+                    now_s = time.monotonic()
+                    if not_ready_since_s is None:
+                        not_ready_since_s = now_s
+                        last_not_ready_warn_s = now_s
+                    elif now_s - last_not_ready_warn_s >= _UNREGISTERED_WARN_INTERVAL_S:
+                        last_not_ready_warn_s = now_s
+                        logger.warning(
+                            "kvcm still unregistered; no available endpoint",
+                            step="kvcm_register",
+                            tags={
+                                "unregistered_for_s": round(
+                                    now_s - not_ready_since_s, 1
+                                ),
+                            },
+                        )
+                    continue
+                not_ready_since_s = None
+                await self._register_and_report_node()
+                if not self._registered:
+                    continue
+                report_registration_recovery()
+                logger.info(
+                    "kvcm registration recovered",
+                    step="kvcm_register",
+                )
+            not_ready_since_s = None
+
+            try:
+                response = await self._report_events([self._heartbeat_event()])
+                self._handle_heartbeat_snapshot_required(response)
+                report_heartbeat(success=True)
+            except Exception as exc:
+                self._set_registration_state(False)
+                report_heartbeat(success=False)
+                logger.warning(
+                    "kvcm heartbeat report failed (%s: %s)",
+                    type(exc).__name__,
+                    exc,
+                    step="kvcm_heartbeat",
+                    exc_info=exc,
+                )
+
+    async def _report_events(self, events: list[dict[str, object]]) -> dict[str, Any]:
+        """Send registration or heartbeat events outside the forwarding seam."""
+
+        if not self._started or self._manager_client is None:
+            raise RuntimeError("kvcm client has not been started")
+        return await self._manager_client.report_event(
+            self._report_event_request(events)
+        )
+
+    async def _report_events_checked(
+        self, request: dict[str, object], epoch: int
+    ) -> dict[str, Any]:
+        """Send a prepared ReportEvent request and classify transport failures.
+
+        Transports raise ``KvcmResponseRejectedError`` for non-OK responses
+        (rejected reports); those become :class:`KvcmReportRejectedError`. Any
+        other exception is a retryable transport failure and becomes
+        :class:`KvcmUnavailableError`. A response carrying partial
+        ``item_results`` is also rejected. Registration state is deliberately
+        NOT changed here; the heartbeat loop owns reconnection and
+        re-registration independently.
+        """
+
+        try:
+            response = await self._manager_client.report_event(
+                request, check_response=True
+            )
+        except asyncio.CancelledError:
+            raise
+        except KvcmResponseRejectedError as exc:
+            raise KvcmReportRejectedError(
+                str(exc),
+                status_code=exc.status_code,
+                reason="rejected",
+                retry_count=exc.retry_count,
+                request_bytes=exc.request_bytes,
+                wire_encode_ms=exc.wire_encode_ms,
+                grpc_call_ms=exc.grpc_call_ms,
+            ) from exc
+        except KvcmUnavailableError as exc:
+            raise KvcmUnavailableError(
+                str(exc),
+                status_code=exc.status_code,
+                reason=exc.reason,
+                retry_count=exc.retry_count,
+                request_bytes=exc.request_bytes,
+                wire_encode_ms=exc.wire_encode_ms,
+                grpc_call_ms=exc.grpc_call_ms,
+            ) from exc
+        except grpc.aio.AioRpcError as exc:
+            diagnostics = report_event_transport_diagnostics(exc)
+            raise KvcmUnavailableError(
+                str(exc),
+                status_code=f"GRPC_{exc.code().name}",
+                reason="transport",
+                request_bytes=diagnostics.request_bytes,
+                wire_encode_ms=diagnostics.wire_encode_ms,
+                grpc_call_ms=diagnostics.grpc_call_ms,
+            ) from exc
+        except Exception as exc:
+            if _REPORT_REJECTED_PREFIX in str(exc):
+                raise KvcmReportRejectedError(
+                    str(exc),
+                    reason="rejected",
+                ) from exc
+            raise KvcmUnavailableError(str(exc), reason="transport") from exc
+        item_results = (
+            response.get("item_results") if isinstance(response, dict) else None
+        )
+        if item_results:
+            trace_id = request.get("trace_id")
+            logger.warning(
+                "kvcm report_event returned partial item results",
+                step="kvcm_send",
+                tags={
+                    "epoch": epoch,
+                    "trace_id": trace_id,
+                    "item_results": item_results,
+                },
+            )
+            raise KvcmReportRejectedError(
+                f"kvcm report_event returned partial item_results: {item_results!r}",
+                status_code="ITEM_RESULTS",
+                reason="partial_results",
+                retry_count=_response_retry_count(response),
+                request_bytes=response.get("_subscriber_request_bytes"),
+                wire_encode_ms=response.get("_subscriber_wire_encode_ms"),
+                grpc_call_ms=response.get("_subscriber_grpc_call_ms"),
+            )
+        return response
+
+    def _ensure_send_ready(self) -> None:
+        """Raise if the client is not in a state that can send reports."""
+
+        if not self._started or self._manager_client is None:
+            raise RuntimeError("kvcm client has not been started")
+        if not self._registered:
+            raise KvcmUnavailableError("kvcm client is not ready")
+
+    async def _send_report_and_record_result(
+        self,
+        request: dict[str, object],
+        epoch: int,
+        *,
+        log_message: str,
+        extra_tags: dict[str, object],
+        send_started_at: float,
+        request_telemetry: BatchTelemetry | None = None,
+        additional_request_gauges: Mapping[str, float] | None = None,
+    ) -> dict[str, Any]:
+        """Send one logical ReportEvent and record its terminal telemetry.
+
+        This is the forwarding seam's one owner for final request/result
+        observations: request/failure/retry counters, logical call duration,
+        gRPC transport diagnostics, and optional path-specific gauges. It only
+        appends to ``BatchTelemetry``; ``MetricsReporter`` performs backend I/O
+        later. ``extra_tags`` are log-only path diagnostics, not metric labels.
+        """
+
+        report_event_started_at = time.monotonic()
+        status_code = "UNKNOWN"
+        failure_reason: str | None = None
+        retry_count = 0
+        all_request_gauges = dict(additional_request_gauges or {})
+        try:
+            response = await self._report_events_checked(request, epoch)
+            status_code = _report_status_code(response)
+            retry_count = _response_retry_count(response)
+            all_request_gauges.update(_response_transport_gauges(response))
+            return response
+        except KvcmReportError as exc:
+            status_code = exc.status_code
+            failure_reason = exc.reason
+            retry_count = exc.retry_count
+            all_request_gauges.update(
+                _transport_gauges(
+                    request_bytes=exc.request_bytes,
+                    wire_encode_ms=exc.wire_encode_ms,
+                    grpc_call_ms=exc.grpc_call_ms,
+                )
+            )
+            raise
+        finally:
+            report_event_call_ms = (time.monotonic() - report_event_started_at) * 1000
+            if request_telemetry is not None:
+                request_telemetry.count(
+                    "kvcm_report_event_request_count",
+                    1,
+                    tags={"status_code": status_code},
+                )
+                if failure_reason is not None:
+                    request_telemetry.count(
+                        "kvcm_report_event_failure_count",
+                        1,
+                        tags={
+                            "status_code": status_code,
+                            "reason": failure_reason,
+                        },
+                    )
+                if retry_count:
+                    request_telemetry.count(
+                        "kvcm_report_event_retry_count",
+                        retry_count,
+                        tags={"reason": "SERVER_NOT_LEADER"},
+                    )
+                request_telemetry.gauge(
+                    "kvcm_report_event_call_ms",
+                    report_event_call_ms,
+                    tags={"status_code": status_code},
+                )
+                for name, value in all_request_gauges.items():
+                    request_telemetry.gauge(
+                        name,
+                        value,
+                        tags={"status_code": status_code},
+                    )
+            if logger.is_debug_enabled():
+                tags: dict[str, object] = {"epoch": epoch}
+                trace_id = request.get("trace_id")
+                if trace_id is not None:
+                    tags["trace_id"] = trace_id
+                tags.update(extra_tags)
+                tags["status_code"] = status_code
+                tags["kvcm_report_event_call_ms"] = round(report_event_call_ms, 3)
+                tags["kvcm_send_total_ms"] = round(
+                    (time.monotonic() - send_started_at) * 1000, 3
+                )
+                logger.debug(log_message, step="kvcm_send", tags=tags)
+
+    async def report_kv_events(
+        self,
+        batches: list[KVEventBatch],
+        epoch: int,
+        telemetries: list[BatchTelemetry] | None = None,
+        trace_id: str | None = None,
+        *,
+        reregister_after_host_down: bool = True,
+    ) -> bool:
+        """Report incremental KV event batches to kvcm.
+
+        Returns ``True`` when the KVCM response indicates a full snapshot is
+        required (``snapshot_required`` field is boolean ``True``). Missing or
+        non-boolean values (e.g. from older KVCM versions) return ``False``.
+
+        When ``telemetries`` is provided, marks two sequential stages on each:
+        ``expand`` (payload serialization) and ``kvcm_send`` (KVCM ReportEvent
+        调用). This mirrors the stage-marking contract of
+        :meth:`report_snapshot`.
+
+        Engine-originated ``AllBlocksCleared`` means that the cache was reset
+        while the engine remains available. KVCM represents the reset as
+        ``EVENT_HOST_DOWN``, which removes the node, so the default path sends
+        a standalone ``EVENT_NODE_REGISTER`` immediately afterwards. Health
+        and shutdown callers pass ``reregister_after_host_down=False`` because
+        their host-down is terminal for the current engine epoch.
+        """
+
+        self._ensure_send_ready()
+        send_started_at = time.monotonic()
+        try:
+            events = self._report_events_for_batches(batches)
+        except MetadataProtocolError as exc:
+            if telemetries:
+                for telemetry in telemetries:
+                    telemetry.mark("expand")
+            raise self._metadata_protocol_rejection(exc) from exc
+        request_telemetry = telemetries[0] if telemetries else None
+        if telemetries:
+            for t in telemetries:
+                t.mark("expand")
+        event_expand_ms = (time.monotonic() - send_started_at) * 1000
+        if not events:
+            if logger.is_debug_enabled():
+                logger.debug(
+                    "kvcm send skipped because batch group has no reportable events",
+                    step="kvcm_send",
+                    tags={"epoch": epoch},
+                )
+            return False
+        request_event_groups = split_report_event_requests(events)
+        if reregister_after_host_down:
+            normalized_groups: list[list[dict[str, object]]] = []
+            for request_events in request_event_groups:
+                normalized_groups.append(request_events)
+                if request_events[0].get("event_type") == KvcmReportEventType.HOST_DOWN:
+                    normalized_groups.append([self._node_register_event()])
+            request_event_groups = normalized_groups
+        if request_telemetry is not None:
+            request_telemetry.gauge(
+                "kvcm_report_event_count",
+                sum(len(group) for group in request_event_groups),
+            )
+        counts = source_counts(batches)
+        snapshot_required = False
+        try:
+            for request_part_index, request_events in enumerate(request_event_groups):
+                request = self._report_event_request(
+                    request_events,
+                    trace_id=trace_id,
+                )
+                response = await self._send_report_and_record_result(
+                    request,
+                    epoch,
+                    log_message="kvcm report_event timing",
+                    extra_tags={
+                        "source_batch_count": counts.batch_count,
+                        "source_event_count": counts.event_count,
+                        "report_event_count": len(request_events),
+                        "request_part_index": request_part_index,
+                        "request_part_count": len(request_event_groups),
+                        "event_expand_ms": round(event_expand_ms, 3),
+                    },
+                    send_started_at=time.monotonic(),
+                    request_telemetry=request_telemetry,
+                )
+                snapshot_required = (
+                    response.get("snapshot_required") is True or snapshot_required
+                )
+        finally:
+            if telemetries:
+                for t in telemetries:
+                    t.mark("kvcm_send")
+        return snapshot_required
+
+    async def report_snapshot(
+        self,
+        batches: list[KVEventBatch],
+        epoch: int,
+        telemetry: BatchTelemetry | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        """Report a full KV cache block snapshot to kvcm.
+
+        Contract mirrors :meth:`report_kv_events`: gated on registration, lossy error
+        classification (rejected vs unavailable), partial ``item_results``
+        rejection, and debug timing diagnostics. All ``BlockSnapshot`` events in
+        ``batches`` are flattened into a single ``EVENT_BLOCK_SNAPSHOT`` report;
+        when no snapshot block is present the report is skipped entirely.
+
+        When ``telemetry`` is provided, marks two sequential stages:
+        ``expand`` (fused collect + merge) and ``kvcm_send`` (KVCM ReportEvent
+        调用).
+        """
+
+        self._ensure_send_ready()
+        send_started_at = time.monotonic()
+        snapshots = [
+            event
+            for batch in batches
+            for event in batch.events
+            if isinstance(event, BlockSnapshot)
+        ]
+        if not snapshots:
+            if logger.is_debug_enabled():
+                logger.debug(
+                    "kvcm snapshot send skipped because batch has no snapshot blocks",
+                    step="kvcm_send",
+                    tags={"epoch": epoch},
+                )
+            return
+        try:
+            merged = build_merged_snapshot_blocks(
+                batches,
+                medium_mapper=self._medium_mapper,
+                block_specs=self._block_specs,
+            )
+        except MetadataProtocolError as exc:
+            if telemetry is not None:
+                telemetry.mark("expand")
+            raise self._metadata_protocol_rejection(exc) from exc
+        if telemetry is not None:
+            telemetry.mark("expand")
+        snapshot_block_count = sum(len(snapshot.items) for snapshot in snapshots)
+        event: dict[str, object] = {
+            "event_type": KvcmReportEventType.BLOCK_SNAPSHOT,
+            "block_snapshot": {"blocks": merged},
+        }
+        request = self._report_event_request(
+            [event], operation="report_snapshot", trace_id=trace_id
+        )
+        counts = source_counts(batches)
+        event_expand_ms = (time.monotonic() - send_started_at) * 1000
+        try:
+            await self._send_report_and_record_result(
+                request,
+                epoch,
+                log_message="kvcm snapshot report_event timing",
+                extra_tags={
+                    "source_batch_count": counts.batch_count,
+                    "source_event_count": counts.event_count,
+                    "snapshot_block_count": snapshot_block_count,
+                    "event_expand_ms": round(event_expand_ms, 3),
+                },
+                send_started_at=send_started_at,
+                request_telemetry=telemetry,
+                additional_request_gauges={
+                    "kvcm_snapshot_source_block_count": float(snapshot_block_count),
+                    "kvcm_snapshot_merged_block_count": float(len(merged)),
+                },
+            )
+        finally:
+            if telemetry is not None:
+                telemetry.mark("kvcm_send")
+
+    async def close(self) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            self._heartbeat_task = None
+        if self._manager_client is not None:
+            await self._manager_client.close()
+        self._set_registration_state(False)
+        self._started = False

--- a/subscriber/subscriber/kvcm/enum.py
+++ b/subscriber/subscriber/kvcm/enum.py
@@ -1,0 +1,36 @@
+from enum import StrEnum
+
+
+class KvcmReportEventType(StrEnum):
+    """Wire event types accepted by KVCM ReportEvent."""
+
+    NODE_REGISTER = "EVENT_NODE_REGISTER"
+    HEARTBEAT = "EVENT_HEARTBEAT"
+    BLOCK_ADD = "EVENT_BLOCK_ADD"
+    BLOCK_DELETE = "EVENT_BLOCK_DELETE"
+    BLOCK_SNAPSHOT = "EVENT_BLOCK_SNAPSHOT"
+    HOST_DOWN = "EVENT_HOST_DOWN"
+
+
+class KvcmQueryType(StrEnum):
+    """Wire query types accepted by KVCM registerInstance."""
+
+    QT_UNSPECIFIED = "QT_UNSPECIFIED"
+    QT_BATCH_GET = "QT_BATCH_GET"
+    QT_PREFIX_MATCH = "QT_PREFIX_MATCH"
+    QT_REVERSE_ROLL_SW_MATCH = "QT_REVERSE_ROLL_SW_MATCH"
+    QT_PREFIX_MATCH_WITH_MAMBA = "QT_PREFIX_MATCH_WITH_MAMBA"
+
+
+class KvcmStorageType(StrEnum):
+    """Storage types supported by the authoritative KVCM protobuf schema."""
+
+    ST_UNSPECIFIED = "ST_UNSPECIFIED"
+    ST_3FS = "ST_3FS"
+    ST_MOONCAKE = "ST_MOONCAKE"
+    ST_TAIRMEMPOOL = "ST_TAIRMEMPOOL"
+    ST_NFS = "ST_NFS"
+    ST_VCNS_3FS = "ST_VCNS_3FS"
+    ST_DUMMY = "ST_DUMMY"
+    ST_EVENT_REPORT_L1P5 = "ST_EVENT_REPORT_L1P5"
+    ST_EVENT_REPORT_L2 = "ST_EVENT_REPORT_L2"

--- a/subscriber/subscriber/kvcm/errors.py
+++ b/subscriber/subscriber/kvcm/errors.py
@@ -1,0 +1,116 @@
+"""Typed errors raised when reporting KV events to KVCM.
+
+The forwarding loop catches :class:`KvcmReportError` to drop the affected
+batch and continue consuming. This is intentionally lossy so a KVCM
+control-plane failure cannot backpressure or stop engine serving. KVCM
+availability is not a forwarding gate input; the KVCM heartbeat loop owns
+re-registration independently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_REPORT_EVENT_TRANSPORT_DIAGNOSTICS_ATTRIBUTE = (
+    "_subscriber_report_event_transport_diagnostics"
+)
+
+
+@dataclass(frozen=True)
+class ReportEventTransportDiagnostics:
+    """Local gRPC ReportEvent diagnostics, independent of response semantics.
+
+    A raw transport exception cannot be changed to a domain error without
+    breaking direct gRPC callers. In that narrow case the gRPC adapter stores
+    this immutable value on the exception; callers use
+    :func:`report_event_transport_diagnostics` instead of depending on an
+    adapter-private attribute name.
+    """
+
+    request_bytes: int | None = None
+    wire_encode_ms: float | None = None
+    grpc_call_ms: float | None = None
+
+
+def attach_report_event_transport_diagnostics(
+    error: BaseException,
+    diagnostics: ReportEventTransportDiagnostics,
+) -> None:
+    """Attach the one internal diagnostics value to a raw transport error."""
+
+    setattr(error, _REPORT_EVENT_TRANSPORT_DIAGNOSTICS_ATTRIBUTE, diagnostics)
+
+
+def report_event_transport_diagnostics(
+    error: BaseException,
+) -> ReportEventTransportDiagnostics:
+    """Return ReportEvent diagnostics attached to a raw transport error.
+
+    Errors from a transport that does not provide gRPC diagnostics return an
+    empty value so consumers can preserve their existing fallback behavior.
+    """
+
+    value = getattr(error, _REPORT_EVENT_TRANSPORT_DIAGNOSTICS_ATTRIBUTE, None)
+    if isinstance(value, ReportEventTransportDiagnostics):
+        return value
+    return ReportEventTransportDiagnostics()
+
+
+class KvcmReportError(RuntimeError):
+    """Base error for KVCM event reporting failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: str = "UNKNOWN",
+        reason: str = "unknown",
+        retry_count: int = 0,
+        request_bytes: int | None = None,
+        wire_encode_ms: float | None = None,
+        grpc_call_ms: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.reason = reason
+        self.retry_count = max(0, retry_count)
+        self.request_bytes = request_bytes
+        self.wire_encode_ms = wire_encode_ms
+        self.grpc_call_ms = grpc_call_ms
+
+
+class KvcmUnavailableError(KvcmReportError):
+    """KVCM is not registered or a retryable transport failure occurred.
+
+    Registration state is deliberately NOT changed here: the KVCM heartbeat
+    loop owns reconnection and re-registration.
+    """
+
+
+class KvcmReportRejectedError(KvcmReportError):
+    """KVCM rejected the report (non-retryable for this batch).
+
+    A rejected/partial report is dropped and observed without changing
+    registration.
+    """
+
+
+class KvcmResponseRejectedError(RuntimeError):
+    """Non-OK KVCM response before domain-level error classification."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: str = "UNKNOWN",
+        retry_count: int = 0,
+        request_bytes: int | None = None,
+        wire_encode_ms: float | None = None,
+        grpc_call_ms: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retry_count = max(0, retry_count)
+        self.request_bytes = request_bytes
+        self.wire_encode_ms = wire_encode_ms
+        self.grpc_call_ms = grpc_call_ms

--- a/subscriber/subscriber/kvcm/event_payload.py
+++ b/subscriber/subscriber/kvcm/event_payload.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
+
+from subscriber.kvcm.enum import KvcmReportEventType
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockSnapshot,
+    BlockStored,
+    KVEventBatch,
+)
+
+
+@dataclass(frozen=True)
+class ReportEventSourceCounts:
+    """Number of subscriber batches and events that produced a request."""
+
+    batch_count: int
+    event_count: int
+
+
+def expand_report_events(
+    batches: list[KVEventBatch],
+    *,
+    medium_mapper: Callable[[str | None], str],
+    block_specs: Callable[[str, int | None], list[dict[str, str]]],
+    block_spec_names: Callable[[int | None], list[str]],
+) -> list[dict[str, object]]:
+    """Expand subscriber batches into ordered KVCM report events."""
+
+    events: list[dict[str, object]] = []
+    for batch in batches:
+        for event in batch.events:
+            if isinstance(event, BlockStored):
+                medium = medium_mapper(event.medium)
+                component_id = (
+                    event.component_id
+                    if event.component_id is not None
+                    else event.group_idx
+                )
+                specs = block_specs(medium, component_id)
+                for block_hash in event.block_hashes:
+                    events.append(
+                        {
+                            "event_type": KvcmReportEventType.BLOCK_ADD,
+                            "block_add": {
+                                "block_key": str(block_hash),
+                                "medium": medium,
+                                "specs": specs,
+                            },
+                        }
+                    )
+            elif isinstance(event, BlockRemoved):
+                medium = medium_mapper(event.medium)
+                component_id = (
+                    event.component_id
+                    if event.component_id is not None
+                    else event.group_idx
+                )
+                spec_names = block_spec_names(component_id)
+                for block_hash in event.block_hashes:
+                    events.append(
+                        {
+                            "event_type": KvcmReportEventType.BLOCK_DELETE,
+                            "block_delete": {
+                                "block_key": str(block_hash),
+                                "medium": medium,
+                                "spec_names": spec_names,
+                            },
+                        }
+                    )
+            elif isinstance(event, AllBlocksCleared):
+                events.append(
+                    {"event_type": KvcmReportEventType.HOST_DOWN, "host_down": {}}
+                )
+    return events
+
+
+def split_report_event_requests(
+    events: list[dict[str, object]],
+) -> list[list[dict[str, object]]]:
+    """Build KVCM-valid requests while preserving the latest reset boundary.
+
+    KVCM requires ``EVENT_HOST_DOWN`` to be the only event in a ReportEvent
+    request. Events before the latest host-down are stale by definition, so
+    they are discarded; later block events are sent in a second request.
+    """
+
+    last_host_down_index: int | None = None
+    for index, event in enumerate(events):
+        if event.get("event_type") == KvcmReportEventType.HOST_DOWN:
+            last_host_down_index = index
+    if last_host_down_index is None:
+        return [events] if events else []
+
+    requests = [[events[last_host_down_index]]]
+    current_events = events[last_host_down_index + 1 :]
+    if current_events:
+        requests.append(current_events)
+    return requests
+
+
+def build_merged_snapshot_blocks(
+    batches: list[KVEventBatch],
+    *,
+    medium_mapper: Callable[[str | None], str],
+    block_specs: Callable[[str, int | None], list[dict[str, str]]],
+) -> list[dict[str, object]]:
+    """Single-pass fused collect + merge for snapshot blocks.
+
+    Flattens and merges blocks sharing ``(block_key, medium)`` inline, then
+    deduplicates specs by ``group_idx`` — the same ``(block_hash, group_idx)``
+    pair appearing multiple times (high-concurrency duplicate) produces only one
+    spec entry. Order of first occurrence is preserved.
+    """
+
+    if not batches:
+        return []
+
+    index: dict[tuple[str, str], int] = {}
+    seen_groups: list[int | set[int]] = []
+    merged: list[dict[str, object]] = []
+
+    for batch in batches:
+        for event in batch.events:
+            if not isinstance(event, BlockSnapshot):
+                continue
+            medium = medium_mapper(event.medium)
+            for item in event.items:
+                block_key = str(item.block_hash)
+                key = (block_key, medium)
+                pos = index.get(key)
+                if pos is None:
+                    idx = len(merged)
+                    index[key] = idx
+                    seen_groups.append(item.group_idx)
+                    merged.append(
+                        {
+                            "block_key": block_key,
+                            "medium": medium,
+                            "specs": list(block_specs(medium, item.group_idx)),
+                        }
+                    )
+                    continue
+                groups = seen_groups[pos]
+                if isinstance(groups, int):
+                    if item.group_idx == groups:
+                        continue
+                    seen_groups[pos] = {groups, item.group_idx}
+                elif item.group_idx in groups:
+                    continue
+                else:
+                    groups.add(item.group_idx)
+                specs = cast(list[dict[str, str]], merged[pos]["specs"])
+                specs.extend(block_specs(medium, item.group_idx))
+
+    return merged
+
+
+def report_event_count(batches: list[KVEventBatch]) -> int:
+    """Count KVCM report events without expanding payloads or serializing JSON."""
+
+    count = 0
+    for batch in batches:
+        for event in batch.events:
+            if isinstance(event, (BlockStored, BlockRemoved)):
+                count += len(event.block_hashes)
+            elif isinstance(event, AllBlocksCleared):
+                count += 1
+    return count
+
+
+def source_counts(batches: list[KVEventBatch]) -> ReportEventSourceCounts:
+    """Count source batches and unexpanded subscriber events."""
+
+    return ReportEventSourceCounts(
+        batch_count=len(batches),
+        event_count=sum(len(batch.events) for batch in batches),
+    )

--- a/subscriber/subscriber/kvcm/grpc_manager_client.py
+++ b/subscriber/subscriber/kvcm/grpc_manager_client.py
@@ -1,0 +1,1285 @@
+"""KVCM manager gRPC client with service discovery and leader discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+import grpc
+
+from subscriber import logger
+from subscriber.kvcm.base import AbstractKvCacheManagerClient
+from subscriber.kvcm.errors import (
+    KvcmResponseRejectedError,
+    KvcmUnavailableError,
+    ReportEventTransportDiagnostics,
+    attach_report_event_transport_diagnostics,
+    report_event_transport_diagnostics,
+)
+from subscriber.kvcm.service_discovery import (
+    ServiceDiscovery,
+    create_service_discovery,
+)
+from subscriber.proto import kvcm_meta_service_pb2, kvcm_meta_service_pb2_grpc
+
+_DISCOVERY_STEP = "kvcm_discovery"
+_REQUEST_STEP = "kvcm_request"
+_CHANNEL_OPTIONS: list[tuple[str, int]] = [
+    ("grpc.max_receive_message_length", 8 * 1024 * 1024),
+    ("grpc.keepalive_time_ms", 2_000),
+    ("grpc.keepalive_timeout_ms", 10_000),
+    ("grpc.keepalive_permit_without_calls", 1),
+    ("grpc.http2.max_pings_without_data", 0),
+    ("grpc.enable_retries", 0),
+    ("grpc.initial_reconnect_backoff_ms", 100),
+    ("grpc.max_reconnect_backoff_ms", 1_000),
+    ("grpc.tcp_receive_buffer_size", 512 * 1024),
+]
+
+
+@dataclass(frozen=True)
+class _RequestResult:
+    """One logical manager request and its retry and RPC-attempt diagnostics."""
+
+    response: Any
+    retry_count: int
+    grpc_call_ms: float
+
+
+@dataclass(frozen=True)
+class _CallResult:
+    """One completed RPC attempt and the time spent awaiting that RPC."""
+
+    response: Any
+    grpc_call_ms: float
+
+
+class GrpcKvCacheManagerClient(AbstractKvCacheManagerClient):
+    """gRPC manager client with optional service-discovery and leader refresh."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        instance_id: str = "",
+        auto_discover_leader: bool = True,
+        leader_retry_count: int = 1,
+        leader_retry_base_interval_seconds: float = 0.005,
+        discovery_refresh_interval_seconds: int = 30,
+        min_discover_interval_seconds: float = 1.0,
+        request_timeout_seconds: float = 5.0,
+    ) -> None:
+        super().__init__()
+        self._configured_base_url = base_url
+        self._request_timeout_seconds = float(request_timeout_seconds)
+        if self._request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be positive")
+
+        self._instance_id = instance_id
+        self._auto_discover_leader = auto_discover_leader
+        self._leader_retry_count = leader_retry_count
+        self._leader_retry_base_interval = leader_retry_base_interval_seconds
+        self._discovery_refresh_interval = discovery_refresh_interval_seconds
+        self._min_discover_interval = min_discover_interval_seconds
+
+        self._service_discovery: ServiceDiscovery | None = None
+        self._target = _base_url_to_target(base_url)
+        self._discovery_target = self._target
+        self._channel: grpc.aio.Channel | None = None
+        self._stub: kvcm_meta_service_pb2_grpc.MetaServiceStub | None = None
+        self._inflight_calls: dict[
+            grpc.aio.Channel, set[grpc.aio.UnaryUnaryCall[Any, Any]]
+        ] = {}
+        self._raw_report_event: Any | None = None
+        self._leader_lock = asyncio.Lock()
+        self._refresh_event = asyncio.Event()
+        self._closed = False
+        self._last_discover_time: float = 0.0
+        self._refresh_task: asyncio.Task[None] | None = None
+        self._started = False
+
+    async def start(self) -> None:
+        """Start service discovery, leader refresh, and the initial channel."""
+        if self._started:
+            return
+        if self._target is None:
+            self._service_discovery = create_service_discovery(
+                self._configured_base_url
+            )
+            if self._service_discovery is None:
+                raise ValueError(
+                    f"Invalid service discovery address: {self._configured_base_url}"
+                )
+            await self._service_discovery.start()
+            ep = self._service_discovery.get_one_endpoint()
+            if ep is not None:
+                self._set_target(ep.host)
+                self._discovery_target = ep.host
+                logger.info(
+                    "service discovery resolved manager endpoint",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "discovery_type": self._service_discovery.get_type(),
+                        "target": self._target,
+                    },
+                )
+            else:
+                logger.warning(
+                    "service discovery returned no endpoints; "
+                    "waiting for background refresh",
+                    step=_DISCOVERY_STEP,
+                    tags={"discovery_url": self._configured_base_url},
+                )
+
+        if self._target is not None:
+            self._get_stub()
+        if self._auto_discover_leader:
+            try:
+                if await self.is_ready():
+                    await self._discover_leader()
+            except Exception as exc:
+                logger.warning(
+                    "initial leader discovery failed; keeping base target",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "target": self._target or "",
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                    },
+                )
+            self._refresh_task = asyncio.create_task(
+                self._leader_refresh_loop(),
+                name="kvcm-grpc-leader-refresh",
+            )
+        self._started = True
+
+    async def is_ready(self) -> bool:
+        """Return whether requests have a usable gRPC target."""
+
+        if self._target:
+            return True
+        if self._service_discovery is None:
+            return False
+        endpoint = self._service_discovery.get_one_endpoint()
+        if endpoint is None:
+            return False
+        async with self._leader_lock:
+            if not self._target:
+                self._set_target(endpoint.host)
+                logger.info(
+                    "service discovery recovered manager endpoint",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "discovery_type": self._service_discovery.get_type(),
+                        "target": self._target,
+                    },
+                )
+        return True
+
+    async def register_instance(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        """Register an instance through the protobuf MetaService RPC."""
+        request = _register_instance_request_from_dict(data)
+        result = await self._request("RegisterInstance", request, check_response)
+        return _register_instance_response_to_dict(
+            cast(kvcm_meta_service_pb2.RegisterInstanceResponse, result.response)
+        )
+
+    async def report_event(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        """Report lifecycle or KV events and attach local gRPC diagnostics.
+
+        The returned dict and classified KVCM errors carry final wire bytes,
+        raw encoder duration, and cumulative RPC-attempt duration for the
+        domain client's asynchronous telemetry. A raw ``AioRpcError`` remains
+        raw for direct transport callers; its diagnostics are available through
+        :func:`subscriber.kvcm.errors.report_event_transport_diagnostics`.
+        """
+        wire_encode_started_at = time.monotonic()
+        request = _report_event_request_to_wire_bytes(data)
+        wire_encode_ms = (time.monotonic() - wire_encode_started_at) * 1000
+        try:
+            result = await self._request("ReportEvent", request, check_response)
+        except KvcmResponseRejectedError as exc:
+            exc.request_bytes = len(request)
+            exc.wire_encode_ms = wire_encode_ms
+            raise
+        except KvcmUnavailableError as exc:
+            exc.request_bytes = len(request)
+            exc.wire_encode_ms = wire_encode_ms
+            if exc.grpc_call_ms is None:
+                exc.grpc_call_ms = 0.0
+            raise
+        except grpc.aio.AioRpcError as exc:
+            diagnostics = report_event_transport_diagnostics(exc)
+            attach_report_event_transport_diagnostics(
+                exc,
+                ReportEventTransportDiagnostics(
+                    request_bytes=len(request),
+                    wire_encode_ms=wire_encode_ms,
+                    grpc_call_ms=diagnostics.grpc_call_ms,
+                ),
+            )
+            raise
+        response = _report_event_response_to_dict(
+            cast(kvcm_meta_service_pb2.ReportEventResponse, result.response)
+        )
+        response["_subscriber_retry_count"] = result.retry_count
+        response["_subscriber_request_bytes"] = len(request)
+        response["_subscriber_wire_encode_ms"] = wire_encode_ms
+        response["_subscriber_grpc_call_ms"] = result.grpc_call_ms
+        return response
+
+    async def close(self) -> None:
+        """Stop refresh work and immediately release transport resources."""
+        self._closed = True
+        self._refresh_event.set()
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            try:
+                await self._refresh_task
+            except asyncio.CancelledError:
+                pass
+            self._refresh_task = None
+        await self._close_channel()
+        if self._service_discovery is not None:
+            await self._service_discovery.close()
+
+    def _set_target(self, target: str | None) -> None:
+        if target == self._target:
+            return
+        self._target = target
+        self._stub = None
+        self._raw_report_event = None
+
+    async def _switch_target(self, target: str) -> None:
+        if target == self._target:
+            return
+        previous = self._target
+        previous_channel = self._detach_channel()
+        self._set_target(target)
+        self._get_stub()
+        if previous_channel is not None:
+            await self._wait_for_channel_calls(previous_channel)
+            await previous_channel.close()
+        logger.info(
+            "leader discovery switched manager endpoint",
+            step=_DISCOVERY_STEP,
+            tags={"previous_target": previous or "", "target": target},
+        )
+
+    async def _close_channel(self) -> None:
+        channel = self._detach_channel()
+        if channel is not None:
+            await channel.close()
+
+    def _detach_channel(self) -> grpc.aio.Channel | None:
+        """Remove the active channel so new RPCs use the current target."""
+        channel = self._channel
+        self._channel = None
+        self._stub = None
+        self._raw_report_event = None
+        return channel
+
+    async def _wait_for_channel_calls(self, channel: grpc.aio.Channel) -> None:
+        """Let deadline-bounded RPCs finish before retiring their channel."""
+        calls = tuple(self._inflight_calls.get(channel, ()))
+        if calls:
+            await asyncio.gather(*calls, return_exceptions=True)
+
+    def _get_stub(self) -> kvcm_meta_service_pb2_grpc.MetaServiceStub:
+        if not self._target:
+            raise KvcmUnavailableError("KVCM gRPC target is unavailable")
+        if self._stub is None:
+            self._channel = grpc.aio.insecure_channel(
+                self._target,
+                options=_CHANNEL_OPTIONS,
+            )
+            self._stub = kvcm_meta_service_pb2_grpc.MetaServiceStub(
+                cast(grpc.Channel, self._channel)
+            )
+            self._raw_report_event = self._channel.unary_unary(
+                "/kv_cache_manager.proto.meta.MetaService/ReportEvent",
+                request_serializer=lambda request: request,
+                response_deserializer=(
+                    kvcm_meta_service_pb2.ReportEventResponse.FromString
+                ),
+            )
+        return self._stub
+
+    def _resolve_discovery_target(self) -> str | None:
+        if self._service_discovery is not None:
+            ep = self._service_discovery.get_one_endpoint()
+            if ep is not None:
+                return ep.host
+        return self._discovery_target or self._target
+
+    async def _discover_leader(self) -> bool:
+        snapshot = self._target
+        async with self._leader_lock:
+            if self._target != snapshot:
+                return True
+            return await self._do_discover_leader()
+
+    async def _do_discover_leader(self) -> bool:
+        target = self._resolve_discovery_target()
+        if not target:
+            return False
+        original_target = self._target
+        leader_discovered = False
+        if target != self._target:
+            await self._switch_target(target)
+        try:
+            request = kvcm_meta_service_pb2.GetClusterInfoRequest(
+                trace_id=f"leader_discovery_{time.monotonic()}",
+                instance_id=self._instance_id,
+            )
+            call_result = await self._call(
+                "GetClusterInfo", request, notify_refresh=False
+            )
+            response = cast(
+                kvcm_meta_service_pb2.GetClusterInfoResponse,
+                call_result.response,
+            )
+            data = _get_cluster_info_response_to_dict(response)
+            if _get_status_code(data) != "OK":
+                status = data.get("header", {}).get("status", {})
+                logger.warning(
+                    "leader discovery returned error",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "target": target,
+                        "kvcm_status_code": status.get("code", "Unknown"),
+                        "message": status.get("message", ""),
+                    },
+                )
+                return False
+            leader_ep = data.get("leader_endpoint")
+            if (
+                not isinstance(leader_ep, dict)
+                or not leader_ep.get("host")
+                or not leader_ep.get("meta_rpc_port")
+            ):
+                logger.warning(
+                    "leader discovery response missing leader endpoint",
+                    step=_DISCOVERY_STEP,
+                    tags={"target": target},
+                )
+                return False
+            leader_discovered = True
+            await self._switch_target(
+                f"{leader_ep['host']}:{leader_ep['meta_rpc_port']}"
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "leader discovery request failed",
+                step=_DISCOVERY_STEP,
+                tags={
+                    "target": target,
+                    "error": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+            )
+            return False
+        finally:
+            if (
+                not leader_discovered
+                and original_target
+                and self._target == target
+                and target != original_target
+            ):
+                await self._switch_target(original_target)
+            self._last_discover_time = time.monotonic()
+
+    async def _leader_refresh_loop(self) -> None:
+        while not self._closed:
+            try:
+                await asyncio.wait_for(
+                    self._refresh_event.wait(),
+                    timeout=self._discovery_refresh_interval,
+                )
+            except TimeoutError:
+                pass
+            self._refresh_event.clear()
+            if self._closed:
+                break
+            remaining = self._min_discover_interval - (
+                time.monotonic() - self._last_discover_time
+            )
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+                if self._closed:
+                    break
+            try:
+                await self._discover_leader()
+            except Exception as exc:
+                logger.warning(
+                    "background leader refresh failed",
+                    step=_DISCOVERY_STEP,
+                    tags={"error": exc.__class__.__name__, "message": str(exc)},
+                )
+
+    def _notify_leader_refresh(self) -> None:
+        if self._auto_discover_leader:
+            self._refresh_event.set()
+
+    async def _request(
+        self,
+        method_name: str,
+        request: Any,
+        check_response: bool,
+    ) -> _RequestResult:
+        retries_left = self._leader_retry_count if self._auto_discover_leader else 0
+        retry_count = 0
+        grpc_call_ms = 0.0
+        while True:
+            try:
+                call_result = await self._call(
+                    method_name,
+                    request,
+                    attempt=retry_count + 1,
+                )
+            except grpc.aio.AioRpcError as exc:
+                diagnostics = report_event_transport_diagnostics(exc)
+                if diagnostics.grpc_call_ms is not None:
+                    grpc_call_ms += diagnostics.grpc_call_ms
+                if not retry_count:
+                    attach_report_event_transport_diagnostics(
+                        exc,
+                        ReportEventTransportDiagnostics(grpc_call_ms=grpc_call_ms),
+                    )
+                    raise
+                raise KvcmUnavailableError(
+                    str(exc),
+                    status_code=f"GRPC_{exc.code().name}",
+                    reason="transport",
+                    retry_count=retry_count,
+                    grpc_call_ms=grpc_call_ms,
+                ) from exc
+            else:
+                response = call_result.response
+                grpc_call_ms += call_result.grpc_call_ms
+            payload = _response_to_dict(response)
+            if (
+                self._auto_discover_leader
+                and _get_status_code(payload) == "SERVER_NOT_LEADER"
+            ):
+                if retries_left > 0:
+                    retries_left -= 1
+                    retry_count += 1
+                    sleep_time = (
+                        self._leader_retry_base_interval * retry_count
+                        + random.uniform(0, self._leader_retry_base_interval)
+                    )
+                    logger.warning(
+                        "kvcm request returned SERVER_NOT_LEADER; retrying",
+                        step=_REQUEST_STEP,
+                        tags={
+                            "method": method_name,
+                            "attempt": retry_count,
+                            "retry_count": retry_count,
+                            "kvcm_status_code": "SERVER_NOT_LEADER",
+                            "retry_delay_seconds": round(sleep_time, 3),
+                            "retries_left": retries_left,
+                        },
+                    )
+                    await asyncio.sleep(sleep_time)
+                    await self._discover_leader()
+                    continue
+                if retries_left <= 0:
+                    logger.error(
+                        "kvcm leader discovery retries exhausted",
+                        step=_REQUEST_STEP,
+                        tags={"method": method_name},
+                    )
+                    raise KvcmUnavailableError(
+                        f"KVCM leader unavailable for {method_name}: "
+                        "SERVER_NOT_LEADER and leader discovery exhausted",
+                        status_code="SERVER_NOT_LEADER",
+                        reason="leader_retry_exhausted",
+                        retry_count=retry_count,
+                        grpc_call_ms=grpc_call_ms,
+                    )
+            if check_response:
+                status = payload.get("header", {}).get("status", {})
+                if status.get("code") != "OK":
+                    item_results = payload.get("item_results")
+                    item_results_detail = (
+                        f"; item_results={item_results!r}" if item_results else ""
+                    )
+                    raise KvcmResponseRejectedError(
+                        f"KVCM /grpc/{method_name} failed: "
+                        f"{status.get('code')} {status.get('message')}"
+                        f"{item_results_detail}",
+                        status_code=_get_status_code(payload) or "UNKNOWN",
+                        retry_count=retry_count,
+                        grpc_call_ms=grpc_call_ms,
+                    )
+            return _RequestResult(
+                response=response,
+                retry_count=retry_count,
+                grpc_call_ms=grpc_call_ms,
+            )
+
+    async def _call(
+        self,
+        method_name: str,
+        request: Any,
+        *,
+        notify_refresh: bool = True,
+        attempt: int = 1,
+    ) -> _CallResult:
+        """Execute one RPC attempt with channel bookkeeping and transport logs.
+
+        The returned duration covers only ``await call``. Stub/channel setup,
+        inflight-set maintenance, and logging stay outside that measurement so
+        ``grpc_call_ms`` remains comparable with downstream RPC latency.
+        """
+
+        target = self._target or ""
+        request_bytes = len(request) if isinstance(request, bytes) else None
+        try:
+            if method_name == "ReportEvent" and isinstance(request, bytes):
+                self._get_stub()
+                method = self._raw_report_event
+                if method is None:
+                    raise KvcmUnavailableError(
+                        "KVCM gRPC ReportEvent method is unavailable"
+                    )
+            else:
+                method = getattr(self._get_stub(), method_name)
+            channel = self._channel
+            if channel is None:
+                raise RuntimeError("KVCM gRPC channel was not initialized")
+            call = method(
+                request,
+                timeout=self._request_timeout_seconds,
+                wait_for_ready=False,
+            )
+            active_calls = self._inflight_calls.setdefault(channel, set())
+            active_calls.add(call)
+            try:
+                rpc_started_at = time.monotonic()
+                response = await call
+            except grpc.aio.AioRpcError as exc:
+                attach_report_event_transport_diagnostics(
+                    exc,
+                    ReportEventTransportDiagnostics(
+                        grpc_call_ms=(time.monotonic() - rpc_started_at) * 1000
+                    ),
+                )
+                raise
+            finally:
+                active_calls.discard(call)
+                if not active_calls:
+                    self._inflight_calls.pop(channel, None)
+            grpc_call_ms = (time.monotonic() - rpc_started_at) * 1000
+            if logger.is_debug_enabled():
+                completed_tags: dict[str, object] = {
+                    "target": target,
+                    "method": method_name,
+                    "attempt": attempt,
+                    "grpc_status": "OK",
+                    "grpc_call_ms": round(grpc_call_ms, 3),
+                }
+                if request_bytes is not None:
+                    completed_tags["request_bytes"] = request_bytes
+                logger.debug(
+                    "kvcm grpc request completed",
+                    step=_REQUEST_STEP,
+                    tags=completed_tags,
+                )
+            return _CallResult(response=response, grpc_call_ms=grpc_call_ms)
+        except asyncio.CancelledError:
+            raise
+        except grpc.aio.AioRpcError as exc:
+            if notify_refresh:
+                self._notify_leader_refresh()
+            code = exc.code()
+            message = exc.details() or str(exc)
+            error_tags: dict[str, object] = {
+                "target": target,
+                "method": method_name,
+                "attempt": attempt,
+                "grpc_status": code.name,
+                "grpc_call_ms": round(
+                    report_event_transport_diagnostics(exc).grpc_call_ms or 0.0,
+                    3,
+                ),
+            }
+            if request_bytes is not None:
+                error_tags["request_bytes"] = request_bytes
+            if code == grpc.StatusCode.DEADLINE_EXCEEDED:
+                error_tags["timeout_seconds"] = self._request_timeout_seconds
+                logger.warning(
+                    "kvcm grpc request timed out",
+                    step=_REQUEST_STEP,
+                    tags=error_tags,
+                )
+            elif code == grpc.StatusCode.UNAVAILABLE:
+                error_tags["message"] = message
+                logger.warning(
+                    "kvcm grpc request connection failed; notifying leader refresh",
+                    step=_REQUEST_STEP,
+                    tags=error_tags,
+                )
+            else:
+                error_tags["message"] = message
+                logger.warning(
+                    "kvcm grpc request failed",
+                    step=_REQUEST_STEP,
+                    tags=error_tags,
+                )
+            raise
+
+
+def _base_url_to_target(base_url: str) -> str | None:
+    """Return a direct gRPC target, or ``None`` to request service discovery.
+
+    ``start()`` treats ``None`` as an internal sentinel: it passes the configured
+    address to ``create_service_discovery()``. Bare targets and ``http(s)`` or
+    ``grpc`` URLs are direct targets; ``static`` and ``spectrum`` URLs therefore
+    return ``None``. An empty or unsupported discovery address is rejected by
+    ``start()`` rather than being used as a gRPC target.
+    """
+    if not base_url:
+        return None
+    if "://" not in base_url:
+        return base_url.rstrip("/")
+    parsed = urlsplit(base_url)
+    if parsed.scheme in {"http", "https", "grpc"} and parsed.netloc:
+        return parsed.netloc.rstrip("/")
+    if parsed.scheme:
+        return None
+    return base_url.rstrip("/")
+
+
+def _enum_value(enum_wrapper: Any, value: object, *, default_name: str | None) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value in enum_wrapper.DESCRIPTOR.values_by_number:
+            return value
+    if isinstance(value, str) and value:
+        values = enum_wrapper.DESCRIPTOR.values_by_name
+        if value in values:
+            return cast(int, values[value].number)
+    if default_name is not None:
+        return cast(int, enum_wrapper.Value(default_name))
+    raise ValueError(f"invalid {enum_wrapper.DESCRIPTOR.full_name} value: {value!r}")
+
+
+def _event_type_value(value: object) -> int:
+    if (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value
+        not in kvcm_meta_service_pb2.ReportEventType.DESCRIPTOR.values_by_number
+    ):
+        raise ValueError(f"invalid ReportEventType value: {value!r}")
+    return _enum_value(
+        kvcm_meta_service_pb2.ReportEventType,
+        value,
+        default_name="EVENT_UNSPECIFIED",
+    )
+
+
+def _enum_name(enum_wrapper: Any, value: int) -> str:
+    try:
+        return cast(str, enum_wrapper.Name(value))
+    except ValueError:
+        return str(value)
+
+
+def _dict_list(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _register_instance_request_from_dict(
+    data: dict[str, Any],
+) -> kvcm_meta_service_pb2.RegisterInstanceRequest:
+    model = data.get("model_deployment")
+    model_data = model if isinstance(model, dict) else {}
+    return kvcm_meta_service_pb2.RegisterInstanceRequest(
+        trace_id=str(data.get("trace_id", "")),
+        instance_group=str(data.get("instance_group", "")),
+        instance_id=str(data.get("instance_id", "")),
+        block_size=int(data.get("block_size", 0) or 0),
+        location_spec_infos=[
+            kvcm_meta_service_pb2.LocationSpecInfo(
+                name=str(item.get("name", "")),
+                size=int(item.get("size", 0) or 0),
+            )
+            for item in _dict_list(data.get("location_spec_infos"))
+        ],
+        model_deployment=kvcm_meta_service_pb2.ModelDeployment(
+            model_name=str(model_data.get("model_name", "")),
+            dtype=str(model_data.get("dtype", "")),
+            use_mla=bool(model_data.get("use_mla", False)),
+            tp_size=int(model_data.get("tp_size", 0) or 0),
+            dp_size=int(model_data.get("dp_size", 0) or 0),
+            lora_name=str(model_data.get("lora_name", "")),
+            pp_size=int(model_data.get("pp_size", 0) or 0),
+            extra=str(model_data.get("extra", "")),
+            user_data=str(model_data.get("user_data", "")),
+            use_eagle_pop=bool(model_data.get("use_eagle_pop", False)),
+        ),
+        location_spec_groups=[
+            kvcm_meta_service_pb2.LocationSpecGroup(
+                name=str(item.get("name", "")),
+                spec_names=[
+                    str(spec_name)
+                    for spec_name in item.get("spec_names", [])
+                    if isinstance(spec_name, str)
+                ],
+            )
+            for item in _dict_list(data.get("location_spec_groups"))
+        ],
+        default_query_type=cast(
+            kvcm_meta_service_pb2.QueryType,
+            _enum_value(
+                kvcm_meta_service_pb2.QueryType,
+                data.get("default_query_type"),
+                default_name="QT_UNSPECIFIED",
+            ),
+        ),
+    )
+
+
+def _location_specs_from_list(specs: object) -> list[Any]:
+    return [
+        kvcm_meta_service_pb2.LocationSpec(
+            name=str(item.get("name", "")),
+            uri=str(item.get("uri", "")),
+        )
+        for item in _dict_list(specs)
+    ]
+
+
+_WIRE_VARINT = 0
+_WIRE_LEN = 2
+
+
+def _write_varint(out: bytearray, value: int) -> None:
+    value = int(value)
+    while value > 0x7F:
+        out.append((value & 0x7F) | 0x80)
+        value >>= 7
+    out.append(value)
+
+
+def _varint_size(value: int) -> int:
+    value = int(value)
+    size = 1
+    while value > 0x7F:
+        size += 1
+        value >>= 7
+    return size
+
+
+def _write_key(out: bytearray, field_number: int, wire_type: int) -> None:
+    _write_varint(out, (field_number << 3) | wire_type)
+
+
+def _key_size(field_number: int, wire_type: int) -> int:
+    return _varint_size((field_number << 3) | wire_type)
+
+
+def _write_string(out: bytearray, field_number: int, value: object) -> None:
+    if value is None:
+        return
+    encoded = str(value).encode()
+    if not encoded:
+        return
+    _write_encoded_string(out, field_number, encoded)
+
+
+def _write_encoded_string(out: bytearray, field_number: int, encoded: bytes) -> None:
+    _write_key(out, field_number, _WIRE_LEN)
+    _write_varint(out, len(encoded))
+    out.extend(encoded)
+
+
+def _encoded_string_size(field_number: int, encoded: bytes) -> int:
+    if not encoded:
+        return 0
+    return (
+        _key_size(field_number, _WIRE_LEN) + _varint_size(len(encoded)) + len(encoded)
+    )
+
+
+def _repeated_encoded_string_size(field_number: int, encoded: bytes) -> int:
+    return (
+        _key_size(field_number, _WIRE_LEN) + _varint_size(len(encoded)) + len(encoded)
+    )
+
+
+def _write_enum(out: bytearray, field_number: int, value: int) -> None:
+    if value == 0:
+        return
+    _write_key(out, field_number, _WIRE_VARINT)
+    _write_varint(out, value)
+
+
+def _write_message(out: bytearray, field_number: int, payload: bytes) -> None:
+    _write_key(out, field_number, _WIRE_LEN)
+    _write_varint(out, len(payload))
+    out.extend(payload)
+
+
+def _message_size(field_number: int, payload_len: int) -> int:
+    return _key_size(field_number, _WIRE_LEN) + _varint_size(payload_len) + payload_len
+
+
+def _location_spec_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    out = bytearray()
+    _write_string(out, 1, data.get("name", ""))
+    _write_string(out, 2, data.get("uri", ""))
+    return bytes(out)
+
+
+def _location_specs_to_wire_messages(
+    out: bytearray, field_number: int, specs: object
+) -> None:
+    for item in _dict_list(specs):
+        _write_message(out, field_number, _location_spec_to_wire_bytes(item))
+
+
+def _node_register_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    out = bytearray()
+    for medium in data.get("mediums", []):
+        if isinstance(medium, str):
+            _write_encoded_string(out, 1, medium.encode())
+    return bytes(out)
+
+
+def _block_add_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    out = bytearray()
+    _write_string(out, 1, data.get("block_key", ""))
+    _write_string(out, 2, data.get("uri", ""))
+    _write_string(out, 3, data.get("medium", ""))
+    _location_specs_to_wire_messages(out, 4, data.get("specs"))
+    return bytes(out)
+
+
+def _block_delete_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    out = bytearray()
+    _write_string(out, 1, data.get("block_key", ""))
+    _write_string(out, 2, data.get("medium", ""))
+    for name in data.get("spec_names", []):
+        if isinstance(name, str):
+            _write_encoded_string(out, 3, name.encode())
+    return bytes(out)
+
+
+def _heartbeat_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    out = bytearray()
+    system_status = data.get("system_status")
+    status_map = system_status if isinstance(system_status, dict) else {}
+    for key, value in status_map.items():
+        entry = bytearray()
+        _write_string(entry, 1, key)
+        _write_string(entry, 2, value)
+        _write_message(out, 1, bytes(entry))
+    return bytes(out)
+
+
+def _block_snapshot_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    out = bytearray()
+    _write_string(out, 1, data.get("medium", ""))
+    spec_cache: dict[tuple[str, str], bytes] = {}
+    blocks = data.get("blocks")
+    if not isinstance(blocks, list):
+        return bytes(out)
+    for item in blocks:
+        if not isinstance(item, dict):
+            continue
+        block_key = str(item.get("block_key", "")).encode()
+        medium = str(item.get("medium", "")).encode()
+        specs_len = 0
+        spec_payloads: list[bytes] = []
+        specs = item.get("specs")
+        if isinstance(specs, list):
+            for spec in specs:
+                if isinstance(spec, dict):
+                    payload = _location_spec_to_cached_wire_bytes(spec, spec_cache)
+                    spec_payloads.append(payload)
+                    specs_len += _message_size(3, len(payload))
+        payload_len = (
+            _encoded_string_size(1, block_key)
+            + _encoded_string_size(2, medium)
+            + specs_len
+        )
+        out.append(0x12)
+        _write_varint(out, payload_len)
+        if block_key:
+            out.append(0x0A)
+            _write_varint(out, len(block_key))
+            out.extend(block_key)
+        if medium:
+            out.append(0x12)
+            _write_varint(out, len(medium))
+            out.extend(medium)
+        for spec_payload in spec_payloads:
+            out.append(0x1A)
+            _write_varint(out, len(spec_payload))
+            out.extend(spec_payload)
+    return bytes(out)
+
+
+def _location_spec_to_cached_wire_bytes(
+    data: dict[str, Any], cache: dict[tuple[str, str], bytes]
+) -> bytes:
+    name = str(data.get("name", ""))
+    uri = str(data.get("uri", ""))
+    key = (name, uri)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    out = bytearray()
+    _write_string(out, 1, name)
+    _write_string(out, 2, uri)
+    payload = bytes(out)
+    cache[key] = payload
+    return payload
+
+
+def _write_block_add_event_message(
+    out: bytearray,
+    field_number: int,
+    data: dict[str, Any],
+    spec_cache: dict[tuple[str, str], bytes],
+) -> None:
+    payload = data.get("block_add")
+    block_add = payload if isinstance(payload, dict) else {}
+    block_key = str(block_add.get("block_key", "")).encode()
+    uri = str(block_add.get("uri", "")).encode()
+    medium = str(block_add.get("medium", "")).encode()
+    specs_len = 0
+    spec_payloads: list[bytes] = []
+    specs = block_add.get("specs")
+    if isinstance(specs, list):
+        for spec in specs:
+            if isinstance(spec, dict):
+                spec_payload = _location_spec_to_cached_wire_bytes(spec, spec_cache)
+                spec_payloads.append(spec_payload)
+                specs_len += _message_size(4, len(spec_payload))
+    block_add_len = (
+        _encoded_string_size(1, block_key)
+        + _encoded_string_size(2, uri)
+        + _encoded_string_size(3, medium)
+        + specs_len
+    )
+    event_type_len = _key_size(1, _WIRE_VARINT) + _varint_size(
+        kvcm_meta_service_pb2.EVENT_BLOCK_ADD
+    )
+    event_len = event_type_len + _message_size(3, block_add_len)
+    _write_key(out, field_number, _WIRE_LEN)
+    _write_varint(out, event_len)
+    out.append(0x08)
+    _write_varint(out, kvcm_meta_service_pb2.EVENT_BLOCK_ADD)
+    out.append(0x1A)
+    _write_varint(out, block_add_len)
+    if block_key:
+        out.append(0x0A)
+        _write_varint(out, len(block_key))
+        out.extend(block_key)
+    if uri:
+        out.append(0x12)
+        _write_varint(out, len(uri))
+        out.extend(uri)
+    if medium:
+        out.append(0x1A)
+        _write_varint(out, len(medium))
+        out.extend(medium)
+    for spec_payload in spec_payloads:
+        out.append(0x22)
+        _write_varint(out, len(spec_payload))
+        out.extend(spec_payload)
+
+
+def _write_block_delete_event_message(
+    out: bytearray, field_number: int, data: dict[str, Any]
+) -> None:
+    payload = data.get("block_delete")
+    block_delete = payload if isinstance(payload, dict) else {}
+    block_key = str(block_delete.get("block_key", "")).encode()
+    medium = str(block_delete.get("medium", "")).encode()
+    spec_names_len = 0
+    encoded_spec_names: list[bytes] = []
+    spec_names = block_delete.get("spec_names")
+    if isinstance(spec_names, list):
+        for name in spec_names:
+            if isinstance(name, str):
+                encoded = name.encode()
+                encoded_spec_names.append(encoded)
+                spec_names_len += _repeated_encoded_string_size(3, encoded)
+    block_delete_len = (
+        _encoded_string_size(1, block_key)
+        + _encoded_string_size(2, medium)
+        + spec_names_len
+    )
+    event_type_len = _key_size(1, _WIRE_VARINT) + _varint_size(
+        kvcm_meta_service_pb2.EVENT_BLOCK_DELETE
+    )
+    event_len = event_type_len + _message_size(4, block_delete_len)
+    _write_key(out, field_number, _WIRE_LEN)
+    _write_varint(out, event_len)
+    out.append(0x08)
+    _write_varint(out, kvcm_meta_service_pb2.EVENT_BLOCK_DELETE)
+    out.append(0x22)
+    _write_varint(out, block_delete_len)
+    if block_key:
+        out.append(0x0A)
+        _write_varint(out, len(block_key))
+        out.extend(block_key)
+    if medium:
+        out.append(0x12)
+        _write_varint(out, len(medium))
+        out.extend(medium)
+    for encoded in encoded_spec_names:
+        out.append(0x1A)
+        _write_varint(out, len(encoded))
+        out.extend(encoded)
+
+
+def _event_item_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    event_type = data.get("event_type")
+    event_type_number = _event_type_value(event_type)
+    out = bytearray()
+    _write_enum(out, 1, event_type_number)
+    if event_type == "EVENT_NODE_REGISTER":
+        payload = data.get("node_register")
+        node_register = payload if isinstance(payload, dict) else {}
+        _write_message(out, 2, _node_register_to_wire_bytes(node_register))
+    elif event_type == "EVENT_BLOCK_ADD":
+        payload = data.get("block_add")
+        block_add = payload if isinstance(payload, dict) else {}
+        _write_message(out, 3, _block_add_to_wire_bytes(block_add))
+    elif event_type == "EVENT_BLOCK_DELETE":
+        payload = data.get("block_delete")
+        block_delete = payload if isinstance(payload, dict) else {}
+        _write_message(out, 4, _block_delete_to_wire_bytes(block_delete))
+    elif event_type == "EVENT_HOST_DOWN":
+        _write_message(out, 5, b"")
+    elif event_type == "EVENT_HEARTBEAT":
+        payload = data.get("heartbeat")
+        heartbeat = payload if isinstance(payload, dict) else {}
+        _write_message(out, 6, _heartbeat_to_wire_bytes(heartbeat))
+    elif event_type == "EVENT_BLOCK_SNAPSHOT":
+        payload = data.get("block_snapshot")
+        block_snapshot = payload if isinstance(payload, dict) else {}
+        _write_message(out, 7, _block_snapshot_to_wire_bytes(block_snapshot))
+    return bytes(out)
+
+
+def _report_event_request_to_wire_bytes(data: dict[str, Any]) -> bytes:
+    """Encode a ReportEvent request without building protobuf message objects.
+
+    The output must be wire-equivalent to ``_report_event_request_from_dict`` for
+    accepted input. This path writes KVCM's fixed field layout directly so large
+    snapshots avoid per-block Python protobuf allocations; update it together
+    with the protobuf schema and its equivalence tests.
+    """
+    out = bytearray()
+    _write_string(out, 1, data.get("trace_id", ""))
+    _write_string(out, 2, data.get("instance_id", ""))
+    _write_string(out, 3, data.get("host_ip_port", ""))
+    spec_cache: dict[tuple[str, str], bytes] = {}
+    for item in _dict_list(data.get("events")):
+        event_type = item.get("event_type")
+        if event_type == "EVENT_BLOCK_ADD":
+            _write_block_add_event_message(out, 4, item, spec_cache)
+        elif event_type == "EVENT_BLOCK_DELETE":
+            _write_block_delete_event_message(out, 4, item)
+        else:
+            _write_message(out, 4, _event_item_to_wire_bytes(item))
+    _write_enum(
+        out,
+        5,
+        _enum_value(
+            kvcm_meta_service_pb2.StorageType,
+            data.get("storage_type"),
+            default_name=None,
+        ),
+    )
+    return bytes(out)
+
+
+def _event_item_from_dict(data: dict[str, Any]) -> kvcm_meta_service_pb2.EventItem:
+    event_type = data.get("event_type")
+    event_type_number = _event_type_value(event_type)
+    common: dict[str, Any] = {
+        "event_type": cast(kvcm_meta_service_pb2.ReportEventType, event_type_number)
+    }
+    if event_type == "EVENT_NODE_REGISTER":
+        payload = data.get("node_register")
+        node_register = payload if isinstance(payload, dict) else {}
+        return kvcm_meta_service_pb2.EventItem(
+            **common,
+            node_register=kvcm_meta_service_pb2.NodeRegisterEventParams(
+                mediums=[
+                    str(medium)
+                    for medium in node_register.get("mediums", [])
+                    if isinstance(medium, str)
+                ]
+            ),
+        )
+    if event_type == "EVENT_BLOCK_ADD":
+        payload = data.get("block_add")
+        block_add = payload if isinstance(payload, dict) else {}
+        return kvcm_meta_service_pb2.EventItem(
+            **common,
+            block_add=kvcm_meta_service_pb2.BlockAddEventParams(
+                block_key=str(block_add.get("block_key", "")),
+                uri=str(block_add.get("uri", "")),
+                medium=str(block_add.get("medium", "")),
+                specs=_location_specs_from_list(block_add.get("specs")),
+            ),
+        )
+    if event_type == "EVENT_BLOCK_DELETE":
+        payload = data.get("block_delete")
+        block_delete = payload if isinstance(payload, dict) else {}
+        return kvcm_meta_service_pb2.EventItem(
+            **common,
+            block_delete=kvcm_meta_service_pb2.BlockDeleteEventParams(
+                block_key=str(block_delete.get("block_key", "")),
+                medium=str(block_delete.get("medium", "")),
+                spec_names=[
+                    str(name)
+                    for name in block_delete.get("spec_names", [])
+                    if isinstance(name, str)
+                ],
+            ),
+        )
+    if event_type == "EVENT_HOST_DOWN":
+        return kvcm_meta_service_pb2.EventItem(
+            **common,
+            host_down=kvcm_meta_service_pb2.HostDownEventParams(),
+        )
+    if event_type == "EVENT_HEARTBEAT":
+        payload = data.get("heartbeat")
+        heartbeat = payload if isinstance(payload, dict) else {}
+        system_status = heartbeat.get("system_status")
+        status_map = system_status if isinstance(system_status, dict) else {}
+        return kvcm_meta_service_pb2.EventItem(
+            **common,
+            heartbeat=kvcm_meta_service_pb2.HeartbeatEventParams(
+                system_status={
+                    str(key): str(value) for key, value in status_map.items()
+                }
+            ),
+        )
+    if event_type == "EVENT_BLOCK_SNAPSHOT":
+        payload = data.get("block_snapshot")
+        block_snapshot = payload if isinstance(payload, dict) else {}
+        return kvcm_meta_service_pb2.EventItem(
+            **common,
+            block_snapshot=kvcm_meta_service_pb2.BlockSnapshotEventParams(
+                medium=str(block_snapshot.get("medium", "")),
+                blocks=[
+                    kvcm_meta_service_pb2.BlockSnapshotItem(
+                        block_key=str(item.get("block_key", "")),
+                        medium=str(item.get("medium", "")),
+                        specs=_location_specs_from_list(item.get("specs")),
+                    )
+                    for item in _dict_list(block_snapshot.get("blocks"))
+                ],
+            ),
+        )
+    return kvcm_meta_service_pb2.EventItem(**common)
+
+
+def _report_event_request_from_dict(
+    data: dict[str, Any],
+) -> kvcm_meta_service_pb2.ReportEventRequest:
+    return kvcm_meta_service_pb2.ReportEventRequest(
+        trace_id=str(data.get("trace_id", "")),
+        instance_id=str(data.get("instance_id", "")),
+        host_ip_port=str(data.get("host_ip_port", "")),
+        events=[_event_item_from_dict(item) for item in _dict_list(data.get("events"))],
+        storage_type=cast(
+            kvcm_meta_service_pb2.StorageType,
+            _enum_value(
+                kvcm_meta_service_pb2.StorageType,
+                data.get("storage_type"),
+                default_name=None,
+            ),
+        ),
+    )
+
+
+def _status_to_dict(header: Any) -> dict[str, Any]:
+    return {
+        "status": {
+            "code": _enum_name(kvcm_meta_service_pb2.ErrorCode, header.status.code),
+            "message": header.status.message,
+        },
+        "request_id": header.request_id,
+        "tracer_result": header.tracer_result,
+    }
+
+
+def _register_instance_response_to_dict(
+    response: kvcm_meta_service_pb2.RegisterInstanceResponse,
+) -> dict[str, Any]:
+    return {
+        "header": _status_to_dict(response.header),
+        "storage_configs": response.storage_configs,
+        "extra_info": response.extra_info,
+    }
+
+
+def _report_event_response_to_dict(
+    response: kvcm_meta_service_pb2.ReportEventResponse,
+) -> dict[str, Any]:
+    return {
+        "header": _status_to_dict(response.header),
+        "item_results": [
+            _enum_name(kvcm_meta_service_pb2.ErrorCode, item)
+            for item in response.item_results
+        ],
+        "committed_snapshot_version": response.committed_snapshot_version,
+        "retry_after_ms": response.retry_after_ms,
+        "snapshot_required": response.snapshot_required,
+        "extra_info": response.extra_info,
+    }
+
+
+def _get_cluster_info_response_to_dict(
+    response: kvcm_meta_service_pb2.GetClusterInfoResponse,
+) -> dict[str, Any]:
+    return {
+        "header": _status_to_dict(response.header),
+        "self_node_id": response.self_node_id,
+        "leader_node_id": response.leader_node_id,
+        "leader_endpoint": {
+            "node_id": response.leader_endpoint.node_id,
+            "host": response.leader_endpoint.host,
+            "meta_rpc_port": response.leader_endpoint.meta_rpc_port,
+            "meta_http_port": response.leader_endpoint.meta_http_port,
+            "custom_info": response.leader_endpoint.custom_info,
+        },
+    }
+
+
+def _response_to_dict(response: Any) -> dict[str, Any]:
+    if isinstance(response, kvcm_meta_service_pb2.RegisterInstanceResponse):
+        return _register_instance_response_to_dict(response)
+    if isinstance(response, kvcm_meta_service_pb2.ReportEventResponse):
+        return _report_event_response_to_dict(response)
+    if isinstance(response, kvcm_meta_service_pb2.GetClusterInfoResponse):
+        return _get_cluster_info_response_to_dict(response)
+    return {}
+
+
+def _get_status_code(response_data: dict[str, Any]) -> str | None:
+    code = response_data.get("header", {}).get("status", {}).get("code")
+    return code if isinstance(code, str) else None

--- a/subscriber/subscriber/kvcm/kinds.py
+++ b/subscriber/subscriber/kvcm/kinds.py
@@ -1,0 +1,50 @@
+"""Shared bootstrap component-kind to KVCM-category contract."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+
+BUILTIN_ATTENTION_TYPE_CATEGORIES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "full_attention": "F",
+        "mla_attention": "F",
+        "sink_full_attention": "F",
+        "mamba": "L",
+        "sliding_window": "W",
+        "sliding_window_mla": "W",
+        "chunked_local_attention": "C",
+        "encoder_only_attention": "E",
+        "cross_attention": "X",
+    }
+)
+
+
+def validate_extra_attention_types(extra_attention_types: object) -> None:
+    """Ensure configured attention kinds extend, but never replace, the contract."""
+
+    if not isinstance(extra_attention_types, dict) or any(
+        not isinstance(kind, str) or not isinstance(category, str)
+        for kind, category in extra_attention_types.items()
+    ):
+        raise ValueError(
+            "extra_attention_types must be a mapping with string keys and values"
+        )
+    conflicts = sorted(
+        set(extra_attention_types).intersection(BUILTIN_ATTENTION_TYPE_CATEGORIES)
+    )
+    if conflicts:
+        raise ValueError(
+            "extra_attention_types cannot override built-in attention types: "
+            + ", ".join(conflicts)
+        )
+
+
+def effective_attention_type_categories(
+    extra_attention_types: Mapping[str, str],
+) -> dict[str, str]:
+    """Return the canonical KVCM categories extended by explicit local mappings."""
+
+    validate_extra_attention_types(extra_attention_types)
+    return {**BUILTIN_ATTENTION_TYPE_CATEGORIES, **extra_attention_types}

--- a/subscriber/subscriber/kvcm/manager_client.py
+++ b/subscriber/subscriber/kvcm/manager_client.py
@@ -1,0 +1,488 @@
+"""KVCM manager HTTP client with service discovery and leader discovery.
+
+Extracted from ``store.py`` to keep manager-client concerns separate from
+the store/transfer layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from typing import Any
+
+import httpx
+
+from subscriber import logger
+from subscriber.kvcm.base import AbstractKvCacheManagerClient
+from subscriber.kvcm.errors import KvcmResponseRejectedError, KvcmUnavailableError
+from subscriber.kvcm.service_discovery import (
+    ServiceDiscovery,
+    create_service_discovery,
+)
+
+_DISCOVERY_STEP = "kvcm_discovery"
+_REQUEST_STEP = "kvcm_request"
+
+
+class HttpKvCacheManagerClient(AbstractKvCacheManagerClient):
+    """HTTP manager client with optional service-discovery and leader-discovery.
+
+    Compatible with the ``KvCacheManagerClient`` API surface used by
+    ``TairKVCMClient`` (register_instance, get_cache_location, …).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        instance_id: str = "",
+        auto_discover_leader: bool = True,
+        leader_retry_count: int = 1,
+        leader_retry_base_interval_seconds: float = 0.005,
+        discovery_refresh_interval_seconds: int = 30,
+        min_discover_interval_seconds: float = 1.0,
+        request_timeout_seconds: float = 5.0,
+        http_client: Any | None = None,
+    ):
+        """Initialize the HTTP manager client.
+
+        Args:
+            base_url: Manager service address. Supported formats:
+                - ``http://host:port`` or ``https://host:port`` — used directly
+                - ``static://ip:port[,ip:port]...`` — resolved via static
+                  service discovery (round-robin)
+                - ``spectrum://<vsid>[:port]`` with optional
+                  ``cache_time`` / ``timeout`` / ``retry_time`` query params
+                  — resolved via Spectrum gateway
+        """
+        super().__init__()
+
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        self._http_client = http_client or httpx.AsyncClient(headers=self.headers)
+        self._request_timeout_seconds = float(request_timeout_seconds)
+        if self._request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be positive")
+
+        # --- service discovery ---
+        # http(s):// → use directly; other schemes → try service discovery
+        self._configured_base_url = base_url
+        self._service_discovery: ServiceDiscovery | None = None
+
+        self.base_url = base_url.rstrip("/")
+        # Immutable seed address for leader discovery requests.
+        self._discovery_url = self.base_url
+
+        # --- leader discovery ---
+        self._instance_id = instance_id
+        self._auto_discover_leader = auto_discover_leader
+        self._leader_retry_count = leader_retry_count
+        self._leader_retry_base_interval = leader_retry_base_interval_seconds
+        self._discovery_refresh_interval = discovery_refresh_interval_seconds
+        self._min_discover_interval = min_discover_interval_seconds
+
+        self._leader_lock = asyncio.Lock()
+        self._refresh_event = asyncio.Event()
+        self._closed = False
+        self._last_discover_time: float = 0.0
+        self._refresh_task: asyncio.Task[None] | None = None
+        self._started = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        base_url = self._configured_base_url
+        if base_url and not base_url.startswith(("http://", "https://")):
+            self._service_discovery = create_service_discovery(base_url)
+            if self._service_discovery is None:
+                await self._http_client.aclose()
+                raise ValueError(f"Invalid service discovery address: {base_url}")
+            await self._service_discovery.start()
+            ep = self._service_discovery.get_one_endpoint()
+            if ep is not None:
+                base_url = f"http://{ep.host}"
+                logger.info(
+                    "service discovery resolved manager endpoint",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "discovery_type": self._service_discovery.get_type(),
+                        "base_url": base_url,
+                    },
+                )
+            else:
+                logger.warning(
+                    "service discovery returned no endpoints; "
+                    "waiting for background refresh",
+                    step=_DISCOVERY_STEP,
+                    tags={"discovery_url": base_url},
+                )
+
+        self.base_url = base_url.rstrip("/")
+        self._discovery_url = self.base_url
+
+        if self._auto_discover_leader:
+            try:
+                if await self.is_ready():
+                    await self._discover_leader()
+            except Exception as e:
+                logger.warning(
+                    "initial leader discovery failed; keeping base URL",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "base_url": self.base_url,
+                        "error": e.__class__.__name__,
+                        "message": str(e),
+                    },
+                )
+            self._refresh_task = asyncio.create_task(
+                self._leader_refresh_loop(),
+                name="kvcm-leader-refresh",
+            )
+        self._started = True
+
+    async def is_ready(self) -> bool:
+        """Return whether requests have a usable HTTP endpoint."""
+
+        if self.base_url.startswith(("http://", "https://")):
+            return True
+        if self._service_discovery is None:
+            return False
+        endpoint = self._service_discovery.get_one_endpoint()
+        if endpoint is None:
+            return False
+        async with self._leader_lock:
+            # Re-check under the lock: a concurrent leader discovery may have
+            # resolved base_url already, and it must not be clobbered.
+            if not self.base_url.startswith(("http://", "https://")):
+                self.base_url = f"http://{endpoint.host}"
+                logger.info(
+                    "service discovery recovered manager endpoint",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "discovery_type": self._service_discovery.get_type(),
+                        "base_url": self.base_url,
+                    },
+                )
+        return True
+
+    # ----- leader discovery internals -----
+
+    @staticmethod
+    def _get_status_code(response_data: dict[str, Any]) -> str | None:
+        code: str | None = response_data.get("header", {}).get("status", {}).get("code")
+        return code
+
+    async def _discover_leader(self) -> bool:
+        snapshot = self.base_url
+        async with self._leader_lock:
+            if self.base_url != snapshot:
+                return True
+            return await self._do_discover_leader()
+
+    def _resolve_discovery_url(self) -> str:
+        """Return a fresh URL for leader discovery queries.
+
+        When service discovery is available, pick a (possibly different)
+        endpoint each time so we are not stuck on a single dead node.
+        Falls back to the static ``_discovery_url`` seed address.
+        """
+        if self._service_discovery is not None:
+            ep = self._service_discovery.get_one_endpoint()
+            if ep is not None:
+                return f"http://{ep.host}"
+        return self._discovery_url
+
+    async def _do_discover_leader(self) -> bool:
+        """Actual discovery logic. Must be called under ``_leader_lock``."""
+        url = self._resolve_discovery_url()
+        try:
+            try:
+                resp = await self._http_client.post(
+                    url + "/api/getClusterInfo",
+                    json={
+                        "trace_id": f"leader_discovery_{time.monotonic()}",
+                        "instance_id": self._instance_id,
+                    },
+                    headers=self.headers,
+                    timeout=self._request_timeout_seconds,
+                )
+            except Exception as e:
+                logger.warning(
+                    "leader discovery request failed",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "url": url,
+                        "error": e.__class__.__name__,
+                        "message": str(e),
+                    },
+                )
+                return False
+
+            if resp.status_code != 200:
+                logger.warning(
+                    "leader discovery returned unexpected status",
+                    step=_DISCOVERY_STEP,
+                    tags={"url": url, "status_code": resp.status_code},
+                )
+                return False
+
+            try:
+                data = resp.json()
+            except Exception as e:
+                logger.warning(
+                    "leader discovery response is not valid JSON",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "url": url,
+                        "error": e.__class__.__name__,
+                        "message": str(e),
+                    },
+                )
+                return False
+
+            if self._get_status_code(data) != "OK":
+                msg = data.get("header", {}).get("status", {}).get("message", "unknown")
+                logger.warning(
+                    "leader discovery returned error",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "url": url,
+                        "kvcm_status_code": self._get_status_code(data) or "Unknown",
+                        "message": msg,
+                    },
+                )
+                return False
+
+            leader_ep = data.get("leader_endpoint")
+            if (
+                not leader_ep
+                or not leader_ep.get("host")
+                or not leader_ep.get("meta_http_port")
+            ):
+                logger.warning(
+                    "leader discovery response missing leader endpoint",
+                    step=_DISCOVERY_STEP,
+                    tags={"url": url},
+                )
+                return False
+
+            new_url = f"http://{leader_ep['host']}:{leader_ep['meta_http_port']}"
+            if new_url != self.base_url:
+                logger.info(
+                    "leader discovery switched manager endpoint",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "previous_base_url": self.base_url,
+                        "base_url": new_url,
+                    },
+                )
+                self.base_url = new_url
+            return True
+        finally:
+            self._last_discover_time = time.monotonic()
+
+    async def _leader_refresh_loop(self) -> None:
+        """Background daemon: periodically refresh leader address."""
+        while not self._closed:
+            try:
+                await asyncio.wait_for(
+                    self._refresh_event.wait(),
+                    timeout=self._discovery_refresh_interval,
+                )
+            except TimeoutError:
+                pass
+            self._refresh_event.clear()
+            if self._closed:
+                break
+            remaining = self._min_discover_interval - (
+                time.monotonic() - self._last_discover_time
+            )
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+                if self._closed:
+                    break
+            try:
+                await self._discover_leader()
+            except Exception as e:
+                logger.warning(
+                    "background leader refresh failed",
+                    step=_DISCOVERY_STEP,
+                    tags={
+                        "error": e.__class__.__name__,
+                        "message": str(e),
+                    },
+                )
+
+    # ----- HTTP request helpers -----
+
+    def _notify_leader_refresh(self) -> None:
+        """Wake the background leader-refresh loop when discovery is enabled."""
+        if self._auto_discover_leader:
+            self._refresh_event.set()
+
+    async def _request(
+        self,
+        endpoint: str,
+        data: dict[str, Any],
+        check_response: bool = True,
+    ) -> dict[str, Any]:
+        retries_left = self._leader_retry_count if self._auto_discover_leader else 0
+        retry_count = 0
+
+        while True:
+            url = self.base_url + endpoint
+            try:
+                response = await self._http_client.post(
+                    url,
+                    json=data,
+                    headers=self.headers,
+                    timeout=self._request_timeout_seconds,
+                )
+            except httpx.TimeoutException as e:
+                logger.warning(
+                    "kvcm request timed out",
+                    step=_REQUEST_STEP,
+                    tags={
+                        "url": url,
+                        "timeout_seconds": self._request_timeout_seconds,
+                        "error": e.__class__.__name__,
+                    },
+                )
+                self._notify_leader_refresh()
+                raise
+            except httpx.ConnectError as e:
+                logger.warning(
+                    "kvcm request connection failed; notifying leader refresh",
+                    step=_REQUEST_STEP,
+                    tags={
+                        "url": url,
+                        "error": e.__class__.__name__,
+                        "message": str(e),
+                    },
+                )
+                self._notify_leader_refresh()
+                raise
+            except httpx.RequestError as e:
+                logger.warning(
+                    "kvcm request failed",
+                    step=_REQUEST_STEP,
+                    tags={
+                        "url": url,
+                        "error": e.__class__.__name__,
+                        "message": str(e),
+                    },
+                )
+                raise
+
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError:
+                logger.warning(
+                    "kvcm request returned http error status",
+                    step=_REQUEST_STEP,
+                    tags={"url": url, "status_code": response.status_code},
+                )
+                raise
+            try:
+                payload: dict[str, Any] = response.json()
+            except ValueError as e:
+                logger.warning(
+                    "kvcm response is not valid JSON",
+                    step=_REQUEST_STEP,
+                    tags={
+                        "url": url,
+                        "status_code": response.status_code,
+                        "error": e.__class__.__name__,
+                        "message": str(e),
+                    },
+                )
+                raise
+
+            # SERVER_NOT_LEADER handling
+            if (
+                self._auto_discover_leader
+                and self._get_status_code(payload) == "SERVER_NOT_LEADER"
+            ):
+                if retries_left > 0:
+                    retries_left -= 1
+                    retry_count += 1
+                    sleep_time = (
+                        self._leader_retry_base_interval * retry_count
+                        + random.uniform(0, self._leader_retry_base_interval)
+                    )
+                    logger.warning(
+                        "kvcm request returned SERVER_NOT_LEADER; retrying",
+                        step=_REQUEST_STEP,
+                        tags={
+                            "endpoint": endpoint,
+                            "retry_delay_seconds": round(sleep_time, 3),
+                            "retries_left": retries_left,
+                        },
+                    )
+                    await asyncio.sleep(sleep_time)
+                    await self._discover_leader()
+                    continue
+                if retries_left <= 0:
+                    logger.error(
+                        "kvcm leader discovery retries exhausted",
+                        step=_REQUEST_STEP,
+                        tags={"endpoint": endpoint},
+                    )
+                    # A leader failover in progress is a transient outage, not
+                    # a report rejection: check_response would raise the
+                    # rejected-report error and the batch would be dropped
+                    # permanently instead of retried.
+                    raise KvcmUnavailableError(
+                        f"KVCM leader unavailable for {endpoint}: "
+                        "SERVER_NOT_LEADER and leader discovery exhausted",
+                        status_code="SERVER_NOT_LEADER",
+                        reason="leader_retry_exhausted",
+                        retry_count=retry_count,
+                    )
+
+            if check_response:
+                status = payload.get("header", {}).get("status", {})
+                if status.get("code") != "OK":
+                    item_results = payload.get("item_results")
+                    item_results_detail = (
+                        f"; item_results={item_results!r}" if item_results else ""
+                    )
+                    raise KvcmResponseRejectedError(
+                        f"KVCM {endpoint} failed: "
+                        f"{status.get('code')} {status.get('message')}"
+                        f"{item_results_detail}",
+                        status_code=self._get_status_code(payload) or "UNKNOWN",
+                        retry_count=retry_count,
+                    )
+            if retry_count:
+                payload["_subscriber_retry_count"] = retry_count
+            return payload
+
+    # ----- public API (matches KvCacheManagerClient interface) -----
+
+    async def register_instance(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        return await self._request("/api/registerInstance", data, check_response)
+
+    async def report_event(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        return await self._request("/api/reportEvent", data, check_response)
+
+    async def close(self) -> None:
+        self._closed = True
+        self._refresh_event.set()
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            try:
+                await self._refresh_task
+            except asyncio.CancelledError:
+                pass
+            self._refresh_task = None
+        await self._http_client.aclose()
+        if self._service_discovery is not None:
+            await self._service_discovery.close()

--- a/subscriber/subscriber/kvcm/service_discovery.py
+++ b/subscriber/subscriber/kvcm/service_discovery.py
@@ -1,0 +1,406 @@
+"""Service discovery for Tair KVCM manager endpoints.
+
+Supports URL-based configuration compatible with tair-kvcache C++/Python conventions:
+    - ``static://ip:port[,ip:port]...``
+    - ``spectrum://<virtual_service_id>[?cache_time=<sec>&timeout=<ms>&retry_time=<n>]``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import httpx
+
+from subscriber import logger
+from subscriber.utils.spectrum import (
+    fetch_spectrum_endpoints,
+)
+
+_DISCOVERY_STEP = "kvcm_discovery"
+
+
+@dataclass
+class ServiceEndpoint:
+    """A resolved service endpoint."""
+
+    ip: str
+    port: int
+    host: str  # f"{ip}:{port}"
+    weight: int = 100
+    healthy: bool = True
+
+
+class ServiceDiscovery(ABC):
+    """Service discovery abstract base class."""
+
+    @abstractmethod
+    def get_all_endpoints(self) -> list[ServiceEndpoint]:
+        """Return all available endpoints; empty list on failure."""
+
+    @abstractmethod
+    def get_one_endpoint(self) -> ServiceEndpoint | None:
+        """Return a single endpoint via load-balancing; None if unavailable."""
+
+    @abstractmethod
+    async def refresh(self) -> bool:
+        """Force refresh; return whether successful."""
+
+    @abstractmethod
+    def get_type(self) -> str:
+        """Return implementation type name (e.g. "Static", "Spectrum")."""
+
+    async def start(self) -> None:
+        """Initialize discovery resources; no-op by default."""
+        return None
+
+    async def close(self) -> None:
+        """Release resources; no-op by default."""
+        return None
+
+    def __enter__(self) -> ServiceDiscovery:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> Literal[False]:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Static
+# ---------------------------------------------------------------------------
+
+
+def _parse_host_port_list(host_list: str) -> list[ServiceEndpoint]:
+    if not host_list:
+        raise ValueError("host_list is empty")
+    endpoints: list[ServiceEndpoint] = []
+    for token in host_list.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if ":" not in token:
+            raise ValueError(f"static endpoint missing host:port format: {token!r}")
+        host, _, port_str = token.partition(":")
+        if not host or not port_str:
+            raise ValueError(f"static endpoint missing host or port: {token!r}")
+        if not port_str.isdigit():
+            raise ValueError(f"static endpoint port not numeric: {token!r}")
+        port = int(port_str)
+        if port <= 0 or port > 65535:
+            raise ValueError(f"static endpoint port out of range: {token!r}")
+        endpoints.append(ServiceEndpoint(ip=host, port=port, host=f"{host}:{port}"))
+    if not endpoints:
+        raise ValueError(f"static endpoint list is empty after parsing: {host_list!r}")
+    return endpoints
+
+
+class StaticServiceDiscovery(ServiceDiscovery):
+    """Fixed ip:port list service discovery with round-robin selection."""
+
+    def __init__(
+        self,
+        host_list: str | None = None,
+        *,
+        endpoints: Sequence[ServiceEndpoint] | None = None,
+    ):
+        if endpoints is not None:
+            parsed: list[ServiceEndpoint] = list(endpoints)
+        elif host_list is not None:
+            parsed = _parse_host_port_list(host_list)
+        else:
+            raise ValueError("must provide either host_list or endpoints")
+        if not parsed:
+            raise ValueError("StaticServiceDiscovery init with empty endpoints")
+        self._endpoints: list[ServiceEndpoint] = parsed
+        self._rr_index = 0
+        self._rr_lock = asyncio.Lock()
+
+    def get_type(self) -> str:
+        return "Static"
+
+    def get_all_endpoints(self) -> list[ServiceEndpoint]:
+        return list(self._endpoints)
+
+    def get_one_endpoint(self) -> ServiceEndpoint | None:
+        if not self._endpoints:
+            return None
+        ep = self._endpoints[self._rr_index % len(self._endpoints)]
+        self._rr_index = (self._rr_index + 1) % len(self._endpoints)
+        return ep
+
+    async def refresh(self) -> bool:
+        return bool(self._endpoints)
+
+
+# ---------------------------------------------------------------------------
+# Spectrum
+# ---------------------------------------------------------------------------
+
+
+class SpectrumServiceDiscovery(ServiceDiscovery):
+    """Spectrum gateway service discovery with a background refresh loop."""
+
+    def __init__(
+        self,
+        virtual_service_id: str,
+        *,
+        port_override: int | None = None,
+        cache_ttl: float = 1,
+        refresh_timeout: float = 5,
+        auto_refresh: bool = True,
+        retry_count: int = 0,
+        http_client: Any | None = None,
+    ) -> None:
+        if not virtual_service_id:
+            raise ValueError("virtual_service_id must not be empty")
+        self.virtual_service_id = virtual_service_id
+        self.port_override = port_override
+        self.cache_ttl = cache_ttl
+        self.refresh_timeout = refresh_timeout
+        self.auto_refresh = auto_refresh
+        self.retry_count = max(0, retry_count)
+        if self.cache_ttl <= 0:
+            raise ValueError("spectrum poll interval must be positive")
+
+        self._cache: list[ServiceEndpoint] = []
+        self._cache_lock = asyncio.Lock()
+        self._refresh_lock = asyncio.Lock()
+        self._closed = False
+
+        self._http_client = http_client or httpx.AsyncClient(
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
+        self._refresh_task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        await self.refresh()
+        if self.auto_refresh and self._refresh_task is None:
+            self._refresh_task = asyncio.create_task(
+                self._refresh_loop(),
+                name="spectrum-service-discovery-refresh",
+            )
+
+    def get_type(self) -> str:
+        return "Spectrum"
+
+    def get_all_endpoints(self) -> list[ServiceEndpoint]:
+        return self._cache.copy()
+
+    def get_one_endpoint(self) -> ServiceEndpoint | None:
+        endpoints = self.get_all_endpoints()
+        if not endpoints:
+            return None
+        return random.choice(endpoints)
+
+    async def refresh(self) -> bool:
+        async with self._refresh_lock:
+            total_attempts = self.retry_count + 1
+            last_err: Exception | None = None
+            for _ in range(total_attempts):
+                try:
+                    endpoints = await self._fetch_from_spectrum()
+                    changed = endpoints != self._cache
+                    if changed:
+                        self._cache = endpoints
+                    if changed:
+                        logger.info(
+                            "Spectrum service discovery updated endpoints",
+                            step=_DISCOVERY_STEP,
+                            tags={
+                                "virtual_service_id": self.virtual_service_id,
+                                "endpoint_count": len(endpoints),
+                                "endpoints": [endpoint.host for endpoint in endpoints],
+                            },
+                        )
+                    return True
+                except Exception as e:
+                    last_err = e
+            logger.error(
+                "failed to refresh Spectrum service discovery; "
+                "keeping cached endpoints",
+                step=_DISCOVERY_STEP,
+                tags={
+                    "virtual_service_id": self.virtual_service_id,
+                    "attempt_count": total_attempts,
+                    "error": last_err.__class__.__name__ if last_err else "Unknown",
+                    "message": str(last_err) if last_err else "",
+                    "cached_endpoint_count": len(self._cache),
+                },
+            )
+            return False
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            try:
+                await self._refresh_task
+            except asyncio.CancelledError:
+                pass
+            self._refresh_task = None
+        await self._http_client.aclose()
+
+    async def _refresh_loop(self) -> None:
+        while not self._closed:
+            await asyncio.sleep(self.cache_ttl)
+            if self._closed:
+                break
+            await self.refresh()
+
+    async def _fetch_from_spectrum(self) -> list[ServiceEndpoint]:
+        spectrum_endpoints = await fetch_spectrum_endpoints(
+            self.virtual_service_id,
+            port_override=self.port_override,
+            refresh_timeout=self.refresh_timeout,
+            http_client=self._http_client,
+        )
+        return [
+            ServiceEndpoint(
+                ip=endpoint.ip,
+                port=endpoint.port,
+                host=f"{endpoint.ip}:{endpoint.port}",
+                weight=endpoint.weight,
+            )
+            for endpoint in spectrum_endpoints
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+_SCHEME_STATIC = "static"
+_SCHEME_SPECTRUM = "spectrum"
+
+
+def _parse_discovery_url(
+    url: str,
+) -> tuple[str, str, dict[str, str]] | None:
+    """Parse ``<scheme>://<body>[?k=v(&k=v)*]``."""
+    if not url:
+        return None
+    sep = url.find("://")
+    if sep <= 0:
+        logger.error(
+            "invalid service discovery url",
+            step=_DISCOVERY_STEP,
+            tags={"reason": "missing_scheme", "url": url},
+        )
+        return None
+    scheme = url[:sep]
+    rest = url[sep + 3 :]
+    if not rest:
+        logger.error(
+            "invalid service discovery url",
+            step=_DISCOVERY_STEP,
+            tags={"reason": "empty_body", "url": url},
+        )
+        return None
+    body, sep_char, query = rest.partition("?")
+    params: dict[str, str] = {}
+    if sep_char:
+        for kv in query.split("&"):
+            if not kv:
+                continue
+            k, eq, v = kv.partition("=")
+            params[k] = v if eq else ""
+    if not body:
+        logger.error(
+            "invalid service discovery url",
+            step=_DISCOVERY_STEP,
+            tags={"reason": "empty_body", "url": url},
+        )
+        return None
+    return scheme, body, params
+
+
+def _get_int_param(params: dict[str, str], key: str, default: int) -> int:
+    raw = params.get(key)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def create_service_discovery(url: str) -> ServiceDiscovery | None:
+    """Create a ServiceDiscovery instance from a URL string.
+
+    Supported schemes: ``static://``, ``spectrum://``.
+    Returns None for empty/invalid URLs.
+    """
+    if not url:
+        return None
+    parsed = _parse_discovery_url(url)
+    if parsed is None:
+        return None
+    scheme, body, params = parsed
+
+    if scheme == _SCHEME_STATIC:
+        try:
+            return StaticServiceDiscovery(body)
+        except Exception as e:
+            logger.error(
+                "failed to create static service discovery",
+                step=_DISCOVERY_STEP,
+                tags={
+                    "url": url,
+                    "error": e.__class__.__name__,
+                    "message": str(e),
+                },
+            )
+            return None
+
+    if scheme == _SCHEME_SPECTRUM:
+        # spectrum://vsid or spectrum://vsid:port
+        port_override: int | None = None
+        vsid = body
+        colon_pos = body.rfind(":")
+        if colon_pos > 0:
+            maybe_port = body[colon_pos + 1 :]
+            if maybe_port.isdigit():
+                port_override = int(maybe_port)
+                vsid = body[:colon_pos]
+        cache_ttl = _get_int_param(params, "cache_time", 1)
+        timeout_ms = _get_int_param(params, "timeout", 0)
+        refresh_timeout = max(1, timeout_ms // 1000) if timeout_ms > 0 else 5
+        retry_count = _get_int_param(params, "retry_time", 0)
+        try:
+            return SpectrumServiceDiscovery(
+                vsid,
+                port_override=port_override,
+                cache_ttl=cache_ttl,
+                refresh_timeout=refresh_timeout,
+                retry_count=retry_count,
+            )
+        except Exception as e:
+            logger.error(
+                "failed to create Spectrum service discovery",
+                step=_DISCOVERY_STEP,
+                tags={
+                    "url": url,
+                    "error": e.__class__.__name__,
+                    "message": str(e),
+                },
+            )
+            return None
+
+    logger.error(
+        "unsupported service discovery scheme",
+        step=_DISCOVERY_STEP,
+        tags={"scheme": scheme, "url": url},
+    )
+    return None

--- a/subscriber/subscriber/logger.py
+++ b/subscriber/subscriber/logger.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import gzip
+import logging as _logging
+import os
+import shutil
+import traceback as _tb
+from collections.abc import Callable
+from logging.handlers import RotatingFileHandler
+
+_LOG_FILE_MAX_BYTES = 100 * 1024 * 1024
+_LOG_FILE_BACKUP_COUNT = 3
+try:
+    import dashlog as _dl
+except ImportError:
+    _dl = None
+
+
+def _render_exc(exc_info: object) -> str:
+    """Render ``exc_info`` into a traceback string.
+
+    Accepts ``None`` / ``False`` (no output), ``True`` (current exception via
+    ``sys.exc_info``), a ``(type, value, tb)`` triple (the standard
+    ``sys.exc_info`` shape), or an exception object (uses its
+    ``__traceback__`` and follows ``__cause__`` / ``__context__`` chains).
+    Returns the empty string when there is nothing to render.
+    """
+
+    if exc_info is None or exc_info is False:
+        return ""
+    if exc_info is True:
+        return _tb.format_exc().rstrip()
+    if isinstance(exc_info, BaseException):
+        return "".join(_tb.format_exception(exc_info)).rstrip()
+    if (
+        isinstance(exc_info, tuple)
+        and len(exc_info) == 3
+        and isinstance(exc_info[1], BaseException)
+    ):
+        return "".join(_tb.format_exception(*exc_info)).rstrip()
+    return ""
+
+
+def _render_body(msg: object, args: tuple[object, ...], exc_info: object) -> str:
+    """Percent-format ``msg`` with ``args`` and append a rendered traceback.
+
+    This is the backend-agnostic core shared by the stdlib and dashlog code
+    paths. Backend-specific structured fields (``step``, ``tags``, ...) are
+    handled by each path's wrapper and deliberately NOT folded in here.
+    """
+
+    text = str(msg) % args if args else str(msg)
+    tb = _render_exc(exc_info)
+    return f"{text}\n{tb}" if tb else text
+
+
+def _wrap_dashlog(dl_fn: Callable[..., object]) -> Callable[..., None]:
+    """Forward to a dashlog level function with ``exc_info`` folded into the
+    message string. dashlog itself ignores ``exc_info``; this wrapper makes
+    tracebacks visible by embedding them in the message and strips the kwarg
+    so it never leaks downstream. ``step`` / ``tags`` / ``request_id`` /
+    ``flush`` / ``stacklevel`` pass through in kwargs as native dashlog
+    fields and are NOT rendered into the message."""
+
+    def _log(
+        msg: object,
+        *args: object,
+        exc_info: object = None,
+        **kwargs: object,
+    ) -> None:
+        try:
+            dl_fn(_render_body(msg, args, exc_info), **kwargs)
+        except Exception:
+            pass
+
+    return _log
+
+
+if _dl is not None:
+    _debug_enabled = False
+
+    _LEVEL_TO_INT = {
+        "debug": 9,
+        "info": 7,
+        "warning": 5,
+        "error": 4,
+        "critical": 2,
+    }
+
+    def init(name: str, *, level: str = "info", **_ignored: object) -> None:
+        global _debug_enabled
+        _debug_enabled = level.lower() == "debug"
+        log_level = _LEVEL_TO_INT.get(level.lower(), 7)
+        try:
+            _dl.init(name, log_level=log_level)
+        except Exception:
+            pass
+
+    def is_debug_enabled() -> bool:
+        return _debug_enabled
+
+    debug = _wrap_dashlog(_dl.debug)
+    info = _wrap_dashlog(_dl.info)
+    warning = _wrap_dashlog(_dl.warning)
+    error = _wrap_dashlog(_dl.error)
+    critical = _wrap_dashlog(_dl.critical)
+
+else:
+
+    def _gzip_rotator(source: str, destination: str) -> None:
+        with open(source, "rb") as source_file, gzip.open(destination, "wb") as output:
+            shutil.copyfileobj(source_file, output)
+        os.remove(source)
+
+    class _GzipRotatingFileHandler(RotatingFileHandler):
+        """Rotate logs into compressed backups to bound disk usage."""
+
+        def __init__(
+            self,
+            filename: str | os.PathLike[str],
+            mode: str = "a",
+            maxBytes: int = 0,
+            backupCount: int = 0,
+            encoding: str | None = None,
+            delay: bool = False,
+            errors: str | None = None,
+        ) -> None:
+            super().__init__(
+                filename,
+                mode=mode,
+                maxBytes=maxBytes,
+                backupCount=backupCount,
+                encoding=encoding,
+                delay=delay,
+                errors=errors,
+            )
+            self.namer = lambda default_name: f"{default_name}.gz"
+            self.rotator = _gzip_rotator
+
+    _log = _logging.getLogger("subscriber")
+    _log.setLevel(_logging.INFO)
+    _log.propagate = False
+
+    _fmt = _logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    # Runtime log files must never land in the repo root (AGENTS.md): the
+    # file handler is opt-in via SUBSCRIBER_LOG_FILE. Unset -> stderr only.
+    _log_file = os.environ.get("SUBSCRIBER_LOG_FILE", "")
+    if _log_file:
+        _fh = _GzipRotatingFileHandler(
+            _log_file,
+            maxBytes=_LOG_FILE_MAX_BYTES,
+            backupCount=_LOG_FILE_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+        _fh.setFormatter(_fmt)
+        _log.addHandler(_fh)
+
+    _sh = _logging.StreamHandler()
+    _sh.setFormatter(_fmt)
+    _log.addHandler(_sh)
+
+    def init(name: str, *, level: str = "info", **_: object) -> None:
+        try:
+            log_level = getattr(_logging, level.upper(), _logging.INFO)
+            _log.setLevel(log_level)
+            _log.info("initialized stdlib logging (name=%s)", name)
+        except Exception:
+            pass
+
+    def _make_log(level: int) -> Callable[..., None]:
+        def _log_fn(
+            msg: object,
+            *args: object,
+            step: str = "",
+            tags: dict[str, object] | None = None,
+            exc_info: object = None,
+            **_: object,
+        ) -> None:
+            try:
+                parts = [_render_body(msg, args, exc_info)]
+                if step:
+                    parts.append(f"step={step}")
+                if tags:
+                    parts.append(
+                        " ".join(f"{key}={value}" for key, value in tags.items())
+                    )
+                _log.log(level, " | ".join(parts))
+            except Exception:
+                pass
+
+        return _log_fn
+
+    def is_debug_enabled() -> bool:
+        return _log.isEnabledFor(_logging.DEBUG)
+
+    debug = _make_log(_logging.DEBUG)
+    info = _make_log(_logging.INFO)
+    warning = _make_log(_logging.WARNING)
+    error = _make_log(_logging.ERROR)
+    critical = _make_log(_logging.CRITICAL)

--- a/subscriber/subscriber/main.py
+++ b/subscriber/subscriber/main.py
@@ -1,0 +1,669 @@
+from __future__ import annotations
+
+import asyncio
+import signal
+from collections.abc import Awaitable
+from contextlib import suppress
+from typing import TypeVar
+
+import grpc.aio
+import httpx
+
+from subscriber import logger
+from subscriber.config import SubscriberConfig
+from subscriber.engine.base import AbstractEngineAdapter
+from subscriber.engine.metadata import (
+    KvCacheDescriptor,
+    KvEventBootstrap,
+    MetadataProtocolError,
+    MetadataTemporarilyUnavailable,
+)
+from subscriber.forwarding import (
+    consume_incremental_events,
+    consume_snapshot_events,
+    send_incremental_events,
+    send_snapshot_events,
+)
+from subscriber.health.coordinator import EngineHealthCoordinator
+from subscriber.health.state_reporter import DashservingStateReporter
+from subscriber.kvcm.client import KvcmClient
+from subscriber.metrics import MetricsReporter, init_dashlog
+from subscriber.pipeline.context import PipelineContext
+
+__all__ = [
+    "PipelineContext",
+    "SubscriberLifecycle",
+    "consume_incremental_events",
+    "consume_snapshot_events",
+    "run",
+    "send_incremental_events",
+    "send_snapshot_events",
+]
+
+# Delay between retries of transient startup steps (metadata fetch, KVCM
+# registration wait, first active report). Transient startup errors stay
+# ``starting`` and keep retrying until the deployment startup/liveness policy
+# replaces the Pod; these are not converted to ``failed``.
+_STARTUP_RETRY_DELAY_S = 1.0
+_REGISTRATION_POLL_S = 0.2
+_REGISTRATION_WAIT_WARN_INTERVAL_S = 5.0
+
+_T = TypeVar("_T")
+
+
+class _FatalStartupError(Exception):
+    """A pre-active startup error that must report ``failed`` and exit."""
+
+
+class _ShutdownRequested(Exception):
+    """Shutdown was requested during startup; exit gracefully, not ``failed``."""
+
+
+class SubscriberLifecycle:
+    """Own the subscriber startup order and graceful shutdown sequence.
+
+    Startup order (exactly):
+        engine alive -> metadata success -> KVCM two-step registration ->
+        pipeline tasks running -> accepted active report -> heartbeat running ->
+        forwarding once the engine epoch is ready.
+
+    Fatal pre-active errors (invalid metadata protocol, unsupported adapter)
+    report ``failed`` and exit; transient engine/metadata/KVCM errors remain
+    ``starting`` and keep retrying. Shutdown follows §1.5 in a single ``finally``
+    path; every close is idempotent so a partial startup uses the same path.
+
+    Dependencies (adapter, KVCM client, state reporter) may be injected for
+    tests; otherwise they are constructed from ``config``. Tests inject a
+    ``shutdown_event`` and never send real OS signals.
+    """
+
+    def __init__(
+        self,
+        config: SubscriberConfig,
+        *,
+        adapter: AbstractEngineAdapter | None = None,
+        kvcm_client: KvcmClient | None = None,
+        state_reporter: DashservingStateReporter | None = None,
+        shutdown_event: asyncio.Event | None = None,
+        install_signal_handlers: bool = True,
+        startup_retry_delay_s: float = _STARTUP_RETRY_DELAY_S,
+    ) -> None:
+        self._config = config
+        self._adapter = adapter or AbstractEngineAdapter.create(
+            config.engine_type, config
+        )
+        self._shutdown = shutdown_event or asyncio.Event()
+        self._install_signal_handlers = install_signal_handlers
+        self._startup_retry_delay_s = startup_retry_delay_s
+        self._incremental_pipeline_enabled = (
+            config.incremental_kv_event_pipeline_enabled
+        )
+        self._snapshot_pipeline_enabled = config.snapshot_kv_event_pipeline_enabled
+
+        self._coordinator = EngineHealthCoordinator(self._adapter, None, config)
+        # Reporter is only created when the health link is enabled and not
+        # injected. When disabled, state reporting is skipped entirely.
+        self._state_reporter: DashservingStateReporter | None = None
+        if state_reporter is not None:
+            self._state_reporter = state_reporter
+        elif config.subscriber_health_enabled:
+            self._state_reporter = DashservingStateReporter(config)
+        else:
+            self._state_reporter = None
+
+        self._kvcm: KvcmClient | None = kvcm_client
+        self._watch_task: asyncio.Task[None] | None = None
+        self._incremental_producer_task: asyncio.Task[None] | None = None
+        self._incremental_sender_task: asyncio.Task[None] | None = None
+        self._snapshot_producer_task: asyncio.Task[None] | None = None
+        self._snapshot_sender_task: asyncio.Task[None] | None = None
+        self._incremental_metrics_reporter: MetricsReporter | None = None
+        self._snapshot_metrics_reporter: MetricsReporter | None = None
+        self._active_reported = False
+        self._metadata_protocol_inactive_reported = False
+        self._startup_failure: str | None = None
+        self._task_failure: BaseException | None = None
+
+    @property
+    def coordinator(self) -> EngineHealthCoordinator:
+        return self._coordinator
+
+    @property
+    def shutdown_event(self) -> asyncio.Event:
+        return self._shutdown
+
+    async def run(self) -> None:
+        """Run startup, serve until shutdown, then run the shutdown sequence.
+
+        A fatal pre-active error reports ``failed`` and returns normally. A
+        non-cancellation forwarding/watch task failure is re-raised after
+        cleanup so it is never suppressed.
+        """
+
+        original_handlers = self._install_signals()
+        try:
+            await self._graceful_startup()
+            if self._startup_failure is None:
+                await self._serve_until_shutdown()
+        finally:
+            await self._graceful_shutdown()
+            self._restore_signals(original_handlers)
+        if self._task_failure is not None:
+            raise self._task_failure
+
+    # ------------------------------------------------------------------
+    # Startup
+    # ------------------------------------------------------------------
+
+    async def _graceful_startup(self) -> None:
+        try:
+            # 1. Engine alive: start the watcher, then gate on a sendable epoch.
+            self._watch_task = asyncio.create_task(
+                self._coordinator.watch_loop(), name="engine-health-watch"
+            )
+            await self._await_or_shutdown(
+                self._coordinator.wait_ready_epoch(), "before engine ready"
+            )
+            logger.info("engine ready", step="startup", tags={})
+
+            # 2. Bootstrap success; the adapter opens engine-owned ZMQ endpoints.
+            bootstrap = await self._await_or_shutdown(
+                self._fetch_kv_event_bootstrap_until_success(),
+                "during KV event bootstrap fetch",
+            )
+            logger.info(
+                "KV event bootstrap fetched",
+                step="startup",
+                tags={
+                    "bootstrap_info": bootstrap.to_log_json(),
+                },
+            )
+
+            # 3. KVCM two-step registration through the subscriber translation.
+            await self._await_or_shutdown(
+                self._register_kvcm(bootstrap.to_kv_cache_descriptor()),
+                "during kvcm registration",
+            )
+            logger.info("kvcm registered", step="startup", tags={})
+
+            # 4. Pipeline tasks running (gated until the epoch is sendable).
+            await self._await_or_shutdown(
+                self._start_pipeline(), "during pipeline start"
+            )
+            logger.info(
+                "pipelines started",
+                step="startup",
+                tags={
+                    "incremental_pipeline": self._incremental_pipeline_enabled,
+                    "snapshot_pipeline": self._snapshot_pipeline_enabled,
+                    "incremental_queue_maxsize": (
+                        self._config.kv_event_queue_maxsize
+                        if self._incremental_pipeline_enabled
+                        else None
+                    ),
+                    "snapshot_queue_maxsize": (
+                        self._config.snapshot_queue_maxsize
+                        if self._snapshot_pipeline_enabled
+                        else None
+                    ),
+                },
+            )
+
+            # 5. Accepted active report.
+            await self._await_or_shutdown(
+                self._report_active_until_accepted(), "during active report"
+            )
+
+            # 6. Heartbeat running.
+            if self._state_reporter is not None and self._active_reported:
+                self._state_reporter.start_heartbeat()
+
+            # 7. Forwarding once the engine epoch is ready. The gate opened in
+            # step 1; this re-confirms a sendable epoch before serving begins.
+            await self._await_or_shutdown(
+                self._coordinator.wait_ready_epoch(), "before serving"
+            )
+
+            logger.info(
+                "subscriber started",
+                step="startup",
+                tags={
+                    "engine_type": self._config.engine_type,
+                    "kvcm_base_url": self._config.kvcm_base_url,
+                    "kvcm_protocol": self._config.kvcm_protocol,
+                    "kvcm_instance_group": self._config.kvcm_instance_group,
+                    "engine_grpc_endpoint": self._config.engine_grpc_endpoint,
+                    "engine_kv_event_control_uds_path": (
+                        self._config.engine_kv_event_control_uds_path
+                    ),
+                    "host_port": self._config.host_port,
+                    "kvcm_heartbeat_interval_s": (
+                        self._config.kvcm_heartbeat_interval_s
+                    ),
+                    "kv_event_merge_max_report_events": (
+                        self._config.kv_event_merge_max_report_events
+                    ),
+                    "kv_event_merge_max_queue_items": (
+                        self._config.kv_event_merge_max_queue_items
+                    ),
+                    "incremental_pipeline_enabled": self._incremental_pipeline_enabled,
+                    "snapshot_pipeline_enabled": self._snapshot_pipeline_enabled,
+                    "engine_health_interval_s": self._config.engine_health_interval_s,
+                    "engine_health_failure_threshold": (
+                        self._config.engine_health_failure_threshold
+                    ),
+                    "subscriber_health_enabled": (
+                        self._config.subscriber_health_enabled
+                    ),
+                },
+            )
+        except _ShutdownRequested as exc:
+            # Graceful shutdown during startup: exit without reporting failed.
+            self._startup_failure = str(exc)
+            logger.info(
+                "subscriber shutdown requested during startup",
+                step="startup",
+                tags={"reason": str(exc)},
+            )
+        except _FatalStartupError as exc:
+            self._startup_failure = str(exc)
+            logger.error(
+                "subscriber startup failed; reporting failed",
+                step="startup",
+                tags={"reason": str(exc)},
+            )
+            if self._state_reporter is not None:
+                await self._state_reporter.report_failed(str(exc))
+
+    async def _await_or_shutdown(self, coro: Awaitable[_T], description: str) -> _T:
+        """Race an awaitable against shutdown.
+
+        Raises _ShutdownRequested if shutdown wins.
+        """
+
+        task = asyncio.ensure_future(coro)
+        shutdown_waiter = asyncio.create_task(self._shutdown.wait())
+        done, pending = await asyncio.wait(
+            {task, shutdown_waiter}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for p in pending:
+            p.cancel()
+            try:
+                await p
+            except asyncio.CancelledError:
+                pass
+        if shutdown_waiter in done:
+            raise _ShutdownRequested(f"shutdown requested {description}")
+        # Re-raise any exception from the task
+        return task.result()
+
+    async def _fetch_kv_event_bootstrap_until_success(self) -> KvEventBootstrap:
+        """Fetch authoritative bootstrap, retrying transient failures.
+
+        ``MetadataProtocolError`` is fatal and reports ``failed``. Only
+        ``MetadataTemporarilyUnavailable``, gRPC
+        transport errors, timeouts, and OS connection errors are transient and
+        keep the subscriber ``starting``. All other exceptions are fatal.
+        """
+
+        while True:
+            if self._shutdown.is_set():
+                raise _ShutdownRequested("shutdown requested during bootstrap fetch")
+            try:
+                return await self._adapter.fetch_kv_event_bootstrap()
+            except MetadataProtocolError as exc:
+                raise _FatalStartupError(
+                    f"KV event bootstrap protocol error: {exc}"
+                ) from exc
+            except (
+                MetadataTemporarilyUnavailable,
+                grpc.aio.AioRpcError,
+                TimeoutError,
+                OSError,
+            ) as exc:
+                logger.warning(
+                    "KV event bootstrap temporarily unavailable; retrying",
+                    step="startup",
+                    tags={"error": exc.__class__.__name__, "message": str(exc)},
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                raise _FatalStartupError(
+                    f"KV event bootstrap fetch failed fatally: {exc}"
+                ) from exc
+            await self._sleep_or_shutdown(self._startup_retry_delay_s)
+
+    async def _register_kvcm(self, descriptor: KvCacheDescriptor) -> None:
+        if self._kvcm is None:
+            try:
+                KvcmClient.validate_descriptor_location_specs(self._config, descriptor)
+            except MetadataProtocolError as exc:
+                raise _FatalStartupError(
+                    f"KV cache descriptor protocol error: {exc}"
+                ) from exc
+            self._kvcm = KvcmClient(
+                self._config,
+                medium_mapper=self._adapter.map_medium,
+                storage_type=self._adapter.storage_type(),
+                supported_mediums=self._adapter.supported_mediums(),
+                descriptor=descriptor,
+                on_snapshot_required=self._adapter.request_immediate_snapshot,
+            )
+        else:
+            try:
+                self._kvcm.validate_location_specs()
+            except MetadataProtocolError as exc:
+                raise _FatalStartupError(
+                    f"KV cache descriptor protocol error: {exc}"
+                ) from exc
+        await self._kvcm.start()
+        self._coordinator.attach_kvcm_client(self._kvcm)
+        await self._wait_kvcm_registered()
+
+    async def _wait_kvcm_registered(self) -> None:
+        """Wait for the KVCM two-step registration to succeed.
+
+        ``KvcmClient.start()`` may return in a not-ready state; registration is
+        completed by its internal heartbeat loop. A not-yet-registered state is
+        transient, so this waits (polling ``is_registered``) rather than failing.
+        A periodic warning surfaces a stalled registration.
+        """
+
+        assert self._kvcm is not None
+        waited_s = 0.0
+        last_warn_s = 0.0
+        while not self._kvcm.is_registered:
+            await self._await_or_shutdown(
+                self._sleep_or_shutdown(_REGISTRATION_POLL_S),
+                "during kvcm registration",
+            )
+            waited_s += _REGISTRATION_POLL_S
+            if waited_s - last_warn_s >= _REGISTRATION_WAIT_WARN_INTERVAL_S:
+                last_warn_s = waited_s
+                logger.warning(
+                    "still waiting for kvcm registration",
+                    step="startup",
+                    tags={"waited_s": round(waited_s, 1)},
+                )
+
+    async def _start_pipeline(self) -> None:
+        assert self._kvcm is not None
+        if self._incremental_pipeline_enabled:
+            self._incremental_metrics_reporter = MetricsReporter(
+                task_name="incremental-kv-event-metrics",
+            )
+            await self._incremental_metrics_reporter.start()
+            incremental_queue: asyncio.Queue[PipelineContext] = asyncio.Queue(
+                maxsize=self._config.kv_event_queue_maxsize
+            )
+            self._incremental_producer_task = asyncio.create_task(
+                consume_incremental_events(
+                    self._adapter,
+                    self._coordinator,
+                    incremental_queue,
+                    self._incremental_metrics_reporter,
+                ),
+                name="incremental-kv-event-producer",
+            )
+            self._incremental_sender_task = asyncio.create_task(
+                send_incremental_events(
+                    self._kvcm,
+                    self._coordinator,
+                    incremental_queue,
+                    max_merged_report_events=(
+                        self._config.kv_event_merge_max_report_events
+                    ),
+                    max_merged_queue_items=self._config.kv_event_merge_max_queue_items,
+                    pipeline="incremental",
+                    on_snapshot_required=self._adapter.request_immediate_snapshot,
+                    on_metadata_protocol_error=(
+                        self._report_metadata_protocol_inactive
+                    ),
+                ),
+                name="incremental-kv-event-sender",
+            )
+
+        if self._snapshot_pipeline_enabled:
+            self._snapshot_metrics_reporter = MetricsReporter(
+                task_name="snapshot-kv-event-metrics",
+            )
+            await self._snapshot_metrics_reporter.start()
+            snapshot_queue: asyncio.Queue[PipelineContext] = asyncio.Queue(
+                maxsize=self._config.snapshot_queue_maxsize
+            )
+            self._snapshot_producer_task = asyncio.create_task(
+                consume_snapshot_events(
+                    self._adapter,
+                    self._coordinator,
+                    snapshot_queue,
+                    self._snapshot_metrics_reporter,
+                ),
+                name="snapshot-kv-event-producer",
+            )
+            self._snapshot_sender_task = asyncio.create_task(
+                send_snapshot_events(
+                    self._kvcm,
+                    self._coordinator,
+                    snapshot_queue,
+                    pipeline="snapshot",
+                    on_metadata_protocol_error=(
+                        self._report_metadata_protocol_inactive
+                    ),
+                ),
+                name="snapshot-kv-event-sender",
+            )
+
+    async def _report_active_until_accepted(self) -> None:
+        if self._state_reporter is None:
+            return
+        while True:
+            if self._shutdown.is_set():
+                raise _ShutdownRequested("shutdown requested during active report")
+            try:
+                await self._state_reporter.report_active()
+                self._active_reported = True
+                return
+            except (
+                httpx.TransportError,
+                httpx.HTTPStatusError,
+                TimeoutError,
+                OSError,
+            ) as exc:
+                logger.warning(
+                    "active state report not accepted; retrying",
+                    step="startup",
+                    tags={"error": exc.__class__.__name__, "message": str(exc)},
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                raise _FatalStartupError(
+                    f"active state report failed fatally: {exc}"
+                ) from exc
+            await self._sleep_or_shutdown(self._startup_retry_delay_s)
+
+    async def _report_metadata_protocol_inactive(self) -> None:
+        """Make DashServing terminally unhealthy after a local metadata breach."""
+
+        if self._metadata_protocol_inactive_reported:
+            return
+        self._metadata_protocol_inactive_reported = True
+        if self._state_reporter is not None:
+            await self._state_reporter.report_shutdown_inactive("metadata_protocol")
+
+    # ------------------------------------------------------------------
+    # Serving
+    # ------------------------------------------------------------------
+
+    async def _serve_until_shutdown(self) -> None:
+        assert self._watch_task is not None
+        pipeline_tasks = [
+            self._watch_task,
+        ]
+        if self._snapshot_pipeline_enabled:
+            assert self._snapshot_producer_task is not None
+            assert self._snapshot_sender_task is not None
+            pipeline_tasks.extend(
+                [self._snapshot_producer_task, self._snapshot_sender_task]
+            )
+        if self._incremental_pipeline_enabled:
+            assert self._incremental_producer_task is not None
+            assert self._incremental_sender_task is not None
+            pipeline_tasks.extend(
+                [self._incremental_producer_task, self._incremental_sender_task]
+            )
+        shutdown_waiter = asyncio.create_task(
+            self._shutdown.wait(), name="shutdown-waiter"
+        )
+        tasks = [*pipeline_tasks, shutdown_waiter]
+        try:
+            done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            shutdown_waiter.cancel()
+            with suppress(asyncio.CancelledError):
+                await shutdown_waiter
+        first_failure: BaseException | None = None
+        for task in pipeline_tasks:
+            if task in done and not task.cancelled():
+                exc = task.exception()
+                if exc is None:
+                    exc = RuntimeError(f"{task.get_name()} ended unexpectedly")
+                logger.error(
+                    "subscriber task failed; initiating shutdown",
+                    step="lifecycle",
+                    tags={
+                        "task": task.get_name(),
+                        "error": exc.__class__.__name__,
+                        "message": str(exc),
+                    },
+                )
+                if first_failure is None:
+                    first_failure = exc
+        if first_failure is not None:
+            self._task_failure = first_failure
+            self._shutdown.set()
+
+    # ------------------------------------------------------------------
+    # Shutdown (§1.5)
+    # ------------------------------------------------------------------
+
+    async def _graceful_shutdown(self) -> None:
+        logger.info("graceful shutdown started", step="shutdown", tags={})
+        # 1. Set shutdown flag: no new forwarding permit is issued.
+        self._shutdown.set()
+
+        # 2. Stop/cancel pipeline tasks, await them, so no KV batch can race
+        #    behind AllBlocksCleared. The watch task is stopped too so it
+        #    cannot emit a concurrent HostDown for the same epoch.
+        await self._cancel_task(self._incremental_producer_task)
+        await self._cancel_task(self._incremental_sender_task)
+        await self._cancel_task(self._snapshot_producer_task)
+        await self._cancel_task(self._snapshot_sender_task)
+        await self._cancel_task(self._watch_task)
+        if self._incremental_metrics_reporter is not None:
+            await self._incremental_metrics_reporter.stop()
+            self._incremental_metrics_reporter = None
+        if self._snapshot_metrics_reporter is not None:
+            await self._snapshot_metrics_reporter.stop()
+            self._snapshot_metrics_reporter = None
+        logger.info("pipeline tasks stopped", step="shutdown", tags={})
+
+        # 3. Stop and await the state heartbeat task.
+        if self._state_reporter is not None:
+            await self._state_reporter.stop_heartbeat()
+
+        # 4. HostDown: at most one AllBlocksCleared for a sendable epoch.
+        await self._coordinator.report_host_down("shutdown")
+        logger.info("host_down reported", step="shutdown", tags={})
+
+        # 5. POST higher-seq inactive with a bounded timeout (best effort).
+        if (
+            self._state_reporter is not None
+            and not self._metadata_protocol_inactive_reported
+        ):
+            await self._state_reporter.report_shutdown_inactive("shutdown")
+            logger.info("inactive reported", step="shutdown", tags={})
+
+        # 6. Close KVCM, gRPC/HTTP clients, engine adapter (each idempotent).
+        if self._kvcm is not None:
+            await self._kvcm.close()
+        if self._state_reporter is not None:
+            await self._state_reporter.close()
+        await self._adapter.close()
+        logger.info("graceful shutdown complete", step="shutdown", tags={})
+
+    @staticmethod
+    async def _cancel_task(task: asyncio.Task[None] | None) -> None:
+        if task is None or task.done():
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    async def _sleep_or_shutdown(self, delay_s: float) -> None:
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._shutdown.wait(), timeout=delay_s)
+
+    # ------------------------------------------------------------------
+    # Signal handling
+    # ------------------------------------------------------------------
+
+    def _install_signals(self) -> dict[int, object]:
+        original: dict[int, object] = {}
+        if not self._install_signal_handlers:
+            return original
+        try:
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                original[sig] = signal.getsignal(sig)
+                loop.add_signal_handler(sig, self._request_shutdown, sig)
+        except (NotImplementedError, RuntimeError):
+            # Platform without loop signal handlers (e.g. Windows proactor) or
+            # no running loop: rely on the injected/external shutdown event.
+            return {}
+        return original
+
+    def _restore_signals(self, original: dict[int, object]) -> None:
+        if not original:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            for sig in original:
+                loop.remove_signal_handler(sig)
+            for sig, handler in original.items():
+                if callable(handler):
+                    signal.signal(sig, handler)
+        except (NotImplementedError, RuntimeError, ValueError):
+            pass
+
+    def _request_shutdown(self, sig: signal.Signals) -> None:
+        logger.info(
+            "received signal; requesting graceful shutdown",
+            step="lifecycle",
+            tags={"signal": sig.name},
+        )
+        self._shutdown.set()
+
+
+async def run(
+    config: SubscriberConfig,
+    *,
+    shutdown_event: asyncio.Event | None = None,
+    adapter: AbstractEngineAdapter | None = None,
+    kvcm_client: KvcmClient | None = None,
+    state_reporter: DashservingStateReporter | None = None,
+    install_signal_handlers: bool = True,
+) -> None:
+    """Run the subscriber until shutdown, cancellation, or fatal startup error."""
+
+    init_dashlog("kvcache-subscriber")
+    lifecycle = SubscriberLifecycle(
+        config,
+        adapter=adapter,
+        kvcm_client=kvcm_client,
+        state_reporter=state_reporter,
+        shutdown_event=shutdown_event,
+        install_signal_handlers=install_signal_handlers,
+    )
+    await lifecycle.run()

--- a/subscriber/subscriber/metrics/__init__.py
+++ b/subscriber/subscriber/metrics/__init__.py
@@ -1,0 +1,59 @@
+"""Subscriber metrics package.
+
+This package exposes two clearly separated surfaces:
+
+- **Main-path metrics**: per-batch telemetry produced by the forwarding and
+  snapshot pipelines. Callers construct a :class:`BatchTelemetry` per event,
+  ``mark`` / ``count`` / ``mark_dropped`` on it during the pipeline, and
+  finally submit it to the pipeline's :class:`MetricsReporter` for
+  asynchronous flush to dashlog. This is the single async output for all
+  hot-path metric emission.
+
+- **Lifecycle metrics**: sparse, point-event counters and histograms that
+  live outside the main path (engine health probes, KVCM heartbeat, ZMQ
+  message throughput, subscriber shutdown, ...). Each lifecycle helper is a
+  synchronous, best-effort ``report_xxx()`` function that writes to dashlog
+  directly.
+
+The ``_base`` module provides the underlying dashlog wrappers and the
+``init_dashlog`` bootstrap; callers should prefer the higher-level helpers
+above over reaching for the ``_dashlog_*`` primitives directly.
+"""
+
+from subscriber.metrics._base import (
+    _dashlog_counter,
+    _dashlog_gauge,
+    init_dashlog,
+)
+from subscriber.metrics.lifecycle import (
+    report_dashserving_heartbeat,
+    report_dashserving_state_report,
+    report_engine_probe,
+    report_engine_state_transition,
+    report_heartbeat,
+    report_registration_recovery,
+    report_registration_transition,
+    report_shutdown,
+    report_subscriber_phase_transition,
+    report_zmq_message,
+)
+from subscriber.metrics.reporter import BatchTelemetry, MetricsReporter, Span
+
+__all__ = [
+    "BatchTelemetry",
+    "MetricsReporter",
+    "Span",
+    "_dashlog_counter",
+    "_dashlog_gauge",
+    "init_dashlog",
+    "report_dashserving_heartbeat",
+    "report_dashserving_state_report",
+    "report_engine_probe",
+    "report_engine_state_transition",
+    "report_heartbeat",
+    "report_registration_recovery",
+    "report_registration_transition",
+    "report_shutdown",
+    "report_subscriber_phase_transition",
+    "report_zmq_message",
+]

--- a/subscriber/subscriber/metrics/_base.py
+++ b/subscriber/subscriber/metrics/_base.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Mapping
+
+try:
+    import dashlog as _dashlog
+except ImportError:
+    _dashlog = None
+
+_METRIC_PREFIX = "kvcache_subscriber_"
+
+_RESET_INTERVAL_S = 10.0
+_counter_accumulators: dict[tuple[str, tuple[tuple[str, str], ...]], float] = {}
+_counter_last_reset_s: float = 0.0
+
+# Mirrors dashlog EASOTelClient::Enabled() truthiness so the subscriber's
+# counter routing never disagrees with the native backend.
+_OTEL_DISABLED_VALUES = frozenset(("false", "False", "FALSE", "0"))
+
+
+def _otel_enabled() -> bool:
+    val = os.environ.get("DS_EAS_USE_OTEL")
+    return bool(val) and val not in _OTEL_DISABLED_VALUES
+
+
+def _dashlog_init(app_name: str) -> None:
+    if _dashlog is not None:
+        _dashlog.Init(app_name)
+
+
+def _dashlog_gauge(
+    name: str, value: float, tags: Mapping[str, str] | None = None
+) -> None:
+    if _dashlog is not None:
+        _dashlog.Gauge(
+            _METRIC_PREFIX + name, value, tags=dict(tags or {}), add_app_prefix=False
+        )
+
+
+def _dashlog_counter(
+    name: str, value: int, tags: Mapping[str, str] | None = None
+) -> None:
+    if _otel_enabled():
+        # ASI-EAS (DS_EAS_USE_OTEL): dashlog routes Counter to the native OTel
+        # instrument with delta semantics, so no local accumulation is needed.
+        # Truthiness mirrors EASOTelClient::Enabled() (dashlog
+        # csrc/metrics/eas_otel_client.cc:1136); Counter accepts non-negative
+        # deltas only, and all callers pass counts.
+        if _dashlog is None:
+            return
+        try:
+            _dashlog.Counter(
+                _METRIC_PREFIX + name,
+                value,
+                tags=dict(tags or {}),
+                add_app_prefix=False,
+            )
+        except Exception:
+            pass
+        return
+    # PAI-EAS: EASClient::AddCounters drops data when OTel is disabled, so
+    # route counters through Gauge to reach /realtime_metrics.
+    # Limitation: the reset (and idle-key zeroing) is driven lazily by the
+    # next counter that fires, so if every counter goes idle the last window
+    # values remain until any counter fires again.
+    global _counter_last_reset_s
+    now = time.monotonic()
+    key = (name, tuple(sorted((tags or {}).items())))
+    if now - _counter_last_reset_s >= _RESET_INTERVAL_S:
+        stale_keys = [k for k in _counter_accumulators if k != key]
+        _counter_accumulators.clear()
+        _counter_last_reset_s = now
+        for stale_name, stale_tags in stale_keys:
+            try:
+                _dashlog_gauge(stale_name, 0.0, tags=dict(stale_tags) or None)
+            except Exception:
+                pass
+    accumulated = _counter_accumulators.get(key, 0.0) + value
+    _counter_accumulators[key] = accumulated
+    try:
+        _dashlog_gauge(name, accumulated, tags=tags)
+    except Exception:
+        pass
+
+
+def init_dashlog(app_name: str) -> None:
+    from subscriber import logger
+
+    if _dashlog is None:
+        logger.warning(
+            "dashlog is unavailable; metrics reporting is disabled",
+            step="metrics_init",
+            tags={"app_name": app_name},
+        )
+        return
+    try:
+        _dashlog_init(app_name)
+    except Exception as exc:
+        logger.warning(
+            "dashlog init failed; metrics reporting is disabled",
+            step="metrics_init",
+            tags={
+                "app_name": app_name,
+                "error": exc.__class__.__name__,
+                "message": str(exc),
+            },
+        )

--- a/subscriber/subscriber/metrics/lifecycle.py
+++ b/subscriber/subscriber/metrics/lifecycle.py
@@ -1,0 +1,142 @@
+"""Lifecycle metric helpers — synchronous, low-frequency, point-event counters.
+
+These functions cover metrics that are not part of the main forwarding path:
+
+- Engine and subscriber health transitions.
+- KVCM registration and heartbeat.
+- DashServing heartbeats and state reports.
+- Individual ZMQ message receipts (background throughput counter).
+- Subscriber shutdown outcomes.
+
+Per-batch main-path metrics (forwarding stages, snapshot fetch/build,
+drop counts, etc.) go through :class:`~subscriber.metrics.MetricsReporter`
+instead — see :mod:`subscriber.metrics.reporter`.
+
+Each helper wraps the underlying dashlog call in ``try/except`` so metric
+reporting never blocks or fails the caller. Every metric preserves the
+``kvcache_subscriber_`` prefix and its tags exactly as before the refactor.
+"""
+
+from __future__ import annotations
+
+from subscriber.metrics._base import _dashlog_counter, _dashlog_gauge
+
+# ---------------------------------------------------------------------------
+# Engine and subscriber health
+# ---------------------------------------------------------------------------
+
+
+def report_engine_probe(result: str, latency_ms: float) -> None:
+    try:
+        _dashlog_counter("engine_health_probe_count", 1, tags={"result": result})
+        _dashlog_gauge(
+            "engine_health_probe_latency_ms", latency_ms, tags={"result": result}
+        )
+    except Exception:
+        pass
+
+
+def report_engine_state_transition(from_state: str, to_state: str) -> None:
+    try:
+        _dashlog_counter(
+            "engine_health_state_transition_count",
+            1,
+            tags={"from": from_state, "to": to_state},
+        )
+    except Exception:
+        pass
+
+
+def report_subscriber_phase_transition(from_phase: str, to_phase: str) -> None:
+    try:
+        _dashlog_counter(
+            "subscriber_phase_transition_count",
+            1,
+            tags={"from": from_phase, "to": to_phase},
+        )
+    except Exception:
+        pass
+
+
+def report_dashserving_heartbeat(success: bool) -> None:
+    try:
+        _dashlog_counter(
+            "dashserving_heartbeat_count",
+            1,
+            tags={"status": "success" if success else "failure"},
+        )
+    except Exception:
+        pass
+
+
+def report_dashserving_state_report(
+    state: str,
+    result: str,
+    latency_ms: float,
+) -> None:
+    try:
+        tags = {"state": state, "result": result}
+        _dashlog_counter("dashserving_state_report_count", 1, tags=tags)
+        _dashlog_gauge("dashserving_state_report_latency_ms", latency_ms, tags=tags)
+    except Exception:
+        pass
+
+
+def report_shutdown(outcome: str) -> None:
+    try:
+        _dashlog_counter("subscriber_shutdown_count", 1, tags={"outcome": outcome})
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# KVCM registration and heartbeat
+# ---------------------------------------------------------------------------
+
+
+def report_heartbeat(success: bool) -> None:
+    try:
+        _dashlog_counter(
+            "kvcm_heartbeat_count",
+            1,
+            tags={"status": "success" if success else "failure"},
+        )
+    except Exception:
+        pass
+
+
+def report_registration_recovery() -> None:
+    try:
+        _dashlog_counter("kvcm_registration_recovery_count", 1)
+    except Exception:
+        pass
+
+
+def report_registration_transition(from_state: str, to_state: str) -> None:
+    try:
+        _dashlog_counter(
+            "kvcm_registration_transition_count",
+            1,
+            tags={"from": from_state, "to": to_state},
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# ZMQ background throughput
+# ---------------------------------------------------------------------------
+
+
+def report_zmq_message() -> None:
+    """Increment the background ZMQ message counter.
+
+    Emitted once per received ZMQ message. This is a lifecycle-style
+    high-frequency counter that reflects background throughput, deliberately
+    kept separate from per-batch main-path telemetry (see :class:`BatchTelemetry`).
+    """
+
+    try:
+        _dashlog_counter("zmq_received_message_count", 1)
+    except Exception:
+        pass

--- a/subscriber/subscriber/metrics/reporter.py
+++ b/subscriber/subscriber/metrics/reporter.py
@@ -1,0 +1,441 @@
+"""Main-path telemetry container and the single async metrics output.
+
+This module owns the two objects the forwarding and snapshot pipelines use to
+capture and flush per-batch metrics:
+
+- :class:`BatchTelemetry`: an event-scoped record that the adapter and
+  forwarding code populate incrementally with :meth:`mark`, :meth:`count`, and
+  :meth:`mark_dropped`. It carries the timing origin, per-stage spans, aggregate
+  counters, a drop reason, and the pipeline tag.
+- :class:`MetricsReporter`: the single asynchronous output for main-path
+  metrics. Callers submit finalized :class:`BatchTelemetry` objects; the
+  reporter's background task flushes them to dashlog and emits a warning log
+  when a *successful* batch exceeds a latency threshold. Submitting a
+  dropped-batch telemetry emits a drop counter plus any span data captured
+  before the drop, tagged with ``drop_reason``, and skips the slow-batch
+  warning.
+
+The reporter is best-effort: :meth:`submit` never blocks or raises, and
+dashlog failures inside the flush task are swallowed. This preserves the
+project invariant that metrics reporting must never fail the main path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+
+from subscriber import logger
+from subscriber.metrics._base import _dashlog_counter, _dashlog_gauge
+
+
+@dataclass(frozen=True)
+class Span:
+    """A single named pipeline stage with its measured duration in seconds."""
+
+    name: str
+    duration_s: float
+
+
+@dataclass(frozen=True)
+class _CounterObservation:
+    """One counter observation; ``tags`` may be empty for an unlabelled value."""
+
+    name: str
+    delta: int
+    tags: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class _GaugeObservation:
+    """One gauge observation; ``tags`` may be empty for an unlabelled value."""
+
+    name: str
+    value: float
+    tags: Mapping[str, str]
+
+
+class BatchTelemetry:
+    """Per-event telemetry container for the main forwarding path.
+
+    An adapter constructs one instance per yielded event and marks its own
+    internal stages (``decode``, ``replay_fetch``, ``snapshot_fetch``, ...).
+    The subscriber core then continues marking downstream stages
+    (``queue_wait``, ``engine_gate_wait``, ``block_filter``, ``kvcm_send``) on
+    the same instance and, in the terminal step, calls :meth:`count` for
+    aggregate counters or :meth:`mark_dropped` for a lossy path. The instance
+    is finally submitted to :class:`MetricsReporter` for asynchronous flush.
+
+    The container replaces the earlier ``StageTimer`` + ad-hoc ``MetricSample``
+    pair: instead of building an anonymous sample tuple at the terminal step,
+    the same object accumulates every observation as it happens.
+    """
+
+    def __init__(
+        self,
+        *,
+        pipeline: str,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._pipeline = pipeline
+        self._clock = clock
+        self._origin = self._clock_now(0.0)
+        self._marks: list[tuple[str, float]] = []
+        self._checkpoints: dict[str, float] = {}
+        self._counter_observations: list[_CounterObservation] = []
+        self._gauge_observations: list[_GaugeObservation] = []
+        self._drop_reason: str | None = None
+
+    def _clock_now(self, fallback_s: float) -> float:
+        """Read the monotonic clock without letting telemetry break forwarding."""
+
+        try:
+            return float(self._clock())
+        except Exception:
+            return fallback_s
+
+    @property
+    def pipeline(self) -> str:
+        return self._pipeline
+
+    @property
+    def drop_reason(self) -> str | None:
+        return self._drop_reason
+
+    @property
+    def spans(self) -> list[Span]:
+        """Derive per-stage spans from the recorded marks."""
+
+        spans: list[Span] = []
+        previous = self._origin
+        for name, at in self._marks:
+            spans.append(Span(name, at - previous))
+            previous = at
+        return spans
+
+    @property
+    def counters(self) -> Mapping[str, int]:
+        """Aggregate unlabelled counters recorded on this telemetry."""
+
+        counters: dict[str, int] = {}
+        for observation in self._counter_observations:
+            if not observation.tags:
+                counters[observation.name] = (
+                    counters.get(observation.name, 0) + observation.delta
+                )
+        return counters
+
+    @property
+    def gauges(self) -> Mapping[str, float]:
+        """Per-batch gauge values recorded on this telemetry.
+
+        Unlike counters (which accumulate deltas), gauges record the *last*
+        value written under each name. Use gauges for per-event measurements
+        like a fetched payload size or a fetch latency where each observation
+        is a standalone data point rather than a rate.
+        """
+
+        gauges: dict[str, float] = {}
+        for observation in self._gauge_observations:
+            if not observation.tags:
+                gauges[observation.name] = observation.value
+        return gauges
+
+    def mark(self, name: str) -> float:
+        """Close and label the current stage, returning its duration in seconds."""
+
+        previous_s = self._marks[-1][1] if self._marks else self._origin
+        now_s = self._clock_now(previous_s)
+        self._marks.append((name, now_s))
+        return now_s - previous_s
+
+    def checkpoint(self, name: str) -> None:
+        """Record a named timestamp without creating a stage span."""
+
+        fallback_s = self._marks[-1][1] if self._marks else self._origin
+        self._checkpoints[name] = self._clock_now(fallback_s)
+
+    def elapsed_since_checkpoint(
+        self, name: str, *, at_s: float | None = None
+    ) -> float | None:
+        """Return elapsed seconds since ``name`` was checkpointed, or ``None``."""
+
+        checkpoint_at_s = self._checkpoints.get(name)
+        if checkpoint_at_s is None:
+            return None
+        now_s = self._clock_now(checkpoint_at_s) if at_s is None else at_s
+        try:
+            return now_s - checkpoint_at_s
+        except Exception:
+            return None
+
+    def count(
+        self,
+        name: str,
+        delta: int,
+        *,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        """Record a counter observation, optionally with request-specific labels.
+
+        Omitting ``tags`` (or passing an empty mapping) retains the historical
+        per-batch accumulation behavior. Non-empty labels identify an
+        independent observation and are preserved until the asynchronous flush.
+        """
+
+        try:
+            self._counter_observations.append(
+                _CounterObservation(name, int(delta), dict(tags or {}))
+            )
+        except Exception:
+            pass
+
+    def gauge(
+        self,
+        name: str,
+        value: float,
+        *,
+        tags: Mapping[str, str] | None = None,
+    ) -> None:
+        """Record a gauge observation, optionally with request-specific labels.
+
+        Omitting ``tags`` (or passing an empty mapping) retains the historical
+        last-value behavior. Non-empty labels identify an independent
+        observation and are preserved until the asynchronous flush.
+        """
+
+        try:
+            self._gauge_observations.append(
+                _GaugeObservation(name, float(value), dict(tags or {}))
+            )
+        except Exception:
+            pass
+
+    def mark_dropped(self, reason: str) -> None:
+        """Record that this batch was dropped mid-pipeline with the given reason.
+
+        Preserves any stage marks captured before the drop so the reporter can
+        report which stage the pipeline reached before dropping.
+        """
+
+        self._drop_reason = reason
+
+
+@dataclass(frozen=True)
+class _FinalizedTelemetry:
+    """Immutable snapshot of a :class:`BatchTelemetry` for the flush task."""
+
+    pipeline: str
+    spans: Sequence[Span]
+    counter_observations: Sequence[_CounterObservation]
+    gauge_observations: Sequence[_GaugeObservation]
+    drop_reason: str | None = field(default=None)
+
+
+def _snapshot(telemetry: BatchTelemetry) -> _FinalizedTelemetry:
+    return _FinalizedTelemetry(
+        pipeline=telemetry.pipeline,
+        spans=telemetry.spans,
+        counter_observations=tuple(telemetry._counter_observations),
+        gauge_observations=tuple(telemetry._gauge_observations),
+        drop_reason=telemetry.drop_reason,
+    )
+
+
+class MetricsReporter:
+    """Best-effort asynchronous flush for main-path :class:`BatchTelemetry`.
+
+    A single background task drains submissions and writes them to dashlog.
+    Successful batches emit per-stage histograms, an end-to-end latency
+    histogram, and any accumulated counters, all tagged with the batch's
+    ``pipeline``. Dropped batches emit a ``kv_batch_drop_count`` counter and
+    stage histograms tagged with ``drop_reason`` in addition to ``pipeline``;
+    the slow-batch warning is skipped for dropped telemetry because a partial
+    pipeline is expected.
+
+    :meth:`submit` is non-blocking and never raises; if the internal queue
+    fails or the flush task has not been started, the sample is silently
+    discarded. Dashlog failures inside the flush task are swallowed. Callers
+    should not depend on any specific delivery guarantee.
+    """
+
+    def __init__(
+        self,
+        *,
+        task_name: str = "kv-event-metrics",
+        warning_threshold_s: float = 0.05,
+    ) -> None:
+        self._task_name = task_name
+        self._warning_threshold_s = warning_threshold_s
+        self._queue: asyncio.Queue[_FinalizedTelemetry] = asyncio.Queue(maxsize=1024)
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        try:
+            if self._task is not None and not self._task.done():
+                return
+            self._task = asyncio.create_task(self._run(), name=self._task_name)
+        except Exception:
+            pass
+
+    async def stop(self) -> None:
+        try:
+            task = self._task
+            if task is None:
+                return
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            finally:
+                if self._task is task:
+                    self._task = None
+        except Exception:
+            pass
+
+    def submit(self, telemetry: BatchTelemetry) -> None:
+        """Queue a finalized telemetry for async flush. Never blocks or raises."""
+
+        try:
+            self._queue.put_nowait(_snapshot(telemetry))
+        except Exception:
+            pass
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                try:
+                    sample = await self._queue.get()
+                    if sample.drop_reason is not None:
+                        self._flush_dropped(sample)
+                    else:
+                        self._flush_success(sample)
+                        self._log_warning_if_slow(sample)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    pass
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "metrics reporter flush task terminated unexpectedly; "
+                "subsequent submissions will be dropped",
+                step="kv_event_metrics",
+                exc_info=True,
+            )
+
+    # ------------------------------------------------------------------ flush
+
+    def _flush_success(self, sample: _FinalizedTelemetry) -> None:
+        try:
+            tags = {"pipeline": sample.pipeline}
+            for span in sample.spans:
+                _dashlog_gauge(
+                    f"kv_stage_{span.name}_ms",
+                    span.duration_s * 1000,
+                    tags=tags,
+                )
+            if sample.spans:
+                total_s = sum(span.duration_s for span in sample.spans)
+                _dashlog_gauge(
+                    "kv_event_e2e_latency_ms",
+                    total_s * 1000,
+                    tags=tags,
+                )
+            self._flush_observations(sample, tags)
+        except Exception:
+            pass
+
+    def _flush_dropped(self, sample: _FinalizedTelemetry) -> None:
+        try:
+            reason = sample.drop_reason or "unknown"
+            _dashlog_counter(
+                "kv_batch_drop_count",
+                1,
+                tags={"pipeline": sample.pipeline, "reason": reason},
+            )
+            drop_tags = {"pipeline": sample.pipeline, "drop_reason": reason}
+            for span in sample.spans:
+                _dashlog_gauge(
+                    f"kv_stage_{span.name}_ms",
+                    span.duration_s * 1000,
+                    tags=drop_tags,
+                )
+            # Counters and gauges recorded before the drop are still emitted
+            # so partial-batch data isn't lost; the drop_reason tag lets
+            # dashboards separate them from successful measurements.
+            self._flush_observations(sample, drop_tags)
+        except Exception:
+            pass
+
+    def _flush_observations(
+        self,
+        sample: _FinalizedTelemetry,
+        base_tags: Mapping[str, str],
+    ) -> None:
+        """Flush observations while preserving label and legacy aggregation rules.
+
+        Unlabelled counters are accumulated and unlabelled gauges keep their
+        final value, matching the original ``BatchTelemetry`` interface.
+        Labelled observations stay independent even if their metric names
+        match. ``base_tags`` (pipeline and optional drop reason) intentionally
+        override a caller-provided tag of the same name.
+        """
+
+        counters: dict[str, int] = {}
+        gauges: dict[str, float] = {}
+        labelled_counters: list[_CounterObservation] = []
+        labelled_gauges: list[_GaugeObservation] = []
+        for observation in sample.counter_observations:
+            if not observation.tags:
+                counters[observation.name] = (
+                    counters.get(observation.name, 0) + observation.delta
+                )
+                continue
+            labelled_counters.append(observation)
+        for name, count in counters.items():
+            _dashlog_counter(name, count, tags=base_tags)
+        for observation in labelled_counters:
+            tags = dict(observation.tags)
+            tags.update(base_tags)
+            _dashlog_counter(observation.name, observation.delta, tags=tags)
+        for gauge_observation in sample.gauge_observations:
+            if not gauge_observation.tags:
+                gauges[gauge_observation.name] = gauge_observation.value
+                continue
+            labelled_gauges.append(gauge_observation)
+        for name, value in gauges.items():
+            _dashlog_gauge(name, value, tags=base_tags)
+        for gauge_observation in labelled_gauges:
+            gauge_tags = dict(gauge_observation.tags)
+            gauge_tags.update(base_tags)
+            _dashlog_gauge(
+                gauge_observation.name,
+                gauge_observation.value,
+                tags=gauge_tags,
+            )
+
+    def _log_warning_if_slow(self, sample: _FinalizedTelemetry) -> None:
+        if not sample.spans:
+            return
+        total_s = sum(span.duration_s for span in sample.spans)
+        if total_s <= self._warning_threshold_s:
+            return
+        tags: dict[str, object] = {"pipeline": sample.pipeline}
+        tags.update(
+            {
+                f"{span.name}_ms": round(span.duration_s * 1000, 3)
+                for span in sample.spans
+            }
+        )
+        tags["total_ms"] = round(total_s * 1000, 3)
+        tags["threshold_ms"] = round(self._warning_threshold_s * 1000, 3)
+        logger.warning(
+            "kv event forwarding latency exceeded threshold",
+            step="kv_event_metrics",
+            tags=tags,
+        )

--- a/subscriber/subscriber/pipeline/block_filter.py
+++ b/subscriber/subscriber/pipeline/block_filter.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from subscriber import logger
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockSnapshot,
+    BlockStored,
+    KVEventBatch,
+)
+
+
+def filter_block_removals(batches: list[KVEventBatch]) -> list[KVEventBatch]:
+    """Suppress BlockRemoved hashes whose remaining physical copies are non-zero.
+
+    When ``remaining_copy_counts`` is provided by the engine, only block hashes
+    with a remaining count of 0 are forwarded to KVCM.  When the field is
+    ``None`` (engine does not support it), the event passes through unmodified.
+    BlockSnapshot events pass through unchanged.
+    """
+
+    result: list[KVEventBatch] = []
+    for batch in batches:
+        events = _filter_events(batch.events)
+        if not events:
+            continue
+        if len(events) == len(batch.events) and all(
+            e is orig for e, orig in zip(events, batch.events, strict=True)
+        ):
+            result.append(batch)
+        else:
+            result.append(
+                KVEventBatch(
+                    ts=batch.ts,
+                    events=events,
+                    data_parallel_rank=batch.data_parallel_rank,
+                )
+            )
+    return result
+
+
+def _filter_events(
+    events: list[BlockStored | BlockRemoved | AllBlocksCleared | BlockSnapshot],
+) -> list[BlockStored | BlockRemoved | AllBlocksCleared | BlockSnapshot]:
+    filtered: list[BlockStored | BlockRemoved | AllBlocksCleared | BlockSnapshot] = []
+    for event in events:
+        if not isinstance(event, BlockRemoved):
+            filtered.append(event)
+            continue
+        if event.remaining_copy_counts is None:
+            filtered.append(event)
+            continue
+        if len(event.block_hashes) != len(event.remaining_copy_counts):
+            logger.warning(
+                "dropping block removal with mismatched remaining copy counts",
+                step="block_filter",
+                tags={
+                    "block_hash_count": len(event.block_hashes),
+                    "remaining_copy_count": len(event.remaining_copy_counts),
+                    "medium": event.medium,
+                    "group_idx": event.group_idx,
+                },
+            )
+            continue
+        kept_hashes: list[bytes | int] = []
+        kept_counts: list[int] = []
+        for block_hash, count in zip(
+            event.block_hashes, event.remaining_copy_counts, strict=True
+        ):
+            if count == 0:
+                kept_hashes.append(block_hash)
+                kept_counts.append(0)
+        if not kept_hashes:
+            continue
+        if len(kept_hashes) == len(event.block_hashes):
+            filtered.append(event)
+        else:
+            filtered.append(
+                BlockRemoved(
+                    block_hashes=kept_hashes,
+                    medium=event.medium,
+                    group_idx=event.group_idx,
+                    component_id=event.component_id,
+                    remaining_copy_counts=kept_counts,
+                    snapshot_version=event.snapshot_version,
+                )
+            )
+    return filtered

--- a/subscriber/subscriber/pipeline/context.py
+++ b/subscriber/subscriber/pipeline/context.py
@@ -1,0 +1,56 @@
+"""Per-batch mutable context flowing through the forwarding pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from subscriber.engine.base import EngineEventBatch
+from subscriber.metrics import BatchTelemetry
+from subscriber.types import KVEventBatch
+
+if TYPE_CHECKING:
+    from subscriber.metrics import MetricsReporter
+
+
+@dataclass
+class PipelineContext:
+    """Mutable per-batch context carried from producer through sender to kvcm.
+
+    Replaces ``QueuedKVEventBatch`` as the queue item type.  Holds the
+    adapter's :class:`EngineEventBatch` and enriches it with epoch gating
+    and merge correlation metadata.  Owns the telemetry lifecycle: mark
+    stages, record drops, and submit to the reporter.
+    """
+
+    event: EngineEventBatch
+    epoch_snapshot: int
+    reporter: MetricsReporter
+    batch_trace_id: str | None = None
+    drop_reason: str | None = None
+
+    @property
+    def trace_id(self) -> str:
+        return self.event.trace_id
+
+    @property
+    def batches(self) -> list[KVEventBatch]:
+        return self.event.batches
+
+    @property
+    def telemetry(self) -> BatchTelemetry:
+        return self.event.telemetry
+
+    def mark(self, stage: str) -> None:
+        self.telemetry.mark(stage)
+
+    def mark_dropped(self, reason: str) -> None:
+        self.drop_reason = reason
+        self.telemetry.mark_dropped(reason)
+
+    def submit(self) -> None:
+        self.reporter.submit(self.telemetry)
+
+    def submit_dropped(self, reason: str) -> None:
+        self.mark_dropped(reason)
+        self.submit()

--- a/subscriber/subscriber/pipeline/merge.py
+++ b/subscriber/subscriber/pipeline/merge.py
@@ -1,0 +1,140 @@
+"""Greedy same-epoch merge of queued pipeline contexts.
+
+Selects contiguous items from an asyncio queue that share the same engine
+epoch, bounded by both a maximum number of queue items and a maximum number
+of report events.  Returns a :class:`MergedBatch` describing the selection
+and any item that was dequeued but not merged (handed back as ``pending``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from subscriber import logger
+from subscriber.kvcm.event_payload import report_event_count
+from subscriber.pipeline.context import PipelineContext
+from subscriber.types import KVEventBatch
+
+
+@dataclass(frozen=True)
+class MergedBatch:
+    """Contiguous same-epoch queue items selected for one KVCM request."""
+
+    queued_items: list[PipelineContext]
+    epoch_snapshot: int
+    queue_qsize_before_merge: int
+    queue_qsize_after_merge: int
+    source_batch_count: int
+    source_event_count: int
+    report_event_count: int
+
+    @property
+    def batches(self) -> list[KVEventBatch]:
+        return [batch for item in self.queued_items for batch in item.batches]
+
+
+def exceeds_merge_limit(
+    count: int,
+    max_merged_report_events: int,
+) -> bool:
+    return count > max_merged_report_events
+
+
+async def dequeue_merged_batches(
+    queue: asyncio.Queue[PipelineContext],
+    pending: PipelineContext | None,
+    max_merged_report_events: int,
+    max_merged_queue_items: int,
+) -> tuple[MergedBatch, PipelineContext | None]:
+    """Select immediately available same-epoch items within both merge caps."""
+
+    first = pending if pending is not None else await queue.get()
+    queue_qsize_before_merge = queue.qsize()
+    queued_items = [first]
+    source_batch_count = len(first.batches)
+    source_event_count = sum(len(batch.events) for batch in first.batches)
+    merged_report_event_count = report_event_count(first.batches)
+    next_pending: PipelineContext | None = None
+
+    while len(queued_items) < max_merged_queue_items:
+        try:
+            candidate = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+        if candidate.epoch_snapshot != first.epoch_snapshot:
+            next_pending = candidate
+            break
+
+        candidate_report_event_count = report_event_count(candidate.batches)
+        if exceeds_merge_limit(
+            merged_report_event_count + candidate_report_event_count,
+            max_merged_report_events,
+        ):
+            next_pending = candidate
+            break
+
+        queued_items.append(candidate)
+        source_batch_count += len(candidate.batches)
+        source_event_count += sum(len(batch.events) for batch in candidate.batches)
+        merged_report_event_count += candidate_report_event_count
+
+    return (
+        MergedBatch(
+            queued_items=queued_items,
+            epoch_snapshot=first.epoch_snapshot,
+            queue_qsize_before_merge=queue_qsize_before_merge,
+            queue_qsize_after_merge=queue.qsize(),
+            source_batch_count=source_batch_count,
+            source_event_count=source_event_count,
+            report_event_count=merged_report_event_count,
+        ),
+        next_pending,
+    )
+
+
+def log_merge_diagnostics(
+    merged: MergedBatch,
+    *,
+    pipeline: str,
+    send_started_at_s: float,
+) -> None:
+    if logger.is_debug_enabled():
+        oldest_enqueue_to_kvcm_send_s = merged.queued_items[
+            0
+        ].telemetry.elapsed_since_checkpoint(
+            "queue_enqueued",
+            at_s=send_started_at_s,
+        )
+        newest_enqueue_to_kvcm_send_s = merged.queued_items[
+            -1
+        ].telemetry.elapsed_since_checkpoint(
+            "queue_enqueued",
+            at_s=send_started_at_s,
+        )
+        tags: dict[str, object] = {
+            "pipeline": pipeline,
+            "trace_id": merged.queued_items[0].trace_id,
+            "merged_trace_ids": [item.trace_id for item in merged.queued_items],
+            "queue_qsize_before_merge": merged.queue_qsize_before_merge,
+            "queue_qsize_after_merge": merged.queue_qsize_after_merge,
+            "merged_queue_item_count": len(merged.queued_items),
+            "source_batch_count": merged.source_batch_count,
+            "source_event_count": merged.source_event_count,
+            "merged_report_event_count": merged.report_event_count,
+        }
+        if oldest_enqueue_to_kvcm_send_s is not None:
+            tags["oldest_enqueue_to_kvcm_send_ms"] = round(
+                oldest_enqueue_to_kvcm_send_s * 1000,
+                3,
+            )
+        if newest_enqueue_to_kvcm_send_s is not None:
+            tags["newest_enqueue_to_kvcm_send_ms"] = round(
+                newest_enqueue_to_kvcm_send_s * 1000,
+                3,
+            )
+        logger.debug(
+            "sending merged kv event batches to kvcm",
+            step="kvcm_send",
+            tags=tags,
+        )

--- a/subscriber/subscriber/proto/__init__.py
+++ b/subscriber/subscriber/proto/__init__.py
@@ -1,0 +1,1 @@
+"""Local protocol bindings used by the subscriber."""

--- a/subscriber/subscriber/proto/engine_service_rpc.proto
+++ b/subscriber/subscriber/proto/engine_service_rpc.proto
@@ -1,0 +1,162 @@
+syntax = "proto3";
+
+message StatusVersionPB {
+  int64 latest_cache_version = 1;
+  int64 latest_finished_version = 2;
+}
+
+message WorkerStatusPB {
+  // Fields 1-11 are reserved for other worker status information.
+  int64 status_version = 12;
+  bool alive = 13;
+  // Field 14 is reserved for precision in the authoritative schema.
+  int64 latest_finished_version = 15;
+}
+
+message KvCacheBlockListPB {
+  bytes raw_snapshot = 1;
+  int64 snapshot_version = 2;
+  int32 block_size = 3;
+}
+
+message KvCacheBlocksRequestPB {}
+
+enum KvEventBootstrapErrorCode {
+  KV_EVENT_BOOTSTRAP_OK = 0;
+  KV_EVENT_BOOTSTRAP_UNAVAILABLE = 1;
+  KV_EVENT_BOOTSTRAP_INCOMPATIBLE = 2;
+}
+
+message OptionalUInt64PB {
+  uint64 value = 1;
+}
+
+message OptionalInt64PB {
+  int64 value = 1;
+}
+
+message StringListPB {
+  repeated string values = 1;
+}
+
+message Int64ListPB {
+  repeated sint64 values = 1;
+}
+
+message UInt64ListPB {
+  repeated uint64 values = 1;
+}
+
+message DoubleListPB {
+  repeated double values = 1;
+}
+
+message BoolListPB {
+  repeated bool values = 1;
+}
+
+message TypedSettingPB {
+  string name = 1;
+  oneof value {
+    bool bool_value = 2;
+    sint64 int64_value = 3;
+    uint64 uint64_value = 4;
+    double double_value = 5;
+    string string_value = 6;
+    bytes bytes_value = 7;
+    StringListPB string_list = 8;
+    Int64ListPB int64_list = 9;
+    UInt64ListPB uint64_list = 10;
+    DoubleListPB double_list = 11;
+    BoolListPB bool_list = 12;
+  }
+}
+
+message EventTransportPB {
+  string live_endpoint = 1;
+  string topic = 2;
+  bool replay_supported = 3;
+  string replay_endpoint = 4;
+  string serialization = 5;
+}
+
+message RuntimeTopologyPB {
+  uint32 data_parallel_size = 1;
+  uint32 tensor_parallel_size = 2;
+  uint32 pipeline_parallel_size = 3;
+  uint32 data_parallel_rank = 4;
+  uint32 tensor_parallel_rank = 5;
+  uint32 pipeline_parallel_rank = 6;
+}
+
+message SnapshotCapabilityPB {
+  bool supported = 1;
+  bool versioned = 2;
+}
+
+message CacheGeometryPB {
+  uint64 block_size_tokens = 1;
+  OptionalUInt64PB page_size_tokens = 2;
+  OptionalUInt64PB block_count = 3;
+  OptionalUInt64PB group_payload_size_bytes = 4;
+  string cache_dtype = 5;
+  OptionalUInt64PB element_size_bytes = 6;
+  OptionalUInt64PB layer_count = 7;
+  string cache_layout = 8;
+  OptionalInt64PB sliding_window_tokens = 9;
+  OptionalUInt64PB checkpoint_alignment_tokens = 10;
+}
+
+message CacheComponentPB {
+  uint32 component_id = 1;
+  string component_kind = 2;
+  CacheGeometryPB geometry = 3;
+  repeated TypedSettingPB compatibility_settings = 4;
+  repeated TypedSettingPB diagnostic_settings = 5;
+}
+
+message VllmKvEventSchemaPB {
+  uint32 event_schema_version = 1;
+  bool use_eagle_pop = 2;
+  string mamba_cache_mode = 3;
+  string hash_algorithm = 4;
+  string hash_version = 5;
+  repeated TypedSettingPB cache_settings = 6;
+}
+
+message SglangKvEventSchemaPB {
+  string cache_key_mode = 1;
+  uint32 event_schema_version = 2;
+  string native_hash_algorithm = 3;
+  repeated TypedSettingPB cache_settings = 4;
+}
+
+message KvEventBootstrapInfoPB {
+  uint32 protocol_version = 1;
+  string engine_kind = 2;
+  EventTransportPB event_transport = 3;
+  RuntimeTopologyPB runtime_topology = 4;
+  SnapshotCapabilityPB snapshot = 5;
+  repeated CacheComponentPB components = 6;
+  KvEventBootstrapErrorCode err_code = 7;
+  string err_msg = 8;
+  repeated TypedSettingPB compatibility_settings = 9;
+  repeated TypedSettingPB diagnostic_settings = 10;
+  oneof engine_schema {
+    VllmKvEventSchemaPB vllm = 20;
+    SglangKvEventSchemaPB sglang = 21;
+  }
+}
+
+message KvEventBootstrapInfoRequestPB {}
+
+service RpcService {
+  rpc GetWorkerStatus(StatusVersionPB) returns (WorkerStatusPB);
+}
+
+service KvEventControlService {
+  rpc GetKvEventBootstrapInfo(KvEventBootstrapInfoRequestPB)
+      returns (KvEventBootstrapInfoPB);
+  rpc GetAllKvCacheBlocks(KvCacheBlocksRequestPB)
+      returns (KvCacheBlockListPB);
+}

--- a/subscriber/subscriber/proto/engine_service_rpc_pb2.py
+++ b/subscriber/subscriber/proto/engine_service_rpc_pb2.py
@@ -1,0 +1,332 @@
+# -*- coding: utf-8 -*-
+"""Hand-written protobuf definitions for engine_service_rpc.proto.
+
+Compatible with protobuf>=3.20.3 (no runtime_version / _builder dependency).
+Mirrors the worker-status and KV-event bootstrap/control schema.
+"""
+
+from google.protobuf import descriptor_pb2 as _descriptor_pb2
+from google.protobuf import descriptor_pool as _descriptor_pool
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import message_factory as _message_factory
+from google.protobuf import symbol_database as _symbol_database
+
+_sym_db = _symbol_database.Default()
+
+
+def _add_field(
+    message: _descriptor_pb2.DescriptorProto,
+    name: str,
+    number: int,
+    label: int,
+    field_type: int,
+    type_name: str = "",
+    oneof_index: int | None = None,
+) -> None:
+    field = message.field.add()
+    field.name = name
+    field.number = number
+    field.label = label
+    field.type = field_type
+    if type_name:
+        field.type_name = type_name
+    if oneof_index is not None:
+        field.oneof_index = oneof_index
+
+
+def _build_file_descriptor():
+    file_proto = _descriptor_pb2.FileDescriptorProto()
+    file_proto.name = "subscriber/proto/engine_service_rpc.proto"
+    file_proto.syntax = "proto3"
+
+    # message StatusVersionPB
+    status_version = file_proto.message_type.add()
+    status_version.name = "StatusVersionPB"
+    _add_field(status_version, "latest_cache_version", 1, 1, 3)  # int64
+    _add_field(status_version, "latest_finished_version", 2, 1, 3)  # int64
+
+    # message WorkerStatusPB
+    worker_status = file_proto.message_type.add()
+    worker_status.name = "WorkerStatusPB"
+    _add_field(worker_status, "status_version", 12, 1, 3)  # int64
+    _add_field(worker_status, "alive", 13, 1, 8)  # bool
+    _add_field(worker_status, "latest_finished_version", 15, 1, 3)  # int64
+
+    # message KvCacheBlockListPB
+    block_list = file_proto.message_type.add()
+    block_list.name = "KvCacheBlockListPB"
+    _add_field(block_list, "raw_snapshot", 1, 1, 12)  # bytes
+    _add_field(block_list, "snapshot_version", 2, 1, 3)  # int64
+    _add_field(block_list, "block_size", 3, 1, 5)  # int32
+
+    # message KvCacheBlocksRequestPB (empty)
+    file_proto.message_type.add().name = "KvCacheBlocksRequestPB"
+
+    bootstrap_error = file_proto.enum_type.add()
+    bootstrap_error.name = "KvEventBootstrapErrorCode"
+    bootstrap_error.value.add(name="KV_EVENT_BOOTSTRAP_OK", number=0)
+    bootstrap_error.value.add(name="KV_EVENT_BOOTSTRAP_UNAVAILABLE", number=1)
+    bootstrap_error.value.add(name="KV_EVENT_BOOTSTRAP_INCOMPATIBLE", number=2)
+
+    optional_uint64 = file_proto.message_type.add()
+    optional_uint64.name = "OptionalUInt64PB"
+    _add_field(optional_uint64, "value", 1, 1, 4)  # uint64
+
+    optional_int64 = file_proto.message_type.add()
+    optional_int64.name = "OptionalInt64PB"
+    _add_field(optional_int64, "value", 1, 1, 3)  # int64
+
+    string_list = file_proto.message_type.add()
+    string_list.name = "StringListPB"
+    _add_field(string_list, "values", 1, 3, 9)  # repeated string
+
+    int64_list = file_proto.message_type.add()
+    int64_list.name = "Int64ListPB"
+    _add_field(int64_list, "values", 1, 3, 18)  # repeated sint64
+
+    uint64_list = file_proto.message_type.add()
+    uint64_list.name = "UInt64ListPB"
+    _add_field(uint64_list, "values", 1, 3, 4)  # repeated uint64
+
+    double_list = file_proto.message_type.add()
+    double_list.name = "DoubleListPB"
+    _add_field(double_list, "values", 1, 3, 1)  # repeated double
+
+    bool_list = file_proto.message_type.add()
+    bool_list.name = "BoolListPB"
+    _add_field(bool_list, "values", 1, 3, 8)  # repeated bool
+
+    typed_setting = file_proto.message_type.add()
+    typed_setting.name = "TypedSettingPB"
+    typed_setting.oneof_decl.add().name = "value"
+    _add_field(typed_setting, "name", 1, 1, 9)
+    _add_field(typed_setting, "bool_value", 2, 1, 8, oneof_index=0)
+    _add_field(typed_setting, "int64_value", 3, 1, 18, oneof_index=0)
+    _add_field(typed_setting, "uint64_value", 4, 1, 4, oneof_index=0)
+    _add_field(typed_setting, "double_value", 5, 1, 1, oneof_index=0)
+    _add_field(typed_setting, "string_value", 6, 1, 9, oneof_index=0)
+    _add_field(typed_setting, "bytes_value", 7, 1, 12, oneof_index=0)
+    _add_field(typed_setting, "string_list", 8, 1, 11, ".StringListPB", 0)
+    _add_field(typed_setting, "int64_list", 9, 1, 11, ".Int64ListPB", 0)
+    _add_field(typed_setting, "uint64_list", 10, 1, 11, ".UInt64ListPB", 0)
+    _add_field(typed_setting, "double_list", 11, 1, 11, ".DoubleListPB", 0)
+    _add_field(typed_setting, "bool_list", 12, 1, 11, ".BoolListPB", 0)
+
+    event_transport = file_proto.message_type.add()
+    event_transport.name = "EventTransportPB"
+    _add_field(event_transport, "live_endpoint", 1, 1, 9)
+    _add_field(event_transport, "topic", 2, 1, 9)
+    _add_field(event_transport, "replay_supported", 3, 1, 8)
+    _add_field(event_transport, "replay_endpoint", 4, 1, 9)
+    _add_field(event_transport, "serialization", 5, 1, 9)
+
+    topology = file_proto.message_type.add()
+    topology.name = "RuntimeTopologyPB"
+    _add_field(topology, "data_parallel_size", 1, 1, 13)
+    _add_field(topology, "tensor_parallel_size", 2, 1, 13)
+    _add_field(topology, "pipeline_parallel_size", 3, 1, 13)
+    _add_field(topology, "data_parallel_rank", 4, 1, 13)
+    _add_field(topology, "tensor_parallel_rank", 5, 1, 13)
+    _add_field(topology, "pipeline_parallel_rank", 6, 1, 13)
+
+    snapshot_capability = file_proto.message_type.add()
+    snapshot_capability.name = "SnapshotCapabilityPB"
+    _add_field(snapshot_capability, "supported", 1, 1, 8)
+    _add_field(snapshot_capability, "versioned", 2, 1, 8)
+
+    geometry = file_proto.message_type.add()
+    geometry.name = "CacheGeometryPB"
+    _add_field(geometry, "block_size_tokens", 1, 1, 4)
+    _add_field(geometry, "page_size_tokens", 2, 1, 11, ".OptionalUInt64PB")
+    _add_field(geometry, "block_count", 3, 1, 11, ".OptionalUInt64PB")
+    _add_field(
+        geometry,
+        "group_payload_size_bytes",
+        4,
+        1,
+        11,
+        ".OptionalUInt64PB",
+    )
+    _add_field(geometry, "cache_dtype", 5, 1, 9)
+    _add_field(geometry, "element_size_bytes", 6, 1, 11, ".OptionalUInt64PB")
+    _add_field(geometry, "layer_count", 7, 1, 11, ".OptionalUInt64PB")
+    _add_field(geometry, "cache_layout", 8, 1, 9)
+    _add_field(geometry, "sliding_window_tokens", 9, 1, 11, ".OptionalInt64PB")
+    _add_field(
+        geometry,
+        "checkpoint_alignment_tokens",
+        10,
+        1,
+        11,
+        ".OptionalUInt64PB",
+    )
+
+    cache_component = file_proto.message_type.add()
+    cache_component.name = "CacheComponentPB"
+    _add_field(cache_component, "component_id", 1, 1, 13)
+    _add_field(cache_component, "component_kind", 2, 1, 9)
+    _add_field(cache_component, "geometry", 3, 1, 11, ".CacheGeometryPB")
+    _add_field(
+        cache_component,
+        "compatibility_settings",
+        4,
+        3,
+        11,
+        ".TypedSettingPB",
+    )
+    _add_field(
+        cache_component,
+        "diagnostic_settings",
+        5,
+        3,
+        11,
+        ".TypedSettingPB",
+    )
+
+    vllm_schema = file_proto.message_type.add()
+    vllm_schema.name = "VllmKvEventSchemaPB"
+    _add_field(vllm_schema, "event_schema_version", 1, 1, 13)
+    _add_field(vllm_schema, "use_eagle_pop", 2, 1, 8)
+    _add_field(vllm_schema, "mamba_cache_mode", 3, 1, 9)
+    _add_field(vllm_schema, "hash_algorithm", 4, 1, 9)
+    _add_field(vllm_schema, "hash_version", 5, 1, 9)
+    _add_field(vllm_schema, "cache_settings", 6, 3, 11, ".TypedSettingPB")
+
+    sglang_schema = file_proto.message_type.add()
+    sglang_schema.name = "SglangKvEventSchemaPB"
+    _add_field(sglang_schema, "cache_key_mode", 1, 1, 9)
+    _add_field(sglang_schema, "event_schema_version", 2, 1, 13)
+    _add_field(sglang_schema, "native_hash_algorithm", 3, 1, 9)
+    _add_field(sglang_schema, "cache_settings", 4, 3, 11, ".TypedSettingPB")
+
+    bootstrap = file_proto.message_type.add()
+    bootstrap.name = "KvEventBootstrapInfoPB"
+    bootstrap.oneof_decl.add().name = "engine_schema"
+    _add_field(bootstrap, "protocol_version", 1, 1, 13)
+    _add_field(bootstrap, "engine_kind", 2, 1, 9)
+    _add_field(bootstrap, "event_transport", 3, 1, 11, ".EventTransportPB")
+    _add_field(bootstrap, "runtime_topology", 4, 1, 11, ".RuntimeTopologyPB")
+    _add_field(bootstrap, "snapshot", 5, 1, 11, ".SnapshotCapabilityPB")
+    _add_field(bootstrap, "components", 6, 3, 11, ".CacheComponentPB")
+    _add_field(
+        bootstrap,
+        "err_code",
+        7,
+        1,
+        _descriptor_pb2.FieldDescriptorProto.TYPE_ENUM,
+        ".KvEventBootstrapErrorCode",
+    )
+    _add_field(bootstrap, "err_msg", 8, 1, 9)
+    _add_field(
+        bootstrap,
+        "compatibility_settings",
+        9,
+        3,
+        11,
+        ".TypedSettingPB",
+    )
+    _add_field(
+        bootstrap,
+        "diagnostic_settings",
+        10,
+        3,
+        11,
+        ".TypedSettingPB",
+    )
+    _add_field(bootstrap, "vllm", 20, 1, 11, ".VllmKvEventSchemaPB", 0)
+    _add_field(bootstrap, "sglang", 21, 1, 11, ".SglangKvEventSchemaPB", 0)
+
+    file_proto.message_type.add().name = "KvEventBootstrapInfoRequestPB"
+
+    # service RpcService
+    service = file_proto.service.add()
+    service.name = "RpcService"
+    method = service.method.add()
+    method.name = "GetWorkerStatus"
+    method.input_type = ".StatusVersionPB"
+    method.output_type = ".WorkerStatusPB"
+
+    control_service = file_proto.service.add()
+    control_service.name = "KvEventControlService"
+    method = control_service.method.add()
+    method.name = "GetKvEventBootstrapInfo"
+    method.input_type = ".KvEventBootstrapInfoRequestPB"
+    method.output_type = ".KvEventBootstrapInfoPB"
+    method = control_service.method.add()
+    method.name = "GetAllKvCacheBlocks"
+    method.input_type = ".KvCacheBlocksRequestPB"
+    method.output_type = ".KvCacheBlockListPB"
+
+    pool = _descriptor_pool.Default()
+    try:
+        return pool.AddSerializedFile(file_proto.SerializeToString())
+    except Exception:
+        return pool.FindFileByName(file_proto.name)
+
+
+DESCRIPTOR = _build_file_descriptor()
+
+
+def _message_class(name: str):
+    descriptor = DESCRIPTOR.message_types_by_name[name]
+    get_message_class = getattr(_message_factory, "GetMessageClass", None)
+    if get_message_class is not None:
+        return get_message_class(descriptor)
+    factory = _message_factory.MessageFactory()
+    return factory.GetPrototype(descriptor)
+
+
+StatusVersionPB = _message_class("StatusVersionPB")
+WorkerStatusPB = _message_class("WorkerStatusPB")
+KvCacheBlockListPB = _message_class("KvCacheBlockListPB")
+KvCacheBlocksRequestPB = _message_class("KvCacheBlocksRequestPB")
+OptionalUInt64PB = _message_class("OptionalUInt64PB")
+OptionalInt64PB = _message_class("OptionalInt64PB")
+StringListPB = _message_class("StringListPB")
+Int64ListPB = _message_class("Int64ListPB")
+UInt64ListPB = _message_class("UInt64ListPB")
+DoubleListPB = _message_class("DoubleListPB")
+BoolListPB = _message_class("BoolListPB")
+TypedSettingPB = _message_class("TypedSettingPB")
+EventTransportPB = _message_class("EventTransportPB")
+RuntimeTopologyPB = _message_class("RuntimeTopologyPB")
+SnapshotCapabilityPB = _message_class("SnapshotCapabilityPB")
+CacheGeometryPB = _message_class("CacheGeometryPB")
+CacheComponentPB = _message_class("CacheComponentPB")
+VllmKvEventSchemaPB = _message_class("VllmKvEventSchemaPB")
+SglangKvEventSchemaPB = _message_class("SglangKvEventSchemaPB")
+KvEventBootstrapInfoPB = _message_class("KvEventBootstrapInfoPB")
+KvEventBootstrapInfoRequestPB = _message_class("KvEventBootstrapInfoRequestPB")
+
+KvEventBootstrapErrorCode = _enum_type_wrapper.EnumTypeWrapper(
+    DESCRIPTOR.enum_types_by_name["KvEventBootstrapErrorCode"]
+)
+KV_EVENT_BOOTSTRAP_OK = KvEventBootstrapErrorCode.KV_EVENT_BOOTSTRAP_OK
+KV_EVENT_BOOTSTRAP_UNAVAILABLE = (
+    KvEventBootstrapErrorCode.KV_EVENT_BOOTSTRAP_UNAVAILABLE
+)
+KV_EVENT_BOOTSTRAP_INCOMPATIBLE = (
+    KvEventBootstrapErrorCode.KV_EVENT_BOOTSTRAP_INCOMPATIBLE
+)
+
+_sym_db.RegisterMessage(StatusVersionPB)
+_sym_db.RegisterMessage(WorkerStatusPB)
+_sym_db.RegisterMessage(KvCacheBlockListPB)
+_sym_db.RegisterMessage(KvCacheBlocksRequestPB)
+_sym_db.RegisterMessage(OptionalUInt64PB)
+_sym_db.RegisterMessage(OptionalInt64PB)
+_sym_db.RegisterMessage(StringListPB)
+_sym_db.RegisterMessage(Int64ListPB)
+_sym_db.RegisterMessage(UInt64ListPB)
+_sym_db.RegisterMessage(DoubleListPB)
+_sym_db.RegisterMessage(BoolListPB)
+_sym_db.RegisterMessage(TypedSettingPB)
+_sym_db.RegisterMessage(EventTransportPB)
+_sym_db.RegisterMessage(RuntimeTopologyPB)
+_sym_db.RegisterMessage(SnapshotCapabilityPB)
+_sym_db.RegisterMessage(CacheGeometryPB)
+_sym_db.RegisterMessage(CacheComponentPB)
+_sym_db.RegisterMessage(VllmKvEventSchemaPB)
+_sym_db.RegisterMessage(SglangKvEventSchemaPB)
+_sym_db.RegisterMessage(KvEventBootstrapInfoPB)
+_sym_db.RegisterMessage(KvEventBootstrapInfoRequestPB)

--- a/subscriber/subscriber/proto/engine_service_rpc_pb2.pyi
+++ b/subscriber/subscriber/proto/engine_service_rpc_pb2.pyi
@@ -1,0 +1,185 @@
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class KvEventBootstrapErrorCode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    KV_EVENT_BOOTSTRAP_OK: _ClassVar[KvEventBootstrapErrorCode]
+    KV_EVENT_BOOTSTRAP_UNAVAILABLE: _ClassVar[KvEventBootstrapErrorCode]
+    KV_EVENT_BOOTSTRAP_INCOMPATIBLE: _ClassVar[KvEventBootstrapErrorCode]
+KV_EVENT_BOOTSTRAP_OK: KvEventBootstrapErrorCode
+KV_EVENT_BOOTSTRAP_UNAVAILABLE: KvEventBootstrapErrorCode
+KV_EVENT_BOOTSTRAP_INCOMPATIBLE: KvEventBootstrapErrorCode
+
+class StatusVersionPB(_message.Message):
+    __slots__ = ("latest_cache_version", "latest_finished_version")
+    LATEST_CACHE_VERSION_FIELD_NUMBER: _ClassVar[int]
+    LATEST_FINISHED_VERSION_FIELD_NUMBER: _ClassVar[int]
+    latest_cache_version: int
+    latest_finished_version: int
+    def __init__(self, latest_cache_version: _Optional[int] = ..., latest_finished_version: _Optional[int] = ...) -> None: ...
+
+class WorkerStatusPB(_message.Message):
+    __slots__ = ("status_version", "alive", "latest_finished_version")
+    STATUS_VERSION_FIELD_NUMBER: _ClassVar[int]
+    ALIVE_FIELD_NUMBER: _ClassVar[int]
+    LATEST_FINISHED_VERSION_FIELD_NUMBER: _ClassVar[int]
+    status_version: int
+    alive: bool
+    latest_finished_version: int
+    def __init__(self, status_version: _Optional[int] = ..., alive: _Optional[bool] = ..., latest_finished_version: _Optional[int] = ...) -> None: ...
+
+class KvCacheBlockListPB(_message.Message):
+    __slots__ = ("raw_snapshot", "snapshot_version", "block_size")
+    RAW_SNAPSHOT_FIELD_NUMBER: _ClassVar[int]
+    SNAPSHOT_VERSION_FIELD_NUMBER: _ClassVar[int]
+    BLOCK_SIZE_FIELD_NUMBER: _ClassVar[int]
+    raw_snapshot: bytes
+    snapshot_version: int
+    block_size: int
+    def __init__(self, raw_snapshot: _Optional[bytes] = ..., snapshot_version: _Optional[int] = ..., block_size: _Optional[int] = ...) -> None: ...
+
+class KvCacheBlocksRequestPB(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class OptionalUInt64PB(_message.Message):
+    __slots__ = ("value",)
+    value: int
+    def __init__(self, value: _Optional[int] = ...) -> None: ...
+
+class OptionalInt64PB(_message.Message):
+    __slots__ = ("value",)
+    value: int
+    def __init__(self, value: _Optional[int] = ...) -> None: ...
+
+class StringListPB(_message.Message):
+    __slots__ = ("values",)
+    values: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, values: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class Int64ListPB(_message.Message):
+    __slots__ = ("values",)
+    values: _containers.RepeatedScalarFieldContainer[int]
+    def __init__(self, values: _Optional[_Iterable[int]] = ...) -> None: ...
+
+class UInt64ListPB(_message.Message):
+    __slots__ = ("values",)
+    values: _containers.RepeatedScalarFieldContainer[int]
+    def __init__(self, values: _Optional[_Iterable[int]] = ...) -> None: ...
+
+class DoubleListPB(_message.Message):
+    __slots__ = ("values",)
+    values: _containers.RepeatedScalarFieldContainer[float]
+    def __init__(self, values: _Optional[_Iterable[float]] = ...) -> None: ...
+
+class BoolListPB(_message.Message):
+    __slots__ = ("values",)
+    values: _containers.RepeatedScalarFieldContainer[bool]
+    def __init__(self, values: _Optional[_Iterable[bool]] = ...) -> None: ...
+
+class TypedSettingPB(_message.Message):
+    __slots__ = ("name", "bool_value", "int64_value", "uint64_value", "double_value", "string_value", "bytes_value", "string_list", "int64_list", "uint64_list", "double_list", "bool_list")
+    name: str
+    bool_value: bool
+    int64_value: int
+    uint64_value: int
+    double_value: float
+    string_value: str
+    bytes_value: bytes
+    string_list: StringListPB
+    int64_list: Int64ListPB
+    uint64_list: UInt64ListPB
+    double_list: DoubleListPB
+    bool_list: BoolListPB
+    def __init__(self, name: _Optional[str] = ..., bool_value: _Optional[bool] = ..., int64_value: _Optional[int] = ..., uint64_value: _Optional[int] = ..., double_value: _Optional[float] = ..., string_value: _Optional[str] = ..., bytes_value: _Optional[bytes] = ..., string_list: _Optional[_Union[StringListPB, _Mapping]] = ..., int64_list: _Optional[_Union[Int64ListPB, _Mapping]] = ..., uint64_list: _Optional[_Union[UInt64ListPB, _Mapping]] = ..., double_list: _Optional[_Union[DoubleListPB, _Mapping]] = ..., bool_list: _Optional[_Union[BoolListPB, _Mapping]] = ...) -> None: ...
+
+class EventTransportPB(_message.Message):
+    __slots__ = ("live_endpoint", "topic", "replay_supported", "replay_endpoint", "serialization")
+    live_endpoint: str
+    topic: str
+    replay_supported: bool
+    replay_endpoint: str
+    serialization: str
+    def __init__(self, live_endpoint: _Optional[str] = ..., topic: _Optional[str] = ..., replay_supported: _Optional[bool] = ..., replay_endpoint: _Optional[str] = ..., serialization: _Optional[str] = ...) -> None: ...
+
+class RuntimeTopologyPB(_message.Message):
+    __slots__ = ("data_parallel_size", "tensor_parallel_size", "pipeline_parallel_size", "data_parallel_rank", "tensor_parallel_rank", "pipeline_parallel_rank")
+    data_parallel_size: int
+    tensor_parallel_size: int
+    pipeline_parallel_size: int
+    data_parallel_rank: int
+    tensor_parallel_rank: int
+    pipeline_parallel_rank: int
+    def __init__(self, data_parallel_size: _Optional[int] = ..., tensor_parallel_size: _Optional[int] = ..., pipeline_parallel_size: _Optional[int] = ..., data_parallel_rank: _Optional[int] = ..., tensor_parallel_rank: _Optional[int] = ..., pipeline_parallel_rank: _Optional[int] = ...) -> None: ...
+
+class SnapshotCapabilityPB(_message.Message):
+    __slots__ = ("supported", "versioned")
+    supported: bool
+    versioned: bool
+    def __init__(self, supported: _Optional[bool] = ..., versioned: _Optional[bool] = ...) -> None: ...
+
+class CacheGeometryPB(_message.Message):
+    __slots__ = ("block_size_tokens", "page_size_tokens", "block_count", "group_payload_size_bytes", "cache_dtype", "element_size_bytes", "layer_count", "cache_layout", "sliding_window_tokens", "checkpoint_alignment_tokens")
+    block_size_tokens: int
+    page_size_tokens: OptionalUInt64PB
+    block_count: OptionalUInt64PB
+    group_payload_size_bytes: OptionalUInt64PB
+    cache_dtype: str
+    element_size_bytes: OptionalUInt64PB
+    layer_count: OptionalUInt64PB
+    cache_layout: str
+    sliding_window_tokens: OptionalInt64PB
+    checkpoint_alignment_tokens: OptionalUInt64PB
+    def __init__(self, block_size_tokens: _Optional[int] = ..., page_size_tokens: _Optional[_Union[OptionalUInt64PB, _Mapping]] = ..., block_count: _Optional[_Union[OptionalUInt64PB, _Mapping]] = ..., group_payload_size_bytes: _Optional[_Union[OptionalUInt64PB, _Mapping]] = ..., cache_dtype: _Optional[str] = ..., element_size_bytes: _Optional[_Union[OptionalUInt64PB, _Mapping]] = ..., layer_count: _Optional[_Union[OptionalUInt64PB, _Mapping]] = ..., cache_layout: _Optional[str] = ..., sliding_window_tokens: _Optional[_Union[OptionalInt64PB, _Mapping]] = ..., checkpoint_alignment_tokens: _Optional[_Union[OptionalUInt64PB, _Mapping]] = ...) -> None: ...
+
+class CacheComponentPB(_message.Message):
+    __slots__ = ("component_id", "component_kind", "geometry", "compatibility_settings", "diagnostic_settings")
+    component_id: int
+    component_kind: str
+    geometry: CacheGeometryPB
+    compatibility_settings: _containers.RepeatedCompositeFieldContainer[TypedSettingPB]
+    diagnostic_settings: _containers.RepeatedCompositeFieldContainer[TypedSettingPB]
+    def __init__(self, component_id: _Optional[int] = ..., component_kind: _Optional[str] = ..., geometry: _Optional[_Union[CacheGeometryPB, _Mapping]] = ..., compatibility_settings: _Optional[_Iterable[_Union[TypedSettingPB, _Mapping]]] = ..., diagnostic_settings: _Optional[_Iterable[_Union[TypedSettingPB, _Mapping]]] = ...) -> None: ...
+
+class VllmKvEventSchemaPB(_message.Message):
+    __slots__ = ("event_schema_version", "use_eagle_pop", "mamba_cache_mode", "hash_algorithm", "hash_version", "cache_settings")
+    event_schema_version: int
+    use_eagle_pop: bool
+    mamba_cache_mode: str
+    hash_algorithm: str
+    hash_version: str
+    cache_settings: _containers.RepeatedCompositeFieldContainer[TypedSettingPB]
+    def __init__(self, event_schema_version: _Optional[int] = ..., use_eagle_pop: _Optional[bool] = ..., mamba_cache_mode: _Optional[str] = ..., hash_algorithm: _Optional[str] = ..., hash_version: _Optional[str] = ..., cache_settings: _Optional[_Iterable[_Union[TypedSettingPB, _Mapping]]] = ...) -> None: ...
+
+class SglangKvEventSchemaPB(_message.Message):
+    __slots__ = ("cache_key_mode", "event_schema_version", "native_hash_algorithm", "cache_settings")
+    cache_key_mode: str
+    event_schema_version: int
+    native_hash_algorithm: str
+    cache_settings: _containers.RepeatedCompositeFieldContainer[TypedSettingPB]
+    def __init__(self, cache_key_mode: _Optional[str] = ..., event_schema_version: _Optional[int] = ..., native_hash_algorithm: _Optional[str] = ..., cache_settings: _Optional[_Iterable[_Union[TypedSettingPB, _Mapping]]] = ...) -> None: ...
+
+class KvEventBootstrapInfoPB(_message.Message):
+    __slots__ = ("protocol_version", "engine_kind", "event_transport", "runtime_topology", "snapshot", "components", "err_code", "err_msg", "compatibility_settings", "diagnostic_settings", "vllm", "sglang")
+    protocol_version: int
+    engine_kind: str
+    event_transport: EventTransportPB
+    runtime_topology: RuntimeTopologyPB
+    snapshot: SnapshotCapabilityPB
+    components: _containers.RepeatedCompositeFieldContainer[CacheComponentPB]
+    err_code: KvEventBootstrapErrorCode
+    err_msg: str
+    compatibility_settings: _containers.RepeatedCompositeFieldContainer[TypedSettingPB]
+    diagnostic_settings: _containers.RepeatedCompositeFieldContainer[TypedSettingPB]
+    vllm: VllmKvEventSchemaPB
+    sglang: SglangKvEventSchemaPB
+    def __init__(self, protocol_version: _Optional[int] = ..., engine_kind: _Optional[str] = ..., event_transport: _Optional[_Union[EventTransportPB, _Mapping]] = ..., runtime_topology: _Optional[_Union[RuntimeTopologyPB, _Mapping]] = ..., snapshot: _Optional[_Union[SnapshotCapabilityPB, _Mapping]] = ..., components: _Optional[_Iterable[_Union[CacheComponentPB, _Mapping]]] = ..., err_code: _Optional[_Union[KvEventBootstrapErrorCode, str]] = ..., err_msg: _Optional[str] = ..., compatibility_settings: _Optional[_Iterable[_Union[TypedSettingPB, _Mapping]]] = ..., diagnostic_settings: _Optional[_Iterable[_Union[TypedSettingPB, _Mapping]]] = ..., vllm: _Optional[_Union[VllmKvEventSchemaPB, _Mapping]] = ..., sglang: _Optional[_Union[SglangKvEventSchemaPB, _Mapping]] = ...) -> None: ...
+
+class KvEventBootstrapInfoRequestPB(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...

--- a/subscriber/subscriber/proto/engine_service_rpc_pb2_grpc.py
+++ b/subscriber/subscriber/proto/engine_service_rpc_pb2_grpc.py
@@ -1,0 +1,151 @@
+"""Hand-maintained gRPC stubs.
+
+DO NOT regenerate via grpc_tools.protoc; see AGENTS.md for the wire-schema
+maintenance rules (protobuf 3.20.3 compatibility must be preserved).
+"""
+import grpc
+import warnings
+
+from subscriber.proto import engine_service_rpc_pb2 as subscriber_dot_proto_dot_engine__service__rpc__pb2
+
+GRPC_GENERATED_VERSION = '1.68.1'
+GRPC_VERSION = grpc.__version__
+_version_not_supported = False
+
+try:
+    from grpc._utilities import first_version_is_lower
+    _version_not_supported = first_version_is_lower(GRPC_VERSION, GRPC_GENERATED_VERSION)
+except ImportError:
+    _version_not_supported = True
+
+if _version_not_supported:
+    raise RuntimeError(
+        f'The grpc package installed is at version {GRPC_VERSION},'
+        + f' but the generated code in subscriber/proto/engine_service_rpc_pb2_grpc.py depends on'
+        + f' grpcio>={GRPC_GENERATED_VERSION}.'
+        + f' Please upgrade your grpc module to grpcio>={GRPC_GENERATED_VERSION}'
+        + f' or downgrade your generated code using grpcio-tools<={GRPC_VERSION}.'
+    )
+
+
+class RpcServiceStub(object):
+    """Missing associated documentation comment in .proto file."""
+
+    def __init__(self, channel):
+        """Constructor.
+
+        Args:
+            channel: A grpc.Channel.
+        """
+        self.GetWorkerStatus = channel.unary_unary(
+                '/RpcService/GetWorkerStatus',
+                request_serializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.StatusVersionPB.SerializeToString,
+                response_deserializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.WorkerStatusPB.FromString,
+                _registered_method=True)
+
+
+class RpcServiceServicer(object):
+    """Missing associated documentation comment in .proto file."""
+
+    def GetWorkerStatus(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+
+def add_RpcServiceServicer_to_server(servicer, server):
+    rpc_method_handlers = {
+            'GetWorkerStatus': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetWorkerStatus,
+                    request_deserializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.StatusVersionPB.FromString,
+                    response_serializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.WorkerStatusPB.SerializeToString,
+            ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+            'RpcService', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))
+    server.add_registered_method_handlers('RpcService', rpc_method_handlers)
+
+
+ # This class is part of an EXPERIMENTAL API.
+class RpcService(object):
+    """Missing associated documentation comment in .proto file."""
+
+    @staticmethod
+    def GetWorkerStatus(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/RpcService/GetWorkerStatus',
+            subscriber_dot_proto_dot_engine__service__rpc__pb2.StatusVersionPB.SerializeToString,
+            subscriber_dot_proto_dot_engine__service__rpc__pb2.WorkerStatusPB.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+
+
+class KvEventControlServiceStub(object):
+    """Local KV-event bootstrap and snapshot control service."""
+
+    def __init__(self, channel):
+        self.GetKvEventBootstrapInfo = channel.unary_unary(
+                '/KvEventControlService/GetKvEventBootstrapInfo',
+                request_serializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvEventBootstrapInfoRequestPB.SerializeToString,
+                response_deserializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvEventBootstrapInfoPB.FromString,
+                _registered_method=True)
+        self.GetAllKvCacheBlocks = channel.unary_unary(
+                '/KvEventControlService/GetAllKvCacheBlocks',
+                request_serializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvCacheBlocksRequestPB.SerializeToString,
+                response_deserializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvCacheBlockListPB.FromString,
+                _registered_method=True)
+
+
+class KvEventControlServiceServicer(object):
+    """Local KV-event bootstrap and snapshot control service."""
+
+    def GetKvEventBootstrapInfo(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def GetAllKvCacheBlocks(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+
+def add_KvEventControlServiceServicer_to_server(servicer, server):
+    rpc_method_handlers = {
+            'GetKvEventBootstrapInfo': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetKvEventBootstrapInfo,
+                    request_deserializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvEventBootstrapInfoRequestPB.FromString,
+                    response_serializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvEventBootstrapInfoPB.SerializeToString,
+            ),
+            'GetAllKvCacheBlocks': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetAllKvCacheBlocks,
+                    request_deserializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvCacheBlocksRequestPB.FromString,
+                    response_serializer=subscriber_dot_proto_dot_engine__service__rpc__pb2.KvCacheBlockListPB.SerializeToString,
+            ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+            'KvEventControlService', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))
+    server.add_registered_method_handlers(
+            'KvEventControlService', rpc_method_handlers)

--- a/subscriber/subscriber/proto/kvcm_meta_service.proto
+++ b/subscriber/subscriber/proto/kvcm_meta_service.proto
@@ -1,0 +1,203 @@
+syntax = "proto3";
+
+package kv_cache_manager.proto.meta;
+
+// Authoritative source for the hand-maintained protobuf 3.20-compatible
+// kvcm_meta_service_pb2.py subset used by the subscriber.
+
+enum ErrorCode {
+  UNSPECIFIED = 0;
+  OK = 1;
+  UNSUPPORTED = 2;
+  INTERNAL_ERROR = 3;
+  SERVICE_NOT_READY = 4;
+  INVALID_ARGUMENT = 5;
+  DUPLICATE_ENTITY = 6;
+  REACH_MAX_ENTITY_CAPACITY = 7;
+  INSTANCE_NOT_EXIST = 8;
+  SERVER_NOT_LEADER = 9;
+  NODE_NOT_REGISTERED = 10;
+  SNAPSHOT_IN_PROGRESS = 11;
+  SNAPSHOT_RATE_LIMITED = 13;
+  SNAPSHOT_REQUIRED = 14;
+  IO_ERROR = 20;
+  UNKNOWN_ERROR = 100;
+  ERROR_MAX = 65535;
+}
+
+enum StorageType {
+  ST_UNSPECIFIED = 0;
+  ST_3FS = 1;
+  ST_MOONCAKE = 2;
+  ST_TAIRMEMPOOL = 3;
+  ST_NFS = 4;
+  ST_VCNS_3FS = 5;
+  ST_DUMMY = 6;
+  ST_EVENT_REPORT_L1P5 = 7;
+  ST_EVENT_REPORT_L2 = 8;
+}
+
+enum ReportEventType {
+  EVENT_UNSPECIFIED = 0;
+  EVENT_NODE_REGISTER = 1;
+  EVENT_BLOCK_ADD = 2;
+  EVENT_BLOCK_DELETE = 3;
+  EVENT_HOST_DOWN = 4;
+  EVENT_HEARTBEAT = 5;
+  EVENT_BLOCK_SNAPSHOT = 6;
+}
+
+enum QueryType {
+  QT_UNSPECIFIED = 0;
+  QT_BATCH_GET = 1;
+  QT_PREFIX_MATCH = 2;
+  QT_REVERSE_ROLL_SW_MATCH = 3;
+  QT_PREFIX_MATCH_WITH_MAMBA = 4;
+}
+
+message Status {
+  ErrorCode code = 1;
+  string message = 2;
+}
+
+message CommonResponseHeader {
+  Status status = 1;
+  string request_id = 2;
+  string tracer_result = 3;
+}
+
+message NodeRegisterEventParams {
+  repeated string mediums = 1;
+}
+
+message LocationSpec {
+  string name = 1;
+  string uri = 2;
+}
+
+message BlockAddEventParams {
+  string block_key = 1;
+  string uri = 2;
+  string medium = 3;
+  repeated LocationSpec specs = 4;
+}
+
+message BlockDeleteEventParams {
+  string block_key = 1;
+  string medium = 2;
+  repeated string spec_names = 3;
+}
+
+message BlockSnapshotItem {
+  string block_key = 1;
+  string medium = 2;
+  repeated LocationSpec specs = 3;
+}
+
+message BlockSnapshotEventParams {
+  string medium = 1;
+  repeated BlockSnapshotItem blocks = 2;
+}
+
+message HostDownEventParams {}
+
+message HeartbeatEventParams {
+  map<string, string> system_status = 1;
+}
+
+message EventItem {
+  ReportEventType event_type = 1;
+  oneof event_params {
+    NodeRegisterEventParams node_register = 2;
+    BlockAddEventParams block_add = 3;
+    BlockDeleteEventParams block_delete = 4;
+    HostDownEventParams host_down = 5;
+    HeartbeatEventParams heartbeat = 6;
+    BlockSnapshotEventParams block_snapshot = 7;
+  }
+}
+
+message ReportEventRequest {
+  string trace_id = 1;
+  string instance_id = 2;
+  string host_ip_port = 3;
+  repeated EventItem events = 4;
+  StorageType storage_type = 5;
+}
+
+message ReportEventResponse {
+  CommonResponseHeader header = 1;
+  repeated ErrorCode item_results = 2;
+  string committed_snapshot_version = 3;
+  uint64 retry_after_ms = 4;
+  bool snapshot_required = 5;
+  string extra_info = 6;
+}
+
+message LocationSpecInfo {
+  string name = 1;
+  int64 size = 2;
+}
+
+message ModelDeployment {
+  string model_name = 1;
+  string dtype = 2;
+  bool use_mla = 3;
+  int32 tp_size = 4;
+  int32 dp_size = 5;
+  string lora_name = 6;
+  int32 pp_size = 7;
+  string extra = 8;
+  string user_data = 9;
+  bool use_eagle_pop = 10;
+}
+
+message LocationSpecGroup {
+  string name = 1;
+  repeated string spec_names = 2;
+}
+
+message RegisterInstanceRequest {
+  string trace_id = 1;
+  string instance_group = 2;
+  string instance_id = 3;
+  int32 block_size = 4;
+  repeated LocationSpecInfo location_spec_infos = 5;
+  ModelDeployment model_deployment = 6;
+  repeated LocationSpecGroup location_spec_groups = 7;
+  QueryType default_query_type = 8;
+}
+
+message RegisterInstanceResponse {
+  CommonResponseHeader header = 1;
+  string storage_configs = 2;
+  string extra_info = 3;
+}
+
+message MetaNodeEndpoint {
+  string node_id = 1;
+  string host = 2;
+  int32 meta_rpc_port = 3;
+  int32 meta_http_port = 4;
+  string custom_info = 5;
+}
+
+message GetClusterInfoRequest {
+  string trace_id = 1;
+  string instance_id = 2;
+}
+
+message GetClusterInfoResponse {
+  CommonResponseHeader header = 1;
+  string self_node_id = 2;
+  string leader_node_id = 3;
+  MetaNodeEndpoint leader_endpoint = 4;
+}
+
+service MetaService {
+  rpc RegisterInstance(RegisterInstanceRequest)
+      returns (RegisterInstanceResponse);
+  rpc GetClusterInfo(GetClusterInfoRequest)
+      returns (GetClusterInfoResponse);
+  rpc ReportEvent(ReportEventRequest) returns (ReportEventResponse);
+}

--- a/subscriber/subscriber/proto/kvcm_meta_service_pb2.py
+++ b/subscriber/subscriber/proto/kvcm_meta_service_pb2.py
@@ -1,0 +1,570 @@
+# -*- coding: utf-8 -*-
+"""Hand-written protobuf definitions for KVCM meta_service.proto.
+
+Compatible with protobuf>=3.20.3 (no runtime_version / _builder dependency).
+This file intentionally keeps only the KVCM MetaService subset used by the
+subscriber transport.
+"""
+
+from __future__ import annotations
+
+from google.protobuf import descriptor_pb2 as _descriptor_pb2
+from google.protobuf import descriptor_pool as _descriptor_pool
+from google.protobuf import message_factory as _message_factory
+from google.protobuf import symbol_database as _symbol_database
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+
+_sym_db = _symbol_database.Default()
+_PKG = "kv_cache_manager.proto.meta"
+_T = _descriptor_pb2.FieldDescriptorProto
+_LABEL_OPTIONAL = _T.LABEL_OPTIONAL
+_LABEL_REPEATED = _T.LABEL_REPEATED
+
+
+def _type_name(name: str) -> str:
+    return f".{_PKG}.{name}"
+
+
+def _add_field(
+    message: _descriptor_pb2.DescriptorProto,
+    name: str,
+    number: int,
+    label: int,
+    field_type: int,
+    type_name: str = "",
+    oneof_index: int | None = None,
+) -> None:
+    field = message.field.add()
+    field.name = name
+    field.number = number
+    field.label = label
+    field.type = field_type
+    if type_name:
+        field.type_name = type_name
+    if oneof_index is not None:
+        field.oneof_index = oneof_index
+
+
+def _add_enum(
+    file_proto: _descriptor_pb2.FileDescriptorProto,
+    name: str,
+    values: tuple[tuple[str, int], ...],
+) -> None:
+    enum = file_proto.enum_type.add()
+    enum.name = name
+    for value_name, number in values:
+        enum.value.add(name=value_name, number=number)
+
+
+def _add_message(
+    file_proto: _descriptor_pb2.FileDescriptorProto, name: str
+) -> _descriptor_pb2.DescriptorProto:
+    message = file_proto.message_type.add()
+    message.name = name
+    return message
+
+
+def _build_file_descriptor():
+    file_proto = _descriptor_pb2.FileDescriptorProto()
+    file_proto.name = "subscriber/proto/kvcm_meta_service.proto"
+    file_proto.package = _PKG
+    file_proto.syntax = "proto3"
+
+    _add_enum(
+        file_proto,
+        "ErrorCode",
+        (
+            ("UNSPECIFIED", 0),
+            ("OK", 1),
+            ("UNSUPPORTED", 2),
+            ("INTERNAL_ERROR", 3),
+            ("SERVICE_NOT_READY", 4),
+            ("INVALID_ARGUMENT", 5),
+            ("DUPLICATE_ENTITY", 6),
+            ("REACH_MAX_ENTITY_CAPACITY", 7),
+            ("INSTANCE_NOT_EXIST", 8),
+            ("SERVER_NOT_LEADER", 9),
+            ("NODE_NOT_REGISTERED", 10),
+            ("SNAPSHOT_IN_PROGRESS", 11),
+            ("SNAPSHOT_RATE_LIMITED", 13),
+            ("SNAPSHOT_REQUIRED", 14),
+            ("IO_ERROR", 20),
+            ("UNKNOWN_ERROR", 100),
+            ("ERROR_MAX", 65535),
+        ),
+    )
+    _add_enum(
+        file_proto,
+        "StorageType",
+        (
+            ("ST_UNSPECIFIED", 0),
+            ("ST_3FS", 1),
+            ("ST_MOONCAKE", 2),
+            ("ST_TAIRMEMPOOL", 3),
+            ("ST_NFS", 4),
+            ("ST_VCNS_3FS", 5),
+            ("ST_DUMMY", 6),
+            ("ST_EVENT_REPORT_L1P5", 7),
+            ("ST_EVENT_REPORT_L2", 8),
+        ),
+    )
+    _add_enum(
+        file_proto,
+        "ReportEventType",
+        (
+            ("EVENT_UNSPECIFIED", 0),
+            ("EVENT_NODE_REGISTER", 1),
+            ("EVENT_BLOCK_ADD", 2),
+            ("EVENT_BLOCK_DELETE", 3),
+            ("EVENT_HOST_DOWN", 4),
+            ("EVENT_HEARTBEAT", 5),
+            ("EVENT_BLOCK_SNAPSHOT", 6),
+        ),
+    )
+    _add_enum(
+        file_proto,
+        "QueryType",
+        (
+            ("QT_UNSPECIFIED", 0),
+            ("QT_BATCH_GET", 1),
+            ("QT_PREFIX_MATCH", 2),
+            ("QT_REVERSE_ROLL_SW_MATCH", 3),
+            ("QT_PREFIX_MATCH_WITH_MAMBA", 4),
+        ),
+    )
+
+    status = _add_message(file_proto, "Status")
+    _add_field(
+        status,
+        "code",
+        1,
+        _LABEL_OPTIONAL,
+        _T.TYPE_ENUM,
+        _type_name("ErrorCode"),
+    )
+    _add_field(status, "message", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+
+    header = _add_message(file_proto, "CommonResponseHeader")
+    _add_field(
+        header,
+        "status",
+        1,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("Status"),
+    )
+    _add_field(header, "request_id", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(header, "tracer_result", 3, _LABEL_OPTIONAL, _T.TYPE_STRING)
+
+    node_register = _add_message(file_proto, "NodeRegisterEventParams")
+    _add_field(node_register, "mediums", 1, _LABEL_REPEATED, _T.TYPE_STRING)
+
+    location_spec = _add_message(file_proto, "LocationSpec")
+    _add_field(location_spec, "name", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(location_spec, "uri", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+
+    block_add = _add_message(file_proto, "BlockAddEventParams")
+    _add_field(block_add, "block_key", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(block_add, "uri", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(block_add, "medium", 3, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(
+        block_add,
+        "specs",
+        4,
+        _LABEL_REPEATED,
+        _T.TYPE_MESSAGE,
+        _type_name("LocationSpec"),
+    )
+
+    block_delete = _add_message(file_proto, "BlockDeleteEventParams")
+    _add_field(block_delete, "block_key", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(block_delete, "medium", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(block_delete, "spec_names", 3, _LABEL_REPEATED, _T.TYPE_STRING)
+
+    block_snapshot_item = _add_message(file_proto, "BlockSnapshotItem")
+    _add_field(block_snapshot_item, "block_key", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(block_snapshot_item, "medium", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(
+        block_snapshot_item,
+        "specs",
+        3,
+        _LABEL_REPEATED,
+        _T.TYPE_MESSAGE,
+        _type_name("LocationSpec"),
+    )
+
+    block_snapshot = _add_message(file_proto, "BlockSnapshotEventParams")
+    _add_field(block_snapshot, "medium", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(
+        block_snapshot,
+        "blocks",
+        2,
+        _LABEL_REPEATED,
+        _T.TYPE_MESSAGE,
+        _type_name("BlockSnapshotItem"),
+    )
+
+    _add_message(file_proto, "HostDownEventParams")
+
+    heartbeat = _add_message(file_proto, "HeartbeatEventParams")
+    system_status = heartbeat.nested_type.add()
+    system_status.name = "SystemStatusEntry"
+    system_status.options.map_entry = True
+    _add_field(system_status, "key", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(system_status, "value", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(
+        heartbeat,
+        "system_status",
+        1,
+        _LABEL_REPEATED,
+        _T.TYPE_MESSAGE,
+        f"{_type_name('HeartbeatEventParams')}.SystemStatusEntry",
+    )
+
+    event_item = _add_message(file_proto, "EventItem")
+    event_item.oneof_decl.add().name = "event_params"
+    _add_field(
+        event_item,
+        "event_type",
+        1,
+        _LABEL_OPTIONAL,
+        _T.TYPE_ENUM,
+        _type_name("ReportEventType"),
+    )
+    _add_field(
+        event_item,
+        "node_register",
+        2,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("NodeRegisterEventParams"),
+        0,
+    )
+    _add_field(
+        event_item,
+        "block_add",
+        3,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("BlockAddEventParams"),
+        0,
+    )
+    _add_field(
+        event_item,
+        "block_delete",
+        4,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("BlockDeleteEventParams"),
+        0,
+    )
+    _add_field(
+        event_item,
+        "host_down",
+        5,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("HostDownEventParams"),
+        0,
+    )
+    _add_field(
+        event_item,
+        "heartbeat",
+        6,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("HeartbeatEventParams"),
+        0,
+    )
+    _add_field(
+        event_item,
+        "block_snapshot",
+        7,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("BlockSnapshotEventParams"),
+        0,
+    )
+
+    report_request = _add_message(file_proto, "ReportEventRequest")
+    _add_field(report_request, "trace_id", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(report_request, "instance_id", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(report_request, "host_ip_port", 3, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(
+        report_request,
+        "events",
+        4,
+        _LABEL_REPEATED,
+        _T.TYPE_MESSAGE,
+        _type_name("EventItem"),
+    )
+    _add_field(
+        report_request,
+        "storage_type",
+        5,
+        _LABEL_OPTIONAL,
+        _T.TYPE_ENUM,
+        _type_name("StorageType"),
+    )
+
+    report_response = _add_message(file_proto, "ReportEventResponse")
+    _add_field(
+        report_response,
+        "header",
+        1,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("CommonResponseHeader"),
+    )
+    _add_field(
+        report_response,
+        "item_results",
+        2,
+        _LABEL_REPEATED,
+        _T.TYPE_ENUM,
+        _type_name("ErrorCode"),
+    )
+    _add_field(
+        report_response,
+        "committed_snapshot_version",
+        3,
+        _LABEL_OPTIONAL,
+        _T.TYPE_STRING,
+    )
+    _add_field(report_response, "retry_after_ms", 4, _LABEL_OPTIONAL, _T.TYPE_UINT64)
+    _add_field(report_response, "snapshot_required", 5, _LABEL_OPTIONAL, _T.TYPE_BOOL)
+    _add_field(report_response, "extra_info", 6, _LABEL_OPTIONAL, _T.TYPE_STRING)
+
+    location_spec_info = _add_message(file_proto, "LocationSpecInfo")
+    _add_field(location_spec_info, "name", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(location_spec_info, "size", 2, _LABEL_OPTIONAL, _T.TYPE_INT64)
+
+    model_deployment = _add_message(file_proto, "ModelDeployment")
+    _add_field(model_deployment, "model_name", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(model_deployment, "dtype", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(model_deployment, "use_mla", 3, _LABEL_OPTIONAL, _T.TYPE_BOOL)
+    _add_field(model_deployment, "tp_size", 4, _LABEL_OPTIONAL, _T.TYPE_INT32)
+    _add_field(model_deployment, "dp_size", 5, _LABEL_OPTIONAL, _T.TYPE_INT32)
+    _add_field(model_deployment, "lora_name", 6, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(model_deployment, "pp_size", 7, _LABEL_OPTIONAL, _T.TYPE_INT32)
+    _add_field(model_deployment, "extra", 8, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(model_deployment, "user_data", 9, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(model_deployment, "use_eagle_pop", 10, _LABEL_OPTIONAL, _T.TYPE_BOOL)
+
+    location_spec_group = _add_message(file_proto, "LocationSpecGroup")
+    _add_field(location_spec_group, "name", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(location_spec_group, "spec_names", 2, _LABEL_REPEATED, _T.TYPE_STRING)
+
+    register_request = _add_message(file_proto, "RegisterInstanceRequest")
+    _add_field(register_request, "trace_id", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(register_request, "instance_group", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(register_request, "instance_id", 3, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(register_request, "block_size", 4, _LABEL_OPTIONAL, _T.TYPE_INT32)
+    _add_field(
+        register_request,
+        "location_spec_infos",
+        5,
+        _LABEL_REPEATED,
+        _T.TYPE_MESSAGE,
+        _type_name("LocationSpecInfo"),
+    )
+    _add_field(
+        register_request,
+        "model_deployment",
+        6,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("ModelDeployment"),
+    )
+    _add_field(
+        register_request,
+        "location_spec_groups",
+        7,
+        _LABEL_REPEATED,
+        _T.TYPE_MESSAGE,
+        _type_name("LocationSpecGroup"),
+    )
+    _add_field(
+        register_request,
+        "default_query_type",
+        8,
+        _LABEL_OPTIONAL,
+        _T.TYPE_ENUM,
+        _type_name("QueryType"),
+    )
+
+    register_response = _add_message(file_proto, "RegisterInstanceResponse")
+    _add_field(
+        register_response,
+        "header",
+        1,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("CommonResponseHeader"),
+    )
+    _add_field(register_response, "storage_configs", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(register_response, "extra_info", 3, _LABEL_OPTIONAL, _T.TYPE_STRING)
+
+    endpoint = _add_message(file_proto, "MetaNodeEndpoint")
+    _add_field(endpoint, "node_id", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(endpoint, "host", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(endpoint, "meta_rpc_port", 3, _LABEL_OPTIONAL, _T.TYPE_INT32)
+    _add_field(endpoint, "meta_http_port", 4, _LABEL_OPTIONAL, _T.TYPE_INT32)
+    _add_field(endpoint, "custom_info", 5, _LABEL_OPTIONAL, _T.TYPE_STRING)
+
+    cluster_request = _add_message(file_proto, "GetClusterInfoRequest")
+    _add_field(cluster_request, "trace_id", 1, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(cluster_request, "instance_id", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+
+    cluster_response = _add_message(file_proto, "GetClusterInfoResponse")
+    _add_field(
+        cluster_response,
+        "header",
+        1,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("CommonResponseHeader"),
+    )
+    _add_field(cluster_response, "self_node_id", 2, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(cluster_response, "leader_node_id", 3, _LABEL_OPTIONAL, _T.TYPE_STRING)
+    _add_field(
+        cluster_response,
+        "leader_endpoint",
+        4,
+        _LABEL_OPTIONAL,
+        _T.TYPE_MESSAGE,
+        _type_name("MetaNodeEndpoint"),
+    )
+
+    service = file_proto.service.add()
+    service.name = "MetaService"
+    for method_name, request_name, response_name in (
+        ("RegisterInstance", "RegisterInstanceRequest", "RegisterInstanceResponse"),
+        ("GetClusterInfo", "GetClusterInfoRequest", "GetClusterInfoResponse"),
+        ("ReportEvent", "ReportEventRequest", "ReportEventResponse"),
+    ):
+        method = service.method.add()
+        method.name = method_name
+        method.input_type = _type_name(request_name)
+        method.output_type = _type_name(response_name)
+
+    pool = _descriptor_pool.Default()
+    try:
+        return pool.AddSerializedFile(file_proto.SerializeToString())
+    except Exception:
+        return pool.FindFileByName(file_proto.name)
+
+
+DESCRIPTOR = _build_file_descriptor()
+
+
+def _message_class(name: str):
+    descriptor = DESCRIPTOR.message_types_by_name[name]
+    get_message_class = getattr(_message_factory, "GetMessageClass", None)
+    if get_message_class is not None:
+        return get_message_class(descriptor)
+    factory = _message_factory.MessageFactory()
+    return factory.GetPrototype(descriptor)
+
+
+Status = _message_class("Status")
+CommonResponseHeader = _message_class("CommonResponseHeader")
+NodeRegisterEventParams = _message_class("NodeRegisterEventParams")
+LocationSpec = _message_class("LocationSpec")
+BlockAddEventParams = _message_class("BlockAddEventParams")
+BlockDeleteEventParams = _message_class("BlockDeleteEventParams")
+BlockSnapshotItem = _message_class("BlockSnapshotItem")
+BlockSnapshotEventParams = _message_class("BlockSnapshotEventParams")
+HostDownEventParams = _message_class("HostDownEventParams")
+HeartbeatEventParams = _message_class("HeartbeatEventParams")
+EventItem = _message_class("EventItem")
+ReportEventRequest = _message_class("ReportEventRequest")
+ReportEventResponse = _message_class("ReportEventResponse")
+LocationSpecInfo = _message_class("LocationSpecInfo")
+ModelDeployment = _message_class("ModelDeployment")
+LocationSpecGroup = _message_class("LocationSpecGroup")
+RegisterInstanceRequest = _message_class("RegisterInstanceRequest")
+RegisterInstanceResponse = _message_class("RegisterInstanceResponse")
+MetaNodeEndpoint = _message_class("MetaNodeEndpoint")
+GetClusterInfoRequest = _message_class("GetClusterInfoRequest")
+GetClusterInfoResponse = _message_class("GetClusterInfoResponse")
+
+ErrorCode = _enum_type_wrapper.EnumTypeWrapper(
+    DESCRIPTOR.enum_types_by_name["ErrorCode"]
+)
+StorageType = _enum_type_wrapper.EnumTypeWrapper(
+    DESCRIPTOR.enum_types_by_name["StorageType"]
+)
+ReportEventType = _enum_type_wrapper.EnumTypeWrapper(
+    DESCRIPTOR.enum_types_by_name["ReportEventType"]
+)
+QueryType = _enum_type_wrapper.EnumTypeWrapper(
+    DESCRIPTOR.enum_types_by_name["QueryType"]
+)
+
+UNSPECIFIED = ErrorCode.UNSPECIFIED
+OK = ErrorCode.OK
+UNSUPPORTED = ErrorCode.UNSUPPORTED
+INTERNAL_ERROR = ErrorCode.INTERNAL_ERROR
+SERVICE_NOT_READY = ErrorCode.SERVICE_NOT_READY
+INVALID_ARGUMENT = ErrorCode.INVALID_ARGUMENT
+DUPLICATE_ENTITY = ErrorCode.DUPLICATE_ENTITY
+REACH_MAX_ENTITY_CAPACITY = ErrorCode.REACH_MAX_ENTITY_CAPACITY
+INSTANCE_NOT_EXIST = ErrorCode.INSTANCE_NOT_EXIST
+SERVER_NOT_LEADER = ErrorCode.SERVER_NOT_LEADER
+NODE_NOT_REGISTERED = ErrorCode.NODE_NOT_REGISTERED
+SNAPSHOT_IN_PROGRESS = ErrorCode.SNAPSHOT_IN_PROGRESS
+SNAPSHOT_RATE_LIMITED = ErrorCode.SNAPSHOT_RATE_LIMITED
+SNAPSHOT_REQUIRED = ErrorCode.SNAPSHOT_REQUIRED
+IO_ERROR = ErrorCode.IO_ERROR
+UNKNOWN_ERROR = ErrorCode.UNKNOWN_ERROR
+ERROR_MAX = ErrorCode.ERROR_MAX
+
+ST_UNSPECIFIED = StorageType.ST_UNSPECIFIED
+ST_3FS = StorageType.ST_3FS
+ST_MOONCAKE = StorageType.ST_MOONCAKE
+ST_TAIRMEMPOOL = StorageType.ST_TAIRMEMPOOL
+ST_NFS = StorageType.ST_NFS
+ST_VCNS_3FS = StorageType.ST_VCNS_3FS
+ST_DUMMY = StorageType.ST_DUMMY
+ST_EVENT_REPORT_L1P5 = StorageType.ST_EVENT_REPORT_L1P5
+ST_EVENT_REPORT_L2 = StorageType.ST_EVENT_REPORT_L2
+
+EVENT_UNSPECIFIED = ReportEventType.EVENT_UNSPECIFIED
+EVENT_NODE_REGISTER = ReportEventType.EVENT_NODE_REGISTER
+EVENT_BLOCK_ADD = ReportEventType.EVENT_BLOCK_ADD
+EVENT_BLOCK_DELETE = ReportEventType.EVENT_BLOCK_DELETE
+EVENT_HOST_DOWN = ReportEventType.EVENT_HOST_DOWN
+EVENT_HEARTBEAT = ReportEventType.EVENT_HEARTBEAT
+EVENT_BLOCK_SNAPSHOT = ReportEventType.EVENT_BLOCK_SNAPSHOT
+
+QT_UNSPECIFIED = QueryType.QT_UNSPECIFIED
+QT_BATCH_GET = QueryType.QT_BATCH_GET
+QT_PREFIX_MATCH = QueryType.QT_PREFIX_MATCH
+QT_REVERSE_ROLL_SW_MATCH = QueryType.QT_REVERSE_ROLL_SW_MATCH
+QT_PREFIX_MATCH_WITH_MAMBA = QueryType.QT_PREFIX_MATCH_WITH_MAMBA
+
+for _message in (
+    Status,
+    CommonResponseHeader,
+    NodeRegisterEventParams,
+    LocationSpec,
+    BlockAddEventParams,
+    BlockDeleteEventParams,
+    BlockSnapshotItem,
+    BlockSnapshotEventParams,
+    HostDownEventParams,
+    HeartbeatEventParams,
+    EventItem,
+    ReportEventRequest,
+    ReportEventResponse,
+    LocationSpecInfo,
+    ModelDeployment,
+    LocationSpecGroup,
+    RegisterInstanceRequest,
+    RegisterInstanceResponse,
+    MetaNodeEndpoint,
+    GetClusterInfoRequest,
+    GetClusterInfoResponse,
+):
+    _sym_db.RegisterMessage(_message)

--- a/subscriber/subscriber/proto/kvcm_meta_service_pb2.pyi
+++ b/subscriber/subscriber/proto/kvcm_meta_service_pb2.pyi
@@ -1,0 +1,313 @@
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from typing import (
+    Iterable as _Iterable,
+    Mapping as _Mapping,
+    Optional as _Optional,
+    Union as _Union,
+)
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class ErrorCode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper): ...
+UNSPECIFIED: ErrorCode
+OK: ErrorCode
+UNSUPPORTED: ErrorCode
+INTERNAL_ERROR: ErrorCode
+SERVICE_NOT_READY: ErrorCode
+INVALID_ARGUMENT: ErrorCode
+DUPLICATE_ENTITY: ErrorCode
+REACH_MAX_ENTITY_CAPACITY: ErrorCode
+INSTANCE_NOT_EXIST: ErrorCode
+SERVER_NOT_LEADER: ErrorCode
+NODE_NOT_REGISTERED: ErrorCode
+SNAPSHOT_IN_PROGRESS: ErrorCode
+SNAPSHOT_RATE_LIMITED: ErrorCode
+SNAPSHOT_REQUIRED: ErrorCode
+IO_ERROR: ErrorCode
+UNKNOWN_ERROR: ErrorCode
+ERROR_MAX: ErrorCode
+
+class StorageType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper): ...
+ST_UNSPECIFIED: StorageType
+ST_3FS: StorageType
+ST_MOONCAKE: StorageType
+ST_TAIRMEMPOOL: StorageType
+ST_NFS: StorageType
+ST_VCNS_3FS: StorageType
+ST_DUMMY: StorageType
+ST_EVENT_REPORT_L1P5: StorageType
+ST_EVENT_REPORT_L2: StorageType
+
+class ReportEventType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper): ...
+EVENT_UNSPECIFIED: ReportEventType
+EVENT_NODE_REGISTER: ReportEventType
+EVENT_BLOCK_ADD: ReportEventType
+EVENT_BLOCK_DELETE: ReportEventType
+EVENT_HOST_DOWN: ReportEventType
+EVENT_HEARTBEAT: ReportEventType
+EVENT_BLOCK_SNAPSHOT: ReportEventType
+
+class QueryType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper): ...
+QT_UNSPECIFIED: QueryType
+QT_BATCH_GET: QueryType
+QT_PREFIX_MATCH: QueryType
+QT_REVERSE_ROLL_SW_MATCH: QueryType
+QT_PREFIX_MATCH_WITH_MAMBA: QueryType
+
+class Status(_message.Message):
+    code: ErrorCode
+    message: str
+    def __init__(
+        self,
+        code: _Optional[_Union[ErrorCode, str]] = ...,
+        message: _Optional[str] = ...,
+    ) -> None: ...
+
+class CommonResponseHeader(_message.Message):
+    status: Status
+    request_id: str
+    tracer_result: str
+    def __init__(
+        self,
+        status: _Optional[_Union[Status, _Mapping]] = ...,
+        request_id: _Optional[str] = ...,
+        tracer_result: _Optional[str] = ...,
+    ) -> None: ...
+
+class NodeRegisterEventParams(_message.Message):
+    mediums: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, mediums: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class LocationSpec(_message.Message):
+    name: str
+    uri: str
+    def __init__(
+        self,
+        name: _Optional[str] = ...,
+        uri: _Optional[str] = ...,
+    ) -> None: ...
+
+class BlockAddEventParams(_message.Message):
+    block_key: str
+    uri: str
+    medium: str
+    specs: _containers.RepeatedCompositeFieldContainer[LocationSpec]
+    def __init__(
+        self,
+        block_key: _Optional[str] = ...,
+        uri: _Optional[str] = ...,
+        medium: _Optional[str] = ...,
+        specs: _Optional[_Iterable[_Union[LocationSpec, _Mapping]]] = ...,
+    ) -> None: ...
+
+class BlockDeleteEventParams(_message.Message):
+    block_key: str
+    medium: str
+    spec_names: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(
+        self,
+        block_key: _Optional[str] = ...,
+        medium: _Optional[str] = ...,
+        spec_names: _Optional[_Iterable[str]] = ...,
+    ) -> None: ...
+
+class BlockSnapshotItem(_message.Message):
+    block_key: str
+    medium: str
+    specs: _containers.RepeatedCompositeFieldContainer[LocationSpec]
+    def __init__(
+        self,
+        block_key: _Optional[str] = ...,
+        medium: _Optional[str] = ...,
+        specs: _Optional[_Iterable[_Union[LocationSpec, _Mapping]]] = ...,
+    ) -> None: ...
+
+class BlockSnapshotEventParams(_message.Message):
+    medium: str
+    blocks: _containers.RepeatedCompositeFieldContainer[BlockSnapshotItem]
+    def __init__(
+        self,
+        medium: _Optional[str] = ...,
+        blocks: _Optional[_Iterable[_Union[BlockSnapshotItem, _Mapping]]] = ...,
+    ) -> None: ...
+
+class HostDownEventParams(_message.Message):
+    def __init__(self) -> None: ...
+
+class HeartbeatEventParams(_message.Message):
+    system_status: _Mapping[str, str]
+    def __init__(self, system_status: _Optional[_Mapping[str, str]] = ...) -> None: ...
+
+class EventItem(_message.Message):
+    event_type: ReportEventType
+    node_register: NodeRegisterEventParams
+    block_add: BlockAddEventParams
+    block_delete: BlockDeleteEventParams
+    host_down: HostDownEventParams
+    heartbeat: HeartbeatEventParams
+    block_snapshot: BlockSnapshotEventParams
+    def __init__(
+        self,
+        event_type: _Optional[_Union[ReportEventType, str]] = ...,
+        node_register: _Optional[
+            _Union[NodeRegisterEventParams, _Mapping]
+        ] = ...,
+        block_add: _Optional[_Union[BlockAddEventParams, _Mapping]] = ...,
+        block_delete: _Optional[_Union[BlockDeleteEventParams, _Mapping]] = ...,
+        host_down: _Optional[_Union[HostDownEventParams, _Mapping]] = ...,
+        heartbeat: _Optional[_Union[HeartbeatEventParams, _Mapping]] = ...,
+        block_snapshot: _Optional[
+            _Union[BlockSnapshotEventParams, _Mapping]
+        ] = ...,
+    ) -> None: ...
+
+class ReportEventRequest(_message.Message):
+    trace_id: str
+    instance_id: str
+    host_ip_port: str
+    events: _containers.RepeatedCompositeFieldContainer[EventItem]
+    storage_type: StorageType
+    def __init__(
+        self,
+        trace_id: _Optional[str] = ...,
+        instance_id: _Optional[str] = ...,
+        host_ip_port: _Optional[str] = ...,
+        events: _Optional[_Iterable[_Union[EventItem, _Mapping]]] = ...,
+        storage_type: _Optional[_Union[StorageType, str]] = ...,
+    ) -> None: ...
+
+class ReportEventResponse(_message.Message):
+    header: CommonResponseHeader
+    item_results: _containers.RepeatedScalarFieldContainer[ErrorCode]
+    committed_snapshot_version: str
+    retry_after_ms: int
+    snapshot_required: bool
+    extra_info: str
+    def __init__(
+        self,
+        header: _Optional[_Union[CommonResponseHeader, _Mapping]] = ...,
+        item_results: _Optional[_Iterable[_Union[ErrorCode, str]]] = ...,
+        committed_snapshot_version: _Optional[str] = ...,
+        retry_after_ms: _Optional[int] = ...,
+        snapshot_required: _Optional[bool] = ...,
+        extra_info: _Optional[str] = ...,
+    ) -> None: ...
+
+class LocationSpecInfo(_message.Message):
+    name: str
+    size: int
+    def __init__(
+        self,
+        name: _Optional[str] = ...,
+        size: _Optional[int] = ...,
+    ) -> None: ...
+
+class ModelDeployment(_message.Message):
+    model_name: str
+    dtype: str
+    use_mla: bool
+    tp_size: int
+    dp_size: int
+    lora_name: str
+    pp_size: int
+    extra: str
+    user_data: str
+    use_eagle_pop: bool
+    def __init__(
+        self,
+        model_name: _Optional[str] = ...,
+        dtype: _Optional[str] = ...,
+        use_mla: _Optional[bool] = ...,
+        tp_size: _Optional[int] = ...,
+        dp_size: _Optional[int] = ...,
+        lora_name: _Optional[str] = ...,
+        pp_size: _Optional[int] = ...,
+        extra: _Optional[str] = ...,
+        user_data: _Optional[str] = ...,
+        use_eagle_pop: _Optional[bool] = ...,
+    ) -> None: ...
+
+class LocationSpecGroup(_message.Message):
+    name: str
+    spec_names: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(
+        self,
+        name: _Optional[str] = ...,
+        spec_names: _Optional[_Iterable[str]] = ...,
+    ) -> None: ...
+
+class RegisterInstanceRequest(_message.Message):
+    trace_id: str
+    instance_group: str
+    instance_id: str
+    block_size: int
+    location_spec_infos: _containers.RepeatedCompositeFieldContainer[LocationSpecInfo]
+    model_deployment: ModelDeployment
+    location_spec_groups: _containers.RepeatedCompositeFieldContainer[LocationSpecGroup]
+    default_query_type: QueryType
+    def __init__(
+        self,
+        trace_id: _Optional[str] = ...,
+        instance_group: _Optional[str] = ...,
+        instance_id: _Optional[str] = ...,
+        block_size: _Optional[int] = ...,
+        location_spec_infos: _Optional[
+            _Iterable[_Union[LocationSpecInfo, _Mapping]]
+        ] = ...,
+        model_deployment: _Optional[_Union[ModelDeployment, _Mapping]] = ...,
+        location_spec_groups: _Optional[
+            _Iterable[_Union[LocationSpecGroup, _Mapping]]
+        ] = ...,
+        default_query_type: _Optional[_Union[QueryType, str]] = ...,
+    ) -> None: ...
+
+class RegisterInstanceResponse(_message.Message):
+    header: CommonResponseHeader
+    storage_configs: str
+    extra_info: str
+    def __init__(
+        self,
+        header: _Optional[_Union[CommonResponseHeader, _Mapping]] = ...,
+        storage_configs: _Optional[str] = ...,
+        extra_info: _Optional[str] = ...,
+    ) -> None: ...
+
+class MetaNodeEndpoint(_message.Message):
+    node_id: str
+    host: str
+    meta_rpc_port: int
+    meta_http_port: int
+    custom_info: str
+    def __init__(
+        self,
+        node_id: _Optional[str] = ...,
+        host: _Optional[str] = ...,
+        meta_rpc_port: _Optional[int] = ...,
+        meta_http_port: _Optional[int] = ...,
+        custom_info: _Optional[str] = ...,
+    ) -> None: ...
+
+class GetClusterInfoRequest(_message.Message):
+    trace_id: str
+    instance_id: str
+    def __init__(
+        self,
+        trace_id: _Optional[str] = ...,
+        instance_id: _Optional[str] = ...,
+    ) -> None: ...
+
+class GetClusterInfoResponse(_message.Message):
+    header: CommonResponseHeader
+    self_node_id: str
+    leader_node_id: str
+    leader_endpoint: MetaNodeEndpoint
+    def __init__(
+        self,
+        header: _Optional[_Union[CommonResponseHeader, _Mapping]] = ...,
+        self_node_id: _Optional[str] = ...,
+        leader_node_id: _Optional[str] = ...,
+        leader_endpoint: _Optional[_Union[MetaNodeEndpoint, _Mapping]] = ...,
+    ) -> None: ...

--- a/subscriber/subscriber/proto/kvcm_meta_service_pb2_grpc.py
+++ b/subscriber/subscriber/proto/kvcm_meta_service_pb2_grpc.py
@@ -1,0 +1,213 @@
+"""Hand-maintained gRPC stubs for KVCM MetaService."""
+
+from __future__ import annotations
+
+import warnings
+
+import grpc
+
+from subscriber.proto import kvcm_meta_service_pb2 as _pb2
+
+GRPC_GENERATED_VERSION = "1.68.1"
+GRPC_VERSION = grpc.__version__
+_version_not_supported = False
+
+try:
+    from grpc._utilities import first_version_is_lower
+
+    _version_not_supported = first_version_is_lower(
+        GRPC_VERSION, GRPC_GENERATED_VERSION
+    )
+except ImportError:
+    _version_not_supported = True
+
+if _version_not_supported:
+    raise RuntimeError(
+        f"The grpc package installed is at version {GRPC_VERSION},"
+        + " but subscriber/proto/kvcm_meta_service_pb2_grpc.py depends on"
+        + f" grpcio>={GRPC_GENERATED_VERSION}."
+    )
+
+
+class MetaServiceStub:
+    """Client stub for kv_cache_manager.proto.meta.MetaService."""
+
+    def __init__(self, channel: grpc.Channel) -> None:
+        self.RegisterInstance = channel.unary_unary(
+            "/kv_cache_manager.proto.meta.MetaService/RegisterInstance",
+            request_serializer=_pb2.RegisterInstanceRequest.SerializeToString,
+            response_deserializer=_pb2.RegisterInstanceResponse.FromString,
+            _registered_method=True,
+        )
+        self.GetClusterInfo = channel.unary_unary(
+            "/kv_cache_manager.proto.meta.MetaService/GetClusterInfo",
+            request_serializer=_pb2.GetClusterInfoRequest.SerializeToString,
+            response_deserializer=_pb2.GetClusterInfoResponse.FromString,
+            _registered_method=True,
+        )
+        self.ReportEvent = channel.unary_unary(
+            "/kv_cache_manager.proto.meta.MetaService/ReportEvent",
+            request_serializer=_pb2.ReportEventRequest.SerializeToString,
+            response_deserializer=_pb2.ReportEventResponse.FromString,
+            _registered_method=True,
+        )
+
+
+class MetaServiceServicer:
+    """Server base class for tests."""
+
+    def RegisterInstance(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
+    def GetClusterInfo(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
+    def ReportEvent(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
+
+def add_MetaServiceServicer_to_server(
+    servicer: MetaServiceServicer,
+    server: grpc.Server,
+) -> None:
+    rpc_method_handlers = {
+        "RegisterInstance": grpc.unary_unary_rpc_method_handler(
+            servicer.RegisterInstance,
+            request_deserializer=_pb2.RegisterInstanceRequest.FromString,
+            response_serializer=_pb2.RegisterInstanceResponse.SerializeToString,
+        ),
+        "GetClusterInfo": grpc.unary_unary_rpc_method_handler(
+            servicer.GetClusterInfo,
+            request_deserializer=_pb2.GetClusterInfoRequest.FromString,
+            response_serializer=_pb2.GetClusterInfoResponse.SerializeToString,
+        ),
+        "ReportEvent": grpc.unary_unary_rpc_method_handler(
+            servicer.ReportEvent,
+            request_deserializer=_pb2.ReportEventRequest.FromString,
+            response_serializer=_pb2.ReportEventResponse.SerializeToString,
+        ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+        "kv_cache_manager.proto.meta.MetaService",
+        rpc_method_handlers,
+    )
+    server.add_generic_rpc_handlers((generic_handler,))
+    server.add_registered_method_handlers(
+        "kv_cache_manager.proto.meta.MetaService",
+        rpc_method_handlers,
+    )
+
+
+class MetaService:
+    """Experimental static call helpers matching grpc_tools output."""
+
+    @staticmethod
+    def RegisterInstance(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        warnings.warn(
+            "MetaService static methods are experimental",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/kv_cache_manager.proto.meta.MetaService/RegisterInstance",
+            _pb2.RegisterInstanceRequest.SerializeToString,
+            _pb2.RegisterInstanceResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True,
+        )
+
+    @staticmethod
+    def GetClusterInfo(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        warnings.warn(
+            "MetaService static methods are experimental",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/kv_cache_manager.proto.meta.MetaService/GetClusterInfo",
+            _pb2.GetClusterInfoRequest.SerializeToString,
+            _pb2.GetClusterInfoResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True,
+        )
+
+    @staticmethod
+    def ReportEvent(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        warnings.warn(
+            "MetaService static methods are experimental",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/kv_cache_manager.proto.meta.MetaService/ReportEvent",
+            _pb2.ReportEventRequest.SerializeToString,
+            _pb2.ReportEventResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True,
+        )

--- a/subscriber/subscriber/trace.py
+++ b/subscriber/subscriber/trace.py
@@ -1,0 +1,46 @@
+"""EagleEye-style trace ID generator.
+
+Produces a 30-character identifier with the layout::
+
+    {ip_hex8}{timestamp_ms13}{counter4}d{pid_hex4}
+
+Matches EagleEye's time-ordered, machine-identifiable correlation format. Its
+counter intentionally cycles from 1000 through 9001; IP resolution failures
+fall back to ``ffffffff``.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+import time
+
+_FALLBACK_IP_HEX = "ffffffff"
+
+
+def _resolve_ip_hex() -> str:
+    try:
+        addr = socket.gethostbyname(socket.gethostname())
+        return "".join(f"{int(octet):02x}" for octet in addr.split("."))
+    except Exception:
+        return _FALLBACK_IP_HEX
+
+
+_IP_HEX: str = _resolve_ip_hex()
+
+_pid = os.getpid()
+_PID_HEX: str = f"{_pid % 60000 if _pid > 65535 else _pid:04x}"
+
+_counter_lock = threading.Lock()
+_counter = 1000
+
+
+def generate_trace_id() -> str:
+    """Generate an EagleEye-compatible trace ID (30 chars, never raises)."""
+    global _counter
+    ts = int(time.time() * 1000)
+    with _counter_lock:
+        _counter = 1000 if _counter > 9000 else _counter + 1
+        seq = _counter
+    return f"{_IP_HEX}{ts}{seq}d{_PID_HEX}"

--- a/subscriber/subscriber/types.py
+++ b/subscriber/subscriber/types.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+import msgspec
+
+# ExternalBlockHash is used for reproducible prefix-cache block hashing.
+# It's a union of `bytes` and `int` to keep backward compatibility
+# after we default block hashing to use sha256 bytes.
+ExternalBlockHash: TypeAlias = bytes | int
+
+
+def format_block_hash(block_hash: ExternalBlockHash) -> str:
+    """Human-readable string encoding of a block hash for debug logging only.
+
+    Bytes hashes render as lowercase hex; int hashes as decimal ``str``.
+    This is used exclusively in debug log output (e.g. ``_event_for_debug``)
+    to make block hashes readable. Wire/forwarding paths use ``str()``
+    directly since production hashes are always ints.
+    """
+
+    if isinstance(block_hash, bytes):
+        return block_hash.hex()
+    return str(block_hash)
+
+
+@dataclass(frozen=True)
+class KvCacheGroupSpec:
+    """Per-group KV cache metadata fetched from the engine.
+
+    ``block_size`` is the group's token span. ``group_payload_size_bytes`` is
+    the complete logical group-block payload used as the KVCM location size.
+    Both are provided explicitly by the engine metadata endpoint; do not infer
+    ``group_idx`` from list position. ``sliding_window`` is ``None`` for
+    non-windowed kinds.
+    """
+
+    group_idx: int
+    kind: str
+    block_size: int
+    group_payload_size_bytes: int | None
+    sliding_window: int | None = None
+
+
+class EventBatch(
+    msgspec.Struct,
+    array_like=True,
+    omit_defaults=True,
+    gc=False,
+):
+    ts: float
+    events: list[Any]
+    data_parallel_rank: int | None = None
+
+
+class KVCacheEvent(
+    msgspec.Struct,
+    omit_defaults=True,
+    gc=False,
+    tag=True,
+):
+    """Common pipeline event with engine-native component identity.
+
+    vLLM publishes ``group_idx`` while SGLang publishes ``component_id`` for
+    the same semantic concept. SGLang's adapter also maps its component ID to
+    the common pipeline ``group_idx`` used by KVCM; publishers are never
+    required to put both fields on their wire event.
+    """
+
+
+class BlockStored(KVCacheEvent):
+    block_hashes: list[ExternalBlockHash]
+    parent_block_hash: ExternalBlockHash | None
+    token_ids: list[int]
+    block_size: int
+    lora_id: int | None
+    medium: str | None
+    lora_name: str | None
+    extra_keys: list[tuple[Any, ...] | None] | None = None
+    # vLLM-native identity; for SGLang this is the adapter's normalized mapping.
+    group_idx: int | None = None
+    # SGLang-native identity retained after normalization; absent on vLLM wire.
+    component_id: int | None = None
+    kv_cache_spec_kind: str | None = None
+    kv_cache_spec_sliding_window: int | None = None
+    snapshot_version: int = 0
+
+
+class BlockRemoved(KVCacheEvent):
+    block_hashes: list[ExternalBlockHash]
+    medium: str | None
+    # vLLM-native identity; for SGLang this is the adapter's normalized mapping.
+    group_idx: int | None = None
+    # SGLang-native identity retained after normalization; absent on vLLM wire.
+    component_id: int | None = None
+    remaining_copy_counts: list[int] | None = None
+    snapshot_version: int = 0
+
+
+class AllBlocksCleared(KVCacheEvent):
+    pass
+
+
+class BlockSnapshotItem(msgspec.Struct, omit_defaults=True, gc=False):
+    """One block in a full snapshot report."""
+
+    block_hash: ExternalBlockHash
+    group_idx: int
+
+
+class BlockSnapshot(KVCacheEvent):
+    """Full snapshot of all currently cached blocks.
+
+    Sent periodically by the hybrid adapter for kvcm reconciliation.
+    KVCM handles add/delete bookkeeping from successive snapshots.
+    """
+
+    medium: str
+    block_size: int
+    items: list[BlockSnapshotItem]
+    snapshot_version: int = 0
+
+
+class KVEventBatch(EventBatch):
+    events: list[BlockStored | BlockRemoved | AllBlocksCleared | BlockSnapshot]

--- a/subscriber/subscriber/utils/__init__.py
+++ b/subscriber/subscriber/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for subscriber internals."""

--- a/subscriber/subscriber/utils/msgpack_helper.py
+++ b/subscriber/subscriber/utils/msgpack_helper.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import msgspec
+
+from subscriber import logger
+from subscriber.types import KVEventBatch
+
+
+class KVEventBatchMsgpackHelper:
+    """Decode KV event batch msgpack payloads with consistent logging."""
+
+    def __init__(self) -> None:
+        self._decoder = msgspec.msgpack.Decoder(type=KVEventBatch)
+
+    def decode(
+        self,
+        payload: bytes,
+        *,
+        step: str,
+        tags: dict[str, object] | None = None,
+    ) -> KVEventBatch | None:
+        try:
+            return self._decoder.decode(payload)
+        except (msgspec.DecodeError, msgspec.ValidationError, TypeError) as exc:
+            log_tags: dict[str, object] = {
+                "error": exc.__class__.__name__,
+                "message": str(exc),
+            }
+            if tags:
+                log_tags = {**tags, **log_tags}
+            logger.warning(
+                "failed to decode kv event msgpack payload",
+                step=step,
+                tags=log_tags,
+            )
+            return None

--- a/subscriber/subscriber/utils/network.py
+++ b/subscriber/subscriber/utils/network.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+_ROUTE_PROBE_ADDRESS = ("192.0.2.1", 80)
+
+
+def local_ip_address() -> str:
+    """Return the preferred local address, falling back safely when offline."""
+
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        try:
+            sock.connect(_ROUTE_PROBE_ADDRESS)
+            address = str(sock.getsockname()[0])
+            if not ipaddress.ip_address(address).is_loopback:
+                return address
+        except OSError:
+            pass
+
+    try:
+        addresses = socket.getaddrinfo(
+            socket.gethostname(), None, type=socket.SOCK_DGRAM
+        )
+    except OSError:
+        addresses = []
+    for _, _, _, _, sockaddr in addresses:
+        address = str(sockaddr[0])
+        try:
+            if not ipaddress.ip_address(address).is_loopback:
+                return address
+        except ValueError:
+            continue
+    return "127.0.0.1"
+
+
+async def resolve_host_ip_port(port: int) -> str:
+    """Resolve the local worker identity address as ``ip:port``.
+
+    ``port`` is the worker identity port seen by FlexLB/KVCM; it must match
+    the engine endpoint port published in Spectrum (8080 on PAI-EAS).
+    """
+
+    address = local_ip_address()
+    if ":" in address:
+        address = f"[{address}]"
+    return f"{address}:{port}"

--- a/subscriber/subscriber/utils/spectrum.py
+++ b/subscriber/subscriber/utils/spectrum.py
@@ -1,0 +1,105 @@
+"""Spectrum virtual-service endpoint requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from subscriber import logger
+
+_DISCOVERY_STEP = "kvcm_discovery"
+
+SPECTRUM_GATEWAY_BASE_URL = "http://127.0.0.1:8880"
+SPECTRUM_INSTANCES_PATH_TEMPLATE = "/api/v1/discovery/virtual-services/{vsid}/instances"
+
+
+@dataclass(frozen=True)
+class SpectrumEndpoint:
+    """One valid endpoint returned by Spectrum."""
+
+    ip: str
+    port: int
+    weight: int = 100
+
+
+async def fetch_spectrum_endpoints(
+    virtual_service_id: str,
+    *,
+    port_override: int | None = None,
+    refresh_timeout: float = 5,
+    http_client: Any | None = None,
+) -> list[SpectrumEndpoint]:
+    """Fetch and validate endpoints for one Spectrum virtual service.
+
+    When ``http_client`` is omitted, this function creates and closes an
+    ``httpx.AsyncClient`` for the request. Callers that need connection reuse
+    must create and pass their own client; this function does not close it.
+    """
+
+    if not virtual_service_id:
+        raise ValueError("virtual_service_id must not be empty")
+    client: Any
+    if http_client is None:
+        owns_http_client = True
+        client = httpx.AsyncClient(
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
+    else:
+        owns_http_client = False
+        client = http_client
+    try:
+        path = SPECTRUM_INSTANCES_PATH_TEMPLATE.format(vsid=virtual_service_id)
+        response = await client.get(
+            SPECTRUM_GATEWAY_BASE_URL + path, timeout=refresh_timeout
+        )
+        response.raise_for_status()
+        data = response.json()
+        items = data.get("instances", [])
+        if not isinstance(items, list):
+            logger.warning(
+                "Spectrum response 'instances' is not a list",
+                step=_DISCOVERY_STEP,
+                tags={"virtual_service_id": virtual_service_id},
+            )
+            return []
+        endpoints: list[SpectrumEndpoint] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            ip = item.get("ip")
+            port = port_override if port_override is not None else item.get("port")
+            if not isinstance(ip, str) or not ip:
+                continue
+            if not isinstance(port, (int, str)) or isinstance(port, bool):
+                continue
+            try:
+                parsed_port = int(port)
+            except (TypeError, ValueError):
+                continue
+            if parsed_port <= 0 or parsed_port > 65535:
+                continue
+            endpoints.append(
+                SpectrumEndpoint(
+                    ip=ip,
+                    port=parsed_port,
+                    weight=item.get("weight", 100),
+                )
+            )
+        if items and not endpoints:
+            logger.warning(
+                "Spectrum returned instances but none were valid endpoints",
+                step=_DISCOVERY_STEP,
+                tags={
+                    "virtual_service_id": virtual_service_id,
+                    "instance_count": len(items),
+                },
+            )
+        return sorted(endpoints, key=lambda endpoint: (endpoint.ip, endpoint.port))
+    finally:
+        if owns_http_client:
+            await client.aclose()

--- a/subscriber/tests/benchmark/test_cold_prefill_latency.py
+++ b/subscriber/tests/benchmark/test_cold_prefill_latency.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_RUNNER_PATH = Path(__file__).parents[2] / "benchmark" / "cold_prefill_latency.py"
+_SPEC = importlib.util.spec_from_file_location("cold_prefill_latency", _RUNNER_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_build_request_body_uses_unique_prompt_and_single_token_output() -> None:
+    first = _MODULE.build_request_body(
+        model="pre-flexlb-hongyi-test-glm-5.2",
+        target_tokens=256_000,
+        seed=101,
+        chars_per_token=4.8,
+    )
+    second = _MODULE.build_request_body(
+        model="pre-flexlb-hongyi-test-glm-5.2",
+        target_tokens=256_000,
+        seed=102,
+        chars_per_token=4.8,
+    )
+
+    assert first.api_body["max_tokens"] == 1
+    assert first.api_body["stream"] is False
+    assert (
+        first.api_body["messages"][0]["content"]
+        != second.api_body["messages"][0]["content"]
+    )
+    assert first.prompt_sha256 != second.prompt_sha256
+
+
+def test_parse_response_extracts_usage_fields() -> None:
+    response = {
+        "choices": [{"message": {"content": "x"}, "finish_reason": "stop"}],
+        "usage": {
+            "prompt_tokens": 256_123,
+            "completion_tokens": 1,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        },
+    }
+
+    parsed = _MODULE.parse_response(json.dumps(response))
+
+    assert parsed.body_ok is True
+    assert parsed.prompt_tokens == 256_123
+    assert parsed.completion_tokens == 1
+    assert parsed.cached_tokens == 0
+    assert parsed.reason == "-"
+
+
+def test_parse_response_rejects_malformed_or_empty_content() -> None:
+    parsed = _MODULE.parse_response('{"choices": []}')
+
+    assert parsed.body_ok is False
+    assert "no_choices" in parsed.reason
+
+
+def test_parse_response_accepts_one_token_reasoning_output() -> None:
+    response = {
+        "choices": [
+            {
+                "message": {"content": "", "reasoning_content": "The"},
+                "finish_reason": "length",
+            }
+        ],
+        "usage": {"prompt_tokens": 256, "completion_tokens": 1},
+    }
+
+    parsed = _MODULE.parse_response(json.dumps(response))
+
+    assert parsed.body_ok is True
+    assert parsed.completion_tokens == 1
+
+
+def test_cache_hit_response_cannot_be_accepted() -> None:
+    accepted, reason = _MODULE._is_accepted(
+        http_code=200,
+        parsed=_MODULE.ParsedResponse(
+            body_ok=True,
+            reason="-",
+            prompt_tokens=256_000,
+            cached_tokens=128,
+            completion_tokens=1,
+        ),
+        target_tokens=256_000,
+        token_tolerance=0.02,
+    )
+
+    assert accepted is False
+    assert reason == "cache_hit"
+
+
+def test_curl_config_keeps_api_key_out_of_process_arguments() -> None:
+    config = _MODULE._build_curl_config(
+        base_url="https://example.test/v1",
+        api_key="test-secret",
+        request_path=Path("/tmp/request.json"),
+        response_path=Path("/tmp/response.json"),
+        timeout_s=60,
+    )
+
+    assert "Authorization: Bearer test-secret" in config
+    assert _MODULE._CURL_COMMAND == ("curl", "--config", "-")
+
+
+def test_chart_svg_includes_samples_means_and_axis_units() -> None:
+    chart = _MODULE._chart_svg(
+        [
+            (256_000, 256_000, 12_000.0),
+            (256_000, 256_500, 13_000.0),
+            (400_000, 400_000, 21_000.0),
+        ]
+    )
+
+    assert "Actual prompt tokens" in chart
+    assert "End-to-end latency (s)" in chart
+    assert '<rect width="100%" height="100%" fill="#ffffff"/>' in chart
+    assert 'aria-label="individual cold-cache samples"' in chart
+    assert 'aria-label="mean latency by target length"' in chart
+    assert 'aria-label="individual sample coordinates"' in chart
+    assert 'aria-label="quadratic least-squares fit"' in chart
+    assert "1M fit:" in chart
+
+
+def test_quadratic_fit_predicts_known_curve() -> None:
+    coefficients = _MODULE._fit_quadratic(
+        [
+            (0, 0, 1.0),
+            (1_000_000, 1_000_000, 6.0),
+            (2_000_000, 2_000_000, 17.0),
+        ]
+    )
+
+    assert _MODULE._quadratic_value(coefficients, 1.0) == pytest.approx(6.0)
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin"
+    or shutil.which("qlmanage") is None
+    or shutil.which("sips") is None,
+    reason="PNG conversion uses local macOS image tools",
+)
+def test_render_chart_writes_png(tmp_path: Path) -> None:
+    result_path = tmp_path / "results.csv"
+    result_path.write_text(
+        "target_tokens,prompt_tokens,elapsed_ms,accepted\n"
+        "256000,256120,12000.0,True\n"
+        "256000,255990,13000.0,True\n",
+        encoding="utf-8",
+    )
+    chart_path = _MODULE.render_chart(result_path, tmp_path / "chart.png")
+
+    assert chart_path.exists()
+    assert chart_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    dimensions = subprocess.run(
+        ["sips", "-g", "pixelWidth", "-g", "pixelHeight", str(chart_path)],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+    assert "pixelWidth: 1280" in dimensions
+    assert "pixelHeight: 1280" in dimensions

--- a/subscriber/tests/conftest.py
+++ b/subscriber/tests/conftest.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/subscriber/tests/e2e/test_dashserving_protocol.py
+++ b/subscriber/tests/e2e/test_dashserving_protocol.py
@@ -1,0 +1,260 @@
+"""End-to-end protocol test against the real ``dashservingd`` binary.
+
+Spawns the actual DashServing daemon (no workers, subscriber integration
+enabled) as a subprocess and drives it with the real
+``DashservingStateReporter`` over HTTP, verifying:
+
+- ``POST /subscriber_state`` accepts monotonically increasing reports and
+  rejects stale/duplicate ones with ``accepted=false`` (200).
+- ``GET /readiness`` is 503 during starting (never active), flips to 200
+  on active, drops to 503 once a previously-active subscriber reports
+  inactive, and recovers to 200 on a higher-seq active.
+- ``GET /liveness`` is 200 during starting (startup grace), stays 200
+  while active, and drops to 503 when a previously-active subscriber goes
+  inactive (spec: 同生同死).
+- ``report_failed`` from the starting phase is accepted and terminal; a
+  higher-seq active report is rejected.
+
+The suite is explicit opt-in: it skips unless ``DSV_BINARY`` points at a
+built ``dashservingd`` binary, so the default pytest run behaves the same
+on every machine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+from subscriber.config import SubscriberConfig
+from subscriber.health.state_reporter import (
+    DashservingStateReporter,
+    SubscriberPhase,
+)
+
+# e2e is explicit opt-in: set DSV_BINARY to a built dashservingd binary.
+# No machine-specific default, so the default pytest run is deterministic
+# (these tests always skip) on every machine.
+_BINARY = Path(os.environ.get("DSV_BINARY", ""))
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        not _BINARY.is_file(),
+        reason="e2e opt-in: set DSV_BINARY to a dashservingd binary "
+        "(build with `cargo build` in the dashserving repo)",
+    ),
+]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture
+def dashserving() -> Iterator[dict[str, object]]:
+    """Start dashservingd with subscriber integration enabled, no workers.
+
+    ``DSV_PORT`` and ``DSV_CONTROL_PORT`` are deliberately far apart because
+    the daemon also binds a secondary listener at ``DSV_PORT+1``.
+    """
+
+    port = _free_port()
+    # The daemon also binds a secondary listener at DSV_PORT+1, so the control
+    # port must avoid both `port` and `port + 1`.
+    control_port = _free_port()
+    while control_port in (port, port + 1):
+        control_port = _free_port()
+    env = os.environ.copy()
+    env.update(
+        {
+            "DSV_PORT": str(port),
+            "DSV_CONTROL_PORT": str(control_port),
+            "DS_LLM_LAUNCH_KV_EVENT_SUBSCRIBER": "1",
+            "DSV_SUBSCRIBER_TTL_S": "20",
+            "DSV_LOG_FORMAT": "text",
+        }
+    )
+    proc = subprocess.Popen(  # noqa: S603 - fixed-path trusted local binary
+        [_BINARY],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    base = f"http://127.0.0.1:{control_port}"
+    try:
+        deadline = time.monotonic() + 10.0
+        while True:
+            if proc.poll() is not None:
+                output = (
+                    proc.stdout.read().decode(errors="replace") if proc.stdout else ""
+                )
+                pytest.fail(
+                    f"dashservingd exited early (code={proc.returncode}): "
+                    f"{output[-2000:]}"
+                )
+            try:
+                resp = httpx.get(f"{base}/liveness", timeout=0.5)
+            except httpx.HTTPError:
+                resp = None
+            if resp is not None and resp.status_code == 200:
+                break
+            if time.monotonic() > deadline:
+                proc.terminate()
+                pytest.fail(
+                    f"dashservingd control port {control_port} did not "
+                    "become ready within 10s"
+                )
+            time.sleep(0.05)
+        yield {
+            "proc": proc,
+            "base": base,
+            "control_port": control_port,
+        }
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+
+def make_reporter(base: str) -> DashservingStateReporter:
+    # Extract port from base URL and set DSV_CONTROL_PORT so the
+    # subscriber_state_url property derives the correct endpoint.
+    port = base.rsplit(":", 1)[1]
+    os.environ["DSV_CONTROL_PORT"] = port
+    config = SubscriberConfig(
+        subscriber_heartbeat_interval_s=3.0,
+        subscriber_state_request_timeout_s=2.0,
+        subscriber_shutdown_report_timeout_s=2.0,
+    )
+    return DashservingStateReporter(config)
+
+
+async def _wait_status(
+    client: httpx.AsyncClient, url: str, expected: int, timeout: float = 5.0
+) -> None:
+    deadline = time.monotonic() + timeout
+    last = 0
+    while time.monotonic() < deadline:
+        last = (await client.get(url)).status_code
+        if last == expected:
+            return
+        await _sleep(0.05)
+    raise AssertionError(
+        f"{url}: expected HTTP {expected} within {timeout}s, last={last}"
+    )
+
+
+async def _sleep(seconds: float) -> None:
+    await asyncio.sleep(seconds)
+
+
+async def test_full_protocol_against_real_dashserving(
+    dashserving: dict[str, object],
+) -> None:
+    """Drive the complete subscriber-state protocol against the real binary."""
+
+    base = str(dashserving["base"])
+    reporter = make_reporter(base)
+    try:
+        async with httpx.AsyncClient() as client:
+            readiness = f"{base}/readiness"
+            liveness = f"{base}/liveness"
+
+            # Subscriber starting (never active) blocks readiness (spec: 503)
+            # but liveness stays 200 (startup grace).
+            await _wait_status(client, readiness, 503)
+            assert (await client.get(liveness)).status_code == 200
+
+            # (a) First active report → accepted, seq starts at 1.
+            await reporter.report_active()
+            assert reporter.phase is SubscriberPhase.ACTIVE
+            assert reporter.next_seq_id == 2
+            await _wait_status(client, readiness, 200)
+
+            # (b) Second active with higher seq → accepted.
+            await reporter.report_active()
+            assert reporter.next_seq_id == 3
+
+            # (c) Terminal inactive → accepted (best-effort, never raises).
+            await reporter.report_shutdown_inactive("e2e-test")
+            phase: SubscriberPhase = reporter.phase
+            assert phase is SubscriberPhase.INACTIVE
+
+            # Readiness must drop to 503 once a previously-active subscriber
+            # goes inactive; liveness also drops to 503 (spec: 同生同死).
+            await _wait_status(client, readiness, 503)
+            await _wait_status(client, liveness, 503)
+
+            # (d) Stale active (lower seq) is rejected with accepted=false,
+            # and does NOT flip readiness back to 200.
+            stale = await client.post(
+                f"{base}/subscriber_state",
+                json={"state": "active", "seq_id": 1},
+            )
+            assert stale.status_code == 200
+            assert stale.json() == {"accepted": False, "last_seq_id": 3}
+            assert (await client.get(readiness)).status_code == 503
+
+            # A higher-seq active recovers: accepted=true and readiness 200.
+            recover = await client.post(
+                f"{base}/subscriber_state",
+                json={"state": "active", "seq_id": 4},
+            )
+            assert recover.status_code == 200
+            assert recover.json() == {"accepted": True, "last_seq_id": 4}
+            await _wait_status(client, readiness, 200)
+
+            # Duplicate (same seq) is rejected as idempotent no-op.
+            dup = await client.post(
+                f"{base}/subscriber_state",
+                json={"state": "active", "seq_id": 4},
+            )
+            assert dup.status_code == 200
+            assert dup.json() == {"accepted": False, "last_seq_id": 4}
+
+            # /status exposes the subscriber snapshot.
+            status = (await client.get(f"{base}/status")).json()
+            sub = status["subscriber"]
+            assert sub["enabled"] is True
+            assert sub["phase"] == "active"
+            assert sub["last_seq_id"] == 4
+    finally:
+        await reporter.close()
+
+
+async def test_failed_from_starting_is_terminal(
+    dashserving: dict[str, object],
+) -> None:
+    """``failed`` is legal while starting and rejects later transitions."""
+
+    base = str(dashserving["base"])
+    reporter = make_reporter(base)
+    try:
+        await reporter.report_failed("e2e startup failure")
+        assert reporter.phase is SubscriberPhase.FAILED
+
+        async with httpx.AsyncClient() as client:
+            await _wait_status(client, f"{base}/readiness", 503)
+            await _wait_status(client, f"{base}/liveness", 503)
+
+            conflict = await client.post(
+                f"{base}/subscriber_state",
+                json={"state": "active", "seq_id": 2},
+            )
+            assert conflict.status_code == 409
+    finally:
+        await reporter.close()

--- a/subscriber/tests/e2e/test_health_linkage.py
+++ b/subscriber/tests/e2e/test_health_linkage.py
@@ -1,0 +1,395 @@
+"""End-to-end health-linkage tests for the readiness/liveness + subscriber state.
+
+Spawns the real ``dashservingd`` binary (no workers, so worker readiness is
+vacuously satisfied and the probes are driven purely by subscriber state) and
+verifies the state matrix from
+``docs/specs/2026-07-22_subscriber-health-dashserving-integration.md``:
+
+| # | subscriber state              | /readiness | /liveness |
+|---|-------------------------------|:----------:|:---------:|
+| 1 | starting (never active)       |    503     |    200    |
+| 2 | active + TTL valid            |    200     |    200    |
+| 3 | inactive after ever active    |    503     |    503    |
+| 4 | failed (from starting)        |    503     |    503    |
+| 5 | TTL expired (heartbeat stop)  |    503     |    503    |
+| 6 | recovery after TTL expiry     |    200     |    200    |
+| 7 | stale active after inactive   |    503     |    503    |
+| 8 | feature disabled              |  existing  |  existing |
+
+Each scenario that needs a pristine state machine gets its own daemon
+subprocess via a factory fixture. The suite is explicit opt-in: it skips
+unless ``DSV_BINARY`` points at a built ``dashservingd`` binary, so the
+default pytest run behaves the same on every machine.
+
+These assertions encode the spec matrix verbatim so the suite doubles as a
+cross-process conformance check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import subprocess
+import time
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+# e2e is explicit opt-in: set DSV_BINARY to a built dashservingd binary.
+# No machine-specific default, so the default pytest run is deterministic
+# (these tests always skip) on every machine.
+_BINARY = Path(os.environ.get("DSV_BINARY", ""))
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        not _BINARY.is_file(),
+        reason="e2e opt-in: set DSV_BINARY to a dashservingd binary "
+        "(build with `cargo build` in the dashserving repo)",
+    ),
+]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _distinct_ports(count: int) -> list[int]:
+    """Return ``count`` mutually distinct free ports.
+
+    The daemon binds a secondary listener at ``DSV_PORT+1``, so the control
+    port must avoid both the data port and its successor.
+    """
+
+    ports: list[int] = []
+    while len(ports) < count:
+        candidate = _free_port()
+        reserved = set(ports)
+        reserved.update(p + 1 for p in ports)
+        if candidate not in reserved:
+            ports.append(candidate)
+    return ports
+
+
+class DashServingInstance:
+    """A running ``dashservingd`` subprocess bound to a control port."""
+
+    def __init__(self, proc: subprocess.Popen[bytes], base: str) -> None:
+        self.proc = proc
+        self.base = base
+
+    @property
+    def readiness_url(self) -> str:
+        return f"{self.base}/readiness"
+
+    @property
+    def liveness_url(self) -> str:
+        return f"{self.base}/liveness"
+
+    @property
+    def state_url(self) -> str:
+        return f"{self.base}/subscriber_state"
+
+    @property
+    def status_url(self) -> str:
+        return f"{self.base}/status"
+
+    def stop(self) -> None:
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait(timeout=5)
+
+
+def _spawn(extra_env: dict[str, str]) -> DashServingInstance:
+    """Start a fresh daemon and wait until its control port serves /liveness."""
+
+    port, control_port = _distinct_ports(2)
+    env = os.environ.copy()
+    env.update(
+        {
+            "DSV_PORT": str(port),
+            "DSV_CONTROL_PORT": str(control_port),
+            "DSV_LOG_FORMAT": "text",
+        }
+    )
+    env.update(extra_env)
+    proc = subprocess.Popen(  # noqa: S603 - fixed-path trusted local binary
+        [_BINARY],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    base = f"http://127.0.0.1:{control_port}"
+    deadline = time.monotonic() + 10.0
+    while True:
+        if proc.poll() is not None:
+            output = proc.stdout.read().decode(errors="replace") if proc.stdout else ""
+            proc.wait()
+            raise RuntimeError(
+                f"dashservingd exited early (code={proc.returncode}): {output[-2000:]}"
+            )
+        try:
+            resp = httpx.get(f"{base}/liveness", timeout=0.5)
+        except httpx.HTTPError:
+            resp = None
+        if resp is not None and resp.status_code in (200, 503):
+            # The control port is up. /liveness may legitimately be 503 in some
+            # states, so accept either as "server is listening".
+            break
+        if time.monotonic() > deadline:
+            proc.terminate()
+            raise RuntimeError(
+                f"dashservingd control port {control_port} did not respond within 10s"
+            )
+        time.sleep(0.05)
+    return DashServingInstance(proc, base)
+
+
+@pytest.fixture
+def spawn_dashserving() -> Iterator[Callable[..., DashServingInstance]]:
+    """Factory fixture: spawn a fresh daemon per call, tear all down at end."""
+
+    instances: list[DashServingInstance] = []
+
+    def _factory(
+        *,
+        enabled: bool = True,
+        ttl_s: int = 20,
+    ) -> DashServingInstance:
+        extra = {
+            "DS_LLM_LAUNCH_KV_EVENT_SUBSCRIBER": "1" if enabled else "0",
+            "DSV_SUBSCRIBER_TTL_S": str(ttl_s),
+        }
+        instance = _spawn(extra)
+        instances.append(instance)
+        return instance
+
+    yield _factory
+
+    for instance in instances:
+        instance.stop()
+
+
+async def _sleep(seconds: float) -> None:
+    await asyncio.sleep(seconds)
+
+
+async def _wait_status(
+    client: httpx.AsyncClient,
+    url: str,
+    expected: int,
+    timeout: float = 5.0,
+) -> int:
+    """Poll ``url`` until it returns ``expected``; return the last status."""
+
+    deadline = time.monotonic() + timeout
+    last = 0
+    while time.monotonic() < deadline:
+        last = (await client.get(url)).status_code
+        if last == expected:
+            return last
+        await _sleep(0.05)
+    return last
+
+
+async def _post_state(
+    client: httpx.AsyncClient,
+    instance: DashServingInstance,
+    state: str,
+    seq_id: int,
+) -> httpx.Response:
+    return await client.post(
+        instance.state_url,
+        json={"state": state, "seq_id": seq_id},
+    )
+
+
+async def test_scenario_1_starting_never_active(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #1: starting (never active) → readiness 503, liveness 200."""
+
+    instance = spawn_dashserving()
+    async with httpx.AsyncClient() as client:
+        readiness = (await client.get(instance.readiness_url)).status_code
+        liveness = (await client.get(instance.liveness_url)).status_code
+
+    assert liveness == 200, f"starting liveness: expected 200, got {liveness}"
+    assert readiness == 503, f"starting readiness: expected 503, got {readiness}"
+
+
+async def test_scenario_2_active_ttl_valid(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #2: active + TTL valid → readiness 200, liveness 200."""
+
+    instance = spawn_dashserving()
+    async with httpx.AsyncClient() as client:
+        ack = await _post_state(client, instance, "active", 1)
+        assert ack.status_code == 200
+        assert ack.json() == {"accepted": True, "last_seq_id": 1}
+
+        readiness = await _wait_status(client, instance.readiness_url, 200)
+        liveness = (await client.get(instance.liveness_url)).status_code
+
+    assert readiness == 200, f"active readiness: expected 200, got {readiness}"
+    assert liveness == 200, f"active liveness: expected 200, got {liveness}"
+
+
+async def test_scenario_3_inactive_after_active(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #3: inactive after ever active → readiness 503, liveness 503."""
+
+    instance = spawn_dashserving()
+    async with httpx.AsyncClient() as client:
+        active = await _post_state(client, instance, "active", 1)
+        assert active.json() == {"accepted": True, "last_seq_id": 1}
+        await _wait_status(client, instance.readiness_url, 200)
+
+        inactive = await _post_state(client, instance, "inactive", 2)
+        assert inactive.json() == {"accepted": True, "last_seq_id": 2}
+
+        readiness = await _wait_status(client, instance.readiness_url, 503)
+        liveness = await _wait_status(client, instance.liveness_url, 503)
+
+    assert readiness == 503, f"inactive readiness: expected 503, got {readiness}"
+    assert liveness == 503, f"inactive liveness: expected 503, got {liveness}"
+
+
+async def test_scenario_4_failed_from_starting(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #4: failed from starting → readiness 503, liveness 503."""
+
+    instance = spawn_dashserving()
+    async with httpx.AsyncClient() as client:
+        failed = await _post_state(client, instance, "failed", 1)
+        assert failed.status_code == 200
+        assert failed.json() == {"accepted": True, "last_seq_id": 1}
+
+        readiness = (await client.get(instance.readiness_url)).status_code
+        liveness = (await client.get(instance.liveness_url)).status_code
+
+    assert readiness == 503, f"failed readiness: expected 503, got {readiness}"
+    assert liveness == 503, f"failed liveness: expected 503, got {liveness}"
+
+
+async def test_scenario_5_ttl_expiry(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #5: TTL expiry (heartbeat stopped) → readiness 503, liveness 503."""
+
+    instance = spawn_dashserving(ttl_s=2)
+    async with httpx.AsyncClient() as client:
+        active = await _post_state(client, instance, "active", 1)
+        assert active.json() == {"accepted": True, "last_seq_id": 1}
+        readiness_active = await _wait_status(client, instance.readiness_url, 200)
+        assert readiness_active == 200
+
+        # Stop heartbeating and wait past the 2s TTL; expiry is lazy, so probe
+        # /status to force evaluation, then read the probes.
+        await _sleep(2.5)
+        status = (await client.get(instance.status_url)).json()
+        assert status["subscriber"]["phase"] == "inactive", status["subscriber"]
+        assert status["subscriber"]["expired_total"] >= 1, status["subscriber"]
+
+        readiness = await _wait_status(client, instance.readiness_url, 503)
+        liveness = await _wait_status(client, instance.liveness_url, 503)
+
+    assert readiness == 503, f"ttl-expired readiness: expected 503, got {readiness}"
+    assert liveness == 503, f"ttl-expired liveness: expected 503, got {liveness}"
+
+
+async def test_scenario_6_recovery_after_ttl_expiry(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #6: a higher-seq active after TTL expiry recovers readiness 200."""
+
+    instance = spawn_dashserving(ttl_s=2)
+    async with httpx.AsyncClient() as client:
+        active = await _post_state(client, instance, "active", 1)
+        assert active.json() == {"accepted": True, "last_seq_id": 1}
+        await _wait_status(client, instance.readiness_url, 200)
+
+        await _sleep(2.5)
+        expired = await _wait_status(client, instance.readiness_url, 503)
+        assert expired == 503
+
+        recover = await _post_state(client, instance, "active", 2)
+        assert recover.status_code == 200
+        assert recover.json() == {"accepted": True, "last_seq_id": 2}
+
+        readiness = await _wait_status(client, instance.readiness_url, 200)
+        liveness = (await client.get(instance.liveness_url)).status_code
+
+    assert readiness == 200, f"recovery readiness: expected 200, got {readiness}"
+    assert liveness == 200, f"recovery liveness: expected 200, got {liveness}"
+
+
+async def test_scenario_7_stale_active_cannot_revive(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #7: a stale active (lower seq) after inactive cannot revive readiness."""
+
+    instance = spawn_dashserving()
+    async with httpx.AsyncClient() as client:
+        active = await _post_state(client, instance, "active", 1)
+        assert active.json() == {"accepted": True, "last_seq_id": 1}
+        await _wait_status(client, instance.readiness_url, 200)
+
+        inactive = await _post_state(client, instance, "inactive", 2)
+        assert inactive.json() == {"accepted": True, "last_seq_id": 2}
+        await _wait_status(client, instance.readiness_url, 503)
+
+        stale = await _post_state(client, instance, "active", 1)
+        assert stale.status_code == 200
+        assert stale.json() == {"accepted": False, "last_seq_id": 2}
+
+        readiness = (await client.get(instance.readiness_url)).status_code
+
+    assert readiness == 503, f"stale-active readiness: expected 503, got {readiness}"
+
+
+async def test_scenario_8_feature_disabled(
+    spawn_dashserving: Callable[..., DashServingInstance],
+) -> None:
+    """Spec #8: feature disabled → probes keep existing semantics (200, no workers).
+
+    With no workers configured and the subscriber integration off, readiness and
+    liveness are governed purely by the daemon's own running state and stay 200
+    regardless of any subscriber_state reports.
+    """
+
+    instance = spawn_dashserving(enabled=False)
+    async with httpx.AsyncClient() as client:
+        readiness_before = (await client.get(instance.readiness_url)).status_code
+        liveness_before = (await client.get(instance.liveness_url)).status_code
+
+        # The endpoint still accepts reports, but they must not affect probes.
+        inactive = await _post_state(client, instance, "inactive", 1)
+        assert inactive.status_code == 200
+
+        readiness_after = (await client.get(instance.readiness_url)).status_code
+        liveness_after = (await client.get(instance.liveness_url)).status_code
+
+        status = (await client.get(instance.status_url)).json()
+
+    assert readiness_before == 200, f"disabled readiness: {readiness_before}"
+    assert liveness_before == 200, f"disabled liveness: {liveness_before}"
+    assert readiness_after == 200, (
+        f"disabled readiness changed by report: {readiness_after}"
+    )
+    assert liveness_after == 200, (
+        f"disabled liveness changed by report: {liveness_after}"
+    )
+    assert status["subscriber"]["enabled"] is False, status["subscriber"]

--- a/subscriber/tests/e2e/test_kvcm_grpc.py
+++ b/subscriber/tests/e2e/test_kvcm_grpc.py
@@ -1,0 +1,199 @@
+"""End-to-end KVCM gRPC transport test against a real KVCM deployment.
+
+The suite is explicit opt-in: it skips unless ``KVCM_REAL_GRPC_TARGET`` names
+a reachable KVCM MetaService endpoint. ``KVCM_REAL_ADMIN_HTTP_URL`` is
+optional; when set, the test creates an isolated event-report instance group
+through the real admin API before issuing gRPC requests.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+import pytest
+
+from subscriber.kvcm.errors import KvcmResponseRejectedError
+from subscriber.kvcm.grpc_manager_client import GrpcKvCacheManagerClient
+
+_KVCM_REAL_GRPC_TARGET = os.environ.get("KVCM_REAL_GRPC_TARGET", "").strip()
+_KVCM_REAL_ADMIN_HTTP_URL = os.environ.get("KVCM_REAL_ADMIN_HTTP_URL", "").strip()
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        not _KVCM_REAL_GRPC_TARGET,
+        reason="e2e opt-in: set KVCM_REAL_GRPC_TARGET to a real KVCM MetaService",
+    ),
+]
+
+
+async def _setup_real_event_report_instance_group(
+    admin_url: str,
+    *,
+    instance_group: str,
+    storage_name: str,
+) -> None:
+    async with httpx.AsyncClient(
+        base_url=admin_url.rstrip("/"),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        timeout=2.0,
+    ) as http_client:
+        storage = {
+            "global_unique_name": storage_name,
+            "storage_type": "ST_EVENT_REPORT_L1P5",
+            "event_report": {
+                "heartbeat_timeout_ms": 1000,
+                "cleanup_grace_ms": 2000,
+                "liveness_check_interval_ms": 200,
+            },
+            "check_storage_available_when_open": False,
+        }
+        add_response = await http_client.post(
+            "/api/addStorage",
+            json={"trace_id": "real-grpc-add-storage", "storage": storage},
+        )
+        add_response.raise_for_status()
+        add_body = add_response.json()
+        add_code = add_body.get("header", {}).get("status", {}).get("code")
+        assert add_code in {"OK", "DUPLICATE_ENTITY"}, add_body
+
+        group_response = await http_client.post(
+            "/api/createInstanceGroup",
+            json={
+                "trace_id": "real-grpc-create-instance-group",
+                "instance_group": {
+                    "name": instance_group,
+                    "storage_candidates": ["nfs_01"],
+                    "global_quota_group_name": "default_quota_group",
+                    "max_instance_count": 100,
+                    "quota": {
+                        "capacity": 10737418240,
+                        "quota_config": [{"storage_type": 4, "capacity": 10737418240}],
+                    },
+                    "cache_config": {
+                        "reclaim_strategy": {
+                            "storage_unique_name": "nfs_01",
+                            "reclaim_policy": 1,
+                            "trigger_strategy": {
+                                "used_size": 1073741824,
+                                "used_percentage": 0.8,
+                            },
+                            "trigger_period_seconds": 60,
+                            "reclaim_step_size": 1073741824,
+                            "reclaim_step_percentage": 10,
+                        },
+                        "data_storage_strategy": 2,
+                        "meta_indexer_config": {
+                            "max_key_count": 1000000,
+                            "mutex_shard_num": 16,
+                            "batch_key_size": 16,
+                            "meta_storage_backend_config": {
+                                "storage_type": "local",
+                                "storage_uri": "",
+                            },
+                            "meta_cache_policy_config": {
+                                "type": "LRU",
+                                "capacity": 10000,
+                            },
+                        },
+                    },
+                    "event_report_storage_candidates": [storage_name],
+                    "version": 1,
+                },
+            },
+        )
+        group_response.raise_for_status()
+        group_body = group_response.json()
+        group_code = group_body.get("header", {}).get("status", {}).get("code")
+        assert group_code in {"OK", "DUPLICATE_ENTITY"}, group_body
+
+
+async def test_real_kvcm_grpc_register_and_report_event() -> None:
+    """Register an isolated instance and report node/heartbeat events over gRPC.
+
+    Setup in the KVCM repo:
+
+    ```bash
+    bazel build //kv_cache_manager:kv_cache_manager_bin
+    bazel-bin/kv_cache_manager/kv_cache_manager_bin \\
+      --env kvcm.service.rpc_port=56010 \\
+      --env kvcm.service.http_port=56020 \\
+      --env kvcm.service.admin_rpc_port=56031 \\
+      --env kvcm.service.admin_http_port=56040 \\
+      --env kvcm.service.enable_debug_service=false
+    ```
+
+    Run in this repo:
+
+    ```bash
+    KVCM_REAL_GRPC_TARGET=127.0.0.1:56010 \\
+    KVCM_REAL_ADMIN_HTTP_URL=http://127.0.0.1:56040 \\
+    uv run pytest tests/e2e/test_kvcm_grpc.py -vv
+    ```
+    """
+    suffix = uuid.uuid4().hex
+    instance_id = f"subscriber-real-grpc-{suffix}"
+    instance_group = "default"
+    if _KVCM_REAL_ADMIN_HTTP_URL:
+        instance_group = f"subscriber-real-grpc-group-{suffix}"
+        await _setup_real_event_report_instance_group(
+            _KVCM_REAL_ADMIN_HTTP_URL,
+            instance_group=instance_group,
+            storage_name=f"subscriber-real-grpc-l1p5-{suffix}",
+        )
+    client = GrpcKvCacheManagerClient(
+        _KVCM_REAL_GRPC_TARGET,
+        auto_discover_leader=True,
+        request_timeout_seconds=2.0,
+    )
+
+    try:
+        await client.start()
+        register_response = await client.register_instance(
+            {
+                "trace_id": "real-grpc-register",
+                "instance_group": instance_group,
+                "instance_id": instance_id,
+                "block_size": 16,
+                "location_spec_infos": [{"name": "vllm_16", "size": 16}],
+                "location_spec_groups": [
+                    {"name": "default", "spec_names": ["vllm_16"]}
+                ],
+                "model_deployment": {
+                    "model_name": "subscriber-real-grpc",
+                    "dtype": "bytes",
+                    "tp_size": 1,
+                    "dp_size": 1,
+                    "pp_size": 1,
+                },
+                "default_query_type": "QT_PREFIX_MATCH_WITH_MAMBA",
+            }
+        )
+        report_request = {
+            "trace_id": "real-grpc-report",
+            "instance_id": instance_id,
+            "host_ip_port": "127.0.0.1:8080",
+            "storage_type": "ST_EVENT_REPORT_L1P5",
+            "events": [
+                {
+                    "event_type": "EVENT_NODE_REGISTER",
+                    "node_register": {"mediums": ["hbm"]},
+                },
+                {"event_type": "EVENT_HEARTBEAT"},
+            ],
+        }
+        try:
+            report_response = await client.report_event(report_request)
+        except KvcmResponseRejectedError as exc:
+            if "EventReportBackend not found" in str(exc):
+                pytest.skip(
+                    "real KVCM server has no event_report_l1p5 backend configured"
+                )
+            raise
+    finally:
+        await client.close()
+
+    assert register_response["header"]["status"]["code"] == "OK"
+    assert report_response["header"]["status"]["code"] == "OK"

--- a/subscriber/tests/engine/__init__.py
+++ b/subscriber/tests/engine/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/subscriber/tests/engine/sglang/test_adapter.py
+++ b/subscriber/tests/engine/sglang/test_adapter.py
@@ -1,0 +1,793 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import msgspec
+import pytest
+import zmq
+import zmq.asyncio
+
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.base import AbstractEngineAdapter
+from subscriber.engine.metadata import MetadataProtocolError
+from subscriber.engine.sglang import SGLangAdapter
+from subscriber.engine.sglang.incremental import SglangIncrementalSource
+from subscriber.health.events import LivenessEvent
+from subscriber.kvcm.enum import KvcmStorageType
+from subscriber.proto import engine_service_rpc_pb2
+from subscriber.types import AllBlocksCleared, BlockRemoved, BlockStored, KVEventBatch
+
+
+def _publisher_endpoint(
+    publisher: zmq.asyncio.Socket,
+    replay: zmq.asyncio.Socket,
+) -> DpEndpoint:
+    return DpEndpoint(
+        rank=0,
+        zmq_pub_endpoint=publisher.getsockopt_string(zmq.LAST_ENDPOINT),
+        zmq_replay_endpoint=replay.getsockopt_string(zmq.LAST_ENDPOINT),
+    )
+
+
+class _SglangWireEvent(
+    msgspec.Struct,
+    array_like=True,
+    omit_defaults=True,
+    gc=False,
+    tag=True,
+):
+    pass
+
+
+class _SglangWireBlockStored(_SglangWireEvent, tag="BlockStored"):
+    block_hashes: list[int]
+    parent_block_hash: int | None
+    token_ids: list[int | tuple[int, int]]
+    block_size: int
+    lora_id: int | None
+    component_type: str
+    component_id: int | None = None
+    snapshot_version: int = 0
+    medium: str | None = None
+
+
+class _SglangWireBlockRemoved(_SglangWireEvent, tag="BlockRemoved"):
+    block_hashes: list[int]
+    component_type: str
+    component_id: int | None = None
+    snapshot_version: int = 0
+    medium: str | None = None
+
+
+class _SglangWireAllBlocksCleared(_SglangWireEvent, tag="AllBlocksCleared"):
+    pass
+
+
+class _SglangWireBatch(msgspec.Struct, array_like=True, gc=False):
+    ts: float
+    events: list[
+        _SglangWireBlockStored | _SglangWireBlockRemoved | _SglangWireAllBlocksCleared
+    ]
+    attn_dp_rank: int | None = None
+
+
+async def _publish_until_received(
+    publisher: zmq.asyncio.Socket,
+    frames: list[bytes],
+    received: asyncio.Event,
+) -> None:
+    while not received.is_set():
+        await publisher.send_multipart(frames)
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(received.wait(), timeout=0.02)
+
+
+def test_sglang_adapter_is_registered() -> None:
+    assert "sglang" in AbstractEngineAdapter._registry
+    assert AbstractEngineAdapter._registry["sglang"] is SGLangAdapter
+
+
+def test_snapshot_subscription_is_a_required_adapter_contract() -> None:
+    assert "subscribe_snapshot_events" in AbstractEngineAdapter.__abstractmethods__
+
+
+async def test_sglang_snapshot_subscription_requires_bootstrap() -> None:
+    adapter = SGLangAdapter(SubscriberConfig())
+
+    with pytest.raises(RuntimeError, match="bootstrap must be fetched"):
+        await anext(adapter.subscribe_snapshot_events())
+
+
+def test_snapshot_signal_is_a_required_adapter_contract() -> None:
+    assert "request_immediate_snapshot" in AbstractEngineAdapter.__abstractmethods__
+
+
+def test_sglang_adapter_can_be_created_via_factory() -> None:
+    config = SubscriberConfig()
+    adapter = AbstractEngineAdapter.create("sglang", config)
+    assert isinstance(adapter, SGLangAdapter)
+
+
+def test_sglang_adapter_maps_only_supported_sglang_media() -> None:
+    config = SubscriberConfig()
+    adapter = SGLangAdapter(config)
+
+    assert adapter.map_medium("GPU") == "hbm"
+    assert adapter.map_medium("CPU_PINNED") == "mem"
+    assert adapter.map_medium("EXTERNAL") == ""
+    assert adapter.map_medium(None) == ""
+    assert adapter.supported_mediums() == ["hbm", "mem"]
+    assert adapter.storage_type() == KvcmStorageType.ST_EVENT_REPORT_L1P5
+
+
+async def test_sglang_adapter_delegates_snapshot_signal_after_bootstrap(
+    mocker: Any,
+) -> None:
+    _mock_dashllm_clients(mocker, _bootstrap_response())
+    adapter = SGLangAdapter(SubscriberConfig(snapshot_kv_event_pipeline_enabled=True))
+    await adapter.fetch_kv_event_bootstrap()
+    assert adapter._snapshot is not None
+    request = mocker.patch.object(adapter._snapshot, "request_immediate_snapshot")
+
+    adapter.request_immediate_snapshot()
+
+    request.assert_called_once_with()
+
+
+def _bootstrap_response() -> engine_service_rpc_pb2.KvEventBootstrapInfoPB:
+    response = engine_service_rpc_pb2.KvEventBootstrapInfoPB(
+        protocol_version=1,
+        engine_kind="sglang",
+        err_code=engine_service_rpc_pb2.KV_EVENT_BOOTSTRAP_OK,
+    )
+    response.event_transport.live_endpoint = "tcp://127.0.0.1:5557"
+    response.event_transport.replay_supported = True
+    response.event_transport.replay_endpoint = "tcp://127.0.0.1:5558"
+    response.event_transport.serialization = "msgpack-v1"
+    response.runtime_topology.data_parallel_size = 1
+    response.runtime_topology.tensor_parallel_size = 1
+    response.runtime_topology.pipeline_parallel_size = 1
+    response.snapshot.supported = True
+    response.snapshot.versioned = True
+    response.sglang.cache_key_mode = "token"
+    response.sglang.event_schema_version = 2
+    response.sglang.native_hash_algorithm = "sglang-radix-native-int64"
+    full = response.components.add(component_id=0, component_kind="full_attention")
+    full.geometry.block_size_tokens = 16
+    mamba = response.components.add(component_id=2, component_kind="mamba")
+    mamba.geometry.block_size_tokens = 128
+    mamba.geometry.checkpoint_alignment_tokens.value = 128
+    return response
+
+
+class _MockDashllmClients:
+    def __init__(self, mocker: Any, response: object) -> None:
+        self.control = MagicMock()
+        self.control.get_kv_event_bootstrap_info = AsyncMock(return_value=response)
+        self.control.close = AsyncMock()
+        self.status = MagicMock()
+        self.status.get_worker_status = AsyncMock(
+            return_value=engine_service_rpc_pb2.WorkerStatusPB(alive=True)
+        )
+        self.status.close = AsyncMock()
+        mocker.patch(
+            "subscriber.engine.sglang.adapter.DashllmKvEventControlClient",
+            return_value=self.control,
+        )
+        mocker.patch(
+            "subscriber.engine.sglang.adapter.DashllmWorkerStatusClient",
+            return_value=self.status,
+        )
+
+
+def _mock_dashllm_clients(mocker: Any, response: object) -> _MockDashllmClients:
+    return _MockDashllmClients(mocker, response)
+
+
+async def test_sglang_adapter_fetches_bootstrap_before_opening_zmq(
+    mocker: Any,
+) -> None:
+    response = _bootstrap_response()
+    clients = _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(SubscriberConfig(snapshot_kv_event_pipeline_enabled=True))
+
+    assert adapter._incremental is None
+    bootstrap = await adapter.fetch_kv_event_bootstrap()
+
+    assert [component.component_id for component in bootstrap.components] == [0, 2]
+    assert adapter._incremental is not None
+    assert adapter._incremental._component_group_idxs == {0: 0, 2: 2}
+    assert adapter._snapshot is not None
+    assert adapter._snapshot._component_group_idxs == {0: 0, 2: 2}
+    clients.control.get_kv_event_bootstrap_info.assert_awaited_once()
+
+
+async def test_sglang_adapter_accepts_snapshot_unsupported_when_pipeline_is_disabled(
+    mocker: Any,
+) -> None:
+    response = _bootstrap_response()
+    response.snapshot.supported = False
+    response.snapshot.versioned = False
+    _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(SubscriberConfig())
+
+    await adapter.fetch_kv_event_bootstrap()
+
+    assert adapter._incremental is not None
+    assert adapter._snapshot is None
+
+
+async def test_sglang_adapter_accepts_snapshot_only_bootstrap_without_event_transport(
+    mocker: Any,
+) -> None:
+    response = _bootstrap_response()
+    response.event_transport.Clear()
+    _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(
+        SubscriberConfig(
+            incremental_kv_event_pipeline_enabled=False,
+            snapshot_kv_event_pipeline_enabled=True,
+        )
+    )
+
+    await adapter.fetch_kv_event_bootstrap()
+
+    assert adapter._incremental is None
+    assert adapter._snapshot is not None
+
+
+async def test_sglang_adapter_rejects_duplicate_component_id(
+    mocker: Any,
+) -> None:
+    response = _bootstrap_response()
+    duplicate = response.components.add(component_id=0, component_kind="full_attention")
+    duplicate.geometry.block_size_tokens = 16
+    _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(SubscriberConfig())
+
+    with pytest.raises(MetadataProtocolError, match="duplicate component_id"):
+        await adapter.fetch_kv_event_bootstrap()
+
+
+async def test_sglang_adapter_rejects_unknown_component_kind(
+    mocker: Any,
+) -> None:
+    response = _bootstrap_response()
+    response.components[0].component_kind = "unknown"
+    _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(SubscriberConfig())
+
+    with pytest.raises(MetadataProtocolError, match="unsupported component_kind"):
+        await adapter.fetch_kv_event_bootstrap()
+
+
+@pytest.mark.parametrize(
+    "obsolete_kind",
+    ["linear_state_checkpoint", "sliding_window_attention"],
+)
+async def test_sglang_adapter_rejects_obsolete_component_kind(
+    mocker: Any,
+    obsolete_kind: str,
+) -> None:
+    response = _bootstrap_response()
+    response.components[0].component_kind = obsolete_kind
+    _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(SubscriberConfig())
+
+    with pytest.raises(MetadataProtocolError, match="unsupported component_kind"):
+        await adapter.fetch_kv_event_bootstrap()
+
+
+async def test_sglang_adapter_accepts_configured_extra_component_kind(
+    mocker: Any,
+) -> None:
+    response = _bootstrap_response()
+    response.components[0].component_kind = "custom_attention"
+    _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(
+        SubscriberConfig(extra_attention_types={"custom_attention": "custom"})
+    )
+
+    bootstrap = await adapter.fetch_kv_event_bootstrap()
+
+    assert bootstrap.components[0].component_kind == "custom_attention"
+
+
+def _disable_replay(response: engine_service_rpc_pb2.KvEventBootstrapInfoPB) -> None:
+    response.event_transport.replay_supported = False
+    response.event_transport.replay_endpoint = ""
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda response: setattr(
+                response.runtime_topology, "data_parallel_size", 2
+            ),
+            "data_parallel_size=1",
+        ),
+        (
+            lambda response: setattr(response.snapshot, "supported", False),
+            "snapshot transport must be supported",
+        ),
+        (
+            lambda response: setattr(response.snapshot, "versioned", False),
+            "snapshot transport must be versioned",
+        ),
+        (_disable_replay, "event replay must be supported"),
+    ],
+)
+async def test_sglang_adapter_rejects_unsupported_bootstrap_contract(
+    mocker: Any, mutate: Any, match: str
+) -> None:
+    response = _bootstrap_response()
+    mutate(response)
+    _mock_dashllm_clients(mocker, response)
+    adapter = SGLangAdapter(SubscriberConfig(snapshot_kv_event_pipeline_enabled=True))
+
+    with pytest.raises(MetadataProtocolError, match=match):
+        await adapter.fetch_kv_event_bootstrap()
+
+
+async def test_sglang_adapter_reset_generation_state_resets_zmq_source(
+    mocker: Any,
+) -> None:
+    _mock_dashllm_clients(mocker, _bootstrap_response())
+    adapter = SGLangAdapter(SubscriberConfig(snapshot_kv_event_pipeline_enabled=True))
+    await adapter.fetch_kv_event_bootstrap()
+    assert adapter._incremental is not None
+    assert adapter._snapshot is not None
+    reset = mocker.patch.object(adapter._incremental, "reset_generation_state")
+    reset_snapshot = mocker.patch.object(adapter._snapshot, "reset_generation_state")
+
+    await adapter.reset_generation_state()
+
+    reset.assert_awaited_once()
+    reset_snapshot.assert_awaited_once()
+
+
+async def test_sglang_adapter_close_releases_transport_and_grpc_client(
+    mocker: Any,
+) -> None:
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    adapter = SGLangAdapter(SubscriberConfig(snapshot_kv_event_pipeline_enabled=True))
+    await adapter.fetch_kv_event_bootstrap()
+    assert adapter._incremental is not None
+    assert adapter._snapshot is not None
+    close_transport = mocker.patch.object(adapter._incremental, "close")
+    close_snapshot = mocker.patch.object(adapter._snapshot, "close")
+
+    await adapter.close()
+
+    close_transport.assert_awaited_once()
+    close_snapshot.assert_awaited_once()
+    clients.status.close.assert_awaited_once()
+    clients.control.close.assert_awaited_once()
+
+
+async def test_sglang_adapter_delegates_existing_worker_status_liveness(
+    mocker: Any,
+) -> None:
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    adapter = SGLangAdapter(SubscriberConfig())
+    events = adapter.watch_liveness()
+
+    try:
+        assert await anext(events) is LivenessEvent.HEALTHY
+    finally:
+        await events.aclose()
+
+    clients.status.get_worker_status.assert_awaited_once()
+
+
+async def test_sglang_adapter_reports_unhealthy_worker_status(
+    mocker: Any,
+) -> None:
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status.return_value = (
+        engine_service_rpc_pb2.WorkerStatusPB(alive=False)
+    )
+    adapter = SGLangAdapter(SubscriberConfig(engine_health_interval_s=60.0))
+    events = adapter.watch_liveness()
+
+    try:
+        assert await anext(events) is LivenessEvent.UNHEALTHY
+    finally:
+        await events.aclose()
+
+    clients.status.get_worker_status.assert_awaited_once()
+
+
+@pytest.mark.integration
+async def test_sglang_incremental_source_decodes_full_gpu_event() -> None:
+    context = zmq.asyncio.Context.instance()
+    publisher = context.socket(zmq.PUB)
+    replay = context.socket(zmq.ROUTER)
+    publisher.bind("tcp://127.0.0.1:0")
+    replay.bind("tcp://127.0.0.1:0")
+    source = SglangIncrementalSource(
+        SubscriberConfig(),
+        component_group_idxs={0: 0},
+        endpoint=_publisher_endpoint(publisher, replay),
+    )
+    wire_batch = _SglangWireBatch(
+        ts=1.0,
+        events=[
+            _SglangWireBlockStored(
+                block_hashes=[101],
+                parent_block_hash=None,
+                token_ids=[11, 12],
+                block_size=2,
+                lora_id=None,
+                component_type="full",
+                component_id=0,
+                medium="GPU",
+            ),
+            _SglangWireBlockRemoved(
+                block_hashes=[102],
+                component_type="full",
+                component_id=0,
+                medium="GPU",
+            ),
+            _SglangWireAllBlocksCleared(),
+        ],
+        attn_dp_rank=0,
+    )
+    delivered = asyncio.Event()
+    results: list[KVEventBatch] = []
+
+    async def _consume() -> None:
+        async for event_batch in source.subscribe():
+            results.extend(event_batch.batches)
+            delivered.set()
+            break
+
+    consumer = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(
+            _publish_until_received(
+                publisher,
+                [b"", (0).to_bytes(8, "big"), msgspec.msgpack.encode(wire_batch)],
+                delivered,
+            ),
+            timeout=5.0,
+        )
+        await asyncio.wait_for(consumer, timeout=5.0)
+    finally:
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+        publisher.close(linger=0)
+        replay.close(linger=0)
+
+    assert results == [
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                BlockStored(
+                    block_hashes=[101],
+                    parent_block_hash=None,
+                    token_ids=[11, 12],
+                    block_size=2,
+                    lora_id=None,
+                    medium="GPU",
+                    lora_name=None,
+                    group_idx=0,
+                    component_id=0,
+                    kv_cache_spec_kind="full",
+                ),
+                BlockRemoved(
+                    block_hashes=[102],
+                    medium="GPU",
+                    group_idx=0,
+                    component_id=0,
+                    remaining_copy_counts=None,
+                ),
+                AllBlocksCleared(),
+            ],
+            data_parallel_rank=0,
+        )
+    ]
+
+
+@pytest.mark.integration
+async def test_sglang_incremental_source_logs_rich_debug_batch_summary(
+    mocker: pytest.MockFixture,
+) -> None:
+    context = zmq.asyncio.Context.instance()
+    publisher = context.socket(zmq.PUB)
+    replay = context.socket(zmq.ROUTER)
+    publisher.bind("tcp://127.0.0.1:0")
+    replay.bind("tcp://127.0.0.1:0")
+    source = SglangIncrementalSource(
+        SubscriberConfig(),
+        component_group_idxs={0: 0},
+        endpoint=_publisher_endpoint(publisher, replay),
+    )
+    mocker.patch(
+        "subscriber.engine.sglang.incremental.logger.is_debug_enabled",
+        return_value=True,
+    )
+    mocker.patch(
+        "subscriber.engine.zmq_source.generate_trace_id",
+        return_value="sglang-live-trace",
+    )
+    debug = mocker.patch("subscriber.engine.sglang.incremental.logger.debug")
+    wire_batch = _SglangWireBatch(
+        ts=1.0,
+        events=[
+            _SglangWireBlockStored(
+                block_hashes=[101, 102],
+                parent_block_hash=100,
+                token_ids=[11, 12],
+                block_size=2,
+                lora_id=None,
+                component_type="full",
+                component_id=0,
+                medium="GPU",
+            ),
+            _SglangWireBlockRemoved(
+                block_hashes=[103],
+                component_type="full",
+                component_id=0,
+                medium="GPU",
+            ),
+            _SglangWireAllBlocksCleared(),
+        ],
+        attn_dp_rank=0,
+    )
+    delivered = asyncio.Event()
+
+    async def _consume() -> None:
+        async for _ in source.subscribe():
+            delivered.set()
+            break
+
+    consumer = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(
+            _publish_until_received(
+                publisher,
+                [b"", (0).to_bytes(8, "big"), msgspec.msgpack.encode(wire_batch)],
+                delivered,
+            ),
+            timeout=5.0,
+        )
+        await asyncio.wait_for(consumer, timeout=5.0)
+    finally:
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+        publisher.close(linger=0)
+        replay.close(linger=0)
+
+    debug.assert_any_call(
+        "decoded SGLang KV event batch",
+        step="zmq_subscribe",
+        tags={
+            "seq": 0,
+            "trace_id": "sglang-live-trace",
+            "event_count": 3,
+            "event_types": "AllBlocksCleared:1,BlockRemoved:1,BlockStored:1",
+            "data_parallel_rank": 0,
+            "stored_block_count": 1,
+            "stored_blocks": [
+                {
+                    "block_hashes": ["101", "102"],
+                    "parent_block_hash": "100",
+                    "block_size": 2,
+                    "lora_id": None,
+                    "medium": "GPU",
+                    "lora_name": None,
+                    "extra_keys": None,
+                    "group_idx": 0,
+                    "component_id": 0,
+                    "kv_cache_spec_kind": "full",
+                    "kv_cache_spec_sliding_window": None,
+                    "snapshot_version": 0,
+                }
+            ],
+            "stored_blocks_truncated": False,
+            "removed_block_count": 1,
+            "removed_blocks": [
+                {
+                    "block_hashes": ["103"],
+                    "medium": "GPU",
+                    "group_idx": 0,
+                    "component_id": 0,
+                    "remaining_copy_counts": None,
+                    "snapshot_version": 0,
+                }
+            ],
+            "removed_blocks_truncated": False,
+        },
+    )
+
+
+@pytest.mark.integration
+async def test_sglang_incremental_source_keeps_valid_event_without_drop_metric(
+    mocker: pytest.MockFixture,
+) -> None:
+    counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+    context = zmq.asyncio.Context.instance()
+    publisher = context.socket(zmq.PUB)
+    replay = context.socket(zmq.ROUTER)
+    publisher.bind("tcp://127.0.0.1:0")
+    replay.bind("tcp://127.0.0.1:0")
+    source = SglangIncrementalSource(
+        SubscriberConfig(),
+        component_group_idxs={0: 0},
+        endpoint=_publisher_endpoint(publisher, replay),
+    )
+    wire_batch = _SglangWireBatch(
+        ts=2.0,
+        events=[
+            _SglangWireBlockStored(
+                block_hashes=[201],
+                parent_block_hash=None,
+                token_ids=[21],
+                block_size=1,
+                lora_id=None,
+                component_type="full",
+                component_id=0,
+                medium="GPU",
+            ),
+            _SglangWireBlockStored(
+                block_hashes=[202],
+                parent_block_hash=None,
+                token_ids=[22],
+                block_size=1,
+                lora_id=None,
+                component_type="full",
+                component_id=0,
+                medium="EXTERNAL",
+            ),
+        ],
+    )
+    delivered = asyncio.Event()
+    results: list[KVEventBatch] = []
+
+    async def _consume() -> None:
+        async for event_batch in source.subscribe():
+            results.extend(event_batch.batches)
+            delivered.set()
+            break
+
+    consumer = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(
+            _publish_until_received(
+                publisher,
+                [b"", (0).to_bytes(8, "big"), msgspec.msgpack.encode(wire_batch)],
+                delivered,
+            ),
+            timeout=5.0,
+        )
+        await asyncio.wait_for(consumer, timeout=5.0)
+    finally:
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+        publisher.close(linger=0)
+        replay.close(linger=0)
+
+    assert results[0].events[0].block_hashes == [201]
+    assert len(results[0].events) == 1
+    assert all(
+        call.args[0] != "sglang_event_drop_count" for call in counter.call_args_list
+    )
+
+
+@pytest.mark.integration
+async def test_sglang_incremental_source_replays_missing_batch_before_live() -> None:
+    context = zmq.asyncio.Context.instance()
+    publisher = context.socket(zmq.PUB)
+    replay = context.socket(zmq.ROUTER)
+    publisher.bind("tcp://127.0.0.1:0")
+    replay.bind("tcp://127.0.0.1:0")
+    source = SglangIncrementalSource(
+        SubscriberConfig(),
+        component_group_idxs={0: 0},
+        endpoint=_publisher_endpoint(publisher, replay),
+    )
+
+    def _wire_batch(block_hash: int) -> bytes:
+        return msgspec.msgpack.encode(
+            _SglangWireBatch(
+                ts=float(block_hash),
+                events=[
+                    _SglangWireBlockStored(
+                        block_hashes=[block_hash],
+                        parent_block_hash=None,
+                        token_ids=[block_hash],
+                        block_size=1,
+                        lora_id=None,
+                        component_type="full",
+                        component_id=0,
+                        medium="GPU",
+                    )
+                ],
+            )
+        )
+
+    first_live = asyncio.Event()
+    delivered = asyncio.Event()
+    results: list[KVEventBatch] = []
+
+    async def _consume() -> None:
+        async for event_batch in source.subscribe():
+            results.extend(event_batch.batches)
+            if len(results) == 1:
+                first_live.set()
+            if len(results) == 3:
+                delivered.set()
+                break
+
+    async def _serve_replay() -> None:
+        client_id, delimiter, start_seq = await replay.recv_multipart()
+        assert delimiter == b""
+        assert int.from_bytes(start_seq, "big") == 1
+        await replay.send_multipart(
+            [
+                client_id,
+                b"",
+                b"",
+                (1).to_bytes(8, "big"),
+                _wire_batch(301),
+            ]
+        )
+        await replay.send_multipart(
+            [
+                client_id,
+                b"",
+                b"",
+                (-1).to_bytes(8, "big", signed=True),
+                b"",
+            ]
+        )
+
+    consumer = asyncio.create_task(_consume())
+    replay_server = asyncio.create_task(_serve_replay())
+    try:
+        await asyncio.wait_for(
+            _publish_until_received(
+                publisher,
+                [b"", (0).to_bytes(8, "big"), _wire_batch(300)],
+                first_live,
+            ),
+            timeout=5.0,
+        )
+        await asyncio.wait_for(
+            _publish_until_received(
+                publisher,
+                [b"", (2).to_bytes(8, "big"), _wire_batch(302)],
+                delivered,
+            ),
+            timeout=5.0,
+        )
+        await asyncio.wait_for(replay_server, timeout=5.0)
+        await asyncio.wait_for(consumer, timeout=5.0)
+    finally:
+        for task in (consumer, replay_server):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        publisher.close(linger=0)
+        replay.close(linger=0)
+
+    assert [
+        (
+            batch.events[0].block_hashes,
+            batch.events[0].group_idx,
+            batch.events[0].medium,
+        )
+        for batch in results
+    ] == [
+        ([300], 0, "GPU"),
+        ([301], 0, "GPU"),
+        ([302], 0, "GPU"),
+    ]

--- a/subscriber/tests/engine/sglang/test_integration.py
+++ b/subscriber/tests/engine/sglang/test_integration.py
@@ -1,0 +1,117 @@
+"""Real UDS integration for SGLang bootstrap and snapshot decoding."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from uuid import uuid4
+
+import grpc
+import msgspec
+import pytest
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.sglang import SGLangAdapter
+from subscriber.proto import (
+    engine_service_rpc_pb2,
+    engine_service_rpc_pb2_grpc,
+)
+from subscriber.types import BlockSnapshot, BlockSnapshotItem
+
+pytestmark = pytest.mark.integration
+
+
+class _SglangControlService(engine_service_rpc_pb2_grpc.KvEventControlServiceServicer):
+    def __init__(self) -> None:
+        self.snapshot_requests = 0
+
+    async def GetKvEventBootstrapInfo(
+        self,
+        request: engine_service_rpc_pb2.KvEventBootstrapInfoRequestPB,
+        context: grpc.aio.ServicerContext,
+    ) -> engine_service_rpc_pb2.KvEventBootstrapInfoPB:
+        del request, context
+        response = engine_service_rpc_pb2.KvEventBootstrapInfoPB(
+            protocol_version=1,
+            engine_kind="sglang",
+            err_code=engine_service_rpc_pb2.KV_EVENT_BOOTSTRAP_OK,
+        )
+        response.event_transport.live_endpoint = "tcp://127.0.0.1:5557"
+        response.event_transport.topic = "kv-events"
+        response.event_transport.replay_supported = True
+        response.event_transport.replay_endpoint = "tcp://127.0.0.1:5558"
+        response.event_transport.serialization = "msgpack-v1"
+        response.runtime_topology.data_parallel_size = 1
+        response.runtime_topology.tensor_parallel_size = 1
+        response.runtime_topology.pipeline_parallel_size = 1
+        response.snapshot.supported = True
+        response.snapshot.versioned = True
+        response.sglang.cache_key_mode = "token"
+        response.sglang.event_schema_version = 2
+        response.sglang.native_hash_algorithm = "sglang-radix-native-int64"
+        response.components.add(
+            component_id=0,
+            component_kind="full_attention",
+        ).geometry.block_size_tokens = 16
+        response.components.add(
+            component_id=2,
+            component_kind="mamba",
+        ).geometry.block_size_tokens = 128
+        return response
+
+    async def GetAllKvCacheBlocks(
+        self,
+        request: engine_service_rpc_pb2.KvCacheBlocksRequestPB,
+        context: grpc.aio.ServicerContext,
+    ) -> engine_service_rpc_pb2.KvCacheBlockListPB:
+        del request, context
+        self.snapshot_requests += 1
+        return engine_service_rpc_pb2.KvCacheBlockListPB(
+            raw_snapshot=msgspec.msgpack.encode([(-11, 0), (22, 2)]),
+            snapshot_version=9,
+        )
+
+
+def _short_uds_path() -> Path:
+    return Path("/tmp") / f"sglang-snapshot-{uuid4().hex[:12]}.sock"
+
+
+async def test_adapter_round_trips_mixed_component_snapshot_over_uds() -> None:
+    service = _SglangControlService()
+    server = grpc.aio.server()
+    engine_service_rpc_pb2_grpc.add_KvEventControlServiceServicer_to_server(
+        service, server
+    )
+    uds_path = _short_uds_path()
+    assert server.add_insecure_port(f"unix://{uds_path}") == 1
+    await server.start()
+
+    adapter = SGLangAdapter(
+        SubscriberConfig(
+            engine_kv_event_control_uds_path=str(uds_path),
+            engine_snapshot_full_sync_interval_s=60.0,
+            snapshot_kv_event_pipeline_enabled=True,
+        )
+    )
+    events = adapter.subscribe_snapshot_events()
+    try:
+        await adapter.fetch_kv_event_bootstrap()
+        event = await asyncio.wait_for(anext(events), timeout=5.0)
+    finally:
+        await events.aclose()
+        await adapter.close()
+        await server.stop(None)
+        uds_path.unlink(missing_ok=True)
+
+    assert service.snapshot_requests == 1
+    assert event.batches[0].events == [
+        BlockSnapshot(
+            medium="GPU",
+            block_size=0,
+            items=[
+                BlockSnapshotItem(block_hash=-11, group_idx=0),
+                BlockSnapshotItem(block_hash=22, group_idx=2),
+            ],
+            snapshot_version=9,
+        )
+    ]

--- a/subscriber/tests/engine/sglang/test_snapshot.py
+++ b/subscriber/tests/engine/sglang/test_snapshot.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import msgspec
+import pytest
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.base import EngineEventBatch
+from subscriber.engine.sglang.snapshot import SglangSnapshotSource
+from subscriber.proto import engine_service_rpc_pb2
+from subscriber.types import BlockSnapshot, BlockSnapshotItem
+
+
+def _response(
+    items: object,
+    *,
+    snapshot_version: int = 3,
+) -> engine_service_rpc_pb2.KvCacheBlockListPB:
+    return engine_service_rpc_pb2.KvCacheBlockListPB(
+        raw_snapshot=msgspec.msgpack.encode(items),
+        snapshot_version=snapshot_version,
+    )
+
+
+async def _next(source: SglangSnapshotSource) -> EngineEventBatch:
+    return await asyncio.wait_for(anext(source.subscribe()), timeout=1.0)
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [(1,)],
+        [(1, 0, 2)],
+        [(b"not-an-int", 0)],
+        [(1, "full")],
+    ],
+)
+async def test_rejects_malformed_engine_specific_schema(
+    items: object,
+    mocker: Any,
+) -> None:
+    client = MagicMock()
+    client.get_all_kv_cache_blocks = AsyncMock(return_value=_response(items))
+    source = SglangSnapshotSource(
+        SubscriberConfig(), client, component_group_idxs={0: 0, 2: 2}
+    )
+    mocker.patch.object(source, "_wait_interval", AsyncMock())
+
+    event = await _next(source)
+
+    assert event.batches == []
+    assert event.telemetry.drop_reason == "schema_mismatch"
+
+
+async def test_decodes_signed_hashes_and_mixed_component_ids(
+    mocker: Any,
+) -> None:
+    client = MagicMock()
+    response = _response([(-11, 0), (22, 2)], snapshot_version=9)
+    client.get_all_kv_cache_blocks = AsyncMock(return_value=response)
+    source = SglangSnapshotSource(
+        SubscriberConfig(), client, component_group_idxs={0: 0, 2: 2}
+    )
+    mocker.patch.object(source, "_wait_interval", AsyncMock())
+
+    event = await _next(source)
+
+    assert event.batches[0].events == [
+        BlockSnapshot(
+            medium="GPU",
+            block_size=0,
+            items=[
+                BlockSnapshotItem(block_hash=-11, group_idx=0),
+                BlockSnapshotItem(block_hash=22, group_idx=2),
+            ],
+            snapshot_version=9,
+        )
+    ]
+
+
+async def test_rejects_component_not_declared_by_bootstrap(mocker: Any) -> None:
+    client = MagicMock()
+    client.get_all_kv_cache_blocks = AsyncMock(return_value=_response([(11, 1)]))
+    source = SglangSnapshotSource(
+        SubscriberConfig(), client, component_group_idxs={0: 0, 2: 2}
+    )
+    mocker.patch.object(source, "_wait_interval", AsyncMock())
+
+    event = await _next(source)
+
+    assert event.batches == []
+    assert event.telemetry.drop_reason == "schema_mismatch"
+
+
+async def test_msgpack_empty_list_is_authoritative_empty_snapshot(
+    mocker: Any,
+) -> None:
+    client = MagicMock()
+    client.get_all_kv_cache_blocks = AsyncMock(return_value=_response([]))
+    source = SglangSnapshotSource(
+        SubscriberConfig(), client, component_group_idxs={0: 0, 2: 2}
+    )
+    mocker.patch.object(source, "_wait_interval", AsyncMock())
+
+    event = await _next(source)
+
+    assert event.telemetry.drop_reason is None
+    assert event.batches[0].events[0].items == []

--- a/subscriber/tests/engine/test_grpc_clients.py
+++ b/subscriber/tests/engine/test_grpc_clients.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import grpc
+import pytest
+
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.worker_status_client import DashllmWorkerStatusClient
+from subscriber.proto import (
+    engine_service_rpc_pb2,
+    engine_service_rpc_pb2_grpc,
+)
+
+
+class _FakeGrpcChannel:
+    def __init__(self, response: object | list[object]) -> None:
+        self._responses = response if isinstance(response, list) else [response]
+        self.paths: list[str] = []
+        self.requests: list[object] = []
+        self.timeouts: list[float] = []
+        self.close = AsyncMock()
+
+    def unary_unary(self, path: str, **_: Any) -> Any:
+        self.paths.append(path)
+
+        async def invoke(request: object, *, timeout: float) -> object:
+            self.requests.append(request)
+            self.timeouts.append(timeout)
+            response_index = min(
+                len(self.requests) - 1,
+                len(self._responses) - 1,
+            )
+            return self._responses[response_index]
+
+        return invoke
+
+
+class _MockKvEventControlService(
+    engine_service_rpc_pb2_grpc.KvEventControlServiceServicer
+):
+    async def GetKvEventBootstrapInfo(
+        self,
+        request: object,
+        context: grpc.aio.ServicerContext,
+    ) -> engine_service_rpc_pb2.KvEventBootstrapInfoPB:
+        del request, context
+        response = engine_service_rpc_pb2.KvEventBootstrapInfoPB(
+            protocol_version=1,
+            engine_kind="vllm",
+        )
+        response.event_transport.live_endpoint = "tcp://127.0.0.1:5557"
+        response.event_transport.topic = "kv-events"
+        response.event_transport.replay_supported = True
+        response.event_transport.replay_endpoint = "tcp://127.0.0.1:5558"
+        response.event_transport.serialization = "msgpack-v1"
+        response.components.add(
+            component_id=3,
+            component_kind="sliding_window",
+        ).geometry.block_size_tokens = 16
+        return response
+
+    async def GetAllKvCacheBlocks(
+        self,
+        request: object,
+        context: grpc.aio.ServicerContext,
+    ) -> engine_service_rpc_pb2.KvCacheBlockListPB:
+        del request, context
+        return engine_service_rpc_pb2.KvCacheBlockListPB(
+            raw_snapshot=b"snapshot-wire",
+            snapshot_version=41,
+            block_size=16,
+        )
+
+
+@pytest.mark.integration
+async def test_kv_event_control_client_round_trips_over_real_uds() -> None:
+    with tempfile.TemporaryDirectory(prefix="kvctl-", dir="/tmp") as directory:
+        uds_path = Path(directory) / "control.sock"
+        server = grpc.aio.server()
+        engine_service_rpc_pb2_grpc.add_KvEventControlServiceServicer_to_server(
+            _MockKvEventControlService(),
+            server,
+        )
+        assert server.add_insecure_port(f"unix://{uds_path}") == 1
+        await server.start()
+        client = DashllmKvEventControlClient(str(uds_path))
+        try:
+            bootstrap = await client.get_kv_event_bootstrap_info(timeout_s=5.0)
+            snapshot = await client.get_all_kv_cache_blocks(timeout_s=5.0)
+        finally:
+            await client.close()
+            await server.stop(None)
+            uds_path.unlink(missing_ok=True)
+
+    assert bootstrap.engine_kind == "vllm"
+    assert bootstrap.event_transport.topic == "kv-events"
+    assert bootstrap.components[0].component_id == 3
+    assert bootstrap.components[0].geometry.block_size_tokens == 16
+    assert snapshot.raw_snapshot == b"snapshot-wire"
+    assert snapshot.snapshot_version == 41
+    assert snapshot.block_size == 16
+
+
+async def test_metadata_requests_reuse_one_channel(mocker: Any) -> None:
+    response = engine_service_rpc_pb2.KvEventBootstrapInfoPB()
+    channel = _FakeGrpcChannel(response)
+    insecure_channel = mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmKvEventControlClient("/tmp/dashllm-kv-event-control.sock")
+
+    assert await client.get_kv_event_bootstrap_info(1.0) is response
+    assert await client.get_kv_event_bootstrap_info(2.0) is response
+
+    insecure_channel.assert_called_once()
+    assert insecure_channel.call_args.args == (
+        "unix:///tmp/dashllm-kv-event-control.sock",
+    )
+    assert insecure_channel.call_args.kwargs["options"]
+    assert "/KvEventControlService/GetKvEventBootstrapInfo" in channel.paths
+    assert len(channel.requests) == 2
+    assert channel.timeouts == [1.0, 2.0]
+
+
+async def test_close_releases_created_channel_once(mocker: Any) -> None:
+    response = engine_service_rpc_pb2.KvEventBootstrapInfoPB()
+    channel = _FakeGrpcChannel(response)
+    mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmKvEventControlClient("/tmp/dashllm-kv-event-control.sock")
+
+    await client.get_kv_event_bootstrap_info(1.0)
+    await client.close()
+    await client.close()
+
+    channel.close.assert_awaited_once()
+
+
+# --- GetWorkerStatus proto and client tests ---
+
+
+def test_status_version_pb_is_request_type() -> None:
+    """StatusVersionPB exists and is the request message for GetWorkerStatus."""
+    msg = engine_service_rpc_pb2.StatusVersionPB()
+    assert msg.latest_cache_version == 0
+    assert msg.latest_finished_version == 0
+
+
+def test_worker_status_pb_alive_field_number_is_13() -> None:
+    """WorkerStatusPB.alive must be field number 13."""
+    descriptor = engine_service_rpc_pb2.WorkerStatusPB.DESCRIPTOR
+    alive_field = descriptor.fields_by_name["alive"]
+    assert alive_field.number == 13
+
+
+def test_worker_status_pb_version_field_numbers_match_dashllm() -> None:
+    descriptor = engine_service_rpc_pb2.WorkerStatusPB.DESCRIPTOR
+
+    assert descriptor.fields_by_name["status_version"].number == 12
+    assert descriptor.fields_by_name["latest_finished_version"].number == 15
+
+
+def test_worker_status_pb_from_string_tolerates_unknown_fields() -> None:
+    """WorkerStatusPB.FromString with unknown fields still parses alive."""
+    # \x08\x01 = field 1 varint 1 (unknown), \x68\x01 = field 13 varint 1 (alive)
+    msg = engine_service_rpc_pb2.WorkerStatusPB.FromString(b"\x08\x01\x68\x01")
+    assert msg.alive is True
+
+
+def test_worker_status_pb_parses_version_fields_by_wire_number() -> None:
+    # field 12 = 100, field 13 = true, field 15 = 7
+    msg = engine_service_rpc_pb2.WorkerStatusPB.FromString(b"\x60\x64\x68\x01\x78\x07")
+
+    assert msg.status_version == 100
+    assert msg.alive is True
+    assert msg.latest_finished_version == 7
+
+
+def test_worker_status_pb_alive_false_by_default() -> None:
+    """Default WorkerStatusPB has alive=False."""
+    msg = engine_service_rpc_pb2.WorkerStatusPB()
+    assert msg.alive is False
+
+
+def test_rpc_path_is_rpc_service_get_worker_status() -> None:
+    """The full RPC path must be /RpcService/GetWorkerStatus (no package)."""
+    stub_cls = engine_service_rpc_pb2_grpc.RpcServiceStub
+    # Inspect the stub constructor source to verify path registration.
+    # We verify by creating a stub with a fake channel that captures the path.
+    paths: list[str] = []
+
+    class _PathCapture:
+        def unary_unary(self, path: str, **_: Any) -> Any:
+            paths.append(path)
+            return AsyncMock()
+
+    stub_cls(_PathCapture())
+    assert "/RpcService/GetWorkerStatus" in paths
+
+
+async def test_get_worker_status_sends_initial_flexlb_cursors(
+    mocker: Any,
+) -> None:
+    response = engine_service_rpc_pb2.WorkerStatusPB(
+        alive=True,
+        status_version=100,
+        latest_finished_version=7,
+    )
+    channel = _FakeGrpcChannel(response)
+    mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmWorkerStatusClient("127.0.0.1:18002")
+
+    result = await client.get_worker_status(timeout_s=2.0)
+
+    assert result is response
+    assert result.alive is True
+    assert "/RpcService/GetWorkerStatus" in channel.paths
+    assert len(channel.requests) == 1
+    request = channel.requests[0]
+    assert isinstance(request, engine_service_rpc_pb2.StatusVersionPB)
+    assert request.latest_cache_version == 0
+    assert request.latest_finished_version == -1
+    assert channel.timeouts == [2.0]
+
+
+async def test_get_worker_status_sends_response_finished_cursor_on_next_request(
+    mocker: Any,
+) -> None:
+    responses = [
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=100,
+            latest_finished_version=7,
+        ),
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=101,
+            latest_finished_version=8,
+        ),
+    ]
+    channel = _FakeGrpcChannel(responses)
+    mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmWorkerStatusClient("127.0.0.1:18002")
+
+    await client.get_worker_status(timeout_s=1.0)
+    await client.get_worker_status(timeout_s=1.0)
+
+    assert [request.latest_finished_version for request in channel.requests] == [-1, 7]
+
+
+async def test_get_worker_status_ignores_stale_response_cursor(mocker: Any) -> None:
+    responses = [
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=100,
+            latest_finished_version=7,
+        ),
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=99,
+            latest_finished_version=3,
+        ),
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=101,
+            latest_finished_version=8,
+        ),
+    ]
+    channel = _FakeGrpcChannel(responses)
+    mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmWorkerStatusClient("127.0.0.1:18002")
+
+    await client.get_worker_status(timeout_s=1.0)
+    await client.get_worker_status(timeout_s=1.0)
+    await client.get_worker_status(timeout_s=1.0)
+
+    assert [request.latest_finished_version for request in channel.requests] == [
+        -1,
+        7,
+        7,
+    ]
+
+
+async def test_get_worker_status_accepts_finished_cursor_reset_from_new_snapshot(
+    mocker: Any,
+) -> None:
+    responses = [
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=100,
+            latest_finished_version=7,
+        ),
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=False,
+            status_version=101,
+            latest_finished_version=0,
+        ),
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=102,
+            latest_finished_version=1,
+        ),
+    ]
+    channel = _FakeGrpcChannel(responses)
+    mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmWorkerStatusClient("127.0.0.1:18002")
+
+    await client.get_worker_status(timeout_s=1.0)
+    await client.get_worker_status(timeout_s=1.0)
+    await client.get_worker_status(timeout_s=1.0)
+
+    assert [request.latest_finished_version for request in channel.requests] == [
+        -1,
+        7,
+        0,
+    ]
+
+
+async def test_get_worker_status_ignores_zero_status_version(mocker: Any) -> None:
+    responses = [
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=0,
+            latest_finished_version=9,
+        ),
+        engine_service_rpc_pb2.WorkerStatusPB(
+            alive=True,
+            status_version=100,
+            latest_finished_version=10,
+        ),
+    ]
+    channel = _FakeGrpcChannel(responses)
+    mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmWorkerStatusClient("127.0.0.1:18002")
+
+    await client.get_worker_status(timeout_s=1.0)
+    await client.get_worker_status(timeout_s=1.0)
+
+    assert [request.latest_finished_version for request in channel.requests] == [-1, -1]
+
+
+async def test_get_worker_status_rpc_failure_does_not_advance_cursor(
+    mocker: Any,
+) -> None:
+    response = engine_service_rpc_pb2.WorkerStatusPB(
+        alive=True,
+        status_version=100,
+        latest_finished_version=7,
+    )
+    client = DashllmWorkerStatusClient("127.0.0.1:18002")
+    mock_stub = AsyncMock()
+    mock_stub.GetWorkerStatus = AsyncMock(
+        side_effect=[RuntimeError("rpc failed"), response]
+    )
+    mocker.patch.object(client, "_get_service", return_value=mock_stub)
+
+    with pytest.raises(RuntimeError, match="rpc failed"):
+        await client.get_worker_status(timeout_s=1.0)
+    await client.get_worker_status(timeout_s=1.0)
+
+    requests = [call.args[0] for call in mock_stub.GetWorkerStatus.await_args_list]
+    assert [request.latest_finished_version for request in requests] == [-1, -1]
+    assert [request.latest_cache_version for request in requests] == [0, 0]
+
+
+async def test_get_worker_status_uses_rpc_service_facade(mocker: Any) -> None:
+    """get_worker_status must use the dedicated remote-status facade."""
+    response = engine_service_rpc_pb2.WorkerStatusPB(alive=True)
+    client = DashllmWorkerStatusClient("127.0.0.1:18002")
+    mock_stub = AsyncMock()
+    mock_stub.GetWorkerStatus = AsyncMock(return_value=response)
+    mocker.patch.object(client, "_get_service", return_value=mock_stub)
+
+    result = await client.get_worker_status(timeout_s=1.5)
+
+    assert result is response
+    mock_stub.GetWorkerStatus.assert_awaited_once_with(
+        engine_service_rpc_pb2.StatusVersionPB(
+            latest_cache_version=0,
+            latest_finished_version=-1,
+        ),
+        timeout=1.5,
+    )
+
+
+# --- GetAllKvCacheBlocks proto and client tests ---
+
+
+def test_kv_cache_block_proto_field_numbers_match_dashllm() -> None:
+    list_descriptor = engine_service_rpc_pb2.KvCacheBlockListPB.DESCRIPTOR
+
+    assert list_descriptor.fields_by_name["raw_snapshot"].number == 1
+    assert list_descriptor.fields_by_name["snapshot_version"].number == 2
+    assert list_descriptor.fields_by_name["block_size"].number == 3
+
+
+def test_kv_cache_block_list_parses_raw_snapshot_by_wire_number() -> None:
+    msg = engine_service_rpc_pb2.KvCacheBlockListPB(
+        raw_snapshot=b"\x93\xa1a\xa1b\xa1c",
+        snapshot_version=42,
+        block_size=1072,
+    )
+    parsed = engine_service_rpc_pb2.KvCacheBlockListPB.FromString(
+        msg.SerializeToString()
+    )
+
+    assert parsed.raw_snapshot == b"\x93\xa1a\xa1b\xa1c"
+    assert parsed.snapshot_version == 42
+    assert parsed.block_size == 1072
+
+
+def test_rpc_path_is_control_service_get_all_kv_cache_blocks() -> None:
+    """The full RPC path must be package-free for DashLLM compatibility."""
+
+    paths: list[str] = []
+
+    class _PathCapture:
+        def unary_unary(self, path: str, **_: Any) -> Any:
+            paths.append(path)
+            return AsyncMock()
+
+    engine_service_rpc_pb2_grpc.KvEventControlServiceStub(_PathCapture())
+
+    assert "/KvEventControlService/GetAllKvCacheBlocks" in paths
+
+
+async def test_get_all_kv_cache_blocks_sends_empty_request_and_returns_response(
+    mocker: Any,
+) -> None:
+    response = engine_service_rpc_pb2.KvCacheBlockListPB(
+        block_size=16,
+        snapshot_version=42,
+    )
+    channel = _FakeGrpcChannel(response)
+    mocker.patch("grpc.aio.insecure_channel", return_value=channel)
+    client = DashllmKvEventControlClient("/tmp/dashllm-kv-event-control.sock")
+
+    result = await client.get_all_kv_cache_blocks(timeout_s=2.0)
+
+    assert result is response
+    assert "/KvEventControlService/GetAllKvCacheBlocks" in channel.paths
+    assert len(channel.requests) == 1
+    assert isinstance(
+        channel.requests[0],
+        engine_service_rpc_pb2.KvCacheBlocksRequestPB,
+    )
+    assert channel.timeouts == [2.0]

--- a/subscriber/tests/engine/test_interval_adjuster.py
+++ b/subscriber/tests/engine/test_interval_adjuster.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import pytest
+
+from subscriber.engine.interval_adjuster import DynamicIntervalAdjuster
+
+
+class TestDynamicIntervalAdjuster:
+    def test_initial_interval(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        assert adjuster.current_interval_s == 1.0
+
+    def test_no_adjustment_below_min_samples(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # First update: only 1 sample, no adjustment
+        adjuster.update(500)
+        assert adjuster.current_interval_s == 1.0
+
+        # Second update: only 2 samples, still no adjustment
+        adjuster.update(500)
+        assert adjuster.current_interval_s == 1.0
+
+    def test_no_adjustment_within_threshold(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # Feed 3 samples that average to exactly target (deviation = 0)
+        adjuster.update(100)
+        adjuster.update(100)
+        adjuster.update(100)
+        assert adjuster.current_interval_s == 1.0
+
+        # Feed samples averaging within 10% threshold
+        # 3 samples: 95, 100, 105 -> avg = 100, deviation = 0
+        adjuster.update(95)
+        adjuster.update(100)
+        adjuster.update(105)
+        assert adjuster.current_interval_s == 1.0
+
+    def test_shorten_interval_when_diff_large(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # Feed 3 samples well above target so rolling_avg >> target
+        # deviation > 10%, rolling_avg > target -> shorten by 30%
+        adjuster.update(200)
+        adjuster.update(200)
+        adjuster.update(200)
+        # avg = 200, deviation = (200-100)/100 = 1.0 > 0.1
+        # new_interval = 1.0 * (1 - 0.3) = 0.7
+        assert adjuster.current_interval_s == pytest.approx(0.7)
+
+    def test_lengthen_interval_when_diff_small(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # Feed 3 samples well below target so rolling_avg << target
+        # deviation < -10%, rolling_avg < target -> lengthen by 30%
+        adjuster.update(10)
+        adjuster.update(10)
+        adjuster.update(10)
+        # avg = 10, deviation = (10-100)/100 = -0.9, |deviation| > 0.1
+        # new_interval = 1.0 * (1 + 0.3) = 1.3
+        assert adjuster.current_interval_s == pytest.approx(1.3)
+
+    def test_clamp_to_min(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.5,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # Repeatedly shorten: 1.0 -> 0.7 -> 0.49 -> clamped to 0.5
+        adjuster.update(500)
+        adjuster.update(500)
+        adjuster.update(500)
+        # 1.0 * 0.7 = 0.7
+        assert adjuster.current_interval_s == pytest.approx(0.7)
+
+        adjuster.update(500)
+        # 0.7 * 0.7 = 0.49, clamped to 0.5
+        assert adjuster.current_interval_s == pytest.approx(0.5)
+
+    def test_clamp_to_max(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=2.0,
+            initial_interval_s=1.5,
+        )
+        # Repeatedly lengthen: 1.5 -> 1.95 -> 2.535 -> clamped to 2.0
+        adjuster.update(5)
+        adjuster.update(5)
+        adjuster.update(5)
+        # 1.5 * 1.3 = 1.95
+        assert adjuster.current_interval_s == pytest.approx(1.95)
+
+        adjuster.update(5)
+        # 1.95 * 1.3 = 2.535, clamped to 2.0
+        assert adjuster.current_interval_s == pytest.approx(2.0)
+
+    def test_rolling_average_smooths_spikes(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # Fill window with target-matching values
+        for _ in range(30):
+            adjuster.update(100)
+        assert adjuster.current_interval_s == 1.0
+
+        # One spike
+        adjuster.update(10000)
+        # Window: 29 * 100 + 10000 = 12900, avg = 12900/30 = 430
+        # deviation = (430 - 100) / 100 = 3.3 > 0.1 -> shorten
+        # new_interval = 1.0 * 0.7 = 0.7
+        # The spike caused ONE adjustment, not a wild swing
+        assert adjuster.current_interval_s == pytest.approx(0.7)
+
+    def test_reset_clears_state(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # Make some adjustments
+        adjuster.update(500)
+        adjuster.update(500)
+        adjuster.update(500)
+        assert adjuster.current_interval_s != 1.0
+
+        # Reset
+        adjuster.reset()
+        assert adjuster.current_interval_s == 1.0
+
+        # After reset, first 2 updates should not adjust (history cleared)
+        adjuster.update(500)
+        adjuster.update(500)
+        assert adjuster.current_interval_s == 1.0
+
+    def test_convergence(self) -> None:
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=5.0,
+        )
+        # Repeatedly feed a diff_size above target; interval should keep
+        # shrinking and eventually clamp to min
+        for _ in range(100):
+            adjuster.update(300)
+
+        # After many updates with consistently high diff, interval is at min
+        assert adjuster.current_interval_s == pytest.approx(0.1)
+
+    def test_window_is_rolling_not_cumulative(self) -> None:
+        """After WINDOW_SIZE samples, old values fall out of the window."""
+        adjuster = DynamicIntervalAdjuster(
+            target_diff_size=100,
+            min_interval_s=0.1,
+            max_interval_s=10.0,
+            initial_interval_s=1.0,
+        )
+        # Fill 30 samples at target
+        for _ in range(30):
+            adjuster.update(100)
+        interval_after_fill = adjuster.current_interval_s
+
+        # Now feed 30 more samples at a very different value
+        for _ in range(30):
+            adjuster.update(10)
+
+        # The old 100s have all fallen out; window is all 10s
+        # avg = 10, deviation = (10-100)/100 = -0.9 -> lengthen
+        # The interval should have been lengthened from whatever it was
+        assert adjuster.current_interval_s > interval_after_fill

--- a/subscriber/tests/engine/test_metadata.py
+++ b/subscriber/tests/engine/test_metadata.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from subscriber.engine.metadata import (
+    KvCacheDescriptor,
+    MetadataFetchError,
+    MetadataProtocolError,
+    MetadataTemporarilyUnavailable,
+    parse_kv_event_bootstrap,
+)
+from subscriber.proto import engine_service_rpc_pb2 as pb2
+from subscriber.types import KvCacheGroupSpec
+
+
+def _component(
+    component_id: int,
+    kind: str,
+    *,
+    block_size: int = 16,
+    payload_size: int | None = 1024,
+) -> pb2.CacheComponentPB:
+    geometry = pb2.CacheGeometryPB(block_size_tokens=block_size)
+    if payload_size is not None:
+        geometry.group_payload_size_bytes.value = payload_size
+    return pb2.CacheComponentPB(
+        component_id=component_id,
+        component_kind=kind,
+        geometry=geometry,
+    )
+
+
+def _bootstrap(engine_kind: str = "vllm") -> pb2.KvEventBootstrapInfoPB:
+    response = pb2.KvEventBootstrapInfoPB(
+        protocol_version=1,
+        engine_kind=engine_kind,
+        err_code=pb2.KV_EVENT_BOOTSTRAP_OK,
+    )
+    response.event_transport.live_endpoint = "tcp://127.0.0.1:5557"
+    response.event_transport.topic = "kv-events"
+    response.event_transport.replay_supported = True
+    response.event_transport.replay_endpoint = "tcp://127.0.0.1:5558"
+    response.event_transport.serialization = "msgpack-v1"
+    response.runtime_topology.data_parallel_size = 1
+    response.runtime_topology.tensor_parallel_size = 2
+    response.runtime_topology.pipeline_parallel_size = 1
+    response.snapshot.supported = engine_kind == "vllm"
+    response.snapshot.versioned = engine_kind == "vllm"
+    if engine_kind == "vllm":
+        response.vllm.event_schema_version = 2
+        response.vllm.use_eagle_pop = True
+        response.vllm.mamba_cache_mode = "none"
+        response.vllm.hash_algorithm = "sha256"
+        response.vllm.hash_version = "vllm-block-hash-v1"
+    else:
+        response.sglang.event_schema_version = 2
+        response.sglang.cache_key_mode = "token"
+        response.sglang.native_hash_algorithm = "sglang-radix-native-int64"
+    return response
+
+
+def test_parse_vllm_bootstrap_preserves_numeric_component_and_typed_settings() -> None:
+    response = _bootstrap()
+    component = response.components.add()
+    component.CopyFrom(_component(0, "full_attention"))
+    component.geometry.page_size_tokens.value = 16
+    component.compatibility_settings.add(
+        name="vllm.layer_names",
+        string_list=pb2.StringListPB(values=["layer.0", "layer.1"]),
+    )
+    response.compatibility_settings.add(
+        name="vllm.enable_prefix_caching", bool_value=True
+    )
+
+    bootstrap = parse_kv_event_bootstrap(response, expected_engine_kind="vllm")
+
+    assert bootstrap.engine_kind == "vllm"
+    assert bootstrap.event_transport.topic == "kv-events"
+    assert bootstrap.components[0].component_id == 0
+    assert bootstrap.components[0].geometry.group_payload_size_bytes == 1024
+    assert bootstrap.components[0].compatibility_settings == (
+        ("vllm.layer_names", ("layer.0", "layer.1")),
+    )
+    assert bootstrap.compatibility_settings == (("vllm.enable_prefix_caching", True),)
+    assert bootstrap.to_kv_cache_descriptor().use_eagle_pop is True
+
+
+def test_parse_sglang_bootstrap_keeps_payload_absent_for_kvcm_fallback() -> None:
+    response = _bootstrap("sglang")
+    response.components.add().CopyFrom(
+        _component(2, "mamba", block_size=128, payload_size=None)
+    )
+
+    bootstrap = parse_kv_event_bootstrap(response, expected_engine_kind="sglang")
+
+    assert bootstrap.components[0].component_id == 2
+    assert bootstrap.components[0].geometry.group_payload_size_bytes is None
+    descriptor = bootstrap.to_kv_cache_descriptor()
+    assert descriptor.groups[0].group_idx == 2
+    assert descriptor.groups[0].group_payload_size_bytes is None
+
+
+def test_parse_bootstrap_allows_empty_transport_without_incremental_pipeline() -> None:
+    response = _bootstrap()
+    response.event_transport.Clear()
+    response.components.add().CopyFrom(_component(0, "full_attention"))
+
+    bootstrap = parse_kv_event_bootstrap(
+        response,
+        expected_engine_kind="vllm",
+        require_incremental_transport=False,
+    )
+
+    assert bootstrap.event_transport.live_endpoint == ""
+    assert bootstrap.event_transport.replay_supported is False
+
+
+def test_parse_bootstrap_requires_event_transport_with_incremental_pipeline() -> None:
+    response = _bootstrap()
+    response.event_transport.Clear()
+    response.components.add().CopyFrom(_component(0, "full_attention"))
+
+    with pytest.raises(MetadataProtocolError, match="missing live_endpoint"):
+        parse_kv_event_bootstrap(response, expected_engine_kind="vllm")
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda response: setattr(response, "protocol_version", 99), "protocol"),
+        (lambda response: setattr(response, "engine_kind", "sglang"), "engine"),
+        (
+            lambda response: setattr(response.event_transport, "serialization", "json"),
+            "serialization",
+        ),
+    ],
+)
+def test_parse_bootstrap_rejects_incompatible_contract(mutate, match: str) -> None:
+    response = _bootstrap()
+    response.components.add().CopyFrom(_component(0, "full_attention"))
+    mutate(response)
+
+    with pytest.raises(MetadataProtocolError, match=match):
+        parse_kv_event_bootstrap(response, expected_engine_kind="vllm")
+
+
+def test_parse_bootstrap_rejects_duplicate_component_ids() -> None:
+    response = _bootstrap()
+    response.components.add().CopyFrom(_component(0, "full_attention"))
+    response.components.add().CopyFrom(_component(0, "mamba"))
+
+    with pytest.raises(MetadataProtocolError, match="duplicate component_id 0"):
+        parse_kv_event_bootstrap(response, expected_engine_kind="vllm")
+
+
+def test_parse_bootstrap_rejects_non_positive_block_size() -> None:
+    response = _bootstrap()
+    response.components.add().CopyFrom(_component(0, "full_attention", block_size=0))
+
+    with pytest.raises(MetadataProtocolError, match="invalid block_size_tokens 0"):
+        parse_kv_event_bootstrap(response, expected_engine_kind="vllm")
+
+
+@pytest.mark.parametrize(
+    ("settings", "match"),
+    [
+        ([pb2.TypedSettingPB(name="", string_value="value")], "empty setting name"),
+        (
+            [
+                pb2.TypedSettingPB(name="duplicate", bool_value=True),
+                pb2.TypedSettingPB(name="duplicate", bool_value=False),
+            ],
+            "duplicate setting name",
+        ),
+        ([pb2.TypedSettingPB(name="missing-value")], "has no typed value"),
+    ],
+)
+def test_parse_bootstrap_rejects_invalid_typed_settings(
+    settings: list[pb2.TypedSettingPB], match: str
+) -> None:
+    response = _bootstrap()
+    response.components.add().CopyFrom(_component(0, "full_attention"))
+    response.compatibility_settings.extend(settings)
+
+    with pytest.raises(MetadataProtocolError, match=match):
+        parse_kv_event_bootstrap(response, expected_engine_kind="vllm")
+
+
+def test_bootstrap_log_json_contains_transport_geometry_and_engine_schema() -> None:
+    response = _bootstrap()
+    response.components.add().CopyFrom(_component(0, "full_attention"))
+    bootstrap = parse_kv_event_bootstrap(response, expected_engine_kind="vllm")
+
+    payload = bootstrap.to_log_json()
+
+    assert '"live_endpoint": "tcp://127.0.0.1:5557"' in payload
+    assert '"component_kind": "full_attention"' in payload
+    assert '"event_schema_version": 2' in payload
+
+
+def test_kv_cache_descriptor_holds_groups_tuple() -> None:
+    spec = KvCacheGroupSpec(
+        group_idx=0,
+        kind="full_attention",
+        block_size=16,
+        sliding_window=None,
+        group_payload_size_bytes=1024,
+    )
+
+    assert KvCacheDescriptor(groups=(spec,)).groups == (spec,)
+
+
+def test_kv_cache_group_spec_can_mark_payload_size_unavailable() -> None:
+    spec = KvCacheGroupSpec(
+        group_idx=0,
+        kind="full_attention",
+        block_size=16,
+        group_payload_size_bytes=None,
+    )
+
+    assert spec.group_payload_size_bytes is None
+
+
+def test_kv_cache_descriptor_empty_groups_is_valid() -> None:
+    metadata = KvCacheDescriptor(groups=())
+
+    assert metadata.groups == ()
+
+
+def test_kv_cache_descriptor_is_frozen() -> None:
+    metadata = KvCacheDescriptor(groups=())
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        metadata.groups = ()
+
+
+def test_metadata_fetch_error_is_runtime_error() -> None:
+    assert issubclass(MetadataFetchError, RuntimeError)
+
+
+def test_metadata_error_subclasses_derive_from_base() -> None:
+    assert issubclass(MetadataTemporarilyUnavailable, MetadataFetchError)
+    assert issubclass(MetadataProtocolError, MetadataFetchError)
+
+
+def test_metadata_error_subclasses_are_catchable_as_base() -> None:
+    for exc_type in (MetadataTemporarilyUnavailable, MetadataProtocolError):
+        with pytest.raises(MetadataFetchError):
+            raise exc_type("boom")

--- a/subscriber/tests/engine/vllm/test_incremental.py
+++ b/subscriber/tests/engine/vllm/test_incremental.py
@@ -1,0 +1,1535 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import msgspec
+import pytest
+import zmq
+
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.base import EngineEventBatch
+from subscriber.engine.metadata import MetadataProtocolError
+from subscriber.engine.vllm import VllmAdapter
+from subscriber.engine.vllm import control as vllm_control_module
+from subscriber.engine.vllm import incremental as vllm_transport_module
+from subscriber.engine.vllm.incremental import VllmIncrementalSource
+from subscriber.health.events import LivenessEvent
+from subscriber.kvcm.enum import KvcmStorageType
+from subscriber.proto import engine_service_rpc_pb2
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    KVEventBatch,
+)
+
+
+@pytest.fixture
+def config() -> SubscriberConfig:
+    return SubscriberConfig(snapshot_kv_event_pipeline_enabled=True)
+
+
+def _dp_endpoint() -> DpEndpoint:
+    return DpEndpoint(
+        rank=0,
+        zmq_pub_endpoint="tcp://localhost:5557",
+        zmq_replay_endpoint="tcp://localhost:5558",
+    )
+
+
+def _encode_batch(batch: KVEventBatch) -> bytes:
+    return msgspec.msgpack.encode(batch)
+
+
+def _seq_bytes(seq: int) -> bytes:
+    return seq.to_bytes(8, "big")
+
+
+def _mock_adapter_sockets(mocker: Any) -> tuple[MagicMock, MagicMock]:
+    mock_sub = MagicMock()
+    mock_dealer = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.socket.side_effect = [mock_sub, mock_dealer]
+    mocker.patch(
+        "subscriber.engine.zmq_source.zmq.asyncio.Context.instance",
+        return_value=mock_ctx,
+    )
+    return mock_sub, mock_dealer
+
+
+def _mock_adapter_socket_sequence(mocker: Any, *sockets: MagicMock) -> MagicMock:
+    mock_ctx = MagicMock()
+    mock_ctx.socket.side_effect = list(sockets)
+    mocker.patch(
+        "subscriber.engine.zmq_source.zmq.asyncio.Context.instance",
+        return_value=mock_ctx,
+    )
+    return mock_ctx
+
+
+def _bootstrap_response() -> engine_service_rpc_pb2.KvEventBootstrapInfoPB:
+    response = engine_service_rpc_pb2.KvEventBootstrapInfoPB(
+        protocol_version=1,
+        engine_kind="vllm",
+        err_code=engine_service_rpc_pb2.KV_EVENT_BOOTSTRAP_OK,
+    )
+    response.event_transport.live_endpoint = "tcp://127.0.0.1:6557"
+    response.event_transport.topic = "kv-events"
+    response.event_transport.replay_supported = True
+    response.event_transport.replay_endpoint = "tcp://127.0.0.1:6558"
+    response.event_transport.serialization = "msgpack-v1"
+    response.runtime_topology.data_parallel_size = 1
+    response.runtime_topology.tensor_parallel_size = 1
+    response.runtime_topology.pipeline_parallel_size = 1
+    response.snapshot.supported = True
+    response.snapshot.versioned = True
+    response.vllm.event_schema_version = 2
+    response.vllm.mamba_cache_mode = "none"
+    response.vllm.hash_algorithm = "sha256"
+    response.vllm.hash_version = "vllm-block-hash-v1"
+    component = response.components.add(component_id=0, component_kind="full_attention")
+    component.geometry.block_size_tokens = 16
+    component.geometry.group_payload_size_bytes.value = 1024
+    return response
+
+
+class _MockDashllmClients:
+    def __init__(self, mocker: Any, response: object) -> None:
+        self.control = MagicMock()
+        self.control.get_kv_event_bootstrap_info = AsyncMock(return_value=response)
+        self.control.close = AsyncMock()
+        self.status = MagicMock()
+        self.status.get_worker_status = AsyncMock(
+            return_value=engine_service_rpc_pb2.WorkerStatusPB(alive=True)
+        )
+        self.status.close = AsyncMock()
+        mocker.patch(
+            "subscriber.engine.vllm.adapter.DashllmKvEventControlClient",
+            return_value=self.control,
+        )
+        mocker.patch(
+            "subscriber.engine.vllm.adapter.DashllmWorkerStatusClient",
+            return_value=self.status,
+        )
+
+
+def _mock_dashllm_clients(mocker: Any, response: object) -> _MockDashllmClients:
+    return _MockDashllmClients(mocker, response)
+
+
+def _make_rpc_error(code: grpc.StatusCode, details: str = "") -> grpc.aio.AioRpcError:
+    """Create a real AioRpcError for testing."""
+    return grpc.aio.AioRpcError(code, {}, {}, details, "")
+
+
+def test_adapter_composes_focused_transport_and_control_helpers(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+
+    transport_type = getattr(vllm_transport_module, "VllmIncrementalSource", None)
+    control_type = getattr(vllm_control_module, "VllmControl", None)
+
+    assert transport_type is not None
+    assert control_type is not None
+
+    adapter = VllmAdapter(config)
+
+    assert adapter._incremental is None
+    assert adapter._snapshot is None
+    assert isinstance(adapter._control, control_type)
+
+
+def test_adapter_storage_type_reflects_config(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+
+    adapter = VllmAdapter(config)
+    assert adapter.storage_type() == KvcmStorageType.ST_EVENT_REPORT_L1P5
+
+    config.kvcm_storage_type = "ST_CUSTOM"
+    assert adapter.storage_type() == "ST_CUSTOM"
+
+
+async def test_adapter_fetches_bootstrap_before_opening_engine_owned_zmq(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    sub, dealer = _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    adapter = VllmAdapter(config)
+
+    assert adapter._incremental is None
+    bootstrap = await adapter.fetch_kv_event_bootstrap()
+
+    assert bootstrap.components[0].component_id == 0
+    assert adapter._incremental is not None
+    assert adapter._snapshot is not None
+    sub.connect.assert_called_once_with("tcp://127.0.0.1:6557")
+    sub.setsockopt_string.assert_called_once_with(zmq.SUBSCRIBE, "kv-events")
+    dealer.connect.assert_called_once_with("tcp://127.0.0.1:6558")
+    clients.control.get_kv_event_bootstrap_info.assert_awaited_once_with(
+        config.engine_kv_event_bootstrap_timeout_ms / 1000
+    )
+
+
+async def test_adapter_accepts_snapshot_unsupported_when_pipeline_is_disabled(
+    mocker: Any,
+) -> None:
+    sub, dealer = _mock_adapter_sockets(mocker)
+    response = _bootstrap_response()
+    response.snapshot.supported = False
+    response.snapshot.versioned = False
+    _mock_dashllm_clients(mocker, response)
+    adapter = VllmAdapter(SubscriberConfig())
+
+    await adapter.fetch_kv_event_bootstrap()
+
+    assert adapter._incremental is not None
+    assert adapter._snapshot is None
+    sub.connect.assert_called_once()
+    dealer.connect.assert_called_once()
+
+
+async def test_adapter_accepts_snapshot_only_bootstrap_without_event_transport(
+    mocker: Any,
+) -> None:
+    response = _bootstrap_response()
+    response.event_transport.Clear()
+    _mock_dashllm_clients(mocker, response)
+    adapter = VllmAdapter(
+        SubscriberConfig(
+            incremental_kv_event_pipeline_enabled=False,
+            snapshot_kv_event_pipeline_enabled=True,
+        )
+    )
+
+    await adapter.fetch_kv_event_bootstrap()
+
+    assert adapter._incremental is None
+    assert adapter._snapshot is not None
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda response: setattr(
+                response.runtime_topology, "data_parallel_size", 2
+            ),
+            "data_parallel_size=1",
+        ),
+        (
+            lambda response: setattr(response.snapshot, "supported", False),
+            "snapshot transport must be supported",
+        ),
+        (
+            lambda response: setattr(response.snapshot, "versioned", False),
+            "snapshot transport must be versioned",
+        ),
+    ],
+)
+async def test_adapter_rejects_unsupported_bootstrap_contract(
+    config: SubscriberConfig,
+    mocker: Any,
+    mutate: Any,
+    match: str,
+) -> None:
+    response = _bootstrap_response()
+    mutate(response)
+    _mock_dashllm_clients(mocker, response)
+    adapter = VllmAdapter(config)
+
+    with pytest.raises(MetadataProtocolError, match=match):
+        await adapter.fetch_kv_event_bootstrap()
+
+
+async def test_adapter_close_before_bootstrap_only_closes_grpc(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    adapter = VllmAdapter(config)
+
+    await adapter.close()
+
+    clients.status.close.assert_awaited_once()
+    clients.control.close.assert_awaited_once()
+
+
+# --- gRPC-based watch_liveness tests ---
+
+
+async def test_watch_liveness_grpc_alive_true_is_healthy(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        return_value=engine_service_rpc_pb2.WorkerStatusPB(alive=True)
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 2:
+            break
+
+    assert events == [LivenessEvent.HEALTHY, LivenessEvent.HEALTHY]
+    assert clients.status.get_worker_status.await_count == 2
+    clients.status.get_worker_status.assert_awaited_with(
+        config.engine_kvcache_worker_status_timeout_ms / 1000
+    )
+
+
+async def test_watch_liveness_grpc_alive_false_is_unhealthy(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        return_value=engine_service_rpc_pb2.WorkerStatusPB(alive=False)
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+    mocker.patch("subscriber.engine.vllm.control.logger.warning")
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 1:
+            break
+
+    assert events == [LivenessEvent.UNHEALTHY]
+
+
+async def test_watch_liveness_grpc_deadline_exceeded_is_unhealthy(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        side_effect=_make_rpc_error(
+            grpc.StatusCode.DEADLINE_EXCEEDED, "deadline exceeded"
+        )
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+    mocker.patch("subscriber.engine.vllm.control.logger.warning")
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 1:
+            break
+
+    assert events == [LivenessEvent.UNHEALTHY]
+
+
+async def test_watch_liveness_grpc_unavailable_is_unhealthy(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        side_effect=_make_rpc_error(grpc.StatusCode.UNAVAILABLE, "connection refused")
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+    mocker.patch("subscriber.engine.vllm.control.logger.warning")
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 1:
+            break
+
+    assert events == [LivenessEvent.UNHEALTHY]
+
+
+async def test_watch_liveness_grpc_other_rpc_error_is_unhealthy(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        side_effect=_make_rpc_error(grpc.StatusCode.INTERNAL, "internal error")
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+    mocker.patch("subscriber.engine.vllm.control.logger.warning")
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 1:
+            break
+
+    assert events == [LivenessEvent.UNHEALTHY]
+
+
+async def test_watch_liveness_grpc_reraises_cancellation(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(side_effect=asyncio.CancelledError())
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+
+    adapter = VllmAdapter(config)
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in adapter.watch_liveness():
+            pass
+
+
+async def test_watch_liveness_logs_first_failure_not_every_poll(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """Only the first failure (transition) is logged, not every poll."""
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        return_value=engine_service_rpc_pb2.WorkerStatusPB(alive=False)
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+    warning = mocker.patch("subscriber.engine.vllm.control.logger.warning")
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 4:
+            break
+
+    assert events == [LivenessEvent.UNHEALTHY] * 4
+    # Only the first failure should produce a warning log
+    assert warning.call_count == 1
+
+
+async def test_watch_liveness_logs_recovery_transition(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """Recovery from unhealthy to healthy is logged."""
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        side_effect=[
+            engine_service_rpc_pb2.WorkerStatusPB(alive=False),
+            engine_service_rpc_pb2.WorkerStatusPB(alive=True),
+        ]
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+    warning = mocker.patch("subscriber.engine.vllm.control.logger.warning")
+    info = mocker.patch("subscriber.engine.vllm.control.logger.info")
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 2:
+            break
+
+    assert events == [LivenessEvent.UNHEALTHY, LivenessEvent.HEALTHY]
+    # First failure logged as warning
+    assert warning.call_count == 1
+    # Recovery logged as info
+    info.assert_any_call(
+        "engine health recovered",
+        step="engine_health",
+        tags={
+            "consecutive_failures_before_recovery": 1,
+            "target": config.engine_grpc_endpoint,
+        },
+    )
+
+
+async def test_watch_liveness_unexpected_error_is_unhealthy(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        side_effect=[
+            RuntimeError("boom"),
+            engine_service_rpc_pb2.WorkerStatusPB(alive=True),
+        ]
+    )
+    mocker.patch("subscriber.engine.vllm.control.asyncio.sleep", AsyncMock())
+    mocker.patch("subscriber.engine.vllm.control.logger.warning")
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 2:
+            break
+
+    assert events == [LivenessEvent.UNHEALTHY, LivenessEvent.HEALTHY]
+
+
+async def test_watch_liveness_polls_at_configured_interval(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        return_value=engine_service_rpc_pb2.WorkerStatusPB(alive=True)
+    )
+    sleep_mock = mocker.patch(
+        "subscriber.engine.vllm.control.asyncio.sleep", AsyncMock()
+    )
+
+    adapter = VllmAdapter(config)
+    events: list[LivenessEvent] = []
+    async for event in adapter.watch_liveness():
+        events.append(event)
+        if len(events) == 3:
+            break
+
+    # Events are yielded before the interval sleep, so the third event is
+    # observed after only two sleeps.
+    assert sleep_mock.await_count == 2
+    sleep_mock.assert_awaited_with(config.engine_health_interval_s)
+
+
+async def test_watch_liveness_yields_probe_result_before_interval_sleep(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """The probe result must reach the health coordinator immediately;
+    sleeping first would delay DEAD detection and gate reopening by one
+    full engine_health_interval_s."""
+
+    _mock_adapter_sockets(mocker)
+    clients = _mock_dashllm_clients(mocker, _bootstrap_response())
+    clients.status.get_worker_status = AsyncMock(
+        return_value=engine_service_rpc_pb2.WorkerStatusPB(alive=True)
+    )
+    sleep_mock = mocker.patch(
+        "subscriber.engine.vllm.control.asyncio.sleep", AsyncMock()
+    )
+
+    adapter = VllmAdapter(config)
+    async for event in adapter.watch_liveness():
+        assert event is LivenessEvent.HEALTHY
+        break
+
+    assert sleep_mock.await_count == 0
+
+
+# --- ZMQ transport tests ---
+
+
+def test_adapter_opens_sub_and_dealer_without_monitor(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+
+    VllmIncrementalSource(config, endpoint=_dp_endpoint())
+
+    mock_sub.connect.assert_called_once_with(_dp_endpoint().zmq_pub_endpoint)
+    mock_sub.setsockopt_string.assert_called_once()
+    mock_dealer.connect.assert_called_once_with(_dp_endpoint().zmq_replay_endpoint)
+    mock_sub.get_monitor_socket.assert_not_called()
+
+
+def test_component_validation_uses_group_idx_and_filters_only_invalid_events(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    source = VllmIncrementalSource(
+        config,
+        endpoint=_dp_endpoint(),
+        valid_component_ids={1},
+    )
+    valid = BlockStored(
+        block_hashes=[11],
+        parent_block_hash=None,
+        token_ids=[1, 2],
+        block_size=2,
+        lora_id=None,
+        medium="GPU",
+        lora_name=None,
+        group_idx=1,
+    )
+    unknown = BlockRemoved(block_hashes=[12], medium="GPU", group_idx=7)
+    missing = BlockRemoved(block_hashes=[13], medium="GPU")
+
+    decoded = source._decode_payload(
+        _encode_batch(KVEventBatch(ts=1.0, events=[valid, unknown, missing])),
+        step="decode",
+        tags={"source": "test"},
+    )
+
+    assert decoded is not None
+    assert decoded.events == [valid]
+
+
+async def test_live_receive_records_zmq_queue_backlog_signal(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    mock_sub, _ = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(return_value=[b"topic", _seq_bytes(7), b"body"])
+    mock_sub.getsockopt.return_value = zmq.POLLIN
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        return_value="live-trace",
+    )
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    diagnostics = mocker.Mock()
+    adapter._zmq_gap_diagnostics = diagnostics
+
+    assert await adapter._recv_live_message() == (7, b"body", "live-trace")
+
+    diagnostics.record_message.assert_called_once_with(
+        message_bytes=len(b"topic") + len(_seq_bytes(7)) + len(b"body"),
+        queue_nonempty_after_receive=True,
+    )
+
+
+def test_adapter_reports_current_zmq_queue_state(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    mock_sub, _ = _mock_adapter_sockets(mocker)
+    mock_sub.getsockopt.side_effect = lambda option: {
+        zmq.EVENTS: zmq.POLLIN,
+        zmq.RCVHWM: 1000,
+    }[option]
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+
+    assert adapter._zmq_queue_state() == {
+        "zmq_sub_readable": True,
+        "zmq_sub_rcvhwm": 1000,
+        "zmq_exact_queue_depth_available": False,
+    }
+
+
+def test_adapter_logs_zmq_endpoints_at_info(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    _mock_adapter_sockets(mocker)
+    info = mocker.patch("subscriber.engine.vllm.incremental.logger.info")
+
+    VllmIncrementalSource(config, endpoint=_dp_endpoint())
+
+    info.assert_any_call(
+        "connecting vLLM ZMQ sockets",
+        step="zmq_connect",
+        tags={
+            "pub_endpoint": _dp_endpoint().zmq_pub_endpoint,
+            "replay_endpoint": _dp_endpoint().zmq_replay_endpoint,
+            "topic": _dp_endpoint().zmq_topic,
+            "reconnect_ivl_ms": config.zmq_reconnect_ivl_ms,
+            "reconnect_ivl_max_ms": config.zmq_reconnect_ivl_max_ms,
+        },
+    )
+
+
+async def test_reset_generation_state_resets_seq_and_recreates_sockets(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    new_sub = MagicMock()
+    new_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, new_sub, new_dealer)
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    adapter._last_seq = 99
+
+    await adapter.reset_generation_state()
+
+    assert adapter._last_seq == -1
+    old_sub.close.assert_called_once_with(linger=0)
+    old_dealer.close.assert_called_once_with(linger=0)
+    new_sub.connect.assert_called_once_with(_dp_endpoint().zmq_pub_endpoint)
+    new_sub.setsockopt_string.assert_called_once()
+    new_dealer.connect.assert_called_once_with(_dp_endpoint().zmq_replay_endpoint)
+
+
+async def test_reset_generation_drops_inflight_live_message(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    new_sub = MagicMock()
+    new_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, new_sub, new_dealer)
+    recv_started = asyncio.Event()
+    release_recv = asyncio.Event()
+
+    async def recv_multipart() -> list[bytes]:
+        recv_started.set()
+        await release_recv.wait()
+        return [b"", _seq_bytes(0), payload]
+
+    old_sub.recv_multipart = AsyncMock(side_effect=recv_multipart)
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    receive_task = asyncio.create_task(adapter._recv_live_message())
+    await recv_started.wait()
+
+    await adapter.reset_generation_state()
+    release_recv.set()
+
+    assert await asyncio.wait_for(receive_task, timeout=1.0) is None
+    old_sub.close.assert_called_once_with(linger=0)
+    old_dealer.close.assert_called_once_with(linger=0)
+
+
+async def test_reset_generation_drops_inflight_replay_batches(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """Race scenario: reset lands between replay send and replay recv.
+
+    Without the generation guard, ``_replay_missing_batches`` would return
+    the stale replay batch decoded from the old dealer socket and the
+    subscribe loop would re-anchor ``_last_seq`` to a sequence belonging to
+    the previous engine instance.
+    """
+    stale_batch = KVEventBatch(ts=0.5, events=[AllBlocksCleared()])
+    stale_payload = _encode_batch(stale_batch)
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    new_sub = MagicMock()
+    new_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, new_sub, new_dealer)
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+    recv_started = asyncio.Event()
+    release_recv = asyncio.Event()
+
+    async def fake_send(_frames: list[bytes]) -> None:
+        send_started.set()
+        await release_send.wait()
+
+    async def fake_recv() -> list[bytes]:
+        recv_started.set()
+        await release_recv.wait()
+        return [b"", _seq_bytes(1), stale_payload]
+
+    old_dealer.send_multipart = AsyncMock(side_effect=fake_send)
+    old_dealer.recv_multipart = AsyncMock(side_effect=fake_recv)
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    adapter._last_seq = 0
+    replay_task = asyncio.create_task(
+        adapter._replay_missing_batches(5, 0, "replay-trace")
+    )
+    await send_started.wait()
+    release_send.set()
+    await recv_started.wait()
+
+    await adapter.reset_generation_state()
+    release_recv.set()
+
+    assert await asyncio.wait_for(replay_task, timeout=1.0) is None
+    old_sub.close.assert_called_once_with(linger=0)
+    old_dealer.close.assert_called_once_with(linger=0)
+    assert adapter._last_seq == -1, (
+        "reset must keep _last_seq at -1; replay must not have anchored it "
+        "to the stale batch's sequence"
+    )
+
+
+async def test_replay_missing_batches_uses_new_dealer_after_reset(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """After reset, a fresh replay call must use the new dealer socket and
+    succeed — proving generation advancement does not permanently disable
+    replay.
+    """
+    stale_batch = KVEventBatch(ts=0.5, events=[AllBlocksCleared()])
+    stale_payload = _encode_batch(stale_batch)
+    fresh_batch = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    fresh_payload = _encode_batch(fresh_batch)
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    new_sub = MagicMock()
+    new_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, new_sub, new_dealer)
+    recv_started = asyncio.Event()
+    release_recv = asyncio.Event()
+
+    async def stale_recv() -> list[bytes]:
+        recv_started.set()
+        await release_recv.wait()
+        return [b"", _seq_bytes(1), stale_payload]
+
+    old_dealer.send_multipart = AsyncMock()
+    old_dealer.recv_multipart = AsyncMock(side_effect=stale_recv)
+    new_dealer.send_multipart = AsyncMock()
+    new_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(1), fresh_payload],
+            [b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    adapter._last_seq = 0
+    stale_task = asyncio.create_task(
+        adapter._replay_missing_batches(5, 0, "stale-trace")
+    )
+    await recv_started.wait()
+
+    await adapter.reset_generation_state()
+    release_recv.set()
+    assert await asyncio.wait_for(stale_task, timeout=1.0) is None
+
+    result = await adapter._replay_missing_batches(
+        5, adapter._generation, "fresh-trace"
+    )
+    assert result == [fresh_batch]
+    new_dealer.send_multipart.assert_awaited_once_with([b"", (0).to_bytes(8, "big")])
+
+
+async def _collect_n(adapter: VllmAdapter, n: int) -> list[list[KVEventBatch]]:
+    events = await _collect_events_n(adapter, n)
+    return [event.batches for event in events]
+
+
+async def _collect_events_n(adapter: VllmAdapter, n: int) -> list[EngineEventBatch]:
+    results: list[EngineEventBatch] = []
+
+    async def _run() -> None:
+        async for event in adapter.subscribe():
+            results.append(event)
+            if len(results) >= n:
+                break
+
+    await asyncio.wait_for(_run(), timeout=1.0)
+    return results
+
+
+async def test_live_event_carries_decode_span(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+    mock_sub, _ = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(return_value=[b"", _seq_bytes(0), payload])
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    events = await _collect_events_n(adapter, 1)
+
+    spans = events[0].telemetry.spans
+    assert [span.name for span in spans] == ["decode"]
+    assert spans[0].duration_s >= 0
+
+
+async def test_replayed_event_carries_replay_fetch_span(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+    replay_batch = KVEventBatch(ts=0.5, events=[AllBlocksCleared()])
+    replay_payload = _encode_batch(replay_batch)
+
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(1), payload],
+            [b"", _seq_bytes(2), payload],
+        ]
+    )
+    mock_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), replay_payload],
+            [b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+    mock_dealer.send_multipart = AsyncMock()
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    events = await _collect_events_n(adapter, 1)
+
+    spans = events[0].telemetry.spans
+    assert [span.name for span in spans] == ["replay_fetch"]
+    assert spans[0].duration_s >= 0
+
+
+async def test_yields_single_batch_no_gap(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), payload],
+            [b"", _seq_bytes(1), payload],
+        ]
+    )
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 2)
+
+    assert len(results) == 2
+    assert len(results[0]) == 1
+    assert len(results[1]) == 1
+    mock_dealer.send_multipart.assert_not_called()
+
+
+async def test_recv_live_message_logs_debug_metadata(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+    mock_sub, _ = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(return_value=[b"topic", _seq_bytes(7), payload])
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.logger.is_debug_enabled", return_value=True
+    )
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        return_value="live-trace",
+    )
+    debug = mocker.patch("subscriber.engine.vllm.incremental.logger.debug")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    assert await adapter._recv_live_message() == (7, payload, "live-trace")
+
+    debug.assert_any_call(
+        "received vLLM ZMQ live message",
+        step="zmq_subscribe",
+        tags={
+            "topic": "topic",
+            "seq": 7,
+            "payload_bytes": len(payload),
+            "trace_id": "live-trace",
+        },
+    )
+
+
+async def test_subscribe_logs_decoded_event_types_and_block_hashes(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=[11, (1 << 63) + 1],
+                parent_block_hash=None,
+                token_ids=[1, 2, 3],
+                block_size=16,
+                lora_id=None,
+                medium="gpu",
+                lora_name=None,
+            ),
+            BlockRemoved(block_hashes=[33], medium="gpu"),
+            AllBlocksCleared(),
+        ],
+        data_parallel_rank=2,
+    )
+    payload = _encode_batch(batch)
+    mock_sub, _ = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(return_value=[b"", _seq_bytes(0), payload])
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.logger.is_debug_enabled", return_value=True
+    )
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        return_value="live-trace",
+    )
+    debug = mocker.patch("subscriber.engine.vllm.incremental.logger.debug")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 1)
+
+    assert results == [[batch]]
+    debug.assert_any_call(
+        "decoded vLLM KV event batch",
+        step="zmq_subscribe",
+        tags={
+            "seq": 0,
+            "trace_id": "live-trace",
+            "event_count": 3,
+            "event_types": "AllBlocksCleared:1,BlockRemoved:1,BlockStored:1",
+            "data_parallel_rank": 2,
+            "stored_block_count": 1,
+            "stored_blocks": [
+                {
+                    "block_hashes": ["11", "9223372036854775809"],
+                    "parent_block_hash": None,
+                    "block_size": 16,
+                    "lora_id": None,
+                    "medium": "gpu",
+                    "lora_name": None,
+                    "extra_keys": None,
+                    "group_idx": None,
+                    "component_id": None,
+                    "kv_cache_spec_kind": None,
+                    "kv_cache_spec_sliding_window": None,
+                    "snapshot_version": 0,
+                }
+            ],
+            "stored_blocks_truncated": False,
+            "removed_block_count": 1,
+            "removed_blocks": [
+                {
+                    "block_hashes": ["33"],
+                    "medium": "gpu",
+                    "group_idx": None,
+                    "component_id": None,
+                    "remaining_copy_counts": None,
+                    "snapshot_version": 0,
+                }
+            ],
+            "removed_blocks_truncated": False,
+        },
+    )
+
+
+async def test_recv_live_message_skips_debug_when_disabled(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+    mock_sub, _ = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(return_value=[b"topic", _seq_bytes(7), payload])
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.logger.is_debug_enabled", return_value=False
+    )
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        return_value="live-trace",
+    )
+    debug = mocker.patch("subscriber.engine.vllm.incremental.logger.debug")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    assert await adapter._recv_live_message() == (7, payload, "live-trace")
+
+    debug.assert_not_called()
+
+
+async def test_triggers_replay_on_gap(config: SubscriberConfig, mocker: Any) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+    missed_batch = KVEventBatch(ts=0.5, events=[AllBlocksCleared()])
+    missed_payload = _encode_batch(missed_batch)
+
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), payload],
+            [b"", _seq_bytes(2), payload],
+        ]
+    )
+    END_SEQ = (-1).to_bytes(8, "big", signed=True)
+    mock_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(1), missed_payload],
+            [b"", END_SEQ, b""],
+        ]
+    )
+    mock_dealer.send_multipart = AsyncMock()
+    mock_sub.getsockopt.side_effect = lambda option: {
+        zmq.EVENTS: 0,
+        zmq.RCVHWM: 1000,
+    }[option]
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        side_effect=["first-live-trace", "second-live-trace", "replay-trace"],
+    )
+    warning = mocker.patch("subscriber.engine.vllm.incremental.logger.warning")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    events = await _collect_events_n(adapter, 3)
+
+    assert len(events) == 3
+    assert len(events[1].batches) == 1
+    mock_dealer.send_multipart.assert_called_once_with([b"", (1).to_bytes(8, "big")])
+    # After the refactor, the gap warning only carries static socket state
+    # plus the per-window byte / queue-nonempty observations. Cumulative
+    # gap/miss counters are attached to the replay batch's BatchTelemetry
+    # so downstream dashboards can attribute the loss to the batch that
+    # exposed it.
+    warning.assert_any_call(
+        "kv event sequence gap detected, triggering replay",
+        step="zmq_replay",
+        tags={
+            "last_seq": 0,
+            "current_seq": 2,
+            "missed": 1,
+            "trace_id": "replay-trace",
+            "zmq_sub_readable": False,
+            "zmq_sub_rcvhwm": 1000,
+            "zmq_exact_queue_depth_available": False,
+            "zmq_received_message_bytes": 2 * (8 + len(payload)),
+            "zmq_queue_nonempty_observation_count": 0,
+        },
+    )
+    replay_event = events[1]
+    assert replay_event.telemetry.counters == {
+        "zmq_sequence_gap_count": 1,
+        "zmq_missed_message_count": 1,
+    }
+
+
+async def test_replay_logs_decoded_event_types_and_block_hashes(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    live_batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    live_payload = _encode_batch(live_batch)
+    replay_batch = KVEventBatch(
+        ts=0.5,
+        events=[
+            BlockStored(
+                block_hashes=[44, 55],
+                parent_block_hash=None,
+                token_ids=[4, 5],
+                block_size=16,
+                lora_id=None,
+                medium="gpu",
+                lora_name=None,
+            )
+        ],
+        data_parallel_rank=1,
+    )
+    replay_payload = _encode_batch(replay_batch)
+
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), live_payload],
+            [b"", _seq_bytes(2), live_payload],
+        ]
+    )
+    mock_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(1), replay_payload],
+            [b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+    mock_dealer.send_multipart = AsyncMock()
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.logger.is_debug_enabled", return_value=True
+    )
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        side_effect=["first-live-trace", "second-live-trace", "replay-trace"],
+    )
+    debug = mocker.patch("subscriber.engine.vllm.incremental.logger.debug")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    await _collect_n(adapter, 3)
+
+    debug.assert_any_call(
+        "decoded vLLM KV event batch",
+        step="zmq_replay",
+        tags={
+            "gap_start_seq": 1,
+            "current_seq": 2,
+            "replay_seq": 1,
+            "trace_id": "replay-trace",
+            "event_count": 1,
+            "event_types": "BlockStored:1",
+            "data_parallel_rank": 1,
+            "stored_block_count": 1,
+            "stored_blocks": [
+                {
+                    "block_hashes": ["44", "55"],
+                    "parent_block_hash": None,
+                    "block_size": 16,
+                    "lora_id": None,
+                    "medium": "gpu",
+                    "lora_name": None,
+                    "extra_keys": None,
+                    "group_idx": None,
+                    "component_id": None,
+                    "kv_cache_spec_kind": None,
+                    "kv_cache_spec_sliding_window": None,
+                    "snapshot_version": 0,
+                }
+            ],
+            "stored_blocks_truncated": False,
+            "removed_block_count": 0,
+            "removed_blocks": [],
+            "removed_blocks_truncated": False,
+        },
+    )
+
+
+async def test_skips_bad_live_payload_without_advancing_sequence(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    payload = _encode_batch(batch)
+    replay_batch = KVEventBatch(ts=0.5, events=[AllBlocksCleared()])
+    replay_payload = _encode_batch(replay_batch)
+
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), b"not msgpack"],
+            [b"", _seq_bytes(1), payload],
+        ]
+    )
+    mock_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), replay_payload],
+            [b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+    mock_dealer.send_multipart = AsyncMock()
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 2)
+
+    assert results == [[replay_batch], [batch]]
+    mock_dealer.send_multipart.assert_called_once_with([b"", (0).to_bytes(8, "big")])
+
+
+async def test_replay_pr_45177_four_frames_filters_current_and_newer_seqs(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """vLLM PR #45177 replay replies include topic, so DEALER receives four
+    frames. The replay endpoint returns every buffered batch with seq >=
+    gap_start_seq, including the live batch that exposed the gap and any newer
+    batches. Only the missing range must be forwarded via replay; the rest
+    arrive live."""
+
+    batch0 = KVEventBatch(ts=0.0, events=[AllBlocksCleared()])
+    batch1 = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    batch2 = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    batch3 = KVEventBatch(ts=3.0, events=[AllBlocksCleared()])
+
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), _encode_batch(batch0)],
+            [b"", _seq_bytes(2), _encode_batch(batch2)],
+            [b"", _seq_bytes(3), _encode_batch(batch3)],
+        ]
+    )
+    mock_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", b"", _seq_bytes(1), _encode_batch(batch1)],
+            [b"", b"", _seq_bytes(2), _encode_batch(batch2)],
+            [b"", b"", _seq_bytes(3), _encode_batch(batch3)],
+            [b"", b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+    mock_dealer.send_multipart = AsyncMock()
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 4)
+
+    assert results == [[batch0], [batch1], [batch2], [batch3]]
+    mock_dealer.send_multipart.assert_awaited_once_with([b"", (1).to_bytes(8, "big")])
+
+
+async def test_successful_replay_advances_sequence_despite_live_decode_failure(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """A completed replay resolves the gap up to current_seq - 1. If the live
+    payload that exposed the gap then fails to decode, the next live message
+    must not replay the already-forwarded range again."""
+
+    batch0 = KVEventBatch(ts=0.0, events=[AllBlocksCleared()])
+    batch1 = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    batch2 = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    batch3 = KVEventBatch(ts=3.0, events=[AllBlocksCleared()])
+
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    mock_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), _encode_batch(batch0)],
+            [b"", _seq_bytes(2), b"not msgpack"],
+            [b"", _seq_bytes(3), _encode_batch(batch3)],
+        ]
+    )
+    mock_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            # First replay for gap [1, 1].
+            [b"", b"", _seq_bytes(1), _encode_batch(batch1)],
+            [b"", b"", (-1).to_bytes(8, "big", signed=True), b""],
+            # Second replay must request the undecoded live seq 2, not seq 1.
+            [b"", b"", _seq_bytes(2), _encode_batch(batch2)],
+            [b"", b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+    mock_dealer.send_multipart = AsyncMock()
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 4)
+
+    assert results == [[batch0], [batch1], [batch2], [batch3]]
+    assert mock_dealer.send_multipart.await_args_list == [
+        mocker.call([b"", (1).to_bytes(8, "big")]),
+        mocker.call([b"", (2).to_bytes(8, "big")]),
+    ]
+
+
+@pytest.mark.parametrize("abort_reason", ["malformed_frames", "decode_failure"])
+async def test_replay_abort_replaces_dealer_socket(
+    config: SubscriberConfig, mocker: Any, abort_reason: str
+) -> None:
+    """Malformed frames or a decode failure abort the replay mid-stream; the
+    DEALER socket must be replaced so leftover frames (later batches and the
+    END marker) cannot poison the next replay request."""
+
+    batch0 = KVEventBatch(ts=0.0, events=[AllBlocksCleared()])
+    batch2 = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    batch3 = KVEventBatch(ts=3.0, events=[AllBlocksCleared()])
+    batch4 = KVEventBatch(ts=4.0, events=[AllBlocksCleared()])
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    replacement_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, replacement_dealer)
+    old_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), _encode_batch(batch0)],
+            [b"", _seq_bytes(2), _encode_batch(batch2)],
+            [b"", _seq_bytes(4), _encode_batch(batch4)],
+        ]
+    )
+    if abort_reason == "malformed_frames":
+        aborting_frames = [b"", _seq_bytes(1)]
+    else:
+        aborting_frames = [b"", _seq_bytes(1), b"not msgpack"]
+    old_dealer.send_multipart = AsyncMock()
+    old_dealer.recv_multipart = AsyncMock(side_effect=[aborting_frames])
+    replacement_dealer.send_multipart = AsyncMock()
+    replacement_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(3), _encode_batch(batch3)],
+            [b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 4)
+
+    assert results == [[batch0], [batch2], [batch3], [batch4]]
+    old_dealer.close.assert_called_once_with(linger=0)
+    replacement_dealer.send_multipart.assert_awaited_once_with(
+        [b"", (3).to_bytes(8, "big")]
+    )
+
+
+@pytest.mark.parametrize("failure_point", ["send", "recv"])
+async def test_replay_transport_failure_forwards_current_and_later_live_batches(
+    config: SubscriberConfig, mocker: Any, failure_point: str
+) -> None:
+    first_batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    gapped_batch = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    later_batch = KVEventBatch(ts=3.0, events=[AllBlocksCleared()])
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    replacement_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, replacement_dealer)
+    old_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), _encode_batch(first_batch)],
+            [b"", _seq_bytes(2), _encode_batch(gapped_batch)],
+            [b"", _seq_bytes(3), _encode_batch(later_batch)],
+        ]
+    )
+    if failure_point == "send":
+        old_dealer.send_multipart = AsyncMock(side_effect=zmq.ZMQError("down"))
+    else:
+        old_dealer.send_multipart = AsyncMock()
+        old_dealer.recv_multipart = AsyncMock(side_effect=zmq.ZMQError("down"))
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        side_effect=[
+            "first-live-trace",
+            "second-live-trace",
+            "replay-trace",
+            "later-live-trace",
+        ],
+    )
+    warning = mocker.patch("subscriber.engine.vllm.incremental.logger.warning")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 3)
+
+    assert results == [[first_batch], [gapped_batch], [later_batch]]
+    assert old_dealer.send_multipart.await_count == 1
+    old_dealer.close.assert_called_once_with(linger=0)
+    warning.assert_any_call(
+        "kv event replay unavailable; sequence gap remains; forwarding live batch",
+        step="zmq_replay",
+        tags={
+            "gap_start_seq": 1,
+            "current_seq": 2,
+            "error": "ZMQError",
+            "message": "down",
+            "trace_id": "replay-trace",
+        },
+    )
+
+
+async def test_replay_timeout_forwards_current_live_batch(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    config.zmq_replay_timeout_s = 0.01
+    first_batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    gapped_batch = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    replacement_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, replacement_dealer)
+    old_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), _encode_batch(first_batch)],
+            [b"", _seq_bytes(2), _encode_batch(gapped_batch)],
+        ]
+    )
+    old_dealer.send_multipart = AsyncMock()
+
+    async def wait_forever() -> list[bytes]:
+        await asyncio.Event().wait()
+        return []
+
+    old_dealer.recv_multipart = AsyncMock(side_effect=wait_forever)
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        side_effect=["first-live-trace", "second-live-trace", "replay-trace"],
+    )
+    warning = mocker.patch("subscriber.engine.vllm.incremental.logger.warning")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 2)
+
+    assert results == [[first_batch], [gapped_batch]]
+    old_dealer.close.assert_called_once_with(linger=0)
+    warning.assert_any_call(
+        "kv event replay unavailable; sequence gap remains; forwarding live batch",
+        step="zmq_replay",
+        tags={
+            "gap_start_seq": 1,
+            "current_seq": 2,
+            "error": "TimeoutError",
+            "message": "replay timed out",
+            "trace_id": "replay-trace",
+        },
+    )
+
+
+async def test_replay_send_timeout_forwards_current_live_batch(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    config.zmq_replay_timeout_s = 0.01
+    first_batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    gapped_batch = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    replacement_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, replacement_dealer)
+    old_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), _encode_batch(first_batch)],
+            [b"", _seq_bytes(2), _encode_batch(gapped_batch)],
+        ]
+    )
+
+    async def wait_forever(_frames: list[bytes]) -> None:
+        await asyncio.Event().wait()
+
+    old_dealer.send_multipart = AsyncMock(side_effect=wait_forever)
+    mocker.patch(
+        "subscriber.engine.vllm.incremental.generate_trace_id",
+        side_effect=["first-live-trace", "second-live-trace", "replay-trace"],
+    )
+    warning = mocker.patch("subscriber.engine.vllm.incremental.logger.warning")
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 2)
+
+    assert results == [[first_batch], [gapped_batch]]
+    old_dealer.close.assert_called_once_with(linger=0)
+    warning.assert_any_call(
+        "kv event replay unavailable; sequence gap remains; forwarding live batch",
+        step="zmq_replay",
+        tags={
+            "gap_start_seq": 1,
+            "current_seq": 2,
+            "error": "TimeoutError",
+            "message": "replay timed out",
+            "trace_id": "replay-trace",
+        },
+    )
+
+
+async def test_replacement_replay_socket_recovers_a_later_gap(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    first_batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    first_gapped_batch = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    later_batch = KVEventBatch(ts=3.0, events=[AllBlocksCleared()])
+    replayed_batch = KVEventBatch(ts=4.0, events=[AllBlocksCleared()])
+    second_gapped_batch = KVEventBatch(ts=5.0, events=[AllBlocksCleared()])
+    old_sub = MagicMock()
+    old_dealer = MagicMock()
+    replacement_dealer = MagicMock()
+    _mock_adapter_socket_sequence(mocker, old_sub, old_dealer, replacement_dealer)
+    old_sub.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(0), _encode_batch(first_batch)],
+            [b"", _seq_bytes(2), _encode_batch(first_gapped_batch)],
+            [b"", _seq_bytes(3), _encode_batch(later_batch)],
+            [b"", _seq_bytes(5), _encode_batch(second_gapped_batch)],
+        ]
+    )
+    old_dealer.send_multipart = AsyncMock(side_effect=zmq.ZMQError("down"))
+    replacement_dealer.send_multipart = AsyncMock()
+    replacement_dealer.recv_multipart = AsyncMock(
+        side_effect=[
+            [b"", _seq_bytes(4), _encode_batch(replayed_batch)],
+            [b"", (-1).to_bytes(8, "big", signed=True), b""],
+        ]
+    )
+
+    adapter = VllmIncrementalSource(config, endpoint=_dp_endpoint())
+    results = await _collect_n(adapter, 5)
+
+    assert results == [
+        [first_batch],
+        [first_gapped_batch],
+        [later_batch],
+        [replayed_batch],
+        [second_gapped_batch],
+    ]
+    replacement_dealer.send_multipart.assert_awaited_once_with(
+        [b"", (4).to_bytes(8, "big")]
+    )
+
+
+def test_adapter_configures_sub_socket_transport(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    config.zmq_reconnect_ivl_ms = 250
+    config.zmq_reconnect_ivl_max_ms = 4000
+    config.zmq_tcp_keepalive = True
+    config.zmq_tcp_keepalive_idle_s = 9
+    config.zmq_tcp_keepalive_intvl_s = 3
+    config.zmq_tcp_keepalive_cnt = 5
+
+    VllmIncrementalSource(config, endpoint=_dp_endpoint())
+
+    mock_sub.setsockopt.assert_any_call(zmq.RECONNECT_IVL, 250)
+    mock_sub.setsockopt.assert_any_call(zmq.RECONNECT_IVL_MAX, 4000)
+    mock_sub.setsockopt.assert_any_call(zmq.TCP_KEEPALIVE, 1)
+    mock_sub.setsockopt.assert_any_call(zmq.TCP_KEEPALIVE_IDLE, 9)
+    mock_sub.setsockopt.assert_any_call(zmq.TCP_KEEPALIVE_INTVL, 3)
+    mock_sub.setsockopt.assert_any_call(zmq.TCP_KEEPALIVE_CNT, 5)
+
+
+def test_adapter_disables_keepalive_when_configured(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    mock_sub, mock_dealer = _mock_adapter_sockets(mocker)
+    config.zmq_tcp_keepalive = False
+
+    VllmIncrementalSource(config, endpoint=_dp_endpoint())
+
+    mock_sub.setsockopt.assert_any_call(zmq.TCP_KEEPALIVE, 0)

--- a/subscriber/tests/engine/vllm/test_integration.py
+++ b/subscriber/tests/engine/vllm/test_integration.py
@@ -1,0 +1,580 @@
+"""Integration tests: real ZMQ and gRPC sockets, no mocks.
+
+Exercises VllmAdapter against a FakeVllmPublisher that reproduces the wire
+protocol of vllm.distributed.kv_events.ZmqEventPublisher (PUB 3-frame
+multipart with msgspec.msgpack payloads, plus ROUTER/DEALER replay replies
+with delimiter, topic, 8-byte big-endian sequence number, and payload after
+vLLM PR #45177) without depending on the vllm package itself. The snapshot test
+additionally hosts an in-process
+DashLLM ``RpcService`` over a real gRPC channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import grpc
+import msgspec
+import pytest
+import zmq
+import zmq.asyncio
+
+from subscriber.config import DpEndpoint, SubscriberConfig
+from subscriber.engine.metadata import KvCacheDescriptor
+from subscriber.engine.vllm import VllmAdapter
+from subscriber.engine.vllm.incremental import VllmIncrementalSource
+from subscriber.forwarding import (
+    consume_incremental_events,
+    consume_snapshot_events,
+    send_incremental_events,
+    send_snapshot_events,
+)
+from subscriber.kvcm.base import AbstractKvCacheManagerClient
+from subscriber.kvcm.client import KvcmClient
+from subscriber.kvcm.enum import KvcmReportEventType
+from subscriber.pipeline.context import PipelineContext
+from subscriber.proto import (
+    engine_service_rpc_pb2,
+    engine_service_rpc_pb2_grpc,
+)
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockSnapshot,
+    BlockSnapshotItem,
+    BlockStored,
+    KVEventBatch,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class FakeVllmPublisher:
+    """Minimal stand-in for ZmqEventPublisher that speaks its exact wire
+    protocol over real ZMQ sockets."""
+
+    END_SEQ = (-1).to_bytes(8, "big", signed=True)
+
+    def __init__(self, topic: str = "") -> None:
+        self._ctx = zmq.asyncio.Context.instance()
+        self._pub: zmq.asyncio.Socket = self._ctx.socket(zmq.PUB)
+        self._pub.bind("tcp://127.0.0.1:0")
+        self._router: zmq.asyncio.Socket = self._ctx.socket(zmq.ROUTER)
+        self._router.bind("tcp://127.0.0.1:0")
+        self._topic_bytes = topic.encode("utf-8")
+        self._buffer: list[tuple[int, bytes]] = []
+        self._replay_task: asyncio.Task[None] | None = None
+
+    @property
+    def pub_endpoint(self) -> str:
+        return self._pub.getsockopt_string(zmq.LAST_ENDPOINT)
+
+    @property
+    def replay_endpoint(self) -> str:
+        return self._router.getsockopt_string(zmq.LAST_ENDPOINT)
+
+    def start_replay_server(self) -> None:
+        self._replay_task = asyncio.create_task(self._serve_replay_loop())
+
+    async def _serve_replay_loop(self) -> None:
+        while True:
+            client_id, _, start_seq_bytes = await self._router.recv_multipart()
+            start_seq = int.from_bytes(start_seq_bytes, "big")
+            for seq, payload in self._buffer:
+                if seq >= start_seq:
+                    await self._router.send_multipart(
+                        [
+                            client_id,
+                            b"",
+                            self._topic_bytes,
+                            seq.to_bytes(8, "big"),
+                            payload,
+                        ]
+                    )
+            await self._router.send_multipart([client_id, b"", b"", self.END_SEQ, b""])
+
+    async def publish(self, seq: int, batch: KVEventBatch) -> None:
+        """Send live on the wire and record in the replay buffer."""
+        payload = msgspec.msgpack.encode(batch)
+        self._buffer.append((seq, payload))
+        await self._pub.send_multipart(
+            [self._topic_bytes, seq.to_bytes(8, "big"), payload]
+        )
+
+    def record_dropped(self, seq: int, batch: KVEventBatch) -> None:
+        """Simulate a message lost in transit: kept in the replay buffer
+        only, never sent live, so a later gap must be filled via replay."""
+        payload = msgspec.msgpack.encode(batch)
+        self._buffer.append((seq, payload))
+
+    async def publish_until_delivered(
+        self,
+        seq: int,
+        batch: KVEventBatch,
+        delivered: asyncio.Event,
+        interval: float = 0.02,
+    ) -> None:
+        """Work around the PUB/SUB slow-joiner race by resending until the
+        subscriber confirms receipt. Safe because ZMQ PUB never queues a
+        message for a socket that connects after it was sent, so at most
+        one resend actually reaches the subscriber."""
+        payload = msgspec.msgpack.encode(batch)
+        if not any(existing_seq == seq for existing_seq, _ in self._buffer):
+            self._buffer.append((seq, payload))
+        while not delivered.is_set():
+            await self._pub.send_multipart(
+                [self._topic_bytes, seq.to_bytes(8, "big"), payload]
+            )
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(delivered.wait(), timeout=interval)
+
+    async def close(self) -> None:
+        if self._replay_task is not None:
+            self._replay_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._replay_task
+        self._pub.close(linger=0)
+        self._router.close(linger=0)
+
+
+class FakeDashllmSnapshotService(
+    engine_service_rpc_pb2_grpc.KvEventControlServiceServicer
+):
+    """In-process DashLLM RPC peer for the full-snapshot wire boundary."""
+
+    def __init__(
+        self,
+        response: engine_service_rpc_pb2.KvCacheBlockListPB,
+        publisher: FakeVllmPublisher | None = None,
+    ) -> None:
+        self._response = response
+        self._publisher = publisher
+        self.requests: list[engine_service_rpc_pb2.KvCacheBlocksRequestPB] = []
+
+    async def GetKvEventBootstrapInfo(
+        self,
+        request: engine_service_rpc_pb2.KvEventBootstrapInfoRequestPB,
+        context: grpc.aio.ServicerContext,
+    ) -> engine_service_rpc_pb2.KvEventBootstrapInfoPB:
+        del request, context
+        response = engine_service_rpc_pb2.KvEventBootstrapInfoPB(
+            protocol_version=1,
+            engine_kind="vllm",
+            err_code=engine_service_rpc_pb2.KV_EVENT_BOOTSTRAP_OK,
+        )
+        response.event_transport.live_endpoint = (
+            self._publisher.pub_endpoint
+            if self._publisher is not None
+            else "tcp://127.0.0.1:6557"
+        )
+        response.event_transport.topic = ""
+        response.event_transport.replay_supported = True
+        response.event_transport.replay_endpoint = (
+            self._publisher.replay_endpoint
+            if self._publisher is not None
+            else "tcp://127.0.0.1:6558"
+        )
+        response.event_transport.serialization = "msgpack-v1"
+        response.runtime_topology.data_parallel_size = 1
+        response.runtime_topology.tensor_parallel_size = 1
+        response.runtime_topology.pipeline_parallel_size = 1
+        response.snapshot.supported = True
+        response.snapshot.versioned = True
+        response.vllm.event_schema_version = 2
+        response.vllm.mamba_cache_mode = "none"
+        response.vllm.hash_algorithm = "sha256"
+        response.vllm.hash_version = "vllm-block-hash-v1"
+        response.components.add(
+            component_id=0,
+            component_kind="full_attention",
+        ).geometry.block_size_tokens = 16
+        return response
+
+    async def GetAllKvCacheBlocks(
+        self,
+        request: engine_service_rpc_pb2.KvCacheBlocksRequestPB,
+        context: grpc.aio.ServicerContext,
+    ) -> engine_service_rpc_pb2.KvCacheBlockListPB:
+        self.requests.append(request)
+        return self._response
+
+
+def _incremental_source(
+    config: SubscriberConfig,
+    publisher: FakeVllmPublisher,
+) -> VllmIncrementalSource:
+    return VllmIncrementalSource(
+        config,
+        endpoint=DpEndpoint(
+            rank=0,
+            zmq_pub_endpoint=publisher.pub_endpoint,
+            zmq_replay_endpoint=publisher.replay_endpoint,
+        ),
+    )
+
+
+def _short_uds_path() -> Path:
+    """Keep the macOS AF_UNIX path below its 104-byte limit."""
+
+    return Path("/tmp") / f"kv-event-test-{uuid4().hex[:12]}.sock"
+
+
+class FakeKvcmSignalManager(AbstractKvCacheManagerClient):
+    """In-process KVCM transport that asks for a snapshot after a live add."""
+
+    def __init__(self) -> None:
+        self.incremental_requests: list[dict[str, Any]] = []
+        self.snapshot_requests: list[dict[str, Any]] = []
+        self.incremental_reported = asyncio.Event()
+
+    async def start(self) -> None:
+        return None
+
+    async def is_ready(self) -> bool:
+        return True
+
+    async def register_instance(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        return {"header": {"status": {"code": "OK"}}}
+
+    async def report_event(
+        self, data: dict[str, Any], check_response: bool = True
+    ) -> dict[str, Any]:
+        event_type = data["events"][0]["event_type"]
+        if event_type == KvcmReportEventType.BLOCK_ADD:
+            self.incremental_requests.append(data)
+            self.incremental_reported.set()
+            return {
+                "header": {"status": {"code": "OK"}},
+                "snapshot_required": True,
+            }
+        if event_type == KvcmReportEventType.BLOCK_SNAPSHOT:
+            self.snapshot_requests.append(data)
+        return {"header": {"status": {"code": "OK"}}}
+
+    async def close(self) -> None:
+        return None
+
+
+class AlwaysReadyCoordinator:
+    """Minimal ready epoch contract used to exercise both forwarding tasks."""
+
+    def capture_epoch(self) -> int:
+        return 1
+
+    async def wait_ready_epoch(self) -> int:
+        return 1
+
+    def is_epoch_current(self, epoch: int) -> bool:
+        return epoch == 1
+
+
+async def _stop_consumer(consumer: asyncio.Task[None]) -> None:
+    consumer.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await consumer
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    while not predicate():
+        await asyncio.sleep(0.01)
+
+
+async def test_real_zmq_publisher_delivers_single_event() -> None:
+    publisher = FakeVllmPublisher()
+    config = SubscriberConfig()
+    source = _incremental_source(config, publisher)
+
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=[1, 2],
+                parent_block_hash=None,
+                token_ids=[10, 20, 30],
+                block_size=16,
+                lora_id=None,
+                medium="GPU",
+                lora_name=None,
+            )
+        ],
+    )
+
+    delivered = asyncio.Event()
+    results: list[list[KVEventBatch]] = []
+
+    async def _consume() -> None:
+        async for received in source.subscribe():
+            results.append(received.batches)
+            delivered.set()
+            break
+
+    consumer = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(
+            publisher.publish_until_delivered(0, batch, delivered), timeout=5.0
+        )
+        await asyncio.wait_for(consumer, timeout=5.0)
+    finally:
+        await _stop_consumer(consumer)
+        await publisher.close()
+
+    assert results == [[batch]]
+
+
+async def test_sequence_gap_triggers_pr_45177_four_frame_real_replay() -> None:
+    """A real ROUTER/DEALER round trip accepts the topic-bearing replay reply
+    introduced in vLLM PR #45177 and yields each sequence exactly once."""
+
+    publisher = FakeVllmPublisher()
+    publisher.start_replay_server()
+    config = SubscriberConfig()
+    source = _incremental_source(config, publisher)
+
+    batch0 = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    dropped_batch1 = KVEventBatch(ts=2.0, events=[AllBlocksCleared()])
+    batch2 = KVEventBatch(ts=3.0, events=[AllBlocksCleared()])
+
+    delivered = asyncio.Event()
+    results: list[list[KVEventBatch]] = []
+
+    async def _consume() -> None:
+        async for received in source.subscribe():
+            results.append(received.batches)
+            delivered.set()
+            if len(results) >= 3:
+                break
+
+    consumer = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(
+            publisher.publish_until_delivered(0, batch0, delivered), timeout=5.0
+        )
+        publisher.record_dropped(1, dropped_batch1)
+        await publisher.publish(2, batch2)
+        await asyncio.wait_for(consumer, timeout=5.0)
+    finally:
+        await _stop_consumer(consumer)
+        await publisher.close()
+
+    # The publisher's replay buffer returns every batch with seq >= start_seq,
+    # including the live batch that exposed the gap. The adapter filters the
+    # replay stream to the missing range only, so the triggering live batch
+    # is forwarded exactly once.
+    assert results == [[batch0], [dropped_batch1], [batch2]]
+
+
+async def test_real_zmq_backlog_is_recorded_after_one_message_is_received() -> None:
+    publisher = FakeVllmPublisher()
+    config = SubscriberConfig()
+    source = _incremental_source(config, publisher)
+    batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+    warmup_received = asyncio.Event()
+
+    async def _receive_warmup() -> tuple[int, bytes] | None:
+        received = await source._recv_live_message()
+        warmup_received.set()
+        return received
+
+    warmup = asyncio.create_task(_receive_warmup())
+    try:
+        await asyncio.wait_for(
+            publisher.publish_until_delivered(0, batch, warmup_received), timeout=5.0
+        )
+        assert (await asyncio.wait_for(warmup, timeout=5.0))[0] == 0
+
+        queue_metrics = MagicMock()
+        source._zmq_queue_metrics = queue_metrics
+        await publisher.publish(1, batch)
+        await publisher.publish(2, batch)
+        await asyncio.sleep(0.05)
+
+        assert (await source._recv_live_message())[0] == 1
+        assert (await source._recv_live_message())[0] == 2
+    finally:
+        await _stop_consumer(warmup)
+        source._sub.close(linger=0)
+        source._dealer.close(linger=0)
+        await publisher.close()
+
+
+async def test_real_dashllm_grpc_snapshot_yields_full_kv_cache_blocks() -> None:
+    import msgspec.msgpack
+
+    items = [(b"\xaa", 0, 3, 1), (b"\xbb", 2, 7, 1)]
+    response = engine_service_rpc_pb2.KvCacheBlockListPB(
+        raw_snapshot=msgspec.msgpack.encode(items),
+        block_size=16,
+        snapshot_version=9,
+    )
+    service = FakeDashllmSnapshotService(response)
+    server = grpc.aio.server()
+    engine_service_rpc_pb2_grpc.add_KvEventControlServiceServicer_to_server(
+        service, server
+    )
+    uds_path = _short_uds_path()
+    bound = server.add_insecure_port(f"unix://{uds_path}")
+    assert bound == 1
+    await server.start()
+
+    adapter = VllmAdapter(
+        SubscriberConfig(
+            engine_kv_event_control_uds_path=str(uds_path),
+            engine_snapshot_full_sync_interval_s=60.0,
+            snapshot_kv_event_pipeline_enabled=True,
+        )
+    )
+    try:
+        await adapter.fetch_kv_event_bootstrap()
+        events = adapter.subscribe_snapshot_events()
+        event = await asyncio.wait_for(events.__anext__(), timeout=5.0)
+    finally:
+        if "events" in locals():
+            await events.aclose()
+        await adapter.close()
+        await server.stop(None)
+        uds_path.unlink(missing_ok=True)
+
+    assert service.requests == [engine_service_rpc_pb2.KvCacheBlocksRequestPB()]
+    assert len(event.batches) == 1
+    assert event.batches[0].events == [
+        BlockSnapshot(
+            medium="GPU",
+            block_size=16,
+            items=[
+                BlockSnapshotItem(block_hash=b"\xaa", group_idx=0),
+                BlockSnapshotItem(block_hash=b"\xbb", group_idx=2),
+            ],
+            snapshot_version=9,
+        )
+    ]
+    assert [span.name for span in event.telemetry.spans] == [
+        "snapshot_fetch",
+        "decode",
+        "snapshot_build",
+    ]
+
+
+async def test_snapshot_required_signal_runs_snapshot_pipeline_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """KVCM's signal wakes snapshot polling without stopping incremental sends."""
+
+    import msgspec.msgpack
+
+    response = engine_service_rpc_pb2.KvCacheBlockListPB(
+        raw_snapshot=msgspec.msgpack.encode([(b"\xaa", 0, 3, 1)]),
+        block_size=16,
+        snapshot_version=9,
+    )
+    publisher = FakeVllmPublisher()
+    snapshot_service = FakeDashllmSnapshotService(response, publisher)
+    grpc_server = grpc.aio.server()
+    engine_service_rpc_pb2_grpc.add_KvEventControlServiceServicer_to_server(
+        snapshot_service, grpc_server
+    )
+    uds_path = _short_uds_path()
+    bound = grpc_server.add_insecure_port(f"unix://{uds_path}")
+    assert bound == 1
+    await grpc_server.start()
+
+    manager = FakeKvcmSignalManager()
+    config = SubscriberConfig(
+        engine_kv_event_control_uds_path=str(uds_path),
+        engine_snapshot_full_sync_interval_s=60.0,
+        snapshot_kv_event_pipeline_enabled=True,
+        kvcm_base_url="spectrum://vs-test:6382",
+        kvcm_heartbeat_interval_s=60.0,
+    )
+    adapter = VllmAdapter(config)
+    await adapter.fetch_kv_event_bootstrap()
+    kvcm = KvcmClient(
+        config,
+        medium_mapper=adapter.map_medium,
+        storage_type=adapter.storage_type(),
+        supported_mediums=adapter.supported_mediums(),
+        descriptor=KvCacheDescriptor(groups=()),
+        manager_client=manager,
+    )
+
+    async def resolve_host_ip_port(port: int) -> str:
+        return "127.0.0.1:9000"
+
+    monkeypatch.setattr(
+        "subscriber.kvcm.client.resolve_host_ip_port", resolve_host_ip_port
+    )
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-integration")
+    await kvcm.start()
+
+    coordinator = AlwaysReadyCoordinator()
+    incremental_queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    snapshot_queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    incremental_producer = asyncio.create_task(
+        consume_incremental_events(adapter, coordinator, incremental_queue, MagicMock())
+    )
+    incremental_sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            incremental_queue,
+            on_snapshot_required=adapter.request_immediate_snapshot,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    snapshot_producer = asyncio.create_task(
+        consume_snapshot_events(adapter, coordinator, snapshot_queue, MagicMock())
+    )
+    snapshot_sender = asyncio.create_task(
+        send_snapshot_events(kvcm, coordinator, snapshot_queue)
+    )
+
+    try:
+        await asyncio.wait_for(
+            _wait_until(lambda: len(manager.snapshot_requests) == 1), timeout=5.0
+        )
+        await asyncio.wait_for(
+            publisher.publish_until_delivered(
+                0,
+                KVEventBatch(
+                    ts=1.0,
+                    events=[
+                        BlockStored(
+                            block_hashes=[1],
+                            parent_block_hash=None,
+                            token_ids=[10],
+                            block_size=16,
+                            lora_id=None,
+                            medium="GPU",
+                            lora_name=None,
+                            group_idx=0,
+                        )
+                    ],
+                ),
+                manager.incremental_reported,
+            ),
+            timeout=5.0,
+        )
+        await asyncio.wait_for(
+            _wait_until(lambda: len(manager.snapshot_requests) >= 2), timeout=5.0
+        )
+
+        assert manager.incremental_requests
+        assert len(snapshot_service.requests) >= 2
+        assert not incremental_sender.done()
+    finally:
+        await _stop_consumer(incremental_producer)
+        await _stop_consumer(incremental_sender)
+        await _stop_consumer(snapshot_producer)
+        await _stop_consumer(snapshot_sender)
+        await kvcm.close()
+        await adapter.close()
+        await publisher.close()
+        await grpc_server.stop(None)
+        uds_path.unlink(missing_ok=True)

--- a/subscriber/tests/engine/vllm/test_snapshot.py
+++ b/subscriber/tests/engine/vllm/test_snapshot.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import ANY, AsyncMock, MagicMock
+
+import grpc
+import msgspec.msgpack
+import pytest
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine import snapshot as snapshot_module
+from subscriber.engine.base import EngineEventBatch
+from subscriber.engine.vllm.snapshot import VllmSnapshotSource
+from subscriber.metrics import BatchTelemetry
+from subscriber.proto import engine_service_rpc_pb2
+from subscriber.types import BlockSnapshot, BlockSnapshotItem
+
+
+@pytest.fixture
+def config() -> SubscriberConfig:
+    return SubscriberConfig()
+
+
+def _snapshot_response(
+    *,
+    block_hashes: list[bytes] | None = None,
+    block_hashes_uint64: list[int] | None = None,
+    block_size: int = 16,
+    snapshot_version: int = 0,
+) -> engine_service_rpc_pb2.KvCacheBlockListPB:
+    items: list[tuple] = []
+    idx = 0
+    for block_hash in block_hashes or []:
+        items.append((block_hash, idx, 0, 0))
+        idx += 1
+    for block_hash in block_hashes_uint64 or []:
+        items.append((block_hash, idx, 0, 0))
+        idx += 1
+    return engine_service_rpc_pb2.KvCacheBlockListPB(
+        raw_snapshot=msgspec.msgpack.encode(items),
+        block_size=block_size,
+        snapshot_version=snapshot_version,
+    )
+
+
+def _make_grpc_error() -> grpc.aio.AioRpcError:
+    return grpc.aio.AioRpcError(
+        code=grpc.StatusCode.UNAVAILABLE,
+        initial_metadata=None,
+        trailing_metadata=None,
+        details="engine down",
+        debug_error_string=None,
+    )
+
+
+async def _collect_events(source: VllmSnapshotSource, n: int) -> list[EngineEventBatch]:
+    results: list[EngineEventBatch] = []
+
+    async def _run() -> None:
+        async for event in source.subscribe():
+            results.append(event)
+            if len(results) >= n:
+                break
+
+    await asyncio.wait_for(_run(), timeout=1.0)
+    return results
+
+
+async def test_subscribe_yields_snapshot_with_version(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        return_value=_snapshot_response(
+            block_hashes=[b"\x01", b"\x02"], snapshot_version=7
+        )
+    )
+    mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    events = await _collect_events(source, 1)
+
+    grpc_client.get_all_kv_cache_blocks.assert_awaited_once_with(
+        timeout_s=config.engine_kvcache_snapshot_timeout_ms / 1000,
+    )
+    assert len(events) == 1
+    batches = events[0].batches
+    assert len(batches) == 1
+    assert batches[0].events == [
+        BlockSnapshot(
+            medium="GPU",
+            block_size=16,
+            items=[
+                BlockSnapshotItem(block_hash=b"\x01", group_idx=0),
+                BlockSnapshotItem(block_hash=b"\x02", group_idx=1),
+            ],
+            snapshot_version=7,
+        )
+    ]
+    spans = events[0].telemetry.spans
+    assert [span.name for span in spans] == [
+        "snapshot_fetch",
+        "decode",
+        "snapshot_build",
+    ]
+    assert all(span.duration_s >= 0 for span in spans)
+    assert events[0].telemetry.drop_reason is None
+
+
+async def test_subscribe_yields_uint64_block_hashes(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        return_value=_snapshot_response(
+            block_hashes_uint64=[10400093841463714284, 2], snapshot_version=3
+        )
+    )
+    mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    events = await _collect_events(source, 1)
+
+    assert events[0].batches[0].events == [
+        BlockSnapshot(
+            medium="GPU",
+            block_size=16,
+            items=[
+                BlockSnapshotItem(block_hash=10400093841463714284, group_idx=0),
+                BlockSnapshotItem(block_hash=2, group_idx=1),
+            ],
+            snapshot_version=3,
+        )
+    ]
+
+
+async def test_success_records_latency_payload_and_fetch_count(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    response = _snapshot_response(block_hashes=[b"\x01", b"\x02"])
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(return_value=response)
+    mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    events = await _collect_events(source, 1)
+
+    telemetry = events[0].telemetry
+    assert telemetry.counters == {}
+    assert telemetry.gauges["full_snapshot_payload_bytes"] == response.ByteSize()
+
+
+async def test_debug_log_reports_snapshot_fetch_span_not_build_span(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        return_value=_snapshot_response(block_hashes=[b"\x01"])
+    )
+    telemetry = BatchTelemetry(
+        pipeline="snapshot",
+        clock=MagicMock(side_effect=[0.0, 0.05, 0.1, 0.2]),
+    )
+    mocker.patch.object(snapshot_module, "BatchTelemetry", return_value=telemetry)
+    mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    mocker.patch(
+        "subscriber.engine.snapshot.logger.is_debug_enabled", return_value=True
+    )
+    debug = mocker.patch("subscriber.engine.snapshot.logger.debug")
+    source = VllmSnapshotSource(config, grpc_client)
+
+    await _collect_events(source, 1)
+
+    debug.assert_called_once_with(
+        "snapshot poll completed",
+        step="grpc_snapshot",
+        tags={
+            "block_count": 1,
+            "snapshot_version": 0,
+            "payload_bytes": _snapshot_response(block_hashes=[b"\x01"]).ByteSize(),
+            "fetch_ms": 50.0,
+            "trace_id": ANY,
+        },
+    )
+
+
+async def test_subscribe_retries_on_grpc_error(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        side_effect=[
+            _make_grpc_error(),
+            _snapshot_response(block_hashes=[b"\x09"]),
+        ]
+    )
+    warning = mocker.patch("subscriber.engine.snapshot.logger.warning")
+    wait_mock = mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    # Two events are now yielded: one drop-marker for the failed poll and
+    # one successful snapshot from the retry.
+    events = await _collect_events(source, 2)
+
+    assert grpc_client.get_all_kv_cache_blocks.await_count == 2
+    warning.assert_called_once()
+    assert warning.call_args.kwargs["tags"]["code"] == "UNAVAILABLE"
+
+    failed = events[0].telemetry
+    assert events[0].batches == []
+    assert failed.drop_reason == "fetch_failed"
+    assert failed.counters == {}
+    assert [s.name for s in failed.spans] == ["snapshot_fetch"]
+    assert "full_snapshot_payload_bytes" not in failed.gauges
+
+    success = events[1].telemetry
+    assert success.drop_reason is None
+    assert success.counters == {}
+    assert success.gauges["full_snapshot_payload_bytes"] == (
+        _snapshot_response(block_hashes=[b"\x09"]).ByteSize()
+    )
+
+    # The failed poll must wait one full interval before retrying.
+    wait_mock.assert_awaited_with(config.engine_snapshot_full_sync_interval_s)
+
+
+async def test_reset_discards_inflight_result(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    grpc_client = MagicMock()
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+
+    async def slow_poll(timeout_s: float) -> object:
+        poll_started.set()
+        await release_poll.wait()
+        return _snapshot_response(block_hashes=[b"\xaa"])
+
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(side_effect=slow_poll)
+    mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    gen = source.subscribe()
+    discarded_task = asyncio.create_task(gen.__anext__())
+    await poll_started.wait()
+
+    await source.reset_generation_state()
+    release_poll.set()
+
+    # First yield is the discarded stale result (drop_reason set, no batches).
+    discarded_event = await asyncio.wait_for(discarded_task, timeout=1.0)
+    assert discarded_event.batches == []
+    assert discarded_event.telemetry.drop_reason == "generation_reset"
+
+    # After the discard the source polls again and yields the fresh snapshot.
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        return_value=_snapshot_response(block_hashes=[b"\xbb"])
+    )
+    fresh_event = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert fresh_event.batches[0].events == [
+        BlockSnapshot(
+            medium="GPU",
+            block_size=16,
+            items=[BlockSnapshotItem(block_hash=b"\xbb", group_idx=0)],
+            snapshot_version=0,
+        )
+    ]
+    assert fresh_event.telemetry.drop_reason is None
+    await gen.aclose()
+
+
+async def test_stale_response_marks_generation_reset_drop(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    grpc_client = MagicMock()
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+
+    async def slow_poll(timeout_s: float) -> object:
+        poll_started.set()
+        await release_poll.wait()
+        return _snapshot_response(block_hashes=[b"\xaa"])
+
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(side_effect=slow_poll)
+    mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    gen = source.subscribe()
+    discarded_task = asyncio.create_task(gen.__anext__())
+    await poll_started.wait()
+
+    await source.reset_generation_state()
+    release_poll.set()
+
+    discarded = await asyncio.wait_for(discarded_task, timeout=1.0)
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        return_value=_snapshot_response(block_hashes=[b"\xbb"])
+    )
+    fresh = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    await gen.aclose()
+
+    assert discarded.telemetry.drop_reason == "generation_reset"
+    # Discarded telemetry still records fetch_count, latency, and payload
+    # bytes: the response arrived (so its size is a real measurement), the
+    # subscriber is only choosing to discard the *content*. Reporting the
+    # size lets dashboards distinguish an empty snapshot from a missing
+    # observation.
+    assert discarded.telemetry.counters == {}
+    assert [s.name for s in discarded.telemetry.spans] == ["snapshot_fetch"]
+    assert (
+        discarded.telemetry.gauges["full_snapshot_payload_bytes"]
+        == _snapshot_response(block_hashes=[b"\xaa"]).ByteSize()
+    )
+    assert fresh.telemetry.drop_reason is None
+
+
+async def test_fixed_interval_from_config(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    config.engine_snapshot_full_sync_interval_s = 42.0
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        return_value=_snapshot_response(block_hashes=[b"\x01"])
+    )
+    wait_mock = mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    await _collect_events(source, 3)
+
+    # The collector breaks on the third yield before its trailing wait, so two
+    # waits are observed. Every poll must wait the configured fixed interval
+    # (no dynamic backoff).
+    assert wait_mock.await_count == 2
+    for call in wait_mock.await_args_list:
+        assert call.args == (42.0,)
+
+
+async def test_subscribe_retries_on_unexpected_error(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        side_effect=[
+            ConnectionResetError("peer reset"),
+            _snapshot_response(block_hashes=[b"\x01"]),
+        ]
+    )
+    warning = mocker.patch("subscriber.engine.snapshot.logger.warning")
+    wait_mock = mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    events = await _collect_events(source, 2)
+
+    assert grpc_client.get_all_kv_cache_blocks.await_count == 2
+    warning.assert_called_once()
+    assert warning.call_args.kwargs["tags"]["error"] == "ConnectionResetError"
+    assert events[0].batches == []
+    assert events[0].telemetry.drop_reason == "fetch_failed"
+    assert events[1].telemetry.drop_reason is None
+    wait_mock.assert_awaited_with(config.engine_snapshot_full_sync_interval_s)
+
+
+async def test_sleeps_interval_after_successful_poll(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    config.engine_snapshot_full_sync_interval_s = 10.0
+    grpc_client = MagicMock()
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(
+        return_value=_snapshot_response(block_hashes=[b"\x01"])
+    )
+    wait_mock = mocker.patch.object(VllmSnapshotSource, "_wait_interval", AsyncMock())
+    source = VllmSnapshotSource(config, grpc_client)
+
+    await _collect_events(source, 2)
+
+    wait_mock.assert_awaited_once_with(10.0)

--- a/subscriber/tests/engine/vllm/test_snapshot_signal.py
+++ b/subscriber/tests/engine/vllm/test_snapshot_signal.py
@@ -1,0 +1,251 @@
+"""Tests for VllmSnapshotSource.request_immediate_snapshot signal mechanism."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import msgspec.msgpack
+import pytest
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine import snapshot as snapshot_module
+from subscriber.engine.vllm.snapshot import VllmSnapshotSource
+from subscriber.proto import engine_service_rpc_pb2
+
+
+@pytest.fixture
+def config() -> SubscriberConfig:
+    cfg = SubscriberConfig()
+    cfg.engine_snapshot_full_sync_interval_s = 30.0
+    return cfg
+
+
+def _snapshot_response(
+    *, block_hashes: list[bytes] | None = None
+) -> engine_service_rpc_pb2.KvCacheBlockListPB:
+    items: list[tuple] = []
+    for idx, bh in enumerate(block_hashes or []):
+        items.append((bh, idx, 0, 0))
+    return engine_service_rpc_pb2.KvCacheBlockListPB(
+        raw_snapshot=msgspec.msgpack.encode(items),
+        block_size=16,
+        snapshot_version=1,
+    )
+
+
+def _make_source(
+    config: SubscriberConfig,
+    responses: list[Any] | None = None,
+) -> tuple[VllmSnapshotSource, MagicMock]:
+    grpc_client = MagicMock()
+    if responses is not None:
+        grpc_client.get_all_kv_cache_blocks = AsyncMock(side_effect=responses)
+    else:
+        grpc_client.get_all_kv_cache_blocks = AsyncMock(
+            return_value=_snapshot_response(block_hashes=[b"\x01"])
+        )
+    source = VllmSnapshotSource(config, grpc_client)
+    return source, grpc_client
+
+
+async def test_signal_wakes_poll_before_interval(config: SubscriberConfig) -> None:
+    """request_immediate_snapshot wakes the source without waiting full interval."""
+    source, grpc_client = _make_source(config)
+
+    gen = source.subscribe()
+    first_task = asyncio.create_task(gen.__anext__())
+    first_event = await asyncio.wait_for(first_task, timeout=1.0)
+    assert first_event.telemetry.drop_reason is None
+
+    # Source is now in _wait_interval. Signal it.
+    source.request_immediate_snapshot()
+
+    # The next poll should complete quickly (not after 30s).
+    second_task = asyncio.create_task(gen.__anext__())
+    second_event = await asyncio.wait_for(second_task, timeout=1.0)
+    assert second_event.telemetry.drop_reason is None
+    assert grpc_client.get_all_kv_cache_blocks.await_count == 2
+    await gen.aclose()
+
+
+async def test_coalesce_multiple_signals_into_one_poll(
+    config: SubscriberConfig,
+) -> None:
+    """Multiple signals before consumption yield only one extra poll."""
+    source, grpc_client = _make_source(config)
+
+    gen = source.subscribe()
+    first = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert first.telemetry.drop_reason is None
+
+    # Signal multiple times while source is waiting.
+    source.request_immediate_snapshot()
+    source.request_immediate_snapshot()
+    source.request_immediate_snapshot()
+
+    # Only one extra poll should happen.
+    second = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert second.telemetry.drop_reason is None
+    assert grpc_client.get_all_kv_cache_blocks.await_count == 2
+
+    # After the coalesced poll, source waits full interval again.
+    # Signal once more to get a third poll to prove no extra poll was queued.
+    source.request_immediate_snapshot()
+    await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert grpc_client.get_all_kv_cache_blocks.await_count == 3
+    await gen.aclose()
+
+
+async def test_signal_during_poll_triggers_one_extra_poll(
+    config: SubscriberConfig,
+) -> None:
+    """Signal arriving while gRPC poll is in-flight causes one extra poll after."""
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+    call_count = 0
+
+    async def controlled_poll(timeout_s: float) -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            poll_started.set()
+            await release_poll.wait()
+        return _snapshot_response(block_hashes=[b"\x01"])
+
+    source, grpc_client = _make_source(config)
+    grpc_client.get_all_kv_cache_blocks = AsyncMock(side_effect=controlled_poll)
+
+    gen = source.subscribe()
+    # First poll completes normally.
+    await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+
+    # Signal to trigger second poll, which will block.
+    source.request_immediate_snapshot()
+    second_task = asyncio.create_task(gen.__anext__())
+    await asyncio.wait_for(poll_started.wait(), timeout=1.0)
+
+    # Signal while poll is in-flight — should coalesce into one extra poll.
+    source.request_immediate_snapshot()
+    release_poll.set()
+
+    second = await asyncio.wait_for(second_task, timeout=1.0)
+    assert second.telemetry.drop_reason is None
+
+    # One extra poll should happen (from the in-flight signal).
+    third = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert third.telemetry.drop_reason is None
+    assert call_count == 3
+    await gen.aclose()
+
+
+async def test_signal_during_error_backoff_wakes_immediately(
+    config: SubscriberConfig,
+) -> None:
+    """Signal during error-path wait interrupts the backoff interval."""
+    import grpc
+
+    grpc_error = grpc.aio.AioRpcError(
+        code=grpc.StatusCode.UNAVAILABLE,
+        initial_metadata=None,
+        trailing_metadata=None,
+        details="down",
+        debug_error_string=None,
+    )
+    source, grpc_client = _make_source(
+        config,
+        responses=[
+            grpc_error,
+            _snapshot_response(block_hashes=[b"\x01"]),
+        ],
+    )
+
+    gen = source.subscribe()
+    # First poll fails and enters error backoff wait.
+    first_task = asyncio.create_task(gen.__anext__())
+    first = await asyncio.wait_for(first_task, timeout=1.0)
+    assert first.telemetry.drop_reason == "fetch_failed"
+
+    # Source is now in error-path _wait_interval. Signal it.
+    source.request_immediate_snapshot()
+
+    # Retry should happen quickly.
+    second_task = asyncio.create_task(gen.__anext__())
+    second = await asyncio.wait_for(second_task, timeout=1.0)
+    assert second.telemetry.drop_reason is None
+    await gen.aclose()
+
+
+async def test_rate_limited_warning_on_repeated_signal(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """Warning is logged (rate-limited) when signal arrives with event already set."""
+    warning_mock = mocker.patch("subscriber.engine.snapshot.logger.warning")
+    source, _ = _make_source(config)
+
+    # Signal twice without consumption.
+    source.request_immediate_snapshot()
+    source.request_immediate_snapshot()
+
+    # At least one warning about coalesced signal.
+    warning_mock.assert_called()
+    call_messages = [str(c.args[0]) for c in warning_mock.call_args_list]
+    assert any("snapshot signal" in msg for msg in call_messages)
+
+
+async def test_no_signal_preserves_interval_behavior(
+    config: SubscriberConfig,
+) -> None:
+    """Without signal, source still polls on the configured interval."""
+    source, grpc_client = _make_source(config)
+
+    gen = source.subscribe()
+    first = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+    assert first.telemetry.drop_reason is None
+
+    # Without signal, the next poll should NOT complete within 0.1s
+    # (interval is 30s). We verify by timing out.
+    second_task = asyncio.create_task(gen.__anext__())
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(second_task), timeout=0.1)
+
+    # Cleanup: signal to unblock, then close.
+    source.request_immediate_snapshot()
+    await asyncio.wait_for(second_task, timeout=1.0)
+    await gen.aclose()
+
+
+async def test_no_signal_polls_after_wait_interval_timeout(
+    config: SubscriberConfig, mocker: Any
+) -> None:
+    """The normal polling path resumes only after its interval wait times out."""
+
+    config.engine_snapshot_full_sync_interval_s = 0.01
+    source, grpc_client = _make_source(config)
+    real_wait_for = asyncio.wait_for
+    interval_timed_out = asyncio.Event()
+
+    async def observe_wait_for(awaitable: Any, timeout: float | None = None) -> Any:
+        try:
+            return await real_wait_for(awaitable, timeout)
+        except TimeoutError:
+            interval_timed_out.set()
+            raise
+
+    mocker.patch.object(
+        snapshot_module.asyncio, "wait_for", side_effect=observe_wait_for
+    )
+    gen = source.subscribe()
+    try:
+        async with asyncio.timeout(1.0):
+            first = await gen.__anext__()
+        async with asyncio.timeout(1.0):
+            second = await gen.__anext__()
+
+        assert first.telemetry.drop_reason is None
+        assert second.telemetry.drop_reason is None
+        assert interval_timed_out.is_set()
+        assert grpc_client.get_all_kv_cache_blocks.await_count == 2
+    finally:
+        await gen.aclose()

--- a/subscriber/tests/harness/e2e/test_flexlb_kv_cache_suite_cli.py
+++ b/subscriber/tests/harness/e2e/test_flexlb_kv_cache_suite_cli.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness.e2e.flexlb_kv_cache_suite import main
+
+
+def test_plan_command_writes_engine_specific_manifest(tmp_path: Path) -> None:
+    output_path = tmp_path / "manifest.json"
+
+    exit_code = main(
+        [
+            "plan",
+            "--engine-kind",
+            "vllm",
+            "--cache-unit-tokens",
+            "64",
+            "--max-context-tokens",
+            "64000",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    manifest = json.loads(output_path.read_text())
+    assert exit_code == 0
+    assert manifest["engine_kind"] == "vllm"
+    assert manifest["cache_unit_tokens"] == 64

--- a/subscriber/tests/harness/e2e/test_flexlb_suite_feedback.py
+++ b/subscriber/tests/harness/e2e/test_flexlb_suite_feedback.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness.e2e.flexlb_suite.feedback import analyze_feedback, extract_cache_feedback
+
+
+def test_extract_cache_feedback_ignores_other_pv_events(tmp_path: Path) -> None:
+    pv_path = tmp_path / "pv.log"
+    output_path = tmp_path / "feedback.jsonl"
+    pv_path.write_text(
+        "\n".join(
+            (
+                '2026 INFO pvLogger - {"requestId":"route","success":true}',
+                "not-json",
+                '2026 INFO pvLogger - {"event":"cache_hit_comparison",'
+                '"requestId":"feedback","source":"KVCM"}',
+            )
+        )
+        + "\n"
+    )
+
+    extracted = extract_cache_feedback(pv_path=pv_path, output_path=output_path)
+
+    assert extracted == 1
+    assert json.loads(output_path.read_text())["requestId"] == "feedback"
+
+
+def test_feedback_analysis_correlates_request_ids_and_preserves_evidence(
+    tmp_path: Path,
+) -> None:
+    requests_path = tmp_path / "requests.jsonl"
+    feedback_path = tmp_path / "feedback.jsonl"
+    verdicts_path = tmp_path / "verdicts.jsonl"
+    requests_path.write_text(
+        json.dumps(
+            {
+                "gateway_request_id": "request-1",
+                "response_id": "response-1",
+                "case_id": "partial-32000",
+                "cache_relation": "partial",
+                "expected_prefix_tokens": 24_000,
+                "prompt_tokens": 32_000,
+                "cache_unit_tokens": 128,
+                "settled": True,
+            }
+        )
+        + "\n"
+    )
+    feedback_path.write_text(
+        json.dumps(
+            {
+                "requestId": "request-1",
+                "event": "cache_hit_comparison",
+                "source": "KVCM",
+                "worker": "10.0.0.7:8000",
+                "inputTokens": 32_000,
+                "kvcm": {"hit": 23_936, "delta": 64},
+                "actual": {"hit": 24_000},
+            }
+        )
+        + "\n"
+    )
+
+    summary = analyze_feedback(
+        requests_path=requests_path,
+        feedback_path=feedback_path,
+        output_path=verdicts_path,
+    )
+
+    assert summary == {
+        "total_requests": 1,
+        "matched_feedback": 1,
+        "unmatched_requests": 0,
+        "pass": 1,
+        "fail": 0,
+        "inconclusive": 0,
+        "prediction_match": 1,
+        "prediction_underprediction": 0,
+        "prediction_overprediction": 0,
+    }
+    verdict = json.loads(verdicts_path.read_text())
+    assert verdict["status"] == "pass"
+    assert verdict["selected_worker"] == "10.0.0.7:8000"
+    assert verdict["predicted_hit_tokens"] == 23_936
+    assert verdict["actual_hit_tokens"] == 24_000
+    assert verdict["prediction_status"] == "match"
+
+
+def test_feedback_analysis_marks_missing_or_invalid_feedback_inconclusive(
+    tmp_path: Path,
+) -> None:
+    requests_path = tmp_path / "requests.jsonl"
+    feedback_path = tmp_path / "feedback.jsonl"
+    verdicts_path = tmp_path / "verdicts.jsonl"
+    requests_path.write_text(
+        "\n".join(
+            (
+                json.dumps(
+                    {
+                        "gateway_request_id": "missing",
+                        "case_id": "cold",
+                        "cache_relation": "cold",
+                        "expected_prefix_tokens": 0,
+                        "prompt_tokens": 1_024,
+                        "cache_unit_tokens": 128,
+                        "settled": True,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "gateway_request_id": "invalid",
+                        "case_id": "exact",
+                        "cache_relation": "exact",
+                        "expected_prefix_tokens": 1_024,
+                        "prompt_tokens": 1_024,
+                        "cache_unit_tokens": 128,
+                        "settled": True,
+                    }
+                ),
+            )
+        )
+        + "\n"
+    )
+    feedback_path.write_text(
+        json.dumps(
+            {
+                "requestId": "invalid",
+                "cacheMatchSource": "KVCM",
+                "predictedHitTokens": "not-an-int",
+                "actualHitTokens": 1_024,
+            }
+        )
+        + "\n"
+    )
+
+    summary = analyze_feedback(
+        requests_path=requests_path,
+        feedback_path=feedback_path,
+        output_path=verdicts_path,
+    )
+
+    assert summary["matched_feedback"] == 1
+    assert summary["unmatched_requests"] == 1
+    assert summary["inconclusive"] == 2
+    verdicts = [json.loads(line) for line in verdicts_path.read_text().splitlines()]
+    assert [row["reasons"] for row in verdicts] == [
+        ["feedback_not_found"],
+        ["feedback_invalid"],
+    ]
+
+
+def test_feedback_analysis_scales_planned_prefix_to_actual_tokenization(
+    tmp_path: Path,
+) -> None:
+    requests_path = tmp_path / "requests.jsonl"
+    feedback_path = tmp_path / "feedback.jsonl"
+    verdicts_path = tmp_path / "verdicts.jsonl"
+    requests_path.write_text(
+        json.dumps(
+            {
+                "gateway_request_id": "request-1",
+                "case_id": "exact-32000",
+                "cache_relation": "exact",
+                "target_tokens": 32_000,
+                "expected_prefix_tokens": 32_000,
+                "prompt_tokens": 29_788,
+                "cache_unit_tokens": 1_152,
+                "settled": True,
+            }
+        )
+        + "\n"
+    )
+    feedback_path.write_text(
+        json.dumps(
+            {
+                "requestId": "request-1",
+                "source": "KVCM",
+                "inputTokens": 29_799,
+                "kvcm": {"hit": 28_800},
+                "actual": {"hit": 28_800},
+            }
+        )
+        + "\n"
+    )
+
+    summary = analyze_feedback(
+        requests_path=requests_path,
+        feedback_path=feedback_path,
+        output_path=verdicts_path,
+    )
+
+    assert summary["pass"] == 1
+    assert summary["fail"] == 0
+
+
+def test_feedback_analysis_separates_stress_parity_from_prefix_residency(
+    tmp_path: Path,
+) -> None:
+    requests_path = tmp_path / "requests.jsonl"
+    feedback_path = tmp_path / "feedback.jsonl"
+    verdicts_path = tmp_path / "verdicts.jsonl"
+    requests_path.write_text(
+        json.dumps(
+            {
+                "gateway_request_id": "request-1",
+                "case_id": "stress-partial-32000-p1",
+                "family": "stress",
+                "cache_relation": "partial",
+                "target_tokens": 32_000,
+                "expected_prefix_tokens": 24_000,
+                "prompt_tokens": 29_800,
+                "cache_unit_tokens": 1_152,
+                "settled": True,
+            }
+        )
+        + "\n"
+    )
+    feedback_path.write_text(
+        json.dumps(
+            {
+                "requestId": "request-1",
+                "source": "KVCM",
+                "inputTokens": 29_800,
+                "kvcm": {"hit": 0},
+                "actual": {"hit": 17_280},
+            }
+        )
+        + "\n"
+    )
+
+    summary = analyze_feedback(
+        requests_path=requests_path,
+        feedback_path=feedback_path,
+        output_path=verdicts_path,
+    )
+
+    assert summary["fail"] == 1
+    assert summary["prediction_underprediction"] == 1
+    verdict = json.loads(verdicts_path.read_text())
+    assert verdict["reasons"] == ["kvcm_underprediction"]
+    assert verdict["prediction_status"] == "underprediction"

--- a/subscriber/tests/harness/e2e/test_flexlb_suite_manifest.py
+++ b/subscriber/tests/harness/e2e/test_flexlb_suite_manifest.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from harness.e2e.flexlb_suite.manifest import build_default_manifest
+
+
+def test_default_manifest_covers_boundaries_lengths_and_cache_relations() -> None:
+    manifest = build_default_manifest(
+        engine_kind="vllm",
+        cache_unit_tokens=128,
+        max_context_tokens=65_536,
+    )
+
+    boundary_targets = {
+        case.target_tokens for case in manifest.cases if case.family == "boundary"
+    }
+    assert boundary_targets == {127, 128, 129, 511, 512, 513}
+
+    standard_targets = {
+        case.target_tokens
+        for case in manifest.cases
+        if case.family == "standard_length"
+    }
+    assert standard_targets == {1_024, 4_096, 16_384, 32_000, 64_000}
+
+    relations = {case.cache_relation for case in manifest.cases}
+    assert relations == {"cold", "exact", "partial", "negative", "observational"}
+    assert manifest.stress.duration_s == 1_200
+    assert manifest.stress.concurrency_steps == (1, 4, 8, 4)
+
+
+def test_default_manifest_adds_sglang_bigram_cases_only_for_sglang() -> None:
+    sglang = build_default_manifest(
+        engine_kind="sglang",
+        cache_unit_tokens=128,
+        max_context_tokens=131_072,
+    )
+    vllm = build_default_manifest(
+        engine_kind="vllm",
+        cache_unit_tokens=1_152,
+        max_context_tokens=131_072,
+    )
+
+    assert {case.case_id for case in sglang.cases if case.family == "bigram"} == {
+        "bigram-overlap",
+        "bigram-reordered-negative",
+    }
+    assert not [case for case in vllm.cases if case.family == "bigram"]
+    assert max(case.target_tokens for case in vllm.cases) == 64_000
+    assert max(length for length, _ in vllm.stress.length_weights) == 64_000
+
+
+def test_default_manifest_omits_lengths_that_do_not_fit_context_window() -> None:
+    manifest = build_default_manifest(
+        engine_kind="vllm",
+        cache_unit_tokens=1_152,
+        max_context_tokens=32_768,
+    )
+
+    assert all(case.target_tokens <= 32_768 for case in manifest.cases)
+    assert 64_000 not in {case.target_tokens for case in manifest.cases}

--- a/subscriber/tests/harness/e2e/test_flexlb_suite_oracle.py
+++ b/subscriber/tests/harness/e2e/test_flexlb_suite_oracle.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from harness.e2e.flexlb_suite.model import CacheComparison
+from harness.e2e.flexlb_suite.oracle import evaluate_cache_comparison
+
+
+def test_cold_kvcm_match_with_no_hit_passes() -> None:
+    verdict = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="cold-32000",
+            cache_relation="cold",
+            input_tokens=32_000,
+            expected_prefix_tokens=0,
+            predicted_hit_tokens=0,
+            actual_hit_tokens=0,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+        )
+    )
+
+    assert verdict.status == "pass"
+    assert verdict.delta_hit_tokens == 0
+    assert verdict.reasons == ()
+
+
+def test_exact_and_partial_matches_allow_one_cache_unit_of_alignment() -> None:
+    exact = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="exact-32000",
+            cache_relation="exact",
+            input_tokens=32_000,
+            expected_prefix_tokens=32_000,
+            predicted_hit_tokens=31_872,
+            actual_hit_tokens=31_872,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+        )
+    )
+    partial = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="partial-32000",
+            cache_relation="partial",
+            input_tokens=32_000,
+            expected_prefix_tokens=24_000,
+            predicted_hit_tokens=23_936,
+            actual_hit_tokens=24_064,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+        )
+    )
+
+    assert exact.status == "pass"
+    assert partial.status == "pass"
+
+
+def test_partial_reuse_allows_eviction_but_rejects_impossible_extra_hit() -> None:
+    evicted = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="partial-32000",
+            cache_relation="partial",
+            input_tokens=32_000,
+            expected_prefix_tokens=24_000,
+            predicted_hit_tokens=12_000,
+            actual_hit_tokens=12_000,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+        )
+    )
+    impossible = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="partial-32000",
+            cache_relation="partial",
+            input_tokens=32_000,
+            expected_prefix_tokens=24_000,
+            predicted_hit_tokens=30_000,
+            actual_hit_tokens=30_000,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+        )
+    )
+
+    assert evicted.status == "pass"
+    assert impossible.status == "fail"
+    assert "actual_hit_exceeds_shared_prefix" in impossible.reasons
+
+
+def test_stress_prediction_parity_does_not_require_cache_residency() -> None:
+    verdict = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="stress-partial-32000-p1",
+            cache_relation="partial",
+            input_tokens=32_000,
+            expected_prefix_tokens=24_000,
+            predicted_hit_tokens=0,
+            actual_hit_tokens=0,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+            enforce_expected_prefix=False,
+        )
+    )
+
+    assert verdict.status == "pass"
+    assert verdict.reasons == ()
+
+
+def test_steady_kvcm_overprediction_fails_even_when_request_succeeds() -> None:
+    verdict = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="partial-64000",
+            cache_relation="partial",
+            input_tokens=64_000,
+            expected_prefix_tokens=32_000,
+            predicted_hit_tokens=48_000,
+            actual_hit_tokens=32_000,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+        )
+    )
+
+    assert verdict.status == "fail"
+    assert "kvcm_overprediction" in verdict.reasons
+
+
+def test_non_kvcm_source_fails_a_measured_cache_case() -> None:
+    verdict = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="exact-4096",
+            cache_relation="exact",
+            input_tokens=4_096,
+            expected_prefix_tokens=4_096,
+            predicted_hit_tokens=4_096,
+            actual_hit_tokens=4_096,
+            cache_unit_tokens=128,
+            cache_match_source="LOCAL_SYNC",
+            settled=True,
+        )
+    )
+
+    assert verdict.status == "fail"
+    assert "cache_source_not_kvcm" in verdict.reasons
+
+
+def test_unsettled_and_observational_cases_are_inconclusive() -> None:
+    unsettled = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="incremental-convergence",
+            cache_relation="exact",
+            input_tokens=32_000,
+            expected_prefix_tokens=32_000,
+            predicted_hit_tokens=0,
+            actual_hit_tokens=31_872,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=False,
+        )
+    )
+    observational = evaluate_cache_comparison(
+        CacheComparison(
+            case_id="boundary-127",
+            cache_relation="observational",
+            input_tokens=127,
+            expected_prefix_tokens=0,
+            predicted_hit_tokens=0,
+            actual_hit_tokens=0,
+            cache_unit_tokens=128,
+            cache_match_source="KVCM",
+            settled=True,
+        )
+    )
+
+    assert unsettled.status == "inconclusive"
+    assert observational.status == "inconclusive"

--- a/subscriber/tests/harness/e2e/test_flexlb_suite_runner.py
+++ b/subscriber/tests/harness/e2e/test_flexlb_suite_runner.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from harness.e2e.flexlb_suite.model import (
+    ScenarioCase,
+    ScenarioManifest,
+    StressSpec,
+)
+from harness.e2e.flexlb_suite.runner import (
+    run_functional_suite,
+    run_stress_suite,
+    summarize_requests,
+)
+
+
+@pytest.mark.asyncio
+async def test_functional_runner_preserves_each_case_prompt_relationship(
+    tmp_path: Path,
+) -> None:
+    observed_messages: dict[str, list[list[dict[str, str]]]] = {}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        marker = request.headers["x-kv-test-case"]
+        observed_messages.setdefault(marker, []).append(body["messages"])
+        return httpx.Response(
+            200,
+            headers={"x-request-id": f"gateway-{marker}"},
+            json={
+                "id": f"response-{marker}",
+                "choices": [
+                    {
+                        "message": {"content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1_024,
+                    "completion_tokens": 1,
+                    "prompt_tokens_details": {"cached_tokens": 0},
+                },
+            },
+        )
+
+    manifest = ScenarioManifest(
+        schema_version=1,
+        engine_kind="vllm",
+        cache_unit_tokens=128,
+        max_context_tokens=4_096,
+        cases=(
+            ScenarioCase(
+                case_id="cold",
+                family="standard_length",
+                cache_relation="cold",
+                target_tokens=1_024,
+                repetitions=2,
+            ),
+            ScenarioCase(
+                case_id="exact",
+                family="standard_length",
+                cache_relation="exact",
+                target_tokens=1_024,
+                prefix_tokens=1_024,
+                repetitions=2,
+            ),
+            ScenarioCase(
+                case_id="partial",
+                family="standard_length",
+                cache_relation="partial",
+                target_tokens=1_024,
+                prefix_tokens=768,
+                tail_tokens=256,
+                repetitions=2,
+            ),
+            ScenarioCase(
+                case_id="branch-a-b",
+                family="branch",
+                cache_relation="partial",
+                target_tokens=1_024,
+                prefix_tokens=768,
+                tail_tokens=256,
+                repetitions=4,
+            ),
+            ScenarioCase(
+                case_id="reordered-negative",
+                family="negative",
+                cache_relation="negative",
+                target_tokens=1_024,
+                repetitions=2,
+            ),
+            ScenarioCase(
+                case_id="bigram-overlap",
+                family="bigram",
+                cache_relation="observational",
+                target_tokens=1_024,
+                repetitions=2,
+            ),
+        ),
+        stress=StressSpec(0, (), (), ()),
+    )
+    output_path = tmp_path / "requests.jsonl"
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="https://example.test/v1"
+    ) as client:
+        await run_functional_suite(
+            manifest=manifest,
+            client=client,
+            model="test-model",
+            output_path=output_path,
+            run_id="run-123",
+            chars_per_token=4.8,
+            max_tokens=1,
+        )
+
+    cold = observed_messages["cold"]
+    exact = observed_messages["exact"]
+    partial = observed_messages["partial"]
+    branch = observed_messages["branch-a-b"]
+    reordered = observed_messages["reordered-negative"]
+    bigram = observed_messages["bigram-overlap"]
+    assert cold[0] != cold[1]
+    assert exact[0] == exact[1]
+    assert partial[0][0] == partial[1][0]
+    assert partial[0][1] != partial[1][1]
+    assert branch[0][0] == branch[2][0]
+    assert branch[1][0] == branch[3][0]
+    assert branch[0][0] != branch[1][0]
+    reordered_words = [messages[0]["content"].split() for messages in reordered]
+    assert sorted(reordered_words[0]) == sorted(reordered_words[1])
+    assert reordered_words[0] != reordered_words[1]
+    bigram_words = [messages[0]["content"].split() for messages in bigram]
+    first_bigrams = set(zip(bigram_words[0], bigram_words[0][1:], strict=False))
+    second_bigrams = set(zip(bigram_words[1], bigram_words[1][1:], strict=False))
+    assert bigram_words[0][0] != bigram_words[1][0]
+    assert len(first_bigrams & second_bigrams) >= len(first_bigrams) * 0.8
+
+    rows = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert len(rows) == 14
+    assert {row["gateway_request_id"] for row in rows} == {
+        "gateway-bigram-overlap",
+        "gateway-branch-a-b",
+        "gateway-cold",
+        "gateway-exact",
+        "gateway-partial",
+        "gateway-reordered-negative",
+    }
+    assert all(row["body_ok"] for row in rows)
+    assert all("prompt_sha256" in row for row in rows)
+    assert all(row["cache_unit_tokens"] == 128 for row in rows)
+    assert [row["settled"] for row in rows if row["case_id"] == "exact"] == [
+        False,
+        True,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stress_runner_executes_all_concurrency_phases(tmp_path: Path) -> None:
+    active_requests = 0
+    max_active_requests = 0
+
+    async def handle(request: httpx.Request) -> httpx.Response:
+        nonlocal active_requests, max_active_requests
+        active_requests += 1
+        max_active_requests = max(max_active_requests, active_requests)
+        await asyncio.sleep(0)
+        active_requests -= 1
+        return httpx.Response(
+            200,
+            headers={"x-request-id": request.headers["x-kv-test-marker"]},
+            json={
+                "id": "response",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1_024, "completion_tokens": 1},
+            },
+        )
+
+    manifest = ScenarioManifest(
+        schema_version=1,
+        engine_kind="vllm",
+        cache_unit_tokens=128,
+        max_context_tokens=4_096,
+        cases=(),
+        stress=StressSpec(
+            duration_s=60,
+            concurrency_steps=(1, 2),
+            length_weights=((1_024, 100),),
+            relation_weights=(("exact", 100),),
+        ),
+    )
+    output_path = tmp_path / "stress.jsonl"
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="https://example.test/v1"
+    ) as client:
+        records = await run_stress_suite(
+            manifest=manifest,
+            client=client,
+            model="test-model",
+            output_path=output_path,
+            run_id="stress-run",
+            chars_per_token=4.8,
+            max_tokens=1,
+            duration_s=60,
+            max_requests=6,
+            seed=11,
+            prefix_pool_size=1,
+        )
+
+    assert len(records) == 6
+    assert max_active_requests == 2
+    assert {row["concurrency"] for row in records} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_stress_runner_only_settles_after_a_prior_batch_completed(
+    tmp_path: Path,
+) -> None:
+    async def handle(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0)
+        return httpx.Response(
+            200,
+            headers={"x-request-id": request.headers["x-kv-test-marker"]},
+            json={
+                "id": "response",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1_024, "completion_tokens": 1},
+            },
+        )
+
+    manifest = ScenarioManifest(
+        schema_version=1,
+        engine_kind="vllm",
+        cache_unit_tokens=128,
+        max_context_tokens=4_096,
+        cases=(),
+        stress=StressSpec(
+            duration_s=60,
+            concurrency_steps=(2,),
+            length_weights=((1_024, 100),),
+            relation_weights=(("exact", 100),),
+        ),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="https://example.test/v1/"
+    ) as client:
+        records = await run_stress_suite(
+            manifest=manifest,
+            client=client,
+            model="test-model",
+            output_path=tmp_path / "stress-warmup.jsonl",
+            run_id="warmup-run",
+            chars_per_token=4.8,
+            max_tokens=1,
+            duration_s=60,
+            max_requests=4,
+            seed=11,
+            prefix_pool_size=1,
+        )
+
+    assert [row["settled"] for row in records] == [False, False, True, True]
+
+
+@pytest.mark.asyncio
+async def test_stress_runner_aborts_after_consecutive_response_failures(
+    tmp_path: Path,
+) -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "unavailable"})
+
+    manifest = ScenarioManifest(
+        schema_version=1,
+        engine_kind="vllm",
+        cache_unit_tokens=128,
+        max_context_tokens=4_096,
+        cases=(),
+        stress=StressSpec(
+            duration_s=60,
+            concurrency_steps=(1,),
+            length_weights=((1_024, 100),),
+            relation_weights=(("cold", 100),),
+        ),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="https://example.test/v1/"
+    ) as client:
+        records = await run_stress_suite(
+            manifest=manifest,
+            client=client,
+            model="test-model",
+            output_path=tmp_path / "stress.jsonl",
+            run_id="failing-run",
+            chars_per_token=4.8,
+            max_tokens=1,
+            duration_s=60,
+            max_requests=100,
+            seed=11,
+            prefix_pool_size=1,
+            failure_backoff_s=0,
+            max_consecutive_failures=2,
+        )
+
+    assert len(records) == 2
+
+
+def test_request_summary_keeps_failures_separate_from_cache_expectations(
+    tmp_path: Path,
+) -> None:
+    requests_path = tmp_path / "requests.jsonl"
+    requests_path.write_text(
+        "\n".join(
+            (
+                json.dumps(
+                    {
+                        "case_id": "cold",
+                        "http_code": 200,
+                        "body_ok": True,
+                        "cache_relation": "cold",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "case_id": "exact",
+                        "http_code": 500,
+                        "body_ok": False,
+                        "cache_relation": "exact",
+                    }
+                ),
+            )
+        )
+        + "\n"
+    )
+
+    summary = summarize_requests(requests_path)
+
+    assert summary == {
+        "total_requests": 2,
+        "valid_responses": 1,
+        "failed_responses": 1,
+        "by_case": {
+            "cold": {"total": 1, "valid": 1},
+            "exact": {"total": 1, "valid": 0},
+        },
+    }

--- a/subscriber/tests/harness/e2e/test_flexlb_suite_storage.py
+++ b/subscriber/tests/harness/e2e/test_flexlb_suite_storage.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness.e2e.flexlb_suite.manifest import build_default_manifest
+from harness.e2e.flexlb_suite.storage import read_manifest, write_manifest
+
+
+def test_manifest_json_round_trip_preserves_tuple_contracts(tmp_path: Path) -> None:
+    manifest = build_default_manifest(
+        engine_kind="sglang",
+        cache_unit_tokens=128,
+        max_context_tokens=64_000,
+    )
+    path = tmp_path / "manifest.json"
+
+    write_manifest(manifest, path)
+
+    assert read_manifest(path) == manifest

--- a/subscriber/tests/harness/e2e/test_flexlb_suite_stress.py
+++ b/subscriber/tests/harness/e2e/test_flexlb_suite_stress.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from harness.e2e.flexlb_suite.model import ScenarioManifest, StressSpec
+from harness.e2e.flexlb_suite.stress import build_stress_schedule
+
+
+def test_exact_stress_schedule_reuses_a_bounded_prefix_pool() -> None:
+    manifest = ScenarioManifest(
+        schema_version=1,
+        engine_kind="vllm",
+        cache_unit_tokens=128,
+        max_context_tokens=64_000,
+        cases=(),
+        stress=StressSpec(
+            duration_s=1_200,
+            concurrency_steps=(1, 4, 8, 4),
+            length_weights=((32_000, 100),),
+            relation_weights=(("exact", 100),),
+        ),
+    )
+
+    schedule = build_stress_schedule(
+        manifest=manifest,
+        seed=7,
+        request_count=6,
+        prefix_pool_size=2,
+    )
+
+    assert [item.case.case_id for item in schedule] == [
+        "stress-exact-32000-p0",
+        "stress-exact-32000-p1",
+        "stress-exact-32000-p0",
+        "stress-exact-32000-p1",
+        "stress-exact-32000-p0",
+        "stress-exact-32000-p1",
+    ]
+    assert [item.sample_index for item in schedule] == [0, 0, 1, 1, 2, 2]
+
+
+def test_cold_stress_schedule_never_reuses_a_case_identity() -> None:
+    manifest = ScenarioManifest(
+        schema_version=1,
+        engine_kind="sglang",
+        cache_unit_tokens=128,
+        max_context_tokens=64_000,
+        cases=(),
+        stress=StressSpec(
+            duration_s=1_200,
+            concurrency_steps=(1,),
+            length_weights=((4_096, 100),),
+            relation_weights=(("cold", 100),),
+        ),
+    )
+
+    schedule = build_stress_schedule(
+        manifest=manifest,
+        seed=9,
+        request_count=4,
+        prefix_pool_size=2,
+    )
+
+    assert len({item.case.case_id for item in schedule}) == 4
+    assert all(item.sample_index == 0 for item in schedule)

--- a/subscriber/tests/harness/test_loop.py
+++ b/subscriber/tests/harness/test_loop.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).parents[2]
+_LOOP = _REPO_ROOT / "harness" / "loop.py"
+
+
+def _write_manifest(
+    path: Path, repository: Path, gates: list[dict[str, object]]
+) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 2,
+                "workspace_root": ".",
+                "policy": {"output_tail_lines": 20, "slow_gate_threshold_s": 10},
+                "repositories": {
+                    "sample": {
+                        "path": str(repository),
+                        "profiles": {"quality": gates},
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_loop(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_LOOP), *args],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_run_profile_records_passed_gate(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    records = tmp_path / "runs"
+    _write_manifest(
+        manifest,
+        tmp_path,
+        [
+            {
+                "id": "sample.pass",
+                "category": "unit",
+                "timeout_s": 10,
+                "command": [sys.executable, "-c", "print('gate-ok')"],
+            }
+        ],
+    )
+
+    completed = _run_loop(
+        "run",
+        "quality",
+        "all",
+        "--manifest",
+        str(manifest),
+        "--record-dir",
+        str(records),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    record_paths = list(records.glob("*.json"))
+    assert len(record_paths) == 1
+    record = json.loads(record_paths[0].read_text(encoding="utf-8"))
+    assert record["profile"] == "quality"
+    assert record["results"][0]["gate_id"] == "sample.pass"
+    assert record["results"][0]["status"] == "passed"
+    assert record["results"][0]["output_tail"] == "gate-ok"
+
+
+def test_run_profile_fails_fast_and_records_failure(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    records = tmp_path / "runs"
+    marker = tmp_path / "should-not-exist"
+    _write_manifest(
+        manifest,
+        tmp_path,
+        [
+            {
+                "id": "sample.fail",
+                "category": "unit",
+                "timeout_s": 10,
+                "command": [sys.executable, "-c", "raise SystemExit(7)"],
+            },
+            {
+                "id": "sample.after",
+                "category": "unit",
+                "timeout_s": 10,
+                "command": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(marker)!r}).touch()",
+                ],
+            },
+        ],
+    )
+
+    completed = _run_loop(
+        "run",
+        "quality",
+        "sample",
+        "--manifest",
+        str(manifest),
+        "--record-dir",
+        str(records),
+    )
+
+    assert completed.returncode == 1
+    assert not marker.exists()
+    record_path = next(records.glob("*.json"))
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["selected_gate_ids"] == ["sample.fail", "sample.after"]
+    assert [result["status"] for result in record["results"]] == ["failed"]
+    assert record["results"][0]["exit_code"] == 7
+
+    review = _run_loop(
+        "review",
+        "--feedback-file",
+        str(tmp_path / "missing-feedback.jsonl"),
+        "--run-dir",
+        str(records),
+    )
+    assert review.returncode == 0, review.stderr
+    assert "`sample.fail`: gate_failed x1" in review.stdout
+
+
+def test_keep_going_records_blocked_gate_and_runs_next_gate(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    records = tmp_path / "runs"
+    marker = tmp_path / "continued"
+    _write_manifest(
+        manifest,
+        tmp_path,
+        [
+            {
+                "id": "sample.blocked",
+                "category": "static",
+                "timeout_s": 10,
+                "command": ["definitely-missing-harness-executable"],
+            },
+            {
+                "id": "sample.continued",
+                "category": "unit",
+                "timeout_s": 10,
+                "command": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(marker)!r}).touch()",
+                ],
+            },
+        ],
+    )
+
+    completed = _run_loop(
+        "run",
+        "quality",
+        "sample",
+        "--manifest",
+        str(manifest),
+        "--record-dir",
+        str(records),
+        "--keep-going",
+    )
+
+    assert completed.returncode == 1
+    assert marker.exists()
+    record_path = next(records.glob("*.json"))
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert [result["status"] for result in record["results"]] == [
+        "blocked",
+        "passed",
+    ]
+    assert record["results"][0]["signals"] == ["prerequisite_blocked"]
+
+
+def test_missing_repository_is_recorded_as_blocked(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    records = tmp_path / "runs"
+    _write_manifest(
+        manifest,
+        tmp_path / "missing-repository",
+        [
+            {
+                "id": "sample.missing-repository",
+                "category": "workspace",
+                "timeout_s": 10,
+                "command": [sys.executable, "-c", "print('unreachable')"],
+            }
+        ],
+    )
+
+    completed = _run_loop(
+        "run",
+        "quality",
+        "sample",
+        "--manifest",
+        str(manifest),
+        "--record-dir",
+        str(records),
+    )
+
+    assert completed.returncode == 1
+    record_path = next(records.glob("*.json"))
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["repositories"]["sample"]["error"] == (
+        "repository path does not exist"
+    )
+    assert record["results"][0]["status"] == "blocked"
+
+
+def test_dry_run_is_planned_and_does_not_execute_gate(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    records = tmp_path / "runs"
+    marker = tmp_path / "not-executed"
+    _write_manifest(
+        manifest,
+        tmp_path,
+        [
+            {
+                "id": "sample.plan",
+                "category": "unit",
+                "timeout_s": 10,
+                "command": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(marker)!r}).touch()",
+                ],
+            }
+        ],
+    )
+
+    completed = _run_loop(
+        "run",
+        "quality",
+        "sample",
+        "--manifest",
+        str(manifest),
+        "--record-dir",
+        str(records),
+        "--dry-run",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not marker.exists()
+    record_path = next(records.glob("*.json"))
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["status"] == "planned"
+    assert record["results"][0]["status"] == "planned"
+
+
+def test_feedback_is_append_only_and_resolution_leaves_no_open_item(
+    tmp_path: Path,
+) -> None:
+    feedback_file = tmp_path / "feedback.jsonl"
+    created = _run_loop(
+        "feedback",
+        "--feedback-file",
+        str(feedback_file),
+        "--gate-id",
+        "sample.fail",
+        "--signal",
+        "failure",
+        "--observation",
+        "dependency missing",
+        "--proposal",
+        "document the prerequisite",
+    )
+    assert created.returncode == 0, created.stderr
+    feedback_id = json.loads(created.stdout)["id"]
+
+    resolved = _run_loop(
+        "feedback",
+        "--feedback-file",
+        str(feedback_file),
+        "--gate-id",
+        "sample.fail",
+        "--signal",
+        "resolved",
+        "--observation",
+        "prerequisite documented",
+        "--resolves",
+        feedback_id,
+    )
+    assert resolved.returncode == 0, resolved.stderr
+    assert len(feedback_file.read_text(encoding="utf-8").splitlines()) == 2
+
+    review = _run_loop(
+        "review",
+        "--feedback-file",
+        str(feedback_file),
+        "--run-dir",
+        str(tmp_path / "missing-runs"),
+    )
+    assert review.returncode == 0, review.stderr
+    assert "No open feedback." in review.stdout

--- a/subscriber/tests/health/__init__.py
+++ b/subscriber/tests/health/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/subscriber/tests/health/test_coordinator.py
+++ b/subscriber/tests/health/test_coordinator.py
@@ -1,0 +1,638 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.base import AbstractEngineAdapter, EngineEventBatch
+from subscriber.engine.metadata import KvEventBootstrap
+from subscriber.health.coordinator import EngineHealthCoordinator, EngineHealthState
+from subscriber.health.events import LivenessEvent
+from subscriber.kvcm.client import KvcmClient
+from subscriber.metrics import BatchTelemetry
+from subscriber.types import AllBlocksCleared, KVEventBatch
+
+
+class FakeAdapter(AbstractEngineAdapter):
+    def __init__(self, events: list[LivenessEvent] | None = None) -> None:
+        self._events = events or []
+        self.reset_generation_calls = 0
+
+    async def subscribe_kv_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        if False:
+            yield EngineEventBatch(
+                [], BatchTelemetry(pipeline="incremental"), trace_id=""
+            )
+
+    async def fetch_kv_event_bootstrap(self) -> KvEventBootstrap:
+        raise AssertionError("health coordinator must not fetch engine bootstrap")
+
+    async def subscribe_snapshot_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        if False:
+            yield EngineEventBatch([], BatchTelemetry(pipeline="snapshot"), trace_id="")
+
+    async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+        for event in self._events:
+            yield event
+
+    async def reset_generation_state(self) -> None:
+        self.reset_generation_calls += 1
+
+    def map_medium(self, medium: str | None) -> str:
+        return ""
+
+    def supported_mediums(self) -> list[str]:
+        return []
+
+    def storage_type(self) -> str:
+        return "ST_UNSPECIFIED"
+
+    def request_immediate_snapshot(self) -> None:
+        return None
+
+
+class RecordingKvcmClient(KvcmClient):
+    def __init__(self) -> None:
+        self.sent: list[tuple[list[KVEventBatch], int]] = []
+        self.reregister_after_host_down: list[bool] = []
+
+    async def report_kv_events(
+        self,
+        batches: list[KVEventBatch],
+        epoch: int,
+        *,
+        reregister_after_host_down: bool = True,
+    ) -> None:
+        self.sent.append((batches, epoch))
+        self.reregister_after_host_down.append(reregister_after_host_down)
+
+
+def _config(threshold: int = 3, health_interval_s: float = 5.0) -> SubscriberConfig:
+    return SubscriberConfig(
+        engine_health_failure_threshold=threshold,
+        engine_health_interval_s=health_interval_s,
+    )
+
+
+async def test_cold_start_unhealthy_does_not_send_reset() -> None:
+    adapter = FakeAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+
+    for _ in range(5):
+        await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    assert coordinator.state is EngineHealthState.STARTING
+    assert coordinator.epoch == 0
+    assert kvcm.sent == []
+
+
+async def test_cold_start_unhealthy_logs_when_threshold_reached(mocker) -> None:
+    adapter = FakeAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+    warning = mocker.patch("subscriber.health.coordinator.logger.warning")
+
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    warning.assert_called_once_with(
+        "engine health still unhealthy during startup",
+        step="engine_health",
+        tags={
+            "state": "starting",
+            "failure_count": 2,
+            "failure_threshold": 2,
+        },
+    )
+
+
+async def test_first_healthy_opens_epoch_one_and_releases_waiters() -> None:
+    adapter = FakeAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config())
+    waiter = asyncio.create_task(coordinator.wait_ready_epoch())
+    await asyncio.sleep(0)
+
+    assert not waiter.done()
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+    assert await asyncio.wait_for(waiter, timeout=1.0) == 1
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert coordinator.epoch == 1
+    assert kvcm.sent == []
+    assert adapter.reset_generation_calls == 0
+
+
+async def test_healthy_healthy_resets_failure_and_keeps_gate_open() -> None:
+    adapter = FakeAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=3))
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert coordinator.epoch == 1
+    assert kvcm.sent == []
+    assert adapter.reset_generation_calls == 0
+    # Third UNHEALTHY after the reset must not immediately trip DEAD.
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert kvcm.sent == []
+
+
+async def test_unhealthy_below_threshold_closes_gate_but_stays_healthy() -> None:
+    adapter = FakeAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=3))
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert coordinator.epoch == 1
+    assert kvcm.sent == []
+    waiter = asyncio.create_task(coordinator.wait_ready_epoch())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    assert await asyncio.wait_for(waiter, timeout=1.0) == 1
+
+
+async def test_healthy_to_dead_sends_reset_once_with_current_epoch() -> None:
+    adapter = FakeAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(
+        adapter,
+        kvcm,
+        _config(threshold=2),
+        clock=lambda: 123.0,
+    )
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    assert coordinator.state is EngineHealthState.DEAD
+    assert coordinator.epoch == 1
+    assert len(kvcm.sent) == 1
+    batches, epoch = kvcm.sent[0]
+    assert epoch == 1
+    assert batches == [KVEventBatch(ts=123.0, events=[AllBlocksCleared()])]
+
+    # Further UNHEALTHY events must NOT resend reset.
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    assert len(kvcm.sent) == 1
+
+
+async def test_reset_report_failure_is_logged_and_recovery_continues(mocker) -> None:
+    class FailingResetKvcmClient(RecordingKvcmClient):
+        async def report_kv_events(
+            self,
+            batches: list[KVEventBatch],
+            epoch: int,
+            *,
+            reregister_after_host_down: bool = True,
+        ) -> None:
+            raise RuntimeError("reset report failed")
+
+    adapter = FakeAdapter()
+    kvcm = FailingResetKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=1))
+    warning = mocker.patch("subscriber.health.coordinator.logger.warning")
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert coordinator.epoch == 2
+    warning.assert_called_once_with(
+        "failed to report all blocks cleared to kvcm",
+        step="engine_health",
+        tags={
+            "epoch": 1,
+            "reason": "engine_dead",
+            "timeout_s": 2.0,
+            "error": "RuntimeError",
+            "message": "reset report failed",
+        },
+        exc_info=True,
+    )
+
+
+async def test_dead_recovery_resets_generation_and_bumps_epoch() -> None:
+    adapter = FakeAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=1))
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    assert coordinator.state is EngineHealthState.DEAD
+    assert coordinator.epoch == 1
+    assert len(kvcm.sent) == 1
+
+    waiter = asyncio.create_task(coordinator.wait_ready_epoch())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert coordinator.epoch == 2
+    assert adapter.reset_generation_calls == 1
+    assert await asyncio.wait_for(waiter, timeout=1.0) == 2
+
+
+async def test_reset_generation_runs_before_epoch_bump_and_gate_open() -> None:
+    events_order: list[str] = []
+
+    class OrderRecordingAdapter(FakeAdapter):
+        def __init__(self, coordinator_ref: list[EngineHealthCoordinator]) -> None:
+            super().__init__()
+            self._coordinator_ref = coordinator_ref
+
+        async def reset_generation_state(self) -> None:
+            await super().reset_generation_state()
+            coordinator = self._coordinator_ref[0]
+            events_order.append(f"reset(epoch={coordinator.epoch})")
+
+    coordinator_ref: list[EngineHealthCoordinator] = []
+    adapter = OrderRecordingAdapter(coordinator_ref)
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=1))
+    coordinator_ref.append(coordinator)
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+    assert events_order == ["reset(epoch=1)"]
+    assert coordinator.epoch == 2
+
+
+async def test_reset_generation_failure_is_logged_and_retried(mocker) -> None:
+    class FlakyResetAdapter(FakeAdapter):
+        async def reset_generation_state(self) -> None:
+            self.reset_generation_calls += 1
+            if self.reset_generation_calls == 1:
+                raise RuntimeError("socket recreation failed")
+
+    adapter = FlakyResetAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=1))
+    warning = mocker.patch("subscriber.health.coordinator.logger.warning")
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+    assert coordinator.state is EngineHealthState.DEAD
+    assert coordinator.epoch == 1
+    warning.assert_called_once_with(
+        "failed to reset engine generation state; remaining not ready",
+        step="engine_health",
+        tags={
+            "epoch": 1,
+            "error": "RuntimeError",
+            "message": "socket recreation failed",
+        },
+        exc_info=True,
+    )
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert coordinator.epoch == 2
+    assert adapter.reset_generation_calls == 2
+
+
+async def test_watch_loop_consumes_adapter_events() -> None:
+    completed = asyncio.Event()
+
+    class BlockingAdapter(FakeAdapter):
+        async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+            for event in self._events:
+                yield event
+            completed.set()
+            await asyncio.Event().wait()
+
+    adapter = BlockingAdapter(
+        [LivenessEvent.HEALTHY, LivenessEvent.UNHEALTHY, LivenessEvent.UNHEALTHY]
+    )
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+
+    watch_task = asyncio.create_task(coordinator.watch_loop())
+    await asyncio.wait_for(completed.wait(), timeout=1.0)
+
+    assert coordinator.state is EngineHealthState.DEAD
+    assert coordinator.epoch == 1
+    assert len(kvcm.sent) == 1
+    _, epoch = kvcm.sent[0]
+    assert epoch == 1
+
+    watch_task.cancel()
+    try:
+        await watch_task
+    except asyncio.CancelledError:
+        pass
+
+
+async def test_watch_loop_recovers_after_liveness_exception(mocker) -> None:
+    recovered = asyncio.Event()
+
+    class FlakyWatchAdapter(FakeAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.watch_attempts = 0
+
+        async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+            self.watch_attempts += 1
+            if self.watch_attempts == 1:
+                yield LivenessEvent.HEALTHY
+                raise RuntimeError("liveness monitor failed")
+            recovered.set()
+            await asyncio.Event().wait()
+
+    adapter = FlakyWatchAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(
+        adapter, kvcm, _config(threshold=1, health_interval_s=0)
+    )
+    warning = mocker.patch("subscriber.health.coordinator.logger.warning")
+    watch_task = asyncio.create_task(coordinator.watch_loop())
+
+    await asyncio.wait_for(recovered.wait(), timeout=1.0)
+    assert coordinator.state is EngineHealthState.DEAD
+    assert len(kvcm.sent) == 1
+    warning.assert_any_call(
+        "engine liveness watch failed; treating as unhealthy and retrying",
+        step="engine_health",
+        tags={
+            "error": "RuntimeError",
+            "message": "liveness monitor failed",
+            "retry_in_s": 0,
+        },
+        exc_info=True,
+    )
+
+    watch_task.cancel()
+    try:
+        await watch_task
+    except asyncio.CancelledError:
+        pass
+
+
+async def test_watch_loop_recovers_after_liveness_stream_ends(mocker) -> None:
+    recovered = asyncio.Event()
+
+    class EndingWatchAdapter(FakeAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.watch_attempts = 0
+
+        async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+            self.watch_attempts += 1
+            if self.watch_attempts == 1:
+                yield LivenessEvent.HEALTHY
+                return
+            recovered.set()
+            await asyncio.Event().wait()
+
+    adapter = EndingWatchAdapter()
+    kvcm = RecordingKvcmClient()
+    coordinator = EngineHealthCoordinator(
+        adapter, kvcm, _config(threshold=1, health_interval_s=0)
+    )
+    warning = mocker.patch("subscriber.health.coordinator.logger.warning")
+    watch_task = asyncio.create_task(coordinator.watch_loop())
+
+    await asyncio.wait_for(recovered.wait(), timeout=1.0)
+    assert coordinator.state is EngineHealthState.DEAD
+    assert len(kvcm.sent) == 1
+    warning.assert_any_call(
+        "engine liveness watch ended unexpectedly; treating as unhealthy and retrying",
+        step="engine_health",
+        tags={"retry_in_s": 0},
+    )
+
+    watch_task.cancel()
+    try:
+        await watch_task
+    except asyncio.CancelledError:
+        pass
+
+
+async def test_construct_with_kvcm_none() -> None:
+    adapter = FakeAdapter()
+    coordinator = EngineHealthCoordinator(adapter, None, _config())
+
+    assert coordinator.state is EngineHealthState.STARTING
+    assert coordinator.epoch == 0
+
+
+async def test_attach_kvcm_client_sets_reference() -> None:
+    adapter = FakeAdapter()
+    coordinator = EngineHealthCoordinator(adapter, None, _config(threshold=2))
+    kvcm = RecordingKvcmClient()
+
+    coordinator.attach_kvcm_client(kvcm)
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    assert coordinator.state is EngineHealthState.DEAD
+    assert len(kvcm.sent) == 1
+
+
+async def test_send_all_blocks_cleared_skipped_when_kvcm_none(mocker) -> None:
+    adapter = FakeAdapter()
+    coordinator = EngineHealthCoordinator(
+        adapter, None, _config(threshold=1), clock=lambda: 42.0
+    )
+    warning = mocker.patch("subscriber.health.coordinator.logger.warning")
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    coordinator.attach_kvcm_client(RecordingKvcmClient())
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    assert coordinator.state is EngineHealthState.DEAD
+    warning.assert_not_called()
+
+
+async def test_deferred_kvcm_lifecycle() -> None:
+    """Full lifecycle: start without kvcm, become healthy, attach, then go dead."""
+    adapter = FakeAdapter()
+    coordinator = EngineHealthCoordinator(
+        adapter, None, _config(threshold=2), clock=lambda: 99.0
+    )
+
+    await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+    assert coordinator.state is EngineHealthState.HEALTHY
+    assert coordinator.epoch == 1
+
+    kvcm = RecordingKvcmClient()
+    coordinator.attach_kvcm_client(kvcm)
+
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+    await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+
+    assert coordinator.state is EngineHealthState.DEAD
+    assert len(kvcm.sent) == 1
+    batches, epoch = kvcm.sent[0]
+    assert epoch == 1
+    assert batches == [KVEventBatch(ts=99.0, events=[AllBlocksCleared()])]
+
+
+class TestReportHostDownIdempotent:
+    """report_host_down emits AllBlocksCleared once per sendable epoch."""
+
+    async def test_cold_start_emits_nothing(self) -> None:
+        adapter = FakeAdapter()
+        kvcm = RecordingKvcmClient()
+        coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+
+        await coordinator.report_host_down("shutdown")
+
+        assert kvcm.sent == []
+
+    async def test_sendable_epoch_emits_once(self) -> None:
+        adapter = FakeAdapter()
+        kvcm = RecordingKvcmClient()
+        coordinator = EngineHealthCoordinator(
+            adapter, kvcm, _config(threshold=2), clock=lambda: 7.0
+        )
+        await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+        await coordinator.report_host_down("shutdown")
+
+        assert len(kvcm.sent) == 1
+        batches, epoch = kvcm.sent[0]
+        assert epoch == 1
+        assert batches == [KVEventBatch(ts=7.0, events=[AllBlocksCleared()])]
+        assert kvcm.reregister_after_host_down == [False]
+
+    async def test_repeated_calls_are_idempotent(self) -> None:
+        adapter = FakeAdapter()
+        kvcm = RecordingKvcmClient()
+        coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+        await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+        await coordinator.report_host_down("shutdown")
+        await coordinator.report_host_down("shutdown")
+        await coordinator.report_host_down("engine_dead")
+
+        assert len(kvcm.sent) == 1
+
+    async def test_engine_dead_then_shutdown_emits_once(self) -> None:
+        adapter = FakeAdapter()
+        kvcm = RecordingKvcmClient()
+        coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=1))
+        await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+        # Engine DEAD emits via the watch path.
+        await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+        assert coordinator.state is EngineHealthState.DEAD
+        assert len(kvcm.sent) == 1
+
+        # Graceful shutdown for the same epoch must not re-emit.
+        await coordinator.report_host_down("shutdown")
+        assert len(kvcm.sent) == 1
+
+    async def test_recovery_rearms_new_epoch(self) -> None:
+        adapter = FakeAdapter()
+        kvcm = RecordingKvcmClient()
+        coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=1))
+        await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+        await coordinator.handle_liveness_event(LivenessEvent.UNHEALTHY)
+        assert len(kvcm.sent) == 1
+
+        # Recover into a new sendable epoch.
+        await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+        assert coordinator.epoch == 2
+
+        await coordinator.report_host_down("shutdown")
+        assert len(kvcm.sent) == 2
+        _, epoch = kvcm.sent[1]
+        assert epoch == 2
+
+    async def test_stale_mark_epoch_sendable_is_ignored(self) -> None:
+        adapter = FakeAdapter()
+        kvcm = RecordingKvcmClient()
+        coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+
+        # No epoch is current at 0; marking a stale epoch must not arm emission.
+        coordinator.mark_epoch_sendable(0)
+        await coordinator.report_host_down("shutdown")
+
+        assert kvcm.sent == []
+
+    async def test_slow_send_is_bounded_by_timeout(self) -> None:
+        class SlowKvcmClient(RecordingKvcmClient):
+            async def report_kv_events(
+                self,
+                batches: list[KVEventBatch],
+                epoch: int,
+                *,
+                reregister_after_host_down: bool = True,
+            ) -> None:
+                await asyncio.sleep(10)
+                await super().report_kv_events(
+                    batches,
+                    epoch,
+                    reregister_after_host_down=reregister_after_host_down,
+                )
+
+        adapter = FakeAdapter()
+        kvcm = SlowKvcmClient()
+        coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+        await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+        await asyncio.wait_for(
+            coordinator.report_host_down("shutdown", timeout_s=0.01), timeout=1.0
+        )
+
+        # The bounded send did not deliver, but emission was still claimed.
+        assert kvcm.sent == []
+
+    async def test_concurrent_callers_emit_once(self) -> None:
+        class GatedKvcmClient(RecordingKvcmClient):
+            def __init__(self) -> None:
+                super().__init__()
+                self.release = asyncio.Event()
+
+            async def report_kv_events(
+                self,
+                batches: list[KVEventBatch],
+                epoch: int,
+                *,
+                reregister_after_host_down: bool = True,
+            ) -> None:
+                await self.release.wait()
+                await super().report_kv_events(
+                    batches,
+                    epoch,
+                    reregister_after_host_down=reregister_after_host_down,
+                )
+
+        adapter = FakeAdapter()
+        kvcm = GatedKvcmClient()
+        coordinator = EngineHealthCoordinator(adapter, kvcm, _config(threshold=2))
+        await coordinator.handle_liveness_event(LivenessEvent.HEALTHY)
+
+        first = asyncio.create_task(coordinator.report_host_down("engine_dead"))
+        second = asyncio.create_task(coordinator.report_host_down("shutdown"))
+        await asyncio.sleep(0)
+        kvcm.release.set()
+        await asyncio.gather(first, second)
+
+        assert len(kvcm.sent) == 1

--- a/subscriber/tests/health/test_state_reporter.py
+++ b/subscriber/tests/health/test_state_reporter.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+
+import httpx
+import pytest
+
+from subscriber.config import SubscriberConfig
+from subscriber.health.state_reporter import (
+    DashservingStateReporter,
+    StateReportError,
+    SubscriberPhase,
+)
+
+
+class FakeClock:
+    """Deterministic monotonic clock the test advances manually."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeTransport(httpx.AsyncBaseTransport):
+    """Injected fake transport.
+
+    Default behavior echoes an accepted ack carrying the request's own seq_id.
+    Tests can queue explicit responses/exceptions, or install an async handler
+    (e.g. one that blocks on an event to simulate an in-flight request).
+    """
+
+    def __init__(
+        self,
+        handler: Callable[[httpx.Request], Awaitable[httpx.Response]] | None = None,
+    ) -> None:
+        self.requests: list[dict[str, object]] = []
+        self.raw: list[httpx.Request] = []
+        self._queued: list[httpx.Response | Exception] = []
+        self._handler = handler
+
+    def queue(self, *items: httpx.Response | Exception) -> None:
+        self._queued.extend(items)
+
+    def states(self) -> list[str]:
+        return [str(r["state"]) for r in self.requests]
+
+    def seqs(self) -> list[int]:
+        return [int(r["seq_id"]) for r in self.requests]
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        self.raw.append(request)
+        self.requests.append(json.loads(request.content.decode()))
+        if self._queued:
+            item = self._queued.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+        if self._handler is not None:
+            return await self._handler(request)
+        seq = self.requests[-1]["seq_id"]
+        return httpx.Response(200, json={"accepted": True, "last_seq_id": seq})
+
+
+def make_reporter(
+    transport: FakeTransport | None = None,
+    *,
+    heartbeat_interval_s: float = 0.01,
+    request_timeout_s: float = 1.0,
+    shutdown_timeout_s: float = 1.0,
+    clock: Callable[[], float] | None = None,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> tuple[DashservingStateReporter, FakeTransport]:
+    transport = transport or FakeTransport()
+    config = SubscriberConfig(
+        subscriber_heartbeat_interval_s=heartbeat_interval_s,
+        subscriber_state_request_timeout_s=request_timeout_s,
+        subscriber_shutdown_report_timeout_s=shutdown_timeout_s,
+    )
+    client = httpx.AsyncClient(transport=transport)
+    reporter = DashservingStateReporter(
+        config, http_client=client, clock=clock, sleep=sleep
+    )
+    return reporter, transport
+
+
+async def wait_until(predicate: Callable[[], bool], timeout: float = 2.0) -> None:
+    async def _poll() -> None:
+        while not predicate():
+            await asyncio.sleep(0.001)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+# --- strict increment -------------------------------------------------------
+
+
+async def test_active_reports_strictly_increment_from_one() -> None:
+    reporter, transport = make_reporter()
+
+    await reporter.report_active()
+    await reporter.report_active()
+    await reporter.report_active()
+
+    assert transport.seqs() == [1, 2, 3]
+    assert transport.states() == ["active", "active", "active"]
+    assert reporter.next_seq_id == 4
+    assert reporter.phase is SubscriberPhase.ACTIVE
+
+
+async def test_first_active_logs_phase_transition_once(mocker) -> None:
+    reporter, _ = make_reporter()
+    info = mocker.patch("subscriber.health.state_reporter.logger.info")
+
+    await reporter.report_active()
+    await reporter.report_active()
+
+    transition_calls = [
+        c for c in info.call_args_list if c.args and "transition" in c.args[0]
+    ]
+    assert len(transition_calls) == 1
+    assert transition_calls[0].kwargs["tags"]["from"] == "starting"
+    assert transition_calls[0].kwargs["tags"]["to"] == "active"
+
+
+# --- timeout gaps -----------------------------------------------------------
+
+
+async def test_timed_out_sequence_is_never_reused() -> None:
+    transport = FakeTransport()
+    transport.queue(httpx.ConnectTimeout("boom"))
+    reporter, transport = make_reporter(transport)
+
+    with pytest.raises(httpx.ConnectTimeout):
+        await reporter.report_active()
+
+    # seq 1 was consumed by the timeout; the retry must use seq 2, not reuse 1.
+    assert reporter.next_seq_id == 2
+    await reporter.report_active()
+    assert transport.seqs() == [1, 2]
+    assert reporter.phase is SubscriberPhase.ACTIVE
+
+
+async def test_non_2xx_response_is_a_failed_report() -> None:
+    transport = FakeTransport()
+    transport.queue(httpx.Response(500, json={}))
+    reporter, transport = make_reporter(transport)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await reporter.report_active()
+
+    assert reporter.next_seq_id == 2
+
+
+async def test_malformed_ack_is_a_failed_report() -> None:
+    transport = FakeTransport()
+    transport.queue(httpx.Response(200, json={"accepted": "yes"}))
+    reporter, _ = make_reporter(transport)
+
+    with pytest.raises(StateReportError):
+        await reporter.report_active()
+
+    # bool last_seq_id must also be rejected (bool is an int subclass).
+    transport.queue(httpx.Response(200, json={"accepted": True, "last_seq_id": True}))
+    with pytest.raises(StateReportError):
+        await reporter.report_active()
+
+
+# --- duplicate / stale acknowledgement --------------------------------------
+
+
+async def test_stale_ack_with_higher_server_seq_is_invariant_warning(mocker) -> None:
+    transport = FakeTransport()
+    transport.queue(httpx.Response(200, json={"accepted": False, "last_seq_id": 99}))
+    reporter, _ = make_reporter(transport)
+    warning = mocker.patch("subscriber.health.state_reporter.logger.warning")
+
+    with pytest.raises(StateReportError):
+        await reporter.report_active()
+
+    assert warning.call_count == 1
+    tags = warning.call_args.kwargs["tags"]
+    assert tags["seq_id"] == 1
+    assert tags["last_seq_id"] == 99
+    assert "invariant" in warning.call_args.args[0]
+
+
+async def test_duplicate_ack_is_rejected_not_success(mocker) -> None:
+    transport = FakeTransport()
+    transport.queue(httpx.Response(200, json={"accepted": False, "last_seq_id": 1}))
+    reporter, _ = make_reporter(transport)
+    warning = mocker.patch("subscriber.health.state_reporter.logger.warning")
+
+    with pytest.raises(StateReportError):
+        await reporter.report_active()
+
+    assert warning.call_count == 1
+    assert "duplicate/stale" in warning.call_args.args[0]
+
+
+# --- no active after graceful inactive --------------------------------------
+
+
+async def test_no_active_after_graceful_inactive() -> None:
+    reporter, transport = make_reporter()
+
+    await reporter.report_active()
+    await reporter.report_shutdown_inactive("graceful shutdown")
+
+    assert reporter.phase is SubscriberPhase.INACTIVE
+    with pytest.raises(StateReportError):
+        await reporter.report_active()
+
+    # Only the active and the terminal inactive were sent; no active after.
+    assert transport.states() == ["active", "inactive"]
+    assert transport.seqs() == [1, 2]
+
+
+async def test_late_active_ack_does_not_roll_back_inactive() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        if body["state"] == "active":
+            entered.set()
+            await release.wait()
+        return httpx.Response(
+            200, json={"accepted": True, "last_seq_id": body["seq_id"]}
+        )
+
+    transport = FakeTransport(handler=handler)
+    reporter, _ = make_reporter(transport)
+
+    active_task = asyncio.create_task(reporter.report_active())
+    await wait_until(entered.is_set)
+
+    # A newer local transition lands while the active POST is still in flight.
+    await reporter.report_shutdown_inactive("shutdown")
+    assert reporter.phase is SubscriberPhase.INACTIVE
+
+    release.set()
+    await active_task
+
+    # The late accepted active ack must not roll back the terminal inactive phase.
+    assert reporter.phase is SubscriberPhase.INACTIVE
+
+
+async def test_shutdown_inactive_uses_higher_seq_than_last_heartbeat() -> None:
+    reporter, transport = make_reporter(heartbeat_interval_s=0.005)
+
+    await reporter.report_active()
+    reporter.start_heartbeat()
+    await wait_until(lambda: len(transport.requests) >= 3)
+    await reporter.report_shutdown_inactive("shutdown")
+
+    last = transport.requests[-1]
+    assert last["state"] == "inactive"
+    heartbeat_seqs = [
+        int(r["seq_id"]) for r in transport.requests if r["state"] == "active"
+    ]
+    assert int(last["seq_id"]) > max(heartbeat_seqs)
+
+
+async def test_shutdown_inactive_is_best_effort_on_transport_failure(mocker) -> None:
+    transport = FakeTransport()
+    reporter, transport = make_reporter(transport)
+    await reporter.report_active()
+    transport.queue(httpx.ConnectTimeout("down"))
+    warning = mocker.patch("subscriber.health.state_reporter.logger.warning")
+
+    # Must not raise even though the POST fails.
+    await reporter.report_shutdown_inactive("shutdown")
+
+    assert reporter.phase is SubscriberPhase.INACTIVE
+    assert warning.call_count == 1
+
+
+async def test_shutdown_inactive_is_idempotent() -> None:
+    reporter, transport = make_reporter()
+    await reporter.report_active()
+
+    await reporter.report_shutdown_inactive("first")
+    await reporter.report_shutdown_inactive("second")
+
+    assert transport.states() == ["active", "inactive"]
+
+
+# --- report_failed ----------------------------------------------------------
+
+
+async def test_report_failed_allowed_only_while_starting() -> None:
+    reporter, transport = make_reporter()
+
+    await reporter.report_failed("bad metadata")
+
+    assert reporter.phase is SubscriberPhase.FAILED
+    assert transport.requests == [{"state": "failed", "seq_id": 1}]
+    with pytest.raises(StateReportError):
+        await reporter.report_failed("again")
+
+
+async def test_report_failed_rejected_after_active() -> None:
+    reporter, transport = make_reporter()
+    await reporter.report_active()
+
+    with pytest.raises(StateReportError):
+        await reporter.report_failed("too late")
+
+    assert transport.states() == ["active"]
+    assert reporter.phase is SubscriberPhase.ACTIVE
+
+
+# --- heartbeat task ownership -----------------------------------------------
+
+
+async def test_start_heartbeat_rejects_second_start() -> None:
+    reporter, _ = make_reporter(heartbeat_interval_s=10.0)
+
+    reporter.start_heartbeat()
+    try:
+        with pytest.raises(StateReportError):
+            reporter.start_heartbeat()
+    finally:
+        await reporter.stop_heartbeat()
+
+
+async def test_stop_heartbeat_cancels_and_clears_task() -> None:
+    reporter, _ = make_reporter(heartbeat_interval_s=10.0)
+    reporter.start_heartbeat()
+    task = reporter._heartbeat_task
+    assert task is not None
+
+    await reporter.stop_heartbeat()
+
+    assert reporter._heartbeat_task is None
+    assert task.cancelled()
+    # Idempotent.
+    await reporter.stop_heartbeat()
+
+
+async def test_heartbeat_sends_new_seq_active_each_interval() -> None:
+    reporter, transport = make_reporter(heartbeat_interval_s=0.005)
+    await reporter.report_active()  # seq 1
+
+    reporter.start_heartbeat()
+    try:
+        await wait_until(lambda: len(transport.requests) >= 4)
+    finally:
+        await reporter.stop_heartbeat()
+
+    assert all(r["state"] == "active" for r in transport.requests)
+    seqs = transport.seqs()
+    assert seqs[0] == 1
+    # Strictly increasing by one across startup active + heartbeats.
+    assert seqs == list(range(1, len(seqs) + 1))
+
+
+async def test_heartbeat_transient_failure_logged_then_continues(mocker) -> None:
+    transport = FakeTransport()
+    transport.queue(httpx.ConnectTimeout("blip"))  # first heartbeat fails
+    reporter, transport = make_reporter(transport, heartbeat_interval_s=0.005)
+    warning = mocker.patch("subscriber.health.state_reporter.logger.warning")
+    info = mocker.patch("subscriber.health.state_reporter.logger.info")
+
+    reporter.start_heartbeat()
+    try:
+        # Wait past the failed heartbeat and a subsequent successful one.
+        await wait_until(lambda: len(transport.requests) >= 2)
+        await wait_until(
+            lambda: any(
+                c.args and "recovered" in c.args[0] for c in info.call_args_list
+            )
+        )
+    finally:
+        await reporter.stop_heartbeat()
+
+    first_failures = [
+        c for c in warning.call_args_list if c.args and "failed" in c.args[0]
+    ]
+    assert len(first_failures) == 1
+    recovered = [c for c in info.call_args_list if c.args and "recovered" in c.args[0]]
+    assert len(recovered) == 1
+
+
+async def test_heartbeat_failure_summaries_are_suppressed_by_clock(mocker) -> None:
+    clock = FakeClock()
+    reporter, _ = make_reporter(clock=clock)
+    warning = mocker.patch("subscriber.health.state_reporter.logger.warning")
+
+    reporter._note_heartbeat_failure(error="E", message="m", seq_id=1)
+    reporter._note_heartbeat_failure(error="E", message="m", seq_id=2)
+    # Only the first failure warns; the next is suppressed within the window.
+    assert warning.call_count == 1
+
+    clock.advance(31.0)
+    reporter._note_heartbeat_failure(error="E", message="m", seq_id=3)
+    assert warning.call_count == 2
+    summary_tags = warning.call_args.kwargs["tags"]
+    assert summary_tags["consecutive_failures"] == 3
+
+
+# --- cancellation during in-flight heartbeat --------------------------------
+
+
+async def test_cancellation_during_in_flight_heartbeat() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        entered.set()
+        await release.wait()
+        return httpx.Response(
+            200, json={"accepted": True, "last_seq_id": body["seq_id"]}
+        )
+
+    transport = FakeTransport(handler=handler)
+    reporter, _ = make_reporter(transport, heartbeat_interval_s=0.001)
+
+    reporter.start_heartbeat()
+    task = reporter._heartbeat_task
+    assert task is not None
+    await wait_until(entered.is_set)  # heartbeat POST is now in flight
+
+    # stop_heartbeat must cancel the in-flight request and await it, not hang.
+    await asyncio.wait_for(reporter.stop_heartbeat(), timeout=2.0)
+    assert task.cancelled()
+    assert reporter._heartbeat_task is None
+    release.set()
+
+
+async def test_heartbeat_loop_reraises_cancellation() -> None:
+    reporter, _ = make_reporter(heartbeat_interval_s=10.0)
+    reporter.start_heartbeat()
+    task = reporter._heartbeat_task
+    assert task is not None
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# --- unsupported independent-restart fail-safe ------------------------------
+
+
+async def test_independent_restart_is_loud_not_silent_success(mocker) -> None:
+    # A surviving DashServing already holds a higher seq from a previous reporter
+    # instance. A freshly restarted reporter begins at seq 1 and is rejected as
+    # stale. Sequence-only ordering cannot represent this topology; the reporter
+    # must fail loudly rather than report a false active. See module TODO.
+    transport = FakeTransport()
+    transport.queue(httpx.Response(200, json={"accepted": False, "last_seq_id": 500}))
+    reporter, _ = make_reporter(transport)
+    warning = mocker.patch("subscriber.health.state_reporter.logger.warning")
+
+    with pytest.raises(StateReportError):
+        await reporter.report_active()
+
+    assert reporter.phase is SubscriberPhase.STARTING
+    assert warning.call_count == 1
+    assert "invariant" in warning.call_args.args[0]
+
+
+# --- close ------------------------------------------------------------------
+
+
+async def test_close_is_idempotent() -> None:
+    reporter, _ = make_reporter(heartbeat_interval_s=10.0)
+    reporter.start_heartbeat()
+
+    await reporter.close()
+    await reporter.close()
+
+    assert reporter._heartbeat_task is None

--- a/subscriber/tests/kvcm/__init__.py
+++ b/subscriber/tests/kvcm/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/subscriber/tests/kvcm/test_base.py
+++ b/subscriber/tests/kvcm/test_base.py
@@ -1,0 +1,8 @@
+import pytest
+
+from subscriber.kvcm.base import AbstractKvCacheManagerClient
+
+
+def test_kvcm_manager_client_contract_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError):
+        AbstractKvCacheManagerClient()

--- a/subscriber/tests/kvcm/test_client.py
+++ b/subscriber/tests/kvcm/test_client.py
@@ -1,0 +1,3282 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable
+from enum import Enum
+from unittest.mock import AsyncMock, call
+
+import pytest
+from pytest_mock import MockerFixture
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.metadata import KvCacheDescriptor, MetadataProtocolError
+from subscriber.kvcm.base import AbstractKvCacheManagerClient
+from subscriber.kvcm.client import KvcmClient, _get_engine_config_from_env
+from subscriber.kvcm.errors import (
+    KvcmReportRejectedError,
+    KvcmResponseRejectedError,
+    KvcmUnavailableError,
+)
+from subscriber.metrics import BatchTelemetry, MetricsReporter
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockSnapshot,
+    BlockSnapshotItem,
+    BlockStored,
+    KvCacheGroupSpec,
+    KVEventBatch,
+)
+
+
+class FakeSdkClient(AbstractKvCacheManagerClient):
+    def __init__(self, base_url: str = "") -> None:
+        self.base_url = base_url
+        self.started = False
+        self.start = AsyncMock(side_effect=self._start)
+        self.register_instance = AsyncMock(
+            return_value={"header": {"status": {"code": "OK"}}}
+        )
+        self.report_event = AsyncMock(
+            return_value={"header": {"status": {"code": "OK"}}}
+        )
+        self.close = AsyncMock()
+        self.ready = True
+        self.is_ready = AsyncMock(side_effect=self._is_ready)
+
+    async def _start(self) -> None:
+        self.started = True
+
+    async def _is_ready(self) -> bool:
+        return self.ready
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def is_ready(self) -> bool:
+        return self.ready
+
+    async def register_instance(
+        self, data: dict[str, object], check_response: bool = True
+    ) -> dict[str, object]:
+        return {"header": {"status": {"code": "OK"}}}
+
+    async def report_event(
+        self, data: dict[str, object], check_response: bool = True
+    ) -> dict[str, object]:
+        return {"header": {"status": {"code": "OK"}}}
+
+    async def close(self) -> None:
+        pass
+
+
+_VLLM_MEDIUM_MAP = {"GPU": "hbm", "CPU": "mem"}
+
+
+@pytest.fixture(autouse=True)
+def _mock_host_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def resolve_host_ip_port(port: int) -> str:
+        return "10.0.0.8:9000"
+
+    monkeypatch.setattr(
+        "subscriber.kvcm.client.resolve_host_ip_port", resolve_host_ip_port
+    )
+
+
+@pytest.fixture(autouse=True)
+def _default_deployment_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-a")
+    monkeypatch.delenv("DS_LLM_ENGINE_CONFIG", raising=False)
+
+
+def _vllm_medium_mapper(medium: str | None) -> str:
+    if medium is None:
+        return ""
+    return _VLLM_MEDIUM_MAP.get(medium, "")
+
+
+def _client(config: SubscriberConfig | None = None) -> KvcmClient:
+    client = KvcmClient(
+        config or SubscriberConfig(kvcm_base_url="spectrum://vs-test:6382"),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        descriptor=KvCacheDescriptor(groups=()),
+        manager_client=FakeSdkClient(),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+    return client
+
+
+def _make_kvcm(
+    config: SubscriberConfig,
+    fake_sdk: FakeSdkClient,
+    *,
+    groups: tuple[KvCacheGroupSpec, ...] = (),
+    on_snapshot_required: Callable[[], None] | None = None,
+) -> KvcmClient:
+    return KvcmClient(
+        config,
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        descriptor=KvCacheDescriptor(groups=groups),
+        manager_client=fake_sdk,
+        on_snapshot_required=on_snapshot_required,
+    )
+
+
+def test_storage_type_maps_engine_type() -> None:
+    assert (
+        _client(SubscriberConfig(engine_type="vllm"))._storage_type
+        == "ST_EVENT_REPORT_L1P5"
+    )
+    assert (
+        KvcmClient(
+            SubscriberConfig(engine_type="unknown"),
+            medium_mapper=_vllm_medium_mapper,
+            storage_type="ST_UNSPECIFIED",
+            supported_mediums=["hbm", "mem"],
+            descriptor=KvCacheDescriptor(groups=()),
+            manager_client=FakeSdkClient(),
+        )._storage_type
+        == "ST_UNSPECIFIED"
+    )
+
+
+def test_register_instance_request_uses_env_instance_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-a")
+    request = _client()._register_instance_request()
+    assert request["instance_id"] == "deploy-a_1"
+    assert request["instance_group"] == ""
+    assert request["block_size"] == 1
+    assert request["default_query_type"] == "QT_PREFIX_MATCH_WITH_MAMBA"
+    assert "query_type" not in request
+    assert request["location_spec_infos"] == [{"name": "vllm_1", "size": 1}]
+    assert request["location_spec_groups"] == [
+        {"name": "default", "spec_names": ["vllm_1"]}
+    ]
+    assert request["model_deployment"] == {
+        "model_name": "default",
+        "dtype": "bytes",
+        "use_mla": False,
+        "tp_size": 1,
+        "dp_size": 1,
+        "lora_name": "",
+        "pp_size": 1,
+        "extra": "",
+        "user_data": "",
+        "use_eagle_pop": False,
+    }
+
+
+def test_register_instance_request_forwards_use_eagle_pop() -> None:
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        descriptor=KvCacheDescriptor(groups=(), use_eagle_pop=True),
+        manager_client=FakeSdkClient(),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    request = client._register_instance_request()
+
+    assert request["model_deployment"]["use_eagle_pop"] is True
+
+
+def test_register_instance_request_preserves_empty_extra() -> None:
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        descriptor=KvCacheDescriptor(groups=()),
+        manager_client=FakeSdkClient(),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    request = client._register_instance_request()
+
+    assert request["model_deployment"]["extra"] == ""
+
+
+def test_register_instance_request_appends_block_size_to_instance_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-a")
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 16}')
+    request = _client()._register_instance_request()
+    assert request["instance_id"] == "deploy-a_16"
+
+
+def test_effective_block_size_uses_runtime_metadata_with_heterogeneous_groups(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 128}')
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=2192,
+            group_payload_size_bytes=70_254_592,
+        ),
+        KvCacheGroupSpec(
+            group_idx=1,
+            kind="mamba",
+            block_size=16,
+            group_payload_size_bytes=35_127_296,
+        ),
+    ]
+    client = _make_kvcm(
+        SubscriberConfig(),
+        FakeSdkClient(),
+        groups=tuple(metadata),
+    )
+    assert client._effective_block_size() == 16
+    warning.assert_called_once_with(
+        "group metadata contains heterogeneous block_sizes; using min",
+        step="kvcm_register",
+        tags={
+            "block_sizes": {0: 2192, 1: 16},
+            "effective_block_size": 16,
+        },
+    )
+
+
+def test_effective_block_size_uses_uniform_runtime_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DS_LLM_ENGINE_CONFIG", raising=False)
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=2192,
+            group_payload_size_bytes=70_254_592,
+        ),
+        KvCacheGroupSpec(
+            group_idx=1,
+            kind="mamba",
+            block_size=2192,
+            group_payload_size_bytes=35_127_296,
+        ),
+    ]
+    client = _make_kvcm(
+        SubscriberConfig(),
+        FakeSdkClient(),
+        groups=tuple(metadata),
+    )
+    assert client._effective_block_size() == 2192
+
+
+def test_effective_block_size_falls_back_to_env_without_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 64}')
+    assert _client()._effective_block_size() == 64
+
+
+def test_effective_block_size_logs_metadata_fallback_once(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 64}')
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _client()
+
+    assert client._effective_block_size() == 64
+    assert client._effective_block_size() == 64
+
+    warning.assert_called_once_with(
+        "kv cache metadata unavailable; using engine config block_size fallback",
+        step="kvcm_register",
+        tags={"block_size": 64},
+    )
+
+
+def test_non_object_engine_config_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", "[]")
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+
+    assert _get_engine_config_from_env() == {}
+
+    warning.assert_called_once_with(
+        "DS_LLM_ENGINE_CONFIG must decode to a JSON object",
+        step="kvcm_client_init",
+        tags={"parsed_type": "list"},
+    )
+
+
+def test_register_instance_request_uses_runtime_block_size_and_payload_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-a")
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 128}')
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=2192,
+            group_payload_size_bytes=70_254_592,
+        ),
+        KvCacheGroupSpec(
+            group_idx=1,
+            kind="mamba",
+            block_size=2192,
+            group_payload_size_bytes=35_127_296,
+        ),
+    ]
+    client = _make_kvcm(
+        SubscriberConfig(),
+        FakeSdkClient(),
+        groups=tuple(metadata),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+    request = client._register_instance_request()
+    assert request["block_size"] == 2192
+    assert request["instance_id"] == "deploy-a_2192"
+    assert request["location_spec_infos"] == [
+        {"name": "F0", "size": 70_254_592},
+        {"name": "L1", "size": 35_127_296},
+    ]
+
+
+def test_registration_falls_back_to_block_size_and_logs_once(
+    mocker: MockerFixture,
+) -> None:
+    info = mocker.patch("subscriber.kvcm.client.logger.info")
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(
+            groups=(
+                KvCacheGroupSpec(
+                    group_idx=2,
+                    kind="mamba",
+                    block_size=128,
+                    group_payload_size_bytes=None,
+                ),
+            ),
+        ),
+    )
+
+    assert client._location_specs()[0] == [{"name": "L2", "size": 128}]
+    assert client._location_specs()[0] == [{"name": "L2", "size": 128}]
+    info.assert_called_once_with(
+        "Engine component payload size unavailable; using block size",
+        step="kvcm_register",
+        tags={"component_id": 2, "block_size": 128},
+    )
+
+
+def test_group_aware_missing_component_identity_fails_closed() -> None:
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=2192,
+            group_payload_size_bytes=70_254_592,
+        ),
+    ]
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=tuple(metadata)),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+    with pytest.raises(MetadataProtocolError, match="missing component identity"):
+        client._block_specs("hbm", group_idx=None)
+
+
+def test_block_specs_use_configured_engine_uri_scheme() -> None:
+    client = KvcmClient(
+        SubscriberConfig(engine_type="sglang"),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(
+            groups=(
+                KvCacheGroupSpec(
+                    group_idx=0,
+                    kind="full_attention",
+                    block_size=16,
+                    group_payload_size_bytes=None,
+                ),
+            )
+        ),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    assert client._block_specs("hbm", group_idx=0) == [
+        {"name": "F0", "uri": "sglang://10.0.0.8:9000/hbm"}
+    ]
+
+
+def test_block_specs_use_registered_location_spec_name() -> None:
+    client = _client()
+    register_request = client._register_instance_request()
+    block_events = client._report_events_for_batches(
+        [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockStored(
+                        block_hashes=[11],
+                        parent_block_hash=None,
+                        token_ids=[1, 2],
+                        block_size=2,
+                        lora_id=None,
+                        medium="GPU",
+                        lora_name=None,
+                    )
+                ],
+            )
+        ]
+    )
+
+    registered_spec_names = {
+        spec["name"] for spec in register_request["location_spec_infos"]
+    }
+    block_specs = block_events[0]["block_add"]["specs"]
+
+    assert block_specs == [{"name": "vllm_1", "uri": "vllm://10.0.0.8:9000/hbm"}]
+    assert {spec["name"] for spec in block_specs} <= registered_spec_names
+
+
+def test_register_and_block_specs_use_configured_block_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 16}')
+    client = _client()
+
+    register_request = client._register_instance_request()
+    block_events = client._report_events_for_batches(
+        [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockStored(
+                        block_hashes=[11],
+                        parent_block_hash=None,
+                        token_ids=[1, 2],
+                        block_size=16,
+                        lora_id=None,
+                        medium="GPU",
+                        lora_name=None,
+                    )
+                ],
+            )
+        ]
+    )
+
+    assert register_request["block_size"] == 16
+    assert register_request["location_spec_infos"] == [{"name": "vllm_16", "size": 16}]
+    assert register_request["location_spec_groups"] == [
+        {"name": "default", "spec_names": ["vllm_16"]}
+    ]
+    assert block_events[0]["block_add"]["specs"] == [
+        {"name": "vllm_16", "uri": "vllm://10.0.0.8:9000/hbm"}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("raw_config", "expected_block_size"),
+    [
+        ('{"block_size": 16}', 16),
+        ("{invalid-json", 1),
+        ("[]", 1),
+        ("1", 1),
+        ('{"block_size": true}', 1),
+        ('{"block_size": 0}', 1),
+    ],
+)
+def test_block_size_falls_back_for_invalid_engine_config_shapes(
+    monkeypatch: pytest.MonkeyPatch, raw_config: str, expected_block_size: int
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", raw_config)
+    assert _client()._register_instance_request()["block_size"] == expected_block_size
+
+
+@pytest.mark.parametrize("env_value", [None, "", "   "])
+async def test_start_rejects_missing_or_blank_deployment_name(
+    monkeypatch: pytest.MonkeyPatch, env_value: str | None
+) -> None:
+    """A blank SPECTRUM_DEPLOYMENT_NAME would produce a degenerate
+    instance_id like "_16" shared by unrelated engine instances, breaking
+    cross-instance KVCache isolation. Startup must fail instead."""
+
+    if env_value is None:
+        monkeypatch.delenv("SPECTRUM_DEPLOYMENT_NAME", raising=False)
+    else:
+        monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", env_value)
+    client = _client()
+    with pytest.raises(ValueError, match="SPECTRUM_DEPLOYMENT_NAME"):
+        await client.start()
+
+
+def test_empty_group_metadata_registers_with_default_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty metadata tuple is a valid topology and must register the
+    same default location spec as the no-metadata path; KVCM rejects empty
+    location_spec_infos."""
+
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-a")
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 16}')
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=()),
+    )
+    request = client._register_instance_request()
+    assert request["location_spec_infos"] == [{"name": "vllm_16", "size": 16}]
+    assert request["location_spec_groups"] == [
+        {"name": "default", "spec_names": ["vllm_16"]}
+    ]
+
+
+def test_register_instance_request_reads_parallelism_from_engine_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "DS_LLM_ENGINE_CONFIG",
+        '{"block_size": 64, "dtype": "bfloat16", '
+        '"tensor_parallel_size": 2, "data_parallel_size": 4, '
+        '"pipeline_parallel_size": 3}',
+    )
+    deployment = _client()._register_instance_request()["model_deployment"]
+    assert deployment["dtype"] == "bytes"
+    assert deployment["tp_size"] == 2
+    assert deployment["dp_size"] == 4
+    assert deployment["pp_size"] == 3
+
+
+def test_register_instance_request_falls_back_parallelism_for_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "DS_LLM_ENGINE_CONFIG",
+        '{"tensor_parallel_size": true, "data_parallel_size": -1}',
+    )
+    deployment = _client()._register_instance_request()["model_deployment"]
+    assert deployment["tp_size"] == 1
+    assert deployment["dp_size"] == 1
+    assert deployment["pp_size"] == 1
+
+
+def test_report_event_request_contains_common_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-a")
+    client = _client(SubscriberConfig(engine_type="vllm"))
+    events = [{"event_type": "EVENT_HOST_DOWN", "host_down": {}}]
+
+    request = client._report_event_request(events)
+
+    assert request["instance_id"] == "deploy-a_1"
+    assert request["host_ip_port"] == "10.0.0.8:9000"
+    assert request["storage_type"] == "ST_EVENT_REPORT_L1P5"
+    assert request["events"] == events
+
+
+def test_report_events_for_batches_maps_all_supported_event_types() -> None:
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=[11, 12],
+                parent_block_hash=None,
+                token_ids=[1, 2],
+                block_size=2,
+                lora_id=None,
+                medium="GPU",
+                lora_name=None,
+            ),
+            BlockRemoved(block_hashes=[13], medium="CPU"),
+            AllBlocksCleared(),
+        ],
+    )
+    events = _client()._report_events_for_batches([batch])
+
+    assert events == [
+        {
+            "event_type": "EVENT_BLOCK_ADD",
+            "block_add": {
+                "block_key": "11",
+                "medium": "hbm",
+                "specs": [{"name": "vllm_1", "uri": "vllm://10.0.0.8:9000/hbm"}],
+            },
+        },
+        {
+            "event_type": "EVENT_BLOCK_ADD",
+            "block_add": {
+                "block_key": "12",
+                "medium": "hbm",
+                "specs": [{"name": "vllm_1", "uri": "vllm://10.0.0.8:9000/hbm"}],
+            },
+        },
+        {
+            "event_type": "EVENT_BLOCK_DELETE",
+            "block_delete": {
+                "block_key": "13",
+                "medium": "mem",
+                "spec_names": ["vllm_1"],
+            },
+        },
+        {"event_type": "EVENT_HOST_DOWN", "host_down": {}},
+    ]
+
+
+def test_report_events_for_batches_maps_unknown_medium_to_empty_string() -> None:
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[BlockRemoved(block_hashes=[13], medium="DISK")],
+    )
+    assert _client()._report_events_for_batches([batch]) == [
+        {
+            "event_type": "EVENT_BLOCK_DELETE",
+            "block_delete": {
+                "block_key": "13",
+                "medium": "",
+                "spec_names": ["vllm_1"],
+            },
+        }
+    ]
+
+
+def test_register_and_report_use_per_group_specs() -> None:
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=16,
+            group_payload_size_bytes=128,
+        ),
+        KvCacheGroupSpec(
+            group_idx=1,
+            kind="mamba",
+            block_size=16,
+            sliding_window=4096,
+            group_payload_size_bytes=64,
+        ),
+        KvCacheGroupSpec(
+            group_idx=2,
+            kind="mla_attention",
+            block_size=16,
+            group_payload_size_bytes=32,
+        ),
+    ]
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=tuple(metadata)),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    request = client._register_instance_request()
+    assert request["location_spec_infos"] == [
+        {"name": "F0", "size": 128},
+        {"name": "L1", "size": 64},
+        {"name": "F2", "size": 32},
+    ]
+    assert request["location_spec_groups"] == [
+        {"name": "F0", "spec_names": ["F0"]},
+        {"name": "L1", "spec_names": ["L1"]},
+        {"name": "F2", "spec_names": ["F2"]},
+    ]
+
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=[1],
+                parent_block_hash=None,
+                token_ids=[0],
+                block_size=1,
+                lora_id=None,
+                medium="GPU",
+                lora_name=None,
+                group_idx=0,
+                kv_cache_spec_kind="full_attention",
+            ),
+            BlockRemoved(block_hashes=[2], medium="GPU", group_idx=1),
+        ],
+    )
+    events = client._report_events_for_batches([batch])
+    assert events[0]["block_add"]["specs"] == [
+        {"name": "F0", "uri": "vllm://10.0.0.8:9000/hbm"}
+    ]
+    assert events[1]["block_delete"]["spec_names"] == ["L1"]
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_name"),
+    [
+        ("full_attention", "F0"),
+        ("mla_attention", "F0"),
+        ("sink_full_attention", "F0"),
+        ("mamba", "L0"),
+        ("sliding_window", "W0"),
+        ("sliding_window_mla", "W0"),
+        ("chunked_local_attention", "C0"),
+        ("encoder_only_attention", "E0"),
+        ("cross_attention", "X0"),
+    ],
+)
+def test_location_spec_name_supports_engine_cache_kinds(
+    kind: str, expected_name: str
+) -> None:
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(
+            groups=(
+                KvCacheGroupSpec(
+                    group_idx=0,
+                    kind=kind,
+                    block_size=16,
+                    group_payload_size_bytes=128,
+                ),
+            )
+        ),
+    )
+
+    assert client._location_spec_name(0) == expected_name
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "qwen3_next_indexer_attention",
+        "mla",
+        "linear_state_checkpoint",
+        "sliding_window_attention",
+    ],
+)
+def test_location_spec_name_rejects_removed_component_kind(kind: str) -> None:
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(
+            groups=(
+                KvCacheGroupSpec(
+                    group_idx=0,
+                    kind=kind,
+                    block_size=16,
+                    group_payload_size_bytes=128,
+                ),
+            )
+        ),
+    )
+
+    with pytest.raises(MetadataProtocolError, match="cannot classify"):
+        client._location_spec_name(0)
+
+
+def test_location_spec_name_uses_configured_extra_attention_type() -> None:
+    client = KvcmClient(
+        SubscriberConfig(extra_attention_types={"custom_attention": "arbitrary"}),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(
+            groups=(
+                KvCacheGroupSpec(
+                    group_idx=0,
+                    kind="custom_attention",
+                    block_size=16,
+                    group_payload_size_bytes=128,
+                ),
+            )
+        ),
+    )
+
+    assert client._location_spec_name(0) == "arbitrary0"
+
+
+def test_location_spec_name_rejects_unknown_component_kind() -> None:
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(
+            groups=(
+                KvCacheGroupSpec(
+                    group_idx=0,
+                    kind="unknown",
+                    block_size=16,
+                    group_payload_size_bytes=128,
+                ),
+            )
+        ),
+    )
+
+    with pytest.raises(MetadataProtocolError, match="cannot classify"):
+        client._location_spec_name(0)
+
+
+def test_validate_location_specs_rejects_unknown_component_kind_before_start() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(),
+        fake_sdk,
+        groups=(
+            KvCacheGroupSpec(
+                group_idx=0,
+                kind="unknown",
+                block_size=16,
+                group_payload_size_bytes=128,
+            ),
+        ),
+    )
+
+    with pytest.raises(MetadataProtocolError, match="cannot classify"):
+        client.validate_location_specs()
+
+    fake_sdk.start.assert_not_awaited()
+
+
+def test_validate_descriptor_location_specs_rejects_unknown_kind_without_client() -> (
+    None
+):
+    descriptor = KvCacheDescriptor(
+        groups=(
+            KvCacheGroupSpec(
+                group_idx=0,
+                kind="unknown",
+                block_size=16,
+                group_payload_size_bytes=128,
+            ),
+        )
+    )
+
+    with pytest.raises(MetadataProtocolError, match="cannot classify"):
+        KvcmClient.validate_descriptor_location_specs(SubscriberConfig(), descriptor)
+
+
+async def test_report_events_classifies_component_identity_drift_without_rpc() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+        groups=(
+            KvCacheGroupSpec(
+                group_idx=0,
+                kind="full_attention",
+                block_size=16,
+                group_payload_size_bytes=128,
+            ),
+        ),
+    )
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=[1],
+                parent_block_hash=None,
+                token_ids=[1],
+                block_size=16,
+                lora_id=None,
+                medium="GPU",
+                lora_name=None,
+                group_idx=99,
+            )
+        ],
+    )
+
+    with pytest.raises(KvcmReportRejectedError) as raised:
+        await client.report_kv_events([batch], epoch=1)
+
+    assert raised.value.status_code == "METADATA_PROTOCOL"
+    assert raised.value.reason == "metadata_protocol"
+    fake_sdk.report_event.assert_not_awaited()
+    await client.close()
+
+
+def test_kvcm_event_types_are_string_enum_values() -> None:
+    event_type = _client()._node_register_event()["event_type"]
+
+    assert isinstance(event_type, Enum)
+    assert event_type == "EVENT_NODE_REGISTER"
+
+
+async def test_start_creates_sdk_registers_instance_reports_node_and_starts_heartbeat():
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    await client.close()
+
+    fake_sdk.start.assert_awaited_once()
+    fake_sdk.register_instance.assert_called_once()
+    register_request = fake_sdk.register_instance.call_args.args[0]
+    assert register_request["block_size"] == 1
+
+    fake_sdk.report_event.assert_called_once()
+    node_request = fake_sdk.report_event.call_args.args[0]
+    assert node_request["events"] == [
+        {
+            "event_type": "EVENT_NODE_REGISTER",
+            "node_register": {"mediums": ["hbm", "mem"]},
+        }
+    ]
+    fake_sdk.close.assert_awaited_once()
+
+
+async def test_start_uses_injected_manager_client() -> None:
+    fake_sdk = FakeSdkClient()
+    client = KvcmClient(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        descriptor=KvCacheDescriptor(groups=()),
+        manager_client=fake_sdk,
+    )
+
+    await client.start()
+    await client.close()
+
+    fake_sdk.start.assert_awaited_once()
+    fake_sdk.is_ready.assert_awaited_once()
+    fake_sdk.register_instance.assert_awaited_once()
+    fake_sdk.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("base_url_env", "expected_url"),
+    [
+        ("spectrum://vs-a:6382", "spectrum://vs-a:6382"),
+        ("http://10.0.0.1:8080", "http://10.0.0.1:8080"),
+        (
+            "static://10.0.0.1:8080,10.0.0.2:8080",
+            "static://10.0.0.1:8080,10.0.0.2:8080",
+        ),
+    ],
+    ids=["spectrum", "http", "static"],
+)
+async def test_start_passes_kvcm_base_url_to_manager_client(
+    monkeypatch: pytest.MonkeyPatch, base_url_env: str, expected_url: str
+) -> None:
+    created_clients: list[FakeSdkClient] = []
+
+    def create_http_client(
+        base_url: str, *, request_timeout_seconds: float
+    ) -> FakeSdkClient:
+        client = FakeSdkClient(base_url)
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        "subscriber.kvcm.client.HttpKvCacheManagerClient", create_http_client
+    )
+
+    client = KvcmClient(
+        SubscriberConfig(
+            kvcm_base_url=base_url_env,
+            kvcm_protocol="http",
+            kvcm_heartbeat_interval_s=60.0,
+        ),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        descriptor=KvCacheDescriptor(groups=()),
+    )
+
+    await client.start()
+    await client.close()
+
+    assert [created.base_url for created in created_clients] == [expected_url]
+
+
+async def test_start_passes_kvcm_base_url_to_grpc_manager_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_clients: list[FakeSdkClient] = []
+
+    def create_grpc_client(
+        base_url: str, *, request_timeout_seconds: float
+    ) -> FakeSdkClient:
+        client = FakeSdkClient(base_url)
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        "subscriber.kvcm.grpc_manager_client.GrpcKvCacheManagerClient",
+        create_grpc_client,
+    )
+
+    client = KvcmClient(
+        SubscriberConfig(
+            kvcm_base_url="spectrum://vs-test:6381",
+            kvcm_heartbeat_interval_s=60.0,
+        ),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        descriptor=KvCacheDescriptor(groups=()),
+    )
+
+    await client.start()
+    await client.close()
+
+    assert [created.base_url for created in created_clients] == [
+        "spectrum://vs-test:6381"
+    ]
+
+
+def test_base_url_raises_when_kvcm_base_url_missing() -> None:
+    with pytest.raises(ValueError, match="kvcm_base_url"):
+        KvcmClient(
+            SubscriberConfig(),
+            medium_mapper=_vllm_medium_mapper,
+            storage_type="ST_EVENT_REPORT_L1P5",
+            supported_mediums=["hbm", "mem"],
+            descriptor=KvCacheDescriptor(groups=()),
+        )
+
+
+async def test_start_resolves_host_ip_port_once_and_reuses_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    config = SubscriberConfig(kvcm_heartbeat_interval_s=60.0)
+    resolver_calls: list[None] = []
+
+    async def resolve_host_ip_port(port: int) -> str:
+        resolver_calls.append(None)
+        return "10.0.0.7:8123"
+
+    monkeypatch.setattr(
+        "subscriber.kvcm.client.resolve_host_ip_port",
+        resolve_host_ip_port,
+    )
+    client = _make_kvcm(config, fake_sdk)
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_kv_events(
+        [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=7
+    )
+    await client._report_events([client._heartbeat_event()])
+    await client.close()
+
+    assert resolver_calls == [None]
+    assert [
+        call.args[0]["host_ip_port"] for call in fake_sdk.report_event.call_args_list
+    ] == ["10.0.0.7:8123", "10.0.0.7:8123", "10.0.0.7:8123"]
+
+
+async def test_start_survives_register_failure_and_starts_heartbeat(mocker) -> None:
+    fake_sdk = FakeSdkClient()
+    register_error = RuntimeError("register failed")
+    fake_sdk.register_instance.side_effect = register_error
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+
+    await client.start()
+
+    assert not client.is_registered
+    warning.assert_any_call(
+        "kvcm register_instance failed (%s: %s)",
+        "RuntimeError",
+        register_error,
+        step="kvcm_register",
+        tags={"phase": "register_instance"},
+        exc_info=register_error,
+    )
+    assert client._heartbeat_task is not None
+
+    await client.close()
+
+
+async def test_start_resets_registered_when_node_register_report_fails(
+    mocker,
+) -> None:
+    """Regression: if register_instance succeeds but the NODE_REGISTER report
+    fails, _registered must stay False so the heartbeat loop retries."""
+
+    fake_sdk = FakeSdkClient()
+    report_error = RuntimeError("node register report failed")
+
+    async def report_event(
+        request: dict[str, object], **_: object
+    ) -> dict[str, object]:
+        events = request.get("events")
+        if (
+            isinstance(events, list)
+            and events
+            and events[0].get("event_type") == "EVENT_NODE_REGISTER"
+        ):
+            raise report_error
+        return {"header": {"status": {"code": "OK"}}}
+
+    fake_sdk.report_event.side_effect = report_event
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+
+    await client.start()
+
+    assert not client.is_registered
+    warning.assert_any_call(
+        "kvcm node_register report failed (%s: %s)",
+        "RuntimeError",
+        report_error,
+        step="kvcm_register",
+        tags={"phase": "node_register"},
+        exc_info=report_error,
+    )
+    assert client._heartbeat_task is not None
+
+    await client.close()
+
+
+async def test_start_without_endpoint_drops_batches_then_registers_after_recovery(
+    mocker,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    fake_sdk.ready = False
+    registered = asyncio.Event()
+
+    async def register_instance(_request: dict[str, object]) -> dict[str, object]:
+        registered.set()
+        return {"header": {"status": {"code": "OK"}}}
+
+    fake_sdk.register_instance.side_effect = register_instance
+    warning = mocker.patch("subscriber.main.logger.warning")
+    client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+    await client.start()
+
+    fake_sdk.register_instance.assert_not_awaited()
+    fake_sdk.report_event.assert_not_awaited()
+
+    from subscriber.main import send_incremental_events
+
+    queue = asyncio.Queue()
+    batches = [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])]
+    await queue.put(mocker.Mock(batches=batches, epoch_snapshot=1))
+    coordinator = mocker.Mock()
+    coordinator.wait_ready_epoch = AsyncMock(return_value=1)
+    coordinator.is_epoch_current.return_value = True
+    sender = asyncio.create_task(
+        send_incremental_events(
+            client,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await queue.join()
+
+    warning.assert_any_call(
+        "kvcm has no available endpoint; starting in not-ready state",
+        step="kvcm_register",
+    )
+    send_warning = next(
+        call
+        for call in warning.call_args_list
+        if call.args == ("failed to send kv event batch to kvcm; dropping batch",)
+    )
+    assert "kvcm client is not ready" in send_warning.kwargs["tags"]["message"]
+
+    fake_sdk.ready = True
+    await asyncio.wait_for(registered.wait(), timeout=0.2)
+
+    fake_sdk.report_event.reset_mock()
+    await client.report_kv_events(batches, epoch=1)
+
+    assert fake_sdk.report_event.await_count == 2
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+    await client.close()
+
+
+async def test_report_events_before_start_raises_clear_error() -> None:
+    client = _client()
+
+    with pytest.raises(RuntimeError, match="kvcm client has not been started"):
+        await client._report_events([client._heartbeat_event()])
+
+
+async def test_report_kv_events_before_start_raises_clear_error() -> None:
+    client = _client()
+
+    with pytest.raises(RuntimeError, match="kvcm client has not been started"):
+        await client.report_kv_events(
+            [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+        )
+
+
+async def test_report_kv_events_raises_when_started_but_not_registered() -> None:
+    fake_sdk = FakeSdkClient()
+    fake_sdk.ready = False
+    client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+
+    await client.start()
+    assert not client.is_registered
+
+    with pytest.raises(RuntimeError, match="kvcm client is not ready"):
+        await client.report_kv_events(
+            [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+        )
+
+    fake_sdk.register_instance.assert_not_awaited()
+    await client.close()
+
+
+async def test_heartbeat_reports_periodically() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+    )
+
+    await client.start()
+    await asyncio.sleep(0.03)
+    await client.close()
+
+    heartbeat_calls = [
+        call.args[0]
+        for call in fake_sdk.report_event.call_args_list
+        if call.args[0]["events"]
+        == [{"event_type": "EVENT_HEARTBEAT", "heartbeat": {"system_status": {}}}]
+    ]
+    assert heartbeat_calls
+    fake_sdk.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "reset_response",
+    [{"snapshot_required": False}, {}],
+)
+async def test_heartbeat_snapshot_required_deduplicates_until_reset(
+    reset_response: dict[str, object],
+) -> None:
+    fake_sdk = FakeSdkClient()
+    heartbeat_responses = [
+        {"snapshot_required": True},
+        {"snapshot_required": True},
+        reset_response,
+        {"snapshot_required": True},
+    ]
+    heartbeat_count = 0
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        nonlocal heartbeat_count
+        if request["events"][0]["event_type"] == "EVENT_HEARTBEAT":
+            # Repeat the last response for stray heartbeats before close().
+            response = heartbeat_responses[min(heartbeat_count, 3)]
+            heartbeat_count += 1
+            return response
+        return {"header": {"status": {"code": "OK"}}}
+
+    callback_heartbeats: list[int] = []
+    second_snapshot_requested = asyncio.Event()
+
+    def on_snapshot_required() -> None:
+        callback_heartbeats.append(heartbeat_count)
+        if len(callback_heartbeats) == 2:
+            second_snapshot_requested.set()
+
+    fake_sdk.report_event.side_effect = report_event
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+        on_snapshot_required=on_snapshot_required,
+    )
+
+    await client.start()
+    await asyncio.wait_for(second_snapshot_requested.wait(), timeout=0.2)
+    await client.close()
+
+    # Fired on the first heartbeat of each snapshot_required=True streak:
+    # heartbeat 2 is deduplicated, heartbeat 3 resets, heartbeat 4 re-fires.
+    assert callback_heartbeats == [1, 4]
+
+
+async def test_heartbeat_snapshot_callback_failure_retries(mocker) -> None:
+    fake_sdk = FakeSdkClient()
+    callback_error = RuntimeError("snapshot callback failed")
+    callback_count = 0
+    callback_retried = asyncio.Event()
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        if request["events"][0]["event_type"] == "EVENT_HEARTBEAT":
+            return {"snapshot_required": True}
+        return {"header": {"status": {"code": "OK"}}}
+
+    def on_snapshot_required() -> None:
+        nonlocal callback_count
+        callback_count += 1
+        if callback_count == 1:
+            raise callback_error
+        callback_retried.set()
+
+    fake_sdk.report_event.side_effect = report_event
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+        on_snapshot_required=on_snapshot_required,
+    )
+
+    await client.start()
+    await asyncio.wait_for(callback_retried.wait(), timeout=0.2)
+    assert client.is_registered
+    await client.close()
+
+    assert callback_count == 2
+    warning.assert_any_call(
+        "failed to request immediate snapshot from kvcm heartbeat; "
+        "continuing heartbeat",
+        step="snapshot_signal",
+        tags={
+            "error": "RuntimeError",
+            "message": str(callback_error),
+            "failure_count": 1,
+        },
+        exc_info=callback_error,
+    )
+
+
+async def test_heartbeat_snapshot_persistent_failure_rate_limits_warnings(
+    mocker,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    failure_count = 0
+    three_failures = asyncio.Event()
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        if request["events"][0]["event_type"] == "EVENT_HEARTBEAT":
+            return {"snapshot_required": True}
+        return {"header": {"status": {"code": "OK"}}}
+
+    def on_snapshot_required() -> None:
+        nonlocal failure_count
+        failure_count += 1
+        if failure_count == 3:
+            three_failures.set()
+        raise RuntimeError("snapshot callback failed")
+
+    fake_sdk.report_event.side_effect = report_event
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+        on_snapshot_required=on_snapshot_required,
+    )
+
+    await client.start()
+    await asyncio.wait_for(three_failures.wait(), timeout=0.3)
+    await client.close()
+
+    assert failure_count >= 3
+    snapshot_warns = [
+        call
+        for call in warning.call_args_list
+        if call.kwargs.get("step") == "snapshot_signal"
+    ]
+    assert len(snapshot_warns) == 1
+    assert snapshot_warns[0].kwargs["tags"]["failure_count"] == 1
+
+
+async def test_heartbeat_snapshot_failure_count_resets_per_streak(mocker) -> None:
+    fake_sdk = FakeSdkClient()
+    heartbeat_count = 0
+    failure_count = 0
+    second_streak_failed = asyncio.Event()
+    # True -> failure streak 1; False -> streak reset; True -> streak 2.
+    heartbeat_responses = [
+        {"snapshot_required": True},
+        {"snapshot_required": False},
+        {"snapshot_required": True},
+    ]
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        nonlocal heartbeat_count
+        if request["events"][0]["event_type"] != "EVENT_HEARTBEAT":
+            return {"header": {"status": {"code": "OK"}}}
+        # Repeat the last response for stray heartbeats before close().
+        response = heartbeat_responses[min(heartbeat_count, 2)]
+        heartbeat_count += 1
+        return response
+
+    def on_snapshot_required() -> None:
+        nonlocal failure_count
+        failure_count += 1
+        if failure_count == 2:
+            second_streak_failed.set()
+        raise RuntimeError("snapshot callback failed")
+
+    fake_sdk.report_event.side_effect = report_event
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+        on_snapshot_required=on_snapshot_required,
+    )
+
+    await client.start()
+    await asyncio.wait_for(second_streak_failed.wait(), timeout=0.3)
+    await client.close()
+
+    snapshot_warns = [
+        call
+        for call in warning.call_args_list
+        if call.kwargs.get("step") == "snapshot_signal"
+    ]
+    assert len(snapshot_warns) == 2
+    assert [call.kwargs["tags"]["failure_count"] for call in snapshot_warns] == [1, 1]
+
+
+async def test_heartbeat_snapshot_dedup_resets_after_reregistration() -> None:
+    fake_sdk = FakeSdkClient()
+    heartbeat_count = 0
+    callback_count = 0
+    snapshot_requested_after_recovery = asyncio.Event()
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        nonlocal heartbeat_count
+        if request["events"][0]["event_type"] != "EVENT_HEARTBEAT":
+            return {"header": {"status": {"code": "OK"}}}
+        heartbeat_count += 1
+        if heartbeat_count == 2:
+            raise RuntimeError("kvcm unavailable")
+        return {"snapshot_required": True}
+
+    def on_snapshot_required() -> None:
+        nonlocal callback_count
+        callback_count += 1
+        if callback_count == 2:
+            snapshot_requested_after_recovery.set()
+
+    fake_sdk.report_event.side_effect = report_event
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+        on_snapshot_required=on_snapshot_required,
+    )
+
+    await client.start()
+    await asyncio.wait_for(snapshot_requested_after_recovery.wait(), timeout=0.3)
+    assert client.is_registered
+    await client.close()
+
+    assert callback_count == 2
+    assert fake_sdk.register_instance.await_count >= 2
+
+
+@pytest.mark.parametrize("value", [1, "true"])
+async def test_heartbeat_snapshot_required_requires_strict_bool(
+    value: object,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    heartbeat_count = 0
+    two_heartbeats_done = asyncio.Event()
+    callback_count = 0
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        nonlocal heartbeat_count
+        if request["events"][0]["event_type"] == "EVENT_HEARTBEAT":
+            heartbeat_count += 1
+            if heartbeat_count >= 2:
+                two_heartbeats_done.set()
+            return {"snapshot_required": value}
+        return {"header": {"status": {"code": "OK"}}}
+
+    def on_snapshot_required() -> None:
+        nonlocal callback_count
+        callback_count += 1
+
+    fake_sdk.report_event.side_effect = report_event
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+        on_snapshot_required=on_snapshot_required,
+    )
+
+    await client.start()
+    await asyncio.wait_for(two_heartbeats_done.wait(), timeout=0.2)
+    assert client.is_registered
+    await client.close()
+
+    assert callback_count == 0
+
+
+async def test_heartbeat_snapshot_required_without_callback_is_ignored() -> None:
+    fake_sdk = FakeSdkClient()
+    heartbeat_count = 0
+    two_heartbeats_done = asyncio.Event()
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        nonlocal heartbeat_count
+        if request["events"][0]["event_type"] == "EVENT_HEARTBEAT":
+            heartbeat_count += 1
+            if heartbeat_count >= 2:
+                two_heartbeats_done.set()
+            return {"snapshot_required": True}
+        return {"header": {"status": {"code": "OK"}}}
+
+    fake_sdk.report_event.side_effect = report_event
+    client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+    await client.start()
+    await asyncio.wait_for(two_heartbeats_done.wait(), timeout=0.2)
+    assert client.is_registered
+    await client.close()
+
+
+async def test_heartbeat_failure_logs_warning_and_continues(mocker) -> None:
+    fake_sdk = FakeSdkClient()
+    heartbeat_error = RuntimeError("heartbeat failed")
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        events = request["events"]
+        if (
+            isinstance(events, list)
+            and events
+            and events[0].get("event_type") == "EVENT_HEARTBEAT"
+        ):
+            raise heartbeat_error
+        return {"header": {"status": {"code": "OK"}}}
+
+    fake_sdk.report_event.side_effect = report_event
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=0.01),
+        fake_sdk,
+    )
+
+    await client.start()
+    await asyncio.sleep(0.03)
+    await client.close()
+
+    warning.assert_any_call(
+        "kvcm heartbeat report failed (%s: %s)",
+        "RuntimeError",
+        heartbeat_error,
+        step="kvcm_heartbeat",
+        exc_info=heartbeat_error,
+    )
+
+
+async def test_runtime_kvcm_failure_retries_registration_until_recovered() -> None:
+    fake_sdk = FakeSdkClient()
+    recovered = asyncio.Event()
+    heartbeat_failed = False
+
+    async def register_instance(_request: dict[str, object]) -> dict[str, object]:
+        if fake_sdk.register_instance.await_count < 4:
+            if fake_sdk.register_instance.await_count > 1:
+                raise RuntimeError("kvcm registration unavailable")
+        else:
+            recovered.set()
+        return {"header": {"status": {"code": "OK"}}}
+
+    async def report_event(
+        request: dict[str, object], **_kwargs: object
+    ) -> dict[str, object]:
+        nonlocal heartbeat_failed
+        event_type = request["events"][0]["event_type"]
+        if event_type == "EVENT_HEARTBEAT" and not heartbeat_failed:
+            heartbeat_failed = True
+            raise RuntimeError("kvcm unavailable")
+        return {"header": {"status": {"code": "OK"}}}
+
+    fake_sdk.register_instance.side_effect = register_instance
+    fake_sdk.report_event.side_effect = report_event
+    client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+    await client.start()
+    await asyncio.wait_for(recovered.wait(), timeout=0.3)
+    assert fake_sdk.register_instance.await_count == 4
+    assert client.is_registered
+    await client.close()
+
+
+async def test_report_kv_events_reports_events_without_blocking_sdk_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    main_thread = threading.current_thread()
+    report_threads: list[threading.Thread] = []
+
+    async def track_report(
+        request: dict[str, object], *, check_response: bool = True
+    ) -> dict[str, object]:
+        report_threads.append(threading.current_thread())
+        return {"header": {"status": {"code": "OK"}}}
+
+    monkeypatch.setattr(fake_sdk, "report_event", track_report)
+
+    await client.start()
+    await client.report_kv_events(
+        [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=7
+    )
+    await client.close()
+
+    assert report_threads
+    assert report_threads == [main_thread, main_thread, main_thread]
+
+
+async def test_report_kv_events_reports_converted_events() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_kv_events([batch], epoch=7, trace_id="incremental-trace")
+    await client.close()
+
+    fake_sdk.report_event.assert_called_once()
+    request = fake_sdk.report_event.call_args.args[0]
+    assert request["trace_id"] == "incremental-trace"
+    assert request["events"] == [
+        {
+            "event_type": "EVENT_BLOCK_DELETE",
+            "block_delete": {
+                "block_key": "13",
+                "medium": "mem",
+                "spec_names": ["vllm_1"],
+            },
+        }
+    ]
+
+
+async def test_report_kv_events_sends_host_down_before_replayed_blocks() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    batches = [
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                BlockStored(
+                    block_hashes=[11],
+                    parent_block_hash=None,
+                    token_ids=[1],
+                    block_size=1,
+                    lora_id=None,
+                    medium="GPU",
+                    lora_name=None,
+                ),
+                AllBlocksCleared(),
+            ],
+        ),
+        KVEventBatch(
+            ts=2.0,
+            events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+        ),
+    ]
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_kv_events(batches, epoch=7, trace_id="replay-trace")
+    await client.close()
+
+    requests = [call.args[0] for call in fake_sdk.report_event.call_args_list]
+    assert [request["events"] for request in requests] == [
+        [{"event_type": "EVENT_HOST_DOWN", "host_down": {}}],
+        [
+            {
+                "event_type": "EVENT_NODE_REGISTER",
+                "node_register": {"mediums": ["hbm", "mem"]},
+            }
+        ],
+        [
+            {
+                "event_type": "EVENT_BLOCK_DELETE",
+                "block_delete": {
+                    "block_key": "13",
+                    "medium": "mem",
+                    "spec_names": ["vllm_1"],
+                },
+            }
+        ],
+    ]
+    assert [request["trace_id"] for request in requests] == [
+        "replay-trace",
+        "replay-trace",
+        "replay-trace",
+    ]
+
+
+async def test_report_kv_events_logs_expansion_and_report_event_diagnostics(
+    mocker,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    debug = mocker.patch("subscriber.kvcm.client.logger.debug")
+    mocker.patch("subscriber.kvcm.client.logger.is_debug_enabled", return_value=True)
+
+    await client.report_kv_events([batch], epoch=7, trace_id="incremental-trace")
+    await client.close()
+
+    debug.assert_called_once()
+    args = debug.call_args
+    assert args.args == ("kvcm report_event timing",)
+    assert args.kwargs["step"] == "kvcm_send"
+    tags = args.kwargs["tags"]
+    assert tags["source_batch_count"] == 1
+    assert tags["trace_id"] == "incremental-trace"
+    assert tags["source_event_count"] == 1
+    assert tags["report_event_count"] == 1
+    assert tags["event_expand_ms"] >= 0
+    assert tags["status_code"] == "OK"
+    assert tags["kvcm_report_event_call_ms"] >= 0
+    assert tags["kvcm_send_total_ms"] >= 0
+
+
+async def test_report_kv_events_ignores_telemetry_recording_failures() -> None:
+    """A telemetry failure must not turn a successful report into a failure."""
+
+    def failing_clock() -> float:
+        raise RuntimeError("telemetry clock failed")
+
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    telemetry = BatchTelemetry(pipeline="incremental", clock=failing_clock)
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    try:
+        snapshot_required = await client.report_kv_events(
+            [
+                KVEventBatch(
+                    ts=1.0,
+                    events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+                )
+            ],
+            epoch=7,
+            telemetries=[telemetry],
+        )
+    finally:
+        await client.close()
+
+    assert snapshot_required is False
+    fake_sdk.report_event.assert_awaited_once()
+
+
+async def test_report_kv_events_emits_terminal_qps_and_latency(
+    mocker: MockerFixture,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    telemetry = BatchTelemetry(pipeline="incremental")
+    counter = mocker.patch("subscriber.metrics.reporter._dashlog_counter")
+    gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+    reporter = MetricsReporter()
+
+    await client.start()
+    fake_sdk.report_event.return_value = {
+        "header": {"status": {"code": "OK"}},
+        "_subscriber_retry_count": 1,
+        "_subscriber_request_bytes": 256,
+        "_subscriber_wire_encode_ms": 1.25,
+        "_subscriber_grpc_call_ms": 2.5,
+    }
+    await reporter.start()
+    try:
+        await client.report_kv_events(
+            [
+                KVEventBatch(
+                    ts=1.0,
+                    events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+                )
+            ],
+            epoch=7,
+            telemetries=[telemetry],
+        )
+        assert telemetry.gauges["kvcm_report_event_count"] == 1
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+    finally:
+        await reporter.stop()
+        await client.close()
+
+    assert (
+        call(
+            "kvcm_report_event_request_count",
+            1,
+            tags={"pipeline": "incremental", "status_code": "OK"},
+        )
+        in counter.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_retry_count",
+            1,
+            tags={"pipeline": "incremental", "reason": "SERVER_NOT_LEADER"},
+        )
+        in counter.call_args_list
+    )
+    assert any(
+        recorded.args[0] == "kvcm_report_event_call_ms"
+        and recorded.kwargs["tags"] == {"pipeline": "incremental", "status_code": "OK"}
+        and recorded.args[1] >= 0
+        for recorded in gauge.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_request_bytes",
+            256,
+            tags={"pipeline": "incremental", "status_code": "OK"},
+        )
+        in gauge.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_wire_encode_ms",
+            1.25,
+            tags={"pipeline": "incremental", "status_code": "OK"},
+        )
+        in gauge.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_grpc_call_ms",
+            2.5,
+            tags={"pipeline": "incremental", "status_code": "OK"},
+        )
+        in gauge.call_args_list
+    )
+
+
+async def test_report_kv_events_emits_failed_qps_and_latency_with_status(
+    mocker: MockerFixture,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    telemetry = BatchTelemetry(pipeline="incremental")
+    counter = mocker.patch("subscriber.metrics.reporter._dashlog_counter")
+    gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+    reporter = MetricsReporter()
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    fake_sdk.report_event.side_effect = KvcmUnavailableError(
+        "KVCM transport failed after retry",
+        status_code="GRPC_UNAVAILABLE",
+        reason="transport",
+        retry_count=1,
+        request_bytes=256,
+        wire_encode_ms=1.25,
+        grpc_call_ms=0.0,
+    )
+    await reporter.start()
+    try:
+        with pytest.raises(
+            KvcmUnavailableError, match="KVCM transport failed after retry"
+        ):
+            await client.report_kv_events(
+                [
+                    KVEventBatch(
+                        ts=1.0,
+                        events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+                    )
+                ],
+                epoch=7,
+                telemetries=[telemetry],
+            )
+        assert [span.name for span in telemetry.spans] == ["expand", "kvcm_send"]
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+    finally:
+        await reporter.stop()
+        await client.close()
+
+    assert (
+        call(
+            "kvcm_report_event_request_count",
+            1,
+            tags={"pipeline": "incremental", "status_code": "GRPC_UNAVAILABLE"},
+        )
+        in counter.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_failure_count",
+            1,
+            tags={
+                "pipeline": "incremental",
+                "status_code": "GRPC_UNAVAILABLE",
+                "reason": "transport",
+            },
+        )
+        in counter.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_retry_count",
+            1,
+            tags={"pipeline": "incremental", "reason": "SERVER_NOT_LEADER"},
+        )
+        in counter.call_args_list
+    )
+    assert any(
+        recorded.args[0] == "kvcm_report_event_call_ms"
+        and recorded.kwargs["tags"]
+        == {"pipeline": "incremental", "status_code": "GRPC_UNAVAILABLE"}
+        and recorded.args[1] >= 0
+        for recorded in gauge.call_args_list
+    )
+    failure_gauge_tags = {
+        "pipeline": "incremental",
+        "status_code": "GRPC_UNAVAILABLE",
+    }
+    assert (
+        call("kvcm_report_event_request_bytes", 256, tags=failure_gauge_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_wire_encode_ms", 1.25, tags=failure_gauge_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_grpc_call_ms", 0.0, tags=failure_gauge_tags)
+        in gauge.call_args_list
+    )
+
+
+async def test_send_empty_batch_does_not_report_event() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_kv_events([], epoch=7)
+    await client.close()
+
+    fake_sdk.report_event.assert_not_called()
+
+
+async def test_report_kv_events_no_longer_rejects_snapshot_batch() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockSnapshot(
+                medium="GPU",
+                block_size=16,
+                items=[BlockSnapshotItem(block_hash=101, group_idx=0)],
+                snapshot_version=1,
+            )
+        ],
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_kv_events([batch], epoch=7)
+    await client.close()
+
+    fake_sdk.report_event.assert_not_called()
+
+
+def _snapshot_batch() -> KVEventBatch:
+    return KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockSnapshot(
+                medium="GPU",
+                block_size=16,
+                items=[
+                    BlockSnapshotItem(block_hash=101, group_idx=0),
+                    BlockSnapshotItem(block_hash=102, group_idx=0),
+                ],
+                snapshot_version=3,
+            )
+        ],
+    )
+
+
+def _empty_snapshot_batch() -> KVEventBatch:
+    return KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockSnapshot(
+                medium="GPU",
+                block_size=16,
+                items=[],
+                snapshot_version=4,
+            )
+        ],
+    )
+
+
+async def test_report_snapshot_before_start_raises_clear_error() -> None:
+    client = _client()
+
+    with pytest.raises(RuntimeError, match="kvcm client has not been started"):
+        await client.report_snapshot([_snapshot_batch()], epoch=1)
+
+
+async def test_report_snapshot_raises_when_started_but_not_registered() -> None:
+    fake_sdk = FakeSdkClient()
+    fake_sdk.ready = False
+    client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+
+    await client.start()
+    assert not client.is_registered
+
+    with pytest.raises(KvcmUnavailableError, match="kvcm client is not ready"):
+        await client.report_snapshot([_snapshot_batch()], epoch=1)
+
+    fake_sdk.report_event.assert_not_awaited()
+    await client.close()
+
+
+async def test_report_snapshot_reports_snapshot_event() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_snapshot(
+        [_snapshot_batch()], epoch=7, trace_id="snapshot-trace"
+    )
+    await client.close()
+
+    fake_sdk.report_event.assert_awaited_once()
+    request = fake_sdk.report_event.call_args.args[0]
+    assert request["trace_id"] == "snapshot-trace"
+    assert request["instance_id"] == client._instance_id()
+    assert request["host_ip_port"] == "10.0.0.8:9000"
+    assert request["storage_type"] == "ST_EVENT_REPORT_L1P5"
+    assert request["events"] == [
+        {
+            "event_type": "EVENT_BLOCK_SNAPSHOT",
+            "block_snapshot": {
+                "blocks": [
+                    {
+                        "block_key": "101",
+                        "medium": "hbm",
+                        "specs": [
+                            {
+                                "name": "vllm_1",
+                                "uri": "vllm://10.0.0.8:9000/hbm",
+                            }
+                        ],
+                    },
+                    {
+                        "block_key": "102",
+                        "medium": "hbm",
+                        "specs": [
+                            {
+                                "name": "vllm_1",
+                                "uri": "vllm://10.0.0.8:9000/hbm",
+                            }
+                        ],
+                    },
+                ]
+            },
+        }
+    ]
+    assert fake_sdk.report_event.call_args.kwargs == {"check_response": True}
+
+
+async def test_group_aware_snapshot_uses_registered_short_spec_name() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+        groups=(
+            KvCacheGroupSpec(
+                group_idx=5,
+                kind="cross_attention",
+                block_size=16,
+                group_payload_size_bytes=128,
+            ),
+        ),
+    )
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockSnapshot(
+                medium="GPU",
+                block_size=16,
+                items=[BlockSnapshotItem(block_hash=101, group_idx=5)],
+                snapshot_version=1,
+            )
+        ],
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_snapshot([batch], epoch=7)
+    await client.close()
+
+    request = fake_sdk.report_event.call_args.args[0]
+    blocks = request["events"][0]["block_snapshot"]["blocks"]
+    assert blocks == [
+        {
+            "block_key": "101",
+            "medium": "hbm",
+            "specs": [
+                {
+                    "name": "X5",
+                    "uri": "vllm://10.0.0.8:9000/hbm",
+                }
+            ],
+        }
+    ]
+
+
+async def test_report_snapshot_emits_source_and_deduplicated_block_sizes(
+    mocker: MockerFixture,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    telemetry = BatchTelemetry(pipeline="snapshot")
+    counter = mocker.patch("subscriber.metrics.reporter._dashlog_counter")
+    gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+    reporter = MetricsReporter()
+    batches = [
+        _snapshot_batch(),
+        KVEventBatch(
+            ts=2.0,
+            events=[
+                BlockSnapshot(
+                    medium="GPU",
+                    block_size=16,
+                    items=[
+                        BlockSnapshotItem(block_hash=102, group_idx=0),
+                        BlockSnapshotItem(block_hash=103, group_idx=0),
+                    ],
+                    snapshot_version=3,
+                )
+            ],
+        ),
+    ]
+
+    await client.start()
+    fake_sdk.report_event.return_value = {
+        "header": {"status": {"code": "OK"}},
+        "_subscriber_request_bytes": 512,
+        "_subscriber_wire_encode_ms": 3.5,
+        "_subscriber_grpc_call_ms": 7.0,
+    }
+    await reporter.start()
+    try:
+        await client.report_snapshot(batches, epoch=7, telemetry=telemetry)
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+    finally:
+        await reporter.stop()
+        await client.close()
+
+    expected_tags = {"pipeline": "snapshot", "status_code": "OK"}
+    assert (
+        call("kvcm_snapshot_source_block_count", 4, tags=expected_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_snapshot_merged_block_count", 3, tags=expected_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_request_count",
+            1,
+            tags=expected_tags,
+        )
+        in counter.call_args_list
+    )
+    assert any(
+        recorded.args[0] == "kvcm_report_event_call_ms"
+        and recorded.kwargs["tags"] == expected_tags
+        and recorded.args[1] >= 0
+        for recorded in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_request_bytes", 512, tags=expected_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_wire_encode_ms", 3.5, tags=expected_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_grpc_call_ms", 7.0, tags=expected_tags)
+        in gauge.call_args_list
+    )
+
+
+async def test_report_snapshot_emits_failed_qps_and_latency_with_status(
+    mocker: MockerFixture,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    telemetry = BatchTelemetry(pipeline="snapshot")
+    counter = mocker.patch("subscriber.metrics.reporter._dashlog_counter")
+    gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+    reporter = MetricsReporter()
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    fake_sdk.report_event.side_effect = KvcmResponseRejectedError(
+        "KVCM rejected snapshot",
+        status_code="INVALID_ARGUMENT",
+        request_bytes=512,
+        wire_encode_ms=3.5,
+        grpc_call_ms=7.0,
+    )
+    await reporter.start()
+    try:
+        with pytest.raises(KvcmReportRejectedError, match="KVCM rejected snapshot"):
+            await client.report_snapshot(
+                [_snapshot_batch()], epoch=7, telemetry=telemetry
+            )
+        assert [span.name for span in telemetry.spans] == ["expand", "kvcm_send"]
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+    finally:
+        await reporter.stop()
+        await client.close()
+
+    expected_tags = {
+        "pipeline": "snapshot",
+        "status_code": "INVALID_ARGUMENT",
+    }
+    assert (
+        call("kvcm_report_event_request_count", 1, tags=expected_tags)
+        in counter.call_args_list
+    )
+    assert (
+        call(
+            "kvcm_report_event_failure_count",
+            1,
+            tags={**expected_tags, "reason": "rejected"},
+        )
+        in counter.call_args_list
+    )
+    assert any(
+        recorded.args[0] == "kvcm_report_event_call_ms"
+        and recorded.kwargs["tags"] == expected_tags
+        and recorded.args[1] >= 0
+        for recorded in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_request_bytes", 512, tags=expected_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_wire_encode_ms", 3.5, tags=expected_tags)
+        in gauge.call_args_list
+    )
+    assert (
+        call("kvcm_report_event_grpc_call_ms", 7.0, tags=expected_tags)
+        in gauge.call_args_list
+    )
+
+
+async def test_report_snapshot_forwards_empty_snapshot_to_clear_stale_blocks() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_snapshot([_empty_snapshot_batch()], epoch=7)
+    await client.close()
+
+    fake_sdk.report_event.assert_awaited_once()
+    request = fake_sdk.report_event.call_args.args[0]
+    assert request["events"] == [
+        {
+            "event_type": "EVENT_BLOCK_SNAPSHOT",
+            "block_snapshot": {"blocks": []},
+        }
+    ]
+    assert fake_sdk.report_event.call_args.kwargs == {"check_response": True}
+
+
+async def test_report_snapshot_without_snapshots_does_not_report_event() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    await client.report_snapshot([batch], epoch=7)
+    await client.close()
+
+    fake_sdk.report_event.assert_not_called()
+
+
+async def test_report_snapshot_classifies_rejected_report_error() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    fake_sdk.report_event.side_effect = RuntimeError(
+        "KVCM /api/reportEvent failed: INTERNAL_ERROR"
+    )
+
+    with pytest.raises(KvcmReportRejectedError, match="INTERNAL_ERROR"):
+        await client.report_snapshot(
+            [_snapshot_batch()], epoch=7, trace_id="snapshot-trace"
+        )
+    await client.close()
+
+
+async def test_report_snapshot_classifies_transport_rejected_error() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    fake_sdk.report_event.side_effect = KvcmResponseRejectedError(
+        "KVCM /grpc/ReportEvent failed: INTERNAL_ERROR"
+    )
+
+    with pytest.raises(KvcmReportRejectedError, match="INTERNAL_ERROR"):
+        await client.report_snapshot([_snapshot_batch()], epoch=7)
+    await client.close()
+
+
+async def test_report_snapshot_classifies_unavailable_error() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    fake_sdk.report_event.side_effect = RuntimeError("connection refused")
+
+    with pytest.raises(KvcmUnavailableError, match="connection refused"):
+        await client.report_snapshot([_snapshot_batch()], epoch=7)
+    await client.close()
+
+
+async def test_report_snapshot_logs_warning_for_item_results(mocker) -> None:
+    fake_sdk = FakeSdkClient()
+    fake_sdk.report_event.return_value = {
+        "header": {"status": {"code": "OK"}},
+        "item_results": ["OK", "INTERNAL_ERROR"],
+    }
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    warning.reset_mock()
+
+    with pytest.raises(KvcmReportRejectedError, match="item_results"):
+        await client.report_snapshot(
+            [_snapshot_batch()], epoch=7, trace_id="snapshot-trace"
+        )
+    await client.close()
+
+    warning.assert_called_once_with(
+        "kvcm report_event returned partial item results",
+        step="kvcm_send",
+        tags={
+            "epoch": 7,
+            "trace_id": "snapshot-trace",
+            "item_results": ["OK", "INTERNAL_ERROR"],
+        },
+    )
+
+
+async def test_report_snapshot_logs_expansion_and_report_event_diagnostics(
+    mocker,
+) -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    debug = mocker.patch("subscriber.kvcm.client.logger.debug")
+    mocker.patch("subscriber.kvcm.client.logger.is_debug_enabled", return_value=True)
+
+    await client.report_snapshot(
+        [_snapshot_batch()], epoch=7, trace_id="snapshot-trace"
+    )
+    await client.close()
+
+    debug.assert_called_once()
+    args = debug.call_args
+    assert args.args == ("kvcm snapshot report_event timing",)
+    assert args.kwargs["step"] == "kvcm_send"
+    tags = args.kwargs["tags"]
+    assert tags["epoch"] == 7
+    assert tags["trace_id"] == "snapshot-trace"
+    assert tags["source_batch_count"] == 1
+    assert tags["source_event_count"] == 1
+    assert tags["snapshot_block_count"] == 2
+    assert tags["event_expand_ms"] >= 0
+    assert tags["status_code"] == "OK"
+    assert tags["kvcm_report_event_call_ms"] >= 0
+    assert tags["kvcm_send_total_ms"] >= 0
+
+
+async def test_report_kv_events_logs_warning_for_item_results(mocker) -> None:
+    fake_sdk = FakeSdkClient()
+    fake_sdk.report_event.return_value = {
+        "header": {"status": {"code": "OK"}},
+        "item_results": ["OK", "INTERNAL_ERROR"],
+    }
+    warning = mocker.patch("subscriber.kvcm.client.logger.warning")
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    warning.reset_mock()
+
+    from subscriber.kvcm.errors import KvcmReportRejectedError
+
+    with pytest.raises(KvcmReportRejectedError, match="item_results"):
+        await client.report_kv_events([batch], epoch=7, trace_id="incremental-trace")
+    await client.close()
+
+    warning.assert_called_once_with(
+        "kvcm report_event returned partial item results",
+        step="kvcm_send",
+        tags={
+            "epoch": 7,
+            "trace_id": "incremental-trace",
+            "item_results": ["OK", "INTERNAL_ERROR"],
+        },
+    )
+
+
+async def test_report_kv_events_requests_manager_response_validation() -> None:
+    fake_sdk = FakeSdkClient()
+    client = _make_kvcm(
+        SubscriberConfig(kvcm_heartbeat_interval_s=60.0),
+        fake_sdk,
+    )
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[BlockRemoved(block_hashes=[13], medium="CPU")],
+    )
+
+    await client.start()
+    fake_sdk.report_event.reset_mock()
+    fake_sdk.report_event.side_effect = RuntimeError(
+        "KVCM /api/reportEvent failed: INTERNAL_ERROR "
+        "ReportEvent partially failed; see item_results"
+    )
+
+    with pytest.raises(RuntimeError, match="INTERNAL_ERROR"):
+        await client.report_kv_events([batch], epoch=7)
+
+    await client.close()
+
+    fake_sdk.report_event.assert_awaited_once()
+    assert fake_sdk.report_event.call_args.kwargs == {"check_response": True}
+
+
+@pytest.mark.parametrize(
+    "engine_config",
+    [None, '{"block_size": 16}'],
+    ids=["default_block_size", "custom_block_size"],
+)
+def test_register_and_report_event_use_same_instance_id(
+    monkeypatch: pytest.MonkeyPatch, engine_config: str | None
+) -> None:
+    monkeypatch.setenv("SPECTRUM_DEPLOYMENT_NAME", "deploy-x")
+    if engine_config is not None:
+        monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", engine_config)
+    else:
+        monkeypatch.delenv("DS_LLM_ENGINE_CONFIG", raising=False)
+
+    client = _client()
+    register_request = client._register_instance_request()
+    report_request = client._report_event_request(
+        [{"event_type": "EVENT_HOST_DOWN", "host_down": {}}]
+    )
+
+    assert register_request["instance_id"] == report_request["instance_id"]
+
+
+def test_location_specs_uses_configured_block_size_without_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 32}')
+    client = _client()
+
+    infos, groups = client._location_specs()
+
+    assert infos == [{"name": "vllm_32", "size": 32}]
+    assert groups == [{"name": "default", "spec_names": ["vllm_32"]}]
+    assert client._effective_block_size() == 32
+
+
+def test_location_specs_uses_per_group_payload_bytes_with_metadata() -> None:
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=128,
+            group_payload_size_bytes=70_254_592,
+        ),
+        KvCacheGroupSpec(
+            group_idx=1,
+            kind="mamba",
+            block_size=64,
+            group_payload_size_bytes=35_127_296,
+        ),
+    ]
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=tuple(metadata)),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    infos, groups = client._location_specs()
+
+    assert infos == [
+        {"name": "F0", "size": 70_254_592},
+        {"name": "L1", "size": 35_127_296},
+    ]
+    assert groups == [
+        {"name": "F0", "spec_names": ["F0"]},
+        {"name": "L1", "spec_names": ["L1"]},
+    ]
+
+
+def test_register_request_block_size_coherent_with_location_specs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 64}')
+    client = _client()
+
+    request = client._register_instance_request()
+
+    assert request["block_size"] == 64
+    for spec_info in request["location_spec_infos"]:
+        assert spec_info["size"] == request["block_size"]
+
+
+def test_register_request_separates_block_size_from_payload_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DS_LLM_ENGINE_CONFIG", '{"block_size": 16}')
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=2192,
+            group_payload_size_bytes=70_254_592,
+        ),
+        KvCacheGroupSpec(
+            group_idx=1,
+            kind="mamba",
+            block_size=16,
+            group_payload_size_bytes=35_127_296,
+        ),
+    ]
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=tuple(metadata)),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    request = client._register_instance_request()
+
+    assert request["block_size"] == 16
+    spec_sizes = {s["name"]: s["size"] for s in request["location_spec_infos"]}
+    assert spec_sizes == {"F0": 70_254_592, "L1": 35_127_296}
+
+
+def test_block_spec_names_consistent_with_registered_specs() -> None:
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=16,
+            group_payload_size_bytes=128,
+        ),
+        KvCacheGroupSpec(
+            group_idx=1,
+            kind="mamba",
+            block_size=16,
+            group_payload_size_bytes=64,
+        ),
+    ]
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=tuple(metadata)),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    registered_names = {
+        s["name"] for s in client._register_instance_request()["location_spec_infos"]
+    }
+    for group_idx in (0, 1):
+        assert set(client._block_spec_names(group_idx)) <= registered_names
+
+
+def test_group_aware_unknown_component_identity_fails_closed() -> None:
+    metadata = [
+        KvCacheGroupSpec(
+            group_idx=0,
+            kind="full_attention",
+            block_size=128,
+            group_payload_size_bytes=1024,
+        ),
+    ]
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=tuple(metadata)),
+    )
+    client._host_ip_port_value = "10.0.0.8:9000"
+
+    with pytest.raises(MetadataProtocolError, match="missing component identity"):
+        client._location_spec_name(group_idx=None)
+    with pytest.raises(MetadataProtocolError, match="not present"):
+        client._location_spec_name(group_idx=99)
+
+
+def test_location_specs_are_sorted_by_component_id() -> None:
+    metadata = [
+        KvCacheGroupSpec(11, "mamba", 16, 64),
+        KvCacheGroupSpec(2, "sliding_window", 16, 32),
+        KvCacheGroupSpec(10, "full_attention", 16, 128),
+    ]
+    client = KvcmClient(
+        SubscriberConfig(),
+        medium_mapper=_vllm_medium_mapper,
+        storage_type="ST_EVENT_REPORT_L1P5",
+        supported_mediums=["hbm", "mem"],
+        manager_client=FakeSdkClient(),
+        descriptor=KvCacheDescriptor(groups=tuple(metadata)),
+    )
+
+    infos, groups = client._location_specs()
+
+    assert infos == [
+        {"name": "W2", "size": 32},
+        {"name": "F10", "size": 128},
+        {"name": "L11", "size": 64},
+    ]
+    assert groups == [
+        {"name": "W2", "spec_names": ["W2"]},
+        {"name": "F10", "spec_names": ["F10"]},
+        {"name": "L11", "spec_names": ["L11"]},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Registration state tests (simple boolean, no generation/snapshot)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationState:
+    """Tests for the simple boolean registration state."""
+
+    def test_initial_state_is_unregistered(self) -> None:
+        client = _client()
+        assert client.is_registered is False
+
+    def test_set_registration_state_true(self) -> None:
+        client = _client()
+        client._set_registration_state(True)
+        assert client.is_registered is True
+
+    def test_set_registration_state_false(self) -> None:
+        client = _client()
+        client._set_registration_state(True)
+        client._set_registration_state(False)
+        assert client.is_registered is False
+
+    def test_deduplicated_true_does_not_re_log(self) -> None:
+        client = _client()
+        client._set_registration_state(True)
+        # Calling again with same value should be a no-op (deduplication)
+        client._set_registration_state(True)
+        assert client.is_registered is True
+
+    def test_deduplicated_false_does_not_re_log(self) -> None:
+        client = _client()
+        # Initial state is False; setting False again should be a no-op
+        client._set_registration_state(False)
+        assert client.is_registered is False
+
+    def test_transitions_flip_correctly(self) -> None:
+        client = _client()
+        client._set_registration_state(True)
+        assert client.is_registered is True
+        client._set_registration_state(False)
+        assert client.is_registered is False
+        client._set_registration_state(True)
+        assert client.is_registered is True
+
+    def test_transitions_report_metrics_once(self, mocker: MockerFixture) -> None:
+        report = mocker.patch("subscriber.kvcm.client.report_registration_transition")
+        client = _client()
+
+        client._set_registration_state(True)
+        client._set_registration_state(True)
+        client._set_registration_state(False)
+
+        assert report.call_args_list == [
+            call("unregistered", "registered"),
+            call("registered", "unregistered"),
+        ]
+
+
+class TestTwoStepRegistrationPrerequisite:
+    """Registration requires BOTH registerInstance and NODE_REGISTER to succeed."""
+
+    async def test_register_instance_failure_leaves_unregistered(self) -> None:
+        fake_sdk = FakeSdkClient()
+        fake_sdk.register_instance.side_effect = RuntimeError("rpc fail")
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+
+        await client.start()
+
+        assert client.is_registered is False
+        await client.close()
+
+    async def test_node_register_failure_leaves_unregistered(self) -> None:
+        fake_sdk = FakeSdkClient()
+
+        async def report_event(
+            request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            events = request.get("events")
+            if (
+                isinstance(events, list)
+                and events
+                and events[0].get("event_type") == "EVENT_NODE_REGISTER"
+            ):
+                raise RuntimeError("node register failed")
+            return {"header": {"status": {"code": "OK"}}}
+
+        fake_sdk.report_event.side_effect = report_event
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+
+        await client.start()
+
+        assert client.is_registered is False
+        await client.close()
+
+    async def test_both_steps_succeed_sets_registered(self) -> None:
+        fake_sdk = FakeSdkClient()
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+
+        await client.start()
+
+        assert client.is_registered is True
+        await client.close()
+
+
+class TestIndefiniteUnavailableRetries:
+    """Heartbeat loop retries registration indefinitely while KVCM is down."""
+
+    async def test_retries_registration_indefinitely_until_available(self) -> None:
+        fake_sdk = FakeSdkClient()
+        fake_sdk.ready = False
+        attempt_count = 0
+        registered_event = asyncio.Event()
+
+        async def is_ready() -> bool:
+            nonlocal attempt_count
+            attempt_count += 1
+            # Become ready after 5 attempts
+            return attempt_count >= 5
+
+        async def register_instance(
+            _request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            registered_event.set()
+            return {"header": {"status": {"code": "OK"}}}
+
+        fake_sdk.is_ready = AsyncMock(side_effect=is_ready)
+        fake_sdk.register_instance = AsyncMock(side_effect=register_instance)
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+        await client.start()
+        assert client.is_registered is False
+
+        await asyncio.wait_for(registered_event.wait(), timeout=1.0)
+        assert client.is_registered is True
+        assert attempt_count >= 5
+        await client.close()
+
+    async def test_register_instance_failure_retries_next_cycle(self) -> None:
+        fake_sdk = FakeSdkClient()
+        call_count = 0
+        registered_event = asyncio.Event()
+
+        async def register_instance(
+            _request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError("temporary failure")
+            registered_event.set()
+            return {"header": {"status": {"code": "OK"}}}
+
+        fake_sdk.register_instance = AsyncMock(side_effect=register_instance)
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+        await client.start()
+        # First attempt fails, heartbeat loop retries
+        await asyncio.wait_for(registered_event.wait(), timeout=1.0)
+        assert client.is_registered is True
+        assert call_count == 3
+        await client.close()
+
+
+class TestFalseToTrueRecovery:
+    """false->true transition only restores future event reporting, no callback."""
+
+    async def test_heartbeat_failure_transitions_to_unregistered(self) -> None:
+        fake_sdk = FakeSdkClient()
+        heartbeat_count = 0
+        unregistered_event = asyncio.Event()
+
+        async def report_event(
+            request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            nonlocal heartbeat_count
+            events = request.get("events")
+            if (
+                isinstance(events, list)
+                and events
+                and events[0].get("event_type") == "EVENT_HEARTBEAT"
+            ):
+                heartbeat_count += 1
+                if heartbeat_count == 1:
+                    raise RuntimeError("kvcm down")
+            return {"header": {"status": {"code": "OK"}}}
+
+        fake_sdk.report_event = AsyncMock(side_effect=report_event)
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+        await client.start()
+        assert client.is_registered is True
+
+        # Poll until heartbeat failure causes unregistered state
+        async def wait_unregistered() -> None:
+            while client.is_registered:
+                await asyncio.sleep(0.005)
+            unregistered_event.set()
+
+        task = asyncio.create_task(wait_unregistered())
+        await asyncio.wait_for(unregistered_event.wait(), timeout=1.0)
+        assert client.is_registered is False
+        task.cancel()
+        await client.close()
+
+    async def test_recovery_after_failure_restores_registered(self) -> None:
+        fake_sdk = FakeSdkClient()
+        heartbeat_count = 0
+        recovered_event = asyncio.Event()
+
+        async def report_event(
+            request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            nonlocal heartbeat_count
+            events = request.get("events")
+            if (
+                isinstance(events, list)
+                and events
+                and events[0].get("event_type") == "EVENT_HEARTBEAT"
+            ):
+                heartbeat_count += 1
+                if heartbeat_count == 1:
+                    raise RuntimeError("kvcm down")
+            return {"header": {"status": {"code": "OK"}}}
+
+        async def register_instance(
+            _request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            if fake_sdk.register_instance.await_count > 1:
+                recovered_event.set()
+            return {"header": {"status": {"code": "OK"}}}
+
+        fake_sdk.report_event = AsyncMock(side_effect=report_event)
+        fake_sdk.register_instance = AsyncMock(side_effect=register_instance)
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+        await client.start()
+        assert client.is_registered is True
+
+        # Wait for failure then recovery
+        await asyncio.wait_for(recovered_event.wait(), timeout=1.0)
+        await asyncio.sleep(0.02)
+
+        assert client.is_registered is True
+        await client.close()
+
+    async def test_recovery_does_not_invoke_any_subscriber_health_callback(
+        self,
+    ) -> None:
+        """false->true recovery only restores future event reporting;
+        no external callback or subscriber-health notification is made."""
+        fake_sdk = FakeSdkClient()
+        heartbeat_count = 0
+        recovered_event = asyncio.Event()
+
+        async def report_event(
+            request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            nonlocal heartbeat_count
+            events = request.get("events")
+            if (
+                isinstance(events, list)
+                and events
+                and events[0].get("event_type") == "EVENT_HEARTBEAT"
+            ):
+                heartbeat_count += 1
+                if heartbeat_count == 1:
+                    raise RuntimeError("kvcm down")
+            return {"header": {"status": {"code": "OK"}}}
+
+        async def register_instance(
+            _request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            if fake_sdk.register_instance.await_count > 1:
+                recovered_event.set()
+            return {"header": {"status": {"code": "OK"}}}
+
+        fake_sdk.report_event = AsyncMock(side_effect=report_event)
+        fake_sdk.register_instance = AsyncMock(side_effect=register_instance)
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+
+        await client.start()
+        await asyncio.wait_for(recovered_event.wait(), timeout=1.0)
+        await asyncio.sleep(0.02)
+
+        # After recovery, report_kv_events should work (future event reporting restored)
+        assert client.is_registered is True
+        fake_sdk.report_event.reset_mock()
+        await client.report_kv_events(
+            [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+        )
+        assert fake_sdk.report_event.await_count == 2
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# KvcmReportError hierarchy and report_kv_events typed-error semantics
+# ---------------------------------------------------------------------------
+
+
+class TestKvcmReportErrorHierarchy:
+    """Tests for the typed KvcmReportError exception hierarchy."""
+
+    def test_kvcm_unavailable_error_is_kvcm_report_error(self) -> None:
+        from subscriber.kvcm.errors import KvcmReportError, KvcmUnavailableError
+
+        exc = KvcmUnavailableError("transport failure")
+        assert isinstance(exc, KvcmReportError)
+
+    def test_kvcm_report_rejected_error_is_kvcm_report_error(self) -> None:
+        from subscriber.kvcm.errors import KvcmReportError, KvcmReportRejectedError
+
+        exc = KvcmReportRejectedError("rejected")
+        assert isinstance(exc, KvcmReportError)
+
+    def test_kvcm_report_error_is_runtime_error(self) -> None:
+        from subscriber.kvcm.errors import KvcmReportError
+
+        exc = KvcmReportError("base")
+        assert isinstance(exc, RuntimeError)
+
+
+class TestSendBatchTypedErrors:
+    """report_kv_events raises typed errors without changing registration state.
+
+    Registration is owned by the heartbeat loop; report_kv_events transport failures
+    must not flip ``is_registered``.
+    """
+
+    async def test_transport_failure_does_not_change_registration(self) -> None:
+        """Retryable transport failure raises but leaves is_registered=True."""
+        fake_sdk = FakeSdkClient()
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+        await client.start()
+        assert client.is_registered is True
+
+        # Simulate a retryable transport failure
+        fake_sdk.report_event.side_effect = RuntimeError("connection reset")
+
+        from subscriber.kvcm.errors import KvcmUnavailableError
+
+        with pytest.raises(KvcmUnavailableError, match="connection reset"):
+            await client.report_kv_events(
+                [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+            )
+
+        # Registration must NOT change on a report_kv_events transport failure.
+        assert client.is_registered is True
+        await client.close()
+
+    async def test_not_registered_raises_kvcm_unavailable(self) -> None:
+        """report_kv_events when not registered raises KvcmUnavailableError."""
+        fake_sdk = FakeSdkClient()
+        fake_sdk.ready = False
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+        await client.start()
+        assert client.is_registered is False
+
+        from subscriber.kvcm.errors import KvcmUnavailableError
+
+        with pytest.raises(KvcmUnavailableError, match="not ready"):
+            await client.report_kv_events(
+                [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+            )
+        await client.close()
+
+    async def test_rejected_report_does_not_flip_registration(self) -> None:
+        """A rejected/partial report is dropped without changing registration."""
+        fake_sdk = FakeSdkClient()
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+        await client.start()
+        assert client.is_registered is True
+
+        # Simulate a non-OK response (rejected report)
+        fake_sdk.report_event.side_effect = RuntimeError(
+            "KVCM /api/reportEvent failed: INTERNAL_ERROR "
+            "ReportEvent partially failed; item_results=['OK', 'INTERNAL_ERROR']"
+        )
+
+        from subscriber.kvcm.errors import KvcmReportRejectedError
+
+        with pytest.raises(KvcmReportRejectedError, match="INTERNAL_ERROR"):
+            await client.report_kv_events(
+                [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+            )
+
+        # Registration must NOT change on rejected report
+        assert client.is_registered is True
+        await client.close()
+
+    async def test_programming_error_not_classified_as_kvcm_down(self) -> None:
+        """Programming errors remain distinct and are not KvcmReportError."""
+        client = _client()
+
+        from subscriber.kvcm.errors import KvcmReportError
+
+        with pytest.raises(RuntimeError, match="has not been started"):
+            await client.report_kv_events(
+                [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+            )
+
+        # Verify it's NOT a KvcmReportError
+        try:
+            await client.report_kv_events(
+                [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+            )
+        except RuntimeError as exc:
+            assert not isinstance(exc, KvcmReportError)
+
+    async def test_next_batch_sends_after_transport_failure(self) -> None:
+        """After a transport failure the next new batch sends normally.
+
+        Registration never flipped, so no re-registration is required.
+        """
+        fake_sdk = FakeSdkClient()
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=60.0), fake_sdk)
+        await client.start()
+        assert client.is_registered is True
+
+        from subscriber.kvcm.errors import KvcmUnavailableError
+
+        fake_sdk.report_event.side_effect = RuntimeError("transport failure")
+        with pytest.raises(KvcmUnavailableError):
+            await client.report_kv_events(
+                [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])], epoch=1
+            )
+        assert client.is_registered is True
+
+        # Next new batch sends normally (no blind replay).
+        fake_sdk.report_event.side_effect = None
+        fake_sdk.report_event.return_value = {"header": {"status": {"code": "OK"}}}
+        await client.report_kv_events(
+            [KVEventBatch(ts=2.0, events=[AllBlocksCleared()])], epoch=1
+        )
+        await client.close()
+
+    async def test_heartbeat_failure_flips_registration(self) -> None:
+        """Heartbeat report failure flips registration to false.
+
+        The heartbeat loop (not report_kv_events) owns reconnection state.
+        """
+        fake_sdk = FakeSdkClient()
+        heartbeat_count = 0
+
+        async def report_event(
+            request: dict[str, object], **_kwargs: object
+        ) -> dict[str, object]:
+            nonlocal heartbeat_count
+            events = request.get("events")
+            if (
+                isinstance(events, list)
+                and events
+                and events[0].get("event_type") == "EVENT_HEARTBEAT"
+            ):
+                heartbeat_count += 1
+                if heartbeat_count == 1:
+                    raise RuntimeError("heartbeat transport failure")
+            return {"header": {"status": {"code": "OK"}}}
+
+        fake_sdk.report_event = AsyncMock(side_effect=report_event)
+        client = _make_kvcm(SubscriberConfig(kvcm_heartbeat_interval_s=0.01), fake_sdk)
+        await client.start()
+        assert client.is_registered is True
+
+        # Wait for heartbeat failure to flip registration
+        async def wait_unregistered() -> None:
+            while client.is_registered:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_unregistered(), timeout=1.0)
+        assert client.is_registered is False
+        await client.close()

--- a/subscriber/tests/kvcm/test_errors.py
+++ b/subscriber/tests/kvcm/test_errors.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import pytest
+
+from subscriber.forwarding import KvcmDropTracker
+from subscriber.kvcm.errors import (
+    KvcmReportError,
+    KvcmReportRejectedError,
+    KvcmResponseRejectedError,
+    KvcmUnavailableError,
+)
+
+
+class TestKvcmReportErrorHierarchy:
+    """The typed KVCM report error hierarchy."""
+
+    def test_base_is_runtime_error(self) -> None:
+        assert isinstance(KvcmReportError("base"), RuntimeError)
+
+    def test_unavailable_is_report_error(self) -> None:
+        exc = KvcmUnavailableError("transport failure")
+        assert isinstance(exc, KvcmReportError)
+
+    def test_rejected_is_report_error(self) -> None:
+        exc = KvcmReportRejectedError("rejected")
+        assert isinstance(exc, KvcmReportError)
+
+    def test_transport_rejected_is_internal_runtime_error(self) -> None:
+        exc = KvcmResponseRejectedError("rejected")
+        assert isinstance(exc, RuntimeError)
+        assert not isinstance(exc, KvcmReportError)
+
+    def test_subclasses_are_distinct(self) -> None:
+        assert not issubclass(KvcmUnavailableError, KvcmReportRejectedError)
+        assert not issubclass(KvcmReportRejectedError, KvcmUnavailableError)
+
+    def test_catch_base_catches_both_subclasses(self) -> None:
+        for exc in (
+            KvcmUnavailableError("unavailable"),
+            KvcmReportRejectedError("rejected"),
+        ):
+            with pytest.raises(KvcmReportError):
+                raise exc
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for testing time-based rate limits."""
+
+    def __init__(self, start_s: float = 0.0) -> None:
+        self.now_s = start_s
+
+    def __call__(self) -> float:
+        return self.now_s
+
+    def advance(self, seconds: float) -> None:
+        self.now_s += seconds
+
+
+class TestKvcmDropTracker:
+    """Rate-limited drop warnings: first immediate, then summarized."""
+
+    def test_first_drop_logs_immediately(self, mocker) -> None:
+        warning = mocker.patch("subscriber.forwarding.logger.warning")
+        tracker = KvcmDropTracker(clock=_FakeClock())
+
+        tracker.record_drop(
+            epoch=1,
+            batch_count=2,
+            event_count=4,
+            error=KvcmUnavailableError("down"),
+        )
+
+        warning.assert_called_once_with(
+            "failed to send kv event batch to kvcm; dropping batch",
+            step="kvcm_send",
+            tags={
+                "pipeline": "incremental",
+                "epoch": 1,
+                "batch_count": 2,
+                "event_count": 4,
+                "error": "KvcmUnavailableError",
+                "message": "down",
+                "reason": "unknown",
+                "dropped_batch_total": 2,
+                "dropped_event_total": 4,
+            },
+        )
+        assert tracker.dropped_batch_count == 2
+        assert tracker.dropped_event_count == 4
+
+    def test_subsequent_drops_within_window_are_silent(self, mocker) -> None:
+        warning = mocker.patch("subscriber.forwarding.logger.warning")
+        clock = _FakeClock()
+        tracker = KvcmDropTracker(
+            summary_every=100, summary_interval_s=30.0, clock=clock
+        )
+
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.reset_mock()
+
+        # Within both the count and time window: no further logging.
+        clock.advance(1.0)
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+
+        warning.assert_not_called()
+        assert tracker.dropped_batch_count == 2
+
+    def test_summary_emitted_after_count_threshold(self, mocker) -> None:
+        warning = mocker.patch("subscriber.forwarding.logger.warning")
+        clock = _FakeClock()
+        tracker = KvcmDropTracker(
+            summary_every=3, summary_interval_s=9999.0, clock=clock
+        )
+
+        # First drop logs immediately.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.reset_mock()
+
+        # Drops 2 and 3 accumulate but stay under the count threshold.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.assert_not_called()
+
+        # Drop 4 crosses summary_every=3 since the first failure.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.assert_called_once()
+        tags = warning.call_args.kwargs["tags"]
+        assert tags["dropped_batch_since_summary"] == 3
+        assert tags["dropped_batch_total"] == 4
+        assert tags["dropped_event_total"] == 4
+
+    def test_summary_emitted_after_time_threshold(self, mocker) -> None:
+        warning = mocker.patch("subscriber.forwarding.logger.warning")
+        clock = _FakeClock()
+        tracker = KvcmDropTracker(
+            summary_every=1000, summary_interval_s=30.0, clock=clock
+        )
+
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.reset_mock()
+
+        # Advance past the time threshold; a single drop triggers a summary.
+        clock.advance(31.0)
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmReportRejectedError("r")
+        )
+
+        warning.assert_called_once_with(
+            "kvcm send failures continue; dropping batches",
+            step="kvcm_send",
+            tags={
+                "pipeline": "incremental",
+                "epoch": 1,
+                "error": "KvcmReportRejectedError",
+                "message": "r",
+                "reason": "unknown",
+                "dropped_batch_since_summary": 1,
+                "dropped_batch_total": 2,
+                "dropped_event_total": 2,
+            },
+        )
+
+    def test_summary_counter_resets_after_emit(self, mocker) -> None:
+        warning = mocker.patch("subscriber.forwarding.logger.warning")
+        clock = _FakeClock()
+        tracker = KvcmDropTracker(
+            summary_every=2, summary_interval_s=9999.0, clock=clock
+        )
+
+        # Drop 1: first failure, immediate log.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.reset_mock()
+
+        # Drop 2: accumulates, still under threshold.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.assert_not_called()
+
+        # Drop 3: reaches summary_every=2, emits and resets the counter.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.assert_called_once()
+        tags = warning.call_args.kwargs["tags"]
+        assert tags["dropped_batch_since_summary"] == 2
+        assert tags["dropped_batch_total"] == 3
+        warning.reset_mock()
+
+        # Drop 4: counter restarted, accumulates silently.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.assert_not_called()
+
+        # Drop 5: reaches the threshold again.
+        tracker.record_drop(
+            epoch=1, batch_count=1, event_count=1, error=KvcmUnavailableError("e")
+        )
+        warning.assert_called_once()
+        tags = warning.call_args.kwargs["tags"]
+        assert tags["dropped_batch_since_summary"] == 2
+        assert tags["dropped_batch_total"] == 5

--- a/subscriber/tests/kvcm/test_event_payload.py
+++ b/subscriber/tests/kvcm/test_event_payload.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from subscriber.kvcm.event_payload import (
+    ReportEventSourceCounts,
+    expand_report_events,
+    report_event_count,
+    source_counts,
+    split_report_event_requests,
+)
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    KVEventBatch,
+)
+
+
+def _medium_mapper(medium: str | None) -> str:
+    return {"GPU": "hbm", "CPU": "mem"}.get(medium, "")
+
+
+def _block_specs(medium: str, group_idx: int | None) -> list[dict[str, str]]:
+    return [
+        {
+            "name": f"spec-{group_idx}",
+            "uri": f"vllm://127.0.0.1:9000/{medium}",
+        }
+    ]
+
+
+def _block_spec_names(group_idx: int | None) -> list[str]:
+    return [f"spec-{group_idx}"]
+
+
+def test_event_payload_expands_ordered_events_and_counts_report_events() -> None:
+    batches = [
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                BlockStored(
+                    block_hashes=[11, 12],
+                    parent_block_hash=None,
+                    token_ids=[1, 2],
+                    block_size=2,
+                    lora_id=None,
+                    medium="GPU",
+                    lora_name=None,
+                    group_idx=0,
+                ),
+                BlockRemoved(block_hashes=[13], medium="CPU", group_idx=1),
+            ],
+        ),
+        KVEventBatch(ts=2.0, events=[AllBlocksCleared()]),
+    ]
+
+    events = expand_report_events(
+        batches,
+        medium_mapper=_medium_mapper,
+        block_specs=_block_specs,
+        block_spec_names=_block_spec_names,
+    )
+    assert events == [
+        {
+            "event_type": "EVENT_BLOCK_ADD",
+            "block_add": {
+                "block_key": "11",
+                "medium": "hbm",
+                "specs": [
+                    {
+                        "name": "spec-0",
+                        "uri": "vllm://127.0.0.1:9000/hbm",
+                    }
+                ],
+            },
+        },
+        {
+            "event_type": "EVENT_BLOCK_ADD",
+            "block_add": {
+                "block_key": "12",
+                "medium": "hbm",
+                "specs": [
+                    {
+                        "name": "spec-0",
+                        "uri": "vllm://127.0.0.1:9000/hbm",
+                    }
+                ],
+            },
+        },
+        {
+            "event_type": "EVENT_BLOCK_DELETE",
+            "block_delete": {
+                "block_key": "13",
+                "medium": "mem",
+                "spec_names": ["spec-1"],
+            },
+        },
+        {"event_type": "EVENT_HOST_DOWN", "host_down": {}},
+    ]
+    assert source_counts(batches) == ReportEventSourceCounts(
+        batch_count=2, event_count=3
+    )
+    assert report_event_count(batches) == 4
+
+
+def test_split_report_event_requests_keeps_host_down_exclusive() -> None:
+    stale_add = {"event_type": "EVENT_BLOCK_ADD", "block_add": {"block_key": "1"}}
+    host_down = {"event_type": "EVENT_HOST_DOWN", "host_down": {}}
+    current_add = {
+        "event_type": "EVENT_BLOCK_ADD",
+        "block_add": {"block_key": "2"},
+    }
+
+    assert split_report_event_requests([stale_add, host_down, current_add]) == [
+        [host_down],
+        [current_add],
+    ]

--- a/subscriber/tests/kvcm/test_grpc_manager_client.py
+++ b/subscriber/tests/kvcm/test_grpc_manager_client.py
@@ -1,0 +1,1077 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import time
+import uuid
+
+import grpc
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from subscriber.kvcm.enum import KvcmStorageType
+from subscriber.kvcm.errors import (
+    KvcmResponseRejectedError,
+    KvcmUnavailableError,
+    report_event_transport_diagnostics,
+)
+from subscriber.kvcm.grpc_manager_client import (
+    GrpcKvCacheManagerClient,
+    _get_cluster_info_response_to_dict,
+    _register_instance_request_from_dict,
+    _report_event_request_from_dict,
+    _report_event_request_to_wire_bytes,
+    _report_event_response_to_dict,
+)
+from subscriber.proto import kvcm_meta_service_pb2, kvcm_meta_service_pb2_grpc
+
+
+class FakeKvcmMetaService(kvcm_meta_service_pb2_grpc.MetaServiceServicer):
+    def __init__(
+        self,
+        *,
+        report_status: int = kvcm_meta_service_pb2.OK,
+        cluster_status: int = kvcm_meta_service_pb2.OK,
+        leader_port: int = 0,
+        item_results: list[int] | None = None,
+        report_status_by_event: dict[int, int] | None = None,
+        heartbeat_started: asyncio.Event | None = None,
+        heartbeat_release: asyncio.Event | None = None,
+        cluster_abort_code: grpc.StatusCode | None = None,
+    ) -> None:
+        self.report_status = report_status
+        self.cluster_status = cluster_status
+        self.leader_port = leader_port
+        self.item_results = item_results or []
+        self.report_status_by_event = report_status_by_event or {}
+        self.heartbeat_started = heartbeat_started
+        self.heartbeat_release = heartbeat_release
+        self.cluster_abort_code = cluster_abort_code
+        self.register_requests: list[kvcm_meta_service_pb2.RegisterInstanceRequest] = []
+        self.report_requests: list[kvcm_meta_service_pb2.ReportEventRequest] = []
+        self.cluster_requests: list[kvcm_meta_service_pb2.GetClusterInfoRequest] = []
+
+    async def RegisterInstance(
+        self,
+        request: kvcm_meta_service_pb2.RegisterInstanceRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> kvcm_meta_service_pb2.RegisterInstanceResponse:
+        self.register_requests.append(request)
+        return kvcm_meta_service_pb2.RegisterInstanceResponse(
+            header={"status": {"code": kvcm_meta_service_pb2.OK}}
+        )
+
+    async def ReportEvent(
+        self,
+        request: kvcm_meta_service_pb2.ReportEventRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> kvcm_meta_service_pb2.ReportEventResponse:
+        self.report_requests.append(request)
+        if (
+            request.events
+            and request.events[0].event_type == kvcm_meta_service_pb2.EVENT_HEARTBEAT
+            and self.heartbeat_started is not None
+            and self.heartbeat_release is not None
+        ):
+            self.heartbeat_started.set()
+            await self.heartbeat_release.wait()
+        event_type = request.events[0].event_type if request.events else 0
+        return kvcm_meta_service_pb2.ReportEventResponse(
+            header={
+                "status": {
+                    "code": self.report_status_by_event.get(
+                        event_type, self.report_status
+                    )
+                }
+            },
+            item_results=self.item_results,
+            snapshot_required=True,
+        )
+
+    async def GetClusterInfo(
+        self,
+        request: kvcm_meta_service_pb2.GetClusterInfoRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> kvcm_meta_service_pb2.GetClusterInfoResponse:
+        self.cluster_requests.append(request)
+        if self.cluster_abort_code is not None:
+            await context.abort(self.cluster_abort_code, "cluster unavailable")
+        return kvcm_meta_service_pb2.GetClusterInfoResponse(
+            header={"status": {"code": self.cluster_status}},
+            leader_endpoint={
+                "host": "127.0.0.1",
+                "meta_rpc_port": self.leader_port,
+            },
+        )
+
+
+async def _start_fake_kvcm_server(
+    service: FakeKvcmMetaService,
+) -> tuple[grpc.aio.Server, int]:
+    server = grpc.aio.server()
+    kvcm_meta_service_pb2_grpc.add_MetaServiceServicer_to_server(service, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    assert port != 0
+    await server.start()
+    return server, port
+
+
+def _unused_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def test_kvcm_proto_critical_field_numbers_match_authoritative_schema() -> None:
+    register = kvcm_meta_service_pb2.RegisterInstanceRequest.DESCRIPTOR
+    report = kvcm_meta_service_pb2.ReportEventRequest.DESCRIPTOR
+    cluster = kvcm_meta_service_pb2.GetClusterInfoResponse.DESCRIPTOR
+
+    assert register.fields_by_name["location_spec_infos"].number == 5
+    assert register.fields_by_name["model_deployment"].number == 6
+    assert register.fields_by_name["default_query_type"].number == 8
+    assert report.fields_by_name["events"].number == 4
+    assert report.fields_by_name["storage_type"].number == 5
+    assert cluster.fields_by_name["leader_endpoint"].number == 4
+
+
+def test_kvcm_storage_types_match_authoritative_proto() -> None:
+    assert {storage_type.value for storage_type in KvcmStorageType} == set(
+        kvcm_meta_service_pb2.StorageType.DESCRIPTOR.values_by_name
+    )
+
+
+def test_kvcm_grpc_stub_uses_full_package_rpc_paths() -> None:
+    class FakeChannel:
+        def __init__(self) -> None:
+            self.paths: list[str] = []
+
+        def unary_unary(self, path: str, **kwargs: object) -> object:
+            self.paths.append(path)
+            return object()
+
+    channel = FakeChannel()
+    kvcm_meta_service_pb2_grpc.MetaServiceStub(channel)
+
+    assert channel.paths == [
+        "/kv_cache_manager.proto.meta.MetaService/RegisterInstance",
+        "/kv_cache_manager.proto.meta.MetaService/GetClusterInfo",
+        "/kv_cache_manager.proto.meta.MetaService/ReportEvent",
+    ]
+
+
+def test_register_instance_dict_maps_to_proto() -> None:
+    request = _register_instance_request_from_dict(
+        {
+            "trace_id": "trace-1",
+            "instance_group": "group-a",
+            "instance_id": "deploy_16",
+            "block_size": 16,
+            "location_spec_infos": [{"name": "full_0", "size": 4096}],
+            "model_deployment": {
+                "model_name": "default",
+                "dtype": "bytes",
+                "use_mla": False,
+                "tp_size": 2,
+                "dp_size": 1,
+                "pp_size": 1,
+                "use_eagle_pop": True,
+            },
+            "location_spec_groups": [
+                {"name": "full_0", "spec_names": ["full_0"]},
+            ],
+            "default_query_type": "QT_PREFIX_MATCH_WITH_MAMBA",
+        }
+    )
+
+    assert request.trace_id == "trace-1"
+    assert request.location_spec_infos[0].name == "full_0"
+    assert request.location_spec_infos[0].size == 4096
+    assert request.model_deployment.tp_size == 2
+    assert request.model_deployment.use_eagle_pop is True
+    assert list(request.location_spec_groups[0].spec_names) == ["full_0"]
+    assert (
+        request.default_query_type == kvcm_meta_service_pb2.QT_PREFIX_MATCH_WITH_MAMBA
+    )
+
+
+def test_report_event_dict_maps_all_subscriber_event_shapes() -> None:
+    data = {
+        "trace_id": "trace-2",
+        "instance_id": "deploy_16",
+        "host_ip_port": "10.0.0.8:9000",
+        "storage_type": "ST_EVENT_REPORT_L1P5",
+        "events": [
+            {
+                "event_type": "EVENT_NODE_REGISTER",
+                "node_register": {"mediums": ["hbm"]},
+            },
+            {
+                "event_type": "EVENT_HEARTBEAT",
+                "heartbeat": {"system_status": {"alive": "1"}},
+            },
+            {
+                "event_type": "EVENT_BLOCK_ADD",
+                "block_add": {
+                    "block_key": "11",
+                    "medium": "hbm",
+                    "specs": [{"name": "full_0", "uri": "vllm://host/hbm"}],
+                },
+            },
+            {
+                "event_type": "EVENT_BLOCK_DELETE",
+                "block_delete": {
+                    "block_key": "11",
+                    "medium": "hbm",
+                    "spec_names": ["full_0"],
+                },
+            },
+            {"event_type": "EVENT_HOST_DOWN", "host_down": {}},
+            {
+                "event_type": "EVENT_BLOCK_SNAPSHOT",
+                "block_snapshot": {
+                    "blocks": [
+                        {
+                            "block_key": "11",
+                            "medium": "hbm",
+                            "specs": [
+                                {
+                                    "name": "full_0",
+                                    "uri": "vllm://host/hbm",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        ],
+    }
+    request = _report_event_request_from_dict(data)
+    fast_request = kvcm_meta_service_pb2.ReportEventRequest.FromString(
+        _report_event_request_to_wire_bytes(data)
+    )
+
+    assert request.storage_type == kvcm_meta_service_pb2.ST_EVENT_REPORT_L1P5
+    assert list(request.events[0].node_register.mediums) == ["hbm"]
+    assert request.events[1].heartbeat.system_status["alive"] == "1"
+    assert request.events[2].block_add.specs[0].name == "full_0"
+    assert list(request.events[3].block_delete.spec_names) == ["full_0"]
+    assert request.events[4].HasField("host_down")
+    assert request.events[5].block_snapshot.blocks[0].specs[0].uri == "vllm://host/hbm"
+    assert fast_request == request
+
+
+def test_report_event_wire_bytes_match_proto_for_many_add_delete_events() -> None:
+    data = {
+        "trace_id": "trace-many-events",
+        "instance_id": "deploy_16",
+        "host_ip_port": "10.0.0.8:9000",
+        "storage_type": "ST_EVENT_REPORT_L1P5",
+        "events": [
+            {
+                "event_type": "EVENT_BLOCK_ADD",
+                "block_add": {
+                    "block_key": str(block_key),
+                    "medium": "hbm",
+                    "specs": [{"name": "full_0", "uri": "vllm://host/hbm"}],
+                },
+            }
+            for block_key in range(16)
+        ]
+        + [
+            {
+                "event_type": "EVENT_BLOCK_DELETE",
+                "block_delete": {
+                    "block_key": str(block_key),
+                    "medium": "hbm",
+                    "spec_names": ["full_0"],
+                },
+            }
+            for block_key in range(16)
+        ],
+    }
+
+    request = _report_event_request_from_dict(data)
+    fast_request = kvcm_meta_service_pb2.ReportEventRequest.FromString(
+        _report_event_request_to_wire_bytes(data)
+    )
+
+    assert fast_request == request
+
+
+def test_report_event_wire_bytes_match_proto_for_4k_block_snapshot() -> None:
+    data = {
+        "trace_id": "trace-4k-snapshot",
+        "instance_id": "deploy_16",
+        "host_ip_port": "10.0.0.8:9000",
+        "storage_type": "ST_EVENT_REPORT_L1P5",
+        "events": [
+            {
+                "event_type": "EVENT_BLOCK_SNAPSHOT",
+                "block_snapshot": {
+                    "medium": "hbm",
+                    "blocks": [
+                        {
+                            "block_key": str(block_key),
+                            "medium": "hbm" if block_key % 2 == 0 else "cpu",
+                            "specs": [
+                                {
+                                    "name": f"full_{block_key % 2}",
+                                    "uri": "vllm://host/hbm",
+                                },
+                                {
+                                    "name": "cpu_0",
+                                    "uri": "vllm://host/cpu",
+                                },
+                            ],
+                        }
+                        for block_key in range(4_096)
+                    ],
+                },
+            }
+        ],
+    }
+
+    request = _report_event_request_from_dict(data)
+    fast_request = kvcm_meta_service_pb2.ReportEventRequest.FromString(
+        _report_event_request_to_wire_bytes(data)
+    )
+
+    assert fast_request == request
+
+
+def test_report_event_proto_round_trip_preserves_storage_type_and_oneof() -> None:
+    request = _report_event_request_from_dict(
+        {
+            "storage_type": "ST_EVENT_REPORT_L1P5",
+            "events": [
+                {
+                    "event_type": "EVENT_HEARTBEAT",
+                    "heartbeat": {"system_status": {"alive": "1"}},
+                }
+            ],
+        }
+    )
+    parsed = kvcm_meta_service_pb2.ReportEventRequest()
+
+    parsed.ParseFromString(request.SerializeToString())
+
+    assert parsed.storage_type == kvcm_meta_service_pb2.ST_EVENT_REPORT_L1P5
+    assert parsed.events[0].HasField("heartbeat")
+    assert parsed.events[0].heartbeat.system_status["alive"] == "1"
+
+
+@pytest.mark.parametrize("storage_type", ["ST_EVENT_REPORT", 99, -1])
+def test_report_event_rejects_unknown_storage_type(storage_type: object) -> None:
+    data = {
+        "storage_type": storage_type,
+        "events": [{"event_type": "EVENT_HEARTBEAT"}],
+    }
+
+    with pytest.raises(ValueError):
+        _report_event_request_from_dict(data)
+    with pytest.raises(ValueError):
+        _report_event_request_to_wire_bytes(data)
+
+
+@pytest.mark.parametrize("event_type", [99, -1])
+def test_report_event_rejects_unknown_numeric_event_type(event_type: int) -> None:
+    data = {
+        "storage_type": "ST_EVENT_REPORT_L1P5",
+        "events": [{"event_type": event_type}],
+    }
+
+    with pytest.raises(ValueError):
+        _report_event_request_from_dict(data)
+    with pytest.raises(ValueError):
+        _report_event_request_to_wire_bytes(data)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [{}, {"event_type": ""}, {"event_type": "EVENT_FUTURE"}],
+)
+def test_report_event_dict_defaults_unrecognized_event_type_to_unspecified(
+    event: dict[str, str],
+) -> None:
+    request = _report_event_request_from_dict(
+        {
+            "storage_type": "ST_EVENT_REPORT_L1P5",
+            "events": [event],
+        }
+    )
+
+    assert request.events[0].event_type == kvcm_meta_service_pb2.EVENT_UNSPECIFIED
+    assert request.events[0].WhichOneof("event_params") is None
+
+
+def test_report_event_wire_bytes_preserve_unspecified_oneof_behavior() -> None:
+    data = {
+        "storage_type": "ST_EVENT_REPORT_L1P5",
+        "events": [
+            {
+                "block_add": {
+                    "block_key": "11",
+                    "medium": "hbm",
+                    "specs": [{"name": "full_0", "uri": "vllm://host/hbm"}],
+                },
+            },
+            {
+                "event_type": "EVENT_FUTURE",
+                "block_delete": {
+                    "block_key": "12",
+                    "medium": "hbm",
+                    "spec_names": ["full_0"],
+                },
+            },
+        ],
+    }
+
+    request = _report_event_request_from_dict(data)
+    fast_request = kvcm_meta_service_pb2.ReportEventRequest.FromString(
+        _report_event_request_to_wire_bytes(data)
+    )
+
+    assert fast_request == request
+    assert [event.WhichOneof("event_params") for event in fast_request.events] == [
+        None,
+        None,
+    ]
+
+
+def test_grpc_responses_convert_to_domain_dict_shape() -> None:
+    report_response = kvcm_meta_service_pb2.ReportEventResponse(
+        header={"status": {"code": kvcm_meta_service_pb2.OK, "message": ""}},
+        item_results=[kvcm_meta_service_pb2.INTERNAL_ERROR],
+        committed_snapshot_version="7",
+        retry_after_ms=123,
+        snapshot_required=True,
+        extra_info='{"source":"test"}',
+    )
+    cluster_response = kvcm_meta_service_pb2.GetClusterInfoResponse(
+        header={"status": {"code": kvcm_meta_service_pb2.OK}},
+        self_node_id="node-a",
+        leader_node_id="node-b",
+        leader_endpoint={
+            "node_id": "node-b",
+            "host": "10.0.0.9",
+            "meta_rpc_port": 6381,
+            "meta_http_port": 6382,
+        },
+    )
+
+    report = _report_event_response_to_dict(report_response)
+    cluster = _get_cluster_info_response_to_dict(cluster_response)
+
+    assert report["header"]["status"]["code"] == "OK"
+    assert report["item_results"] == ["INTERNAL_ERROR"]
+    assert report["snapshot_required"] is True
+    assert cluster["leader_endpoint"]["host"] == "10.0.0.9"
+    assert cluster["leader_endpoint"]["meta_rpc_port"] == 6381
+
+
+async def test_grpc_manager_client_sends_real_aio_rpc_requests() -> None:
+    service = FakeKvcmMetaService()
+    server, port = await _start_fake_kvcm_server(service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{port}",
+        auto_discover_leader=False,
+        request_timeout_seconds=1.0,
+    )
+
+    try:
+        await client.start()
+        register = await client.register_instance(
+            {
+                "trace_id": "trace-register",
+                "instance_id": "deploy_16",
+                "block_size": 16,
+            }
+        )
+        report = await client.report_event(
+            {
+                "trace_id": "trace-report",
+                "instance_id": "deploy_16",
+                "storage_type": "ST_EVENT_REPORT_L1P5",
+                "events": [{"event_type": "EVENT_HEARTBEAT"}],
+            }
+        )
+    finally:
+        await client.close()
+        await server.stop(None)
+
+    assert register["header"]["status"]["code"] == "OK"
+    assert report["snapshot_required"] is True
+    assert service.register_requests[0].trace_id == "trace-register"
+    assert service.register_requests[0].block_size == 16
+    assert service.report_requests[0].events[0].event_type == (
+        kvcm_meta_service_pb2.EVENT_HEARTBEAT
+    )
+
+
+async def test_grpc_report_event_returns_wire_diagnostics() -> None:
+    service = FakeKvcmMetaService()
+    server, port = await _start_fake_kvcm_server(service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{port}",
+        auto_discover_leader=False,
+        request_timeout_seconds=1.0,
+    )
+    request = {
+        "trace_id": "trace-report",
+        "instance_id": "deploy_16",
+        "storage_type": "ST_EVENT_REPORT_L1P5",
+        "events": [{"event_type": "EVENT_HEARTBEAT"}],
+    }
+
+    try:
+        await client.start()
+        response = await client.report_event(request)
+    finally:
+        await client.close()
+        await server.stop(None)
+
+    assert response["_subscriber_request_bytes"] == len(
+        _report_event_request_to_wire_bytes(request)
+    )
+    assert response["_subscriber_wire_encode_ms"] >= 0
+    assert response["_subscriber_grpc_call_ms"] >= 0
+
+
+async def test_grpc_report_event_logs_completed_attempt_dimensions(
+    mocker: MockerFixture,
+) -> None:
+    service = FakeKvcmMetaService()
+    server, port = await _start_fake_kvcm_server(service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{port}",
+        auto_discover_leader=False,
+        request_timeout_seconds=1.0,
+    )
+    debug = mocker.patch("subscriber.kvcm.grpc_manager_client.logger.debug")
+    mocker.patch(
+        "subscriber.kvcm.grpc_manager_client.logger.is_debug_enabled",
+        return_value=True,
+    )
+
+    try:
+        await client.start()
+        await client.report_event(
+            {
+                "storage_type": "ST_EVENT_REPORT_L1P5",
+                "events": [{"event_type": "EVENT_HEARTBEAT"}],
+            }
+        )
+    finally:
+        await client.close()
+        await server.stop(None)
+
+    report_log = next(
+        entry
+        for entry in debug.call_args_list
+        if entry.args == ("kvcm grpc request completed",)
+        and entry.kwargs["tags"]["method"] == "ReportEvent"
+    )
+    tags = report_log.kwargs["tags"]
+    assert tags["attempt"] == 1
+    assert tags["grpc_status"] == "OK"
+    assert tags["request_bytes"] > 0
+    assert tags["grpc_call_ms"] >= 0
+
+
+async def test_grpc_manager_client_switches_to_leader_meta_rpc_port() -> None:
+    leader_service = FakeKvcmMetaService()
+    leader_server, leader_port = await _start_fake_kvcm_server(leader_service)
+    follower_service = FakeKvcmMetaService(
+        report_status=kvcm_meta_service_pb2.SERVER_NOT_LEADER,
+        cluster_status=kvcm_meta_service_pb2.INTERNAL_ERROR,
+        leader_port=leader_port,
+    )
+    follower_server, follower_port = await _start_fake_kvcm_server(follower_service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{follower_port}",
+        leader_retry_base_interval_seconds=0.0,
+        request_timeout_seconds=1.0,
+    )
+
+    try:
+        await client.start()
+        follower_service.cluster_status = kvcm_meta_service_pb2.OK
+        follower_service.cluster_requests.clear()
+        report = await client.report_event(
+            {
+                "trace_id": "trace-report",
+                "instance_id": "deploy_16",
+                "storage_type": "ST_EVENT_REPORT_L1P5",
+                "events": [{"event_type": "EVENT_HOST_DOWN"}],
+            }
+        )
+    finally:
+        await client.close()
+        await follower_server.stop(None)
+        await leader_server.stop(None)
+
+    assert report["header"]["status"]["code"] == "OK"
+    assert report["_subscriber_retry_count"] == 1
+    assert len(follower_service.report_requests) == 1
+    assert len(follower_service.cluster_requests) == 1
+    assert len(leader_service.report_requests) == 1
+
+
+async def test_grpc_retry_then_rejection_preserves_retry_count() -> None:
+    leader_service = FakeKvcmMetaService(
+        report_status=kvcm_meta_service_pb2.INVALID_ARGUMENT,
+    )
+    leader_server, leader_port = await _start_fake_kvcm_server(leader_service)
+    follower_service = FakeKvcmMetaService(
+        report_status=kvcm_meta_service_pb2.SERVER_NOT_LEADER,
+        cluster_status=kvcm_meta_service_pb2.INTERNAL_ERROR,
+        leader_port=leader_port,
+    )
+    follower_server, follower_port = await _start_fake_kvcm_server(follower_service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{follower_port}",
+        leader_retry_base_interval_seconds=0.0,
+        request_timeout_seconds=1.0,
+    )
+
+    try:
+        await client.start()
+        follower_service.cluster_status = kvcm_meta_service_pb2.OK
+        with pytest.raises(KvcmResponseRejectedError) as error:
+            await client.report_event(
+                {
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HOST_DOWN"}],
+                }
+            )
+    finally:
+        await client.close()
+        await follower_server.stop(None)
+        await leader_server.stop(None)
+
+    assert error.value.status_code == "INVALID_ARGUMENT"
+    assert error.value.retry_count == 1
+    assert error.value.request_bytes is not None
+    assert error.value.request_bytes > 0
+    assert error.value.wire_encode_ms is not None
+    assert error.value.wire_encode_ms >= 0
+    assert error.value.grpc_call_ms is not None
+    assert error.value.grpc_call_ms >= 0
+
+
+async def test_grpc_retry_then_transport_failure_preserves_retry_count() -> None:
+    unavailable_leader_port = _unused_loopback_port()
+    follower_service = FakeKvcmMetaService(
+        report_status=kvcm_meta_service_pb2.SERVER_NOT_LEADER,
+        cluster_status=kvcm_meta_service_pb2.INTERNAL_ERROR,
+        leader_port=unavailable_leader_port,
+    )
+    follower_server, follower_port = await _start_fake_kvcm_server(follower_service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{follower_port}",
+        leader_retry_base_interval_seconds=0.0,
+        request_timeout_seconds=1.0,
+    )
+
+    try:
+        await client.start()
+        follower_service.cluster_status = kvcm_meta_service_pb2.OK
+        with pytest.raises(KvcmUnavailableError) as error:
+            await client.report_event(
+                {
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HOST_DOWN"}],
+                }
+            )
+    finally:
+        await client.close()
+        await follower_server.stop(None)
+
+    assert error.value.status_code == "GRPC_UNAVAILABLE"
+    assert error.value.reason == "transport"
+    assert error.value.retry_count == 1
+
+
+async def test_grpc_leader_switch_does_not_cancel_inflight_heartbeat() -> None:
+    heartbeat_started = asyncio.Event()
+    heartbeat_release = asyncio.Event()
+    leader_service = FakeKvcmMetaService()
+    leader_server, leader_port = await _start_fake_kvcm_server(leader_service)
+    follower_service = FakeKvcmMetaService(
+        cluster_status=kvcm_meta_service_pb2.INTERNAL_ERROR,
+        leader_port=leader_port,
+        report_status_by_event={
+            kvcm_meta_service_pb2.EVENT_HOST_DOWN: (
+                kvcm_meta_service_pb2.SERVER_NOT_LEADER
+            )
+        },
+        heartbeat_started=heartbeat_started,
+        heartbeat_release=heartbeat_release,
+    )
+    follower_server, follower_port = await _start_fake_kvcm_server(follower_service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{follower_port}",
+        leader_retry_base_interval_seconds=0.0,
+        request_timeout_seconds=1.0,
+    )
+
+    try:
+        await client.start()
+        follower_service.cluster_status = kvcm_meta_service_pb2.OK
+        follower_service.cluster_requests.clear()
+        heartbeat_task = asyncio.create_task(
+            client.report_event(
+                {
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HEARTBEAT"}],
+                }
+            )
+        )
+        await asyncio.wait_for(heartbeat_started.wait(), timeout=0.5)
+        switched_report_task = asyncio.create_task(
+            client.report_event(
+                {
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HOST_DOWN"}],
+                }
+            )
+        )
+        await asyncio.sleep(0.05)
+
+        assert follower_service.cluster_requests
+        assert not heartbeat_task.done()
+        heartbeat_release.set()
+        heartbeat_response = await heartbeat_task
+        switched_response = await switched_report_task
+    finally:
+        heartbeat_release.set()
+        await client.close()
+        await follower_server.stop(None)
+        await leader_server.stop(None)
+
+    assert heartbeat_response["header"]["status"]["code"] == "OK"
+    assert switched_response["header"]["status"]["code"] == "OK"
+    assert len(leader_service.report_requests) == 1
+
+
+async def test_grpc_server_not_leader_with_failed_discovery_is_unavailable() -> None:
+    follower_service = FakeKvcmMetaService(
+        report_status=kvcm_meta_service_pb2.SERVER_NOT_LEADER
+    )
+    follower_server, follower_port = await _start_fake_kvcm_server(follower_service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{follower_port}",
+        leader_retry_count=2,
+        leader_retry_base_interval_seconds=0.0,
+        request_timeout_seconds=1.0,
+    )
+
+    try:
+        await client.start()
+        with pytest.raises(KvcmUnavailableError):
+            await client.report_event(
+                {
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HEARTBEAT"}],
+                }
+            )
+    finally:
+        await client.close()
+        await follower_server.stop(None)
+
+    assert len(follower_service.report_requests) == 3
+
+
+async def test_grpc_refused_target_is_unavailable_without_deadline_wait() -> None:
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{_unused_loopback_port()}",
+        auto_discover_leader=False,
+        request_timeout_seconds=0.4,
+    )
+
+    try:
+        await client.start()
+        started_at = time.monotonic()
+        with pytest.raises(grpc.aio.AioRpcError) as error:
+            await client.report_event(
+                {
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HEARTBEAT"}],
+                }
+            )
+    finally:
+        await client.close()
+
+    assert error.value.code() == grpc.StatusCode.UNAVAILABLE
+    assert time.monotonic() - started_at < 0.3
+    diagnostics = report_event_transport_diagnostics(error.value)
+    assert diagnostics.request_bytes is not None
+    assert diagnostics.request_bytes > 0
+    assert diagnostics.wire_encode_ms is not None
+    assert diagnostics.wire_encode_ms >= 0
+    assert diagnostics.grpc_call_ms is not None
+    assert diagnostics.grpc_call_ms >= 0
+
+
+async def test_grpc_report_event_before_rpc_sets_zero_rpc_diagnostic(
+    mocker: MockerFixture,
+) -> None:
+    client = GrpcKvCacheManagerClient("127.0.0.1:1", auto_discover_leader=False)
+    mocker.patch.object(
+        client,
+        "_get_stub",
+        side_effect=KvcmUnavailableError("KVCM gRPC channel is unavailable"),
+    )
+
+    try:
+        with pytest.raises(KvcmUnavailableError) as error:
+            await client.report_event(
+                {
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HEARTBEAT"}],
+                }
+            )
+    finally:
+        await client.close()
+
+    assert error.value.request_bytes is not None
+    assert error.value.request_bytes > 0
+    assert error.value.wire_encode_ms is not None
+    assert error.value.wire_encode_ms >= 0
+    assert error.value.grpc_call_ms == 0.0
+
+
+async def test_failed_grpc_discovery_does_not_trigger_rapid_refresh() -> None:
+    service = FakeKvcmMetaService(cluster_abort_code=grpc.StatusCode.UNAVAILABLE)
+    server, port = await _start_fake_kvcm_server(service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{port}",
+        min_discover_interval_seconds=0.01,
+        discovery_refresh_interval_seconds=1,
+        request_timeout_seconds=0.1,
+    )
+
+    try:
+        await client.start()
+        await asyncio.sleep(0.05)
+    finally:
+        await client.close()
+        await server.stop(None)
+
+    assert len(service.cluster_requests) == 1
+
+
+async def test_grpc_manager_client_rejects_non_ok_response() -> None:
+    service = FakeKvcmMetaService(
+        report_status=kvcm_meta_service_pb2.INTERNAL_ERROR,
+        item_results=[kvcm_meta_service_pb2.INTERNAL_ERROR],
+    )
+    server, port = await _start_fake_kvcm_server(service)
+    client = GrpcKvCacheManagerClient(
+        f"127.0.0.1:{port}",
+        auto_discover_leader=False,
+        request_timeout_seconds=1.0,
+    )
+
+    try:
+        with pytest.raises(KvcmResponseRejectedError, match="INTERNAL_ERROR"):
+            await client.report_event(
+                {
+                    "trace_id": "trace-report",
+                    "instance_id": "deploy_16",
+                    "storage_type": "ST_EVENT_REPORT_L1P5",
+                    "events": [{"event_type": "EVENT_HEARTBEAT"}],
+                }
+            )
+    finally:
+        await client.close()
+        await server.stop(None)
+
+
+async def test_grpc_manager_client_unavailable_target_raises_retryable() -> None:
+    client = GrpcKvCacheManagerClient(
+        "",
+        auto_discover_leader=False,
+        request_timeout_seconds=1.0,
+    )
+
+    with pytest.raises(KvcmUnavailableError, match="target is unavailable"):
+        await client.report_event(
+            {"storage_type": "ST_EVENT_REPORT_L1P5", "events": []}
+        )
+
+
+async def _setup_real_event_report_instance_group(
+    admin_url: str,
+    *,
+    instance_group: str,
+    storage_name: str,
+) -> None:
+    async with httpx.AsyncClient(
+        base_url=admin_url.rstrip("/"),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        timeout=2.0,
+    ) as http_client:
+        storage = {
+            "global_unique_name": storage_name,
+            "storage_type": "ST_EVENT_REPORT_L1P5",
+            "event_report": {
+                "heartbeat_timeout_ms": 1000,
+                "cleanup_grace_ms": 2000,
+                "liveness_check_interval_ms": 200,
+            },
+            "check_storage_available_when_open": False,
+        }
+        add_response = await http_client.post(
+            "/api/addStorage",
+            json={"trace_id": "real-grpc-add-storage", "storage": storage},
+        )
+        add_response.raise_for_status()
+        add_body = add_response.json()
+        add_code = add_body.get("header", {}).get("status", {}).get("code")
+        assert add_code in {"OK", "DUPLICATE_ENTITY"}, add_body
+
+        group_response = await http_client.post(
+            "/api/createInstanceGroup",
+            json={
+                "trace_id": "real-grpc-create-instance-group",
+                "instance_group": {
+                    "name": instance_group,
+                    "storage_candidates": ["nfs_01"],
+                    "global_quota_group_name": "default_quota_group",
+                    "max_instance_count": 100,
+                    "quota": {
+                        "capacity": 10737418240,
+                        "quota_config": [{"storage_type": 4, "capacity": 10737418240}],
+                    },
+                    "cache_config": {
+                        "reclaim_strategy": {
+                            "storage_unique_name": "nfs_01",
+                            "reclaim_policy": 1,
+                            "trigger_strategy": {
+                                "used_size": 1073741824,
+                                "used_percentage": 0.8,
+                            },
+                            "trigger_period_seconds": 60,
+                            "reclaim_step_size": 1073741824,
+                            "reclaim_step_percentage": 10,
+                        },
+                        "data_storage_strategy": 2,
+                        "meta_indexer_config": {
+                            "max_key_count": 1000000,
+                            "mutex_shard_num": 16,
+                            "batch_key_size": 16,
+                            "meta_storage_backend_config": {
+                                "storage_type": "local",
+                                "storage_uri": "",
+                            },
+                            "meta_cache_policy_config": {
+                                "type": "LRU",
+                                "capacity": 10000,
+                            },
+                        },
+                    },
+                    "event_report_storage_candidates": [storage_name],
+                    "version": 1,
+                },
+            },
+        )
+        group_response.raise_for_status()
+        group_body = group_response.json()
+        group_code = group_body.get("header", {}).get("status", {}).get("code")
+        assert group_code in {"OK", "DUPLICATE_ENTITY"}, group_body
+
+
+# Opt-in real KVCM integration test.
+#
+# Setup in the KVCM repo:
+#   bazel build //kv_cache_manager:kv_cache_manager_bin
+#   bazel-bin/kv_cache_manager/kv_cache_manager_bin \
+#     --env kvcm.service.rpc_port=56010 \
+#     --env kvcm.service.http_port=56020 \
+#     --env kvcm.service.admin_rpc_port=56031 \
+#     --env kvcm.service.admin_http_port=56040 \
+#     --env kvcm.service.enable_debug_service=false
+#
+# Run in this subscriber repo:
+#   KVCM_REAL_GRPC_TARGET=127.0.0.1:56010 \
+#   KVCM_REAL_ADMIN_HTTP_URL=http://127.0.0.1:56040 \
+#   uv run pytest \
+#     tests/kvcm/test_grpc_manager_client.py \
+#     -k test_real_kvcm_grpc_register_and_report_event \
+#     -vv
+#
+# KVCM_REAL_ADMIN_HTTP_URL is used only for setup; tested requests use gRPC.
+async def test_real_kvcm_grpc_register_and_report_event() -> None:
+    target = os.environ.get("KVCM_REAL_GRPC_TARGET")
+    if not target:
+        pytest.skip("set KVCM_REAL_GRPC_TARGET to run against a real KVCM server")
+
+    suffix = uuid.uuid4().hex
+    instance_id = f"subscriber-real-grpc-{suffix}"
+    instance_group = "default"
+    admin_url = os.environ.get("KVCM_REAL_ADMIN_HTTP_URL")
+    if admin_url:
+        instance_group = f"subscriber-real-grpc-group-{suffix}"
+        await _setup_real_event_report_instance_group(
+            admin_url,
+            instance_group=instance_group,
+            storage_name=f"subscriber-real-grpc-l1p5-{suffix}",
+        )
+    client = GrpcKvCacheManagerClient(
+        target,
+        auto_discover_leader=True,
+        request_timeout_seconds=2.0,
+    )
+
+    try:
+        await client.start()
+        register_response = await client.register_instance(
+            {
+                "trace_id": "real-grpc-register",
+                "instance_group": instance_group,
+                "instance_id": instance_id,
+                "block_size": 16,
+                "location_spec_infos": [{"name": "vllm_16", "size": 16}],
+                "location_spec_groups": [
+                    {"name": "default", "spec_names": ["vllm_16"]}
+                ],
+                "model_deployment": {
+                    "model_name": "subscriber-real-grpc",
+                    "dtype": "bytes",
+                    "tp_size": 1,
+                    "dp_size": 1,
+                    "pp_size": 1,
+                },
+                "default_query_type": "QT_PREFIX_MATCH_WITH_MAMBA",
+            }
+        )
+        report_request = {
+            "trace_id": "real-grpc-report",
+            "instance_id": instance_id,
+            "host_ip_port": "127.0.0.1:8080",
+            "storage_type": "ST_EVENT_REPORT_L1P5",
+            "events": [
+                {
+                    "event_type": "EVENT_NODE_REGISTER",
+                    "node_register": {"mediums": ["hbm"]},
+                },
+                {"event_type": "EVENT_HEARTBEAT"},
+            ],
+        }
+        try:
+            report_response = await client.report_event(report_request)
+        except KvcmResponseRejectedError as exc:
+            if "EventReportBackend not found" in str(exc):
+                pytest.skip(
+                    "real KVCM server has no event_report_l1p5 backend configured"
+                )
+            raise
+    finally:
+        await client.close()
+
+    assert register_response["header"]["status"]["code"] == "OK"
+    assert report_response["header"]["status"]["code"] == "OK"

--- a/subscriber/tests/kvcm/test_manager_client.py
+++ b/subscriber/tests/kvcm/test_manager_client.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from subscriber.kvcm import manager_client
+from subscriber.kvcm.errors import KvcmUnavailableError
+from subscriber.kvcm.manager_client import HttpKvCacheManagerClient
+
+
+async def test_http_manager_client_has_awaitable_readiness() -> None:
+    client = HttpKvCacheManagerClient("http://127.0.0.1:8080")
+
+    try:
+        assert await client.is_ready() is True
+    finally:
+        await client.close()
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, object], *, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+class _RaisingHttpClient:
+    """Raises a configured exception on reportEvent; OK (no leader) elsewhere."""
+
+    def __init__(self, exc: Exception) -> None:
+        self.headers: dict[str, str] = {}
+        self._exc = exc
+        self.closed = False
+        self.report_calls = 0
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, object],
+        headers: dict[str, str],
+        timeout: float,
+    ) -> _FakeResponse:
+        if url.endswith("/api/reportEvent"):
+            self.report_calls += 1
+            raise self._exc
+        return _FakeResponse({"header": {"status": {"code": "OK"}}})
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+async def _started_client(
+    exc: Exception, *, auto_discover_leader: bool = True
+) -> tuple[HttpKvCacheManagerClient, _RaisingHttpClient]:
+    http_client = _RaisingHttpClient(exc)
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=auto_discover_leader,
+        discovery_refresh_interval_seconds=60,
+        request_timeout_seconds=0.25,
+        http_client=http_client,
+    )
+    await client.start()
+    return client, http_client
+
+
+async def test_request_timeout_reraises_and_notifies_leader_refresh(
+    mocker: MockerFixture,
+) -> None:
+    client, http_client = await _started_client(httpx.ReadTimeout("slow"))
+    notify = mocker.patch.object(client, "_notify_leader_refresh")
+
+    with pytest.raises(httpx.ReadTimeout):
+        await client.report_event({"trace_id": "t1"})
+
+    assert http_client.report_calls == 1
+    notify.assert_called_once_with()
+    await client.close()
+
+
+async def test_request_timeout_logs_distinct_timeout_message(
+    mocker: MockerFixture,
+) -> None:
+    client, _ = await _started_client(httpx.ReadTimeout("slow"))
+    warning = mocker.patch.object(manager_client.logger, "warning")
+
+    with pytest.raises(httpx.ReadTimeout):
+        await client.report_event({"trace_id": "t1"})
+
+    warning.assert_any_call(
+        "kvcm request timed out",
+        step="kvcm_request",
+        tags={
+            "url": "http://manager.test:8080/api/reportEvent",
+            "timeout_seconds": 0.25,
+            "error": "ReadTimeout",
+        },
+    )
+    await client.close()
+
+
+async def test_connect_error_reraises_and_notifies_leader_refresh(
+    mocker: MockerFixture,
+) -> None:
+    client, _ = await _started_client(httpx.ConnectError("refused"))
+    notify = mocker.patch.object(client, "_notify_leader_refresh")
+
+    with pytest.raises(httpx.ConnectError):
+        await client.report_event({"trace_id": "t1"})
+
+    notify.assert_called_once_with()
+    await client.close()
+
+
+async def test_generic_request_error_reraises_without_leader_refresh(
+    mocker: MockerFixture,
+) -> None:
+    exc = httpx.ReadError("connection dropped")
+    client, _ = await _started_client(exc)
+    notify = mocker.patch.object(client, "_notify_leader_refresh")
+    warning = mocker.patch.object(manager_client.logger, "warning")
+
+    with pytest.raises(httpx.ReadError):
+        await client.report_event({"trace_id": "t1"})
+
+    notify.assert_not_called()
+    warning.assert_any_call(
+        "kvcm request failed",
+        step="kvcm_request",
+        tags={
+            "url": "http://manager.test:8080/api/reportEvent",
+            "error": "ReadError",
+            "message": "connection dropped",
+        },
+    )
+    await client.close()
+
+
+async def test_notify_leader_refresh_sets_event_only_when_discovery_enabled() -> None:
+    enabled, _ = await _started_client(httpx.ReadTimeout("x"))
+    enabled._notify_leader_refresh()
+    assert enabled._refresh_event.is_set()
+    await enabled.close()
+
+    disabled, _ = await _started_client(
+        httpx.ReadTimeout("x"), auto_discover_leader=False
+    )
+    disabled._notify_leader_refresh()
+    assert not disabled._refresh_event.is_set()
+    await disabled.close()
+
+
+class _ScriptedHttpClient:
+    """Returns a fixed cluster-info payload and a queue of reportEvent payloads."""
+
+    def __init__(
+        self,
+        cluster_payload: dict[str, object],
+        report_payloads: list[dict[str, object]],
+    ) -> None:
+        self.headers: dict[str, str] = {}
+        self.closed = False
+        self._cluster_payload = cluster_payload
+        self._report_payloads = list(report_payloads)
+        self.report_calls = 0
+        self.cluster_calls = 0
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, object],
+        headers: dict[str, str],
+        timeout: float,
+    ) -> _FakeResponse:
+        if url.endswith("/api/getClusterInfo"):
+            self.cluster_calls += 1
+            return _FakeResponse(self._cluster_payload)
+        if url.endswith("/api/reportEvent"):
+            self.report_calls += 1
+            return _FakeResponse(self._report_payloads.pop(0))
+        return _FakeResponse({"header": {"status": {"code": "OK"}}})
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+_CLUSTER_WITH_LEADER: dict[str, object] = {
+    "header": {"status": {"code": "OK"}},
+    "leader_endpoint": {"host": "10.0.0.5", "meta_http_port": 9999},
+}
+
+
+async def test_leader_discovery_switches_base_url_on_start() -> None:
+    http_client = _ScriptedHttpClient(_CLUSTER_WITH_LEADER, [])
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=True,
+        discovery_refresh_interval_seconds=60,
+        http_client=http_client,
+    )
+
+    await client.start()
+
+    assert client.base_url == "http://10.0.0.5:9999"
+    assert http_client.cluster_calls == 1
+    await client.close()
+
+
+async def test_server_not_leader_triggers_rediscovery_then_succeeds() -> None:
+    ok: dict[str, object] = {"header": {"status": {"code": "OK"}}}
+    report_payloads: list[dict[str, object]] = [
+        {"header": {"status": {"code": "SERVER_NOT_LEADER"}}},
+        ok,
+    ]
+    http_client = _ScriptedHttpClient(_CLUSTER_WITH_LEADER, report_payloads)
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=True,
+        leader_retry_count=1,
+        leader_retry_base_interval_seconds=0.0,
+        discovery_refresh_interval_seconds=60,
+        http_client=http_client,
+    )
+    await client.start()
+
+    payload = await client.report_event({"trace_id": "t1"})
+
+    assert payload == {**ok, "_subscriber_retry_count": 1}
+    assert http_client.report_calls == 2
+    await client.close()
+
+
+async def test_server_not_leader_exhausted_raises_unavailable_not_rejected() -> None:
+    """When leader discovery fails and retries exhaust, the failure is a
+    retryable leader failover, not a permanent report rejection: it must not
+    surface as the rejected-report RuntimeError that KvcmClient classifies
+    as KvcmReportRejectedError (a permanent drop)."""
+
+    cluster_without_leader: dict[str, object] = {"header": {"status": {"code": "OK"}}}
+    not_leader: dict[str, object] = {
+        "header": {"status": {"code": "SERVER_NOT_LEADER"}}
+    }
+    http_client = _ScriptedHttpClient(cluster_without_leader, [not_leader, not_leader])
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=True,
+        leader_retry_count=1,
+        leader_retry_base_interval_seconds=0.0,
+        discovery_refresh_interval_seconds=60,
+        http_client=http_client,
+    )
+    await client.start()
+
+    with pytest.raises(KvcmUnavailableError) as error:
+        await client.report_event({"trace_id": "t1"})
+
+    assert error.value.status_code == "SERVER_NOT_LEADER"
+    assert error.value.reason == "leader_retry_exhausted"
+    assert error.value.retry_count == 1
+    await client.close()
+
+
+async def test_server_not_leader_retries_failed_discovery_until_exhausted() -> None:
+    cluster_without_leader: dict[str, object] = {"header": {"status": {"code": "OK"}}}
+    not_leader: dict[str, object] = {
+        "header": {"status": {"code": "SERVER_NOT_LEADER"}}
+    }
+    http_client = _ScriptedHttpClient(
+        cluster_without_leader, [not_leader, not_leader, not_leader]
+    )
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=True,
+        leader_retry_count=2,
+        leader_retry_base_interval_seconds=0.0,
+        discovery_refresh_interval_seconds=60,
+        http_client=http_client,
+    )
+    await client.start()
+
+    with pytest.raises(KvcmUnavailableError):
+        await client.report_event({"trace_id": "t1"})
+
+    assert http_client.report_calls == 3
+    await client.close()
+
+
+class _StubEndpoint:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _StubDiscovery:
+    def __init__(self, endpoint: _StubEndpoint | None) -> None:
+        self._endpoint = endpoint
+
+    def get_one_endpoint(self) -> _StubEndpoint | None:
+        return self._endpoint
+
+    def get_type(self) -> str:
+        return "stub"
+
+    async def close(self) -> None:
+        return None
+
+
+async def test_concurrent_is_ready_does_not_skip_leader_discovery() -> None:
+    """is_ready() resolving a service-discovery endpoint must not mutate
+    base_url outside the leader lock: doing so makes a concurrent
+    _discover_leader() see a changed snapshot and skip discovery, leaving
+    requests routed to a non-leader endpoint."""
+
+    http_client = _ScriptedHttpClient(_CLUSTER_WITH_LEADER, [])
+    client = HttpKvCacheManagerClient(
+        "static://seed",
+        auto_discover_leader=True,
+        discovery_refresh_interval_seconds=60,
+        http_client=http_client,
+    )
+    # Simulate a not-yet-resolved discovery scheme with an endpoint available.
+    client._service_discovery = _StubDiscovery(_StubEndpoint("10.0.0.7:8080"))  # type: ignore[assignment]
+
+    async with client._leader_lock:
+        discover_task = asyncio.create_task(client._discover_leader())
+        await asyncio.sleep(0)  # discover snapshots base_url, blocks on the lock
+        ready_task = asyncio.create_task(client.is_ready())
+        await asyncio.sleep(0)
+
+    assert await discover_task is True
+    assert await ready_task is True
+    assert http_client.cluster_calls == 1
+    assert client.base_url == "http://10.0.0.5:9999"
+    await client.close()

--- a/subscriber/tests/kvcm/test_service_discovery.py
+++ b/subscriber/tests/kvcm/test_service_discovery.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from pytest_mock import MockerFixture
+
+from subscriber.kvcm import manager_client, service_discovery
+from subscriber.kvcm.manager_client import HttpKvCacheManagerClient
+from subscriber.kvcm.service_discovery import (
+    ServiceDiscovery,
+    ServiceEndpoint,
+    SpectrumServiceDiscovery,
+    create_service_discovery,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object], *, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+class SequencedFakeHttpClient:
+    def __init__(self, **_: object) -> None:
+        self.headers: dict[str, str] = {}
+        self.calls: list[tuple[str, float]] = []
+        self._lock = threading.Lock()
+        self._payload = {"instances": [{"ip": "10.0.0.9", "port": 7001}]}
+        self.requested = threading.Event()
+        self.closed = False
+
+    def set_payload(self, payload: dict[str, object]) -> None:
+        with self._lock:
+            self._payload = payload
+
+    async def get(self, url: str, timeout: float) -> FakeResponse:
+        with self._lock:
+            self.calls.append((url, timeout))
+            payload = self._payload
+        self.requested.set()
+        return FakeResponse(payload)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class RecordingAsyncHttpClient:
+    def __init__(self, payload: dict[str, object] | None = None) -> None:
+        self.headers: dict[str, str] = {}
+        self.post_calls: list[tuple[str, dict[str, object], float]] = []
+        self.closed = False
+        self.payload = payload or {"header": {"status": {"code": "OK"}}}
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, object],
+        headers: dict[str, str],
+        timeout: float,
+    ) -> FakeResponse:
+        self.post_calls.append((url, json, timeout))
+        return FakeResponse(self.payload)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class EmptyServiceDiscovery(ServiceDiscovery):
+    def __init__(self) -> None:
+        self.endpoint: ServiceEndpoint | None = None
+        self.closed = False
+
+    def get_type(self) -> str:
+        return "Empty"
+
+    def get_all_endpoints(self) -> list[ServiceEndpoint]:
+        return [self.endpoint] if self.endpoint is not None else []
+
+    def get_one_endpoint(self) -> ServiceEndpoint | None:
+        return self.endpoint
+
+    async def refresh(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_spectrum_service_discovery_does_not_expose_service_url() -> None:
+    assert not hasattr(SpectrumServiceDiscovery, "service_url")
+
+
+async def test_spectrum_service_discovery_fetches_initial_endpoints() -> None:
+    http_client = SequencedFakeHttpClient()
+
+    discovery = SpectrumServiceDiscovery(
+        "vs-a",
+        refresh_timeout=0.5,
+        http_client=http_client,
+    )
+    await discovery.start()
+
+    assert http_client.calls == [
+        (
+            "http://127.0.0.1:8880/api/v1/discovery/virtual-services/vs-a/instances",
+            0.5,
+        )
+    ]
+    assert [
+        (endpoint.ip, endpoint.port) for endpoint in discovery.get_all_endpoints()
+    ] == [("10.0.0.9", 7001)]
+    await discovery.close()
+    assert http_client.closed
+
+
+async def test_spectrum_service_discovery_polls_changed_endpoints() -> None:
+    http_client = SequencedFakeHttpClient()
+    discovery = SpectrumServiceDiscovery(
+        "vs-a",
+        cache_ttl=0.01,
+        http_client=http_client,
+    )
+    await discovery.start()
+
+    http_client.requested.clear()
+    http_client.set_payload({"instances": [{"ip": "10.0.0.10", "port": 7002}]})
+    assert await asyncio.to_thread(http_client.requested.wait, 1.0)
+    assert [
+        (endpoint.ip, endpoint.port) for endpoint in discovery.get_all_endpoints()
+    ] == [("10.0.0.10", 7002)]
+    await discovery.close()
+
+
+async def test_spectrum_service_discovery_keeps_cached_endpoints_on_poll_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    http_client = SequencedFakeHttpClient()
+    discovery = SpectrumServiceDiscovery("vs-a", cache_ttl=60, http_client=http_client)
+    await discovery.start()
+    error = mocker.patch.object(service_discovery.logger, "error")
+
+    async def fail_get(url: str, timeout: float) -> FakeResponse:
+        raise RuntimeError("gateway unavailable")
+
+    monkeypatch.setattr(http_client, "get", fail_get)
+    assert not await discovery.refresh()
+    assert [
+        (endpoint.ip, endpoint.port) for endpoint in discovery.get_all_endpoints()
+    ] == [("10.0.0.9", 7001)]
+    error.assert_called_once_with(
+        "failed to refresh Spectrum service discovery; keeping cached endpoints",
+        step="kvcm_discovery",
+        tags={
+            "virtual_service_id": "vs-a",
+            "attempt_count": 1,
+            "error": "RuntimeError",
+            "message": "gateway unavailable",
+            "cached_endpoint_count": 1,
+        },
+    )
+    await discovery.close()
+
+
+async def test_manager_client_recovers_when_initial_spectrum_discovery_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    discovery = EmptyServiceDiscovery()
+    monkeypatch.setattr(
+        manager_client,
+        "create_service_discovery",
+        lambda _: discovery,
+    )
+
+    client = HttpKvCacheManagerClient(
+        "spectrum://vs-a",
+        auto_discover_leader=False,
+    )
+
+    await client.start()
+
+    assert await client.is_ready() is False
+    assert discovery.closed is False
+
+    discovery.endpoint = ServiceEndpoint(ip="10.0.0.9", port=7001, host="10.0.0.9:7001")
+
+    assert await client.is_ready() is True
+    assert client.base_url == "http://10.0.0.9:7001"
+
+    await client.close()
+    assert discovery.closed is True
+
+
+async def test_manager_client_reports_with_reused_async_http_client() -> None:
+    http_client = RecordingAsyncHttpClient()
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=False,
+        request_timeout_seconds=0.25,
+        http_client=http_client,
+    )
+    await client.start()
+
+    payload = await client.report_event({"trace_id": "t1"})
+    await client.close()
+
+    assert payload == {"header": {"status": {"code": "OK"}}}
+    assert http_client.post_calls == [
+        (
+            "http://manager.test:8080/api/reportEvent",
+            {"trace_id": "t1"},
+            0.25,
+        )
+    ]
+    assert http_client.closed
+
+
+async def test_manager_report_event_raises_for_non_ok_status_by_default() -> None:
+    http_client = RecordingAsyncHttpClient(
+        {
+            "header": {
+                "status": {
+                    "code": "INTERNAL_ERROR",
+                    "message": "ReportEvent partially failed",
+                }
+            },
+            "item_results": ["OK", "INTERNAL_ERROR"],
+        }
+    )
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=False,
+        http_client=http_client,
+    )
+    await client.start()
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "KVCM /api/reportEvent failed: INTERNAL_ERROR ReportEvent partially failed"
+        ),
+    ) as exc_info:
+        await client.report_event({"trace_id": "t1"})
+
+    await client.close()
+
+    assert "item_results=['OK', 'INTERNAL_ERROR']" in str(exc_info.value)
+
+
+async def test_manager_report_event_can_return_non_ok_for_explicit_inspection() -> None:
+    response = {
+        "header": {"status": {"code": "INTERNAL_ERROR", "message": "failed"}},
+        "item_results": ["INTERNAL_ERROR"],
+    }
+    http_client = RecordingAsyncHttpClient(response)
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        auto_discover_leader=False,
+        http_client=http_client,
+    )
+    await client.start()
+
+    payload = await client.report_event({"trace_id": "t1"}, check_response=False)
+    await client.close()
+
+    assert payload == response
+
+
+async def test_manager_initial_leader_discovery_failure_is_nonfatal() -> None:
+    class FailingHttpClient(RecordingAsyncHttpClient):
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict[str, object],
+            headers: dict[str, str],
+            timeout: float,
+        ) -> FakeResponse:
+            raise RuntimeError("manager unavailable")
+
+    http_client = FailingHttpClient()
+    client = HttpKvCacheManagerClient(
+        "http://manager.test:8080",
+        discovery_refresh_interval_seconds=60,
+        http_client=http_client,
+    )
+
+    await client.start()
+    await client.close()
+
+    assert http_client.closed
+
+
+async def test_create_service_discovery_defaults_to_one_second_spectrum_polling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        service_discovery.httpx,
+        "AsyncClient",
+        SequencedFakeHttpClient,
+    )
+
+    discovery = create_service_discovery("spectrum://vs-a")
+    assert discovery is not None
+    await discovery.start()
+
+    assert isinstance(discovery, SpectrumServiceDiscovery)
+    assert discovery.cache_ttl == 1
+    await discovery.close()

--- a/subscriber/tests/kvcm/test_snapshot_expand_optimization.py
+++ b/subscriber/tests/kvcm/test_snapshot_expand_optimization.py
@@ -1,0 +1,324 @@
+"""Tests for the unique fused snapshot block builder."""
+
+from __future__ import annotations
+
+from subscriber.kvcm.event_payload import build_merged_snapshot_blocks
+from subscriber.types import (
+    BlockSnapshot,
+    BlockSnapshotItem,
+    BlockStored,
+    KVEventBatch,
+)
+
+
+def _medium_mapper(medium: str | None) -> str:
+    return {"GPU": "hbm", "CPU": "mem"}.get(medium, "")
+
+
+def _block_specs(medium: str, group_idx: int | None) -> list[dict[str, str]]:
+    return [
+        {
+            "name": f"spec-{group_idx}",
+            "uri": f"vllm://127.0.0.1:9000/{medium}",
+        }
+    ]
+
+
+class TestBuildMergedSnapshotBlocks:
+    """Core behavior of the fused collect+merge function."""
+
+    def test_empty_batches_returns_empty(self) -> None:
+        assert (
+            build_merged_snapshot_blocks(
+                [], medium_mapper=_medium_mapper, block_specs=_block_specs
+            )
+            == []
+        )
+
+    def test_no_snapshot_events_returns_empty(self) -> None:
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockStored(
+                        block_hashes=[1],
+                        parent_block_hash=None,
+                        token_ids=[1],
+                        block_size=2,
+                        lora_id=None,
+                        medium="GPU",
+                        lora_name=None,
+                        group_idx=0,
+                    )
+                ],
+            )
+        ]
+        assert (
+            build_merged_snapshot_blocks(
+                batches, medium_mapper=_medium_mapper, block_specs=_block_specs
+            )
+            == []
+        )
+
+    def test_single_block_produces_one_entry(self) -> None:
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[BlockSnapshotItem(block_hash=101, group_idx=0)],
+                    )
+                ],
+            )
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=_block_specs
+        )
+        assert result == [
+            {
+                "block_key": "101",
+                "medium": "hbm",
+                "specs": [{"name": "spec-0", "uri": "vllm://127.0.0.1:9000/hbm"}],
+            }
+        ]
+
+    def test_merges_same_block_hash_different_group_idx(self) -> None:
+        """Hybrid model: same block_hash appears with group 0 and group 1."""
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[
+                            BlockSnapshotItem(block_hash=100, group_idx=0),
+                            BlockSnapshotItem(block_hash=100, group_idx=1),
+                            BlockSnapshotItem(block_hash=100, group_idx=1),
+                        ],
+                    )
+                ],
+            )
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=_block_specs
+        )
+        assert result == [
+            {
+                "block_key": "100",
+                "medium": "hbm",
+                "specs": [
+                    {"name": "spec-0", "uri": "vllm://127.0.0.1:9000/hbm"},
+                    {"name": "spec-1", "uri": "vllm://127.0.0.1:9000/hbm"},
+                ],
+            }
+        ]
+
+    def test_deduplicates_same_block_hash_same_group_idx(self) -> None:
+        """High-concurrency duplicate: same (block_hash, group_idx) twice."""
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[
+                            BlockSnapshotItem(block_hash=100, group_idx=0),
+                            BlockSnapshotItem(block_hash=100, group_idx=0),
+                        ],
+                    )
+                ],
+            )
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=_block_specs
+        )
+        assert result == [
+            {
+                "block_key": "100",
+                "medium": "hbm",
+                "specs": [{"name": "spec-0", "uri": "vllm://127.0.0.1:9000/hbm"}],
+            }
+        ]
+
+    def test_preserves_first_occurrence_order(self) -> None:
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[
+                            BlockSnapshotItem(block_hash=10, group_idx=0),
+                            BlockSnapshotItem(block_hash=20, group_idx=0),
+                            BlockSnapshotItem(block_hash=10, group_idx=1),
+                        ],
+                    )
+                ],
+            )
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=_block_specs
+        )
+        assert len(result) == 2
+        assert result[0]["block_key"] == "10"
+        assert result[0]["specs"] == [
+            {"name": "spec-0", "uri": "vllm://127.0.0.1:9000/hbm"},
+            {"name": "spec-1", "uri": "vllm://127.0.0.1:9000/hbm"},
+        ]
+        assert result[1]["block_key"] == "20"
+
+    def test_different_mediums_not_merged(self) -> None:
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[BlockSnapshotItem(block_hash=1, group_idx=0)],
+                    ),
+                    BlockSnapshot(
+                        medium="CPU",
+                        block_size=16,
+                        items=[BlockSnapshotItem(block_hash=1, group_idx=0)],
+                    ),
+                ],
+            )
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=_block_specs
+        )
+        assert len(result) == 2
+        assert result[0]["medium"] == "hbm"
+        assert result[1]["medium"] == "mem"
+
+    def test_multiple_batches_merged_together(self) -> None:
+        """Blocks across separate batches merge by (block_key, medium)."""
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[BlockSnapshotItem(block_hash=5, group_idx=0)],
+                    )
+                ],
+            ),
+            KVEventBatch(
+                ts=2.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[BlockSnapshotItem(block_hash=5, group_idx=1)],
+                    )
+                ],
+            ),
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=_block_specs
+        )
+        assert result == [
+            {
+                "block_key": "5",
+                "medium": "hbm",
+                "specs": [
+                    {"name": "spec-0", "uri": "vllm://127.0.0.1:9000/hbm"},
+                    {"name": "spec-1", "uri": "vllm://127.0.0.1:9000/hbm"},
+                ],
+            }
+        ]
+
+
+class TestSpecCaching:
+    """Verify that block_specs callable can return cached (shared) references."""
+
+    def test_cached_spec_dicts_shared_across_blocks(self) -> None:
+        """Inner spec dicts are shared references from the cache."""
+        cache: dict[tuple[str, int | None], list[dict[str, str]]] = {}
+
+        def cached_block_specs(
+            medium: str, group_idx: int | None
+        ) -> list[dict[str, str]]:
+            key = (medium, group_idx)
+            if key not in cache:
+                cache[key] = [
+                    {"name": f"spec-{group_idx}", "uri": f"vllm://host/{medium}"}
+                ]
+            return cache[key]
+
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[
+                            BlockSnapshotItem(block_hash=1, group_idx=0),
+                            BlockSnapshotItem(block_hash=2, group_idx=0),
+                            BlockSnapshotItem(block_hash=3, group_idx=0),
+                        ],
+                    )
+                ],
+            )
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=cached_block_specs
+        )
+        # Inner spec dicts share the same cached object
+        specs_0 = result[0]["specs"]
+        specs_1 = result[1]["specs"]
+        assert isinstance(specs_0, list) and isinstance(specs_1, list)
+        assert specs_0[0] is specs_1[0]
+        # Only one cache entry was created
+        assert len(cache) == 1
+
+    def test_cached_specs_not_corrupted_by_merge(self) -> None:
+        """Merging group 1 into block 100 must not pollute cached spec for group 0."""
+        cache: dict[tuple[str, int | None], list[dict[str, str]]] = {}
+
+        def cached_block_specs(
+            medium: str, group_idx: int | None
+        ) -> list[dict[str, str]]:
+            key = (medium, group_idx)
+            if key not in cache:
+                cache[key] = [
+                    {"name": f"spec-{group_idx}", "uri": f"vllm://host/{medium}"}
+                ]
+            return cache[key]
+
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockSnapshot(
+                        medium="GPU",
+                        block_size=16,
+                        items=[
+                            BlockSnapshotItem(block_hash=100, group_idx=0),
+                            BlockSnapshotItem(block_hash=100, group_idx=1),
+                            BlockSnapshotItem(block_hash=200, group_idx=0),
+                        ],
+                    )
+                ],
+            )
+        ]
+        result = build_merged_snapshot_blocks(
+            batches, medium_mapper=_medium_mapper, block_specs=cached_block_specs
+        )
+        # Block 100 merged: has both specs
+        merged_specs = result[0]["specs"]
+        assert isinstance(merged_specs, list)
+        assert len(merged_specs) == 2
+        # Block 200 must have only spec-0
+        assert result[1]["specs"] == [{"name": "spec-0", "uri": "vllm://host/hbm"}]
+        # Cache must not be corrupted
+        assert cache[("hbm", 0)] == [{"name": "spec-0", "uri": "vllm://host/hbm"}]
+        assert cache[("hbm", 1)] == [{"name": "spec-1", "uri": "vllm://host/hbm"}]

--- a/subscriber/tests/metrics/__init__.py
+++ b/subscriber/tests/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for subscriber.metrics."""

--- a/subscriber/tests/metrics/test_base.py
+++ b/subscriber/tests/metrics/test_base.py
@@ -1,0 +1,179 @@
+"""Tests for _base._dashlog_counter gauge-accumulation behavior.
+
+_dashlog_counter accumulates deltas per (name, tags) key and reports the
+running per-interval total via _dashlog_gauge (which reaches EAS
+realtime_metrics). Accumulators reset after _RESET_INTERVAL_S seconds so
+the reported gauge value represents a per-interval delta.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from subscriber.metrics import _base
+
+
+@pytest.fixture(autouse=True)
+def _reset_accumulators(monkeypatch):
+    """Reset module-level accumulator state between tests.
+
+    DS_EAS_USE_OTEL is removed so legacy-path tests stay deterministic even
+    when the test host is injected with the variable (e.g. ASI-EAS).
+    """
+    monkeypatch.delenv("DS_EAS_USE_OTEL", raising=False)
+    _base._counter_accumulators.clear()
+    _base._counter_last_reset_s = 0.0
+    yield
+    _base._counter_accumulators.clear()
+    _base._counter_last_reset_s = 0.0
+
+
+class TestCounterAsGauge:
+    def test_single_call_reports_delta_as_gauge(self, mocker) -> None:
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+
+        _base._dashlog_counter("zmq_received_message_count", 1)
+
+        gauge.assert_called_once_with("zmq_received_message_count", 1.0, tags=None)
+
+    def test_accumulates_within_interval(self, mocker) -> None:
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+        now = time.monotonic()
+        mocker.patch("time.monotonic", return_value=now)
+
+        _base._dashlog_counter("zmq_received_message_count", 1)
+        _base._dashlog_counter("zmq_received_message_count", 1)
+        _base._dashlog_counter("zmq_received_message_count", 3)
+
+        assert gauge.call_count == 3
+        assert gauge.call_args_list[-1] == mocker.call(
+            "zmq_received_message_count", 5.0, tags=None
+        )
+
+    def test_separate_keys_per_tags(self, mocker) -> None:
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+        now = time.monotonic()
+        mocker.patch("time.monotonic", return_value=now)
+
+        _base._dashlog_counter("heartbeat_count", 1, tags={"status": "success"})
+        _base._dashlog_counter("heartbeat_count", 1, tags={"status": "failure"})
+        _base._dashlog_counter("heartbeat_count", 1, tags={"status": "success"})
+
+        assert gauge.call_args_list[-1] == mocker.call(
+            "heartbeat_count", 2.0, tags={"status": "success"}
+        )
+
+    def test_resets_after_interval(self, mocker) -> None:
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+        now = time.monotonic()
+        mocker.patch("time.monotonic", return_value=now)
+
+        _base._dashlog_counter("msg_count", 5)
+
+        mocker.patch("time.monotonic", return_value=now + _base._RESET_INTERVAL_S + 1)
+        _base._dashlog_counter("msg_count", 2)
+
+        assert gauge.call_args_list[-1] == mocker.call("msg_count", 2.0, tags=None)
+
+    def test_reset_emits_zero_for_idle_keys(self, mocker) -> None:
+        """A counter that stops incrementing must be zeroed at the next
+        window reset, otherwise dashboards report its last accumulated
+        value as a live rate forever."""
+
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+        now = time.monotonic()
+        mocker.patch("time.monotonic", return_value=now)
+
+        _base._dashlog_counter("active_count", 5)
+        _base._dashlog_counter("idle_count", 7, tags={"endpoint": "a"})
+
+        mocker.patch("time.monotonic", return_value=now + _base._RESET_INTERVAL_S + 1)
+        _base._dashlog_counter("active_count", 1)
+
+        assert (
+            mocker.call("idle_count", 0.0, tags={"endpoint": "a"})
+            in gauge.call_args_list
+        )
+        assert gauge.call_args_list[-1] == mocker.call("active_count", 1.0, tags=None)
+        # The key that fired again must not be zeroed in the same reset.
+        assert mocker.call("active_count", 0.0, tags=None) not in gauge.call_args_list
+
+    def test_does_not_call_dashlog_counter(self, mocker) -> None:
+        mock_dashlog = mocker.patch("subscriber.metrics._base._dashlog")
+
+        _base._dashlog_counter("test_metric", 1)
+
+        mock_dashlog.Counter.assert_not_called()
+
+    def test_swallows_gauge_errors(self, mocker) -> None:
+        mocker.patch(
+            "subscriber.metrics._base._dashlog_gauge",
+            side_effect=RuntimeError("gauge failed"),
+        )
+
+        _base._dashlog_counter("test_metric", 1)
+
+
+class TestCounterOtelPath:
+    """DS_EAS_USE_OTEL 开启（ASI-EAS）时 counter 直调 dashlog.Counter。
+
+    dashlog 的 EASClient::AddCounters 在非 OTel 环境直接丢弃，因此 legacy
+    路径必须保持 Gauge 累积绕行；OTel 路径使用原生 Counter 增量语义。
+    """
+
+    def test_otel_enabled_true_when_env_set(self, mocker) -> None:
+        mocker.patch.dict("os.environ", {"DS_EAS_USE_OTEL": "true"}, clear=False)
+
+        assert _base._otel_enabled() is True
+
+    def test_otel_enabled_false_when_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv("DS_EAS_USE_OTEL", raising=False)
+
+        assert _base._otel_enabled() is False
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "0"])
+    def test_otel_enabled_false_when_falsy(self, mocker, value: str) -> None:
+        mocker.patch.dict("os.environ", {"DS_EAS_USE_OTEL": value}, clear=False)
+
+        assert _base._otel_enabled() is False
+
+    def test_otel_path_calls_native_counter(self, mocker) -> None:
+        mocker.patch.dict("os.environ", {"DS_EAS_USE_OTEL": "true"}, clear=False)
+        dashlog = mocker.patch("subscriber.metrics._base._dashlog", mocker.MagicMock())
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+
+        _base._dashlog_counter("zmq_received_message_count", 3, tags={"kind": "x"})
+
+        dashlog.Counter.assert_called_once_with(
+            _base._METRIC_PREFIX + "zmq_received_message_count",
+            3,
+            tags={"kind": "x"},
+            add_app_prefix=False,
+        )
+        gauge.assert_not_called()
+        assert _base._counter_accumulators == {}
+
+    def test_otel_path_swallows_counter_errors(self, mocker) -> None:
+        mocker.patch.dict("os.environ", {"DS_EAS_USE_OTEL": "true"}, clear=False)
+        mocker.patch("subscriber.metrics._base._dashlog", mocker.MagicMock())
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+        mocker.patch.object(
+            _base._dashlog, "Counter", side_effect=RuntimeError("counter failed")
+        )
+
+        _base._dashlog_counter("test_metric", 1)
+
+        gauge.assert_not_called()
+        assert _base._counter_accumulators == {}
+
+    def test_otel_path_noop_when_dashlog_unavailable(self, mocker) -> None:
+        mocker.patch.dict("os.environ", {"DS_EAS_USE_OTEL": "true"}, clear=False)
+        mocker.patch("subscriber.metrics._base._dashlog", None)
+        gauge = mocker.patch("subscriber.metrics._base._dashlog_gauge")
+
+        _base._dashlog_counter("test_metric", 1)
+
+        gauge.assert_not_called()
+        assert _base._counter_accumulators == {}

--- a/subscriber/tests/metrics/test_catalog.py
+++ b/subscriber/tests/metrics/test_catalog.py
@@ -1,0 +1,233 @@
+"""Canonical-truth inspection: every metric name the code can emit must
+appear in ``docs/metrics.json``.
+
+The test exercises both metric emission surfaces:
+
+- **Lifecycle helpers** — each ``report_xxx()`` function in
+  ``subscriber.metrics.lifecycle``.
+- **Main-path reporter** — ``MetricsReporter`` flush for both the success
+  and drop paths, covering dynamically constructed stage names
+  (``kv_stage_{span}_ms``), e2e latency, aggregate counters, and gauges.
+
+Every stage name, counter name, and gauge name used in production code is
+represented.  The test collects the full prefixed metric names and asserts
+membership in the ``docs/metrics.json`` catalog.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# All stage / counter / gauge names used in production code.
+#
+# Stage names: every ``telemetry.mark("<name>")`` call site in
+#   subscriber/engine/**, subscriber/forwarding.py, subscriber/kvcm/client.py.
+# Counter names: every ``telemetry.count("<name>", …)`` call site.
+# Gauge names: every ``telemetry.gauge("<name>", …)`` call site.
+# ---------------------------------------------------------------------------
+
+_PRODUCTION_STAGE_NAMES: list[str] = [
+    "decode",  # incremental adapter, snapshot adapter
+    "replay_fetch",  # incremental adapter (replay path)
+    "snapshot_fetch",  # snapshot adapter (gRPC fetch)
+    "snapshot_build",  # snapshot adapter (build batch)
+    "queue_wait",  # forwarding (dequeue)
+    "engine_gate_wait",  # forwarding (health gate)
+    "block_filter",  # forwarding (incremental filter)
+    "expand",  # kvcm client (payload serialization)
+    "kvcm_send",  # kvcm client (KVCM ReportEvent call)
+]
+
+_PRODUCTION_COUNTER_NAMES: list[str] = [
+    "stored_block_hash_count",  # forwarding._submit_incremental_success
+    "removed_block_hash_count",  # forwarding._submit_incremental_success
+    "snapshot_block_count",  # forwarding._submit_snapshot_success
+    "zmq_sequence_gap_count",  # incremental adapter (replay)
+    "zmq_missed_message_count",  # incremental adapter (replay)
+]
+
+_PRODUCTION_TAGGED_COUNTERS: list[tuple[str, dict[str, str]]] = [
+    ("kvcm_report_event_request_count", {"status_code": "OK"}),
+    (
+        "kvcm_report_event_failure_count",
+        {"status_code": "GRPC_UNAVAILABLE", "reason": "transport"},
+    ),
+    ("kvcm_report_event_retry_count", {"reason": "SERVER_NOT_LEADER"}),
+]
+
+_PRODUCTION_GAUGE_NAMES: list[str] = [
+    "full_snapshot_payload_bytes",  # snapshot adapter
+    "kvcm_merged_queue_item_count",  # forwarding incremental merge diagnostics
+    "kvcm_source_batch_count",  # forwarding incremental merge diagnostics
+    "kvcm_source_event_count",  # forwarding incremental merge diagnostics
+    "kvcm_merged_report_event_count",  # forwarding incremental merge diagnostics
+    "kvcm_queue_size_before_merge",  # forwarding incremental merge diagnostics
+    "kvcm_queue_size_after_merge",  # forwarding incremental merge diagnostics
+    "kvcm_oldest_enqueue_to_send_ms",  # forwarding incremental merge diagnostics
+    "kvcm_newest_enqueue_to_send_ms",  # forwarding incremental merge diagnostics
+    "kvcm_report_event_count",  # KvcmClient incremental report request
+]
+
+_PRODUCTION_TAGGED_GAUGES: list[tuple[str, dict[str, str]]] = [
+    ("kvcm_report_event_call_ms", {"status_code": "OK"}),
+    ("kvcm_report_event_request_bytes", {"status_code": "OK"}),
+    ("kvcm_report_event_wire_encode_ms", {"status_code": "OK"}),
+    ("kvcm_report_event_grpc_call_ms", {"status_code": "OK"}),
+    ("kvcm_snapshot_source_block_count", {"status_code": "OK"}),
+    ("kvcm_snapshot_merged_block_count", {"status_code": "OK"}),
+]
+
+_METRICS_JSON_PATH = Path(__file__).resolve().parents[2] / "docs" / "metrics.json"
+
+
+def _load_metrics_catalog() -> set[str]:
+    """Return the set of fully-qualified metric names from docs/metrics.json."""
+    data = json.loads(_METRICS_JSON_PATH.read_text())
+    return {entry["name"] for entry in data["metrics"]}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle emission
+# ---------------------------------------------------------------------------
+
+
+def _exercise_lifecycle(collector: set[str], mocker: pytest.MockFixture) -> None:
+    """Call every lifecycle helper, capturing emitted metric names."""
+    metrics = importlib.import_module("subscriber.metrics")
+
+    def _capture(name: str, *args: object, **kwargs: object) -> None:
+        collector.add(name)
+
+    mocker.patch("subscriber.metrics.lifecycle._dashlog_counter", side_effect=_capture)
+    mocker.patch("subscriber.metrics.lifecycle._dashlog_gauge", side_effect=_capture)
+
+    metrics.report_engine_probe("alive", 1.0)
+    metrics.report_engine_probe("dead", 2.0)
+    metrics.report_engine_probe("timeout", 3.0)
+    metrics.report_engine_probe("rpc_error", 4.0)
+
+    metrics.report_engine_state_transition("starting", "healthy")
+    metrics.report_engine_state_transition("healthy", "dead")
+
+    metrics.report_subscriber_phase_transition("starting", "active")
+    metrics.report_subscriber_phase_transition("active", "inactive")
+
+    metrics.report_dashserving_heartbeat(success=True)
+    metrics.report_dashserving_heartbeat(success=False)
+
+    metrics.report_dashserving_state_report("active", "accepted", 5.0)
+    metrics.report_dashserving_state_report("failed", "error", 1.0)
+
+    metrics.report_shutdown("host_down_sent:shutdown")
+    metrics.report_shutdown("host_down_failed:timeout")
+
+    metrics.report_heartbeat(success=True)
+    metrics.report_heartbeat(success=False)
+
+    metrics.report_registration_recovery()
+    metrics.report_registration_transition("unregistered", "registered")
+
+    metrics.report_zmq_message()
+
+
+# ---------------------------------------------------------------------------
+# Reporter emission
+# ---------------------------------------------------------------------------
+
+
+async def _exercise_reporter(collector: set[str], mocker: pytest.MockFixture) -> None:
+    """Exercise MetricsReporter success + drop paths with all production names."""
+    metrics = importlib.import_module("subscriber.metrics")
+
+    def _capture(name: str, *args: object, **kwargs: object) -> None:
+        collector.add(name)
+
+    mocker.patch("subscriber.metrics.reporter._dashlog_counter", side_effect=_capture)
+    mocker.patch("subscriber.metrics.reporter._dashlog_gauge", side_effect=_capture)
+
+    # --- Success path: all stages, all counters, all gauges ---
+    ticks = iter([0.0] + [float(i) for i in range(1, len(_PRODUCTION_STAGE_NAMES) + 1)])
+    telemetry = metrics.BatchTelemetry(
+        pipeline="incremental", clock=lambda: next(ticks)
+    )
+    for stage in _PRODUCTION_STAGE_NAMES:
+        telemetry.mark(stage)
+    for name in _PRODUCTION_COUNTER_NAMES:
+        telemetry.count(name, 1)
+    for name in _PRODUCTION_GAUGE_NAMES:
+        telemetry.gauge(name, 100.0)
+    for name, tags in _PRODUCTION_TAGGED_COUNTERS:
+        telemetry.count(name, 1, tags=tags)
+    for name, tags in _PRODUCTION_TAGGED_GAUGES:
+        telemetry.gauge(name, 100.0, tags=tags)
+
+    reporter = metrics.MetricsReporter()
+    await reporter.start()
+    reporter.submit(telemetry)
+    await asyncio.sleep(0.05)
+
+    # --- Drop path: partial stages then drop ---
+    ticks2 = iter([0.0, 0.1, 0.2])
+    drop_telemetry = metrics.BatchTelemetry(
+        pipeline="snapshot", clock=lambda: next(ticks2)
+    )
+    drop_telemetry.mark("snapshot_fetch")
+    drop_telemetry.mark("decode")
+    drop_telemetry.gauge("full_snapshot_payload_bytes", 512)
+    drop_telemetry.mark_dropped("fetch_failed")
+    reporter.submit(drop_telemetry)
+    await asyncio.sleep(0.05)
+
+    await reporter.stop()
+
+
+# ---------------------------------------------------------------------------
+# The canonical-truth test
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsCatalog:
+    """docs/metrics.json and emitted metric names must match in both directions."""
+
+    async def test_all_emitted_metrics_are_cataloged(
+        self, mocker: pytest.MockFixture
+    ) -> None:
+        catalog = _load_metrics_catalog()
+        prefix = "kvcache_subscriber_"
+        raw_names: set[str] = set()
+
+        _exercise_lifecycle(raw_names, mocker)
+        await _exercise_reporter(raw_names, mocker)
+
+        # Build the full qualified names the way _base.py does:
+        # _dashlog_counter / _dashlog_gauge prepend _METRIC_PREFIX.
+        full_names = {prefix + name for name in raw_names}
+
+        missing = sorted(full_names - catalog)
+        assert not missing, (
+            f"Metric name(s) emitted by code but absent from "
+            f"docs/metrics.json: {missing}"
+        )
+
+    async def test_no_stale_catalog_entries(self, mocker: pytest.MockFixture) -> None:
+        """Reverse drift: every cataloged metric must still be emitted by code."""
+        catalog = _load_metrics_catalog()
+        prefix = "kvcache_subscriber_"
+        raw_names: set[str] = set()
+
+        _exercise_lifecycle(raw_names, mocker)
+        await _exercise_reporter(raw_names, mocker)
+
+        full_names = {prefix + name for name in raw_names}
+
+        stale = sorted(catalog - full_names)
+        assert not stale, (
+            f"Metric name(s) cataloged in docs/metrics.json but no longer "
+            f"emitted by code (remove them or exercise them here): {stale}"
+        )

--- a/subscriber/tests/metrics/test_lifecycle.py
+++ b/subscriber/tests/metrics/test_lifecycle.py
@@ -1,0 +1,202 @@
+"""Tests for lifecycle metric helpers (synchronous dashlog emitters).
+
+Main-path telemetry (``BatchTelemetry`` + ``MetricsReporter``) is covered by
+``tests/metrics/test_reporter.py``. This file only exercises the sparse,
+point-event ``report_xxx()`` helpers that live in
+``subscriber.metrics.lifecycle`` and route straight to dashlog.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+class TestInitDashlog:
+    def test_calls_dashlog_init(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        mocker.patch("subscriber.metrics._base._dashlog", mocker.MagicMock())
+        init = mocker.patch("subscriber.metrics._base._dashlog_init")
+
+        metrics.init_dashlog("kvcache-subscriber")
+
+        init.assert_called_once_with("kvcache-subscriber")
+
+    def test_swallows_errors(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        mocker.patch("subscriber.metrics._base._dashlog", mocker.MagicMock())
+        mocker.patch(
+            "subscriber.metrics._base._dashlog_init",
+            side_effect=RuntimeError("init failed"),
+        )
+
+        metrics.init_dashlog("kvcache-subscriber")
+
+    def test_warns_when_dashlog_unavailable(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        mocker.patch("subscriber.metrics._base._dashlog", None)
+        init = mocker.patch("subscriber.metrics._base._dashlog_init")
+        warning = mocker.patch("subscriber.logger.warning")
+
+        metrics.init_dashlog("kvcache-subscriber")
+
+        init.assert_not_called()
+        warning.assert_called_once_with(
+            "dashlog is unavailable; metrics reporting is disabled",
+            step="metrics_init",
+            tags={"app_name": "kvcache-subscriber"},
+        )
+
+
+class TestKvcmHeartbeat:
+    def test_success_increments_counter_with_tag(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+
+        metrics.report_heartbeat(success=True)
+
+        counter.assert_called_once_with(
+            "kvcm_heartbeat_count", 1, tags={"status": "success"}
+        )
+
+    def test_failure_increments_counter_with_tag(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+
+        metrics.report_heartbeat(success=False)
+
+        counter.assert_called_once_with(
+            "kvcm_heartbeat_count", 1, tags={"status": "failure"}
+        )
+
+    def test_swallows_errors(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        mocker.patch(
+            "subscriber.metrics.lifecycle._dashlog_counter",
+            side_effect=RuntimeError("fail"),
+        )
+
+        metrics.report_heartbeat(success=True)
+
+
+class TestKvcmRegistration:
+    def test_recovery_increments_counter(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+
+        metrics.report_registration_recovery()
+
+        counter.assert_called_once_with("kvcm_registration_recovery_count", 1)
+
+    def test_transition_is_tagged(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+
+        metrics.report_registration_transition("unregistered", "registered")
+
+        counter.assert_called_once_with(
+            "kvcm_registration_transition_count",
+            1,
+            tags={"from": "unregistered", "to": "registered"},
+        )
+
+
+class TestHealthMetrics:
+    def test_engine_probe_reports_count_and_latency(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+        gauge = mocker.patch("subscriber.metrics.lifecycle._dashlog_gauge")
+
+        metrics.report_engine_probe("alive", 12.5)
+
+        counter.assert_called_once_with(
+            "engine_health_probe_count", 1, tags={"result": "alive"}
+        )
+        gauge.assert_called_once_with(
+            "engine_health_probe_latency_ms", 12.5, tags={"result": "alive"}
+        )
+
+    def test_engine_and_subscriber_transitions_are_tagged(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+
+        metrics.report_engine_state_transition("starting", "healthy")
+        metrics.report_subscriber_phase_transition("starting", "active")
+
+        assert counter.call_args_list == [
+            mocker.call(
+                "engine_health_state_transition_count",
+                1,
+                tags={"from": "starting", "to": "healthy"},
+            ),
+            mocker.call(
+                "subscriber_phase_transition_count",
+                1,
+                tags={"from": "starting", "to": "active"},
+            ),
+        ]
+
+    def test_dashserving_heartbeat_and_state_report_are_observable(
+        self, mocker
+    ) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+        gauge = mocker.patch("subscriber.metrics.lifecycle._dashlog_gauge")
+
+        metrics.report_dashserving_heartbeat(success=False)
+        metrics.report_dashserving_state_report("active", "error", 7.5)
+
+        assert counter.call_args_list == [
+            mocker.call("dashserving_heartbeat_count", 1, tags={"status": "failure"}),
+            mocker.call(
+                "dashserving_state_report_count",
+                1,
+                tags={"state": "active", "result": "error"},
+            ),
+        ]
+        gauge.assert_called_once_with(
+            "dashserving_state_report_latency_ms",
+            7.5,
+            tags={"state": "active", "result": "error"},
+        )
+
+    def test_shutdown_is_tagged(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+
+        metrics.report_shutdown("host_down_sent:shutdown")
+
+        counter.assert_called_once_with(
+            "subscriber_shutdown_count",
+            1,
+            tags={"outcome": "host_down_sent:shutdown"},
+        )
+
+    def test_helpers_swallow_dashlog_errors(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        mocker.patch(
+            "subscriber.metrics.lifecycle._dashlog_counter",
+            side_effect=RuntimeError("dashlog unavailable"),
+        )
+
+        metrics.report_engine_probe("rpc_error", 1.0)
+        metrics.report_dashserving_state_report("failed", "error", 2.0)
+        metrics.report_registration_transition("registered", "unregistered")
+
+
+class TestZmqMessageCounter:
+    def test_increments_received_counter(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        counter = mocker.patch("subscriber.metrics.lifecycle._dashlog_counter")
+
+        metrics.report_zmq_message()
+
+        counter.assert_called_once_with("zmq_received_message_count", 1)
+
+    def test_swallows_errors(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        mocker.patch(
+            "subscriber.metrics.lifecycle._dashlog_counter",
+            side_effect=RuntimeError("dashlog unavailable"),
+        )
+
+        metrics.report_zmq_message()

--- a/subscriber/tests/metrics/test_reporter.py
+++ b/subscriber/tests/metrics/test_reporter.py
@@ -1,0 +1,584 @@
+"""Tests for the new metrics reporter architecture (BatchTelemetry + MetricsReporter).
+
+These tests exercise the two public seams introduced by the metrics refactor:
+
+- ``BatchTelemetry``: main-path telemetry container with ``mark`` / ``count`` /
+  ``mark_dropped`` verbs; observed via its finalized ``spans`` / ``counters`` /
+  ``drop_reason`` / ``pipeline`` snapshot.
+- ``MetricsReporter``: the single async output for the main path; observed via
+  the dashlog counter/gauge calls it emits when a telemetry is submitted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import pytest
+
+
+def _telemetry(module, pipeline: str = "incremental", clock=None):
+    if clock is None:
+        return module.BatchTelemetry(pipeline=pipeline)
+    return module.BatchTelemetry(pipeline=pipeline, clock=clock)
+
+
+# ---------------------------------------------------------------------------
+# BatchTelemetry
+# ---------------------------------------------------------------------------
+
+
+class TestBatchTelemetry:
+    def test_mark_produces_named_spans_between_marks(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        ticks = iter([100.0, 100.2, 100.5, 101.0])
+        telemetry = _telemetry(metrics, clock=lambda: next(ticks))
+
+        telemetry.mark("queue_wait")
+        telemetry.mark("gate_wait")
+        telemetry.mark("kvcm_send")
+
+        spans = telemetry.spans
+        assert [span.name for span in spans] == [
+            "queue_wait",
+            "gate_wait",
+            "kvcm_send",
+        ]
+        assert [span.duration_s for span in spans] == pytest.approx([0.2, 0.3, 0.5])
+
+    def test_mark_returns_duration_since_previous_mark(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        ticks = iter([100.0, 100.2, 100.5])
+        telemetry = _telemetry(metrics, clock=lambda: next(ticks))
+
+        first_duration_s = telemetry.mark("snapshot_fetch")
+        second_duration_s = telemetry.mark("snapshot_build")
+
+        assert first_duration_s == pytest.approx(0.2)
+        assert second_duration_s == pytest.approx(0.3)
+
+    def test_mark_ignores_clock_failures(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        ticks = iter([100.0])
+
+        def failing_clock() -> float:
+            try:
+                return next(ticks)
+            except StopIteration as exc:
+                raise RuntimeError("metric clock failed") from exc
+
+        telemetry = _telemetry(metrics, clock=failing_clock)
+
+        assert telemetry.mark("kvcm_send") == 0.0
+        assert [span.name for span in telemetry.spans] == ["kvcm_send"]
+        assert telemetry.spans[0].duration_s == 0.0
+
+    def test_count_accumulates_named_counters(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        telemetry = _telemetry(metrics)
+
+        telemetry.count("stored_block_hash_count", 3)
+        telemetry.count("stored_block_hash_count", 2, tags={})
+        telemetry.count("removed_block_hash_count", 1)
+
+        assert telemetry.counters == {
+            "stored_block_hash_count": 5,
+            "removed_block_hash_count": 1,
+        }
+
+    def test_count_and_gauge_ignore_unconvertible_values(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+
+        class UnconvertibleValue:
+            def __int__(self) -> int:
+                raise RuntimeError("counter conversion failed")
+
+            def __float__(self) -> float:
+                raise RuntimeError("gauge conversion failed")
+
+        telemetry = _telemetry(metrics)
+        value = UnconvertibleValue()
+
+        telemetry.count("stored_block_hash_count", value)
+        telemetry.gauge("full_snapshot_payload_bytes", value)
+
+        assert telemetry.counters == {}
+        assert telemetry.gauges == {}
+
+    def test_gauge_records_last_value_per_name(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        telemetry = _telemetry(metrics)
+
+        telemetry.gauge("full_snapshot_fetch_latency_ms", 12.5)
+        telemetry.gauge("full_snapshot_payload_bytes", 2048)
+        # Repeated gauge writes overwrite (gauge semantics, not accumulate).
+        telemetry.gauge("full_snapshot_fetch_latency_ms", 20.0, tags={})
+
+        assert telemetry.gauges == {
+            "full_snapshot_fetch_latency_ms": 20.0,
+            "full_snapshot_payload_bytes": 2048,
+        }
+
+    def test_mark_dropped_records_reason_and_preserves_spans(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        ticks = iter([100.0, 100.1, 100.3])
+        telemetry = _telemetry(metrics, clock=lambda: next(ticks))
+
+        telemetry.mark("queue_wait")
+        telemetry.mark_dropped("send_failed")
+
+        assert telemetry.drop_reason == "send_failed"
+        # The completed stage before the drop is still visible.
+        assert [span.name for span in telemetry.spans] == ["queue_wait"]
+
+    def test_checkpoint_and_elapsed_since_checkpoint(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        # 4 ticks: origin, checkpoint, elapsed-read, missing-check
+        ticks = iter([100.0, 100.1, 100.5, 101.0])
+        telemetry = _telemetry(metrics, clock=lambda: next(ticks))
+
+        telemetry.checkpoint("queue_enqueued")
+        elapsed = telemetry.elapsed_since_checkpoint("queue_enqueued")
+
+        assert elapsed == pytest.approx(0.4)
+        assert telemetry.elapsed_since_checkpoint("missing") is None
+
+    def test_pipeline_is_exposed(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        telemetry = _telemetry(metrics, pipeline="snapshot")
+
+        assert telemetry.pipeline == "snapshot"
+
+
+# ---------------------------------------------------------------------------
+# MetricsReporter
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsReporterSuccess:
+    async def test_flushes_stage_spans_e2e_latency_and_counters(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+        counter = mocker.patch("subscriber.metrics.reporter._dashlog_counter")
+
+        ticks = iter([100.0, 100.002, 100.012, 100.042])
+        telemetry = _telemetry(
+            metrics, pipeline="incremental", clock=lambda: next(ticks)
+        )
+        telemetry.mark("decode")
+        telemetry.mark("queue_wait")
+        telemetry.mark("kvcm_send")
+        telemetry.count("stored_block_hash_count", 3)
+        telemetry.count("removed_block_hash_count", 2)
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+        await reporter.stop()
+
+        assert gauge.call_args_list == [
+            mocker.call(
+                "kv_stage_decode_ms",
+                pytest.approx(2.0),
+                tags={"pipeline": "incremental"},
+            ),
+            mocker.call(
+                "kv_stage_queue_wait_ms",
+                pytest.approx(10.0),
+                tags={"pipeline": "incremental"},
+            ),
+            mocker.call(
+                "kv_stage_kvcm_send_ms",
+                pytest.approx(30.0),
+                tags={"pipeline": "incremental"},
+            ),
+            mocker.call(
+                "kv_event_e2e_latency_ms",
+                pytest.approx(42.0),
+                tags={"pipeline": "incremental"},
+            ),
+        ]
+        assert counter.call_args_list == [
+            mocker.call("stored_block_hash_count", 3, tags={"pipeline": "incremental"}),
+            mocker.call(
+                "removed_block_hash_count", 2, tags={"pipeline": "incremental"}
+            ),
+        ]
+
+    async def test_slow_success_emits_warning(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        warning_logged = asyncio.Event()
+        warning = mocker.patch(
+            "subscriber.metrics.reporter.logger.warning",
+            side_effect=lambda *args, **kwargs: warning_logged.set(),
+        )
+
+        ticks = iter([0.0, 0.01, 0.015, 0.065])
+        telemetry = _telemetry(metrics, pipeline="snapshot", clock=lambda: next(ticks))
+        telemetry.mark("queue_wait")
+        telemetry.mark("gate_wait")
+        telemetry.mark("kvcm_send")
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+
+        try:
+            await asyncio.wait_for(warning_logged.wait(), timeout=1)
+        finally:
+            await reporter.stop()
+
+        warning.assert_called_once_with(
+            "kv event forwarding latency exceeded threshold",
+            step="kv_event_metrics",
+            tags={
+                "pipeline": "snapshot",
+                "queue_wait_ms": 10.0,
+                "gate_wait_ms": 5.0,
+                "kvcm_send_ms": 50.0,
+                "total_ms": 65.0,
+                "threshold_ms": 50.0,
+            },
+        )
+
+    async def test_fast_success_skips_warning(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        processed = asyncio.Event()
+        warning = mocker.patch("subscriber.metrics.reporter.logger.warning")
+        mocker.patch(
+            "subscriber.metrics.reporter._dashlog_gauge",
+            side_effect=lambda *args, **kwargs: processed.set(),
+        )
+
+        ticks = iter([0.0, 0.001])
+        telemetry = _telemetry(metrics, clock=lambda: next(ticks))
+        telemetry.mark("kvcm_send")
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+
+        try:
+            await asyncio.wait_for(processed.wait(), timeout=1)
+        finally:
+            await reporter.stop()
+
+        warning.assert_not_called()
+
+    async def test_empty_spans_do_not_emit_e2e_latency(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+
+        telemetry = _telemetry(metrics)  # no marks
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+        await reporter.stop()
+
+        gauge.assert_not_called()
+
+    async def test_flushes_gauges_with_pipeline_tag(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+
+        telemetry = _telemetry(metrics, pipeline="snapshot")
+        telemetry.gauge("full_snapshot_fetch_latency_ms", 12.5)
+        telemetry.gauge("full_snapshot_payload_bytes", 2048)
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+        await reporter.stop()
+
+        # Gauges are emitted with the pipeline tag, alongside any stage span
+        # gauges (there are none here since the telemetry has no marks).
+        assert (
+            mocker.call(
+                "full_snapshot_fetch_latency_ms",
+                12.5,
+                tags={"pipeline": "snapshot"},
+            )
+            in gauge.call_args_list
+        )
+        assert (
+            mocker.call(
+                "full_snapshot_payload_bytes",
+                2048,
+                tags={"pipeline": "snapshot"},
+            )
+            in gauge.call_args_list
+        )
+
+    async def test_flushes_tagged_request_observations_asynchronously(
+        self, mocker
+    ) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        flushed = asyncio.Event()
+        emitted: list[object] = []
+
+        def capture(*args: object, **kwargs: object) -> None:
+            emitted.append((args, kwargs))
+            if len(emitted) == 2:
+                flushed.set()
+
+        counter = mocker.patch(
+            "subscriber.metrics.reporter._dashlog_counter", side_effect=capture
+        )
+        gauge = mocker.patch(
+            "subscriber.metrics.reporter._dashlog_gauge", side_effect=capture
+        )
+        telemetry = _telemetry(metrics, pipeline="incremental")
+        telemetry.count(
+            "kvcm_report_event_request_count",
+            1,
+            tags={"status_code": "OK"},
+        )
+        telemetry.gauge(
+            "kvcm_report_event_call_ms",
+            12.5,
+            tags={"status_code": "OK"},
+        )
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+
+        counter.assert_not_called()
+        gauge.assert_not_called()
+        try:
+            await asyncio.wait_for(flushed.wait(), timeout=1)
+        finally:
+            await reporter.stop()
+
+        assert (
+            mocker.call(
+                "kvcm_report_event_request_count",
+                1,
+                tags={"pipeline": "incremental", "status_code": "OK"},
+            )
+            in counter.call_args_list
+        )
+        assert (
+            mocker.call(
+                "kvcm_report_event_call_ms",
+                12.5,
+                tags={"pipeline": "incremental", "status_code": "OK"},
+            )
+            in gauge.call_args_list
+        )
+
+    async def test_flushes_same_metric_with_distinct_tags_separately(
+        self, mocker
+    ) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        telemetry = _telemetry(metrics, pipeline="incremental")
+        counter = mocker.patch("subscriber.metrics.reporter._dashlog_counter")
+        gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+
+        telemetry.count("kvcm_report_event_request_count", 1, tags={"status": "OK"})
+        telemetry.count(
+            "kvcm_report_event_request_count", 1, tags={"status": "REJECTED"}
+        )
+        telemetry.gauge("kvcm_report_event_call_ms", 1.5, tags={"status": "OK"})
+        telemetry.gauge("kvcm_report_event_call_ms", 2.5, tags={"status": "REJECTED"})
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        try:
+            reporter.submit(telemetry)
+            await asyncio.sleep(0.05)
+        finally:
+            await reporter.stop()
+
+        assert counter.call_args_list == [
+            mocker.call(
+                "kvcm_report_event_request_count",
+                1,
+                tags={"pipeline": "incremental", "status": "OK"},
+            ),
+            mocker.call(
+                "kvcm_report_event_request_count",
+                1,
+                tags={"pipeline": "incremental", "status": "REJECTED"},
+            ),
+        ]
+        assert gauge.call_args_list == [
+            mocker.call(
+                "kvcm_report_event_call_ms",
+                1.5,
+                tags={"pipeline": "incremental", "status": "OK"},
+            ),
+            mocker.call(
+                "kvcm_report_event_call_ms",
+                2.5,
+                tags={"pipeline": "incremental", "status": "REJECTED"},
+            ),
+        ]
+
+
+class TestMetricsReporterDrop:
+    async def test_drop_emits_drop_counter_and_preserved_spans(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+        counter = mocker.patch("subscriber.metrics.reporter._dashlog_counter")
+
+        ticks = iter([0.0, 0.01, 0.015])
+        telemetry = _telemetry(
+            metrics, pipeline="incremental", clock=lambda: next(ticks)
+        )
+        telemetry.mark("queue_wait")
+        telemetry.mark("engine_gate_wait")
+        telemetry.mark_dropped("epoch_changed")
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+        await reporter.stop()
+
+        # Drop counter is emitted with pipeline + reason tags.
+        assert (
+            mocker.call(
+                "kv_batch_drop_count",
+                1,
+                tags={"pipeline": "incremental", "reason": "epoch_changed"},
+            )
+            in counter.call_args_list
+        )
+        # Stage histograms up to the drop point are still emitted, but tagged
+        # with the drop reason so dashboards can distinguish them from
+        # successful batches.
+        assert gauge.call_args_list == [
+            mocker.call(
+                "kv_stage_queue_wait_ms",
+                pytest.approx(10.0),
+                tags={
+                    "pipeline": "incremental",
+                    "drop_reason": "epoch_changed",
+                },
+            ),
+            mocker.call(
+                "kv_stage_engine_gate_wait_ms",
+                pytest.approx(5.0),
+                tags={
+                    "pipeline": "incremental",
+                    "drop_reason": "epoch_changed",
+                },
+            ),
+        ]
+
+    async def test_drop_emits_gauges_with_drop_reason_tag(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        gauge = mocker.patch("subscriber.metrics.reporter._dashlog_gauge")
+
+        telemetry = _telemetry(metrics, pipeline="snapshot")
+        telemetry.gauge("full_snapshot_fetch_latency_ms", 12.5)
+        telemetry.mark_dropped("fetch_failed")
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+        await reporter.stop()
+
+        # On drop, gauges carry both pipeline and drop_reason tags so
+        # dashboards can distinguish partial from successful measurements.
+        assert (
+            mocker.call(
+                "full_snapshot_fetch_latency_ms",
+                12.5,
+                tags={"pipeline": "snapshot", "drop_reason": "fetch_failed"},
+            )
+            in gauge.call_args_list
+        )
+
+    async def test_drop_does_not_emit_slow_warning(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        warning = mocker.patch("subscriber.metrics.reporter.logger.warning")
+        processed = asyncio.Event()
+        mocker.patch(
+            "subscriber.metrics.reporter._dashlog_counter",
+            side_effect=lambda *args, **kwargs: processed.set(),
+        )
+
+        # A long-running batch that ultimately dropped: total span 200 ms.
+        ticks = iter([0.0, 0.1, 0.2])
+        telemetry = _telemetry(metrics, clock=lambda: next(ticks))
+        telemetry.mark("queue_wait")
+        telemetry.mark("engine_gate_wait")
+        telemetry.mark_dropped("send_failed")
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+
+        try:
+            await asyncio.wait_for(processed.wait(), timeout=1)
+        finally:
+            await reporter.stop()
+
+        warning.assert_not_called()
+
+
+class TestMetricsReporterLifecycle:
+    async def test_start_is_idempotent(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        reporter = metrics.MetricsReporter()
+
+        await reporter.start()
+        first_task = reporter._task
+        await reporter.start()
+
+        try:
+            assert reporter._task is first_task
+        finally:
+            await reporter.stop()
+
+    async def test_uses_configured_task_name(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        reporter = metrics.MetricsReporter(task_name="snapshot-kv-event-metrics")
+
+        await reporter.start()
+        try:
+            assert reporter._task is not None
+            assert reporter._task.get_name() == "snapshot-kv-event-metrics"
+        finally:
+            await reporter.stop()
+
+    def test_submit_without_start_does_not_raise(self) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        reporter = metrics.MetricsReporter()
+        telemetry = _telemetry(metrics)
+        telemetry.mark("kvcm_send")
+
+        # Must not raise even though the flush task never started.
+        reporter.submit(telemetry)
+
+    def test_submit_swallows_queue_errors(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        reporter = metrics.MetricsReporter()
+        reporter._queue = mocker.Mock()
+        reporter._queue.put_nowait.side_effect = RuntimeError("queue failure")
+
+        telemetry = _telemetry(metrics)
+        telemetry.mark("kvcm_send")
+
+        reporter.submit(telemetry)  # must not raise
+
+    async def test_dashlog_failures_are_swallowed(self, mocker) -> None:
+        metrics = importlib.import_module("subscriber.metrics")
+        mocker.patch(
+            "subscriber.metrics.reporter._dashlog_gauge",
+            side_effect=RuntimeError("dashlog unavailable"),
+        )
+        telemetry = _telemetry(metrics)
+        telemetry.mark("kvcm_send")
+
+        reporter = metrics.MetricsReporter()
+        await reporter.start()
+        reporter.submit(telemetry)
+        await asyncio.sleep(0.05)
+        await reporter.stop()  # must not raise

--- a/subscriber/tests/pipeline/__init__.py
+++ b/subscriber/tests/pipeline/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/subscriber/tests/pipeline/test_block_filter.py
+++ b/subscriber/tests/pipeline/test_block_filter.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from subscriber.pipeline.block_filter import filter_block_removals
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    ExternalBlockHash,
+    KVEventBatch,
+)
+
+
+def _stored(
+    block_hashes: list[ExternalBlockHash], *, medium: str = "GPU"
+) -> BlockStored:
+    return BlockStored(
+        block_hashes=block_hashes,
+        parent_block_hash=None,
+        token_ids=[],
+        block_size=16,
+        lora_id=None,
+        medium=medium,
+        lora_name=None,
+    )
+
+
+def _removed(
+    block_hashes: list[ExternalBlockHash],
+    *,
+    medium: str = "GPU",
+    group_idx: int | None = None,
+    remaining_copy_counts: list[int] | None = None,
+) -> BlockRemoved:
+    return BlockRemoved(
+        block_hashes=block_hashes,
+        medium=medium,
+        group_idx=group_idx,
+        remaining_copy_counts=remaining_copy_counts,
+    )
+
+
+def _batch(
+    *events: BlockStored | BlockRemoved | AllBlocksCleared,
+) -> list[KVEventBatch]:
+    return [KVEventBatch(ts=1.0, events=list(events))]
+
+
+def _events(batches: list[KVEventBatch]) -> list[object]:
+    return [event for batch in batches for event in batch.events]
+
+
+# --- remaining_copy_counts provided: filter by count ---
+
+
+def test_all_zero_remaining_counts_forwards_all_hashes() -> None:
+    """All remaining counts are 0 → forward all block hashes."""
+    batches = _batch(
+        _removed([1, 2, 3], remaining_copy_counts=[0, 0, 0]),
+    )
+    result = filter_block_removals(batches)
+    assert _events(result) == [_removed([1, 2, 3], remaining_copy_counts=[0, 0, 0])]
+
+
+def test_all_nonzero_remaining_counts_suppresses_entire_event() -> None:
+    """All remaining counts > 0 → suppress entire BlockRemoved event."""
+    batches = _batch(
+        _removed([1, 2], remaining_copy_counts=[2, 1]),
+    )
+    result = filter_block_removals(batches)
+    assert _events(result) == []
+
+
+def test_mixed_remaining_counts_keeps_only_zero_count_hashes() -> None:
+    """Mixed counts → only forward hashes with remaining_copy_counts == 0."""
+    batches = _batch(
+        _removed([1, 2, 3], group_idx=5, remaining_copy_counts=[1, 0, 0]),
+    )
+    result = filter_block_removals(batches)
+    assert _events(result) == [
+        _removed([2, 3], group_idx=5, remaining_copy_counts=[0, 0]),
+    ]
+
+
+def test_mismatched_remaining_counts_drops_removal_and_preserves_later_batch(
+    mocker,
+) -> None:
+    warning = mocker.patch("subscriber.logger.warning")
+    stored = _stored([3])
+
+    result = filter_block_removals(
+        [
+            KVEventBatch(
+                ts=1.0,
+                events=[_removed([1, 2], group_idx=5, remaining_copy_counts=[0])],
+            ),
+            KVEventBatch(ts=2.0, events=[stored]),
+        ]
+    )
+
+    assert _events(result) == [stored]
+    warning.assert_called_once_with(
+        "dropping block removal with mismatched remaining copy counts",
+        step="block_filter",
+        tags={
+            "block_hash_count": 2,
+            "remaining_copy_count": 1,
+            "medium": "GPU",
+            "group_idx": 5,
+        },
+    )
+
+
+# --- remaining_copy_counts is None: passthrough ---
+
+
+def test_none_remaining_counts_forwards_all_hashes() -> None:
+    """remaining_copy_counts is None → forward all (engine didn't provide counts)."""
+    batches = _batch(
+        _removed([1, 2]),
+    )
+    result = filter_block_removals(batches)
+    assert _events(result) == [_removed([1, 2])]
+
+
+# --- non-BlockRemoved events pass through ---
+
+
+def test_block_stored_and_all_cleared_pass_through() -> None:
+    """BlockStored and AllBlocksCleared are never filtered."""
+    batches = _batch(
+        _stored([1]),
+        AllBlocksCleared(),
+    )
+    result = filter_block_removals(batches)
+    assert _events(result) == [_stored([1]), AllBlocksCleared()]
+
+
+# --- empty batch is dropped ---
+
+
+def test_empty_batch_after_full_suppression_is_dropped() -> None:
+    """If all events in a batch are suppressed, the batch itself is omitted."""
+    batches = _batch(
+        _removed([1], remaining_copy_counts=[3]),
+    )
+    result = filter_block_removals(batches)
+    assert result == []
+
+
+# --- multiple batches ---
+
+
+def test_filters_across_multiple_batches() -> None:
+    """Filter applies independently to each batch."""
+    batch1 = KVEventBatch(
+        ts=1.0,
+        events=[_removed([1, 2], remaining_copy_counts=[0, 1])],
+    )
+    batch2 = KVEventBatch(
+        ts=2.0,
+        events=[
+            _stored([3]),
+            _removed([4], remaining_copy_counts=[0]),
+        ],
+    )
+    result = filter_block_removals([batch1, batch2])
+    assert len(result) == 2
+    assert _events([result[0]]) == [
+        _removed([1], remaining_copy_counts=[0]),
+    ]
+    assert _events([result[1]]) == [
+        _stored([3]),
+        _removed([4], remaining_copy_counts=[0]),
+    ]

--- a/subscriber/tests/pipeline/test_context.py
+++ b/subscriber/tests/pipeline/test_context.py
@@ -1,0 +1,92 @@
+"""Tests for PipelineContext — the per-batch mutable pipeline context."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from subscriber.engine.base import EngineEventBatch
+from subscriber.metrics import BatchTelemetry
+from subscriber.pipeline.context import PipelineContext
+from subscriber.trace import generate_trace_id
+from subscriber.types import BlockStored, KVEventBatch
+
+
+def _make_event_batch() -> EngineEventBatch:
+    batch = KVEventBatch(
+        ts=1.0,
+        events=[
+            BlockStored(
+                block_hashes=["hash1"],
+                parent_block_hash=None,
+                token_ids=[],
+                block_size=16,
+                lora_id=None,
+                medium="gpu",
+                lora_name=None,
+            )
+        ],
+        data_parallel_rank=None,
+    )
+    telemetry = BatchTelemetry(pipeline="incremental")
+    trace_id = generate_trace_id()
+    return EngineEventBatch(batches=[batch], telemetry=telemetry, trace_id=trace_id)
+
+
+def _ctx(**kwargs: object) -> PipelineContext:
+    defaults: dict = {
+        "event": _make_event_batch(),
+        "epoch_snapshot": 1,
+        "reporter": MagicMock(),
+    }
+    defaults.update(kwargs)
+    return PipelineContext(**defaults)
+
+
+class TestPipelineContext:
+    """PipelineContext delegates to EngineEventBatch and tracks pipeline state."""
+
+    def test_property_delegation(self) -> None:
+        event = _make_event_batch()
+        ctx = PipelineContext(event=event, epoch_snapshot=1, reporter=MagicMock())
+        assert ctx.trace_id == event.trace_id
+        assert ctx.batches is event.batches
+        assert ctx.telemetry is event.telemetry
+
+    def test_initial_state(self) -> None:
+        ctx = _ctx()
+        assert ctx.epoch_snapshot == 1
+        assert ctx.batch_trace_id is None
+        assert ctx.drop_reason is None
+
+    def test_epoch_snapshot_set_by_producer(self) -> None:
+        ctx = _ctx(epoch_snapshot=3)
+        assert ctx.epoch_snapshot == 3
+
+    def test_batch_trace_id_set_by_sender(self) -> None:
+        ctx = _ctx()
+        ctx.batch_trace_id = "some_first_item_trace"
+        assert ctx.batch_trace_id == "some_first_item_trace"
+
+    def test_mark_dropped_sets_both_fields(self) -> None:
+        ctx = _ctx()
+        ctx.mark_dropped("epoch_changed")
+        assert ctx.drop_reason == "epoch_changed"
+        assert ctx.telemetry.drop_reason == "epoch_changed"
+
+    def test_trace_id_is_30_chars(self) -> None:
+        ctx = _ctx()
+        assert len(ctx.trace_id) == 30
+
+    def test_submit_calls_reporter(self) -> None:
+        reporter = MagicMock()
+        ctx = _ctx(reporter=reporter)
+        ctx.submit()
+        reporter.submit.assert_called_once_with(ctx.telemetry)
+
+    def test_submit_dropped_marks_and_submits(self) -> None:
+        reporter = MagicMock()
+        ctx = _ctx(reporter=reporter)
+        ctx.submit_dropped("send_failed")
+        assert ctx.drop_reason == "send_failed"
+        assert ctx.telemetry.drop_reason == "send_failed"
+        reporter.submit.assert_called_once_with(ctx.telemetry)

--- a/subscriber/tests/proto/__init__.py
+++ b/subscriber/tests/proto/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for subscriber.proto."""

--- a/subscriber/tests/proto/test_engine_service_rpc.py
+++ b/subscriber/tests/proto/test_engine_service_rpc.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+from subscriber.engine.kv_event_control_client import DashllmKvEventControlClient
+from subscriber.engine.worker_status_client import DashllmWorkerStatusClient
+from subscriber.proto import (
+    engine_service_rpc_pb2,
+    engine_service_rpc_pb2_grpc,
+)
+
+
+class _PathCapture:
+    def __init__(self) -> None:
+        self.paths: list[str] = []
+
+    def unary_unary(self, path: str, **_: Any) -> AsyncMock:
+        self.paths.append(path)
+        return AsyncMock()
+
+
+class _InvokingChannel(_PathCapture):
+    def __init__(self, response: object) -> None:
+        super().__init__()
+        self.response = response
+        self.requests: list[object] = []
+        self.close = AsyncMock()
+
+    def unary_unary(self, path: str, **_: Any) -> Any:
+        self.paths.append(path)
+
+        async def invoke(request: object, *, timeout: float) -> object:
+            del timeout
+            self.requests.append(request)
+            return self.response
+
+        return invoke
+
+
+def test_bootstrap_response_uses_versioned_engine_oneof_and_stable_fields() -> None:
+    descriptor = engine_service_rpc_pb2.KvEventBootstrapInfoPB.DESCRIPTOR
+
+    assert descriptor.fields_by_name["protocol_version"].number == 1
+    assert descriptor.fields_by_name["engine_kind"].number == 2
+    assert descriptor.fields_by_name["event_transport"].number == 3
+    assert descriptor.fields_by_name["runtime_topology"].number == 4
+    assert descriptor.fields_by_name["snapshot"].number == 5
+    assert descriptor.fields_by_name["components"].number == 6
+    assert descriptor.fields_by_name["err_code"].number == 7
+    assert descriptor.fields_by_name["err_msg"].number == 8
+    assert descriptor.fields_by_name["compatibility_settings"].number == 9
+    assert descriptor.fields_by_name["diagnostic_settings"].number == 10
+    assert descriptor.fields_by_name["vllm"].number == 20
+    assert descriptor.fields_by_name["sglang"].number == 21
+    assert descriptor.oneofs_by_name["engine_schema"].fields == [
+        descriptor.fields_by_name["vllm"],
+        descriptor.fields_by_name["sglang"],
+    ]
+    topic = engine_service_rpc_pb2.EventTransportPB.DESCRIPTOR.fields_by_name["topic"]
+    assert topic.number == 2
+    assert topic.type == topic.TYPE_STRING
+
+
+def test_bootstrap_raw_wire_is_shared_without_a_proto_package() -> None:
+    # protocol_version=1, engine_kind="sglang", sglang={cache_key_mode:"token"}.
+    raw = b"\x08\x01\x12\x06sglang\xaa\x01\x07\x0a\x05token"
+
+    response = engine_service_rpc_pb2.KvEventBootstrapInfoPB.FromString(raw)
+
+    assert response.protocol_version == 1
+    assert response.engine_kind == "sglang"
+    assert response.WhichOneof("engine_schema") == "sglang"
+    assert response.sglang.cache_key_mode == "token"
+
+
+def test_component_geometry_preserves_unavailable_payload_size() -> None:
+    component = engine_service_rpc_pb2.CacheComponentPB(
+        component_id=0,
+        component_kind="full_attention",
+        geometry=engine_service_rpc_pb2.CacheGeometryPB(
+            block_size_tokens=128,
+            page_size_tokens=engine_service_rpc_pb2.OptionalUInt64PB(value=1),
+        ),
+    )
+
+    assert component.geometry.HasField("page_size_tokens")
+    assert not component.geometry.HasField("group_payload_size_bytes")
+
+
+def test_typed_setting_retains_value_type() -> None:
+    setting = engine_service_rpc_pb2.TypedSettingPB(
+        name="vllm.use_eagle_pop",
+        bool_value=True,
+    )
+
+    assert setting.WhichOneof("value") == "bool_value"
+    assert setting.bool_value is True
+
+
+def test_control_and_remote_status_use_separate_services() -> None:
+    status_channel = _PathCapture()
+    control_channel = _PathCapture()
+
+    engine_service_rpc_pb2_grpc.RpcServiceStub(status_channel)
+    engine_service_rpc_pb2_grpc.KvEventControlServiceStub(control_channel)
+
+    assert status_channel.paths == ["/RpcService/GetWorkerStatus"]
+    assert control_channel.paths == [
+        "/KvEventControlService/GetKvEventBootstrapInfo",
+        "/KvEventControlService/GetAllKvCacheBlocks",
+    ]
+
+
+async def test_client_uses_tcp_for_status_and_uds_for_bootstrap(
+    mocker: Any,
+) -> None:
+    status_response = engine_service_rpc_pb2.WorkerStatusPB(alive=True)
+    bootstrap_response = engine_service_rpc_pb2.KvEventBootstrapInfoPB(
+        protocol_version=1,
+        engine_kind="vllm",
+        vllm=engine_service_rpc_pb2.VllmKvEventSchemaPB(),
+    )
+    status_channel = _InvokingChannel(status_response)
+    control_channel = _InvokingChannel(bootstrap_response)
+    insecure_channel = mocker.patch(
+        "grpc.aio.insecure_channel",
+        side_effect=[status_channel, control_channel],
+    )
+    status_client = DashllmWorkerStatusClient("127.0.0.1:18002")
+    control_client = DashllmKvEventControlClient("/tmp/dashllm-kv-event-control.sock")
+
+    assert (await status_client.get_worker_status(1.0)).alive is True
+    assert (await control_client.get_kv_event_bootstrap_info(1.0)).engine_kind == "vllm"
+
+    assert [call.args[0] for call in insecure_channel.call_args_list] == [
+        "127.0.0.1:18002",
+        "unix:///tmp/dashllm-kv-event-control.sock",
+    ]
+    assert status_channel.paths == ["/RpcService/GetWorkerStatus"]
+    assert control_channel.paths == [
+        "/KvEventControlService/GetKvEventBootstrapInfo",
+        "/KvEventControlService/GetAllKvCacheBlocks",
+    ]
+
+    await status_client.close()
+    await control_client.close()
+    status_channel.close.assert_awaited_once()
+    control_channel.close.assert_awaited_once()

--- a/subscriber/tests/test_cli.py
+++ b/subscriber/tests/test_cli.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from subscriber.cli import _build_cli_parser
+from subscriber.config import SubscriberConfig
+
+_KVCM_ARGS = [
+    "--kvcm-base-url",
+    "http://kvcm-test:8080",
+    "--host-port",
+    "8080",
+]
+
+
+def test_cli_parser_accepts_serve_subcommand_log_level() -> None:
+    parser = _build_cli_parser()
+    args = parser.parse_args(["serve", "--log-level", "debug", *_KVCM_ARGS])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert args.command == "serve"
+    assert config.log_level == "debug"
+
+
+def test_cli_parser_accepts_legacy_top_level_args() -> None:
+    parser = _build_cli_parser()
+    args = parser.parse_args(["--log-level", "debug", *_KVCM_ARGS])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.log_level == "debug"
+
+
+def test_cli_parser_preserves_top_level_log_level_before_serve() -> None:
+    parser = _build_cli_parser()
+    args = parser.parse_args(["--log-level", "debug", "serve", *_KVCM_ARGS])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert args.command == "serve"
+    assert config.log_level == "debug"
+
+
+def test_cli_parser_preserves_top_level_config_before_serve(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "log_level: 'debug'\nkvcm_base_url: 'http://kvcm-test:8080'\n"
+    )
+    parser = _build_cli_parser()
+    args = parser.parse_args(
+        ["--config", str(config_file), "serve", "--host-port", "8080"]
+    )
+
+    config = SubscriberConfig.from_args(args)
+
+    assert args.command == "serve"
+    assert config.log_level == "debug"

--- a/subscriber/tests/test_config.py
+++ b/subscriber/tests/test_config.py
@@ -1,0 +1,814 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from subscriber.config import SubscriberConfig, build_parser
+from subscriber.kvcm.enum import KvcmStorageType
+
+_KVCM_ARGS = [
+    "--kvcm-base-url",
+    "http://kvcm-test:8080",
+    "--host-port",
+    "8080",
+]
+
+
+def test_defaults() -> None:
+    config = SubscriberConfig()
+    assert config.engine_type == "vllm"
+    assert (
+        config.engine_kv_event_control_uds_path == "/tmp/dashllm-kv-event-control.sock"
+    )
+    assert config.engine_kv_event_bootstrap_timeout_ms == 1000.0
+    assert config.engine_kv_event_bootstrap_max_retries == 5
+    assert config.kvcm_protocol == "grpc"
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        {"DS_LLM_PROC_ENGINE_RANK": "3", "DS_LLM_PROC_RANK": "7"},
+        {"DS_LLM_PROC_RANK": "7"},
+    ],
+)
+def test_control_uds_default_ignores_dashllm_process_ranks(
+    monkeypatch: pytest.MonkeyPatch,
+    environment: dict[str, str],
+) -> None:
+    monkeypatch.delenv("DS_LLM_PROC_ENGINE_RANK", raising=False)
+    monkeypatch.delenv("DS_LLM_PROC_RANK", raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+
+    config = SubscriberConfig()
+
+    assert (
+        config.engine_kv_event_control_uds_path == "/tmp/dashllm-kv-event-control.sock"
+    )
+
+
+def test_incremental_kv_event_pipeline_is_enabled_by_default() -> None:
+    config = SubscriberConfig()
+
+    assert config.incremental_kv_event_pipeline_enabled is True
+
+
+def test_incremental_kv_event_pipeline_cli_disable() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [*_KVCM_ARGS, "--no-incremental-kv-event-pipeline-enabled"]
+    )
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.incremental_kv_event_pipeline_enabled is False
+
+
+def test_incremental_kv_event_pipeline_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("incremental_kv_event_pipeline_enabled: false\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.incremental_kv_event_pipeline_enabled is False
+
+
+def test_snapshot_kv_event_pipeline_is_disabled_by_default() -> None:
+    config = SubscriberConfig()
+
+    assert config.snapshot_kv_event_pipeline_enabled is False
+
+
+def test_snapshot_kv_event_pipeline_cli_disable() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--no-snapshot-kv-event-pipeline-enabled"])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.snapshot_kv_event_pipeline_enabled is False
+
+
+def test_snapshot_kv_event_pipeline_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("snapshot_kv_event_pipeline_enabled: false\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.snapshot_kv_event_pipeline_enabled is False
+
+
+def test_engine_type_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--engine-type", "sglang"])
+    config = SubscriberConfig.from_args(args)
+    assert config.engine_type == "sglang"
+
+
+def test_extra_attention_types_cli_overrides_yaml(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("extra_attention_types:\n  custom_attention: yaml-prefix\n")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--config",
+            str(yaml_file),
+            "--extra-attention-types",
+            '{"custom_attention":"cli-prefix"}',
+        ]
+    )
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.extra_attention_types == {"custom_attention": "cli-prefix"}
+
+
+def test_extra_attention_types_cannot_override_builtin_mapping() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--extra-attention-types",
+            '{"full_attention":"custom-prefix"}',
+        ]
+    )
+
+    with pytest.raises(ValueError, match="cannot override built-in"):
+        SubscriberConfig.from_args(args)
+
+
+def test_storage_type_defaults_to_event_report() -> None:
+    config = SubscriberConfig()
+
+    assert config.kvcm_storage_type == KvcmStorageType.ST_EVENT_REPORT_L1P5
+
+
+def test_removed_storage_type_is_rejected() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kvcm-storage-type", "ST_EVENT_REPORT"])
+
+    with pytest.raises(ValueError, match="kvcm_storage_type"):
+        SubscriberConfig.from_args(args)
+
+
+def test_protobuf_storage_type_cli_override_is_accepted() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kvcm-storage-type", "ST_NFS"])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.kvcm_storage_type == KvcmStorageType.ST_NFS
+
+
+def test_unspecified_storage_type_is_rejected() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kvcm-storage-type", "ST_UNSPECIFIED"])
+
+    with pytest.raises(ValueError, match="must not be ST_UNSPECIFIED"):
+        SubscriberConfig.from_args(args)
+
+
+def test_blank_kvcm_base_url_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KVS_KVCM_ENDPOINT", raising=False)
+    parser = build_parser()
+    args = parser.parse_args(["--host-port", "8080"])
+    with pytest.raises(ValueError, match="kvcm_base_url is required"):
+        SubscriberConfig.from_args(args)
+
+
+def test_kvcm_base_url_falls_back_to_kvs_kvcm_endpoint_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KVS_KVCM_ENDPOINT", "spectrum://v-46354ead:6382")
+    parser = build_parser()
+    args = parser.parse_args(["--host-port", "8080"])
+    config = SubscriberConfig.from_args(args)
+    assert config.kvcm_base_url == "spectrum://v-46354ead:6382"
+
+
+def test_kvcm_base_url_cli_takes_precedence_over_kvs_kvcm_endpoint_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KVS_KVCM_ENDPOINT", "spectrum://v-46354ead:6382")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS])
+    config = SubscriberConfig.from_args(args)
+    assert config.kvcm_base_url == "http://kvcm-test:8080"
+
+
+def test_kvcm_protocol_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kvcm-protocol", "http"])
+    config = SubscriberConfig.from_args(args)
+    assert config.kvcm_protocol == "http"
+
+
+def test_kvcm_protocol_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("kvcm_protocol: http\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+    config = SubscriberConfig.from_args(args)
+    assert config.kvcm_protocol == "http"
+
+
+def test_invalid_kvcm_protocol_is_rejected() -> None:
+    config = SubscriberConfig(
+        kvcm_base_url="spectrum://v-46354ead:6381",
+        kvcm_protocol="tcp",
+        host_port=8080,
+    )
+    with pytest.raises(ValueError, match="kvcm_protocol must be one of"):
+        config.validate()
+
+
+def test_kv_event_queue_maxsize_defaults_to_4096() -> None:
+    config = SubscriberConfig()
+
+    assert config.kv_event_queue_maxsize == 4096
+
+
+def test_kv_event_queue_maxsize_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kv-event-queue-maxsize", "7"])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.kv_event_queue_maxsize == 7
+
+
+def test_kv_event_queue_maxsize_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("kv_event_queue_maxsize: 9\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.kv_event_queue_maxsize == 9
+
+
+def test_kv_event_queue_maxsize_must_be_positive() -> None:
+    config = SubscriberConfig(kv_event_queue_maxsize=0, host_port=8080)
+
+    with pytest.raises(ValueError, match="kv_event_queue_maxsize must be >= 1"):
+        config.validate()
+
+
+def test_kv_event_merge_max_report_events_defaults_to_16() -> None:
+    config = SubscriberConfig()
+
+    assert config.kv_event_merge_max_report_events == 16
+
+
+def test_kv_event_merge_max_report_events_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kv-event-merge-max-report-events", "7"])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.kv_event_merge_max_report_events == 7
+
+
+def test_kv_event_merge_max_report_events_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("kv_event_merge_max_report_events: 9\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.kv_event_merge_max_report_events == 9
+
+
+def test_kv_event_merge_max_report_events_must_be_positive() -> None:
+    config = SubscriberConfig(kv_event_merge_max_report_events=0, host_port=8080)
+
+    with pytest.raises(
+        ValueError,
+        match="kv_event_merge_max_report_events must be >= 1",
+    ):
+        config.validate()
+
+
+def test_kv_event_merge_max_queue_items_defaults_to_4() -> None:
+    config = SubscriberConfig()
+
+    assert config.kv_event_merge_max_queue_items == 4
+
+
+def test_kv_event_merge_max_queue_items_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kv-event-merge-max-queue-items", "2"])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.kv_event_merge_max_queue_items == 2
+
+
+def test_kv_event_merge_max_queue_items_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("kv_event_merge_max_queue_items: 3\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.kv_event_merge_max_queue_items == 3
+
+
+def test_kv_event_merge_max_queue_items_must_be_positive() -> None:
+    config = SubscriberConfig(kv_event_merge_max_queue_items=0, host_port=8080)
+
+    with pytest.raises(
+        ValueError,
+        match="kv_event_merge_max_queue_items must be >= 1",
+    ):
+        config.validate()
+
+
+def test_kvcm_runtime_config_defaults() -> None:
+    config = SubscriberConfig()
+    assert config.kvcm_heartbeat_interval_s == 5.0
+
+
+def test_kvcm_runtime_config_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--kvcm-heartbeat-interval-s",
+            "2.5",
+        ]
+    )
+    config = SubscriberConfig.from_args(args)
+    assert config.kvcm_heartbeat_interval_s == 2.5
+
+
+def test_kvcm_runtime_config_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(
+        textwrap.dedent(
+            """\
+            kvcm_heartbeat_interval_s: 3.0
+            """
+        )
+    )
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+    config = SubscriberConfig.from_args(args)
+    assert config.kvcm_heartbeat_interval_s == 3.0
+
+
+def test_non_positive_kvcm_heartbeat_interval_raises() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--kvcm-heartbeat-interval-s", "0"])
+
+    with pytest.raises(ValueError, match="^kvcm_heartbeat_interval_s must be > 0$"):
+        SubscriberConfig.from_args(args)
+
+
+def test_host_port_has_no_default() -> None:
+    assert SubscriberConfig().host_port is None
+
+
+def test_host_port_missing_rejected_by_from_args() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["--kvcm-base-url", "http://kvcm-test:8080"])
+    with pytest.raises(ValueError, match="^host_port is required"):
+        SubscriberConfig.from_args(args)
+
+
+def test_host_port_missing_raises_in_validate() -> None:
+    config = SubscriberConfig(kvcm_base_url="http://kvcm-test:8080")
+    with pytest.raises(ValueError, match="^host_port is required"):
+        config.validate()
+
+
+def test_host_port_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--host-port", "9001"])
+    config = SubscriberConfig.from_args(args)
+    assert config.host_port == 9001
+
+
+def test_host_port_out_of_range_raises() -> None:
+    parser = build_parser()
+    for value in ("0", "65536"):
+        args = parser.parse_args([*_KVCM_ARGS, "--host-port", value])
+        with pytest.raises(ValueError, match=r"^host_port must be in \[1, 65535\]$"):
+            SubscriberConfig.from_args(args)
+
+
+def test_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(
+        textwrap.dedent("""\
+            engine_kv_event_control_uds_path: "/tmp/custom-control.sock"
+        """)
+    )
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+    config = SubscriberConfig.from_args(args)
+    assert config.engine_kv_event_control_uds_path == "/tmp/custom-control.sock"
+
+
+def test_cli_overrides_yaml(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("engine_type: vllm\n")
+    parser = build_parser()
+    args = parser.parse_args(
+        [*_KVCM_ARGS, "--config", str(yaml_file), "--engine-type", "sglang"]
+    )
+    config = SubscriberConfig.from_args(args)
+    assert config.engine_type == "sglang"
+
+
+def test_health_config_defaults() -> None:
+    config = SubscriberConfig()
+    assert config.engine_health_interval_s == 5.0
+    assert config.engine_kvcache_worker_status_timeout_ms == 1000.0
+    assert config.engine_health_failure_threshold == 3
+
+
+def test_health_config_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--engine-health-interval-s",
+            "0.25",
+            "--engine-kvcache-worker-status-timeout-ms",
+            "100",
+            "--engine-health-failure-threshold",
+            "5",
+        ]
+    )
+    config = SubscriberConfig.from_args(args)
+    assert config.engine_health_interval_s == 0.25
+    assert config.engine_kvcache_worker_status_timeout_ms == 100.0
+    assert config.engine_health_failure_threshold == 5
+
+
+def test_health_config_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(
+        textwrap.dedent(
+            """\
+            engine_health_interval_s: 2.5
+            engine_kvcache_worker_status_timeout_ms: 750
+            engine_health_failure_threshold: 7
+            """
+        )
+    )
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+    config = SubscriberConfig.from_args(args)
+    assert config.engine_health_interval_s == 2.5
+    assert config.engine_kvcache_worker_status_timeout_ms == 750
+    assert config.engine_health_failure_threshold == 7
+
+
+def test_legacy_engine_health_timeout_cli_argument_is_rejected() -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([*_KVCM_ARGS, "--engine-health-timeout-s", "0.1"])
+
+
+def test_zmq_transport_config_defaults() -> None:
+    config = SubscriberConfig()
+    assert config.zmq_reconnect_ivl_ms == 100
+    assert config.zmq_reconnect_ivl_max_ms == 5000
+    assert config.zmq_replay_timeout_s == 1.0
+    assert config.zmq_tcp_keepalive is True
+    assert config.zmq_tcp_keepalive_idle_s == 30
+    assert config.zmq_tcp_keepalive_intvl_s == 5
+    assert config.zmq_tcp_keepalive_cnt == 3
+
+
+def test_zmq_replay_timeout_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--zmq-replay-timeout-s", "0.25"])
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.zmq_replay_timeout_s == 0.25
+
+
+def test_zmq_replay_timeout_cli_overrides_yaml(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("zmq_replay_timeout_s: 0.75\n")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--config",
+            str(yaml_file),
+            "--zmq-replay-timeout-s",
+            "0.25",
+        ]
+    )
+
+    config = SubscriberConfig.from_args(args)
+
+    assert config.zmq_replay_timeout_s == 0.25
+
+
+def test_zmq_replay_timeout_must_be_positive() -> None:
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        zmq_replay_timeout_s=0,
+        host_port=8080,
+    )
+
+    with pytest.raises(ValueError, match="zmq_replay_timeout_s must be > 0"):
+        config.validate()
+
+
+def test_zmq_transport_config_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--zmq-reconnect-ivl-ms",
+            "200",
+            "--zmq-reconnect-ivl-max-ms",
+            "3000",
+            "--no-zmq-tcp-keepalive",
+            "--zmq-tcp-keepalive-idle-s",
+            "10",
+            "--zmq-tcp-keepalive-intvl-s",
+            "2",
+            "--zmq-tcp-keepalive-cnt",
+            "4",
+        ]
+    )
+    config = SubscriberConfig.from_args(args)
+    assert config.zmq_reconnect_ivl_ms == 200
+    assert config.zmq_reconnect_ivl_max_ms == 3000
+    assert config.zmq_tcp_keepalive is False
+    assert config.zmq_tcp_keepalive_idle_s == 10
+    assert config.zmq_tcp_keepalive_intvl_s == 2
+    assert config.zmq_tcp_keepalive_cnt == 4
+
+
+def test_log_level_cli_override() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--log-level", "debug"])
+    config = SubscriberConfig.from_args(args)
+    assert config.log_level == "debug"
+
+
+def test_log_level_yaml_loading(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("log_level: 'warning'\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+    config = SubscriberConfig.from_args(args)
+    assert config.log_level == "warning"
+
+
+def test_invalid_log_level_yaml_raises(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("log_level: 'verbose'\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+
+    with pytest.raises(
+        ValueError,
+        match="^log_level must be one of: critical, debug, error, info, warning$",
+    ):
+        SubscriberConfig.from_args(args)
+
+
+def test_non_string_log_level_yaml_raises(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("log_level: 123\n")
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+
+    with pytest.raises(
+        ValueError,
+        match="^log_level must be one of: critical, debug, error, info, warning$",
+    ):
+        SubscriberConfig.from_args(args)
+
+
+def test_non_positive_health_failure_threshold_raises() -> None:
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--engine-health-failure-threshold", "0"])
+
+    with pytest.raises(
+        ValueError,
+        match="^engine_health_failure_threshold must be >= 1$",
+    ):
+        SubscriberConfig.from_args(args)
+
+
+# --- Subscriber health integration config ---
+
+
+def test_subscriber_health_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DSV_CONTROL_PORT", raising=False)
+    config = SubscriberConfig()
+    assert config.subscriber_health_enabled is True
+    assert config.subscriber_state_url == "http://127.0.0.1:8601/subscriber_state"
+    assert config.subscriber_heartbeat_interval_s == 3.0
+    assert config.subscriber_state_request_timeout_s == 2.0
+    assert config.subscriber_shutdown_report_timeout_s == 2.0
+
+
+def test_removed_dashserving_readiness_and_ttl_fields_are_not_in_config() -> None:
+    config = SubscriberConfig()
+
+    assert not hasattr(config, "subscriber_state_ttl_s")
+    assert not hasattr(config, "dashserving_readiness_url")
+    assert not hasattr(config, "dashserving_readiness_interval_s")
+
+
+def test_subscriber_health_config_cli_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DSV_CONTROL_PORT", "9999")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--subscriber-health-enabled",
+            "--subscriber-heartbeat-interval-s",
+            "5.0",
+            "--subscriber-state-request-timeout-s",
+            "3.0",
+            "--subscriber-shutdown-report-timeout-s",
+            "4.0",
+        ]
+    )
+    config = SubscriberConfig.from_args(args)
+    assert config.subscriber_health_enabled is True
+    assert config.subscriber_state_url == "http://127.0.0.1:9999/subscriber_state"
+    assert config.subscriber_heartbeat_interval_s == 5.0
+    assert config.subscriber_state_request_timeout_s == 3.0
+    assert config.subscriber_shutdown_report_timeout_s == 4.0
+
+
+def test_subscriber_health_config_yaml_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DSV_CONTROL_PORT", "7777")
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(
+        textwrap.dedent(
+            """\
+            subscriber_health_enabled: true
+            subscriber_heartbeat_interval_s: 4.0
+            subscriber_state_request_timeout_s: 1.5
+            subscriber_shutdown_report_timeout_s: 3.5
+            """
+        )
+    )
+    parser = build_parser()
+    args = parser.parse_args([*_KVCM_ARGS, "--config", str(yaml_file)])
+    config = SubscriberConfig.from_args(args)
+    assert config.subscriber_health_enabled is True
+    assert config.subscriber_state_url == "http://127.0.0.1:7777/subscriber_state"
+    assert config.subscriber_heartbeat_interval_s == 4.0
+    assert config.subscriber_state_request_timeout_s == 1.5
+    assert config.subscriber_shutdown_report_timeout_s == 3.5
+
+
+def test_subscriber_health_cli_overrides_yaml(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(
+        textwrap.dedent(
+            """\
+            subscriber_health_enabled: true
+            subscriber_heartbeat_interval_s: 4.0
+            """
+        )
+    )
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            *_KVCM_ARGS,
+            "--config",
+            str(yaml_file),
+            "--subscriber-heartbeat-interval-s",
+            "2.0",
+        ]
+    )
+    config = SubscriberConfig.from_args(args)
+    assert config.subscriber_health_enabled is True
+    assert config.subscriber_heartbeat_interval_s == 2.0
+
+
+def test_subscriber_health_cli_disable_overrides_yaml_true(tmp_path: Path) -> None:
+    """--no-subscriber-health-enabled must override YAML `true`.
+
+    Guards against regressing back to action="store_true", which has no
+    --no- form and would make a YAML-enabled flag impossible to disable
+    from the CLI.
+    """
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("subscriber_health_enabled: true\n")
+    parser = build_parser()
+    args = parser.parse_args(
+        [*_KVCM_ARGS, "--config", str(yaml_file), "--no-subscriber-health-enabled"]
+    )
+    config = SubscriberConfig.from_args(args)
+    assert config.subscriber_health_enabled is False
+
+
+def test_subscriber_health_disabled_skips_validation() -> None:
+    """When subscriber_health_enabled=False, no health validation runs."""
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        subscriber_health_enabled=False,
+        subscriber_heartbeat_interval_s=-1.0,
+        host_port=8080,
+    )
+    # Should not raise — validation only applies when enabled
+    config.validate()
+
+
+def test_subscriber_health_enabled_positive_intervals() -> None:
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        subscriber_health_enabled=True,
+        subscriber_heartbeat_interval_s=0,
+        host_port=8080,
+    )
+    with pytest.raises(ValueError, match="subscriber_heartbeat_interval_s must be > 0"):
+        config.validate()
+
+
+def test_subscriber_health_enabled_positive_request_timeout() -> None:
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        subscriber_health_enabled=True,
+        subscriber_state_request_timeout_s=0,
+        host_port=8080,
+    )
+    with pytest.raises(
+        ValueError, match="subscriber_state_request_timeout_s must be > 0"
+    ):
+        config.validate()
+
+
+def test_subscriber_health_enabled_positive_shutdown_timeout() -> None:
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        subscriber_health_enabled=True,
+        subscriber_shutdown_report_timeout_s=-0.5,
+        host_port=8080,
+    )
+    with pytest.raises(
+        ValueError, match="subscriber_shutdown_report_timeout_s must be > 0"
+    ):
+        config.validate()
+
+
+def test_subscriber_health_valid_config_passes() -> None:
+    """A fully valid enabled config passes validation."""
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        subscriber_health_enabled=True,
+        subscriber_heartbeat_interval_s=3.0,
+        subscriber_state_request_timeout_s=2.0,
+        subscriber_shutdown_report_timeout_s=2.0,
+        host_port=8080,
+    )
+    config.validate()  # Should not raise
+
+
+def test_engine_snapshot_full_sync_interval_must_be_positive() -> None:
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        engine_snapshot_full_sync_interval_s=0,
+        host_port=8080,
+    )
+
+    with pytest.raises(
+        ValueError, match="engine_snapshot_full_sync_interval_s must be > 0"
+    ):
+        config.validate()
+
+
+def test_engine_snapshot_full_sync_interval_negative_raises() -> None:
+    config = SubscriberConfig(
+        kvcm_base_url="http://kvcm-test:8080",
+        engine_snapshot_full_sync_interval_s=-5.0,
+        host_port=8080,
+    )
+
+    with pytest.raises(
+        ValueError, match="engine_snapshot_full_sync_interval_s must be > 0"
+    ):
+        config.validate()

--- a/subscriber/tests/test_forwarding.py
+++ b/subscriber/tests/test_forwarding.py
@@ -1,0 +1,1740 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import ANY, AsyncMock, MagicMock, call
+
+import pytest
+
+from subscriber.config import SubscriberConfig
+from subscriber.engine.base import EngineEventBatch
+from subscriber.engine.metadata import (
+    EventTransport,
+    KvEventBootstrap,
+    RuntimeTopology,
+    SnapshotCapability,
+    VllmEventSchema,
+)
+from subscriber.kvcm.errors import (
+    KvcmReportRejectedError,
+    KvcmUnavailableError,
+)
+from subscriber.main import (
+    consume_incremental_events,
+    consume_snapshot_events,
+    send_incremental_events,
+    send_snapshot_events,
+)
+from subscriber.metrics import BatchTelemetry
+from subscriber.pipeline.context import PipelineContext
+from subscriber.trace import generate_trace_id
+from subscriber.types import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockSnapshot,
+    BlockSnapshotItem,
+    BlockStored,
+    KVEventBatch,
+)
+
+
+def _batch() -> list[KVEventBatch]:
+    return [KVEventBatch(ts=1.0, events=[AllBlocksCleared()])]
+
+
+def _empty_bootstrap() -> KvEventBootstrap:
+    return KvEventBootstrap(
+        protocol_version=1,
+        engine_kind="vllm",
+        event_transport=EventTransport(
+            live_endpoint="tcp://127.0.0.1:5557",
+            topic=b"",
+            replay_supported=True,
+            replay_endpoint="tcp://127.0.0.1:5558",
+            serialization="msgpack-v1",
+        ),
+        runtime_topology=RuntimeTopology(1, 1, 1, 0, 0, 0),
+        snapshot=SnapshotCapability(True, True),
+        components=(),
+        compatibility_settings=(),
+        diagnostic_settings=(),
+        vllm=VllmEventSchema(2, False, "none", "sha256", "v1"),
+    )
+
+
+def _batch_with_report_event_count(
+    ts: float, report_event_count: int
+) -> list[KVEventBatch]:
+    return [
+        KVEventBatch(
+            ts=ts,
+            events=[AllBlocksCleared() for _ in range(report_event_count)],
+        )
+    ]
+
+
+def _batch_with_zero_report_events(ts: float) -> list[KVEventBatch]:
+    return [
+        KVEventBatch(
+            ts=ts,
+            events=[
+                BlockStored(
+                    block_hashes=[],
+                    parent_block_hash=None,
+                    token_ids=[],
+                    block_size=16,
+                    lora_id=None,
+                    medium="GPU",
+                    lora_name=None,
+                )
+            ],
+        )
+    ]
+
+
+def _batch_with_block_hashes() -> list[KVEventBatch]:
+    return [
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                BlockStored(
+                    block_hashes=[1, 2],
+                    parent_block_hash=None,
+                    token_ids=[10, 11],
+                    block_size=16,
+                    lora_id=None,
+                    medium="GPU",
+                    lora_name=None,
+                ),
+                BlockRemoved(block_hashes=[3], medium="GPU"),
+            ],
+        ),
+        KVEventBatch(
+            ts=2.0,
+            events=[
+                BlockStored(
+                    block_hashes=[4],
+                    parent_block_hash=None,
+                    token_ids=[12],
+                    block_size=16,
+                    lora_id=None,
+                    medium="GPU",
+                    lora_name=None,
+                ),
+                BlockRemoved(block_hashes=[5, 6], medium="GPU"),
+            ],
+        ),
+    ]
+
+
+def _event(batches: list[KVEventBatch]) -> EngineEventBatch:
+    return EngineEventBatch(
+        batches, BatchTelemetry(pipeline="incremental"), trace_id=generate_trace_id()
+    )
+
+
+def _queued(
+    batches: list,
+    epoch: int,
+    telemetry: BatchTelemetry,
+    reporter: object | None = None,
+    trace_id: str | None = None,
+) -> PipelineContext:
+    return PipelineContext(
+        event=EngineEventBatch(
+            batches=batches,
+            telemetry=telemetry,
+            trace_id=trace_id if trace_id is not None else generate_trace_id(),
+        ),
+        epoch_snapshot=epoch,
+        reporter=reporter if reporter is not None else MagicMock(),
+    )
+
+
+def test_main_reexports_forwarding_public_api() -> None:
+    from subscriber import forwarding
+    from subscriber.pipeline.context import PipelineContext as ContextPipelineContext
+
+    assert PipelineContext is ContextPipelineContext
+    assert consume_incremental_events is forwarding.consume_incremental_events
+    assert send_incremental_events is forwarding.send_incremental_events
+    assert send_snapshot_events is forwarding.send_snapshot_events
+
+
+def test_pipeline_context_requires_event() -> None:
+    with pytest.raises(TypeError):
+        PipelineContext()
+
+
+@pytest.fixture
+def adapter() -> MagicMock:
+    mock = MagicMock()
+
+    async def _subscribe():
+        return
+        yield  # pragma: no cover
+
+    mock.subscribe_kv_events = _subscribe
+    mock.subscribe_snapshot_events = _subscribe
+    return mock
+
+
+@pytest.fixture
+def kvcm() -> MagicMock:
+    mock = MagicMock()
+    mock.report_kv_events = AsyncMock()
+    mock.report_snapshot = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def coordinator() -> MagicMock:
+    mock = MagicMock()
+    mock.wait_ready_epoch = AsyncMock(return_value=1)
+    mock.capture_epoch = MagicMock(return_value=1)
+    mock.is_epoch_current = MagicMock(return_value=True)
+    return mock
+
+
+async def test_consume_incremental_events_queues_batch_with_epoch_snapshot(
+    adapter: MagicMock, coordinator: MagicMock
+) -> None:
+    batch = _batch()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue(maxsize=1)
+
+    async def _subscribe():
+        yield _event(batch)
+
+    adapter.subscribe_kv_events = _subscribe
+    coordinator.capture_epoch.return_value = 3
+
+    await consume_incremental_events(adapter, coordinator, queue, MagicMock())
+
+    queued = queue.get_nowait()
+    assert queued.batches == batch
+    assert queued.epoch_snapshot == 3
+
+
+async def test_incremental_and_snapshot_consumers_share_not_ready_log_step(
+    adapter: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    async def _subscribe_incremental():
+        yield EngineEventBatch(
+            _batch(), BatchTelemetry(pipeline="incremental"), "incremental-trace"
+        )
+
+    async def _subscribe_snapshot():
+        yield EngineEventBatch(
+            _batch(), BatchTelemetry(pipeline="snapshot"), "snapshot-trace"
+        )
+
+    adapter.subscribe_kv_events = _subscribe_incremental
+    adapter.subscribe_snapshot_events = _subscribe_snapshot
+    coordinator.capture_epoch.return_value = None
+    warning = mocker.patch("subscriber.forwarding.logger.warning")
+
+    await consume_incremental_events(adapter, coordinator, asyncio.Queue(), MagicMock())
+    await consume_snapshot_events(adapter, coordinator, asyncio.Queue(), MagicMock())
+
+    assert warning.call_args_list == [
+        call(
+            "dropping pipeline batch captured while engine is not ready",
+            step="engine_event_consume",
+            tags={"pipeline": "incremental", "trace_id": "incremental-trace"},
+        ),
+        call(
+            "dropping pipeline batch captured while engine is not ready",
+            step="engine_event_consume",
+            tags={"pipeline": "snapshot", "trace_id": "snapshot-trace"},
+        ),
+    ]
+
+
+async def test_consume_incremental_events_marks_time_after_queue_admission(
+    adapter: MagicMock, coordinator: MagicMock
+) -> None:
+    timer = BatchTelemetry(pipeline="incremental")
+    batch = _batch()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue(maxsize=1)
+    await queue.put(_queued(_batch(), 1, BatchTelemetry(pipeline="incremental")))
+
+    async def _subscribe():
+        yield EngineEventBatch(batch, timer, trace_id=generate_trace_id())
+
+    adapter.subscribe_kv_events = _subscribe
+    consumer = asyncio.create_task(
+        consume_incremental_events(adapter, coordinator, queue, MagicMock())
+    )
+    await asyncio.sleep(0)
+
+    assert timer.elapsed_since_checkpoint("queue_enqueued") is None
+    queue.get_nowait()
+    queue.task_done()
+    await consumer
+
+    assert timer.elapsed_since_checkpoint("queue_enqueued") is not None
+
+
+async def test_consume_incremental_events_drops_batch_when_not_ready(
+    adapter: MagicMock, coordinator: MagicMock
+) -> None:
+    batch = _batch()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue(maxsize=1)
+
+    async def _subscribe():
+        yield _event(batch)
+
+    adapter.subscribe_kv_events = _subscribe
+    coordinator.capture_epoch.return_value = None
+
+    await consume_incremental_events(adapter, coordinator, queue, MagicMock())
+
+    assert queue.empty()
+
+
+async def test_send_kv_events_sends_immediately_when_queue_is_empty(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batch = _batch()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(_queued(batch, 1, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await asyncio.sleep(0)
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_kv_events.assert_awaited_once_with(
+        batch, 1, telemetries=ANY, trace_id=ANY
+    )
+    assert queue.empty()
+
+
+async def test_snapshot_signal_callback_failure_keeps_incremental_sender_running(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    """A local signal failure must not turn a successful KVCM send into a drop."""
+
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    telemetry = BatchTelemetry(pipeline="incremental")
+    await queue.put(_queued(_batch(), 1, telemetry, reporter=reporter))
+    kvcm.report_kv_events.return_value = True
+    signal_error = RuntimeError("snapshot signal failed")
+    on_snapshot_required = MagicMock(side_effect=signal_error)
+    warning = mocker.patch("subscriber.forwarding.logger.warning")
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            on_snapshot_required=on_snapshot_required,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    try:
+        await queue.join()
+
+        on_snapshot_required.assert_called_once_with()
+        reporter.submit.assert_called_once_with(telemetry)
+        assert not sender.done()
+        warning.assert_called_once_with(
+            "failed to request immediate snapshot; continuing incremental forwarding",
+            step="snapshot_signal",
+            tags={
+                "pipeline": "incremental",
+                "trace_id": ANY,
+                "merged_trace_ids": ANY,
+                "error": "RuntimeError",
+                "message": "snapshot signal failed",
+            },
+            exc_info=True,
+        )
+    finally:
+        sender.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await sender
+
+
+async def test_send_kv_events_merges_contiguous_batches_from_same_epoch(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    first_batch = _batch()
+    second_batch = [KVEventBatch(ts=2.0, events=[AllBlocksCleared()])]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(_queued(first_batch, 1, BatchTelemetry(pipeline="incremental")))
+    await queue.put(_queued(second_batch, 1, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=100,
+            max_merged_report_events=100,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_kv_events.assert_awaited_once_with(
+        first_batch + second_batch, 1, telemetries=ANY, trace_id=ANY
+    )
+
+
+async def test_send_kv_events_keeps_different_epochs_in_separate_sends(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    first_batch = _batch()
+    second_batch = [KVEventBatch(ts=2.0, events=[AllBlocksCleared()])]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(_queued(first_batch, 1, BatchTelemetry(pipeline="incremental")))
+    await queue.put(_queued(second_batch, 2, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_kv_events.await_args_list == [
+        ((first_batch, 1), {"telemetries": ANY, "trace_id": ANY}),
+        ((second_batch, 1), {"telemetries": ANY, "trace_id": ANY}),
+    ]
+
+
+async def test_send_kv_events_stops_merge_at_report_event_limit(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batches = [_batch_with_report_event_count(float(index), 8) for index in range(3)]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    for batch in batches:
+        await queue.put(_queued(batch, 1, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=4,
+            max_merged_report_events=16,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_kv_events.await_args_list == [
+        ((batches[0] + batches[1], 1), {"telemetries": ANY, "trace_id": ANY}),
+        ((batches[2], 1), {"telemetries": ANY, "trace_id": ANY}),
+    ]
+
+
+async def test_send_kv_events_uses_configured_report_event_limit(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batches = [_batch_with_report_event_count(float(index), 5) for index in range(3)]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    for batch in batches:
+        await queue.put(_queued(batch, 1, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_report_events=10,
+            max_merged_queue_items=100,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_kv_events.await_args_list == [
+        ((batches[0] + batches[1], 1), {"telemetries": ANY, "trace_id": ANY}),
+        ((batches[2], 1), {"telemetries": ANY, "trace_id": ANY}),
+    ]
+
+
+async def test_send_kv_events_stops_merge_at_default_queue_item_limit(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batches = [_batch_with_report_event_count(float(index), 1) for index in range(5)]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    for batch in batches:
+        await queue.put(_queued(batch, 1, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=4,
+            max_merged_report_events=16,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_kv_events.await_args_list == [
+        (
+            (batches[0] + batches[1] + batches[2] + batches[3], 1),
+            {"telemetries": ANY, "trace_id": ANY},
+        ),
+        ((batches[4], 1), {"telemetries": ANY, "trace_id": ANY}),
+    ]
+
+
+async def test_send_kv_events_uses_configured_queue_item_limit(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batches = [_batch_with_report_event_count(float(index), 1) for index in range(5)]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    for batch in batches:
+        await queue.put(_queued(batch, 1, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=2,
+            max_merged_report_events=100,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_kv_events.await_args_list == [
+        ((batches[0] + batches[1], 1), {"telemetries": ANY, "trace_id": ANY}),
+        ((batches[2] + batches[3], 1), {"telemetries": ANY, "trace_id": ANY}),
+        ((batches[4], 1), {"telemetries": ANY, "trace_id": ANY}),
+    ]
+
+
+async def test_send_kv_events_continues_when_diagnostics_logging_fails(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    batch = _batch()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(
+        _queued(
+            batch,
+            1,
+            BatchTelemetry(pipeline="incremental"),
+            trace_id="diagnostics-trace",
+        )
+    )
+    mocker.patch(
+        "subscriber.forwarding.log_merge_diagnostics",
+        side_effect=RuntimeError("diagnostics failed"),
+    )
+    warning = mocker.patch("subscriber.forwarding.logger.warning")
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_kv_events.assert_awaited_once_with(
+        batch, 1, telemetries=ANY, trace_id=ANY
+    )
+    warning.assert_called_once_with(
+        "failed to log kv event batch diagnostics; continuing with send",
+        step="kvcm_send",
+        tags={
+            "pipeline": "incremental",
+            "trace_id": "diagnostics-trace",
+            "merged_trace_ids": ["diagnostics-trace"],
+            "error": "RuntimeError",
+            "message": "diagnostics failed",
+        },
+        exc_info=True,
+    )
+
+
+async def test_send_kv_events_does_not_limit_source_batch_count(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batches = [
+        batch
+        for index in range(65)
+        for batch in _batch_with_zero_report_events(float(index))
+    ]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(_queued(batches, 1, BatchTelemetry(pipeline="incremental")))
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_kv_events.await_args_list == [
+        ((batches, 1), {"telemetries": ANY, "trace_id": ANY}),
+    ]
+
+
+async def test_send_kv_events_logs_enqueue_to_send_and_merge_diagnostics(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    first_batch = _batch()
+    second_batch = [KVEventBatch(ts=2.0, events=[AllBlocksCleared()])]
+    first_timer = BatchTelemetry(pipeline="incremental", clock=lambda: 10.0)
+    second_timer = BatchTelemetry(pipeline="incremental", clock=lambda: 10.25)
+    first_timer.checkpoint("queue_enqueued")
+    second_timer.checkpoint("queue_enqueued")
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    first_context = _queued(first_batch, 1, first_timer, trace_id="first-trace")
+    second_context = _queued(second_batch, 1, second_timer, trace_id="second-trace")
+    await queue.put(first_context)
+    await queue.put(second_context)
+    debug = mocker.patch("subscriber.main.logger.debug")
+    mocker.patch("subscriber.main.logger.is_debug_enabled", return_value=True)
+    mocker.patch("subscriber.forwarding.time.monotonic", return_value=10.5)
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=4,
+            max_merged_report_events=16,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    debug.assert_called_once_with(
+        "sending merged kv event batches to kvcm",
+        step="kvcm_send",
+        tags={
+            "pipeline": "incremental",
+            "trace_id": "first-trace",
+            "merged_trace_ids": ["first-trace", "second-trace"],
+            "queue_qsize_before_merge": 1,
+            "queue_qsize_after_merge": 0,
+            "merged_queue_item_count": 2,
+            "source_batch_count": 2,
+            "source_event_count": 2,
+            "merged_report_event_count": 2,
+            "oldest_enqueue_to_kvcm_send_ms": 500.0,
+            "newest_enqueue_to_kvcm_send_ms": 250.0,
+        },
+    )
+    assert second_context.batch_trace_id == "first-trace"
+
+
+async def test_send_kv_events_records_merged_request_gauges_once(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    first_batch = _batch()
+    second_batch = [KVEventBatch(ts=2.0, events=[AllBlocksCleared()])]
+    first_telemetry = BatchTelemetry(pipeline="incremental", clock=lambda: 10.0)
+    second_telemetry = BatchTelemetry(pipeline="incremental", clock=lambda: 10.25)
+    first_telemetry.checkpoint("queue_enqueued")
+    second_telemetry.checkpoint("queue_enqueued")
+    first_reporter = MagicMock()
+    second_reporter = MagicMock()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(_queued(first_batch, 1, first_telemetry, reporter=first_reporter))
+    await queue.put(
+        _queued(second_batch, 1, second_telemetry, reporter=second_reporter)
+    )
+    mocker.patch("subscriber.forwarding.time.monotonic", return_value=10.5)
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=4,
+            max_merged_report_events=16,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert first_telemetry.gauges == {
+        "kvcm_merged_queue_item_count": 2,
+        "kvcm_source_batch_count": 2,
+        "kvcm_source_event_count": 2,
+        "kvcm_merged_report_event_count": 2,
+        "kvcm_queue_size_before_merge": 1,
+        "kvcm_queue_size_after_merge": 0,
+        "kvcm_oldest_enqueue_to_send_ms": 500,
+        "kvcm_newest_enqueue_to_send_ms": 250,
+    }
+    assert second_telemetry.gauges == {}
+    first_reporter.submit.assert_called_once_with(first_telemetry)
+    second_reporter.submit.assert_called_once_with(second_telemetry)
+
+
+async def test_send_kv_events_logs_pending_batch_dropped_on_cancellation(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    first_batch = _batch()
+    second_batch = [KVEventBatch(ts=2.0, events=[AllBlocksCleared()])]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(
+        _queued(
+            first_batch,
+            1,
+            BatchTelemetry(pipeline="incremental"),
+            trace_id="first-trace",
+        )
+    )
+    await queue.put(
+        _queued(
+            second_batch,
+            2,
+            BatchTelemetry(pipeline="incremental"),
+            trace_id="pending-trace",
+        )
+    )
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def _send_kv_events(
+        _batches: list[KVEventBatch], _epoch: int, **kwargs
+    ) -> None:
+        send_started.set()
+        await release_send.wait()
+
+    kvcm.report_kv_events.side_effect = _send_kv_events
+    info = mocker.patch("subscriber.main.logger.info")
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=4,
+            max_merged_report_events=16,
+        )
+    )
+    await send_started.wait()
+
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+    await asyncio.wait_for(queue.join(), timeout=0.1)
+
+    info.assert_called_once_with(
+        "dropping pending kv event batch because sender stopped",
+        step="kv_event_loop",
+        tags={
+            "pipeline": "incremental",
+            "trace_id": "pending-trace",
+            "captured_epoch": 2,
+            "batch_count": 1,
+            "event_count": 1,
+        },
+    )
+
+
+async def test_send_kv_events_drops_merged_batch_after_kvcm_failure(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    first_batch = _batch()
+    second_batch = [KVEventBatch(ts=2.0, events=[AllBlocksCleared()])]
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(
+        _queued(
+            first_batch,
+            1,
+            BatchTelemetry(pipeline="incremental"),
+            trace_id="first-trace",
+        )
+    )
+    await queue.put(
+        _queued(
+            second_batch,
+            1,
+            BatchTelemetry(pipeline="incremental"),
+            trace_id="second-trace",
+        )
+    )
+    kvcm.report_kv_events.side_effect = KvcmUnavailableError("request failed")
+    warning = mocker.patch("subscriber.main.logger.warning")
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=4,
+            max_merged_report_events=16,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_kv_events.assert_awaited_once_with(
+        first_batch + second_batch, 1, telemetries=ANY, trace_id="first-trace"
+    )
+    warning.assert_called_once_with(
+        "failed to send kv event batch to kvcm; dropping batch",
+        step="kvcm_send",
+        tags={
+            "pipeline": "incremental",
+            "trace_id": "first-trace",
+            "merged_trace_ids": ["first-trace", "second-trace"],
+            "epoch": 1,
+            "batch_count": 2,
+            "event_count": 2,
+            "error": "KvcmUnavailableError",
+            "message": "request failed",
+            "reason": "unknown",
+            "dropped_batch_total": 2,
+            "dropped_event_total": 2,
+        },
+    )
+
+
+async def test_send_kv_events_reports_successful_batch_latency(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batch = _batch_with_block_hashes()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    await queue.put(
+        _queued(batch, 1, BatchTelemetry(pipeline="incremental"), reporter=reporter)
+    )
+
+    async def _mark_stages(_batches, _epoch, telemetries=None, **kw):
+        if telemetries:
+            for t in telemetries:
+                t.mark("expand")
+                t.mark("kvcm_send")
+
+    kvcm.report_kv_events.side_effect = _mark_stages
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await asyncio.sleep(0)
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    reporter.submit.assert_called_once()
+    telemetry = reporter.submit.call_args.args[0]
+    spans = telemetry.spans
+    assert [span.name for span in spans] == [
+        "queue_wait",
+        "engine_gate_wait",
+        "block_filter",
+        "expand",
+        "kvcm_send",
+    ]
+    assert all(span.duration_s >= 0 for span in spans)
+    assert telemetry.counters == {
+        "stored_block_hash_count": 3,
+        "removed_block_hash_count": 3,
+    }
+    assert telemetry.drop_reason is None
+
+
+async def test_send_kv_events_suppresses_removal_with_remaining_copies(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    store = BlockStored(
+        block_hashes=[1],
+        parent_block_hash=None,
+        token_ids=[10],
+        block_size=16,
+        lora_id=None,
+        medium="GPU",
+        lora_name=None,
+    )
+    suppressed_removal = BlockRemoved(
+        block_hashes=[1], medium="GPU", remaining_copy_counts=[1]
+    )
+    final_removal = BlockRemoved(
+        block_hashes=[1], medium="GPU", remaining_copy_counts=[0]
+    )
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(
+        _queued(
+            [KVEventBatch(ts=1.0, events=[store, suppressed_removal])],
+            1,
+            BatchTelemetry(pipeline="incremental"),
+        )
+    )
+    await queue.put(
+        _queued(
+            [KVEventBatch(ts=2.0, events=[final_removal])],
+            2,
+            BatchTelemetry(pipeline="incremental"),
+        )
+    )
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    first_sent = [
+        event
+        for batch in kvcm.report_kv_events.await_args_list[0].args[0]
+        for event in batch.events
+    ]
+    second_sent = [
+        event
+        for batch in kvcm.report_kv_events.await_args_list[1].args[0]
+        for event in batch.events
+    ]
+    assert first_sent == [store]
+    assert second_sent == [final_removal]
+
+
+async def test_send_kv_events_submits_telemetry_when_filter_empties_batch(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    suppressed_removal = BlockRemoved(
+        block_hashes=[1], medium="GPU", remaining_copy_counts=[1]
+    )
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    await queue.put(
+        _queued(
+            [KVEventBatch(ts=1.0, events=[suppressed_removal])],
+            1,
+            BatchTelemetry(pipeline="incremental"),
+            reporter=reporter,
+        )
+    )
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_kv_events.assert_not_awaited()
+    reporter.submit.assert_called_once()
+    telemetry = reporter.submit.call_args.args[0]
+    assert telemetry.drop_reason == "filtered_empty"
+    assert [span.name for span in telemetry.spans] == [
+        "queue_wait",
+        "engine_gate_wait",
+        "block_filter",
+    ]
+
+
+async def test_send_kv_events_drops_batch_when_epoch_changed(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    batch = _batch_with_block_hashes()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    await queue.put(
+        _queued(batch, 1, BatchTelemetry(pipeline="incremental"), reporter=reporter)
+    )
+    coordinator.wait_ready_epoch.return_value = 2
+    coordinator.is_epoch_current.return_value = False
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+            pipeline="snapshot",
+        )
+    )
+    await asyncio.sleep(0)
+    sender.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_kv_events.assert_not_awaited()
+    # Dropped batches are submitted to the reporter with drop_reason set;
+    # the reporter fans out to the drop-count metric internally.
+    reporter.submit.assert_called_once()
+    dropped_telemetry = reporter.submit.call_args.args[0]
+    assert dropped_telemetry.drop_reason == "epoch_changed"
+    assert queue.empty()
+
+
+def _snapshot_batch_list() -> list[KVEventBatch]:
+    return [
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                BlockSnapshot(
+                    medium="GPU",
+                    block_size=16,
+                    items=[
+                        BlockSnapshotItem(block_hash=101, group_idx=0),
+                        BlockSnapshotItem(block_hash=102, group_idx=0),
+                    ],
+                    snapshot_version=1,
+                )
+            ],
+        )
+    ]
+
+
+async def test_send_snapshot_events_forwards_batch_and_reports_success_telemetry(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batches = _snapshot_batch_list()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    telemetry = BatchTelemetry(pipeline="snapshot")
+    await queue.put(_queued(batches, 1, telemetry, reporter=reporter))
+
+    async def _fake_report_snapshot(
+        _batches: list,
+        _epoch: int,
+        *,
+        telemetry: BatchTelemetry | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        if telemetry is not None:
+            telemetry.mark("expand")
+            telemetry.mark("kvcm_send")
+
+    kvcm.report_snapshot = AsyncMock(side_effect=_fake_report_snapshot)
+
+    sender = asyncio.create_task(send_snapshot_events(kvcm, coordinator, queue))
+    await asyncio.sleep(0)
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_snapshot.assert_awaited_once_with(
+        batches, 1, telemetry=telemetry, trace_id=ANY
+    )
+    reporter.submit.assert_called_once()
+    submitted = reporter.submit.call_args.args[0]
+    assert [span.name for span in submitted.spans] == [
+        "queue_wait",
+        "engine_gate_wait",
+        "expand",
+        "kvcm_send",
+    ]
+    assert submitted.counters == {
+        "snapshot_block_count": 2,
+    }
+    assert telemetry.drop_reason is None
+
+
+async def test_send_snapshot_events_drops_batch_when_epoch_changed(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    batches = _snapshot_batch_list()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    await queue.put(
+        _queued(batches, 1, BatchTelemetry(pipeline="snapshot"), reporter=reporter)
+    )
+    coordinator.wait_ready_epoch.return_value = 2
+    coordinator.is_epoch_current.return_value = False
+
+    sender = asyncio.create_task(send_snapshot_events(kvcm, coordinator, queue))
+    await asyncio.sleep(0)
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    kvcm.report_snapshot.assert_not_awaited()
+    reporter.submit.assert_called_once()
+    dropped_telemetry = reporter.submit.call_args.args[0]
+    assert dropped_telemetry.drop_reason == "epoch_changed"
+    assert queue.empty()
+
+
+async def test_send_snapshot_events_drops_batch_on_kvcm_failure_and_continues(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(
+        _queued(
+            _snapshot_batch_list(),
+            1,
+            BatchTelemetry(pipeline="snapshot"),
+            trace_id="snapshot-first-trace",
+        )
+    )
+    await queue.put(
+        _queued(_snapshot_batch_list(), 1, BatchTelemetry(pipeline="snapshot"))
+    )
+    kvcm.report_snapshot.side_effect = KvcmUnavailableError("request failed")
+    warning = mocker.patch("subscriber.main.logger.warning")
+
+    sender = asyncio.create_task(send_snapshot_events(kvcm, coordinator, queue))
+    await queue.join()
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_snapshot.await_count == 2
+    warning.assert_called_once_with(
+        "failed to send kv event batch to kvcm; dropping batch",
+        step="kvcm_send",
+        tags={
+            "pipeline": "snapshot",
+            "trace_id": "snapshot-first-trace",
+            "merged_trace_ids": ["snapshot-first-trace"],
+            "epoch": 1,
+            "batch_count": 1,
+            "event_count": 1,
+            "error": "KvcmUnavailableError",
+            "message": "request failed",
+            "reason": "unknown",
+            "dropped_batch_total": 1,
+            "dropped_event_total": 1,
+        },
+    )
+
+
+async def test_send_kv_events_logs_failure_and_continues_with_next_batch(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+    mocker,
+) -> None:
+    first_batch = _batch_with_block_hashes()
+    second_batch = _batch()
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    await queue.put(
+        _queued(
+            first_batch,
+            1,
+            BatchTelemetry(pipeline="incremental"),
+            reporter=reporter,
+            trace_id="first-trace",
+        )
+    )
+    await queue.put(
+        _queued(
+            second_batch,
+            2,
+            BatchTelemetry(pipeline="incremental"),
+            reporter=reporter,
+            trace_id="second-trace",
+        )
+    )
+    error_message = (
+        "KVCM /api/reportEvent failed: INTERNAL_ERROR "
+        "ReportEvent partially failed; item_results=['OK', 'INTERNAL_ERROR']"
+    )
+    kvcm.report_kv_events.side_effect = [KvcmReportRejectedError(error_message), None]
+    warning = mocker.patch("subscriber.main.logger.warning")
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    assert kvcm.report_kv_events.await_count == 2
+    # The failed first batch is submitted as dropped; the second batch is
+    # submitted as a successful send with block-hash counters attached.
+    assert reporter.submit.call_count == 2
+    dropped_telemetry = reporter.submit.call_args_list[0].args[0]
+    success_telemetry = reporter.submit.call_args_list[1].args[0]
+    assert dropped_telemetry.drop_reason == "send_failed"
+    assert success_telemetry.drop_reason is None
+    assert success_telemetry.counters == {
+        "stored_block_hash_count": 0,
+        "removed_block_hash_count": 0,
+    }
+    warning.assert_called_once_with(
+        "failed to send kv event batch to kvcm; dropping batch",
+        step="kvcm_send",
+        tags={
+            "pipeline": "incremental",
+            "trace_id": "first-trace",
+            "merged_trace_ids": ["first-trace"],
+            "epoch": 1,
+            "batch_count": 2,
+            "event_count": 4,
+            "error": "KvcmReportRejectedError",
+            "message": error_message,
+            "reason": "unknown",
+            "dropped_batch_total": 2,
+            "dropped_event_total": 4,
+        },
+    )
+
+
+async def test_send_kv_events_marks_metadata_protocol_drop_and_notifies_lifecycle(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    reporter = MagicMock()
+    await queue.put(
+        _queued(
+            _batch(),
+            1,
+            BatchTelemetry(pipeline="incremental"),
+            reporter=reporter,
+        )
+    )
+    kvcm.report_kv_events.side_effect = KvcmReportRejectedError(
+        "component identity drift",
+        status_code="METADATA_PROTOCOL",
+        reason="metadata_protocol",
+    )
+    report_inactive = AsyncMock()
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+            on_metadata_protocol_error=report_inactive,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    dropped_telemetry = reporter.submit.call_args.args[0]
+    assert dropped_telemetry.drop_reason == "metadata_protocol"
+    report_inactive.assert_awaited_once_with()
+
+
+async def test_send_kv_events_filters_correctly_after_kvcm_failure(
+    kvcm: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    store = BlockStored(
+        block_hashes=[1],
+        parent_block_hash=None,
+        token_ids=[10],
+        block_size=16,
+        lora_id=None,
+        medium="GPU",
+        lora_name=None,
+    )
+    suppressed = BlockRemoved(block_hashes=[1], medium="GPU", remaining_copy_counts=[1])
+    final_removal = BlockRemoved(
+        block_hashes=[1], medium="GPU", remaining_copy_counts=[0]
+    )
+    queue: asyncio.Queue[PipelineContext] = asyncio.Queue()
+    await queue.put(
+        _queued([KVEventBatch(1.0, [store])], 1, BatchTelemetry(pipeline="incremental"))
+    )
+    await queue.put(
+        _queued(
+            [KVEventBatch(2.0, [suppressed])], 2, BatchTelemetry(pipeline="incremental")
+        )
+    )
+    await queue.put(
+        _queued(
+            [KVEventBatch(3.0, [store, final_removal])],
+            3,
+            BatchTelemetry(pipeline="incremental"),
+        )
+    )
+    # Second send fails — filter state should not matter (stateless).
+    kvcm.report_kv_events.side_effect = [
+        None,
+        KvcmUnavailableError("delete failed"),
+        None,
+    ]
+
+    sender = asyncio.create_task(
+        send_incremental_events(
+            kvcm,
+            coordinator,
+            queue,
+            max_merged_queue_items=1,
+            max_merged_report_events=1,
+        )
+    )
+    await queue.join()
+    sender.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await sender
+
+    # Suppressed removal batch is never sent to kvcm (empty after filtering).
+    # send_kv_events is called for batch 1 (store), then skips batch 2 (suppressed,
+    # no events left), then sends batch 3 (store + final_removal).
+    assert kvcm.report_kv_events.await_count == 2
+    third_sent_events = [
+        event
+        for batch in kvcm.report_kv_events.await_args_list[1].args[0]
+        for event in batch.events
+    ]
+    assert third_sent_events == [store, final_removal]
+
+
+async def test_run_uses_configured_queue_and_merge_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SubscriberConfig(
+        kv_event_queue_maxsize=7,
+        kv_event_merge_max_report_events=11,
+        kv_event_merge_max_queue_items=3,
+    )
+    adapter = MagicMock()
+    adapter.fetch_kv_event_bootstrap = AsyncMock(return_value=_empty_bootstrap())
+    adapter.close = AsyncMock()
+    kvcm = MagicMock()
+    kvcm.start = AsyncMock()
+    kvcm.close = AsyncMock()
+    kvcm.is_registered = True
+    coordinator = MagicMock()
+
+    async def _wait_ready_epoch() -> int:
+        await asyncio.sleep(0)
+        return 1
+
+    coordinator.wait_ready_epoch = _wait_ready_epoch
+    coordinator.attach_kvcm_client = MagicMock()
+    coordinator.capture_epoch = MagicMock(return_value=1)
+    coordinator.report_host_down = AsyncMock()
+    coordinator_factory = MagicMock(return_value=coordinator)
+    sender_started = asyncio.Event()
+    watch_loop_started = asyncio.Event()
+    captured_kwargs: dict = {}
+
+    async def _send_incremental_events(
+        _kvcm,
+        _coordinator,
+        _queue,
+        max_merged_report_events=16,
+        drop_tracker=None,
+        max_merged_queue_items=4,
+        pipeline="incremental",
+        on_snapshot_required=None,
+        on_metadata_protocol_error=None,
+    ):
+        if _queue.maxsize != config.kv_event_queue_maxsize:
+            await asyncio.Event().wait()
+            return
+        captured_kwargs["max_merged_report_events"] = max_merged_report_events
+        captured_kwargs["max_merged_queue_items"] = max_merged_queue_items
+        captured_kwargs["queue_maxsize"] = _queue.maxsize
+        sender_started.set()
+        await asyncio.Event().wait()
+
+    async def _consume_incremental_events(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    async def _consume_snapshot_events(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    async def _watch_loop() -> None:
+        watch_loop_started.set()
+        await asyncio.Event().wait()
+
+    coordinator.watch_loop = _watch_loop
+    monkeypatch.setattr(
+        "subscriber.main.AbstractEngineAdapter.create", MagicMock(return_value=adapter)
+    )
+    monkeypatch.setattr("subscriber.main.KvcmClient", MagicMock(return_value=kvcm))
+    monkeypatch.setattr("subscriber.main.EngineHealthCoordinator", coordinator_factory)
+    monkeypatch.setattr(
+        "subscriber.main.send_incremental_events", _send_incremental_events
+    )
+    monkeypatch.setattr(
+        "subscriber.main.consume_incremental_events", _consume_incremental_events
+    )
+    monkeypatch.setattr(
+        "subscriber.main.consume_snapshot_events", _consume_snapshot_events
+    )
+
+    from subscriber.main import run
+
+    run_task = asyncio.create_task(run(config))
+    await asyncio.wait_for(sender_started.wait(), timeout=1)
+    await asyncio.wait_for(watch_loop_started.wait(), timeout=1)
+
+    assert captured_kwargs["max_merged_report_events"] == 11
+    assert captured_kwargs["max_merged_queue_items"] == 3
+    assert captured_kwargs["queue_maxsize"] == 7
+
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    coordinator_factory.assert_called_once_with(adapter, None, config)
+    coordinator.attach_kvcm_client.assert_called_once_with(kvcm)
+    kvcm.close.assert_awaited_once()
+
+
+async def test_run_awaits_kvcm_close_when_start_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SubscriberConfig()
+    adapter = MagicMock()
+    adapter.fetch_kv_event_bootstrap = AsyncMock(return_value=_empty_bootstrap())
+    adapter.close = AsyncMock()
+    kvcm = MagicMock()
+    kvcm.start = AsyncMock(side_effect=RuntimeError("start failed"))
+    kvcm.close = AsyncMock()
+    coordinator = MagicMock()
+
+    async def _wait_ready_epoch() -> int:
+        await asyncio.sleep(0)
+        return 1
+
+    coordinator.wait_ready_epoch = _wait_ready_epoch
+
+    async def _watch_loop() -> None:
+        await asyncio.Event().wait()
+
+    coordinator.watch_loop = _watch_loop
+    coordinator.report_host_down = AsyncMock()
+
+    monkeypatch.setattr(
+        "subscriber.main.AbstractEngineAdapter.create", MagicMock(return_value=adapter)
+    )
+    monkeypatch.setattr("subscriber.main.KvcmClient", MagicMock(return_value=kvcm))
+    monkeypatch.setattr(
+        "subscriber.main.EngineHealthCoordinator", MagicMock(return_value=coordinator)
+    )
+
+    from subscriber.main import run
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await run(config)
+
+    kvcm.close.assert_awaited_once()
+    adapter.close.assert_awaited_once()
+
+
+async def test_run_starts_watch_loop_before_metadata_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """watch_loop must start before fetch_kv_event_bootstrap is called."""
+    config = SubscriberConfig()
+    call_order: list[str] = []
+
+    adapter = MagicMock()
+
+    async def _fetch_metadata():
+        call_order.append("fetch_metadata")
+        return _empty_bootstrap()
+
+    adapter.fetch_kv_event_bootstrap = _fetch_metadata
+    adapter.close = AsyncMock()
+
+    kvcm = MagicMock()
+    kvcm.start = AsyncMock()
+    kvcm.close = AsyncMock()
+    kvcm.is_registered = True
+
+    coordinator = MagicMock()
+
+    async def _watch_loop():
+        call_order.append("watch_loop_started")
+        await asyncio.Event().wait()
+
+    coordinator.watch_loop = _watch_loop
+
+    async def _wait_ready_epoch():
+        await asyncio.sleep(0)
+        call_order.append("wait_ready_epoch")
+        return 1
+
+    coordinator.wait_ready_epoch = _wait_ready_epoch
+
+    attach_called = False
+
+    def _attach_kvcm_client(kvcm_ref):
+        nonlocal attach_called
+        attach_called = True
+
+    coordinator.attach_kvcm_client = _attach_kvcm_client
+    coordinator.report_host_down = AsyncMock()
+
+    pipeline_started = asyncio.Event()
+
+    async def _send_kv_events(*args, **kwargs):
+        pipeline_started.set()
+        await asyncio.Event().wait()
+
+    async def _consume_incremental_events(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    async def _consume_snapshot_events(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        "subscriber.main.AbstractEngineAdapter.create",
+        MagicMock(return_value=adapter),
+    )
+    kvcm_factory = MagicMock(return_value=kvcm)
+    monkeypatch.setattr("subscriber.main.KvcmClient", kvcm_factory)
+    monkeypatch.setattr(
+        "subscriber.main.EngineHealthCoordinator", MagicMock(return_value=coordinator)
+    )
+    monkeypatch.setattr("subscriber.main.send_incremental_events", _send_kv_events)
+    monkeypatch.setattr(
+        "subscriber.main.consume_incremental_events", _consume_incremental_events
+    )
+    monkeypatch.setattr(
+        "subscriber.main.consume_snapshot_events", _consume_snapshot_events
+    )
+
+    from subscriber.main import run
+
+    run_task = asyncio.create_task(run(config))
+    await asyncio.wait_for(pipeline_started.wait(), timeout=1.0)
+
+    assert call_order[0] == "watch_loop_started"
+    assert "fetch_metadata" in call_order
+    assert call_order.index("watch_loop_started") < call_order.index("fetch_metadata")
+    assert attach_called
+    assert kvcm_factory.call_args.kwargs["descriptor"].groups == ()
+
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    kvcm.close.assert_awaited_once()
+    adapter.close.assert_awaited_once()
+
+
+async def test_run_fatal_metadata_error_reports_failed_and_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fatal metadata error (MetadataProtocolError) reports failed and exits."""
+    from subscriber.engine.metadata import MetadataProtocolError
+
+    config = SubscriberConfig()
+
+    adapter = MagicMock()
+    adapter.fetch_kv_event_bootstrap = AsyncMock(
+        side_effect=MetadataProtocolError("bad schema")
+    )
+    adapter.close = AsyncMock()
+
+    coordinator = MagicMock()
+
+    async def _watch_loop() -> None:
+        await asyncio.Event().wait()
+
+    coordinator.watch_loop = _watch_loop
+
+    async def _wait_ready_epoch() -> int:
+        await asyncio.sleep(0)
+        return 1
+
+    coordinator.wait_ready_epoch = _wait_ready_epoch
+    coordinator.report_host_down = AsyncMock()
+
+    kvcm_factory = MagicMock()
+
+    monkeypatch.setattr(
+        "subscriber.main.AbstractEngineAdapter.create",
+        MagicMock(return_value=adapter),
+    )
+    monkeypatch.setattr(
+        "subscriber.main.EngineHealthCoordinator", MagicMock(return_value=coordinator)
+    )
+    monkeypatch.setattr("subscriber.main.KvcmClient", kvcm_factory)
+
+    from subscriber.main import run
+
+    # Fatal metadata error exits cleanly (reports failed internally, no raise).
+    await asyncio.wait_for(run(config), timeout=1.0)
+
+    kvcm_factory.assert_not_called()
+    adapter.close.assert_awaited_once()
+
+
+async def test_run_initializes_dashlog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The run() entrypoint initializes dashlog metrics before serving."""
+    config = SubscriberConfig()
+    adapter = MagicMock()
+    adapter.fetch_kv_event_bootstrap = AsyncMock(return_value=_empty_bootstrap())
+    adapter.close = AsyncMock()
+    kvcm = MagicMock()
+    kvcm.start = AsyncMock()
+    kvcm.close = AsyncMock()
+    kvcm.is_registered = True
+    coordinator = MagicMock()
+
+    async def _wait_ready_epoch() -> int:
+        await asyncio.sleep(0)
+        return 1
+
+    coordinator.wait_ready_epoch = _wait_ready_epoch
+    coordinator.attach_kvcm_client = MagicMock()
+    coordinator.capture_epoch = MagicMock(return_value=1)
+    coordinator.report_host_down = AsyncMock()
+
+    async def _watch_loop() -> None:
+        await asyncio.Event().wait()
+
+    coordinator.watch_loop = _watch_loop
+
+    init_dashlog_mock = MagicMock()
+    sender_started = asyncio.Event()
+
+    async def _send_kv_events(*args, **kwargs):
+        sender_started.set()
+        await asyncio.Event().wait()
+
+    async def _consume_incremental_events(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    async def _consume_snapshot_events(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        "subscriber.main.AbstractEngineAdapter.create", MagicMock(return_value=adapter)
+    )
+    monkeypatch.setattr("subscriber.main.KvcmClient", MagicMock(return_value=kvcm))
+    monkeypatch.setattr(
+        "subscriber.main.EngineHealthCoordinator", MagicMock(return_value=coordinator)
+    )
+    monkeypatch.setattr("subscriber.main.init_dashlog", init_dashlog_mock)
+    monkeypatch.setattr("subscriber.main.send_incremental_events", _send_kv_events)
+    monkeypatch.setattr(
+        "subscriber.main.consume_incremental_events", _consume_incremental_events
+    )
+    monkeypatch.setattr(
+        "subscriber.main.consume_snapshot_events", _consume_snapshot_events
+    )
+
+    from subscriber.main import run
+
+    run_task = asyncio.create_task(run(config))
+    await asyncio.wait_for(sender_started.wait(), timeout=1)
+    run_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    init_dashlog_mock.assert_called_once_with("kvcache-subscriber")

--- a/subscriber/tests/test_logger.py
+++ b/subscriber/tests/test_logger.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import gzip
+import importlib
+import logging
+import sys
+import types
+from collections.abc import Callable
+
+import pytest
+
+from subscriber import logger
+
+
+def test_init_applies_debug_log_level() -> None:
+    logger.init("test-subscriber", level="debug")
+
+    assert logger.is_debug_enabled() is True
+    subscriber_logger = logging.getLogger("subscriber")
+    if subscriber_logger.handlers:
+        assert subscriber_logger.level == logging.DEBUG
+
+
+def test_fallback_logger_preserves_exception_traceback(caplog) -> None:
+    """exc_info=True renders the traceback into the formatted message."""
+
+    with caplog.at_level(logging.WARNING, logger="subscriber"):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            logger.warning("operation failed", step="test", exc_info=True)
+
+    message = caplog.records[-1].getMessage()
+    assert "operation failed" in message
+    assert "RuntimeError" in message
+    assert "boom" in message
+    assert "Traceback" in message
+
+
+def test_fallback_logger_compresses_rotated_file(tmp_path) -> None:
+    log_file = tmp_path / "subscriber.log"
+    handler = logger._GzipRotatingFileHandler(log_file, maxBytes=1, backupCount=3)
+    handler.emit(logging.makeLogRecord({"msg": "log record"}))
+    handler.doRollover()
+
+    rotated_log = tmp_path / "subscriber.log.1.gz"
+    assert rotated_log.exists()
+    with gzip.open(rotated_log, "rt") as file:
+        assert "log record" in file.read()
+
+
+def test_file_handler_attached_when_env_set(tmp_path, monkeypatch) -> None:
+    log_file = tmp_path / "subscriber.log"
+    monkeypatch.setenv("SUBSCRIBER_LOG_FILE", str(log_file))
+    logging.getLogger("subscriber").handlers.clear()
+    importlib.reload(logger)
+    try:
+        handlers = logging.getLogger("subscriber").handlers
+        assert any(isinstance(h, logger._GzipRotatingFileHandler) for h in handlers)
+        assert log_file.exists()
+    finally:
+        monkeypatch.delenv("SUBSCRIBER_LOG_FILE")
+        logging.getLogger("subscriber").handlers.clear()
+        importlib.reload(logger)
+
+
+def test_no_file_handler_without_env(monkeypatch) -> None:
+    monkeypatch.delenv("SUBSCRIBER_LOG_FILE", raising=False)
+    logging.getLogger("subscriber").handlers.clear()
+    importlib.reload(logger)
+    handlers = logging.getLogger("subscriber").handlers
+    assert not any(
+        isinstance(h, logging.handlers.RotatingFileHandler) for h in handlers
+    )
+
+
+def test_dashlog_backend_failure_does_not_escape_logger(monkeypatch) -> None:
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("dashlog backend failed")
+
+    failing_dashlog = types.SimpleNamespace(
+        init=fail,
+        debug=fail,
+        info=fail,
+        warning=fail,
+        error=fail,
+        critical=fail,
+    )
+    monkeypatch.setitem(sys.modules, "dashlog", failing_dashlog)
+    importlib.reload(logger)
+    try:
+        logger.init("test-subscriber", level="debug")
+        logger.warning("observability backend failed", step="test")
+    finally:
+        monkeypatch.delitem(sys.modules, "dashlog", raising=False)
+        importlib.reload(logger)
+
+
+def test_stdlib_backend_failure_does_not_escape_logger_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            raise RuntimeError("stdlib backend failed")
+
+    monkeypatch.setitem(sys.modules, "dashlog", None)
+    importlib.reload(logger)
+    subscriber_logger = logging.getLogger("subscriber")
+    failing_handler = FailingHandler()
+    subscriber_logger.addHandler(failing_handler)
+    try:
+        logger.init("test-subscriber", level="debug")
+    finally:
+        subscriber_logger.removeHandler(failing_handler)
+        monkeypatch.delitem(sys.modules, "dashlog", raising=False)
+        importlib.reload(logger)
+
+
+# ---------------------------------------------------------------------------
+# exc_info rendering — stdlib path
+# ---------------------------------------------------------------------------
+
+
+def test_stdlib_exc_info_none_omits_traceback(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="subscriber"):
+        logger.warning("plain warning", step="s")
+
+    message = caplog.records[-1].getMessage()
+    assert "plain warning" in message
+    assert "Traceback" not in message
+
+
+def test_stdlib_exc_info_exception_object_renders_traceback_in_message(caplog) -> None:
+    try:
+        raise ValueError("specific failure")
+    except ValueError as exc:
+        captured = exc
+    assert captured is not None
+
+    with caplog.at_level(logging.WARNING, logger="subscriber"):
+        logger.warning("op failed", step="s", exc_info=captured)
+
+    message = caplog.records[-1].getMessage()
+    assert "op failed" in message
+    assert "ValueError" in message
+    assert "specific failure" in message
+    assert "Traceback" in message
+
+
+def test_stdlib_exc_info_true_renders_current_exception(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="subscriber"):
+        try:
+            raise RuntimeError("live boom")
+        except RuntimeError:
+            logger.warning("during op", step="s", exc_info=True)
+
+    message = caplog.records[-1].getMessage()
+    assert "during op" in message
+    assert "RuntimeError" in message
+    assert "live boom" in message
+    assert "Traceback" in message
+
+
+def test_stdlib_exc_info_false_omits_traceback(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="subscriber"):
+        logger.warning("quiet", exc_info=False)
+
+    assert "Traceback" not in caplog.records[-1].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# exc_info rendering — dashlog path (mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def dashlog_mocked(monkeypatch):
+    """Force logger.py onto the dashlog code path with a fake dashlog.
+
+    Each level function on the fake is a spy that records (args, kwargs); the
+    captured list is exposed as an attribute so tests can assert on it. Spies
+    are installed BEFORE the reload so logger.py binds its wrappers to them.
+    """
+
+    def _make_spy() -> tuple[Callable[..., None], list[tuple[tuple, dict]]]:
+        calls: list[tuple[tuple, dict]] = []
+
+        def _impl(*args: object, **kwargs: object) -> None:
+            calls.append((args, kwargs))
+
+        return _impl, calls
+
+    spies = {
+        name: _make_spy() for name in ("debug", "info", "warning", "error", "critical")
+    }
+    fake = types.SimpleNamespace(
+        init=lambda *args, **kwargs: None,
+        **{name: impl for name, (impl, _calls) in spies.items()},
+    )
+    for name, (_impl, calls) in spies.items():
+        setattr(fake, f"{name}_calls", calls)
+
+    monkeypatch.setitem(sys.modules, "dashlog", fake)
+    importlib.reload(logger)
+    try:
+        yield fake
+    finally:
+        monkeypatch.delitem(sys.modules, "dashlog", raising=False)
+        importlib.reload(logger)
+
+
+def test_dashlog_exc_info_exception_object_appends_traceback(dashlog_mocked) -> None:
+    try:
+        raise ValueError("dashlog failure")
+    except ValueError as exc:
+        captured = exc
+    assert captured is not None
+
+    logger.warning("op broke", step="s", exc_info=captured)
+
+    assert len(dashlog_mocked.warning_calls) == 1
+    args, kwargs = dashlog_mocked.warning_calls[0]
+    message = args[0]
+    assert "op broke" in message
+    assert "ValueError" in message
+    assert "dashlog failure" in message
+    assert "Traceback" in message
+    assert "exc_info" not in kwargs
+
+
+def test_dashlog_exc_info_true_appends_current_traceback(dashlog_mocked) -> None:
+    try:
+        raise RuntimeError("live dashlog boom")
+    except RuntimeError:
+        logger.warning("during op", step="s", exc_info=True)
+
+    args, kwargs = dashlog_mocked.warning_calls[0]
+    message = args[0]
+    assert "during op" in message
+    assert "RuntimeError" in message
+    assert "live dashlog boom" in message
+    assert "Traceback" in message
+    assert "exc_info" not in kwargs
+
+
+def test_dashlog_exc_info_none_passes_through(dashlog_mocked) -> None:
+    logger.warning("plain", step="s")
+
+    args, kwargs = dashlog_mocked.warning_calls[0]
+    assert args[0] == "plain"
+    assert "Traceback" not in args[0]
+    assert "exc_info" not in kwargs
+
+
+def test_dashlog_exc_info_false_passes_through(dashlog_mocked) -> None:
+    logger.warning("plain", exc_info=False)
+
+    args, kwargs = dashlog_mocked.warning_calls[0]
+    assert "Traceback" not in args[0]
+    assert "exc_info" not in kwargs
+
+
+def test_dashlog_does_not_double_render_step_and_tags(dashlog_mocked) -> None:
+    """step/tags are native dashlog fields; they must live in kwargs and NOT
+    be duplicated into the message string."""
+
+    logger.warning(
+        "op happened",
+        step="kvcm_register",
+        tags={"phase": "initial", "retry": 3},
+    )
+
+    args, kwargs = dashlog_mocked.warning_calls[0]
+    message = args[0]
+    assert "op happened" in message
+    # step/tags must NOT leak into the message
+    assert "step=kvcm_register" not in message
+    assert "phase=initial" not in message
+    assert "retry=3" not in message
+    # step/tags must stay in kwargs as native dashlog fields
+    assert kwargs.get("step") == "kvcm_register"
+    assert kwargs.get("tags") == {"phase": "initial", "retry": 3}
+
+
+def test_render_exc_preserves_exception_chain(dashlog_mocked) -> None:
+    """`raise B from A` must surface both A and B in the rendered traceback."""
+
+    try:
+        try:
+            raise ValueError("root cause")
+        except ValueError as inner:
+            raise RuntimeError("wrapper") from inner
+    except RuntimeError as outer:
+        logger.warning("chained failure", exc_info=outer)
+
+    message = dashlog_mocked.warning_calls[0][0][0]
+    assert "wrapper" in message
+    assert "root cause" in message
+    assert "Traceback" in message
+
+
+def test_render_exc_accepts_tuple_form(dashlog_mocked) -> None:
+    """sys.exc_info() returns (type, value, tb); wrapper must render it
+    instead of silently swallowing the traceback."""
+
+    try:
+        raise KeyError("tuple-form failure")
+    except KeyError:
+        triple = sys.exc_info()
+
+    logger.warning("tuple path", exc_info=triple)
+
+    message = dashlog_mocked.warning_calls[0][0][0]
+    assert "tuple path" in message
+    assert "KeyError" in message
+    assert "tuple-form failure" in message
+    assert "Traceback" in message

--- a/subscriber/tests/test_main.py
+++ b/subscriber/tests/test_main.py
@@ -1,0 +1,968 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+import subscriber.__main__
+from subscriber.cli import cli as real_cli
+from subscriber.config import SubscriberConfig
+from subscriber.engine.base import AbstractEngineAdapter, EngineEventBatch
+from subscriber.engine.metadata import (
+    EventTransport,
+    KvCacheDescriptor,
+    KvEventBootstrap,
+    MetadataProtocolError,
+    MetadataTemporarilyUnavailable,
+    RuntimeTopology,
+    SnapshotCapability,
+    VllmEventSchema,
+)
+from subscriber.health.coordinator import EngineHealthState
+from subscriber.health.events import LivenessEvent
+from subscriber.health.state_reporter import DashservingStateReporter
+from subscriber.kvcm.client import KvcmClient
+from subscriber.kvcm.errors import KvcmReportRejectedError, KvcmUnavailableError
+from subscriber.main import SubscriberLifecycle, _FatalStartupError
+from subscriber.metrics import BatchTelemetry
+from subscriber.trace import generate_trace_id
+from subscriber.types import AllBlocksCleared, BlockSnapshot, BlockStored, KVEventBatch
+
+
+def test_main_module_exposes_cli() -> None:
+    assert hasattr(subscriber.__main__, "cli")
+
+
+def test_main_module_cli_is_the_real_cli() -> None:
+    assert subscriber.__main__.cli is real_cli
+
+
+def test_main_module_cli_is_callable() -> None:
+    assert callable(subscriber.__main__.cli)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _kv_batch() -> list[KVEventBatch]:
+    return [
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                BlockStored(
+                    block_hashes=[1],
+                    parent_block_hash=None,
+                    token_ids=[1],
+                    block_size=16,
+                    lora_id=None,
+                    medium="GPU",
+                    lora_name=None,
+                )
+            ],
+        )
+    ]
+
+
+def _snapshot_batch() -> list[KVEventBatch]:
+    return [
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                BlockSnapshot(
+                    medium="GPU",
+                    block_size=16,
+                    items=[],
+                    snapshot_version=1,
+                )
+            ],
+        )
+    ]
+
+
+def _bootstrap() -> KvEventBootstrap:
+    return KvEventBootstrap(
+        protocol_version=1,
+        engine_kind="vllm",
+        event_transport=EventTransport(
+            live_endpoint="tcp://127.0.0.1:5557",
+            topic="",
+            replay_supported=True,
+            replay_endpoint="tcp://127.0.0.1:5558",
+            serialization="msgpack-v1",
+        ),
+        runtime_topology=RuntimeTopology(1, 1, 1, 0, 0, 0),
+        snapshot=SnapshotCapability(supported=True, versioned=True),
+        components=(),
+        compatibility_settings=(),
+        diagnostic_settings=(),
+        vllm=VllmEventSchema(2, False, "none", "sha256", "v1"),
+    )
+
+
+class FakeAdapter(AbstractEngineAdapter):
+    """Adapter whose liveness is driven through a queue.
+
+    ``watch_liveness`` yields an initial HEALTHY then forwards whatever the test
+    pushes onto ``liveness``. ``subscribe_kv_events`` forwards batches pushed
+    onto ``kv_queue``. Metadata result/error are configurable.
+    """
+
+    def __init__(
+        self,
+        calls: list[str],
+        *,
+        snapshot_ends_immediately: bool = False,
+        immediate_snapshot: list[KVEventBatch] | None = None,
+    ) -> None:
+        self._calls = calls
+        self._snapshot_ends_immediately = snapshot_ends_immediately
+        self._immediate_snapshot = immediate_snapshot
+        self.liveness: asyncio.Queue[LivenessEvent] = asyncio.Queue()
+        self.kv_queue: asyncio.Queue[list[KVEventBatch]] = asyncio.Queue()
+        self.snapshot_queue: asyncio.Queue[list[KVEventBatch]] = asyncio.Queue()
+        self.bootstrap_result = _bootstrap()
+        self.metadata_errors: list[Exception] = []
+        self.fetch_count = 0
+        self.snapshot_yield_count = 0
+        self.snapshot_consumed_count = 0
+        self.reset_count = 0
+        self.closed = False
+
+    async def subscribe_kv_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        while True:
+            batches = await self.kv_queue.get()
+            yield EngineEventBatch(
+                batches,
+                BatchTelemetry(pipeline="incremental"),
+                trace_id=generate_trace_id(),
+            )
+
+    async def subscribe_snapshot_events(self) -> AsyncGenerator[EngineEventBatch, None]:
+        if self._snapshot_ends_immediately:
+            return
+        if self._immediate_snapshot is not None:
+            self.snapshot_yield_count += 1
+            yield EngineEventBatch(
+                self._immediate_snapshot,
+                BatchTelemetry(pipeline="snapshot"),
+                trace_id=generate_trace_id(),
+            )
+            self.snapshot_consumed_count += 1
+        while True:
+            batches = await self.snapshot_queue.get()
+            self.snapshot_yield_count += 1
+            yield EngineEventBatch(
+                batches,
+                BatchTelemetry(pipeline="snapshot"),
+                trace_id=generate_trace_id(),
+            )
+            self.snapshot_consumed_count += 1
+
+    async def watch_liveness(self) -> AsyncGenerator[LivenessEvent, None]:
+        self._calls.append("watch_started")
+        yield LivenessEvent.HEALTHY
+        while True:
+            yield await self.liveness.get()
+
+    async def fetch_kv_event_bootstrap(self) -> KvEventBootstrap:
+        self.fetch_count += 1
+        self._calls.append("metadata")
+        if self.metadata_errors:
+            raise self.metadata_errors.pop(0)
+        return self.bootstrap_result
+
+    async def reset_generation_state(self) -> None:
+        self.reset_count += 1
+
+    def map_medium(self, medium: str | None) -> str:
+        return ""
+
+    def supported_mediums(self) -> list[str]:
+        return []
+
+    def storage_type(self) -> str:
+        return "ST_UNSPECIFIED"
+
+    def request_immediate_snapshot(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+        self._calls.append("adapter_close")
+
+
+class FakeKvcmClient(KvcmClient):
+    """KVCM client double recording sends and lifecycle calls."""
+
+    def __init__(
+        self,
+        calls: list[str],
+        *,
+        registered: bool = True,
+        send_error: Exception | None = None,
+        location_spec_error: MetadataProtocolError | None = None,
+    ) -> None:
+        self._calls = calls
+        self._registered = registered
+        self._send_error = send_error
+        self._location_spec_error = location_spec_error
+        self.sent: list[tuple[list[KVEventBatch], int]] = []
+        self.snapshots: list[tuple[list[KVEventBatch], int]] = []
+        self.started = False
+        self.closed = False
+
+    @property
+    def is_registered(self) -> bool:
+        return self._registered
+
+    async def start(self) -> None:
+        self.started = True
+        self._calls.append("kvcm_start")
+
+    def validate_location_specs(self) -> None:
+        self._calls.append("kvcm_validate")
+        if self._location_spec_error is not None:
+            raise self._location_spec_error
+
+    async def report_kv_events(
+        self,
+        batches: list[KVEventBatch],
+        epoch: int,
+        telemetries=None,
+        trace_id=None,
+        *,
+        reregister_after_host_down: bool = True,
+    ) -> None:
+        self._calls.append("kvcm_send")
+        if self._send_error is not None:
+            raise self._send_error
+        self.sent.append((batches, epoch))
+
+    async def report_snapshot(
+        self,
+        batches: list[KVEventBatch],
+        epoch: int,
+        telemetry: object | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        self._calls.append("kvcm_send_snapshot")
+        if self._send_error is not None:
+            raise self._send_error
+        self.snapshots.append((batches, epoch))
+
+    async def close(self) -> None:
+        self.closed = True
+        self._calls.append("kvcm_close")
+
+
+class RecordingReporter(DashservingStateReporter):
+    """State reporter double recording the logical report sequence."""
+
+    def __init__(
+        self,
+        calls: list[str],
+        active_event: asyncio.Event,
+        *,
+        fail_active_times: int = 0,
+    ) -> None:
+        self._calls = calls
+        self._active_event = active_event
+        self._fail_active_times = fail_active_times
+        self._active_attempts = 0
+        self.failed_reasons: list[str] = []
+
+    async def report_active(self) -> None:
+        self._active_attempts += 1
+        if self._active_attempts <= self._fail_active_times:
+            raise httpx.ConnectError("connection refused")
+        self._calls.append("active")
+        self._active_event.set()
+
+    def start_heartbeat(self) -> None:
+        self._calls.append("heartbeat_start")
+
+    async def stop_heartbeat(self) -> None:
+        self._calls.append("heartbeat_stop")
+
+    async def report_failed(self, reason: str) -> None:
+        self.failed_reasons.append(reason)
+        self._calls.append("failed")
+
+    async def report_shutdown_inactive(self, reason: str) -> None:
+        self._calls.append("inactive")
+
+    async def close(self) -> None:
+        self._calls.append("reporter_close")
+
+
+class BlockingActiveReporter(RecordingReporter):
+    """Reporter that exposes the interval while the initial active POST waits."""
+
+    def __init__(
+        self,
+        calls: list[str],
+        active_event: asyncio.Event,
+        active_attempted: asyncio.Event,
+        release_active: asyncio.Event,
+    ) -> None:
+        super().__init__(calls, active_event)
+        self._active_attempted = active_attempted
+        self._release_active = release_active
+
+    async def report_active(self) -> None:
+        self._active_attempted.set()
+        await self._release_active.wait()
+        await super().report_active()
+
+
+class _LifecycleBundle:
+    def __init__(
+        self,
+        calls: list[str],
+        active_event: asyncio.Event,
+        *,
+        threshold: int = 1,
+        registered: bool = True,
+        fail_active_times: int = 0,
+        metadata_errors: list[Exception] | None = None,
+        send_error: Exception | None = None,
+        location_spec_error: MetadataProtocolError | None = None,
+        snapshot_ends_immediately: bool = False,
+        immediate_snapshot: list[KVEventBatch] | None = None,
+        incremental_pipeline_enabled: bool = True,
+        snapshot_pipeline_enabled: bool = True,
+        reporter: DashservingStateReporter | None = None,
+    ) -> None:
+        config = SubscriberConfig(
+            engine_health_failure_threshold=threshold,
+            subscriber_health_enabled=True,
+            incremental_kv_event_pipeline_enabled=incremental_pipeline_enabled,
+            snapshot_kv_event_pipeline_enabled=snapshot_pipeline_enabled,
+        )
+        self.adapter = FakeAdapter(
+            calls,
+            snapshot_ends_immediately=snapshot_ends_immediately,
+            immediate_snapshot=immediate_snapshot,
+        )
+        if metadata_errors:
+            self.adapter.metadata_errors = list(metadata_errors)
+        self.kvcm = FakeKvcmClient(
+            calls,
+            registered=registered,
+            send_error=send_error,
+            location_spec_error=location_spec_error,
+        )
+        self.reporter = reporter or RecordingReporter(
+            calls, active_event, fail_active_times=fail_active_times
+        )
+        self.shutdown = asyncio.Event()
+        self.lifecycle = SubscriberLifecycle(
+            config,
+            adapter=self.adapter,
+            kvcm_client=self.kvcm,
+            state_reporter=self.reporter,
+            shutdown_event=self.shutdown,
+            install_signal_handlers=False,
+            startup_retry_delay_s=0.0,
+        )
+        self.calls = calls
+        self.active_event = active_event
+
+    async def start(self) -> asyncio.Task[None]:
+        task = asyncio.create_task(self.lifecycle.run())
+        await asyncio.wait_for(self.active_event.wait(), timeout=1.0)
+        while "heartbeat_start" not in self.calls:
+            await asyncio.sleep(0)
+        return task
+
+    async def stop(self, task: asyncio.Task[None]) -> None:
+        self.shutdown.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+
+def _make_bundle(**kwargs) -> _LifecycleBundle:
+    return _LifecycleBundle([], asyncio.Event(), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Startup order and active prerequisites
+# ---------------------------------------------------------------------------
+
+
+async def test_register_kvcm_wires_adapter_snapshot_callback(
+    mocker: MockerFixture,
+) -> None:
+    calls: list[str] = []
+    adapter = FakeAdapter(calls)
+    lifecycle = SubscriberLifecycle(
+        SubscriberConfig(),
+        adapter=adapter,
+        state_reporter=RecordingReporter(calls, asyncio.Event()),
+        install_signal_handlers=False,
+    )
+    kvcm_cls = mocker.patch("subscriber.main.KvcmClient", autospec=True)
+    kvcm_cls.return_value.is_registered = True
+
+    descriptor = KvCacheDescriptor(groups=())
+    await lifecycle._register_kvcm(descriptor)
+
+    kvcm_cls.validate_descriptor_location_specs.assert_called_once_with(
+        lifecycle._config, descriptor
+    )
+    kvcm_cls.assert_called_once()
+    assert (
+        kvcm_cls.call_args.kwargs["on_snapshot_required"]
+        == adapter.request_immediate_snapshot
+    )
+
+
+async def test_incompatible_descriptor_is_checked_before_kvcm_construction(
+    mocker: MockerFixture,
+) -> None:
+    calls: list[str] = []
+    lifecycle = SubscriberLifecycle(
+        SubscriberConfig(),
+        adapter=FakeAdapter(calls),
+        state_reporter=RecordingReporter(calls, asyncio.Event()),
+        install_signal_handlers=False,
+    )
+    kvcm_cls = mocker.patch("subscriber.main.KvcmClient", autospec=True)
+    kvcm_cls.validate_descriptor_location_specs.side_effect = MetadataProtocolError(
+        "unknown component kind"
+    )
+
+    with pytest.raises(_FatalStartupError, match="KV cache descriptor protocol error"):
+        await lifecycle._register_kvcm(KvCacheDescriptor(groups=()))
+
+    kvcm_cls.assert_not_called()
+
+
+async def test_startup_exact_call_order_and_shutdown_sequence() -> None:
+    bundle = _make_bundle()
+    task = await bundle.start()
+    await bundle.stop(task)
+
+    assert bundle.calls == [
+        "watch_started",
+        "metadata",
+        "kvcm_validate",
+        "kvcm_start",
+        "active",
+        "heartbeat_start",
+        "heartbeat_stop",
+        "kvcm_send",  # AllBlocksCleared (HostDown)
+        "inactive",
+        "kvcm_close",
+        "reporter_close",
+        "adapter_close",
+    ]
+
+
+async def test_startup_logs_complete_bootstrap_info(mocker: MockerFixture) -> None:
+    info = mocker.patch("subscriber.main.logger.info")
+    bundle = _make_bundle()
+
+    task = await bundle.start()
+    await bundle.stop(task)
+
+    bootstrap_log = next(
+        call
+        for call in info.call_args_list
+        if call.args == ("KV event bootstrap fetched",)
+    )
+    payload = json.loads(bootstrap_log.kwargs["tags"]["bootstrap_info"])
+    assert payload["event_transport"]["live_endpoint"] == "tcp://127.0.0.1:5557"
+    assert payload["runtime_topology"]["data_parallel_rank"] == 0
+    assert payload["vllm"]["event_schema_version"] == 2
+
+
+async def test_active_not_reported_before_prerequisites() -> None:
+    bundle = _make_bundle()
+    task = await bundle.start()
+    await bundle.stop(task)
+
+    active_idx = bundle.calls.index("active")
+    assert bundle.calls.index("metadata") < active_idx
+    assert bundle.calls.index("kvcm_start") < active_idx
+    assert bundle.calls.index("heartbeat_start") > active_idx
+
+
+async def test_pipeline_receives_no_kv_event_while_initial_active_is_blocked() -> None:
+    calls: list[str] = []
+    active_event = asyncio.Event()
+    active_attempted = asyncio.Event()
+    release_active = asyncio.Event()
+    reporter = BlockingActiveReporter(
+        calls,
+        active_event,
+        active_attempted,
+        release_active,
+    )
+    bundle = _LifecycleBundle(calls, active_event, reporter=reporter)
+    task = asyncio.create_task(bundle.lifecycle.run())
+
+    await asyncio.wait_for(active_attempted.wait(), timeout=1.0)
+    await asyncio.sleep(0)
+
+    assert "kvcm_send" not in calls
+    assert bundle.kvcm.sent == []
+
+    release_active.set()
+    await asyncio.wait_for(active_event.wait(), timeout=1.0)
+    while "heartbeat_start" not in calls:
+        await asyncio.sleep(0)
+    await bundle.stop(task)
+
+
+# ---------------------------------------------------------------------------
+# Failed-vs-transient classification
+# ---------------------------------------------------------------------------
+
+
+async def test_fatal_metadata_error_reports_failed_and_exits() -> None:
+    bundle = _make_bundle(
+        metadata_errors=[MetadataProtocolError("bad schema")],
+    )
+    task = asyncio.create_task(bundle.lifecycle.run())
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert "active" not in bundle.calls
+    assert "failed" in bundle.calls
+    assert bundle.reporter.failed_reasons == [
+        "KV event bootstrap protocol error: bad schema"
+    ]
+    # KVCM registration never happened; cleanup still ran on the partial path.
+    assert bundle.kvcm.started is False
+    assert bundle.adapter.closed is True
+
+
+async def test_incompatible_descriptor_reports_failed_before_kvcm_start() -> None:
+    bundle = _make_bundle(
+        location_spec_error=MetadataProtocolError("unknown component kind"),
+    )
+
+    await asyncio.wait_for(bundle.lifecycle.run(), timeout=1.0)
+
+    assert bundle.reporter.failed_reasons == [
+        "KV cache descriptor protocol error: unknown component kind"
+    ]
+    assert "kvcm_validate" in bundle.calls
+    assert "kvcm_start" not in bundle.calls
+    assert "active" not in bundle.calls
+    assert "heartbeat_start" not in bundle.calls
+
+
+async def test_transient_metadata_error_retries_then_active() -> None:
+    bundle = _make_bundle(
+        metadata_errors=[MetadataTemporarilyUnavailable("try again")],
+    )
+    task = await bundle.start()
+    await bundle.stop(task)
+
+    assert bundle.adapter.fetch_count == 2
+    assert "active" in bundle.calls
+    assert "failed" not in bundle.calls
+
+
+async def test_transient_active_report_retries_then_active() -> None:
+    bundle = _make_bundle(fail_active_times=2)
+    task = await bundle.start()
+    await bundle.stop(task)
+
+    assert "active" in bundle.calls
+    assert "failed" not in bundle.calls
+
+
+async def test_transient_http_5xx_active_report_retries_then_active() -> None:
+    """raise_for_status() raises HTTPStatusError, which is not a
+    TransportError subclass; a transient 5xx must retry, not report failed."""
+
+    class _Http5xxOnceReporter(RecordingReporter):
+        def __init__(self, calls: list[str], active_event: asyncio.Event) -> None:
+            super().__init__(calls, active_event)
+            self._raised = False
+
+        async def report_active(self) -> None:
+            if not self._raised:
+                self._raised = True
+                request = httpx.Request("POST", "http://127.0.0.1:8601/state")
+                response = httpx.Response(503, request=request)
+                raise httpx.HTTPStatusError(
+                    "503 Service Unavailable", request=request, response=response
+                )
+            await super().report_active()
+
+    calls: list[str] = []
+    active_event = asyncio.Event()
+    bundle = _LifecycleBundle(
+        calls, active_event, reporter=_Http5xxOnceReporter(calls, active_event)
+    )
+    task = await bundle.start()
+    await bundle.stop(task)
+
+    assert "active" in bundle.calls
+    assert "failed" not in bundle.calls
+
+
+# ---------------------------------------------------------------------------
+# Readiness regression / KVCM outage isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_kvcm_outage_does_not_affect_heartbeat_or_engine_health() -> None:
+    bundle = _make_bundle(send_error=KvcmUnavailableError("kvcm down"))
+    task = await bundle.start()
+
+    # Push a KV batch; the sender's send_kv_events raises and the batch is dropped.
+    await bundle.adapter.kv_queue.put(_kv_batch())
+    while "kvcm_send" not in bundle.calls:
+        await asyncio.sleep(0)
+
+    # Engine health is driven only by liveness, not KVCM availability.
+    assert bundle.lifecycle.coordinator.state is EngineHealthState.HEALTHY
+    # The active heartbeat is unaffected by the KVCM outage.
+    assert "active" in bundle.calls
+    # No HostDown is emitted for a KVCM outage while the engine is healthy.
+    assert bundle.kvcm.sent == []
+
+    await bundle.stop(task)
+
+
+async def test_metadata_protocol_drop_reports_inactive_without_exiting() -> None:
+    bundle = _make_bundle(
+        send_error=KvcmReportRejectedError(
+            "component identity drift",
+            status_code="METADATA_PROTOCOL",
+            reason="metadata_protocol",
+        )
+    )
+    task = await bundle.start()
+
+    await bundle.adapter.kv_queue.put(_kv_batch())
+    while "inactive" not in bundle.calls:
+        await asyncio.sleep(0)
+
+    assert task.done() is False
+    assert bundle.calls.count("inactive") == 1
+    assert bundle.lifecycle.coordinator.state is EngineHealthState.HEALTHY
+
+    await bundle.stop(task)
+
+    assert bundle.calls.count("inactive") == 1
+
+
+async def test_snapshot_pipeline_forwards_batch_to_kvcm() -> None:
+    bundle = _make_bundle()
+    task = await bundle.start()
+
+    await bundle.adapter.snapshot_queue.put(_snapshot_batch())
+    while not bundle.kvcm.snapshots:
+        await asyncio.sleep(0)
+
+    assert len(bundle.kvcm.snapshots) == 1
+    assert bundle.kvcm.sent == []
+    await bundle.stop(task)
+
+
+async def test_snapshot_only_mode_disables_incremental_pipeline() -> None:
+    bundle = _make_bundle(incremental_pipeline_enabled=False)
+    task = await bundle.start()
+
+    assert bundle.lifecycle._incremental_producer_task is None
+    assert bundle.lifecycle._incremental_sender_task is None
+    assert bundle.lifecycle._incremental_metrics_reporter is None
+
+    for _ in range(17):
+        await bundle.adapter.snapshot_queue.put(_snapshot_batch())
+    while bundle.adapter.snapshot_consumed_count != 17:
+        await asyncio.sleep(0)
+
+    await bundle.adapter.kv_queue.put(_kv_batch())
+    await asyncio.sleep(0)
+    assert bundle.kvcm.sent == []
+
+    await bundle.stop(task)
+
+
+async def test_snapshot_pipeline_can_be_disabled_independently() -> None:
+    bundle = _make_bundle(snapshot_pipeline_enabled=False)
+    task = await bundle.start()
+
+    assert bundle.lifecycle._snapshot_producer_task is None
+    assert bundle.lifecycle._snapshot_sender_task is None
+    assert bundle.lifecycle._snapshot_metrics_reporter is None
+
+    await bundle.adapter.kv_queue.put(_kv_batch())
+    while not bundle.kvcm.sent:
+        await asyncio.sleep(0)
+
+    await bundle.stop(task)
+
+
+async def test_pipeline_metrics_reporters_are_independent_instances() -> None:
+    bundle = _make_bundle()
+    task = await bundle.start()
+
+    incremental = bundle.lifecycle._incremental_metrics_reporter
+    snapshot = bundle.lifecycle._snapshot_metrics_reporter
+    assert incremental is not None
+    assert snapshot is not None
+    # Each pipeline gets its own MetricsReporter instance with a distinct
+    # background task name so pipeline-scoped flushes never interfere.
+    assert incremental is not snapshot
+    assert incremental._task is not None
+    assert snapshot._task is not None
+    assert incremental._task.get_name() == "incremental-kv-event-metrics"
+    assert snapshot._task.get_name() == "snapshot-kv-event-metrics"
+
+    await bundle.stop(task)
+
+
+# ---------------------------------------------------------------------------
+# Recovery without process restart
+# ---------------------------------------------------------------------------
+
+
+async def test_recovery_without_process_restart() -> None:
+    bundle = _make_bundle(threshold=1)
+    task = await bundle.start()
+    coordinator = bundle.lifecycle.coordinator
+    assert coordinator.epoch == 1
+
+    # Engine DEAD: emits AllBlocksCleared for epoch 1.
+    await bundle.adapter.liveness.put(LivenessEvent.UNHEALTHY)
+    while coordinator.state is not EngineHealthState.DEAD:
+        await asyncio.sleep(0)
+    assert len(bundle.kvcm.sent) == 1
+
+    # Engine recovers in-process: new sendable epoch, no restart.
+    await bundle.adapter.liveness.put(LivenessEvent.HEALTHY)
+    while coordinator.state is not EngineHealthState.HEALTHY:
+        await asyncio.sleep(0)
+    assert coordinator.epoch == 2
+    assert bundle.adapter.reset_count == 1
+
+    # Graceful shutdown emits HostDown for the new epoch.
+    await bundle.stop(task)
+    assert len(bundle.kvcm.sent) == 2
+    assert bundle.kvcm.sent[1][1] == 2
+
+
+# ---------------------------------------------------------------------------
+# HostDown once / no KV report after HostDown
+# ---------------------------------------------------------------------------
+
+
+async def test_host_down_emitted_once_on_shutdown() -> None:
+    bundle = _make_bundle()
+    task = await bundle.start()
+    await bundle.stop(task)
+
+    host_downs = [
+        batches
+        for batches, _ in bundle.kvcm.sent
+        if any(
+            isinstance(e, AllBlocksCleared) for batch in batches for e in batch.events
+        )
+    ]
+    assert len(host_downs) == 1
+
+
+async def test_engine_dead_then_shutdown_emits_host_down_once() -> None:
+    bundle = _make_bundle(threshold=1)
+    task = await bundle.start()
+    coordinator = bundle.lifecycle.coordinator
+
+    await bundle.adapter.liveness.put(LivenessEvent.UNHEALTHY)
+    while coordinator.state is not EngineHealthState.DEAD:
+        await asyncio.sleep(0)
+    assert len(bundle.kvcm.sent) == 1
+
+    await bundle.stop(task)
+    # Shutdown for the same (still current) epoch must not re-emit.
+    assert len(bundle.kvcm.sent) == 1
+
+
+async def test_no_kv_report_after_host_down() -> None:
+    bundle = _make_bundle()
+    task = await bundle.start()
+
+    # Queue a KV batch that would be forwarded while serving.
+    await bundle.adapter.kv_queue.put(_kv_batch())
+    while not bundle.kvcm.sent:
+        await asyncio.sleep(0)
+    forwarded_before = len(bundle.kvcm.sent)
+
+    await bundle.stop(task)
+
+    # The only send after shutdown begins is the single AllBlocksCleared; it is
+    # the last KVCM state transition and no KV batch follows it.
+    last_batches, _ = bundle.kvcm.sent[-1]
+    assert any(
+        isinstance(e, AllBlocksCleared) for batch in last_batches for e in batch.events
+    )
+    assert len(bundle.kvcm.sent) == forwarded_before + 1
+
+
+# ---------------------------------------------------------------------------
+# Shutdown inactive sequence greater than last heartbeat
+# ---------------------------------------------------------------------------
+
+
+class _RecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.states: list[str] = []
+        self.seqs: list[int] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        payload = json.loads(request.content.decode())
+        self.states.append(str(payload["state"]))
+        self.seqs.append(int(payload["seq_id"]))
+        return httpx.Response(
+            200, json={"accepted": True, "last_seq_id": payload["seq_id"]}
+        )
+
+
+async def test_shutdown_inactive_seq_greater_than_last_heartbeat() -> None:
+    transport = _RecordingTransport()
+    config = SubscriberConfig(
+        subscriber_heartbeat_interval_s=0.01,
+        subscriber_health_enabled=True,
+        engine_health_failure_threshold=1,
+    )
+    client = httpx.AsyncClient(transport=transport)
+    reporter = DashservingStateReporter(config, http_client=client)
+
+    bundle = _LifecycleBundle([], asyncio.Event(), reporter=reporter)
+    task = asyncio.create_task(bundle.lifecycle.run())
+
+    # Wait for the initial active report plus at least one heartbeat active.
+    while transport.states.count("active") < 2:
+        await asyncio.sleep(0.005)
+
+    bundle.shutdown.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert transport.states[-1] == "inactive"
+    assert transport.seqs[-1] == max(transport.seqs)
+    assert transport.seqs == sorted(transport.seqs)
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup after a task failure
+# ---------------------------------------------------------------------------
+
+
+async def test_cleanup_after_sender_task_failure_reraises() -> None:
+    bundle = _make_bundle(send_error=RuntimeError("sender exploded"))
+    task = await bundle.start()
+
+    # Push a KV batch so the sender calls send_kv_events and fails.
+    await bundle.adapter.kv_queue.put(_kv_batch())
+
+    with pytest.raises(RuntimeError, match="sender exploded"):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    # Cleanup ran on the failure path.
+    assert bundle.kvcm.closed is True
+    assert bundle.adapter.closed is True
+    assert bundle.kvcm.started is True
+
+
+async def test_cleanup_after_snapshot_sender_task_failure_reraises(
+    mocker: MockerFixture,
+) -> None:
+    release_failure = asyncio.Event()
+
+    async def failing_snapshot_sender(*args: object, **kwargs: object) -> None:
+        await release_failure.wait()
+        raise RuntimeError("snapshot sender exploded")
+
+    mocker.patch(
+        "subscriber.main.send_snapshot_events",
+        new=failing_snapshot_sender,
+    )
+    bundle = _make_bundle()
+    task = await bundle.start()
+
+    release_failure.set()
+
+    with pytest.raises(RuntimeError, match="snapshot sender exploded"):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    # Cleanup ran on the failure path.
+    assert bundle.kvcm.closed is True
+    assert bundle.adapter.closed is True
+    assert bundle.kvcm.started is True
+
+
+async def test_cleanup_after_snapshot_producer_ends_reraises() -> None:
+    bundle = _make_bundle(snapshot_ends_immediately=True)
+    task = await bundle.start()
+
+    with pytest.raises(RuntimeError, match="snapshot-kv-event-producer ended"):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert bundle.kvcm.closed is True
+    assert bundle.adapter.closed is True
+    assert bundle.kvcm.started is True
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-before-active ordering invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_first_snapshot_reaches_kvcm_before_active_accepted() -> None:
+    """KVCM receives the initial snapshot while report_active is still in-flight.
+
+    This proves the ordering invariant: KVCM has a baseline snapshot before
+    DashServing marks the pod ready (readiness 200) and traffic starts flowing
+    incremental events.
+    """
+
+    calls: list[str] = []
+    active_event = asyncio.Event()
+    active_attempted = asyncio.Event()
+    release_active = asyncio.Event()
+    reporter = BlockingActiveReporter(
+        calls,
+        active_event,
+        active_attempted,
+        release_active,
+    )
+    bundle = _LifecycleBundle(
+        calls,
+        active_event,
+        reporter=reporter,
+        immediate_snapshot=_snapshot_batch(),
+    )
+    task = asyncio.create_task(bundle.lifecycle.run())
+
+    # Wait until report_active is attempted (startup reached step 5).
+    await asyncio.wait_for(active_attempted.wait(), timeout=1.0)
+
+    # While active is still blocked, the snapshot pipeline (started in step 4)
+    # has already polled and sent the initial snapshot to KVCM.
+    while "kvcm_send_snapshot" not in calls:
+        await asyncio.sleep(0)
+    assert "active" not in calls
+    assert len(bundle.kvcm.snapshots) == 1
+
+    # Release active; startup completes normally.
+    release_active.set()
+    await asyncio.wait_for(active_event.wait(), timeout=1.0)
+    while "heartbeat_start" not in calls:
+        await asyncio.sleep(0)
+    await bundle.stop(task)
+
+    # Snapshot was sent before active was accepted.
+    assert calls.index("kvcm_send_snapshot") < calls.index("active")

--- a/subscriber/tests/test_trace.py
+++ b/subscriber/tests/test_trace.py
@@ -1,0 +1,68 @@
+"""Tests for the EagleEye-style trace ID generator."""
+
+from __future__ import annotations
+
+import importlib
+import re
+
+import pytest
+
+from subscriber.trace import generate_trace_id
+
+
+class TestGenerateTraceId:
+    """generate_trace_id produces EagleEye-compatible trace identifiers."""
+
+    def test_returns_30_char_string(self) -> None:
+        trace_id = generate_trace_id()
+        assert len(trace_id) == 30
+
+    def test_format_matches_eagleeye_layout(self) -> None:
+        """ip_hex(8) + timestamp_ms(13) + counter(4) + 'd' + pid_hex(4)."""
+        trace_id = generate_trace_id()
+        assert re.fullmatch(r"[0-9a-f]{8}\d{13}\d{4}d[0-9a-f]{4}", trace_id)
+
+    def test_monotonic_time_prefix(self) -> None:
+        """Successive IDs have non-decreasing timestamp portions."""
+        ids = [generate_trace_id() for _ in range(100)]
+        timestamps = [int(tid[8:21]) for tid in ids]
+        assert timestamps == sorted(timestamps)
+
+    def test_uniqueness_across_10k_calls(self) -> None:
+        ids = {generate_trace_id() for _ in range(10_000)}
+        assert len(ids) == 10_000
+
+    def test_counter_cycles_within_range(self) -> None:
+        """Counter portion stays in 1000-9000."""
+        for _ in range(200):
+            trace_id = generate_trace_id()
+            counter = int(trace_id[21:25])
+            assert 1000 <= counter <= 9000
+
+    def test_never_raises_on_ip_resolution_failure(self) -> None:
+        """Fallback to 'ffffffff' when IP cannot be resolved."""
+        import subscriber.trace as trace_mod
+
+        original = trace_mod._IP_HEX
+        try:
+            trace_mod._IP_HEX = "ffffffff"
+            trace_id = generate_trace_id()
+            assert trace_id[:8] == "ffffffff"
+            assert len(trace_id) == 30
+        finally:
+            trace_mod._IP_HEX = original
+
+    def test_pid_suffix_matches_eagleeye_for_large_process_ids(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """EagleEye reduces PIDs above 65535 modulo 60000 before hex encoding."""
+
+        import subscriber.trace as trace_mod
+
+        monkeypatch.setattr(trace_mod.os, "getpid", lambda: 70_000)
+        try:
+            reloaded = importlib.reload(trace_mod)
+            assert reloaded.generate_trace_id().endswith("d2710")
+        finally:
+            monkeypatch.undo()
+            importlib.reload(trace_mod)

--- a/subscriber/tests/utils/__init__.py
+++ b/subscriber/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/subscriber/tests/utils/test_network.py
+++ b/subscriber/tests/utils/test_network.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from subscriber.utils import network
+
+
+class FakeSocket:
+    def __init__(
+        self,
+        connect_error: OSError | None = None,
+        local_ip: str = "10.0.0.5",
+    ) -> None:
+        self._connect_error = connect_error
+        self._local_ip = local_ip
+
+    def connect(self, address: tuple[str, int]) -> None:
+        if self._connect_error is not None:
+            raise self._connect_error
+
+    def getsockname(self) -> tuple[str, int]:
+        return (self._local_ip, 12345)
+
+    def __enter__(self) -> FakeSocket:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+def test_local_ip_address_returns_probe_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        network.socket, "socket", lambda *a, **kw: FakeSocket(local_ip="10.0.0.5")
+    )
+
+    assert network.local_ip_address() == "10.0.0.5"
+
+
+def test_local_ip_address_falls_back_to_getaddrinfo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        network.socket,
+        "socket",
+        lambda *a, **kw: FakeSocket(connect_error=OSError("no route")),
+    )
+    monkeypatch.setattr(
+        network.socket,
+        "getaddrinfo",
+        lambda host, port, type: [
+            (None, None, None, None, ("192.168.1.10", 0)),
+        ],
+    )
+
+    assert network.local_ip_address() == "192.168.1.10"
+
+
+def test_local_ip_address_returns_loopback_when_all_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        network.socket,
+        "socket",
+        lambda *a, **kw: FakeSocket(connect_error=OSError("no route")),
+    )
+    monkeypatch.setattr(
+        network.socket,
+        "getaddrinfo",
+        lambda host, port, type: (_ for _ in ()).throw(OSError("no info")),
+    )
+
+    assert network.local_ip_address() == "127.0.0.1"
+
+
+async def test_resolve_host_ip_port_uses_given_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(network, "local_ip_address", lambda: "10.0.0.7")
+
+    assert await network.resolve_host_ip_port(8080) == "10.0.0.7:8080"
+    assert await network.resolve_host_ip_port(9001) == "10.0.0.7:9001"
+
+
+async def test_resolve_host_ip_port_formats_local_ipv6(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(network, "local_ip_address", lambda: "2001:db8::1")
+
+    assert await network.resolve_host_ip_port(8080) == "[2001:db8::1]:8080"

--- a/subscriber/tests/utils/test_spectrum.py
+++ b/subscriber/tests/utils/test_spectrum.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+
+from subscriber.utils import network
+from subscriber.utils.spectrum import SpectrumEndpoint, fetch_spectrum_endpoints
+
+
+def test_spectrum_fetch_is_available_without_kvcm_dependency() -> None:
+    assert importlib.util.find_spec("subscriber.utils.spectrum") is not None
+    assert "subscriber.kvcm" not in inspect.getsource(network)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+class FakeHttpClient:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, float]] = []
+
+    async def get(self, url: str, timeout: float) -> FakeResponse:
+        self.calls.append((url, timeout))
+        return FakeResponse(self.payload)
+
+
+async def test_fetch_spectrum_endpoints_validates_response_once() -> None:
+    http_client = FakeHttpClient(
+        {
+            "instances": [
+                {"ip": "10.0.0.8", "port": "8000", "weight": 20},
+                {"ip": "10.0.0.7", "port": 7000},
+                {"ip": "10.0.0.9", "port": 0},
+                {"ip": "10.0.0.10", "port": True},
+            ]
+        }
+    )
+
+    endpoints = await fetch_spectrum_endpoints(
+        "engine-vs-a", http_client=http_client, refresh_timeout=0.5
+    )
+
+    assert http_client.calls == [
+        (
+            "http://127.0.0.1:8880/api/v1/discovery/virtual-services/"
+            "engine-vs-a/instances",
+            0.5,
+        )
+    ]
+    assert endpoints == [
+        SpectrumEndpoint(ip="10.0.0.7", port=7000),
+        SpectrumEndpoint(ip="10.0.0.8", port=8000, weight=20),
+    ]


### PR DESCRIPTION
## Summary

- Add a standalone Python process `subscriber/` (managed by `uv`, independent of the parent Bazel build) that subscribes to inference engine KV cache events and forwards them to the kvcm service.
- Engine adapters behind `AbstractEngineAdapter`: vLLM incremental (ZMQ pub/replay with seq-gap replay via DEALER socket) and snapshot pipelines, plus an SGLang placeholder adapter; the event loop is engine-agnostic.
- Health integration with DashServing ("live and die together"): engine liveness driven by `GetWorkerStatus.alive`, `EngineHealthCoordinator` epoch gating for sends, seq_id-linearized state reporting, idempotent `AllBlocksCleared` per sendable epoch.
- kvcm side: client, manager client, service discovery, event payload expansion; KVCM is a lossy bypass — unavailability never blocks forwarding.
- Observability: per-stage span timing (`StageTimer`), unified metrics via `subscriber/metrics/` with `kvcache_subscriber_` prefix, cataloged in `docs/metrics.json` and enforced by `test_metrics_catalog.py`.
- Hand-maintained protobuf pb files compatible with protobuf 3.20.3 (no `runtime_version`/`_builder`); `kv_cache_group_metadata.proto` remains the authoritative wire schema.

## Why

KVCache reuse requires the kvcm service to learn block store/remove events from co-located inference engines in real time. This subscriber decouples that forwarding from the engine and from kvcm availability, with explicit health semantics so DashServing never routes traffic to a node whose events are not being forwarded.

## Validation

- `uv run pytest` — 523 passed
- `uv run ruff check subscriber/ tests/` — all checks passed
- `uv run mypy subscriber/` — no issues in 48 source files