### PR TITLE
[optimizer] add fixed per-group TTL to LiteHit replay and online serving

### DIFF
--- a/kv_cache_manager/optimizer/docs/optimizer_architecture.md
+++ b/kv_cache_manager/optimizer/docs/optimizer_architecture.md
@@ -154,7 +154,7 @@ kv_cache_manager/optimizer/
 
 在线服务协议定义在 `kv_cache_manager/protocol/protobuf/optimizer_service.proto`，由 service 层转换为 optimizer online config/runtime 对象。
 
-full-attention TraceQuery 只把完整 block 放入 `block_keys`，并用 `input_token_len` 传入包含尾部 token 的原始输入长度。Online Manager 用 full location spec group 的固定字节 charge 将 `capacity_gb` 向下取整为 block 容量，再把同一请求交给 LiteHit；请求级与累计命中率均为 `prefix_hit_blocks * block_size_tokens / input_tokens`。旧客户端缺少长度时兼容假设没有尾部 token。第一阶段 full-attention + TTL 不支持；linear attention 的统计口径和 TTL 行为保持 legacy 路径不变。
+full-attention TraceQuery 只把完整 block 放入 `block_keys`，并用 `input_token_len` 传入包含尾部 token 的原始输入长度。Online Manager 用 full location spec group 的固定字节 charge 将 `capacity_gb` 向下取整为 block 容量，再把同一请求交给 LiteHit；请求级与累计命中率均为 `prefix_hit_blocks * block_size_tokens / input_tokens`。旧客户端缺少长度时兼容假设没有尾部 token。full-attention 组配置 `ttl_seconds != 0` 时，固定 TTL 以墙钟时间叠加在 LiteHit 之上（口径与 `TtlCacheIndexerWrapper` 一致）；linear attention 的统计口径和 TTL 行为保持 legacy 路径不变。
 
 ---
 

--- a/kv_cache_manager/optimizer/liteHit/BUILD
+++ b/kv_cache_manager/optimizer/liteHit/BUILD
@@ -50,3 +50,4 @@ cc_library(
         ":hit_curve",
     ],
 )
+

--- a/kv_cache_manager/optimizer/liteHit/README.md
+++ b/kv_cache_manager/optimizer/liteHit/README.md
@@ -19,7 +19,7 @@ LiteHit 要解决的问题是：
 - full attention；
 - 每个完整 block 的 KVCache charge 相同（等 charge，见 6.4）；
 - 精确 LRU，请求内倒序提交；
-- 不处理 linear attention / Mamba、不同大小 block、TTL、admission、prefetch 和多级缓存策略。
+- 不处理 linear attention / Mamba、不同大小 block、admission、prefetch 和多级缓存策略；TTL 支持为"每组一个固定 TTL"叠加在 LRU 之上（见 §7 TTL 回放），不支持任意 TTL 的查询期扫描。
 
 ## 0. 架构总览
 
@@ -272,6 +272,8 @@ Offline runner（`lite_hit_main` + `OptimizerLiteHitConfig`）逐批处理标准
 
 **fanout 模式**：`fanout_all_instances = true` 时每条请求广播到全部 lane（各 lane 独立 LRU 状态、独立 facts 行），配合多个不同 `block_size` 的 instance 即可一次回放对同一份 trace 扫多个分析粒度；与 `override_instance_id` 互斥。facts query 的 summary 按 instance 分组输出（每 instance 一行 + 总计一行），fanout 结果直接可读。
 
+**TTL 回放**：instance group 配置 `ttl_seconds != 0` 时，该组 lane 的 `LiteHit` 核心叠加固定 TTL（与 online `TtlCacheIndexerWrapper` 语义一致：块在距上次访问严格小于 TTL 内存活，过期块对任意容量都是 miss 并像冷块一样截断前缀；每次访问（命中或未命中）都刷新 last_access；时间取 trace 时间戳，回放确定性）。年龄沿 LRU 栈单调，过期块不会抬高存活块的复用距离，因此一次回放对"固定 TTL × 任意容量"的联合口径仍然精确，facts 仍是普通 hit curve 行。TTL 是回放期参数，直接取组里的 `ttl_seconds`；要扫多个 TTL 就配多个 group 各带不同 `ttl_seconds`（可配合 fanout 一次回放完成）。
+
 **fail-fast**：时间戳乱序、未知 instance、长度校验失败、全文件零有效行，任一发生即整体失败并给出原因——facts 是全有或全无的对账账本，不允许静默丢行。
 
 **原子发布**：先写 `litehit_facts.csv.tmp`，全部成功后 `rename` 为 `litehit_facts.csv`；读者永远不会看到半成品。
@@ -301,7 +303,7 @@ trace_id,instance_id,timestamp_ns,input_token_len,block_size_tokens,block_bytes,
 
 ## 8. Online 集成
 
-Online Optimizer 的 full-attention `InstanceState` 直接持有 `LiteHit`。每次 TraceQuery：
+Online Optimizer 的 full-attention `InstanceState` 直接持有 `LiteHit`（组配置 `ttl_seconds != 0` 时以墙钟时间叠加固定 TTL，口径与 linear 路径的 `TtlCacheIndexerWrapper` 一致）。每次 TraceQuery：
 
 ```text
 NormalizeRequest → ProcessRequest → 得到 RequestFact

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.cc
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.cc
@@ -169,6 +169,20 @@ void LiteHit::MaybeCompactPositions() {
     for (PositionEpoch &epoch : position_epochs_) {
         epoch.start_position = remap_boundary(epoch.start_position);
     }
+    // Equal remapped starts prove there is no alive marker between the two
+    // epochs, so the earlier one governs an empty range and can be dropped
+    // without changing any future liveness answer. Keeping the last epoch per
+    // start bounds the deque by the alive working set (hot keys otherwise
+    // accumulate one empty epoch per request until the TTL elapses).
+    std::size_t deduped_size = 0;
+    for (const PositionEpoch &epoch : position_epochs_) {
+        if (deduped_size > 0 && position_epochs_[deduped_size - 1].start_position == epoch.start_position) {
+            position_epochs_[deduped_size - 1].timestamp_ns = epoch.timestamp_ns;
+        } else {
+            position_epochs_[deduped_size++] = epoch;
+        }
+    }
+    position_epochs_.resize(deduped_size);
     if (dead_below_position_ > 0) {
         dead_below_position_ = remap_boundary(dead_below_position_);
     }

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.cc
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.cc
@@ -11,11 +11,26 @@ constexpr std::size_t kCompactionSlackPositions = 4096;
 
 } // namespace
 
-RequestFact LiteHit::ProcessRequest(const std::vector<int64_t> &block_keys) {
+RequestFact LiteHit::ProcessRequest(const std::vector<int64_t> &block_keys, int64_t now_ns) {
+    if (ttl_ns_ > 0) {
+        AdvanceTtlWatermark(now_ns);
+    }
     RequestFact fact = BuildHitCurve(block_keys);
-    CommitRequest(block_keys);
+    CommitRequest(block_keys, now_ns);
     MaybeCompactPositions();
     return fact;
+}
+
+void LiteHit::AdvanceTtlWatermark(int64_t now_ns) {
+    // Strict boundary: an epoch whose deadline has been reached is dead,
+    // matching the online TtlCacheIndexerWrapper harvest. Every position of
+    // a dead epoch is below the next epoch's start (or below everything when
+    // it is the last one).
+    while (!position_epochs_.empty() &&
+           position_epochs_.front().timestamp_ns <= now_ns - static_cast<int64_t>(ttl_ns_)) {
+        position_epochs_.pop_front();
+        dead_below_position_ = position_epochs_.empty() ? fenwick_.size() + 1 : position_epochs_.front().start_position;
+    }
 }
 
 RequestFact LiteHit::BuildHitCurve(const std::vector<int64_t> &block_keys) const {
@@ -25,8 +40,8 @@ RequestFact LiteHit::BuildHitCurve(const std::vector<int64_t> &block_keys) const
     }
 
     // All ranks are read from one immutable request-start snapshot. Repeated
-    // keys reuse the same snapshot entry. A cold key stops every capacity's
-    // prefix, so its later occurrence cannot revive the prefix.
+    // keys reuse the same snapshot entry. A cold or expired key stops every
+    // capacity's prefix, so its later occurrence cannot revive the prefix.
     std::unordered_map<int64_t, SnapshotEntry> snapshot_entries;
     snapshot_entries.reserve(block_keys.size());
     for (int64_t block_key : block_keys) {
@@ -35,7 +50,7 @@ RequestFact LiteHit::BuildHitCurve(const std::vector<int64_t> &block_keys) const
             continue;
         }
         const auto previous = last_positions_.find(block_key);
-        if (previous != last_positions_.end()) {
+        if (previous != last_positions_.end() && previous->second >= dead_below_position_) {
             entry_it->second.is_resident = true;
             entry_it->second.required_blocks = ReuseDistance(previous->second) + 1;
         }
@@ -66,9 +81,21 @@ RequestFact LiteHit::BuildHitCurve(const std::vector<int64_t> &block_keys) const
     return fact;
 }
 
-void LiteHit::CommitRequest(const std::vector<int64_t> &block_keys) {
+void LiteHit::CommitRequest(const std::vector<int64_t> &block_keys, int64_t now_ns) {
     if (block_keys.empty()) {
         return;
+    }
+
+    if (ttl_ns_ > 0) {
+        // Positions appended below belong to this commit's epoch. Merge with
+        // the previous epoch when the timestamp did not advance; clamp a
+        // defensively out-of-order timestamp so the deque stays monotone
+        // (equivalent to the age-clamp of a per-key timestamp table).
+        const int64_t epoch_ns =
+            position_epochs_.empty() ? now_ns : std::max(now_ns, position_epochs_.back().timestamp_ns);
+        if (position_epochs_.empty() || position_epochs_.back().timestamp_ns != epoch_ns) {
+            position_epochs_.push_back(PositionEpoch{fenwick_.size() + 1, epoch_ns});
+        }
     }
 
     // State commits tail-to-head: sequentially touching the request in
@@ -120,6 +147,24 @@ void LiteHit::MaybeCompactPositions() {
     }
     std::sort(ordered_positions.begin(), ordered_positions.end());
 
+    // Old position boundary S maps to (surviving markers below S) + 1; the
+    // mapping is monotone, so epoch starts and the watermark keep their
+    // order and semantics.
+    const auto remap_boundary = [&ordered_positions](std::size_t old_position) -> std::size_t {
+        const auto it = std::lower_bound(
+            ordered_positions.begin(),
+            ordered_positions.end(),
+            old_position,
+            [](const std::pair<std::size_t, int64_t> &entry, std::size_t value) { return entry.first < value; });
+        return static_cast<std::size_t>(it - ordered_positions.begin()) + 1;
+    };
+    for (PositionEpoch &epoch : position_epochs_) {
+        epoch.start_position = remap_boundary(epoch.start_position);
+    }
+    if (dead_below_position_ > 0) {
+        dead_below_position_ = remap_boundary(dead_below_position_);
+    }
+
     DynamicFenwickTree compacted_fenwick;
     for (const auto &[_, block_key] : ordered_positions) {
         compacted_fenwick.AppendZero();
@@ -137,6 +182,8 @@ uint64_t LiteHit::ReuseDistance(std::size_t previous_position) const {
 void LiteHit::Reset() {
     fenwick_.Clear();
     last_positions_.clear();
+    position_epochs_.clear();
+    dead_below_position_ = 0;
 }
 
 uint64_t LiteHit::memory_usage_bytes() const {
@@ -145,6 +192,7 @@ uint64_t LiteHit::memory_usage_bytes() const {
     constexpr uint64_t kEstimatedHashNodeOverhead = sizeof(void *) * 2;
     bytes += static_cast<uint64_t>(last_positions_.size()) *
              (sizeof(std::pair<const int64_t, std::size_t>) + kEstimatedHashNodeOverhead);
+    bytes += static_cast<uint64_t>(position_epochs_.size()) * sizeof(PositionEpoch);
     return bytes;
 }
 

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.cc
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.cc
@@ -131,7 +131,7 @@ void LiteHit::CommitRequest(const std::vector<int64_t> &block_keys, int64_t now_
 }
 
 void LiteHit::MaybeCompactPositions() {
-    const std::size_t active_positions = last_positions_.size();
+    const std::size_t active_positions = static_cast<std::size_t>(alive_marker_count());
     if (fenwick_.size() <= kCompactionSlackPositions) {
         return;
     }
@@ -140,10 +140,18 @@ void LiteHit::MaybeCompactPositions() {
         return;
     }
 
+    // Markers below the TTL watermark are a miss for every capacity forever,
+    // so compaction drops them together with their table entries; the state
+    // afterwards is bounded by the alive working set again.
     std::vector<std::pair<std::size_t, int64_t>> ordered_positions;
     ordered_positions.reserve(active_positions);
-    for (const auto &[block_key, position] : last_positions_) {
-        ordered_positions.emplace_back(position, block_key);
+    for (auto it = last_positions_.begin(); it != last_positions_.end();) {
+        if (it->second < dead_below_position_) {
+            it = last_positions_.erase(it);
+        } else {
+            ordered_positions.emplace_back(it->second, it->first);
+            ++it;
+        }
     }
     std::sort(ordered_positions.begin(), ordered_positions.end());
 
@@ -177,6 +185,14 @@ void LiteHit::MaybeCompactPositions() {
 
 uint64_t LiteHit::ReuseDistance(std::size_t previous_position) const {
     return fenwick_.PrefixSum(fenwick_.size()) - fenwick_.PrefixSum(previous_position);
+}
+
+uint64_t LiteHit::alive_marker_count() const {
+    const uint64_t total = fenwick_.PrefixSum(fenwick_.size());
+    if (dead_below_position_ <= 1) {
+        return total;
+    }
+    return total - fenwick_.PrefixSum(dead_below_position_ - 1);
 }
 
 void LiteHit::Reset() {

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.h
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <unordered_map>
 #include <vector>
 
@@ -15,17 +16,37 @@ namespace kv_cache_manager {
 // capacity-independent facts (RequestFact); it never receives a capacity
 // list and never accumulates per-capacity results. Any capacity is answered
 // afterwards by projecting the facts with HitCurveProjector.
+//
+// An optional fixed TTL adds the online TtlCacheIndexerWrapper semantics on
+// top of the LRU stack: a block whose age since last access reached the TTL
+// is a miss for every capacity, every access (hit or miss) refreshes
+// last_access, and time is the caller-provided trace timestamp so the replay
+// stays deterministic. Ages are monotone along the LRU stack (younger blocks
+// are always fresher), so expired blocks never inflate the reuse distance of
+// alive ones and one replay stays exact for every capacity under the fixed
+// TTL.
+//
+// The TTL needs no per-key timestamps: marker positions are assigned
+// monotonically, so a block's last access time is the commit time of the
+// request that assigned its current position. A small epoch deque maps
+// position ranges to commit timestamps; expired epochs advance a single
+// dead-below watermark and liveness is one integer comparison. The extra
+// state is O(distinct commit timestamps inside one TTL window), independent
+// of the number of unique blocks.
 class LiteHit {
 public:
-    LiteHit() = default;
+    // ttl_ns == 0 disables the TTL (pure LRU).
+    explicit LiteHit(uint64_t ttl_ns = 0) : ttl_ns_(ttl_ns) {}
 
     // One call is one request boundary. block_keys must be the normalized
     // prefix-chained keys of all complete blocks of the request, in request
     // order; input length parsing, validation, and prefix hashing happen in
-    // the shared preprocessing outside the core.
+    // the shared preprocessing outside the core. now_ns is the request trace
+    // timestamp (time-sorted); it is only consulted when a TTL is configured.
     //
     // Phase 1 evaluates the prefix hit curve against the request-start LRU
-    // snapshot. Phase 2 commits every complete block tail-to-head (reverse
+    // snapshot; with a TTL an expired block stops the prefix like a cold
+    // one. Phase 2 commits every complete block tail-to-head (reverse
     // request order), including blocks after the first miss. With
     // prefix-chained keys a chain head is therefore always newer than its
     // resident descendants, so the global LRU victim is always a leaf,
@@ -37,9 +58,11 @@ public:
     // input (duplicate keys inside a request) is first defensively merged to
     // its longest prefix per threshold and then encoded monotonically; the
     // projection is never optimistic.
-    RequestFact ProcessRequest(const std::vector<int64_t> &block_keys);
+    RequestFact ProcessRequest(const std::vector<int64_t> &block_keys, int64_t now_ns = 0);
 
     void Reset();
+
+    uint64_t ttl_ns() const { return ttl_ns_; }
 
     uint64_t current_unique_blocks() const { return static_cast<uint64_t>(last_positions_.size()); }
 
@@ -53,13 +76,28 @@ private:
         uint64_t required_blocks = 0;
     };
 
+    // Positions in [start_position, next epoch's start_position) were
+    // assigned by a commit at timestamp_ns; timestamps are non-decreasing
+    // along the deque.
+    struct PositionEpoch {
+        std::size_t start_position = 0;
+        int64_t timestamp_ns = 0;
+    };
+
     RequestFact BuildHitCurve(const std::vector<int64_t> &block_keys) const;
-    void CommitRequest(const std::vector<int64_t> &block_keys);
+    void CommitRequest(const std::vector<int64_t> &block_keys, int64_t now_ns);
     void MaybeCompactPositions();
     uint64_t ReuseDistance(std::size_t previous_position) const;
+    // Pops expired epochs and advances dead_below_position_.
+    void AdvanceTtlWatermark(int64_t now_ns);
 
+    uint64_t ttl_ns_ = 0;
     DynamicFenwickTree fenwick_;
     std::unordered_map<int64_t, std::size_t> last_positions_;
+    // TTL state (empty when ttl_ns_ == 0): markers below the watermark are
+    // expired.
+    std::deque<PositionEpoch> position_epochs_;
+    std::size_t dead_below_position_ = 0;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.h
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.h
@@ -64,6 +64,15 @@ public:
 
     uint64_t ttl_ns() const { return ttl_ns_; }
 
+    // Advances the TTL watermark to now_ns without processing a request, so
+    // observability reads reflect the current time instead of the last
+    // request's. No-op without a TTL.
+    void AdvanceTime(int64_t now_ns) {
+        if (ttl_ns_ > 0) {
+            AdvanceTtlWatermark(now_ns);
+        }
+    }
+
     // Unique blocks currently alive: expired markers below the TTL watermark
     // are excluded even though their table entries linger until compaction.
     uint64_t current_unique_blocks() const { return alive_marker_count(); }

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.h
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.h
@@ -64,7 +64,9 @@ public:
 
     uint64_t ttl_ns() const { return ttl_ns_; }
 
-    uint64_t current_unique_blocks() const { return static_cast<uint64_t>(last_positions_.size()); }
+    // Unique blocks currently alive: expired markers below the TTL watermark
+    // are excluded even though their table entries linger until compaction.
+    uint64_t current_unique_blocks() const { return alive_marker_count(); }
 
     // Coarse memory estimate for observability. It is derived from the state
     // already required by the algorithm and does not retain extra trace data.
@@ -88,6 +90,9 @@ private:
     void CommitRequest(const std::vector<int64_t> &block_keys, int64_t now_ns);
     void MaybeCompactPositions();
     uint64_t ReuseDistance(std::size_t previous_position) const;
+    // Resident markers at or above the TTL watermark (all markers when no
+    // watermark is active).
+    uint64_t alive_marker_count() const;
     // Pops expired epochs and advances dead_below_position_.
     void AdvanceTtlWatermark(int64_t now_ns);
 

--- a/kv_cache_manager/optimizer/manager/lite_hit_offline_runner.cc
+++ b/kv_cache_manager/optimizer/manager/lite_hit_offline_runner.cc
@@ -30,7 +30,10 @@ namespace {
 
 // One per-instance replay lane. LiteHit state updates are serial inside a
 // lane; preprocessing and row formatting are parallel across the batch.
+// A group with ttl_seconds > 0 layers that fixed TTL onto the lane's core.
 struct InstanceLane {
+    explicit InstanceLane(uint64_t ttl_ns) : core(ttl_ns) {}
+
     LiteHit core;
     uint64_t block_size_tokens = 0;
     uint64_t block_bytes = 0;
@@ -128,13 +131,14 @@ bool LiteHitOfflineRunner::Run() {
                            static_cast<int>(ec));
             return false;
         }
-        auto lane = std::make_unique<InstanceLane>();
-        lane->block_size_tokens = static_cast<uint64_t>(instance.block_size());
-        lane->block_bytes = static_cast<uint64_t>(register_result.size_full_only);
         // Key shape follows the model deployment, so the switch lives on the
         // instance group and applies to every instance in it. RegisterInstance
         // already guaranteed the group exists.
-        lane->enable_prefix_hash = groups_by_name.at(instance.instance_group_name())->enable_prefix_hash();
+        const OptimizerInstanceGroup &group = *groups_by_name.at(instance.instance_group_name());
+        auto lane = std::make_unique<InstanceLane>(static_cast<uint64_t>(group.ttl_seconds()) * 1000000000ULL);
+        lane->block_size_tokens = static_cast<uint64_t>(instance.block_size());
+        lane->block_bytes = static_cast<uint64_t>(register_result.size_full_only);
+        lane->enable_prefix_hash = group.enable_prefix_hash();
         if (!lanes.emplace(instance.instance_id(), std::move(lane)).second) {
             KVCM_LOG_ERROR("LiteHitOfflineRunner: duplicate instance_id[%s] in config", instance.instance_id().c_str());
             return false;
@@ -207,7 +211,7 @@ bool LiteHitOfflineRunner::Run() {
         // Lane commits stay in input order; only same-lane order is
         // semantically required, and input order trivially satisfies it.
         for (BatchItem &item : batch) {
-            item.record.fact = item.lane->core.ProcessRequest(item.normalized.block_keys);
+            item.record.fact = item.lane->core.ProcessRequest(item.normalized.block_keys, item.record.timestamp_ns);
         }
 
         ParallelForIndex(batch.size(), worker_count, [&](std::size_t i) {

--- a/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
+++ b/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/optimizer/config/optimizer_registry_manager.h"
 #include "kv_cache_manager/optimizer/index/online/cache_indexer_factory.h"
 #include "kv_cache_manager/optimizer/liteHit/hit_curve.h"
@@ -269,11 +270,6 @@ ErrorCode OnlineOptimizerManager::RegisterInstanceInternal(const OptimizerInstan
         KVCM_LOG_ERROR("RegisterInstance failed: negative TTL for instance[%s]", instance_id.c_str());
         return EC_BADARGS;
     }
-    if (linear_step == 0 && instance_group.ttl_seconds() > 0) {
-        KVCM_LOG_ERROR("RegisterInstance failed: LiteHit full-attention mode does not support TTL for instance[%s]",
-                       instance_id.c_str());
-        return EC_BADARGS;
-    }
 
     const auto &optimizer_state_info = instance_info.optimizer_state_info();
     if (optimizer_state_info.full_location_spec_group_name().empty()) {
@@ -359,7 +355,10 @@ ErrorCode OnlineOptimizerManager::RegisterInstanceInternal(const OptimizerInstan
 
     if (linear_step == 0) {
         state->lite_hit_capacity_blocks = estimated_capacity_blocks;
-        state->lite_hit = std::make_unique<LiteHit>();
+        // A group TTL is layered onto the LiteHit core; online time is the
+        // wall clock, mirroring the linear-path TtlCacheIndexerWrapper.
+        state->lite_hit =
+            std::make_unique<LiteHit>(static_cast<uint64_t>(instance_group.ttl_seconds()) * 1000000000ULL);
     } else {
         auto indexer = CacheIndexerFactory::CreateCacheIndexer(instance_group.eviction_policy(),
                                                                instance_group.enable_theoretical_max_cache(),
@@ -483,7 +482,8 @@ ErrorCode OnlineOptimizerManager::TraceQuery(const std::string &instance_id,
             return EC_BADARGS;
         }
 
-        const RequestFact fact = state->lite_hit->ProcessRequest(normalized.block_keys);
+        const RequestFact fact =
+            state->lite_hit->ProcessRequest(normalized.block_keys, TimestampUtil::GetCurrentTimeUs() * 1000);
         result.input_token_len = ClampToInt64(normalized.input_token_len);
 
         const uint64_t block_size = static_cast<uint64_t>(state->instance_info->block_size());

--- a/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
+++ b/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
@@ -596,6 +596,10 @@ ErrorCode OnlineOptimizerManager::ListInstances(const std::string &instance_grou
             }
             s.total_queries = state->total_queries;
             s.total_input_tokens = state->total_input_tokens;
+            // Summaries arrive without traffic; advance the TTL watermark so
+            // idle instances report the alive set as of now, not as of the
+            // last request.
+            state->lite_hit->AdvanceTime(static_cast<int64_t>(TimestampUtil::GetCurrentTimeUs()) * 1000);
             s.unique_keys = ClampToInt64(state->lite_hit->current_unique_blocks());
             s.memory_usage_bytes = ClampToInt64(state->lite_hit->memory_usage_bytes());
 

--- a/kv_cache_manager/optimizer/test/BUILD
+++ b/kv_cache_manager/optimizer/test/BUILD
@@ -171,6 +171,19 @@ cc_test(
 )
 
 cc_test(
+    name = "LiteHitTtlTest",
+    srcs = [
+        "lite_hit_ttl_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/optimizer/liteHit:hit_curve",
+        "//kv_cache_manager/optimizer/liteHit:lite_hit",
+    ],
+)
+
+cc_test(
     name = "LiteHitOfflineRunnerTest",
     srcs = [
         "lite_hit_offline_runner_test.cc",

--- a/kv_cache_manager/optimizer/test/lite_hit_offline_runner_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_offline_runner_test.cc
@@ -122,6 +122,65 @@ TEST_F(LiteHitOfflineRunnerTest, FactsCsvRowRoundTrips) {
     EXPECT_FALSE(ParseLiteHitFactRow("t,i,x,2,3,4,\"[]\"", bad, error));
 }
 
+TEST_F(LiteHitOfflineRunnerTest, TtlGroupLayersTtlOntoTheHitCurve) {
+    // Group TTL is 3s; timestamps in ns make ages 2s/1s/3s at the later
+    // requests. TTL rows are ordinary hit-curve facts: the fixed TTL was
+    // applied during the replay, the capacity axis stays queryable.
+    const std::string trace_path = WriteTrace("facts_ttl.jsonl",
+                                              {
+                                                  TraceLine("i1", "r1", 1000000000, {1, 2, 3}, 13),
+                                                  TraceLine("i1", "r2", 3000000000, {1, 2, 9}, 12),
+                                                  TraceLine("i1", "r3", 4000000000, {1, 2, 3}, 13),
+                                              });
+    const std::string output_dir = GetTestTempRootPath() + "/ttl";
+    ASSERT_EQ(0, ::system(("mkdir -p " + output_dir).c_str()));
+    OptimizerLiteHitConfig config = MakeConfig(trace_path, output_dir);
+    OptimizerInstanceGroup group = MakeGroup();
+    group.set_ttl_seconds(3);
+    config.set_instance_groups({group});
+    ASSERT_TRUE(LiteHitOfflineRunner(config).Run());
+
+    const std::vector<std::string> lines = ReadLines(output_dir + "/" + kLiteHitFactsFileName);
+    ASSERT_EQ(4, lines.size());
+    std::string error;
+    LiteHitFactRecord r1;
+    ASSERT_TRUE(ParseLiteHitFactRow(lines[1], r1, error)) << error;
+    EXPECT_TRUE(r1.fact.hit_curve.empty()); // cold
+
+    LiteHitFactRecord r2;
+    ASSERT_TRUE(ParseLiteHitFactRow(lines[2], r2, error)) << error;
+    // Blocks 1,2 are 2s old (alive); 9 was never seen.
+    EXPECT_EQ((std::vector<HitCurveSegment>{{1, 2}}), r2.fact.hit_curve);
+
+    LiteHitFactRecord r3;
+    ASSERT_TRUE(ParseLiteHitFactRow(lines[3], r3, error)) << error;
+    // Blocks 1,2 refreshed by r2 (1s old); block 3 is 3s old: deadline
+    // reached, the prefix stops there for every capacity. Without the TTL
+    // this request would produce thresholds 1,2,4.
+    EXPECT_EQ((std::vector<HitCurveSegment>{{1, 2}}), r3.fact.hit_curve);
+
+    // Capacity stays a query-time axis on top of the fixed TTL.
+    const double capacity_1_block_gb = 16384.0 / (1024.0 * 1024.0 * 1024.0);
+    const std::string query_log = output_dir + "/query.jsonl";
+    ASSERT_TRUE(
+        RunLiteHitFactsQuery(output_dir + "/" + kLiteHitFactsFileName, {capacity_1_block_gb, -1.0}, query_log, error))
+        << error;
+    const std::vector<std::string> query_lines = ReadLines(query_log);
+    ASSERT_EQ(5, query_lines.size()); // 3 requests + i1 summary + overall
+    EXPECT_NE(std::string::npos, query_lines[2].find("\"hit_blocks\":[1,2]"));
+    EXPECT_NE(std::string::npos, query_lines[4].find("\"total_hit_blocks\":[2,4]"));
+    EXPECT_NE(std::string::npos, query_lines[4].find("\"total_input_tokens\":38"));
+}
+
+TEST_F(LiteHitOfflineRunnerTest, RejectsNegativeTtlGroup) {
+    const std::string trace_path = WriteTrace("facts_ttl_bad.jsonl", {TraceLine("i1", "r1", 1000, {1}, 4)});
+    OptimizerLiteHitConfig config = MakeConfig(trace_path, GetTestTempRootPath());
+    OptimizerInstanceGroup group = MakeGroup();
+    group.set_ttl_seconds(-1);
+    config.set_instance_groups({group});
+    EXPECT_FALSE(LiteHitOfflineRunner(config).Run());
+}
+
 TEST_F(LiteHitOfflineRunnerTest, PublishesFactsAndMatchesOnlineReplay) {
     const std::string trace_path = WriteTrace("facts_ok.jsonl",
                                               {

--- a/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
@@ -1,0 +1,141 @@
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/optimizer/liteHit/hit_curve.h"
+#include "kv_cache_manager/optimizer/liteHit/lite_hit.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+// Naive joint LRU+TTL reference. Recency is a most-recent-first list; the
+// hit prefix under (capacity C, fixed TTL) is the longest prefix whose
+// blocks are all seen, alive (age strictly below TTL) and within the top C
+// of the recency stack on the request-start snapshot. Commits touch
+// tail-to-head (chain head most recent) and refresh last_access for every
+// block, matching the LiteHit contract and the online TTL wrapper.
+class NaiveLruTtlOracle {
+public:
+    uint64_t Evaluate(const std::vector<int64_t> &keys, int64_t now_ns, uint64_t ttl_ns, uint64_t capacity) const {
+        uint64_t hits = 0;
+        for (int64_t key : keys) {
+            const auto it = last_access_.find(key);
+            if (it == last_access_.end()) {
+                break;
+            }
+            const uint64_t age = it->second < now_ns ? static_cast<uint64_t>(now_ns - it->second) : 0;
+            if (age >= ttl_ns) {
+                break;
+            }
+            const auto pos = std::find(recency_.begin(), recency_.end(), key);
+            const uint64_t rank = static_cast<uint64_t>(pos - recency_.begin()) + 1;
+            if (rank > capacity) {
+                break;
+            }
+            ++hits;
+        }
+        return hits;
+    }
+
+    void Commit(const std::vector<int64_t> &keys, int64_t now_ns) {
+        for (std::size_t i = keys.size(); i > 0; --i) {
+            const int64_t key = keys[i - 1];
+            const auto pos = std::find(recency_.begin(), recency_.end(), key);
+            if (pos != recency_.end()) {
+                recency_.erase(pos);
+            }
+            recency_.insert(recency_.begin(), key);
+            last_access_[key] = now_ns;
+        }
+    }
+
+private:
+    std::vector<int64_t> recency_;
+    std::unordered_map<int64_t, int64_t> last_access_;
+};
+
+} // namespace
+
+class LiteHitTtlTest : public TESTBASE {};
+
+TEST_F(LiteHitTtlTest, StrictDeadlineBoundary) {
+    LiteHit core(2000);
+    EXPECT_TRUE(core.ProcessRequest({1, 2, 3}, 1000).hit_curve.empty()); // cold
+    // Ages 1999 < 2000: alive, normal LRU curve.
+    EXPECT_EQ((std::vector<HitCurveSegment>{{1, 3}}), core.ProcessRequest({1, 2, 3}, 2999).hit_curve);
+    // Ages exactly 2000: deadline reached, miss (matches the online wrapper).
+    EXPECT_TRUE(core.ProcessRequest({1, 2, 3}, 4999).hit_curve.empty());
+    // The expired access still refreshed last_access.
+    EXPECT_EQ(3, HitCurveProjector::ProjectInfinite(core.ProcessRequest({1, 2, 3}, 5000)));
+}
+
+TEST_F(LiteHitTtlTest, ExpiredBlockStopsThePrefixLikeAColdOne) {
+    LiteHit core(2500);
+    core.ProcessRequest({10, 11}, 1000);
+    core.ProcessRequest({10, 11, 12}, 3000); // all refreshed at 3000
+    // At 5600 every block is 2600 old: dead despite being LRU-resident.
+    EXPECT_TRUE(core.ProcessRequest({10, 11, 12}, 5600).hit_curve.empty());
+}
+
+TEST_F(LiteHitTtlTest, TtlZeroIsPureLru) {
+    LiteHit core; // default: no TTL, timestamps ignored
+    core.ProcessRequest({1, 2, 3}, 1000);
+    const RequestFact fact = core.ProcessRequest({1, 2, 3}, 1000000000000);
+    EXPECT_EQ((std::vector<HitCurveSegment>{{1, 3}}), fact.hit_curve);
+}
+
+TEST_F(LiteHitTtlTest, ResetClearsTtlState) {
+    LiteHit core(1000000);
+    core.ProcessRequest({1, 2}, 1000);
+    EXPECT_EQ(2, core.current_unique_blocks());
+    core.Reset();
+    EXPECT_EQ(0, core.current_unique_blocks());
+    EXPECT_TRUE(core.ProcessRequest({1, 2}, 2000).hit_curve.empty());
+}
+
+TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
+    std::mt19937_64 rng(20260730);
+    std::uniform_int_distribution<int64_t> base_dist(0, 12);
+    std::uniform_int_distribution<int> len_dist(1, 6);
+    std::uniform_int_distribution<int64_t> delta_dist(0, 100);
+    const std::vector<uint64_t> ttls = {1, 17, 50, 120, 1000};
+    const std::vector<uint64_t> capacities = {1, 2, 3, 5, 8, 1000000};
+
+    // One core per fixed TTL; commits are TTL-independent, so every core and
+    // the single oracle share the same recency and last-access evolution.
+    std::vector<std::unique_ptr<LiteHit>> cores;
+    for (uint64_t ttl : ttls) {
+        cores.push_back(std::make_unique<LiteHit>(ttl));
+    }
+    NaiveLruTtlOracle oracle;
+    int64_t now = 0;
+    for (int step = 0; step < 2000; ++step) {
+        now += delta_dist(rng);
+        // Prefix-chained keys: requests with the same base share prefixes,
+        // key base*100+i identifies the whole chain prefix.
+        const int64_t base = base_dist(rng);
+        const int len = len_dist(rng);
+        std::vector<int64_t> keys;
+        keys.reserve(len);
+        for (int i = 1; i <= len; ++i) {
+            keys.push_back(base * 100 + i);
+        }
+
+        for (std::size_t t = 0; t < ttls.size(); ++t) {
+            const RequestFact fact = cores[t]->ProcessRequest(keys, now);
+            for (uint64_t capacity : capacities) {
+                ASSERT_EQ(oracle.Evaluate(keys, now, ttls[t], capacity),
+                          HitCurveProjector::ProjectBlocks(fact, capacity))
+                    << "step " << step << " ttl " << ttls[t] << " capacity " << capacity;
+            }
+        }
+        oracle.Commit(keys, now);
+    }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
@@ -161,6 +161,24 @@ TEST_F(LiteHitTtlTest, CompactionCollapsesEmptyEpochs) {
     EXPECT_TRUE(core.ProcessRequest({7}, 10001 + 1000000000).hit_curve.empty());
 }
 
+TEST_F(LiteHitTtlTest, AdvanceTimeRefreshesUniqueCount) {
+    LiteHit core(1000);
+    core.ProcessRequest({1, 2}, 0);
+    EXPECT_EQ(2, core.current_unique_blocks());
+    core.AdvanceTime(999); // ages 999 < 1000: still alive
+    EXPECT_EQ(2, core.current_unique_blocks());
+    core.AdvanceTime(1000); // strict deadline: dead without any request
+    EXPECT_EQ(0, core.current_unique_blocks());
+    // Re-access after the observational advance still revives normally.
+    core.ProcessRequest({1}, 1000);
+    EXPECT_EQ(1, core.current_unique_blocks());
+
+    LiteHit pure_lru;
+    pure_lru.ProcessRequest({1, 2}, 0);
+    pure_lru.AdvanceTime(1000000000); // no TTL: a pure no-op
+    EXPECT_EQ(2, pure_lru.current_unique_blocks());
+}
+
 TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
     std::mt19937_64 rng(20260730);
     std::uniform_int_distribution<int64_t> base_dist(0, 12);

--- a/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
@@ -98,6 +98,38 @@ TEST_F(LiteHitTtlTest, ResetClearsTtlState) {
     EXPECT_TRUE(core.ProcessRequest({1, 2}, 2000).hit_curve.empty());
 }
 
+TEST_F(LiteHitTtlTest, UniqueBlocksExcludeExpired) {
+    LiteHit core(1000);
+    core.ProcessRequest({1, 2, 3}, 0);
+    EXPECT_EQ(3, core.current_unique_blocks());
+    // All three expire; only the new key is alive even though the expired
+    // table entries linger until compaction.
+    core.ProcessRequest({100}, 5000);
+    EXPECT_EQ(1, core.current_unique_blocks());
+}
+
+TEST_F(LiteHitTtlTest, CompactionDropsExpiredEntries) {
+    LiteHit core(1000);
+    for (int64_t r = 0; r < 600; ++r) {
+        std::vector<int64_t> keys;
+        keys.reserve(10);
+        for (int64_t i = 0; i < 10; ++i) {
+            keys.push_back(1000000 + r * 100 + i);
+        }
+        core.ProcessRequest(keys, 0);
+    }
+    EXPECT_EQ(6000, core.current_unique_blocks());
+    // Every block expires; the next request pushes the state past the
+    // compaction threshold and the dead entries are dropped, not carried.
+    core.ProcessRequest({1, 2, 3}, 5000);
+    EXPECT_EQ(3, core.current_unique_blocks());
+    EXPECT_EQ(3u, core.last_positions_.size());
+    // Semantics survive the cleanup: dropped keys stay cold, alive ones hit
+    // (the re-committed cold key occupies MRU, shifting thresholds by one).
+    EXPECT_TRUE(core.ProcessRequest({1000000}, 5001).hit_curve.empty());
+    EXPECT_EQ((std::vector<HitCurveSegment>{{2, 3}}), core.ProcessRequest({1, 2, 3}, 5001).hit_curve);
+}
+
 TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
     std::mt19937_64 rng(20260730);
     std::uniform_int_distribution<int64_t> base_dist(0, 12);

--- a/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
@@ -54,6 +54,21 @@ public:
         }
     }
 
+    // Keys whose age at now_ns is strictly below the TTL (0 = no TTL).
+    uint64_t AliveCount(int64_t now_ns, uint64_t ttl_ns) const {
+        if (ttl_ns == 0) {
+            return static_cast<uint64_t>(last_access_.size());
+        }
+        uint64_t alive = 0;
+        for (const auto &[key, last_ns] : last_access_) {
+            const uint64_t age = last_ns < now_ns ? static_cast<uint64_t>(now_ns - last_ns) : 0;
+            if (age < ttl_ns) {
+                ++alive;
+            }
+        }
+        return alive;
+    }
+
 private:
     std::vector<int64_t> recency_;
     std::unordered_map<int64_t, int64_t> last_access_;
@@ -183,6 +198,10 @@ TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
             }
         }
         oracle.Commit(keys, now);
+        for (std::size_t t = 0; t < ttls.size(); ++t) {
+            ASSERT_EQ(oracle.AliveCount(now, ttls[t]), cores[t]->current_unique_blocks())
+                << "step " << step << " ttl " << ttls[t];
+        }
     }
 }
 

--- a/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
@@ -130,6 +130,22 @@ TEST_F(LiteHitTtlTest, CompactionDropsExpiredEntries) {
     EXPECT_EQ((std::vector<HitCurveSegment>{{2, 3}}), core.ProcessRequest({1, 2, 3}, 5001).hit_curve);
 }
 
+TEST_F(LiteHitTtlTest, CompactionCollapsesEmptyEpochs) {
+    LiteHit core(1000000000); // TTL far beyond the replayed horizon
+    // A single hot key with a distinct timestamp per request: every commit
+    // moves the marker and leaves the previous epoch's range empty. Without
+    // the compaction dedupe the deque would hold one epoch per request.
+    for (int64_t t = 1; t <= 10000; ++t) {
+        core.ProcessRequest({7}, t);
+    }
+    EXPECT_LE(core.position_epochs_.size(), 4200u);
+    EXPECT_EQ(1, core.current_unique_blocks());
+    // Exactness survives the collapse: alive within TTL, dead at the strict
+    // deadline measured from the true last access.
+    EXPECT_EQ((std::vector<HitCurveSegment>{{1, 1}}), core.ProcessRequest({7}, 10001).hit_curve);
+    EXPECT_TRUE(core.ProcessRequest({7}, 10001 + 1000000000).hit_curve.empty());
+}
+
 TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
     std::mt19937_64 rng(20260730);
     std::uniform_int_distribution<int64_t> base_dist(0, 12);

--- a/kv_cache_manager/optimizer/test/online_optimizer_manager_test.cc
+++ b/kv_cache_manager/optimizer/test/online_optimizer_manager_test.cc
@@ -316,11 +316,25 @@ TEST_F(OnlineOptimizerManagerTest, FullAttentionRequiresConsistentInputTokenLeng
     EXPECT_EQ(7, summaries[0].total_input_tokens);
 }
 
-TEST_F(OnlineOptimizerManagerTest, FullAttentionRejectsTtlInLiteHitPhase) {
+TEST_F(OnlineOptimizerManagerTest, FullAttentionLayersGroupTtlOntoLiteHit) {
     auto info = MakeInfo("i1", "g1", 4, 0);
-    auto group = MakeGroup("g1", {FullCapacityGb(2)}, "lru", false, 60);
+    auto group = MakeGroup("g1", {FullCapacityGb(2)}, "lru", /*enable_theoretical_max_cache=*/true, /*ttl=*/60);
     RegisterInstanceResult reg_result;
-    EXPECT_EQ(EC_BADARGS, RegisterInstance(info, group, reg_result));
+    ASSERT_EQ(EC_OK, RegisterInstance(info, group, reg_result));
+
+    TraceQueryResult first;
+    ASSERT_EQ(EC_OK, mgr_->TraceQuery("i1", {1, 2}, 8, first));
+    EXPECT_EQ(0, first.max_hit_count);
+    // The immediate re-query is well inside the 60s TTL: plain LRU behavior.
+    TraceQueryResult second;
+    ASSERT_EQ(EC_OK, mgr_->TraceQuery("i1", {1, 2}, 8, second));
+    EXPECT_EQ(2, second.max_hit_count);
+    EXPECT_EQ(2, second.hit_count_per_capacity.at(0));
+
+    // Negative TTL is still rejected.
+    auto bad_info = MakeInfo("i2", "g2", 4, 0);
+    auto bad_group = MakeGroup("g2", {FullCapacityGb(2)}, "lru", false, /*ttl=*/-1);
+    EXPECT_EQ(EC_BADARGS, RegisterInstance(bad_info, bad_group, reg_result));
 }
 
 TEST_F(OnlineOptimizerManagerTest, ResetStatsResetsFullAttentionLiteHit) {


### PR DESCRIPTION
## Summary

在 LiteHit 多容量 LRU 回放核心上叠加**固定 per-group TTL**：instance group 配置 `ttl_seconds != 0` 时，该组的离线回放与在线 full-attention 路径均按 "LRU + 固定 TTL" 口径评估命中率，语义与 online `TtlCacheIndexerWrapper` 一致（块自上次访问起严格小于 TTL 内存活；过期块对任意容量都是 miss，并像冷块一样截断前缀；每次访问——命中或未命中——都刷新 last_access）。

## Design

- **单核心**：TTL 直接并入 `LiteHit`，不引入第二个 core；facts 仍是普通 hit curve（CSV 格式不变），查询侧无 TTL 概念。
- **精确性**：年龄沿 LRU 栈单调（越新的块越年轻），过期块不会抬高存活块的复用距离，因此一次回放对"固定 TTL × 任意容量"的联合口径仍然精确。
- **位置水位线（position-epoch watermark）**：marker 位置单调分配，块的 last-access 时间等于为其分配当前位置的那次提交时间。用 `deque<PositionEpoch{start_position, timestamp_ns}>`（每个不同提交时间戳一条）+ `dead_below_position_` 水位线代替逐 key 时间戳表：过期推进为摊还 O(1)，存活判定为一次整数比较，内存 O(一个 TTL 窗口内不同提交时间戳数)，与 unique key 数无关。压缩（compaction）时用单调 lower_bound 重映射 epoch 边界与水位线。
- **TTL 懒惰无状态**：不做 harvest/物理清理，过期 marker 留在 Fenwick/位置表中无害，重新访问自然复活；TTL 不改变底层 LRU 顺序。
- **多 TTL**：一个 group 一个固定 TTL；要扫多个 TTL 就配多个 group 各带不同 `ttl_seconds`（可配合 fanout 一次回放完成）。
- **在线路径**：online full-attention `InstanceState` 的 LiteHit 以墙钟时间叠加组 TTL，移除原"full-attention + TTL 拒绝注册"的限制；离线回放用 trace 时间戳，保持确定性。

## Test plan

- [x] 新增 `LiteHitTtlTest`：严格边界（deadline 到达即 miss、过期访问仍刷新）、过期块截断前缀、`ttl=0` 退化纯 LRU、Reset 清理 TTL 状态、**随机化对拍**（5 TTL × 6 容量 × 2000 步 vs naive LRU+TTL oracle，覆盖 compaction）
- [x] `LiteHitOfflineRunnerTest`：TTL group 端到端回放（含恰好到期块）、负 TTL 拒绝
- [x] `OnlineOptimizerManagerTest`：TTL group 注册即服务、负 TTL 拒绝
- [x] 外源全量 ASAN UT（`//kv_cache_manager/...`）通过（2 个 `config/` timing flaky 单跑通过）
- [x] 内源全量 ASAN UT（含 `//stub_source/.../test:all`）通过（`VcnsHf3fsAllocatorTest` 超时为本机无 3fs 挂载环境所致，与本改动无关）