### PR TITLE
[metrics] add per-storage data_storage.write_bytes_dispatched_total counter

### DIFF
--- a/kv_cache_manager/data_storage/data_storage_manager.cc
+++ b/kv_cache_manager/data_storage/data_storage_manager.cc
@@ -307,4 +307,23 @@ std::vector<ErrorCode> DataStorageManager::UnLock(const std::string &unique_name
     auto storage_backend = iter->second;
     return storage_backend->UnLock(storage_uris);
 }
+
+void DataStorageManager::RecordWriteBytes(const std::string &unique_name, std::uint64_t bytes) {
+    if (bytes == 0) {
+        return;
+    }
+    std::shared_lock<std::shared_mutex> lock(rw_lock_);
+    auto iter = storage_map_.find(unique_name); // iter->second 指向 DataStorageBackend 对象
+    if (iter == storage_map_.end() || iter->second == nullptr) {
+        KVCM_LOG_WARN("RecordWriteBytes: storage [%s] not found, drop %llu bytes",
+                      unique_name.c_str(), static_cast<unsigned long long>(bytes));
+        return;
+    }
+    const auto collector = iter->second->GetMetricsCollector(); // 指向 DataStorageMetricsCollector 对象
+    if (collector == nullptr) {
+        return;
+    }
+    collector->AddWriteBytes(bytes);
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/data_storage_manager.h
+++ b/kv_cache_manager/data_storage/data_storage_manager.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <cstdint>
 
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/data_storage/data_storage_backend.h"
@@ -56,6 +57,10 @@ public:
     Exist(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris, bool fastpath = false);
     std::vector<ErrorCode> Lock(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
     std::vector<ErrorCode> UnLock(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
+
+    // 写入量统计统一入口：按 unique_name 找到 backend 的 collector 并累加预估写入字节数。
+    // 普通写入（StartWriteCache）与 Migration Copy 共用。
+    void RecordWriteBytes(const std::string &unique_name, std::uint64_t bytes);
 
 private:
     std::shared_ptr<DataStorageBackend> CreateStorageBackend(const DataStorageType &type);

--- a/kv_cache_manager/data_storage/data_storage_manager.h
+++ b/kv_cache_manager/data_storage/data_storage_manager.h
@@ -58,8 +58,12 @@ public:
     std::vector<ErrorCode> Lock(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
     std::vector<ErrorCode> UnLock(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
 
-    // 写入量统计统一入口：按 unique_name 找到 backend 的 collector 并累加预估写入字节数。
-    // 普通写入（StartWriteCache）与 Migration Copy 共用。
+    // 写入量统计统一入口：按 unique_name 找到 backend 的 collector 并累加。
+    // Adds `bytes` to the named storage's data_storage.write_bytes_dispatched_total
+    // counter. Dispatched-view semantics: callers invoke this once a write has been
+    // dispatched (locations handed to the client / copy task accepted by executor),
+    // NOT when bytes are confirmed written to the backend. See the metric definition
+    // in metrics/metrics_collector.h for the full semantic contract.
     void RecordWriteBytes(const std::string &unique_name, std::uint64_t bytes);
 
 private:

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1083,6 +1083,7 @@ CacheManager::StartWriteCache(RequestContext *request_context,
             for (const auto &add_result : add_results) {
                 location_ids.push_back(add_result.location_id);
             }
+            RecordWriteBytesForLocations(new_locations);  // 记录写入量
         }
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, StartWriteCacheInfo, "start write cache failed");
     }
@@ -2322,6 +2323,37 @@ ErrorCode CacheManager::GenWriteLocation(RequestContext *request_context,
         }
     }
     return EC_OK;
+}
+
+void CacheManager::RecordWriteBytesForLocations(const CacheLocationVector &locations) {
+    if (locations.empty()) {
+        return;
+    }
+    auto data_storage_manager = registry_manager_->data_storage_manager();
+    if (data_storage_manager == nullptr) {
+        return;
+    }
+    std::map<std::string, std::uint64_t> bytes_by_storage;
+    for (const auto &location : locations) {
+        if (location == nullptr) {
+            continue;
+        }
+        for (const auto &spec : location->location_specs()) {
+            const DataStorageUri uri = DataStorageUri::FromUri(spec.uri());
+            if (!uri.Valid() || uri.GetHostName().empty()) {
+                continue;
+            }
+            std::uint64_t size = 0;
+            uri.GetParamAs<std::uint64_t>("size", size);
+            if (size == 0) {
+                continue; // URI 无 size 参数或解析失败时 GetParamAs 保持 0，跳过
+            }
+            bytes_by_storage[uri.GetHostName()] += size;
+        }
+    }
+    for (const auto &[unique_name, bytes] : bytes_by_storage) {
+        data_storage_manager->RecordWriteBytes(unique_name, bytes);
+    }
 }
 
 namespace {

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -2326,6 +2326,9 @@ ErrorCode CacheManager::GenWriteLocation(RequestContext *request_context,
 }
 
 void CacheManager::RecordWriteBytesForLocations(const CacheLocationVector &locations) {
+    if (metrics_registry_ == nullptr) {
+        return;
+    }
     if (locations.empty()) {
         return;
     }

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -256,6 +256,10 @@ private:
                                const std::vector<std::string_view> &location_spec_group_names,
                                const std::vector<std::string> &tiered_targets,
                                CacheLocationVector &new_locations);
+    // 按 LocationSpec URI 汇总各 storage 的预估写入字节并记录到 per-storage 指标。
+    // URI 约定：hostname = storage unique_name（DataStorageManager::Create 设置），
+    // size 参数 = 该 spec 的字节数（各 backend Create 时写入）。解析失败的 spec 跳过。
+    void RecordWriteBytesForLocations(const CacheLocationVector &locations);
     // 在指定 storage 上为 keys 分配写 location（GenWriteLocation 的单 storage 分配单元，
     // 供多层存储 Mark 路径按 block 路由到不同 storage 复用）。out_locations 与 keys 同序追加。
     ErrorCode GenWriteLocationOnStorage(RequestContext *request_context,

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -1305,6 +1305,11 @@ void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
                       block_key);
         return;
     }
+
+    if (metrics_enabled_) {
+        data_storage_manager_->RecordWriteBytes(ctx.dst_storage_name, ctx.total_bytes);
+    }
+
     if (claim == ClaimResult::kWasCancelling) {
         // 用户已取消。copy 虽成功也丢弃：不 promote、不删源，删掉仍为 WRITING 的目标半成品。
         CompleteCancelledTask(ctx);

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -751,6 +751,10 @@ ErrorCode MigrationManager::Submit(const std::string &trace_id, MigrationRequest
     stat_copy_submitted_.fetch_add(1, std::memory_order_relaxed);
     if (metrics_enabled_) {
         ++m_tasks_submitted_total_;
+        // 统一口径：copy 任务成功提交 executor（派发不可逆完成）即计入，
+        // 与普通写路径（StartWriteCache 在 BatchAddLocation 成功后、location 交付
+        // client 前）的统计点对成；之后的取消/copy 失败/源丢失均不影响该计数。
+        data_storage_manager_->RecordWriteBytes(ctx.dst_storage_name, ctx.total_bytes);
     }
     if (event_manager_ != nullptr) {
         auto ev = std::make_shared<MigrationSubmittedEvent>(ctx.instance_id);
@@ -1220,6 +1224,8 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             stat_copy_submitted_.fetch_add(1, std::memory_order_relaxed);
             if (metrics_enabled_) {
                 ++m_tasks_submitted_total_;
+                // 与单条 Submit 同口径：任务成功提交 executor 即计入，后续结果不影响。
+                data_storage_manager_->RecordWriteBytes(ctx.dst_storage_name, ctx.total_bytes);
             }
             if (event_manager_ != nullptr) {
                 auto ev = std::make_shared<MigrationSubmittedEvent>(ctx.instance_id);
@@ -1304,10 +1310,6 @@ void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
                       instance_id.c_str(),
                       block_key);
         return;
-    }
-
-    if (metrics_enabled_) {
-        data_storage_manager_->RecordWriteBytes(ctx.dst_storage_name, ctx.total_bytes);
     }
 
     if (claim == ClaimResult::kWasCancelling) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -1004,7 +1004,7 @@ TEST_F(CacheManagerTest, TestStartWriteCacheRecordWriteBytes) {
                                                std::vector<LocationSpecGroup>()));
     // 取出统计的写入量
     auto get_write_bytes = [&]() {
-        return metrics_registry_->GetCounter("data_storage.write_bytes_total",
+        return metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total",
                                              {{"type", ToString(kDefaultStorageType)},
                                               {"unique_name", "nfs_01"}}).Get();
     };

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -992,6 +992,65 @@ TEST_F(CacheManagerTest, TestStartWriteDuplicateCache) {
     }
 }
 
+TEST_F(CacheManagerTest, TestStartWriteCacheRecordWriteBytes) {
+    auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    ASSERT_EQ(expected,
+              cache_manager_->RegisterInstance(request_context_.get(),
+                                               "default",
+                                               "test_instance",
+                                               64,
+                                               createLocationSpecInfos(),
+                                               createModelDeployment(),
+                                               std::vector<LocationSpecGroup>()));
+    // 取出统计的写入量
+    auto get_write_bytes = [&]() {
+        return metrics_registry_->GetCounter("data_storage.write_bytes_total",
+                                             {{"type", ToString(kDefaultStorageType)},
+                                              {"unique_name", "nfs_01"}}).Get();
+    };
+    // 成功写入
+    std::vector<int64_t> keys{1, 2, 3};
+    auto [ec, start_write_cache_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 1000);
+    ASSERT_EQ(EC_OK, ec);
+    ASSERT_EQ(3 * 4 * 512, get_write_bytes());  // 验证写入量
+
+    {// 部分写入成功场景，不新增写入量，写入量统计放在 BatchAddLoation 成功之后
+        auto meta_indexer = cache_manager_->meta_indexer_manager_->GetMetaIndexer("test_instance");
+        ASSERT_TRUE(meta_indexer);
+
+        // 先备份原设置
+        const auto orig_batch_size = meta_indexer->batch_key_size_;
+        const auto orig_max_key_count = meta_indexer->max_key_count_;
+        meta_indexer->batch_key_size_ = 1;
+        meta_indexer->max_key_count_ = meta_indexer->GetKeyCount() + 1;  // 已写入的key_count + 1，确保已经写入的是成功的
+
+        std::vector<int64_t> keys{1001, 1002};
+        while (GetShardIndex(keys[0], meta_indexer->mutex_shard_mask_) ==
+               GetShardIndex(keys[1], meta_indexer->mutex_shard_mask_)) {
+            ++keys[1];
+        }
+
+        auto [ec, start_write_cache_info] =
+            cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 1000);
+        EXPECT_EQ(EC_PARTIAL_OK, ec);
+        EXPECT_TRUE(start_write_cache_info.locations().cache_locations_view().empty());
+        ASSERT_EQ(3 * 4 * 512, get_write_bytes());  // 验证写入量
+
+        // 恢复现场
+        meta_indexer->batch_key_size_ = orig_batch_size;
+        meta_indexer->max_key_count_ = orig_max_key_count;
+    }
+
+    {// 重复写入
+        std::vector<int64_t> keys{1, 2};
+        auto [ec, start_write_cache_info] =
+            cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+        ASSERT_EQ(EC_OK, ec);
+        ASSERT_EQ(3 * 4 * 512, get_write_bytes());  // 验证写入量
+    }
+}
+
 // StartWriteCache with min_replica_count > 1 requires n_total >= min_replica_count to skip,
 // whereas min_replica_count=1 (default) skips with any 1 replica.
 // Also tests spec-group-aware filtering with location_spec_group_names.

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -1891,7 +1891,7 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCo
         return req;
     };
 
-    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, nullptr);
     mgr.DebugEnableCopySubmissionsForTest();
     preparing_reservation_stub::Reset();
     preparing_reservation_stub::g_manager = &mgr;
@@ -1920,6 +1920,14 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCo
     EXPECT_NE(std::string::npos,
               preparing_reservation_stub::g_deleted_uris.front().ToUriString().find(
                   StringUtil::Uint64ToHex(block_keys[failed_index])));
+
+    // 统一口径：add 成功项已提交 executor（stub pending future），计入其 4 字节；
+    // add 失败项（EC_NOSPC）已回滚且未提交，不计入。
+    EXPECT_EQ(4u,
+              metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total",
+                                            {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)},
+                                             {"unique_name", "cold_01"}})
+                  .Get());
 }
 
 // 真批量路径在 Create 阶段收到取消后，同样不能覆盖取消态或提交 copy。
@@ -2553,7 +2561,7 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
     mgr.DebugEnableCopySubmissionsForTest();
 
     auto get_write_bytes = [&]() {
-        return metrics_registry_->GetCounter("data_storage.write_bytes_total",
+        return metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total",
                               {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)},
                                {"unique_name", "cold_01"}}).Get();
     };
@@ -2570,7 +2578,10 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
         req.src_storage_name = "hot_01";
         req.dst_storage_name = "cold_01";
         ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+        // 统一口径：任务成功提交 executor 即计入（Submit 返回时已发生）
+        ASSERT_EQ(10u, get_write_bytes());
         mgr.OnTaskSuccess(kInstance, block_key);
+        // 完成回调不再重复计入
         ASSERT_EQ(10u, get_write_bytes());
         ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get());
     }
@@ -2587,11 +2598,12 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
         req.src_storage_name = "hot_01";
         req.dst_storage_name = "cold_01";
         ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+        ASSERT_EQ(20u, get_write_bytes()); // 提交 executor 即计入，累计：场景1的10 + 本次10
         // copy 进行中用户取消：任务标记 kCancelling，仍留在活跃表
         ASSERT_EQ(ErrorCode::EC_OK, mgr.Cancel(kInstance, block_key));
-        // 完成回调认领到 kWasCancelling：统计点先于取消分支执行，计入但不走主路径
+        // 完成回调认领到 kWasCancelling：不计入也不走主路径（计数在提交时已发生）
         mgr.OnTaskSuccess(kInstance, block_key);
-        ASSERT_EQ(20u, get_write_bytes()); // 累计：场景1的10 + 本次10
+        ASSERT_EQ(20u, get_write_bytes());
         ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get()); // 取消不 promote，不涨
     }
 
@@ -2607,8 +2619,10 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
         req.src_storage_name = "hot_01";
         req.dst_storage_name = "cold_01";
         ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+        // copy 失败仍计入：任务已提交 executor，失败属于派发未兑现（累计 20 + 10）
+        ASSERT_EQ(30u, get_write_bytes());
         mgr.OnTaskFailed(kInstance, block_key, ErrorCode::EC_IO_ERROR);
-        ASSERT_EQ(20u, get_write_bytes()); // copy 失败不计入，保持场景2结束时的累计值
+        ASSERT_EQ(30u, get_write_bytes()); // 失败回调不再影响计数
         ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get());
     }
 
@@ -2624,6 +2638,7 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
         req.src_storage_name = "hot_01";
         req.dst_storage_name = "cold_01";
         ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+        ASSERT_EQ(40u, get_write_bytes()); // 提交 executor 即计入，累计：30 + 10
 
         // 破坏源：把源 location 从 SERVING CAS 成 DELETING，模拟 copy 期间源被回收
         auto rc = std::make_shared<RequestContext>("break_source");
@@ -2633,9 +2648,9 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
         std::vector<std::vector<ErrorCode>> cas_results;
         ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchCASLocationStatus(rc.get(), {block_key}, cas, cas_results));
 
-        // 完成回调：统计点先于 IsSourceLocationServing 检查执行，计入后走 source_lost 失败收尾
+        // 完成回调：计数已在提交时发生；此处走 source_lost 失败收尾，不再影响计数
         mgr.OnTaskSuccess(kInstance, block_key);
-        ASSERT_EQ(30u, get_write_bytes()); // 累计：20 + 10
+        ASSERT_EQ(40u, get_write_bytes());
         ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get()); // 源丢失按失败收尾，不涨
     }
 

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -2539,6 +2539,108 @@ TEST_F(MigrationManagerTest, TestMetricsAndEvents) {
     ASSERT_DOUBLE_EQ(0.0, metrics_registry_->GetGauge("migration.tasks_active").Get());
 }
 
+TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "m_hot/"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "m_cold/"));
+
+    MigrationManager mgr(schedule_plan_executor_,
+                         meta_manager_,
+                         data_storage_manager_,
+                         metrics_registry_,
+                         nullptr);
+
+    mgr.DebugEnableCopySubmissionsForTest();
+
+    auto get_write_bytes = [&]() {
+        return metrics_registry_->GetCounter("data_storage.write_bytes_total",
+                              {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)},
+                               {"unique_name", "cold_01"}}).Get();
+    };
+
+    // 场景1：成功复制
+    {
+        int64_t block_key = 1000;
+        std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "abcdefghij");
+
+        MigrationManager::MigrationRequest req;
+        req.instance_id = kInstance;
+        req.block_key = block_key;
+        req.src_location_id = src_loc;
+        req.src_storage_name = "hot_01";
+        req.dst_storage_name = "cold_01";
+        ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+        mgr.OnTaskSuccess(kInstance, block_key);
+        ASSERT_EQ(10u, get_write_bytes());
+        ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get());
+    }
+
+    // 场景2：取消仍计入
+    {
+        int64_t block_key = 1001;
+        std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "abcdefghij");
+
+        MigrationManager::MigrationRequest req;
+        req.instance_id = kInstance;
+        req.block_key = block_key;
+        req.src_location_id = src_loc;
+        req.src_storage_name = "hot_01";
+        req.dst_storage_name = "cold_01";
+        ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+        // copy 进行中用户取消：任务标记 kCancelling，仍留在活跃表
+        ASSERT_EQ(ErrorCode::EC_OK, mgr.Cancel(kInstance, block_key));
+        // 完成回调认领到 kWasCancelling：统计点先于取消分支执行，计入但不走主路径
+        mgr.OnTaskSuccess(kInstance, block_key);
+        ASSERT_EQ(20u, get_write_bytes()); // 累计：场景1的10 + 本次10
+        ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get()); // 取消不 promote，不涨
+    }
+
+    // 场景3: Copy 失败
+    {
+        int64_t block_key = 1002;
+        std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "abcdefghij");
+
+        MigrationManager::MigrationRequest req;
+        req.instance_id = kInstance;
+        req.block_key = block_key;
+        req.src_location_id = src_loc;
+        req.src_storage_name = "hot_01";
+        req.dst_storage_name = "cold_01";
+        ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+        mgr.OnTaskFailed(kInstance, block_key, ErrorCode::EC_IO_ERROR);
+        ASSERT_EQ(20u, get_write_bytes()); // copy 失败不计入，保持场景2结束时的累计值
+        ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get());
+    }
+
+    // 场景4: 源丢失，仍计入
+    {
+        int64_t block_key = 1003;
+        std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "abcdefghij");
+
+        MigrationManager::MigrationRequest req;
+        req.instance_id = kInstance;
+        req.block_key = block_key;
+        req.src_location_id = src_loc;
+        req.src_storage_name = "hot_01";
+        req.dst_storage_name = "cold_01";
+        ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
+
+        // 破坏源：把源 location 从 SERVING CAS 成 DELETING，模拟 copy 期间源被回收
+        auto rc = std::make_shared<RequestContext>("break_source");
+        MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kInstance));
+        std::vector<std::vector<MetaSearcher::LocationCASTask>> cas{
+            {MetaSearcher::LocationCASTask{src_loc, CLS_SERVING, CLS_DELETING}}};
+        std::vector<std::vector<ErrorCode>> cas_results;
+        ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchCASLocationStatus(rc.get(), {block_key}, cas, cas_results));
+
+        // 完成回调：统计点先于 IsSourceLocationServing 检查执行，计入后走 source_lost 失败收尾
+        mgr.OnTaskSuccess(kInstance, block_key);
+        ASSERT_EQ(30u, get_write_bytes()); // 累计：20 + 10
+        ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get()); // 源丢失按失败收尾，不涨
+    }
+
+}
+
 // ============ Copy 准入策略：CheckCopyAdmission ============
 
 namespace {

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -119,7 +119,7 @@ struct KmonitorMetricsReporter::Context {
     // data storage metrics
     DECLARE_METRICS(data_storage, healthy_status);
     DECLARE_METRICS(data_storage, storage_usage_ratio);
-    DECLARE_METRICS(data_storage, write_bytes_total);
+    DECLARE_METRICS(data_storage, write_bytes_dispatched_total);
 
     // schedule plan executor metrics
     DECLARE_METRICS(scheduler_plan_executor, waiting_task_count);
@@ -381,7 +381,7 @@ bool KmonitorMetricsReporter::InitMetrics() {
     // data storage metrics
     REGISTER_GAUGE_METRIC(data_storage, healthy_status);
     REGISTER_GAUGE_METRIC(data_storage, storage_usage_ratio);
-    REGISTER_GAUGE_METRIC(data_storage, write_bytes_total);
+    REGISTER_GAUGE_METRIC(data_storage, write_bytes_dispatched_total);
 
     // schedule plan executor metrics
     REGISTER_GAUGE_METRIC(scheduler_plan_executor, waiting_task_count);
@@ -617,10 +617,11 @@ void KmonitorMetricsReporter::ReportInterval() {
     } while (false);
 
     do {
-        // for per-storage accumulative write bytes
+        // for per-storage accumulative dispatched write bytes
         // the counter is updated in real-time on each backend's DataStorageMetricsCollector
         // (via DataStorageManager::RecordWriteBytes, covering both normal writes and migration
-        // copies), so read the current cumulative values and report them to kmonitor periodically
+        // copies at their dispatch points), so read the current cumulative values and report
+        // them to kmonitor periodically
         const auto registry_manager = cache_manager_->GetRegistryManager();
         if (!registry_manager) {
             break;
@@ -641,9 +642,9 @@ void KmonitorMetricsReporter::ReportInterval() {
                 continue;
             }
             std::uint64_t write_bytes_v;
-            GET_METRICS_(collector, data_storage, write_bytes_total, write_bytes_v);
+            GET_METRICS_(collector, data_storage, write_bytes_dispatched_total, write_bytes_v);
             const kmonitor::MetricsTags tags = ctx_->GetKmonitorTags(collector->GetMetricsTags());
-            REPORT_METRICS(data_storage, write_bytes_total, static_cast<double>(write_bytes_v));
+            REPORT_METRICS(data_storage, write_bytes_dispatched_total, static_cast<double>(write_bytes_v));
         }
     } while (false);
 

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -10,6 +10,7 @@
 #include "kv_cache_manager/common/env_util.h"
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
 #include "kv_cache_manager/manager/cache_manager.h"
 #include "kv_cache_manager/manager/cache_reclaimer.h"
@@ -118,6 +119,7 @@ struct KmonitorMetricsReporter::Context {
     // data storage metrics
     DECLARE_METRICS(data_storage, healthy_status);
     DECLARE_METRICS(data_storage, storage_usage_ratio);
+    DECLARE_METRICS(data_storage, write_bytes_total);
 
     // schedule plan executor metrics
     DECLARE_METRICS(scheduler_plan_executor, waiting_task_count);
@@ -379,6 +381,7 @@ bool KmonitorMetricsReporter::InitMetrics() {
     // data storage metrics
     REGISTER_GAUGE_METRIC(data_storage, healthy_status);
     REGISTER_GAUGE_METRIC(data_storage, storage_usage_ratio);
+    REGISTER_GAUGE_METRIC(data_storage, write_bytes_total);
 
     // schedule plan executor metrics
     REGISTER_GAUGE_METRIC(scheduler_plan_executor, waiting_task_count);
@@ -610,6 +613,37 @@ void KmonitorMetricsReporter::ReportInterval() {
                 GET_METRICS_(p, data_storage, storage_usage_ratio, storage_usage_ratio_v);
                 REPORT_METRICS(data_storage, storage_usage_ratio, storage_usage_ratio_v);
             }
+        }
+    } while (false);
+
+    do {
+        // for per-storage accumulative write bytes
+        // the counter is updated in real-time on each backend's DataStorageMetricsCollector
+        // (via DataStorageManager::RecordWriteBytes, covering both normal writes and migration
+        // copies), so read the current cumulative values and report them to kmonitor periodically
+        const auto registry_manager = cache_manager_->GetRegistryManager();
+        if (!registry_manager) {
+            break;
+        }
+        const auto data_storage_manager = registry_manager->data_storage_manager();
+        if (!data_storage_manager) {
+            break;
+        }
+
+        const auto storage_names = data_storage_manager->GetAllStorageNames();
+        for (const auto &unique_name : storage_names) {
+            const auto storage_backend = data_storage_manager->GetDataStorageBackend(unique_name);
+            if (storage_backend == nullptr) {
+                continue;
+            }
+            const auto collector = storage_backend->GetMetricsCollector();
+            if (collector == nullptr) {
+                continue;
+            }
+            std::uint64_t write_bytes_v;
+            GET_METRICS_(collector, data_storage, write_bytes_total, write_bytes_v);
+            const kmonitor::MetricsTags tags = ctx_->GetKmonitorTags(collector->GetMetricsTags());
+            REPORT_METRICS(data_storage, write_bytes_total, static_cast<double>(write_bytes_v));
         }
     } while (false);
 

--- a/kv_cache_manager/metrics/metrics_collector.cc
+++ b/kv_cache_manager/metrics/metrics_collector.cc
@@ -234,7 +234,7 @@ DEFINE_METRICS_NAME_FOR_DATA_STORAGE(create_keys_counter);
 DEFINE_METRICS_NAME_FOR_DATA_STORAGE(create_time_us);
 DEFINE_METRICS_NAME_FOR_DATA_STORAGE(copy_keys_qps);
 DEFINE_METRICS_NAME_FOR_DATA_STORAGE(copy_time_us);
-DEFINE_METRICS_NAME_FOR_DATA_STORAGE(write_bytes_total);
+DEFINE_METRICS_NAME_FOR_DATA_STORAGE(write_bytes_dispatched_total);
 
 DataStorageMetricsCollector::DataStorageMetricsCollector(std::shared_ptr<MetricsRegistry> metrics_registry) noexcept
     : MetricsCollector(std::move(metrics_registry)) {}
@@ -254,7 +254,7 @@ bool DataStorageMetricsCollector::Init() {
     REGISTER_GAUGE_METRICS_FOR_DATA_STORAGE(create_time_us);
     REGISTER_GAUGE_METRICS_FOR_DATA_STORAGE(copy_keys_qps);
     REGISTER_GAUGE_METRICS_FOR_DATA_STORAGE(copy_time_us);
-    REGISTER_COUNTER_METRICS_FOR_DATA_STORAGE(write_bytes_total);
+    REGISTER_COUNTER_METRICS_FOR_DATA_STORAGE(write_bytes_dispatched_total);
 
     return true;
 }

--- a/kv_cache_manager/metrics/metrics_collector.cc
+++ b/kv_cache_manager/metrics/metrics_collector.cc
@@ -234,6 +234,7 @@ DEFINE_METRICS_NAME_FOR_DATA_STORAGE(create_keys_counter);
 DEFINE_METRICS_NAME_FOR_DATA_STORAGE(create_time_us);
 DEFINE_METRICS_NAME_FOR_DATA_STORAGE(copy_keys_qps);
 DEFINE_METRICS_NAME_FOR_DATA_STORAGE(copy_time_us);
+DEFINE_METRICS_NAME_FOR_DATA_STORAGE(write_bytes_total);
 
 DataStorageMetricsCollector::DataStorageMetricsCollector(std::shared_ptr<MetricsRegistry> metrics_registry) noexcept
     : MetricsCollector(std::move(metrics_registry)) {}
@@ -253,6 +254,7 @@ bool DataStorageMetricsCollector::Init() {
     REGISTER_GAUGE_METRICS_FOR_DATA_STORAGE(create_time_us);
     REGISTER_GAUGE_METRICS_FOR_DATA_STORAGE(copy_keys_qps);
     REGISTER_GAUGE_METRICS_FOR_DATA_STORAGE(copy_time_us);
+    REGISTER_COUNTER_METRICS_FOR_DATA_STORAGE(write_bytes_total);
 
     return true;
 }

--- a/kv_cache_manager/metrics/metrics_collector.h
+++ b/kv_cache_manager/metrics/metrics_collector.h
@@ -377,6 +377,8 @@ class DataStorageMetricsCollector final : public MetricsCollector {
     KVCM_GAUGE_METRICS(data_storage, copy_keys_qps)
     KVCM_CHRONO_METRICS(data_storage, copy_time_us, DataStorageCopy)
 
+    KVCM_COUNTER_METRICS(data_storage, write_bytes_total) // 按 storage 聚合的累计预估写入字节数
+
 public:
     DataStorageMetricsCollector() = delete;
     explicit DataStorageMetricsCollector(std::shared_ptr<MetricsRegistry> metrics_registry) noexcept;
@@ -384,6 +386,10 @@ public:
     ~DataStorageMetricsCollector() override = default;
 
     bool Init() override;
+
+    void AddWriteBytes(std::uint64_t bytes) {
+        data_storage_write_bytes_total_metrics_ += bytes;
+    }
 };
 
 /* --------------- DataStorageIntervalMetricsCollector ---------------- */

--- a/kv_cache_manager/metrics/metrics_collector.h
+++ b/kv_cache_manager/metrics/metrics_collector.h
@@ -377,7 +377,15 @@ class DataStorageMetricsCollector final : public MetricsCollector {
     KVCM_GAUGE_METRICS(data_storage, copy_keys_qps)
     KVCM_CHRONO_METRICS(data_storage, copy_time_us, DataStorageCopy)
 
-    KVCM_COUNTER_METRICS(data_storage, write_bytes_total) // 按 storage 聚合的累计预估写入字节数
+    // Dispatched-view estimate of bytes written to this storage, aggregated per storage.
+    // Incremented when the control plane finishes dispatching a write:
+    //   - normal writes: in StartWriteCache once BatchAddLocation succeeds (locations
+    //     are about to be handed to the client);
+    //   - migration copies: once the copy task is accepted by the schedule plan executor.
+    // This is an upper-bound estimate of bytes actually written to the backend:
+    // abandoned client writes and failed/cancelled copies are still counted, and the
+    // counter is cumulative and never decreases.
+    KVCM_COUNTER_METRICS(data_storage, write_bytes_dispatched_total)
 
 public:
     DataStorageMetricsCollector() = delete;
@@ -387,8 +395,10 @@ public:
 
     bool Init() override;
 
+    // Accumulates dispatched write bytes; see the semantic contract on the
+    // write_bytes_dispatched_total definition above.
     void AddWriteBytes(std::uint64_t bytes) {
-        data_storage_write_bytes_total_metrics_ += bytes;
+        data_storage_write_bytes_dispatched_total_metrics_ += bytes;
     }
 };
 

--- a/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
@@ -2,6 +2,8 @@
 
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/config/registry_manager.h"
+#include "kv_cache_manager/data_storage/data_storage_manager.h"
+#include "kv_cache_manager/data_storage/nfs_backend.h"
 #include "kv_cache_manager/manager/cache_manager.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
 #include "kv_cache_manager/metrics/kmonitor_metrics_reporter.h"
@@ -123,4 +125,25 @@ TEST_F(KmonitorMetricsReporterTest, TestReportInterval) {
         reporter_->metrics_registry_ = nullptr;
         EXPECT_NO_FATAL_FAILURE(reporter_->ReportInterval());
     }
+}
+
+TEST_F(KmonitorMetricsReporterTest, TestReportIntervalWriteBytes) {
+    // the per-storage counter lives on the backend's DataStorageMetricsCollector,
+    // which is only created after Open()
+    auto be = std::make_shared<NfsBackend>(metrics_registry_);
+    auto spec = std::make_shared<NfsStorageSpec>();
+    spec->set_root_path(GetPrivateTestRuntimeDataPath() + "nfs_root/");
+    StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_NFS, "abc", spec);
+    ASSERT_EQ(ErrorCode::EC_OK, be->Open(config, "trace_1"));
+
+    registry_manager_->data_storage_manager_ = std::make_shared<DataStorageManager>(metrics_registry_);
+    registry_manager_->data_storage_manager_->storage_map_.emplace("abc", be);
+
+    registry_manager_->data_storage_manager_->RecordWriteBytes("abc", 2048);
+    EXPECT_NO_FATAL_FAILURE(reporter_->ReportInterval());
+
+    // the kmonitor side has no mock injection point; assert the registry-side value
+    // that ReportInterval reads from instead
+    const auto &tags = be->GetMetricsCollector()->GetMetricsTags();
+    EXPECT_EQ(2048u, metrics_registry_->GetCounter("data_storage.write_bytes_total", tags).Get());
 }

--- a/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
@@ -145,5 +145,5 @@ TEST_F(KmonitorMetricsReporterTest, TestReportIntervalWriteBytes) {
     // the kmonitor side has no mock injection point; assert the registry-side value
     // that ReportInterval reads from instead
     const auto &tags = be->GetMetricsCollector()->GetMetricsTags();
-    EXPECT_EQ(2048u, metrics_registry_->GetCounter("data_storage.write_bytes_total", tags).Get());
+    EXPECT_EQ(2048u, metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total", tags).Get());
 }

--- a/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/local_metrics_reporter_test.cc
@@ -114,7 +114,7 @@ TEST_F(LocalMetricsReporterTest, TestReportPerQuery00) {
 }
 
 TEST_F(LocalMetricsReporterTest, TestReportPerQuery01) {
-    constexpr int kDataStorageMetricsCount = 9;
+    constexpr int kDataStorageMetricsCount = 10;
     EXPECT_EQ(3, metrics_registry_->GetSize());
 
     DataStorageMetricsCollector collector(metrics_registry_);

--- a/kv_cache_manager/metrics/test/metrics_collector_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_collector_test.cc
@@ -280,12 +280,12 @@ TEST_F(MetricsCollectorTest, DataStorageMetricsCollectorTest) {
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, DataStorageCreate);
     EXPECT_GT(GET(p, data_storage, create_time_us), 1000.);
 
-    // Test write_bytes counter.
-    EXPECT_EQ(GET(p, data_storage, write_bytes_total), 0);
+    // Test write_bytes_dispatched counter.
+    EXPECT_EQ(GET(p, data_storage, write_bytes_dispatched_total), 0);
     p->AddWriteBytes(1024);
     p->AddWriteBytes(1024);
-    EXPECT_EQ(GET(p, data_storage, write_bytes_total), 2048);
-    EXPECT_EQ(metrics_registry_->GetCounter("data_storage.write_bytes_total").Get(), 2048);
+    EXPECT_EQ(GET(p, data_storage, write_bytes_dispatched_total), 2048);
+    EXPECT_EQ(metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total").Get(), 2048);
 }
 
 TEST_F(MetricsCollectorTest, DataStorageHealthMetricsCollectorTest) {

--- a/kv_cache_manager/metrics/test/metrics_collector_test.cc
+++ b/kv_cache_manager/metrics/test/metrics_collector_test.cc
@@ -279,6 +279,13 @@ TEST_F(MetricsCollectorTest, DataStorageMetricsCollectorTest) {
     usleep(1000); // 1ms
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(p, DataStorageCreate);
     EXPECT_GT(GET(p, data_storage, create_time_us), 1000.);
+
+    // Test write_bytes counter.
+    EXPECT_EQ(GET(p, data_storage, write_bytes_total), 0);
+    p->AddWriteBytes(1024);
+    p->AddWriteBytes(1024);
+    EXPECT_EQ(GET(p, data_storage, write_bytes_total), 2048);
+    EXPECT_EQ(metrics_registry_->GetCounter("data_storage.write_bytes_total").Get(), 2048);
 }
 
 TEST_F(MetricsCollectorTest, DataStorageHealthMetricsCollectorTest) {


### PR DESCRIPTION
## Motivation

Today there is no per-storage visibility into write volume:
`migration.copy_bytes_total` only reflects the *completion* view (counted after
full promotion), and regular writes (`StartWriteCache`) are not accounted at all.
This makes it impossible to answer operational questions like "how much write I/O
has each storage backend absorbed" — which matters for load balancing, tier
capacity planning, and disk wear estimation.

This PR adds a per-storage cumulative counter
`data_storage.write_bytes_dispatched_total{type, unique_name}` tracking
**dispatched write bytes**: both write paths account at the point where the write
is handed off and the outcome leaves the control plane's control — regular writes
when locations are returned to the client, migration copies when the task is
submitted to the executor. It complements (not replaces) `migration.copy_bytes_total`,
which remains the confirmed-completion view.

## Changes

- **metrics**: declare and register `data_storage.write_bytes_dispatched_total` in
  `DataStorageMetricsCollector`; add `AddWriteBytes()` since the metrics macros
  only generate copy/set/get accessors (collector members share the underlying
  `MetricsValue` with registry entries, so writing the member is exportable).
  Header comments document the dispatched-view accounting contract.
- **data_storage**: add `DataStorageManager::RecordWriteBytes(unique_name, bytes)`
  as the single shared entry point (shared_lock on `storage_map_`, WARN+drop on
  unknown storage); header comments document the semantics.
- **manager (regular write)**: `CacheManager::RecordWriteBytesForLocations()`
  aggregates the `size` param of each LocationSpec URI by hostname (= storage
  `unique_name`); called in `StartWriteCache` only when `BatchAddLocation` fully
  succeeds (partial-failure rollbacks are excluded), with a null metrics-registry
  guard.
- **manager (migration copy)**: record `ctx.total_bytes` to the destination
  storage in `Submit`/`BatchSubmit` right after the copy task is handed to the
  executor — at the same site as `m_tasks_submitted_total_` — instead of in
  `OnTaskSuccess`. Copies that fail/cancel/lose-source *after* dispatch are now
  counted (covering partial-write-then-fail); tasks failing before dispatch
  (prepare/AddLocation rollback, cancelled before submission) are not, matching
  the tasks-submitted boundary.
- **metrics (kmonitor)**: declare/register the gauge in `KmonitorMetricsReporter`
  and report it in `ReportInterval` by enumerating each backend's collector with
  per-storage `{type, unique_name}` tags, covering both write paths.

## Semantics

| Scenario | `write_bytes_dispatched_total` | `copy_bytes_total` |
|---|---|---|
| Regular write success (locations handed out) | +Σ size | — |
| Regular write partial failure (rolled back) | unchanged | — |
| Regular write with duplicate keys | unchanged | — |
| Migration copy submitted to executor | +total_bytes | — |
| Migration copy completes successfully | (already counted at dispatch) | +total_bytes |
| Migration cancelled after dispatch | (already counted) | unchanged |
| Migration copy fails after dispatch | (already counted) | unchanged |
| Migration source lost after dispatch | (already counted) | unchanged |
| Migration fails before dispatch (rollback / pre-submission cancel) | unchanged | unchanged |

The counter records **estimated** bytes (LocationSpec `size` params / task-level
`total_bytes`), counted at dispatch time — actual data I/O happens asynchronously
(client-side writes, executor-side copies) and is not confirmed by this metric.
It answers "how much write I/O has approximately been placed on each storage",
not "how many bytes are currently stored". The counter never decrements
(reclaim/delete is not subtracted) and resets on process restart, matching
standard Prometheus counter semantics.

## Test Plan

- `MetricsCollectorTest.DataStorageMetricsCollectorTest`: member r/w plus registry
  side-door read, 0 → 2048 after two `AddWriteBytes(1024)`.
- `LocalMetricsReporterTest.TestReportPerQuery01`: tripwire constant 9 → 10.
- `CacheManagerTest.TestStartWriteCacheRecordWriteBytes`: success counts 3×4×512;
  injected partial failure and duplicate keys count nothing.
- `MigrationManagerTest.TestCopyWriteBytesRecorded`: double-assert structure —
  counted immediately after `Submit` returns, never re-counted by completion
  callbacks; cumulative 10→20→30→40 across success / cancel / failure /
  source-lost scenarios, while `copy_bytes_total` stays at 10 (success only).
- `MigrationManagerTest.TestBatchAddLocationPartialFailureKeepsSuccessfulCopies`:
  within a partially failing batch, only the submitted item's bytes (4) are
  counted; the rolled-back item is not.
- `KmonitorMetricsReporterTest`: gauge declared/registered and reported with
  per-storage tags.

All test targets pass locally; GitHub CI (normal_test / asan_test / CodeQL) green.

## Known follow-ups (out of scope here)

- Document the reporter's `metrics → config → data_storage` enumeration edge in
  AGENTS.md / `docs/design/module_architecture.md` (Codex review item).
- `SchedulePlanExecutor::Submit` returns a valid-but-`EC_ERROR` future when the
  executor rejects a copy, so `!future.valid()` cannot detect rejection; in the
  narrow shutdown race a rejected task is still counted. Verified fix: return an
  invalid future on rejection (migration's existing `!valid()` cleanup branch and
  `CopySubmitInvalid_stub` already assume this contract).