### PR TITLE
[protocol/manager/config/docs] support async Redis snapshots, use_eagle_pop and snapshot_required

### DIFF
--- a/docs/api/report_event.md
+++ b/docs/api/report_event.md
@@ -406,7 +406,7 @@ ADD A -> DELETE A -> ADD A(new URI)
         |
 snapshot 关闭新的 delta 入口
         |
-snapshot replace + Sync + commit/abort
+snapshot replace + commit/abort
         |
 等待中的 delta 使用 commit 后的 generation 继续
 ```
@@ -418,6 +418,11 @@ snapshot replace + Sync + commit/abort
 - ADD/DELETE 等待超过统一写门超时后返回可重试的 `SNAPSHOT_IN_PROGRESS`，且不会获得
   delta lease 或取消 snapshot；
 - snapshot commit 后，等待中的增量不会再被刚完成的 snapshot 覆盖；
+
+当 meta storage 使用 `cached + persistent_type=async_redis` 时，snapshot 与增量具有相同的
+Redis 返回点：mutation 成功进入异步队列并更新 local cache 后即可 commit/返回，不等待 Redis
+consumer flush。`committed_snapshot_version` 是当前 KVCM 进程的查询栅栏，不是 Redis flush
+checkpoint；响应后的 pipeline 失败不会改写已经返回的 ReportEvent 状态。
 - snapshot abort 后，等待中的增量继续执行；
 - 第二个并发 snapshot 返回 `SNAPSHOT_IN_PROGRESS`；
 - 不同 host、instance 或 storage type 不共享该写门。
@@ -539,7 +544,7 @@ REGISTER 成功后重试该 ADD。
 | `SNAPSHOT_IN_PROGRESS` | 同 reporter 已有 snapshot、snapshot 未能及时排空已准入 delta，或 delta 未能及时等到 snapshot 完成 | 按失败事件类型退避重试：SNAPSHOT 重发完整全量，ADD/DELETE 幂等重试失败项 |
 | `SNAPSHOT_RATE_LIMITED` | 距上次成功 snapshot 太近 | 按 `retry_after_ms` 重试完整 snapshot |
 | `SNAPSHOT_REQUIRED` | 等待期间 reporter 被注销/关闭等状态变化 | 重新 REGISTER；realtime-only 可直接重试增量 |
-| `INTERNAL_ERROR` | metadata replace、Sync、commit 等内部失败 | 保留实时链路；完整重试 snapshot 或幂等重试增量 |
+| `INTERNAL_ERROR` | metadata replace、commit 等内部失败 | 保留实时链路；完整重试 snapshot 或幂等重试增量 |
 
 ## 11. 查询行为
 
@@ -676,7 +681,7 @@ Snapshot 使用稳定 location 原地更新，不提供原子查询视图：
 | 限流/并发拒绝 | 旧值 | 原数据 | 按错误码退避 |
 | snapshot 写入中 | 旧值 | 新旧合法 candidate | 不做版本大小判断 |
 | 部分 replace 失败 | 旧值 | 已写入的新数据 + 未覆盖的旧数据 | 完整重试 |
-| Sync/commit 失败 | 旧值 | 已写入的新数据可能可见 | 完整重试 |
+| commit 失败 | 旧值 | 已写入的新数据可能可见 | 完整重试 |
 | commit 成功、cleanup 未完成 | 新值 | 完全属于旧 version 的遗漏 block 已不可见 | cleanup 仅回收空间 |
 | cleanup 与新写重叠 | 新值 | 新写必须保留 | 无需特殊处理 |
 | KVCM 重启 | 空 | 第一条合法汇报后历史数据可能可见 | 正常继续心跳/增量；可选低频全量 |
@@ -762,7 +767,7 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 | S-06 | snapshot 遗漏 block 后 cleanup 最终删除 | `TestReportEventSnapshotCommitReclaimsOnlyStaleReporterLocations`；snapshot 集成 `test_22` |
 | S-07 | snapshot 和 delta 两种先后顺序均收敛 | `TestReportEventDeltaAlreadyAdmittedThenSnapshotWins`、`TestReportEventSnapshotGateThenDeltaInheritsNewTokenAndWins`；snapshot 集成 `test_24` |
 | S-08 | 第二个 snapshot busy，成功后 rate limit 带 retry_after | `ConcurrentSnapshotsHaveExactlyOneWinner`、`SnapshotRateLimitReturnsRetryDelay`；snapshot 集成 `test_18/24` |
-| S-09 | snapshot 部分 replace/Sync 失败后仍可读并可完整重试 | `TestReportEventPartialSnapshotFailureKeepsCacheReadableAndRetryConverges`、`TestReportEventSyncFailureKeepsWrittenCacheReadableAndImmediateRetryConverges` |
+| S-09 | snapshot 部分 replace 失败后仍可读并可完整重试；成功路径不等待 persistent Sync | `TestReportEventPartialSnapshotFailureKeepsCacheReadableAndRetryConverges`、`TestReportEventSnapshotCommitsWithoutWaitingForPersistentSync` |
 | S-10 | cleanup 与下一轮写入 CAS/attempt epoch 竞争不删除新值，并在 epoch 变化后按批次提前退出 | `TestSnapshotCleanupPreservesInFlightStableLocationUntilAbort`、`TestSnapshotCleanupCASPreservesLocationRefreshedAfterScan`、`TestOldSnapshotCleanupDoesNotDeleteLaterAbortedAttemptWrites` |
 | S-11 | snapshot commit 后增量刷新 mixed/legacy location，旧 cleanup 不删除新写 | `TestSnapshotCleanupPreservesPostCommitDeltaOnMixedGenerationLocation`、`TestSnapshotCleanupPreservesCurrentDeltaBesideLegacySpec`；snapshot 集成 `test_32_*` |
 | S-12 | snapshot cleanup 只删 metadata，不调用外部 URI backend | `TestMetadataOnlyLocationDeleteSkipsPhysicalBackend`、`TestCleanupLocationsByPredicateSubmitsExactObservedValue` |

--- a/docs/design/report_event_snapshot_uri_version.md
+++ b/docs/design/report_event_snapshot_uri_version.md
@@ -244,10 +244,15 @@ Generation 在获得 delta lease 时建立。参数校验、tombstone 等准入�
    超时则 abort candidate、重新打开写门并返回可重试的 `SNAPSHOT_IN_PROGRESS`；
 6. 为本次全部 URI 追加 candidate `s_version`；
 7. 使用稳定 location id 原地替换完整 specs；
-8. 对本次 block keys 执行 `Sync`；
-9. 更新内存 committed generation并打开写门；
-10. 返回新的 `committed_snapshot_version`；
-11. 异步扫描并回收该 reporter 的旧 generation。
+8. 更新内存 committed generation并打开写门；
+9. 返回新的 `committed_snapshot_version`；
+10. 异步扫描并回收该 reporter 的旧 generation。
+
+当 meta storage 使用 `cached + persistent_type=async_redis` 时，第 7 步与增量使用相同的写入
+语义：先把 Redis mutation 放入异步队列，再同步更新 local cache。Snapshot 不等待 Redis
+consumer flush；成功响应表示本次全部 mutation 已成功 enqueue 且 local cache 已更新，不表示
+Redis 已经执行完成。响应后发生的 pipeline 失败通过异步 Redis 日志和指标暴露，不回溯修改
+已经返回的 ReportEvent 结果。
 
 不同 reporter、不同 storage type 可以并行。第二个并发 snapshot 返回
 `SNAPSHOT_IN_PROGRESS`。
@@ -268,7 +273,7 @@ Snapshot 期间到达的 ADD/DELETE 会在配置的上限内等待。Snapshot �
 
 Snapshot 使用稳定 location id 原地覆盖，不做 copy-on-write。
 
-如果部分 replace、Sync 或 commit 失败：
+如果部分 replace 或 commit 失败：
 
 - candidate 不成为 committed generation；
 - snapshot abort，等待中的 delta 继续；
@@ -288,7 +293,7 @@ abort，committed generation 和已有 metadata 都不变。
 | 参数校验 | 不变 | 原数据不变 | 修正请求 |
 | 频率限制 | 不变 | 原数据不变 | 按 `retry_after_ms` 重试 |
 | 部分 replace | 不变 | 新旧候选可能共存 | 完整重试 |
-| Sync/commit | 不变 | 已写候选仍可能可见 | 完整重试 |
+| commit | 不变 | 已写候选仍可能可见 | 完整重试 |
 | cleanup 中断 | 已更新 | 完全属于旧 version 的 location 已被 strict 隐藏 | 下次 snapshot 再清理空间 |
 
 ## 8. 查询规则
@@ -357,7 +362,7 @@ snapshot 关闭新 delta 入口
         |
 等待已有 delta 完成
         |
-snapshot replace + Sync + commit/abort
+snapshot replace + commit/abort
         |
 打开入口，等待中的 delta 继续
 ```
@@ -446,7 +451,7 @@ reporter -> location 反向索引，而不是继续提高全量频率。
 - snapshot 与 delta 两种先后顺序、commit 和 abort 均不死锁；
 - snapshot 等待 active delta、delta 等待 in-flight snapshot 两个方向均有统一可配置超时，
   且超时后可重试；
-- snapshot 部分失败或 Sync 失败后，已写候选仍可见且完整重试收敛；
+- snapshot 部分失败后，已写候选仍可见且完整重试收敛；
 - cleanup 与下一轮 snapshot 的 CAS 竞态不删除新值；
 - snapshot commit 后 delta 刷新 mixed-generation location 时，旧 cleanup 不删除新写；
 - snapshot cleanup 只删除 metadata，不调用外部 URI backend；
@@ -465,7 +470,7 @@ reporter -> location 反向索引，而不是继续提高全量频率。
 - realtime-only reporter 不补 snapshot 也能持续 ADD/DELETE；
 - heartbeat timeout、恢复、超过 grace cleanup；
 - 多 reporter、多 instance、多 storage type 隔离；
-- snapshot partial/Sync failure、完整重试；
+- snapshot partial failure、完整重试；
 - snapshot commit 后立即到达的 delta 在异步 cleanup 后仍可查询；
 - reporter host 或 medium 含 `#` 时 fail closed 且无写入副作用；
 - ASAN/TSAN 或等价并发检测（仅记录实际执行结果，不能由普通 CI 结果推断）。

--- a/integration_test/meta_service/test_report_event.py
+++ b/integration_test/meta_service/test_report_event.py
@@ -670,7 +670,7 @@ class EventReportFunctionalTest(unittest.TestCase):
             self.assertEqual(body["header"]["status"]["code"], "OK")
             self.assertEqual(body.get("item_results", []), [])
             self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
-            self.assertFalse(body.get("snapshot_required"))
+            self.assertTrue(body.get("snapshot_required"))
             self._assert_profile_specs(
                 block_key,
                 profile_name,
@@ -701,7 +701,7 @@ class EventReportFunctionalTest(unittest.TestCase):
             self.assertEqual(body["header"]["status"]["code"], "OK")
             self.assertEqual(body.get("item_results", []), [])
             self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
-            self.assertFalse(body.get("snapshot_required"))
+            self.assertTrue(body.get("snapshot_required"))
             self._assert_profile_specs(
                 block_key,
                 profile_name,
@@ -839,7 +839,7 @@ class EventReportFunctionalTest(unittest.TestCase):
             self.assertEqual(body["header"]["status"]["code"], "OK")
             self.assertEqual(body.get("item_results", []), [])
             self.assertEqual(len(body.get("committed_snapshot_version", "")), 32)
-            self.assertFalse(body.get("snapshot_required"))
+            self.assertTrue(body.get("snapshot_required"))
         self._for_each_profile(run)
 
     # 12. Empty events array: should be a no-op success

--- a/integration_test/meta_service/test_report_event_snapshot.py
+++ b/integration_test/meta_service/test_report_event_snapshot.py
@@ -953,7 +953,7 @@ class EventReportFunctionalTest(unittest.TestCase):
         self.assertEqual(body.get("item_results", []), [])
         version = body["committed_snapshot_version"]
         self.assertEqual(len(version), 32)
-        self.assertFalse(body.get("snapshot_required"))
+        self.assertTrue(body.get("snapshot_required"))
 
         specs = _wait_for_block_spec_names(
             self.client,
@@ -1514,7 +1514,7 @@ class EventReportFunctionalTest(unittest.TestCase):
         self.assertEqual(
             accepted_delta["header"]["status"]["code"], "OK"
         )
-        self.assertFalse(accepted_delta.get("snapshot_required"))
+        self.assertTrue(accepted_delta.get("snapshot_required"))
         _wait_for_block_spec_names(
             self.client,
             instance_id,
@@ -1839,7 +1839,7 @@ class EventReportFunctionalTest(unittest.TestCase):
         self.assertEqual(delta["header"]["status"]["code"], "OK")
         delta_version = delta["committed_snapshot_version"]
         self.assertEqual(len(delta_version), 32)
-        self.assertFalse(delta.get("snapshot_required"))
+        self.assertTrue(delta.get("snapshot_required"))
 
         duplicate = self.client.report_event(
             _make_request(
@@ -3156,7 +3156,7 @@ class EventReportFunctionalTest(unittest.TestCase):
             )
         )
         self.assertEqual(first_delta["header"]["status"]["code"], "OK")
-        self.assertFalse(first_delta.get("snapshot_required"))
+        self.assertTrue(first_delta.get("snapshot_required"))
         delta_version = first_delta["committed_snapshot_version"]
         self.assertEqual(len(delta_version), 32)
         _wait_for_block_spec_names(
@@ -3337,7 +3337,11 @@ class EventReportFunctionalTest(unittest.TestCase):
             self.assertEqual(
                 response["header"]["status"]["code"], "OK", response
             )
-            self.assertFalse(response.get("snapshot_required"))
+        self.assertEqual(
+            sum(response.get("snapshot_required") is True for response in responses),
+            1,
+            responses,
+        )
 
         for writer in range(writer_count):
             specs = _wait_for_block_spec_names(
@@ -3436,7 +3440,7 @@ class EventReportFunctionalTest(unittest.TestCase):
         self.assertEqual(response["header"]["status"]["code"], "OK")
         self.assertEqual(response.get("item_results", []), [])
         self.assertEqual(len(response["committed_snapshot_version"]), 32)
-        self.assertFalse(response.get("snapshot_required"))
+        self.assertTrue(response.get("snapshot_required"))
         _wait_for_block_spec_names(
             self.client,
             self.instance_id,
@@ -3458,7 +3462,7 @@ class EventReportFunctionalTest(unittest.TestCase):
         )
         version = deleted["committed_snapshot_version"]
         self.assertEqual(len(version), 32)
-        self.assertFalse(deleted.get("snapshot_required"))
+        self.assertTrue(deleted.get("snapshot_required"))
         _wait_for_block_spec_names(
             self.client,
             self.instance_id,
@@ -3729,7 +3733,7 @@ class EventReportFunctionalTest(unittest.TestCase):
             same_batch_wrong_register.get("item_results"),
             ["INVALID_ARGUMENT", "OK"],
         )
-        self.assertFalse(same_batch_wrong_register.get("snapshot_required"))
+        self.assertTrue(same_batch_wrong_register.get("snapshot_required"))
         self.assertEqual(
             {spec.get("name") for spec in _query_block_specs(
                 self.client,
@@ -4016,7 +4020,7 @@ class EventReportBenchTest(unittest.TestCase):
             print(f"  Latency avg: {statistics.mean(latencies):.2f}ms")
         self.assertEqual(len(errors), 0, f"Bench had errors: {errors[:5]}")
 
-    # 18. Mixed ADD/DELETE/HEARTBEAT batch throughput.
+    # 18. Mixed ADD/DELETE batch throughput.
     def test_18_block_add_delete_mixed(self):
         num_threads = 50
         ops_per_thread = 100
@@ -4033,7 +4037,7 @@ class EventReportBenchTest(unittest.TestCase):
             for i in range(ops_per_thread):
                 block_key = thread_id * ops_per_thread + i + 200000
                 events = [_ev_block_add(block_key, "mem", _make_single_spec("spec_4096", _build_event_report_uri(
-                    host, "mem"))), _ev_block_delete(block_key, "mem", ["spec_4096"]), _ev_heartbeat({"thread": str(thread_id)}), ]
+                    host, "mem"))), _ev_block_delete(block_key, "mem", ["spec_4096"]), ]
                 payload = _make_request(
                     self.instance_id, host, events,
                     trace_id=f"bench_mixed_{thread_id}_{i}",
@@ -4063,7 +4067,7 @@ class EventReportBenchTest(unittest.TestCase):
         p50 = self._percentile(latencies, 50)
         p99 = self._percentile(latencies, 99)
 
-        print(f"\n[BENCH] Mixed ADD/DELETE/HEARTBEAT batch:")
+        print(f"\n[BENCH] Mixed ADD/DELETE batch:")
         print(f"  Total batches: {len(latencies)} / {total_batches} (errors: {len(errors)})")
         print(f"  Elapsed:       {elapsed:.2f}s")
         print(f"  Batch QPS:     {qps:.1f}")

--- a/kv_cache_manager/config/model_deployment.cc
+++ b/kv_cache_manager/config/model_deployment.cc
@@ -11,7 +11,8 @@ bool ModelDeployment::operator==(const ModelDeployment &other) const {
     }
     return model_name_ == other.model_name_ && dtype_ == other.dtype_ && use_mla_ == other.use_mla_ &&
            tp_size_ == other.tp_size_ && dp_size_ == other.dp_size_ && lora_name_ == other.lora_name_ &&
-           pp_size_ == other.pp_size_ && extra_ == other.extra_ /* && user_data_ == other.user_data_*/;
+           pp_size_ == other.pp_size_ && extra_ == other.extra_ && use_eagle_pop_ == other.use_eagle_pop_
+        /* && user_data_ == other.user_data_*/;
 }
 bool ModelDeployment::operator!=(const ModelDeployment &other) const { return !((*this) == other); }
 
@@ -25,6 +26,7 @@ bool ModelDeployment::FromRapidValue(const rapidjson::Value &rapid_value) {
     KVCM_JSON_GET_MACRO(rapid_value, "pp_size", pp_size_);
     KVCM_JSON_GET_MACRO(rapid_value, "extra", extra_);
     KVCM_JSON_GET_MACRO(rapid_value, "user_data", user_data_);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "use_eagle_pop", use_eagle_pop_, use_eagle_pop_);
     return true;
 }
 
@@ -38,6 +40,7 @@ void ModelDeployment::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &
     Put(writer, "pp_size", pp_size_);
     Put(writer, "extra", extra_);
     Put(writer, "user_data", user_data_);
+    Put(writer, "use_eagle_pop", use_eagle_pop_);
 }
 bool ModelDeployment::ValidateRequiredFields(std::string &invalid_fields) const {
     bool valid = true;

--- a/kv_cache_manager/config/model_deployment.h
+++ b/kv_cache_manager/config/model_deployment.h
@@ -22,6 +22,7 @@ public:
     int32_t pp_size() const noexcept { return pp_size_; }
     const std::string &extra() const noexcept { return extra_; }
     const std::string &user_data() const noexcept { return user_data_; }
+    bool use_eagle_pop() const noexcept { return use_eagle_pop_; }
 
     // Setter methods
     void set_model_name(const std::string &v) { model_name_ = v; }
@@ -33,6 +34,7 @@ public:
     void set_pp_size(int32_t pp_size) { pp_size_ = pp_size; }
     void set_extra(const std::string &v) { extra_ = v; }
     void set_user_data(const std::string &v) { user_data_ = v; }
+    void set_use_eagle_pop(bool v) noexcept { use_eagle_pop_ = v; }
 
 private:
     std::string model_name_;
@@ -44,5 +46,6 @@ private:
     int32_t pp_size_ = 0;
     std::string extra_;
     std::string user_data_;
+    bool use_eagle_pop_ = false;
 };
 } // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -705,10 +705,14 @@ std::string EventReportBackend::HostSuffix(const std::string &host_ip_port) cons
 
 ErrorCode EventReportBackend::BeginDeltaMutation(const ReporterSnapshotKey &reporter_key,
                                                  std::string &out_committed_version,
-                                                 uint64_t *out_lifecycle_generation) {
+                                                 uint64_t *out_lifecycle_generation,
+                                                 bool *out_created_generation) {
     out_committed_version.clear();
     if (out_lifecycle_generation) {
         *out_lifecycle_generation = 0;
+    }
+    if (out_created_generation) {
+        *out_created_generation = false;
     }
     if (reporter_key.instance_id.empty() || reporter_key.host_ip_port.empty()) {
         return EC_BADARGS;
@@ -747,6 +751,9 @@ ErrorCode EventReportBackend::BeginDeltaMutation(const ReporterSnapshotKey &repo
         new_state.committed = candidate;
         snapshot_token_owners_[candidate] = reporter_key;
         state_it = snapshot_versions_.find(reporter_key);
+        if (out_created_generation) {
+            *out_created_generation = true;
+        }
     }
     auto &state = state_it->second;
     if (state.active_delta_mutations == std::numeric_limits<uint64_t>::max()) {

--- a/kv_cache_manager/data_storage/event_report_backend.h
+++ b/kv_cache_manager/data_storage/event_report_backend.h
@@ -91,7 +91,8 @@ public:
     // timeout for commit/abort instead of racing it.
     ErrorCode BeginDeltaMutation(const ReporterSnapshotKey &reporter_key,
                                  std::string &out_committed_version,
-                                 uint64_t *out_lifecycle_generation = nullptr);
+                                 uint64_t *out_lifecycle_generation = nullptr,
+                                 bool *out_created_generation = nullptr);
     void EndDeltaMutation(const ReporterSnapshotKey &reporter_key, uint64_t lifecycle_generation = 0);
     ErrorCode BeginSnapshot(const ReporterSnapshotKey &reporter_key,
                             std::string &out_candidate_version,

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -2479,7 +2479,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         std::string version;
         uint64_t attempt_epoch;
         int event_index;
-        KeyVector block_keys;
     };
     struct DeltaSpecMutation {
         bool is_add = false;
@@ -2721,8 +2720,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 break;
             }
 
-            KeyVector snapshot_block_keys;
-            snapshot_block_keys.reserve(validated_blocks.size());
             for (auto &block : validated_blocks) {
                 for (auto &spec : block.specs) {
                     std::string versioned_uri;
@@ -2736,7 +2733,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 if (per_item_ec[i] != EC_OK) {
                     break;
                 }
-                snapshot_block_keys.push_back(block.block_key);
                 snapshot_to_replace[block.block_key].push_back(SnapshotReplaceEntry{
                     event_backend->BuildLocationId(block.medium, host_ip_port), std::move(block.specs), i});
             }
@@ -2746,11 +2742,8 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 request_snapshot_version.clear();
                 break;
             }
-            snapshot_commit_tasks.push_back(SnapshotCommitTask{reporter_key,
-                                                               request_snapshot_version,
-                                                               event_backend->GetSnapshotAttemptEpoch(reporter_key),
-                                                               i,
-                                                               std::move(snapshot_block_keys)});
+            snapshot_commit_tasks.push_back(SnapshotCommitTask{
+                reporter_key, request_snapshot_version, event_backend->GetSnapshotAttemptEpoch(reporter_key), i});
             break;
         }
         default:
@@ -3010,17 +3003,10 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     if (!snapshot_commit_tasks.empty()) {
         const auto &task = snapshot_commit_tasks.front();
         bool snapshot_failed = per_item_ec[task.event_index] != EC_OK;
-        // An empty snapshot is a valid authoritative "reporter owns no blocks"
-        // update.  With no block writes there is nothing to flush before the
-        // in-memory token is published; stale locations are removed by the
-        // cleanup task below.
-        if (!snapshot_failed && !task.block_keys.empty() && !meta_searcher->Sync(task.block_keys)) {
-            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: failed to sync host [%s] token [%s]",
-                          trace_id.c_str(),
-                          task.reporter_key.host_ip_port.c_str(),
-                          task.version.c_str());
-            snapshot_failed = true;
-        }
+        // Event-report metadata is a soft cache index. Like delta mutations,
+        // a snapshot commits after every persistent write has been accepted
+        // by the async backend and mirrored into the local cache; it does not
+        // wait for Redis consumers to flush their queues.
         if (!snapshot_failed && !event_backend->CommitSnapshotVersion(task.reporter_key, task.version)) {
             KVCM_LOG_ERROR("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: failed to publish host [%s] token [%s]",
                            trace_id.c_str(),

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -3709,18 +3709,19 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
                                           instance_id.c_str());
     }
 
+    auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);
+    if (!instance_info) {
+        request_context->error_tracer()->AddErrorMsg("instance not found");
+        RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
+            WARN, EC_INSTANCE_NOT_EXIST, std::vector<HostCacheMatch>, "instance not found");
+    }
     if (query_type == QueryType::QT_UNSPECIFIED) {
-        auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);
-        if (!instance_info) {
-            request_context->error_tracer()->AddErrorMsg("instance not found");
-            RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
-                WARN, EC_INSTANCE_NOT_EXIST, std::vector<HostCacheMatch>, "instance not found");
-        }
         query_type = static_cast<QueryType>(instance_info->default_query_type());
         if (query_type == QueryType::QT_UNSPECIFIED) {
             RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, EC_ERROR, std::vector<HostCacheMatch>, "unknown query type");
         }
     }
+    const bool use_eagle_pop = instance_info->model_deployment().use_eagle_pop();
     if (query_type != QueryType::QT_PREFIX_MATCH && query_type != QueryType::QT_PREFIX_MATCH_WITH_MAMBA) {
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN,
                                           EC_BADARGS,
@@ -3737,17 +3738,17 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
     ErrorCode ec = EC_ERROR;
     switch (query_type) {
     case QueryType::QT_PREFIX_MATCH: {
-        ec = meta_searcher->PrefixMatchByHost(request_context, block_cache_keys, medium_filter, host_matches);
+        ec = meta_searcher->PrefixMatchByHost(
+            request_context, block_cache_keys, use_eagle_pop, medium_filter, host_matches);
         break;
     }
     case QueryType::QT_PREFIX_MATCH_WITH_MAMBA: {
-        auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);
-        if (!instance_info) {
-            RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
-                WARN, EC_INSTANCE_NOT_EXIST, std::vector<HostCacheMatch>, "instance not found");
-        }
-        ec = meta_searcher->PrefixMatchWithMambaByHost(
-            request_context, block_cache_keys, medium_filter, instance_info->location_spec_groups(), host_matches);
+        ec = meta_searcher->PrefixMatchWithMambaByHost(request_context,
+                                                       block_cache_keys,
+                                                       use_eagle_pop,
+                                                       medium_filter,
+                                                       instance_info->location_spec_groups(),
+                                                       host_matches);
         break;
     }
     default:

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -147,22 +147,26 @@ public:
 
     ErrorCode Acquire(const ReporterSnapshotKey &reporter_key,
                       std::string &out_committed_version,
-                      uint64_t &out_lifecycle_generation) {
+                      uint64_t &out_lifecycle_generation,
+                      bool &out_created_generation) {
         const auto failure_it = snapshot_wait_failures_.find(reporter_key);
         if (failure_it != snapshot_wait_failures_.end()) {
             out_committed_version.clear();
             out_lifecycle_generation = 0;
+            out_created_generation = false;
             return failure_it->second;
         }
         const auto it = versions_.find(reporter_key);
         if (it != versions_.end()) {
             out_committed_version = it->second.snapshot_version;
             out_lifecycle_generation = it->second.lifecycle_generation;
+            out_created_generation = false;
             return EC_OK;
         }
-        const ErrorCode ec =
-            backend_->BeginDeltaMutation(reporter_key, out_committed_version, &out_lifecycle_generation);
+        const ErrorCode ec = backend_->BeginDeltaMutation(
+            reporter_key, out_committed_version, &out_lifecycle_generation, &out_created_generation);
         if (ec != EC_OK) {
+            out_created_generation = false;
             if (ec == EC_SNAPSHOT_IN_PROGRESS) {
                 snapshot_wait_failures_.emplace(reporter_key, ec);
             }
@@ -2399,12 +2403,13 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     }
 
     const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
-    auto refresh_snapshot_response = [&]() {
+    bool request_created_generation = false;
+    auto refresh_snapshot_response = [&](bool force_snapshot_required) {
         const std::string committed = event_backend->GetSnapshotVersion(reporter_key);
         response->set_committed_snapshot_version(committed);
-        response->set_snapshot_required(committed.empty());
+        response->set_snapshot_required(committed.empty() || force_snapshot_required);
     };
-    refresh_snapshot_response();
+    refresh_snapshot_response(false);
 
     if (!event_backend->IsCleanupCallbackSet()) {
         event_backend->SetCleanupCallback([this, requested_type](const std::string &cleanup_instance,
@@ -2566,11 +2571,15 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
 
             std::string committed_version;
-            const ErrorCode fence_ec =
-                delta_mutations.Acquire(reporter_key, committed_version, mutation_lifecycle_generation);
+            bool created_generation = false;
+            const ErrorCode fence_ec = delta_mutations.Acquire(
+                reporter_key, committed_version, mutation_lifecycle_generation, created_generation);
             if (fence_ec != EC_OK) {
                 per_item_ec[i] = fence_ec;
                 break;
+            }
+            if (created_generation) {
+                request_created_generation = true;
             }
             for (auto &spec : specs) {
                 std::string versioned_uri;
@@ -2628,11 +2637,15 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
 
             std::string committed_version;
-            const ErrorCode fence_ec =
-                delta_mutations.Acquire(reporter_key, committed_version, mutation_lifecycle_generation);
+            bool created_generation = false;
+            const ErrorCode fence_ec = delta_mutations.Acquire(
+                reporter_key, committed_version, mutation_lifecycle_generation, created_generation);
             if (fence_ec != EC_OK) {
                 per_item_ec[i] = fence_ec;
                 break;
+            }
+            if (created_generation) {
+                request_created_generation = true;
             }
             const std::string location_id = event_backend->BuildLocationId(params.medium(), host_ip_port);
             auto &mutations_by_name = delta_spec_mutations[block_key][location_id];
@@ -3093,7 +3106,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     };
 
-    refresh_snapshot_response();
+    refresh_snapshot_response(request_created_generation);
     if (any_failure) {
         std::map<std::pair<proto::meta::ReportEventType, proto::meta::ErrorCode>, size_t> failure_counts;
         size_t failed_item_count = 0;

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -1944,8 +1944,6 @@ MetaSearcher::VisitAllLocations(RequestContext *request_context, size_t scan_bat
     return has_failure ? EC_PARTIAL_OK : EC_OK;
 }
 
-bool MetaSearcher::Sync(const KeyVector &keys) noexcept { return meta_indexer_->Sync(keys); }
-
 ErrorCode MetaSearcher::CleanupLocationsByPredicate(RequestContext *request_context,
                                                     DataStorageType storage_type,
                                                     size_t scan_batch_size,

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -765,6 +765,7 @@ ErrorCode MetaSearcher::ReverseRollSlideWindowMatch(RequestContext *request_cont
 
 ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
                                           const KeyVector &keys,
+                                          bool use_eagle_pop,
                                           const std::vector<std::string> &medium_filter,
                                           std::vector<HostCacheMatch> &out_matches) const {
     SPAN_TRACER(request_context);
@@ -810,13 +811,19 @@ ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
             }
             ++prefix_len;
         }
-        out_matches.push_back(HostCacheMatch{host, prefix_len});
+        if (use_eagle_pop) {
+            prefix_len = std::max<int64_t>(prefix_len - 1, 0);
+        }
+        if (prefix_len > 0) {
+            out_matches.push_back(HostCacheMatch{host, prefix_len});
+        }
     }
     return EC_OK;
 }
 
 ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_context,
                                                    const KeyVector &keys,
+                                                   bool use_eagle_pop,
                                                    const std::vector<std::string> &medium_filter,
                                                    const std::vector<LocationSpecGroup> &location_spec_groups,
                                                    std::vector<HostCacheMatch> &out_matches) const {
@@ -878,6 +885,9 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
                 !HasAllLocationSpecGroups(host_it->second, full_groups)) {
                 break;
             }
+        }
+        if (use_eagle_pop && full_prefix_len > 0) {
+            --full_prefix_len;
         }
         if (full_prefix_len == 0) {
             continue;

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -186,7 +186,6 @@ public:
                                      size_t scan_batch_size = 1000,
                                      std::function<bool()> should_abort = nullptr,
                                      AcquireMetadataWriteLeaseFunc acquire_cleanup_lease = nullptr);
-    bool Sync(const KeyVector &keys) noexcept;
 
 private:
     struct StorageTypeWeights {

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -80,10 +80,12 @@ public:
                                           SelectLocationPolicy *policy) const;
     ErrorCode PrefixMatchByHost(RequestContext *request_context,
                                 const KeyVector &keys,
+                                bool use_eagle_pop,
                                 const std::vector<std::string> &medium_filter,
                                 std::vector<HostCacheMatch> &out_matches) const;
     ErrorCode PrefixMatchWithMambaByHost(RequestContext *request_context,
                                          const KeyVector &keys,
+                                         bool use_eagle_pop,
                                          const std::vector<std::string> &medium_filter,
                                          const std::vector<LocationSpecGroup> &location_spec_groups,
                                          std::vector<HostCacheMatch> &out_matches) const;

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -190,9 +190,9 @@ public:
         fail_key_on_next_upsert_ = key;
     }
 
-    void FailNextSync() {
+    size_t GetSyncCallCount() {
         std::lock_guard<std::mutex> lock(control_mutex_);
-        fail_next_sync_ = true;
+        return sync_call_count_;
     }
 
     std::vector<ErrorCode> Upsert(RequestContext *request_context,
@@ -236,10 +236,7 @@ public:
     bool Sync(const KeyTypeVec &keys) noexcept override {
         {
             std::lock_guard<std::mutex> lock(control_mutex_);
-            if (fail_next_sync_) {
-                fail_next_sync_ = false;
-                return false;
-            }
+            ++sync_call_count_;
         }
         return MetaLocalBackend::Sync(keys);
     }
@@ -276,7 +273,7 @@ private:
     bool location_read_entered_ = false;
     bool release_location_read_ = false;
     std::optional<int64_t> fail_key_on_next_upsert_;
-    bool fail_next_sync_ = false;
+    size_t sync_call_count_ = 0;
 };
 
 class CacheManagerTest : public TESTBASE {
@@ -2810,42 +2807,30 @@ TEST_F(CacheManagerTest, TestReportEventPartialSnapshotFailureKeepsCacheReadable
     EXPECT_EQ((std::set<std::string>{"retry_a", "retry_b"}), retry_sources);
 }
 
-TEST_F(CacheManagerTest, TestReportEventSyncFailureKeepsWrittenCacheReadableAndImmediateRetryConverges) {
+TEST_F(CacheManagerTest, TestReportEventSnapshotCommitsWithoutWaitingForPersistentSync) {
     const std::string host = "192.168.10.30:8080";
     const int64_t key = 9425;
     auto event_backend = InstallEventReportBackend();
     auto *meta_backend = InstallControllableMetaBackend();
     ASSERT_NE(nullptr, event_backend);
     ASSERT_NE(nullptr, meta_backend);
-    event_backend->SetSnapshotMinIntervalMsForTest(30'000);
     ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
 
-    meta_backend->FailNextSync();
-    const auto [failed_ec, failed_response] =
-        CallReportEvent(MakeSnapshotRequest(host, {{key, "sync_failure"}}), "sync_failure_snapshot");
-    EXPECT_EQ(EC_PARTIAL_OK, failed_ec);
-    EXPECT_EQ(proto::meta::INTERNAL_ERROR, failed_response.header().status().code());
-    ASSERT_EQ(1, failed_response.item_results_size());
-    EXPECT_EQ(proto::meta::INTERNAL_ERROR, failed_response.item_results(0));
-    EXPECT_TRUE(failed_response.committed_snapshot_version().empty());
-    EXPECT_TRUE(failed_response.snapshot_required());
-    EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
-    const auto visible_after_failure = QueryEventReportUris({key});
-    ASSERT_EQ(1u, visible_after_failure.size());
-    EXPECT_NE(std::string::npos, visible_after_failure.front().find("source=sync_failure"));
-    ASSERT_EQ(1u, QueryRawEventReportUris(key).size());
-
-    // A failed attempt must not start the rate-limit interval.
-    const auto [retry_ec, retry_response] =
-        CallReportEvent(MakeSnapshotRequest(host, {{key, "sync_retry"}}), "sync_failure_immediate_retry");
-    ASSERT_EQ(EC_OK, retry_ec);
-    const std::string committed = retry_response.committed_snapshot_version();
+    ASSERT_EQ(0u, meta_backend->GetSyncCallCount());
+    const auto [snapshot_ec, snapshot_response] =
+        CallReportEvent(MakeSnapshotRequest(host, {{key, "async_snapshot"}}), "async_snapshot_no_sync");
+    ASSERT_EQ(EC_OK, snapshot_ec);
+    EXPECT_EQ(proto::meta::OK, snapshot_response.header().status().code());
+    EXPECT_EQ(0, snapshot_response.item_results_size());
+    const std::string committed = snapshot_response.committed_snapshot_version();
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(committed));
-    EXPECT_FALSE(retry_response.snapshot_required());
+    EXPECT_FALSE(snapshot_response.snapshot_required());
+    EXPECT_EQ(committed, event_backend->GetSnapshotVersion({"test_instance", host}));
+    EXPECT_EQ(0u, meta_backend->GetSyncCallCount());
 
     const auto visible = QueryEventReportUris({key});
     ASSERT_EQ(1u, visible.size());
-    EXPECT_NE(std::string::npos, visible.front().find("source=sync_retry"));
+    EXPECT_NE(std::string::npos, visible.front().find("source=async_snapshot"));
     EXPECT_NE(std::string::npos, visible.front().find("s_version=" + committed));
 }
 
@@ -3875,7 +3860,6 @@ TEST_F(CacheManagerTest, TestSnapshotCleanupCASPreservesLocationRefreshedAfterSc
                                                           {LocationSpec("tp0", refreshed_uri)}}}},
                                                        replace_results));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), replace_results);
-    ASSERT_TRUE(meta_searcher->Sync({key}));
     ASSERT_TRUE(event_backend->CommitSnapshotVersion({"test_instance", host}, refreshed_token));
 
     CacheLocationDelRequest stale_cleanup_request{

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -2913,7 +2913,7 @@ TEST_F(CacheManagerTest, TestReportEventFoldedDeltaEventsShareFinalWriteFailure)
     EXPECT_EQ(proto::meta::INTERNAL_ERROR, response.item_results(0));
     EXPECT_EQ(proto::meta::INTERNAL_ERROR, response.item_results(1));
     EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
-    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(response.snapshot_required());
     EXPECT_TRUE(QueryEventReportUris({key}).empty());
 }
 
@@ -2943,7 +2943,7 @@ TEST_F(CacheManagerTest, TestReportEventLazilyRestoresReporterWithoutRegisterOrS
     ASSERT_EQ(EC_OK, first_delta_ec);
     EXPECT_EQ(proto::meta::OK, first_delta.header().status().code());
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(first_delta.committed_snapshot_version()));
-    EXPECT_FALSE(first_delta.snapshot_required());
+    EXPECT_TRUE(first_delta.snapshot_required());
     auto visible = QueryEventReportUris({9427});
     ASSERT_EQ(1u, visible.size());
     EXPECT_NE(std::string::npos, visible.front().find("source=first_delta"));
@@ -2979,6 +2979,57 @@ TEST_F(CacheManagerTest, TestReportEventLazilyRestoresReporterWithoutRegisterOrS
     visible = QueryEventReportUris({9427});
     ASSERT_EQ(1u, visible.size());
     EXPECT_NE(std::string::npos, visible.front().find("source=registered_but_unavailable"));
+}
+
+TEST_F(CacheManagerTest, TestReportEventSnapshotRequiredOnlyForGenerationCreatingDelta) {
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    const std::string add_host = "192.168.10.133:8080";
+    proto::meta::ReportEventRequest heartbeat;
+    heartbeat.set_instance_id("test_instance");
+    heartbeat.set_host_ip_port(add_host);
+    heartbeat.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *heartbeat_event = heartbeat.add_events();
+    heartbeat_event->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    heartbeat_event->mutable_heartbeat();
+    const auto [heartbeat_ec, heartbeat_response] = CallReportEvent(heartbeat, "snapshot_required_heartbeat");
+    ASSERT_EQ(EC_OK, heartbeat_ec);
+    EXPECT_TRUE(heartbeat_response.committed_snapshot_version().empty());
+    EXPECT_TRUE(heartbeat_response.snapshot_required());
+
+    const auto [first_add_ec, first_add] =
+        CallReportEvent(MakeAddRequest(add_host, 94'427, "first_add"), "snapshot_required_first_add");
+    ASSERT_EQ(EC_OK, first_add_ec);
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(first_add.committed_snapshot_version()));
+    EXPECT_TRUE(first_add.snapshot_required());
+
+    const auto [second_add_ec, second_add] =
+        CallReportEvent(MakeAddRequest(add_host, 94'428, "second_add"), "snapshot_required_second_add");
+    ASSERT_EQ(EC_OK, second_add_ec);
+    EXPECT_EQ(first_add.committed_snapshot_version(), second_add.committed_snapshot_version());
+    EXPECT_FALSE(second_add.snapshot_required());
+
+    const std::string delete_host = "192.168.10.134:8080";
+    auto first_delete_request = MakeAddRequest(delete_host, 94'429, "placeholder");
+    first_delete_request.clear_events();
+    auto *delete_event = first_delete_request.add_events();
+    delete_event->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+    delete_event->mutable_block_delete()->set_block_key("94429");
+    delete_event->mutable_block_delete()->set_medium("mem");
+    delete_event->mutable_block_delete()->add_spec_names("tp0");
+    const auto [first_delete_ec, first_delete] =
+        CallReportEvent(first_delete_request, "snapshot_required_first_delete");
+    ASSERT_EQ(EC_OK, first_delete_ec);
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(first_delete.committed_snapshot_version()));
+    EXPECT_TRUE(first_delete.snapshot_required());
+
+    const std::string snapshot_host = "192.168.10.135:8080";
+    const auto [snapshot_ec, snapshot] =
+        CallReportEvent(MakeSnapshotRequest(snapshot_host, {}), "snapshot_required_first_snapshot");
+    ASSERT_EQ(EC_OK, snapshot_ec);
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(snapshot.committed_snapshot_version()));
+    EXPECT_FALSE(snapshot.snapshot_required());
 }
 
 TEST_F(CacheManagerTest, TestReportEventSnapshotWhileUnavailableCommitsButStaysHiddenUntilHeartbeat) {
@@ -3044,7 +3095,7 @@ TEST_F(CacheManagerTest, TestReportEventRegisterThenFirstDeltaInSameRequest) {
     EXPECT_EQ(proto::meta::OK, response.header().status().code());
     EXPECT_EQ(0, response.item_results_size());
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
-    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(response.snapshot_required());
     EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
     EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
 
@@ -3073,7 +3124,7 @@ TEST_F(CacheManagerTest, TestReportEventDeltaBeforeExplicitRegisterSucceedsInSam
     EXPECT_EQ(proto::meta::OK, response.header().status().code());
     EXPECT_EQ(0, response.item_results_size());
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
-    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(response.snapshot_required());
     EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
     EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
     const auto visible = QueryEventReportUris({key});
@@ -3113,7 +3164,7 @@ TEST_F(CacheManagerTest, TestReportEventInvalidFirstDeltaDoesNotCreateVersionBut
     EXPECT_EQ(proto::meta::INVALID_ARGUMENT, partial_response.item_results(0));
     EXPECT_EQ(proto::meta::OK, partial_response.item_results(1));
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(partial_response.committed_snapshot_version()));
-    EXPECT_FALSE(partial_response.snapshot_required());
+    EXPECT_TRUE(partial_response.snapshot_required());
     EXPECT_EQ(partial_response.committed_snapshot_version(),
               event_backend->GetSnapshotVersion({"test_instance", host}));
     EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
@@ -3143,7 +3194,7 @@ TEST_F(CacheManagerTest, TestReportEventFirstDeleteWithoutSnapshotCreatesReusabl
     ASSERT_EQ(EC_OK, delete_ec);
     const std::string version = delete_response.committed_snapshot_version();
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(version));
-    EXPECT_FALSE(delete_response.snapshot_required());
+    EXPECT_TRUE(delete_response.snapshot_required());
     EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
     EXPECT_TRUE(QueryEventReportUris({key}).empty());
 
@@ -3178,7 +3229,7 @@ TEST_F(CacheManagerTest, TestReportEventMissingBlockDeletesRemainSuccessfulAsOne
     EXPECT_EQ(proto::meta::OK, response.header().status().code());
     EXPECT_EQ(0, response.item_results_size());
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
-    EXPECT_FALSE(response.snapshot_required());
+    EXPECT_TRUE(response.snapshot_required());
     EXPECT_TRUE(QueryEventReportUris({94'437, 94'438, 94'439}).empty());
 }
 
@@ -3208,19 +3259,29 @@ TEST_F(CacheManagerTest, TestReportEventRestartKeepsHistoricalCacheAndAcceptsDel
         CallReportEvent(MakeAddRequest(host, realtime_key, "after_restart"), "first_delta_after_restart");
     ASSERT_EQ(EC_OK, delta_ec);
     EXPECT_EQ(proto::meta::OK, delta.header().status().code());
-    EXPECT_FALSE(delta.snapshot_required());
+    EXPECT_TRUE(delta.snapshot_required());
     ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(delta.committed_snapshot_version()));
     EXPECT_NE(previous_version, delta.committed_snapshot_version());
     EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
     EXPECT_TRUE(event_backend->IsNodeAvailable("test_instance", host));
 
-    const auto visible = QueryEventReportUris({historical_key, realtime_key});
-    ASSERT_EQ(2u, visible.size());
+    const int64_t followup_key = 94'433;
+    const auto [followup_ec, followup] =
+        CallReportEvent(MakeAddRequest(host, followup_key, "second_after_restart"), "second_delta_after_restart");
+    ASSERT_EQ(EC_OK, followup_ec);
+    EXPECT_FALSE(followup.snapshot_required());
+    EXPECT_EQ(delta.committed_snapshot_version(), followup.committed_snapshot_version());
+
+    const auto visible = QueryEventReportUris({historical_key, realtime_key, followup_key});
+    ASSERT_EQ(3u, visible.size());
     EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const std::string &uri) {
         return uri.find("source=before_restart") != std::string::npos;
     }));
     EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const std::string &uri) {
         return uri.find("source=after_restart") != std::string::npos;
+    }));
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const std::string &uri) {
+        return uri.find("source=second_after_restart") != std::string::npos;
     }));
 }
 
@@ -5483,7 +5544,7 @@ TEST_F(CacheManagerTest, TestReportEventFirstDeltaMetadataFailureReportsFailureA
     EXPECT_EQ(proto::meta::INTERNAL_ERROR, failed.item_results(0));
     const std::string generation = failed.committed_snapshot_version();
     EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(generation));
-    EXPECT_FALSE(failed.snapshot_required());
+    EXPECT_TRUE(failed.snapshot_required());
     EXPECT_EQ(generation, event_backend->GetSnapshotVersion({"test_instance", host}));
     EXPECT_TRUE(QueryEventReportUris({key}).empty());
 

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -376,6 +376,12 @@ public:
         return model_deployment;
     }
 
+    ModelDeployment createModelDeploymentWithEaglePop() {
+        ModelDeployment model_deployment = createModelDeployment();
+        model_deployment.set_use_eagle_pop(true);
+        return model_deployment;
+    }
+
     std::vector<LocationSpecInfo> createLocationSpecInfos() {
         std::vector<LocationSpecInfo> location_spec_infos = {
             LocationSpecInfo("tp0", 512),
@@ -6680,7 +6686,7 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
                                                instance_id,
                                                64,
                                                location_spec_infos,
-                                               createModelDeployment(),
+                                               createModelDeploymentWithEaglePop(),
                                                location_spec_groups,
                                                CacheManager::QueryType::QT_PREFIX_MATCH_WITH_MAMBA));
 
@@ -6722,9 +6728,11 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
     const std::string host_a = "10.0.1.1:8080";
     const std::string host_b = "10.0.1.2:8080";
     const std::string host_c = "10.0.1.3:8080";
+    const std::string host_e = "10.0.1.5:8080";
     InitializeEventReporter(instance_id, host_a, proto::meta::ST_EVENT_REPORT_L1P5);
     InitializeEventReporter(instance_id, host_b, proto::meta::ST_EVENT_REPORT_L1P5);
     InitializeEventReporter(instance_id, host_c, proto::meta::ST_EVENT_REPORT_L1P5);
+    InitializeEventReporter(instance_id, host_e, proto::meta::ST_EVENT_REPORT_L1P5);
 
     report_specs(host_a, 100, {"full_0", "linear_0", "linear_1"});
     report_specs(host_a, 200, {"full_0"});
@@ -6739,6 +6747,10 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
 
     report_specs(host_c, 100, {"full_0"});
     report_specs(host_c, 200, {"full_0"});
+
+    report_specs(host_e, 100, {"full_0", "linear_0", "linear_1"});
+    report_specs(host_e, 200, {"full_0", "linear_0", "linear_1"});
+    report_specs(host_e, 300, {"full_0", "linear_0", "linear_1"});
 
     const std::string host_d = "10.0.1.4:8080";
     InitializeEventReporter(instance_id, host_d, proto::meta::ST_EVENT_REPORT_L1P5);
@@ -6761,9 +6773,10 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
 
     auto expect_mamba_matches = [&](const std::vector<CacheManager::HostCacheMatch> &matches) {
         EXPECT_EQ(3, find_prefix(matches, host_a));
-        EXPECT_EQ(4, find_prefix(matches, host_b));
+        EXPECT_EQ(-1, find_prefix(matches, host_b));
         EXPECT_EQ(-1, find_prefix(matches, host_c));
         EXPECT_EQ(-1, find_prefix(matches, host_d));
+        EXPECT_EQ(2, find_prefix(matches, host_e));
     };
     expect_mamba_matches(hosts);
 
@@ -6771,10 +6784,11 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
     auto [explicit_ec, explicit_hosts] = cache_manager_->GetHostCacheState(
         request_context_.get(), instance_id, CacheManager::QueryType::QT_PREFIX_MATCH, keys);
     ASSERT_EQ(EC_OK, explicit_ec);
-    EXPECT_EQ(4, find_prefix(explicit_hosts, host_a));
-    EXPECT_EQ(4, find_prefix(explicit_hosts, host_b));
-    EXPECT_EQ(2, find_prefix(explicit_hosts, host_c));
+    EXPECT_EQ(3, find_prefix(explicit_hosts, host_a));
+    EXPECT_EQ(3, find_prefix(explicit_hosts, host_b));
+    EXPECT_EQ(1, find_prefix(explicit_hosts, host_c));
     EXPECT_EQ(-1, find_prefix(explicit_hosts, host_d));
+    EXPECT_EQ(2, find_prefix(explicit_hosts, host_e));
 
     auto [fallback_ec, fallback_hosts] = cache_manager_->GetHostCacheState(
         request_context_.get(), instance_id, CacheManager::QueryType::QT_UNSPECIFIED, keys);
@@ -6786,10 +6800,11 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
         auto [break_ec, break_hosts] = cache_manager_->GetHostCacheState(
             request_context_.get(), instance_id, CacheManager::QueryType::QT_PREFIX_MATCH_WITH_MAMBA, break_keys);
         ASSERT_EQ(EC_OK, break_ec);
-        EXPECT_EQ(1, find_prefix(break_hosts, host_a));
+        EXPECT_EQ(-1, find_prefix(break_hosts, host_a));
         EXPECT_EQ(-1, find_prefix(break_hosts, host_b));
         EXPECT_EQ(-1, find_prefix(break_hosts, host_c));
         EXPECT_EQ(-1, find_prefix(break_hosts, host_d));
+        EXPECT_EQ(-1, find_prefix(break_hosts, host_e));
     }
 
     {
@@ -6800,10 +6815,11 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
                                               CacheManager::QueryType::QT_PREFIX_MATCH_WITH_MAMBA,
                                               keys_without_host_d_first);
         ASSERT_EQ(EC_OK, absent_ec);
-        EXPECT_EQ(3, find_prefix(absent_hosts, host_a));
+        EXPECT_EQ(1, find_prefix(absent_hosts, host_a));
         EXPECT_EQ(-1, find_prefix(absent_hosts, host_b));
         EXPECT_EQ(-1, find_prefix(absent_hosts, host_c));
         EXPECT_EQ(-1, find_prefix(absent_hosts, host_d));
+        EXPECT_EQ(2, find_prefix(absent_hosts, host_e));
     }
 
     dsm->storage_map_.erase("event_backend_mamba");

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -451,6 +451,7 @@ message ModelDeployment {
     int32 pp_size = 7;            // Pipeline模式下使用，Pipeline数量
     string extra = 8;             // 额外字段，用于标识模型，参与判断唯一标识校验
     string user_data = 9;        // 用户自定义数据，不参与判断唯一标识校验
+    bool use_eagle_pop = 10;     // EaglePop 模式下 full attention 前缀长度减一
 }
 
 message InstanceInfo {

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -147,8 +147,10 @@ message ReportEventResponse {
     // temporarily falls back to soft visibility until a later snapshot.
     string committed_snapshot_version = 3;
     uint64 retry_after_ms = 4;
-    // Advisory: true while this process has no generation yet. ADD/DELETE do
-    // not require an initial snapshot and may create the generation.
+    // Advisory: true while this process has no generation yet, and once on
+    // the ADD/DELETE request that lazily creates the first generation. The
+    // caller should schedule a full snapshot for reconciliation; realtime
+    // mutations remain accepted while that snapshot is pending.
     bool snapshot_required = 5;
     string extra_info = 6; // opaque JSON passed through from InstanceGroup
 }

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -184,6 +184,7 @@ message ModelDeployment {
     int32 pp_size = 7;            // Pipeline模式下使用，Pipeline数量
     string extra = 8;             // 额外字段，用于标识模型，参与判断唯一标识校验
     string user_data = 9;        // 用户自定义数据，不参与判断唯一标识校验
+    bool use_eagle_pop = 10;    // EaglePop 模式下 full attention 前缀长度减一
 }
 
 message LocationSpecGroup {

--- a/kv_cache_manager/service/util/manager_message_proto_util.h
+++ b/kv_cache_manager/service/util/manager_message_proto_util.h
@@ -177,6 +177,7 @@ void ProtoConvert::ModelDeploymentToProto(const ModelDeployment &model_deploymen
     proto_model_deployment->set_pp_size(model_deployment_info.pp_size());
     proto_model_deployment->set_extra(model_deployment_info.extra());
     proto_model_deployment->set_user_data(model_deployment_info.user_data());
+    proto_model_deployment->set_use_eagle_pop(model_deployment_info.use_eagle_pop());
 }
 // DONE
 template <typename T>
@@ -193,6 +194,7 @@ void ProtoConvert::ModelDeploymentFromProto(const T *proto_model_deployment, Mod
     model_deployment_info.set_pp_size(proto_model_deployment->pp_size());
     model_deployment_info.set_extra(proto_model_deployment->extra());
     model_deployment_info.set_user_data(proto_model_deployment->user_data());
+    model_deployment_info.set_use_eagle_pop(proto_model_deployment->use_eagle_pop());
 }
 // DONE
 template <typename T>

--- a/kv_cache_manager/service/util/test/BUILD
+++ b/kv_cache_manager/service/util/test/BUILD
@@ -11,6 +11,8 @@ cc_test(
     deps = [
         ":service_util_test_cc_proto",
         "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+        "//kv_cache_manager/service/util:manager_message_proto_util",
         "//kv_cache_manager/service/util:proto_message_json_util",
     ],
 )

--- a/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
@@ -1,6 +1,8 @@
 #include <algorithm>
 
 #include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/protocol/protobuf/meta_service.pb.h"
+#include "kv_cache_manager/service/util/manager_message_proto_util.h"
 #include "service/util/proto_message_json_util.h"
 #include "service/util/test/service_util_test.pb.h"
 
@@ -435,6 +437,31 @@ TEST_F(ProtoMessageJsonUtilTest, TestFromJsonRepeated) {
             ASSERT_EQ("hello", msg.oneofvec(2).v3().stringvalue());
         }
     }
+}
+
+} // namespace kv_cache_manager
+
+namespace kv_cache_manager {
+
+TEST_F(ProtoMessageJsonUtilTest, TestModelDeploymentUseEaglePopConversion) {
+    ModelDeployment default_model_deployment;
+    EXPECT_FALSE(default_model_deployment.use_eagle_pop());
+
+    proto::meta::ModelDeployment proto_model_deployment;
+    proto_model_deployment.set_model_name("m");
+    proto_model_deployment.set_dtype("fp8");
+    proto_model_deployment.set_use_eagle_pop(false);
+
+    ModelDeployment model_deployment;
+    ProtoConvert::ModelDeploymentFromProto(&proto_model_deployment, model_deployment);
+    EXPECT_FALSE(model_deployment.use_eagle_pop());
+
+    ProtoConvert::ModelDeploymentToProto(model_deployment, &proto_model_deployment);
+    EXPECT_FALSE(proto_model_deployment.use_eagle_pop());
+
+    proto_model_deployment.set_use_eagle_pop(true);
+    ProtoConvert::ModelDeploymentFromProto(&proto_model_deployment, model_deployment);
+    EXPECT_TRUE(model_deployment.use_eagle_pop());
 }
 
 } // namespace kv_cache_manager

--- a/tools/scripts/get_host_cache_state_stress.sh
+++ b/tools/scripts/get_host_cache_state_stress.sh
@@ -26,6 +26,7 @@ MEDIUM="${MEDIUM:-mem}"
 SECONDARY_MEDIUM="${SECONDARY_MEDIUM:-disk}"
 FULL_SPEC_NAME="${FULL_SPEC_NAME:-full_attention}"
 MAMBA_SPEC_NAME="${MAMBA_SPEC_NAME:-mamba_state}"
+USE_EAGLE_POP="${USE_EAGLE_POP:-0}"
 EVENT_HEARTBEAT_TIMEOUT_MS="${EVENT_HEARTBEAT_TIMEOUT_MS:-300000}"
 EVENT_CLEANUP_GRACE_MS="${EVENT_CLEANUP_GRACE_MS:-300000}"
 EVENT_LIVENESS_CHECK_INTERVAL_MS="${EVENT_LIVENESS_CHECK_INTERVAL_MS:-5000}"
@@ -105,6 +106,8 @@ DATA MODEL
                            default: full_attention
   MAMBA_SPEC_NAME          Mamba/linear LocationSpec name
                            default: mamba_state
+  USE_EAGLE_POP            Register model_deployment.use_eagle_pop as true when set to 1.
+                           default: 0, preserving existing stress expectations
   EVENT_HEARTBEAT_TIMEOUT_MS
                            Synthetic event-report node heartbeat timeout.
                            Increase this for long read stress runs.
@@ -313,6 +316,7 @@ build_register_payload() {
         --arg instance "$INSTANCE_ID" \
         --arg full_spec "$FULL_SPEC_NAME" \
         --arg mamba_spec "$MAMBA_SPEC_NAME" \
+        --argjson use_eagle_pop "$USE_EAGLE_POP" \
         '{
             trace_id: $trace,
             instance_group: $group,
@@ -324,7 +328,8 @@ build_register_payload() {
                 use_mla: false,
                 tp_size: 1,
                 dp_size: 1,
-                pp_size: 1
+                pp_size: 1,
+                use_eagle_pop: ($use_eagle_pop == 1)
             },
             location_spec_infos: [
                 {name: "tp0", size: 1024},


### PR DESCRIPTION
## Summary

- Add authoritative snapshot reconciliation for event reporting so cache state can be rebuilt from a complete snapshot.
- Harden snapshot lifecycle, generation handling, and query fencing against stale or reordered updates.
- Request a snapshot when the first delta creates a generation, and allow snapshot reporting without waiting for the Redis flush path.
- Expose the new behavior through the meta-service protocol, manager/config plumbing, metrics, documentation, and operations tooling.
- Add `use_eagle_pop` to `RegisterInstance` and propagate it through the manager/config path.

## Validation coverage

- Add and extend event-report unit tests for the backend, cache manager, meta searcher, scheduling, storage config, metrics, and service utilities.
- Add integration coverage for snapshot reconciliation, restart behavior, and report-event flows.
- Add load/stress tooling and related tests for event reporting and host cache state queries.

## Notes

- This PR contains 6 commits and changes 68 files.
- Tests were not run as part of creating this PR.