### PR TITLE
[manager] optimize GetHostCacheState and ReportEvent metadata hot paths

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -1,9 +1,17 @@
 #
-name: Create and publish a develop Docker image
+name: Create and publish a KVCM Docker image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   workflow_dispatch:
+    inputs:
+      flavor:
+        description: Image flavor
+        type: choice
+        options:
+          - dev
+          - integration
+        default: dev
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -12,7 +20,60 @@ env:
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
+  integration:
+    if: ${{ inputs.flavor == 'integration' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build server package
+        env:
+          BUILD_IMAGE: ghcr.io/alibaba/tair-kvcache-kvcm-dev:2026_02_13_12_03_24230b1
+        run: |
+          docker run --rm --privileged \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            "${BUILD_IMAGE}" \
+            bash -lc '
+              git config --global --add safe.directory /workspace &&
+              bazelisk build //package:kv_cache_manager_server --config=ci_fast &&
+              cp bazel-bin/package/kv_cache_manager_server.tar.gz open_source/docker/ &&
+              chown "$(stat -c %u /workspace):$(stat -c %g /workspace)" \
+                open_source/docker/kv_cache_manager_server.tar.gz
+            '
+
+      - name: Prepare image tag and context
+        id: integration_image
+        run: |
+          VERSION="integration-$(date -u '+%Y_%m_%d_%H_%M')-${GITHUB_SHA::7}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
+          test -r open_source/docker/kv_cache_manager_server.tar.gz
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "KVCM integration image: ${IMAGE}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish integration image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: open_source/docker
+          file: open_source/docker/Dockerfile.prod
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.integration_image.outputs.image }}
+          build-args: BINARY_PACKAGE_TAR=kv_cache_manager_server.tar.gz
+
   build:
+    if: ${{ inputs.flavor != 'integration' }}
     strategy:
       fail-fast: false
       matrix:
@@ -97,6 +158,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: ${{ inputs.flavor != 'integration' }}
     runs-on: ubuntu-latest
     needs:
       - build

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 - [模块架构与关联关系](design/module_architecture.md) - 各模块职责、依赖方向、控制流与数据流，附 Mermaid 图
 - [基本概念](design/basic_concepts.md) - Storage、Instance Group、Instance、Block、CacheLocation 等核心概念
 - [ReportEvent 增量上报与权威快照设计](design/report_event_snapshot_uri_version.md) - 增量/快照协同、提交屏障、故障恢复、性能取舍与 Subscriber 集成
-- [ReportEvent 小 block / 大批量性能优化记录](design/report_event_performance.md) - 热路径放大、锁语义、容量基准与后续 Redis I/O 优化边界
+- [ReportEvent / GetHostCacheState 小 block 性能记录](design/report_event_performance.md) - local/Redis 指标解释、锁与可见性语义、有界并发、容量基准及后续优化边界
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [模块架构与关联关系](design/module_architecture.md) - 各模块职责、依赖方向、控制流与数据流，附 Mermaid 图
 - [基本概念](design/basic_concepts.md) - Storage、Instance Group、Instance、Block、CacheLocation 等核心概念
 - [ReportEvent 增量上报与权威快照设计](design/report_event_snapshot_uri_version.md) - 增量/快照协同、提交屏障、故障恢复、性能取舍与 Subscriber 集成
+- [ReportEvent 小 block / 大批量性能优化记录](design/report_event_performance.md) - 热路径放大、锁语义、容量基准与后续 Redis I/O 优化边界
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
 

--- a/docs/api/report_event.md
+++ b/docs/api/report_event.md
@@ -860,7 +860,7 @@ heartbeat/grace 短时序测试使用独立 storage/instance group，不得缩�
 | CFG-01 | snapshot interval/drain timeout 默认值、正数校验、负数拒绝、JSON/proto round trip，并由 backend 加载 | `TestEventReportStorageSpecSnapshotSettingsDefaultAndValidation`、`TestEventReportStorageSpecJsonRoundTripIncludesSnapshotSettings`、`EventReportStorageSpecProtoRoundTripPreservesSnapshotSettings`、`BasicAccessors` |
 | PERF-01 | 100 线程共 1 万 ADD、50 线程共 5000 混合批次均无错误 | `EventReportBenchTest.test_17/18` |
 | PERF-02 | 10 reporter × 每台 5000 blocks 完整 snapshot，并查询每台首/中/末 block | `EventReportBenchTest.test_19_ten_reporters_full_snapshot_capacity` |
-| PERF-03 | 单请求 512 个跨重复 medium 的增量正确落盘；手工容量测试记录 100/1000/5000 个 ADD 的总 RT 与单 event 开销 | `TestReportEventLargeDeltaBatchAcrossRepeatedMediums`、`EventReportBenchTest.test_20_large_single_request_delta_scaling` |
+| PERF-03 | 单请求 512 个跨重复 medium 的增量正确落盘；手工容量测试记录 100/1000/5000/20000 个 ADD 的总 RT 与单 event 开销 | `TestReportEventLargeDeltaBatchAcrossRepeatedMediums`、`EventReportBenchTest.test_20_large_single_request_delta_scaling` |
 
 上表中的参数解析、故障注入、CAS 竞态等内部边界使用 UT 验证；跨 HTTP 的正常流程、并发流程、
 节点生命周期和 Redis/KVCM 重启使用集成测试验证。

--- a/docs/api/report_event.md
+++ b/docs/api/report_event.md
@@ -56,6 +56,11 @@ KVCM 更新的最小逻辑身份是：
 block_key + medium + spec.name
 ```
 
+HTTP/protobuf 中 `block_key` 使用十进制字符串。调用方既可以发送 signed int64，也可以发送
+unsigned uint64；KVCM 按相同的 64-bit bit pattern 归一化，例如
+`"18446744073709551615"` 与 `"-1"` 指向同一个内部 block key。这与 vLLM 外部 block hash
+使用 uint64 的约定兼容；超出 uint64 或 int64 表示范围、带正号或空白的字符串会被拒绝。
+
 - `medium` 是 block 级属性，例如 `gpu`、`hbm`、`memory`、`disk`；
 - `spec.name` 区分一个 block 内的多个物理组成部分，例如不同 TP、full attention 或 mamba state；
 - 同一 `block_key` 可以同时存在于多个 medium；
@@ -198,9 +203,11 @@ InstanceGroup 必须把对应 EventReport storage 配置在
 行为：
 
 - 建立或刷新该 reporter 的节点状态；
-- 重复 REGISTER 可安全重试，medium 列表会合并；但每次成功 REGISTER 都是新的 reporter
-  lifecycle 栅栏，会使更早生命周期中尚未落盘的 mutation/cleanup 失效，因此不能把
-  REGISTER 当作 HEARTBEAT 高频发送，也不应与普通数据请求无序并发；
+- 重复 REGISTER 可安全重试，medium 列表会合并；同一请求中的多个合法 REGISTER 分别校验、
+  合并后只执行一次实际注册，因此至多推进一次 lifecycle，所有合法 REGISTER item 获得相同
+  注册结果，非法 REGISTER 只影响自身 item；跨请求的每次成功 REGISTER 都会建立新的 reporter
+  lifecycle 栅栏，使更早生命周期中尚未落盘的 mutation/cleanup 失效，因此不能把 REGISTER
+  当作 HEARTBEAT 高频发送，也不应与普通数据请求无序并发；
 - REGISTER 本身不创建 `committed_snapshot_version`；
 - REGISTER 后可以直接发 ADD/DELETE；
 - KVCM 重启后不必重新 REGISTER；

--- a/docs/api/report_event.md
+++ b/docs/api/report_event.md
@@ -16,7 +16,8 @@
 5. 客户端不得在 URI 中填写 `s_version`；KVCM 会自动追加。
 6. `committed_snapshot_version` 是 32 位十六进制 opaque generation，不能按大小比较；成功完整
    snapshot 后它会成为该 reporter 的严格查询栅栏。
-7. `snapshot_required=true` 是“当前 KVCM 进程还没有该 reporter generation”的提示，不会阻止合法增量。
+7. `snapshot_required=true` 表示请求到达时当前进程还没有该 reporter generation；创建 generation
+   的首条 ADD/DELETE 自身仍返回 `true`，下一条事件才返回 `false`。该提示不会阻止合法增量。
 8. 当前进程尚未收到该 reporter 的任何合法事件，或节点 unavailable 时，查询不会返回该
    节点的数据；节点存活状态是硬门槛。
 9. snapshot 失败、进程重启或从未成功 snapshot 的 soft 模式可能返回 stale cache candidate；
@@ -140,7 +141,8 @@ Instance/InstanceGroup 和 cache metadata 会持久化；reporter 节点表、li
 2. 第一条 HEARTBEAT、ADD、DELETE 或 SNAPSHOT 会自动重建 reporter 节点状态，不要求再次 REGISTER；
 3. 如果第一条只是 HEARTBEAT，响应为 `snapshot_required=true`、
    `committed_snapshot_version=""`，格式合法的历史 metadata 可以重新成为 cache candidate；
-4. 如果第一条是 ADD/DELETE，它正常成功并建立新 generation；
+4. 如果第一条是 ADD/DELETE，它正常成功并建立新 generation；该次响应仍为
+   `snapshot_required=true`，后续事件复用 generation 时变为 `false`；
 5. 该增量只更新明确涉及的 spec，不删除其他历史 block/spec；
 6. snapshot-capable 调用方可以稍后补一次完整 snapshot；
 7. realtime-only 调用方可以继续只发增量。
@@ -496,14 +498,17 @@ SNAPSHOT_IN_PROGRESS  -> SNAPSHOT 失败时重发完整 snapshot
 
 ### 9.2 snapshot_required
 
-`snapshot_required` 等价于“当前进程还没有该 reporter generation”：
+`snapshot_required` 表示“本次请求到达时当前进程还没有该 reporter generation”。对于首条合法
+ADD/DELETE，KVCM 会在请求内创建 generation 并返回到 `committed_snapshot_version`，但本次响应
+仍保留 `snapshot_required=true`；下一条事件复用该 generation 时才返回 `false`：
 
 | 场景 | 值 |
 | --- | --- |
 | fresh REGISTER 后 | `true` |
 | KVCM 重启后的第一条 HEARTBEAT | `true` |
 | 只有 REGISTER/HEARTBEAT、还没有合法 mutation | `true` |
-| 第一条合法 ADD/DELETE 后 | `false` |
+| 创建 generation 的第一条合法 ADD/DELETE | `true` |
+| 后续复用已有 generation 的 ADD/DELETE | `false` |
 | 成功 SNAPSHOT 后 | `false` |
 | invalid-only 首批增量 | 仍为 `true` |
 | realtime-only reporter | 可忽略该提示，继续发合法增量 |
@@ -606,6 +611,23 @@ HTTP 接口为 `POST /api/getCacheLocation`：
 该接口当前支持 `QT_BATCH_GET`，可通过 `backend_selectors` 明确选择
 `ST_EVENT_REPORT_L1P5`、`ST_EVENT_REPORT_L2` 等 backend，适合验证两种 EventReport storage 的
 隔离状态。
+
+`location_spec_names` 不只是返回结果的投影条件，也是 backend/peer 选择前的候选条件：
+
+- 为空时，location 中任意合法 spec 都可使该 location 成为候选；
+- 非空时，location 至少包含一个请求的 spec name 才能成为候选；
+- 同一 EventReport location 由 `storage_type + medium + host_ip_port` 标识，其中各 spec 必须属于
+  同一个 reporter endpoint；location 命中过滤后，selector 从第一个合法 spec URI 提取 peer；
+- 多个 peer 的 prefix/coverage 相同时按 endpoint 字典序选择，保证调用方按 spec 分批查询时
+  各批次不会因为容器遍历顺序选择不同 peer；
+- peer 选择完成后，响应仍只保留 `location_spec_names` 指定的 specs。
+
+因此 spec name 是 reporter 与查询方之间的稳定协议字段，不能用 object size 代替：不同 cache
+group 即使 byte size 相同，也必须使用不同且稳定的 spec name。调用方如果每个 key 需要的 spec
+不同，应先按 spec name 分组发起查询，再按原 object key 合并结果；`location_spec_names` 是一次
+请求级过滤条件，不是 per-key 数组。确定性 tie-break 只消除无序遍历造成的抖动；若各组候选
+peer 集合不同，分组请求无法保证得到全局最优公共 peer。该能力需要后续扩展 per-key spec filter
+或等价的联合选择接口。
 
 ### 11.4 GetHostCacheState
 
@@ -728,12 +750,38 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 - Backend UT：`kv_cache_manager/data_storage/test/event_report_backend_test.cc`
 - Manager UT：`kv_cache_manager/manager/test/cache_manager_test.cc`
 - Meta UT：`kv_cache_manager/manager/test/meta_searcher_test.cc`
+- PR HTTP 集成：`integration_test/meta_service/http_interface_test.py`
 - 基础集成：`integration_test/meta_service/test_report_event.py`
 - Snapshot 集成：`integration_test/meta_service/test_report_event_snapshot.py`
 - 重启集成：`integration_test/meta_service/test_report_event_restart.py`
 
-后两项对应的 Bazel target 带 `manual` 标签，不属于默认 GitHub CI。覆盖结论必须以显式执行结果为准；
-同样，普通 GitHub check 通过不代表已经执行 ASAN。
+PR HTTP 集成由 `//integration_test/meta_service:http_interface_test` 启动真实 KVCM 进程，属于默认
+`//integration_test/...` CI。基础 ReportEvent 脚本当前没有 Bazel target；Snapshot target 带
+`manual` 标签，重启脚本也需显式执行，因此三者不属于默认 GitHub CI。覆盖结论必须以显式执行
+结果为准；同样，普通 GitHub check 通过不代表已经执行 ASAN。
+
+Snapshot target 是外部服务测试，单独执行 `bazel test` 不会替它启动 KVCM。先按脚本头部说明
+启动 meta/admin HTTP 服务，再显式传入端口。功能与容量入口分别为：
+
+```bash
+bazel run //integration_test/meta_service:test_report_event_snapshot -- \
+  --host localhost --http_port 56020 --admin_http_port 56040 \
+  --instance_id event_report_functional --skip-bench
+
+bazel run //integration_test/meta_service:test_report_event_snapshot -- \
+  --host localhost --http_port 56020 --admin_http_port 56040 \
+  --instance_id event_report_bench --only-bench
+
+# 仅运行小 block / 大批量单请求基准；默认使用进程内 local metadata backend
+bazel run //integration_test/meta_service:test_report_event_snapshot -- \
+  --host localhost --http_port 56020 --admin_http_port 56040 \
+  --instance_id event_report_large_delta \
+  --bench-test test_20_large_single_request_delta_scaling
+```
+
+同一 KVCM 进程上重复执行时，fixture 会通过 `listStorage` 校验已有 storage 的 type 和 EventReport
+时序配置；配置不一致应立即失败，不能把任意 `addStorage` 错误当作“可能已存在”后继续测试。
+heartbeat/grace 短时序测试使用独立 storage/instance group，不得缩短功能与容量用例的主 storage。
 
 | ID | 用户行为 | 自动化覆盖 |
 | --- | --- | --- |
@@ -781,6 +829,10 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 | Q-07 | GetCacheLocationsByBackend 同样执行 reporter liveness 过滤 | `TestGetCacheLocationsByBackendWithBackendSelectors`；snapshot 集成 `test_16a` |
 | Q-08 | 三个查询入口在 timeout 隐藏和 HEARTBEAT 恢复时结果一致 | snapshot 集成 `test_16a_heartbeat_timeout_then_recovery` |
 | Q-09 | snapshot 成功后即使异步 cleanup 尚未运行，遗漏的旧 version block 也立即不可见 | `TestSuccessfulSnapshotImmediatelyFencesOmittedOldVersionBeforeCleanup`、`TestGetCacheLocationEnforcesReporterLifecycleAndBatchOrdering` |
+| Q-10 | backend 查询在 peer 选择前按 spec 过滤，并对同覆盖率 peer 确定性择优 | `TestGetCacheLocationsByBackendWithBackendSelectors`；`EventReportPrefixFiltersRequestedSpecBeforePeerSelection`；`EventReportCoverageFiltersRequestedSpecBeforePeerSelection`；`EventReportPrefixTieBreaksByPeerAddress`；`EventReportCoverageTieBreaksByPeerAddress`；HTTP 集成 `test_event_report_requested_spec_filters_before_peer_selection` |
+| Q-11 | requested spec 不存在时 Prefix/Coverage 都返回与输入等长的空结果，不回退到其他 spec | `EventReportUnknownRequestedSpecReturnsNoCandidate`；HTTP 集成 `test_event_report_requested_spec_filters_before_peer_selection` |
+| Q-12 | requested spec 按 any-of 语义匹配，重复 name 不改变结果；匹配同一 location 的非首个 spec 时仍使用该 reporter endpoint | `EventReportRequestedSpecMatchesAnyNameIncludingNonFirstSpec` |
+| Q-13 | requested-spec gap 会终止 Prefix，但 Coverage 可跳过 gap 继续返回后续命中；响应投影后 `spec_size` 始终等于实际 specs 数量 | `EventReportRequestedSpecGapStopsPrefixButNotCoverage`；`TestGetCacheLocationsByBackendWithBackendSelectors` |
 | L-01 | 自动 heartbeat timeout 隐藏、grace 内恢复原 generation | `MightExistFollowsAutomaticLivenessAndFullReporterLifecycle`；snapshot 集成 `test_16a` |
 | L-02 | unavailable 期间增量可写但保持不可见，HEARTBEAT 后恢复 | `TestReportEventLazilyRestoresReporterWithoutRegisterOrSnapshot`；snapshot 集成 `test_16a` |
 | L-03 | 超过 grace 后按 generation 原子 unregister，最终 metadata 删除持有 generation lease，旧 cleanup 不伤重新注册数据 | `HeartbeatRecoveryFencesCleanupAlreadySelectedByLivenessLoop`、`ConditionalUnregisterCannotRemoveNewGeneration`、`CleanupLeaseFencesReregisterThroughFinalDeleteStage`；snapshot 集成 `test_16b` |
@@ -797,6 +849,7 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 | C-04 | 已进入 metadata I/O 的旧 lifecycle 请求不能在 HOST_DOWN、REGISTER、新 snapshot 后恢复写入 | `TestOldDeltaCannotCrossReporterLifecycleAfterReregisterAndSnapshot` |
 | C-05 | snapshot 等待 active delta 超时后 abort candidate、保留 committed generation 并重新打开 delta 写门 | `SnapshotDrainTimeoutAbortsCandidateAndReopensWriteGate` |
 | C-06 | delta 等待 in-flight snapshot 超时后返回可重试错误，且不会中止 snapshot；节点校验不会在超时栅栏前无限等待 | `DeltaWaitTimeoutReturnsSnapshotInProgressWithoutAbortingSnapshot`、`TestReportEventDeltaGateTimeoutReturnsSnapshotInProgressAndCanRetry` |
+| C-07 | mutation lease 每个 RMW 阶段只获取一次，但阻塞在 metadata read 的旧请求仍可被 HOST_DOWN/新 lifecycle 抢占 | `TestBatchMutationWriteLeaseIsAcquiredOncePerRmwPhase`、`TestBatchMutationWriteLeaseFailurePreventsAllWrites`、`TestHostDownCancelsSnapshotAlreadyWritingMetadata`、`TestHostDownMakesAlreadyAdmittedDeltaInvisibleWithoutDeadlock`、`TestOldDeltaCannotCrossReporterLifecycleAfterReregisterAndSnapshot` |
 | V-01 | reporter host、ADD/DELETE/SNAPSHOT medium 含 `#` 时拒绝且无写入副作用 | `RegisterNodeWithMediums`、`TestReportEventRejectsInvalidRequestsAndMapsItemErrors`；snapshot 集成 `test_19_*` |
 | V-02 | instance/host/storage type/instance backend 的公共字段校验 | `TestReportEventRejectsInvalidRequestsAndMapsItemErrors`；snapshot 集成 `test_14_*` |
 | V-03 | event_type 与 oneof payload 缺失/错配时该 item fail closed；同批其他合法 mutation 可独立懒初始化并生效 | `TestReportEventRejectsMismatchedPayloadsWithoutSideEffects`；snapshot 集成 `test_13/33` |
@@ -807,6 +860,7 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 | CFG-01 | snapshot interval/drain timeout 默认值、正数校验、负数拒绝、JSON/proto round trip，并由 backend 加载 | `TestEventReportStorageSpecSnapshotSettingsDefaultAndValidation`、`TestEventReportStorageSpecJsonRoundTripIncludesSnapshotSettings`、`EventReportStorageSpecProtoRoundTripPreservesSnapshotSettings`、`BasicAccessors` |
 | PERF-01 | 100 线程共 1 万 ADD、50 线程共 5000 混合批次均无错误 | `EventReportBenchTest.test_17/18` |
 | PERF-02 | 10 reporter × 每台 5000 blocks 完整 snapshot，并查询每台首/中/末 block | `EventReportBenchTest.test_19_ten_reporters_full_snapshot_capacity` |
+| PERF-03 | 单请求 512 个跨重复 medium 的增量正确落盘；手工容量测试记录 100/1000/5000 个 ADD 的总 RT 与单 event 开销 | `TestReportEventLargeDeltaBatchAcrossRepeatedMediums`、`EventReportBenchTest.test_20_large_single_request_delta_scaling` |
 
 上表中的参数解析、故障注入、CAS 竞态等内部边界使用 UT 验证；跨 HTTP 的正常流程、并发流程、
 节点生命周期和 Redis/KVCM 重启使用集成测试验证。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,16 @@ kvcm.schedule_plan_executor_thread_count=8
 # 0 < migration_worker_budget < executor_thread_count
 kvcm.schedule_plan_migration_worker_budget=3
 
+# GetHostCacheState 大请求使用的独立有界 metadata query executor。
+# worker_count 包含当前 RPC caller；默认 4 表示 caller + 3 个后台线程，设为 1 可禁用并行。
+kvcm.meta_query.worker_count=4
+
+# key/投影元素数达到该阈值才进入并行路径；小请求保持串行。
+kvcm.meta_query.parallel_threshold=256
+
+# 每个并行任务一次领取的连续元素数，必须不大于 parallel_threshold。
+kvcm.meta_query.chunk_size=128
+
 # CacheReclaimer 删除 Future 在 delay 结束后可继续抵扣水位的最长时间；到期只关闭 credit，
 # 不取消底层删除。默认 60000ms。
 kvcm.cache_reclaimer.inflight_delete_timeout_ms=60000
@@ -152,6 +162,25 @@ executor_thread_count > 1
 该约束是进程级 Executor 的启动条件，与启动时是否已经配置 migration strategy 无关；instance group 可在运行期
 新增迁移策略，因此不能根据启动时的策略状态放宽校验。`2/1`、`8/3` 是合法配置，`1/1`、`8/8` 和 `8/0`
 会导致 `ServerConfig::Check` 或 `CacheManager::Init` 失败。已有单线程自定义配置需要至少调整为 `2/1`。
+
+### GetHostCacheState metadata query executor
+
+`kvcm.meta_query.*` 控制独立于 `SchedulePlanExecutor` 的进程级有界查询池，仅服务大规模
+GetHostCacheState metadata read 和 host 投影/归约。线程不会按 instance 或请求创建：所有 MetaIndexer
+共享一个 executor，RPC caller 始终参与工作，因此 `worker_count=4` 只创建 3 个后台线程。队列饱和时
+请求由 caller 继续执行，不会无限堆积任务。
+
+只有单一 `local` metadata backend 的大批 key 读取会并发；`redis`、`cached` 和其他 backend 保持原有
+batch 调用。CPU 投影使用同一有界池。参数约束为：
+
+```TEXT
+1 <= worker_count <= 64
+0 < chunk_size <= parallel_threshold
+```
+
+默认值是 `4/256/128`。`worker_count=1` 是线上回退开关；调大 worker 前应同时对比单请求和并发请求
+p99、CPU 与 ReportEvent RT。设计、指标含义、测试命令见
+[`design/report_event_performance.md`](design/report_event_performance.md)。
 
 同一个 `migration_config` 中，`strategies` 的 `(source_storage_name, target_storage_name)` 组合必须唯一。
 相同 source 迁移到不同 target、不同 source 迁移到相同 target，以及 `hot -> warm -> cold` 级联均可配置；只有

--- a/docs/design/report_event_followup_todo.md
+++ b/docs/design/report_event_followup_todo.md
@@ -51,6 +51,10 @@
 - 同一请求内多个 REGISTER 逐 item 校验，合法 item 的 mediums 合并并只执行一次实际注册，因此
   每个请求至多推进一次 lifecycle；非法 sibling 只影响自身结果。
 - HTTP 与 ServiceImpl 的 ReportEvent 成功入口日志已降为 DEBUG；错误日志仍保留诊断字段。
+- ReportEvent delta 热路径已压平为 block 哈希表和 location/spec 小向量，并直接生成最终 metadata task；
+  `LocationSpec`/`CacheLocation` 的失效 move、重复 URI parse、BatchMerge task 深拷贝和 ordered-map spec
+  merge 已修正。同机 Release/O2、纯 local 的 20k create/update 相对直接父提交下降约 21%/25%；具体
+  A/B、语义约束与剩余并行边界见 `report_event_performance.md` 2.4 和 5.5。
 - `snapshot_delta_drain_timeout_ms` 已进入 Admin proto/config 转换和运行时验证，非正值会被配置
   校验拒绝；仓库内 round-trip 和非法边界测试已覆盖。
 - 查询有界线程池对部分线程创建失败和 `ParallelFor` 分配/入队异常执行显式清理；`noexcept` 热路径

--- a/docs/design/report_event_followup_todo.md
+++ b/docs/design/report_event_followup_todo.md
@@ -7,6 +7,8 @@
 [`report_event.md`](../api/report_event.md) 和
 [`report_event_snapshot_uri_version.md`](report_event_snapshot_uri_version.md)
 中的接口与生命周期契约为准，并为并发问题优先补充可控阻塞点的确定性测试。
+小 block / 大批量性能问题的已完成优化、禁止破坏的 HOST_DOWN 抢占窗口和后续目标化 Redis
+读取方案记录在 [`report_event_performance.md`](report_event_performance.md)。
 
 ## P1：生命周期与重试语义
 

--- a/docs/design/report_event_followup_todo.md
+++ b/docs/design/report_event_followup_todo.md
@@ -1,7 +1,8 @@
-# ReportEvent follow-up TODO
+# ReportEvent follow-up 状态与 TODO
 
-本文记录 PR #233 完成后暂缓处理的 Review 项。它们不属于当前 PR 的已实现能力，
-也不应在发布说明或测试结论中描述为已覆盖。
+本文最初记录 PR #233 暂缓处理的 Review 项。后续 hardened/performance 分支已经解决其中多数
+问题；为避免后续 AI 重复修改或把已覆盖能力误报为缺口，本文件现在同时维护“仍未完成事项”
+和“已解决证据”。以当前工作分支相对 main 的完整 diff 为准，不能只看最早两个 feature commit。
 
 后续修改仍应以
 [`report_event.md`](../api/report_event.md) 和
@@ -10,133 +11,68 @@
 小 block / 大批量性能问题的已完成优化、禁止破坏的 HOST_DOWN 抢占窗口和后续目标化 Redis
 读取方案记录在 [`report_event_performance.md`](report_event_performance.md)。
 
-## P1：生命周期与重试语义
+## 仍未完成
 
-### 1. Snapshot 最终提交需要覆盖完整 reporter lifecycle
+### 1. 运维 CLI 的 snapshot delta drain timeout 兼容性
 
-当前 lifecycle generation lease 覆盖 metadata replace，但 replace 完成后的 `Sync`
-和 snapshot version commit 不在同一个 generation 栅栏内。旧 snapshot 可能在 metadata
-写入完成后被阻塞，期间新 REGISTER 启动新的 reporter lifecycle，随后旧请求恢复并提交
-旧 snapshot version。
+仓库内 Admin proto、proto/config 转换、序列化、默认值和正数/零/负数校验已经覆盖；若生产使用的
+`kvcm_ops` 来自外部运维仓库，仍需在该仓库确认 add/update storage 暴露
+`snapshot_delta_drain_timeout_ms`，且旧服务端不会因未知字段受影响。
 
-建议：
-
-- snapshot candidate 绑定创建时的 lifecycle generation；
-- lifecycle 变化时取消旧 candidate；
-- 提供原子的 `CommitSnapshotVersionIfGeneration(expected_generation)` 或等价操作，
-  使 generation 校验、candidate 校验和最终 commit 不可分割；
-- 明确 `Sync` 失败、generation 失效和 candidate 被替换时的可重试错误。
-
-验收测试：
-
-- 旧 snapshot 阻塞在 `Sync`；
-- 同一 reporter 执行 REGISTER 并进入新 lifecycle；
-- 恢复旧 snapshot；
-- 断言旧请求不能 commit，新 lifecycle 的 snapshot version 和 metadata 不受影响。
-
-### 2. Delta 部分失败的 `item_results` 需要满足安全重试契约
-
-ADD 和 DELETE 分阶段写 metadata 时，同一 block/location 上的事件可能存在依赖。例如：
-
-```text
-event 0: ADD {A, B}
-event 1: DELETE {A}
-期望最终状态：只有 B
-```
-
-若 ADD B 失败、DELETE A 成功，接口可能返回 event 0 失败、event 1 成功。调用方按当前文档
-只重试失败的 event 0 后，最终状态会变成 A、B 均存在。
-
-建议优先保持现有“只重试失败项”契约，并将失败传播到同一 block/location 的事件依赖闭包。
-如果选择要求调用方重试整个相关 delta batch，需要先评估兼容性并同步修改接口文档。
-
-验收测试应覆盖同一请求内的 ADD→DELETE、DELETE→ADD、重复 ADD/DELETE，以及每个 metadata
-阶段分别部分失败的组合。
-
-### 3. EventReport storage 在线变更需要 backend incarnation 栅栏
-
-在线 disable、update 或 remove EventReport storage 时存在以下待完善边界：
-
-- backend lookup 需要检查 backend 是否仍然 available；
-- 已持有旧 `shared_ptr` 的请求需要在状态锁内检查 backend 是否仍 open/available；
-- HOST_DOWN/liveness cleanup 不能只携带可能从头计数的数值 generation；
-- backend 重建后，旧请求和旧 cleanup 不能命中新 backend 中同值 generation 的 reporter。
-
-建议为每次 backend 创建分配不可复用的 incarnation，并让请求 admission、generation lease
-和异步 cleanup 同时校验 incarnation + reporter generation。
-
-验收测试：
-
-- 阻塞旧请求或旧 cleanup；
-- disable/update/remove storage 并重建 backend；
-- 注册 reporter 并写入新 metadata；
-- 恢复旧操作；
-- 断言旧操作失败或提前退出，且不能修改新 backend 的状态。
-
-### 4. 重复 RegisterInstance 需要校验 instance group
-
-同一 `instance_id` 的重复注册一致性校验还需要包含 `instance_group_name`。否则调用方使用
-另一个 instance group 重复注册时可能先收到成功，随后 ReportEvent 仍按持久化的旧 group
-查找 backend，并返回不直观的 `EventReportBackend not found`。
-
-建议在重复注册时直接返回明确的冲突错误，并在错误信息中同时给出已有 group 和请求 group。
-
-验收测试应覆盖相同 group 幂等注册、不同 group 冲突，以及冲突后原 instance 仍可正常查询
-和上报。
-
-## P2：接口、配置与运维一致性
-
-### 5. 完成 snapshot delta drain timeout 的端到端配置
-
-- 在 `kvcm_ops add_storage` / `update_storage` 暴露
-  `snapshot_delta_drain_timeout_ms`；
-- Admin Proto 输入负数时返回参数错误，不应静默忽略并回落到默认值；
-- 保持配置文件、Admin API、运维 CLI 和运行时 update 使用同一校验范围；
-- 为默认值、合法边界、零值和负值补齐端到端测试。
-
-### 6. 明确并实现同一请求内 HEARTBEAT 的事件顺序语义
-
-当前 HEARTBEAT 延迟到事件解析完成后处理。对于 unavailable reporter 的
-`[HEARTBEAT, ADD]`，ADD 可能先捕获旧 lifecycle，随后 HEARTBEAT 更新 generation，
-导致按输入顺序本应可执行的 ADD 失败。
-
-需要明确 ReportEvent 是严格按序执行，还是仅对 mutation 定义顺序。如果接口保持按序语义，
-应让 HEARTBEAT 的 lifecycle 变更在后续 mutation 捕获 lease 前生效，并补
-`HEARTBEAT→ADD/DELETE/SNAPSHOT` 组合测试。
-
-### 7. 多个 REGISTER 的逐 item 结果应与实际处理一致
-
-同一请求内多个 REGISTER 当前会预聚合 mediums 并只执行一次。后续非法 REGISTER 可能使
-前面的合法 REGISTER 一并失败，与逐 item 的结果契约不完全一致。
-
-后续应选择并文档化一种语义：
-
-- 按输入顺序逐项验证和执行；或
-- 将 REGISTER 定义为请求级原子操作，并让所有相关 item 返回一致且明确的结果。
-
-需要覆盖合法/非法 REGISTER 混合、重复 medium 和 REGISTER 与其他事件混合的测试。
-
-### 8. 收敛 ReportEvent 成功路径的逐请求 INFO 日志
-
-HTTP 层和 ServiceImpl 层仍可能为同一 ReportEvent 请求各输出一条 INFO 日志。高 QPS 下
-会产生重复日志和额外 I/O。
-
-建议只保留一处必要的成功日志，或改为 DEBUG/采样日志；错误日志仍需保留 trace id、
-instance id、reporter、storage type、event type 和错误码，且不能打印完整大 snapshot。
-
-## P3：低优先级维护项
-
-### 9. 避免在热路径依赖 `std::random_device`
+### 2. 避免在热路径依赖 `std::random_device`
 
 评估 snapshot version/token 生成对随机性的真实要求。若不要求密码学安全，可改为进程级
 初始化的生成器或无锁/低锁的单调序列与随机前缀组合，避免某些平台上
 `std::random_device` 阻塞或产生不稳定延迟。修改后需继续保证 token 格式、进程内唯一性和
 并发安全。
 
-### 10. 保持 PR/发布说明中的验证口径可审计
+### 3. 保持 PR/发布说明中的验证口径可审计
 
 - 带 `manual` 标签的 snapshot/restart HTTP 集成测试不属于默认 GitHub CI；
 - 没有实际 ASAN workflow 或本地执行记录时，不应写成“ASAN 已覆盖”；
 - force-push 或新增 commit 后，应区分“此前 head 的全量结果”和“当前 head 的定向结果”；
 - 发布前记录实际执行的 commit SHA、命令、target、模式（内源/外源、debug/release、
   ASAN/UBSAN）和结果。
+
+## 当前分支已解决的历史项
+
+- Snapshot candidate 绑定 reporter lifecycle generation，并通过
+  `CommitSnapshotVersionIfGeneration` 原子校验 generation/candidate 后提交；测试覆盖 REGISTER
+  抢占旧 snapshot、cleanup 与后续 attempt 的 fence。
+- Delta 同一 block/location 的 ADD/DELETE 建立安全重试依赖闭包；任一阶段失败会传播到相关
+  item，避免仅重试失败项反转 last-operation-wins 结果。
+- 在线 disable/remove/rebuild 会检查 backend open/available；异步 cleanup 同时携带旧 backend
+  `shared_ptr` 和 generation，旧 incarnation 不能清理新 backend。等待中的 delta/snapshot 在
+  `Close()` 或 disable 时会被主动唤醒并二次检查 admission；disable 遗留的 candidate 会被 abort，
+  re-enable 后写门可继续使用，不能等待完整的 snapshot drain timeout。
+- 重复 `RegisterInstance` 校验 `instance_group_name`，不能把既有 instance 移到另一 group。
+- unavailable reporter 的同请求 HEARTBEAT 恢复会把已准入 ADD/DELETE/SNAPSHOT 统一收敛到恢复后
+  generation；正反事件顺序均有测试。
+- 同一请求内多个 REGISTER 逐 item 校验，合法 item 的 mediums 合并并只执行一次实际注册，因此
+  每个请求至多推进一次 lifecycle；非法 sibling 只影响自身结果。
+- HTTP 与 ServiceImpl 的 ReportEvent 成功入口日志已降为 DEBUG；错误日志仍保留诊断字段。
+- `snapshot_delta_drain_timeout_ms` 已进入 Admin proto/config 转换和运行时验证，非正值会被配置
+  校验拒绝；仓库内 round-trip 和非法边界测试已覆盖。
+- 查询有界线程池对部分线程创建失败和 `ParallelFor` 分配/入队异常执行显式清理；`noexcept` 热路径
+  不会因资源异常直接 `std::terminate`，已入队 helper 也不能越过请求返回边界访问调用方引用。
+- cached backend 恢复一旦由 SCAN cursor 得到非空批次，就保留该批精确 key，直到 Get 与
+  PutIfAbsent 全部成功后才推进 cursor；失败重试不得重新 SCAN 同一 cursor，否则变化中的 Redis
+  集合可能让原失败 key 在发布 Running 前被跳过。
+- `MetaStorageBackendManager` 的 `Init()` 只在所有 backend factory 都成功后一次性发布对象，
+  `noexcept` 内部的分配/工厂异常会转成 `EC_ERROR`；成功初始化后拒绝重复 Init。`Open()` 同样
+  拒绝重复调用，cache open 或 recovery-thread 创建失败会回滚两侧 backend，避免半初始化状态和
+  给 joinable `std::thread` 再赋值触发 `std::terminate`。
+- Python Manager Client 的 route-refresh 线程启动失败会事务回滚 HTTP/session-discovery 资源；
+  `close()` 超时后由 refresh worker 延迟关闭仍在使用的 discovery client。HTTP 非 200 和公共响应
+  envelope 损坏统一归类为 `requests.RequestException` 子类（并兼容旧 `AssertionError`），包括
+  `check_response=False` 路径，供 Vineyard 等上层正确推进熔断器；明确的 Manager 非 OK 业务状态
+  保持原异常语义。
+
+关键回归入口包括 `SnapshotCommitRejectsChangedLifecycleGeneration`、
+`TestReportEventDeltaFailureMarksSafeRetryDependencyClosure`、
+`TestHostCleanupCannotCrossEventBackendIncarnations`、
+`CloseUnblocksSnapshotAndDeltaWaiters`、
+`DisableWhileSnapshotDrainsAbortsCandidateAndReopensGate`、
+`TestReportEventHeartbeatRecoveryCarriesSameRequestMutationsIntoNewLifecycle`、
+`TestReportEventValidatesMultipleRegisterItemsIndependently` 和
+`TestReportEventCoalescesMultipleValidRegistersIntoOneLifecycle`。

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -76,7 +76,16 @@ instance group、data-storage backend 和 reporter node lock。当前实现做�
    liveness 与 committed-version 快照。每个 backend 只持有一次 `nodes_mutex_` shared lock，后续
    `(block, location)` 只读不可变快照；
 5. host/spec 投影和候选 host 前缀归约复用同一个有界 executor，输出仍按 host 字典序构造，普通 prefix、
-   Mamba、Eagle pop 和 medium filter 的结果语义不变。
+   Mamba、Eagle pop 和 medium filter 的结果语义不变；
+6. 普通 prefix 只为首 key 建立排序后的候选 host，后续 key 直接写入按候选编号组织的 packed bitset，
+   不再为每个 key 构造 `map<string, set<string>>`，也不保存普通 prefix 根本不需要的 spec name。
+   Mamba 仍需 spec 完整性信息，但改用排序的小 vector，避免每个 key 的红黑树 node 分配；
+7. GetHostCacheState 专用可见性 checker 在校验 EventReport reporter 状态和 URI 时一并返回已经解析的
+   medium/host。host 投影复用该结果，不再对同一 location id 做第二次 split，也不再对已经验证的 URI
+   做第二次完整 parse；普通 prefix 对一个 EventReport location 只做一次候选 host 标记；
+8. service access log 默认只记录 key count、首末 key、query type、medium count、返回 host 数和最大
+   prefix，不再把数千 key 的 protobuf 完整转 JSON 后再 parse 成 DOM。诊断时可临时设置
+   `KVCM_GET_HOST_CACHE_STATE_FULL_ACCESS_LOG=true` 恢复完整 request/response，压测时应保持关闭。
 
 可见性快照在 metadata read 之后开始采集。采集前已经可见的 HOST_DOWN 会被当前请求过滤；与采集并发
 的 HOST_DOWN 允许当前请求看到前或后的状态，但采集完成后本请求不再变化，下一请求会重新采集。由于
@@ -345,12 +354,30 @@ RT 为 224/841/924ms；Get 为 0.099 QPS、平均 8,984 keys/request，平均/p9
 这轮数据发生在 5.5 的本地性能 patch 推送之前；当时该远端开发分支 head 仍为 `637d3e0`，所以不能把
 它当作 5.5 优化后的线上结果。应在包含 5.5 commit 的新 head 上用相同流量重跑 before/after，再判断
 剩余差距。预期 20%~25% 的 RMW/折叠收益仍不足以完全消除 800ms p99；若 after 仍呈相同斜率，下一项
-结构性工作应是一次 shard lock 内同时返回“key 是否存在 + 目标 location value”的 fused targeted RMW，
-而不是继续扩大 Get 查询线程数。
+若本轮只优化 GetHostCacheState，应先上线 2.3 的紧凑投影、摘要 access log，并在 CPU 有余量的环境用
+worker 4/8 做 A/B；fused targeted RMW 会改变 ReportEvent 写入原语和 key-count 语义，不应混入这次
+低风险查询优化。
 
-代码复核还确认两个次级问题：`GetHostCacheState` 的默认 access log 会先完整 protobuf-to-JSON，再由
-access-log builder parse 为 DOM；`MakeBatches` 的 `batch_key_size` 是 shard-boundary soft limit，同一
-shard 的 keys 不会被硬切。这两点都值得单独收敛和补指标，但前者在本轮 0.099 Get QPS 下不足以解释
-共享压力，后者的 writer shard lock 也不阻塞纯 local Get。若线上 `mutex_shard_num=16`，10k keys 的
-均匀请求约为 625 keys/shard；增加 128/256 的 lock-hold hard limit 主要改善写写公平性，必须用混合写
-p99 验证，不能把它误报成 Get 尾延迟根因。
+`GetHostCacheState` 的完整 access-log JSON 问题已按 2.3 收敛。`MakeBatches` 的 `batch_key_size` 仍是
+shard-boundary soft limit，同一 shard 的 keys 不会被硬切；但 writer shard lock 不阻塞纯 local Get。
+若线上 `mutex_shard_num=16`，10k keys 的均匀请求约为 625 keys/shard；增加 128/256 的 lock-hold hard
+limit 主要改善写写公平性，必须用混合写 p99 验证，不能把它误报成 Get 尾延迟根因。
+
+### 5.7 2026-08-05 GetHostCacheState 紧凑投影与 worker 4/8 A/B
+
+在 2.3 的 packed presence、EventReport 解析复用和摘要 access log 完成后，使用同一 Release/O2
+二进制、纯 local metadata、真实 HTTP 接口运行 `test_21_get_host_cache_state_local_scaling`。每档都先
+构造连续命中 block，再追加一个尾部 miss；20 次串行与 16-way 请求逐次校验 prefix。结果如下：
+
+| blocks | worker=4 串行 p50/p99 | worker=8 串行 p50/p99 | worker=4 16-way p50/p99 | worker=8 16-way p50/p99 |
+| ---: | ---: | ---: | ---: | ---: |
+| 100 | 0.56/0.59ms | 0.56/0.59ms | 8.47/17.51ms | 10.84/28.22ms |
+| 1000 | 1.32/1.35ms | 1.20/1.23ms | 6.47/10.87ms | 6.49/11.22ms |
+| 5000 | 4.54/4.72ms | 3.86/3.89ms | 21.12/40.57ms | 20.18/39.99ms |
+| 20000 | 16.07/16.18ms | 13.56/13.63ms | 77.87/101.60ms | 103.57/134.09ms |
+
+对比 5.5 中改动前同一分支的 20k worker=4 基线（串行 25.52ms、16-way 95.65/125.41ms），新实现的
+串行 p50 下降约 37%，16-way p50/p99 下降约 19%/19%。worker=8 在低并发 20k 单请求上比 worker=4
+再快约 16%，符合“CPU 有余量、Get QPS 很低”的部署条件；但 16-way 20k p99 反而增加约 32%。因此代码
+默认值继续保持 4。若线上 Get 约 0.1 QPS 且 CPU 确有余量，可显式配置 worker=8 做小流量 A/B，必须
+同时观察 L2 ReportEvent 压力下的 Get p99 和 executor queue；不能仅凭单请求数据修改全局默认值。

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -35,16 +35,16 @@
 只有缺少 medium 时才释放 shared lock、获取 unique lock 并二次检查。节点 map 和 mediums 仍始终
 受 `nodes_mutex_` 保护，不能改成无锁读取或用一个原子布尔值替代整个 map 的一致性。
 
-### 2.2 lifecycle lease 从每 key 收敛到每 RMW 阶段一次
+### 2.2 lifecycle lease 从每 key 收敛到每次 metadata mutation 一次
 
 原实现会在 modifier 的每个 key 上查 reporter fence、分配 `shared_lock`；已有 location 的 ADD
-经过 block-create 和 targeted-location 两阶段时还会重复一轮。现在每个 RMW 阶段第一次进入
-modifier 时获取一次，后续 key 复用同一个 lease：
+经过 block-create 和 targeted-location 两阶段时还会重复一轮。当前 `BatchMergeLocationSpecs` 已按
+2.5 合并为一次 targeted RMW，在该次 RMW 第一次进入 modifier 时获取一个 lease，后续 key 复用：
 
 ```text
 metadata read（可被 lifecycle writer 抢占）
         |
-non-blocking lifecycle lease（每阶段一次）
+non-blocking lifecycle lease（本次 fused RMW 一次）
         |
 本阶段全部 metadata mutation
         |
@@ -53,8 +53,9 @@ non-blocking lifecycle lease（每阶段一次）
 
 lease 不能在 metadata read 前获取，也不能无条件持有整个 ReportEvent。HOST_DOWN/REGISTER 的
 锁序是 `lifecycle -> metadata`；如果旧请求阻塞在 metadata I/O，lifecycle writer 必须能先完成。
-旧请求恢复后 `try_lock` 失败并放弃写入。BatchMerge 的两个 RMW 阶段之间释放并重新获取，保留同样
-的抢占窗口。确定性 HOST_DOWN/重注册竞态测试是这个优化的强制回归项。
+旧请求恢复后获取 generation-pinned lease 失败并放弃写入。fused RMW 从读取 key/目标 location 到
+upsert 始终处于同一个 metadata shard 临界区，lease 从 read 后持有到 upsert 返回。确定性
+HOST_DOWN/重注册竞态测试是这个优化的强制回归项。
 
 ### 2.3 GetHostCacheState 的 local 大查询路径
 
@@ -137,45 +138,88 @@ ReportEvent RT；worker 并非越多越好。
 4. 协议 URI 在入口完整校验时保存已经解析的 `DataStorageUri`，追加 `s_version` 时复用，不再为同一 URI
    重复 parse；BatchMerge 的版本一致性校验也复用本轮已解析对象，同时仍在 API 边界保留 raw 参数计数，
    duplicate `s_version` 仍会 fail closed；
-5. `BatchMergeLocationSpecs` 的第二阶段只保存原 task 下标，不再复制 location id 和整组 spec/URI。
-   existing Location 仍做一次必要的 copy-on-write，之后在其小 vector 内按 name 原地覆盖、兼容 legacy
-   重名并恢复字典序；不再构造每 key 的 ordered map 和第二份完整 spec vector。
+5. `BatchMergeLocationSpecs` 直接让 caller-owned task 与目标 location id 对齐，不再复制 location id 和
+   整组 spec/URI。existing Location 仍做一次必要的 copy-on-write，之后在其小 vector 内按 name 原地
+   覆盖、兼容 legacy 重名并恢复字典序；不再构造每 key 的 ordered map 和第二份完整 spec vector；
+6. 单 spec/task 的常见路径不创建去重 hash set，多 spec 时 set 保存 `string_view`；storage usage 使用
+   一段 flat vector + offsets，不再为每 key 分配 vector。入口 URI 校验时顺带累计新 spec 的 `size`，
+   merge 只解析旧 spec，避免写入成功后再次遍历、解析全部新 URI。
 
-这些优化没有合并两阶段 RMW，也没有改变 lifecycle lease、shard lock 或 HOST_DOWN 的锁序。收益来自减少
-进入和持有 metadata shard 锁期间的 CPU/分配工作，因此既降低单请求 RT，也缩短并发请求的锁占用窗口；
-不能把它解释成“把锁换成原子变量”。
+这些优化不改变 lifecycle lease、shard lock 或 HOST_DOWN 的锁序。收益来自减少进入和持有 metadata
+shard 锁期间的 CPU/分配工作，因此既降低单请求 RT，也缩短并发请求的锁占用窗口；不能把它解释成
+“把锁换成原子变量”。
+
+### 2.5 BLOCK_ADD fused targeted RMW
+
+2026-08-06 在独立分支落地了此前刻意延后的 fused 原语。旧的 existing-location ADD 先通过
+`ReadModifyWriteBlock(GetLocationIds)` 枚举 block 的全部 location id，再通过
+`ReadModifyWriteLocation` 读取目标 location 并 merge/upsert；纯 local 下至少产生两次 metadata read、
+一次 upsert 和两轮 RMW 容器。当前路径改为：
+
+```text
+GetLocationsWithKeyStatus(key, requested_location_ids)
+        |  同时返回 key 是否存在 + 各目标 location 的值/错误
+        v
+modifier：create 或 copy-on-write merge
+        |
+同一 shard-lock 临界区内一次 Upsert
+```
+
+必须保持以下不变量：
+
+1. `key missing` 与 `key exists but target location missing` 严格区分。只有前者进入
+   `put_global_indices`，参与 `max_key_count` 检查并在 upsert 成功后增加 `key_count`；已有 key 新增
+   location 不增加 key 数，容量已满时仍允许更新已有 key。若一个 internal upsert batch 同时包含已有
+   key 更新和超容量的新 key，只给新 key 返回 `EC_NOSPC`，不能把已有更新连带拒绝；
+2. local backend 在一次 LRU lookup/item shared-lock 中返回上述两个层次的状态。返回 `EC_OK` 的 location
+   必须非空且 id 与请求一致，否则 indexer fail closed；输出 vector 每次重新初始化，miss 不能泄漏 caller
+   复用缓冲区中的旧指针；
+3. `MetaStorageBackendManager` 在 cached recovery 模式仅对真正的 cache key miss 回源 persistent；cache
+   中已有 key 但缺目标 location 时，cache 状态仍是 authoritative。generic backend fallback 仅对
+   “所有目标均 NOENT”的歧义行补一次 `Exists`；纯 local 主路径不走该 fallback；
+4. generation-pinned lifecycle lease 在 targeted read 后、modifier 第一次 mutation 前获取一次，并持有到
+   upsert 返回；不能提前到 metadata read 前，也不能在 read 与 write 之间释放；
+5. 逐 location read/type/modifier/write 错误保持原位，部分成功只更新成功 location 的 storage usage。
+   legacy duplicate spec name 仍按原 last-value-wins 规则归一化；malformed backend shape、空/错 id、
+   `key missing + target EC_OK` 等矛盾状态全部拒绝写入；
+6. 当前实现只是把两个逻辑 RMW 合为一个 targeted read-modify-upsert；local backend 的 upsert 仍会再次
+   lookup 并获取 item unique-lock。没有把 backend item 指针或锁暴露给 modifier，也没有引入批内线程。
 
 ## 3. 当前明确不做的事情
 
-暂不并行执行 ReportEvent 内的 metadata batch。原因不是并行永远无效，而是当前主要指标已经指向
-backend I/O；直接并行可能把排队转移到 Redis、放大连接池竞争并拖高查询 p99，同时会引入
-key-count 容量、同 key mutation 顺序和 lifecycle fencing 的新并发面。
+暂不并行执行 ReportEvent 内的 metadata batch。原因不是并行永远无效，而是 5.10 的同吞吐 A/B 已证明
+把单次 L2 batch 控制在约 2k 能显著降低 ReportEvent、Get 和 Heartbeat 尾延迟；服务端再增加 writer
+会与优先级更高的查询争夺 CPU、allocator 和 local LRU/item lock，同时扩大 key-count、请求内顺序与
+lifecycle fencing 的并发面。若后续仍要并行，必须使用独立有界 executor、按互斥 shard 分组并保留串行
+回退，不能创建 request-local thread 或复用查询 executor。
 
-暂不把 `BatchMergeLocationSpecs` 的两阶段 RMW 简单合并。第一阶段通过“整个 block 是否存在”维护
-`key_count/max_key_count`，第二阶段按目标 location 做 merge。仅使用目标 HMGET 无法区分“key 不存在”
-和“key 存在但目标 location 不存在”；直接替换会造成容量计数错误。
+暂不把 local targeted read 与 upsert 进一步合成“持有一个 item unique-lock、在 backend 内执行
+modifier”的原语。那会让 manager callback 进入 backend 临界区、扩大锁序与异常安全边界；当前一次
+targeted read + 一次 upsert 已消除整轮 block-id 枚举，同时保持 backend API 分层。
 
 GetHostCacheState 也不并发 Redis/cached backend batch，不创建 request-local thread，不复用只有少量
 worker 且承载回收/迁移的 `SchedulePlanExecutor`。查询池独立且有界，避免长 metadata 请求饿死系统任务。
 
-## 4. 下一步最值得验证的 I/O 优化
+## 4. 非 local backend 的扩展边界
 
-Redis `GetLocationIds` 当前为每批 key 做 EXISTS，再用 HSCAN 枚举 location field；已有目标 location
-还要进入 targeted HMGET。若优化后线上 `get_io_time_us` 仍占主导，优先设计一个 backend/indexer
-原语，在保持 shard lock 的一次 RMW 中同时返回：
+当前部署和本轮交付门槛是纯 local metadata；真实 Redis 不在本轮验证范围。通用
+`GetLocationsWithKeyStatus` fallback 已保证正确性，但当所有目标 location 均不存在时会额外调用
+`Exists`。若未来启用 Redis，应实现原生 pipeline，在一个 round trip 中同时返回：
 
 1. key 是否存在（用于 `key_count/max_key_count`）；
 2. 请求指定 location id 的值与逐项错误；
 3. 不枚举、不传输无关 location value。
 
-Redis 实现应尽量把 EXISTS 与目标 HMGET 放进同一 pipeline round trip；Local/Dummy/Async Redis 和
-cached+recover 模式必须具有一致语义。只有补齐新 key、已有 key 缺 location、已有 location、
-properties-only key、tombstone、部分 I/O 失败和 max-key-count UT 后，才能替换现有两阶段逻辑。
+Redis 实现应把 EXISTS 与目标 HMGET 放进同一 pipeline round trip，并单独跑真实 Redis 的新 key、已有
+key 缺 location、已有 location、properties-only key、部分 I/O 失败与恢复测试。在完成这些验证前，
+不能把本轮纯 local 性能数据外推到 Redis，也不能删除 generic fallback。
 
 ## 5. 验证与观测清单
 
-- UT：请求内 512 个跨重复 medium 的 ADD；并发 EnsureNodeRegistered；每 RMW 阶段 lease 次数与失败
-  原子性；HOST_DOWN、REGISTER、新 snapshot 抢占阻塞 metadata read；同请求 ADD/DELETE 顺序。
+- UT：请求内 512 个跨重复 medium 的 ADD；并发 EnsureNodeRegistered；fused RMW 单 lease 与失败原子性；
+  HOST_DOWN、REGISTER、新 snapshot 抢占阻塞 metadata read；同请求 ADD/DELETE 顺序；新 key、已有 key
+  缺 location、已有 location、容量已满更新、部分 backend 错误、malformed response shape 与 storage
+  usage 精确性。
 - 手工容量：`EventReportBenchTest.test_20_large_single_request_delta_scaling` 分别记录 100/1000/5000/20000
   个新 block ADD 与相同 block 再次 ADD 的总 RT、单 event RT，并查询首/中/末 block，不能只看
   HTTP 成功码。
@@ -183,7 +227,8 @@ properties-only key、tombstone、部分 I/O 失败和 max-key-count UT 后，�
   部署保持默认 local metadata backend；只有明确验证 Redis 部署形态时才传 `--meta-storage-uri`。
 - 线上对比：至少拆分 request parse/fold、node ensure、lifecycle lease wait/fail、RMW lock wait、
   `get_io_time_us`、serialize、enqueue/upsert 和完整 ReportEvent RT；同时观察查询 p50/p99。
-- 若去重后 `get_io_time_us` 仍接近总 RT，下一步应做目标化 backend read，而不是先加线程。
+- local 路径已经使用目标化 backend read；若 `get_io_time_us` 仍接近总 RT，应先看 LRU/item-lock wait 与
+  request key-count 分桶，不能再归因于已删除的全 location-id 枚举。
 - 若 backend I/O 已显著下降但 CPU/锁等待仍主导，再评估按互斥 shard 分组的有界并行（建议先从
   2~4 并发开始），并对查询 p99、连接池等待和 Redis CPU 设置回退阈值。
 
@@ -277,6 +322,9 @@ worker 8；必须同时观察 ReportEvent p99、GetHost key-count 分桶、CPU �
 
 ### 5.4 ReportEvent 高基数结论
 
+本节与 5.5、5.6 保留的是 fused targeted RMW 落地前的历史基线和决策背景；当前实现状态以 2.5 和
+5.10 为准，不能再把“尚未合并两阶段”当作现状。
+
 Release/O2、纯 local 下，当前版本单请求 20k BLOCK_ADD 的 create/update 为
 196.55/239.51ms，约 9.8/12.0us 每 event，整体近似线性。对比 `feature/event_report_4@b776dd4`，
 5000-event 单请求及 100-thread ADD、50-thread mixed throughput 均只相差约 0~4%，属于噪声；当前改动
@@ -318,6 +366,9 @@ shard 并行并增加 parse/fold 指标。并行会触及写入原子性、lifec
 ReportEvent key-count 分桶、RMW 两阶段、lock wait、CPU 与 GetHost p99。
 
 ### 5.6 2026-08-05 线上 L2 大批次反馈与后续判别
+
+本节记录当时尚未落地 fused targeted RMW 的线上反馈。后文关于“下一步做 fused”的表述是历史判断，
+最终实现、风险控制与新数据见 2.5、5.10。
 
 一轮按目标 QPS 持续发送的线上压测中，客户端全程 `fail/drop/skipped=0`，工作队列通常为 0~1；
 RSS 峰值约 159.4MB、payload budget 峰值约 129.2MB。停止边界丢弃的一个任务不计入稳态失败。
@@ -464,3 +515,71 @@ allocator/LRU 经高分配压力后的持续退化。
 prefix，并同时检查 Eagle-pop 和 medium filter。该用例完成 Release 100 轮、ASAN 20 轮以及完整
 MetaSearcher Release/ASAN 回归，结果一致。它主要防止 packed presence 的跨 word 索引、并行 slice 写入
 或 prefix reduction 在后续优化中发生静默错位。
+
+### 5.10 2026-08-06 fused targeted RMW、纯 local 回归与同吞吐分批 A/B
+
+本轮工作位于 `codex/report-event-write-performance`，开始前已 fetch 并 rebase 到
+`origin/main@ae9cb0dfa593071be47e0a601af05d8159b383b7`；原查询优化分支未改动。部署明确使用纯 local
+metadata，因此本节的功能、ASAN 与性能结论只以 local 为交付门槛，不把真实 Redis 结果混入结论。
+
+#### 单请求 before/after
+
+在同一 Release/O2、真实 HTTP、全新 local instance 上运行
+`test_20_large_single_request_delta_scaling`。before 是 rebase 后、fused 改动前的基线；after 是最终链接
+产物三次独立串行复测的中位数。每档均校验 committed token 和首/中/末 block 的最终 URI：
+
+| events/request | before create/update | after create/update | update 降幅 |
+| ---: | ---: | ---: | ---: |
+| 100 | 1.57/1.59ms | 1.53/1.40ms | 11.9% |
+| 1000 | 9.41/10.16ms | 9.20/8.73ms | 14.1% |
+| 5000 | 43.75/48.26ms | 42.34/40.99ms | 15.1% |
+| 20000 | 172.00/202.12ms | 169.75/172.09ms | 14.9% |
+
+create 路径没有旧的第二阶段，after 基本持平，说明新 key-status 语义和 flat bookkeeping 没有引入明显
+回归；收益集中在已有 location。三轮 20k create/update 区间为 `166.81~191.29ms` /
+`170.75~189.44ms`，因此应看中位数和线上分桶，不能拿单次最好值当 SLA。20k 的 KVCM
+service/access-log timer 从 before create/update `81.642/113.413ms` 变为两轮 after 平均
+`79.28/85.60ms`，约下降 `2.9%/24.5%`。客户端 update 中位数下降约 14.9%，剩余差异主要在 HTTP
+JSON/protobuf 边界和 worker 排队，不能继续算作 metadata RMW 收益。
+
+#### 相同约 150k blocks/s 的 batch-size A/B
+
+使用 `tools/scripts/report_event_load.py`、16 reporter、纯 local、真实 HTTP，把总 blocks/s 保持接近，
+同时发送 9k-key Get 和 heartbeat。三轮 ADD、Get、heartbeat 均 `failed=0`，每个 ADD 还抽查一个最终 key；
+结果如下：
+
+| ADD 形态 | 成功数 / 实际 QPS | ADD avg/p95/p99 | 9k Get avg/p95/p99 | Heartbeat avg/p99 |
+| --- | ---: | ---: | ---: | ---: |
+| 10k × 15QPS | 317 / 14.41 | 364.49/1268.12/1661.32ms | 271.45/1050.49/1254.13ms（n=5） | 54.66/489.21ms |
+| 5k × 30QPS | 457 / 29.60 | 98.84/197.97/313.58ms | 29.56/150.72/152.65ms（n=16） | 12.55/82.22ms |
+| 2k × 75QPS | 1149 / 74.62 | 50.04/123.93/174.86ms | 18.71/56.68/99.07ms（n=16） | 14.36/87.62ms |
+
+10k 轮的 Get 只有 5 个样本，不能把其 percentile 当成精确 SLA；但 ADD 样本数足够，三个 API 的尾延迟
+又同向变化，足以说明超大 HTTP 请求的长任务、瞬时分配和共享执行资源占用是主要放大器。相同吞吐下，
+2k batch 的 ADD p99 比 10k batch 低约 89%，本轮 9k Get p99 也降到约 99ms。当前推荐发布端先以
+`2k blocks/request` 为起点做线上 A/B；5k 可作为降低 QPS/请求数的折中。该建议不是服务端硬限制，也
+不是无条件的 SLA 保证，仍需按线上 CPU、HTTP worker 数和 URI 大小复测。
+
+这组数据同时否定了“先在 ReportEvent 内继续加线程”的必要性：外部分批已经在不改变写入语义的前提下
+显著改善公平性；服务端 writer 并行会抢占 Get 使用的 CPU、allocator 与 local LRU/item lock。若线上
+2k 分批后仍不满足，下一轮先补 HTTP parse/serialize/worker queue 和 item-lock wait 指标，再决定是否
+做独立有界 writer executor。
+
+#### 本轮验证矩阵
+
+- HTTP 功能：`test_report_event_snapshot.py --skip-bench`，36/36 通过，覆盖 ADD/DELETE/SNAPSHOT、
+  last-operation-wins、校验无副作用、部分失败/重试、并发 snapshot/delta、首次 delta 与清理；
+- Release UT：纯内存 meta/manager 全包 23/23 通过；`CacheManagerTest` 的 10 个 shard 全部通过；
+- 生命周期竞态：HOST_DOWN 拦截已 admission 的 delta、旧 lifecycle 不能跨重注册写入，两项连续 50 轮
+  通过。测试 backend 已显式拦截新的 `GetLocationsWithKeyStatus`，不能只 hook 旧 `GetLocations`；
+- 容量边界：新 key、已有 key 缺 location、已有 target update、max capacity，以及“已有更新 + 超容量新
+  key 位于同一个 internal batch”均通过；最后一种返回 `EC_OK/EC_NOSPC`，`key_count` 与 usage 不漂移；
+- ASAN：`meta_indexer_test`、`meta_local_backend_test`、`meta_dummy_backend_test`、
+  `meta_storage_backend_manager_test`、`MetaSearcherTest` 全部通过；ReportEvent/HOST_DOWN/并发相关
+  `CacheManagerTest` filter 通过；
+- 性能与数据正确性：100/1k/5k/20k create/update 单请求通过；10k/5k/2k 同吞吐持续压测全部零失败。
+
+新增原语不改变协议、URI 或持久化 schema，回滚可以整体 revert 本轮 ReportEvent commit，恢复原两阶段
+RMW。回滚/后续修改时必须一起处理 `MetaStorageBackend::GetLocationsWithKeyStatus`、manager recovery
+路由、`MetaIndexer::ReadModifyWriteTargetLocations` 和 `BatchMergeLocationSpecs`，不能只删除其中一层；
+否则最容易出现的是 `key_count` 漂移或 lifecycle fence 窗口被重新打开。

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -1,0 +1,106 @@
+# ReportEvent 小 block / 大批量性能优化记录
+
+本文记录 `ReportEvent` 在 block size 较小、单次或并发上报 block 数较多时的性能分析、已经实施的
+低风险优化、必须保持的并发语义，以及后续继续优化的边界。后续 AI 或开发者应先阅读本文和
+[`report_event_snapshot_uri_version.md`](report_event_snapshot_uri_version.md)，不要仅根据某个 RT
+指标直接引入并行。
+
+## 1. 现象与指标解释
+
+线上曾观察到 `ReportEvent` 与查询 RT 接近 100ms，同时 `meta_indexer.get_io_time_us` 可占约
+80ms，查询侧 `manager.prefix_match_time_us` 也偏高。需要分开判断：
+
+- `meta_indexer.get_io_time_us` 表示 metadata backend 的读 I/O；对 Redis 而言，批量 key 越多，
+  pipeline 的命令数、reply 大小和 HSCAN/HMGET 成本越高；
+- `manager.prefix_match_time_us` 属于查询候选计算，不能用它直接证明 ReportEvent 本地锁慢；
+- ReportEvent 原有的节点表独占锁和 lifecycle lease 放大会增加 CPU/排队与 heap allocation，
+  但不会解释全部 80ms Redis I/O。优化后仍需按阶段观测，而不是预期一个改动消除所有 RT。
+
+## 2. 已实施的低风险优化
+
+### 2.1 请求内 medium 注册去重
+
+一个 ReportEvent 请求内，相同 reporter/medium 的每个 ADD/DELETE 原来都会调用
+`EnsureNodeRegistered`。现在只在该 medium 第一次成功时调用；成功 REGISTER 声明的 medium 也会
+写入请求内集合。失败不会缓存，因此后续有序 REGISTER 或下一事件仍可重试，保持
+“delta 可以出现在显式 REGISTER 前”的既有语义。
+节点是否已经确保与 medium 集合分开记录：fresh reporter 的空 snapshot 即使没有 medium，也必须
+调用一次 `EnsureNodeRegistered` 完成懒初始化，不能被“缺少待注册 medium”的快路径跳过。
+
+`EventReportBackend::EnsureNodeRegistered` 对已存在且 medium 已知的节点使用 shared lock 快路径；
+只有缺少 medium 时才释放 shared lock、获取 unique lock 并二次检查。节点 map 和 mediums 仍始终
+受 `nodes_mutex_` 保护，不能改成无锁读取或用一个原子布尔值替代整个 map 的一致性。
+
+### 2.2 lifecycle lease 从每 key 收敛到每 RMW 阶段一次
+
+原实现会在 modifier 的每个 key 上查 reporter fence、分配 `shared_lock`；已有 location 的 ADD
+经过 block-create 和 targeted-location 两阶段时还会重复一轮。现在每个 RMW 阶段第一次进入
+modifier 时获取一次，后续 key 复用同一个 lease：
+
+```text
+metadata read（可被 lifecycle writer 抢占）
+        |
+non-blocking lifecycle lease（每阶段一次）
+        |
+本阶段全部 metadata mutation
+        |
+释放 lease
+```
+
+lease 不能在 metadata read 前获取，也不能无条件持有整个 ReportEvent。HOST_DOWN/REGISTER 的
+锁序是 `lifecycle -> metadata`；如果旧请求阻塞在 metadata I/O，lifecycle writer 必须能先完成。
+旧请求恢复后 `try_lock` 失败并放弃写入。BatchMerge 的两个 RMW 阶段之间释放并重新获取，保留同样
+的抢占窗口。确定性 HOST_DOWN/重注册竞态测试是这个优化的强制回归项。
+
+## 3. 当前明确不做的事情
+
+暂不并行执行 ReportEvent 内的 metadata batch。原因不是并行永远无效，而是当前主要指标已经指向
+backend I/O；直接并行可能把排队转移到 Redis、放大连接池竞争并拖高查询 p99，同时会引入
+key-count 容量、同 key mutation 顺序和 lifecycle fencing 的新并发面。
+
+暂不把 `BatchMergeLocationSpecs` 的两阶段 RMW 简单合并。第一阶段通过“整个 block 是否存在”维护
+`key_count/max_key_count`，第二阶段按目标 location 做 merge。仅使用目标 HMGET 无法区分“key 不存在”
+和“key 存在但目标 location 不存在”；直接替换会造成容量计数错误。
+
+## 4. 下一步最值得验证的 I/O 优化
+
+Redis `GetLocationIds` 当前为每批 key 做 EXISTS，再用 HSCAN 枚举 location field；已有目标 location
+还要进入 targeted HMGET。若优化后线上 `get_io_time_us` 仍占主导，优先设计一个 backend/indexer
+原语，在保持 shard lock 的一次 RMW 中同时返回：
+
+1. key 是否存在（用于 `key_count/max_key_count`）；
+2. 请求指定 location id 的值与逐项错误；
+3. 不枚举、不传输无关 location value。
+
+Redis 实现应尽量把 EXISTS 与目标 HMGET 放进同一 pipeline round trip；Local/Dummy/Async Redis 和
+cached+recover 模式必须具有一致语义。只有补齐新 key、已有 key 缺 location、已有 location、
+properties-only key、tombstone、部分 I/O 失败和 max-key-count UT 后，才能替换现有两阶段逻辑。
+
+## 5. 验证与观测清单
+
+- UT：请求内 512 个跨重复 medium 的 ADD；并发 EnsureNodeRegistered；每 RMW 阶段 lease 次数与失败
+  原子性；HOST_DOWN、REGISTER、新 snapshot 抢占阻塞 metadata read；同请求 ADD/DELETE 顺序。
+- 手工容量：`EventReportBenchTest.test_20_large_single_request_delta_scaling` 分别记录 100/1000/5000
+  个新 block ADD 与相同 block 再次 ADD 的总 RT、单 event RT，并查询首/中/末 block，不能只看
+  HTTP 成功码。
+  可在启动 KVCM 后用 `--bench-test test_20_large_single_request_delta_scaling` 单独执行；评估线上
+  metadata I/O 时必须给 `--meta-storage-uri` 传入 Redis，而不是只测 local backend。
+- 线上对比：至少拆分 request parse/fold、node ensure、lifecycle lease wait/fail、RMW lock wait、
+  `get_io_time_us`、serialize、enqueue/upsert 和完整 ReportEvent RT；同时观察查询 p50/p99。
+- 若去重后 `get_io_time_us` 仍接近总 RT，下一步应做目标化 backend read，而不是先加线程。
+- 若 backend I/O 已显著下降但 CPU/锁等待仍主导，再评估按互斥 shard 分组的有界并行（建议先从
+  2~4 并发开始），并对查询 p99、连接池等待和 Redis CPU 设置回退阈值。
+
+### 5.1 2026-08-04 本地 Redis 基准记录
+
+在同机 Redis 7.2.5、debug KVCM、真实 meta/admin HTTP 接口下，使用本文新增的 benchmark 得到：
+
+| events/request | 新建 block ADD | 已有 block/location 再次 ADD |
+| ---: | ---: | ---: |
+| 100 | 7.61ms（0.0761ms/event） | 10.40ms（0.1040ms/event） |
+| 1000 | 62.99ms（0.0630ms/event） | 88.10ms（0.0881ms/event） |
+| 5000 | 303.59ms（0.0607ms/event） | 420.14ms（0.0840ms/event） |
+
+命令使用独立 Redis metadata backend，并对每档首/中/末 block 做查询校验。该数据只是当前开发机的
+可重复基线，不是 SLA；已有 location 明显更慢也印证了两阶段 HSCAN + targeted HMGET 是下一轮
+I/O 优化重点。线上判断必须结合 `get_io_time_us`、Redis CPU/网络和查询 p99。

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -91,7 +91,10 @@ instance group、data-storage backend 和 reporter node lock。当前实现做�
 9. local metadata read 不再让每个 query worker 对每个 block 直接更新共享 revisit histogram counters。
    每个 128-key chunk 先在本地累计 bucket/count/sum，再按非零 bucket 提交原子增量。Prometheus 最终值与
    逐 key `Observe` 完全一致，但避免十万级原子 RMW 争抢同一组 cache line；这段时间属于
-   `meta_indexer.get_io_time_us`。
+   `meta_indexer.get_io_time_us`；
+10. prefix 只把首个 `EC_NOENT` 当作正常终止。首个 miss 之后的 speculative read 结果不影响已经确定的
+    前缀；但 miss 之前的 `EC_ERROR`、`EC_MISMATCH` 等硬错误必须原样返回，不能伪装成较短的 cache miss。
+    普通 prefix 与 Mamba 路径遵循相同规则。
 
 可见性快照在 metadata read 之后开始采集。采集前已经可见的 HOST_DOWN 会被当前请求过滤；与采集并发
 的 HOST_DOWN 允许当前请求看到前或后的状态，但采集完成后本请求不再变化，下一请求会重新采集。由于

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -81,11 +81,17 @@ instance group、data-storage backend 和 reporter node lock。当前实现做�
    不再为每个 key 构造 `map<string, set<string>>`，也不保存普通 prefix 根本不需要的 spec name。
    Mamba 仍需 spec 完整性信息，但改用排序的小 vector，避免每个 key 的红黑树 node 分配；
 7. GetHostCacheState 专用可见性 checker 在校验 EventReport reporter 状态和 URI 时一并返回已经解析的
-   medium/host。host 投影复用该结果，不再对同一 location id 做第二次 split，也不再对已经验证的 URI
-   做第二次完整 parse；普通 prefix 对一个 EventReport location 只做一次候选 host 标记；
+   medium/host。host 投影复用该结果，不再对同一 location id 做第二次 split。EventReport URI 的查询侧
+   校验直接在不可变字符串上单次扫描，用 `string_view` 比较 generation；不再为每个 spec 拆分
+   protocol/host/path、构造 query-param `std::map` 或复制 token。普通 prefix 对一个 EventReport location
+   只做一次候选 host 标记；
 8. service access log 默认只记录 key count、首末 key、query type、medium count、返回 host 数和最大
    prefix，不再把数千 key 的 protobuf 完整转 JSON 后再 parse 成 DOM。诊断时可临时设置
-   `KVCM_GET_HOST_CACHE_STATE_FULL_ACCESS_LOG=true` 恢复完整 request/response，压测时应保持关闭。
+   `KVCM_GET_HOST_CACHE_STATE_FULL_ACCESS_LOG=true` 恢复完整 request/response，压测时应保持关闭；
+9. local metadata read 不再让每个 query worker 对每个 block 直接更新共享 revisit histogram counters。
+   每个 128-key chunk 先在本地累计 bucket/count/sum，再按非零 bucket 提交原子增量。Prometheus 最终值与
+   逐 key `Observe` 完全一致，但避免十万级原子 RMW 争抢同一组 cache line；这段时间属于
+   `meta_indexer.get_io_time_us`。
 
 可见性快照在 metadata read 之后开始采集。采集前已经可见的 HOST_DOWN 会被当前请求过滤；与采集并发
 的 HOST_DOWN 允许当前请求看到前或后的状态，但采集完成后本请求不再变化，下一请求会重新采集。由于
@@ -381,3 +387,48 @@ limit 主要改善写写公平性，必须用混合写 p99 验证，不能把它
 再快约 16%，符合“CPU 有余量、Get QPS 很低”的部署条件；但 16-way 20k p99 反而增加约 32%。因此代码
 默认值继续保持 4。若线上 Get 约 0.1 QPS 且 CPU 确有余量，可显式配置 worker=8 做小流量 A/B，必须
 同时观察 L2 ReportEvent 压力下的 Get p99 和 executor queue；不能仅凭单请求数据修改全局默认值。
+
+### 5.8 2026-08-05 Get 查询 URI 零分配扫描与 histogram 批量提交
+
+在 5.7 的 worker=4 版本上继续检查发现两个与 block 数线性相关、且都位于 GetHostCacheState 的热点：
+
+1. `IsEventReportLocationReadable` 对每个 spec 构造 `DataStorageUri`。解析会复制 URI 的多个 substring，并为
+   每个 query param 分配 `std::map` node；随后 `GetParam` 和 `SnapshotUriInfo` 又复制 32-byte token。查询
+   实际只需要确认 URI 有合法 scheme、`s_version` 不重复且为 32 位十六进制，并与 request snapshot 中的
+   committed token 比较。因此改为一次 `string_view` 扫描，malformed/重复 token 仍然 fail closed；
+2. `MetaLocalBackend::GetLocationValues` 对每个命中 key 调用 revisit histogram `Observe`。默认 13 个 bucket
+   下，一次 10k-key 查询会产生十万级共享 counter 原子 RMW；4 个 query worker 会争抢同一组 cache line。
+   现在每个 executor chunk 先本地聚合，再一次性提交 bucket/count/sum，最终指标值不变。
+
+用当前源码、Release/O2、4096 条变化的典型 EventReport URI、100 万次循环做隔离微基准：
+
+| URI 可见性检查 | 每 spec 分配次数 | 每 spec 累计分配 | 每 spec CPU |
+| --- | ---: | ---: | ---: |
+| 原完整 `DataStorageUri` parse | 10 | 605.7B | 约 497ns |
+| 新 `string_view` 单次扫描 | 0 | 0B | 约 51ns |
+
+新扫描约快 9.7 倍。按 20k specs 估算，仅这一步减少约 12.1MB 短生命周期 allocator 流量和 8.9ms
+单核 CPU；这里的 MB 是累计分配流量，不是常驻 RSS。另一个 4-thread、默认 13 buckets、128-key chunk、
+每轮 10240 observations 的隔离基准中，逐 key 原子更新每轮约 3.9~4.1ms，chunk 聚合约
+0.039~0.041ms，count/sum/buckets 完全一致。该数字只衡量 histogram 自身，不应外推成完整 API 倍数。
+
+随后使用与 5.7 相同的 Release/O2 二进制、纯 local metadata、真实 HTTP benchmark，连续运行三次并取
+各项中位数：
+
+| blocks | 本轮 worker=4 串行 p50/p99 | 5.7 串行 p50/p99 | 本轮 worker=4 16-way p50/p99 | 5.7 16-way p50/p99 |
+| ---: | ---: | ---: | ---: | ---: |
+| 100 | 0.51/0.54ms | 0.56/0.59ms | 6.26/13.51ms | 8.47/17.51ms |
+| 1000 | 1.12/1.15ms | 1.32/1.35ms | 5.91/10.48ms | 6.47/10.87ms |
+| 5000 | 3.10/3.17ms | 4.54/4.72ms | 10.32/23.56ms | 21.12/40.57ms |
+| 20000 | 10.28/10.47ms | 16.07/16.18ms | 23.95/34.25ms | 77.87/101.60ms |
+
+20k 串行 p50/p99 下降约 36%/35%，16-way p50/p99 下降约 69%/66%；三次 20k 串行 p50 为
+10.26/10.30/10.28ms，结果稳定。最后一批 20k 并发请求的 gauges 随单请求调度不同落在：
+`get_io_time_us=4.7~8.4ms`、`host_projection_time_us=2.2~3.3ms`、外层
+`prefix_match_time_us=8.7~12.9ms`。这证明两项分别降低了 metadata read 内共享原子竞争和 read 后 URI
+投影；它不改变 ReportEvent 写入语义，也不缓存每 block 的解析对象。
+
+该 benchmark 是空闲服务的 local 对照，不含线上 15 QPS、约 10k blocks/request 的 L2 ReportEvent
+混合压力。上线后仍需用同一压测流量重点比较 `meta_indexer.get_io_time_us`、
+`meta_searcher.host_projection_time_us` 和 Get p99；若混合负载仍远高于该基线，再依据分段指标检查 local
+LRU/item lock，而不是重新增加无界 worker。

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -435,3 +435,32 @@ limit 主要改善写写公平性，必须用混合写 p99 验证，不能把它
 混合压力。上线后仍需用同一压测流量重点比较 `meta_indexer.get_io_time_us`、
 `meta_searcher.host_projection_time_us` 和 Get p99；若混合负载仍远高于该基线，再依据分段指标检查 local
 LRU/item lock，而不是重新增加无界 worker。
+
+### 5.9 2026-08-05 混合压力复核与并行位图组合回归
+
+在当前 Release/O2、纯 local metadata、真实 HTTP 服务上继续做两组隔离验证。第一组持续 75 秒，使用
+4 个 reporter 混合 20 QPS ADD（100 blocks/request）、10 QPS DELETE（50 blocks/request）、2 QPS
+10k-key Get、5 秒 heartbeat，并在 35 秒周期 snapshot 中主动遗漏 10% 当前数据验证 authoritative cleanup。
+最终 1503 ADD、752 DELETE、8 snapshot、151 Get 和 60 heartbeat 全部成功，影子状态逐事件校验无误；
+10k Get 客户端 p50/p95/p99 为 5.43/20.35/25.18ms，最大 101.20ms 出现在大 snapshot 并发窗口。
+
+第二组按线上复现参数发送约 15 QPS、约 10k blocks/request 的 L2 ADD，持续 45 秒。单个 Python 进程
+同时承担大 JSON 构包、writer、逐 ADD 的 10k-key 正确性查询和独立 reader 时，客户端统计出现约 2.7s
+的 Get p99；但三种小请求的延迟同时抬升，说明该值包含本地 GIL/worker 排队。以服务端 access log 作为
+业务处理边界重新统计，同一阶段结果为：
+
+| 服务端请求 | count | avg | p95 | p99 | max |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| GetHostCacheState（全部） | 753 | 7.43ms | 11.35ms | 12.83ms | 26.00ms |
+| GetHostCacheState（独立 10k reader） | 46 | 7.11ms | 10.16ms | 10.28ms | 10.47ms |
+| ReportEvent | 707 | 73.77ms | 96.97ms | 117.87ms | 143.41ms |
+
+因此同进程压测器的 HTTP wall time 不能直接当作服务端 Get RT。大写入结束后立即重新运行连续命中
+benchmark，20k Get 串行 p50/p99 为 8.84/8.95ms，16-way p50/p99 为 23.39/35.07ms，未观察到
+allocator/LRU 经高分配压力后的持续退化。
+
+另外补充一个确定性参考模型 UT，将此前分别覆盖的两个维度叠加：70 个 candidate host 横跨两个
+64-bit presence word，384 个 key 触发 metadata query executor 并行路径，每个 host 使用不同的预期
+prefix，并同时检查 Eagle-pop 和 medium filter。该用例完成 Release 100 轮、ASAN 20 轮以及完整
+MetaSearcher Release/ASAN 回归，结果一致。它主要防止 packed presence 的跨 word 索引、并行 slice 写入
+或 prefix reduction 在后续优化中发生静默错位。

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -8,13 +8,17 @@
 ## 1. 现象与指标解释
 
 线上曾观察到 `ReportEvent` 与查询 RT 接近 100ms，同时 `meta_indexer.get_io_time_us` 可占约
-80ms，查询侧 `manager.prefix_match_time_us` 也偏高。需要分开判断：
+80ms，查询侧 `manager.prefix_match_time_us` 也偏高。这里最容易误判的是指标名：
 
-- `meta_indexer.get_io_time_us` 表示 metadata backend 的读 I/O；对 Redis 而言，批量 key 越多，
-  pipeline 的命令数、reply 大小和 HSCAN/HMGET 成本越高；
-- `manager.prefix_match_time_us` 属于查询候选计算，不能用它直接证明 ReportEvent 本地锁慢；
-- ReportEvent 原有的节点表独占锁和 lifecycle lease 放大会增加 CPU/排队与 heap allocation，
-  但不会解释全部 80ms Redis I/O。优化后仍需按阶段观测，而不是预期一个改动消除所有 RT。
+- `meta_indexer.get_io_time_us` 是 metadata backend 调用的墙钟时间，不等于磁盘或 Redis 网络 I/O。
+  `storage_type=local` 时完全不经过 Redis，时间来自 sharded LRU lookup、每个 item 的 shared lock、
+  location 容器复制/分配、revisit 统计及 CPU/cache miss；
+- `storage_type=cached` 才是 local cache 加 persistent backend fallback/recovery；`storage_type=redis`
+  才会进入 Redis pipeline、reply 传输和 HSCAN/HMGET。分析监控前必须先确认实例实际 storage type；
+- `manager.prefix_match_time_us` 包含 metadata read、location 可见性判断、URI 解析、host 投影和前缀
+  归约。其内层指标不能与它相加；
+- ReportEvent 原有的节点表独占锁和 lifecycle lease 放大会增加 CPU/排队与 heap allocation。纯 local
+  模式观察到 80ms 时，应先查 O(block 数) 的串行读和容器复制，不能归因于不存在的 Redis。
 
 ## 2. 已实施的低风险优化
 
@@ -52,6 +56,47 @@ lease 不能在 metadata read 前获取，也不能无条件持有整个 ReportE
 旧请求恢复后 `try_lock` 失败并放弃写入。BatchMerge 的两个 RMW 阶段之间释放并重新获取，保留同样
 的抢占窗口。确定性 HOST_DOWN/重注册竞态测试是这个优化的强制回归项。
 
+### 2.3 GetHostCacheState 的 local 大查询路径
+
+小 block 会放大一次请求的 block key 数。旧查询对每个 key 串行读取 local LRU，并把完整
+`unordered_map<location_id, shared_ptr<CacheLocation>>` 克隆到请求结果；随后每个 location 又重复查
+instance group、data-storage backend 和 reporter node lock。当前实现做了以下收敛：
+
+1. `MetaLocalBackend::GetLocationValues` 只复制不可变 `CacheLocation` 的 `shared_ptr`，不复制 map node、
+   hash bucket 和 location-id 字符串。原有 `GetLocations` 保留给需要按 id 查找的调用方；
+2. 仅在“单一 persistent backend 且类型为 `local`”时，把达到阈值的 key 切成连续 chunk 并发读取。
+   `cached`、`redis`、dummy 等模式仍执行一次原有 batch 调用，避免放大远端请求或破坏 recovery 语义；
+3. 全进程所有 MetaIndexer 共享一个有界 `QueryExecutor`。配置的 worker 数包含 RPC caller，默认 4
+   表示 caller + 3 个后台线程，不为每个请求创建线程。队列满时 caller 自己完成剩余 chunk；若 caller
+   已完成全部工作，尚未启动的 helper 会取消，不能为了一个排队中的空任务制造队头阻塞；
+4. metadata read 完成后，第一次处理 event-report location 时用 `std::call_once` 为该请求抓取 reporter
+   liveness 与 committed-version 快照。每个 backend 只持有一次 `nodes_mutex_` shared lock，后续
+   `(block, location)` 只读不可变快照；
+5. host/spec 投影和候选 host 前缀归约复用同一个有界 executor，输出仍按 host 字典序构造，普通 prefix、
+   Mamba、Eagle pop 和 medium filter 的结果语义不变。
+
+可见性快照在 metadata read 之后开始采集。采集前已经可见的 HOST_DOWN 会被当前请求过滤；与采集并发
+的 HOST_DOWN 允许当前请求看到前或后的状态，但采集完成后本请求不再变化，下一请求会重新采集。由于
+`available` 是逐 reporter atomic，多个 reporter 与并发 liveness 变化之间不承诺一个全局事务时间点；这里
+保证的是 request-stable 结果，避免同一 reporter 在一次长 projection 中前半段 up、后半段 down，也把
+stale window 放在耗时 metadata read 之后。
+
+这不是用“原子变量 + 双重检查”替换 node map。`available` 本身可以是 atomic，但 reporter 的存在性、
+lifecycle generation、strict flag 与 committed token 必须在同一个受保护快照中一致；只原子化一个布尔值
+会产生 host 已换代但仍配旧 token 的组合。`EnsureNodeRegistered` 的 shared-lock fast path + unique-lock
+二次检查仍用于写路径，请求级只读快照用于大查询路径，两者解决的问题不同。
+
+相关启动参数如下，修改后需重启：
+
+| 参数 | 默认值 | 约束/含义 |
+| --- | ---: | --- |
+| `kvcm.meta_query.worker_count` | 4 | 1..64；包含 caller，设为 1 可回退为串行 |
+| `kvcm.meta_query.parallel_threshold` | 256 | key/投影元素数小于该值时不并发 |
+| `kvcm.meta_query.chunk_size` | 128 | `0 < chunk_size <= threshold` |
+
+默认值是保守起点，不是固定 SLA。调参必须同时看单请求 p50/p99、并发查询 p99、CPU、RPC worker 排队和
+ReportEvent RT；worker 并非越多越好。
+
 ## 3. 当前明确不做的事情
 
 暂不并行执行 ReportEvent 内的 metadata batch。原因不是并行永远无效，而是当前主要指标已经指向
@@ -61,6 +106,9 @@ key-count 容量、同 key mutation 顺序和 lifecycle fencing 的新并发面�
 暂不把 `BatchMergeLocationSpecs` 的两阶段 RMW 简单合并。第一阶段通过“整个 block 是否存在”维护
 `key_count/max_key_count`，第二阶段按目标 location 做 merge。仅使用目标 HMGET 无法区分“key 不存在”
 和“key 存在但目标 location 不存在”；直接替换会造成容量计数错误。
+
+GetHostCacheState 也不并发 Redis/cached backend batch，不创建 request-local thread，不复用只有少量
+worker 且承载回收/迁移的 `SchedulePlanExecutor`。查询池独立且有界，避免长 metadata 请求饿死系统任务。
 
 ## 4. 下一步最值得验证的 I/O 优化
 
@@ -80,16 +128,39 @@ properties-only key、tombstone、部分 I/O 失败和 max-key-count UT 后，�
 
 - UT：请求内 512 个跨重复 medium 的 ADD；并发 EnsureNodeRegistered；每 RMW 阶段 lease 次数与失败
   原子性；HOST_DOWN、REGISTER、新 snapshot 抢占阻塞 metadata read；同请求 ADD/DELETE 顺序。
-- 手工容量：`EventReportBenchTest.test_20_large_single_request_delta_scaling` 分别记录 100/1000/5000
+- 手工容量：`EventReportBenchTest.test_20_large_single_request_delta_scaling` 分别记录 100/1000/5000/20000
   个新 block ADD 与相同 block 再次 ADD 的总 RT、单 event RT，并查询首/中/末 block，不能只看
   HTTP 成功码。
-  可在启动 KVCM 后用 `--bench-test test_20_large_single_request_delta_scaling` 单独执行；评估线上
-  metadata I/O 时必须给 `--meta-storage-uri` 传入 Redis，而不是只测 local backend。
+  可在启动 KVCM 后用 `--bench-test test_20_large_single_request_delta_scaling` 单独执行。纯 cache
+  部署保持默认 local metadata backend；只有明确验证 Redis 部署形态时才传 `--meta-storage-uri`。
 - 线上对比：至少拆分 request parse/fold、node ensure、lifecycle lease wait/fail、RMW lock wait、
   `get_io_time_us`、serialize、enqueue/upsert 和完整 ReportEvent RT；同时观察查询 p50/p99。
 - 若去重后 `get_io_time_us` 仍接近总 RT，下一步应做目标化 backend read，而不是先加线程。
 - 若 backend I/O 已显著下降但 CPU/锁等待仍主导，再评估按互斥 shard 分组的有界并行（建议先从
   2~4 并发开始），并对查询 p99、连接池等待和 Redis CPU 设置回退阈值。
+
+GetHostCacheState 的新增分段指标：
+
+- `meta_searcher.indexer_get_time_us`：整个 MetaIndexer 读取；
+- `meta_indexer.get_io_time_us`：其内部 backend 调用墙钟时间；
+- `meta_searcher.host_projection_time_us`：location 可见性、URI/host/spec 投影；
+- `meta_searcher.host_prefix_reduce_time_us`：按 host 计算普通或 Mamba 前缀；
+- `manager.prefix_match_time_us`：上述阶段及少量管理层开销的外层总时间。
+
+UT 覆盖单线程/4-worker 结果对照、缺失 key 和重复 key、普通/Mamba 大于阈值、medium filter、Eagle pop、
+HOST_DOWN 发生在 metadata read 期间、快照 instance 隔离、并发读写 local item、executor 队列饱和、
+callback 异常与嵌套调用。可选 HTTP benchmark：
+
+```bash
+python integration_test/meta_service/test_report_event_snapshot.py \
+  --host localhost --http_port 56020 --admin_http_port 56040 \
+  --instance_id event_report_cluster_0 \
+  --bench-test test_21_get_host_cache_state_local_scaling
+```
+
+它会对 100/1000/5000/20000 个命中 block（再加一个尾部 miss）记录 20 次串行请求以及 16-way 并发请求的
+p50/p99，并逐次校验 host prefix。对照串行基线时分别用
+`kvcm.meta_query.worker_count=1` 和默认 `4` 重启服务运行；不要在一次进程内动态改配置。
 
 ### 5.1 2026-08-04 本地 Redis 基准记录
 
@@ -104,3 +175,72 @@ properties-only key、tombstone、部分 I/O 失败和 max-key-count UT 后，�
 命令使用独立 Redis metadata backend，并对每档首/中/末 block 做查询校验。该数据只是当前开发机的
 可重复基线，不是 SLA；已有 location 明显更慢也印证了两阶段 HSCAN + targeted HMGET 是下一轮
 I/O 优化重点。线上判断必须结合 `get_io_time_us`、Redis CPU/网络和查询 p99。
+
+### 5.2 2026-08-04 GetHostCacheState 纯 local 对照
+
+同一台开发机、debug KVCM、真实 meta/admin HTTP 接口、单 reporter/medium 下，分别以
+`kvcm.meta_query.worker_count=1` 和默认 `4` 重启进程运行
+`test_21_get_host_cache_state_local_scaling`。每个请求包含 N 个连续命中 block 和一个尾部 miss；串行数据
+为 3 次 warmup 后 20 次请求，并发数据为 16-way、共 32 次请求。每次响应均校验 prefix：
+
+| blocks | worker=1 串行 p50/p99 | worker=4 串行 p50/p99 | worker=1 16-way p50/p99 | worker=4 16-way p50/p99 |
+| ---: | ---: | ---: | ---: | ---: |
+| 100 | 1.83/1.87ms | 1.87/2.71ms | 10.71/23.03ms | 13.68/23.01ms |
+| 1000 | 11.26/11.62ms | 6.25/6.31ms | 14.86/23.20ms | 13.24/21.75ms |
+| 5000 | 53.35/55.41ms | 27.79/29.60ms | 68.45/102.07ms | 52.59/70.90ms |
+
+100 block 小于默认 threshold，差异属于噪声且没有并发收益；5000 block 的单请求 p50 下降约 48%，
+16-way p99 下降约 31%。这是 debug 单机趋势而非线上 SLA。线上 rollout 仍应先小流量，确认分段 metrics、
+CPU 和 ReportEvent p99；若并发度带来负收益，可直接把 worker_count 回退为 1。
+
+### 5.3 2026-08-04 Release/O2 纯 local before/after
+
+为避免把 Debug 构建开销当成线上结论，在同一台开发机上分别构建性能提交的直接父版本
+`88e29c1` 和当前版本；两者均使用 Release/O2、真实 meta/admin HTTP、纯 local metadata backend。
+当前版本使用默认 `worker_count=4`、`parallel_threshold=256`、`chunk_size=128`。下表选择双方第二轮
+完整运行的数据；每个响应仍逐次校验 host prefix：
+
+| blocks | 父版本串行 p50/p99 | 当前串行 p50/p99 | 父版本 16-way p50/p99 | 当前 16-way p50/p99 |
+| ---: | ---: | ---: | ---: | ---: |
+| 100 | 0.71/0.73ms | 0.68/0.70ms | 5.09/10.27ms | 5.34/11.42ms |
+| 1000 | 2.62/2.69ms | 1.80/1.87ms | 9.03/15.78ms | 6.99/11.10ms |
+| 5000 | 11.60/11.82ms | 6.95/7.05ms | 29.04/42.10ms | 22.01/28.56ms |
+| 20000 | 47.33/51.67ms | 26.02/27.30ms | 142.68/188.26ms | 95.26/123.18ms |
+
+20k 串行 p50 下降约 45%；这说明轻量 local read、host 投影与有界并行都产生了实际收益。高基数
+16-way 请求即使优化后仍可能超过 100ms，不应只看全局 RT；至少要按 `request_key_count` 分桶。
+一次 5001-key 并发请求的 gauge 快照中，父版本 `prefix_match/get_io/service` 分别为
+25.717/9.620/25.750ms；当前版本为 10.441/6.623/10.471ms，且新增 projection/reduce 分别为
+3.168/0.184ms。Gauge 只是最后一次观测，不是 percentile，不能与上表混用。
+
+并发度和 chunk 调优结论：
+
+- 低并发下 worker 8/16 可继续降低单请求 RT，但 worker 32 收益已明显递减且并发尾延迟回升；
+- 20k isolated 热轮中，worker 4/8/16 的串行 p50 约为 26.02/23.05/21.18ms；16-way
+  p50/p99 代表值分别为 95.26/123.18、73.92/115.82、100.24/133.01ms；
+- 同时运行 100-thread ReportEvent ADD 与重复 20k GetHost 时，worker 4 与 8 的 ReportEvent 分别为
+  1399/1435 QPS、p99 186.93/184.97ms；但第二轮 GetHost 16-way p50/p99 从 worker 4 的
+  108.62/184.91ms 恶化到 worker 8 的 132.50/217.67ms；
+- chunk 64 在小批次略快但冷并发更抖，chunk 256 在 5000 blocks 略慢，默认 128 更均衡。
+
+因此默认仍保持 worker 4/chunk 128。低并发、CPU 余量充足且更关心单请求 RT 的部署可以显式尝试
+worker 8；必须同时观察 ReportEvent p99、GetHost key-count 分桶、CPU 和 executor queue saturation，
+不能把本机 isolated 结果直接当作通用默认值。
+
+### 5.4 ReportEvent 高基数结论
+
+Release/O2、纯 local 下，当前版本单请求 20k BLOCK_ADD 的 create/update 为
+196.55/239.51ms，约 9.8/12.0us 每 event，整体近似线性。对比 `feature/event_report_4@b776dd4`，
+5000-event 单请求及 100-thread ADD、50-thread mixed throughput 均只相差约 0~4%，属于噪声；当前改动
+没有回归 ReportEvent，但也不能宣称改善其高并发尾延迟。
+
+一次 20k existing-location update 的详细观测为：客户端 RT 249.59ms，KVCM service/event timer
+约 161ms，block RMW 32.18ms，location RMW 63.38ms，local backend get/upsert I/O 仅
+7.33/6.04ms，metadata lock wait 约 1us。也就是说，剩余成本不是 Redis 或全局锁，而是：
+
+1. HTTP/JSON/protobuf 请求解析与响应边界约 89ms；
+2. 两阶段 RMW 内逐 key 的 CPU、拷贝和 modifier 约 95ms，其中真实 backend I/O 约 13ms。
+
+若线上 10k~20k 单批 ReportEvent 仍需显著低于 100ms，下一轮应单独设计 local RMW shard 并行或减少
+block-create/targeted-location 两阶段数据变换，并增加 parse/fold 指标。该改动会触及写入原子性、
+lifecycle fence 和锁序，不能作为本轮查询优化的顺手补丁；上线前可先限制单请求 event 数或分批上报。

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -68,7 +68,10 @@ instance group、data-storage backend 和 reporter node lock。当前实现做�
    `cached`、`redis`、dummy 等模式仍执行一次原有 batch 调用，避免放大远端请求或破坏 recovery 语义；
 3. 全进程所有 MetaIndexer 共享一个有界 `QueryExecutor`。配置的 worker 数包含 RPC caller，默认 4
    表示 caller + 3 个后台线程，不为每个请求创建线程。队列满时 caller 自己完成剩余 chunk；若 caller
-   已完成全部工作，尚未启动的 helper 会取消，不能为了一个排队中的空任务制造队头阻塞；
+   已完成全部工作，尚未启动的 helper 会取消，不能为了一个排队中的空任务制造队头阻塞。线程池部分
+   构造失败时会停止并 join 已创建线程；`ParallelFor` 的分配/入队失败会先阻止 queued helper 再进入
+   callback、等待 active helper 退出并返回失败，不能因 `noexcept` 直接终止进程，也不能让 helper 在
+   请求返回后继续访问 request-local 引用；
 4. metadata read 完成后，第一次处理 event-report location 时用 `std::call_once` 为该请求抓取 reporter
    liveness 与 committed-version 快照。每个 backend 只持有一次 `nodes_mutex_` shared lock，后续
    `(block, location)` 只读不可变快照；
@@ -149,7 +152,7 @@ GetHostCacheState 的新增分段指标：
 
 UT 覆盖单线程/4-worker 结果对照、缺失 key 和重复 key、普通/Mamba 大于阈值、medium filter、Eagle pop、
 HOST_DOWN 发生在 metadata read 期间、快照 instance 隔离、并发读写 local item、executor 队列饱和、
-callback 异常与嵌套调用。可选 HTTP benchmark：
+callback 异常、嵌套调用与线程池异常清理。可选 HTTP benchmark：
 
 ```bash
 python integration_test/meta_service/test_report_event_snapshot.py \

--- a/docs/design/report_event_performance.md
+++ b/docs/design/report_event_performance.md
@@ -100,6 +100,33 @@ lifecycle generation、strict flag 与 committed token 必须在同一个受保�
 默认值是保守起点，不是固定 SLA。调参必须同时看单请求 p50/p99、并发查询 p99、CPU、RPC worker 排队和
 ReportEvent RT；worker 并非越多越好。
 
+### 2.4 ReportEvent 折叠、URI 与 Location 拷贝收敛
+
+2026-08-05 的进一步分段和同机 A/B 表明，纯 local 模式下两阶段 RMW 的真实 backend I/O 只占少数，
+主要成本是请求内聚合以及 modifier 在 metadata shard 锁内做的 Location/spec 深拷贝。当前实现做了以下
+不改变持久化语义的收敛：
+
+1. `LocationSpec` 和 `CacheLocation` 因显式析构函数而没有隐式 move，原来多处看似
+   `std::move` 的代码实际退化为深拷贝；`set_location_specs(vector&&)` 也错误地执行了拷贝赋值。现在显式
+   提供 `noexcept` move，并真正移动 vector。该修复同时覆盖新建 Location、spec merge、迁移等已有调用点；
+2. delta 请求从“三层 `map` + 每个 mutation 的 event vector”改为 block 哈希表以及通常很小的
+   location/spec 连续 vector。每个稳定 `(block, location, spec name)` 仍按请求顺序原地覆盖，最后按
+   block/location/spec 排序后直接生成 ADD/DELETE task；删除了
+   `delta_spec_mutations -> block_to_add/del -> merged_entries -> tasks` 的重复聚合和拷贝链；
+3. 重试依赖保留为每个稳定 block/location 的有序 event 引用。只有已经 materialize 且参与最终 ADD 或
+   DELETE phase 的事件先接收该 phase 的写错误，随后再按原有规则闭包传播。因此 last-operation-wins、
+   admission failure、两 phase 不同错误以及逐 item 返回语义均未因扁平化改变；
+4. 协议 URI 在入口完整校验时保存已经解析的 `DataStorageUri`，追加 `s_version` 时复用，不再为同一 URI
+   重复 parse；BatchMerge 的版本一致性校验也复用本轮已解析对象，同时仍在 API 边界保留 raw 参数计数，
+   duplicate `s_version` 仍会 fail closed；
+5. `BatchMergeLocationSpecs` 的第二阶段只保存原 task 下标，不再复制 location id 和整组 spec/URI。
+   existing Location 仍做一次必要的 copy-on-write，之后在其小 vector 内按 name 原地覆盖、兼容 legacy
+   重名并恢复字典序；不再构造每 key 的 ordered map 和第二份完整 spec vector。
+
+这些优化没有合并两阶段 RMW，也没有改变 lifecycle lease、shard lock 或 HOST_DOWN 的锁序。收益来自减少
+进入和持有 metadata shard 锁期间的 CPU/分配工作，因此既降低单请求 RT，也缩短并发请求的锁占用窗口；
+不能把它解释成“把锁换成原子变量”。
+
 ## 3. 当前明确不做的事情
 
 暂不并行执行 ReportEvent 内的 metadata batch。原因不是并行永远无效，而是当前主要指标已经指向
@@ -244,6 +271,86 @@ Release/O2、纯 local 下，当前版本单请求 20k BLOCK_ADD 的 create/upda
 1. HTTP/JSON/protobuf 请求解析与响应边界约 89ms；
 2. 两阶段 RMW 内逐 key 的 CPU、拷贝和 modifier 约 95ms，其中真实 backend I/O 约 13ms。
 
-若线上 10k~20k 单批 ReportEvent 仍需显著低于 100ms，下一轮应单独设计 local RMW shard 并行或减少
-block-create/targeted-location 两阶段数据变换，并增加 parse/fold 指标。该改动会触及写入原子性、
-lifecycle fence 和锁序，不能作为本轮查询优化的顺手补丁；上线前可先限制单请求 event 数或分批上报。
+这组数据是 5.5 拷贝收敛前的基线；本轮先减少 block-create/targeted-location 两阶段的数据变换，并保持
+串行 RMW。若线上 10k~20k 单批 ReportEvent 在 5.5 的收益后仍需显著低于 100ms，再单独评估 local RMW
+shard 并行并增加 parse/fold 指标。并行会触及写入原子性、lifecycle fence 和锁序，不能仅凭单请求 RT
+开启；上线前仍可通过限制单请求 event 数或分批上报控制尾延迟。
+
+### 5.5 2026-08-05 ReportEvent 拷贝收敛同机 A/B
+
+使用本节 2.4 的性能改动直接父提交 `8f7d5bc` 和当前工作树分别构建 Release/O2 二进制；两个进程使用
+独立端口、独立纯 local instance，在同一台机器连续运行
+`test_20_large_single_request_delta_scaling` 两轮。下表是两轮平均值，所有请求均校验 committed token 以及
+首/中/末 block 的最终 URI：
+
+| events/request | 父提交 create/update | 当前 create/update | create/update 降幅 |
+| ---: | ---: | ---: | ---: |
+| 100 | 1.84/1.89ms | 1.55/1.56ms | 15.8%/17.7% |
+| 1000 | 11.78/13.16ms | 9.41/10.16ms | 20.1%/22.8% |
+| 5000 | 54.23/63.01ms | 43.88/48.14ms | 19.1%/23.6% |
+| 20000 | 217.19/269.40ms | 171.52/202.26ms | 21.0%/24.9% |
+
+20k 单次请求的两轮原始区间分别为：父提交 create 216.86~217.51ms、update
+267.44~271.36ms；当前 create 170.27~172.77ms、update 201.97~202.54ms。趋势随规模增大而扩大，
+符合“减少每 event/node 分配与深拷贝”的预期，不是固定开销或单次快样本。
+
+同一当前二进制随后运行 GetHostCacheState local benchmark，100/1000/5000/20000 block 串行 p50 为
+0.67/1.78/6.71/25.52ms；20k 的 16-way p50/p99 为 95.65/125.41ms，与 5.3 的优化后基线基本一致，
+未观察到通用 move 修复带来的查询回归。以上仍是单机趋势而非 SLA；线上 rollout 应同时观察
+ReportEvent key-count 分桶、RMW 两阶段、lock wait、CPU 与 GetHost p99。
+
+### 5.6 2026-08-05 线上 L2 大批次反馈与后续判别
+
+一轮按目标 QPS 持续发送的线上压测中，客户端全程 `fail/drop/skipped=0`，工作队列通常为 0~1；
+RSS 峰值约 159.4MB、payload budget 峰值约 129.2MB。停止边界丢弃的一个任务不计入稳态失败。
+客户端 L2 构包平均约 3.84ms，而 HTTP 约 217ms；Get 构包约 1.28ms，而 HTTP 约 118ms。因此本轮
+瓶颈不在客户端构包、排队或内存预算，HTTP 往返与服务端处理占绝大多数。
+
+L2 延迟随单批 block 数近似线性：batch p50 约 7k 时 RT p50 约 158ms，batch p95 约 34.5k 时
+RT p95 约 795ms，两点折算的处理速度都约为 44k blocks/s。大批次期间 Get 出现 200~400ms 尾延迟，
+很小的 Heartbeat 也达到约 164ms p99。这些数据足以判断“大 L2 请求的服务端线性工作正在拖慢共享
+资源”，但仅凭客户端 HTTP 时间仍不能区分以下来源各占多少：
+
+1. meta HTTP 端口上的所有 API 共用同一组 `coro_http_server` I/O worker，业务 handler 又同步进入
+   `MetaServiceImpl`/`CacheManager`；长请求可能造成 worker 占用或 CPU 调度排队；
+2. `MetaIndexer` 的 RMW 对每个 batch 在 writer shard lock 内依次完成 backend read、modifier、可选的
+   persistent-backend 序列化和 upsert/delete；同 shard 的其他写入会等待。纯 local 的 Get 不获取这把
+   writer shard lock，但会和 upsert 争用对应 `MetaMemCacheItem` 的 shared/unique mutex；跨 shard 请求
+   仍可能争用 CPU、allocator 和 cache；
+3. HTTP body 解析、protobuf/JSON 转换以及响应序列化不在现有 RMW 分段指标内，大 payload 会继续带来
+   线性 CPU 和内存带宽成本。
+
+下一轮线上观测应把客户端 HTTP RT 与服务端 `ReportEvent` service timer 对齐，并同时按 batch-size
+分桶采集 request parse/fold、block/location RMW、`get_io_time_us`、deserialize/serialize、
+`lock_wait_time_us`、upsert 和 HTTP worker queue/active 数。现有 `lock_wait_time_us` 只覆盖 writer shard
+mutex，不覆盖 local item mutex；若要验证 Get 被 upsert 阻塞，需另加 item-lock wait 指标。若 HTTP RT
+显著大于 service timer，优先查 HTTP worker 排队与 body 编解码；若 service timer 本身接近 HTTP RT，
+再依据 RMW/lock/CPU 分段决定是继续减少 Location 处理成本，还是做 shard-aware 并行。不要从 Heartbeat
+p99 单独反推出某一把锁有问题。
+
+本节 5.5 的拷贝收敛可把 20k create/update 降低约 21%/25%，属于应先上线验证的常数优化；按本轮
+34.5k p95 批次估算，它不足以单独消除 700ms 级尾延迟。发布侧最直接的保护是限制单次 L2 block 数并
+拆成较小批次（可先以 2k~5k 做压测起点），同时给 Get/Heartbeat 保留独立的并发或队列预算。若拆批后
+服务端总吞吐仍稳定且尾延迟显著下降，再决定是否需要把 ReportEvent 放到独立有界 executor，或按互斥
+metadata shard 做 2~4 路有界并行。两种结构性改动都必须保留 request 内 last-operation-wins、两阶段
+key-count、lifecycle fence 和逐 item 错误语义，并设置过载回退，不能用无限并行掩盖单批过大。
+
+随后另一轮混合压测得到：L1P5 ADD 为 1.999 QPS、平均/p99/max RT 为
+7.56/42/146ms；L2 ADD 为 14.998 QPS、149,969 blocks/s，即平均约 10k blocks/request，平均/p99/max
+RT 为 224/841/924ms；Get 为 0.099 QPS、平均 8,984 keys/request，平均/p99 RT 为 119/418ms。L2 的
+单请求处理速度约为 44.6k blocks/s，与前一轮约 44k blocks/s 基本相同，进一步确认瓶颈随 block 数线性
+增长，而不是压测器吞吐不足；约 3.36 个 L2 请求的平均并发也解释了为何 aggregate blocks/s 高于单请求
+速度。
+
+这轮数据发生在 5.5 的本地性能 patch 推送之前；当时该远端开发分支 head 仍为 `637d3e0`，所以不能把
+它当作 5.5 优化后的线上结果。应在包含 5.5 commit 的新 head 上用相同流量重跑 before/after，再判断
+剩余差距。预期 20%~25% 的 RMW/折叠收益仍不足以完全消除 800ms p99；若 after 仍呈相同斜率，下一项
+结构性工作应是一次 shard lock 内同时返回“key 是否存在 + 目标 location value”的 fused targeted RMW，
+而不是继续扩大 Get 查询线程数。
+
+代码复核还确认两个次级问题：`GetHostCacheState` 的默认 access log 会先完整 protobuf-to-JSON，再由
+access-log builder parse 为 DOM；`MakeBatches` 的 `batch_key_size` 是 shard-boundary soft limit，同一
+shard 的 keys 不会被硬切。这两点都值得单独收敛和补指标，但前者在本轮 0.099 Get QPS 下不足以解释
+共享压力，后者的 writer shard lock 也不阻塞纯 local Get。若线上 `mutex_shard_num=16`，10k keys 的
+均匀请求约为 625 keys/shard；增加 128/256 的 lock-hold hard limit 主要改善写写公平性，必须用混合写
+p99 验证，不能把它误报成 Get 尾延迟根因。

--- a/docs/design/report_event_snapshot_uri_version.md
+++ b/docs/design/report_event_snapshot_uri_version.md
@@ -374,12 +374,16 @@ snapshot replace + commit/abort
 - commit 后等待 delta 使用新 generation；
 - abort 后等待 delta 使用旧 generation；若此前没有旧 generation，则创建一个新 generation；
 - Close、Unregister、HOST_DOWN 唤醒 waiter；等待 active delta 另有可配置超时，不会无界阻塞；
-- metadata read-modify-write 在最终写阶段持有 lifecycle generation lease；旧请求不能在
-  HOST_DOWN、重新 REGISTER 和新 snapshot 后恢复写入；
-- mutation 在已经持有 metadata 锁时只做非阻塞的 per-reporter lifecycle lease 获取；若同一
-  reporter 的 HOST_DOWN/REGISTER lifecycle writer 已经开始等待，则旧 mutation 立即失败，
-  避免与 cleanup 的 `lifecycle -> metadata` 顺序形成锁序反转；不同 reporter 使用独立
-  fence，不会因其他 host 的 HEARTBEAT/REGISTER 产生假失败；
+- metadata read-modify-write 在每个 RMW 阶段完成读、准备进入最终写时，只获取一次
+  lifecycle generation lease，并持有到该阶段结束；同一阶段不再按 key 重复查 fence 或分配
+  shared lock；
+- lease 不能提前到 metadata read 之前获取。这样旧请求阻塞在 metadata I/O 时，HOST_DOWN/
+  REGISTER 仍可先取得 lifecycle writer；旧请求恢复后使用非阻塞获取立即失败，不能跨越新
+  lifecycle 写入；BatchMerge 的 block-create 与 targeted-location 两个 RMW 阶段之间同样释放并
+  重新获取 lease；
+- mutation 在已经持有 metadata 锁时只做上述非阻塞的 per-reporter lifecycle lease 获取，
+  避免与 cleanup 的 `lifecycle -> metadata` 顺序形成锁序反转；不同 reporter 使用独立 fence，
+  不会因其他 host 的 HEARTBEAT/REGISTER 产生假失败；
 - liveness unregister 的 generation 比较与节点删除在同一把锁内完成；
 - 显式 HOST_DOWN 的 generation 捕获与节点删除同样在同一把锁内完成，Heartbeat/REGISTER
   只能在线性化的 HOST_DOWN 之前或之后生效，不能在中间恢复后又被旧请求删除；
@@ -456,6 +460,8 @@ reporter -> location 反向索引，而不是继续提高全量频率。
 - snapshot commit 后 delta 刷新 mixed-generation location 时，旧 cleanup 不删除新写；
 - snapshot cleanup 只删除 metadata，不调用外部 URI backend；
 - 成功 snapshot 最终清理旧数据，失败 snapshot 不触发专用清理；
+- backend requested-spec 使用 any-of 语义，在 peer 选择前检查 location 的所有 specs；Prefix 在
+  spec gap 停止，Coverage 跳过 gap，最终响应投影保持 `spec_size == location_specs.size()`；
 - snapshot 限流、storage type 隔离和 liveness 竞态。
 
 ### 12.2 集成测试
@@ -473,9 +479,31 @@ reporter -> location 反向索引，而不是继续提高全量频率。
 - snapshot partial failure、完整重试；
 - snapshot commit 后立即到达的 delta 在异步 cleanup 后仍可查询；
 - reporter host 或 medium 含 `#` 时 fail closed 且无写入副作用；
+- Bazel `--runs_per_test` 并发重复时，每个 test action 的可变 worker 目录必须位于其私有
+  `TEST_TMPDIR`，不得在共享 runfiles/source tree 中清理或复制；至少用 20 路重复验证目录隔离；
+- heartbeat/grace 计时用例必须使用独立的短超时 storage/instance group，不能缩短功能与容量
+  用例共享 storage 的生命周期窗口，否则异步 cleanup 验证会被 liveness cleanup 交叉干扰；
 - ASAN/TSAN 或等价并发检测（仅记录实际执行结果，不能由普通 CI 结果推断）。
 
 Snapshot 与重启 HTTP 测试 target 带 `manual` 标签，不属于默认 GitHub CI；需要显式执行并单独记录结果。
+
+### 12.3 Vineyard 跨仓集成镜像
+
+Vineyard 的 ReportEvent 集成不能继续使用不含 `event_report` protobuf 的旧 KVCM 镜像；否则
+`addStorage` 会返回 `missing or invalid fields: {StorageConfig: {storage_spec}}`，后续用例全部是
+同一前置失败的连锁结果。
+
+需要验证 KVCM 分支时，手动运行 `.github/workflows/build-dev-image.yml` 并选择
+`flavor=integration`。该 flavor 只构建 CI 所需的 `linux/amd64` 生产镜像，并发布唯一的
+`integration-<UTC time>-<short sha>` tag；把该精确 tag 写入 Vineyard 的
+`.aoneci/v6d-pytest-integration.yaml`，禁止使用 `latest`。合并前至少确认 Vineyard 的
+group-aware 三节点用例、green、KVCM fault 和 PACE fault 都实际执行，且从失败制品中的
+pytest 汇总判断结果，不能根据 Aone 对自由脚本显示的 `NOT_RUN` 状态推断。
+
+该 workflow 在 dev 容器内完成 Bazel 构建后，也必须在容器仍存活时把 server tar 复制到
+Docker build context，并把文件 owner 改回 runner 用户。`bazel-bin` 可能指向容器内的
+`/root/.cache/bazel`；容器退出后再从宿主 runner 读取该 symlink 会得到 `Permission denied`
+或断链，不能据此误判为编译失败。
 
 ## 13. 接受的取舍
 

--- a/docs/design/report_event_snapshot_uri_version.md
+++ b/docs/design/report_event_snapshot_uri_version.md
@@ -33,8 +33,10 @@ ADD 或 DELETE 直接建立一个进程内 version，然后执行写入。不要
 进程内发生 HOST_DOWN 或 grace cleanup 后会留下 tombstone，必须由 REGISTER 明确清除，
 防止迟到数据事件复活已下线节点。KVCM 重启会清空该进程内 tombstone。
 
-每次成功 REGISTER 同时开启一个新的 lifecycle generation：重复请求会合并 medium 并返回
-成功，但会取消更早 lifecycle 中尚未进入最终 metadata 写入阶段的 mutation/cleanup。因此
+每次至少包含一个合法 REGISTER 的成功请求至多开启一个新的 lifecycle generation：同一请求
+中的多个合法 REGISTER 会先分别校验，再合并 medium，只执行一次实际注册，并给每个合法 item
+返回相同的注册结果；非法 REGISTER 只影响自身 item。跨请求的重复 REGISTER 会再次开启新
+generation，并取消更早 lifecycle 中尚未进入最终 metadata 写入阶段的 mutation/cleanup。因此
 REGISTER 是启动/重建边界，不是 HEARTBEAT 的替代品；调用方不应高频发送或与普通数据请求
 无序并发。
 

--- a/docs/design/service_discovery_framework.md
+++ b/docs/design/service_discovery_framework.md
@@ -504,6 +504,18 @@ extra config 中透传这些 Manager Client 参数，包括
 `request_timeout_seconds`；未配置时普通 API 请求默认超时为 `1.0` 秒。
 Leader 查询使用独立的 5 秒超时，不受该参数影响。
 
+Manager Client 的构造和关闭是资源事务：服务发现 factory、初始 endpoint 解析、discovery
+type 读取以及 route-refresh 线程构造/启动中的任意一步失败时，已创建的 HTTP session 与服务
+发现 client 都会回滚；`close()` 等待刷新线程最多 5 秒。若线程仍在 Leader/Spectrum
+请求中，HTTP session 可以立即关闭，但服务发现 client 必须由刷新线程退出时延迟关闭，不能与
+正在进行的 endpoint refresh 并发释放。重复 `close()` 对两类资源都只执行一次。
+
+响应异常按以下契约分类，供上层熔断器稳定判断：连接、超时和 JSON 解码沿用
+`requests.RequestException`；HTTP 非 200 抛 `KvCacheManagerHTTPError`；HTTP 200 但缺少合法
+`header.status.code` 抛 `KvCacheManagerProtocolError`。后两者同时兼容旧的 `AssertionError`
+捕获方式。Manager 明确返回非 `OK` 的业务状态仍抛原有 `AssertionError`。即使调用方传入
+`check_response=False`，也只跳过业务状态检查，不能跳过 HTTP 与公共 envelope 校验。
+
 开源构建可直接使用 `static://`；需要内部实现的 scheme 仍由对应的
 `stub_source` 实现提供，通用 Client 不依赖具体服务发现类型。
 

--- a/docs/prometheus-en_US.md
+++ b/docs/prometheus-en_US.md
@@ -131,7 +131,11 @@ every `kvcm.metrics.report_interval_ms`, default 20s).
 | `manager.prefix_match_len` | gauge | Prefix match length |
 | `manager.get_cache_location_query_block_counter` | counter | Total blocks queried via GetCacheLocation (cumulative) |
 | `manager.get_cache_location_hit_block_counter` | counter | Total blocks hit via GetCacheLocation (cumulative) |
-| `manager.prefix_match_time_us` | gauge | Prefix match latency (us) |
+| `manager.prefix_match_time_us` | gauge | Outer total latency for GetHostCacheState-style prefix matching (us) |
+| `meta_searcher.indexer_get_time_us` | gauge | Wall time spent reading metadata through MetaIndexer (us) |
+| `meta_indexer.get_io_time_us` | gauge | Metadata-backend wall time; local mode includes LRU/locks/copies and does not imply Redis I/O |
+| `meta_searcher.host_projection_time_us` | gauge | GetHostCacheState visibility checks and host/spec projection time (us) |
+| `meta_searcher.host_prefix_reduce_time_us` | gauge | GetHostCacheState normal/Mamba host-prefix reduction time (us) |
 | `meta_indexer.search_cache_hit_ratio` | gauge | Search cache hit ratio |
 | `data_storage.create_keys_counter` | counter | Total created keys |
 
@@ -150,6 +154,12 @@ every `kvcm.metrics.report_interval_ms`, default 20s).
 
 The full list depends on the active `MetricsReporter` type. The
 `kmonitor` reporter populates the most complete set of metrics.
+
+The GetHostCacheState phase metrics above are nested:
+`meta_indexer.get_io_time_us` is inside `meta_searcher.indexer_get_time_us`, and
+the indexer/projection/reduction phases are inside `manager.prefix_match_time_us`.
+Do not add them together. `get_io_time_us` is a historical name; with
+`storage_type=local` it contains no Redis network operation.
 
 ## Mapping to KMonitor Metrics
 

--- a/docs/prometheus-zh_CN.md
+++ b/docs/prometheus-zh_CN.md
@@ -128,7 +128,11 @@ kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="store_02"} 0.3
 | `manager.prefix_match_len` | gauge | 前缀匹配长度 |
 | `manager.get_cache_location_query_block_counter` | counter | GetCacheLocation 查询的 Block 总数（累计） |
 | `manager.get_cache_location_hit_block_counter` | counter | GetCacheLocation 命中的 Block 总数（累计） |
-| `manager.prefix_match_time_us` | gauge | 前缀匹配延迟（微秒） |
+| `manager.prefix_match_time_us` | gauge | GetHostCacheState 等前缀匹配的外层总延迟（微秒） |
+| `meta_searcher.indexer_get_time_us` | gauge | MetaSearcher 调用 MetaIndexer 读取 metadata 的墙钟时间（微秒） |
+| `meta_indexer.get_io_time_us` | gauge | metadata backend 调用墙钟时间；local 模式也包含 LRU/锁/复制，并不表示 Redis I/O |
+| `meta_searcher.host_projection_time_us` | gauge | GetHostCacheState location 可见性检查及 host/spec 投影时间（微秒） |
+| `meta_searcher.host_prefix_reduce_time_us` | gauge | GetHostCacheState 普通/Mamba host 前缀归约时间（微秒） |
 | `meta_indexer.search_cache_hit_ratio` | gauge | 搜索缓存命中率 |
 | `data_storage.create_keys_counter` | counter | 已创建 key 总数 |
 
@@ -147,6 +151,11 @@ kvcm_data_storage_storage_usage_ratio{type="nfs",unique_name="store_02"} 0.3
 
 完整指标列表取决于当前使用的 `MetricsReporter` 类型。`kmonitor`
 类型的 reporter 会填充最完整的指标集。
+
+上述 GetHostCacheState 分段指标是嵌套关系：`meta_indexer.get_io_time_us` 位于
+`meta_searcher.indexer_get_time_us` 内，后者与 projection/reduce 又位于
+`manager.prefix_match_time_us` 内，排障时不能把它们相加。`get_io_time_us` 是历史命名；当实例使用
+`storage_type=local` 时没有 Redis 网络调用。
 
 ## 与 KMonitor 指标对照
 

--- a/integration_test/meta_service/http_interface_test.py
+++ b/integration_test/meta_service/http_interface_test.py
@@ -276,6 +276,25 @@ class MetaServiceHttpTest(cases.MetaServiceTestBase):
             unknown_response,
         )
 
+        # Protobuf enums are open on the wire. 263 would truncate to the
+        # internal uint8 value 7 (L1P5) if the service used a direct cast.
+        invalid_selector = self._client.get_cache_locations_by_backend({
+            "trace_id": "event_report_query_unknown_backend",
+            "instance_id": instance_id,
+            "query_type": "QT_BATCH_GET",
+            "block_keys": block_keys,
+            "block_mask": {"offset": 0},
+            "backend_selectors": [{
+                "backend_type": 263,
+                "strategy": "LSS_WEIGHTED_RANDOM",
+            }],
+        }, check_response=False)
+        self.assertEqual(
+            "INVALID_ARGUMENT",
+            invalid_selector.get("header", {}).get("status", {}).get("code"),
+            invalid_selector,
+        )
+
 
 if __name__ == "__main__":
     import unittest

--- a/integration_test/meta_service/http_interface_test.py
+++ b/integration_test/meta_service/http_interface_test.py
@@ -5,14 +5,15 @@ import integration_test.meta_service.meta_interface_cases as cases
 class MetaServiceHttpClient(cases.MetaServiceClientBase):
     """HTTP client for MetaService API endpoints"""
 
-    def __init__(self, base_url):
+    def __init__(self, base_url, admin_url=None):
         self.base_url = base_url
+        self.admin_url = admin_url or base_url
         self.session = requests.Session()
         self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
 
-    def _make_request(self, method, endpoint, data=None):
+    def _make_request(self, method, endpoint, data=None, base_url=None):
         """Helper method to make HTTP requests to the service"""
-        url = self.base_url + endpoint
+        url = (base_url or self.base_url) + endpoint
 
         if method == 'POST':
             response = self.session.post(url, json=data, headers=self.headers)
@@ -23,9 +24,9 @@ class MetaServiceHttpClient(cases.MetaServiceClientBase):
 
         return response
 
-    def _make_api_request(self, endpoint, data=None, check_response=True):
+    def _make_api_request(self, endpoint, data=None, check_response=True, base_url=None):
         """Helper method to make POST requests to API endpoints and optionally validate response"""
-        response = self._make_request('POST', endpoint, data)
+        response = self._make_request('POST', endpoint, data, base_url=base_url)
         if response.status_code != 200:
             raise AssertionError(f"Request to {endpoint} failed with status code {response.status_code}")
         try:
@@ -72,6 +73,30 @@ class MetaServiceHttpClient(cases.MetaServiceClientBase):
         """Get cluster info (leader discovery)"""
         return self._make_api_request('/api/getClusterInfo', data, check_response)
 
+    def report_event(self, data, check_response=True):
+        """Report EventReport node/block lifecycle events."""
+        return self._make_api_request('/api/reportEvent', data, check_response)
+
+    def get_cache_locations_by_backend(self, data, check_response=True):
+        """Query locations with explicit backend selection."""
+        return self._make_api_request('/api/getCacheLocationsByBackend', data, check_response)
+
+    def _make_admin_api_request(self, endpoint, data=None, check_response=True):
+        return self._make_api_request(
+            endpoint,
+            data,
+            check_response,
+            base_url=self.admin_url,
+        )
+
+    def add_storage(self, data, check_response=True):
+        """Register storage through the admin HTTP endpoint."""
+        return self._make_admin_api_request('/api/addStorage', data, check_response)
+
+    def create_instance_group(self, data, check_response=True):
+        """Create an instance group through the admin HTTP endpoint."""
+        return self._make_admin_api_request('/api/createInstanceGroup', data, check_response)
+
     def close(self):
         """Close the HTTP session"""
         self.session.close()
@@ -81,9 +106,175 @@ class MetaServiceHttpTest(cases.MetaServiceTestBase):
     """HTTP version of the MetaService tests"""
 
     def _get_manager_client(self):
-        self._http_port = self.worker_manager.get_worker(0).env.http_port
+        worker_env = self.worker_manager.get_worker(0).env
+        self._http_port = worker_env.http_port
         self._http_url = "http://localhost:%d" % self._http_port
-        return MetaServiceHttpClient(self._http_url)
+        self._admin_http_url = "http://localhost:%d" % worker_env.admin_http_port
+        return MetaServiceHttpClient(self._http_url, self._admin_http_url)
+
+    @staticmethod
+    def _event_report_storage(storage_name):
+        return {
+            "global_unique_name": storage_name,
+            "storage_type": "ST_EVENT_REPORT_L2",
+            "event_report": {
+                "heartbeat_timeout_ms": 30000,
+                "cleanup_grace_ms": 30000,
+                "liveness_check_interval_ms": 1000,
+            },
+            "check_storage_available_when_open": False,
+        }
+
+    @staticmethod
+    def _event_report_instance_group(group_name, storage_name):
+        return {
+            "name": group_name,
+            "storage_candidates": ["nfs_01"],
+            "global_quota_group_name": "default_quota_group",
+            "max_instance_count": 10,
+            "quota": {
+                "capacity": 10737418240,
+                "quota_config": [{"storage_type": 4, "capacity": 10737418240}],
+            },
+            "cache_config": {
+                "reclaim_strategy": {
+                    "storage_unique_name": "nfs_01",
+                    "reclaim_policy": 1,
+                    "trigger_strategy": {"used_size": 1073741824, "used_percentage": 0.8},
+                    "trigger_period_seconds": 60,
+                    "reclaim_step_size": 1073741824,
+                    "reclaim_step_percentage": 10,
+                },
+                "data_storage_strategy": 2,
+                "meta_indexer_config": {
+                    "max_key_count": 10000,
+                    "mutex_shard_num": 16,
+                    "batch_key_size": 16,
+                    "meta_storage_backend_config": {"storage_type": "local", "storage_uri": ""},
+                    "meta_cache_policy_config": {"type": "LRU", "capacity": 10000},
+                },
+            },
+            "event_report_storage_candidates": [storage_name],
+            "version": 1,
+        }
+
+    @staticmethod
+    def _report_events(instance_id, host, events, trace_id):
+        return {
+            "trace_id": trace_id,
+            "instance_id": instance_id,
+            "host_ip_port": host,
+            "storage_type": "ST_EVENT_REPORT_L2",
+            "events": events,
+        }
+
+    @staticmethod
+    def _node_and_block_events(host, spec_name, block_keys):
+        events = [{
+            "event_type": "EVENT_NODE_REGISTER",
+            "node_register": {"mediums": ["mem"]},
+        }]
+        events.extend({
+            "event_type": "EVENT_BLOCK_ADD",
+            "block_add": {
+                "block_key": str(block_key),
+                "medium": "mem",
+                "specs": [{
+                    "name": spec_name,
+                    "uri": f"vineyard://{host}/mem",
+                }],
+            },
+        } for block_key in block_keys)
+        return events
+
+    def test_event_report_requested_spec_filters_before_peer_selection(self):
+        """Exercise ReportEvent -> HTTP query with the adversarial peer layout.
+
+        The full-only peer has better raw coverage. Both cross-key strategies
+        must nevertheless select the linear peer when linear_1 is requested.
+        """
+        storage_name = "event_report_l2_http_spec_filter"
+        group_name = "event_report_http_spec_filter_group"
+        instance_id = "event_report_http_spec_filter_instance"
+        full_host = "10.10.0.1:9600"
+        linear_host = "10.10.0.2:9600"
+        block_keys = [82000, 82001]
+
+        self._client.add_storage({
+            "trace_id": "event_report_add_storage",
+            "storage": self._event_report_storage(storage_name),
+        })
+        self._client.create_instance_group({
+            "trace_id": "event_report_create_group",
+            "instance_group": self._event_report_instance_group(group_name, storage_name),
+        })
+        self._client.register_instance({
+            "trace_id": "event_report_register_instance",
+            "instance_group": group_name,
+            "instance_id": instance_id,
+            "block_size": 128,
+            "model_deployment": self._get_test_model_deployment(),
+            "location_spec_infos": [
+                {"name": "full_0", "size": 1024},
+                {"name": "linear_1", "size": 1024},
+            ],
+            "location_spec_groups": [
+                {"name": "full_0", "spec_names": ["full_0"]},
+                {"name": "linear_1", "spec_names": ["linear_1"]},
+            ],
+        })
+        self._client.report_event(self._report_events(
+            instance_id,
+            full_host,
+            self._node_and_block_events(full_host, "full_0", block_keys),
+            "event_report_full_peer",
+        ))
+        self._client.report_event(self._report_events(
+            instance_id,
+            linear_host,
+            self._node_and_block_events(linear_host, "linear_1", block_keys[:1]),
+            "event_report_linear_peer",
+        ))
+
+        for strategy in ("LSS_V6D_PREFIX", "LSS_V6D_COVERAGE"):
+            response = self._client.get_cache_locations_by_backend({
+                "trace_id": f"event_report_query_{strategy}",
+                "instance_id": instance_id,
+                "query_type": "QT_BATCH_GET",
+                "block_keys": block_keys,
+                "block_mask": {"offset": 0},
+                "location_spec_names": ["linear_1"],
+                "backend_selectors": [{
+                    "backend_type": "ST_EVENT_REPORT_L2",
+                    "strategy": strategy,
+                }],
+            })
+            key_locations = response.get("key_locations", [])
+            self.assertEqual(2, len(key_locations), response)
+            first_locations = key_locations[0].get("locations", [])
+            self.assertEqual(1, len(first_locations), response)
+            first_specs = first_locations[0].get("location_specs", [])
+            self.assertEqual(["linear_1"], [spec.get("name") for spec in first_specs], response)
+            self.assertIn(linear_host, first_specs[0].get("uri", ""), response)
+            self.assertEqual([], key_locations[1].get("locations", []), response)
+
+        unknown_response = self._client.get_cache_locations_by_backend({
+            "trace_id": "event_report_query_unknown_spec",
+            "instance_id": instance_id,
+            "query_type": "QT_BATCH_GET",
+            "block_keys": block_keys,
+            "block_mask": {"offset": 0},
+            "location_spec_names": ["unknown_spec"],
+            "backend_selectors": [{
+                "backend_type": "ST_EVENT_REPORT_L2",
+                "strategy": "LSS_V6D_PREFIX",
+            }],
+        })
+        self.assertEqual(
+            [[], []],
+            [item.get("locations", []) for item in unknown_response.get("key_locations", [])],
+            unknown_response,
+        )
 
 
 if __name__ == "__main__":

--- a/integration_test/meta_service/test_report_event_restart.py
+++ b/integration_test/meta_service/test_report_event_restart.py
@@ -138,7 +138,11 @@ def verify(args, client, checks):
     checks.assertEqual(accepted["header"]["status"]["code"], "OK")
     active_version = accepted["committed_snapshot_version"]
     checks.assertEqual(len(active_version), 32)
-    checks.assertFalse(accepted.get("snapshot_required"))
+    # A generation-creating delta is accepted immediately, but its own
+    # response keeps snapshot_required=true so a snapshot-capable caller sees
+    # that the request arrived without a current-process generation. The next
+    # delta reuses the generation and clears the hint.
+    checks.assertTrue(accepted.get("snapshot_required"))
     delta_specs = report_event._wait_for_block_spec_names(
         client,
         args.instance_id,
@@ -159,6 +163,26 @@ def verify(args, client, checks):
         {"linear_0"},
         "restart_verify_delta_keeps_untouched_historical_cache",
     )
+
+    followup = client.report_event(
+        report_event._make_request(
+            args.instance_id,
+            HOST,
+            [report_event._ev_block_add(
+                BLOCK_KEY + 2,
+                "gpu",
+                report_event._make_single_spec(
+                    "gpu_0",
+                    report_event._build_event_report_uri(HOST, "gpu"),
+                ),
+            )],
+            trace_id="restart_verify_followup_delta",
+        )
+    )
+    checks.assertEqual(
+        followup.get("committed_snapshot_version"), active_version
+    )
+    checks.assertFalse(followup.get("snapshot_required"))
 
     after_uri = report_event._build_event_report_uri(
         HOST, "mem", {"source": "after_restart"}

--- a/integration_test/meta_service/test_report_event_snapshot.py
+++ b/integration_test/meta_service/test_report_event_snapshot.py
@@ -1688,6 +1688,28 @@ class EventReportFunctionalTest(unittest.TestCase):
                 f"host {host}: expected prefix={prefix}, got {actual[host]}",
             )
 
+        # Cross the default parallel threshold and verify that chunked local
+        # reads plus parallel projection preserve prefix and output ordering.
+        large_keys = [10000, 10001, 10002, 10003] * 96
+        large_resp = self.client.get_host_cache_state({
+            "trace_id": "t16_large_query",
+            "instance_id": instance_id,
+            "query_type": "QT_PREFIX_MATCH",
+            "block_cache_keys": large_keys,
+        })
+        large_hosts = large_resp.get("hosts", [])
+        self.assertEqual(
+            [item["host_ip_port"] for item in large_hosts],
+            ["10.0.0.1:8080", "10.0.0.2:8080", "10.0.0.3:8080"],
+        )
+        large_actual = {
+            item["host_ip_port"]: int(item["prefix_match_blocks"])
+            for item in large_hosts
+        }
+        self.assertEqual(large_actual["10.0.0.1:8080"], 2)
+        self.assertEqual(large_actual["10.0.0.2:8080"], len(large_keys))
+        self.assertEqual(large_actual["10.0.0.3:8080"], 1)
+
     # 17. Snapshot is a complete reconciliation barrier and supports empty clear.
     def test_17_snapshot_reconciliation_contract(self):
         host = "192.168.1.240:8080"
@@ -4219,8 +4241,9 @@ class EventReportBenchTest(unittest.TestCase):
         self._ensure_host_registered(self.client, self.instance_id, host)
         measurements = []
 
-        for batch_index, event_count in enumerate((100, 1000, 5000)):
-            base_key = 40_000_000 + batch_index * 10_000
+        for batch_index, event_count in enumerate((100, 1000, 5000, 20_000)):
+            # Keep every scale isolated even when larger cases are appended.
+            base_key = 40_000_000 + batch_index * 100_000
             create_events = [
                 _ev_block_add(
                     base_key + offset,
@@ -4324,6 +4347,127 @@ class EventReportBenchTest(unittest.TestCase):
                 f"({create_elapsed_ms / event_count:.4f}ms/event), "
                 f"update: {update_elapsed_ms:9.2f}ms "
                 f"({update_elapsed_ms / event_count:.4f}ms/event)"
+            )
+
+    # 21. GetHostCacheState scaling for the pure local metadata path. There is
+    # no latency assertion because debug/release builds and test hosts differ;
+    # correctness is checked on every measured response and the output is a
+    # reproducible before/after baseline.
+    def test_21_get_host_cache_state_local_scaling(self):
+        host = "192.168.2.210:8080"
+        self._ensure_host_registered(self.client, self.instance_id, host)
+        measurements = []
+
+        for batch_index, block_count in enumerate((100, 1000, 5000, 20_000)):
+            # Keep every scale isolated even when larger cases are appended.
+            base_key = 50_000_000 + batch_index * 100_000
+            block_keys = [base_key + offset for offset in range(block_count)]
+            events = [
+                _ev_block_add(
+                    block_key,
+                    "mem",
+                    _make_single_spec(
+                        "spec_4096",
+                        _build_event_report_uri(
+                            host, "mem", {"block": str(block_key)}
+                        ),
+                    ),
+                )
+                for block_key in block_keys
+            ]
+            self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    events,
+                    trace_id=f"bench_host_state_setup_{block_count}",
+                )
+            )
+            query_keys = block_keys + [base_key + block_count + 1]
+            payload = {
+                "trace_id": f"bench_host_state_{block_count}",
+                "instance_id": self.instance_id,
+                "query_type": "QT_PREFIX_MATCH",
+                "block_cache_keys": query_keys,
+                "medium": ["mem"],
+            }
+
+            def assert_response(response):
+                prefixes = {
+                    item["host_ip_port"]: int(item["prefix_match_blocks"])
+                    for item in response.get("hosts", [])
+                }
+                self.assertEqual(prefixes.get(host), block_count)
+
+            for _ in range(3):
+                assert_response(self.client.get_host_cache_state(payload))
+
+            latencies = []
+            for _ in range(20):
+                start = time.monotonic()
+                response = self.client.get_host_cache_state(payload)
+                latencies.append((time.monotonic() - start) * 1000)
+                assert_response(response)
+
+            concurrent_latencies = []
+            errors = []
+
+            def query_worker(worker_index):
+                session = requests.Session()
+                session.headers.update({
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                })
+                started = time.monotonic()
+                try:
+                    response = session.post(
+                        f"{BASE_URL}/api/getHostCacheState", json=payload
+                    )
+                    response.raise_for_status()
+                    body = response.json()
+                    code = body.get("header", {}).get("status", {}).get("code")
+                    if code != "OK":
+                        raise AssertionError(
+                            f"worker {worker_index}: status={code}, body={body}"
+                        )
+                    prefixes = {
+                        item["host_ip_port"]: int(item["prefix_match_blocks"])
+                        for item in body.get("hosts", [])
+                    }
+                    if prefixes.get(host) != block_count:
+                        raise AssertionError(
+                            f"worker {worker_index}: prefixes={prefixes}"
+                        )
+                    return (time.monotonic() - started) * 1000
+                except Exception as error:
+                    errors.append(str(error))
+                    return None
+                finally:
+                    session.close()
+
+            with ThreadPoolExecutor(max_workers=16) as pool:
+                futures = [pool.submit(query_worker, index) for index in range(32)]
+                for future in as_completed(futures):
+                    latency = future.result()
+                    if latency is not None:
+                        concurrent_latencies.append(latency)
+            self.assertEqual(errors, [])
+            self.assertEqual(32, len(concurrent_latencies))
+            measurements.append(
+                (block_count, sorted(latencies), sorted(concurrent_latencies))
+            )
+
+        print("\n[BENCH] GetHostCacheState local metadata scaling:")
+        for block_count, serial, concurrent in measurements:
+            print(
+                f"  Blocks: {block_count:5d}, "
+                f"serial p50/p99/avg: "
+                f"{self._percentile(serial, 50):8.2f}/"
+                f"{self._percentile(serial, 99):8.2f}/"
+                f"{statistics.mean(serial):8.2f}ms, "
+                f"16-way p50/p99: "
+                f"{self._percentile(concurrent, 50):8.2f}/"
+                f"{self._percentile(concurrent, 99):8.2f}ms"
             )
 
 

--- a/integration_test/meta_service/test_report_event_snapshot.py
+++ b/integration_test/meta_service/test_report_event_snapshot.py
@@ -33,8 +33,6 @@ ADMIN_URL = ""
 INSTANCE_ID = "event_report_cluster_0"
 SKIP_BENCH = False
 ONLY_BENCH = False
-# Requires small heartbeat_timeout_ms/cleanup_grace_ms in addStorage spec.
-ENABLE_LIVENESS_TIMING_TESTS = False
 HEARTBEAT_TIMEOUT_MS = 1000
 CLEANUP_GRACE_MS = 2000
 SNAPSHOT_MIN_INTERVAL_MS = 1000
@@ -80,6 +78,16 @@ class KVCMClient:
         code = body.get("header", {}).get("status", {}).get("code")
         if code not in ("OK", "DUPLICATE_ENTITY"):
             raise AssertionError(f"addStorage failed: {json.dumps(body)}")
+        return body
+
+    def list_storage(self, data):
+        url = f"{self.admin_url}/api/listStorage"
+        resp = self.session.post(url, json=data)
+        resp.raise_for_status()
+        body = resp.json()
+        code = body.get("header", {}).get("status", {}).get("code")
+        if code != "OK":
+            raise AssertionError(f"listStorage failed: {json.dumps(body)}")
         return body
 
     def create_instance_group(self, data):
@@ -391,32 +399,60 @@ class EventReportFunctionalTest(unittest.TestCase):
 
     @classmethod
     def _ensure_event_report_storage_registered(cls):
-        try:
-            cls.client.add_storage({
-                "trace_id": "setup_storage",
-                "storage": {
-                    "global_unique_name": cls.EVENT_REPORT_STORAGE_NAME,
-                    "storage_type": "ST_EVENT_REPORT_L2",
-                    "event_report": {
-                        "heartbeat_timeout_ms": (
-                            HEARTBEAT_TIMEOUT_MS
-                            if ENABLE_LIVENESS_TIMING_TESTS else 30000
-                        ),
-                        "cleanup_grace_ms": (
-                            CLEANUP_GRACE_MS
-                            if ENABLE_LIVENESS_TIMING_TESTS else 300000
-                        ),
-                        "liveness_check_interval_ms": (
-                            100 if ENABLE_LIVENESS_TIMING_TESTS else 5000
-                        ),
-                        "snapshot_min_interval_ms": SNAPSHOT_MIN_INTERVAL_MS,
-                    },
-                    "check_storage_available_when_open": False,
+        cls._ensure_storage_registered(
+            "setup_storage",
+            {
+                "global_unique_name": cls.EVENT_REPORT_STORAGE_NAME,
+                "storage_type": "ST_EVENT_REPORT_L2",
+                "event_report": {
+                    # Functional and capacity cases share this backend and
+                    # intentionally do not turn data events into implicit
+                    # heartbeats. Keep their lifecycle window independent
+                    # from the fast timing fixture below; otherwise a cleanup
+                    # test can pass and then lose its reporter while observing
+                    # asynchronous snapshot cleanup.
+                    "heartbeat_timeout_ms": 30000,
+                    "cleanup_grace_ms": 300000,
+                    "liveness_check_interval_ms": 5000,
+                    "snapshot_min_interval_ms": SNAPSHOT_MIN_INTERVAL_MS,
                 },
+                "check_storage_available_when_open": False,
+            },
+        )
+
+    @classmethod
+    def _ensure_storage_registered(cls, trace_id, expected_storage):
+        storage_name = expected_storage["global_unique_name"]
+        listed = cls.client.list_storage({"trace_id": f"{trace_id}_list"})
+        existing = next(
+            (
+                storage
+                for storage in listed.get("storage", [])
+                if storage.get("global_unique_name") == storage_name
+            ),
+            None,
+        )
+        if existing is None:
+            cls.client.add_storage({
+                "trace_id": trace_id,
+                "storage": expected_storage,
             })
-            print(f"[SETUP] Event report storage '{cls.EVENT_REPORT_STORAGE_NAME}' registered")
-        except Exception as e:
-            print(f"[WARN] addStorage failed (may already exist): {e}")
+            print(f"[SETUP] Event report storage '{storage_name}' registered")
+            return
+
+        if existing.get("storage_type") != expected_storage.get("storage_type"):
+            raise AssertionError(
+                f"Storage {storage_name!r} has unexpected type: {existing}"
+            )
+        actual_spec = existing.get("event_report", {})
+        for name, expected_value in expected_storage.get("event_report", {}).items():
+            actual_value = actual_spec.get(name)
+            if str(actual_value) != str(expected_value):
+                raise AssertionError(
+                    f"Storage {storage_name!r} has {name}={actual_value!r}; "
+                    f"expected {expected_value!r}"
+                )
+        print(f"[SETUP] Event report storage '{storage_name}' reused")
 
     @classmethod
     def _ensure_instance_group_created(cls):
@@ -516,9 +552,9 @@ class EventReportFunctionalTest(unittest.TestCase):
         Keeping the small timeout on a dedicated instance group prevents the
         long functional/benchmark cases from timing out their shared reporters.
         """
-        cls.client.add_storage({
-            "trace_id": "setup_liveness_storage",
-            "storage": {
+        cls._ensure_storage_registered(
+            "setup_liveness_storage",
+            {
                 "global_unique_name": cls.LIVENESS_STORAGE_NAME,
                 "storage_type": "ST_EVENT_REPORT_L2",
                 "event_report": {
@@ -529,7 +565,7 @@ class EventReportFunctionalTest(unittest.TestCase):
                 },
                 "check_storage_available_when_open": False,
             },
-        })
+        )
 
         existing = cls.client.get_instance_group({
             "trace_id": "setup_get_liveness_ig",
@@ -3923,6 +3959,14 @@ class EventReportBenchTest(unittest.TestCase):
     def setUpClass(cls):
         cls.client = KVCMClient(BASE_URL, ADMIN_URL)
         cls.instance_id = INSTANCE_ID
+        # --only-bench does not load EventReportFunctionalTest, so benchmark
+        # setup must not depend on that class having run first.
+        fixture = EventReportFunctionalTest
+        fixture.client = cls.client
+        fixture.instance_id = cls.instance_id
+        fixture._ensure_event_report_storage_registered()
+        fixture._ensure_instance_group_created()
+        fixture._ensure_instance_registered()
 
     @classmethod
     def tearDownClass(cls):
@@ -4167,6 +4211,121 @@ class EventReportBenchTest(unittest.TestCase):
         )
         print(f"  Latency max: {max(ordered_latencies):.2f}ms")
 
+    # 20. One ReportEvent carrying many small-block deltas. This benchmark
+    # tracks the workload that previously amplified reporter-node locking and
+    # lifecycle lease acquisition once per event/key.
+    def test_20_large_single_request_delta_scaling(self):
+        host = "192.168.2.200:8080"
+        self._ensure_host_registered(self.client, self.instance_id, host)
+        measurements = []
+
+        for batch_index, event_count in enumerate((100, 1000, 5000)):
+            base_key = 40_000_000 + batch_index * 10_000
+            create_events = [
+                _ev_block_add(
+                    base_key + offset,
+                    "mem",
+                    _make_single_spec(
+                        "spec_4096",
+                        _build_event_report_uri(
+                            host,
+                            "mem",
+                            {
+                                "block": str(base_key + offset),
+                                "phase": "create",
+                            },
+                        ),
+                    ),
+                )
+                for offset in range(event_count)
+            ]
+            start = time.monotonic()
+            response = self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    create_events,
+                    trace_id=f"bench_large_delta_{event_count}",
+                )
+            )
+            create_elapsed_ms = (time.monotonic() - start) * 1000
+            version = response.get("committed_snapshot_version", "")
+            self.assertEqual(len(version), 32)
+            self.assertFalse(response.get("snapshot_required"))
+
+            # Report the same blocks again to exercise the existing-location
+            # path, including BatchMerge's block lookup and targeted merge
+            # RMW phases.
+            update_events = [
+                _ev_block_add(
+                    base_key + offset,
+                    "mem",
+                    _make_single_spec(
+                        "spec_4096",
+                        _build_event_report_uri(
+                            host,
+                            "mem",
+                            {
+                                "block": str(base_key + offset),
+                                "phase": "update",
+                            },
+                        ),
+                    ),
+                )
+                for offset in range(event_count)
+            ]
+            start = time.monotonic()
+            update_response = self.client.report_event(
+                _make_request(
+                    self.instance_id,
+                    host,
+                    update_events,
+                    trace_id=f"bench_large_delta_update_{event_count}",
+                )
+            )
+            update_elapsed_ms = (time.monotonic() - start) * 1000
+            self.assertEqual(
+                update_response.get("committed_snapshot_version", ""),
+                version,
+            )
+            measurements.append(
+                (event_count, create_elapsed_ms, update_elapsed_ms)
+            )
+
+            for offset in (0, event_count // 2, event_count - 1):
+                block_key = base_key + offset
+                specs = _query_block_specs(
+                    self.client,
+                    self.instance_id,
+                    block_key,
+                    f"bench_large_delta_query_{event_count}_{offset}",
+                )
+                self.assertEqual(len(specs), 1)
+                self.assertEqual(specs[0].get("name"), "spec_4096")
+                _assert_reporter_scope(
+                    self,
+                    specs[0]["uri"],
+                    _build_event_report_uri(
+                        host,
+                        "mem",
+                        {"block": str(block_key), "phase": "update"},
+                    ),
+                    self.instance_id,
+                    host,
+                    "mem",
+                    version,
+                )
+
+        print("\n[BENCH] Large single-request BLOCK_ADD scaling:")
+        for event_count, create_elapsed_ms, update_elapsed_ms in measurements:
+            print(
+                f"  Events: {event_count:5d}, "
+                f"create: {create_elapsed_ms:9.2f}ms "
+                f"({create_elapsed_ms / event_count:.4f}ms/event), "
+                f"update: {update_elapsed_ms:9.2f}ms "
+                f"({update_elapsed_ms / event_count:.4f}ms/event)"
+            )
+
 
 def main():
     parser = argparse.ArgumentParser(description="Event Report ReportEvent HTTP integration tests")
@@ -4184,10 +4343,18 @@ def main():
         help="Run only the named EventReportFunctionalTest method; repeatable.",
     )
     parser.add_argument(
+        "--bench-test",
+        action="append",
+        default=[],
+        help="Run only the named EventReportBenchTest method; repeatable.",
+    )
+    parser.add_argument(
         "--enable-liveness-timing-tests",
         action="store_true",
-        help=("Run heartbeat/cleanup timing tests. Requires the Event report storage to be opened with "
-              "small heartbeat_timeout_ms / cleanup_grace_ms (defaults to 1000ms / 2000ms here)."),
+        help=(
+            "Compatibility flag. Heartbeat/cleanup timing tests use their own "
+            "isolated fast-liveness storage and always run."
+        ),
     )
     parser.add_argument("--heartbeat-timeout-ms", type=int, default=1000)
     parser.add_argument("--cleanup-grace-ms", type=int, default=2000)
@@ -4202,11 +4369,12 @@ def main():
     )
 
     args, _ = parser.parse_known_args()
+    if args.functional_test and args.bench_test:
+        parser.error("--functional-test and --bench-test are mutually exclusive")
 
     admin_port = args.admin_http_port or args.http_port
 
     global BASE_URL, ADMIN_URL, INSTANCE_ID, SKIP_BENCH, ONLY_BENCH
-    global ENABLE_LIVENESS_TIMING_TESTS
     global HEARTBEAT_TIMEOUT_MS, CLEANUP_GRACE_MS
     global SNAPSHOT_MIN_INTERVAL_MS, META_STORAGE_URI
     BASE_URL = f"http://{args.host}:{args.http_port}"
@@ -4214,7 +4382,6 @@ def main():
     INSTANCE_ID = args.instance_id
     SKIP_BENCH = args.skip_bench
     ONLY_BENCH = args.only_bench
-    ENABLE_LIVENESS_TIMING_TESTS = args.enable_liveness_timing_tests
     HEARTBEAT_TIMEOUT_MS = args.heartbeat_timeout_ms
     CLEANUP_GRACE_MS = args.cleanup_grace_ms
     SNAPSHOT_MIN_INTERVAL_MS = args.snapshot_min_interval_ms
@@ -4226,9 +4393,12 @@ def main():
     if args.functional_test:
         for test_name in args.functional_test:
             suite.addTest(EventReportFunctionalTest(test_name))
+    elif args.bench_test:
+        for test_name in args.bench_test:
+            suite.addTest(EventReportBenchTest(test_name))
     elif not ONLY_BENCH:
         suite.addTests(loader.loadTestsFromTestCase(EventReportFunctionalTest))
-    if not args.functional_test and not SKIP_BENCH:
+    if not args.functional_test and not args.bench_test and not SKIP_BENCH:
         suite.addTests(loader.loadTestsFromTestCase(EventReportBenchTest))
 
     runner = unittest.TextTestRunner(verbosity=2)

--- a/integration_test/testlib/BUILD
+++ b/integration_test/testlib/BUILD
@@ -17,3 +17,10 @@ py_library(
     imports = [".."],
     deps = [],
 )
+
+py_test(
+    name = "TestBaseTest",
+    srcs = ["test_base_test.py"],
+    main = "test_base_test.py",
+    deps = [":test_base"],
+)

--- a/integration_test/testlib/test_base.py
+++ b/integration_test/testlib/test_base.py
@@ -63,6 +63,13 @@ class TestBase(object):
         return range_from, range_to
 
     def get_workdir(self):
+        # Bazel gives every test action (including each --runs_per_test
+        # repetition) a private TEST_TMPDIR. Keep mutable test state there so
+        # concurrently executing copies cannot delete or overwrite each
+        # other's worker tree under the shared runfiles directory.
+        test_tmpdir = os.environ.get('TEST_TMPDIR')
+        if test_tmpdir:
+            return os.path.join(os.path.abspath(test_tmpdir), self._testMethodName)
         return os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')), self._testMethodName)
 
     def clean_workdir(self):
@@ -72,7 +79,10 @@ class TestBase(object):
 
     def _init_dirs(self, work_dir):
         self.workdir = work_dir if work_dir is not None else self.get_workdir()
-        self.path_root = os.path.abspath(os.path.join(self.workdir, '../'))
+        # The packaged binary is a read-only runfile. It must not be resolved
+        # relative to TEST_TMPDIR now that the per-test worker tree lives
+        # there.
+        self.path_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
         self.global_install_root = os.path.join(self.path_root, 'install_root')
         self.worker_install_root = os.path.join(self.workdir, 'install_root')
 

--- a/integration_test/testlib/test_base_test.py
+++ b/integration_test/testlib/test_base_test.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from integration_test.testlib.module_base import ModuleBase
+from integration_test.testlib.test_base import TestBase
+
+
+class TestBaseWorkdirTest(unittest.TestCase):
+    def setUp(self):
+        self.harness = TestBase()
+        self.harness._testMethodName = "concurrent_case"
+
+    def test_bazel_tmpdir_isolates_mutable_workdir_from_runfiles(self):
+        with tempfile.TemporaryDirectory() as test_tmpdir:
+            with mock.patch.dict(os.environ, {"TEST_TMPDIR": test_tmpdir}):
+                expected_workdir = os.path.join(test_tmpdir, "concurrent_case")
+                self.assertEqual(expected_workdir, self.harness.get_workdir())
+
+                with mock.patch.object(ModuleBase, "create_symlink") as create_symlink:
+                    self.harness._init_dirs(None)
+
+                expected_source_root = os.path.abspath(
+                    os.path.join(os.path.dirname(__file__), "../")
+                )
+                self.assertEqual(expected_workdir, self.harness.workdir)
+                self.assertEqual(expected_source_root, self.harness.path_root)
+                create_symlink.assert_called_once_with(
+                    os.path.join(expected_source_root, "install_root"),
+                    os.path.join(expected_workdir, "install_root"),
+                )
+
+    def test_non_bazel_run_preserves_source_relative_workdir(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            expected_workdir = os.path.join(
+                os.path.abspath(os.path.join(os.path.dirname(__file__), "../")),
+                "concurrent_case",
+            )
+            self.assertEqual(expected_workdir, self.harness.get_workdir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/config/registry_manager.cc
+++ b/kv_cache_manager/config/registry_manager.cc
@@ -291,6 +291,9 @@ ErrorCode RegistryManager::RegisterInstance(RequestContext *request_context,
         const auto &existing = it->second;
         auto mismatched = existing->MismatchFields(
             block_size, location_spec_infos, model_deployment, location_spec_groups, default_query_type);
+        if (existing->instance_group_name() != instance_group) {
+            mismatched.insert(mismatched.begin(), "instance_group_name");
+        }
         if (!mismatched.empty()) {
             auto mismatched_str = StringUtil::Join(mismatched, ", ");
             request_context->error_tracer()->AddErrorMsg(

--- a/kv_cache_manager/config/test/instance_group_test.cc
+++ b/kv_cache_manager/config/test/instance_group_test.cc
@@ -228,6 +228,31 @@ TEST_F(InstanceGroupTest, EventReportStorageSpecProtoRoundTripPreservesSnapshotS
     EXPECT_EQ(90, restored_spec->liveness_check_interval_ms());
     EXPECT_EQ(4321, restored_spec->snapshot_min_interval_ms());
     EXPECT_EQ(8765, restored_spec->snapshot_delta_drain_timeout_ms());
+
+    proto::admin::StorageConfig invalid_proto_config;
+    invalid_proto_config.set_global_unique_name("invalid_event_report");
+    invalid_proto_config.set_storage_type(proto::admin::ST_EVENT_REPORT_L2);
+    invalid_proto_config.mutable_event_report()->set_snapshot_delta_drain_timeout_ms(-1);
+    StorageConfig invalid_restored;
+    ProtoConvert::StorageFromProto(&invalid_proto_config, invalid_restored);
+    auto invalid_spec = std::dynamic_pointer_cast<EventReportStorageSpec>(invalid_restored.storage_spec());
+    ASSERT_NE(nullptr, invalid_spec);
+    EXPECT_EQ(-1, invalid_spec->snapshot_delta_drain_timeout_ms());
+    std::string invalid_fields;
+    EXPECT_FALSE(invalid_restored.ValidateRequiredFields(invalid_fields));
+    EXPECT_NE(std::string::npos, invalid_fields.find("snapshot_delta_drain_timeout_ms"));
+}
+
+TEST_F(InstanceGroupTest, UnknownProtoStorageTypeFailsClosed) {
+    DataStorageType storage_type = DataStorageType::DATA_STORAGE_TYPE_NFS;
+    ProtoConvert::DataStorageTypeFromProto(static_cast<proto::admin::StorageType>(263), storage_type);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN, storage_type);
+
+    proto::admin::CacheLocation proto_location;
+    proto_location.set_type(static_cast<proto::admin::StorageType>(263));
+    CacheLocation location;
+    ProtoConvert::CacheLocationFromProto(&proto_location, location);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN, location.type());
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/config/test/registry_manager_local_backend_test.cc
+++ b/kv_cache_manager/config/test/registry_manager_local_backend_test.cc
@@ -246,6 +246,25 @@ TEST_F(RegistryManagerLocalBackendTest, TestInstanceRegistration) {
     ASSERT_EQ(1, instance_infos_after_remove.size());
 }
 
+TEST_F(RegistryManagerLocalBackendTest, DuplicateInstanceCannotMoveToAnotherGroup) {
+    std::string local_path = GetPrivateTestRuntimeDataPath() + "_registry_local_backend_group_mismatch";
+    ASSERT_TRUE(InitRegistryManager("local://" + local_path + "?cluster_name=test"));
+    AddNfsStorage("storage1", 1);
+    CreateInstanceGroup("group1");
+    CreateInstanceGroup("group2");
+    RegisterInstance("group1", "shared_instance");
+
+    LocationSpecInfo info;
+    ModelDeployment model_deployment;
+    EXPECT_EQ(EC_DUPLICATE_ENTITY,
+              registry_manager_->RegisterInstance(
+                  request_context_.get(), "group2", "shared_instance", 1024, {info}, model_deployment));
+    const auto existing = registry_manager_->GetInstanceInfo(request_context_.get(), "shared_instance");
+    ASSERT_NE(nullptr, existing);
+    EXPECT_EQ("group1", existing->instance_group_name());
+    EXPECT_NE(std::string::npos, request_context_->error_tracer()->ToJsonString().find("instance_group_name"));
+}
+
 TEST_F(RegistryManagerLocalBackendTest, TestAccountManagement) {
     std::string local_path = GetPrivateTestRuntimeDataPath() + "_registry_local_backend_account_test";
     std::string uri = "local://" + local_path + "?cluster_name=test";

--- a/kv_cache_manager/data_storage/BUILD
+++ b/kv_cache_manager/data_storage/BUILD
@@ -29,7 +29,6 @@ cc_library(
         "event_report_backend.h",
         "hf3fs_backend.h",
         "nfs_backend.h",
-        "snapshot_uri_utils.h",
     ] + select({
         ":enable_mooncake": ["mooncake_backend.h"],
         "//conditions:default": [],
@@ -46,6 +45,7 @@ cc_library(
         # "//3rdparty/3fs:hf3fs",
         "//kv_cache_manager/common/hash",  # for xxph3
         ":common_define",
+        ":snapshot_uri_utils",
         # Internal implementations
         "//stub_source/kv_cache_manager/data_storage:tair_mempool",
     ] + select({
@@ -55,6 +55,16 @@ cc_library(
         ":enable_vcns": ["//stub_source/kv_cache_manager/data_storage:vcns_hf3fs"],
         "//conditions:default": [],
     }),
+)
+
+cc_library(
+    name = "snapshot_uri_utils",
+    hdrs = [
+        "snapshot_uri_utils.h",
+    ],
+    deps = [
+        ":common_define",
+    ],
 )
 
 cc_library(

--- a/kv_cache_manager/data_storage/data_storage_backend.h
+++ b/kv_cache_manager/data_storage/data_storage_backend.h
@@ -25,7 +25,7 @@ public:
     virtual double GetStorageUsageRatio(const std::string &trace_id) const = 0;
     inline bool IsOpen() const { return is_open_.load(std::memory_order_relaxed); }
     inline void SetOpen(bool open) { is_open_.store(open, std::memory_order_relaxed); }
-    inline void SetAvailable(bool available) { is_available_.store(available, std::memory_order_relaxed); }
+    virtual void SetAvailable(bool available) { is_available_.store(available, std::memory_order_release); }
     std::shared_ptr<DataStorageMetricsCollector> GetMetricsCollector() { return metrics_collector_; }
     virtual const StorageConfig &GetStorageConfig() { return config_; }
 
@@ -72,7 +72,7 @@ public:
     }
 
 protected:
-    inline bool IsAvailable() const { return is_available_.load(std::memory_order_relaxed); }
+    inline bool IsAvailable() const { return is_available_.load(std::memory_order_acquire); }
 
 protected:
     StorageConfig config_;

--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -4,7 +4,9 @@
 #include <array>
 #include <chrono>
 #include <cinttypes>
+#include <cmath>
 #include <cstdlib>
+#include <exception>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -74,9 +76,29 @@ DataStorageType EventReportBackend::GetType() { return config_.type(); }
 
 bool EventReportBackend::Available() { return IsOpen() && IsAvailable(); }
 
+void EventReportBackend::SetAvailable(bool available) {
+    DataStorageBackend::SetAvailable(available);
+    if (!available) {
+        snapshot_state_cv_.notify_all();
+    }
+}
+
 double EventReportBackend::GetStorageUsageRatio(const std::string & /*trace_id*/) const { return 1.0; }
 
+ErrorCode EventReportBackend::Open(const StorageConfig &config, const std::string &trace_id) {
+    if (IsOpen() || Retired()) {
+        KVCM_LOG_WARN("trace_id [%s] | EventReportBackend::Open: backend objects cannot be opened twice or reused "
+                      "after Close",
+                      trace_id.c_str());
+        return EC_ERROR;
+    }
+    return DataStorageBackend::Open(config, trace_id);
+}
+
 ErrorCode EventReportBackend::DoOpen(const StorageConfig &config, const std::string &trace_id) {
+    if (IsOpen() || Retired()) {
+        return EC_ERROR;
+    }
     auto spec = std::dynamic_pointer_cast<EventReportStorageSpec>(config.storage_spec());
     if (!spec) {
         KVCM_LOG_WARN("trace_id [%s] | EventReportBackend::DoOpen: unexpected config type, storage config: [%s]",
@@ -101,7 +123,25 @@ ErrorCode EventReportBackend::DoOpen(const StorageConfig &config, const std::str
     SetAvailable(true);
 
     liveness_checker_running_.store(true, std::memory_order_relaxed);
-    liveness_checker_thread_ = std::thread(&EventReportBackend::LivenessCheckerLoop, this);
+    try {
+        liveness_checker_thread_ = std::thread(&EventReportBackend::LivenessCheckerLoop, this);
+    } catch (const std::exception &e) {
+        liveness_checker_running_.store(false, std::memory_order_release);
+        SetAvailable(false);
+        SetOpen(false);
+        KVCM_LOG_ERROR("trace_id [%s] | EventReportBackend::DoOpen: start liveness checker failed: [%s]",
+                       trace_id.c_str(),
+                       e.what());
+        return EC_ERROR;
+    } catch (...) {
+        liveness_checker_running_.store(false, std::memory_order_release);
+        SetAvailable(false);
+        SetOpen(false);
+        KVCM_LOG_ERROR("trace_id [%s] | EventReportBackend::DoOpen: start liveness checker failed with unknown "
+                       "exception",
+                       trace_id.c_str());
+        return EC_ERROR;
+    }
 
     KVCM_LOG_INFO("trace_id [%s] | EventReportBackend opened, storage: [%s], type: [%s], hb_timeout=%ldms, "
                   "cleanup_grace=%ldms, check_interval=%ldms, snapshot_min_interval=%ldms, "
@@ -118,9 +158,11 @@ ErrorCode EventReportBackend::DoOpen(const StorageConfig &config, const std::str
 }
 
 ErrorCode EventReportBackend::Close() {
+    retired_.store(true, std::memory_order_release);
     SetOpen(false);
     SetAvailable(false);
-    liveness_checker_running_.store(false, std::memory_order_relaxed);
+    liveness_checker_running_.store(false, std::memory_order_release);
+    liveness_wait_cv_.notify_all();
     if (liveness_checker_thread_.joinable()) {
         liveness_checker_thread_.join();
     }
@@ -153,6 +195,11 @@ ErrorCode EventReportBackend::Close() {
 
 void EventReportBackend::SetCleanupCallback(CleanupCallback cb) {
     std::lock_guard<std::mutex> lock(cleanup_cb_mutex_);
+    if (Retired()) {
+        cleanup_callback_ = nullptr;
+        cleanup_cb_set_.store(false, std::memory_order_release);
+        return;
+    }
     cleanup_callback_ = std::move(cb);
     cleanup_cb_set_.store(cleanup_callback_ != nullptr, std::memory_order_release);
 }
@@ -166,15 +213,21 @@ ErrorCode EventReportBackend::RegisterNode(const std::string &instance_id,
         })) {
         return EC_BADARGS;
     }
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
     const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    auto &host_map = instance_nodes_[instance_id];
+    auto it = host_map.find(host_ip_port);
     ++node_generation_[instance_id][host_ip_port];
     lifecycle_fence->generation = node_generation_[instance_id][host_ip_port];
     lifecycle_fence->registered = true;
-    auto &host_map = instance_nodes_[instance_id];
-    auto it = host_map.find(host_ip_port);
     int64_t now_ms = NowMillis();
     if (it != host_map.end()) {
         auto &info = *it->second;
@@ -225,6 +278,9 @@ ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_i
         })) {
         return EC_BADARGS;
     }
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
 
     auto merge_mediums = [&mediums](NodeInfo &info) {
         for (const auto &medium : mediums) {
@@ -263,6 +319,9 @@ ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_i
     // instead of blocking here indefinitely.
     {
         std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+        if (!AcceptingReports()) {
+            return EC_INSTANCE_NOT_EXIST;
+        }
         auto instance_it = instance_nodes_.find(instance_id);
         if (instance_it != instance_nodes_.end()) {
             auto node_it = instance_it->second.find(host_ip_port);
@@ -276,6 +335,9 @@ ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_i
     const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
     const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     auto &host_map = instance_nodes_[instance_id];
     if (auto it = host_map.find(host_ip_port); it != host_map.end()) {
@@ -317,6 +379,9 @@ ErrorCode EventReportBackend::UnregisterNode(const std::string &instance_id, con
     const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
     const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
+    if (Retired()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     const ErrorCode ec = UnregisterNodeLocked(instance_id, host_ip_port);
     lifecycle_fence->generation = node_generation_[instance_id][host_ip_port];
@@ -330,6 +395,9 @@ ErrorCode EventReportBackend::UnregisterNodeForHostDown(const std::string &insta
     const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
     const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     out_generation = node_generation_[instance_id][host_ip_port];
     lifecycle_fence->generation = out_generation;
@@ -349,6 +417,9 @@ ErrorCode EventReportBackend::UnregisterNodeIfGeneration(const std::string &inst
     const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
     const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
+    if (Retired()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     const auto generation_it = node_generation_.find(instance_id);
     uint64_t current_generation = 0;
@@ -417,6 +488,9 @@ ErrorCode EventReportBackend::OnHeartbeat(const std::string &instance_id,
     const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
     const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     auto &host_map = instance_nodes_[instance_id];
     auto it = host_map.find(host_ip_port);
@@ -465,25 +539,46 @@ ErrorCode EventReportBackend::OnHeartbeat(const std::string &instance_id,
     }
     lifecycle_fence->generation = node_generation_[instance_id][host_ip_port];
     lifecycle_fence->registered = true;
-    {
-        std::lock_guard<std::mutex> status_lock(info.status_mutex);
-        info.last_system_status = system_status;
-    }
+    std::unique_lock<std::mutex> status_lock(info.status_mutex);
+    const std::map<std::string, std::string> previous_system_status = info.last_system_status;
+    info.last_system_status = system_status;
     const auto metrics_tags = info.metrics_tags;
 
-    // Keep the node lifecycle lock until the gauges are published.
-    // UnregisterNodeLocked removes the same tagged gauges while holding this
-    // lock; releasing it earlier would allow HOST_DOWN to remove the node and
-    // an older heartbeat to recreate ghost metrics afterwards.
+    // The per-reporter lifecycle writer keeps NodeInfo alive and prevents
+    // HOST_DOWN/REGISTER from crossing gauge publication. The status lock
+    // serializes SetNodeUnavailable's gauge reset. Release the global node
+    // table lock so metric work for one reporter does not block all others.
+    lock.unlock();
     if (metrics_registry_) {
-        auto prefix = "event_report.";
-        for (const auto &kv : system_status) {
-            const auto &s = kv.second;
-            if (s.empty())
-                continue;
+        const auto parse_gauge = [](const std::string &value, double &out) {
+            if (value.empty()) {
+                return false;
+            }
             char *end = nullptr;
-            double val = std::strtod(s.c_str(), &end);
-            if (end == s.c_str() + s.size()) {
+            out = std::strtod(value.c_str(), &end);
+            return end == value.c_str() + value.size() && std::isfinite(out);
+        };
+        const std::string prefix = "event_report.";
+        // system_status is a full heartbeat snapshot, not a patch. Remove a
+        // prior numeric gauge when the next heartbeat omits it or changes it
+        // to a non-numeric value; otherwise stale values would survive and a
+        // later unregister could no longer discover the omitted key.
+        for (const auto &[name, previous_value] : previous_system_status) {
+            double ignored_previous = 0.0;
+            if (!parse_gauge(previous_value, ignored_previous)) {
+                continue;
+            }
+            const auto current_it = system_status.find(name);
+            double ignored_current = 0.0;
+            if (current_it == system_status.end() || !parse_gauge(current_it->second, ignored_current)) {
+                if (auto data = metrics_registry_->GetMetricsData(prefix + name)) {
+                    data->RemoveByTags(metrics_tags);
+                }
+            }
+        }
+        for (const auto &kv : system_status) {
+            double val = 0.0;
+            if (parse_gauge(kv.second, val)) {
                 REPORT_DYNAMIC_GAUGE_(metrics_registry_, prefix + kv.first, metrics_tags, val);
             }
         }
@@ -617,14 +712,6 @@ void EventReportBackend::LivenessCheckerLoop() {
                 cb_copy = cleanup_callback_;
             }
             for (const auto &entry : to_cleanup) {
-                KVCM_LOG_WARN("EventReportBackend: node [%s] instance [%s] passed cleanup_grace_ms, "
-                              "triggering cleanup (gen=%" PRIu64 ")",
-                              entry.host.c_str(),
-                              entry.instance_id.c_str(),
-                              entry.gen);
-                if (cb_copy) {
-                    cb_copy(entry.instance_id, entry.host, entry.gen);
-                }
                 const ErrorCode unregister_ec = UnregisterNodeIfGeneration(entry.instance_id, entry.host, entry.gen);
                 if (unregister_ec == EC_MISMATCH) {
                     const uint64_t current_gen = GetNodeGeneration(entry.instance_id, entry.host);
@@ -633,11 +720,38 @@ void EventReportBackend::LivenessCheckerLoop() {
                                   entry.host.c_str(),
                                   entry.gen,
                                   current_gen);
+                    continue;
+                }
+                if (unregister_ec != EC_OK) {
+                    KVCM_LOG_WARN("EventReportBackend: failed to unregister expired node [%s] instance [%s], "
+                                  "ec=%d (gen=%" PRIu64 ")",
+                                  entry.host.c_str(),
+                                  entry.instance_id.c_str(),
+                                  unregister_ec,
+                                  entry.gen);
+                    continue;
+                }
+
+                // Unregister is the liveness-expiry linearization point. It
+                // must happen before cleanup is dispatched: otherwise cleanup
+                // can delete metadata while a heartbeat waits behind its
+                // lifecycle lease, then let that heartbeat revive the old
+                // committed snapshot without requiring reconciliation.
+                KVCM_LOG_WARN("EventReportBackend: node [%s] instance [%s] passed cleanup_grace_ms, "
+                              "unregistered and triggering cleanup (gen=%" PRIu64 ")",
+                              entry.host.c_str(),
+                              entry.instance_id.c_str(),
+                              entry.gen);
+                if (cb_copy) {
+                    cb_copy(entry.instance_id, entry.host, entry.gen);
                 }
             }
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(liveness_check_interval_ms_));
+        std::unique_lock<std::mutex> wait_lock(liveness_wait_mutex_);
+        liveness_wait_cv_.wait_for(wait_lock, std::chrono::milliseconds(liveness_check_interval_ms_), [this] {
+            return !liveness_checker_running_.load(std::memory_order_acquire) || !IsOpen();
+        });
     }
 }
 
@@ -662,6 +776,9 @@ std::vector<bool> EventReportBackend::Exist(const std::vector<DataStorageUri> &s
 }
 
 std::vector<bool> EventReportBackend::MightExist(const std::vector<DataStorageUri> &storage_uris) {
+    if (!AcceptingReports()) {
+        return std::vector<bool>(storage_uris.size(), false);
+    }
     std::vector<bool> result;
     result.reserve(storage_uris.size());
     std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
@@ -741,14 +858,23 @@ ErrorCode EventReportBackend::BeginDeltaMutation(const ReporterSnapshotKey &repo
         return EC_BADARGS;
     }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     const int64_t snapshot_wait_timeout_ms = snapshot_delta_drain_timeout_ms_;
     const bool snapshot_finished =
         snapshot_state_cv_.wait_for(lock, std::chrono::milliseconds(snapshot_wait_timeout_ms), [&] {
             auto it = snapshot_versions_.find(reporter_key);
-            return it == snapshot_versions_.end() || it->second.in_flight.empty();
+            return !AcceptingReports() || it == snapshot_versions_.end() || it->second.in_flight.empty();
         });
     if (!snapshot_finished) {
         return EC_SNAPSHOT_IN_PROGRESS;
+    }
+    // Close()/dynamic disable can wake this waiter by clearing the snapshot
+    // state.  Admission was checked before wait_for() released nodes_mutex_,
+    // so check again before creating or incrementing any mutation state.
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
     }
     auto state_it = snapshot_versions_.find(reporter_key);
     if (state_it == snapshot_versions_.end() || state_it->second.committed.empty()) {
@@ -790,9 +916,22 @@ ErrorCode EventReportBackend::BeginDeltaMutation(const ReporterSnapshotKey &repo
     return EC_OK;
 }
 
-void EventReportBackend::EndDeltaMutation(const ReporterSnapshotKey &reporter_key, uint64_t lifecycle_generation) {
+void EventReportBackend::EndDeltaMutation(const ReporterSnapshotKey &reporter_key,
+                                          uint64_t lifecycle_generation,
+                                          const std::string &expected_snapshot_version) {
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     auto it = snapshot_versions_.find(reporter_key);
+    if (it != snapshot_versions_.end() && !expected_snapshot_version.empty() &&
+        it->second.committed != expected_snapshot_version) {
+        // HOST_DOWN removes snapshot state before an already-admitted delta
+        // necessarily reaches its final metadata lease. If the reporter is
+        // then registered again, a new delta can recreate state at the same
+        // key. The old guard must not drain that newer lifecycle's admission.
+        KVCM_LOG_DEBUG("EventReportBackend: ignoring stale delta mutation lease for instance [%s] host [%s]",
+                       reporter_key.instance_id.c_str(),
+                       reporter_key.host_ip_port.c_str());
+        return;
+    }
     if (it == snapshot_versions_.end() || it->second.active_delta_mutations == 0) {
         const auto generation_it = node_generation_.find(reporter_key.instance_id);
         const auto node_it = instance_nodes_.find(reporter_key.instance_id);
@@ -832,12 +971,23 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
     if (reporter_key.instance_id.empty() || reporter_key.host_ip_port.empty()) {
         return EC_BADARGS;
     }
+    // The in-flight token/attempt epoch is the snapshot-cleanup fence. Change
+    // it while holding the reporter lifecycle writer so an older cleanup can
+    // either acquire its read lease first and finish, or observe the newer
+    // epoch after this transition; it can never delete across the boundary.
+    const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
+    std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     const auto instance_it = instance_nodes_.find(reporter_key.instance_id);
     if (instance_it == instance_nodes_.end() ||
-        instance_it->second.find(reporter_key.host_ip_port) == instance_it->second.end()) {
+        instance_it->second.find(reporter_key.host_ip_port) == instance_it->second.end() ||
+        !lifecycle_fence->registered) {
         return EC_SNAPSHOT_REQUIRED;
     }
+    const uint64_t admitted_lifecycle_generation = lifecycle_fence->generation;
     auto &state = snapshot_versions_[reporter_key];
     if (!state.in_flight.empty()) {
         return EC_SNAPSHOT_IN_PROGRESS;
@@ -865,13 +1015,32 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
     // deltas. Deltas arriving from this point wait until commit or abort.
     ++state.attempt_epoch;
     state.in_flight = out_candidate_version;
+    // Do not retain the lifecycle writer while draining already-admitted
+    // deltas: their final metadata phase needs a lifecycle read lease before
+    // it can end its delta admission and wake this waiter.
+    lifecycle_lock.unlock();
     const int64_t delta_drain_timeout_ms = snapshot_delta_drain_timeout_ms_;
     const bool deltas_drained =
         snapshot_state_cv_.wait_for(lock, std::chrono::milliseconds(delta_drain_timeout_ms), [&] {
             auto it = snapshot_versions_.find(reporter_key);
-            return it == snapshot_versions_.end() || it->second.in_flight != out_candidate_version ||
-                   it->second.active_delta_mutations == 0;
+            return !AcceptingReports() || it == snapshot_versions_.end() ||
+                   it->second.in_flight != out_candidate_version || it->second.active_delta_mutations == 0;
         });
+    // The wait releases nodes_mutex_.  If the backend was retired or disabled
+    // meanwhile, do not return a usable candidate.  Close() has already
+    // cleared the state; for a dynamic disable, reopen the reporter write gate
+    // explicitly so a later re-enable is not stuck behind this abandoned
+    // candidate.
+    if (!AcceptingReports()) {
+        auto it = snapshot_versions_.find(reporter_key);
+        if (it != snapshot_versions_.end() && it->second.in_flight == out_candidate_version) {
+            it->second.in_flight.clear();
+        }
+        out_candidate_version.clear();
+        lock.unlock();
+        snapshot_state_cv_.notify_all();
+        return EC_INSTANCE_NOT_EXIST;
+    }
     if (!deltas_drained) {
         auto it = snapshot_versions_.find(reporter_key);
         const uint64_t active_delta_mutations = it == snapshot_versions_.end() ? 0 : it->second.active_delta_mutations;
@@ -896,7 +1065,7 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
         return EC_SNAPSHOT_REQUIRED;
     }
     if (out_lifecycle_generation) {
-        *out_lifecycle_generation = node_generation_[reporter_key.instance_id][reporter_key.host_ip_port];
+        *out_lifecycle_generation = admitted_lifecycle_generation;
     }
     return EC_OK;
 }
@@ -916,11 +1085,36 @@ ErrorCode EventReportBackend::AcquireLifecycleMutationLease(const ReporterSnapsh
         // (lifecycle -> metadata), so blocking here would deadlock.
         return EC_NODE_NOT_REGISTERED;
     }
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
     if (!lifecycle_fence->registered || lifecycle_fence->generation != expected_generation) {
         return EC_NODE_NOT_REGISTERED;
     }
     out_lease = std::move(lease);
     return EC_OK;
+}
+
+ErrorCode EventReportBackend::CommitSnapshotVersionIfGeneration(const ReporterSnapshotKey &reporter_key,
+                                                                const std::string &version,
+                                                                uint64_t expected_generation) {
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return EC_NODE_NOT_REGISTERED;
+    }
+    // Commit runs after the metadata RMW has released its shard locks, so it
+    // can safely wait for a transient HEARTBEAT writer. Using the mutation
+    // path's try-lock here would turn harmless lock contention into a failed
+    // snapshot. REGISTER/HOST_DOWN still serialize first and are rejected by
+    // the generation/registered check below.
+    std::shared_lock<std::shared_mutex> lifecycle_lease(lifecycle_fence->mutex);
+    if (!AcceptingReports()) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
+    if (!lifecycle_fence->registered || lifecycle_fence->generation != expected_generation) {
+        return EC_NODE_NOT_REGISTERED;
+    }
+    return CommitSnapshotVersion(reporter_key, version) ? EC_OK : EC_ERROR;
 }
 
 ErrorCode EventReportBackend::AcquireLifecycleCleanupLease(const ReporterSnapshotKey &reporter_key,
@@ -932,7 +1126,44 @@ ErrorCode EventReportBackend::AcquireLifecycleCleanupLease(const ReporterSnapsho
         return EC_MISMATCH;
     }
     auto lease = std::make_shared<std::shared_lock<std::shared_mutex>>(lifecycle_fence->mutex);
-    if (lifecycle_fence->generation != expected_generation) {
+    // Host cleanup is only valid after HOST_DOWN/liveness has atomically
+    // unregistered this exact reporter generation.  Checking `registered`
+    // under the retained lifecycle lease prevents an accidental cleanup caller
+    // from deleting metadata that still belongs to an active reporter, while
+    // the generation check fences a concurrent re-registration.
+    if (!AcceptingReports() || lifecycle_fence->registered || lifecycle_fence->generation != expected_generation) {
+        return EC_MISMATCH;
+    }
+    out_lease = std::move(lease);
+    return EC_OK;
+}
+
+ErrorCode EventReportBackend::AcquireSnapshotCleanupLease(const ReporterSnapshotKey &reporter_key,
+                                                          uint64_t expected_generation,
+                                                          const std::string &expected_snapshot_version,
+                                                          uint64_t expected_attempt_epoch,
+                                                          LifecycleMutationLease &out_lease) const {
+    out_lease.reset();
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return EC_MISMATCH;
+    }
+    // Cleanup acquires this lease before taking metadata locks. It can block
+    // behind a short-lived HEARTBEAT/REGISTER writer without creating the
+    // lifecycle->metadata / metadata->lifecycle inversion that forces delta
+    // mutations to use try_lock.
+    auto lease = std::make_shared<std::shared_lock<std::shared_mutex>>(lifecycle_fence->mutex);
+    if (!AcceptingReports() || !lifecycle_fence->registered || lifecycle_fence->generation != expected_generation) {
+        return EC_MISMATCH;
+    }
+
+    // BeginSnapshot publishes a new attempt epoch under the lifecycle writer
+    // before releasing it. Holding the read lease here therefore makes this
+    // validation atomic with respect to every later snapshot admission.
+    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+    const auto state_it = snapshot_versions_.find(reporter_key);
+    if (state_it == snapshot_versions_.end() || state_it->second.committed != expected_snapshot_version ||
+        (expected_attempt_epoch != 0 && state_it->second.attempt_epoch != expected_attempt_epoch)) {
         return EC_MISMATCH;
     }
     out_lease = std::move(lease);
@@ -1004,6 +1235,9 @@ bool EventReportBackend::GetQueryVisibilityState(const ReporterSnapshotKey &repo
                                                  std::string &out_committed) const {
     out_strict = false;
     out_committed.clear();
+    if (!AcceptingReports()) {
+        return false;
+    }
     std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
     const auto instance_it = instance_nodes_.find(reporter_key.instance_id);
     if (instance_it == instance_nodes_.end()) {
@@ -1025,6 +1259,9 @@ bool EventReportBackend::GetQueryVisibilityState(const ReporterSnapshotKey &repo
 void EventReportBackend::GetQueryVisibilitySnapshot(const std::string &instance_id,
                                                     QueryVisibilitySnapshot &out_snapshot) const {
     out_snapshot.clear();
+    if (!AcceptingReports()) {
+        return;
+    }
     std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
     const auto instance_it = instance_nodes_.find(instance_id);
     if (instance_it == instance_nodes_.end()) {

--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -234,10 +234,33 @@ ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_i
         }
     };
 
-    // The common path only enriches an existing node. It must not wait for
-    // the lifecycle write lock: an in-flight metadata mutation intentionally
-    // holds a shared lifecycle lease, and new deltas still need to reach the
-    // bounded snapshot gate instead of blocking here indefinitely.
+    // Repeated reports normally carry a medium that is already known. Keep
+    // that path read-only so it does not serialize all reporters on the node
+    // table's exclusive lock. A missing medium is rechecked under the unique
+    // lock before it is merged (lock-based double check; the map itself must
+    // never be read without nodes_mutex_).
+    {
+        std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+        auto instance_it = instance_nodes_.find(instance_id);
+        if (instance_it != instance_nodes_.end()) {
+            auto node_it = instance_it->second.find(host_ip_port);
+            if (node_it != instance_it->second.end() && node_it->second) {
+                const auto &known_mediums = node_it->second->mediums;
+                const bool all_known =
+                    std::all_of(mediums.begin(), mediums.end(), [&known_mediums](const auto &medium) {
+                        return std::find(known_mediums.begin(), known_mediums.end(), medium) != known_mediums.end();
+                    });
+                if (all_known) {
+                    return EC_OK;
+                }
+            }
+        }
+    }
+
+    // Enriching an existing node must not wait for the lifecycle write lock:
+    // an in-flight metadata mutation intentionally holds a shared lifecycle
+    // lease, and new deltas still need to reach the bounded snapshot gate
+    // instead of blocking here indefinitely.
     {
         std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
         auto instance_it = instance_nodes_.find(instance_id);

--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -1022,6 +1022,29 @@ bool EventReportBackend::GetQueryVisibilityState(const ReporterSnapshotKey &repo
     return true;
 }
 
+void EventReportBackend::GetQueryVisibilitySnapshot(const std::string &instance_id,
+                                                    QueryVisibilitySnapshot &out_snapshot) const {
+    out_snapshot.clear();
+    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+    const auto instance_it = instance_nodes_.find(instance_id);
+    if (instance_it == instance_nodes_.end()) {
+        return;
+    }
+    out_snapshot.reserve(instance_it->second.size());
+    for (const auto &[host_ip_port, node] : instance_it->second) {
+        if (!node || !node->available.load(std::memory_order_relaxed)) {
+            continue;
+        }
+        QueryVisibilityState state;
+        const auto version_it = snapshot_versions_.find({instance_id, host_ip_port});
+        if (version_it != snapshot_versions_.end()) {
+            state.strict = version_it->second.strict_query_visibility;
+            state.committed_version = version_it->second.committed;
+        }
+        out_snapshot.emplace(host_ip_port, std::move(state));
+    }
+}
+
 uint64_t EventReportBackend::GetSnapshotAttemptEpoch(const ReporterSnapshotKey &reporter_key) const {
     std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
     const auto it = snapshot_versions_.find(reporter_key);

--- a/kv_cache_manager/data_storage/event_report_backend.h
+++ b/kv_cache_manager/data_storage/event_report_backend.h
@@ -25,6 +25,11 @@ class EventReportBackend : public DataStorageBackend {
 public:
     using CleanupCallback =
         std::function<void(const std::string &instance_id, const std::string &host_ip_port, uint64_t generation)>;
+    struct QueryVisibilityState {
+        bool strict = false;
+        std::string committed_version;
+    };
+    using QueryVisibilitySnapshot = std::unordered_map<std::string, QueryVisibilityState>;
 
     EventReportBackend() = delete;
     explicit EventReportBackend(std::shared_ptr<MetricsRegistry> metrics_registry);
@@ -119,6 +124,11 @@ public:
     bool GetQueryVisibilityState(const ReporterSnapshotKey &reporter_key,
                                  bool &out_strict,
                                  std::string &out_committed) const;
+    // Captures every currently queryable reporter for one instance under one
+    // node-table read lock. GetHostCacheState uses this request-level snapshot
+    // instead of repeating registry/backend lookups and nodes_mutex_ acquisition
+    // for every (block, location).
+    void GetQueryVisibilitySnapshot(const std::string &instance_id, QueryVisibilitySnapshot &out_snapshot) const;
     uint64_t GetSnapshotAttemptEpoch(const ReporterSnapshotKey &reporter_key) const;
     void SetSnapshotMinIntervalMsForTest(int64_t interval_ms);
     void SetSnapshotDeltaDrainTimeoutMsForTest(int64_t timeout_ms);

--- a/kv_cache_manager/data_storage/event_report_backend.h
+++ b/kv_cache_manager/data_storage/event_report_backend.h
@@ -38,7 +38,12 @@ public:
     // --- DataStorageBackend interface ---
     DataStorageType GetType() override;
     bool Available() override;
+    // Dynamic disable is also an admission cancellation event. Wake snapshot
+    // and delta waiters so they fail immediately instead of waiting for the
+    // configured drain timeout before observing the unavailable state.
+    void SetAvailable(bool available) override;
     double GetStorageUsageRatio(const std::string &trace_id) const override;
+    ErrorCode Open(const StorageConfig &config, const std::string &trace_id) override;
     ErrorCode DoOpen(const StorageConfig &config, const std::string &trace_id) override;
     ErrorCode Close() override;
 
@@ -98,7 +103,9 @@ public:
                                  std::string &out_committed_version,
                                  uint64_t *out_lifecycle_generation = nullptr,
                                  bool *out_created_generation = nullptr);
-    void EndDeltaMutation(const ReporterSnapshotKey &reporter_key, uint64_t lifecycle_generation = 0);
+    void EndDeltaMutation(const ReporterSnapshotKey &reporter_key,
+                          uint64_t lifecycle_generation = 0,
+                          const std::string &expected_snapshot_version = {});
     ErrorCode BeginSnapshot(const ReporterSnapshotKey &reporter_key,
                             std::string &out_candidate_version,
                             uint64_t &out_retry_after_ms,
@@ -110,6 +117,19 @@ public:
     ErrorCode AcquireLifecycleCleanupLease(const ReporterSnapshotKey &reporter_key,
                                            uint64_t expected_generation,
                                            LifecycleMutationLease &out_lease) const;
+    // Atomically fences a stale-snapshot cleanup against both reporter
+    // lifecycle changes and the start of a later snapshot attempt. The lease
+    // must be retained through the metadata compare-and-delete.
+    ErrorCode AcquireSnapshotCleanupLease(const ReporterSnapshotKey &reporter_key,
+                                          uint64_t expected_generation,
+                                          const std::string &expected_snapshot_version,
+                                          uint64_t expected_attempt_epoch,
+                                          LifecycleMutationLease &out_lease) const;
+    // Retains a lifecycle read lease through candidate validation and commit,
+    // so REGISTER/HOST_DOWN cannot cross the final publication boundary.
+    ErrorCode CommitSnapshotVersionIfGeneration(const ReporterSnapshotKey &reporter_key,
+                                                const std::string &version,
+                                                uint64_t expected_generation);
     bool CommitSnapshotVersion(const ReporterSnapshotKey &reporter_key, const std::string &version);
     void AbortSnapshotVersion(const ReporterSnapshotKey &reporter_key, const std::string &version);
     std::string GetSnapshotVersion(const ReporterSnapshotKey &reporter_key) const;
@@ -135,6 +155,12 @@ public:
     DataStorageType GetStorageType() const;
 
 private:
+    // Unit-level state-machine tests also exercise a never-opened backend.
+    // Treat that state as usable, while permanently fencing operations after
+    // Close and respecting DataStorageManager disablement for opened storage.
+    bool AcceptingReports() const { return !retired_.load(std::memory_order_acquire) && (!IsOpen() || IsAvailable()); }
+    bool Retired() const { return retired_.load(std::memory_order_acquire); }
+
     struct LifecycleFence {
         mutable std::shared_mutex mutex;
         uint64_t generation = 0;
@@ -208,6 +234,9 @@ private:
 
     std::thread liveness_checker_thread_;
     std::atomic<bool> liveness_checker_running_{false};
+    std::atomic<bool> retired_{false};
+    std::mutex liveness_wait_mutex_;
+    std::condition_variable liveness_wait_cv_;
 
     int64_t heartbeat_timeout_ms_ = EventReportStorageSpec::kDefaultHeartbeatTimeoutMs;
     int64_t cleanup_grace_ms_ = EventReportStorageSpec::kDefaultCleanupGraceMs;

--- a/kv_cache_manager/data_storage/snapshot_uri_utils.h
+++ b/kv_cache_manager/data_storage/snapshot_uri_utils.h
@@ -3,6 +3,7 @@
 #include <cctype>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "kv_cache_manager/data_storage/data_storage_uri.h"
@@ -74,6 +75,75 @@ public:
         }
         for (const unsigned char ch : version) {
             if (!std::isxdigit(ch)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // GetHostCacheState only needs to know whether an EventReport URI is
+    // structurally usable and which snapshot generation it belongs to. A full
+    // DataStorageUri parse would copy every URI component and allocate one
+    // std::map node per query parameter for every (key, spec) visited. Scan the
+    // immutable URI in place instead. An empty out_version means legacy
+    // metadata without s_version; malformed or duplicate s_version parameters
+    // fail closed.
+    //
+    // The returned view borrows uri_text and must not outlive it.
+    static bool InspectSnapshotUriForVisibility(std::string_view uri_text, std::string_view &out_version) noexcept {
+        out_version = {};
+
+        // This is the observable validity condition used by StandardUri::Valid
+        // for a freshly constructed URI: it must have a non-empty protocol
+        // before "://". ReportEvent performs the full parse before persisting
+        // metadata; this read-side check additionally protects recovered or
+        // otherwise malformed metadata without rebuilding the parsed object.
+        const size_t protocol_end = uri_text.find("://");
+        if (protocol_end == std::string_view::npos || protocol_end == 0) {
+            return false;
+        }
+
+        const size_t query_begin = uri_text.find('?');
+        if (query_begin == std::string_view::npos) {
+            return true;
+        }
+        if (query_begin < protocol_end + 3) {
+            return false;
+        }
+
+        bool found_version = false;
+        size_t begin = query_begin + 1;
+        while (begin <= uri_text.size()) {
+            size_t end = uri_text.find('&', begin);
+            if (end == std::string_view::npos) {
+                end = uri_text.size();
+            }
+            const size_t equals = uri_text.find('=', begin);
+            const size_t key_end = equals != std::string_view::npos && equals < end ? equals : end;
+            constexpr std::string_view version_key{kSnapshotVersionParam};
+            if (key_end - begin == version_key.size() &&
+                uri_text.compare(begin, version_key.size(), version_key) == 0) {
+                if (found_version || equals == std::string_view::npos || equals >= end) {
+                    return false;
+                }
+                found_version = true;
+                out_version = uri_text.substr(equals + 1, end - equals - 1);
+            }
+            if (end == uri_text.size()) {
+                break;
+            }
+            begin = end + 1;
+        }
+
+        if (!found_version) {
+            return true;
+        }
+        if (out_version.size() != 32) {
+            return false;
+        }
+        for (const unsigned char ch : out_version) {
+            const bool is_hex_digit = (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+            if (!is_hex_digit) {
                 return false;
             }
         }

--- a/kv_cache_manager/data_storage/snapshot_uri_utils.h
+++ b/kv_cache_manager/data_storage/snapshot_uri_utils.h
@@ -3,6 +3,7 @@
 #include <cctype>
 #include <functional>
 #include <string>
+#include <utility>
 
 #include "kv_cache_manager/data_storage/data_storage_uri.h"
 
@@ -113,6 +114,17 @@ public:
         DataStorageUri uri(raw_uri);
         if (!uri.Valid() || !IsValidSnapshotVersionToken(version) ||
             CountUriParam(raw_uri, kSnapshotVersionParam) != 0) {
+            return false;
+        }
+        return AddSnapshotVersionToUri(std::move(uri), version, out_uri);
+    }
+
+    // ReportEvent validates and parses every URI before it acquires the
+    // snapshot/delta fence. Reusing that parsed value avoids parsing the same
+    // URI again merely to append KVCM's internal generation token.
+    static bool AddSnapshotVersionToUri(DataStorageUri uri, const std::string &version, std::string &out_uri) {
+        out_uri.clear();
+        if (!uri.Valid() || !IsValidSnapshotVersionToken(version) || HasEventReportInternalUriMetadata(uri)) {
             return false;
         }
         uri.SetParam(kSnapshotVersionParam, version);

--- a/kv_cache_manager/data_storage/test/BUILD
+++ b/kv_cache_manager/data_storage/test/BUILD
@@ -78,3 +78,13 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "SnapshotUriUtilsTest",
+    srcs = [
+        "snapshot_uri_utils_test.cc",
+    ],
+    deps = [
+        "//kv_cache_manager/data_storage:snapshot_uri_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -497,6 +497,35 @@ TEST_F(EventReportBackendTest, EnsureNodeRegisteredMergesNewMediums) {
     ASSERT_EQ(2u, backend.instance_nodes_["medium-merge"]["10.0.0.91:8080"]->mediums.size());
 }
 
+TEST_F(EventReportBackendTest, EnsureNodeRegisteredHandlesConcurrentKnownAndNewMediums) {
+    EventReportBackend backend(metrics_registry_);
+    const std::string instance_id = "medium-concurrency";
+    const std::string host = "10.0.0.95:8080";
+    ASSERT_EQ(EC_OK, backend.EnsureNodeRegistered(instance_id, host, {"mem"}));
+    const uint64_t generation = backend.GetNodeGeneration(instance_id, host);
+
+    std::atomic<size_t> failures{0};
+    std::vector<std::thread> workers;
+    for (size_t worker = 0; worker < 12; ++worker) {
+        workers.emplace_back([&, worker] {
+            const std::string medium = worker % 2 == 0 ? "mem" : "disk";
+            for (size_t iteration = 0; iteration < 200; ++iteration) {
+                if (backend.EnsureNodeRegistered(instance_id, host, {medium}) != EC_OK) {
+                    failures.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto &worker : workers) {
+        worker.join();
+    }
+
+    EXPECT_EQ(0u, failures.load(std::memory_order_relaxed));
+    EXPECT_EQ(generation, backend.GetNodeGeneration(instance_id, host));
+    const auto &mediums = backend.instance_nodes_[instance_id][host]->mediums;
+    EXPECT_EQ((std::set<std::string>{"disk", "mem"}), (std::set<std::string>(mediums.begin(), mediums.end())));
+}
+
 // (7) Re-registration after cleanup
 TEST_F(EventReportBackendTest, RegisterAfterCleanupCreatesNewEntry) {
     EventReportBackend backend(metrics_registry_);

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -941,6 +941,44 @@ TEST(EventReportBackendSnapshotTest, QueryVisibilityIsStrictOnlyAfterSuccessfulS
     EXPECT_EQ(recovered, committed);
 }
 
+TEST(EventReportBackendSnapshotTest, QueryVisibilitySnapshotIsInstanceScopedAndExcludesUnavailableReporters) {
+    EventReportBackend backend(nullptr);
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    const ReporterSnapshotKey soft_reporter{"instance-a", "10.0.0.1:8080"};
+    const ReporterSnapshotKey strict_reporter{"instance-a", "10.0.0.2:8080"};
+    const ReporterSnapshotKey other_instance{"instance-b", "10.0.0.3:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(soft_reporter.instance_id, soft_reporter.host_ip_port, {"mem"}));
+    ASSERT_EQ(EC_OK, backend.RegisterNode(strict_reporter.instance_id, strict_reporter.host_ip_port, {"mem"}));
+    ASSERT_EQ(EC_OK, backend.RegisterNode(other_instance.instance_id, other_instance.host_ip_port, {"mem"}));
+
+    std::string soft_version;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(soft_reporter, soft_version));
+    backend.EndDeltaMutation(soft_reporter);
+    std::string strict_version;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(strict_reporter, strict_version, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(strict_reporter, strict_version));
+
+    EventReportBackend::QueryVisibilitySnapshot snapshot;
+    backend.GetQueryVisibilitySnapshot("instance-a", snapshot);
+    ASSERT_EQ(2u, snapshot.size());
+    EXPECT_FALSE(snapshot.at(soft_reporter.host_ip_port).strict);
+    EXPECT_EQ(soft_version, snapshot.at(soft_reporter.host_ip_port).committed_version);
+    EXPECT_TRUE(snapshot.at(strict_reporter.host_ip_port).strict);
+    EXPECT_EQ(strict_version, snapshot.at(strict_reporter.host_ip_port).committed_version);
+    EXPECT_EQ(0u, snapshot.count(other_instance.host_ip_port));
+
+    backend.SetNodeUnavailable(soft_reporter.instance_id, soft_reporter.host_ip_port);
+    backend.GetQueryVisibilitySnapshot("instance-a", snapshot);
+    ASSERT_EQ(1u, snapshot.size());
+    EXPECT_EQ(0u, snapshot.count(soft_reporter.host_ip_port));
+    EXPECT_EQ(1u, snapshot.count(strict_reporter.host_ip_port));
+
+    ASSERT_EQ(EC_OK, backend.UnregisterNode(strict_reporter.instance_id, strict_reporter.host_ip_port));
+    backend.GetQueryVisibilitySnapshot("instance-a", snapshot);
+    EXPECT_TRUE(snapshot.empty());
+}
+
 TEST(EventReportBackendSnapshotTest, SnapshotTokensAreNeverReusedAcrossAttempts) {
     EventReportBackend backend(nullptr);
     backend.SetSnapshotMinIntervalMsForTest(0);

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -127,15 +127,30 @@ TEST_F(EventReportBackendTest, OpenStartsLivenessLoopAndCloseStops) {
     ASSERT_TRUE(backend.liveness_checker_running_.load());
     ASSERT_TRUE(backend.liveness_checker_thread_.joinable());
 
-    backend.SetAvailable(false);
+    DataStorageBackend &backend_base = backend;
+    backend_base.SetAvailable(false);
     ASSERT_FALSE(backend.Available());
-    backend.SetAvailable(true);
+    backend_base.SetAvailable(true);
     ASSERT_TRUE(backend.Available());
+    EXPECT_NE(EC_OK, backend.Open(MakeConfig(), "duplicate_open"));
+    EXPECT_TRUE(backend.Available());
 
     ASSERT_EQ(EC_OK, backend.Close());
     ASSERT_FALSE(backend.Available());
+    EXPECT_NE(EC_OK, backend.Open(MakeConfig(), "reopen_retired_backend"));
+    EXPECT_FALSE(backend.Available());
     ASSERT_FALSE(backend.liveness_checker_running_.load());
     ASSERT_EQ(EC_OK, backend.Close());
+}
+
+TEST_F(EventReportBackendTest, CloseInterruptsLongLivenessWait) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 60000), "trace"));
+
+    const auto close_begin = std::chrono::steady_clock::now();
+    ASSERT_EQ(EC_OK, backend.Close());
+    const auto close_elapsed = std::chrono::steady_clock::now() - close_begin;
+    EXPECT_LT(close_elapsed, 2s);
 }
 
 // (2) RegisterNode / UnregisterNode
@@ -216,6 +231,12 @@ TEST_F(EventReportBackendTest, MightExistTracksRegisteredNodeAvailability) {
     result = backend.MightExist({available_uri});
     ASSERT_EQ(1u, result.size());
     EXPECT_TRUE(result[0]);
+
+    backend.SetAvailable(false);
+    EXPECT_EQ((std::vector<bool>{false}), backend.MightExist({available_uri}));
+    EXPECT_EQ(EC_INSTANCE_NOT_EXIST, backend.EnsureNodeRegistered(instance_id, available_host, {"mem"}));
+    backend.SetAvailable(true);
+    EXPECT_EQ((std::vector<bool>{true}), backend.MightExist({available_uri}));
 
     ASSERT_EQ(EC_OK, backend.Close());
 }
@@ -303,8 +324,8 @@ TEST_F(EventReportBackendTest, LivenessLoopHealthyToUnavailableToCleanup) {
     std::atomic<int> cleanup_calls{0};
     std::string cleanup_host;
     backend.SetCleanupCallback([&](const std::string & /*instance_id*/, const std::string &host, uint64_t /*gen*/) {
-        ++cleanup_calls;
         cleanup_host = host;
+        cleanup_calls.fetch_add(1, std::memory_order_release);
     });
 
     ASSERT_EQ(EC_OK, backend.RegisterNode("test_inst", "10.0.0.4:8080", {"mem"}));
@@ -319,12 +340,13 @@ TEST_F(EventReportBackendTest, LivenessLoopHealthyToUnavailableToCleanup) {
     EXPECT_EQ(cleanup_calls.load(), 0);
 
     const auto cleanup_deadline = std::chrono::steady_clock::now() + 1s;
-    while (backend.IsNodeRegistered("test_inst", "10.0.0.4:8080") &&
+    while ((backend.IsNodeRegistered("test_inst", "10.0.0.4:8080") ||
+            cleanup_calls.load(std::memory_order_acquire) == 0) &&
            std::chrono::steady_clock::now() < cleanup_deadline) {
         std::this_thread::yield();
     }
     ASSERT_FALSE(backend.IsNodeRegistered("test_inst", "10.0.0.4:8080"));
-    EXPECT_GE(cleanup_calls.load(), 1);
+    EXPECT_GE(cleanup_calls.load(std::memory_order_acquire), 1);
     EXPECT_EQ(cleanup_host, "10.0.0.4:8080");
 
     ASSERT_EQ(EC_OK, backend.Close());
@@ -351,7 +373,7 @@ TEST_F(EventReportBackendTest, HeartbeatWithinGraceWindowRecovers) {
     ASSERT_EQ(EC_OK, backend.Close());
 }
 
-TEST_F(EventReportBackendTest, HeartbeatRecoveryFencesCleanupAlreadySelectedByLivenessLoop) {
+TEST_F(EventReportBackendTest, LivenessUnregistersBeforeCleanupAndHeartbeatCannotReviveOldSnapshot) {
     EventReportBackend backend(metrics_registry_);
     ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 100, /*grace*/ 50, /*tick*/ 5), "trace"));
     backend.SetSnapshotMinIntervalMsForTest(0);
@@ -388,19 +410,22 @@ TEST_F(EventReportBackendTest, HeartbeatRecoveryFencesCleanupAlreadySelectedByLi
     EXPECT_FALSE(backend.IsNodeAvailable(instance_id, host));
     EXPECT_EQ((std::vector<bool>{false}), backend.MightExist({DataStorageUri(uri)}));
 
-    // The callback has selected the old generation but has not started
-    // deleting. A successful heartbeat must invalidate that cleanup before
-    // it is allowed to continue.
-    EXPECT_EQ(EC_OK, backend.OnHeartbeat(instance_id, host, {}));
-    EXPECT_GT(backend.GetNodeGeneration(instance_id, host), initial_generation);
-    EXPECT_TRUE(backend.IsNodeAvailable(instance_id, host));
-    EXPECT_EQ((std::vector<bool>{true}), backend.MightExist({DataStorageUri(uri)}));
+    // Expiry is linearized before the callback can delete metadata. A heartbeat
+    // arriving while cleanup is running must observe the tombstone instead of
+    // reviving a committed version whose metadata may already be gone.
+    EXPECT_FALSE(backend.IsNodeRegistered(instance_id, host));
+    EXPECT_EQ(initial_generation, backend.GetNodeGeneration(instance_id, host));
+    EXPECT_TRUE(backend.GetSnapshotVersion(reporter_key).empty());
+    EXPECT_EQ(EC_NODE_NOT_REGISTERED, backend.OnHeartbeat(instance_id, host, {}));
 
     release_cleanup.set_value();
     ASSERT_EQ(std::future_status::ready, cleanup_returned.get_future().wait_for(1s));
-    EXPECT_TRUE(backend.IsNodeRegistered(instance_id, host));
-    EXPECT_TRUE(backend.IsNodeAvailable(instance_id, host));
-    EXPECT_EQ((std::vector<bool>{true}), backend.MightExist({DataStorageUri(uri)}));
+    EXPECT_FALSE(backend.IsNodeRegistered(instance_id, host));
+    EXPECT_EQ((std::vector<bool>{false}), backend.MightExist({DataStorageUri(uri)}));
+
+    ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, host, {"mem"}));
+    EXPECT_GT(backend.GetNodeGeneration(instance_id, host), initial_generation);
+    EXPECT_TRUE(backend.GetSnapshotVersion(reporter_key).empty());
 
     ASSERT_EQ(EC_OK, backend.Close());
 }
@@ -453,6 +478,12 @@ TEST_F(EventReportBackendTest, CleanupLeaseFencesReregisterThroughFinalDeleteSta
     const uint64_t cleanup_generation = backend.GetNodeGeneration(reporter_key.instance_id, reporter_key.host_ip_port);
 
     EventReportBackend::LifecycleMutationLease cleanup_lease;
+    EXPECT_EQ(EC_MISMATCH, backend.AcquireLifecycleCleanupLease(reporter_key, cleanup_generation, cleanup_lease));
+    uint64_t unregistered_generation = 0;
+    ASSERT_EQ(EC_OK,
+              backend.UnregisterNodeForHostDown(
+                  reporter_key.instance_id, reporter_key.host_ip_port, unregistered_generation));
+    ASSERT_EQ(cleanup_generation, unregistered_generation);
     ASSERT_EQ(EC_OK, backend.AcquireLifecycleCleanupLease(reporter_key, cleanup_generation, cleanup_lease));
     auto reregister = std::async(std::launch::async, [&] {
         return backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"disk"});
@@ -474,6 +505,11 @@ TEST_F(EventReportBackendTest, LifecycleCleanupLeaseDoesNotBlockUnrelatedReporte
     ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_b.instance_id, reporter_b.host_ip_port, {"mem"}));
 
     const uint64_t generation_a = backend.GetNodeGeneration(reporter_a.instance_id, reporter_a.host_ip_port);
+    uint64_t unregistered_generation_a = 0;
+    ASSERT_EQ(
+        EC_OK,
+        backend.UnregisterNodeForHostDown(reporter_a.instance_id, reporter_a.host_ip_port, unregistered_generation_a));
+    ASSERT_EQ(generation_a, unregistered_generation_a);
     EventReportBackend::LifecycleMutationLease cleanup_lease_a;
     ASSERT_EQ(EC_OK, backend.AcquireLifecycleCleanupLease(reporter_a, generation_a, cleanup_lease_a));
 
@@ -670,6 +706,19 @@ TEST_F(EventReportBackendTest, OnHeartbeatPublishesMetricsGauges) {
     auto new_gauge = new_data->GetOrCreateGauge(expected_tags);
     ASSERT_DOUBLE_EQ(42.0, new_gauge.Get());
     ASSERT_DOUBLE_EQ(0.90, gauge.Get());
+    EXPECT_FALSE(leases_data->GetGauge(expected_tags).has_value());
+
+    // A non-numeric replacement is also a full-snapshot removal rather than
+    // leaving the prior numeric sample visible forever.
+    ASSERT_EQ(EC_OK, backend.OnHeartbeat("test_inst", "10.0.0.10:9600", {{"hit_rate", "unknown"}}));
+    EXPECT_FALSE(hit_rate_data->GetGauge(expected_tags).has_value());
+
+    // strtod accepts these spellings, but non-finite values are not valid
+    // operational gauges and must not poison downstream metric aggregation.
+    ASSERT_EQ(EC_OK,
+              backend.OnHeartbeat("test_inst", "10.0.0.10:9600", {{"nan_metric", "nan"}, {"inf_metric", "inf"}}));
+    EXPECT_EQ(nullptr, metrics_registry_->GetMetricsData("event_report.nan_metric"));
+    EXPECT_EQ(nullptr, metrics_registry_->GetMetricsData("event_report.inf_metric"));
 
     ASSERT_EQ(EC_OK, backend.Close());
 }
@@ -898,6 +947,119 @@ TEST(EventReportBackendSnapshotTest, SnapshotCommitPublishesOpaqueToken) {
     ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(scope, committed));
     EXPECT_EQ(candidate, committed);
     backend.EndDeltaMutation(scope);
+}
+
+TEST(EventReportBackendSnapshotTest, SnapshotCommitRejectsChangedLifecycleGeneration) {
+    EventReportBackend backend(nullptr);
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    const ReporterSnapshotKey reporter_key{"instance-commit-fence", "10.0.0.71:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+
+    std::string candidate;
+    uint64_t retry_after_ms = 0;
+    uint64_t admitted_generation = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms, &admitted_generation));
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(candidate));
+    ASSERT_NE(0u, admitted_generation);
+
+    // An explicit REGISTER is a lifecycle boundary. A snapshot admitted by
+    // the previous lifecycle must not publish after that boundary even if its
+    // metadata phase already completed.
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+    ASSERT_NE(admitted_generation, backend.GetNodeGeneration(reporter_key.instance_id, reporter_key.host_ip_port));
+    EXPECT_EQ(EC_NODE_NOT_REGISTERED,
+              backend.CommitSnapshotVersionIfGeneration(reporter_key, candidate, admitted_generation));
+    EXPECT_TRUE(backend.GetSnapshotVersion(reporter_key).empty());
+    backend.AbortSnapshotVersion(reporter_key, candidate);
+}
+
+TEST(EventReportBackendSnapshotTest, SnapshotCleanupLeaseFencesLaterAttemptAdmission) {
+    EventReportBackend backend(nullptr);
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    const ReporterSnapshotKey reporter_key{"instance-cleanup-fence", "10.0.0.72:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+
+    std::string committed;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, committed, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, committed));
+    const uint64_t cleanup_generation = backend.GetNodeGeneration(reporter_key.instance_id, reporter_key.host_ip_port);
+    const uint64_t cleanup_attempt_epoch = backend.GetSnapshotAttemptEpoch(reporter_key);
+
+    EventReportBackend::LifecycleMutationLease cleanup_lease;
+    ASSERT_EQ(EC_OK,
+              backend.AcquireSnapshotCleanupLease(
+                  reporter_key, cleanup_generation, committed, cleanup_attempt_epoch, cleanup_lease));
+
+    std::promise<void> attempt_started;
+    std::string next_candidate;
+    auto next_attempt = std::async(std::launch::async, [&] {
+        attempt_started.set_value();
+        uint64_t retry_ms = 0;
+        return backend.BeginSnapshot(reporter_key, next_candidate, retry_ms);
+    });
+    attempt_started.get_future().wait();
+    EXPECT_EQ(std::future_status::timeout, next_attempt.wait_for(20ms));
+
+    // Releasing the old cleanup's final-delete lease lets the next attempt
+    // publish its epoch. The same cleanup identity must then be rejected even
+    // though the reporter lifecycle generation itself has not changed.
+    cleanup_lease.reset();
+    ASSERT_EQ(std::future_status::ready, next_attempt.wait_for(1s));
+    ASSERT_EQ(EC_OK, next_attempt.get());
+    ASSERT_GT(backend.GetSnapshotAttemptEpoch(reporter_key), cleanup_attempt_epoch);
+
+    EventReportBackend::LifecycleMutationLease stale_cleanup_lease;
+    EXPECT_EQ(EC_MISMATCH,
+              backend.AcquireSnapshotCleanupLease(
+                  reporter_key, cleanup_generation, committed, cleanup_attempt_epoch, stale_cleanup_lease));
+    EXPECT_FALSE(stale_cleanup_lease);
+    backend.AbortSnapshotVersion(reporter_key, next_candidate);
+}
+
+TEST(EventReportBackendSnapshotTest, SnapshotCommitAndCleanupWaitForTransientLifecycleWriter) {
+    EventReportBackend backend(nullptr);
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    const ReporterSnapshotKey reporter_key{"instance-transient-writer", "10.0.0.74:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+
+    std::string candidate;
+    uint64_t retry_after_ms = 0;
+    uint64_t lifecycle_generation = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms, &lifecycle_generation));
+    const auto lifecycle_fence = backend.GetOrCreateLifecycleFence(reporter_key);
+    ASSERT_TRUE(lifecycle_fence);
+
+    {
+        std::unique_lock<std::shared_mutex> transient_writer(lifecycle_fence->mutex);
+        std::promise<void> call_started;
+        auto commit = std::async(std::launch::async, [&] {
+            call_started.set_value();
+            return backend.CommitSnapshotVersionIfGeneration(reporter_key, candidate, lifecycle_generation);
+        });
+        call_started.get_future().wait();
+        EXPECT_EQ(std::future_status::timeout, commit.wait_for(20ms));
+        transient_writer.unlock();
+        ASSERT_EQ(std::future_status::ready, commit.wait_for(1s));
+        EXPECT_EQ(EC_OK, commit.get());
+    }
+
+    const uint64_t attempt_epoch = backend.GetSnapshotAttemptEpoch(reporter_key);
+    {
+        std::unique_lock<std::shared_mutex> transient_writer(lifecycle_fence->mutex);
+        std::promise<void> call_started;
+        auto cleanup = std::async(std::launch::async, [&] {
+            call_started.set_value();
+            EventReportBackend::LifecycleMutationLease lease;
+            return backend.AcquireSnapshotCleanupLease(
+                reporter_key, lifecycle_generation, candidate, attempt_epoch, lease);
+        });
+        call_started.get_future().wait();
+        EXPECT_EQ(std::future_status::timeout, cleanup.wait_for(20ms));
+        transient_writer.unlock();
+        ASSERT_EQ(std::future_status::ready, cleanup.wait_for(1s));
+        EXPECT_EQ(EC_OK, cleanup.get());
+    }
 }
 
 TEST(EventReportBackendSnapshotTest, QueryVisibilityIsStrictOnlyAfterSuccessfulSnapshot) {
@@ -1576,6 +1738,32 @@ TEST(EventReportBackendSnapshotTest, UnregisterThenReregisterLetsFirstDeltaCreat
     EXPECT_TRUE(backend.CommitSnapshotVersion(scope, second_token));
 }
 
+TEST(EventReportBackendSnapshotTest, StaleDeltaEndCannotDrainReregisteredLifecycle) {
+    EventReportBackend backend(nullptr);
+    const ReporterSnapshotKey reporter_key{"delta-incarnation", "10.0.0.73:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+
+    std::string old_token;
+    uint64_t old_generation = 0;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, old_token, &old_generation));
+    ASSERT_EQ(1u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+
+    ASSERT_EQ(EC_OK, backend.UnregisterNode(reporter_key.instance_id, reporter_key.host_ip_port));
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+    std::string new_token;
+    uint64_t new_generation = 0;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, new_token, &new_generation));
+    ASSERT_NE(old_token, new_token);
+    ASSERT_NE(old_generation, new_generation);
+    ASSERT_EQ(1u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+
+    backend.EndDeltaMutation(reporter_key, old_generation, old_token);
+    EXPECT_EQ(1u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+
+    backend.EndDeltaMutation(reporter_key, new_generation, new_token);
+    EXPECT_EQ(0u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+}
+
 TEST(EventReportBackendSnapshotTest, StableLocationIdHasNoSnapshotGeneration) {
     EventReportBackend backend(nullptr);
     ASSERT_EQ(EC_OK, backend.Open(EventReportBackendTest::MakeConfig(), "snapshot_location_test"));
@@ -1921,7 +2109,7 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         ASSERT_EQ(std::future_status::timeout, waiting_snapshot.wait_for(0ms));
         ASSERT_EQ(EC_OK, backend.Close());
         ASSERT_EQ(std::future_status::ready, waiting_snapshot.wait_for(1s));
-        EXPECT_EQ(EC_SNAPSHOT_REQUIRED, waiting_snapshot.get());
+        EXPECT_EQ(EC_INSTANCE_NOT_EXIST, waiting_snapshot.get());
         backend.EndDeltaMutation(reporter_key);
     }
 
@@ -1948,8 +2136,59 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
         ASSERT_EQ(std::future_status::timeout, waiting_delta.wait_for(20ms));
         ASSERT_EQ(EC_OK, backend.Close());
         ASSERT_EQ(std::future_status::ready, waiting_delta.wait_for(1s));
-        EXPECT_EQ(EC_SNAPSHOT_REQUIRED, waiting_delta.get());
+        EXPECT_EQ(EC_INSTANCE_NOT_EXIST, waiting_delta.get());
     }
+}
+
+TEST_F(EventReportBackendTest, DisableWhileSnapshotDrainsAbortsCandidateAndReopensGate) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK,
+              backend.Open(MakeConfig(/*hb*/ 5000,
+                                      /*grace*/ 10000,
+                                      /*tick*/ 60000,
+                                      DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5,
+                                      /*snapshot_min_interval*/ 0),
+                           "disable_while_snapshot_drains"));
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    const ReporterSnapshotKey reporter_key{"instance-disable", "10.0.0.72:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+    std::string first;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter_key, first, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(reporter_key, first));
+    std::string committed;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, committed));
+
+    std::string candidate;
+    auto waiting_snapshot = std::async(std::launch::async, [&] {
+        uint64_t retry_ms = 0;
+        return backend.BeginSnapshot(reporter_key, candidate, retry_ms);
+    });
+    std::string observed_committed;
+    std::string observed_in_flight;
+    const auto in_flight_deadline = std::chrono::steady_clock::now() + 1s;
+    do {
+        backend.GetSnapshotVersionTokens(reporter_key, observed_committed, observed_in_flight);
+        if (!observed_in_flight.empty()) {
+            break;
+        }
+        std::this_thread::yield();
+    } while (std::chrono::steady_clock::now() < in_flight_deadline);
+    ASSERT_FALSE(observed_in_flight.empty());
+
+    DataStorageBackend &backend_base = backend;
+    backend_base.SetAvailable(false);
+    ASSERT_EQ(std::future_status::ready, waiting_snapshot.wait_for(1s));
+    EXPECT_EQ(EC_INSTANCE_NOT_EXIST, waiting_snapshot.get());
+    EXPECT_TRUE(candidate.empty());
+
+    backend_base.SetAvailable(true);
+    backend.EndDeltaMutation(reporter_key);
+    std::string after_reenable;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, after_reenable));
+    EXPECT_EQ(first, after_reenable);
+    backend.EndDeltaMutation(reporter_key);
+    ASSERT_EQ(EC_OK, backend.Close());
 }
 
 TEST(EventReportBackendSnapshotTest, SnapshotUriUtilitiesHandleExactParameterBoundaries) {

--- a/kv_cache_manager/data_storage/test/snapshot_uri_utils_test.cc
+++ b/kv_cache_manager/data_storage/test/snapshot_uri_utils_test.cc
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "kv_cache_manager/data_storage/snapshot_uri_utils.h"
+
+namespace kv_cache_manager {
+
+class SnapshotUriUtilsTest : public ::testing::Test {};
+
+TEST_F(SnapshotUriUtilsTest, InspectSnapshotUriForVisibilityReturnsBorrowedVersion) {
+    constexpr std::string_view token = "0123456789abcdefABCDEF0123456789";
+    const std::string uri = "event_report://10.0.0.1:8080/mem?rank=0&s_version=" + std::string(token) + "&size=4096";
+
+    std::string_view version;
+    ASSERT_TRUE(SnapshotUriUtils::InspectSnapshotUriForVisibility(uri, version));
+    EXPECT_EQ(token, version);
+    EXPECT_EQ(uri.data() + uri.find(token), version.data());
+}
+
+TEST_F(SnapshotUriUtilsTest, InspectSnapshotUriForVisibilityAcceptsLegacyAndUnrelatedParams) {
+    const std::vector<std::string> uris = {
+        "event_report://10.0.0.1:8080/mem",
+        "event_report://10.0.0.1:8080/mem?rank=0&size=4096",
+        "event_report://10.0.0.1:8080/mem?xs_version=ignored&s_version_suffix=ignored",
+        "event_report://10.0.0.1:8080/mem?&rank=0&&",
+    };
+
+    for (const auto &uri : uris) {
+        std::string_view version = "must be cleared";
+        EXPECT_TRUE(SnapshotUriUtils::InspectSnapshotUriForVisibility(uri, version)) << uri;
+        EXPECT_TRUE(version.empty()) << uri;
+    }
+}
+
+TEST_F(SnapshotUriUtilsTest, InspectSnapshotUriForVisibilityRejectsMalformedUri) {
+    const std::vector<std::string> uris = {
+        "",
+        "event_report:/10.0.0.1/mem",
+        "://10.0.0.1/mem",
+        "event?bad_report://10.0.0.1/mem",
+    };
+
+    for (const auto &uri : uris) {
+        std::string_view version = "must be cleared";
+        EXPECT_FALSE(SnapshotUriUtils::InspectSnapshotUriForVisibility(uri, version)) << uri;
+        EXPECT_TRUE(version.empty()) << uri;
+    }
+}
+
+TEST_F(SnapshotUriUtilsTest, InspectSnapshotUriForVisibilityRejectsInvalidOrDuplicateVersion) {
+    constexpr const char *token = "0123456789abcdef0123456789abcdef";
+    const std::vector<std::string> uris = {
+        "event_report://host/mem?s_version",
+        "event_report://host/mem?s_version=",
+        "event_report://host/mem?s_version=0123456789abcdef0123456789abcde",
+        "event_report://host/mem?s_version=0123456789abcdef0123456789abcdef0",
+        "event_report://host/mem?s_version=0123456789abcdef0123456789abcdeg",
+        std::string("event_report://host/mem?s_version=") + token + "&s_version=" + token,
+        std::string("event_report://host/mem?s_version=") + token + "&s_version",
+        std::string("event_report://host/mem?s_version&rank=0&s_version=") + token,
+    };
+
+    for (const auto &uri : uris) {
+        std::string_view version = "must be cleared";
+        EXPECT_FALSE(SnapshotUriUtils::InspectSnapshotUriForVisibility(uri, version)) << uri;
+    }
+}
+
+TEST_F(SnapshotUriUtilsTest, InspectSnapshotUriForVisibilityAcceptsVersionAtParamBoundaries) {
+    constexpr const char *token = "abcdef0123456789abcdef0123456789";
+    const std::vector<std::string> uris = {
+        std::string("event_report://host/mem?s_version=") + token,
+        std::string("event_report://host/mem?&s_version=") + token,
+        std::string("event_report://host/mem?rank=0&s_version=") + token + "&",
+        std::string("event_report://host/mem?rank=0&s_version=") + token + "&size=1",
+    };
+
+    for (const auto &uri : uris) {
+        std::string_view version;
+        ASSERT_TRUE(SnapshotUriUtils::InspectSnapshotUriForVisibility(uri, version)) << uri;
+        EXPECT_EQ(token, version) << uri;
+    }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <charconv>
 #include <chrono>
 #include <cinttypes>
 #include <limits>
@@ -141,7 +142,7 @@ public:
 
     ~DeltaMutationGuard() {
         for (const auto &entry : versions_) {
-            backend_->EndDeltaMutation(entry.first, entry.second.lifecycle_generation);
+            backend_->EndDeltaMutation(entry.first, entry.second.lifecycle_generation, entry.second.snapshot_version);
         }
     }
 
@@ -414,6 +415,7 @@ CacheManager::CacheManager(std::shared_ptr<MetricsRegistry> metrics_registry,
 CacheManager::~CacheManager() {
     ClearEventCleanupCallbacks();
     StopRecoverRetryLoop();
+    DeactivateEventCleanupCallbacks();
     if (write_location_manager_) {
         write_location_manager_->Stop();
         write_location_manager_.reset();
@@ -545,6 +547,9 @@ CacheManager::RegisterInstance(RequestContext *request_context,
                                                         model_deployment,
                                                         location_spec_groups,
                                                         static_cast<int32_t>(default_query_type));
+        if (instance_info->instance_group_name() != instance_group) {
+            mismatched.insert(mismatched.begin(), "instance_group_name");
+        }
         if (!mismatched.empty()) {
             auto mismatched_str = StringUtil::Join(mismatched, ", ");
             request_context->error_tracer()->AddErrorMsg(
@@ -889,6 +894,14 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
         query_keys = GenKeyVector(tokens, block_size);
     }
 
+    const bool has_implicit_empty_mask =
+        std::holds_alternative<BlockMaskVector>(block_mask) && std::get<BlockMaskVector>(block_mask).empty();
+    if (!has_implicit_empty_mask && !IsBlockMaskValid(block_mask, query_keys.size())) {
+        request_context->error_tracer()->AddErrorMsg("block_mask must match the number of query keys");
+        RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
+            WARN, EC_BADARGS, BatchLocationsView, "block_mask must match the number of query keys");
+    }
+
     auto query_scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(service_metrics_collector, ManagerBatchGet);
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, request_key_count, query_keys.size());
 
@@ -896,10 +909,44 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
         request_context->error_tracer()->AddErrorMsg("backend_selectors must not be empty");
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, EC_BADARGS, BatchLocationsView, "backend_selectors must not be empty");
     }
+    std::unordered_set<DataStorageType> selected_backend_types;
+    for (const auto &selector : backend_selectors) {
+        const auto backend_index = ToIndex(selector.backend_type);
+        if (selector.backend_type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN ||
+            backend_index >= ToIndex(DataStorageType::COUNT)) {
+            request_context->error_tracer()->AddErrorMsg("backend selector has invalid backend_type");
+            RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
+                WARN, EC_BADARGS, BatchLocationsView, "backend selector has invalid backend_type");
+        }
+        if (!selected_backend_types.insert(selector.backend_type).second) {
+            request_context->error_tracer()->AddErrorMsg("backend selector contains duplicate backend_type");
+            RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
+                WARN, EC_BADARGS, BatchLocationsView, "backend selector contains duplicate backend_type");
+        }
+        switch (selector.strategy) {
+        case LocationSelectStrategy::LSS_WEIGHTED_RANDOM:
+            break;
+        case LocationSelectStrategy::LSS_V6D_PREFIX:
+        case LocationSelectStrategy::LSS_V6D_COVERAGE:
+            if (selector.backend_type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2) {
+                break;
+            }
+            [[fallthrough]];
+        default:
+            request_context->error_tracer()->AddErrorMsg("backend selector has invalid strategy for backend_type");
+            RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
+                WARN, EC_BADARGS, BatchLocationsView, "backend selector has invalid strategy for backend_type");
+        }
+    }
 
     LocationsPerKey locations_per_key;
-    ec = meta_searcher->BatchGetBestLocationByBackend(
-        request_context, query_keys, locations_per_key, policy.get(), backend_selectors, location_spec_names);
+    ec = meta_searcher->BatchGetBestLocationByBackend(request_context,
+                                                      query_keys,
+                                                      locations_per_key,
+                                                      policy.get(),
+                                                      backend_selectors,
+                                                      location_spec_names,
+                                                      block_mask);
     query_scope = ChronoScopeGuard{};
     // prefix_match_len: count keys with at least one hit (non-empty id).
     // Miss keys have empty CacheLocation objects with no id.
@@ -2342,7 +2389,8 @@ namespace {
 
 std::shared_ptr<DataStorageBackend> LookupEventReportBackend(const std::shared_ptr<RegistryManager> &registry_manager,
                                                              const std::string &instance_id,
-                                                             DataStorageType requested_type) {
+                                                             DataStorageType requested_type,
+                                                             bool require_available = false) {
     if (!registry_manager || !registry_manager->data_storage_manager()) {
         return nullptr;
     }
@@ -2361,27 +2409,62 @@ std::shared_ptr<DataStorageBackend> LookupEventReportBackend(const std::shared_p
     for (const auto &candidate_name : ig->event_report_storage_candidates()) {
         auto backend = dsm->GetDataStorageBackend(candidate_name);
         auto *event_backend = dynamic_cast<EventReportBackend *>(backend.get());
-        if (event_backend && event_backend->GetStorageType() == requested_type) {
+        if (event_backend && event_backend->GetStorageType() == requested_type &&
+            (!require_available || event_backend->Available())) {
             return backend;
         }
     }
     return nullptr;
 }
 
+bool IsCurrentEventReportBackend(const std::shared_ptr<RegistryManager> &registry_manager,
+                                 const std::string &instance_id,
+                                 DataStorageType requested_type,
+                                 const std::shared_ptr<EventReportBackend> &expected_backend) {
+    if (!expected_backend || expected_backend->GetStorageType() != requested_type) {
+        return false;
+    }
+    // Match the same first-available-candidate rule used by ReportEvent and
+    // GetHostCacheState. Merely remaining in the candidate list is not enough:
+    // an older backend incarnation must never clean metadata owned by the
+    // backend that currently wins routing for this storage tier.
+    const auto current = LookupEventReportBackend(registry_manager, instance_id, requested_type, true);
+    return current.get() == expected_backend.get();
+}
+
 bool ParseInt64(const std::string &s, int64_t &out) {
-    try {
-        size_t consumed = 0;
-        uint64_t v = std::stoull(s, &consumed);
-        if (consumed != s.size()) {
+    if (s.empty() || s.front() == '+') {
+        return false;
+    }
+
+    const bool negative = s.front() == '-';
+    const char *begin = s.data() + (negative ? 1 : 0);
+    const char *end = s.data() + s.size();
+    if (begin == end) {
+        return false;
+    }
+
+    uint64_t magnitude = 0;
+    const auto [parsed_end, parse_ec] = std::from_chars(begin, end, magnitude);
+    if (parse_ec != std::errc{} || parsed_end != end) {
+        return false;
+    }
+
+    constexpr uint64_t kSignBit = uint64_t{1} << 63;
+    if (negative) {
+        if (magnitude > kSignBit) {
             return false;
         }
-        if (v <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-            out = static_cast<int64_t>(v);
-        } else {
-            out = std::numeric_limits<int64_t>::min() + static_cast<int64_t>(v - (uint64_t{1} << 63));
-        }
+        out = magnitude == kSignBit ? std::numeric_limits<int64_t>::min() : -static_cast<int64_t>(magnitude);
         return true;
-    } catch (...) { return false; }
+    }
+
+    // vLLM serializes its external block hash as an unsigned uint64 decimal.
+    // Preserve that 64-bit pattern when KVCM stores and queries signed int64
+    // keys instead of rejecting values above INT64_MAX.
+    out = magnitude < kSignBit ? static_cast<int64_t>(magnitude)
+                               : std::numeric_limits<int64_t>::min() + static_cast<int64_t>(magnitude - kSignBit);
+    return true;
 }
 
 bool IsSnapshotLocationStale(const EventReportBackend *event_backend,
@@ -2521,23 +2604,33 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         return EC_BADARGS;
     }
 
-    DataStorageType requested_type = static_cast<DataStorageType>(request->storage_type());
-    if (requested_type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN) {
+    DataStorageType requested_type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
+    switch (request->storage_type()) {
+    case proto::meta::ST_EVENT_REPORT_L1P5:
+        requested_type = DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5;
+        break;
+    case proto::meta::ST_EVENT_REPORT_L2:
+        requested_type = DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2;
+        break;
+    case proto::meta::ST_UNSPECIFIED:
         KVCM_LOG_WARN("trace_id [%s] | ReportEvent: storage_type is required but not specified", trace_id.c_str());
         response_status->set_code(proto::meta::INVALID_ARGUMENT);
         response_status->set_message("storage_type is required");
         return EC_BADARGS;
-    }
-    if (!IsEventReportStorageType(requested_type)) {
+    default:
+        // Do not cast the open protobuf enum directly to DataStorageType (whose
+        // underlying type is uint8_t): an unknown wire value such as 263 would
+        // truncate to 7 and be misrouted to the L1P5 backend.
         KVCM_LOG_WARN("trace_id [%s] | ReportEvent: unsupported event-report storage_type [%d]",
                       trace_id.c_str(),
-                      static_cast<int>(requested_type));
+                      static_cast<int>(request->storage_type()));
         response_status->set_code(proto::meta::INVALID_ARGUMENT);
-        response_status->set_message("unsupported event-report storage_type: " + ToString(requested_type));
+        response_status->set_message("unsupported event-report storage_type: " +
+                                     std::to_string(static_cast<int>(request->storage_type())));
         return EC_BADARGS;
     }
 
-    auto event_backend_holder = LookupEventReportBackend(registry_manager_, instance_id, requested_type);
+    auto event_backend_holder = LookupEventReportBackend(registry_manager_, instance_id, requested_type, true);
     auto event_backend = std::dynamic_pointer_cast<EventReportBackend>(event_backend_holder);
     if (!event_backend) {
         KVCM_LOG_WARN("trace_id [%s] | ReportEvent: EventReportBackend not found for instance [%s] type [%d]",
@@ -2571,13 +2664,49 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     refresh_snapshot_response(false);
 
     if (!event_backend->IsCleanupCallbackSet()) {
-        event_backend->SetCleanupCallback([this, requested_type](const std::string &cleanup_instance,
-                                                                 const std::string &down_host,
-                                                                 uint64_t generation) {
-            assert(this->schedule_plan_executor_);
-            this->schedule_plan_executor_->SubmitTask([this, cleanup_instance, down_host, generation, requested_type] {
-                this->CleanupHostLocations(cleanup_instance, down_host, generation, requested_type);
-            });
+        const std::weak_ptr<EventReportBackend> expected_backend = event_backend;
+        const auto callback_state = event_cleanup_callback_state_;
+        event_backend->SetCleanupCallback([this, requested_type, expected_backend, callback_state](
+                                              const std::string &cleanup_instance,
+                                              const std::string &down_host,
+                                              uint64_t generation) {
+            std::shared_lock<std::shared_mutex> callback_lease(callback_state->mutex);
+            if (!callback_state->accepting) {
+                return;
+            }
+            const uint64_t callback_epoch = callback_state->epoch;
+            auto cleanup_backend = expected_backend.lock();
+            if (!cleanup_backend) {
+                return;
+            }
+            const auto cleanup = [this,
+                                  cleanup_instance,
+                                  down_host,
+                                  generation,
+                                  requested_type,
+                                  cleanup_backend,
+                                  callback_state,
+                                  callback_epoch] {
+                // A queued task may start after the backend callback that
+                // submitted it has returned. Hold the same lifetime lease for
+                // the whole cleanup so DoCleanup/destruction drains running
+                // tasks and makes tasks that are still queued harmless.
+                std::shared_lock<std::shared_mutex> task_lease(callback_state->mutex);
+                if (!callback_state->accepting || callback_state->epoch != callback_epoch) {
+                    return;
+                }
+                this->CleanupHostLocations(cleanup_instance, down_host, generation, requested_type, cleanup_backend);
+            };
+            if (!this->schedule_plan_executor_ || !this->schedule_plan_executor_->SubmitTask(cleanup)) {
+                // This callback runs on EventReportBackend's liveness thread.
+                // Running inline could enter DataStorageManager while an
+                // unregister operation holds its write lock and waits for this
+                // backend thread to join. The node is still removed from the
+                // visibility table below, so dropping best-effort physical
+                // metadata cleanup during executor shutdown is fail-closed.
+                KVCM_LOG_WARN("ReportEvent liveness cleanup queue unavailable; skipping metadata cleanup for host [%s]",
+                              down_host.c_str());
+            }
         });
     }
 
@@ -2598,10 +2727,20 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
 
     bool has_heartbeat = false;
     bool has_host_down = false;
+    std::vector<int> valid_heartbeat_indices;
     std::vector<std::string> register_mediums;
     std::map<std::string, std::string> heartbeat_status;
-    for (const auto &item : request->events()) {
+    for (int i = 0; i < events_size; ++i) {
+        const auto &item = request->events(i);
         if (item.event_type() != proto::meta::EVENT_NODE_REGISTER || !item.has_node_register()) {
+            continue;
+        }
+        const bool valid_mediums =
+            std::all_of(item.node_register().mediums().begin(),
+                        item.node_register().mediums().end(),
+                        [](const std::string &medium) { return SnapshotUriUtils::IsValidLocationIdComponent(medium); });
+        if (!valid_mediums) {
+            per_item_ec[i] = EC_BADARGS;
             continue;
         }
         for (const auto &medium : item.node_register().mediums()) {
@@ -2683,6 +2822,11 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     std::map<int64_t, std::vector<BlockAddEntry>> block_to_add;
     std::map<int64_t, std::vector<BlockDelEntry>> block_to_del;
     std::map<int64_t, std::map<std::string, std::map<std::string, DeltaSpecMutation>>> delta_spec_mutations;
+    // Events touching one stable block/location form a retry dependency
+    // group. ADD and DELETE are persisted in separate phases; if either
+    // phase fails, every event in the group must be retried in request order
+    // to preserve last-operation-wins semantics.
+    std::map<int64_t, std::map<std::string, std::set<int>>> delta_retry_groups;
     std::map<int64_t, std::vector<SnapshotReplaceEntry>> snapshot_to_replace;
     std::vector<SnapshotCommitTask> snapshot_commit_tasks;
     std::string request_snapshot_version;
@@ -2693,6 +2837,9 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         case proto::meta::EVENT_NODE_REGISTER: {
             if (!item.has_node_register()) {
                 per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            if (per_item_ec[i] != EC_OK) {
                 break;
             }
             if (!registration_applied) {
@@ -2714,6 +2861,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 break;
             }
             has_heartbeat = true;
+            valid_heartbeat_indices.push_back(i);
             heartbeat_status.clear();
             for (const auto &kv : item.heartbeat().system_status()) {
                 heartbeat_status[kv.first] = kv.second;
@@ -2755,6 +2903,14 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
+            const std::string location_id = event_backend->BuildLocationId(params.medium(), host_ip_port);
+            // Record the retry dependency as soon as the event is
+            // structurally valid. Admission may still fail before a mutation
+            // is materialized (for example, a tombstoned reporter followed by
+            // REGISTER and a later related mutation). In that case a later
+            // success must also be retried, otherwise retrying only the early
+            // failed item could reverse the request's final operation order.
+            delta_retry_groups[block_key][location_id].insert(i);
             const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
@@ -2783,7 +2939,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            const std::string location_id = event_backend->BuildLocationId(params.medium(), host_ip_port);
             auto &mutations_by_name = delta_spec_mutations[block_key][location_id];
             for (auto &spec : specs) {
                 auto &mutation = mutations_by_name[spec.name()];
@@ -2820,6 +2975,8 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
+            const std::string location_id = event_backend->BuildLocationId(params.medium(), host_ip_port);
+            delta_retry_groups[block_key][location_id].insert(i);
             const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
@@ -2837,7 +2994,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (created_generation) {
                 request_created_generation = true;
             }
-            const std::string location_id = event_backend->BuildLocationId(params.medium(), host_ip_port);
             auto &mutations_by_name = delta_spec_mutations[block_key][location_id];
             for (auto &spec_name : spec_names) {
                 auto &mutation = mutations_by_name[spec_name];
@@ -2964,6 +3120,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         for (auto &[location_id, mutations_by_name] : mutations_by_location) {
             for (auto &[spec_name, mutation] : mutations_by_name) {
                 for (const int event_index : mutation.event_indices) {
+                    delta_retry_groups[block_key][location_id].insert(event_index);
                     if (mutation.is_add) {
                         block_to_add[block_key].push_back(BlockAddEntry{location_id, {mutation.spec}, event_index});
                     } else {
@@ -2977,11 +3134,16 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     if (has_heartbeat) {
         const ErrorCode ec = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
         if (ec != EC_OK) {
-            for (int i = 0; i < events_size; ++i) {
-                if (request->events(i).event_type() == proto::meta::EVENT_HEARTBEAT) {
-                    per_item_ec[i] = ec;
-                }
+            for (const int event_index : valid_heartbeat_indices) {
+                per_item_ec[event_index] = ec;
             }
+        } else {
+            // Recovering an unavailable reporter advances its lifecycle to
+            // fence cleanup selected for the old generation. Mutations
+            // admitted by this same RPC belong to the recovered lifecycle;
+            // retain that generation through metadata writes and lease drain.
+            mutation_lifecycle_generation = event_backend->GetNodeGeneration(instance_id, host_ip_port);
+            delta_mutations.AdoptLifecycleGeneration(reporter_key, mutation_lifecycle_generation);
         }
     }
 
@@ -3116,7 +3278,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
 
         for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
             ErrorCode key_ec = EC_OK;
-            if (k < per_location_ec.size()) {
+            if (k < per_location_ec.size() && per_location_ec[k].size() == del_merged_entries_aggr[k].size()) {
                 for (const auto &loc_ec : per_location_ec[k]) {
                     if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
                         key_ec = loc_ec;
@@ -3202,12 +3364,18 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         // a snapshot commits after every persistent write has been accepted
         // by the async backend and mirrored into the local cache; it does not
         // wait for Redis consumers to flush their queues.
-        if (!snapshot_failed && !event_backend->CommitSnapshotVersion(task.reporter_key, task.version)) {
-            KVCM_LOG_ERROR("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: failed to publish host [%s] token [%s]",
-                           trace_id.c_str(),
-                           task.reporter_key.host_ip_port.c_str(),
-                           task.version.c_str());
-            snapshot_failed = true;
+        if (!snapshot_failed) {
+            const ErrorCode commit_ec = event_backend->CommitSnapshotVersionIfGeneration(
+                task.reporter_key, task.version, mutation_lifecycle_generation);
+            if (commit_ec != EC_OK) {
+                KVCM_LOG_ERROR("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: failed to publish host [%s] token [%s], ec [%d]",
+                               trace_id.c_str(),
+                               task.reporter_key.host_ip_port.c_str(),
+                               task.version.c_str(),
+                               commit_ec);
+                per_item_ec[task.event_index] = commit_ec;
+                snapshot_failed = true;
+            }
         }
         if (snapshot_failed) {
             if (per_item_ec[task.event_index] == EC_OK) {
@@ -3216,14 +3384,29 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             event_backend->AbortSnapshotVersion(task.reporter_key, task.version);
         } else if (schedule_plan_executor_) {
             const auto cleanup_backend = event_backend;
+            const auto cleanup_state = event_cleanup_callback_state_;
+            uint64_t cleanup_epoch = 0;
+            {
+                std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
+                if (cleanup_state->accepting) {
+                    cleanup_epoch = cleanup_state->epoch;
+                }
+            }
             if (!schedule_plan_executor_->SubmitTask([this,
                                                       reporter_key = task.reporter_key,
                                                       version = task.version,
                                                       attempt_epoch = task.attempt_epoch,
+                                                      lifecycle_generation = mutation_lifecycle_generation,
                                                       requested_type,
-                                                      cleanup_backend] {
+                                                      cleanup_backend,
+                                                      cleanup_state,
+                                                      cleanup_epoch] {
+                    std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
+                    if (!cleanup_state->accepting || cleanup_state->epoch != cleanup_epoch) {
+                        return;
+                    }
                     this->CleanupStaleSnapshotLocations(
-                        reporter_key, version, requested_type, cleanup_backend, attempt_epoch);
+                        reporter_key, version, requested_type, cleanup_backend, attempt_epoch, lifecycle_generation);
                 })) {
                 KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: failed to submit stale-data scan for host [%s]",
                               trace_id.c_str(),
@@ -3234,26 +3417,82 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
 
     if (has_host_down) {
         uint64_t gen_at_trigger = 0;
-        event_backend->UnregisterNodeForHostDown(instance_id, host_ip_port, gen_at_trigger);
-        assert(schedule_plan_executor_);
-        const bool cleanup_scheduled =
-            schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
-                this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
-            });
-        if (!cleanup_scheduled) {
-            KVCM_LOG_WARN("trace_id [%s] | HOST_DOWN: failed to submit metadata cleanup for host [%s], "
-                          "instance [%s], gen=%" PRIu64,
+        const ErrorCode host_down_ec =
+            event_backend->UnregisterNodeForHostDown(instance_id, host_ip_port, gen_at_trigger);
+        if (host_down_ec != EC_OK) {
+            per_item_ec[0] = host_down_ec;
+        }
+        bool cleanup_dispatched = false;
+        if (host_down_ec == EC_OK) {
+            const auto cleanup_state = event_cleanup_callback_state_;
+            uint64_t cleanup_epoch = 0;
+            {
+                std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
+                if (cleanup_state->accepting) {
+                    cleanup_epoch = cleanup_state->epoch;
+                }
+            }
+            const auto cleanup = [this,
+                                  instance_id,
+                                  host_ip_port,
+                                  gen_at_trigger,
+                                  requested_type,
+                                  event_backend,
+                                  cleanup_state,
+                                  cleanup_epoch] {
+                std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
+                if (!cleanup_state->accepting || cleanup_state->epoch != cleanup_epoch) {
+                    return;
+                }
+                this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type, event_backend);
+            };
+            cleanup_dispatched = schedule_plan_executor_ && schedule_plan_executor_->SubmitTask(cleanup);
+            if (!cleanup_dispatched) {
+                KVCM_LOG_WARN("trace_id [%s] | HOST_DOWN: cleanup queue unavailable for host [%s], "
+                              "instance [%s], gen=%" PRIu64 "; running inline",
+                              trace_id.c_str(),
+                              host_ip_port.c_str(),
+                              instance_id.c_str(),
+                              gen_at_trigger);
+                cleanup();
+                cleanup_dispatched = true;
+            }
+            KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] removed from node table, cleanup_dispatched=%s "
+                          "(gen=%" PRIu64 ")",
+                          trace_id.c_str(),
+                          host_ip_port.c_str(),
+                          cleanup_dispatched ? "true" : "false",
+                          gen_at_trigger);
+        } else {
+            KVCM_LOG_WARN("trace_id [%s] | HOST_DOWN: failed to end lifecycle for host [%s], "
+                          "instance [%s], ec=%d",
                           trace_id.c_str(),
                           host_ip_port.c_str(),
                           instance_id.c_str(),
-                          gen_at_trigger);
+                          host_down_ec);
         }
-        KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] removed from node table, cleanup_scheduled=%s "
-                      "(gen=%" PRIu64 ")",
-                      trace_id.c_str(),
-                      host_ip_port.c_str(),
-                      cleanup_scheduled ? "true" : "false",
-                      gen_at_trigger);
+    }
+
+    for (const auto &[block_key, groups_by_location] : delta_retry_groups) {
+        (void)block_key;
+        for (const auto &[location_id, event_indices] : groups_by_location) {
+            (void)location_id;
+            ErrorCode group_failure = EC_OK;
+            for (const int event_index : event_indices) {
+                if (per_item_ec[event_index] != EC_OK) {
+                    group_failure = per_item_ec[event_index];
+                    break;
+                }
+            }
+            if (group_failure == EC_OK) {
+                continue;
+            }
+            for (const int event_index : event_indices) {
+                if (per_item_ec[event_index] == EC_OK) {
+                    per_item_ec[event_index] = group_failure;
+                }
+            }
+        }
     }
 
     bool any_failure = false;
@@ -3337,21 +3576,25 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
 void CacheManager::CleanupHostLocations(const std::string &instance_id,
                                         const std::string &host_ip_port,
                                         uint64_t cleanup_generation,
-                                        DataStorageType storage_type) {
-    auto event_backend_holder = LookupEventReportBackend(registry_manager_, instance_id, storage_type);
-    auto *event_backend = dynamic_cast<EventReportBackend *>(event_backend_holder.get());
+                                        DataStorageType storage_type,
+                                        const std::shared_ptr<EventReportBackend> &expected_backend) {
+    if (!IsCurrentEventReportBackend(registry_manager_, instance_id, storage_type, expected_backend)) {
+        KVCM_LOG_INFO("CleanupHostLocations: skipping stale backend incarnation for host [%s] instance [%s]",
+                      host_ip_port.c_str(),
+                      instance_id.c_str());
+        return;
+    }
+    const auto &event_backend = expected_backend;
 
-    if (event_backend) {
-        uint64_t current_gen = event_backend->GetNodeGeneration(instance_id, host_ip_port);
-        if (current_gen != cleanup_generation) {
-            KVCM_LOG_INFO("CleanupHostLocations: skipping stale cleanup for host [%s] instance [%s] "
-                          "(trigger_gen=%" PRIu64 ", current_gen=%" PRIu64 " — node re-registered)",
-                          host_ip_port.c_str(),
-                          instance_id.c_str(),
-                          cleanup_generation,
-                          current_gen);
-            return;
-        }
+    uint64_t current_gen = event_backend->GetNodeGeneration(instance_id, host_ip_port);
+    if (current_gen != cleanup_generation) {
+        KVCM_LOG_INFO("CleanupHostLocations: skipping stale cleanup for host [%s] instance [%s] "
+                      "(trigger_gen=%" PRIu64 ", current_gen=%" PRIu64 " — node re-registered)",
+                      host_ip_port.c_str(),
+                      instance_id.c_str(),
+                      cleanup_generation,
+                      current_gen);
+        return;
     }
 
     MetaSearcher *meta_searcher = meta_searcher_manager_->GetMetaSearcher(instance_id);
@@ -3361,21 +3604,26 @@ void CacheManager::CleanupHostLocations(const std::string &instance_id,
     }
 
     RequestContext cleanup_ctx("cleanup_host_" + host_ip_port);
-    const std::string host_suffix = event_backend ? event_backend->HostSuffix(host_ip_port) : ("#" + host_ip_port);
+    const std::string host_suffix = event_backend->HostSuffix(host_ip_port);
 
-    auto abort_if_reregistered = [event_backend, instance_id, host_ip_port, cleanup_generation]() -> bool {
-        if (!event_backend) {
-            return false;
-        }
-        return event_backend->GetNodeGeneration(instance_id, host_ip_port) != cleanup_generation;
+    auto backend_is_current = [registry_manager = registry_manager_, instance_id, storage_type, event_backend] {
+        return IsCurrentEventReportBackend(registry_manager, instance_id, storage_type, event_backend);
     };
-    auto acquire_cleanup_lease = [event_backend, instance_id, host_ip_port, cleanup_generation] {
+    auto abort_if_reregistered =
+        [event_backend, instance_id, host_ip_port, cleanup_generation, backend_is_current]() -> bool {
+        return !backend_is_current() ||
+               event_backend->GetNodeGeneration(instance_id, host_ip_port) != cleanup_generation;
+    };
+    auto acquire_cleanup_lease = [event_backend, instance_id, host_ip_port, cleanup_generation, backend_is_current] {
         EventReportBackend::LifecycleMutationLease lease;
-        if (!event_backend) {
-            return std::make_pair(EC_OK, MetaSearcher::MetadataWriteLease{});
+        if (!backend_is_current()) {
+            return std::make_pair(EC_MISMATCH, MetaSearcher::MetadataWriteLease{});
         }
         const ErrorCode ec =
             event_backend->AcquireLifecycleCleanupLease({instance_id, host_ip_port}, cleanup_generation, lease);
+        // Keep the global lock order DataStorageManager -> backend lifecycle.
+        // Re-entering backend_is_current() while holding this lease would
+        // invert UnRegisterStorage's DataStorageManager -> Close order.
         return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
     };
 
@@ -3401,7 +3649,11 @@ ErrorCode CacheManager::CleanupStaleSnapshotLocations(const ReporterSnapshotKey 
                                                       const std::string &snapshot_version,
                                                       DataStorageType storage_type,
                                                       const std::shared_ptr<EventReportBackend> &event_backend,
-                                                      uint64_t snapshot_attempt_epoch) {
+                                                      uint64_t snapshot_attempt_epoch,
+                                                      uint64_t lifecycle_generation) {
+    if (!IsCurrentEventReportBackend(registry_manager_, reporter_key.instance_id, storage_type, event_backend)) {
+        return EC_OK;
+    }
     if (!event_backend || snapshot_version.empty() || event_backend->GetStorageType() != storage_type ||
         event_backend->GetSnapshotVersion(reporter_key) != snapshot_version ||
         (snapshot_attempt_epoch != 0 &&
@@ -3430,15 +3682,39 @@ ErrorCode CacheManager::CleanupStaleSnapshotLocations(const ReporterSnapshotKey 
                IsSnapshotLocationStale(
                    event_backend.get(), reporter_key.instance_id, location, /*preserve_in_flight=*/true);
     };
-    auto should_abort = [event_backend, reporter_key, snapshot_attempt_epoch] {
-        return snapshot_attempt_epoch != 0 &&
-               event_backend->GetSnapshotAttemptEpoch(reporter_key) != snapshot_attempt_epoch;
+    auto backend_is_current = [registry_manager = registry_manager_, reporter_key, storage_type, event_backend] {
+        return IsCurrentEventReportBackend(registry_manager, reporter_key.instance_id, storage_type, event_backend);
+    };
+    auto should_abort = [event_backend, reporter_key, snapshot_attempt_epoch, backend_is_current] {
+        return !backend_is_current() || (snapshot_attempt_epoch != 0 && event_backend->GetSnapshotAttemptEpoch(
+                                                                            reporter_key) != snapshot_attempt_epoch);
+    };
+    if (lifecycle_generation == 0) {
+        lifecycle_generation = event_backend->GetNodeGeneration(reporter_key.instance_id, reporter_key.host_ip_port);
+    }
+    auto acquire_cleanup_lease = [event_backend,
+                                  reporter_key,
+                                  snapshot_version,
+                                  snapshot_attempt_epoch,
+                                  lifecycle_generation,
+                                  backend_is_current] {
+        EventReportBackend::LifecycleMutationLease lease;
+        if (!backend_is_current()) {
+            return std::make_pair(EC_MISMATCH, MetaSearcher::MetadataWriteLease{});
+        }
+        const ErrorCode ec = event_backend->AcquireSnapshotCleanupLease(
+            reporter_key, lifecycle_generation, snapshot_version, snapshot_attempt_epoch, lease);
+        // Do not query DataStorageManager again while holding the backend
+        // lifecycle lease; storage unregister takes those locks in the
+        // opposite (global-manager then backend) order.
+        return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
     };
     const ErrorCode ec = meta_searcher->CleanupLocationsByPredicate(&cleanup_ctx,
                                                                     storage_type,
                                                                     /*scan_batch_size=*/1000,
                                                                     std::move(should_delete),
-                                                                    std::move(should_abort));
+                                                                    std::move(should_abort),
+                                                                    std::move(acquire_cleanup_lease));
     const auto elapsed_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - scan_begin).count();
     KVCM_LOG_INFO("SnapshotReclaimer: scanned instance [%s] host [%s] token [%s] in [%" PRId64 "] ms, ec [%d]",
@@ -3603,6 +3879,7 @@ ErrorCode CacheManager::GetCacheLocationByQueryType(MetaSearcher *meta_searcher,
 }
 
 ErrorCode CacheManager::DoRecoverOnce() {
+    ActivateEventCleanupCallbacks();
     if (!registry_manager_) {
         KVCM_LOG_ERROR("CacheManager do recover failed, registry_manager is nullptr");
         return EC_ERROR;
@@ -3701,16 +3978,35 @@ void CacheManager::ClearEventCleanupCallbacks() {
     }
     auto dsm = registry_manager_->data_storage_manager();
     for (const auto &name : dsm->GetAllStorageNames()) {
-        auto *erb = dynamic_cast<EventReportBackend *>(dsm->GetDataStorageBackend(name).get());
-        if (erb) {
-            erb->SetCleanupCallback(nullptr);
+        auto backend = dsm->GetDataStorageBackend(name);
+        auto event_backend = std::dynamic_pointer_cast<EventReportBackend>(std::move(backend));
+        if (event_backend) {
+            event_backend->SetCleanupCallback(nullptr);
         }
     }
+}
+
+void CacheManager::DeactivateEventCleanupCallbacks() {
+    if (!event_cleanup_callback_state_) {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> callback_fence(event_cleanup_callback_state_->mutex);
+    event_cleanup_callback_state_->accepting = false;
+    ++event_cleanup_callback_state_->epoch;
+}
+
+void CacheManager::ActivateEventCleanupCallbacks() {
+    if (!event_cleanup_callback_state_) {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> callback_fence(event_cleanup_callback_state_->mutex);
+    event_cleanup_callback_state_->accepting = true;
 }
 
 ErrorCode CacheManager::DoCleanup() {
     ClearEventCleanupCallbacks();
     StopRecoverRetryLoop();
+    DeactivateEventCleanupCallbacks();
     // aborting write session need meta indexer
     if (write_location_manager_) {
         write_location_manager_->DoCleanup();
@@ -3815,7 +4111,7 @@ CheckLocDataExistFunc CacheManager::GetCheckLocDataExistFunc(const std::string &
         }
 
         if (IsEventReportStorageType(loc.type())) {
-            auto event_backend_holder = LookupEventReportBackend(registry_manager_, instance_id, loc.type());
+            auto event_backend_holder = LookupEventReportBackend(registry_manager_, instance_id, loc.type(), true);
             auto *event_backend = dynamic_cast<EventReportBackend *>(event_backend_holder.get());
             if (!event_backend || loc.type() != event_backend->GetStorageType()) {
                 return false;
@@ -3846,7 +4142,8 @@ CheckLocDataExistFunc CacheManager::GetCheckLocDataExistFunc(const std::string &
 
         const std::string storage_unique_name = storage_uris.front().GetHostName();
         const auto result = registry_manager_->data_storage_manager()->Exist(storage_unique_name, storage_uris, true);
-        return std::all_of(result.cbegin(), result.cend(), [](bool value) { return value; });
+        return result.size() == storage_uris.size() &&
+               std::all_of(result.cbegin(), result.cend(), [](bool value) { return value; });
     };
 }
 
@@ -3874,7 +4171,7 @@ CheckLocDataExistFunc CacheManager::GetHostCacheStateCheckLocDataExistFunc(const
         for (const auto &candidate_name : instance_group->event_report_storage_candidates()) {
             auto event_backend =
                 std::dynamic_pointer_cast<EventReportBackend>(storage_manager->GetDataStorageBackend(candidate_name));
-            if (!event_backend) {
+            if (!event_backend || !event_backend->Available()) {
                 continue;
             }
             const DataStorageType storage_type = event_backend->GetStorageType();
@@ -3977,7 +4274,7 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
                                           QueryTypeToString(query_type).c_str());
     }
 
-    PREFIX_LOG(INFO, "GetHostCacheState query_type [%s]", QueryTypeToString(query_type).c_str());
+    PREFIX_LOG(DEBUG, "GetHostCacheState query_type [%s]", QueryTypeToString(query_type).c_str());
 
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, request_key_count, block_cache_keys.size());
     auto query_scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(service_metrics_collector, ManagerPrefixMatch);

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -886,7 +886,12 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
 
     LocationsPerKey locations_per_key;
     ec = meta_searcher->BatchGetBestLocationByBackend(
-        request_context, query_keys, locations_per_key, policy.get(), backend_selectors);
+        request_context,
+        query_keys,
+        locations_per_key,
+        policy.get(),
+        backend_selectors,
+        location_spec_names);
     query_scope = ChronoScopeGuard{};
     // prefix_match_len: count keys with at least one hit (non-empty id).
     // Miss keys have empty CacheLocation objects with no id.

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1257,8 +1257,7 @@ void CacheManager::RollbackAddLocations(RequestContext *request_context,
                                                 false /* failed adds were never counted as new keys */);
             KeyVector deleted_metadata_keys;
             for (size_t i = 0; i < uncertain_indices.size(); ++i) {
-                if (i < delete_results.size() && delete_results[i].size() == 1 &&
-                    delete_results[i].front() == EC_OK) {
+                if (i < delete_results.size() && delete_results[i].size() == 1 && delete_results[i].front() == EC_OK) {
                     deleted_metadata_keys.push_back(uncertain_keys[i]);
                 }
             }
@@ -2899,11 +2898,15 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
 
             std::vector<ValidatedLocationSpec> specs;
             specs.reserve(params.specs_size());
-            std::unordered_set<std::string> seen_spec_names;
+            std::unordered_set<std::string_view> seen_spec_names;
+            if (params.specs_size() > 1) {
+                seen_spec_names.reserve(params.specs_size());
+            }
             for (const auto &spec : params.specs()) {
                 DataStorageUri parsed_uri(spec.uri());
-                if (spec.name().empty() || !seen_spec_names.insert(spec.name()).second || !parsed_uri.Valid() ||
-                    SnapshotUriUtils::HasEventReportInternalUriMetadata(parsed_uri)) {
+                if (spec.name().empty() ||
+                    (params.specs_size() > 1 && !seen_spec_names.insert(std::string_view(spec.name())).second) ||
+                    !parsed_uri.Valid() || SnapshotUriUtils::HasEventReportInternalUriMetadata(parsed_uri)) {
                     per_item_ec[i] = EC_BADARGS;
                     break;
                 }
@@ -2971,9 +2974,13 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            std::unordered_set<std::string> seen_spec_names;
+            std::unordered_set<std::string_view> seen_spec_names;
+            if (params.spec_names_size() > 1) {
+                seen_spec_names.reserve(params.spec_names_size());
+            }
             for (const auto &spec_name : params.spec_names()) {
-                if (spec_name.empty() || !seen_spec_names.insert(spec_name).second) {
+                if (spec_name.empty() ||
+                    (params.spec_names_size() > 1 && !seen_spec_names.insert(std::string_view(spec_name)).second)) {
                     per_item_ec[i] = EC_BADARGS;
                     break;
                 }
@@ -3035,11 +3042,15 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 }
                 std::vector<ValidatedLocationSpec> specs;
                 specs.reserve(block.specs_size());
-                std::unordered_set<std::string> seen_spec_names;
+                std::unordered_set<std::string_view> seen_spec_names;
+                if (block.specs_size() > 1) {
+                    seen_spec_names.reserve(block.specs_size());
+                }
                 for (const auto &spec : block.specs()) {
                     DataStorageUri parsed_uri(spec.uri());
-                    if (spec.name().empty() || !seen_spec_names.insert(spec.name()).second || !parsed_uri.Valid() ||
-                        SnapshotUriUtils::HasEventReportInternalUriMetadata(parsed_uri)) {
+                    if (spec.name().empty() ||
+                        (block.specs_size() > 1 && !seen_spec_names.insert(std::string_view(spec.name())).second) ||
+                        !parsed_uri.Valid() || SnapshotUriUtils::HasEventReportInternalUriMetadata(parsed_uri)) {
                         per_item_ec[i] = EC_BADARGS;
                         break;
                     }
@@ -3239,7 +3250,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
-    // MetaSearcher calls this once per metadata RMW phase, after its read and
+    // MetaSearcher calls this once after the fused target-location read and
     // before its first mutation. This removes the old per-key lock/allocation
     // amplification while preserving the window in which HOST_DOWN can fence
     // a request that is stalled in metadata I/O.

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -4174,7 +4174,8 @@ CheckLocDataExistFunc CacheManager::GetCheckLocDataExistFunc(const std::string &
     };
 }
 
-CheckLocDataExistFunc CacheManager::GetHostCacheStateCheckLocDataExistFunc(const std::string &instance_id) const {
+MetaSearcher::CheckHostCacheLocationFunc
+CacheManager::GetHostCacheStateCheckLocDataExistFunc(const std::string &instance_id) const {
     auto fallback = GetCheckLocDataExistFunc(instance_id);
     struct EventVisibilitySnapshot {
         std::shared_ptr<EventReportBackend> backend;
@@ -4214,7 +4215,9 @@ CheckLocDataExistFunc CacheManager::GetHostCacheStateCheckLocDataExistFunc(const
 
     return [fallback = std::move(fallback),
             event_snapshots = std::move(event_snapshots),
-            initialize_event_snapshots = std::move(initialize_event_snapshots)](const CacheLocation &location) -> bool {
+            initialize_event_snapshots = std::move(initialize_event_snapshots)](
+               const CacheLocation &location, MetaSearcher::HostCacheLocationInfo &out_info) -> bool {
+        out_info = {};
         if (!IsEventReportStorageType(location.type())) {
             return fallback ? fallback(location) : true;
         }
@@ -4235,8 +4238,17 @@ CheckLocDataExistFunc CacheManager::GetHostCacheStateCheckLocDataExistFunc(const
         if (reporter_it == snapshot_it->second.reporters.end()) {
             return false;
         }
-        return IsEventReportLocationReadable(
-            location, reporter_it->second.strict, reporter_it->second.committed_version);
+        if (!IsEventReportLocationReadable(
+                location, reporter_it->second.strict, reporter_it->second.committed_version)) {
+            return false;
+        }
+        // Return the identity parsed during visibility validation so host
+        // projection does not split the same location id again. URI validity
+        // was also checked above for every EventReport spec.
+        out_info.has_reporter_identity = true;
+        out_info.reporter_medium = std::move(reporter_medium);
+        out_info.reporter_host = std::move(reporter_host);
+        return true;
     };
 }
 
@@ -4305,17 +4317,13 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
 
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, request_key_count, block_cache_keys.size());
     auto query_scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(service_metrics_collector, ManagerPrefixMatch);
-    const auto request_check_loc_data_exist = GetHostCacheStateCheckLocDataExistFunc(instance_id);
+    const auto request_check_location = GetHostCacheStateCheckLocDataExistFunc(instance_id);
     std::vector<MetaSearcher::HostCacheMatch> host_matches;
     ErrorCode ec = EC_ERROR;
     switch (query_type) {
     case QueryType::QT_PREFIX_MATCH: {
-        ec = meta_searcher->PrefixMatchByHost(request_context,
-                                              block_cache_keys,
-                                              use_eagle_pop,
-                                              medium_filter,
-                                              host_matches,
-                                              &request_check_loc_data_exist);
+        ec = meta_searcher->PrefixMatchByHost(
+            request_context, block_cache_keys, use_eagle_pop, medium_filter, host_matches, &request_check_location);
         break;
     }
     case QueryType::QT_PREFIX_MATCH_WITH_MAMBA: {
@@ -4325,7 +4333,7 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
                                                        medium_filter,
                                                        instance_info->location_spec_groups(),
                                                        host_matches,
-                                                       &request_check_loc_data_exist);
+                                                       &request_check_location);
         break;
     }
     default:

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -886,12 +886,7 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
 
     LocationsPerKey locations_per_key;
     ec = meta_searcher->BatchGetBestLocationByBackend(
-        request_context,
-        query_keys,
-        locations_per_key,
-        policy.get(),
-        backend_selectors,
-        location_spec_names);
+        request_context, query_keys, locations_per_key, policy.get(), backend_selectors, location_spec_names);
     query_scope = ChronoScopeGuard{};
     // prefix_match_len: count keys with at least one hit (non-empty id).
     // Miss keys have empty CacheLocation objects with no id.
@@ -1582,6 +1577,7 @@ void CacheManager::FilterLocationSpecByName(CacheLocationVector &locations,
         // COW: copy, modify, replace
         auto new_loc = std::make_shared<CacheLocation>(*loc_ptr);
         new_loc->set_location_specs(std::move(new_specs));
+        new_loc->set_spec_size(new_loc->location_specs().size());
         loc_ptr = std::move(new_loc);
     }
 }
@@ -2603,6 +2599,37 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     }
     bool registration_applied = false;
     ErrorCode register_ec = EC_OK;
+    bool node_registration_ensured = false;
+    std::unordered_set<std::string> ensured_mediums;
+    auto ensure_node_medium = [&](const std::string &medium) {
+        if (node_registration_ensured && ensured_mediums.count(medium) > 0) {
+            return EC_OK;
+        }
+        const ErrorCode ec = event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {medium});
+        if (ec == EC_OK) {
+            node_registration_ensured = true;
+            ensured_mediums.insert(medium);
+        }
+        return ec;
+    };
+    auto ensure_node_mediums = [&](const std::vector<std::string> &mediums) {
+        std::vector<std::string> missing_mediums;
+        missing_mediums.reserve(mediums.size());
+        for (const auto &medium : mediums) {
+            if (ensured_mediums.count(medium) == 0) {
+                missing_mediums.push_back(medium);
+            }
+        }
+        if (node_registration_ensured && missing_mediums.empty()) {
+            return EC_OK;
+        }
+        const ErrorCode ec = event_backend->EnsureNodeRegistered(instance_id, host_ip_port, missing_mediums);
+        if (ec == EC_OK) {
+            node_registration_ensured = true;
+            ensured_mediums.insert(missing_mediums.begin(), missing_mediums.end());
+        }
+        return ec;
+    };
 
     struct BlockAddEntry {
         std::string location_id;
@@ -2659,6 +2686,8 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 register_ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
                 registration_applied = true;
                 if (register_ec == EC_OK) {
+                    node_registration_ensured = true;
+                    ensured_mediums.insert(register_mediums.begin(), register_mediums.end());
                     mutation_lifecycle_generation = event_backend->GetNodeGeneration(instance_id, host_ip_port);
                     delta_mutations.AdoptLifecycleGeneration(reporter_key, mutation_lifecycle_generation);
                 }
@@ -2713,8 +2742,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            const ErrorCode ensure_node_ec =
-                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {params.medium()});
+            const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
                 break;
@@ -2779,8 +2807,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            const ErrorCode ensure_node_ec =
-                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, {params.medium()});
+            const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
                 break;
@@ -2863,8 +2890,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                     snapshot_mediums.push_back(block.medium);
                 }
             }
-            const ErrorCode ensure_node_ec =
-                event_backend->EnsureNodeRegistered(instance_id, host_ip_port, snapshot_mediums);
+            const ErrorCode ensure_node_ec = ensure_node_mediums(snapshot_mediums);
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
                 break;
@@ -2946,6 +2972,17 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
+    // MetaSearcher calls this once per metadata RMW phase, after its read and
+    // before its first mutation. This removes the old per-key lock/allocation
+    // amplification while preserving the window in which HOST_DOWN can fence
+    // a request that is stalled in metadata I/O.
+    auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
+        EventReportBackend::LifecycleMutationLease lease;
+        const ErrorCode ec =
+            event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
+        return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
+    };
+
     if (!block_to_add.empty()) {
         KeyVector add_keys_aggr;
         std::vector<std::vector<BlockAddMergeEntry>> add_merged_entries_aggr;
@@ -2996,12 +3033,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
 
         std::vector<ErrorCode> per_key_ec;
-        auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
-            EventReportBackend::LifecycleMutationLease lease;
-            const ErrorCode ec =
-                event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
-            return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
-        };
         meta_searcher->BatchMergeLocationSpecs(
             request_context, add_keys_aggr, merge_tasks, per_key_ec, acquire_write_lease);
 
@@ -3063,12 +3094,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
             delete_target_count += delete_tasks[i].size();
         }
-        auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
-            EventReportBackend::LifecycleMutationLease lease;
-            const ErrorCode ec =
-                event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
-            return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
-        };
         meta_searcher->BatchDeleteLocationSpecs(request_context,
                                                 del_keys_aggr,
                                                 delete_tasks,
@@ -3142,12 +3167,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
 
         std::vector<ErrorCode> per_key_ec;
-        auto acquire_write_lease = [event_backend, reporter_key, mutation_lifecycle_generation] {
-            EventReportBackend::LifecycleMutationLease lease;
-            const ErrorCode ec =
-                event_backend->AcquireLifecycleMutationLease(reporter_key, mutation_lifecycle_generation, lease);
-            return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
-        };
         meta_searcher->BatchReplaceLocationSpecs(
             request_context, snapshot_keys, replace_tasks, per_key_ec, acquire_write_lease);
         for (size_t key_index = 0; key_index < snapshot_keys.size(); ++key_index) {

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -435,12 +435,25 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
                         uint32_t cache_reclaimer_idle_interval_ms,
                         uint32_t cache_reclaimer_worker_size,
                         CacheReclaimerAsyncDeleteConfig cache_reclaimer_async_delete_config,
-                        uint32_t schedule_plan_migration_worker_budget) {
+                        uint32_t schedule_plan_migration_worker_budget,
+                        uint32_t meta_query_worker_count,
+                        std::size_t meta_query_parallel_threshold,
+                        std::size_t meta_query_chunk_size) {
     if (schedule_plan_executor_thread_count <= 1 || schedule_plan_migration_worker_budget == 0 ||
         schedule_plan_migration_worker_budget >= static_cast<uint32_t>(schedule_plan_executor_thread_count)) {
         KVCM_LOG_ERROR("invalid schedule executor budget: worker_count=%d migration_worker_budget=%u",
                        schedule_plan_executor_thread_count,
                        schedule_plan_migration_worker_budget);
+        return false;
+    }
+    if (meta_query_worker_count == 0 || meta_query_worker_count > 64 || meta_query_parallel_threshold == 0 ||
+        meta_query_chunk_size == 0 || meta_query_chunk_size > meta_query_parallel_threshold ||
+        !meta_indexer_manager_->ConfigureQueryExecutor(
+            meta_query_worker_count, meta_query_parallel_threshold, meta_query_chunk_size)) {
+        KVCM_LOG_ERROR("invalid meta query executor config: workers=%u threshold=%zu chunk_size=%zu",
+                       meta_query_worker_count,
+                       meta_query_parallel_threshold,
+                       meta_query_chunk_size);
         return false;
     }
     schedule_plan_executor_ = std::make_shared<SchedulePlanExecutor>(schedule_plan_executor_thread_count,
@@ -3837,6 +3850,72 @@ CheckLocDataExistFunc CacheManager::GetCheckLocDataExistFunc(const std::string &
     };
 }
 
+CheckLocDataExistFunc CacheManager::GetHostCacheStateCheckLocDataExistFunc(const std::string &instance_id) const {
+    auto fallback = GetCheckLocDataExistFunc(instance_id);
+    struct EventVisibilitySnapshot {
+        std::shared_ptr<EventReportBackend> backend;
+        EventReportBackend::QueryVisibilitySnapshot reporters;
+    };
+    struct EventVisibilitySnapshots {
+        std::once_flag initialize_once;
+        std::map<DataStorageType, EventVisibilitySnapshot> by_storage_type;
+    };
+    auto event_snapshots = std::make_shared<EventVisibilitySnapshots>();
+    auto initialize_event_snapshots = [registry_manager = registry_manager_, instance_id, event_snapshots] {
+        if (!registry_manager || !registry_manager->data_storage_manager()) {
+            return;
+        }
+        const std::string group_name = registry_manager->GetInstanceGroupName(instance_id);
+        const auto instance_group = registry_manager->GetInstanceGroupConfig(group_name);
+        const auto storage_manager = registry_manager->data_storage_manager();
+        if (!instance_group || !storage_manager) {
+            return;
+        }
+        for (const auto &candidate_name : instance_group->event_report_storage_candidates()) {
+            auto event_backend =
+                std::dynamic_pointer_cast<EventReportBackend>(storage_manager->GetDataStorageBackend(candidate_name));
+            if (!event_backend) {
+                continue;
+            }
+            const DataStorageType storage_type = event_backend->GetStorageType();
+            if (event_snapshots->by_storage_type.find(storage_type) != event_snapshots->by_storage_type.end()) {
+                continue;
+            }
+            EventVisibilitySnapshot snapshot;
+            snapshot.backend = std::move(event_backend);
+            snapshot.backend->GetQueryVisibilitySnapshot(instance_id, snapshot.reporters);
+            event_snapshots->by_storage_type.emplace(storage_type, std::move(snapshot));
+        }
+    };
+
+    return [fallback = std::move(fallback),
+            event_snapshots = std::move(event_snapshots),
+            initialize_event_snapshots = std::move(initialize_event_snapshots)](const CacheLocation &location) -> bool {
+        if (!IsEventReportStorageType(location.type())) {
+            return fallback ? fallback(location) : true;
+        }
+        // Initialization is intentionally lazy: MetaSearcher reads metadata
+        // before invoking this callback, so the request-level liveness/version
+        // snapshot is taken after the potentially expensive metadata I/O.
+        std::call_once(event_snapshots->initialize_once, initialize_event_snapshots);
+        const auto snapshot_it = event_snapshots->by_storage_type.find(location.type());
+        if (snapshot_it == event_snapshots->by_storage_type.end() || !snapshot_it->second.backend) {
+            return false;
+        }
+        std::string reporter_medium;
+        std::string reporter_host;
+        if (!snapshot_it->second.backend->ParseLocationId(location.id(), reporter_medium, reporter_host)) {
+            return false;
+        }
+        const auto reporter_it = snapshot_it->second.reporters.find(reporter_host);
+        if (reporter_it == snapshot_it->second.reporters.end()) {
+            return false;
+        }
+        return IsEventReportLocationReadable(
+            location, reporter_it->second.strict, reporter_it->second.committed_version);
+    };
+}
+
 SubmitDelReqFunc CacheManager::GetSubmitDelReqFunc(const std::string &instance_id) const {
     return [this, instance_id](const std::vector<std::int64_t> &blk_keys,
                                const std::vector<std::vector<std::string>> &loc_ids,
@@ -3902,12 +3981,17 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
 
     KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, request_key_count, block_cache_keys.size());
     auto query_scope = KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(service_metrics_collector, ManagerPrefixMatch);
+    const auto request_check_loc_data_exist = GetHostCacheStateCheckLocDataExistFunc(instance_id);
     std::vector<MetaSearcher::HostCacheMatch> host_matches;
     ErrorCode ec = EC_ERROR;
     switch (query_type) {
     case QueryType::QT_PREFIX_MATCH: {
-        ec = meta_searcher->PrefixMatchByHost(
-            request_context, block_cache_keys, use_eagle_pop, medium_filter, host_matches);
+        ec = meta_searcher->PrefixMatchByHost(request_context,
+                                              block_cache_keys,
+                                              use_eagle_pop,
+                                              medium_filter,
+                                              host_matches,
+                                              &request_check_loc_data_exist);
         break;
     }
     case QueryType::QT_PREFIX_MATCH_WITH_MAMBA: {
@@ -3916,7 +4000,8 @@ CacheManager::GetHostCacheState(RequestContext *request_context,
                                                        use_eagle_pop,
                                                        medium_filter,
                                                        instance_info->location_spec_groups(),
-                                                       host_matches);
+                                                       host_matches,
+                                                       &request_check_loc_data_exist);
         break;
     }
     default:

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -2783,25 +2783,9 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         return ec;
     };
 
-    struct BlockAddEntry {
-        std::string location_id;
-        std::vector<LocationSpec> specs;
-        int event_index;
-    };
-    struct BlockAddMergeEntry {
-        std::string location_id;
-        std::vector<LocationSpec> specs;
-        std::vector<int> event_indices;
-    };
-    struct BlockDelEntry {
-        std::string location_id;
-        std::vector<std::string> spec_names;
-        int event_index;
-    };
-    struct BlockDelMergeEntry {
-        std::string location_id;
-        std::vector<std::string> spec_names;
-        std::vector<int> event_indices;
+    struct ValidatedLocationSpec {
+        std::string name;
+        DataStorageUri uri;
     };
     struct SnapshotReplaceEntry {
         std::string location_id;
@@ -2817,16 +2801,54 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     struct DeltaSpecMutation {
         bool is_add = false;
         LocationSpec spec;
-        std::vector<int> event_indices;
     };
-    std::map<int64_t, std::vector<BlockAddEntry>> block_to_add;
-    std::map<int64_t, std::vector<BlockDelEntry>> block_to_del;
-    std::map<int64_t, std::map<std::string, std::map<std::string, DeltaSpecMutation>>> delta_spec_mutations;
-    // Events touching one stable block/location form a retry dependency
-    // group. ADD and DELETE are persisted in separate phases; if either
-    // phase fails, every event in the group must be retried in request order
-    // to preserve last-operation-wins semantics.
-    std::map<int64_t, std::map<std::string, std::set<int>>> delta_retry_groups;
+    struct DeltaEventMutation {
+        int event_index = 0;
+        bool materialized = false;
+    };
+    struct DeltaLocationMutation {
+        std::string location_id;
+        std::vector<DeltaSpecMutation> spec_mutations;
+        // Structurally valid events in request order. ADD and DELETE are
+        // persisted in separate phases; if either phase fails, every event
+        // touching this stable block/location must be retried together.
+        std::vector<DeltaEventMutation> events;
+    };
+    struct DeltaBlockMutation {
+        int64_t block_key = 0;
+        std::vector<DeltaLocationMutation> locations;
+    };
+    std::unordered_map<int64_t, DeltaBlockMutation> delta_mutations_by_block;
+    delta_mutations_by_block.reserve(events_size);
+    auto record_delta_event = [&delta_mutations_by_block](int64_t block_key,
+                                                          const std::string &location_id,
+                                                          int event_index) -> DeltaLocationMutation & {
+        auto [block_it, inserted] = delta_mutations_by_block.try_emplace(block_key);
+        if (inserted) {
+            block_it->second.block_key = block_key;
+        }
+        auto &locations = block_it->second.locations;
+        auto location_it = std::find_if(locations.begin(), locations.end(), [&location_id](const auto &entry) {
+            return entry.location_id == location_id;
+        });
+        if (location_it == locations.end()) {
+            locations.push_back(DeltaLocationMutation{location_id});
+            location_it = std::prev(locations.end());
+        }
+        location_it->events.push_back(DeltaEventMutation{event_index, false});
+        return *location_it;
+    };
+    auto apply_delta_spec = [](DeltaLocationMutation &location, bool is_add, LocationSpec spec) {
+        auto mutation_it = std::find_if(location.spec_mutations.begin(),
+                                        location.spec_mutations.end(),
+                                        [&spec](const auto &mutation) { return mutation.spec.name() == spec.name(); });
+        if (mutation_it == location.spec_mutations.end()) {
+            location.spec_mutations.push_back(DeltaSpecMutation{is_add, std::move(spec)});
+            return;
+        }
+        mutation_it->is_add = is_add;
+        mutation_it->spec = std::move(spec);
+    };
     std::map<int64_t, std::vector<SnapshotReplaceEntry>> snapshot_to_replace;
     std::vector<SnapshotCommitTask> snapshot_commit_tasks;
     std::string request_snapshot_version;
@@ -2888,17 +2910,17 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 break;
             }
 
-            std::vector<LocationSpec> specs;
+            std::vector<ValidatedLocationSpec> specs;
             specs.reserve(params.specs_size());
             std::unordered_set<std::string> seen_spec_names;
             for (const auto &spec : params.specs()) {
-                const DataStorageUri parsed_uri(spec.uri());
+                DataStorageUri parsed_uri(spec.uri());
                 if (spec.name().empty() || !seen_spec_names.insert(spec.name()).second || !parsed_uri.Valid() ||
                     SnapshotUriUtils::HasEventReportInternalUriMetadata(parsed_uri)) {
                     per_item_ec[i] = EC_BADARGS;
                     break;
                 }
-                specs.emplace_back(spec.name(), spec.uri());
+                specs.push_back(ValidatedLocationSpec{spec.name(), std::move(parsed_uri)});
             }
             if (per_item_ec[i] != EC_OK) {
                 break;
@@ -2910,7 +2932,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             // REGISTER and a later related mutation). In that case a later
             // success must also be retried, otherwise retrying only the early
             // failed item could reverse the request's final operation order.
-            delta_retry_groups[block_key][location_id].insert(i);
+            auto &location_mutation = record_delta_event(block_key, location_id, i);
             const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
@@ -2928,26 +2950,26 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (created_generation) {
                 request_created_generation = true;
             }
+            std::vector<LocationSpec> versioned_specs;
+            versioned_specs.reserve(specs.size());
             for (auto &spec : specs) {
                 std::string versioned_uri;
-                if (!SnapshotUriUtils::AddSnapshotVersionToUri(spec.uri(), committed_version, versioned_uri)) {
+                if (!SnapshotUriUtils::AddSnapshotVersionToUri(std::move(spec.uri), committed_version, versioned_uri)) {
                     per_item_ec[i] = EC_BADARGS;
                     break;
                 }
-                spec.set_uri(std::move(versioned_uri));
+                LocationSpec versioned_spec;
+                versioned_spec.set_name(std::move(spec.name));
+                versioned_spec.set_uri(std::move(versioned_uri));
+                versioned_specs.push_back(std::move(versioned_spec));
             }
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
-            auto &mutations_by_name = delta_spec_mutations[block_key][location_id];
-            for (auto &spec : specs) {
-                auto &mutation = mutations_by_name[spec.name()];
-                mutation.is_add = true;
-                mutation.spec = std::move(spec);
-                if (mutation.event_indices.empty() || mutation.event_indices.back() != i) {
-                    mutation.event_indices.push_back(i);
-                }
+            for (auto &spec : versioned_specs) {
+                apply_delta_spec(location_mutation, true, std::move(spec));
             }
+            location_mutation.events.back().materialized = true;
             break;
         }
         case proto::meta::EVENT_BLOCK_DELETE: {
@@ -2962,21 +2984,18 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            std::vector<std::string> spec_names;
-            spec_names.reserve(params.spec_names_size());
             std::unordered_set<std::string> seen_spec_names;
             for (const auto &spec_name : params.spec_names()) {
                 if (spec_name.empty() || !seen_spec_names.insert(spec_name).second) {
                     per_item_ec[i] = EC_BADARGS;
                     break;
                 }
-                spec_names.push_back(spec_name);
             }
             if (per_item_ec[i] != EC_OK) {
                 break;
             }
             const std::string location_id = event_backend->BuildLocationId(params.medium(), host_ip_port);
-            delta_retry_groups[block_key][location_id].insert(i);
+            auto &location_mutation = record_delta_event(block_key, location_id, i);
             const ErrorCode ensure_node_ec = ensure_node_medium(params.medium());
             if (ensure_node_ec != EC_OK) {
                 per_item_ec[i] = ensure_node_ec;
@@ -2994,14 +3013,10 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (created_generation) {
                 request_created_generation = true;
             }
-            auto &mutations_by_name = delta_spec_mutations[block_key][location_id];
-            for (auto &spec_name : spec_names) {
-                auto &mutation = mutations_by_name[spec_name];
-                mutation.is_add = false;
-                if (mutation.event_indices.empty() || mutation.event_indices.back() != i) {
-                    mutation.event_indices.push_back(i);
-                }
+            for (const auto &spec_name : params.spec_names()) {
+                apply_delta_spec(location_mutation, false, LocationSpec(spec_name, ""));
             }
+            location_mutation.events.back().materialized = true;
             break;
         }
         case proto::meta::EVENT_BLOCK_SNAPSHOT: {
@@ -3013,7 +3028,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             struct ValidatedBlock {
                 int64_t block_key;
                 std::string medium;
-                std::vector<LocationSpec> specs;
+                std::vector<ValidatedLocationSpec> specs;
             };
             std::vector<ValidatedBlock> validated_blocks;
             validated_blocks.reserve(params.blocks_size());
@@ -3031,17 +3046,17 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                     per_item_ec[i] = EC_BADARGS;
                     break;
                 }
-                std::vector<LocationSpec> specs;
+                std::vector<ValidatedLocationSpec> specs;
                 specs.reserve(block.specs_size());
                 std::unordered_set<std::string> seen_spec_names;
                 for (const auto &spec : block.specs()) {
-                    const DataStorageUri parsed_uri(spec.uri());
+                    DataStorageUri parsed_uri(spec.uri());
                     if (spec.name().empty() || !seen_spec_names.insert(spec.name()).second || !parsed_uri.Valid() ||
                         SnapshotUriUtils::HasEventReportInternalUriMetadata(parsed_uri)) {
                         per_item_ec[i] = EC_BADARGS;
                         break;
                     }
-                    specs.emplace_back(spec.name(), spec.uri());
+                    specs.push_back(ValidatedLocationSpec{spec.name(), std::move(parsed_uri)});
                 }
                 if (per_item_ec[i] != EC_OK) {
                     break;
@@ -3079,20 +3094,25 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
 
             for (auto &block : validated_blocks) {
+                std::vector<LocationSpec> versioned_specs;
+                versioned_specs.reserve(block.specs.size());
                 for (auto &spec : block.specs) {
                     std::string versioned_uri;
                     if (!SnapshotUriUtils::AddSnapshotVersionToUri(
-                            spec.uri(), request_snapshot_version, versioned_uri)) {
+                            std::move(spec.uri), request_snapshot_version, versioned_uri)) {
                         per_item_ec[i] = EC_BADARGS;
                         break;
                     }
-                    spec.set_uri(std::move(versioned_uri));
+                    LocationSpec versioned_spec;
+                    versioned_spec.set_name(std::move(spec.name));
+                    versioned_spec.set_uri(std::move(versioned_uri));
+                    versioned_specs.push_back(std::move(versioned_spec));
                 }
                 if (per_item_ec[i] != EC_OK) {
                     break;
                 }
                 snapshot_to_replace[block.block_key].push_back(SnapshotReplaceEntry{
-                    event_backend->BuildLocationId(block.medium, host_ip_port), std::move(block.specs), i});
+                    event_backend->BuildLocationId(block.medium, host_ip_port), std::move(versioned_specs), i});
             }
             if (per_item_ec[i] != EC_OK) {
                 event_backend->AbortSnapshotVersion(reporter_key, request_snapshot_version);
@@ -3110,26 +3130,111 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
-    // A request is an ordered event stream. Resolve repeated mutations of the
-    // same (block, stable location, spec name) by keeping the last operation,
-    // then batch the disjoint final ADD and DELETE sets. All original events
-    // absorbed into one final mutation share that mutation's write result:
-    // none of the intermediate operations is persisted independently. This
-    // preserves request order without giving up batched metadata writes.
-    for (auto &[block_key, mutations_by_location] : delta_spec_mutations) {
-        for (auto &[location_id, mutations_by_name] : mutations_by_location) {
-            for (auto &[spec_name, mutation] : mutations_by_name) {
-                for (const int event_index : mutation.event_indices) {
-                    delta_retry_groups[block_key][location_id].insert(event_index);
-                    if (mutation.is_add) {
-                        block_to_add[block_key].push_back(BlockAddEntry{location_id, {mutation.spec}, event_index});
-                    } else {
-                        block_to_del[block_key].push_back(BlockDelEntry{location_id, {spec_name}, event_index});
+    // A request is an ordered event stream. Each flat location/spec vector is
+    // updated in place while parsing, so repeated mutations retain only their
+    // last operation without allocating nested map nodes. Build the final
+    // MetaSearcher tasks directly from that folded state; the old
+    // delta_spec_mutations -> block entries -> merged entries -> tasks copy
+    // chain scaled with every original event even though only the final state
+    // is persisted.
+    std::vector<DeltaBlockMutation *> ordered_delta_blocks;
+    ordered_delta_blocks.reserve(delta_mutations_by_block.size());
+    for (auto &[block_key, block] : delta_mutations_by_block) {
+        (void)block_key;
+        ordered_delta_blocks.push_back(&block);
+    }
+    std::sort(ordered_delta_blocks.begin(), ordered_delta_blocks.end(), [](const auto *lhs, const auto *rhs) {
+        return lhs->block_key < rhs->block_key;
+    });
+
+    KeyVector add_keys_aggr;
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks;
+    std::vector<DeltaBlockMutation *> add_delta_blocks;
+    KeyVector del_keys_aggr;
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks;
+    std::vector<DeltaBlockMutation *> del_delta_blocks;
+    add_keys_aggr.reserve(ordered_delta_blocks.size());
+    merge_tasks.reserve(ordered_delta_blocks.size());
+    add_delta_blocks.reserve(ordered_delta_blocks.size());
+    del_keys_aggr.reserve(ordered_delta_blocks.size());
+    delete_tasks.reserve(ordered_delta_blocks.size());
+    del_delta_blocks.reserve(ordered_delta_blocks.size());
+
+    for (auto *block : ordered_delta_blocks) {
+        std::sort(block->locations.begin(), block->locations.end(), [](const auto &lhs, const auto &rhs) {
+            return lhs.location_id < rhs.location_id;
+        });
+        std::vector<MetaSearcher::MergeLocationSpecsTask> block_add_tasks;
+        std::vector<MetaSearcher::DeleteLocationSpecsTask> block_delete_tasks;
+        block_add_tasks.reserve(block->locations.size());
+        block_delete_tasks.reserve(block->locations.size());
+        for (auto &location : block->locations) {
+            std::sort(location.spec_mutations.begin(),
+                      location.spec_mutations.end(),
+                      [](const auto &lhs, const auto &rhs) { return lhs.spec.name() < rhs.spec.name(); });
+            MetaSearcher::MergeLocationSpecsTask add_task{
+                location.location_id,
+                event_backend->GetStorageType(),
+                CacheLocationStatus::CLS_SERVING,
+                {},
+            };
+            MetaSearcher::DeleteLocationSpecsTask delete_task{location.location_id, {}};
+            add_task.specs.reserve(location.spec_mutations.size());
+            delete_task.spec_names.reserve(location.spec_mutations.size());
+            for (auto &mutation : location.spec_mutations) {
+                if (mutation.is_add) {
+                    add_task.specs.push_back(std::move(mutation.spec));
+                } else {
+                    delete_task.spec_names.push_back(mutation.spec.name());
+                }
+            }
+            if (!add_task.specs.empty()) {
+                block_add_tasks.push_back(std::move(add_task));
+            }
+            if (!delete_task.spec_names.empty()) {
+                block_delete_tasks.push_back(std::move(delete_task));
+            }
+        }
+        if (!block_add_tasks.empty()) {
+            add_keys_aggr.push_back(block->block_key);
+            merge_tasks.push_back(std::move(block_add_tasks));
+            add_delta_blocks.push_back(block);
+        }
+        if (!block_delete_tasks.empty()) {
+            del_keys_aggr.push_back(block->block_key);
+            delete_tasks.push_back(std::move(block_delete_tasks));
+            del_delta_blocks.push_back(block);
+        }
+    }
+
+    auto mark_delta_phase_failure =
+        [&per_item_ec, request](const DeltaBlockMutation &block, ErrorCode ec, const auto &spec_participates) {
+            for (const auto &location : block.locations) {
+                for (const auto &event_ref : location.events) {
+                    if (!event_ref.materialized || per_item_ec[event_ref.event_index] != EC_OK) {
+                        continue;
+                    }
+                    const auto &event = request->events(event_ref.event_index);
+                    bool participates = false;
+                    if (event.event_type() == proto::meta::EVENT_BLOCK_ADD && event.has_block_add()) {
+                        participates = std::any_of(event.block_add().specs().begin(),
+                                                   event.block_add().specs().end(),
+                                                   [&spec_participates, &location](const auto &spec) {
+                                                       return spec_participates(location.location_id, spec.name());
+                                                   });
+                    } else if (event.event_type() == proto::meta::EVENT_BLOCK_DELETE && event.has_block_delete()) {
+                        participates = std::any_of(event.block_delete().spec_names().begin(),
+                                                   event.block_delete().spec_names().end(),
+                                                   [&spec_participates, &location](const auto &spec_name) {
+                                                       return spec_participates(location.location_id, spec_name);
+                                                   });
+                    }
+                    if (participates) {
+                        per_item_ec[event_ref.event_index] = ec;
                     }
                 }
             }
-        }
-    }
+        };
 
     if (has_heartbeat) {
         const ErrorCode ec = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
@@ -3158,55 +3263,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         return std::make_pair(ec, std::static_pointer_cast<void>(std::move(lease)));
     };
 
-    if (!block_to_add.empty()) {
-        KeyVector add_keys_aggr;
-        std::vector<std::vector<BlockAddMergeEntry>> add_merged_entries_aggr;
-        add_keys_aggr.reserve(block_to_add.size());
-        add_merged_entries_aggr.reserve(block_to_add.size());
-        for (const auto &kv : block_to_add) {
-            add_keys_aggr.push_back(kv.first);
-
-            std::map<std::string, std::map<std::string, LocationSpec>> specs_by_location;
-            std::map<std::string, std::vector<int>> event_indices_by_location;
-            for (const auto &entry : kv.second) {
-                auto &specs_by_name = specs_by_location[entry.location_id];
-                for (const auto &spec : entry.specs) {
-                    specs_by_name[spec.name()] = spec;
-                }
-                event_indices_by_location[entry.location_id].push_back(entry.event_index);
-            }
-
-            auto &merged_entries = add_merged_entries_aggr.emplace_back();
-            merged_entries.reserve(specs_by_location.size());
-            for (auto &[location_id, specs_by_name] : specs_by_location) {
-                BlockAddMergeEntry merged_entry;
-                auto event_indices_it = event_indices_by_location.find(location_id);
-                if (event_indices_it != event_indices_by_location.end()) {
-                    merged_entry.event_indices = std::move(event_indices_it->second);
-                }
-                merged_entry.location_id = location_id;
-                merged_entry.specs.reserve(specs_by_name.size());
-                for (auto &[spec_name, spec] : specs_by_name) {
-                    merged_entry.specs.push_back(std::move(spec));
-                }
-                merged_entries.push_back(std::move(merged_entry));
-            }
-        }
-
-        std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks(add_keys_aggr.size());
-        for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
-            const auto &entries = add_merged_entries_aggr[i];
-            merge_tasks[i].reserve(entries.size());
-            for (const auto &entry : entries) {
-                merge_tasks[i].push_back(MetaSearcher::MergeLocationSpecsTask{
-                    entry.location_id,
-                    event_backend->GetStorageType(),
-                    CacheLocationStatus::CLS_SERVING,
-                    entry.specs,
-                });
-            }
-        }
-
+    if (!add_keys_aggr.empty()) {
         std::vector<ErrorCode> per_key_ec;
         meta_searcher->BatchMergeLocationSpecs(
             request_context, add_keys_aggr, merge_tasks, per_key_ec, acquire_write_lease);
@@ -3216,58 +3273,26 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (key_ec == EC_OK) {
                 continue;
             }
-            for (const auto &entry : add_merged_entries_aggr[k]) {
-                for (int event_index : entry.event_indices) {
-                    if (per_item_ec[event_index] == EC_OK) {
-                        per_item_ec[event_index] = key_ec;
-                    }
-                }
-            }
+            const auto &tasks = merge_tasks[k];
+            mark_delta_phase_failure(
+                *add_delta_blocks[k], key_ec, [&tasks](const std::string &location_id, const std::string &spec_name) {
+                    const auto task = std::find_if(tasks.begin(), tasks.end(), [&location_id](const auto &candidate) {
+                        return candidate.location_id == location_id;
+                    });
+                    return task != tasks.end() &&
+                           std::any_of(task->specs.begin(), task->specs.end(), [&spec_name](const auto &spec) {
+                               return spec.name() == spec_name;
+                           });
+                });
         }
     }
 
-    if (!block_to_del.empty()) {
-        KeyVector del_keys_aggr;
-        std::vector<std::vector<BlockDelMergeEntry>> del_merged_entries_aggr;
-        del_keys_aggr.reserve(block_to_del.size());
-        del_merged_entries_aggr.reserve(block_to_del.size());
-        for (const auto &kv : block_to_del) {
-            del_keys_aggr.push_back(kv.first);
-
-            std::map<std::string, std::set<std::string>> spec_names_by_location;
-            std::map<std::string, std::vector<int>> event_indices_by_location;
-            for (const auto &entry : kv.second) {
-                event_indices_by_location[entry.location_id].push_back(entry.event_index);
-                auto &spec_names = spec_names_by_location[entry.location_id];
-                spec_names.insert(entry.spec_names.begin(), entry.spec_names.end());
-            }
-
-            auto &merged_entries = del_merged_entries_aggr.emplace_back();
-            merged_entries.reserve(event_indices_by_location.size());
-            for (auto &[location_id, event_indices] : event_indices_by_location) {
-                BlockDelMergeEntry merged_entry;
-                merged_entry.location_id = location_id;
-                merged_entry.event_indices = std::move(event_indices);
-                const auto &spec_names = spec_names_by_location[location_id];
-                merged_entry.spec_names.assign(spec_names.begin(), spec_names.end());
-                merged_entries.push_back(std::move(merged_entry));
-            }
-        }
-
+    if (!del_keys_aggr.empty()) {
         std::vector<std::vector<ErrorCode>> per_location_ec;
         std::vector<std::vector<bool>> missing_delete_targets;
-        std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks(del_keys_aggr.size());
         size_t delete_target_count = 0;
-        for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
-            const auto &entries = del_merged_entries_aggr[i];
-            delete_tasks[i].reserve(entries.size());
-            for (const auto &entry : entries) {
-                delete_tasks[i].push_back(MetaSearcher::DeleteLocationSpecsTask{
-                    entry.location_id,
-                    entry.spec_names,
-                });
-            }
-            delete_target_count += delete_tasks[i].size();
+        for (const auto &tasks : delete_tasks) {
+            delete_target_count += tasks.size();
         }
         meta_searcher->BatchDeleteLocationSpecs(request_context,
                                                 del_keys_aggr,
@@ -3278,7 +3303,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
 
         for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
             ErrorCode key_ec = EC_OK;
-            if (k < per_location_ec.size() && per_location_ec[k].size() == del_merged_entries_aggr[k].size()) {
+            if (k < per_location_ec.size() && per_location_ec[k].size() == delete_tasks[k].size()) {
                 for (const auto &loc_ec : per_location_ec[k]) {
                     if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
                         key_ec = loc_ec;
@@ -3291,13 +3316,16 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             if (key_ec == EC_OK) {
                 continue;
             }
-            for (const auto &entry : del_merged_entries_aggr[k]) {
-                for (int event_index : entry.event_indices) {
-                    if (per_item_ec[event_index] == EC_OK) {
-                        per_item_ec[event_index] = key_ec;
-                    }
-                }
-            }
+            const auto &tasks = delete_tasks[k];
+            mark_delta_phase_failure(
+                *del_delta_blocks[k], key_ec, [&tasks](const std::string &location_id, const std::string &spec_name) {
+                    const auto task = std::find_if(tasks.begin(), tasks.end(), [&location_id](const auto &candidate) {
+                        return candidate.location_id == location_id;
+                    });
+                    return task != tasks.end() &&
+                           std::find(task->spec_names.begin(), task->spec_names.end(), spec_name) !=
+                               task->spec_names.end();
+                });
         }
         size_t missing_block_count = 0;
         for (const auto &missing_per_key : missing_delete_targets) {
@@ -3473,23 +3501,22 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
-    for (const auto &[block_key, groups_by_location] : delta_retry_groups) {
+    for (const auto &[block_key, block] : delta_mutations_by_block) {
         (void)block_key;
-        for (const auto &[location_id, event_indices] : groups_by_location) {
-            (void)location_id;
+        for (const auto &location : block.locations) {
             ErrorCode group_failure = EC_OK;
-            for (const int event_index : event_indices) {
-                if (per_item_ec[event_index] != EC_OK) {
-                    group_failure = per_item_ec[event_index];
+            for (const auto &event_ref : location.events) {
+                if (per_item_ec[event_ref.event_index] != EC_OK) {
+                    group_failure = per_item_ec[event_ref.event_index];
                     break;
                 }
             }
             if (group_failure == EC_OK) {
                 continue;
             }
-            for (const int event_index : event_indices) {
-                if (per_item_ec[event_index] == EC_OK) {
-                    per_item_ec[event_index] = group_failure;
+            for (const auto &event_ref : location.events) {
+                if (per_item_ec[event_ref.event_index] == EC_OK) {
+                    per_item_ec[event_ref.event_index] = group_failure;
                 }
             }
         }

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -2523,26 +2523,13 @@ bool IsEventReportLocationReadable(const CacheLocation &location,
     }
     bool contains_readable_version = !strict_query_visibility;
     for (const auto &spec : location.location_specs()) {
-        const DataStorageUri uri(spec.uri());
-        if (!uri.Valid()) {
+        std::string_view snapshot_version;
+        if (!SnapshotUriUtils::InspectSnapshotUriForVisibility(spec.uri(), snapshot_version)) {
             return false;
         }
-        const size_t version_param_count =
-            SnapshotUriUtils::CountUriParam(spec.uri(), SnapshotUriUtils::kSnapshotVersionParam);
-        if (version_param_count > 1) {
-            return false;
-        }
-        if (version_param_count == 1) {
-            SnapshotUriInfo info;
-            // Count on the raw text first so duplicate parameters remain
-            // observable, then reuse the parsed URI instead of parsing it a
-            // second time on every query.
-            if (!SnapshotUriUtils::ParseSnapshotUriInfo(uri, info)) {
-                return false;
-            }
-            if (strict_query_visibility && info.version == committed_version) {
-                contains_readable_version = true;
-            }
+        if (!snapshot_version.empty() && strict_query_visibility &&
+            snapshot_version == std::string_view(committed_version)) {
+            contains_readable_version = true;
         }
     }
     // Delta merge is spec-granular. A post-snapshot ADD may refresh one spec

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -39,6 +40,9 @@ struct MetricsLifecycle;
 class MigrationManager;
 constexpr unsigned int DEFAULT_SCHEDULE_PLAN_EXECUTOR_THREAD_COUNT = 2;
 constexpr unsigned int DEFAULT_SCHEDULE_PLAN_MIGRATION_WORKER_BUDGET = 1;
+constexpr unsigned int DEFAULT_META_QUERY_WORKER_COUNT = 4;
+constexpr std::size_t DEFAULT_META_QUERY_PARALLEL_THRESHOLD = 256;
+constexpr std::size_t DEFAULT_META_QUERY_CHUNK_SIZE = 128;
 
 class CacheManager {
     // TODO should not public
@@ -88,7 +92,10 @@ public:
               uint32_t cache_reclaimer_idle_interval_ms = 100,
               uint32_t cache_reclaimer_worker_size = 16,
               CacheReclaimerAsyncDeleteConfig cache_reclaimer_async_delete_config = {},
-              uint32_t schedule_plan_migration_worker_budget = DEFAULT_SCHEDULE_PLAN_MIGRATION_WORKER_BUDGET);
+              uint32_t schedule_plan_migration_worker_budget = DEFAULT_SCHEDULE_PLAN_MIGRATION_WORKER_BUDGET,
+              uint32_t meta_query_worker_count = DEFAULT_META_QUERY_WORKER_COUNT,
+              std::size_t meta_query_parallel_threshold = DEFAULT_META_QUERY_PARALLEL_THRESHOLD,
+              std::size_t meta_query_chunk_size = DEFAULT_META_QUERY_CHUNK_SIZE);
     ErrorCode DoRecover();
     ErrorCode DoRecoverOnce();
     void StartRecoverRetryLoop();
@@ -340,6 +347,7 @@ private:
     std::unique_ptr<SelectLocationPolicy> genSelectLocationPolicy(RequestContext *request_context,
                                                                   const std::string &instance_id) const;
     CheckLocDataExistFunc GetCheckLocDataExistFunc(const std::string &instance_id) const;
+    CheckLocDataExistFunc GetHostCacheStateCheckLocDataExistFunc(const std::string &instance_id) const;
     SubmitDelReqFunc GetSubmitDelReqFunc(const std::string &instance_id) const;
     void ClearEventCleanupCallbacks();
 

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -359,7 +359,8 @@ private:
     std::unique_ptr<SelectLocationPolicy> genSelectLocationPolicy(RequestContext *request_context,
                                                                   const std::string &instance_id) const;
     CheckLocDataExistFunc GetCheckLocDataExistFunc(const std::string &instance_id) const;
-    CheckLocDataExistFunc GetHostCacheStateCheckLocDataExistFunc(const std::string &instance_id) const;
+    MetaSearcher::CheckHostCacheLocationFunc
+    GetHostCacheStateCheckLocDataExistFunc(const std::string &instance_id) const;
     SubmitDelReqFunc GetSubmitDelReqFunc(const std::string &instance_id) const;
     void ClearEventCleanupCallbacks();
     void DeactivateEventCleanupCallbacks();

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -237,6 +238,15 @@ public:
     void SetRevisitHistogramConfig(const std::vector<double> &boundaries);
 
 private:
+    struct EventCleanupCallbackState {
+        std::shared_mutex mutex;
+        bool accepting = true;
+        // Advances whenever cleanup is deactivated. A task admitted before a
+        // leader cleanup must stay stale even if the same CacheManager is later
+        // activated again during recovery.
+        uint64_t epoch = 1;
+    };
+
     ErrorCode FilterWriteCache(RequestContext *request_context,
                                const std::string &instance_id,
                                MetaSearcher *meta_searcher,
@@ -319,12 +329,14 @@ private:
     void CleanupHostLocations(const std::string &instance_id,
                               const std::string &host_ip_port,
                               uint64_t cleanup_generation,
-                              DataStorageType storage_type);
+                              DataStorageType storage_type,
+                              const std::shared_ptr<EventReportBackend> &expected_backend);
     ErrorCode CleanupStaleSnapshotLocations(const ReporterSnapshotKey &reporter_key,
                                             const std::string &snapshot_version,
                                             DataStorageType storage_type,
                                             const std::shared_ptr<EventReportBackend> &event_backend,
-                                            uint64_t snapshot_attempt_epoch = 0);
+                                            uint64_t snapshot_attempt_epoch = 0,
+                                            uint64_t lifecycle_generation = 0);
     ErrorCode GetCacheLocationByQueryType(MetaSearcher *meta_searcher,
                                           RequestContext *request_context,
                                           const std::string &instance_id,
@@ -350,6 +362,8 @@ private:
     CheckLocDataExistFunc GetHostCacheStateCheckLocDataExistFunc(const std::string &instance_id) const;
     SubmitDelReqFunc GetSubmitDelReqFunc(const std::string &instance_id) const;
     void ClearEventCleanupCallbacks();
+    void DeactivateEventCleanupCallbacks();
+    void ActivateEventCleanupCallbacks();
 
     // purge metrics registry entries and invoke the removal callback
     // for a given instance_id
@@ -388,6 +402,11 @@ private:
     std::shared_ptr<EventManager> event_manager_;
     // 无需清理
     std::shared_ptr<MetricsLifecycle> metrics_lifecycle_;
+    // EventReportBackend owns a callback that cannot retain CacheManager.
+    // This separate gate lets destruction drain a callback copy that was
+    // already taken by the liveness thread and reject copies invoked later.
+    std::shared_ptr<EventCleanupCallbackState> event_cleanup_callback_state_ =
+        std::make_shared<EventCleanupCallbackState>();
     // 需要清理 - 避免有metrics遗留
     std::shared_ptr<CacheManagerMetricsRecorder> metrics_recorder_;
     // 无需清理

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -316,12 +316,11 @@ bool IsMediumMatched(const StandardUri &uri, const std::unordered_set<std::strin
 using HostToSpecNames = std::map<std::string, std::set<std::string>>;
 using KeyToHostSpecNames = std::vector<HostToSpecNames>; // key -> host -> spec names
 
-void BuildHostSpecNamesForOneKey(const CacheLocationMap &location_map,
-                                 CheckLocDataExistFunc check_loc_data_exist,
+void BuildHostSpecNamesForOneKey(const CacheLocationVector &locations,
+                                 const CheckLocDataExistFunc &check_loc_data_exist,
                                  const std::unordered_set<std::string> &medium_set,
                                  HostToSpecNames &host_specs) {
-    for (const auto &kv : location_map) {
-        const auto &loc = kv.second;
+    for (const auto &loc : locations) {
         if (!loc || loc->location_specs().empty()) {
             continue;
         }
@@ -332,7 +331,7 @@ void BuildHostSpecNamesForOneKey(const CacheLocationMap &location_map,
         std::string reporter_host;
         const bool has_reporter_identity =
             IsEventReportStorageType(loc->type()) &&
-            SnapshotUriUtils::ParseEventReportLocationId(kv.first, event_medium, reporter_host);
+            SnapshotUriUtils::ParseEventReportLocationId(loc->id(), event_medium, reporter_host);
         for (const auto &spec : loc->location_specs()) {
             StandardUri uri(spec.uri());
             const bool medium_matches = has_reporter_identity ? medium_set.empty() || medium_set.count(event_medium) > 0
@@ -786,7 +785,8 @@ ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
                                           const KeyVector &keys,
                                           bool use_eagle_pop,
                                           const std::vector<std::string> &medium_filter,
-                                          std::vector<HostCacheMatch> &out_matches) const {
+                                          std::vector<HostCacheMatch> &out_matches,
+                                          const CheckLocDataExistFunc *request_check_loc_data_exist) const {
     SPAN_TRACER(request_context);
     out_matches.clear();
     if (keys.empty()) {
@@ -795,46 +795,86 @@ ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
-    CacheLocationMapVector location_maps;
-    auto result = meta_indexer_->GetLocations(request_context, keys, location_maps);
+    LocationsPerKey location_values;
+    auto result = meta_indexer_->GetLocationValues(request_context, keys, location_values);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     LogErrorCodes("PrefixMatchByHost", result.error_codes, keys);
-    assert(keys.size() == location_maps.size());
+    assert(keys.size() == location_values.size());
 
-    KeyToHostSpecNames key_to_host_spec_names;
-    key_to_host_spec_names.reserve(keys.size());
-    const std::unordered_set<std::string> medium_set(medium_filter.begin(), medium_filter.end());
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (result.error_codes[i] != ErrorCode::EC_OK) {
-            KVCM_LOG_DEBUG(
-                "prefix match by host end because Get keys[%lu](%lu) return %d", i, keys[i], result.error_codes[i]);
-            break;
-        }
-        HostToSpecNames host_to_spec_names;
-        BuildHostSpecNamesForOneKey(location_maps[i], check_loc_data_exist_func_, medium_set, host_to_spec_names);
-        // 只保留可参与前缀匹配的连续 key 前缀。
-        key_to_host_spec_names.push_back(std::move(host_to_spec_names));
+    std::size_t valid_key_count = 0;
+    while (valid_key_count < keys.size() && result.error_codes[valid_key_count] == ErrorCode::EC_OK) {
+        ++valid_key_count;
     }
-
-    if (key_to_host_spec_names.empty() || key_to_host_spec_names.front().empty()) {
+    if (valid_key_count < keys.size()) {
+        KVCM_LOG_DEBUG("prefix match by host end because Get keys[%lu](%lu) return %d",
+                       valid_key_count,
+                       keys[valid_key_count],
+                       result.error_codes[valid_key_count]);
+    }
+    if (valid_key_count == 0) {
         return EC_OK;
     }
 
-    out_matches.reserve(key_to_host_spec_names.front().size());
-    // 只有命中第一个 key 的 host 才可能有大于 0 的前缀长度。
-    for (const auto &[host, _] : key_to_host_spec_names.front()) {
-        int64_t prefix_len = 1;
-        for (size_t i = 1; i < key_to_host_spec_names.size(); ++i) {
-            if (key_to_host_spec_names[i].find(host) == key_to_host_spec_names[i].end()) {
-                break;
+    KeyToHostSpecNames key_to_host_spec_names(valid_key_count);
+    const std::unordered_set<std::string> medium_set(medium_filter.begin(), medium_filter.end());
+    const auto &check_loc_data_exist =
+        request_check_loc_data_exist ? *request_check_loc_data_exist : check_loc_data_exist_func_;
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostProjection);
+    const bool projection_ok = meta_indexer_->ParallelForQuery(
+        valid_key_count,
+        [&location_values, &check_loc_data_exist, &medium_set, &key_to_host_spec_names](std::size_t begin,
+                                                                                        std::size_t end) {
+            for (std::size_t i = begin; i < end; ++i) {
+                BuildHostSpecNamesForOneKey(
+                    location_values[i], check_loc_data_exist, medium_set, key_to_host_spec_names[i]);
             }
-            ++prefix_len;
-        }
-        if (use_eagle_pop) {
-            prefix_len = std::max<int64_t>(prefix_len - 1, 0);
-        }
-        if (prefix_len > 0) {
-            out_matches.push_back(HostCacheMatch{host, prefix_len});
+        });
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostProjection);
+    if (!projection_ok) {
+        request_context->error_tracer()->AddErrorMsg("parallel host cache projection failed");
+        return EC_ERROR;
+    }
+
+    if (key_to_host_spec_names.front().empty()) {
+        return EC_OK;
+    }
+
+    std::vector<std::string> candidate_hosts;
+    candidate_hosts.reserve(key_to_host_spec_names.front().size());
+    for (const auto &[host, spec_names] : key_to_host_spec_names.front()) {
+        (void)spec_names;
+        candidate_hosts.push_back(host);
+    }
+    std::vector<int64_t> prefix_lengths(candidate_hosts.size(), 0);
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostPrefixReduce);
+    const bool reduce_ok = meta_indexer_->ParallelForQuery(
+        candidate_hosts.size(),
+        [&candidate_hosts, &key_to_host_spec_names, &prefix_lengths, use_eagle_pop](std::size_t begin,
+                                                                                    std::size_t end) {
+            for (std::size_t host_index = begin; host_index < end; ++host_index) {
+                const auto &host = candidate_hosts[host_index];
+                int64_t prefix_len = 1;
+                for (size_t i = 1; i < key_to_host_spec_names.size(); ++i) {
+                    if (key_to_host_spec_names[i].find(host) == key_to_host_spec_names[i].end()) {
+                        break;
+                    }
+                    ++prefix_len;
+                }
+                if (use_eagle_pop) {
+                    prefix_len = std::max<int64_t>(prefix_len - 1, 0);
+                }
+                prefix_lengths[host_index] = prefix_len;
+            }
+        });
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostPrefixReduce);
+    if (!reduce_ok) {
+        request_context->error_tracer()->AddErrorMsg("parallel host prefix reduction failed");
+        return EC_ERROR;
+    }
+    out_matches.reserve(candidate_hosts.size());
+    for (std::size_t i = 0; i < candidate_hosts.size(); ++i) {
+        if (prefix_lengths[i] > 0) {
+            out_matches.push_back(HostCacheMatch{std::move(candidate_hosts[i]), prefix_lengths[i]});
         }
     }
     return EC_OK;
@@ -845,7 +885,8 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
                                                    bool use_eagle_pop,
                                                    const std::vector<std::string> &medium_filter,
                                                    const std::vector<LocationSpecGroup> &location_spec_groups,
-                                                   std::vector<HostCacheMatch> &out_matches) const {
+                                                   std::vector<HostCacheMatch> &out_matches,
+                                                   const CheckLocDataExistFunc *request_check_loc_data_exist) const {
     SPAN_TRACER(request_context);
     out_matches.clear();
     if (keys.empty()) {
@@ -873,58 +914,97 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
-    CacheLocationMapVector location_maps;
-    auto result = meta_indexer_->GetLocations(request_context, keys, location_maps);
+    LocationsPerKey location_values;
+    auto result = meta_indexer_->GetLocationValues(request_context, keys, location_values);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     LogErrorCodes("PrefixMatchWithMambaByHost", result.error_codes, keys);
-    assert(keys.size() == location_maps.size());
+    assert(keys.size() == location_values.size());
 
-    KeyToHostSpecNames key_to_host_spec_names(keys.size());
-    const std::unordered_set<std::string> medium_set(medium_filter.begin(), medium_filter.end());
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (result.error_codes[i] != ErrorCode::EC_OK) {
-            KVCM_LOG_DEBUG("prefix match with mamba by host end because Get keys[%lu](%lu) return %d",
-                           i,
-                           keys[i],
-                           result.error_codes[i]);
-            break;
-        }
-        BuildHostSpecNamesForOneKey(
-            location_maps[i], check_loc_data_exist_func_, medium_set, key_to_host_spec_names[i]);
+    std::size_t valid_key_count = 0;
+    while (valid_key_count < keys.size() && result.error_codes[valid_key_count] == ErrorCode::EC_OK) {
+        ++valid_key_count;
+    }
+    if (valid_key_count < keys.size()) {
+        KVCM_LOG_DEBUG("prefix match with mamba by host end because Get keys[%lu](%lu) return %d",
+                       valid_key_count,
+                       keys[valid_key_count],
+                       result.error_codes[valid_key_count]);
+    }
+    if (valid_key_count == 0) {
+        return EC_OK;
     }
 
-    out_matches.reserve(key_to_host_spec_names.front().size());
-    // 只有命中第一个 key 的 host 才可能有大于 0 的前缀长度。
-    for (const auto &kv : key_to_host_spec_names.front()) {
-        const auto &host = kv.first;
-        size_t full_prefix_len = 0;
-        for (; full_prefix_len < key_to_host_spec_names.size(); ++full_prefix_len) {
-            auto host_it = key_to_host_spec_names[full_prefix_len].find(host);
-            if (host_it == key_to_host_spec_names[full_prefix_len].end() ||
-                !HasAllLocationSpecGroups(host_it->second, full_groups)) {
-                break;
+    KeyToHostSpecNames key_to_host_spec_names(valid_key_count);
+    const std::unordered_set<std::string> medium_set(medium_filter.begin(), medium_filter.end());
+    const auto &check_loc_data_exist =
+        request_check_loc_data_exist ? *request_check_loc_data_exist : check_loc_data_exist_func_;
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostProjection);
+    const bool projection_ok = meta_indexer_->ParallelForQuery(
+        valid_key_count,
+        [&location_values, &check_loc_data_exist, &medium_set, &key_to_host_spec_names](std::size_t begin,
+                                                                                        std::size_t end) {
+            for (std::size_t i = begin; i < end; ++i) {
+                BuildHostSpecNamesForOneKey(
+                    location_values[i], check_loc_data_exist, medium_set, key_to_host_spec_names[i]);
             }
-        }
-        if (use_eagle_pop && full_prefix_len > 0) {
-            --full_prefix_len;
-        }
-        if (full_prefix_len == 0) {
-            continue;
-        }
+        });
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostProjection);
+    if (!projection_ok) {
+        request_context->error_tracer()->AddErrorMsg("parallel mamba host cache projection failed");
+        return EC_ERROR;
+    }
 
-        int64_t prefix_len = 0;
-        // Mamba 模式要求 full 前缀范围内最后一个可用 block 同时具备 mamba state。
-        for (size_t offset = full_prefix_len; offset > 0; --offset) {
-            const size_t index = offset - 1;
-            auto host_it = key_to_host_spec_names[index].find(host);
-            if (host_it != key_to_host_spec_names[index].end() &&
-                HasAllLocationSpecGroups(host_it->second, mamba_state_groups)) {
-                prefix_len = static_cast<int64_t>(index + 1);
-                break;
+    std::vector<std::string> candidate_hosts;
+    candidate_hosts.reserve(key_to_host_spec_names.front().size());
+    for (const auto &[host, spec_names] : key_to_host_spec_names.front()) {
+        (void)spec_names;
+        candidate_hosts.push_back(host);
+    }
+    std::vector<int64_t> prefix_lengths(candidate_hosts.size(), 0);
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostPrefixReduce);
+    const bool reduce_ok = meta_indexer_->ParallelForQuery(
+        candidate_hosts.size(),
+        [&candidate_hosts, &key_to_host_spec_names, &full_groups, &mamba_state_groups, &prefix_lengths, use_eagle_pop](
+            std::size_t begin, std::size_t end) {
+            for (std::size_t host_index = begin; host_index < end; ++host_index) {
+                const auto &host = candidate_hosts[host_index];
+                size_t full_prefix_len = 0;
+                for (; full_prefix_len < key_to_host_spec_names.size(); ++full_prefix_len) {
+                    auto host_it = key_to_host_spec_names[full_prefix_len].find(host);
+                    if (host_it == key_to_host_spec_names[full_prefix_len].end() ||
+                        !HasAllLocationSpecGroups(host_it->second, full_groups)) {
+                        break;
+                    }
+                }
+                if (use_eagle_pop && full_prefix_len > 0) {
+                    --full_prefix_len;
+                }
+                if (full_prefix_len == 0) {
+                    continue;
+                }
+
+                // Mamba requires the last usable block in the full-prefix
+                // range to also contain every state spec group.
+                for (size_t offset = full_prefix_len; offset > 0; --offset) {
+                    const size_t index = offset - 1;
+                    auto host_it = key_to_host_spec_names[index].find(host);
+                    if (host_it != key_to_host_spec_names[index].end() &&
+                        HasAllLocationSpecGroups(host_it->second, mamba_state_groups)) {
+                        prefix_lengths[host_index] = static_cast<int64_t>(index + 1);
+                        break;
+                    }
+                }
             }
-        }
-        if (prefix_len > 0) {
-            out_matches.push_back(HostCacheMatch{host, prefix_len});
+        });
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostPrefixReduce);
+    if (!reduce_ok) {
+        request_context->error_tracer()->AddErrorMsg("parallel mamba host prefix reduction failed");
+        return EC_ERROR;
+    }
+    out_matches.reserve(candidate_hosts.size());
+    for (std::size_t i = 0; i < candidate_hosts.size(); ++i) {
+        if (prefix_lengths[i] > 0) {
+            out_matches.push_back(HostCacheMatch{std::move(candidate_hosts[i]), prefix_lengths[i]});
         }
     }
     return EC_OK;

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -533,7 +533,8 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                                                       const KeyVector &keys,
                                                       LocationsPerKey &out_locations,
                                                       SelectLocationPolicy *policy,
-                                                      const std::vector<BackendSelector> &selectors) const {
+                                                      const std::vector<BackendSelector> &selectors,
+                                                      const std::vector<std::string> &requested_spec_names) const {
     assert(policy != nullptr);
     SPAN_TRACER(request_context);
     out_locations.clear();
@@ -594,6 +595,15 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 for (const auto &[id, loc] : vmap) {
                     if (loc->type() != target_type)
                         continue;
+                    if (!requested_spec_names.empty() &&
+                        std::none_of(loc->location_specs().begin(),
+                                     loc->location_specs().end(),
+                                     [&requested_spec_names](const LocationSpec &spec) {
+                                         return std::find(requested_spec_names.begin(),
+                                                          requested_spec_names.end(),
+                                                          spec.name()) != requested_spec_names.end();
+                                     }))
+                        continue;
                     std::string addr = ExtractPeerAddrFromLocation(*loc);
                     if (addr.empty())
                         continue;
@@ -642,7 +652,16 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 const auto &vmap = valid_maps[i];
                 CacheLocationMap filtered;
                 for (const auto &[id, loc] : vmap) {
-                    if (loc->type() == target_type) {
+                    const bool matches_requested_spec =
+                        requested_spec_names.empty() ||
+                        std::any_of(loc->location_specs().begin(),
+                                    loc->location_specs().end(),
+                                    [&requested_spec_names](const LocationSpec &spec) {
+                                        return std::find(requested_spec_names.begin(),
+                                                         requested_spec_names.end(),
+                                                         spec.name()) != requested_spec_names.end();
+                                    });
+                    if (loc->type() == target_type && matches_requested_spec) {
                         filtered.try_emplace(id, loc);
                     }
                 }

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -979,6 +979,10 @@ ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
                        valid_key_count,
                        keys[valid_key_count],
                        result.error_codes[valid_key_count]);
+        if (result.error_codes[valid_key_count] != ErrorCode::EC_NOENT) {
+            request_context->error_tracer()->AddErrorMsg("prefix match metadata read failed");
+            return result.error_codes[valid_key_count];
+        }
     }
     if (valid_key_count == 0) {
         return EC_OK;
@@ -1117,6 +1121,10 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
                        valid_key_count,
                        keys[valid_key_count],
                        result.error_codes[valid_key_count]);
+        if (result.error_codes[valid_key_count] != ErrorCode::EC_NOENT) {
+            request_context->error_tracer()->AddErrorMsg("mamba prefix match metadata read failed");
+            return result.error_codes[valid_key_count];
+        }
     }
     if (valid_key_count == 0) {
         return EC_OK;

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -6,6 +6,7 @@
 #include <map>
 #include <set>
 #include <sstream>
+#include <string_view>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -69,18 +70,29 @@ struct StorageUsageChange {
     bool has_old = false;
 };
 
-ErrorCode ValidateConsistentSnapshotVersion(const std::vector<LocationSpec> &specs) {
+ErrorCode ValidateConsistentSnapshotVersion(const std::vector<LocationSpec> &specs,
+                                            std::uint64_t *out_total_size = nullptr) {
     if (specs.empty()) {
         return EC_BADARGS;
     }
     bool has_snapshot_version = false;
     std::string snapshot_version;
     bool has_unversioned_spec = false;
-    std::unordered_set<std::string> spec_names;
+    std::uint64_t total_size = 0;
+    std::unordered_set<std::string_view> spec_names;
+    if (specs.size() > 1) {
+        spec_names.reserve(specs.size());
+    }
     for (const auto &spec : specs) {
         const DataStorageUri uri(spec.uri());
-        if (spec.name().empty() || !spec_names.insert(spec.name()).second || !uri.Valid()) {
+        if (spec.name().empty() || (specs.size() > 1 && !spec_names.insert(std::string_view(spec.name())).second) ||
+            !uri.Valid()) {
             return EC_BADARGS;
+        }
+        if (out_total_size) {
+            std::uint64_t spec_size = 0;
+            uri.GetParamAs<std::uint64_t>("size", spec_size);
+            total_size += spec_size;
         }
         const size_t version_param_count =
             SnapshotUriUtils::CountUriParam(spec.uri(), SnapshotUriUtils::kSnapshotVersionParam);
@@ -101,6 +113,9 @@ ErrorCode ValidateConsistentSnapshotVersion(const std::vector<LocationSpec> &spe
         } else if (info.version != snapshot_version) {
             return EC_BADARGS;
         }
+    }
+    if (out_total_size) {
+        *out_total_size = total_size;
     }
     return EC_OK;
 }
@@ -1515,210 +1530,156 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
         return EC_OK;
     }
 
-    std::unordered_set<int64_t> seen_keys;
-    for (size_t key_index = 0; key_index < keys.size(); ++key_index) {
-        if (!seen_keys.insert(keys[key_index]).second) {
-            std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), EC_BADARGS);
-            return EC_BADARGS;
+    bool has_duplicate_keys = false;
+    if (std::is_sorted(keys.begin(), keys.end())) {
+        has_duplicate_keys = std::adjacent_find(keys.begin(), keys.end()) != keys.end();
+    } else {
+        std::unordered_set<int64_t> seen_keys;
+        seen_keys.reserve(keys.size());
+        for (const int64_t key : keys) {
+            if (!seen_keys.insert(key).second) {
+                has_duplicate_keys = true;
+                break;
+            }
         }
-        std::unordered_set<std::string> seen_location_ids;
+    }
+    if (has_duplicate_keys) {
+        std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), EC_BADARGS);
+        return EC_BADARGS;
+    }
+
+    LocationIdsPerKey location_ids_per_key(keys.size());
+    std::vector<size_t> usage_offsets(keys.size() + 1, 0);
+    std::vector<std::uint64_t> incoming_task_sizes;
+    incoming_task_sizes.reserve(keys.size());
+    for (size_t key_index = 0; key_index < keys.size(); ++key_index) {
+        std::unordered_set<std::string_view> seen_location_ids;
+        if (tasks_per_key[key_index].size() > 1) {
+            seen_location_ids.reserve(tasks_per_key[key_index].size());
+        }
+        auto &location_ids = location_ids_per_key[key_index];
+        location_ids.reserve(tasks_per_key[key_index].size());
         for (const auto &task : tasks_per_key[key_index]) {
-            if (task.location_id.empty() || !seen_location_ids.insert(task.location_id).second ||
-                ValidateConsistentSnapshotVersion(task.specs) != EC_OK) {
+            std::uint64_t incoming_size = 0;
+            if (task.location_id.empty() ||
+                (tasks_per_key[key_index].size() > 1 &&
+                 !seen_location_ids.insert(std::string_view(task.location_id)).second) ||
+                ValidateConsistentSnapshotVersion(task.specs, &incoming_size) != EC_OK) {
                 std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), EC_BADARGS);
                 return EC_BADARGS;
             }
+            location_ids.push_back(task.location_id);
+            incoming_task_sizes.push_back(incoming_size);
         }
+        usage_offsets[key_index + 1] = usage_offsets[key_index] + location_ids.size();
     }
+    std::vector<StorageUsageChange> usage_changes(usage_offsets.back());
 
-    std::vector<std::vector<std::pair<DataStorageType, std::uint64_t>>> created_locs_sz(keys.size());
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
-    // Keep indices into the caller-owned task vectors. Copying each task here
-    // duplicated every location id, spec name and URI before the second RMW
-    // phase, which is especially expensive for large ReportEvent batches.
-    std::vector<std::vector<size_t>> merge_task_indices_per_key(keys.size());
-    bool create_write_lease_attempted = false;
-    ErrorCode create_write_lease_ec = EC_OK;
-    MetadataWriteLease create_write_lease;
+    bool write_lease_attempted = false;
+    ErrorCode write_lease_ec = EC_OK;
+    MetadataWriteLease write_lease;
+    auto modifier = [&keys,
+                     &tasks_per_key,
+                     &usage_offsets,
+                     &usage_changes,
+                     &incoming_task_sizes,
+                     &acquire_write_lease,
+                     &write_lease_attempted,
+                     &write_lease_ec,
+                     &write_lease,
+                     batch_create_time](const std::vector<ErrorCode> &get_ecs,
+                                        const LocationIdVector &location_ids,
+                                        size_t key_index,
+                                        CacheLocationVector &locations,
+                                        PropertyMap & /*upsert_property_map*/) -> LocationModifierResult {
+        if (location_ids.empty()) {
+            return {ModifierAction::MA_SKIP, {}};
+        }
+        if (acquire_write_lease && !write_lease_attempted) {
+            std::tie(write_lease_ec, write_lease) = acquire_write_lease();
+            write_lease_attempted = true;
+        }
+        if (write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(location_ids.size(), write_lease_ec)};
+        }
+        if (key_index >= tasks_per_key.size() || get_ecs.size() != location_ids.size() ||
+            locations.size() != location_ids.size() || tasks_per_key[key_index].size() != location_ids.size()) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(location_ids.size(), EC_MISMATCH)};
+        }
 
-    auto create_modifier = [&tasks_per_key,
-                            &merge_task_indices_per_key,
-                            &keys,
-                            &created_locs_sz,
-                            &acquire_write_lease,
-                            &create_write_lease_attempted,
-                            &create_write_lease_ec,
-                            &create_write_lease,
-                            batch_create_time](const LocationIdVector &existing_ids,
-                                               ErrorCode get_ec,
-                                               size_t index,
-                                               PropertyMap & /*upsert_property_map*/,
-                                               CacheLocationMap &out_new_locations) -> ModifierResult {
-        if (acquire_write_lease && !create_write_lease_attempted) {
-            std::tie(create_write_lease_ec, create_write_lease) = acquire_write_lease();
-            create_write_lease_attempted = true;
-        }
-        if (create_write_lease_ec != EC_OK) {
-            return {ModifierAction::MA_FAIL, create_write_lease_ec};
-        }
-        if (get_ec != ErrorCode::EC_OK && get_ec != ErrorCode::EC_NOENT) {
-            KVCM_LOG_WARN("load location ids failed, key[%lu](%lu) return %d", index, keys[index], get_ec);
-            return {ModifierAction::MA_FAIL, get_ec};
-        }
-
-        bool created = false;
-        for (size_t task_index = 0; task_index < tasks_per_key[index].size(); ++task_index) {
-            const auto &entry = tasks_per_key[index][task_index];
-            if (get_ec == ErrorCode::EC_OK &&
-                std::find(existing_ids.begin(), existing_ids.end(), entry.location_id) != existing_ids.end()) {
-                merge_task_indices_per_key[index].push_back(task_index);
-                continue;
-            }
-
-            CacheLocation loc;
-            loc.set_id(entry.location_id);
-            loc.set_type(entry.type);
-            loc.set_status(entry.status);
-            loc.set_spec_size(entry.specs.size());
-            loc.set_create_time(batch_create_time);
-            for (const auto &ls : entry.specs) {
-                loc.push_location_spec(LocationSpec(ls.name(), ls.uri()));
-            }
-            out_new_locations[entry.location_id] = std::make_shared<const CacheLocation>(std::move(loc));
-            created_locs_sz[index].emplace_back(entry.type, GetLocationSpecsSize(entry.specs));
-            created = true;
-        }
-        if (!created) {
-            return {ModifierAction::MA_SKIP, ErrorCode::EC_OK};
-        }
-        return {ModifierAction::MA_OK, ErrorCode::EC_OK};
-    };
-
-    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
-    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerReadModifyWriteBlock);
-    auto result = meta_indexer_->ReadModifyWriteBlock(request_context, keys, create_modifier);
-    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteBlock);
-    ErrorCode final_ec = result.ec;
-
-    if (result.error_codes.size() != keys.size()) {
-        KVCM_LOG_ERROR("BatchMergeLocationSpecs create result size mismatch, keys[%zu], results[%zu]",
-                       keys.size(),
-                       result.error_codes.size());
-        std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), ErrorCode::EC_MISMATCH);
-        return ErrorCode::EC_MISMATCH;
-    }
-    for (size_t i = 0; i < keys.size(); ++i) {
-        ErrorCode key_ec = result.error_codes[i];
-        out_per_key_ec[i] = key_ec;
-        if (key_ec == ErrorCode::EC_OK) {
-            for (const auto &[type, size] : created_locs_sz[i]) {
-                meta_indexer_->AddStorageUsageByType(type, size);
-            }
-        }
-    }
-
-    if (result.ec != ErrorCode::EC_OK) {
-        LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
-    }
-
-    KeyVector merge_keys;
-    std::vector<size_t> merge_key_indices;
-    LocationIdsPerKey merge_location_ids;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (out_per_key_ec[i] != ErrorCode::EC_OK || merge_task_indices_per_key[i].empty()) {
-            continue;
-        }
-        merge_keys.push_back(keys[i]);
-        merge_key_indices.push_back(i);
-        auto &ids = merge_location_ids.emplace_back();
-        ids.reserve(merge_task_indices_per_key[i].size());
-        for (const size_t task_index : merge_task_indices_per_key[i]) {
-            ids.push_back(tasks_per_key[i][task_index].location_id);
-        }
-    }
-
-    if (merge_keys.empty()) {
-        return final_ec;
-    }
-
-    std::vector<std::vector<StorageUsageChange>> merge_usage_changes(keys.size());
-    for (size_t i = 0; i < keys.size(); ++i) {
-        merge_usage_changes[i].resize(merge_task_indices_per_key[i].size());
-    }
-    create_write_lease.reset();
-    bool merge_write_lease_attempted = false;
-    ErrorCode merge_write_lease_ec = EC_OK;
-    MetadataWriteLease merge_write_lease;
-    auto merge_modifier = [&keys,
-                           &tasks_per_key,
-                           &merge_task_indices_per_key,
-                           &merge_key_indices,
-                           &merge_usage_changes,
-                           &acquire_write_lease,
-                           &merge_write_lease_attempted,
-                           &merge_write_lease_ec,
-                           &merge_write_lease,
-                           batch_create_time](const std::vector<ErrorCode> &get_ecs,
-                                              const LocationIdVector &loc_ids,
-                                              size_t key_index,
-                                              CacheLocationVector &locs,
-                                              PropertyMap &upsert_property_map) -> LocationModifierResult {
-        (void)upsert_property_map;
-        if (acquire_write_lease && !merge_write_lease_attempted) {
-            std::tie(merge_write_lease_ec, merge_write_lease) = acquire_write_lease();
-            merge_write_lease_attempted = true;
-        }
-        if (merge_write_lease_ec != EC_OK) {
-            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), merge_write_lease_ec)};
-        }
-        const size_t original_key_index = merge_key_indices[key_index];
-        const auto &task_indices = merge_task_indices_per_key[original_key_index];
-        std::vector<ErrorCode> modifier_ecs(loc_ids.size(), ErrorCode::EC_OK);
+        std::vector<ErrorCode> modifier_ecs(location_ids.size(), ErrorCode::EC_OK);
         bool updated = false;
-        for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
-            if (loc_index >= task_indices.size() || loc_index >= get_ecs.size() || loc_index >= locs.size()) {
-                modifier_ecs[loc_index] = ErrorCode::EC_ERROR;
-                continue;
-            }
-            const ErrorCode ec = get_ecs[loc_index];
-            const auto &task = tasks_per_key[original_key_index][task_indices[loc_index]];
-            if (ec != ErrorCode::EC_OK && ec != ErrorCode::EC_NOENT) {
-                modifier_ecs[loc_index] = ec;
-                KVCM_LOG_WARN("load location failed, key[%lu](%lu), location_id: %s, return %d",
-                              original_key_index,
-                              keys[original_key_index],
-                              task.location_id.c_str(),
-                              ec);
+        for (size_t location_index = 0; location_index < location_ids.size(); ++location_index) {
+            const auto &task = tasks_per_key[key_index][location_index];
+            if (location_ids[location_index] != task.location_id) {
+                modifier_ecs[location_index] = EC_MISMATCH;
                 continue;
             }
 
-            auto &usage = merge_usage_changes[original_key_index][loc_index];
-            std::shared_ptr<CacheLocation> new_loc;
-            if (ec == ErrorCode::EC_OK && locs[loc_index]) {
-                if (locs[loc_index]->type() != task.type) {
-                    modifier_ecs[loc_index] = ErrorCode::EC_BADARGS;
+            const ErrorCode get_ec = get_ecs[location_index];
+            if (get_ec != EC_OK && get_ec != EC_NOENT) {
+                modifier_ecs[location_index] = get_ec;
+                KVCM_LOG_WARN("load target location failed, key[%lu](%lu), location_id[%s], return[%d]",
+                              key_index,
+                              keys[key_index],
+                              task.location_id.c_str(),
+                              get_ec);
+                continue;
+            }
+
+            const size_t usage_index = usage_offsets[key_index] + location_index;
+            auto &usage = usage_changes[usage_index];
+            const std::uint64_t incoming_size = incoming_task_sizes[usage_index];
+            std::shared_ptr<CacheLocation> new_location;
+            if (get_ec == EC_OK) {
+                if (!locations[location_index] || locations[location_index]->type() != task.type) {
+                    modifier_ecs[location_index] =
+                        locations[location_index] ? ErrorCode::EC_BADARGS : ErrorCode::EC_MISMATCH;
                     continue;
                 }
-                usage.old_size = GetLocationSpecsSize(locs[loc_index]->location_specs());
+                std::uint64_t replaced_old_size = 0;
+                bool has_legacy_duplicate_names = false;
+                const auto &old_specs = locations[location_index]->location_specs();
+                for (size_t old_index = 0; old_index < old_specs.size(); ++old_index) {
+                    const auto &old_spec = old_specs[old_index];
+                    std::uint64_t old_spec_size = 0;
+                    if (DataStorageUri old_uri(old_spec.uri()); old_uri.Valid()) {
+                        old_uri.GetParamAs<std::uint64_t>("size", old_spec_size);
+                    }
+                    usage.old_size += old_spec_size;
+                    if (std::any_of(task.specs.begin(), task.specs.end(), [&old_spec](const auto &new_spec) {
+                            return new_spec.name() == old_spec.name();
+                        })) {
+                        replaced_old_size += old_spec_size;
+                    }
+                    has_legacy_duplicate_names =
+                        has_legacy_duplicate_names ||
+                        std::any_of(old_specs.begin(), old_specs.begin() + old_index, [&old_spec](const auto &prior) {
+                            return prior.name() == old_spec.name();
+                        });
+                }
                 usage.has_old = true;
-                new_loc = std::make_shared<CacheLocation>(*locs[loc_index]);
-                MergeLocationSpecsByName(new_loc->mutable_location_specs(), task.specs);
+                new_location = std::make_shared<CacheLocation>(*locations[location_index]);
+                MergeLocationSpecsByName(new_location->mutable_location_specs(), task.specs);
+                usage.new_size = has_legacy_duplicate_names ? GetLocationSpecsSize(new_location->location_specs())
+                                                            : usage.old_size - replaced_old_size + incoming_size;
             } else {
-                new_loc = std::make_shared<CacheLocation>();
-                new_loc->set_id(task.location_id);
+                new_location = std::make_shared<CacheLocation>();
+                new_location->set_id(task.location_id);
                 std::vector<LocationSpec> specs;
                 specs.reserve(task.specs.size());
                 for (const auto &spec : task.specs) {
                     specs.emplace_back(spec.name(), spec.uri());
                 }
-                new_loc->set_location_specs(std::move(specs));
+                new_location->set_location_specs(std::move(specs));
+                usage.new_size = incoming_size;
             }
-            new_loc->set_type(task.type);
-            new_loc->set_status(task.status);
-            new_loc->set_create_time(batch_create_time);
-            new_loc->set_spec_size(new_loc->location_specs().size());
-            usage.new_size = GetLocationSpecsSize(new_loc->location_specs());
-            locs[loc_index] = std::move(new_loc);
+            new_location->set_type(task.type);
+            new_location->set_status(task.status);
+            new_location->set_create_time(batch_create_time);
+            new_location->set_spec_size(new_location->location_specs().size());
+            locations[location_index] = std::move(new_location);
             updated = true;
         }
         if (!updated) {
@@ -1727,62 +1688,54 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
         return {ModifierAction::MA_OK, std::move(modifier_ecs)};
     };
 
+    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
-    auto merge_result =
-        meta_indexer_->ReadModifyWriteLocation(request_context, merge_keys, merge_location_ids, merge_modifier);
+    auto result = meta_indexer_->ReadModifyWriteTargetLocations(request_context, keys, location_ids_per_key, modifier);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
 
-    bool malformed_merge_result = merge_result.per_location_error_codes.size() != merge_key_indices.size();
-    if (malformed_merge_result) {
-        KVCM_LOG_ERROR("BatchMergeLocationSpecs merge result size mismatch, keys[%zu], results[%zu]",
-                       merge_key_indices.size(),
-                       merge_result.per_location_error_codes.size());
+    bool malformed_result = result.per_location_error_codes.size() != keys.size();
+    if (malformed_result) {
+        KVCM_LOG_ERROR("BatchMergeLocationSpecs fused result size mismatch, keys[%zu], results[%zu]",
+                       keys.size(),
+                       result.per_location_error_codes.size());
     }
-    for (size_t i = 0; i < merge_key_indices.size(); ++i) {
-        const size_t original_key_index = merge_key_indices[i];
-        ErrorCode key_ec = ErrorCode::EC_OK;
-        const auto &task_indices = merge_task_indices_per_key[original_key_index];
-        const size_t expected_location_count = task_indices.size();
-        if (i >= merge_result.per_location_error_codes.size() ||
-            merge_result.per_location_error_codes[i].size() != expected_location_count) {
-            key_ec = ErrorCode::EC_MISMATCH;
-            malformed_merge_result = true;
+    for (size_t key_index = 0; key_index < keys.size(); ++key_index) {
+        ErrorCode key_ec = EC_OK;
+        const size_t expected_location_count = tasks_per_key[key_index].size();
+        if (key_index >= result.per_location_error_codes.size() ||
+            result.per_location_error_codes[key_index].size() != expected_location_count) {
+            key_ec = EC_MISMATCH;
+            malformed_result = true;
         } else {
-            for (size_t loc_index = 0; loc_index < expected_location_count; ++loc_index) {
-                const auto loc_ec = merge_result.per_location_error_codes[i][loc_index];
-                if (loc_ec == ErrorCode::EC_OK) {
-                    const auto &usage = merge_usage_changes[original_key_index][loc_index];
-                    const auto &task = tasks_per_key[original_key_index][task_indices[loc_index]];
-                    if (usage.has_old) {
-                        ApplyStorageUsageChange(meta_indexer_.get(), task.type, usage.old_size, usage.new_size);
-                    } else {
-                        meta_indexer_->AddStorageUsageByType(task.type, usage.new_size);
+            for (size_t location_index = 0; location_index < expected_location_count; ++location_index) {
+                const ErrorCode location_ec = result.per_location_error_codes[key_index][location_index];
+                if (location_ec != EC_OK) {
+                    if (key_ec == EC_OK) {
+                        key_ec = location_ec;
                     }
                     continue;
                 }
-                if (key_ec == ErrorCode::EC_OK) {
-                    key_ec = loc_ec;
+                const auto &usage = usage_changes[usage_offsets[key_index] + location_index];
+                const auto &task = tasks_per_key[key_index][location_index];
+                if (usage.has_old) {
+                    ApplyStorageUsageChange(meta_indexer_.get(), task.type, usage.old_size, usage.new_size);
+                } else {
+                    meta_indexer_->AddStorageUsageByType(task.type, usage.new_size);
                 }
             }
         }
-        if (key_ec != ErrorCode::EC_OK) {
-            out_per_key_ec[original_key_index] = key_ec;
-        }
+        out_per_key_ec[key_index] = key_ec;
     }
 
-    if (merge_result.ec != ErrorCode::EC_OK) {
-        KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", merge_result.ec);
-        if (final_ec == ErrorCode::EC_OK) {
-            final_ec = merge_result.ec;
-        } else if (merge_result.ec != final_ec) {
-            final_ec = ErrorCode::EC_PARTIAL_OK;
-        }
+    ErrorCode final_ec = result.ec;
+    if (result.ec != EC_OK) {
+        KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteTargetLocations failed, ec: %d", result.ec);
     }
-    if (malformed_merge_result) {
-        if (final_ec == ErrorCode::EC_OK) {
-            final_ec = ErrorCode::EC_MISMATCH;
-        } else if (final_ec != ErrorCode::EC_MISMATCH) {
-            final_ec = ErrorCode::EC_PARTIAL_OK;
+    if (malformed_result) {
+        if (final_ec == EC_OK) {
+            final_ec = EC_MISMATCH;
+        } else if (final_ec != EC_MISMATCH) {
+            final_ec = EC_PARTIAL_OK;
         }
     }
     return final_ec;

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -69,10 +69,18 @@ struct StorageUsageChange {
 };
 
 ErrorCode ValidateConsistentSnapshotVersion(const std::vector<LocationSpec> &specs) {
+    if (specs.empty()) {
+        return EC_BADARGS;
+    }
     bool has_snapshot_version = false;
     std::string snapshot_version;
     bool has_unversioned_spec = false;
+    std::unordered_set<std::string> spec_names;
     for (const auto &spec : specs) {
+        const DataStorageUri uri(spec.uri());
+        if (spec.name().empty() || !spec_names.insert(spec.name()).second || !uri.Valid()) {
+            return EC_BADARGS;
+        }
         const size_t version_param_count =
             SnapshotUriUtils::CountUriParam(spec.uri(), SnapshotUriUtils::kSnapshotVersionParam);
         if (version_param_count == 0) {
@@ -321,7 +329,10 @@ void BuildHostSpecNamesForOneKey(const CacheLocationVector &locations,
                                  const std::unordered_set<std::string> &medium_set,
                                  HostToSpecNames &host_specs) {
     for (const auto &loc : locations) {
-        if (!loc || loc->location_specs().empty()) {
+        // Host cache state is a read-availability API. WRITING, DELETING and
+        // other transitional locations must not contribute a hit merely
+        // because their URI is already present in metadata.
+        if (!loc || loc->status() != CacheLocationStatus::CLS_SERVING || loc->location_specs().empty()) {
             continue;
         }
         if (check_loc_data_exist && !check_loc_data_exist(*loc)) {
@@ -548,28 +559,54 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                                                       LocationsPerKey &out_locations,
                                                       SelectLocationPolicy *policy,
                                                       const std::vector<BackendSelector> &selectors,
-                                                      const std::vector<std::string> &requested_spec_names) const {
+                                                      const std::vector<std::string> &requested_spec_names,
+                                                      const BlockMask &input_mask) const {
     assert(policy != nullptr);
     SPAN_TRACER(request_context);
     out_locations.clear();
     out_locations.resize(keys.size());
+
+    const bool has_implicit_empty_mask =
+        std::holds_alternative<BlockMaskVector>(input_mask) && std::get<BlockMaskVector>(input_mask).empty();
+    if (!has_implicit_empty_mask && !IsBlockMaskValid(input_mask, keys.size())) {
+        return EC_BADARGS;
+    }
+
+    // A masked block is already available to the caller.  Do not send it to
+    // the metadata backend, but preserve the request's positional response
+    // shape so callers can safely correlate each entry with the original key.
+    KeyVector query_keys;
+    std::vector<size_t> query_to_output_index;
+    query_keys.reserve(keys.size());
+    query_to_output_index.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (IsIndexInMaskRange(input_mask, i)) {
+            continue;
+        }
+        query_keys.push_back(keys[i]);
+        query_to_output_index.push_back(i);
+    }
+    if (query_keys.empty()) {
+        return EC_OK;
+    }
+
     const RequestedSpecNameSet requested_spec_name_set(requested_spec_names.begin(), requested_spec_names.end());
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
     CacheLocationMapVector location_maps;
-    auto result = meta_indexer_->GetLocations(request_context, keys, location_maps);
+    auto result = meta_indexer_->GetLocations(request_context, query_keys, location_maps);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerGet);
     KeyVector prune_keys;
     std::vector<std::vector<std::string>> prune_loc_ids_vec;
-    std::vector<CacheLocationMap> valid_maps(keys.size());
+    std::vector<CacheLocationMap> valid_maps(query_keys.size());
     bool has_error = false;
 
-    for (size_t i = 0; i < keys.size(); ++i) {
+    for (size_t i = 0; i < query_keys.size(); ++i) {
         if (result.error_codes[i] == ErrorCode::EC_NOENT) {
             continue;
         }
         if (result.error_codes[i] != ErrorCode::EC_OK) {
-            KVCM_LOG_WARN("get key failed, key[%lu](%lu), error_code: %d", i, keys[i], result.error_codes[i]);
+            KVCM_LOG_WARN("get key failed, key[%lu](%lu), error_code: %d", i, query_keys[i], result.error_codes[i]);
             has_error = true;
             break;
         }
@@ -579,7 +616,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
         std::vector<std::string> prune_loc_ids;
         valid_maps[i] = FilterValidLocations(location_maps[i], check_loc_data_exist_func_, prune_loc_ids);
         if (!prune_loc_ids.empty()) {
-            prune_keys.emplace_back(keys[i]);
+            prune_keys.emplace_back(query_keys[i]);
             prune_loc_ids_vec.emplace_back(std::move(prune_loc_ids));
         }
     }
@@ -600,7 +637,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
             std::unordered_map<size_t, std::unordered_map<std::string, CacheLocationConstPtr>> key_peer_to_location;
 
             bool stop_vineyard = false;
-            for (size_t i = 0; i < keys.size(); ++i) {
+            for (size_t i = 0; i < query_keys.size(); ++i) {
                 if (stop_vineyard)
                     break;
 
@@ -650,13 +687,13 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                     auto loc_it = peer_it->second.find(selection.peer_addr);
                     if (loc_it == peer_it->second.end())
                         continue;
-                    out_locations[idx].push_back(loc_it->second);
+                    out_locations[query_to_output_index[idx]].push_back(loc_it->second);
                 }
             }
 
         } else {
             // --- Per-key independent selection (WEIGHTED_RANDOM or other non-event-report) ---
-            for (size_t i = 0; i < keys.size(); ++i) {
+            for (size_t i = 0; i < query_keys.size(); ++i) {
                 const auto &vmap = valid_maps[i];
                 CacheLocationMap filtered;
                 for (const auto &[id, loc] : vmap) {
@@ -695,7 +732,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 }
                 merged->set_spec_size(specs.size());
                 merged->set_location_specs(std::move(specs));
-                out_locations[i].push_back(std::move(merged));
+                out_locations[query_to_output_index[i]].push_back(std::move(merged));
             }
         }
     }
@@ -1159,15 +1196,21 @@ MetaSearcher::BatchReplaceLocationSpecs(RequestContext *request_context,
 
     LocationIdsPerKey location_ids_per_key(keys.size());
     std::vector<std::vector<StorageUsageChange>> usage_changes(keys.size());
+    std::unordered_set<int64_t> seen_keys;
     for (size_t key_index = 0; key_index < keys.size(); ++key_index) {
+        if (!seen_keys.insert(keys[key_index]).second) {
+            std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), EC_BADARGS);
+            return EC_BADARGS;
+        }
         auto &location_ids = location_ids_per_key[key_index];
         auto &key_usage_changes = usage_changes[key_index];
         location_ids.reserve(tasks_per_key[key_index].size());
         key_usage_changes.resize(tasks_per_key[key_index].size());
         std::unordered_set<std::string> seen_location_ids;
         for (const auto &task : tasks_per_key[key_index]) {
-            if (task.location_id.empty() || !seen_location_ids.insert(task.location_id).second) {
-                out_per_key_ec[key_index] = EC_BADARGS;
+            if (task.location_id.empty() || !seen_location_ids.insert(task.location_id).second ||
+                ValidateConsistentSnapshotVersion(task.specs) != EC_OK) {
+                std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), EC_BADARGS);
                 return EC_BADARGS;
             }
             location_ids.push_back(task.location_id);
@@ -1259,13 +1302,22 @@ MetaSearcher::BatchReplaceLocationSpecs(RequestContext *request_context,
         meta_indexer_->ReadModifyWriteLocation(request_context, keys, location_ids_per_key, std::move(modifier));
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
 
+    bool malformed_result = result.per_location_error_codes.size() != keys.size();
+    if (malformed_result) {
+        KVCM_LOG_ERROR("BatchReplaceLocationSpecs result size mismatch, keys[%zu], results[%zu]",
+                       keys.size(),
+                       result.per_location_error_codes.size());
+    }
     for (size_t key_index = 0; key_index < keys.size(); ++key_index) {
         ErrorCode key_ec = ErrorCode::EC_OK;
-        if (key_index >= result.per_location_error_codes.size()) {
-            key_ec = result.ec == ErrorCode::EC_OK ? ErrorCode::EC_ERROR : result.ec;
+        const size_t expected_location_count = tasks_per_key[key_index].size();
+        if (key_index >= result.per_location_error_codes.size() ||
+            result.per_location_error_codes[key_index].size() != expected_location_count) {
+            key_ec = ErrorCode::EC_MISMATCH;
+            malformed_result = true;
         } else {
             const auto &location_ecs = result.per_location_error_codes[key_index];
-            for (size_t location_index = 0; location_index < location_ecs.size(); ++location_index) {
+            for (size_t location_index = 0; location_index < expected_location_count; ++location_index) {
                 const ErrorCode location_ec = location_ecs[location_index];
                 if (location_ec != ErrorCode::EC_OK) {
                     if (key_ec == ErrorCode::EC_OK) {
@@ -1289,7 +1341,7 @@ MetaSearcher::BatchReplaceLocationSpecs(RequestContext *request_context,
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
     }
-    return result.ec;
+    return malformed_result ? ErrorCode::EC_MISMATCH : result.ec;
 }
 
 ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
@@ -1303,6 +1355,22 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
     out_per_key_ec.assign(keys.size(), ErrorCode::EC_OK);
     if (keys.empty()) {
         return EC_OK;
+    }
+
+    std::unordered_set<int64_t> seen_keys;
+    for (size_t key_index = 0; key_index < keys.size(); ++key_index) {
+        if (!seen_keys.insert(keys[key_index]).second) {
+            std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), EC_BADARGS);
+            return EC_BADARGS;
+        }
+        std::unordered_set<std::string> seen_location_ids;
+        for (const auto &task : tasks_per_key[key_index]) {
+            if (task.location_id.empty() || !seen_location_ids.insert(task.location_id).second ||
+                ValidateConsistentSnapshotVersion(task.specs) != EC_OK) {
+                std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), EC_BADARGS);
+                return EC_BADARGS;
+            }
+        }
     }
 
     std::vector<std::vector<std::pair<DataStorageType, std::uint64_t>>> created_locs_sz(keys.size());
@@ -1340,10 +1408,6 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
         const std::unordered_set<std::string> existing_id_set(existing_ids.begin(), existing_ids.end());
         bool created = false;
         for (const auto &entry : tasks_per_key[index]) {
-            const ErrorCode validation_ec = ValidateConsistentSnapshotVersion(entry.specs);
-            if (validation_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, validation_ec};
-            }
             if (get_ec == ErrorCode::EC_OK && existing_id_set.count(entry.location_id) > 0) {
                 merge_tasks_per_key[index].push_back(entry);
                 continue;
@@ -1374,8 +1438,15 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteBlock);
     ErrorCode final_ec = result.ec;
 
+    if (result.error_codes.size() != keys.size()) {
+        KVCM_LOG_ERROR("BatchMergeLocationSpecs create result size mismatch, keys[%zu], results[%zu]",
+                       keys.size(),
+                       result.error_codes.size());
+        std::fill(out_per_key_ec.begin(), out_per_key_ec.end(), ErrorCode::EC_MISMATCH);
+        return ErrorCode::EC_MISMATCH;
+    }
     for (size_t i = 0; i < keys.size(); ++i) {
-        ErrorCode key_ec = (i < result.error_codes.size()) ? result.error_codes[i] : result.ec;
+        ErrorCode key_ec = result.error_codes[i];
         out_per_key_ec[i] = key_ec;
         if (key_ec == ErrorCode::EC_OK) {
             for (const auto &[type, size] : created_locs_sz[i]) {
@@ -1442,11 +1513,11 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
         std::vector<ErrorCode> modifier_ecs(loc_ids.size(), ErrorCode::EC_OK);
         bool updated = false;
         for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
-            const ErrorCode ec = get_ecs[loc_index];
-            if (loc_index >= tasks.size()) {
+            if (loc_index >= tasks.size() || loc_index >= get_ecs.size() || loc_index >= locs.size()) {
                 modifier_ecs[loc_index] = ErrorCode::EC_ERROR;
                 continue;
             }
+            const ErrorCode ec = get_ecs[loc_index];
             const auto &task = tasks[loc_index];
             if (ec != ErrorCode::EC_OK && ec != ErrorCode::EC_NOENT) {
                 modifier_ecs[loc_index] = ec;
@@ -1505,13 +1576,22 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
         meta_indexer_->ReadModifyWriteLocation(request_context, merge_keys, merge_location_ids, merge_modifier);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
 
+    bool malformed_merge_result = merge_result.per_location_error_codes.size() != merge_key_indices.size();
+    if (malformed_merge_result) {
+        KVCM_LOG_ERROR("BatchMergeLocationSpecs merge result size mismatch, keys[%zu], results[%zu]",
+                       merge_key_indices.size(),
+                       merge_result.per_location_error_codes.size());
+    }
     for (size_t i = 0; i < merge_key_indices.size(); ++i) {
         const size_t original_key_index = merge_key_indices[i];
         ErrorCode key_ec = ErrorCode::EC_OK;
-        if (i >= merge_result.per_location_error_codes.size()) {
-            key_ec = merge_result.ec == ErrorCode::EC_OK ? ErrorCode::EC_ERROR : merge_result.ec;
+        const size_t expected_location_count = merge_tasks_per_key[original_key_index].size();
+        if (i >= merge_result.per_location_error_codes.size() ||
+            merge_result.per_location_error_codes[i].size() != expected_location_count) {
+            key_ec = ErrorCode::EC_MISMATCH;
+            malformed_merge_result = true;
         } else {
-            for (size_t loc_index = 0; loc_index < merge_result.per_location_error_codes[i].size(); ++loc_index) {
+            for (size_t loc_index = 0; loc_index < expected_location_count; ++loc_index) {
                 const auto loc_ec = merge_result.per_location_error_codes[i][loc_index];
                 if (loc_ec == ErrorCode::EC_OK) {
                     const auto &usage = merge_usage_changes[original_key_index][loc_index];
@@ -1544,6 +1624,13 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
             final_ec = ErrorCode::EC_PARTIAL_OK;
         }
     }
+    if (malformed_merge_result) {
+        if (final_ec == ErrorCode::EC_OK) {
+            final_ec = ErrorCode::EC_MISMATCH;
+        } else if (final_ec != ErrorCode::EC_MISMATCH) {
+            final_ec = ErrorCode::EC_PARTIAL_OK;
+        }
+    }
     return final_ec;
 }
 
@@ -1563,18 +1650,38 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
         out_missing_targets->resize(keys.size());
     }
 
-    // 每个 DeleteLocationSpecsTask 需要独立返回结果；同一个 key 下多个 task
-    // 也可能删除同一个 location 的不同 specs，因此先展开成 task 维度执行。
+    std::unordered_set<int64_t> seen_keys;
+    bool invalid_input = false;
+    for (size_t key_index = 0; key_index < keys.size(); ++key_index) {
+        out_batch_results[key_index].assign(tasks_per_key[key_index].size(), ErrorCode::EC_OK);
+        if (out_missing_targets) {
+            (*out_missing_targets)[key_index].assign(tasks_per_key[key_index].size(), false);
+        }
+        if (!seen_keys.insert(keys[key_index]).second) {
+            invalid_input = true;
+        }
+        std::unordered_set<std::string> seen_location_ids;
+        for (const auto &task : tasks_per_key[key_index]) {
+            if (task.location_id.empty() || !seen_location_ids.insert(task.location_id).second) {
+                invalid_input = true;
+            }
+        }
+    }
+    if (invalid_input) {
+        for (auto &per_key_results : out_batch_results) {
+            std::fill(per_key_results.begin(), per_key_results.end(), EC_BADARGS);
+        }
+        return EC_BADARGS;
+    }
+
+    // 每个 DeleteLocationSpecsTask 需要独立返回结果。一个 key 下的 location
+    // 必须唯一；否则多个 RMW 槽会从同一旧值计算并发生 last-write-wins 丢更新。
     KeyVector flat_keys;
     LocationIdsPerKey flat_location_ids;
     std::vector<std::pair<size_t, size_t>> flat_to_original_task_indices;
     std::vector<std::pair<DataStorageType, std::uint64_t>> flat_deleted_specs_size;
     std::vector<std::uint8_t> flat_missing_targets;
     for (size_t i = 0; i < keys.size(); ++i) {
-        out_batch_results[i].assign(tasks_per_key[i].size(), ErrorCode::EC_OK);
-        if (out_missing_targets) {
-            (*out_missing_targets)[i].assign(tasks_per_key[i].size(), false);
-        }
         for (size_t task_index = 0; task_index < tasks_per_key[i].size(); ++task_index) {
             flat_keys.push_back(keys[i]);
             flat_location_ids.push_back({tasks_per_key[i][task_index].location_id});
@@ -1621,6 +1728,12 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
 
         const auto [original_key_index, original_task_index] = flat_to_original_task_indices[key_index];
         const auto &task = tasks_per_key[original_key_index][original_task_index];
+        if (task.spec_names.empty() || std::any_of(task.spec_names.begin(),
+                                                   task.spec_names.end(),
+                                                   [](const std::string &name) { return name.empty(); })) {
+            modifier_ecs[0] = ErrorCode::EC_BADARGS;
+            return {ModifierAction::MA_SKIP, std::move(modifier_ecs)};
+        }
         const ErrorCode ec = get_ecs.empty() ? ErrorCode::EC_ERROR : get_ecs[0];
         const std::string &loc_id = loc_ids[0];
 
@@ -1642,11 +1755,6 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
         if (locs.empty() || !locs[0]) {
             flat_missing_targets[key_index] = 1;
             modifier_ecs[0] = ErrorCode::EC_OK;
-            return {ModifierAction::MA_SKIP, std::move(modifier_ecs)};
-        }
-
-        if (task.spec_names.empty()) {
-            modifier_ecs[0] = ErrorCode::EC_BADARGS;
             return {ModifierAction::MA_SKIP, std::move(modifier_ecs)};
         }
 
@@ -1684,11 +1792,19 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
 
     // ReadModifyWriteLocation 返回 flat 维度结果，这里映射回原始 key/task 维度。
+    bool malformed_result = result.per_location_error_codes.size() != flat_to_original_task_indices.size();
+    if (malformed_result) {
+        KVCM_LOG_ERROR("BatchDeleteLocationSpecs result size mismatch, tasks[%zu], results[%zu]",
+                       flat_to_original_task_indices.size(),
+                       result.per_location_error_codes.size());
+    }
     for (size_t i = 0; i < flat_to_original_task_indices.size(); ++i) {
         const auto [original_key_index, original_task_index] = flat_to_original_task_indices[i];
-        ErrorCode ec = result.ec;
-        if (i < result.per_location_error_codes.size() && !result.per_location_error_codes[i].empty()) {
+        ErrorCode ec = ErrorCode::EC_MISMATCH;
+        if (i < result.per_location_error_codes.size() && result.per_location_error_codes[i].size() == 1) {
             ec = result.per_location_error_codes[i][0];
+        } else {
+            malformed_result = true;
         }
         out_batch_results[original_key_index][original_task_index] = ec;
         if (out_missing_targets) {
@@ -1708,7 +1824,7 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
     }
-    return result.ec;
+    return malformed_result ? ErrorCode::EC_MISMATCH : result.ec;
 }
 
 ErrorCode MetaSearcher::BatchUpdateLocationStatus(RequestContext *request_context,
@@ -2102,7 +2218,8 @@ ErrorCode MetaSearcher::CleanupLocationsByPredicate(RequestContext *request_cont
                                                     DataStorageType storage_type,
                                                     size_t scan_batch_size,
                                                     LocationCleanupPredicate should_delete,
-                                                    std::function<bool()> should_abort) {
+                                                    std::function<bool()> should_abort,
+                                                    AcquireMetadataWriteLeaseFunc acquire_cleanup_lease) {
     if (!should_delete) {
         return EC_BADARGS;
     }
@@ -2154,11 +2271,59 @@ ErrorCode MetaSearcher::CleanupLocationsByPredicate(RequestContext *request_cont
                 }
             }
             if (has_deletes) {
-                if (!submit_del_req_func_) {
-                    KVCM_LOG_WARN("CleanupLocationsByPredicate: reclaimer submit callback is unavailable");
-                    return EC_ERROR;
+                // Callers without a lifecycle lease historically cancel only at
+                // scan-batch boundaries.  Lease-aware cleanup rechecks here so
+                // a lifecycle change during the scan cannot reach the delete.
+                if (acquire_cleanup_lease && should_abort && should_abort()) {
+                    KVCM_LOG_INFO("CleanupLocationsByPredicate: aborted before delete");
+                    return EC_OK;
                 }
-                submit_del_req_func_(keys, delete_location_ids, expected_location_values, true);
+                if (acquire_cleanup_lease) {
+                    auto [lease_ec, cleanup_lease] = acquire_cleanup_lease();
+                    if (lease_ec == EC_MISMATCH || lease_ec == EC_NODE_NOT_REGISTERED ||
+                        lease_ec == EC_INSTANCE_NOT_EXIST) {
+                        KVCM_LOG_INFO("CleanupLocationsByPredicate: lifecycle changed before delete, ec %d", lease_ec);
+                        return EC_OK;
+                    }
+                    if (lease_ec != EC_OK) {
+                        KVCM_LOG_WARN("CleanupLocationsByPredicate: failed to acquire cleanup lease, ec %d", lease_ec);
+                        return lease_ec;
+                    }
+
+                    KeyVector delete_keys;
+                    LocationIdsPerKey compact_location_ids;
+                    std::vector<std::vector<std::string>> compact_expected_values;
+                    delete_keys.reserve(keys.size());
+                    compact_location_ids.reserve(keys.size());
+                    compact_expected_values.reserve(keys.size());
+                    for (size_t i = 0; i < keys.size(); ++i) {
+                        if (delete_location_ids[i].empty()) {
+                            continue;
+                        }
+                        delete_keys.push_back(keys[i]);
+                        compact_location_ids.push_back(std::move(delete_location_ids[i]));
+                        compact_expected_values.push_back(std::move(expected_location_values[i]));
+                    }
+                    std::vector<std::vector<ErrorCode>> per_location_ec;
+                    const ErrorCode delete_ec = BatchDeleteLocations(
+                        request_context, delete_keys, compact_location_ids, per_location_ec, compact_expected_values);
+                    if (delete_ec != EC_OK) {
+                        has_failure = true;
+                    }
+                    for (const auto &per_key_ec : per_location_ec) {
+                        for (const ErrorCode location_ec : per_key_ec) {
+                            if (location_ec != EC_OK && location_ec != EC_NOENT && location_ec != EC_MISMATCH) {
+                                has_failure = true;
+                            }
+                        }
+                    }
+                } else {
+                    if (!submit_del_req_func_) {
+                        KVCM_LOG_WARN("CleanupLocationsByPredicate: reclaimer submit callback is unavailable");
+                        return EC_ERROR;
+                    }
+                    submit_del_req_func_(keys, delete_location_ids, expected_location_values, true);
+                }
             }
         }
         cursor = next_cursor;
@@ -2210,6 +2375,10 @@ ErrorCode MetaSearcher::CleanupLocationsByHost(RequestContext *request_context,
                     }
                     for (const auto &kv : location_maps[i]) {
                         const std::string &loc_id = kv.first;
+                        if (!kv.second) {
+                            has_failure = true;
+                            continue;
+                        }
                         const CacheLocation &loc = *kv.second;
                         if (loc.type() == storage_type && loc_id.size() >= host_suffix.size() &&
                             loc_id.compare(loc_id.size() - host_suffix.size(), host_suffix.size(), host_suffix) == 0) {

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <set>
 #include <sstream>
@@ -331,13 +332,21 @@ bool IsMediumMatched(const StandardUri &uri, const std::unordered_set<std::strin
     return medium_set.find(medium) != medium_set.end();
 }
 
-using HostToSpecNames = std::map<std::string, std::set<std::string>>;
-using KeyToHostSpecNames = std::vector<HostToSpecNames>; // key -> host -> spec names
+struct HostSpecNames {
+    std::string host;
+    std::vector<std::string> spec_names;
+};
 
-void BuildHostSpecNamesForOneKey(const CacheLocationVector &locations,
-                                 const CheckLocDataExistFunc &check_loc_data_exist,
-                                 const std::unordered_set<std::string> &medium_set,
-                                 HostToSpecNames &host_specs) {
+using HostSpecNamesVector = std::vector<HostSpecNames>;
+using KeyToHostSpecNames = std::vector<HostSpecNamesVector>;
+
+template <typename Visitor>
+void VisitHostSpecsForOneKey(const CacheLocationVector &locations,
+                             const CheckLocDataExistFunc &check_loc_data_exist,
+                             const MetaSearcher::CheckHostCacheLocationFunc *request_check_location,
+                             const std::unordered_set<std::string> &medium_set,
+                             bool visit_spec_names,
+                             Visitor &&visitor) {
     for (const auto &loc : locations) {
         // Host cache state is a read-availability API. WRITING, DELETING and
         // other transitional locations must not contribute a hit merely
@@ -345,28 +354,141 @@ void BuildHostSpecNamesForOneKey(const CacheLocationVector &locations,
         if (!loc || loc->status() != CacheLocationStatus::CLS_SERVING || loc->location_specs().empty()) {
             continue;
         }
-        if (check_loc_data_exist && !check_loc_data_exist(*loc)) {
-            continue;
-        }
-        std::string event_medium;
-        std::string reporter_host;
-        const bool has_reporter_identity =
-            IsEventReportStorageType(loc->type()) &&
-            SnapshotUriUtils::ParseEventReportLocationId(loc->id(), event_medium, reporter_host);
-        for (const auto &spec : loc->location_specs()) {
-            StandardUri uri(spec.uri());
-            const bool medium_matches = has_reporter_identity ? medium_set.empty() || medium_set.count(event_medium) > 0
-                                                              : IsMediumMatched(uri, medium_set);
-            if (!uri.Valid() || !medium_matches) {
+
+        MetaSearcher::HostCacheLocationInfo location_info;
+        if (request_check_location) {
+            if (!(*request_check_location)(*loc, location_info)) {
                 continue;
             }
-            std::string host = has_reporter_identity ? reporter_host : uri.GetHostPort();
+        } else if (check_loc_data_exist && !check_loc_data_exist(*loc)) {
+            continue;
+        }
+
+        bool has_reporter_identity = location_info.has_reporter_identity;
+        if (!has_reporter_identity && IsEventReportStorageType(loc->type())) {
+            has_reporter_identity = SnapshotUriUtils::ParseEventReportLocationId(
+                loc->id(), location_info.reporter_medium, location_info.reporter_host);
+        }
+        if (has_reporter_identity) {
+            if ((!medium_set.empty() && medium_set.count(location_info.reporter_medium) == 0) ||
+                location_info.reporter_host.empty()) {
+                continue;
+            }
+            // The request-specific EventReport checker validates every URI
+            // while applying the reporter generation/liveness fence. Reuse
+            // that work instead of reparsing each URI during host projection.
+            const bool specs_already_validated =
+                request_check_location != nullptr && location_info.has_reporter_identity;
+            if (!visit_spec_names) {
+                if (specs_already_validated) {
+                    visitor(location_info.reporter_host, std::string{});
+                    continue;
+                }
+                for (const auto &spec : loc->location_specs()) {
+                    const StandardUri uri(spec.uri());
+                    if (uri.Valid()) {
+                        visitor(location_info.reporter_host, std::string{});
+                        break;
+                    }
+                }
+                continue;
+            }
+            for (const auto &spec : loc->location_specs()) {
+                if (!specs_already_validated) {
+                    const StandardUri uri(spec.uri());
+                    if (!uri.Valid()) {
+                        continue;
+                    }
+                }
+                visitor(location_info.reporter_host, spec.name());
+            }
+            continue;
+        }
+
+        for (const auto &spec : loc->location_specs()) {
+            const StandardUri uri(spec.uri());
+            if (!uri.Valid() || !IsMediumMatched(uri, medium_set)) {
+                continue;
+            }
+            std::string host = uri.GetHostPort();
             if (host.empty()) {
                 continue;
             }
-            host_specs[std::move(host)].insert(spec.name());
+            visitor(host, spec.name());
         }
     }
+}
+
+void BuildHostsForOneKey(const CacheLocationVector &locations,
+                         const CheckLocDataExistFunc &check_loc_data_exist,
+                         const MetaSearcher::CheckHostCacheLocationFunc *request_check_location,
+                         const std::unordered_set<std::string> &medium_set,
+                         std::vector<std::string> &hosts) {
+    VisitHostSpecsForOneKey(locations,
+                            check_loc_data_exist,
+                            request_check_location,
+                            medium_set,
+                            false,
+                            [&hosts](const std::string &host, const std::string &) { hosts.push_back(host); });
+    std::sort(hosts.begin(), hosts.end());
+    hosts.erase(std::unique(hosts.begin(), hosts.end()), hosts.end());
+}
+
+void BuildCandidatePresenceForOneKey(const CacheLocationVector &locations,
+                                     const CheckLocDataExistFunc &check_loc_data_exist,
+                                     const MetaSearcher::CheckHostCacheLocationFunc *request_check_location,
+                                     const std::unordered_set<std::string> &medium_set,
+                                     const std::unordered_map<std::string, std::size_t> &candidate_indices,
+                                     std::uint64_t *presence_words) {
+    VisitHostSpecsForOneKey(locations,
+                            check_loc_data_exist,
+                            request_check_location,
+                            medium_set,
+                            false,
+                            [&candidate_indices, presence_words](const std::string &host, const std::string &) {
+                                const auto it = candidate_indices.find(host);
+                                if (it != candidate_indices.end()) {
+                                    presence_words[it->second / 64] |= std::uint64_t{1} << (it->second % 64);
+                                }
+                            });
+}
+
+void BuildHostSpecNamesForOneKey(const CacheLocationVector &locations,
+                                 const CheckLocDataExistFunc &check_loc_data_exist,
+                                 const MetaSearcher::CheckHostCacheLocationFunc *request_check_location,
+                                 const std::unordered_set<std::string> &medium_set,
+                                 HostSpecNamesVector &host_specs) {
+    VisitHostSpecsForOneKey(locations,
+                            check_loc_data_exist,
+                            request_check_location,
+                            medium_set,
+                            true,
+                            [&host_specs](const std::string &host, const std::string &spec_name) {
+                                auto host_it = std::find_if(host_specs.begin(),
+                                                            host_specs.end(),
+                                                            [&host](const auto &entry) { return entry.host == host; });
+                                if (host_it == host_specs.end()) {
+                                    host_specs.push_back(HostSpecNames{host, {spec_name}});
+                                    return;
+                                }
+                                if (std::find(host_it->spec_names.begin(), host_it->spec_names.end(), spec_name) ==
+                                    host_it->spec_names.end()) {
+                                    host_it->spec_names.push_back(spec_name);
+                                }
+                            });
+    for (auto &host_spec : host_specs) {
+        std::sort(host_spec.spec_names.begin(), host_spec.spec_names.end());
+    }
+    std::sort(
+        host_specs.begin(), host_specs.end(), [](const auto &lhs, const auto &rhs) { return lhs.host < rhs.host; });
+}
+
+const std::vector<std::string> *FindHostSpecNames(const HostSpecNamesVector &host_specs, const std::string &host) {
+    const auto it =
+        std::lower_bound(host_specs.begin(), host_specs.end(), host, [](const auto &entry, const auto &name) {
+            return entry.host < name;
+        });
+    return it != host_specs.end() && it->host == host ? &it->spec_names : nullptr;
 }
 
 bool IsFullLocationSpecGroup(const LocationSpecGroup &group) {
@@ -374,11 +496,11 @@ bool IsFullLocationSpecGroup(const LocationSpecGroup &group) {
     return name.rfind("full", 0) == 0 || name.rfind("FULL", 0) == 0;
 }
 
-bool HasAllLocationSpecGroups(const std::set<std::string> &spec_names,
+bool HasAllLocationSpecGroups(const std::vector<std::string> &spec_names,
                               const std::vector<const LocationSpecGroup *> &groups) {
     for (const auto *group : groups) {
         for (const auto &spec_name : group->spec_names()) {
-            if (spec_names.find(spec_name) == spec_names.end()) {
+            if (!std::binary_search(spec_names.begin(), spec_names.end(), spec_name)) {
                 return false;
             }
         }
@@ -833,7 +955,7 @@ ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
                                           bool use_eagle_pop,
                                           const std::vector<std::string> &medium_filter,
                                           std::vector<HostCacheMatch> &out_matches,
-                                          const CheckLocDataExistFunc *request_check_loc_data_exist) const {
+                                          const CheckHostCacheLocationFunc *request_check_location) const {
     SPAN_TRACER(request_context);
     out_matches.clear();
     if (keys.empty()) {
@@ -862,18 +984,46 @@ ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
         return EC_OK;
     }
 
-    KeyToHostSpecNames key_to_host_spec_names(valid_key_count);
     const std::unordered_set<std::string> medium_set(medium_filter.begin(), medium_filter.end());
-    const auto &check_loc_data_exist =
-        request_check_loc_data_exist ? *request_check_loc_data_exist : check_loc_data_exist_func_;
+    const auto &check_loc_data_exist = check_loc_data_exist_func_;
+    std::vector<std::string> candidate_hosts;
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostProjection);
+    BuildHostsForOneKey(
+        location_values.front(), check_loc_data_exist, request_check_location, medium_set, candidate_hosts);
+    if (candidate_hosts.empty()) {
+        KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostProjection);
+        return EC_OK;
+    }
+
+    std::unordered_map<std::string, std::size_t> candidate_indices;
+    candidate_indices.reserve(candidate_hosts.size());
+    for (std::size_t i = 0; i < candidate_hosts.size(); ++i) {
+        candidate_indices.emplace(candidate_hosts[i], i);
+    }
+    const std::size_t presence_word_count = (candidate_hosts.size() + 63) / 64;
+    if (valid_key_count > std::numeric_limits<std::size_t>::max() / presence_word_count) {
+        KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostProjection);
+        request_context->error_tracer()->AddErrorMsg("host presence matrix size overflow");
+        return EC_ERROR;
+    }
+    std::vector<std::uint64_t> candidate_presence(valid_key_count * presence_word_count, 0);
     const bool projection_ok = meta_indexer_->ParallelForQuery(
-        valid_key_count,
-        [&location_values, &check_loc_data_exist, &medium_set, &key_to_host_spec_names](std::size_t begin,
-                                                                                        std::size_t end) {
-            for (std::size_t i = begin; i < end; ++i) {
-                BuildHostSpecNamesForOneKey(
-                    location_values[i], check_loc_data_exist, medium_set, key_to_host_spec_names[i]);
+        valid_key_count - 1,
+        [&location_values,
+         &check_loc_data_exist,
+         request_check_location,
+         &medium_set,
+         &candidate_indices,
+         &candidate_presence,
+         presence_word_count](std::size_t begin, std::size_t end) {
+            for (std::size_t offset = begin; offset < end; ++offset) {
+                const std::size_t key_index = offset + 1;
+                BuildCandidatePresenceForOneKey(location_values[key_index],
+                                                check_loc_data_exist,
+                                                request_check_location,
+                                                medium_set,
+                                                candidate_indices,
+                                                candidate_presence.data() + key_index * presence_word_count);
             }
         });
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostProjection);
@@ -882,27 +1032,18 @@ ErrorCode MetaSearcher::PrefixMatchByHost(RequestContext *request_context,
         return EC_ERROR;
     }
 
-    if (key_to_host_spec_names.front().empty()) {
-        return EC_OK;
-    }
-
-    std::vector<std::string> candidate_hosts;
-    candidate_hosts.reserve(key_to_host_spec_names.front().size());
-    for (const auto &[host, spec_names] : key_to_host_spec_names.front()) {
-        (void)spec_names;
-        candidate_hosts.push_back(host);
-    }
     std::vector<int64_t> prefix_lengths(candidate_hosts.size(), 0);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostPrefixReduce);
     const bool reduce_ok = meta_indexer_->ParallelForQuery(
         candidate_hosts.size(),
-        [&candidate_hosts, &key_to_host_spec_names, &prefix_lengths, use_eagle_pop](std::size_t begin,
-                                                                                    std::size_t end) {
+        [&candidate_presence, presence_word_count, valid_key_count, &prefix_lengths, use_eagle_pop](std::size_t begin,
+                                                                                                    std::size_t end) {
             for (std::size_t host_index = begin; host_index < end; ++host_index) {
-                const auto &host = candidate_hosts[host_index];
                 int64_t prefix_len = 1;
-                for (size_t i = 1; i < key_to_host_spec_names.size(); ++i) {
-                    if (key_to_host_spec_names[i].find(host) == key_to_host_spec_names[i].end()) {
+                const std::size_t word_index = host_index / 64;
+                const std::uint64_t bit = std::uint64_t{1} << (host_index % 64);
+                for (std::size_t i = 1; i < valid_key_count; ++i) {
+                    if ((candidate_presence[i * presence_word_count + word_index] & bit) == 0) {
                         break;
                     }
                     ++prefix_len;
@@ -933,7 +1074,7 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
                                                    const std::vector<std::string> &medium_filter,
                                                    const std::vector<LocationSpecGroup> &location_spec_groups,
                                                    std::vector<HostCacheMatch> &out_matches,
-                                                   const CheckLocDataExistFunc *request_check_loc_data_exist) const {
+                                                   const CheckHostCacheLocationFunc *request_check_location) const {
     SPAN_TRACER(request_context);
     out_matches.clear();
     if (keys.empty()) {
@@ -983,16 +1124,18 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
 
     KeyToHostSpecNames key_to_host_spec_names(valid_key_count);
     const std::unordered_set<std::string> medium_set(medium_filter.begin(), medium_filter.end());
-    const auto &check_loc_data_exist =
-        request_check_loc_data_exist ? *request_check_loc_data_exist : check_loc_data_exist_func_;
+    const auto &check_loc_data_exist = check_loc_data_exist_func_;
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostProjection);
     const bool projection_ok = meta_indexer_->ParallelForQuery(
         valid_key_count,
-        [&location_values, &check_loc_data_exist, &medium_set, &key_to_host_spec_names](std::size_t begin,
-                                                                                        std::size_t end) {
+        [&location_values, &check_loc_data_exist, request_check_location, &medium_set, &key_to_host_spec_names](
+            std::size_t begin, std::size_t end) {
             for (std::size_t i = begin; i < end; ++i) {
-                BuildHostSpecNamesForOneKey(
-                    location_values[i], check_loc_data_exist, medium_set, key_to_host_spec_names[i]);
+                BuildHostSpecNamesForOneKey(location_values[i],
+                                            check_loc_data_exist,
+                                            request_check_location,
+                                            medium_set,
+                                            key_to_host_spec_names[i]);
             }
         });
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherHostProjection);
@@ -1003,9 +1146,8 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
 
     std::vector<std::string> candidate_hosts;
     candidate_hosts.reserve(key_to_host_spec_names.front().size());
-    for (const auto &[host, spec_names] : key_to_host_spec_names.front()) {
-        (void)spec_names;
-        candidate_hosts.push_back(host);
+    for (const auto &host_spec_names : key_to_host_spec_names.front()) {
+        candidate_hosts.push_back(host_spec_names.host);
     }
     std::vector<int64_t> prefix_lengths(candidate_hosts.size(), 0);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherHostPrefixReduce);
@@ -1017,9 +1159,8 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
                 const auto &host = candidate_hosts[host_index];
                 size_t full_prefix_len = 0;
                 for (; full_prefix_len < key_to_host_spec_names.size(); ++full_prefix_len) {
-                    auto host_it = key_to_host_spec_names[full_prefix_len].find(host);
-                    if (host_it == key_to_host_spec_names[full_prefix_len].end() ||
-                        !HasAllLocationSpecGroups(host_it->second, full_groups)) {
+                    const auto *spec_names = FindHostSpecNames(key_to_host_spec_names[full_prefix_len], host);
+                    if (!spec_names || !HasAllLocationSpecGroups(*spec_names, full_groups)) {
                         break;
                     }
                 }
@@ -1034,9 +1175,8 @@ ErrorCode MetaSearcher::PrefixMatchWithMambaByHost(RequestContext *request_conte
                 // range to also contain every state spec group.
                 for (size_t offset = full_prefix_len; offset > 0; --offset) {
                     const size_t index = offset - 1;
-                    auto host_it = key_to_host_spec_names[index].find(host);
-                    if (host_it != key_to_host_spec_names[index].end() &&
-                        HasAllLocationSpecGroups(host_it->second, mamba_state_groups)) {
+                    const auto *spec_names = FindHostSpecNames(key_to_host_spec_names[index], host);
+                    if (spec_names && HasAllLocationSpecGroups(*spec_names, mamba_state_groups)) {
                         prefix_lengths[host_index] = static_cast<int64_t>(index + 1);
                         break;
                     }

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -5,6 +5,7 @@
 #include <map>
 #include <set>
 #include <sstream>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -191,6 +192,17 @@ CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
     return result;
 }
 
+using RequestedSpecNameSet = std::unordered_set<std::string>;
+
+bool MatchesRequestedSpec(const CacheLocation &loc, const RequestedSpecNameSet &requested_spec_names) {
+    if (requested_spec_names.empty()) {
+        return true;
+    }
+    return std::any_of(loc.location_specs().begin(), loc.location_specs().end(), [&](const LocationSpec &spec) {
+        return requested_spec_names.count(spec.name()) > 0;
+    });
+}
+
 std::string ExtractPeerAddrFromLocation(const CacheLocation &loc) {
     if (loc.location_specs().empty()) {
         return {};
@@ -232,7 +244,9 @@ V6DPeerSelection SelectV6DByPrefix(const std::vector<size_t> &candidate_indices,
             }
             prefix_covered.push_back(ci);
         }
-        if (prefix_covered.size() > best.covered_indices.size()) {
+        if (prefix_covered.size() > best.covered_indices.size() ||
+            (prefix_covered.size() == best.covered_indices.size() &&
+             (best.peer_addr.empty() || addr < best.peer_addr))) {
             best.peer_addr = addr;
             best.covered_indices = std::move(prefix_covered);
         }
@@ -258,7 +272,8 @@ SelectV6DByCoverage(const std::vector<size_t> &candidate_indices,
     }
     V6DPeerSelection best;
     for (auto &[addr, indices] : addr_to_indices) {
-        if (indices.size() > best.covered_indices.size()) {
+        if (indices.size() > best.covered_indices.size() ||
+            (indices.size() == best.covered_indices.size() && (best.peer_addr.empty() || addr < best.peer_addr))) {
             best.peer_addr = addr;
             best.covered_indices = indices;
         }
@@ -539,6 +554,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
     SPAN_TRACER(request_context);
     out_locations.clear();
     out_locations.resize(keys.size());
+    const RequestedSpecNameSet requested_spec_name_set(requested_spec_names.begin(), requested_spec_names.end());
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
     CacheLocationMapVector location_maps;
@@ -595,14 +611,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 for (const auto &[id, loc] : vmap) {
                     if (loc->type() != target_type)
                         continue;
-                    if (!requested_spec_names.empty() &&
-                        std::none_of(loc->location_specs().begin(),
-                                     loc->location_specs().end(),
-                                     [&requested_spec_names](const LocationSpec &spec) {
-                                         return std::find(requested_spec_names.begin(),
-                                                          requested_spec_names.end(),
-                                                          spec.name()) != requested_spec_names.end();
-                                     }))
+                    if (!MatchesRequestedSpec(*loc, requested_spec_name_set))
                         continue;
                     std::string addr = ExtractPeerAddrFromLocation(*loc);
                     if (addr.empty())
@@ -652,16 +661,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 const auto &vmap = valid_maps[i];
                 CacheLocationMap filtered;
                 for (const auto &[id, loc] : vmap) {
-                    const bool matches_requested_spec =
-                        requested_spec_names.empty() ||
-                        std::any_of(loc->location_specs().begin(),
-                                    loc->location_specs().end(),
-                                    [&requested_spec_names](const LocationSpec &spec) {
-                                        return std::find(requested_spec_names.begin(),
-                                                         requested_spec_names.end(),
-                                                         spec.name()) != requested_spec_names.end();
-                                    });
-                    if (loc->type() == target_type && matches_requested_spec) {
+                    if (loc->type() == target_type && MatchesRequestedSpec(*loc, requested_spec_name_set)) {
                         filtered.try_emplace(id, loc);
                     }
                 }
@@ -1095,19 +1095,27 @@ MetaSearcher::BatchReplaceLocationSpecs(RequestContext *request_context,
     }
 
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
-    std::vector<MetadataWriteLease> write_leases;
-    auto modifier = [&keys, &tasks_per_key, &usage_changes, &acquire_write_lease, &write_leases, batch_create_time](
-                        const std::vector<ErrorCode> &get_ecs,
-                        const LocationIdVector &location_ids,
-                        size_t key_index,
-                        CacheLocationVector &locations,
-                        PropertyMap & /*upsert_property_map*/) -> LocationModifierResult {
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(location_ids.size(), lease_ec)};
-            }
-            write_leases.push_back(std::move(lease));
+    bool write_lease_attempted = false;
+    ErrorCode write_lease_ec = EC_OK;
+    MetadataWriteLease write_lease;
+    auto modifier = [&keys,
+                     &tasks_per_key,
+                     &usage_changes,
+                     &acquire_write_lease,
+                     &write_lease_attempted,
+                     &write_lease_ec,
+                     &write_lease,
+                     batch_create_time](const std::vector<ErrorCode> &get_ecs,
+                                        const LocationIdVector &location_ids,
+                                        size_t key_index,
+                                        CacheLocationVector &locations,
+                                        PropertyMap & /*upsert_property_map*/) -> LocationModifierResult {
+        if (acquire_write_lease && !write_lease_attempted) {
+            std::tie(write_lease_ec, write_lease) = acquire_write_lease();
+            write_lease_attempted = true;
+        }
+        if (write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(location_ids.size(), write_lease_ec)};
         }
         const auto &tasks = tasks_per_key[key_index];
         std::vector<ErrorCode> modifier_ecs(location_ids.size(), ErrorCode::EC_OK);
@@ -1213,29 +1221,36 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
         return EC_BADARGS;
     }
     out_per_key_ec.assign(keys.size(), ErrorCode::EC_OK);
+    if (keys.empty()) {
+        return EC_OK;
+    }
 
     std::vector<std::vector<std::pair<DataStorageType, std::uint64_t>>> created_locs_sz(keys.size());
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
     std::vector<std::vector<MergeLocationSpecsTask>> merge_tasks_per_key(keys.size());
-    std::vector<MetadataWriteLease> write_leases;
+    bool create_write_lease_attempted = false;
+    ErrorCode create_write_lease_ec = EC_OK;
+    MetadataWriteLease create_write_lease;
 
     auto create_modifier = [&tasks_per_key,
                             &merge_tasks_per_key,
                             &keys,
                             &created_locs_sz,
                             &acquire_write_lease,
-                            &write_leases,
+                            &create_write_lease_attempted,
+                            &create_write_lease_ec,
+                            &create_write_lease,
                             batch_create_time](const LocationIdVector &existing_ids,
                                                ErrorCode get_ec,
                                                size_t index,
                                                PropertyMap & /*upsert_property_map*/,
                                                CacheLocationMap &out_new_locations) -> ModifierResult {
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, lease_ec};
-            }
-            write_leases.push_back(std::move(lease));
+        if (acquire_write_lease && !create_write_lease_attempted) {
+            std::tie(create_write_lease_ec, create_write_lease) = acquire_write_lease();
+            create_write_lease_attempted = true;
+        }
+        if (create_write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, create_write_lease_ec};
         }
         if (get_ec != ErrorCode::EC_OK && get_ec != ErrorCode::EC_NOENT) {
             KVCM_LOG_WARN("load location ids failed, key[%lu](%lu) return %d", index, keys[index], get_ec);
@@ -1317,25 +1332,30 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
     for (size_t i = 0; i < keys.size(); ++i) {
         merge_usage_changes[i].resize(merge_tasks_per_key[i].size());
     }
-    write_leases.clear();
+    create_write_lease.reset();
+    bool merge_write_lease_attempted = false;
+    ErrorCode merge_write_lease_ec = EC_OK;
+    MetadataWriteLease merge_write_lease;
     auto merge_modifier = [&keys,
                            &merge_tasks_per_key,
                            &merge_key_indices,
                            &merge_usage_changes,
                            &acquire_write_lease,
-                           &write_leases,
+                           &merge_write_lease_attempted,
+                           &merge_write_lease_ec,
+                           &merge_write_lease,
                            batch_create_time](const std::vector<ErrorCode> &get_ecs,
                                               const LocationIdVector &loc_ids,
                                               size_t key_index,
                                               CacheLocationVector &locs,
                                               PropertyMap &upsert_property_map) -> LocationModifierResult {
         (void)upsert_property_map;
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), lease_ec)};
-            }
-            write_leases.push_back(std::move(lease));
+        if (acquire_write_lease && !merge_write_lease_attempted) {
+            std::tie(merge_write_lease_ec, merge_write_lease) = acquire_write_lease();
+            merge_write_lease_attempted = true;
+        }
+        if (merge_write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), merge_write_lease_ec)};
         }
         const size_t original_key_index = merge_key_indices[key_index];
         const auto &tasks = merge_tasks_per_key[original_key_index];
@@ -1470,7 +1490,6 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
     std::vector<std::pair<size_t, size_t>> flat_to_original_task_indices;
     std::vector<std::pair<DataStorageType, std::uint64_t>> flat_deleted_specs_size;
     std::vector<std::uint8_t> flat_missing_targets;
-    std::vector<MetadataWriteLease> write_leases;
     for (size_t i = 0; i < keys.size(); ++i) {
         out_batch_results[i].assign(tasks_per_key[i].size(), ErrorCode::EC_OK);
         if (out_missing_targets) {
@@ -1490,24 +1509,29 @@ ErrorCode MetaSearcher::BatchDeleteLocationSpecs(RequestContext *request_context
 
     // 每条 flat task 独立处理：NOENT 视为幂等成功；spec_names 为空返回 BADARGS；
     // 删除后无剩余 specs 则删除整个 location，否则 COW 更新 location_specs。
+    bool write_lease_attempted = false;
+    ErrorCode write_lease_ec = EC_OK;
+    MetadataWriteLease write_lease;
     auto modifier = [&keys,
                      &tasks_per_key,
                      &flat_to_original_task_indices,
                      &flat_deleted_specs_size,
                      &flat_missing_targets,
                      &acquire_write_lease,
-                     &write_leases](const std::vector<ErrorCode> &get_ecs,
-                                    const LocationIdVector &loc_ids,
-                                    size_t key_index,
-                                    CacheLocationVector &locs,
-                                    PropertyMap &upsert_property_map) -> LocationModifierResult {
+                     &write_lease_attempted,
+                     &write_lease_ec,
+                     &write_lease](const std::vector<ErrorCode> &get_ecs,
+                                   const LocationIdVector &loc_ids,
+                                   size_t key_index,
+                                   CacheLocationVector &locs,
+                                   PropertyMap &upsert_property_map) -> LocationModifierResult {
         (void)upsert_property_map;
-        if (acquire_write_lease) {
-            auto [lease_ec, lease] = acquire_write_lease();
-            if (lease_ec != EC_OK) {
-                return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), lease_ec)};
-            }
-            write_leases.push_back(std::move(lease));
+        if (acquire_write_lease && !write_lease_attempted) {
+            std::tie(write_lease_ec, write_lease) = acquire_write_lease();
+            write_lease_attempted = true;
+        }
+        if (write_lease_ec != EC_OK) {
+            return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), write_lease_ec)};
         }
         std::vector<ErrorCode> modifier_ecs(loc_ids.size(), ErrorCode::EC_OK);
         if (loc_ids.size() != 1 || key_index >= flat_to_original_task_indices.size()) {

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -91,8 +91,7 @@ ErrorCode ValidateConsistentSnapshotVersion(const std::vector<LocationSpec> &spe
             continue;
         }
         SnapshotUriInfo info;
-        if (has_unversioned_spec || version_param_count != 1 ||
-            !SnapshotUriUtils::ParseSnapshotUriInfo(spec.uri(), info)) {
+        if (has_unversioned_spec || version_param_count != 1 || !SnapshotUriUtils::ParseSnapshotUriInfo(uri, info)) {
             return EC_BADARGS;
         }
         if (!has_snapshot_version) {
@@ -105,32 +104,43 @@ ErrorCode ValidateConsistentSnapshotVersion(const std::vector<LocationSpec> &spe
     return EC_OK;
 }
 
-ErrorCode MergeLocationSpecsByName(const std::vector<LocationSpec> &old_specs,
-                                   const std::vector<LocationSpec> &new_specs,
-                                   std::vector<LocationSpec> &out_specs) {
-    const ErrorCode parse_ec = ValidateConsistentSnapshotVersion(new_specs);
-    if (parse_ec != EC_OK) {
-        return parse_ec;
+void MergeLocationSpecsByName(std::vector<LocationSpec> &merged_specs, const std::vector<LocationSpec> &new_specs) {
+    // Snapshot generations are reconciliation/cleanup tags, not a visibility
+    // fence. After a KVCM restart, a new delta may use a fresh generation while
+    // untouched specs still carry an older one. Preserve those specs and
+    // overwrite only names present in this delta. Normalize any legacy
+    // duplicate names in place with the same last-value-wins behavior the old
+    // std::map implementation provided.
+    size_t unique_count = 0;
+    for (size_t i = 0; i < merged_specs.size(); ++i) {
+        auto duplicate =
+            std::find_if(merged_specs.begin(),
+                         merged_specs.begin() + unique_count,
+                         [&merged_specs, i](const auto &spec) { return spec.name() == merged_specs[i].name(); });
+        if (duplicate != merged_specs.begin() + unique_count) {
+            *duplicate = std::move(merged_specs[i]);
+            continue;
+        }
+        if (i != unique_count) {
+            merged_specs[unique_count] = std::move(merged_specs[i]);
+        }
+        ++unique_count;
     }
+    merged_specs.resize(unique_count);
 
-    std::map<std::string, LocationSpec> merged_specs;
-    for (const auto &spec : old_specs) {
-        // Snapshot generations are reconciliation/cleanup tags, not a
-        // visibility fence. After a KVCM restart, a new delta may use a fresh
-        // generation while untouched specs still carry an older one. Preserve
-        // those specs and overwrite only names present in this delta.
-        merged_specs[spec.name()] = spec;
-    }
     for (const auto &spec : new_specs) {
-        merged_specs[spec.name()] = spec;
+        auto existing = std::find_if(merged_specs.begin(), merged_specs.end(), [&spec](const auto &candidate) {
+            return candidate.name() == spec.name();
+        });
+        if (existing == merged_specs.end()) {
+            merged_specs.push_back(spec);
+        } else {
+            *existing = spec;
+        }
     }
-
-    out_specs.clear();
-    out_specs.reserve(merged_specs.size());
-    for (auto &[name, spec] : merged_specs) {
-        out_specs.push_back(std::move(spec));
-    }
-    return EC_OK;
+    std::sort(merged_specs.begin(), merged_specs.end(), [](const auto &lhs, const auto &rhs) {
+        return lhs.name() < rhs.name();
+    });
 }
 
 CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
@@ -1375,13 +1385,16 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
 
     std::vector<std::vector<std::pair<DataStorageType, std::uint64_t>>> created_locs_sz(keys.size());
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
-    std::vector<std::vector<MergeLocationSpecsTask>> merge_tasks_per_key(keys.size());
+    // Keep indices into the caller-owned task vectors. Copying each task here
+    // duplicated every location id, spec name and URI before the second RMW
+    // phase, which is especially expensive for large ReportEvent batches.
+    std::vector<std::vector<size_t>> merge_task_indices_per_key(keys.size());
     bool create_write_lease_attempted = false;
     ErrorCode create_write_lease_ec = EC_OK;
     MetadataWriteLease create_write_lease;
 
     auto create_modifier = [&tasks_per_key,
-                            &merge_tasks_per_key,
+                            &merge_task_indices_per_key,
                             &keys,
                             &created_locs_sz,
                             &acquire_write_lease,
@@ -1405,11 +1418,12 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
             return {ModifierAction::MA_FAIL, get_ec};
         }
 
-        const std::unordered_set<std::string> existing_id_set(existing_ids.begin(), existing_ids.end());
         bool created = false;
-        for (const auto &entry : tasks_per_key[index]) {
-            if (get_ec == ErrorCode::EC_OK && existing_id_set.count(entry.location_id) > 0) {
-                merge_tasks_per_key[index].push_back(entry);
+        for (size_t task_index = 0; task_index < tasks_per_key[index].size(); ++task_index) {
+            const auto &entry = tasks_per_key[index][task_index];
+            if (get_ec == ErrorCode::EC_OK &&
+                std::find(existing_ids.begin(), existing_ids.end(), entry.location_id) != existing_ids.end()) {
+                merge_task_indices_per_key[index].push_back(task_index);
                 continue;
             }
 
@@ -1463,15 +1477,15 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
     std::vector<size_t> merge_key_indices;
     LocationIdsPerKey merge_location_ids;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (out_per_key_ec[i] != ErrorCode::EC_OK || merge_tasks_per_key[i].empty()) {
+        if (out_per_key_ec[i] != ErrorCode::EC_OK || merge_task_indices_per_key[i].empty()) {
             continue;
         }
         merge_keys.push_back(keys[i]);
         merge_key_indices.push_back(i);
         auto &ids = merge_location_ids.emplace_back();
-        ids.reserve(merge_tasks_per_key[i].size());
-        for (const auto &task : merge_tasks_per_key[i]) {
-            ids.push_back(task.location_id);
+        ids.reserve(merge_task_indices_per_key[i].size());
+        for (const size_t task_index : merge_task_indices_per_key[i]) {
+            ids.push_back(tasks_per_key[i][task_index].location_id);
         }
     }
 
@@ -1481,14 +1495,15 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
 
     std::vector<std::vector<StorageUsageChange>> merge_usage_changes(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        merge_usage_changes[i].resize(merge_tasks_per_key[i].size());
+        merge_usage_changes[i].resize(merge_task_indices_per_key[i].size());
     }
     create_write_lease.reset();
     bool merge_write_lease_attempted = false;
     ErrorCode merge_write_lease_ec = EC_OK;
     MetadataWriteLease merge_write_lease;
     auto merge_modifier = [&keys,
-                           &merge_tasks_per_key,
+                           &tasks_per_key,
+                           &merge_task_indices_per_key,
                            &merge_key_indices,
                            &merge_usage_changes,
                            &acquire_write_lease,
@@ -1509,16 +1524,16 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
             return {ModifierAction::MA_FAIL, std::vector<ErrorCode>(loc_ids.size(), merge_write_lease_ec)};
         }
         const size_t original_key_index = merge_key_indices[key_index];
-        const auto &tasks = merge_tasks_per_key[original_key_index];
+        const auto &task_indices = merge_task_indices_per_key[original_key_index];
         std::vector<ErrorCode> modifier_ecs(loc_ids.size(), ErrorCode::EC_OK);
         bool updated = false;
         for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
-            if (loc_index >= tasks.size() || loc_index >= get_ecs.size() || loc_index >= locs.size()) {
+            if (loc_index >= task_indices.size() || loc_index >= get_ecs.size() || loc_index >= locs.size()) {
                 modifier_ecs[loc_index] = ErrorCode::EC_ERROR;
                 continue;
             }
             const ErrorCode ec = get_ecs[loc_index];
-            const auto &task = tasks[loc_index];
+            const auto &task = tasks_per_key[original_key_index][task_indices[loc_index]];
             if (ec != ErrorCode::EC_OK && ec != ErrorCode::EC_NOENT) {
                 modifier_ecs[loc_index] = ec;
                 KVCM_LOG_WARN("load location failed, key[%lu](%lu), location_id: %s, return %d",
@@ -1539,14 +1554,7 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
                 usage.old_size = GetLocationSpecsSize(locs[loc_index]->location_specs());
                 usage.has_old = true;
                 new_loc = std::make_shared<CacheLocation>(*locs[loc_index]);
-                std::vector<LocationSpec> merged_specs;
-                const ErrorCode merge_ec =
-                    MergeLocationSpecsByName(new_loc->location_specs(), task.specs, merged_specs);
-                if (merge_ec != EC_OK) {
-                    modifier_ecs[loc_index] = merge_ec;
-                    continue;
-                }
-                new_loc->set_location_specs(std::move(merged_specs));
+                MergeLocationSpecsByName(new_loc->mutable_location_specs(), task.specs);
             } else {
                 new_loc = std::make_shared<CacheLocation>();
                 new_loc->set_id(task.location_id);
@@ -1585,7 +1593,8 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
     for (size_t i = 0; i < merge_key_indices.size(); ++i) {
         const size_t original_key_index = merge_key_indices[i];
         ErrorCode key_ec = ErrorCode::EC_OK;
-        const size_t expected_location_count = merge_tasks_per_key[original_key_index].size();
+        const auto &task_indices = merge_task_indices_per_key[original_key_index];
+        const size_t expected_location_count = task_indices.size();
         if (i >= merge_result.per_location_error_codes.size() ||
             merge_result.per_location_error_codes[i].size() != expected_location_count) {
             key_ec = ErrorCode::EC_MISMATCH;
@@ -1595,14 +1604,11 @@ ErrorCode MetaSearcher::BatchMergeLocationSpecs(RequestContext *request_context,
                 const auto loc_ec = merge_result.per_location_error_codes[i][loc_index];
                 if (loc_ec == ErrorCode::EC_OK) {
                     const auto &usage = merge_usage_changes[original_key_index][loc_index];
+                    const auto &task = tasks_per_key[original_key_index][task_indices[loc_index]];
                     if (usage.has_old) {
-                        ApplyStorageUsageChange(meta_indexer_.get(),
-                                                merge_tasks_per_key[original_key_index][loc_index].type,
-                                                usage.old_size,
-                                                usage.new_size);
+                        ApplyStorageUsageChange(meta_indexer_.get(), task.type, usage.old_size, usage.new_size);
                     } else {
-                        meta_indexer_->AddStorageUsageByType(merge_tasks_per_key[original_key_index][loc_index].type,
-                                                             usage.new_size);
+                        meta_indexer_->AddStorageUsageByType(task.type, usage.new_size);
                     }
                     continue;
                 }

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -110,7 +110,9 @@ public:
         std::vector<LocationSpec> specs;
     };
     // Replaces existing specs or creates the stable location in one metadata
-    // read-modify-write operation per batch.
+    // read-modify-write operation per batch. When supplied, the write-lease
+    // callback is invoked once after the metadata read and before the first
+    // mutation; the returned lease is retained until the operation returns.
     ErrorCode BatchReplaceLocationSpecs(RequestContext *request_context,
                                         const KeyVector &keys,
                                         const std::vector<std::vector<ReplaceLocationSpecsTask>> &tasks_per_key,
@@ -122,6 +124,10 @@ public:
         CacheLocationStatus status;
         std::vector<LocationSpec> specs;
     };
+    // The optional write lease is acquired once per RMW phase, after that
+    // phase's metadata read. Releasing it between the block-create and
+    // location-merge phases lets a concurrent lifecycle writer fence stale
+    // work before the next phase mutates metadata.
     ErrorCode BatchMergeLocationSpecs(RequestContext *request_context,
                                       const KeyVector &keys,
                                       const std::vector<std::vector<MergeLocationSpecsTask>> &tasks_per_key,
@@ -133,7 +139,9 @@ public:
     };
     // Missing block/location targets are idempotent EC_OK. When requested,
     // out_missing_targets mirrors tasks_per_key and marks those no-op targets;
-    // an existing location with only missing spec_names is not marked.
+    // an existing location with only missing spec_names is not marked. The
+    // optional write lease is acquired once after the metadata read and before
+    // the first mutation.
     ErrorCode BatchDeleteLocationSpecs(RequestContext *request_context,
                                        const KeyVector &keys,
                                        const std::vector<std::vector<DeleteLocationSpecsTask>> &tasks_per_key,

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -73,7 +73,8 @@ public:
                                             LocationsPerKey &out_locations,
                                             SelectLocationPolicy *policy,
                                             const std::vector<BackendSelector> &selectors,
-                                            const std::vector<std::string> &requested_spec_names = {}) const;
+                                            const std::vector<std::string> &requested_spec_names = {},
+                                            const BlockMask &input_mask = BlockMask{}) const;
     ErrorCode ReverseRollSlideWindowMatch(RequestContext *request_context,
                                           const KeyVector &keys,
                                           int32_t sw_size,
@@ -112,9 +113,12 @@ public:
         std::vector<LocationSpec> specs;
     };
     // Replaces existing specs or creates the stable location in one metadata
-    // read-modify-write operation per batch. When supplied, the write-lease
-    // callback is invoked once after the metadata read and before the first
-    // mutation; the returned lease is retained until the operation returns.
+    // read-modify-write operation per batch. Keys and location ids within a
+    // key must be unique. Every task requires non-empty, uniquely named specs
+    // with valid URIs and cannot mix versioned/unversioned specs or multiple
+    // snapshot versions. When supplied, the write-lease callback is invoked
+    // once after the metadata read and before the first mutation; the returned
+    // lease is retained until the operation returns.
     ErrorCode BatchReplaceLocationSpecs(RequestContext *request_context,
                                         const KeyVector &keys,
                                         const std::vector<std::vector<ReplaceLocationSpecsTask>> &tasks_per_key,
@@ -126,10 +130,12 @@ public:
         CacheLocationStatus status;
         std::vector<LocationSpec> specs;
     };
-    // The optional write lease is acquired once per RMW phase, after that
-    // phase's metadata read. Releasing it between the block-create and
-    // location-merge phases lets a concurrent lifecycle writer fence stale
-    // work before the next phase mutates metadata.
+    // Keys and location ids within a key must be unique. Every task requires
+    // non-empty, uniquely named specs with valid URIs and cannot mix
+    // versioned/unversioned specs or multiple snapshot versions. The optional
+    // write lease is acquired once per RMW phase, after that phase's metadata
+    // read. Releasing it between the block-create and location-merge phases lets
+    // a concurrent lifecycle writer fence stale work before the next phase.
     ErrorCode BatchMergeLocationSpecs(RequestContext *request_context,
                                       const KeyVector &keys,
                                       const std::vector<std::vector<MergeLocationSpecsTask>> &tasks_per_key,
@@ -139,11 +145,13 @@ public:
         std::string location_id;
         std::vector<std::string> spec_names;
     };
-    // Missing block/location targets are idempotent EC_OK. When requested,
-    // out_missing_targets mirrors tasks_per_key and marks those no-op targets;
-    // an existing location with only missing spec_names is not marked. The
-    // optional write lease is acquired once after the metadata read and before
-    // the first mutation.
+    // Missing block/location targets are idempotent EC_OK. Keys and location
+    // ids within a key must be unique, and every task must name at least one
+    // non-empty spec. When requested, out_missing_targets mirrors
+    // tasks_per_key and marks missing block/location no-ops; an existing
+    // location with only missing spec_names is not marked. The optional write
+    // lease is acquired once after the metadata read and before the first
+    // mutation.
     ErrorCode BatchDeleteLocationSpecs(RequestContext *request_context,
                                        const KeyVector &keys,
                                        const std::vector<std::vector<DeleteLocationSpecsTask>> &tasks_per_key,
@@ -197,7 +205,8 @@ public:
                                           DataStorageType storage_type,
                                           size_t scan_batch_size,
                                           LocationCleanupPredicate should_delete,
-                                          std::function<bool()> should_abort = nullptr);
+                                          std::function<bool()> should_abort = nullptr,
+                                          AcquireMetadataWriteLeaseFunc acquire_cleanup_lease = nullptr);
     ErrorCode CleanupLocationsByHost(RequestContext *request_context,
                                      const std::string &host_suffix,
                                      DataStorageType storage_type,

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -83,13 +83,15 @@ public:
                                 const KeyVector &keys,
                                 bool use_eagle_pop,
                                 const std::vector<std::string> &medium_filter,
-                                std::vector<HostCacheMatch> &out_matches) const;
+                                std::vector<HostCacheMatch> &out_matches,
+                                const CheckLocDataExistFunc *request_check_loc_data_exist = nullptr) const;
     ErrorCode PrefixMatchWithMambaByHost(RequestContext *request_context,
                                          const KeyVector &keys,
                                          bool use_eagle_pop,
                                          const std::vector<std::string> &medium_filter,
                                          const std::vector<LocationSpecGroup> &location_spec_groups,
-                                         std::vector<HostCacheMatch> &out_matches) const;
+                                         std::vector<HostCacheMatch> &out_matches,
+                                         const CheckLocDataExistFunc *request_check_loc_data_exist = nullptr) const;
     ErrorCode BatchGetLocation(RequestContext *request_context,
                                const KeyVector &keys,
                                const BlockMask &input_mask,

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -51,6 +51,16 @@ public:
         int64_t prefix_match_blocks;
     };
 
+    struct HostCacheLocationInfo {
+        // When true, the checker has already parsed the EventReport location
+        // id and validated every spec URI while applying query visibility.
+        bool has_reporter_identity = false;
+        std::string reporter_medium;
+        std::string reporter_host;
+    };
+    using CheckHostCacheLocationFunc =
+        std::function<bool(const CacheLocation &location, HostCacheLocationInfo &out_info)>;
+
     explicit MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_manager);
     MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
                  CheckLocDataExistFunc check_loc_data_exist,
@@ -85,14 +95,14 @@ public:
                                 bool use_eagle_pop,
                                 const std::vector<std::string> &medium_filter,
                                 std::vector<HostCacheMatch> &out_matches,
-                                const CheckLocDataExistFunc *request_check_loc_data_exist = nullptr) const;
+                                const CheckHostCacheLocationFunc *request_check_location = nullptr) const;
     ErrorCode PrefixMatchWithMambaByHost(RequestContext *request_context,
                                          const KeyVector &keys,
                                          bool use_eagle_pop,
                                          const std::vector<std::string> &medium_filter,
                                          const std::vector<LocationSpecGroup> &location_spec_groups,
                                          std::vector<HostCacheMatch> &out_matches,
-                                         const CheckLocDataExistFunc *request_check_loc_data_exist = nullptr) const;
+                                         const CheckHostCacheLocationFunc *request_check_location = nullptr) const;
     ErrorCode BatchGetLocation(RequestContext *request_context,
                                const KeyVector &keys,
                                const BlockMask &input_mask,

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -142,10 +142,12 @@ public:
     };
     // Keys and location ids within a key must be unique. Every task requires
     // non-empty, uniquely named specs with valid URIs and cannot mix
-    // versioned/unversioned specs or multiple snapshot versions. The optional
-    // write lease is acquired once per RMW phase, after that phase's metadata
-    // read. Releasing it between the block-create and location-merge phases lets
-    // a concurrent lifecycle writer fence stale work before the next phase.
+    // versioned/unversioned specs or multiple snapshot versions. The block
+    // existence state and every requested target location are read
+    // together, then merged in one targeted RMW phase. The optional write
+    // lease is acquired once after that read and before the first mutation;
+    // it is retained through the upsert so a concurrent lifecycle change can
+    // fence work that was admitted under an older reporter generation.
     ErrorCode BatchMergeLocationSpecs(RequestContext *request_context,
                                       const KeyVector &keys,
                                       const std::vector<std::vector<MergeLocationSpecsTask>> &tasks_per_key,

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -72,7 +72,8 @@ public:
                                             const KeyVector &keys,
                                             LocationsPerKey &out_locations,
                                             SelectLocationPolicy *policy,
-                                            const std::vector<BackendSelector> &selectors) const;
+                                            const std::vector<BackendSelector> &selectors,
+                                            const std::vector<std::string> &requested_spec_names = {}) const;
     ErrorCode ReverseRollSlideWindowMatch(RequestContext *request_context,
                                           const KeyVector &keys,
                                           int32_t sw_size,

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -71,10 +71,11 @@ cc_test(
     data = [],
     deps = [
         "//kv_cache_manager/common:unittest",
-        "//kv_cache_manager/meta:cache_location",
-        "//kv_cache_manager/meta:meta_local_backend",
+        "//kv_cache_manager/config:instance_info",
         "//kv_cache_manager/manager:meta_searcher",
         "//kv_cache_manager/meta",
+        "//kv_cache_manager/meta:cache_location",
+        "//kv_cache_manager/meta:meta_local_backend",
     ],
 )
 
@@ -141,9 +142,9 @@ cc_test(
     ],
     deps = [
         "//kv_cache_manager/common:unittest",
-        "//kv_cache_manager/meta:cache_location",
         "//kv_cache_manager/manager:meta_searcher",
         "//kv_cache_manager/meta",
+        "//kv_cache_manager/meta:cache_location",
     ],
 )
 

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -6229,12 +6229,16 @@ TEST_F(CacheManagerTest, TestReportEventBlockDeleteRemovesLocationSpecs) {
 
 TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    const std::string instance_id = "test_backend_selectors";
+    auto location_spec_infos = createLocationSpecInfos();
+    location_spec_infos.emplace_back("full_0", 512);
+    location_spec_infos.emplace_back("linear_1", 512);
     ASSERT_EQ(expected_reg,
               cache_manager_->RegisterInstance(request_context_.get(),
                                                "default",
-                                               "test_instance",
+                                               instance_id,
                                                64,
-                                               createLocationSpecInfos(),
+                                               location_spec_infos,
                                                createModelDeployment(),
                                                std::vector<LocationSpecGroup>()));
 
@@ -6244,12 +6248,12 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     std::vector<int64_t> nfs_keys{300, 500, 700};
     {
         auto [ec, swci] =
-            cache_manager_->StartWriteCache(request_context_.get(), "test_instance", nfs_keys, {}, {}, 100000000);
+            cache_manager_->StartWriteCache(request_context_.get(), instance_id, nfs_keys, {}, {}, 100000000);
         ASSERT_EQ(EC_OK, ec);
         BlockMask bm = static_cast<size_t>(nfs_keys.size());
         ASSERT_EQ(
             EC_OK,
-            cache_manager_->FinishWriteCache(request_context_.get(), "test_instance", swci.write_session_id(), bm));
+            cache_manager_->FinishWriteCache(request_context_.get(), instance_id, swci.write_session_id(), bm));
     }
 
     // Set up EventReportBackend
@@ -6280,9 +6284,9 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         {"192.168.1.3:8080", {300}},
     };
     for (const auto &pd : peer_data) {
-        InitializeEventReporter("test_instance", pd.host, proto::meta::ST_EVENT_REPORT_L2);
+        InitializeEventReporter(instance_id, pd.host, proto::meta::ST_EVENT_REPORT_L2);
         proto::meta::ReportEventRequest req;
-        req.set_instance_id("test_instance");
+        req.set_instance_id(instance_id);
         req.set_host_ip_port(pd.host);
         req.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
 
@@ -6305,7 +6309,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     {
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      all_keys,
                                                                      {},
@@ -6324,7 +6328,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      all_keys,
                                                                      {},
@@ -6378,7 +6382,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      all_keys,
                                                                      {},
@@ -6413,7 +6417,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      all_keys,
                                                                      {},
@@ -6448,7 +6452,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      keys_no_er_first,
                                                                      {},
@@ -6479,7 +6483,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      keys_gap,
                                                                      {},
@@ -6508,7 +6512,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      bad_keys,
                                                                      {},
@@ -6529,7 +6533,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         };
         BlockMask bm = static_cast<size_t>(0);
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     "test_instance",
+                                                                     instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
                                                                      {300},
                                                                      {},
@@ -6544,17 +6548,72 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         EXPECT_EQ(2u, kl[0].location_specs().size());
     }
 
-    // --- Test 9: backend-selected queries enforce reporter liveness ---
+    // --- Test 9: spec filtering happens before Vineyard peer selection ---
+    // The full-only peer covers two keys and would win an unfiltered prefix
+    // selection. A linear_1 query must instead select the linear-only peer.
+    {
+        auto report_spec = [&](const std::string &host,
+                               const std::vector<int64_t> &keys,
+                               const std::string &spec_name) {
+            proto::meta::ReportEventRequest req;
+            req.set_instance_id(instance_id);
+            req.set_host_ip_port(host);
+            req.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+            for (int64_t key : keys) {
+                auto *ev = req.add_events();
+                ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+                auto *ba = ev->mutable_block_add();
+                ba->set_block_key(std::to_string(key));
+                ba->set_medium("mem");
+                auto *spec = ba->add_specs();
+                spec->set_name(spec_name);
+                spec->set_uri("event_report://" + host + "/mem");
+            }
+            proto::meta::ReportEventResponse resp;
+            ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        };
+
+        const std::string full_host = "192.168.2.1:8080";
+        const std::string linear_host = "192.168.2.2:8080";
+        InitializeEventReporter(instance_id, full_host, proto::meta::ST_EVENT_REPORT_L2);
+        InitializeEventReporter(instance_id, linear_host, proto::meta::ST_EVENT_REPORT_L2);
+        report_spec(full_host, {800, 801}, "full_0");
+        report_spec(linear_host, {800}, "linear_1");
+
+        const std::vector<BackendSelector> selectors = {
+            {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+        };
+        BlockMask block_mask = static_cast<size_t>(0);
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                     instance_id,
+                                                                     CacheManager::QueryType::QT_BATCH_GET,
+                                                                     {800, 801},
+                                                                     {},
+                                                                     block_mask,
+                                                                     0,
+                                                                     {"linear_1"},
+                                                                     selectors);
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(2u, locs.size());
+        ASSERT_EQ(1u, locs[0].cache_locations_view().size());
+        ASSERT_EQ(1u, locs[0].cache_locations_view()[0].location_specs().size());
+        EXPECT_EQ("linear_1", locs[0].cache_locations_view()[0].location_specs()[0].name());
+        EXPECT_NE(std::string::npos,
+                  locs[0].cache_locations_view()[0].location_specs()[0].uri().find(linear_host));
+        EXPECT_TRUE(locs[1].cache_locations_view().empty());
+    }
+
+    // --- Test 10: backend-selected queries enforce reporter liveness ---
     {
         for (const auto &peer : peer_data) {
-            event_report_backend->SetNodeUnavailable("test_instance", peer.host);
+            event_report_backend->SetNodeUnavailable(instance_id, peer.host);
         }
         const std::vector<BackendSelector> selectors = {
             {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
         };
         BlockMask block_mask = static_cast<size_t>(0);
         auto [hidden_ec, hidden] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                              "test_instance",
+                                                                              instance_id,
                                                                               CacheManager::QueryType::QT_BATCH_GET,
                                                                               all_keys,
                                                                               {},
@@ -6569,10 +6628,10 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         }
 
         for (const auto &peer : peer_data) {
-            ASSERT_EQ(EC_OK, event_report_backend->OnHeartbeat("test_instance", peer.host, {}));
+            ASSERT_EQ(EC_OK, event_report_backend->OnHeartbeat(instance_id, peer.host, {}));
         }
         auto [restored_ec, restored] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                                  "test_instance",
+                                                                                  instance_id,
                                                                                   CacheManager::QueryType::QT_BATCH_GET,
                                                                                   all_keys,
                                                                                   {},

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -253,6 +253,13 @@ public:
         return MetaLocalBackend::GetLocations(request_context, keys, location_ids, out_locations);
     }
 
+    std::vector<ErrorCode> GetLocationValues(RequestContext *request_context,
+                                             const KeyTypeVec &keys,
+                                             LocationsPerKey &out_locations) noexcept override {
+        MaybeBlockLocationRead();
+        return MetaLocalBackend::GetLocationValues(request_context, keys, out_locations);
+    }
+
     bool Sync(const KeyTypeVec &keys) noexcept override {
         {
             std::lock_guard<std::mutex> lock(control_mutex_);
@@ -6700,6 +6707,137 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
 //   host_B: 100→200→300→400→(miss 500) → prefix=4
 //   host_C: 100→(miss 200) → prefix=1
 //
+TEST_F(CacheManagerTest, TestGetHostCacheStateSnapshotsHostLivenessAfterMetadataRead) {
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_TRUE(event_backend);
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_TRUE(meta_backend);
+
+    const std::string instance_id = "test_instance";
+    const std::string host = "10.0.9.1:8080";
+    InitializeEventReporter(instance_id, host, proto::meta::ST_EVENT_REPORT_L2);
+    proto::meta::ReportEventRequest report;
+    report.set_instance_id(instance_id);
+    report.set_host_ip_port(host);
+    report.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *event = report.add_events();
+    event->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+    event->mutable_block_add()->set_block_key("9001");
+    event->mutable_block_add()->set_medium("mem");
+    auto *spec = event->mutable_block_add()->add_specs();
+    spec->set_name("tp0");
+    spec->set_uri("event_report://" + host + "/mem");
+    proto::meta::ReportEventResponse report_response;
+    ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &report, &report_response));
+
+    meta_backend->BlockNextLocationRead();
+    auto query = std::async(std::launch::async, [&] {
+        RequestContext context("host_liveness_after_meta_read");
+        return cache_manager_->GetHostCacheState(
+            &context, instance_id, CacheManager::QueryType::QT_PREFIX_MATCH, {9001});
+    });
+    const bool read_entered = meta_backend->WaitUntilLocationReadEntered(std::chrono::seconds(2));
+    if (!read_entered) {
+        meta_backend->ReleaseLocationRead();
+        (void)query.get();
+        FAIL() << "GetHostCacheState did not enter the controlled metadata read";
+    }
+
+    event_backend->SetNodeUnavailable(instance_id, host);
+    meta_backend->ReleaseLocationRead();
+    auto [ec, hosts] = query.get();
+    EXPECT_EQ(EC_OK, ec);
+    EXPECT_TRUE(hosts.empty());
+}
+
+TEST_F(CacheManagerTest, TestGetHostCacheStateConcurrentWithReportEventAndHostDown) {
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_TRUE(event_backend);
+    const std::string instance_id = "test_instance";
+    const std::string host = "10.0.9.2:8080";
+    constexpr std::size_t kBlockCount = 384;
+    InitializeEventReporter(instance_id, host, proto::meta::ST_EVENT_REPORT_L2);
+
+    auto make_add_request = [&](std::size_t round) {
+        proto::meta::ReportEventRequest request;
+        request.set_instance_id(instance_id);
+        request.set_host_ip_port(host);
+        request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+        for (std::size_t i = 0; i < kBlockCount; ++i) {
+            auto *event = request.add_events();
+            event->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+            auto *add = event->mutable_block_add();
+            add->set_block_key(std::to_string(10000 + i));
+            add->set_medium("mem");
+            auto *spec = add->add_specs();
+            spec->set_name("tp0");
+            spec->set_uri("event_report://" + host + "/mem?round=" + std::to_string(round));
+        }
+        return request;
+    };
+
+    auto setup_request = make_add_request(0);
+    proto::meta::ReportEventResponse setup_response;
+    ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &setup_request, &setup_response));
+    CacheManager::KeyVector keys;
+    keys.reserve(kBlockCount);
+    for (std::size_t i = 0; i < kBlockCount; ++i) {
+        keys.push_back(10000 + i);
+    }
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> writer_done{false};
+    std::atomic<std::size_t> failures{0};
+    std::thread writer([&] {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        for (std::size_t round = 1; round <= 12; ++round) {
+            auto request = make_add_request(round);
+            proto::meta::ReportEventResponse response;
+            RequestContext context("concurrent_report_" + std::to_string(round));
+            if (cache_manager_->ReportEvent(&context, &request, &response) != EC_OK) {
+                failures.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+        writer_done.store(true, std::memory_order_release);
+    });
+    std::thread reader([&] {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        std::size_t query_count = 0;
+        while (!writer_done.load(std::memory_order_acquire) || query_count < 24) {
+            RequestContext context("concurrent_host_query_" + std::to_string(query_count));
+            auto [ec, hosts] = cache_manager_->GetHostCacheState(
+                &context, instance_id, CacheManager::QueryType::QT_PREFIX_MATCH, keys, {"mem"});
+            if (ec != EC_OK || hosts.size() != 1 || hosts.front().host_ip_port != host ||
+                hosts.front().prefix_match_blocks != static_cast<int64_t>(kBlockCount)) {
+                failures.fetch_add(1, std::memory_order_relaxed);
+            }
+            ++query_count;
+        }
+    });
+    start.store(true, std::memory_order_release);
+    writer.join();
+    reader.join();
+    EXPECT_EQ(0u, failures.load(std::memory_order_relaxed));
+
+    proto::meta::ReportEventRequest host_down;
+    host_down.set_instance_id(instance_id);
+    host_down.set_host_ip_port(host);
+    host_down.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *host_down_event = host_down.add_events();
+    host_down_event->set_event_type(proto::meta::EVENT_HOST_DOWN);
+    host_down_event->mutable_host_down();
+    proto::meta::ReportEventResponse host_down_response;
+    ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &host_down, &host_down_response));
+    auto [ec, hosts] = cache_manager_->GetHostCacheState(
+        request_context_.get(), instance_id, CacheManager::QueryType::QT_PREFIX_MATCH, keys);
+    EXPECT_EQ(EC_OK, ec);
+    EXPECT_TRUE(hosts.empty());
+}
+
 TEST_F(CacheManagerTest, TestGetHostCacheState) {
     auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
     const std::string instance_id = "test_host_cache_state_prefix";
@@ -6891,7 +7029,28 @@ TEST_F(CacheManagerTest, TestGetHostCacheState) {
         EXPECT_EQ(-1, find_prefix(hosts, "10.0.0.4:8080"));
     }
 
-    // --- Test 9: unavailable host is filtered even before metadata cleanup ---
+    // --- Test 9: requests above the parallel threshold preserve ordering and
+    // prefix semantics. Repeated keys also stress concurrent reads of the same
+    // local-cache item rather than only independent LRU shards. ---
+    {
+        CacheManager::KeyVector keys;
+        keys.reserve(384);
+        for (std::size_t i = 0; i < 96; ++i) {
+            keys.insert(keys.end(), {100, 200, 300, 400});
+        }
+        auto [ec, hosts] = cache_manager_->GetHostCacheState(
+            request_context_.get(), instance_id, CacheManager::QueryType::QT_PREFIX_MATCH, keys);
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(3u, hosts.size());
+        EXPECT_EQ("10.0.0.1:8080", hosts[0].host_ip_port);
+        EXPECT_EQ("10.0.0.2:8080", hosts[1].host_ip_port);
+        EXPECT_EQ("10.0.0.3:8080", hosts[2].host_ip_port);
+        EXPECT_EQ(2, find_prefix(hosts, "10.0.0.1:8080"));
+        EXPECT_EQ(384, find_prefix(hosts, "10.0.0.2:8080"));
+        EXPECT_EQ(1, find_prefix(hosts, "10.0.0.3:8080"));
+    }
+
+    // --- Test 10: unavailable host is filtered even before metadata cleanup ---
     {
         event_backend->SetNodeUnavailable(instance_id, "10.0.0.2:8080");
         CacheManager::KeyVector keys = {100, 200, 300, 400};
@@ -7080,6 +7239,22 @@ TEST_F(CacheManagerTest, TestGetHostCacheStatePrefixMatchWithMamba) {
         EXPECT_EQ(-1, find_prefix(absent_hosts, host_c));
         EXPECT_EQ(-1, find_prefix(absent_hosts, host_d));
         EXPECT_EQ(2, find_prefix(absent_hosts, host_e));
+    }
+
+    {
+        CacheManager::KeyVector large_keys;
+        large_keys.reserve(384);
+        for (std::size_t i = 0; i < 128; ++i) {
+            large_keys.insert(large_keys.end(), {100, 200, 300});
+        }
+        auto [large_ec, large_hosts] = cache_manager_->GetHostCacheState(
+            request_context_.get(), instance_id, CacheManager::QueryType::QT_PREFIX_MATCH_WITH_MAMBA, large_keys);
+        ASSERT_EQ(EC_OK, large_ec);
+        EXPECT_EQ(382, find_prefix(large_hosts, host_a));
+        EXPECT_EQ(-1, find_prefix(large_hosts, host_b));
+        EXPECT_EQ(-1, find_prefix(large_hosts, host_c));
+        EXPECT_EQ(-1, find_prefix(large_hosts, host_d));
+        EXPECT_EQ(383, find_prefix(large_hosts, host_e));
     }
 
     dsm->storage_map_.erase("event_backend_mamba");

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -253,6 +253,13 @@ public:
         return MetaLocalBackend::GetLocations(request_context, keys, location_ids, out_locations);
     }
 
+    std::vector<ErrorCode> GetLocations(RequestContext *request_context,
+                                        const KeyTypeVec &keys,
+                                        CacheLocationMapVector &out_locations) noexcept override {
+        MaybeBlockLocationRead();
+        return MetaLocalBackend::GetLocations(request_context, keys, out_locations);
+    }
+
     std::vector<ErrorCode> GetLocationValues(RequestContext *request_context,
                                              const KeyTypeVec &keys,
                                              LocationsPerKey &out_locations) noexcept override {
@@ -491,8 +498,8 @@ public:
         }
     }
 
-    std::shared_ptr<EventReportBackend> InstallEventReportBackend() {
-        const std::string storage_name = "event_report_default";
+    std::shared_ptr<EventReportBackend>
+    InstallEventReportBackend(const std::string &storage_name = "event_report_default") {
         const std::string group_name = registry_manager_->GetInstanceGroupName("test_instance");
         auto group = registry_manager_->instance_group_configs_.at(group_name);
         group->set_event_report_storage_candidates({storage_name});
@@ -734,6 +741,22 @@ TEST_F(CacheManagerTest, TestRegisterInstance) {
             EXPECT_EQ(true, success_count == error_count);
         }
     }
+}
+
+TEST_F(CacheManagerTest, TestRegisterInstanceRejectsDifferentInstanceGroup) {
+    auto [ec, storage_configs] = cache_manager_->RegisterInstance(request_context_.get(),
+                                                                  "different_group",
+                                                                  "test_instance",
+                                                                  64,
+                                                                  createLocationSpecInfos(),
+                                                                  createModelDeployment(),
+                                                                  {});
+    EXPECT_EQ(EC_DUPLICATE_ENTITY, ec);
+    EXPECT_TRUE(storage_configs.empty());
+    const auto existing = registry_manager_->GetInstanceInfo(request_context_.get(), "test_instance");
+    ASSERT_NE(nullptr, existing);
+    EXPECT_EQ("default", existing->instance_group_name());
+    EXPECT_NE(std::string::npos, request_context_->error_tracer()->ToJsonString().find("instance_group_name"));
 }
 
 TEST_F(CacheManagerTest, TestRegisterInstanceReturnsTieredMigrationStorageConfigs) {
@@ -2546,16 +2569,33 @@ TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_VerifiesUriPassthrough) {
 }
 
 TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_UnregisteredBackend) {
-    // valid URIs whose hostname does not match any registered backend;
-    // DataStorageManager::Exist returns an empty vector, and
-    // std::all_of on an empty range is true -> functor returns true
+    // A missing backend returns no per-URI result and must fail closed.
     auto func = cache_manager_->GetCheckLocDataExistFunc("test_instance");
 
     CacheLocation loc;
     loc.set_status(CLS_SERVING);
     loc.set_type(DataStorageType::DATA_STORAGE_TYPE_NFS);
     loc.set_location_specs({LocationSpec("tp0", "file://nonexistent_backend/path")});
-    ASSERT_EQ(func(loc), true);
+    EXPECT_FALSE(func(loc));
+}
+
+TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_ShortBackendResultFailsClosed) {
+    auto mock_backend = std::make_shared<MockDataStorageBackend>(cache_manager_->metrics_registry_);
+    EXPECT_CALL(*mock_backend, MightExist(_)).WillOnce([](const std::vector<DataStorageUri> &) {
+        return std::vector<bool>{true};
+    });
+    auto dsm = registry_manager_->data_storage_manager_;
+    dsm->storage_map_["short_result_store"] = mock_backend;
+
+    const auto func = cache_manager_->GetCheckLocDataExistFunc("test_instance");
+    CacheLocation loc;
+    loc.set_status(CLS_SERVING);
+    loc.set_type(DataStorageType::DATA_STORAGE_TYPE_NFS);
+    loc.set_location_specs({LocationSpec("tp0", "file://short_result_store/path_a"),
+                            LocationSpec("tp1", "file://short_result_store/path_b")});
+    EXPECT_FALSE(func(loc));
+
+    dsm->storage_map_.erase("short_result_store");
 }
 
 TEST(ReportEventContractTest, SnapshotAndResponseFieldNumbersMatchContract) {
@@ -2831,6 +2871,99 @@ TEST_F(CacheManagerTest, TestHostDownMakesAlreadyAdmittedDeltaInvisibleWithoutDe
     EXPECT_TRUE(QueryEventReportUris({key}).empty());
 }
 
+TEST_F(CacheManagerTest, TestEventCleanupTasksDrainAndRemainFencedAcrossReactivation) {
+    const std::string host = "192.168.10.78:8080";
+    const int64_t key = 94'478;
+    auto event_backend = InstallEventReportBackend();
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_NE(nullptr, meta_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeSnapshotRequest(host, {{key, "baseline"}}), "cleanup_gate_baseline").first);
+    ASSERT_EQ(1u, QueryRawEventReportUris(key).size());
+    ASSERT_TRUE(event_backend->IsCleanupCallbackSet());
+
+    // Stop executor workers so the test can deterministically take ownership
+    // of the cleanup closure admitted by the backend callback.
+    cache_manager_->reclaimer_task_supervisor_->Stop();
+    auto &executor = cache_manager_->schedule_plan_executor_;
+    executor->stop_.store(true);
+    executor->condition_.notify_all();
+    for (auto &worker : executor->workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+    executor->workers_.clear();
+    executor->stop_.store(false);
+    {
+        std::lock_guard<std::mutex> lock(executor->queue_mutex_);
+        for (auto &queue : executor->task_queues_) {
+            queue.clear();
+        }
+    }
+
+    EventReportBackend::CleanupCallback callback;
+    {
+        std::lock_guard<std::mutex> lock(event_backend->cleanup_cb_mutex_);
+        callback = event_backend->cleanup_callback_;
+    }
+    ASSERT_TRUE(callback);
+
+    auto take_only_queued_task = [&]() {
+        std::function<void()> task;
+        std::lock_guard<std::mutex> lock(executor->queue_mutex_);
+        EXPECT_EQ(1u, executor->WaitingTaskCountLocked());
+        for (auto &queue : executor->task_queues_) {
+            if (!queue.empty()) {
+                task = queue.begin()->task;
+                queue.clear();
+            }
+        }
+        return task;
+    };
+
+    uint64_t cleanup_generation = 0;
+    ASSERT_EQ(EC_OK, event_backend->UnregisterNodeForHostDown("test_instance", host, cleanup_generation));
+    callback("test_instance", host, cleanup_generation);
+    auto running_cleanup = take_only_queued_task();
+    ASSERT_TRUE(running_cleanup);
+
+    // A cleanup already executing must hold the lifetime lease until its
+    // metadata access completes. Deactivation therefore waits rather than
+    // racing manager cleanup against the raw-this task.
+    meta_backend->BlockNextLocationRead();
+    auto cleanup_future = std::async(std::launch::async, std::move(running_cleanup));
+    ASSERT_TRUE(meta_backend->WaitUntilLocationReadEntered(std::chrono::seconds(1)));
+    auto deactivate_future =
+        std::async(std::launch::async, [this] { cache_manager_->DeactivateEventCleanupCallbacks(); });
+    EXPECT_EQ(std::future_status::timeout, deactivate_future.wait_for(std::chrono::milliseconds(50)));
+    meta_backend->ReleaseLocationRead();
+    ASSERT_EQ(std::future_status::ready, cleanup_future.wait_for(std::chrono::seconds(2)));
+    cleanup_future.get();
+    ASSERT_EQ(std::future_status::ready, deactivate_future.wait_for(std::chrono::seconds(2)));
+    deactivate_future.get();
+    EXPECT_TRUE(QueryRawEventReportUris(key).empty());
+
+    cache_manager_->ActivateEventCleanupCallbacks();
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeAddRequest(host, key, "after_reactivate"), "cleanup_gate_delta").first);
+    ASSERT_EQ(1u, QueryRawEventReportUris(key).size());
+
+    // A task queued in the old epoch must remain inert after reactivation; a
+    // boolean-only gate would incorrectly make it live again here.
+    uint64_t stale_cleanup_generation = 0;
+    ASSERT_EQ(EC_OK, event_backend->UnregisterNodeForHostDown("test_instance", host, stale_cleanup_generation));
+    callback("test_instance", host, stale_cleanup_generation);
+    auto stale_queued_cleanup = take_only_queued_task();
+    ASSERT_TRUE(stale_queued_cleanup);
+    cache_manager_->DeactivateEventCleanupCallbacks();
+    cache_manager_->ActivateEventCleanupCallbacks();
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+    stale_queued_cleanup();
+    EXPECT_EQ(1u, QueryRawEventReportUris(key).size());
+}
+
 TEST_F(CacheManagerTest, TestOldDeltaCannotCrossReporterLifecycleAfterReregisterAndSnapshot) {
     const std::string host = "192.168.10.45:8080";
     const int64_t key = 94'422;
@@ -3048,6 +3181,47 @@ TEST_F(CacheManagerTest, TestReportEventFoldedDeltaEventsShareFinalWriteFailure)
     EXPECT_TRUE(QueryEventReportUris({key}).empty());
 }
 
+TEST_F(CacheManagerTest, TestReportEventDeltaFailureMarksSafeRetryDependencyClosure) {
+    const std::string host = "192.168.10.72:8080";
+    const int64_t key = 94'472;
+    auto event_backend = InstallEventReportBackend();
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_NE(nullptr, meta_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeAddRequest(host, key, "baseline_a"), "retry_closure_baseline").first);
+
+    auto request = MakeAddRequest(host, key, "readd_a");
+    auto *spec_b = request.mutable_events(0)->mutable_block_add()->add_specs();
+    spec_b->set_name("tp1");
+    spec_b->set_uri("event_report://" + host + "/mem?source=add_b");
+    auto *delete_a = request.add_events();
+    delete_a->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+    delete_a->mutable_block_delete()->set_block_key(std::to_string(key));
+    delete_a->mutable_block_delete()->set_medium("mem");
+    delete_a->mutable_block_delete()->add_spec_names("tp0");
+
+    // The final ADD phase writes only tp1; tp0's final operation is DELETE.
+    // Fail that ADD, then let DELETE succeed. Retrying only event 0 would
+    // otherwise resurrect tp0, so both dependent events must be reported as
+    // failed and retried in their original order.
+    meta_backend->FailKeyOnNextUpsert(key);
+    const auto [failed_ec, failed_response] = CallReportEvent(request, "retry_closure_injected_failure");
+    EXPECT_EQ(EC_PARTIAL_OK, failed_ec);
+    ASSERT_EQ(2, failed_response.item_results_size());
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, failed_response.item_results(0));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, failed_response.item_results(1));
+    EXPECT_TRUE(QueryRawEventReportUris(key).empty());
+
+    const auto [retry_ec, retry_response] = CallReportEvent(request, "retry_closure_retry_all_failed_items");
+    EXPECT_EQ(EC_OK, retry_ec);
+    EXPECT_EQ(0, retry_response.item_results_size());
+    const auto final_uris = QueryRawEventReportUris(key);
+    ASSERT_EQ(1u, final_uris.size());
+    EXPECT_NE(std::string::npos, final_uris.front().find("source=add_b"));
+}
+
 TEST_F(CacheManagerTest, TestReportEventLazilyRestoresReporterWithoutRegisterOrSnapshot) {
     const std::string host = "192.168.10.32:8080";
     const std::string snapshot_host = "192.168.10.132:8080";
@@ -3110,6 +3284,33 @@ TEST_F(CacheManagerTest, TestReportEventLazilyRestoresReporterWithoutRegisterOrS
     visible = QueryEventReportUris({9427});
     ASSERT_EQ(1u, visible.size());
     EXPECT_NE(std::string::npos, visible.front().find("source=registered_but_unavailable"));
+}
+
+TEST_F(CacheManagerTest, TestReportEventHeartbeatFailureDoesNotOverwriteMalformedItems) {
+    const std::string host = "192.168.10.79:8080";
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+    ASSERT_EQ(EC_OK, event_backend->UnregisterNode("test_instance", host));
+
+    proto::meta::ReportEventRequest request;
+    request.set_instance_id("test_instance");
+    request.set_host_ip_port(host);
+    request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    // This item is structurally invalid and must keep INVALID_ARGUMENT even
+    // when the valid heartbeat in the same request fails at the backend.
+    request.add_events()->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    auto *valid_heartbeat = request.add_events();
+    valid_heartbeat->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    valid_heartbeat->mutable_heartbeat();
+
+    const auto [ec, response] = CallReportEvent(request, "mixed_invalid_and_tombstoned_heartbeat");
+    EXPECT_EQ(EC_PARTIAL_OK, ec);
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+    ASSERT_EQ(2, response.item_results_size());
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.item_results(0));
+    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, response.item_results(1));
+    EXPECT_FALSE(event_backend->IsNodeRegistered("test_instance", host));
 }
 
 TEST_F(CacheManagerTest, TestReportEventSnapshotRequiredOnlyForGenerationCreatingDelta) {
@@ -3204,6 +3405,67 @@ TEST_F(CacheManagerTest, TestReportEventSnapshotWhileUnavailableCommitsButStaysH
     EXPECT_NE(std::string::npos, visible.front().find("s_version=" + snapshot_generation));
 }
 
+TEST_F(CacheManagerTest, TestReportEventHeartbeatRecoveryCarriesSameRequestMutationsIntoNewLifecycle) {
+    const std::string host = "192.168.10.73:8080";
+    const int64_t add_key = 94'473;
+    const int64_t delete_key = 94'474;
+    const int64_t snapshot_key = 94'475;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+    ASSERT_EQ(EC_OK,
+              CallReportEvent(MakeAddRequest(host, delete_key, "delete_baseline"), "recovery_batch_baseline").first);
+
+    event_backend->SetNodeUnavailable("test_instance", host);
+    const uint64_t add_old_generation = event_backend->GetNodeGeneration("test_instance", host);
+    auto heartbeat_then_add = MakeAddRequest(host, add_key, "heartbeat_then_add");
+    const auto add_event = heartbeat_then_add.events(0);
+    heartbeat_then_add.clear_events();
+    auto *heartbeat = heartbeat_then_add.add_events();
+    heartbeat->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    (*heartbeat->mutable_heartbeat()->mutable_system_status())["phase"] = "recover_add";
+    *heartbeat_then_add.add_events() = add_event;
+    const auto [add_ec, add_response] = CallReportEvent(heartbeat_then_add, "recovery_batch_heartbeat_then_add");
+    ASSERT_EQ(EC_OK, add_ec);
+    EXPECT_EQ(0, add_response.item_results_size());
+    EXPECT_GT(event_backend->GetNodeGeneration("test_instance", host), add_old_generation);
+    ASSERT_EQ(1u, QueryEventReportUris({add_key}).size());
+
+    event_backend->SetNodeUnavailable("test_instance", host);
+    proto::meta::ReportEventRequest delete_then_heartbeat;
+    delete_then_heartbeat.set_instance_id("test_instance");
+    delete_then_heartbeat.set_host_ip_port(host);
+    delete_then_heartbeat.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *delete_event = delete_then_heartbeat.add_events();
+    delete_event->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+    delete_event->mutable_block_delete()->set_block_key(std::to_string(delete_key));
+    delete_event->mutable_block_delete()->set_medium("mem");
+    delete_event->mutable_block_delete()->add_spec_names("tp0");
+    heartbeat = delete_then_heartbeat.add_events();
+    heartbeat->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    heartbeat->mutable_heartbeat();
+    const auto [delete_ec, delete_response] =
+        CallReportEvent(delete_then_heartbeat, "recovery_batch_delete_then_heartbeat");
+    ASSERT_EQ(EC_OK, delete_ec);
+    EXPECT_EQ(0, delete_response.item_results_size());
+    EXPECT_TRUE(QueryEventReportUris({delete_key}).empty());
+
+    event_backend->SetNodeUnavailable("test_instance", host);
+    auto heartbeat_then_snapshot = MakeSnapshotRequest(host, {{snapshot_key, "heartbeat_then_snapshot"}});
+    const auto snapshot_event = heartbeat_then_snapshot.events(0);
+    heartbeat_then_snapshot.clear_events();
+    heartbeat = heartbeat_then_snapshot.add_events();
+    heartbeat->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    heartbeat->mutable_heartbeat();
+    *heartbeat_then_snapshot.add_events() = snapshot_event;
+    const auto [snapshot_ec, snapshot_response] =
+        CallReportEvent(heartbeat_then_snapshot, "recovery_batch_heartbeat_then_snapshot");
+    ASSERT_EQ(EC_OK, snapshot_ec);
+    EXPECT_EQ(0, snapshot_response.item_results_size());
+    EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(snapshot_response.committed_snapshot_version()));
+    ASSERT_EQ(1u, QueryEventReportUris({snapshot_key}).size());
+}
+
 TEST_F(CacheManagerTest, TestReportEventRegisterThenFirstDeltaInSameRequest) {
     const std::string host = "192.168.10.48:8080";
     const int64_t key = 94'433;
@@ -3262,6 +3524,217 @@ TEST_F(CacheManagerTest, TestReportEventDeltaBeforeExplicitRegisterSucceedsInSam
     ASSERT_EQ(1u, visible.size());
     EXPECT_NE(std::string::npos, visible.front().find("source=delta_before_register"));
     EXPECT_NE(std::string::npos, visible.front().find("s_version=" + response.committed_snapshot_version()));
+}
+
+TEST_F(CacheManagerTest, TestReportEventAdmissionFailurePropagatesToLaterRelatedMutation) {
+    const std::string host = "192.168.10.81:8080";
+    const int64_t key = 94'481;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+    ASSERT_EQ(EC_OK, event_backend->UnregisterNode("test_instance", host));
+
+    auto request = MakeAddRequest(host, key, "must_be_deleted_after_retry");
+    auto *register_event = request.add_events();
+    register_event->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    register_event->mutable_node_register()->add_mediums("mem");
+    auto *delete_event = request.add_events();
+    delete_event->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+    delete_event->mutable_block_delete()->set_block_key(std::to_string(key));
+    delete_event->mutable_block_delete()->set_medium("mem");
+    delete_event->mutable_block_delete()->add_spec_names("tp0");
+
+    const auto [ec, response] = CallReportEvent(request, "admission_failure_dependency_closure");
+    EXPECT_EQ(EC_PARTIAL_OK, ec);
+    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, response.header().status().code());
+    ASSERT_EQ(3, response.item_results_size());
+    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, response.item_results(0));
+    EXPECT_EQ(proto::meta::OK, response.item_results(1));
+    // The DELETE physically succeeded, but it shares the retry dependency
+    // group with the earlier failed ADD. Returning success here would let a
+    // caller retry only ADD and reverse the request's last-operation-wins
+    // result.
+    EXPECT_EQ(proto::meta::NODE_NOT_REGISTERED, response.item_results(2));
+    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+
+    proto::meta::ReportEventRequest retry = request;
+    retry.clear_events();
+    *retry.add_events() = request.events(0);
+    *retry.add_events() = request.events(2);
+    const auto [retry_ec, retry_response] = CallReportEvent(retry, "admission_failure_dependency_retry");
+    EXPECT_EQ(EC_OK, retry_ec);
+    EXPECT_EQ(0, retry_response.item_results_size());
+    EXPECT_TRUE(QueryEventReportUris({key}).empty());
+}
+
+TEST_F(CacheManagerTest, TestReportEventValidatesMultipleRegisterItemsIndependently) {
+    const std::string host = "192.168.10.74:8080";
+    const int64_t key = 94'476;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    auto request = MakeAddRequest(host, key, "valid_register_survives_invalid_sibling");
+    const auto add_event = request.events(0);
+    request.clear_events();
+    auto *valid_register = request.add_events();
+    valid_register->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    valid_register->mutable_node_register()->add_mediums("mem");
+    auto *invalid_register = request.add_events();
+    invalid_register->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    invalid_register->mutable_node_register()->add_mediums("bad#medium");
+    *request.add_events() = add_event;
+
+    const auto [ec, response] = CallReportEvent(request, "multiple_register_item_validation");
+    EXPECT_EQ(EC_PARTIAL_OK, ec);
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+    ASSERT_EQ(3, response.item_results_size());
+    EXPECT_EQ(proto::meta::OK, response.item_results(0));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.item_results(1));
+    EXPECT_EQ(proto::meta::OK, response.item_results(2));
+    EXPECT_TRUE(event_backend->IsNodeRegistered("test_instance", host));
+    ASSERT_EQ(1u, QueryEventReportUris({key}).size());
+}
+
+TEST_F(CacheManagerTest, TestReportEventCoalescesMultipleValidRegistersIntoOneLifecycle) {
+    const std::string host = "192.168.10.82:8080";
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    proto::meta::ReportEventRequest request;
+    request.set_instance_id("test_instance");
+    request.set_host_ip_port(host);
+    request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *mem_register = request.add_events();
+    mem_register->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    mem_register->mutable_node_register()->add_mediums("mem");
+    auto *disk_register = request.add_events();
+    disk_register->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    disk_register->mutable_node_register()->add_mediums("disk");
+    disk_register->mutable_node_register()->add_mediums("mem");
+
+    const auto [ec, response] = CallReportEvent(request, "multiple_valid_registers_one_lifecycle");
+    ASSERT_EQ(EC_OK, ec);
+    EXPECT_EQ(proto::meta::OK, response.header().status().code());
+    EXPECT_EQ(0, response.item_results_size());
+    EXPECT_EQ(1u, event_backend->GetNodeGeneration("test_instance", host));
+
+    const auto [retry_ec, retry_response] = CallReportEvent(request, "multiple_valid_registers_next_request");
+    ASSERT_EQ(EC_OK, retry_ec);
+    EXPECT_EQ(0, retry_response.item_results_size());
+    EXPECT_EQ(2u, event_backend->GetNodeGeneration("test_instance", host));
+}
+
+TEST_F(CacheManagerTest, TestReportEventDisabledBackendRejectsReportsAndHidesExistingLocations) {
+    const std::string host = "192.168.10.75:8080";
+    const int64_t baseline_key = 94'477;
+    const int64_t rejected_key = 94'478;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK,
+              CallReportEvent(MakeAddRequest(host, baseline_key, "before_disable"), "disable_backend_baseline").first);
+    ASSERT_EQ(1u, QueryEventReportUris({baseline_key}).size());
+
+    event_backend->SetAvailable(false);
+    EXPECT_TRUE(QueryEventReportUris({baseline_key}).empty());
+    const auto [rejected_ec, rejected_response] =
+        CallReportEvent(MakeAddRequest(host, rejected_key, "must_not_write"), "disable_backend_reject_report");
+    EXPECT_EQ(EC_INSTANCE_NOT_EXIST, rejected_ec);
+    EXPECT_EQ(proto::meta::INSTANCE_NOT_EXIST, rejected_response.header().status().code());
+    EXPECT_TRUE(QueryRawEventReportUris(rejected_key).empty());
+
+    event_backend->SetAvailable(true);
+    ASSERT_EQ(1u, QueryEventReportUris({baseline_key}).size());
+}
+
+TEST_F(CacheManagerTest, TestHostCleanupCannotCrossEventBackendIncarnations) {
+    const std::string host = "192.168.10.76:8080";
+    const int64_t key = 94'479;
+    auto old_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, old_backend);
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeAddRequest(host, key, "old_incarnation"), "old_incarnation_add").first);
+    const uint64_t old_generation = old_backend->GetNodeGeneration("test_instance", host);
+    ASSERT_NE(0u, old_generation);
+    ASSERT_EQ(EC_OK, old_backend->Close());
+
+    auto new_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, new_backend);
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeAddRequest(host, key, "new_incarnation"), "new_incarnation_add").first);
+    ASSERT_EQ(old_generation, new_backend->GetNodeGeneration("test_instance", host));
+
+    cache_manager_->CleanupHostLocations(
+        "test_instance", host, old_generation, DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, old_backend);
+    const auto uris = QueryRawEventReportUris(key);
+    ASSERT_EQ(1u, uris.size());
+    EXPECT_NE(std::string::npos, uris.front().find("source=new_incarnation"));
+}
+
+TEST_F(CacheManagerTest, TestHostCleanupUsesTheBackendThatCurrentlyWinsCandidateRouting) {
+    const std::string host = "192.168.10.77:8080";
+    const int64_t key = 94'480;
+    auto old_backend = InstallEventReportBackend("event_report_old_candidate");
+    ASSERT_NE(nullptr, old_backend);
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeAddRequest(host, key, "old_candidate"), "old_candidate_add").first);
+    const uint64_t old_generation = old_backend->GetNodeGeneration("test_instance", host);
+    ASSERT_NE(0u, old_generation);
+
+    auto current_backend = InstallEventReportBackend("event_report_current_candidate");
+    ASSERT_NE(nullptr, current_backend);
+    const std::string group_name = registry_manager_->GetInstanceGroupName("test_instance");
+    registry_manager_->instance_group_configs_.at(group_name)
+        ->set_event_report_storage_candidates({"event_report_current_candidate", "event_report_old_candidate"});
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeAddRequest(host, key, "current_candidate"), "current_candidate_add").first);
+    ASSERT_EQ(old_generation, current_backend->GetNodeGeneration("test_instance", host));
+
+    cache_manager_->CleanupHostLocations(
+        "test_instance", host, old_generation, DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, old_backend);
+    const auto uris = QueryRawEventReportUris(key);
+    ASSERT_EQ(1u, uris.size());
+    EXPECT_NE(std::string::npos, uris.front().find("source=current_candidate"));
+}
+
+TEST_F(CacheManagerTest, TestSnapshotCleanupCannotCrossBackendReplacementDuringScan) {
+    const std::string host = "192.168.10.78:8080";
+    const int64_t key = 94'482;
+    auto old_backend = InstallEventReportBackend();
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, old_backend);
+    ASSERT_NE(nullptr, meta_backend);
+
+    const auto [baseline_ec, baseline] =
+        CallReportEvent(MakeAddRequest(host, key, "old_snapshot"), "old_snapshot_for_cleanup");
+    ASSERT_EQ(EC_OK, baseline_ec);
+    const ReporterSnapshotKey reporter_key{"test_instance", host};
+    const uint64_t cleanup_generation = old_backend->GetNodeGeneration("test_instance", host);
+
+    std::string cleanup_version;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, old_backend->BeginSnapshot(reporter_key, cleanup_version, retry_after_ms));
+    ASSERT_NE(baseline.committed_snapshot_version(), cleanup_version);
+    ASSERT_TRUE(old_backend->CommitSnapshotVersion(reporter_key, cleanup_version));
+    const uint64_t cleanup_epoch = old_backend->GetSnapshotAttemptEpoch(reporter_key);
+
+    meta_backend->BlockNextLocationRead();
+    auto cleanup = std::async(std::launch::async, [&] {
+        return cache_manager_->CleanupStaleSnapshotLocations(reporter_key,
+                                                             cleanup_version,
+                                                             DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                                                             old_backend,
+                                                             cleanup_epoch,
+                                                             cleanup_generation);
+    });
+    ASSERT_TRUE(meta_backend->WaitUntilLocationReadEntered(std::chrono::seconds(2)));
+
+    ASSERT_EQ(EC_OK, old_backend->Close());
+    auto new_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, new_backend);
+    ASSERT_EQ(EC_OK, CallReportEvent(MakeAddRequest(host, key, "new_backend_value"), "new_backend_value_add").first);
+
+    meta_backend->ReleaseLocationRead();
+    ASSERT_EQ(std::future_status::ready, cleanup.wait_for(std::chrono::seconds(2)));
+    EXPECT_EQ(EC_OK, cleanup.get());
+    const auto uris = QueryRawEventReportUris(key);
+    ASSERT_EQ(1u, uris.size());
+    EXPECT_NE(std::string::npos, uris.front().find("source=new_backend_value"));
 }
 
 TEST_F(CacheManagerTest, TestReportEventInvalidFirstDeltaDoesNotCreateVersionButPartialBatchDoes) {
@@ -3421,8 +3894,13 @@ TEST_F(CacheManagerTest, TestReportEventRestartKeepsHistoricalCacheAndAcceptsDel
 
     const StorageConfig storage_config = event_backend->GetStorageConfig();
     ASSERT_EQ(EC_OK, event_backend->Close());
+    // A process/configuration restart creates a fresh backend incarnation. A
+    // closed object deliberately cannot be reopened because queued callbacks
+    // and lifecycle fences are scoped to exactly one incarnation.
+    event_backend = std::make_shared<EventReportBackend>(metrics_registry_);
     ASSERT_EQ(EC_OK, event_backend->Open(storage_config, "delta_only_restart"));
     event_backend->SetSnapshotMinIntervalMsForTest(0);
+    registry_manager_->data_storage_manager_->storage_map_[storage_config.global_unique_name()] = event_backend;
     EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
     EXPECT_TRUE(QueryEventReportUris({historical_key}).empty());
 
@@ -3887,17 +4365,25 @@ TEST_F(CacheManagerTest, TestSnapshotCleanupPreservesCurrentDeltaBesideLegacySpe
 
     MetaSearcher *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
     ASSERT_NE(nullptr, meta_searcher);
-    std::vector<ErrorCode> replace_results;
+    std::vector<ErrorCode> merge_results;
     ASSERT_EQ(EC_OK,
-              meta_searcher->BatchReplaceLocationSpecs(
-                  request_context_.get(),
-                  {key},
-                  {{{event_backend->BuildLocationId("mem", host),
-                     DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
-                     CacheLocationStatus::CLS_SERVING,
-                     {LocationSpec("tp0", current_uri), LocationSpec("tp1", legacy_uri)}}}},
-                  replace_results));
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), replace_results);
+              meta_searcher->BatchMergeLocationSpecs(request_context_.get(),
+                                                     {key},
+                                                     {{{event_backend->BuildLocationId("mem", host),
+                                                        DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                                                        CacheLocationStatus::CLS_SERVING,
+                                                        {LocationSpec("tp1", legacy_uri)}}}},
+                                                     merge_results));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), merge_results);
+    ASSERT_EQ(EC_OK,
+              meta_searcher->BatchMergeLocationSpecs(request_context_.get(),
+                                                     {key},
+                                                     {{{event_backend->BuildLocationId("mem", host),
+                                                        DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                                                        CacheLocationStatus::CLS_SERVING,
+                                                        {LocationSpec("tp0", current_uri)}}}},
+                                                     merge_results));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), merge_results);
 
     ASSERT_EQ(
         EC_OK,
@@ -5444,6 +5930,30 @@ TEST_F(CacheManagerTest, TestReportEventMutationValidationMatrixHasNoSideEffects
          [=](auto *event, int64_t key, const std::string &host) {
              configure_valid_add(event, key, host)->set_block_key("not-a-number");
          }},
+        {"add_positive_overflow_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_block_key("18446744073709551616");
+         }},
+        {"add_negative_overflow_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_block_key("-9223372036854775809");
+         }},
+        {"add_negative_uint64_alias_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_block_key("-18446744073709551615");
+         }},
+        {"add_leading_plus_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_block_key("+1");
+         }},
+        {"add_leading_space_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_block_key(" 1");
+         }},
+        {"add_trailing_space_key",
+         [=](auto *event, int64_t key, const std::string &host) {
+             configure_valid_add(event, key, host)->set_block_key("1 ");
+         }},
         {"add_empty_medium",
          [=](auto *event, int64_t key, const std::string &host) {
              configure_valid_add(event, key, host)->clear_medium();
@@ -5566,6 +6076,36 @@ TEST_F(CacheManagerTest, TestReportEventMutationValidationMatrixHasNoSideEffects
         EXPECT_TRUE(response.snapshot_required());
         EXPECT_TRUE(event_backend->GetSnapshotVersion({"test_instance", host}).empty());
         EXPECT_TRUE(QueryRawEventReportUris(key).empty());
+    }
+}
+
+TEST_F(CacheManagerTest, TestReportEventAcceptsSignedAndUnsignedBlockKeySpellingsWithoutChangingBitPattern) {
+    const std::string host = "192.168.12.100:8080";
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+    ASSERT_EQ(EC_OK, event_backend->RegisterNode("test_instance", host, {"mem"}));
+
+    struct TestCase {
+        const char *text;
+        int64_t expected_key;
+    };
+    const std::vector<TestCase> cases = {
+        {"0", 0},
+        {"9223372036854775807", std::numeric_limits<int64_t>::max()},
+        {"-9223372036854775808", std::numeric_limits<int64_t>::min()},
+        {"9223372036854775808", std::numeric_limits<int64_t>::min()},
+        {"-1", -1},
+        {"18446744073709551615", -1},
+    };
+
+    for (size_t index = 0; index < cases.size(); ++index) {
+        SCOPED_TRACE(cases[index].text);
+        auto request = MakeAddRequest(host, 0, "block_key_boundary_" + std::to_string(index));
+        request.mutable_events(0)->mutable_block_add()->set_block_key(cases[index].text);
+        const auto [ec, response] = CallReportEvent(request, "block_key_boundary");
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(proto::meta::OK, response.header().status().code());
+        EXPECT_FALSE(QueryRawEventReportUris(cases[index].expected_key).empty());
     }
 }
 
@@ -5771,6 +6311,22 @@ TEST_F(CacheManagerTest, TestReportEventRejectsInvalidRequestsAndMapsItemErrors)
         proto::meta::ReportEventResponse response;
         EXPECT_EQ(EC_BADARGS, cache_manager_->ReportEvent(request_context_.get(), &request, &response));
         EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+    }
+
+    {
+        proto::meta::ReportEventRequest request;
+        request.set_instance_id("test_instance");
+        request.set_host_ip_port("10.0.0.30:8080");
+        // 263 has the same low byte as ST_EVENT_REPORT_L1P5 (7). It must remain
+        // an unsupported open-enum value rather than being truncated and
+        // routed to a real backend.
+        request.set_storage_type(static_cast<proto::meta::StorageType>(263));
+        add_register_event(request);
+
+        proto::meta::ReportEventResponse response;
+        EXPECT_EQ(EC_BADARGS, cache_manager_->ReportEvent(request_context_.get(), &request, &response));
+        EXPECT_EQ(proto::meta::INVALID_ARGUMENT, response.header().status().code());
+        EXPECT_EQ("unsupported event-report storage_type: 263", response.header().status().message());
     }
 
     {
@@ -6357,6 +6913,89 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(
             request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, all_keys, {}, bm, 0, {}, {});
         ASSERT_EQ(EC_BADARGS, ec);
+    }
+
+    // Invalid, incompatible, and duplicate selectors fail closed instead of
+    // silently behaving like weighted-random selection or duplicating output.
+    for (const auto &selectors : std::vector<std::vector<BackendSelector>>{
+             {{DataStorageType::DATA_STORAGE_TYPE_UNKNOWN, LocationSelectStrategy::LSS_WEIGHTED_RANDOM}},
+             {{DataStorageType::DATA_STORAGE_TYPE_NFS, LocationSelectStrategy::LSS_UNSPECIFIED}},
+             {{DataStorageType::DATA_STORAGE_TYPE_NFS, LocationSelectStrategy::LSS_V6D_PREFIX}},
+             {{DataStorageType::DATA_STORAGE_TYPE_NFS, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+              {DataStorageType::DATA_STORAGE_TYPE_NFS, LocationSelectStrategy::LSS_WEIGHTED_RANDOM}},
+         }) {
+        BlockMask bm = static_cast<size_t>(0);
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                     instance_id,
+                                                                     CacheManager::QueryType::QT_BATCH_GET,
+                                                                     all_keys,
+                                                                     {},
+                                                                     bm,
+                                                                     0,
+                                                                     {},
+                                                                     selectors);
+        EXPECT_EQ(EC_BADARGS, ec);
+        EXPECT_TRUE(locs.empty());
+    }
+
+    // Invalid masks must fail closed. An omitted protobuf mask is represented
+    // as an empty bool vector and remains backward-compatible with no mask.
+    const std::vector<BackendSelector> nfs_selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_NFS, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+    };
+    for (const BlockMask &invalid_mask : std::vector<BlockMask>{
+             BlockMaskOffset{all_keys.size() + 1},
+             BlockMaskVector{true, false},
+         }) {
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                     instance_id,
+                                                                     CacheManager::QueryType::QT_BATCH_GET,
+                                                                     all_keys,
+                                                                     {},
+                                                                     invalid_mask,
+                                                                     0,
+                                                                     {},
+                                                                     nfs_selectors);
+        EXPECT_EQ(EC_BADARGS, ec);
+        EXPECT_TRUE(locs.empty());
+    }
+    {
+        const BlockMask implicit_empty_mask = BlockMaskVector{};
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                     instance_id,
+                                                                     CacheManager::QueryType::QT_BATCH_GET,
+                                                                     all_keys,
+                                                                     {},
+                                                                     implicit_empty_mask,
+                                                                     0,
+                                                                     {},
+                                                                     nfs_selectors);
+        EXPECT_EQ(EC_OK, ec);
+        EXPECT_EQ(all_keys.size(), locs.size());
+    }
+
+    // Masked entries stay positionally aligned but do not expose a remote
+    // location. Both vector and prefix-offset forms are supported.
+    for (const BlockMask &mask : std::vector<BlockMask>{
+             BlockMaskVector{true, false, true, false, true},
+             BlockMaskOffset{2},
+         }) {
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
+                                                                     instance_id,
+                                                                     CacheManager::QueryType::QT_BATCH_GET,
+                                                                     all_keys,
+                                                                     {},
+                                                                     mask,
+                                                                     0,
+                                                                     {},
+                                                                     nfs_selectors);
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(all_keys.size(), locs.size());
+        for (size_t i = 0; i < all_keys.size(); ++i) {
+            if (IsIndexInMaskRange(mask, i)) {
+                EXPECT_TRUE(locs[i].cache_locations_view().empty());
+            }
+        }
     }
 
     // --- Test 2: EVENT_REPORT PREFIX + NFS (NFS on 300,500,700 should not affect event report peer selection) ---
@@ -7487,6 +8126,7 @@ TEST_F(CacheManagerTest, TestMigrationTargetsRespectGroupQuota) {
 
 TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaFallsBackOnMarkReadError) {
     EnableTieredMigrationStrategy();
+    ASSERT_TRUE(RegisterDummyStorage("hot_02"));
     cache_manager_->RegisterInstance(request_context_.get(),
                                      "default",
                                      "min_replica_mark_read_error",
@@ -7536,6 +8176,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaFallsBackOnMarkReadEr
 
 TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaInvalidTieredTargetUsesOrdinaryPolicy) {
     EnableTieredMigrationStrategy();
+    ASSERT_TRUE(RegisterDummyStorage("hot_02"));
     cache_manager_->RegisterInstance(request_context_.get(),
                                      "default",
                                      "min_replica_invalid_target",
@@ -7793,6 +8434,7 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaUsesTieredMarkTarget)
 
 TEST_F(CacheManagerTest, TestFilterWriteCacheWithMinReplicaHonorsTieredMarkWhenReplicaSatisfied) {
     EnableTieredMigrationStrategy();
+    ASSERT_TRUE(RegisterDummyStorage("hot_02"));
     cache_manager_->RegisterInstance(request_context_.get(),
                                      "default",
                                      "min_replica_satisfied_tiered",

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -253,6 +253,17 @@ public:
         return MetaLocalBackend::GetLocations(request_context, keys, location_ids, out_locations);
     }
 
+    std::vector<std::vector<ErrorCode>>
+    GetLocationsWithKeyStatus(RequestContext *request_context,
+                              const KeyTypeVec &keys,
+                              const LocationIdsPerKey &location_ids,
+                              LocationsPerKey &out_locations,
+                              std::vector<ErrorCode> &out_key_error_codes) noexcept override {
+        MaybeBlockLocationRead();
+        return MetaLocalBackend::GetLocationsWithKeyStatus(
+            request_context, keys, location_ids, out_locations, out_key_error_codes);
+    }
+
     std::vector<ErrorCode> GetLocations(RequestContext *request_context,
                                         const KeyTypeVec &keys,
                                         CacheLocationMapVector &out_locations) noexcept override {
@@ -8298,7 +8309,8 @@ TEST_F(CacheManagerTest, TestFilterWriteCacheTieredMarkSkipsExistingTarget) {
                                                            LocationSpec("tp3", "dummy://cold_01/blk2/tp3?size=1"),
                                                        });
     std::vector<std::string> ids;
-    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1, 2}, {writing_loc, serving_loc}, ids));
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(meta_searcher, request_context_.get(), {1, 2}, {writing_loc, serving_loc}, ids));
     ASSERT_EQ(2u, ids.size());
     std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
         {MetaSearcher::LocationCASTask{ids[1], CLS_WRITING, CLS_SERVING}}};
@@ -8663,10 +8675,10 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheClearsTieredMark) {
     ASSERT_TRUE(meta_searcher);
     std::vector<std::string> source_ids;
     {
-        auto loc = std::make_shared<CacheLocation>(
-            DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-            1,
-            std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot/blk1?size=1")});
+        auto loc =
+            std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                            1,
+                                            std::vector<LocationSpec>{LocationSpec("tp0", "dummy://hot/blk1?size=1")});
         ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {loc}, source_ids));
     }
     ASSERT_EQ(1u, source_ids.size());
@@ -8843,7 +8855,8 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheFullBlockPolicyKeepsPartialMark) {
         1,
         std::vector<LocationSpec>{LocationSpec("tp0", "dummy://cold_01/blk1/tp0?size=1")});
     std::vector<std::string> partial_ids;
-    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {partial_cold_loc}, partial_ids));
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {partial_cold_loc}, partial_ids));
     auto partial_info = std::make_unique<WriteLocationManager::WriteLocationInfo>();
     partial_info->keys = {1};
     partial_info->location_ids = {partial_ids[0]};
@@ -8864,7 +8877,8 @@ TEST_F(CacheManagerTest, TestFinishWriteCacheFullBlockPolicyKeepsPartialMark) {
                                             LocationSpec("tp3", "dummy://cold_01/blk1/tp3?size=1"),
                                         });
     std::vector<std::string> remaining_ids;
-    ASSERT_EQ(EC_OK, BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {remaining_cold_loc}, remaining_ids));
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(meta_searcher, request_context_.get(), {1}, {remaining_cold_loc}, remaining_ids));
     auto remaining_info = std::make_unique<WriteLocationManager::WriteLocationInfo>();
     remaining_info->keys = {1};
     remaining_info->location_ids = {remaining_ids[0]};

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -3357,6 +3357,46 @@ TEST_F(CacheManagerTest, TestReportEventMissingBlockDeletesRemainSuccessfulAsOne
     EXPECT_TRUE(QueryEventReportUris({94'437, 94'438, 94'439}).empty());
 }
 
+TEST_F(CacheManagerTest, TestReportEventLargeDeltaBatchAcrossRepeatedMediums) {
+    const std::string host = "192.168.10.56:8080";
+    constexpr int64_t first_key = 95'000;
+    constexpr size_t event_count = 512;
+    auto event_backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, event_backend);
+
+    auto request = MakeAddRequest(host, first_key, "batch_0");
+    for (size_t i = 1; i < event_count; ++i) {
+        auto event_request = MakeAddRequest(host, first_key + static_cast<int64_t>(i), "batch_" + std::to_string(i));
+        if (i % 2 != 0) {
+            event_request.mutable_events(0)->mutable_block_add()->set_medium("disk");
+            event_request.mutable_events(0)->mutable_block_add()->mutable_specs(0)->set_uri(
+                "event_report://" + host + "/disk?source=batch_" + std::to_string(i));
+        }
+        *request.add_events() = event_request.events(0);
+    }
+
+    const auto [ec, response] = CallReportEvent(request, "large_repeated_medium_delta_batch");
+    ASSERT_EQ(EC_OK, ec);
+    EXPECT_EQ(proto::meta::OK, response.header().status().code());
+    EXPECT_EQ(0, response.item_results_size());
+    ASSERT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(response.committed_snapshot_version()));
+    EXPECT_TRUE(response.snapshot_required());
+
+    const auto visible = QueryEventReportUris({first_key,
+                                               first_key + static_cast<int64_t>(event_count / 2),
+                                               first_key + static_cast<int64_t>(event_count - 1)});
+    ASSERT_EQ(3u, visible.size());
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const auto &uri) {
+        return uri.find("source=batch_0") != std::string::npos;
+    }));
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const auto &uri) {
+        return uri.find("source=batch_256") != std::string::npos;
+    }));
+    EXPECT_TRUE(std::any_of(visible.begin(), visible.end(), [](const auto &uri) {
+        return uri.find("source=batch_511") != std::string::npos;
+    }));
+}
+
 TEST_F(CacheManagerTest, TestReportEventRestartKeepsHistoricalCacheAndAcceptsDeltaWithoutSnapshot) {
     const std::string host = "192.168.10.47:8080";
     const int64_t historical_key = 94'431;
@@ -6251,9 +6291,8 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
             cache_manager_->StartWriteCache(request_context_.get(), instance_id, nfs_keys, {}, {}, 100000000);
         ASSERT_EQ(EC_OK, ec);
         BlockMask bm = static_cast<size_t>(nfs_keys.size());
-        ASSERT_EQ(
-            EC_OK,
-            cache_manager_->FinishWriteCache(request_context_.get(), instance_id, swci.write_session_id(), bm));
+        ASSERT_EQ(EC_OK,
+                  cache_manager_->FinishWriteCache(request_context_.get(), instance_id, swci.write_session_id(), bm));
     }
 
     // Set up EventReportBackend
@@ -6308,15 +6347,8 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     // --- Test 1: empty backend_selectors → returns EC_BADARGS ---
     {
         BlockMask bm = static_cast<size_t>(0);
-        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
-                                                                     instance_id,
-                                                                     CacheManager::QueryType::QT_BATCH_GET,
-                                                                     all_keys,
-                                                                     {},
-                                                                     bm,
-                                                                     0,
-                                                                     {},
-                                                                     {});
+        auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(
+            request_context_.get(), instance_id, CacheManager::QueryType::QT_BATCH_GET, all_keys, {}, bm, 0, {}, {});
         ASSERT_EQ(EC_BADARGS, ec);
     }
 
@@ -6546,32 +6578,32 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         const auto &kl = locs[0].cache_locations_view();
         ASSERT_EQ(1u, kl.size());
         EXPECT_EQ(2u, kl[0].location_specs().size());
+        EXPECT_EQ(2u, kl[0].spec_size());
     }
 
     // --- Test 9: spec filtering happens before Vineyard peer selection ---
     // The full-only peer covers two keys and would win an unfiltered prefix
     // selection. A linear_1 query must instead select the linear-only peer.
     {
-        auto report_spec = [&](const std::string &host,
-                               const std::vector<int64_t> &keys,
-                               const std::string &spec_name) {
-            proto::meta::ReportEventRequest req;
-            req.set_instance_id(instance_id);
-            req.set_host_ip_port(host);
-            req.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
-            for (int64_t key : keys) {
-                auto *ev = req.add_events();
-                ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
-                auto *ba = ev->mutable_block_add();
-                ba->set_block_key(std::to_string(key));
-                ba->set_medium("mem");
-                auto *spec = ba->add_specs();
-                spec->set_name(spec_name);
-                spec->set_uri("event_report://" + host + "/mem");
-            }
-            proto::meta::ReportEventResponse resp;
-            ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
-        };
+        auto report_spec =
+            [&](const std::string &host, const std::vector<int64_t> &keys, const std::string &spec_name) {
+                proto::meta::ReportEventRequest req;
+                req.set_instance_id(instance_id);
+                req.set_host_ip_port(host);
+                req.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+                for (int64_t key : keys) {
+                    auto *ev = req.add_events();
+                    ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+                    auto *ba = ev->mutable_block_add();
+                    ba->set_block_key(std::to_string(key));
+                    ba->set_medium("mem");
+                    auto *spec = ba->add_specs();
+                    spec->set_name(spec_name);
+                    spec->set_uri("event_report://" + host + "/mem");
+                }
+                proto::meta::ReportEventResponse resp;
+                ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+            };
 
         const std::string full_host = "192.168.2.1:8080";
         const std::string linear_host = "192.168.2.2:8080";
@@ -6597,9 +6629,9 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
         ASSERT_EQ(2u, locs.size());
         ASSERT_EQ(1u, locs[0].cache_locations_view().size());
         ASSERT_EQ(1u, locs[0].cache_locations_view()[0].location_specs().size());
+        EXPECT_EQ(1u, locs[0].cache_locations_view()[0].spec_size());
         EXPECT_EQ("linear_1", locs[0].cache_locations_view()[0].location_specs()[0].name());
-        EXPECT_NE(std::string::npos,
-                  locs[0].cache_locations_view()[0].location_specs()[0].uri().find(linear_host));
+        EXPECT_NE(std::string::npos, locs[0].cache_locations_view()[0].location_specs()[0].uri().find(linear_host));
         EXPECT_TRUE(locs[1].cache_locations_view().empty());
     }
 

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -12,6 +12,7 @@
 
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/meta_indexer_config.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/manager/meta_searcher.h"
@@ -93,6 +94,34 @@ public:
 
 private:
     std::optional<KeyType> failed_key_;
+};
+
+class FaultyGetLocationValuesBackend : public MetaLocalBackend {
+public:
+    void SetFailedKey(KeyType key, ErrorCode error = EC_ERROR) {
+        failed_key_ = key;
+        error_ = error;
+    }
+
+    std::vector<ErrorCode> GetLocationValues(RequestContext *request_context,
+                                             const KeyTypeVec &keys,
+                                             LocationsPerKey &out_locations) noexcept override {
+        auto results = MetaLocalBackend::GetLocationValues(request_context, keys, out_locations);
+        if (!failed_key_.has_value()) {
+            return results;
+        }
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (keys[i] == failed_key_.value()) {
+                results[i] = error_;
+                out_locations[i].clear();
+            }
+        }
+        return results;
+    }
+
+private:
+    std::optional<KeyType> failed_key_;
+    ErrorCode error_ = EC_ERROR;
 };
 
 class CommitThenFailUpsertBackend : public MetaLocalBackend {
@@ -204,6 +233,18 @@ public:
     FaultyGetLocationIdsBackend *ReplaceWithFaultyBackend() {
         auto backend_config = ConstructMetaStorageBackendConfig();
         auto faulty_backend = std::make_unique<FaultyGetLocationIdsBackend>();
+        EXPECT_EQ(EC_OK, faulty_backend->Init("test", backend_config));
+        EXPECT_EQ(EC_OK, faulty_backend->Open());
+        auto backend_raw = faulty_backend.get();
+        meta_indexer_->backend_manager_->persistent_backend_->Close();
+        meta_indexer_->backend_manager_->persistent_backend_ = std::move(faulty_backend);
+        meta_indexer_->backend_manager_->cache_backend_.reset();
+        return backend_raw;
+    }
+
+    FaultyGetLocationValuesBackend *ReplaceWithFaultyGetLocationValuesBackend() {
+        auto backend_config = ConstructMetaStorageBackendConfig();
+        auto faulty_backend = std::make_unique<FaultyGetLocationValuesBackend>();
         EXPECT_EQ(EC_OK, faulty_backend->Init("test", backend_config));
         EXPECT_EQ(EC_OK, faulty_backend->Open());
         auto backend_raw = faulty_backend.get();
@@ -497,6 +538,65 @@ TEST_F(MetaSearcherTest, TestPrefixMatchByHostIgnoresNonServingLocations) {
     ASSERT_EQ(1u, matches.size());
     EXPECT_EQ("serving:8080", matches[0].host_ip_port);
     EXPECT_EQ(1, matches[0].prefix_match_blocks);
+}
+
+TEST_F(MetaSearcherTest, TestPrefixMatchByHostPropagatesHardReadFailureBeforeFirstMiss) {
+    auto *backend = ReplaceWithFaultyGetLocationValuesBackend();
+    const MetaSearcher::KeyVector keys = {10016, 10017};
+    const MetaSearcher::MergeLocationSpecsTask task{
+        "kvs#event_report_l2#mem#serving:8080",
+        DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+        CacheLocationStatus::CLS_SERVING,
+        {LocationSpec("tp0", "event_report://serving:8080/mem")},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, {{task}, {task}}, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), per_key_ec);
+
+    for (const ErrorCode hard_error : {EC_ERROR, EC_MISMATCH}) {
+        backend->SetFailedKey(keys[1], hard_error);
+        std::vector<MetaSearcher::HostCacheMatch> matches = {{"stale:8080", 99}};
+        EXPECT_EQ(hard_error, meta_searcher_->PrefixMatchByHost(request_context_.get(), keys, false, {"mem"}, matches));
+        EXPECT_TRUE(matches.empty());
+    }
+}
+
+TEST_F(MetaSearcherTest, TestPrefixMatchByHostIgnoresSpeculativeFailureAfterFirstMiss) {
+    auto *backend = ReplaceWithFaultyGetLocationValuesBackend();
+    const MetaSearcher::KeyVector keys = {10018, 10019, 10020};
+    const MetaSearcher::MergeLocationSpecsTask task{
+        "kvs#event_report_l2#mem#serving:8080",
+        DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+        CacheLocationStatus::CLS_SERVING,
+        {LocationSpec("tp0", "event_report://serving:8080/mem")},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {keys[0]}, {{task}}, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
+
+    backend->SetFailedKey(keys[2]);
+    std::vector<MetaSearcher::HostCacheMatch> matches;
+    ASSERT_EQ(EC_OK, meta_searcher_->PrefixMatchByHost(request_context_.get(), keys, false, {"mem"}, matches));
+    ASSERT_EQ(1u, matches.size());
+    EXPECT_EQ("serving:8080", matches[0].host_ip_port);
+    EXPECT_EQ(1, matches[0].prefix_match_blocks);
+}
+
+TEST_F(MetaSearcherTest, TestPrefixMatchWithMambaByHostPropagatesHardReadFailure) {
+    auto *backend = ReplaceWithFaultyGetLocationValuesBackend();
+    const int64_t key = 10021;
+    backend->SetFailedKey(key, EC_ERROR);
+    const std::vector<LocationSpecGroup> groups = {
+        LocationSpecGroup("full_0", {"full_0"}),
+        LocationSpecGroup("linear_0", {"linear_0"}),
+    };
+
+    std::vector<MetaSearcher::HostCacheMatch> matches = {{"stale:8080", 99}};
+    EXPECT_EQ(
+        EC_ERROR,
+        meta_searcher_->PrefixMatchWithMambaByHost(request_context_.get(), {key}, false, {"mem"}, groups, matches));
+    EXPECT_TRUE(matches.empty());
 }
 
 TEST_F(MetaSearcherTest, TestPrefixMatchByHostSupportsMoreThanOnePresenceWord) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -7,6 +7,7 @@
 #include <set>
 #include <thread>
 #include <tuple>
+#include <type_traits>
 
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/common/unittest.h"
@@ -18,6 +19,29 @@
 #include "kv_cache_manager/meta/utils.h"
 
 using namespace kv_cache_manager;
+
+static_assert(std::is_nothrow_move_constructible_v<LocationSpec>);
+static_assert(std::is_nothrow_move_assignable_v<LocationSpec>);
+static_assert(std::is_nothrow_move_constructible_v<CacheLocation>);
+static_assert(std::is_nothrow_move_assignable_v<CacheLocation>);
+
+TEST(CacheLocationMoveTest, SetAndMoveLocationSpecsTransferVectorStorage) {
+    std::vector<LocationSpec> specs;
+    specs.reserve(2);
+    specs.emplace_back("tp0", "event_report://move-test:8080/mem?payload=" + std::string(128, 'a'));
+    specs.emplace_back("tp1", "event_report://move-test:8080/mem?payload=" + std::string(128, 'b'));
+    const LocationSpec *const original_storage = specs.data();
+
+    CacheLocation location;
+    location.set_location_specs(std::move(specs));
+    ASSERT_EQ(original_storage, location.location_specs().data());
+    ASSERT_EQ(2u, location.location_specs().size());
+
+    CacheLocation moved(std::move(location));
+    EXPECT_EQ(original_storage, moved.location_specs().data());
+    EXPECT_EQ("tp0", moved.location_specs()[0].name());
+    EXPECT_EQ("tp1", moved.location_specs()[1].name());
+}
 
 namespace {
 // Helper class to create test data
@@ -408,6 +432,43 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsAppendsAndOverwrites) {
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["linear_0"]);
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["linear_1"]);
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["full_3"]);
+}
+
+TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsNormalizesLegacyDuplicateNamesInPlace) {
+    const MetaSearcher::KeyVector keys = {10015};
+    const auto seed =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                                        3,
+                                        std::vector<LocationSpec>{
+                                            LocationSpec("z", "event_report://legacy:8080/mem?source=first"),
+                                            LocationSpec("a", "event_report://legacy:8080/mem?source=untouched"),
+                                            LocationSpec("z", "event_report://legacy:8080/mem?source=last"),
+                                        });
+    std::vector<MetaSearcher::AddLocationResult> add_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchAddLocation(request_context_.get(), keys, CacheLocationVector{seed}, add_results));
+    ASSERT_EQ(1u, add_results.size());
+    ASSERT_EQ(EC_OK, add_results[0].ec);
+
+    std::vector<ErrorCode> per_key_ec;
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks = {{
+        {add_results[0].location_id,
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_SERVING,
+         {LocationSpec("b", "event_report://legacy:8080/mem?source=new")}},
+    }};
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    const auto &specs = location_maps[0].at(add_results[0].location_id)->location_specs();
+    ASSERT_EQ(3u, specs.size());
+    EXPECT_EQ("a", specs[0].name());
+    EXPECT_EQ("b", specs[1].name());
+    EXPECT_EQ("z", specs[2].name());
+    EXPECT_EQ("event_report://legacy:8080/mem?source=last", specs[2].uri());
 }
 
 TEST_F(MetaSearcherTest, TestPrefixMatchByHostIgnoresNonServingLocations) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -640,6 +640,77 @@ TEST_F(MetaSearcherTest, TestPrefixMatchByHostSupportsMoreThanOnePresenceWord) {
     EXPECT_EQ(3, prefix_for(host_name(69)));
 }
 
+TEST_F(MetaSearcherTest, TestPrefixMatchByHostParallelPresenceMatrixMatchesReference) {
+    constexpr std::size_t kHostCount = 70;
+    constexpr std::size_t kKeyCount = 384;
+    MetaSearcher::KeyVector keys;
+    keys.reserve(kKeyCount);
+    for (std::size_t key_index = 0; key_index < kKeyCount; ++key_index) {
+        keys.push_back(11000 + key_index);
+    }
+
+    auto host_name = [](std::size_t index) {
+        return std::string("parallel-host-") + (index < 10 ? "0" : "") + std::to_string(index) + ":8080";
+    };
+    std::vector<std::size_t> expected_prefixes(kHostCount);
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks(kKeyCount);
+    for (std::size_t host_index = 0; host_index < kHostCount; ++host_index) {
+        std::size_t prefix = 1 + (host_index * 83) % kKeyCount;
+        if (host_index == 63) {
+            prefix = 257;
+        } else if (host_index == 64) {
+            prefix = 1;
+        } else if (host_index == 69) {
+            prefix = kKeyCount;
+        }
+        expected_prefixes[host_index] = prefix;
+
+        const std::string host = host_name(host_index);
+        const MetaSearcher::MergeLocationSpecsTask task{
+            "kvs#event_report_l2#mem#" + host,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://" + host + "/mem")},
+        };
+        for (std::size_t key_index = 0; key_index < prefix; ++key_index) {
+            tasks[key_index].push_back(task);
+        }
+    }
+
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec));
+    ASSERT_EQ(kKeyCount, per_key_ec.size());
+    EXPECT_TRUE(std::all_of(per_key_ec.begin(), per_key_ec.end(), [](ErrorCode ec) { return ec == EC_OK; }));
+
+    auto verify_matches = [&](const std::vector<MetaSearcher::HostCacheMatch> &matches, bool use_eagle_pop) {
+        std::map<std::string, int64_t> actual;
+        for (const auto &match : matches) {
+            ASSERT_TRUE(actual.emplace(match.host_ip_port, match.prefix_match_blocks).second);
+        }
+        for (std::size_t host_index = 0; host_index < kHostCount; ++host_index) {
+            const int64_t expected = static_cast<int64_t>(expected_prefixes[host_index]) - (use_eagle_pop ? 1 : 0);
+            const auto it = actual.find(host_name(host_index));
+            if (expected == 0) {
+                EXPECT_EQ(actual.end(), it) << "host_index=" << host_index;
+            } else {
+                ASSERT_NE(actual.end(), it) << "host_index=" << host_index;
+                EXPECT_EQ(expected, it->second) << "host_index=" << host_index;
+            }
+        }
+    };
+
+    std::vector<MetaSearcher::HostCacheMatch> matches;
+    ASSERT_EQ(EC_OK, meta_searcher_->PrefixMatchByHost(request_context_.get(), keys, false, {"mem"}, matches));
+    ASSERT_EQ(kHostCount, matches.size());
+    verify_matches(matches, false);
+
+    ASSERT_EQ(EC_OK, meta_searcher_->PrefixMatchByHost(request_context_.get(), keys, true, {"mem"}, matches));
+    verify_matches(matches, true);
+
+    ASSERT_EQ(EC_OK, meta_searcher_->PrefixMatchByHost(request_context_.get(), keys, false, {"disk"}, matches));
+    EXPECT_TRUE(matches.empty());
+}
+
 TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsPreservesUntouchedSpecsAcrossGenerationChange) {
     const MetaSearcher::KeyVector keys = {10007};
     const std::string location_id = "kvs#event_report_l2#mem#127.0.0.1:8080";

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -2,6 +2,7 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <thread>
@@ -90,6 +91,33 @@ private:
     bool fail_upsert_ = false;
 };
 
+class RecordingGetLocationsBackend : public MetaLocalBackend {
+public:
+    std::vector<ErrorCode> GetLocations(RequestContext *request_context,
+                                        const KeyTypeVec &keys,
+                                        CacheLocationMapVector &out_locations) noexcept override {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            requested_key_batches_.push_back(keys);
+        }
+        return MetaLocalBackend::GetLocations(request_context, keys, out_locations);
+    }
+
+    void ResetReadLog() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        requested_key_batches_.clear();
+    }
+
+    std::vector<KeyTypeVec> RequestedKeyBatches() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return requested_key_batches_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<KeyTypeVec> requested_key_batches_;
+};
+
 ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
                                   RequestContext *request_context,
                                   const KeyVector &keys,
@@ -163,6 +191,18 @@ public:
     CommitThenFailUpsertBackend *ReplaceWithCommitThenFailUpsertBackend() {
         auto backend_config = ConstructMetaStorageBackendConfig();
         auto backend = std::make_unique<CommitThenFailUpsertBackend>();
+        EXPECT_EQ(EC_OK, backend->Init("test", backend_config));
+        EXPECT_EQ(EC_OK, backend->Open());
+        auto backend_raw = backend.get();
+        meta_indexer_->backend_manager_->persistent_backend_->Close();
+        meta_indexer_->backend_manager_->persistent_backend_ = std::move(backend);
+        meta_indexer_->backend_manager_->cache_backend_.reset();
+        return backend_raw;
+    }
+
+    RecordingGetLocationsBackend *ReplaceWithRecordingGetLocationsBackend() {
+        auto backend_config = ConstructMetaStorageBackendConfig();
+        auto backend = std::make_unique<RecordingGetLocationsBackend>();
         EXPECT_EQ(EC_OK, backend->Init("test", backend_config));
         EXPECT_EQ(EC_OK, backend->Open());
         auto backend_raw = backend.get();
@@ -370,6 +410,33 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsAppendsAndOverwrites) {
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["full_3"]);
 }
 
+TEST_F(MetaSearcherTest, TestPrefixMatchByHostIgnoresNonServingLocations) {
+    const int64_t key = 10014;
+    std::vector<ErrorCode> per_key_ec;
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks = {{
+        {"kvs#event_report_l2#mem#writing:8080",
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_WRITING,
+         {LocationSpec("tp0", "event_report://writing:8080/mem")}},
+        {"kvs#event_report_l2#mem#serving:8080",
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_SERVING,
+         {LocationSpec("tp0", "event_report://serving:8080/mem")}},
+        {"kvs#event_report_l2#mem#deleting:8080",
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_DELETING,
+         {LocationSpec("tp0", "event_report://deleting:8080/mem")}},
+    }};
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {key}, tasks, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
+
+    std::vector<MetaSearcher::HostCacheMatch> matches;
+    ASSERT_EQ(EC_OK, meta_searcher_->PrefixMatchByHost(request_context_.get(), {key}, false, {"mem"}, matches));
+    ASSERT_EQ(1u, matches.size());
+    EXPECT_EQ("serving:8080", matches[0].host_ip_port);
+    EXPECT_EQ(1, matches[0].prefix_match_blocks);
+}
+
 TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsPreservesUntouchedSpecsAcrossGenerationChange) {
     const MetaSearcher::KeyVector keys = {10007};
     const std::string location_id = "kvs#event_report_l2#mem#127.0.0.1:8080";
@@ -385,12 +452,19 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsPreservesUntouchedSpecsAcros
          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
          CacheLocationStatus::CLS_SERVING,
          {LocationSpec("linear_0", uri("old_linear", version_a)),
-          LocationSpec("mamba_0", uri("old_mamba", version_a)),
-          LocationSpec("legacy", "event_report://127.0.0.1:8080/mem?source=legacy")}},
+          LocationSpec("mamba_0", uri("old_mamba", version_a))}},
     }};
     ASSERT_EQ(EC_OK, meta_searcher_->BatchReplaceLocationSpecs(request_context_.get(), keys, seed_tasks, per_key_ec));
 
     std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks = {{
+        {location_id,
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_SERVING,
+         {LocationSpec("legacy", "event_report://127.0.0.1:8080/mem?source=legacy")}},
+    }};
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec));
+
+    tasks = {{
         {location_id,
          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
          CacheLocationStatus::CLS_SERVING,
@@ -451,6 +525,17 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsRejectsMixedOrMalformedSnaps
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
 
     const std::vector<std::vector<LocationSpec>> invalid_specs = {
+        {},
+        {
+            LocationSpec("", "event_report://127.0.0.1:8080/mem"),
+        },
+        {
+            LocationSpec("duplicate_name", "event_report://127.0.0.1:8080/mem?source=first"),
+            LocationSpec("duplicate_name", "event_report://127.0.0.1:8080/mem?source=second"),
+        },
+        {
+            LocationSpec("invalid_uri", "not a valid uri"),
+        },
         {
             LocationSpec("valid", uri("valid", version_b)),
             LocationSpec("missing", "event_report://127.0.0.1:8080/mem?source=missing"),
@@ -497,6 +582,29 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsRejectsMixedOrMalformedSnaps
     ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), new_keys, mask, location_maps));
     ASSERT_EQ(1u, location_maps.size());
     EXPECT_TRUE(location_maps.front().empty());
+
+    // Replace performs the same validation as merge, before any key in the
+    // batch is mutated. A valid sibling must therefore remain unwritten when
+    // another task carries inconsistent snapshot metadata.
+    const KeyVector replace_keys = {10014, 10015};
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+          CacheLocationStatus::CLS_SERVING,
+          {LocationSpec("valid", uri("valid", version_a))}}},
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+          CacheLocationStatus::CLS_SERVING,
+          invalid_specs.front()}},
+    };
+    EXPECT_EQ(
+        EC_BADARGS,
+        meta_searcher_->BatchReplaceLocationSpecs(request_context_.get(), replace_keys, replace_tasks, per_key_ec));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_BADARGS, EC_BADARGS}), per_key_ec);
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), replace_keys, mask, location_maps));
+    ASSERT_EQ(2u, location_maps.size());
+    EXPECT_TRUE(location_maps[0].empty());
+    EXPECT_TRUE(location_maps[1].empty());
 }
 
 TEST_F(MetaSearcherTest, TestConcurrentSnapshotReplaceIsAtomicAndSameTokenDeltasDoNotLoseUpdates) {
@@ -891,6 +999,55 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocationSpecsPartialDelete) {
     EXPECT_FALSE(location_maps[0].empty());
 }
 
+TEST_F(MetaSearcherTest, TestBatchDeleteFinalLocationsReclaimsDuplicateKeyOnce) {
+    constexpr KeyType reclaimed_key = 10014;
+    constexpr KeyType retained_key = 10015;
+    const std::string location_a = "event_report#mem#127.0.0.14:8080";
+    const std::string location_b = "event_report#disk#127.0.0.14:8080";
+    const std::string retained_location = "event_report#mem#127.0.0.15:8080";
+
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks = {
+        {{location_a,
+          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5,
+          CacheLocationStatus::CLS_SERVING,
+          {LocationSpec("tp0", "event_report://127.0.0.14:8080/mem")}},
+         {location_b,
+          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5,
+          CacheLocationStatus::CLS_SERVING,
+          {LocationSpec("tp1", "event_report://127.0.0.14:8080/disk")}}},
+        {{retained_location,
+          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5,
+          CacheLocationStatus::CLS_SERVING,
+          {LocationSpec("tp0", "event_report://127.0.0.15:8080/mem")}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(
+                  request_context_.get(), {reclaimed_key, retained_key}, merge_tasks, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), per_key_ec);
+    ASSERT_EQ(2u, meta_indexer_->GetKeyCount());
+
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks = {{
+        {location_a, {"tp0"}},
+        {location_b, {"tp1"}},
+    }};
+    std::vector<std::vector<ErrorCode>> delete_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocationSpecs(
+                  request_context_.get(), {reclaimed_key}, delete_tasks, delete_results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK, EC_OK}}), delete_results);
+    EXPECT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchGetLocation(request_context_.get(), {reclaimed_key, retained_key}, mask, location_maps));
+    ASSERT_EQ(2u, location_maps.size());
+    EXPECT_TRUE(location_maps[0].empty());
+    EXPECT_EQ(1u, location_maps[1].count(retained_location));
+}
+
 TEST_F(MetaSearcherTest, TestBatchDeleteLocationSpecsValidatesShapeAndMissingLocationIsIdempotent) {
     MetaSearcher::KeyVector keys = {10004};
     const std::string existing_location_id = "event_report#mem#127.0.0.1:8080";
@@ -929,6 +1086,71 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocationSpecsValidatesShapeAndMissingLoc
     ASSERT_TRUE(existing->second);
     ASSERT_EQ(1u, existing->second->location_specs().size());
     EXPECT_EQ("linear_0", existing->second->location_specs()[0].name());
+}
+
+TEST_F(MetaSearcherTest, TestBatchSpecMutationsRejectDuplicateRmwTargetsBeforeWriting) {
+    const int64_t key = 10013;
+    const std::string location_id = "kvs#event_report_l2#mem#duplicate-target:8080";
+    std::vector<ErrorCode> per_key_ec;
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> seed = {{
+        {location_id,
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_SERVING,
+         {LocationSpec("tp0", "event_report://duplicate-target:8080/mem?source=seed_tp0"),
+          LocationSpec("tp1", "event_report://duplicate-target:8080/mem?source=seed_tp1")}},
+    }};
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {key}, seed, per_key_ec));
+
+    auto duplicate_merge = seed;
+    duplicate_merge[0].push_back({location_id,
+                                  DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                                  CacheLocationStatus::CLS_SERVING,
+                                  {LocationSpec("tp2", "event_report://duplicate-target:8080/mem?source=lost")}});
+    EXPECT_EQ(EC_BADARGS,
+              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {key}, duplicate_merge, per_key_ec));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_BADARGS}), per_key_ec);
+
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> duplicate_delete = {{
+        {location_id, {"tp0"}},
+        {location_id, {"tp1"}},
+    }};
+    std::vector<std::vector<ErrorCode>> delete_results;
+    EXPECT_EQ(
+        EC_BADARGS,
+        meta_searcher_->BatchDeleteLocationSpecs(request_context_.get(), {key}, duplicate_delete, delete_results));
+    ASSERT_EQ(1u, delete_results.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_BADARGS, EC_BADARGS}), delete_results[0]);
+
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> empty_delete = {{
+        {"kvs#event_report_l2#mem#missing:8080", {}},
+    }};
+    EXPECT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocationSpecs(request_context_.get(), {key}, empty_delete, delete_results));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_BADARGS}), delete_results[0]);
+
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> duplicate_key_replace = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+          CacheLocationStatus::CLS_SERVING,
+          {LocationSpec("tp0", "event_report://duplicate-target:8080/mem?source=replace_a")}}},
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+          CacheLocationStatus::CLS_SERVING,
+          {LocationSpec("tp0", "event_report://duplicate-target:8080/mem?source=replace_b")}}},
+    };
+    EXPECT_EQ(EC_BADARGS,
+              meta_searcher_->BatchReplaceLocationSpecs(
+                  request_context_.get(), {key, key}, duplicate_key_replace, per_key_ec));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_BADARGS, EC_BADARGS}), per_key_ec);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {key}, mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    const auto &specs = location_maps[0].at(location_id)->location_specs();
+    ASSERT_EQ(2u, specs.size());
+    EXPECT_EQ(std::string::npos, specs[0].uri().find("source=lost"));
+    EXPECT_EQ(std::string::npos, specs[1].uri().find("source=lost"));
 }
 
 TEST_F(MetaSearcherTest, TestBatchDeleteLocationSpecsIsIdempotentForMissingData) {
@@ -2576,6 +2798,7 @@ protected:
 
     void SetUp() override {
         MetaSearcherTest::SetUp();
+        recording_backend_ = ReplaceWithRecordingGetLocationsBackend();
 
         // event report locations
         std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> er_upserts = {
@@ -2639,7 +2862,10 @@ protected:
             std::vector<std::vector<ErrorCode>> results;
             meta_searcher_->BatchUpdateLocationStatus(request_context_.get(), {key}, tasks, results);
         }
+        recording_backend_->ResetReadLog();
     }
+
+    RecordingGetLocationsBackend *recording_backend_ = nullptr;
 };
 
 TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixStrategy) {
@@ -2685,6 +2911,72 @@ TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageStrategy) {
         EXPECT_NE(out[i][0]->location_specs()[0].uri().find("peer_b"), std::string::npos);
     }
     EXPECT_TRUE(out[4].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, BlockMaskSkipsMetadataReadsAndPreservesOutputPositions) {
+    const MetaSearcher::KeyVector keys = {80000, 80001, 80002, 80003, 80004};
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+        {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+    };
+    const BlockMask mask = BlockMaskVector{true, false, true, false, true};
+
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), keys, out, &policy_, selectors, {}, mask));
+
+    ASSERT_EQ(keys.size(), out.size());
+    EXPECT_TRUE(out[0].empty());
+    ASSERT_EQ(2u, out[1].size());
+    EXPECT_TRUE(out[2].empty());
+    ASSERT_EQ(2u, out[3].size());
+    EXPECT_TRUE(out[4].empty());
+
+    const auto batches = recording_backend_->RequestedKeyBatches();
+    ASSERT_EQ(1u, batches.size());
+    EXPECT_EQ((MetaSearcher::KeyVector{80001, 80003}), batches[0]);
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, FullyMaskedRequestAvoidsMetadataBackend) {
+    const MetaSearcher::KeyVector keys = {80000, 80001, 80002, 80003, 80004};
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+    };
+    const BlockMask mask = BlockMaskOffset{keys.size()};
+
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), keys, out, &policy_, selectors, {}, mask));
+
+    ASSERT_EQ(keys.size(), out.size());
+    for (const auto &locations : out) {
+        EXPECT_TRUE(locations.empty());
+    }
+    EXPECT_TRUE(recording_backend_->RequestedKeyBatches().empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, InvalidBlockMaskFailsBeforeMetadataRead) {
+    const MetaSearcher::KeyVector keys = {80000, 80001, 80002};
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+    };
+
+    for (const BlockMask &mask : std::vector<BlockMask>{
+             BlockMaskOffset{keys.size() + 1},
+             BlockMaskVector{true, false},
+         }) {
+        LocationsPerKey out;
+        EXPECT_EQ(ErrorCode::EC_BADARGS,
+                  meta_searcher_->BatchGetBestLocationByBackend(
+                      request_context_.get(), keys, out, &policy_, selectors, {}, mask));
+        ASSERT_EQ(keys.size(), out.size());
+        for (const auto &locations : out) {
+            EXPECT_TRUE(locations.empty());
+        }
+    }
+    EXPECT_TRUE(recording_backend_->RequestedKeyBatches().empty());
 }
 
 TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixTieBreaksByPeerAddress) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -980,6 +980,182 @@ TEST_F(MetaSearcherTest, TestBatchDeleteLocationSpecsIsIdempotentForMissingData)
     EXPECT_EQ("linear_0", specs[0].name());
 }
 
+TEST_F(MetaSearcherTest, TestBatchMutationWriteLeaseIsAcquiredOncePerRmwPhase) {
+    const MetaSearcher::KeyVector keys = {10081, 10082, 10083};
+    const std::string location_id = "kvs#event_report_l2#mem#lease-host:8080";
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        merge_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://lease-host:8080/mem?size=1")},
+        }});
+    }
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, merge_tasks, per_key_ec));
+
+    size_t acquire_count = 0;
+    MetaSearcher::AcquireMetadataWriteLeaseFunc acquire_write_lease = [&] {
+        ++acquire_count;
+        return std::make_pair(EC_OK, std::static_pointer_cast<void>(std::make_shared<size_t>(acquire_count)));
+    };
+
+    // Every key already has this location, so BatchMerge exercises both its
+    // block lookup and targeted location RMW phases with one lease per phase.
+    for (auto &tasks : merge_tasks) {
+        tasks[0].specs = {LocationSpec("tp1", "event_report://lease-host:8080/mem?size=2")};
+    }
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(
+                  request_context_.get(), keys, merge_tasks, per_key_ec, acquire_write_lease));
+    EXPECT_EQ(2u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), per_key_ec);
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        replace_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp2", "event_report://lease-host:8080/mem?size=3")},
+        }});
+    }
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchReplaceLocationSpecs(
+                  request_context_.get(), keys, replace_tasks, per_key_ec, acquire_write_lease));
+    EXPECT_EQ(1u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), per_key_ec);
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        delete_tasks.push_back({{location_id, {"tp2"}}});
+    }
+    std::vector<std::vector<ErrorCode>> delete_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocationSpecs(
+                  request_context_.get(), keys, delete_tasks, delete_results, nullptr, acquire_write_lease));
+    EXPECT_EQ(1u, acquire_count);
+    ASSERT_EQ(keys.size(), delete_results.size());
+    for (const auto &results : delete_results) {
+        EXPECT_EQ((std::vector<ErrorCode>{EC_OK}), results);
+    }
+}
+
+TEST_F(MetaSearcherTest, TestBatchMutationWriteLeaseFailurePreventsAllWrites) {
+    const MetaSearcher::KeyVector keys = {10084, 10085};
+    const std::string location_id = "kvs#event_report_l2#mem#fenced-host:8080";
+    size_t acquire_count = 0;
+    MetaSearcher::AcquireMetadataWriteLeaseFunc reject_write = [&] {
+        ++acquire_count;
+        return std::make_pair(EC_NODE_NOT_REGISTERED, MetaSearcher::MetadataWriteLease{});
+    };
+
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        merge_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://fenced-host:8080/mem")},
+        }});
+    }
+    std::vector<ErrorCode> per_key_ec;
+    EXPECT_EQ(
+        EC_ERROR,
+        meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, merge_tasks, per_key_ec, reject_write));
+    EXPECT_EQ(1u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_NODE_NOT_REGISTERED), per_key_ec);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    ASSERT_EQ(keys.size(), location_maps.size());
+    EXPECT_TRUE(std::all_of(
+        location_maps.begin(), location_maps.end(), [](const auto &locations) { return locations.empty(); }));
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        replace_tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp1", "event_report://fenced-host:8080/mem")},
+        }});
+    }
+    EXPECT_NE(EC_OK,
+              meta_searcher_->BatchReplaceLocationSpecs(
+                  request_context_.get(), keys, replace_tasks, per_key_ec, reject_write));
+    EXPECT_EQ(1u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_NODE_NOT_REGISTERED), per_key_ec);
+
+    acquire_count = 0;
+    std::vector<std::vector<MetaSearcher::DeleteLocationSpecsTask>> delete_tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        delete_tasks.push_back({{location_id, {"tp0"}}});
+    }
+    std::vector<std::vector<ErrorCode>> delete_results;
+    std::vector<std::vector<bool>> missing_targets;
+    EXPECT_NE(EC_OK,
+              meta_searcher_->BatchDeleteLocationSpecs(
+                  request_context_.get(), keys, delete_tasks, delete_results, &missing_targets, reject_write));
+    EXPECT_EQ(1u, acquire_count);
+    ASSERT_EQ(keys.size(), delete_results.size());
+    ASSERT_EQ(keys.size(), missing_targets.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        EXPECT_EQ((std::vector<ErrorCode>{EC_NODE_NOT_REGISTERED}), delete_results[i]);
+        EXPECT_EQ((std::vector<bool>{false}), missing_targets[i]);
+    }
+}
+
+TEST_F(MetaSearcherTest, TestBatchMergeReacquiresWriteLeaseBetweenRmwPhases) {
+    const MetaSearcher::KeyVector keys = {10086, 10087};
+    const std::string location_id = "kvs#event_report_l2#mem#lease-race:8080";
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        tasks.push_back({{
+            location_id,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://lease-race:8080/mem?phase=seed")},
+        }});
+    }
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec));
+
+    for (auto &per_key_tasks : tasks) {
+        per_key_tasks[0].specs = {LocationSpec("tp1", "event_report://lease-race:8080/mem?phase=stale")};
+    }
+    size_t acquire_count = 0;
+    MetaSearcher::AcquireMetadataWriteLeaseFunc fail_second_phase = [&] {
+        ++acquire_count;
+        if (acquire_count == 1) {
+            return std::make_pair(EC_OK, std::static_pointer_cast<void>(std::make_shared<size_t>(acquire_count)));
+        }
+        return std::make_pair(EC_NODE_NOT_REGISTERED, MetaSearcher::MetadataWriteLease{});
+    };
+    EXPECT_NE(
+        EC_OK,
+        meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec, fail_second_phase));
+    EXPECT_EQ(2u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_NODE_NOT_REGISTERED), per_key_ec);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
+    ASSERT_EQ(keys.size(), location_maps.size());
+    for (const auto &locations : location_maps) {
+        ASSERT_EQ(1u, locations.size());
+        const auto &specs = locations.at(location_id)->location_specs();
+        ASSERT_EQ(1u, specs.size());
+        EXPECT_EQ("tp0", specs[0].name());
+        EXPECT_EQ(std::string::npos, specs[0].uri().find("phase=stale"));
+    }
+}
+
 TEST_F(MetaSearcherTest, TestCleanupLocationsByPredicateSubmitsExactObservedValue) {
     const MetaSearcher::KeyVector keys = {10009, 10010};
     const std::string stale_id = "kvs#event_report_l2#mem#127.0.0.1:8080";
@@ -2330,6 +2506,74 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
 
 class BatchGetBestLocationByBackendTest : public MetaSearcherTest {
 protected:
+    void AddRequestedSpecMatrixEventReportPeer() {
+        // The requested spec is deliberately the second spec in the first
+        // and third locations. The middle key has the same reporter but only
+        // a different spec, forming a requested-spec gap.
+        std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> upserts = {
+            {
+                {"kvs#event_report_l2#mem#matrix_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {
+                     LocationSpec("full_0", "event_report://matrix_peer:8080/mem"),
+                     LocationSpec("linear_1", "event_report://matrix_peer:8080/mem"),
+                 }},
+            },
+            {
+                {"kvs#event_report_l2#mem#matrix_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("full_0", "event_report://matrix_peer:8080/mem")}},
+            },
+            {
+                {"kvs#event_report_l2#mem#matrix_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {
+                     LocationSpec("full_0", "event_report://matrix_peer:8080/mem"),
+                     LocationSpec("linear_1", "event_report://matrix_peer:8080/mem"),
+                 }},
+            },
+        };
+        std::vector<ErrorCode> per_key_ec;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchMergeLocationSpecs(
+                      request_context_.get(), {82000, 82001, 82002}, upserts, per_key_ec));
+        ASSERT_EQ(3u, per_key_ec.size());
+        EXPECT_TRUE(std::all_of(per_key_ec.begin(), per_key_ec.end(), [](ErrorCode ec) { return ec == EC_OK; }));
+    }
+
+    void AddSpecFilteredEventReportPeers() {
+        // full_peer has better raw coverage, but none of its locations match
+        // linear_1. linear_peer must therefore win after requested-spec
+        // filtering for both cross-key selection strategies.
+        std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> upserts = {
+            {
+                {"kvs#event_report_l2#mem#full_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("full_0", "event_report://full_peer:8080/mem")}},
+                {"kvs#event_report_l2#mem#linear_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("linear_1", "event_report://linear_peer:8080/mem")}},
+            },
+            {
+                {"kvs#event_report_l2#mem#full_peer:8080",
+                 DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                 CLS_SERVING,
+                 {LocationSpec("full_0", "event_report://full_peer:8080/mem")}},
+            },
+        };
+        std::vector<ErrorCode> per_key_ec;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {81000, 81001}, upserts, per_key_ec));
+        ASSERT_EQ(2u, per_key_ec.size());
+        EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[0]);
+        EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[1]);
+    }
+
     void SetUp() override {
         MetaSearcherTest::SetUp();
 
@@ -2441,6 +2685,138 @@ TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageStrategy) {
         EXPECT_NE(out[i][0]->location_specs()[0].uri().find("peer_b"), std::string::npos);
     }
     EXPECT_TRUE(out[4].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixTieBreaksByPeerAddress) {
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {80000, 80001}, out, &policy_, selectors));
+
+    ASSERT_EQ(2u, out.size());
+    for (const auto &locations : out) {
+        ASSERT_EQ(1u, locations.size());
+        EXPECT_NE(locations[0]->location_specs()[0].uri().find("peer_a"), std::string::npos);
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageTieBreaksByPeerAddress) {
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {80000, 80001}, out, &policy_, selectors));
+
+    ASSERT_EQ(2u, out.size());
+    for (const auto &locations : out) {
+        ASSERT_EQ(1u, locations.size());
+        EXPECT_NE(locations[0]->location_specs()[0].uri().find("peer_a"), std::string::npos);
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixFiltersRequestedSpecBeforePeerSelection) {
+    AddSpecFilteredEventReportPeers();
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {81000, 81001}, out, &policy_, selectors, {"linear_1"}));
+
+    ASSERT_EQ(2u, out.size());
+    ASSERT_EQ(1u, out[0].size());
+    ASSERT_EQ(1u, out[0][0]->location_specs().size());
+    EXPECT_EQ("linear_1", out[0][0]->location_specs()[0].name());
+    EXPECT_NE(std::string::npos, out[0][0]->location_specs()[0].uri().find("linear_peer"));
+    EXPECT_TRUE(out[1].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageFiltersRequestedSpecBeforePeerSelection) {
+    AddSpecFilteredEventReportPeers();
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), {81000, 81001}, out, &policy_, selectors, {"linear_1"}));
+
+    ASSERT_EQ(2u, out.size());
+    ASSERT_EQ(1u, out[0].size());
+    ASSERT_EQ(1u, out[0][0]->location_specs().size());
+    EXPECT_EQ("linear_1", out[0][0]->location_specs()[0].name());
+    EXPECT_NE(std::string::npos, out[0][0]->location_specs()[0].uri().find("linear_peer"));
+    EXPECT_TRUE(out[1].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportUnknownRequestedSpecReturnsNoCandidate) {
+    AddSpecFilteredEventReportPeers();
+    for (const auto strategy : {LocationSelectStrategy::LSS_V6D_PREFIX, LocationSelectStrategy::LSS_V6D_COVERAGE}) {
+        const std::vector<BackendSelector> selectors = {
+            {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, strategy},
+        };
+        LocationsPerKey out;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchGetBestLocationByBackend(
+                      request_context_.get(), {81000, 81001}, out, &policy_, selectors, {"missing_spec"}));
+        ASSERT_EQ(2u, out.size());
+        EXPECT_TRUE(out[0].empty());
+        EXPECT_TRUE(out[1].empty());
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportRequestedSpecMatchesAnyNameIncludingNonFirstSpec) {
+    AddRequestedSpecMatrixEventReportPeer();
+    for (const auto strategy : {LocationSelectStrategy::LSS_V6D_PREFIX, LocationSelectStrategy::LSS_V6D_COVERAGE}) {
+        const std::vector<BackendSelector> selectors = {
+            {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, strategy},
+        };
+        LocationsPerKey out;
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher_->BatchGetBestLocationByBackend(
+                      request_context_.get(), {82000}, out, &policy_, selectors, {"missing", "linear_1", "linear_1"}));
+        ASSERT_EQ(1u, out.size());
+        ASSERT_EQ(1u, out[0].size());
+        ASSERT_EQ(2u, out[0][0]->location_specs().size());
+        EXPECT_EQ("full_0", out[0][0]->location_specs()[0].name());
+        EXPECT_EQ("linear_1", out[0][0]->location_specs()[1].name());
+        EXPECT_NE(std::string::npos, out[0][0]->location_specs()[0].uri().find("matrix_peer"));
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportRequestedSpecGapStopsPrefixButNotCoverage) {
+    AddRequestedSpecMatrixEventReportPeer();
+    const MetaSearcher::KeyVector keys = {82000, 82001, 82002};
+
+    LocationsPerKey prefix_out;
+    const std::vector<BackendSelector> prefix_selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+    };
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), keys, prefix_out, &policy_, prefix_selectors, {"linear_1"}));
+    ASSERT_EQ(3u, prefix_out.size());
+    ASSERT_EQ(1u, prefix_out[0].size());
+    EXPECT_TRUE(prefix_out[1].empty());
+    EXPECT_TRUE(prefix_out[2].empty());
+
+    LocationsPerKey coverage_out;
+    const std::vector<BackendSelector> coverage_selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
+    };
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), keys, coverage_out, &policy_, coverage_selectors, {"linear_1"}));
+    ASSERT_EQ(3u, coverage_out.size());
+    ASSERT_EQ(1u, coverage_out[0].size());
+    EXPECT_TRUE(coverage_out[1].empty());
+    ASSERT_EQ(1u, coverage_out[2].size());
 }
 
 TEST_F(BatchGetBestLocationByBackendTest, PrefixStopsAtGap) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -72,21 +72,26 @@ SubmitDelReqFunc dummy_submit_del_req = [](const std::vector<std::int64_t> &,
                                            const std::vector<std::vector<std::string>> &,
                                            bool) -> void {};
 
-class FaultyGetLocationIdsBackend : public MetaLocalBackend {
+class FaultyTargetedLocationBackend : public MetaLocalBackend {
 public:
     void SetFailedKey(KeyType key) { failed_key_ = key; }
 
-    std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
-                                          const KeyTypeVec &keys,
-                                          LocationIdsPerKey &out_location_ids) noexcept override {
-        auto results = MetaLocalBackend::GetLocationIds(request_context, keys, out_location_ids);
+    std::vector<std::vector<ErrorCode>>
+    GetLocationsWithKeyStatus(RequestContext *request_context,
+                              const KeyTypeVec &keys,
+                              const LocationIdsPerKey &location_ids,
+                              LocationsPerKey &out_locations,
+                              std::vector<ErrorCode> &out_key_error_codes) noexcept override {
+        auto results = MetaLocalBackend::GetLocationsWithKeyStatus(
+            request_context, keys, location_ids, out_locations, out_key_error_codes);
         if (!failed_key_.has_value()) {
             return results;
         }
         for (size_t i = 0; i < keys.size(); ++i) {
             if (keys[i] == failed_key_.value()) {
-                results[i] = EC_ERROR;
-                out_location_ids[i].clear();
+                out_key_error_codes[i] = EC_ERROR;
+                results[i].assign(location_ids[i].size(), EC_ERROR);
+                out_locations[i].assign(location_ids[i].size(), CacheLocationConstPtr{});
             }
         }
         return results;
@@ -230,9 +235,9 @@ public:
         return indexer;
     }
 
-    FaultyGetLocationIdsBackend *ReplaceWithFaultyBackend() {
+    FaultyTargetedLocationBackend *ReplaceWithFaultyBackend() {
         auto backend_config = ConstructMetaStorageBackendConfig();
-        auto faulty_backend = std::make_unique<FaultyGetLocationIdsBackend>();
+        auto faulty_backend = std::make_unique<FaultyTargetedLocationBackend>();
         EXPECT_EQ(EC_OK, faulty_backend->Init("test", backend_config));
         EXPECT_EQ(EC_OK, faulty_backend->Open());
         auto backend_raw = faulty_backend.get();
@@ -474,6 +479,70 @@ TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsAppendsAndOverwrites) {
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["linear_0"]);
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["linear_1"]);
     EXPECT_EQ("event_report://127.0.0.1:8080/mem", spec_uris["full_3"]);
+}
+
+TEST_F(MetaSearcherTest, TestBatchMergeFusedRmwTracksNewKeysAndCapacity) {
+    meta_indexer_->max_key_count_ = 1;
+    const KeyType existing_key = 10022;
+    const KeyType rejected_key = 10023;
+    const std::string location_a = "kvs#event_report_l2#mem#capacity-a:8080";
+    const std::string location_b = "kvs#event_report_l2#disk#capacity-a:8080";
+    auto make_task = [](const std::string &location_id, const std::string &name, const std::string &uri) {
+        return MetaSearcher::MergeLocationSpecsTask{location_id,
+                                                    DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+                                                    CacheLocationStatus::CLS_SERVING,
+                                                    {LocationSpec(name, uri)}};
+    };
+
+    std::vector<ErrorCode> per_key_ec;
+    auto task_a = make_task(location_a, "tp0", "event_report://capacity-a:8080/mem?size=3");
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {existing_key}, {{task_a}}, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
+    ASSERT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    // A new target location under an existing key must not consume another
+    // key-count slot, even though the targeted read returns EC_NOENT for that
+    // location.
+    auto task_b = make_task(location_b, "tp1", "event_report://capacity-a:8080/disk?size=5");
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {existing_key}, {{task_b}}, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
+    EXPECT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    // Updating an existing target also remains admissible at capacity.
+    task_a.specs = {LocationSpec("tp0", "event_report://capacity-a:8080/mem?size=7")};
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {existing_key}, {{task_a}}, per_key_ec));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
+    EXPECT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    EXPECT_NE(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {rejected_key}, {{task_a}}, per_key_ec));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_NOSPC}), per_key_ec);
+    EXPECT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    // A capacity failure for a new key must not reject an existing-key
+    // update that happens to share the same internal upsert batch. The old
+    // two-phase path admitted the existing update in its merge phase.
+    task_a.specs = {LocationSpec("tp0", "event_report://capacity-a:8080/mem?size=9")};
+    const auto rejected_task = make_task(location_a, "tp0", "event_report://capacity-rejected:8080/mem?size=4");
+    EXPECT_EQ(EC_PARTIAL_OK,
+              meta_searcher_->BatchMergeLocationSpecs(
+                  request_context_.get(), {existing_key, rejected_key}, {{task_a}, {rejected_task}}, per_key_ec));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOSPC}), per_key_ec);
+    EXPECT_EQ(1u, meta_indexer_->GetKeyCount());
+
+    std::vector<CacheLocationMap> locations;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchGetLocation(request_context_.get(), {existing_key, rejected_key}, mask, locations));
+    ASSERT_EQ(2u, locations.size());
+    EXPECT_EQ(2u, locations[0].size());
+    ASSERT_TRUE(locations[0].at(location_a));
+    EXPECT_NE(std::string::npos, locations[0].at(location_a)->location_specs()[0].uri().find("size=9"));
+    EXPECT_TRUE(locations[1].empty());
+    EXPECT_EQ(14u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
 }
 
 TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsNormalizesLegacyDuplicateNamesInPlace) {
@@ -1497,15 +1566,15 @@ TEST_F(MetaSearcherTest, TestBatchMutationWriteLeaseIsAcquiredOncePerRmwPhase) {
         return std::make_pair(EC_OK, std::static_pointer_cast<void>(std::make_shared<size_t>(acquire_count)));
     };
 
-    // Every key already has this location, so BatchMerge exercises both its
-    // block lookup and targeted location RMW phases with one lease per phase.
+    // Every key already has this location. The fused targeted RMW holds one
+    // lease from the post-read fence check through the single upsert phase.
     for (auto &tasks : merge_tasks) {
         tasks[0].specs = {LocationSpec("tp1", "event_report://lease-host:8080/mem?size=2")};
     }
     ASSERT_EQ(EC_OK,
               meta_searcher_->BatchMergeLocationSpecs(
                   request_context_.get(), keys, merge_tasks, per_key_ec, acquire_write_lease));
-    EXPECT_EQ(2u, acquire_count);
+    EXPECT_EQ(1u, acquire_count);
     EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), per_key_ec);
 
     acquire_count = 0;
@@ -1607,7 +1676,7 @@ TEST_F(MetaSearcherTest, TestBatchMutationWriteLeaseFailurePreventsAllWrites) {
     }
 }
 
-TEST_F(MetaSearcherTest, TestBatchMergeReacquiresWriteLeaseBetweenRmwPhases) {
+TEST_F(MetaSearcherTest, TestBatchMergeDoesNotReacquireLeaseInsideFusedRmw) {
     const MetaSearcher::KeyVector keys = {10086, 10087};
     const std::string location_id = "kvs#event_report_l2#mem#lease-race:8080";
     std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks;
@@ -1626,18 +1695,18 @@ TEST_F(MetaSearcherTest, TestBatchMergeReacquiresWriteLeaseBetweenRmwPhases) {
         per_key_tasks[0].specs = {LocationSpec("tp1", "event_report://lease-race:8080/mem?phase=stale")};
     }
     size_t acquire_count = 0;
-    MetaSearcher::AcquireMetadataWriteLeaseFunc fail_second_phase = [&] {
+    MetaSearcher::AcquireMetadataWriteLeaseFunc fail_if_reacquired = [&] {
         ++acquire_count;
         if (acquire_count == 1) {
             return std::make_pair(EC_OK, std::static_pointer_cast<void>(std::make_shared<size_t>(acquire_count)));
         }
         return std::make_pair(EC_NODE_NOT_REGISTERED, MetaSearcher::MetadataWriteLease{});
     };
-    EXPECT_NE(
+    EXPECT_EQ(
         EC_OK,
-        meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec, fail_second_phase));
-    EXPECT_EQ(2u, acquire_count);
-    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_NODE_NOT_REGISTERED), per_key_ec);
+        meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec, fail_if_reacquired));
+    EXPECT_EQ(1u, acquire_count);
+    EXPECT_EQ(std::vector<ErrorCode>(keys.size(), EC_OK), per_key_ec);
 
     std::vector<CacheLocationMap> location_maps;
     BlockMask mask;
@@ -1646,9 +1715,10 @@ TEST_F(MetaSearcherTest, TestBatchMergeReacquiresWriteLeaseBetweenRmwPhases) {
     for (const auto &locations : location_maps) {
         ASSERT_EQ(1u, locations.size());
         const auto &specs = locations.at(location_id)->location_specs();
-        ASSERT_EQ(1u, specs.size());
+        ASSERT_EQ(2u, specs.size());
         EXPECT_EQ("tp0", specs[0].name());
-        EXPECT_EQ(std::string::npos, specs[0].uri().find("phase=stale"));
+        EXPECT_EQ("tp1", specs[1].name());
+        EXPECT_NE(std::string::npos, specs[1].uri().find("phase=stale"));
     }
 }
 

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <filesystem>
 #include <future>
 #include <map>
@@ -496,6 +497,47 @@ TEST_F(MetaSearcherTest, TestPrefixMatchByHostIgnoresNonServingLocations) {
     ASSERT_EQ(1u, matches.size());
     EXPECT_EQ("serving:8080", matches[0].host_ip_port);
     EXPECT_EQ(1, matches[0].prefix_match_blocks);
+}
+
+TEST_F(MetaSearcherTest, TestPrefixMatchByHostSupportsMoreThanOnePresenceWord) {
+    const MetaSearcher::KeyVector keys = {10020, 10021, 10022};
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> tasks(keys.size());
+    auto host_name = [](std::size_t index) {
+        return std::string("host-") + (index < 10 ? "0" : "") + std::to_string(index) + ":8080";
+    };
+    for (std::size_t host_index = 0; host_index < 70; ++host_index) {
+        const std::string host = host_name(host_index);
+        const MetaSearcher::MergeLocationSpecsTask task{
+            "kvs#event_report_l2#mem#" + host,
+            DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+            CacheLocationStatus::CLS_SERVING,
+            {LocationSpec("tp0", "event_report://" + host + "/mem")},
+        };
+        tasks[0].push_back(task);
+        if (host_index != 64) {
+            tasks[1].push_back(task);
+        }
+        if (host_index != 63 && host_index != 64) {
+            tasks[2].push_back(task);
+        }
+    }
+
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), keys, tasks, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), per_key_ec);
+
+    std::vector<MetaSearcher::HostCacheMatch> matches;
+    ASSERT_EQ(EC_OK, meta_searcher_->PrefixMatchByHost(request_context_.get(), keys, false, {"mem"}, matches));
+    ASSERT_EQ(70u, matches.size());
+    auto prefix_for = [&matches](const std::string &host) {
+        const auto it = std::find_if(
+            matches.begin(), matches.end(), [&host](const auto &match) { return match.host_ip_port == host; });
+        return it == matches.end() ? int64_t{-1} : it->prefix_match_blocks;
+    };
+    EXPECT_EQ(3, prefix_for(host_name(0)));
+    EXPECT_EQ(2, prefix_for(host_name(63)));
+    EXPECT_EQ(1, prefix_for(host_name(64)));
+    EXPECT_EQ(3, prefix_for(host_name(69)));
 }
 
 TEST_F(MetaSearcherTest, TestBatchMergeLocationSpecsPreservesUntouchedSpecsAcrossGenerationChange) {

--- a/kv_cache_manager/meta/BUILD
+++ b/kv_cache_manager/meta/BUILD
@@ -8,6 +8,15 @@ cc_library(
 )
 
 cc_library(
+    name = "query_executor",
+    srcs = ["query_executor.cc"],
+    hdrs = ["query_executor.h"],
+    deps = [
+        "//kv_cache_manager/common:logger",
+    ],
+)
+
+cc_library(
     name = "meta_indexer_manager",
     srcs = [
         "meta_indexer_manager.cc",
@@ -17,6 +26,7 @@ cc_library(
     ],
     deps = [
         ":meta_indexer",
+        ":query_executor",
         "//kv_cache_manager/metrics:revisit_interval_histogram",
     ],
 )
@@ -53,6 +63,7 @@ cc_library(
         ":common",
         ":meta_search_cache",
         ":meta_storage_backend_manager",
+        ":query_executor",
         ":storage_usage_data",
         ":types",
         ":utils",
@@ -274,4 +285,3 @@ cc_library(
         "//kv_cache_manager/config",
     ],
 )
-

--- a/kv_cache_manager/meta/cache_location.h
+++ b/kv_cache_manager/meta/cache_location.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -18,6 +19,11 @@ public:
 
     LocationSpec(const std::string &name, const std::string &uri) : name_(name), uri_(uri) {}
 
+    LocationSpec(const LocationSpec &) = default;
+    LocationSpec &operator=(const LocationSpec &) = default;
+    LocationSpec(LocationSpec &&) noexcept = default;
+    LocationSpec &operator=(LocationSpec &&) noexcept = default;
+
     ~LocationSpec() override;
 
     void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override {
@@ -32,7 +38,9 @@ public:
     }
 
     void set_name(const std::string &name) { name_ = name; }
+    void set_name(std::string &&name) noexcept { name_ = std::move(name); }
     void set_uri(const std::string &uri) { uri_ = uri; }
+    void set_uri(std::string &&uri) noexcept { uri_ = std::move(uri); }
 
     inline const std::string &name() const { return name_; }
     inline const std::string &uri() const { return uri_; }
@@ -75,6 +83,10 @@ PutBlockMask(rapidjson::Writer<rapidjson::StringBuffer> &writer, const std::stri
 class CacheLocation : public Jsonizable {
 public:
     CacheLocation();
+    CacheLocation(const CacheLocation &) = default;
+    CacheLocation &operator=(const CacheLocation &) = default;
+    CacheLocation(CacheLocation &&) noexcept = default;
+    CacheLocation &operator=(CacheLocation &&) noexcept = default;
     CacheLocation(DataStorageType type, size_t spec_size, const std::vector<LocationSpec> &location_specs);
     CacheLocation(const std::string &id,
                   CacheLocationStatus status,
@@ -125,9 +137,10 @@ public:
     void set_spec_size(size_t spec_size) { spec_size_ = spec_size; }
     void set_create_time(int64_t create_time) { create_time_ = create_time; }
     void push_location_spec(LocationSpec &&location_spec) { location_specs_.push_back(std::move(location_spec)); }
-    void set_location_specs(std::vector<LocationSpec> &&location_specs) { location_specs_ = location_specs; }
+    void set_location_specs(std::vector<LocationSpec> &&location_specs) { location_specs_ = std::move(location_specs); }
 
     [[nodiscard]] const std::vector<LocationSpec> &location_specs() const { return location_specs_; }
+    [[nodiscard]] std::vector<LocationSpec> &mutable_location_specs() { return location_specs_; }
     [[nodiscard]] const std::string &id() const { return id_; }
     [[nodiscard]] CacheLocationStatus status() const { return status_; }
     [[nodiscard]] DataStorageType type() const { return type_; }

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -510,7 +510,13 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
 
     LocationResult location_result(location_ids);
     Result rmw_result(keys.size());
-    int32_t error_count = 0;
+    // The aggregate result reports whether the RMW machinery completed for
+    // each key. Per-location semantic outcomes (for example, a CAS mismatch
+    // or a rejected task in an otherwise valid batch) remain in
+    // per_location_error_codes and do not fail the whole operation. Track
+    // structural/read/modifier/write failures separately so malformed backend
+    // responses still fail closed without changing that established contract.
+    std::vector<bool> key_level_failures(keys.size(), false);
     RmwStats stats;
     for (auto &batch : batches) {
         ScopedBatchLock lock(*this, batch.batch_shard_indexs, &stats.lock_wait_time_us);
@@ -530,6 +536,20 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         stats.index_deserialize_time_us += v;
         stats.has_index_deserialize = true;
 
+        if (get_ecs_per_key.size() != batch_keys.size() || batch_locations_per_key.size() != batch_keys.size()) {
+            PREFIX_INDEXER_LOG(ERROR,
+                               "ReadModifyWriteLocation result size mismatch, keys[%lu], ecs[%lu], locations[%lu]",
+                               batch_keys.size(),
+                               get_ecs_per_key.size(),
+                               batch_locations_per_key.size());
+            for (const int32_t global_idx : batch.batch_indexs) {
+                location_result.per_location_error_codes[global_idx].assign(location_ids[global_idx].size(),
+                                                                            EC_MISMATCH);
+                key_level_failures[global_idx] = true;
+            }
+            continue;
+        }
+
         // 2. Per-key modifier dispatch -> bucket each key into the upsert sub-batch or the delete sub-batch.
         BatchMetaData upsert_batch;
         BatchMetaData delete_batch;
@@ -539,15 +559,58 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
             const int32_t global_idx = batch.batch_indexs[i];
             const KeyType key = batch_keys[i];
 
-            const std::vector<ErrorCode> &get_ecs = get_ecs_per_key[i];
+            std::vector<ErrorCode> &get_ecs = get_ecs_per_key[i];
             const LocationIdVector &loc_ids = batch.batch_location_ids[i];
             CacheLocationVector &loc_values = batch_locations_per_key[i];
+            if (get_ecs.size() != loc_ids.size() || loc_values.size() != loc_ids.size()) {
+                PREFIX_INDEXER_LOG(ERROR,
+                                   "ReadModifyWriteLocation per-key result size mismatch, key[%ld], ids[%lu], "
+                                   "ecs[%lu], locations[%lu]",
+                                   key,
+                                   loc_ids.size(),
+                                   get_ecs.size(),
+                                   loc_values.size());
+                location_result.per_location_error_codes[global_idx].assign(loc_ids.size(), EC_MISMATCH);
+                key_level_failures[global_idx] = true;
+                continue;
+            }
+            // EC_OK promises a usable value for the requested id. Treat a
+            // null or mis-keyed value as corruption and never let a modifier
+            // turn it into a write based on fabricated state.
+            for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
+                if (get_ecs[loc_index] == EC_OK &&
+                    (!loc_values[loc_index] || loc_values[loc_index]->id() != loc_ids[loc_index])) {
+                    PREFIX_INDEXER_LOG(ERROR,
+                                       "ReadModifyWriteLocation invalid EC_OK value, key[%ld], requested id[%s]",
+                                       key,
+                                       loc_ids[loc_index].c_str());
+                    get_ecs[loc_index] = EC_MISMATCH;
+                    loc_values[loc_index].reset();
+                }
+                if (get_ecs[loc_index] != EC_OK && get_ecs[loc_index] != EC_NOENT) {
+                    key_level_failures[global_idx] = true;
+                }
+            }
             PropertyMap upsert_property_map;
             auto [action, modifier_ecs] =
                 modifier(get_ecs, loc_ids, static_cast<size_t>(global_idx), loc_values, upsert_property_map);
             if (modifier_ecs.size() != loc_ids.size()) {
                 modifier_ecs.assign(loc_ids.size(), EC_ERROR);
                 action = MA_FAIL;
+                key_level_failures[global_idx] = true;
+            }
+            // A read error other than NOENT is not a valid basis for an RMW.
+            // Force it back into the corresponding result slot even if a
+            // buggy modifier accidentally returned EC_OK.
+            for (size_t loc_index = 0; loc_index < loc_ids.size(); ++loc_index) {
+                if (get_ecs[loc_index] != EC_OK && get_ecs[loc_index] != EC_NOENT) {
+                    modifier_ecs[loc_index] = get_ecs[loc_index];
+                }
+            }
+            if (action == MA_FAIL &&
+                std::all_of(modifier_ecs.begin(), modifier_ecs.end(), [](ErrorCode ec) { return ec == EC_OK; })) {
+                modifier_ecs.assign(loc_ids.size(), EC_ERROR);
+                key_level_failures[global_idx] = true;
             }
             if (action == MA_OK) {
                 CacheLocationMap upsert_loc_map;
@@ -558,7 +621,11 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                     }
                     const LocationId &loc_id = loc_ids[loc_index];
                     const CacheLocationConstPtr &working_loc = loc_values[loc_index];
-                    assert(working_loc && loc_id == working_loc->id());
+                    if (!working_loc || loc_id != working_loc->id()) {
+                        location_result.per_location_error_codes[global_idx][loc_index] = EC_MISMATCH;
+                        key_level_failures[global_idx] = true;
+                        continue;
+                    }
                     upsert_loc_map.emplace(loc_id, working_loc);
                     upsert_location_indexs[global_idx].emplace_back(loc_index);
                 }
@@ -586,7 +653,10 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
             } else {
                 // MA_FAIL / MA_SKIP / unknown: surface modifier_ec if any.
                 if (action == MA_FAIL) {
-                    ++error_count;
+                    key_level_failures[global_idx] = true;
+                } else if (action != MA_SKIP) {
+                    modifier_ecs.assign(loc_ids.size(), EC_ERROR);
+                    key_level_failures[global_idx] = true;
                 }
                 location_result.per_location_error_codes[global_idx] = std::move(modifier_ecs);
             }
@@ -596,7 +666,11 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         static std::vector<int32_t> empty_put_global_indexs;
         const auto [upsert_errs, put_success_count] = ExecuteRmwUpsert(
             trace_id, ephemeral_request_context.get(), upsert_batch, empty_put_global_indexs, keys, stats, rmw_result);
+        (void)upsert_errs;
         for (const auto &global_index : upsert_batch.batch_indexs) {
+            if (rmw_result.error_codes[global_index] != EC_OK) {
+                key_level_failures[global_index] = true;
+            }
             for (const auto &location_index : upsert_location_indexs[global_index]) {
                 location_result.per_location_error_codes[global_index][location_index] =
                     rmw_result.error_codes[global_index];
@@ -604,24 +678,29 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         }
         const auto [delete_errs, delete_success_count] =
             ExecuteRmwDelete(trace_id, ephemeral_request_context.get(), delete_batch, keys, stats, rmw_result);
+        (void)delete_errs;
         for (const auto &global_index : delete_batch.batch_indexs) {
+            if (rmw_result.error_codes[global_index] != EC_OK) {
+                key_level_failures[global_index] = true;
+            }
             for (const auto &location_index : delete_location_indexs[global_index]) {
                 location_result.per_location_error_codes[global_index][location_index] =
                     rmw_result.error_codes[global_index];
             }
         }
-        error_count += upsert_errs + delete_errs;
         AdjustKeyCountMeta(put_success_count - (adjust_reclaimed_key_count ? delete_success_count : 0));
     }
 
     EmitRmwMetrics(request_context->metrics_collector(), stats, keys.size());
-    if (error_count == keys.size()) {
+    const size_t failed_key_count =
+        static_cast<size_t>(std::count(key_level_failures.begin(), key_level_failures.end(), true));
+    if (failed_key_count == keys.size()) {
         location_result.ec = EC_ERROR;
-        PREFIX_INDEXER_LOG(DEBUG, "all locations rmw failed, error count[%d]", error_count);
-    } else if (error_count > 0) {
+        PREFIX_INDEXER_LOG(DEBUG, "all locations rmw failed, error count[%lu]", failed_key_count);
+    } else if (failed_key_count > 0) {
         location_result.ec = EC_PARTIAL_OK;
         PREFIX_INDEXER_LOG(
-            DEBUG, "partial locations rmw failed, keys count[%lu] failed count[%d]", keys.size(), error_count);
+            DEBUG, "partial locations rmw failed, keys count[%lu] failed count[%lu]", keys.size(), failed_key_count);
     }
     return location_result;
 }
@@ -675,6 +754,15 @@ MetaIndexer::Result MetaIndexer::GetLocations(RequestContext *request_context,
 
     int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
     auto error_codes = backend_manager_->GetLocations(request_context, keys, out_location_maps);
+    if (error_codes.size() != keys.size() || out_location_maps.size() != keys.size()) {
+        PREFIX_INDEXER_LOG(ERROR,
+                           "GetLocations result size mismatch, keys[%lu], ecs[%lu], locations[%lu]",
+                           keys.size(),
+                           error_codes.size(),
+                           out_location_maps.size());
+        error_codes.assign(keys.size(), EC_MISMATCH);
+        out_location_maps.assign(keys.size(), CacheLocationMap{});
+    }
     KVCM_METRICS_COLLECTOR_SET_METRICS(
         service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
 
@@ -739,11 +827,11 @@ MetaIndexer::Result MetaIndexer::GetLocationValues(RequestContext *request_conte
                        error_codes.size(),
                        out_locations.size(),
                        keys.size());
-        std::vector<ErrorCode> normalized_errors(keys.size(), EC_ERROR);
-        const std::size_t error_count = std::min(keys.size(), error_codes.size());
-        std::copy_n(error_codes.begin(), error_count, normalized_errors.begin());
-        error_codes = std::move(normalized_errors);
-        out_locations.resize(keys.size());
+        // Errors and values are one positional response. If either outer
+        // shape is malformed, no apparent in-range EC_OK/value pair can be
+        // trusted to refer to the requested key.
+        error_codes.assign(keys.size(), EC_MISMATCH);
+        out_locations.assign(keys.size(), CacheLocationVector{});
     }
     KVCM_METRICS_COLLECTOR_SET_METRICS(
         service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
@@ -758,7 +846,14 @@ MetaIndexer::LocationResult MetaIndexer::GetLocations(RequestContext *request_co
                                                       const KeyVector &keys,
                                                       const LocationIdsPerKey &location_ids,
                                                       LocationsPerKey &out_locations) noexcept {
-    assert(keys.size() == location_ids.size());
+    if (keys.size() != location_ids.size()) {
+        out_locations.clear();
+        KVCM_LOG_ERROR("instance[%s] | GetLocations keys size[%lu] != location_ids size[%lu]",
+                       instance_id_.c_str(),
+                       keys.size(),
+                       location_ids.size());
+        return LocationResult(EC_BADARGS);
+    }
     if (keys.empty()) {
         out_locations.clear();
         return LocationResult(EC_OK);
@@ -773,7 +868,46 @@ MetaIndexer::LocationResult MetaIndexer::GetLocations(RequestContext *request_co
         service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
 
     LocationResult result(location_ids);
-    result.per_location_error_codes = std::move(per_location_ecs);
+    if (per_location_ecs.size() != keys.size() || out_locations.size() != keys.size()) {
+        PREFIX_INDEXER_LOG(ERROR,
+                           "GetLocations result size mismatch, keys[%lu], ecs[%lu], locations[%lu]",
+                           keys.size(),
+                           per_location_ecs.size(),
+                           out_locations.size());
+        out_locations.assign(keys.size(), CacheLocationVector{});
+        for (size_t i = 0; i < keys.size(); ++i) {
+            out_locations[i].resize(location_ids[i].size());
+            result.per_location_error_codes[i].assign(location_ids[i].size(), EC_MISMATCH);
+        }
+    } else {
+        for (size_t i = 0; i < keys.size(); ++i) {
+            const size_t expected = location_ids[i].size();
+            if (per_location_ecs[i].size() != expected || out_locations[i].size() != expected) {
+                PREFIX_INDEXER_LOG(ERROR,
+                                   "GetLocations per-key result size mismatch, key[%ld], ids[%lu], ecs[%lu], "
+                                   "locations[%lu]",
+                                   keys[i],
+                                   expected,
+                                   per_location_ecs[i].size(),
+                                   out_locations[i].size());
+                out_locations[i].assign(expected, CacheLocationConstPtr{});
+                result.per_location_error_codes[i].assign(expected, EC_MISMATCH);
+                continue;
+            }
+            result.per_location_error_codes[i] = std::move(per_location_ecs[i]);
+            for (size_t j = 0; j < expected; ++j) {
+                if (result.per_location_error_codes[i][j] == EC_OK &&
+                    (!out_locations[i][j] || out_locations[i][j]->id() != location_ids[i][j])) {
+                    PREFIX_INDEXER_LOG(ERROR,
+                                       "GetLocations invalid EC_OK value, key[%ld], requested id[%s]",
+                                       keys[i],
+                                       location_ids[i][j].c_str());
+                    out_locations[i][j].reset();
+                    result.per_location_error_codes[i][j] = EC_MISMATCH;
+                }
+            }
+        }
+    }
 
     int64_t total_slots = 0;
     int64_t error_slots = 0;

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -230,7 +230,8 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwUpsert(const std::string &tra
                                                           const std::vector<int32_t> &put_global_indexs,
                                                           const KeyVector &all_keys,
                                                           RmwStats &stats,
-                                                          Result &result) noexcept {
+                                                          Result &result,
+                                                          bool preserve_existing_updates_when_full) noexcept {
     if (upsert_batch.batch_keys.empty()) {
         return {0, 0};
     }
@@ -239,17 +240,64 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwUpsert(const std::string &tra
     stats.update_key_count += static_cast<int64_t>(upsert_batch.batch_keys.size() - put_global_indexs.size());
 
     std::vector<ErrorCode> upsert_ecs;
-    if (put_global_indexs.size() + GetKeyCount() > max_key_count_) {
+    BatchMetaData existing_update_batch;
+    std::vector<size_t> existing_update_positions;
+    BatchMetaData *backend_batch = &upsert_batch;
+    const bool capacity_exceeded = put_global_indexs.size() + GetKeyCount() > max_key_count_;
+    if (capacity_exceeded) {
         PREFIX_INDEXER_LOG(ERROR,
                            "ReadModifyWrite put keys count[%lu] + current key count[%lu] > max key count[%lu]",
                            put_global_indexs.size(),
                            GetKeyCount(),
                            max_key_count_);
-        upsert_ecs.assign(upsert_batch.batch_keys.size(), EC_NOSPC);
-    } else {
+        if (!preserve_existing_updates_when_full) {
+            upsert_ecs.assign(upsert_batch.batch_keys.size(), EC_NOSPC);
+        } else {
+            // Fused targeted RMW can mix brand-new keys and updates to keys
+            // that already count toward capacity. Reject only the former;
+            // the old two-phase merge still admitted the latter at capacity.
+            std::vector<bool> is_new_key(all_keys.size(), false);
+            for (const int32_t global_index : put_global_indexs) {
+                if (global_index >= 0 && static_cast<size_t>(global_index) < is_new_key.size()) {
+                    is_new_key[global_index] = true;
+                }
+            }
+            upsert_ecs.assign(upsert_batch.batch_keys.size(), EC_NOSPC);
+            existing_update_positions.reserve(upsert_batch.batch_keys.size());
+            for (size_t i = 0; i < upsert_batch.batch_keys.size(); ++i) {
+                const int32_t global_index = upsert_batch.batch_indexs[i];
+                if (global_index < 0 || static_cast<size_t>(global_index) >= is_new_key.size() ||
+                    is_new_key[global_index]) {
+                    continue;
+                }
+                existing_update_positions.push_back(i);
+                existing_update_batch.batch_keys.push_back(upsert_batch.batch_keys[i]);
+                existing_update_batch.batch_indexs.push_back(global_index);
+                existing_update_batch.batch_locations.push_back(upsert_batch.batch_locations[i]);
+                existing_update_batch.batch_properties.push_back(upsert_batch.batch_properties[i]);
+            }
+            backend_batch = &existing_update_batch;
+        }
+    }
+    if (upsert_ecs.empty() || !existing_update_positions.empty()) {
         const int64_t begin = TimestampUtil::GetCurrentTimeUs();
-        upsert_ecs = backend_manager_->Upsert(request_context, upsert_batch);
+        std::vector<ErrorCode> backend_ecs = backend_manager_->Upsert(request_context, *backend_batch);
         stats.upsert_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin;
+        if (existing_update_positions.empty()) {
+            upsert_ecs = std::move(backend_ecs);
+        } else if (backend_ecs.size() != existing_update_positions.size()) {
+            PREFIX_INDEXER_LOG(ERROR,
+                               "ReadModifyWrite existing update results[%lu] mismatch keys[%lu]",
+                               backend_ecs.size(),
+                               existing_update_positions.size());
+            for (const size_t original_position : existing_update_positions) {
+                upsert_ecs[original_position] = EC_MISMATCH;
+            }
+        } else {
+            for (size_t i = 0; i < backend_ecs.size(); ++i) {
+                upsert_ecs[existing_update_positions[i]] = backend_ecs[i];
+            }
+        }
         int64_t v = 0;
         auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
         KVCM_METRICS_COLLECTOR_GET_METRICS(service_metrics_collector, meta_searcher, index_serialize_time_us, v);
@@ -482,6 +530,23 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                                                                  const LocationIdsPerKey &location_ids,
                                                                  const LocationModifierFunc &modifier,
                                                                  bool adjust_reclaimed_key_count) noexcept {
+    return ReadModifyWriteLocationImpl(
+        request_context, keys, location_ids, modifier, adjust_reclaimed_key_count, false);
+}
+
+MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteTargetLocations(RequestContext *request_context,
+                                                                        const KeyVector &keys,
+                                                                        const LocationIdsPerKey &location_ids,
+                                                                        const LocationModifierFunc &modifier) noexcept {
+    return ReadModifyWriteLocationImpl(request_context, keys, location_ids, modifier, false, true);
+}
+
+MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestContext *request_context,
+                                                                     const KeyVector &keys,
+                                                                     const LocationIdsPerKey &location_ids,
+                                                                     const LocationModifierFunc &modifier,
+                                                                     bool adjust_reclaimed_key_count,
+                                                                     bool track_created_key_count) noexcept {
     const auto &trace_id = request_context->trace_id();
     if (keys.empty()) {
         return LocationResult(EC_OK);
@@ -500,8 +565,9 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
     std::shared_ptr<MetricsCollector> ephemeral_metrics_collector =
         std::make_shared<ServiceMetricsCollector>(ephemeral_metrics_registry);
     ephemeral_metrics_collector->Init();
-    auto ephemeral_request_context =
-        std::make_shared<RequestContext>("read_modify_write_location", ephemeral_metrics_collector);
+    auto ephemeral_request_context = std::make_shared<RequestContext>(
+        track_created_key_count ? "read_modify_write_target_locations" : "read_modify_write_location",
+        ephemeral_metrics_collector);
 
     static CacheLocationMapVector empty_locations;
     static PropertyMapVector empty_properties;
@@ -524,9 +590,19 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         // 1. One batched read for every (key, location_id) return deserialised CacheLocation
         const auto &batch_keys = batch.batch_keys;
         LocationsPerKey batch_locations_per_key;
+        std::vector<ErrorCode> batch_key_get_ecs;
         const int64_t begin_get = TimestampUtil::GetCurrentTimeUs();
-        std::vector<std::vector<ErrorCode>> get_ecs_per_key = backend_manager_->GetLocations(
-            ephemeral_request_context.get(), batch_keys, batch.batch_location_ids, batch_locations_per_key);
+        std::vector<std::vector<ErrorCode>> get_ecs_per_key;
+        if (track_created_key_count) {
+            get_ecs_per_key = backend_manager_->GetLocationsWithKeyStatus(ephemeral_request_context.get(),
+                                                                          batch_keys,
+                                                                          batch.batch_location_ids,
+                                                                          batch_locations_per_key,
+                                                                          batch_key_get_ecs);
+        } else {
+            get_ecs_per_key = backend_manager_->GetLocations(
+                ephemeral_request_context.get(), batch_keys, batch.batch_location_ids, batch_locations_per_key);
+        }
         stats.get_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin_get;
         int64_t v = 0;
         auto *ephemeral_service_metrics_collector =
@@ -536,12 +612,15 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         stats.index_deserialize_time_us += v;
         stats.has_index_deserialize = true;
 
-        if (get_ecs_per_key.size() != batch_keys.size() || batch_locations_per_key.size() != batch_keys.size()) {
+        if (get_ecs_per_key.size() != batch_keys.size() || batch_locations_per_key.size() != batch_keys.size() ||
+            (track_created_key_count && batch_key_get_ecs.size() != batch_keys.size())) {
             PREFIX_INDEXER_LOG(ERROR,
-                               "ReadModifyWriteLocation result size mismatch, keys[%lu], ecs[%lu], locations[%lu]",
+                               "ReadModifyWriteLocation result size mismatch, keys[%lu], ecs[%lu], locations[%lu], "
+                               "key_ecs[%lu]",
                                batch_keys.size(),
                                get_ecs_per_key.size(),
-                               batch_locations_per_key.size());
+                               batch_locations_per_key.size(),
+                               batch_key_get_ecs.size());
             for (const int32_t global_idx : batch.batch_indexs) {
                 location_result.per_location_error_codes[global_idx].assign(location_ids[global_idx].size(),
                                                                             EC_MISMATCH);
@@ -553,8 +632,7 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         // 2. Per-key modifier dispatch -> bucket each key into the upsert sub-batch or the delete sub-batch.
         BatchMetaData upsert_batch;
         BatchMetaData delete_batch;
-        std::vector<std::vector<int32_t>> upsert_location_indexs(keys.size());
-        std::vector<std::vector<int32_t>> delete_location_indexs(keys.size());
+        std::vector<int32_t> put_global_indexs;
         for (size_t i = 0; i < batch_keys.size(); ++i) {
             const int32_t global_idx = batch.batch_indexs[i];
             const KeyType key = batch_keys[i];
@@ -574,6 +652,12 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                 key_level_failures[global_idx] = true;
                 continue;
             }
+            const ErrorCode key_get_ec = track_created_key_count ? batch_key_get_ecs[i] : EC_OK;
+            if (key_get_ec != EC_OK && key_get_ec != EC_NOENT) {
+                location_result.per_location_error_codes[global_idx].assign(loc_ids.size(), key_get_ec);
+                key_level_failures[global_idx] = true;
+                continue;
+            }
             // EC_OK promises a usable value for the requested id. Treat a
             // null or mis-keyed value as corruption and never let a modifier
             // turn it into a write based on fabricated state.
@@ -590,6 +674,16 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                 if (get_ecs[loc_index] != EC_OK && get_ecs[loc_index] != EC_NOENT) {
                     key_level_failures[global_idx] = true;
                 }
+            }
+            if (track_created_key_count && key_get_ec == EC_NOENT &&
+                std::any_of(get_ecs.begin(), get_ecs.end(), [](ErrorCode ec) { return ec == EC_OK; })) {
+                PREFIX_INDEXER_LOG(ERROR,
+                                   "ReadModifyWriteTargetLocations key[%ld] reported missing with an existing "
+                                   "target location",
+                                   key);
+                location_result.per_location_error_codes[global_idx].assign(loc_ids.size(), EC_MISMATCH);
+                key_level_failures[global_idx] = true;
+                continue;
             }
             PropertyMap upsert_property_map;
             auto [action, modifier_ecs] =
@@ -627,13 +721,15 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                         continue;
                     }
                     upsert_loc_map.emplace(loc_id, working_loc);
-                    upsert_location_indexs[global_idx].emplace_back(loc_index);
                 }
                 if (!upsert_loc_map.empty() || !upsert_property_map.empty()) {
                     upsert_batch.batch_keys.emplace_back(key);
                     upsert_batch.batch_indexs.emplace_back(global_idx);
                     upsert_batch.batch_locations.emplace_back(std::move(upsert_loc_map));
                     upsert_batch.batch_properties.emplace_back(std::move(upsert_property_map));
+                    if (track_created_key_count && key_get_ec == EC_NOENT) {
+                        put_global_indexs.emplace_back(global_idx);
+                    }
                 }
             } else if (action == MA_DELETE) {
                 LocationIdVector alive_ids;
@@ -643,7 +739,6 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                         continue;
                     }
                     alive_ids.emplace_back(loc_ids[loc_index]);
-                    delete_location_indexs[global_idx].emplace_back(loc_index);
                 }
                 if (!alive_ids.empty()) {
                     delete_batch.batch_keys.emplace_back(key);
@@ -663,17 +758,23 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
         }
 
         // 3. Dispatch upsert and delete sub-batches.
-        static std::vector<int32_t> empty_put_global_indexs;
-        const auto [upsert_errs, put_success_count] = ExecuteRmwUpsert(
-            trace_id, ephemeral_request_context.get(), upsert_batch, empty_put_global_indexs, keys, stats, rmw_result);
+        const auto [upsert_errs, put_success_count] = ExecuteRmwUpsert(trace_id,
+                                                                       ephemeral_request_context.get(),
+                                                                       upsert_batch,
+                                                                       put_global_indexs,
+                                                                       keys,
+                                                                       stats,
+                                                                       rmw_result,
+                                                                       track_created_key_count);
         (void)upsert_errs;
         for (const auto &global_index : upsert_batch.batch_indexs) {
             if (rmw_result.error_codes[global_index] != EC_OK) {
                 key_level_failures[global_index] = true;
             }
-            for (const auto &location_index : upsert_location_indexs[global_index]) {
-                location_result.per_location_error_codes[global_index][location_index] =
-                    rmw_result.error_codes[global_index];
+            for (auto &location_ec : location_result.per_location_error_codes[global_index]) {
+                if (location_ec == EC_OK) {
+                    location_ec = rmw_result.error_codes[global_index];
+                }
             }
         }
         const auto [delete_errs, delete_success_count] =
@@ -683,9 +784,10 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
             if (rmw_result.error_codes[global_index] != EC_OK) {
                 key_level_failures[global_index] = true;
             }
-            for (const auto &location_index : delete_location_indexs[global_index]) {
-                location_result.per_location_error_codes[global_index][location_index] =
-                    rmw_result.error_codes[global_index];
+            for (auto &location_ec : location_result.per_location_error_codes[global_index]) {
+                if (location_ec == EC_OK) {
+                    location_ec = rmw_result.error_codes[global_index];
+                }
             }
         }
         AdjustKeyCountMeta(put_success_count - (adjust_reclaimed_key_count ? delete_success_count : 0));

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -4,6 +4,7 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <set>
 #include <string>
 #include <vector>
@@ -683,6 +684,76 @@ MetaIndexer::Result MetaIndexer::GetLocations(RequestContext *request_context,
     return result;
 }
 
+MetaIndexer::Result MetaIndexer::GetLocationValues(RequestContext *request_context,
+                                                   const KeyVector &keys,
+                                                   LocationsPerKey &out_locations) noexcept {
+    if (keys.empty()) {
+        out_locations.clear();
+        return Result(EC_OK);
+    }
+    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
+    const auto &trace_id = request_context->trace_id();
+
+    const int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
+    std::vector<ErrorCode> error_codes;
+    const bool use_parallel_local_read = query_executor_ && query_executor_->worker_count() > 1 &&
+                                         keys.size() >= query_executor_->parallel_threshold() &&
+                                         backend_manager_->SupportsConcurrentLocationValueReads();
+    if (use_parallel_local_read) {
+        error_codes.assign(keys.size(), EC_ERROR);
+        out_locations.clear();
+        out_locations.resize(keys.size());
+        const bool completed = query_executor_->ParallelFor(
+            keys.size(), [this, &keys, &error_codes, &out_locations](std::size_t begin, std::size_t end) {
+                KeyVector chunk_keys(keys.begin() + begin, keys.begin() + end);
+                LocationsPerKey chunk_locations;
+                auto chunk_errors = backend_manager_->GetLocationValues(nullptr, chunk_keys, chunk_locations);
+                const std::size_t expected = end - begin;
+                if (chunk_errors.size() != expected || chunk_locations.size() != expected) {
+                    KVCM_LOG_ERROR(
+                        "parallel local location read size mismatch: errors[%zu] locations[%zu] expected[%zu]",
+                        chunk_errors.size(),
+                        chunk_locations.size(),
+                        expected);
+                    return;
+                }
+                for (std::size_t i = 0; i < expected; ++i) {
+                    error_codes[begin + i] = chunk_errors[i];
+                    out_locations[begin + i] = std::move(chunk_locations[i]);
+                }
+            });
+        if (!completed) {
+            KVCM_LOG_ERROR("trace_id[%s] instance[%s] | parallel local location read callback failed",
+                           trace_id.c_str(),
+                           instance_id_.c_str());
+        }
+    } else {
+        error_codes = backend_manager_->GetLocationValues(request_context, keys, out_locations);
+    }
+    if (error_codes.size() != keys.size() || out_locations.size() != keys.size()) {
+        KVCM_LOG_ERROR("trace_id[%s] instance[%s] | location value result size mismatch: errors[%zu] "
+                       "locations[%zu] keys[%zu]",
+                       trace_id.c_str(),
+                       instance_id_.c_str(),
+                       error_codes.size(),
+                       out_locations.size(),
+                       keys.size());
+        std::vector<ErrorCode> normalized_errors(keys.size(), EC_ERROR);
+        const std::size_t error_count = std::min(keys.size(), error_codes.size());
+        std::copy_n(error_codes.begin(), error_count, normalized_errors.begin());
+        error_codes = std::move(normalized_errors);
+        out_locations.resize(keys.size());
+    }
+    KVCM_METRICS_COLLECTOR_SET_METRICS(
+        service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
+
+    Result result(keys.size());
+    int32_t error_count = ProcessErrorCodes(trace_id, error_codes, {}, keys, kGetMetaOperation, result);
+    ProcessErrorResult(trace_id, kGetMetaOperation, error_count, keys.size(), result);
+    return result;
+}
+
 MetaIndexer::LocationResult MetaIndexer::GetLocations(RequestContext *request_context,
                                                       const KeyVector &keys,
                                                       const LocationIdsPerKey &location_ids,
@@ -728,6 +799,22 @@ MetaIndexer::LocationResult MetaIndexer::GetLocations(RequestContext *request_co
         result.ec = EC_PARTIAL_OK;
     }
     return result;
+}
+
+bool MetaIndexer::ParallelForQuery(std::size_t count, const QueryExecutor::RangeFunction &fn) const noexcept {
+    if (query_executor_) {
+        return query_executor_->ParallelFor(count, fn);
+    }
+    if (count == 0) {
+        return true;
+    }
+    try {
+        fn(0, count);
+        return true;
+    } catch (const std::exception &e) {
+        KVCM_LOG_ERROR("serial query callback threw exception: %s", e.what());
+    } catch (...) { KVCM_LOG_ERROR("serial query callback threw unknown exception"); }
+    return false;
 }
 
 MetaIndexer::Result MetaIndexer::GetProperties(RequestContext *request_context,

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -79,6 +79,14 @@ public:
                                            const LocationIdsPerKey &location_ids,
                                            const LocationModifierFunc &modifier,
                                            bool adjust_reclaimed_key_count = true) noexcept;
+    // Targeted upsert RMW that also distinguishes a brand-new key from an
+    // existing key missing the requested location. This lets ReportEvent
+    // create or merge locations in one shard-lock/read/write pass while
+    // keeping max_key_count and key_count exact.
+    LocationResult ReadModifyWriteTargetLocations(RequestContext *request_context,
+                                                  const KeyVector &keys,
+                                                  const LocationIdsPerKey &location_ids,
+                                                  const LocationModifierFunc &modifier) noexcept;
 
     // ---------- READ ----------
     Result Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept;
@@ -138,6 +146,13 @@ public:
 private:
     class ScopedBatchLock;
 
+    LocationResult ReadModifyWriteLocationImpl(RequestContext *request_context,
+                                               const KeyVector &keys,
+                                               const LocationIdsPerKey &location_ids,
+                                               const LocationModifierFunc &modifier,
+                                               bool adjust_reclaimed_key_count,
+                                               bool track_created_key_count) noexcept;
+
 private:
     std::vector<BatchMetaData> MakeBatches(const KeyVector &keys,
                                            const LocationIdsPerKey &location_ids,
@@ -182,7 +197,8 @@ private:
                                                  const std::vector<int32_t> &put_global_indexs,
                                                  const KeyVector &all_keys,
                                                  RmwStats &stats,
-                                                 Result &result) noexcept;
+                                                 Result &result,
+                                                 bool preserve_existing_updates_when_full = false) noexcept;
     // Returns {error_count, delete_success_count}.
     std::pair<int32_t, int32_t> ExecuteRmwDelete(const std::string &trace_id,
                                                  RequestContext *request_context,

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -15,6 +15,7 @@
 #include "kv_cache_manager/meta/cache_location.h"
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_storage_backend_manager.h"
+#include "kv_cache_manager/meta/query_executor.h"
 #include "kv_cache_manager/meta/storage_usage_data.h"
 #include "kv_cache_manager/meta/types.h"
 #include "kv_cache_manager/metrics/revisit_interval_histogram.h"
@@ -59,6 +60,8 @@ public:
 
     // Set revisit interval histogram for tracking cache access patterns.
     void SetRevisitHistogram(std::shared_ptr<RevisitIntervalHistogram> histogram);
+    // Injected once by MetaIndexerManager before Init/traffic begins.
+    void SetQueryExecutor(std::shared_ptr<QueryExecutor> executor) { query_executor_ = std::move(executor); }
 
     // ---------- WRITE ----------
     Result Put(RequestContext *request_context,
@@ -86,6 +89,11 @@ public:
     Result GetLocations(RequestContext *request_context,
                         const KeyVector &keys,
                         CacheLocationMapVector &out_location_maps) noexcept;
+    // Lightweight all-location view used by GetHostCacheState. For a single
+    // local backend, large requests are read concurrently through the shared
+    // bounded query executor. Other backend modes remain one batched call.
+    Result
+    GetLocationValues(RequestContext *request_context, const KeyVector &keys, LocationsPerKey &out_locations) noexcept;
     LocationResult GetLocations(RequestContext *request_context,
                                 const KeyVector &keys,
                                 const LocationIdsPerKey &location_ids,
@@ -102,6 +110,11 @@ public:
     ErrorCode RandomSample(RequestContext *request_context, const size_t count, KeyVector &out_keys) const noexcept;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyVector &out_keys) const noexcept;
+
+    // Reuses the same bounded executor for CPU-only query projection/reduction.
+    // Directly constructed test/indexer instances without an executor retain
+    // serial behavior.
+    bool ParallelForQuery(std::size_t count, const QueryExecutor::RangeFunction &fn) const noexcept;
 
     void PersistMetaData() noexcept;
     size_t GetKeyCount() const noexcept;
@@ -183,6 +196,7 @@ private:
 private:
     std::vector<std::unique_ptr<std::mutex>> mutex_shards_;
     std::unique_ptr<MetaStorageBackendManager> backend_manager_;
+    std::shared_ptr<QueryExecutor> query_executor_;
 
     std::atomic<int64_t> key_count_ = {0};
     int64_t last_persist_metadata_time_ = 0;

--- a/kv_cache_manager/meta/meta_indexer_manager.cc
+++ b/kv_cache_manager/meta/meta_indexer_manager.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 
 #include <algorithm>
+#include <exception>
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/config/meta_indexer_config.h"
@@ -33,8 +34,21 @@ bool MetaIndexerManager::ConfigureQueryExecutor(std::size_t worker_count,
         return false;
     }
     constexpr std::size_t kQueueSlotsPerWorker = 64;
-    query_executor_ = std::make_shared<QueryExecutor>(
-        worker_count, parallel_threshold, chunk_size, std::max<std::size_t>(64, worker_count * kQueueSlotsPerWorker));
+    try {
+        query_executor_ =
+            std::make_shared<QueryExecutor>(worker_count,
+                                            parallel_threshold,
+                                            chunk_size,
+                                            std::max<std::size_t>(64, worker_count * kQueueSlotsPerWorker));
+    } catch (const std::exception &e) {
+        KVCM_LOG_ERROR("failed to create query executor: %s", e.what());
+        query_executor_.reset();
+        return false;
+    } catch (...) {
+        KVCM_LOG_ERROR("failed to create query executor with unknown exception");
+        query_executor_.reset();
+        return false;
+    }
     KVCM_LOG_INFO("configured query executor: workers[%zu] threshold[%zu] chunk_size[%zu]",
                   worker_count,
                   parallel_threshold,

--- a/kv_cache_manager/meta/meta_indexer_manager.cc
+++ b/kv_cache_manager/meta/meta_indexer_manager.cc
@@ -1,8 +1,11 @@
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 
+#include <algorithm>
+
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/config/meta_indexer_config.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
+#include "kv_cache_manager/meta/query_executor.h"
 #include "kv_cache_manager/metrics/revisit_interval_histogram.h"
 
 namespace kv_cache_manager {
@@ -11,6 +14,32 @@ void MetaIndexerManager::SetRevisitHistogramConfig(std::shared_ptr<MetricsRegist
                                                    const std::vector<double> &boundaries) {
     metrics_registry_ = std::move(registry);
     revisit_boundaries_ = boundaries;
+}
+
+bool MetaIndexerManager::ConfigureQueryExecutor(std::size_t worker_count,
+                                                std::size_t parallel_threshold,
+                                                std::size_t chunk_size) {
+    if (worker_count == 0 || worker_count > 64 || parallel_threshold == 0 || chunk_size == 0 ||
+        chunk_size > parallel_threshold) {
+        KVCM_LOG_ERROR("invalid query executor config: workers[%zu] threshold[%zu] chunk_size[%zu]",
+                       worker_count,
+                       parallel_threshold,
+                       chunk_size);
+        return false;
+    }
+    std::scoped_lock write_guard(mutex_);
+    if (!meta_indexers_.empty()) {
+        KVCM_LOG_ERROR("query executor must be configured before creating meta indexers");
+        return false;
+    }
+    constexpr std::size_t kQueueSlotsPerWorker = 64;
+    query_executor_ = std::make_shared<QueryExecutor>(
+        worker_count, parallel_threshold, chunk_size, std::max<std::size_t>(64, worker_count * kQueueSlotsPerWorker));
+    KVCM_LOG_INFO("configured query executor: workers[%zu] threshold[%zu] chunk_size[%zu]",
+                  worker_count,
+                  parallel_threshold,
+                  chunk_size);
+    return true;
 }
 
 ErrorCode MetaIndexerManager::CreateMetaIndexer(const std::string &instance_id,
@@ -28,6 +57,7 @@ ErrorCode MetaIndexerManager::CreateMetaIndexer(const std::string &instance_id,
             return ErrorCode::EC_EXIST;
         }
         indexer = std::make_shared<MetaIndexer>();
+        indexer->SetQueryExecutor(query_executor_);
         auto ec = indexer->Init(instance_id, config);
         if (ec != ErrorCode::EC_OK) {
             KVCM_LOG_ERROR("Init meta indexer failed, instance_id: %s", instance_id.c_str());

--- a/kv_cache_manager/meta/meta_indexer_manager.h
+++ b/kv_cache_manager/meta/meta_indexer_manager.h
@@ -14,6 +14,7 @@ namespace kv_cache_manager {
 class MetaIndexerConfig;
 class MetaIndexer;
 class MetricsRegistry;
+class QueryExecutor;
 
 class MetaIndexerManager {
 public:
@@ -24,6 +25,11 @@ public:
     // Set histogram configuration for revisit interval tracking.
     // Must be called before CreateMetaIndexer.
     void SetRevisitHistogramConfig(std::shared_ptr<MetricsRegistry> registry, const std::vector<double> &boundaries);
+
+    // Configures the single process-level executor shared by every indexer.
+    // Must be called before CreateMetaIndexer. worker_count == 1 keeps the
+    // exact serial behavior while preserving the same code path.
+    bool ConfigureQueryExecutor(std::size_t worker_count, std::size_t parallel_threshold, std::size_t chunk_size);
 
     ErrorCode CreateMetaIndexer(const std::string &instance_id,
                                 const std::shared_ptr<MetaIndexerConfig> &config,
@@ -50,6 +56,7 @@ private:
     // Histogram configuration (shared across all indexers)
     std::shared_ptr<MetricsRegistry> metrics_registry_;
     std::vector<double> revisit_boundaries_;
+    std::shared_ptr<QueryExecutor> query_executor_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -468,6 +468,10 @@ std::vector<ErrorCode> MetaLocalBackend::GetLocationValues(RequestContext * /*re
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     out_locations.clear();
     out_locations.resize(keys.size());
+    std::vector<int64_t> revisit_intervals;
+    if (revisit_histogram_) {
+        revisit_intervals.reserve(keys.size());
+    }
     for (size_t i = 0; i < keys.size(); ++i) {
         std::string_view key_sv = KeyToView(keys[i]);
         Cache::Handle *handle = cache_->Lookup(key_sv);
@@ -478,7 +482,7 @@ std::vector<ErrorCode> MetaLocalBackend::GetLocationValues(RequestContext * /*re
         auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
         const int64_t stored_time = item->GetLastAccessTime();
         if (revisit_histogram_ && stored_time > 0) {
-            revisit_histogram_->Observe(TimestampUtil::GetCurrentTimeUs() - stored_time);
+            revisit_intervals.push_back(TimestampUtil::GetCurrentTimeUs() - stored_time);
         }
         item->TouchAccessTime();
         {
@@ -492,6 +496,9 @@ std::vector<ErrorCode> MetaLocalBackend::GetLocationValues(RequestContext * /*re
             }
         }
         cache_->Release(handle);
+    }
+    if (revisit_histogram_) {
+        revisit_histogram_->ObserveBatch(revisit_intervals);
     }
     return results;
 }

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -462,6 +462,40 @@ std::vector<ErrorCode> MetaLocalBackend::GetLocations(RequestContext * /*request
     return results;
 }
 
+std::vector<ErrorCode> MetaLocalBackend::GetLocationValues(RequestContext * /*request_context*/,
+                                                           const KeyTypeVec &keys,
+                                                           LocationsPerKey &out_locations) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_locations.clear();
+    out_locations.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        std::string_view key_sv = KeyToView(keys[i]);
+        Cache::Handle *handle = cache_->Lookup(key_sv);
+        if (!handle) {
+            results[i] = EC_NOENT;
+            continue;
+        }
+        auto *item = static_cast<MetaMemCacheItem *>(cache_->Value(handle));
+        const int64_t stored_time = item->GetLastAccessTime();
+        if (revisit_histogram_ && stored_time > 0) {
+            revisit_histogram_->Observe(TimestampUtil::GetCurrentTimeUs() - stored_time);
+        }
+        item->TouchAccessTime();
+        {
+            std::shared_lock lock(item->GetMutex());
+            const auto &locations = item->GetLocations();
+            auto &values = out_locations[i];
+            values.reserve(locations.size());
+            for (const auto &[location_id, location] : locations) {
+                (void)location_id;
+                values.push_back(location);
+            }
+        }
+        cache_->Release(handle);
+    }
+    return results;
+}
+
 std::vector<std::vector<ErrorCode>> MetaLocalBackend::GetLocations(RequestContext * /*request_context*/,
                                                                    const KeyTypeVec &keys,
                                                                    const LocationIdsPerKey &location_ids,

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -503,13 +503,24 @@ std::vector<ErrorCode> MetaLocalBackend::GetLocationValues(RequestContext * /*re
     return results;
 }
 
-std::vector<std::vector<ErrorCode>> MetaLocalBackend::GetLocations(RequestContext * /*request_context*/,
+std::vector<std::vector<ErrorCode>> MetaLocalBackend::GetLocations(RequestContext *request_context,
                                                                    const KeyTypeVec &keys,
                                                                    const LocationIdsPerKey &location_ids,
                                                                    LocationsPerKey &out_locations) noexcept {
+    std::vector<ErrorCode> ignored_key_error_codes;
+    return GetLocationsWithKeyStatus(request_context, keys, location_ids, out_locations, ignored_key_error_codes);
+}
+
+std::vector<std::vector<ErrorCode>>
+MetaLocalBackend::GetLocationsWithKeyStatus(RequestContext * /*request_context*/,
+                                            const KeyTypeVec &keys,
+                                            const LocationIdsPerKey &location_ids,
+                                            LocationsPerKey &out_locations,
+                                            std::vector<ErrorCode> &out_key_error_codes) noexcept {
     assert(keys.size() == location_ids.size());
     std::vector<std::vector<ErrorCode>> results(keys.size());
-    out_locations.resize(keys.size());
+    out_key_error_codes.assign(keys.size(), EC_OK);
+    out_locations.assign(keys.size(), CacheLocationVector{});
 
     for (size_t i = 0; i < keys.size(); ++i) {
         out_locations[i].resize(location_ids[i].size());
@@ -517,6 +528,7 @@ std::vector<std::vector<ErrorCode>> MetaLocalBackend::GetLocations(RequestContex
         std::string_view key_sv = KeyToView(keys[i]);
         Cache::Handle *handle = cache_->Lookup(key_sv);
         if (!handle) {
+            out_key_error_codes[i] = EC_NOENT;
             results[i].assign(location_ids[i].size(), EC_NOENT);
             continue;
         }

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -142,6 +142,12 @@ public:
                                                      const KeyTypeVec &keys,
                                                      const LocationIdsPerKey &location_ids,
                                                      LocationsPerKey &out_locations) noexcept override;
+    std::vector<std::vector<ErrorCode>>
+    GetLocationsWithKeyStatus(RequestContext *request_context,
+                              const KeyTypeVec &keys,
+                              const LocationIdsPerKey &location_ids,
+                              LocationsPerKey &out_locations,
+                              std::vector<ErrorCode> &out_key_error_codes) noexcept override;
     std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
                                           const KeyTypeVec &keys,
                                           LocationIdsPerKey &out_location_ids) noexcept override;

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -135,6 +135,9 @@ public:
     std::vector<ErrorCode> GetLocations(RequestContext *request_context,
                                         const KeyTypeVec &keys,
                                         CacheLocationMapVector &out_locations) noexcept override;
+    std::vector<ErrorCode> GetLocationValues(RequestContext *request_context,
+                                             const KeyTypeVec &keys,
+                                             LocationsPerKey &out_locations) noexcept override;
     std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
                                                      const KeyTypeVec &keys,
                                                      const LocationIdsPerKey &location_ids,

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string>
@@ -135,6 +136,30 @@ public:
     virtual std::vector<ErrorCode> GetLocations(RequestContext *request_context,
                                                 const KeyTypeVec &keys,
                                                 CacheLocationMapVector &out_locations) noexcept = 0;
+
+    // Lightweight all-location read for consumers that only need immutable
+    // CacheLocation values and do not need to look them up again by id. The
+    // default implementation preserves every backend's existing behavior by
+    // flattening GetLocations. Local memory overrides it to avoid cloning an
+    // unordered_map (including every location-id string and hash node) per key.
+    virtual std::vector<ErrorCode> GetLocationValues(RequestContext *request_context,
+                                                     const KeyTypeVec &keys,
+                                                     LocationsPerKey &out_locations) noexcept {
+        CacheLocationMapVector location_maps;
+        auto results = GetLocations(request_context, keys, location_maps);
+        out_locations.clear();
+        out_locations.resize(keys.size());
+        const std::size_t count = std::min(keys.size(), location_maps.size());
+        for (std::size_t i = 0; i < count; ++i) {
+            auto &values = out_locations[i];
+            values.reserve(location_maps[i].size());
+            for (const auto &[location_id, location] : location_maps[i]) {
+                (void)location_id;
+                values.push_back(location);
+            }
+        }
+        return results;
+    }
 
     // 读取指定 location id 对应的 CacheLocation。
     // @param request_context  请求上下文；可为 nullptr

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -177,6 +177,68 @@ public:
                                                              const LocationIdsPerKey &location_ids,
                                                              LocationsPerKey &out_locations) noexcept = 0;
 
+    // Read selected locations and preserve the key-level existence result.
+    // A targeted read alone cannot distinguish a missing key from an existing
+    // key that does not contain any requested location. RMW callers need that
+    // distinction to update key_count correctly when an upsert creates a new
+    // block. Backends that can determine both states in one lookup should
+    // override this method. The generic fallback only probes key existence for
+    // ambiguous all-NOENT rows, so existing-location reads remain one request.
+    virtual std::vector<std::vector<ErrorCode>>
+    GetLocationsWithKeyStatus(RequestContext *request_context,
+                              const KeyTypeVec &keys,
+                              const LocationIdsPerKey &location_ids,
+                              LocationsPerKey &out_locations,
+                              std::vector<ErrorCode> &out_key_error_codes) noexcept {
+        auto results = GetLocations(request_context, keys, location_ids, out_locations);
+        out_key_error_codes.assign(keys.size(), EC_MISMATCH);
+        if (results.size() != keys.size() || out_locations.size() != keys.size()) {
+            return results;
+        }
+
+        KeyTypeVec ambiguous_keys;
+        std::vector<size_t> ambiguous_indices;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (results[i].size() != location_ids[i].size() || out_locations[i].size() != location_ids[i].size()) {
+                continue;
+            }
+            bool found_location = false;
+            ErrorCode hard_error = EC_OK;
+            for (const ErrorCode ec : results[i]) {
+                if (ec == EC_OK) {
+                    found_location = true;
+                    break;
+                }
+                if (ec != EC_NOENT && hard_error == EC_OK) {
+                    hard_error = ec;
+                }
+            }
+            if (found_location) {
+                out_key_error_codes[i] = EC_OK;
+            } else if (hard_error != EC_OK) {
+                out_key_error_codes[i] = hard_error;
+            } else {
+                ambiguous_keys.push_back(keys[i]);
+                ambiguous_indices.push_back(i);
+            }
+        }
+
+        if (ambiguous_keys.empty()) {
+            return results;
+        }
+        std::vector<bool> exists;
+        const auto exists_results = Exists(request_context, ambiguous_keys, exists);
+        if (exists_results.size() != ambiguous_keys.size() || exists.size() != ambiguous_keys.size()) {
+            return results;
+        }
+        for (size_t i = 0; i < ambiguous_keys.size(); ++i) {
+            const size_t original_index = ambiguous_indices[i];
+            out_key_error_codes[original_index] =
+                exists_results[i] == EC_OK ? (exists[i] ? EC_OK : EC_NOENT) : exists_results[i];
+        }
+        return results;
+    }
+
     // 仅获取 key 的 location id 列表（不读取 location body）。
     // @param request_context    请求上下文；可为 nullptr
     // @param keys               待查询的 key 列表

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cassert>
 #include <climits>
+#include <exception>
+#include <unordered_set>
 #include <utility>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -26,7 +28,11 @@ std::pair<KeyTypeVec, std::vector<size_t>> CollectMissingKeys(const KeyVector &k
                                                               const std::vector<ErrorCode> &results) {
     KeyTypeVec missing_keys;
     std::vector<size_t> missing_indices;
-    for (size_t i = 0; i < keys.size(); ++i) {
+    // Callers validate the positional contract before recovery. Keep this
+    // helper defensive as well so a newly added caller cannot index a short
+    // backend response before its outer layer normalizes the failure.
+    const size_t result_count = std::min(keys.size(), results.size());
+    for (size_t i = 0; i < result_count; ++i) {
         if (results[i] == EC_NOENT) {
             missing_keys.push_back(keys[i]);
             missing_indices.push_back(i);
@@ -37,77 +43,101 @@ std::pair<KeyTypeVec, std::vector<size_t>> CollectMissingKeys(const KeyVector &k
 } // namespace
 
 MetaStorageBackendManager::~MetaStorageBackendManager() {
-    // Defensive cleanup in case Close was never called explicitly.
-    is_closed_.store(true, std::memory_order_release);
-    if (recover_thread_.joinable()) {
-        recover_thread_.join();
-    }
+    // Close is idempotent and also owns recovery-thread shutdown, so an owner
+    // that forgets the explicit lifecycle call cannot leak backend resources.
+    (void)Close();
 }
 
 ErrorCode MetaStorageBackendManager::Init(const std::string &instance_id,
                                           const std::shared_ptr<MetaStorageBackendConfig> &config) noexcept {
-    if (instance_id.empty()) {
-        KVCM_LOG_ERROR("init meta storage backend manager failed, empty instance id");
-        return EC_BADARGS;
-    }
-    if (!config) {
-        KVCM_LOG_ERROR("init meta storage backend manager failed, null storage backend config");
-        return EC_BADARGS;
-    }
-    instance_id_ = instance_id;
+    try {
+        std::lock_guard<std::mutex> lifecycle_guard(lifecycle_mutex_);
+        if (instance_id.empty()) {
+            KVCM_LOG_ERROR("init meta storage backend manager failed, empty instance id");
+            return EC_BADARGS;
+        }
+        if (!config) {
+            KVCM_LOG_ERROR("init meta storage backend manager failed, null storage backend config");
+            return EC_BADARGS;
+        }
+        if (persistent_backend_ || cache_backend_ || opened_) {
+            KVCM_LOG_ERROR("meta storage backend manager is already initialized, instance[%s]", instance_id_.c_str());
+            return EC_ERROR;
+        }
 
-    const std::string &storage_uri = config->GetStorageUri();
-    if (config->GetStorageType() != META_CACHED_BACKEND_TYPE_STR) {
-        // Single-backend mode: one backend serves every read/write directly.
-        persistent_backend_ = MetaStorageBackendFactory::CreateAndInitStorageBackend(instance_id_, config);
-        if (!persistent_backend_) {
+        const std::string &storage_uri = config->GetStorageUri();
+        if (config->GetStorageType() != META_CACHED_BACKEND_TYPE_STR) {
+            // Single-backend mode: one backend serves every read/write directly.
+            auto persistent_backend = MetaStorageBackendFactory::CreateAndInitStorageBackend(instance_id, config);
+            if (!persistent_backend) {
+                KVCM_LOG_ERROR("fail to create persistent backend uri[%s]", storage_uri.c_str());
+                return EC_ERROR;
+            }
+            instance_id_ = instance_id;
+            persistent_backend_ = std::move(persistent_backend);
+            KVCM_LOG_INFO("meta storage backend manager init ok in single-backend mode, instance[%s] type[%s]",
+                          instance_id_.c_str(),
+                          config->GetStorageType().c_str());
+            return EC_OK;
+        }
+
+        assert((config->GetStorageType() == META_CACHED_BACKEND_TYPE_STR));
+        std::string persistent_type;
+        std::string cache_type;
+        if (!storage_uri.empty()) {
+            StandardUri uri = StandardUri::FromUri(storage_uri);
+            if (!uri.Valid()) {
+                KVCM_LOG_ERROR("invalid storage uri[%s]", storage_uri.c_str());
+                return EC_BADARGS;
+            }
+            persistent_type = uri.GetParam("persistent_type");
+            cache_type = uri.GetParam("cache_type");
+        }
+        // default to redis / local
+        persistent_type = persistent_type.empty() ? META_REDIS_BACKEND_TYPE_STR : persistent_type;
+        cache_type = cache_type.empty() ? META_LOCAL_BACKEND_TYPE_STR : cache_type;
+
+        auto persistent_config = std::make_shared<MetaStorageBackendConfig>(persistent_type);
+        persistent_config->SetStorageUri(storage_uri);
+        auto persistent_backend = MetaStorageBackendFactory::CreatePersistentBackend(instance_id, persistent_config);
+        if (!persistent_backend) {
             KVCM_LOG_ERROR("fail to create persistent backend uri[%s]", storage_uri.c_str());
             return EC_ERROR;
         }
-        KVCM_LOG_INFO("meta storage backend manager init ok in single-backend mode, instance[%s] type[%s]",
-                      instance_id_.c_str(),
-                      config->GetStorageType().c_str());
-        return EC_OK;
-    }
-
-    assert((config->GetStorageType() == META_CACHED_BACKEND_TYPE_STR));
-    std::string persistent_type;
-    std::string cache_type;
-    if (!storage_uri.empty()) {
-        StandardUri uri = StandardUri::FromUri(storage_uri);
-        if (!uri.Valid()) {
-            KVCM_LOG_ERROR("invalid storage uri[%s]", storage_uri.c_str());
-            return EC_BADARGS;
+        auto cache_config = std::make_shared<MetaStorageBackendConfig>(cache_type);
+        cache_config->SetStorageUri(storage_uri);
+        auto cache_backend = MetaStorageBackendFactory::CreateCacheBackend(instance_id, cache_config);
+        if (!cache_backend) {
+            KVCM_LOG_ERROR("fail to create cache backend uri[%s]", storage_uri.c_str());
+            return EC_ERROR;
         }
-        persistent_type = uri.GetParam("persistent_type");
-        cache_type = uri.GetParam("cache_type");
-    }
-    // default to redis / local
-    persistent_type = persistent_type.empty() ? META_REDIS_BACKEND_TYPE_STR : persistent_type;
-    cache_type = cache_type.empty() ? META_LOCAL_BACKEND_TYPE_STR : cache_type;
 
-    auto persistent_config = std::make_shared<MetaStorageBackendConfig>(persistent_type);
-    persistent_config->SetStorageUri(storage_uri);
-    persistent_backend_ = MetaStorageBackendFactory::CreatePersistentBackend(instance_id_, persistent_config);
-    if (!persistent_backend_) {
-        KVCM_LOG_ERROR("fail to create persistent backend uri[%s]", storage_uri.c_str());
-        return EC_ERROR;
+        // Publish the pair only after both factories have succeeded. A failed
+        // dual-backend Init can therefore be retried on the same object and
+        // never exposes a half-configured persistent side to Open().
+        instance_id_ = instance_id;
+        persistent_backend_ = std::move(persistent_backend);
+        cache_backend_ = std::move(cache_backend);
+        KVCM_LOG_INFO("meta storage backend manager init ok, instance[%s] cache[%s] persistent[%s]",
+                      instance_id_.c_str(),
+                      cache_type.c_str(),
+                      persistent_type.c_str());
+        return EC_OK;
+    } catch (const std::exception &e) {
+        KVCM_LOG_ERROR(
+            "init meta storage backend manager raised, instance[%s] error[%s]", instance_id.c_str(), e.what());
+    } catch (...) {
+        KVCM_LOG_ERROR("init meta storage backend manager raised unknown exception, instance[%s]", instance_id.c_str());
     }
-    auto cache_config = std::make_shared<MetaStorageBackendConfig>(cache_type);
-    cache_config->SetStorageUri(storage_uri);
-    cache_backend_ = MetaStorageBackendFactory::CreateCacheBackend(instance_id_, cache_config);
-    if (!cache_backend_) {
-        KVCM_LOG_ERROR("fail to create cache backend uri[%s]", storage_uri.c_str());
-        return EC_ERROR;
-    }
-    KVCM_LOG_INFO("meta storage backend manager init ok, instance[%s] cache[%s] persistent[%s]",
-                  instance_id_.c_str(),
-                  cache_type.c_str(),
-                  persistent_type.c_str());
-    return EC_OK;
+    return EC_ERROR;
 }
 
 ErrorCode MetaStorageBackendManager::Open() noexcept {
+    std::lock_guard<std::mutex> lifecycle_guard(lifecycle_mutex_);
+    if (opened_) {
+        KVCM_LOG_ERROR("meta storage backend manager is already open, instance[%s]", instance_id_.c_str());
+        return EC_ERROR;
+    }
     if (!persistent_backend_) {
         KVCM_LOG_ERROR("persistent backend not inited! instance[%s]", instance_id_.c_str());
         return EC_ERROR;
@@ -115,13 +145,20 @@ ErrorCode MetaStorageBackendManager::Open() noexcept {
 
     ErrorCode ec = persistent_backend_->Open();
     if (ec != EC_OK) {
-        KVCM_LOG_ERROR("open persistent failed, instance[%s] ec[%d]", instance_id_.c_str(), ec);
+        // Open implementations may have allocated resources before reporting
+        // failure. Roll them back even though the manager never publishes an
+        // opened state.
+        is_closed_.store(true, std::memory_order_release);
+        const ErrorCode close_ec = persistent_backend_->Close();
+        KVCM_LOG_ERROR(
+            "open persistent failed, instance[%s] ec[%d] rollback_close_ec[%d]", instance_id_.c_str(), ec, close_ec);
         return ec;
     }
     is_closed_.store(false, std::memory_order_release);
 
     if (!cache_backend_) {
         recover_state_.store(RecoverState::kRunning, std::memory_order_release);
+        opened_ = true;
         KVCM_LOG_INFO("meta storage backend manager opened in single-backend mode, instance[%s]", instance_id_.c_str());
         return EC_OK;
     }
@@ -129,18 +166,63 @@ ErrorCode MetaStorageBackendManager::Open() noexcept {
     ec = cache_backend_->Open();
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("open cache failed, instance[%s] ec[%d]", instance_id_.c_str(), ec);
+        // Open is transactional from the manager's point of view. Do not
+        // leave the persistent side live when the cache side cannot serve.
+        // Also close the cache defensively in case its Open partially
+        // initialized resources before returning an error.
+        is_closed_.store(true, std::memory_order_release);
+        ErrorCode cache_close_ec = cache_backend_->Close();
+        ErrorCode persistent_close_ec = persistent_backend_->Close();
+        if (cache_close_ec != EC_OK || persistent_close_ec != EC_OK) {
+            KVCM_LOG_ERROR("rollback after cache open failure was incomplete, instance[%s] "
+                           "cache_close_ec[%d] persistent_close_ec[%d]",
+                           instance_id_.c_str(),
+                           cache_close_ec,
+                           persistent_close_ec);
+        }
         return ec;
     }
     recover_state_.store(RecoverState::kRecover, std::memory_order_release);
-    recover_thread_ = std::thread(&MetaStorageBackendManager::AsyncRecoverTask, this);
+    try {
+        recover_thread_ = std::thread(&MetaStorageBackendManager::AsyncRecoverTask, this);
+    } catch (const std::exception &e) {
+        // Open is noexcept, so thread construction must not escape. Roll both
+        // backends back to a closed state instead of publishing a manager that
+        // can never finish recovery.
+        is_closed_.store(true, std::memory_order_release);
+        ErrorCode cache_close_ec = cache_backend_->Close();
+        ErrorCode persistent_close_ec = persistent_backend_->Close();
+        KVCM_LOG_ERROR("start async recover failed, instance[%s] error[%s] "
+                       "cache_close_ec[%d] persistent_close_ec[%d]",
+                       instance_id_.c_str(),
+                       e.what(),
+                       cache_close_ec,
+                       persistent_close_ec);
+        return EC_ERROR;
+    } catch (...) {
+        is_closed_.store(true, std::memory_order_release);
+        ErrorCode cache_close_ec = cache_backend_->Close();
+        ErrorCode persistent_close_ec = persistent_backend_->Close();
+        KVCM_LOG_ERROR("start async recover failed with unknown exception, instance[%s] "
+                       "cache_close_ec[%d] persistent_close_ec[%d]",
+                       instance_id_.c_str(),
+                       cache_close_ec,
+                       persistent_close_ec);
+        return EC_ERROR;
+    }
+    opened_ = true;
     KVCM_LOG_INFO("meta storage backend manager opened, instance[%s], async recover started", instance_id_.c_str());
     return EC_OK;
 }
 
 ErrorCode MetaStorageBackendManager::Close() noexcept {
+    std::lock_guard<std::mutex> lifecycle_guard(lifecycle_mutex_);
     is_closed_.store(true, std::memory_order_release);
     if (recover_thread_.joinable()) {
         recover_thread_.join();
+    }
+    if (!opened_) {
+        return EC_OK;
     }
 
     ErrorCode cache_ec = EC_OK;
@@ -159,6 +241,7 @@ ErrorCode MetaStorageBackendManager::Close() noexcept {
         KVCM_LOG_ERROR("close persistent failed, instance[%s] ec[%d]", instance_id_.c_str(), persistent_ec);
         return persistent_ec;
     }
+    opened_ = false;
     KVCM_LOG_INFO("meta storage backend manager closed, instance[%s]", instance_id_.c_str());
     return EC_OK;
 }
@@ -171,27 +254,82 @@ void MetaStorageBackendManager::AsyncRecoverTask() noexcept {
     std::string next_cursor;
     KeyTypeVec scanned_keys;
     FieldMapVec field_maps;
-    do {
+    bool has_pending_batch = false;
+    bool recovery_complete = false;
+    while (!recovery_complete) {
         if (is_closed_.load(std::memory_order_acquire)) {
             KVCM_LOG_INFO("async recover aborted due to close, instance[%s]", instance_id_.c_str());
             return;
         }
 
-        scanned_keys.clear();
-        field_maps.clear();
-        ErrorCode scan_ec =
-            persistent_backend_->ListKeys(nullptr, cursor, kRecoverScanBatchSize, next_cursor, scanned_keys);
-        if (scan_ec != EC_OK) {
+        if (!has_pending_batch) {
+            scanned_keys.clear();
+            field_maps.clear();
+            ErrorCode scan_ec =
+                persistent_backend_->ListKeys(nullptr, cursor, kRecoverScanBatchSize, next_cursor, scanned_keys);
+            if (scan_ec != EC_OK) {
+                ++consecutive_failures;
+                KVCM_LOG_ERROR("async recover scan failed, instance[%s] cursor[%s] ec[%d] attempt[%d/%d]",
+                               instance_id_.c_str(),
+                               cursor.c_str(),
+                               scan_ec,
+                               consecutive_failures,
+                               kRecoverMaxConsecutiveFailures);
+                if (consecutive_failures >= kRecoverMaxConsecutiveFailures) {
+                    KVCM_LOG_ERROR("async recover giving up after %d consecutive scan failures, "
+                                   "leaving backend in Recover, instance[%s]",
+                                   kRecoverMaxConsecutiveFailures,
+                                   instance_id_.c_str());
+                    break;
+                }
+                continue;
+            }
+
+            if (scanned_keys.empty()) {
+                consecutive_failures = 0;
+                cursor = next_cursor;
+                recovery_complete = (cursor == SCAN_BASE_CURSOR);
+                continue;
+            }
+            // Redis SCAN is not a stable snapshot.  Once a cursor yields a
+            // batch, retain those exact keys across Get/backfill retries;
+            // rescanning the cursor could return a different set and let the
+            // failed keys disappear before recovery is published complete.
+            has_pending_batch = true;
+        }
+        CacheLocationMapVector locations;
+        PropertyMapVector properties;
+        std::vector<ErrorCode> get_error_codes = persistent_backend_->Get(nullptr, scanned_keys, locations, properties);
+        if (get_error_codes.size() != scanned_keys.size() || locations.size() != scanned_keys.size() ||
+            properties.size() != scanned_keys.size()) {
+            KVCM_LOG_ERROR("async recover Get results[%lu] locations[%lu] properties[%lu] mismatch keys[%lu], "
+                           "skip batch",
+                           get_error_codes.size(),
+                           locations.size(),
+                           properties.size(),
+                           scanned_keys.size());
             ++consecutive_failures;
-            KVCM_LOG_ERROR("async recover scan failed, instance[%s] cursor[%s] ec[%d] attempt[%d/%d]",
-                           instance_id_.c_str(),
-                           cursor.c_str(),
-                           scan_ec,
-                           consecutive_failures,
-                           kRecoverMaxConsecutiveFailures);
             if (consecutive_failures >= kRecoverMaxConsecutiveFailures) {
-                KVCM_LOG_ERROR("async recover giving up after %d consecutive failures, "
-                               "forcing transition to Running, instance[%s]",
+                KVCM_LOG_ERROR("async recover giving up after %d malformed Get responses, "
+                               "leaving backend in Recover, instance[%s]",
+                               kRecoverMaxConsecutiveFailures,
+                               instance_id_.c_str());
+                break;
+            }
+            continue;
+        }
+        bool get_complete = true;
+        for (size_t i = 0; i < scanned_keys.size(); ++i) {
+            if (get_error_codes[i] != EC_OK && get_error_codes[i] != EC_NOENT) {
+                KVCM_LOG_WARN("async recover key[%ld] get failed ec[%d]", scanned_keys[i], get_error_codes[i]);
+                get_complete = false;
+            }
+        }
+        if (!get_complete) {
+            ++consecutive_failures;
+            if (consecutive_failures >= kRecoverMaxConsecutiveFailures) {
+                KVCM_LOG_ERROR("async recover giving up after %d incomplete Get responses, "
+                               "leaving backend in Recover, instance[%s]",
                                kRecoverMaxConsecutiveFailures,
                                instance_id_.c_str());
                 break;
@@ -199,31 +337,46 @@ void MetaStorageBackendManager::AsyncRecoverTask() noexcept {
             continue;
         }
 
-        consecutive_failures = 0;
-        cursor = next_cursor;
-        if (scanned_keys.empty()) {
+        bool backfill_success = false;
+        const int64_t backfilled_keys =
+            BackfillKeysToCache(scanned_keys, locations, properties, get_error_codes, &backfill_success);
+        if (!backfill_success) {
+            ++consecutive_failures;
+            KVCM_LOG_ERROR("async recover backfill failed, instance[%s] cursor[%s] attempt[%d/%d]",
+                           instance_id_.c_str(),
+                           cursor.c_str(),
+                           consecutive_failures,
+                           kRecoverMaxConsecutiveFailures);
+            if (consecutive_failures >= kRecoverMaxConsecutiveFailures) {
+                KVCM_LOG_ERROR("async recover giving up after %d consecutive backfill failures, "
+                               "leaving backend in Recover, instance[%s]",
+                               kRecoverMaxConsecutiveFailures,
+                               instance_id_.c_str());
+                break;
+            }
             continue;
         }
-        CacheLocationMapVector locations;
-        PropertyMapVector properties;
-        std::vector<ErrorCode> get_error_codes = persistent_backend_->Get(nullptr, scanned_keys, locations, properties);
-        for (size_t i = 0; i < scanned_keys.size(); ++i) {
-            if (get_error_codes[i] != EC_OK && get_error_codes[i] != EC_NOENT) {
-                KVCM_LOG_WARN("async recover key[%ld] get failed ec[%d]", scanned_keys[i], get_error_codes[i]);
-            }
-        }
-        total_backfilled_keys += BackfillKeysToCache(scanned_keys, locations, properties, get_error_codes);
-    } while (cursor != SCAN_BASE_CURSOR);
 
-    if (consecutive_failures == 0) {
-        KVCM_LOG_INFO("async recover completed instance[%s] total_backfilled_keys[%ld]",
-                      instance_id_.c_str(),
-                      total_backfilled_keys);
-    } else {
-        KVCM_LOG_WARN("async recover partial, instance[%s] total_backfilled_keys[%ld], forcing transition to Running",
-                      instance_id_.c_str(),
-                      total_backfilled_keys);
+        total_backfilled_keys += backfilled_keys;
+        consecutive_failures = 0;
+        cursor = next_cursor;
+        recovery_complete = (cursor == SCAN_BASE_CURSOR);
+        has_pending_batch = false;
     }
+
+    if (!recovery_complete) {
+        // Recover mode is deliberately retained. Reads can still fall back to
+        // persistent storage, and delete tombstones must remain live so a
+        // partial cache cannot resurrect keys through a late backfill.
+        KVCM_LOG_ERROR("async recover incomplete, instance[%s] total_backfilled_keys[%ld], "
+                       "backend remains in Recover",
+                       instance_id_.c_str(),
+                       total_backfilled_keys);
+        return;
+    }
+
+    KVCM_LOG_INFO(
+        "async recover completed instance[%s] total_backfilled_keys[%ld]", instance_id_.c_str(), total_backfilled_keys);
     recover_state_.store(RecoverState::kRunning, std::memory_order_release);
     {
         std::lock_guard<std::mutex> lock(deleted_keys_mutex_);
@@ -231,12 +384,19 @@ void MetaStorageBackendManager::AsyncRecoverTask() noexcept {
     }
 }
 
-void MetaStorageBackendManager::EnsureKeyInCache(RequestContext *request_context, const KeyTypeVec &keys) noexcept {
+bool MetaStorageBackendManager::EnsureKeyInCache(RequestContext *request_context, const KeyTypeVec &keys) noexcept {
     if (keys.empty()) {
-        return;
+        return true;
     }
     std::vector<bool> exists_vec;
     std::vector<ErrorCode> exists_results = cache_backend_->Exists(request_context, keys, exists_vec);
+    if (exists_results.size() != keys.size() || exists_vec.size() != keys.size()) {
+        KVCM_LOG_ERROR("ensure cache Exists results[%lu] values[%lu] mismatch keys[%lu]",
+                       exists_results.size(),
+                       exists_vec.size(),
+                       keys.size());
+        return false;
+    }
     KeyTypeVec missing_keys;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (exists_results[i] != EC_OK || !exists_vec[i]) {
@@ -244,50 +404,117 @@ void MetaStorageBackendManager::EnsureKeyInCache(RequestContext *request_context
         }
     }
     if (missing_keys.empty()) {
-        return;
+        return true;
     }
 
     CacheLocationMapVector locations;
     PropertyMapVector properties;
     std::vector<ErrorCode> get_results = persistent_backend_->Get(request_context, missing_keys, locations, properties);
+    if (get_results.size() != missing_keys.size() || locations.size() != missing_keys.size() ||
+        properties.size() != missing_keys.size()) {
+        KVCM_LOG_ERROR("ensure cache Get results[%lu] locations[%lu] properties[%lu] mismatch keys[%lu]",
+                       get_results.size(),
+                       locations.size(),
+                       properties.size(),
+                       missing_keys.size());
+        return false;
+    }
+
+    // PutIfAbsent prevents a stale persistent read from overwriting a newer
+    // dual-write that populated the cache after the Exists probe.
     std::vector<ErrorCode> put_results =
-        cache_backend_->Put(request_context, missing_keys, locations, properties, get_results);
+        cache_backend_->PutIfAbsent(request_context, missing_keys, locations, properties, get_results);
+    if (put_results.size() != missing_keys.size()) {
+        KVCM_LOG_ERROR(
+            "ensure cache PutIfAbsent results[%lu] mismatch keys[%lu]", put_results.size(), missing_keys.size());
+        return false;
+    }
+    bool hydrated = true;
     for (size_t i = 0; i < missing_keys.size(); ++i) {
-        if (put_results[i] != EC_OK && get_results[i] == EC_OK) {
-            KVCM_LOG_WARN("ensure key[%ld] in cache failed, ec[%d]", missing_keys[i], put_results[i]);
+        if (get_results[i] == EC_NOENT) {
+            // The key is genuinely new. The following Upsert can safely
+            // create it from the request's fields.
+            continue;
+        }
+        if (get_results[i] != EC_OK || (put_results[i] != EC_OK && put_results[i] != EC_EXIST)) {
+            KVCM_LOG_WARN("ensure key[%ld] in cache failed, get_ec[%d] put_ec[%d]",
+                          missing_keys[i],
+                          get_results[i],
+                          put_results[i]);
+            hydrated = false;
         }
     }
+    return hydrated;
 }
 
 int64_t MetaStorageBackendManager::BackfillKeysToCache(const KeyTypeVec &keys,
                                                        const CacheLocationMapVector &locations,
                                                        const PropertyMapVector &properties,
-                                                       const std::vector<ErrorCode> &get_error_codes) noexcept {
+                                                       const std::vector<ErrorCode> &get_error_codes,
+                                                       bool *out_success) noexcept {
+    if (out_success) {
+        *out_success = false;
+    }
     std::lock_guard<std::mutex> lock(deleted_keys_mutex_);
 
     // Merge get errors and deleted-key tombstones into a single error vector.
-    assert(get_error_codes.size() == keys.size());
+    if (get_error_codes.size() != keys.size() || locations.size() != keys.size() || properties.size() != keys.size()) {
+        KVCM_LOG_ERROR("backfill results[%lu] locations[%lu] properties[%lu] mismatch keys[%lu], skip batch",
+                       get_error_codes.size(),
+                       locations.size(),
+                       properties.size(),
+                       keys.size());
+        return 0;
+    }
     int64_t valid_count = 0;
     std::vector<ErrorCode> merged_error_codes = get_error_codes;
     for (size_t i = 0; i < keys.size(); ++i) {
+        if (merged_error_codes[i] != EC_OK && merged_error_codes[i] != EC_NOENT) {
+            KVCM_LOG_ERROR("backfill source read failed key[%ld] ec[%d], skip batch", keys[i], merged_error_codes[i]);
+            return 0;
+        }
         if (merged_error_codes[i] == EC_OK && deleted_keys_.count(keys[i]) > 0) {
             merged_error_codes[i] = EC_NOENT;
         }
         valid_count += (merged_error_codes[i] == EC_OK);
     }
     if (valid_count == 0) {
+        if (out_success) {
+            *out_success = true;
+        }
         return 0;
     }
 
     std::vector<ErrorCode> put_results =
         cache_backend_->PutIfAbsent(nullptr, keys, locations, properties, merged_error_codes);
+    if (put_results.size() != keys.size()) {
+        KVCM_LOG_ERROR(
+            "backfill PutIfAbsent results[%lu] mismatch keys[%lu], skip accounting", put_results.size(), keys.size());
+        return 0;
+    }
     int64_t backfilled_count = 0;
+    bool write_complete = true;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (put_results[i] == EC_OK) {
-            ++backfilled_count;
-        } else if (merged_error_codes[i] == EC_OK && put_results[i] != EC_NOENT) {
-            KVCM_LOG_WARN("backfill PutIfAbsent failed key[%ld] ec[%d]", keys[i], put_results[i]);
+        if (merged_error_codes[i] == EC_OK) {
+            if (put_results[i] == EC_OK) {
+                ++backfilled_count;
+            } else if (put_results[i] != EC_EXIST) {
+                KVCM_LOG_WARN("backfill PutIfAbsent failed key[%ld] ec[%d]", keys[i], put_results[i]);
+                write_complete = false;
+            }
+        } else if (put_results[i] != merged_error_codes[i]) {
+            // Conditional cache writes must preserve the source error for
+            // skipped keys. EC_OK here could mean a tombstoned value was
+            // inserted despite the guard, so never publish this cache.
+            KVCM_LOG_WARN("backfill PutIfAbsent violated skip contract key[%ld] source_ec[%d] put_ec[%d]",
+                          keys[i],
+                          merged_error_codes[i],
+                          put_results[i]);
+            write_complete = false;
         }
+    }
+    if (out_success) {
+        *out_success = write_complete;
     }
     return backfilled_count;
 }
@@ -298,6 +525,10 @@ std::vector<ErrorCode> MetaStorageBackendManager::Put(RequestContext *request_co
     CacheLocationMapVector &locations = batch.batch_locations;
     PropertyMapVector &properties = batch.batch_properties;
     std::vector<ErrorCode> persistent_results = persistent_backend_->Put(request_context, keys, locations, properties);
+    if (persistent_results.size() != keys.size()) {
+        KVCM_LOG_ERROR("persistent Put results[%lu] mismatch keys[%lu]", persistent_results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
     if (!cache_backend_) {
         return persistent_results;
     }
@@ -307,6 +538,10 @@ std::vector<ErrorCode> MetaStorageBackendManager::Put(RequestContext *request_co
         auto *mc = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
         KVCM_METRICS_COLLECTOR_SET_METRICS(
             mc, meta_indexer, cache_backend_put_time_us, TimestampUtil::GetCurrentTimeUs() - cache_begin);
+    }
+    if (results.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache Put results[%lu] mismatch keys[%lu]", results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
     }
     return results;
 }
@@ -321,10 +556,16 @@ std::vector<ErrorCode> MetaStorageBackendManager::Upsert(RequestContext *request
     // Upsert may touch only a subset of fields, so Recover-time hydration
     // is needed to avoid overwriting unmentioned fields with empty values.
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
-        EnsureKeyInCache(request_context, keys);
+        if (!EnsureKeyInCache(request_context, keys)) {
+            return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+        }
     }
     std::vector<ErrorCode> persistent_results =
         persistent_backend_->Upsert(request_context, keys, locations, properties);
+    if (persistent_results.size() != keys.size()) {
+        KVCM_LOG_ERROR("persistent Upsert results[%lu] mismatch keys[%lu]", persistent_results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
     if (!cache_backend_) {
         return persistent_results;
     }
@@ -335,20 +576,30 @@ std::vector<ErrorCode> MetaStorageBackendManager::Upsert(RequestContext *request
         KVCM_METRICS_COLLECTOR_SET_METRICS(
             mc, meta_indexer, cache_backend_upsert_time_us, TimestampUtil::GetCurrentTimeUs() - cache_begin);
     }
+    if (results.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache Upsert results[%lu] mismatch keys[%lu]", results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
     return results;
 }
 
 std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request_context,
                                                          const KeyVector &keys) noexcept {
     std::vector<ErrorCode> persistent_results = persistent_backend_->Delete(request_context, keys);
+    if (persistent_results.size() != keys.size()) {
+        KVCM_LOG_ERROR("persistent Delete results[%lu] mismatch keys[%lu]", persistent_results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
     if (!cache_backend_) {
         return persistent_results;
     }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
         // Tombstone to prevent Recover backfill from resurrecting deleted keys.
         std::lock_guard<std::mutex> lock(deleted_keys_mutex_);
-        for (const auto &key : keys) {
-            deleted_keys_.insert(key);
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (persistent_results[i] == EC_OK || persistent_results[i] == EC_NOENT) {
+                deleted_keys_.insert(keys[i]);
+            }
         }
     }
     const int64_t cache_begin = TimestampUtil::GetCurrentTimeUs();
@@ -357,6 +608,10 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request
         auto *mc = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
         KVCM_METRICS_COLLECTOR_SET_METRICS(
             mc, meta_indexer, cache_backend_delete_time_us, TimestampUtil::GetCurrentTimeUs() - cache_begin);
+    }
+    if (results.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache Delete results[%lu] mismatch keys[%lu]", results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
     }
     return results;
 }
@@ -369,17 +624,26 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request
     if (keys.empty()) {
         return {};
     }
-    assert(location_ids.size() == keys.size());
+    if (location_ids.size() != keys.size()) {
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
 
     // Partial-delete during Recover: hydrate cache from persistent first so
     // the conditional mirror write below has the full pre-restart field set
     // to delete against (and async backfill cannot later overwrite us).
     if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
-        EnsureKeyInCache(request_context, keys);
+        if (!EnsureKeyInCache(request_context, keys)) {
+            return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+        }
     }
 
     std::vector<ErrorCode> persistent_results =
         persistent_backend_->DeleteLocations(request_context, keys, location_ids);
+    if (persistent_results.size() != keys.size()) {
+        KVCM_LOG_ERROR(
+            "persistent DeleteLocations results[%lu] mismatch keys[%lu]", persistent_results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
     std::vector<ErrorCode> results;
     if (!cache_backend_) {
         results = std::move(persistent_results);
@@ -392,6 +656,10 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request
                 mc, meta_indexer, cache_backend_delete_time_us, TimestampUtil::GetCurrentTimeUs() - cache_begin);
         }
     }
+    if (results.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache DeleteLocations results[%lu] mismatch keys[%lu]", results.size(), keys.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
 
     out_reclaimed_count = MaybeReclaimEmptyKeys(request_context, keys, results);
     return results;
@@ -400,9 +668,20 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request
 int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(RequestContext *request_context,
                                                          const KeyVector &keys,
                                                          const std::vector<ErrorCode> &delete_results) noexcept {
+    if (delete_results.size() != keys.size()) {
+        KVCM_LOG_ERROR(
+            "delete results[%lu] mismatch keys[%lu], skip empty-key reclamation", delete_results.size(), keys.size());
+        return 0;
+    }
+
     KeyVector candidate_keys;
+    std::unordered_set<KeyType> seen_candidates;
+    candidate_keys.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (delete_results[i] == EC_OK) {
+        // A single block may contribute several location-deletion tasks to one
+        // RMW batch.  Reclaim and account for that block at most once even when
+        // several of its locations become empty in the same request.
+        if (delete_results[i] == EC_OK && seen_candidates.insert(keys[i]).second) {
             candidate_keys.push_back(keys[i]);
         }
     }
@@ -417,6 +696,14 @@ int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(RequestContext *request
     } else {
         exists_ecs = persistent_backend_->ExistsLocation(request_context, candidate_keys, has_locations);
     }
+    if (exists_ecs.size() != candidate_keys.size() || has_locations.size() != candidate_keys.size()) {
+        KVCM_LOG_ERROR("ExistsLocation results[%lu] values[%lu] mismatch candidate keys[%lu], "
+                       "skip empty-key reclamation",
+                       exists_ecs.size(),
+                       has_locations.size(),
+                       candidate_keys.size());
+        return 0;
+    }
 
     KeyVector reclaimed_keys;
     for (size_t i = 0; i < candidate_keys.size(); ++i) {
@@ -429,6 +716,13 @@ int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(RequestContext *request
     }
 
     std::vector<ErrorCode> whole_ecs = Delete(request_context, reclaimed_keys);
+    if (whole_ecs.size() != reclaimed_keys.size()) {
+        KVCM_LOG_ERROR("whole-key delete results[%lu] mismatch reclaimed keys[%lu], "
+                       "skip key-count adjustment",
+                       whole_ecs.size(),
+                       reclaimed_keys.size());
+        return 0;
+    }
     int32_t reclaimed = 0;
     for (const ErrorCode ec : whole_ecs) {
         if (ec == EC_OK || ec == EC_NOENT) {
@@ -447,6 +741,16 @@ std::vector<ErrorCode> MetaStorageBackendManager::Get(RequestContext *request_co
     }
 
     std::vector<ErrorCode> results = cache_backend_->Get(request_context, keys, out_locations, out_properties);
+    if (results.size() != keys.size() || out_locations.size() != keys.size() || out_properties.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache Get results[%lu] locations[%lu] properties[%lu] mismatch keys[%lu]",
+                       results.size(),
+                       out_locations.size(),
+                       out_properties.size(),
+                       keys.size());
+        results.assign(keys.size(), EC_ERROR);
+        out_locations.assign(keys.size(), CacheLocationMap{});
+        out_properties.assign(keys.size(), PropertyMap{});
+    }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
@@ -460,13 +764,18 @@ std::vector<ErrorCode> MetaStorageBackendManager::Get(RequestContext *request_co
     PropertyMapVector persistent_properties;
     std::vector<ErrorCode> persistent_results =
         persistent_backend_->Get(request_context, missing_keys, persistent_locations, persistent_properties);
-    if (missing_keys.size() != persistent_locations.size() || missing_keys.size() != persistent_properties.size()) {
-        KVCM_LOG_ERROR("persistent Get size mismatch: locations[%lu] properties[%lu] vs keys[%lu]",
+    if (missing_keys.size() != persistent_results.size() || missing_keys.size() != persistent_locations.size() ||
+        missing_keys.size() != persistent_properties.size()) {
+        KVCM_LOG_ERROR("persistent Get size mismatch: results[%lu] locations[%lu] properties[%lu] vs keys[%lu]",
+                       persistent_results.size(),
                        persistent_locations.size(),
                        persistent_properties.size(),
                        missing_keys.size());
         for (size_t i = 0; i < missing_keys.size(); ++i) {
-            results[missing_indices[i]] = EC_ERROR;
+            const size_t original_idx = missing_indices[i];
+            results[original_idx] = EC_ERROR;
+            out_locations[original_idx].clear();
+            out_properties[original_idx].clear();
         }
         return results;
     }
@@ -489,6 +798,14 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocations(RequestContext *r
     }
 
     std::vector<ErrorCode> results = cache_backend_->GetLocations(request_context, keys, out_location_maps);
+    if (results.size() != keys.size() || out_location_maps.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache GetLocations results[%lu] locations[%lu] mismatch keys[%lu]",
+                       results.size(),
+                       out_location_maps.size(),
+                       keys.size());
+        results.assign(keys.size(), EC_ERROR);
+        out_location_maps.assign(keys.size(), CacheLocationMap{});
+    }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
@@ -501,11 +818,15 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocations(RequestContext *r
     CacheLocationMapVector persistent_locations;
     std::vector<ErrorCode> persistent_results =
         persistent_backend_->GetLocations(request_context, missing_keys, persistent_locations);
-    if (missing_keys.size() != persistent_locations.size()) {
-        KVCM_LOG_ERROR(
-            "persistent_locations size[%lu] mismatch keys's[%lu]", persistent_locations.size(), missing_keys.size());
+    if (missing_keys.size() != persistent_results.size() || missing_keys.size() != persistent_locations.size()) {
+        KVCM_LOG_ERROR("persistent GetLocations results[%lu] locations[%lu] mismatch keys[%lu]",
+                       persistent_results.size(),
+                       persistent_locations.size(),
+                       missing_keys.size());
         for (size_t i = 0; i < missing_keys.size(); ++i) {
-            results[missing_indices[i]] = EC_ERROR;
+            const size_t original_idx = missing_indices[i];
+            results[original_idx] = EC_ERROR;
+            out_location_maps[original_idx].clear();
         }
         return results;
     }
@@ -532,10 +853,11 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocationValues(RequestConte
                        results.size(),
                        out_locations.size(),
                        keys.size());
-        std::vector<ErrorCode> normalized_results(keys.size(), EC_ERROR);
-        std::copy_n(results.begin(), std::min(results.size(), keys.size()), normalized_results.begin());
-        results = std::move(normalized_results);
-        out_locations.resize(keys.size());
+        // The two arrays form one positional contract. Once either shape is
+        // broken, even an in-range EC_OK cannot be trusted to describe the
+        // value at the same index.
+        results.assign(keys.size(), EC_ERROR);
+        out_locations.assign(keys.size(), CacheLocationVector{});
     }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
@@ -573,24 +895,89 @@ std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(Requ
                                                                             const KeyVector &keys,
                                                                             const LocationIdsPerKey &location_ids,
                                                                             LocationsPerKey &out_locations) noexcept {
+    if (keys.size() != location_ids.size()) {
+        out_locations.assign(keys.size(), CacheLocationVector{});
+        return std::vector<std::vector<ErrorCode>>(keys.size(), std::vector<ErrorCode>{EC_BADARGS});
+    }
     if (!cache_backend_) {
         return persistent_backend_->GetLocations(request_context, keys, location_ids, out_locations);
     }
 
     std::vector<std::vector<ErrorCode>> results =
         cache_backend_->GetLocations(request_context, keys, location_ids, out_locations);
+    if (results.size() != keys.size() || out_locations.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache targeted GetLocations results[%lu] locations[%lu] mismatch keys[%lu]",
+                       results.size(),
+                       out_locations.size(),
+                       keys.size());
+        out_locations.assign(keys.size(), CacheLocationVector{});
+        results.resize(keys.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            results[i].assign(location_ids[i].size(), EC_ERROR);
+            out_locations[i].assign(location_ids[i].size(), CacheLocationConstPtr{});
+        }
+        return results;
+    }
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (results[i].size() != location_ids[i].size() || out_locations[i].size() != location_ids[i].size()) {
+            KVCM_LOG_ERROR("cache targeted GetLocations key[%ld] results[%lu] locations[%lu] mismatch ids[%lu]",
+                           keys[i],
+                           results[i].size(),
+                           out_locations[i].size(),
+                           location_ids[i].size());
+            results[i].assign(location_ids[i].size(), EC_ERROR);
+            out_locations[i].assign(location_ids[i].size(), CacheLocationConstPtr{});
+        }
+    }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
+    }
+
+    // Per-location EC_NOENT does not say whether the cache missed the whole
+    // key or found the key without that location. Mixed OK/NOENT is
+    // unambiguously a cache hit and must never fall back to a potentially
+    // older persistent value. When every requested location is absent, use a
+    // cheap key-existence probe to distinguish the two cases.
+    KeyTypeVec ambiguous_keys;
+    std::vector<size_t> ambiguous_indices;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (!results[i].empty() &&
+            std::all_of(results[i].begin(), results[i].end(), [](ErrorCode ec) { return ec == EC_NOENT; })) {
+            ambiguous_keys.push_back(keys[i]);
+            ambiguous_indices.push_back(i);
+        }
     }
 
     KeyTypeVec missing_keys;
     std::vector<size_t> missing_indices;
     LocationIdsPerKey missing_location_ids;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        if (!results[i].empty() && results[i][0] == EC_NOENT) {
-            missing_keys.push_back(keys[i]);
-            missing_indices.push_back(i);
-            missing_location_ids.push_back(location_ids[i]);
+    if (!ambiguous_keys.empty()) {
+        std::vector<bool> cache_key_exists;
+        const std::vector<ErrorCode> exists_results =
+            cache_backend_->Exists(request_context, ambiguous_keys, cache_key_exists);
+        if (exists_results.size() != ambiguous_keys.size() || cache_key_exists.size() != ambiguous_keys.size()) {
+            KVCM_LOG_ERROR("cache key-existence results[%lu] values[%lu] mismatch ambiguous keys[%lu]",
+                           exists_results.size(),
+                           cache_key_exists.size(),
+                           ambiguous_keys.size());
+            for (const size_t original_idx : ambiguous_indices) {
+                results[original_idx].assign(location_ids[original_idx].size(), EC_ERROR);
+                out_locations[original_idx].assign(location_ids[original_idx].size(), CacheLocationConstPtr{});
+            }
+            return results;
+        }
+        for (size_t i = 0; i < ambiguous_keys.size(); ++i) {
+            const size_t original_idx = ambiguous_indices[i];
+            if (exists_results[i] != EC_OK) {
+                results[original_idx].assign(location_ids[original_idx].size(), exists_results[i]);
+                out_locations[original_idx].assign(location_ids[original_idx].size(), CacheLocationConstPtr{});
+                continue;
+            }
+            if (!cache_key_exists[i]) {
+                missing_keys.push_back(keys[original_idx]);
+                missing_indices.push_back(original_idx);
+                missing_location_ids.push_back(location_ids[original_idx]);
+            }
         }
     }
     if (missing_keys.empty()) {
@@ -600,9 +987,11 @@ std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(Requ
     LocationsPerKey persistent_locations;
     std::vector<std::vector<ErrorCode>> persistent_results =
         persistent_backend_->GetLocations(request_context, missing_keys, missing_location_ids, persistent_locations);
-    if (missing_keys.size() != persistent_results.size()) {
-        KVCM_LOG_ERROR(
-            "persistent results size[%lu] mismatch keys's[%lu]", persistent_results.size(), missing_keys.size());
+    if (missing_keys.size() != persistent_results.size() || missing_keys.size() != persistent_locations.size()) {
+        KVCM_LOG_ERROR("persistent targeted GetLocations results[%lu] locations[%lu] mismatch keys[%lu]",
+                       persistent_results.size(),
+                       persistent_locations.size(),
+                       missing_keys.size());
         for (size_t i = 0; i < missing_keys.size(); ++i) {
             results[missing_indices[i]].assign(location_ids[missing_indices[i]].size(), EC_ERROR);
         }
@@ -610,6 +999,17 @@ std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(Requ
     }
     for (size_t i = 0; i < missing_keys.size(); ++i) {
         const size_t original_idx = missing_indices[i];
+        if (persistent_results[i].size() != missing_location_ids[i].size() ||
+            persistent_locations[i].size() != missing_location_ids[i].size()) {
+            KVCM_LOG_ERROR("persistent targeted GetLocations key[%ld] results[%lu] locations[%lu] mismatch ids[%lu]",
+                           missing_keys[i],
+                           persistent_results[i].size(),
+                           persistent_locations[i].size(),
+                           missing_location_ids[i].size());
+            results[original_idx].assign(location_ids[original_idx].size(), EC_ERROR);
+            out_locations[original_idx].assign(location_ids[original_idx].size(), CacheLocationConstPtr{});
+            continue;
+        }
         results[original_idx] = std::move(persistent_results[i]);
         out_locations[original_idx] = std::move(persistent_locations[i]);
     }
@@ -629,6 +1029,14 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(RequestContext 
     }
 
     std::vector<ErrorCode> results = cache_backend_->GetLocationIds(request_context, keys, out_location_ids);
+    if (results.size() != keys.size() || out_location_ids.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache location ids results[%lu] ids[%lu] mismatch keys[%lu]",
+                       results.size(),
+                       out_location_ids.size(),
+                       keys.size());
+        results.assign(keys.size(), EC_ERROR);
+        out_location_ids.assign(keys.size(), LocationIdVector{});
+    }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
@@ -641,8 +1049,9 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(RequestContext 
     LocationIdsPerKey persistent_location_ids;
     std::vector<ErrorCode> persistent_results =
         persistent_backend_->GetLocationIds(request_context, missing_keys, persistent_location_ids);
-    if (missing_keys.size() != persistent_location_ids.size()) {
-        KVCM_LOG_ERROR("persistent_location_ids size[%lu] mismatch keys's[%lu]",
+    if (missing_keys.size() != persistent_results.size() || missing_keys.size() != persistent_location_ids.size()) {
+        KVCM_LOG_ERROR("persistent location ids results[%lu] ids[%lu] mismatch keys[%lu]",
+                       persistent_results.size(),
                        persistent_location_ids.size(),
                        missing_keys.size());
         for (size_t i = 0; i < missing_keys.size(); ++i) {
@@ -669,6 +1078,14 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetProperties(RequestContext *
     }
 
     std::vector<ErrorCode> results = cache_backend_->GetProperties(request_context, keys, field_names, out_properties);
+    if (results.size() != keys.size() || out_properties.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache GetProperties results[%lu] properties[%lu] mismatch keys[%lu]",
+                       results.size(),
+                       out_properties.size(),
+                       keys.size());
+        results.assign(keys.size(), EC_ERROR);
+        out_properties.assign(keys.size(), PropertyMap{});
+    }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
@@ -681,11 +1098,15 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetProperties(RequestContext *
     PropertyMapVector persistent_properties;
     std::vector<ErrorCode> persistent_results =
         persistent_backend_->GetProperties(request_context, missing_keys, field_names, persistent_properties);
-    if (missing_keys.size() != persistent_properties.size()) {
-        KVCM_LOG_ERROR(
-            "persistent_properties size[%lu] mismatch keys's[%lu]", persistent_properties.size(), missing_keys.size());
+    if (missing_keys.size() != persistent_results.size() || missing_keys.size() != persistent_properties.size()) {
+        KVCM_LOG_ERROR("persistent GetProperties results[%lu] properties[%lu] mismatch keys[%lu]",
+                       persistent_results.size(),
+                       persistent_properties.size(),
+                       missing_keys.size());
         for (size_t i = 0; i < missing_keys.size(); ++i) {
-            results[missing_indices[i]] = EC_ERROR;
+            const size_t original_idx = missing_indices[i];
+            results[original_idx] = EC_ERROR;
+            out_properties[original_idx].clear();
         }
         return results;
     }
@@ -706,6 +1127,14 @@ std::vector<ErrorCode> MetaStorageBackendManager::Exists(RequestContext *request
         return persistent_backend_->Exists(request_context, keys, out_is_exist_vec);
     }
     std::vector<ErrorCode> results = cache_backend_->Exists(request_context, keys, out_is_exist_vec);
+    if (results.size() != keys.size() || out_is_exist_vec.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache Exists results[%lu] values[%lu] mismatch keys[%lu]",
+                       results.size(),
+                       out_is_exist_vec.size(),
+                       keys.size());
+        results.assign(keys.size(), EC_ERROR);
+        out_is_exist_vec.assign(keys.size(), false);
+    }
     if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
         return results;
     }
@@ -725,11 +1154,15 @@ std::vector<ErrorCode> MetaStorageBackendManager::Exists(RequestContext *request
     std::vector<bool> persistent_exists;
     std::vector<ErrorCode> persistent_results =
         persistent_backend_->Exists(request_context, missing_keys, persistent_exists);
-    if (missing_keys.size() != persistent_exists.size()) {
-        KVCM_LOG_ERROR(
-            "persistent_exists size[%lu] mismatch missing_keys's[%lu]", persistent_exists.size(), missing_keys.size());
+    if (missing_keys.size() != persistent_results.size() || missing_keys.size() != persistent_exists.size()) {
+        KVCM_LOG_ERROR("persistent Exists results[%lu] values[%lu] mismatch keys[%lu]",
+                       persistent_results.size(),
+                       persistent_exists.size(),
+                       missing_keys.size());
         for (size_t i = 0; i < missing_keys.size(); ++i) {
-            results[missing_indices[i]] = EC_ERROR;
+            const size_t original_idx = missing_indices[i];
+            results[original_idx] = EC_ERROR;
+            out_is_exist_vec[original_idx] = false;
         }
         return results;
     }

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/meta/meta_storage_backend_manager.h"
 
+#include <algorithm>
 #include <cassert>
 #include <climits>
 #include <utility>
@@ -518,6 +519,56 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetLocations(RequestContext *r
     return results;
 }
 
+std::vector<ErrorCode> MetaStorageBackendManager::GetLocationValues(RequestContext *request_context,
+                                                                    const KeyVector &keys,
+                                                                    LocationsPerKey &out_locations) noexcept {
+    if (!cache_backend_) {
+        return persistent_backend_->GetLocationValues(request_context, keys, out_locations);
+    }
+
+    std::vector<ErrorCode> results = cache_backend_->GetLocationValues(request_context, keys, out_locations);
+    if (results.size() != keys.size() || out_locations.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache location values results[%lu] locations[%lu] mismatch keys[%lu]",
+                       results.size(),
+                       out_locations.size(),
+                       keys.size());
+        std::vector<ErrorCode> normalized_results(keys.size(), EC_ERROR);
+        std::copy_n(results.begin(), std::min(results.size(), keys.size()), normalized_results.begin());
+        results = std::move(normalized_results);
+        out_locations.resize(keys.size());
+    }
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        return results;
+    }
+
+    auto [missing_keys, missing_indices] = CollectMissingKeys(keys, results);
+    if (missing_keys.empty()) {
+        return results;
+    }
+
+    LocationsPerKey persistent_locations;
+    std::vector<ErrorCode> persistent_results =
+        persistent_backend_->GetLocationValues(request_context, missing_keys, persistent_locations);
+    if (missing_keys.size() != persistent_results.size() || missing_keys.size() != persistent_locations.size()) {
+        KVCM_LOG_ERROR("persistent location values results[%lu] locations[%lu] mismatch keys[%lu]",
+                       persistent_results.size(),
+                       persistent_locations.size(),
+                       missing_keys.size());
+        for (size_t i = 0; i < missing_keys.size(); ++i) {
+            results[missing_indices[i]] = EC_ERROR;
+        }
+        return results;
+    }
+    for (size_t i = 0; i < missing_keys.size(); ++i) {
+        const size_t original_idx = missing_indices[i];
+        results[original_idx] = persistent_results[i];
+        if (persistent_results[i] == EC_OK) {
+            out_locations[original_idx] = std::move(persistent_locations[i]);
+        }
+    }
+    return results;
+}
+
 std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(RequestContext *request_context,
                                                                             const KeyVector &keys,
                                                                             const LocationIdsPerKey &location_ids,
@@ -563,6 +614,11 @@ std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(Requ
         out_locations[original_idx] = std::move(persistent_locations[i]);
     }
     return results;
+}
+
+bool MetaStorageBackendManager::SupportsConcurrentLocationValueReads() const noexcept {
+    return !cache_backend_ && persistent_backend_ &&
+           persistent_backend_->GetStorageType() == META_LOCAL_BACKEND_TYPE_STR;
 }
 
 std::vector<ErrorCode> MetaStorageBackendManager::GetLocationIds(RequestContext *request_context,

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -1016,6 +1016,106 @@ std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(Requ
     return results;
 }
 
+std::vector<std::vector<ErrorCode>>
+MetaStorageBackendManager::GetLocationsWithKeyStatus(RequestContext *request_context,
+                                                     const KeyVector &keys,
+                                                     const LocationIdsPerKey &location_ids,
+                                                     LocationsPerKey &out_locations,
+                                                     std::vector<ErrorCode> &out_key_error_codes) noexcept {
+    if (keys.size() != location_ids.size()) {
+        out_locations.assign(keys.size(), CacheLocationVector{});
+        out_key_error_codes.assign(keys.size(), EC_BADARGS);
+        return std::vector<std::vector<ErrorCode>>(keys.size(), std::vector<ErrorCode>{EC_BADARGS});
+    }
+    if (!cache_backend_) {
+        return persistent_backend_->GetLocationsWithKeyStatus(
+            request_context, keys, location_ids, out_locations, out_key_error_codes);
+    }
+
+    std::vector<std::vector<ErrorCode>> results = cache_backend_->GetLocationsWithKeyStatus(
+        request_context, keys, location_ids, out_locations, out_key_error_codes);
+    auto response_shape_valid = [&keys, &location_ids](const std::vector<std::vector<ErrorCode>> &per_location_ecs,
+                                                       const LocationsPerKey &locations,
+                                                       const std::vector<ErrorCode> &per_key_ecs) {
+        if (per_location_ecs.size() != keys.size() || locations.size() != keys.size() ||
+            per_key_ecs.size() != keys.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (per_location_ecs[i].size() != location_ids[i].size() || locations[i].size() != location_ids[i].size()) {
+                return false;
+            }
+        }
+        return true;
+    };
+    if (!response_shape_valid(results, out_locations, out_key_error_codes)) {
+        KVCM_LOG_ERROR("cache targeted GetLocationsWithKeyStatus response shape mismatch keys[%lu]", keys.size());
+        out_locations.resize(keys.size());
+        results.resize(keys.size());
+        out_key_error_codes.assign(keys.size(), EC_ERROR);
+        for (size_t i = 0; i < keys.size(); ++i) {
+            out_locations[i].assign(location_ids[i].size(), CacheLocationConstPtr{});
+            results[i].assign(location_ids[i].size(), EC_ERROR);
+        }
+        return results;
+    }
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        return results;
+    }
+
+    KeyVector missing_keys;
+    std::vector<size_t> missing_indices;
+    LocationIdsPerKey missing_location_ids;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (out_key_error_codes[i] == EC_NOENT) {
+            missing_keys.push_back(keys[i]);
+            missing_indices.push_back(i);
+            missing_location_ids.push_back(location_ids[i]);
+        }
+    }
+    if (missing_keys.empty()) {
+        return results;
+    }
+
+    LocationsPerKey persistent_locations;
+    std::vector<ErrorCode> persistent_key_error_codes;
+    std::vector<std::vector<ErrorCode>> persistent_results = persistent_backend_->GetLocationsWithKeyStatus(
+        request_context, missing_keys, missing_location_ids, persistent_locations, persistent_key_error_codes);
+    const auto persistent_shape_valid =
+        [&missing_keys, &missing_location_ids](const std::vector<std::vector<ErrorCode>> &per_location_ecs,
+                                               const LocationsPerKey &locations,
+                                               const std::vector<ErrorCode> &per_key_ecs) {
+            if (per_location_ecs.size() != missing_keys.size() || locations.size() != missing_keys.size() ||
+                per_key_ecs.size() != missing_keys.size()) {
+                return false;
+            }
+            for (size_t i = 0; i < missing_keys.size(); ++i) {
+                if (per_location_ecs[i].size() != missing_location_ids[i].size() ||
+                    locations[i].size() != missing_location_ids[i].size()) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    if (!persistent_shape_valid(persistent_results, persistent_locations, persistent_key_error_codes)) {
+        KVCM_LOG_ERROR("persistent targeted GetLocationsWithKeyStatus response shape mismatch keys[%lu]",
+                       missing_keys.size());
+        for (const size_t original_index : missing_indices) {
+            results[original_index].assign(location_ids[original_index].size(), EC_ERROR);
+            out_locations[original_index].assign(location_ids[original_index].size(), CacheLocationConstPtr{});
+            out_key_error_codes[original_index] = EC_ERROR;
+        }
+        return results;
+    }
+    for (size_t i = 0; i < missing_keys.size(); ++i) {
+        const size_t original_index = missing_indices[i];
+        results[original_index] = std::move(persistent_results[i]);
+        out_locations[original_index] = std::move(persistent_locations[i]);
+        out_key_error_codes[original_index] = persistent_key_error_codes[i];
+    }
+    return results;
+}
+
 bool MetaStorageBackendManager::SupportsConcurrentLocationValueReads() const noexcept {
     return !cache_backend_ && persistent_backend_ &&
            persistent_backend_->GetStorageType() == META_LOCAL_BACKEND_TYPE_STR;

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -67,6 +67,11 @@ public:
                                                      const KeyVector &keys,
                                                      const LocationIdsPerKey &location_ids,
                                                      LocationsPerKey &out_locations) noexcept;
+    std::vector<std::vector<ErrorCode>> GetLocationsWithKeyStatus(RequestContext *request_context,
+                                                                  const KeyVector &keys,
+                                                                  const LocationIdsPerKey &location_ids,
+                                                                  LocationsPerKey &out_locations,
+                                                                  std::vector<ErrorCode> &out_key_error_codes) noexcept;
     std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
                                           const KeyVector &keys,
                                           LocationIdsPerKey &out_location_ids) noexcept;

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -61,6 +61,8 @@ public:
     std::vector<ErrorCode> GetLocations(RequestContext *request_context,
                                         const KeyVector &keys,
                                         CacheLocationMapVector &out_location_maps) noexcept;
+    std::vector<ErrorCode>
+    GetLocationValues(RequestContext *request_context, const KeyVector &keys, LocationsPerKey &out_locations) noexcept;
     std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *request_context,
                                                      const KeyVector &keys,
                                                      const LocationIdsPerKey &location_ids,
@@ -99,6 +101,11 @@ public:
 
     // Set revisit interval histogram for cache backend (optional, for metrics tracking).
     void SetRevisitHistogram(std::shared_ptr<RevisitIntervalHistogram> histogram);
+
+    // Only the single local backend is safe and useful to fan out: its cache
+    // and items are independently sharded/locked and it ignores RequestContext.
+    // Redis and cached modes retain their existing batched request semantics.
+    bool SupportsConcurrentLocationValueReads() const noexcept;
 
 private:
     void AsyncRecoverTask() noexcept;

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -112,9 +112,14 @@ private:
     int64_t BackfillKeysToCache(const KeyTypeVec &keys,
                                 const CacheLocationMapVector &locations,
                                 const PropertyMapVector &properties,
-                                const std::vector<ErrorCode> &get_error_codes) noexcept;
-    // Hydrate missing keys from persistent into cache during Recover.
-    void EnsureKeyInCache(RequestContext *request_context, const KeyTypeVec &keys) noexcept;
+                                const std::vector<ErrorCode> &get_error_codes,
+                                // Reports whether every source entry and
+                                // conditional cache write completed safely.
+                                bool *out_success = nullptr) noexcept;
+    // Hydrate missing keys from persistent into cache during Recover. Returns
+    // false when a backend violates the positional response contract or the
+    // full pre-update value cannot be made available safely.
+    bool EnsureKeyInCache(RequestContext *request_context, const KeyTypeVec &keys) noexcept;
     // Delete keys that have no remaining location fields. Returns reclaimed count.
     int32_t MaybeReclaimEmptyKeys(RequestContext *request_context,
                                   const KeyVector &keys,
@@ -127,6 +132,11 @@ private:
     std::atomic<RecoverState> recover_state_{RecoverState::kRecover};
     std::atomic<bool> is_closed_{false};
     std::thread recover_thread_;
+    // Serializes lifecycle transitions and prevents assigning a second
+    // recovery thread over an already-joinable std::thread (which would call
+    // std::terminate even though Open() is noexcept).
+    mutable std::mutex lifecycle_mutex_;
+    bool opened_ = false;
 
     mutable std::mutex deleted_keys_mutex_;
     std::unordered_set<KeyType> deleted_keys_;

--- a/kv_cache_manager/meta/query_executor.cc
+++ b/kv_cache_manager/meta/query_executor.cc
@@ -55,8 +55,25 @@ QueryExecutor::QueryExecutor(std::size_t worker_count,
     , chunk_size_(std::max<std::size_t>(1, chunk_size))
     , queue_capacity_(std::max<std::size_t>(1, queue_capacity)) {
     workers_.reserve(worker_count_ - 1);
-    for (std::size_t i = 1; i < worker_count_; ++i) {
-        workers_.emplace_back([this] { WorkerLoop(); });
+    try {
+        for (std::size_t i = 1; i < worker_count_; ++i) {
+            workers_.emplace_back([this] { WorkerLoop(); });
+        }
+    } catch (...) {
+        // A partially constructed vector of joinable std::threads would call
+        // std::terminate during stack unwinding. Stop and join every worker
+        // that was created before propagating the construction failure.
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        condition_.notify_all();
+        for (auto &worker : workers_) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+        throw;
     }
 }
 
@@ -129,48 +146,66 @@ bool QueryExecutor::ParallelFor(std::size_t count, const RangeFunction &fn) cons
         return false;
     }
 
-    auto state = std::make_shared<ParallelState>();
-    auto fn_holder = std::make_shared<RangeFunction>(fn);
-    auto run_ranges = [state, fn_holder, count, chunk_size = chunk_size_]() noexcept {
-        while (true) {
-            const std::size_t begin = state->next.fetch_add(chunk_size, std::memory_order_relaxed);
-            if (begin >= count) {
-                return;
-            }
-            const std::size_t end = std::min(count, begin + chunk_size);
-            try {
-                (*fn_holder)(begin, end);
-            } catch (const std::exception &e) {
-                state->failed.store(true, std::memory_order_relaxed);
-                KVCM_LOG_ERROR("query executor parallel callback threw exception: %s", e.what());
-            } catch (...) {
-                state->failed.store(true, std::memory_order_relaxed);
-                KVCM_LOG_ERROR("query executor parallel callback threw unknown exception");
-            }
-        }
-    };
-
-    for (std::size_t i = 1; i < parallelism; ++i) {
-        if (!TrySubmit([state, run_ranges] {
-                // The caller may have consumed every range while this task was
-                // waiting behind another request. In that case it cancels the
-                // queued helper and returns without waiting for a no-op task to
-                // reach the head of the global queue.
-                if (!state->TryStartWorker()) {
+    std::shared_ptr<ParallelState> state;
+    try {
+        state = std::make_shared<ParallelState>();
+        auto fn_holder = std::make_shared<RangeFunction>(fn);
+        auto run_ranges = [state, fn_holder, count, chunk_size = chunk_size_]() noexcept {
+            while (true) {
+                const std::size_t begin = state->next.fetch_add(chunk_size, std::memory_order_relaxed);
+                if (begin >= count) {
                     return;
                 }
-                run_ranges();
-                state->CompleteWorker();
-            })) {
-            // The caller and any admitted workers consume every range via the
-            // shared atomic cursor when the bounded queue is full.
-            break;
-        }
-    }
+                const std::size_t end = std::min(count, begin + chunk_size);
+                try {
+                    (*fn_holder)(begin, end);
+                } catch (const std::exception &e) {
+                    state->failed.store(true, std::memory_order_relaxed);
+                    KVCM_LOG_ERROR("query executor parallel callback threw exception: %s", e.what());
+                } catch (...) {
+                    state->failed.store(true, std::memory_order_relaxed);
+                    KVCM_LOG_ERROR("query executor parallel callback threw unknown exception");
+                }
+            }
+        };
 
-    run_ranges();
-    state->StopWorkersAndWait();
-    return !state->failed.load(std::memory_order_relaxed);
+        for (std::size_t i = 1; i < parallelism; ++i) {
+            if (!TrySubmit([state, run_ranges] {
+                    // The caller may have consumed every range while this task was
+                    // waiting behind another request. In that case it cancels the
+                    // queued helper and returns without waiting for a no-op task to
+                    // reach the head of the global queue.
+                    if (!state->TryStartWorker()) {
+                        return;
+                    }
+                    run_ranges();
+                    state->CompleteWorker();
+                })) {
+                // The caller and any admitted workers consume every range via the
+                // shared atomic cursor when the bounded queue is full.
+                break;
+            }
+        }
+
+        run_ranges();
+        state->StopWorkersAndWait();
+        return !state->failed.load(std::memory_order_relaxed);
+    } catch (const std::exception &e) {
+        // ParallelFor is noexcept. Allocation or queue growth failure must be
+        // reported as a failed query instead of terminating the server. Tasks
+        // admitted before the exception may capture request-local references,
+        // so drain active helpers before returning.
+        if (state) {
+            state->StopWorkersAndWait();
+        }
+        KVCM_LOG_ERROR("query executor failed to schedule parallel query: %s", e.what());
+    } catch (...) {
+        if (state) {
+            state->StopWorkersAndWait();
+        }
+        KVCM_LOG_ERROR("query executor failed to schedule parallel query with unknown exception");
+    }
+    return false;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/query_executor.cc
+++ b/kv_cache_manager/meta/query_executor.cc
@@ -1,0 +1,176 @@
+#include "kv_cache_manager/meta/query_executor.h"
+
+#include <algorithm>
+#include <atomic>
+#include <exception>
+#include <memory>
+
+#include "kv_cache_manager/common/logger.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+thread_local const QueryExecutor *current_query_executor = nullptr;
+
+struct ParallelState {
+    std::atomic<std::size_t> next{0};
+    std::atomic<bool> failed{false};
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool accepting_workers = true;
+    std::size_t active_workers = 0;
+
+    bool TryStartWorker() {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!accepting_workers) {
+            return false;
+        }
+        ++active_workers;
+        return true;
+    }
+
+    void CompleteWorker() {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (--active_workers == 0) {
+            condition.notify_all();
+        }
+    }
+
+    void StopWorkersAndWait() {
+        std::unique_lock<std::mutex> lock(mutex);
+        accepting_workers = false;
+        condition.wait(lock, [this] { return active_workers == 0; });
+    }
+};
+
+} // namespace
+
+QueryExecutor::QueryExecutor(std::size_t worker_count,
+                             std::size_t parallel_threshold,
+                             std::size_t chunk_size,
+                             std::size_t queue_capacity)
+    : worker_count_(std::max<std::size_t>(1, worker_count))
+    , parallel_threshold_(std::max<std::size_t>(1, parallel_threshold))
+    , chunk_size_(std::max<std::size_t>(1, chunk_size))
+    , queue_capacity_(std::max<std::size_t>(1, queue_capacity)) {
+    workers_.reserve(worker_count_ - 1);
+    for (std::size_t i = 1; i < worker_count_; ++i) {
+        workers_.emplace_back([this] { WorkerLoop(); });
+    }
+}
+
+QueryExecutor::~QueryExecutor() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stopping_ = true;
+    }
+    condition_.notify_all();
+    for (auto &worker : workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+}
+
+bool QueryExecutor::TrySubmit(std::function<void()> task) const {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (stopping_ || tasks_.size() >= queue_capacity_) {
+            return false;
+        }
+        tasks_.push_back(std::move(task));
+    }
+    condition_.notify_one();
+    return true;
+}
+
+void QueryExecutor::WorkerLoop() {
+    current_query_executor = this;
+    while (true) {
+        std::function<void()> task;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+            if (stopping_ && tasks_.empty()) {
+                break;
+            }
+            task = std::move(tasks_.front());
+            tasks_.pop_front();
+        }
+        task();
+    }
+    current_query_executor = nullptr;
+}
+
+bool QueryExecutor::ParallelFor(std::size_t count, const RangeFunction &fn) const noexcept {
+    if (count == 0) {
+        return true;
+    }
+    if (worker_count_ <= 1 || count < parallel_threshold_ || current_query_executor == this) {
+        try {
+            fn(0, count);
+            return true;
+        } catch (const std::exception &e) {
+            KVCM_LOG_ERROR("query executor serial callback threw exception: %s", e.what());
+        } catch (...) { KVCM_LOG_ERROR("query executor serial callback threw unknown exception"); }
+        return false;
+    }
+
+    const std::size_t chunk_count = 1 + (count - 1) / chunk_size_;
+    const std::size_t parallelism = std::min(worker_count_, chunk_count);
+    if (parallelism <= 1) {
+        try {
+            fn(0, count);
+            return true;
+        } catch (const std::exception &e) {
+            KVCM_LOG_ERROR("query executor callback threw exception: %s", e.what());
+        } catch (...) { KVCM_LOG_ERROR("query executor callback threw unknown exception"); }
+        return false;
+    }
+
+    auto state = std::make_shared<ParallelState>();
+    auto fn_holder = std::make_shared<RangeFunction>(fn);
+    auto run_ranges = [state, fn_holder, count, chunk_size = chunk_size_]() noexcept {
+        while (true) {
+            const std::size_t begin = state->next.fetch_add(chunk_size, std::memory_order_relaxed);
+            if (begin >= count) {
+                return;
+            }
+            const std::size_t end = std::min(count, begin + chunk_size);
+            try {
+                (*fn_holder)(begin, end);
+            } catch (const std::exception &e) {
+                state->failed.store(true, std::memory_order_relaxed);
+                KVCM_LOG_ERROR("query executor parallel callback threw exception: %s", e.what());
+            } catch (...) {
+                state->failed.store(true, std::memory_order_relaxed);
+                KVCM_LOG_ERROR("query executor parallel callback threw unknown exception");
+            }
+        }
+    };
+
+    for (std::size_t i = 1; i < parallelism; ++i) {
+        if (!TrySubmit([state, run_ranges] {
+                // The caller may have consumed every range while this task was
+                // waiting behind another request. In that case it cancels the
+                // queued helper and returns without waiting for a no-op task to
+                // reach the head of the global queue.
+                if (!state->TryStartWorker()) {
+                    return;
+                }
+                run_ranges();
+                state->CompleteWorker();
+            })) {
+            // The caller and any admitted workers consume every range via the
+            // shared atomic cursor when the bounded queue is full.
+            break;
+        }
+    }
+
+    run_ranges();
+    state->StopWorkersAndWait();
+    return !state->failed.load(std::memory_order_relaxed);
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/meta/query_executor.h
+++ b/kv_cache_manager/meta/query_executor.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace kv_cache_manager {
+
+// Process-local, bounded executor for latency-sensitive metadata queries.
+//
+// The calling RPC thread always participates in ParallelFor. worker_count is
+// therefore the maximum parallelism of one query, not the number of background
+// threads: an executor configured with N workers owns N - 1 threads. A bounded
+// queue prevents concurrent large requests from creating unbounded work; when
+// admission fails, the caller and any already-admitted workers finish the
+// remaining chunks themselves.
+class QueryExecutor {
+public:
+    using RangeFunction = std::function<void(std::size_t begin, std::size_t end)>;
+
+    QueryExecutor(std::size_t worker_count,
+                  std::size_t parallel_threshold,
+                  std::size_t chunk_size,
+                  std::size_t queue_capacity);
+    ~QueryExecutor();
+
+    QueryExecutor(const QueryExecutor &) = delete;
+    QueryExecutor &operator=(const QueryExecutor &) = delete;
+
+    // Runs fn over disjoint half-open ranges that cover [0, count). Returns
+    // false only if a callback throws. Calls made recursively from this
+    // executor's own worker thread deliberately fall back to serial execution
+    // so a task can never wait for the pool that is currently running it.
+    bool ParallelFor(std::size_t count, const RangeFunction &fn) const noexcept;
+
+    [[nodiscard]] std::size_t worker_count() const noexcept { return worker_count_; }
+    [[nodiscard]] std::size_t parallel_threshold() const noexcept { return parallel_threshold_; }
+    [[nodiscard]] std::size_t chunk_size() const noexcept { return chunk_size_; }
+
+private:
+    bool TrySubmit(std::function<void()> task) const;
+    void WorkerLoop();
+
+private:
+    std::size_t worker_count_ = 1;
+    std::size_t parallel_threshold_ = 1;
+    std::size_t chunk_size_ = 1;
+    std::size_t queue_capacity_ = 1;
+
+    mutable std::mutex mutex_;
+    mutable std::condition_variable condition_;
+    mutable std::deque<std::function<void()>> tasks_;
+    mutable bool stopping_ = false;
+    std::vector<std::thread> workers_;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/meta/query_executor.h
+++ b/kv_cache_manager/meta/query_executor.h
@@ -32,9 +32,10 @@ public:
     QueryExecutor &operator=(const QueryExecutor &) = delete;
 
     // Runs fn over disjoint half-open ranges that cover [0, count). Returns
-    // false only if a callback throws. Calls made recursively from this
-    // executor's own worker thread deliberately fall back to serial execution
-    // so a task can never wait for the pool that is currently running it.
+    // false if a callback throws or the parallel work cannot be allocated or
+    // scheduled. Calls made recursively from this executor's own worker thread
+    // deliberately fall back to serial execution so a task can never wait for
+    // the pool that is currently running it.
     bool ParallelFor(std::size_t count, const RangeFunction &fn) const noexcept;
 
     [[nodiscard]] std::size_t worker_count() const noexcept { return worker_count_; }

--- a/kv_cache_manager/meta/test/BUILD
+++ b/kv_cache_manager/meta/test/BUILD
@@ -1,5 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
+cc_test(
+    name = "query_executor_test",
+    srcs = ["query_executor_test.cc"],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/meta:query_executor",
+    ],
+)
+
 cc_library(
     name = "meta_indexer_testlib",
     srcs = [
@@ -23,8 +32,8 @@ cc_test(
     copts = ["-fno-access-control"],
     data = [],
     deps = [
-        "//kv_cache_manager/common:unittest",
         ":meta_indexer_testlib",
+        "//kv_cache_manager/common:unittest",
     ],
 )
 
@@ -66,8 +75,8 @@ cc_library(
     copts = ["-fno-access-control"],
     deps = [
         "//kv_cache_manager/meta:meta_cache_base_backend",
-        "//kv_cache_manager/meta:meta_storage_backend",
         "//kv_cache_manager/meta:meta_redis_backend",
+        "//kv_cache_manager/meta:meta_storage_backend",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -122,13 +131,13 @@ cc_test(
     ],
     copts = ["-fno-access-control"],
     data = [],
-    deps = [
-        "//kv_cache_manager/common:unittest",
-        "//kv_cache_manager/meta:meta_redis_backend",
-    ],
     tags = [
         "manual",
         "redis",
+    ],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/meta:meta_redis_backend",
     ],
 )
 
@@ -139,13 +148,13 @@ cc_test(
     ],
     copts = ["-fno-access-control"],
     data = [],
-    deps = [
-        "//kv_cache_manager/common:unittest",
-        ":meta_indexer_testlib",
-    ],
     tags = [
         "manual",
         "redis",
+    ],
+    deps = [
+        ":meta_indexer_testlib",
+        "//kv_cache_manager/common:unittest",
     ],
 )
 
@@ -204,6 +213,10 @@ cc_test(
     ],
     copts = ["-fno-access-control"],
     data = [],
+    tags = [
+        "manual",
+        "redis",
+    ],
     deps = [
         "//kv_cache_manager/common:unittest",
         "//kv_cache_manager/meta:cache_location",
@@ -211,9 +224,5 @@ cc_test(
         "//kv_cache_manager/meta:meta_storage_backend",
         "//kv_cache_manager/meta:meta_storage_backend_manager",
         "//kv_cache_manager/meta:types",
-    ],
-    tags = [
-        "manual",
-        "redis",
     ],
 )

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -103,6 +103,35 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaDummyBackendTest, TestGenericTargetedLocationsPreserveKeyStatus) {
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("targeted_status", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id("target");
+    CacheLocationMapVector locations(2);
+    locations[0].emplace("target", location);
+    PropertyMapVector properties(2);
+    properties[1].emplace("property_only", "value");
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              meta_storage_backend_->Put(nullptr, {1, 2}, locations, properties));
+
+    LocationsPerKey selected;
+    std::vector<ErrorCode> key_error_codes;
+    const auto per_location_ecs = meta_storage_backend_->GetLocationsWithKeyStatus(
+        nullptr, {1, 2, 3}, {{"target"}, {"target"}, {"target"}}, selected, key_error_codes);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}), key_error_codes);
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}, {EC_NOENT}, {EC_NOENT}}), per_location_ecs);
+    ASSERT_EQ(3u, selected.size());
+    ASSERT_EQ(1u, selected[0].size());
+    ASSERT_TRUE(selected[0][0]);
+    EXPECT_EQ("target", selected[0][0]->id());
+    ASSERT_EQ(1u, selected[1].size());
+    EXPECT_FALSE(selected[1][0]);
+    ASSERT_EQ(1u, selected[2].size());
+    EXPECT_FALSE(selected[2][0]);
+}
+
 TEST_F(MetaDummyBackendTest, TestInit) {
     // invalid config
     ASSERT_NE(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));

--- a/kv_cache_manager/meta/test/meta_indexer_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_manager_test.cc
@@ -8,6 +8,7 @@
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 #include "kv_cache_manager/meta/meta_local_backend.h"
 #include "kv_cache_manager/meta/meta_storage_backend.h"
+#include "kv_cache_manager/meta/query_executor.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 namespace kv_cache_manager {
 
@@ -103,6 +104,26 @@ TEST_F(MetaIndexerManagerTest, TestCreateFailed) {
     std::string id_1 = "1";
     ASSERT_EQ(ErrorCode::EC_ERROR, CreateMetaIndexer(id_1, "test"));
     ASSERT_EQ(0, manager_->GetIndexerSize());
+}
+
+TEST_F(MetaIndexerManagerTest, TestConfigureQueryExecutorBeforeCreatingIndexers) {
+    EXPECT_FALSE(manager_->ConfigureQueryExecutor(0, 256, 128));
+    EXPECT_FALSE(manager_->ConfigureQueryExecutor(65, 256, 128));
+    EXPECT_FALSE(manager_->ConfigureQueryExecutor(4, 0, 128));
+    EXPECT_FALSE(manager_->ConfigureQueryExecutor(4, 256, 0));
+    EXPECT_FALSE(manager_->ConfigureQueryExecutor(4, 128, 256));
+
+    ASSERT_TRUE(manager_->ConfigureQueryExecutor(4, 256, 128));
+    ASSERT_TRUE(manager_->query_executor_);
+    EXPECT_EQ(4u, manager_->query_executor_->worker_count());
+    EXPECT_EQ(256u, manager_->query_executor_->parallel_threshold());
+    EXPECT_EQ(128u, manager_->query_executor_->chunk_size());
+
+    ASSERT_EQ(EC_OK, CreateMetaIndexer("configured", META_LOCAL_BACKEND_TYPE_STR));
+    const auto indexer = manager_->GetMetaIndexer("configured");
+    ASSERT_TRUE(indexer);
+    EXPECT_EQ(manager_->query_executor_, indexer->query_executor_);
+    EXPECT_FALSE(manager_->ConfigureQueryExecutor(2, 64, 32));
 }
 
 TEST_F(MetaIndexerManagerTest, TestDoCleanup) {

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -16,6 +16,7 @@
 #include "kv_cache_manager/meta/meta_search_cache.h"
 #include "kv_cache_manager/meta/meta_storage_backend.h"
 #include "kv_cache_manager/meta/meta_storage_backend_manager.h"
+#include "kv_cache_manager/meta/query_executor.h"
 #include "kv_cache_manager/meta/storage_usage_data.h"
 #include "kv_cache_manager/meta/types.h"
 #include "kv_cache_manager/meta/utils.h"
@@ -114,6 +115,59 @@ TEST_F(MetaIndexerTest, TestProcessErrorCodesRejectsAbnormalResultCount) {
                   "trace", {EC_OK, EC_OK, EC_OK, EC_OK}, {}, keys, "test_long_result", long_result));
     EXPECT_EQ(EC_MISMATCH, long_result.ec);
     EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH, EC_MISMATCH, EC_MISMATCH}), long_result.error_codes);
+}
+
+TEST_F(MetaIndexerTest, TestParallelLocalLocationValuesMatchSerialAndPreserveErrors) {
+    constexpr std::size_t kKeyCount = 1024;
+    meta_indexer_->SetQueryExecutor(std::make_shared<QueryExecutor>(
+        /*worker_count*/ 4, /*parallel_threshold*/ 64, /*chunk_size*/ 32, /*queue_capacity*/ 32));
+    const std::string config_str = R"({
+        "max_key_count" : 2048,
+        "mutex_shard_num" : 64,
+        "batch_key_size" : 128,
+        "meta_storage_backend_config" : { "storage_type" : "local" },
+        "meta_cache_policy_config" : { "capacity" : 0 }
+    })";
+    ASSERT_EQ(EC_OK, InitIndexer(config_str));
+
+    KVData data;
+    MakeKVData(0, kKeyCount, data);
+    ASSERT_EQ(EC_OK, meta_indexer_->Put(request_context_.get(), data.keys, data.location_maps, data.properties).ec);
+
+    KeyVector query_keys = data.keys;
+    constexpr std::size_t kMissingIndex = 333;
+    query_keys[kMissingIndex] = 100000;
+    LocationsPerKey parallel_values;
+    const auto parallel_result = meta_indexer_->GetLocationValues(request_context_.get(), query_keys, parallel_values);
+    ASSERT_EQ(EC_PARTIAL_OK, parallel_result.ec);
+    ASSERT_EQ(kKeyCount, parallel_result.error_codes.size());
+    ASSERT_EQ(kKeyCount, parallel_values.size());
+    for (std::size_t i = 0; i < kKeyCount; ++i) {
+        if (i == kMissingIndex) {
+            EXPECT_EQ(EC_NOENT, parallel_result.error_codes[i]);
+            EXPECT_TRUE(parallel_values[i].empty());
+            continue;
+        }
+        EXPECT_EQ(EC_OK, parallel_result.error_codes[i]) << "index=" << i;
+        ASSERT_EQ(1u, parallel_values[i].size()) << "index=" << i;
+        ASSERT_TRUE(parallel_values[i].front());
+        EXPECT_EQ("loc_" + std::to_string(query_keys[i]), parallel_values[i].front()->id());
+    }
+
+    meta_indexer_->SetQueryExecutor(std::make_shared<QueryExecutor>(
+        /*worker_count*/ 1, /*parallel_threshold*/ 64, /*chunk_size*/ 32, /*queue_capacity*/ 1));
+    LocationsPerKey serial_values;
+    const auto serial_result = meta_indexer_->GetLocationValues(request_context_.get(), query_keys, serial_values);
+    EXPECT_EQ(parallel_result.ec, serial_result.ec);
+    EXPECT_EQ(parallel_result.error_codes, serial_result.error_codes);
+    ASSERT_EQ(parallel_values.size(), serial_values.size());
+    for (std::size_t i = 0; i < parallel_values.size(); ++i) {
+        ASSERT_EQ(parallel_values[i].size(), serial_values[i].size()) << "index=" << i;
+        for (std::size_t j = 0; j < parallel_values[i].size(); ++j) {
+            ASSERT_TRUE(serial_values[i][j]);
+            EXPECT_EQ(parallel_values[i][j]->id(), serial_values[i][j]->id()) << "index=" << i;
+        }
+    }
 }
 
 // Verifies the invariants of MakeBatches() that callers rely on, regardless

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -13,6 +13,7 @@
 #include "kv_cache_manager/meta//test/meta_indexer_test_base.h"
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
+#include "kv_cache_manager/meta/meta_local_backend.h"
 #include "kv_cache_manager/meta/meta_search_cache.h"
 #include "kv_cache_manager/meta/meta_storage_backend.h"
 #include "kv_cache_manager/meta/meta_storage_backend_manager.h"
@@ -30,6 +31,59 @@ namespace {
 std::string GetPersistentStorageType(const MetaIndexer &indexer) {
     return indexer.backend_manager_->persistent_backend_->GetStorageType();
 }
+
+class MalformedLocationReadBackend : public MetaLocalBackend {
+public:
+    enum class Shape {
+        kShortOuter,
+        kShortInner,
+        kNullValueWithOk,
+    };
+
+    void SetShape(Shape shape) { shape_ = shape; }
+
+    std::vector<ErrorCode> GetLocations(RequestContext * /*request_context*/,
+                                        const KeyTypeVec & /*keys*/,
+                                        CacheLocationMapVector &out_locations) noexcept override {
+        out_locations.clear();
+        return {EC_OK};
+    }
+
+    std::vector<std::vector<ErrorCode>> GetLocations(RequestContext * /*request_context*/,
+                                                     const KeyTypeVec &keys,
+                                                     const LocationIdsPerKey &location_ids,
+                                                     LocationsPerKey &out_locations) noexcept override {
+        if (shape_ == Shape::kShortOuter) {
+            out_locations.clear();
+            return {};
+        }
+        if (shape_ == Shape::kShortInner) {
+            out_locations.assign(keys.size(), CacheLocationVector{});
+            return std::vector<std::vector<ErrorCode>>(keys.size());
+        }
+        out_locations.resize(keys.size());
+        std::vector<std::vector<ErrorCode>> result(keys.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            out_locations[i].assign(location_ids[i].size(), CacheLocationConstPtr{});
+            result[i].assign(location_ids[i].size(), EC_OK);
+        }
+        return result;
+    }
+
+    std::vector<ErrorCode> GetLocationValues(RequestContext * /*request_context*/,
+                                             const KeyTypeVec &keys,
+                                             LocationsPerKey &out_locations) noexcept override {
+        if (shape_ == Shape::kShortOuter) {
+            out_locations.clear();
+            return {EC_OK};
+        }
+        out_locations.assign(keys.size(), CacheLocationVector{});
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+private:
+    Shape shape_ = Shape::kShortOuter;
+};
 } // namespace
 
 class MetaIndexerTest : public MetaIndexerTestBase, public TESTBASE {
@@ -168,6 +222,123 @@ TEST_F(MetaIndexerTest, TestParallelLocalLocationValuesMatchSerialAndPreserveErr
             EXPECT_EQ(parallel_values[i][j]->id(), serial_values[i][j]->id()) << "index=" << i;
         }
     }
+}
+
+TEST_F(MetaIndexerTest, TestReadModifyWriteLocationRejectsMalformedBackendResultShapes) {
+    const std::string config_str = R"({
+        "max_key_count" : 100,
+        "mutex_shard_num" : 8,
+        "meta_storage_backend_config" : { "storage_type" : "local" },
+        "meta_cache_policy_config" : { "capacity" : 0 }
+    })";
+    ASSERT_EQ(EC_OK, InitIndexer(config_str));
+
+    auto malformed = std::make_unique<MalformedLocationReadBackend>();
+    auto backend_config = std::make_shared<MetaStorageBackendConfig>();
+    ASSERT_EQ(EC_OK, malformed->Init("test", backend_config));
+    ASSERT_EQ(EC_OK, malformed->Open());
+    auto *malformed_raw = malformed.get();
+    ASSERT_EQ(EC_OK, meta_indexer_->backend_manager_->persistent_backend_->Close());
+    meta_indexer_->backend_manager_->persistent_backend_ = std::move(malformed);
+    meta_indexer_->backend_manager_->cache_backend_.reset();
+
+    const KeyVector keys{123};
+    const LocationIdsPerKey location_ids{{"loc"}};
+    size_t modifier_calls = 0;
+    const auto modifier =
+        [&modifier_calls](
+            const std::vector<ErrorCode> &, const LocationIdVector &ids, size_t, CacheLocationVector &, PropertyMap &) {
+            ++modifier_calls;
+            return LocationModifierResult{ModifierAction::MA_SKIP, std::vector<ErrorCode>(ids.size(), EC_OK)};
+        };
+
+    auto result = meta_indexer_->ReadModifyWriteLocation(request_context_.get(), keys, location_ids, modifier);
+    EXPECT_EQ(EC_ERROR, result.ec);
+    ASSERT_EQ(1u, result.per_location_error_codes.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH}), result.per_location_error_codes[0]);
+    EXPECT_EQ(0u, modifier_calls);
+
+    malformed_raw->SetShape(MalformedLocationReadBackend::Shape::kShortInner);
+    result = meta_indexer_->ReadModifyWriteLocation(request_context_.get(), keys, location_ids, modifier);
+    EXPECT_EQ(EC_ERROR, result.ec);
+    ASSERT_EQ(1u, result.per_location_error_codes.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH}), result.per_location_error_codes[0]);
+    EXPECT_EQ(0u, modifier_calls);
+
+    malformed_raw->SetShape(MalformedLocationReadBackend::Shape::kNullValueWithOk);
+    result = meta_indexer_->ReadModifyWriteLocation(request_context_.get(), keys, location_ids, modifier);
+    EXPECT_EQ(EC_ERROR, result.ec);
+    ASSERT_EQ(1u, result.per_location_error_codes.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH}), result.per_location_error_codes[0]);
+    EXPECT_EQ(1u, modifier_calls);
+
+    LocationsPerKey locations;
+    auto get_result = meta_indexer_->GetLocations(request_context_.get(), keys, location_ids, locations);
+    EXPECT_EQ(EC_ERROR, get_result.ec);
+    ASSERT_EQ(1u, get_result.per_location_error_codes.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH}), get_result.per_location_error_codes[0]);
+    ASSERT_EQ(1u, locations.size());
+    ASSERT_EQ(1u, locations[0].size());
+    EXPECT_FALSE(locations[0][0]);
+
+    CacheLocationMapVector location_maps;
+    const auto get_all_result = meta_indexer_->GetLocations(request_context_.get(), keys, location_maps);
+    EXPECT_EQ(EC_ERROR, get_all_result.ec);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH}), get_all_result.error_codes);
+    ASSERT_EQ(1u, location_maps.size());
+    EXPECT_TRUE(location_maps[0].empty());
+
+    malformed_raw->SetShape(MalformedLocationReadBackend::Shape::kShortOuter);
+    LocationsPerKey location_values;
+    const KeyVector two_keys{123, 124};
+    const auto get_values_result = meta_indexer_->GetLocationValues(request_context_.get(), two_keys, location_values);
+    EXPECT_EQ(EC_ERROR, get_values_result.ec);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_MISMATCH, EC_MISMATCH}), get_values_result.error_codes);
+    ASSERT_EQ(2u, location_values.size());
+    EXPECT_TRUE(location_values[0].empty());
+    EXPECT_TRUE(location_values[1].empty());
+}
+
+TEST_F(MetaIndexerTest, TestReadModifyWriteLocationPreservesPartialModifierResult) {
+    const std::string config_str = R"({
+        "max_key_count" : 100,
+        "mutex_shard_num" : 8,
+        "meta_storage_backend_config" : { "storage_type" : "local" },
+        "meta_cache_policy_config" : { "capacity" : 0 }
+    })";
+    ASSERT_EQ(EC_OK, InitIndexer(config_str));
+
+    const KeyVector keys{124};
+    const LocationIdsPerKey location_ids{{"good", "bad"}};
+    const auto modifier = [](const std::vector<ErrorCode> &get_ecs,
+                             const LocationIdVector &ids,
+                             size_t,
+                             CacheLocationVector &locations,
+                             PropertyMap &) {
+        EXPECT_EQ((std::vector<ErrorCode>{EC_NOENT, EC_NOENT}), get_ecs);
+        auto good = std::make_shared<CacheLocation>();
+        good->set_id(ids[0]);
+        good->set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+        good->set_status(CLS_SERVING);
+        locations[0] = std::move(good);
+        return LocationModifierResult{MA_OK, {EC_OK, EC_BADARGS}};
+    };
+
+    const auto result = meta_indexer_->ReadModifyWriteLocation(request_context_.get(), keys, location_ids, modifier);
+    // The RMW itself succeeded. A per-location validation failure is surfaced
+    // in the aligned result without turning the whole batch into an
+    // infrastructure failure.
+    EXPECT_EQ(EC_OK, result.ec);
+    ASSERT_EQ(1u, result.per_location_error_codes.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_BADARGS}), result.per_location_error_codes[0]);
+
+    LocationsPerKey stored_locations;
+    const auto get_result = meta_indexer_->GetLocations(request_context_.get(), keys, location_ids, stored_locations);
+    EXPECT_EQ(EC_PARTIAL_OK, get_result.ec);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT}), get_result.per_location_error_codes[0]);
+    ASSERT_TRUE(stored_locations[0][0]);
+    EXPECT_EQ("good", stored_locations[0][0]->id());
+    EXPECT_FALSE(stored_locations[0][1]);
 }
 
 // Verifies the invariants of MakeBatches() that callers rely on, regardless

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -891,6 +891,48 @@ TEST_F(MetaLocalBackendTest, TestConditionalDeleteFields) {
 // ---------------------------------------------------------------------------
 // Concurrent read-write stress test for MetaMemCacheItem fields_ mutex
 // ---------------------------------------------------------------------------
+TEST_F(MetaLocalBackendTest, TestGetLocationValuesPreservesKeyOrderAndSharedValues) {
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_location_values", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    auto make_location = [](const std::string &id) {
+        auto location = std::make_shared<CacheLocation>();
+        location->set_id(id);
+        location->set_status(CacheLocationStatus::CLS_SERVING);
+        location->set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+        location->set_location_specs({LocationSpec("tp0", "event_report://host/mem")});
+        return location;
+    };
+    auto location_a = make_location("location-a");
+    auto location_b = make_location("location-b");
+    CacheLocationMapVector locations(2);
+    locations[0].emplace(location_a->id(), location_a);
+    locations[0].emplace(location_b->id(), location_b);
+    PropertyMapVector properties(2);
+    properties[1][PROPERTY_URI] = "property-only-key";
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              meta_storage_backend_->Put(nullptr, {11, 22}, locations, properties));
+
+    LocationsPerKey values;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT, EC_OK, EC_OK}),
+              meta_storage_backend_->GetLocationValues(nullptr, {11, 33, 22, 11}, values));
+    ASSERT_EQ(4u, values.size());
+    EXPECT_TRUE(values[1].empty());
+    EXPECT_TRUE(values[2].empty());
+    for (const std::size_t index : {std::size_t{0}, std::size_t{3}}) {
+        ASSERT_EQ(2u, values[index].size());
+        std::set<std::string> ids;
+        for (const auto &location : values[index]) {
+            ASSERT_TRUE(location);
+            ids.insert(location->id());
+            EXPECT_TRUE(location == location_a || location == location_b);
+        }
+        EXPECT_EQ((std::set<std::string>{"location-a", "location-b"}), ids);
+    }
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestConcurrentReadWrite) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_concurrent", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
@@ -954,6 +996,17 @@ TEST_F(MetaLocalBackendTest, TestConcurrentReadWrite) {
             auto get_loc_ids_ec = meta_storage_backend_->GetLocationIds(nullptr, {kTestKey}, loc_ids);
             ASSERT_EQ(1u, get_loc_ids_ec.size());
             ASSERT_EQ(EC_OK, get_loc_ids_ec[0]);
+
+            // Lightweight host-query projection must be safe while location
+            // entries are concurrently inserted and removed.
+            LocationsPerKey location_values;
+            auto get_values_ec = meta_storage_backend_->GetLocationValues(nullptr, {kTestKey}, location_values);
+            ASSERT_EQ(1u, get_values_ec.size());
+            ASSERT_EQ(EC_OK, get_values_ec[0]);
+            ASSERT_EQ(1u, location_values.size());
+            for (const auto &location : location_values[0]) {
+                ASSERT_TRUE(location);
+            }
         }
     };
 

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -90,6 +90,38 @@ TEST_F(MetaLocalBackendTest, TestSimple) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaLocalBackendTest, TestTargetedLocationsPreserveKeyStatus) {
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("targeted_status", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id("target");
+    CacheLocationMapVector locations(2);
+    locations[0].emplace("target", location);
+    PropertyMapVector properties(2);
+    properties[1].emplace("property_only", "value");
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              meta_storage_backend_->Put(nullptr, {1, 2}, locations, properties));
+
+    auto stale = std::make_shared<CacheLocation>();
+    stale->set_id("stale");
+    LocationsPerKey selected(3, CacheLocationVector{stale});
+    std::vector<ErrorCode> key_error_codes;
+    const auto per_location_ecs = meta_storage_backend_->GetLocationsWithKeyStatus(
+        nullptr, {1, 2, 3}, {{"target"}, {"target"}, {"target"}}, selected, key_error_codes);
+
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}), key_error_codes);
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}, {EC_NOENT}, {EC_NOENT}}), per_location_ecs);
+    ASSERT_EQ(3u, selected.size());
+    ASSERT_EQ(1u, selected[0].size());
+    ASSERT_TRUE(selected[0][0]);
+    EXPECT_EQ("target", selected[0][0]->id());
+    ASSERT_EQ(1u, selected[1].size());
+    EXPECT_FALSE(selected[1][0]);
+    ASSERT_EQ(1u, selected[2].size());
+    EXPECT_FALSE(selected[2][0]);
+}
+
 TEST_F(MetaLocalBackendTest, TestInit) {
     // invalid config
     ASSERT_EQ(EC_BADARGS, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -146,6 +146,21 @@ TEST_F(MetaStorageBackendManagerTest, TestInitDualBackend) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
+TEST_F(MetaStorageBackendManagerTest, TestConcurrentLocationValueReadsAreLocalOnly) {
+    MetaStorageBackendManager mgr;
+    EXPECT_FALSE(mgr.SupportsConcurrentLocationValueReads());
+
+    mgr.persistent_backend_ = std::make_unique<MetaLocalBackend>();
+    EXPECT_TRUE(mgr.SupportsConcurrentLocationValueReads());
+
+    mgr.cache_backend_ = std::make_unique<MetaLocalBackend>();
+    EXPECT_FALSE(mgr.SupportsConcurrentLocationValueReads());
+
+    mgr.cache_backend_.reset();
+    mgr.persistent_backend_ = std::make_unique<MetaDummyBackend>();
+    EXPECT_FALSE(mgr.SupportsConcurrentLocationValueReads());
+}
+
 // --- Put/Get: CacheLocation serialization round-trip --------------------------
 
 TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {
@@ -183,6 +198,16 @@ TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {
         ASSERT_TRUE(it != out_locations[i].end());
         ASSERT_EQ("uri_" + std::to_string(keys[i]), it->second->location_specs().front().uri());
     }
+
+    LocationsPerKey location_values;
+    auto get_value_ecs = mgr.GetLocationValues(request_context_.get(), {1, 404, 3}, location_values);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT, EC_OK}), get_value_ecs);
+    ASSERT_EQ(3u, location_values.size());
+    ASSERT_EQ(1u, location_values[0].size());
+    EXPECT_EQ("loc_1", location_values[0].front()->id());
+    EXPECT_TRUE(location_values[1].empty());
+    ASSERT_EQ(1u, location_values[2].size());
+    EXPECT_EQ("loc_3", location_values[2].front()->id());
 
     // Block-level properties should be preserved alongside the location fields.
     PropertyMapVector field_maps;

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "kv_cache_manager/common/request_context.h"
@@ -15,6 +16,292 @@
 #include "kv_cache_manager/meta/types.h"
 
 namespace kv_cache_manager {
+
+namespace {
+
+class MalformedMetaCacheBackend : public MetaLocalBackend {
+public:
+    std::vector<ErrorCode> Get(RequestContext *,
+                               const KeyTypeVec &,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties) noexcept override {
+        out_locations.clear();
+        out_properties.clear();
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode>
+    GetLocations(RequestContext *, const KeyTypeVec &, CacheLocationMapVector &out_locations) noexcept override {
+        out_locations.clear();
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode>
+    GetLocationValues(RequestContext *, const KeyTypeVec &, LocationsPerKey &out_locations) noexcept override {
+        out_locations.clear();
+        return {EC_OK};
+    }
+
+    std::vector<std::vector<ErrorCode>> GetLocations(RequestContext *,
+                                                     const KeyTypeVec &,
+                                                     const LocationIdsPerKey &,
+                                                     LocationsPerKey &out_locations) noexcept override {
+        out_locations.clear();
+        return {};
+    }
+
+    std::vector<ErrorCode>
+    GetLocationIds(RequestContext *, const KeyTypeVec &, LocationIdsPerKey &out_location_ids) noexcept override {
+        out_location_ids.clear();
+        return {};
+    }
+
+    std::vector<ErrorCode> GetProperties(RequestContext *,
+                                         const KeyTypeVec &,
+                                         const std::vector<std::string> &,
+                                         PropertyMapVector &out_properties) noexcept override {
+        out_properties.clear();
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode>
+    Exists(RequestContext *, const KeyTypeVec &, std::vector<bool> &out_exists) noexcept override {
+        out_exists.clear();
+        return {EC_OK};
+    }
+};
+
+class RecoverContractCacheBackend : public MetaLocalBackend {
+public:
+    explicit RecoverContractCacheBackend(std::vector<ErrorCode> put_results = {})
+        : put_results_(std::move(put_results)) {}
+
+    std::vector<ErrorCode>
+    Exists(RequestContext *, const KeyTypeVec &keys, std::vector<bool> &out_exists) noexcept override {
+        out_exists.assign(keys.size(), false);
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+    std::vector<ErrorCode> PutIfAbsent(RequestContext *,
+                                       const KeyTypeVec &keys,
+                                       const CacheLocationMapVector &,
+                                       const PropertyMapVector &,
+                                       const std::vector<ErrorCode> &) noexcept override {
+        if (!put_results_.empty()) {
+            return put_results_;
+        }
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+private:
+    std::vector<ErrorCode> put_results_;
+};
+
+class MalformedPersistentGetBackend : public MetaLocalBackend {
+public:
+    std::vector<ErrorCode> Get(RequestContext *,
+                               const KeyTypeVec &,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties) noexcept override {
+        out_locations.clear();
+        out_properties.clear();
+        return {EC_OK};
+    }
+};
+
+class ScriptedRecoverPersistentBackend : public MetaLocalBackend {
+public:
+    ScriptedRecoverPersistentBackend(int scan_failures, int get_failures, bool malformed_get)
+        : scan_failures_(scan_failures), get_failures_(get_failures), malformed_get_(malformed_get) {}
+
+    ErrorCode ListKeys(RequestContext *,
+                       const std::string &,
+                       const int64_t,
+                       std::string &out_next_cursor,
+                       KeyTypeVec &out_keys) noexcept override {
+        ++list_calls_;
+        if (list_calls_ <= scan_failures_) {
+            return EC_ERROR;
+        }
+        out_next_cursor = SCAN_BASE_CURSOR;
+        out_keys = {101};
+        return EC_OK;
+    }
+
+    std::vector<ErrorCode> Get(RequestContext *,
+                               const KeyTypeVec &keys,
+                               CacheLocationMapVector &out_locations,
+                               PropertyMapVector &out_properties) noexcept override {
+        ++get_calls_;
+        if (malformed_get_) {
+            out_locations.clear();
+            out_properties.clear();
+            return std::vector<ErrorCode>(keys.size(), EC_OK);
+        }
+        out_locations.resize(keys.size());
+        out_properties.resize(keys.size());
+        if (get_calls_ <= get_failures_) {
+            return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+        }
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+    int list_calls() const { return list_calls_; }
+    int get_calls() const { return get_calls_; }
+
+private:
+    int scan_failures_ = 0;
+    int get_failures_ = 0;
+    bool malformed_get_ = false;
+    int list_calls_ = 0;
+    int get_calls_ = 0;
+};
+
+class FlakyRecoverCacheBackend : public RecoverContractCacheBackend {
+public:
+    explicit FlakyRecoverCacheBackend(int put_failures) : put_failures_(put_failures) {}
+
+    std::vector<ErrorCode> PutIfAbsent(RequestContext *,
+                                       const KeyTypeVec &keys,
+                                       const CacheLocationMapVector &,
+                                       const PropertyMapVector &,
+                                       const std::vector<ErrorCode> &) noexcept override {
+        ++put_calls_;
+        return std::vector<ErrorCode>(keys.size(), put_calls_ <= put_failures_ ? EC_ERROR : EC_OK);
+    }
+
+    int put_calls() const { return put_calls_; }
+
+private:
+    int put_failures_ = 0;
+    int put_calls_ = 0;
+};
+
+class MalformedPersistentWriteBackend : public MetaLocalBackend {
+public:
+    std::vector<ErrorCode> Put(RequestContext *,
+                               const KeyTypeVec &,
+                               const CacheLocationMapVector &,
+                               const PropertyMapVector &) noexcept override {
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode> Upsert(RequestContext *,
+                                  const KeyTypeVec &,
+                                  const CacheLocationMapVector &,
+                                  const PropertyMapVector &) noexcept override {
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode> Delete(RequestContext *, const KeyTypeVec &) noexcept override { return {EC_OK}; }
+
+    std::vector<ErrorCode>
+    DeleteLocations(RequestContext *, const KeyTypeVec &, const LocationIdsPerKey &) noexcept override {
+        return {EC_OK};
+    }
+};
+
+class WellFormedPersistentWriteBackend : public MetaLocalBackend {
+public:
+    std::vector<ErrorCode> Put(RequestContext *,
+                               const KeyTypeVec &keys,
+                               const CacheLocationMapVector &,
+                               const PropertyMapVector &) noexcept override {
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+    std::vector<ErrorCode> Upsert(RequestContext *,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &,
+                                  const PropertyMapVector &) noexcept override {
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+    std::vector<ErrorCode> Delete(RequestContext *, const KeyTypeVec &keys) noexcept override {
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+
+    std::vector<ErrorCode>
+    DeleteLocations(RequestContext *, const KeyTypeVec &keys, const LocationIdsPerKey &) noexcept override {
+        return std::vector<ErrorCode>(keys.size(), EC_OK);
+    }
+};
+
+class MalformedCacheWriteBackend : public MetaLocalBackend {
+public:
+    std::vector<ErrorCode> Put(RequestContext *,
+                               const KeyTypeVec &,
+                               const CacheLocationMapVector &,
+                               const PropertyMapVector &,
+                               const std::vector<ErrorCode> &) noexcept override {
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode> Upsert(RequestContext *,
+                                  const KeyTypeVec &,
+                                  const CacheLocationMapVector &,
+                                  const PropertyMapVector &,
+                                  const std::vector<ErrorCode> &) noexcept override {
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode>
+    Delete(RequestContext *, const KeyTypeVec &, const std::vector<ErrorCode> &) noexcept override {
+        return {EC_OK};
+    }
+
+    std::vector<ErrorCode> DeleteLocations(RequestContext *,
+                                           const KeyTypeVec &,
+                                           const LocationIdsPerKey &,
+                                           const std::vector<ErrorCode> &) noexcept override {
+        return {EC_OK};
+    }
+};
+
+class MixedDeletePersistentBackend : public WellFormedPersistentWriteBackend {
+public:
+    std::vector<ErrorCode> Delete(RequestContext *, const KeyTypeVec &keys) noexcept override {
+        std::vector<ErrorCode> results(keys.size(), EC_OK);
+        if (!results.empty()) {
+            results.front() = EC_ERROR;
+        }
+        return results;
+    }
+};
+
+class PassthroughDeleteCacheBackend : public RecoverContractCacheBackend {
+public:
+    std::vector<ErrorCode>
+    Delete(RequestContext *, const KeyTypeVec &, const std::vector<ErrorCode> &previous_error_codes) noexcept override {
+        return previous_error_codes;
+    }
+};
+
+struct BackendLifecycleCalls {
+    ErrorCode open_result = EC_OK;
+    int open_calls = 0;
+    int close_calls = 0;
+};
+
+class LifecycleMetaLocalBackend : public MetaLocalBackend {
+public:
+    explicit LifecycleMetaLocalBackend(std::shared_ptr<BackendLifecycleCalls> calls) : calls_(std::move(calls)) {}
+
+    ErrorCode Open() noexcept override {
+        ++calls_->open_calls;
+        return calls_->open_result;
+    }
+
+    ErrorCode Close() noexcept override {
+        ++calls_->close_calls;
+        return EC_OK;
+    }
+
+private:
+    std::shared_ptr<BackendLifecycleCalls> calls_;
+};
+
+} // namespace
 
 class MetaStorageBackendManagerTest : public TESTBASE {
 public:
@@ -146,6 +433,109 @@ TEST_F(MetaStorageBackendManagerTest, TestInitDualBackend) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
+TEST_F(MetaStorageBackendManagerTest, TestInitIsTransactionalAndOneShot) {
+    auto invalid_cache_config = std::make_shared<MetaStorageBackendConfig>();
+    invalid_cache_config->SetStorageType(META_CACHED_BACKEND_TYPE_STR);
+    invalid_cache_config->SetStorageUri(
+        "file:///tmp/kvcm_invalid_cache?persistent_type=dummy&cache_type=unknown_backend");
+
+    MetaStorageBackendManager mgr;
+    EXPECT_EQ(EC_ERROR, mgr.Init("failed_dual", invalid_cache_config));
+    EXPECT_FALSE(mgr.persistent_backend_);
+    EXPECT_FALSE(mgr.cache_backend_);
+    EXPECT_TRUE(mgr.instance_id_.empty());
+
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_transactional_retry";
+    std::filesystem::remove(path);
+    ASSERT_EQ(EC_OK, mgr.Init("valid_after_failure", MakeSingleConfig(path)));
+    auto *const persistent_backend = mgr.persistent_backend_.get();
+    ASSERT_NE(nullptr, persistent_backend);
+
+    EXPECT_EQ(EC_ERROR, mgr.Init("must_not_replace", MakeDualConfig(path + "_other")));
+    EXPECT_EQ("valid_after_failure", mgr.instance_id_);
+    EXPECT_EQ(persistent_backend, mgr.persistent_backend_.get());
+    EXPECT_FALSE(mgr.cache_backend_);
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestCacheOpenFailureRollsBackBothBackends) {
+    auto persistent_calls = std::make_shared<BackendLifecycleCalls>();
+    auto cache_calls = std::make_shared<BackendLifecycleCalls>();
+    cache_calls->open_result = EC_ERROR;
+
+    MetaStorageBackendManager mgr;
+    mgr.instance_id_ = "rollback_instance";
+    mgr.persistent_backend_ = std::make_unique<LifecycleMetaLocalBackend>(persistent_calls);
+    mgr.cache_backend_ = std::make_unique<LifecycleMetaLocalBackend>(cache_calls);
+
+    EXPECT_EQ(EC_ERROR, mgr.Open());
+    EXPECT_TRUE(mgr.is_closed_.load(std::memory_order_acquire));
+    EXPECT_EQ(1, persistent_calls->open_calls);
+    EXPECT_EQ(1, cache_calls->open_calls);
+    EXPECT_EQ(1, persistent_calls->close_calls);
+    EXPECT_EQ(1, cache_calls->close_calls);
+    EXPECT_FALSE(mgr.recover_thread_.joinable());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestPersistentOpenFailureRollsBackBackend) {
+    auto persistent_calls = std::make_shared<BackendLifecycleCalls>();
+    persistent_calls->open_result = EC_ERROR;
+
+    MetaStorageBackendManager mgr;
+    mgr.instance_id_ = "persistent_rollback_instance";
+    mgr.persistent_backend_ = std::make_unique<LifecycleMetaLocalBackend>(persistent_calls);
+
+    EXPECT_EQ(EC_ERROR, mgr.Open());
+    EXPECT_TRUE(mgr.is_closed_.load(std::memory_order_acquire));
+    EXPECT_FALSE(mgr.opened_);
+    EXPECT_EQ(1, persistent_calls->open_calls);
+    EXPECT_EQ(1, persistent_calls->close_calls);
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestRepeatedOpenIsRejectedWithoutReopeningBackend) {
+    auto persistent_calls = std::make_shared<BackendLifecycleCalls>();
+
+    MetaStorageBackendManager mgr;
+    mgr.instance_id_ = "repeat_open_instance";
+    mgr.persistent_backend_ = std::make_unique<LifecycleMetaLocalBackend>(persistent_calls);
+
+    ASSERT_EQ(EC_OK, mgr.Open());
+    EXPECT_TRUE(mgr.opened_);
+    EXPECT_EQ(EC_ERROR, mgr.Open());
+    EXPECT_EQ(1, persistent_calls->open_calls);
+
+    EXPECT_EQ(EC_OK, mgr.Close());
+    EXPECT_FALSE(mgr.opened_);
+    EXPECT_EQ(1, persistent_calls->close_calls);
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestCloseIsIdempotent) {
+    auto persistent_calls = std::make_shared<BackendLifecycleCalls>();
+
+    MetaStorageBackendManager mgr;
+    mgr.instance_id_ = "repeat_close_instance";
+    mgr.persistent_backend_ = std::make_unique<LifecycleMetaLocalBackend>(persistent_calls);
+
+    ASSERT_EQ(EC_OK, mgr.Open());
+    ASSERT_EQ(EC_OK, mgr.Close());
+    EXPECT_EQ(EC_OK, mgr.Close());
+    EXPECT_EQ(1, persistent_calls->close_calls);
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestDestructorClosesOpenedBackendExactlyOnce) {
+    auto persistent_calls = std::make_shared<BackendLifecycleCalls>();
+
+    {
+        MetaStorageBackendManager mgr;
+        mgr.instance_id_ = "destructor_close_instance";
+        mgr.persistent_backend_ = std::make_unique<LifecycleMetaLocalBackend>(persistent_calls);
+
+        ASSERT_EQ(EC_OK, mgr.Open());
+        EXPECT_EQ(0, persistent_calls->close_calls);
+    }
+
+    EXPECT_EQ(1, persistent_calls->close_calls);
+}
+
 TEST_F(MetaStorageBackendManagerTest, TestConcurrentLocationValueReadsAreLocalOnly) {
     MetaStorageBackendManager mgr;
     EXPECT_FALSE(mgr.SupportsConcurrentLocationValueReads());
@@ -159,6 +549,227 @@ TEST_F(MetaStorageBackendManagerTest, TestConcurrentLocationValueReadsAreLocalOn
     mgr.cache_backend_.reset();
     mgr.persistent_backend_ = std::make_unique<MetaDummyBackend>();
     EXPECT_FALSE(mgr.SupportsConcurrentLocationValueReads());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMalformedCacheReadShapesFailClosed) {
+    MetaStorageBackendManager mgr;
+    mgr.persistent_backend_ = std::make_unique<MetaLocalBackend>();
+    mgr.cache_backend_ = std::make_unique<MalformedMetaCacheBackend>();
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning);
+
+    const KeyVector keys{1, 2};
+    CacheLocationMapVector all_locations;
+    PropertyMapVector all_properties;
+    const auto get_results = mgr.Get(request_context_.get(), keys, all_locations, all_properties);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), get_results);
+    EXPECT_EQ(2u, all_locations.size());
+    EXPECT_EQ(2u, all_properties.size());
+
+    const auto all_location_results = mgr.GetLocations(request_context_.get(), keys, all_locations);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), all_location_results);
+    EXPECT_EQ(2u, all_locations.size());
+
+    const LocationIdsPerKey requested_ids{{"a"}, {"b", "c"}};
+    LocationsPerKey locations;
+    const auto per_location = mgr.GetLocations(request_context_.get(), keys, requested_ids, locations);
+    ASSERT_EQ(2u, per_location.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR}), per_location[0]);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), per_location[1]);
+    ASSERT_EQ(2u, locations.size());
+    EXPECT_EQ(1u, locations[0].size());
+    EXPECT_EQ(2u, locations[1].size());
+
+    LocationIdsPerKey location_ids;
+    const auto per_key = mgr.GetLocationIds(request_context_.get(), keys, location_ids);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), per_key);
+    EXPECT_EQ(2u, location_ids.size());
+
+    LocationsPerKey location_values;
+    const auto value_results = mgr.GetLocationValues(request_context_.get(), keys, location_values);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), value_results);
+    EXPECT_EQ(2u, location_values.size());
+
+    const auto property_results = mgr.GetProperties(request_context_.get(), keys, {"field"}, all_properties);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), property_results);
+    EXPECT_EQ(2u, all_properties.size());
+
+    std::vector<bool> exists;
+    const auto exists_results = mgr.Exists(request_context_.get(), keys, exists);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), exists_results);
+    EXPECT_EQ((std::vector<bool>{false, false}), exists);
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestRecoverHydrationMalformedShapesFailClosed) {
+    const KeyVector keys{1, 2};
+
+    MetaStorageBackendManager malformed_exists;
+    malformed_exists.persistent_backend_ = std::make_unique<MetaLocalBackend>();
+    malformed_exists.cache_backend_ = std::make_unique<MalformedMetaCacheBackend>();
+    malformed_exists.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
+    BatchMetaData upsert = MakeBatch(keys);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), malformed_exists.Upsert(request_context_.get(), upsert));
+
+    MetaStorageBackendManager malformed_get;
+    malformed_get.persistent_backend_ = std::make_unique<MalformedPersistentGetBackend>();
+    malformed_get.cache_backend_ = std::make_unique<RecoverContractCacheBackend>();
+    EXPECT_FALSE(malformed_get.EnsureKeyInCache(request_context_.get(), keys));
+
+    MetaStorageBackendManager malformed_put;
+    malformed_put.cache_backend_ = std::make_unique<RecoverContractCacheBackend>(std::vector<ErrorCode>{EC_OK});
+    const CacheLocationMapVector locations(keys.size());
+    const PropertyMapVector properties(keys.size());
+    bool backfill_success = true;
+    EXPECT_EQ(0, malformed_put.BackfillKeysToCache(keys, locations, properties, {EC_OK, EC_OK}, &backfill_success));
+    EXPECT_FALSE(backfill_success);
+    backfill_success = true;
+    EXPECT_EQ(
+        0,
+        malformed_put.BackfillKeysToCache(
+            keys, CacheLocationMapVector(1), properties, std::vector<ErrorCode>{EC_OK, EC_OK}, &backfill_success));
+    EXPECT_FALSE(backfill_success);
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestRecoverFailureKeepsFallbackAndTombstones) {
+    MetaStorageBackendManager mgr;
+    auto persistent = std::make_unique<ScriptedRecoverPersistentBackend>(/*scan_failures*/ 3,
+                                                                         /*get_failures*/ 0,
+                                                                         /*malformed_get*/ false);
+    auto *persistent_ptr = persistent.get();
+    mgr.persistent_backend_ = std::move(persistent);
+    mgr.cache_backend_ = std::make_unique<RecoverContractCacheBackend>();
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
+    mgr.deleted_keys_.insert(404);
+
+    mgr.AsyncRecoverTask();
+
+    EXPECT_EQ(3, persistent_ptr->list_calls());
+    EXPECT_EQ(MetaStorageBackendManager::RecoverState::kRecover, mgr.GetRecoverState());
+    EXPECT_EQ(1u, mgr.deleted_keys_.count(404));
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestRecoverMalformedGetDoesNotPublishPartialCache) {
+    MetaStorageBackendManager mgr;
+    auto persistent = std::make_unique<ScriptedRecoverPersistentBackend>(/*scan_failures*/ 0,
+                                                                         /*get_failures*/ 0,
+                                                                         /*malformed_get*/ true);
+    auto *persistent_ptr = persistent.get();
+    mgr.persistent_backend_ = std::move(persistent);
+    mgr.cache_backend_ = std::make_unique<RecoverContractCacheBackend>();
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
+
+    mgr.AsyncRecoverTask();
+
+    EXPECT_EQ(3, persistent_ptr->get_calls());
+    EXPECT_EQ(MetaStorageBackendManager::RecoverState::kRecover, mgr.GetRecoverState());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestRecoverRetriesSameBatchUntilFullyBackfilled) {
+    MetaStorageBackendManager mgr;
+    auto persistent = std::make_unique<ScriptedRecoverPersistentBackend>(/*scan_failures*/ 0,
+                                                                         /*get_failures*/ 1,
+                                                                         /*malformed_get*/ false);
+    auto *persistent_ptr = persistent.get();
+    auto cache = std::make_unique<FlakyRecoverCacheBackend>(/*put_failures*/ 1);
+    auto *cache_ptr = cache.get();
+    mgr.persistent_backend_ = std::move(persistent);
+    mgr.cache_backend_ = std::move(cache);
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
+    mgr.deleted_keys_.insert(404);
+
+    mgr.AsyncRecoverTask();
+
+    // First Get fails, then the first cache fill fails. Neither attempt may
+    // rescan or advance the cursor; only the third complete attempt publishes
+    // the retained batch and clears Recover-time tombstones.
+    EXPECT_EQ(1, persistent_ptr->list_calls());
+    EXPECT_EQ(3, persistent_ptr->get_calls());
+    EXPECT_EQ(2, cache_ptr->put_calls());
+    EXPECT_EQ(MetaStorageBackendManager::RecoverState::kRunning, mgr.GetRecoverState());
+    EXPECT_TRUE(mgr.deleted_keys_.empty());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMalformedWriteShapesFailClosed) {
+    const KeyVector keys{1, 2};
+    BatchMetaData batch = MakeBatch(keys);
+    const LocationIdsPerKey location_ids{{"a"}, {"b"}};
+
+    MetaStorageBackendManager malformed_persistent;
+    malformed_persistent.persistent_backend_ = std::make_unique<MalformedPersistentWriteBackend>();
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), malformed_persistent.Put(request_context_.get(), batch));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), malformed_persistent.Upsert(request_context_.get(), batch));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), malformed_persistent.Delete(request_context_.get(), keys));
+    int32_t reclaimed = -1;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}),
+              malformed_persistent.Delete(request_context_.get(), keys, location_ids, reclaimed));
+    EXPECT_EQ(0, reclaimed);
+
+    MetaStorageBackendManager malformed_cache;
+    malformed_cache.persistent_backend_ = std::make_unique<WellFormedPersistentWriteBackend>();
+    malformed_cache.cache_backend_ = std::make_unique<MalformedCacheWriteBackend>();
+    malformed_cache.recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), malformed_cache.Put(request_context_.get(), batch));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), malformed_cache.Upsert(request_context_.get(), batch));
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), malformed_cache.Delete(request_context_.get(), keys));
+    reclaimed = -1;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}),
+              malformed_cache.Delete(request_context_.get(), keys, location_ids, reclaimed));
+    EXPECT_EQ(0, reclaimed);
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestRecoverDeleteTombstonesOnlyCommittedKeys) {
+    MetaStorageBackendManager mgr;
+    mgr.persistent_backend_ = std::make_unique<MixedDeletePersistentBackend>();
+    mgr.cache_backend_ = std::make_unique<PassthroughDeleteCacheBackend>();
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
+
+    const KeyVector keys{1, 2};
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_OK}), mgr.Delete(request_context_.get(), keys));
+    EXPECT_EQ(0u, mgr.deleted_keys_.count(1));
+    EXPECT_EQ(1u, mgr.deleted_keys_.count(2));
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestTargetedRecoveryReadDoesNotOverwriteCacheHitWithPersistentData) {
+    MetaStorageBackendManager mgr;
+    auto backend_config = std::make_shared<MetaStorageBackendConfig>();
+    mgr.persistent_backend_ = std::make_unique<MetaLocalBackend>();
+    mgr.cache_backend_ = std::make_unique<MetaLocalBackend>();
+    ASSERT_EQ(EC_OK, mgr.persistent_backend_->Init("targeted_persistent", backend_config));
+    ASSERT_EQ(EC_OK, mgr.cache_backend_->Init("targeted_cache", backend_config));
+    ASSERT_EQ(EC_OK, mgr.persistent_backend_->Open());
+    ASSERT_EQ(EC_OK, mgr.cache_backend_->Open());
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
+
+    const KeyVector persistent_keys{77, 78};
+    CacheLocationMapVector persistent_locations(2);
+    persistent_locations[0].emplace("missing", MakeLocation("missing", "persistent_missing"));
+    persistent_locations[0].emplace("present", MakeLocation("present", "persistent_stale"));
+    persistent_locations[1].emplace("only_persistent", MakeLocation("only_persistent", "persistent_fallback"));
+    PropertyMapVector properties(2);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              mgr.persistent_backend_->Put(request_context_.get(), persistent_keys, persistent_locations, properties));
+
+    CacheLocationMapVector cache_locations(1);
+    cache_locations[0].emplace("present", MakeLocation("present", "cache_current"));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.cache_backend_->Put(request_context_.get(), {77}, cache_locations, PropertyMapVector(1)));
+
+    LocationsPerKey locations;
+    const LocationIdsPerKey requested_ids{{"missing", "present"}, {"only_persistent"}};
+    const auto results = mgr.GetLocations(request_context_.get(), persistent_keys, requested_ids, locations);
+    ASSERT_EQ(2u, results.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_NOENT, EC_OK}), results[0]);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK}), results[1]);
+    ASSERT_EQ(2u, locations.size());
+    ASSERT_EQ(2u, locations[0].size());
+    EXPECT_FALSE(locations[0][0]);
+    ASSERT_TRUE(locations[0][1]);
+    EXPECT_EQ("cache_current", locations[0][1]->location_specs().front().uri());
+    ASSERT_EQ(1u, locations[1].size());
+    ASSERT_TRUE(locations[1][0]);
+    EXPECT_EQ("persistent_fallback", locations[1][0]->location_specs().front().uri());
+
+    ASSERT_EQ(EC_OK, mgr.cache_backend_->Close());
+    ASSERT_EQ(EC_OK, mgr.persistent_backend_->Close());
 }
 
 // --- Put/Get: CacheLocation serialization round-trip --------------------------
@@ -679,6 +1290,44 @@ TEST_F(MetaStorageBackendManagerTest, TestMaybeReclaimEmptyKeysAfterLastLocation
     auto exists_ecs = mgr.Exists(nullptr, keys, exists_vec);
     ASSERT_EQ(EC_OK, exists_ecs[0]);
     EXPECT_FALSE(exists_vec[0]);
+
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaybeReclaimCountsDuplicateKeyOnce) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_reclaim_duplicate_key";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_reclaim_duplicate", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    constexpr KeyType key = 31;
+    BatchMetaData batch;
+    batch.batch_keys = {key};
+    batch.batch_indexs = {0};
+    batch.batch_locations.resize(1);
+    batch.batch_properties.resize(1);
+    batch.batch_locations[0].emplace("loc_31_a", MakeLocation("loc_31_a", "uri_31_a"));
+    batch.batch_locations[0].emplace("loc_31_b", MakeLocation("loc_31_b", "uri_31_b"));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
+
+    // MetaSearcher flattens one location-deletion task per entry, so deleting
+    // the final two locations of one block legitimately supplies the key twice.
+    // The physical key and key-count metadata must nevertheless be reclaimed
+    // exactly once.
+    const KeyVector duplicate_keys = {key, key};
+    const LocationIdsPerKey location_ids = {{"loc_31_a"}, {"loc_31_b"}};
+    int32_t reclaimed = 0;
+    const auto delete_ecs = mgr.Delete(nullptr, duplicate_keys, location_ids, reclaimed);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), delete_ecs);
+    EXPECT_EQ(1, reclaimed);
+
+    std::vector<bool> exists;
+    const auto exists_ecs = mgr.Exists(nullptr, {key}, exists);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), exists_ecs);
+    ASSERT_EQ(1u, exists.size());
+    EXPECT_FALSE(exists[0]);
 
     ASSERT_EQ(EC_OK, mgr.Close());
 }

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -50,6 +50,17 @@ public:
         return {};
     }
 
+    std::vector<std::vector<ErrorCode>>
+    GetLocationsWithKeyStatus(RequestContext *,
+                              const KeyTypeVec &,
+                              const LocationIdsPerKey &,
+                              LocationsPerKey &out_locations,
+                              std::vector<ErrorCode> &out_key_error_codes) noexcept override {
+        out_locations.clear();
+        out_key_error_codes = {EC_OK};
+        return {};
+    }
+
     std::vector<ErrorCode>
     GetLocationIds(RequestContext *, const KeyTypeVec &, LocationIdsPerKey &out_location_ids) noexcept override {
         out_location_ids.clear();
@@ -579,6 +590,17 @@ TEST_F(MetaStorageBackendManagerTest, TestMalformedCacheReadShapesFailClosed) {
     EXPECT_EQ(1u, locations[0].size());
     EXPECT_EQ(2u, locations[1].size());
 
+    std::vector<ErrorCode> key_error_codes;
+    const auto with_key_status =
+        mgr.GetLocationsWithKeyStatus(request_context_.get(), keys, requested_ids, locations, key_error_codes);
+    ASSERT_EQ(2u, with_key_status.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR}), with_key_status[0]);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), with_key_status[1]);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), key_error_codes);
+    ASSERT_EQ(2u, locations.size());
+    EXPECT_EQ(1u, locations[0].size());
+    EXPECT_EQ(2u, locations[1].size());
+
     LocationIdsPerKey location_ids;
     const auto per_key = mgr.GetLocationIds(request_context_.get(), keys, location_ids);
     EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), per_key);
@@ -767,6 +789,24 @@ TEST_F(MetaStorageBackendManagerTest, TestTargetedRecoveryReadDoesNotOverwriteCa
     ASSERT_EQ(1u, locations[1].size());
     ASSERT_TRUE(locations[1][0]);
     EXPECT_EQ("persistent_fallback", locations[1][0]->location_specs().front().uri());
+
+    locations.clear();
+    std::vector<ErrorCode> key_error_codes;
+    const KeyVector status_keys{77, 78, 79};
+    const LocationIdsPerKey status_ids{{"missing", "present"}, {"only_persistent"}, {"absent"}};
+    const auto status_results =
+        mgr.GetLocationsWithKeyStatus(request_context_.get(), status_keys, status_ids, locations, key_error_codes);
+    ASSERT_EQ(3u, status_results.size());
+    EXPECT_EQ((std::vector<ErrorCode>{EC_NOENT, EC_OK}), status_results[0]);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK}), status_results[1]);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_NOENT}), status_results[2]);
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_NOENT}), key_error_codes);
+    ASSERT_EQ(3u, locations.size());
+    ASSERT_TRUE(locations[0][1]);
+    EXPECT_EQ("cache_current", locations[0][1]->location_specs().front().uri());
+    ASSERT_TRUE(locations[1][0]);
+    EXPECT_EQ("persistent_fallback", locations[1][0]->location_specs().front().uri());
+    EXPECT_FALSE(locations[2][0]);
 
     ASSERT_EQ(EC_OK, mgr.cache_backend_->Close());
     ASSERT_EQ(EC_OK, mgr.persistent_backend_->Close());

--- a/kv_cache_manager/meta/test/query_executor_test.cc
+++ b/kv_cache_manager/meta/test/query_executor_test.cc
@@ -1,0 +1,224 @@
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/meta/query_executor.h"
+
+namespace kv_cache_manager {
+namespace {
+
+using namespace std::chrono_literals;
+
+TEST(QueryExecutorTest, EmptyAndBelowThresholdCallsStayOnCaller) {
+    QueryExecutor executor(/*worker_count*/ 4,
+                           /*parallel_threshold*/ 10,
+                           /*chunk_size*/ 2,
+                           /*queue_capacity*/ 8);
+    std::size_t call_count = 0;
+    std::thread::id callback_thread;
+    const std::thread::id caller_thread = std::this_thread::get_id();
+
+    EXPECT_TRUE(executor.ParallelFor(0, [&](std::size_t, std::size_t) { ++call_count; }));
+    EXPECT_EQ(0u, call_count);
+    EXPECT_TRUE(executor.ParallelFor(9, [&](std::size_t begin, std::size_t end) {
+        ++call_count;
+        callback_thread = std::this_thread::get_id();
+        EXPECT_EQ(0u, begin);
+        EXPECT_EQ(9u, end);
+    }));
+    EXPECT_EQ(1u, call_count);
+    EXPECT_EQ(caller_thread, callback_thread);
+}
+
+TEST(QueryExecutorTest, ParallelRangesCoverEveryIndexExactlyOnce) {
+    QueryExecutor executor(/*worker_count*/ 4,
+                           /*parallel_threshold*/ 1,
+                           /*chunk_size*/ 1,
+                           /*queue_capacity*/ 16);
+    constexpr std::size_t kCount = 512;
+    std::vector<std::atomic<uint32_t>> visits(kCount);
+    for (auto &visit : visits) {
+        visit.store(0, std::memory_order_relaxed);
+    }
+
+    std::mutex threads_mutex;
+    std::condition_variable threads_cv;
+    std::set<std::thread::id> callback_threads;
+    ASSERT_TRUE(executor.ParallelFor(kCount, [&](std::size_t begin, std::size_t end) {
+        {
+            std::unique_lock<std::mutex> lock(threads_mutex);
+            callback_threads.insert(std::this_thread::get_id());
+            threads_cv.notify_all();
+            if (callback_threads.size() == 1) {
+                threads_cv.wait_for(lock, 2s, [&] { return callback_threads.size() >= 2; });
+            }
+        }
+        for (std::size_t i = begin; i < end; ++i) {
+            visits[i].fetch_add(1, std::memory_order_relaxed);
+        }
+    }));
+
+    EXPECT_GE(callback_threads.size(), 2u);
+    EXPECT_LE(callback_threads.size(), 4u);
+    for (std::size_t i = 0; i < kCount; ++i) {
+        EXPECT_EQ(1u, visits[i].load(std::memory_order_relaxed)) << "index=" << i;
+    }
+}
+
+TEST(QueryExecutorTest, CallbackExceptionIsReportedWithoutDroppingOtherRanges) {
+    QueryExecutor executor(/*worker_count*/ 4,
+                           /*parallel_threshold*/ 1,
+                           /*chunk_size*/ 1,
+                           /*queue_capacity*/ 16);
+    constexpr std::size_t kCount = 128;
+    std::vector<std::atomic<uint32_t>> visits(kCount);
+    for (auto &visit : visits) {
+        visit.store(0, std::memory_order_relaxed);
+    }
+
+    EXPECT_FALSE(executor.ParallelFor(kCount, [&](std::size_t begin, std::size_t end) {
+        for (std::size_t i = begin; i < end; ++i) {
+            visits[i].fetch_add(1, std::memory_order_relaxed);
+            if (i == 37) {
+                throw std::runtime_error("expected test exception");
+            }
+        }
+    }));
+    for (std::size_t i = 0; i < kCount; ++i) {
+        EXPECT_EQ(1u, visits[i].load(std::memory_order_relaxed)) << "index=" << i;
+    }
+}
+
+TEST(QueryExecutorTest, NestedParallelForDoesNotDeadlockOrDuplicateWork) {
+    QueryExecutor executor(/*worker_count*/ 4,
+                           /*parallel_threshold*/ 1,
+                           /*chunk_size*/ 1,
+                           /*queue_capacity*/ 16);
+    constexpr std::size_t kOuterCount = 32;
+    constexpr std::size_t kInnerCount = 8;
+    std::vector<std::atomic<uint32_t>> visits(kOuterCount * kInnerCount);
+    for (auto &visit : visits) {
+        visit.store(0, std::memory_order_relaxed);
+    }
+
+    ASSERT_TRUE(executor.ParallelFor(kOuterCount, [&](std::size_t outer_begin, std::size_t outer_end) {
+        for (std::size_t outer = outer_begin; outer < outer_end; ++outer) {
+            ASSERT_TRUE(executor.ParallelFor(kInnerCount, [&](std::size_t inner_begin, std::size_t inner_end) {
+                for (std::size_t inner = inner_begin; inner < inner_end; ++inner) {
+                    visits[outer * kInnerCount + inner].fetch_add(1, std::memory_order_relaxed);
+                }
+            }));
+        }
+    }));
+    for (std::size_t i = 0; i < visits.size(); ++i) {
+        EXPECT_EQ(1u, visits[i].load(std::memory_order_relaxed)) << "index=" << i;
+    }
+}
+
+TEST(QueryExecutorTest, CompletedCallerDoesNotWaitForQueuedHelper) {
+    QueryExecutor executor(/*worker_count*/ 2,
+                           /*parallel_threshold*/ 1,
+                           /*chunk_size*/ 1,
+                           /*queue_capacity*/ 8);
+    std::mutex blocker_mutex;
+    std::condition_variable blocker_cv;
+    std::size_t blocked_callbacks = 0;
+    bool release_blocker = false;
+
+    std::thread blocker([&] {
+        EXPECT_TRUE(executor.ParallelFor(2, [&](std::size_t, std::size_t) {
+            std::unique_lock<std::mutex> lock(blocker_mutex);
+            ++blocked_callbacks;
+            blocker_cv.notify_all();
+            blocker_cv.wait(lock, [&] { return release_blocker; });
+        }));
+    });
+    bool both_callbacks_blocked = false;
+    {
+        std::unique_lock<std::mutex> lock(blocker_mutex);
+        both_callbacks_blocked = blocker_cv.wait_for(lock, 2s, [&] { return blocked_callbacks == 2; });
+    }
+    if (!both_callbacks_blocked) {
+        {
+            std::lock_guard<std::mutex> lock(blocker_mutex);
+            release_blocker = true;
+        }
+        blocker_cv.notify_all();
+        blocker.join();
+        FAIL() << "query executor background worker did not enter the blocking callback";
+    }
+
+    std::mutex fast_mutex;
+    std::condition_variable fast_cv;
+    bool fast_done = false;
+    std::thread fast([&] {
+        EXPECT_TRUE(executor.ParallelFor(2, [](std::size_t, std::size_t) {}));
+        {
+            std::lock_guard<std::mutex> lock(fast_mutex);
+            fast_done = true;
+        }
+        fast_cv.notify_one();
+    });
+    {
+        std::unique_lock<std::mutex> lock(fast_mutex);
+        EXPECT_TRUE(fast_cv.wait_for(lock, 1s, [&] { return fast_done; }));
+    }
+    {
+        std::lock_guard<std::mutex> lock(blocker_mutex);
+        release_blocker = true;
+    }
+    blocker_cv.notify_all();
+    fast.join();
+    blocker.join();
+}
+
+TEST(QueryExecutorTest, ConcurrentRequestsRemainExactWithSaturatedQueue) {
+    QueryExecutor executor(/*worker_count*/ 4,
+                           /*parallel_threshold*/ 1,
+                           /*chunk_size*/ 3,
+                           /*queue_capacity*/ 1);
+    constexpr std::size_t kThreadCount = 16;
+    constexpr std::size_t kRounds = 20;
+    constexpr std::size_t kCount = 257;
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+    for (std::size_t thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+        threads.emplace_back([&, thread_index] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            for (std::size_t round = 0; round < kRounds; ++round) {
+                std::vector<std::atomic<uint32_t>> visits(kCount);
+                for (auto &visit : visits) {
+                    visit.store(0, std::memory_order_relaxed);
+                }
+                EXPECT_TRUE(executor.ParallelFor(kCount,
+                                                 [&](std::size_t begin, std::size_t end) {
+                                                     for (std::size_t i = begin; i < end; ++i) {
+                                                         visits[i].fetch_add(1, std::memory_order_relaxed);
+                                                     }
+                                                 }))
+                    << "thread=" << thread_index << " round=" << round;
+                for (std::size_t i = 0; i < kCount; ++i) {
+                    EXPECT_EQ(1u, visits[i].load(std::memory_order_relaxed))
+                        << "thread=" << thread_index << " round=" << round << " index=" << i;
+                }
+            }
+        });
+    }
+    start.store(true, std::memory_order_release);
+    for (auto &thread : threads) {
+        thread.join();
+    }
+}
+
+} // namespace
+} // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -72,6 +72,8 @@ struct KmonitorMetricsReporter::Context {
 
     // meta searcher metrics
     DECLARE_METRICS(meta_searcher, indexer_get_time_us);
+    DECLARE_METRICS(meta_searcher, host_projection_time_us);
+    DECLARE_METRICS(meta_searcher, host_prefix_reduce_time_us);
     DECLARE_METRICS(meta_searcher, indexer_read_modify_write_block_time_us);
     DECLARE_METRICS(meta_searcher, indexer_read_modify_write_location_time_us);
     DECLARE_METRICS(meta_searcher, index_serialize_time_us);
@@ -333,6 +335,8 @@ bool KmonitorMetricsReporter::InitMetrics() {
 
     // meta searcher metrics
     REGISTER_GAUGE_METRIC(meta_searcher, indexer_get_time_us);
+    REGISTER_GAUGE_METRIC(meta_searcher, host_projection_time_us);
+    REGISTER_GAUGE_METRIC(meta_searcher, host_prefix_reduce_time_us);
     REGISTER_GAUGE_METRIC(meta_searcher, indexer_read_modify_write_block_time_us);
     REGISTER_GAUGE_METRIC(meta_searcher, indexer_read_modify_write_location_time_us);
     REGISTER_GAUGE_METRIC(meta_searcher, index_serialize_time_us);
@@ -517,6 +521,8 @@ void KmonitorMetricsReporter::ReportPerQuery(MetricsCollector *collector) {
 
         // meta searcher metrics
         REPORT_COLLECTED_METRICS(meta_searcher, indexer_get_time_us);
+        REPORT_COLLECTED_METRICS(meta_searcher, host_projection_time_us);
+        REPORT_COLLECTED_METRICS(meta_searcher, host_prefix_reduce_time_us);
         REPORT_STEAL_METRICS(meta_searcher, indexer_read_modify_write_block_time_us);
         REPORT_STEAL_METRICS(meta_searcher, indexer_read_modify_write_location_time_us);
         REPORT_STEAL_METRICS(meta_searcher, index_serialize_time_us);

--- a/kv_cache_manager/metrics/metrics_collector.cc
+++ b/kv_cache_manager/metrics/metrics_collector.cc
@@ -78,6 +78,8 @@ DEFINE_METRICS_NAME_FOR_MANAGER(batch_update_location_time_us);
     REGISTER_METRICS_W_TAGS_GAUGE_(metrics_registry_, meta_searcher, name, metrics_tags_)
 
 DEFINE_METRICS_NAME_FOR_META_SEARCHER(indexer_get_time_us);
+DEFINE_METRICS_NAME_FOR_META_SEARCHER(host_projection_time_us);
+DEFINE_METRICS_NAME_FOR_META_SEARCHER(host_prefix_reduce_time_us);
 DEFINE_METRICS_NAME_FOR_META_SEARCHER(indexer_read_modify_write_block_time_us);
 DEFINE_METRICS_NAME_FOR_META_SEARCHER(indexer_read_modify_write_location_time_us);
 DEFINE_METRICS_NAME_FOR_META_SEARCHER(index_serialize_time_us);
@@ -150,6 +152,8 @@ bool ServiceMetricsCollector::Init() {
 
     // meta searcher metrics
     REGISTER_GAUGE_METRICS_FOR_META_SEARCHER(indexer_get_time_us);
+    REGISTER_GAUGE_METRICS_FOR_META_SEARCHER(host_projection_time_us);
+    REGISTER_GAUGE_METRICS_FOR_META_SEARCHER(host_prefix_reduce_time_us);
     REGISTER_GAUGE_METRICS_FOR_META_SEARCHER(indexer_read_modify_write_block_time_us);
     REGISTER_GAUGE_METRICS_FOR_META_SEARCHER(indexer_read_modify_write_location_time_us);
     REGISTER_GAUGE_METRICS_FOR_META_SEARCHER(index_serialize_time_us);

--- a/kv_cache_manager/metrics/metrics_collector.h
+++ b/kv_cache_manager/metrics/metrics_collector.h
@@ -277,6 +277,8 @@ class ServiceMetricsCollector final : public MetricsCollector {
 
     // meta searcher metrics
     KVCM_CHRONO_METRICS(meta_searcher, indexer_get_time_us, MetaSearcherIndexerGet)
+    KVCM_CHRONO_METRICS(meta_searcher, host_projection_time_us, MetaSearcherHostProjection)
+    KVCM_CHRONO_METRICS(meta_searcher, host_prefix_reduce_time_us, MetaSearcherHostPrefixReduce)
     KVCM_CHRONO_METRICS(meta_searcher, indexer_read_modify_write_block_time_us, MetaSearcherIndexerReadModifyWriteBlock)
     KVCM_CHRONO_METRICS(meta_searcher,
                         indexer_read_modify_write_location_time_us,

--- a/kv_cache_manager/metrics/revisit_interval_histogram.cc
+++ b/kv_cache_manager/metrics/revisit_interval_histogram.cc
@@ -78,6 +78,41 @@ void RevisitIntervalHistogram::Observe(int64_t interval_us) {
     ++count_counter_;
 }
 
+void RevisitIntervalHistogram::ObserveBatch(const std::vector<int64_t> &intervals_us) {
+    if (intervals_us.empty()) {
+        return;
+    }
+
+    std::vector<uint64_t> bucket_deltas(boundaries_.size() + 1, 0);
+    uint64_t sum_delta = 0;
+    uint64_t count_delta = 0;
+    for (const int64_t interval_us : intervals_us) {
+        if (interval_us <= 0) {
+            continue;
+        }
+        const double interval_s = static_cast<double>(interval_us) / 1e6;
+        for (size_t i = 0; i < boundaries_.size(); ++i) {
+            if (boundaries_[i] >= interval_s) {
+                ++bucket_deltas[i];
+            }
+        }
+        ++bucket_deltas.back();
+        sum_delta += static_cast<uint64_t>(interval_us);
+        ++count_delta;
+    }
+
+    if (count_delta == 0) {
+        return;
+    }
+    for (size_t i = 0; i < bucket_deltas.size(); ++i) {
+        if (bucket_deltas[i] != 0) {
+            bucket_counters_[i] += bucket_deltas[i];
+        }
+    }
+    sum_counter_ += sum_delta;
+    count_counter_ += count_delta;
+}
+
 std::vector<uint64_t> RevisitIntervalHistogram::GetBucketCounts() const {
     std::vector<uint64_t> counts;
     counts.reserve(bucket_counters_.size());

--- a/kv_cache_manager/metrics/revisit_interval_histogram.h
+++ b/kv_cache_manager/metrics/revisit_interval_histogram.h
@@ -47,6 +47,13 @@ public:
     // Thread-safe: uses only atomic operations.
     void Observe(int64_t interval_us);
 
+    // Records a batch with the same histogram semantics as repeated Observe()
+    // calls, but aggregates bucket deltas locally before touching the shared
+    // counters. Large GetHostCacheState reads otherwise make every worker
+    // update the same counters for every block, creating avoidable cache-line
+    // contention inside the metadata I/O timer.
+    void ObserveBatch(const std::vector<int64_t> &intervals_us);
+
     // Get bucket boundaries (for testing/debugging).
     const std::vector<double> &GetBoundaries() const { return boundaries_; }
 

--- a/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
@@ -173,12 +173,12 @@ TEST_F(LocalMetricsReporterTest, TestReportPerQuery02) {
     ServiceMetricsCollector collector(metrics_registry_);
     collector.Init();
 
-    EXPECT_EQ(3 + 5 + 14 + 6 + 23, metrics_registry_->GetSize());
+    EXPECT_EQ(3 + 5 + 14 + 6 + 25, metrics_registry_->GetSize());
 
     {
         reporter_->ReportPerQuery(&collector);
 
-        EXPECT_EQ(3 + 5 + 14 + 6 + 23, metrics_registry_->GetSize());
+        EXPECT_EQ(3 + 5 + 14 + 6 + 25, metrics_registry_->GetSize());
 
         std::uint64_t v;
         GET_METRICS_(&collector, service, query_counter, v);
@@ -195,7 +195,7 @@ TEST_F(LocalMetricsReporterTest, TestReportPerQuery02) {
 
         reporter_->ReportPerQuery(&collector);
 
-        EXPECT_EQ(3 + 5 + 14 + 6 + 23, metrics_registry_->GetSize());
+        EXPECT_EQ(3 + 5 + 14 + 6 + 25, metrics_registry_->GetSize());
 
         std::uint64_t v;
         GET_METRICS_(&collector, service, query_counter, v);

--- a/kv_cache_manager/metrics/test/metrics_collector_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_collector_test.cc
@@ -131,6 +131,8 @@ TEST_F(MetricsCollectorTest, MetaSearcherMetricsTest) {
     ASSERT_NE(nullptr, p);
 
     EXPECT_DOUBLE_EQ(GET(p, meta_searcher, indexer_get_time_us), 0.);
+    EXPECT_DOUBLE_EQ(GET(p, meta_searcher, host_projection_time_us), 0.);
+    EXPECT_DOUBLE_EQ(GET(p, meta_searcher, host_prefix_reduce_time_us), 0.);
     EXPECT_DOUBLE_EQ(GET(p, meta_searcher, indexer_read_modify_write_block_time_us), 0.);
     EXPECT_DOUBLE_EQ(GET(p, meta_searcher, indexer_read_modify_write_location_time_us), 0.);
     EXPECT_DOUBLE_EQ(GET(p, meta_searcher, index_serialize_time_us), 0.);
@@ -146,13 +148,19 @@ TEST_F(MetricsCollectorTest, MetaSearcherMetricsTest) {
 
     // Test time measurement for indexer get
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, MetaSearcherIndexerGet);
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, MetaSearcherHostProjection);
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, MetaSearcherHostPrefixReduce);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, MetaSearcherIndexerReadModifyWriteBlock);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(p, MetaSearcherIndexerReadModifyWriteLocation);
     usleep(1000); // 1ms
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, MetaSearcherIndexerGet);
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, MetaSearcherHostProjection);
+    KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, MetaSearcherHostPrefixReduce);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, MetaSearcherIndexerReadModifyWriteBlock);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, MetaSearcherIndexerReadModifyWriteLocation);
     EXPECT_GE(GET(p, meta_searcher, indexer_get_time_us), 1000.0);
+    EXPECT_GE(GET(p, meta_searcher, host_projection_time_us), 1000.0);
+    EXPECT_GE(GET(p, meta_searcher, host_prefix_reduce_time_us), 1000.0);
     EXPECT_GE(GET(p, meta_searcher, indexer_read_modify_write_block_time_us), 1000.0);
     EXPECT_GE(GET(p, meta_searcher, indexer_read_modify_write_location_time_us), 1000.0);
 }

--- a/kv_cache_manager/metrics/test/revisit_interval_histogram_test.cc
+++ b/kv_cache_manager/metrics/test/revisit_interval_histogram_test.cc
@@ -217,6 +217,46 @@ TEST_F(RevisitIntervalHistogramTest, ManyObservations) {
     EXPECT_EQ(counts[3], 1000); // <= +Inf
 }
 
+TEST_F(RevisitIntervalHistogramTest, ObserveBatchMatchesIndividualObservations) {
+    const std::vector<double> boundaries = {1.0, 5.0, 10.0};
+    RevisitIntervalHistogram individual;
+    RevisitIntervalHistogram batched;
+    ASSERT_TRUE(individual.Init(registry_, boundaries, "individual"));
+    ASSERT_TRUE(batched.Init(registry_, boundaries, "batched"));
+
+    const std::vector<int64_t> intervals = {
+        -1,
+        0,
+        500000,
+        1000000,
+        3000000,
+        5000000,
+        7000000,
+        10000000,
+        50000000,
+    };
+    for (const int64_t interval : intervals) {
+        individual.Observe(interval);
+    }
+    batched.ObserveBatch(intervals);
+
+    EXPECT_EQ(individual.GetBucketCounts(), batched.GetBucketCounts());
+    EXPECT_EQ(individual.GetSum(), batched.GetSum());
+    EXPECT_EQ(individual.GetCount(), batched.GetCount());
+}
+
+TEST_F(RevisitIntervalHistogramTest, ObserveBatchIgnoresEmptyAndNonPositiveBatch) {
+    RevisitIntervalHistogram hist;
+    ASSERT_TRUE(hist.Init(registry_, {1.0, 5.0, 10.0}, "test_instance"));
+
+    hist.ObserveBatch({});
+    hist.ObserveBatch({-100, 0, -1});
+
+    EXPECT_EQ(0u, hist.GetCount());
+    EXPECT_EQ(0u, hist.GetSum());
+    EXPECT_EQ(std::vector<uint64_t>({0, 0, 0, 0}), hist.GetBucketCounts());
+}
+
 // 测试 le 标签格式化（整数边界不含多余零）
 TEST_F(RevisitIntervalHistogramTest, LeLabelFormatting) {
     RevisitIntervalHistogram hist;

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -80,7 +80,9 @@ message NodeRegisterEventParams {
 }
 
 message BlockAddEventParams {
-    string block_key = 1; // int64 as string
+    // Signed int64 decimal, or unsigned uint64 decimal mapped to the same
+    // internal 64-bit key (e.g. UINT64_MAX is equivalent to -1).
+    string block_key = 1;
     string uri = 2;       // deprecated, use specs instead
     string medium = 3;    // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
     repeated LocationSpec specs = 4;

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -17,6 +17,14 @@ from kv_cache_manager.py_connector.common.service_discovery_factory import (
 _LEADER_DISCOVERY_TIMEOUT_SECONDS = 5.0
 
 
+class KvCacheManagerHTTPError(requests.HTTPError, AssertionError):
+    """A non-200 Manager response, compatible with the legacy assertion API."""
+
+
+class KvCacheManagerProtocolError(requests.RequestException, AssertionError):
+    """The Manager returned HTTP 200 with a malformed API envelope."""
+
+
 class KvCacheManagerClient:
     @classmethod
     def from_connector_config(
@@ -60,40 +68,43 @@ class KvCacheManagerClient:
 
         self.session = requests.Session()
         self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        self._resource_lock = threading.Lock()
+        self._session_close_claimed = False
+        self._service_discovery_close_claimed = False
+        self._service_discovery_close_deferred = False
+        self._refresh_worker_cleanup_reached = False
+        # Constructor rollback uses the normal close path, so initialize its
+        # synchronization fields before invoking any discovery plugin code.
+        self._refresh_event = threading.Event()
+        self._closed = threading.Event()
+        self._refresh_thread = None
 
         # Resolve service-discovery URLs before issuing any HTTP requests. Keep the
         # discovery object alive so each leader refresh can start from a fresh endpoint.
         self._service_discovery: Optional[ServiceDiscovery] = None
         resolved_url = base_url
-        if not self._is_http_url(base_url):
-            self._service_discovery = create_service_discovery(base_url)
-            if self._service_discovery is None:
-                self.session.close()
-                raise ValueError(
-                    f"failed to create service discovery from manager address {base_url!r}"
-                )
-
-            try:
+        try:
+            if not self._is_http_url(base_url):
+                self._service_discovery = create_service_discovery(base_url)
+                if self._service_discovery is None:
+                    raise ValueError(
+                        f"failed to create service discovery from manager address {base_url!r}"
+                    )
                 endpoint = self._service_discovery.get_one_endpoint()
-            except Exception as e:
-                self._close_service_discovery()
-                self.session.close()
-                raise RuntimeError(
-                    f"failed to resolve manager endpoints from {base_url!r}"
-                ) from e
-            if endpoint is None:
-                self._close_service_discovery()
-                self.session.close()
-                raise RuntimeError(
-                    f"service discovery returned no manager endpoints for {base_url!r}"
-                )
+                if endpoint is None:
+                    raise RuntimeError(
+                        f"service discovery returned no manager endpoints for {base_url!r}"
+                    )
 
-            resolved_url = self._endpoint_url(endpoint)
-            logger.info(
-                "Service discovery (%s) resolved manager endpoint: %s",
-                self._service_discovery.get_type(),
-                resolved_url,
-            )
+                resolved_url = self._endpoint_url(endpoint)
+                logger.info(
+                    "Service discovery (%s) resolved manager endpoint: %s",
+                    self._service_discovery.get_type(),
+                    resolved_url,
+                )
+        except BaseException:
+            self._rollback_construction()
+            raise
 
         self.base_url = resolved_url.rstrip('/')
 
@@ -109,10 +120,7 @@ class KvCacheManagerClient:
         self._min_discover_interval = min_discover_interval_seconds
 
         self._route_lock = threading.Lock()
-        self._refresh_event = threading.Event()
-        self._closed = threading.Event()
         self._last_route_refresh_time = 0.0  # time.monotonic()
-        self._refresh_thread = None
 
         if self._auto_discover_leader:
             try:
@@ -124,10 +132,16 @@ class KvCacheManagerClient:
         # One route-refresh thread serves both modes. Leader discovery wakes
         # periodically; service-discovery-only mode waits for transport failures.
         if self._auto_discover_leader or self._service_discovery is not None:
-            self._refresh_thread = threading.Thread(
-                target=self._route_refresh_loop, daemon=True,
-                name="kvcm-route-refresh")
-            self._refresh_thread.start()
+            try:
+                self._refresh_thread = threading.Thread(
+                    target=self._route_refresh_loop, daemon=True,
+                    name="kvcm-route-refresh")
+                self._refresh_thread.start()
+            except BaseException:
+                # The caller cannot close an object whose constructor failed.
+                # Roll back both resources even when OS thread admission fails.
+                self._rollback_construction()
+                raise
 
     @staticmethod
     def _is_http_url(url):
@@ -239,29 +253,32 @@ class KvCacheManagerClient:
 
     def _route_refresh_loop(self):
         """Background daemon for periodic leader and event-driven route refresh."""
-        while not self._closed.is_set():
-            timeout = (
-                self._discovery_refresh_interval
-                if self._auto_discover_leader
-                else None
-            )
-            refresh_requested = self._refresh_event.wait(timeout=timeout)
-            self._refresh_event.clear()
-            if self._closed.is_set():
-                break
-            # Min interval protection: wait remaining time instead of skipping
-            remaining = self._min_discover_interval - (
-                time.monotonic() - self._last_route_refresh_time
-            )
-            if remaining > 0:
-                if self._closed.wait(timeout=remaining):
-                    break
-            try:
-                self._refresh_manager_route(
-                    force_service_refresh=refresh_requested,
+        try:
+            while not self._closed.is_set():
+                timeout = (
+                    self._discovery_refresh_interval
+                    if self._auto_discover_leader
+                    else None
                 )
-            except Exception as e:
-                logger.warning("Background manager route refresh failed: %s", e)
+                refresh_requested = self._refresh_event.wait(timeout=timeout)
+                self._refresh_event.clear()
+                if self._closed.is_set():
+                    break
+                # Min interval protection: wait remaining time instead of skipping
+                remaining = self._min_discover_interval - (
+                    time.monotonic() - self._last_route_refresh_time
+                )
+                if remaining > 0:
+                    if self._closed.wait(timeout=remaining):
+                        break
+                try:
+                    self._refresh_manager_route(
+                        force_service_refresh=refresh_requested,
+                    )
+                except Exception as e:
+                    logger.warning("Background manager route refresh failed: %s", e)
+        finally:
+            self._close_deferred_service_discovery()
 
     def _make_request(self, method, endpoint, data=None):
         """Helper method to make HTTP requests to the service"""
@@ -286,17 +303,34 @@ class KvCacheManagerClient:
 
         return response
 
-    def _check_response(self, endpoint, response, response_data):
-        """Validate API response, raise AssertionError on failure."""
+    def _check_response(self, endpoint, response, response_data,
+                        check_business_status=True):
+        """Validate transport/envelope and optionally the Manager status."""
         if response.status_code != 200:
-            raise AssertionError(f"Request to {endpoint} failed with status code {response.status_code}")
+            raise KvCacheManagerHTTPError(
+                f"Request to {endpoint} failed with status code {response.status_code}",
+                response=response,
+            )
 
-        if 'header' not in response_data:
-            raise AssertionError(f"Response from {endpoint} missing 'header' field")
+        if not isinstance(response_data, dict):
+            raise KvCacheManagerProtocolError(
+                f"Response from {endpoint} is not a JSON object"
+            )
+        header = response_data.get('header')
+        if not isinstance(header, dict):
+            raise KvCacheManagerProtocolError(
+                f"Response from {endpoint} missing a valid 'header' field"
+            )
+        status = header.get('status')
+        if not isinstance(status, dict) or not status.get('code'):
+            raise KvCacheManagerProtocolError(
+                f"Response from {endpoint} missing a valid 'header.status' field"
+            )
 
-        if response_data['header']['status']['code'] != "OK":
+        if check_business_status and status['code'] != "OK":
             raise AssertionError(
-                f"Request to {endpoint} failed with error: {response_data['header']['status']['message']}")
+                f"Request to {endpoint} failed with error: "
+                f"{status.get('message', '')}")
 
     def _make_api_request(self, endpoint, data=None, check_response=True):
         """Helper method to make POST requests to API endpoints and optionally validate response"""
@@ -319,6 +353,16 @@ class KvCacheManagerClient:
                 raise
 
             response_data = response.json()
+
+            # Validate transport and the common envelope before inspecting the
+            # status for leader routing. This remains mandatory even when callers
+            # ask to receive a non-OK business status verbatim.
+            self._check_response(
+                endpoint,
+                response,
+                response_data,
+                check_business_status=False,
+            )
 
             # SERVER_NOT_LEADER handling: rediscover leader and retry with backoff
             if self._auto_discover_leader and self._get_status_code(response_data) == 'SERVER_NOT_LEADER':
@@ -389,11 +433,75 @@ class KvCacheManagerClient:
         """Get cluster info including leader endpoint (leader discovery API)"""
         return self._make_api_request('/api/getClusterInfo', data, check_response)
 
+    def _close_session_once(self):
+        with self._resource_lock:
+            if self._session_close_claimed:
+                return
+            self._session_close_claimed = True
+        self.session.close()
+
+    def _rollback_construction(self):
+        try:
+            self.close()
+        except BaseException:
+            logger.error(
+                "Failed to release a partially constructed manager client",
+                exc_info=True,
+            )
+
+    def _request_service_discovery_close(self, refresh_thread):
+        discovery = None
+        with self._resource_lock:
+            if (
+                self._service_discovery_close_claimed
+                or self._service_discovery_close_deferred
+            ):
+                return
+            if (
+                refresh_thread is not None
+                and refresh_thread.is_alive()
+                and not self._refresh_worker_cleanup_reached
+            ):
+                self._service_discovery_close_deferred = True
+                return
+            self._service_discovery_close_claimed = True
+            discovery = self._service_discovery
+            self._service_discovery = None
+        if discovery is not None:
+            discovery.close()
+
+    def _close_deferred_service_discovery(self):
+        discovery = None
+        with self._resource_lock:
+            self._refresh_worker_cleanup_reached = True
+            if (
+                not self._service_discovery_close_deferred
+                or self._service_discovery_close_claimed
+            ):
+                return
+            self._service_discovery_close_deferred = False
+            self._service_discovery_close_claimed = True
+            discovery = self._service_discovery
+            self._service_discovery = None
+        if discovery is not None:
+            try:
+                discovery.close()
+            except Exception:
+                logger.error(
+                    "Failed to close service discovery after route-refresh exit",
+                    exc_info=True,
+                )
+
     def close(self):
         """Close the HTTP session, discovery client, and background refresh thread."""
         self._closed.set()
         self._refresh_event.set()
-        if self._refresh_thread and self._refresh_thread.is_alive():
-            self._refresh_thread.join(timeout=5)
-        self.session.close()
-        self._close_service_discovery()
+        refresh_thread = self._refresh_thread
+        if (
+            refresh_thread is not None
+            and refresh_thread is not threading.current_thread()
+            and refresh_thread.is_alive()
+        ):
+            refresh_thread.join(timeout=5)
+        self._close_session_once()
+        self._request_service_discovery_close(refresh_thread)

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock, patch, PropertyMock
 
 import requests
 
-from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
+from kv_cache_manager.py_connector.common.manager_client import (
+    KvCacheManagerClient,
+    KvCacheManagerProtocolError,
+)
 from kv_cache_manager.py_connector.common.service_discovery import ServiceEndpoint
 
 
@@ -97,6 +100,50 @@ class TestServiceDiscoveryInit(unittest.TestCase):
         mock_create.return_value = None
         with self.assertRaisesRegex(ValueError, "failed to create service discovery"):
             KvCacheManagerClient("custom://manager-service")
+
+    @patch(
+        "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
+    )
+    @patch("kv_cache_manager.py_connector.common.manager_client.requests.Session")
+    def test_discovery_factory_exception_closes_session(
+        self,
+        mock_session_cls,
+        mock_create,
+    ):
+        session = MagicMock()
+        mock_session_cls.return_value = session
+        mock_create.side_effect = RuntimeError("discovery plugin failed")
+
+        with self.assertRaisesRegex(RuntimeError, "discovery plugin failed"):
+            KvCacheManagerClient("custom://manager-service")
+
+        session.close.assert_called_once_with()
+
+    @patch(
+        "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
+    )
+    @patch("kv_cache_manager.py_connector.common.manager_client.requests.Session")
+    def test_discovery_post_resolution_exception_rolls_back_all_resources(
+        self,
+        mock_session_cls,
+        mock_create,
+    ):
+        session = MagicMock()
+        mock_session_cls.return_value = session
+        discovery = MagicMock()
+        discovery.get_one_endpoint.return_value = ServiceEndpoint(
+            ip="10.0.0.1",
+            port=8080,
+            host="10.0.0.1:8080",
+        )
+        discovery.get_type.side_effect = RuntimeError("discovery metadata failed")
+        mock_create.return_value = discovery
+
+        with self.assertRaisesRegex(RuntimeError, "discovery metadata failed"):
+            KvCacheManagerClient("custom://manager-service")
+
+        session.close.assert_called_once_with()
+        discovery.close.assert_called_once_with()
 
     @patch(
         "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
@@ -224,6 +271,65 @@ class TestRequestTimeout(unittest.TestCase):
             self.assertEqual(mock_post.call_args.kwargs["timeout"], 5.0)
         finally:
             client.close()
+
+
+class TestResponseClassification(unittest.TestCase):
+    """Transport/protocol failures must be distinct from Manager business errors."""
+
+    def setUp(self):
+        self.client = KvCacheManagerClient(
+            "http://10.0.0.1:8080",
+            auto_discover_leader=False,
+        )
+
+    def tearDown(self):
+        self.client.close()
+
+    def test_non_200_response_is_transport_failure(self):
+        self.client.session.post = MagicMock(
+            return_value=_make_mock_response({}, status_code=503)
+        )
+
+        with self.assertRaises(requests.HTTPError):
+            self.client.register_instance({"trace_id": "test"})
+
+    def test_malformed_api_envelope_is_protocol_failure(self):
+        for payload in ([], {}, {"header": {}}, {"header": {"status": {}}}):
+            with self.subTest(payload=payload):
+                self.client.session.post = MagicMock(
+                    return_value=_make_mock_response(payload)
+                )
+                with self.assertRaises(KvCacheManagerProtocolError):
+                    self.client.register_instance({"trace_id": "test"})
+
+    def test_manager_business_error_keeps_assertion_contract(self):
+        self.client.session.post = MagicMock(
+            return_value=_make_mock_response({
+                "header": {
+                    "status": {
+                        "code": "INVALID_ARGUMENT",
+                        "message": "bad request",
+                    }
+                }
+            })
+        )
+
+        with self.assertRaises(AssertionError) as caught:
+            self.client.register_instance({"trace_id": "test"})
+        self.assertNotIsInstance(caught.exception, requests.RequestException)
+
+    def test_check_response_false_still_validates_transport_and_envelope(self):
+        for response, error_type in (
+            (_make_mock_response({}, status_code=503), requests.HTTPError),
+            (_make_mock_response([]), KvCacheManagerProtocolError),
+        ):
+            with self.subTest(error_type=error_type.__name__):
+                self.client.session.post = MagicMock(return_value=response)
+                with self.assertRaises(error_type):
+                    self.client.report_event(
+                        {"trace_id": "test"},
+                        check_response=False,
+                    )
 
 
 class TestLeaderDiscoveryInit(unittest.TestCase):
@@ -678,6 +784,73 @@ class TestCloseLifecycle(unittest.TestCase):
         client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=False)
         client.close()  # Should not raise
         self.assertTrue(client._closed.is_set())
+
+    @patch(
+        "kv_cache_manager.py_connector.common.manager_client.create_service_discovery"
+    )
+    @patch("kv_cache_manager.py_connector.common.manager_client.requests.Session")
+    def test_refresh_thread_start_failure_rolls_back_resources(
+        self,
+        mock_session_cls,
+        mock_create_discovery,
+    ):
+        session = MagicMock()
+        mock_session_cls.return_value = session
+        discovery = MagicMock()
+        discovery.get_one_endpoint.return_value = ServiceEndpoint(
+            ip="10.0.0.1",
+            port=8080,
+            host="10.0.0.1:8080",
+        )
+        discovery.get_type.return_value = "Test"
+        mock_create_discovery.return_value = discovery
+
+        with patch(
+            "kv_cache_manager.py_connector.common.manager_client.threading.Thread.start",
+            side_effect=RuntimeError("thread admission failed"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "thread admission failed"):
+                KvCacheManagerClient(
+                    "custom://manager-service",
+                    auto_discover_leader=False,
+                )
+
+        session.close.assert_called_once_with()
+        discovery.close.assert_called_once_with()
+
+    def test_close_defers_discovery_cleanup_until_refresh_worker_exits(self):
+        client = KvCacheManagerClient(
+            "http://10.0.0.1:8080",
+            auto_discover_leader=False,
+        )
+        discovery = MagicMock()
+        client._service_discovery = discovery
+        worker_entered = threading.Event()
+        release_worker = threading.Event()
+
+        def blocked_refresh_worker():
+            try:
+                worker_entered.set()
+                release_worker.wait(timeout=5)
+            finally:
+                client._close_deferred_service_discovery()
+
+        refresh_thread = threading.Thread(target=blocked_refresh_worker)
+        client._refresh_thread = refresh_thread
+        refresh_thread.start()
+        self.assertTrue(worker_entered.wait(timeout=1))
+
+        with patch.object(refresh_thread, "join", return_value=None):
+            client.close()
+
+        discovery.close.assert_not_called()
+        release_worker.set()
+        refresh_thread.join(timeout=1)
+        self.assertFalse(refresh_thread.is_alive())
+        discovery.close.assert_called_once_with()
+
+        client.close()
+        discovery.close.assert_called_once_with()
 
 
 class TestThreadSafety(unittest.TestCase):

--- a/kv_cache_manager/service/grpc_service/meta_service_grpc.cc
+++ b/kv_cache_manager/service/grpc_service/meta_service_grpc.cc
@@ -116,28 +116,7 @@ grpc::Status MetaServiceGRpc::ReportEvent(grpc::ServerContext *context,
                                           const proto::meta::ReportEventRequest *request,
                                           proto::meta::ReportEventResponse *response) {
     std::string metrics_type;
-    std::shared_ptr<MetricsCollector> metrics_collector;
-    switch (request->storage_type()) {
-    case proto::meta::ST_EVENT_REPORT_L1P5:
-        metrics_type = kEventReportL1P5MetricsType;
-        metrics_collector = GetTypedMetricsCollectorForReportEvent(request->instance_id(), metrics_type);
-        break;
-    case proto::meta::ST_EVENT_REPORT_L2:
-        metrics_type = kEventReportL2MetricsType;
-        metrics_collector = GetTypedMetricsCollectorForReportEvent(request->instance_id(), metrics_type);
-        break;
-    default:
-        metrics_collector = get_metrics_collector_from_map_for_ReportEvent(request->instance_id());
-        break;
-    }
-    if (metrics_collector == nullptr) {
-        KVCM_LOG_ERROR("get ReportEvent metrics collector failed");
-        auto *header = response->mutable_header();
-        auto *status = header->mutable_status();
-        status->set_code(proto::meta::INSTANCE_NOT_EXIST);
-        status->set_message("get ReportEvent metrics collector failed");
-        return grpc::Status::OK;
-    }
+    auto metrics_collector = ResolveReportEventMetricsCollector(*request, metrics_type);
     API_CONTEXT_INIT(metrics_collector, ExtractIpFromPeer, context->peer())
     AttachReportEventTypeMetricsCollectors(*request, metrics_type, request_context);
     meta_service_impl_->ReportEvent(request_context, request, response);

--- a/kv_cache_manager/service/http_service/meta_service_http.cc
+++ b/kv_cache_manager/service/http_service/meta_service_http.cc
@@ -179,28 +179,7 @@ void MetaServiceHttp::ReportEvent(coro_http::coro_http_connection *http_conn,
                                   proto::meta::ReportEventRequest *request,
                                   proto::meta::ReportEventResponse *response) {
     std::string metrics_type;
-    std::shared_ptr<MetricsCollector> metrics_collector;
-    switch (request->storage_type()) {
-    case proto::meta::ST_EVENT_REPORT_L1P5:
-        metrics_type = kEventReportL1P5MetricsType;
-        metrics_collector = GetTypedMetricsCollectorForReportEvent(request->instance_id(), metrics_type);
-        break;
-    case proto::meta::ST_EVENT_REPORT_L2:
-        metrics_type = kEventReportL2MetricsType;
-        metrics_collector = GetTypedMetricsCollectorForReportEvent(request->instance_id(), metrics_type);
-        break;
-    default:
-        metrics_collector = get_metrics_collector_from_map_for_ReportEvent(request->instance_id());
-        break;
-    }
-    if (metrics_collector == nullptr) {
-        KVCM_LOG_ERROR("get ReportEvent metrics collector failed");
-        auto *header = response->mutable_header();
-        auto *status = header->mutable_status();
-        status->set_code(proto::meta::INSTANCE_NOT_EXIST);
-        status->set_message("get ReportEvent metrics collector failed");
-        return;
-    }
+    auto metrics_collector = ResolveReportEventMetricsCollector(*request, metrics_type);
     API_CONTEXT_INIT(metrics_collector, GetHttpClientIp, http_conn)
     std::string first_event_type = "N/A";
     std::string first_block_key = "N/A";
@@ -217,14 +196,14 @@ void MetaServiceHttp::ReportEvent(coro_http::coro_http_connection *http_conn,
             }
         }
     }
-    KVCM_LOG_INFO("[traceId: %s] ReportEvent called, instance_id: %s, host_ip_port: %s, event_count: %d, "
-                  "first_event_type: %s, first_block_key: %s",
-                  request->trace_id().c_str(),
-                  request->instance_id().c_str(),
-                  request->host_ip_port().c_str(),
-                  request->events_size(),
-                  first_event_type.c_str(),
-                  first_block_key.c_str());
+    KVCM_LOG_DEBUG("[traceId: %s] ReportEvent called, instance_id: %s, host_ip_port: %s, event_count: %d, "
+                   "first_event_type: %s, first_block_key: %s",
+                   request->trace_id().c_str(),
+                   request->instance_id().c_str(),
+                   request->host_ip_port().c_str(),
+                   request->events_size(),
+                   first_event_type.c_str(),
+                   first_block_key.c_str());
     AttachReportEventTypeMetricsCollectors(*request, metrics_type, request_context);
     meta_service_impl_->ReportEvent(request_context, request, response);
 }
@@ -233,10 +212,10 @@ void MetaServiceHttp::GetHostCacheState(coro_http::coro_http_connection *http_co
                                         proto::meta::GetHostCacheStateRequest *request,
                                         proto::meta::GetHostCacheStateResponse *response) {
     API_CONTEXT_GET_COLLECTOR_AND_INIT_HTTP(GetHostCacheState, __NOTHING__);
-    KVCM_LOG_INFO("[traceId: %s] GetHostCacheState called, instance_id: %s, block_cache_keys_count: %d",
-                  request->trace_id().c_str(),
-                  request->instance_id().c_str(),
-                  request->block_cache_keys_size());
+    KVCM_LOG_DEBUG("[traceId: %s] GetHostCacheState called, instance_id: %s, block_cache_keys_count: %d",
+                   request->trace_id().c_str(),
+                   request->instance_id().c_str(),
+                   request->block_cache_keys_size());
     meta_service_impl_->GetHostCacheState(request_context, request, response);
 }
 

--- a/kv_cache_manager/service/meta_service_impl.cc
+++ b/kv_cache_manager/service/meta_service_impl.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/service/meta_service_impl.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -111,6 +112,7 @@ namespace kv_cache_manager {
 namespace {
 
 constexpr const char *kReportEventFullAccessLogEnv = "KVCM_REPORT_EVENT_FULL_ACCESS_LOG";
+constexpr const char *kGetHostCacheStateFullAccessLogEnv = "KVCM_GET_HOST_CACHE_STATE_FULL_ACCESS_LOG";
 
 std::string BuildProtoMessageDebugJson(const google::protobuf::Message *message) {
     std::string debug_json;
@@ -119,6 +121,8 @@ std::string BuildProtoMessageDebugJson(const google::protobuf::Message *message)
 }
 
 bool IsReportEventFullAccessLogEnabled() { return EnvUtil::GetEnv(kReportEventFullAccessLogEnv, false); }
+
+bool IsGetHostCacheStateFullAccessLogEnabled() { return EnvUtil::GetEnv(kGetHostCacheStateFullAccessLogEnv, false); }
 
 const char *FirstBlockKeyFromEvent(const proto::meta::EventItem &event) {
     if (event.has_block_add()) {
@@ -244,6 +248,59 @@ std::string BuildReportEventResponseAccessLogSummary(const proto::meta::ReportEv
     writer.Int(failed_item_count);
     writer.Key("extra_info_size");
     writer.Uint64(response->extra_info().size());
+    writer.EndObject();
+    return sb.GetString();
+}
+
+std::string BuildGetHostCacheStateRequestAccessLogSummary(const proto::meta::GetHostCacheStateRequest *request) {
+    if (IsGetHostCacheStateFullAccessLogEnabled()) {
+        return BuildProtoMessageDebugJson(request);
+    }
+
+    rapidjson::StringBuffer sb;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+    writer.StartObject();
+    writer.Key("trace_id");
+    writer.String(request->trace_id().c_str());
+    writer.Key("instance_id");
+    writer.String(request->instance_id().c_str());
+    writer.Key("query_type");
+    writer.String(proto::meta::QueryType_Name(request->query_type()).c_str());
+    writer.Key("key_count");
+    writer.Int(request->block_cache_keys_size());
+    if (request->block_cache_keys_size() > 0) {
+        writer.Key("first_key");
+        writer.Int64(request->block_cache_keys(0));
+        writer.Key("last_key");
+        writer.Int64(request->block_cache_keys(request->block_cache_keys_size() - 1));
+    }
+    writer.Key("medium_count");
+    writer.Int(request->medium_size());
+    writer.EndObject();
+    return sb.GetString();
+}
+
+std::string BuildGetHostCacheStateResponseAccessLogSummary(const proto::meta::GetHostCacheStateResponse *response) {
+    if (IsGetHostCacheStateFullAccessLogEnabled()) {
+        return BuildProtoMessageDebugJson(response);
+    }
+
+    int64_t max_prefix_match_blocks = 0;
+    for (const auto &host : response->hosts()) {
+        max_prefix_match_blocks = std::max(max_prefix_match_blocks, host.prefix_match_blocks());
+    }
+    const auto &status = response->header().status();
+    rapidjson::StringBuffer sb;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+    writer.StartObject();
+    writer.Key("status_code");
+    writer.String(proto::meta::ErrorCode_Name(status.code()).c_str());
+    writer.Key("status_message");
+    writer.String(status.message().c_str());
+    writer.Key("returned_host_count");
+    writer.Int(response->hosts_size());
+    writer.Key("max_prefix_match_blocks");
+    writer.Int64(max_prefix_match_blocks);
     writer.EndObject();
     return sb.GetString();
 }
@@ -907,7 +964,10 @@ void MetaServiceImpl::GetHostCacheState(RequestContext *request_context,
                                         const proto::meta::GetHostCacheStateRequest *request,
                                         proto::meta::GetHostCacheStateResponse *response) {
     SPAN_TRACER(request_context);
-    API_CALL_GUARD("GetHostCacheState", true);
+    API_CALL_GUARD_WITH_DEBUG("GetHostCacheState",
+                              true,
+                              BuildGetHostCacheStateRequestAccessLogSummary(request),
+                              BuildGetHostCacheStateResponseAccessLogSummary(response));
     auto *header = response->mutable_header();
     auto *status = header->mutable_status();
     std::string invalid_fields = "missing or invalid fields: ";

--- a/kv_cache_manager/service/meta_service_impl.cc
+++ b/kv_cache_manager/service/meta_service_impl.cc
@@ -487,8 +487,13 @@ void MetaServiceImpl::GetCacheLocationsByBackend(RequestContext *request_context
     std::vector<BackendSelector> backend_selectors;
     backend_selectors.reserve(request->backend_selectors_size());
     for (const auto &sel : request->backend_selectors()) {
+        DataStorageType backend_type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
+        // StorageType is an open protobuf enum while DataStorageType uses an
+        // uint8_t underlying type. Explicit conversion prevents an unknown
+        // wire value such as 263 from truncating to L1P5 (7).
+        ProtoConvert::DataStorageTypeFromProto(sel.backend_type(), backend_type);
         backend_selectors.push_back({
-            static_cast<DataStorageType>(sel.backend_type()),
+            backend_type,
             static_cast<LocationSelectStrategy>(sel.strategy()),
         });
     }
@@ -877,11 +882,11 @@ void MetaServiceImpl::ReportEvent(RequestContext *request_context,
                               BuildReportEventResponseAccessLogSummary(response));
     auto *header = response->mutable_header();
 
-    KVCM_LOG_INFO("[traceId: %s] ReportEvent called, instance_id: %s, host_ip_port: %s, event_count: %d",
-                  request->trace_id().c_str(),
-                  request->instance_id().c_str(),
-                  request->host_ip_port().c_str(),
-                  request->events_size());
+    KVCM_LOG_DEBUG("[traceId: %s] ReportEvent called, instance_id: %s, host_ip_port: %s, event_count: %d",
+                   request->trace_id().c_str(),
+                   request->instance_id().c_str(),
+                   request->host_ip_port().c_str(),
+                   request->events_size());
 
     auto ec = cache_manager_->ReportEvent(request_context, request, response);
     // Partial failures are logged once with bounded per-type/error counts by
@@ -920,10 +925,10 @@ void MetaServiceImpl::GetHostCacheState(RequestContext *request_context,
     CacheManager::KeyVector keys(request->block_cache_keys().begin(), request->block_cache_keys().end());
     std::vector<std::string> mediums(request->medium().begin(), request->medium().end());
 
-    KVCM_LOG_INFO("[traceId: %s] GetHostCacheState called, instance_id: %s, block_cache_keys_count: %d",
-                  request->trace_id().c_str(),
-                  request->instance_id().c_str(),
-                  request->block_cache_keys_size());
+    KVCM_LOG_DEBUG("[traceId: %s] GetHostCacheState called, instance_id: %s, block_cache_keys_count: %d",
+                   request->trace_id().c_str(),
+                   request->instance_id().c_str(),
+                   request->block_cache_keys_size());
 
     auto [ec, host_matches] =
         cache_manager_->GetHostCacheState(request_context,
@@ -945,9 +950,9 @@ void MetaServiceImpl::GetHostCacheState(RequestContext *request_context,
         status->set_code(proto::meta::OK);
         request_context->set_status_code(status->code());
         status->set_message("Host cache state retrieved successfully");
-        KVCM_LOG_INFO("[traceId: %s] GetHostCacheState succeeded, returned %d hosts",
-                      request->trace_id().c_str(),
-                      response->hosts_size());
+        KVCM_LOG_DEBUG("[traceId: %s] GetHostCacheState succeeded, returned %d hosts",
+                       request->trace_id().c_str(),
+                       response->hosts_size());
     }
     SET_SPAN_TRACER_STR_IN_HEADER(request_context);
 }

--- a/kv_cache_manager/service/meta_service_metrics_base.cc
+++ b/kv_cache_manager/service/meta_service_metrics_base.cc
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <utility>
 
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/config/registry_manager.h"
@@ -46,6 +47,7 @@ void MetaServiceMetricsBase::InitMetrics() {
     MAKE_SERVICE_METRICS_COLLECTOR(RegisterInstance);
     MAKE_SERVICE_METRICS_COLLECTOR(GetInstanceInfo);
     MAKE_SERVICE_METRICS_COLLECTOR(GetClusterInfo);
+    MAKE_SERVICE_METRICS_COLLECTOR(ReportEvent);
     // GetClusterInfo 的全局 collector 也预置到 MAP 中，以空 instance_id 为 key
     KVCM_METRICS_COLLECTOR_MAP_(GetClusterInfo)[""] = KVCM_METRICS_COLLECTOR_(GetClusterInfo);
 }
@@ -173,6 +175,27 @@ std::shared_ptr<MetricsCollector> MetaServiceMetricsBase::GetEventTypeMetricsCol
 std::shared_ptr<MetricsCollector> MetaServiceMetricsBase::GetTypedMetricsCollectorForReportEventType(
     const std::string &instance_id, const std::string &type, const std::string &event_type) {
     return GetEventTypeMetricsCollectorFromMap(instance_id, type, event_type);
+}
+
+std::shared_ptr<MetricsCollector>
+MetaServiceMetricsBase::ResolveReportEventMetricsCollector(const proto::meta::ReportEventRequest &request,
+                                                           std::string &out_metrics_type) {
+    out_metrics_type.clear();
+    std::shared_ptr<MetricsCollector> collector;
+    switch (request.storage_type()) {
+    case proto::meta::ST_EVENT_REPORT_L1P5:
+        out_metrics_type = kEventReportL1P5MetricsType;
+        collector = GetTypedMetricsCollectorForReportEvent(request.instance_id(), out_metrics_type);
+        break;
+    case proto::meta::ST_EVENT_REPORT_L2:
+        out_metrics_type = kEventReportL2MetricsType;
+        collector = GetTypedMetricsCollectorForReportEvent(request.instance_id(), out_metrics_type);
+        break;
+    default:
+        collector = get_metrics_collector_from_map_for_ReportEvent(request.instance_id());
+        break;
+    }
+    return collector ? std::move(collector) : KVCM_METRICS_COLLECTOR_(ReportEvent);
 }
 
 void MetaServiceMetricsBase::AttachReportEventTypeMetricsCollectors(const proto::meta::ReportEventRequest &request,

--- a/kv_cache_manager/service/meta_service_metrics_base.h
+++ b/kv_cache_manager/service/meta_service_metrics_base.h
@@ -81,6 +81,11 @@ protected:
     std::shared_ptr<MetricsCollector> GetTypedMetricsCollectorForReportEventType(const std::string &instance_id,
                                                                                  const std::string &type,
                                                                                  const std::string &event_type);
+    // Metrics lookup must never become a functional precondition for the API:
+    // malformed or unknown-instance requests still need to reach ReportEvent's
+    // canonical validation path and return its status.
+    std::shared_ptr<MetricsCollector> ResolveReportEventMetricsCollector(const proto::meta::ReportEventRequest &request,
+                                                                         std::string &out_metrics_type);
     void AttachReportEventTypeMetricsCollectors(const proto::meta::ReportEventRequest &request,
                                                 const std::string &type,
                                                 RequestContext *request_context);
@@ -91,6 +96,7 @@ protected:
     KVCM_DECLARE_METRICS_COLLECTOR_(RegisterInstance);
     KVCM_DECLARE_METRICS_COLLECTOR_(GetInstanceInfo);
     KVCM_DECLARE_METRICS_COLLECTOR_(GetClusterInfo);
+    KVCM_DECLARE_METRICS_COLLECTOR_(ReportEvent);
     KVCM_DECLARE_METRICS_COLLECTOR_MAP_(GetCacheMeta);
     KVCM_DECLARE_METRICS_COLLECTOR_MAP_(GetCacheLocation);
     KVCM_DECLARE_METRICS_COLLECTOR_MAP_(GetCacheLocationsByBackend);

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -74,7 +74,10 @@ bool Server::Init(const ServerConfig &config) {
                               config_.GetCacheReclaimerIdleIntervalMs(),
                               config_.GetCacheReclaimerWorkerSize(),
                               async_delete_config,
-                              config_.GetSchedulePlanMigrationWorkerBudget())) {
+                              config_.GetSchedulePlanMigrationWorkerBudget(),
+                              config_.GetMetaQueryWorkerCount(),
+                              config_.GetMetaQueryParallelThreshold(),
+                              config_.GetMetaQueryChunkSize())) {
         KVCM_LOG_ERROR("cache manager init failed");
         return false;
     }

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -12,6 +12,22 @@
 
 namespace kv_cache_manager {
 
+namespace {
+
+bool ParseUint32Setting(const std::string &value, uint32_t &out) {
+    try {
+        std::size_t parsed_length = 0;
+        const auto parsed = std::stoull(value, &parsed_length);
+        if (parsed_length != value.size() || parsed > std::numeric_limits<uint32_t>::max()) {
+            return false;
+        }
+        out = static_cast<uint32_t>(parsed);
+        return true;
+    } catch (...) { return false; }
+}
+
+} // namespace
+
 std::vector<double> ServerConfig::ParseRevisitIntervalBuckets(const std::string &buckets_str) {
     auto boundaries = StringUtil::ParseBucketBoundaries(buckets_str);
     if (!buckets_str.empty() && boundaries.empty()) {
@@ -119,6 +135,18 @@ std::unordered_map<std::string, ServerConfig::SettingFunction> ServerConfig::kSe
          } catch (...) {
              return false;
          }
+     }},
+    {"kvcm.meta_query.worker_count",
+     [](const std::string &value, ServerConfig *config) {
+         return ParseUint32Setting(value, config->meta_query_worker_count_);
+     }},
+    {"kvcm.meta_query.parallel_threshold",
+     [](const std::string &value, ServerConfig *config) {
+         return ParseUint32Setting(value, config->meta_query_parallel_threshold_);
+     }},
+    {"kvcm.meta_query.chunk_size",
+     [](const std::string &value, ServerConfig *config) {
+         return ParseUint32Setting(value, config->meta_query_chunk_size_);
      }},
     {"kvcm.cache_reclaimer.key_sampling_size_total",
      [](const std::string &value, ServerConfig *config) {
@@ -239,6 +267,9 @@ void ServerConfig::UpdateDefaultConfig() {
     leader_elector_loop_interval_ms_ = 100;
     schedule_plan_executor_thread_count_ = 2;
     schedule_plan_migration_worker_budget_ = 1;
+    meta_query_worker_count_ = 4;
+    meta_query_parallel_threshold_ = 256;
+    meta_query_chunk_size_ = 128;
     cache_reclaimer_key_sampling_size_total_ = 1000;
     cache_reclaimer_key_sampling_size_per_task_ = 100;
     cache_reclaimer_del_batch_size_ = 100;
@@ -379,6 +410,13 @@ bool ServerConfig::Check() {
         schedule_plan_migration_worker_budget_ >= static_cast<uint32_t>(schedule_plan_executor_thread_count_)) {
         fprintf(stderr,
                 "SchedulePlanExecutor requires thread_count > 1 and 0 < migration_worker_budget < thread_count\n");
+        return false;
+    }
+
+    if (meta_query_worker_count_ == 0 || meta_query_worker_count_ > 64 || meta_query_parallel_threshold_ == 0 ||
+        meta_query_chunk_size_ == 0 || meta_query_chunk_size_ > meta_query_parallel_threshold_) {
+        fprintf(stderr,
+                "Meta query executor requires 1 <= worker_count <= 64 and 0 < chunk_size <= parallel_threshold\n");
         return false;
     }
 

--- a/kv_cache_manager/service/server_config.h
+++ b/kv_cache_manager/service/server_config.h
@@ -34,6 +34,9 @@ public:
     const std::string &startup_config() { return startup_config_; }
     int32_t GetSchedulePlanExecutorThreadCount() { return schedule_plan_executor_thread_count_; }
     uint32_t GetSchedulePlanMigrationWorkerBudget() const { return schedule_plan_migration_worker_budget_; }
+    uint32_t GetMetaQueryWorkerCount() const { return meta_query_worker_count_; }
+    uint32_t GetMetaQueryParallelThreshold() const { return meta_query_parallel_threshold_; }
+    uint32_t GetMetaQueryChunkSize() const { return meta_query_chunk_size_; }
     uint64_t GetCacheReclaimerKeySamplingSizeTotal() { return cache_reclaimer_key_sampling_size_total_; }
     uint64_t GetCacheReclaimerKeySamplingSizePerTask() { return cache_reclaimer_key_sampling_size_per_task_; }
     uint64_t GetCacheReclaimerDelBatchSize() { return cache_reclaimer_del_batch_size_; }
@@ -91,6 +94,9 @@ private:
     std::string startup_config_;
     int32_t schedule_plan_executor_thread_count_ = 0;
     uint32_t schedule_plan_migration_worker_budget_ = 0;
+    uint32_t meta_query_worker_count_ = 0;
+    uint32_t meta_query_parallel_threshold_ = 0;
+    uint32_t meta_query_chunk_size_ = 0;
     uint64_t cache_reclaimer_key_sampling_size_total_ = 0;
     uint64_t cache_reclaimer_key_sampling_size_per_task_ = 0;
     uint64_t cache_reclaimer_del_batch_size_ = 0;

--- a/kv_cache_manager/service/test/meta_service_metrics_base_test.cc
+++ b/kv_cache_manager/service/test/meta_service_metrics_base_test.cc
@@ -96,6 +96,24 @@ TEST_F(MetaServiceMetricsBaseTest, TypedReportEventCollectorUsesTypeTagAndStable
     ASSERT_EQ(l1p5, l1p5_cached);
 }
 
+TEST_F(MetaServiceMetricsBaseTest, ReportEventMetricsFallbackDoesNotGateRequestValidation) {
+    proto::meta::ReportEventRequest request;
+    request.set_instance_id("unknown-instance");
+    request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+
+    std::string metrics_type;
+    auto collector = base_->ResolveReportEventMetricsCollector(request, metrics_type);
+    ASSERT_NE(nullptr, collector);
+    EXPECT_EQ("event_report_l2", metrics_type);
+    EXPECT_EQ((MetricsTags{{"api_name", "ReportEvent"}}), collector->GetMetricsTags());
+
+    request.clear_instance_id();
+    request.set_storage_type(proto::meta::ST_UNSPECIFIED);
+    auto invalid_request_collector = base_->ResolveReportEventMetricsCollector(request, metrics_type);
+    EXPECT_EQ(collector, invalid_request_collector);
+    EXPECT_TRUE(metrics_type.empty());
+}
+
 TEST_F(MetaServiceMetricsBaseTest, InvalidateCollectorCacheRemovesTypedReportEventEntries) {
     SeedInstance("inst1", "grp1");
 

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -22,6 +22,9 @@ TEST_F(ServerConfigTest, TestSimple) {
         ASSERT_TRUE(config.Check());
         ASSERT_EQ(2, config.GetSchedulePlanExecutorThreadCount());
         ASSERT_EQ(1u, config.GetSchedulePlanMigrationWorkerBudget());
+        ASSERT_EQ(4u, config.GetMetaQueryWorkerCount());
+        ASSERT_EQ(256u, config.GetMetaQueryParallelThreshold());
+        ASSERT_EQ(128u, config.GetMetaQueryChunkSize());
         ASSERT_EQ(60000, config.GetCacheReclaimerInflightDeleteTimeoutMs());
         ASSERT_EQ(100000, config.GetCacheReclaimerPendingLocationLimitPerGroupType());
         ASSERT_EQ(64ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimitPerGroupType());
@@ -162,6 +165,42 @@ TEST_F(ServerConfigTest, TestSchedulePlanMigrationWorkerBudget) {
             {"kvcm.schedule_plan_migration_worker_budget", "invalid"},
         };
         EXPECT_FALSE(config.Parse("", environ));
+    }
+}
+
+TEST_F(ServerConfigTest, TestMetaQueryExecutorConfig) {
+    {
+        ServerConfig config;
+        std::unordered_map<std::string, std::string> environ{
+            {"kvcm.meta_query.worker_count", "8"},
+            {"kvcm.meta_query.parallel_threshold", "512"},
+            {"kvcm.meta_query.chunk_size", "64"},
+        };
+        ASSERT_TRUE(config.Parse("", environ));
+        EXPECT_TRUE(config.Check());
+        EXPECT_EQ(8u, config.GetMetaQueryWorkerCount());
+        EXPECT_EQ(512u, config.GetMetaQueryParallelThreshold());
+        EXPECT_EQ(64u, config.GetMetaQueryChunkSize());
+    }
+    for (const auto &invalid : std::vector<std::pair<std::string, std::string>>{
+             {"kvcm.meta_query.worker_count", "0"},
+             {"kvcm.meta_query.worker_count", "65"},
+             {"kvcm.meta_query.parallel_threshold", "0"},
+             {"kvcm.meta_query.chunk_size", "0"},
+         }) {
+        ServerConfig config;
+        ASSERT_TRUE(config.Parse("", {{invalid.first, invalid.second}}));
+        EXPECT_FALSE(config.Check()) << invalid.first << "=" << invalid.second;
+    }
+    {
+        ServerConfig config;
+        ASSERT_TRUE(
+            config.Parse("", {{"kvcm.meta_query.parallel_threshold", "128"}, {"kvcm.meta_query.chunk_size", "129"}}));
+        EXPECT_FALSE(config.Check());
+    }
+    for (const auto &invalid_value : {"invalid", "12x", "-1", "4294967296"}) {
+        ServerConfig config;
+        EXPECT_FALSE(config.Parse("", {{"kvcm.meta_query.worker_count", invalid_value}})) << invalid_value;
     }
 }
 

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -150,15 +150,19 @@ void ProtoConvert::StorageFromProto(const proto::admin::StorageConfig *proto_sto
     case proto::admin::StorageConfig::kEventReport: {
         EventReportStorageSpec spec;
         const auto &v = proto_storage_config->event_report();
-        if (v.heartbeat_timeout_ms() > 0)
+        // Proto3 scalar zero means "not supplied" for backward
+        // compatibility. Preserve any non-zero value so negative inputs reach
+        // StorageConfig validation instead of silently falling back to a
+        // valid-looking default.
+        if (v.heartbeat_timeout_ms() != 0)
             spec.set_heartbeat_timeout_ms(v.heartbeat_timeout_ms());
-        if (v.cleanup_grace_ms() > 0)
+        if (v.cleanup_grace_ms() != 0)
             spec.set_cleanup_grace_ms(v.cleanup_grace_ms());
-        if (v.liveness_check_interval_ms() > 0)
+        if (v.liveness_check_interval_ms() != 0)
             spec.set_liveness_check_interval_ms(v.liveness_check_interval_ms());
-        if (v.snapshot_min_interval_ms() > 0)
+        if (v.snapshot_min_interval_ms() != 0)
             spec.set_snapshot_min_interval_ms(v.snapshot_min_interval_ms());
-        if (v.snapshot_delta_drain_timeout_ms() > 0)
+        if (v.snapshot_delta_drain_timeout_ms() != 0)
             spec.set_snapshot_delta_drain_timeout_ms(v.snapshot_delta_drain_timeout_ms());
         storage_config.set_storage_spec(std::make_shared<EventReportStorageSpec>(spec));
         DataStorageType event_report_type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
@@ -246,7 +250,8 @@ void ProtoConvert::CacheConfigToProto(const CacheConfig &cache_config_info,
         auto *method_configs = proto_migration_strategy->mutable_method_configs();
         method_configs->mutable_copy()->set_enabled(migration_strategy->methods().copy().enabled());
         method_configs->mutable_mark()->set_enabled(migration_strategy->methods().mark().enabled());
-        method_configs->mutable_mark()->mutable_timeout_ms()->set_value(migration_strategy->methods().mark().timeout_ms());
+        method_configs->mutable_mark()->mutable_timeout_ms()->set_value(
+            migration_strategy->methods().mark().timeout_ms());
         proto_migration_strategy->set_retention(
             static_cast<proto::admin::MigrationRetention>(migration_strategy->retention()));
     }
@@ -328,13 +333,13 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
         methods.mutable_copy().set_enabled(proto_migration_strategy.method_configs().copy().enabled());
         methods.mutable_mark().set_enabled(proto_migration_strategy.method_configs().mark().enabled());
         if (proto_migration_strategy.method_configs().mark().has_timeout_ms()) {
-            methods.mutable_mark().set_timeout_ms(proto_migration_strategy.method_configs().mark().timeout_ms().value());
+            methods.mutable_mark().set_timeout_ms(
+                proto_migration_strategy.method_configs().mark().timeout_ms().value());
         } else {
             methods.mutable_mark().set_timeout_ms(MigrationMarkMethod::kDefaultTimeoutMs);
         }
         migration_strategy->set_methods(methods);
-        migration_strategy->set_retention(
-            static_cast<MigrationRetention>(proto_migration_strategy.retention()));
+        migration_strategy->set_retention(static_cast<MigrationRetention>(proto_migration_strategy.retention()));
         migration_strategies.push_back(migration_strategy);
     }
     cache_config_info.set_migration_strategies(migration_strategies);

--- a/kv_cache_manager/service/util/manager_message_proto_util.h
+++ b/kv_cache_manager/service/util/manager_message_proto_util.h
@@ -319,6 +319,10 @@ template <typename T>
 void ProtoConvert::DataStorageTypeFromProto(const T proto_data_storage_type, DataStorageType &data_storage_type_info) {
     static_assert(std::is_same_v<T, proto::meta::StorageType> || std::is_same_v<T, proto::admin::StorageType>,
                   "T must be either proto::meta::DataStorage or proto::admin::DataStorage");
+    // Protobuf enums are open on the wire. Always initialize the output so an
+    // unknown numeric value fails closed instead of leaving callers with an
+    // indeterminate DataStorageType.
+    data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
     switch (proto_data_storage_type) {
     case T::ST_UNSPECIFIED: {
         data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;

--- a/package/etc/default_server_config.conf
+++ b/package/etc/default_server_config.conf
@@ -72,6 +72,12 @@ kvcm.schedule_plan_executor_thread_count=8
 # 0 < migration_worker_budget < executor_thread_count，以保证至少一个 worker 可处理回收和系统任务
 kvcm.schedule_plan_migration_worker_budget=3
 
+# GetHostCacheState 大请求的独立有界 query executor。worker_count 包含 RPC caller，
+# 4 表示 caller + 3 个后台线程；小于 threshold 的请求保持串行。
+kvcm.meta_query.worker_count=4
+kvcm.meta_query.parallel_threshold=256
+kvcm.meta_query.chunk_size=128
+
 # 删除请求在 delay 结束后允许继续抵扣水位的最长时间；只关闭 credit，不中止底层 I/O
 kvcm.cache_reclaimer.inflight_delete_timeout_ms=60000
 


### PR DESCRIPTION
## Summary

This branch keeps the reviewed GetHostCacheState query-path optimizations and adds a focused pure-memory ReportEvent write-path optimization.

The ReportEvent change fuses the previous two metadata read-modify-write phases into one targeted RMW operation. For the local backend, key existence and requested location values are obtained from one LRU lookup and one item read lock, then mutations are applied under the existing shard-level ordering discipline.

The production implementation and the tests/documentation are intentionally split into two commits:

- `4342a1e [manager] fuse ReportEvent targeted metadata RMW`
- `ea05e58 [test] cover fused ReportEvent RMW performance`

## Why

Large L2 ADD batches showed block-count-linear latency. The old existing-location path performed two RMW phases and rebuilt several intermediate structures, increasing LRU lookups, item-lock operations, allocations, and metadata parsing. Under mixed load this also consumed CPU and allocator/LRU capacity needed by GetHostCacheState.

## Correctness and compatibility

- No protocol, persistence schema, or public API change.
- Preserves key-count and max-key-count semantics, including mixed batches containing existing updates plus new keys at capacity.
- Preserves lifecycle fencing, partial per-key errors, storage accounting, type validation, duplicate-name behavior, and cache/persistent fallback semantics.
- Status-aware response validation fails closed on malformed backend output.
- Query branch behavior remains unchanged by the two new ReportEvent commits.
- Runtime delivery target is pure in-memory `MetaLocalBackend`; a real Redis service is not required by this change.

## Validation

Pure-memory/local validation completed:

- `MetaSearcherTest`
- `meta_indexer_test`
- `CacheManagerTest` (10 shards)
- full manager/meta suite: 23/23 targets
- HTTP ReportEvent functional suite: 36/36 cases
- repeated HOST_DOWN and re-registration lifecycle races: 50 runs each
- targeted ASAN runs for manager/indexer/local backend
- Release build and linked-binary functional/performance runs
- `git diff --check`

## Performance

Release/O2 local single-request medians (create/update):

| Blocks | Before | After |
|---:|---:|---:|
| 100 | 1.57 / 1.59 ms | 1.53 / 1.40 ms |
| 1K | 9.41 / 10.16 ms | 9.20 / 8.73 ms |
| 5K | 43.75 / 48.26 ms | 42.34 / 40.99 ms |
| 20K | 172.00 / 202.12 ms | 169.75 / 172.09 ms |

The existing-location update path improves about 12–15%. In mixed ~150K block/s local tests, smaller publisher batches materially improved GetHostCacheState tail latency; approximately 2K blocks/batch was the stable tested point. These are comparative local measurements, not an SLA.

Detailed design, invariants, test matrix, raw measurements, and rollback guidance are in `docs/design/report_event_performance.md`.
