### PR TITLE
[optimizer] report TTL expirations on the online LiteHit summary path

### DIFF
--- a/kv_cache_manager/optimizer/liteHit/lite_hit.cc
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.cc
@@ -26,10 +26,18 @@ void LiteHit::AdvanceTtlWatermark(int64_t now_ns) {
     // matching the online TtlCacheIndexerWrapper harvest. Every position of
     // a dead epoch is below the next epoch's start (or below everything when
     // it is the last one).
+    const std::size_t old_watermark = dead_below_position_;
     while (!position_epochs_.empty() &&
            position_epochs_.front().timestamp_ns <= now_ns - static_cast<int64_t>(ttl_ns_)) {
         position_epochs_.pop_front();
         dead_below_position_ = position_epochs_.empty() ? fenwick_.size() + 1 : position_epochs_.front().start_position;
+    }
+    // Markers the watermark sweeps over are blocks that reached the deadline
+    // without a refreshing access (re-touched blocks moved their marker
+    // above); this equals the online wrapper's harvested-eviction count.
+    if (dead_below_position_ > old_watermark) {
+        const uint64_t already_dead = old_watermark > 1 ? fenwick_.PrefixSum(old_watermark - 1) : 0;
+        ttl_expired_blocks_ += fenwick_.PrefixSum(dead_below_position_ - 1) - already_dead;
     }
 }
 
@@ -214,6 +222,7 @@ void LiteHit::Reset() {
     last_positions_.clear();
     position_epochs_.clear();
     dead_below_position_ = 0;
+    ttl_expired_blocks_ = 0;
 }
 
 uint64_t LiteHit::memory_usage_bytes() const {

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.cc
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.cc
@@ -163,6 +163,14 @@ void LiteHit::MaybeCompactPositions() {
     }
     std::sort(ordered_positions.begin(), ordered_positions.end());
 
+    // The bucket array never shrinks on erase and would otherwise stay at
+    // the historical peak. Shrink only when it is far above the surviving
+    // set (with headroom) so oscillating working sets do not rehash back and
+    // forth.
+    if (last_positions_.bucket_count() > 4 * (last_positions_.size() + 1)) {
+        last_positions_.rehash(2 * last_positions_.size());
+    }
+
     // Old position boundary S maps to (surviving markers below S) + 1; the
     // mapping is monotone, so epoch starts and the watermark keep their
     // order and semantics.

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.h
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.h
@@ -77,6 +77,12 @@ public:
     // are excluded even though their table entries linger until compaction.
     uint64_t current_unique_blocks() const { return alive_marker_count(); }
 
+    // Cumulative blocks that reached the TTL deadline without a refreshing
+    // access; counted when the watermark sweeps over them, matching the
+    // online TtlCacheIndexerWrapper eviction statistics. A revived block
+    // counts again on its next expiry.
+    uint64_t ttl_expired_blocks() const { return ttl_expired_blocks_; }
+
     // Coarse memory estimate for observability. It is derived from the state
     // already required by the algorithm and does not retain extra trace data.
     uint64_t memory_usage_bytes() const;
@@ -112,6 +118,7 @@ private:
     // expired.
     std::deque<PositionEpoch> position_epochs_;
     std::size_t dead_below_position_ = 0;
+    uint64_t ttl_expired_blocks_ = 0;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
+++ b/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
@@ -601,6 +601,7 @@ ErrorCode OnlineOptimizerManager::ListInstances(const std::string &instance_grou
             // last request.
             state->lite_hit->AdvanceTime(static_cast<int64_t>(TimestampUtil::GetCurrentTimeUs()) * 1000);
             s.unique_keys = ClampToInt64(state->lite_hit->current_unique_blocks());
+            s.ttl_eviction_count = ClampToInt64(state->lite_hit->ttl_expired_blocks());
             s.memory_usage_bytes = ClampToInt64(state->lite_hit->memory_usage_bytes());
 
             // Infinite-capacity residency: nothing is ever evicted, so every

--- a/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
+++ b/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
@@ -604,9 +604,10 @@ ErrorCode OnlineOptimizerManager::ListInstances(const std::string &instance_grou
             s.ttl_eviction_count = ClampToInt64(state->lite_hit->ttl_expired_blocks());
             s.memory_usage_bytes = ClampToInt64(state->lite_hit->memory_usage_bytes());
 
-            // Infinite-capacity residency: nothing is ever evicted, so every
-            // distinct block ever seen counts. Finite tiers are min(U, C) of
-            // this same U and need no separate report.
+            // Capacity-unbounded residency: without a TTL every distinct
+            // block ever seen counts; with a group TTL only the alive working
+            // set does. Finite tiers are min(U, C) of this same U and need no
+            // separate report.
             s.kv_cache_usage_bytes = SaturatingMultiplyToInt64(state->lite_hit->current_unique_blocks(),
                                                                static_cast<uint64_t>(state->size_full_only));
 

--- a/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
+++ b/kv_cache_manager/optimizer/manager/online_runtime/online_optimizer_manager.cc
@@ -602,6 +602,10 @@ ErrorCode OnlineOptimizerManager::ListInstances(const std::string &instance_grou
             state->lite_hit->AdvanceTime(static_cast<int64_t>(TimestampUtil::GetCurrentTimeUs()) * 1000);
             s.unique_keys = ClampToInt64(state->lite_hit->current_unique_blocks());
             s.ttl_eviction_count = ClampToInt64(state->lite_hit->ttl_expired_blocks());
+            // Total-eviction contract: LiteHit has no capacity evictions, so
+            // the total equals the TTL expirations (the linear wrapper also
+            // counts harvested entries in both).
+            s.eviction_count = s.ttl_eviction_count;
             s.memory_usage_bytes = ClampToInt64(state->lite_hit->memory_usage_bytes());
 
             // Capacity-unbounded residency: without a TTL every distinct

--- a/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
@@ -3,6 +3,7 @@
 #include <memory>
 #include <random>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/unittest.h"
@@ -179,6 +180,23 @@ TEST_F(LiteHitTtlTest, AdvanceTimeRefreshesUniqueCount) {
     EXPECT_EQ(2, pure_lru.current_unique_blocks());
 }
 
+TEST_F(LiteHitTtlTest, CountsTtlExpiredBlocks) {
+    LiteHit core(1000);
+    core.ProcessRequest({1, 2, 3}, 0);
+    EXPECT_EQ(0, core.ttl_expired_blocks());
+    // All three reached the deadline; key 1 revives after being counted.
+    core.ProcessRequest({1}, 2000);
+    EXPECT_EQ(3, core.ttl_expired_blocks());
+    // Repeated advances must not double count the already-swept markers.
+    core.AdvanceTime(2500);
+    EXPECT_EQ(3, core.ttl_expired_blocks());
+    // The revived key expires again and counts again, via AdvanceTime alone.
+    core.AdvanceTime(3000);
+    EXPECT_EQ(4, core.ttl_expired_blocks());
+    core.Reset();
+    EXPECT_EQ(0, core.ttl_expired_blocks());
+}
+
 TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
     std::mt19937_64 rng(20260730);
     std::uniform_int_distribution<int64_t> base_dist(0, 12);
@@ -194,6 +212,12 @@ TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
         cores.push_back(std::make_unique<LiteHit>(ttl));
     }
     NaiveLruTtlOracle oracle;
+    // Naive harvest model per TTL: a tracked key leaves the alive set and
+    // counts once when its age reaches the TTL at a step boundary; a commit
+    // re-adds it, so a revived key counts again on its next expiry.
+    std::unordered_map<int64_t, int64_t> naive_last_access;
+    std::vector<std::unordered_set<int64_t>> naive_alive(ttls.size());
+    std::vector<uint64_t> naive_expired(ttls.size(), 0);
     int64_t now = 0;
     for (int step = 0; step < 2000; ++step) {
         now += delta_dist(rng);
@@ -208,12 +232,27 @@ TEST_F(LiteHitTtlTest, RandomizedMatchesNaiveJointOracle) {
         }
 
         for (std::size_t t = 0; t < ttls.size(); ++t) {
+            for (auto it = naive_alive[t].begin(); it != naive_alive[t].end();) {
+                const int64_t last_ns = naive_last_access.at(*it);
+                const uint64_t age = last_ns < now ? static_cast<uint64_t>(now - last_ns) : 0;
+                if (age >= ttls[t]) {
+                    it = naive_alive[t].erase(it);
+                    ++naive_expired[t];
+                } else {
+                    ++it;
+                }
+            }
             const RequestFact fact = cores[t]->ProcessRequest(keys, now);
+            ASSERT_EQ(naive_expired[t], cores[t]->ttl_expired_blocks()) << "step " << step << " ttl " << ttls[t];
             for (uint64_t capacity : capacities) {
                 ASSERT_EQ(oracle.Evaluate(keys, now, ttls[t], capacity),
                           HitCurveProjector::ProjectBlocks(fact, capacity))
                     << "step " << step << " ttl " << ttls[t] << " capacity " << capacity;
             }
+            naive_alive[t].insert(keys.begin(), keys.end());
+        }
+        for (int64_t key : keys) {
+            naive_last_access[key] = now;
         }
         oracle.Commit(keys, now);
         for (std::size_t t = 0; t < ttls.size(); ++t) {

--- a/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
+++ b/kv_cache_manager/optimizer/test/lite_hit_ttl_test.cc
@@ -140,6 +140,9 @@ TEST_F(LiteHitTtlTest, CompactionDropsExpiredEntries) {
     core.ProcessRequest({1, 2, 3}, 5000);
     EXPECT_EQ(3, core.current_unique_blocks());
     EXPECT_EQ(3u, core.last_positions_.size());
+    // The bucket array shrinks with the entries instead of staying at the
+    // 6000-key high-water mark.
+    EXPECT_LT(core.last_positions_.bucket_count(), 1000u);
     // Semantics survive the cleanup: dropped keys stay cold, alive ones hit
     // (the re-committed cold key occupies MRU, shifting thresholds by one).
     EXPECT_TRUE(core.ProcessRequest({1000000}, 5001).hit_curve.empty());

--- a/kv_cache_manager/optimizer/test/online_optimizer_manager_test.cc
+++ b/kv_cache_manager/optimizer/test/online_optimizer_manager_test.cc
@@ -331,6 +331,13 @@ TEST_F(OnlineOptimizerManagerTest, FullAttentionLayersGroupTtlOntoLiteHit) {
     EXPECT_EQ(2, second.max_hit_count);
     EXPECT_EQ(2, second.hit_count_per_capacity.at(0));
 
+    // Total-eviction contract: LiteHit has no capacity evictions, so the
+    // summary total must always equal the TTL eviction count.
+    std::vector<InstanceSummary> summaries;
+    mgr_->ListInstances("g1", summaries);
+    ASSERT_EQ(1, summaries.size());
+    EXPECT_EQ(summaries[0].ttl_eviction_count, summaries[0].eviction_count);
+
     // Negative TTL is still rejected.
     auto bad_info = MakeInfo("i2", "g2", 4, 0);
     auto bad_group = MakeGroup("g2", {FullCapacityGb(2)}, "lru", false, /*ttl=*/-1);

--- a/kv_cache_manager/protocol/protobuf/optimizer_service.proto
+++ b/kv_cache_manager/protocol/protobuf/optimizer_service.proto
@@ -61,7 +61,7 @@ message OptimizerInstanceGroupProto {
     repeated double capacity_gb = 3;     // group 下的多容量列表，单位 GB
     bool shared_group_quota = 4;         // true 表示 group 内 instance 共享容量预算
     int64 ttl_seconds = 5;               // TTL 秒数，0 表示不启用 TTL
-    bool enable_theoretical_max_cache = 6; // 是否启用 theoretical/max cache
+    bool enable_theoretical_max_cache = 6; // 是否统计 theoretical 结果（理论无限容量命中）
     bool enable_prefix_hash = 7;         // true 时 group 内所有实例输入的 block_keys 为逐 block raw hash，统一转换为 rolling prefix hash
 }
 
@@ -172,8 +172,9 @@ message TraceQueryCapacityResult {
 }
 
 message TraceQueryTheoreticalResult {
-    int64 max_hit_count = 1;        // theoretical/max cache 前缀连续命中长度（block 数），未启用时为 -1
-    int64 current_unique_keys = 2;  // theoretical/max cache 当前 resident unique key 数，未启用时为 -1
+    // theoretical = 理论无限容量下的命中结果。
+    int64 max_hit_count = 1;        // 前缀连续命中长度（block 数），未启用时为 -1
+    int64 current_unique_keys = 2;  // 当前 resident unique key 数，未启用时为 -1
     double hit_rate = 3;            // 未启用时为 -1（与 max_hit_count 同哨兵；0 表示已计算且为 0）
 }
 
@@ -192,7 +193,7 @@ message OptimizerCapacitySummary {
 
 message OptimizerTheoreticalSummary {
     int64 total_max_hits = 1;
-    double max_hit_rate = 2;    // full-attention 实例未启用 theoretical max cache 时为 -1
+    double max_hit_rate = 2;    // full-attention 实例未启用 theoretical 统计时为 -1
 }
 
 message OptimizerInstanceDebugInfo {
@@ -201,7 +202,7 @@ message OptimizerInstanceDebugInfo {
     int32 linear_step = 3;
     int64 eviction_count = 4;
     int64 memory_usage_bytes = 5;
-    int64 kv_cache_usage_bytes = 6;  // full-attention 实例为无限容量口径：历史 unique block 数 × block_bytes
+    int64 kv_cache_usage_bytes = 6;  // full-attention 实例为无限容量口径：当前 resident unique block 数 × block_bytes
     int64 ttl_eviction_count = 7;
 }
 


### PR DESCRIPTION
> Stacked on #259（base 分支为 `optimizer-litehit-ttl`），聚焦 online LiteHit 路径的 TTL 统计信息补齐；后续 online 观测信息的扩展也将堆在本 PR。

## Summary

补齐 full-attention（LiteHit）分支 summary 中缺失的 `ttl_eviction_count`：此前只有 linear 分支从 `TtlCacheIndexerWrapper` 上报，LiteHit TTL 组恒为 0。

## Design

- `LiteHit::ttl_expired_blocks()`：水位线每次推进时，`PrefixSum(新水位−1) − PrefixSum(旧水位−1)` 即"到达 deadline 且未被刷新重访"的 marker 数（被重访的块 marker 已上移，天然不计；复活后再过期再计一次）——与 wrapper harvest 的口径逐一对应，O(log n) 增量维护。
- 口径为**无限容量**视角（LiteHit 单栈多容量投影的固有口径，与同分支 `unique_keys` / `kv_cache_usage_bytes` 一致）；有限容量下部分块会先被 LRU 挤出，真实 TTL 驱逐数会更小。
- `ResetStats`（`LiteHit::Reset`）清零；summary 读取路径复用 #259 的 `AdvanceTime` 墙钟推进，空闲实例的计数也是最新的。

## Test plan

- [x] `CountsTtlExpiredBlocks`：到期计数、重复推进不重复计数、复活块再过期再计、Reset 清零
- [x] 随机对拍新增逐步累计过期数差分（5 TTL × 2000 步 vs naive harvest 模型），与既有 hit-curve/unique-count 差分同跑
- [x] 外源 optimizer ASAN 套件 19/19 通过