### PR TITLE
[manager] converge BatchAddLocation rollback compensation into MetaSearcher

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1130,12 +1130,31 @@ void CacheManager::RollbackAddLocations(RequestContext *request_context,
         return;
     }
 
-    CacheLocationDelRequest metadata_rollback{.instance_id = instance_id, .delay = std::chrono::seconds(0)};
-    std::map<std::string, std::vector<DataStorageUri>> direct_delete_uris;
-    KeyVector uncertain_keys;
-    std::vector<std::string> uncertain_location_ids;
-    std::vector<size_t> uncertain_indices;
+    MetaSearcher *meta_searcher = meta_searcher_manager_->GetMetaSearcher(instance_id);
+    if (!meta_searcher) {
+        // 无法确认任何项的元数据状态：URI 全部保留，confirmed success 的 WRITING
+        // location 由既有清理扫描兜底。
+        PREFIX_LOG(ERROR, "rollback add locations failed: meta searcher not found");
+        return;
+    }
+    MetaSearcher::AddLocationRollbackPlan plan;
+    if (meta_searcher->ReconcileAddLocationRollback(request_context, keys, add_results, plan) != EC_OK) {
+        PREFIX_LOG(ERROR, "rollback add locations reconcile failed, key_count[%lu]", keys.size());
+        return;
+    }
 
+    // 已成功写入元数据的 location 复用标准删除流水线：标记 DELETING、Sync、删 URI、删元数据。
+    if (!plan.pipeline_keys.empty()) {
+        CacheLocationDelRequest metadata_rollback{.instance_id = instance_id, .delay = std::chrono::seconds(0)};
+        metadata_rollback.block_keys = plan.pipeline_keys;
+        metadata_rollback.location_ids.reserve(plan.pipeline_location_ids.size());
+        for (const auto &location_id : plan.pipeline_location_ids) {
+            metadata_rollback.location_ids.push_back({location_id});
+        }
+        reclaimer_task_supervisor_->Submit(trace_id, std::move(metadata_rollback));
+    }
+
+    std::map<std::string, std::vector<DataStorageUri>> direct_delete_uris;
     auto queue_uri_delete = [&](size_t index) {
         if (!locations[index]) {
             PREFIX_LOG(WARN, "rollback add location has null location, key[%lu](%lu)", index, keys[index]);
@@ -1154,75 +1173,11 @@ void CacheManager::RollbackAddLocations(RequestContext *request_context,
             direct_delete_uris[uri.GetHostName()].push_back(std::move(uri));
         }
     };
-
-    for (size_t i = 0; i < keys.size(); ++i) {
-        const auto &add_result = add_results[i];
-        if (add_result.ec == EC_OK && !add_result.location_id.empty()) {
-            metadata_rollback.block_keys.push_back(keys[i]);
-            metadata_rollback.location_ids.push_back({add_result.location_id});
-            continue;
-        }
-        if (!add_result.location_id.empty()) {
-            // location id 已生成但写结果失败/未知：先做幂等元数据删除，确认无引用后才能删 URI。
-            uncertain_keys.push_back(keys[i]);
-            uncertain_location_ids.push_back(add_result.location_id);
-            uncertain_indices.push_back(i);
-            continue;
-        }
-        queue_uri_delete(i);
+    for (const size_t index : plan.direct_delete_indices) {
+        queue_uri_delete(index);
     }
-
-    // 已成功写入元数据的 location 复用标准删除流水线：标记 DELETING、Sync、删 URI、删元数据。
-    if (!metadata_rollback.block_keys.empty()) {
-        reclaimer_task_supervisor_->Submit(trace_id, std::move(metadata_rollback));
-    }
-
-    if (!uncertain_keys.empty()) {
-        MetaSearcher *meta_searcher = meta_searcher_manager_->GetMetaSearcher(instance_id);
-        if (!meta_searcher) {
-            PREFIX_LOG(ERROR, "rollback uncertain add locations failed: meta searcher not found");
-        } else {
-            LocationIdsPerKey location_ids_per_key;
-            location_ids_per_key.reserve(uncertain_location_ids.size());
-            for (const auto &location_id : uncertain_location_ids) {
-                location_ids_per_key.push_back({location_id});
-            }
-            std::vector<std::vector<ErrorCode>> delete_results;
-            meta_searcher->BatchDeleteLocations(request_context,
-                                                uncertain_keys,
-                                                location_ids_per_key,
-                                                delete_results,
-                                                {},
-                                                false /* these failed adds were never included in usage */,
-                                                false /* failed adds were never counted as new keys */);
-            KeyVector deleted_metadata_keys;
-            for (size_t i = 0; i < uncertain_indices.size(); ++i) {
-                if (i < delete_results.size() && delete_results[i].size() == 1 &&
-                    delete_results[i].front() == EC_OK) {
-                    deleted_metadata_keys.push_back(uncertain_keys[i]);
-                }
-            }
-
-            bool metadata_synced = true;
-            if (!deleted_metadata_keys.empty()) {
-                auto meta_indexer = meta_indexer_manager_->GetMetaIndexer(instance_id);
-                metadata_synced = meta_indexer && meta_indexer->Sync(deleted_metadata_keys);
-                if (!metadata_synced) {
-                    PREFIX_LOG(WARN,
-                               "rollback uncertain add locations failed to sync deleted metadata, key_count[%zu]",
-                               deleted_metadata_keys.size());
-                }
-            }
-            for (size_t i = 0; i < uncertain_indices.size(); ++i) {
-                if (i >= delete_results.size() || delete_results[i].size() != 1) {
-                    continue;
-                }
-                const ErrorCode delete_ec = delete_results[i].front();
-                if (delete_ec == EC_NOENT || (delete_ec == EC_OK && metadata_synced)) {
-                    queue_uri_delete(uncertain_indices[i]);
-                }
-            }
-        }
+    if (direct_delete_uris.empty()) {
+        return;
     }
 
     auto data_storage_manager = registry_manager_->data_storage_manager();
@@ -1230,7 +1185,7 @@ void CacheManager::RollbackAddLocations(RequestContext *request_context,
         PREFIX_LOG(ERROR, "rollback add locations failed: data storage manager not found");
         return;
     }
-    // 明确未写入元数据的项没有 location 可交给删除流水线，直接释放其已分配 URI。
+    // 已确认元数据无引用的项直接释放其已分配 URI。
     for (const auto &[storage_name, uris] : direct_delete_uris) {
         const auto delete_results = data_storage_manager->Delete(request_context, storage_name, uris, nullptr);
         if (delete_results.size() != uris.size()) {

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1131,14 +1131,17 @@ void CacheManager::RollbackAddLocations(RequestContext *request_context,
     }
 
     MetaSearcher *meta_searcher = meta_searcher_manager_->GetMetaSearcher(instance_id);
-    if (!meta_searcher) {
-        // 无法确认任何项的元数据状态：URI 全部保留，confirmed success 的 WRITING
-        // location 由既有清理扫描兜底。
-        PREFIX_LOG(ERROR, "rollback add locations failed: meta searcher not found");
-        return;
-    }
     MetaSearcher::AddLocationRollbackPlan plan;
-    if (meta_searcher->ReconcileAddLocationRollback(request_context, keys, add_results, plan) != EC_OK) {
+    if (!meta_searcher) {
+        // 无元数据访问时无法 reconcile uncertain 项，只能保留其 URI；但
+        // confirmed-success 与无 ID 项的清理不依赖元数据，照常执行。
+        const size_t uncertain_count = MetaSearcher::ClassifyAddLocationRollback(keys, add_results, plan);
+        PREFIX_LOG(ERROR,
+                   "rollback add locations without meta searcher: uncertain URIs retained, uncertain_count[%lu], "
+                   "key_count[%lu]",
+                   uncertain_count,
+                   keys.size());
+    } else if (meta_searcher->ReconcileAddLocationRollback(request_context, keys, add_results, plan) != EC_OK) {
         PREFIX_LOG(ERROR, "rollback add locations reconcile failed, key_count[%lu]", keys.size());
         return;
     }

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -1044,6 +1044,97 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
     return aggregate_ec;
 }
 
+ErrorCode MetaSearcher::ReconcileAddLocationRollback(RequestContext *request_context,
+                                                     const KeyVector &keys,
+                                                     const std::vector<AddLocationResult> &add_results,
+                                                     AddLocationRollbackPlan &out_plan) {
+    out_plan = {};
+    if (keys.size() != add_results.size()) {
+        KVCM_LOG_ERROR("ReconcileAddLocationRollback input size mismatch, keys[%lu], results[%lu]",
+                       keys.size(),
+                       add_results.size());
+        return EC_BADARGS;
+    }
+
+    KeyVector uncertain_keys;
+    std::vector<std::string> uncertain_location_ids;
+    std::vector<size_t> uncertain_indices;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const auto &add_result = add_results[i];
+        if (add_result.ec == EC_OK && !add_result.location_id.empty()) {
+            out_plan.pipeline_keys.push_back(keys[i]);
+            out_plan.pipeline_location_ids.push_back(add_result.location_id);
+        } else if (!add_result.location_id.empty()) {
+            // location id 已生成但写结果失败/未知：先做幂等元数据删除，确认无引用后才能删 URI。
+            uncertain_keys.push_back(keys[i]);
+            uncertain_location_ids.push_back(add_result.location_id);
+            uncertain_indices.push_back(i);
+        } else {
+            out_plan.direct_delete_indices.push_back(i);
+        }
+    }
+
+    if (uncertain_keys.empty()) {
+        return EC_OK;
+    }
+
+    LocationIdsPerKey location_ids_per_key;
+    location_ids_per_key.reserve(uncertain_location_ids.size());
+    for (const auto &location_id : uncertain_location_ids) {
+        location_ids_per_key.push_back({location_id});
+    }
+    std::vector<std::vector<ErrorCode>> delete_results;
+    const ErrorCode delete_ec = BatchDeleteLocations(request_context,
+                                                     uncertain_keys,
+                                                     location_ids_per_key,
+                                                     delete_results,
+                                                     {},
+                                                     false /* these failed adds were never included in usage */,
+                                                     false /* failed adds were never counted as new keys */);
+    const size_t invalid_result_count =
+        std::count_if(delete_results.begin(), delete_results.end(), [](const auto &per_location_results) {
+            return per_location_results.size() != 1;
+        });
+    if (delete_results.size() != uncertain_keys.size() || invalid_result_count != 0) {
+        KVCM_LOG_WARN("ReconcileAddLocationRollback metadata delete returned unexpected result shape, expected %zu, "
+                      "got %zu, invalid inner result count %zu, ec %d; retaining URIs",
+                      uncertain_keys.size(),
+                      delete_results.size(),
+                      invalid_result_count,
+                      delete_ec);
+        return EC_OK;
+    }
+
+    KeyVector sync_keys;
+    for (size_t i = 0; i < delete_results.size(); ++i) {
+        if (delete_results[i].front() == EC_OK) {
+            sync_keys.push_back(uncertain_keys[i]);
+        }
+    }
+    bool metadata_synced = true;
+    if (!sync_keys.empty()) {
+        metadata_synced = meta_indexer_->Sync(sync_keys);
+        if (!metadata_synced) {
+            KVCM_LOG_WARN("ReconcileAddLocationRollback failed to sync deleted metadata, key_count[%zu]",
+                          sync_keys.size());
+        }
+    }
+
+    for (size_t i = 0; i < delete_results.size(); ++i) {
+        const ErrorCode per_location_ec = delete_results[i].front();
+        if (per_location_ec == EC_NOENT || (per_location_ec == EC_OK && metadata_synced)) {
+            out_plan.direct_delete_indices.push_back(uncertain_indices[i]);
+        } else if (per_location_ec != EC_OK) {
+            KVCM_LOG_WARN("ReconcileAddLocationRollback metadata delete failed, key[%lu](%lu), location_id %s, ec %d",
+                          i,
+                          uncertain_keys[i],
+                          uncertain_location_ids[i].c_str(),
+                          per_location_ec);
+        }
+    }
+    return EC_OK;
+}
+
 ErrorCode
 MetaSearcher::BatchReplaceLocationSpecs(RequestContext *request_context,
                                         const KeyVector &keys,

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -1044,6 +1044,44 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
     return aggregate_ec;
 }
 
+namespace {
+
+void ClassifyAddLocationRollbackItems(const KeyVector &keys,
+                                      const std::vector<MetaSearcher::AddLocationResult> &add_results,
+                                      MetaSearcher::AddLocationRollbackPlan &out_plan,
+                                      KeyVector &uncertain_keys,
+                                      std::vector<std::string> &uncertain_location_ids,
+                                      std::vector<size_t> &uncertain_indices) {
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const auto &add_result = add_results[i];
+        if (add_result.ec == EC_OK && !add_result.location_id.empty()) {
+            out_plan.pipeline_keys.push_back(keys[i]);
+            out_plan.pipeline_location_ids.push_back(add_result.location_id);
+        } else if (!add_result.location_id.empty()) {
+            // location id 已生成但写结果失败/未知：先做幂等元数据删除，确认无引用后才能删 URI。
+            uncertain_keys.push_back(keys[i]);
+            uncertain_location_ids.push_back(add_result.location_id);
+            uncertain_indices.push_back(i);
+        } else {
+            out_plan.direct_delete_indices.push_back(i);
+        }
+    }
+}
+
+} // namespace
+
+size_t MetaSearcher::ClassifyAddLocationRollback(const KeyVector &keys,
+                                                 const std::vector<AddLocationResult> &add_results,
+                                                 AddLocationRollbackPlan &out_plan) {
+    out_plan = {};
+    KeyVector uncertain_keys;
+    std::vector<std::string> uncertain_location_ids;
+    std::vector<size_t> uncertain_indices;
+    ClassifyAddLocationRollbackItems(
+        keys, add_results, out_plan, uncertain_keys, uncertain_location_ids, uncertain_indices);
+    return uncertain_keys.size();
+}
+
 ErrorCode MetaSearcher::ReconcileAddLocationRollback(RequestContext *request_context,
                                                      const KeyVector &keys,
                                                      const std::vector<AddLocationResult> &add_results,
@@ -1059,20 +1097,8 @@ ErrorCode MetaSearcher::ReconcileAddLocationRollback(RequestContext *request_con
     KeyVector uncertain_keys;
     std::vector<std::string> uncertain_location_ids;
     std::vector<size_t> uncertain_indices;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        const auto &add_result = add_results[i];
-        if (add_result.ec == EC_OK && !add_result.location_id.empty()) {
-            out_plan.pipeline_keys.push_back(keys[i]);
-            out_plan.pipeline_location_ids.push_back(add_result.location_id);
-        } else if (!add_result.location_id.empty()) {
-            // location id 已生成但写结果失败/未知：先做幂等元数据删除，确认无引用后才能删 URI。
-            uncertain_keys.push_back(keys[i]);
-            uncertain_location_ids.push_back(add_result.location_id);
-            uncertain_indices.push_back(i);
-        } else {
-            out_plan.direct_delete_indices.push_back(i);
-        }
-    }
+    ClassifyAddLocationRollbackItems(
+        keys, add_results, out_plan, uncertain_keys, uncertain_location_ids, uncertain_indices);
 
     if (uncertain_keys.empty()) {
         return EC_OK;

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -102,6 +102,26 @@ public:
                                const KeyVector &keys,
                                const CacheLocationVector &locations,
                                std::vector<AddLocationResult> &out_results);
+    struct AddLocationRollbackPlan {
+        // Confirmed-successful items (EC_OK + non-empty location id). The
+        // caller submits these to the standard location delete pipeline.
+        KeyVector pipeline_keys;
+        std::vector<std::string> pipeline_location_ids;
+        // Indices into the original batch whose metadata is confirmed to hold
+        // no reference (or was never written). The caller may delete their
+        // allocated URIs directly.
+        std::vector<size_t> direct_delete_indices;
+    };
+    // Reconciles a failed BatchAddLocation batch into a rollback plan.
+    // Confirmed-successful items are routed to the standard delete pipeline;
+    // uncertain items (location id generated but write result failed/unknown)
+    // are idempotently deleted from metadata and synced before their URIs may
+    // be released. Whenever an item's metadata state cannot be confirmed, its
+    // URI is retained (not added to direct_delete_indices).
+    ErrorCode ReconcileAddLocationRollback(RequestContext *request_context,
+                                           const KeyVector &keys,
+                                           const std::vector<AddLocationResult> &add_results,
+                                           AddLocationRollbackPlan &out_plan);
     struct ReplaceLocationSpecsTask {
         std::string location_id;
         DataStorageType type;

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -122,6 +122,13 @@ public:
                                            const KeyVector &keys,
                                            const std::vector<AddLocationResult> &add_results,
                                            AddLocationRollbackPlan &out_plan);
+    // Metadata-free classification used when no MetaSearcher is available:
+    // confirmed-successful items go to pipeline_* and items without a location
+    // id go to direct_delete_indices, while uncertain items stay unclassified
+    // so their URIs are retained. Returns the number of uncertain items.
+    static size_t ClassifyAddLocationRollback(const KeyVector &keys,
+                                              const std::vector<AddLocationResult> &add_results,
+                                              AddLocationRollbackPlan &out_plan);
     struct ReplaceLocationSpecsTask {
         std::string location_id;
         DataStorageType type;

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -89,9 +89,8 @@ void RollbackAddedLocations(RequestContext *request_context,
         for (const auto &location_id : plan.pipeline_location_ids) {
             known_success_request.location_ids.push_back({location_id});
         }
-        if (!schedule_plan_executor ||
-            !schedule_plan_executor->SubmitNonBlocking(
-                known_success_request, ScheduleTaskClass::kMigrationContinuation)) {
+        if (!schedule_plan_executor || !schedule_plan_executor->SubmitNonBlocking(
+                                           known_success_request, ScheduleTaskClass::kMigrationContinuation)) {
             KVCM_LOG_WARN("[%s] rollback known successful migration locations failed to submit delete, instance %s, "
                           "key_count %zu",
                           trace_id.c_str(),

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -42,7 +42,8 @@ struct AddLocationRollbackItem {
     std::string location_id;
 };
 
-// BatchAddLocation 失败后的补偿规则与返回契约一致：
+// BatchAddLocation 失败后的补偿规则与返回契约一致，统一收敛在
+// MetaSearcher::ReconcileAddLocationRollback：
 // - 已知成功项走标准 Location 删除流水线，由流水线回收 usage；
 // - 失败但已生成 ID 的项先幂等删除元数据并 Sync，确认无引用后才删 URI；
 // - 未生成 ID 的项可直接删 URI。
@@ -54,119 +55,60 @@ void RollbackAddedLocations(RequestContext *request_context,
                             const std::shared_ptr<DataStorageManager> &data_storage_manager,
                             const std::shared_ptr<SchedulePlanExecutor> &schedule_plan_executor,
                             const std::vector<AddLocationRollbackItem> &items) {
-    CacheLocationDelRequest known_success_request;
-    known_success_request.instance_id = instance_id;
-
-    KeyVector uncertain_keys;
-    std::vector<std::string> uncertain_location_ids;
-    std::vector<const AddLocationRollbackItem *> uncertain_items;
-    std::unordered_map<std::string, std::vector<DataStorageUri>> direct_delete_uris;
-    auto queue_uri_delete = [&direct_delete_uris](const AddLocationRollbackItem &item) {
-        if (item.uris.empty()) {
-            return;
-        }
-        auto &uris = direct_delete_uris[item.storage_name];
-        uris.insert(uris.end(), item.uris.begin(), item.uris.end());
-    };
-
-    for (const auto &item : items) {
-        if (item.ec == EC_OK && !item.location_id.empty()) {
-            known_success_request.block_keys.push_back(item.block_key);
-            known_success_request.location_ids.push_back({item.location_id});
-        } else if (!item.location_id.empty()) {
-            uncertain_keys.push_back(item.block_key);
-            uncertain_location_ids.push_back(item.location_id);
-            uncertain_items.push_back(&item);
-        } else {
-            queue_uri_delete(item);
-        }
-    }
-
-    if (!known_success_request.block_keys.empty() &&
-        (!schedule_plan_executor ||
-         !schedule_plan_executor->SubmitNonBlocking(
-             known_success_request, ScheduleTaskClass::kMigrationContinuation))) {
-        KVCM_LOG_WARN("[%s] rollback known successful migration locations failed to submit delete, instance %s, "
+    MetaSearcher::AddLocationRollbackPlan plan;
+    if (!indexer) {
+        KVCM_LOG_WARN("[%s] rollback migration locations retained URIs: meta indexer missing, instance %s, "
                       "key_count %zu",
                       trace_id.c_str(),
                       instance_id.c_str(),
-                      known_success_request.block_keys.size());
-    }
-
-    if (!uncertain_keys.empty()) {
-        if (!indexer) {
-            KVCM_LOG_WARN("[%s] rollback uncertain migration locations retained URIs: meta indexer missing, "
-                          "instance %s, key_count %zu",
+                      items.size());
+    } else {
+        KeyVector keys;
+        std::vector<MetaSearcher::AddLocationResult> add_results;
+        keys.reserve(items.size());
+        add_results.reserve(items.size());
+        for (const auto &item : items) {
+            keys.push_back(item.block_key);
+            add_results.push_back({item.ec, item.location_id});
+        }
+        MetaSearcher meta_searcher(indexer);
+        if (meta_searcher.ReconcileAddLocationRollback(request_context, keys, add_results, plan) != EC_OK) {
+            KVCM_LOG_WARN("[%s] rollback migration locations reconcile failed, instance %s, key_count %zu",
                           trace_id.c_str(),
                           instance_id.c_str(),
-                          uncertain_keys.size());
-        } else {
-            MetaSearcher meta_searcher(indexer);
-            LocationIdsPerKey location_ids_per_key;
-            location_ids_per_key.reserve(uncertain_location_ids.size());
-            for (const auto &location_id : uncertain_location_ids) {
-                location_ids_per_key.push_back({location_id});
-            }
-            std::vector<std::vector<ErrorCode>> delete_results;
-            const ErrorCode delete_ec =
-                meta_searcher.BatchDeleteLocations(request_context,
-                                                   uncertain_keys,
-                                                   location_ids_per_key,
-                                                   delete_results,
-                                                   {},
-                                                   false /* failed adds were never included in usage */,
-                                                   false /* failed adds were never counted as new keys */);
-            const size_t invalid_result_count =
-                std::count_if(delete_results.begin(), delete_results.end(), [](const auto &per_location_results) {
-                    return per_location_results.size() != 1;
-                });
-            if (delete_results.size() != uncertain_items.size() || invalid_result_count != 0) {
-                KVCM_LOG_WARN("[%s] rollback uncertain migration metadata returned unexpected result shape, "
-                              "instance %s, expected %zu, got %zu, invalid inner result count %zu, ec %d",
-                              trace_id.c_str(),
-                              instance_id.c_str(),
-                              uncertain_items.size(),
-                              delete_results.size(),
-                              invalid_result_count,
-                              delete_ec);
-            } else {
-                KeyVector sync_keys;
-                for (std::size_t i = 0; i < delete_results.size(); ++i) {
-                    if (delete_results[i].front() == EC_OK) {
-                        sync_keys.push_back(uncertain_keys[i]);
-                    }
-                }
-
-                bool metadata_synced = true;
-                if (!sync_keys.empty()) {
-                    metadata_synced = indexer->Sync(sync_keys);
-                    if (!metadata_synced) {
-                        KVCM_LOG_WARN("[%s] rollback uncertain migration locations failed to sync deleted metadata, "
-                                      "instance %s, key_count %zu",
-                                      trace_id.c_str(),
-                                      instance_id.c_str(),
-                                      sync_keys.size());
-                    }
-                }
-
-                for (std::size_t i = 0; i < delete_results.size(); ++i) {
-                    const ErrorCode per_location_ec = delete_results[i].front();
-                    if (per_location_ec == EC_NOENT || (per_location_ec == EC_OK && metadata_synced)) {
-                        queue_uri_delete(*uncertain_items[i]);
-                    } else if (per_location_ec != EC_OK) {
-                        KVCM_LOG_WARN("[%s] rollback uncertain migration metadata failed, instance %s, block_key %ld, "
-                                      "location_id %s, ec %d",
-                                      trace_id.c_str(),
-                                      instance_id.c_str(),
-                                      uncertain_keys[i],
-                                      uncertain_location_ids[i].c_str(),
-                                      per_location_ec);
-                    }
-                }
-            }
+                          items.size());
+            return;
         }
     }
 
+    if (!plan.pipeline_keys.empty()) {
+        CacheLocationDelRequest known_success_request;
+        known_success_request.instance_id = instance_id;
+        known_success_request.block_keys = plan.pipeline_keys;
+        known_success_request.location_ids.reserve(plan.pipeline_location_ids.size());
+        for (const auto &location_id : plan.pipeline_location_ids) {
+            known_success_request.location_ids.push_back({location_id});
+        }
+        if (!schedule_plan_executor ||
+            !schedule_plan_executor->SubmitNonBlocking(
+                known_success_request, ScheduleTaskClass::kMigrationContinuation)) {
+            KVCM_LOG_WARN("[%s] rollback known successful migration locations failed to submit delete, instance %s, "
+                          "key_count %zu",
+                          trace_id.c_str(),
+                          instance_id.c_str(),
+                          known_success_request.block_keys.size());
+        }
+    }
+
+    std::unordered_map<std::string, std::vector<DataStorageUri>> direct_delete_uris;
+    for (const size_t index : plan.direct_delete_indices) {
+        const auto &item = items[index];
+        if (item.uris.empty()) {
+            continue;
+        }
+        auto &uris = direct_delete_uris[item.storage_name];
+        uris.insert(uris.end(), item.uris.begin(), item.uris.end());
+    }
     if (direct_delete_uris.empty()) {
         return;
     }

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -56,21 +56,25 @@ void RollbackAddedLocations(RequestContext *request_context,
                             const std::shared_ptr<SchedulePlanExecutor> &schedule_plan_executor,
                             const std::vector<AddLocationRollbackItem> &items) {
     MetaSearcher::AddLocationRollbackPlan plan;
+    KeyVector keys;
+    std::vector<MetaSearcher::AddLocationResult> add_results;
+    keys.reserve(items.size());
+    add_results.reserve(items.size());
+    for (const auto &item : items) {
+        keys.push_back(item.block_key);
+        add_results.push_back({item.ec, item.location_id});
+    }
     if (!indexer) {
-        KVCM_LOG_WARN("[%s] rollback migration locations retained URIs: meta indexer missing, instance %s, "
-                      "key_count %zu",
+        // 无元数据访问时无法 reconcile uncertain 项，只能保留其 URI；但
+        // confirmed-success 与无 ID 项的清理不依赖元数据，照常执行。
+        const size_t uncertain_count = MetaSearcher::ClassifyAddLocationRollback(keys, add_results, plan);
+        KVCM_LOG_WARN("[%s] rollback migration locations without meta indexer: uncertain URIs retained, instance %s, "
+                      "uncertain_count %zu, key_count %zu",
                       trace_id.c_str(),
                       instance_id.c_str(),
+                      uncertain_count,
                       items.size());
     } else {
-        KeyVector keys;
-        std::vector<MetaSearcher::AddLocationResult> add_results;
-        keys.reserve(items.size());
-        add_results.reserve(items.size());
-        for (const auto &item : items) {
-            keys.push_back(item.block_key);
-            add_results.push_back({item.ec, item.location_id});
-        }
         MetaSearcher meta_searcher(indexer);
         if (meta_searcher.ReconcileAddLocationRollback(request_context, keys, add_results, plan) != EC_OK) {
             KVCM_LOG_WARN("[%s] rollback migration locations reconcile failed, instance %s, key_count %zu",

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -1715,6 +1715,7 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackClassifiesStates) {
     EXPECT_EQ((std::vector<std::string>{success_results[0].location_id}), plan.pipeline_location_ids);
     std::vector<size_t> direct_indices = plan.direct_delete_indices;
     std::sort(direct_indices.begin(), direct_indices.end());
+    // 1 = uncertain_key (metadata deleted), 2 = no_id_key, 3 = ghost_key (delete hit EC_NOENT).
     EXPECT_EQ((std::vector<size_t>{1, 2, 3}), direct_indices);
 
     // uncertain metadata is deleted; confirmed-success metadata is left for the delete pipeline.
@@ -1800,6 +1801,8 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRetainsUrisWhenSyncFail
     BlockMask mask;
     ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {uncertain_key}, mask, location_maps));
     ASSERT_EQ(1u, location_maps.size());
+    // Unlike RetainsUrisOnDeleteError (location still present), here the in-memory
+    // delete succeeded and only the sync failed, so the map is empty.
     EXPECT_TRUE(location_maps[0].empty());
 }
 

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <filesystem>
 #include <future>
 #include <map>
@@ -90,6 +91,52 @@ private:
     bool fail_upsert_ = false;
 };
 
+class RollbackFaultBackend : public MetaLocalBackend {
+public:
+    void SetFailUpsert(bool fail_upsert) { fail_upsert_ = fail_upsert; }
+    void SetFailSync(bool fail_sync) { fail_sync_ = fail_sync; }
+    void SetGetLocationsFailedKey(std::optional<KeyType> key) { get_locations_failed_key_ = key; }
+
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties) noexcept override {
+        auto results = MetaLocalBackend::Upsert(request_context, keys, locations, properties);
+        if (fail_upsert_) {
+            for (auto &result : results) {
+                result = EC_ERROR;
+            }
+        }
+        return results;
+    }
+
+    std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
+                                                     const KeyTypeVec &keys,
+                                                     const LocationIdsPerKey &location_ids,
+                                                     LocationsPerKey &out_locations) noexcept override {
+        auto results = MetaLocalBackend::GetLocations(request_context, keys, location_ids, out_locations);
+        if (!get_locations_failed_key_.has_value()) {
+            return results;
+        }
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (keys[i] == get_locations_failed_key_.value()) {
+                for (auto &ec : results[i]) {
+                    ec = EC_ERROR;
+                }
+                out_locations[i].clear();
+            }
+        }
+        return results;
+    }
+
+    bool Sync(const KeyTypeVec & /*keys*/) noexcept override { return !fail_sync_; }
+
+private:
+    bool fail_upsert_ = false;
+    bool fail_sync_ = false;
+    std::optional<KeyType> get_locations_failed_key_;
+};
+
 ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
                                   RequestContext *request_context,
                                   const KeyVector &keys,
@@ -163,6 +210,18 @@ public:
     CommitThenFailUpsertBackend *ReplaceWithCommitThenFailUpsertBackend() {
         auto backend_config = ConstructMetaStorageBackendConfig();
         auto backend = std::make_unique<CommitThenFailUpsertBackend>();
+        EXPECT_EQ(EC_OK, backend->Init("test", backend_config));
+        EXPECT_EQ(EC_OK, backend->Open());
+        auto backend_raw = backend.get();
+        meta_indexer_->backend_manager_->persistent_backend_->Close();
+        meta_indexer_->backend_manager_->persistent_backend_ = std::move(backend);
+        meta_indexer_->backend_manager_->cache_backend_.reset();
+        return backend_raw;
+    }
+
+    RollbackFaultBackend *ReplaceWithRollbackFaultBackend() {
+        auto backend_config = ConstructMetaStorageBackendConfig();
+        auto backend = std::make_unique<RollbackFaultBackend>();
         EXPECT_EQ(EC_OK, backend->Init("test", backend_config));
         EXPECT_EQ(EC_OK, backend->Open());
         auto backend_raw = backend.get();
@@ -1614,6 +1673,134 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocationsCanPreserveKeyCountForUncertain
     ASSERT_EQ(2u, location_maps.size());
     EXPECT_EQ(1u, location_maps[0].count(existing_results[0].location_id));
     EXPECT_TRUE(location_maps[1].empty());
+}
+
+TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackClassifiesStates) {
+    auto backend = ReplaceWithRollbackFaultBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType success_key = 7301;
+    const KeyType uncertain_key = 7302;
+    const KeyType no_id_key = 7303;
+    const KeyType ghost_key = 7304;
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+
+    std::vector<MetaSearcher::AddLocationResult> success_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {success_key}, {location}, success_results));
+    ASSERT_EQ(1u, success_results.size());
+    ASSERT_EQ(EC_OK, success_results[0].ec);
+    ASSERT_FALSE(success_results[0].location_id.empty());
+
+    backend->SetFailUpsert(true);
+    std::vector<MetaSearcher::AddLocationResult> uncertain_results;
+    ASSERT_EQ(EC_ERROR,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {uncertain_key}, {location}, uncertain_results));
+    ASSERT_EQ(1u, uncertain_results.size());
+    ASSERT_EQ(EC_ERROR, uncertain_results[0].ec);
+    ASSERT_FALSE(uncertain_results[0].location_id.empty());
+    backend->SetFailUpsert(false);
+
+    // batch: confirmed success / uncertain with id / failed without id / failed with a ghost id
+    const KeyVector keys = {success_key, uncertain_key, no_id_key, ghost_key};
+    std::vector<MetaSearcher::AddLocationResult> add_results = {success_results[0],
+                                                                uncertain_results[0],
+                                                                {EC_ERROR, ""},
+                                                                {EC_ERROR, "ghost_location_id"}};
+    MetaSearcher::AddLocationRollbackPlan plan;
+    ASSERT_EQ(EC_OK, meta_searcher_->ReconcileAddLocationRollback(request_context_.get(), keys, add_results, plan));
+
+    EXPECT_EQ((KeyVector{success_key}), plan.pipeline_keys);
+    EXPECT_EQ((std::vector<std::string>{success_results[0].location_id}), plan.pipeline_location_ids);
+    std::vector<size_t> direct_indices = plan.direct_delete_indices;
+    std::sort(direct_indices.begin(), direct_indices.end());
+    EXPECT_EQ((std::vector<size_t>{1, 2, 3}), direct_indices);
+
+    // uncertain metadata is deleted; confirmed-success metadata is left for the delete pipeline.
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {success_key, uncertain_key}, mask, location_maps));
+    ASSERT_EQ(2u, location_maps.size());
+    EXPECT_EQ(1u, location_maps[0].count(success_results[0].location_id));
+    EXPECT_TRUE(location_maps[1].empty());
+}
+
+TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRejectsShapeMismatch) {
+    MetaSearcher::AddLocationRollbackPlan plan;
+    plan.pipeline_keys = {42};
+    plan.pipeline_location_ids = {"stale_id"};
+    plan.direct_delete_indices = {0};
+
+    EXPECT_EQ(EC_BADARGS,
+              meta_searcher_->ReconcileAddLocationRollback(
+                  request_context_.get(), {1, 2}, {{EC_OK, "some_id"}}, plan));
+    EXPECT_TRUE(plan.pipeline_keys.empty());
+    EXPECT_TRUE(plan.pipeline_location_ids.empty());
+    EXPECT_TRUE(plan.direct_delete_indices.empty());
+}
+
+TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRetainsUrisOnDeleteError) {
+    auto backend = ReplaceWithRollbackFaultBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType uncertain_key = 7400;
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+
+    backend->SetFailUpsert(true);
+    std::vector<MetaSearcher::AddLocationResult> uncertain_results;
+    ASSERT_EQ(EC_ERROR,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {uncertain_key}, {location}, uncertain_results));
+    ASSERT_EQ(1u, uncertain_results.size());
+    ASSERT_FALSE(uncertain_results[0].location_id.empty());
+
+    backend->SetGetLocationsFailedKey(uncertain_key);
+    MetaSearcher::AddLocationRollbackPlan plan;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->ReconcileAddLocationRollback(
+                  request_context_.get(), {uncertain_key}, uncertain_results, plan));
+    EXPECT_TRUE(plan.pipeline_keys.empty());
+    EXPECT_TRUE(plan.direct_delete_indices.empty());
+
+    // metadata state unconfirmed: the location stays and the URI must be retained.
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {uncertain_key}, mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    EXPECT_EQ(1u, location_maps[0].count(uncertain_results[0].location_id));
+}
+
+TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRetainsUrisWhenSyncFails) {
+    auto backend = ReplaceWithRollbackFaultBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType uncertain_key = 7500;
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+
+    backend->SetFailUpsert(true);
+    std::vector<MetaSearcher::AddLocationResult> uncertain_results;
+    ASSERT_EQ(EC_ERROR,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {uncertain_key}, {location}, uncertain_results));
+    ASSERT_EQ(1u, uncertain_results.size());
+    ASSERT_FALSE(uncertain_results[0].location_id.empty());
+    backend->SetFailUpsert(false);
+
+    backend->SetFailSync(true);
+    MetaSearcher::AddLocationRollbackPlan plan;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->ReconcileAddLocationRollback(
+                  request_context_.get(), {uncertain_key}, uncertain_results, plan));
+    EXPECT_TRUE(plan.pipeline_keys.empty());
+    // metadata was deleted in memory but the delete could not be synced: retain the URI.
+    EXPECT_TRUE(plan.direct_delete_indices.empty());
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {uncertain_key}, mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    EXPECT_TRUE(location_maps[0].empty());
 }
 
 TEST_F(MetaSearcherTest, TestBatchVsSequentialPerformance) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -1741,6 +1741,25 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRejectsShapeMismatch) {
     EXPECT_TRUE(plan.direct_delete_indices.empty());
 }
 
+TEST_F(MetaSearcherTest, TestClassifyAddLocationRollbackWithoutMetadata) {
+    // Metadata-free classification: confirmed-success -> pipeline, no id ->
+    // direct delete, uncertain (id present but non-OK) stays unclassified so
+    // its URI is retained.
+    const KeyVector keys = {8101, 8102, 8103};
+    const std::vector<MetaSearcher::AddLocationResult> add_results = {
+        {EC_OK, "confirmed_id"}, {EC_ERROR, "uncertain_id"}, {EC_ERROR, ""}};
+    MetaSearcher::AddLocationRollbackPlan plan;
+    plan.pipeline_keys = {42};
+    plan.pipeline_location_ids = {"stale_id"};
+    plan.direct_delete_indices = {0};
+
+    EXPECT_EQ(1u, MetaSearcher::ClassifyAddLocationRollback(keys, add_results, plan));
+    EXPECT_EQ((KeyVector{8101}), plan.pipeline_keys);
+    EXPECT_EQ((std::vector<std::string>{"confirmed_id"}), plan.pipeline_location_ids);
+    // 2 = no_id_key; index 1 (uncertain) is intentionally absent so its URI is retained.
+    EXPECT_EQ((std::vector<size_t>{2}), plan.direct_delete_indices);
+}
+
 TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRetainsUrisOnDeleteError) {
     auto backend = ReplaceWithRollbackFaultBackend();
     ASSERT_NE(nullptr, backend);


### PR DESCRIPTION
## Summary

- Consolidate the two isomorphic metadata three-state rollback compensation state machines (`CacheManager::RollbackAddLocations` and migration `RollbackAddedLocations`) into a single dedicated API `MetaSearcher::ReconcileAddLocationRollback` producing an `AddLocationRollbackPlan`:
  - confirmed success (EC_OK + location id) -> `pipeline_keys`/`pipeline_location_ids` for the standard location delete pipeline;
  - uncertain (id generated but write failed/unknown) -> idempotent metadata delete via `BatchDeleteLocations(false, false)` + `Sync`, URI only released after metadata is confirmed unreferenced;
  - no id -> `direct_delete_indices` for direct best-effort URI delete.
- Slim down both callers to build the plan and dispatch; scheduling lifecycles unchanged (`reclaimer_task_supervisor_` for normal writes, `kMigrationContinuation` for migration).
- Semantics preserved: all-or-nothing for normal writes, partial progress for migration, URI retained whenever metadata state is uncertain. The only behavioral change is more conservative: on delete-result shape anomalies CacheManager now retains URIs instead of skipping per item.

## Test plan

- [x] New unit tests in `meta_searcher_test.cc` covering all six scenarios: confirmed success, failed-with-ID, failed-without-ID, short/invalid result shape, per-item delete error, Sync failure.
- [x] `bazel test //kv_cache_manager/manager/test/...` — 13/13 passed (incl. CacheManager/MigrationManager rollback regressions).
- [x] Full `bazel test //kv_cache_manager/... //integration_test/...` — 118 passed / 1 skipped.
- [x] Same targets under `--config=debug --config=asan` — 118 passed / 1 skipped, no ASAN reports.