### PR TITLE
[ci] consolidate non-ASAN test jobs

### DIFF
--- a/.github/workflows/test-opensrc.yml
+++ b/.github/workflows/test-opensrc.yml
@@ -31,18 +31,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: unit_test
-            test_target: "//kv_cache_manager/..."
-            test_args: ""
-          - name: integration_test
-            test_target: "//integration_test/..."
+          - name: normal_test
+            test_target: "//kv_cache_manager/... //integration_test/..."
             test_args: ""
           - name: asan_test
             test_target: "//kv_cache_manager/... //integration_test/..."
             test_args: "--config=debug --config=asan"
-          - name: client_test
-            test_target: "//kv_cache_manager/client/..."
-            test_args: "--config=client"
     name: ${{ matrix.name }}
     runs-on: ${{ inputs.runs-on || vars.TEST_OPEN_SRC_RUNS_ON || 'ubuntu-latest' }}
     container:

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -158,4 +158,4 @@ githooks中已经添加了C++等语言的格式化脚本，请确保开发环境
 提交前检查和 commit message 格式见 [Commit 要求](commit_requirements.md)。
 
 ## CI
-可参考```.github/workflows```目录下的配置。```test-opensrc``` 包含普通测试和 ASAN 测试。
+可参考```.github/workflows```目录下的配置。```test-opensrc``` 在一个 ```normal_test``` job 中运行普通单元测试和集成测试（包含默认配置下的客户端测试目标），ASAN 测试使用独立 job。


### PR DESCRIPTION
## Summary

- replace the separate unit, integration, and client jobs with one `normal_test` job
- run the complete normal target set once with the default build configuration and `--config=ci_fast`
- use one setup-bazel disk cache for the consolidated normal test job
- update the CI documentation to describe the consolidated layout

## Why

The three previous jobs compile overlapping dependency graphs and maintain separate caches. Consolidating them preserves the test target set while reducing runner usage and GitHub Actions cache consumption.

The superseded unit, integration, and client caches are intentionally left untouched by this PR and can be deleted once after merge.

## Validation

- Manual workflow dispatch passed for both `normal_test` and `asan_test` with the same target/config matrix: https://github.com/alibaba/tair-kvcache/actions/runs/30617614114
- Workflow YAML parsing and `git diff --check` passed

## Stack

Depends on #267. This PR should be reviewed and merged after the ASAN PR.