### PR TITLE
feat: pass shared-memory fd through RegistSpan

### DIFF
--- a/kv_cache_manager/client/include/common.h
+++ b/kv_cache_manager/client/include/common.h
@@ -172,6 +172,14 @@ struct RegistSpan {
     [[nodiscard]] uint64_t base_as_uint64() const { return reinterpret_cast<uint64_t>(base); }
 };
 
+// Keep shared-memory metadata separate from RegistSpan so existing callers
+// retain the original ABI.
+struct SharedMemoryRegistration {
+    void *base{nullptr};
+    size_t size{0};
+    int fd{-1};
+};
+
 struct InitParams {
     RoleType role_type{RoleType::UNKNOWN};
     RegistSpan *regist_span{nullptr};    // used by worker

--- a/kv_cache_manager/client/include/transfer_client.h
+++ b/kv_cache_manager/client/include/transfer_client.h
@@ -15,6 +15,10 @@ class TransferClient {
 public:
     virtual ~TransferClient() = default;
     static std::unique_ptr<TransferClient> Create(const std::string &client_config, const InitParams &init_params);
+    static std::unique_ptr<TransferClient>
+    Create(const std::string &client_config,
+           const InitParams &init_params,
+           const SharedMemoryRegistration &shared_memory_registration);
 
     virtual ClientErrorCode LoadKvCaches(const UriStrVec &uri_str_vec,
                                          const BlockBuffers &block_buffers,

--- a/kv_cache_manager/client/pybind/py_client_binding.cc
+++ b/kv_cache_manager/client/pybind/py_client_binding.cc
@@ -12,6 +12,33 @@ namespace {
 struct OSException {
     int errcode;
 };
+
+struct PyRegistSpan {
+    kvcm::RegistSpan span;
+    int fd{-1};
+    py::object owner{py::none()};
+
+    void set_base_as_uint64(uint64_t base_ptr) { span.set_base_as_uint64(base_ptr); }
+    uint64_t base_as_uint64() const { return span.base_as_uint64(); }
+    void set_size(size_t size) { span.size = size; }
+    size_t size() const { return span.size; }
+};
+
+struct PyInitParams {
+    kvcm::RoleType role_type{kvcm::RoleType::UNKNOWN};
+    std::shared_ptr<PyRegistSpan> regist_span;
+    std::string self_location_spec_name;
+    std::string storage_configs;
+
+    kvcm::InitParams ToCpp() const {
+        kvcm::InitParams params;
+        params.role_type = role_type;
+        params.regist_span = regist_span == nullptr ? nullptr : &regist_span->span;
+        params.self_location_spec_name = self_location_spec_name;
+        params.storage_configs = storage_configs;
+        return params;
+    }
+};
 } // namespace
 
 PYBIND11_MODULE(kvcm_py_client, module) {
@@ -95,17 +122,19 @@ PYBIND11_MODULE(kvcm_py_client, module) {
         .def(py::init<>())
         .def_readwrite("iovs", &kvcm::BlockBuffer::iovs);
 
-    py::class_<kvcm::RegistSpan, py::smart_holder>(module, "RegistSpan")
+    py::class_<PyRegistSpan, py::smart_holder>(module, "RegistSpan")
         .def(py::init<>())
-        .def_property("base", &kvcm::RegistSpan::base_as_uint64, &kvcm::RegistSpan::set_base_as_uint64)
-        .def_readwrite("size", &kvcm::RegistSpan::size);
+        .def_property("base", &PyRegistSpan::base_as_uint64, &PyRegistSpan::set_base_as_uint64)
+        .def_property("size", &PyRegistSpan::size, &PyRegistSpan::set_size)
+        .def_readwrite("fd", &PyRegistSpan::fd)
+        .def_readwrite("owner", &PyRegistSpan::owner);
 
-    py::class_<kvcm::InitParams, py::smart_holder>(module, "InitParams")
+    py::class_<PyInitParams, py::smart_holder>(module, "InitParams")
         .def(py::init<>())
-        .def_readwrite("role_type", &kvcm::InitParams::role_type)
-        .def_readwrite("regist_span", &kvcm::InitParams::regist_span)
-        .def_readwrite("self_location_spec_name", &kvcm::InitParams::self_location_spec_name)
-        .def_readwrite("storage_configs", &kvcm::InitParams::storage_configs);
+        .def_readwrite("role_type", &PyInitParams::role_type)
+        .def_readwrite("regist_span", &PyInitParams::regist_span)
+        .def_readwrite("self_location_spec_name", &PyInitParams::self_location_spec_name)
+        .def_readwrite("storage_configs", &PyInitParams::storage_configs);
 
     py::class_<kvcm::ForwardContext, py::smart_holder>(module, "ForwardContext")
         .def(py::init<>())
@@ -122,8 +151,36 @@ PYBIND11_MODULE(kvcm_py_client, module) {
     // 保留这些类型定义以支持C++接口，但使用Python原生类型进行交互
 
     // 绑定TransferClient类
-    py::class_<kvcm::TransferClient, py::smart_holder>(module, "TransferClient")
-        .def_static("Create", &kvcm::TransferClient::Create, py::call_guard<py::gil_scoped_release>())
+    py::class_<kvcm::TransferClient, py::smart_holder>(module, "TransferClient", py::dynamic_attr())
+        .def_static(
+            "Create",
+            [](const std::string &client_config, const PyInitParams &py_init_params) -> py::object {
+                auto init_params = py_init_params.ToCpp();
+                auto captured_span = py_init_params.regist_span;
+                py::object captured_owner = captured_span == nullptr ? py::none() : captured_span->owner;
+                std::unique_ptr<kvcm::TransferClient> client;
+                {
+                    py::gil_scoped_release release;
+                    if (captured_span != nullptr && captured_span->fd != -1) {
+                        kvcm::SharedMemoryRegistration registration;
+                        registration.base = captured_span->span.base;
+                        registration.size = captured_span->span.size;
+                        registration.fd = captured_span->fd;
+                        client = kvcm::TransferClient::Create(client_config, init_params, registration);
+                    } else {
+                        client = kvcm::TransferClient::Create(client_config, init_params);
+                    }
+                }
+                if (client == nullptr) {
+                    return py::none();
+                }
+                auto py_client = py::cast(std::move(client));
+                py_client.attr("_regist_span") = py::cast(captured_span);
+                py_client.attr("_regist_span_owner") = captured_owner;
+                return py_client;
+            },
+            py::arg("client_config"),
+            py::arg("init_params"))
         .def("LoadKvCaches",
              &kvcm::TransferClient::LoadKvCaches,
              py::arg("uri_str_vec"),

--- a/kv_cache_manager/client/src/internal/config/sdk_config.h
+++ b/kv_cache_manager/client/src/internal/config/sdk_config.h
@@ -157,6 +157,19 @@ public:
     bool operator==(const TairMempoolSdkConfig &other) const { return SdkBackendConfig::operator==(other); }
 
     bool operator!=(const TairMempoolSdkConfig &other) const { return !(*this == other); }
+
+    int shm_fd() const { return shm_fd_; }
+    size_t shm_size() const { return shm_size_; }
+    void *client_base() const { return client_base_; }
+
+    void set_shm_fd(int fd) { shm_fd_ = fd; }
+    void set_shm_size(size_t size) { shm_size_ = size; }
+    void set_client_base(void *base) { client_base_ = base; }
+
+private:
+    int shm_fd_{-1};
+    size_t shm_size_{0};
+    void *client_base_{nullptr};
 };
 
 class NfsSdkConfig : public SdkBackendConfig {

--- a/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.cc
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.cc
@@ -1,19 +1,36 @@
 #include "kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h"
 
+#include <fcntl.h>
+#include <limits>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <unordered_map>
 
 #include "kv_cache_manager/client/src/internal/sdk/lock_free_thread_pool.h"
 #include "kv_cache_manager/client/src/internal/sdk/sdk_factory.h"
 #include "kv_cache_manager/client/src/internal/sdk/sdk_interface.h"
 #include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/data_storage/storage_config.h"
 
 namespace kv_cache_manager {
 
 SdkWrapper::SdkWrapper() : sdk_factory_(SdkFactory::GetInstance()) {}
 
-SdkWrapper::~SdkWrapper() {}
+SdkWrapper::~SdkWrapper() {
+    if (wait_task_thread_pool_) {
+        wait_task_thread_pool_->stop();
+        wait_task_thread_pool_.reset();
+    }
+    sdk_map_.clear();
+    if (owned_shm_fd_ >= 0) {
+        close(owned_shm_fd_);
+        owned_shm_fd_ = -1;
+    }
+}
 
-ClientErrorCode SdkWrapper::Init(const std::unique_ptr<ClientConfig> &client_config, const InitParams &init_params) {
+ClientErrorCode SdkWrapper::Init(const std::unique_ptr<ClientConfig> &client_config,
+                                 const InitParams &init_params,
+                                 const SharedMemoryRegistration *shared_memory_registration) {
     if (!client_config) {
         KVCM_LOG_WARN("client config is null");
         return ER_INVALID_CLIENT_CONFIG;
@@ -31,6 +48,16 @@ ClientErrorCode SdkWrapper::Init(const std::unique_ptr<ClientConfig> &client_con
     if (storage_configs_.empty()) {
         KVCM_LOG_WARN("storage config is empty");
         return ER_INVALID_STORAGE_CONFIG;
+    }
+
+    SharedMemoryRegistration prepared_registration;
+    const SharedMemoryRegistration *active_registration = nullptr;
+    if (shared_memory_registration != nullptr) {
+        auto ec = PrepareSharedMemoryRegistration(*shared_memory_registration, prepared_registration);
+        if (ec != ER_OK) {
+            return ec;
+        }
+        active_registration = &prepared_registration;
     }
 
     wait_task_thread_pool_ = std::make_unique<LockFreeThreadPool>(
@@ -66,6 +93,11 @@ ClientErrorCode SdkWrapper::Init(const std::unique_ptr<ClientConfig> &client_con
         auto ec = UpdateMooncakeSdkConfig(sdk_backend_config, regist_span, init_params.self_location_spec_name);
         if (ec != ER_OK) {
             KVCM_LOG_WARN("fill span failed, storage config: %s", storage_config->ToString().c_str());
+            return ec;
+        }
+        ec = UpdateTairMempoolSdkConfig(sdk_backend_config, active_registration);
+        if (ec != ER_OK) {
+            KVCM_LOG_WARN("fill tair mempool span failed, storage config: %s", storage_config->ToString().c_str());
             return ec;
         }
 
@@ -174,7 +206,7 @@ ClientErrorCode SdkWrapper::Put(const std::vector<DataStorageUri> &remote_uris,
     for (size_t i = 0; i < groups.size(); ++i) {
         const auto &group = groups[i];
         const auto &group_actual_uris = group_results[i];
-        
+
         if (group_actual_uris->size() != group.indices.size()) {
             KVCM_LOG_WARN("sdk returned mismatched actual_uris size: %zu vs %zu",
                           group_actual_uris->size(),
@@ -319,6 +351,67 @@ ClientErrorCode SdkWrapper::UpdateMooncakeSdkConfig(const std::shared_ptr<SdkBac
     config->set_local_mem_ptr(span->base);
     config->set_local_buffer_size(span->size);
     config->set_self_location_spec_name(self_location_spec_name);
+    return ER_OK;
+}
+
+ClientErrorCode SdkWrapper::PrepareSharedMemoryRegistration(const SharedMemoryRegistration &shared_memory_registration,
+                                                            SharedMemoryRegistration &prepared_registration) {
+    const bool disabled = shared_memory_registration.fd == -1 && shared_memory_registration.base == nullptr &&
+                          shared_memory_registration.size == 0;
+    if (disabled) {
+        prepared_registration = shared_memory_registration;
+        return ER_OK;
+    }
+
+    if (shared_memory_registration.fd < 0 || shared_memory_registration.base == nullptr ||
+        shared_memory_registration.size == 0) {
+        KVCM_LOG_WARN("shared memory registration must provide fd, base and size together");
+        return ER_INVALID_PARAMS;
+    }
+
+    const uintptr_t base = reinterpret_cast<uintptr_t>(shared_memory_registration.base);
+    if (shared_memory_registration.size > std::numeric_limits<uintptr_t>::max() - base) {
+        KVCM_LOG_WARN("shared memory registration address range overflows");
+        return ER_INVALID_PARAMS;
+    }
+
+    struct stat file_stat{};
+    if (fstat(shared_memory_registration.fd, &file_stat) != 0 || file_stat.st_size < 0 ||
+        static_cast<uintmax_t>(file_stat.st_size) < shared_memory_registration.size) {
+        KVCM_LOG_WARN("shared memory fd is invalid or smaller than the registered range");
+        return ER_INVALID_PARAMS;
+    }
+
+    int duplicated_fd = fcntl(shared_memory_registration.fd, F_DUPFD_CLOEXEC, 0);
+    if (duplicated_fd < 0) {
+        KVCM_LOG_WARN("duplicate shared memory fd failed");
+        return ER_INVALID_PARAMS;
+    }
+    if (owned_shm_fd_ >= 0) {
+        close(owned_shm_fd_);
+    }
+    owned_shm_fd_ = duplicated_fd;
+    prepared_registration = shared_memory_registration;
+    prepared_registration.fd = owned_shm_fd_;
+    return ER_OK;
+}
+
+ClientErrorCode SdkWrapper::UpdateTairMempoolSdkConfig(const std::shared_ptr<SdkBackendConfig> &sdk_backend_config,
+                                                       const SharedMemoryRegistration *shared_memory_registration) {
+    if (!IsTairMempoolStorageType(sdk_backend_config->type())) {
+        return ER_OK;
+    }
+    auto config = std::dynamic_pointer_cast<TairMempoolSdkConfig>(sdk_backend_config);
+    if (!config) {
+        KVCM_LOG_WARN("convert to tair mempool config failed");
+        return ER_INVALID_SDKBACKEND_CONFIG;
+    }
+    if (shared_memory_registration == nullptr || shared_memory_registration->fd < 0) {
+        return ER_OK;
+    }
+    config->set_shm_fd(shared_memory_registration->fd);
+    config->set_shm_size(shared_memory_registration->size);
+    config->set_client_base(shared_memory_registration->base);
     return ER_OK;
 }
 

--- a/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h
@@ -22,7 +22,9 @@ public:
     ~SdkWrapper();
 
 public:
-    ClientErrorCode Init(const std::unique_ptr<ClientConfig> &client_config, const InitParams &init_params);
+    ClientErrorCode Init(const std::unique_ptr<ClientConfig> &client_config,
+                         const InitParams &init_params,
+                         const SharedMemoryRegistration *shared_memory_registration = nullptr);
 
     ClientErrorCode Get(const std::vector<DataStorageUri> &remote_uris, const BlockBuffers &local_buffers);
     ClientErrorCode Put(const std::vector<DataStorageUri> &remote_uris,
@@ -58,6 +60,10 @@ private:
     ClientErrorCode UpdateMooncakeSdkConfig(const std::shared_ptr<SdkBackendConfig> &sdk_backend_config,
                                             RegistSpan *span,
                                             const std::string &self_location_spec_name);
+    ClientErrorCode PrepareSharedMemoryRegistration(const SharedMemoryRegistration &shared_memory_registration,
+                                                    SharedMemoryRegistration &prepared_registration);
+    ClientErrorCode UpdateTairMempoolSdkConfig(const std::shared_ptr<SdkBackendConfig> &sdk_backend_config,
+                                               const SharedMemoryRegistration *shared_memory_registration);
 
 private:
     SdkFactory *sdk_factory_;
@@ -66,6 +72,7 @@ private:
     std::unique_ptr<LockFreeThreadPool> wait_task_thread_pool_;
     // storage unique name -> storage_sdk
     std::map<std::string, std::shared_ptr<SdkInterface>> sdk_map_;
+    int owned_shm_fd_{-1};
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/client/src/internal/sdk/test/sdk_wrapper_test.cc
+++ b/kv_cache_manager/client/src/internal/sdk/test/sdk_wrapper_test.cc
@@ -1,9 +1,18 @@
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <fcntl.h>
+#include <future>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
 #include <vector>
 
 #include "kv_cache_manager/client/src/internal/config/sdk_config.h"
+#include "kv_cache_manager/client/src/internal/sdk/lock_free_thread_pool.h"
 #include "kv_cache_manager/client/src/internal/sdk/sdk_wrapper.h"
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/data_storage/data_storage_uri.h"
@@ -121,6 +130,127 @@ TEST_F(SdkWrapperTest, TestInitWithInvalidStorageConfigs) {
     InitParams init_params = init_params_;
     init_params.storage_configs = "[invalid json]";
     ASSERT_EQ(ER_INVALID_STORAGE_CONFIG, sdk_wrapper.Init(client_config_, init_params));
+}
+
+TEST_F(SdkWrapperTest, TestPrepareSharedMemoryRegistrationOwnsFd) {
+    FILE *file = tmpfile();
+    ASSERT_NE(file, nullptr);
+    ASSERT_EQ(ftruncate(fileno(file), static_cast<off_t>(init_params_.regist_span->size)), 0);
+
+    SharedMemoryRegistration registration;
+    registration.base = init_params_.regist_span->base;
+    registration.size = init_params_.regist_span->size;
+    registration.fd = fileno(file);
+
+    SdkWrapper sdk_wrapper;
+    SharedMemoryRegistration prepared_registration;
+    ASSERT_EQ(ER_OK, sdk_wrapper.PrepareSharedMemoryRegistration(registration, prepared_registration));
+    EXPECT_NE(prepared_registration.fd, registration.fd);
+    const int fd_flags = fcntl(prepared_registration.fd, F_GETFD);
+    ASSERT_GE(fd_flags, 0);
+    EXPECT_NE(fd_flags & FD_CLOEXEC, 0);
+
+    ASSERT_EQ(fclose(file), 0);
+    struct stat file_stat{};
+    EXPECT_EQ(fstat(prepared_registration.fd, &file_stat), 0);
+}
+
+TEST_F(SdkWrapperTest, TestDestructorKeepsSharedMemoryFdAliveForRunningTasks) {
+    FILE *file = tmpfile();
+    ASSERT_NE(file, nullptr);
+    ASSERT_EQ(ftruncate(fileno(file), static_cast<off_t>(init_params_.regist_span->size)), 0);
+
+    SharedMemoryRegistration registration;
+    registration.base = init_params_.regist_span->base;
+    registration.size = init_params_.regist_span->size;
+    registration.fd = fileno(file);
+
+    auto sdk_wrapper = std::make_unique<SdkWrapper>();
+    SharedMemoryRegistration prepared_registration;
+    ASSERT_EQ(ER_OK, sdk_wrapper->PrepareSharedMemoryRegistration(registration, prepared_registration));
+    const int owned_fd = prepared_registration.fd;
+
+    sdk_wrapper->wait_task_thread_pool_ = std::make_unique<LockFreeThreadPool>(1, 1, "SdkWrapperTestPool");
+    ASSERT_TRUE(sdk_wrapper->wait_task_thread_pool_->start());
+
+    std::promise<void> task_started;
+    auto task_started_future = task_started.get_future();
+    std::promise<void> allow_task_finish;
+    auto allow_task_finish_future = allow_task_finish.get_future().share();
+    std::atomic<bool> fd_valid_in_task{false};
+    auto task_result = sdk_wrapper->wait_task_thread_pool_->async([&]() {
+        task_started.set_value();
+        allow_task_finish_future.wait();
+        struct stat file_stat{};
+        fd_valid_in_task.store(fstat(owned_fd, &file_stat) == 0);
+        return ER_OK;
+    });
+    ASSERT_EQ(task_started_future.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+    std::promise<void> destructor_started;
+    auto destructor_started_future = destructor_started.get_future();
+    std::thread destroyer([&]() {
+        destructor_started.set_value();
+        sdk_wrapper.reset();
+    });
+    EXPECT_EQ(destructor_started_future.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    allow_task_finish.set_value();
+    destroyer.join();
+
+    EXPECT_EQ(task_result.get(), ER_OK);
+    EXPECT_TRUE(fd_valid_in_task.load());
+    EXPECT_EQ(fcntl(owned_fd, F_GETFD), -1);
+    ASSERT_EQ(fclose(file), 0);
+}
+
+TEST_F(SdkWrapperTest, TestPrepareSharedMemoryRegistrationRejectsInvalidValues) {
+    SdkWrapper sdk_wrapper;
+    SharedMemoryRegistration prepared_registration;
+    SharedMemoryRegistration registration;
+
+    registration.fd = 0;
+    EXPECT_EQ(ER_INVALID_PARAMS, sdk_wrapper.PrepareSharedMemoryRegistration(registration, prepared_registration));
+
+    registration = SharedMemoryRegistration();
+    registration.base = init_params_.regist_span->base;
+    EXPECT_EQ(ER_INVALID_PARAMS, sdk_wrapper.PrepareSharedMemoryRegistration(registration, prepared_registration));
+
+    FILE *file = tmpfile();
+    ASSERT_NE(file, nullptr);
+    registration = SharedMemoryRegistration();
+    registration.base = init_params_.regist_span->base;
+    registration.size = init_params_.regist_span->size;
+    registration.fd = fileno(file);
+    EXPECT_EQ(ER_INVALID_PARAMS, sdk_wrapper.PrepareSharedMemoryRegistration(registration, prepared_registration));
+    ASSERT_EQ(fclose(file), 0);
+}
+
+TEST_F(SdkWrapperTest, TestUpdateTairMempoolSdkConfigWithSharedMemory) {
+    FILE *file = tmpfile();
+    ASSERT_NE(file, nullptr);
+    ASSERT_EQ(ftruncate(fileno(file), static_cast<off_t>(init_params_.regist_span->size)), 0);
+
+    SharedMemoryRegistration registration;
+    registration.base = init_params_.regist_span->base;
+    registration.size = init_params_.regist_span->size;
+    registration.fd = fileno(file);
+
+    SdkWrapper sdk_wrapper;
+    SharedMemoryRegistration prepared_registration;
+    ASSERT_EQ(ER_OK, sdk_wrapper.PrepareSharedMemoryRegistration(registration, prepared_registration));
+
+    for (const auto type : {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL,
+                            DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD}) {
+        SCOPED_TRACE(static_cast<int>(type));
+        auto config = std::make_shared<TairMempoolSdkConfig>(type);
+        ASSERT_EQ(ER_OK, sdk_wrapper.UpdateTairMempoolSdkConfig(config, &prepared_registration));
+        EXPECT_EQ(config->shm_fd(), prepared_registration.fd);
+        EXPECT_EQ(config->shm_size(), registration.size);
+        EXPECT_EQ(config->client_base(), registration.base);
+    }
+
+    ASSERT_EQ(fclose(file), 0);
 }
 
 // TODO: mock mooncake

--- a/kv_cache_manager/client/src/transfer_client_impl.cc
+++ b/kv_cache_manager/client/src/transfer_client_impl.cc
@@ -27,6 +27,19 @@ TransferClientImpl::TransferClientImpl() {}
 TransferClientImpl::~TransferClientImpl() {}
 
 ClientErrorCode TransferClientImpl::Init(const std::string &client_config, const InitParams &init_params) {
+    return InitInternal(client_config, init_params, nullptr);
+}
+
+ClientErrorCode
+TransferClientImpl::InitWithSharedMemory(const std::string &client_config,
+                                         const InitParams &init_params,
+                                         const SharedMemoryRegistration &shared_memory_registration) {
+    return InitInternal(client_config, init_params, &shared_memory_registration);
+}
+
+ClientErrorCode TransferClientImpl::InitInternal(const std::string &client_config,
+                                                 const InitParams &init_params,
+                                                 const SharedMemoryRegistration *shared_memory_registration) {
     {
         std::shared_lock read_guard(config_mutex_);
         if (client_config_ != nullptr) {
@@ -70,7 +83,7 @@ ClientErrorCode TransferClientImpl::Init(const std::string &client_config, const
                       init_params_.regist_span,
                       init_params_.self_location_spec_name.c_str(),
                       init_params_.storage_configs.c_str());
-        ec = sdk_wrapper_->Init(client_config_, init_params_);
+        ec = sdk_wrapper_->Init(client_config_, init_params_, shared_memory_registration);
         if (ec != ER_OK) {
             KVCM_LOG_ERROR("init sdk wrapper failed");
             client_config_.reset();
@@ -216,6 +229,20 @@ std::unique_ptr<TransferClient> TransferClient::Create(const std::string &client
         return client;
     }
     KVCM_LOG_ERROR("create transfer client failed with errocode: %d", ec);
+    return nullptr;
+}
+
+std::unique_ptr<TransferClient>
+TransferClient::Create(const std::string &client_config,
+                       const InitParams &init_params,
+                       const SharedMemoryRegistration &shared_memory_registration) {
+    LoggerBroker::InitLoggerForClientOnce();
+    auto client = std::make_unique<TransferClientImpl>();
+    auto ec = client->InitWithSharedMemory(client_config, init_params, shared_memory_registration);
+    if (ec == ER_OK) {
+        return client;
+    }
+    KVCM_LOG_ERROR("create transfer client with shared memory failed with errocode: %d", ec);
     return nullptr;
 }
 

--- a/kv_cache_manager/client/src/transfer_client_impl.h
+++ b/kv_cache_manager/client/src/transfer_client_impl.h
@@ -32,6 +32,12 @@ protected:
     ClientErrorCode Init(const std::string &client_config, const InitParams &init_params) override;
 
 private:
+    ClientErrorCode InitWithSharedMemory(const std::string &client_config,
+                                         const InitParams &init_params,
+                                         const SharedMemoryRegistration &shared_memory_registration);
+    ClientErrorCode InitInternal(const std::string &client_config,
+                                 const InitParams &init_params,
+                                 const SharedMemoryRegistration *shared_memory_registration);
     ClientErrorCode IsValid(const std::unique_ptr<ClientConfig> &client_config) const;
     std::vector<DataStorageUri> ParseLocations(const UriStrVec &uri_str_vec);
     UriStrVec ConstructLocations(const std::vector<DataStorageUri> &uris);

--- a/kv_cache_manager/client/test/transfer_client_py_test.py
+++ b/kv_cache_manager/client/test/transfer_client_py_test.py
@@ -10,7 +10,9 @@ import sys
 import os
 import tempfile
 import ctypes
+import gc
 import unittest
+import weakref
 from kv_cache_manager.client.pybind import kvcm_py_client
 
 class TransferClientPyTest(unittest.TestCase):
@@ -79,6 +81,7 @@ class TransferClientPyTest(unittest.TestCase):
         regist_span = kvcm_py_client.RegistSpan()
         regist_span.base = buffer_addr  # 使用地址值
         regist_span.size = buffer_size
+        regist_span.owner = buffer
         init_params.regist_span = regist_span
         
         init_params.self_location_spec_name = spec_name
@@ -94,6 +97,60 @@ class TransferClientPyTest(unittest.TestCase):
         ]'''
         
         return init_params
+
+    def test_regist_span_lifetime_survives_gc(self):
+        """注册内存及其持有对象在客户端生命周期内保持有效。"""
+
+        class BufferOwner:
+            def __init__(self, size):
+                self.buffer = ctypes.create_string_buffer(size)
+
+        owner = BufferOwner(1024 * 1024)
+        owner_ref = weakref.ref(owner)
+        init_params = self._create_init_params("tp0")
+        init_params.regist_span.base = ctypes.addressof(owner.buffer)
+        init_params.regist_span.owner = owner
+        del owner
+
+        gc.collect()
+        self.assertIsNotNone(owner_ref())
+
+        captured_span = init_params.regist_span
+        client = kvcm_py_client.TransferClient.Create(self.client_config, init_params)
+        self.assertIsNotNone(client)
+        init_params.regist_span = None
+        captured_span.owner = None
+        del captured_span
+        del init_params
+        gc.collect()
+        self.assertIsNotNone(owner_ref())
+
+        del client
+        gc.collect()
+        self.assertIsNone(owner_ref())
+
+    def test_create_with_valid_shared_memory_fd(self):
+        """fd、base 和 size 同时有效时使用共享内存接口。"""
+
+        with tempfile.TemporaryFile() as shared_memory_file:
+            shared_memory_file.truncate(self.init_params.regist_span.size)
+            self.init_params.regist_span.fd = shared_memory_file.fileno()
+            client = kvcm_py_client.TransferClient.Create(self.client_config, self.init_params)
+            self.assertIsNotNone(client)
+
+    def test_reject_partial_shared_memory_registration(self):
+        """只提供部分共享内存字段时创建失败。"""
+
+        with tempfile.TemporaryFile() as shared_memory_file:
+            shared_memory_file.truncate(self.init_params.regist_span.size)
+            self.init_params.regist_span.fd = shared_memory_file.fileno()
+            self.init_params.regist_span.base = 0
+            client = kvcm_py_client.TransferClient.Create(self.client_config, self.init_params)
+            self.assertIsNone(client)
+
+        self.init_params.regist_span.fd = -2
+        client = kvcm_py_client.TransferClient.Create(self.client_config, self.init_params)
+        self.assertIsNone(client)
 
     def tearDown(self):
         """测试后清理"""

--- a/kv_cache_manager/client/test/transfer_client_test.cc
+++ b/kv_cache_manager/client/test/transfer_client_test.cc
@@ -1,11 +1,19 @@
+#include <cstddef>
+#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
+#include <unistd.h>
 
 #include "kv_cache_manager/client/src/transfer_client_impl.h"
 #include "kv_cache_manager/common/unittest.h"
 
 using namespace kv_cache_manager;
+
+static_assert(offsetof(RegistSpan, base) == 0);
+static_assert(offsetof(RegistSpan, size) == sizeof(void *));
+static_assert(sizeof(RegistSpan) == sizeof(void *) + sizeof(size_t));
 
 class TransferClientTest : public TESTBASE {
 public:
@@ -92,6 +100,55 @@ TEST_F(TransferClientTest, TestCreate) {
         auto client = TransferClient::Create(invalid_config, init_params_);
         EXPECT_EQ(client, nullptr);
     }
+}
+
+TEST_F(TransferClientTest, TestCreateWithSharedMemory) {
+    FILE *file = tmpfile();
+    ASSERT_NE(file, nullptr);
+    ASSERT_EQ(ftruncate(fileno(file), static_cast<off_t>(init_params_.regist_span->size)), 0);
+
+    SharedMemoryRegistration registration;
+    registration.base = init_params_.regist_span->base;
+    registration.size = init_params_.regist_span->size;
+    registration.fd = fileno(file);
+
+    auto client = TransferClient::Create(client_config_, init_params_, registration);
+    ASSERT_NE(client, nullptr);
+
+    ASSERT_EQ(fclose(file), 0);
+    client.reset();
+}
+
+TEST_F(TransferClientTest, TestCreateWithDisabledSharedMemory) {
+    SharedMemoryRegistration registration;
+    auto client = TransferClient::Create(client_config_, init_params_, registration);
+    EXPECT_NE(client, nullptr);
+}
+
+TEST_F(TransferClientTest, TestRejectsPartialSharedMemoryRegistration) {
+    FILE *file = tmpfile();
+    ASSERT_NE(file, nullptr);
+    ASSERT_EQ(ftruncate(fileno(file), static_cast<off_t>(init_params_.regist_span->size)), 0);
+
+    SharedMemoryRegistration registration;
+    registration.base = init_params_.regist_span->base;
+    registration.size = init_params_.regist_span->size;
+    registration.fd = -1;
+    EXPECT_EQ(TransferClient::Create(client_config_, init_params_, registration), nullptr);
+
+    registration.fd = fileno(file);
+    registration.base = nullptr;
+    EXPECT_EQ(TransferClient::Create(client_config_, init_params_, registration), nullptr);
+
+    registration.base = init_params_.regist_span->base;
+    registration.size = 0;
+    EXPECT_EQ(TransferClient::Create(client_config_, init_params_, registration), nullptr);
+
+    registration.size = init_params_.regist_span->size;
+    registration.base = reinterpret_cast<void *>(std::numeric_limits<uintptr_t>::max());
+    EXPECT_EQ(TransferClient::Create(client_config_, init_params_, registration), nullptr);
+
+    ASSERT_EQ(fclose(file), 0);
 }
 
 TEST_F(TransferClientTest, TestCreateWithEmptySelfLocationSpecName) {


### PR DESCRIPTION
Add an fd field to RegistSpan and expose it through pybind. Propagate the registered span into TairMempoolSdkConfig so the SDK can use the shared-memory fd, size, and client base for zero-copy transfers. The earlier direct-IO Bazel source fix is already covered by the current main branch glob. Local build and tests were not run per project policy.