### PR TITLE
[optimizer] add English docs as default and optimizer usage skills

### DIFF
--- a/kv_cache_manager/optimizer/README.md
+++ b/kv_cache_manager/optimizer/README.md
@@ -1,129 +1,131 @@
 # KVCacheManager Optimizer
 
-## 概述
+> [中文](README_zh.md) | English
 
-KVCacheManager Optimizer 是一个独立的缓存优化分析模块，通过回放 trace 数据来模拟缓存读写操作，评估不同驱逐策略和配置对缓存命中率的影响，并为 KVCacheManager 主程序提供参数优化能力。
+## Overview
 
-核心功能包括：
-- Trace 数据的回放和模拟
-- 多种驱逐策略的模拟和对比
-- 缓存命中率的实时统计和分析
-- Radix Tree 索引结构的可视化
-- LiteHit：full-attention 场景的容量无关命中率分析（一次回放产出事实，任意 LRU 容量事后投影，支持重分块与多 block size fanout），见 [liteHit/README.md](liteHit/README.md)
+KVCacheManager Optimizer is a standalone cache optimization analysis module. It replays trace data to simulate cache read/write operations, evaluates the impact of different eviction policies and configurations on cache hit rate, and provides parameter optimization capabilities for the KVCacheManager main program.
 
-## 动机
+Core capabilities include:
+- Trace data replay and simulation
+- Simulation and comparison of multiple eviction policies
+- Real-time statistics and analysis of cache hit rate
+- Visualization of the Radix Tree index structure
+- LiteHit: capacity-independent hit-rate analysis for full-attention scenarios (a single replay produces facts, arbitrary LRU capacities are projected after the fact, with re-blocking and multi block-size fanout supported). See [liteHit/README.md](liteHit/README.md)
 
-在大语言模型（LLM）推理场景中，KV Cache 的管理对系统性能至关重要。不同的驱逐策略、缓存容量配置和存储层级设置会显著影响缓存命中率和整体推理效率。Optimizer 模块的设计动机包括：
+## Motivation
 
-1. **策略评估**：在生产环境部署前，通过 trace 回放评估不同驱逐策略的效果，选择最优配置
-2. **参数调优**：分析缓存访问模式，为驱逐策略参数（如采样率、TTL 等）提供优化建议
-3. **性能预测**：预测不同容量配置下的缓存命中率，辅助资源规划
-4. **问题诊断**：通过 Radix Tree 可视化和详细统计，帮助理解缓存行为和性能瓶颈
+In large language model (LLM) inference scenarios, KV Cache management is critical to system performance. Different eviction policies, cache capacity configurations, and storage tier settings significantly affect cache hit rate and overall inference efficiency. The design motivations of the Optimizer module include:
 
-## 特性与架构
+1. **Policy evaluation**: Before deploying to production, evaluate the effectiveness of different eviction policies through trace replay and select the optimal configuration
+2. **Parameter tuning**: Analyze cache access patterns and provide optimization suggestions for eviction policy parameters (such as sample rate, TTL, etc.)
+3. **Performance prediction**: Predict cache hit rate under different capacity configurations to assist resource planning
+4. **Problem diagnosis**: Help understand cache behavior and performance bottlenecks through Radix Tree visualization and detailed statistics
 
-### 核心特性
+## Features and Architecture
 
-- **多种驱逐策略**：支持 LRU、RandomLRU、LeafAwareLRU、TTL 等驱逐算法
-- **TTL 过期机制**：当前采用 V1 语义，仅 `POLICY_TTL` 执行 TTL 过期物理清理
-- **分层存储**：支持多层级存储配置，目前功能不完备
-- **Trace 回放**：支持 Publisher Log、Qwen Bailian 等多种 trace 格式
-- **详细统计**：提供命中率、缓存使用情况等详细统计
-- **灵活配置**：通过 JSON 配置文件灵活配置实例、存储和策略
-- **可视化分析**：支持 Radix Tree 可视化和命中率图表生成
+### Core Features
 
-标准策略配置、multi-instance replay、trace schema 和命中率口径见 [docs/strategy_config.md](docs/strategy_config.md)。标准版中 `HitRate` 统一表示整体 token hit rate，即 `HitTokens / InputTokens`；local/remote 只作为 trace `block_mask` 与 optimizer 模拟命中的诊断拆分，不作为标准结论维度。传入 optimizer config 的 Python 入口统一使用配置中的 `output_result_path`；`multi_instance_replay` 不读取完整 config，使用显式 `--output-dir`。标准 `get` trace 必须包含 `input_len`；外部只有请求级日志时可使用 `type=request`，optimizer 会按 `trace_replay.write_delay_ns` 在内部调度 delayed write；已经拆分好的 `get` / `write` trace 仍然支持（仅限 replay 路径；LiteHit facts 回放会识别并忽略 `write` 事件，`get` 提交即视为写回完成）。
+- **Multiple eviction policies**: Supports eviction algorithms such as LRU, RandomLRU, LeafAwareLRU, and TTL
+- **TTL expiration mechanism**: Currently adopts V1 semantics; only `POLICY_TTL` performs physical cleanup of TTL-expired entries
+- **Tiered storage**: Supports multi-tier storage configuration; currently the feature is not fully complete
+- **Trace replay**: Supports multiple trace formats such as Publisher Log and Qwen Bailian
+- **Detailed statistics**: Provides detailed statistics such as hit rate and cache usage
+- **Flexible configuration**: Flexibly configure instances, storage, and policies through JSON configuration files
+- **Visual analysis**: Supports Radix Tree visualization and hit-rate chart generation
 
-### 架构设计
+Standard strategy configuration, multi-instance replay, trace schema, and hit-rate metrics are described in [docs/strategy_config.md](docs/strategy_config.md). In the standard edition, `HitRate` uniformly denotes the overall token hit rate, i.e. `HitTokens / InputTokens`; local/remote serve only as a diagnostic split between the trace `block_mask` and the optimizer's simulated hits, and are not used as a standard conclusion dimension. Python entry points that pass an optimizer config uniformly use `output_result_path` from the config; `multi_instance_replay` does not read the full config and uses an explicit `--output-dir`. A standard `get` trace must contain `input_len`; when only request-level logs are available externally, `type=request` can be used, and the optimizer will internally schedule delayed writes according to `trace_replay.write_delay_ns`; already-split `get` / `write` traces are still supported (replay path only; LiteHit facts replay recognizes and ignores `write` events, and a `get` submission is treated as write-back complete).
+
+### Architecture Design
 
 ```
-OptimizerManager (核心协调器)
-    ├── OptEvictionManager (驱逐管理器)
-    ├── OptIndexerManager (索引管理器)
-    └── OptimizerRunner (Trace 执行器)
+OptimizerManager (core coordinator)
+    ├── OptEvictionManager (eviction manager)
+    ├── OptIndexerManager (indexer manager)
+    └── OptimizerRunner (trace executor)
         ↓
-    ├── Eviction Policies (驱逐策略)
-    ├── RadixTreeIndex (索引)
-    └── Trace Converter (转换器)
+    ├── Eviction Policies
+    ├── RadixTreeIndex (index)
+    └── Trace Converter
         ↓
-    HitAnalysis (结果分析)
+    HitAnalysis (result analysis)
 ```
 
 
-### 驱逐策略
+### Eviction Policies
 
 **LRU (Least Recently Used)**
-- 维护双向链表记录块的访问顺序，最近访问的块在链表头部，最久未访问的块在链表尾部
+- Maintains a doubly linked list recording the access order of blocks; the most recently accessed block is at the head of the list, and the least recently accessed block is at the tail
 
 **RandomLRU**
-- 结合随机采样和 LRU 策略，从缓存中随机采样一定数量的块，选择最久未访问的块进行驱逐
+- Combines random sampling with the LRU policy: randomly samples a number of blocks from the cache and evicts the least recently accessed one among them
 
 **LeafAwareLRU**
-- 在 LRU 基础上增加了对叶子节点的感知，优先驱逐叶子节点中的块
+- Adds leaf-node awareness on top of LRU, preferentially evicting blocks within leaf nodes
 
 **TTL (Time-To-Live)**
-- 两阶段驱逐：先清走所有 TTL 过期的 block，若容量仍超限则按 `last_access_time` 从最旧开始兜底驱逐
-- `fallback_on_pressure`（默认 true）：关闭后退化为纯 TTL，只回收过期 block，无容量兜底
+- Two-phase eviction: first clears all TTL-expired blocks; if capacity still exceeds the limit, falls back to evicting from the oldest by `last_access_time`
+- `fallback_on_pressure` (default true): when disabled, degrades to pure TTL, only reclaiming expired blocks with no capacity fallback
 
-#### TTL 过期机制（V1）
+#### TTL Expiration Mechanism (V1)
 
-当前实现语义：
+Current implementation semantics:
 
-- 仅 `eviction_policy_type: "ttl"` 的实例会执行读写前 TTL 过期物理清理。
-- 非 TTL 策略（`lru` / `random_lru` / `leaf_aware_lru`）下，TTL 视为不存在（既不做前置清理，也不做逻辑过期判定）。
+- Only instances with `eviction_policy_type: "ttl"` perform physical TTL expiration cleanup before reads/writes.
+- Under non-TTL policies (`lru` / `random_lru` / `leaf_aware_lru`), TTL is treated as nonexistent (neither pre-cleanup nor logical expiration judgment is performed).
 
-| 使用模式 | 配置方式 | 驱逐行为 |
+| Usage mode | Configuration | Eviction behavior |
 |---|---|---|
-| 纯 LRU 容量管理 | `eviction_policy_type: "lru"` | LRU 按访问时间驱逐 |
-| TTL 优先 + 容量兜底 | `eviction_policy_type: "ttl"` + `fallback_on_pressure: true` | 先清所有过期 block，不够则按链表尾部兜底 |
-| 纯时间驱逐（无兜底） | `eviction_policy_type: "ttl"` + `fallback_on_pressure: false` | 只清过期 block，容量不足不管 |
+| Pure LRU capacity management | `eviction_policy_type: "lru"` | LRU evicts by access time |
+| TTL priority + capacity fallback | `eviction_policy_type: "ttl"` + `fallback_on_pressure: true` | First clears all expired blocks; if insufficient, falls back by list tail |
+| Pure time eviction (no fallback) | `eviction_policy_type: "ttl"` + `fallback_on_pressure: false` | Only clears expired blocks; ignores capacity shortage |
 
-**TTL 行为规则**：
-- `default_block_ttl_seconds`：在 instance group 级别配置，`0` 表示组级禁用 TTL。
-- `ttl_refresh_on_read`：控制读命中是否刷新 TTL 锚点；默认 `true`（Sliding TTL），`false` 时读不续命。
-- 组级禁用 TTL 时，请求级 `ttl_seconds > 0` 不生效（写入路径会强制关闭 TTL）。
-- 写入时，`ttl_anchor_time` 重置为写入时间，TTL 从该锚点开始计时。
-- 读取时（`PrefixQuery`），`last_access_time` 总是刷新；仅在 `ttl_refresh_on_read=true` 时刷新 `ttl_anchor_time`。
-- 读写请求执行前，会先进行一次 TTL 过期块物理清理，并由 `CleanEvictedBlocks` 统一做节点清理。
-- 写入完成后，`CheckAndEvict` 负责容量驱逐；当 `fallback_on_pressure=false` 时跳过容量驱逐。
-- `POLICY_TTL` 过期清理已优化为基于最小过期时间堆（min-heap）的增量回收，避免每次请求全链表扫描。
+**TTL behavior rules**:
+- `default_block_ttl_seconds`: configured at the instance group level; `0` means TTL is disabled at the group level.
+- `ttl_refresh_on_read`: controls whether a read hit refreshes the TTL anchor; default `true` (Sliding TTL); when `false`, reads do not extend lifetime.
+- When TTL is disabled at the group level, request-level `ttl_seconds > 0` does not take effect (the write path forcibly disables TTL).
+- On write, `ttl_anchor_time` is reset to the write time, and TTL starts counting from that anchor.
+- On read (`PrefixQuery`), `last_access_time` is always refreshed; `ttl_anchor_time` is refreshed only when `ttl_refresh_on_read=true`.
+- Before a read/write request is executed, a physical cleanup of TTL-expired blocks is performed first, and `CleanEvictedBlocks` uniformly handles node cleanup.
+- After a write completes, `CheckAndEvict` handles capacity eviction; when `fallback_on_pressure=false`, capacity eviction is skipped.
+- `POLICY_TTL` expiration cleanup has been optimized to incremental reclamation based on a min-heap of expiration times, avoiding a full list scan on every request.
 
-**TTL 生命周期统计注意事项（重要）**：
-- TTL 模式下的 Block 生命周期统计（`birth_time_us/death_time_us/lifespan_us`）仅反映系统实际处理事件的时间点，不代表真实过期时刻。
-- 由于当前采用写后惰性驱逐（Lazy Eviction），`death_time_us` 记录的是被系统清理/处理的时间，而非严格的 `last_access_time + ttl`。
-- 因此 TTL 场景下的生命周期数据仅用于相对趋势分析，不建议用于精确时长评估或跨策略精确对比。
+**TTL lifecycle statistics notes (important)**:
+- Block lifecycle statistics in TTL mode (`birth_time_us/death_time_us/lifespan_us`) only reflect the time points at which the system actually processes events, not the real expiration moments.
+- Because the current implementation uses lazy eviction after write, `death_time_us` records the time when the block is cleaned up/processed by the system, not strictly `last_access_time + ttl`.
+- Therefore, lifecycle data in TTL scenarios should only be used for relative trend analysis, and is not recommended for precise duration estimation or precise cross-policy comparison.
 
-**Per-request TTL 覆盖**（通过 `WriteCache` API）：
+**Per-request TTL override** (via the `WriteCache` API):
 
-| `ttl_seconds` 值 | 含义 |
+| `ttl_seconds` value | Meaning |
 |---|---|
-| `0`（默认） | 使用 group 的 `default_block_ttl_seconds` |
-| `-1` | 禁用 TTL，该 block 永不过期 |
-| `>0` | 自定义 TTL（秒）；若 group 已禁用 TTL（`default_block_ttl_seconds=0`），该值会被忽略 |
+| `0` (default) | Use the group's `default_block_ttl_seconds` |
+| `-1` | Disable TTL; the block never expires |
+| `>0` | Custom TTL (seconds); if the group has disabled TTL (`default_block_ttl_seconds=0`), this value is ignored |
 
-### Trace 类型
+### Trace Types
 
 ```
-OptimizerSchemaTrace (基类)
-    ├── GetLocationSchemaTrace (读操作)
-    └── WriteCacheSchemaTrace (写操作)
+OptimizerSchemaTrace (base class)
+    ├── GetLocationSchemaTrace (read operation)
+    └── WriteCacheSchemaTrace (write operation)
 ```
 
-**支持的 Trace 格式**
-- **Publisher Log**：KVCacheManager Event Publisher 日志，区分读写请求
-- **Qwen Bailian**：百炼开源数据集格式，转换后强制区分读写请求
+**Supported Trace Formats**
+- **Publisher Log**: KVCacheManager Event Publisher log, distinguishing read and write requests
+- **Qwen Bailian**: Qwen Bailian open-source dataset format; forcibly distinguishes read and write requests after conversion
 
-## 快速开始
+## Quick Start
 
-### 步骤1: 转换trace为标准格式
+### Step 1: Convert trace to standard format
 
 ```bash
 cd tools/trace_converter
 
-# 安装依赖 (首次使用)
+# Install dependencies (first time only)
 pip install -r requirements.txt
 
-# 转换trace
+# Convert trace
 python trace_converter.py \
     -i /path/to/your_trace.jsonl \
     -o /path/to/optimizer_trace.jsonl \
@@ -131,7 +133,7 @@ python trace_converter.py \
     --mode optimizer
 ```
 
-### 步骤2: 编译 Optimizer
+### Step 2: Build the Optimizer
 
 ```bash
 bazel build \
@@ -139,9 +141,9 @@ bazel build \
     //kv_cache_manager/optimizer/analysis/script:optimizer_run
 ```
 
-### 步骤3: 创建配置文件
+### Step 3: Create a configuration file
 
-创建 JSON 配置文件。下面是非分层 LRU 的最小可用配置；trace 中的 `instance_id` 必须能匹配这里的 `instances[].instance_id`。
+Create a JSON configuration file. Below is a minimal usable configuration for non-tiered LRU; the `instance_id` in the trace must match the `instances[].instance_id` here.
 
 ```json
 {
@@ -186,18 +188,18 @@ bazel build \
 ```
 
 
-### 步骤4: 运行Optimizer
+### Step 4: Run the Optimizer
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     -c /path/to/config.json
 ```
 
-运行完成后，会在 `output_result_path` 指定的目录下生成：
+After running, the following is generated in the directory specified by `output_result_path`:
 
-- `{instance_id}_hit_rates.csv` - 每个 instance 的命中率数据
+- `{instance_id}_hit_rates.csv` - hit-rate data for each instance
 
-需要画命中率时序图时加 `--draw-chart`：
+To draw a hit-rate time-series chart, add `--draw-chart`:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
@@ -205,29 +207,29 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     --draw-chart
 ```
 
-常见入口速查：
+Quick reference for common entry points:
 
-| 需求 | 推荐入口 |
+| Need | Recommended entry point |
 |---|---|
-| 单次回放、输出 `*_hit_rates.csv` | `optimizer_run -c config.json` |
-| 单次回放并画时序图 | `optimizer_run -c config.json --draw-chart` |
-| 无限容量理论命中率 | config 中将 `quota_capacity` 或 tier `capacity` 设为 `-1` 后运行 `optimizer_run` |
-| 非分层容量 Pareto | `tradeoff -c config.json --num-points 30` |
-| 多驱逐策略 Pareto | `tradeoff -c config.json --eviction-policies lru random_lru leaf_aware_lru ttl` |
-| 每个 pod/instance 独立缓存回放 | `multi_instance_replay --trace-dir ... --output-dir ...` |
-| 导出生命周期 CSV | `optimizer_run -c config.json --export-lifecycle` |
-| 分析 lifecycle 图表 | `analyze_lifecycle -i <lifecycle.csv 或目录>` |
-| 导出/可视化 RadixTree | `export_tree -c config.json --show-hot-paths` |
+| Single replay, output `*_hit_rates.csv` | `optimizer_run -c config.json` |
+| Single replay with time-series chart | `optimizer_run -c config.json --draw-chart` |
+| Infinite-capacity theoretical hit rate | Set `quota_capacity` or tier `capacity` to `-1` in config, then run `optimizer_run` |
+| Non-tiered capacity Pareto | `tradeoff -c config.json --num-points 30` |
+| Multi eviction-policy Pareto | `tradeoff -c config.json --eviction-policies lru random_lru leaf_aware_lru ttl` |
+| Per-pod/instance independent cache replay | `multi_instance_replay --trace-dir ... --output-dir ...` |
+| Export lifecycle CSV | `optimizer_run -c config.json --export-lifecycle` |
+| Analyze lifecycle charts | `analyze_lifecycle -i <lifecycle.csv or dir>` |
+| Export/visualize RadixTree | `export_tree -c config.json --show-hot-paths` |
 
-### 可视化分析
+### Visual Analysis
 
-Optimizer 模块提供多种可视化分析工具，用于分析缓存性能、命中率和 Radix Tree 结构。
+The Optimizer module provides a variety of visual analysis tools for analyzing cache performance, hit rate, and Radix Tree structure.
 
-#### 命中率随时间变化图表
+#### Hit Rate Over Time Chart
 
-运行optimizer，分析trace并绘制多实例缓存分析图表，展示所有 instance 的存储容量总和以及各自命中率随时间的变化。
+Run the optimizer to analyze the trace and draw multi-instance cache analysis charts, showing the sum of storage capacity across all instances and their respective hit rates over time.
 
-**注意**: 配置文件中的 `trace_file_path` 必须是标准格式trace文件。
+**Note**: The `trace_file_path` in the configuration file must be a standard-format trace file.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
@@ -235,27 +237,27 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     --draw-chart
 ```
 
-**输出**：`{output_result_path}/timeseries/multi_instance_cache_analysis.png`
+**Output**: `{output_result_path}/timeseries/multi_instance_cache_analysis.png`
 
-#### Radix Tree 可视化
+#### Radix Tree Visualization
 
-导出并可视化前缀树结构，统计并展示热节点以及所属节点的前缀路径。
-具体配置见 `analysis/script/run/export_tree.py`。
+Export and visualize the prefix tree structure, counting and displaying hot nodes and the prefix paths of their associated nodes.
+See `analysis/script/run/export_tree.py` for specific configuration.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:export_tree -- \
     -c /path/to/config.json
 ```
 
-**输出**：
-- `{output_result_path}/radix_tree/{instance_id}_radix_tree.json` - Radix Tree 导出数据
-- `{output_result_path}/radix_tree/{instance_id}_radix_tree.png` - Radix Tree 可视化图表
+**Output**:
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.json` - Radix Tree export data
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.png` - Radix Tree visualization chart
 
-#### Pareto 容量-命中率曲线分析
+#### Pareto Capacity-Hit-Rate Curve Analysis
 
-统一入口是 `tradeoff`。它先用无限容量 warmup 获取理论命中率和最大缓存量，然后按容量点回放 optimizer，绘制容量与命中率的 Pareto 曲线。
+The unified entry point is `tradeoff`. It first uses infinite-capacity warmup to obtain the theoretical hit rate and maximum cache size, then replays the optimizer per capacity point and draws the Pareto curve of capacity versus hit rate.
 
-> **适用范围**：Tradeoff 只适用于非分层模式。在分层模式下，容量扫描只修改 `quota_capacity`，不会修改各 tier 的 `storages[i].capacity`，因此不能代表真实分层容量权衡。
+> **Scope of applicability**: Tradeoff only applies to non-tiered mode. In tiered mode, the capacity scan only modifies `quota_capacity` and does not modify each tier's `storages[i].capacity`, so it cannot represent the real tiered capacity tradeoff.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
@@ -266,19 +268,19 @@ bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     --max-workers 4
 ```
 
-**参数说明**：
-- `-c, --config` - 配置文件路径
-- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中率后提前停止
-- `--min-capacity-ratio` - 最小容量点相对阈值（默认 `1e-4`）
-- `--hit-rate-type` - 命中率类型：total/local/remote/all（默认 total）
-- `--max-workers` - 并行执行的最大线程数（默认 4）
-- `--plot-title` - 覆盖图标题
+**Parameter description**:
+- `-c, --config` - configuration file path
+- `--num-points` - maximum number of capacity sampling points to run per policy (default 30); stops early after reaching 99% of the theoretical hit rate
+- `--min-capacity-ratio` - minimum capacity point relative threshold (default `1e-4`)
+- `--hit-rate-type` - hit-rate type: total/local/remote/all (default total)
+- `--max-workers` - maximum number of parallel execution threads (default 4)
+- `--plot-title` - override the chart title
 
-**输出**：`{output_result_path}/pareto/pareto_curve_{hit_rate_type}.png`
+**Output**: `{output_result_path}/pareto/pareto_curve_{hit_rate_type}.png`
 
-#### 多策略对比分析
+#### Multi-Policy Comparison Analysis
 
-通过 `--eviction-policies` 对比多个驱逐策略。每个策略独立 warmup、独立计算理论命中率，并独立在达到 99% 理论命中后停止。
+Compare multiple eviction policies via `--eviction-policies`. Each policy warms up independently, computes its theoretical hit rate independently, and independently stops after reaching 99% of the theoretical hit rate.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
@@ -289,82 +291,82 @@ bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     --max-workers 4
 ```
 
-**参数说明**：
-- `-c, --config` - 配置文件路径
-- `--eviction-policies` - 要对比的驱逐策略列表（默认 lru random_lru leaf_aware_lru ttl）
-- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中率后提前停止
-- `--hit-rate-type` - 命中率类型：total/local/remote/all（默认 total）
-- `--max-workers` - 并行执行的最大线程数（默认 4）
+**Parameter description**:
+- `-c, --config` - configuration file path
+- `--eviction-policies` - list of eviction policies to compare (default lru random_lru leaf_aware_lru ttl)
+- `--num-points` - maximum number of capacity sampling points to run per policy (default 30); stops early after reaching 99% of the theoretical hit rate
+- `--hit-rate-type` - hit-rate type: total/local/remote/all (default total)
+- `--max-workers` - maximum number of parallel execution threads (default 4)
 
-**输出**：`{output_result_path}/pareto/multi_policy_{hit_rate_type}.png`
+**Output**: `{output_result_path}/pareto/multi_policy_{hit_rate_type}.png`
 
-图形规则：X 轴为 `Capacity (GB)`，Y 轴为 `HitRate (%)`；曲线从 `(0 GB, 0%)` 开始，只画上升段；95% 和 99% 理论命中率用插值交点、虚线和标签标出。若某个容量点出现下降，会从图上剔除并在日志中打印，原始 CSV 保留。
+Chart rules: the X axis is `Capacity (GB)`, the Y axis is `HitRate (%)`; the curve starts from `(0 GB, 0%)` and only the rising segment is drawn; the 95% and 99% theoretical hit rates are marked with interpolation intersections, dashed lines, and labels. If a capacity point shows a decrease, it is removed from the chart and printed in the log, while the original CSV is retained.
 
-### Python 接口示例
+### Python Interface Example
 
 ```python
 from kv_cache_manager.optimizer import OptimizerConfigLoader, OptimizerLoader, OptimizerManager
 
-# 加载配置
+# Load configuration
 config_loader = OptimizerConfigLoader()
 config = config_loader.Load("/path/to/config.json")
 
-# 创建优化器
+# Create the optimizer
 optimizer = OptimizerManager(config)
 optimizer.Init()
 
-# 运行
+# Run
 optimizer.DirectRun()
 
-# 分析结果
+# Analyze results
 optimizer.AnalyzeResults()
 
-# 单次读写操作（需要指定instance_id）
+# Single read/write operations (instance_id must be specified)
 write_res = optimizer.WriteCache("instance_id", "trace_001", timestamp, block_ids)
 read_res = optimizer.GetCacheLocation("instance_id", "trace_002", timestamp, block_ids, block_mask,
                                       input_len=real_prompt_tokens)
 
-# 写入时指定 TTL（可选）
+# Specify TTL on write (optional)
 write_res = optimizer.WriteCache("instance_id", "trace_003", timestamp, block_ids,
-                                  ttl_seconds=0)     # 使用 group 默认
+                                  ttl_seconds=0)     # Use group default
 write_res = optimizer.WriteCache("instance_id", "trace_004", timestamp, block_ids,
-                                  ttl_seconds=-1)    # 禁用 TTL，永不过期
+                                  ttl_seconds=-1)    # Disable TTL, never expires
 write_res = optimizer.WriteCache("instance_id", "trace_005", timestamp, block_ids,
-                                  ttl_seconds=300)   # 自定义 300 秒
+                                  ttl_seconds=300)   # Custom 300 seconds
 
-# 清空缓存（保留统计）
-optimizer.ClearCache("instance_id")        # 清空指定实例
-optimizer.ClearAllCaches()                 # 清空所有实例
+# Clear cache (keep statistics)
+optimizer.ClearCache("instance_id")        # Clear the specified instance
+optimizer.ClearAllCaches()                 # Clear all instances
 
-# 清空缓存并重置统计
-optimizer.ClearCacheAndResetStats("instance_id")  # 清空指定实例并重置统计
-optimizer.ClearAllCachesAndResetStats()           # 清空所有实例并重置统计
+# Clear cache and reset statistics
+optimizer.ClearCacheAndResetStats("instance_id")  # Clear the specified instance and reset statistics
+optimizer.ClearAllCachesAndResetStats()           # Clear all instances and reset statistics
 ```
 
-### 配置参数说明
+### Configuration Parameter Description
 
-| 参数 | 说明 |
+| Parameter | Description |
 |------|------|
-| eviction_mode | 驱逐模式：1=GROUP_ROUGH, 2=INSTANCE_ROUGH, 3=INSTANCE_PRECISE |
-| eviction_policy_type | 驱逐策略类型：lru、random_lru、leaf_aware_lru、ttl |
-| quota_capacity | 非分层模式下的 group 总容量，单位 GB；`-1` 表示无限容量，不触发容量驱逐 |
-| storages[].capacity | 分层模式下单个 tier 的容量，单位 GB；`-1` 表示该 tier 无限容量 |
-| tier_strategy | 多层读写策略包，包含分层驱逐开关、写入模式、读访问传播、promote 和 selective write 阈值；顶层字段是所有相邻 tier edge 的默认策略 |
-| tier_strategy.write_mode | 写入/下沉模式：`write_through`、`cascading`、`write_through_selective` |
-| tier_strategy.access_propagation_enabled | 读命中上层副本时是否刷新下层副本访问时间；它不是写入模式 |
-| tier_strategy.tier_flows | 相邻 tier edge 的策略覆盖；未覆盖 edge 继承 `tier_strategy` 默认策略 |
-| bytes_per_token | 单 token KV 大小；Python 分析脚本用它和 `block_size` 将 block 容量换算为 GB |
-| default_block_ttl_seconds | instance group 级别的默认 TTL（秒），0 = 关闭 TTL |
-| ttl_refresh_on_read | instance group 级别 TTL 续命开关：true=读续命，false=固定窗口 |
-| fallback_on_pressure | TTL 策略参数：过期不够时是否按 LRU 兜底（默认 true） |
+| eviction_mode | Eviction mode: 1=GROUP_ROUGH, 2=INSTANCE_ROUGH, 3=INSTANCE_PRECISE |
+| eviction_policy_type | Eviction policy type: lru, random_lru, leaf_aware_lru, ttl |
+| quota_capacity | Total group capacity in non-tiered mode, in GB; `-1` means infinite capacity, no capacity eviction triggered |
+| storages[].capacity | Capacity of a single tier in tiered mode, in GB; `-1` means infinite capacity for that tier |
+| tier_strategy | Multi-tier read/write policy package, including hierarchical eviction switch, write mode, read access propagation, promote and selective write thresholds; top-level fields are the default policy for all adjacent tier edges |
+| tier_strategy.write_mode | Write/sink mode: `write_through`, `cascading`, `write_through_selective` |
+| tier_strategy.access_propagation_enabled | Whether to refresh the access time of lower-tier copies when a read hits an upper-tier copy; it is not a write mode |
+| tier_strategy.tier_flows | Policy overrides for adjacent tier edges; edges not overridden inherit the `tier_strategy` default policy |
+| bytes_per_token | KV size per token; Python analysis scripts use it together with `block_size` to convert block capacity to GB |
+| default_block_ttl_seconds | Default TTL (seconds) at the instance group level; 0 = disable TTL |
+| ttl_refresh_on_read | TTL refresh switch at the instance group level: true=read refreshes, false=fixed window |
+| fallback_on_pressure | TTL policy parameter: whether to fall back to LRU when expiration is insufficient (default true) |
 
-## 使用案例
+## Use Cases
 
-下面的案例都假设输入已经是标准 optimizer JSONL trace。标准结论使用 token hit rate，即 CSV 最后一行的 `AccHitRate = AccHitTokens / AccInputTokens`。示例中的 JSON 多数只展示 `instance_groups[]` 中的一项，完整 config 仍需要顶层 `trace_file_path`、`output_result_path` 和 `eviction_params`。
+The following cases all assume the input is already a standard optimizer JSONL trace. Standard conclusions use token hit rate, i.e. `AccHitRate = AccHitTokens / AccInputTokens` in the last row of the CSV. The JSON in the examples mostly shows only one item in `instance_groups[]`; a complete config still requires the top-level `trace_file_path`, `output_result_path`, and `eviction_params`.
 
-### 案例 1：全局池化无限容量理论命中率
+### Case 1: Global Pooled Infinite-Capacity Theoretical Hit Rate
 
-用于回答“如果容量无限，当前 trace 理论上最多能命中多少”。非分层全局池化配置中把 `quota_capacity` 设为 `-1`：
+Used to answer "if capacity were infinite, how much could the current trace theoretically hit at most". In a non-tiered global pooled configuration, set `quota_capacity` to `-1`:
 
 ```json
 {
@@ -396,19 +398,19 @@ optimizer.ClearAllCachesAndResetStats()           # 清空所有实例并重置�
 }
 ```
 
-运行：
+Run:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     -c /path/to/global_pool_unlimited.json
 ```
 
-结果看 `{output_result_path}/global_hit_rates.csv` 最后一行的 `AccHitRate`、`AccInputTokens`、`AccHitTokens`。
-如果 trace 中使用真实 pod 名作为 `instance_id`，需要把上面示例里的 `instances[].instance_id` 同步改成对应名称。
+For results, look at `AccHitRate`, `AccInputTokens`, and `AccHitTokens` in the last row of `{output_result_path}/global_hit_rates.csv`.
+If the trace uses real pod names as `instance_id`, you need to change `instances[].instance_id` in the example above to the corresponding names.
 
-### 案例 2：单层有限容量回放
+### Case 2: Single-Tier Finite-Capacity Replay
 
-用于评估给定容量下的实际 token 命中率。非分层模式只需要设置 `quota_capacity`，单位是 GB：
+Used to evaluate the actual token hit rate under a given capacity. Non-tiered mode only requires setting `quota_capacity`, in GB:
 
 ```json
 {
@@ -426,7 +428,7 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
 }
 ```
 
-`block_size * bytes_per_token` 决定一个 block 对应的 KV 容量；Pareto 图和容量输出都依赖这个换算。
+`block_size * bytes_per_token` determines the KV capacity corresponding to one block; Pareto charts and capacity output all depend on this conversion.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
@@ -434,14 +436,14 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     --draw-chart
 ```
 
-输出：
+Output:
 
 - `{output_result_path}/*_hit_rates.csv`
 - `{output_result_path}/timeseries/multi_instance_cache_analysis.png`
 
-### 案例 3：HBM + DRAM 分层回放，write-through，读不更新下层
+### Case 3: HBM + DRAM Tiered Replay, write-through, reads do not update lower tier
 
-用于模拟线上多层缓存。`hierarchical_eviction_enabled=true` 时，每层按 `storages[].capacity` 独立驱逐；此时 `quota_capacity` 只是保留字段，不用于每层驱逐。
+Used to simulate online multi-tier caching. When `hierarchical_eviction_enabled=true`, each tier evicts independently according to `storages[].capacity`; in this case `quota_capacity` is only a reserved field and is not used for per-tier eviction.
 
 ```json
 {
@@ -474,7 +476,7 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
 }
 ```
 
-运行：
+Run:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
@@ -482,11 +484,11 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     --draw-chart
 ```
 
-分层结果看 `Tier<N>(name)_HitTokens`、`AccTier<N>(name)_HitRate` 和 `Tier<N>(name)_BlockNum`，图在 `{output_result_path}/timeseries/per_tier_timeseries.png`。
+For tiered results, look at `Tier<N>(name)_HitTokens`, `AccTier<N>(name)_HitRate`, and `Tier<N>(name)_BlockNum`; the chart is at `{output_result_path}/timeseries/per_tier_timeseries.png`.
 
-### 案例 4：三层 HBM + DRAM + L3，前两层 write-through，DRAM 到 L3 cascading
+### Case 4: Three-Tier HBM + DRAM + L3, first two tiers write-through, DRAM to L3 cascading
 
-当每条 edge 策略不一致时，用 `tier_flows` 覆盖默认策略：
+When the policy differs per edge, use `tier_flows` to override the default policy:
 
 ```json
 {
@@ -521,11 +523,11 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
 }
 ```
 
-`tier_strategy` 顶层字段是默认 edge 策略；`tier_flows` 只覆盖指定相邻 edge。
+The top-level fields of `tier_strategy` are the default edge policy; `tier_flows` only overrides the specified adjacent edges.
 
-### 案例 5：每个 pod 独立缓存回放并聚合全局命中率
+### Case 5: Per-Pod Independent Cache Replay with Global Hit-Rate Aggregation
 
-当线上每个 pod/实例独立缓存时，用 `multi_instance_replay`。输入目录下每个 JSONL 文件只能包含一个 `instance_id`。
+When each online pod/instance caches independently, use `multi_instance_replay`. Each JSONL file in the input directory can only contain one `instance_id`.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:multi_instance_replay -- \
@@ -544,18 +546,18 @@ bazel run //kv_cache_manager/optimizer/analysis/script:multi_instance_replay -- 
     --window-seconds 60
 ```
 
-输出：
+Output:
 
-- `<output_dir>/<instance_id>_hit_rates.csv`：每个 pod 的回放结果
-- `<output_dir>/aggregate/instance_aggregate.csv`：每个 pod 汇总
-- `<output_dir>/aggregate/global_aggregate.csv`：所有 pod 聚合后的整体命中率
-- `<output_dir>/aggregate/global_window_hit_rates.csv`：窗口级整体命中率
+- `<output_dir>/<instance_id>_hit_rates.csv`: replay result for each pod
+- `<output_dir>/aggregate/instance_aggregate.csv`: summary per pod
+- `<output_dir>/aggregate/global_aggregate.csv`: overall hit rate after aggregating all pods
+- `<output_dir>/aggregate/global_window_hit_rates.csv`: window-level overall hit rate
 
-当前 `multi_instance_replay` CLI 直接支持 L1/L2 两层。需要 L3 或更复杂拓扑时，使用完整 optimizer config 或扩展脚本。
+The current `multi_instance_replay` CLI directly supports two tiers, L1/L2. When L3 or more complex topologies are needed, use a full optimizer config or extend the script.
 
-### 案例 6：容量 Pareto 图
+### Case 6: Capacity Pareto Chart
 
-非分层容量扫描使用 `tradeoff`。脚本先跑无限容量 warmup 获取理论命中率，再生成容量点；达到 99% 理论命中后停止。
+Non-tiered capacity scanning uses `tradeoff`. The script first runs an infinite-capacity warmup to obtain the theoretical hit rate, then generates capacity points; it stops after reaching 99% of the theoretical hit rate.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
@@ -567,7 +569,7 @@ bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     --plot-title "service-a Pareto"
 ```
 
-多策略对比：
+Multi-policy comparison:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
@@ -578,16 +580,16 @@ bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     --max-workers 8
 ```
 
-输出：
+Output:
 
 - `{output_result_path}/pareto/pareto_curve_total.png`
 - `{output_result_path}/pareto/multi_policy_total.png`
 
-图上会标出 95%/99% 理论命中对应容量；下降点只从图上剔除，原始 CSV 不改。
+The chart marks the capacities corresponding to 95%/99% theoretical hit rate; decreasing points are only removed from the chart, and the original CSV is not modified.
 
-### 案例 7：Block 生命周期分析
+### Case 7: Block Lifecycle Analysis
 
-先在回放时导出 lifecycle CSV：
+First export the lifecycle CSV during replay:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
@@ -595,14 +597,14 @@ bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     --export-lifecycle
 ```
 
-再生成生命周期统计和图：
+Then generate lifecycle statistics and charts:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:analyze_lifecycle -- \
     -i /path/to/output_result_path
 ```
 
-只打印统计、不画图：
+To print statistics only, without drawing charts:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:analyze_lifecycle -- \
@@ -610,9 +612,9 @@ bazel run //kv_cache_manager/optimizer/analysis/script:analyze_lifecycle -- \
     --stats-only
 ```
 
-### 案例 8：RadixTree 热点路径排查
+### Case 8: RadixTree Hot Path Troubleshooting
 
-用于看热点前缀、叶子节点和已缓存/已驱逐 block：
+Used to inspect hot prefixes, leaf nodes, and cached/evicted blocks:
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:export_tree -- \
@@ -622,56 +624,56 @@ bazel run //kv_cache_manager/optimizer/analysis/script:export_tree -- \
     --show-blocks
 ```
 
-输出：
+Output:
 
 - `{output_result_path}/radix_tree/{instance_id}_radix_tree.json`
 - `{output_result_path}/radix_tree/{instance_id}_hot_paths.png`
 
-### 案例 9：结果读取口径
+### Case 9: Result Reading Metrics
 
-标准报告只看 token hit rate：
+Standard reports only look at token hit rate:
 
-| 指标 | 说明 |
+| Metric | Description |
 |---|---|
-| `InputTokens` / `AccInputTokens` | 当前 / 累计输入 token 数 |
-| `HitTokens` / `AccHitTokens` | 当前 / 累计命中 token 数 |
-| `HitRate` | 当前请求 token 命中率 |
-| `AccHitRate` | 累计 token 命中率，主要结论看这一列 |
-| `ReadBlocks` / `HitBlocks` | block 级诊断字段，不作为最终命中率口径 |
-| `Tier<N>(name)_HitTokens` | 分层命中 token 数 |
-| `AccTier<N>(name)_HitRate` | 分层累计 token 命中率 |
+| `InputTokens` / `AccInputTokens` | Current / cumulative input token count |
+| `HitTokens` / `AccHitTokens` | Current / cumulative hit token count |
+| `HitRate` | Current request token hit rate |
+| `AccHitRate` | Cumulative token hit rate; the main conclusion looks at this column |
+| `ReadBlocks` / `HitBlocks` | Block-level diagnostic fields, not used as the final hit-rate metric |
+| `Tier<N>(name)_HitTokens` | Tiered hit token count |
+| `AccTier<N>(name)_HitRate` | Tiered cumulative token hit rate |
 
 
-## Trace 输入格式
+## Trace Input Format
 
-### 概述
+### Overview
 
-Optimizer 只接受标准格式的trace文件。使用独立的Python工具将各种trace格式转换为标准格式。
+The Optimizer only accepts standard-format trace files. Use a standalone Python tool to convert various trace formats to the standard format.
 
-### 标准格式
+### Standard Format
 
-Optimizer 支持两种标准 trace 类型：
+The Optimizer supports two standard trace types:
 
-- **GetLocationSchemaTrace**: 读操作 (prefill阶段)
-- **WriteCacheSchemaTrace**: 写操作 (decode阶段)
+- **GetLocationSchemaTrace**: read operation (prefill phase)
+- **WriteCacheSchemaTrace**: write operation (decode phase)
 
-**推荐**: 所有Optimizer输入统一使用Get+Write格式以保留精确的读写时序。
-标准 `get` trace 必须包含 `input_len`；`keys` 只能包含完整 block key，不足一个 block 的尾部 token 不写入 `keys`，但仍计入 `InputTokens`。
+**Recommendation**: Unify all Optimizer inputs to the Get+Write format to preserve precise read/write timing.
+A standard `get` trace must contain `input_len`; `keys` can only contain complete block keys — trailing tokens that do not fill a full block are not written into `keys`, but are still counted into `InputTokens`.
 
 ---
 
-### 转换工具
+### Conversion Tool
 
-使用独立的Python工具转换各种格式 (无需bazel):
+Use a standalone Python tool to convert various formats (no bazel required):
 
 ```bash
-# 进入工具目录
+# Enter the tool directory
 cd tools/trace_converter
 
-# 安装依赖 (首次使用)
+# Install dependencies (first time only)
 pip install -r requirements.txt
 
-# 转换trace为Optimizer格式
+# Convert trace to Optimizer format
 python trace_converter.py \
     -i your_trace.log \
     -o optimizer_trace.jsonl \
@@ -680,31 +682,31 @@ python trace_converter.py \
 
 ```
 
-**支持的格式**:
-- `publisher_log`: KVCacheManager Event Publisher日志
-- `qwen_bailian`: Qwen Bailian开源数据集
-- `text`: 文本对话 (需要指定--tokenizer-path)
+**Supported formats**:
+- `publisher_log`: KVCacheManager Event Publisher log
+- `qwen_bailian`: Qwen Bailian open-source dataset
+- `text`: text conversation (requires specifying --tokenizer-path)
 
-**自动发现 Converter**:
+**Auto-discovery of Converters**:
 
-系统会自动扫描并发现所有可用的 converter：
+The system automatically scans and discovers all available converters:
 
 ```bash
-# 使用内置 converter
+# Use a built-in converter
 python3 trace_converter.py -i input.jsonl -o output.jsonl -f qwen_bailian
 
-# 使用自定义 converter
+# Use a custom converter
 python3 trace_converter.py -i input.jsonl -o output.jsonl -f custom \
     --converter-module /path/to/custom_converter.py
 ```
 
-详见: [Trace Converter文档](tools/trace_converter/README.md)
+See: [Trace Converter documentation](tools/trace_converter/README.md)
 
 ---
 
-### 配置文件
+### Configuration File
 
-**新版配置**:
+**New configuration**:
 ```json
 {
     "trace_file_path": "/path/to/optimizer_trace.jsonl",
@@ -740,17 +742,17 @@ python3 trace_converter.py -i input.jsonl -o output.jsonl -f custom \
 }
 ```
 
-**注意**: 
-- `trace_file_path` 必须是标准格式文件
+**Note**:
+- `trace_file_path` must be a standard-format file
 
 ---
 
-### 使用示例
+### Usage Example
 
-完整流程:
+Complete workflow:
 
 ```bash
-# 步骤1: 转换trace
+# Step 1: Convert trace
 cd tools/trace_converter
 python trace_converter.py \
     -i /path/to/qwen_trace.jsonl \
@@ -758,47 +760,47 @@ python trace_converter.py \
     -f qwen_bailian \
     --mode optimizer
 
-# 步骤2: 运行Optimizer
+# Step 2: Run the Optimizer
 cd ../..
 bazel run //kv_cache_manager/optimizer:optimizer_main -- /path/to/config.json
 ```
 
 ---
 
-### 添加自定义 Trace Converter
+### Adding a Custom Trace Converter
 
-如果需要支持新的 trace 格式,在Python工具中添加新的converter:
+If you need to support a new trace format, add a new converter in the Python tool:
 
-1. **创建Converter类**: 在任意目录创建新文件
+1. **Create a Converter class**: create a new file in any directory
    ```python
    from converters.base import BaseConverter
    
    class MyCustomConverter(BaseConverter):
        def convert(self, input_file: str, output_file: str) -> int:
-           # 实现转换逻辑
+           # Implement conversion logic
            pass
    ```
 
-2. **使用 - 方式1 (自动扫描目录)**:
+2. **Usage - Option 1 (auto-scan directory)**:
    ```bash
-   # 将converter文件放到指定目录，自动发现所有继承BaseConverter的类
+   # Place the converter file in the specified directory; automatically discovers all classes inheriting BaseConverter
    python trace_converter.py -i input.log -o output.jsonl -f my_custom \
        --converter-dir /path/to/your/converters
    ```
 
-3. **使用 - 方式2 (显式注册文件)**:
+3. **Usage - Option 2 (explicitly register file)**:
    ```bash
-   # 直接指定converter文件和类名
+   # Directly specify the converter file and class name
    python trace_converter.py -i input.log -o output.jsonl -f my_custom \
        --converter-module /path/to/my_custom_converter.py:MyCustomConverter
    ```
 
-**无需修改 `trace_converter.py` 源码** Converter会根据类名自动推断format名称：
+**No need to modify the `trace_converter.py` source code** — the Converter automatically infers the format name from the class name:
 - `MyCustomConverter` → `my_custom`
 - `QwenBailianConverter` → `qwen_bailian`
 
 ---
 
-### 相关文档
+### Related Documentation
 
-- [Trace Converter工具文档](tools/trace_converter/README.md) - Python转换工具详细说明
+- [Trace Converter tool documentation](tools/trace_converter/README.md) - detailed description of the Python conversion tool

--- a/kv_cache_manager/optimizer/README_zh.md
+++ b/kv_cache_manager/optimizer/README_zh.md
@@ -1,0 +1,806 @@
+# KVCacheManager Optimizer
+
+> 中文 | [English](README.md)
+
+## 概述
+
+KVCacheManager Optimizer 是一个独立的缓存优化分析模块，通过回放 trace 数据来模拟缓存读写操作，评估不同驱逐策略和配置对缓存命中率的影响，并为 KVCacheManager 主程序提供参数优化能力。
+
+核心功能包括：
+- Trace 数据的回放和模拟
+- 多种驱逐策略的模拟和对比
+- 缓存命中率的实时统计和分析
+- Radix Tree 索引结构的可视化
+- LiteHit：full-attention 场景的容量无关命中率分析（一次回放产出事实，任意 LRU 容量事后投影，支持重分块与多 block size fanout），见 [liteHit/README_zh.md](liteHit/README_zh.md)
+
+## 动机
+
+在大语言模型（LLM）推理场景中，KV Cache 的管理对系统性能至关重要。不同的驱逐策略、缓存容量配置和存储层级设置会显著影响缓存命中率和整体推理效率。Optimizer 模块的设计动机包括：
+
+1. **策略评估**：在生产环境部署前，通过 trace 回放评估不同驱逐策略的效果，选择最优配置
+2. **参数调优**：分析缓存访问模式，为驱逐策略参数（如采样率、TTL 等）提供优化建议
+3. **性能预测**：预测不同容量配置下的缓存命中率，辅助资源规划
+4. **问题诊断**：通过 Radix Tree 可视化和详细统计，帮助理解缓存行为和性能瓶颈
+
+## 特性与架构
+
+### 核心特性
+
+- **多种驱逐策略**：支持 LRU、RandomLRU、LeafAwareLRU、TTL 等驱逐算法
+- **TTL 过期机制**：当前采用 V1 语义，仅 `POLICY_TTL` 执行 TTL 过期物理清理
+- **分层存储**：支持多层级存储配置，目前功能不完备
+- **Trace 回放**：支持 Publisher Log、Qwen Bailian 等多种 trace 格式
+- **详细统计**：提供命中率、缓存使用情况等详细统计
+- **灵活配置**：通过 JSON 配置文件灵活配置实例、存储和策略
+- **可视化分析**：支持 Radix Tree 可视化和命中率图表生成
+
+标准策略配置、multi-instance replay、trace schema 和命中率口径见 [docs/strategy_config_zh.md](docs/strategy_config_zh.md)。标准版中 `HitRate` 统一表示整体 token hit rate，即 `HitTokens / InputTokens`；local/remote 只作为 trace `block_mask` 与 optimizer 模拟命中的诊断拆分，不作为标准结论维度。传入 optimizer config 的 Python 入口统一使用配置中的 `output_result_path`；`multi_instance_replay` 不读取完整 config，使用显式 `--output-dir`。标准 `get` trace 必须包含 `input_len`；外部只有请求级日志时可使用 `type=request`，optimizer 会按 `trace_replay.write_delay_ns` 在内部调度 delayed write；已经拆分好的 `get` / `write` trace 仍然支持（仅限 replay 路径；LiteHit facts 回放会识别并忽略 `write` 事件，`get` 提交即视为写回完成）。
+
+### 架构设计
+
+```
+OptimizerManager (核心协调器)
+    ├── OptEvictionManager (驱逐管理器)
+    ├── OptIndexerManager (索引管理器)
+    └── OptimizerRunner (Trace 执行器)
+        ↓
+    ├── Eviction Policies (驱逐策略)
+    ├── RadixTreeIndex (索引)
+    └── Trace Converter (转换器)
+        ↓
+    HitAnalysis (结果分析)
+```
+
+
+### 驱逐策略
+
+**LRU (Least Recently Used)**
+- 维护双向链表记录块的访问顺序，最近访问的块在链表头部，最久未访问的块在链表尾部
+
+**RandomLRU**
+- 结合随机采样和 LRU 策略，从缓存中随机采样一定数量的块，选择最久未访问的块进行驱逐
+
+**LeafAwareLRU**
+- 在 LRU 基础上增加了对叶子节点的感知，优先驱逐叶子节点中的块
+
+**TTL (Time-To-Live)**
+- 两阶段驱逐：先清走所有 TTL 过期的 block，若容量仍超限则按 `last_access_time` 从最旧开始兜底驱逐
+- `fallback_on_pressure`（默认 true）：关闭后退化为纯 TTL，只回收过期 block，无容量兜底
+
+#### TTL 过期机制（V1）
+
+当前实现语义：
+
+- 仅 `eviction_policy_type: "ttl"` 的实例会执行读写前 TTL 过期物理清理。
+- 非 TTL 策略（`lru` / `random_lru` / `leaf_aware_lru`）下，TTL 视为不存在（既不做前置清理，也不做逻辑过期判定）。
+
+| 使用模式 | 配置方式 | 驱逐行为 |
+|---|---|---|
+| 纯 LRU 容量管理 | `eviction_policy_type: "lru"` | LRU 按访问时间驱逐 |
+| TTL 优先 + 容量兜底 | `eviction_policy_type: "ttl"` + `fallback_on_pressure: true` | 先清所有过期 block，不够则按链表尾部兜底 |
+| 纯时间驱逐（无兜底） | `eviction_policy_type: "ttl"` + `fallback_on_pressure: false` | 只清过期 block，容量不足不管 |
+
+**TTL 行为规则**：
+- `default_block_ttl_seconds`：在 instance group 级别配置，`0` 表示组级禁用 TTL。
+- `ttl_refresh_on_read`：控制读命中是否刷新 TTL 锚点；默认 `true`（Sliding TTL），`false` 时读不续命。
+- 组级禁用 TTL 时，请求级 `ttl_seconds > 0` 不生效（写入路径会强制关闭 TTL）。
+- 写入时，`ttl_anchor_time` 重置为写入时间，TTL 从该锚点开始计时。
+- 读取时（`PrefixQuery`），`last_access_time` 总是刷新；仅在 `ttl_refresh_on_read=true` 时刷新 `ttl_anchor_time`。
+- 读写请求执行前，会先进行一次 TTL 过期块物理清理，并由 `CleanEvictedBlocks` 统一做节点清理。
+- 写入完成后，`CheckAndEvict` 负责容量驱逐；当 `fallback_on_pressure=false` 时跳过容量驱逐。
+- `POLICY_TTL` 过期清理已优化为基于最小过期时间堆（min-heap）的增量回收，避免每次请求全链表扫描。
+
+**TTL 生命周期统计注意事项（重要）**：
+- TTL 模式下的 Block 生命周期统计（`birth_time_us/death_time_us/lifespan_us`）仅反映系统实际处理事件的时间点，不代表真实过期时刻。
+- 由于当前采用写后惰性驱逐（Lazy Eviction），`death_time_us` 记录的是被系统清理/处理的时间，而非严格的 `last_access_time + ttl`。
+- 因此 TTL 场景下的生命周期数据仅用于相对趋势分析，不建议用于精确时长评估或跨策略精确对比。
+
+**Per-request TTL 覆盖**（通过 `WriteCache` API）：
+
+| `ttl_seconds` 值 | 含义 |
+|---|---|
+| `0`（默认） | 使用 group 的 `default_block_ttl_seconds` |
+| `-1` | 禁用 TTL，该 block 永不过期 |
+| `>0` | 自定义 TTL（秒）；若 group 已禁用 TTL（`default_block_ttl_seconds=0`），该值会被忽略 |
+
+### Trace 类型
+
+```
+OptimizerSchemaTrace (基类)
+    ├── GetLocationSchemaTrace (读操作)
+    └── WriteCacheSchemaTrace (写操作)
+```
+
+**支持的 Trace 格式**
+- **Publisher Log**：KVCacheManager Event Publisher 日志，区分读写请求
+- **Qwen Bailian**：百炼开源数据集格式，转换后强制区分读写请求
+
+## 快速开始
+
+### 步骤1: 转换trace为标准格式
+
+```bash
+cd tools/trace_converter
+
+# 安装依赖 (首次使用)
+pip install -r requirements.txt
+
+# 转换trace
+python trace_converter.py \
+    -i /path/to/your_trace.jsonl \
+    -o /path/to/optimizer_trace.jsonl \
+    -f qwen_bailian \
+    --mode optimizer
+```
+
+### 步骤2: 编译 Optimizer
+
+```bash
+bazel build \
+    //kv_cache_manager/optimizer:optimizer_main \
+    //kv_cache_manager/optimizer/analysis/script:optimizer_run
+```
+
+### 步骤3: 创建配置文件
+
+创建 JSON 配置文件。下面是非分层 LRU 的最小可用配置；trace 中的 `instance_id` 必须能匹配这里的 `instances[].instance_id`。
+
+```json
+{
+    "trace_file_path": "/path/to/optimizer_trace.jsonl",
+    "output_result_path": "/path/to/output/result/",
+    "eviction_params": {
+        "eviction_mode": 1,
+        "eviction_batch_size_per_instance": 100
+    },
+    "instance_groups": [
+        {
+            "group_name": "instance_group_01",
+            "quota_capacity": 12000,
+            "used_percentage": 1.0,
+            "tier_strategy": {
+                "hierarchical_eviction_enabled": false,
+                "write_mode": "write_through",
+                "access_propagation_enabled": true,
+                "promote_enabled": true,
+                "selective_write_threshold": 2
+            },
+            "default_block_ttl_seconds": 0,
+            "ttl_refresh_on_read": true,
+            "storages": [],
+            "instances": [
+                {
+                    "instance_id": "instance-a",
+                    "block_size": 16,
+                    "bytes_per_token": 512,
+                    "eviction_policy_type": "lru",
+                    "eviction_policy_params": {
+                        "sample_rate": 1.0,
+                        "shard_count": 1,
+                        "sample_times": 32,
+                        "eviction_amplification_factor": 1.0
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
+
+
+### 步骤4: 运行Optimizer
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/config.json
+```
+
+运行完成后，会在 `output_result_path` 指定的目录下生成：
+
+- `{instance_id}_hit_rates.csv` - 每个 instance 的命中率数据
+
+需要画命中率时序图时加 `--draw-chart`：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/config.json \
+    --draw-chart
+```
+
+常见入口速查：
+
+| 需求 | 推荐入口 |
+|---|---|
+| 单次回放、输出 `*_hit_rates.csv` | `optimizer_run -c config.json` |
+| 单次回放并画时序图 | `optimizer_run -c config.json --draw-chart` |
+| 无限容量理论命中率 | config 中将 `quota_capacity` 或 tier `capacity` 设为 `-1` 后运行 `optimizer_run` |
+| 非分层容量 Pareto | `tradeoff -c config.json --num-points 30` |
+| 多驱逐策略 Pareto | `tradeoff -c config.json --eviction-policies lru random_lru leaf_aware_lru ttl` |
+| 每个 pod/instance 独立缓存回放 | `multi_instance_replay --trace-dir ... --output-dir ...` |
+| 导出生命周期 CSV | `optimizer_run -c config.json --export-lifecycle` |
+| 分析 lifecycle 图表 | `analyze_lifecycle -i <lifecycle.csv 或目录>` |
+| 导出/可视化 RadixTree | `export_tree -c config.json --show-hot-paths` |
+
+### 可视化分析
+
+Optimizer 模块提供多种可视化分析工具，用于分析缓存性能、命中率和 Radix Tree 结构。
+
+#### 命中率随时间变化图表
+
+运行optimizer，分析trace并绘制多实例缓存分析图表，展示所有 instance 的存储容量总和以及各自命中率随时间的变化。
+
+**注意**: 配置文件中的 `trace_file_path` 必须是标准格式trace文件。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/config.json \
+    --draw-chart
+```
+
+**输出**：`{output_result_path}/timeseries/multi_instance_cache_analysis.png`
+
+#### Radix Tree 可视化
+
+导出并可视化前缀树结构，统计并展示热节点以及所属节点的前缀路径。
+具体配置见 `analysis/script/run/export_tree.py`。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:export_tree -- \
+    -c /path/to/config.json
+```
+
+**输出**：
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.json` - Radix Tree 导出数据
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.png` - Radix Tree 可视化图表
+
+#### Pareto 容量-命中率曲线分析
+
+统一入口是 `tradeoff`。它先用无限容量 warmup 获取理论命中率和最大缓存量，然后按容量点回放 optimizer，绘制容量与命中率的 Pareto 曲线。
+
+> **适用范围**：Tradeoff 只适用于非分层模式。在分层模式下，容量扫描只修改 `quota_capacity`，不会修改各 tier 的 `storages[i].capacity`，因此不能代表真实分层容量权衡。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
+    -c /path/to/config.json \
+    --num-points 30 \
+    --min-capacity-ratio 1e-4 \
+    --hit-rate-type total \
+    --max-workers 4
+```
+
+**参数说明**：
+- `-c, --config` - 配置文件路径
+- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中率后提前停止
+- `--min-capacity-ratio` - 最小容量点相对阈值（默认 `1e-4`）
+- `--hit-rate-type` - 命中率类型：total/local/remote/all（默认 total）
+- `--max-workers` - 并行执行的最大线程数（默认 4）
+- `--plot-title` - 覆盖图标题
+
+**输出**：`{output_result_path}/pareto/pareto_curve_{hit_rate_type}.png`
+
+#### 多策略对比分析
+
+通过 `--eviction-policies` 对比多个驱逐策略。每个策略独立 warmup、独立计算理论命中率，并独立在达到 99% 理论命中后停止。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
+    -c /path/to/config.json \
+    --eviction-policies lru random_lru leaf_aware_lru ttl \
+    --num-points 30 \
+    --hit-rate-type total \
+    --max-workers 4
+```
+
+**参数说明**：
+- `-c, --config` - 配置文件路径
+- `--eviction-policies` - 要对比的驱逐策略列表（默认 lru random_lru leaf_aware_lru ttl）
+- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中率后提前停止
+- `--hit-rate-type` - 命中率类型：total/local/remote/all（默认 total）
+- `--max-workers` - 并行执行的最大线程数（默认 4）
+
+**输出**：`{output_result_path}/pareto/multi_policy_{hit_rate_type}.png`
+
+图形规则：X 轴为 `Capacity (GB)`，Y 轴为 `HitRate (%)`；曲线从 `(0 GB, 0%)` 开始，只画上升段；95% 和 99% 理论命中率用插值交点、虚线和标签标出。若某个容量点出现下降，会从图上剔除并在日志中打印，原始 CSV 保留。
+
+### Python 接口示例
+
+```python
+from kv_cache_manager.optimizer import OptimizerConfigLoader, OptimizerLoader, OptimizerManager
+
+# 加载配置
+config_loader = OptimizerConfigLoader()
+config = config_loader.Load("/path/to/config.json")
+
+# 创建优化器
+optimizer = OptimizerManager(config)
+optimizer.Init()
+
+# 运行
+optimizer.DirectRun()
+
+# 分析结果
+optimizer.AnalyzeResults()
+
+# 单次读写操作（需要指定instance_id）
+write_res = optimizer.WriteCache("instance_id", "trace_001", timestamp, block_ids)
+read_res = optimizer.GetCacheLocation("instance_id", "trace_002", timestamp, block_ids, block_mask,
+                                      input_len=real_prompt_tokens)
+
+# 写入时指定 TTL（可选）
+write_res = optimizer.WriteCache("instance_id", "trace_003", timestamp, block_ids,
+                                  ttl_seconds=0)     # 使用 group 默认
+write_res = optimizer.WriteCache("instance_id", "trace_004", timestamp, block_ids,
+                                  ttl_seconds=-1)    # 禁用 TTL，永不过期
+write_res = optimizer.WriteCache("instance_id", "trace_005", timestamp, block_ids,
+                                  ttl_seconds=300)   # 自定义 300 秒
+
+# 清空缓存（保留统计）
+optimizer.ClearCache("instance_id")        # 清空指定实例
+optimizer.ClearAllCaches()                 # 清空所有实例
+
+# 清空缓存并重置统计
+optimizer.ClearCacheAndResetStats("instance_id")  # 清空指定实例并重置统计
+optimizer.ClearAllCachesAndResetStats()           # 清空所有实例并重置统计
+```
+
+### 配置参数说明
+
+| 参数 | 说明 |
+|------|------|
+| eviction_mode | 驱逐模式：1=GROUP_ROUGH, 2=INSTANCE_ROUGH, 3=INSTANCE_PRECISE |
+| eviction_policy_type | 驱逐策略类型：lru、random_lru、leaf_aware_lru、ttl |
+| quota_capacity | 非分层模式下的 group 总容量，单位 GB；`-1` 表示无限容量，不触发容量驱逐 |
+| storages[].capacity | 分层模式下单个 tier 的容量，单位 GB；`-1` 表示该 tier 无限容量 |
+| tier_strategy | 多层读写策略包，包含分层驱逐开关、写入模式、读访问传播、promote 和 selective write 阈值；顶层字段是所有相邻 tier edge 的默认策略 |
+| tier_strategy.write_mode | 写入/下沉模式：`write_through`、`cascading`、`write_through_selective` |
+| tier_strategy.access_propagation_enabled | 读命中上层副本时是否刷新下层副本访问时间；它不是写入模式 |
+| tier_strategy.tier_flows | 相邻 tier edge 的策略覆盖；未覆盖 edge 继承 `tier_strategy` 默认策略 |
+| bytes_per_token | 单 token KV 大小；Python 分析脚本用它和 `block_size` 将 block 容量换算为 GB |
+| default_block_ttl_seconds | instance group 级别的默认 TTL（秒），0 = 关闭 TTL |
+| ttl_refresh_on_read | instance group 级别 TTL 续命开关：true=读续命，false=固定窗口 |
+| fallback_on_pressure | TTL 策略参数：过期不够时是否按 LRU 兜底（默认 true） |
+
+## 使用案例
+
+下面的案例都假设输入已经是标准 optimizer JSONL trace。标准结论使用 token hit rate，即 CSV 最后一行的 `AccHitRate = AccHitTokens / AccInputTokens`。示例中的 JSON 多数只展示 `instance_groups[]` 中的一项，完整 config 仍需要顶层 `trace_file_path`、`output_result_path` 和 `eviction_params`。
+
+### 案例 1：全局池化无限容量理论命中率
+
+用于回答“如果容量无限，当前 trace 理论上最多能命中多少”。非分层全局池化配置中把 `quota_capacity` 设为 `-1`：
+
+```json
+{
+    "group_name": "global_pool",
+    "quota_capacity": -1,
+    "used_percentage": 1.0,
+    "tier_strategy": {
+        "hierarchical_eviction_enabled": false,
+        "write_mode": "write_through",
+        "access_propagation_enabled": true,
+        "promote_enabled": true,
+        "selective_write_threshold": 2
+    },
+    "storages": [],
+    "instances": [
+        {
+            "instance_id": "global",
+            "block_size": 256,
+            "bytes_per_token": 512,
+            "eviction_policy_type": "lru",
+            "eviction_policy_params": {
+                "sample_rate": 1.0,
+                "shard_count": 1,
+                "sample_times": 32,
+                "eviction_amplification_factor": 1.0
+            }
+        }
+    ]
+}
+```
+
+运行：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/global_pool_unlimited.json
+```
+
+结果看 `{output_result_path}/global_hit_rates.csv` 最后一行的 `AccHitRate`、`AccInputTokens`、`AccHitTokens`。
+如果 trace 中使用真实 pod 名作为 `instance_id`，需要把上面示例里的 `instances[].instance_id` 同步改成对应名称。
+
+### 案例 2：单层有限容量回放
+
+用于评估给定容量下的实际 token 命中率。非分层模式只需要设置 `quota_capacity`，单位是 GB：
+
+```json
+{
+    "group_name": "finite_pool",
+    "quota_capacity": 742.18,
+    "used_percentage": 1.0,
+    "tier_strategy": {
+        "hierarchical_eviction_enabled": false,
+        "write_mode": "write_through",
+        "access_propagation_enabled": true,
+        "promote_enabled": true,
+        "selective_write_threshold": 2
+    },
+    "storages": []
+}
+```
+
+`block_size * bytes_per_token` 决定一个 block 对应的 KV 容量；Pareto 图和容量输出都依赖这个换算。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/finite_pool.json \
+    --draw-chart
+```
+
+输出：
+
+- `{output_result_path}/*_hit_rates.csv`
+- `{output_result_path}/timeseries/multi_instance_cache_analysis.png`
+
+### 案例 3：HBM + DRAM 分层回放，write-through，读不更新下层
+
+用于模拟线上多层缓存。`hierarchical_eviction_enabled=true` 时，每层按 `storages[].capacity` 独立驱逐；此时 `quota_capacity` 只是保留字段，不用于每层驱逐。
+
+```json
+{
+    "group_name": "tiered_pool",
+    "quota_capacity": 1,
+    "used_percentage": 1.0,
+    "tier_strategy": {
+        "hierarchical_eviction_enabled": true,
+        "write_mode": "write_through",
+        "access_propagation_enabled": false,
+        "promote_enabled": true,
+        "selective_write_threshold": 2
+    },
+    "storages": [
+        {
+            "unique_name": "hbm",
+            "storage_type": "hbm",
+            "band_width_mbps": 20000,
+            "priority": 0,
+            "capacity": 1167
+        },
+        {
+            "unique_name": "dram",
+            "storage_type": "dram",
+            "band_width_mbps": 20000,
+            "priority": 1,
+            "capacity": 1070.4
+        }
+    ]
+}
+```
+
+运行：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/tiered_hbm_dram.json \
+    --draw-chart
+```
+
+分层结果看 `Tier<N>(name)_HitTokens`、`AccTier<N>(name)_HitRate` 和 `Tier<N>(name)_BlockNum`，图在 `{output_result_path}/timeseries/per_tier_timeseries.png`。
+
+### 案例 4：三层 HBM + DRAM + L3，前两层 write-through，DRAM 到 L3 cascading
+
+当每条 edge 策略不一致时，用 `tier_flows` 覆盖默认策略：
+
+```json
+{
+    "tier_strategy": {
+        "hierarchical_eviction_enabled": true,
+        "write_mode": "write_through",
+        "access_propagation_enabled": false,
+        "promote_enabled": true,
+        "selective_write_threshold": 2,
+        "tier_flows": [
+            {
+                "from_tier": "hbm",
+                "to_tier": "dram",
+                "write_mode": "write_through",
+                "access_propagation_enabled": false,
+                "promote_enabled": true
+            },
+            {
+                "from_tier": "dram",
+                "to_tier": "l3",
+                "write_mode": "cascading",
+                "access_propagation_enabled": false,
+                "promote_enabled": true
+            }
+        ]
+    },
+    "storages": [
+        {"unique_name": "hbm", "storage_type": "hbm", "band_width_mbps": 20000, "priority": 0, "capacity": 1167},
+        {"unique_name": "dram", "storage_type": "dram", "band_width_mbps": 20000, "priority": 1, "capacity": 960},
+        {"unique_name": "l3", "storage_type": "ssd", "band_width_mbps": 20000, "priority": 2, "capacity": 2048}
+    ]
+}
+```
+
+`tier_strategy` 顶层字段是默认 edge 策略；`tier_flows` 只覆盖指定相邻 edge。
+
+### 案例 5：每个 pod 独立缓存回放并聚合全局命中率
+
+当线上每个 pod/实例独立缓存时，用 `multi_instance_replay`。输入目录下每个 JSONL 文件只能包含一个 `instance_id`。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:multi_instance_replay -- \
+    --trace-dir /path/to/pod_traces \
+    --trace-glob "*.jsonl" \
+    --output-dir /path/to/pod_replay_output \
+    --l1-capacity 349.52 \
+    --l2-capacity 614.4 \
+    --block-size 1024 \
+    --bytes-per-token 163840 \
+    --eviction-policy lru \
+    --default-tier-write-mode write_through \
+    --disable-tier-access-propagation \
+    --enable-promote \
+    --max-workers 16 \
+    --window-seconds 60
+```
+
+输出：
+
+- `<output_dir>/<instance_id>_hit_rates.csv`：每个 pod 的回放结果
+- `<output_dir>/aggregate/instance_aggregate.csv`：每个 pod 汇总
+- `<output_dir>/aggregate/global_aggregate.csv`：所有 pod 聚合后的整体命中率
+- `<output_dir>/aggregate/global_window_hit_rates.csv`：窗口级整体命中率
+
+当前 `multi_instance_replay` CLI 直接支持 L1/L2 两层。需要 L3 或更复杂拓扑时，使用完整 optimizer config 或扩展脚本。
+
+### 案例 6：容量 Pareto 图
+
+非分层容量扫描使用 `tradeoff`。脚本先跑无限容量 warmup 获取理论命中率，再生成容量点；达到 99% 理论命中后停止。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
+    -c /path/to/global_pool_config.json \
+    --num-points 30 \
+    --min-capacity-ratio 1e-4 \
+    --hit-rate-type total \
+    --max-workers 8 \
+    --plot-title "service-a Pareto"
+```
+
+多策略对比：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
+    -c /path/to/global_pool_config.json \
+    --eviction-policies lru random_lru leaf_aware_lru ttl \
+    --num-points 30 \
+    --hit-rate-type total \
+    --max-workers 8
+```
+
+输出：
+
+- `{output_result_path}/pareto/pareto_curve_total.png`
+- `{output_result_path}/pareto/multi_policy_total.png`
+
+图上会标出 95%/99% 理论命中对应容量；下降点只从图上剔除，原始 CSV 不改。
+
+### 案例 7：Block 生命周期分析
+
+先在回放时导出 lifecycle CSV：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/config.json \
+    --export-lifecycle
+```
+
+再生成生命周期统计和图：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:analyze_lifecycle -- \
+    -i /path/to/output_result_path
+```
+
+只打印统计、不画图：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:analyze_lifecycle -- \
+    -i /path/to/output_result_path \
+    --stats-only
+```
+
+### 案例 8：RadixTree 热点路径排查
+
+用于看热点前缀、叶子节点和已缓存/已驱逐 block：
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:export_tree -- \
+    -c /path/to/config.json \
+    --show-hot-paths \
+    --hot-nodes 50 \
+    --show-blocks
+```
+
+输出：
+
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.json`
+- `{output_result_path}/radix_tree/{instance_id}_hot_paths.png`
+
+### 案例 9：结果读取口径
+
+标准报告只看 token hit rate：
+
+| 指标 | 说明 |
+|---|---|
+| `InputTokens` / `AccInputTokens` | 当前 / 累计输入 token 数 |
+| `HitTokens` / `AccHitTokens` | 当前 / 累计命中 token 数 |
+| `HitRate` | 当前请求 token 命中率 |
+| `AccHitRate` | 累计 token 命中率，主要结论看这一列 |
+| `ReadBlocks` / `HitBlocks` | block 级诊断字段，不作为最终命中率口径 |
+| `Tier<N>(name)_HitTokens` | 分层命中 token 数 |
+| `AccTier<N>(name)_HitRate` | 分层累计 token 命中率 |
+
+
+## Trace 输入格式
+
+### 概述
+
+Optimizer 只接受标准格式的trace文件。使用独立的Python工具将各种trace格式转换为标准格式。
+
+### 标准格式
+
+Optimizer 支持两种标准 trace 类型：
+
+- **GetLocationSchemaTrace**: 读操作 (prefill阶段)
+- **WriteCacheSchemaTrace**: 写操作 (decode阶段)
+
+**推荐**: 所有Optimizer输入统一使用Get+Write格式以保留精确的读写时序。
+标准 `get` trace 必须包含 `input_len`；`keys` 只能包含完整 block key，不足一个 block 的尾部 token 不写入 `keys`，但仍计入 `InputTokens`。
+
+---
+
+### 转换工具
+
+使用独立的Python工具转换各种格式 (无需bazel):
+
+```bash
+# 进入工具目录
+cd tools/trace_converter
+
+# 安装依赖 (首次使用)
+pip install -r requirements.txt
+
+# 转换trace为Optimizer格式
+python trace_converter.py \
+    -i your_trace.log \
+    -o optimizer_trace.jsonl \
+    -f <format> \
+    --mode optimizer
+
+```
+
+**支持的格式**:
+- `publisher_log`: KVCacheManager Event Publisher日志
+- `qwen_bailian`: Qwen Bailian开源数据集
+- `text`: 文本对话 (需要指定--tokenizer-path)
+
+**自动发现 Converter**:
+
+系统会自动扫描并发现所有可用的 converter：
+
+```bash
+# 使用内置 converter
+python3 trace_converter.py -i input.jsonl -o output.jsonl -f qwen_bailian
+
+# 使用自定义 converter
+python3 trace_converter.py -i input.jsonl -o output.jsonl -f custom \
+    --converter-module /path/to/custom_converter.py
+```
+
+详见: [Trace Converter文档](tools/trace_converter/README.md)
+
+---
+
+### 配置文件
+
+**新版配置**:
+```json
+{
+    "trace_file_path": "/path/to/optimizer_trace.jsonl",
+    "output_result_path": "/path/to/output",
+    "eviction_params": {
+        "eviction_mode": 1,
+        "eviction_batch_size_per_instance": 100
+    },
+    "instance_groups": [
+        {
+            "group_name": "instance_group_01",
+            "quota_capacity": 12000,
+            "used_percentage": 1.0,
+            "tier_strategy": {
+                "hierarchical_eviction_enabled": false,
+                "write_mode": "write_through",
+                "access_propagation_enabled": true,
+                "promote_enabled": true,
+                "selective_write_threshold": 2
+            },
+            "default_block_ttl_seconds": 0,
+            "storages": [],
+            "instances": [
+                {
+                    "instance_id": "instance",
+                    "block_size": 16,
+                    "bytes_per_token": 512,
+                    "eviction_policy_type": "lru"
+                }
+            ]
+        }
+    ]
+}
+```
+
+**注意**: 
+- `trace_file_path` 必须是标准格式文件
+
+---
+
+### 使用示例
+
+完整流程:
+
+```bash
+# 步骤1: 转换trace
+cd tools/trace_converter
+python trace_converter.py \
+    -i /path/to/qwen_trace.jsonl \
+    -o /path/to/optimizer_trace.jsonl \
+    -f qwen_bailian \
+    --mode optimizer
+
+# 步骤2: 运行Optimizer
+cd ../..
+bazel run //kv_cache_manager/optimizer:optimizer_main -- /path/to/config.json
+```
+
+---
+
+### 添加自定义 Trace Converter
+
+如果需要支持新的 trace 格式,在Python工具中添加新的converter:
+
+1. **创建Converter类**: 在任意目录创建新文件
+   ```python
+   from converters.base import BaseConverter
+   
+   class MyCustomConverter(BaseConverter):
+       def convert(self, input_file: str, output_file: str) -> int:
+           # 实现转换逻辑
+           pass
+   ```
+
+2. **使用 - 方式1 (自动扫描目录)**:
+   ```bash
+   # 将converter文件放到指定目录，自动发现所有继承BaseConverter的类
+   python trace_converter.py -i input.log -o output.jsonl -f my_custom \
+       --converter-dir /path/to/your/converters
+   ```
+
+3. **使用 - 方式2 (显式注册文件)**:
+   ```bash
+   # 直接指定converter文件和类名
+   python trace_converter.py -i input.log -o output.jsonl -f my_custom \
+       --converter-module /path/to/my_custom_converter.py:MyCustomConverter
+   ```
+
+**无需修改 `trace_converter.py` 源码** Converter会根据类名自动推断format名称：
+- `MyCustomConverter` → `my_custom`
+- `QwenBailianConverter` → `qwen_bailian`
+
+---
+
+### 相关文档
+
+- [Trace Converter工具文档](tools/trace_converter/README.md) - Python转换工具详细说明

--- a/kv_cache_manager/optimizer/docs/optimizer_architecture.md
+++ b/kv_cache_manager/optimizer/docs/optimizer_architecture.md
@@ -1,170 +1,172 @@
-# KVCacheManager Optimizer 架构文档
+# KVCacheManager Optimizer Architecture Document
 
-## 目录
+> [中文](optimizer_architecture_zh.md) | English
 
-1. [概述](#概述)
-2. [架构设计](#架构设计)
-3. [核心模块](#核心模块)
-4. [配置系统](#配置系统)
-5. [驱逐策略](#驱逐策略)
-6. [索引系统](#索引系统)
-7. [Trace 处理](#trace-处理)
-8. [结果分析](#结果分析)
-9. [可视化分析](#可视化分析)
-10. [使用说明](#使用说明)
-11. [扩展指南](#扩展指南)
+## Table of Contents
 
----
-
-## 概述
-
-KVCacheManager Optimizer 是一个独立的缓存优化分析模块，通过回放 trace 数据来模拟缓存读写操作，评估不同驱逐策略和配置对缓存命中率的影响，并为 KVCacheManager 主程序提供参数优化能力。
-
-### 主要特性
-
-- **多种驱逐策略**：支持 LRU、RandomLRU、LeafAwareLRU、TTL 等驱逐算法
-- **分层存储**：支持多层级存储配置，目前功能不完备
-- **Trace 回放**：支持 Publisher Log、Qwen Bailian 等多种 trace 格式
-- **读写分离**：支持读写分离模式和组合模式
-- **详细统计**：提供命中率、缓存使用情况等详细统计
-- **灵活配置**：通过 JSON 配置文件灵活配置实例、存储和策略
-- **可视化分析**：支持 Radix Tree 可视化、命中率图表和 Trade-off 曲线分析
-- **在线优化服务**：支持通过服务接口注册在线实例、实时 TraceQuery 统计命中率和容量使用
-- **轻量多容量分析**：LiteHit 用 reuse distance 一次精确计算多个 full-attention LRU 容量（含无限容量）的命中率，同时支持离线请求序列和在线流式请求
+1. [Overview](#overview)
+2. [Architecture Design](#architecture-design)
+3. [Core Modules](#core-modules)
+4. [Configuration System](#configuration-system)
+5. [Eviction Policies](#eviction-policies)
+6. [Index System](#index-system)
+7. [Trace Processing](#trace-processing)
+8. [Result Analysis](#result-analysis)
+9. [Visual Analysis](#visual-analysis)
+10. [Usage Instructions](#usage-instructions)
+11. [Extension Guide](#extension-guide)
 
 ---
 
-## 架构设计
+## Overview
 
-### 整体架构
+KVCacheManager Optimizer is a standalone cache optimization analysis module. It replays trace data to simulate cache read/write operations, evaluates the impact of different eviction policies and configurations on cache hit rate, and provides parameter optimization capabilities for the KVCacheManager main program.
 
-Optimizer 当前包含离线 trace 回放和在线优化服务两条运行路径：
+### Main Features
 
-- 离线回放路径使用 `OptimizerManager`、`OptIndexerManager`、`OptEvictionManager` 和 `RadixTreeIndex`，依赖 replay 配置、trace loader/converter 和 data storage 类型。
-- 在线服务路径使用 `OnlineOptimizerManager`、LiteHit、`CacheIndexerFactory`、`LruCacheIndexer`/`TtlCacheIndexerWrapper` 和 service/protobuf 接口，依赖 online 实例组/实例配置与 registry。full-attention 多容量 LRU 由 `InstanceState` 直接持有 LiteHit；linear attention 仍由通用 `CacheIndexer` 模拟。
+- **Multiple eviction policies**: Supports eviction algorithms such as LRU, RandomLRU, LeafAwareLRU, and TTL
+- **Tiered storage**: Supports multi-tier storage configuration; currently the feature is not fully complete
+- **Trace replay**: Supports multiple trace formats such as Publisher Log and Qwen Bailian
+- **Read/write separation**: Supports read/write separation mode and combined mode
+- **Detailed statistics**: Provides detailed statistics such as hit rate and cache usage
+- **Flexible configuration**: Flexibly configure instances, storage, and policies through JSON configuration files
+- **Visual analysis**: Supports Radix Tree visualization, hit-rate charts, and Trade-off curve analysis
+- **Online optimization service**: Supports registering online instances via service interfaces, real-time TraceQuery statistics of hit rate and capacity usage
+- **Lightweight multi-capacity analysis**: LiteHit uses reuse distance to precisely compute hit rates for multiple full-attention LRU capacities (including infinite capacity) in one pass, supporting both offline request sequences and online streaming requests
 
-两条路径共享 optimizer 模块内的命中率建模代码，但运行时、配置 target 和服务边界保持独立，避免在线服务引入离线 replay/data storage 依赖。
+---
 
-#### 离线回放
+## Architecture Design
+
+### Overall Architecture
+
+The Optimizer currently contains two execution paths: offline trace replay and online optimization service:
+
+- The offline replay path uses `OptimizerManager`, `OptIndexerManager`, `OptEvictionManager`, and `RadixTreeIndex`, depending on replay configuration, trace loader/converter, and data storage types.
+- The online service path uses `OnlineOptimizerManager`, LiteHit, `CacheIndexerFactory`, `LruCacheIndexer`/`TtlCacheIndexerWrapper`, and service/protobuf interfaces, depending on online instance group/instance configuration and registry. Full-attention multi-capacity LRU is directly held by `InstanceState` as LiteHit; linear attention is still simulated by the generic `CacheIndexer`.
+
+The two paths share the hit-rate modeling code within the optimizer module, but the runtime, configuration targets, and service boundaries remain independent, avoiding the online service introducing offline replay/data storage dependencies.
+
+#### Offline Replay
 
 ```
-main.cc (程序入口)
+main.cc (program entry)
     ↓
-OptimizerManager (核心协调器)
-    ├── OptEvictionManager (驱逐管理器)
-    ├── OptIndexerManager (索引管理器)
-    └── OptimizerRunner (Trace 执行器)
+OptimizerManager (core coordinator)
+    ├── OptEvictionManager (eviction manager)
+    ├── OptIndexerManager (indexer manager)
+    └── OptimizerRunner (trace executor)
         ↓
-    ├── Eviction Policies (驱逐策略)
+    ├── Eviction Policies
     │   ├── LRU
     │   ├── RandomLRU
     │   └── LeafAwareLRU
-    ├── RadixTreeIndex (索引)
-    └── Trace Converter (转换器)
+    ├── RadixTreeIndex (index)
+    └── Trace Converter
         ↓
-    HitAnalysis (结果分析)
+    HitAnalysis (result analysis)
         ↓
-    Visualization Tools (可视化工具)
+    Visualization Tools
 ```
 
-#### 在线服务
+#### Online Service
 
 ```
-OptimizerServiceImpl (HTTP/gRPC 接口)
+OptimizerServiceImpl (HTTP/gRPC interface)
     ↓
-OnlineOptimizerManager (在线运行时协调器)
-    ├── OptimizerRegistryManager (实例组/实例持久化)
-    └── InstanceState (instance_id 隔离的运行状态)
+OnlineOptimizerManager (online runtime coordinator)
+    ├── OptimizerRegistryManager (instance group/instance persistence)
+    └── InstanceState (instance_id-isolated runtime state)
         ↓
-    ├── LiteHit (full-attention 多容量 LRU)
+    ├── LiteHit (full-attention multi-capacity LRU)
     └── CacheIndexerFactory (linear attention)
         └── LruCacheIndexer / TtlCacheIndexerWrapper
 ```
 
-### 目录结构
+### Directory Structure
 
 ```
 kv_cache_manager/optimizer/
-├── manager/              # 核心管理层
-│   ├── optimizer_manager.h/cc       # 主协调器
-│   ├── optimizer_runner.h/cc        # Trace 执行器
-│   ├── eviction_manager.h/cc        # 驱逐管理器
-│   ├── indexer_manager.h/cc         # 索引管理器
-│   ├── optimizer_loader.h/cc        # Trace 加载器
-│   ├── lite_hit_offline_runner.h/cc # 离线 LiteHit runner：进程内驱动 OnlineOptimizerManager
-│   └── online_runtime/              # 在线运行时
-│       └── online_optimizer_manager.h/cc # 在线实例注册、TraceQuery 和统计
-├── index/                # 索引层
-│   ├── radix_tree_index.h/cc        # 离线 Radix 树索引
-│   └── online/                    # linear attention 在线容量/TTL 索引器
-├── liteHit/              # 轻量多容量 full-attention LRU 命中率核心
-│   ├── lite_hit.h/cc                # 多容量 LRU 命中率分析器
-│   └── dynamic_fenwick_tree.h/cc    # reuse-distance 用的 order-statistics Fenwick
-├── eviction_policy/      # 驱逐策略层
-│   ├── base.h                   # 策略基类
-│   ├── common_structure.h       # 通用数据结构
-│   ├── lru.h/cc                 # LRU 策略
-│   ├── random_lru.h/cc          # RandomLRU 策略
-│   ├── leaf_aware_lru.h/cc      # LeafAwareLRU 策略
-│   └── policy_factory.h/cc      # 策略工厂
-├── trace_converter/      # Trace 转换层
-│   ├── optimizer_schema_trace.h  # Trace 定义
-│   ├── base_converter.h          # 转换器基类
-│   ├── publisher_log_converter.h/cc  # Publisher Log 转换器
-│   ├── qwen_bailian_converter.h/cc    # Qwen Bailian 转换器
-│   ├── converter_factory.h/cc    # 转换器工厂
-│   └── trace_util.h              # Trace 工具
-├── config/               # 配置层
-│   ├── optimizer_config.h/cc     # 顶层配置
-│   ├── replay_instance_group_config.h/cc # trace replay/tier 模拟实例组配置
-│   ├── replay_instance_config.h/cc      # trace replay 实例配置
-│   ├── optimizer_instance_group.h/cc    # 在线优化实例组配置
-│   ├── optimizer_instance_info.h/cc     # 在线优化实例配置
-│   ├── optimizer_registry_manager.h/cc  # 在线实例 registry
-│   ├── tier_config.h/cc          # 存储层配置
-│   ├── eviction_config.h         # 驱逐策略参数
-│   └── types.h                   # 类型定义
-├── service/              # 在线服务实现
-│   ├── optimizer_service_impl.h/cc    # 服务接口适配层
-│   └── metrics/                   # 在线指标上报
-├── analysis/             # 分析层
-│   ├── result_structure.h        # 结果结构定义
-│   ├── result_analysis.h/cc      # 命中率分析
-│   └── script/                   # 分析脚本
+├── manager/              # core management layer
+│   ├── optimizer_manager.h/cc       # main coordinator
+│   ├── optimizer_runner.h/cc        # trace executor
+│   ├── eviction_manager.h/cc        # eviction manager
+│   ├── indexer_manager.h/cc         # indexer manager
+│   ├── optimizer_loader.h/cc        # trace loader
+│   ├── lite_hit_offline_runner.h/cc # offline LiteHit runner: drives OnlineOptimizerManager in-process
+│   └── online_runtime/              # online runtime
+│       └── online_optimizer_manager.h/cc # online instance registration, TraceQuery, and statistics
+├── index/                # index layer
+│   ├── radix_tree_index.h/cc        # offline Radix tree index
+│   └── online/                    # linear attention online capacity/TTL indexer
+├── liteHit/              # lightweight multi-capacity full-attention LRU hit-rate core
+│   ├── lite_hit.h/cc                # multi-capacity LRU hit-rate analyzer
+│   └── dynamic_fenwick_tree.h/cc    # order-statistics Fenwick for reuse-distance
+├── eviction_policy/      # eviction policy layer
+│   ├── base.h                   # policy base class
+│   ├── common_structure.h       # common data structures
+│   ├── lru.h/cc                 # LRU policy
+│   ├── random_lru.h/cc          # RandomLRU policy
+│   ├── leaf_aware_lru.h/cc      # LeafAwareLRU policy
+│   └── policy_factory.h/cc      # policy factory
+├── trace_converter/      # trace conversion layer
+│   ├── optimizer_schema_trace.h  # trace definitions
+│   ├── base_converter.h          # converter base class
+│   ├── publisher_log_converter.h/cc  # Publisher Log converter
+│   ├── qwen_bailian_converter.h/cc    # Qwen Bailian converter
+│   ├── converter_factory.h/cc    # converter factory
+│   └── trace_util.h              # trace utilities
+├── config/               # configuration layer
+│   ├── optimizer_config.h/cc     # top-level config
+│   ├── replay_instance_group_config.h/cc # trace replay/tier simulation instance group config
+│   ├── replay_instance_config.h/cc      # trace replay instance config
+│   ├── optimizer_instance_group.h/cc    # online optimization instance group config
+│   ├── optimizer_instance_info.h/cc     # online optimization instance config
+│   ├── optimizer_registry_manager.h/cc  # online instance registry
+│   ├── tier_config.h/cc          # storage tier config
+│   ├── eviction_config.h         # eviction policy parameters
+│   └── types.h                   # type definitions
+├── service/              # online service implementation
+│   ├── optimizer_service_impl.h/cc    # service interface adapter layer
+│   └── metrics/                   # online metrics reporting
+├── analysis/             # analysis layer
+│   ├── result_structure.h        # result structure definitions
+│   ├── result_analysis.h/cc      # hit-rate analysis
+│   └── script/                   # analysis scripts
 │       ├── run/
-│       │   ├── optimizer_run.py          # 单次回放 + 可选时序图
-│       │   ├── tradeoff.py               # Pareto 曲线，单策略/多策略统一入口
-│       │   ├── export_tree.py            # RadixTree 导出 + 可视化
-│       │   ├── analyze_lifecycle.py      # Block lifecycle 统计
-│       │   └── multi_instance_replay.py  # 多实例并行回放 + 聚合
+│       │   ├── optimizer_run.py          # single replay + optional time-series chart
+│       │   ├── tradeoff.py               # Pareto curve, unified entry for single/multi-policy
+│       │   ├── export_tree.py            # RadixTree export + visualization
+│       │   ├── analyze_lifecycle.py      # block lifecycle statistics
+│       │   └── multi_instance_replay.py  # multi-instance parallel replay + aggregation
 │       ├── plot/
-│       │   ├── hit_rate_plot.py          # 命中率时序图
-│       │   ├── radix_tree_plot.py        # RadixTree 绘图
-│       │   └── lifecycle_plot.py         # Lifecycle CDF/直方图
+│       │   ├── hit_rate_plot.py          # hit-rate time-series chart
+│       │   ├── radix_tree_plot.py        # RadixTree plotting
+│       │   └── lifecycle_plot.py         # lifecycle CDF/histogram
 │       └── utils/
-│           ├── optimizer_runner.py       # optimizer 运行封装
-│           ├── csv_loader.py             # CSV 加载 + 容量点生成
-│           └── plot_utils.py             # Pareto/per-tier 绘图工具
-├── pybind/               # Python 绑定
-│   └── py_optimizer_binding.cc   # Python 接口
-├── main.cc               # 离线回放程序入口（optimizer_main）
-├── lite_hit_main.cc      # 离线 LiteHit 多容量分析入口（lite_hit_main）
-└── optimizer_startup_config_load.json  # 配置示例
+│           ├── optimizer_runner.py       # optimizer run wrapper
+│           ├── csv_loader.py             # CSV loading + capacity point generation
+│           └── plot_utils.py             # Pareto/per-tier plotting utilities
+├── pybind/               # Python bindings
+│   └── py_optimizer_binding.cc   # Python interface
+├── main.cc               # offline replay program entry (optimizer_main)
+├── lite_hit_main.cc      # offline LiteHit multi-capacity analysis entry (lite_hit_main)
+└── optimizer_startup_config_load.json  # config example
 ```
 
-在线服务协议定义在 `kv_cache_manager/protocol/protobuf/optimizer_service.proto`，由 service 层转换为 optimizer online config/runtime 对象。
+The online service protocol is defined in `kv_cache_manager/protocol/protobuf/optimizer_service.proto`, and is converted by the service layer into optimizer online config/runtime objects.
 
-full-attention TraceQuery 只把完整 block 放入 `block_keys`，并用 `input_token_len` 传入包含尾部 token 的原始输入长度。Online Manager 用 full location spec group 的固定字节 charge 将 `capacity_gb` 向下取整为 block 容量，再把同一请求交给 LiteHit；请求级与累计命中率均为 `prefix_hit_blocks * block_size_tokens / input_tokens`。旧客户端缺少长度时兼容假设没有尾部 token。full-attention 组配置 `ttl_seconds != 0` 时，固定 TTL 以墙钟时间叠加在 LiteHit 之上（口径与 `TtlCacheIndexerWrapper` 一致）；linear attention 的统计口径和 TTL 行为保持 legacy 路径不变。
+A full-attention TraceQuery only puts complete blocks into `block_keys`, and passes the original input length including trailing tokens via `input_token_len`. The Online Manager uses the fixed byte charge of the full location spec group to floor `capacity_gb` to block capacity, then hands the same request to LiteHit; both per-request and cumulative hit rates are `prefix_hit_blocks * block_size_tokens / input_tokens`. When old clients lack the length, the compatibility assumption is that there are no trailing tokens. When a full-attention group config has `ttl_seconds != 0`, a fixed TTL is layered on top of LiteHit with wall-clock time (metrics consistent with `TtlCacheIndexerWrapper`); the statistics metrics and TTL behavior of linear attention keep the legacy path unchanged.
 
 ---
 
-## 核心模块
+## Core Modules
 
-### 1. OptimizerManager（优化器管理器）
+### 1. OptimizerManager
 
-**职责**：核心协调器，初始化所有子组件，管理实例组和实例配置，提供公共 API 接口。
+**Responsibility**: Core coordinator; initializes all subcomponents, manages instance group and instance configuration, and provides the public API interface.
 
-**主要接口**：
+**Main interfaces**:
 ```cpp
 class OptimizerManager {
 public:
@@ -178,18 +180,18 @@ public:
 };
 ```
 
-### 2. OptimizerRunner（优化器运行器）
+### 2. OptimizerRunner
 
-**职责**：执行 Trace 回放和模拟，处理两种 Trace 类型（GetLocationSchemaTrace、WriteCacheSchemaTrace），支持读写分离模式。
+**Responsibility**: Executes trace replay and simulation, handles two trace types (GetLocationSchemaTrace, WriteCacheSchemaTrace), and supports read/write separation mode.
 
-### 3. OptEvictionManager（驱逐管理器）
+### 3. OptEvictionManager
 
-**职责**：管理跨实例的驱逐策略，支持三种驱逐模式：
-- `EVICTION_MODE_GROUP_ROUGH` - 组级别粗粒度驱逐
-- `EVICTION_MODE_INSTANCE_ROUGH` - 实例级别粗粒度驱逐
-- `EVICTION_MODE_INSTANCE_PRECISE` - 实例级别精确驱逐
+**Responsibility**: Manages cross-instance eviction policies, supporting three eviction modes:
+- `EVICTION_MODE_GROUP_ROUGH` - group-level coarse-grained eviction
+- `EVICTION_MODE_INSTANCE_ROUGH` - instance-level coarse-grained eviction
+- `EVICTION_MODE_INSTANCE_PRECISE` - instance-level precise eviction
 
-**主要接口**：
+**Main interfaces**:
 ```cpp
 class OptEvictionManager {
 public:
@@ -201,11 +203,11 @@ public:
 };
 ```
 
-### 4. OptIndexerManager（索引管理器）
+### 4. OptIndexerManager
 
-**职责**：管理 RadixTreeIndex 实例，为每个实例创建索引器，支持多层存储配置。
+**Responsibility**: Manages RadixTreeIndex instances, creates an indexer for each instance, and supports multi-tier storage configuration.
 
-**主要接口**：
+**Main interfaces**:
 ```cpp
 class OptIndexerManager {
 public:
@@ -218,42 +220,42 @@ public:
 };
 ```
 
-### 5. OptimizerLoader（Trace 加载器）
+### 5. OptimizerLoader
 
-**职责**：加载和转换 trace 文件，按时间戳排序 trace，导出转换后的 trace 到文件。
+**Responsibility**: Loads and converts trace files, sorts traces by timestamp, and exports converted traces to files.
 
 ---
 
-## 配置系统
+## Configuration System
 
-### 配置层次结构
+### Configuration Hierarchy
 
 ```
-OptimizerConfig (顶层配置)
-    ├── trace_file_path (Trace 文件路径)
-    ├── output_result_path (输出路径)
-    ├── eviction_params (驱逐参数)
-    │   ├── eviction_mode (驱逐模式)
-    │   └── eviction_batch_size_per_instance (驱逐批量大小)
-    └── instance_groups[] (实例组数组)
-        ├── group_name (组名)
-        ├── quota_capacity (配额容量)
-        ├── used_percentage (使用百分比)
-        ├── tier_strategy (多层读写策略)
-        │   ├── hierarchical_eviction_enabled (分层驱逐)
-        │   ├── write_mode (多层写入模式)
-        │   ├── access_propagation_enabled (读访问传播)
-        │   ├── promote_enabled (低层命中回填高层)
-        │   └── selective_write_threshold (选择性下写阈值)
-        ├── storages[] (存储层数组)
-        └── instances[] (实例数组)
-            ├── instance_id (实例ID)
-            ├── block_size (块大小)
-            ├── eviction_policy_type (驱逐策略类型)
-            └── eviction_policy_params (驱逐策略参数)
+OptimizerConfig (top-level config)
+    ├── trace_file_path (trace file path)
+    ├── output_result_path (output path)
+    ├── eviction_params (eviction parameters)
+    │   ├── eviction_mode (eviction mode)
+    │   └── eviction_batch_size_per_instance (eviction batch size)
+    └── instance_groups[] (instance group array)
+        ├── group_name (group name)
+        ├── quota_capacity (quota capacity)
+        ├── used_percentage (used percentage)
+        ├── tier_strategy (multi-tier read/write policy)
+        │   ├── hierarchical_eviction_enabled (hierarchical eviction)
+        │   ├── write_mode (multi-tier write mode)
+        │   ├── access_propagation_enabled (read access propagation)
+        │   ├── promote_enabled (lower-tier hit backfill to higher tier)
+        │   └── selective_write_threshold (selective down-write threshold)
+        ├── storages[] (storage tier array)
+        └── instances[] (instance array)
+            ├── instance_id (instance ID)
+            ├── block_size (block size)
+            ├── eviction_policy_type (eviction policy type)
+            └── eviction_policy_params (eviction policy parameters)
 ```
 
-### 配置文件示例
+### Configuration File Example
 
 ```json
 {
@@ -300,27 +302,27 @@ OptimizerConfig (顶层配置)
 }
 ```
 
-### 配置参数说明
+### Configuration Parameter Description
 
-| 参数 | 说明 |
+| Parameter | Description |
 |------|------|
-| trace_file_path | Trace 文件路径 |
-| output_result_path | 结果输出目录；所有 config 驱动入口都使用该目录，`export_tree` 输出到其下的 `radix_tree/` |
-| eviction_mode | 驱逐模式：1=GROUP_ROUGH, 2=INSTANCE_ROUGH, 3=INSTANCE_PRECISE |
-| eviction_batch_size_per_instance | 粗粒度驱逐时的批量大小 |
-| group_name | 实例组唯一标识 |
-| quota_capacity | 组的总容量（GB）；`-1` 表示无限容量，不触发容量驱逐 |
-| used_percentage | 实际使用的配额百分比 |
-| instance_id | 实例唯一标识 |
-| block_size | 每个 block 包含的 token 数量 |
-| bytes_per_token | 单 token KV 大小；Python 分析脚本用它和 `block_size` 将 block 容量换算为 GB |
-| eviction_policy_type | 驱逐策略类型：lru、random_lru、leaf_aware_lru |
+| trace_file_path | trace file path |
+| output_result_path | result output directory; all config-driven entry points use this directory, and `export_tree` outputs to `radix_tree/` under it |
+| eviction_mode | eviction mode: 1=GROUP_ROUGH, 2=INSTANCE_ROUGH, 3=INSTANCE_PRECISE |
+| eviction_batch_size_per_instance | batch size for coarse-grained eviction |
+| group_name | unique identifier of the instance group |
+| quota_capacity | total capacity of the group (GB); `-1` means infinite capacity, no capacity eviction triggered |
+| used_percentage | percentage of quota actually used |
+| instance_id | unique identifier of the instance |
+| block_size | number of tokens contained in each block |
+| bytes_per_token | KV size per token; Python analysis scripts use it together with `block_size` to convert block capacity to GB |
+| eviction_policy_type | eviction policy type: lru, random_lru, leaf_aware_lru |
 
 ---
 
-## 驱逐策略
+## Eviction Policies
 
-### 驱逐策略接口
+### Eviction Policy Interface
 
 ```cpp
 class EvictionPolicy {
@@ -336,77 +338,77 @@ public:
 };
 ```
 
-### LRU 策略
+### LRU Policy
 
-**原理**：维护双向链表记录块的访问顺序，最近访问的块在链表头部，最久未访问的块在链表尾部，驱逐时从链表尾部移除块。
+**Principle**: Maintains a doubly linked list recording the access order of blocks; the most recently accessed block is at the head of the list, and the least recently accessed block is at the tail. During eviction, blocks are removed from the tail of the list.
 
-**时间复杂度**：
+**Time complexity**:
 - `OnBlockAccessed()`: O(1)
 - `OnBlockWritten()`: O(1)
 - `EvictBlocks()`: O(n)
 
-### RandomLRU 策略
+### RandomLRU Policy
 
-**原理**：结合随机采样和 LRU 策略，从缓存中随机采样一定比例的块，选择最久未访问的块进行驱逐。
+**Principle**: Combines random sampling with the LRU policy; randomly samples a certain proportion of blocks from the cache and selects the least recently accessed block for eviction.
 
-**时间复杂度**：
+**Time complexity**:
 - `OnBlockAccessed()`: O(1)
 - `OnBlockWritten()`: O(1)
-- `EvictBlocks()`: O(m log m)，其中 m 为采样数量
+- `EvictBlocks()`: O(m log m), where m is the number of samples
 
-### LeafAwareLRU 策略
+### LeafAwareLRU Policy
 
-**原理**：在 LRU 基础上增加了对叶子节点的感知，优先驱逐叶子节点中的块，提高缓存效率。
+**Principle**: Adds leaf-node awareness on top of LRU, preferentially evicting blocks within leaf nodes to improve cache efficiency.
 
-**实现特点**：
-- 维护一个独立的叶子节点 LRU 链表
-- 跟踪叶子节点中的所有 block
-- 驱逐时优先从叶子节点链表中选择最久未访问的块
+**Implementation characteristics**:
+- Maintains an independent LRU linked list of leaf nodes
+- Tracks all blocks within leaf nodes
+- During eviction, preferentially selects the least recently accessed block from the leaf-node list
 
-### TTL 语义分阶段说明（V1 / V2）
+### TTL Semantics Phased Description (V1 / V2)
 
-当前实现采用 **V1 语义**（已落地）：
+The current implementation adopts **V1 semantics** (already implemented):
 
-- 仅 `POLICY_TTL` 实例会执行“读写前 TTL 过期物理清理”
-- 非 TTL 策略（`lru` / `random_lru` / `leaf_aware_lru`）下，TTL 视为不存在
-  - 不做前置 TTL 物理清理
-  - 也不做 TTL 逻辑过期判定
-- `POLICY_TTL` 下保证先清理过期块，再进入读写流程
-- `default_block_ttl_seconds = 0` 表示组级禁用 TTL：
-  - 写入路径会将 TTL 解析为“不过期”
-  - 若 `fallback_on_pressure = false`，则不会发生 TTL 过期驱逐，也不会触发容量兜底驱逐
-  - 若 `fallback_on_pressure = true`，则仅在容量压力时走链表尾部兜底驱逐（行为等价于 LRU）
-- `POLICY_TTL` 的过期清理实现已从“每次读写前全链表扫描”优化为“最小过期时间堆（min-heap）增量回收”：
-  - 写入/访问时写入过期事件
-  - 清理时仅弹出到期事件，不再全量扫描
-  - 使用版本号做惰性失效，避免过期事件重复处理
-  - 在不改变 TTL 语义的前提下显著降低回放时延
+- Only `POLICY_TTL` instances perform "physical cleanup of TTL-expired entries before reads/writes"
+- Under non-TTL policies (`lru` / `random_lru` / `leaf_aware_lru`), TTL is treated as nonexistent
+  - No pre-TTL physical cleanup is performed
+  - No TTL logical expiration judgment is performed either
+- Under `POLICY_TTL`, it is guaranteed that expired blocks are cleaned up first before entering the read/write flow
+- `default_block_ttl_seconds = 0` means TTL is disabled at the group level:
+  - The write path parses TTL as "never expires"
+  - If `fallback_on_pressure = false`, no TTL expiration eviction occurs, and no capacity fallback eviction is triggered
+  - If `fallback_on_pressure = true`, only under capacity pressure does it fall back to list-tail eviction (behavior equivalent to LRU)
+- The expiration cleanup implementation of `POLICY_TTL` has been optimized from "full list scan before every read/write" to "min-heap of minimum expiration times with incremental reclamation":
+  - Expiration events are written on write/access
+  - During cleanup, only due events are popped, no full scan
+  - Version numbers are used for lazy invalidation, avoiding repeated processing of expiration events
+  - Significantly reduces replay latency without changing TTL semantics
 
-后续 **V2 设计**（仅文档方案，暂不实现）：
+The subsequent **V2 design** (documentation plan only, not implemented for now):
 
-- 统一语义：所有策略都支持前置过期清理
-- 对过期扫描做精细化性能优化（例如 next_expire_ts / min-heap 等）
-- 在不改变容量驱逐策略语义的前提下，实现跨策略一致的 TTL 生命周期
+- Unified semantics: all policies support pre-expiration cleanup
+- Fine-grained performance optimization for expiration scanning (e.g. next_expire_ts / min-heap, etc.)
+- Achieve cross-policy consistent TTL lifecycle without changing the semantics of capacity eviction policies
 
 ---
 
-## 索引系统
+## Index System
 
-### RadixTreeIndex 概述
+### RadixTreeIndex Overview
 
-**职责**：基于前缀树（Radix Tree）的数据结构，支持高效的前缀匹配查询，管理缓存的插入、查询和驱逐。
+**Responsibility**: A data structure based on the prefix tree (Radix Tree), supporting efficient prefix matching queries, and managing cache insertion, query, and eviction.
 
-**核心操作**：
-1. `InsertOnly()` - 仅插入块，不查询
-2. `PrefixQuery()` - 前缀匹配查询
-3. `ExportForVisualization()` - 导出前缀树用于可视化
+**Core operations**:
+1. `InsertOnly()` - insert blocks only, no query
+2. `PrefixQuery()` - prefix matching query
+3. `ExportForVisualization()` - export the prefix tree for visualization
 
-### Radix Tree 数据结构
+### Radix Tree Data Structure
 
 ```cpp
 struct RadixTreeNode {
-    std::vector<std::unique_ptr<BlockEntry>> blocks;  // 连续的块段
-    NodeStat stat;  // 节点统计信息
+    std::vector<std::unique_ptr<BlockEntry>> blocks;  // contiguous block segment
+    NodeStat stat;  // node statistics
     RadixTreeNode *parent = nullptr;
     std::unordered_map<int64_t, std::unique_ptr<RadixTreeNode>> children;
     bool isLeaf() const { return children.empty(); }
@@ -415,7 +417,7 @@ struct RadixTreeNode {
 struct NodeStat {
     size_t access_count = 0;
     int64_t last_access_time = 0;
-    int64_t ttl = 250000;  // 默认TTL为250000微秒
+    int64_t ttl = 250000;  // default TTL is 250000 microseconds
 };
 
 struct BlockEntry {
@@ -428,53 +430,53 @@ struct BlockEntry {
 };
 ```
 
-### Radix Tree 可视化
+### Radix Tree Visualization
 
-支持导出 Radix Tree 结构用于可视化分析，可以展示：
-- 节点访问次数
-- 最后访问时间
-- 节点中的块数量
-- 缓存的块数量
-- 节点层级关系
-
----
-
-## Trace 处理
-
-### Trace 类型定义
-
-**继承关系**：
-```
-OptimizerSchemaTrace (基类)
-    ├── GetLocationSchemaTrace (读操作)
-    ├── RequestSchemaTrace (请求级操作，内部调度读和延迟写)
-    └── WriteCacheSchemaTrace (写操作)
-```
-
-### Trace 转换器
-
-**支持的格式**：
-- **Publisher Log**：转换 KVCacheManager Event Publisher 日志，区分读和写请求
-- **Qwen Bailian**：转换 Qwen Bailian 数据集格式，输出读写分离 trace
-
-**转换流程**：
-1. 根据配置文件选择转换器
-2. 解析日志文件并转换为标准 Trace；标准 `get` 必须带 `input_len`
-3. 按时间戳排序 Trace
-4. 分配唯一 Trace ID
-
-标准 trace 接受显式 `type=get/write/request` 的 JSONL。`request` 用于外部只有请求级记录的场景，optimizer 会按 `trace_replay.write_delay_ns` 在内部调度 delayed write。`get/request.keys` 只能包含完整 block key，不足一个 block 的尾部 token 不写入 `keys`，但仍通过 `input_len` 计入 token 命中率分母。缺少 `input_len`、时间戳非法、`keys` 超过 `input_len / block_size` 等输入会在回放前失败。
+Supports exporting the Radix Tree structure for visual analysis, which can display:
+- Node access count
+- Last access time
+- Number of blocks in the node
+- Number of cached blocks
+- Node hierarchy relationships
 
 ---
 
-## 结果分析
+## Trace Processing
 
-### 结果结构
+### Trace Type Definitions
+
+**Inheritance relationships**:
+```
+OptimizerSchemaTrace (base class)
+    ├── GetLocationSchemaTrace (read operation)
+    ├── RequestSchemaTrace (request-level operation, internally schedules read and delayed write)
+    └── WriteCacheSchemaTrace (write operation)
+```
+
+### Trace Converters
+
+**Supported formats**:
+- **Publisher Log**: converts KVCacheManager Event Publisher logs, distinguishing read and write requests
+- **Qwen Bailian**: converts the Qwen Bailian dataset format, outputting read/write separated traces
+
+**Conversion flow**:
+1. Select the converter based on the configuration file
+2. Parse the log file and convert to standard Trace; a standard `get` must carry `input_len`
+3. Sort traces by timestamp
+4. Assign unique Trace IDs
+
+Standard traces accept JSONL with explicit `type=get/write/request`. `request` is used for scenarios where externally only request-level records exist; the optimizer schedules delayed writes internally according to `trace_replay.write_delay_ns`. `get/request.keys` can only contain complete block keys; trailing tokens that do not fill a block are not written into `keys`, but are still counted into the token hit-rate denominator via `input_len`. Inputs missing `input_len`, with illegal timestamps, or with `keys` exceeding `input_len / block_size` will fail before replay.
+
+---
+
+## Result Analysis
+
+### Result Structure
 
 ```cpp
 struct ReadRecord {
     int64_t timestamp_ns;
-    // local = trace block_mask 带入的已有本地命中；remote = optimizer 模拟层命中
+    // local = existing local hits brought in by trace block_mask; remote = hits from the optimizer simulation layer
     size_t remote_read_blocks;
     size_t remote_hit_blocks;
     size_t local_read_blocks;
@@ -490,92 +492,92 @@ struct ReadRecord {
 };
 ```
 
-### CSV 输出格式
+### CSV Output Format
 
-**文件名**：`{instance_id}_hit_rates.csv`
+**File name**: `{instance_id}_hit_rates.csv`
 
-**主要列**：
-- `TimestampNs` - 时间戳（纳秒）
-- `CachedBlocks` - 当前 CSV 对应 instance 的缓存 block 数
-- `CachedBlocksAllInstances` - 同一 optimizer 进程内所有 instance 的总缓存 block 数
-- `ReadBlocks` / `HitBlocks` - 当前请求读取和命中的 block 数
-- `LocalHitBlocks` / `RemoteHitBlocks` - 诊断字段：trace `block_mask` 带入的已有本地命中 / optimizer 模拟层命中
-- `InputTokens` / `HitTokens` - 当前请求的输入 token 数和命中 token 数
-- `HitRate` - 当前 token 命中率，`HitTokens / InputTokens`
-- `LocalHitTokens` / `RemoteHitTokens` - 诊断字段：本地 / optimizer 模拟层命中 token 数
-- `AccReadBlocks` / `AccHitBlocks` - 累计读取和命中的 block 数
-- `AccHitRate` - 累积 token 命中率，`AccHitTokens / AccInputTokens`
-- `AccLocalHitRate` / `AccRemoteHitRate` - 诊断字段，不作为标准分析主口径
-- `Tier<N>(name)_HitTokens` / `Tier<N>(name)_HitRate` / `AccTier<N>(name)_HitRate` - 分层命中 token 指标
+**Main columns**:
+- `TimestampNs` - timestamp (nanoseconds)
+- `CachedBlocks` - number of cached blocks for the instance corresponding to the current CSV
+- `CachedBlocksAllInstances` - total number of cached blocks across all instances within the same optimizer process
+- `ReadBlocks` / `HitBlocks` - number of blocks read and hit by the current request
+- `LocalHitBlocks` / `RemoteHitBlocks` - diagnostic fields: existing local hits brought in by trace `block_mask` / hits from the optimizer simulation layer
+- `InputTokens` / `HitTokens` - input token count and hit token count of the current request
+- `HitRate` - current token hit rate, `HitTokens / InputTokens`
+- `LocalHitTokens` / `RemoteHitTokens` - diagnostic fields: local / optimizer simulation layer hit token count
+- `AccReadBlocks` / `AccHitBlocks` - cumulative read and hit block count
+- `AccHitRate` - cumulative token hit rate, `AccHitTokens / AccInputTokens`
+- `AccLocalHitRate` / `AccRemoteHitRate` - diagnostic fields, not used as the main metric of standard analysis
+- `Tier<N>(name)_HitTokens` / `Tier<N>(name)_HitRate` / `AccTier<N>(name)_HitRate` - tiered hit token metrics
 
-标准分析直接按请求输入计算整体 `HitRate`，不把 local/remote 作为独立结论维度。local/remote 只用于兼容 optimizer 作为单独 L3 模拟并和 HiSim 结合、或直接分析 KVCacheManager event log 时已有的本地命中信息。
+Standard analysis directly computes the overall `HitRate` from request input, and does not treat local/remote as independent conclusion dimensions. local/remote are only used for compatibility when the optimizer acts as a standalone L3 simulation combined with HiSim, or when directly analyzing KVCacheManager event logs with existing local hit information.
 
 ---
 
-## 可视化分析
+## Visual Analysis
 
-### 1. 命中率随时间变化图表
+### 1. Hit Rate Over Time Chart
 
-**脚本**：`optimizer_run.py --draw-chart`，绘图实现位于 `plot/hit_rate_plot.py`
+**Script**: `optimizer_run.py --draw-chart`; the plotting implementation is in `plot/hit_rate_plot.py`
 
-**功能**：绘制多实例缓存分析图表，展示所有 instance 的存储容量总和以及各自命中率随时间的变化。
+**Function**: Draws multi-instance cache analysis charts, showing the sum of storage capacity across all instances and their respective hit rates over time.
 
-**运行方式**：
+**How to run**:
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
     -c /path/to/config.json \
     --draw-chart
 ```
 
-**输出**：
+**Output**:
 - `{output_result_path}/timeseries/multi_instance_cache_analysis.png`
-- 分层配置额外输出 `{output_result_path}/timeseries/per_tier_timeseries.png`
+- Tiered configurations additionally output `{output_result_path}/timeseries/per_tier_timeseries.png`
 
-**图表内容**：
-- 上图：累计命中率随时间变化
-- 下图：当前 trace 命中率随时间变化
+**Chart content**:
+- Top chart: cumulative hit rate over time
+- Bottom chart: current trace hit rate over time
 
-### 2. Radix Tree 可视化
+### 2. Radix Tree Visualization
 
-**脚本**：`export_tree.py`，绘图实现位于 `plot/radix_tree_plot.py`
+**Script**: `export_tree.py`; the plotting implementation is in `plot/radix_tree_plot.py`
 
-**功能**：导出并可视化前缀树结构，统计并展示热节点以及所属节点的前缀路径。
+**Function**: Exports and visualizes the prefix tree structure, counting and displaying hot nodes and the prefix paths of their associated nodes.
 
-**运行方式**：
+**How to run**:
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:export_tree -- \
     -c /path/to/config.json
 ```
 
-**输出**：
-- `{output_result_path}/radix_tree/{instance_id}_radix_tree.json` - Radix Tree 导出数据
-- `{output_result_path}/radix_tree/{instance_id}_radix_tree.png` - Radix Tree 可视化图表
-- `{output_result_path}/radix_tree/{instance_id}_hot_paths.png` - 热点路径图（传 `--show-hot-paths` 时）
+**Output**:
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.json` - Radix Tree export data
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.png` - Radix Tree visualization chart
+- `{output_result_path}/radix_tree/{instance_id}_hot_paths.png` - hot path chart (when `--show-hot-paths` is passed)
 
-**可视化内容**：
-- 节点访问次数
-- 最后访问时间
-- 节点中的块数量
-- 缓存的块数量
-- 节点层级关系
+**Visualization content**:
+- Node access count
+- Last access time
+- Number of blocks in the node
+- Number of cached blocks
+- Node hierarchy relationships
 
-### 3. Pareto 容量-命中率曲线分析
+### 3. Pareto Capacity-Hit-Rate Curve Analysis
 
-**脚本**：`tradeoff.py`
+**Script**: `tradeoff.py`
 
-**功能**：在不同容量配置下回放 optimizer，绘制容量与 token 命中率的 Pareto 曲线。不给 `--eviction-policies` 时使用配置文件中的策略；给出多个策略时生成多策略对比图。
+**Function**: Replays the optimizer under different capacity configurations and draws the Pareto curve of capacity versus token hit rate. When `--eviction-policies` is not given, the policy in the config file is used; when multiple policies are given, a multi-policy comparison chart is generated.
 
-> **适用范围**：Trade-off 分析仅适用于非分层模式。在分层模式（`tier_strategy.hierarchical_eviction_enabled=true`）下，容量扫描仅修改 `quota_capacity`，不影响各 tier 独立的 `storages[i].capacity`，因此无法产生有意义的容量-性能权衡结果。
+> **Scope of applicability**: Trade-off analysis only applies to non-tiered mode. In tiered mode (`tier_strategy.hierarchical_eviction_enabled=true`), the capacity scan only modifies `quota_capacity` and does not affect each tier's independent `storages[i].capacity`, so it cannot produce meaningful capacity-performance tradeoff results.
 
-**运行流程**：
+**Execution flow**:
 
-1. 用无限容量 warmup 跑完整 trace。实现上会将 `quota_capacity` 写为 `-1`，C++ optimizer 将负容量视作无限容量。
-2. 从 warmup 读取理论命中率和最大缓存 block 数。
-3. 基于最大缓存 block 数按指数分布生成最多 `--num-points` 个容量点，并用 `--min-capacity-ratio` 过滤过小点。
-4. 对每个容量点运行 optimizer；达到 99% 理论命中率后停止继续扫更大容量。
-5. 画图时补 `(0 GB, 0%)` 起点，只保留命中率上升段。下降点会从图上剔除，并在 stdout 打印 `Drop descending Pareto point ...`；原始 CSV 保留。
+1. Run the full trace with infinite-capacity warmup. In implementation, `quota_capacity` is written as `-1`, and the C++ optimizer treats negative capacity as infinite capacity.
+2. Read the theoretical hit rate and maximum cache block count from the warmup.
+3. Generate up to `--num-points` capacity points based on the maximum cache block count with an exponential distribution, and filter out overly small points with `--min-capacity-ratio`.
+4. Run the optimizer for each capacity point; stop scanning larger capacities after reaching 99% of the theoretical hit rate.
+5. When plotting, add the `(0 GB, 0%)` starting point and only keep the rising segment of hit rate. Descending points are removed from the chart, and `Drop descending Pareto point ...` is printed to stdout; the original CSV is retained.
 
-**运行方式**：
+**How to run**:
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     -c /path/to/config.json \
@@ -585,25 +587,25 @@ bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     --max-workers 4
 ```
 
-**参数说明**：
-- `-c, --config` - 配置文件路径
-- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中后提前停止
-- `--min-capacity-ratio` - 最小容量点相对阈值（默认 `1e-4`）
-- `--hit-rate-type` - 命中率类型，标准分析使用 total；local/remote/all 仅作诊断拆分（默认 total）
-- `--max-workers` - 并行执行的最大线程数（默认 4）
-- `--plot-title` - 覆盖图标题
+**Parameter description**:
+- `-c, --config` - configuration file path
+- `--num-points` - maximum number of capacity sampling points to run per policy (default 30); stops early after reaching 99% of the theoretical hit rate
+- `--min-capacity-ratio` - minimum capacity point relative threshold (default `1e-4`)
+- `--hit-rate-type` - hit-rate type; standard analysis uses total; local/remote/all are only diagnostic splits (default total)
+- `--max-workers` - maximum number of parallel execution threads (default 4)
+- `--plot-title` - override the chart title
 
-**输出**：`{output_result_path}/pareto/pareto_curve_{hit_rate_type}.png`
+**Output**: `{output_result_path}/pareto/pareto_curve_{hit_rate_type}.png`
 
-### 4. 多策略对比分析
+### 4. Multi-Policy Comparison Analysis
 
-**脚本**：`tradeoff.py --eviction-policies ...`
+**Script**: `tradeoff.py --eviction-policies ...`
 
-**功能**：对比多个驱逐策略在不同容量配置下的表现。所有 instance 使用同一个给定策略进行一轮回放；每个策略独立 warmup、独立计算理论命中率，并独立提前停止。
+**Function**: Compares the performance of multiple eviction policies under different capacity configurations. All instances use the same given policy for one round of replay; each policy warms up independently, computes its theoretical hit rate independently, and stops early independently.
 
-> **适用范围**：同单策略 Trade-off 分析，仅适用于非分层模式。
+> **Scope of applicability**: Same as single-policy Trade-off analysis, only applies to non-tiered mode.
 
-**运行方式**：
+**How to run**:
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     -c /path/to/config.json \
@@ -613,40 +615,40 @@ bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
     --max-workers 4
 ```
 
-**参数说明**：
-- `-c, --config` - 配置文件路径
-- `--eviction-policies` - 要对比的驱逐策略列表（默认 lru random_lru leaf_aware_lru）
-- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中后提前停止
-- `--hit-rate-type` - 命中率类型，标准分析使用 total；local/remote/all 仅作诊断拆分（默认 total）
-- `--max-workers` - 并行执行的最大线程数（默认 4）
+**Parameter description**:
+- `-c, --config` - configuration file path
+- `--eviction-policies` - list of eviction policies to compare (default lru random_lru leaf_aware_lru)
+- `--num-points` - maximum number of capacity sampling points to run per policy (default 30); stops early after reaching 99% of the theoretical hit rate
+- `--hit-rate-type` - hit-rate type; standard analysis uses total; local/remote/all are only diagnostic splits (default total)
+- `--max-workers` - maximum number of parallel execution threads (default 4)
 
-**输出**：`{output_result_path}/pareto/multi_policy_{hit_rate_type}.png`
+**Output**: `{output_result_path}/pareto/multi_policy_{hit_rate_type}.png`
 
-图形规则：X 轴是 `Capacity (GB)`，Y 轴是 `HitRate (%)`；95%/99% 理论命中率会按相邻 sweep 点线性插值后标出容量和命中率。`--skip-run` 只从已有 `csv_results` 画图，不重新 warmup，因此不会生成理论 95%/99% 标注。
+Chart rules: the X axis is `Capacity (GB)`, the Y axis is `HitRate (%)`; the 95%/99% theoretical hit rates are marked with capacity and hit rate after linear interpolation between adjacent sweep points. `--skip-run` only plots from existing `csv_results` without re-warming up, so the theoretical 95%/99% annotations are not generated.
 
 ---
 
-## 使用说明
+## Usage Instructions
 
-### 编译
+### Build
 
 ```bash
 bazel build //kv_cache_manager/optimizer:optimizer_main
 ```
 
-### 运行优化器
+### Run the Optimizer
 
-**方式：直接运行二进制文件**
+**Method: run the binary directly**
 
 ```bash
 bazel run //kv_cache_manager/optimizer:optimizer_main -- /path/to/config.json
 ```
 
-### 离线 LiteHit 多容量分析
+### Offline LiteHit Multi-Capacity Analysis
 
-独立入口 `lite_hit_main`，与上面的 replay 回放并行、互不干扰。它把标准 trace 的读请求按到达顺序回放进 LiteHit 核心，产出**与容量无关**的逐请求 facts CSV（`litehit_facts.csv`，先写 `.tmp` 再原子 rename）；命中率不在回放时计算，而是由第二个 CLI `lite_hit_facts_query_main` 在 facts 上按任意容量列表投影得到（JSONL 逐请求结果 + per-instance / overall 汇总）。同一份 facts 可反复用不同容量查询，无需重放 trace。
+A standalone entry point `lite_hit_main`, parallel to and non-interfering with the replay above. It replays the read requests of a standard trace into the LiteHit core in arrival order, producing **capacity-independent** per-request facts CSV (`litehit_facts.csv`, written to `.tmp` first then atomically renamed); the hit rate is not computed during replay, but is obtained by a second CLI `lite_hit_facts_query_main` projecting onto the facts with an arbitrary capacity list (JSONL per-request results + per-instance / overall summary). The same facts can be repeatedly queried with different capacities without replaying the trace.
 
-trace 复用共享的 `StandardTraceLoader`：同一份标准格式 trace 既能喂给 liteHit 离线分析，也能直接给 replay 回放用。回放固定为流式（`StreamFromFile`，内存 O(1)），要求 trace 已按 `timestamp_ns` 有序。**写事件会被识别并忽略**：读请求提交时视为全部 block 已写回（写回本身就是一次 touch），因此拆分的 `write` trace 对 liteHit 无副作用——它只对 replay 路径有意义。
+The trace reuses the shared `StandardTraceLoader`: the same standard-format trace can be fed to both liteHit offline analysis and directly to replay. Replay is fixed to streaming (`StreamFromFile`, memory O(1)), requiring the trace to be ordered by `timestamp_ns`. **Write events are recognized and ignored**: when a read request is submitted, all blocks are treated as written back (write-back itself is a touch), so split `write` traces have no side effect on liteHit — they are only meaningful for the replay path.
 
 ```bash
 bazel build //kv_cache_manager/optimizer:lite_hit_main //kv_cache_manager/optimizer:lite_hit_facts_query_main
@@ -654,144 +656,144 @@ bazel run //kv_cache_manager/optimizer:lite_hit_main -- /path/to/lite_hit_config
 bazel run //kv_cache_manager/optimizer:lite_hit_facts_query_main -- <facts_csv> <capacity_gb_list> <output_jsonl>
 ```
 
-配置 `OptimizerLiteHitConfig` 复用在线的 `OptimizerInstanceGroup` / `OptimizerInstanceInfo` 对象（full-attention 实例要求 `linear_step=0`）：
+The config `OptimizerLiteHitConfig` reuses the online `OptimizerInstanceGroup` / `OptimizerInstanceInfo` objects (full-attention instances require `linear_step=0`):
 
-| 字段 | 含义 |
+| Field | Meaning |
 |------|------|
-| trace_file_path | 标准格式 trace 文件路径（与 replay 共用同一份 trace） |
-| output_result_path | facts CSV 输出目录 |
-| instance_groups | 在线 `OptimizerInstanceGroup` 列表（含 eviction_policy / enable_prefix_hash 等） |
-| instances | 在线 `OptimizerInstanceInfo` 列表（含 block_size / linear_step / location spec 等） |
-| block_size | trace 的 token 粒度（默认 256）；实例 block_size 必须是它的整数倍（re-blocking 只做粗化） |
-| override_instance_id | 把所有请求路由到指定实例（须在 instances 中） |
-| fanout_all_instances | 把每条请求广播到所有配置实例（与 override 互斥），用于一次回放对比多种 block_size |
-| pipeline_worker_count | 回放流水线并行度（默认 1） |
+| trace_file_path | standard-format trace file path (shares the same trace as replay) |
+| output_result_path | facts CSV output directory |
+| instance_groups | list of online `OptimizerInstanceGroup` (including eviction_policy / enable_prefix_hash, etc.) |
+| instances | list of online `OptimizerInstanceInfo` (including block_size / linear_step / location spec, etc.) |
+| block_size | token granularity of the trace (default 256); instance block_size must be an integer multiple of it (re-blocking only coarsens) |
+| override_instance_id | route all requests to the specified instance (must be in instances) |
+| fanout_all_instances | broadcast each request to all configured instances (mutually exclusive with override), used to compare multiple block_size in one replay |
+| pipeline_worker_count | replay pipeline parallelism (default 1) |
 
-算法细节、facts 字段定义、投影口径与验证清单见 [liteHit/README.md](../liteHit/README.md)。
+Algorithm details, facts field definitions, projection metrics, and the verification checklist are in [liteHit/README.md](../liteHit/README.md).
 
-### Python 接口
+### Python Interface
 
 ```python
 from kv_cache_manager.optimizer import OptimizerConfigLoader, OptimizerLoader, OptimizerManager
 
-# 加载配置
+# Load configuration
 config_loader = OptimizerConfigLoader()
 config = config_loader.Load("/path/to/config.json")
 
-# 创建优化器
+# Create the optimizer
 optimizer = OptimizerManager(config)
 optimizer.Init()
 
-# 运行
+# Run
 optimizer.DirectRun()
 
-# 分析结果
+# Analyze results
 optimizer.AnalyzeResults()
 ```
 
-### 输出文件
+### Output Files
 
-运行完成后，会在 `output_result_path` 指定的目录下生成：
-- `{instance_id}_hit_rates.csv` - 每个 instance 的命中率数据
-
----
-
-## 扩展指南
-
-### 添加新的驱逐策略
-
-1. 在 `kv_cache_manager/optimizer/eviction_policy/` 创建新策略文件，继承 `EvictionPolicy` 基类
-2. 在 `kv_cache_manager/optimizer/config/types.h` 添加新的策略类型枚举值
-3. 在 `kv_cache_manager/optimizer/config/eviction_config.h` 添加新的参数类型
-4. 在 `kv_cache_manager/optimizer/eviction_policy/policy_factory.cc` 添加新的策略创建逻辑
-5. 在 BUILD 文件中添加新的源文件
-
-### 添加新的 Trace 转换器
-
-1. 在 `kv_cache_manager/optimizer/trace_converter/` 创建新转换器文件，继承 `BaseConverter` 基类
-2. 在 `kv_cache_manager/optimizer/config/types.h` 添加新的 trace 类型枚举值
-3. 在 `kv_cache_manager/optimizer/trace_converter/converter_factory.cc` 添加新的转换器创建逻辑
-4. 在 BUILD 文件中添加新的源文件
-
-### 添加新的分析指标
-
-1. 在 `kv_cache_manager/optimizer/analysis/result_structure.h` 添加新的统计字段
-2. 在 `kv_cache_manager/optimizer/analysis/result_analysis.cc` 添加新的分析逻辑
-3. 实现新的导出函数来输出自定义指标
+After running, the following is generated in the directory specified by `output_result_path`:
+- `{instance_id}_hit_rates.csv` - hit-rate data for each instance
 
 ---
 
-## 附录
+## Extension Guide
 
-### 文件索引
+### Adding a New Eviction Policy
 
-**核心管理器**：
-- optimizer_manager.h/cc - 主协调器
-- optimizer_runner.h/cc - Trace 执行器
-- eviction_manager.h/cc - 驱逐管理器
-- indexer_manager.h/cc - 索引管理器
-- optimizer_loader.h/cc - Trace 加载器
+1. Create a new policy file in `kv_cache_manager/optimizer/eviction_policy/`, inheriting the `EvictionPolicy` base class
+2. Add a new policy type enum value in `kv_cache_manager/optimizer/config/types.h`
+3. Add a new parameter type in `kv_cache_manager/optimizer/config/eviction_config.h`
+4. Add new policy creation logic in `kv_cache_manager/optimizer/eviction_policy/policy_factory.cc`
+5. Add the new source file in the BUILD file
 
-**索引层**：
-- radix_tree_index.h/cc - Radix 树索引
+### Adding a New Trace Converter
 
-**驱逐策略**：
-- base.h - 策略基类
-- common_structure.h - 通用数据结构
-- lru.h/cc - LRU 策略
-- random_lru.h/cc - RandomLRU 策略
-- leaf_aware_lru.h/cc - LeafAwareLRU 策略
-- policy_factory.h/cc - 策略工厂
+1. Create a new converter file in `kv_cache_manager/optimizer/trace_converter/`, inheriting the `BaseConverter` base class
+2. Add a new trace type enum value in `kv_cache_manager/optimizer/config/types.h`
+3. Add new converter creation logic in `kv_cache_manager/optimizer/trace_converter/converter_factory.cc`
+4. Add the new source file in the BUILD file
 
-**Trace 转换**：
-- optimizer_schema_trace.h - Trace 定义
-- base_converter.h - 转换器基类
-- publisher_log_converter.h/cc - Publisher Log 转换器
-- qwen_bailian_converter.h/cc - Qwen Bailian 转换器
-- converter_factory.h/cc - 转换工厂
-- trace_util.h - Trace 工具
+### Adding a New Analysis Metric
 
-**配置**：
-- optimizer_config.h/cc - 顶层配置
-- replay_instance_group_config.h/cc - trace replay/tier 模拟实例组配置
-- replay_instance_config.h/cc - trace replay 实例配置
-- tier_config.h/cc - 存储层配置
-- eviction_config.h - 驱逐策略参数
-- types.h - 类型定义
-- optimizer_config_loader.h/cc - 配置加载器
+1. Add a new statistics field in `kv_cache_manager/optimizer/analysis/result_structure.h`
+2. Add new analysis logic in `kv_cache_manager/optimizer/analysis/result_analysis.cc`
+3. Implement a new export function to output custom metrics
 
-**分析**：
-- result_structure.h - 结果结构定义
-- result_analysis.h/cc - 命中率分析
-- script/run/optimizer_run.py - 单次回放 + 可选时序图
-- script/run/tradeoff.py - Pareto 曲线，单策略/多策略统一入口
-- script/run/export_tree.py - Radix Tree 导出 + 可视化
-- script/run/analyze_lifecycle.py - Block lifecycle 分析
-- script/run/multi_instance_replay.py - 多实例并行回放 + 聚合
-- script/plot/hit_rate_plot.py - 命中率时序图
-- script/plot/radix_tree_plot.py - Radix Tree 绘图
-- script/utils/optimizer_runner.py - optimizer 运行封装
+---
 
-**Python 绑定**：
-- pybind/py_optimizer_binding.cc - Python 接口
+## Appendix
 
-### 术语表
+### File Index
 
-| 术语 | 说明 |
+**Core managers**:
+- optimizer_manager.h/cc - main coordinator
+- optimizer_runner.h/cc - trace executor
+- eviction_manager.h/cc - eviction manager
+- indexer_manager.h/cc - indexer manager
+- optimizer_loader.h/cc - trace loader
+
+**Index layer**:
+- radix_tree_index.h/cc - Radix tree index
+
+**Eviction policies**:
+- base.h - policy base class
+- common_structure.h - common data structures
+- lru.h/cc - LRU policy
+- random_lru.h/cc - RandomLRU policy
+- leaf_aware_lru.h/cc - LeafAwareLRU policy
+- policy_factory.h/cc - policy factory
+
+**Trace conversion**:
+- optimizer_schema_trace.h - trace definitions
+- base_converter.h - converter base class
+- publisher_log_converter.h/cc - Publisher Log converter
+- qwen_bailian_converter.h/cc - Qwen Bailian converter
+- converter_factory.h/cc - converter factory
+- trace_util.h - trace utilities
+
+**Configuration**:
+- optimizer_config.h/cc - top-level config
+- replay_instance_group_config.h/cc - trace replay/tier simulation instance group config
+- replay_instance_config.h/cc - trace replay instance config
+- tier_config.h/cc - storage tier config
+- eviction_config.h - eviction policy parameters
+- types.h - type definitions
+- optimizer_config_loader.h/cc - config loader
+
+**Analysis**:
+- result_structure.h - result structure definitions
+- result_analysis.h/cc - hit-rate analysis
+- script/run/optimizer_run.py - single replay + optional time-series chart
+- script/run/tradeoff.py - Pareto curve, unified entry for single/multi-policy
+- script/run/export_tree.py - Radix Tree export + visualization
+- script/run/analyze_lifecycle.py - block lifecycle analysis
+- script/run/multi_instance_replay.py - multi-instance parallel replay + aggregation
+- script/plot/hit_rate_plot.py - hit-rate time-series chart
+- script/plot/radix_tree_plot.py - Radix Tree plotting
+- script/utils/optimizer_runner.py - optimizer run wrapper
+
+**Python bindings**:
+- pybind/py_optimizer_binding.cc - Python interface
+
+### Glossary
+
+| Term | Description |
 |------|------|
-| 驱逐策略 | 当缓存满时选择哪些块被移除的算法 |
-| LRU | 最近最少使用算法 |
-| RandomLRU | 结合随机采样和 LRU 的混合算法 |
-| LeafAwareLRU | 叶子节点感知的 LRU 算法 |
-| Radix Tree | 用于高效前缀匹配的树形数据结构 |
-| Trace | 记录系统操作序列的数据 |
-| Instance | 缓存系统的独立实例 |
-| Instance Group | 共享资源的实例集合 |
-| Block | 缓存的基本单位 |
-| Hit Rate | 缓存命中次数与总访问次数的比值 |
-| Prefix Match | 查找具有相同前缀的键 |
-| Read/Write Separation | 将读和写操作分开处理 |
-| Trade-off Curve | 容量与命中率之间的权衡曲线 |
+| Eviction Policy | The algorithm that selects which blocks are removed when the cache is full |
+| LRU | Least Recently Used algorithm |
+| RandomLRU | A hybrid algorithm combining random sampling and LRU |
+| LeafAwareLRU | A leaf-node-aware LRU algorithm |
+| Radix Tree | A tree data structure for efficient prefix matching |
+| Trace | Data recording the sequence of system operations |
+| Instance | An independent instance of the cache system |
+| Instance Group | A collection of instances sharing resources |
+| Block | The basic unit of the cache |
+| Hit Rate | The ratio of cache hits to total accesses |
+| Prefix Match | Finding keys that share the same prefix |
+| Read/Write Separation | Processing read and write operations separately |
+| Trade-off Curve | The tradeoff curve between capacity and hit rate |
 
 
 

--- a/kv_cache_manager/optimizer/docs/optimizer_architecture_zh.md
+++ b/kv_cache_manager/optimizer/docs/optimizer_architecture_zh.md
@@ -1,0 +1,800 @@
+# KVCacheManager Optimizer 架构文档
+
+> 中文 | [English](optimizer_architecture.md)
+
+## 目录
+
+1. [概述](#概述)
+2. [架构设计](#架构设计)
+3. [核心模块](#核心模块)
+4. [配置系统](#配置系统)
+5. [驱逐策略](#驱逐策略)
+6. [索引系统](#索引系统)
+7. [Trace 处理](#trace-处理)
+8. [结果分析](#结果分析)
+9. [可视化分析](#可视化分析)
+10. [使用说明](#使用说明)
+11. [扩展指南](#扩展指南)
+
+---
+
+## 概述
+
+KVCacheManager Optimizer 是一个独立的缓存优化分析模块，通过回放 trace 数据来模拟缓存读写操作，评估不同驱逐策略和配置对缓存命中率的影响，并为 KVCacheManager 主程序提供参数优化能力。
+
+### 主要特性
+
+- **多种驱逐策略**：支持 LRU、RandomLRU、LeafAwareLRU、TTL 等驱逐算法
+- **分层存储**：支持多层级存储配置，目前功能不完备
+- **Trace 回放**：支持 Publisher Log、Qwen Bailian 等多种 trace 格式
+- **读写分离**：支持读写分离模式和组合模式
+- **详细统计**：提供命中率、缓存使用情况等详细统计
+- **灵活配置**：通过 JSON 配置文件灵活配置实例、存储和策略
+- **可视化分析**：支持 Radix Tree 可视化、命中率图表和 Trade-off 曲线分析
+- **在线优化服务**：支持通过服务接口注册在线实例、实时 TraceQuery 统计命中率和容量使用
+- **轻量多容量分析**：LiteHit 用 reuse distance 一次精确计算多个 full-attention LRU 容量（含无限容量）的命中率，同时支持离线请求序列和在线流式请求
+
+---
+
+## 架构设计
+
+### 整体架构
+
+Optimizer 当前包含离线 trace 回放和在线优化服务两条运行路径：
+
+- 离线回放路径使用 `OptimizerManager`、`OptIndexerManager`、`OptEvictionManager` 和 `RadixTreeIndex`，依赖 replay 配置、trace loader/converter 和 data storage 类型。
+- 在线服务路径使用 `OnlineOptimizerManager`、LiteHit、`CacheIndexerFactory`、`LruCacheIndexer`/`TtlCacheIndexerWrapper` 和 service/protobuf 接口，依赖 online 实例组/实例配置与 registry。full-attention 多容量 LRU 由 `InstanceState` 直接持有 LiteHit；linear attention 仍由通用 `CacheIndexer` 模拟。
+
+两条路径共享 optimizer 模块内的命中率建模代码，但运行时、配置 target 和服务边界保持独立，避免在线服务引入离线 replay/data storage 依赖。
+
+#### 离线回放
+
+```
+main.cc (程序入口)
+    ↓
+OptimizerManager (核心协调器)
+    ├── OptEvictionManager (驱逐管理器)
+    ├── OptIndexerManager (索引管理器)
+    └── OptimizerRunner (Trace 执行器)
+        ↓
+    ├── Eviction Policies (驱逐策略)
+    │   ├── LRU
+    │   ├── RandomLRU
+    │   └── LeafAwareLRU
+    ├── RadixTreeIndex (索引)
+    └── Trace Converter (转换器)
+        ↓
+    HitAnalysis (结果分析)
+        ↓
+    Visualization Tools (可视化工具)
+```
+
+#### 在线服务
+
+```
+OptimizerServiceImpl (HTTP/gRPC 接口)
+    ↓
+OnlineOptimizerManager (在线运行时协调器)
+    ├── OptimizerRegistryManager (实例组/实例持久化)
+    └── InstanceState (instance_id 隔离的运行状态)
+        ↓
+    ├── LiteHit (full-attention 多容量 LRU)
+    └── CacheIndexerFactory (linear attention)
+        └── LruCacheIndexer / TtlCacheIndexerWrapper
+```
+
+### 目录结构
+
+```
+kv_cache_manager/optimizer/
+├── manager/              # 核心管理层
+│   ├── optimizer_manager.h/cc       # 主协调器
+│   ├── optimizer_runner.h/cc        # Trace 执行器
+│   ├── eviction_manager.h/cc        # 驱逐管理器
+│   ├── indexer_manager.h/cc         # 索引管理器
+│   ├── optimizer_loader.h/cc        # Trace 加载器
+│   ├── lite_hit_offline_runner.h/cc # 离线 LiteHit runner：进程内驱动 OnlineOptimizerManager
+│   └── online_runtime/              # 在线运行时
+│       └── online_optimizer_manager.h/cc # 在线实例注册、TraceQuery 和统计
+├── index/                # 索引层
+│   ├── radix_tree_index.h/cc        # 离线 Radix 树索引
+│   └── online/                    # linear attention 在线容量/TTL 索引器
+├── liteHit/              # 轻量多容量 full-attention LRU 命中率核心
+│   ├── lite_hit.h/cc                # 多容量 LRU 命中率分析器
+│   └── dynamic_fenwick_tree.h/cc    # reuse-distance 用的 order-statistics Fenwick
+├── eviction_policy/      # 驱逐策略层
+│   ├── base.h                   # 策略基类
+│   ├── common_structure.h       # 通用数据结构
+│   ├── lru.h/cc                 # LRU 策略
+│   ├── random_lru.h/cc          # RandomLRU 策略
+│   ├── leaf_aware_lru.h/cc      # LeafAwareLRU 策略
+│   └── policy_factory.h/cc      # 策略工厂
+├── trace_converter/      # Trace 转换层
+│   ├── optimizer_schema_trace.h  # Trace 定义
+│   ├── base_converter.h          # 转换器基类
+│   ├── publisher_log_converter.h/cc  # Publisher Log 转换器
+│   ├── qwen_bailian_converter.h/cc    # Qwen Bailian 转换器
+│   ├── converter_factory.h/cc    # 转换器工厂
+│   └── trace_util.h              # Trace 工具
+├── config/               # 配置层
+│   ├── optimizer_config.h/cc     # 顶层配置
+│   ├── replay_instance_group_config.h/cc # trace replay/tier 模拟实例组配置
+│   ├── replay_instance_config.h/cc      # trace replay 实例配置
+│   ├── optimizer_instance_group.h/cc    # 在线优化实例组配置
+│   ├── optimizer_instance_info.h/cc     # 在线优化实例配置
+│   ├── optimizer_registry_manager.h/cc  # 在线实例 registry
+│   ├── tier_config.h/cc          # 存储层配置
+│   ├── eviction_config.h         # 驱逐策略参数
+│   └── types.h                   # 类型定义
+├── service/              # 在线服务实现
+│   ├── optimizer_service_impl.h/cc    # 服务接口适配层
+│   └── metrics/                   # 在线指标上报
+├── analysis/             # 分析层
+│   ├── result_structure.h        # 结果结构定义
+│   ├── result_analysis.h/cc      # 命中率分析
+│   └── script/                   # 分析脚本
+│       ├── run/
+│       │   ├── optimizer_run.py          # 单次回放 + 可选时序图
+│       │   ├── tradeoff.py               # Pareto 曲线，单策略/多策略统一入口
+│       │   ├── export_tree.py            # RadixTree 导出 + 可视化
+│       │   ├── analyze_lifecycle.py      # Block lifecycle 统计
+│       │   └── multi_instance_replay.py  # 多实例并行回放 + 聚合
+│       ├── plot/
+│       │   ├── hit_rate_plot.py          # 命中率时序图
+│       │   ├── radix_tree_plot.py        # RadixTree 绘图
+│       │   └── lifecycle_plot.py         # Lifecycle CDF/直方图
+│       └── utils/
+│           ├── optimizer_runner.py       # optimizer 运行封装
+│           ├── csv_loader.py             # CSV 加载 + 容量点生成
+│           └── plot_utils.py             # Pareto/per-tier 绘图工具
+├── pybind/               # Python 绑定
+│   └── py_optimizer_binding.cc   # Python 接口
+├── main.cc               # 离线回放程序入口（optimizer_main）
+├── lite_hit_main.cc      # 离线 LiteHit 多容量分析入口（lite_hit_main）
+└── optimizer_startup_config_load.json  # 配置示例
+```
+
+在线服务协议定义在 `kv_cache_manager/protocol/protobuf/optimizer_service.proto`，由 service 层转换为 optimizer online config/runtime 对象。
+
+full-attention TraceQuery 只把完整 block 放入 `block_keys`，并用 `input_token_len` 传入包含尾部 token 的原始输入长度。Online Manager 用 full location spec group 的固定字节 charge 将 `capacity_gb` 向下取整为 block 容量，再把同一请求交给 LiteHit；请求级与累计命中率均为 `prefix_hit_blocks * block_size_tokens / input_tokens`。旧客户端缺少长度时兼容假设没有尾部 token。full-attention 组配置 `ttl_seconds != 0` 时，固定 TTL 以墙钟时间叠加在 LiteHit 之上（口径与 `TtlCacheIndexerWrapper` 一致）；linear attention 的统计口径和 TTL 行为保持 legacy 路径不变。
+
+---
+
+## 核心模块
+
+### 1. OptimizerManager（优化器管理器）
+
+**职责**：核心协调器，初始化所有子组件，管理实例组和实例配置，提供公共 API 接口。
+
+**主要接口**：
+```cpp
+class OptimizerManager {
+public:
+    OptimizerManager(const OptimizerConfig &config);
+    bool Init();
+    void DirectRun();
+    WriteCacheRes WriteCache(...);
+    GetCacheLocationRes GetCacheLocation(...);
+    void AnalyzeResults();
+    std::unordered_map<std::string, RadixTreeExport> ExportRadixTrees() const;
+};
+```
+
+### 2. OptimizerRunner（优化器运行器）
+
+**职责**：执行 Trace 回放和模拟，处理两种 Trace 类型（GetLocationSchemaTrace、WriteCacheSchemaTrace），支持读写分离模式。
+
+### 3. OptEvictionManager（驱逐管理器）
+
+**职责**：管理跨实例的驱逐策略，支持三种驱逐模式：
+- `EVICTION_MODE_GROUP_ROUGH` - 组级别粗粒度驱逐
+- `EVICTION_MODE_INSTANCE_ROUGH` - 实例级别粗粒度驱逐
+- `EVICTION_MODE_INSTANCE_PRECISE` - 实例级别精确驱逐
+
+**主要接口**：
+```cpp
+class OptEvictionManager {
+public:
+    bool Init(const EvictionConfig &eviction_config);
+    std::shared_ptr<EvictionPolicy> CreateAndRegisterEvictionPolicy(...);
+    std::unordered_map<std::string, std::vector<BlockEntry *>> EvictByMode(...);
+    size_t GetCurrentGroupUsage(...) const;
+    size_t GetCurrentInstanceUsage(...) const;
+};
+```
+
+### 4. OptIndexerManager（索引管理器）
+
+**职责**：管理 RadixTreeIndex 实例，为每个实例创建索引器，支持多层存储配置。
+
+**主要接口**：
+```cpp
+class OptIndexerManager {
+public:
+    bool CreateOptIndexer(...);
+    std::shared_ptr<RadixTreeIndex> GetOptIndexer(...) const;
+    void RegisterInstanceGroups(...);
+    void RegisterInstances(...);
+    bool CheckAndEvict(...);
+    size_t GetCurrentInstanceUsage(...) const;
+};
+```
+
+### 5. OptimizerLoader（Trace 加载器）
+
+**职责**：加载和转换 trace 文件，按时间戳排序 trace，导出转换后的 trace 到文件。
+
+---
+
+## 配置系统
+
+### 配置层次结构
+
+```
+OptimizerConfig (顶层配置)
+    ├── trace_file_path (Trace 文件路径)
+    ├── output_result_path (输出路径)
+    ├── eviction_params (驱逐参数)
+    │   ├── eviction_mode (驱逐模式)
+    │   └── eviction_batch_size_per_instance (驱逐批量大小)
+    └── instance_groups[] (实例组数组)
+        ├── group_name (组名)
+        ├── quota_capacity (配额容量)
+        ├── used_percentage (使用百分比)
+        ├── tier_strategy (多层读写策略)
+        │   ├── hierarchical_eviction_enabled (分层驱逐)
+        │   ├── write_mode (多层写入模式)
+        │   ├── access_propagation_enabled (读访问传播)
+        │   ├── promote_enabled (低层命中回填高层)
+        │   └── selective_write_threshold (选择性下写阈值)
+        ├── storages[] (存储层数组)
+        └── instances[] (实例数组)
+            ├── instance_id (实例ID)
+            ├── block_size (块大小)
+            ├── eviction_policy_type (驱逐策略类型)
+            └── eviction_policy_params (驱逐策略参数)
+```
+
+### 配置文件示例
+
+```json
+{
+    "trace_file_path": "/path/to/trace/file.jsonl",
+    "output_result_path": "/path/to/output/result/",
+    "eviction_params": {
+        "eviction_mode": 1,
+        "eviction_batch_size_per_instance": 100
+    },
+    "instance_groups": [
+        {
+            "group_name": "instance_group_01",
+            "quota_capacity": 12000,
+            "used_percentage": 1.0,
+            "tier_strategy": {
+                "hierarchical_eviction_enabled": false,
+                "write_mode": "write_through",
+                "access_propagation_enabled": true,
+                "promote_enabled": true,
+                "selective_write_threshold": 2
+            },
+            "storages": [
+                {
+                    "unique_name": "pace_00",
+                    "storage_type": "pace",
+                    "band_width_mbps": 20000,
+                    "priority": 0,
+                    "capacity": 100000
+                }
+            ],
+            "instances": [
+                {
+                    "instance_id": "instance",
+                    "block_size": 16,
+                    "bytes_per_token": 512,
+                    "eviction_policy_type": "random_lru",
+                    "eviction_policy_params": {
+                        "sample_rate": 0.1
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
+
+### 配置参数说明
+
+| 参数 | 说明 |
+|------|------|
+| trace_file_path | Trace 文件路径 |
+| output_result_path | 结果输出目录；所有 config 驱动入口都使用该目录，`export_tree` 输出到其下的 `radix_tree/` |
+| eviction_mode | 驱逐模式：1=GROUP_ROUGH, 2=INSTANCE_ROUGH, 3=INSTANCE_PRECISE |
+| eviction_batch_size_per_instance | 粗粒度驱逐时的批量大小 |
+| group_name | 实例组唯一标识 |
+| quota_capacity | 组的总容量（GB）；`-1` 表示无限容量，不触发容量驱逐 |
+| used_percentage | 实际使用的配额百分比 |
+| instance_id | 实例唯一标识 |
+| block_size | 每个 block 包含的 token 数量 |
+| bytes_per_token | 单 token KV 大小；Python 分析脚本用它和 `block_size` 将 block 容量换算为 GB |
+| eviction_policy_type | 驱逐策略类型：lru、random_lru、leaf_aware_lru |
+
+---
+
+## 驱逐策略
+
+### 驱逐策略接口
+
+```cpp
+class EvictionPolicy {
+public:
+    virtual ~EvictionPolicy() = default;
+    virtual size_t size() const = 0;
+    virtual void OnBlockWritten(BlockEntry *block) = 0;
+    virtual void OnNodeWritten(std::vector<BlockEntry *> &blocks) = 0;
+    virtual void OnBlockAccessed(BlockEntry *block, int64_t timestamp) = 0;
+    virtual std::vector<BlockEntry *> EvictBlocks(size_t num_blocks) = 0;
+    virtual std::string name() const = 0;
+    virtual void set_name(const std::string &name) = 0;
+};
+```
+
+### LRU 策略
+
+**原理**：维护双向链表记录块的访问顺序，最近访问的块在链表头部，最久未访问的块在链表尾部，驱逐时从链表尾部移除块。
+
+**时间复杂度**：
+- `OnBlockAccessed()`: O(1)
+- `OnBlockWritten()`: O(1)
+- `EvictBlocks()`: O(n)
+
+### RandomLRU 策略
+
+**原理**：结合随机采样和 LRU 策略，从缓存中随机采样一定比例的块，选择最久未访问的块进行驱逐。
+
+**时间复杂度**：
+- `OnBlockAccessed()`: O(1)
+- `OnBlockWritten()`: O(1)
+- `EvictBlocks()`: O(m log m)，其中 m 为采样数量
+
+### LeafAwareLRU 策略
+
+**原理**：在 LRU 基础上增加了对叶子节点的感知，优先驱逐叶子节点中的块，提高缓存效率。
+
+**实现特点**：
+- 维护一个独立的叶子节点 LRU 链表
+- 跟踪叶子节点中的所有 block
+- 驱逐时优先从叶子节点链表中选择最久未访问的块
+
+### TTL 语义分阶段说明（V1 / V2）
+
+当前实现采用 **V1 语义**（已落地）：
+
+- 仅 `POLICY_TTL` 实例会执行“读写前 TTL 过期物理清理”
+- 非 TTL 策略（`lru` / `random_lru` / `leaf_aware_lru`）下，TTL 视为不存在
+  - 不做前置 TTL 物理清理
+  - 也不做 TTL 逻辑过期判定
+- `POLICY_TTL` 下保证先清理过期块，再进入读写流程
+- `default_block_ttl_seconds = 0` 表示组级禁用 TTL：
+  - 写入路径会将 TTL 解析为“不过期”
+  - 若 `fallback_on_pressure = false`，则不会发生 TTL 过期驱逐，也不会触发容量兜底驱逐
+  - 若 `fallback_on_pressure = true`，则仅在容量压力时走链表尾部兜底驱逐（行为等价于 LRU）
+- `POLICY_TTL` 的过期清理实现已从“每次读写前全链表扫描”优化为“最小过期时间堆（min-heap）增量回收”：
+  - 写入/访问时写入过期事件
+  - 清理时仅弹出到期事件，不再全量扫描
+  - 使用版本号做惰性失效，避免过期事件重复处理
+  - 在不改变 TTL 语义的前提下显著降低回放时延
+
+后续 **V2 设计**（仅文档方案，暂不实现）：
+
+- 统一语义：所有策略都支持前置过期清理
+- 对过期扫描做精细化性能优化（例如 next_expire_ts / min-heap 等）
+- 在不改变容量驱逐策略语义的前提下，实现跨策略一致的 TTL 生命周期
+
+---
+
+## 索引系统
+
+### RadixTreeIndex 概述
+
+**职责**：基于前缀树（Radix Tree）的数据结构，支持高效的前缀匹配查询，管理缓存的插入、查询和驱逐。
+
+**核心操作**：
+1. `InsertOnly()` - 仅插入块，不查询
+2. `PrefixQuery()` - 前缀匹配查询
+3. `ExportForVisualization()` - 导出前缀树用于可视化
+
+### Radix Tree 数据结构
+
+```cpp
+struct RadixTreeNode {
+    std::vector<std::unique_ptr<BlockEntry>> blocks;  // 连续的块段
+    NodeStat stat;  // 节点统计信息
+    RadixTreeNode *parent = nullptr;
+    std::unordered_map<int64_t, std::unique_ptr<RadixTreeNode>> children;
+    bool isLeaf() const { return children.empty(); }
+};
+
+struct NodeStat {
+    size_t access_count = 0;
+    int64_t last_access_time = 0;
+    int64_t ttl = 250000;  // 默认TTL为250000微秒
+};
+
+struct BlockEntry {
+    int64_t key;
+    LocationStatMap location_map;
+    int64_t writing_time = -1;
+    int64_t last_access_time = -1;
+    size_t access_count = 0;
+    RadixTreeNode *owner_node = nullptr;
+};
+```
+
+### Radix Tree 可视化
+
+支持导出 Radix Tree 结构用于可视化分析，可以展示：
+- 节点访问次数
+- 最后访问时间
+- 节点中的块数量
+- 缓存的块数量
+- 节点层级关系
+
+---
+
+## Trace 处理
+
+### Trace 类型定义
+
+**继承关系**：
+```
+OptimizerSchemaTrace (基类)
+    ├── GetLocationSchemaTrace (读操作)
+    ├── RequestSchemaTrace (请求级操作，内部调度读和延迟写)
+    └── WriteCacheSchemaTrace (写操作)
+```
+
+### Trace 转换器
+
+**支持的格式**：
+- **Publisher Log**：转换 KVCacheManager Event Publisher 日志，区分读和写请求
+- **Qwen Bailian**：转换 Qwen Bailian 数据集格式，输出读写分离 trace
+
+**转换流程**：
+1. 根据配置文件选择转换器
+2. 解析日志文件并转换为标准 Trace；标准 `get` 必须带 `input_len`
+3. 按时间戳排序 Trace
+4. 分配唯一 Trace ID
+
+标准 trace 接受显式 `type=get/write/request` 的 JSONL。`request` 用于外部只有请求级记录的场景，optimizer 会按 `trace_replay.write_delay_ns` 在内部调度 delayed write。`get/request.keys` 只能包含完整 block key，不足一个 block 的尾部 token 不写入 `keys`，但仍通过 `input_len` 计入 token 命中率分母。缺少 `input_len`、时间戳非法、`keys` 超过 `input_len / block_size` 等输入会在回放前失败。
+
+---
+
+## 结果分析
+
+### 结果结构
+
+```cpp
+struct ReadRecord {
+    int64_t timestamp_ns;
+    // local = trace block_mask 带入的已有本地命中；remote = optimizer 模拟层命中
+    size_t remote_read_blocks;
+    size_t remote_hit_blocks;
+    size_t local_read_blocks;
+    size_t local_hit_blocks;
+    size_t current_cache_blocks;
+    size_t input_tokens;
+    size_t block_size_tokens;
+    std::vector<size_t> per_tier_hit_blocks;
+    std::vector<std::string> tier_names;
+    std::vector<size_t> per_tier_blocks;
+    std::vector<size_t> blocks_per_instance;
+    std::string trace_id;
+};
+```
+
+### CSV 输出格式
+
+**文件名**：`{instance_id}_hit_rates.csv`
+
+**主要列**：
+- `TimestampNs` - 时间戳（纳秒）
+- `CachedBlocks` - 当前 CSV 对应 instance 的缓存 block 数
+- `CachedBlocksAllInstances` - 同一 optimizer 进程内所有 instance 的总缓存 block 数
+- `ReadBlocks` / `HitBlocks` - 当前请求读取和命中的 block 数
+- `LocalHitBlocks` / `RemoteHitBlocks` - 诊断字段：trace `block_mask` 带入的已有本地命中 / optimizer 模拟层命中
+- `InputTokens` / `HitTokens` - 当前请求的输入 token 数和命中 token 数
+- `HitRate` - 当前 token 命中率，`HitTokens / InputTokens`
+- `LocalHitTokens` / `RemoteHitTokens` - 诊断字段：本地 / optimizer 模拟层命中 token 数
+- `AccReadBlocks` / `AccHitBlocks` - 累计读取和命中的 block 数
+- `AccHitRate` - 累积 token 命中率，`AccHitTokens / AccInputTokens`
+- `AccLocalHitRate` / `AccRemoteHitRate` - 诊断字段，不作为标准分析主口径
+- `Tier<N>(name)_HitTokens` / `Tier<N>(name)_HitRate` / `AccTier<N>(name)_HitRate` - 分层命中 token 指标
+
+标准分析直接按请求输入计算整体 `HitRate`，不把 local/remote 作为独立结论维度。local/remote 只用于兼容 optimizer 作为单独 L3 模拟并和 HiSim 结合、或直接分析 KVCacheManager event log 时已有的本地命中信息。
+
+---
+
+## 可视化分析
+
+### 1. 命中率随时间变化图表
+
+**脚本**：`optimizer_run.py --draw-chart`，绘图实现位于 `plot/hit_rate_plot.py`
+
+**功能**：绘制多实例缓存分析图表，展示所有 instance 的存储容量总和以及各自命中率随时间的变化。
+
+**运行方式**：
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/config.json \
+    --draw-chart
+```
+
+**输出**：
+- `{output_result_path}/timeseries/multi_instance_cache_analysis.png`
+- 分层配置额外输出 `{output_result_path}/timeseries/per_tier_timeseries.png`
+
+**图表内容**：
+- 上图：累计命中率随时间变化
+- 下图：当前 trace 命中率随时间变化
+
+### 2. Radix Tree 可视化
+
+**脚本**：`export_tree.py`，绘图实现位于 `plot/radix_tree_plot.py`
+
+**功能**：导出并可视化前缀树结构，统计并展示热节点以及所属节点的前缀路径。
+
+**运行方式**：
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:export_tree -- \
+    -c /path/to/config.json
+```
+
+**输出**：
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.json` - Radix Tree 导出数据
+- `{output_result_path}/radix_tree/{instance_id}_radix_tree.png` - Radix Tree 可视化图表
+- `{output_result_path}/radix_tree/{instance_id}_hot_paths.png` - 热点路径图（传 `--show-hot-paths` 时）
+
+**可视化内容**：
+- 节点访问次数
+- 最后访问时间
+- 节点中的块数量
+- 缓存的块数量
+- 节点层级关系
+
+### 3. Pareto 容量-命中率曲线分析
+
+**脚本**：`tradeoff.py`
+
+**功能**：在不同容量配置下回放 optimizer，绘制容量与 token 命中率的 Pareto 曲线。不给 `--eviction-policies` 时使用配置文件中的策略；给出多个策略时生成多策略对比图。
+
+> **适用范围**：Trade-off 分析仅适用于非分层模式。在分层模式（`tier_strategy.hierarchical_eviction_enabled=true`）下，容量扫描仅修改 `quota_capacity`，不影响各 tier 独立的 `storages[i].capacity`，因此无法产生有意义的容量-性能权衡结果。
+
+**运行流程**：
+
+1. 用无限容量 warmup 跑完整 trace。实现上会将 `quota_capacity` 写为 `-1`，C++ optimizer 将负容量视作无限容量。
+2. 从 warmup 读取理论命中率和最大缓存 block 数。
+3. 基于最大缓存 block 数按指数分布生成最多 `--num-points` 个容量点，并用 `--min-capacity-ratio` 过滤过小点。
+4. 对每个容量点运行 optimizer；达到 99% 理论命中率后停止继续扫更大容量。
+5. 画图时补 `(0 GB, 0%)` 起点，只保留命中率上升段。下降点会从图上剔除，并在 stdout 打印 `Drop descending Pareto point ...`；原始 CSV 保留。
+
+**运行方式**：
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
+    -c /path/to/config.json \
+    --num-points 30 \
+    --min-capacity-ratio 1e-4 \
+    --hit-rate-type total \
+    --max-workers 4
+```
+
+**参数说明**：
+- `-c, --config` - 配置文件路径
+- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中后提前停止
+- `--min-capacity-ratio` - 最小容量点相对阈值（默认 `1e-4`）
+- `--hit-rate-type` - 命中率类型，标准分析使用 total；local/remote/all 仅作诊断拆分（默认 total）
+- `--max-workers` - 并行执行的最大线程数（默认 4）
+- `--plot-title` - 覆盖图标题
+
+**输出**：`{output_result_path}/pareto/pareto_curve_{hit_rate_type}.png`
+
+### 4. 多策略对比分析
+
+**脚本**：`tradeoff.py --eviction-policies ...`
+
+**功能**：对比多个驱逐策略在不同容量配置下的表现。所有 instance 使用同一个给定策略进行一轮回放；每个策略独立 warmup、独立计算理论命中率，并独立提前停止。
+
+> **适用范围**：同单策略 Trade-off 分析，仅适用于非分层模式。
+
+**运行方式**：
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:tradeoff -- \
+    -c /path/to/config.json \
+    --eviction-policies lru random_lru leaf_aware_lru \
+    --num-points 30 \
+    --hit-rate-type total \
+    --max-workers 4
+```
+
+**参数说明**：
+- `-c, --config` - 配置文件路径
+- `--eviction-policies` - 要对比的驱逐策略列表（默认 lru random_lru leaf_aware_lru）
+- `--num-points` - 每个策略最多运行的容量采样点数量（默认 30），达到 99% 理论命中后提前停止
+- `--hit-rate-type` - 命中率类型，标准分析使用 total；local/remote/all 仅作诊断拆分（默认 total）
+- `--max-workers` - 并行执行的最大线程数（默认 4）
+
+**输出**：`{output_result_path}/pareto/multi_policy_{hit_rate_type}.png`
+
+图形规则：X 轴是 `Capacity (GB)`，Y 轴是 `HitRate (%)`；95%/99% 理论命中率会按相邻 sweep 点线性插值后标出容量和命中率。`--skip-run` 只从已有 `csv_results` 画图，不重新 warmup，因此不会生成理论 95%/99% 标注。
+
+---
+
+## 使用说明
+
+### 编译
+
+```bash
+bazel build //kv_cache_manager/optimizer:optimizer_main
+```
+
+### 运行优化器
+
+**方式：直接运行二进制文件**
+
+```bash
+bazel run //kv_cache_manager/optimizer:optimizer_main -- /path/to/config.json
+```
+
+### 离线 LiteHit 多容量分析
+
+独立入口 `lite_hit_main`，与上面的 replay 回放并行、互不干扰。它把标准 trace 的读请求按到达顺序回放进 LiteHit 核心，产出**与容量无关**的逐请求 facts CSV（`litehit_facts.csv`，先写 `.tmp` 再原子 rename）；命中率不在回放时计算，而是由第二个 CLI `lite_hit_facts_query_main` 在 facts 上按任意容量列表投影得到（JSONL 逐请求结果 + per-instance / overall 汇总）。同一份 facts 可反复用不同容量查询，无需重放 trace。
+
+trace 复用共享的 `StandardTraceLoader`：同一份标准格式 trace 既能喂给 liteHit 离线分析，也能直接给 replay 回放用。回放固定为流式（`StreamFromFile`，内存 O(1)），要求 trace 已按 `timestamp_ns` 有序。**写事件会被识别并忽略**：读请求提交时视为全部 block 已写回（写回本身就是一次 touch），因此拆分的 `write` trace 对 liteHit 无副作用——它只对 replay 路径有意义。
+
+```bash
+bazel build //kv_cache_manager/optimizer:lite_hit_main //kv_cache_manager/optimizer:lite_hit_facts_query_main
+bazel run //kv_cache_manager/optimizer:lite_hit_main -- /path/to/lite_hit_config.json
+bazel run //kv_cache_manager/optimizer:lite_hit_facts_query_main -- <facts_csv> <capacity_gb_list> <output_jsonl>
+```
+
+配置 `OptimizerLiteHitConfig` 复用在线的 `OptimizerInstanceGroup` / `OptimizerInstanceInfo` 对象（full-attention 实例要求 `linear_step=0`）：
+
+| 字段 | 含义 |
+|------|------|
+| trace_file_path | 标准格式 trace 文件路径（与 replay 共用同一份 trace） |
+| output_result_path | facts CSV 输出目录 |
+| instance_groups | 在线 `OptimizerInstanceGroup` 列表（含 eviction_policy / enable_prefix_hash 等） |
+| instances | 在线 `OptimizerInstanceInfo` 列表（含 block_size / linear_step / location spec 等） |
+| block_size | trace 的 token 粒度（默认 256）；实例 block_size 必须是它的整数倍（re-blocking 只做粗化） |
+| override_instance_id | 把所有请求路由到指定实例（须在 instances 中） |
+| fanout_all_instances | 把每条请求广播到所有配置实例（与 override 互斥），用于一次回放对比多种 block_size |
+| pipeline_worker_count | 回放流水线并行度（默认 1） |
+
+算法细节、facts 字段定义、投影口径与验证清单见 [liteHit/README_zh.md](../liteHit/README_zh.md)。
+
+### Python 接口
+
+```python
+from kv_cache_manager.optimizer import OptimizerConfigLoader, OptimizerLoader, OptimizerManager
+
+# 加载配置
+config_loader = OptimizerConfigLoader()
+config = config_loader.Load("/path/to/config.json")
+
+# 创建优化器
+optimizer = OptimizerManager(config)
+optimizer.Init()
+
+# 运行
+optimizer.DirectRun()
+
+# 分析结果
+optimizer.AnalyzeResults()
+```
+
+### 输出文件
+
+运行完成后，会在 `output_result_path` 指定的目录下生成：
+- `{instance_id}_hit_rates.csv` - 每个 instance 的命中率数据
+
+---
+
+## 扩展指南
+
+### 添加新的驱逐策略
+
+1. 在 `kv_cache_manager/optimizer/eviction_policy/` 创建新策略文件，继承 `EvictionPolicy` 基类
+2. 在 `kv_cache_manager/optimizer/config/types.h` 添加新的策略类型枚举值
+3. 在 `kv_cache_manager/optimizer/config/eviction_config.h` 添加新的参数类型
+4. 在 `kv_cache_manager/optimizer/eviction_policy/policy_factory.cc` 添加新的策略创建逻辑
+5. 在 BUILD 文件中添加新的源文件
+
+### 添加新的 Trace 转换器
+
+1. 在 `kv_cache_manager/optimizer/trace_converter/` 创建新转换器文件，继承 `BaseConverter` 基类
+2. 在 `kv_cache_manager/optimizer/config/types.h` 添加新的 trace 类型枚举值
+3. 在 `kv_cache_manager/optimizer/trace_converter/converter_factory.cc` 添加新的转换器创建逻辑
+4. 在 BUILD 文件中添加新的源文件
+
+### 添加新的分析指标
+
+1. 在 `kv_cache_manager/optimizer/analysis/result_structure.h` 添加新的统计字段
+2. 在 `kv_cache_manager/optimizer/analysis/result_analysis.cc` 添加新的分析逻辑
+3. 实现新的导出函数来输出自定义指标
+
+---
+
+## 附录
+
+### 文件索引
+
+**核心管理器**：
+- optimizer_manager.h/cc - 主协调器
+- optimizer_runner.h/cc - Trace 执行器
+- eviction_manager.h/cc - 驱逐管理器
+- indexer_manager.h/cc - 索引管理器
+- optimizer_loader.h/cc - Trace 加载器
+
+**索引层**：
+- radix_tree_index.h/cc - Radix 树索引
+
+**驱逐策略**：
+- base.h - 策略基类
+- common_structure.h - 通用数据结构
+- lru.h/cc - LRU 策略
+- random_lru.h/cc - RandomLRU 策略
+- leaf_aware_lru.h/cc - LeafAwareLRU 策略
+- policy_factory.h/cc - 策略工厂
+
+**Trace 转换**：
+- optimizer_schema_trace.h - Trace 定义
+- base_converter.h - 转换器基类
+- publisher_log_converter.h/cc - Publisher Log 转换器
+- qwen_bailian_converter.h/cc - Qwen Bailian 转换器
+- converter_factory.h/cc - 转换工厂
+- trace_util.h - Trace 工具
+
+**配置**：
+- optimizer_config.h/cc - 顶层配置
+- replay_instance_group_config.h/cc - trace replay/tier 模拟实例组配置
+- replay_instance_config.h/cc - trace replay 实例配置
+- tier_config.h/cc - 存储层配置
+- eviction_config.h - 驱逐策略参数
+- types.h - 类型定义
+- optimizer_config_loader.h/cc - 配置加载器
+
+**分析**：
+- result_structure.h - 结果结构定义
+- result_analysis.h/cc - 命中率分析
+- script/run/optimizer_run.py - 单次回放 + 可选时序图
+- script/run/tradeoff.py - Pareto 曲线，单策略/多策略统一入口
+- script/run/export_tree.py - Radix Tree 导出 + 可视化
+- script/run/analyze_lifecycle.py - Block lifecycle 分析
+- script/run/multi_instance_replay.py - 多实例并行回放 + 聚合
+- script/plot/hit_rate_plot.py - 命中率时序图
+- script/plot/radix_tree_plot.py - Radix Tree 绘图
+- script/utils/optimizer_runner.py - optimizer 运行封装
+
+**Python 绑定**：
+- pybind/py_optimizer_binding.cc - Python 接口
+
+### 术语表
+
+| 术语 | 说明 |
+|------|------|
+| 驱逐策略 | 当缓存满时选择哪些块被移除的算法 |
+| LRU | 最近最少使用算法 |
+| RandomLRU | 结合随机采样和 LRU 的混合算法 |
+| LeafAwareLRU | 叶子节点感知的 LRU 算法 |
+| Radix Tree | 用于高效前缀匹配的树形数据结构 |
+| Trace | 记录系统操作序列的数据 |
+| Instance | 缓存系统的独立实例 |
+| Instance Group | 共享资源的实例集合 |
+| Block | 缓存的基本单位 |
+| Hit Rate | 缓存命中次数与总访问次数的比值 |
+| Prefix Match | 查找具有相同前缀的键 |
+| Read/Write Separation | 将读和写操作分开处理 |
+| Trade-off Curve | 容量与命中率之间的权衡曲线 |
+
+
+
+---

--- a/kv_cache_manager/optimizer/docs/strategy_config.md
+++ b/kv_cache_manager/optimizer/docs/strategy_config.md
@@ -1,49 +1,51 @@
-# Optimizer 标准策略配置说明
+# Optimizer Standard Strategy Configuration Guide
 
-本文档定义标准版 optimizer 的策略配置、multi-instance replay 入口和命中率口径。后续新增实验脚本应复用这里的字段语义，避免在脚本里引入另一套配置命名。
+> [中文](strategy_config_zh.md) | English
 
-## 指标口径
+This document defines the strategy configuration, multi-instance replay entry point, and hit-rate metrics of the standard edition optimizer. Subsequent new experimental scripts should reuse the field semantics here, avoiding introducing another set of configuration naming in scripts.
 
-标准版只对外暴露一种命中率口径：
+## Metric Definitions
+
+The standard edition exposes only one hit-rate metric externally:
 
 ```text
 HitRate = HitTokens / InputTokens
 AccHitRate = AccHitTokens / AccInputTokens
 ```
 
-相关约定：
+Related conventions:
 
-- `HitRate`、`AccHitRate`、`LocalHitRate`、`RemoteHitRate` 和 `Tier*_HitRate` 都是 token hit rate。
-- 标准命中率只按 token 计算，但 CSV 保留 block 读/命中计数，便于核对读放大、命中规模和容量行为。
-- 标准分析不把 local/remote 当作独立结论维度。`local` 只表示 trace `block_mask` 带进来的已有本地命中 block，例如 optimizer 作为单独 L3 模拟并和 HiSim 结合时，或直接分析 KVCacheManager event log 时，日志里已经包含的本地命中 block key；`remote` 表示 optimizer 模拟层贡献的命中。当前标准报告直接按请求输入计算整体 `HitRate`，不依赖 local/remote 拆分。
-- 标准 `get` trace 必须包含 `input_len`，`InputTokens` 直接使用 `input_len`。
-- 不再兼容缺失 `input_len` 的旧 `get` trace。其他来源的日志需要先转换成 optimizer schema。
-- `keys` 只包含完整 block key；不足一个 block 的尾部 token 不写入 `keys`，但仍计入 `InputTokens`。例如 `block_size=16`、`input_len=33` 时，`keys` 最多包含 2 个完整 block，尾部 1 个 token 只进入分母。
+- `HitRate`, `AccHitRate`, `LocalHitRate`, `RemoteHitRate`, and `Tier*_HitRate` are all token hit rates.
+- The standard hit rate is computed only by token, but the CSV retains block read/hit counts for verifying read amplification, hit scale, and capacity behavior.
+- The standard analysis does not treat local/remote as independent conclusion dimensions. `local` only denotes existing local hit blocks brought in by the trace `block_mask`, e.g. when the optimizer acts as a standalone L3 simulation combined with HiSim, or when directly analyzing KVCacheManager event logs, the local hit block keys already contained in the log; `remote` denotes hits contributed by the optimizer simulation layer. The current standard report directly computes the overall `HitRate` from request input, without relying on the local/remote split.
+- A standard `get` trace must contain `input_len`; `InputTokens` directly uses `input_len`.
+- Old `get` traces missing `input_len` are no longer compatible. Logs from other sources must first be converted to the optimizer schema.
+- `keys` only contains complete block keys; trailing tokens that do not fill a block are not written into `keys`, but are still counted into `InputTokens`. For example, when `block_size=16` and `input_len=33`, `keys` contains at most 2 complete blocks, and the trailing 1 token only enters the denominator.
 
-标准 `*_hit_rates.csv` 的核心列：
+Core columns of the standard `*_hit_rates.csv`:
 
-| 列 | 说明 |
+| Column | Description |
 |---|---|
-| `TimestampNs` | trace 时间戳，单位 ns |
-| `CachedBlocks` | 当前 CSV 对应 instance 的缓存 block 数 |
-| `CachedBlocksAllInstances` | 同一 optimizer 进程内所有 instance 的总缓存 block 数 |
-| `ReadBlocks` / `HitBlocks` | 当前请求读取 / 命中的 block 数 |
-| `LocalHitBlocks` / `RemoteHitBlocks` | 诊断字段：trace `block_mask` 带入的已有本地命中 / optimizer 模拟层命中 |
-| `InputTokens` / `HitTokens` | 当前请求的输入 token 数 / 命中 token 数 |
-| `LocalHitTokens` / `RemoteHitTokens` | 诊断字段：本地 / optimizer 模拟层命中 token 数 |
-| `HitRate` | 当前请求整体 token hit rate |
-| `LocalHitRate` / `RemoteHitRate` | 诊断字段，不作为标准分析主口径 |
-| `AccReadBlocks` / `AccHitBlocks` | 累计读取 / 命中的 block 数 |
-| `AccInputTokens` / `AccHitTokens` | 累计输入 token 数 / 累计命中 token 数 |
-| `AccLocalHitTokens` / `AccRemoteHitTokens` | 诊断字段：累计本地 / optimizer 模拟层命中 token 数 |
-| `AccHitRate` | 累计整体 token hit rate |
-| `AccLocalHitRate` / `AccRemoteHitRate` | 诊断字段，不作为标准分析主口径 |
-| `AccWriteBlocks` | 截至当前时间的累计写入 block 数 |
-| `Tier<N>(name)_HitTokens` | 当前请求在某个 tier 的命中 token 数 |
-| `Tier<N>(name)_HitRate` / `AccTier<N>(name)_HitRate` | 当前 / 累计 tier token hit rate |
-| `Tier<N>(name)_BlockNum` | 当前 tier 的缓存 block 数 |
+| `TimestampNs` | trace timestamp, in ns |
+| `CachedBlocks` | number of cached blocks for the instance corresponding to the current CSV |
+| `CachedBlocksAllInstances` | total number of cached blocks across all instances within the same optimizer process |
+| `ReadBlocks` / `HitBlocks` | number of blocks read / hit by the current request |
+| `LocalHitBlocks` / `RemoteHitBlocks` | diagnostic fields: existing local hits brought in by trace `block_mask` / hits from the optimizer simulation layer |
+| `InputTokens` / `HitTokens` | input token count / hit token count of the current request |
+| `LocalHitTokens` / `RemoteHitTokens` | diagnostic fields: local / optimizer simulation layer hit token count |
+| `HitRate` | overall token hit rate of the current request |
+| `LocalHitRate` / `RemoteHitRate` | diagnostic fields, not used as the main metric of standard analysis |
+| `AccReadBlocks` / `AccHitBlocks` | cumulative read / hit block count |
+| `AccInputTokens` / `AccHitTokens` | cumulative input token count / cumulative hit token count |
+| `AccLocalHitTokens` / `AccRemoteHitTokens` | diagnostic fields: cumulative local / optimizer simulation layer hit token count |
+| `AccHitRate` | cumulative overall token hit rate |
+| `AccLocalHitRate` / `AccRemoteHitRate` | diagnostic fields, not used as the main metric of standard analysis |
+| `AccWriteBlocks` | cumulative written block count up to the current time |
+| `Tier<N>(name)_HitTokens` | hit token count of the current request in a certain tier |
+| `Tier<N>(name)_HitRate` / `AccTier<N>(name)_HitRate` | current / cumulative tier token hit rate |
+| `Tier<N>(name)_BlockNum` | number of cached blocks in the current tier |
 
-## 顶层配置
+## Top-Level Configuration
 
 ```json
 {
@@ -60,36 +62,36 @@ AccHitRate = AccHitTokens / AccInputTokens
 }
 ```
 
-`output_result_path` 是所有 config 驱动入口的结果输出目录，包括 `optimizer_main`、`optimizer_run`、`tradeoff` 和 `export_tree`。`export_tree` 会写到该目录下的 `radix_tree/`。`multi_instance_replay` 不读取完整 optimizer config，需要通过 `--output-dir` 显式指定输出目录。
+`output_result_path` is the result output directory for all config-driven entry points, including `optimizer_main`, `optimizer_run`, `tradeoff`, and `export_tree`. `export_tree` writes to `radix_tree/` under that directory. `multi_instance_replay` does not read the full optimizer config and requires the output directory to be explicitly specified via `--output-dir`.
 
 ### eviction_params
 
-| 字段 | 类型 | 默认 | 说明 |
+| Field | Type | Default | Description |
 |---|---:|---:|---|
-| `eviction_mode` | int | 必填 | `1`=`GROUP_ROUGH`，`2`=`INSTANCE_ROUGH`，`3`=`INSTANCE_PRECISE` |
-| `eviction_batch_size_per_instance` | int | 必填 | 每轮每实例最多驱逐的 block 数。rough 模式必须大于 0 |
+| `eviction_mode` | int | required | `1`=`GROUP_ROUGH`, `2`=`INSTANCE_ROUGH`, `3`=`INSTANCE_PRECISE` |
+| `eviction_batch_size_per_instance` | int | required | maximum number of blocks evicted per instance per round. Must be greater than 0 in rough mode |
 
-推荐标准实验使用 `eviction_mode=3`，因为它按剩余超额容量截断最后一轮驱逐，容量点更稳定。
+It is recommended to use `eviction_mode=3` for standard experiments, because it truncates the last eviction round by the remaining excess capacity, making capacity points more stable.
 
 ### trace_replay
 
-| 字段 | 类型 | 默认 | 说明 |
+| Field | Type | Default | Description |
 |---|---:|---:|---|
-| `write_delay_ns` | int64 | `1` | `type=request` trace 的内部写入延迟。回放时先在 `timestamp_ns` 执行读，再在 `timestamp_ns + write_delay_ns` 调度写入。必须大于 0 |
+| `write_delay_ns` | int64 | `1` | internal write delay for `type=request` traces. During replay, the read is executed first at `timestamp_ns`, then the write is scheduled at `timestamp_ns + write_delay_ns`. Must be greater than 0 |
 
-## 标准 trace schema
+## Standard Trace Schema
 
-optimizer 回放输入只接受 JSONL，每行一条标准 trace。字段不完整时直接失败，不做旧格式推断。
+The optimizer replay input only accepts JSONL, with one standard trace per line. When fields are incomplete it fails directly, without doing old-format inference.
 
-`timestamp_ns`、`get.input_len`、`block_mask` offset 和 `ttl_us` 必须落在 `int64_t` 范围内：
+`timestamp_ns`, `get.input_len`, `block_mask` offset, and `ttl_us` must fall within the `int64_t` range:
 
 ```text
 [-9223372036854775808, 9223372036854775807]
 ```
 
-`keys` 支持 JSON signed/unsigned 整数。超过 `INT64_MAX=9223372036854775807` 的 unsigned 64-bit 值会按补码稳定映射到内部 `int64_t`，例如 `9223372036854775808 -> -9223372036854775808`、`18446744073709551615 -> -1`。
+`keys` supports JSON signed/unsigned integers. Unsigned 64-bit values exceeding `INT64_MAX=9223372036854775807` are stably mapped to the internal `int64_t` via two's complement, e.g. `9223372036854775808 -> -9223372036854775808`, `18446744073709551615 -> -1`.
 
-Get trace：
+Get trace:
 
 ```json
 {
@@ -106,12 +108,12 @@ Get trace：
 }
 ```
 
-Request trace：
+Request trace:
 
-当外部 trace 只有请求级记录、没有显式拆成读写两行时，使用 `request`。它等价于：
+When the external trace only has request-level records and is not explicitly split into read and write rows, use `request`. It is equivalent to:
 
-- 在 `timestamp_ns` 执行一次 `get`
-- 在 `timestamp_ns + trace_replay.write_delay_ns` 执行一次 `write`
+- executing a `get` at `timestamp_ns`
+- executing a `write` at `timestamp_ns + trace_replay.write_delay_ns`
 
 ```json
 {
@@ -129,7 +131,7 @@ Request trace：
 }
 ```
 
-Write trace：
+Write trace:
 
 ```json
 {
@@ -142,54 +144,54 @@ Write trace：
 }
 ```
 
-必填字段：
+Required fields:
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 |---|---|---|
-| `type` | string | 只能是 `get`、`write` 或 `request` |
-| `instance_id` | string | 非空，必须匹配配置中的 instance |
-| `timestamp_ns` | int64 | ns 时间戳，必须为正整数；不再接受 `timestamp_us` |
-| `keys` | int64/uint64 array | block key 列表，可为空 |
+| `type` | string | can only be `get`, `write`, or `request` |
+| `instance_id` | string | non-empty, must match an instance in the config |
+| `timestamp_ns` | int64 | ns timestamp, must be a positive integer; `timestamp_us` is no longer accepted |
+| `keys` | int64/uint64 array | list of block keys, may be empty |
 
-可选公共字段：
+Optional common fields:
 
-| 字段 | 类型 | 默认 | 说明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `trace_id` | string | 空字符串 | 请求标识，用于调试和模板分析 |
+| `trace_id` | string | empty string | request identifier, used for debugging and template analysis |
 
-`get` 专用字段：
+`get`-specific fields:
 
-| 字段 | 类型 | 默认 | 说明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `input_len` | int64 | 必填 | 输入 token 数，必须为正整数；`InputTokens` 直接使用该值 |
-| `query_type` | string | `prefix_match` | 当前只支持 `prefix_match`；其他值会被跳过 |
-| `block_mask` | bool array 或非负 int64 | 空数组 | trace 已经知道的本地命中 block。数组形式逐 block 标记；整数形式表示从前缀开始的本地命中 block 数 |
-| `sw_size` | int32 | 0 | 滑窗参数，当前标准前缀匹配通常为 0 |
-| `location_spec_names` | string array | 空数组 | 兼容字段，标准分析通常为空 |
+| `input_len` | int64 | required | input token count, must be a positive integer; `InputTokens` directly uses this value |
+| `query_type` | string | `prefix_match` | currently only `prefix_match` is supported; other values are skipped |
+| `block_mask` | bool array or non-negative int64 | empty array | local hit blocks already known by the trace. The array form marks per block; the integer form denotes the number of local hit blocks from the prefix start |
+| `sw_size` | int32 | 0 | sliding window parameter, usually 0 for the current standard prefix matching |
+| `location_spec_names` | string array | empty array | compatibility field, usually empty for standard analysis |
 
-`write` 专用字段：
+`write`-specific fields:
 
-| 字段 | 类型 | 默认 | 说明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `ttl_us` | int64 | 0 | 请求级 TTL，单位微秒；`0` 使用 group 默认 TTL，`-1` 表示禁用 TTL |
+| `ttl_us` | int64 | 0 | request-level TTL, in microseconds; `0` uses the group default TTL, `-1` denotes disabling TTL |
 
-`request` 字段：
+`request` fields:
 
-`request` 复用 `get` 的所有字段，并额外支持 `write.ttl_us`。`request` 内部生成的写入会使用同一组 `keys` 和该 `ttl_us`。
+`request` reuses all fields of `get`, and additionally supports `write.ttl_us`. The write internally generated by `request` uses the same set of `keys` and that `ttl_us`.
 
-`write` 只读取 `type`、`instance_id`、`trace_id`、`timestamp_ns`、`keys` 和 `ttl_us`；其他字段包括 `input_len` 和 `block_mask` 都忽略。`block_mask` 只用于标记 trace 已经知道的本地命中 block，不是标准报告的分组依据。直接分析请求输入时通常可传空数组，此时整体 `HitRate` 仍按 `HitTokens / InputTokens` 计算。
+`write` only reads `type`, `instance_id`, `trace_id`, `timestamp_ns`, `keys`, and `ttl_us`; other fields including `input_len` and `block_mask` are ignored. `block_mask` is only used to mark local hit blocks already known by the trace, and is not the grouping basis of the standard report. When directly analyzing request input, an empty array can usually be passed, in which case the overall `HitRate` is still computed as `HitTokens / InputTokens`.
 
-旧格式或不合法输入会失败，包括：
+Old-format or invalid input will fail, including:
 
-- 缺少 `type`、`instance_id`、`timestamp_ns`、`keys`，或 `get` / `request` trace 缺少 `input_len`。
-- `get/request.input_len <= 0`、`timestamp_ns <= 0`，或 `keys` 不是数组。
-- `get/request.keys.size() > input_len / block_size`。标准 trace 的 `keys` 只能包含完整 block，不允许把不足一个 block 的尾部 key 写入 trace。
-- 使用 `timestamp_us` 但没有 `timestamp_ns`。
-- `keys` 中存在非整数。
-- `block_mask` 数组中存在非 bool 值，或 offset 为负数 / 超过 `INT64_MAX`。
-- legacy dialog-style trace 只有 `query_type` / `block_mask` / decode metadata 但没有显式 `type=get/write`。
+- Missing `type`, `instance_id`, `timestamp_ns`, `keys`, or `get` / `request` traces missing `input_len`.
+- `get/request.input_len <= 0`, `timestamp_ns <= 0`, or `keys` not being an array.
+- `get/request.keys.size() > input_len / block_size`. The `keys` of a standard trace can only contain complete blocks; writing a trailing key that does not fill a block into the trace is not allowed.
+- Using `timestamp_us` but without `timestamp_ns`.
+- Non-integers present in `keys`.
+- Non-bool values present in the `block_mask` array, or offset being negative / exceeding `INT64_MAX`.
+- Legacy dialog-style traces that only have `query_type` / `block_mask` / decode metadata but no explicit `type=get/write`.
 
-## instance group 配置
+## Instance Group Configuration
 
 ```json
 {
@@ -211,45 +213,45 @@ Write trace：
 }
 ```
 
-| 字段 | 类型 | 默认 | 标准语义 |
+| Field | Type | Default | Standard Semantics |
 |---|---:|---:|---|
-| `group_name` | string | 必填 | 实例组名称。multi-instance replay 中通常等于 instance 的 `instance_id` |
-| `quota_capacity` | number | 必填 | group 总容量，单位 GB。非分层模式按该字段驱逐；`-1` 表示无限容量，不触发容量驱逐，主要用于全局池化理论命中和 Pareto warmup |
-| `used_percentage` | number | 必填 | 容量水位比例，实际阈值为 capacity × used_percentage |
-| `tier_strategy` | object | 必填 | 多层读写策略包，见下表 |
-| `default_block_ttl_seconds` | int | `0` | group 默认 TTL 秒数，`0` 表示组级禁用 TTL |
-| `ttl_refresh_on_read` | bool | `true` | TTL 策略下读命中是否刷新 TTL 锚点 |
-| `storages` | array | 必填 | tier 列表，按 `priority` 从小到大排序 |
-| `instances` | array | 必填 | 该 group 下的 optimizer instance 列表 |
+| `group_name` | string | required | instance group name. In multi-instance replay usually equal to the instance's `instance_id` |
+| `quota_capacity` | number | required | total group capacity, in GB. Non-tiered mode evicts by this field; `-1` means infinite capacity, no capacity eviction triggered, mainly used for global pooled theoretical hits and Pareto warmup |
+| `used_percentage` | number | required | capacity watermark ratio; the actual threshold is capacity × used_percentage |
+| `tier_strategy` | object | required | multi-tier read/write policy package, see table below |
+| `default_block_ttl_seconds` | int | `0` | group default TTL in seconds; `0` means TTL disabled at the group level |
+| `ttl_refresh_on_read` | bool | `true` | whether a read hit refreshes the TTL anchor under the TTL policy |
+| `storages` | array | required | tier list, sorted by `priority` ascending |
+| `instances` | array | required | list of optimizer instances under this group |
 
 ### tier_strategy
 
-`tier_strategy` 顶层字段是所有相邻 tier edge 的默认策略；`tier_flows` 只用于覆盖特定相邻 edge。若所有层间策略一致，可以只配置顶层字段并省略 `tier_flows`，它们不是两套重复配置。
+The top-level fields of `tier_strategy` are the default policy for all adjacent tier edges; `tier_flows` is only used to override specific adjacent edges. If all inter-tier policies are consistent, you can configure only the top-level fields and omit `tier_flows`; they are not two sets of duplicate configuration.
 
-| 字段 | 类型 | 默认 | 标准语义 |
+| Field | Type | Default | Standard Semantics |
 |---|---:|---:|---|
-| `hierarchical_eviction_enabled` | bool | 必填 | 是否启用分层容量和分层驱逐；`false` 时所有 tier 共享一个 `shared` 策略与 `quota_capacity` 配额 |
-| `write_mode` | string | `write_through` | 多 tier 写入和层间流动策略 |
-| `access_propagation_enabled` | bool | `true` | 读命中高优先级 tier 时，是否刷新后续持有副本 tier 的访问时间；`false` 表示只刷新命中 tier |
-| `promote_enabled` | bool | `true` | 低层命中后是否逐层复制回经过的高优先级层 |
-| `selective_write_threshold` | int | `2` | `write_through_selective` 下命中层访问次数达到该阈值后复制到下一层；必须为正整数 |
-| `tier_flows` | array | `[]` | 相邻 tier edge 的策略覆盖。未覆盖的 edge 继承 `tier_strategy` 的默认策略 |
+| `hierarchical_eviction_enabled` | bool | required | whether to enable tiered capacity and tiered eviction; when `false`, all tiers share one `shared` policy and the `quota_capacity` quota |
+| `write_mode` | string | `write_through` | multi-tier write and inter-tier flow policy |
+| `access_propagation_enabled` | bool | `true` | when a read hits a higher-priority tier, whether to refresh the access time of subsequent tiers holding copies; `false` means only the hit tier is refreshed |
+| `promote_enabled` | bool | `true` | whether to copy back layer by layer to the higher-priority tiers passed through after a lower-tier hit |
+| `selective_write_threshold` | int | `2` | under `write_through_selective`, copy to the next tier after the hit tier's access count reaches this threshold; must be a positive integer |
+| `tier_flows` | array | `[]` | policy overrides for adjacent tier edges. Unoverridden edges inherit the default policy of `tier_strategy` |
 
 ### write_mode
 
-| 值 | 写入行为 | 驱逐行为 | 适用场景 |
+| Value | Write Behavior | Eviction Behavior | Applicable Scenario |
 |---|---|---|---|
-| `write_through` | 写入时同时落所有 tier | 各 tier 独立按自身容量驱逐 | 基线、全量副本、多层独立命中率分析 |
-| `cascading` | 写入时只落 tier 0 | tier i 驱逐出的 block 降级到 tier i+1，最后一层驱逐后丢弃 | HBM→DRAM→SSD 逐级下沉 |
-| `write_through_selective` | 初始只落 tier 0 | 命中层访问次数达到 `tier_strategy.selective_write_threshold` 后复制到下一层 | 控制低层写放大，只让热块下沉 |
+| `write_through` | writes land in all tiers simultaneously | each tier evicts independently by its own capacity | baseline, full replicas, multi-tier independent hit-rate analysis |
+| `cascading` | writes land only in tier 0 | blocks evicted from tier i are demoted to tier i+1; discarded after eviction from the last tier | HBM→DRAM→SSD progressive sinking |
+| `write_through_selective` | initially lands only in tier 0 | copy to the next tier after the hit tier's access count reaches `tier_strategy.selective_write_threshold` | control lower-tier write amplification, only let hot blocks sink |
 
-`tier_strategy.write_mode` 只接受上表三个值，其他值会导致 config 解析失败。
-`access_propagation_enabled` 不是一种 `write_mode`，而是读命中后是否刷新下层副本访问时间的独立开关。
+`tier_strategy.write_mode` only accepts the three values in the table above; other values cause config parsing to fail.
+`access_propagation_enabled` is not a kind of `write_mode`, but an independent switch for whether to refresh the access time of lower-tier copies after a read hit.
 
 ### tier_flows
 
-`tier_flows` 用于覆盖相邻 tier 之间的读写流动策略。每个 flow 必须引用 `storages` 中相邻的两个 `unique_name`，不支持跨层跳配，也不允许重复配置同一条 edge。
-配置加载时会按 `storages[*].priority` 排序后校验 edge。未知 tier、非相邻 edge、重复 edge、重复 `unique_name` 或重复 `priority` 都会直接报错并拒绝加载。
+`tier_flows` is used to override the read/write flow policy between adjacent tiers. Each flow must reference two adjacent `unique_name`s in `storages`; cross-tier skipping is not supported, and configuring the same edge twice is not allowed.
+At config load time, edges are validated after sorting by `storages[*].priority`. Unknown tiers, non-adjacent edges, duplicate edges, duplicate `unique_name`s, or duplicate `priority`s all directly raise an error and refuse to load.
 
 ```json
 {
@@ -277,27 +279,27 @@ Write trace：
 }
 ```
 
-单条 flow 的字段：
+Fields of a single flow:
 
-| 字段 | 类型 | 默认 | 标准语义 |
+| Field | Type | Default | Standard Semantics |
 |---|---:|---:|---|
-| `from_tier` | string | 必填 | edge 的高优先级 tier 名称，必须等于某个 `storages[i].unique_name` |
-| `to_tier` | string | 必填 | edge 的低优先级 tier 名称，必须等于相邻的 `storages[i+1].unique_name` |
-| `write_mode` | string | 继承默认 | 这条 edge 的写入/驱逐下沉策略 |
-| `access_propagation_enabled` | bool | 继承默认 | 访问命中高层后，是否跨这条 edge 刷新下层访问时间 |
-| `promote_enabled` | bool | 继承默认 | 低层命中后，是否允许跨这条 edge 回填到高层 |
-| `selective_write_threshold` | int | 继承默认 | 这条 edge 使用 `write_through_selective` 时的下写阈值 |
+| `from_tier` | string | required | the higher-priority tier name of the edge, must equal some `storages[i].unique_name` |
+| `to_tier` | string | required | the lower-priority tier name of the edge, must equal the adjacent `storages[i+1].unique_name` |
+| `write_mode` | string | inherit default | the write/eviction sinking policy of this edge |
+| `access_propagation_enabled` | bool | inherit default | after a hit on the higher tier, whether to refresh the lower-tier access time across this edge |
+| `promote_enabled` | bool | inherit default | after a lower-tier hit, whether to allow backfilling to the higher tier across this edge |
+| `selective_write_threshold` | int | inherit default | the down-write threshold when this edge uses `write_through_selective` |
 
 ### access_propagation_enabled
 
-这个开关与 `tier_strategy.write_mode` 正交：
+This switch is orthogonal to `tier_strategy.write_mode`:
 
-- `true`：一个 block 在多个 tier 有副本时，读命中最高优先级 tier 后，也刷新后续副本 tier 的访问时间。这是默认行为。
-- `false`：只刷新实际命中的最高优先级 tier，不刷新下层副本的访问时间。适用于评估 write-through 或 cascading/promote 后多副本场景下的下层独立冷热衰减。
+- `true`: when a block has copies in multiple tiers, after a read hits the highest-priority tier, the access time of subsequent copy tiers is also refreshed. This is the default behavior.
+- `false`: only the actually hit highest-priority tier is refreshed; the access time of lower-tier copies is not refreshed. Suitable for evaluating the independent lower-tier hot/cold decay in multi-copy scenarios after write-through or cascading/promote.
 
-`promote_enabled=true` 时，低优先级 tier 命中会触发向更高优先级 tier 逐层复制。比如 L3 命中会补齐 L2 和 L1，L2 命中只补 L1，不会额外写入更低层。复制动作会走容量检查，可能立刻触发对应 tier 的驱逐。
+When `promote_enabled=true`, a lower-priority tier hit triggers layer-by-layer copying to higher-priority tiers. For example, an L3 hit fills in L2 and L1, an L2 hit only fills in L1, and there is no extra writing to even lower tiers. The copy action goes through capacity checks and may immediately trigger eviction of the corresponding tier.
 
-## storage 配置
+## Storage Configuration
 
 ```json
 {
@@ -309,15 +311,15 @@ Write trace：
 }
 ```
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 |---|---:|---|
-| `unique_name` | string | tier 名称，会进入 CSV 的 `Tier<N>(name)_*` 列 |
-| `storage_type` | string | 存储类型标签，当前主要用于配置记录 |
-| `band_width_mbps` | number | 带宽标签，当前主要用于分析记录 |
-| `priority` | int | tier 优先级，越小越靠近计算侧 |
-| `capacity` | number | tier 容量，单位 GB；`-1` 表示该 tier 无限容量，不触发该 tier 的容量驱逐 |
+| `unique_name` | string | tier name, which enters the `Tier<N>(name)_*` columns of the CSV |
+| `storage_type` | string | storage type label, currently mainly used for config records |
+| `band_width_mbps` | number | bandwidth label, currently mainly used for analysis records |
+| `priority` | int | tier priority; smaller means closer to the compute side |
+| `capacity` | number | tier capacity, in GB; `-1` means infinite capacity for that tier, no capacity eviction triggered for that tier |
 
-## instance 配置
+## Instance Configuration
 
 ```json
 {
@@ -329,13 +331,13 @@ Write trace：
 }
 ```
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 |---|---:|---|
-| `instance_id` | string | trace 中的实例 ID，必须与 trace 行内 `instance_id` 匹配 |
-| `block_size` | int | 每个 block 的 token 数。token hit rate 会用它把命中 block 转为命中 token |
-| `bytes_per_token` | int | 单 token KV 大小。`bytes_per_block = block_size * bytes_per_token` |
-| `eviction_policy_type` | string | `lru`、`random_lru`、`leaf_aware_lru`、`ttl` |
-| `eviction_policy_params` | object | 策略参数，见下文 |
+| `instance_id` | string | instance ID in the trace, must match the `instance_id` within trace rows |
+| `block_size` | int | number of tokens per block. Token hit rate uses it to convert hit blocks to hit tokens |
+| `bytes_per_token` | int | KV size per token. `bytes_per_block = block_size * bytes_per_token` |
+| `eviction_policy_type` | string | `lru`, `random_lru`, `leaf_aware_lru`, `ttl` |
+| `eviction_policy_params` | object | policy parameters, see below |
 
 ## eviction_policy_params
 
@@ -350,12 +352,12 @@ Write trace：
 }
 ```
 
-| 字段 | 说明 |
+| Field | Description |
 |---|---|
-| `sample_rate` | 采样比例。`1.0` 表示完整 LRU |
-| `shard_count` | LRU 分片数 |
-| `sample_times` | 每次采样次数 |
-| `eviction_amplification_factor` | 驱逐放大系数 |
+| `sample_rate` | sampling ratio. `1.0` means complete LRU |
+| `shard_count` | number of LRU shards |
+| `sample_times` | number of samples per round |
+| `eviction_amplification_factor` | eviction amplification factor |
 
 ### random_lru
 
@@ -365,7 +367,7 @@ Write trace：
 }
 ```
 
-`random_lru` 只要求 `sample_rate`，用于控制采样范围。
+`random_lru` only requires `sample_rate`, used to control the sampling range.
 
 ### ttl
 
@@ -375,18 +377,18 @@ Write trace：
 }
 ```
 
-| 字段 | 说明 |
+| Field | Description |
 |---|---|
-| `fallback_on_pressure=true` | 先清理 TTL 过期 block；容量仍超限时按 LRU 兜底 |
-| `fallback_on_pressure=false` | 纯 TTL，只清理过期 block；容量压力不会触发 LRU 兜底 |
+| `fallback_on_pressure=true` | first clear TTL-expired blocks; if capacity still exceeds the limit, fall back to LRU |
+| `fallback_on_pressure=false` | pure TTL, only clear expired blocks; capacity pressure does not trigger LRU fallback |
 
-TTL 只在 `eviction_policy_type="ttl"` 时执行。非 TTL 策略会忽略 `default_block_ttl_seconds` 和 `ttl_refresh_on_read` 的过期清理语义。
+TTL is only executed when `eviction_policy_type="ttl"`. Non-TTL policies ignore the expiration cleanup semantics of `default_block_ttl_seconds` and `ttl_refresh_on_read`.
 
-## 标准多实例回放
+## Standard Multi-Instance Replay
 
-标准版保留 `multi_instance_replay`，不再把 multi-machine scheduler 作为默认回放入口。
-脚本完整参数以 [analysis/script/README.md](../analysis/script/README.md) 为准；这里给出标准回放配置示例和输出约定。
-`multi_instance_replay` 不读取完整 optimizer config；它根据 CLI 参数为每个 pod/instance 生成单实例 config，然后并行运行 optimizer。当前 CLI 直接支持 L1/L2 两层容量；需要 L3 或更复杂 tier 拓扑时，需要使用完整 optimizer config 跑单次回放，或扩展该脚本的 config 生成逻辑。
+The standard edition retains `multi_instance_replay` and no longer uses the multi-machine scheduler as the default replay entry point.
+The complete script parameters are subject to [analysis/script/README.md](../analysis/script/README.md); here we give a standard replay configuration example and output conventions.
+`multi_instance_replay` does not read the full optimizer config; it generates a single-instance config for each pod/instance based on CLI parameters, then runs the optimizer in parallel. The current CLI directly supports two tiers of capacity, L1/L2; when L3 or more complex tier topologies are needed, you need to use a full optimizer config to run a single replay, or extend the config generation logic of this script.
 
 ```bash
 bazel run //kv_cache_manager/optimizer/analysis/script:multi_instance_replay -- \
@@ -403,15 +405,15 @@ bazel run //kv_cache_manager/optimizer/analysis/script:multi_instance_replay -- 
   --max-workers 32
 ```
 
-输出：
+Output:
 
-- 输出根目录为 `--output-dir`。
-- `configs/<instance_id>.json`：每个 instance 的生成配置。
-- `<instance_id>_hit_rates.csv`：每个 instance 的标准 token hit-rate 时序。
-- `aggregate/instance_aggregate.csv`：每个 instance 的聚合结果。
-- `aggregate/global_aggregate.csv`：所有 instance 汇总后的全局结果。
-- `aggregate/global_window_hit_rates.csv`：指定 `--window-ns` 或 `--window-seconds` 时生成的窗口结果。
+- The output root directory is `--output-dir`.
+- `configs/<instance_id>.json`: the generated config for each instance.
+- `<instance_id>_hit_rates.csv`: the standard token hit-rate time series for each instance.
+- `aggregate/instance_aggregate.csv`: the aggregated result for each instance.
+- `aggregate/global_aggregate.csv`: the global result after summarizing all instances.
+- `aggregate/global_window_hit_rates.csv`: the window result generated when `--window-ns` or `--window-seconds` is specified.
 
-multi-instance replay 聚合后的 `HitRate` 仍然是 token hit rate，计算方式为所有 instance 的 `HitTokens` 总和除以 `InputTokens` 总和。
-`--bucket-name` 只写入聚合 CSV 的 `Bucket` 列，用于标记实验来源；`--trace-glob` 和 `--recursive` 只在使用 `--trace-dir` 扫描输入文件时生效。
-`--default-tier-write-mode`、`--tier-flow-config`、`--enable/disable-tier-access-propagation`、`--enable/disable-promote` 和 `--selective-write-threshold` 会写入生成 config 的 `tier_strategy`，语义与上文一致。
+The aggregated `HitRate` of multi-instance replay is still token hit rate, computed as the sum of `HitTokens` across all instances divided by the sum of `InputTokens`.
+`--bucket-name` only writes into the `Bucket` column of the aggregate CSV, used to mark the experiment source; `--trace-glob` and `--recursive` only take effect when using `--trace-dir` to scan input files.
+`--default-tier-write-mode`, `--tier-flow-config`, `--enable/disable-tier-access-propagation`, `--enable/disable-promote`, and `--selective-write-threshold` are written into the `tier_strategy` of the generated config, with semantics consistent with the above.

--- a/kv_cache_manager/optimizer/docs/strategy_config_zh.md
+++ b/kv_cache_manager/optimizer/docs/strategy_config_zh.md
@@ -1,0 +1,419 @@
+# Optimizer 标准策略配置说明
+
+> 中文 | [English](strategy_config.md)
+
+本文档定义标准版 optimizer 的策略配置、multi-instance replay 入口和命中率口径。后续新增实验脚本应复用这里的字段语义，避免在脚本里引入另一套配置命名。
+
+## 指标口径
+
+标准版只对外暴露一种命中率口径：
+
+```text
+HitRate = HitTokens / InputTokens
+AccHitRate = AccHitTokens / AccInputTokens
+```
+
+相关约定：
+
+- `HitRate`、`AccHitRate`、`LocalHitRate`、`RemoteHitRate` 和 `Tier*_HitRate` 都是 token hit rate。
+- 标准命中率只按 token 计算，但 CSV 保留 block 读/命中计数，便于核对读放大、命中规模和容量行为。
+- 标准分析不把 local/remote 当作独立结论维度。`local` 只表示 trace `block_mask` 带进来的已有本地命中 block，例如 optimizer 作为单独 L3 模拟并和 HiSim 结合时，或直接分析 KVCacheManager event log 时，日志里已经包含的本地命中 block key；`remote` 表示 optimizer 模拟层贡献的命中。当前标准报告直接按请求输入计算整体 `HitRate`，不依赖 local/remote 拆分。
+- 标准 `get` trace 必须包含 `input_len`，`InputTokens` 直接使用 `input_len`。
+- 不再兼容缺失 `input_len` 的旧 `get` trace。其他来源的日志需要先转换成 optimizer schema。
+- `keys` 只包含完整 block key；不足一个 block 的尾部 token 不写入 `keys`，但仍计入 `InputTokens`。例如 `block_size=16`、`input_len=33` 时，`keys` 最多包含 2 个完整 block，尾部 1 个 token 只进入分母。
+
+标准 `*_hit_rates.csv` 的核心列：
+
+| 列 | 说明 |
+|---|---|
+| `TimestampNs` | trace 时间戳，单位 ns |
+| `CachedBlocks` | 当前 CSV 对应 instance 的缓存 block 数 |
+| `CachedBlocksAllInstances` | 同一 optimizer 进程内所有 instance 的总缓存 block 数 |
+| `ReadBlocks` / `HitBlocks` | 当前请求读取 / 命中的 block 数 |
+| `LocalHitBlocks` / `RemoteHitBlocks` | 诊断字段：trace `block_mask` 带入的已有本地命中 / optimizer 模拟层命中 |
+| `InputTokens` / `HitTokens` | 当前请求的输入 token 数 / 命中 token 数 |
+| `LocalHitTokens` / `RemoteHitTokens` | 诊断字段：本地 / optimizer 模拟层命中 token 数 |
+| `HitRate` | 当前请求整体 token hit rate |
+| `LocalHitRate` / `RemoteHitRate` | 诊断字段，不作为标准分析主口径 |
+| `AccReadBlocks` / `AccHitBlocks` | 累计读取 / 命中的 block 数 |
+| `AccInputTokens` / `AccHitTokens` | 累计输入 token 数 / 累计命中 token 数 |
+| `AccLocalHitTokens` / `AccRemoteHitTokens` | 诊断字段：累计本地 / optimizer 模拟层命中 token 数 |
+| `AccHitRate` | 累计整体 token hit rate |
+| `AccLocalHitRate` / `AccRemoteHitRate` | 诊断字段，不作为标准分析主口径 |
+| `AccWriteBlocks` | 截至当前时间的累计写入 block 数 |
+| `Tier<N>(name)_HitTokens` | 当前请求在某个 tier 的命中 token 数 |
+| `Tier<N>(name)_HitRate` / `AccTier<N>(name)_HitRate` | 当前 / 累计 tier token hit rate |
+| `Tier<N>(name)_BlockNum` | 当前 tier 的缓存 block 数 |
+
+## 顶层配置
+
+```json
+{
+  "trace_file_path": "/path/to/optimizer_trace.jsonl",
+  "output_result_path": "/path/to/output",
+  "eviction_params": {
+    "eviction_mode": 3,
+    "eviction_batch_size_per_instance": 100
+  },
+  "trace_replay": {
+    "write_delay_ns": 1
+  },
+  "instance_groups": []
+}
+```
+
+`output_result_path` 是所有 config 驱动入口的结果输出目录，包括 `optimizer_main`、`optimizer_run`、`tradeoff` 和 `export_tree`。`export_tree` 会写到该目录下的 `radix_tree/`。`multi_instance_replay` 不读取完整 optimizer config，需要通过 `--output-dir` 显式指定输出目录。
+
+### eviction_params
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---:|---:|---|
+| `eviction_mode` | int | 必填 | `1`=`GROUP_ROUGH`，`2`=`INSTANCE_ROUGH`，`3`=`INSTANCE_PRECISE` |
+| `eviction_batch_size_per_instance` | int | 必填 | 每轮每实例最多驱逐的 block 数。rough 模式必须大于 0 |
+
+推荐标准实验使用 `eviction_mode=3`，因为它按剩余超额容量截断最后一轮驱逐，容量点更稳定。
+
+### trace_replay
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---:|---:|---|
+| `write_delay_ns` | int64 | `1` | `type=request` trace 的内部写入延迟。回放时先在 `timestamp_ns` 执行读，再在 `timestamp_ns + write_delay_ns` 调度写入。必须大于 0 |
+
+## 标准 trace schema
+
+optimizer 回放输入只接受 JSONL，每行一条标准 trace。字段不完整时直接失败，不做旧格式推断。
+
+`timestamp_ns`、`get.input_len`、`block_mask` offset 和 `ttl_us` 必须落在 `int64_t` 范围内：
+
+```text
+[-9223372036854775808, 9223372036854775807]
+```
+
+`keys` 支持 JSON signed/unsigned 整数。超过 `INT64_MAX=9223372036854775807` 的 unsigned 64-bit 值会按补码稳定映射到内部 `int64_t`，例如 `9223372036854775808 -> -9223372036854775808`、`18446744073709551615 -> -1`。
+
+Get trace：
+
+```json
+{
+  "type": "get",
+  "instance_id": "instance-a",
+  "trace_id": "trace_instance-a_1000",
+  "timestamp_ns": 1000,
+  "keys": [101, 102, 103],
+  "input_len": 33,
+  "query_type": "prefix_match",
+  "block_mask": [],
+  "sw_size": 0,
+  "location_spec_names": []
+}
+```
+
+Request trace：
+
+当外部 trace 只有请求级记录、没有显式拆成读写两行时，使用 `request`。它等价于：
+
+- 在 `timestamp_ns` 执行一次 `get`
+- 在 `timestamp_ns + trace_replay.write_delay_ns` 执行一次 `write`
+
+```json
+{
+  "type": "request",
+  "instance_id": "instance-a",
+  "trace_id": "trace_instance-a_1000",
+  "timestamp_ns": 1000,
+  "keys": [101, 102, 103],
+  "input_len": 33,
+  "query_type": "prefix_match",
+  "block_mask": [],
+  "sw_size": 0,
+  "location_spec_names": [],
+  "ttl_us": 0
+}
+```
+
+Write trace：
+
+```json
+{
+  "type": "write",
+  "instance_id": "instance-a",
+  "trace_id": "trace_instance-a_1001",
+  "timestamp_ns": 1001,
+  "keys": [101, 102, 103],
+  "ttl_us": 0
+}
+```
+
+必填字段：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `type` | string | 只能是 `get`、`write` 或 `request` |
+| `instance_id` | string | 非空，必须匹配配置中的 instance |
+| `timestamp_ns` | int64 | ns 时间戳，必须为正整数；不再接受 `timestamp_us` |
+| `keys` | int64/uint64 array | block key 列表，可为空 |
+
+可选公共字段：
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `trace_id` | string | 空字符串 | 请求标识，用于调试和模板分析 |
+
+`get` 专用字段：
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `input_len` | int64 | 必填 | 输入 token 数，必须为正整数；`InputTokens` 直接使用该值 |
+| `query_type` | string | `prefix_match` | 当前只支持 `prefix_match`；其他值会被跳过 |
+| `block_mask` | bool array 或非负 int64 | 空数组 | trace 已经知道的本地命中 block。数组形式逐 block 标记；整数形式表示从前缀开始的本地命中 block 数 |
+| `sw_size` | int32 | 0 | 滑窗参数，当前标准前缀匹配通常为 0 |
+| `location_spec_names` | string array | 空数组 | 兼容字段，标准分析通常为空 |
+
+`write` 专用字段：
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `ttl_us` | int64 | 0 | 请求级 TTL，单位微秒；`0` 使用 group 默认 TTL，`-1` 表示禁用 TTL |
+
+`request` 字段：
+
+`request` 复用 `get` 的所有字段，并额外支持 `write.ttl_us`。`request` 内部生成的写入会使用同一组 `keys` 和该 `ttl_us`。
+
+`write` 只读取 `type`、`instance_id`、`trace_id`、`timestamp_ns`、`keys` 和 `ttl_us`；其他字段包括 `input_len` 和 `block_mask` 都忽略。`block_mask` 只用于标记 trace 已经知道的本地命中 block，不是标准报告的分组依据。直接分析请求输入时通常可传空数组，此时整体 `HitRate` 仍按 `HitTokens / InputTokens` 计算。
+
+旧格式或不合法输入会失败，包括：
+
+- 缺少 `type`、`instance_id`、`timestamp_ns`、`keys`，或 `get` / `request` trace 缺少 `input_len`。
+- `get/request.input_len <= 0`、`timestamp_ns <= 0`，或 `keys` 不是数组。
+- `get/request.keys.size() > input_len / block_size`。标准 trace 的 `keys` 只能包含完整 block，不允许把不足一个 block 的尾部 key 写入 trace。
+- 使用 `timestamp_us` 但没有 `timestamp_ns`。
+- `keys` 中存在非整数。
+- `block_mask` 数组中存在非 bool 值，或 offset 为负数 / 超过 `INT64_MAX`。
+- legacy dialog-style trace 只有 `query_type` / `block_mask` / decode metadata 但没有显式 `type=get/write`。
+
+## instance group 配置
+
+```json
+{
+  "group_name": "instance-a",
+  "quota_capacity": 178,
+  "used_percentage": 1.0,
+  "tier_strategy": {
+    "hierarchical_eviction_enabled": true,
+    "write_mode": "write_through",
+    "access_propagation_enabled": true,
+    "promote_enabled": true,
+    "selective_write_threshold": 2,
+    "tier_flows": []
+  },
+  "default_block_ttl_seconds": 0,
+  "ttl_refresh_on_read": true,
+  "storages": [],
+  "instances": []
+}
+```
+
+| 字段 | 类型 | 默认 | 标准语义 |
+|---|---:|---:|---|
+| `group_name` | string | 必填 | 实例组名称。multi-instance replay 中通常等于 instance 的 `instance_id` |
+| `quota_capacity` | number | 必填 | group 总容量，单位 GB。非分层模式按该字段驱逐；`-1` 表示无限容量，不触发容量驱逐，主要用于全局池化理论命中和 Pareto warmup |
+| `used_percentage` | number | 必填 | 容量水位比例，实际阈值为 capacity × used_percentage |
+| `tier_strategy` | object | 必填 | 多层读写策略包，见下表 |
+| `default_block_ttl_seconds` | int | `0` | group 默认 TTL 秒数，`0` 表示组级禁用 TTL |
+| `ttl_refresh_on_read` | bool | `true` | TTL 策略下读命中是否刷新 TTL 锚点 |
+| `storages` | array | 必填 | tier 列表，按 `priority` 从小到大排序 |
+| `instances` | array | 必填 | 该 group 下的 optimizer instance 列表 |
+
+### tier_strategy
+
+`tier_strategy` 顶层字段是所有相邻 tier edge 的默认策略；`tier_flows` 只用于覆盖特定相邻 edge。若所有层间策略一致，可以只配置顶层字段并省略 `tier_flows`，它们不是两套重复配置。
+
+| 字段 | 类型 | 默认 | 标准语义 |
+|---|---:|---:|---|
+| `hierarchical_eviction_enabled` | bool | 必填 | 是否启用分层容量和分层驱逐；`false` 时所有 tier 共享一个 `shared` 策略与 `quota_capacity` 配额 |
+| `write_mode` | string | `write_through` | 多 tier 写入和层间流动策略 |
+| `access_propagation_enabled` | bool | `true` | 读命中高优先级 tier 时，是否刷新后续持有副本 tier 的访问时间；`false` 表示只刷新命中 tier |
+| `promote_enabled` | bool | `true` | 低层命中后是否逐层复制回经过的高优先级层 |
+| `selective_write_threshold` | int | `2` | `write_through_selective` 下命中层访问次数达到该阈值后复制到下一层；必须为正整数 |
+| `tier_flows` | array | `[]` | 相邻 tier edge 的策略覆盖。未覆盖的 edge 继承 `tier_strategy` 的默认策略 |
+
+### write_mode
+
+| 值 | 写入行为 | 驱逐行为 | 适用场景 |
+|---|---|---|---|
+| `write_through` | 写入时同时落所有 tier | 各 tier 独立按自身容量驱逐 | 基线、全量副本、多层独立命中率分析 |
+| `cascading` | 写入时只落 tier 0 | tier i 驱逐出的 block 降级到 tier i+1，最后一层驱逐后丢弃 | HBM→DRAM→SSD 逐级下沉 |
+| `write_through_selective` | 初始只落 tier 0 | 命中层访问次数达到 `tier_strategy.selective_write_threshold` 后复制到下一层 | 控制低层写放大，只让热块下沉 |
+
+`tier_strategy.write_mode` 只接受上表三个值，其他值会导致 config 解析失败。
+`access_propagation_enabled` 不是一种 `write_mode`，而是读命中后是否刷新下层副本访问时间的独立开关。
+
+### tier_flows
+
+`tier_flows` 用于覆盖相邻 tier 之间的读写流动策略。每个 flow 必须引用 `storages` 中相邻的两个 `unique_name`，不支持跨层跳配，也不允许重复配置同一条 edge。
+配置加载时会按 `storages[*].priority` 排序后校验 edge。未知 tier、非相邻 edge、重复 edge、重复 `unique_name` 或重复 `priority` 都会直接报错并拒绝加载。
+
+```json
+{
+  "tier_strategy": {
+    "hierarchical_eviction_enabled": true,
+    "write_mode": "write_through",
+    "access_propagation_enabled": true,
+    "promote_enabled": true,
+    "selective_write_threshold": 2,
+    "tier_flows": [
+      {
+        "from_tier": "hbm",
+        "to_tier": "dram",
+        "write_mode": "write_through",
+        "access_propagation_enabled": false
+      },
+      {
+        "from_tier": "dram",
+        "to_tier": "ssd",
+        "write_mode": "cascading",
+        "promote_enabled": false
+      }
+    ]
+  }
+}
+```
+
+单条 flow 的字段：
+
+| 字段 | 类型 | 默认 | 标准语义 |
+|---|---:|---:|---|
+| `from_tier` | string | 必填 | edge 的高优先级 tier 名称，必须等于某个 `storages[i].unique_name` |
+| `to_tier` | string | 必填 | edge 的低优先级 tier 名称，必须等于相邻的 `storages[i+1].unique_name` |
+| `write_mode` | string | 继承默认 | 这条 edge 的写入/驱逐下沉策略 |
+| `access_propagation_enabled` | bool | 继承默认 | 访问命中高层后，是否跨这条 edge 刷新下层访问时间 |
+| `promote_enabled` | bool | 继承默认 | 低层命中后，是否允许跨这条 edge 回填到高层 |
+| `selective_write_threshold` | int | 继承默认 | 这条 edge 使用 `write_through_selective` 时的下写阈值 |
+
+### access_propagation_enabled
+
+这个开关与 `tier_strategy.write_mode` 正交：
+
+- `true`：一个 block 在多个 tier 有副本时，读命中最高优先级 tier 后，也刷新后续副本 tier 的访问时间。这是默认行为。
+- `false`：只刷新实际命中的最高优先级 tier，不刷新下层副本的访问时间。适用于评估 write-through 或 cascading/promote 后多副本场景下的下层独立冷热衰减。
+
+`promote_enabled=true` 时，低优先级 tier 命中会触发向更高优先级 tier 逐层复制。比如 L3 命中会补齐 L2 和 L1，L2 命中只补 L1，不会额外写入更低层。复制动作会走容量检查，可能立刻触发对应 tier 的驱逐。
+
+## storage 配置
+
+```json
+{
+  "unique_name": "hbm",
+  "storage_type": "pace",
+  "band_width_mbps": 20000,
+  "priority": 0,
+  "capacity": 50
+}
+```
+
+| 字段 | 类型 | 说明 |
+|---|---:|---|
+| `unique_name` | string | tier 名称，会进入 CSV 的 `Tier<N>(name)_*` 列 |
+| `storage_type` | string | 存储类型标签，当前主要用于配置记录 |
+| `band_width_mbps` | number | 带宽标签，当前主要用于分析记录 |
+| `priority` | int | tier 优先级，越小越靠近计算侧 |
+| `capacity` | number | tier 容量，单位 GB；`-1` 表示该 tier 无限容量，不触发该 tier 的容量驱逐 |
+
+## instance 配置
+
+```json
+{
+  "instance_id": "instance-a",
+  "block_size": 16,
+  "bytes_per_token": 512,
+  "eviction_policy_type": "lru",
+  "eviction_policy_params": {}
+}
+```
+
+| 字段 | 类型 | 说明 |
+|---|---:|---|
+| `instance_id` | string | trace 中的实例 ID，必须与 trace 行内 `instance_id` 匹配 |
+| `block_size` | int | 每个 block 的 token 数。token hit rate 会用它把命中 block 转为命中 token |
+| `bytes_per_token` | int | 单 token KV 大小。`bytes_per_block = block_size * bytes_per_token` |
+| `eviction_policy_type` | string | `lru`、`random_lru`、`leaf_aware_lru`、`ttl` |
+| `eviction_policy_params` | object | 策略参数，见下文 |
+
+## eviction_policy_params
+
+### lru / leaf_aware_lru
+
+```json
+{
+  "sample_rate": 1.0,
+  "shard_count": 1,
+  "sample_times": 32,
+  "eviction_amplification_factor": 1.0
+}
+```
+
+| 字段 | 说明 |
+|---|---|
+| `sample_rate` | 采样比例。`1.0` 表示完整 LRU |
+| `shard_count` | LRU 分片数 |
+| `sample_times` | 每次采样次数 |
+| `eviction_amplification_factor` | 驱逐放大系数 |
+
+### random_lru
+
+```json
+{
+  "sample_rate": 1.0
+}
+```
+
+`random_lru` 只要求 `sample_rate`，用于控制采样范围。
+
+### ttl
+
+```json
+{
+  "fallback_on_pressure": true
+}
+```
+
+| 字段 | 说明 |
+|---|---|
+| `fallback_on_pressure=true` | 先清理 TTL 过期 block；容量仍超限时按 LRU 兜底 |
+| `fallback_on_pressure=false` | 纯 TTL，只清理过期 block；容量压力不会触发 LRU 兜底 |
+
+TTL 只在 `eviction_policy_type="ttl"` 时执行。非 TTL 策略会忽略 `default_block_ttl_seconds` 和 `ttl_refresh_on_read` 的过期清理语义。
+
+## 标准多实例回放
+
+标准版保留 `multi_instance_replay`，不再把 multi-machine scheduler 作为默认回放入口。
+脚本完整参数以 [analysis/script/README.md](../analysis/script/README.md) 为准；这里给出标准回放配置示例和输出约定。
+`multi_instance_replay` 不读取完整 optimizer config；它根据 CLI 参数为每个 pod/instance 生成单实例 config，然后并行运行 optimizer。当前 CLI 直接支持 L1/L2 两层容量；需要 L3 或更复杂 tier 拓扑时，需要使用完整 optimizer config 跑单次回放，或扩展该脚本的 config 生成逻辑。
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:multi_instance_replay -- \
+  --trace-dir /path/to/instance_traces \
+  --trace-glob "*.jsonl" \
+  --output-dir /path/to/output \
+  --bucket-name bucket-a \
+  --l1-capacity 50 \
+  --l2-capacity 128 \
+  --block-size 16 \
+  --bytes-per-token 512 \
+  --eviction-policy lru \
+  --default-tier-write-mode write_through \
+  --max-workers 32
+```
+
+输出：
+
+- 输出根目录为 `--output-dir`。
+- `configs/<instance_id>.json`：每个 instance 的生成配置。
+- `<instance_id>_hit_rates.csv`：每个 instance 的标准 token hit-rate 时序。
+- `aggregate/instance_aggregate.csv`：每个 instance 的聚合结果。
+- `aggregate/global_aggregate.csv`：所有 instance 汇总后的全局结果。
+- `aggregate/global_window_hit_rates.csv`：指定 `--window-ns` 或 `--window-seconds` 时生成的窗口结果。
+
+multi-instance replay 聚合后的 `HitRate` 仍然是 token hit rate，计算方式为所有 instance 的 `HitTokens` 总和除以 `InputTokens` 总和。
+`--bucket-name` 只写入聚合 CSV 的 `Bucket` 列，用于标记实验来源；`--trace-glob` 和 `--recursive` 只在使用 `--trace-dir` 扫描输入文件时生效。
+`--default-tier-write-mode`、`--tier-flow-config`、`--enable/disable-tier-access-propagation`、`--enable/disable-promote` 和 `--selective-write-threshold` 会写入生成 config 的 `tier_strategy`，语义与上文一致。

--- a/kv_cache_manager/optimizer/liteHit/README.md
+++ b/kv_cache_manager/optimizer/liteHit/README.md
@@ -1,402 +1,405 @@
-# LiteHit：一次回放产出容量无关事实，任意 LRU 容量事后投影
+# LiteHit: A Single Replay Produces Capacity-Independent Facts; Arbitrary LRU Capacities Are Projected After the Fact
 
-LiteHit 是面向 full-attention KVCache block 的轻量、精确 LRU 命中率分析器。核心只回放一次 trace，为每条请求产出**容量无关的事实**（`RequestFact`，一条等差段 RLE 编码的 hit curve）；任何容量的命中数都由无状态投影器 `HitCurveProjector` 事后从事实推出，核心从不接收容量列表，也不累计任何逐容量结果。
+> [中文](README_zh.md) | English
 
-LiteHit 要解决的问题是：
+LiteHit is a lightweight, exact LRU hit-rate analyzer for full-attention KVCache blocks. The core replays a trace only once, producing **capacity-independent facts** for each request (`RequestFact`, a hit curve encoded as arithmetic-segment RLE); the hit count for any capacity is derived after the fact from the facts by the stateless projector `HitCurveProjector`. The core never receives a capacity list, nor does it accumulate any per-capacity results.
+
+The problem LiteHit solves is:
 
 ```text
-给定一组带请求边界的 block trace，
-如何只回放一次 trace，就能对"任意"LRU 容量精确回答：
+Given a set of block traces with request boundaries,
+how to replay the trace only once and precisely answer, for "any" LRU capacity:
 
-1. 每条请求的 prefix 命中块数；
-2. 整段 trace 的累计 prefix 命中率。
+1. the number of prefix hit blocks for each request;
+2. the cumulative prefix hit rate over the entire trace.
 
-容量不再需要在分析开始前给定。
+Capacity no longer needs to be given before the analysis starts.
 ```
 
-第一阶段只支持以下模型：
+The first phase only supports the following model:
 
-- full attention；
-- 每个完整 block 的 KVCache charge 相同（等 charge，见 6.4）；
-- 精确 LRU，请求内倒序提交；
-- 不处理 linear attention / Mamba、不同大小 block、admission、prefetch 和多级缓存策略；TTL 支持为"每组一个固定 TTL"叠加在 LRU 之上（见 §7 TTL 回放），不支持任意 TTL 的查询期扫描。
+- full attention;
+- every complete block has the same KVCache charge (equal charge, see 6.4);
+- exact LRU, with in-request reverse-order submission;
+- does not handle linear attention / Mamba, blocks of different sizes, admission, prefetch, or multi-level cache policies; TTL support is "one fixed TTL per group" layered on top of LRU (see §7 TTL Replay), and does not support query-time scanning of arbitrary TTLs.
 
-## 0. 架构总览
+## 0. Architecture Overview
 
 ```text
                  ┌────────────────────────────────────────────┐
-   原始请求      │ 共享预处理 request_preprocess               │
- (keys,len) ───> │  NormalizeRequest：长度校验/推导 +          │
-                 │  可选 ApplyPrefixHash（前缀链式 hash）      │
+  Raw request    │ Shared preprocessing request_preprocess     │
+ (keys,len) ───> │  NormalizeRequest: length check/derivation +│
+                 │  optional ApplyPrefixHash (prefix chained   │
+                 │  hash)                                      │
                  └───────────────┬────────────────────────────┘
                                  │ NormalizedRequest
                  ┌───────────────▼────────────────────────────┐
-                 │ LiteHit 核心（容量无关）                     │
+                 │ LiteHit core (capacity-independent)         │
                  │  ProcessRequest(block_keys) → RequestFact   │
-                 │  状态：Fenwick + last_positions             │
+                 │  state: Fenwick + last_positions            │
                  └───────┬───────────────────────┬────────────┘
                          │ RequestFact           │ RequestFact
-            Online 路径  │                       │  Offline 路径
+            Online path  │                       │  Offline path
                  ┌───────▼────────┐      ┌───────▼─────────────┐
                  │ HitCurveProjector│    │ facts CSV            │
-                 │ 逐 slot 投影 +   │    │ litehit_facts.csv    │
-                 │ 累计整数         │    │ (原子发布)           │
+                 │ per-slot project +│   │ litehit_facts.csv    │
+                 │ cumulative ints  │    │ (atomic publish)     │
                  └────────────────┘      └───────┬─────────────┘
-                                                 │ 任意时刻、任意容量
+                                                 │ any time, any capacity
                                          ┌───────▼─────────────┐
-                                         │ facts query 工具     │
+                                         │ facts query tool     │
                                          │ HitCurveProjector    │
                                          └─────────────────────┘
 ```
 
-三个不可违反的分层约束：
+Three inviolable layering constraints:
 
-1. **核心容量无关**：`LiteHit::ProcessRequest` 只接收 block key，返回 `RequestFact`；不存在容量参数。
-2. **投影唯一入口**：所有"容量 → 命中块数"的换算必须经过 `HitCurveProjector`，Online 与 facts query 共用同一实现，禁止任何组件自行实现边界逻辑。
-3. **字节换算只发生在投影边界**：核心与事实全部以 block 为单位；`ProjectBytes` 在投影时用 `block_bytes` 做一次 floor 除法。
-
----
-
-## 1. 输入模型与共享预处理
-
-### 1.1 每条请求
-
-每条请求向预处理层提供：
-
-```text
-block_keys[]            按请求从前到后排列的完整 block key（或原始逐块 hash）
-input_token_len         原始请求的 input token 数
-```
-
-`NormalizeRequest(block_keys, input_token_len, block_size_tokens, enable_prefix_hash, trace_block_size_tokens = 0)`：
-
-- `trace_block_size_tokens` 是 trace 原生 block 粒度（0 = 与 `block_size_tokens` 相同，不重分块）；长度校验发生在 trace 粒度：
-  `block_keys.size() == floor(input_token_len / trace_block_size_tokens)`；
-- `input_token_len > 0` 时为权威分母；`input_token_len <= 0` 视为缺省，按 `block_keys.size() * trace_block_size_tokens` 推导；
-- 违反约束（含 `block_size_tokens` 不是 `trace_block_size_tokens` 的整数倍——只允许变粗）抛 `std::invalid_argument`（Offline 对此 fail-fast，见第 7 节）。
-
-不足一个完整 block 的尾部 token 不进入 LRU，但保留在命中率分母中。
-
-### 1.1a 重分块（re-blocking）：零重 hash 的粒度变粗
-
-分析粒度粗于 trace 粒度时（`block_size_tokens = k * trace_block_size_tokens`，k > 1），无需重算任何 hash：前缀链式 key 的第 `j*k` 个恰好编码了前 j 个粗 block 的全部 token，因此**先做前缀链（若输入是逐块 hash）、再每 k 个取第 k 个**即得到粗粒度下合法的前缀链式 key，凑不满 k 个细块的尾部丢弃（其 token 留在分母中）。只允许变粗——变细需要 block 内部的 token 信息，trace 中不存在。
-
-### 1.2 block key 契约：前缀链式 hash
-
-full-attention 下 block j 的 KVCache 依赖请求前 j 个 block 的全部 token，因此 key 必须编码整个前缀：
-
-```text
-key_j = hash(请求前 j 个完整 block 的全部 token)
-```
-
-key 相等当且仅当整个 token 前缀完全相同。合法的 trace 形态是"共享前缀 + 分叉"，例如 `[A, B, C]` 与 `[A, B, D]` 共享前两个 block；`[B, A, C]` 这类重排序列在契约下不可能出现。
-
-当输入是逐块独立 hash 时，在 **Instance Group** 上置 `enable_prefix_hash = true`（key 形态跟模型部署走，group 正是这个粒度；online 建组 RPC 与 offline 配置共用同一字段），预处理用滚动 hash 把它转成前缀链式 key：
-
-```text
-PrefixHashNext(prev, raw)：Jenkins 64 位变体，显式 uint64 运算（逻辑右移），
-与 Python 生产端 prefix_hash.py::hash_int64_func 逐 bit 一致。
-注意：有意不复用 HashUtil::HashIntFunc（有符号右移，负 hash 时结果分歧）。
-```
-
-契约的两个推论（第 5 节会用到）：
-
-```text
-1. 同一请求内 key 必然互不相同（每个 key 编码严格递增的前缀）。
-2. 请求内首个 cold block 之后，后续 key 的前缀都包含分歧点，必然也 cold。
-```
+1. **Core is capacity-independent**: `LiteHit::ProcessRequest` only receives block keys and returns a `RequestFact`; there is no capacity parameter.
+2. **Projection is the sole entry point**: all "capacity → hit block count" conversions must go through `HitCurveProjector`; Online and facts query share the same implementation, and no component is allowed to implement boundary logic on its own.
+3. **Byte conversion happens only at the projection boundary**: the core and facts are all in block units; `ProjectBytes` performs a single floor division using `block_bytes` at projection time.
 
 ---
 
-## 2. 命中语义：prefix hit + 倒序提交
+## 1. Input Model and Shared Preprocessing
+
+### 1.1 Per Request
+
+Each request provides to the preprocessing layer:
+
+```text
+block_keys[]            complete block keys ordered from front to back of the request (or raw per-block hashes)
+input_token_len         the number of input tokens of the original request
+```
+
+`NormalizeRequest(block_keys, input_token_len, block_size_tokens, enable_prefix_hash, trace_block_size_tokens = 0)`:
+
+- `trace_block_size_tokens` is the trace's native block granularity (0 = same as `block_size_tokens`, no re-blocking); length validation happens at trace granularity:
+  `block_keys.size() == floor(input_token_len / trace_block_size_tokens)`;
+- when `input_token_len > 0` it is the authoritative denominator; `input_token_len <= 0` is treated as missing and derived as `block_keys.size() * trace_block_size_tokens`;
+- violating the constraints (including `block_size_tokens` not being an integer multiple of `trace_block_size_tokens` — only coarsening is allowed) throws `std::invalid_argument` (Offline fails fast on this, see Section 7).
+
+Trailing tokens that do not fill a complete block do not enter the LRU, but are retained in the hit-rate denominator.
+
+### 1.1a Re-blocking: Granularity Coarsening with Zero Re-hashing
+
+When the analysis granularity is coarser than the trace granularity (`block_size_tokens = k * trace_block_size_tokens`, k > 1), no hash needs to be recomputed: the `j*k`-th key of the prefix chained keys happens to encode all tokens of the first j coarse blocks, so **first build the prefix chain (if the input is per-block hashes), then take every k-th (the k-th) key** to obtain valid prefix chained keys at the coarse granularity; the tail that cannot fill k fine blocks is discarded (its tokens remain in the denominator). Only coarsening is allowed — refining requires token information inside a block, which does not exist in the trace.
+
+### 1.2 Block Key Contract: Prefix Chained Hash
+
+Under full attention, the KVCache of block j depends on all tokens of the first j blocks of the request, so the key must encode the entire prefix:
+
+```text
+key_j = hash(all tokens of the first j complete blocks of the request)
+```
+
+Keys are equal if and only if the entire token prefix is exactly identical. The valid trace shape is "shared prefix + fork", e.g. `[A, B, C]` and `[A, B, D]` share the first two blocks; a reordered sequence like `[B, A, C]` cannot occur under the contract.
+
+When the input is per-block independent hashes, set `enable_prefix_hash = true` on the **Instance Group** (the key shape follows model deployment, and group is exactly that granularity; the online group-creation RPC and offline config share the same field), and preprocessing converts it to prefix chained keys using a rolling hash:
+
+```text
+PrefixHashNext(prev, raw): Jenkins 64-bit variant, explicit uint64 arithmetic (logical right shift),
+bit-for-bit identical to the Python producer prefix_hash.py::hash_int64_func.
+Note: intentionally does not reuse HashUtil::HashIntFunc (signed right shift, results diverge for negative hashes).
+```
+
+Two corollaries of the contract (used in Section 5):
+
+```text
+1. Keys within the same request are necessarily distinct (each key encodes a strictly growing prefix).
+2. After the first cold block within a request, the prefixes of subsequent keys all contain the divergence point, so they are necessarily cold too.
+```
+
+---
+
+## 2. Hit Semantics: prefix hit + reverse-order submission
 
 ### 2.1 prefix hit
 
-full-attention 请求采用 prefix hit：对某个容量，一条请求的命中块数是从请求第一个 block 开始连续命中的完整 block 数，即首个 miss 的位置。首个 miss 只截断本条请求的命中，不停止 LRU 状态更新——所有完整 block 仍然全部提交，否则后续请求看到的缓存状态会错误。
+Full-attention requests adopt prefix hit: for a given capacity, the hit block count of a request is the number of consecutively hit complete blocks starting from the first block of the request, i.e. the position of the first miss. The first miss only truncates the hits of the current request; it does not stop the LRU state update — all complete blocks are still submitted in full, otherwise the cache state seen by subsequent requests would be wrong.
 
-提交不区分 hit / miss 的物理依据是：真实 prefix cache 里 miss 的 block 会被重算并**写回**缓存，写入本身就是一次 touch——请求结束后无论命中与否，block 都在 MRU 端。于是"LRU 更新"与"命中判定"天然解耦（Mattson 栈算法性质）：命中判定依赖容量，推迟到投影层；LRU 更新不依赖容量，核心无条件把所有 block 提交到位置末尾。这也意味着若 trace 带 output（decode 生成的新 block），同一机制可按**读写分离**扩展：output block 不参与阶段一的命中评估（新生成的块谈不上命中），照常参与阶段二提交进入 LRU，供后续请求命中。
+The physical basis for submission not distinguishing hit / miss is: in a real prefix cache, a missed block is recomputed and **written back** to the cache, and the write itself is a touch — after the request ends, regardless of hit or miss, the block is at the MRU end. Thus "LRU update" and "hit determination" are naturally decoupled (Mattson stack algorithm property): hit determination depends on capacity and is deferred to the projection layer; LRU update does not depend on capacity, and the core unconditionally submits all blocks to the end of the position. This also means that if the trace carries output (new blocks generated by decode), the same mechanism can be extended with **read/write separation**: output blocks do not participate in phase-one hit evaluation (newly generated blocks cannot be called hits), but participate as usual in phase-two submission into the LRU, to be hit by subsequent requests.
 
-### 2.2 状态提交按请求倒序（尾先、头后）
+### 2.2 State Submission in Reverse Request Order (tail first, head last)
 
-正序 touch 会让链头最老、最先被驱逐——对 prefix 语义这是**价值倒挂**：没有链头，链上其余 resident block 一个 prefix hit 都贡献不了，却还占着容量。生产 prefix cache 全部选择尾先驱逐：vLLM 按逆序把 block 放回 free 队列，SGLang radix cache 只驱逐 LRU 叶子。
+Forward-order touching would make the head of the chain the oldest and the first to be evicted — for prefix semantics this is **value inversion**: without the head, none of the other resident blocks on the chain can contribute a single prefix hit, yet they still occupy capacity. Production prefix caches all choose tail-first eviction: vLLM puts blocks back into the free queue in reverse order, and the SGLang radix cache only evicts LRU leaves.
 
-倒序提交配合 1.2 的前缀 hash 契约，给出不变式：
+Reverse-order submission, combined with the prefix hash contract of 1.2, yields the invariant:
 
 ```text
-父 key 永远比它的任何 resident 后代更新
-    ⇒ 全局 LRU 的驱逐牺牲者永远是叶子
-    ⇒ 倒序提交的 LRU 等价于"驱逐最久未用的叶子"
+A parent key is always newer than any of its resident descendants
+    ⇒ the eviction victim of global LRU is always a leaf
+    ⇒ reverse-order submission LRU is equivalent to "evict the least recently used leaf"
 ```
 
-且全局顺序仍由访问序列唯一决定、与容量无关——栈包含性质保持（第 3 节）。
+And the global order is still uniquely determined by the access sequence, independent of capacity — the stack inclusion property is preserved (Section 3).
 
-实现分两阶段：**阶段一**基于请求到达前的只读 LRU 快照计算 hit curve（首个 miss 前只有 hit，hit 改变顺序但不改变成员集合，快照评估精确）；**阶段二**按"每个 key 的首次出现位置、从请求尾部向头部"批量提交，对含重复 key 的输入也与倒序逐块 touch 等价（契约下请求内无重复 key，该去重是防御行为）。
+The implementation has two phases: **Phase one** computes the hit curve based on the read-only LRU snapshot before the request arrives (before the first miss there are only hits; hits change order but not the member set, so snapshot evaluation is exact); **Phase two** batch-submits "by the first-occurrence position of each key, from the request tail toward the head", which is equivalent to reverse-order per-block touching even for inputs with duplicate keys (under the contract there are no duplicate keys within a request; this deduplication is defensive behavior).
 
 ---
 
-## 3. 为什么一个 LRU 状态可以回答所有容量
+## 3. Why a Single LRU State Can Answer All Capacities
 
-LRU 具有栈包含性质。假设当前全局最近访问顺序是：
+LRU has the stack inclusion property. Suppose the current global most-recent-access order is:
 
 ```text
 MRU → [X, A, Y, B] → LRU
 ```
 
-那么容量 1/2/3/4 的缓存内容分别是这条顺序的前 1/2/3/4 个元素。block `B` 位于第 4 位，则它在容量 1、2、3 下 miss，容量 ≥ 4 命中。因此一次访问只需要知道 block 在全局 LRU 顺序中的深度，就能同时回答所有容量——这正是"容量无关事实"可行的根源。
+Then the cache contents for capacities 1/2/3/4 are respectively the first 1/2/3/4 elements of this order. Block `B` is at position 4, so it misses at capacities 1, 2, 3 and hits at capacity ≥ 4. Therefore a single access only needs to know the depth of the block in the global LRU order to simultaneously answer all capacities — this is exactly the root of why "capacity-independent facts" are feasible.
 
 ---
 
-## 4. Reuse distance 与 Fenwick
+## 4. Reuse Distance and Fenwick
 
-对一次重复访问：
-
-```text
-reuse distance d = 上次访问之后、这次访问之前出现过的不同 block 数
-required_capacity = d + 1        （容量 C 命中 ⇔ C >= d + 1）
-```
-
-第一次出现的 block 是 cold miss，没有有限的 required_capacity；无限容量也不能命中 cold access。
-
-LiteHit 为每个 block 只保留最新访问位置 `last[key]`，Fenwick 的逻辑数组在"某 block 的最新位置"处为 1、历史旧位置处为 0：
+For a repeated access:
 
 ```text
-d = Fenwick.sum(i - 1) - Fenwick.sum(prev)     // (prev, i) 内仍为 1 的位置数
-随后 Fenwick.add(prev, -1)、Fenwick.add(i, +1)、last[key] = i
+reuse distance d = number of distinct blocks appearing after the last access and before this access
+required_capacity = d + 1        (capacity C hits ⇔ C >= d + 1)
 ```
 
-Fenwick 不是一套缓存，只是全局 LRU 顺序的 order-statistics 表示。当历史废弃位置超过活跃 key 数的一倍加上固定 slack 时，实现会重建位置空间（compaction），使 Fenwick 空间由当前活跃 key 数而不是历史访问总数主导——注意这只回收**位置**，不删除任何 key（见第 9 节）。
+A block appearing for the first time is a cold miss, with no finite required_capacity; even infinite capacity cannot hit a cold access.
+
+LiteHit retains only the latest access position `last[key]` for each block; the Fenwick's logical array is 1 at "the latest position of some block" and 0 at historical stale positions:
+
+```text
+d = Fenwick.sum(i - 1) - Fenwick.sum(prev)     // number of positions still 1 within (prev, i)
+then Fenwick.add(prev, -1), Fenwick.add(i, +1), last[key] = i
+```
+
+The Fenwick is not a cache; it is merely an order-statistics representation of the global LRU order. When historical abandoned positions exceed twice the number of active keys plus a fixed slack, the implementation rebuilds the position space (compaction), so that the Fenwick space is dominated by the current number of active keys rather than the total number of historical accesses — note this only reclaims **positions**, it does not delete any key (see Section 9).
 
 ---
 
-## 5. RequestFact：等差段 RLE 编码的 hit curve
+## 5. RequestFact: Hit Curve Encoded as Arithmetic-Segment RLE
 
-### 5.1 从逐块门槛到 hit curve
+### 5.1 From Per-Block Thresholds to Hit Curve
 
-设一条请求各 block 基于快照的最小命中容量是 `required = [r1, ..., rm]`（cold 截断于首个无穷）。要让前 j 个 block 连续命中，容量必须满足前面所有 block：
+Suppose the minimum hit capacity of each block of a request based on the snapshot is `required = [r1, ..., rm]` (cold truncates at the first infinity). To make the first j blocks hit consecutively, the capacity must satisfy all preceding blocks:
 
 ```text
 prefix_required[j] = max(r1, ..., rj)
 ```
 
-序列 `prefix_required[1..h]`（h 为 cold 截断前的长度）就完整决定了该请求在**一切容量**下的命中块数：
+The sequence `prefix_required[1..h]` (h being the length before cold truncation) completely determines the hit block count of that request at **all capacities**:
 
 ```text
 hit_blocks(C) = |{ j : prefix_required[j] <= C }|
 ```
 
-这条单调阶梯函数就是本请求的 **hit curve**——它就是这条请求的全部事实。
+This monotonic step function is the **hit curve** of this request — it is the entire fact of this request.
 
-### 5.2 契约下门槛严格递增 ⇒ 等差段 RLE 无损
+### 5.2 Under the Contract, Thresholds Are Strictly Increasing ⇒ Arithmetic-Segment RLE Is Lossless
 
-倒序提交下链上后块的最小命中容量**严格大于**前块（每深一块，快照区间内至少多出它的父 key），因此契约输入的 `prefix_required` 严格递增。更强的结构性质是：链上相邻 block 在全局 LRU 中占据**连续**位置，门槛只在"插队"点（兄弟分支交错进来的位置）跳变。于是把连续 `+1` 的门槛压成一个等差段：
+Under reverse-order submission, the minimum hit capacity of a later block on the chain is **strictly greater** than that of an earlier block (each block deeper adds at least its parent key within the snapshot interval), so for contract inputs `prefix_required` is strictly increasing. A stronger structural property is: adjacent blocks on the chain occupy **consecutive** positions in the global LRU, and the threshold only jumps at "queue-jumping" points (positions where sibling branches interleave). So consecutive `+1` thresholds are compressed into one arithmetic segment:
 
 ```text
 HitCurveSegment { start_required_blocks, run_length }
-段内第 j 个 block（0-based）在容量 >= start + j 时成为 prefix hit。
-段数 = 1 + 插队次数，与请求长度无关。
+The j-th block (0-based) within a segment becomes a prefix hit at capacity >= start + j.
+Number of segments = 1 + number of queue-jumps, independent of request length.
 ```
 
-例如门槛 `[1, 2, 3]`（无人插队的整链重放）编码为一段 `{1, 3}`；门槛 `[1, 2, 4]`（第三块前被插了一队）编码为 `{1, 2}, {4, 1}`。相邻段之间必有至少 1 的门槛空隙，不可再合并。
+For example, thresholds `[1, 2, 3]` (a whole-chain replay with no queue-jumping) encode as one segment `{1, 3}`; thresholds `[1, 2, 4]` (a queue jumped in before the third block) encode as `{1, 2}, {4, 1}`. Between adjacent segments there is necessarily a threshold gap of at least 1, so they cannot be merged further.
 
-### 5.3 非契约输入的单调防御
+### 5.3 Monotonic Defense for Non-Contract Inputs
 
-对不满足契约的输入（请求内重复 key 等），门槛可能不严格递增。编码时施加单调防御：
+For inputs that do not satisfy the contract (duplicate keys within a request, etc.), thresholds may not be strictly increasing. A monotonic defense is applied during encoding:
 
 ```text
 encoded_threshold = max(prefix_required[j], last_encoded + 1)
 ```
 
-契约输入下该防御恒为 no-op；非契约输入下它只会把门槛**抬高**（悲观、绝不乐观），投影结果是真实命中的下界。
+For contract inputs this defense is always a no-op; for non-contract inputs it only **raises** thresholds (pessimistic, never optimistic), and the projection result is a lower bound of the true hits.
 
 ### 5.4 HitCurveProjector
 
 ```cpp
-ProjectBlocks(fact, capacity_blocks)   // 沿段线性扫描：
-                                       // hits += min(run_length, C - start + 1)，直到 start > C
+ProjectBlocks(fact, capacity_blocks)   // linear scan along segments:
+                                       // hits += min(run_length, C - start + 1), until start > C
 ProjectBytes(fact, capacity_bytes, block_bytes)
                                        // = ProjectBlocks(fact, floor(bytes / block_bytes))
-ProjectInfinite(fact)                  // = Σ run_length（无 capacity miss，仅 cold miss）
+ProjectInfinite(fact)                  // = Σ run_length (no capacity miss, only cold miss)
 ```
 
-空 curve 表示请求头即 cold，任何容量命中为 0。
+An empty curve means the request head is cold, and hits are 0 at any capacity.
 
 ---
 
-## 6. 单位与换算
+## 6. Units and Conversions
 
-### 6.1 两个大小，用途不同
+### 6.1 Two Sizes, Different Purposes
 
-| 名称 | 单位 | 用途 |
+| Name | Unit | Purpose |
 |---|---:|---|
-| `block_size_tokens` | token/block | 将命中块数换算成命中 token 数 |
-| `block_bytes` | byte/block | 将字节容量换算成 block 容量（仅投影边界） |
+| `block_size_tokens` | token/block | convert hit block count to hit token count |
+| `block_bytes` | byte/block | convert byte capacity to block capacity (projection boundary only) |
 
-### 6.2 token 命中率
+### 6.2 Token Hit Rate
 
 ```text
 hit_tokens = hit_blocks * block_size_tokens
 trace_hit_rate = hit_tokens / input_token_len
 ```
 
-尾部不完整 token 在分母中，因此全命中也未必 100%。累计命中率必须先累加整数分子分母（`Σ hit_tokens / Σ input_token_len`），不能对每条请求命中率做算术平均。
+Trailing incomplete tokens are in the denominator, so even a full hit may not be 100%. The cumulative hit rate must first accumulate the integer numerator and denominator (`Σ hit_tokens / Σ input_token_len`); it must not be the arithmetic mean of per-request hit rates.
 
-### 6.3 字节容量换算
+### 6.3 Byte Capacity Conversion
 
 ```text
 capacity_blocks = floor(capacity_bytes / block_bytes)
-capacity_gb 使用二进制换算：capacity_bytes = capacity_gb * 1024^3
+capacity_gb uses binary conversion: capacity_bytes = capacity_gb * 1024^3
 ```
 
-`block_bytes` 来自实例注册的 full location spec group 各 spec.size 之和（`size_full_only`）。facts CSV 每行记录 `block_bytes`，事实自描述：即使日后修正 charge 估计，也能对历史事实重投影。
+`block_bytes` comes from the sum of spec.size of each spec in the full location spec group of instance registration (`size_full_only`). Each row of the facts CSV records `block_bytes`, making facts self-describing: even if the charge estimate is corrected later, historical facts can be re-projected.
 
-### 6.4 等 charge 不变量（block 单位 RLE 的前提）
+### 6.4 Equal-Charge Invariant (Premise of Block-Unit RLE)
 
-hit curve 以 block 为单位、`ProjectBytes` 做单一 floor 除法，**当且仅当**所有参与块 charge 完全相等才精确——full-only 实例满足（每块 charge 恒为 `size_full_only`，是精确值不是平均值）。linear/Mamba 混合实例每块 charge 不等，必须改用 charge 加权门槛，属于后续独立任务；当前 Offline 拒绝 `linear_step != 0` 的实例。
+The hit curve is in block units and `ProjectBytes` performs a single floor division, which is exact **if and only if** the charges of all participating blocks are exactly equal — full-only instances satisfy this (each block's charge is constantly `size_full_only`, an exact value not an average). For linear/Mamba mixed instances, the per-block charge is unequal, and charge-weighted thresholds must be used instead, which is a separate subsequent task; currently Offline rejects instances with `linear_step != 0`.
 
 ---
 
-## 7. Offline facts 流水线
+## 7. Offline Facts Pipeline
 
-Offline runner（`lite_hit_main` + `OptimizerLiteHitConfig`）逐批处理标准 trace：
+The Offline runner (`lite_hit_main` + `OptimizerLiteHitConfig`) processes standard traces in batches:
 
 ```text
-批窗口 = pipeline_worker_count * 256 条
-  ├─ 并行预处理（按下标条带分配 worker）：解析 + NormalizeRequest + prefix hash
-  ├─ 按 instance 分 lane，lane 内严格按输入顺序串行 ProcessRequest
-  └─ 按输入顺序串行写出 facts 行
+batch window = pipeline_worker_count * 256 entries
+  ├─ parallel preprocessing (workers assigned by index stripe): parse + NormalizeRequest + prefix hash
+  ├─ split into lanes by instance; within a lane, strictly serial ProcessRequest in input order
+  └─ serially write out facts rows in input order
 ```
 
-**trace 粒度与重分块**：配置字段 `block_size`（默认 256）声明 trace 的原生 block 粒度；每个 instance 的 `block_size` 是该 lane 的分析粒度，必须是它的整数倍（只允许变粗，违约在 lane 初始化时整体失败），按 1.1a 的采样方式重分块。
+**Trace granularity and re-blocking**: the config field `block_size` (default 256) declares the native block granularity of the trace; each instance's `block_size` is the analysis granularity of that lane, which must be an integer multiple of it (only coarsening allowed; violation fails the whole thing at lane initialization), re-blocking per the sampling method of 1.1a.
 
-**写事件**：`write` trace 事件会被识别并忽略。`get` 提交时视为全部 block 已写回（§2 的物理依据：写回本身就是一次 touch），因此拆分的 `get`/`write` trace 中的 `write` 行对 facts 无影响；delayed write 建模只属于 replay 路径。
+**Write events**: `write` trace events are recognized and ignored. When a `get` is submitted, all blocks are treated as written back (the physical basis of §2: write-back itself is a touch), so `write` rows in split `get`/`write` traces have no effect on facts; delayed write modeling belongs only to the replay path.
 
-**fanout 模式**：`fanout_all_instances = true` 时每条请求广播到全部 lane（各 lane 独立 LRU 状态、独立 facts 行），配合多个不同 `block_size` 的 instance 即可一次回放对同一份 trace 扫多个分析粒度；与 `override_instance_id` 互斥。facts query 的 summary 按 instance 分组输出（每 instance 一行 + 总计一行），fanout 结果直接可读。
+**Fanout mode**: when `fanout_all_instances = true`, each request is broadcast to all lanes (each lane has independent LRU state and independent facts rows); combined with multiple instances of different `block_size`, a single replay can scan multiple analysis granities over the same trace; mutually exclusive with `override_instance_id`. The facts query summary is grouped by instance (one row per instance + one total row), and fanout results are directly readable.
 
-**TTL 回放**：instance group 配置 `ttl_seconds != 0` 时，该组 lane 的 `LiteHit` 核心叠加固定 TTL（与 online `TtlCacheIndexerWrapper` 语义一致：块在距上次访问严格小于 TTL 内存活，过期块对任意容量都是 miss 并像冷块一样截断前缀；每次访问（命中或未命中）都刷新 last_access；时间取 trace 时间戳，回放确定性）。年龄沿 LRU 栈单调，过期块不会抬高存活块的复用距离，因此一次回放对"固定 TTL × 任意容量"的联合口径仍然精确，facts 仍是普通 hit curve 行。TTL 是回放期参数，直接取组里的 `ttl_seconds`；要扫多个 TTL 就配多个 group 各带不同 `ttl_seconds`（可配合 fanout 一次回放完成）。
+**TTL replay**: when the instance group config has `ttl_seconds != 0`, the `LiteHit` core of that group's lanes layers a fixed TTL on top (consistent with the online `TtlCacheIndexerWrapper` semantics: a block survives while strictly less than TTL since its last access; expired blocks are misses at any capacity and truncate the prefix like cold blocks; every access (hit or miss) refreshes last_access; time is taken from the trace timestamp, and replay is deterministic). Age is monotonic along the LRU stack, and expired blocks do not raise the reuse distance of surviving blocks, so a single replay remains exact for the joint metric of "fixed TTL × arbitrary capacity", and facts are still ordinary hit curve rows. TTL is a replay-time parameter, taken directly from the group's `ttl_seconds`; to scan multiple TTLs, configure multiple groups each with a different `ttl_seconds` (can be combined with fanout to complete in a single replay).
 
-**fail-fast**：时间戳乱序、未知 instance、长度校验失败、全文件零有效行，任一发生即整体失败并给出原因——facts 是全有或全无的对账账本，不允许静默丢行。
+**Fail-fast**: timestamp out of order, unknown instance, length validation failure, zero valid rows in the whole file — any of these fails the whole thing with a reason — facts are an all-or-nothing reconciliation ledger, and silent row loss is not allowed.
 
-**原子发布**：先写 `litehit_facts.csv.tmp`，全部成功后 `rename` 为 `litehit_facts.csv`；读者永远不会看到半成品。
+**Atomic publish**: first write `litehit_facts.csv.tmp`, then `rename` to `litehit_facts.csv` after all succeed; readers never see a half-finished product.
 
-### 7.1 facts CSV 格式
+### 7.1 facts CSV Format
 
 ```text
 trace_id,instance_id,timestamp_ns,input_token_len,block_size_tokens,block_bytes,hit_curve
 ```
 
-`hit_curve` 是带引号的 JSON 数组 `[[start_required_blocks, run_length], ...]`；字符串字段按 CSV 规则引用转义。每行独立可解析、自描述、可重投影。
+`hit_curve` is a quoted JSON array `[[start_required_blocks, run_length], ...]`; string fields are quote-escaped per CSV rules. Each row is independently parseable, self-describing, and re-projectable.
 
-### 7.2 facts query 工具
+### 7.2 facts query Tool
 
-`lite_hit_facts_query_main`（`RunLiteHitFactsQuery`）对已发布的 facts 做事后容量查询：
+`lite_hit_facts_query_main` (`RunLiteHitFactsQuery`) performs after-the-fact capacity queries on published facts:
 
 ```text
-输入：facts CSV + capacity_gb 列表（保序、允许重复和 0，负数 = 无限容量）
-输出：JSONL，每请求一行（hit_blocks/hit_rates 按 slot）
-     + 每个 instance_id 一行 summary（instance_id 字典序）+ 一行总计 summary
-     （requests / total_input_tokens / total_hit_blocks / total_hit_tokens / hit_rates）
+input: facts CSV + capacity_gb list (order-preserving, duplicates and 0 allowed, negative = infinite capacity)
+output: JSONL, one row per request (hit_blocks/hit_rates per slot)
+     + one summary row per instance_id (instance_id in lexicographic order) + one total summary row
+     (requests / total_input_tokens / total_hit_blocks / total_hit_tokens / hit_rates)
 ```
 
-内存只有 O(instance 数 × 容量 slot 数) 个累计整数；任一畸形行使整个查询失败。
+Memory is only O(number of instances × number of capacity slots) cumulative integers; any malformed row fails the entire query.
 
 ---
 
-## 8. Online 集成
+## 8. Online Integration
 
-Online Optimizer 的 full-attention `InstanceState` 直接持有 `LiteHit`（组配置 `ttl_seconds != 0` 时以墙钟时间叠加固定 TTL，口径与 linear 路径的 `TtlCacheIndexerWrapper` 一致）。每次 TraceQuery：
+The Online Optimizer's full-attention `InstanceState` directly holds a `LiteHit` (when the group config has `ttl_seconds != 0`, a fixed TTL is layered on with wall-clock time, with metrics consistent with the linear path's `TtlCacheIndexerWrapper`). Each TraceQuery:
 
 ```text
-NormalizeRequest → ProcessRequest → 得到 RequestFact
-  ├─ 对每个配置容量 slot：ProjectBlocks(fact, lite_hit_capacity_blocks[i])
-  ├─ 理论上界：ProjectInfinite(fact)
-  └─ 更新累计整数：total_queries / total_input_tokens / 各 slot total_hits
+NormalizeRequest → ProcessRequest → obtain RequestFact
+  ├─ for each configured capacity slot: ProjectBlocks(fact, lite_hit_capacity_blocks[i])
+  ├─ theoretical upper bound: ProjectInfinite(fact)
+  └─ update cumulative integers: total_queries / total_input_tokens / total_hits per slot
 ```
 
-Online 不持久化 facts（facts 落盘当前是 Offline 专属）；`ListInstances` 的命中率从累计整数推导（`total_hits * block_size_tokens / total_input_tokens`）。linear attention 继续走 legacy indexer 路径（启用 prefix hash 时仅做 `ApplyPrefixHash`）。
+Online does not persist facts (facts persistence is currently Offline-exclusive); the hit rate of `ListInstances` is derived from cumulative integers (`total_hits * block_size_tokens / total_input_tokens`). linear attention continues to go through the legacy indexer path (when prefix hash is enabled, only `ApplyPrefixHash` is performed).
 
 ---
 
-## 9. 复杂度与状态量
+## 9. Complexity and State Size
 
-设 N = 总 block access 数，U = 历史不同 block 数，Q = 请求数，S = 单请求段数（= 1 + 插队次数）。
+Let N = total number of block accesses, U = number of historically distinct blocks, Q = number of requests, S = number of segments per request (= 1 + number of queue-jumps).
 
 ```text
-ProcessRequest：O(m log U)（m 为请求块数）
-ProjectBlocks： O(S)，与容量值无关
-核心持久状态： Fenwick + last_positions，O(U)
+ProcessRequest: O(m log U) (m is the number of request blocks)
+ProjectBlocks:  O(S), independent of capacity value
+core persistent state: Fenwick + last_positions, O(U)
 ```
 
-**没有基于容量的剪枝**：容量事后才知道，任何 key 都可能被将来某个大容量查询用到，因此核心保留全部历史 unique key（这是容量无关性的固有代价）。第 4 节的 compaction 只回收废弃位置，不删除 key。`memory_usage_bytes()` / `current_unique_blocks()` 提供观测。
+**No capacity-based pruning**: capacity is only known after the fact, and any key may be used by some future large-capacity query, so the core retains all historical unique keys (this is the inherent cost of capacity independence). The compaction in Section 4 only reclaims abandoned positions, it does not delete keys. `memory_usage_bytes()` / `current_unique_blocks()` provide observability.
 
 ---
 
-## 10. 端到端示例
+## 10. End-to-End Example
 
 ```text
-block_size_tokens = 4，block_bytes = 1024
-五条请求（满足前缀 hash 契约，[A,B,C] 与 [A,B,D] 共享前两块，[A,E] 一块后分叉）
+block_size_tokens = 4, block_bytes = 1024
+five requests (satisfying the prefix hash contract, [A,B,C] and [A,B,D] share the first two blocks, [A,E] forks after one block)
 ```
 
-| # | keys | len | 快照门槛 prefix_required | hit_curve (RLE) |
+| # | keys | len | snapshot threshold prefix_required | hit_curve (RLE) |
 |---|---|---:|---|---|
-| 1 | [A,B,C] | 13 | 全 cold | `[]` |
-| 2 | [A,B,D] | 12 | [1, 2]，D cold 截断 | `[[1,2]]` |
-| 3 | [A,B,C] | 13 | [1, 2, 4]（D 插队使 C 深度 4） | `[[1,2],[4,1]]` |
-| 4 | [A,E] | 8 | [1]，E cold 截断 | `[[1,1]]` |
+| 1 | [A,B,C] | 13 | all cold | `[]` |
+| 2 | [A,B,D] | 12 | [1, 2], D cold truncates | `[[1,2]]` |
+| 3 | [A,B,C] | 13 | [1, 2, 4] (D's queue-jump makes C depth 4) | `[[1,2],[4,1]]` |
+| 4 | [A,E] | 8 | [1], E cold truncates | `[[1,1]]` |
 | 5 | [A,E] | 8 | [1, 2] | `[[1,2]]` |
 
-各请求结束后的 LRU 依次为 `[A,B,C]`、`[A,B,D,C]`、`[A,B,C,D]`、`[A,E,B,C,D]`、`[A,E,B,C,D]`。
+The LRU after each request ends is respectively `[A,B,C]`, `[A,B,D,C]`, `[A,B,C,D]`, `[A,E,B,C,D]`, `[A,E,B,C,D]`.
 
-事后投影三个容量（2048 B → 2 块，3072 B → 3 块，无限）：
+After-the-fact projection of three capacities (2048 B → 2 blocks, 3072 B → 3 blocks, infinite):
 
-| 容量 | 各请求 hit_blocks | 累计块 | 累计 token | 累计命中率 |
+| Capacity | hit_blocks per request | cumulative blocks | cumulative tokens | cumulative hit rate |
 |---:|---|---:|---:|---:|
-| 2 块 | 0,2,2,1,2 | 7 | 28 | `28 / 54 = 51.85%` |
-| 3 块 | 0,2,2,1,2 | 7 | 28 | `28 / 54 = 51.85%` |
+| 2 blocks | 0,2,2,1,2 | 7 | 28 | `28 / 54 = 51.85%` |
+| 3 blocks | 0,2,2,1,2 | 7 | 28 | `28 / 54 = 51.85%` |
 | ∞ | 0,2,3,1,2 | 8 | 32 | `32 / 54 = 59.26%` |
 
-请求 3 的 curve `[[1,2],[4,1]]` 直接读出：容量 2、3 命中 2 块（第二段 start=4 超出），容量 ≥ 4 与无限命中 3 块。对比正序提交（链头最老）：同一 trace 下容量 2 的累计命中会从 7 块跌到 2 块——这正是 2.2 所说的价值倒挂。
+Request 3's curve `[[1,2],[4,1]]` reads directly: capacity 2, 3 hits 2 blocks (the second segment start=4 exceeds), capacity ≥ 4 and infinite hit 3 blocks. Compared with forward-order submission (chain head oldest): under the same trace, the cumulative hits at capacity 2 would drop from 7 blocks to 2 blocks — this is exactly the value inversion mentioned in 2.2.
 
 ---
 
-## 11. 正确性验证
+## 11. Correctness Verification
 
-单元测试（`LiteHitTest` / `LiteHitOfflineRunnerTest`）覆盖：
+Unit tests (`LiteHitTest` / `LiteHitOfflineRunnerTest`) cover:
 
-1. **oracle 对拍**：契约输入（随机树状链 + `ApplyPrefixHash`）下，`ProjectBlocks` 与朴素多容量 LRU（快照评估 + 倒序逐块 touch）在容量 {0,1,2,4,9,∞} 上**完全一致**；
-2. 非契约输入投影 ≤ oracle（单调防御悲观、绝不乐观），无限容量仍精确；
-3. RLE 形态：整链重放单段、插队断段、相邻段不可合并；
-4. 投影边界：容量 0、段边界、字节 floor 换算；
-5. Offline facts 与 Online 逐请求投影交叉对账一致；并行度 4 与串行输出逐字节相同；
-6. fail-fast：乱序时间戳、未知 instance、长度违约、零有效行、分析粒度非 trace 粒度整数倍；
-7. prefix hash golden vector 与 Python 生产端逐 bit 一致；
-8. compaction 后所有 key 仍可命中（不丢历史）；
-9. 重分块：粗粒度采样 key / 尾部丢弃 / 只允许变粗；fanout 一次回放对多 block_size 各产出独立 facts，query summary 按 instance 分组。
+1. **oracle comparison**: under contract inputs (random tree-shaped chains + `ApplyPrefixHash`), `ProjectBlocks` is **exactly identical** to naive multi-capacity LRU (snapshot evaluation + reverse-order per-block touch) at capacities {0,1,2,4,9,∞};
+2. non-contract input projection ≤ oracle (monotonic defense is pessimistic, never optimistic), infinite capacity still exact;
+3. RLE shape: whole-chain replay single segment, queue-jump breaks segments, adjacent segments cannot be merged;
+4. projection boundaries: capacity 0, segment boundaries, byte floor conversion;
+5. Offline facts and Online per-request projection cross-reconcile consistently; parallelism 4 and serial output are byte-for-byte identical;
+6. fail-fast: out-of-order timestamps, unknown instance, length violation, zero valid rows, analysis granularity not an integer multiple of trace granularity;
+7. prefix hash golden vectors are bit-for-bit identical to the Python producer;
+8. after compaction all keys can still be hit (no history lost);
+9. re-blocking: coarse-granularity sampled keys / tail discard / only coarsening allowed; fanout produces independent facts for multiple block_size in a single replay, query summary grouped by instance.
 
 ---
 
-## 12. 核心结论
+## 12. Core Conclusions
 
 ```text
-多个（任意）容量的 LRU cache
-    ↓ LRU 栈包含性质
-一条全局最近访问顺序
+Multiple (arbitrary) capacity LRU caches
+    ↓ LRU stack inclusion property
+one global most-recent-access order
     ↓ Fenwick / order statistics
-每次访问的最小命中容量
-    ↓ 请求内 prefix max（契约下严格递增）
-等差段 RLE hit curve = 容量无关事实
-    ↓ HitCurveProjector（唯一投影入口，字节换算仅在此边界）
-任意容量的 prefix hit_blocks
+minimum hit capacity per access
+    ↓ in-request prefix max (strictly increasing under the contract)
+arithmetic-segment RLE hit curve = capacity-independent fact
+    ↓ HitCurveProjector (sole projection entry, byte conversion only at this boundary)
+prefix hit_blocks at arbitrary capacity
     ↓ block_size_tokens / input_token_len
-每条和累计 token 命中率
+per-request and cumulative token hit rate
 ```
 
-最容易混淆的三点：
+The three most easily confused points:
 
 ```text
-1. hit curve 是"事实"，容量是"查询"——核心与容量彻底解耦，
-   代价是不能做基于容量的剪枝。
-2. block_size_tokens 换 token，block_bytes 换容量，不能互相替代。
-3. 等差段 RLE 的无损性依赖前缀 hash 契约 + 倒序提交 + 等 charge；
-   混合 charge（linear/Mamba）必须另行设计。
+1. The hit curve is a "fact", capacity is a "query" — the core is completely decoupled from capacity,
+   at the cost of not being able to do capacity-based pruning.
+2. block_size_tokens converts tokens, block_bytes converts capacity; they cannot replace each other.
+3. The losslessness of arithmetic-segment RLE depends on the prefix hash contract + reverse-order submission + equal charge;
+   mixed charge (linear/Mamba) must be designed separately.
 ```

--- a/kv_cache_manager/optimizer/liteHit/README_zh.md
+++ b/kv_cache_manager/optimizer/liteHit/README_zh.md
@@ -1,0 +1,404 @@
+# LiteHit：一次回放产出容量无关事实，任意 LRU 容量事后投影
+
+> 中文 | [English](README.md)
+
+LiteHit 是面向 full-attention KVCache block 的轻量、精确 LRU 命中率分析器。核心只回放一次 trace，为每条请求产出**容量无关的事实**（`RequestFact`，一条等差段 RLE 编码的 hit curve）；任何容量的命中数都由无状态投影器 `HitCurveProjector` 事后从事实推出，核心从不接收容量列表，也不累计任何逐容量结果。
+
+LiteHit 要解决的问题是：
+
+```text
+给定一组带请求边界的 block trace，
+如何只回放一次 trace，就能对"任意"LRU 容量精确回答：
+
+1. 每条请求的 prefix 命中块数；
+2. 整段 trace 的累计 prefix 命中率。
+
+容量不再需要在分析开始前给定。
+```
+
+第一阶段只支持以下模型：
+
+- full attention；
+- 每个完整 block 的 KVCache charge 相同（等 charge，见 6.4）；
+- 精确 LRU，请求内倒序提交；
+- 不处理 linear attention / Mamba、不同大小 block、admission、prefetch 和多级缓存策略；TTL 支持为"每组一个固定 TTL"叠加在 LRU 之上（见 §7 TTL 回放），不支持任意 TTL 的查询期扫描。
+
+## 0. 架构总览
+
+```text
+                 ┌────────────────────────────────────────────┐
+   原始请求      │ 共享预处理 request_preprocess               │
+ (keys,len) ───> │  NormalizeRequest：长度校验/推导 +          │
+                 │  可选 ApplyPrefixHash（前缀链式 hash）      │
+                 └───────────────┬────────────────────────────┘
+                                 │ NormalizedRequest
+                 ┌───────────────▼────────────────────────────┐
+                 │ LiteHit 核心（容量无关）                     │
+                 │  ProcessRequest(block_keys) → RequestFact   │
+                 │  状态：Fenwick + last_positions             │
+                 └───────┬───────────────────────┬────────────┘
+                         │ RequestFact           │ RequestFact
+            Online 路径  │                       │  Offline 路径
+                 ┌───────▼────────┐      ┌───────▼─────────────┐
+                 │ HitCurveProjector│    │ facts CSV            │
+                 │ 逐 slot 投影 +   │    │ litehit_facts.csv    │
+                 │ 累计整数         │    │ (原子发布)           │
+                 └────────────────┘      └───────┬─────────────┘
+                                                 │ 任意时刻、任意容量
+                                         ┌───────▼─────────────┐
+                                         │ facts query 工具     │
+                                         │ HitCurveProjector    │
+                                         └─────────────────────┘
+```
+
+三个不可违反的分层约束：
+
+1. **核心容量无关**：`LiteHit::ProcessRequest` 只接收 block key，返回 `RequestFact`；不存在容量参数。
+2. **投影唯一入口**：所有"容量 → 命中块数"的换算必须经过 `HitCurveProjector`，Online 与 facts query 共用同一实现，禁止任何组件自行实现边界逻辑。
+3. **字节换算只发生在投影边界**：核心与事实全部以 block 为单位；`ProjectBytes` 在投影时用 `block_bytes` 做一次 floor 除法。
+
+---
+
+## 1. 输入模型与共享预处理
+
+### 1.1 每条请求
+
+每条请求向预处理层提供：
+
+```text
+block_keys[]            按请求从前到后排列的完整 block key（或原始逐块 hash）
+input_token_len         原始请求的 input token 数
+```
+
+`NormalizeRequest(block_keys, input_token_len, block_size_tokens, enable_prefix_hash, trace_block_size_tokens = 0)`：
+
+- `trace_block_size_tokens` 是 trace 原生 block 粒度（0 = 与 `block_size_tokens` 相同，不重分块）；长度校验发生在 trace 粒度：
+  `block_keys.size() == floor(input_token_len / trace_block_size_tokens)`；
+- `input_token_len > 0` 时为权威分母；`input_token_len <= 0` 视为缺省，按 `block_keys.size() * trace_block_size_tokens` 推导；
+- 违反约束（含 `block_size_tokens` 不是 `trace_block_size_tokens` 的整数倍——只允许变粗）抛 `std::invalid_argument`（Offline 对此 fail-fast，见第 7 节）。
+
+不足一个完整 block 的尾部 token 不进入 LRU，但保留在命中率分母中。
+
+### 1.1a 重分块（re-blocking）：零重 hash 的粒度变粗
+
+分析粒度粗于 trace 粒度时（`block_size_tokens = k * trace_block_size_tokens`，k > 1），无需重算任何 hash：前缀链式 key 的第 `j*k` 个恰好编码了前 j 个粗 block 的全部 token，因此**先做前缀链（若输入是逐块 hash）、再每 k 个取第 k 个**即得到粗粒度下合法的前缀链式 key，凑不满 k 个细块的尾部丢弃（其 token 留在分母中）。只允许变粗——变细需要 block 内部的 token 信息，trace 中不存在。
+
+### 1.2 block key 契约：前缀链式 hash
+
+full-attention 下 block j 的 KVCache 依赖请求前 j 个 block 的全部 token，因此 key 必须编码整个前缀：
+
+```text
+key_j = hash(请求前 j 个完整 block 的全部 token)
+```
+
+key 相等当且仅当整个 token 前缀完全相同。合法的 trace 形态是"共享前缀 + 分叉"，例如 `[A, B, C]` 与 `[A, B, D]` 共享前两个 block；`[B, A, C]` 这类重排序列在契约下不可能出现。
+
+当输入是逐块独立 hash 时，在 **Instance Group** 上置 `enable_prefix_hash = true`（key 形态跟模型部署走，group 正是这个粒度；online 建组 RPC 与 offline 配置共用同一字段），预处理用滚动 hash 把它转成前缀链式 key：
+
+```text
+PrefixHashNext(prev, raw)：Jenkins 64 位变体，显式 uint64 运算（逻辑右移），
+与 Python 生产端 prefix_hash.py::hash_int64_func 逐 bit 一致。
+注意：有意不复用 HashUtil::HashIntFunc（有符号右移，负 hash 时结果分歧）。
+```
+
+契约的两个推论（第 5 节会用到）：
+
+```text
+1. 同一请求内 key 必然互不相同（每个 key 编码严格递增的前缀）。
+2. 请求内首个 cold block 之后，后续 key 的前缀都包含分歧点，必然也 cold。
+```
+
+---
+
+## 2. 命中语义：prefix hit + 倒序提交
+
+### 2.1 prefix hit
+
+full-attention 请求采用 prefix hit：对某个容量，一条请求的命中块数是从请求第一个 block 开始连续命中的完整 block 数，即首个 miss 的位置。首个 miss 只截断本条请求的命中，不停止 LRU 状态更新——所有完整 block 仍然全部提交，否则后续请求看到的缓存状态会错误。
+
+提交不区分 hit / miss 的物理依据是：真实 prefix cache 里 miss 的 block 会被重算并**写回**缓存，写入本身就是一次 touch——请求结束后无论命中与否，block 都在 MRU 端。于是"LRU 更新"与"命中判定"天然解耦（Mattson 栈算法性质）：命中判定依赖容量，推迟到投影层；LRU 更新不依赖容量，核心无条件把所有 block 提交到位置末尾。这也意味着若 trace 带 output（decode 生成的新 block），同一机制可按**读写分离**扩展：output block 不参与阶段一的命中评估（新生成的块谈不上命中），照常参与阶段二提交进入 LRU，供后续请求命中。
+
+### 2.2 状态提交按请求倒序（尾先、头后）
+
+正序 touch 会让链头最老、最先被驱逐——对 prefix 语义这是**价值倒挂**：没有链头，链上其余 resident block 一个 prefix hit 都贡献不了，却还占着容量。生产 prefix cache 全部选择尾先驱逐：vLLM 按逆序把 block 放回 free 队列，SGLang radix cache 只驱逐 LRU 叶子。
+
+倒序提交配合 1.2 的前缀 hash 契约，给出不变式：
+
+```text
+父 key 永远比它的任何 resident 后代更新
+    ⇒ 全局 LRU 的驱逐牺牲者永远是叶子
+    ⇒ 倒序提交的 LRU 等价于"驱逐最久未用的叶子"
+```
+
+且全局顺序仍由访问序列唯一决定、与容量无关——栈包含性质保持（第 3 节）。
+
+实现分两阶段：**阶段一**基于请求到达前的只读 LRU 快照计算 hit curve（首个 miss 前只有 hit，hit 改变顺序但不改变成员集合，快照评估精确）；**阶段二**按"每个 key 的首次出现位置、从请求尾部向头部"批量提交，对含重复 key 的输入也与倒序逐块 touch 等价（契约下请求内无重复 key，该去重是防御行为）。
+
+---
+
+## 3. 为什么一个 LRU 状态可以回答所有容量
+
+LRU 具有栈包含性质。假设当前全局最近访问顺序是：
+
+```text
+MRU → [X, A, Y, B] → LRU
+```
+
+那么容量 1/2/3/4 的缓存内容分别是这条顺序的前 1/2/3/4 个元素。block `B` 位于第 4 位，则它在容量 1、2、3 下 miss，容量 ≥ 4 命中。因此一次访问只需要知道 block 在全局 LRU 顺序中的深度，就能同时回答所有容量——这正是"容量无关事实"可行的根源。
+
+---
+
+## 4. Reuse distance 与 Fenwick
+
+对一次重复访问：
+
+```text
+reuse distance d = 上次访问之后、这次访问之前出现过的不同 block 数
+required_capacity = d + 1        （容量 C 命中 ⇔ C >= d + 1）
+```
+
+第一次出现的 block 是 cold miss，没有有限的 required_capacity；无限容量也不能命中 cold access。
+
+LiteHit 为每个 block 只保留最新访问位置 `last[key]`，Fenwick 的逻辑数组在"某 block 的最新位置"处为 1、历史旧位置处为 0：
+
+```text
+d = Fenwick.sum(i - 1) - Fenwick.sum(prev)     // (prev, i) 内仍为 1 的位置数
+随后 Fenwick.add(prev, -1)、Fenwick.add(i, +1)、last[key] = i
+```
+
+Fenwick 不是一套缓存，只是全局 LRU 顺序的 order-statistics 表示。当历史废弃位置超过活跃 key 数的一倍加上固定 slack 时，实现会重建位置空间（compaction），使 Fenwick 空间由当前活跃 key 数而不是历史访问总数主导——注意这只回收**位置**，不删除任何 key（见第 9 节）。
+
+---
+
+## 5. RequestFact：等差段 RLE 编码的 hit curve
+
+### 5.1 从逐块门槛到 hit curve
+
+设一条请求各 block 基于快照的最小命中容量是 `required = [r1, ..., rm]`（cold 截断于首个无穷）。要让前 j 个 block 连续命中，容量必须满足前面所有 block：
+
+```text
+prefix_required[j] = max(r1, ..., rj)
+```
+
+序列 `prefix_required[1..h]`（h 为 cold 截断前的长度）就完整决定了该请求在**一切容量**下的命中块数：
+
+```text
+hit_blocks(C) = |{ j : prefix_required[j] <= C }|
+```
+
+这条单调阶梯函数就是本请求的 **hit curve**——它就是这条请求的全部事实。
+
+### 5.2 契约下门槛严格递增 ⇒ 等差段 RLE 无损
+
+倒序提交下链上后块的最小命中容量**严格大于**前块（每深一块，快照区间内至少多出它的父 key），因此契约输入的 `prefix_required` 严格递增。更强的结构性质是：链上相邻 block 在全局 LRU 中占据**连续**位置，门槛只在"插队"点（兄弟分支交错进来的位置）跳变。于是把连续 `+1` 的门槛压成一个等差段：
+
+```text
+HitCurveSegment { start_required_blocks, run_length }
+段内第 j 个 block（0-based）在容量 >= start + j 时成为 prefix hit。
+段数 = 1 + 插队次数，与请求长度无关。
+```
+
+例如门槛 `[1, 2, 3]`（无人插队的整链重放）编码为一段 `{1, 3}`；门槛 `[1, 2, 4]`（第三块前被插了一队）编码为 `{1, 2}, {4, 1}`。相邻段之间必有至少 1 的门槛空隙，不可再合并。
+
+### 5.3 非契约输入的单调防御
+
+对不满足契约的输入（请求内重复 key 等），门槛可能不严格递增。编码时施加单调防御：
+
+```text
+encoded_threshold = max(prefix_required[j], last_encoded + 1)
+```
+
+契约输入下该防御恒为 no-op；非契约输入下它只会把门槛**抬高**（悲观、绝不乐观），投影结果是真实命中的下界。
+
+### 5.4 HitCurveProjector
+
+```cpp
+ProjectBlocks(fact, capacity_blocks)   // 沿段线性扫描：
+                                       // hits += min(run_length, C - start + 1)，直到 start > C
+ProjectBytes(fact, capacity_bytes, block_bytes)
+                                       // = ProjectBlocks(fact, floor(bytes / block_bytes))
+ProjectInfinite(fact)                  // = Σ run_length（无 capacity miss，仅 cold miss）
+```
+
+空 curve 表示请求头即 cold，任何容量命中为 0。
+
+---
+
+## 6. 单位与换算
+
+### 6.1 两个大小，用途不同
+
+| 名称 | 单位 | 用途 |
+|---|---:|---|
+| `block_size_tokens` | token/block | 将命中块数换算成命中 token 数 |
+| `block_bytes` | byte/block | 将字节容量换算成 block 容量（仅投影边界） |
+
+### 6.2 token 命中率
+
+```text
+hit_tokens = hit_blocks * block_size_tokens
+trace_hit_rate = hit_tokens / input_token_len
+```
+
+尾部不完整 token 在分母中，因此全命中也未必 100%。累计命中率必须先累加整数分子分母（`Σ hit_tokens / Σ input_token_len`），不能对每条请求命中率做算术平均。
+
+### 6.3 字节容量换算
+
+```text
+capacity_blocks = floor(capacity_bytes / block_bytes)
+capacity_gb 使用二进制换算：capacity_bytes = capacity_gb * 1024^3
+```
+
+`block_bytes` 来自实例注册的 full location spec group 各 spec.size 之和（`size_full_only`）。facts CSV 每行记录 `block_bytes`，事实自描述：即使日后修正 charge 估计，也能对历史事实重投影。
+
+### 6.4 等 charge 不变量（block 单位 RLE 的前提）
+
+hit curve 以 block 为单位、`ProjectBytes` 做单一 floor 除法，**当且仅当**所有参与块 charge 完全相等才精确——full-only 实例满足（每块 charge 恒为 `size_full_only`，是精确值不是平均值）。linear/Mamba 混合实例每块 charge 不等，必须改用 charge 加权门槛，属于后续独立任务；当前 Offline 拒绝 `linear_step != 0` 的实例。
+
+---
+
+## 7. Offline facts 流水线
+
+Offline runner（`lite_hit_main` + `OptimizerLiteHitConfig`）逐批处理标准 trace：
+
+```text
+批窗口 = pipeline_worker_count * 256 条
+  ├─ 并行预处理（按下标条带分配 worker）：解析 + NormalizeRequest + prefix hash
+  ├─ 按 instance 分 lane，lane 内严格按输入顺序串行 ProcessRequest
+  └─ 按输入顺序串行写出 facts 行
+```
+
+**trace 粒度与重分块**：配置字段 `block_size`（默认 256）声明 trace 的原生 block 粒度；每个 instance 的 `block_size` 是该 lane 的分析粒度，必须是它的整数倍（只允许变粗，违约在 lane 初始化时整体失败），按 1.1a 的采样方式重分块。
+
+**写事件**：`write` trace 事件会被识别并忽略。`get` 提交时视为全部 block 已写回（§2 的物理依据：写回本身就是一次 touch），因此拆分的 `get`/`write` trace 中的 `write` 行对 facts 无影响；delayed write 建模只属于 replay 路径。
+
+**fanout 模式**：`fanout_all_instances = true` 时每条请求广播到全部 lane（各 lane 独立 LRU 状态、独立 facts 行），配合多个不同 `block_size` 的 instance 即可一次回放对同一份 trace 扫多个分析粒度；与 `override_instance_id` 互斥。facts query 的 summary 按 instance 分组输出（每 instance 一行 + 总计一行），fanout 结果直接可读。
+
+**TTL 回放**：instance group 配置 `ttl_seconds != 0` 时，该组 lane 的 `LiteHit` 核心叠加固定 TTL（与 online `TtlCacheIndexerWrapper` 语义一致：块在距上次访问严格小于 TTL 内存活，过期块对任意容量都是 miss 并像冷块一样截断前缀；每次访问（命中或未命中）都刷新 last_access；时间取 trace 时间戳，回放确定性）。年龄沿 LRU 栈单调，过期块不会抬高存活块的复用距离，因此一次回放对"固定 TTL × 任意容量"的联合口径仍然精确，facts 仍是普通 hit curve 行。TTL 是回放期参数，直接取组里的 `ttl_seconds`；要扫多个 TTL 就配多个 group 各带不同 `ttl_seconds`（可配合 fanout 一次回放完成）。
+
+**fail-fast**：时间戳乱序、未知 instance、长度校验失败、全文件零有效行，任一发生即整体失败并给出原因——facts 是全有或全无的对账账本，不允许静默丢行。
+
+**原子发布**：先写 `litehit_facts.csv.tmp`，全部成功后 `rename` 为 `litehit_facts.csv`；读者永远不会看到半成品。
+
+### 7.1 facts CSV 格式
+
+```text
+trace_id,instance_id,timestamp_ns,input_token_len,block_size_tokens,block_bytes,hit_curve
+```
+
+`hit_curve` 是带引号的 JSON 数组 `[[start_required_blocks, run_length], ...]`；字符串字段按 CSV 规则引用转义。每行独立可解析、自描述、可重投影。
+
+### 7.2 facts query 工具
+
+`lite_hit_facts_query_main`（`RunLiteHitFactsQuery`）对已发布的 facts 做事后容量查询：
+
+```text
+输入：facts CSV + capacity_gb 列表（保序、允许重复和 0，负数 = 无限容量）
+输出：JSONL，每请求一行（hit_blocks/hit_rates 按 slot）
+     + 每个 instance_id 一行 summary（instance_id 字典序）+ 一行总计 summary
+     （requests / total_input_tokens / total_hit_blocks / total_hit_tokens / hit_rates）
+```
+
+内存只有 O(instance 数 × 容量 slot 数) 个累计整数；任一畸形行使整个查询失败。
+
+---
+
+## 8. Online 集成
+
+Online Optimizer 的 full-attention `InstanceState` 直接持有 `LiteHit`（组配置 `ttl_seconds != 0` 时以墙钟时间叠加固定 TTL，口径与 linear 路径的 `TtlCacheIndexerWrapper` 一致）。每次 TraceQuery：
+
+```text
+NormalizeRequest → ProcessRequest → 得到 RequestFact
+  ├─ 对每个配置容量 slot：ProjectBlocks(fact, lite_hit_capacity_blocks[i])
+  ├─ 理论上界：ProjectInfinite(fact)
+  └─ 更新累计整数：total_queries / total_input_tokens / 各 slot total_hits
+```
+
+Online 不持久化 facts（facts 落盘当前是 Offline 专属）；`ListInstances` 的命中率从累计整数推导（`total_hits * block_size_tokens / total_input_tokens`）。linear attention 继续走 legacy indexer 路径（启用 prefix hash 时仅做 `ApplyPrefixHash`）。
+
+---
+
+## 9. 复杂度与状态量
+
+设 N = 总 block access 数，U = 历史不同 block 数，Q = 请求数，S = 单请求段数（= 1 + 插队次数）。
+
+```text
+ProcessRequest：O(m log U)（m 为请求块数）
+ProjectBlocks： O(S)，与容量值无关
+核心持久状态： Fenwick + last_positions，O(U)
+```
+
+**没有基于容量的剪枝**：容量事后才知道，任何 key 都可能被将来某个大容量查询用到，因此核心保留全部历史 unique key（这是容量无关性的固有代价）。第 4 节的 compaction 只回收废弃位置，不删除 key。`memory_usage_bytes()` / `current_unique_blocks()` 提供观测。
+
+---
+
+## 10. 端到端示例
+
+```text
+block_size_tokens = 4，block_bytes = 1024
+五条请求（满足前缀 hash 契约，[A,B,C] 与 [A,B,D] 共享前两块，[A,E] 一块后分叉）
+```
+
+| # | keys | len | 快照门槛 prefix_required | hit_curve (RLE) |
+|---|---|---:|---|---|
+| 1 | [A,B,C] | 13 | 全 cold | `[]` |
+| 2 | [A,B,D] | 12 | [1, 2]，D cold 截断 | `[[1,2]]` |
+| 3 | [A,B,C] | 13 | [1, 2, 4]（D 插队使 C 深度 4） | `[[1,2],[4,1]]` |
+| 4 | [A,E] | 8 | [1]，E cold 截断 | `[[1,1]]` |
+| 5 | [A,E] | 8 | [1, 2] | `[[1,2]]` |
+
+各请求结束后的 LRU 依次为 `[A,B,C]`、`[A,B,D,C]`、`[A,B,C,D]`、`[A,E,B,C,D]`、`[A,E,B,C,D]`。
+
+事后投影三个容量（2048 B → 2 块，3072 B → 3 块，无限）：
+
+| 容量 | 各请求 hit_blocks | 累计块 | 累计 token | 累计命中率 |
+|---:|---|---:|---:|---:|
+| 2 块 | 0,2,2,1,2 | 7 | 28 | `28 / 54 = 51.85%` |
+| 3 块 | 0,2,2,1,2 | 7 | 28 | `28 / 54 = 51.85%` |
+| ∞ | 0,2,3,1,2 | 8 | 32 | `32 / 54 = 59.26%` |
+
+请求 3 的 curve `[[1,2],[4,1]]` 直接读出：容量 2、3 命中 2 块（第二段 start=4 超出），容量 ≥ 4 与无限命中 3 块。对比正序提交（链头最老）：同一 trace 下容量 2 的累计命中会从 7 块跌到 2 块——这正是 2.2 所说的价值倒挂。
+
+---
+
+## 11. 正确性验证
+
+单元测试（`LiteHitTest` / `LiteHitOfflineRunnerTest`）覆盖：
+
+1. **oracle 对拍**：契约输入（随机树状链 + `ApplyPrefixHash`）下，`ProjectBlocks` 与朴素多容量 LRU（快照评估 + 倒序逐块 touch）在容量 {0,1,2,4,9,∞} 上**完全一致**；
+2. 非契约输入投影 ≤ oracle（单调防御悲观、绝不乐观），无限容量仍精确；
+3. RLE 形态：整链重放单段、插队断段、相邻段不可合并；
+4. 投影边界：容量 0、段边界、字节 floor 换算；
+5. Offline facts 与 Online 逐请求投影交叉对账一致；并行度 4 与串行输出逐字节相同；
+6. fail-fast：乱序时间戳、未知 instance、长度违约、零有效行、分析粒度非 trace 粒度整数倍；
+7. prefix hash golden vector 与 Python 生产端逐 bit 一致；
+8. compaction 后所有 key 仍可命中（不丢历史）；
+9. 重分块：粗粒度采样 key / 尾部丢弃 / 只允许变粗；fanout 一次回放对多 block_size 各产出独立 facts，query summary 按 instance 分组。
+
+---
+
+## 12. 核心结论
+
+```text
+多个（任意）容量的 LRU cache
+    ↓ LRU 栈包含性质
+一条全局最近访问顺序
+    ↓ Fenwick / order statistics
+每次访问的最小命中容量
+    ↓ 请求内 prefix max（契约下严格递增）
+等差段 RLE hit curve = 容量无关事实
+    ↓ HitCurveProjector（唯一投影入口，字节换算仅在此边界）
+任意容量的 prefix hit_blocks
+    ↓ block_size_tokens / input_token_len
+每条和累计 token 命中率
+```
+
+最容易混淆的三点：
+
+```text
+1. hit curve 是"事实"，容量是"查询"——核心与容量彻底解耦，
+   代价是不能做基于容量的剪枝。
+2. block_size_tokens 换 token，block_bytes 换容量，不能互相替代。
+3. 等差段 RLE 的无损性依赖前缀 hash 契约 + 倒序提交 + 等 charge；
+   混合 charge（linear/Mamba）必须另行设计。
+```

--- a/kv_cache_manager/optimizer/skills/README.md
+++ b/kv_cache_manager/optimizer/skills/README.md
@@ -1,0 +1,10 @@
+# Optimizer Skills
+
+These skills are task-level workflows. Pick a skill first, then read the deeper references it points to.
+
+| Skill | When to use |
+|---|---|
+| [getting-started](getting-started/SKILL.md) | Start from scratch: set up the environment, build the optimizer, run your first replay |
+| [liteHit](liteHit/SKILL.md) | Exact capacity-independent LRU hit-rate analysis for full-attention, required trace, multi block-size sweep, online service |
+
+Documentation entry point: [../README.md](../README.md).

--- a/kv_cache_manager/optimizer/skills/getting-started/SKILL.md
+++ b/kv_cache_manager/optimizer/skills/getting-started/SKILL.md
@@ -1,0 +1,79 @@
+# Getting Started with the Optimizer Skill
+
+Use this skill when a user is new to the optimizer and needs to set up the environment from scratch, build it, and run the first replay.
+
+## Required Components
+
+| Component | Purpose | How to get it |
+|---|---|---|
+| bazelisk | Build the C++ optimizer binaries | Install [bazelisk](https://github.com/bazelbuild/bazelisk); the repo pins the Bazel version via `.bazeliskrc` |
+| Python 3 + pip | Run the trace converter and analysis scripts | System-provided |
+| trace data | Replay input | Convert external logs to standard JSONL via the trace converter |
+| optimizer config | Describes instance groups / instances / capacity / policy | Hand-written JSON, see below |
+
+For full build details (Bazel cache, optional backends `--config=mooncake/vcns`), see [../../../../docs/develop/README.md](../../../../docs/develop/README.md).
+
+## Steps
+
+1. **Set up the environment**: confirm `bazelisk --version` works. All bazel commands must run inside the `github-opensource/` directory.
+
+2. **Build the binaries**:
+
+```bash
+# Offline replay main + analysis script entry
+bazel build \
+    //kv_cache_manager/optimizer:optimizer_main \
+    //kv_cache_manager/optimizer/analysis/script:optimizer_run
+
+# LiteHit multi-capacity analysis (optional, full-attention scenarios)
+bazel build \
+    //kv_cache_manager/optimizer:lite_hit_main \
+    //kv_cache_manager/optimizer:lite_hit_facts_query_main
+```
+
+3. **Prepare the trace**: use the standalone Python tool to convert external logs to standard JSONL (no bazel needed):
+
+```bash
+cd kv_cache_manager/optimizer/tools/trace_converter
+pip install -r requirements.txt
+python trace_converter.py \
+    -i /path/to/your_trace.log \
+    -o /path/to/optimizer_trace.jsonl \
+    -f publisher_log \
+    --mode optimizer
+```
+
+Supported formats and fields: [../../tools/trace_converter/README.md](../../tools/trace_converter/README.md).
+
+4. **Write the config**: a minimal usable config needs top-level `trace_file_path` / `output_result_path` / `eviction_params`, plus `instance_groups[]` (where `instances[].instance_id` must match the `instance_id` in the trace). Templates and field semantics: the "Quick Start" section of [../../README.md](../../README.md) and [../../docs/strategy_config.md](../../docs/strategy_config.md).
+
+5. **Run the first replay**:
+
+```bash
+bazel run //kv_cache_manager/optimizer/analysis/script:optimizer_run -- \
+    -c /path/to/config.json
+```
+
+Results land under `output_result_path` as `{instance_id}_hit_rates.csv`; the last row's `AccHitRate` is the cumulative token hit rate. Add `--draw-chart` for a time-series chart.
+
+6. **Going further**:
+   - Exact capacity-independent hit rate for full-attention → [liteHit skill](../liteHit/SKILL.md)
+   - Capacity Pareto / multi-policy comparison, RadixTree visualization, lifecycle analysis → [../../analysis/script/README.md](../../analysis/script/README.md)
+
+## Validation
+
+- `bazel build` produces the binaries with no compile errors.
+- Every trace line parses as JSON, is ordered by `timestamp_ns`, and `get/request` carry a positive `input_len`.
+- Every trace `instance_id` has a corresponding instance in the config.
+- The replay produces `*_hit_rates.csv` and the last row's `AccHitRate` is in `[0, 1]`.
+
+## Reply Content
+
+Report:
+
+- the built binaries / targets
+- trace and config paths
+- output directory and final token hit rate
+- any unfinished validation items
+
+Architecture and module overview: [../../docs/optimizer_architecture.md](../../docs/optimizer_architecture.md).

--- a/kv_cache_manager/optimizer/skills/liteHit/SKILL.md
+++ b/kv_cache_manager/optimizer/skills/liteHit/SKILL.md
@@ -1,0 +1,76 @@
+# LiteHit Usage Skill
+
+Use this skill when the analysis target is a full-attention prefix cache and any of the following holds:
+
+- The capacity assumption changes repeatedly (capacity is projected after the fact, without replaying the trace);
+- You need to sweep multiple block sizes over the same trace in a single replay;
+- You need an exact LRU prefix hit rate (not sampled, not approximate);
+- You need an online real-time hit rate (gRPC/HTTP service).
+
+## Required Trace
+
+LiteHit reuses the optimizer standard trace (JSONL, one record per line). Only read-request fields are needed; `write` events are recognized and ignored (a `get` submission is treated as all blocks written back):
+
+| Field | Requirement |
+|---|---|
+| `type` | `get` or `request` (`write` rows are ignored) |
+| `instance_id` | non-empty; must match an instance in the config (or be routed via `override_instance_id` / `fanout`) |
+| `timestamp_ns` | positive integer ns timestamp; the trace must be ordered by it (streaming replay assumption) |
+| `keys` | list of complete block keys, in one of two forms (see below) |
+| `input_len` | positive integer, original input token count; trailing tokens that do not fill a block stay out of `keys` but count in the denominator |
+
+The key form is one of:
+
+- **Prefix chained key**: `key_j = hash(all tokens of the first j complete blocks of the request)`; two keys are equal iff the entire token prefix is identical;
+- **Per-block raw hash**: enable `enable_prefix_hash` on the Instance Group, and preprocessing converts it into a prefix chained key via a rolling hash.
+
+Hard constraint: `len(keys) <= input_len // block_size`. For trace conversion and validation see [../../tools/trace_converter/README.md](../../tools/trace_converter/README.md); for the full schema see [../../docs/strategy_config.md](../../docs/strategy_config.md).
+
+## Inputs to Confirm
+
+- The trace's native block granularity (config `block_size`, default 256 token/block).
+- Each instance's analysis granularity (instance `block_size`, which must be an integer multiple of the trace granularity; only coarsening is allowed).
+- Key form: prefix chained key or per-block raw hash (enable `enable_prefix_hash` for the latter).
+- Routing: by trace `instance_id`, `override_instance_id` to aggregate into one service view, or `fanout_all_instances` to broadcast and sweep granularity (mutually exclusive with override).
+- location spec size (determines `block_bytes`, the anchor for capacity GB → block conversion).
+- The capacity list to query (GB; may contain duplicates and 0; negative = infinite; offline does not need it up front).
+
+## Offline Two-Step Flow
+
+```bash
+# Step 1: replay to produce facts (config has no capacity)
+bazel run //kv_cache_manager/optimizer:lite_hit_main -- /path/to/lite_hit_config.json
+# -> <output_result_path>/litehit_facts.csv (atomic publish, fail-fast all-or-nothing)
+
+# Step 2: project arbitrary capacities after the fact, repeatable (arg order: facts_csv output_log capacity_gb...)
+bazel run //kv_cache_manager/optimizer:lite_hit_facts_query_main -- \
+  /path/to/litehit_facts.csv /path/to/result.jsonl 10 50 100 -1
+```
+
+Multi block-size sweep: configure N instances with different `block_size` plus `fanout_all_instances: true`; a single replay produces independent facts per lane; the query summary is grouped by instance (one row per instance + one total row).
+
+## Online Service
+
+```bash
+bazel run //kv_cache_manager/optimizer:online_optimizer_server_main -- /path/to/server_config.json
+```
+
+On the engine side, use `client/` (Python gRPC/HTTP SDK): create group (capacity slots, `enable_prefix_hash`) → register instances → per-request TraceQuery → `ListInstances` for the cumulative hit rate.
+
+## Validation
+
+- The trace is ordered by `timestamp_ns`; `get/request` carry a positive `input_len`.
+- facts row count = number of valid read requests × (number of lanes under fanout).
+- query summary cumulative hit rate = `Σ hit_tokens / Σ input_tokens` (token metric, trailing tokens in the denominator).
+- Theoretical upper bound (infinite-capacity projection) ≥ all finite-capacity results.
+
+## Reply Content
+
+Report:
+
+- facts CSV path and row count
+- cumulative token hit rate per capacity (and per instance/block size)
+- theoretical upper-bound hit rate
+- any unfinished validation items
+
+Semantic details: [../../liteHit/README.md](../../liteHit/README.md).


### PR DESCRIPTION
## Summary

Provide English documentation for the optimizer tool (for external users) and add task-level usage skills.

## Changes

### 1. Bilingual optimizer docs (English as default)

- Add English versions of the four core optimizer docs as the default filenames:
  - `README.md`, `liteHit/README.md`, `docs/strategy_config.md`, `docs/optimizer_architecture.md`
- Rename the original Chinese docs to the `_zh` suffix:
  - `README_zh.md`, `liteHit/README_zh.md`, `docs/strategy_config_zh.md`, `docs/optimizer_architecture_zh.md`
- Add bidirectional language-switch links at the top of each doc.
- Internal cross-references updated: English docs link to default names, Chinese docs link to `_zh` names.

### 2. Optimizer skills

Add `optimizer/skills/` with task-level workflows:
- `getting-started/SKILL.md`: set up the environment, build the optimizer, run the first replay.
- `liteHit/SKILL.md`: LiteHit usage, required trace format, offline two-step flow, online service.
- `README.md`: skill index.

## Notes

- External reference docs (root `CLAUDE.md`, `docs/optimizer.md`, `tools/trace_converter/README.md`) are intentionally left unchanged; their links to `README.md` now resolve to the English default.
- Docs only; no code changes.
