### PR TITLE
[manager] harden and streamline group-aware ReportEvent paths

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -1,9 +1,17 @@
 #
-name: Create and publish a develop Docker image
+name: Create and publish a KVCM Docker image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   workflow_dispatch:
+    inputs:
+      flavor:
+        description: Image flavor
+        type: choice
+        options:
+          - dev
+          - integration
+        default: dev
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -12,7 +20,60 @@ env:
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
+  integration:
+    if: ${{ inputs.flavor == 'integration' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build server package
+        env:
+          BUILD_IMAGE: ghcr.io/alibaba/tair-kvcache-kvcm-dev:2026_02_13_12_03_24230b1
+        run: |
+          docker run --rm --privileged \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            "${BUILD_IMAGE}" \
+            bash -lc '
+              git config --global --add safe.directory /workspace &&
+              bazelisk build //package:kv_cache_manager_server --config=ci_fast &&
+              cp bazel-bin/package/kv_cache_manager_server.tar.gz open_source/docker/ &&
+              chown "$(stat -c %u /workspace):$(stat -c %g /workspace)" \
+                open_source/docker/kv_cache_manager_server.tar.gz
+            '
+
+      - name: Prepare image tag and context
+        id: integration_image
+        run: |
+          VERSION="integration-$(date -u '+%Y_%m_%d_%H_%M')-${GITHUB_SHA::7}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
+          test -r open_source/docker/kv_cache_manager_server.tar.gz
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "KVCM integration image: ${IMAGE}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish integration image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: open_source/docker
+          file: open_source/docker/Dockerfile.prod
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.integration_image.outputs.image }}
+          build-args: BINARY_PACKAGE_TAR=kv_cache_manager_server.tar.gz
+
   build:
+    if: ${{ inputs.flavor != 'integration' }}
     strategy:
       fail-fast: false
       matrix:
@@ -97,6 +158,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: ${{ inputs.flavor != 'integration' }}
     runs-on: ubuntu-latest
     needs:
       - build

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [模块架构与关联关系](design/module_architecture.md) - 各模块职责、依赖方向、控制流与数据流，附 Mermaid 图
 - [基本概念](design/basic_concepts.md) - Storage、Instance Group、Instance、Block、CacheLocation 等核心概念
 - [ReportEvent 增量上报与权威快照设计](design/report_event_snapshot_uri_version.md) - 增量/快照协同、提交屏障、故障恢复、性能取舍与 Subscriber 集成
+- [ReportEvent 小 block / 大批量性能优化记录](design/report_event_performance.md) - 热路径放大、锁语义、容量基准与后续 Redis I/O 优化边界
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
 

--- a/docs/api/report_event.md
+++ b/docs/api/report_event.md
@@ -16,7 +16,8 @@
 5. 客户端不得在 URI 中填写 `s_version`；KVCM 会自动追加。
 6. `committed_snapshot_version` 是 32 位十六进制 opaque generation，不能按大小比较；成功完整
    snapshot 后它会成为该 reporter 的严格查询栅栏。
-7. `snapshot_required=true` 是“当前 KVCM 进程还没有该 reporter generation”的提示，不会阻止合法增量。
+7. `snapshot_required=true` 表示请求到达时当前进程还没有该 reporter generation；创建 generation
+   的首条 ADD/DELETE 自身仍返回 `true`，下一条事件才返回 `false`。该提示不会阻止合法增量。
 8. 当前进程尚未收到该 reporter 的任何合法事件，或节点 unavailable 时，查询不会返回该
    节点的数据；节点存活状态是硬门槛。
 9. snapshot 失败、进程重启或从未成功 snapshot 的 soft 模式可能返回 stale cache candidate；
@@ -140,7 +141,8 @@ Instance/InstanceGroup 和 cache metadata 会持久化；reporter 节点表、li
 2. 第一条 HEARTBEAT、ADD、DELETE 或 SNAPSHOT 会自动重建 reporter 节点状态，不要求再次 REGISTER；
 3. 如果第一条只是 HEARTBEAT，响应为 `snapshot_required=true`、
    `committed_snapshot_version=""`，格式合法的历史 metadata 可以重新成为 cache candidate；
-4. 如果第一条是 ADD/DELETE，它正常成功并建立新 generation；
+4. 如果第一条是 ADD/DELETE，它正常成功并建立新 generation；该次响应仍为
+   `snapshot_required=true`，后续事件复用 generation 时变为 `false`；
 5. 该增量只更新明确涉及的 spec，不删除其他历史 block/spec；
 6. snapshot-capable 调用方可以稍后补一次完整 snapshot；
 7. realtime-only 调用方可以继续只发增量。
@@ -496,14 +498,17 @@ SNAPSHOT_IN_PROGRESS  -> SNAPSHOT 失败时重发完整 snapshot
 
 ### 9.2 snapshot_required
 
-`snapshot_required` 等价于“当前进程还没有该 reporter generation”：
+`snapshot_required` 表示“本次请求到达时当前进程还没有该 reporter generation”。对于首条合法
+ADD/DELETE，KVCM 会在请求内创建 generation 并返回到 `committed_snapshot_version`，但本次响应
+仍保留 `snapshot_required=true`；下一条事件复用该 generation 时才返回 `false`：
 
 | 场景 | 值 |
 | --- | --- |
 | fresh REGISTER 后 | `true` |
 | KVCM 重启后的第一条 HEARTBEAT | `true` |
 | 只有 REGISTER/HEARTBEAT、还没有合法 mutation | `true` |
-| 第一条合法 ADD/DELETE 后 | `false` |
+| 创建 generation 的第一条合法 ADD/DELETE | `true` |
+| 后续复用已有 generation 的 ADD/DELETE | `false` |
 | 成功 SNAPSHOT 后 | `false` |
 | invalid-only 首批增量 | 仍为 `true` |
 | realtime-only reporter | 可忽略该提示，继续发合法增量 |
@@ -606,6 +611,23 @@ HTTP 接口为 `POST /api/getCacheLocation`：
 该接口当前支持 `QT_BATCH_GET`，可通过 `backend_selectors` 明确选择
 `ST_EVENT_REPORT_L1P5`、`ST_EVENT_REPORT_L2` 等 backend，适合验证两种 EventReport storage 的
 隔离状态。
+
+`location_spec_names` 不只是返回结果的投影条件，也是 backend/peer 选择前的候选条件：
+
+- 为空时，location 中任意合法 spec 都可使该 location 成为候选；
+- 非空时，location 至少包含一个请求的 spec name 才能成为候选；
+- 同一 EventReport location 由 `storage_type + medium + host_ip_port` 标识，其中各 spec 必须属于
+  同一个 reporter endpoint；location 命中过滤后，selector 从第一个合法 spec URI 提取 peer；
+- 多个 peer 的 prefix/coverage 相同时按 endpoint 字典序选择，保证调用方按 spec 分批查询时
+  各批次不会因为容器遍历顺序选择不同 peer；
+- peer 选择完成后，响应仍只保留 `location_spec_names` 指定的 specs。
+
+因此 spec name 是 reporter 与查询方之间的稳定协议字段，不能用 object size 代替：不同 cache
+group 即使 byte size 相同，也必须使用不同且稳定的 spec name。调用方如果每个 key 需要的 spec
+不同，应先按 spec name 分组发起查询，再按原 object key 合并结果；`location_spec_names` 是一次
+请求级过滤条件，不是 per-key 数组。确定性 tie-break 只消除无序遍历造成的抖动；若各组候选
+peer 集合不同，分组请求无法保证得到全局最优公共 peer。该能力需要后续扩展 per-key spec filter
+或等价的联合选择接口。
 
 ### 11.4 GetHostCacheState
 
@@ -728,12 +750,39 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 - Backend UT：`kv_cache_manager/data_storage/test/event_report_backend_test.cc`
 - Manager UT：`kv_cache_manager/manager/test/cache_manager_test.cc`
 - Meta UT：`kv_cache_manager/manager/test/meta_searcher_test.cc`
+- PR HTTP 集成：`integration_test/meta_service/http_interface_test.py`
 - 基础集成：`integration_test/meta_service/test_report_event.py`
 - Snapshot 集成：`integration_test/meta_service/test_report_event_snapshot.py`
 - 重启集成：`integration_test/meta_service/test_report_event_restart.py`
 
-后两项对应的 Bazel target 带 `manual` 标签，不属于默认 GitHub CI。覆盖结论必须以显式执行结果为准；
-同样，普通 GitHub check 通过不代表已经执行 ASAN。
+PR HTTP 集成由 `//integration_test/meta_service:http_interface_test` 启动真实 KVCM 进程，属于默认
+`//integration_test/...` CI。基础 ReportEvent 脚本当前没有 Bazel target；Snapshot target 带
+`manual` 标签，重启脚本也需显式执行，因此三者不属于默认 GitHub CI。覆盖结论必须以显式执行
+结果为准；同样，普通 GitHub check 通过不代表已经执行 ASAN。
+
+Snapshot target 是外部服务测试，单独执行 `bazel test` 不会替它启动 KVCM。先按脚本头部说明
+启动 meta/admin HTTP 服务，再显式传入端口。功能与容量入口分别为：
+
+```bash
+bazel run //integration_test/meta_service:test_report_event_snapshot -- \
+  --host localhost --http_port 56020 --admin_http_port 56040 \
+  --instance_id event_report_functional --skip-bench
+
+bazel run //integration_test/meta_service:test_report_event_snapshot -- \
+  --host localhost --http_port 56020 --admin_http_port 56040 \
+  --instance_id event_report_bench --only-bench
+
+# 仅运行小 block / 大批量单请求基准；生产形态评估应显式传 Redis URI
+bazel run //integration_test/meta_service:test_report_event_snapshot -- \
+  --host localhost --http_port 56020 --admin_http_port 56040 \
+  --instance_id event_report_large_delta \
+  --meta-storage-uri redis://127.0.0.1:6379 \
+  --bench-test test_20_large_single_request_delta_scaling
+```
+
+同一 KVCM 进程上重复执行时，fixture 会通过 `listStorage` 校验已有 storage 的 type 和 EventReport
+时序配置；配置不一致应立即失败，不能把任意 `addStorage` 错误当作“可能已存在”后继续测试。
+heartbeat/grace 短时序测试使用独立 storage/instance group，不得缩短功能与容量用例的主 storage。
 
 | ID | 用户行为 | 自动化覆盖 |
 | --- | --- | --- |
@@ -781,6 +830,10 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 | Q-07 | GetCacheLocationsByBackend 同样执行 reporter liveness 过滤 | `TestGetCacheLocationsByBackendWithBackendSelectors`；snapshot 集成 `test_16a` |
 | Q-08 | 三个查询入口在 timeout 隐藏和 HEARTBEAT 恢复时结果一致 | snapshot 集成 `test_16a_heartbeat_timeout_then_recovery` |
 | Q-09 | snapshot 成功后即使异步 cleanup 尚未运行，遗漏的旧 version block 也立即不可见 | `TestSuccessfulSnapshotImmediatelyFencesOmittedOldVersionBeforeCleanup`、`TestGetCacheLocationEnforcesReporterLifecycleAndBatchOrdering` |
+| Q-10 | backend 查询在 peer 选择前按 spec 过滤，并对同覆盖率 peer 确定性择优 | `TestGetCacheLocationsByBackendWithBackendSelectors`；`EventReportPrefixFiltersRequestedSpecBeforePeerSelection`；`EventReportCoverageFiltersRequestedSpecBeforePeerSelection`；`EventReportPrefixTieBreaksByPeerAddress`；`EventReportCoverageTieBreaksByPeerAddress`；HTTP 集成 `test_event_report_requested_spec_filters_before_peer_selection` |
+| Q-11 | requested spec 不存在时 Prefix/Coverage 都返回与输入等长的空结果，不回退到其他 spec | `EventReportUnknownRequestedSpecReturnsNoCandidate`；HTTP 集成 `test_event_report_requested_spec_filters_before_peer_selection` |
+| Q-12 | requested spec 按 any-of 语义匹配，重复 name 不改变结果；匹配同一 location 的非首个 spec 时仍使用该 reporter endpoint | `EventReportRequestedSpecMatchesAnyNameIncludingNonFirstSpec` |
+| Q-13 | requested-spec gap 会终止 Prefix，但 Coverage 可跳过 gap 继续返回后续命中；响应投影后 `spec_size` 始终等于实际 specs 数量 | `EventReportRequestedSpecGapStopsPrefixButNotCoverage`；`TestGetCacheLocationsByBackendWithBackendSelectors` |
 | L-01 | 自动 heartbeat timeout 隐藏、grace 内恢复原 generation | `MightExistFollowsAutomaticLivenessAndFullReporterLifecycle`；snapshot 集成 `test_16a` |
 | L-02 | unavailable 期间增量可写但保持不可见，HEARTBEAT 后恢复 | `TestReportEventLazilyRestoresReporterWithoutRegisterOrSnapshot`；snapshot 集成 `test_16a` |
 | L-03 | 超过 grace 后按 generation 原子 unregister，最终 metadata 删除持有 generation lease，旧 cleanup 不伤重新注册数据 | `HeartbeatRecoveryFencesCleanupAlreadySelectedByLivenessLoop`、`ConditionalUnregisterCannotRemoveNewGeneration`、`CleanupLeaseFencesReregisterThroughFinalDeleteStage`；snapshot 集成 `test_16b` |
@@ -797,6 +850,7 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 | C-04 | 已进入 metadata I/O 的旧 lifecycle 请求不能在 HOST_DOWN、REGISTER、新 snapshot 后恢复写入 | `TestOldDeltaCannotCrossReporterLifecycleAfterReregisterAndSnapshot` |
 | C-05 | snapshot 等待 active delta 超时后 abort candidate、保留 committed generation 并重新打开 delta 写门 | `SnapshotDrainTimeoutAbortsCandidateAndReopensWriteGate` |
 | C-06 | delta 等待 in-flight snapshot 超时后返回可重试错误，且不会中止 snapshot；节点校验不会在超时栅栏前无限等待 | `DeltaWaitTimeoutReturnsSnapshotInProgressWithoutAbortingSnapshot`、`TestReportEventDeltaGateTimeoutReturnsSnapshotInProgressAndCanRetry` |
+| C-07 | mutation lease 每个 RMW 阶段只获取一次，但阻塞在 metadata read 的旧请求仍可被 HOST_DOWN/新 lifecycle 抢占 | `TestBatchMutationWriteLeaseIsAcquiredOncePerRmwPhase`、`TestBatchMutationWriteLeaseFailurePreventsAllWrites`、`TestHostDownCancelsSnapshotAlreadyWritingMetadata`、`TestHostDownMakesAlreadyAdmittedDeltaInvisibleWithoutDeadlock`、`TestOldDeltaCannotCrossReporterLifecycleAfterReregisterAndSnapshot` |
 | V-01 | reporter host、ADD/DELETE/SNAPSHOT medium 含 `#` 时拒绝且无写入副作用 | `RegisterNodeWithMediums`、`TestReportEventRejectsInvalidRequestsAndMapsItemErrors`；snapshot 集成 `test_19_*` |
 | V-02 | instance/host/storage type/instance backend 的公共字段校验 | `TestReportEventRejectsInvalidRequestsAndMapsItemErrors`；snapshot 集成 `test_14_*` |
 | V-03 | event_type 与 oneof payload 缺失/错配时该 item fail closed；同批其他合法 mutation 可独立懒初始化并生效 | `TestReportEventRejectsMismatchedPayloadsWithoutSideEffects`；snapshot 集成 `test_13/33` |
@@ -807,6 +861,7 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 | CFG-01 | snapshot interval/drain timeout 默认值、正数校验、负数拒绝、JSON/proto round trip，并由 backend 加载 | `TestEventReportStorageSpecSnapshotSettingsDefaultAndValidation`、`TestEventReportStorageSpecJsonRoundTripIncludesSnapshotSettings`、`EventReportStorageSpecProtoRoundTripPreservesSnapshotSettings`、`BasicAccessors` |
 | PERF-01 | 100 线程共 1 万 ADD、50 线程共 5000 混合批次均无错误 | `EventReportBenchTest.test_17/18` |
 | PERF-02 | 10 reporter × 每台 5000 blocks 完整 snapshot，并查询每台首/中/末 block | `EventReportBenchTest.test_19_ten_reporters_full_snapshot_capacity` |
+| PERF-03 | 单请求 512 个跨重复 medium 的增量正确落盘；手工容量测试记录 100/1000/5000 个 ADD 的总 RT 与单 event 开销 | `TestReportEventLargeDeltaBatchAcrossRepeatedMediums`、`EventReportBenchTest.test_20_large_single_request_delta_scaling` |
 
 上表中的参数解析、故障注入、CAS 竞态等内部边界使用 UT 验证；跨 HTTP 的正常流程、并发流程、
 节点生命周期和 Redis/KVCM 重启使用集成测试验证。

--- a/docs/design/report_event_followup_todo.md
+++ b/docs/design/report_event_followup_todo.md
@@ -7,6 +7,8 @@
 [`report_event.md`](../api/report_event.md) 和
 [`report_event_snapshot_uri_version.md`](report_event_snapshot_uri_version.md)
 中的接口与生命周期契约为准，并为并发问题优先补充可控阻塞点的确定性测试。
+小 block / 大批量性能问题的已完成优化、禁止破坏的 HOST_DOWN 抢占窗口和后续目标化 Redis
+读取方案记录在 [`report_event_performance.md`](report_event_performance.md)。
 
 ## P1：生命周期与重试语义
 

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -1,0 +1,106 @@
+# ReportEvent 小 block / 大批量性能优化记录
+
+本文记录 `ReportEvent` 在 block size 较小、单次或并发上报 block 数较多时的性能分析、已经实施的
+低风险优化、必须保持的并发语义，以及后续继续优化的边界。后续 AI 或开发者应先阅读本文和
+[`report_event_snapshot_uri_version.md`](report_event_snapshot_uri_version.md)，不要仅根据某个 RT
+指标直接引入并行。
+
+## 1. 现象与指标解释
+
+线上曾观察到 `ReportEvent` 与查询 RT 接近 100ms，同时 `meta_indexer.get_io_time_us` 可占约
+80ms，查询侧 `manager.prefix_match_time_us` 也偏高。需要分开判断：
+
+- `meta_indexer.get_io_time_us` 表示 metadata backend 的读 I/O；对 Redis 而言，批量 key 越多，
+  pipeline 的命令数、reply 大小和 HSCAN/HMGET 成本越高；
+- `manager.prefix_match_time_us` 属于查询候选计算，不能用它直接证明 ReportEvent 本地锁慢；
+- ReportEvent 原有的节点表独占锁和 lifecycle lease 放大会增加 CPU/排队与 heap allocation，
+  但不会解释全部 80ms Redis I/O。优化后仍需按阶段观测，而不是预期一个改动消除所有 RT。
+
+## 2. 已实施的低风险优化
+
+### 2.1 请求内 medium 注册去重
+
+一个 ReportEvent 请求内，相同 reporter/medium 的每个 ADD/DELETE 原来都会调用
+`EnsureNodeRegistered`。现在只在该 medium 第一次成功时调用；成功 REGISTER 声明的 medium 也会
+写入请求内集合。失败不会缓存，因此后续有序 REGISTER 或下一事件仍可重试，保持
+“delta 可以出现在显式 REGISTER 前”的既有语义。
+节点是否已经确保与 medium 集合分开记录：fresh reporter 的空 snapshot 即使没有 medium，也必须
+调用一次 `EnsureNodeRegistered` 完成懒初始化，不能被“缺少待注册 medium”的快路径跳过。
+
+`EventReportBackend::EnsureNodeRegistered` 对已存在且 medium 已知的节点使用 shared lock 快路径；
+只有缺少 medium 时才释放 shared lock、获取 unique lock 并二次检查。节点 map 和 mediums 仍始终
+受 `nodes_mutex_` 保护，不能改成无锁读取或用一个原子布尔值替代整个 map 的一致性。
+
+### 2.2 lifecycle lease 从每 key 收敛到每 RMW 阶段一次
+
+原实现会在 modifier 的每个 key 上查 reporter fence、分配 `shared_lock`；已有 location 的 ADD
+经过 block-create 和 targeted-location 两阶段时还会重复一轮。现在每个 RMW 阶段第一次进入
+modifier 时获取一次，后续 key 复用同一个 lease：
+
+```text
+metadata read（可被 lifecycle writer 抢占）
+        |
+non-blocking lifecycle lease（每阶段一次）
+        |
+本阶段全部 metadata mutation
+        |
+释放 lease
+```
+
+lease 不能在 metadata read 前获取，也不能无条件持有整个 ReportEvent。HOST_DOWN/REGISTER 的
+锁序是 `lifecycle -> metadata`；如果旧请求阻塞在 metadata I/O，lifecycle writer 必须能先完成。
+旧请求恢复后 `try_lock` 失败并放弃写入。BatchMerge 的两个 RMW 阶段之间释放并重新获取，保留同样
+的抢占窗口。确定性 HOST_DOWN/重注册竞态测试是这个优化的强制回归项。
+
+## 3. 当前明确不做的事情
+
+暂不并行执行 ReportEvent 内的 metadata batch。原因不是并行永远无效，而是当前主要指标已经指向
+backend I/O；直接并行可能把排队转移到 Redis、放大连接池竞争并拖高查询 p99，同时会引入
+key-count 容量、同 key mutation 顺序和 lifecycle fencing 的新并发面。
+
+暂不把 `BatchMergeLocationSpecs` 的两阶段 RMW 简单合并。第一阶段通过“整个 block 是否存在”维护
+`key_count/max_key_count`，第二阶段按目标 location 做 merge。仅使用目标 HMGET 无法区分“key 不存在”
+和“key 存在但目标 location 不存在”；直接替换会造成容量计数错误。
+
+## 4. 下一步最值得验证的 I/O 优化
+
+Redis `GetLocationIds` 当前为每批 key 做 EXISTS，再用 HSCAN 枚举 location field；已有目标 location
+还要进入 targeted HMGET。若优化后线上 `get_io_time_us` 仍占主导，优先设计一个 backend/indexer
+原语，在保持 shard lock 的一次 RMW 中同时返回：
+
+1. key 是否存在（用于 `key_count/max_key_count`）；
+2. 请求指定 location id 的值与逐项错误；
+3. 不枚举、不传输无关 location value。
+
+Redis 实现应尽量把 EXISTS 与目标 HMGET 放进同一 pipeline round trip；Local/Dummy/Async Redis 和
+cached+recover 模式必须具有一致语义。只有补齐新 key、已有 key 缺 location、已有 location、
+properties-only key、tombstone、部分 I/O 失败和 max-key-count UT 后，才能替换现有两阶段逻辑。
+
+## 5. 验证与观测清单
+
+- UT：请求内 512 个跨重复 medium 的 ADD；并发 EnsureNodeRegistered；每 RMW 阶段 lease 次数与失败
+  原子性；HOST_DOWN、REGISTER、新 snapshot 抢占阻塞 metadata read；同请求 ADD/DELETE 顺序。
+- 手工容量：`EventReportBenchTest.test_20_large_single_request_delta_scaling` 分别记录 100/1000/5000
+  个新 block ADD 与相同 block 再次 ADD 的总 RT、单 event RT，并查询首/中/末 block，不能只看
+  HTTP 成功码。
+  可在启动 KVCM 后用 `--bench-test test_20_large_single_request_delta_scaling` 单独执行；评估线上
+  metadata I/O 时必须给 `--meta-storage-uri` 传入 Redis，而不是只测 local backend。
+- 线上对比：至少拆分 request parse/fold、node ensure、lifecycle lease wait/fail、RMW lock wait、
+  `get_io_time_us`、serialize、enqueue/upsert 和完整 ReportEvent RT；同时观察查询 p50/p99。
+- 若去重后 `get_io_time_us` 仍接近总 RT，下一步应做目标化 backend read，而不是先加线程。
+- 若 backend I/O 已显著下降但 CPU/锁等待仍主导，再评估按互斥 shard 分组的有界并行（建议先从
+  2~4 并发开始），并对查询 p99、连接池等待和 Redis CPU 设置回退阈值。
+
+### 5.1 2026-08-04 本地 Redis 基准记录
+
+在同机 Redis 7.2.5、debug KVCM、真实 meta/admin HTTP 接口下，使用本文新增的 benchmark 得到：
+
+| events/request | 新建 block ADD | 已有 block/location 再次 ADD |
+| ---: | ---: | ---: |
+| 100 | 7.61ms（0.0761ms/event） | 10.40ms（0.1040ms/event） |
+| 1000 | 62.99ms（0.0630ms/event） | 88.10ms（0.0881ms/event） |
+| 5000 | 303.59ms（0.0607ms/event） | 420.14ms（0.0840ms/event） |
+
+命令使用独立 Redis metadata backend，并对每档首/中/末 block 做查询校验。该数据只是当前开发机的
+可重复基线，不是 SLA；已有 location 明显更慢也印证了两阶段 HSCAN + targeted HMGET 是下一轮
+I/O 优化重点。线上判断必须结合 `get_io_time_us`、Redis CPU/网络和查询 p99。

--- a/docs/design/report_event_snapshot_uri_version.md
+++ b/docs/design/report_event_snapshot_uri_version.md
@@ -374,12 +374,16 @@ snapshot replace + commit/abort
 - commit 后等待 delta 使用新 generation；
 - abort 后等待 delta 使用旧 generation；若此前没有旧 generation，则创建一个新 generation；
 - Close、Unregister、HOST_DOWN 唤醒 waiter；等待 active delta 另有可配置超时，不会无界阻塞；
-- metadata read-modify-write 在最终写阶段持有 lifecycle generation lease；旧请求不能在
-  HOST_DOWN、重新 REGISTER 和新 snapshot 后恢复写入；
-- mutation 在已经持有 metadata 锁时只做非阻塞的 per-reporter lifecycle lease 获取；若同一
-  reporter 的 HOST_DOWN/REGISTER lifecycle writer 已经开始等待，则旧 mutation 立即失败，
-  避免与 cleanup 的 `lifecycle -> metadata` 顺序形成锁序反转；不同 reporter 使用独立
-  fence，不会因其他 host 的 HEARTBEAT/REGISTER 产生假失败；
+- metadata read-modify-write 在每个 RMW 阶段完成读、准备进入最终写时，只获取一次
+  lifecycle generation lease，并持有到该阶段结束；同一阶段不再按 key 重复查 fence 或分配
+  shared lock；
+- lease 不能提前到 metadata read 之前获取。这样旧请求阻塞在 metadata I/O 时，HOST_DOWN/
+  REGISTER 仍可先取得 lifecycle writer；旧请求恢复后使用非阻塞获取立即失败，不能跨越新
+  lifecycle 写入；BatchMerge 的 block-create 与 targeted-location 两个 RMW 阶段之间同样释放并
+  重新获取 lease；
+- mutation 在已经持有 metadata 锁时只做上述非阻塞的 per-reporter lifecycle lease 获取，
+  避免与 cleanup 的 `lifecycle -> metadata` 顺序形成锁序反转；不同 reporter 使用独立 fence，
+  不会因其他 host 的 HEARTBEAT/REGISTER 产生假失败；
 - liveness unregister 的 generation 比较与节点删除在同一把锁内完成；
 - 显式 HOST_DOWN 的 generation 捕获与节点删除同样在同一把锁内完成，Heartbeat/REGISTER
   只能在线性化的 HOST_DOWN 之前或之后生效，不能在中间恢复后又被旧请求删除；
@@ -456,6 +460,8 @@ reporter -> location 反向索引，而不是继续提高全量频率。
 - snapshot commit 后 delta 刷新 mixed-generation location 时，旧 cleanup 不删除新写；
 - snapshot cleanup 只删除 metadata，不调用外部 URI backend；
 - 成功 snapshot 最终清理旧数据，失败 snapshot 不触发专用清理；
+- backend requested-spec 使用 any-of 语义，在 peer 选择前检查 location 的所有 specs；Prefix 在
+  spec gap 停止，Coverage 跳过 gap，最终响应投影保持 `spec_size == location_specs.size()`；
 - snapshot 限流、storage type 隔离和 liveness 竞态。
 
 ### 12.2 集成测试
@@ -473,9 +479,31 @@ reporter -> location 反向索引，而不是继续提高全量频率。
 - snapshot partial failure、完整重试；
 - snapshot commit 后立即到达的 delta 在异步 cleanup 后仍可查询；
 - reporter host 或 medium 含 `#` 时 fail closed 且无写入副作用；
+- Bazel `--runs_per_test` 并发重复时，每个 test action 的可变 worker 目录必须位于其私有
+  `TEST_TMPDIR`，不得在共享 runfiles/source tree 中清理或复制；至少用 20 路重复验证目录隔离；
+- heartbeat/grace 计时用例必须使用独立的短超时 storage/instance group，不能缩短功能与容量
+  用例共享 storage 的生命周期窗口，否则异步 cleanup 验证会被 liveness cleanup 交叉干扰；
 - ASAN/TSAN 或等价并发检测（仅记录实际执行结果，不能由普通 CI 结果推断）。
 
 Snapshot 与重启 HTTP 测试 target 带 `manual` 标签，不属于默认 GitHub CI；需要显式执行并单独记录结果。
+
+### 12.3 Vineyard 跨仓集成镜像
+
+Vineyard 的 ReportEvent 集成不能继续使用不含 `event_report` protobuf 的旧 KVCM 镜像；否则
+`addStorage` 会返回 `missing or invalid fields: {StorageConfig: {storage_spec}}`，后续用例全部是
+同一前置失败的连锁结果。
+
+需要验证 KVCM 分支时，手动运行 `.github/workflows/build-dev-image.yml` 并选择
+`flavor=integration`。该 flavor 只构建 CI 所需的 `linux/amd64` 生产镜像，并发布唯一的
+`integration-<UTC time>-<short sha>` tag；把该精确 tag 写入 Vineyard 的
+`.aoneci/v6d-pytest-integration.yaml`，禁止使用 `latest`。合并前至少确认 Vineyard 的
+group-aware 三节点用例、green、KVCM fault 和 PACE fault 都实际执行，且从失败制品中的
+pytest 汇总判断结果，不能根据 Aone 对自由脚本显示的 `NOT_RUN` 状态推断。
+
+该 workflow 在 dev 容器内完成 Bazel 构建后，也必须在容器仍存活时把 server tar 复制到
+Docker build context，并把文件 owner 改回 runner 用户。`bazel-bin` 可能指向容器内的
+`/root/.cache/bazel`；容器退出后再从宿主 runner 读取该 symlink 会得到 `Permission denied`
+或断链，不能据此误判为编译失败。
 
 ## 13. 接受的取舍
 

--- a/integration_test/meta_service/http_interface_test.py
+++ b/integration_test/meta_service/http_interface_test.py
@@ -5,14 +5,15 @@ import integration_test.meta_service.meta_interface_cases as cases
 class MetaServiceHttpClient(cases.MetaServiceClientBase):
     """HTTP client for MetaService API endpoints"""
 
-    def __init__(self, base_url):
+    def __init__(self, base_url, admin_url=None):
         self.base_url = base_url
+        self.admin_url = admin_url or base_url
         self.session = requests.Session()
         self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
 
-    def _make_request(self, method, endpoint, data=None):
+    def _make_request(self, method, endpoint, data=None, base_url=None):
         """Helper method to make HTTP requests to the service"""
-        url = self.base_url + endpoint
+        url = (base_url or self.base_url) + endpoint
 
         if method == 'POST':
             response = self.session.post(url, json=data, headers=self.headers)
@@ -23,9 +24,9 @@ class MetaServiceHttpClient(cases.MetaServiceClientBase):
 
         return response
 
-    def _make_api_request(self, endpoint, data=None, check_response=True):
+    def _make_api_request(self, endpoint, data=None, check_response=True, base_url=None):
         """Helper method to make POST requests to API endpoints and optionally validate response"""
-        response = self._make_request('POST', endpoint, data)
+        response = self._make_request('POST', endpoint, data, base_url=base_url)
         if response.status_code != 200:
             raise AssertionError(f"Request to {endpoint} failed with status code {response.status_code}")
         try:
@@ -72,6 +73,30 @@ class MetaServiceHttpClient(cases.MetaServiceClientBase):
         """Get cluster info (leader discovery)"""
         return self._make_api_request('/api/getClusterInfo', data, check_response)
 
+    def report_event(self, data, check_response=True):
+        """Report EventReport node/block lifecycle events."""
+        return self._make_api_request('/api/reportEvent', data, check_response)
+
+    def get_cache_locations_by_backend(self, data, check_response=True):
+        """Query locations with explicit backend selection."""
+        return self._make_api_request('/api/getCacheLocationsByBackend', data, check_response)
+
+    def _make_admin_api_request(self, endpoint, data=None, check_response=True):
+        return self._make_api_request(
+            endpoint,
+            data,
+            check_response,
+            base_url=self.admin_url,
+        )
+
+    def add_storage(self, data, check_response=True):
+        """Register storage through the admin HTTP endpoint."""
+        return self._make_admin_api_request('/api/addStorage', data, check_response)
+
+    def create_instance_group(self, data, check_response=True):
+        """Create an instance group through the admin HTTP endpoint."""
+        return self._make_admin_api_request('/api/createInstanceGroup', data, check_response)
+
     def close(self):
         """Close the HTTP session"""
         self.session.close()
@@ -81,9 +106,175 @@ class MetaServiceHttpTest(cases.MetaServiceTestBase):
     """HTTP version of the MetaService tests"""
 
     def _get_manager_client(self):
-        self._http_port = self.worker_manager.get_worker(0).env.http_port
+        worker_env = self.worker_manager.get_worker(0).env
+        self._http_port = worker_env.http_port
         self._http_url = "http://localhost:%d" % self._http_port
-        return MetaServiceHttpClient(self._http_url)
+        self._admin_http_url = "http://localhost:%d" % worker_env.admin_http_port
+        return MetaServiceHttpClient(self._http_url, self._admin_http_url)
+
+    @staticmethod
+    def _event_report_storage(storage_name):
+        return {
+            "global_unique_name": storage_name,
+            "storage_type": "ST_EVENT_REPORT_L2",
+            "event_report": {
+                "heartbeat_timeout_ms": 30000,
+                "cleanup_grace_ms": 30000,
+                "liveness_check_interval_ms": 1000,
+            },
+            "check_storage_available_when_open": False,
+        }
+
+    @staticmethod
+    def _event_report_instance_group(group_name, storage_name):
+        return {
+            "name": group_name,
+            "storage_candidates": ["nfs_01"],
+            "global_quota_group_name": "default_quota_group",
+            "max_instance_count": 10,
+            "quota": {
+                "capacity": 10737418240,
+                "quota_config": [{"storage_type": 4, "capacity": 10737418240}],
+            },
+            "cache_config": {
+                "reclaim_strategy": {
+                    "storage_unique_name": "nfs_01",
+                    "reclaim_policy": 1,
+                    "trigger_strategy": {"used_size": 1073741824, "used_percentage": 0.8},
+                    "trigger_period_seconds": 60,
+                    "reclaim_step_size": 1073741824,
+                    "reclaim_step_percentage": 10,
+                },
+                "data_storage_strategy": 2,
+                "meta_indexer_config": {
+                    "max_key_count": 10000,
+                    "mutex_shard_num": 16,
+                    "batch_key_size": 16,
+                    "meta_storage_backend_config": {"storage_type": "local", "storage_uri": ""},
+                    "meta_cache_policy_config": {"type": "LRU", "capacity": 10000},
+                },
+            },
+            "event_report_storage_candidates": [storage_name],
+            "version": 1,
+        }
+
+    @staticmethod
+    def _report_events(instance_id, host, events, trace_id):
+        return {
+            "trace_id": trace_id,
+            "instance_id": instance_id,
+            "host_ip_port": host,
+            "storage_type": "ST_EVENT_REPORT_L2",
+            "events": events,
+        }
+
+    @staticmethod
+    def _node_and_block_events(host, spec_name, block_keys):
+        events = [{
+            "event_type": "EVENT_NODE_REGISTER",
+            "node_register": {"mediums": ["mem"]},
+        }]
+        events.extend({
+            "event_type": "EVENT_BLOCK_ADD",
+            "block_add": {
+                "block_key": str(block_key),
+                "medium": "mem",
+                "specs": [{
+                    "name": spec_name,
+                    "uri": f"vineyard://{host}/mem",
+                }],
+            },
+        } for block_key in block_keys)
+        return events
+
+    def test_event_report_requested_spec_filters_before_peer_selection(self):
+        """Exercise ReportEvent -> HTTP query with the adversarial peer layout.
+
+        The full-only peer has better raw coverage. Both cross-key strategies
+        must nevertheless select the linear peer when linear_1 is requested.
+        """
+        storage_name = "event_report_l2_http_spec_filter"
+        group_name = "event_report_http_spec_filter_group"
+        instance_id = "event_report_http_spec_filter_instance"
+        full_host = "10.10.0.1:9600"
+        linear_host = "10.10.0.2:9600"
+        block_keys = [82000, 82001]
+
+        self._client.add_storage({
+            "trace_id": "event_report_add_storage",
+            "storage": self._event_report_storage(storage_name),
+        })
+        self._client.create_instance_group({
+            "trace_id": "event_report_create_group",
+            "instance_group": self._event_report_instance_group(group_name, storage_name),
+        })
+        self._client.register_instance({
+            "trace_id": "event_report_register_instance",
+            "instance_group": group_name,
+            "instance_id": instance_id,
+            "block_size": 128,
+            "model_deployment": self._get_test_model_deployment(),
+            "location_spec_infos": [
+                {"name": "full_0", "size": 1024},
+                {"name": "linear_1", "size": 1024},
+            ],
+            "location_spec_groups": [
+                {"name": "full_0", "spec_names": ["full_0"]},
+                {"name": "linear_1", "spec_names": ["linear_1"]},
+            ],
+        })
+        self._client.report_event(self._report_events(
+            instance_id,
+            full_host,
+            self._node_and_block_events(full_host, "full_0", block_keys),
+            "event_report_full_peer",
+        ))
+        self._client.report_event(self._report_events(
+            instance_id,
+            linear_host,
+            self._node_and_block_events(linear_host, "linear_1", block_keys[:1]),
+            "event_report_linear_peer",
+        ))
+
+        for strategy in ("LSS_V6D_PREFIX", "LSS_V6D_COVERAGE"):
+            response = self._client.get_cache_locations_by_backend({
+                "trace_id": f"event_report_query_{strategy}",
+                "instance_id": instance_id,
+                "query_type": "QT_BATCH_GET",
+                "block_keys": block_keys,
+                "block_mask": {"offset": 0},
+                "location_spec_names": ["linear_1"],
+                "backend_selectors": [{
+                    "backend_type": "ST_EVENT_REPORT_L2",
+                    "strategy": strategy,
+                }],
+            })
+            key_locations = response.get("key_locations", [])
+            self.assertEqual(2, len(key_locations), response)
+            first_locations = key_locations[0].get("locations", [])
+            self.assertEqual(1, len(first_locations), response)
+            first_specs = first_locations[0].get("location_specs", [])
+            self.assertEqual(["linear_1"], [spec.get("name") for spec in first_specs], response)
+            self.assertIn(linear_host, first_specs[0].get("uri", ""), response)
+            self.assertEqual([], key_locations[1].get("locations", []), response)
+
+        unknown_response = self._client.get_cache_locations_by_backend({
+            "trace_id": "event_report_query_unknown_spec",
+            "instance_id": instance_id,
+            "query_type": "QT_BATCH_GET",
+            "block_keys": block_keys,
+            "block_mask": {"offset": 0},
+            "location_spec_names": ["unknown_spec"],
+            "backend_selectors": [{
+                "backend_type": "ST_EVENT_REPORT_L2",
+                "strategy": "LSS_V6D_PREFIX",
+            }],
+        })
+        self.assertEqual(
+            [[], []],
+            [item.get("locations", []) for item in unknown_response.get("key_locations", [])],
+            unknown_response,
+        )
 
 
 if __name__ == "__main__":

--- a/integration_test/meta_service/test_report_event_restart.py
+++ b/integration_test/meta_service/test_report_event_restart.py
@@ -138,7 +138,11 @@ def verify(args, client, checks):
     checks.assertEqual(accepted["header"]["status"]["code"], "OK")
     active_version = accepted["committed_snapshot_version"]
     checks.assertEqual(len(active_version), 32)
-    checks.assertFalse(accepted.get("snapshot_required"))
+    # A generation-creating delta is accepted immediately, but its own
+    # response keeps snapshot_required=true so a snapshot-capable caller sees
+    # that the request arrived without a current-process generation. The next
+    # delta reuses the generation and clears the hint.
+    checks.assertTrue(accepted.get("snapshot_required"))
     delta_specs = report_event._wait_for_block_spec_names(
         client,
         args.instance_id,
@@ -159,6 +163,26 @@ def verify(args, client, checks):
         {"linear_0"},
         "restart_verify_delta_keeps_untouched_historical_cache",
     )
+
+    followup = client.report_event(
+        report_event._make_request(
+            args.instance_id,
+            HOST,
+            [report_event._ev_block_add(
+                BLOCK_KEY + 2,
+                "gpu",
+                report_event._make_single_spec(
+                    "gpu_0",
+                    report_event._build_event_report_uri(HOST, "gpu"),
+                ),
+            )],
+            trace_id="restart_verify_followup_delta",
+        )
+    )
+    checks.assertEqual(
+        followup.get("committed_snapshot_version"), active_version
+    )
+    checks.assertFalse(followup.get("snapshot_required"))
 
     after_uri = report_event._build_event_report_uri(
         HOST, "mem", {"source": "after_restart"}

--- a/integration_test/meta_service/test_report_event_snapshot.py
+++ b/integration_test/meta_service/test_report_event_snapshot.py
@@ -33,8 +33,6 @@ ADMIN_URL = ""
 INSTANCE_ID = "event_report_cluster_0"
 SKIP_BENCH = False
 ONLY_BENCH = False
-# Requires small heartbeat_timeout_ms/cleanup_grace_ms in addStorage spec.
-ENABLE_LIVENESS_TIMING_TESTS = False
 HEARTBEAT_TIMEOUT_MS = 1000
 CLEANUP_GRACE_MS = 2000
 SNAPSHOT_MIN_INTERVAL_MS = 1000
@@ -80,6 +78,16 @@ class KVCMClient:
         code = body.get("header", {}).get("status", {}).get("code")
         if code not in ("OK", "DUPLICATE_ENTITY"):
             raise AssertionError(f"addStorage failed: {json.dumps(body)}")
+        return body
+
+    def list_storage(self, data):
+        url = f"{self.admin_url}/api/listStorage"
+        resp = self.session.post(url, json=data)
+        resp.raise_for_status()
+        body = resp.json()
+        code = body.get("header", {}).get("status", {}).get("code")
+        if code != "OK":
+            raise AssertionError(f"listStorage failed: {json.dumps(body)}")
         return body
 
     def create_instance_group(self, data):
@@ -391,32 +399,60 @@ class EventReportFunctionalTest(unittest.TestCase):
 
     @classmethod
     def _ensure_event_report_storage_registered(cls):
-        try:
-            cls.client.add_storage({
-                "trace_id": "setup_storage",
-                "storage": {
-                    "global_unique_name": cls.EVENT_REPORT_STORAGE_NAME,
-                    "storage_type": "ST_EVENT_REPORT_L2",
-                    "event_report": {
-                        "heartbeat_timeout_ms": (
-                            HEARTBEAT_TIMEOUT_MS
-                            if ENABLE_LIVENESS_TIMING_TESTS else 30000
-                        ),
-                        "cleanup_grace_ms": (
-                            CLEANUP_GRACE_MS
-                            if ENABLE_LIVENESS_TIMING_TESTS else 300000
-                        ),
-                        "liveness_check_interval_ms": (
-                            100 if ENABLE_LIVENESS_TIMING_TESTS else 5000
-                        ),
-                        "snapshot_min_interval_ms": SNAPSHOT_MIN_INTERVAL_MS,
-                    },
-                    "check_storage_available_when_open": False,
+        cls._ensure_storage_registered(
+            "setup_storage",
+            {
+                "global_unique_name": cls.EVENT_REPORT_STORAGE_NAME,
+                "storage_type": "ST_EVENT_REPORT_L2",
+                "event_report": {
+                    # Functional and capacity cases share this backend and
+                    # intentionally do not turn data events into implicit
+                    # heartbeats. Keep their lifecycle window independent
+                    # from the fast timing fixture below; otherwise a cleanup
+                    # test can pass and then lose its reporter while observing
+                    # asynchronous snapshot cleanup.
+                    "heartbeat_timeout_ms": 30000,
+                    "cleanup_grace_ms": 300000,
+                    "liveness_check_interval_ms": 5000,
+                    "snapshot_min_interval_ms": SNAPSHOT_MIN_INTERVAL_MS,
                 },
+                "check_storage_available_when_open": False,
+            },
+        )
+
+    @classmethod
+    def _ensure_storage_registered(cls, trace_id, expected_storage):
+        storage_name = expected_storage["global_unique_name"]
+        listed = cls.client.list_storage({"trace_id": f"{trace_id}_list"})
+        existing = next(
+            (
+                storage
+                for storage in listed.get("storage", [])
+                if storage.get("global_unique_name") == storage_name
+            ),
+            None,
+        )
+        if existing is None:
+            cls.client.add_storage({
+                "trace_id": trace_id,
+                "storage": expected_storage,
             })
-            print(f"[SETUP] Event report storage '{cls.EVENT_REPORT_STORAGE_NAME}' registered")
-        except Exception as e:
-            print(f"[WARN] addStorage failed (may already exist): {e}")
+            print(f"[SETUP] Event report storage '{storage_name}' registered")
+            return
+
+        if existing.get("storage_type") != expected_storage.get("storage_type"):
+            raise AssertionError(
+                f"Storage {storage_name!r} has unexpected type: {existing}"
+            )
+        actual_spec = existing.get("event_report", {})
+        for name, expected_value in expected_storage.get("event_report", {}).items():
+            actual_value = actual_spec.get(name)
+            if str(actual_value) != str(expected_value):
+                raise AssertionError(
+                    f"Storage {storage_name!r} has {name}={actual_value!r}; "
+                    f"expected {expected_value!r}"
+                )
+        print(f"[SETUP] Event report storage '{storage_name}' reused")
 
     @classmethod
     def _ensure_instance_group_created(cls):
@@ -516,9 +552,9 @@ class EventReportFunctionalTest(unittest.TestCase):
         Keeping the small timeout on a dedicated instance group prevents the
         long functional/benchmark cases from timing out their shared reporters.
         """
-        cls.client.add_storage({
-            "trace_id": "setup_liveness_storage",
-            "storage": {
+        cls._ensure_storage_registered(
+            "setup_liveness_storage",
+            {
                 "global_unique_name": cls.LIVENESS_STORAGE_NAME,
                 "storage_type": "ST_EVENT_REPORT_L2",
                 "event_report": {
@@ -529,7 +565,7 @@ class EventReportFunctionalTest(unittest.TestCase):
                 },
                 "check_storage_available_when_open": False,
             },
-        })
+        )
 
         existing = cls.client.get_instance_group({
             "trace_id": "setup_get_liveness_ig",
@@ -3923,6 +3959,14 @@ class EventReportBenchTest(unittest.TestCase):
     def setUpClass(cls):
         cls.client = KVCMClient(BASE_URL, ADMIN_URL)
         cls.instance_id = INSTANCE_ID
+        # --only-bench does not load EventReportFunctionalTest, so benchmark
+        # setup must not depend on that class having run first.
+        fixture = EventReportFunctionalTest
+        fixture.client = cls.client
+        fixture.instance_id = cls.instance_id
+        fixture._ensure_event_report_storage_registered()
+        fixture._ensure_instance_group_created()
+        fixture._ensure_instance_registered()
 
     @classmethod
     def tearDownClass(cls):
@@ -4167,6 +4211,121 @@ class EventReportBenchTest(unittest.TestCase):
         )
         print(f"  Latency max: {max(ordered_latencies):.2f}ms")
 
+    # 20. One ReportEvent carrying many small-block deltas. This benchmark
+    # tracks the workload that previously amplified reporter-node locking and
+    # lifecycle lease acquisition once per event/key.
+    def test_20_large_single_request_delta_scaling(self):
+        host = "192.168.2.200:8080"
+        self._ensure_host_registered(self.client, self.instance_id, host)
+        measurements = []
+
+        for batch_index, event_count in enumerate((100, 1000, 5000)):
+            base_key = 40_000_000 + batch_index * 10_000
+            create_events = [
+                _ev_block_add(
+                    base_key + offset,
+                    "mem",
+                    _make_single_spec(
+                        "spec_4096",
+                        _build_event_report_uri(
+                            host,
+                            "mem",
+                            {
+                                "block": str(base_key + offset),
+                                "phase": "create",
+                            },
+                        ),
+                    ),
+                )
+                for offset in range(event_count)
+            ]
+            start = time.monotonic()
+            response = self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    create_events,
+                    trace_id=f"bench_large_delta_{event_count}",
+                )
+            )
+            create_elapsed_ms = (time.monotonic() - start) * 1000
+            version = response.get("committed_snapshot_version", "")
+            self.assertEqual(len(version), 32)
+            self.assertFalse(response.get("snapshot_required"))
+
+            # Report the same blocks again to exercise the existing-location
+            # path, including BatchMerge's block lookup and targeted merge
+            # RMW phases.
+            update_events = [
+                _ev_block_add(
+                    base_key + offset,
+                    "mem",
+                    _make_single_spec(
+                        "spec_4096",
+                        _build_event_report_uri(
+                            host,
+                            "mem",
+                            {
+                                "block": str(base_key + offset),
+                                "phase": "update",
+                            },
+                        ),
+                    ),
+                )
+                for offset in range(event_count)
+            ]
+            start = time.monotonic()
+            update_response = self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    update_events,
+                    trace_id=f"bench_large_delta_update_{event_count}",
+                )
+            )
+            update_elapsed_ms = (time.monotonic() - start) * 1000
+            self.assertEqual(
+                update_response.get("committed_snapshot_version", ""),
+                version,
+            )
+            measurements.append(
+                (event_count, create_elapsed_ms, update_elapsed_ms)
+            )
+
+            for offset in (0, event_count // 2, event_count - 1):
+                block_key = base_key + offset
+                specs = _query_block_specs(
+                    self.client,
+                    self.instance_id,
+                    block_key,
+                    f"bench_large_delta_query_{event_count}_{offset}",
+                )
+                self.assertEqual(len(specs), 1)
+                self.assertEqual(specs[0].get("name"), "spec_4096")
+                _assert_reporter_scope(
+                    self,
+                    specs[0]["uri"],
+                    _build_event_report_uri(
+                        host,
+                        "mem",
+                        {"block": str(block_key), "phase": "update"},
+                    ),
+                    self.instance_id,
+                    host,
+                    "mem",
+                    version,
+                )
+
+        print("\n[BENCH] Large single-request BLOCK_ADD scaling:")
+        for event_count, create_elapsed_ms, update_elapsed_ms in measurements:
+            print(
+                f"  Events: {event_count:5d}, "
+                f"create: {create_elapsed_ms:9.2f}ms "
+                f"({create_elapsed_ms / event_count:.4f}ms/event), "
+                f"update: {update_elapsed_ms:9.2f}ms "
+                f"({update_elapsed_ms / event_count:.4f}ms/event)"
+            )
+
 
 def main():
     parser = argparse.ArgumentParser(description="Event Report ReportEvent HTTP integration tests")
@@ -4184,10 +4343,18 @@ def main():
         help="Run only the named EventReportFunctionalTest method; repeatable.",
     )
     parser.add_argument(
+        "--bench-test",
+        action="append",
+        default=[],
+        help="Run only the named EventReportBenchTest method; repeatable.",
+    )
+    parser.add_argument(
         "--enable-liveness-timing-tests",
         action="store_true",
-        help=("Run heartbeat/cleanup timing tests. Requires the Event report storage to be opened with "
-              "small heartbeat_timeout_ms / cleanup_grace_ms (defaults to 1000ms / 2000ms here)."),
+        help=(
+            "Compatibility flag. Heartbeat/cleanup timing tests use their own "
+            "isolated fast-liveness storage and always run."
+        ),
     )
     parser.add_argument("--heartbeat-timeout-ms", type=int, default=1000)
     parser.add_argument("--cleanup-grace-ms", type=int, default=2000)
@@ -4202,11 +4369,12 @@ def main():
     )
 
     args, _ = parser.parse_known_args()
+    if args.functional_test and args.bench_test:
+        parser.error("--functional-test and --bench-test are mutually exclusive")
 
     admin_port = args.admin_http_port or args.http_port
 
     global BASE_URL, ADMIN_URL, INSTANCE_ID, SKIP_BENCH, ONLY_BENCH
-    global ENABLE_LIVENESS_TIMING_TESTS
     global HEARTBEAT_TIMEOUT_MS, CLEANUP_GRACE_MS
     global SNAPSHOT_MIN_INTERVAL_MS, META_STORAGE_URI
     BASE_URL = f"http://{args.host}:{args.http_port}"
@@ -4214,7 +4382,6 @@ def main():
     INSTANCE_ID = args.instance_id
     SKIP_BENCH = args.skip_bench
     ONLY_BENCH = args.only_bench
-    ENABLE_LIVENESS_TIMING_TESTS = args.enable_liveness_timing_tests
     HEARTBEAT_TIMEOUT_MS = args.heartbeat_timeout_ms
     CLEANUP_GRACE_MS = args.cleanup_grace_ms
     SNAPSHOT_MIN_INTERVAL_MS = args.snapshot_min_interval_ms
@@ -4226,9 +4393,12 @@ def main():
     if args.functional_test:
         for test_name in args.functional_test:
             suite.addTest(EventReportFunctionalTest(test_name))
+    elif args.bench_test:
+        for test_name in args.bench_test:
+            suite.addTest(EventReportBenchTest(test_name))
     elif not ONLY_BENCH:
         suite.addTests(loader.loadTestsFromTestCase(EventReportFunctionalTest))
-    if not args.functional_test and not SKIP_BENCH:
+    if not args.functional_test and not args.bench_test and not SKIP_BENCH:
         suite.addTests(loader.loadTestsFromTestCase(EventReportBenchTest))
 
     runner = unittest.TextTestRunner(verbosity=2)

--- a/integration_test/testlib/BUILD
+++ b/integration_test/testlib/BUILD
@@ -17,3 +17,10 @@ py_library(
     imports = [".."],
     deps = [],
 )
+
+py_test(
+    name = "TestBaseTest",
+    srcs = ["test_base_test.py"],
+    main = "test_base_test.py",
+    deps = [":test_base"],
+)

--- a/integration_test/testlib/test_base.py
+++ b/integration_test/testlib/test_base.py
@@ -63,6 +63,13 @@ class TestBase(object):
         return range_from, range_to
 
     def get_workdir(self):
+        # Bazel gives every test action (including each --runs_per_test
+        # repetition) a private TEST_TMPDIR. Keep mutable test state there so
+        # concurrently executing copies cannot delete or overwrite each
+        # other's worker tree under the shared runfiles directory.
+        test_tmpdir = os.environ.get('TEST_TMPDIR')
+        if test_tmpdir:
+            return os.path.join(os.path.abspath(test_tmpdir), self._testMethodName)
         return os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')), self._testMethodName)
 
     def clean_workdir(self):
@@ -72,7 +79,10 @@ class TestBase(object):
 
     def _init_dirs(self, work_dir):
         self.workdir = work_dir if work_dir is not None else self.get_workdir()
-        self.path_root = os.path.abspath(os.path.join(self.workdir, '../'))
+        # The packaged binary is a read-only runfile. It must not be resolved
+        # relative to TEST_TMPDIR now that the per-test worker tree lives
+        # there.
+        self.path_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
         self.global_install_root = os.path.join(self.path_root, 'install_root')
         self.worker_install_root = os.path.join(self.workdir, 'install_root')
 

--- a/integration_test/testlib/test_base_test.py
+++ b/integration_test/testlib/test_base_test.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from integration_test.testlib.module_base import ModuleBase
+from integration_test.testlib.test_base import TestBase
+
+
+class TestBaseWorkdirTest(unittest.TestCase):
+    def setUp(self):
+        self.harness = TestBase()
+        self.harness._testMethodName = "concurrent_case"
+
+    def test_bazel_tmpdir_isolates_mutable_workdir_from_runfiles(self):
+        with tempfile.TemporaryDirectory() as test_tmpdir:
+            with mock.patch.dict(os.environ, {"TEST_TMPDIR": test_tmpdir}):
+                expected_workdir = os.path.join(test_tmpdir, "concurrent_case")
+                self.assertEqual(expected_workdir, self.harness.get_workdir())
+
+                with mock.patch.object(ModuleBase, "create_symlink") as create_symlink:
+                    self.harness._init_dirs(None)
+
+                expected_source_root = os.path.abspath(
+                    os.path.join(os.path.dirname(__file__), "../")
+                )
+                self.assertEqual(expected_workdir, self.harness.workdir)
+                self.assertEqual(expected_source_root, self.harness.path_root)
+                create_symlink.assert_called_once_with(
+                    os.path.join(expected_source_root, "install_root"),
+                    os.path.join(expected_workdir, "install_root"),
+                )
+
+    def test_non_bazel_run_preserves_source_relative_workdir(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            expected_workdir = os.path.join(
+                os.path.abspath(os.path.join(os.path.dirname(__file__), "../")),
+                "concurrent_case",
+            )
+            self.assertEqual(expected_workdir, self.harness.get_workdir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -234,10 +234,33 @@ ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_i
         }
     };
 
-    // The common path only enriches an existing node. It must not wait for
-    // the lifecycle write lock: an in-flight metadata mutation intentionally
-    // holds a shared lifecycle lease, and new deltas still need to reach the
-    // bounded snapshot gate instead of blocking here indefinitely.
+    // Repeated reports normally carry a medium that is already known. Keep
+    // that path read-only so it does not serialize all reporters on the node
+    // table's exclusive lock. A missing medium is rechecked under the unique
+    // lock before it is merged (lock-based double check; the map itself must
+    // never be read without nodes_mutex_).
+    {
+        std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+        auto instance_it = instance_nodes_.find(instance_id);
+        if (instance_it != instance_nodes_.end()) {
+            auto node_it = instance_it->second.find(host_ip_port);
+            if (node_it != instance_it->second.end() && node_it->second) {
+                const auto &known_mediums = node_it->second->mediums;
+                const bool all_known =
+                    std::all_of(mediums.begin(), mediums.end(), [&known_mediums](const auto &medium) {
+                        return std::find(known_mediums.begin(), known_mediums.end(), medium) != known_mediums.end();
+                    });
+                if (all_known) {
+                    return EC_OK;
+                }
+            }
+        }
+    }
+
+    // Enriching an existing node must not wait for the lifecycle write lock:
+    // an in-flight metadata mutation intentionally holds a shared lifecycle
+    // lease, and new deltas still need to reach the bounded snapshot gate
+    // instead of blocking here indefinitely.
     {
         std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
         auto instance_it = instance_nodes_.find(instance_id);

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -496,6 +496,35 @@ TEST_F(EventReportBackendTest, EnsureNodeRegisteredMergesNewMediums) {
     ASSERT_EQ(2u, backend.instance_nodes_["medium-merge"]["10.0.0.91:8080"]->mediums.size());
 }
 
+TEST_F(EventReportBackendTest, EnsureNodeRegisteredHandlesConcurrentKnownAndNewMediums) {
+    EventReportBackend backend(metrics_registry_);
+    const std::string instance_id = "medium-concurrency";
+    const std::string host = "10.0.0.95:8080";
+    ASSERT_EQ(EC_OK, backend.EnsureNodeRegistered(instance_id, host, {"mem"}));
+    const uint64_t generation = backend.GetNodeGeneration(instance_id, host);
+
+    std::atomic<size_t> failures{0};
+    std::vector<std::thread> workers;
+    for (size_t worker = 0; worker < 12; ++worker) {
+        workers.emplace_back([&, worker] {
+            const std::string medium = worker % 2 == 0 ? "mem" : "disk";
+            for (size_t iteration = 0; iteration < 200; ++iteration) {
+                if (backend.EnsureNodeRegistered(instance_id, host, {medium}) != EC_OK) {
+                    failures.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto &worker : workers) {
+        worker.join();
+    }
+
+    EXPECT_EQ(0u, failures.load(std::memory_order_relaxed));
+    EXPECT_EQ(generation, backend.GetNodeGeneration(instance_id, host));
+    const auto &mediums = backend.instance_nodes_[instance_id][host]->mediums;
+    EXPECT_EQ((std::set<std::string>{"disk", "mem"}), (std::set<std::string>(mediums.begin(), mediums.end())));
+}
+
 // (7) Re-registration after cleanup
 TEST_F(EventReportBackendTest, RegisterAfterCleanupCreatesNewEntry) {
     EventReportBackend backend(metrics_registry_);
@@ -510,12 +539,20 @@ TEST_F(EventReportBackendTest, RegisterAfterCleanupCreatesNewEntry) {
     }
     ASSERT_GE(cleanup_calls.load(), 1);
 
-    EXPECT_EQ(backend.instance_nodes_["test_inst"].count("10.0.0.6:8080"), 0u);
+    const auto cleanup_deadline = std::chrono::steady_clock::now() + 1s;
+    while (backend.IsNodeRegistered("test_inst", "10.0.0.6:8080") &&
+           std::chrono::steady_clock::now() < cleanup_deadline) {
+        std::this_thread::yield();
+    }
+    ASSERT_FALSE(backend.IsNodeRegistered("test_inst", "10.0.0.6:8080"));
 
     ASSERT_EQ(EC_OK, backend.RegisterNode("test_inst", "10.0.0.6:8080", {"mem", "disk"}));
     ASSERT_TRUE(backend.IsNodeAvailable("test_inst", "10.0.0.6:8080"));
     {
-        auto &host_map = backend.instance_nodes_["test_inst"];
+        std::shared_lock<std::shared_mutex> lock(backend.nodes_mutex_);
+        auto instance_it = backend.instance_nodes_.find("test_inst");
+        ASSERT_NE(instance_it, backend.instance_nodes_.end());
+        auto &host_map = instance_it->second;
         auto it = host_map.find("10.0.0.6:8080");
         ASSERT_NE(it, host_map.end());
         EXPECT_EQ(it->second->mediums.size(), 2u);
@@ -1829,9 +1866,20 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         auto waiting_snapshot = std::async(std::launch::async, [&] {
             std::string candidate;
             uint64_t retry_ms = 0;
-            return BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_ms);
+            return backend.BeginSnapshot(reporter_key, candidate, retry_ms);
         });
-        ASSERT_EQ(std::future_status::timeout, waiting_snapshot.wait_for(20ms));
+        std::string observed_committed;
+        std::string observed_in_flight;
+        const auto in_flight_deadline = std::chrono::steady_clock::now() + 1s;
+        do {
+            backend.GetSnapshotVersionTokens(reporter_key, observed_committed, observed_in_flight);
+            if (!observed_in_flight.empty()) {
+                break;
+            }
+            std::this_thread::yield();
+        } while (std::chrono::steady_clock::now() < in_flight_deadline);
+        ASSERT_FALSE(observed_in_flight.empty());
+        ASSERT_EQ(std::future_status::timeout, waiting_snapshot.wait_for(0ms));
         ASSERT_EQ(EC_OK, backend.Close());
         ASSERT_EQ(std::future_status::ready, waiting_snapshot.wait_for(1s));
         EXPECT_EQ(EC_SNAPSHOT_REQUIRED, waiting_snapshot.get());
@@ -1850,10 +1898,14 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         std::string second;
         ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, second, retry_after_ms));
 
+        std::promise<void> delta_call_started;
+        auto delta_call_started_future = delta_call_started.get_future();
         auto waiting_delta = std::async(std::launch::async, [&] {
+            delta_call_started.set_value();
             std::string committed;
             return backend.BeginDeltaMutation(reporter_key, committed);
         });
+        ASSERT_EQ(std::future_status::ready, delta_call_started_future.wait_for(1s));
         ASSERT_EQ(std::future_status::timeout, waiting_delta.wait_for(20ms));
         ASSERT_EQ(EC_OK, backend.Close());
         ASSERT_EQ(std::future_status::ready, waiting_delta.wait_for(1s));

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -886,7 +886,7 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
 
     LocationsPerKey locations_per_key;
     ec = meta_searcher->BatchGetBestLocationByBackend(
-        request_context, query_keys, locations_per_key, policy.get(), backend_selectors);
+        request_context, query_keys, locations_per_key, policy.get(), backend_selectors, location_spec_names);
     query_scope = ChronoScopeGuard{};
     // prefix_match_len: count keys with at least one hit (non-empty id).
     // Miss keys have empty CacheLocation objects with no id.
@@ -1432,6 +1432,7 @@ void CacheManager::FilterLocationSpecByName(CacheLocationVector &locations,
         // COW: copy, modify, replace
         auto new_loc = std::make_shared<CacheLocation>(*loc_ptr);
         new_loc->set_location_specs(std::move(new_specs));
+        new_loc->set_spec_size(new_loc->location_specs().size());
         loc_ptr = std::move(new_loc);
     }
 }
@@ -2453,6 +2454,37 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     }
     bool registration_applied = false;
     ErrorCode register_ec = EC_OK;
+    bool node_registration_ensured = false;
+    std::unordered_set<std::string> ensured_mediums;
+    auto ensure_node_medium = [&](const std::string &medium) {
+        if (node_registration_ensured && ensured_mediums.count(medium) > 0) {
+            return EC_OK;
+        }
+        const ErrorCode ec = event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {medium});
+        if (ec == EC_OK) {
+            node_registration_ensured = true;
+            ensured_mediums.insert(medium);
+        }
+        return ec;
+    };
+    auto ensure_node_mediums = [&](const std::vector<std::string> &mediums) {
+        std::vector<std::string> missing_mediums;
+        missing_mediums.reserve(mediums.size());
+        for (const auto &medium : mediums) {
+            if (ensured_mediums.count(medium) == 0) {
+                missing_mediums.push_back(medium);
+            }
+        }
+        if (node_registration_ensured && missing_mediums.empty()) {
+            return EC_OK;
+        }
+        const ErrorCode ec = event_backend->EnsureNodeRegistered(instance_id, host_ip_port, missing_mediums);
+        if (ec == EC_OK) {
+            node_registration_ensured = true;
+            ensured_mediums.insert(missing_mediums.begin(), missing_mediums.end());
+        }
+        return ec;
+    };
 
     struct BlockAddEntry {
         std::string location_id;
@@ -2509,6 +2541,8 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 register_ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
                 registration_applied = true;
                 if (register_ec == EC_OK) {
+                    node_registration_ensured = true;
+                    ensured_mediums.insert(register_mediums.begin(), register_mediums.end());
                     mutation_lifecycle_generation = event_backend->GetNodeGeneration(instance_id, host_ip_port);
                     delta_mutations.AdoptLifecycleGeneration(reporter_key, mutation_lifecycle_generation);
                 }
@@ -2563,8 +2597,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            const ErrorCode ensure_node_ec =
-                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {params.medium()});
+            const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
                 break;
@@ -2629,8 +2662,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            const ErrorCode ensure_node_ec =
-                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {params.medium()});
+            const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
                 break;
@@ -2713,8 +2745,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                     snapshot_mediums.push_back(block.medium);
                 }
             }
-            const ErrorCode ensure_node_ec =
-                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, snapshot_mediums);
+            const ErrorCode ensure_node_ec = ensure_node_mediums(snapshot_mediums);
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
                 break;
@@ -2796,6 +2827,17 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
+    // MetaSearcher calls this once per metadata RMW phase, after its read and
+    // before its first mutation. This removes the old per-key lock/allocation
+    // amplification while preserving the window in which HOST_DOWN can fence
+    // a request that is stalled in metadata I/O.
+    auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
+        EventReportBackend::LifecycleMutationLease lease;
+        const ErrorCode ec =
+            event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
+        return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
+    };
+
     if (!block_to_add.empty()) {
         KeyVector add_keys_aggr;
         std::vector<std::vector<BlockAddMergeEntry>> add_merged_entries_aggr;
@@ -2846,12 +2888,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
 
         std::vector<ErrorCode> per_key_ec;
-        auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
-            EventReportBackend::LifecycleMutationLease lease;
-            const ErrorCode ec =
-                event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
-            return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
-        };
         meta_searcher->BatchMergeLocationSpecs(
             request_context, add_keys_aggr, merge_tasks, per_key_ec, acquire_write_lease);
 
@@ -2913,12 +2949,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
             delete_target_count += delete_tasks[i].size();
         }
-        auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
-            EventReportBackend::LifecycleMutationLease lease;
-            const ErrorCode ec =
-                event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
-            return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
-        };
         meta_searcher->BatchDeleteLocationSpecs(request_context,
                                                 del_keys_aggr,
                                                 delete_tasks,
@@ -2992,12 +3022,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
 
         std::vector<ErrorCode> per_key_ec;
-        auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
-            EventReportBackend::LifecycleMutationLease lease;
-            const ErrorCode ec =
-                event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
-            return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
-        };
         meta_searcher->BatchReplaceLocationSpecs(
             request_context, snapshot_keys, replace_tasks, per_key_ec, acquire_write_lease);
         for (size_t key_index = 0; key_index < snapshot_keys.size(); ++key_index) {

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -5,6 +5,7 @@
 #include <map>
 #include <set>
 #include <sstream>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -191,6 +192,17 @@ CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
     return result;
 }
 
+using RequestedSpecNameSet = std::unordered_set<std::string>;
+
+bool MatchesRequestedSpec(const CacheLocation &loc, const RequestedSpecNameSet &requested_spec_names) {
+    if (requested_spec_names.empty()) {
+        return true;
+    }
+    return std::any_of(loc.location_specs().begin(), loc.location_specs().end(), [&](const LocationSpec &spec) {
+        return requested_spec_names.count(spec.name()) > 0;
+    });
+}
+
 std::string ExtractPeerAddrFromLocation(const CacheLocation &loc) {
     if (loc.location_specs().empty()) {
         return {};
@@ -232,7 +244,9 @@ V6DPeerSelection SelectV6DByPrefix(const std::vector<size_t> &candidate_indices,
             }
             prefix_covered.push_back(ci);
         }
-        if (prefix_covered.size() > best.covered_indices.size()) {
+        if (prefix_covered.size() > best.covered_indices.size() ||
+            (prefix_covered.size() == best.covered_indices.size() &&
+             (best.peer_addr.empty() || addr < best.peer_addr))) {
             best.peer_addr = addr;
             best.covered_indices = std::move(prefix_covered);
         }
@@ -258,7 +272,8 @@ SelectV6DByCoverage(const std::vector<size_t> &candidate_indices,
     }
     V6DPeerSelection best;
     for (auto &[addr, indices] : addr_to_indices) {
-        if (indices.size() > best.covered_indices.size()) {
+        if (indices.size() > best.covered_indices.size() ||
+            (indices.size() == best.covered_indices.size() && (best.peer_addr.empty() || addr < best.peer_addr))) {
             best.peer_addr = addr;
             best.covered_indices = indices;
         }
@@ -533,11 +548,13 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                                                       const KeyVector &keys,
                                                       LocationsPerKey &out_locations,
                                                       SelectLocationPolicy *policy,
-                                                      const std::vector<BackendSelector> &selectors) const {
+                                                      const std::vector<BackendSelector> &selectors,
+                                                      const std::vector<std::string> &requested_spec_names) const {
     assert(policy != nullptr);
     SPAN_TRACER(request_context);
     out_locations.clear();
     out_locations.resize(keys.size());
+    const RequestedSpecNameSet requested_spec_name_set(requested_spec_names.begin(), requested_spec_names.end());
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
     CacheLocationMapVector location_maps;
@@ -594,6 +611,8 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 for (const auto &[id, loc] : vmap) {
                     if (loc->type() != target_type)
                         continue;
+                    if (!MatchesRequestedSpec(*loc, requested_spec_name_set))
+                        continue;
                     std::string addr = ExtractPeerAddrFromLocation(*loc);
                     if (addr.empty())
                         continue;
@@ -642,7 +661,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 const auto &vmap = valid_maps[i];
                 CacheLocationMap filtered;
                 for (const auto &[id, loc] : vmap) {
-                    if (loc->type() == target_type) {
+                    if (loc->type() == target_type && MatchesRequestedSpec(*loc, requested_spec_name_set)) {
                         filtered.try_emplace(id, loc);
                     }
                 }
@@ -1050,19 +1069,27 @@ MetaSearcher::BatchReplaceLocationSpecs(RequestContext *request_context,
     }
 
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
-    std::vector<MetadataWriteLease> write_leases;
-    auto modifier = [&keys, &tasks_per_key, &usage_changes, &acquire_write_lease, &write_leases, batch_create_time](
-                        const std::vector<ErrorCode> &get_ecs,
-                        const LocationIdVector &location_ids,
-                        size_t key_index,
-                        CacheLocationVector &locations,
-                        PropertyMap & /*upsert_property_map*/) -> LocationModifierResult {
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(location_ids.size(), lease_ec)};
-            }
-            write_leases.push_back(std::move(lease));
+    bool write_lease_attempted = false;
+    ErrorCode write_lease_ec = EC_OK;
+    MetadataWriteLease write_lease;
+    auto modifier = [&keys,
+                     &tasks_per_key,
+                     &usage_changes,
+                     &acquire_write_lease,
+                     &write_lease_attempted,
+                     &write_lease_ec,
+                     &write_lease,
+                     batch_create_time](const std::vector<ErrorCode> &get_ecs,
+                                        const LocationIdVector &location_ids,
+                                        size_t key_index,
+                                        CacheLocationVector &locations,
+                                        PropertyMap & /*upsert_property_map*/) -> LocationModifierResult {
+        if (acquire_write_lease && !write_lease_attempted) {
+            std::tie(write_lease_ec, write_lease) = acquire_write_lease();
+            write_lease_attempted = true;
+        }
+        if (write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(location_ids.size(), write_lease_ec)};
         }
         const auto &tasks = tasks_per_key[key_index];
         std::vector<ErrorCode> modifier_ecs(location_ids.size(), ErrorCode::EC_OK);
@@ -1168,29 +1195,36 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
         return EC_BADARGS;
     }
     out_per_key_ec.assign(keys.size(), ErrorCode::EC_OK);
+    if (keys.empty()) {
+        return EC_OK;
+    }
 
     std::vector<std::vector<std::pair<DataStorageType, std::uint64_t>>> created_locs_sz(keys.size());
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
     std::vector<std::vector<MergeLocationSpecsTask>> merge_tasks_per_key(keys.size());
-    std::vector<MetadataWriteLease> write_leases;
+    bool create_write_lease_attempted = false;
+    ErrorCode create_write_lease_ec = EC_OK;
+    MetadataWriteLease create_write_lease;
 
     auto create_modifier = [&tasks_per_key,
                             &merge_tasks_per_key,
                             &keys,
                             &created_locs_sz,
                             &acquire_write_lease,
-                            &write_leases,
+                            &create_write_lease_attempted,
+                            &create_write_lease_ec,
+                            &create_write_lease,
                             batch_create_time](const LocationIdVector &existing_ids,
                                                ErrorCode get_ec,
                                                size_t index,
                                                PropertyMap & /*upsert_property_map*/,
                                                CacheLocationMap &out_new_locations) -> ModifierResult {
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, lease_ec};
-            }
-            write_leases.push_back(std::move(lease));
+        if (acquire_write_lease && !create_write_lease_attempted) {
+            std::tie(create_write_lease_ec, create_write_lease) = acquire_write_lease();
+            create_write_lease_attempted = true;
+        }
+        if (create_write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, create_write_lease_ec};
         }
         if (get_ec != ErrorCode::EC_OK && get_ec != ErrorCode::EC_NOENT) {
             KVCM_LOG_WARN("load location ids failed, key[%lu](%lu) return %d", index, keys[index], get_ec);
@@ -1272,25 +1306,30 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
     for (size_t i = 0; i < keys.size(); ++i) {
         merge_usage_changes[i].resize(merge_tasks_per_key[i].size());
     }
-    write_leases.clear();
+    create_write_lease.reset();
+    bool merge_write_lease_attempted = false;
+    ErrorCode merge_write_lease_ec = EC_OK;
+    MetadataWriteLease merge_write_lease;
     auto merge_modifier = [&keys,
                            &merge_tasks_per_key,
                            &merge_key_indices,
                            &merge_usage_changes,
                            &acquire_write_lease,
-                           &write_leases,
+                           &merge_write_lease_attempted,
+                           &merge_write_lease_ec,
+                           &merge_write_lease,
                            batch_create_time](const std::vector<ErrorCode> &get_ecs,
                                               const LocationIdVector &loc_ids,
                                               size_t key_index,
                                               CacheLocationVector &locs,
                                               PropertyMap &upsert_property_map) -> LocationModifierResult {
         (void)upsert_property_map;
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), lease_ec)};
-            }
-            write_leases.push_back(std::move(lease));
+        if (acquire_write_lease && !merge_write_lease_attempted) {
+            std::tie(merge_write_lease_ec, merge_write_lease) = acquire_write_lease();
+            merge_write_lease_attempted = true;
+        }
+        if (merge_write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), merge_write_lease_ec)};
         }
         const size_t original_key_index = merge_key_indices[key_index];
         const auto &tasks = merge_tasks_per_key[original_key_index];
@@ -1425,7 +1464,6 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
     std::vector<std::pair<size_t, size_t>> flat_to_original_task_indices;
     std::vector<std::pair<DataStorageType, std::uint64_t>> flat_deleted_specs_size;
     std::vector<std::uint8_t> flat_missing_targets;
-    std::vector<MetadataWriteLease> write_leases;
     for (size_t i = 0; i < keys.size(); ++i) {
         out_batch_results[i].assign(tasks_per_key[i].size(), ErrorCode::EC_OK);
         if (out_missing_targets) {
@@ -1445,24 +1483,29 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
 
     // 每条 flat task 独立处理：NOENT 视为幂等成功；spec_names 为空返回 BADARGS；
     // 删除后无剩余 specs 则删除整个 location，否则 COW 更新 location_specs。
+    bool write_lease_attempted = false;
+    ErrorCode write_lease_ec = EC_OK;
+    MetadataWriteLease write_lease;
     auto modifier = [&keys,
                      &tasks_per_key,
                      &flat_to_original_task_indices,
                      &flat_deleted_specs_size,
                      &flat_missing_targets,
                      &acquire_write_lease,
-                     &write_leases](const std::vector<ErrorCode> &get_ecs,
-                                    const LocationIdVector &loc_ids,
-                                    size_t key_index,
-                                    CacheLocationVector &locs,
-                                    PropertyMap &upsert_property_map) -> LocationModifierResult {
+                     &write_lease_attempted,
+                     &write_lease_ec,
+                     &write_lease](const std::vector<ErrorCode> &get_ecs,
+                                   const LocationIdVector &loc_ids,
+                                   size_t key_index,
+                                   CacheLocationVector &locs,
+                                   PropertyMap &upsert_property_map) -> LocationModifierResult {
         (void)upsert_property_map;
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), lease_ec)};
-            }
-            write_leases.push_back(std::move(lease));
+        if (acquire_write_lease && !write_lease_attempted) {
+            std::tie(write_lease_ec, write_lease) = acquire_write_lease();
+            write_lease_attempted = true;
+        }
+        if (write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), write_lease_ec)};
         }
         std::vector<ErrorCode> modifier_ecs(loc_ids.size(), ErrorCode::EC_OK);
         if (loc_ids.size() != 1 || key_index >= flat_to_original_task_indices.size()) {

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -72,7 +72,8 @@ public:
                                             const KeyVector &keys,
                                             LocationsPerKey &out_locations,
                                             SelectLocationPolicy *policy,
-                                            const std::vector<BackendSelector> &selectors) const;
+                                            const std::vector<BackendSelector> &selectors,
+                                            const std::vector<std::string> &requested_spec_names = {}) const;
     ErrorCode ReverseRollSlideWindowMatch(RequestContext *request_context,
                                           const KeyVector &keys,
                                           int32_t sw_size,
@@ -104,7 +105,9 @@ public:
         std::vector<LocationSpec> specs;
     };
     // Replaces existing specs or creates the stable location in one metadata
-    // read-modify-write operation per batch.
+    // read-modify-write operation per batch. When supplied, the write-lease
+    // callback is invoked once after the metadata read and before the first
+    // mutation; the returned lease is retained until the operation returns.
     ErrorCode BatchReplaceLocationSpecs(RequestContext *request_context,
                                         const KeyVector &keys,
                                         const std::vector<std::vector<ReplaceLocationSpecsTask>> &tasks_per_key,
@@ -116,6 +119,10 @@ public:
         CacheLocationStatus status;
         std::vector<LocationSpec> specs;
     };
+    // The optional write lease is acquired once per RMW phase, after that
+    // phase's metadata read. Releasing it between the block-create and
+    // location-merge phases lets a concurrent lifecycle writer fence stale
+    // work before the next phase mutates metadata.
     ErrorCode BatchMergeLocationSpecs(RequestContext *request_context,
                                       const KeyVector &keys,
                                       const std::vector<std::vector<MergeLocationSpecsTask>> &tasks_per_key,
@@ -127,7 +134,9 @@ public:
     };
     // Missing block/location targets are idempotent EC_OK. When requested,
     // out_missing_targets mirrors tasks_per_key and marks those no-op targets;
-    // an existing location with only missing spec_names is not marked.
+    // an existing location with only missing spec_names is not marked. The
+    // optional write lease is acquired once after the metadata read and before
+    // the first mutation.
     ErrorCode BatchDeleteLocationSpecs(RequestContext *request_context,
                                        const KeyVector &keys,
                                        const std::vector<std::vector<DeleteLocationSpecsTask>> &tasks_per_key,

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -3233,6 +3233,46 @@ TEST_F(CacheManagerTest, TestReportEventMissingBlockDeletesRemainSuccessfulAsOne
     EXPECT_TRUE(QueryEventReportUris({94'437, 94'438, 94'439}).empty());
 }
 
+TEST_F(CacheManagerTest, TestReportEventLargeDeltaBatchAcrossRepeatedMediums) {
+    const std::string host = "192.168.10.56:8080";
+    constexpr int64_t first_key = 95'000;
+    constexpr size_t event_count = 512;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    auto request = MakeAddRequest(host, first_key, "batch_0");
+    for (size_t i = 1; i < event_count; ++i) {
+        auto event_request = MakeAddRequest(host, first_key + static_cast<int64_t>(i), "batch_" + std::to_string(i));
+        if (i % 2 != 0) {
+            event_request.mutable_events(0)->mutable_block_add()->set_medium("disk");
+            event_request.mutable_events(0)->mutable_block_add()->mutable_specs(0)->set_uri(
+                "event_report://" + host + "/disk?source=batch_" + std::to_string(i));
+        }
+        *request.add_events() = event_request.events(0);
+    }
+
+    const auto [ec, response] = CallReportEvent(request, "large_repeated_medium_delta_batch");
+    ASSERT_EQ(EC_OK, ec);
+    EXPECT_EQ(proto::meta::OK, response.header().status().code());
+    EXPECT_EQ(0, response.item_results_size());
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
+    EXPECT_TRUE(response.snapshot_required());
+
+    const auto visible = QueryEventReportUris({first_key,
+                                               first_key + static_cast<int64_t>(event_count / 2),
+                                               first_key + static_cast<int64_t>(event_count - 1)});
+    ASSERT_EQ(3u, visible.size());
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const auto &uri) {
+        return uri.find("source=batch_0") != std::string::npos;
+    }));
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const auto &uri) {
+        return uri.find("source=batch_256") != std::string::npos;
+    }));
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const auto &uri) {
+        return uri.find("source=batch_511") != std::string::npos;
+    }));
+}
+
 TEST_F(CacheManagerTest, TestReportEventRestartKeepsHistoricalCacheAndAcceptsDeltaWithoutSnapshot) {
     const std::string host = "192.168.10.47:8080";
     const int64_t historical_key = 94'431;
@@ -6105,12 +6145,16 @@ TEST_F(CacheManagerTest, TestReportEventBlockDeleteRemovesLocationSpecs) {
 
 TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    const std::string instance_id = "test_backend_selectors";
+    auto location_spec_infos = createLocationSpecInfos();
+    location_spec_infos.emplace_back("full_0", 512);
+    location_spec_infos.emplace_back("linear_1", 512);
     ASSERT_EQ(expected_reg,
               cache_manager_->RegisterInstance(request_context_.get(),
                                                "default",
-                                               "test_instance",
+                                               instance_id,
                                                64,
-                                               createLocationSpecInfos(),
+                                               location_spec_infos,
                                                createModelDeployment(),
                                                std::vector<LocationSpecGroup>()));
 
@@ -6120,12 +6164,11 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     std::vector<int64_t> nfs_keys{300, 500, 700};
     {
         auto [ec, swci] =
-            cache_manager_->StartWriteCache(request_context_.get(), "test_instance", nfs_keys, {}, {}, 100000000);
+            cache_manager_->StartWriteCache(request_context_.get(), instance_id, nfs_keys, {}, {}, 100000000);
         ASSERT_EQ(EC_OK, ec);
         BlockMask bm = static_cast<size_t>(nfs_keys.size());
-        ASSERT_EQ(
-            EC_OK,
-            cache_manager_->FinishWriteCache(request_context_.get(), "test_instance", swci.write_session_id(), bm));
+        ASSERT_EQ(EC_OK,
+                  cache_manager_->FinishWriteCache(request_context_.get(), instance_id, swci.write_session_id(), bm));
     }
 
     // Set up EventReportBackend
@@ -6156,9 +6199,9 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         {"192.168.1.3:8080", {300}},
     };
     for (const auto &pd : peer_data) {
-        InitializeEventReporter("test_instance", pd.host, proto::meta::ST_EVENT_REPORT_L2);
+        InitializeEventReporter(instance_id, pd.host, proto::meta::ST_EVENT_REPORT_L2);
         proto::meta::ReportEventRequest req;
-        req.set_instance_id("test_instance");
+        req.set_instance_id(instance_id);
         req.set_host_ip_port(pd.host);
         req.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
 
@@ -6180,15 +6223,8 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     // --- Test 1: empty backend_selectors → returns EC_BADARGS ---
     {
         BlockMask bm = static_cast<size_t>(0);
-        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
-                                                                     CacheManager::QueryType::QT_BATCH_GET,
-                                                                     all_keys,
-                                                                     {},
-                                                                     bm,
-                                                                     0,
-                                                                     {},
-                                                                     {});
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(
+            request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, all_keys, {}, bm, 0, {}, {});
         ASSERT_EQ(EC_BADARGS, ec);
     }
 
@@ -6200,7 +6236,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      all_keys,
                                                                      {},
@@ -6254,7 +6290,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      all_keys,
                                                                      {},
@@ -6289,7 +6325,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      all_keys,
                                                                      {},
@@ -6324,7 +6360,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      keys_no_er_first,
                                                                      {},
@@ -6355,7 +6391,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      keys_gap,
                                                                      {},
@@ -6384,7 +6420,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      bad_keys,
                                                                      {},
@@ -6405,7 +6441,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      {300},
                                                                      {},
@@ -6418,19 +6454,74 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         const auto &kl = locs[0].cache_locations_view();
         ASSERT_EQ(1u, kl.size());
         EXPECT_EQ(2u, kl[0].location_specs().size());
+        EXPECT_EQ(2u, kl[0].spec_size());
     }
 
-    // --- Test 9: backend-selected queries enforce reporter liveness ---
+    // --- Test 9: spec filtering happens before Vineyard peer selection ---
+    // The full-only peer covers two keys and would win an unfiltered prefix
+    // selection. A linear_1 query must instead select the linear-only peer.
+    {
+        auto report_spec =
+            [&](const std::string &host, const std::vector<int64_t> &keys, const std::string &spec_name) {
+                proto::meta::ReportEventRequest req;
+                req.set_instance_id(instance_id);
+                req.set_host_ip_port(host);
+                req.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+                for (int64_t key : keys) {
+                    auto *ev = req.add_events();
+                    ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+                    auto *ba = ev->mutable_block_add();
+                    ba->set_block_key(std::to_string(key));
+                    ba->set_medium("mem");
+                    auto *spec = ba->add_specs();
+                    spec->set_name(spec_name);
+                    spec->set_uri("event_report://" + host + "/mem");
+                }
+                proto::meta::ReportEventResponse resp;
+                ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+            };
+
+        const std::string full_host = "192.168.2.1:8080";
+        const std::string linear_host = "192.168.2.2:8080";
+        InitializeEventReporter(instance_id, full_host, proto::meta::ST_EVENT_REPORT_L2);
+        InitializeEventReporter(instance_id, linear_host, proto::meta::ST_EVENT_REPORT_L2);
+        report_spec(full_host, {800, 801}, "full_0");
+        report_spec(linear_host, {800}, "linear_1");
+
+        const std::vector<BackendSelector> selectors = {
+            {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+        };
+        BlockMask block_mask = static_cast<size_t>(0);
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                     instance_id,
+                                                                     CacheManager::QueryType::QT_BATCH_GET,
+                                                                     {800, 801},
+                                                                     {},
+                                                                     block_mask,
+                                                                     0,
+                                                                     {"linear_1"},
+                                                                     selectors);
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(2u, locs.size());
+        ASSERT_EQ(1u, locs[0].cache_locations_view().size());
+        ASSERT_EQ(1u, locs[0].cache_locations_view()[0].location_specs().size());
+        EXPECT_EQ(1u, locs[0].cache_locations_view()[0].spec_size());
+        EXPECT_EQ("linear_1", locs[0].cache_locations_view()[0].location_specs()[0].name());
+        EXPECT_NE(std::string::npos, locs[0].cache_locations_view()[0].location_specs()[0].uri().find(linear_host));
+        EXPECT_TRUE(locs[1].cache_locations_view().empty());
+    }
+
+    // --- Test 10: backend-selected queries enforce reporter liveness ---
     {
         for (const auto &peer : peer_data) {
-            event_report_backend->SetNodeUnavailable("test_instance", peer.host);
+            event_report_backend->SetNodeUnavailable(instance_id, peer.host);
         }
         const std::vector<BackendSelector> selectors = {
             {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
         };
         BlockMask block_mask = static_cast<size_t>(0);
         auto [hidden_ec, hidden] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                              "test_instance",
+                                                                              instance_id,
                                                                               CacheManager::QueryType::QT_BATCH_GET,
                                                                               all_keys,
                                                                               {},
@@ -6445,10 +6536,10 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         }
 
         for (const auto &peer : peer_data) {
-            ASSERT_EQ(EC_OK, event_report_backend->OnHeartbeat("test_instance", peer.host, {}));
+            ASSERT_EQ(EC_OK, event_report_backend->OnHeartbeat(instance_id, peer.host, {}));
         }
         auto [restored_ec, restored] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                                  "test_instance",
+                                                                                  instance_id,
                                                                                   CacheManager::QueryType::QT_BATCH_GET,
                                                                                   all_keys,
                                                                                   {},

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -881,6 +881,182 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocationSpecsIsIdempotentForMissingData)
     EXPECT_EQ("linear_0", specs[0].name());
 }
 
+TEST_F(MetaSearcherTest, TestBatchMutationWriteLeaseIsAcquiredOncePerRmwPhase) {
+    const MetaSearcher::KeyVector keys = {10081, 10082, 10083};
+    const std::string location_id = "kvs#event_report_l2#mem#lease-host:8080";
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        merge_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://lease-host:8080/mem?size=1")},
+        }});
+    }
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, merge_tasks, per_key_ec));
+
+    size_t acquire_count = 0;
+    MetaSearcher::AcquireMetadataWriteLeaseFunc acquire_write_lease = [&] {
+        ++acquire_count;
+        return std::make_pair(EC_OK, std::static_pointer_cast<void>(std::make_shared<size_t>(acquire_count)));
+    };
+
+    // Every key already has this location, so BatchMerge exercises both its
+    // block lookup and targeted location RMW phases with one lease per phase.
+    for (auto &tasks : merge_tasks) {
+        tasks[0].specs = {LocationSpec("tp1", "event_report://lease-host:8080/mem?size=2")};
+    }
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(
+                  request_context_.get(), keys, merge_tasks, per_key_ec, acquire_write_lease));
+    EXPECT_EQ(2u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), per_key_ec);
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        replace_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp2", "event_report://lease-host:8080/mem?size=3")},
+        }});
+    }
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchReplaceLocationSpecs(
+                  request_context_.get(), keys, replace_tasks, per_key_ec, acquire_write_lease));
+    EXPECT_EQ(1u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), per_key_ec);
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        delete_tasks.push_back({{location_id, {"tp2"}}});
+    }
+    std::vector<std::vector<ErrorCode>> delete_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocationSpecs(
+                  request_context_.get(), keys, delete_tasks, delete_results, nullptr, acquire_write_lease));
+    EXPECT_EQ(1u, acquire_count);
+    ASSERT_EQ(keys.size(), delete_results.size());
+    for (const auto &results : delete_results) {
+        EXPECT_EQ((std::vector<ErrorCode>{EC_OK}), results);
+    }
+}
+
+TEST_F(MetaSearcherTest, TestBatchMutationWriteLeaseFailurePreventsAllWrites) {
+    const MetaSearcher::KeyVector keys = {10084, 10085};
+    const std::string location_id = "kvs#event_report_l2#mem#fenced-host:8080";
+    size_t acquire_count = 0;
+    MetaSearcher::AcquireMetadataWriteLeaseFunc reject_write = [&] {
+        ++acquire_count;
+        return std::make_pair(EC_NODE_NOT_REGISTERED, MetaSearcher::MetadataWriteLease{});
+    };
+
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        merge_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://fenced-host:8080/mem")},
+        }});
+    }
+    std::vector<ErrorCode> per_key_ec;
+    EXPECT_EQ(
+        EC_ERROR,
+        meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, merge_tasks, per_key_ec, reject_write));
+    EXPECT_EQ(1u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_NODE_NOT_REGISTERED), per_key_ec);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    ASSERT_EQ(keys.size(), location_maps.size());
+    EXPECT_TRUE(std::all_of(
+        location_maps.begin(), location_maps.end(), [](const auto &locations) { return locations.empty(); }));
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        replace_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp1", "event_report://fenced-host:8080/mem")},
+        }});
+    }
+    EXPECT_NE(EC_OK,
+              meta_searcher_->BatchReplaceLocationSpecs(
+                  request_context_.get(), keys, replace_tasks, per_key_ec, reject_write));
+    EXPECT_EQ(1u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_NODE_NOT_REGISTERED), per_key_ec);
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        delete_tasks.push_back({{location_id, {"tp0"}}});
+    }
+    std::vector<std::vector<ErrorCode>> delete_results;
+    std::vector<std::vector<bool>> missing_targets;
+    EXPECT_NE(EC_OK,
+              meta_searcher_->BatchDeleteLocationSpecs(
+                  request_context_.get(), keys, delete_tasks, delete_results, &missing_targets, reject_write));
+    EXPECT_EQ(1u, acquire_count);
+    ASSERT_EQ(keys.size(), delete_results.size());
+    ASSERT_EQ(keys.size(), missing_targets.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        EXPECT_EQ((std::vector<ErrorCode>{EC_NODE_NOT_REGISTERED}), delete_results[i]);
+        EXPECT_EQ((std::vector<bool>{false}), missing_targets[i]);
+    }
+}
+
+TEST_F(MetaSearcherTest, TestBatchMergeReacquiresWriteLeaseBetweenRmwPhases) {
+    const MetaSearcher::KeyVector keys = {10086, 10087};
+    const std::string location_id = "kvs#event_report_l2#mem#lease-race:8080";
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://lease-race:8080/mem?phase=seed")},
+        }});
+    }
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec));
+
+    for (auto &per_key_tasks : tasks) {
+        per_key_tasks[0].specs = {LocationSpec("tp1", "event_report://lease-race:8080/mem?phase=stale")};
+    }
+    size_t acquire_count = 0;
+    MetaSearcher::AcquireMetadataWriteLeaseFunc fail_second_phase = [&] {
+        ++acquire_count;
+        if (acquire_count == 1) {
+            return std::make_pair(EC_OK, std::static_pointer_cast<void>(std::make_shared<size_t>(acquire_count)));
+        }
+        return std::make_pair(EC_NODE_NOT_REGISTERED, MetaSearcher::MetadataWriteLease{});
+    };
+    EXPECT_NE(
+        EC_OK,
+        meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec, fail_second_phase));
+    EXPECT_EQ(2u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_NODE_NOT_REGISTERED), per_key_ec);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    ASSERT_EQ(keys.size(), location_maps.size());
+    for (const auto &locations : location_maps) {
+        ASSERT_EQ(1u, locations.size());
+        const auto &specs = locations.at(location_id)->location_specs();
+        ASSERT_EQ(1u, specs.size());
+        EXPECT_EQ("tp0", specs[0].name());
+        EXPECT_EQ(std::string::npos, specs[0].uri().find("phase=stale"));
+    }
+}
+
 TEST_F(MetaSearcherTest, TestCleanupLocationsByPredicateSubmitsExactObservedValue) {
     const MetaSearcher::KeyVector keys = {10009, 10010};
     const std::string stale_id = "kvs#event_report_l2#mem#127.0.0.1:8080";
@@ -2031,6 +2207,74 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
 
 class BatchGetBestLocationByBackendTest : public MetaSearcherTest {
 protected:
+    void AddRequestedSpecMatrixEventReportPeer() {
+        // The requested spec is deliberately the second spec in the first
+        // and third locations. The middle key has the same reporter but only
+        // a different spec, forming a requested-spec gap.
+        std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> upserts = {
+            {
+                {"kvs#event_report_l2#mem#matrix_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {
+                     LocationSpec("full_0", "event_report://matrix_peer:8080/mem"),
+                     LocationSpec("linear_1", "event_report://matrix_peer:8080/mem"),
+                 }},
+            },
+            {
+                {"kvs#event_report_l2#mem#matrix_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("full_0", "event_report://matrix_peer:8080/mem")}},
+            },
+            {
+                {"kvs#event_report_l2#mem#matrix_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {
+                     LocationSpec("full_0", "event_report://matrix_peer:8080/mem"),
+                     LocationSpec("linear_1", "event_report://matrix_peer:8080/mem"),
+                 }},
+            },
+        };
+        std::vector<ErrorCode> per_key_ec;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchMergeLocationSpecs(
+                      request_context_.get(), {82000, 82001, 82002}, upserts, per_key_ec));
+        ASSERT_EQ(3u, per_key_ec.size());
+        EXPECT_TRUE(std::all_of(per_key_ec.begin(), per_key_ec.end(), [](ErrorCode ec) { return ec == EC_OK; }));
+    }
+
+    void AddSpecFilteredEventReportPeers() {
+        // full_peer has better raw coverage, but none of its locations match
+        // linear_1. linear_peer must therefore win after requested-spec
+        // filtering for both cross-key selection strategies.
+        std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> upserts = {
+            {
+                {"kvs#event_report_l2#mem#full_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("full_0", "event_report://full_peer:8080/mem")}},
+                {"kvs#event_report_l2#mem#linear_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("linear_1", "event_report://linear_peer:8080/mem")}},
+            },
+            {
+                {"kvs#event_report_l2#mem#full_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("full_0", "event_report://full_peer:8080/mem")}},
+            },
+        };
+        std::vector<ErrorCode> per_key_ec;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {81000, 81001}, upserts, per_key_ec));
+        ASSERT_EQ(2u, per_key_ec.size());
+        EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[0]);
+        EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[1]);
+    }
+
     void SetUp() override {
         MetaSearcherTest::SetUp();
 
@@ -2142,6 +2386,138 @@ TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageStrategy) {
         EXPECT_NE(out[i][0]->location_specs()[0].uri().find("peer_b"), std::string::npos);
     }
     EXPECT_TRUE(out[4].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixTieBreaksByPeerAddress) {
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {80000, 80001}, out, &policy_, selectors));
+
+    ASSERT_EQ(2u, out.size());
+    for (const auto &locations : out) {
+        ASSERT_EQ(1u, locations.size());
+        EXPECT_NE(locations[0]->location_specs()[0].uri().find("peer_a"), std::string::npos);
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageTieBreaksByPeerAddress) {
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {80000, 80001}, out, &policy_, selectors));
+
+    ASSERT_EQ(2u, out.size());
+    for (const auto &locations : out) {
+        ASSERT_EQ(1u, locations.size());
+        EXPECT_NE(locations[0]->location_specs()[0].uri().find("peer_a"), std::string::npos);
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixFiltersRequestedSpecBeforePeerSelection) {
+    AddSpecFilteredEventReportPeers();
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {81000, 81001}, out, &policy_, selectors, {"linear_1"}));
+
+    ASSERT_EQ(2u, out.size());
+    ASSERT_EQ(1u, out[0].size());
+    ASSERT_EQ(1u, out[0][0]->location_specs().size());
+    EXPECT_EQ("linear_1", out[0][0]->location_specs()[0].name());
+    EXPECT_NE(std::string::npos, out[0][0]->location_specs()[0].uri().find("linear_peer"));
+    EXPECT_TRUE(out[1].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageFiltersRequestedSpecBeforePeerSelection) {
+    AddSpecFilteredEventReportPeers();
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {81000, 81001}, out, &policy_, selectors, {"linear_1"}));
+
+    ASSERT_EQ(2u, out.size());
+    ASSERT_EQ(1u, out[0].size());
+    ASSERT_EQ(1u, out[0][0]->location_specs().size());
+    EXPECT_EQ("linear_1", out[0][0]->location_specs()[0].name());
+    EXPECT_NE(std::string::npos, out[0][0]->location_specs()[0].uri().find("linear_peer"));
+    EXPECT_TRUE(out[1].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportUnknownRequestedSpecReturnsNoCandidate) {
+    AddSpecFilteredEventReportPeers();
+    for (const auto strategy : {LocationSelectStrategy::LSS_V6D_PREFIX, LocationSelectStrategy::LSS_V6D_COVERAGE}) {
+        const std::vector<BackendSelector> selectors = {
+            {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, strategy},
+        };
+        LocationsPerKey out;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchGetBestLocationByBackend(
+                      request_context_.get(), {81000, 81001}, out, &policy_, selectors, {"missing_spec"}));
+        ASSERT_EQ(2u, out.size());
+        EXPECT_TRUE(out[0].empty());
+        EXPECT_TRUE(out[1].empty());
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportRequestedSpecMatchesAnyNameIncludingNonFirstSpec) {
+    AddRequestedSpecMatrixEventReportPeer();
+    for (const auto strategy : {LocationSelectStrategy::LSS_V6D_PREFIX, LocationSelectStrategy::LSS_V6D_COVERAGE}) {
+        const std::vector<BackendSelector> selectors = {
+            {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, strategy},
+        };
+        LocationsPerKey out;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchGetBestLocationByBackend(
+                      request_context_.get(), {82000}, out, &policy_, selectors, {"missing", "linear_1", "linear_1"}));
+        ASSERT_EQ(1u, out.size());
+        ASSERT_EQ(1u, out[0].size());
+        ASSERT_EQ(2u, out[0][0]->location_specs().size());
+        EXPECT_EQ("full_0", out[0][0]->location_specs()[0].name());
+        EXPECT_EQ("linear_1", out[0][0]->location_specs()[1].name());
+        EXPECT_NE(std::string::npos, out[0][0]->location_specs()[0].uri().find("matrix_peer"));
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportRequestedSpecGapStopsPrefixButNotCoverage) {
+    AddRequestedSpecMatrixEventReportPeer();
+    const MetaSearcher::KeyVector keys = {82000, 82001, 82002};
+
+    LocationsPerKey prefix_out;
+    const std::vector<BackendSelector> prefix_selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+    };
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), keys, prefix_out, &policy_, prefix_selectors, {"linear_1"}));
+    ASSERT_EQ(3u, prefix_out.size());
+    ASSERT_EQ(1u, prefix_out[0].size());
+    EXPECT_TRUE(prefix_out[1].empty());
+    EXPECT_TRUE(prefix_out[2].empty());
+
+    LocationsPerKey coverage_out;
+    const std::vector<BackendSelector> coverage_selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
+    };
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), keys, coverage_out, &policy_, coverage_selectors, {"linear_1"}));
+    ASSERT_EQ(3u, coverage_out.size());
+    ASSERT_EQ(1u, coverage_out[0].size());
+    EXPECT_TRUE(coverage_out[1].empty());
+    ASSERT_EQ(1u, coverage_out[2].size());
 }
 
 TEST_F(BatchGetBestLocationByBackendTest, PrefixStopsAtGap) {


### PR DESCRIPTION
## What

- Add request-level `location_spec_names` filtering before V6D prefix/coverage peer selection, then project selected locations to the requested specs.
- Make equal-prefix/equal-coverage peer selection deterministic by endpoint.
- Deduplicate reporter medium registration inside one ReportEvent request and add a shared-lock fast path for already-known node media.
- Acquire the reporter lifecycle lease once per metadata RMW phase instead of once per key, while keeping acquisition after metadata reads so HOST_DOWN/REGISTER can still fence stalled stale work.
- Add adversarial query, large-batch, lease-failure, node-concurrency, HOST_DOWN/re-registration, and real HTTP/Redis capacity coverage.
- Document the cross-repository contract, lifecycle lock ordering, observed performance baseline, and the safe boundary for a future targeted Redis read API.

## Why

Vineyard reports one ReportEvent spec per vLLM KV-cache group and queries those groups independently. Previously, an unrelated group spec could influence peer selection.

For small block sizes, a single request can also carry thousands of events. The old hot path took the node table's exclusive lock for every event and repeatedly looked up/allocated the same lifecycle shared lock for every key (twice for existing-location ADD). The new implementation reduces those operations to unique media per request and one lease per RMW phase without weakening lifecycle fencing.

The implementation preserves these reviewed producer and lifecycle invariants:

- vLLM/Vineyard may report a uint64 decimal block key; KVCM normalizes it to the query API's int64 bit pattern.
- All specs merged into one EventReport location belong to the same reporter/medium endpoint, so extracting the first valid spec URI after location-level filtering remains correct.
- A mutation blocked in metadata I/O does not hold the lifecycle lease; HOST_DOWN or a new REGISTER may win, after which the stale mutation fails before writing.
- Fresh reporters can still send an empty snapshot, and a delta may appear before an explicit REGISTER in the same request.

## Impact

Group-scoped Vineyard lookups no longer select peers using unrelated specs, and repeated per-group queries choose the same peer when candidates tie. Existing callers without `location_spec_names` keep their previous behavior.

For a 5,000-event request, reporter-node ensure calls fall from 5,000 to one for a repeated medium; lifecycle lease acquisition falls from up to 10,000 calls for existing-location ADD to two RMW-phase calls. Redis metadata I/O is intentionally unchanged in this patch and remains the next measured bottleneck.

## Checks

- Debug full targets: `EventReportBackendTest`, `MetaSearcherTest`, and all 10 `CacheManagerTest` shards.
- ASAN targeted node concurrency, large delta batch, lifecycle lease failure/reacquisition, HOST_DOWN, old-lifecycle, and empty-snapshot cases.
- Deterministic HOST_DOWN tests caught and prevented acquiring the lifecycle lease before metadata reads.
- Real HTTP + Redis 7.2.5 benchmark validated create/update batches of 100, 1,000, and 5,000 events and queried the first/middle/last key in each batch.
- Local 5,000-event results on this development host: 303.59ms create and 420.14ms existing-location update; recorded as a reproducible baseline, not an SLA.
- Python AST parse and `git diff --check`.
