### PR TITLE
[py_connector] package standalone Manager Python client

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,8 @@
+exports_files(
+    ["LICENSE"],
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "using_cuda",
     values = {"define": "using_cuda=true"},

--- a/kv_cache_manager/manager_client/BUILD
+++ b/kv_cache_manager/manager_client/BUILD
@@ -27,6 +27,7 @@ py_wheel(
     name = "kv_cache_manager_manager_client_wheel",
     abi = "none",
     classifiers = [
+        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
         "Operating System :: OS Independent",
@@ -34,7 +35,11 @@ py_wheel(
     description_content_type = "text/markdown",
     description_file = "README.md",
     distribution = "tair-kvcache-manager-client",
+    extra_distinfo_files = {
+        "//:LICENSE": "LICENSE",
+    },
     homepage = "https://github.com/alibaba/tair-kvcache",
+    license = "Apache-2.0",
     platform = "any",
     python_requires = ">=3.9",
     python_tag = "py3",

--- a/kv_cache_manager/manager_client/BUILD
+++ b/kv_cache_manager/manager_client/BUILD
@@ -1,0 +1,71 @@
+load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "kv_cache_manager_manager_client",
+    srcs = ["__init__.py"],
+    deps = [
+        "//kv_cache_manager/py_connector/common:manager_client",
+    ],
+)
+
+py_package(
+    name = "kv_cache_manager_manager_client_pkg",
+    packages = [
+        "kv_cache_manager",
+        "stub_source",
+    ],
+    deps = [
+        ":kv_cache_manager_manager_client",
+    ],
+)
+
+py_wheel(
+    name = "kv_cache_manager_manager_client_wheel",
+    abi = "none",
+    classifiers = [
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Operating System :: OS Independent",
+    ],
+    description_content_type = "text/markdown",
+    description_file = "README.md",
+    distribution = "tair-kvcache-manager-client",
+    homepage = "https://github.com/alibaba/tair-kvcache",
+    platform = "any",
+    python_requires = ">=3.9",
+    python_tag = "py3",
+    requires = [
+        "requests>=2.31.0,<3",
+    ],
+    stamp = 1,
+    summary = "Python HTTP client for Tair KVCache Manager",
+    version = "{STABLE_KVCM_VERSION}+{STABLE_BUILD_TIMESTAMP}.{STABLE_GIT_COMMIT}",
+    deps = [
+        ":kv_cache_manager_manager_client_pkg",
+    ],
+)
+
+py_test(
+    name = "ManagerClientPublicApiTest",
+    size = "small",
+    srcs = ["public_api_test.py"],
+    main = "public_api_test.py",
+    deps = [
+        ":kv_cache_manager_manager_client",
+    ],
+)
+
+py_test(
+    name = "ManagerClientWheelContentsTest",
+    size = "small",
+    srcs = ["wheel_contents_test.py"],
+    args = ["$(location :kv_cache_manager_manager_client_wheel)"],
+    data = [
+        ":kv_cache_manager_manager_client_wheel",
+    ],
+    main = "wheel_contents_test.py",
+)

--- a/kv_cache_manager/manager_client/README.md
+++ b/kv_cache_manager/manager_client/README.md
@@ -1,0 +1,47 @@
+# Tair KVCache Manager Python Client
+
+`tair-kvcache-manager-client` is the lightweight HTTP client for Tair KVCache
+Manager. It contains the Manager client and its service-discovery helpers only;
+transfer SDKs, inference connectors, PyTorch, and native extensions are not
+included.
+
+## Installation
+
+```bash
+pip install tair-kvcache-manager-client
+```
+
+Python 3.9 or newer is required.
+
+## Build
+
+From the repository root:
+
+```bash
+bazelisk build //kv_cache_manager/manager_client:kv_cache_manager_manager_client_wheel.dist
+```
+
+## Usage
+
+```python
+from kv_cache_manager.manager_client import KvCacheManagerClient
+
+client = KvCacheManagerClient("http://127.0.0.1:6382")
+try:
+    response = client.get_cluster_info({"trace_id": "example"})
+finally:
+    client.close()
+```
+
+Static service discovery is also available through the Manager URI:
+
+```python
+client = KvCacheManagerClient(
+    "static://10.0.0.1:6382,10.0.0.2:6382",
+    auto_discover_leader=True,
+)
+try:
+    response = client.get_cluster_info({"trace_id": "example"})
+finally:
+    client.close()
+```

--- a/kv_cache_manager/manager_client/__init__.py
+++ b/kv_cache_manager/manager_client/__init__.py
@@ -1,0 +1,17 @@
+"""Public API for the standalone KVCM Manager Python client."""
+
+from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
+
+try:
+    from kv_cache_manager.py_connector.common._version_info import (
+        FULL_VERSION as __version__,
+    )
+except ImportError:  # Source-tree imports outside Bazel do not generate this module.
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        __version__ = version("tair-kvcache-manager-client")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"
+
+__all__ = ["KvCacheManagerClient", "__version__"]

--- a/kv_cache_manager/manager_client/public_api_test.py
+++ b/kv_cache_manager/manager_client/public_api_test.py
@@ -1,0 +1,15 @@
+import unittest
+
+import kv_cache_manager.manager_client as manager_client
+from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
+
+
+class PublicApiTest(unittest.TestCase):
+    def test_exports_manager_client_and_version(self):
+        self.assertIs(manager_client.KvCacheManagerClient, KvCacheManagerClient)
+        self.assertIsInstance(manager_client.__version__, str)
+        self.assertTrue(manager_client.__version__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kv_cache_manager/manager_client/wheel_contents_test.py
+++ b/kv_cache_manager/manager_client/wheel_contents_test.py
@@ -1,0 +1,45 @@
+import sys
+import unittest
+import zipfile
+from pathlib import Path
+
+
+class WheelContentsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.wheel_path = Path(sys.argv[1])
+        cls.archive = zipfile.ZipFile(cls.wheel_path)
+        cls.names = set(cls.archive.namelist())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.archive.close()
+
+    def test_contains_only_manager_client_runtime(self):
+        expected_files = {
+            "kv_cache_manager/manager_client/__init__.py",
+            "kv_cache_manager/py_connector/common/_version_info.py",
+            "kv_cache_manager/py_connector/common/logger.py",
+            "kv_cache_manager/py_connector/common/manager_client.py",
+            "kv_cache_manager/py_connector/common/service_discovery.py",
+            "kv_cache_manager/py_connector/common/service_discovery_factory.py",
+            "kv_cache_manager/py_connector/common/static_service_discovery.py",
+            "stub_source/kv_cache_manager/py_connector/common/__init__.py",
+            "stub_source/kv_cache_manager/py_connector/common/spectrum_service_discovery.py",
+        }
+        runtime_python_files = {name for name in self.names if name.endswith(".py")}
+        self.assertEqual(expected_files, runtime_python_files)
+        self.assertFalse(any(name.endswith((".so", ".pyd")) for name in self.names))
+
+    def test_declares_requests_dependency(self):
+        metadata_name = next(
+            name for name in self.names if name.endswith(".dist-info/METADATA")
+        )
+        metadata = self.archive.read(metadata_name).decode("utf-8")
+        self.assertIn("Name: tair-kvcache-manager-client", metadata)
+        self.assertIn("Requires-Dist: requests>=2.31.0,<3", metadata)
+        self.assertIn("Requires-Python: >=3.9", metadata)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/kv_cache_manager/manager_client/wheel_contents_test.py
+++ b/kv_cache_manager/manager_client/wheel_contents_test.py
@@ -37,8 +37,21 @@ class WheelContentsTest(unittest.TestCase):
         )
         metadata = self.archive.read(metadata_name).decode("utf-8")
         self.assertIn("Name: tair-kvcache-manager-client", metadata)
+        self.assertIn("License: Apache-2.0", metadata)
+        self.assertIn(
+            "Classifier: License :: OSI Approved :: Apache Software License",
+            metadata,
+        )
         self.assertIn("Requires-Dist: requests>=2.31.0,<3", metadata)
         self.assertIn("Requires-Python: >=3.9", metadata)
+
+    def test_contains_license(self):
+        license_name = next(
+            name for name in self.names if name.endswith(".dist-info/LICENSE")
+        )
+        license_text = self.archive.read(license_name).decode("utf-8")
+        self.assertIn("Apache License", license_text)
+        self.assertIn("Version 2.0", license_text)
 
 
 if __name__ == "__main__":

--- a/kv_cache_manager/py_connector/common/BUILD
+++ b/kv_cache_manager/py_connector/common/BUILD
@@ -11,3 +11,22 @@ py_library(
         "//stub_source/kv_cache_manager/py_connector/common:common",
     ],
 )
+
+# Keep the standalone Manager client dependency surface intentionally small.
+# In particular, do not pull types.py or tp_coordinator.py into its wheel: those
+# modules add torch/attrs/zmq dependencies that the HTTP client does not need.
+py_library(
+    name = "manager_client",
+    srcs = [
+        ":gen_version_info",
+        "logger.py",
+        "manager_client.py",
+        "service_discovery.py",
+        "service_discovery_factory.py",
+        "static_service_discovery.py",
+    ],
+    deps = [
+        "//stub_source/kv_cache_manager/py_connector/common:common",
+        "@pip_cpu//requests",
+    ],
+)


### PR DESCRIPTION
## Summary

- add a standalone pure-Python wheel target for the KVCache Manager HTTP client
- expose the stable `kv_cache_manager.manager_client` public import path
- keep the wheel dependency surface limited to `requests` and the required service-discovery modules
- add public API and wheel contract tests to guard package metadata and contents

## Validation

- Bazel ASAN tests for the public API and wheel contract
- existing Manager client and service-discovery unit tests (62 tests)
- clean virtual-environment installation and import of the generated wheel