### PR TITLE
[manager] move EventReport cleanup into background GC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
 - [后台扫描 GC](design/cache_garbage_collector.md) - 基于 authoritative cursor 的后台全量巡检；V1 清理长期 orphan WRITING 和普通 SERVING storage-missing，并提供无副作用读取、精确值条件 CAS 与 HA 生命周期
 - [CacheReclaimer 跨 Instance 公平逐出](design/cache_reclaimer_instance_fairness.md) - 按 Instance 用量分配采样与逐出预算，并与异步 credit 协同
+- [EventReport 主动回收纳入后台扫描 GC](design/event_report_background_gc.md) - 由 EventReportBackend 提供状态驱动的批量判定，复用统一 GC round 回收 stale snapshot 与 down host metadata
 
 ### 开发文档
 - [开发指南](develop/README.md) - 开发者入门指南和开发环境配置

--- a/docs/api/report_event.md
+++ b/docs/api/report_event.md
@@ -358,13 +358,13 @@ Snapshot 的完整性规则：
 - `medium` 不能包含 location id 分隔符 `#`；
 - 每个 block 的 specs 必须非空，且 spec name 必须已在
   `RegisterInstance.location_spec_infos` 中注册并且不能重复；
-- `blocks=[]` 表示该 reporter 当前没有任何 cache，会异步清理其全部旧 location。
+- `blocks=[]` 表示该 reporter 当前没有任何 cache；旧 location 会立即从 strict 查询结果隐藏，并由后台 GC 周期回收 metadata。
 
 Snapshot 的更新语义：
 
 - snapshot 中出现的 `block_key + medium` 会原地替换完整 spec 集合；
 - 已存在 block 中被本次省略的 spec 会被替换掉；
-- 整个 snapshot 中被省略的旧 block 由异步 cleanup 最终删除；
+- 整个 snapshot 中被省略的旧 block 由后台 GC 周期 cleanup 最终删除；
 - 成功后返回新的 generation；
 - 失败时不回滚已经完成的部分 metadata 写入，应完整重试。
 
@@ -381,7 +381,7 @@ Snapshot 的更新语义：
 
 - 必须是请求中的唯一事件；
 - 立即把 reporter 标记为不可用并从节点表注销；
-- 查询立即隐藏该 reporter，metadata 异步清理；
+- 查询立即隐藏该 reporter，metadata 由后台 GC 周期清理；
 - 重复 HOST_DOWN 幂等；
 - 同一 KVCM 进程内后续重新使用该 reporter identity 时必须先 REGISTER；KVCM 重启会清空
   进程内 tombstone，下一条合法汇报可以再次懒初始化。
@@ -704,8 +704,8 @@ snapshot 失败、KVCM 重启恢复或 realtime-only reporter 仍使用 soft met
 | registered + available | 所有合法事件按规则执行 | 可见 |
 | heartbeat timeout、仍在 grace | ADD/DELETE/SNAPSHOT 仍可能被接受；HEARTBEAT 可恢复 | 不可见 |
 | grace 内 HEARTBEAT 恢复 | 保留原 generation 和已写 metadata | 重新可见 |
-| 超过 grace 被 unregister | tombstone 后 mutation 返回 `NODE_NOT_REGISTERED` | 不可见，metadata 异步清理 |
-| HOST_DOWN | 立即 unregister，异步清理 | 立即不可见 |
+| 超过 grace 被 unregister | tombstone 后 mutation 返回 `NODE_NOT_REGISTERED` | 不可见，metadata 由后台 GC 周期清理 |
+| HOST_DOWN | 立即 unregister，metadata 由后台 GC 周期清理 | 立即不可见 |
 | tombstone 后重新 REGISTER | 可继续增量；generation 初始为空 | 未清干净的合法历史 metadata 可能重新可见 |
 | KVCM 重启 | 下一条合法事件自动恢复，不要求 REGISTER | 首条事件前隐藏；之后历史 metadata 可能重新可见 |
 
@@ -736,13 +736,19 @@ cache 发起物理 DELETE。清理以稳定 location 为粒度：如果一次增
 当前或 in-flight spec，清理就保留整个 location，避免误删刚成功的增量。旧 sibling spec
 由后续完整 snapshot 替换或回收。
 
-清理扫描耗时通过
-`event_report.snapshot_cleanup_scan_latency_ms{instance_id,host,type}` 暴露。典型场景下，
-1 个 instance、10 个 reporter、每台 5000 个 block，一次单 reporter snapshot 约产生 5000
-次 metadata replace，并以 1000 key 为批次扫描该 instance 约 5 万个 key。10 台同时完整对账
-约有 5 万次 replace、累计约 50 万次 key 检查；具体 Redis 命令数受 backend batching 影响。
-如果扫描延迟或 cleanup backlog 持续升高，应考虑按 reporter 建反向索引，而不是继续扩大
-全 instance 扫描频率。
+启用 EventReport 后台 GC 扩展后，Snapshot/HOST_DOWN 不再各自触发一次全 Instance 扫描；它们
+只更新 Backend 当前状态，统一 GC 在下一次成功覆盖目标 key 的 shared round 中完成 metadata
+回收。该路径是低优先级 best-effort 收敛，不提供事件级实时 SLA：对 scan view 中持续可见的
+目标，默认 2 小时 round cooldown 下保守量级约为
+`2h + 两段 round 扫描时间 + action 失败后的重新发现`。cached metadata 模式下 GC 只扫描内存 cache，
+不主动加载已淘汰的冷 key，因此这类 persistent-only metadata 不受上述时间上界约束。查询可见性
+不等待 GC，cleanup 延迟或残留只影响 metadata 空间和统计，不会让已判无效的 Reporter/旧
+generation 重新参与 strict 查询。
+
+运维通过 `cache_gc.scan_key_count`、`cache_gc.candidate_count{reason}`、
+`cache_gc.candidate_dropped_count{reason,cause}`、EventReport probe/delete 结果以及共享
+inflight count/age 指标观察扫描成本与积压。若后续形成更短的硬 SLO，应增加独立 cadence 的
+状态驱动扫描源或索引化 Candidate Source，不能恢复“每个事件投递一次全表扫描”。
 
 ## 14. 调用方上线检查清单
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,19 +121,25 @@ kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
 kvcm.cache_reclaimer.pending_delete_handler_limit=1024
 kvcm.cache_reclaimer.pending_bytes_limit=274877906944
 
-# leader 后台 metadata GC，默认关闭。V1 处理超过 grace 的 CLS_WRITING，
-# 以及 MightExist 明确 missing 的普通 CLS_SERVING Location（EventReport 除外）。
-kvcm.cache_gc.enabled=false
+# leader 后台 metadata GC，默认开启。处理超过 grace 的 CLS_WRITING、
+# MightExist 明确 missing 的普通 CLS_SERVING 以及 EventReport metadata 回收。
+kvcm.cache_gc.enabled=true
 # active round 的 tick 间隔；每个 tick 最多推进一个 backend batch。
 kvcm.cache_gc.scan_interval_ms=1000
-# 一个 full round 完成后的 cooldown，默认 24 小时。
-kvcm.cache_gc.round_pause_ms=86400000
-# backend key 数 hint，同时限制单次删除请求的 Location target 数。
+# 一个 full round 完成后的 cooldown，默认 2 小时；0 表示下一 tick 可开始新 round。
+kvcm.cache_gc.round_pause_ms=7200000
+# backend key 数 hint，同时限制单 tick 两类 action 合计的 Location target 数。
 kvcm.cache_gc.scan_batch_size=256
 # orphan WRITING grace，最小 1 小时（3600000ms），默认 24 小时。
 kvcm.cache_gc.orphan_writing_grace_period_ms=86400000
-# GC 在途删除请求硬上限；默认 2。一个慢请求只占一个槽位，全部槽位占满后暂停扫描。
+# 普通删除与 EventReport metadata action 共用的 GC 在途硬上限；默认 2。
+# 一个慢 action 只占一个槽位，全部槽位占满后暂停扫描。
 kvcm.cache_gc.max_inflight_delete_requests=2
+# 迁移期开关：由常规 GC round 基于 EventReportBackend 当前状态统一回收 metadata；
+# 默认开启，但仍受 kvcm.cache_gc.enabled 总开关控制；总开关关闭时保留 legacy 路径。
+kvcm.cache_gc.event_report_cleanup_enabled=true
+# 每个 GC tick 最多提交的 EventReport metadata Block key 数；Location 总数仍受 scan_batch_size 限制。
+kvcm.cache_gc.event_report_action_batch_size=32
 
 # 可选值有dummy，local，logging，kmonitor；若不配置或配置为空，默认使用local
 kvcm.metrics.reporter_type=local

--- a/docs/design/cache_garbage_collector.md
+++ b/docs/design/cache_garbage_collector.md
@@ -3,7 +3,7 @@
 | 项目 | 内容 |
 |---|---|
 | 状态 | V1 已实现并完成相关单测、E2E 与性能冒烟；基线已包含异步删除（#234）、分层存储迁移（#209）和精确值条件删除（#233） |
-| 更新时间 | 2026-07-30 |
+| 更新时间 | 2026-09-01 |
 | 涉及模块 | `manager`、`meta`、`data_storage`、`config`、`metrics`、`service` |
 | 历史参考 | [PR #184](https://github.com/alibaba/tair-kvcache/pull/184) |
 
@@ -24,11 +24,11 @@ CLS_WRITING -> CLS_SERVING -> CLS_DELETING -> metadata removed
 1. 容量达到水位后，由 Reclaimer 采样逐出；
 2. key 再次被访问时，通过 `MightExist()` 等检查机会式清理。
 
-如果容量没有达到水位，异常 key 此后也不再被访问，metadata 就可能长期残留。本需求建立一个只在 leader 运行的后台 GC，使长期 WRITING 和存储已明确丢失的普通 SERVING Location 能够主动收敛，并为后续 TTL 等场景提供统一的后台执行入口。
+如果容量没有达到水位，异常 key 此后也不再被访问，metadata 就可能长期残留。本需求建立一个只在 leader 运行的后台 GC，使 scan view 中可见的长期 WRITING 和存储已明确丢失的普通 SERVING Location 能够主动收敛，并为后续 TTL 等场景提供统一的后台执行入口。
 
-当前 metadata backend 没有按 Location 状态或创建时间查询的索引。V1 不在写入热路径维护新索引，而是按 cursor 分批扫描 authoritative metadata。cursor 只把一次全量扫描摊到多个 tick；一个完整 round 仍会读取全部 Block 和 Location metadata，成本约为 `O(keyspace + location metadata)`。
+当前 metadata backend 没有按 Location 状态或创建时间查询的索引。V1 不在写入热路径维护新索引，而是按 cursor 分批扫描 maintenance view：dual-backend 模式扫描内存 cache backend，single-backend 模式扫描唯一的 persistent backend。cursor 只把一次扫描摊到多个 tick；在 dual-backend 模式下，已从内存淘汰且未再次加载的冷 metadata 可能不会被发现，这是避免周期性全量扫描 Redis 的显式精度取舍。
 
-V1 采用“以固定间隔扫完一轮，再长时间休眠”的简单策略。默认 WRITING grace 和 round cooldown 都是 24 小时，避免小 keyspace 被持续重复扫描。若 active round 的开销仍不可接受，再根据性能数据引入动态 pacing 或到期索引。
+V1 采用“以固定间隔扫完一轮，再休眠固定时间”的简单策略。WRITING grace 默认 24 小时，round cooldown 默认 2 小时；两者分别控制删除资格和重复扫描频率。若 active round 的开销仍不可接受，再根据性能数据引入动态 pacing 或到期索引。
 
 ### 1.2 当前已知的异常状态
 
@@ -47,7 +47,7 @@ V1 采用“以固定间隔扫完一轮，再长时间休眠”的简单策略�
 
 `CLS_SERVING` 只表示 metadata 已完成写入结算，不保证 URI 对应的物理数据仍然存在。例如 TairMempool 节点退出后，若该 Block 没有再次被访问且容量未触发逐出，失效 metadata 会一直保留。
 
-在线查询已经通过低成本 `MightExist()` 机会式过滤这类 Location。GC V1 复用同一 backend 能力做后台探测：仅当普通 storage 的某个 spec 被明确判定为 missing 时，才把整个 Location 作为候选；backend 不支持低成本探测、返回 unknown、结果 shape 异常或调用失败时均不删除。EventReport 有独立的版本和所有权语义，不进入本规则。
+在线查询已经通过低成本 `MightExist()` 机会式过滤这类 Location。GC V1 复用同一 backend 能力做后台探测：仅当普通 storage 的某个 spec 被明确判定为 missing 时，才把整个 Location 作为候选；backend 不支持低成本探测、返回 unknown、结果 shape 异常或调用失败时均不删除。EventReport 不进入该布尔规则；其扩展在同一个 metadata batch 上调用 Backend 专用的三态判定，详见 [EventReport 主动回收纳入统一后台 GC](event_report_background_gc.md)。
 
 #### 长期 CLS_DELETING
 
@@ -65,7 +65,7 @@ V1 处理两类可保守判定的垃圾：超过 grace 且不属于活跃 Migrat
 
 ```text
 leader LoopThread
-  -> authoritative batch scan
+  -> no-touch maintenance batch scan
   -> 固定 WRITING 判定 / 批量 MightExist 探测
   -> 携带扫描快照的条件删除
   -> 复用 SchedulePlanExecutor::SubmitAsync
@@ -82,12 +82,12 @@ V1 不提前抽象通用 Rule Engine、Candidate Source、Action Dispatcher 或 
 
 V1 实现以下六项能力：
 
-1. **低频全量巡检**：按 Instance 和 cursor 分批读取 authoritative metadata；每个 tick 最多推进一个 batch，完成一轮后进入 cooldown。
+1. **低频内存优先巡检**：按 Instance 和 cursor 分批读取 maintenance view；dual-backend 扫描内存 cache backend，single-backend 扫描唯一 backend；每个 tick 最多推进一个 batch，完成一轮后进入 cooldown。
 2. **无副作用读取**：GC 扫描不能更新 LRU/access time、hit count、revisit histogram，也不能改变 online hot cache。
 3. **保守识别长期 WRITING**：只处理状态、创建时间和标识均明确有效，年龄达到 grace，且不属于活跃 Migration Copy 目标的 Location；异常时间、读取错误或活跃迁移一律跳过。
-4. **保守识别普通 SERVING 失效**：按 storage 批量调用低成本 `MightExist()`；任一 spec 明确 missing 时整个 Location 失效，unsupported/unknown/错误均跳过，EventReport 明确排除。
+4. **保守识别普通 SERVING 失效**：按 storage 批量调用低成本 `MightExist()`；任一 spec 明确 missing 时整个 Location 失效，unsupported/unknown/错误均跳过。EventReport 明确排除该规则，但其独立业务判定可复用同一个 scan batch 和统一预算。
 5. **异步精确条件删除**：请求携带扫描时的完整 Location 序列化值；Executor worker 重新读取 metadata，只有对象仍与快照完全一致时才执行当前状态到 `CLS_DELETING` 的 CAS。
-6. **有界异步反压和 leader 生命周期**：使用小型在途窗口并行消费 Executor 能力，每个 tick 最多提交一个请求，达到窗口上限后停止扫描；GC 只在 leader recovery 完成后运行，降级时在 metadata cleanup 前停止并 join。
+6. **有界异步反压和 leader 生命周期**：使用小型在途窗口并行消费 Executor 能力；基础 GC 每个 tick 最多提交一个物理删除请求，EventReport 扩展开启时还可提交一个 metadata-only action。达到窗口上限后停止扫描；GC 只在 leader recovery 完成后运行，降级时在 metadata cleanup 前停止并 join。
 
 所有扫描、判定和提交均保持严格的 `instance_id` 隔离。
 
@@ -97,11 +97,11 @@ V1 实现以下六项能力：
 
 1. 通用 Rule/Candidate/Action 框架和动态规则注册。
 2. WRITING deadline ZSET、TTL expiry index、CDC 或其他增量候选源。
-3. 动态 pacing、adaptive backoff、每轮预算、跨 Instance 公平调度。
+3. 动态 pacing、adaptive backoff、每轮预算，以及按容量贡献进行跨 Instance 公平逐出；后台扫描仅按 batch 在 Instance 间轮转。
 4. 动态或大规模并发窗口、多维 bytes/Group 配额、Future deadline 和持久化任务。
 5. `WriteLocationManager` 三元组索引、settling guard，以及 Reclaimer/Finish 竞态修复。
 6. `CLS_DELETING` 自动恢复和 storage version/epoch。
-7. EventReport reconciliation、Block TTL 和闲置 Instance 清理。
+7. EventReport reconciliation、Block TTL 和闲置 Instance 清理不属于本文定义的基础 GC V1；其中 EventReport 已作为独立扩展接入同一 round、cursor 和 scan batch，详见 [EventReport 主动回收纳入统一后台 GC](event_report_background_gc.md)。
 8. 查询链路 fast-submit 重构。
 9. GC lease/generation、跨进程 cursor 或 pending 恢复。
 10. data storage I/O timeout/cancel 和 CAS 后补偿状态机。
@@ -132,25 +132,27 @@ flowchart LR
     X[MigrationManager active target guard] --> W
     M --> S[Ordinary SERVING candidates]
     S --> D[DataStorageManager MightExist batches]
+    M --> V[EventReportBackend maintenance probe]
     W --> E[SchedulePlanExecutor exact-value SubmitAsync]
     D --> E
+    V --> C[Metadata-only expected-value delete]
     E --> F[Bounded Future window]
     F --> G
 ```
 
 | 组件 | V1 职责 |
 |---|---|
-| `CacheGarbageCollector` | 复用公共 `LoopThread` 做单线程调度，维护 round/cursor、固定判定、有界 Future 轮询和 pending target 去重 |
+| `CacheGarbageCollector` | 复用公共 `LoopThread` 做单线程调度，维护 round/per-Instance cursor、固定判定、有界 Future 轮询和 pending target 去重 |
 | `RegistryManager` | 在每轮开始时提供 Instance Group/Instance 快照 |
-| `MetaIndexer` | 从 authoritative backend 返回一个无副作用的 metadata batch |
+| `MetaIndexer` | 从 maintenance scan backend 返回一个无副作用的 metadata batch；dual-backend 优先内存层 |
 | `MigrationManager` | 识别仍属于活跃 Copy 的 WRITING 目标，防止被当作 orphan |
-| `DataStorageManager` | 按 storage 合并普通 SERVING 的 URI，并通过 `MightExist()` 做低成本保守探测 |
-| `SchedulePlanExecutor` | accepted 准入、worker 内重新读取、精确值条件 CAS、Sync、物理删除、最终 CAD 和端到端 Future |
+| `DataStorageManager` | 按 storage 合并普通 SERVING 的 URI，并通过 `MightExist()` 做低成本保守探测；EventReport 扩展按 Instance/type 路由到专用 Backend 判定 |
+| `SchedulePlanExecutor` | accepted 准入和端到端 Future；普通候选在 worker 内执行条件 CAS、Sync、物理删除和最终 CAD，EventReport 扩展在 worker 内执行 token/expected-value 复核与 metadata-only RMW |
 | `Server/CacheManager` | 在 leader recovery/demotion 和进程析构时管理 GC 生命周期 |
 
 GC 只访问 data storage 的低成本 `MightExist()` 探测接口，不执行物理删除，也不自行实现 Location 删除状态机。
 
-GC 的扫描协调不放入 `SchedulePlanExecutor`。Executor 是 Reclaimer、GC 等调用方共享的删除执行资源；把可能受 Redis SCAN/Get 延迟影响的完整扫描循环放入其中，会占用删除 worker，并把巡检速度与删除吞吐耦合。若扫描任务在 Executor worker 内提交删除后等待 Future，单 worker 配置下还会形成队内自依赖。
+GC 的扫描协调不放入 `SchedulePlanExecutor`。Executor 是 Reclaimer、GC 等调用方共享的删除执行资源；把 metadata scan/Get 循环放入其中，会占用删除 worker，并把巡检速度与删除吞吐耦合。若扫描任务在 Executor worker 内提交删除后等待 Future，单 worker 配置下还会形成队内自依赖。
 
 因此 V1 只为扫描协调保留一个轻量串行循环，并复用 `common::LoopThread`，不自行实现线程、定时等待和条件变量。GC 找到候选后立即调用 `SchedulePlanExecutor::SubmitAsync()`；Get/CAS/Sync、delay、物理删除和最终 CAD 仍全部由 Executor 执行。
 
@@ -162,14 +164,21 @@ GC 调度循环只保存：
 struct ScanState {
     std::vector<InstanceScanEntry> instances;
     size_t instance_index = 0;
-    std::string cursor = SCAN_BASE_CURSOR;
     uint64_t round_id = 0;
     std::optional<std::chrono::steady_clock::time_point> next_round_at;
+};
+
+struct InstanceScanEntry {
+    std::string instance_group;
+    std::string instance_id;
+    std::string cursor = SCAN_BASE_CURSOR;
+    bool completed = false;
 };
 
 struct InflightDelete {
     uint64_t round_id = 0;
     std::string instance_id;
+    std::string action_name;
     size_t target_count = 0;
     std::chrono::steady_clock::time_point submitted_at;
     std::vector<PendingLocationKey> pending_locations;
@@ -193,36 +202,36 @@ std::set<PendingLocationKey> pending_locations;
 3. 若在途请求数已达到 `max_inflight_delete_requests`，本 tick 结束，不继续扫描。
 4. 若仍处于 round cooldown，本 tick 结束。
 5. 若没有本轮快照，从 Registry 获取 Group/Instance 列表，按 `(instance_group, instance_id)` 排序；失败时按普通 tick 间隔重试。
-6. 对当前 Instance 调用一次 `ScanLocationsForMaintenance(cursor, scan_batch_size)`。
-7. 保存 next cursor，遍历返回的 Location：筛选长期 WRITING 并排除活跃 Migration Copy 目标；对普通 SERVING 的合法 URI 按 `(storage unique name, storage type)` 聚合，每次最多取 512 个 URI 调用 `MightExist()`；每个探测分块前后检查 stop，EventReport 和不确定结果跳过。
-8. 删除 target 按 `(block_key, location_id)` 去重，最多保留 `scan_batch_size` 个。请求为空时不调用 Executor。
-9. 非空请求携带每个 target 在扫描时的 `expected_location_values`，调用 `SubmitAsync()`：
+6. 对当前 Instance 调用一次 `ScanLocationsForMaintenance(entry.cursor, scan_batch_size)`。
+7. 保存该 Instance 的 next cursor，遍历返回的 Location：筛选长期 WRITING 并排除活跃 Migration Copy 目标；对普通 SERVING 的合法 URI 按 `(storage unique name, storage type)` 聚合，每次最多取 512 个 URI 调用 `MightExist()`；每个探测分块前后检查 stop。EventReport 扩展开启时在同一 batch 调用其专用三态 probe；所有不确定结果均跳过。
+8. 候选按 `(block_key, location_id)` 去重并统一排序，Location 总数最多为 `scan_batch_size`。EventReport 扩展另按唯一 Block key 限制 metadata action；请求为空时不调用 Executor。
+9. 普通候选和 EventReport 候选分别构造物理删除请求与 metadata-only 请求，并调用对应 `SubmitAsync()`。物理删除优先，因此一个 tick 最多提交两个请求，且不会超过剩余 inflight 槽位：
    - `accepted=true` 且 Future valid：保存 Future，并为最终请求建立 pending target；
-   - `accepted=false`：不建立 Future 或 pending，记录 `submit_rejected`；
+   - `accepted=false`：视为正常入队反压，不建立 Future 或 pending；
    - accepted/Future 契约不一致：记录 `submit_contract`，不建立本地状态；
    - 调用抛异常：记录 `submit_exception`，不建立本地状态。
-10. 当前 Instance cursor 回到 base 后推进到下一个 Instance；全部 Instance 完成后结束 round，并设置 `next_round_at = now + round_pause_ms`。
+10. 无论当前 cursor 是否回到 base，下一 tick 都轮转到下一个未完成 Instance；当前 Instance 回到 base 时将其标记完成。单个 Instance 在同一 round 内连续 3 次 Scan 失败后也标记为本轮完成，剩余 keyspace 延迟到下一 round 从 base cursor 重试，避免一个故障 Instance 永久卡住其他 Instance 和 Registry 新快照。全部 Instance 完成后结束 round，并设置 `next_round_at = now + round_pause_ms`。
 11. tick 结束后至少等待 `scan_interval_ms`。慢调用返回后不追赶错过的 tick。
 
-窗口默认包含 2 个请求。一个慢或卡住的物理删除只占用一个槽位，其他槽位仍可继续扫描和提交；只有全部槽位被占用时才暂停扫描。这为当前无容量上限的 Executor 队列提供了 GC 调用方侧的硬反压，同时利用 #234 已提供的 worker 并发。每个 tick 仍最多提交一个请求，不会形成突发灌入。`inflight_delete_count` 和 `inflight_delete_age_ms` 分别表示当前在途请求数和最老任务年龄。
+窗口默认包含 2 个请求。一个慢或卡住的物理删除或 metadata action 只占用一个槽位，其他槽位仍可继续扫描和提交；只有全部槽位被占用时才暂停扫描。这为当前无容量上限的 Executor 队列提供 GC 调用方侧的硬反压，同时利用 #234 已提供的 worker 并发。基础 GC 每 tick 最多提交一个物理删除；EventReport 扩展开启时，同一批最多再提交一个 metadata action。`inflight_delete_count` 和 `inflight_delete_age_ms` 分别表示当前 GC 在途 action 数和最老任务年龄。
 
-cursor 在 SubmitAsync 前已经推进。rejected、抛异常或 accepted/Future 契约错误时不回滚 cursor，也不保存该批候选；对象仍保留在 authoritative metadata，等待后续 full round 重新发现。这样避免为 V1 引入额外 retry queue。
+cursor 在 SubmitAsync 前已经推进。rejected、抛异常或 accepted/Future 契约错误时不回滚 cursor，也不保存该批候选；对象仍保留在 metadata 中。若它后续仍可从 maintenance view 观察到，则由后续 round 重新发现；dual-backend 下已被内存淘汰的对象不承诺仅靠 GC 主动重载。这样避免为 V1 引入额外 retry queue。
 
-同一 batch 中超过 target 上限的候选不会保存在额外 pending 表中；它们仍留在 authoritative metadata，等待后续 round 再次发现。这会牺牲极端场景的收敛速度，但保持 V1 状态简单。
+同一 batch 中超过 target 上限的候选不会保存在额外 pending 表中；它们仍留在 metadata 中，并在仍可见于 maintenance view 时由后续 round 再次发现。这会牺牲极端场景的收敛速度，但保持 V1 状态简单。
 
-### 3.4 全量扫描语义和成本
+### 3.4 Maintenance scan 语义和成本
 
-一个 round 只在开始时获取一次 Registry 快照，然后依次把每个 Instance 的 cursor 推进到 base。快照之后新增或删除的 Instance 允许本轮不可见或返回 Indexer 不存在，下一轮重新获取快照后收敛。
+一个 round 只在开始时获取一次 Registry 快照。每个 Instance 保存独立 cursor；调度器每个 tick 只推进一个 batch，随后轮转到下一个未完成 Instance，直到全部 cursor 回到 base。快照之后新增或删除的 Instance 允许本轮不可见或返回 Indexer 不存在，下一轮重新获取快照后收敛。
 
-Redis SCAN 和本地 backend cursor 不提供并发 exactly-once：
+Redis SCAN（single-backend）和本地 backend cursor（dual-backend）都不提供并发 exactly-once：
 
 - 同一 key 在一轮中可能重复；
 - 并发删除或索引移动可能使本轮漏过 key；
 - 并发新增 key 可能到下一轮才被看到。
 
-V1 只要求重复处理安全，并由后续 round 重新覆盖。扫描发现不是删除授权；最终是否删除由 Executor 对完整 Location 快照的条件 CAS 决定。
+V1 只要求重复处理安全；仍存在于 scan view 的对象可由后续 round 重新覆盖。扫描发现不是删除授权：普通物理删除由 Executor 的 authoritative read 和完整 Location 条件 CAS 决定；EventReport 扩展由 worker 内的 Backend token/lease 与 no-touch expected-value RMW 决定。
 
-设某 Instance 有 `N` 个 Block、平均每个 Block 有 `L` 个 Location，则一轮判定成本约为 `O(N + N*L)`。`scan_batch_size` 是 backend hint，不保证 Local backend 的单 shard 返回量严格受限。
+设 scan view 中某 Instance 有 `N` 个 Block、平均每个 Block 有 `L` 个 Location，则一轮判定成本约为 `O(N + N*L)`。dual-backend 的 `N` 是当前内存 cache 中可见的 key 数，不是 persistent keyspace；`scan_batch_size` 是 backend hint，不保证 Local backend 的单 shard 返回量严格受限。
 
 设 active round 耗时为 `S`、cooldown 为 `P`，正常候选的最坏发现时间约为：
 
@@ -230,16 +239,16 @@ V1 只要求重复处理安全，并由后续 round 重新覆盖。扫描发现�
 candidate eligibility delay + S + P
 ```
 
-WRITING 的 eligibility delay 是 grace；普通 SERVING storage-missing 一旦进入扫描即具备资格。默认 WRITING grace 和 `P` 都为 24 小时，因此该能力定位为最终收敛，不提供分钟级 SLA。SCAN 并发遗漏、target 裁剪、backend/探测错误和全部在途槽位卡住都可能继续延长时间。
+WRITING 的 eligibility delay 是 grace；普通 SERVING storage-missing 一旦进入扫描即具备资格。默认 WRITING grace 为 24 小时，`P` 为 2 小时，因此该能力定位为 best-effort 后台收敛，不提供分钟级 SLA。cursor 并发遗漏、target 裁剪、backend/探测错误、全部在途槽位卡住，以及 dual-backend 下目标已从内存淘汰，都可能继续延长时间；最后一种情况不承诺有限时间内仅靠 GC 收敛。
 
 ## 4. 详细设计
 
-### 4.1 无副作用 authoritative scan
+### 4.1 无副作用、内存优先的 maintenance scan
 
 GC 不能直接复用在线 `GetLocations()`：
 
 - Local/Dummy backend 的读取会更新 LRU 或 revisit 统计；
-- dual-backend Running 状态下，现有 `ListKeys()` 可能扫描可淘汰的 hot cache，而不是完整 persistent metadata。
+- 在线读取还可能在 cache miss 时回填完整 key，改变 hot cache 内容。
 
 V1 对 GC 暴露一个合并的维护接口，避免 GC 自己拼接 List 和 Get：
 
@@ -260,13 +269,15 @@ ErrorCode MetaIndexer::ScanLocationsForMaintenance(
 
 接口契约：
 
-1. key 和 Location 都读取 authoritative backend；dual-backend 时不能只看 hot cache。
-2. 读取不更新 access/LRU/revisit，也不向 hot cache 回填。
+1. dual-backend 模式从内存 cache backend 读取 key 和 Location；single-backend 模式从唯一 persistent backend 读取。
+2. 读取不更新 access/LRU/revisit，也不从 persistent backend 回填 hot cache。
 3. `keys`、`locations` 和 `location_results` 必须按下标对齐；shape 不一致视为整批错误，不做删除。
-4. Scan 级错误时不推进 cursor；单 key 已不存在或读取失败时跳过该 key，cursor 正常推进，由下一轮再覆盖。
+4. Scan 级错误时不推进 cursor，并先轮转其他 Instance；同一 Instance 本轮连续 3 次失败后跳过本轮，下一 round 从 base cursor 重试。单 key 已不存在或读取失败时跳过该 key，cursor 正常推进，由下一轮再覆盖。
 5. `limit` 只作为 backend hint；调用方不能假设实际数量一定不超过该值。
 
-实现上，该契约下沉到 backend 的合并扫描接口。Redis/AsyncRedis 组合 authoritative `SCAN` 和只读反序列化；Local/Dummy 在底层容器中直接复制 Location，不调用在线 `Lookup/Touch`。backend manager 在 dual-backend 模式下强制选择 persistent backend，在线读取接口保持不变。
+实现上，该契约下沉到 backend 的合并扫描接口。Local cache 在底层容器中直接复制 Location，不调用在线 `Lookup/Touch`；Redis/AsyncRedis 的 `SCAN` 只用于没有 cache backend 的 single-backend 部署。backend manager 在 dual-backend 模式下选择 cache backend 扫描，不因 miss 回填 persistent；在线读取接口保持不变。普通物理删除仍执行 authoritative revalidation；EventReport metadata action 在执行时 no-touch 对比 hot 与 persistent target，两侧值冲突则 fail-closed，也不会把 persistent 结果回填 hot cache。
+
+正常配置与 recovery 完成后，内存层应覆盖 GC 需要巡检的 metadata；但该完整性是运行期预期，不作为删除框架的强契约。这一选择降低了周期扫描 Redis 的常态成本，同时接受 dual-backend 下对 persistent keyspace 覆盖不完整：内存层未加载或已淘汰的冷 key 本轮不可见。GC 对这类对象只提供 best-effort 清理；后续业务访问、恢复或其他机制使其重新进入内存后，后续 round 才可能发现。
 
 ### 4.2 长期 orphan WRITING 判定
 
@@ -298,7 +309,7 @@ V1 不查询 `WriteLocationManager`。理由是：
 
 ### 4.3 普通 SERVING 的 storage-missing 判定
 
-GC 只探测 `status == CLS_SERVING` 且 storage type 已知的普通 Location，明确排除 EventReport。每个 scan batch 内先解析 Location spec URI，再按 `(storage unique name, storage type)` 聚合。调用前确认该 storage 仍已注册且 backend type 与 Location 一致；随后按最多 512 个 URI 分块调用 `MightExist()`，限制一次调用和 `DataStorageManager` 共享锁的持有范围。一个 Location 的多个 spec 可以分布在不同分块，结果按原下标映射回 Location。
+GC 的普通规则只探测 `status == CLS_SERVING` 且 storage type 已知的普通 Location，明确排除 EventReport。每个 scan batch 内先解析 Location spec URI，再按 `(storage unique name, storage type)` 聚合。调用前确认该 storage 仍已注册且 backend type 与 Location 一致；随后按最多 512 个 URI 分块调用 `MightExist()`，限制一次调用和 `DataStorageManager` 共享锁的持有范围。一个 Location 的多个 spec 可以分布在不同分块，结果按原下标映射回 Location。EventReport 扩展不复用该布尔判定，但消费同一个 `MaintenanceScanBatch`。
 
 `MightExist()` 的契约是低延迟且允许 false positive：backend 无法低成本或确定判断时返回 `true`，`false` 必须表示明确 missing。GC 的判定为：
 
@@ -339,7 +350,7 @@ GC 对 WRITING 和 SERVING 两类 target 都设置扫描时的 `CacheLocation::T
 
 如果并发 `FinishWriteCache` 已把 WRITING 改为 SERVING，或 SERVING 的 URI、create time 等字段被刷新，完整值比较会失败；如果 Reclaimer 同时提交同一 target，也只有一个 CAS winner。精确值条件比单独的 `expected_status` 更强，并允许一个请求同时包含 WRITING 与 SERVING 候选。
 
-未设置 `expected_location_values`、未启用 `authoritative_read` 的现有调用方保持当前行为。authoritative read 只在候选 admission/CAS 阶段触碰被选中的完整 key；全量 scan 本身仍不回填 hot cache。V1 不新增 GC 专用删除状态机，也不改变物理删除和最终 CAD 的顺序。
+未设置 `expected_location_values`、未启用 `authoritative_read` 的现有调用方保持当前行为。authoritative read 只在候选 admission/CAS 阶段触碰被选中的完整 key；maintenance scan 本身不从 persistent 回填 hot cache。V1 不新增 GC 专用删除状态机，也不改变物理删除和最终 CAD 的顺序。
 
 #234 的 `SubmitAsync()` 首次入队成功后立即返回；Get/CAS/Sync、delay 和物理删除都在 Executor 中完成。精确值筛选和 CAS 已由 #233 落在共享 `PrepareDeleteTaskImpl`/MetaSearcher RMW 中，同步与异步入口复用同一 admission 语义。
 
@@ -354,7 +365,7 @@ GC 同一时刻最多持有 `max_inflight_delete_requests` 个已接受请求的
 - pending key 包含 `instance_id`，相同 block/location 在不同 Instance 中互不影响；
 - 空请求不进入 Executor。
 
-pending 集合不承担删除授权，只用于覆盖请求 accepted 到 Executor CAS 之间的窗口，以及 Redis SCAN 可能在同一 round 重复返回 key 的情况。最终并发安全仍由 Executor 的完整 expected value 条件 CAS 保证。窗口和单请求 target 上限共同限定 pending 集合大小，不新增 bytes credit、deadline 或跨进程恢复。
+pending 集合不承担删除授权，只用于覆盖请求 accepted 到 Executor 执行前的窗口，以及 backend cursor 可能在同一 round 重复返回 key 的情况。普通物理删除最终由完整 expected value 条件 CAS 仲裁；EventReport metadata action 则由 worker 内的 Backend token/lease 和 expected-value RMW 仲裁。窗口和单请求 target 上限共同限定 pending 集合大小，不新增 bytes credit、deadline 或跨进程恢复。
 
 V1 沿用现有 `PlanExecuteResult` 语义，不新增 PARTIAL 或 per-target result：
 
@@ -363,7 +374,7 @@ V1 沿用现有 `PlanExecuteResult` 语义，不新增 PARTIAL 或 per-target re
 - 其他 ErrorCode：删除链路明确失败，记录 `delete_result_count{status}`，并输出包含 round、Instance、target 数和错误信息的 warning；
 - Future exception/invalid：Executor contract error。
 
-GC 不因单次失败停止后续 round，也不自动重试同一请求。仍满足 WRITING 或 storage-missing 判定的对象由后续 full scan 再次发现；已经进入 DELETING 的失败对象留给未来 DELETING reconciliation 处理。
+GC 不因单次失败停止后续 round，也不自动重试同一请求。仍满足 WRITING、storage-missing 或 EventReport Backend 判定，且仍可见于 maintenance view 的对象由后续 round 再次发现；已经进入 DELETING 的物理删除失败对象留给未来 DELETING reconciliation 处理。EventReport action 不进入 DELETING。
 
 ## 5. 生命周期与并发
 
@@ -404,9 +415,9 @@ GC.RequestStop() + Reclaimer.Pause()
 
 `RequestStop()` 只设置 GC stop 标志，并调用 `LoopThread::RunOnce()` 唤醒可能处于 tick/cooldown 等待的循环；回调看到 stop 后立即返回。该操作不 join，不能在关闭 leader 请求之前阻塞。`Join()` 随后调用 `LoopThread::Stop()` 完成 join，且必须位于 MigrationManager Stop 和 CacheManager/Registry cleanup 之前，保证 GC 不再读取活跃 Copy reservation 或其他依赖。V1 不修改公共 `LoopThread` 接口。
 
-`LoopThread` 回调在每次 Registry、Scan、DataStorage 探测分块和 SubmitAsync 前检查 stop，并在每个 `MightExist()` 分块返回后再次检查。已经进入的 Registry/Scan/MightExist 同步调用不能强制取消，`Join()` 会沿用底层现有 timeout/retry 语义，慢调用可能相应延长 demotion。Executor admission 已异步化，不阻塞 GC 的 `Join()`；GC 在 stop 时只丢弃本地 Future handle 和 pending 集合，不等待端到端删除 Future。`Join()` 只保证扫描回调不再访问 Registry、MetaIndexerManager、DataStorageManager 等依赖，不为物理删除建立 drain 屏障。
+`LoopThread` 回调在每次 Registry、Scan、DataStorage 探测分块和 SubmitAsync 前检查 stop，并在每个普通或 EventReport probe 分块返回后再次检查。已经进入的 Registry/Scan/probe 同步调用不能强制取消，`Join()` 会沿用底层现有 timeout/retry 语义，慢调用可能相应延长 demotion。Executor admission 已异步化，不阻塞 GC 的 `Join()`；GC 在 stop 时只丢弃本地 Future handle 和 pending 集合，不等待端到端 action Future。`Join()` 只保证扫描回调不再访问 Registry、MetaIndexerManager、DataStorageManager 等依赖，不为已接受 action 建立 drain 屏障。
 
-降级时若 GC 已提交删除，只丢弃本地 Future handle，不取消 Executor 中的任务。该任务与 Reclaimer 已提交任务使用相同的 best-effort detach 语义：cleanup 前完成则正常收敛；若已完成进入 `CLS_DELETING` 的 CAS，但后续重新获取 MetaIndexer、访问 DataStorage 或执行 metadata CAD 时依赖已被 cleanup，则 Future 可能以错误终态结束并留下长期 `CLS_DELETING`。V1 优先保证物理删除不会阻塞 leader demotion，不引入统一 Executor drain、任务资源 lease、跨 leader generation 或 DELETING 补偿；这些能力作为独立生命周期治理工作处理。
+降级时若 GC 已提交 action，只丢弃本地 Future handle，不取消 Executor 中的任务。普通删除与 Reclaimer 已提交任务使用相同的 best-effort detach 语义：cleanup 前完成则正常收敛；若已完成进入 `CLS_DELETING` 的 CAS，但后续依赖已被 cleanup，则 Future 可能以错误终态结束并留下长期 `CLS_DELETING`。EventReport action 在 worker 中重新校验 Backend/token 和 expected value；依赖已拆除时失败退出，不产生物理删除。V1 不引入统一 Executor drain、跨 leader generation 或 DELETING 补偿；这些能力作为独立生命周期治理工作处理。
 
 ### 5.3 进程停止和析构
 
@@ -420,26 +431,26 @@ Stop 通过 GC stop flag、`LoopThread::RunOnce()` 和最终 `LoopThread::Stop()
 |---|---|
 | Registry snapshot 失败 | 丢弃不完整快照，普通 tick 后重试 |
 | Instance/Indexer 不存在 | 跳过当前 Instance，下一轮重新发现 |
-| Scan 失败 | 不推进 cursor，普通 tick 后重试 |
+| Scan 失败 | 不推进 cursor并轮转其他 Instance；单 Instance 本轮连续 3 次失败后跳过本轮，下一 round 从 base cursor 重试 |
 | key 在 SCAN 后被并发删除（`EC_NOENT`） | 正常跳过，不计入 operation error |
 | 单 key Location 读取失败 | 跳过该 key、记录 `scan_key` error，下一轮覆盖 |
 | batch shape 不一致 | 整批拒绝，不提交 |
 | Location 字段或时间非法 | fail-closed 跳过 |
 | Location 是活跃 Migration Copy 目标 | 正常跳过；任务释放 reservation 后，若仍为 WRITING 则由后续 round 重新判断 |
-| EventReport SERVING | 不进入普通 storage-missing 规则，由独立 reconciliation 需求处理 |
+| EventReport SERVING | 不进入普通 storage-missing 规则；扩展开启时由同一 scan batch 调用 EventReportBackend 三态判定 |
 | URI 无法解析或无可探测 spec | 视为 unknown，单独不授权删除 |
 | storage 未注册 | 视为 unknown，不调用探测，记录 `might_exist_storage_not_found` |
 | backend type 与 Location 不一致 | 视为 unknown，不调用探测，记录 `might_exist_storage_type_mismatch` |
 | `MightExist()` 返回长度不一致 | 丢弃当前 URI 分块结果，记录 `might_exist_shape`；其他分块继续 |
 | `MightExist()` 抛异常 | 当前及后续分块视为 unknown，记录 `might_exist_exception`；已完成分块的明确结果保留，其他 storage 继续 |
 | 空候选 | 不调用 Executor |
-| SubmitAsync rejected | 记录 `submit_rejected` error，不占槽位、不建立 pending；cursor 不回滚，后续 round 重新发现 |
+| SubmitAsync rejected | 视为正常入队反压，不占槽位、不建立 pending；cursor 不回滚，后续 round 重新发现 |
 | SubmitAsync 直接抛异常 | 记录 `submit_exception` error，不占槽位、不建立 pending；cursor 不回滚 |
 | accepted/Future 不一致 | 记录 `submit_contract` error，不占槽位、不建立 pending；cursor 不回滚 |
 | 条件不匹配或 CAS loser | 合法 no-op，不告警为数据错误 |
 | Future 返回错误 | 释放对应槽位和 pending、记录结果，后续 round 继续 |
 | Future 长期未完成 | 保留其槽位和 pending、持续上报最老 age；其他槽位仍可推进，V1 不超时释放 |
-| stop 期间存在 Future | 丢弃本地 handle 和 pending，不取消或等待底层任务；任务 best effort 继续，CAS 后失败可能留下 `CLS_DELETING` |
+| stop 期间存在 Future | 丢弃本地 handle 和 pending，不取消或等待底层任务；任务 best effort 继续，普通删除 CAS 后失败可能留下 `CLS_DELETING`，EventReport action 仍需 worker 复核 |
 
 所有错误路径都必须经过 `scan_interval_ms` 或 cooldown，不能形成零间隔重试。
 
@@ -451,7 +462,7 @@ V1 只保留能回答“是否在扫描、发现了什么、删除是否卡住�
 |---|---|---|
 | `cache_gc.scan_round_count` | Counter | 完整 round 完成次数 |
 | `cache_gc.scan_key_count` | Counter | 扫描 Block 数 |
-| `cache_gc.candidate_count{reason}` | Counter | 候选数；V1 reason 为 `orphan_writing` 或 `storage_missing` |
+| `cache_gc.candidate_count{reason}` | Counter | 候选数；基础 V1 reason 为 `orphan_writing` 或 `storage_missing`，EventReport 扩展增加其业务原因 |
 | `cache_gc.delete_target_count` | Counter | 实际提交的 Location 数 |
 | `cache_gc.delete_result_count{status}` | Counter | Future 终态 |
 | `cache_gc.operation_error_count{stage}` | Counter | Registry/scan/submit/future 等异常；并发 `EC_NOENT`、条件不匹配和 CAS loser 不计入 |
@@ -469,21 +480,21 @@ round 和结果日志包含 `round_id`、`instance_id`、target 数、result；�
 
 1. disabled 不创建 `LoopThread`；Start/RequestStop/Join 重复调用安全，重新 Start 从 base cursor 开始。
 2. 每个 tick 最多调用一次 Scan；cursor、Instance 推进和 round cooldown 正确。
-3. Registry/Scan 失败按普通间隔重试，不推进错误 cursor，也不零间隔空转。
-4. maintenance scan 在 dual-backend 下读取 persistent metadata，不依赖 hot cache；Running 状态下即使候选 key 已从 hot cache 淘汰，Executor 仍会 authoritative re-read、刷新完整 key 并完成条件删除。
-5. Local/Dummy maintenance scan 不改变 LRU/access/revisit，也不回填 hot cache。
+3. Registry/Scan 失败按普通间隔重试，不推进错误 cursor，也不零间隔空转；单 Instance 重试耗尽不会阻塞 round 完成和后续 Registry 快照。
+4. maintenance scan 在 dual-backend 下只读取 cache backend，不回退 persistent；persistent-only key 不会被本轮发现，single-backend 则扫描唯一 backend。
+5. Local/Dummy maintenance scan 不改变 LRU/access/revisit；扫描不会触发 persistent-to-cache 回填。普通物理删除候选仍由 Executor authoritative re-read 后条件删除；EventReport 候选在 worker 中执行 no-touch expected-value RMW。
 6. 只有状态为 WRITING、字段有效且年龄达到 grace 的 Location 成为 orphan 候选；未来时间、解析失败和边界值 fail-closed。
 7. grace 配置不得小于 1 小时，默认值为 24 小时。
-8. 普通 SERVING 按 storage 批量探测，任一 spec 明确 missing 时选择整个 Location；全 true、无可探测 URI、storage 缺失/type 不符、shape 错误和异常均 fail-closed，EventReport 不进入该规则；单次探测不超过 512 URI。
-9. 请求保持 Instance 隔离，按 `(block_key, location_id)` 去重并受 batch target 上限约束；空请求不调用 Executor。
+8. 普通 SERVING 按 storage 批量探测，任一 spec 明确 missing 时选择整个 Location；全 true、无可探测 URI、storage 缺失/type 不符、shape 错误和异常均 fail-closed，EventReport 不进入该布尔规则；单次探测不超过 512 URI。扩展测试另验证 EventReport 与普通候选共享同一次 scan。
+9. 请求保持 Instance 隔离，按 `(block_key, location_id)` 去重并受 Location 总预算约束；EventReport action 另受唯一 Block key 预算约束，空请求不调用 Executor。
 10. GC 请求携带与 target 平行的完整序列化 Location；请求排队后 Finish、URI 刷新、DELETING 或 NOENT 均因 expected value 不匹配而不做物理删除。
 11. #209 活跃 Copy reservation 对应的 WRITING 目标不会成为候选；相同 location ID 在其他 Instance/Block 中不被误保护。
 12. GC 与另一个删除者同时提交同一 target 时只有一个 CAS winner。
-13. 有界窗口未满时一个慢 Future 不阻止其他 batch 提交，窗口占满后停止 Scan；Future 终态只释放自己的槽位和 pending，随后恢复扫描。
+13. 普通删除与 EventReport action 共用有界窗口；窗口未满时一个慢 Future 不阻止其他 batch 提交，窗口占满后停止 Scan；Future 终态只释放自己的槽位和 pending，随后恢复扫描。
 14. RequestStop 能打断 sleep/cooldown，并在当前 DataStorage 探测分块返回后停止后续分块；活跃 maintenance scan 或探测返回前 Join 必须等待，未完成删除 Future 不参与 GC drain 并按 best-effort detach；CacheManager cleanup 会先停止 GC 扫描线程。
 15. 未设置 `expected_location_values`、未启用 `authoritative_read` 的现有 Executor 调用方行为不变。
 16. 并发删除导致的 `EC_NOENT` 不增加 operation error；SubmitAsync 直接抛异常归入 `submit_exception` 而不是 `tick_exception`。
-17. accepted 到 CAS 期间同一 Instance 的相同 target 被 pending 过滤；不同 Instance 的相同 block/location 不互相抑制；rejected、invalid 和空请求不留下 pending。
+17. accepted 到 worker 执行期间同一 Instance 的相同 target 被 pending 过滤；不同 Instance 的相同 block/location 不互相抑制；rejected、invalid 和空请求不留下 pending。
 
 测试使用注入时钟或回填旧 `create_time`，不通过放宽生产 grace 下限制造并发窗口。
 
@@ -493,7 +504,7 @@ round 和结果日志包含 `round_id`、`instance_id`、target 数、result；�
 
 1. KVCM + Dummy metadata + NFS data storage：模拟进程重启后 session 丢失，回填超过 grace 的 WRITING，确认删除链路完成 metadata 清理，Block 可再次写入。
 2. 同一 Group 多 Instance 中，未到 grace 的 WRITING 不删除，只有过期 Instance 被处理。
-3. cached metadata 模式下通过 persistent backend 发现并清理 orphan；persistent-only/no-backfill 和 LRU 不变由 backend component test 单独验证。
+3. cached metadata 模式下，recovery/业务加载后已进入内存的 orphan 可被 GC 发现并清理；cache-only scan、persistent miss 不回填和 LRU 不变由 backend component test 单独验证。
 4. GC 开启期间执行真实 leader demotion，确认进程健康进入 standby，cleanup 完成后 scan round 不再增长。
 5. KVCM + Dummy metadata + Dummy data storage：完成 SERVING 后移除物理文件，不发起 Get，确认后台 `MightExist()` 发现并清理 metadata，Block 可再次写入。
 
@@ -510,20 +521,20 @@ NFS 只用于验证物理删除控制链路；Dummy 持久化文件用于构造�
 3. 逐级扩大 keyspace，并组合不同 `scan_batch_size`、`scan_interval_ms`，观察 active round 的扫描吞吐和在线请求退化趋势。
 4. 让慢物理删除分别占用一个和全部在途槽位，验证部分槽位被占用时仍可推进、窗口满时停止扫描的反压行为。
 
-比较在线 Get/StartWrite/FinishWrite P50/P95/P99、Redis QPS/CPU/网络流量、KVCM CPU/RSS、active round 时长、每秒扫描 key 数和垃圾收敛时间，同时确认业务请求无新增失败、active-scan 场景确实产生扫描量。测试结果用于判断默认 batch/interval 是否可接受，以及 V2 是否需要动态 pacing、减少 metadata 读取量或引入索引化候选源。
+比较在线 Get/StartWrite/FinishWrite P50/P95/P99、内存 cache 扫描 CPU/锁等待、候选 action 产生的 Redis QPS/CPU/网络流量、KVCM CPU/RSS、active round 时长、每秒扫描 key 数和垃圾收敛时间，同时确认业务请求无新增失败、active-scan 场景确实产生扫描量。测试结果用于判断默认 batch/interval 是否可接受，以及 V2 是否需要动态 pacing、提升 persistent 覆盖率或引入索引化候选源。
 
 ## 9. 验收标准
 
 1. disabled、standby 和 leader recovery 完成前不扫描、不提交。
-2. GC 能从 authoritative backend 完成全量 round，且扫描不改变业务访问统计。
+2. GC 能对选定的 maintenance backend 完成一轮 cursor 覆盖；dual-backend 只扫描 cache、single-backend 扫描唯一 backend，且扫描不改变业务访问统计。
 3. grace 最小 1 小时、默认 24 小时，在 30 分钟 write session 上限之外保留安全余量；判定异常时 fail-closed。
-4. 只有长期且不属于活跃 Migration Copy 的 WRITING，或被 backend 明确判定至少一个 spec missing 的普通 SERVING 进入删除请求；EventReport 和不确定探测结果不会被该规则删除。
+4. 只有长期且不属于活跃 Migration Copy 的 WRITING，或被 backend 明确判定至少一个 spec missing 的普通 SERVING 进入物理删除请求；不确定探测结果不会删除。EventReport 只有 Backend 返回明确 `DeleteMetadata` 时才产生 metadata-only action。
 5. 并发 Finish、Location 刷新、Reclaimer 或重复 SCAN 由完整 expected Location value 的条件 CAS 安全仲裁。
-6. 在途删除请求不超过配置上限；单个慢任务不会暂停整个 GC，全部槽位占满时形成硬反压，空请求和错误不会形成提交风暴或 CPU 空转。
+6. 普通删除和 EventReport metadata action 的 GC 在途总数不超过配置上限；单个慢任务不会暂停整个 GC，全部槽位占满时形成硬反压，空请求和错误不会形成提交风暴或 CPU 空转。
 7. 每轮完成后至少等待 `round_pause_ms`，不会持续重复全扫。
-8. demotion 时先停止新 leader 请求，再在 cleanup 前完成 GC 扫描线程 join；慢 maintenance metadata/DataStorage 探测可以延长 join。已接受的物理删除不参与 GC drain，但仍可能因共享 worker 或 DataStorageManager 锁竞争间接延长后续 cleanup。
+8. demotion 时先停止新 leader 请求，再在 cleanup 前完成 GC 扫描线程 join；慢 maintenance metadata/DataStorage 探测可以延长 join。已接受的普通删除和 EventReport action 不参与 GC drain，但仍可能因共享 worker 或依赖竞争间接延长后续 cleanup。
 9. 未设置 `expected_location_values` 的现有 Executor 调用方保持兼容。
-10. 通用规则框架、索引化扫描、DELETING、EventReport reconciliation、TTL、闲置 Instance 和 Reclaimer/Finish 修复均未被隐式实现。
+10. 通用规则框架、索引化扫描、DELETING、TTL、闲置 Instance 和 Reclaimer/Finish 修复均未被隐式实现；EventReport reconciliation 以独立扩展文档为准。
 
 ## 10. 实现落点与配置
 
@@ -531,11 +542,11 @@ NFS 只用于验证物理删除控制链路；Dummy 持久化文件用于构造�
 
 | 文件 | 职责 |
 |---|---|
-| `kv_cache_manager/manager/cache_garbage_collector.h/.cc` | 复用 `common::LoopThread`，维护 round/cursor、固定 WRITING 判定、普通 SERVING 批量探测、Migration 活跃目标过滤、有界 Future/pending 和两阶段停止 |
-| `kv_cache_manager/manager/schedule_plan_executor.*` | 复用 #234 异步链路和 #233 的精确条件删除；为 maintenance 请求增加显式 authoritative admission 选项 |
+| `kv_cache_manager/manager/cache_garbage_collector.h/.cc` | 复用 `common::LoopThread`，维护 round/per-Instance cursor、固定 WRITING 判定、普通 SERVING 与 EventReport 批量探测、Migration 活跃目标过滤、统一预算、Future/pending 和两阶段停止 |
+| `kv_cache_manager/manager/schedule_plan_executor.*` | 复用 #234 异步链路和 #233 的精确条件删除；增加 EventReport metadata-only action，worker 内复核 Backend/token/expected value |
 | `kv_cache_manager/manager/cache_manager.h/.cc` | 注入 Registry、MetaIndexer、DataStorage、Executor 等依赖，并管理 leader 启停和析构 |
-| `kv_cache_manager/meta/meta_indexer.h/.cc` | 合并的 maintenance scan、persistent re-read 与 shard-lock 内 cache refresh 接口 |
-| `kv_cache_manager/meta/meta_storage_backend*.h/.cc` | authoritative List/no-touch Location 读取，以及候选 key 的完整 persistent-to-cache refresh |
+| `kv_cache_manager/meta/meta_indexer.h/.cc` | no-touch maintenance scan，以及沿用普通 mutation fence 的 no-touch expected-value RMW 入口 |
+| `kv_cache_manager/meta/meta_storage_backend*.h/.cc` | dual-backend cache-first maintenance scan、no-touch Location 读取/删除和 recovery fail-closed |
 | `kv_cache_manager/metrics/kmonitor_metrics_reporter.cc` | 注册并周期上报 GC 固定指标及带标签指标族 |
 | `kv_cache_manager/service/server_config.h/.cc` | GC 配置解析和校验 |
 | `kv_cache_manager/service/server.cc` | leader recovery/demotion 接线 |
@@ -550,14 +561,16 @@ V1 不修改 `write_location_manager.*`、`cache_reclaimer.*` 或 `migration_man
 
 | 配置 | 默认值 | 说明 |
 |---|---:|---|
-| `kvcm.cache_gc.enabled` | `false` | 默认关闭，灰度开启 |
+| `kvcm.cache_gc.enabled` | `true` | 默认开启；可显式设为 `false` 回退 |
 | `kvcm.cache_gc.scan_interval_ms` | 1000 | 相邻 tick 的最小间隔 |
-| `kvcm.cache_gc.round_pause_ms` | 86400000 | 完成一个 full round 后的 cooldown |
+| `kvcm.cache_gc.round_pause_ms` | 7200000 | 完成一个 full round 后的 cooldown；0 表示下一 tick 可开始新 round |
 | `kvcm.cache_gc.scan_batch_size` | 256 | backend key 数 hint，同时作为单请求 target 上限 |
 | `kvcm.cache_gc.orphan_writing_grace_period_ms` | 86400000 | WRITING 自动清理 grace，必须不小于 3600000 ms |
-| `kvcm.cache_gc.max_inflight_delete_requests` | 2 | GC 在途删除请求硬上限，必须大于 0；每个请求最多包含 `scan_batch_size` 个 target |
+| `kvcm.cache_gc.max_inflight_delete_requests` | 2 | 普通删除与 EventReport action 共用的 GC 在途硬上限，必须大于 0 |
+| `kvcm.cache_gc.event_report_cleanup_enabled` | `true` | EventReport shared-round 子开关；仍受 GC 总开关控制，总开关关闭时保留 legacy 路径 |
+| `kvcm.cache_gc.event_report_action_batch_size` | 32 | 单 tick EventReport metadata action 的唯一 Block key 上限；Location 总数仍受 `scan_batch_size` 限制 |
 
-配置通过一个内聚的 `CacheGarbageCollector::Config` 传入。时间、batch 和在途请求上限必须为正，毫秒到内部 duration 的转换需要检查溢出。1 小时 grace 下限基于当前 1800 秒 write session 上限；若后续修改该协议上限，必须同步重新评估 GC grace 下限。
+配置通过一个内聚的 `CacheGarbageCollector::Config` 传入。`round_pause_ms` 可以为 0，其他 interval、batch 和在途请求上限必须为正；毫秒到内部 duration 的转换需要检查溢出。EventReport 扩展的收敛、优先级、recovery grace 和 metadata action 边界见其独立设计文档。1 小时 grace 下限基于当前 1800 秒 write session 上限；若后续修改该协议上限，必须同步重新评估 GC grace 下限。
 
 ## 11. 后续演进
 
@@ -565,7 +578,7 @@ V1 不修改 `write_location_manager.*`、`cache_reclaimer.*` 或 `migration_man
 
 ### 11.1 扫描资源治理
 
-若 active full round 对 Redis 或在线延迟影响明显，可以增加：
+若 active round 对内存 cache CPU/锁竞争、single-backend Redis 或在线延迟影响明显，可以增加：
 
 - 根据 keyspace 和目标 round 时长计算 inter-batch pacing；
 - scan budget、adaptive backoff 和大 Instance 公平调度；
@@ -605,11 +618,11 @@ Block TTL 需要先定义 TTL 写入、刷新、authoritative `expire_at`、并�
 4. GC task 持久化、lease/generation 和跨进程恢复；
 5. data storage I/O timeout/cancel；
 6. authoritative time source；
-7. EventReport snapshot/event 的后台 reconciliation；其 metadata-only、版本和所有权语义不能复用普通 storage 的物理删除规则。
+7. EventReport snapshot/event 的后台 reconciliation 已作为独立扩展设计；它与普通规则共享 round/cursor/scan batch，但 metadata-only、版本和所有权语义不复用普通 storage 的物理删除规则，详见 [EventReport 主动回收纳入统一后台 GC](event_report_background_gc.md)。
 
 ### 11.6 建议交付顺序
 
-1. **GC V1 PR**：本文定义的 full scan、固定 WRITING 与普通 SERVING storage-missing 判定、精确值条件删除、有界 Future/pending、leader 生命周期、指标和测试。
+1. **GC V1 PR**：本文定义的 maintenance scan、固定 WRITING 与普通 SERVING storage-missing 判定、精确值条件删除、有界 Future/pending、leader 生命周期、指标和测试。
 2. **公共基础设施跟进（按需）**：若现网验证确认 Redis 命令缺少有限返回上界，再独立补齐 connect/auth/command/reconnect timeout 和坏连接淘汰。
 3. **独立正确性 PR**：WriteLocationManager Instance 隔离和 Reclaimer/Finish settling race。
-4. **后续 PR**：根据性能和业务优先级分别接入 pacing/index、显式三态 probe、TTL、EventReport 和 DELETING reconciliation。
+4. **后续 PR**：根据性能和业务优先级分别接入 pacing/index、普通 Storage 显式三态 probe、TTL 和 DELETING reconciliation；EventReport reconciliation 按独立扩展文档、共享现有 scan 交付。

--- a/docs/design/event_report_background_gc.md
+++ b/docs/design/event_report_background_gc.md
@@ -1,0 +1,491 @@
+# EventReport 主动回收纳入统一后台 GC 设计
+
+| 项目 | 内容 |
+|---|---|
+| 状态 | V1 实现中；本文替代 cleanup intent / 双扫描 lane 方案 |
+| 更新时间 | 2026-09-01 |
+| 依赖 | [后台扫描 GC](cache_garbage_collector.md)、[ReportEvent 增量上报与权威快照](report_event_snapshot_uri_version.md) |
+| 涉及模块 | `manager`、`data_storage`、`meta`、`metrics`、`service` |
+
+本文定义 EventReport metadata 主动回收接入常驻后台 GC 的行为契约。核心边界是：
+
+- `CacheGarbageCollector` 负责周期扫描、候选预算、pending 和 action dispatch；
+- `EventReportBackend` 负责 Reporter 生命周期、Snapshot generation 和“当前是否允许清理”的业务判定；
+- `SchedulePlanExecutor` 承载异步 action，并在 worker 中完成最终 Backend/token/expected-value 复核；
+- Snapshot、`HOST_DOWN`、Heartbeat 和 REGISTER 只更新 Backend 当前状态，不向 GC 登记任务或触发扫描。
+
+该设计只改变垃圾发现和调度方式，不改变 ReportEvent 写入、Snapshot 提交、查询可见性和 Reporter 生命周期协议。
+
+## 1. 背景
+
+### 1.1 现有问题
+
+EventReport metadata 描述 Reporter 外部维护的 cache，不是由 KVCM DataStorage 接口直接管理的物理数据。旧实现有两条主动回收路径：
+
+| 触发事件 | 旧行为 |
+|---|---|
+| Snapshot 成功提交 | 投递 `CleanupStaleSnapshotLocations`，全量扫描目标 Instance |
+| `HOST_DOWN` 或 heartbeat timeout 后超过 cleanup grace | 投递 `CleanupHostLocations`，再次全量扫描目标 Instance |
+
+一次事件对应一次全 Instance 扫描。连续 Snapshot、多个 Reporter 同时下线或任务重试时，同一个 keyspace 会被重复扫描，成本近似“事件数 × keyspace”，并与 Reclaimer、Migration 和删除任务争用共享 Executor。
+
+成功 Snapshot 已在查询侧隐藏完全属于旧 generation 的 Location；Reporter unavailable/unregistered 后查询也不会返回其 Location。因此本需求主要解决 metadata 最终回收，不要求每个事件立即触发扫描。
+
+### 1.2 新模型
+
+V1 改为状态驱动的周期 reconciliation：
+
+```text
+Snapshot / Heartbeat / REGISTER / HOST_DOWN
+  -> 只更新 EventReportBackend 当前状态
+
+GC regular round
+  -> 一次 maintenance metadata scan
+  -> 普通 WRITING/SERVING 判定
+  -> EventReportBackend 批量判定
+  -> 统一预算与异步 action
+```
+
+多个事件天然合并为扫描时看到的最新 Backend 状态。GC 不再维护 cleanup intent map、revision、EventReport 专用 cursor/pass、recovery discovery 或独立 retry lane。
+
+## 2. 设计范围
+
+### 2.1 V1 目标
+
+1. EventReport 与长期 WRITING、普通 storage-missing SERVING 共用同一个 GC round、Instance cursor 和 `MaintenanceScanBatch`。
+2. EventReport 清理资格由 Backend 批量、三态、fail-closed 地判定；GC 不解析 Snapshot 内部状态。
+3. 保留 committed/in-flight generation、Snapshot attempt、Reporter lifecycle generation 和 Backend incarnation fencing。
+4. EventReport 只做完整 expected value 校验后的 metadata 删除，不触发物理 `DELETE`，不进入 `CLS_DELETING`。
+5. 所有候选共用原因优先级、Location 总预算、Instance 隔离、pending 和 GC inflight 窗口。
+6. EventReport action budget 按唯一 Block key 计数；一个已准入 key 可以批量携带多个 EventReport Location。
+7. 每个 active Instance 每次只推进一个 cursor batch，按 Instance round-robin，避免大 Instance 独占 active round。
+8. action 在 Executor worker 中重新校验 Backend/token 并执行 no-touch expected-value RMW；失败由后续周期扫描重新发现。
+9. 默认 full-round cooldown 为 2 小时；配置在启动时读取，不实现热更新。
+
+### 2.2 V1 非目标
+
+1. cleanup intent、EventReport 专用 scan lane、事件唤醒或为每种清理原因建立独立全表任务。
+2. 持久化 GC cursor、pending、Future、Reporter generation 或删除任务。
+3. Reporter 到 Location 的反向索引、Redis ZSET、CDC 或事件到 key 的直接索引。
+4. 通用动态 Rule Engine、插件注册或统一复杂 token ABI。
+5. EventReport 物理删除、`CLS_DELETING` 流转或 storage URI version/epoch。
+6. Block TTL、长期 `CLS_DELETING`、闲置 Instance 和 distributed GC lease。
+7. EventReport 独立扫描线程、独立线程池或独立并发窗口。
+8. Executor 进程级队列容量控制。当前 Executor 队列仍是公共基础设施，其全局限流会影响 Reclaimer、Migration 等调用方，应作为独立需求处理。
+9. GC 配置热更新和缩短 cooldown 时主动唤醒。
+
+### 2.3 依赖与灰度
+
+迁移期保留 `kvcm.cache_gc.event_report_cleanup_enabled`：
+
+- `false`：继续使用 legacy per-event cleanup；
+- `true`（默认）：当 `kvcm.cache_gc.enabled=true` 时，事件只更新 Backend 状态，由 regular round 回收；
+- GC 总开关关闭时，子开关不单独启动线程，EventReport 继续使用 legacy per-event cleanup，配置仍然有效。
+
+开关和其他 GC 参数均不支持热切换，修改后重启生效。新路径稳定后，可在独立清理提交中删除 legacy 路径和临时开关。
+
+回滚不是对称重放：`true -> false` 后，legacy 只能处理之后发生的新事件，不能重放 GC 开启期间已经发生的 Snapshot/HOST_DOWN。紧急回滚允许 stale metadata 暂时残留；查询可见性不依赖其立即物理清理。
+
+对于仍能在 maintenance view 中观察到的目标，保守发现时间约为：
+
+```text
+当前 round 剩余时间 + round_pause_ms + 下一 round 扫描到目标的时间
+```
+
+默认 `round_pause_ms=2h`。持续 Backend/metadata 错误、inflight 窗口长期占满，以及 dual-backend 中已从内存淘汰的冷 key 不在有限收敛保证内。若未来需要独立的小时级或分钟级 SLO，可增加无 intent 的独立 Candidate Source/cadence，但不恢复 per-event full scan。
+
+## 3. 架构与职责
+
+### 3.1 一个 scan，多种判定
+
+每个 GC tick 最多扫描当前 Instance 的一个 maintenance batch，并在同一份快照上执行：
+
+1. 长期 `CLS_WRITING` 判定；
+2. 普通 `CLS_SERVING` 的批量 `MightExist()` 判定；
+3. EventReport `CLS_SERVING` 的 Backend 批量 maintenance probe；
+4. 候选合并、优先级排序、budget 和 pending 过滤；
+5. 普通物理删除与 EventReport metadata action 分别提交 Executor；
+6. 两类 Future 统一进入 GC inflight 窗口。
+
+```mermaid
+flowchart LR
+    E[EventReport events] --> B[EventReportBackend state]
+    S[One maintenance scan batch] --> W[Orphan WRITING]
+    S --> M[Ordinary MightExist]
+    S --> P[EventReport batch probe]
+    B --> P
+    W --> U[Unified priority / budget / pending]
+    M --> U
+    P --> U
+    U --> X[Executor physical delete]
+    U --> Y[Executor metadata-only RMW]
+```
+
+同一 Location 在一个 batch 中最多形成一个候选。物理删除优先提交；如果它占满最后一个 GC inflight 槽位，本批 EventReport 候选不提交，并由后续 round 重新发现。
+
+### 3.2 模块边界
+
+GC 负责：
+
+- Registry Instance 快照、per-Instance cursor 和 round cooldown；
+- no-touch maintenance scan；
+- Storage 路由、批量 probe、shape/异常隔离；
+- 候选优先级、预算、pending、dispatch 和 Future 轮询。
+
+`EventReportBackend` 负责：
+
+- Reporter node table、availability、heartbeat timeout 和 cleanup grace；
+- committed/in-flight Snapshot generation、attempt epoch；
+- lifecycle generation/tombstone；
+- `Keep / DeleteMetadata / Unknown` 判定；
+- action-time cleanup token/lease 复核。
+
+Executor 负责：
+
+- 首次入队 accepted/Future 契约；
+- 在 worker 中重新查找当前 Backend incarnation；
+- 获取 token 对应 lease；
+- 调用 MetaSearcher 完成 no-touch expected-value metadata RMW；
+- 统一 promise exactly-once 完成和停机 cancel。
+
+GC 不读取 `snapshot_versions_`、`node_generation_`，也不复制 stale Snapshot 规则。
+
+### 3.3 Backend owner 路由
+
+普通 Storage 可以从 URI host 解析 storage global unique name；EventReport 的 Location ID/URI host 表示 Reporter，不表示 Backend owner。因此 GC 按以下信息路由：
+
+```text
+instance_id
+  -> InstanceGroup.event_report_storage_candidates
+  -> location.type()
+  -> 唯一 EventReportBackend
+```
+
+V1 要求同一 InstanceGroup 内，每个 EventReport storage type 最多有一个 Backend owner：
+
+- Admin 创建/更新 InstanceGroup 时拒绝已知的同 type 重复 owner；
+- 运行时未注册或 type 不符的 candidate 跳过，与在线 `ReportEvent` 的 matching-type 路由一致；遍历后没有 matching owner 时返回 unknown；
+- matching Backend unavailable 或同 type 多 owner 一律返回 unknown；
+- 不能在 A 暂时不可用时静默切到同 type 的 B，因为 B 不拥有 A 的 Reporter lifecycle 状态。
+
+提交 action 时同时保存 Backend unique name 和弱引用。Executor 必须重新按 unique name 查找，并要求对象 identity、type 和 available 状态仍匹配。
+
+### 3.4 Backpressure 边界
+
+普通物理删除与 EventReport action 共用：
+
+- `CacheGarbageCollector::max_inflight_delete_requests`；
+- `pending_locations_`；
+- `SchedulePlanExecutor` 的 worker；
+- Future 终态释放流程。
+
+这是 GC 调用方级的有界反压，不是 Executor 全局限流。即使 GC 只保留默认 2 个在途任务，Reclaimer、Migration 等其他调用方仍按现有 Executor 语义提交。V1 不修改公共队列容量、任务类别配额或全局 admission。
+
+## 4. EventReport 判定契约
+
+Backend 批量接口返回：
+
+```cpp
+enum class MaintenanceCleanupDecision {
+    kKeep,
+    kDeleteMetadata,
+    kUnknown,
+};
+
+struct MaintenanceLocationProbe {
+    std::string instance_id;
+    std::string location_id;
+    std::vector<std::string> storage_uris;
+};
+
+struct MaintenanceCleanupToken {
+    MaintenanceCleanupReason reason;
+    ReporterSnapshotKey reporter_key;
+    uint64_t lifecycle_generation;
+    std::string committed_version;
+    uint64_t snapshot_attempt_epoch;
+};
+```
+
+`kUnknown`、异常或 shape 不一致都不授权删除。
+
+### 4.1 stale Snapshot
+
+active 且处于 strict visibility 的 Reporter，只有 Location 不包含任何当前 committed 或 in-flight generation spec 时才可删除。
+
+- 任一 spec 属于 committed/in-flight：保留完整 Location；
+- 全部是语法合法的旧/legacy spec：返回 `DeleteMetadata`；
+- URI/version malformed、Snapshot 状态缺失或 soft visibility：返回 `Unknown`；
+- 空 spec 仅在 Backend 能明确按现有协议判定 stale 时删除。
+
+token 保存 committed version、attempt epoch 和 lifecycle generation。Executor 获取 lease 时原子复核这些状态；并发 Snapshot/REGISTER 已推进状态时，旧 token 变为 stale。
+
+### 4.2 Heartbeat timeout 与 cleanup grace
+
+必须保留两阶段行为：
+
+```text
+last heartbeat + heartbeat_timeout
+  -> Reporter unavailable，查询不可见，但 probe 返回 Keep
+
+unavailable_since + cleanup_grace
+  -> generation-checked unregister
+  -> probe 才返回 DownHost DeleteMetadata
+```
+
+当前默认 heartbeat timeout 为 30 秒、cleanup grace 为 5 分钟，均来自 EventReport Storage 配置，不硬编码在 GC。显式 `HOST_DOWN` 成功 unregister 后可直接进入 DownHost 清理资格。
+
+Reporter 在 grace 内恢复，或下线后重新 REGISTER 形成新 lifecycle，旧 token 在 Executor worker 中复核为 stale，不删除新生命周期数据。
+
+### 4.3 重启后的 absent Reporter
+
+进程重启、升主或重新启用 Backend 后，node table 和 tombstone 可能为空。系统建立：
+
+```text
+maintenance_recovery_deadline =
+  maintenance_admission_time + heartbeat_timeout + cleanup_grace
+```
+
+deadline 前，无法找到 Reporter 的 probe 返回 `Unknown(recovery_grace)`；deadline 后仍不存在时，才返回 `RecoveryAbsentHost` token。
+
+`maintenance_admission_time` 在每次 Leader 启动 GC worker 前重置；运行期新建或重新启用 Backend 时也会重置。这样 recovery 时间不会提前消耗 Reporter 真正能够 REGISTER/heartbeat 的窗口。该 grace 只影响对应 EventReport Location 的判定，不暂停 shared GC round，也不阻塞同 batch 的 WRITING、普通 MightExist 或其他 Backend。重启会重新开始 grace；V1 选择 fail-closed，不持久化 absent deadline。
+
+Executor 执行 `RecoveryAbsentHost` action 时必须在 Backend availability lease 内重新检查当前 recovery deadline。若 token 入队后 Backend 经历 disable/re-enable，新 grace 期内返回 busy 并留给后续 round 重试，旧 token 不能跨越新恢复窗口删除 metadata。
+
+## 5. 调度、预算与 Action
+
+### 5.1 per-Instance round-robin
+
+round 开始时取得一次 Group/Instance 快照，每个 `InstanceScanEntry` 保存独立 cursor 和 completed 标志。调度规则是：
+
+1. 当前 Instance 扫描一个 batch；
+2. 保存其 next cursor；
+3. 无论是否到 base，都轮转到下一个未完成 Instance；
+4. 所有 Instance 到 base 后结束 round并进入 cooldown；
+5. 单 Instance scan 失败时保留原 cursor，但先让其他 Instance 推进；同一 round 连续 3 次失败后跳过该 Instance，下一 round 从 base cursor 重试，不能阻塞 round 完成和 Registry 新快照。
+
+该公平性只防止一个大 Instance 长期独占 GC tick，不改变 Reclaimer 的 victim fairness。
+
+dual-backend 扫描内存 cache backend；single-backend 扫描唯一 backend。内存视图中未加载或已淘汰的冷 key 可能不被发现，这是避免周期全扫 Redis 的显式 best-effort 取舍。
+
+### 5.2 候选优先级与预算
+
+固定优先级：
+
+```text
+orphan WRITING
+  > ordinary storage-missing
+  > EventReport down host
+  > EventReport recovery-absent host
+  > EventReport stale snapshot
+```
+
+预算规则：
+
+- 所有原因合计最多准入 `scan_batch_size` 个 Location；
+- EventReport action 最多包含 `event_report_action_batch_size` 个唯一 Block key，默认 32；
+- 一个已准入 Block key 可以携带多个 EventReport Location，但 Location 总数仍受总预算限制；
+- pending target 不重复准入；
+- 超预算、Executor 拒绝或 inflight 已满的候选不进入 deferred queue，只记录指标并等待后续 round 重新发现。
+
+按 key 限制 EventReport action，是因为 metadata RMW、shard lock 和异步持久层写入的主要固定成本都按 Block key 发生；Location 总上限继续限制单请求序列化和遍历成本。
+
+### 5.3 EventReport 异步 metadata action
+
+GC 构造：
+
+```text
+instance_id
+block_keys[]
+targets[][] = {
+  location_id,
+  expected_location_value,
+  backend_unique_name,
+  backend identity,
+  storage_type,
+  cleanup_token
+}
+```
+
+`SubmitAsync(EventReportMetadataDelRequest)` 首次入队失败返回 `accepted=false`，不建立 GC pending/inflight。accepted 后 Future 与 pending 进入普通 GC 窗口。
+
+Executor worker 对每个 Block key：
+
+1. 重新获取 MetaIndexer；
+2. 重新按 Backend unique name 查找当前 EventReportBackend；
+3. 校验 Backend identity/type/available，并按 Backend unique name 的稳定顺序取得 availability lease；
+4. 在 Backend lease 内按稳定顺序获取该 key 所需 Reporter cleanup lease；
+5. stale token 视为正常 mismatch；busy/unavailable 视为可重试错误；
+6. 通过 `MetaSearcher::BatchDeleteLocations(... expected_values, maintenance_no_touch=true)` 执行普通 expected-value RMW；
+7. 持有 Backend availability lease 和 Reporter lease 到 RMW 结束，记录 `deleted/noent/mismatch/error`，统一完成 promise。
+
+该 action 不调用 DataStorage `Delete()`，不修改 Location status，不进入 `CLS_DELETING`。
+
+maintenance RMW 与现有 metadata 写路径使用相同的 per-key mutation fence 和一致性级别：
+
+- 对可能异步持久化的 metadata backend，在 shard fence 内执行读前 `Sync(key)`，确保此前 accepted 的同 key 写入对 expected-value 比较可见。cached metadata 的 hot view 在同一 shard fence 内同步删除，且 persistent queue 保持同 key 顺序，因此删除后直接释放锁；persistent-only backend 没有该 hot fence，仍在释放锁前执行第二个 `Sync(key)`。读前 barrier 失败时不执行 mutation；删后 barrier 失败保留 accepted 的 per-target 结果和一次性 accounting，同时以 aggregate hard error 交由后续 round 重试；
+- dual-backend 同时 no-touch 读取 hot 与 persistent target：一侧缺失允许幂等收敛，两侧均存在但值不同则返回 mismatch；
+- 整 key 回收必须在删除前确认 hot 与 persistent 均不存在非目标 sibling；无法证明时只删目标 Location；
+- 删除仍按 persistent -> hot 的现有镜像顺序执行，整 key 删除失败时保留可被后续 round 重新发现的 Location；
+- single-backend 直接复核唯一 backend；
+- metadata cached recovery 尚未完成时 fail-closed，等待后续 round；
+- 不增加逐层 mutation receipt、maintenance-pending 栅栏或精确跨进程补偿；
+- async persistent write 的最终持久化与 accounting 风险沿用普通 RMW 语义，失败由持续扫描 best effort 重试。
+
+### 5.4 Future、pending 与失败
+
+两类 action 统一遵守：
+
+- 只有 `accepted=true` 且 Future valid 才建立 pending；
+- pending key 为 `(instance_id, block_key, location_id)`；
+- Future ready、异常或 invalid 都释放对应 pending 和 inflight 槽位；
+- `EC_OK/EC_NOENT/EC_MISMATCH` 都是可收敛终态；hard error 记录后由后续 round 重发现；
+- GC 不为 EventReport 维护 retry batch、receipt 或独立 backoff 状态；
+- Join 丢弃本地 Future/pending handle，不等待已接受 action；Executor 继续 best effort，执行时仍需重新校验依赖和 token。
+
+如果 action 在 persistent/hot 之间部分失败，处理级别与普通 metadata RMW 一致，不为 GC 单独建立更强事务。持续异常通过 Future 结果、pending age 和下轮候选观测暴露。
+
+## 6. 生命周期与并发
+
+升主和降级沿用基础 GC：
+
+```text
+升主：
+  Registry/CacheManager recover
+  -> GC.Start 重置 EventReport recovery grace
+  -> 启动 GC worker
+  -> 开放 leader-only 请求
+
+降级：
+  GC.RequestStop + Reclaimer.Pause
+  -> DisableLeaderOnlyRequests
+  -> WaitForAllLeaderOnlyRequestsToComplete
+  -> GC.Join
+  -> Migration/CacheManager/Registry cleanup
+```
+
+EventReport 事件不向 GC 写 intent，因此 `RequestStop` 之后仍可完成 Backend 自身状态更新。Join 只等待当前 GC tick 的同步 scan/probe 返回，不等待已经提交给 Executor 的 action Future。
+
+关键仲裁：
+
+| 并发场景 | 保护 |
+|---|---|
+| scan 后发生 Snapshot/Delta | action-time token lease + expected value mismatch |
+| down-host cleanup 与重新 REGISTER | lifecycle generation + cleanup lease |
+| Backend disable/remove/recreate | unique name + object identity + type 校验；Backend availability lease 持有到 metadata RMW 完成 |
+| GC 重复扫描同一 target | GC pending |
+| GC 与 Reclaimer 同时处理同一 Location | expected-value/CAS 最终仲裁 |
+| cached metadata recovery | maintenance RMW recover guard |
+| 同 block 多 Reporter | lease 稳定排序；一个 per-key RMW |
+
+## 7. 异常与可观测性
+
+| 场景 | 行为 |
+|---|---|
+| Registry/scan 失败 | 保留 cursor；下一 tick 重试并轮转其他 Instance |
+| key `EC_NOENT` | 正常跳过 |
+| Backend missing/ambiguous/unavailable | unknown，不删除 |
+| probe exception/shape mismatch | 当前 EventReport probe batch unknown，普通规则继续 |
+| malformed Location/URI/version | unknown，不删除 |
+| recovery grace | 仅对应 EventReport target unknown，不暂停 shared round |
+| token stale / expected mismatch | 正常竞态，当前 action 跳过 |
+| token busy / metadata hard error | Future 失败或部分失败，后续 round 重发现 |
+| Executor rejected | 不建 pending/inflight；后续 round 重发现 |
+| inflight 满 | 不扫描新 batch，形成 GC 调用方硬反压 |
+
+保留或增加以下低基数指标：
+
+| 指标 | 说明 |
+|---|---|
+| `cache_gc.scan_round_count`、`scan_key_count`、`round_duration_ms` | shared round 进度与成本 |
+| `cache_gc.candidate_count{reason}` | 各原因候选数 |
+| `cache_gc.candidate_dropped_count{reason,cause}` | 总预算、key budget、inflight 等裁剪 |
+| `cache_gc.event_report_probe_count{result}` | keep/delete/unknown/error |
+| `cache_gc.event_report_probe_unknown_count{cause}` | malformed、owner、recovery grace 等 |
+| `cache_gc.event_report_delete_location_count{reason,status}` | worker 最终删除结果 |
+| `cache_gc.inflight_delete_count`、`inflight_delete_age_ms` | 两类 GC action 共用窗口 |
+| `cache_gc.operation_error_count{stage}` | 契约或硬错误 |
+
+不再暴露 intent、EventReport pass、receipt、layer mutation 或专用 retry 指标。指标 tag 不包含 Instance、Reporter host、cursor 或 generation。
+
+## 8. 测试方案
+
+### 8.1 Backend 单元测试
+
+1. committed、in-flight 和 mixed-generation Location 保留；合法旧 generation 删除；malformed 返回 unknown。
+2. heartbeat unavailable 后在 cleanup grace 内保留；unregister 后生成 DownHost token。
+3. 显式 HOST_DOWN 后重新 REGISTER 使旧 token stale。
+4. recovery deadline 前 absent 返回 unknown，deadline 后生成 RecoveryAbsentHost token。
+5. batch probe 顺序和 shape 稳定；Backend unavailable fail-closed。
+6. Snapshot/Down/Recovery token lease 覆盖 acquired、busy、stale；Backend availability lease 阻塞动态 disable/Close 到当前 action 完成。
+
+### 8.2 GC 与 Executor 组件测试
+
+1. 一个 scan batch 同时产生普通物理删除和 EventReport metadata action，只扫描一次。
+2. Instance 每个 tick 只推进一个 batch并 round-robin；失败 Instance 不阻塞其他 Instance，重试耗尽后不阻塞下一 round 或新 Instance 快照。
+3. 未注册或非 matching-type candidate 不遮蔽后续有效 owner；matching owner missing、ambiguous、unavailable 均不删除。
+4. 固定优先级、Location 总预算和 EventReport key budget正确；一个 key 的多个 Location 可共同提交。
+5. 普通物理删除和 EventReport action 共用 inflight/pending；窗口满时停止扫描。
+6. rejected/invalid/exception 不留下本地状态；Future 终态释放全部 pending。
+7. recovery grace 只跳过 EventReport，不阻塞同 batch 普通垃圾。
+8. Executor 入队后再改变 lifecycle/Backend incarnation，worker 必须重新校验并跳过。
+9. expected Location 已更新时返回 mismatch；EventReport 不调用物理 Delete、不进入 `CLS_DELETING`。
+10. no-touch maintenance RMW 不改变 LRU/access/revisit，并正确调整内存 charge、storage usage 和 reclaimed key count。
+11. cached metadata recovery 时拒绝 action；persistent 已 noent 时仍可幂等清理 hot copy。
+12. stale hot 与 newer persistent 不授权删除；跨层存在 sibling 时不执行整 key 回收；整 key 删除失败可重试。
+13. Snapshot abort 与已取得的 cleanup lease 串行，不跨 soft visibility 边界删除。
+14. Join 不等待已接受 EventReport Future，不发生 UAF。
+15. async metadata 的 pending 新写在 maintenance expected-value 读取前完成 barrier，不会被随后入队的删除覆盖；cached mode 依靠同步 hot mutation 作为删后 fence，persistent-only mode 的删后 barrier 在 shard fence 释放前完成。
+16. Backend 提前 Open 但 Leader recovery 超过 grace 时，GC Start 仍重新提供完整恢复窗口。
+
+### 8.3 E2E 与性能
+
+1. 连续 Snapshot 后，旧 generation 由后续 shared round 清理，事件数不线性增加全表任务。
+2. heartbeat unavailable 阶段不删，cleanup grace 后删除；grace 内恢复不误删。
+3. HOST_DOWN 后重新 REGISTER，新 lifecycle metadata 保留。
+4. EventReport 物理 Delete 调用数为 0，strict/soft 查询语义不退化。
+5. 多 Instance 与普通 GC 垃圾共存时，扫描按 batch 轮转且共享 inflight 生效。
+6. 对比 GC disabled、active scan、普通删除和 EventReport action 的 CPU/RSS、metadata QPS、在线请求 P50/P95/P99、round 时长和候选收敛时间。
+7. 统计 2 小时 cooldown 内 stale metadata 峰值，并验证默认节奏可接受。
+
+编译、单测和 E2E 的具体执行环境由测试记录约束，不写入设计契约。
+
+## 9. 配置
+
+| 配置 | 默认值 | 说明 |
+|---|---:|---|
+| `kvcm.cache_gc.enabled` | `true` | GC 总开关；可显式设为 `false` 回退 |
+| `kvcm.cache_gc.scan_interval_ms` | 1000 | active round 相邻 tick 最小间隔 |
+| `kvcm.cache_gc.round_pause_ms` | 7200000 | full round 完成后的 cooldown；0 表示下一 tick 可开始新 round |
+| `kvcm.cache_gc.scan_batch_size` | 256 | scan key hint，也是单 tick Location 总预算 |
+| `kvcm.cache_gc.max_inflight_delete_requests` | 2 | 普通与 EventReport action 共用的 GC 在途上限 |
+| `kvcm.cache_gc.event_report_cleanup_enabled` | `true` | EventReport shared-round 子开关；仍受 GC 总开关控制，总开关关闭时保留 legacy 路径 |
+| `kvcm.cache_gc.event_report_action_batch_size` | 32 | 单 tick EventReport action 的唯一 Block key 上限 |
+
+所有配置启动时读取；V1 不实现运行时热更新。`round_pause_ms` 可以为 0，其他 interval/budget/inflight 必须大于 0。EventReport key budget 与 Scan key hint 是独立上限：前者约束 metadata action 涉及的唯一 Block key 数，后者约束单 tick Location 总预算；key budget 大于 Scan hint 时只是当批通常无法用满，不构成非法配置。
+
+## 10. 实现落点
+
+| 文件 | 调整 |
+|---|---|
+| `cache_garbage_collector.*` | shared scan、per-Instance cursor、Backend probe、优先级/key budget、两类 action 的统一 inflight/pending |
+| `schedule_plan_executor.*` | EventReport metadata-only `SubmitAsync`，worker 内 Backend/token/expected-value 复核 |
+| `event_report_backend.*` | batch 三态 probe、recovery deadline、maintenance token/lease |
+| `meta_searcher.*`、`meta_indexer.*` | expected-value ordinary RMW 的 no-touch maintenance 入口 |
+| `meta_local_backend.*`、`meta_storage_backend_manager.*` | 内存 scan/no-touch read-delete、dual-backend 镜像和 recover guard |
+| `admin_service_impl.cc` | 已知配置下拒绝同 Group/type 多 EventReport owner |
+| metrics、配置和测试 | 新语义对应的指标、默认值和确定性覆盖 |
+
+V1 不新增线程、intent store、EventReport cursor、receipt、全局 Executor admission 或反向索引。
+
+## 11. 风险与后续演进
+
+1. **best-effort 内存 scan**：dual-backend 下冷 key 可能长期残留；如需完整覆盖，再评估 persistent scan、反向索引或增量 Candidate Source。
+2. **周期收敛而非事件即时收敛**：默认 cooldown 2 小时。若数据证明仍过慢，再增加独立但状态驱动的 cadence，不恢复 intent。
+3. **共享 inflight 的优先级取舍**：物理垃圾优先，极端持续压力下 EventReport 可能多等一轮；通过 dropped 和 candidate 指标观察。
+4. **无跨层事务**：V1 通过双层 expected-value 复核和删除前整 key 判定避免误删，但不引入逐层 receipt 或分布式事务；persistent/hot 部分失败由保留下来的候选和后续 round best effort 收敛。
+5. **Backend retirement fail-closed**：owner 被永久移除时缺少 lifecycle 授权，metadata 可能残留；Storage retirement reconciliation 是独立需求。
+6. **重启重置 recovery grace**：频繁切主可能延迟 recovery-absent 清理；跨进程 deadline 需要持久化 Reporter lifecycle。
+7. **Executor 全局容量**：GC 本地窗口不会限制其他调用方。若共享队列容量成为问题，应单独设计进程级 admission、任务类别配额和可观测性。
+8. **动态 pacing/热配置**：V1 固定启动配置。后续若要运行时缩短周期，需要补原子配置快照和 LoopThread 主动唤醒。
+9. **async metadata barrier 延迟**：maintenance action 按单个 Block key 持有 shard fence，cached mode 只保留读前 `Sync(key)`，persistent-only mode 保留读前和删除后两个 barrier，等待上界受 metadata sync timeout 约束。它不会同时锁住整个 action batch，但慢 Redis 会增加同 shard 在线请求延迟，需要结合 RMW lock-wait 指标灰度观察。

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -4,7 +4,7 @@
 
 > **维护提示**：当模块的职责、依赖方向或调用关系发生变化，或新增/删除模块时，请同步更新本文档与文末的 Mermaid 图，并同步更新 [AGENTS.md](../../AGENTS.md) 中的缩略图。
 
-相关文档：[基本概念](basic_concepts.md)、[ReportEvent Snapshot URI 版本方案](report_event_snapshot_uri_version.md)、[高可用与选主机制](ha_leader_elector.md)、[CacheReclaimer 异步删除设计](cache_reclaimer_async_delete.md)、[后台扫描 GC 设计](cache_garbage_collector.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
+相关文档：[基本概念](basic_concepts.md)、[ReportEvent Snapshot URI 版本方案](report_event_snapshot_uri_version.md)、[高可用与选主机制](ha_leader_elector.md)、[CacheReclaimer 异步删除设计](cache_reclaimer_async_delete.md)、[后台扫描 GC 设计](cache_garbage_collector.md)、[EventReport 主动回收纳入后台 GC](event_report_background_gc.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
 
 ---
 
@@ -300,7 +300,7 @@ flowchart LR
 
 ### 4.7 后台 metadata GC
 
-`CacheGarbageCollector` 只在 Leader 上运行，复用公共 `LoopThread`，按 Registry 快照和 backend cursor 串行扫描 authoritative metadata；扫描协调不占用共享的删除 worker。维护扫描不更新在线 LRU/revisit，也不向 local hot cache 回填。V1 识别超过 grace、且不属于活跃 Migration Copy 目标的 `CLS_WRITING`，并对普通 `CLS_SERVING` Location 按 storage 批量调用低成本 `MightExist()`，任一 spec 明确 missing 时选择整个 Location；EventReport 和探测不确定项均跳过。两类候选都通过 `SchedulePlanExecutor::SubmitAsync` 提交扫描时的完整序列化 Location，由 Executor worker 重新读取并以精确值条件 CAS 仲裁并发 Finish、Location 刷新和 Reclaimer。GC 使用固定小窗口管理在途 Future，并以 Instance-aware pending target 覆盖 accepted 到 CAS 的重复窗口；每 tick 最多提交一个请求，窗口满后停止扫描，完整 round 后进入长 cooldown。详细边界见 [后台扫描 GC 设计](cache_garbage_collector.md)。
+`CacheGarbageCollector` 只在 Leader 上运行，复用公共 `LoopThread`，按 Registry 快照和 backend cursor 串行推进统一 maintenance scan；扫描协调不占用共享的删除 worker。dual-backend 模式扫描 no-touch 的内存 hot view，single-backend 模式扫描唯一 backend，因此前者对已淘汰的冷 metadata 只提供 best-effort 收敛。基础 V1 识别超过 grace、且不属于活跃 Migration Copy 目标的 `CLS_WRITING`，并对普通 `CLS_SERVING` Location 按 storage 批量调用低成本 `MightExist()`。EventReport 扩展消费同一个 round/cursor 和 metadata batch，由 `EventReportBackend` 基于 Reporter lifecycle 与 Snapshot generation 返回三态 metadata cleanup 判定，不维护事件 intent 或独立扫描 lane。普通候选通过 `SchedulePlanExecutor::SubmitAsync` 在 worker 中重新读取 authoritative metadata，再执行精确值条件 CAS、物理删除和最终 CAD；EventReport 候选也提交到共享 Executor，由 worker 重新校验 Backend/token/lifecycle lease 后执行 expected-value metadata-only RMW。所有规则共用 Instance 隔离、GC inflight 窗口、target budget 和 pending 去重；本模块不为整个 Executor 增加进程级队列容量限制。详细边界见 [后台扫描 GC 设计](cache_garbage_collector.md) 与 [EventReport 主动回收纳入统一后台 GC](event_report_background_gc.md)。
 
 ### 4.8 HA 故障转移
 

--- a/docs/design/report_event_snapshot_uri_version.md
+++ b/docs/design/report_event_snapshot_uri_version.md
@@ -401,6 +401,8 @@ snapshot replace + commit/abort
 
 ## 11. 限流与清理
 
+本节保留 legacy fallback 的行为说明；启用 `kvcm.cache_gc.event_report_cleanup_enabled` 后，系统按 [EventReport 主动回收纳入统一后台 GC](event_report_background_gc.md) 把 per-event 全 Instance 扫描替换为状态驱动的 shared GC round。Snapshot/HOST_DOWN 只更新 `EventReportBackend` 当前状态，不登记 cleanup intent，也不唤醒或增加扫描；两条路径的 Snapshot、generation、lifecycle fencing 和 metadata-only 契约保持一致。
+
 `EventReportStorageSpec.snapshot_min_interval_ms` 提供 per-reporter 最小 snapshot 间隔，默认
 30 秒。完整维度是：
 
@@ -417,15 +419,15 @@ snapshot 完成。该配置在 backend 级统一设置，对其管理的每个 r
 admission 超时会 abort 当前 candidate；delta 等待超时只拒绝该 delta，不会 abort snapshot，
 两者都不影响其他 reporter。
 
-成功 snapshot 后复用现有任务执行器扫描 instance metadata：
+legacy fallback 在成功 Snapshot/HOST_DOWN 后复用现有任务执行器扫描 Instance metadata。统一 GC 模式不再投递这类任务，而是在 regular metadata batch 上由 `EventReportBackend` 判定：
 
 - 只处理目标 storage type 和 reporter；
 - event-report URI 描述外部 cache，reclaimer 只删除 KVCM metadata，不调用外部 URI
   backend 的物理 DELETE；
 - location 内只要包含任一当前 committed generation 就保留；
 - 下一轮 snapshot 已开始时，location 内只要包含任一 in-flight generation 也保留；
-- 完全由旧 generation 或无 version legacy spec 组成的 location 作为 stale；
-- malformed version 的 location 作为 stale；
+- 完全由旧 generation 或语法合法的无 version legacy spec 组成的 location 作为 stale；
+- malformed/未知 version 或 URI 格式返回 unknown 并告警，周期 GC 不把解析失败作为删除授权；
 - 使用观察值条件删除，避免旧 cleanup 删除刚刷新的新值。
 - cleanup 同时携带 snapshot attempt epoch：epoch 变化后在下一批扫描前退出；对已经扫描的
   location 仍逐条校验 epoch 和 URI generation，批次取消不能替代最终删除条件。
@@ -436,14 +438,9 @@ generation，其他 sibling 仍带旧 generation 或无 version 的 legacy URI�
 location 会造成成功增量的 false negative。保留 mixed-generation location 允许少量 stale
 sibling 暂存，后续完整 snapshot 会替换或回收。
 
-成功 snapshot 进入 strict 后，cleanup 只负责最终空间回收，不是查询正确性的前提。扫描耗时记录为
-`event_report.snapshot_cleanup_scan_latency_ms{instance_id,host,type}`。
+成功 snapshot 进入 strict 后，cleanup 只负责最终空间回收，不是查询正确性的前提。统一模式下多个 Snapshot/HOST_DOWN 事件天然折叠为扫描时的最新 Backend 状态，扫描 key 数不再随事件数线性增长。
 
-容量估算：典型的 1 个 instance、10 个 reporter、每台 5000 个 block 场景中，一次单 reporter
-完整 snapshot 约有 5000 次 metadata replace，并以 1000 key 为批次扫描该 instance 约 5 万
-个 key；10 台同时全量约有 5 万次 replace、累计约 50 万次 key 检查。实际 Redis 命令数取决于
-MetaIndexer backend 的 batching。若清理扫描延迟或 backlog 长期超过运行阈值，应引入
-reporter -> location 反向索引，而不是继续提高全量频率。
+统一模式复用后台 GC 的 round/cursor，默认 2 小时 cooldown 下 best-effort 最终收敛；指标使用 shared `cache_gc.scan_key_count`、按 reason 的 candidate/drop、EventReport probe/delete 结果和共享 inflight count/age，不再上报 per-event `event_report.snapshot_cleanup_scan_latency_ms{instance_id,host,type}`。若后续需要明显更短的收敛 SLO，可增加独立 cadence 的状态驱动 Candidate Source 或 reporter -> location 索引，但不能恢复每事件一次全表扫描。
 
 ## 12. 测试要求
 

--- a/integration_test/cache_garbage_collector/cache_garbage_collector_test.py
+++ b/integration_test/cache_garbage_collector/cache_garbage_collector_test.py
@@ -116,8 +116,8 @@ class CacheGarbageCollectorTest(TestBase, unittest.TestCase):
             "GC rounds must stop after leader demotion",
         )
 
-    def test_cached_metadata_gc_uses_persistent_backend(self):
-        """Dual-backend GC finds and removes an orphan through persistent metadata."""
+    def test_cached_metadata_gc_scans_recovered_cache(self):
+        """Dual-backend recovery makes an orphan visible to the in-memory GC scan."""
         self._create_topology(meta_storage_type="cached")
         instance_id = "cache_gc_cached_instance"
         self._register_instance(instance_id)
@@ -155,7 +155,7 @@ class CacheGarbageCollectorTest(TestBase, unittest.TestCase):
         rewritten = self._start_write(instance_id, self._block_key)
         self.assertTrue(
             rewritten.get("locations"),
-            "persistent orphan should be collected in cached metadata mode",
+            "orphan restored into cached metadata should be collected",
         )
 
     def test_missing_serving_data_is_collected_without_query(self):
@@ -214,8 +214,113 @@ class CacheGarbageCollectorTest(TestBase, unittest.TestCase):
             "missing SERVING metadata should be removed and become writable",
         )
 
+    def test_event_report_host_down_is_collected_by_shared_round(self):
+        """HOST_DOWN is reconciled by the regular metadata scan."""
+        self.worker_manager.stop_worker(0)
+        self.assertTrue(
+            self.worker_manager.start_worker(
+                0,
+                **{
+                    "kvcm.cache_gc.enabled": "true",
+                    "kvcm.cache_gc.event_report_cleanup_enabled": "true",
+                    "kvcm.cache_gc.scan_interval_ms": 25,
+                    "kvcm.cache_gc.round_pause_ms": 100,
+                    "kvcm.cache_gc.scan_batch_size": 8,
+                    "kvcm.cache_gc.event_report_action_batch_size": 8,
+                    "kvcm.cache_gc.orphan_writing_grace_period_ms": self._GRACE_MS,
+                    "kvcm.cache_gc.max_inflight_delete_requests": 2,
+                },
+            )
+        )
+        self._admin_client.close()
+        self._client.close()
+        self._admin_client, self._client = self._get_manager_clients()
+
+        event_storage_name = "cache_gc_event_report"
+        self._admin_client.add_storage(
+            {
+                "trace_id": f"{self._trace_id}_event_storage",
+                "storage": {
+                    "global_unique_name": event_storage_name,
+                    "storage_type": "ST_EVENT_REPORT_L2",
+                    "event_report": {
+                        # Keep recovery fencing observable without making the
+                        # smoke test wait for production-scale grace.
+                        "heartbeat_timeout_ms": 1_000,
+                        "cleanup_grace_ms": 1_000,
+                        "liveness_check_interval_ms": 100,
+                    },
+                    "check_storage_available_when_open": False,
+                },
+            }
+        )
+        self._create_topology(
+            event_report_storage_candidates=[event_storage_name]
+        )
+        instance_id = "cache_gc_event_report_instance"
+        self._register_instance(instance_id)
+        host = "192.168.80.1:8080"
+        location_uri = f"vineyard://{host}/mem?source=cache_gc_e2e"
+        self._client.report_event(
+            {
+                "trace_id": f"{self._trace_id}_event_add",
+                "instance_id": instance_id,
+                "host_ip_port": host,
+                "storage_type": "ST_EVENT_REPORT_L2",
+                "events": [
+                    {
+                        "event_type": "EVENT_NODE_REGISTER",
+                        "node_register": {"mediums": ["mem"]},
+                    },
+                    {
+                        "event_type": "EVENT_BLOCK_ADD",
+                        "block_add": {
+                            "block_key": str(self._block_key),
+                            "medium": "mem",
+                            "specs": [{"name": "tp0", "uri": location_uri}],
+                        },
+                    },
+                ],
+            }
+        )
+        visible = self._client.get_cache_location(
+            {
+                "trace_id": f"{self._trace_id}_event_visible",
+                "instance_id": instance_id,
+                "query_type": "QT_BATCH_GET",
+                "block_keys": [self._block_key],
+                "block_mask": {"offset": 0},
+            }
+        )
+        self.assertTrue(visible.get("locations"))
+
+        self._client.report_event(
+            {
+                "trace_id": f"{self._trace_id}_event_down",
+                "instance_id": instance_id,
+                "host_ip_port": host,
+                "storage_type": "ST_EVENT_REPORT_L2",
+                "events": [
+                    {"event_type": "EVENT_HOST_DOWN", "host_down": {}}
+                ],
+            }
+        )
+        self._wait_metric_at_least(
+            "cache_gc.event_report_delete_location_count",
+            1,
+            tags={"reason": "down_host", "status": "deleted"},
+            timeout_s=10,
+        )
+        self.assertGreaterEqual(
+            self._metric_value("cache_gc.scan_key_count"), 1
+        )
+        self.assertEqual(1, self._metric_value("cache_gc.delete_target_count"))
+
     def _create_topology(
-        self, meta_storage_type="dummy", data_storage_type="nfs"
+        self,
+        meta_storage_type="dummy",
+        data_storage_type="nfs",
+        event_report_storage_candidates=None,
     ):
         metadata_uri = (
             f"file://{self.get_workdir()}/cache_gc_metadata"
@@ -247,6 +352,9 @@ class CacheGarbageCollectorTest(TestBase, unittest.TestCase):
                 "instance_group": {
                     "name": self._group_name,
                     "storage_candidates": [self._storage_name],
+                    "event_report_storage_candidates": (
+                        event_report_storage_candidates or []
+                    ),
                     "global_quota_group_name": "cache_gc_quota",
                     "max_instance_count": 8,
                     "quota": {

--- a/kv_cache_manager/common/cache/advanced_cache.h
+++ b/kv_cache_manager/common/cache/advanced_cache.h
@@ -500,6 +500,17 @@ public: // functions
             const std::string_view &key, ObjectPtr obj, size_t charge, const CacheItemHelper *helper)> & /*callback*/) {
     }
 
+    // Applies a callback to one existing entry without marking it as a hit or
+    // changing its LRU position. The callback runs while the cache shard is
+    // locked and returns the entry charge delta caused by an in-place update.
+    // Callers must keep the callback bounded and must not call back into this
+    // Cache. Returns false when the key is absent or unsupported.
+    virtual bool ApplyToEntryNoTouch(
+        const std::string_view & /*key*/,
+        const std::function<ssize_t(ObjectPtr obj, size_t charge, const CacheItemHelper *helper)> & /*callback*/) {
+        return false;
+    }
+
     // Insert a mapping from key->object only if the key does not already exist.
     // Returns EC_OK on successful insertion, EC_EXIST if the key is already
     // present, or other error codes on failure (e.g. EC_NOSPC).
@@ -775,6 +786,12 @@ public:
             void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)> &callback)
         override {
         target_->ApplyToSingleShard(shard_id, callback);
+    }
+
+    bool ApplyToEntryNoTouch(
+        const std::string_view &key,
+        const std::function<ssize_t(ObjectPtr obj, size_t charge, const CacheItemHelper *helper)> &callback) override {
+        return target_->ApplyToEntryNoTouch(key, callback);
     }
 
     void StartAsyncLookup(AsyncLookupHandle &async_handle) override { target_->StartAsyncLookup(async_handle); }

--- a/kv_cache_manager/common/cache/lru_cache.cc
+++ b/kv_cache_manager/common/cache/lru_cache.cc
@@ -497,6 +497,52 @@ void LRUCacheShard::LookupBatch(const std::string_view *keys,
     }
 }
 
+bool LRUCacheShard::ApplyToEntryNoTouch(
+    const std::string_view &key,
+    uint32_t hash,
+    const std::function<ssize_t(Cache::ObjectPtr obj, size_t charge, const Cache::CacheItemHelper *helper)> &callback) {
+    std::lock_guard<std::mutex> l(mutex_);
+    LRUHandle *e = table_.Lookup(key, hash);
+    if (e == nullptr) {
+        return false;
+    }
+    assert(e->InCache());
+    const bool in_lru = !e->HasRefs();
+    const ssize_t delta = callback(e->value, e->total_charge, e->helper);
+    if (delta > 0) {
+        const size_t increase = static_cast<size_t>(delta);
+        e->total_charge += increase;
+        usage_ += increase;
+        if (in_lru) {
+            lru_usage_ += increase;
+            if (e->InHighPriPool()) {
+                high_pri_pool_usage_ += increase;
+            } else if (e->InLowPriPool()) {
+                low_pri_pool_usage_ += increase;
+            }
+            MaintainPoolSize();
+        }
+    } else if (delta < 0) {
+        size_t decrease = static_cast<size_t>(-delta);
+        decrease = std::min(decrease, e->total_charge);
+        decrease = std::min(decrease, usage_);
+        e->total_charge -= decrease;
+        usage_ -= decrease;
+        if (in_lru) {
+            assert(lru_usage_ >= decrease);
+            lru_usage_ -= decrease;
+            if (e->InHighPriPool()) {
+                assert(high_pri_pool_usage_ >= decrease);
+                high_pri_pool_usage_ -= decrease;
+            } else if (e->InLowPriPool()) {
+                assert(low_pri_pool_usage_ >= decrease);
+                low_pri_pool_usage_ -= decrease;
+            }
+        }
+    }
+    return true;
+}
+
 bool LRUCacheShard::Ref(LRUHandle *e) {
     std::lock_guard<std::mutex> l(mutex_);
     // To create another reference - entry must be already externally referenced.

--- a/kv_cache_manager/common/cache/lru_cache.h
+++ b/kv_cache_manager/common/cache/lru_cache.h
@@ -331,6 +331,12 @@ public: // Function definitions expected as parameter to ShardedCache
                      size_t count,
                      Cache::Handle **out_handles);
 
+    bool ApplyToEntryNoTouch(
+        const std::string_view &key,
+        uint32_t hash,
+        const std::function<ssize_t(Cache::ObjectPtr obj, size_t charge, const Cache::CacheItemHelper *helper)>
+            &callback);
+
     bool Release(LRUHandle *handle, bool useful, bool erase_if_last_ref);
     void ReleaseBatch(Cache::Handle *const *handles, const size_t *ordered_indices, size_t count);
     bool Ref(LRUHandle *handle);

--- a/kv_cache_manager/common/cache/sharded_cache.h
+++ b/kv_cache_manager/common/cache/sharded_cache.h
@@ -212,6 +212,13 @@ public:
         return static_cast<Handle *>(result);
     }
 
+    bool ApplyToEntryNoTouch(
+        const std::string_view &key,
+        const std::function<ssize_t(ObjectPtr obj, size_t charge, const CacheItemHelper *helper)> &callback) override {
+        HashVal hash = CacheShard::ComputeHash(key, hash_seed_);
+        return GetShard(hash).ApplyToEntryNoTouch(key, hash, callback);
+    }
+
     bool Exists(const std::string_view &key) override {
         HashVal hash = CacheShard::ComputeHash(key, hash_seed_);
         return GetShard(hash).Exists(key, hash);

--- a/kv_cache_manager/common/test/lru_cache_test.cc
+++ b/kv_cache_manager/common/test/lru_cache_test.cc
@@ -204,6 +204,33 @@ TEST_F(LRUCacheTest, BatchReleaseFreesEntryErasedWhilePinned) {
     ValidateLRUList({"b"}, 0, 1);
 }
 
+TEST_F(LRUCacheTest, ApplyToEntryNoTouchKeepsUnpinnedPoolChargeConsistent) {
+    NewCache(100, /* high_pri_pool_ratio */ 0.50, /* low_pri_pool_ratio */ 0.50);
+    Insert("a", Cache::Priority::HIGH, 20);
+    ASSERT_EQ(20u, cache_->GetUsage());
+    ASSERT_EQ(0u, cache_->GetPinnedUsage());
+    ValidateLRUList({"a"}, 1, 0, 0);
+
+    ASSERT_TRUE(cache_->ApplyToEntryNoTouch(
+        "a", 0, [](Cache::ObjectPtr, size_t, const Cache::CacheItemHelper *) { return -10; }));
+    EXPECT_EQ(10u, cache_->GetUsage());
+    EXPECT_EQ(0u, cache_->GetPinnedUsage());
+    ValidateLRUList({"a"}, 1, 0, 0);
+
+    ASSERT_TRUE(cache_->ApplyToEntryNoTouch(
+        "a", 0, [](Cache::ObjectPtr, size_t, const Cache::CacheItemHelper *) { return 20; }));
+    EXPECT_EQ(30u, cache_->GetUsage());
+    EXPECT_EQ(0u, cache_->GetPinnedUsage());
+    ValidateLRUList({"a"}, 1, 0, 0);
+
+    // A later insertion exercises MaintainPoolSize and LRU_Remove using the
+    // adjusted charge; stale pool counters would corrupt these transitions.
+    Insert("b", Cache::Priority::HIGH, 30);
+    EXPECT_EQ(60u, cache_->GetUsage());
+    EXPECT_EQ(0u, cache_->GetPinnedUsage());
+    ValidateLRUList({"a", "b"}, 1, 1, 0);
+}
+
 TEST_F(LRUCacheTest, LowPriorityMidpointInsertion) {
     // Allocate 2 cache entries to high-pri pool and 3 to low-pri pool.
     NewCache(5, /* high_pri_pool_ratio */ 0.40, /* low_pri_pool_ratio */ 0.60);

--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -77,7 +77,13 @@ DataStorageType EventReportBackend::GetType() { return config_.type(); }
 bool EventReportBackend::Available() { return IsOpen() && IsAvailable(); }
 
 void EventReportBackend::SetAvailable(bool available) {
+    std::unique_lock<std::shared_mutex> maintenance_lock(maintenance_backend_mutex_);
     DataStorageBackend::SetAvailable(available);
+    if (available) {
+        // Re-enabled Reporters need a complete heartbeat + cleanup-grace
+        // window before recovery-absent cleanup may be authorized.
+        ResetMaintenanceRecoveryGrace();
+    }
     if (!available) {
         snapshot_state_cv_.notify_all();
     }
@@ -1270,6 +1276,245 @@ ErrorCode EventReportBackend::AcquireSnapshotCleanupLease(const ReporterSnapshot
     return EC_OK;
 }
 
+EventReportBackend::CleanupLeaseAcquireResult EventReportBackend::AcquireDownLifecycleCleanupLease(
+    const ReporterSnapshotKey &reporter_key, uint64_t expected_generation, LifecycleMutationLease &out_lease) const {
+    out_lease.reset();
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return CleanupLeaseAcquireResult::kStale;
+    }
+    auto lease = std::make_shared<std::shared_lock<std::shared_mutex>>(lifecycle_fence->mutex, std::try_to_lock);
+    if (!lease->owns_lock()) {
+        return CleanupLeaseAcquireResult::kBusy;
+    }
+    if (lifecycle_fence->generation != expected_generation) {
+        return CleanupLeaseAcquireResult::kStale;
+    }
+    // Producers publish DownHost only after generation-checked unregister.
+    // Treat an unexpected same-generation active state fail-closed as busy:
+    // retain the candidate and never authorize deletion until down is observed.
+    if (lifecycle_fence->registered) {
+        return CleanupLeaseAcquireResult::kBusy;
+    }
+    out_lease = std::move(lease);
+    return CleanupLeaseAcquireResult::kAcquired;
+}
+
+EventReportBackend::CleanupLeaseAcquireResult EventReportBackend::AcquireAbsentReporterCleanupLease(
+    const ReporterSnapshotKey &reporter_key, uint64_t &out_generation, LifecycleMutationLease &out_lease) {
+    out_generation = 0;
+    out_lease.reset();
+    const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
+    auto lease = std::make_shared<std::shared_lock<std::shared_mutex>>(lifecycle_fence->mutex, std::try_to_lock);
+    if (!lease->owns_lock()) {
+        return CleanupLeaseAcquireResult::kBusy;
+    }
+    if (lifecycle_fence->registered) {
+        return CleanupLeaseAcquireResult::kStale;
+    }
+    out_generation = lifecycle_fence->generation;
+    out_lease = std::move(lease);
+    return CleanupLeaseAcquireResult::kAcquired;
+}
+
+std::vector<EventReportBackend::MaintenanceLocationProbeResult>
+EventReportBackend::ProbeLocationsForMaintenance(const std::vector<MaintenanceLocationProbe> &probes) {
+    std::vector<MaintenanceLocationProbeResult> results(probes.size());
+    if (!AcceptingReports()) {
+        for (auto &result : results) {
+            result.unknown_reason = MaintenanceProbeUnknownReason::kBackendUnavailable;
+        }
+        return results;
+    }
+
+    const int64_t now_ms = NowMillis();
+    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+    for (size_t i = 0; i < probes.size(); ++i) {
+        const auto &probe = probes[i];
+        auto &result = results[i];
+        std::string_view medium;
+        std::string_view reporter_host_view;
+        if (probe.instance_id.empty() || !ParseLocationIdView(probe.location_id, medium, reporter_host_view)) {
+            result.unknown_reason = MaintenanceProbeUnknownReason::kReporterIdentityMalformed;
+            continue;
+        }
+
+        ReporterSnapshotKey reporter_key{probe.instance_id, std::string(reporter_host_view)};
+        const auto instance_it = instance_nodes_.find(probe.instance_id);
+        NodeInfo *node = nullptr;
+        if (instance_it != instance_nodes_.end()) {
+            const auto node_it = instance_it->second.find(reporter_key.host_ip_port);
+            if (node_it != instance_it->second.end() && node_it->second) {
+                node = node_it->second.get();
+            }
+        }
+        if (node) {
+            if (!node->available.load(std::memory_order_relaxed)) {
+                result.decision = MaintenanceCleanupDecision::kKeep;
+                continue;
+            }
+
+            const auto state_it = snapshot_versions_.find(reporter_key);
+            if (state_it == snapshot_versions_.end() || state_it->second.committed.empty() ||
+                !state_it->second.strict_query_visibility) {
+                // Before the first successful complete snapshot, after a
+                // failed attempt, or while recovering, historical metadata is
+                // intentionally queryable. Its generation is not a deletion
+                // authorization.
+                result.unknown_reason = MaintenanceProbeUnknownReason::kSnapshotState;
+                continue;
+            }
+
+            bool contains_current = false;
+            bool malformed = false;
+            for (const auto &uri_text : probe.storage_uris) {
+                std::string_view version;
+                if (!SnapshotUriUtils::InspectSnapshotUriForVisibility(uri_text, version)) {
+                    malformed = true;
+                    continue;
+                }
+                // A structurally valid URI without s_version is legacy
+                // metadata. It is stale only when no sibling spec carries the
+                // committed or in-flight generation.
+                contains_current = contains_current || version == state_it->second.committed ||
+                                   (!state_it->second.in_flight.empty() && version == state_it->second.in_flight);
+            }
+            if (contains_current) {
+                result.decision = MaintenanceCleanupDecision::kKeep;
+                continue;
+            }
+            if (malformed) {
+                result.unknown_reason = MaintenanceProbeUnknownReason::kLocationMalformed;
+                continue;
+            }
+
+            uint64_t generation = 0;
+            const auto generation_instance_it = node_generation_.find(probe.instance_id);
+            if (generation_instance_it != node_generation_.end()) {
+                const auto generation_it = generation_instance_it->second.find(reporter_key.host_ip_port);
+                if (generation_it != generation_instance_it->second.end()) {
+                    generation = generation_it->second;
+                }
+            }
+            result.decision = MaintenanceCleanupDecision::kDeleteMetadata;
+            result.token = MaintenanceCleanupToken{
+                .reason = MaintenanceCleanupReason::kStaleSnapshot,
+                .reporter_key = std::move(reporter_key),
+                .lifecycle_generation = generation,
+                .committed_version = state_it->second.committed,
+                .snapshot_attempt_epoch = state_it->second.attempt_epoch,
+            };
+            continue;
+        }
+
+        const auto generation_instance_it = node_generation_.find(probe.instance_id);
+        if (generation_instance_it != node_generation_.end()) {
+            const auto generation_it = generation_instance_it->second.find(reporter_key.host_ip_port);
+            if (generation_it != generation_instance_it->second.end()) {
+                result.decision = MaintenanceCleanupDecision::kDeleteMetadata;
+                result.token = MaintenanceCleanupToken{
+                    .reason = MaintenanceCleanupReason::kDownHost,
+                    .reporter_key = std::move(reporter_key),
+                    .lifecycle_generation = generation_it->second,
+                };
+                continue;
+            }
+        }
+
+        if (now_ms < maintenance_recovery_deadline_ms_.load(std::memory_order_acquire)) {
+            result.unknown_reason = MaintenanceProbeUnknownReason::kRecoveryGrace;
+            continue;
+        }
+        result.decision = MaintenanceCleanupDecision::kDeleteMetadata;
+        result.token = MaintenanceCleanupToken{
+            .reason = MaintenanceCleanupReason::kRecoveryAbsentHost,
+            .reporter_key = std::move(reporter_key),
+        };
+    }
+    return results;
+}
+
+void EventReportBackend::ResetMaintenanceRecoveryGrace() noexcept {
+    const int64_t now_ms = NowMillis();
+    const int64_t heartbeat_timeout_ms = std::max<int64_t>(0, heartbeat_timeout_ms_);
+    const int64_t cleanup_grace_ms = std::max<int64_t>(0, cleanup_grace_ms_);
+    const int64_t wait_ms = heartbeat_timeout_ms > std::numeric_limits<int64_t>::max() - cleanup_grace_ms
+                                ? std::numeric_limits<int64_t>::max()
+                                : heartbeat_timeout_ms + cleanup_grace_ms;
+    const int64_t deadline =
+        now_ms > std::numeric_limits<int64_t>::max() - wait_ms ? std::numeric_limits<int64_t>::max() : now_ms + wait_ms;
+    maintenance_recovery_deadline_ms_.store(deadline, std::memory_order_release);
+}
+
+int64_t EventReportBackend::GetMaintenanceRecoveryGraceRemainingMs() const noexcept {
+    const int64_t now_ms = NowMillis();
+    const int64_t deadline = maintenance_recovery_deadline_ms_.load(std::memory_order_acquire);
+    return deadline > now_ms ? deadline - now_ms : 0;
+}
+
+EventReportBackend::CleanupLeaseAcquireResult
+EventReportBackend::AcquireMaintenanceBackendLease(MaintenanceBackendLease &out_lease) const {
+    out_lease.reset();
+    auto lease = std::make_shared<std::shared_lock<std::shared_mutex>>(maintenance_backend_mutex_, std::try_to_lock);
+    if (!lease->owns_lock() || !AcceptingReports()) {
+        return CleanupLeaseAcquireResult::kBusy;
+    }
+    out_lease = std::move(lease);
+    return CleanupLeaseAcquireResult::kAcquired;
+}
+
+EventReportBackend::CleanupLeaseAcquireResult
+EventReportBackend::AcquireMaintenanceCleanupLease(const MaintenanceCleanupToken &token,
+                                                   LifecycleMutationLease &out_lease) {
+    out_lease.reset();
+    if (!AcceptingReports()) {
+        return CleanupLeaseAcquireResult::kBusy;
+    }
+    switch (token.reason) {
+    case MaintenanceCleanupReason::kStaleSnapshot: {
+        const auto lifecycle_fence = FindLifecycleFence(token.reporter_key);
+        if (!lifecycle_fence) {
+            return CleanupLeaseAcquireResult::kStale;
+        }
+        auto lease = std::make_shared<std::shared_lock<std::shared_mutex>>(lifecycle_fence->mutex, std::try_to_lock);
+        if (!lease->owns_lock() || !AcceptingReports()) {
+            return CleanupLeaseAcquireResult::kBusy;
+        }
+        if (!lifecycle_fence->registered || lifecycle_fence->generation != token.lifecycle_generation) {
+            return CleanupLeaseAcquireResult::kStale;
+        }
+        std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+        const auto state_it = snapshot_versions_.find(token.reporter_key);
+        if (state_it == snapshot_versions_.end() || !state_it->second.strict_query_visibility ||
+            state_it->second.committed != token.committed_version ||
+            state_it->second.attempt_epoch != token.snapshot_attempt_epoch) {
+            return CleanupLeaseAcquireResult::kStale;
+        }
+        out_lease = std::move(lease);
+        return CleanupLeaseAcquireResult::kAcquired;
+    }
+    case MaintenanceCleanupReason::kDownHost:
+        return AcquireDownLifecycleCleanupLease(token.reporter_key, token.lifecycle_generation, out_lease);
+    case MaintenanceCleanupReason::kRecoveryAbsentHost: {
+        // A queued token may outlive a dynamic disable/re-enable, which starts
+        // a fresh recovery window. The Executor pins backend availability
+        // before this final check, so SetAvailable(true) cannot reset the
+        // deadline between this check and the metadata mutation.
+        if (NowMillis() < maintenance_recovery_deadline_ms_.load(std::memory_order_acquire)) {
+            return CleanupLeaseAcquireResult::kBusy;
+        }
+        uint64_t generation = 0;
+        const auto lease_result = AcquireAbsentReporterCleanupLease(token.reporter_key, generation, out_lease);
+        if (lease_result == CleanupLeaseAcquireResult::kAcquired && generation != token.lifecycle_generation) {
+            out_lease.reset();
+            return CleanupLeaseAcquireResult::kStale;
+        }
+        return lease_result;
+    }
+    }
+    return CleanupLeaseAcquireResult::kStale;
+}
+
 bool EventReportBackend::CommitSnapshotVersion(const ReporterSnapshotKey &reporter_key, const std::string &version) {
     if (!SnapshotUriUtils::IsValidSnapshotVersionToken(version)) {
         return false;
@@ -1297,6 +1542,15 @@ void EventReportBackend::AbortSnapshotVersion(const ReporterSnapshotKey &reporte
         reporter_key.host_ip_port.empty()) {
         return;
     }
+    // Cleanup retains a shared lifecycle lease from final token validation
+    // through metadata deletion. Abort changes strict visibility and therefore
+    // must take the matching writer; otherwise an already-authorized cleanup
+    // could delete while the Reporter has moved into soft visibility.
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     auto it = snapshot_versions_.find(reporter_key);
     if (it != snapshot_versions_.end() && it->second.in_flight == version) {

--- a/kv_cache_manager/data_storage/event_report_backend.h
+++ b/kv_cache_manager/data_storage/event_report_backend.h
@@ -118,6 +118,47 @@ public:
                             uint64_t &out_retry_after_ms,
                             uint64_t *out_lifecycle_generation = nullptr);
     using LifecycleMutationLease = std::shared_ptr<std::shared_lock<std::shared_mutex>>;
+    using MaintenanceBackendLease = std::shared_ptr<std::shared_lock<std::shared_mutex>>;
+    enum class CleanupLeaseAcquireResult {
+        kAcquired,
+        kBusy,
+        kStale,
+    };
+    enum class MaintenanceCleanupDecision {
+        kKeep,
+        kDeleteMetadata,
+        kUnknown,
+    };
+    enum class MaintenanceCleanupReason {
+        kStaleSnapshot,
+        kDownHost,
+        kRecoveryAbsentHost,
+    };
+    enum class MaintenanceProbeUnknownReason {
+        kNone,
+        kBackendUnavailable,
+        kReporterIdentityMalformed,
+        kSnapshotState,
+        kLocationMalformed,
+        kRecoveryGrace,
+    };
+    struct MaintenanceLocationProbe {
+        std::string instance_id;
+        std::string location_id;
+        std::vector<std::string> storage_uris;
+    };
+    struct MaintenanceCleanupToken {
+        MaintenanceCleanupReason reason{MaintenanceCleanupReason::kStaleSnapshot};
+        ReporterSnapshotKey reporter_key;
+        uint64_t lifecycle_generation{0};
+        std::string committed_version;
+        uint64_t snapshot_attempt_epoch{0};
+    };
+    struct MaintenanceLocationProbeResult {
+        MaintenanceCleanupDecision decision{MaintenanceCleanupDecision::kUnknown};
+        MaintenanceProbeUnknownReason unknown_reason{MaintenanceProbeUnknownReason::kNone};
+        MaintenanceCleanupToken token;
+    };
     ErrorCode AcquireLifecycleMutationLease(const ReporterSnapshotKey &reporter_key,
                                             uint64_t expected_generation,
                                             LifecycleMutationLease &out_lease) const;
@@ -137,6 +178,25 @@ public:
     ErrorCode CommitSnapshotVersionIfGeneration(const ReporterSnapshotKey &reporter_key,
                                                 const std::string &version,
                                                 uint64_t expected_generation);
+    CleanupLeaseAcquireResult AcquireDownLifecycleCleanupLease(const ReporterSnapshotKey &reporter_key,
+                                                               uint64_t expected_generation,
+                                                               LifecycleMutationLease &out_lease) const;
+    CleanupLeaseAcquireResult AcquireAbsentReporterCleanupLease(const ReporterSnapshotKey &reporter_key,
+                                                                uint64_t &out_generation,
+                                                                LifecycleMutationLease &out_lease);
+    // Background maintenance uses one periodic metadata scan for every
+    // storage type. EventReport keeps its liveness/snapshot policy here and
+    // returns only conservative metadata-cleanup decisions to the scanner.
+    std::vector<MaintenanceLocationProbeResult>
+    ProbeLocationsForMaintenance(const std::vector<MaintenanceLocationProbe> &probes);
+    void ResetMaintenanceRecoveryGrace() noexcept;
+    int64_t GetMaintenanceRecoveryGraceRemainingMs() const noexcept;
+    // Pins this exact Backend incarnation in the available state while a
+    // maintenance action validates reporter tokens and mutates metadata.
+    // Dynamic disable and Close wait for the retained read lease.
+    CleanupLeaseAcquireResult AcquireMaintenanceBackendLease(MaintenanceBackendLease &out_lease) const;
+    CleanupLeaseAcquireResult AcquireMaintenanceCleanupLease(const MaintenanceCleanupToken &token,
+                                                             LifecycleMutationLease &out_lease);
     bool CommitSnapshotVersion(const ReporterSnapshotKey &reporter_key, const std::string &version);
     void AbortSnapshotVersion(const ReporterSnapshotKey &reporter_key, const std::string &version);
     std::string GetSnapshotVersion(const ReporterSnapshotKey &reporter_key) const;
@@ -157,6 +217,8 @@ public:
     // for every (block, location).
     void GetQueryVisibilitySnapshot(const std::string &instance_id, QueryVisibilitySnapshot &out_snapshot) const;
     uint64_t GetSnapshotAttemptEpoch(const ReporterSnapshotKey &reporter_key) const;
+    int64_t GetHeartbeatTimeoutMs() const noexcept { return heartbeat_timeout_ms_; }
+    int64_t GetCleanupGraceMs() const noexcept { return cleanup_grace_ms_; }
     void SetSnapshotMinIntervalMsForTest(int64_t interval_ms);
     void SetSnapshotDeltaDrainTimeoutMsForTest(int64_t timeout_ms);
     DataStorageType GetStorageType() const;
@@ -212,6 +274,10 @@ private:
 
     EventReportStorageSpec spec_;
 
+    // Cleanup takes backend availability -> reporter lifecycle -> metadata.
+    // SetAvailable(false)/Close take the matching writer before retiring the
+    // backend, so a same-name replacement cannot cross an authorized action.
+    mutable std::shared_mutex maintenance_backend_mutex_;
     mutable std::shared_mutex nodes_mutex_;
     // Final metadata writes may already hold a MetaIndexer lock, while host
     // cleanup deliberately holds a lifecycle lease before taking metadata
@@ -227,6 +293,11 @@ private:
     // report after process restart can lazily rebuild the node.
     // instance_id -> (host_ip_port -> generation)
     std::unordered_map<std::string, std::unordered_map<std::string, uint64_t>> node_generation_;
+    // A new Leader cannot distinguish a reporter that is still recovering
+    // from one that disappeared before failover. During this backend-wide
+    // grace, EventReport probes return unknown while other shared-GC rules
+    // continue to run.
+    std::atomic<int64_t> maintenance_recovery_deadline_ms_{0};
     struct SnapshotVersionState {
         // Process-local reporter state, not a distributed lock. KVCM restart
         // clears this state; the first valid delta or snapshot rebuilds it.

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -571,6 +571,54 @@ TEST_F(EventReportBackendTest, LifecycleCleanupLeaseDoesNotBlockUnrelatedReporte
     EXPECT_EQ(EC_OK, backend.AcquireLifecycleMutationLease(reporter_b, generation_b, mutation_lease_b));
 }
 
+TEST_F(EventReportBackendTest, GcCleanupLeasesDistinguishBusyFromStaleLifecycle) {
+    EventReportBackend backend(metrics_registry_);
+    const ReporterSnapshotKey reporter{"gc-cleanup-lease", "10.0.0.95:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    const uint64_t active_generation = backend.GetNodeGeneration(reporter.instance_id, reporter.host_ip_port);
+
+    EventReportBackend::LifecycleMutationLease lease;
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kBusy,
+              backend.AcquireDownLifecycleCleanupLease(reporter, active_generation, lease));
+
+    uint64_t down_generation = 0;
+    ASSERT_EQ(EC_OK, backend.UnregisterNodeForHostDown(reporter.instance_id, reporter.host_ip_port, down_generation));
+
+    const auto fence = backend.FindLifecycleFence(reporter);
+    ASSERT_TRUE(fence);
+    std::promise<void> writer_acquired;
+    std::promise<void> release_writer;
+    const auto release_writer_future = release_writer.get_future().share();
+    auto writer = std::async(std::launch::async, [fence, &writer_acquired, release_writer_future] {
+        std::unique_lock<std::shared_mutex> lock(fence->mutex);
+        writer_acquired.set_value();
+        release_writer_future.wait();
+    });
+    ASSERT_EQ(std::future_status::ready, writer_acquired.get_future().wait_for(1s));
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kBusy,
+              backend.AcquireDownLifecycleCleanupLease(reporter, down_generation, lease));
+    release_writer.set_value();
+    ASSERT_EQ(std::future_status::ready, writer.wait_for(1s));
+    writer.get();
+
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireDownLifecycleCleanupLease(reporter, down_generation, lease));
+    lease.reset();
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kStale,
+              backend.AcquireDownLifecycleCleanupLease(reporter, down_generation, lease));
+
+    const ReporterSnapshotKey absent_reporter{"gc-cleanup-lease", "10.0.0.96:8080"};
+    uint64_t absent_generation = 99;
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireAbsentReporterCleanupLease(absent_reporter, absent_generation, lease));
+    EXPECT_EQ(0, absent_generation);
+    lease.reset();
+    ASSERT_EQ(EC_OK, backend.RegisterNode(absent_reporter.instance_id, absent_reporter.host_ip_port, {"mem"}));
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kStale,
+              backend.AcquireAbsentReporterCleanupLease(absent_reporter, absent_generation, lease));
+}
+
 TEST_F(EventReportBackendTest, EnsureNodeRegisteredMergesNewMediums) {
     EventReportBackend backend(metrics_registry_);
     ASSERT_EQ(EC_OK, backend.EnsureNodeRegistered("medium-merge", "10.0.0.91:8080", {"mem"}));
@@ -2070,6 +2118,210 @@ TEST(EventReportBackendSnapshotTest, MightExistBatchPreservesOrderAcrossTokenAnd
     backend.SetNodeUnavailable(reporter_b.instance_id, reporter_b.host_ip_port);
     EXPECT_EQ((std::vector<bool>{true, false, false, false, false, true}),
               backend.MightExist({current_a_uri, old_a_uri, unknown_uri, current_b_uri, malformed_uri, current_a_uri}));
+}
+
+TEST_F(EventReportBackendTest, MaintenanceProbeUsesCurrentSnapshotAndFailsClosedForMalformedMetadata) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 1000), "trace"));
+    backend.SetSnapshotMinIntervalMsForTest(0);
+
+    const ReporterSnapshotKey reporter{"instance-a", "10.0.0.90:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    const std::string location_id = backend.BuildLocationId("mem", reporter.host_ip_port);
+
+    auto commit_snapshot = [&]() {
+        std::string token;
+        uint64_t retry_after_ms = 0;
+        EXPECT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter, token, retry_after_ms));
+        EXPECT_TRUE(backend.CommitSnapshotVersion(reporter, token));
+        return token;
+    };
+    const std::string old_version = commit_snapshot();
+    const std::string current_version = commit_snapshot();
+
+    auto versioned_uri = [](const std::string &version) {
+        std::string uri;
+        EXPECT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri("event_report://physical-cache:9600/mem", version, uri));
+        return uri;
+    };
+    const std::string old_uri = versioned_uri(old_version);
+    const std::string current_uri = versioned_uri(current_version);
+    const std::string malformed_uri = current_uri + "&s_version=" + current_version;
+    const std::string malformed_legacy_uri = "not-a-uri";
+
+    const std::vector<EventReportBackend::MaintenanceLocationProbe> probes{
+        {reporter.instance_id, location_id, {current_uri}},
+        {reporter.instance_id, location_id, {old_uri}},
+        {reporter.instance_id, location_id, {old_uri, current_uri}},
+        {reporter.instance_id, location_id, {current_uri, malformed_uri}},
+        {reporter.instance_id, location_id, {malformed_uri}},
+        {reporter.instance_id, location_id, {"event_report://physical-cache:9600/mem"}},
+        {reporter.instance_id, "malformed-location-id", {old_uri}},
+        {reporter.instance_id, location_id, {malformed_legacy_uri}},
+    };
+    const auto results = backend.ProbeLocationsForMaintenance(probes);
+    ASSERT_EQ(probes.size(), results.size());
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, results[0].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kDeleteMetadata, results[1].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupReason::kStaleSnapshot, results[1].token.reason);
+    EXPECT_EQ(current_version, results[1].token.committed_version);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, results[2].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, results[3].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kUnknown, results[4].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kLocationMalformed, results[4].unknown_reason);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kDeleteMetadata, results[5].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kUnknown, results[6].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kReporterIdentityMalformed, results[6].unknown_reason);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kUnknown, results[7].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kLocationMalformed, results[7].unknown_reason);
+
+    EventReportBackend::LifecycleMutationLease lease;
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireMaintenanceCleanupLease(results[1].token, lease));
+    lease.reset();
+
+    std::string next_version;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter, next_version, retry_after_ms));
+    const auto in_flight_result =
+        backend.ProbeLocationsForMaintenance({{reporter.instance_id, location_id, {versioned_uri(next_version)}}});
+    ASSERT_EQ(1u, in_flight_result.size());
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, in_flight_result[0].decision);
+
+    const auto candidate_before_abort =
+        backend.ProbeLocationsForMaintenance({{reporter.instance_id, location_id, {old_uri}}});
+    ASSERT_EQ(1u, candidate_before_abort.size());
+    ASSERT_EQ(EventReportBackend::MaintenanceCleanupDecision::kDeleteMetadata, candidate_before_abort[0].decision);
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kStale,
+              backend.AcquireMaintenanceCleanupLease(results[1].token, lease));
+    ASSERT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireMaintenanceCleanupLease(candidate_before_abort[0].token, lease));
+    std::promise<void> abort_started;
+    auto abort_started_future = abort_started.get_future();
+    auto abort_future = std::async(std::launch::async, [&]() {
+        abort_started.set_value();
+        backend.AbortSnapshotVersion(reporter, next_version);
+    });
+    abort_started_future.wait();
+    EXPECT_EQ(std::future_status::timeout, abort_future.wait_for(20ms));
+    lease.reset();
+    ASSERT_EQ(std::future_status::ready, abort_future.wait_for(1s));
+    abort_future.get();
+    const auto soft_result = backend.ProbeLocationsForMaintenance({{reporter.instance_id, location_id, {old_uri}}});
+    ASSERT_EQ(1u, soft_result.size());
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kUnknown, soft_result[0].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kSnapshotState, soft_result[0].unknown_reason);
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kStale,
+              backend.AcquireMaintenanceCleanupLease(candidate_before_abort[0].token, lease));
+    ASSERT_EQ(EC_OK, backend.Close());
+}
+
+TEST_F(EventReportBackendTest, MaintenanceProbeRespectsUnavailableDownAndRecoveryLifecycle) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 1000), "trace"));
+
+    const std::string instance_id = "instance-a";
+    const std::string down_host = "10.0.0.91:8080";
+    const std::string down_location_id = backend.BuildLocationId("mem", down_host);
+    const EventReportBackend::MaintenanceLocationProbe down_probe{
+        instance_id, down_location_id, {"event_report://physical-cache:9600/mem"}};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, down_host, {"mem"}));
+    backend.SetNodeUnavailable(instance_id, down_host);
+    auto result = backend.ProbeLocationsForMaintenance({down_probe});
+    ASSERT_EQ(1u, result.size());
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, result[0].decision);
+
+    uint64_t down_generation = 0;
+    ASSERT_EQ(EC_OK, backend.UnregisterNodeForHostDown(instance_id, down_host, down_generation));
+    result = backend.ProbeLocationsForMaintenance({down_probe});
+    ASSERT_EQ(1u, result.size());
+    ASSERT_EQ(EventReportBackend::MaintenanceCleanupDecision::kDeleteMetadata, result[0].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupReason::kDownHost, result[0].token.reason);
+    EXPECT_EQ(down_generation, result[0].token.lifecycle_generation);
+    const auto down_token = result[0].token;
+
+    EventReportBackend::LifecycleMutationLease lease;
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireMaintenanceCleanupLease(down_token, lease));
+    lease.reset();
+    ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, down_host, {"mem"}));
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kStale,
+              backend.AcquireMaintenanceCleanupLease(down_token, lease));
+
+    const std::string absent_host = "10.0.0.92:8080";
+    const EventReportBackend::MaintenanceLocationProbe absent_probe{
+        instance_id,
+        backend.BuildLocationId("mem", absent_host),
+        {"event_report://physical-cache:9600/mem"},
+    };
+    backend.ResetMaintenanceRecoveryGrace();
+    result = backend.ProbeLocationsForMaintenance({absent_probe});
+    ASSERT_EQ(1u, result.size());
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kUnknown, result[0].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kRecoveryGrace, result[0].unknown_reason);
+
+    backend.maintenance_recovery_deadline_ms_.store(0, std::memory_order_release);
+    result = backend.ProbeLocationsForMaintenance({absent_probe});
+    ASSERT_EQ(1u, result.size());
+    ASSERT_EQ(EventReportBackend::MaintenanceCleanupDecision::kDeleteMetadata, result[0].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupReason::kRecoveryAbsentHost, result[0].token.reason);
+    const auto absent_token = result[0].token;
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireMaintenanceCleanupLease(absent_token, lease));
+    lease.reset();
+
+    backend.SetAvailable(false);
+    backend.SetAvailable(true);
+    EXPECT_GT(backend.GetMaintenanceRecoveryGraceRemainingMs(), 0);
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kBusy,
+              backend.AcquireMaintenanceCleanupLease(absent_token, lease));
+    backend.maintenance_recovery_deadline_ms_.store(0, std::memory_order_release);
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireMaintenanceCleanupLease(absent_token, lease));
+    lease.reset();
+
+    ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, absent_host, {"mem"}));
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kStale,
+              backend.AcquireMaintenanceCleanupLease(absent_token, lease));
+
+    backend.SetAvailable(false);
+    result = backend.ProbeLocationsForMaintenance({down_probe});
+    ASSERT_EQ(1u, result.size());
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kUnknown, result[0].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kBackendUnavailable, result[0].unknown_reason);
+    backend.maintenance_recovery_deadline_ms_.store(0, std::memory_order_release);
+    backend.SetAvailable(true);
+    EXPECT_GT(backend.GetMaintenanceRecoveryGraceRemainingMs(), 0);
+    ASSERT_EQ(EC_OK, backend.Close());
+}
+
+TEST_F(EventReportBackendTest, MaintenanceBackendLeaseFencesDynamicDisable) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(), "trace"));
+
+    EventReportBackend::MaintenanceBackendLease lease;
+    ASSERT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireMaintenanceBackendLease(lease));
+
+    std::promise<void> disable_started;
+    auto disable = std::async(std::launch::async, [&backend, &disable_started] {
+        disable_started.set_value();
+        backend.SetAvailable(false);
+    });
+    ASSERT_EQ(std::future_status::ready, disable_started.get_future().wait_for(1s));
+    EXPECT_EQ(std::future_status::timeout, disable.wait_for(20ms));
+    lease.reset();
+    ASSERT_EQ(std::future_status::ready, disable.wait_for(1s));
+    disable.get();
+    EXPECT_FALSE(backend.Available());
+
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kBusy,
+              backend.AcquireMaintenanceBackendLease(lease));
+    backend.SetAvailable(true);
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
+              backend.AcquireMaintenanceBackendLease(lease));
+    lease.reset();
+    ASSERT_EQ(EC_OK, backend.Close());
 }
 
 TEST(EventReportBackendSnapshotTest, MightExistUsesTokenOwnerAcrossInstancesAndPreservesCommittedOnAbort) {

--- a/kv_cache_manager/manager/BUILD
+++ b/kv_cache_manager/manager/BUILD
@@ -39,9 +39,16 @@ cc_library(
 
 cc_library(
     name = "cache_garbage_collector",
-    srcs = ["cache_garbage_collector.cc"],
-    hdrs = ["cache_garbage_collector.h"],
+    srcs = [
+        "cache_garbage_collector.cc",
+        "event_report_cleanup_util.cc",
+    ],
+    hdrs = [
+        "cache_garbage_collector.h",
+        "event_report_cleanup_util.h",
+    ],
     deps = [
+        ":meta_searcher",
         ":migration_manager",
         ":schedule_plan_executor",
         "//kv_cache_manager/common",

--- a/kv_cache_manager/manager/cache_garbage_collector.cc
+++ b/kv_cache_manager/manager/cache_garbage_collector.cc
@@ -17,6 +17,7 @@
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/data_storage/storage_config.h"
 #include "kv_cache_manager/manager/migration_manager.h"
 #include "kv_cache_manager/meta/cache_location.h"
@@ -45,8 +46,15 @@ constexpr const char *kDeleteResultMetricName = "cache_gc.delete_result_count";
 constexpr const char *kOperationErrorMetricName = "cache_gc.operation_error_count";
 constexpr const char *kOrphanWritingReason = "orphan_writing";
 constexpr const char *kStorageMissingReason = "storage_missing";
+constexpr const char *kEventReportStaleSnapshotReason = "event_report_stale_snapshot";
+constexpr const char *kEventReportDownHostReason = "event_report_down_host";
+constexpr const char *kEventReportRecoveryAbsentHostReason = "event_report_recovery_absent_host";
+constexpr const char *kCandidateDroppedMetricName = "cache_gc.candidate_dropped_count";
+constexpr const char *kEventReportProbeMetricName = "cache_gc.event_report_probe_count";
+constexpr const char *kEventReportProbeUnknownMetricName = "cache_gc.event_report_probe_unknown_count";
 // DataStorageManager keeps a shared registry lock while invoking MightExist().
 constexpr size_t kMightExistProbeBatchSize = 512;
+constexpr size_t kEventReportProbeBatchSize = 512;
 
 using CandidateKey = std::pair<KeyType, std::string>;
 using StorageProbeKey = std::tuple<std::string, DataStorageType>;
@@ -54,11 +62,84 @@ using StorageProbeKey = std::tuple<std::string, DataStorageType>;
 enum class CandidateReason {
     kOrphanWriting,
     kStorageMissing,
+    kEventReportStaleSnapshot,
+    kEventReportDownHost,
+    kEventReportRecoveryAbsentHost,
 };
+
+const char *CandidateReasonName(CandidateReason reason) {
+    switch (reason) {
+    case CandidateReason::kOrphanWriting:
+        return kOrphanWritingReason;
+    case CandidateReason::kStorageMissing:
+        return kStorageMissingReason;
+    case CandidateReason::kEventReportDownHost:
+        return kEventReportDownHostReason;
+    case CandidateReason::kEventReportRecoveryAbsentHost:
+        return kEventReportRecoveryAbsentHostReason;
+    case CandidateReason::kEventReportStaleSnapshot:
+        return kEventReportStaleSnapshotReason;
+    }
+    return "unknown";
+}
+
+int CandidatePriority(CandidateReason reason) {
+    switch (reason) {
+    case CandidateReason::kOrphanWriting:
+        return 0;
+    case CandidateReason::kStorageMissing:
+        return 1;
+    case CandidateReason::kEventReportDownHost:
+        return 2;
+    case CandidateReason::kEventReportRecoveryAbsentHost:
+        return 3;
+    case CandidateReason::kEventReportStaleSnapshot:
+        return 4;
+    }
+    return 5;
+}
+
+bool IsEventReportReason(CandidateReason reason) {
+    return reason == CandidateReason::kEventReportStaleSnapshot || reason == CandidateReason::kEventReportDownHost ||
+           reason == CandidateReason::kEventReportRecoveryAbsentHost;
+}
+
+CandidateReason EventReportTokenReason(const EventReportBackend::MaintenanceCleanupToken &token) {
+    switch (token.reason) {
+    case EventReportBackend::MaintenanceCleanupReason::kStaleSnapshot:
+        return CandidateReason::kEventReportStaleSnapshot;
+    case EventReportBackend::MaintenanceCleanupReason::kDownHost:
+        return CandidateReason::kEventReportDownHost;
+    case EventReportBackend::MaintenanceCleanupReason::kRecoveryAbsentHost:
+        return CandidateReason::kEventReportRecoveryAbsentHost;
+    }
+    return CandidateReason::kEventReportStaleSnapshot;
+}
+
+const char *MaintenanceUnknownReasonName(EventReportBackend::MaintenanceProbeUnknownReason reason) {
+    switch (reason) {
+    case EventReportBackend::MaintenanceProbeUnknownReason::kNone:
+        return "unspecified";
+    case EventReportBackend::MaintenanceProbeUnknownReason::kBackendUnavailable:
+        return "backend_unavailable";
+    case EventReportBackend::MaintenanceProbeUnknownReason::kReporterIdentityMalformed:
+        return "reporter_identity_malformed";
+    case EventReportBackend::MaintenanceProbeUnknownReason::kSnapshotState:
+        return "snapshot_state";
+    case EventReportBackend::MaintenanceProbeUnknownReason::kLocationMalformed:
+        return "malformed";
+    case EventReportBackend::MaintenanceProbeUnknownReason::kRecoveryGrace:
+        return "recovery_grace";
+    }
+    return "unspecified";
+}
 
 struct DeleteCandidate {
     std::string expected_location_value;
     CandidateReason reason{CandidateReason::kOrphanWriting};
+    std::shared_ptr<EventReportBackend> event_report_backend;
+    std::string event_report_backend_unique_name;
+    std::optional<EventReportBackend::MaintenanceCleanupToken> event_report_cleanup_token;
 };
 
 struct ServingProbe {
@@ -71,6 +152,20 @@ struct StorageProbeBatch {
     std::vector<DataStorageUri> uris;
     // Parallel to uris; multiple specs can refer to the same Location.
     std::vector<size_t> serving_probe_indexes;
+};
+
+struct EventReportProbeEntry {
+    CandidateKey key;
+    CacheLocationConstPtr location;
+};
+
+struct EventReportProbeBatch {
+    std::shared_ptr<EventReportBackend> backend;
+    std::string backend_unique_name;
+    const char *route_unknown_cause{nullptr};
+    bool route_checked{false};
+    std::vector<EventReportBackend::MaintenanceLocationProbe> probes;
+    std::vector<size_t> probe_indexes;
 };
 
 } // namespace
@@ -88,8 +183,7 @@ CacheGarbageCollector::CacheGarbageCollector(Config config,
     , data_storage_manager_(std::move(data_storage_manager))
     , schedule_plan_executor_(std::move(schedule_plan_executor))
     , metrics_registry_(std::move(metrics_registry))
-    , migration_manager_(std::move(migration_manager))
-    , cursor_(SCAN_BASE_CURSOR) {}
+    , migration_manager_(std::move(migration_manager)) {}
 
 CacheGarbageCollector::~CacheGarbageCollector() { Stop(); }
 
@@ -102,17 +196,19 @@ ErrorCode CacheGarbageCollector::Validate() const noexcept {
         KVCM_LOG_ERROR("cache gc enabled with missing dependency");
         return EC_CONFIG_ERROR;
     }
-    if (config_.scan_interval_ms <= 0 || config_.round_pause_ms <= 0 || config_.scan_batch_size == 0 ||
+    if (config_.scan_interval_ms <= 0 || config_.round_pause_ms < 0 || config_.scan_batch_size == 0 ||
         config_.max_inflight_delete_requests == 0 ||
-        config_.orphan_writing_grace_period_ms < kMinCacheGcOrphanWritingGracePeriodMs) {
+        config_.orphan_writing_grace_period_ms < kMinCacheGcOrphanWritingGracePeriodMs ||
+        (config_.event_report_cleanup_enabled && config_.event_report_action_batch_size == 0)) {
         KVCM_LOG_ERROR("invalid cache gc config, scan_interval_ms[%ld], round_pause_ms[%ld], scan_batch_size[%zu], "
-                       "max_inflight_delete_requests[%zu], orphan_writing_grace_period_ms[%ld], grace must be at "
-                       "least[%ld]",
+                       "max_inflight_delete_requests[%zu], orphan_writing_grace_period_ms[%ld], "
+                       "event_report_action_batch_size[%zu], grace must be at least[%ld]",
                        config_.scan_interval_ms,
                        config_.round_pause_ms,
                        config_.scan_batch_size,
                        config_.max_inflight_delete_requests,
                        config_.orphan_writing_grace_period_ms,
+                       config_.event_report_action_batch_size,
                        kMinCacheGcOrphanWritingGracePeriodMs);
         return EC_CONFIG_ERROR;
     }
@@ -157,6 +253,17 @@ ErrorCode CacheGarbageCollector::Start() noexcept {
         RegisterMetrics();
         ResetWorkerState();
         stop_requested_.store(false, std::memory_order_release);
+        if (config_.event_report_cleanup_enabled) {
+            // Backend objects can be opened well before leader recovery
+            // finishes. Start recovery-absent grace when this leader is about
+            // to scan and admit ReportEvent requests, not at process/backend
+            // construction time.
+            for (const auto &storage : data_storage_manager_->GetAvailableStorages()) {
+                if (const auto backend = std::dynamic_pointer_cast<EventReportBackend>(storage)) {
+                    backend->ResetMaintenanceRecoveryGrace();
+                }
+            }
+        }
         worker_ = LoopThread::CreateLoopThread(
             [this]() { RunOneTick(); }, config_.scan_interval_ms * 1000, "CacheGarbageCollector", true);
         if (!worker_) {
@@ -199,9 +306,9 @@ void CacheGarbageCollector::Join() noexcept {
         worker_->Stop();
         worker_.reset();
     }
-    // Match CacheReclaimer's demotion policy: accepted deletes continue best effort in the Executor, while GC never
-    // waits for their end-to-end Futures. Clearing these observer handles neither cancels the tasks nor keeps their
-    // MetaIndexer/DataStorage dependencies alive across leader cleanup; a post-CAS failure may remain CLS_DELETING.
+    // Match CacheReclaimer's demotion policy: accepted actions continue best effort in the Executor, while GC never
+    // waits for their end-to-end Futures. Clearing these observer handles does not cancel physical deletes or
+    // EventReport metadata actions. Both paths revalidate their mutation preconditions in the Executor worker.
     inflight_deletes_.clear();
     pending_locations_.clear();
     METRICS_(cache_gc, inflight_delete_count) = 0;
@@ -222,7 +329,6 @@ bool CacheGarbageCollector::IsRunning() const noexcept {
 void CacheGarbageCollector::ResetWorkerState() noexcept {
     instances_.clear();
     instance_index_ = 0;
-    cursor_ = SCAN_BASE_CURSOR;
     round_active_ = false;
     next_round_at_.reset();
     round_context_.reset();
@@ -261,7 +367,7 @@ void CacheGarbageCollector::RunOneTick() noexcept {
             return;
         }
 
-        const InstanceScanEntry entry = instances_[instance_index_];
+        InstanceScanEntry &entry = instances_[instance_index_];
         if (stop_requested_.load(std::memory_order_acquire)) {
             return;
         }
@@ -272,114 +378,162 @@ void CacheGarbageCollector::RunOneTick() noexcept {
                           round_id_,
                           entry.instance_group.c_str(),
                           entry.instance_id.c_str());
-            AdvanceInstance();
+            AdvanceInstance(true);
             return;
         }
 
         MaintenanceScanBatch batch;
-        const std::string scan_cursor = cursor_;
+        const std::string scan_cursor = entry.cursor;
         ErrorCode ec =
             indexer->ScanLocationsForMaintenance(round_context_.get(), scan_cursor, config_.scan_batch_size, batch);
         if (ec != EC_OK) {
             RecordOperationError("scan");
-            KVCM_LOG_WARN("cache gc round[%lu] scan failed, group[%s] instance[%s] cursor[%s] ec[%d]",
+            ++entry.scan_failure_count;
+            const bool retry_exhausted = entry.scan_failure_count >= kMaxScanFailuresPerInstancePerRound;
+            KVCM_LOG_WARN("cache gc round[%lu] scan failed, group[%s] instance[%s] cursor[%s] ec[%d] "
+                          "failure_count[%zu] retry_exhausted[%d]",
                           round_id_,
                           entry.instance_group.c_str(),
                           entry.instance_id.c_str(),
                           scan_cursor.c_str(),
-                          static_cast<int>(ec));
+                          static_cast<int>(ec),
+                          entry.scan_failure_count,
+                          retry_exhausted);
+            if (retry_exhausted) {
+                RecordOperationError("scan_retry_exhausted");
+            }
+            // Preserve the cursor while retries remain. Once this Instance
+            // exhausts its per-round budget, defer the remaining keyspace to
+            // the next round so one broken backend cannot wedge every other
+            // Instance behind an active round forever.
+            AdvanceInstance(retry_exhausted);
             return;
         }
 
+        entry.scan_failure_count = 0;
         METRICS_(cache_gc, scan_key_count) += batch.keys.size();
-        cursor_ = batch.next_cursor;
+        entry.cursor = batch.next_cursor;
         if (stop_requested_.load(std::memory_order_acquire)) {
             return;
         }
-        CacheLocationDelRequest request =
-            BuildDeleteRequest(entry.instance_id, batch, TimestampUtil::GetCurrentTimeUs());
+        ScanDeleteActions actions = BuildDeleteActions(entry.instance_id, batch, TimestampUtil::GetCurrentTimeUs());
+        const std::string instance_id = entry.instance_id;
+        AdvanceInstance(entry.cursor == SCAN_BASE_CURSOR);
 
-        if (cursor_ == SCAN_BASE_CURSOR) {
-            AdvanceInstance();
-        }
-
-        if (request.block_keys.empty() || stop_requested_.load(std::memory_order_acquire)) {
+        if (stop_requested_.load(std::memory_order_acquire)) {
             return;
         }
 
-        const size_t target_count = [&request]() {
-            size_t count = 0;
-            for (const auto &ids : request.location_ids) {
-                count += ids.size();
+        auto submit_and_track = [&](auto &request,
+                                    std::vector<PendingLocationKey> request_targets,
+                                    const char *action_name) {
+            if (request_targets.empty() || inflight_deletes_.size() >= config_.max_inflight_delete_requests) {
+                return false;
             }
-            return count;
-        }();
-
-        AsyncDeleteSubmitResult submit_result;
-        try {
-            submit_result = schedule_plan_executor_->SubmitAsync(request);
-        } catch (const std::exception &e) {
-            RecordOperationError("submit_exception");
-            KVCM_LOG_ERROR("cache gc SubmitAsync threw, instance[%s] error[%s]", entry.instance_id.c_str(), e.what());
-            return;
-        } catch (...) {
-            RecordOperationError("submit_exception");
-            KVCM_LOG_ERROR("cache gc SubmitAsync threw unknown exception, instance[%s]", entry.instance_id.c_str());
-            return;
-        }
-        if (!submit_result.accepted) {
-            if (submit_result.future.valid()) {
+            InflightDelete tracked_action;
+            try {
+                // Prepare the tracking record before SubmitAsync. Pending-set insertion still allocates after
+                // acceptance, so its exception path rolls back every successfully published target below.
+                inflight_deletes_.reserve(inflight_deletes_.size() + 1);
+                tracked_action.instance_id = instance_id;
+                tracked_action.action_name = action_name;
+                tracked_action.pending_locations.reserve(request_targets.size());
+            } catch (...) {
+                RecordOperationError("prepare_action_tracking");
+                return false;
+            }
+            AsyncDeleteSubmitResult submit_result;
+            try {
+                submit_result = schedule_plan_executor_->SubmitAsync(request);
+            } catch (const std::exception &e) {
+                RecordOperationError("submit_exception");
+                KVCM_LOG_ERROR("cache gc %s SubmitAsync threw, instance[%s] error[%s]",
+                               action_name,
+                               instance_id.c_str(),
+                               e.what());
+                return false;
+            } catch (...) {
+                RecordOperationError("submit_exception");
+                KVCM_LOG_ERROR("cache gc %s SubmitAsync threw unknown exception, instance[%s]",
+                               action_name,
+                               instance_id.c_str());
+                return false;
+            }
+            if (!submit_result.accepted) {
+                if (submit_result.future.valid()) {
+                    RecordOperationError("submit_contract");
+                    KVCM_LOG_ERROR("cache gc %s SubmitAsync rejected with a valid Future, instance[%s]",
+                                   action_name,
+                                   instance_id.c_str());
+                }
+                return false;
+            }
+            if (!submit_result.future.valid()) {
                 RecordOperationError("submit_contract");
-                KVCM_LOG_ERROR("cache gc SubmitAsync rejected with a valid Future, instance[%s]",
-                               entry.instance_id.c_str());
-            } else {
-                RecordOperationError("submit_rejected");
+                KVCM_LOG_ERROR("cache gc %s SubmitAsync accepted with an invalid Future, instance[%s]",
+                               action_name,
+                               instance_id.c_str());
+                return false;
             }
-            return;
-        }
-        if (!submit_result.future.valid()) {
-            RecordOperationError("submit_contract");
-            KVCM_LOG_ERROR("cache gc SubmitAsync accepted with an invalid Future, instance[%s]",
-                           entry.instance_id.c_str());
-            return;
-        }
 
-        std::vector<PendingLocationKey> request_pending_locations;
-        try {
-            request_pending_locations.reserve(target_count);
-            for (size_t block_index = 0; block_index < request.block_keys.size(); ++block_index) {
-                for (const auto &location_id : request.location_ids[block_index]) {
-                    PendingLocationKey key{entry.instance_id, request.block_keys[block_index], location_id};
-                    request_pending_locations.emplace_back(key);
-                    if (pending_locations_.insert(key).second) {
-                        continue;
+            try {
+                for (const auto &target : request_targets) {
+                    if (pending_locations_.insert(target).second) {
+                        tracked_action.pending_locations.push_back(target);
+                    } else {
+                        // BuildDeleteActions filters pending targets and this
+                        // callback is single-threaded, so normal execution
+                        // cannot reach this branch. The Executor's final
+                        // conditional check remains the safety barrier for an
+                        // already accepted invariant-violating request.
+                        RecordOperationError("pending_contract");
                     }
-                    // BuildDeleteRequest de-duplicates and filters pending targets, and this callback is
-                    // single-threaded. Reaching here is an invariant violation; keep the existing owner while the
-                    // Executor's conditional CAS remains the final deletion-safety barrier.
-                    request_pending_locations.pop_back();
-                    RecordOperationError("pending_contract");
-                    KVCM_LOG_ERROR("cache gc accepted duplicate pending target, instance[%s] block[%ld] location[%s]",
-                                   entry.instance_id.c_str(),
-                                   request.block_keys[block_index],
-                                   location_id.c_str());
+                }
+                tracked_action.round_id = round_id_;
+                tracked_action.target_count = request_targets.size();
+                tracked_action.submitted_at = Clock::now();
+                tracked_action.future = std::move(submit_result.future);
+                inflight_deletes_.push_back(std::move(tracked_action));
+            } catch (...) {
+                for (const auto &target : tracked_action.pending_locations) {
+                    pending_locations_.erase(target);
+                }
+                RecordOperationError("track_accepted_action");
+                KVCM_LOG_ERROR("cache gc failed to track accepted %s action, instance[%s]",
+                               action_name,
+                               instance_id.c_str());
+                return false;
+            }
+            METRICS_(cache_gc, delete_target_count) += request_targets.size();
+            return true;
+        };
+
+        std::vector<PendingLocationKey> physical_targets;
+        for (size_t i = 0; i < actions.executor_request.block_keys.size(); ++i) {
+            for (const auto &location_id : actions.executor_request.location_ids[i]) {
+                physical_targets.push_back({instance_id, actions.executor_request.block_keys[i], location_id});
+            }
+        }
+        submit_and_track(actions.executor_request, std::move(physical_targets), "physical_delete");
+
+        std::vector<PendingLocationKey> event_report_targets;
+        for (size_t i = 0; i < actions.event_report_request.block_keys.size(); ++i) {
+            for (const auto &target : actions.event_report_request.targets[i]) {
+                event_report_targets.push_back(
+                    {instance_id, actions.event_report_request.block_keys[i], target.location_id});
+            }
+        }
+        if (!event_report_targets.empty() && inflight_deletes_.size() >= config_.max_inflight_delete_requests) {
+            for (const auto &targets : actions.event_report_request.targets) {
+                for (const auto &target : targets) {
+                    RecordCandidateDropped(CandidateReasonName(EventReportTokenReason(target.cleanup_token)),
+                                           "inflight_limit",
+                                           1);
                 }
             }
-            inflight_deletes_.emplace_back(InflightDelete{
-                .round_id = round_id_,
-                .instance_id = entry.instance_id,
-                .target_count = target_count,
-                .submitted_at = Clock::now(),
-                .pending_locations = request_pending_locations,
-                .future = std::move(submit_result.future),
-            });
-        } catch (...) {
-            for (const auto &pending_location : request_pending_locations) {
-                pending_locations_.erase(pending_location);
-            }
-            throw;
+        } else {
+            submit_and_track(actions.event_report_request, std::move(event_report_targets), "event_report_metadata");
         }
-        METRICS_(cache_gc, delete_target_count) += target_count;
         UpdateInflightDeleteMetrics();
     } catch (const std::exception &e) {
         RecordOperationError("tick_exception");
@@ -390,15 +544,56 @@ void CacheGarbageCollector::RunOneTick() noexcept {
     }
 }
 
+CacheGarbageCollector::EventReportBackendRoute
+CacheGarbageCollector::LookupEventReportBackend(const std::string &instance_id, DataStorageType storage_type) const {
+    EventReportBackendRoute route;
+    if (!registry_manager_ || !data_storage_manager_ || !IsEventReportStorageType(storage_type)) {
+        return route;
+    }
+    const std::string group_name = registry_manager_->GetInstanceGroupName(instance_id);
+    const auto group = registry_manager_->GetInstanceGroupConfig(group_name);
+    if (!group) {
+        return route;
+    }
+    std::set<std::string> matched_names;
+    for (const auto &storage_name : group->event_report_storage_candidates()) {
+        auto backend =
+            std::dynamic_pointer_cast<EventReportBackend>(data_storage_manager_->GetDataStorageBackend(storage_name));
+        if (!backend) {
+            // Match the online ReportEvent routing contract: a candidate that
+            // is not currently registered cannot own requests in this
+            // process and must not hide a later, matching storage tier.
+            continue;
+        }
+        if (backend->GetStorageType() != storage_type || !matched_names.insert(storage_name).second) {
+            continue;
+        }
+        if (route.backend) {
+            route = {};
+            route.status = EventReportBackendRouteStatus::kAmbiguous;
+            return route;
+        }
+        route.backend_unique_name = storage_name;
+        route.backend = std::move(backend);
+    }
+    if (!route.backend) {
+        return route;
+    }
+    route.status = route.backend->Available() ? EventReportBackendRouteStatus::kResolved
+                                               : EventReportBackendRouteStatus::kUnavailable;
+    return route;
+}
+
 void CacheGarbageCollector::PollInflightDeletes() noexcept {
     auto it = inflight_deletes_.begin();
     while (it != inflight_deletes_.end()) {
         if (!it->future.valid()) {
             RecordOperationError("future_invalid");
             RecordDeleteResult("invalid");
-            KVCM_LOG_ERROR("cache gc stored invalid Future, round[%lu] instance[%s] targets[%zu]",
+            KVCM_LOG_ERROR("cache gc stored invalid Future, round[%lu] instance[%s] action[%s] targets[%zu]",
                            it->round_id,
                            it->instance_id.c_str(),
+                           it->action_name.c_str(),
                            it->target_count);
             ReleasePendingLocations(*it);
             it = inflight_deletes_.erase(it);
@@ -407,6 +602,7 @@ void CacheGarbageCollector::PollInflightDeletes() noexcept {
 
         const uint64_t round_id = it->round_id;
         const std::string instance_id = it->instance_id;
+        const std::string action_name = it->action_name;
         const size_t target_count = it->target_count;
         try {
             if (it->future.wait_for(std::chrono::microseconds::zero()) != std::future_status::ready) {
@@ -416,33 +612,39 @@ void CacheGarbageCollector::PollInflightDeletes() noexcept {
             const PlanExecuteResult result = it->future.get();
             RecordDeleteResult(std::to_string(static_cast<int>(result.status)));
             if (result.status == EC_OK) {
-                KVCM_LOG_DEBUG("cache gc delete completed, round[%lu] instance[%s] targets[%zu]",
+                KVCM_LOG_DEBUG("cache gc action completed, round[%lu] instance[%s] action[%s] targets[%zu]",
                                round_id,
                                instance_id.c_str(),
+                               action_name.c_str(),
                                target_count);
             } else {
                 KVCM_LOG_WARN(
-                    "cache gc delete completed with status[%d], round[%lu] instance[%s] targets[%zu] error[%s]",
+                    "cache gc action completed with status[%d], round[%lu] instance[%s] action[%s] targets[%zu] "
+                    "error[%s]",
                     static_cast<int>(result.status),
                     round_id,
                     instance_id.c_str(),
+                    action_name.c_str(),
                     target_count,
                     result.error_message.c_str());
             }
         } catch (const std::exception &e) {
             RecordOperationError("future_get");
             RecordDeleteResult("exception");
-            KVCM_LOG_ERROR("cache gc Future get failed, round[%lu] instance[%s] targets[%zu] error[%s]",
+            KVCM_LOG_ERROR("cache gc Future get failed, round[%lu] instance[%s] action[%s] targets[%zu] error[%s]",
                            round_id,
                            instance_id.c_str(),
+                           action_name.c_str(),
                            target_count,
                            e.what());
         } catch (...) {
             RecordOperationError("future_get");
             RecordDeleteResult("exception");
-            KVCM_LOG_ERROR("cache gc Future get failed with unknown exception, round[%lu] instance[%s] targets[%zu]",
+            KVCM_LOG_ERROR("cache gc Future get failed with unknown exception, round[%lu] instance[%s] action[%s] "
+                           "targets[%zu]",
                            round_id,
                            instance_id.c_str(),
+                           action_name.c_str(),
                            target_count);
         }
         ReleasePendingLocations(*it);
@@ -502,7 +704,7 @@ bool CacheGarbageCollector::BeginRound() {
                 KVCM_LOG_WARN("cache gc encountered invalid instance in group[%s]", group->name().c_str());
                 return false;
             }
-            snapshot.push_back({group->name(), instance->instance_id()});
+            snapshot.push_back({group->name(), instance->instance_id(), SCAN_BASE_CURSOR, false});
         }
     }
 
@@ -510,7 +712,6 @@ bool CacheGarbageCollector::BeginRound() {
     snapshot.erase(std::unique(snapshot.begin(), snapshot.end()), snapshot.end());
     instances_ = std::move(snapshot);
     instance_index_ = 0;
-    cursor_ = SCAN_BASE_CURSOR;
     round_id_ = next_round_id;
     round_active_ = true;
     round_started_at_ = Clock::now();
@@ -530,39 +731,54 @@ void CacheGarbageCollector::CompleteRound() noexcept {
 
     instances_.clear();
     instance_index_ = 0;
-    cursor_ = SCAN_BASE_CURSOR;
     round_active_ = false;
     round_context_.reset();
     next_round_at_ = now + std::chrono::milliseconds(config_.round_pause_ms);
 }
 
-void CacheGarbageCollector::AdvanceInstance() noexcept {
-    ++instance_index_;
-    cursor_ = SCAN_BASE_CURSOR;
-    if (instance_index_ >= instances_.size()) {
+void CacheGarbageCollector::AdvanceInstance(bool completed_current) noexcept {
+    if (instances_.empty() || instance_index_ >= instances_.size()) {
         CompleteRound();
+        return;
+    }
+    instances_[instance_index_].completed = instances_[instance_index_].completed || completed_current;
+    if (std::all_of(instances_.begin(), instances_.end(), [](const InstanceScanEntry &entry) {
+            return entry.completed;
+        })) {
+        CompleteRound();
+        return;
+    }
+    for (size_t offset = 1; offset <= instances_.size(); ++offset) {
+        const size_t candidate = (instance_index_ + offset) % instances_.size();
+        if (!instances_[candidate].completed) {
+            instance_index_ = candidate;
+            return;
+        }
     }
 }
 
-CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::string &instance_id,
-                                                                  const MaintenanceScanBatch &batch,
-                                                                  const int64_t now_us) {
-    CacheLocationDelRequest request;
-    request.instance_id = instance_id;
-    request.authoritative_read = true;
+CacheGarbageCollector::ScanDeleteActions CacheGarbageCollector::BuildDeleteActions(const std::string &instance_id,
+                                                                                   const MaintenanceScanBatch &batch,
+                                                                                   const int64_t now_us) {
+    ScanDeleteActions actions;
+    actions.executor_request.instance_id = instance_id;
+    actions.executor_request.authoritative_read = true;
+    actions.event_report_request.instance_id = instance_id;
 
     if (instance_id.empty() || batch.keys.size() != batch.locations.size() ||
         batch.keys.size() != batch.location_results.size()) {
         RecordOperationError("scan_shape");
-        return request;
+        return actions;
     }
 
     std::map<CandidateKey, DeleteCandidate> candidates;
     std::vector<ServingProbe> serving_probes;
     std::map<StorageProbeKey, StorageProbeBatch> storage_probe_batches;
+    std::vector<EventReportProbeEntry> event_report_probe_entries;
+    std::map<DataStorageType, EventReportProbeBatch> event_report_probe_batches;
     for (size_t i = 0; i < batch.keys.size(); ++i) {
         if (stop_requested_.load(std::memory_order_acquire)) {
-            return request;
+            return actions;
         }
         if (batch.location_results[i] != EC_OK) {
             if (batch.location_results[i] != EC_NOENT) {
@@ -588,8 +804,57 @@ CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::str
 
             const auto storage_type = location->type();
             if (location->status() != CLS_SERVING || storage_type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN ||
-                ToIndex(storage_type) >= ToIndex(DataStorageType::COUNT) || IsEventReportStorageType(storage_type) ||
-                location->location_specs().empty()) {
+                ToIndex(storage_type) >= ToIndex(DataStorageType::COUNT)) {
+                continue;
+            }
+
+            if (IsEventReportStorageType(storage_type)) {
+                if (!config_.event_report_cleanup_enabled) {
+                    continue;
+                }
+                auto &probe_batch = event_report_probe_batches[storage_type];
+                if (!probe_batch.route_checked) {
+                    probe_batch.route_checked = true;
+                    const auto route = LookupEventReportBackend(instance_id, storage_type);
+                    if (route.status == EventReportBackendRouteStatus::kResolved) {
+                        probe_batch.backend = route.backend;
+                        probe_batch.backend_unique_name = route.backend_unique_name;
+                    } else {
+                        probe_batch.route_unknown_cause =
+                            route.status == EventReportBackendRouteStatus::kAmbiguous
+                                ? "backend_ambiguous"
+                                : (route.status == EventReportBackendRouteStatus::kUnavailable ? "backend_unavailable"
+                                                                                              : "backend_missing");
+                        if (route.status == EventReportBackendRouteStatus::kAmbiguous) {
+                            KVCM_LOG_WARN("cache gc skips ambiguous EventReport owner, round[%lu] instance[%s] "
+                                          "storage_type[%d]",
+                                          round_id_,
+                                          instance_id.c_str(),
+                                          static_cast<int>(storage_type));
+                        }
+                    }
+                }
+                if (!probe_batch.backend) {
+                    RecordEventReportProbe(
+                        "unknown", probe_batch.route_unknown_cause ? probe_batch.route_unknown_cause : "backend_missing");
+                    continue;
+                }
+                EventReportBackend::MaintenanceLocationProbe probe{
+                    .instance_id = instance_id,
+                    .location_id = location_id,
+                };
+                probe.storage_uris.reserve(location->location_specs().size());
+                for (const auto &spec : location->location_specs()) {
+                    probe.storage_uris.push_back(spec.uri());
+                }
+                const size_t probe_index = event_report_probe_entries.size();
+                event_report_probe_entries.push_back({candidate_key, location});
+                probe_batch.probes.emplace_back(std::move(probe));
+                probe_batch.probe_indexes.push_back(probe_index);
+                continue;
+            }
+
+            if (location->location_specs().empty()) {
                 continue;
             }
 
@@ -617,7 +882,7 @@ CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::str
 
     for (const auto &[storage_key, probe_batch] : storage_probe_batches) {
         if (stop_requested_.load(std::memory_order_acquire)) {
-            return request;
+            return actions;
         }
         const auto &[storage_name, expected_storage_type] = storage_key;
         try {
@@ -641,7 +906,7 @@ CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::str
 
             for (size_t offset = 0; offset < probe_batch.uris.size(); offset += kMightExistProbeBatchSize) {
                 if (stop_requested_.load(std::memory_order_acquire)) {
-                    return request;
+                    return actions;
                 }
                 const size_t end = std::min(offset + kMightExistProbeBatchSize, probe_batch.uris.size());
                 const std::vector<DataStorageUri> uris(probe_batch.uris.begin() + offset,
@@ -649,7 +914,7 @@ CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::str
                 const std::vector<bool> might_exist =
                     data_storage_manager_->Exist(storage_name, uris, /*fastpath=*/true);
                 if (stop_requested_.load(std::memory_order_acquire)) {
-                    return request;
+                    return actions;
                 }
                 if (might_exist.size() != uris.size()) {
                     RecordOperationError("might_exist_shape");
@@ -685,6 +950,73 @@ CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::str
         }
     }
 
+    for (const auto &[storage_type, probe_batch] : event_report_probe_batches) {
+        (void)storage_type;
+        if (stop_requested_.load(std::memory_order_acquire)) {
+            return actions;
+        }
+        try {
+            for (size_t offset = 0; offset < probe_batch.probes.size(); offset += kEventReportProbeBatchSize) {
+                if (stop_requested_.load(std::memory_order_acquire)) {
+                    return actions;
+                }
+                const size_t end = std::min(offset + kEventReportProbeBatchSize, probe_batch.probes.size());
+                const std::vector<EventReportBackend::MaintenanceLocationProbe> probes(
+                    probe_batch.probes.begin() + offset, probe_batch.probes.begin() + end);
+                const auto probe_results = probe_batch.backend->ProbeLocationsForMaintenance(probes);
+                if (stop_requested_.load(std::memory_order_acquire)) {
+                    return actions;
+                }
+                if (probe_results.size() != probes.size()) {
+                    RecordOperationError("event_report_probe_shape");
+                    RecordEventReportProbe("error", "shape");
+                    continue;
+                }
+                for (size_t i = 0; i < probe_results.size(); ++i) {
+                    const auto &probe_result = probe_results[i];
+                    if (probe_result.decision == EventReportBackend::MaintenanceCleanupDecision::kKeep) {
+                        RecordEventReportProbe("keep");
+                        continue;
+                    }
+                    if (probe_result.decision == EventReportBackend::MaintenanceCleanupDecision::kUnknown) {
+                        RecordEventReportProbe("unknown", MaintenanceUnknownReasonName(probe_result.unknown_reason));
+                        continue;
+                    }
+                    RecordEventReportProbe("delete");
+                    const auto &entry = event_report_probe_entries[probe_batch.probe_indexes[offset + i]];
+                    CandidateReason reason = CandidateReason::kEventReportStaleSnapshot;
+                    if (probe_result.token.reason == EventReportBackend::MaintenanceCleanupReason::kDownHost) {
+                        reason = CandidateReason::kEventReportDownHost;
+                    } else if (probe_result.token.reason ==
+                               EventReportBackend::MaintenanceCleanupReason::kRecoveryAbsentHost) {
+                        reason = CandidateReason::kEventReportRecoveryAbsentHost;
+                    }
+                    candidates.emplace(entry.key,
+                                       DeleteCandidate{
+                                           .expected_location_value = entry.location->ToJsonString(),
+                                           .reason = reason,
+                                           .event_report_backend = probe_batch.backend,
+                                           .event_report_backend_unique_name = probe_batch.backend_unique_name,
+                                           .event_report_cleanup_token = probe_result.token,
+                                       });
+                }
+            }
+        } catch (const std::exception &e) {
+            RecordOperationError("event_report_probe_exception");
+            RecordEventReportProbe("error", "exception");
+            KVCM_LOG_WARN("cache gc EventReport maintenance probe threw, round[%lu] instance[%s] error[%s]",
+                          round_id_,
+                          instance_id.c_str(),
+                          e.what());
+        } catch (...) {
+            RecordOperationError("event_report_probe_exception");
+            RecordEventReportProbe("error", "exception");
+            KVCM_LOG_WARN("cache gc EventReport maintenance probe threw unknown exception, round[%lu] instance[%s]",
+                          round_id_,
+                          instance_id.c_str());
+        }
+    }
+
     for (auto &probe : serving_probes) {
         if (probe.storage_missing) {
             candidates.emplace(std::move(probe.key),
@@ -692,48 +1024,87 @@ CacheLocationDelRequest CacheGarbageCollector::BuildDeleteRequest(const std::str
         }
     }
 
-    size_t orphan_writing_count = 0;
-    size_t storage_missing_count = 0;
+    std::map<CandidateReason, size_t> candidate_counts;
     for (const auto &[candidate_key, candidate] : candidates) {
         (void)candidate_key;
-        if (candidate.reason == CandidateReason::kOrphanWriting) {
-            ++orphan_writing_count;
-        } else {
-            ++storage_missing_count;
-        }
+        ++candidate_counts[candidate.reason];
     }
-    RecordCandidateCount(kOrphanWritingReason, orphan_writing_count);
-    RecordCandidateCount(kStorageMissingReason, storage_missing_count);
+    for (const auto &[reason, count] : candidate_counts) {
+        RecordCandidateCount(CandidateReasonName(reason), count);
+    }
 
     struct RequestTargets {
         std::vector<std::string> location_ids;
         std::vector<std::string> expected_location_values;
     };
-    std::map<KeyType, RequestTargets> targets;
-    size_t selected = 0;
+    std::map<KeyType, RequestTargets> executor_targets;
+    std::map<KeyType, std::vector<EventReportMetadataDeleteTarget>> event_report_targets;
+    std::vector<std::pair<CandidateKey, const DeleteCandidate *>> ordered_candidates;
+    ordered_candidates.reserve(candidates.size());
     for (const auto &[candidate_key, candidate] : candidates) {
+        ordered_candidates.emplace_back(candidate_key, &candidate);
+    }
+    std::sort(ordered_candidates.begin(), ordered_candidates.end(), [](const auto &lhs, const auto &rhs) {
+        const int lhs_priority = CandidatePriority(lhs.second->reason);
+        const int rhs_priority = CandidatePriority(rhs.second->reason);
+        return lhs_priority != rhs_priority ? lhs_priority < rhs_priority : lhs.first < rhs.first;
+    });
+
+    size_t selected = 0;
+    std::set<KeyType> event_report_selected_keys;
+    for (const auto &[candidate_key, candidate_ptr] : ordered_candidates) {
+        const auto &candidate = *candidate_ptr;
         const auto &[block_key, location_id] = candidate_key;
         if (pending_locations_.find(PendingLocationKey{instance_id, block_key, location_id}) !=
             pending_locations_.end()) {
             continue;
         }
         if (selected >= config_.scan_batch_size) {
-            break;
+            RecordCandidateDropped(CandidateReasonName(candidate.reason), "total_budget", 1);
+            continue;
         }
-        auto &block_targets = targets[block_key];
-        block_targets.location_ids.push_back(location_id);
-        block_targets.expected_location_values.push_back(candidate.expected_location_value);
+        if (IsEventReportReason(candidate.reason)) {
+            const bool new_key = event_report_selected_keys.find(block_key) == event_report_selected_keys.end();
+            if (new_key && event_report_selected_keys.size() >= config_.event_report_action_batch_size) {
+                RecordCandidateDropped(CandidateReasonName(candidate.reason), "event_report_budget", 1);
+                continue;
+            }
+            if (!candidate.event_report_backend || !candidate.event_report_cleanup_token.has_value()) {
+                RecordOperationError("event_report_candidate_contract");
+                continue;
+            }
+            event_report_targets[block_key].push_back(EventReportMetadataDeleteTarget{
+                .location_id = location_id,
+                .expected_location_value = candidate.expected_location_value,
+                .backend_unique_name = candidate.event_report_backend_unique_name,
+                .storage_type = candidate.event_report_backend->GetStorageType(),
+                .expected_backend = candidate.event_report_backend,
+                .cleanup_token = candidate.event_report_cleanup_token.value(),
+            });
+            event_report_selected_keys.insert(block_key);
+        } else {
+            auto &block_targets = executor_targets[block_key];
+            block_targets.location_ids.push_back(location_id);
+            block_targets.expected_location_values.push_back(candidate.expected_location_value);
+        }
         ++selected;
     }
-    request.block_keys.reserve(targets.size());
-    request.location_ids.reserve(targets.size());
-    request.expected_location_values.reserve(targets.size());
-    for (auto &[block_key, block_targets] : targets) {
-        request.block_keys.push_back(block_key);
-        request.location_ids.emplace_back(std::move(block_targets.location_ids));
-        request.expected_location_values.emplace_back(std::move(block_targets.expected_location_values));
+    actions.executor_request.block_keys.reserve(executor_targets.size());
+    actions.executor_request.location_ids.reserve(executor_targets.size());
+    actions.executor_request.expected_location_values.reserve(executor_targets.size());
+    for (auto &[block_key, block_targets] : executor_targets) {
+        actions.executor_request.block_keys.push_back(block_key);
+        actions.executor_request.location_ids.emplace_back(std::move(block_targets.location_ids));
+        actions.executor_request.expected_location_values.emplace_back(
+            std::move(block_targets.expected_location_values));
     }
-    return request;
+    actions.event_report_request.block_keys.reserve(event_report_targets.size());
+    actions.event_report_request.targets.reserve(event_report_targets.size());
+    for (auto &[block_key, targets] : event_report_targets) {
+        actions.event_report_request.block_keys.push_back(block_key);
+        actions.event_report_request.targets.push_back(std::move(targets));
+    }
+    return actions;
 }
 
 bool CacheGarbageCollector::IsOrphanWriting(const std::string &map_location_id,
@@ -758,6 +1129,34 @@ void CacheGarbageCollector::RecordCandidateCount(const std::string &reason, cons
             counter += count;
         }
     } catch (...) { KVCM_LOG_ERROR("cache gc failed to record candidate metric"); }
+}
+
+void CacheGarbageCollector::RecordCandidateDropped(const std::string &reason,
+                                                   const std::string &cause,
+                                                   const size_t count) noexcept {
+    if (count == 0) {
+        return;
+    }
+    try {
+        if (metrics_registry_) {
+            auto counter = metrics_registry_->GetCounter(kCandidateDroppedMetricName,
+                                                         MetricsTags{{"reason", reason}, {"cause", cause}});
+            counter += count;
+        }
+    } catch (...) { KVCM_LOG_ERROR("cache gc failed to record candidate drop metric"); }
+}
+
+void CacheGarbageCollector::RecordEventReportProbe(const std::string &result,
+                                                   const std::string &unknown_cause) noexcept {
+    try {
+        if (!metrics_registry_) {
+            return;
+        }
+        ++metrics_registry_->GetCounter(kEventReportProbeMetricName, MetricsTags{{"result", result}});
+        if (!unknown_cause.empty()) {
+            ++metrics_registry_->GetCounter(kEventReportProbeUnknownMetricName, MetricsTags{{"cause", unknown_cause}});
+        }
+    } catch (...) { KVCM_LOG_ERROR("cache gc failed to record EventReport probe metric"); }
 }
 
 void CacheGarbageCollector::RecordOperationError(const std::string &stage) noexcept {

--- a/kv_cache_manager/manager/cache_garbage_collector.h
+++ b/kv_cache_manager/manager/cache_garbage_collector.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <future>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -15,7 +16,10 @@
 
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/common/loop_thread.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/meta/common.h"
+#include "kv_cache_manager/meta/types.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
 namespace kv_cache_manager {
@@ -55,10 +59,12 @@ public:
     struct Config {
         bool enabled{false};
         int64_t scan_interval_ms{1000};
-        int64_t round_pause_ms{24LL * 60 * 60 * 1000};
+        int64_t round_pause_ms{2LL * 60 * 60 * 1000};
         size_t scan_batch_size{256};
         int64_t orphan_writing_grace_period_ms{24LL * 60 * 60 * 1000};
         size_t max_inflight_delete_requests{2};
+        bool event_report_cleanup_enabled{true};
+        size_t event_report_action_batch_size{32};
     };
 
     CacheGarbageCollector() = delete;
@@ -83,13 +89,20 @@ public:
     void Stop() noexcept;
     [[nodiscard]] bool IsRunning() const noexcept;
     [[nodiscard]] bool IsEnabled() const noexcept { return config_.enabled; }
+    [[nodiscard]] bool IsEventReportCleanupEnabled() const noexcept {
+        return config_.enabled && config_.event_report_cleanup_enabled;
+    }
 
 private:
     using Clock = std::chrono::steady_clock;
+    static constexpr size_t kMaxScanFailuresPerInstancePerRound = 3;
 
     struct InstanceScanEntry {
         std::string instance_group;
         std::string instance_id;
+        std::string cursor{SCAN_BASE_CURSOR};
+        bool completed{false};
+        size_t scan_failure_count{0};
 
         bool operator<(const InstanceScanEntry &other) const {
             return std::tie(instance_group, instance_id) < std::tie(other.instance_group, other.instance_id);
@@ -113,26 +126,49 @@ private:
     struct InflightDelete {
         uint64_t round_id{0};
         std::string instance_id;
+        std::string action_name;
         size_t target_count{0};
         Clock::time_point submitted_at;
         std::vector<PendingLocationKey> pending_locations;
         std::future<PlanExecuteResult> future;
     };
 
+    enum class EventReportBackendRouteStatus {
+        kResolved,
+        kMissing,
+        kAmbiguous,
+        kUnavailable,
+    };
+
+    struct EventReportBackendRoute {
+        EventReportBackendRouteStatus status{EventReportBackendRouteStatus::kMissing};
+        std::string backend_unique_name;
+        std::shared_ptr<EventReportBackend> backend;
+    };
+
+    struct ScanDeleteActions {
+        CacheLocationDelRequest executor_request;
+        EventReportMetadataDelRequest event_report_request;
+    };
+
     void RunOneTick() noexcept;
+    EventReportBackendRoute LookupEventReportBackend(const std::string &instance_id,
+                                                      DataStorageType storage_type) const;
     void PollInflightDeletes() noexcept;
     void UpdateInflightDeleteMetrics() noexcept;
     void ReleasePendingLocations(const InflightDelete &inflight) noexcept;
     bool BeginRound();
     void CompleteRound() noexcept;
-    void AdvanceInstance() noexcept;
-    CacheLocationDelRequest
-    BuildDeleteRequest(const std::string &instance_id, const MaintenanceScanBatch &batch, int64_t now_us);
+    void AdvanceInstance(bool completed_current) noexcept;
+    ScanDeleteActions
+    BuildDeleteActions(const std::string &instance_id, const MaintenanceScanBatch &batch, int64_t now_us);
     bool
     IsOrphanWriting(const std::string &map_location_id, const CacheLocation &location, int64_t now_us) const noexcept;
     void ResetWorkerState() noexcept;
     void RegisterMetrics();
     void RecordCandidateCount(const std::string &reason, size_t count) noexcept;
+    void RecordCandidateDropped(const std::string &reason, const std::string &cause, size_t count) noexcept;
+    void RecordEventReportProbe(const std::string &result, const std::string &unknown_cause = {}) noexcept;
     void RecordOperationError(const std::string &stage) noexcept;
     void RecordDeleteResult(const std::string &status) noexcept;
 
@@ -152,7 +188,6 @@ private:
     // Worker-thread-only state.
     std::vector<InstanceScanEntry> instances_;
     size_t instance_index_{0};
-    std::string cursor_;
     uint64_t round_id_{0};
     bool round_active_{false};
     Clock::time_point round_started_at_;

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -35,6 +35,7 @@
 #include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
 #include "kv_cache_manager/manager/cache_reclaimer.h"
 #include "kv_cache_manager/manager/data_storage_selector.h"
+#include "kv_cache_manager/manager/event_report_cleanup_util.h"
 #include "kv_cache_manager/manager/hash_util.h"
 #include "kv_cache_manager/manager/meta_searcher_manager.h"
 #include "kv_cache_manager/manager/migration_manager.h"
@@ -411,10 +412,15 @@ CacheManager::CacheManager(std::shared_ptr<MetricsRegistry> metrics_registry,
 
 CacheManager::~CacheManager() {
     if (cache_garbage_collector_) {
-        cache_garbage_collector_->Stop();
-        cache_garbage_collector_.reset();
+        // Stop admitting new GC work before detaching legacy EventReport
+        // callbacks and joining the shared maintenance loop.
+        cache_garbage_collector_->RequestStop();
     }
     ClearEventCleanupCallbacks();
+    if (cache_garbage_collector_) {
+        cache_garbage_collector_->Join();
+        cache_garbage_collector_.reset();
+    }
     StopRecoverRetryLoop();
     DeactivateEventCleanupCallbacks();
     if (write_location_manager_) {
@@ -1182,7 +1188,7 @@ CacheManager::StartWriteCache(RequestContext *request_context,
             for (const auto &add_result : add_results) {
                 location_ids.push_back(add_result.location_id);
             }
-            RecordWriteBytesForLocations(new_locations);  // 记录写入量
+            RecordWriteBytesForLocations(new_locations); // 记录写入量
         }
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, StartWriteCacheInfo, "start write cache failed");
     }
@@ -2597,54 +2603,6 @@ private:
     std::vector<ValidatedEventLocationSpec> many_;
 };
 
-bool IsSnapshotLocationStale(const EventReportBackend *event_backend,
-                             const std::string &instance_id,
-                             const CacheLocation &location,
-                             bool preserve_in_flight = false) {
-    if (!event_backend) {
-        return false;
-    }
-
-    std::string medium;
-    std::string reporter_host;
-    if (!event_backend->ParseLocationId(location.id(), medium, reporter_host)) {
-        return false;
-    }
-
-    const ReporterSnapshotKey reporter_key{instance_id, reporter_host};
-    std::string committed_version;
-    std::string in_flight_version;
-    event_backend->GetSnapshotVersionTokens(reporter_key, committed_version, in_flight_version);
-    if (location.location_specs().empty()) {
-        return true;
-    }
-    bool contains_committed = false;
-    bool contains_in_flight = false;
-    for (const auto &spec : location.location_specs()) {
-        const size_t version_param_count =
-            SnapshotUriUtils::CountUriParam(spec.uri(), SnapshotUriUtils::kSnapshotVersionParam);
-        if (version_param_count == 0) {
-            // Legacy metadata is a stale reconciliation component, but a
-            // current delta spec in the same stable location still protects
-            // the location from coarse-grained cleanup.
-            continue;
-        }
-        SnapshotUriInfo info;
-        if (version_param_count != 1 || !SnapshotUriUtils::ParseSnapshotUriInfo(spec.uri(), info)) {
-            return true;
-        }
-        contains_committed = contains_committed || (!committed_version.empty() && info.version == committed_version);
-        contains_in_flight = contains_in_flight ||
-                             (preserve_in_flight && !in_flight_version.empty() && info.version == in_flight_version);
-    }
-    // Delta merge is spec-granular and can temporarily leave multiple
-    // generations in one stable location. Cleanup is location-granular, so it
-    // must preserve the whole location when any current/in-flight spec is
-    // present; deleting stale sibling specs is deferred to a later complete
-    // snapshot rather than risking a false negative for a successful delta.
-    return !contains_committed && !contains_in_flight;
-}
-
 bool IsEventReportLocationReadable(const CacheLocation &location,
                                    bool strict_query_visibility,
                                    const std::string &committed_version) {
@@ -2782,10 +2740,19 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     };
     refresh_snapshot_response(false);
 
-    if (!event_backend->IsCleanupCallbackSet()) {
-        const std::weak_ptr<EventReportBackend> expected_backend = event_backend;
+    const bool event_report_gc_cleanup =
+        cache_garbage_collector_ && cache_garbage_collector_->IsEventReportCleanupEnabled();
+    if (event_report_gc_cleanup) {
+        // Liveness and Snapshot events update EventReportBackend state only.
+        // The regular GC round discovers cleanup candidates from that state;
+        // no event-specific full scan is enqueued.
+        if (event_backend->IsCleanupCallbackSet()) {
+            event_backend->SetCleanupCallback(nullptr);
+        }
+    } else if (!event_backend->IsCleanupCallbackSet()) {
+        const std::weak_ptr<EventReportBackend> weak_backend = event_backend;
         const auto callback_state = event_cleanup_callback_state_;
-        event_backend->SetCleanupCallback([this, requested_type, expected_backend, callback_state](
+        event_backend->SetCleanupCallback([this, requested_type, weak_backend, callback_state](
                                               const std::string &cleanup_instance,
                                               const std::string &down_host,
                                               uint64_t generation) {
@@ -2794,7 +2761,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 return;
             }
             const uint64_t callback_epoch = callback_state->epoch;
-            auto cleanup_backend = expected_backend.lock();
+            auto cleanup_backend = weak_backend.lock();
             if (!cleanup_backend) {
                 return;
             }
@@ -2806,10 +2773,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                                   cleanup_backend,
                                   callback_state,
                                   callback_epoch] {
-                // A queued task may start after the backend callback that
-                // submitted it has returned. Hold the same lifetime lease for
-                // the whole cleanup so DoCleanup/destruction drains running
-                // tasks and makes tasks that are still queued harmless.
                 std::shared_lock<std::shared_mutex> task_lease(callback_state->mutex);
                 if (!callback_state->accepting || callback_state->epoch != callback_epoch) {
                     return;
@@ -2817,12 +2780,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 this->CleanupHostLocations(cleanup_instance, down_host, generation, requested_type, cleanup_backend);
             };
             if (!this->schedule_plan_executor_ || !this->schedule_plan_executor_->SubmitTask(cleanup)) {
-                // This callback runs on EventReportBackend's liveness thread.
-                // Running inline could enter DataStorageManager while an
-                // unregister operation holds its write lock and waits for this
-                // backend thread to join. The node is still removed from the
-                // visibility table below, so dropping best-effort physical
-                // metadata cleanup during executor shutdown is fail-closed.
                 KVCM_LOG_WARN("ReportEvent liveness cleanup queue unavailable; skipping metadata cleanup for host [%s]",
                               down_host.c_str());
             }
@@ -3664,7 +3621,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             delta_mutations.AdoptLifecycleGeneration(mutation_lifecycle_generation);
         }
     }
-
     // MetaSearcher calls this once after the fused target-location read and
     // before its first mutation. This removes the old per-key lock/allocation
     // amplification while preserving the window in which HOST_DOWN can fence
@@ -3839,7 +3795,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[task.event_index] = EC_ERROR;
             }
             event_backend->AbortSnapshotVersion(task.reporter_key, task.version);
-        } else if (schedule_plan_executor_) {
+        } else if (!event_report_gc_cleanup && schedule_plan_executor_) {
             const auto cleanup_backend = event_backend;
             const auto cleanup_state = event_cleanup_callback_state_;
             uint64_t cleanup_epoch = 0;
@@ -3879,46 +3835,56 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         if (host_down_ec != EC_OK) {
             per_item_ec[0] = host_down_ec;
         }
-        bool cleanup_dispatched = false;
+        const char *cleanup_mode = "none";
         if (host_down_ec == EC_OK) {
-            const auto cleanup_state = event_cleanup_callback_state_;
-            uint64_t cleanup_epoch = 0;
-            {
-                std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
-                if (cleanup_state->accepting) {
-                    cleanup_epoch = cleanup_state->epoch;
+            if (event_report_gc_cleanup) {
+                // The generation-checked unregister is the durable state
+                // transition for this process. Periodic GC observes its
+                // tombstone; no per-event scan task is submitted.
+                cleanup_mode = "periodic_gc";
+            } else {
+                const auto cleanup_state = event_cleanup_callback_state_;
+                uint64_t cleanup_epoch = 0;
+                {
+                    std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
+                    if (cleanup_state->accepting) {
+                        cleanup_epoch = cleanup_state->epoch;
+                    }
+                }
+                const auto cleanup = [this,
+                                      instance_id,
+                                      host_ip_port,
+                                      gen_at_trigger,
+                                      requested_type,
+                                      event_backend,
+                                      cleanup_state,
+                                      cleanup_epoch] {
+                    std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
+                    if (!cleanup_state->accepting || cleanup_state->epoch != cleanup_epoch) {
+                        return;
+                    }
+                    this->CleanupHostLocations(
+                        instance_id, host_ip_port, gen_at_trigger, requested_type, event_backend);
+                };
+                bool cleanup_dispatched = schedule_plan_executor_ && schedule_plan_executor_->SubmitTask(cleanup);
+                if (!cleanup_dispatched) {
+                    KVCM_LOG_WARN("trace_id [%s] | HOST_DOWN: cleanup queue unavailable for host [%s], "
+                                  "instance [%s], gen=%" PRIu64 "; running inline",
+                                  trace_id.c_str(),
+                                  host_ip_port.c_str(),
+                                  instance_id.c_str(),
+                                  gen_at_trigger);
+                    cleanup();
+                    cleanup_mode = "legacy_inline";
+                } else {
+                    cleanup_mode = "legacy_async";
                 }
             }
-            const auto cleanup = [this,
-                                  instance_id,
-                                  host_ip_port,
-                                  gen_at_trigger,
-                                  requested_type,
-                                  event_backend,
-                                  cleanup_state,
-                                  cleanup_epoch] {
-                std::shared_lock<std::shared_mutex> cleanup_lease(cleanup_state->mutex);
-                if (!cleanup_state->accepting || cleanup_state->epoch != cleanup_epoch) {
-                    return;
-                }
-                this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type, event_backend);
-            };
-            cleanup_dispatched = schedule_plan_executor_ && schedule_plan_executor_->SubmitTask(cleanup);
-            if (!cleanup_dispatched) {
-                KVCM_LOG_WARN("trace_id [%s] | HOST_DOWN: cleanup queue unavailable for host [%s], "
-                              "instance [%s], gen=%" PRIu64 "; running inline",
-                              trace_id.c_str(),
-                              host_ip_port.c_str(),
-                              instance_id.c_str(),
-                              gen_at_trigger);
-                cleanup();
-                cleanup_dispatched = true;
-            }
-            KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] removed from node table, cleanup_dispatched=%s "
+            KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] removed from node table, cleanup_mode=%s "
                           "(gen=%" PRIu64 ")",
                           trace_id.c_str(),
                           host_ip_port.c_str(),
-                          cleanup_dispatched ? "true" : "false",
+                          cleanup_mode,
                           gen_at_trigger);
         } else {
             KVCM_LOG_WARN("trace_id [%s] | HOST_DOWN: failed to end lifecycle for host [%s], "
@@ -4134,7 +4100,7 @@ ErrorCode CacheManager::CleanupStaleSnapshotLocations(const ReporterSnapshotKey 
         std::string reporter_host;
         return event_backend->ParseLocationId(location_id, medium, reporter_host) &&
                reporter_host == reporter_key.host_ip_port &&
-               IsSnapshotLocationStale(
+               IsSnapshotLocationStaleForCleanup(
                    event_backend.get(), reporter_key.instance_id, location, /*preserve_in_flight=*/true);
     };
     auto backend_is_current = [registry_manager = registry_manager_, reporter_key, storage_type, event_backend] {

--- a/kv_cache_manager/manager/event_report_cleanup_util.cc
+++ b/kv_cache_manager/manager/event_report_cleanup_util.cc
@@ -1,0 +1,52 @@
+#include "kv_cache_manager/manager/event_report_cleanup_util.h"
+
+#include "kv_cache_manager/data_storage/event_report_backend.h"
+#include "kv_cache_manager/data_storage/snapshot_uri_utils.h"
+#include "kv_cache_manager/meta/cache_location.h"
+
+namespace kv_cache_manager {
+
+bool IsSnapshotLocationStaleForCleanup(const EventReportBackend *event_backend,
+                                       const std::string &instance_id,
+                                       const CacheLocation &location,
+                                       bool preserve_in_flight) {
+    if (!event_backend) {
+        return false;
+    }
+    std::string medium;
+    std::string reporter_host;
+    if (!event_backend->ParseLocationId(location.id(), medium, reporter_host)) {
+        return false;
+    }
+
+    const ReporterSnapshotKey reporter_key{instance_id, reporter_host};
+    std::string committed_version;
+    std::string in_flight_version;
+    event_backend->GetSnapshotVersionTokens(reporter_key, committed_version, in_flight_version);
+    if (location.location_specs().empty()) {
+        return true;
+    }
+    bool contains_committed = false;
+    bool contains_in_flight = false;
+    for (const auto &spec : location.location_specs()) {
+        const size_t version_param_count =
+            SnapshotUriUtils::CountUriParam(spec.uri(), SnapshotUriUtils::kSnapshotVersionParam);
+        if (version_param_count == 0) {
+            continue;
+        }
+        SnapshotUriInfo info;
+        if (version_param_count != 1 || !SnapshotUriUtils::ParseSnapshotUriInfo(spec.uri(), info)) {
+            // Legacy cleanup has only a boolean keep/delete contract. Treat
+            // malformed metadata fail-closed: a malformed sibling must never
+            // authorize deleting a Location that may also contain a current
+            // committed or in-flight spec.
+            return false;
+        }
+        contains_committed = contains_committed || (!committed_version.empty() && info.version == committed_version);
+        contains_in_flight = contains_in_flight ||
+                             (preserve_in_flight && !in_flight_version.empty() && info.version == in_flight_version);
+    }
+    return !contains_committed && !contains_in_flight;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/event_report_cleanup_util.h
+++ b/kv_cache_manager/manager/event_report_cleanup_util.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace kv_cache_manager {
+
+class CacheLocation;
+class EventReportBackend;
+
+bool IsSnapshotLocationStaleForCleanup(const EventReportBackend *event_backend,
+                                       const std::string &instance_id,
+                                       const CacheLocation &location,
+                                       bool preserve_in_flight);
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -3387,7 +3387,8 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
                                              std::vector<std::vector<ErrorCode>> &out_per_location_ec,
                                              const std::vector<std::vector<std::string>> &expected_location_values,
                                              bool adjust_storage_usage,
-                                             bool adjust_reclaimed_key_count) {
+                                             bool adjust_reclaimed_key_count,
+                                             bool maintenance_no_touch) {
     if (keys.size() != location_ids_per_key.size()) {
         return EC_BADARGS;
     }
@@ -3459,8 +3460,11 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
-    auto result = meta_indexer_->ReadModifyWriteLocation(
-        request_context, keys, location_ids_per_key, modifier, adjust_reclaimed_key_count);
+    auto result = maintenance_no_touch
+                      ? meta_indexer_->ReadModifyWriteLocationsForMaintenance(
+                            request_context, keys, location_ids_per_key, modifier, adjust_reclaimed_key_count)
+                      : meta_indexer_->ReadModifyWriteLocation(
+                            request_context, keys, location_ids_per_key, modifier, adjust_reclaimed_key_count);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
     out_per_location_ec = std::move(result.per_location_error_codes);
 
@@ -3485,6 +3489,7 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
     }
     return result.ec;
 }
+
 
 ErrorCode
 MetaSearcher::VisitAllLocations(RequestContext *request_context, size_t scan_batch_size, LocationVisitor visitor) {

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -341,7 +341,8 @@ public:
                                    std::vector<std::vector<ErrorCode>> &out_per_location_ec,
                                    const std::vector<std::vector<std::string>> &expected_location_values = {},
                                    bool adjust_storage_usage = true,
-                                   bool adjust_reclaimed_key_count = true);
+                                   bool adjust_reclaimed_key_count = true,
+                                   bool maintenance_no_touch = false);
     using LocationVisitor =
         std::function<void(KeyType block_key, const std::string &location_id, const CacheLocation &location)>;
     ErrorCode VisitAllLocations(RequestContext *request_context, size_t scan_batch_size, LocationVisitor visitor);

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -3,7 +3,10 @@
 #include <algorithm>
 #include <cassert>
 #include <exception>
+#include <map>
 #include <memory>
+#include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -44,6 +47,18 @@ void HandleErrorPromise(const std::shared_ptr<std::promise<ResultType>> &promise
         .status = error_code,
         .error_message = std::move(error_message),
     });
+}
+
+const char *EventReportCleanupReasonName(EventReportBackend::MaintenanceCleanupReason reason) {
+    switch (reason) {
+    case EventReportBackend::MaintenanceCleanupReason::kStaleSnapshot:
+        return "stale_snapshot";
+    case EventReportBackend::MaintenanceCleanupReason::kDownHost:
+        return "down_host";
+    case EventReportBackend::MaintenanceCleanupReason::kRecoveryAbsentHost:
+        return "recovery_absent_host";
+    }
+    return "unknown";
 }
 } // namespace
 
@@ -824,6 +839,233 @@ AsyncDeleteSubmitResult SchedulePlanExecutor::SubmitAsync(const CacheLocationDel
                    task.block_keys.size());
 
     return SubmitDeleteTaskAsync(task.delay, [this, task]() { return PrepareDeleteTask(task); });
+}
+
+AsyncDeleteSubmitResult SchedulePlanExecutor::SubmitAsync(const EventReportMetadataDelRequest &task) {
+    if (task.instance_id.empty() || task.block_keys.empty() || task.block_keys.size() != task.targets.size()) {
+        return {};
+    }
+    std::set<int64_t> unique_block_keys;
+    if (!std::all_of(task.block_keys.begin(), task.block_keys.end(), [&](int64_t block_key) {
+            return unique_block_keys.insert(block_key).second;
+        })) {
+        return {};
+    }
+    for (const auto &targets : task.targets) {
+        if (targets.empty()) {
+            return {};
+        }
+        std::set<std::string> unique_location_ids;
+        for (const auto &target : targets) {
+            if (target.location_id.empty() || target.expected_location_value.empty() ||
+                target.backend_unique_name.empty() || target.expected_backend.expired() ||
+                !IsEventReportStorageType(target.storage_type) ||
+                target.cleanup_token.reporter_key.instance_id != task.instance_id ||
+                target.cleanup_token.reporter_key.host_ip_port.empty() ||
+                !unique_location_ids.insert(target.location_id).second) {
+                return {};
+            }
+        }
+    }
+
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto future = promise->get_future();
+    auto completion = std::make_shared<PromiseCompletion>(promise);
+    auto execute_task = [this, completion, task]() {
+        try {
+            completion->Complete(DoEventReportMetadataDelTask(task));
+        } catch (const std::exception &e) {
+            completion->Complete(
+                EC_ERROR, StringUtil::FormatString("EventReport metadata delete threw exception: %s", e.what()));
+        } catch (...) { completion->Complete(EC_ERROR, "EventReport metadata delete threw unknown exception"); }
+    };
+    auto cancel_task = [completion]() {
+        completion->Complete(EC_ERROR, "SchedulePlanExecutor stopped before EventReport metadata delete.");
+    };
+    if (!SubmitRaw(execute_task, std::chrono::microseconds::zero(), cancel_task, ScheduleTaskClass::kReclaim)) {
+        return {};
+    }
+    return AsyncDeleteSubmitResult{true, std::move(future)};
+}
+
+PlanExecuteResult
+SchedulePlanExecutor::DoEventReportMetadataDelTask(const EventReportMetadataDelRequest &task) {
+    auto indexer = meta_manager_ ? meta_manager_->GetMetaIndexer(task.instance_id) : nullptr;
+    if (!indexer) {
+        return MakeErrorResult(EC_NOENT,
+                               StringUtil::FormatString("MetaIndexer %s not found", task.instance_id.c_str()));
+    }
+    MetaSearcher meta_searcher(indexer);
+    size_t completed_targets = 0;
+    size_t hard_error_targets = 0;
+    const auto record_delete_result = [this](EventReportBackend::MaintenanceCleanupReason reason,
+                                             const char *status) noexcept {
+        if (!metrics_registry_) {
+            return;
+        }
+        try {
+            metrics_registry_->GetCounter(
+                "cache_gc.event_report_delete_location_count",
+                MetricsTags{{"reason", EventReportCleanupReasonName(reason)}, {"status", status}}) += 1;
+        } catch (const std::exception &e) {
+            KVCM_LOG_ERROR("record EventReport metadata delete metric failed: %s", e.what());
+        } catch (...) { KVCM_LOG_ERROR("record EventReport metadata delete metric failed with unknown exception"); }
+    };
+
+    for (size_t key_index = 0; key_index < task.block_keys.size(); ++key_index) {
+        const auto &targets = task.targets[key_index];
+        using LeaseKey = std::tuple<std::string, std::string, uint64_t, int, std::string, uint64_t>;
+        std::map<std::string, std::shared_ptr<EventReportBackend>> cleanup_backends;
+        std::map<LeaseKey, std::pair<std::shared_ptr<EventReportBackend>, EventReportBackend::MaintenanceCleanupToken>>
+            cleanup_tokens;
+        bool key_stale = false;
+        bool key_busy = false;
+        for (const auto &target : targets) {
+            if (!IsEventReportStorageType(target.storage_type) ||
+                target.cleanup_token.reporter_key.instance_id != task.instance_id) {
+                key_stale = true;
+                break;
+            }
+            auto expected_backend = target.expected_backend.lock();
+            auto current_backend = data_storage_manager_
+                                       ? std::dynamic_pointer_cast<EventReportBackend>(
+                                             data_storage_manager_->GetDataStorageBackend(target.backend_unique_name))
+                                       : nullptr;
+            if (!expected_backend || !current_backend || current_backend.get() != expected_backend.get() ||
+                current_backend->GetStorageConfig().global_unique_name() != target.backend_unique_name ||
+                current_backend->GetStorageType() != target.storage_type) {
+                key_stale = true;
+                break;
+            }
+            if (!current_backend->Available()) {
+                key_busy = true;
+                break;
+            }
+            const auto [backend_it, backend_inserted] =
+                cleanup_backends.emplace(target.backend_unique_name, current_backend);
+            if (!backend_inserted && backend_it->second.get() != current_backend.get()) {
+                key_stale = true;
+                break;
+            }
+            const auto &token = target.cleanup_token;
+            CacheLocation expected_location;
+            std::string reporter_medium;
+            std::string reporter_host;
+            if (!expected_location.FromJsonString(target.expected_location_value) ||
+                expected_location.id() != target.location_id || expected_location.type() != target.storage_type ||
+                expected_location.status() != CLS_SERVING ||
+                !current_backend->ParseLocationId(target.location_id, reporter_medium, reporter_host) ||
+                reporter_host != token.reporter_key.host_ip_port) {
+                key_stale = true;
+                break;
+            }
+            cleanup_tokens.emplace(LeaseKey{target.backend_unique_name,
+                                            token.reporter_key.host_ip_port,
+                                            token.lifecycle_generation,
+                                            static_cast<int>(token.reason),
+                                            token.committed_version,
+                                            token.snapshot_attempt_epoch},
+                                   std::make_pair(std::move(current_backend), token));
+        }
+
+        std::vector<EventReportBackend::MaintenanceBackendLease> backend_leases;
+        if (!key_stale && !key_busy) {
+            backend_leases.reserve(cleanup_backends.size());
+            for (const auto &[_, backend] : cleanup_backends) {
+                EventReportBackend::MaintenanceBackendLease lease;
+                if (backend->AcquireMaintenanceBackendLease(lease) !=
+                    EventReportBackend::CleanupLeaseAcquireResult::kAcquired) {
+                    key_busy = true;
+                    break;
+                }
+                backend_leases.push_back(std::move(lease));
+            }
+        }
+
+        std::vector<EventReportBackend::LifecycleMutationLease> leases;
+        if (!key_stale && !key_busy) {
+            leases.reserve(cleanup_tokens.size());
+            for (const auto &[_, backend_and_token] : cleanup_tokens) {
+                EventReportBackend::LifecycleMutationLease lease;
+                const auto lease_result =
+                    backend_and_token.first->AcquireMaintenanceCleanupLease(backend_and_token.second, lease);
+                if (lease_result == EventReportBackend::CleanupLeaseAcquireResult::kBusy) {
+                    key_busy = true;
+                    break;
+                }
+                if (lease_result == EventReportBackend::CleanupLeaseAcquireResult::kStale) {
+                    key_stale = true;
+                    break;
+                }
+                leases.push_back(std::move(lease));
+            }
+        }
+
+        if (key_stale || key_busy) {
+            const char *status = key_stale ? "mismatch" : "error";
+            for (const auto &target : targets) {
+                record_delete_result(target.cleanup_token.reason, status);
+            }
+            if (key_stale) {
+                completed_targets += targets.size();
+            } else {
+                hard_error_targets += targets.size();
+            }
+            continue;
+        }
+
+        LocationIdsPerKey location_ids(1);
+        std::vector<std::vector<std::string>> expected_values(1);
+        location_ids.front().reserve(targets.size());
+        expected_values.front().reserve(targets.size());
+        for (const auto &target : targets) {
+            location_ids.front().push_back(target.location_id);
+            expected_values.front().push_back(target.expected_location_value);
+        }
+        std::vector<std::vector<ErrorCode>> per_location_ec;
+        RequestContext context("event_report_metadata_delete");
+        const ErrorCode ec = meta_searcher.BatchDeleteLocations(&context,
+                                                                 {task.block_keys[key_index]},
+                                                                 location_ids,
+                                                                 per_location_ec,
+                                                                 expected_values,
+                                                                 true,
+                                                                 true,
+                                                                 true);
+        if (per_location_ec.size() != 1 || per_location_ec.front().size() != targets.size()) {
+            hard_error_targets += targets.size();
+            for (const auto &target : targets) {
+                record_delete_result(target.cleanup_token.reason, "error");
+            }
+            continue;
+        }
+        for (size_t target_index = 0; target_index < targets.size(); ++target_index) {
+            const ErrorCode target_ec = per_location_ec.front()[target_index];
+            const bool hard_error = target_ec != EC_OK && target_ec != EC_NOENT && target_ec != EC_MISMATCH;
+            hard_error_targets += static_cast<size_t>(hard_error);
+            completed_targets += static_cast<size_t>(!hard_error);
+            const char *status = target_ec == EC_OK       ? "deleted"
+                                 : target_ec == EC_NOENT  ? "noent"
+                                 : target_ec == EC_MISMATCH ? "mismatch"
+                                                           : "error";
+            record_delete_result(targets[target_index].cleanup_token.reason, status);
+        }
+        if (ec != EC_OK && ec != EC_PARTIAL_OK &&
+            std::none_of(per_location_ec.front().begin(), per_location_ec.front().end(), [](ErrorCode target_ec) {
+                return target_ec != EC_OK && target_ec != EC_NOENT && target_ec != EC_MISMATCH;
+            })) {
+            // A malformed aggregate result must not be hidden by otherwise
+            // successful per-target values.
+            ++hard_error_targets;
+        }
+    }
+
+    if (hard_error_targets == 0) {
+        return PlanExecuteResult{EC_OK, ""};
+    }
+    return MakeErrorResult(completed_targets == 0 ? EC_ERROR : EC_PARTIAL_OK,
+                           StringUtil::FormatString("EventReport metadata delete hard failures: %zu",
+                                                    hard_error_targets));
 }
 
 AsyncDeleteSubmitResult

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -16,6 +16,7 @@
 
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/data_storage/data_storage_uri.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/manager/meta_searcher.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
@@ -61,9 +62,28 @@ struct CacheLocationDelRequest {
     // Event-report metadata describes externally owned cache. Its reconciliation
     // cleanup must remove only KVCM metadata and never call the URI backend.
     bool metadata_only{false};
-    // Maintenance scans observe the persistent source of truth. Revalidate
-    // admission there and refresh candidate keys into the hot cache before CAS.
+    // GC physical deletion revalidates against the persistent source of truth
+    // and refreshes candidate keys into the hot cache before CAS.
     bool authoritative_read{false};
+};
+
+struct EventReportMetadataDeleteTarget {
+    std::string location_id;
+    std::string expected_location_value;
+    std::string backend_unique_name;
+    DataStorageType storage_type{DataStorageType::DATA_STORAGE_TYPE_UNKNOWN};
+    std::weak_ptr<EventReportBackend> expected_backend;
+    EventReportBackend::MaintenanceCleanupToken cleanup_token;
+};
+
+// Metadata-only reconciliation for externally owned EventReport cache. The
+// Executor revalidates the backend incarnation and cleanup token immediately
+// before an expected-value, no-touch RMW. It never changes Location status or
+// calls the data-storage physical DELETE path.
+struct EventReportMetadataDelRequest {
+    std::string instance_id;
+    std::vector<int64_t> block_keys;
+    std::vector<std::vector<EventReportMetadataDeleteTarget>> targets;
 };
 
 // 单个 block 的跨存储复制请求。URI 由上层（MigrationManager）解析与预分配后传入；
@@ -118,6 +138,7 @@ public:
     std::future<PlanExecuteResult> Submit(const CacheLocationCopyRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const CacheMetaDelRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const CacheLocationDelRequest &task);
+    AsyncDeleteSubmitResult SubmitAsync(const EventReportMetadataDelRequest &task);
 
     bool SubmitNonBlocking(const CacheMetaDelRequest &req, ScheduleTaskClass task_class = ScheduleTaskClass::kSystem);
     bool SubmitNonBlocking(const CacheLocationDelRequest &req,
@@ -185,6 +206,7 @@ private:
     std::future<PlanExecuteResult> SubmitLocationDelete(const CacheLocationDelRequest &task,
                                                         ScheduleTaskClass task_class);
     PlanExecuteResult DoLocationDelTask(const CacheLocationDelRequest &task);
+    PlanExecuteResult DoEventReportMetadataDelTask(const EventReportMetadataDelRequest &task);
     void DoCopyTask(const std::shared_ptr<std::promise<PlanExecuteResult>> &promise,
                     const CacheLocationCopyRequest &task);
 

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -33,6 +33,18 @@ cc_test(
 )
 
 cc_test(
+    name = "EventReportCleanupUtilTest",
+    srcs = ["event_report_cleanup_util_test.cc"],
+    linkstatic = True,
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/data_storage",
+        "//kv_cache_manager/manager:cache_garbage_collector",
+        "//kv_cache_manager/meta:cache_location",
+    ],
+)
+
+cc_test(
     name = "DataStorageSelectorTest",
     srcs = [
         "data_storage_selector_test.cc",

--- a/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
+++ b/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <shared_mutex>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -18,8 +19,10 @@
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
+#include "kv_cache_manager/data_storage/snapshot_uri_utils.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
 #include "kv_cache_manager/manager/cache_garbage_collector.h"
-#include "kv_cache_manager/manager/meta_searcher.h"
 #include "kv_cache_manager/manager/migration_manager.h"
 #include "kv_cache_manager/manager/schedule_plan_executor.h"
 #include "kv_cache_manager/meta/cache_location.h"
@@ -36,6 +39,8 @@ namespace {
 using InstanceGroups = std::vector<std::shared_ptr<const InstanceGroup>>;
 using InstanceInfos = std::vector<std::shared_ptr<const InstanceInfo>>;
 using SubmitAsyncLocation = AsyncDeleteSubmitResult (SchedulePlanExecutor::*)(const CacheLocationDelRequest &);
+using SubmitAsyncEventReport =
+    AsyncDeleteSubmitResult (SchedulePlanExecutor::*)(const EventReportMetadataDelRequest &);
 
 struct ScanResponse {
     ErrorCode ec{EC_OK};
@@ -99,6 +104,7 @@ std::set<std::string> missing_indexers;
 std::string active_instance_id;
 std::shared_ptr<MetaIndexer> dummy_indexer;
 std::vector<CacheLocationDelRequest> submitted_requests;
+std::vector<EventReportMetadataDelRequest> submitted_event_report_requests;
 SubmitMode submit_mode = SubmitMode::kReadyOk;
 std::shared_ptr<std::promise<PlanExecuteResult>> pending_delete_promise;
 std::vector<std::shared_ptr<std::promise<PlanExecuteResult>>> pending_delete_promises;
@@ -113,6 +119,9 @@ std::map<std::string, std::vector<bool>> might_exist_result_overrides;
 std::set<std::string> might_exist_throw_storages;
 std::set<std::string> missing_probe_storages;
 std::map<std::string, DataStorageType> probe_storage_type_overrides;
+std::map<std::string, std::shared_ptr<DataStorageBackend>> storage_backends;
+std::map<std::string, std::shared_ptr<const InstanceGroup>> group_configs;
+std::map<std::string, std::string> group_by_instance;
 std::atomic<bool> block_might_exist{false};
 std::atomic<bool> might_exist_block_entered{false};
 std::atomic<bool> release_might_exist{true};
@@ -139,12 +148,25 @@ std::shared_ptr<MetaIndexer> GetMetaIndexerStub(void *, const std::string &insta
 }
 
 std::shared_ptr<DataStorageBackend> GetDataStorageBackendStub(void *, const std::string &storage_name) {
+    if (const auto backend_it = storage_backends.find(storage_name); backend_it != storage_backends.end()) {
+        return backend_it->second;
+    }
     if (missing_probe_storages.count(storage_name) > 0) {
         return nullptr;
     }
     const auto it = probe_storage_type_overrides.find(storage_name);
     const auto type = it == probe_storage_type_overrides.end() ? DataStorageType::DATA_STORAGE_TYPE_DUMMY : it->second;
     return std::make_shared<ProbeTestBackend>(type);
+}
+
+std::shared_ptr<const InstanceGroup> GetInstanceGroupConfigStub(void *, const std::string &group_name) {
+    const auto it = group_configs.find(group_name);
+    return it == group_configs.end() ? nullptr : it->second;
+}
+
+std::string GetInstanceGroupNameStub(void *, const std::string &instance_id) {
+    const auto it = group_by_instance.find(instance_id);
+    return it == group_by_instance.end() ? std::string{} : it->second;
 }
 
 ErrorCode ScanLocationsForMaintenanceStub(
@@ -175,6 +197,33 @@ ErrorCode ScanLocationsForMaintenanceStub(
 
 AsyncDeleteSubmitResult SubmitAsyncStub(void *, const CacheLocationDelRequest &request) {
     submitted_requests.push_back(request);
+    if (submit_mode == SubmitMode::kThrow) {
+        throw std::runtime_error("injected SubmitAsync exception");
+    }
+    if (submit_mode == SubmitMode::kRejected) {
+        return {};
+    }
+    if (submit_mode == SubmitMode::kAcceptedInvalid) {
+        return {true, {}};
+    }
+
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto future = promise->get_future();
+    if (submit_mode == SubmitMode::kPending) {
+        pending_delete_promise = promise;
+        pending_delete_promises.push_back(promise);
+    } else if (submit_mode == SubmitMode::kFutureException) {
+        promise->set_exception(std::make_exception_ptr(std::runtime_error("injected Future exception")));
+    } else if (submit_mode == SubmitMode::kReadyPartial) {
+        promise->set_value({EC_PARTIAL_OK, "injected partial"});
+    } else {
+        promise->set_value({EC_OK, ""});
+    }
+    return {true, std::move(future)};
+}
+
+AsyncDeleteSubmitResult SubmitAsyncEventReportStub(void *, const EventReportMetadataDelRequest &request) {
+    submitted_event_report_requests.push_back(request);
     if (submit_mode == SubmitMode::kThrow) {
         throw std::runtime_error("injected SubmitAsync exception");
     }
@@ -277,7 +326,11 @@ public:
         stub_.set(ADDR(MetaIndexer, ScanLocationsForMaintenance), ScanLocationsForMaintenanceStub);
         stub_.set(ADDR(DataStorageManager, GetDataStorageBackend), GetDataStorageBackendStub);
         stub_.set(ADDR(DataStorageManager, Exist), DataStorageExistStub);
+        stub_.set(ADDR(RegistryManager, GetInstanceGroupConfig), GetInstanceGroupConfigStub);
+        stub_.set(ADDR(RegistryManager, GetInstanceGroupName), GetInstanceGroupNameStub);
         stub_.set(static_cast<SubmitAsyncLocation>(ADDR(SchedulePlanExecutor, SubmitAsync)), SubmitAsyncStub);
+        stub_.set(static_cast<SubmitAsyncEventReport>(ADDR(SchedulePlanExecutor, SubmitAsync)),
+                  SubmitAsyncEventReportStub);
 
         metrics_registry_ = std::make_shared<MetricsRegistry>();
         registry_manager_ = std::make_shared<RegistryManager>("", metrics_registry_);
@@ -298,6 +351,7 @@ public:
         missing_indexers.clear();
         active_instance_id.clear();
         submitted_requests.clear();
+        submitted_event_report_requests.clear();
         submit_mode = SubmitMode::kReadyOk;
         pending_delete_promise.reset();
         pending_delete_promises.clear();
@@ -312,6 +366,9 @@ public:
         might_exist_throw_storages.clear();
         missing_probe_storages.clear();
         probe_storage_type_overrides.clear();
+        storage_backends.clear();
+        group_configs.clear();
+        group_by_instance.clear();
         block_might_exist.store(false, std::memory_order_relaxed);
         might_exist_block_entered.store(false, std::memory_order_relaxed);
         release_might_exist.store(true, std::memory_order_relaxed);
@@ -336,12 +393,14 @@ public:
             auto group = std::make_shared<InstanceGroup>();
             group->set_name(group_name);
             instance_groups.push_back(group);
+            group_configs[group_name] = group;
         }
         auto instance = std::make_shared<InstanceInfo>();
         instance->set_instance_group_name(group_name);
         instance->set_instance_id(instance_id);
         instances_by_group[group_name].first = EC_OK;
         instances_by_group[group_name].second.push_back(instance);
+        group_by_instance[instance_id] = group_name;
     }
 
     CacheGarbageCollector::Config DefaultConfig() const {
@@ -350,6 +409,10 @@ public:
         config.scan_interval_ms = 1000;
         config.round_pause_ms = 1000;
         config.scan_batch_size = 2;
+        // Most fixture cases exercise regular GC only. EventReport-specific
+        // cases opt in explicitly even though the production default is on.
+        config.event_report_cleanup_enabled = false;
+        config.event_report_action_batch_size = 2;
         config.orphan_writing_grace_period_ms = kMinCacheGcOrphanWritingGracePeriodMs;
         return config;
     }
@@ -368,6 +431,23 @@ public:
         gc.RegisterMetrics();
         gc.ResetWorkerState();
         gc.stop_requested_.store(false);
+    }
+
+    std::shared_ptr<EventReportBackend>
+    AddEventReportBackend(const std::string &storage_name,
+                          DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5) {
+        auto spec = std::make_shared<EventReportStorageSpec>();
+        spec->set_snapshot_min_interval_ms(0);
+        // Keep liveness from changing fixture state during deterministic GC
+        // steps. Recovery-grace tests move the deadline explicitly.
+        spec->set_heartbeat_timeout_ms(60000);
+        spec->set_cleanup_grace_ms(60000);
+        auto backend = std::make_shared<EventReportBackend>(metrics_registry_);
+        EXPECT_EQ(EC_OK, backend->Open(StorageConfig(type, storage_name, spec), "test"));
+        storage_backends[storage_name] = backend;
+        auto group = std::const_pointer_cast<InstanceGroup>(group_configs.at("group_a"));
+        group->set_event_report_storage_candidates({storage_name});
+        return backend;
     }
 
     bool WaitForScanCallCount(size_t expected) const {
@@ -397,9 +477,11 @@ protected:
 TEST_F(CacheGarbageCollectorTest, ConfigAndRestartableLifecycle) {
     auto disabled_config = DefaultConfig();
     disabled_config.enabled = false;
+    disabled_config.event_report_cleanup_enabled = true;
     auto disabled_gc = MakeGc(disabled_config);
     EXPECT_EQ(EC_OK, disabled_gc->Start());
     EXPECT_FALSE(disabled_gc->IsRunning());
+    EXPECT_FALSE(disabled_gc->IsEventReportCleanupEnabled());
 
     auto invalid_config = DefaultConfig();
     invalid_config.orphan_writing_grace_period_ms = kMinCacheGcOrphanWritingGracePeriodMs - 1;
@@ -410,6 +492,27 @@ TEST_F(CacheGarbageCollectorTest, ConfigAndRestartableLifecycle) {
     invalid_config.max_inflight_delete_requests = 0;
     invalid_gc = MakeGc(invalid_config);
     EXPECT_EQ(EC_CONFIG_ERROR, invalid_gc->Validate());
+
+    auto zero_round_pause_config = DefaultConfig();
+    zero_round_pause_config.round_pause_ms = 0;
+    EXPECT_EQ(EC_OK, MakeGc(zero_round_pause_config)->Validate());
+
+    invalid_config = DefaultConfig();
+    invalid_config.round_pause_ms = -1;
+    invalid_gc = MakeGc(invalid_config);
+    EXPECT_EQ(EC_CONFIG_ERROR, invalid_gc->Validate());
+
+    invalid_config = DefaultConfig();
+    invalid_config.event_report_cleanup_enabled = true;
+    invalid_config.event_report_action_batch_size = 0;
+    invalid_gc = MakeGc(invalid_config);
+    EXPECT_EQ(EC_CONFIG_ERROR, invalid_gc->Validate());
+
+    invalid_config = DefaultConfig();
+    invalid_config.event_report_cleanup_enabled = true;
+    invalid_config.event_report_action_batch_size = invalid_config.scan_batch_size + 1;
+    invalid_gc = MakeGc(invalid_config);
+    EXPECT_EQ(EC_OK, invalid_gc->Validate());
 
     auto gc = MakeGc(DefaultConfig());
     ASSERT_EQ(EC_OK, gc->Start());
@@ -425,6 +528,428 @@ TEST_F(CacheGarbageCollectorTest, ConfigAndRestartableLifecycle) {
     EXPECT_TRUE(gc->IsRunning());
     gc->Stop();
     EXPECT_FALSE(gc->IsRunning());
+}
+
+TEST_F(CacheGarbageCollectorTest, StartRestoresFullEventReportRecoveryGraceAfterLeaderRecovery) {
+    auto spec = std::make_shared<EventReportStorageSpec>();
+    spec->set_heartbeat_timeout_ms(60000);
+    spec->set_cleanup_grace_ms(60000);
+    spec->set_liveness_check_interval_ms(60000);
+    const std::string storage_name = "event_report_recovery_grace";
+    RequestContext context("register_event_report_recovery_grace");
+    ASSERT_EQ(EC_OK,
+              data_storage_manager_->RegisterStorage(
+                  &context,
+                  storage_name,
+                  StorageConfig(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5, storage_name, spec)));
+
+    std::shared_ptr<EventReportBackend> backend;
+    for (const auto &storage : data_storage_manager_->GetAvailableStorages()) {
+        if (storage && storage->GetStorageConfig().global_unique_name() == storage_name) {
+            backend = std::dynamic_pointer_cast<EventReportBackend>(storage);
+            break;
+        }
+    }
+    ASSERT_NE(nullptr, backend);
+    // Simulate a Backend opened before a long leader recovery. GC Start must
+    // grant Reporters a fresh registration/heartbeat window.
+    backend->maintenance_recovery_deadline_ms_.store(0, std::memory_order_release);
+    EXPECT_EQ(0, backend->GetMaintenanceRecoveryGraceRemainingMs());
+
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.scan_interval_ms = 60000;
+    auto gc = MakeGc(config);
+    ASSERT_EQ(EC_OK, gc->Start());
+    EXPECT_GT(backend->GetMaintenanceRecoveryGraceRemainingMs(), 0);
+    gc->Stop();
+
+    ASSERT_EQ(EC_OK, data_storage_manager_->UnRegisterStorage(storage_name));
+}
+
+TEST_F(CacheGarbageCollectorTest, EventReportLookupSkipsMissingCandidateAndRejectsAmbiguousOrUnavailableOwner) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto first = AddEventReportBackend("event_report_first");
+    auto second = AddEventReportBackend("event_report_second", DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+    auto duplicate_second =
+        AddEventReportBackend("event_report_second_duplicate", DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+    auto group = std::const_pointer_cast<InstanceGroup>(group_configs.at("group_a"));
+    group->set_event_report_storage_candidates({"event_report_second", "event_report_second_duplicate"});
+    auto route = gc->LookupEventReportBackend("instance_a", second->GetStorageType());
+    EXPECT_EQ(CacheGarbageCollector::EventReportBackendRouteStatus::kAmbiguous, route.status);
+
+    group->set_event_report_storage_candidates({"missing_owner", "event_report_second"});
+    route = gc->LookupEventReportBackend("instance_a", second->GetStorageType());
+    ASSERT_EQ(CacheGarbageCollector::EventReportBackendRouteStatus::kResolved, route.status);
+    EXPECT_EQ(second.get(), route.backend.get());
+
+    group->set_event_report_storage_candidates({"event_report_first"});
+    first->SetAvailable(false);
+    route = gc->LookupEventReportBackend("instance_a", first->GetStorageType());
+    EXPECT_EQ(CacheGarbageCollector::EventReportBackendRouteStatus::kUnavailable, route.status);
+    first->Close();
+    second->Close();
+    duplicate_second->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, SharedScanDeletesOnlyStaleSnapshotAndMalformedIsUnknown) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.scan_batch_size = 8;
+    config.event_report_action_batch_size = 4;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const ReporterSnapshotKey reporter{"instance_a", "10.0.0.1:9000"};
+    ASSERT_EQ(EC_OK, backend->RegisterNode(reporter.instance_id, reporter.host_ip_port, {"hbm"}));
+
+    uint64_t retry_after_ms = 0;
+    std::string old_version;
+    ASSERT_EQ(EC_OK, backend->BeginSnapshot(reporter, old_version, retry_after_ms));
+    ASSERT_TRUE(backend->CommitSnapshotVersion(reporter, old_version));
+    std::string committed_version;
+    ASSERT_EQ(EC_OK, backend->BeginSnapshot(reporter, committed_version, retry_after_ms));
+    ASSERT_TRUE(backend->CommitSnapshotVersion(reporter, committed_version));
+
+    std::string old_uri;
+    std::string committed_uri;
+    ASSERT_TRUE(
+        SnapshotUriUtils::AddSnapshotVersionToUri("event_report://event_report_l1p5/old", old_version, old_uri));
+    ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(
+        "event_report://event_report_l1p5/current", committed_version, committed_uri));
+    const std::string malformed_uri = "event_report://event_report_l1p5/malformed?s_version=first&s_version=second";
+    const std::string location_id = backend->BuildLocationId("hbm", reporter.host_ip_port);
+
+    CacheLocationMap old_locations;
+    old_locations.emplace(location_id,
+                          MakeStoredLocation(location_id, CLS_SERVING, backend->GetStorageType(), {old_uri}));
+    CacheLocationMap current_locations;
+    current_locations.emplace(location_id,
+                              MakeStoredLocation(location_id, CLS_SERVING, backend->GetStorageType(), {committed_uri}));
+    CacheLocationMap malformed_locations;
+    malformed_locations.emplace(
+        location_id, MakeStoredLocation(location_id, CLS_SERVING, backend->GetStorageType(), {malformed_uri}));
+    scan_responses[reporter.instance_id] = {
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {101, 102, 103}, {old_locations, current_locations, malformed_locations})}};
+
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    EXPECT_EQ((KeyVector{101}), submitted_event_report_requests.front().block_keys);
+    ASSERT_EQ(1u, submitted_event_report_requests.front().targets.size());
+    ASSERT_EQ(1u, submitted_event_report_requests.front().targets.front().size());
+    EXPECT_EQ(location_id, submitted_event_report_requests.front().targets.front().front().location_id);
+    EXPECT_TRUE(submitted_requests.empty());
+    EXPECT_EQ(
+        1, metrics_registry_->GetCounter("cache_gc.event_report_probe_unknown_count", {{"cause", "malformed"}}).Get());
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, DownHostsShareOneRegularScanAndUseKeyBoundedActions) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.scan_batch_size = 8;
+    config.event_report_action_batch_size = 4;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    CacheLocationMap first_locations;
+    CacheLocationMap second_locations;
+    const std::vector<std::string> hosts{"10.0.0.1:9000", "10.0.0.2:9000"};
+    for (size_t i = 0; i < hosts.size(); ++i) {
+        ASSERT_EQ(EC_OK, backend->RegisterNode("instance_a", hosts[i], {"hbm"}));
+        uint64_t generation = 0;
+        ASSERT_EQ(EC_OK, backend->UnregisterNodeForHostDown("instance_a", hosts[i], generation));
+        const std::string location_id = backend->BuildLocationId("hbm", hosts[i]);
+        auto location = MakeStoredLocation(location_id,
+                                           CLS_SERVING,
+                                           backend->GetStorageType(),
+                                           {"event_report://event_report_l1p5/object" + std::to_string(i)});
+        (i == 0 ? first_locations : second_locations).emplace(location_id, std::move(location));
+    }
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {101, 202}, {first_locations, second_locations})}};
+
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, scan_calls.size());
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    EXPECT_EQ((KeyVector{101, 202}), submitted_event_report_requests.front().block_keys);
+    EXPECT_TRUE(submitted_requests.empty());
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, UnifiedBudgetPrioritizesBlockingGarbageOverEventReport) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.scan_batch_size = 2;
+    config.event_report_action_batch_size = 1;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const ReporterSnapshotKey reporter{"instance_a", "10.0.0.1:9000"};
+    ASSERT_EQ(EC_OK, backend->RegisterNode(reporter.instance_id, reporter.host_ip_port, {"hbm"}));
+    uint64_t retry_after_ms = 0;
+    std::string old_version;
+    ASSERT_EQ(EC_OK, backend->BeginSnapshot(reporter, old_version, retry_after_ms));
+    ASSERT_TRUE(backend->CommitSnapshotVersion(reporter, old_version));
+    std::string committed_version;
+    ASSERT_EQ(EC_OK, backend->BeginSnapshot(reporter, committed_version, retry_after_ms));
+    ASSERT_TRUE(backend->CommitSnapshotVersion(reporter, committed_version));
+    std::string old_uri;
+    ASSERT_TRUE(
+        SnapshotUriUtils::AddSnapshotVersionToUri("event_report://event_report_l1p5/old", old_version, old_uri));
+
+    const std::string event_location_id = backend->BuildLocationId("hbm", reporter.host_ip_port);
+    CacheLocationMap event_locations;
+    event_locations.emplace(event_location_id,
+                            MakeStoredLocation(event_location_id, CLS_SERVING, backend->GetStorageType(), {old_uri}));
+
+    const std::string missing_uri = "dummy://dummy/missing?size=1";
+    might_exist_by_uri[missing_uri] = false;
+    CacheLocationMap missing_locations;
+    missing_locations.emplace(
+        "missing", MakeStoredLocation("missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_uri}));
+
+    CacheLocationMap orphan_locations;
+    orphan_locations.emplace("orphan", MakeLocation("orphan", CLS_WRITING, OldCreateTimeUs(config, 1)));
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {1, 100, 200}, {event_locations, missing_locations, orphan_locations})}};
+
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, submitted_requests.size());
+    EXPECT_EQ((KeyVector{100, 200}), submitted_requests.front().block_keys);
+    EXPECT_TRUE(submitted_event_report_requests.empty());
+    EXPECT_EQ(1,
+              metrics_registry_
+                  ->GetCounter("cache_gc.candidate_dropped_count",
+                               {{"reason", "event_report_stale_snapshot"}, {"cause", "total_budget"}})
+                  .Get());
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, FullPhysicalInflightWindowPausesSharedEventReportScan) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.max_inflight_delete_requests = 1;
+    config.scan_batch_size = 4;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const std::string host = "10.0.0.1:9000";
+    ASSERT_EQ(EC_OK, backend->RegisterNode("instance_a", host, {"hbm"}));
+    uint64_t generation = 0;
+    ASSERT_EQ(EC_OK, backend->UnregisterNodeForHostDown("instance_a", host, generation));
+    const std::string event_location_id = backend->BuildLocationId("hbm", host);
+    CacheLocationMap event_locations;
+    event_locations.emplace(
+        event_location_id,
+        MakeStoredLocation(
+            event_location_id, CLS_SERVING, backend->GetStorageType(), {"event_report://event_report_l1p5/object"}));
+
+    CacheLocationMap orphan_locations;
+    orphan_locations.emplace("orphan", MakeLocation("orphan", CLS_WRITING, OldCreateTimeUs(config, 1)));
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch("next", {100}, {orphan_locations})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {200}, {event_locations})},
+    };
+
+    submit_mode = SubmitMode::kPending;
+    gc->RunOneTick();
+    ASSERT_EQ(1u, gc->inflight_deletes_.size());
+    ASSERT_EQ(1u, scan_calls.size());
+
+    gc->RunOneTick();
+    EXPECT_EQ(1u, scan_calls.size());
+    EXPECT_TRUE(submitted_event_report_requests.empty());
+
+    ASSERT_TRUE(pending_delete_promise);
+    pending_delete_promise->set_value({EC_OK, ""});
+    gc->RunOneTick();
+    EXPECT_EQ(2u, scan_calls.size());
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    EXPECT_EQ((KeyVector{200}), submitted_event_report_requests.front().block_keys);
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, EventReportActionBudgetCountsKeysAndKeepsLocationsForSelectedKey) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.scan_batch_size = 8;
+    config.event_report_action_batch_size = 1;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const std::vector<std::string> hosts{"10.0.0.1:9000", "10.0.0.2:9000", "10.0.0.3:9000"};
+    CacheLocationMap first_key_locations;
+    CacheLocationMap second_key_locations;
+    for (size_t i = 0; i < hosts.size(); ++i) {
+        ASSERT_EQ(EC_OK, backend->RegisterNode("instance_a", hosts[i], {"hbm"}));
+        uint64_t generation = 0;
+        ASSERT_EQ(EC_OK, backend->UnregisterNodeForHostDown("instance_a", hosts[i], generation));
+        const std::string location_id = backend->BuildLocationId("hbm", hosts[i]);
+        auto location = MakeStoredLocation(location_id,
+                                           CLS_SERVING,
+                                           backend->GetStorageType(),
+                                           {"event_report://event_report_l1p5/object" + std::to_string(i)});
+        (i < 2 ? first_key_locations : second_key_locations).emplace(location_id, std::move(location));
+    }
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {100, 200}, {first_key_locations, second_key_locations})}};
+
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    EXPECT_EQ((KeyVector{100}), submitted_event_report_requests.front().block_keys);
+    ASSERT_EQ(1u, submitted_event_report_requests.front().targets.size());
+    EXPECT_EQ(2u, submitted_event_report_requests.front().targets.front().size());
+    EXPECT_EQ(1,
+              metrics_registry_
+                  ->GetCounter("cache_gc.candidate_dropped_count",
+                               {{"reason", "event_report_down_host"}, {"cause", "event_report_budget"}})
+                  .Get());
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, EventReportActionBudgetIsIndependentAndObservable) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.scan_batch_size = 4;
+    config.event_report_action_batch_size = 1;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const ReporterSnapshotKey reporter{"instance_a", "10.0.0.1:9000"};
+    ASSERT_EQ(EC_OK, backend->RegisterNode(reporter.instance_id, reporter.host_ip_port, {"hbm"}));
+    uint64_t retry_after_ms = 0;
+    std::string old_version;
+    ASSERT_EQ(EC_OK, backend->BeginSnapshot(reporter, old_version, retry_after_ms));
+    ASSERT_TRUE(backend->CommitSnapshotVersion(reporter, old_version));
+    std::string committed_version;
+    ASSERT_EQ(EC_OK, backend->BeginSnapshot(reporter, committed_version, retry_after_ms));
+    ASSERT_TRUE(backend->CommitSnapshotVersion(reporter, committed_version));
+    std::string old_uri;
+    ASSERT_TRUE(
+        SnapshotUriUtils::AddSnapshotVersionToUri("event_report://event_report_l1p5/old", old_version, old_uri));
+    const std::string location_id = backend->BuildLocationId("hbm", reporter.host_ip_port);
+    CacheLocationMap first;
+    CacheLocationMap second;
+    first.emplace(location_id, MakeStoredLocation(location_id, CLS_SERVING, backend->GetStorageType(), {old_uri}));
+    second.emplace(location_id, MakeStoredLocation(location_id, CLS_SERVING, backend->GetStorageType(), {old_uri}));
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {101, 202}, {first, second})}};
+
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    EXPECT_EQ((KeyVector{101}), submitted_event_report_requests.front().block_keys);
+    EXPECT_EQ(1,
+              metrics_registry_
+                  ->GetCounter("cache_gc.candidate_dropped_count",
+                               {{"reason", "event_report_stale_snapshot"}, {"cause", "event_report_budget"}})
+                  .Get());
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, RejectedEventReportSubmissionDoesNotCreatePendingOrInflight) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const std::string host = "10.0.0.1:9000";
+    ASSERT_EQ(EC_OK, backend->RegisterNode("instance_a", host, {"hbm"}));
+    uint64_t generation = 0;
+    ASSERT_EQ(EC_OK, backend->UnregisterNodeForHostDown("instance_a", host, generation));
+    const std::string location_id = backend->BuildLocationId("hbm", host);
+    CacheLocationMap locations;
+    locations.emplace(
+        location_id,
+        MakeStoredLocation(
+            location_id, CLS_SERVING, backend->GetStorageType(), {"event_report://event_report_l1p5/object"}));
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {101}, {locations})}};
+
+    submit_mode = SubmitMode::kRejected;
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    EXPECT_EQ(0, metrics_registry_->GetCounter("cache_gc.operation_error_count", {{"stage", "submit_rejected"}}).Get());
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, PhysicalAndEventReportActionsShareGcInflightWindow) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    config.scan_batch_size = 4;
+    config.max_inflight_delete_requests = 2;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const std::string host = "10.0.0.1:9000";
+    ASSERT_EQ(EC_OK, backend->RegisterNode("instance_a", host, {"hbm"}));
+    uint64_t generation = 0;
+    ASSERT_EQ(EC_OK, backend->UnregisterNodeForHostDown("instance_a", host, generation));
+    const std::string event_location_id = backend->BuildLocationId("hbm", host);
+    CacheLocationMap locations;
+    locations.emplace(
+        event_location_id,
+        MakeStoredLocation(
+            event_location_id, CLS_SERVING, backend->GetStorageType(), {"event_report://event_report_l1p5/object"}));
+    locations.emplace("orphan", MakeLocation("orphan", CLS_WRITING, OldCreateTimeUs(config, 1)));
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {101}, {locations})}};
+
+    submit_mode = SubmitMode::kPending;
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, submitted_requests.size());
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    EXPECT_EQ(2u, gc->inflight_deletes_.size());
+    EXPECT_EQ(2u, gc->pending_locations_.size());
+    backend->Close();
+}
+
+TEST_F(CacheGarbageCollectorTest, BackendRecoveryGraceDoesNotPauseOrdinaryGcCandidates) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const std::string host = "10.0.0.1:9000";
+    const std::string location_id = backend->BuildLocationId("hbm", host);
+    CacheLocationMap locations;
+    locations.emplace(
+        location_id,
+        MakeStoredLocation(
+            location_id, CLS_SERVING, backend->GetStorageType(), {"event_report://event_report_l1p5/object"}));
+    locations.emplace("orphan", MakeLocation("orphan", CLS_WRITING, OldCreateTimeUs(config, 1)));
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {101}, {locations})}};
+
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, scan_calls.size());
+    ASSERT_EQ(1u, submitted_requests.size());
+    EXPECT_EQ((std::vector<std::vector<std::string>>{{"orphan"}}), submitted_requests.front().location_ids);
+    EXPECT_TRUE(submitted_event_report_requests.empty());
+    EXPECT_EQ(1,
+              metrics_registry_
+                  ->GetCounter("cache_gc.event_report_probe_unknown_count", {{"cause", "recovery_grace"}})
+                  .Get());
+    backend->Close();
 }
 
 TEST_F(CacheGarbageCollectorTest, RestartBeginsScanningFromBaseCursor) {
@@ -472,7 +997,7 @@ TEST_F(CacheGarbageCollectorTest, FixedPredicateIsFailClosedAndRequestIsBounded)
 
     const auto batch = MakeBatch(
         SCAN_BASE_CURSOR, {10, 20, 30, 10}, {first_locations, second_locations, third_locations, duplicate_locations});
-    const CacheLocationDelRequest request = gc->BuildDeleteRequest("instance_a", batch, now_us);
+    const CacheLocationDelRequest request = gc->BuildDeleteActions("instance_a", batch, now_us).executor_request;
     ASSERT_EQ(2, request.block_keys.size());
     EXPECT_EQ((KeyVector{10, 20}), request.block_keys);
     EXPECT_EQ((std::vector<std::vector<std::string>>{{"old"}, {"another"}}), request.location_ids);
@@ -484,8 +1009,8 @@ TEST_F(CacheGarbageCollectorTest, FixedPredicateIsFailClosedAndRequestIsBounded)
 
     MaintenanceScanBatch broken_batch = batch;
     broken_batch.location_results.pop_back();
-    EXPECT_TRUE(gc->BuildDeleteRequest("instance_a", broken_batch, now_us).block_keys.empty());
-    EXPECT_TRUE(gc->BuildDeleteRequest("", batch, now_us).block_keys.empty());
+    EXPECT_TRUE(gc->BuildDeleteActions("instance_a", broken_batch, now_us).executor_request.block_keys.empty());
+    EXPECT_TRUE(gc->BuildDeleteActions("", batch, now_us).executor_request.block_keys.empty());
 }
 
 TEST_F(CacheGarbageCollectorTest, ServingMissingSpecIsBatchedAndSubmittedWithExactSnapshot) {
@@ -522,7 +1047,7 @@ TEST_F(CacheGarbageCollectorTest, ServingMissingSpecIsBatchedAndSubmittedWithExa
 
     const auto batch = MakeBatch(SCAN_BASE_CURSOR, {10, 20}, {first_locations, second_locations});
     const CacheLocationDelRequest request =
-        gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs());
+        gc->BuildDeleteActions("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).executor_request;
 
     EXPECT_EQ((KeyVector{10, 20}), request.block_keys);
     EXPECT_EQ((std::vector<std::vector<std::string>>{{"old_writing", "serving_missing"}, {"second_missing"}}),
@@ -574,8 +1099,10 @@ TEST_F(CacheGarbageCollectorTest, ServingProbeErrorsAreUnknownButOtherDefinitive
                            DataStorageType::DATA_STORAGE_TYPE_DUMMY,
                            {"dummy://shape_storage/unknown?size=1", "dummy://missing_storage/missing?size=1"});
 
-    const CacheLocationDelRequest request = gc->BuildDeleteRequest(
-        "instance_a", MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}), TimestampUtil::GetCurrentTimeUs());
+    const CacheLocationDelRequest request = gc->BuildDeleteActions("instance_a",
+                                                                   MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}),
+                                                                   TimestampUtil::GetCurrentTimeUs())
+                                                .executor_request;
 
     EXPECT_EQ((KeyVector{10}), request.block_keys);
     EXPECT_EQ((std::vector<std::vector<std::string>>{{"missing_and_unknown"}}), request.location_ids);
@@ -605,8 +1132,10 @@ TEST_F(CacheGarbageCollectorTest, ServingProbeBatchesBoundEachMightExistCall) {
     CacheLocationMap locations;
     locations["serving"] = MakeStoredLocation("serving", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, uris);
 
-    const CacheLocationDelRequest request = gc->BuildDeleteRequest(
-        "instance_a", MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}), TimestampUtil::GetCurrentTimeUs());
+    const CacheLocationDelRequest request = gc->BuildDeleteActions("instance_a",
+                                                                   MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}),
+                                                                   TimestampUtil::GetCurrentTimeUs())
+                                                .executor_request;
 
     EXPECT_TRUE(request.block_keys.empty());
     ASSERT_EQ(2, might_exist_calls.size());
@@ -672,8 +1201,10 @@ TEST_F(CacheGarbageCollectorTest, MissingOrMismatchedStorageIsUnknownAndClassifi
     locations["definitive_missing"] =
         MakeStoredLocation("definitive_missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_uri});
 
-    const CacheLocationDelRequest request = gc->BuildDeleteRequest(
-        "instance_a", MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}), TimestampUtil::GetCurrentTimeUs());
+    const CacheLocationDelRequest request = gc->BuildDeleteActions("instance_a",
+                                                                   MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}),
+                                                                   TimestampUtil::GetCurrentTimeUs())
+                                                .executor_request;
 
     EXPECT_EQ((KeyVector{10}), request.block_keys);
     EXPECT_EQ((std::vector<std::vector<std::string>>{{"definitive_missing"}}), request.location_ids);
@@ -713,9 +1244,11 @@ TEST_F(CacheGarbageCollectorTest, ActiveMigrationCopyTargetIsNotCollected) {
         MakeLocation("migration_target", CLS_WRITING, now_us - config.orphan_writing_grace_period_ms * 1000 - 1);
 
     const auto batch = MakeBatch(SCAN_BASE_CURSOR, {10, 20}, {migration_locations, orphan_locations});
-    const CacheLocationDelRequest same_instance_request = gc->BuildDeleteRequest("instance_a", batch, now_us);
+    const CacheLocationDelRequest same_instance_request =
+        gc->BuildDeleteActions("instance_a", batch, now_us).executor_request;
     const CacheLocationDelRequest other_instance_request =
-        gc->BuildDeleteRequest("instance_b", MakeBatch(SCAN_BASE_CURSOR, {10}, {migration_locations}), now_us);
+        gc->BuildDeleteActions("instance_b", MakeBatch(SCAN_BASE_CURSOR, {10}, {migration_locations}), now_us)
+            .executor_request;
 
     EXPECT_EQ((KeyVector{20}), same_instance_request.block_keys);
     EXPECT_EQ((std::vector<std::vector<std::string>>{{"migration_target"}}), same_instance_request.location_ids);
@@ -730,7 +1263,8 @@ TEST_F(CacheGarbageCollectorTest, MissingScannedKeyIsNotCountedAsOperationError)
 
     const auto batch =
         MakeBatch(SCAN_BASE_CURSOR, {1, 2}, {CacheLocationMap{}, CacheLocationMap{}}, {EC_NOENT, EC_ERROR});
-    EXPECT_TRUE(gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
+    EXPECT_TRUE(gc->BuildDeleteActions("instance_a", batch, TimestampUtil::GetCurrentTimeUs())
+                    .executor_request.block_keys.empty());
 
     EXPECT_EQ(
         1, metrics_registry_->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "scan_key"}}).Get());
@@ -770,14 +1304,92 @@ TEST_F(CacheGarbageCollectorTest, ScanFailureRetriesSameCursorWithoutBusyLoop) {
 
     gc->RunOneTick();
     ASSERT_EQ(1, scan_calls.size());
-    EXPECT_EQ(SCAN_BASE_CURSOR, gc->cursor_);
+    ASSERT_EQ(1u, gc->instances_.size());
+    EXPECT_EQ(SCAN_BASE_CURSOR, gc->instances_.front().cursor);
     EXPECT_TRUE(gc->inflight_deletes_.empty());
 
     gc->RunOneTick();
     ASSERT_EQ(2, scan_calls.size());
     EXPECT_EQ(SCAN_BASE_CURSOR, scan_calls[0].second);
     EXPECT_EQ(SCAN_BASE_CURSOR, scan_calls[1].second);
-    EXPECT_EQ("next", gc->cursor_);
+    EXPECT_EQ("next", gc->instances_.front().cursor);
+}
+
+TEST_F(CacheGarbageCollectorTest, PersistentlyFailingInstanceIsSkippedAfterBoundedRetriesAndNextRoundProceeds) {
+    AddInstance("group_a", "instance_b");
+    scan_responses["instance_a"] = {
+        {EC_ERROR, {}},
+        {EC_ERROR, {}},
+        {EC_ERROR, {}},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+    scan_responses["instance_b"] = {
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+
+    for (size_t i = 0; i < CacheGarbageCollector::kMaxScanFailuresPerInstancePerRound + 1; ++i) {
+        gc->RunOneTick();
+    }
+
+    EXPECT_EQ((std::vector<std::pair<std::string, std::string>>{
+                  {"instance_a", SCAN_BASE_CURSOR},
+                  {"instance_b", SCAN_BASE_CURSOR},
+                  {"instance_a", SCAN_BASE_CURSOR},
+                  {"instance_a", SCAN_BASE_CURSOR},
+              }),
+              scan_calls);
+    EXPECT_FALSE(gc->round_active_);
+    EXPECT_EQ(1, gc->get_cache_gc_scan_round_count_metrics());
+    EXPECT_EQ(
+        1, metrics_registry_->GetCounter("cache_gc.operation_error_count", {{"stage", "scan_retry_exhausted"}}).Get());
+
+    AddInstance("group_a", "instance_c");
+    gc->next_round_at_ = CacheGarbageCollector::Clock::now();
+    for (size_t i = 0; i < 3; ++i) {
+        gc->RunOneTick();
+    }
+
+    ASSERT_GE(scan_calls.size(), 3u);
+    const std::vector<std::pair<std::string, std::string>> second_round_calls(
+        scan_calls.end() - 3, scan_calls.end());
+    EXPECT_EQ((std::vector<std::pair<std::string, std::string>>{
+                  {"instance_a", SCAN_BASE_CURSOR},
+                  {"instance_b", SCAN_BASE_CURSOR},
+                  {"instance_c", SCAN_BASE_CURSOR},
+              }),
+              second_round_calls);
+    EXPECT_FALSE(gc->round_active_);
+    EXPECT_EQ(2, gc->get_cache_gc_scan_round_count_metrics());
+}
+
+TEST_F(CacheGarbageCollectorTest, ActiveRoundRotatesOneBatchPerInstance) {
+    AddInstance("group_a", "instance_b");
+    scan_responses["instance_a"] = {
+        {EC_OK, MakeBatch("a_next", {}, {})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+    scan_responses["instance_b"] = {
+        {EC_OK, MakeBatch("b_next", {}, {})},
+        {EC_OK, MakeBatch(SCAN_BASE_CURSOR, {}, {})},
+    };
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+
+    for (size_t i = 0; i < 4; ++i) {
+        gc->RunOneTick();
+    }
+
+    EXPECT_EQ((std::vector<std::pair<std::string, std::string>>{
+                  {"instance_a", SCAN_BASE_CURSOR},
+                  {"instance_b", SCAN_BASE_CURSOR},
+                  {"instance_a", "a_next"},
+                  {"instance_b", "b_next"},
+              }),
+              scan_calls);
+    EXPECT_FALSE(gc->round_active_);
 }
 
 TEST_F(CacheGarbageCollectorTest, RegistryFailureDiscardsIncompleteSnapshot) {
@@ -896,14 +1508,17 @@ TEST_F(CacheGarbageCollectorTest, PendingTargetDeduplicatesBeforeCasAndKeepsInst
     EXPECT_EQ(1, submitted_requests.size());
     EXPECT_EQ(1, gc->inflight_deletes_.size());
 
-    EXPECT_TRUE(gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
-    EXPECT_FALSE(gc->BuildDeleteRequest("instance_b", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
+    EXPECT_TRUE(gc->BuildDeleteActions("instance_a", batch, TimestampUtil::GetCurrentTimeUs())
+                    .executor_request.block_keys.empty());
+    EXPECT_FALSE(gc->BuildDeleteActions("instance_b", batch, TimestampUtil::GetCurrentTimeUs())
+                     .executor_request.block_keys.empty());
 
     pending_delete_promises.front()->set_value({EC_OK, ""});
     gc->PollInflightDeletes();
     EXPECT_TRUE(gc->inflight_deletes_.empty());
     EXPECT_TRUE(gc->pending_locations_.empty());
-    EXPECT_FALSE(gc->BuildDeleteRequest("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).block_keys.empty());
+    EXPECT_FALSE(gc->BuildDeleteActions("instance_a", batch, TimestampUtil::GetCurrentTimeUs())
+                     .executor_request.block_keys.empty());
 }
 
 TEST_F(CacheGarbageCollectorTest, PendingTargetRemainsDeduplicatedAcrossRoundBoundary) {
@@ -1111,6 +1726,44 @@ TEST_F(CacheGarbageCollectorTest, JoinDetachesPendingDeleteWithoutWaitingForFutu
     EXPECT_TRUE(gc->pending_locations_.empty());
     EXPECT_EQ(0, gc->get_cache_gc_inflight_delete_count_metrics());
     pending_delete_promise->set_value({EC_OK, ""});
+}
+
+TEST_F(CacheGarbageCollectorTest, JoinDetachesPendingEventReportActionWithoutWaitingForFuture) {
+    auto config = DefaultConfig();
+    config.event_report_cleanup_enabled = true;
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    auto backend = AddEventReportBackend("event_report_l1p5");
+    const std::string host = "10.0.0.1:9000";
+    ASSERT_EQ(EC_OK, backend->RegisterNode("instance_a", host, {"hbm"}));
+    uint64_t generation = 0;
+    ASSERT_EQ(EC_OK, backend->UnregisterNodeForHostDown("instance_a", host, generation));
+    const std::string location_id = backend->BuildLocationId("hbm", host);
+    CacheLocationMap locations;
+    locations.emplace(
+        location_id,
+        MakeStoredLocation(
+            location_id, CLS_SERVING, backend->GetStorageType(), {"event_report://event_report_l1p5/object"}));
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch(SCAN_BASE_CURSOR, {101}, {locations})}};
+
+    submit_mode = SubmitMode::kPending;
+    gc->RunOneTick();
+    ASSERT_EQ(1u, submitted_event_report_requests.size());
+    ASSERT_EQ(1u, gc->inflight_deletes_.size());
+    ASSERT_EQ(1u, gc->pending_locations_.size());
+    ASSERT_TRUE(pending_delete_promise);
+
+    const auto begin = std::chrono::steady_clock::now();
+
+    gc->Join();
+    const auto elapsed = std::chrono::steady_clock::now() - begin;
+
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), 1);
+    EXPECT_TRUE(gc->inflight_deletes_.empty());
+    EXPECT_TRUE(gc->pending_locations_.empty());
+    pending_delete_promise->set_value({EC_OK, ""});
+    backend->Close();
 }
 
 TEST_F(CacheGarbageCollectorTest, JoinWaitsForActiveMaintenanceScan) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -2774,6 +2774,34 @@ TEST(ReportEventContractTest, SnapshotAndResponseFieldNumbersMatchContract) {
     EXPECT_EQ(6, proto::meta::ReportEventResponse::descriptor()->FindFieldByName("extra_info")->number());
 }
 
+TEST_F(CacheManagerTest, TestLegacyEventCleanupCallbackIsSafeAfterCacheManagerDestruction) {
+    auto backend = InstallEventReportBackend();
+    ASSERT_NE(nullptr, backend);
+    proto::meta::ReportEventRequest request;
+    request.set_instance_id("test_instance");
+    request.set_host_ip_port("10.0.0.1:9000");
+    request.set_storage_type(proto::meta::ST_EVENT_REPORT_L2);
+    auto *event = request.add_events();
+    event->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+    event->mutable_node_register()->add_mediums("mem");
+    proto::meta::ReportEventResponse response;
+    ASSERT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &request, &response));
+
+    EventReportBackend::CleanupCallback copied_callback;
+    {
+        std::lock_guard<std::mutex> lock(backend->cleanup_cb_mutex_);
+        copied_callback = backend->cleanup_callback_;
+    }
+    ASSERT_TRUE(copied_callback);
+
+    // EventReportBackend invokes a copied callback outside its callback lock.
+    // Model that exact shutdown race: CacheManager clears and destroys GC,
+    // then the already-copied callback returns without touching either object.
+    cache_manager_.reset();
+    EXPECT_NO_THROW(copied_callback("test_instance", "10.0.0.1:9000", 1));
+    backend->Close();
+}
+
 TEST_F(CacheManagerTest, TestGetCheckLocDataExistFunc_MissingEventReportBackendFailsClosed) {
     auto func = cache_manager_->GetCheckLocDataExistFunc("test_instance");
 
@@ -4125,6 +4153,18 @@ TEST_F(CacheManagerTest, TestReportEventHeartbeatRecoveryCarriesSameRequestMutat
     EXPECT_EQ(0, delete_response.item_results_size());
     EXPECT_TRUE(QueryEventReportUris({delete_key}).empty());
 
+    CacheGarbageCollector::Config gc_config;
+    gc_config.enabled = true;
+    gc_config.event_report_cleanup_enabled = true;
+    auto collector = std::make_shared<CacheGarbageCollector>(gc_config,
+                                                             registry_manager_,
+                                                             cache_manager_->meta_indexer_manager_,
+                                                             registry_manager_->data_storage_manager(),
+                                                             cache_manager_->schedule_plan_executor_,
+                                                             metrics_registry_,
+                                                             cache_manager_->migration_manager_);
+    cache_manager_->cache_garbage_collector_ = collector;
+
     event_backend->SetNodeUnavailable("test_instance", host);
     auto heartbeat_then_snapshot = MakeSnapshotRequest(host, {{snapshot_key, "heartbeat_then_snapshot"}});
     const auto snapshot_event = heartbeat_then_snapshot.events(0);
@@ -4139,6 +4179,9 @@ TEST_F(CacheManagerTest, TestReportEventHeartbeatRecoveryCarriesSameRequestMutat
     EXPECT_EQ(0, snapshot_response.item_results_size());
     EXPECT_TRUE(SnapshotUriUtils::IsValidSnapshotVersionToken(snapshot_response.committed_snapshot_version()));
     ASSERT_EQ(1u, QueryEventReportUris({snapshot_key}).size());
+    EXPECT_EQ(snapshot_response.committed_snapshot_version(),
+              event_backend->GetSnapshotVersion({"test_instance", host}));
+    EXPECT_FALSE(event_backend->IsCleanupCallbackSet());
 }
 
 TEST_F(CacheManagerTest, TestReportEventRegisterThenFirstDeltaInSameRequest) {

--- a/kv_cache_manager/manager/test/event_report_cleanup_util_test.cc
+++ b/kv_cache_manager/manager/test/event_report_cleanup_util_test.cc
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
+#include "kv_cache_manager/data_storage/snapshot_uri_utils.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
+#include "kv_cache_manager/manager/event_report_cleanup_util.h"
+#include "kv_cache_manager/meta/cache_location.h"
+
+using namespace kv_cache_manager;
+
+namespace {
+
+StorageConfig MakeEventReportConfig() {
+    auto spec = std::make_shared<EventReportStorageSpec>();
+    spec->set_snapshot_min_interval_ms(0);
+    return StorageConfig(
+        DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5, "event_report_cleanup_util_test", std::move(spec));
+}
+
+std::string VersionedUri(const std::string &version) {
+    std::string uri;
+    EXPECT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri("event_report://physical-cache:9600/mem", version, uri));
+    return uri;
+}
+
+} // namespace
+
+class EventReportCleanupUtilTest : public TESTBASE {};
+
+TEST_F(EventReportCleanupUtilTest, MalformedSpecNeverAuthorizesLocationDeletion) {
+    EventReportBackend backend(nullptr);
+    ASSERT_EQ(EC_OK, backend.Open(MakeEventReportConfig(), "open"));
+
+    const ReporterSnapshotKey reporter{"instance_a", "10.0.0.1:9000"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+
+    uint64_t retry_after_ms = 0;
+    std::string old_version;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter, old_version, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(reporter, old_version));
+    std::string committed_version;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter, committed_version, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(reporter, committed_version));
+
+    const std::string committed_uri = VersionedUri(committed_version);
+    const std::string malformed_uri = committed_uri + "&s_version=" + committed_version;
+    const std::string location_id = backend.BuildLocationId("mem", reporter.host_ip_port);
+
+    CacheLocation committed_then_malformed(
+        location_id,
+        CLS_SERVING,
+        backend.GetStorageType(),
+        2,
+        {LocationSpec("current", committed_uri), LocationSpec("malformed", malformed_uri)});
+    EXPECT_FALSE(IsSnapshotLocationStaleForCleanup(
+        &backend, reporter.instance_id, committed_then_malformed, /*preserve_in_flight=*/true));
+
+    CacheLocation malformed_only(
+        location_id, CLS_SERVING, backend.GetStorageType(), 1, {LocationSpec("malformed", malformed_uri)});
+    EXPECT_FALSE(
+        IsSnapshotLocationStaleForCleanup(&backend, reporter.instance_id, malformed_only, /*preserve_in_flight=*/true));
+
+    CacheLocation old_only(
+        location_id, CLS_SERVING, backend.GetStorageType(), 1, {LocationSpec("old", VersionedUri(old_version))});
+    EXPECT_TRUE(
+        IsSnapshotLocationStaleForCleanup(&backend, reporter.instance_id, old_only, /*preserve_in_flight=*/true));
+
+    std::string in_flight_version;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter, in_flight_version, retry_after_ms));
+    CacheLocation malformed_then_in_flight(
+        location_id,
+        CLS_SERVING,
+        backend.GetStorageType(),
+        2,
+        {LocationSpec("malformed", malformed_uri), LocationSpec("in_flight", VersionedUri(in_flight_version))});
+    EXPECT_FALSE(IsSnapshotLocationStaleForCleanup(
+        &backend, reporter.instance_id, malformed_then_in_flight, /*preserve_in_flight=*/true));
+
+    ASSERT_EQ(EC_OK, backend.Close());
+}

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <filesystem>
 #include <future>
 #include <limits>
@@ -208,6 +209,64 @@ private:
     std::optional<KeyType> get_locations_failed_key_;
 };
 
+class MaintenanceBarrierBackend : public MetaLocalBackend {
+public:
+    void QueueReplacement(KeyType key, CacheLocationConstPtr location) {
+        pending_key_ = key;
+        pending_location_ = std::move(location);
+    }
+
+    void ResetEvents() {
+        events_.clear();
+        sync_call_count_ = 0;
+    }
+
+    void FailSyncCall(size_t call_index) { fail_sync_call_ = call_index; }
+
+    const std::vector<std::string> &Events() const { return events_; }
+
+    bool Sync(const KeyTypeVec & /*keys*/) noexcept override {
+        events_.push_back("sync");
+        ++sync_call_count_;
+        if (!pending_location_) {
+            return sync_call_count_ != fail_sync_call_;
+        }
+        CacheLocationMapVector locations(1);
+        locations.front().emplace(pending_location_->id(), pending_location_);
+        PropertyMapVector properties(1);
+        const auto results = MetaLocalBackend::Upsert(nullptr, {pending_key_}, locations, properties);
+        pending_location_.reset();
+        return results.size() == 1 && results.front() == EC_OK && sync_call_count_ != fail_sync_call_;
+    }
+
+    std::vector<std::vector<ErrorCode>> GetLocationsForMaintenance(RequestContext *request_context,
+                                                                   const KeyTypeVec &keys,
+                                                                   const LocationIdsPerKey &location_ids,
+                                                                   LocationsPerKey &out_locations) noexcept override {
+        events_.push_back("read");
+        return MetaLocalBackend::GetLocationsForMaintenance(request_context, keys, location_ids, out_locations);
+    }
+
+    std::vector<ErrorCode> DeleteLocationsForMaintenance(RequestContext *request_context,
+                                                         const KeyTypeVec &keys,
+                                                         const LocationIdsPerKey &location_ids) noexcept override {
+        events_.push_back("delete_locations");
+        return MetaLocalBackend::DeleteLocationsForMaintenance(request_context, keys, location_ids);
+    }
+
+    std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyTypeVec &keys) noexcept override {
+        events_.push_back("delete_key");
+        return MetaLocalBackend::Delete(request_context, keys);
+    }
+
+private:
+    KeyType pending_key_{0};
+    CacheLocationConstPtr pending_location_;
+    std::vector<std::string> events_;
+    size_t sync_call_count_{0};
+    size_t fail_sync_call_{0};
+};
+
 class RecordingGetLocationsBackend : public MetaLocalBackend {
 public:
     std::vector<ErrorCode> GetLocations(RequestContext *request_context,
@@ -375,6 +434,30 @@ public:
         meta_indexer_->backend_manager_->persistent_backend_ = std::move(backend);
         meta_indexer_->backend_manager_->cache_backend_.reset();
         return backend_raw;
+    }
+
+    MaintenanceBarrierBackend *ReplaceWithMaintenanceBarrierBackend() {
+        auto backend_config = ConstructMetaStorageBackendConfig();
+        auto backend = std::make_unique<MaintenanceBarrierBackend>();
+        EXPECT_EQ(EC_OK, backend->Init("test", backend_config));
+        EXPECT_EQ(EC_OK, backend->Open());
+        auto backend_raw = backend.get();
+        meta_indexer_->backend_manager_->persistent_backend_->Close();
+        meta_indexer_->backend_manager_->persistent_backend_ = std::move(backend);
+        meta_indexer_->backend_manager_->cache_backend_.reset();
+        return backend_raw;
+    }
+
+    MaintenanceBarrierBackend *ReplaceWithCachedMaintenanceBarrierBackend() {
+        auto *backend = ReplaceWithMaintenanceBarrierBackend();
+        auto cache_config = ConstructMetaStorageBackendConfig();
+        auto cache = std::make_unique<MetaLocalBackend>();
+        EXPECT_EQ(EC_OK, cache->Init("test", cache_config));
+        EXPECT_EQ(EC_OK, cache->Open());
+        meta_indexer_->backend_manager_->cache_backend_ = std::move(cache);
+        meta_indexer_->backend_manager_->recover_state_.store(
+            MetaStorageBackendManager::RecoverState::kRunning, std::memory_order_release);
+        return backend;
     }
 
     RecordingGetLocationsBackend *ReplaceWithRecordingGetLocationsBackend() {
@@ -1955,6 +2038,184 @@ TEST_F(MetaSearcherTest, TestMergeAndReplaceLocationSpecsKeepStorageUsageExact) 
     EXPECT_EQ(7u, validated_size);
 }
 
+TEST_F(MetaSearcherTest, TestMaintenanceDeleteSyncsPendingWriteBeforeExpectedValueRead) {
+    auto *backend = ReplaceWithMaintenanceBarrierBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType key = 10027;
+    const std::string location_id = "kvs#event_report_l2#mem#barrier:8080";
+    auto make_location = [&location_id](const std::string &source) {
+        auto location = std::make_shared<CacheLocation>();
+        location->set_id(location_id);
+        location->set_status(CLS_SERVING);
+        location->set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+        location->set_spec_size(1);
+        location->set_location_specs(
+            {LocationSpec("linear_0", "event_report://barrier:8080/mem?source=" + source + "&size=7")});
+        return location;
+    };
+
+    const auto old_location = make_location("old");
+    CacheLocationMapVector initial_locations(1);
+    initial_locations.front().emplace(location_id, old_location);
+    PropertyMapVector properties(1);
+    ASSERT_EQ(EC_OK, meta_indexer_->Put(request_context_.get(), {key}, initial_locations, properties).ec);
+
+    const auto new_location = make_location("new");
+    backend->QueueReplacement(key, new_location);
+    backend->ResetEvents();
+
+    std::vector<std::vector<ErrorCode>> delete_results;
+    EXPECT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(),
+                                                    {key},
+                                                    {{location_id}},
+                                                    delete_results,
+                                                    {{old_location->ToJsonString()}},
+                                                    false,
+                                                    false,
+                                                    true));
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), delete_results);
+    EXPECT_EQ((std::vector<std::string>{"sync", "read"}), backend->Events());
+
+    LocationsPerKey current_locations;
+    const auto current_results = backend->MetaLocalBackend::GetLocationsForMaintenance(
+        request_context_.get(), {key}, {{location_id}}, current_locations);
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), current_results);
+    ASSERT_EQ(1u, current_locations.size());
+    ASSERT_EQ(1u, current_locations.front().size());
+    ASSERT_TRUE(current_locations.front().front());
+    EXPECT_EQ(new_location->ToJsonString(), current_locations.front().front()->ToJsonString());
+}
+
+TEST_F(MetaSearcherTest, TestMaintenanceDeleteSyncsAcceptedDeleteBeforeShardFenceRelease) {
+    auto *backend = ReplaceWithMaintenanceBarrierBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType key = 10028;
+    const std::string location_id = "kvs#event_report_l2#mem#post-barrier:8080";
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id(location_id);
+    location->set_status(CLS_SERVING);
+    location->set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+    location->set_spec_size(1);
+    location->set_location_specs(
+        {LocationSpec("linear_0", "event_report://post-barrier:8080/mem?source=current&size=7")});
+    CacheLocationMapVector initial_locations(1);
+    initial_locations.front().emplace(location_id, location);
+    PropertyMapVector properties(1);
+    ASSERT_EQ(EC_OK, meta_indexer_->Put(request_context_.get(), {key}, initial_locations, properties).ec);
+    backend->ResetEvents();
+
+    std::vector<std::vector<ErrorCode>> delete_results;
+    EXPECT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(),
+                                                    {key},
+                                                    {{location_id}},
+                                                    delete_results,
+                                                    {{location->ToJsonString()}},
+                                                    false,
+                                                    false,
+                                                    true));
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
+    EXPECT_EQ((std::vector<std::string>{"sync", "read", "delete_key", "sync"}), backend->Events());
+}
+
+TEST_F(MetaSearcherTest, TestCachedMaintenanceDeleteUsesHotMutationInsteadOfPostSync) {
+    auto *backend = ReplaceWithCachedMaintenanceBarrierBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType key = 10130;
+    const std::string location_id = "kvs#event_report_l2#mem#cached-barrier:8080";
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id(location_id);
+    location->set_status(CLS_SERVING);
+    location->set_type(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2);
+    location->set_spec_size(1);
+    location->set_location_specs(
+        {LocationSpec("linear_0", "event_report://cached-barrier:8080/mem?source=current&size=7")});
+    CacheLocationMapVector initial_locations(1);
+    initial_locations.front().emplace(location_id, location);
+    PropertyMapVector properties(1);
+    ASSERT_EQ(EC_OK, meta_indexer_->Put(request_context_.get(), {key}, initial_locations, properties).ec);
+    backend->ResetEvents();
+
+    std::vector<std::vector<ErrorCode>> delete_results;
+    EXPECT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(),
+                                                    {key},
+                                                    {{location_id}},
+                                                    delete_results,
+                                                    {{location->ToJsonString()}},
+                                                    false,
+                                                    false,
+                                                    true));
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
+    EXPECT_EQ((std::vector<std::string>{"sync", "read", "delete_key"}), backend->Events());
+}
+
+TEST_F(MetaSearcherTest, TestMaintenanceDeleteAccountsAcceptedMutationWhenPostSyncFails) {
+    auto *backend = ReplaceWithMaintenanceBarrierBackend();
+    ASSERT_NE(nullptr, backend);
+
+    const KeyType key = 10029;
+    const std::string location_id = "kvs#event_report_l2#mem#post-sync-failure:8080";
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> merge_tasks = {{
+        {location_id,
+         DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+         CacheLocationStatus::CLS_SERVING,
+         {LocationSpec("linear_0", "event_report://post-sync-failure:8080/mem?size=17")}},
+    }};
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {key}, merge_tasks, per_key_ec));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
+    ASSERT_EQ(1u, meta_indexer_->GetKeyCount());
+    ASSERT_EQ(17u,
+              meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {key}, mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_EQ(1u, location_maps.front().count(location_id));
+    const std::string expected_value = location_maps.front().at(location_id)->ToJsonString();
+
+    backend->ResetEvents();
+    backend->FailSyncCall(2);
+    std::vector<std::vector<ErrorCode>> delete_results;
+    EXPECT_EQ(EC_ERROR,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(),
+                                                    {key},
+                                                    {{location_id}},
+                                                    delete_results,
+                                                    {{expected_value}},
+                                                    true,
+                                                    true,
+                                                    true));
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
+    EXPECT_EQ((std::vector<std::string>{"sync", "read", "delete_key", "sync"}), backend->Events());
+    EXPECT_EQ(0u, meta_indexer_->GetKeyCount());
+    EXPECT_EQ(0u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
+
+    // The aggregate error asks the caller to retry. Once the accepted delete
+    // is visible, that retry converges as NOENT and must not account twice.
+    backend->FailSyncCall(0);
+    backend->ResetEvents();
+    EXPECT_EQ(EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(),
+                                                    {key},
+                                                    {{location_id}},
+                                                    delete_results,
+                                                    {{expected_value}},
+                                                    true,
+                                                    true,
+                                                    true));
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_NOENT}}), delete_results);
+    EXPECT_EQ(0u, meta_indexer_->GetKeyCount());
+    EXPECT_EQ(0u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
+}
+
 TEST_F(MetaSearcherTest, TestConditionalDeleteDoesNotRemoveRefreshedStableLocation) {
     const MetaSearcher::KeyVector keys = {10008};
     const std::string location_id = "kvs#event_report_l2#mem#127.0.0.8:8080";
@@ -1985,7 +2246,7 @@ TEST_F(MetaSearcherTest, TestConditionalDeleteDoesNotRemoveRefreshedStableLocati
     std::vector<std::vector<ErrorCode>> delete_results;
     ASSERT_EQ(EC_OK,
               meta_searcher_->BatchDeleteLocations(
-                  request_context_.get(), keys, location_ids, delete_results, {{stale_expected_value}}));
+                  request_context_.get(), keys, location_ids, delete_results, {{stale_expected_value}}, true, true, true));
     ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), delete_results);
 
     ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
@@ -1996,10 +2257,10 @@ TEST_F(MetaSearcherTest, TestConditionalDeleteDoesNotRemoveRefreshedStableLocati
     const std::string current_expected_value = location_maps[0].at(location_id)->ToJsonString();
     ASSERT_EQ(EC_BADARGS,
               meta_searcher_->BatchDeleteLocations(
-                  request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}, {}}));
+                  request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}, {}}, true, true, true));
     ASSERT_EQ(EC_OK,
               meta_searcher_->BatchDeleteLocations(
-                  request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}}));
+                  request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}}, true, true, true));
     ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
 
     ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
@@ -3217,10 +3478,8 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackClassifiesStates) {
 
     // batch: confirmed success / uncertain with id / failed without id / failed with a ghost id
     const KeyVector keys = {success_key, uncertain_key, no_id_key, ghost_key};
-    std::vector<MetaSearcher::AddLocationResult> add_results = {success_results[0],
-                                                                uncertain_results[0],
-                                                                {EC_ERROR, ""},
-                                                                {EC_ERROR, "ghost_location_id"}};
+    std::vector<MetaSearcher::AddLocationResult> add_results = {
+        success_results[0], uncertain_results[0], {EC_ERROR, ""}, {EC_ERROR, "ghost_location_id"}};
     MetaSearcher::AddLocationRollbackPlan plan;
     ASSERT_EQ(EC_OK, meta_searcher_->ReconcileAddLocationRollback(request_context_.get(), keys, add_results, plan));
 
@@ -3234,7 +3493,9 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackClassifiesStates) {
     // uncertain metadata is deleted; confirmed-success metadata is left for the delete pipeline.
     std::vector<CacheLocationMap> location_maps;
     BlockMask mask;
-    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), {success_key, uncertain_key}, mask, location_maps));
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchGetLocation(request_context_.get(), {success_key, uncertain_key}, mask, location_maps));
     ASSERT_EQ(2u, location_maps.size());
     EXPECT_EQ(1u, location_maps[0].count(success_results[0].location_id));
     EXPECT_TRUE(location_maps[1].empty());
@@ -3247,8 +3508,7 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRejectsShapeMismatch) {
     plan.direct_delete_indices = {0};
 
     EXPECT_EQ(EC_BADARGS,
-              meta_searcher_->ReconcileAddLocationRollback(
-                  request_context_.get(), {1, 2}, {{EC_OK, "some_id"}}, plan));
+              meta_searcher_->ReconcileAddLocationRollback(request_context_.get(), {1, 2}, {{EC_OK, "some_id"}}, plan));
     EXPECT_TRUE(plan.pipeline_keys.empty());
     EXPECT_TRUE(plan.pipeline_location_ids.empty());
     EXPECT_TRUE(plan.direct_delete_indices.empty());
@@ -3290,9 +3550,9 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRetainsUrisOnDeleteErro
 
     backend->SetGetLocationsFailedKey(uncertain_key);
     MetaSearcher::AddLocationRollbackPlan plan;
-    ASSERT_EQ(EC_OK,
-              meta_searcher_->ReconcileAddLocationRollback(
-                  request_context_.get(), {uncertain_key}, uncertain_results, plan));
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->ReconcileAddLocationRollback(request_context_.get(), {uncertain_key}, uncertain_results, plan));
     EXPECT_TRUE(plan.pipeline_keys.empty());
     EXPECT_TRUE(plan.direct_delete_indices.empty());
 
@@ -3322,9 +3582,9 @@ TEST_F(MetaSearcherTest, TestReconcileAddLocationRollbackRetainsUrisWhenSyncFail
 
     backend->SetFailSync(true);
     MetaSearcher::AddLocationRollbackPlan plan;
-    ASSERT_EQ(EC_OK,
-              meta_searcher_->ReconcileAddLocationRollback(
-                  request_context_.get(), {uncertain_key}, uncertain_results, plan));
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->ReconcileAddLocationRollback(request_context_.get(), {uncertain_key}, uncertain_results, plan));
     EXPECT_TRUE(plan.pipeline_keys.empty());
     // metadata was deleted in memory but the delete could not be synced: retain the URI.
     EXPECT_TRUE(plan.direct_delete_indices.empty());

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -149,6 +149,17 @@ public:
         auto request_context = std::make_shared<RequestContext>("test_trace_id");
         return data_storage_manager_->RegisterStorage(request_context.get(), "nfs_01", nfs_storage_config);
     }
+
+    std::shared_ptr<EventReportBackend> CreateEventReportStorage(const std::string &name) {
+        auto spec = std::make_shared<EventReportStorageSpec>();
+        spec->set_snapshot_min_interval_ms(0);
+        spec->set_heartbeat_timeout_ms(60000);
+        spec->set_cleanup_grace_ms(60000);
+        StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, name, spec);
+        RequestContext context("create_event_report_storage");
+        EXPECT_EQ(EC_OK, data_storage_manager_->RegisterStorage(&context, name, config));
+        return std::dynamic_pointer_cast<EventReportBackend>(data_storage_manager_->GetDataStorageBackend(name));
+    }
     // 注册一个 Dummy storage（基于文件系统），供 copy 任务做真实文件复制
     bool CreateDummyStorage(const std::string &name, const std::string &root) {
         auto spec = std::make_shared<DummyStorageSpec>();
@@ -838,6 +849,163 @@ TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBack
     const auto control_result = executor.Submit(control_request).get();
     ASSERT_EQ(EC_OK, control_result.status);
     EXPECT_EQ(1u, delete_calls.load());
+}
+
+TEST_F(SchedulePlanExecutorTest, TestEventReportMetadataDeleteRevalidatesTokenOnWorker) {
+    ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    auto backend = CreateEventReportStorage("event_report_l2");
+    ASSERT_TRUE(backend);
+
+    const ReporterSnapshotKey reporter{kTestInstanceName, "127.0.0.1:8080"};
+    ASSERT_EQ(EC_OK, backend->RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    uint64_t lifecycle_generation = 0;
+    ASSERT_EQ(EC_OK,
+              backend->UnregisterNodeForHostDown(
+                  reporter.instance_id, reporter.host_ip_port, lifecycle_generation));
+
+    const KeyVector keys{703};
+    const std::string location_id = backend->BuildLocationId("mem", reporter.host_ip_port);
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    RequestContext context("event_report_executor_test");
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks = {{
+        {location_id,
+         backend->GetStorageType(),
+         CLS_SERVING,
+         {LocationSpec("tp0", "event_report://127.0.0.1:8080/mem?size=11")}},
+    }};
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher.BatchReplaceLocationSpecs(
+                  &context, keys, replace_tasks, per_key_ec));
+
+    std::vector<CacheLocationMap> locations;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(&context, keys, empty_mask, locations));
+    const std::string expected_value = locations.front().at(location_id)->ToJsonString();
+
+    EventReportMetadataDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = keys,
+        .targets = {{EventReportMetadataDeleteTarget{
+            .location_id = location_id,
+            .expected_location_value = expected_value,
+            .backend_unique_name = "event_report_l2",
+            .storage_type = backend->GetStorageType(),
+            .expected_backend = backend,
+            .cleanup_token = EventReportBackend::MaintenanceCleanupToken{
+                .reason = EventReportBackend::MaintenanceCleanupReason::kDownHost,
+                .reporter_key = reporter,
+                .lifecycle_generation = lifecycle_generation,
+            },
+        }}},
+    };
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    const auto release_future = release_blocker.get_future().share();
+    ASSERT_TRUE(executor.SubmitTask([&blocker_started, release_future]() {
+        blocker_started.set_value();
+        release_future.wait();
+    }));
+    ASSERT_EQ(std::future_status::ready, blocker_started.get_future().wait_for(std::chrono::seconds(1)));
+    auto submit_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(submit_result.accepted);
+    ASSERT_TRUE(submit_result.future.valid());
+    EXPECT_EQ(std::future_status::timeout, submit_result.future.wait_for(std::chrono::milliseconds(10)));
+    release_blocker.set_value();
+    EXPECT_EQ(EC_OK, submit_result.future.get().status);
+
+    locations.clear();
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(&context, keys, empty_mask, locations));
+    ASSERT_EQ(1u, locations.size());
+    EXPECT_TRUE(locations.front().empty());
+    EXPECT_EQ(1,
+              metrics_registry_
+                  ->GetCounter("cache_gc.event_report_delete_location_count",
+                               {{"reason", "down_host"}, {"status", "deleted"}})
+                  .Get());
+}
+
+TEST_F(SchedulePlanExecutorTest, TestEventReportMetadataDeleteSkipsStaleLifecycleToken) {
+    ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    auto backend = CreateEventReportStorage("event_report_l2_stale");
+    ASSERT_TRUE(backend);
+
+    const ReporterSnapshotKey reporter{kTestInstanceName, "127.0.0.2:8080"};
+    ASSERT_EQ(EC_OK, backend->RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    uint64_t old_generation = 0;
+    ASSERT_EQ(EC_OK,
+              backend->UnregisterNodeForHostDown(reporter.instance_id, reporter.host_ip_port, old_generation));
+
+    const KeyVector keys{704};
+    const std::string location_id = backend->BuildLocationId("mem", reporter.host_ip_port);
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    RequestContext context("event_report_executor_stale_test");
+    std::vector<std::vector<MetaSearcher::ReplaceLocationSpecsTask>> replace_tasks = {{
+        {location_id,
+         backend->GetStorageType(),
+         CLS_SERVING,
+         {LocationSpec("tp0", "event_report://127.0.0.2:8080/mem?size=13")}},
+    }};
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher.BatchReplaceLocationSpecs(
+                  &context, keys, replace_tasks, per_key_ec));
+    std::vector<CacheLocationMap> locations;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(&context, keys, empty_mask, locations));
+    const std::string expected_value = locations.front().at(location_id)->ToJsonString();
+
+    EventReportMetadataDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = keys,
+        .targets = {{EventReportMetadataDeleteTarget{
+            .location_id = location_id,
+            .expected_location_value = expected_value,
+            .backend_unique_name = "event_report_l2_stale",
+            .storage_type = backend->GetStorageType(),
+            .expected_backend = backend,
+            .cleanup_token = EventReportBackend::MaintenanceCleanupToken{
+                .reason = EventReportBackend::MaintenanceCleanupReason::kDownHost,
+                .reporter_key = reporter,
+                .lifecycle_generation = old_generation,
+            },
+        }}},
+    };
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    std::promise<void> blocker_started;
+    std::promise<void> release_blocker;
+    const auto release_future = release_blocker.get_future().share();
+    ASSERT_TRUE(executor.SubmitTask([&blocker_started, release_future]() {
+        blocker_started.set_value();
+        release_future.wait();
+    }));
+    ASSERT_EQ(std::future_status::ready, blocker_started.get_future().wait_for(std::chrono::seconds(1)));
+    auto submit_result = executor.SubmitAsync(request);
+    ASSERT_TRUE(submit_result.accepted);
+    ASSERT_EQ(EC_OK, backend->RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    release_blocker.set_value();
+    EXPECT_EQ(EC_OK, submit_result.future.get().status);
+
+    locations.clear();
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(&context, keys, empty_mask, locations));
+    ASSERT_EQ(1u, locations.size());
+    EXPECT_EQ(1u, locations.front().count(location_id));
+    EXPECT_EQ(1,
+              metrics_registry_
+                  ->GetCounter("cache_gc.event_report_delete_location_count",
+                               {{"reason", "down_host"}, {"status", "mismatch"}})
+                  .Get());
+}
+
+TEST_F(SchedulePlanExecutorTest, TestEventReportMetadataDeleteRejectsInvalidRequestWithoutFuture) {
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    EventReportMetadataDelRequest request{.instance_id = kTestInstanceName, .block_keys = {1}, .targets = {}};
+    auto submit_result = executor.SubmitAsync(request);
+    EXPECT_FALSE(submit_result.accepted);
+    EXPECT_FALSE(submit_result.future.valid());
 }
 
 // 测试CacheLocationDelRequest的Submit方法 - 非存在实例

--- a/kv_cache_manager/meta/meta_cache_base_backend.h
+++ b/kv_cache_manager/meta/meta_cache_base_backend.h
@@ -68,6 +68,15 @@ public:
                                                    const KeyTypeVec &keys,
                                                    const LocationIdsPerKey &location_ids,
                                                    const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
+
+    // Conditional no-touch delete used by background metadata maintenance.
+    // EC_OK and EC_NOENT from the persistent layer both authorize the
+    // idempotent cache-side delete; hard failures must be preserved.
+    virtual std::vector<ErrorCode>
+    DeleteLocationsForMaintenance(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const LocationIdsPerKey &location_ids,
+                                  const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -92,8 +92,9 @@ public:
     // spent acquiring all shard mutexes (in microseconds).
     ScopedBatchLock(MetaIndexer &indexer,
                     const std::vector<int32_t> &shard_indexs,
-                    int64_t *out_lock_wait_time_us = nullptr)
-        : indexer_(indexer), shard_indexs_(shard_indexs) {
+                    int64_t *out_lock_wait_time_us = nullptr,
+                    int64_t *out_lock_hold_time_us = nullptr)
+        : indexer_(indexer), shard_indexs_(shard_indexs), out_lock_hold_time_us_(out_lock_hold_time_us) {
         const int64_t begin = TimestampUtil::GetCurrentTimeUs();
         for (const int32_t shardIdx : shard_indexs_) {
             indexer_.mutex_shards_[shardIdx]->lock();
@@ -101,10 +102,14 @@ public:
         if (out_lock_wait_time_us != nullptr) {
             *out_lock_wait_time_us += TimestampUtil::GetCurrentTimeUs() - begin;
         }
+        lock_acquired_at_us_ = TimestampUtil::GetCurrentTimeUs();
     }
     ~ScopedBatchLock() {
         for (const int32_t shardIdx : shard_indexs_) {
             indexer_.mutex_shards_[shardIdx]->unlock();
+        }
+        if (out_lock_hold_time_us_ != nullptr) {
+            *out_lock_hold_time_us_ += std::max<int64_t>(0, TimestampUtil::GetCurrentTimeUs() - lock_acquired_at_us_);
         }
     }
 
@@ -114,6 +119,8 @@ public:
 private:
     MetaIndexer &indexer_;
     const std::vector<int32_t> &shard_indexs_;
+    int64_t *out_lock_hold_time_us_{nullptr};
+    int64_t lock_acquired_at_us_{0};
 };
 
 MetaIndexer::~MetaIndexer() {
@@ -410,7 +417,8 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwDelete(const std::string &tra
                                                           const BatchMetaData &delete_batch,
                                                           const KeyVector &all_keys,
                                                           RmwStats &stats,
-                                                          Result &result) noexcept {
+                                                          Result &result,
+                                                          bool maintenance_no_touch) noexcept {
     if (delete_batch.batch_keys.empty()) {
         return {0, 0};
     }
@@ -421,6 +429,9 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwDelete(const std::string &tra
     int32_t reclaimed_count = 0;
     if (delete_batch.batch_location_ids.empty()) {
         delete_ecs = backend_manager_->Delete(request_context, delete_batch.batch_keys);
+    } else if (maintenance_no_touch) {
+        delete_ecs = backend_manager_->DeleteLocationsForMaintenance(
+            request_context, delete_batch.batch_keys, delete_batch.batch_location_ids, reclaimed_count);
     } else {
         delete_ecs = backend_manager_->Delete(
             request_context, delete_batch.batch_keys, delete_batch.batch_location_ids, reclaimed_count);
@@ -614,14 +625,25 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext 
                                        modifier,
                                        adjust_reclaimed_key_count,
                                        false,
-                                       refresh_cache_from_persistent);
+                                       refresh_cache_from_persistent,
+                                       false);
+}
+
+MetaIndexer::LocationResult
+MetaIndexer::ReadModifyWriteLocationsForMaintenance(RequestContext *request_context,
+                                                    const KeyVector &keys,
+                                                    const LocationIdsPerKey &location_ids,
+                                                    const LocationModifierFunc &modifier,
+                                                    bool adjust_reclaimed_key_count) noexcept {
+    return ReadModifyWriteLocationImpl(
+        request_context, keys, location_ids, modifier, adjust_reclaimed_key_count, false, false, true);
 }
 
 MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteTargetLocations(RequestContext *request_context,
                                                                         const KeyVector &keys,
                                                                         const LocationIdsPerKey &location_ids,
                                                                         const LocationModifierFunc &modifier) noexcept {
-    return ReadModifyWriteLocationImpl(request_context, keys, location_ids, modifier, false, true, false);
+    return ReadModifyWriteLocationImpl(request_context, keys, location_ids, modifier, false, true, false, false);
 }
 
 MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestContext *request_context,
@@ -630,7 +652,8 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
                                                                      const LocationModifierFunc &modifier,
                                                                      bool adjust_reclaimed_key_count,
                                                                      bool track_created_key_count,
-                                                                     bool refresh_cache_from_persistent) noexcept {
+                                                                     bool refresh_cache_from_persistent,
+                                                                     bool maintenance_no_touch) noexcept {
     const auto &trace_id = request_context->trace_id();
     if (keys.empty()) {
         return LocationResult(EC_OK);
@@ -673,6 +696,22 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
 
         // 1. One batched read for every (key, location_id) return deserialised CacheLocation
         const auto &batch_keys = batch.batch_keys;
+        if (maintenance_no_touch && !backend_manager_->Sync(batch_keys)) {
+            // A single async metadata backend may still have an accepted
+            // same-key mutation queued. Reading before that mutation reaches
+            // the persistent view could authorize a stale expected-value
+            // delete which is then queued behind, and removes, the newer
+            // mutation. Drain accepted writes while the shard fence prevents
+            // another same-key mutation from being admitted.
+            PREFIX_INDEXER_LOG(WARN, "maintenance pre-read Sync failed for keys[%lu]", batch_keys.size());
+            for (const int32_t global_idx : batch.batch_indexs) {
+                location_result.per_location_error_codes[global_idx].assign(location_ids[global_idx].size(),
+                                                                            EC_TIMEOUT);
+                rmw_result.error_codes[global_idx] = EC_TIMEOUT;
+                key_level_failures[global_idx] = true;
+            }
+            continue;
+        }
         LocationsPerKey batch_locations_per_key;
         std::vector<ErrorCode> batch_key_get_ecs;
         const int64_t begin_get = TimestampUtil::GetCurrentTimeUs();
@@ -681,8 +720,7 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
             // Maintenance candidates originate from the persistent scan. Under
             // the same shard lock as the CAS, replace a missing or stale hot
             // cache entry with the complete source-of-truth key first.
-            refresh_results =
-                backend_manager_->RefreshCacheFromPersistent(ephemeral_request_context.get(), batch_keys);
+            refresh_results = backend_manager_->RefreshCacheFromPersistent(ephemeral_request_context.get(), batch_keys);
         }
         std::vector<std::vector<ErrorCode>> get_ecs_per_key;
         if (track_created_key_count) {
@@ -692,8 +730,15 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
                                                                           batch_locations_per_key,
                                                                           batch_key_get_ecs);
         } else {
-            get_ecs_per_key = backend_manager_->GetLocations(
-                ephemeral_request_context.get(), batch_keys, batch.batch_location_ids, batch_locations_per_key);
+            get_ecs_per_key = maintenance_no_touch
+                                  ? backend_manager_->GetLocationsForMaintenance(ephemeral_request_context.get(),
+                                                                                 batch_keys,
+                                                                                 batch.batch_location_ids,
+                                                                                 batch_locations_per_key)
+                                  : backend_manager_->GetLocations(ephemeral_request_context.get(),
+                                                                   batch_keys,
+                                                                   batch.batch_location_ids,
+                                                                   batch_locations_per_key);
         }
         stats.get_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin_get;
         int64_t v = 0;
@@ -880,9 +925,34 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
                 }
             }
         }
-        const auto [delete_errs, delete_success_count] =
-            ExecuteRmwDelete(trace_id, ephemeral_request_context.get(), delete_batch, keys, stats, rmw_result);
+        const auto [delete_errs, delete_success_count] = ExecuteRmwDelete(trace_id,
+                                                                          ephemeral_request_context.get(),
+                                                                          delete_batch,
+                                                                          keys,
+                                                                          stats,
+                                                                          rmw_result,
+                                                                          maintenance_no_touch);
         (void)delete_errs;
+        const bool maintenance_delete_synced = !maintenance_no_touch || delete_batch.batch_keys.empty() ||
+                                               !backend_manager_->RequiresMaintenancePostDeleteSync() ||
+                                               backend_manager_->Sync(delete_batch.batch_keys);
+        if (!maintenance_delete_synced) {
+            // Keep the per-key shard fence until the accepted maintenance
+            // delete reaches its async backend queue barrier. A timeout is an
+            // unknown persistence outcome, so surface a key-level hard result
+            // and let a later GC round reconcile the authoritative metadata
+            // again. Preserve the accepted per-location results and
+            // accounting: ordinary async RMW uses enqueue acceptance as its
+            // accounting boundary, and replacing those results with TIMEOUT
+            // would permanently leak usage when the delete has already been
+            // applied and is therefore absent from the next scan.
+            PREFIX_INDEXER_LOG(WARN,
+                               "maintenance post-delete Sync failed for keys[%lu]",
+                               delete_batch.batch_keys.size());
+            for (const int32_t global_idx : delete_batch.batch_indexs) {
+                key_level_failures[global_idx] = true;
+            }
+        }
         for (const auto &global_index : delete_batch.batch_indexs) {
             if (rmw_result.error_codes[global_index] != EC_OK) {
                 key_level_failures[global_index] = true;
@@ -1280,6 +1350,7 @@ MetaIndexer::ReadModifyWriteSingleTargetLocations(RequestContext *request_contex
     }
     return result;
 }
+
 
 MetaIndexer::Result
 MetaIndexer::Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept {

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -110,6 +110,11 @@ public:
                                            const LocationModifierFunc &modifier,
                                            bool adjust_reclaimed_key_count = true,
                                            bool refresh_cache_from_persistent = false) noexcept;
+    LocationResult ReadModifyWriteLocationsForMaintenance(RequestContext *request_context,
+                                                          const KeyVector &keys,
+                                                          const LocationIdsPerKey &location_ids,
+                                                          const LocationModifierFunc &modifier,
+                                                          bool adjust_reclaimed_key_count = true) noexcept;
     // Targeted upsert RMW that also distinguishes a brand-new key from an
     // existing key missing the requested location. This lets ReportEvent
     // create or merge locations in one shard-lock/read/write pass while
@@ -127,7 +132,6 @@ public:
                                                               const LocationIdRefVector &location_ids,
                                                               const SingleLocationModifierFunc &modifier) noexcept;
     bool SupportsSingleLocationRmw() const noexcept;
-
     // ---------- READ ----------
     Result Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept;
     Result Get(RequestContext *request_context,
@@ -205,7 +209,8 @@ private:
                                                const LocationModifierFunc &modifier,
                                                bool adjust_reclaimed_key_count,
                                                bool track_created_key_count,
-                                               bool refresh_cache_from_persistent) noexcept;
+                                               bool refresh_cache_from_persistent,
+                                               bool maintenance_no_touch) noexcept;
 
 private:
     int32_t GetMutexShardIndex(KeyType key) const noexcept;
@@ -260,7 +265,8 @@ private:
                                                  const BatchMetaData &delete_batch,
                                                  const KeyVector &all_keys,
                                                  RmwStats &stats,
-                                                 Result &result) noexcept;
+                                                 Result &result,
+                                                 bool maintenance_no_touch = false) noexcept;
     void
     EmitRmwMetrics(MetricsCollector *metrics_collector, const RmwStats &stats, size_t total_key_count) const noexcept;
 

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -223,8 +223,7 @@ ErrorCode MetaLocalBackend::UpdateHandleInPlace(Cache::Handle *handle,
                 ssize_t new_usage = loc_ptr ? static_cast<ssize_t>(loc_ptr->EstimateMemUsage()) : 0;
                 charge_delta += new_usage - old_usage;
             } else {
-                ssize_t new_usage = loc_ptr ? static_cast<ssize_t>(loc_ptr->EstimateMemUsage()) : 0;
-                charge_delta += static_cast<ssize_t>(sizeof(void *) * 4 + loc_id.size()) + new_usage;
+                charge_delta += static_cast<ssize_t>(MetaMemCacheItem::EstimateLocationEntryUsage(loc_id, loc_ptr));
                 existing_locations[loc_id] = loc_ptr;
             }
         }
@@ -278,8 +277,7 @@ ErrorCode MetaLocalBackend::UpdateHandleInPlaceSingleLocation(Cache::Handle *han
             }
             charge_delta = new_usage - old_usage;
         } else {
-            const ssize_t new_usage = location ? static_cast<ssize_t>(location->EstimateMemUsage()) : 0;
-            charge_delta = static_cast<ssize_t>(sizeof(void *) * 4 + location_id.size()) + new_usage;
+            charge_delta = static_cast<ssize_t>(MetaMemCacheItem::EstimateLocationEntryUsage(location_id, location));
             existing_locations.emplace(location_id, std::move(location));
         }
     }
@@ -370,8 +368,8 @@ ErrorCode MetaLocalBackend::DeleteLocationsForOneKey(KeyType key, const std::vec
         for (const auto &loc_id : location_ids) {
             auto it = locs.find(loc_id);
             if (it != locs.end()) {
-                ssize_t loc_usage = it->second ? static_cast<ssize_t>(it->second->EstimateMemUsage()) : 0;
-                charge_delta -= static_cast<ssize_t>(sizeof(void *) * 4 + it->first.size()) + loc_usage;
+                charge_delta -=
+                    static_cast<ssize_t>(MetaMemCacheItem::EstimateLocationEntryUsage(it->first, it->second));
                 locs.erase(it);
             }
         }
@@ -809,6 +807,34 @@ ErrorCode MetaLocalBackend::GetForOneKey(KeyType key,
     return EC_OK;
 }
 
+ErrorCode MetaLocalBackend::GetForOneKeyForMaintenance(KeyType key,
+                                                       CacheLocationMap *out_location_map,
+                                                       std::vector<LocationId> *out_location_ids) {
+    ErrorCode result = EC_OK;
+    const bool found = cache_->ApplyToEntryNoTouch(
+        KeyToView(key),
+        [&](Cache::ObjectPtr value, size_t /*charge*/, const Cache::CacheItemHelper * /*helper*/) -> ssize_t {
+            if (value == nullptr) {
+                result = EC_ERROR;
+                return 0;
+            }
+            const auto *item = static_cast<const MetaMemCacheItem *>(value);
+            std::shared_lock lock(item->GetMutex());
+            const auto &locations = item->GetLocations();
+            if (out_location_map) {
+                *out_location_map = locations;
+            }
+            if (out_location_ids) {
+                out_location_ids->reserve(locations.size());
+                for (const auto &[location_id, _] : locations) {
+                    out_location_ids->push_back(location_id);
+                }
+            }
+            return 0;
+        });
+    return found ? result : EC_NOENT;
+}
+
 std::vector<ErrorCode> MetaLocalBackend::Get(RequestContext * /*request_context*/,
                                              const KeyTypeVec &keys,
                                              CacheLocationMapVector &out_locations,
@@ -1127,6 +1153,46 @@ void MetaLocalBackend::GetSingleLocationsWithKeyStatusIntoImpl(RequestContext * 
     }
 }
 
+std::vector<std::vector<ErrorCode>>
+MetaLocalBackend::GetLocationsForMaintenance(RequestContext * /*request_context*/,
+                                             const KeyTypeVec &keys,
+                                             const LocationIdsPerKey &location_ids,
+                                             LocationsPerKey &out_locations) noexcept {
+    if (keys.size() != location_ids.size()) {
+        out_locations.clear();
+        return {};
+    }
+    std::vector<std::vector<ErrorCode>> results(keys.size());
+    out_locations.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i].assign(location_ids[i].size(), EC_NOENT);
+        out_locations[i].resize(location_ids[i].size());
+        const bool found = cache_->ApplyToEntryNoTouch(
+            KeyToView(keys[i]),
+            [&](Cache::ObjectPtr value, size_t /*charge*/, const Cache::CacheItemHelper * /*helper*/) -> ssize_t {
+                if (value == nullptr) {
+                    std::fill(results[i].begin(), results[i].end(), EC_ERROR);
+                    return 0;
+                }
+                const auto *item = static_cast<const MetaMemCacheItem *>(value);
+                std::shared_lock lock(item->GetMutex());
+                const auto &locations = item->GetLocations();
+                for (size_t j = 0; j < location_ids[i].size(); ++j) {
+                    const auto it = locations.find(location_ids[i][j]);
+                    if (it != locations.end()) {
+                        results[i][j] = EC_OK;
+                        out_locations[i][j] = it->second;
+                    }
+                }
+                return 0;
+            });
+        if (!found) {
+            std::fill(results[i].begin(), results[i].end(), EC_NOENT);
+        }
+    }
+    return results;
+}
+
 std::vector<ErrorCode> MetaLocalBackend::GetLocationIds(RequestContext * /*request_context*/,
                                                         const KeyTypeVec &keys,
                                                         LocationIdsPerKey &out_location_ids) noexcept {
@@ -1134,6 +1200,69 @@ std::vector<ErrorCode> MetaLocalBackend::GetLocationIds(RequestContext * /*reque
     out_location_ids.resize(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         results[i] = GetForOneKey(keys[i], nullptr, nullptr, nullptr, &out_location_ids[i]);
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::GetLocationIdsForMaintenance(RequestContext * /*request_context*/,
+                                                                      const KeyTypeVec &keys,
+                                                                      LocationIdsPerKey &out_location_ids) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_location_ids.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = GetForOneKeyForMaintenance(keys[i], nullptr, &out_location_ids[i]);
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::DeleteLocationsForMaintenance(RequestContext * /*request_context*/,
+                                                                       const KeyTypeVec &keys,
+                                                                       const LocationIdsPerKey &location_ids) noexcept {
+    return DeleteLocationsForMaintenance(nullptr, keys, location_ids, std::vector<ErrorCode>(keys.size(), EC_OK));
+}
+
+std::vector<ErrorCode>
+MetaLocalBackend::DeleteLocationsForMaintenance(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                const LocationIdsPerKey &location_ids,
+                                                const std::vector<ErrorCode> &previous_error_codes) noexcept {
+    if (keys.size() != location_ids.size() || keys.size() != previous_error_codes.size()) {
+        return {};
+    }
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (previous_error_codes[i] != EC_OK && previous_error_codes[i] != EC_NOENT) {
+            results[i] = previous_error_codes[i];
+            continue;
+        }
+        if (location_ids[i].empty()) {
+            continue;
+        }
+        const bool found = cache_->ApplyToEntryNoTouch(
+            KeyToView(keys[i]),
+            [&](Cache::ObjectPtr value, size_t /*charge*/, const Cache::CacheItemHelper * /*helper*/) -> ssize_t {
+                if (value == nullptr) {
+                    results[i] = EC_ERROR;
+                    return 0;
+                }
+                auto *item = static_cast<MetaMemCacheItem *>(value);
+                ssize_t charge_delta = 0;
+                std::unique_lock lock(item->GetMutex());
+                auto &locations = item->GetMutableLocations();
+                for (const auto &location_id : location_ids[i]) {
+                    const auto it = locations.find(location_id);
+                    if (it == locations.end()) {
+                        continue;
+                    }
+                    charge_delta -=
+                        static_cast<ssize_t>(MetaMemCacheItem::EstimateLocationEntryUsage(it->first, it->second));
+                    locations.erase(it);
+                }
+                return charge_delta;
+            });
+        if (!found) {
+            results[i] = EC_NOENT;
+        }
     }
     return results;
 }
@@ -1238,25 +1367,29 @@ ErrorCode MetaLocalBackend::ScanLocationsForMaintenance(RequestContext * /*reque
     const uint32_t num_shards = shard_mask_ + 1;
     int64_t collected = 0;
     for (uint32_t shard_id = static_cast<uint32_t>(start_shard); shard_id < num_shards; ++shard_id) {
+        std::vector<KeyType> shard_keys;
         cache_->ApplyToSingleShard(shard_id,
                                    [&](const std::string_view &key,
-                                       Cache::ObjectPtr value,
+                                       Cache::ObjectPtr /*value*/,
                                        size_t /*charge*/,
                                        const Cache::CacheItemHelper * /*helper*/) {
-                                       if (key.size() != sizeof(KeyType) || value == nullptr) {
+                                       if (key.size() != sizeof(KeyType)) {
                                            return;
                                        }
-                                       const auto *item = static_cast<const MetaMemCacheItem *>(value);
-                                       CacheLocationMap locations;
-                                       {
-                                           std::shared_lock lock(item->GetMutex());
-                                           locations = item->GetLocations();
-                                       }
-                                       out.keys.push_back(ViewToKey(key));
-                                       out.locations.emplace_back(std::move(locations));
-                                       out.location_results.push_back(EC_OK);
-                                       ++collected;
+                                       shard_keys.push_back(ViewToKey(key));
                                    });
+
+        // ApplyToSingleShard owns the LRU shard mutex. Copy each item only
+        // after that iteration lock has been released; ApplyToEntryNoTouch
+        // then pins the exact shard operation without promoting the entry.
+        for (const KeyType key : shard_keys) {
+            CacheLocationMap locations;
+            const ErrorCode ec = GetForOneKeyForMaintenance(key, &locations, nullptr);
+            out.keys.push_back(key);
+            out.locations.emplace_back(std::move(locations));
+            out.location_results.push_back(ec);
+            ++collected;
+        }
 
         if (collected >= limit) {
             const uint32_t next_shard = shard_id + 1;

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -23,14 +23,18 @@
 namespace kv_cache_manager {
 
 struct MetaMemCacheItem {
+    static size_t EstimateLocationEntryUsage(const std::string &location_id, const CacheLocationConstPtr &location) {
+        return sizeof(void *) * 4 + location_id.size() + sizeof(CacheLocationConstPtr) +
+               (location ? location->EstimateMemUsage() : 0);
+    }
+
     // Estimates total memory footprint including the heap memory owned by
     // CacheLocationMap and PropertyMap entries, used as the "charge" for LRU cache eviction accounting.
     size_t Size() const {
         size_t total = sizeof(MetaMemCacheItem);
         for (const auto &[location_id, location] : locations_) {
             // unordered_map node overhead + key string heap + shared_ptr overhead + CacheLocation footprint
-            total += sizeof(void *) * 4 + location_id.size() + sizeof(CacheLocationConstPtr) +
-                     (location ? location->EstimateMemUsage() : 0);
+            total += EstimateLocationEntryUsage(location_id, location);
         }
         for (const auto &[prop_name, prop_value] : properties_) {
             total += sizeof(void *) * 4 + prop_name.size() + prop_value.size();
@@ -226,9 +230,16 @@ public:
                                                  std::vector<ErrorCode> &out_key_error_codes,
                                                  std::vector<ErrorCode> &out_results,
                                                  SingleLocationRmwScratch &scratch) noexcept;
+    std::vector<std::vector<ErrorCode>> GetLocationsForMaintenance(RequestContext *request_context,
+                                                                   const KeyTypeVec &keys,
+                                                                   const LocationIdsPerKey &location_ids,
+                                                                   LocationsPerKey &out_locations) noexcept override;
     std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
                                           const KeyTypeVec &keys,
                                           LocationIdsPerKey &out_location_ids) noexcept override;
+    std::vector<ErrorCode> GetLocationIdsForMaintenance(RequestContext *request_context,
+                                                        const KeyTypeVec &keys,
+                                                        LocationIdsPerKey &out_location_ids) noexcept override;
     std::vector<ErrorCode> GetProperties(RequestContext *request_context,
                                          const KeyTypeVec &keys,
                                          const std::vector<std::string> &field_names,
@@ -248,6 +259,14 @@ public:
                                           const std::string &cursor,
                                           int64_t limit,
                                           MaintenanceScanBatch &out) noexcept override;
+    std::vector<ErrorCode> DeleteLocationsForMaintenance(RequestContext *request_context,
+                                                         const KeyTypeVec &keys,
+                                                         const LocationIdsPerKey &location_ids) noexcept override;
+    std::vector<ErrorCode>
+    DeleteLocationsForMaintenance(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const LocationIdsPerKey &location_ids,
+                                  const std::vector<ErrorCode> &previous_error_codes) noexcept override;
     ErrorCode RandomSample(RequestContext *request_context,
                            const int64_t count,
                            std::vector<KeyType> &out_keys) noexcept override;
@@ -314,6 +333,9 @@ private:
                            CacheLocationMap *out_location_map,
                            PropertyMap *out_property_map,
                            std::vector<LocationId> *out_location_ids);
+    ErrorCode GetForOneKeyForMaintenance(KeyType key,
+                                         CacheLocationMap *out_location_map,
+                                         std::vector<LocationId> *out_location_ids);
 
     std::shared_ptr<Cache::CacheItemHelper> cache_item_helper_;
     std::shared_ptr<Cache> cache_;

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -331,6 +331,16 @@ public:
         return results;
     }
 
+    // Targeted maintenance read. It must not update access/LRU/revisit state
+    // and must not populate another cache tier. Backends without an online
+    // cache can use the ordinary targeted read implementation.
+    virtual std::vector<std::vector<ErrorCode>> GetLocationsForMaintenance(RequestContext *request_context,
+                                                                           const KeyTypeVec &keys,
+                                                                           const LocationIdsPerKey &location_ids,
+                                                                           LocationsPerKey &out_locations) noexcept {
+        return GetLocations(request_context, keys, location_ids, out_locations);
+    }
+
     // 仅获取 key 的 location id 列表（不读取 location body）。
     // @param request_context    请求上下文；可为 nullptr
     // @param keys               待查询的 key 列表
@@ -343,6 +353,15 @@ public:
     virtual std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
                                                   const KeyTypeVec &keys,
                                                   LocationIdsPerKey &out_location_ids) noexcept = 0;
+
+    // Maintenance counterpart of GetLocationIds(). It must not promote or
+    // touch cache entries. Persistent-only backends can use the ordinary
+    // implementation because they have no online LRU state to preserve.
+    virtual std::vector<ErrorCode> GetLocationIdsForMaintenance(RequestContext *request_context,
+                                                                const KeyTypeVec &keys,
+                                                                LocationIdsPerKey &out_location_ids) noexcept {
+        return GetLocationIds(request_context, keys, out_location_ids);
+    }
 
     // 读取指定字段名的 properties。
     // @param request_context  请求上下文；可为 nullptr
@@ -406,6 +425,15 @@ public:
                                                   const std::string &cursor,
                                                   int64_t limit,
                                                   MaintenanceScanBatch &out) noexcept = 0;
+
+    // Maintenance delete counterpart of GetLocationsForMaintenance(). It
+    // must not promote/touch cache entries. The caller already performed the
+    // expected-value comparison under the MetaIndexer shard lock.
+    virtual std::vector<ErrorCode> DeleteLocationsForMaintenance(RequestContext *request_context,
+                                                                 const KeyTypeVec &keys,
+                                                                 const LocationIdsPerKey &location_ids) noexcept {
+        return DeleteLocations(request_context, keys, location_ids);
+    }
 
     // 随机采样 key。
     // @param request_context 请求上下文；可为 nullptr

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -720,6 +720,187 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request
     return results;
 }
 
+std::vector<ErrorCode>
+MetaStorageBackendManager::DeleteLocationsForMaintenance(RequestContext *request_context,
+                                                         const KeyVector &keys,
+                                                         const LocationIdsPerKey &location_ids,
+                                                         int32_t &out_reclaimed_count) noexcept {
+    out_reclaimed_count = 0;
+    if (keys.empty()) {
+        return {};
+    }
+    if (keys.size() != location_ids.size()) {
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
+    if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRecover) {
+        // A recover task can still publish an older persistent snapshot into
+        // the hot cache. Retry this best-effort action after recovery rather
+        // than backfilling or touching cache state from maintenance.
+        return std::vector<ErrorCode>(keys.size(), EC_OUT_OF_LIMIT);
+    }
+
+    // Decide target-only versus whole-key deletion from both layers before
+    // mutating either one. Looking only at the hot cache can erase a newer
+    // persistent sibling; deleting targets first and reclaiming the key later
+    // can also hide a failed whole-key delete from subsequent GC rounds.
+    LocationIdsPerKey persistent_location_ids;
+    const std::vector<ErrorCode> persistent_id_ecs =
+        persistent_backend_->GetLocationIdsForMaintenance(request_context, keys, persistent_location_ids);
+    LocationIdsPerKey hot_location_ids;
+    std::vector<ErrorCode> hot_id_ecs;
+    if (cache_backend_) {
+        hot_id_ecs = cache_backend_->GetLocationIdsForMaintenance(request_context, keys, hot_location_ids);
+    }
+
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    std::vector<bool> id_reads_valid(keys.size(), true);
+    const auto validate_id_reads =
+        [&](const char *layer, const std::vector<ErrorCode> &id_ecs, const LocationIdsPerKey &ids) {
+            if (id_ecs.size() != keys.size() || ids.size() != keys.size()) {
+                KVCM_LOG_ERROR("%s maintenance location-id results[%lu] values[%lu] mismatch keys[%lu]",
+                               layer,
+                               id_ecs.size(),
+                               ids.size(),
+                               keys.size());
+                std::fill(results.begin(), results.end(), EC_ERROR);
+                std::fill(id_reads_valid.begin(), id_reads_valid.end(), false);
+                return;
+            }
+            for (size_t i = 0; i < keys.size(); ++i) {
+                if (id_ecs[i] != EC_OK && id_ecs[i] != EC_NOENT) {
+                    results[i] = id_ecs[i];
+                    id_reads_valid[i] = false;
+                } else if (id_ecs[i] == EC_NOENT && !ids[i].empty()) {
+                    KVCM_LOG_ERROR(
+                        "%s maintenance location-id read returned NOENT with values for key[%ld]", layer, keys[i]);
+                    results[i] = EC_ERROR;
+                    id_reads_valid[i] = false;
+                }
+            }
+        };
+    validate_id_reads("persistent", persistent_id_ecs, persistent_location_ids);
+    if (cache_backend_) {
+        validate_id_reads("cache", hot_id_ecs, hot_location_ids);
+    }
+
+    std::vector<size_t> whole_key_indexes;
+    std::vector<size_t> target_only_indexes;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (!id_reads_valid[i] || location_ids[i].empty()) {
+            continue;
+        }
+        const auto layer_has_only_targets = [&](ErrorCode id_ec, const LocationIdVector &existing_ids) {
+            if (id_ec == EC_NOENT) {
+                return true;
+            }
+            return std::all_of(existing_ids.begin(), existing_ids.end(), [&](const LocationId &existing_id) {
+                return std::find(location_ids[i].begin(), location_ids[i].end(), existing_id) != location_ids[i].end();
+            });
+        };
+        const bool persistent_safe = layer_has_only_targets(persistent_id_ecs[i], persistent_location_ids[i]);
+        const bool hot_safe = !cache_backend_ || layer_has_only_targets(hot_id_ecs[i], hot_location_ids[i]);
+        (persistent_safe && hot_safe ? whole_key_indexes : target_only_indexes).push_back(i);
+    }
+
+    if (!target_only_indexes.empty()) {
+        KeyVector target_keys;
+        LocationIdsPerKey target_location_ids;
+        target_keys.reserve(target_only_indexes.size());
+        target_location_ids.reserve(target_only_indexes.size());
+        for (const size_t index : target_only_indexes) {
+            target_keys.push_back(keys[index]);
+            target_location_ids.push_back(location_ids[index]);
+        }
+
+        std::vector<ErrorCode> persistent_results =
+            persistent_backend_->DeleteLocationsForMaintenance(request_context, target_keys, target_location_ids);
+        if (persistent_results.size() != target_only_indexes.size()) {
+            KVCM_LOG_ERROR("persistent maintenance target delete results[%lu] mismatch keys[%lu]",
+                           persistent_results.size(),
+                           target_only_indexes.size());
+            persistent_results.assign(target_only_indexes.size(), EC_ERROR);
+        }
+        std::vector<ErrorCode> target_results = persistent_results;
+        if (cache_backend_) {
+            target_results = cache_backend_->DeleteLocationsForMaintenance(
+                request_context, target_keys, target_location_ids, persistent_results);
+            if (target_results.size() != target_only_indexes.size()) {
+                KVCM_LOG_ERROR("cache maintenance target delete results[%lu] mismatch keys[%lu]",
+                               target_results.size(),
+                               target_only_indexes.size());
+                target_results.assign(target_only_indexes.size(), EC_ERROR);
+            }
+        }
+        for (size_t i = 0; i < target_only_indexes.size(); ++i) {
+            const ErrorCode persistent_ec = persistent_results[i];
+            const ErrorCode hot_ec = target_results[i];
+            if (persistent_ec != EC_OK && persistent_ec != EC_NOENT) {
+                results[target_only_indexes[i]] = persistent_ec;
+            } else if (hot_ec != EC_OK && hot_ec != EC_NOENT) {
+                results[target_only_indexes[i]] = hot_ec;
+            } else if (persistent_ec == EC_OK || hot_ec == EC_OK) {
+                // Either layer actually removed the logical target. Report
+                // success so storage usage is accounted exactly once even if
+                // the other layer had already converged to NOENT.
+                results[target_only_indexes[i]] = EC_OK;
+            } else {
+                results[target_only_indexes[i]] = EC_NOENT;
+            }
+        }
+    }
+
+    if (!whole_key_indexes.empty()) {
+        KeyVector whole_keys;
+        whole_keys.reserve(whole_key_indexes.size());
+        for (const size_t index : whole_key_indexes) {
+            whole_keys.push_back(keys[index]);
+        }
+
+        std::vector<ErrorCode> persistent_results = persistent_backend_->Delete(request_context, whole_keys);
+        if (persistent_results.size() != whole_key_indexes.size()) {
+            KVCM_LOG_ERROR("persistent maintenance whole-key delete results[%lu] mismatch keys[%lu]",
+                           persistent_results.size(),
+                           whole_key_indexes.size());
+            persistent_results.assign(whole_key_indexes.size(), EC_ERROR);
+        }
+        std::vector<ErrorCode> whole_results = persistent_results;
+        if (cache_backend_) {
+            // A key already absent from persistent still needs its hot copy
+            // removed. Normalize only this idempotent maintenance gate.
+            auto cache_gate = persistent_results;
+            for (auto &ec : cache_gate) {
+                if (ec == EC_NOENT) {
+                    ec = EC_OK;
+                }
+            }
+            whole_results = cache_backend_->Delete(request_context, whole_keys, cache_gate);
+            if (whole_results.size() != whole_key_indexes.size()) {
+                KVCM_LOG_ERROR("cache maintenance whole-key delete results[%lu] mismatch keys[%lu]",
+                               whole_results.size(),
+                               whole_key_indexes.size());
+                whole_results.assign(whole_key_indexes.size(), EC_ERROR);
+            }
+        }
+
+        std::unordered_set<KeyType> reclaimed_keys;
+        for (size_t i = 0; i < whole_key_indexes.size(); ++i) {
+            const size_t original_index = whole_key_indexes[i];
+            if (whole_results[i] != EC_OK && whole_results[i] != EC_NOENT) {
+                results[original_index] = whole_results[i];
+                continue;
+            }
+            results[original_index] = EC_OK;
+            // The preceding expected-value read admitted at least one target.
+            // Count a converged whole-key action once even when one layer was
+            // already missing due to an earlier partial attempt.
+            reclaimed_keys.insert(keys[original_index]);
+        }
+        out_reclaimed_count = static_cast<int32_t>(reclaimed_keys.size());
+    }
+    return results;
+}
+
+
 int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(RequestContext *request_context,
                                                          const KeyVector &keys,
                                                          const std::vector<ErrorCode> &delete_results) noexcept {
@@ -1184,6 +1365,104 @@ std::vector<std::vector<ErrorCode>> MetaStorageBackendManager::GetLocations(Requ
 }
 
 std::vector<std::vector<ErrorCode>>
+MetaStorageBackendManager::GetLocationsForMaintenance(RequestContext *request_context,
+                                                      const KeyVector &keys,
+                                                      const LocationIdsPerKey &location_ids,
+                                                      LocationsPerKey &out_locations) noexcept {
+    if (keys.size() != location_ids.size()) {
+        out_locations.assign(keys.size(), CacheLocationVector{});
+        return std::vector<std::vector<ErrorCode>>(keys.size(), std::vector<ErrorCode>{EC_BADARGS});
+    }
+    if (!cache_backend_) {
+        return persistent_backend_->GetLocationsForMaintenance(request_context, keys, location_ids, out_locations);
+    }
+
+    // A unified GC round scans the hot cache, but a stale hot value must not
+    // authorize deletion of a newer persistent value left by a partial mirror
+    // failure. Revalidate both layers without touching/backfilling the cache;
+    // one missing copy is safe to converge, while two different present copies
+    // fail closed as a compare mismatch.
+    LocationsPerKey hot_locations;
+    const auto hot_results =
+        cache_backend_->GetLocationsForMaintenance(request_context, keys, location_ids, hot_locations);
+    LocationsPerKey persistent_locations;
+    const auto persistent_results =
+        persistent_backend_->GetLocationsForMaintenance(request_context, keys, location_ids, persistent_locations);
+
+    std::vector<std::vector<ErrorCode>> results(keys.size());
+    out_locations.resize(keys.size());
+    const bool outer_shape_valid = hot_results.size() == keys.size() && hot_locations.size() == keys.size() &&
+                                   persistent_results.size() == keys.size() &&
+                                   persistent_locations.size() == keys.size();
+    if (!outer_shape_valid) {
+        KVCM_LOG_ERROR("maintenance target read shape mismatch, keys[%lu] hot_ecs[%lu] hot_values[%lu] "
+                       "persistent_ecs[%lu] persistent_values[%lu]",
+                       keys.size(),
+                       hot_results.size(),
+                       hot_locations.size(),
+                       persistent_results.size(),
+                       persistent_locations.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            results[i].assign(location_ids[i].size(), EC_ERROR);
+            out_locations[i].assign(location_ids[i].size(), CacheLocationConstPtr{});
+        }
+        return results;
+    }
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i].assign(location_ids[i].size(), EC_ERROR);
+        out_locations[i].assign(location_ids[i].size(), CacheLocationConstPtr{});
+        if (hot_results[i].size() != location_ids[i].size() || hot_locations[i].size() != location_ids[i].size() ||
+            persistent_results[i].size() != location_ids[i].size() ||
+            persistent_locations[i].size() != location_ids[i].size()) {
+            KVCM_LOG_ERROR("maintenance target read key[%ld] shape mismatch, ids[%lu] hot_ecs[%lu] hot_values[%lu] "
+                           "persistent_ecs[%lu] persistent_values[%lu]",
+                           keys[i],
+                           location_ids[i].size(),
+                           hot_results[i].size(),
+                           hot_locations[i].size(),
+                           persistent_results[i].size(),
+                           persistent_locations[i].size());
+            continue;
+        }
+
+        for (size_t j = 0; j < location_ids[i].size(); ++j) {
+            const auto validate_layer = [&](ErrorCode ec, const CacheLocationConstPtr &location) {
+                if (ec == EC_NOENT) {
+                    return location ? EC_ERROR : EC_NOENT;
+                }
+                if (ec != EC_OK) {
+                    return ec;
+                }
+                return location && location->id() == location_ids[i][j] ? EC_OK : EC_ERROR;
+            };
+            const ErrorCode hot_ec = validate_layer(hot_results[i][j], hot_locations[i][j]);
+            const ErrorCode persistent_ec = validate_layer(persistent_results[i][j], persistent_locations[i][j]);
+            if (hot_ec != EC_OK && hot_ec != EC_NOENT) {
+                results[i][j] = hot_ec;
+                continue;
+            }
+            if (persistent_ec != EC_OK && persistent_ec != EC_NOENT) {
+                results[i][j] = persistent_ec;
+                continue;
+            }
+            if (hot_ec == EC_NOENT && persistent_ec == EC_NOENT) {
+                results[i][j] = EC_NOENT;
+                continue;
+            }
+            if (hot_ec == EC_OK && persistent_ec == EC_OK &&
+                hot_locations[i][j]->ToJsonString() != persistent_locations[i][j]->ToJsonString()) {
+                results[i][j] = EC_MISMATCH;
+                continue;
+            }
+            results[i][j] = EC_OK;
+            out_locations[i][j] = hot_ec == EC_OK ? hot_locations[i][j] : persistent_locations[i][j];
+        }
+    }
+    return results;
+}
+
+std::vector<std::vector<ErrorCode>>
 MetaStorageBackendManager::GetLocationsWithKeyStatus(RequestContext *request_context,
                                                      const KeyVector &keys,
                                                      const LocationIdsPerKey &location_ids,
@@ -1534,13 +1813,19 @@ ErrorCode MetaStorageBackendManager::ScanLocationsForMaintenance(RequestContext 
                                                                  const int64_t limit,
                                                                  MaintenanceScanBatch &out) noexcept {
     out.Clear();
-    if (!persistent_backend_) {
-        KVCM_LOG_ERROR("maintenance scan failed, persistent backend is null, instance[%s]", instance_id_.c_str());
+    // In dual-backend mode the in-memory backend is the GC discovery view.
+    // It is expected to contain the useful metadata working set and avoids a
+    // periodic full scan against Redis. Missing or evicted keys are an
+    // accepted best-effort tradeoff; deletion admission still performs an
+    // expected-value RMW under the ordinary metadata mutation fence.
+    MetaStorageBackend *scan_backend = cache_backend_ ? cache_backend_.get() : persistent_backend_.get();
+    if (!scan_backend) {
+        KVCM_LOG_ERROR("maintenance scan failed, scan backend is null, instance[%s]", instance_id_.c_str());
         return EC_ERROR;
     }
 
     MaintenanceScanBatch batch;
-    ErrorCode ec = persistent_backend_->ScanLocationsForMaintenance(request_context, cursor, limit, batch);
+    ErrorCode ec = scan_backend->ScanLocationsForMaintenance(request_context, cursor, limit, batch);
     if (ec != EC_OK) {
         return ec;
     }

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -71,6 +71,10 @@ public:
                                   const KeyVector &keys,
                                   const LocationIdsPerKey &location_ids,
                                   int32_t &out_reclaimed_count) noexcept;
+    std::vector<ErrorCode> DeleteLocationsForMaintenance(RequestContext *request_context,
+                                                         const KeyVector &keys,
+                                                         const LocationIdsPerKey &location_ids,
+                                                         int32_t &out_reclaimed_count) noexcept;
 
     // ----- Read APIs -----
     std::vector<ErrorCode> Get(RequestContext *request_context,
@@ -99,6 +103,10 @@ public:
                                                      const KeyVector &keys,
                                                      const LocationIdsPerKey &location_ids,
                                                      LocationsPerKey &out_locations) noexcept;
+    std::vector<std::vector<ErrorCode>> GetLocationsForMaintenance(RequestContext *request_context,
+                                                                   const KeyVector &keys,
+                                                                   const LocationIdsPerKey &location_ids,
+                                                                   LocationsPerKey &out_locations) noexcept;
     std::vector<std::vector<ErrorCode>> GetLocationsWithKeyStatus(RequestContext *request_context,
                                                                   const KeyVector &keys,
                                                                   const LocationIdsPerKey &location_ids,
@@ -140,6 +148,8 @@ public:
                        const int64_t limit,
                        std::string &out_next_cursor,
                        KeyTypeVec &out_keys) noexcept;
+    // Scan the in-memory cache when dual-backend metadata is configured;
+    // single-backend deployments scan their only persistent backend.
     ErrorCode ScanLocationsForMaintenance(RequestContext *request_context,
                                           const std::string &cursor,
                                           int64_t limit,
@@ -153,6 +163,13 @@ public:
     // Synchronously flush pending writes for the given keys to persistent storage.
     // Returns true on success, false on failure/timeout.
     bool Sync(const KeyVector &keys) noexcept;
+
+    // A persistent-only backend has no synchronous hot view that can expose an
+    // accepted maintenance delete to the next same-key RMW. Conservatively
+    // retain the trailing barrier there (it is a no-op for synchronous
+    // backends). Cached mode updates the hot view under the shard fence and
+    // preserves persistent write order, so it can unlock without that barrier.
+    bool RequiresMaintenancePostDeleteSync() const noexcept { return cache_backend_ == nullptr; }
 
     // Returns async write stats from persistent backend.
     MetaStorageBackend::AsyncWriteStats GetAsyncWriteStats() noexcept;
@@ -187,7 +204,6 @@ private:
     int32_t MaybeReclaimEmptyKeys(RequestContext *request_context,
                                   const KeyVector &keys,
                                   const std::vector<ErrorCode> &delete_results) noexcept;
-
     std::string instance_id_;
     std::unique_ptr<MetaStorageBackend> persistent_backend_;
     std::unique_ptr<MetaCacheBaseBackend> cache_backend_;

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -710,6 +710,66 @@ TEST_F(MetaLocalBackendTest, TestMaintenanceScanReturnsLocationsWithoutTouchingL
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaLocalBackendTest, TestMaintenanceTargetReadAndDeleteDoNotTouchAccessTime) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_maintenance_target", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    auto first = std::make_shared<CacheLocation>();
+    first->set_id("loc_first");
+    first->set_status(CacheLocationStatus::CLS_SERVING);
+    auto second = std::make_shared<CacheLocation>();
+    second->set_id("loc_second");
+    second->set_status(CacheLocationStatus::CLS_SERVING);
+    CacheLocationMapVector locations(1);
+    locations[0].emplace(first->id(), first);
+    locations[0].emplace(second->id(), second);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              meta_storage_backend_->Put(nullptr, {1}, locations, PropertyMapVector(1)));
+
+    auto *backend = GetLocalBackend();
+    auto get_last_access_time = [backend]() {
+        int64_t last_access_time = -1;
+        backend->cache_->ApplyToSingleShard(
+            0, [&last_access_time](std::string_view, Cache::ObjectPtr value, size_t, const Cache::CacheItemHelper *) {
+                last_access_time = static_cast<MetaMemCacheItem *>(value)->GetLastAccessTime();
+            });
+        return last_access_time;
+    };
+    const int64_t access_before = get_last_access_time();
+    const size_t usage_before = backend->GetMemUsage();
+
+    LocationsPerKey selected;
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}),
+              backend->GetLocationsForMaintenance(nullptr, {1}, {{"loc_first"}}, selected));
+    ASSERT_EQ(1, selected.size());
+    ASSERT_EQ(1, selected[0].size());
+    ASSERT_TRUE(selected[0][0]);
+    EXPECT_EQ("loc_first", selected[0][0]->id());
+    EXPECT_EQ(access_before, get_last_access_time());
+
+    LocationIdsPerKey location_ids;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->GetLocationIdsForMaintenance(nullptr, {1}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+    EXPECT_THAT(location_ids.front(), UnorderedElementsAre("loc_first", "loc_second"));
+    EXPECT_EQ(access_before, get_last_access_time());
+
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->DeleteLocationsForMaintenance(nullptr, {1}, {{"loc_first"}}));
+    EXPECT_EQ(access_before, get_last_access_time());
+    EXPECT_EQ(usage_before - MetaMemCacheItem::EstimateLocationEntryUsage("loc_first", first), backend->GetMemUsage());
+    LocationsPerKey remaining;
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_NOENT, EC_OK}}),
+              backend->GetLocationsForMaintenance(nullptr, {1}, {{"loc_first", "loc_second"}}, remaining));
+    ASSERT_EQ(1, remaining.size());
+    ASSERT_EQ(2, remaining[0].size());
+    EXPECT_FALSE(remaining[0][0]);
+    ASSERT_TRUE(remaining[0][1]);
+    EXPECT_EQ("loc_second", remaining[0][1]->id());
+    EXPECT_EQ(access_before, get_last_access_time());
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestSampleReclaimKeys) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
@@ -1543,16 +1603,17 @@ TEST_F(MetaLocalBackendTest, TestChargeAdjustment) {
     std::string field_name_b_full = PROPERTY_LOCATION_PREFIX + loc_id_b;
     // SplitFieldMaps creates a CacheLocation with id=loc_id_b and no specs.
     // EstimateMemUsage = sizeof(CacheLocation) + loc_id_b.size()
-    // MetaMemCacheItem::Size location overhead = sizeof(void*)*4 + loc_id.size() + EstimateMemUsage
+    // MetaMemCacheItem::Size location overhead = map node + id + shared_ptr + location body.
     size_t loc_mem_usage = sizeof(CacheLocation) + loc_id_b.size();
-    ssize_t expected_delta_upsert = static_cast<ssize_t>(kMapNodeOverhead + loc_id_b.size() + loc_mem_usage);
+    ssize_t expected_delta_upsert =
+        static_cast<ssize_t>(kMapNodeOverhead + loc_id_b.size() + sizeof(CacheLocationConstPtr) + loc_mem_usage);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
               UpsertWithFieldMaps(backend.get(), {1}, {{{field_name_b_full, loc_value_b}}}));
     size_t usage_after_upsert = backend->GetMemUsage();
     ASSERT_EQ(static_cast<ssize_t>(usage_after_upsert - usage_after_shrink), expected_delta_upsert);
 
     // --- DeleteLocations: remove loc_b ---
-    // Expected delta: -(sizeof(void*)*4 + loc_id.size() + EstimateMemUsage)
+    // Expected delta is the exact inverse of adding the location entry.
     ssize_t expected_delta_delete = -expected_delta_upsert;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), backend->DeleteLocations(nullptr, {1}, {{loc_id_b}}));
     size_t usage_after_delete = backend->GetMemUsage();

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -288,6 +288,22 @@ public:
     }
 };
 
+class FailOnceWholeKeyDeleteBackend : public MetaDummyBackend {
+public:
+    void FailNextDelete() { fail_next_delete_ = true; }
+
+    std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyTypeVec &keys) noexcept override {
+        if (fail_next_delete_) {
+            fail_next_delete_ = false;
+            return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+        }
+        return MetaDummyBackend::Delete(request_context, keys);
+    }
+
+private:
+    bool fail_next_delete_ = false;
+};
+
 struct BackendLifecycleCalls {
     ErrorCode open_result = EC_OK;
     int open_calls = 0;
@@ -973,7 +989,7 @@ TEST_F(MetaStorageBackendManagerTest, TestListKeysAndRandomSample) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
-TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesPersistentWithoutCacheBackfill) {
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesCacheWithoutPersistentFallback) {
     const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_scan";
     std::filesystem::remove(path);
     MetaStorageBackendManager mgr;
@@ -984,6 +1000,10 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesPersistentWithoutCa
     auto batch = MakeBatch({777});
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
               mgr.persistent_backend_->Put(nullptr, batch.batch_keys, batch.batch_locations, batch.batch_properties));
+    auto cache_batch = MakeBatch({888});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.cache_backend_->Put(
+                  nullptr, cache_batch.batch_keys, cache_batch.batch_locations, cache_batch.batch_properties));
 
     std::vector<bool> cache_exists;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
@@ -991,10 +1011,10 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesPersistentWithoutCa
 
     MaintenanceScanBatch scan_batch;
     ASSERT_EQ(EC_OK, mgr.ScanLocationsForMaintenance(nullptr, SCAN_BASE_CURSOR, 10, scan_batch));
-    ASSERT_EQ((KeyVector{777}), scan_batch.keys);
+    ASSERT_EQ((KeyVector{888}), scan_batch.keys);
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), scan_batch.location_results);
-    ASSERT_EQ(1, scan_batch.locations.size());
-    ASSERT_TRUE(scan_batch.locations[0].count("loc_777") > 0);
+    ASSERT_EQ(1u, scan_batch.locations.size());
+    ASSERT_TRUE(scan_batch.locations[0].count("loc_888") > 0);
 
     cache_exists.clear();
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
@@ -1005,8 +1025,8 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesPersistentWithoutCa
     ASSERT_EQ(1u, authoritative_locations.size());
     ASSERT_TRUE(authoritative_locations.front().count("loc_777") > 0);
 
-    // An authoritative read remains side-effect free. Maintenance admission
-    // explicitly refreshes only accepted candidate keys before its RMW.
+    // An authoritative read remains side-effect free. Explicit refresh is a
+    // separate online operation; the maintenance RMW does not invoke it.
     cache_exists.clear();
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
     EXPECT_EQ((std::vector<bool>{false}), cache_exists);
@@ -1014,6 +1034,244 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesPersistentWithoutCa
     cache_exists.clear();
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {777}, cache_exists));
     EXPECT_EQ((std::vector<bool>{true}), cache_exists);
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceScanUsesPersistentForSingleBackend) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_scan_single";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_single", MakeSingleConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+
+    auto batch = MakeBatch({999});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
+
+    MaintenanceScanBatch scan_batch;
+    ASSERT_EQ(EC_OK, mgr.ScanLocationsForMaintenance(nullptr, SCAN_BASE_CURSOR, 10, scan_batch));
+    ASSERT_EQ((KeyVector{999}), scan_batch.keys);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), scan_batch.location_results);
+    ASSERT_EQ(1u, scan_batch.locations.size());
+    ASSERT_TRUE(scan_batch.locations.front().count("loc_999") > 0);
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteMirrorsPersistentAndHotWithoutReceiptState) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_delete";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_delete", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    auto batch = MakeBatch({888});
+    batch.batch_locations[0].emplace("loc_second", MakeLocation("loc_second", "uri_second"));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
+
+    int32_t reclaimed_count = 0;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.DeleteLocationsForMaintenance(
+                  request_context_.get(), {888}, {{"loc_888"}}, reclaimed_count));
+    EXPECT_EQ(0, reclaimed_count);
+
+    CacheLocationMapVector hot_locations;
+    CacheLocationMapVector persistent_locations;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.cache_backend_->GetLocations(nullptr, {888}, hot_locations));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.persistent_backend_->GetLocations(nullptr, {888}, persistent_locations));
+    ASSERT_EQ(1u, hot_locations.size());
+    ASSERT_EQ(1u, persistent_locations.size());
+    EXPECT_EQ(0u, hot_locations[0].count("loc_888"));
+    EXPECT_EQ(0u, persistent_locations[0].count("loc_888"));
+    EXPECT_EQ(1u, hot_locations[0].count("loc_second"));
+    EXPECT_EQ(1u, persistent_locations[0].count("loc_second"));
+
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.DeleteLocationsForMaintenance(
+                  request_context_.get(), {888}, {{"loc_second"}}, reclaimed_count));
+    EXPECT_EQ(1, reclaimed_count);
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteDefersDuringCachedRecovery) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_recover_guard";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_recover_guard", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    auto batch = MakeBatch({889});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
+    int32_t reclaimed_count = 0;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OUT_OF_LIMIT}),
+              mgr.DeleteLocationsForMaintenance(
+                  request_context_.get(), {889}, {{"loc_889"}}, reclaimed_count));
+    EXPECT_EQ(0, reclaimed_count);
+
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning);
+    CacheLocationMapVector remaining;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.GetLocations(nullptr, {889}, remaining));
+    ASSERT_EQ(1u, remaining.size());
+    EXPECT_EQ(1u, remaining[0].count("loc_889"));
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteConvergesHotCopyAfterPersistentNoent) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_persistent_noent";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_persistent_noent", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    auto batch = MakeBatch({890});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.persistent_backend_->Delete(nullptr, {890}));
+
+    int32_t reclaimed_count = 0;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.DeleteLocationsForMaintenance(
+                  request_context_.get(), {890}, {{"loc_890"}}, reclaimed_count));
+    EXPECT_EQ(1, reclaimed_count);
+
+    CacheLocationMapVector hot_locations;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_NOENT}), mgr.cache_backend_->GetLocations(nullptr, {890}, hot_locations));
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceReadRejectsNewerPersistentValueBehindStaleHotCache) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_persistent_newer";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_persistent_newer", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    auto stale = MakeBatch({1000});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), stale));
+    const std::string location_id = "loc_1000";
+
+    CacheLocationMapVector newer_locations(1);
+    PropertyMapVector newer_properties(1);
+    newer_locations[0].emplace(location_id, MakeLocation(location_id, "uri_1000_newer"));
+    newer_properties[0]["p0"] = "p0_1000";
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.persistent_backend_->Put(request_context_.get(), {1000}, newer_locations, newer_properties));
+
+    LocationsPerKey values;
+    EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}),
+              mgr.GetLocationsForMaintenance(nullptr, {1000}, {{location_id}}, values));
+    ASSERT_EQ(1u, values.size());
+    ASSERT_EQ(1u, values.front().size());
+    EXPECT_FALSE(values.front().front());
+
+    LocationsPerKey hot_values;
+    LocationsPerKey persistent_values;
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}),
+              mgr.cache_backend_->GetLocationsForMaintenance(nullptr, {1000}, {{location_id}}, hot_values));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}),
+              mgr.persistent_backend_->GetLocationsForMaintenance(nullptr, {1000}, {{location_id}}, persistent_values));
+    EXPECT_NE(hot_values[0][0]->ToJsonString(), persistent_values[0][0]->ToJsonString());
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteDoesNotReclaimAcrossDivergentLayers) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_divergent_layers";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_divergent", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    BatchMetaData complete;
+    complete.batch_keys = {1001, 1002};
+    complete.batch_indexs = {0, 1};
+    complete.batch_locations.resize(2);
+    complete.batch_properties.resize(2);
+    for (size_t i = 0; i < complete.batch_keys.size(); ++i) {
+        const auto suffix = std::to_string(complete.batch_keys[i]);
+        complete.batch_locations[i].emplace("target_" + suffix,
+                                            MakeLocation("target_" + suffix, "uri_target_" + suffix));
+        complete.batch_locations[i].emplace("other_" + suffix, MakeLocation("other_" + suffix, "uri_other_" + suffix));
+        complete.batch_properties[i]["p0"] = "p0_" + suffix;
+    }
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), mgr.Put(request_context_.get(), complete));
+
+    // key 1001 has a sibling only in hot; key 1002 has a sibling only in persistent.
+    CacheLocationMapVector target_only_locations(1);
+    PropertyMapVector target_only_properties(1);
+    target_only_locations[0].emplace("target_1001", complete.batch_locations[0].at("target_1001"));
+    target_only_properties[0]["p0"] = "p0_1001";
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.persistent_backend_->Put(nullptr, {1001}, target_only_locations, target_only_properties));
+    target_only_locations[0].clear();
+    target_only_properties[0].clear();
+    target_only_locations[0].emplace("target_1002", complete.batch_locations[1].at("target_1002"));
+    target_only_properties[0]["p0"] = "p0_1002";
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.cache_backend_->Put(nullptr, {1002}, target_only_locations, target_only_properties));
+
+    int32_t reclaimed_count = 0;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              mgr.DeleteLocationsForMaintenance(
+                  request_context_.get(), {1001, 1002}, {{"target_1001"}, {"target_1002"}}, reclaimed_count));
+    EXPECT_EQ(0, reclaimed_count);
+
+    CacheLocationMapVector persistent_locations;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              mgr.persistent_backend_->GetLocations(nullptr, {1001, 1002}, persistent_locations));
+    EXPECT_TRUE(persistent_locations[0].empty());
+    EXPECT_EQ(1u, persistent_locations[1].count("other_1002"));
+    CacheLocationMapVector hot_locations;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}),
+              mgr.cache_backend_->GetLocations(nullptr, {1001, 1002}, hot_locations));
+    EXPECT_EQ(1u, hot_locations[0].count("other_1001"));
+    EXPECT_TRUE(hot_locations[1].empty());
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceWholeKeyDeleteFailureRemainsRetryable) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_whole_key_retry";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_whole_key_retry", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    ASSERT_EQ(EC_OK, mgr.persistent_backend_->Close());
+    auto failing_backend = std::make_unique<FailOnceWholeKeyDeleteBackend>();
+    ASSERT_EQ(EC_OK, failing_backend->Init("inst_maintenance_whole_key_retry", MakeSingleConfig(path + "_failing")));
+    ASSERT_EQ(EC_OK, failing_backend->Open());
+    auto *failing_backend_ptr = failing_backend.get();
+    mgr.persistent_backend_ = std::move(failing_backend);
+
+    auto batch = MakeBatch({1003});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.Put(request_context_.get(), batch));
+    failing_backend_ptr->FailNextDelete();
+
+    int32_t reclaimed_count = 0;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_ERROR}),
+              mgr.DeleteLocationsForMaintenance(request_context_.get(), {1003}, {{"loc_1003"}}, reclaimed_count));
+    EXPECT_EQ(0, reclaimed_count);
+    CacheLocationMapVector hot_locations;
+    CacheLocationMapVector persistent_locations;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->GetLocations(nullptr, {1003}, hot_locations));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.persistent_backend_->GetLocations(nullptr, {1003}, persistent_locations));
+    EXPECT_EQ(1u, hot_locations[0].count("loc_1003"));
+    EXPECT_EQ(1u, persistent_locations[0].count("loc_1003"));
+
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.DeleteLocationsForMaintenance(request_context_.get(), {1003}, {{"loc_1003"}}, reclaimed_count));
+    EXPECT_EQ(1, reclaimed_count);
+    std::vector<bool> exists;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, {1003}, exists));
+    EXPECT_EQ((std::vector<bool>{false}), exists);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.persistent_backend_->Exists(nullptr, {1003}, exists));
+    EXPECT_EQ((std::vector<bool>{false}), exists);
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 

--- a/kv_cache_manager/meta/types.h
+++ b/kv_cache_manager/meta/types.h
@@ -56,9 +56,9 @@ using LocationsPerKey = std::vector<CacheLocationVector>;
 // explicit handle release. These views must never escape that interval.
 using CacheLocationViewVector = std::vector<const CacheLocation *>;
 
-// A maintenance scan reads keys and their locations from the authoritative
-// backend without updating online access/LRU state. The three vectors are
-// always index-aligned when the scan succeeds.
+// A maintenance scan reads keys and locations from the backend selected by
+// MetaStorageBackendManager without updating online access/LRU state. The
+// three vectors are always index-aligned when the scan succeeds.
 struct MaintenanceScanBatch {
     std::string next_cursor;
     KeyVector keys;

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -176,12 +176,16 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_gc, scan_round_count);
     DECLARE_METRICS(cache_gc, scan_key_count);
     DECLARE_METRICS(cache_gc, candidate_count);
+    DECLARE_METRICS(cache_gc, candidate_dropped_count);
     DECLARE_METRICS(cache_gc, delete_target_count);
     DECLARE_METRICS(cache_gc, delete_result_count);
     DECLARE_METRICS(cache_gc, operation_error_count);
     DECLARE_METRICS(cache_gc, inflight_delete_count);
     DECLARE_METRICS(cache_gc, inflight_delete_age_ms);
     DECLARE_METRICS(cache_gc, round_duration_ms);
+    DECLARE_METRICS(cache_gc, event_report_probe_count);
+    DECLARE_METRICS(cache_gc, event_report_probe_unknown_count);
+    DECLARE_METRICS(cache_gc, event_report_delete_location_count);
 
     // cache manager
     DECLARE_METRICS(cache_manager, write_location_expire_size);
@@ -461,12 +465,16 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_gc, scan_round_count);
     REGISTER_GAUGE_METRIC(cache_gc, scan_key_count);
     REGISTER_GAUGE_METRIC(cache_gc, candidate_count);
+    REGISTER_GAUGE_METRIC(cache_gc, candidate_dropped_count);
     REGISTER_GAUGE_METRIC(cache_gc, delete_target_count);
     REGISTER_GAUGE_METRIC(cache_gc, delete_result_count);
     REGISTER_GAUGE_METRIC(cache_gc, operation_error_count);
     REGISTER_GAUGE_METRIC(cache_gc, inflight_delete_count);
     REGISTER_GAUGE_METRIC(cache_gc, inflight_delete_age_ms);
     REGISTER_GAUGE_METRIC(cache_gc, round_duration_ms);
+    REGISTER_GAUGE_METRIC(cache_gc, event_report_probe_count);
+    REGISTER_GAUGE_METRIC(cache_gc, event_report_probe_unknown_count);
+    REGISTER_GAUGE_METRIC(cache_gc, event_report_delete_location_count);
 
     // cache manager
     REGISTER_GAUGE_METRIC(cache_manager, write_location_expire_size);
@@ -915,12 +923,20 @@ void KmonitorMetricsReporter::ReportInterval() {
         report_registry_metric(ctx_->cache_gc_scan_round_count_metrics.get(), "cache_gc.scan_round_count");
         report_registry_metric(ctx_->cache_gc_scan_key_count_metrics.get(), "cache_gc.scan_key_count");
         report_registry_metric(ctx_->cache_gc_candidate_count_metrics.get(), "cache_gc.candidate_count");
+        report_registry_metric(ctx_->cache_gc_candidate_dropped_count_metrics.get(),
+                               "cache_gc.candidate_dropped_count");
         report_registry_metric(ctx_->cache_gc_delete_target_count_metrics.get(), "cache_gc.delete_target_count");
         report_registry_metric(ctx_->cache_gc_delete_result_count_metrics.get(), "cache_gc.delete_result_count");
         report_registry_metric(ctx_->cache_gc_operation_error_count_metrics.get(), "cache_gc.operation_error_count");
         report_registry_metric(ctx_->cache_gc_inflight_delete_count_metrics.get(), "cache_gc.inflight_delete_count");
         report_registry_metric(ctx_->cache_gc_inflight_delete_age_ms_metrics.get(), "cache_gc.inflight_delete_age_ms");
         report_registry_metric(ctx_->cache_gc_round_duration_ms_metrics.get(), "cache_gc.round_duration_ms");
+        report_registry_metric(ctx_->cache_gc_event_report_probe_count_metrics.get(),
+                               "cache_gc.event_report_probe_count");
+        report_registry_metric(ctx_->cache_gc_event_report_probe_unknown_count_metrics.get(),
+                               "cache_gc.event_report_probe_unknown_count");
+        report_registry_metric(ctx_->cache_gc_event_report_delete_location_count_metrics.get(),
+                               "cache_gc.event_report_delete_location_count");
     } while (false);
 
     do {

--- a/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
@@ -111,6 +111,12 @@ TEST_F(KmonitorMetricsReporterTest, TestReportInterval) {
         metrics_registry_->GetCounter("cache_gc.delete_result_count", {{"status", "0"}}) += 1;
         metrics_registry_->GetCounter("cache_gc.operation_error_count", {{"stage", "scan"}}) += 1;
         metrics_registry_->GetGauge("cache_gc.inflight_delete_count") = 2;
+        metrics_registry_->GetCounter("cache_gc.candidate_dropped_count",
+                                      {{"reason", "event_report_down_host"}, {"cause", "total_budget"}}) += 1;
+        metrics_registry_->GetCounter("cache_gc.event_report_probe_count", {{"result", "delete"}}) += 2;
+        metrics_registry_->GetCounter("cache_gc.event_report_probe_unknown_count", {{"cause", "malformed"}}) += 1;
+        metrics_registry_->GetCounter("cache_gc.event_report_delete_location_count",
+                                      {{"reason", "down_host"}, {"status", "deleted"}}) += 2;
         EXPECT_NO_FATAL_FAILURE(reporter_->ReportInterval());
     }
 

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/service/admin_service_impl.h"
 
+#include <map>
 #include <memory>
 #include <shared_mutex>
 #include <string>
@@ -17,6 +18,7 @@
 #include "kv_cache_manager/config/node_endpoint_info.h"
 #include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/manager/cache_manager.h"
 #include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
 #include "kv_cache_manager/metrics/metrics_lifecycle.h"
@@ -75,6 +77,29 @@
 namespace {
 kv_cache_manager::proto::admin::ErrorCode ToAdminPbError(kv_cache_manager::ErrorCode ec) {
     return kv_cache_manager::ToPbError<kv_cache_manager::proto::admin::ErrorCode>(ec);
+}
+
+bool HasUniqueEventReportOwnerPerType(const std::shared_ptr<kv_cache_manager::RegistryManager> &registry_manager,
+                                      const kv_cache_manager::InstanceGroup &group,
+                                      std::string &invalid_fields) {
+    const auto storage_manager = registry_manager ? registry_manager->data_storage_manager() : nullptr;
+    if (!storage_manager) {
+        return true;
+    }
+    std::map<kv_cache_manager::DataStorageType, std::string> owner_by_type;
+    for (const auto &storage_name : group.event_report_storage_candidates()) {
+        const auto backend = std::dynamic_pointer_cast<kv_cache_manager::EventReportBackend>(
+            storage_manager->GetDataStorageBackend(storage_name));
+        if (!backend) {
+            continue;
+        }
+        const auto [it, inserted] = owner_by_type.emplace(backend->GetStorageType(), storage_name);
+        if (!inserted && it->second != storage_name) {
+            invalid_fields += "{InstanceGroup: {event_report_storage_candidates_duplicate_type}}";
+            return false;
+        }
+    }
+    return true;
 }
 } // anonymous namespace
 
@@ -285,6 +310,9 @@ void AdminServiceImpl::CreateInstanceGroup(RequestContext *request_context,
         CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("CreateInstanceGroup", "InstanceGroup", false);
         return;
     }
+    if (!HasUniqueEventReportOwnerPerType(registry_manager_, instance_group_req, invalid_fields)) {
+        CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("CreateInstanceGroup", "InstanceGroup", false);
+    }
     ErrorCode ec_info = registry_manager_->CreateInstanceGroup(request_context, instance_group_req);
     if (ec_info != EC_OK) {
         status->set_code(proto::admin::INTERNAL_ERROR);
@@ -314,6 +342,9 @@ void AdminServiceImpl::UpdateInstanceGroup(RequestContext *request_context,
     }
     ProtoConvert::InstanceGroupFromProto(&request->instance_group(), instance_group_req);
     if (!instance_group_req.ValidateRequiredFields(invalid_fields)) {
+        CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("UpdateInstanceGroup", "InstanceGroup", false);
+    }
+    if (!HasUniqueEventReportOwnerPerType(registry_manager_, instance_group_req, invalid_fields)) {
         CHECK_REQUIRED_FIELDS_VALIDATION_AND_RETURN("UpdateInstanceGroup", "InstanceGroup", false);
     }
     ErrorCode ec_info =

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -74,6 +74,9 @@ bool Server::Init(const ServerConfig &config) {
     cache_gc_config.scan_batch_size = static_cast<size_t>(config_.GetCacheGcScanBatchSize());
     cache_gc_config.orphan_writing_grace_period_ms = config_.GetCacheGcOrphanWritingGracePeriodMs();
     cache_gc_config.max_inflight_delete_requests = static_cast<size_t>(config_.GetCacheGcMaxInflightDeleteRequests());
+    cache_gc_config.event_report_cleanup_enabled = config_.IsCacheGcEventReportCleanupEnabled();
+    cache_gc_config.event_report_action_batch_size =
+        static_cast<size_t>(config_.GetCacheGcEventReportActionBatchSize());
     if (!cache_manager_->Init(config_.GetSchedulePlanExecutorThreadCount(),
                               config_.GetCacheReclaimerKeySamplingSizeTotal(),
                               config_.GetCacheReclaimerKeySamplingSizePerTask(),

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -230,6 +230,16 @@ std::unordered_map<std::string, ServerConfig::SettingFunction> ServerConfig::kSe
          config->cache_gc_max_inflight_delete_requests_ = std::stoull(value);
          return true;
      }},
+    {"kvcm.cache_gc.event_report_cleanup_enabled",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_event_report_cleanup_enabled_ = value == "true";
+         return value == "true" || value == "false";
+     }},
+    {"kvcm.cache_gc.event_report_action_batch_size",
+     [](const std::string &value, ServerConfig *config) {
+         config->cache_gc_event_report_action_batch_size_ = std::stoull(value);
+         return true;
+     }},
     {"kvcm.metrics.reporter_type",
      [](const std::string &value, ServerConfig *config) {
          config->metrics_reporter_type_ = value;
@@ -312,12 +322,14 @@ void ServerConfig::UpdateDefaultConfig() {
     cache_reclaimer_pending_bytes_limit_per_group_type_ = 64ULL * 1024 * 1024 * 1024;
     cache_reclaimer_pending_delete_handler_limit_ = 1024;
     cache_reclaimer_pending_bytes_limit_ = 256ULL * 1024 * 1024 * 1024;
-    cache_gc_enabled_ = false;
+    cache_gc_enabled_ = true;
     cache_gc_scan_interval_ms_ = 1000;
-    cache_gc_round_pause_ms_ = 24LL * 60 * 60 * 1000;
+    cache_gc_round_pause_ms_ = 2LL * 60 * 60 * 1000;
     cache_gc_scan_batch_size_ = 256;
     cache_gc_orphan_writing_grace_period_ms_ = 24LL * 60 * 60 * 1000;
     cache_gc_max_inflight_delete_requests_ = 2;
+    cache_gc_event_report_cleanup_enabled_ = true;
+    cache_gc_event_report_action_batch_size_ = 32;
 }
 
 bool ServerConfig::ParseFromFile(const std::string &config_file) {
@@ -463,18 +475,19 @@ bool ServerConfig::Check() {
     }
 
     if (cache_gc_enabled_ &&
-        (cache_gc_scan_interval_ms_ <= 0 || cache_gc_round_pause_ms_ <= 0 || cache_gc_scan_batch_size_ == 0 ||
+        (cache_gc_scan_interval_ms_ <= 0 || cache_gc_round_pause_ms_ < 0 || cache_gc_scan_batch_size_ == 0 ||
          cache_gc_scan_batch_size_ > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
          cache_gc_max_inflight_delete_requests_ == 0 ||
          cache_gc_max_inflight_delete_requests_ > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
-         cache_gc_orphan_writing_grace_period_ms_ < kMinCacheGcOrphanWritingGracePeriodMs)) {
+         cache_gc_orphan_writing_grace_period_ms_ < kMinCacheGcOrphanWritingGracePeriodMs ||
+         (cache_gc_event_report_cleanup_enabled_ && cache_gc_event_report_action_batch_size_ == 0))) {
         fprintf(stderr,
-                "Cache GC intervals, batch size and max in-flight requests must be greater than zero, and orphan "
-                "WRITING grace must be at least %ldms\n",
+                "Cache GC scan interval, batch size and max in-flight requests must be greater than zero; round "
+                "pause must be non-negative; orphan WRITING grace must be at least %ldms; EventReport action "
+                "batch size must be greater than zero when enabled\n",
                 kMinCacheGcOrphanWritingGracePeriodMs);
         return false;
     }
-
     return true;
 }
 

--- a/kv_cache_manager/service/server_config.h
+++ b/kv_cache_manager/service/server_config.h
@@ -59,6 +59,8 @@ public:
     uint64_t GetCacheGcScanBatchSize() const { return cache_gc_scan_batch_size_; }
     int64_t GetCacheGcOrphanWritingGracePeriodMs() const { return cache_gc_orphan_writing_grace_period_ms_; }
     uint64_t GetCacheGcMaxInflightDeleteRequests() const { return cache_gc_max_inflight_delete_requests_; }
+    bool IsCacheGcEventReportCleanupEnabled() const { return cache_gc_event_report_cleanup_enabled_; }
+    uint64_t GetCacheGcEventReportActionBatchSize() const { return cache_gc_event_report_action_batch_size_; }
     const std::string &metrics_reporter_type() { return metrics_reporter_type_; }
     const std::string &metrics_reporter_config() { return metrics_reporter_config_; }
     int64_t metrics_report_interval_ms() { return metrics_report_interval_ms_; }
@@ -113,12 +115,14 @@ private:
     uint64_t cache_reclaimer_pending_bytes_limit_per_group_type_ = 0;
     uint64_t cache_reclaimer_pending_delete_handler_limit_ = 0;
     uint64_t cache_reclaimer_pending_bytes_limit_ = 0;
-    bool cache_gc_enabled_ = false;
+    bool cache_gc_enabled_ = true;
     int64_t cache_gc_scan_interval_ms_ = 0;
     int64_t cache_gc_round_pause_ms_ = 0;
     uint64_t cache_gc_scan_batch_size_ = 0;
     int64_t cache_gc_orphan_writing_grace_period_ms_ = 0;
     uint64_t cache_gc_max_inflight_delete_requests_ = 0;
+    bool cache_gc_event_report_cleanup_enabled_ = true;
+    uint64_t cache_gc_event_report_action_batch_size_ = 0;
     std::string metrics_reporter_type_ = "local";
     std::string metrics_reporter_config_;
     int64_t metrics_report_interval_ms_ = 0;

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -30,11 +30,12 @@ TEST_F(ServerConfigTest, TestSimple) {
         ASSERT_EQ(64ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimitPerGroupType());
         ASSERT_EQ(1024, config.GetCacheReclaimerPendingDeleteHandlerLimit());
         ASSERT_EQ(256ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimit());
-        ASSERT_FALSE(config.IsCacheGcEnabled());
+        ASSERT_TRUE(config.IsCacheGcEnabled());
         ASSERT_EQ(1000, config.GetCacheGcScanIntervalMs());
-        ASSERT_EQ(86400000, config.GetCacheGcRoundPauseMs());
+        ASSERT_EQ(7200000, config.GetCacheGcRoundPauseMs());
         ASSERT_EQ(256, config.GetCacheGcScanBatchSize());
         ASSERT_EQ(86400000, config.GetCacheGcOrphanWritingGracePeriodMs());
+        ASSERT_TRUE(config.IsCacheGcEventReportCleanupEnabled());
     }
     // config_file not exist
     {
@@ -240,6 +241,8 @@ TEST_F(ServerConfigTest, TestCacheGcConfig) {
         {"kvcm.cache_gc.scan_batch_size", "7"},
         {"kvcm.cache_gc.orphan_writing_grace_period_ms", "3600000"},
         {"kvcm.cache_gc.max_inflight_delete_requests", "3"},
+        {"kvcm.cache_gc.event_report_cleanup_enabled", "true"},
+        {"kvcm.cache_gc.event_report_action_batch_size", "5"},
     };
     ASSERT_TRUE(config.Parse("", environ));
     ASSERT_TRUE(config.Check());
@@ -249,6 +252,18 @@ TEST_F(ServerConfigTest, TestCacheGcConfig) {
     EXPECT_EQ(7, config.GetCacheGcScanBatchSize());
     EXPECT_EQ(3600000, config.GetCacheGcOrphanWritingGracePeriodMs());
     EXPECT_EQ(3, config.GetCacheGcMaxInflightDeleteRequests());
+    EXPECT_TRUE(config.IsCacheGcEventReportCleanupEnabled());
+    EXPECT_EQ(5, config.GetCacheGcEventReportActionBatchSize());
+
+    environ["kvcm.cache_gc.round_pause_ms"] = "0";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_TRUE(config.Check());
+
+    environ["kvcm.cache_gc.round_pause_ms"] = "-1";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_FALSE(config.Check());
+
+    environ["kvcm.cache_gc.round_pause_ms"] = "456";
 
     environ["kvcm.cache_gc.orphan_writing_grace_period_ms"] = "3599999";
     ASSERT_TRUE(config.Parse("", environ));
@@ -268,7 +283,23 @@ TEST_F(ServerConfigTest, TestCacheGcConfig) {
     ASSERT_TRUE(config.Parse("", environ));
     EXPECT_FALSE(config.Check());
 
+    environ["kvcm.cache_gc.max_inflight_delete_requests"] = "3";
+    environ["kvcm.cache_gc.event_report_action_batch_size"] = "0";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_FALSE(config.Check());
+
+    environ["kvcm.cache_gc.event_report_action_batch_size"] = "8";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_TRUE(config.Check());
+
+    environ["kvcm.cache_gc.event_report_action_batch_size"] = "5";
     environ["kvcm.cache_gc.enabled"] = "false";
+    ASSERT_TRUE(config.Parse("", environ));
+    EXPECT_TRUE(config.Check());
+    EXPECT_FALSE(config.IsCacheGcEnabled());
+    EXPECT_TRUE(config.IsCacheGcEventReportCleanupEnabled());
+
+    environ["kvcm.cache_gc.event_report_cleanup_enabled"] = "false";
     ASSERT_TRUE(config.Parse("", environ));
     EXPECT_TRUE(config.Check());
 }

--- a/package/etc/default_server_config.conf
+++ b/package/etc/default_server_config.conf
@@ -89,19 +89,24 @@ kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
 kvcm.cache_reclaimer.pending_delete_handler_limit=1024
 kvcm.cache_reclaimer.pending_bytes_limit=274877906944
 
-# 后台 metadata GC 默认关闭；只在 leader 上运行。处理长期 WRITING，
-# 以及 MightExist 明确 missing 的普通 SERVING Location（EventReport 除外）
-kvcm.cache_gc.enabled=false
+# 后台 metadata GC 默认开启，只在 leader 上运行。处理长期 WRITING、
+# MightExist 明确 missing 的普通 SERVING 以及 EventReport metadata 回收。
+kvcm.cache_gc.enabled=true
 # active round 每个 tick 最多扫描一个 batch
 kvcm.cache_gc.scan_interval_ms=1000
-# 完成一轮全量扫描后的休眠时间，默认 24 小时
-kvcm.cache_gc.round_pause_ms=86400000
-# backend 扫描 batch hint，同时限制单次提交的 Location 数
+# 完成一轮全量扫描后的休眠时间，默认 2 小时；0 表示下一 tick 可开始新一轮
+kvcm.cache_gc.round_pause_ms=7200000
+# backend 扫描 batch hint，同时限制单 tick 两类 action 合计的 Location 数
 kvcm.cache_gc.scan_batch_size=256
 # 自动清理 CLS_WRITING 的 grace，最小 1 小时（3600000ms），默认 24 小时
 kvcm.cache_gc.orphan_writing_grace_period_ms=86400000
-# GC 在途删除请求硬上限；默认 2
+# 普通删除与 EventReport metadata action 共用的 GC 在途硬上限；默认 2
 kvcm.cache_gc.max_inflight_delete_requests=2
+# Reconcile EventReport metadata from backend state during the regular GC round.
+# Enabled by default when the parent GC switch is on; parent off keeps the legacy path.
+kvcm.cache_gc.event_report_cleanup_enabled=true
+# Maximum EventReport metadata-only Block keys submitted by one GC tick.
+kvcm.cache_gc.event_report_action_batch_size=32
 
 # 重访间隔统计的桶边界（秒），逗号分隔，必须严格升序
 # 默认值：1,5,30,60,120,180,300,600,900,1800,3600,21600,86400（13个边界，14个桶含+Inf）


### PR DESCRIPTION
## 背景

EventReport 原来会在每次 Snapshot 成功、HOST_DOWN 或存活超时后投递一次 Instance 全量 metadata 扫描。事件密集或反复重试时，扫描成本会放大为“事件数 × keyspace”，并与删除、迁移任务争用共享 Executor。

本 PR 基于已合入的 #244，将 EventReport 回收改为状态驱动的周期 reconciliation：Snapshot、Heartbeat、REGISTER 和 HOST_DOWN 只更新 `EventReportBackend` 的当前状态；后台 GC 在普通 full round 中一次扫描 metadata，同时执行 orphan WRITING、普通 SERVING MightExist 和 EventReport 判定，不再维护 cleanup intent 或第二套扫描 lane。

## 主要改动

- 复用 shared GC scan，并在一个 round 内按 Instance batch round-robin 推进 cursor；cached metadata 模式优先扫描完整的内存 index，扫描和维护读均不更新 LRU/access/hit/revisit，也不回填 hot cache。
- `EventReportBackend` 提供批量三态判定：`Keep / DeleteMetadata / Unknown`。支持 stale Snapshot generation、显式/超时 HOST_DOWN 和重启后 absent Reporter；malformed、状态缺失、Backend 不可用或结果不确定时一律 fail-closed。
- 保留现有两阶段 liveness 语义：heartbeat timeout 后先对查询不可见，cleanup grace 到期并完成 generation-checked unregister 后才允许删除。recovery grace 由 Backend 自己维护，不暂停普通 GC 规则。
- 新建/更新 InstanceGroup 时拒绝同一 EventReport storage type 的多个 owner；存量歧义、owner 缺失或 unavailable 时 GC 返回 `Unknown`。Location URI 尚不携带 Backend unique id，因此 V1 不支持 owner A → B 的静默切换。
- EventReport action 提交到共享 `SchedulePlanExecutor` worker，在真正执行时重新校验 Backend identity、cleanup token 和 lifecycle lease，再通过完整 expected Location value 执行 metadata-only no-touch RMW；不进入 `CLS_DELETING`，也不触发 DataStorage 物理 DELETE。
- 普通删除和 EventReport action 共用 GC 的 inflight window、pending 去重和 Executor worker。EventReport budget 按唯一 Block key 计数，Location 总量仍受 scan batch 限制；V1 不扩展 Executor 全局队列上限，也不新增 deferred queue。
- 默认 `round_pause_ms` 调整为 2 小时并允许配置为 0；配置仍遵循现有 ServerConfig 的启动时生效语义。EventReport cleanup 是周期最终收敛，不承诺 per-event 即时清理。
- 补充 Backend owner、三态 probe、token/lease fencing、双层 metadata compare、no-touch charge accounting、Instance 公平调度、反压、指标和 E2E 覆盖，并同步设计与 API 文档。

## 正确性边界

- cleanup 严格保持 Instance 隔离；任意不确定状态均不授权删除。
- Snapshot committed/in-flight generation、attempt epoch、Reporter lifecycle generation 和 Backend incarnation 在 action time 再次复核。
- hot 与 persistent 同时存在但值不一致时返回 mismatch；整 key 删除必须确认两层都不存在非目标 sibling Location。
- EventReport 只删除 metadata；普通 WRITING/SERVING GC 和物理删除语义保持不变。

---

## Background

EventReport previously submitted an instance-wide metadata scan after every successful Snapshot, HOST_DOWN, or liveness timeout. Under event bursts or retries, the cost grew as “number of events × keyspace” and competed with deletion and migration work in the shared Executor.

Building on the merged #244, this PR changes EventReport cleanup to state-driven periodic reconciliation. Snapshot, Heartbeat, REGISTER, and HOST_DOWN only update the current `EventReportBackend` state. The resident GC evaluates orphan WRITING, ordinary SERVING MightExist, and EventReport cleanup during the same full metadata round, without a cleanup-intent map or a second scan lane.

## Main changes

- Reuse the shared GC scan and rotate Instance cursors by batch within each round. Cached-metadata mode scans the complete in-memory index first. Maintenance scan/read operations do not touch LRU, access, hit, or revisit state and do not backfill the hot cache.
- Add batched `Keep / DeleteMetadata / Unknown` decisions in `EventReportBackend` for stale Snapshot generations, explicit/timed-out HOST_DOWN, and absent Reporters after recovery. Malformed, missing, unavailable, or uncertain state fails closed.
- Preserve the existing two-stage liveness contract: heartbeat timeout first hides a Reporter from queries; cleanup becomes eligible only after cleanup grace and generation-checked unregister. Backend-owned recovery grace does not pause ordinary GC rules.
- Reject multiple owners of the same EventReport storage type for newly created or updated InstanceGroups. Existing ambiguity, missing owners, or unavailable owners produce `Unknown`. Since Location URIs do not yet encode a Backend unique ID, silent owner switching from A to B is unsupported in V1.
- Submit EventReport actions to the shared `SchedulePlanExecutor` worker. At execution time it revalidates Backend identity, cleanup token, and lifecycle lease, then performs a metadata-only no-touch RMW using the full expected Location value. It neither enters `CLS_DELETING` nor issues a physical DataStorage DELETE.
- Share the GC inflight window, pending de-duplication, and Executor workers with ordinary deletion. EventReport action budget counts unique Block keys, while total Locations remain bounded by the scan batch. V1 does not add an Executor-wide queue limit or a deferred candidate queue.
- Change the default `round_pause_ms` to two hours and allow zero. Configuration keeps the existing startup-time ServerConfig semantics. EventReport cleanup provides periodic eventual convergence rather than per-event immediate cleanup.
- Add coverage and observability for owner routing, three-state probes, token/lease fencing, dual-layer metadata comparison, no-touch charge accounting, Instance fairness, backpressure, and E2E behavior; update the design and API documentation accordingly.

## Correctness boundaries

- Cleanup remains strictly Instance-isolated, and uncertainty never authorizes deletion.
- Snapshot committed/in-flight generation, attempt epoch, Reporter lifecycle generation, and Backend incarnation are revalidated at action time.
- A hot/persistent value mismatch is rejected, and whole-key reclamation requires both layers to contain no non-target sibling Location.
- EventReport cleanup removes metadata only; ordinary WRITING/SERVING GC and physical deletion semantics remain unchanged.
