### PR TITLE
[client] fix LocalFileSdk::Put returning out-of-order actual_remote_uris

### DIFF
--- a/kv_cache_manager/client/src/internal/sdk/local_file_sdk.cc
+++ b/kv_cache_manager/client/src/internal/sdk/local_file_sdk.cc
@@ -236,23 +236,37 @@ ClientErrorCode LocalFileSdk::Put(const std::vector<DataStorageUri> &remote_uris
         KVCM_LOG_ERROR("Put failed, remote_uris size not equal to local_buffers size");
         return ER_INVALID_PARAMS;
     }
+    // 预分配并按原始下标回填，保证同序契约：actual_remote_uris[i] 对应 remote_uris[i]。
+    // SplitByPath 按 path 分组后迭代顺序是不确定的（unordered_map），不能按分组
+    // 顺序 append 结果，否则交错输入（同 backend 多 path）会乱序。
+    actual_remote_uris->resize(remote_uris.size());
     auto group_map = SplitByPath(remote_uris, local_buffers);
     for (const auto &group : group_map) {
         std::string file_path = group.first;
+        const BlockGroup &block_group = group.second;
+        std::vector<DataStorageUri> group_actual_uris;
         if (!std::filesystem::exists(file_path)) {
-            auto ec = Alloc(group.second.remote_uris, *actual_remote_uris);
+            auto ec = Alloc(block_group.remote_uris, group_actual_uris);
             if (ec != ER_OK) {
                 KVCM_LOG_ERROR("Put failed, alloc failed, errorcode: %d", ec);
                 return ER_SDKALLOC_ERROR;
             }
         } else {
-            actual_remote_uris->insert(
-                actual_remote_uris->end(), group.second.remote_uris.begin(), group.second.remote_uris.end());
+            group_actual_uris = block_group.remote_uris;
         }
-        auto ec = DoPut(group.second.remote_uris, group.second.local_buffers);
+        auto ec = DoPut(block_group.remote_uris, block_group.local_buffers);
         if (ec != ER_OK) {
             KVCM_LOG_ERROR("Put failed, DoPut failed, errorcode: %d", ec);
             return ER_SDKWRITE_ERROR;
+        }
+        if (group_actual_uris.size() != block_group.indices.size()) {
+            KVCM_LOG_ERROR("Put failed, alloc uris size [%zu] not equal to group size [%zu]",
+                           group_actual_uris.size(),
+                           block_group.indices.size());
+            return ER_SDKWRITE_ERROR;
+        }
+        for (size_t k = 0; k < block_group.indices.size(); ++k) {
+            (*actual_remote_uris)[block_group.indices[k]] = group_actual_uris[k];
         }
     }
     return ER_OK;

--- a/kv_cache_manager/client/src/internal/sdk/sdk_interface.cc
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_interface.cc
@@ -11,6 +11,7 @@ SdkInterface::GroupMap SdkInterface::SplitByPath(const std::vector<DataStorageUr
         auto &group = groups[uri.GetPath()];
         group.remote_uris.push_back(uri);
         group.local_buffers.push_back(buf);
+        group.indices.push_back(i);
     }
     return groups;
 }

--- a/kv_cache_manager/client/src/internal/sdk/sdk_interface.h
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_interface.h
@@ -21,6 +21,15 @@ public:
     virtual SdkType Type() = 0;
 
     // 一个remote_uri和一个Blockbuffer对应一个block
+    //
+    // 同序契约（Get/Put 共同遵守）：出参与入参按位置一一对应。
+    //   - Get：local_buffers[i] 必须被 remote_uris[i] 指向的 block 填充。
+    //   - Put：返回时 (*actual_remote_uris)[i] 必须是 remote_uris[i] /
+    //     local_buffers[i] 这个 block 实际写入的远端位置，且
+    //     actual_remote_uris->size() == remote_uris.size()。
+    // 实现不得按内部分组（如按 path 聚合）的迭代顺序回填 actual_remote_uris；
+    // 即使同一请求内多个 block 落在不同 path（交错出现），也必须保证上述同序性。
+    // 上层 SdkWrapper 依赖该契约把各 SDK 的返回值回填到原始请求位置。
     virtual ClientErrorCode Get(const std::vector<DataStorageUri> &remote_uris, const BlockBuffers &local_buffers) = 0;
     // actual_remote_uris是实际存储的远端地址
     virtual ClientErrorCode Put(const std::vector<DataStorageUri> &remote_uris,

--- a/kv_cache_manager/client/src/internal/sdk/sdk_type.h
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_type.h
@@ -20,6 +20,9 @@ enum class SdkType : uint8_t {
 struct BlockGroup {
     std::vector<DataStorageUri> remote_uris;
     BlockBuffers local_buffers;
+    // remote_uris[k] / local_buffers[k] 在原始输入中的下标，用于把按 path 分组
+    // 处理后的结果按原始输入顺序回填（同序契约，见 SdkInterface::Put）
+    std::vector<size_t> indices;
 };
 
 struct Hf3fsRemoteItem {

--- a/kv_cache_manager/client/src/internal/sdk/test/hf3fs_sdk_test.cc
+++ b/kv_cache_manager/client/src/internal/sdk/test/hf3fs_sdk_test.cc
@@ -486,6 +486,107 @@ TEST_F(Hf3fsSdkTest, PutBatch_ReturnOk_AllSuccess) {
     EXPECT_EQ(std::filesystem::file_size(uris[1].GetPath()), 2 * 4096 + size2);
 }
 
+// 同序契约回归：同一次 Put 包含多个不同 path，且同 path 不连续出现（[a, b, a]）。
+// 要求 actual_remote_uris[i] 与输入 remote_uris[i] 逐位置对应，且各 block 的
+// 数据确实落入输入位置对应的文件，而不是按内部分组顺序错位回填。
+TEST_F(Hf3fsSdkTest, PutBatch_ReturnOk_InterleavedPathsPreserveOrder) {
+    auto base = std::filesystem::path(mount_point_) / ("put_batch_order_" + std::to_string(::getpid()));
+    DataStorageUri u1;
+    u1.SetPath((base / "a/x.bin").string());
+    u1.SetParam("blkid", "0");
+    u1.SetParam("size", "4096");
+
+    DataStorageUri u2;
+    u2.SetPath((base / "b/y.bin").string());
+    u2.SetParam("blkid", "0");
+    u2.SetParam("size", "4096");
+
+    DataStorageUri u3;
+    u3.SetPath((base / "a/z.bin").string());
+    u3.SetParam("blkid", "0");
+    u3.SetParam("size", "4096");
+
+    std::vector<DataStorageUri> uris{u1, u2, u3};
+
+    // 每个 block 使用不同 payload，乱序写入或乱序回填时读回必然错位
+    BlockBuffers bufs(3);
+    std::vector<std::shared_ptr<uint8_t>> data;
+    for (size_t i = 0; i < uris.size(); ++i) {
+        auto d = std::shared_ptr<uint8_t>((uint8_t *)malloc(16), [](void *ptr) { free(ptr); });
+        std::memset(d.get(), 'a' + i, 16);
+        data.push_back(d);
+        bufs[i].iovs.push_back(Iov{MemoryType::CPU, d.get(), 16, false});
+    }
+
+    auto mock = std::dynamic_pointer_cast<MockHf3fsUsrbioApi>(sdk_->usrbio_api_);
+    ASSERT_TRUE(mock != nullptr);
+    EXPECT_CALL(*mock, Hf3fsRegFd(::testing::_, ::testing::_)).WillRepeatedly(::testing::Return(0));
+    EXPECT_CALL(*mock, Hf3fsDeregFd(::testing::_)).Times(::testing::AtLeast(0));
+    EXPECT_CALL(*mock,
+                Hf3fsIorCreate(::testing::NotNull(),
+                               ::testing::_,
+                               ::testing::_,
+                               ::testing::_,
+                               ::testing::_,
+                               ::testing::_,
+                               ::testing::_,
+                               ::testing::_))
+        .WillRepeatedly(::testing::Return(0));
+    EXPECT_CALL(*mock, Hf3fsIorDestroy(::testing::NotNull())).Times(::testing::AtLeast(0));
+    EXPECT_CALL(*mock,
+                Hf3fsPrepIo(::testing::_,
+                            ::testing::_,
+                            ::testing::_,
+                            ::testing::_,
+                            ::testing::_,
+                            ::testing::_,
+                            ::testing::_,
+                            ::testing::_))
+        .WillRepeatedly(::testing::Invoke([](const struct hf3fs_ior *ior,
+                                             const struct hf3fs_iov *iov,
+                                             bool read,
+                                             void *ptr,
+                                             int fd,
+                                             size_t off,
+                                             uint64_t len,
+                                             const void *userdata) {
+            lseek(fd, off, SEEK_SET);
+            return ::write(fd, ptr, len) == len ? 0 : -1;
+        }));
+    EXPECT_CALL(*mock, Hf3fsSubmitIos(::testing::_)).WillRepeatedly(::testing::Return(0));
+    EXPECT_CALL(*mock, Hf3fsWaitForIos(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Invoke([](const ::hf3fs_ior *, ::hf3fs_cqe *cqes, int cqec, int, const timespec *) {
+            for (int i = 0; i < cqec; ++i) {
+                cqes[i].result = 1;
+            }
+            return cqec;
+        }));
+
+    auto out = std::make_shared<std::vector<DataStorageUri>>();
+    auto rc = sdk_->Put(uris, bufs, out);
+    EXPECT_EQ(rc, ER_OK);
+    ASSERT_EQ(out->size(), uris.size());
+
+    // 同序契约：out[i] 与 uris[i] 逐位置对应（此处 URI 无 protocol，
+    // ToUriString() 为空串，须按 path/参数比较）
+    for (size_t i = 0; i < uris.size(); ++i) {
+        EXPECT_EQ(out->at(i).GetPath(), uris[i].GetPath());
+        EXPECT_EQ(out->at(i).GetParam("blkid"), uris[i].GetParam("blkid"));
+        EXPECT_EQ(out->at(i).GetParam("size"), uris[i].GetParam("size"));
+    }
+
+    // 数据确实落入输入位置对应的文件（blkid=0 -> 文件偏移 0 处）
+    for (size_t i = 0; i < uris.size(); ++i) {
+        ASSERT_TRUE(std::filesystem::exists(uris[i].GetPath()));
+        std::ifstream f(uris[i].GetPath(), std::ios::in | std::ios::binary);
+        ASSERT_TRUE(f.is_open());
+        char content[16] = {0};
+        f.read(content, sizeof(content));
+        EXPECT_EQ(std::string(content, sizeof(content)), std::string(16, 'a' + i))
+            << "payload mismatch at input position " << i << ": " << uris[i].ToUriString();
+    }
+}
+
 // ------------- Put (single) -------------
 TEST_F(Hf3fsSdkTest, Put_ReturnOk_EmptyIovs) {
     DataStorageUri uri;

--- a/kv_cache_manager/client/src/internal/sdk/test/local_file_sdk_test.cc
+++ b/kv_cache_manager/client/src/internal/sdk/test/local_file_sdk_test.cc
@@ -92,6 +92,81 @@ TEST_F(LocalFileSdkTest, TestPutGetWithCpu) {
     free(get_buffer);
 }
 
+// 同 backend（同一次 Put 调用）内多个不同 path 交错出现、且 payload 各不相同。
+// 修复前 SplitByPath 按 unordered_map 迭代顺序回填 actual_remote_uris，导致
+// 返回顺序与输入顺序不一致；本测试固定"同序契约"：actual_remote_uris[i] 必须
+// 对应 remote_uris[i]，且数据真正写入各自 path 对应的文件。
+TEST_F(LocalFileSdkTest, TestPutMultiPathInterleavedOrdering) {
+    LocalFileSdk sdk;
+    ASSERT_EQ(ER_OK, sdk.Init(sdk_backend_config_, nullptr));
+
+    // 交错输入：fileA(blk0), fileB(blk0), fileA(blk1)
+    DataStorageUri uri_a0("file://" + root_path_ + "/multi_path/fileA");
+    uri_a0.SetParam("blkid", "0");
+    uri_a0.SetParam("size", "1024");
+    DataStorageUri uri_b0("file://" + root_path_ + "/multi_path/fileB");
+    uri_b0.SetParam("blkid", "0");
+    uri_b0.SetParam("size", "1024");
+    DataStorageUri uri_a1("file://" + root_path_ + "/multi_path/fileA");
+    uri_a1.SetParam("blkid", "1");
+    uri_a1.SetParam("size", "1024");
+
+    const char *payload_a0 = "payload for fileA block0";
+    const char *payload_b0 = "payload for fileB block0";
+    const char *payload_a1 = "payload for fileA block1";
+    size_t len_a0 = strlen(payload_a0);
+    size_t len_b0 = strlen(payload_b0);
+    size_t len_a1 = strlen(payload_a1);
+
+    // 三个 block 使用相互独立、内容各异的 buffer
+    void *buf_a0 = malloc(1024);
+    void *buf_b0 = malloc(1024);
+    void *buf_a1 = malloc(1024);
+    std::memcpy(buf_a0, payload_a0, len_a0);
+    std::memcpy(buf_b0, payload_b0, len_b0);
+    std::memcpy(buf_a1, payload_a1, len_a1);
+
+    auto make_buffer = [](void *base, size_t size) {
+        BlockBuffer bb;
+        Iov iov;
+        iov.base = base;
+        iov.size = size;
+        iov.type = MemoryType::CPU;
+        iov.ignore = false;
+        bb.iovs.push_back(iov);
+        return bb;
+    };
+
+    std::vector<DataStorageUri> remote_uris = {uri_a0, uri_b0, uri_a1};
+    BlockBuffers local_buffers = {make_buffer(buf_a0, len_a0), make_buffer(buf_b0, len_b0), make_buffer(buf_a1, len_a1)};
+
+    auto actual_remote_uris = std::make_shared<std::vector<DataStorageUri>>();
+    ASSERT_EQ(ER_OK, sdk.Put(remote_uris, local_buffers, actual_remote_uris));
+
+    // 同序契约：返回顺序必须与输入一致
+    ASSERT_EQ(actual_remote_uris->size(), remote_uris.size());
+    EXPECT_EQ(actual_remote_uris->at(0).ToUriString(), uri_a0.ToUriString());
+    EXPECT_EQ(actual_remote_uris->at(1).ToUriString(), uri_b0.ToUriString());
+    EXPECT_EQ(actual_remote_uris->at(2).ToUriString(), uri_a1.ToUriString());
+
+    // 用全新的 buffer 读回，验证数据确实写入了各自 path 的文件
+    void *get_a0 = malloc(1024);
+    void *get_b0 = malloc(1024);
+    void *get_a1 = malloc(1024);
+    BlockBuffers get_buffers = {make_buffer(get_a0, len_a0), make_buffer(get_b0, len_b0), make_buffer(get_a1, len_a1)};
+    ASSERT_EQ(ER_OK, sdk.Get(*actual_remote_uris, get_buffers));
+    EXPECT_EQ(std::memcmp(get_a0, payload_a0, len_a0), 0);
+    EXPECT_EQ(std::memcmp(get_b0, payload_b0, len_b0), 0);
+    EXPECT_EQ(std::memcmp(get_a1, payload_a1, len_a1), 0);
+
+    free(buf_a0);
+    free(buf_b0);
+    free(buf_a1);
+    free(get_a0);
+    free(get_b0);
+    free(get_a1);
+}
+
 TEST_F(LocalFileSdkTest, TestPutGetWithGpu) {
 #ifdef USING_CUDA
     LocalFileSdk sdk;

--- a/kv_cache_manager/client/src/internal/sdk/test/mooncake_sdk_test.cc
+++ b/kv_cache_manager/client/src/internal/sdk/test/mooncake_sdk_test.cc
@@ -170,6 +170,9 @@ TEST_F(MooncakeSdkTest, TestMultipleUriWithCpu) {
 
     ASSERT_EQ(ER_OK, sdk.Put(remote_uris, local_buffers, actual_remote_uris));
     ASSERT_EQ(actual_remote_uris->size(), 2);
+    // 同序契约：actual_remote_uris[i] 与 remote_uris[i] 逐位置对应
+    ASSERT_EQ(actual_remote_uris->at(0).ToUriString(), uri1.ToUriString());
+    ASSERT_EQ(actual_remote_uris->at(1).ToUriString(), uri2.ToUriString());
 
     free(put_buffer_1);
     free(put_buffer_2);

--- a/kv_cache_manager/client/test/transfer_client_test.cc
+++ b/kv_cache_manager/client/test/transfer_client_test.cc
@@ -319,3 +319,69 @@ TEST_F(TransferClientMultiStorageTest, TestSaveAndLoadMixedStorage) {
     // Load
     EXPECT_EQ(ER_OK, client->LoadKvCaches(actual_uris, block_buffers));
 }
+
+// 回归测试：nfs_a/path1, nfs_b/pathX, nfs_a/path2 —— 同 backend（nfs_a）内多个
+// 不同 path 被 nfs_b 交错隔开。修复前 LocalFileSdk::Put 按 path 分组后以
+// unordered_map 迭代顺序回填 actual_uris，返回顺序与输入不一致，上层按契约回填
+// 时会把 URI 写到错误位置，后续按返回 URI 读取将拿到错块数据。
+TEST_F(TransferClientMultiStorageTest, TestSaveLoadInterleavedMultiPathOrdering) {
+    auto client = TransferClient::Create(client_config_, init_params_);
+    ASSERT_NE(client, nullptr);
+
+    UriStrVec uri_str_vec = {
+        "file://nfs_a/" + root_path_ + "tmp/nfs_a/path1?blkid=0&size=1024",
+        "file://nfs_b/" + root_path_ + "tmp/nfs_b/pathX?blkid=0&size=1024",
+        "file://nfs_a/" + root_path_ + "tmp/nfs_a/path2?blkid=0&size=1024",
+    };
+
+    const char *payload1 = "payload for nfs_a path1";
+    const char *payloadX = "payload for nfs_b pathX";
+    const char *payload2 = "payload for nfs_a path2";
+    size_t len1 = strlen(payload1);
+    size_t lenX = strlen(payloadX);
+    size_t len2 = strlen(payload2);
+
+    void *mem1 = malloc(1024);
+    void *memX = malloc(1024);
+    void *mem2 = malloc(1024);
+    std::memcpy(mem1, payload1, len1);
+    std::memcpy(memX, payloadX, lenX);
+    std::memcpy(mem2, payload2, len2);
+
+    auto make_buffer = [](void *base, size_t size) {
+        BlockBuffer bb;
+        Iov iov;
+        iov.type = MemoryType::CPU;
+        iov.base = base;
+        iov.size = size;
+        iov.ignore = false;
+        bb.iovs.push_back(iov);
+        return bb;
+    };
+    BlockBuffers block_buffers = {make_buffer(mem1, len1), make_buffer(memX, lenX), make_buffer(mem2, len2)};
+
+    // Save：返回 URI 顺序必须与输入一致
+    auto [save_ec, actual_uris] = client->SaveKvCaches(uri_str_vec, block_buffers);
+    ASSERT_EQ(ER_OK, save_ec);
+    ASSERT_EQ(uri_str_vec.size(), actual_uris.size());
+    EXPECT_EQ(uri_str_vec[0], actual_uris[0]);
+    EXPECT_EQ(uri_str_vec[1], actual_uris[1]);
+    EXPECT_EQ(uri_str_vec[2], actual_uris[2]);
+
+    // Load：用全新 buffer 按返回 URI 读回，验证数据确实落在各自的文件
+    void *get1 = malloc(1024);
+    void *getX = malloc(1024);
+    void *get2 = malloc(1024);
+    BlockBuffers get_buffers = {make_buffer(get1, len1), make_buffer(getX, lenX), make_buffer(get2, len2)};
+    EXPECT_EQ(ER_OK, client->LoadKvCaches(actual_uris, get_buffers));
+    EXPECT_EQ(std::memcmp(get1, payload1, len1), 0);
+    EXPECT_EQ(std::memcmp(getX, payloadX, lenX), 0);
+    EXPECT_EQ(std::memcmp(get2, payload2, len2), 0);
+
+    free(mem1);
+    free(memX);
+    free(mem2);
+    free(get1);
+    free(getX);
+    free(get2);
+}


### PR DESCRIPTION
## Summary

`LocalFileSdk::Put` grouped blocks by path into an `unordered_map` and appended results in map iteration order, so `actual_remote_uris[i]` did not correspond to `remote_uris[i]` when a single request spanned multiple paths (interleaved input). `SdkWrapper` relies on the same-order contract to scatter each SDK's results back to the original request positions, so the mismatch silently mapped blocks to the wrong URIs.

This PR fixes the ordering by recording each block's original index in `BlockGroup` and scattering per-group results back by index, and pins the same-order contract on `SdkInterface::Get/Put` with contract tests across all backends.

## Motivation

Raised as F3 in the review of PR #228: for a single backend with multiple paths, `actual_remote_uris` order may differ from the input order, and this behavior predates PR #228. The same-order contract is implicitly relied upon by `SdkWrapper::Put` (it places each group's results back at the original indices); making the contract explicit and LocalFileSdk order-stable removes a silent data-corruption hazard.

## Technical Details

**Root cause**: `LocalFileSdk::Put` calls `SplitByPath()` which groups blocks by path into an `unordered_map`, then appends each group's results in map iteration order. When the input interleaves paths (e.g. `pathA, pathB, pathA`), the returned `actual_remote_uris` no longer corresponds position-by-position to the input.

**Fix**: `BlockGroup` now records `indices` (each block's original input position) in `SplitByPath()`. `LocalFileSdk::Put` pre-allocates `actual_remote_uris` to the input size and writes each group's results back at the original indices, so the output is order-stable for any input arrangement, independent of the map's iteration order.

**Design note — the `indices` parallel array**: We are aware that the `indices` bookkeeping is less intuitive than a straightforward per-block loop. We kept it because it is the most performant option: it lets each path still be processed as one batch with a single `Alloc` call per path, instead of calling `Alloc` per block just to preserve order. The readability cost is contained in `SplitByPath` / the scatter loop and is compensated by the documented contract on `SdkInterface::Put`. We consider this trade-off acceptable.

**Design note — `actual_remote_uris`**: We were puzzled by the existence of this out-parameter and why it was pre-designed. We chose to respect it rather than simply returning `remote_uris` directly: the field may serve backends whose actual location is only finalized at write time (e.g. Mooncake's actual location may be determined when data is actually written, not before). However, we suspect that for LocalFileSdk — a deliberately "dumb" backend — the actual URI can never differ from the requested one. If that holds true, this path can be simplified in the future (e.g. dropping per-block bookkeeping entirely).

**Contract**: The same-order contract is now documented on `SdkInterface::Get/Put`. `Hf3fsSdk` and `MooncakeSdk` already satisfy it unchanged — they copy the input URIs in order via `Alloc`.

## Changes

| File | Change |
|------|--------|
| `client/src/internal/sdk/sdk_type.h` | `BlockGroup` gains `indices` (original input positions) |
| `client/src/internal/sdk/sdk_interface.cc` | `SplitByPath` records each block's original index |
| `client/src/internal/sdk/sdk_interface.h` | Document the same-order contract on `Get/Put` |
| `client/src/internal/sdk/local_file_sdk.cc` | Pre-allocate `actual_remote_uris`; scatter per-group results back by original index |
| `client/src/internal/sdk/test/local_file_sdk_test.cc` | Multi-path interleaved input with distinct payloads (fails without the fix) |
| `client/test/transfer_client_test.cc` | Regression test of the form `nfs_a/path1, nfs_b/pathX, nfs_a/path2` (fails without the fix) |
| `client/src/internal/sdk/test/hf3fs_sdk_test.cc` | Interleaved multi-path Put contract test via mock usrbio API, verifying URI order and payload placement |
| `client/src/internal/sdk/test/mooncake_sdk_test.cc` | Multi-URI Put test now asserts returned URI order |

## Known Limitations / Risks

- **Readability trade-off**: the `indices` parallel array is less intuitive; see the design note above. The invariant is documented on `SdkInterface::Put` so future SDK implementations cannot silently violate it.
- **LocalFileSdk `actual_remote_uris` is currently an identity**: `Alloc` is a no-op mapping for LocalFileSdk. If this remains true forever, the bookkeeping in this PR can be simplified away later; if a future backend ever relocates blocks, the index-scatter logic already handles it correctly.

## Testing

```bash
bazel test //kv_cache_manager/client/src/internal/sdk/test:LocalFileSdkTest  # PASSED (incl. new multi-path test)
bazel test //kv_cache_manager/client/test:TransferClientTest                 # PASSED (incl. new nfs_a/path1, nfs_b/pathX, nfs_a/path2 regression)
bazel test //kv_cache_manager/client/src/internal/sdk/test:hf3fs_sdk_test    # PASSED (incl. new interleaved multi-path contract test)
bazel test //kv_cache_manager/client/src/internal/sdk/test:MooncakeSdkTest   # pre-existing build failure unrelated to this PR (make_shared<char[]>, C++17 array form; target is manual-tagged)
```

Both LocalFileSdk tests (unit + TransferClient regression) fail without the fix.
