### PR TITLE
[test] stabilize flaky test cases

### DIFF
--- a/integration_test/reclaimer/reclaiming_test.py
+++ b/integration_test/reclaimer/reclaiming_test.py
@@ -88,7 +88,7 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         time.sleep(2)
 
         # now the writing should success
-        self._write(16)
+        self._write_expect_accepted_after_reclaim(16)
 
     def test_reclaiming_01(self):
         """Test start-writing -> reclaiming -> finish-writing."""
@@ -153,13 +153,13 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         # now finish write block 0~15
         for i in range(16):
             # no verify because the location could have been reclaimed
-            self._finish_write_with_verify(i, verify=False)
+            self._finish_write_with_verify(i, verify_readback=False)
 
         time.sleep(2)
         # at least one block in 0~15 should be reclaimed already
         # which give room to block 16
         # now the writing of key=16 should success
-        self._write(16)
+        self._write_expect_accepted_after_reclaim(16)
 
     def test_reclaiming_02(self):
         """Test that CLS_WRITING keys left over after a server restart
@@ -274,7 +274,7 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
 
         # the orphaned CLS_WRITING should not stop the evicting
         # new write should now be accepted
-        self._write(16)
+        self._write_expect_accepted_after_reclaim(16)
 
     def test_no_over_eviction_with_delay(self):
         """In-flight byte credit prevents repeated delayed batches."""
@@ -918,7 +918,7 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
 
         # write should succeed only if reclaiming happened, which
         # requires storage_usage_data to have survived the restart
-        self._write(16)
+        self._write_expect_accepted_after_reclaim(16)
 
     def _get_manager_client(self):
         self._admin_http_port = self.worker_manager.get_worker(
@@ -933,7 +933,7 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             MetaServiceHttpClient(self._http_url),
         )
 
-    def _write(self, blk_key):
+    def _write(self, blk_key, verify_readback=True):
         logging.info(f"write block key: {blk_key}")
         trace_id = f"{self._trace_id}_blk_key_{blk_key}"
 
@@ -941,7 +941,15 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         self._start_write(blk_key)
 
         # finish write cache
-        self._finish_write_with_verify(blk_key)
+        self._finish_write_with_verify(blk_key, verify_readback=verify_readback)
+
+    def _write_expect_accepted_after_reclaim(self, blk_key):
+        """Assert a write is accepted after reclaim opens capacity.
+
+        The reclaimer remains active in these scenarios, so the new location may
+        be evicted before an immediate get_cache_location readback.
+        """
+        self._write(blk_key, verify_readback=False)
 
     def _start_write_expect_fail(self, blk_key):
         logging.info(f"start write expecting failure, block key: {blk_key}")
@@ -1000,7 +1008,7 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         logging.info(
             f"block key: {blk_key} start write OK with write session id: {write_session_id}")
 
-    def _finish_write_with_verify(self, blk_key, verify=True):
+    def _finish_write_with_verify(self, blk_key, verify_readback=True):
         # finish write cache
         trace_id = f"{self._trace_id}_blk_key_{blk_key}"
         resp = self._resp_dict[blk_key]
@@ -1018,7 +1026,7 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             }
         }
         self._client.finish_write_cache(finish_write_req)
-        if not verify:
+        if not verify_readback:
             return
 
         # get cache location to verify it was added correctly

--- a/kv_cache_manager/common/test/loop_thread_test.cc
+++ b/kv_cache_manager/common/test/loop_thread_test.cc
@@ -101,11 +101,15 @@ TEST_F(LoopThreadTest, TestStrictMode) {
         true); // 严格模式
     EXPECT_NE(loop_thread, nullptr);
 
-    // 等待一段时间
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-
-    int final_count = count.load();
-    EXPECT_GT(final_count, 0);
+    auto start_time = std::chrono::steady_clock::now();
+    const auto timeout = std::chrono::seconds(1);
+    while (count.load() == 0) {
+        if (std::chrono::steady_clock::now() - start_time > timeout) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_GT(count.load(), 0);
 
     loop_thread->Stop();
 }

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -510,12 +510,20 @@ TEST_F(EventReportBackendTest, RegisterAfterCleanupCreatesNewEntry) {
     }
     ASSERT_GE(cleanup_calls.load(), 1);
 
-    EXPECT_EQ(backend.instance_nodes_["test_inst"].count("10.0.0.6:8080"), 0u);
+    const auto cleanup_deadline = std::chrono::steady_clock::now() + 1s;
+    while (backend.IsNodeRegistered("test_inst", "10.0.0.6:8080") &&
+           std::chrono::steady_clock::now() < cleanup_deadline) {
+        std::this_thread::yield();
+    }
+    ASSERT_FALSE(backend.IsNodeRegistered("test_inst", "10.0.0.6:8080"));
 
     ASSERT_EQ(EC_OK, backend.RegisterNode("test_inst", "10.0.0.6:8080", {"mem", "disk"}));
     ASSERT_TRUE(backend.IsNodeAvailable("test_inst", "10.0.0.6:8080"));
     {
-        auto &host_map = backend.instance_nodes_["test_inst"];
+        std::shared_lock<std::shared_mutex> lock(backend.nodes_mutex_);
+        auto instance_it = backend.instance_nodes_.find("test_inst");
+        ASSERT_NE(instance_it, backend.instance_nodes_.end());
+        auto &host_map = instance_it->second;
         auto it = host_map.find("10.0.0.6:8080");
         ASSERT_NE(it, host_map.end());
         EXPECT_EQ(it->second->mediums.size(), 2u);
@@ -1829,9 +1837,20 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         auto waiting_snapshot = std::async(std::launch::async, [&] {
             std::string candidate;
             uint64_t retry_ms = 0;
-            return BeginSnapshotForRegisteredReporter(backend, reporter_key, candidate, retry_ms);
+            return backend.BeginSnapshot(reporter_key, candidate, retry_ms);
         });
-        ASSERT_EQ(std::future_status::timeout, waiting_snapshot.wait_for(20ms));
+        std::string observed_committed;
+        std::string observed_in_flight;
+        const auto in_flight_deadline = std::chrono::steady_clock::now() + 1s;
+        do {
+            backend.GetSnapshotVersionTokens(reporter_key, observed_committed, observed_in_flight);
+            if (!observed_in_flight.empty()) {
+                break;
+            }
+            std::this_thread::yield();
+        } while (std::chrono::steady_clock::now() < in_flight_deadline);
+        ASSERT_FALSE(observed_in_flight.empty());
+        ASSERT_EQ(std::future_status::timeout, waiting_snapshot.wait_for(0ms));
         ASSERT_EQ(EC_OK, backend.Close());
         ASSERT_EQ(std::future_status::ready, waiting_snapshot.wait_for(1s));
         EXPECT_EQ(EC_SNAPSHOT_REQUIRED, waiting_snapshot.get());
@@ -1850,10 +1869,14 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         std::string second;
         ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, second, retry_after_ms));
 
+        std::promise<void> delta_call_started;
+        auto delta_call_started_future = delta_call_started.get_future();
         auto waiting_delta = std::async(std::launch::async, [&] {
+            delta_call_started.set_value();
             std::string committed;
             return backend.BeginDeltaMutation(reporter_key, committed);
         });
+        ASSERT_EQ(std::future_status::ready, delta_call_started_future.wait_for(1s));
         ASSERT_EQ(std::future_status::timeout, waiting_delta.wait_for(20ms));
         ASSERT_EQ(EC_OK, backend.Close());
         ASSERT_EQ(std::future_status::ready, waiting_delta.wait_for(1s));

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -318,13 +318,14 @@ TEST_F(EventReportBackendTest, LivenessLoopHealthyToUnavailableToCleanup) {
     ASSERT_FALSE(backend.IsNodeAvailable("test_inst", "10.0.0.4:8080"));
     EXPECT_EQ(cleanup_calls.load(), 0);
 
-    for (int i = 0; i < 50 && cleanup_calls.load() == 0; ++i) {
-        std::this_thread::sleep_for(20ms);
+    const auto cleanup_deadline = std::chrono::steady_clock::now() + 1s;
+    while (backend.IsNodeRegistered("test_inst", "10.0.0.4:8080") &&
+           std::chrono::steady_clock::now() < cleanup_deadline) {
+        std::this_thread::yield();
     }
+    ASSERT_FALSE(backend.IsNodeRegistered("test_inst", "10.0.0.4:8080"));
     EXPECT_GE(cleanup_calls.load(), 1);
     EXPECT_EQ(cleanup_host, "10.0.0.4:8080");
-
-    EXPECT_EQ(backend.instance_nodes_["test_inst"].count("10.0.0.4:8080"), 0u);
 
     ASSERT_EQ(EC_OK, backend.Close());
 }


### PR DESCRIPTION
## Summary

- replace fixed sleeps in flaky tests with condition-based waits
- synchronize event report backend cleanup assertions with the liveness loop
- clarify post-reclaim write acceptance checks so active reclaim does not race immediate readback assertions

## Motivation

The ASAN CI surfaced a flaky `EventReportBackendTest.LivenessLoopHealthyToUnavailableToCleanup` failure without an ASAN report. The failure was caused by the test observing the cleanup callback before the backend unregister operation had completed. This PR keeps the stability fixes scoped to test behavior and assertions.

## Validation

- `bazelisk test //integration_test/reclaimer:reclaiming_test --config=ci_fast --cache_test_results=no --test_output=errors`
- `bazelisk test //kv_cache_manager/common/test:LoopThreadTest //kv_cache_manager/data_storage/test:EventReportBackendTest --config=debug --config=asan --config=ci_fast --cache_test_results=no --test_output=errors`
- `bazelisk test //kv_cache_manager/data_storage/test:EventReportBackendTest --config=debug --config=asan --config=ci_fast --cache_test_results=no --runs_per_test=50 --test_output=errors` passed before the latest history rewrite
- GitHub Actions will validate the updated branch
