### PR TITLE
[build] make Mooncake and VCNS opt-in

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -127,10 +127,13 @@ build:asan --linkopt -fsanitize=address
 build:asan --test_env="ASAN_OPTIONS=detect_odr_violation=0:protect_shadow_gap=0" # protect_shadow_gap : conflict with cuda
 
 build:mooncake --config=cuda
+build:mooncake --config=mooncake_common
 build:mooncake --define MOONCAKE_USE_CUDA=true
 
+build:mooncake_common --define ENABLE_MOONCAKE=true
 build:mooncake_common --define MOONCAKE_USE_HTTP=true --define MOONCAKE_USE_TCP=true
-build --config=mooncake_common
+
+build:vcns --define ENABLE_VCNS=true
 
 build:tair_mempool --config=cuda
 build:tair_mempool --define TAIR_MEMPOOL_USE_CUDA=true
@@ -145,6 +148,7 @@ test --test_env NCCL_DEBUG="INFO"
 # for dp scatter add stable result
 test --test_env TZ=Asia/Shanghai
 
+build:client --config=mooncake_common
 build:client --copt=-DENABLE_MOONCAKE
 build:client --copt=-DENABLE_HF3FS
 build:client --copt=-DENABLE_TAIR_MEMPOOL

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -12,6 +12,21 @@
 bazelisk run //kv_cache_manager:main
 ```
 
+Mooncake 和 VCNS 后端默认不参与编译，需要时通过 Bazel 配置显式启用：
+
+```bash
+# Mooncake（包含 CUDA、HTTP 和 TCP 支持）
+bazelisk run //kv_cache_manager:main --config=mooncake
+
+# Mooncake（不启用 CUDA）
+bazelisk run //kv_cache_manager:main --config=mooncake_common
+
+# VCNS（仅内源模式提供真实实现）
+bazelisk run //kv_cache_manager:main --config=vcns
+```
+
+两个后端可通过同时传入 `--config=mooncake` 和 `--config=vcns` 一起启用。`--config=client` 会继续启用客户端所需的 Mooncake 支持。
+
 ### Bazel 缓存与多 worktree 开发
 
 Bazel 默认会按 workspace 路径生成独立的 `output_base`。因此从同一个仓库拉出新的 git worktree 后，新的 worktree 不能直接复用旧 worktree 的 `bazel-out`、analysis cache 和本地 action cache；首次构建仍需要重新完成 loading/analysis、内部 symlink/action bookkeeping，以及测试执行。

--- a/kv_cache_manager/data_storage/BUILD
+++ b/kv_cache_manager/data_storage/BUILD
@@ -1,5 +1,15 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "enable_mooncake",
+    define_values = {"ENABLE_MOONCAKE": "true"},
+)
+
+config_setting(
+    name = "enable_vcns",
+    define_values = {"ENABLE_VCNS": "true"},
+)
+
 cc_library(
     name = "data_storage",
     srcs = [
@@ -7,29 +17,44 @@ cc_library(
         "dummy_backend.cc",
         "event_report_backend.cc",
         "hf3fs_backend.cc",
-        "mooncake_backend.cc",
         "nfs_backend.cc",
-    ],
+    ] + select({
+        ":enable_mooncake": ["mooncake_backend.cc"],
+        "//conditions:default": [],
+    }),
     hdrs = [
         "data_storage_backend.h",
         "data_storage_manager.h",
         "dummy_backend.h",
         "event_report_backend.h",
         "hf3fs_backend.h",
-        "mooncake_backend.h",
         "nfs_backend.h",
         "snapshot_uri_utils.h",
-    ],
+    ] + select({
+        ":enable_mooncake": ["mooncake_backend.h"],
+        "//conditions:default": [],
+    }),
+    defines = select({
+        ":enable_mooncake": ["ENABLE_MOONCAKE=1"],
+        "//conditions:default": [],
+    }) + select({
+        ":enable_vcns": ["ENABLE_VCNS=1"],
+        "//conditions:default": [],
+    }),
     deps = [
         # 不一定用
         # "//3rdparty/3fs:hf3fs",
-        "//3rdparty/mooncake:mooncake_client_c",
         "//kv_cache_manager/common/hash",  # for xxph3
         ":common_define",
         # Internal implementations
-        "//stub_source/kv_cache_manager/data_storage:vcns_hf3fs",
         "//stub_source/kv_cache_manager/data_storage:tair_mempool",
-    ],
+    ] + select({
+        ":enable_mooncake": ["//3rdparty/mooncake:mooncake_client_c"],
+        "//conditions:default": [],
+    }) + select({
+        ":enable_vcns": ["//stub_source/kv_cache_manager/data_storage:vcns_hf3fs"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(

--- a/kv_cache_manager/data_storage/data_storage_manager.cc
+++ b/kv_cache_manager/data_storage/data_storage_manager.cc
@@ -8,13 +8,17 @@
 #include "kv_cache_manager/data_storage/dummy_backend.h"
 #include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/data_storage/hf3fs_backend.h"
+#ifdef ENABLE_MOONCAKE
 #include "kv_cache_manager/data_storage/mooncake_backend.h"
+#endif
 #include "kv_cache_manager/data_storage/nfs_backend.h"
 #include "kv_cache_manager/data_storage/storage_config.h"
 #include "kv_cache_manager/metrics/metrics_collector.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "stub_source/kv_cache_manager/data_storage/tair_mempool_backend.h"
+#ifdef ENABLE_VCNS
 #include "stub_source/kv_cache_manager/data_storage/vcns_hf3fs_backend.h"
+#endif
 
 namespace kv_cache_manager {
 
@@ -163,10 +167,14 @@ std::shared_ptr<DataStorageBackend> DataStorageManager::CreateStorageBackend(con
     switch (type) {
     case DataStorageType::DATA_STORAGE_TYPE_HF3FS:
         return std::make_shared<Hf3fsBackend>(metrics_registry_);
+#ifdef ENABLE_VCNS
     case DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS:
         return std::make_shared<VcnsHf3fsBackend>(metrics_registry_);
+#endif
+#ifdef ENABLE_MOONCAKE
     case DataStorageType::DATA_STORAGE_TYPE_MOONCAKE:
         return std::make_shared<MooncakeBackend>(metrics_registry_);
+#endif
     case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL:
         return std::make_shared<TairMempoolBackend>(metrics_registry_);
     case DataStorageType::DATA_STORAGE_TYPE_NFS:

--- a/kv_cache_manager/data_storage/perf_test/BUILD
+++ b/kv_cache_manager/data_storage/perf_test/BUILD
@@ -5,9 +5,13 @@ cc_test(
     ],
     copts = ["-fno-access-control"],
     data = [],
+    tags = ["manual"],
+    target_compatible_with = select({
+        "//kv_cache_manager/data_storage:enable_mooncake": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
-        "//kv_cache_manager/data_storage",
         "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/data_storage",
     ],
-    tags = ["manual"]
 )

--- a/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
+++ b/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
@@ -85,3 +85,19 @@ TEST_F(DataStorageManagerTest, TestCopyRejectsMismatchedUris) {
         ASSERT_EQ(EC_BADARGS, ec);
     }
 }
+
+TEST_F(DataStorageManagerTest, TestOptionalBackendsFollowBuildConfig) {
+    DataStorageManager data_storage_manager(metrics_registry_);
+
+#ifdef ENABLE_MOONCAKE
+    EXPECT_NE(nullptr, data_storage_manager.CreateStorageBackend(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE));
+#else
+    EXPECT_EQ(nullptr, data_storage_manager.CreateStorageBackend(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE));
+#endif
+
+#ifdef ENABLE_VCNS
+    EXPECT_NE(nullptr, data_storage_manager.CreateStorageBackend(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS));
+#else
+    EXPECT_EQ(nullptr, data_storage_manager.CreateStorageBackend(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS));
+#endif
+}

--- a/open_source/kv_cache_manager/data_storage/BUILD
+++ b/open_source/kv_cache_manager/data_storage/BUILD
@@ -8,6 +8,10 @@ cc_library(
     hdrs = [
         "vcns_hf3fs_backend.h",
     ],
+    target_compatible_with = select({
+        "//kv_cache_manager/data_storage:enable_vcns": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         "//kv_cache_manager/common",
         "//kv_cache_manager/data_storage:common_define",


### PR DESCRIPTION
## Summary

- make the Manager's Mooncake and VCNS backends opt-in through Bazel configuration
- remove Mooncake and VCNS sources and dependencies from the default `data_storage` build graph
- guard backend factory registration and backend-specific tests with the same feature switches
- preserve Mooncake support for explicit client builds and document the supported configs

## Why

The default Bazel configuration enabled `mooncake_common` globally, while `data_storage` unconditionally depended on both Mooncake and VCNS. As a result, ordinary Manager builds compiled large optional dependency graphs even when neither backend was used.

After this change:

- `--config=mooncake` enables Mooncake with CUDA, HTTP, and TCP
- `--config=mooncake_common` enables Mooncake without CUDA
- `--config=vcns` enables VCNS
- the default build enables neither backend
- `--config=client` keeps its existing Mooncake support

## Validation

- `bazelisk build //kv_cache_manager:main`
- open-source ASAN data-storage tests: 6/6 passed
- `DataStorageManagerTest` passed with the default, Mooncake, and VCNS configurations
- internal-view default tests passed with VCNS tests skipped; VCNS-enabled test targets compiled successfully
- combined Mooncake + VCNS configuration analysis included both optional dependencies
- `clang-format --dry-run --Werror`, `buildifier -mode=check`, and `git diff --check`
