### PR TITLE
[ci] add ASAN test job

### DIFF
--- a/.github/workflows/scheduled-cache-rebuild.yml
+++ b/.github/workflows/scheduled-cache-rebuild.yml
@@ -19,7 +19,7 @@ jobs:
           gh workflow run test-opensrc.yml \
             --repo ${{ github.repository }} \
             --ref main \
-            -f runs-on=ubuntu-latest \
+            -f runs-on=aliyun-ecs-x64 \
             -f rebuildDiskCache=true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -37,6 +37,9 @@ jobs:
           - name: integration_test
             test_target: "//integration_test/..."
             test_args: ""
+          - name: asan_test
+            test_target: "//kv_cache_manager/... //integration_test/..."
+            test_args: "--config=debug --config=asan"
           - name: client_test
             test_target: "//kv_cache_manager/client/..."
             test_args: "--config=client"
@@ -109,7 +112,7 @@ jobs:
           # setup-bazel's internal key format, while not deleting other arches' caches.
           RUNNER_ARCH_LOWER=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
           DISK_CACHE_NAME="disk-${{ runner.os }}-${{ github.workflow }}-${{ matrix.name }}"
-          gh cache list --repo ${{ github.repository }} --json id,key --limit 100 | \
+          gh cache list --repo ${{ github.repository }} --ref "${{ github.ref }}" --json id,key --limit 100 | \
             jq -r --arg arch "$RUNNER_ARCH_LOWER" --arg name "$DISK_CACHE_NAME" \
               '.[] | select((.key | contains($arch)) and (.key | contains($name))) | .id' | \
             xargs -I {} gh cache delete {} --repo ${{ github.repository }} || true

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -158,4 +158,4 @@ githooks中已经添加了C++等语言的格式化脚本，请确保开发环境
 提交前检查和 commit message 格式见 [Commit 要求](commit_requirements.md)。
 
 ## CI
-可参考```.github/workflows```目录下的配置。
+可参考```.github/workflows```目录下的配置。```test-opensrc``` 包含普通测试和 ASAN 测试。


### PR DESCRIPTION
## Summary

- add a dedicated ASAN matrix job for all KVCache Manager and integration test targets
- keep ASAN on its own setup-bazel disk cache while continuing to run tests with `--config=ci_fast`
- keep cache writes limited to explicit rebuilds and scope cache replacement to the current ref
- run the scheduled disk-cache rebuild on `aliyun-ecs-x64`

## Why

ASAN outputs cannot be reused by non-ASAN builds. Keeping it as a separate job and cache provides sanitizer coverage without fragmenting the existing normal test jobs further.

## Validation

- Manual workflow dispatch passed with the same ASAN target and config matrix: https://github.com/alibaba/tair-kvcache/actions/runs/30616690259
- Workflow YAML parsing and `git diff --check` passed

## Stack

This is PR 1 of 2. Follow-up: #268.