### PR TITLE
[optimizer] add online MRC observation path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ### 设计文档
 - [模块架构与关联关系](design/module_architecture.md) - 各模块职责、依赖方向、控制流与数据流，附 Mermaid 图
 - [基本概念](design/basic_concepts.md) - Storage、Instance Group、Instance、Block、CacheLocation 等核心概念
+- [ReportEvent 元数据一致性与 Location 索引设计](design/report_event_metadata_consistency.md) - Subscriber 上报、CacheMeta 持久化、location 反向索引与不一致处理
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 
 ### 开发文档

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -111,10 +111,17 @@ engine-specific cache signals into block-level events:
   `EVENT_BLOCK_DELETE`, and full-clear snapshots.
 
 `storage_type` identifies the storage/cache system, such as Vineyard/V6D.
-`location` identifies one diffable location namespace under the reporting host.
-Use `location.labels` when one host has multiple independent cache groups, such
-as vLLM `dp_rank` or `group_idx`. `specs` describes the concrete address of the
-block in that namespace.
+`medium` identifies one diffable cache namespace under the reporting host.
+`specs` describes the concrete address of the block in that namespace.
+Subscribers should encode component identity in `LocationSpec.name`, for
+example `full_attention:group=0:tp=0` or `mamba_state:group=1`. KVCM currently
+stores and matches only full-attention specs; mamba-state specs are accepted but
+ignored until fine-grained hybrid-cache matching is implemented. Legacy spec
+names such as `tp0` are treated as full-attention for compatibility.
+For `EVENT_BLOCK_SNAPSHOT`, the diff scope is the reporter `host_ip_port` plus
+`medium` after mamba-state specs are filtered. If an engine has multiple
+full-attention groups for one block, report them as multiple `LocationSpec`
+entries on the same `BlockSnapshotItem`.
 
 ```bash
 curl -g -vvv -X POST http://localhost:6382/api/reportEvent \
@@ -135,19 +142,13 @@ curl -g -vvv -X POST http://localhost:6382/api/reportEvent \
       {
         "event_type": "EVENT_BLOCK_SNAPSHOT",
         "block_snapshot": {
-          "location": {
-            "medium": "gpu",
-            "labels": {
-              "dp_rank": "0",
-              "group_idx": "1"
-            }
-          },
+          "medium": "gpu",
           "blocks": [
             {
               "block_key": "123",
               "specs": [
                 {
-                  "name": "tp0",
+                  "name": "full_attention:group=0:tp=0",
                   "uri": "vineyard://192.168.2.1/gpu/123?size=4096"
                 }
               ]

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -101,6 +101,64 @@ curl -g -vvv -X POST http://localhost:6382/api/removeCache \
 }'
 ```
 
+## Report Event
+
+`reportEvent` is the cache-subscriber ingestion API. A subscriber normalizes
+engine-specific cache signals into block-level events:
+
+- RTP-LLM subscriber: report full host/location snapshots with `EVENT_BLOCK_SNAPSHOT`.
+- vLLM subscriber: map KV events to ordered `EVENT_BLOCK_ADD`,
+  `EVENT_BLOCK_DELETE`, and full-clear snapshots.
+
+`storage_type` identifies the storage/cache system, such as Vineyard/V6D.
+`location` identifies one diffable location namespace under the reporting host.
+Use `location.labels` when one host has multiple independent cache groups, such
+as vLLM `dp_rank` or `group_idx`. `specs` describes the concrete address of the
+block in that namespace.
+
+```bash
+curl -g -vvv -X POST http://localhost:6382/api/reportEvent \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "trace_id": "trace_id_131",
+    "instance_id": "test_instance",
+    "host_ip_port": "192.168.2.1:8080",
+    "storage_type": "ST_VINEYARD",
+    "events": [
+      {
+        "event_type": "EVENT_NODE_REGISTER",
+        "node_register": {
+          "mediums": ["gpu"]
+        }
+      },
+      {
+        "event_type": "EVENT_BLOCK_SNAPSHOT",
+        "block_snapshot": {
+          "location": {
+            "medium": "gpu",
+            "labels": {
+              "dp_rank": "0",
+              "group_idx": "1"
+            }
+          },
+          "blocks": [
+            {
+              "block_key": "123",
+              "specs": [
+                {
+                  "name": "tp0",
+                  "uri": "vineyard://192.168.2.1/gpu/123?size=4096"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+}'
+```
+
 ## Trim Cache
 ```bash
 curl -g -vvv -X POST http://localhost:6382/api/trimCache \

--- a/docs/api/meta_service.md
+++ b/docs/api/meta_service.md
@@ -121,7 +121,10 @@ names such as `tp0` are treated as full-attention for compatibility.
 For `EVENT_BLOCK_SNAPSHOT`, the diff scope is the reporter `host_ip_port` plus
 `medium` after mamba-state specs are filtered. If an engine has multiple
 full-attention groups for one block, report them as multiple `LocationSpec`
-entries on the same `BlockSnapshotItem`.
+entries on the same `BlockSnapshotItem`. Snapshot reconciliation verifies
+existing CacheMeta candidates against full-attention specs before deleting
+blocks, so mamba-state-only metadata is not removed by the current full-attention
+matching path.
 
 ```bash
 curl -g -vvv -X POST http://localhost:6382/api/reportEvent \

--- a/docs/design/module_architecture.md
+++ b/docs/design/module_architecture.md
@@ -4,7 +4,7 @@
 
 > **维护提示**：当模块的职责、依赖方向或调用关系发生变化，或新增/删除模块时，请同步更新本文档与文末的 Mermaid 图，并同步更新 [AGENTS.md](../../AGENTS.md) 中的缩略图。
 
-相关文档：[基本概念](basic_concepts.md)、[高可用与选主机制](ha_leader_elector.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
+相关文档：[基本概念](basic_concepts.md)、[ReportEvent 元数据一致性与 Location 索引设计](report_event_metadata_consistency.md)、[高可用与选主机制](ha_leader_elector.md)、[配置指南](../configuration.md)、[优化器文档](../optimizer.md)。
 
 ---
 

--- a/docs/design/report_event_metadata_consistency.md
+++ b/docs/design/report_event_metadata_consistency.md
@@ -1,0 +1,277 @@
+# ReportEvent 元数据一致性与 Location 索引设计
+
+## 1. 背景
+
+`ReportEvent` 用于接收外部 subscriber 上报的 KVCache 事件。KVCM 不主动连接所有推理 Worker，而是由 RTP-LLM、vLLM、V6D 等侧的 subscriber 将本地 cache 变化归一化成 block 级事件，上报给 KVCM。
+
+其中 `EVENT_BLOCK_SNAPSHOT` 是一个按 location 做全量对账的事件：subscriber 上报某个 `host_ip_port + medium` 当前完整拥有的 block 集合，KVCM 需要和自己已有的元数据做 diff，补齐新增 block，并删除已经不在该 location 上的 block。
+
+如果每次 snapshot diff 都从 Redis 全量扫描所有 CacheMeta，再筛选目标 location，会带来几个问题：
+
+- 请求路径延迟不可控，block 数量增长后会直接影响 subscriber 上报。
+- `SCAN` 不是一致性快照，并发写入/删除时可能重复或遗漏。
+- 多 KVCM 进程各自扫描重建内存索引，浪费 Redis 和 KVCM 资源。
+- 依赖 meta backend 支持全量 scan，不利于抽象和后续替换 backend。
+
+因此 snapshot diff 需要一份可持久化、跨 KVCM 共享的 `location_id -> block_key` 二级索引。同时，二级索引不能成为新的事实来源，读链路必须显式处理索引与 CacheMeta 不一致的情况。
+
+## 2. 目标与非目标
+
+### 目标
+
+- `ReportEvent` 写入的 block cache 信息仍然存入普通 CacheMeta，和现有查询链路复用同一份元数据。
+- 为 `EVENT_BLOCK_SNAPSHOT` 提供持久化的 location 反向索引，避免请求路径全库扫描。
+- 读链路容忍索引和 CacheMeta 的短暂不一致，不因索引脏数据误删或误命中。
+- 写链路通过顺序设计，让新写入尽量只产生 over-index，不产生新的 under-index。
+- 支持 RTP-LLM full snapshot 和 vLLM KV events 两类 subscriber。
+
+### 非目标
+
+- 不让 KVCM 主动拉取所有 Worker 的 cache 状态。
+- 不把 location 反向索引暴露成用户查询接口。
+- 当前不实现 mamba-state 的精细匹配。接口接收相关 `LocationSpec.name`，但存储和匹配仍只处理 full-attention。
+- 不要求所有 meta backend 一开始都支持原子多 key 事务；Redis 后端优先实现强一些的一致性语义，其他 backend 可以先实现同接口的最佳努力版本。
+
+## 3. 核心概念
+
+### CacheMeta
+
+CacheMeta 是唯一事实来源，结构仍然是：
+
+```text
+instance_id + block_key -> CacheLocationMap
+```
+
+每个 `CacheLocation` 包含：
+
+- `location_id`
+- `storage_type`
+- `status`
+- `LocationSpec[]`
+
+`GetCacheMeta` / `GetCacheLocation` 等查询接口只信任 CacheMeta，不直接使用 location 反向索引。
+
+### Location
+
+`ReportEvent` 的 diff scope 是一个 location。location 由 event backend 根据 `host_ip_port + medium` 构造，例如 V6D 可构造为：
+
+```text
+kvs#v6d#{medium}#{host_ip_port}
+```
+
+`storage_type` 表示大的存储系统，比如 Vineyard/V6D；`medium` 表示该 host 下可独立 diff 的位置，比如 `gpu`、`mem`、`disk`。更细粒度的 full-attention group、TP、mamba-state 等信息放在 `LocationSpec.name` 中。
+
+### Location 反向索引
+
+二级索引用于加速 snapshot diff：
+
+```text
+instance_id + location_id -> set(block_key)
+```
+
+它是 CacheMeta 的派生索引，不是事实来源。索引允许短暂 over-index：索引里有某个 block_key，但 CacheMeta 中没有对应 location。读链路会过滤这类脏数据，并异步或顺手修复索引。
+
+索引不应产生新的 under-index：CacheMeta 中已有某个 location，但索引缺少该 block_key。under-index 会导致 snapshot diff 找不到应删除的旧 block，读路径无法在不扫描全量 CacheMeta 的情况下完全发现它。因此写路径要通过顺序和失败处理避免新 under-index。
+
+## 4. 持久化模型
+
+建议在 meta 层增加独立抽象，例如：
+
+```cpp
+class LocationKeyIndexBackend {
+public:
+    virtual ErrorCode AddKeys(RequestContext*, const std::string& location_id,
+                              const KeyVector& keys) = 0;
+    virtual ErrorCode RemoveKeys(RequestContext*, const std::string& location_id,
+                                 const KeyVector& keys) = 0;
+    virtual ErrorCode GetKeys(RequestContext*, const std::string& location_id,
+                              KeyVector& out_keys) = 0;
+};
+```
+
+也可以把这组接口挂到 `MetaStorageBackend` 上，前提是不要把索引逻辑散落在 `CacheManager`。`CacheManager` 只表达业务语义：上报 add/delete/snapshot；`MetaSearcher` 负责 CacheMeta 与二级索引的一致性维护。
+
+Redis 后端可以使用 set 存储：
+
+```text
+{meta_prefix}:locidx:{hash(location_id)}:{shard_id} -> SET(block_key)
+```
+
+是否分 shard 由单 location 的 block 数决定。初版可以先用单 set，但接口要保留 shard 能力，避免后续改调用层。
+
+## 5. 写路径设计
+
+### 5.1 Add / Upsert
+
+Add 或 upsert 某个 `block_key -> location_id` 时，顺序应为：
+
+1. 先把 `block_key` 加入 location 反向索引。
+2. 再写入或更新 CacheMeta。
+3. 如果索引写失败，则不写 CacheMeta，并返回该 item 失败。
+4. 如果索引写成功但 CacheMeta 写失败，允许留下 over-index。
+
+这样最坏情况是索引里多了一个 key。后续 snapshot 读索引时会 BatchGet CacheMeta 过滤，发现该 key 并没有对应 location 后可以清理索引。更重要的是，成功写入 CacheMeta 的 location 基本不会缺少反向索引。
+
+### 5.2 Delete
+
+Delete 某个 `block_key -> location_id` 时，顺序应为：
+
+1. 先从 CacheMeta 删除该 location。
+2. 再从 location 反向索引删除该 `block_key`。
+3. CacheMeta 删除失败则返回失败，不删除索引。
+4. CacheMeta 确认删除成功后，再删除索引；如果索引删除失败，允许留下 over-index。
+5. 如果 CacheMeta 返回 `EC_NOENT`，请求热路径不急于删除索引，避免和并发 add-before-meta 形成竞态。此时留下的 over-index 由读路径过滤，后续离线 repair 处理。
+
+这个顺序同样保证失败后最多是 over-index，而不是 CacheMeta 仍有 location 但索引已经丢失。
+
+### 5.3 RemoveCache / HostDown / Reclaimer
+
+所有会删除 CacheMeta 的路径都必须维护 location 反向索引，包括：
+
+- `ReportEvent(EVENT_BLOCK_DELETE)`
+- `ReportEvent(EVENT_BLOCK_SNAPSHOT)` diff 出来的删除
+- `HOST_DOWN` 触发的 host location 清理
+- `RemoveCache`
+- reclaimer 删除
+
+这些路径如果能在删除前读到旧 `CacheLocationMap`，应先记录要删除的 `location_id` 列表，再按“先删 CacheMeta，后删索引”的顺序执行。
+
+### 5.4 Snapshot
+
+`EVENT_BLOCK_SNAPSHOT` 的单 location 对账流程：
+
+1. 读取该 location 的反向索引，得到 candidate keys。
+2. 对 candidate keys 做 `BatchGetLocation`。
+3. 只保留 CacheMeta 中仍然包含该 `location_id` 且状态可服务的 keys，得到 `existing_keys`。
+4. 对于索引有但 CacheMeta 不再包含该 location 的 keys，记录为 stale index；热路径只过滤，不立即删除索引。
+5. 从上报 payload 得到 `reported_keys`。
+6. `to_add = reported_keys - existing_keys`。
+7. `to_delete = existing_keys - reported_keys`。
+8. 对 `to_add` 走 Add / Upsert 顺序。
+9. 对 `to_delete` 走 Delete 顺序。
+
+重要约束：snapshot 只能删除 `existing_keys - reported_keys`，不能删除“索引中存在但 CacheMeta 未确认存在”的 key，也不能根据索引直接判断某个 key 有效。
+
+## 6. 读路径不一致处理
+
+### 6.1 Snapshot Diff 读索引
+
+索引读取结果必须经过 CacheMeta 二次确认。伪代码：
+
+```text
+candidate_keys = LocationIndex.GetKeys(location_id)
+location_maps = BatchGetLocation(candidate_keys)
+
+existing_keys = {}
+stale_index_keys = {}
+
+for key, location_map in zip(candidate_keys, location_maps):
+    if location_map contains location_id and location is serving/full-attention:
+        existing_keys.add(key)
+    else:
+        stale_index_keys.add(key)
+
+record stale_index_keys for metrics / delayed repair
+```
+
+这样 over-index 不会造成误删，也不会让不存在的 cache 被当成命中。不要在这个同步读路径里立刻删除 stale index，因为 add 写路径是先写 index 再写 CacheMeta；如果此时把刚写入的 index 当作 stale 删除，后续 CacheMeta 写成功后反而会制造 under-index。
+
+### 6.2 正常 Cache 查询
+
+`GetCacheMeta` / `GetCacheLocation` 不读 location 反向索引，仍从 CacheMeta 读取 block 对应的 `CacheLocationMap`，并按现有规则过滤：
+
+- instance 隔离
+- `CacheLocationStatus`
+- `DataStorageType`
+- `LocationSpec.name`
+- full-attention / mamba-state 兼容策略
+
+因此索引 over-index 不影响正常 cache 命中。
+
+### 6.3 Under-index 的处理
+
+under-index 是需要重点避免的状态。因为如果 CacheMeta 中存在 `location_id`，但 location 索引缺少该 key，则 snapshot diff 无法发现这个旧 key，自然也无法在该 key 未上报时删除它。
+
+设计上应把 under-index 作为异常状态处理：
+
+- 新写路径通过 add-before-meta、delete-after-meta 避免产生新的 under-index。
+- Redis 后端可以用 Lua 或 pipeline + 幂等重试进一步收敛失败窗口。
+- 启动时不在请求路径全量扫描重建索引。
+- 提供低优先级 repair job 或运维工具，对历史数据和异常状态做离线校验：扫描 CacheMeta，重建/补齐 location 索引，并输出修复指标。
+- 对 snapshot diff 暴露指标：candidate 数、stale index 数、reported 数、add 数、delete 数、repair 失败数。如果 stale index 或 repair 失败持续升高，应告警。
+
+换句话说：读路径要容忍 over-index；under-index 不能靠普通读路径完全修复，只能靠写路径不制造、离线 repair 兜底。
+
+## 7. RTP-LLM 与 vLLM 接入
+
+### RTP-LLM
+
+RTP-LLM subscriber 可以继续使用现有本地 cache 状态采集方式，但对 KVCM 上报时应转换为：
+
+- `EVENT_NODE_REGISTER`：注册 host 和可上报 medium。
+- `EVENT_HEARTBEAT`：汇报活性和观测指标。
+- `EVENT_BLOCK_SNAPSHOT`：按 `host_ip_port + medium` 汇报该 location 的完整 block 集合。
+
+RTP-LLM 的 full snapshot 是 authoritative input，但 KVCM 仍只删除 CacheMeta 二次确认后存在于该 location 的 keys。
+
+### vLLM
+
+vLLM KV events 可以转换为：
+
+- block 创建或变为可服务：`EVENT_BLOCK_ADD`
+- block 删除：`EVENT_BLOCK_DELETE`
+- worker 清空或重建本地 cache：空或完整 `EVENT_BLOCK_SNAPSHOT`
+
+vLLM 上报的 group id、attention 类型、TP 等信息放入 `LocationSpec.name`。当前 KVCM 存储和匹配 full-attention；mamba-state spec 可以上报，但会被过滤掉，后续再扩展精细匹配。
+
+### V6D / 本地显存混合位置
+
+`storage_type` 仍表示大的存储系统，例如 Vineyard/V6D；`medium` 表示该系统下的 diff location，例如 `mem` 或 `disk`；`LocationSpec.uri` 表示具体地址。推理引擎内部显存和外部 V6D 内存/磁盘可以作为不同 `storage_type + medium + uri` 组合表达，不需要在 request 级别再引入更细的存储层级。
+
+## 8. 多 KVCM 与失败语义
+
+多 KVCM 进程共享 Redis 后端时，location 反向索引也必须共享同一 namespace，与 CacheMeta 使用同样的 instance 隔离和 prefix 规则。
+
+所有索引操作都应幂等：
+
+- 重复 Add：结果不变。
+- 重复 Delete：结果不变。
+- 重复 Snapshot：最终收敛到上报集合。
+
+失败时的语义：
+
+- Add 索引失败：不写 CacheMeta，item 返回失败。
+- Add CacheMeta 失败：item 返回失败，可能留下 over-index。
+- Delete CacheMeta 返回 `EC_NOENT`：业务删除可视为幂等成功，但热路径不删除索引，避免误清理并发 add-before-meta 的 index。
+- Delete 索引失败：item 可以返回成功或部分成功，取决于调用方是否要求强一致；但必须打指标，因为它会留下可修复的 over-index。
+- Snapshot 中发现 stale index：不影响 snapshot 主流程，打指标并交给延迟 repair。
+
+## 9. 测试要求
+
+单元测试需要覆盖：
+
+- Add 成功后 CacheMeta 与 location index 都可见。
+- Add 索引失败时不写 CacheMeta。
+- Add CacheMeta 失败时留下 over-index，snapshot 读路径能过滤。
+- Delete 成功后 CacheMeta 和 index 都删除。
+- Delete 索引失败留下 over-index，snapshot 读路径能过滤。
+- Snapshot 只删除 CacheMeta 二次确认存在的 keys。
+- Snapshot 对 stale index 不误删。
+- mamba-state specs 被接收但不进入当前 full-attention 存储和匹配。
+- RTP-LLM full snapshot 与 vLLM add/delete/snapshot 混合事件顺序保持。
+
+集成测试需要覆盖：
+
+- Redis meta backend 下 `ReportEvent` 写入后重启 KVCM，location index 仍可用于 snapshot diff。
+- 多 KVCM 进程共享同一 Redis index 时，A 写入、B snapshot 能正确 diff。
+- 构造 over-index 后，snapshot 不误删，并能清理 stale index。
+- 历史无 index 数据通过 repair job 补齐后，snapshot 不需要请求路径 scan。
+
+## 10. 演进步骤
+
+1. 在 meta 层增加 location index backend 抽象和 Redis 实现。
+2. 将 `MetaSearcher` 的内存 `location_key_index_` 改为持久化 index 读写，并保留小范围内存缓存仅做性能优化，不能作为事实来源。
+3. 调整 `BatchUpsertLocations` 和所有删除 location 的路径，按 add-before-meta、delete-after-meta 顺序维护 index。
+4. 重写 `EVENT_BLOCK_SNAPSHOT` diff：读持久化 index，BatchGet CacheMeta 二次确认，过滤并修复 stale index。
+5. 增加指标和日志，观察 over-index 修复量、索引操作失败量、snapshot diff 数量。
+6. 增加离线 repair 工具，用于老数据迁移和异常状态修复；请求路径不做全量 scan。

--- a/docs/design/report_event_metadata_consistency.md
+++ b/docs/design/report_event_metadata_consistency.md
@@ -69,13 +69,15 @@ kvs#v6d#{medium}#{host_ip_port}
 instance_id + location_id -> set(block_key)
 ```
 
-它是 CacheMeta 的派生索引，不是事实来源。索引允许短暂 over-index：索引里有某个 block_key，但 CacheMeta 中没有对应 location。读链路会过滤这类脏数据，并异步或顺手修复索引。
+它是 CacheMeta 的派生索引，不是事实来源。索引允许短暂 over-index：索引里有某个 block_key，但 CacheMeta 中没有对应 location。读链路会过滤这类脏数据，后续由延迟/离线 repair 清理索引。
 
 索引不应产生新的 under-index：CacheMeta 中已有某个 location，但索引缺少该 block_key。under-index 会导致 snapshot diff 找不到应删除的旧 block，读路径无法在不扫描全量 CacheMeta 的情况下完全发现它。因此写路径要通过顺序和失败处理避免新 under-index。
 
 ## 4. 持久化模型
 
-建议在 meta 层增加独立抽象，例如：
+location 反向索引属于 meta 层能力，调用入口挂在 `MetaStorageBackend` / `MetaIndexer` / `MetaSearcher` 这一层，避免把索引逻辑散落在 `CacheManager`。`CacheManager` 只表达业务语义：上报 add/delete/snapshot；`MetaSearcher` 负责 CacheMeta 与二级索引的一致性维护。
+
+抽象接口等价于：
 
 ```cpp
 class LocationKeyIndexBackend {
@@ -89,15 +91,13 @@ public:
 };
 ```
 
-也可以把这组接口挂到 `MetaStorageBackend` 上，前提是不要把索引逻辑散落在 `CacheManager`。`CacheManager` 只表达业务语义：上报 add/delete/snapshot；`MetaSearcher` 负责 CacheMeta 与二级索引的一致性维护。
-
-Redis 后端可以使用 set 存储：
+Redis / AsyncRedis 后端使用 set 存储并与 CacheMeta 共用 instance namespace：
 
 ```text
 {meta_prefix}:locidx:{hash(location_id)}:{shard_id} -> SET(block_key)
 ```
 
-是否分 shard 由单 location 的 block 数决定。初版可以先用单 set，但接口要保留 shard 能力，避免后续改调用层。
+当前实现先使用单 set，接口保留了后续分 shard 的空间，避免单 location block 数过大时改调用层。Local 后端的 location index 是内存态；Dummy 后端持久化 CacheMeta，并在重新 `Open()` 时从 CacheMeta 重建 location index，因此它可以覆盖本地持久化重启场景，但不是独立持久索引。Redis 后端的 set 才是多 KVCM 共享场景下的持久索引来源。
 
 ## 5. 写路径设计
 
@@ -110,7 +110,7 @@ Add 或 upsert 某个 `block_key -> location_id` 时，顺序应为：
 3. 如果索引写失败，则不写 CacheMeta，并返回该 item 失败。
 4. 如果索引写成功但 CacheMeta 写失败，允许留下 over-index。
 
-这样最坏情况是索引里多了一个 key。后续 snapshot 读索引时会 BatchGet CacheMeta 过滤，发现该 key 并没有对应 location 后可以清理索引。更重要的是，成功写入 CacheMeta 的 location 基本不会缺少反向索引。
+这样最坏情况是索引里多了一个 key。后续 snapshot 读索引时会 BatchGet CacheMeta 过滤，发现该 key 并没有对应 location 后记录为 stale，交给延迟/离线 repair 清理。更重要的是，成功写入 CacheMeta 的 location 基本不会缺少反向索引。
 
 ### 5.2 Delete
 
@@ -198,7 +198,7 @@ under-index 是需要重点避免的状态。因为如果 CacheMeta 中存在 `l
 - Redis 后端可以用 Lua 或 pipeline + 幂等重试进一步收敛失败窗口。
 - 启动时不在请求路径全量扫描重建索引。
 - 提供低优先级 repair job 或运维工具，对历史数据和异常状态做离线校验：扫描 CacheMeta，重建/补齐 location 索引，并输出修复指标。
-- 对 snapshot diff 暴露指标：candidate 数、stale index 数、reported 数、add 数、delete 数、repair 失败数。如果 stale index 或 repair 失败持续升高，应告警。
+- 对 snapshot diff 暴露指标：candidate 数、stale index 数、reported 数、add 数、delete 数；离线 repair 暴露独立修复量和失败数。如果 stale index 或 repair 失败持续升高，应告警。
 
 换句话说：读路径要容忍 over-index；under-index 不能靠普通读路径完全修复，只能靠写路径不制造、离线 repair 兜底。
 
@@ -264,7 +264,7 @@ vLLM 上报的 group id、attention 类型、TP 等信息放入 `LocationSpec.na
 
 - Redis meta backend 下 `ReportEvent` 写入后重启 KVCM，location index 仍可用于 snapshot diff。
 - 多 KVCM 进程共享同一 Redis index 时，A 写入、B snapshot 能正确 diff。
-- 构造 over-index 后，snapshot 不误删，并能清理 stale index。
+- 构造 over-index 后，snapshot 不误删；stale index 清理由延迟/离线 repair 覆盖。
 - 历史无 index 数据通过 repair job 补齐后，snapshot 不需要请求路径 scan。
 
 ## 10. 演进步骤
@@ -272,6 +272,6 @@ vLLM 上报的 group id、attention 类型、TP 等信息放入 `LocationSpec.na
 1. 在 meta 层增加 location index backend 抽象和 Redis 实现。
 2. 将 `MetaSearcher` 的内存 `location_key_index_` 改为持久化 index 读写，并保留小范围内存缓存仅做性能优化，不能作为事实来源。
 3. 调整 `BatchUpsertLocations` 和所有删除 location 的路径，按 add-before-meta、delete-after-meta 顺序维护 index。
-4. 重写 `EVENT_BLOCK_SNAPSHOT` diff：读持久化 index，BatchGet CacheMeta 二次确认，过滤并修复 stale index。
+4. 重写 `EVENT_BLOCK_SNAPSHOT` diff：读持久化 index，BatchGet CacheMeta 二次确认，请求热路径只过滤 stale index。
 5. 增加指标和日志，观察 over-index 修复量、索引操作失败量、snapshot diff 数量。
 6. 增加离线 repair 工具，用于老数据迁移和异常状态修复；请求路径不做全量 scan。

--- a/integration_test/meta_service/test_vineyard_report_event.py
+++ b/integration_test/meta_service/test_vineyard_report_event.py
@@ -160,6 +160,27 @@ def _ev_block_delete(block_key, medium):
     }
 
 
+def _ev_block_snapshot(medium, blocks):
+    """Build a block_snapshot event.
+
+    Args:
+        blocks: list of (block_key, specs) tuples.
+    """
+    return {
+        "event_type": "EVENT_BLOCK_SNAPSHOT",
+        "block_snapshot": {
+            "medium": medium,
+            "blocks": [
+                {
+                    "block_key": str(block_key),
+                    "specs": specs,
+                }
+                for block_key, specs in blocks
+            ],
+        },
+    }
+
+
 def _ev_host_down():
     return {"event_type": "EVENT_HOST_DOWN", "host_down": {}}
 
@@ -614,6 +635,52 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
         locations2 = resp2.get("locations", [])
         self.assertEqual(len(locations2), 0,
                          "Expected no write locations since 2 replicas already exist")
+
+    # 16. BLOCK_SNAPSHOT reconciles the full block set for one host/medium
+    def test_16_block_snapshot_diff(self):
+        host = "192.168.1.240:8080"
+        medium = "mem"
+        key_deleted = 8101
+        key_kept = 8102
+        key_added = 8103
+        uri_deleted = _build_vineyard_uri(host, medium, {"obj_id": "deleted"})
+        uri_kept = _build_vineyard_uri(host, medium, {"obj_id": "kept"})
+        uri_added = _build_vineyard_uri(host, medium, {"obj_id": "added"})
+
+        def has_uri(block_key, expected_uri):
+            resp = self.client.get_cache_location({
+                "trace_id": f"t16_query_{block_key}",
+                "instance_id": self.instance_id,
+                "query_type": "QT_BATCH_GET",
+                "block_keys": [block_key],
+                "block_mask": {"offset": 0},
+            })
+            for loc in resp.get("locations", []):
+                for spec in loc.get("location_specs", []):
+                    if spec.get("uri") == expected_uri:
+                        return True
+            return False
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (key_deleted, _make_single_spec("spec_4096", uri_deleted)),
+                (key_kept, _make_single_spec("spec_4096", uri_kept)),
+            ]),
+        ], trace_id="t16_snapshot_a"))
+        self.assertTrue(has_uri(key_kept, uri_kept))
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_snapshot(medium, [
+                (key_kept, _make_single_spec("spec_4096", uri_kept)),
+                (key_added, _make_single_spec("spec_4096", uri_added)),
+            ]),
+        ], trace_id="t16_snapshot_b"))
+
+        self.assertFalse(has_uri(key_deleted, uri_deleted),
+                         "Second full snapshot should delete blocks missing from the same host/medium")
+        self.assertTrue(has_uri(key_kept, uri_kept))
+        self.assertTrue(has_uri(key_added, uri_added))
 
     # 16a. Heartbeat timeout -> location filtered out, then recovery on heartbeat resume.
     def test_16a_heartbeat_timeout_then_recovery(self):

--- a/integration_test/meta_service/test_vineyard_report_event.py
+++ b/integration_test/meta_service/test_vineyard_report_event.py
@@ -150,12 +150,13 @@ def _make_single_spec(name, uri):
     return [{"name": name, "uri": uri}]
 
 
-def _ev_block_delete(block_key, medium):
+def _ev_block_delete(block_key, medium, spec_names=None):
     return {
         "event_type": "EVENT_BLOCK_DELETE",
         "block_delete": {
             "block_key": str(block_key),
             "medium": medium,
+            "spec_names": list(spec_names or []),
         },
     }
 
@@ -760,6 +761,160 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
         self._assert_uri_absent(key_mem_deleted, uri_mem_deleted, "t16d_query_mem_deleted")
         self._assert_uri_present(key_mem_kept, uri_mem_kept, "t16d_query_mem_kept")
         self._assert_uri_present(key_disk_kept, uri_disk_kept, "t16d_query_disk_kept")
+
+    # 16e. Mamba-only reports are accepted but ignored for current full-attention matching.
+    def test_16e_mamba_only_report_does_not_delete_full_attention(self):
+        host = "192.168.1.244:8080"
+        medium = "gpu"
+        full_key = 8131
+        mamba_key = 8132
+        full_uri = _build_vineyard_uri(host, medium, {"obj_id": "full"})
+        mamba_uri = _build_vineyard_uri(host, medium, {"obj_id": "mamba"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_add(
+                full_key,
+                medium,
+                _make_single_spec("full_attention:group=0:tp=0", full_uri),
+            ),
+        ], trace_id="t16e_full_add"))
+        self._assert_uri_present(full_key, full_uri, "t16e_query_full_before")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_snapshot(medium, [
+                (mamba_key, _make_single_spec("mamba_state:group=1", mamba_uri)),
+            ]),
+            _ev_block_delete(full_key, medium, ["mamba_state:group=1"]),
+        ], trace_id="t16e_mamba_only"))
+
+        self._assert_uri_present(full_key, full_uri, "t16e_query_full_after")
+        self._assert_uri_absent(mamba_key, mamba_uri, "t16e_query_mamba_after")
+
+    # 16f. Snapshot is an ordering barrier inside one ReportEvent request.
+    def test_16f_snapshot_ordering_barrier_inside_batch(self):
+        host = "192.168.1.245:8080"
+        medium = "mem"
+        key_add_after_snapshot = 8141
+        key_add_before_snapshot = 8142
+        uri_after = _build_vineyard_uri(host, medium, {"obj_id": "after"})
+        uri_before = _build_vineyard_uri(host, medium, {"obj_id": "before"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, []),
+            _ev_block_add(
+                key_add_after_snapshot,
+                medium,
+                _make_single_spec("tp0", uri_after),
+            ),
+        ], trace_id="t16f_snapshot_then_add"))
+        self._assert_uri_present(key_add_after_snapshot, uri_after, "t16f_query_after_present")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_add(
+                key_add_before_snapshot,
+                medium,
+                _make_single_spec("tp0", uri_before),
+            ),
+            _ev_block_snapshot(medium, []),
+        ], trace_id="t16f_add_then_snapshot"))
+        self._assert_uri_absent(key_add_after_snapshot, uri_after, "t16f_query_after_deleted")
+        self._assert_uri_absent(key_add_before_snapshot, uri_before, "t16f_query_before_deleted")
+
+    # 16g. Per-item failures do not drop other valid mutations in the same batch.
+    def test_16g_partial_block_add_failure_keeps_valid_adds(self):
+        host = "192.168.1.246:8080"
+        medium = "mem"
+        key_a = 8151
+        key_b = 8152
+        uri_a = _build_vineyard_uri(host, medium, {"obj_id": "valid_a"})
+        uri_b = _build_vineyard_uri(host, medium, {"obj_id": "valid_b"})
+        invalid_uri = _build_vineyard_uri(host, medium, {"obj_id": "invalid"})
+
+        body = self.client.report_event(
+            _make_request(self.instance_id, host, [
+                _ev_node_register([medium]),
+                _ev_block_add(key_a, medium, _make_single_spec("tp0", uri_a)),
+                {
+                    "event_type": "EVENT_BLOCK_ADD",
+                    "block_add": {
+                        "block_key": "not-an-int64",
+                        "medium": medium,
+                        "specs": _make_single_spec("tp0", invalid_uri),
+                    },
+                },
+                _ev_block_add(key_b, medium, _make_single_spec("tp0", uri_b)),
+            ], trace_id="t16g_partial_add"),
+            check_ok=False,
+        )
+        item_results = body.get("item_results", [])
+        self.assertGreaterEqual(len(item_results), 4, json.dumps(body, ensure_ascii=False))
+        self.assertNotIn(item_results[2], ("OK", 1, "1"), json.dumps(body, ensure_ascii=False))
+
+        self._assert_uri_present(key_a, uri_a, "t16g_query_valid_a")
+        self._assert_uri_present(key_b, uri_b, "t16g_query_valid_b")
+
+    # 16h. Snapshot diff is scoped by host even when the same block exists on another host.
+    def test_16h_snapshot_same_block_other_host_survives(self):
+        host_a = "192.168.1.247:8080"
+        host_b = "192.168.1.248:8080"
+        medium = "mem"
+        block_key = 8161
+        uri_a = _build_vineyard_uri(host_a, medium, {"obj_id": "same_block_a"})
+        uri_b = _build_vineyard_uri(host_b, medium, {"obj_id": "same_block_b"})
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (block_key, _make_single_spec("host_a_full", uri_a)),
+            ]),
+        ], trace_id="t16h_snapshot_host_a"))
+        self.client.report_event(_make_request(self.instance_id, host_b, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (block_key, _make_single_spec("host_b_full", uri_b)),
+            ]),
+        ], trace_id="t16h_snapshot_host_b"))
+        self._assert_uri_present(block_key, uri_a, "t16h_query_a_before")
+        self._assert_uri_present(block_key, uri_b, "t16h_query_b_before")
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_block_snapshot(medium, []),
+        ], trace_id="t16h_snapshot_host_a_empty"))
+
+        self._assert_uri_absent(block_key, uri_a, "t16h_query_a_after")
+        self._assert_uri_present(block_key, uri_b, "t16h_query_b_after")
+
+    # 16i. Mixed full-attention and mamba specs store/match only full-attention today.
+    def test_16i_full_attention_and_mamba_mixed_report(self):
+        host = "192.168.1.249:8080"
+        medium = "gpu"
+        block_key = 8171
+        full_uri = _build_vineyard_uri(host, medium, {"obj_id": "full"})
+        mamba_uri = _build_vineyard_uri(host, medium, {"obj_id": "mamba"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (block_key, [
+                    {"name": "full_attention:group=0:tp=0", "uri": full_uri},
+                    {"name": "mamba_state:group=1", "uri": mamba_uri},
+                ]),
+            ]),
+        ], trace_id="t16i_mixed_snapshot"))
+        self._assert_uri_present(block_key, full_uri, "t16i_query_full_after_snapshot")
+        self._assert_uri_absent(block_key, mamba_uri, "t16i_query_mamba_after_snapshot")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_delete(block_key, medium, ["mamba_state:group=1"]),
+        ], trace_id="t16i_mamba_delete"))
+        self._assert_uri_present(block_key, full_uri, "t16i_query_full_after_mamba_delete")
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_delete(block_key, medium, ["full_attention:group=0:tp=0"]),
+        ], trace_id="t16i_full_delete"))
+        self._assert_uri_absent(block_key, full_uri, "t16i_query_full_after_full_delete")
 
     # 16a. Heartbeat timeout -> location filtered out, then recovery on heartbeat resume.
     def test_16a_heartbeat_timeout_then_recovery(self):

--- a/integration_test/meta_service/test_vineyard_report_event.py
+++ b/integration_test/meta_service/test_vineyard_report_event.py
@@ -319,6 +319,33 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
     def tearDownClass(cls):
         cls.client.close()
 
+    def _query_specs(self, block_key, trace_id):
+        resp = self.client.get_cache_location({
+            "trace_id": trace_id,
+            "instance_id": self.instance_id,
+            "query_type": "QT_BATCH_GET",
+            "block_keys": [block_key],
+            "block_mask": {"offset": 0},
+        })
+        specs = []
+        for loc in resp.get("locations", []):
+            specs.extend(loc.get("location_specs", []))
+        return specs
+
+    def _assert_uri_present(self, block_key, expected_uri, trace_id):
+        specs = self._query_specs(block_key, trace_id)
+        self.assertTrue(
+            any(spec.get("uri") == expected_uri for spec in specs),
+            f"Expected uri={expected_uri} for block={block_key}, specs={specs}",
+        )
+
+    def _assert_uri_absent(self, block_key, unexpected_uri, trace_id):
+        specs = self._query_specs(block_key, trace_id)
+        self.assertFalse(
+            any(spec.get("uri") == unexpected_uri for spec in specs),
+            f"Unexpected uri={unexpected_uri} for block={block_key}, specs={specs}",
+        )
+
     # 1. NODE_REGISTER (with mediums)
     def test_01_node_register(self):
         body = self.client.report_event(
@@ -647,20 +674,6 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
         uri_kept = _build_vineyard_uri(host, medium, {"obj_id": "kept"})
         uri_added = _build_vineyard_uri(host, medium, {"obj_id": "added"})
 
-        def has_uri(block_key, expected_uri):
-            resp = self.client.get_cache_location({
-                "trace_id": f"t16_query_{block_key}",
-                "instance_id": self.instance_id,
-                "query_type": "QT_BATCH_GET",
-                "block_keys": [block_key],
-                "block_mask": {"offset": 0},
-            })
-            for loc in resp.get("locations", []):
-                for spec in loc.get("location_specs", []):
-                    if spec.get("uri") == expected_uri:
-                        return True
-            return False
-
         self.client.report_event(_make_request(self.instance_id, host, [
             _ev_node_register([medium]),
             _ev_block_snapshot(medium, [
@@ -668,7 +681,7 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
                 (key_kept, _make_single_spec("spec_4096", uri_kept)),
             ]),
         ], trace_id="t16_snapshot_a"))
-        self.assertTrue(has_uri(key_kept, uri_kept))
+        self._assert_uri_present(key_kept, uri_kept, "t16_query_kept_a")
 
         self.client.report_event(_make_request(self.instance_id, host, [
             _ev_block_snapshot(medium, [
@@ -677,10 +690,76 @@ class VineyardReportEventFunctionalTest(unittest.TestCase):
             ]),
         ], trace_id="t16_snapshot_b"))
 
-        self.assertFalse(has_uri(key_deleted, uri_deleted),
-                         "Second full snapshot should delete blocks missing from the same host/medium")
-        self.assertTrue(has_uri(key_kept, uri_kept))
-        self.assertTrue(has_uri(key_added, uri_added))
+        self._assert_uri_absent(key_deleted, uri_deleted, "t16_query_deleted_b")
+        self._assert_uri_present(key_kept, uri_kept, "t16_query_kept_b")
+        self._assert_uri_present(key_added, uri_added, "t16_query_added_b")
+
+    # 16c. Snapshot diff is scoped by host: same medium on another host survives.
+    def test_16c_block_snapshot_diff_is_host_scoped(self):
+        host_a = "192.168.1.241:8080"
+        host_b = "192.168.1.242:8080"
+        medium = "mem"
+        key_a_deleted = 8111
+        key_a_kept = 8112
+        key_b_kept = 8113
+        uri_a_deleted = _build_vineyard_uri(host_a, medium, {"obj_id": "a_deleted"})
+        uri_a_kept = _build_vineyard_uri(host_a, medium, {"obj_id": "a_kept"})
+        uri_b_kept = _build_vineyard_uri(host_b, medium, {"obj_id": "b_kept"})
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (key_a_deleted, _make_single_spec("host_a_deleted", uri_a_deleted)),
+                (key_a_kept, _make_single_spec("host_a_kept", uri_a_kept)),
+            ]),
+        ], trace_id="t16c_snapshot_host_a_initial"))
+        self.client.report_event(_make_request(self.instance_id, host_b, [
+            _ev_node_register([medium]),
+            _ev_block_snapshot(medium, [
+                (key_b_kept, _make_single_spec("host_b_kept", uri_b_kept)),
+            ]),
+        ], trace_id="t16c_snapshot_host_b_initial"))
+
+        self.client.report_event(_make_request(self.instance_id, host_a, [
+            _ev_block_snapshot(medium, [
+                (key_a_kept, _make_single_spec("host_a_kept", uri_a_kept)),
+            ]),
+        ], trace_id="t16c_snapshot_host_a_reconcile"))
+
+        self._assert_uri_absent(key_a_deleted, uri_a_deleted, "t16c_query_a_deleted")
+        self._assert_uri_present(key_a_kept, uri_a_kept, "t16c_query_a_kept")
+        self._assert_uri_present(key_b_kept, uri_b_kept, "t16c_query_b_kept")
+
+    # 16d. Snapshot diff is scoped by medium: another tier on the same host survives.
+    def test_16d_block_snapshot_diff_is_medium_scoped(self):
+        host = "192.168.1.243:8080"
+        key_mem_deleted = 8121
+        key_mem_kept = 8122
+        key_disk_kept = 8123
+        uri_mem_deleted = _build_vineyard_uri(host, "mem", {"obj_id": "mem_deleted"})
+        uri_mem_kept = _build_vineyard_uri(host, "mem", {"obj_id": "mem_kept"})
+        uri_disk_kept = _build_vineyard_uri(host, "disk", {"obj_id": "disk_kept"})
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_node_register(["mem", "disk"]),
+            _ev_block_snapshot("mem", [
+                (key_mem_deleted, _make_single_spec("mem_deleted", uri_mem_deleted)),
+                (key_mem_kept, _make_single_spec("mem_kept", uri_mem_kept)),
+            ]),
+            _ev_block_snapshot("disk", [
+                (key_disk_kept, _make_single_spec("disk_kept", uri_disk_kept)),
+            ]),
+        ], trace_id="t16d_snapshot_initial"))
+
+        self.client.report_event(_make_request(self.instance_id, host, [
+            _ev_block_snapshot("mem", [
+                (key_mem_kept, _make_single_spec("mem_kept", uri_mem_kept)),
+            ]),
+        ], trace_id="t16d_snapshot_mem_reconcile"))
+
+        self._assert_uri_absent(key_mem_deleted, uri_mem_deleted, "t16d_query_mem_deleted")
+        self._assert_uri_present(key_mem_kept, uri_mem_kept, "t16d_query_mem_kept")
+        self._assert_uri_present(key_disk_kept, uri_disk_kept, "t16d_query_disk_kept")
 
     # 16a. Heartbeat timeout -> location filtered out, then recovery on heartbeat resume.
     def test_16a_heartbeat_timeout_then_recovery(self):

--- a/kv_cache_manager/common/redis_client.cc
+++ b/kv_cache_manager/common/redis_client.cc
@@ -333,6 +333,44 @@ void RedisClient::BuildHashDeleteCmds(const std::vector<std::string> &keys,
     }
 }
 
+void RedisClient::BuildSetAddCmds(const std::vector<std::string> &keys,
+                                  const std::vector<std::vector<std::string>> &members_vec,
+                                  std::vector<CmdArgs> &out_cmds) {
+    assert(keys.size() == members_vec.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (members_vec[i].empty()) {
+            continue;
+        }
+        CmdArgs sadd_cmd;
+        sadd_cmd.reserve(members_vec[i].size() + 2);
+        sadd_cmd.emplace_back("SADD");
+        sadd_cmd.emplace_back(keys[i]);
+        for (const auto &member : members_vec[i]) {
+            sadd_cmd.emplace_back(member);
+        }
+        out_cmds.emplace_back(std::move(sadd_cmd));
+    }
+}
+
+void RedisClient::BuildSetRemoveCmds(const std::vector<std::string> &keys,
+                                     const std::vector<std::vector<std::string>> &members_vec,
+                                     std::vector<CmdArgs> &out_cmds) {
+    assert(keys.size() == members_vec.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (members_vec[i].empty()) {
+            continue;
+        }
+        CmdArgs srem_cmd;
+        srem_cmd.reserve(members_vec[i].size() + 2);
+        srem_cmd.emplace_back("SREM");
+        srem_cmd.emplace_back(keys[i]);
+        for (const auto &member : members_vec[i]) {
+            srem_cmd.emplace_back(member);
+        }
+        out_cmds.emplace_back(std::move(srem_cmd));
+    }
+}
+
 // cover old key-fields
 std::vector<ErrorCode> RedisClient::Set(const std::vector<std::string> &keys,
                                         const std::vector<std::map<std::string, std::string>> &field_maps) {
@@ -545,6 +583,122 @@ std::vector<ErrorCode> RedisClient::DeleteFields(const std::vector<std::string> 
         }
     }
     return ec_per_key;
+}
+
+std::vector<ErrorCode> RedisClient::SAdd(const std::vector<std::string> &keys,
+                                         const std::vector<std::vector<std::string>> &members_vec) {
+    if (keys.size() != members_vec.size()) {
+        KVCM_REDIS_LOG_ERROR("redis sadd fail, keys.size[%lu] != members_vec.size[%lu]",
+                             keys.size(),
+                             members_vec.size());
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
+
+    std::vector<size_t> original_indexes;
+    std::vector<ErrorCode> ec_per_key(keys.size(), EC_OK);
+    original_indexes.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (!members_vec[i].empty()) {
+            original_indexes.emplace_back(i);
+        }
+    }
+
+    std::vector<CmdArgs> sadd_cmds;
+    sadd_cmds.reserve(original_indexes.size());
+    BuildSetAddCmds(keys, members_vec, sadd_cmds);
+    if (sadd_cmds.empty()) {
+        return ec_per_key;
+    }
+
+    std::vector<ReplyUPtr> sadd_replies = CommandPipeline(sadd_cmds);
+    if (sadd_cmds.size() != sadd_replies.size()) {
+        KVCM_REDIS_LOG_ERROR("redis sadd fail, pipeline sadd_cmds.size[%lu] != replies.size[%lu]",
+                             sadd_cmds.size(),
+                             sadd_replies.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+    assert(original_indexes.size() == sadd_replies.size());
+    for (size_t i = 0; i < original_indexes.size(); ++i) {
+        const size_t original_idx = original_indexes[i];
+        const ReplyUPtr &reply = sadd_replies[i];
+        if (!IsReplyOk(reply.get()) || !CheckReplyInteger(reply.get())) {
+            KVCM_REDIS_LOG_ERROR("redis sadd fail, key[%s]", keys[original_idx].c_str());
+            ec_per_key[original_idx] = EC_ERROR;
+        }
+    }
+    return ec_per_key;
+}
+
+std::vector<ErrorCode> RedisClient::SRem(const std::vector<std::string> &keys,
+                                         const std::vector<std::vector<std::string>> &members_vec) {
+    if (keys.size() != members_vec.size()) {
+        KVCM_REDIS_LOG_ERROR("redis srem fail, keys.size[%lu] != members_vec.size[%lu]",
+                             keys.size(),
+                             members_vec.size());
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
+
+    std::vector<size_t> original_indexes;
+    std::vector<ErrorCode> ec_per_key(keys.size(), EC_OK);
+    original_indexes.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (!members_vec[i].empty()) {
+            original_indexes.emplace_back(i);
+        }
+    }
+
+    std::vector<CmdArgs> srem_cmds;
+    srem_cmds.reserve(original_indexes.size());
+    BuildSetRemoveCmds(keys, members_vec, srem_cmds);
+    if (srem_cmds.empty()) {
+        return ec_per_key;
+    }
+
+    std::vector<ReplyUPtr> srem_replies = CommandPipeline(srem_cmds);
+    if (srem_cmds.size() != srem_replies.size()) {
+        KVCM_REDIS_LOG_ERROR("redis srem fail, pipeline srem_cmds.size[%lu] != replies.size[%lu]",
+                             srem_cmds.size(),
+                             srem_replies.size());
+        return std::vector<ErrorCode>(keys.size(), EC_ERROR);
+    }
+    assert(original_indexes.size() == srem_replies.size());
+    for (size_t i = 0; i < original_indexes.size(); ++i) {
+        const size_t original_idx = original_indexes[i];
+        const ReplyUPtr &reply = srem_replies[i];
+        if (!IsReplyOk(reply.get()) || !CheckReplyInteger(reply.get())) {
+            KVCM_REDIS_LOG_ERROR("redis srem fail, key[%s]", keys[original_idx].c_str());
+            ec_per_key[original_idx] = EC_ERROR;
+        }
+    }
+    return ec_per_key;
+}
+
+ErrorCode RedisClient::SMembers(const std::string &key, std::vector<std::string> &out_members) {
+    out_members.clear();
+    std::vector<CmdArgs> cmds{{"SMEMBERS", key}};
+    std::vector<ReplyUPtr> replies = CommandPipeline(cmds);
+    if (replies.size() != 1) {
+        KVCM_REDIS_LOG_ERROR("redis smembers fail, pipeline replies.size[%lu]", replies.size());
+        return EC_ERROR;
+    }
+    const ReplyUPtr &reply = replies[0];
+    if (!IsReplyOk(reply.get()) || !CheckReplyArray(reply.get())) {
+        KVCM_REDIS_LOG_ERROR("redis smembers fail, key[%s]", key.c_str());
+        return EC_ERROR;
+    }
+    out_members.reserve(reply->elements);
+    for (size_t i = 0; i < reply->elements; ++i) {
+        const redisReply *element = reply->element[i];
+        if (!element || element->type != REDIS_REPLY_STRING) {
+            KVCM_REDIS_LOG_ERROR("redis smembers fail, key[%s] unexpected element type[%d]",
+                                 key.c_str(),
+                                 element ? element->type : -1);
+            out_members.clear();
+            return EC_ERROR;
+        }
+        out_members.emplace_back(element->str, element->len);
+    }
+    return EC_OK;
 }
 
 std::vector<ErrorCode> RedisClient::Get(const std::vector<std::string> &keys,

--- a/kv_cache_manager/common/redis_client.h
+++ b/kv_cache_manager/common/redis_client.h
@@ -32,6 +32,11 @@ public:
     std::vector<ErrorCode> Delete(const std::vector<std::string> &keys);
     std::vector<ErrorCode> DeleteFields(const std::vector<std::string> &keys,
                                         const std::vector<std::vector<std::string>> &field_names_vec);
+    std::vector<ErrorCode> SAdd(const std::vector<std::string> &keys,
+                                const std::vector<std::vector<std::string>> &members_vec);
+    std::vector<ErrorCode> SRem(const std::vector<std::string> &keys,
+                                const std::vector<std::vector<std::string>> &members_vec);
+    ErrorCode SMembers(const std::string &key, std::vector<std::string> &out_members);
     std::vector<ErrorCode> Get(const std::vector<std::string> &keys,
                                const std::vector<std::string> &field_names,
                                std::vector<std::map<std::string, std::string>> &out_field_maps);
@@ -84,6 +89,14 @@ public:
     static void BuildHashDeleteCmds(const std::vector<std::string> &keys,
                                     const std::vector<std::vector<std::string>> &field_names_vec,
                                     std::vector<CmdArgs> &out_cmds);
+
+    // SADD/SREM per key. Skips keys with empty member lists.
+    static void BuildSetAddCmds(const std::vector<std::string> &keys,
+                                const std::vector<std::vector<std::string>> &members_vec,
+                                std::vector<CmdArgs> &out_cmds);
+    static void BuildSetRemoveCmds(const std::vector<std::string> &keys,
+                                   const std::vector<std::vector<std::string>> &members_vec,
+                                   std::vector<CmdArgs> &out_cmds);
 
 protected:
 

--- a/kv_cache_manager/common/test/loop_thread_test.cc
+++ b/kv_cache_manager/common/test/loop_thread_test.cc
@@ -37,6 +37,7 @@ TEST_F(LoopThreadTest, TestCreateAndStop) {
 
     loop_thread->Stop();
 
+    count_before_stop = count.load();
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     int count_after_stop = count.load();
     EXPECT_EQ(count_before_stop, count_after_stop);

--- a/kv_cache_manager/common/test/redis_client_test.cc
+++ b/kv_cache_manager/common/test/redis_client_test.cc
@@ -903,6 +903,88 @@ TEST_F(RedisClientTest, TestBuildHashDeleteCmdsEmpty) {
     ASSERT_TRUE(cmds.empty());
 }
 
+TEST_F(RedisClientTest, TestSetIndexCommands) {
+    EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+    std::vector<ReplyUPtr> sadd_replies;
+    sadd_replies.emplace_back(MakeFakeReplyInteger(2));
+    sadd_replies.emplace_back(MakeFakeReplyInteger(1));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"), StrEq("idx_a"), StrEq("11"), StrEq("12")),
+                                            ElementsAre(StrEq("SADD"), StrEq("idx_c"), StrEq("13")))))
+        .WillOnce(Return(ByMove(std::move(sadd_replies))));
+    auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b", "idx_c"}, {{"11", "12"}, {}, {"13"}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_OK}), sadd_ecs);
+
+    std::vector<ReplyUPtr> srem_replies;
+    srem_replies.emplace_back(MakeFakeReplyInteger(1));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"), StrEq("idx_a"), StrEq("11")))))
+        .WillOnce(Return(ByMove(std::move(srem_replies))));
+    auto srem_ecs = redis_client_->SRem({"idx_a", "idx_b"}, {{"11"}, {}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), srem_ecs);
+
+    std::vector<ReplyUPtr> smembers_replies;
+    smembers_replies.emplace_back(MakeFakeReplyArrayString({"11", "12"}));
+    EXPECT_CALL(*redis_client_, TryExecPipeline(ElementsAre(ElementsAre(StrEq("SMEMBERS"), StrEq("idx_a")))))
+        .WillOnce(Return(ByMove(std::move(smembers_replies))));
+    std::vector<std::string> members;
+    ASSERT_EQ(EC_OK, redis_client_->SMembers("idx_a", members));
+    ASSERT_EQ((std::vector<std::string>{"11", "12"}), members);
+}
+
+TEST_F(RedisClientTest, TestSetIndexCommandErrors) {
+    EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+    ASSERT_EQ((std::vector<ErrorCode>{EC_BADARGS}), redis_client_->SAdd({"idx_a"}, {}));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_BADARGS}), redis_client_->SRem({"idx_a"}, {}));
+
+    std::vector<ReplyUPtr> sadd_replies;
+    sadd_replies.emplace_back(MakeFakeReplyInteger(-1));
+    sadd_replies.emplace_back(MakeFakeReplyInteger(1));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"), StrEq("idx_a"), StrEq("11")),
+                                            ElementsAre(StrEq("SADD"), StrEq("idx_c"), StrEq("13")))))
+        .WillOnce(Return(ByMove(std::move(sadd_replies))));
+    auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b", "idx_c"}, {{"11"}, {}, {"13"}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_OK, EC_OK}), sadd_ecs);
+
+    std::vector<ReplyUPtr> srem_replies;
+    srem_replies.emplace_back(MakeFakeReplyInteger(1));
+    srem_replies.emplace_back(MakeFakeReply(REDIS_REPLY_ERROR, "ERR"));
+    EXPECT_CALL(*redis_client_,
+                TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"), StrEq("idx_a"), StrEq("11")),
+                                            ElementsAre(StrEq("SREM"), StrEq("idx_c"), StrEq("13")))))
+        .WillOnce(Return(ByMove(std::move(srem_replies))));
+    auto srem_ecs = redis_client_->SRem({"idx_a", "idx_b", "idx_c"}, {{"11"}, {}, {"13"}});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK, EC_ERROR}), srem_ecs);
+
+    std::vector<ReplyUPtr> smembers_replies;
+    smembers_replies.emplace_back(MakeFakeReplyArrayString({"11", std::nullopt}));
+    EXPECT_CALL(*redis_client_, TryExecPipeline(ElementsAre(ElementsAre(StrEq("SMEMBERS"), StrEq("idx_a")))))
+        .WillOnce(Return(ByMove(std::move(smembers_replies))));
+    std::vector<std::string> members;
+    ASSERT_EQ(EC_ERROR, redis_client_->SMembers("idx_a", members));
+    ASSERT_TRUE(members.empty());
+}
+
+TEST_F(RedisClientTest, TestBuildSetIndexCmds) {
+    std::vector<std::string> keys = {"idx_a", "idx_b", "idx_c"};
+    std::vector<std::vector<std::string>> members = {{"11", "12"}, {}, {"13"}};
+
+    std::vector<CmdArgs> sadd_cmds;
+    RedisClient::BuildSetAddCmds(keys, members, sadd_cmds);
+    ASSERT_EQ(2, sadd_cmds.size());
+    ASSERT_EQ(CmdArgs({"SADD", "idx_a", "11", "12"}), sadd_cmds[0]);
+    ASSERT_EQ(CmdArgs({"SADD", "idx_c", "13"}), sadd_cmds[1]);
+
+    std::vector<CmdArgs> srem_cmds;
+    RedisClient::BuildSetRemoveCmds(keys, members, srem_cmds);
+    ASSERT_EQ(2, srem_cmds.size());
+    ASSERT_EQ(CmdArgs({"SREM", "idx_a", "11", "12"}), srem_cmds[0]);
+    ASSERT_EQ(CmdArgs({"SREM", "idx_c", "13"}), srem_cmds[1]);
+}
+
 TEST_F(RedisClientTest, TestBuildCmdsAppendToExisting) {
     std::vector<CmdArgs> cmds;
     cmds.push_back({"EXISTING_CMD"});

--- a/kv_cache_manager/common/test/redis_client_test.cc
+++ b/kv_cache_manager/common/test/redis_client_test.cc
@@ -968,6 +968,50 @@ TEST_F(RedisClientTest, TestSetIndexCommandErrors) {
     ASSERT_TRUE(members.empty());
 }
 
+TEST_F(RedisClientTest, TestSetIndexCommandsNoopAndPipelineShapeErrors) {
+    {
+        EXPECT_CALL(*redis_client_, TryExecPipeline(_)).Times(0);
+
+        auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b"}, {{}, {}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), sadd_ecs);
+
+        auto srem_ecs = redis_client_->SRem({"idx_a", "idx_b"}, {{}, {}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_OK, EC_OK}), srem_ecs);
+    }
+    {
+        EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> sadd_replies;
+        sadd_replies.emplace_back(MakeFakeReplyInteger(1));
+        EXPECT_CALL(*redis_client_,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"), StrEq("idx_a"), StrEq("11")),
+                                                ElementsAre(StrEq("SADD"), StrEq("idx_b"), StrEq("12")))))
+            .WillOnce(Return(ByMove(std::move(sadd_replies))));
+        auto sadd_ecs = redis_client_->SAdd({"idx_a", "idx_b"}, {{"11"}, {"12"}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR, EC_ERROR}), sadd_ecs);
+    }
+    {
+        EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> srem_replies;
+        EXPECT_CALL(*redis_client_,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"), StrEq("idx_a"), StrEq("11")))))
+            .WillOnce(Return(ByMove(std::move(srem_replies))));
+        auto srem_ecs = redis_client_->SRem({"idx_a"}, {{"11"}});
+        ASSERT_EQ((std::vector<ErrorCode>{EC_ERROR}), srem_ecs);
+    }
+    {
+        EXPECT_CALL(*redis_client_, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> smembers_replies;
+        EXPECT_CALL(*redis_client_, TryExecPipeline(ElementsAre(ElementsAre(StrEq("SMEMBERS"), StrEq("idx_a")))))
+            .WillOnce(Return(ByMove(std::move(smembers_replies))));
+        std::vector<std::string> members = {"stale"};
+        ASSERT_EQ(EC_ERROR, redis_client_->SMembers("idx_a", members));
+        ASSERT_TRUE(members.empty());
+    }
+}
+
 TEST_F(RedisClientTest, TestBuildSetIndexCmds) {
     std::vector<std::string> keys = {"idx_a", "idx_b", "idx_c"};
     std::vector<std::vector<std::string>> members = {{"11", "12"}, {}, {"13"}};
@@ -991,11 +1035,15 @@ TEST_F(RedisClientTest, TestBuildCmdsAppendToExisting) {
 
     RedisClient::BuildDeleteCmds({"k1"}, cmds);
     RedisClient::BuildHashSetCmds({"k2"}, {{{"f", "v"}}}, cmds);
+    RedisClient::BuildSetAddCmds({"idx"}, {{"11", "12"}}, cmds);
+    RedisClient::BuildSetRemoveCmds({"idx"}, {{"11"}}, cmds);
 
-    ASSERT_EQ(3, cmds.size());
+    ASSERT_EQ(5, cmds.size());
     ASSERT_EQ("EXISTING_CMD", cmds[0][0]);
     ASSERT_EQ("DEL", cmds[1][0]);
     ASSERT_EQ("HSET", cmds[2][0]);
+    ASSERT_EQ(CmdArgs({"SADD", "idx", "11", "12"}), cmds[3]);
+    ASSERT_EQ(CmdArgs({"SREM", "idx", "11"}), cmds[4]);
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "kv_cache_manager/common/env_util.h"
 #include "kv_cache_manager/common/jsonizable.h"
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
@@ -1530,8 +1529,14 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         std::string location_id;
         int event_index;
     };
+    struct SnapshotEntry {
+        std::string location_id;
+        std::map<int64_t, std::vector<LocationSpec>> blocks;
+        int event_index;
+    };
     std::map<int64_t, std::vector<BlockAddEntry>> block_to_add;
     std::map<int64_t, std::vector<BlockDelEntry>> block_to_del;
+    std::vector<SnapshotEntry> snapshots;
 
     for (int i = 0; i < events_size; ++i) {
         const auto &item = request->events(i);
@@ -1618,6 +1623,51 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
             block_to_del[block_key].push_back(
                 BlockDelEntry{event_backend->BuildLocationId(p.medium(), host_ip_port), i});
+            break;
+        }
+        case proto::meta::EVENT_BLOCK_SNAPSHOT: {
+            if (!item.has_block_snapshot()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            const auto &p = item.block_snapshot();
+            if (p.medium().empty()) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty medium", trace_id.c_str());
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            SnapshotEntry snapshot;
+            snapshot.location_id = event_backend->BuildLocationId(p.medium(), host_ip_port);
+            snapshot.event_index = i;
+            bool valid_snapshot = true;
+            for (const auto &block : p.blocks()) {
+                int64_t block_key = 0;
+                if (!ParseInt64(block.block_key(), block_key)) {
+                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: invalid block_key [%s]",
+                                  trace_id.c_str(),
+                                  block.block_key().c_str());
+                    valid_snapshot = false;
+                    break;
+                }
+                if (block.specs_size() == 0) {
+                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty specs for block_key [%ld]",
+                                  trace_id.c_str(),
+                                  block_key);
+                    valid_snapshot = false;
+                    break;
+                }
+                auto &specs = snapshot.blocks[block_key];
+                specs.clear();
+                specs.reserve(block.specs_size());
+                for (const auto &s : block.specs()) {
+                    specs.emplace_back(s.name(), s.uri());
+                }
+            }
+            if (!valid_snapshot) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            snapshots.emplace_back(std::move(snapshot));
             break;
         }
         default:
@@ -1760,6 +1810,105 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
             KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
             KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
+        }
+    }
+
+    if (!snapshots.empty()) {
+        for (const auto &snapshot : snapshots) {
+            if (per_item_ec[snapshot.event_index] != EC_OK) {
+                continue;
+            }
+
+            KeyVector existing_keys;
+            auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
+            if (list_ec != EC_OK) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
+                              trace_id.c_str(),
+                              snapshot.location_id.c_str(),
+                              static_cast<int32_t>(list_ec));
+                per_item_ec[snapshot.event_index] = list_ec;
+                continue;
+            }
+
+            std::unordered_set<int64_t> existing_key_set(existing_keys.begin(), existing_keys.end());
+            std::unordered_set<int64_t> reported_key_set;
+            reported_key_set.reserve(snapshot.blocks.size());
+            for (const auto &block : snapshot.blocks) {
+                reported_key_set.insert(block.first);
+            }
+
+            KeyVector add_keys;
+            std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+            for (const auto &block : snapshot.blocks) {
+                if (existing_key_set.find(block.first) != existing_key_set.end()) {
+                    continue;
+                }
+                add_keys.push_back(block.first);
+                upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
+                    MetaSearcher::UpsertLocation{
+                        snapshot.location_id,
+                        event_backend->GetStorageType(),
+                        CacheLocationStatus::CLS_SERVING,
+                        block.second,
+                    },
+                });
+            }
+
+            if (!add_keys.empty()) {
+                std::vector<ErrorCode> per_key_ec;
+                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, add_keys, upserts, per_key_ec);
+                if (add_ec != EC_OK) {
+                    per_item_ec[snapshot.event_index] = add_ec;
+                } else {
+                    for (const auto &key_ec : per_key_ec) {
+                        if (key_ec != EC_OK) {
+                            per_item_ec[snapshot.event_index] = key_ec;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            KeyVector del_keys;
+            LocationIdsPerKey del_location_ids;
+            for (const auto &existing_key : existing_keys) {
+                if (reported_key_set.find(existing_key) != reported_key_set.end()) {
+                    continue;
+                }
+                del_keys.push_back(existing_key);
+                del_location_ids.push_back(LocationIdVector{snapshot.location_id});
+            }
+
+            if (!del_keys.empty()) {
+                std::vector<std::vector<ErrorCode>> per_location_ec;
+                auto del_ec =
+                    meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
+                if (del_ec != EC_OK) {
+                    per_item_ec[snapshot.event_index] = del_ec;
+                } else {
+                    for (const auto &location_ecs : per_location_ec) {
+                        for (const auto &loc_ec : location_ecs) {
+                            if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                                per_item_ec[snapshot.event_index] = loc_ec;
+                                break;
+                            }
+                        }
+                        if (per_item_ec[snapshot.event_index] != EC_OK) {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (per_item_ec[snapshot.event_index] == EC_OK) {
+                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], add[%zu], "
+                              "delete[%zu]",
+                              trace_id.c_str(),
+                              snapshot.location_id.c_str(),
+                              snapshot.blocks.size(),
+                              add_keys.size(),
+                              del_keys.size());
+            }
         }
     }
 
@@ -2077,6 +2226,7 @@ void CacheManager::StopRecoverRetryLoop() {
         recover_retry_thread_.join();
     }
 }
+
 void CacheManager::ClearEventCleanupCallbacks() {
     if (!registry_manager_ || !registry_manager_->data_storage_manager()) {
         return;

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1426,7 +1426,9 @@ LookupEventReportingBackend(const std::shared_ptr<RegistryManager> &registry_man
     return backend;
 }
 
-bool ParseInt64(const std::string &s, int64_t &out) {
+} // namespace
+
+bool CacheManager::ParseInt64(const std::string &s, int64_t &out) {
     try {
         size_t consumed = 0;
         int64_t v = std::stoll(s, &consumed);
@@ -1438,46 +1440,47 @@ bool ParseInt64(const std::string &s, int64_t &out) {
     } catch (...) { return false; }
 }
 
-std::string EscapeLocationScopeToken(const std::string &s) {
-    std::string out;
-    out.reserve(s.size());
-    for (char ch : s) {
-        if (ch == '\\' || ch == ';' || ch == '=') {
-            out.push_back('\\');
+bool CacheManager::HasPrefix(const std::string &s, const std::string &prefix) {
+    return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+bool CacheManager::IsMambaLocationSpecName(const std::string &name) {
+    return name == "mamba" || HasPrefix(name, "mamba:") || HasPrefix(name, "mamba/") ||
+           HasPrefix(name, "mamba_") || name == "mamba_state" || HasPrefix(name, "mamba_state:") ||
+           HasPrefix(name, "mamba_state/") || HasPrefix(name, "mamba_state_");
+}
+
+bool CacheManager::IsFullAttentionLocationSpecName(const std::string &name) {
+    // Legacy reporters use names like "tp0"; treat unknown names as full
+    // attention unless they explicitly opt into the mamba-state namespace.
+    return !IsMambaLocationSpecName(name);
+}
+
+bool CacheManager::ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names) {
+    if (spec_names.empty()) {
+        return true;
+    }
+    for (const auto &name : spec_names) {
+        if (IsFullAttentionLocationSpecName(name)) {
+            return true;
         }
-        out.push_back(ch);
     }
-    return out;
+    return false;
 }
 
-std::string ResolveMedium(const std::string &legacy_medium, const proto::meta::LocationScope &scope) {
-    return scope.medium().empty() ? legacy_medium : scope.medium();
-}
-
-std::string BuildScopedMedium(const std::string &medium, const proto::meta::LocationScope &scope) {
-    if (scope.labels().empty()) {
-        return medium;
-    }
-    std::map<std::string, std::string> sorted_labels;
-    for (const auto &kv : scope.labels()) {
-        if (!kv.first.empty()) {
-            sorted_labels[kv.first] = kv.second;
+std::vector<LocationSpec> CacheManager::BuildFullAttentionSpecs(
+    const google::protobuf::RepeatedPtrField<proto::meta::LocationSpec> &proto_specs) {
+    std::vector<LocationSpec> specs;
+    specs.reserve(proto_specs.size());
+    for (const auto &s : proto_specs) {
+        if (IsFullAttentionLocationSpecName(s.name())) {
+            specs.emplace_back(s.name(), s.uri());
         }
     }
-    if (sorted_labels.empty()) {
-        return medium;
-    }
-    std::string scoped_medium = medium;
-    for (const auto &kv : sorted_labels) {
-        scoped_medium.push_back(';');
-        scoped_medium.append(EscapeLocationScopeToken(kv.first));
-        scoped_medium.push_back('=');
-        scoped_medium.append(EscapeLocationScopeToken(kv.second));
-    }
-    return scoped_medium;
+    return specs;
 }
 
-bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs) {
+bool CacheManager::SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs) {
     if (lhs.size() != rhs.size()) {
         return false;
     }
@@ -1489,18 +1492,18 @@ bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<L
     return true;
 }
 
-bool CacheLocationEquals(const CacheLocationConstPtr &loc,
-                         DataStorageType type,
-                         CacheLocationStatus status,
-                         const std::vector<LocationSpec> &specs) {
+bool CacheManager::CacheLocationEquals(const CacheLocationConstPtr &loc,
+                                       DataStorageType type,
+                                       CacheLocationStatus status,
+                                       const std::vector<LocationSpec> &specs) {
     return loc && loc->type() == type && loc->status() == status && SameLocationSpecs(loc->location_specs(), specs);
 }
 
-bool ExistingLocationEquals(const CacheLocationMap *existing_map,
-                            const std::string &location_id,
-                            DataStorageType type,
-                            CacheLocationStatus status,
-                            const std::vector<LocationSpec> &specs) {
+bool CacheManager::ExistingLocationEquals(const CacheLocationMap *existing_map,
+                                          const std::string &location_id,
+                                          DataStorageType type,
+                                          CacheLocationStatus status,
+                                          const std::vector<LocationSpec> &specs) {
     if (!existing_map) {
         return false;
     }
@@ -1508,7 +1511,7 @@ bool ExistingLocationEquals(const CacheLocationMap *existing_map,
     return iter != existing_map->end() && CacheLocationEquals(iter->second, type, status, specs);
 }
 
-proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec) {
+proto::meta::ErrorCode CacheManager::ToProtoErrorCode(ErrorCode ec) {
     if (ec == EC_OK) {
         return proto::meta::OK;
     }
@@ -1524,7 +1527,547 @@ proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec) {
     return proto::meta::INTERNAL_ERROR;
 }
 
-} // namespace
+ServiceMetricsCollector *CacheManager::FindReportEventSubCollector(RequestContext *request_context,
+                                                                   const std::string &api_name) {
+    for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
+        auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
+        if (smc) {
+            const auto &tags = smc->GetMetricsTags();
+            auto it = tags.find("api_name");
+            if (it != tags.end() && it->second == api_name) {
+                return smc;
+            }
+        }
+    }
+    return nullptr;
+}
+
+void CacheManager::SetReportEventItemEcIfOk(ReportEventState *state, int event_index, ErrorCode ec) {
+    if (state && event_index >= 0 && event_index < static_cast<int>(state->per_item_ec.size()) &&
+        state->per_item_ec[event_index] == EC_OK) {
+        state->per_item_ec[event_index] = ec;
+    }
+}
+
+bool CacheManager::BuildReportEventLocationId(const std::string &trace_id,
+                                              EventReportingBackend *event_backend,
+                                              const std::string &host_ip_port,
+                                              const std::string &medium,
+                                              const char *event_name,
+                                              int event_index,
+                                              ReportEventState *state,
+                                              std::string &out_location_id) const {
+    if (medium.empty()) {
+        KVCM_LOG_WARN("trace_id [%s] | %s: empty medium", trace_id.c_str(), event_name);
+        SetReportEventItemEcIfOk(state, event_index, EC_BADARGS);
+        return false;
+    }
+    out_location_id = event_backend->BuildLocationId(medium, host_ip_port);
+    return true;
+}
+
+void CacheManager::FlushReportEventAdds(RequestContext *request_context,
+                                        MetaSearcher *meta_searcher,
+                                        EventReportingBackend *event_backend,
+                                        ReportEventState *state) const {
+    if (!state || state->pending_adds.empty()) {
+        return;
+    }
+    KeyVector add_keys_aggr;
+    std::vector<const std::vector<ReportEventBlockAddEntry> *> add_entries_aggr;
+    add_keys_aggr.reserve(state->pending_adds.size());
+    add_entries_aggr.reserve(state->pending_adds.size());
+    for (const auto &kv : state->pending_adds) {
+        add_keys_aggr.push_back(kv.first);
+        add_entries_aggr.push_back(&kv.second);
+    }
+
+    std::vector<CacheLocationMap> existing_location_maps;
+    BlockMask bm = static_cast<size_t>(0);
+    auto get_ec = meta_searcher->BatchGetLocation(request_context, add_keys_aggr, bm, existing_location_maps);
+    if (get_ec != EC_OK) {
+        for (const auto *entries : add_entries_aggr) {
+            for (const auto &entry : *entries) {
+                SetReportEventItemEcIfOk(state, entry.event_index, get_ec);
+            }
+        }
+        state->pending_adds.clear();
+        return;
+    }
+
+    struct PendingAddLocation {
+        std::vector<LocationSpec> specs;
+        std::vector<int> event_indices;
+    };
+    KeyVector filtered_keys;
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+    std::vector<std::vector<std::vector<int>>> upsert_event_indices;
+    for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
+        const auto &entries = *add_entries_aggr[i];
+        std::map<std::string, PendingAddLocation> final_entries_by_location;
+        for (const auto &entry : entries) {
+            auto &pending = final_entries_by_location[entry.location_id];
+            pending.specs = entry.specs;
+            pending.event_indices.push_back(entry.event_index);
+        }
+
+        std::vector<MetaSearcher::UpsertLocation> per_key_upserts;
+        std::vector<std::vector<int>> per_key_event_indices;
+        const CacheLocationMap *existing_map =
+            (i < existing_location_maps.size()) ? &existing_location_maps[i] : nullptr;
+        for (const auto &kv : final_entries_by_location) {
+            const auto &location_id = kv.first;
+            const auto &pending = kv.second;
+            if (ExistingLocationEquals(existing_map,
+                                       location_id,
+                                       event_backend->GetStorageType(),
+                                       CacheLocationStatus::CLS_SERVING,
+                                       pending.specs)) {
+                continue;
+            }
+            per_key_upserts.push_back(MetaSearcher::UpsertLocation{
+                location_id,
+                event_backend->GetStorageType(),
+                CacheLocationStatus::CLS_SERVING,
+                pending.specs,
+            });
+            per_key_event_indices.push_back(pending.event_indices);
+        }
+        if (!per_key_upserts.empty()) {
+            filtered_keys.push_back(add_keys_aggr[i]);
+            upserts.push_back(std::move(per_key_upserts));
+            upsert_event_indices.push_back(std::move(per_key_event_indices));
+        }
+    }
+
+    if (!filtered_keys.empty()) {
+        std::vector<ErrorCode> per_key_ec;
+        auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
+
+        for (size_t k = 0; k < filtered_keys.size(); ++k) {
+            ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
+            if (key_ec == EC_OK) {
+                continue;
+            }
+            for (const auto &event_indices : upsert_event_indices[k]) {
+                for (const auto event_index : event_indices) {
+                    SetReportEventItemEcIfOk(state, event_index, key_ec);
+                }
+            }
+        }
+        if (auto *add_mc = FindReportEventSubCollector(request_context, "EventBlockAdd")) {
+            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, filtered_keys.size());
+            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, filtered_keys.size());
+        }
+    }
+    state->pending_adds.clear();
+}
+
+void CacheManager::FlushReportEventDeletes(RequestContext *request_context,
+                                           MetaSearcher *meta_searcher,
+                                           ReportEventState *state) const {
+    if (!state || state->pending_dels.empty()) {
+        return;
+    }
+    KeyVector del_keys_aggr;
+    std::vector<const std::vector<ReportEventBlockDelEntry> *> del_entries_aggr;
+    del_keys_aggr.reserve(state->pending_dels.size());
+    del_entries_aggr.reserve(state->pending_dels.size());
+    for (const auto &kv : state->pending_dels) {
+        del_keys_aggr.push_back(kv.first);
+        del_entries_aggr.push_back(&kv.second);
+    }
+
+    struct PendingDelLocation {
+        std::vector<int> event_indices;
+    };
+    LocationIdsPerKey del_location_ids(del_keys_aggr.size());
+    std::vector<std::vector<std::vector<int>>> del_event_indices(del_keys_aggr.size());
+    for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
+        std::map<std::string, PendingDelLocation> final_entries_by_location;
+        for (const auto &entry : *del_entries_aggr[i]) {
+            final_entries_by_location[entry.location_id].event_indices.push_back(entry.event_index);
+        }
+        del_location_ids[i].reserve(final_entries_by_location.size());
+        del_event_indices[i].reserve(final_entries_by_location.size());
+        for (const auto &kv : final_entries_by_location) {
+            del_location_ids[i].push_back(kv.first);
+            del_event_indices[i].push_back(kv.second.event_indices);
+        }
+    }
+
+    std::vector<std::vector<ErrorCode>> per_location_ec;
+    auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
+
+    for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
+        if (del_ec != EC_OK || k >= per_location_ec.size()) {
+            ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
+            for (const auto &event_indices : del_event_indices[k]) {
+                for (const auto event_index : event_indices) {
+                    SetReportEventItemEcIfOk(state, event_index, key_ec);
+                }
+            }
+            continue;
+        }
+        for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
+            ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
+            if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
+                continue;
+            }
+            for (const auto event_index : del_event_indices[k][loc_index]) {
+                SetReportEventItemEcIfOk(state, event_index, loc_ec);
+            }
+        }
+    }
+    if (auto *del_mc = FindReportEventSubCollector(request_context, "EventBlockDelete")) {
+        KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
+        KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
+    }
+    state->pending_dels.clear();
+}
+
+void CacheManager::FlushReportEventPending(RequestContext *request_context,
+                                           MetaSearcher *meta_searcher,
+                                           EventReportingBackend *event_backend,
+                                           ReportEventState *state) const {
+    if (!state) {
+        return;
+    }
+    if (state->pending_kind == ReportEventPendingMutationKind::ADD) {
+        FlushReportEventAdds(request_context, meta_searcher, event_backend, state);
+    } else if (state->pending_kind == ReportEventPendingMutationKind::DELETE) {
+        FlushReportEventDeletes(request_context, meta_searcher, state);
+    }
+    state->pending_kind = ReportEventPendingMutationKind::NONE;
+}
+
+void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
+                                            MetaSearcher *meta_searcher,
+                                            EventReportingBackend *event_backend,
+                                            const ReportEventSnapshotEntry &snapshot,
+                                            ReportEventState *state) const {
+    if (!state || state->per_item_ec[snapshot.event_index] != EC_OK) {
+        return;
+    }
+
+    const std::string &trace_id = request_context->trace_id();
+    KeyVector existing_keys;
+    auto list_ec = meta_searcher->GetKeysByLocationIndex(request_context, snapshot.location_id, existing_keys);
+    if (list_ec != EC_OK) {
+        KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
+                      trace_id.c_str(),
+                      snapshot.location_id.c_str(),
+                      static_cast<int32_t>(list_ec));
+        state->per_item_ec[snapshot.event_index] = list_ec;
+        return;
+    }
+
+    std::unordered_set<int64_t> reported_key_set;
+    reported_key_set.reserve(snapshot.blocks.size());
+    KeyVector reported_keys;
+    reported_keys.reserve(snapshot.blocks.size());
+    for (const auto &block : snapshot.blocks) {
+        reported_key_set.insert(block.first);
+        reported_keys.push_back(block.first);
+    }
+
+    std::vector<CacheLocationMap> existing_reported_maps;
+    if (!reported_keys.empty()) {
+        BlockMask bm = static_cast<size_t>(0);
+        auto get_ec = meta_searcher->BatchGetLocation(request_context, reported_keys, bm, existing_reported_maps);
+        if (get_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = get_ec;
+            return;
+        }
+    }
+
+    KeyVector upsert_keys;
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+    size_t block_index = 0;
+    for (const auto &block : snapshot.blocks) {
+        const CacheLocationMap *existing_map =
+            (block_index < existing_reported_maps.size()) ? &existing_reported_maps[block_index] : nullptr;
+        ++block_index;
+        if (ExistingLocationEquals(existing_map,
+                                   snapshot.location_id,
+                                   event_backend->GetStorageType(),
+                                   CacheLocationStatus::CLS_SERVING,
+                                   block.second)) {
+            continue;
+        }
+        upsert_keys.push_back(block.first);
+        upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
+            MetaSearcher::UpsertLocation{
+                snapshot.location_id,
+                event_backend->GetStorageType(),
+                CacheLocationStatus::CLS_SERVING,
+                block.second,
+            },
+        });
+    }
+
+    if (!upsert_keys.empty()) {
+        std::vector<ErrorCode> per_key_ec;
+        auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
+        if (add_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = add_ec;
+        } else {
+            for (const auto &key_ec : per_key_ec) {
+                if (key_ec != EC_OK) {
+                    state->per_item_ec[snapshot.event_index] = key_ec;
+                    break;
+                }
+            }
+        }
+    }
+    if (state->per_item_ec[snapshot.event_index] != EC_OK) {
+        return;
+    }
+
+    KeyVector del_keys;
+    LocationIdsPerKey del_location_ids;
+    for (const auto &existing_key : existing_keys) {
+        if (reported_key_set.find(existing_key) != reported_key_set.end()) {
+            continue;
+        }
+        del_keys.push_back(existing_key);
+        del_location_ids.push_back(LocationIdVector{snapshot.location_id});
+    }
+
+    if (!del_keys.empty()) {
+        std::vector<std::vector<ErrorCode>> per_location_ec;
+        auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
+        if (del_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = del_ec;
+        } else {
+            for (const auto &location_ecs : per_location_ec) {
+                for (const auto &loc_ec : location_ecs) {
+                    if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                        state->per_item_ec[snapshot.event_index] = loc_ec;
+                        break;
+                    }
+                }
+                if (state->per_item_ec[snapshot.event_index] != EC_OK) {
+                    break;
+                }
+            }
+        }
+    }
+
+    if (state->per_item_ec[snapshot.event_index] == EC_OK) {
+        KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
+                      "delete[%zu]",
+                      trace_id.c_str(),
+                      snapshot.location_id.c_str(),
+                      snapshot.blocks.size(),
+                      upsert_keys.size(),
+                      del_keys.size());
+    }
+}
+
+void CacheManager::ProcessReportEventItem(RequestContext *request_context,
+                                          const proto::meta::EventItem &item,
+                                          int event_index,
+                                          const std::string &instance_id,
+                                          const std::string &host_ip_port,
+                                          DataStorageType requested_type,
+                                          MetaSearcher *meta_searcher,
+                                          EventReportingBackend *event_backend,
+                                          ReportEventState *state) {
+    const std::string &trace_id = request_context->trace_id();
+    switch (item.event_type()) {
+    case proto::meta::EVENT_NODE_REGISTER: {
+        if (!item.has_node_register()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::vector<std::string> register_mediums;
+        for (const auto &m : item.node_register().mediums()) {
+            if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
+                register_mediums.push_back(m);
+            }
+        }
+        auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
+        if (ec != EC_OK) {
+            state->per_item_ec[event_index] = ec;
+        } else {
+            KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
+                          trace_id.c_str(),
+                          host_ip_port.c_str(),
+                          register_mediums.size(),
+                          instance_id.c_str());
+        }
+        break;
+    }
+    case proto::meta::EVENT_HEARTBEAT: {
+        if (!item.has_heartbeat()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::map<std::string, std::string> heartbeat_status;
+        for (const auto &kv : item.heartbeat().system_status()) {
+            heartbeat_status[kv.first] = kv.second;
+        }
+        state->per_item_ec[event_index] = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
+        break;
+    }
+    case proto::meta::EVENT_HOST_DOWN: {
+        FlushReportEventPending(request_context, meta_searcher, event_backend, state);
+        event_backend->SetNodeUnavailable(instance_id, host_ip_port);
+        uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
+        assert(schedule_plan_executor_);
+        schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
+            this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
+        });
+        event_backend->UnregisterNode(instance_id, host_ip_port);
+        KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
+                      trace_id.c_str(),
+                      host_ip_port.c_str(),
+                      gen_at_trigger);
+        break;
+    }
+    case proto::meta::EVENT_BLOCK_ADD: {
+        if (!item.has_block_add()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        const auto &p = item.block_add();
+        int64_t block_key = 0;
+        if (!ParseInt64(p.block_key(), block_key)) {
+            KVCM_LOG_WARN(
+                "trace_id [%s] | EVENT_BLOCK_ADD: invalid block_key [%s]", trace_id.c_str(), p.block_key().c_str());
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        if (p.specs_size() == 0) {
+            KVCM_LOG_WARN(
+                "trace_id [%s] | EVENT_BLOCK_ADD: empty specs for block_key [%ld]", trace_id.c_str(), block_key);
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::string location_id;
+        if (!BuildReportEventLocationId(
+                trace_id, event_backend, host_ip_port, p.medium(), "EVENT_BLOCK_ADD", event_index, state, location_id)) {
+            break;
+        }
+        std::vector<LocationSpec> entry_specs = BuildFullAttentionSpecs(p.specs());
+        if (entry_specs.empty()) {
+            KVCM_LOG_DEBUG("trace_id [%s] | EVENT_BLOCK_ADD: skip non-full-attention specs for block_key [%ld]",
+                           trace_id.c_str(),
+                           block_key);
+            break;
+        }
+        if (state->pending_kind == ReportEventPendingMutationKind::DELETE) {
+            FlushReportEventDeletes(request_context, meta_searcher, state);
+        }
+        state->pending_kind = ReportEventPendingMutationKind::ADD;
+        state->pending_adds[block_key].push_back(
+            ReportEventBlockAddEntry{std::move(location_id), std::move(entry_specs), event_index});
+        break;
+    }
+    case proto::meta::EVENT_BLOCK_DELETE: {
+        if (!item.has_block_delete()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        const auto &p = item.block_delete();
+        int64_t block_key = 0;
+        if (!ParseInt64(p.block_key(), block_key)) {
+            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_DELETE: invalid block_key [%s]",
+                          trace_id.c_str(),
+                          p.block_key().c_str());
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        std::string location_id;
+        if (!BuildReportEventLocationId(trace_id,
+                                        event_backend,
+                                        host_ip_port,
+                                        p.medium(),
+                                        "EVENT_BLOCK_DELETE",
+                                        event_index,
+                                        state,
+                                        location_id)) {
+            break;
+        }
+        if (!ContainsFullAttentionSpecName(p.spec_names())) {
+            KVCM_LOG_DEBUG("trace_id [%s] | EVENT_BLOCK_DELETE: skip non-full-attention spec_names for block_key "
+                           "[%ld]",
+                           trace_id.c_str(),
+                           block_key);
+            break;
+        }
+        if (state->pending_kind == ReportEventPendingMutationKind::ADD) {
+            FlushReportEventAdds(request_context, meta_searcher, event_backend, state);
+        }
+        state->pending_kind = ReportEventPendingMutationKind::DELETE;
+        state->pending_dels[block_key].push_back(ReportEventBlockDelEntry{std::move(location_id), event_index});
+        break;
+    }
+    case proto::meta::EVENT_BLOCK_SNAPSHOT: {
+        FlushReportEventPending(request_context, meta_searcher, event_backend, state);
+        if (!item.has_block_snapshot()) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        const auto &p = item.block_snapshot();
+        ReportEventSnapshotEntry snapshot;
+        if (!BuildReportEventLocationId(trace_id,
+                                        event_backend,
+                                        host_ip_port,
+                                        p.medium(),
+                                        "EVENT_BLOCK_SNAPSHOT",
+                                        event_index,
+                                        state,
+                                        snapshot.location_id)) {
+            break;
+        }
+        snapshot.event_index = event_index;
+        bool valid_snapshot = true;
+        bool has_filtered_block = false;
+        for (const auto &block : p.blocks()) {
+            int64_t block_key = 0;
+            if (!ParseInt64(block.block_key(), block_key)) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: invalid block_key [%s]",
+                              trace_id.c_str(),
+                              block.block_key().c_str());
+                valid_snapshot = false;
+                break;
+            }
+            if (block.specs_size() == 0) {
+                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty specs for block_key [%ld]",
+                              trace_id.c_str(),
+                              block_key);
+                valid_snapshot = false;
+                break;
+            }
+            auto specs = BuildFullAttentionSpecs(block.specs());
+            if (!specs.empty()) {
+                has_filtered_block = true;
+                snapshot.blocks[block_key] = std::move(specs);
+            }
+        }
+        if (!valid_snapshot) {
+            state->per_item_ec[event_index] = EC_BADARGS;
+            break;
+        }
+        if (p.blocks_size() > 0 && !has_filtered_block) {
+            KVCM_LOG_DEBUG("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: skip non-full-attention snapshot",
+                           trace_id.c_str());
+            break;
+        }
+        ApplyReportEventSnapshot(request_context, meta_searcher, event_backend, snapshot, state);
+        break;
+    }
+    default:
+        KVCM_LOG_WARN("trace_id [%s] | ReportEvent: unknown event_type %d at index %d (ignored)",
+                      trace_id.c_str(),
+                      static_cast<int>(item.event_type()),
+                      event_index);
+        state->per_item_ec[event_index] = EC_BADARGS;
+        break;
+    }
+}
 
 ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                                     const proto::meta::ReportEventRequest *request,
@@ -1598,536 +2141,30 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         return EC_INSTANCE_NOT_EXIST;
     }
 
-    const int events_size = request->events_size();
-    std::vector<ErrorCode> per_item_ec(events_size, EC_OK);
-
-    struct BlockAddEntry {
-        std::string location_id;
-        std::vector<LocationSpec> specs;
-        int event_index;
-    };
-    struct BlockDelEntry {
-        std::string location_id;
-        int event_index;
-    };
-    struct SnapshotEntry {
-        std::string location_id;
-        std::map<int64_t, std::vector<LocationSpec>> blocks;
-        int event_index;
-    };
-    struct PendingAddLocation {
-        std::vector<LocationSpec> specs;
-        std::vector<int> event_indices;
-    };
-    struct PendingDelLocation {
-        std::vector<int> event_indices;
-    };
-    std::map<int64_t, std::vector<BlockAddEntry>> pending_adds;
-    std::map<int64_t, std::vector<BlockDelEntry>> pending_dels;
-    enum class PendingMutationKind { NONE, ADD, DELETE };
-    PendingMutationKind pending_kind = PendingMutationKind::NONE;
-
-    auto find_sub_collector = [&request_context](const std::string &api_name) -> ServiceMetricsCollector * {
-        for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
-            auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
-            if (smc) {
-                const auto &tags = smc->GetMetricsTags();
-                auto it = tags.find("api_name");
-                if (it != tags.end() && it->second == api_name) {
-                    return smc;
-                }
-            }
-        }
-        return nullptr;
-    };
-
-    auto set_item_ec_if_ok = [&per_item_ec](int event_index, ErrorCode ec) {
-        if (event_index >= 0 && event_index < static_cast<int>(per_item_ec.size()) && per_item_ec[event_index] == EC_OK) {
-            per_item_ec[event_index] = ec;
-        }
-    };
-
-    proto::meta::LocationScope empty_scope;
-    auto build_location_id = [&](const std::string &legacy_medium,
-                                 const proto::meta::LocationScope &scope,
-                                 const char *event_name,
-                                 int event_index,
-                                 std::string &out_location_id) -> bool {
-        std::string medium = ResolveMedium(legacy_medium, scope);
-        if (medium.empty()) {
-            KVCM_LOG_WARN("trace_id [%s] | %s: empty medium", trace_id.c_str(), event_name);
-            set_item_ec_if_ok(event_index, EC_BADARGS);
-            return false;
-        }
-        out_location_id = event_backend->BuildLocationId(BuildScopedMedium(medium, scope), host_ip_port);
-        return true;
-    };
-
-    auto flush_adds = [&]() {
-        if (pending_adds.empty()) {
-            return;
-        }
-        KeyVector add_keys_aggr;
-        std::vector<const std::vector<BlockAddEntry> *> add_entries_aggr;
-        add_keys_aggr.reserve(pending_adds.size());
-        add_entries_aggr.reserve(pending_adds.size());
-        for (const auto &kv : pending_adds) {
-            add_keys_aggr.push_back(kv.first);
-            add_entries_aggr.push_back(&kv.second);
-        }
-
-        std::vector<CacheLocationMap> existing_location_maps;
-        BlockMask bm = static_cast<size_t>(0);
-        auto get_ec = meta_searcher->BatchGetLocation(request_context, add_keys_aggr, bm, existing_location_maps);
-        if (get_ec != EC_OK) {
-            for (const auto *entries : add_entries_aggr) {
-                for (const auto &entry : *entries) {
-                    set_item_ec_if_ok(entry.event_index, get_ec);
-                }
-            }
-            pending_adds.clear();
-            return;
-        }
-
-        KeyVector filtered_keys;
-        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
-        std::vector<std::vector<std::vector<int>>> upsert_event_indices;
-        for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
-            const auto &entries = *add_entries_aggr[i];
-            std::map<std::string, PendingAddLocation> final_entries_by_location;
-            for (const auto &entry : entries) {
-                auto &pending = final_entries_by_location[entry.location_id];
-                pending.specs = entry.specs;
-                pending.event_indices.push_back(entry.event_index);
-            }
-
-            std::vector<MetaSearcher::UpsertLocation> per_key_upserts;
-            std::vector<std::vector<int>> per_key_event_indices;
-            const CacheLocationMap *existing_map =
-                (i < existing_location_maps.size()) ? &existing_location_maps[i] : nullptr;
-            for (const auto &kv : final_entries_by_location) {
-                const auto &location_id = kv.first;
-                const auto &pending = kv.second;
-                if (ExistingLocationEquals(existing_map,
-                                           location_id,
-                                           event_backend->GetStorageType(),
-                                           CacheLocationStatus::CLS_SERVING,
-                                           pending.specs)) {
-                    continue;
-                }
-                per_key_upserts.push_back(MetaSearcher::UpsertLocation{
-                    location_id,
-                    event_backend->GetStorageType(),
-                    CacheLocationStatus::CLS_SERVING,
-                    pending.specs,
-                });
-                per_key_event_indices.push_back(pending.event_indices);
-            }
-            if (!per_key_upserts.empty()) {
-                filtered_keys.push_back(add_keys_aggr[i]);
-                upserts.push_back(std::move(per_key_upserts));
-                upsert_event_indices.push_back(std::move(per_key_event_indices));
-            }
-        }
-
-        if (!filtered_keys.empty()) {
-            std::vector<ErrorCode> per_key_ec;
-            auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
-
-            for (size_t k = 0; k < filtered_keys.size(); ++k) {
-                ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
-                if (key_ec == EC_OK) {
-                    continue;
-                }
-                for (const auto &event_indices : upsert_event_indices[k]) {
-                    for (const auto event_index : event_indices) {
-                        set_item_ec_if_ok(event_index, key_ec);
-                    }
-                }
-            }
-            if (auto *add_mc = find_sub_collector("EventBlockAdd")) {
-                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, filtered_keys.size());
-                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, filtered_keys.size());
-            }
-        }
-        pending_adds.clear();
-    };
-
-    auto flush_dels = [&]() {
-        if (pending_dels.empty()) {
-            return;
-        }
-        KeyVector del_keys_aggr;
-        std::vector<const std::vector<BlockDelEntry> *> del_entries_aggr;
-        del_keys_aggr.reserve(pending_dels.size());
-        del_entries_aggr.reserve(pending_dels.size());
-        for (const auto &kv : pending_dels) {
-            del_keys_aggr.push_back(kv.first);
-            del_entries_aggr.push_back(&kv.second);
-        }
-
-        LocationIdsPerKey del_location_ids(del_keys_aggr.size());
-        std::vector<std::vector<std::vector<int>>> del_event_indices(del_keys_aggr.size());
-        for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
-            std::map<std::string, PendingDelLocation> final_entries_by_location;
-            for (const auto &entry : *del_entries_aggr[i]) {
-                final_entries_by_location[entry.location_id].event_indices.push_back(entry.event_index);
-            }
-            del_location_ids[i].reserve(final_entries_by_location.size());
-            del_event_indices[i].reserve(final_entries_by_location.size());
-            for (const auto &kv : final_entries_by_location) {
-                del_location_ids[i].push_back(kv.first);
-                del_event_indices[i].push_back(kv.second.event_indices);
-            }
-        }
-
-        std::vector<std::vector<ErrorCode>> per_location_ec;
-        auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
-
-        for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
-            if (del_ec != EC_OK || k >= per_location_ec.size()) {
-                ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
-                for (const auto &event_indices : del_event_indices[k]) {
-                    for (const auto event_index : event_indices) {
-                        set_item_ec_if_ok(event_index, key_ec);
-                    }
-                }
-                continue;
-            }
-            for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
-                ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
-                if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
-                    continue;
-                }
-                for (const auto event_index : del_event_indices[k][loc_index]) {
-                    set_item_ec_if_ok(event_index, loc_ec);
-                }
-            }
-        }
-        if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
-        }
-        pending_dels.clear();
-    };
-
-    auto flush_pending = [&]() {
-        if (pending_kind == PendingMutationKind::ADD) {
-            flush_adds();
-        } else if (pending_kind == PendingMutationKind::DELETE) {
-            flush_dels();
-        }
-        pending_kind = PendingMutationKind::NONE;
-    };
-
-    auto apply_snapshot = [&](const SnapshotEntry &snapshot) {
-        if (per_item_ec[snapshot.event_index] != EC_OK) {
-            return;
-        }
-
-        KeyVector existing_keys;
-        auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
-        if (list_ec != EC_OK) {
-            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
-                          trace_id.c_str(),
-                          snapshot.location_id.c_str(),
-                          static_cast<int32_t>(list_ec));
-            per_item_ec[snapshot.event_index] = list_ec;
-            return;
-        }
-
-        std::unordered_set<int64_t> reported_key_set;
-        reported_key_set.reserve(snapshot.blocks.size());
-        KeyVector reported_keys;
-        reported_keys.reserve(snapshot.blocks.size());
-        for (const auto &block : snapshot.blocks) {
-            reported_key_set.insert(block.first);
-            reported_keys.push_back(block.first);
-        }
-
-        std::vector<CacheLocationMap> existing_reported_maps;
-        if (!reported_keys.empty()) {
-            BlockMask bm = static_cast<size_t>(0);
-            auto get_ec = meta_searcher->BatchGetLocation(request_context, reported_keys, bm, existing_reported_maps);
-            if (get_ec != EC_OK) {
-                per_item_ec[snapshot.event_index] = get_ec;
-                return;
-            }
-        }
-
-        KeyVector upsert_keys;
-        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
-        size_t block_index = 0;
-        for (const auto &block : snapshot.blocks) {
-            const CacheLocationMap *existing_map =
-                (block_index < existing_reported_maps.size()) ? &existing_reported_maps[block_index] : nullptr;
-            ++block_index;
-            if (ExistingLocationEquals(existing_map,
-                                       snapshot.location_id,
-                                       event_backend->GetStorageType(),
-                                       CacheLocationStatus::CLS_SERVING,
-                                       block.second)) {
-                continue;
-            }
-            upsert_keys.push_back(block.first);
-            upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
-                MetaSearcher::UpsertLocation{
-                    snapshot.location_id,
-                    event_backend->GetStorageType(),
-                    CacheLocationStatus::CLS_SERVING,
-                    block.second,
-                },
-            });
-        }
-
-        if (!upsert_keys.empty()) {
-            std::vector<ErrorCode> per_key_ec;
-            auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
-            if (add_ec != EC_OK) {
-                per_item_ec[snapshot.event_index] = add_ec;
-            } else {
-                for (const auto &key_ec : per_key_ec) {
-                    if (key_ec != EC_OK) {
-                        per_item_ec[snapshot.event_index] = key_ec;
-                        break;
-                    }
-                }
-            }
-        }
-        if (per_item_ec[snapshot.event_index] != EC_OK) {
-            return;
-        }
-
-        KeyVector del_keys;
-        LocationIdsPerKey del_location_ids;
-        for (const auto &existing_key : existing_keys) {
-            if (reported_key_set.find(existing_key) != reported_key_set.end()) {
-                continue;
-            }
-            del_keys.push_back(existing_key);
-            del_location_ids.push_back(LocationIdVector{snapshot.location_id});
-        }
-
-        if (!del_keys.empty()) {
-            std::vector<std::vector<ErrorCode>> per_location_ec;
-            auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
-            if (del_ec != EC_OK) {
-                per_item_ec[snapshot.event_index] = del_ec;
-            } else {
-                for (const auto &location_ecs : per_location_ec) {
-                    for (const auto &loc_ec : location_ecs) {
-                        if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
-                            per_item_ec[snapshot.event_index] = loc_ec;
-                            break;
-                        }
-                    }
-                    if (per_item_ec[snapshot.event_index] != EC_OK) {
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (per_item_ec[snapshot.event_index] == EC_OK) {
-            KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
-                          "delete[%zu]",
-                          trace_id.c_str(),
-                          snapshot.location_id.c_str(),
-                          snapshot.blocks.size(),
-                          upsert_keys.size(),
-                          del_keys.size());
-        }
-    };
-
-    for (int i = 0; i < events_size; ++i) {
-        const auto &item = request->events(i);
-        switch (item.event_type()) {
-        case proto::meta::EVENT_NODE_REGISTER: {
-            if (!item.has_node_register()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::vector<std::string> register_mediums;
-            for (const auto &m : item.node_register().mediums()) {
-                if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
-                    register_mediums.push_back(m);
-                }
-            }
-            auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
-            if (ec != EC_OK) {
-                per_item_ec[i] = ec;
-            } else {
-                KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
-                              trace_id.c_str(),
-                              host_ip_port.c_str(),
-                              register_mediums.size(),
-                              instance_id.c_str());
-            }
-            break;
-        }
-        case proto::meta::EVENT_HEARTBEAT: {
-            if (!item.has_heartbeat()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::map<std::string, std::string> heartbeat_status;
-            for (const auto &kv : item.heartbeat().system_status()) {
-                heartbeat_status[kv.first] = kv.second;
-            }
-            per_item_ec[i] = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
-            break;
-        }
-        case proto::meta::EVENT_HOST_DOWN: {
-            flush_pending();
-            event_backend->SetNodeUnavailable(instance_id, host_ip_port);
-            uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
-            assert(schedule_plan_executor_);
-            schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
-                this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
-            });
-            event_backend->UnregisterNode(instance_id, host_ip_port);
-            KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
-                          trace_id.c_str(),
-                          host_ip_port.c_str(),
-                          gen_at_trigger);
-            break;
-        }
-        case proto::meta::EVENT_BLOCK_ADD: {
-            if (!item.has_block_add()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            const auto &p = item.block_add();
-            int64_t block_key = 0;
-            if (!ParseInt64(p.block_key(), block_key)) {
-                KVCM_LOG_WARN(
-                    "trace_id [%s] | EVENT_BLOCK_ADD: invalid block_key [%s]", trace_id.c_str(), p.block_key().c_str());
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            if (p.specs_size() == 0) {
-                KVCM_LOG_WARN(
-                    "trace_id [%s] | EVENT_BLOCK_ADD: empty specs for block_key [%ld]", trace_id.c_str(), block_key);
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::string location_id;
-            if (!build_location_id(p.medium(),
-                                   p.has_location() ? p.location() : empty_scope,
-                                   "EVENT_BLOCK_ADD",
-                                   i,
-                                   location_id)) {
-                break;
-            }
-            if (pending_kind == PendingMutationKind::DELETE) {
-                flush_dels();
-            }
-            pending_kind = PendingMutationKind::ADD;
-            std::vector<LocationSpec> entry_specs;
-            entry_specs.reserve(p.specs_size());
-            for (const auto &s : p.specs()) {
-                entry_specs.emplace_back(s.name(), s.uri());
-            }
-            pending_adds[block_key].push_back(BlockAddEntry{std::move(location_id), std::move(entry_specs), i});
-            break;
-        }
-        case proto::meta::EVENT_BLOCK_DELETE: {
-            if (!item.has_block_delete()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            const auto &p = item.block_delete();
-            int64_t block_key = 0;
-            if (!ParseInt64(p.block_key(), block_key)) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_DELETE: invalid block_key [%s]",
-                              trace_id.c_str(),
-                              p.block_key().c_str());
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            std::string location_id;
-            if (!build_location_id(p.medium(),
-                                   p.has_location() ? p.location() : empty_scope,
-                                   "EVENT_BLOCK_DELETE",
-                                   i,
-                                   location_id)) {
-                break;
-            }
-            if (pending_kind == PendingMutationKind::ADD) {
-                flush_adds();
-            }
-            pending_kind = PendingMutationKind::DELETE;
-            pending_dels[block_key].push_back(BlockDelEntry{std::move(location_id), i});
-            break;
-        }
-        case proto::meta::EVENT_BLOCK_SNAPSHOT: {
-            flush_pending();
-            if (!item.has_block_snapshot()) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            const auto &p = item.block_snapshot();
-            SnapshotEntry snapshot;
-            if (!build_location_id(p.medium(),
-                                   p.has_location() ? p.location() : empty_scope,
-                                   "EVENT_BLOCK_SNAPSHOT",
-                                   i,
-                                   snapshot.location_id)) {
-                break;
-            }
-            snapshot.event_index = i;
-            bool valid_snapshot = true;
-            for (const auto &block : p.blocks()) {
-                int64_t block_key = 0;
-                if (!ParseInt64(block.block_key(), block_key)) {
-                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: invalid block_key [%s]",
-                                  trace_id.c_str(),
-                                  block.block_key().c_str());
-                    valid_snapshot = false;
-                    break;
-                }
-                if (block.specs_size() == 0) {
-                    KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty specs for block_key [%ld]",
-                                  trace_id.c_str(),
-                                  block_key);
-                    valid_snapshot = false;
-                    break;
-                }
-                auto &specs = snapshot.blocks[block_key];
-                specs.clear();
-                specs.reserve(block.specs_size());
-                for (const auto &s : block.specs()) {
-                    specs.emplace_back(s.name(), s.uri());
-                }
-            }
-            if (!valid_snapshot) {
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
-            apply_snapshot(snapshot);
-            break;
-        }
-        default:
-            KVCM_LOG_WARN("trace_id [%s] | ReportEvent: unknown event_type %d at index %d (ignored)",
-                          trace_id.c_str(),
-                          static_cast<int>(item.event_type()),
-                          i);
-            per_item_ec[i] = EC_BADARGS;
-            break;
-        }
+    ReportEventState state(request->events_size());
+    for (int i = 0; i < request->events_size(); ++i) {
+        ProcessReportEventItem(request_context,
+                               request->events(i),
+                               i,
+                               instance_id,
+                               host_ip_port,
+                               requested_type,
+                               meta_searcher,
+                               event_backend,
+                               &state);
     }
 
-    flush_pending();
+    FlushReportEventPending(request_context, meta_searcher, event_backend, &state);
 
     bool any_failure = false;
-    for (auto ec : per_item_ec) {
+    for (auto ec : state.per_item_ec) {
         if (ec != EC_OK) {
             any_failure = true;
             break;
         }
     }
     if (any_failure) {
-        for (auto ec : per_item_ec) {
+        for (auto ec : state.per_item_ec) {
             response->add_item_results(ToProtoErrorCode(ec));
         }
         response_status->set_code(proto::meta::INTERNAL_ERROR);

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -4,6 +4,7 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -1437,6 +1438,92 @@ bool ParseInt64(const std::string &s, int64_t &out) {
     } catch (...) { return false; }
 }
 
+std::string EscapeLocationScopeToken(const std::string &s) {
+    std::string out;
+    out.reserve(s.size());
+    for (char ch : s) {
+        if (ch == '\\' || ch == ';' || ch == '=') {
+            out.push_back('\\');
+        }
+        out.push_back(ch);
+    }
+    return out;
+}
+
+std::string ResolveMedium(const std::string &legacy_medium, const proto::meta::LocationScope &scope) {
+    return scope.medium().empty() ? legacy_medium : scope.medium();
+}
+
+std::string BuildScopedMedium(const std::string &medium, const proto::meta::LocationScope &scope) {
+    if (scope.labels().empty()) {
+        return medium;
+    }
+    std::map<std::string, std::string> sorted_labels;
+    for (const auto &kv : scope.labels()) {
+        if (!kv.first.empty()) {
+            sorted_labels[kv.first] = kv.second;
+        }
+    }
+    if (sorted_labels.empty()) {
+        return medium;
+    }
+    std::string scoped_medium = medium;
+    for (const auto &kv : sorted_labels) {
+        scoped_medium.push_back(';');
+        scoped_medium.append(EscapeLocationScopeToken(kv.first));
+        scoped_medium.push_back('=');
+        scoped_medium.append(EscapeLocationScopeToken(kv.second));
+    }
+    return scoped_medium;
+}
+
+bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i].name() != rhs[i].name() || lhs[i].uri() != rhs[i].uri()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CacheLocationEquals(const CacheLocationConstPtr &loc,
+                         DataStorageType type,
+                         CacheLocationStatus status,
+                         const std::vector<LocationSpec> &specs) {
+    return loc && loc->type() == type && loc->status() == status && SameLocationSpecs(loc->location_specs(), specs);
+}
+
+bool ExistingLocationEquals(const CacheLocationMap *existing_map,
+                            const std::string &location_id,
+                            DataStorageType type,
+                            CacheLocationStatus status,
+                            const std::vector<LocationSpec> &specs) {
+    if (!existing_map) {
+        return false;
+    }
+    auto iter = existing_map->find(location_id);
+    return iter != existing_map->end() && CacheLocationEquals(iter->second, type, status, specs);
+}
+
+proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec) {
+    if (ec == EC_OK) {
+        return proto::meta::OK;
+    }
+    if (ec == EC_BADARGS) {
+        return proto::meta::INVALID_ARGUMENT;
+    }
+    if (ec == EC_INSTANCE_NOT_EXIST) {
+        return proto::meta::INSTANCE_NOT_EXIST;
+    }
+    if (ec == EC_NODE_NOT_REGISTERED) {
+        return proto::meta::NODE_NOT_REGISTERED;
+    }
+    return proto::meta::INTERNAL_ERROR;
+}
+
 } // namespace
 
 ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
@@ -1514,12 +1601,6 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     const int events_size = request->events_size();
     std::vector<ErrorCode> per_item_ec(events_size, EC_OK);
 
-    bool has_register = false;
-    bool has_heartbeat = false;
-    bool has_host_down = false;
-    std::vector<std::string> register_mediums;
-    std::map<std::string, std::string> heartbeat_status;
-
     struct BlockAddEntry {
         std::string location_id;
         std::vector<LocationSpec> specs;
@@ -1534,36 +1615,381 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         std::map<int64_t, std::vector<LocationSpec>> blocks;
         int event_index;
     };
-    std::map<int64_t, std::vector<BlockAddEntry>> block_to_add;
-    std::map<int64_t, std::vector<BlockDelEntry>> block_to_del;
-    std::vector<SnapshotEntry> snapshots;
+    struct PendingAddLocation {
+        std::vector<LocationSpec> specs;
+        std::vector<int> event_indices;
+    };
+    struct PendingDelLocation {
+        std::vector<int> event_indices;
+    };
+    std::map<int64_t, std::vector<BlockAddEntry>> pending_adds;
+    std::map<int64_t, std::vector<BlockDelEntry>> pending_dels;
+    enum class PendingMutationKind { NONE, ADD, DELETE };
+    PendingMutationKind pending_kind = PendingMutationKind::NONE;
+
+    auto find_sub_collector = [&request_context](const std::string &api_name) -> ServiceMetricsCollector * {
+        for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
+            auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
+            if (smc) {
+                const auto &tags = smc->GetMetricsTags();
+                auto it = tags.find("api_name");
+                if (it != tags.end() && it->second == api_name) {
+                    return smc;
+                }
+            }
+        }
+        return nullptr;
+    };
+
+    auto set_item_ec_if_ok = [&per_item_ec](int event_index, ErrorCode ec) {
+        if (event_index >= 0 && event_index < static_cast<int>(per_item_ec.size()) && per_item_ec[event_index] == EC_OK) {
+            per_item_ec[event_index] = ec;
+        }
+    };
+
+    proto::meta::LocationScope empty_scope;
+    auto build_location_id = [&](const std::string &legacy_medium,
+                                 const proto::meta::LocationScope &scope,
+                                 const char *event_name,
+                                 int event_index,
+                                 std::string &out_location_id) -> bool {
+        std::string medium = ResolveMedium(legacy_medium, scope);
+        if (medium.empty()) {
+            KVCM_LOG_WARN("trace_id [%s] | %s: empty medium", trace_id.c_str(), event_name);
+            set_item_ec_if_ok(event_index, EC_BADARGS);
+            return false;
+        }
+        out_location_id = event_backend->BuildLocationId(BuildScopedMedium(medium, scope), host_ip_port);
+        return true;
+    };
+
+    auto flush_adds = [&]() {
+        if (pending_adds.empty()) {
+            return;
+        }
+        KeyVector add_keys_aggr;
+        std::vector<const std::vector<BlockAddEntry> *> add_entries_aggr;
+        add_keys_aggr.reserve(pending_adds.size());
+        add_entries_aggr.reserve(pending_adds.size());
+        for (const auto &kv : pending_adds) {
+            add_keys_aggr.push_back(kv.first);
+            add_entries_aggr.push_back(&kv.second);
+        }
+
+        std::vector<CacheLocationMap> existing_location_maps;
+        BlockMask bm = static_cast<size_t>(0);
+        auto get_ec = meta_searcher->BatchGetLocation(request_context, add_keys_aggr, bm, existing_location_maps);
+        if (get_ec != EC_OK) {
+            for (const auto *entries : add_entries_aggr) {
+                for (const auto &entry : *entries) {
+                    set_item_ec_if_ok(entry.event_index, get_ec);
+                }
+            }
+            pending_adds.clear();
+            return;
+        }
+
+        KeyVector filtered_keys;
+        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+        std::vector<std::vector<std::vector<int>>> upsert_event_indices;
+        for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
+            const auto &entries = *add_entries_aggr[i];
+            std::map<std::string, PendingAddLocation> final_entries_by_location;
+            for (const auto &entry : entries) {
+                auto &pending = final_entries_by_location[entry.location_id];
+                pending.specs = entry.specs;
+                pending.event_indices.push_back(entry.event_index);
+            }
+
+            std::vector<MetaSearcher::UpsertLocation> per_key_upserts;
+            std::vector<std::vector<int>> per_key_event_indices;
+            const CacheLocationMap *existing_map =
+                (i < existing_location_maps.size()) ? &existing_location_maps[i] : nullptr;
+            for (const auto &kv : final_entries_by_location) {
+                const auto &location_id = kv.first;
+                const auto &pending = kv.second;
+                if (ExistingLocationEquals(existing_map,
+                                           location_id,
+                                           event_backend->GetStorageType(),
+                                           CacheLocationStatus::CLS_SERVING,
+                                           pending.specs)) {
+                    continue;
+                }
+                per_key_upserts.push_back(MetaSearcher::UpsertLocation{
+                    location_id,
+                    event_backend->GetStorageType(),
+                    CacheLocationStatus::CLS_SERVING,
+                    pending.specs,
+                });
+                per_key_event_indices.push_back(pending.event_indices);
+            }
+            if (!per_key_upserts.empty()) {
+                filtered_keys.push_back(add_keys_aggr[i]);
+                upserts.push_back(std::move(per_key_upserts));
+                upsert_event_indices.push_back(std::move(per_key_event_indices));
+            }
+        }
+
+        if (!filtered_keys.empty()) {
+            std::vector<ErrorCode> per_key_ec;
+            auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
+
+            for (size_t k = 0; k < filtered_keys.size(); ++k) {
+                ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
+                if (key_ec == EC_OK) {
+                    continue;
+                }
+                for (const auto &event_indices : upsert_event_indices[k]) {
+                    for (const auto event_index : event_indices) {
+                        set_item_ec_if_ok(event_index, key_ec);
+                    }
+                }
+            }
+            if (auto *add_mc = find_sub_collector("EventBlockAdd")) {
+                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, filtered_keys.size());
+                KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, filtered_keys.size());
+            }
+        }
+        pending_adds.clear();
+    };
+
+    auto flush_dels = [&]() {
+        if (pending_dels.empty()) {
+            return;
+        }
+        KeyVector del_keys_aggr;
+        std::vector<const std::vector<BlockDelEntry> *> del_entries_aggr;
+        del_keys_aggr.reserve(pending_dels.size());
+        del_entries_aggr.reserve(pending_dels.size());
+        for (const auto &kv : pending_dels) {
+            del_keys_aggr.push_back(kv.first);
+            del_entries_aggr.push_back(&kv.second);
+        }
+
+        LocationIdsPerKey del_location_ids(del_keys_aggr.size());
+        std::vector<std::vector<std::vector<int>>> del_event_indices(del_keys_aggr.size());
+        for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
+            std::map<std::string, PendingDelLocation> final_entries_by_location;
+            for (const auto &entry : *del_entries_aggr[i]) {
+                final_entries_by_location[entry.location_id].event_indices.push_back(entry.event_index);
+            }
+            del_location_ids[i].reserve(final_entries_by_location.size());
+            del_event_indices[i].reserve(final_entries_by_location.size());
+            for (const auto &kv : final_entries_by_location) {
+                del_location_ids[i].push_back(kv.first);
+                del_event_indices[i].push_back(kv.second.event_indices);
+            }
+        }
+
+        std::vector<std::vector<ErrorCode>> per_location_ec;
+        auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
+
+        for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
+            if (del_ec != EC_OK || k >= per_location_ec.size()) {
+                ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
+                for (const auto &event_indices : del_event_indices[k]) {
+                    for (const auto event_index : event_indices) {
+                        set_item_ec_if_ok(event_index, key_ec);
+                    }
+                }
+                continue;
+            }
+            for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
+                ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
+                if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
+                    continue;
+                }
+                for (const auto event_index : del_event_indices[k][loc_index]) {
+                    set_item_ec_if_ok(event_index, loc_ec);
+                }
+            }
+        }
+        if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
+            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
+            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
+        }
+        pending_dels.clear();
+    };
+
+    auto flush_pending = [&]() {
+        if (pending_kind == PendingMutationKind::ADD) {
+            flush_adds();
+        } else if (pending_kind == PendingMutationKind::DELETE) {
+            flush_dels();
+        }
+        pending_kind = PendingMutationKind::NONE;
+    };
+
+    auto apply_snapshot = [&](const SnapshotEntry &snapshot) {
+        if (per_item_ec[snapshot.event_index] != EC_OK) {
+            return;
+        }
+
+        KeyVector existing_keys;
+        auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
+        if (list_ec != EC_OK) {
+            KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
+                          trace_id.c_str(),
+                          snapshot.location_id.c_str(),
+                          static_cast<int32_t>(list_ec));
+            per_item_ec[snapshot.event_index] = list_ec;
+            return;
+        }
+
+        std::unordered_set<int64_t> reported_key_set;
+        reported_key_set.reserve(snapshot.blocks.size());
+        KeyVector reported_keys;
+        reported_keys.reserve(snapshot.blocks.size());
+        for (const auto &block : snapshot.blocks) {
+            reported_key_set.insert(block.first);
+            reported_keys.push_back(block.first);
+        }
+
+        std::vector<CacheLocationMap> existing_reported_maps;
+        if (!reported_keys.empty()) {
+            BlockMask bm = static_cast<size_t>(0);
+            auto get_ec = meta_searcher->BatchGetLocation(request_context, reported_keys, bm, existing_reported_maps);
+            if (get_ec != EC_OK) {
+                per_item_ec[snapshot.event_index] = get_ec;
+                return;
+            }
+        }
+
+        KeyVector upsert_keys;
+        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
+        size_t block_index = 0;
+        for (const auto &block : snapshot.blocks) {
+            const CacheLocationMap *existing_map =
+                (block_index < existing_reported_maps.size()) ? &existing_reported_maps[block_index] : nullptr;
+            ++block_index;
+            if (ExistingLocationEquals(existing_map,
+                                       snapshot.location_id,
+                                       event_backend->GetStorageType(),
+                                       CacheLocationStatus::CLS_SERVING,
+                                       block.second)) {
+                continue;
+            }
+            upsert_keys.push_back(block.first);
+            upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
+                MetaSearcher::UpsertLocation{
+                    snapshot.location_id,
+                    event_backend->GetStorageType(),
+                    CacheLocationStatus::CLS_SERVING,
+                    block.second,
+                },
+            });
+        }
+
+        if (!upsert_keys.empty()) {
+            std::vector<ErrorCode> per_key_ec;
+            auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
+            if (add_ec != EC_OK) {
+                per_item_ec[snapshot.event_index] = add_ec;
+            } else {
+                for (const auto &key_ec : per_key_ec) {
+                    if (key_ec != EC_OK) {
+                        per_item_ec[snapshot.event_index] = key_ec;
+                        break;
+                    }
+                }
+            }
+        }
+        if (per_item_ec[snapshot.event_index] != EC_OK) {
+            return;
+        }
+
+        KeyVector del_keys;
+        LocationIdsPerKey del_location_ids;
+        for (const auto &existing_key : existing_keys) {
+            if (reported_key_set.find(existing_key) != reported_key_set.end()) {
+                continue;
+            }
+            del_keys.push_back(existing_key);
+            del_location_ids.push_back(LocationIdVector{snapshot.location_id});
+        }
+
+        if (!del_keys.empty()) {
+            std::vector<std::vector<ErrorCode>> per_location_ec;
+            auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
+            if (del_ec != EC_OK) {
+                per_item_ec[snapshot.event_index] = del_ec;
+            } else {
+                for (const auto &location_ecs : per_location_ec) {
+                    for (const auto &loc_ec : location_ecs) {
+                        if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                            per_item_ec[snapshot.event_index] = loc_ec;
+                            break;
+                        }
+                    }
+                    if (per_item_ec[snapshot.event_index] != EC_OK) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (per_item_ec[snapshot.event_index] == EC_OK) {
+            KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
+                          "delete[%zu]",
+                          trace_id.c_str(),
+                          snapshot.location_id.c_str(),
+                          snapshot.blocks.size(),
+                          upsert_keys.size(),
+                          del_keys.size());
+        }
+    };
 
     for (int i = 0; i < events_size; ++i) {
         const auto &item = request->events(i);
         switch (item.event_type()) {
         case proto::meta::EVENT_NODE_REGISTER: {
-            has_register = true;
-            if (item.has_node_register()) {
-                for (const auto &m : item.node_register().mediums()) {
-                    if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
-                        register_mediums.push_back(m);
-                    }
+            if (!item.has_node_register()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
+            }
+            std::vector<std::string> register_mediums;
+            for (const auto &m : item.node_register().mediums()) {
+                if (std::find(register_mediums.begin(), register_mediums.end(), m) == register_mediums.end()) {
+                    register_mediums.push_back(m);
                 }
+            }
+            auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
+            if (ec != EC_OK) {
+                per_item_ec[i] = ec;
+            } else {
+                KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
+                              trace_id.c_str(),
+                              host_ip_port.c_str(),
+                              register_mediums.size(),
+                              instance_id.c_str());
             }
             break;
         }
         case proto::meta::EVENT_HEARTBEAT: {
-            has_heartbeat = true;
-            if (item.has_heartbeat()) {
-                heartbeat_status.clear();
-                for (const auto &kv : item.heartbeat().system_status()) {
-                    heartbeat_status[kv.first] = kv.second;
-                }
+            if (!item.has_heartbeat()) {
+                per_item_ec[i] = EC_BADARGS;
+                break;
             }
+            std::map<std::string, std::string> heartbeat_status;
+            for (const auto &kv : item.heartbeat().system_status()) {
+                heartbeat_status[kv.first] = kv.second;
+            }
+            per_item_ec[i] = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
             break;
         }
         case proto::meta::EVENT_HOST_DOWN: {
-            has_host_down = true;
+            flush_pending();
+            event_backend->SetNodeUnavailable(instance_id, host_ip_port);
+            uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
+            assert(schedule_plan_executor_);
+            schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
+                this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
+            });
+            event_backend->UnregisterNode(instance_id, host_ip_port);
+            KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
+                          trace_id.c_str(),
+                          host_ip_port.c_str(),
+                          gen_at_trigger);
             break;
         }
         case proto::meta::EVENT_BLOCK_ADD: {
@@ -1579,25 +2005,30 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            if (p.medium().empty()) {
-                KVCM_LOG_WARN(
-                    "trace_id [%s] | EVENT_BLOCK_ADD: empty medium for block_key [%ld]", trace_id.c_str(), block_key);
-                per_item_ec[i] = EC_BADARGS;
-                break;
-            }
             if (p.specs_size() == 0) {
                 KVCM_LOG_WARN(
                     "trace_id [%s] | EVENT_BLOCK_ADD: empty specs for block_key [%ld]", trace_id.c_str(), block_key);
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            std::string location_id = event_backend->BuildLocationId(p.medium(), host_ip_port);
+            std::string location_id;
+            if (!build_location_id(p.medium(),
+                                   p.has_location() ? p.location() : empty_scope,
+                                   "EVENT_BLOCK_ADD",
+                                   i,
+                                   location_id)) {
+                break;
+            }
+            if (pending_kind == PendingMutationKind::DELETE) {
+                flush_dels();
+            }
+            pending_kind = PendingMutationKind::ADD;
             std::vector<LocationSpec> entry_specs;
             entry_specs.reserve(p.specs_size());
             for (const auto &s : p.specs()) {
                 entry_specs.emplace_back(s.name(), s.uri());
             }
-            block_to_add[block_key].push_back(BlockAddEntry{std::move(location_id), std::move(entry_specs), i});
+            pending_adds[block_key].push_back(BlockAddEntry{std::move(location_id), std::move(entry_specs), i});
             break;
         }
         case proto::meta::EVENT_BLOCK_DELETE: {
@@ -1614,30 +2045,36 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            if (p.medium().empty()) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_DELETE: empty medium for block_key [%ld]",
-                              trace_id.c_str(),
-                              block_key);
-                per_item_ec[i] = EC_BADARGS;
+            std::string location_id;
+            if (!build_location_id(p.medium(),
+                                   p.has_location() ? p.location() : empty_scope,
+                                   "EVENT_BLOCK_DELETE",
+                                   i,
+                                   location_id)) {
                 break;
             }
-            block_to_del[block_key].push_back(
-                BlockDelEntry{event_backend->BuildLocationId(p.medium(), host_ip_port), i});
+            if (pending_kind == PendingMutationKind::ADD) {
+                flush_adds();
+            }
+            pending_kind = PendingMutationKind::DELETE;
+            pending_dels[block_key].push_back(BlockDelEntry{std::move(location_id), i});
             break;
         }
         case proto::meta::EVENT_BLOCK_SNAPSHOT: {
+            flush_pending();
             if (!item.has_block_snapshot()) {
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
             const auto &p = item.block_snapshot();
-            if (p.medium().empty()) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: empty medium", trace_id.c_str());
-                per_item_ec[i] = EC_BADARGS;
+            SnapshotEntry snapshot;
+            if (!build_location_id(p.medium(),
+                                   p.has_location() ? p.location() : empty_scope,
+                                   "EVENT_BLOCK_SNAPSHOT",
+                                   i,
+                                   snapshot.location_id)) {
                 break;
             }
-            SnapshotEntry snapshot;
-            snapshot.location_id = event_backend->BuildLocationId(p.medium(), host_ip_port);
             snapshot.event_index = i;
             bool valid_snapshot = true;
             for (const auto &block : p.blocks()) {
@@ -1667,7 +2104,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 per_item_ec[i] = EC_BADARGS;
                 break;
             }
-            snapshots.emplace_back(std::move(snapshot));
+            apply_snapshot(snapshot);
             break;
         }
         default:
@@ -1680,247 +2117,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
         }
     }
 
-    if (has_register) {
-        auto ec = event_backend->RegisterNode(instance_id, host_ip_port, register_mediums);
-        if (ec != EC_OK) {
-            for (int i = 0; i < events_size; ++i) {
-                if (request->events(i).event_type() == proto::meta::EVENT_NODE_REGISTER) {
-                    per_item_ec[i] = ec;
-                }
-            }
-        } else {
-            KVCM_LOG_INFO("trace_id [%s] | NODE_REGISTER: host [%s] mediums=%zu in instance [%s]",
-                          trace_id.c_str(),
-                          host_ip_port.c_str(),
-                          register_mediums.size(),
-                          instance_id.c_str());
-        }
-    }
-
-    if (has_heartbeat) {
-        auto hb_ec = event_backend->OnHeartbeat(instance_id, host_ip_port, heartbeat_status);
-        if (hb_ec != EC_OK) {
-            for (int i = 0; i < events_size; ++i) {
-                if (request->events(i).event_type() == proto::meta::EVENT_HEARTBEAT) {
-                    per_item_ec[i] = hb_ec;
-                }
-            }
-        }
-    }
-
-    auto find_sub_collector = [&request_context](const std::string &api_name) -> ServiceMetricsCollector * {
-        for (const auto &mc : request_context->GetMetricsCollectorsVehicle().GetMetricsCollectors()) {
-            auto *smc = dynamic_cast<ServiceMetricsCollector *>(mc.get());
-            if (smc) {
-                const auto &tags = smc->GetMetricsTags();
-                auto it = tags.find("api_name");
-                if (it != tags.end() && it->second == api_name) {
-                    return smc;
-                }
-            }
-        }
-        return nullptr;
-    };
-
-    if (!block_to_add.empty()) {
-        KeyVector add_keys_aggr;
-        std::vector<const std::vector<BlockAddEntry> *> add_entries_aggr;
-        add_keys_aggr.reserve(block_to_add.size());
-        add_entries_aggr.reserve(block_to_add.size());
-        for (const auto &kv : block_to_add) {
-            add_keys_aggr.push_back(kv.first);
-            add_entries_aggr.push_back(&kv.second);
-        }
-
-        std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts(add_keys_aggr.size());
-        for (size_t i = 0; i < add_keys_aggr.size(); ++i) {
-            const auto &entries = *add_entries_aggr[i];
-            upserts[i].reserve(entries.size());
-            for (const auto &entry : entries) {
-                upserts[i].push_back(MetaSearcher::UpsertLocation{
-                    entry.location_id,
-                    event_backend->GetStorageType(),
-                    CacheLocationStatus::CLS_SERVING,
-                    entry.specs,
-                });
-            }
-        }
-
-        std::vector<ErrorCode> per_key_ec;
-        meta_searcher->BatchUpsertLocations(request_context, add_keys_aggr, upserts, per_key_ec);
-
-        for (size_t k = 0; k < add_keys_aggr.size(); ++k) {
-            ErrorCode key_ec = (k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR;
-            if (key_ec == EC_OK) {
-                continue;
-            }
-            for (const auto &entry : *add_entries_aggr[k]) {
-                if (per_item_ec[entry.event_index] == EC_OK) {
-                    per_item_ec[entry.event_index] = key_ec;
-                }
-            }
-        }
-        if (auto *add_mc = find_sub_collector("EventBlockAdd")) {
-            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, manager, request_key_count, add_keys_aggr.size());
-            KVCM_METRICS_COLLECTOR_SET_METRICS(add_mc, meta_indexer, query_key_count, add_keys_aggr.size());
-        }
-    }
-
-    if (!block_to_del.empty()) {
-        KeyVector del_keys_aggr;
-        std::vector<const std::vector<BlockDelEntry> *> del_entries_aggr;
-        del_keys_aggr.reserve(block_to_del.size());
-        del_entries_aggr.reserve(block_to_del.size());
-        for (const auto &kv : block_to_del) {
-            del_keys_aggr.push_back(kv.first);
-            del_entries_aggr.push_back(&kv.second);
-        }
-
-        LocationIdsPerKey del_location_ids(del_keys_aggr.size());
-        for (size_t i = 0; i < del_keys_aggr.size(); ++i) {
-            for (const auto &entry : *del_entries_aggr[i]) {
-                del_location_ids[i].push_back(entry.location_id);
-            }
-        }
-
-        std::vector<std::vector<ErrorCode>> per_location_ec;
-        meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
-
-        for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
-            ErrorCode key_ec = EC_OK;
-            if (k < per_location_ec.size()) {
-                for (const auto &loc_ec : per_location_ec[k]) {
-                    if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
-                        key_ec = loc_ec;
-                        break;
-                    }
-                }
-            } else {
-                key_ec = EC_ERROR;
-            }
-            if (key_ec == EC_OK) {
-                continue;
-            }
-            for (const auto &entry : *del_entries_aggr[k]) {
-                if (per_item_ec[entry.event_index] == EC_OK) {
-                    per_item_ec[entry.event_index] = key_ec;
-                }
-            }
-        }
-        if (auto *del_mc = find_sub_collector("EventBlockDelete")) {
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, manager, request_key_count, del_keys_aggr.size());
-            KVCM_METRICS_COLLECTOR_SET_METRICS(del_mc, meta_indexer, query_key_count, del_keys_aggr.size());
-        }
-    }
-
-    if (!snapshots.empty()) {
-        for (const auto &snapshot : snapshots) {
-            if (per_item_ec[snapshot.event_index] != EC_OK) {
-                continue;
-            }
-
-            KeyVector existing_keys;
-            auto list_ec = meta_searcher->GetKeysByLocationIndex(snapshot.location_id, existing_keys);
-            if (list_ec != EC_OK) {
-                KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
-                              trace_id.c_str(),
-                              snapshot.location_id.c_str(),
-                              static_cast<int32_t>(list_ec));
-                per_item_ec[snapshot.event_index] = list_ec;
-                continue;
-            }
-
-            std::unordered_set<int64_t> reported_key_set;
-            reported_key_set.reserve(snapshot.blocks.size());
-            for (const auto &block : snapshot.blocks) {
-                reported_key_set.insert(block.first);
-            }
-
-            KeyVector upsert_keys;
-            std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
-            for (const auto &block : snapshot.blocks) {
-                upsert_keys.push_back(block.first);
-                upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
-                    MetaSearcher::UpsertLocation{
-                        snapshot.location_id,
-                        event_backend->GetStorageType(),
-                        CacheLocationStatus::CLS_SERVING,
-                        block.second,
-                    },
-                });
-            }
-
-            if (!upsert_keys.empty()) {
-                std::vector<ErrorCode> per_key_ec;
-                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
-                if (add_ec != EC_OK) {
-                    per_item_ec[snapshot.event_index] = add_ec;
-                } else {
-                    for (const auto &key_ec : per_key_ec) {
-                        if (key_ec != EC_OK) {
-                            per_item_ec[snapshot.event_index] = key_ec;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            KeyVector del_keys;
-            LocationIdsPerKey del_location_ids;
-            for (const auto &existing_key : existing_keys) {
-                if (reported_key_set.find(existing_key) != reported_key_set.end()) {
-                    continue;
-                }
-                del_keys.push_back(existing_key);
-                del_location_ids.push_back(LocationIdVector{snapshot.location_id});
-            }
-
-            if (!del_keys.empty()) {
-                std::vector<std::vector<ErrorCode>> per_location_ec;
-                auto del_ec =
-                    meta_searcher->BatchDeleteLocations(request_context, del_keys, del_location_ids, per_location_ec);
-                if (del_ec != EC_OK) {
-                    per_item_ec[snapshot.event_index] = del_ec;
-                } else {
-                    for (const auto &location_ecs : per_location_ec) {
-                        for (const auto &loc_ec : location_ecs) {
-                            if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
-                                per_item_ec[snapshot.event_index] = loc_ec;
-                                break;
-                            }
-                        }
-                        if (per_item_ec[snapshot.event_index] != EC_OK) {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (per_item_ec[snapshot.event_index] == EC_OK) {
-                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
-                              "delete[%zu]",
-                              trace_id.c_str(),
-                              snapshot.location_id.c_str(),
-                              snapshot.blocks.size(),
-                              upsert_keys.size(),
-                              del_keys.size());
-            }
-        }
-    }
-
-    if (has_host_down) {
-        event_backend->SetNodeUnavailable(instance_id, host_ip_port);
-        uint64_t gen_at_trigger = event_backend->GetNodeGeneration(instance_id, host_ip_port);
-        assert(schedule_plan_executor_);
-        schedule_plan_executor_->SubmitTask([this, instance_id, host_ip_port, gen_at_trigger, requested_type] {
-            this->CleanupHostLocations(instance_id, host_ip_port, gen_at_trigger, requested_type);
-        });
-        event_backend->UnregisterNode(instance_id, host_ip_port);
-        KVCM_LOG_INFO("trace_id [%s] | HOST_DOWN: host [%s] cleanup scheduled (gen=%lu) and removed from node table",
-                      trace_id.c_str(),
-                      host_ip_port.c_str(),
-                      gen_at_trigger);
-    }
+    flush_pending();
 
     bool any_failure = false;
     for (auto ec : per_item_ec) {
@@ -1931,17 +2128,7 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
     }
     if (any_failure) {
         for (auto ec : per_item_ec) {
-            proto::meta::ErrorCode mapped = proto::meta::OK;
-            if (ec == EC_OK) {
-                mapped = proto::meta::OK;
-            } else if (ec == EC_BADARGS) {
-                mapped = proto::meta::INVALID_ARGUMENT;
-            } else if (ec == EC_INSTANCE_NOT_EXIST) {
-                mapped = proto::meta::INSTANCE_NOT_EXIST;
-            } else {
-                mapped = proto::meta::INTERNAL_ERROR;
-            }
-            response->add_item_results(mapped);
+            response->add_item_results(ToProtoErrorCode(ec));
         }
         response_status->set_code(proto::meta::INTERNAL_ERROR);
         response_status->set_message("ReportEvent partially failed; see item_results");

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1830,20 +1830,16 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 continue;
             }
 
-            std::unordered_set<int64_t> existing_key_set(existing_keys.begin(), existing_keys.end());
             std::unordered_set<int64_t> reported_key_set;
             reported_key_set.reserve(snapshot.blocks.size());
             for (const auto &block : snapshot.blocks) {
                 reported_key_set.insert(block.first);
             }
 
-            KeyVector add_keys;
+            KeyVector upsert_keys;
             std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts;
             for (const auto &block : snapshot.blocks) {
-                if (existing_key_set.find(block.first) != existing_key_set.end()) {
-                    continue;
-                }
-                add_keys.push_back(block.first);
+                upsert_keys.push_back(block.first);
                 upserts.push_back(std::vector<MetaSearcher::UpsertLocation>{
                     MetaSearcher::UpsertLocation{
                         snapshot.location_id,
@@ -1854,9 +1850,9 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
                 });
             }
 
-            if (!add_keys.empty()) {
+            if (!upsert_keys.empty()) {
                 std::vector<ErrorCode> per_key_ec;
-                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, add_keys, upserts, per_key_ec);
+                auto add_ec = meta_searcher->BatchUpsertLocations(request_context, upsert_keys, upserts, per_key_ec);
                 if (add_ec != EC_OK) {
                     per_item_ec[snapshot.event_index] = add_ec;
                 } else {
@@ -1901,12 +1897,12 @@ ErrorCode CacheManager::ReportEvent(RequestContext *request_context,
             }
 
             if (per_item_ec[snapshot.event_index] == EC_OK) {
-                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], add[%zu], "
+                KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
                               "delete[%zu]",
                               trace_id.c_str(),
                               snapshot.location_id.c_str(),
                               snapshot.blocks.size(),
-                              add_keys.size(),
+                              upsert_keys.size(),
                               del_keys.size());
             }
         }

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1751,8 +1751,8 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
     }
 
     const std::string &trace_id = request_context->trace_id();
-    KeyVector existing_keys;
-    auto list_ec = meta_searcher->GetKeysByLocationIndex(request_context, snapshot.location_id, existing_keys);
+    KeyVector indexed_keys;
+    auto list_ec = meta_searcher->GetKeysByLocationIndex(request_context, snapshot.location_id, indexed_keys);
     if (list_ec != EC_OK) {
         KVCM_LOG_WARN("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: get keys by location index failed, loc[%s], ec[%d]",
                       trace_id.c_str(),
@@ -1760,6 +1760,35 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
                       static_cast<int32_t>(list_ec));
         state->per_item_ec[snapshot.event_index] = list_ec;
         return;
+    }
+
+    KeyVector existing_keys;
+    size_t stale_index_key_count = 0;
+    if (!indexed_keys.empty()) {
+        std::vector<CacheLocationMap> indexed_location_maps;
+        BlockMask bm = static_cast<size_t>(0);
+        auto get_ec = meta_searcher->BatchGetLocation(request_context, indexed_keys, bm, indexed_location_maps);
+        if (get_ec != EC_OK) {
+            state->per_item_ec[snapshot.event_index] = get_ec;
+            return;
+        }
+        existing_keys.reserve(indexed_keys.size());
+        for (size_t i = 0; i < indexed_keys.size(); ++i) {
+            const CacheLocationMap *location_map =
+                (i < indexed_location_maps.size()) ? &indexed_location_maps[i] : nullptr;
+            if (!location_map) {
+                ++stale_index_key_count;
+                continue;
+            }
+            auto iter = location_map->find(snapshot.location_id);
+            if (iter != location_map->end() && iter->second &&
+                iter->second->type() == event_backend->GetStorageType() &&
+                iter->second->status() == CacheLocationStatus::CLS_SERVING) {
+                existing_keys.push_back(indexed_keys[i]);
+            } else {
+                ++stale_index_key_count;
+            }
+        }
     }
 
     std::unordered_set<int64_t> reported_key_set;
@@ -1856,12 +1885,13 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
 
     if (state->per_item_ec[snapshot.event_index] == EC_OK) {
         KVCM_LOG_INFO("trace_id [%s] | EVENT_BLOCK_SNAPSHOT: reconciled loc[%s], reported[%zu], upsert[%zu], "
-                      "delete[%zu]",
+                      "delete[%zu], stale_index[%zu]",
                       trace_id.c_str(),
                       snapshot.location_id.c_str(),
                       snapshot.blocks.size(),
                       upsert_keys.size(),
-                      del_keys.size());
+                      del_keys.size(),
+                      stale_index_key_count);
     }
 }
 

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1456,6 +1456,15 @@ bool CacheManager::IsFullAttentionLocationSpecName(const std::string &name) {
     return !IsMambaLocationSpecName(name);
 }
 
+bool CacheManager::ContainsFullAttentionLocationSpec(const std::vector<LocationSpec> &specs) {
+    for (const auto &spec : specs) {
+        if (IsFullAttentionLocationSpecName(spec.name())) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool CacheManager::ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names) {
     if (spec_names.empty()) {
         return true;
@@ -1547,6 +1556,51 @@ void CacheManager::SetReportEventItemEcIfOk(ReportEventState *state, int event_i
         state->per_item_ec[event_index] == EC_OK) {
         state->per_item_ec[event_index] = ec;
     }
+}
+
+bool CacheManager::HasReportEventKeyFailure(const std::vector<ErrorCode> &per_key_ec) {
+    return std::any_of(per_key_ec.begin(), per_key_ec.end(), [](ErrorCode ec) { return ec != EC_OK; });
+}
+
+bool CacheManager::HasReportEventHardLocationFailure(const std::vector<std::vector<ErrorCode>> &per_location_ec) {
+    for (const auto &location_ecs : per_location_ec) {
+        for (const auto loc_ec : location_ecs) {
+            if (loc_ec != EC_OK && loc_ec != EC_NOENT) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+ErrorCode CacheManager::ResolveReportEventKeyError(ErrorCode aggregate_ec,
+                                                   bool has_specific_key_failure,
+                                                   const std::vector<ErrorCode> &per_key_ec,
+                                                   size_t key_index) {
+    if (key_index >= per_key_ec.size()) {
+        return aggregate_ec != EC_OK ? aggregate_ec : EC_ERROR;
+    }
+    ErrorCode key_ec = per_key_ec[key_index];
+    if (key_ec == EC_OK && aggregate_ec != EC_OK && !has_specific_key_failure) {
+        key_ec = aggregate_ec;
+    }
+    return key_ec;
+}
+
+ErrorCode CacheManager::ResolveReportEventLocationError(
+    ErrorCode aggregate_ec,
+    bool has_specific_hard_location_failure,
+    const std::vector<std::vector<ErrorCode>> &per_location_ec,
+    size_t key_index,
+    size_t location_index) {
+    if (key_index >= per_location_ec.size() || location_index >= per_location_ec[key_index].size()) {
+        return aggregate_ec != EC_OK ? aggregate_ec : EC_ERROR;
+    }
+    ErrorCode loc_ec = per_location_ec[key_index][location_index];
+    if (loc_ec == EC_OK && aggregate_ec != EC_OK && !has_specific_hard_location_failure) {
+        loc_ec = aggregate_ec;
+    }
+    return loc_ec;
 }
 
 bool CacheManager::BuildReportEventLocationId(const std::string &trace_id,
@@ -1643,9 +1697,10 @@ void CacheManager::FlushReportEventAdds(RequestContext *request_context,
     if (!filtered_keys.empty()) {
         std::vector<ErrorCode> per_key_ec;
         auto upsert_ec = meta_searcher->BatchUpsertLocations(request_context, filtered_keys, upserts, per_key_ec);
+        const bool has_specific_key_failure = HasReportEventKeyFailure(per_key_ec);
 
         for (size_t k = 0; k < filtered_keys.size(); ++k) {
-            ErrorCode key_ec = (upsert_ec != EC_OK) ? upsert_ec : ((k < per_key_ec.size()) ? per_key_ec[k] : EC_ERROR);
+            ErrorCode key_ec = ResolveReportEventKeyError(upsert_ec, has_specific_key_failure, per_key_ec, k);
             if (key_ec == EC_OK) {
                 continue;
             }
@@ -1698,9 +1753,10 @@ void CacheManager::FlushReportEventDeletes(RequestContext *request_context,
 
     std::vector<std::vector<ErrorCode>> per_location_ec;
     auto del_ec = meta_searcher->BatchDeleteLocations(request_context, del_keys_aggr, del_location_ids, per_location_ec);
+    const bool has_specific_hard_location_failure = HasReportEventHardLocationFailure(per_location_ec);
 
     for (size_t k = 0; k < del_keys_aggr.size(); ++k) {
-        if (del_ec != EC_OK || k >= per_location_ec.size()) {
+        if (k >= per_location_ec.size()) {
             ErrorCode key_ec = (del_ec != EC_OK) ? del_ec : EC_ERROR;
             for (const auto &event_indices : del_event_indices[k]) {
                 for (const auto event_index : event_indices) {
@@ -1710,7 +1766,8 @@ void CacheManager::FlushReportEventDeletes(RequestContext *request_context,
             continue;
         }
         for (size_t loc_index = 0; loc_index < del_event_indices[k].size(); ++loc_index) {
-            ErrorCode loc_ec = (loc_index < per_location_ec[k].size()) ? per_location_ec[k][loc_index] : EC_ERROR;
+            ErrorCode loc_ec = ResolveReportEventLocationError(
+                del_ec, has_specific_hard_location_failure, per_location_ec, k, loc_index);
             if (loc_ec == EC_OK || loc_ec == EC_NOENT) {
                 continue;
             }
@@ -1783,7 +1840,8 @@ void CacheManager::ApplyReportEventSnapshot(RequestContext *request_context,
             auto iter = location_map->find(snapshot.location_id);
             if (iter != location_map->end() && iter->second &&
                 iter->second->type() == event_backend->GetStorageType() &&
-                iter->second->status() == CacheLocationStatus::CLS_SERVING) {
+                iter->second->status() == CacheLocationStatus::CLS_SERVING &&
+                ContainsFullAttentionLocationSpec(iter->second->location_specs())) {
                 existing_keys.push_back(indexed_keys[i]);
             } else {
                 ++stale_index_key_count;

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -209,6 +209,7 @@ private:
     static bool HasPrefix(const std::string &s, const std::string &prefix);
     static bool IsMambaLocationSpecName(const std::string &name);
     static bool IsFullAttentionLocationSpecName(const std::string &name);
+    static bool ContainsFullAttentionLocationSpec(const std::vector<LocationSpec> &specs);
     static bool ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names);
     static std::vector<LocationSpec> BuildFullAttentionSpecs(
         const google::protobuf::RepeatedPtrField<proto::meta::LocationSpec> &proto_specs);
@@ -227,6 +228,18 @@ private:
     static ServiceMetricsCollector *FindReportEventSubCollector(RequestContext *request_context,
                                                                 const std::string &api_name);
     static void SetReportEventItemEcIfOk(ReportEventState *state, int event_index, ErrorCode ec);
+    static bool HasReportEventKeyFailure(const std::vector<ErrorCode> &per_key_ec);
+    static bool HasReportEventHardLocationFailure(const std::vector<std::vector<ErrorCode>> &per_location_ec);
+    static ErrorCode ResolveReportEventKeyError(ErrorCode aggregate_ec,
+                                                bool has_specific_key_failure,
+                                                const std::vector<ErrorCode> &per_key_ec,
+                                                size_t key_index);
+    static ErrorCode ResolveReportEventLocationError(
+        ErrorCode aggregate_ec,
+        bool has_specific_hard_location_failure,
+        const std::vector<std::vector<ErrorCode>> &per_location_ec,
+        size_t key_index,
+        size_t location_index);
 
     bool BuildReportEventLocationId(const std::string &trace_id,
                                     EventReportingBackend *event_backend,

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <thread>
@@ -29,6 +30,8 @@ class ReclaimerTaskSupervisor;
 class StartupConfigLoader;
 class EventManager;
 class CacheManagerMetricsRecorder;
+class EventReportingBackend;
+class ServiceMetricsCollector;
 struct MetricsLifecycle;
 constexpr unsigned int DEFAULT_SCHEDULE_PLAN_EXECUTOR_THREAD_COUNT = 2;
 
@@ -180,6 +183,85 @@ public:
     void SetRevisitHistogramConfig(const std::vector<double> &boundaries);
 
 private:
+    struct ReportEventBlockAddEntry {
+        std::string location_id;
+        std::vector<LocationSpec> specs;
+        int event_index = 0;
+    };
+    struct ReportEventBlockDelEntry {
+        std::string location_id;
+        int event_index = 0;
+    };
+    struct ReportEventSnapshotEntry {
+        std::string location_id;
+        std::map<int64_t, std::vector<LocationSpec>> blocks;
+        int event_index = 0;
+    };
+    enum class ReportEventPendingMutationKind { NONE, ADD, DELETE };
+    struct ReportEventState {
+        explicit ReportEventState(size_t event_count) : per_item_ec(event_count, EC_OK) {}
+        std::vector<ErrorCode> per_item_ec;
+        std::map<int64_t, std::vector<ReportEventBlockAddEntry>> pending_adds;
+        std::map<int64_t, std::vector<ReportEventBlockDelEntry>> pending_dels;
+        ReportEventPendingMutationKind pending_kind = ReportEventPendingMutationKind::NONE;
+    };
+
+    static bool HasPrefix(const std::string &s, const std::string &prefix);
+    static bool IsMambaLocationSpecName(const std::string &name);
+    static bool IsFullAttentionLocationSpecName(const std::string &name);
+    static bool ContainsFullAttentionSpecName(const google::protobuf::RepeatedPtrField<std::string> &spec_names);
+    static std::vector<LocationSpec> BuildFullAttentionSpecs(
+        const google::protobuf::RepeatedPtrField<proto::meta::LocationSpec> &proto_specs);
+    static bool SameLocationSpecs(const std::vector<LocationSpec> &lhs, const std::vector<LocationSpec> &rhs);
+    static bool CacheLocationEquals(const CacheLocationConstPtr &loc,
+                                    DataStorageType type,
+                                    CacheLocationStatus status,
+                                    const std::vector<LocationSpec> &specs);
+    static bool ExistingLocationEquals(const CacheLocationMap *existing_map,
+                                       const std::string &location_id,
+                                       DataStorageType type,
+                                       CacheLocationStatus status,
+                                       const std::vector<LocationSpec> &specs);
+    static bool ParseInt64(const std::string &s, int64_t &out);
+    static proto::meta::ErrorCode ToProtoErrorCode(ErrorCode ec);
+    static ServiceMetricsCollector *FindReportEventSubCollector(RequestContext *request_context,
+                                                                const std::string &api_name);
+    static void SetReportEventItemEcIfOk(ReportEventState *state, int event_index, ErrorCode ec);
+
+    bool BuildReportEventLocationId(const std::string &trace_id,
+                                    EventReportingBackend *event_backend,
+                                    const std::string &host_ip_port,
+                                    const std::string &medium,
+                                    const char *event_name,
+                                    int event_index,
+                                    ReportEventState *state,
+                                    std::string &out_location_id) const;
+    void FlushReportEventAdds(RequestContext *request_context,
+                              MetaSearcher *meta_searcher,
+                              EventReportingBackend *event_backend,
+                              ReportEventState *state) const;
+    void FlushReportEventDeletes(RequestContext *request_context,
+                                 MetaSearcher *meta_searcher,
+                                 ReportEventState *state) const;
+    void FlushReportEventPending(RequestContext *request_context,
+                                 MetaSearcher *meta_searcher,
+                                 EventReportingBackend *event_backend,
+                                 ReportEventState *state) const;
+    void ApplyReportEventSnapshot(RequestContext *request_context,
+                                  MetaSearcher *meta_searcher,
+                                  EventReportingBackend *event_backend,
+                                  const ReportEventSnapshotEntry &snapshot,
+                                  ReportEventState *state) const;
+    void ProcessReportEventItem(RequestContext *request_context,
+                                const proto::meta::EventItem &item,
+                                int event_index,
+                                const std::string &instance_id,
+                                const std::string &host_ip_port,
+                                DataStorageType requested_type,
+                                MetaSearcher *meta_searcher,
+                                EventReportingBackend *event_backend,
+                                ReportEventState *state);
+
     ErrorCode FilterWriteCache(RequestContext *request_context,
                                const std::string &instance_id,
                                MetaSearcher *meta_searcher,

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <map>
-#include <mutex>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -36,7 +35,11 @@ void LogErrorCodes(const std::string &operation_name,
 }
 
 bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
-    return ec == ErrorCode::EC_OK || ec == ErrorCode::EC_NOENT;
+    // Remove the index only after CacheMeta confirms the location was deleted.
+    // If we remove on EC_NOENT, a concurrent add-before-meta write can be
+    // observed as over-index and then turned into under-index when its later
+    // CacheMeta write succeeds.
+    return ec == ErrorCode::EC_OK;
 }
 
 std::uint64_t LocationSpecSize(const std::vector<LocationSpec> &specs) {
@@ -230,28 +233,51 @@ MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
 
 MetaSearcher::~MetaSearcher() = default;
 
-void MetaSearcher::AddKeysToLocationIndex(const KeyVector &keys,
+void MetaSearcher::AddKeysToLocationIndex(RequestContext *request_context,
+                                          const KeyVector &keys,
                                           const LocationIdsPerKey &location_ids_per_key,
-                                          const std::vector<ErrorCode> &per_key_ec) {
-    if (keys.size() != location_ids_per_key.size()) {
+                                          std::vector<ErrorCode> *per_key_ec) {
+    if (keys.size() != location_ids_per_key.size() || !per_key_ec || per_key_ec->size() != keys.size()) {
         return;
     }
 
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    std::unordered_map<std::string, KeyVector> keys_by_location;
+    std::unordered_map<std::string, std::vector<size_t>> key_indices_by_location;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (i >= per_key_ec.size() || per_key_ec[i] != ErrorCode::EC_OK) {
+        if ((*per_key_ec)[i] != ErrorCode::EC_OK) {
             continue;
         }
+        std::unordered_set<std::string> seen_location_ids;
         for (const auto &location_id : location_ids_per_key[i]) {
-            if (location_id.empty()) {
+            if (location_id.empty() || !seen_location_ids.insert(location_id).second) {
                 continue;
             }
-            location_key_index_[location_id].insert(keys[i]);
+            keys_by_location[location_id].push_back(keys[i]);
+            key_indices_by_location[location_id].push_back(i);
+        }
+    }
+
+    for (const auto &kv : keys_by_location) {
+        const std::string &location_id = kv.first;
+        const KeyVector &location_keys = kv.second;
+        ErrorCode ec = meta_indexer_->AddKeysToLocationIndex(request_context, location_id, location_keys);
+        if (ec == ErrorCode::EC_OK) {
+            continue;
+        }
+        KVCM_LOG_WARN("add location index failed, location_id[%s], keys[%zu], ec[%d]",
+                      location_id.c_str(),
+                      location_keys.size(),
+                      ec);
+        for (const auto key_index : key_indices_by_location[location_id]) {
+            if ((*per_key_ec)[key_index] == ErrorCode::EC_OK) {
+                (*per_key_ec)[key_index] = ec;
+            }
         }
     }
 }
 
 void MetaSearcher::RemoveKeysFromLocationIndex(
+    RequestContext *request_context,
     const KeyVector &keys,
     const LocationIdsPerKey &location_ids_per_key,
     const std::vector<std::vector<ErrorCode>> &per_location_ec) {
@@ -259,7 +285,9 @@ void MetaSearcher::RemoveKeysFromLocationIndex(
         return;
     }
 
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    std::unordered_map<std::string, KeyVector> keys_by_location;
+    KeyVector keys_to_sync;
+    std::unordered_set<KeyType> seen_keys_to_sync;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (i >= per_location_ec.size()) {
             continue;
@@ -272,84 +300,30 @@ void MetaSearcher::RemoveKeysFromLocationIndex(
             if (location_id.empty()) {
                 continue;
             }
-            auto iter = location_key_index_.find(location_id);
-            if (iter == location_key_index_.end()) {
-                continue;
-            }
-            iter->second.erase(keys[i]);
-            if (iter->second.empty()) {
-                location_key_index_.erase(iter);
+            keys_by_location[location_id].push_back(keys[i]);
+            if (seen_keys_to_sync.insert(keys[i]).second) {
+                keys_to_sync.push_back(keys[i]);
             }
         }
     }
-}
-
-void MetaSearcher::SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const {
-    out_keys.clear();
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-    auto iter = location_key_index_.find(location_id);
-    if (iter == location_key_index_.end()) {
+    if (keys_by_location.empty()) {
         return;
     }
-    out_keys.reserve(iter->second.size());
-    for (const auto &key : iter->second) {
-        out_keys.push_back(key);
-    }
-    std::sort(out_keys.begin(), out_keys.end());
-}
 
-ErrorCode MetaSearcher::RebuildLocationKeyIndex(RequestContext *request_context,
-                                                const std::string &location_id,
-                                                size_t scan_batch_size) {
-    if (location_id.empty() || scan_batch_size == 0) {
-        return EC_BADARGS;
+    if (!meta_indexer_->Sync(keys_to_sync)) {
+        KVCM_LOG_WARN("skip location index removal because meta sync failed, keys[%zu]", keys_to_sync.size());
+        return;
     }
 
-    {
-        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-        if (rebuilt_location_key_index_.find(location_id) != rebuilt_location_key_index_.end()) {
-            return EC_OK;
+    for (const auto &kv : keys_by_location) {
+        ErrorCode ec = meta_indexer_->RemoveKeysFromLocationIndex(request_context, kv.first, kv.second);
+        if (ec != ErrorCode::EC_OK) {
+            KVCM_LOG_WARN("remove location index failed, location_id[%s], keys[%zu], ec[%d]",
+                          kv.first.c_str(),
+                          kv.second.size(),
+                          ec);
         }
     }
-
-    std::unordered_set<KeyType> rebuilt_keys;
-    std::string cursor = "0";
-    do {
-        std::string next_cursor;
-        KeyVector scanned_keys;
-        ErrorCode scan_ec = meta_indexer_->Scan(request_context, cursor, scan_batch_size, next_cursor, scanned_keys);
-        if (scan_ec != EC_OK) {
-            return scan_ec;
-        }
-
-        if (!scanned_keys.empty()) {
-            std::vector<CacheLocationMap> location_maps;
-            BlockMask empty_mask = static_cast<size_t>(0);
-            ErrorCode get_ec = BatchGetLocation(request_context, scanned_keys, empty_mask, location_maps);
-            if (get_ec != EC_OK) {
-                return get_ec;
-            }
-            for (size_t i = 0; i < scanned_keys.size() && i < location_maps.size(); ++i) {
-                if (location_maps[i].find(location_id) != location_maps[i].end()) {
-                    rebuilt_keys.insert(scanned_keys[i]);
-                }
-            }
-        }
-
-        cursor = std::move(next_cursor);
-    } while (!cursor.empty() && cursor != "0");
-
-    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-    auto current_iter = location_key_index_.find(location_id);
-    if (current_iter != location_key_index_.end()) {
-        rebuilt_keys.insert(current_iter->second.begin(), current_iter->second.end());
-    }
-    location_key_index_[location_id] = std::move(rebuilt_keys);
-    rebuilt_location_key_index_.insert(location_id);
-    if (location_key_index_[location_id].empty()) {
-        location_key_index_.erase(location_id);
-    }
-    return EC_OK;
 }
 
 ErrorCode MetaSearcher::GetKeysByLocationIndex(RequestContext *request_context,
@@ -358,21 +332,7 @@ ErrorCode MetaSearcher::GetKeysByLocationIndex(RequestContext *request_context,
     if (location_id.empty()) {
         return EC_BADARGS;
     }
-
-    bool needs_rebuild = false;
-    {
-        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
-        needs_rebuild = rebuilt_location_key_index_.find(location_id) == rebuilt_location_key_index_.end();
-    }
-    if (needs_rebuild) {
-        ErrorCode rebuild_ec = RebuildLocationKeyIndex(request_context, location_id);
-        if (rebuild_ec != EC_OK) {
-            return rebuild_ec;
-        }
-    }
-
-    SnapshotLocationKeyIndex(location_id, out_keys);
-    return EC_OK;
+    return meta_indexer_->GetKeysByLocationIndex(request_context, location_id, out_keys);
 }
 
 std::string MetaSearcher::BatchErrorCodeToStr(const std::vector<std::vector<ErrorCode>> &batch_results) {
@@ -878,7 +838,8 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
     for (size_t i = 0; i < keys.size(); ++i) {
         location_ids_per_key[i].push_back(out_location_ids[i]);
     }
-    AddKeysToLocationIndex(keys, location_ids_per_key, result.error_codes);
+    auto index_ecs = result.error_codes;
+    AddKeysToLocationIndex(request_context, keys, location_ids_per_key, &index_ecs);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -903,6 +864,19 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
     if (existing_ec != ErrorCode::EC_OK) {
         return existing_ec;
     }
+    LocationIdsPerKey location_ids_per_key(keys.size());
+    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        std::unordered_set<std::string> seen_location_ids;
+        location_ids_per_key[i].reserve(new_locations_per_key[i].size());
+        for (const auto &entry : new_locations_per_key[i]) {
+            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
+                continue;
+            }
+            location_ids_per_key[i].push_back(entry.location_id);
+        }
+    }
+    AddKeysToLocationIndex(request_context, keys, location_ids_per_key, &out_per_key_ec);
+
     for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
         if (i >= existing_location_maps.size()) {
             continue;
@@ -922,12 +896,18 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
 
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
 
-    auto modifier = [&new_locations_per_key, &keys, &loc_sz, batch_create_time](
+    auto modifier = [&new_locations_per_key, &keys, &loc_sz, &out_per_key_ec, batch_create_time](
                         const LocationIdVector & /*existing_ids*/,
                         ErrorCode get_ec,
                         size_t index,
                         PropertyMap & /*upsert_property_map*/,
                         CacheLocationMap &out_new_locations) -> ModifierResult {
+        if (index >= out_per_key_ec.size()) {
+            return {ModifierAction::MA_FAIL, ErrorCode::EC_ERROR};
+        }
+        if (out_per_key_ec[index] != ErrorCode::EC_OK) {
+            return {ModifierAction::MA_FAIL, out_per_key_ec[index]};
+        }
         if (get_ec != ErrorCode::EC_OK && get_ec != ErrorCode::EC_NOENT) {
             KVCM_LOG_WARN("load location failed, key[%lu](%lu) return %d", index, keys[index], get_ec);
             return {ModifierAction::MA_FAIL, get_ec};
@@ -977,18 +957,6 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             }
         }
     }
-    LocationIdsPerKey location_ids_per_key(keys.size());
-    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
-        std::unordered_set<std::string> seen_location_ids;
-        location_ids_per_key[i].reserve(new_locations_per_key[i].size());
-        for (const auto &entry : new_locations_per_key[i]) {
-            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
-                continue;
-            }
-            location_ids_per_key[i].push_back(entry.location_id);
-        }
-    }
-    AddKeysToLocationIndex(keys, location_ids_per_key, out_per_key_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -1222,7 +1190,7 @@ ErrorCode MetaSearcher::BatchCADLocationStatus(RequestContext *request_context,
             }
         }
     }
-    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_batch_results);
+    RemoveKeysFromLocationIndex(request_context, keys, location_ids_per_key, out_batch_results);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1316,7 +1284,7 @@ ErrorCode MetaSearcher::BatchDeleteLocation(RequestContext *request_context,
     for (size_t i = 0; i < keys.size(); ++i) {
         per_location_ec[i].push_back(results[i]);
     }
-    RemoveKeysFromLocationIndex(keys, location_ids_per_key, per_location_ec);
+    RemoveKeysFromLocationIndex(request_context, keys, location_ids_per_key, per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1397,7 +1365,7 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
             }
         }
     }
-    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_per_location_ec);
+    RemoveKeysFromLocationIndex(request_context, keys, location_ids_per_key, out_per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -284,22 +284,94 @@ void MetaSearcher::RemoveKeysFromLocationIndex(
     }
 }
 
-ErrorCode MetaSearcher::GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const {
-    if (location_id.empty()) {
-        return EC_BADARGS;
-    }
-
+void MetaSearcher::SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const {
     out_keys.clear();
     std::lock_guard<std::mutex> lock(location_key_index_mutex_);
     auto iter = location_key_index_.find(location_id);
     if (iter == location_key_index_.end()) {
-        return EC_OK;
+        return;
     }
     out_keys.reserve(iter->second.size());
     for (const auto &key : iter->second) {
         out_keys.push_back(key);
     }
     std::sort(out_keys.begin(), out_keys.end());
+}
+
+ErrorCode MetaSearcher::RebuildLocationKeyIndex(RequestContext *request_context,
+                                                const std::string &location_id,
+                                                size_t scan_batch_size) {
+    if (location_id.empty() || scan_batch_size == 0) {
+        return EC_BADARGS;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+        if (rebuilt_location_key_index_.find(location_id) != rebuilt_location_key_index_.end()) {
+            return EC_OK;
+        }
+    }
+
+    std::unordered_set<KeyType> rebuilt_keys;
+    std::string cursor = "0";
+    do {
+        std::string next_cursor;
+        KeyVector scanned_keys;
+        ErrorCode scan_ec = meta_indexer_->Scan(request_context, cursor, scan_batch_size, next_cursor, scanned_keys);
+        if (scan_ec != EC_OK) {
+            return scan_ec;
+        }
+
+        if (!scanned_keys.empty()) {
+            std::vector<CacheLocationMap> location_maps;
+            BlockMask empty_mask = static_cast<size_t>(0);
+            ErrorCode get_ec = BatchGetLocation(request_context, scanned_keys, empty_mask, location_maps);
+            if (get_ec != EC_OK) {
+                return get_ec;
+            }
+            for (size_t i = 0; i < scanned_keys.size() && i < location_maps.size(); ++i) {
+                if (location_maps[i].find(location_id) != location_maps[i].end()) {
+                    rebuilt_keys.insert(scanned_keys[i]);
+                }
+            }
+        }
+
+        cursor = std::move(next_cursor);
+    } while (!cursor.empty() && cursor != "0");
+
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto current_iter = location_key_index_.find(location_id);
+    if (current_iter != location_key_index_.end()) {
+        rebuilt_keys.insert(current_iter->second.begin(), current_iter->second.end());
+    }
+    location_key_index_[location_id] = std::move(rebuilt_keys);
+    rebuilt_location_key_index_.insert(location_id);
+    if (location_key_index_[location_id].empty()) {
+        location_key_index_.erase(location_id);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaSearcher::GetKeysByLocationIndex(RequestContext *request_context,
+                                               const std::string &location_id,
+                                               KeyVector &out_keys) {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+
+    bool needs_rebuild = false;
+    {
+        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+        needs_rebuild = rebuilt_location_key_index_.find(location_id) == rebuilt_location_key_index_.end();
+    }
+    if (needs_rebuild) {
+        ErrorCode rebuild_ec = RebuildLocationKeyIndex(request_context, location_id);
+        if (rebuild_ec != EC_OK) {
+            return rebuild_ec;
+        }
+    }
+
+    SnapshotLocationKeyIndex(location_id, out_keys);
     return EC_OK;
 }
 

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -39,6 +39,22 @@ bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
     return ec == ErrorCode::EC_OK || ec == ErrorCode::EC_NOENT;
 }
 
+std::uint64_t LocationSpecSize(const std::vector<LocationSpec> &specs) {
+    std::uint64_t size = 0;
+    for (const auto &loc_spec : specs) {
+        if (DataStorageUri ds_uri(loc_spec.uri()); ds_uri.Valid()) {
+            std::uint64_t spec_size = 0;
+            ds_uri.GetParamAs<std::uint64_t>("size", spec_size);
+            size += spec_size;
+        }
+    }
+    return size;
+}
+
+std::uint64_t CacheLocationSize(const CacheLocationConstPtr &loc) {
+    return loc ? LocationSpecSize(loc->location_specs()) : 0;
+}
+
 CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
                                              CacheLocationMap &location_map,
                                              CheckLocDataExistFunc check_loc_data_exist,
@@ -808,6 +824,30 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
     out_per_key_ec.assign(keys.size(), ErrorCode::EC_OK);
 
     std::vector<std::pair<DataStorageType, std::uint64_t>> loc_sz(keys.size());
+    std::vector<std::map<DataStorageType, std::uint64_t>> replaced_loc_sz(keys.size());
+    std::vector<CacheLocationMap> existing_location_maps;
+    BlockMask empty_mask = static_cast<size_t>(0);
+    auto existing_ec = BatchGetLocation(request_context, keys, empty_mask, existing_location_maps);
+    if (existing_ec != ErrorCode::EC_OK) {
+        return existing_ec;
+    }
+    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        if (i >= existing_location_maps.size()) {
+            continue;
+        }
+        std::unordered_set<std::string> seen_location_ids;
+        for (const auto &entry : new_locations_per_key[i]) {
+            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
+                continue;
+            }
+            auto existing_iter = existing_location_maps[i].find(entry.location_id);
+            if (existing_iter == existing_location_maps[i].end() || !existing_iter->second) {
+                continue;
+            }
+            replaced_loc_sz[i][existing_iter->second->type()] += CacheLocationSize(existing_iter->second);
+        }
+    }
+
     const int64_t batch_create_time = TimestampUtil::GetCurrentTimeUs();
 
     auto modifier = [&new_locations_per_key, &keys, &loc_sz, batch_create_time](
@@ -822,7 +862,15 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
         }
         std::uint64_t key_total_sz = 0;
         DataStorageType key_type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        for (const auto &entry : new_locations_per_key[index]) {
+        std::map<std::string, size_t> final_entry_index_by_location;
+        for (size_t entry_index = 0; entry_index < new_locations_per_key[index].size(); ++entry_index) {
+            const auto &entry = new_locations_per_key[index][entry_index];
+            if (!entry.location_id.empty()) {
+                final_entry_index_by_location[entry.location_id] = entry_index;
+            }
+        }
+        for (const auto &kv : final_entry_index_by_location) {
+            const auto &entry = new_locations_per_key[index][kv.second];
             CacheLocation loc;
             loc.set_id(entry.location_id);
             loc.set_type(entry.type);
@@ -831,12 +879,8 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             loc.set_create_time(batch_create_time);
             for (const auto &ls : entry.specs) {
                 loc.push_location_spec(LocationSpec(ls.name(), ls.uri()));
-                if (DataStorageUri ds_uri(ls.uri()); ds_uri.Valid()) {
-                    std::uint64_t spec_sz = 0;
-                    ds_uri.GetParamAs<std::uint64_t>("size", spec_sz);
-                    key_total_sz += spec_sz;
-                }
             }
+            key_total_sz += LocationSpecSize(entry.specs);
             out_new_locations[entry.location_id] = std::make_shared<const CacheLocation>(std::move(loc));
             if (key_type == DataStorageType::DATA_STORAGE_TYPE_UNKNOWN) {
                 key_type = entry.type;
@@ -856,12 +900,19 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
         out_per_key_ec[i] = key_ec;
         if (key_ec == ErrorCode::EC_OK) {
             meta_indexer_->AddStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
+            for (const auto &replaced : replaced_loc_sz[i]) {
+                meta_indexer_->SubStorageUsageByType(replaced.first, replaced.second);
+            }
         }
     }
     LocationIdsPerKey location_ids_per_key(keys.size());
     for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        std::unordered_set<std::string> seen_location_ids;
         location_ids_per_key[i].reserve(new_locations_per_key[i].size());
         for (const auto &entry : new_locations_per_key[i]) {
+            if (entry.location_id.empty() || !seen_location_ids.insert(entry.location_id).second) {
+                continue;
+            }
             location_ids_per_key[i].push_back(entry.location_id);
         }
     }

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <map>
+#include <mutex>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "kv_cache_manager/common/logger.h"
@@ -31,6 +33,10 @@ void LogErrorCodes(const std::string &operation_name,
             KVCM_LOG_WARN("%s failed, keys[%lu](%lu) return %d", operation_name.c_str(), i, keys[i], error_codes[i]);
         }
     }
+}
+
+bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
+    return ec == ErrorCode::EC_OK || ec == ErrorCode::EC_NOENT;
 }
 
 CacheLocationConstPtr SelectAndMergeForMatch(SelectLocationPolicy *policy,
@@ -207,6 +213,79 @@ MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
     , submit_del_req_func_(submit_del_req) {}
 
 MetaSearcher::~MetaSearcher() = default;
+
+void MetaSearcher::AddKeysToLocationIndex(const KeyVector &keys,
+                                          const LocationIdsPerKey &location_ids_per_key,
+                                          const std::vector<ErrorCode> &per_key_ec) {
+    if (keys.size() != location_ids_per_key.size()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (i >= per_key_ec.size() || per_key_ec[i] != ErrorCode::EC_OK) {
+            continue;
+        }
+        for (const auto &location_id : location_ids_per_key[i]) {
+            if (location_id.empty()) {
+                continue;
+            }
+            location_key_index_[location_id].insert(keys[i]);
+        }
+    }
+}
+
+void MetaSearcher::RemoveKeysFromLocationIndex(
+    const KeyVector &keys,
+    const LocationIdsPerKey &location_ids_per_key,
+    const std::vector<std::vector<ErrorCode>> &per_location_ec) {
+    if (keys.size() != location_ids_per_key.size()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (i >= per_location_ec.size()) {
+            continue;
+        }
+        for (size_t j = 0; j < location_ids_per_key[i].size(); ++j) {
+            if (j >= per_location_ec[i].size() || !ShouldRemoveLocationIndexEntry(per_location_ec[i][j])) {
+                continue;
+            }
+            const auto &location_id = location_ids_per_key[i][j];
+            if (location_id.empty()) {
+                continue;
+            }
+            auto iter = location_key_index_.find(location_id);
+            if (iter == location_key_index_.end()) {
+                continue;
+            }
+            iter->second.erase(keys[i]);
+            if (iter->second.empty()) {
+                location_key_index_.erase(iter);
+            }
+        }
+    }
+}
+
+ErrorCode MetaSearcher::GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+
+    out_keys.clear();
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    out_keys.reserve(iter->second.size());
+    for (const auto &key : iter->second) {
+        out_keys.push_back(key);
+    }
+    std::sort(out_keys.begin(), out_keys.end());
+    return EC_OK;
+}
 
 std::string MetaSearcher::BatchErrorCodeToStr(const std::vector<std::vector<ErrorCode>> &batch_results) {
     std::stringstream result_stream;
@@ -707,6 +786,11 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
             meta_indexer_->AddStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
         }
     }
+    LocationIdsPerKey location_ids_per_key(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        location_ids_per_key[i].push_back(out_location_ids[i]);
+    }
+    AddKeysToLocationIndex(keys, location_ids_per_key, result.error_codes);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -774,6 +858,14 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             meta_indexer_->AddStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
         }
     }
+    LocationIdsPerKey location_ids_per_key(keys.size());
+    for (size_t i = 0; i < new_locations_per_key.size(); ++i) {
+        location_ids_per_key[i].reserve(new_locations_per_key[i].size());
+        for (const auto &entry : new_locations_per_key[i]) {
+            location_ids_per_key[i].push_back(entry.location_id);
+        }
+    }
+    AddKeysToLocationIndex(keys, location_ids_per_key, out_per_key_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         LogErrorCodes("meta_indexer_->ReadModifyWriteBlock", result.error_codes, keys);
@@ -1007,6 +1099,7 @@ ErrorCode MetaSearcher::BatchCADLocationStatus(RequestContext *request_context,
             }
         }
     }
+    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_batch_results);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1096,6 +1189,11 @@ ErrorCode MetaSearcher::BatchDeleteLocation(RequestContext *request_context,
             meta_indexer_->SubStorageUsageByType(loc_sz[i].first, loc_sz[i].second);
         }
     }
+    std::vector<std::vector<ErrorCode>> per_location_ec(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        per_location_ec[i].push_back(results[i]);
+    }
+    RemoveKeysFromLocationIndex(keys, location_ids_per_key, per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);
@@ -1176,6 +1274,7 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
             }
         }
     }
+    RemoveKeysFromLocationIndex(keys, location_ids_per_key, out_per_location_ec);
 
     if (result.ec != ErrorCode::EC_OK) {
         KVCM_LOG_WARN("meta_indexer_->ReadModifyWriteLocation failed, ec: %d", result.ec);

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -34,14 +34,6 @@ void LogErrorCodes(const std::string &operation_name,
     }
 }
 
-bool ShouldRemoveLocationIndexEntry(ErrorCode ec) {
-    // Remove the index only after CacheMeta confirms the location was deleted.
-    // If we remove on EC_NOENT, a concurrent add-before-meta write can be
-    // observed as over-index and then turned into under-index when its later
-    // CacheMeta write succeeds.
-    return ec == ErrorCode::EC_OK;
-}
-
 std::uint64_t LocationSpecSize(const std::vector<LocationSpec> &specs) {
     std::uint64_t size = 0;
     for (const auto &loc_spec : specs) {
@@ -232,6 +224,14 @@ MetaSearcher::MetaSearcher(const std::shared_ptr<MetaIndexer> &meta_indexer,
     , submit_del_req_func_(submit_del_req) {}
 
 MetaSearcher::~MetaSearcher() = default;
+
+bool MetaSearcher::ShouldRemoveLocationIndexEntry(ErrorCode ec) {
+    // Remove the index only after CacheMeta confirms the location was deleted.
+    // If we remove on EC_NOENT, a concurrent add-before-meta write can be
+    // observed as over-index and then turned into under-index when its later
+    // CacheMeta write succeeds.
+    return ec == ErrorCode::EC_OK;
+}
 
 void MetaSearcher::AddKeysToLocationIndex(RequestContext *request_context,
                                           const KeyVector &keys,
@@ -875,6 +875,10 @@ ErrorCode MetaSearcher::BatchUpsertLocations(RequestContext *request_context,
             location_ids_per_key[i].push_back(entry.location_id);
         }
     }
+    // ReportEvent snapshot diff cannot discover under-index without scanning all
+    // CacheMeta. Add the derived index before writing CacheMeta, so failures can
+    // only leave over-index, which snapshot verification filters and delayed
+    // repair can later clean up.
     AddKeysToLocationIndex(request_context, keys, location_ids_per_key, &out_per_key_ec);
 
     for (size_t i = 0; i < new_locations_per_key.size(); ++i) {

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -3,10 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -145,23 +142,18 @@ private:
                                           const KeyVector &keys,
                                           CacheLocationVector &out_locations,
                                           SelectLocationPolicy *policy) const;
-    void AddKeysToLocationIndex(const KeyVector &keys,
+    void AddKeysToLocationIndex(RequestContext *request_context,
+                                const KeyVector &keys,
                                 const LocationIdsPerKey &location_ids_per_key,
-                                const std::vector<ErrorCode> &per_key_ec);
-    void RemoveKeysFromLocationIndex(const KeyVector &keys,
+                                std::vector<ErrorCode> *per_key_ec);
+    void RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                     const KeyVector &keys,
                                      const LocationIdsPerKey &location_ids_per_key,
                                      const std::vector<std::vector<ErrorCode>> &per_location_ec);
-    ErrorCode RebuildLocationKeyIndex(RequestContext *request_context,
-                                      const std::string &location_id,
-                                      size_t scan_batch_size = 1000);
-    void SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const;
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;
     SubmitDelReqFunc submit_del_req_func_;
-    mutable std::mutex location_key_index_mutex_;
-    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
-    std::unordered_set<std::string> rebuilt_location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -3,7 +3,10 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -121,6 +124,7 @@ public:
                                      DataStorageType storage_type,
                                      size_t scan_batch_size = 1000,
                                      std::function<bool()> should_abort = nullptr);
+    ErrorCode GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const;
 
 private:
     struct StorageTypeWeights {
@@ -139,10 +143,18 @@ private:
                                           const KeyVector &keys,
                                           CacheLocationVector &out_locations,
                                           SelectLocationPolicy *policy) const;
+    void AddKeysToLocationIndex(const KeyVector &keys,
+                                const LocationIdsPerKey &location_ids_per_key,
+                                const std::vector<ErrorCode> &per_key_ec);
+    void RemoveKeysFromLocationIndex(const KeyVector &keys,
+                                     const LocationIdsPerKey &location_ids_per_key,
+                                     const std::vector<std::vector<ErrorCode>> &per_location_ec);
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;
     SubmitDelReqFunc submit_del_req_func_;
+    mutable std::mutex location_key_index_mutex_;
+    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -150,6 +150,7 @@ private:
                                      const KeyVector &keys,
                                      const LocationIdsPerKey &location_ids_per_key,
                                      const std::vector<std::vector<ErrorCode>> &per_location_ec);
+    static bool ShouldRemoveLocationIndexEntry(ErrorCode ec);
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -124,7 +124,9 @@ public:
                                      DataStorageType storage_type,
                                      size_t scan_batch_size = 1000,
                                      std::function<bool()> should_abort = nullptr);
-    ErrorCode GetKeysByLocationIndex(const std::string &location_id, KeyVector &out_keys) const;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                      const std::string &location_id,
+                                      KeyVector &out_keys);
 
 private:
     struct StorageTypeWeights {
@@ -149,12 +151,17 @@ private:
     void RemoveKeysFromLocationIndex(const KeyVector &keys,
                                      const LocationIdsPerKey &location_ids_per_key,
                                      const std::vector<std::vector<ErrorCode>> &per_location_ec);
+    ErrorCode RebuildLocationKeyIndex(RequestContext *request_context,
+                                      const std::string &location_id,
+                                      size_t scan_batch_size = 1000);
+    void SnapshotLocationKeyIndex(const std::string &location_id, KeyVector &out_keys) const;
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;
     SubmitDelReqFunc submit_del_req_func_;
     mutable std::mutex location_key_index_mutex_;
     std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
+    std::unordered_set<std::string> rebuilt_location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -260,6 +260,33 @@ public:
         return location_map.find(location_id) != location_map.end();
     }
 
+    std::string GetFirstSpecUri(int64_t key, const std::string &location_id) {
+        auto location_map = GetLocationMapForKey(key);
+        auto iter = location_map.find(location_id);
+        if (iter == location_map.end() || !iter->second || iter->second->location_specs().empty()) {
+            return "";
+        }
+        return iter->second->location_specs().front().uri();
+    }
+
+    std::string GetFirstQueriedSpecUri(int64_t key) {
+        BlockMask bm = static_cast<size_t>(0);
+        auto [ec, locations] = cache_manager_->GetCacheLocation(request_context_.get(),
+                                                                "test_instance",
+                                                                CacheManager::QueryType::QT_BATCH_GET,
+                                                                {key},
+                                                                {},
+                                                                bm,
+                                                                0,
+                                                                {});
+        EXPECT_EQ(EC_OK, ec);
+        const auto &views = locations.cache_locations_view();
+        if (views.empty() || views.front().location_specs().empty()) {
+            return "";
+        }
+        return views.front().location_specs().front().uri();
+    }
+
     std::unique_ptr<CacheManager> cache_manager_;
     std::shared_ptr<RegistryManager> registry_manager_;
     std::shared_ptr<RequestContext> request_context_;
@@ -3034,6 +3061,78 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDiffsHostLocation) {
     ReportBlockSnapshot(host, "mem", {400, 500});
     EXPECT_FALSE(HasLocation(300, location_id));
     EXPECT_TRUE(HasLocation(400, location_id));
+    EXPECT_TRUE(HasLocation(500, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotVisibleThroughCacheQuery) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true);
+    EXPECT_EQ("vineyard://" + host + "/mem/300", GetFirstQueriedSpecUri(300));
+    EXPECT_EQ("vineyard://" + host + "/mem/400", GetFirstQueriedSpecUri(400));
+
+    ReportBlockSnapshot(host, "mem", {400, 500});
+    EXPECT_EQ("", GetFirstQueriedSpecUri(300));
+    EXPECT_EQ("vineyard://" + host + "/mem/400", GetFirstQueriedSpecUri(400));
+    EXPECT_EQ("vineyard://" + host + "/mem/500", GetFirstQueriedSpecUri(500));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotRefreshesExistingSpecs) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300}, true);
+    ASSERT_EQ("vineyard://" + host + "/mem/300", GetFirstSpecUri(300, location_id));
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    auto *ev = req.add_events();
+    ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *snapshot = ev->mutable_block_snapshot();
+    snapshot->set_medium("mem");
+    auto *block = snapshot->add_blocks();
+    block->set_block_key("300");
+    auto *spec = block->add_specs();
+    spec->set_name("tp0");
+    spec->set_uri("vineyard://" + host + "/mem/300-updated");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_EQ("vineyard://" + host + "/mem/300-updated", GetFirstSpecUri(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotConvergesWithMultipleSnapshotsInOneRequest) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true);
+    ASSERT_TRUE(HasLocation(300, location_id));
+    ASSERT_TRUE(HasLocation(400, location_id));
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddBlockSnapshotEvent(&req, host, "mem", {300, 500});
+    AddBlockSnapshotEvent(&req, host, "mem", {500});
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(400, location_id));
     EXPECT_TRUE(HasLocation(500, location_id));
 }
 

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -3293,6 +3293,62 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {
     EXPECT_TRUE(HasLocation(500, ssd_loc));
 }
 
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotSameBlockOtherHostSurvives) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host_a = "192.168.2.1:8080";
+    const std::string host_b = "192.168.2.2:8080";
+    const std::string loc_a = ExpectedReportEventLocationId(host_a, "mem");
+    const std::string loc_b = ExpectedReportEventLocationId(host_b, "mem");
+
+    ReportBlockSnapshot(host_a, "mem", {300}, true);
+    ReportBlockSnapshot(host_b, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, loc_a));
+    ASSERT_TRUE(HasLocation(300, loc_b));
+
+    ReportBlockSnapshot(host_a, "mem", {});
+    EXPECT_FALSE(HasLocation(300, loc_a));
+    EXPECT_TRUE(HasLocation(300, loc_b));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotReplacesMismatchedReportedLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> mismatched_locations = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_NFS,
+          CLS_SERVING,
+          {LocationSpec("tp0", "file:///tmp/not-vineyard?size=10")}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher->BatchUpsertLocations(request_context_.get(), {300}, mismatched_locations, per_key_ec));
+    ASSERT_EQ(1, per_key_ec.size());
+    ASSERT_EQ(EC_OK, per_key_ec[0]);
+    ASSERT_TRUE(HasLocation(300, location_id));
+    ASSERT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, GetLocationMapForKey(300).at(location_id)->type());
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddBlockSnapshotEvent(&req, host, "mem", {300}, 20, "-reported");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    ASSERT_TRUE(HasLocation(300, location_id));
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_VINEYARD, GetLocationMapForKey(300).at(location_id)->type());
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 20, "-reported"), GetFirstSpecUri(300, location_id));
+}
+
 TEST_F(CacheManagerTest, TestReportEventPreservesDeleteThenAddOrder) {
     RegisterDefaultInstanceForReportEvent();
     SetupVineyardEventReportingBackend();
@@ -3428,6 +3484,82 @@ TEST_F(CacheManagerTest, TestReportEventSkipsMambaStateSpecNames) {
     EXPECT_TRUE(HasLocation(300, location_id));
     EXPECT_FALSE(HasLocation(400, location_id));
     EXPECT_FALSE(HasLocation(401, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventSnapshotDoesNotDeleteMambaOnlyExistingLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
+
+    auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> mamba_locations = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+          CLS_SERVING,
+          {LocationSpec("mamba_state:group=1", ReportEventUri(host, "gpu", 300, 0, "-mamba"))}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK, meta_searcher->BatchUpsertLocations(request_context_.get(), {300}, mamba_locations, per_key_ec));
+    ASSERT_EQ(1, per_key_ec.size());
+    ASSERT_EQ(EC_OK, per_key_ec[0]);
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    ReportBlockSnapshot(host, "gpu", {}, true);
+    EXPECT_TRUE(HasLocation(300, location_id));
+
+    auto indexed_keys = GetLocationIndexKeys(location_id);
+    EXPECT_NE(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 300));
+}
+
+TEST_F(CacheManagerTest, TestReportEventDeleteSpecNamesRequireFullAttention) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"gpu"});
+        AddBlockAddEvent(&req, host, "gpu", 300, 0, "", "full_attention:group=0:tp=0");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockDeleteEvent(&req, "gpu", 300, {"mamba_state:group=1"});
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_TRUE(HasLocation(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockDeleteEvent(&req, "gpu", 300, {"mamba_state:group=1", "full_attention:group=0:tp=0"});
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_FALSE(HasLocation(300, location_id));
 }
 
 TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
@@ -3620,6 +3752,44 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotPartialFailureKeepsValidSna
     EXPECT_EQ(proto::meta::OK, resp.item_results(1));
     EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
     EXPECT_TRUE(HasLocation(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventPartialBlockAddFailureKeepsValidAdds) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"mem"});
+    AddBlockAddEvent(&req, host, "mem", 300);
+
+    auto *invalid_key = req.add_events();
+    invalid_key->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+    auto *invalid_add = invalid_key->mutable_block_add();
+    invalid_add->set_block_key("bad-key");
+    invalid_add->set_medium("mem");
+    auto *invalid_spec = invalid_add->add_specs();
+    invalid_spec->set_name("tp0");
+    invalid_spec->set_uri(ReportEventUri(host, "mem", 301));
+
+    AddBlockAddEvent(&req, host, "mem", 302);
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, resp.header().status().code());
+    ASSERT_EQ(4, resp.item_results_size());
+    EXPECT_EQ(proto::meta::OK, resp.item_results(0));
+    EXPECT_EQ(proto::meta::OK, resp.item_results(1));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
+    EXPECT_EQ(proto::meta::OK, resp.item_results(3));
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(301, location_id));
+    EXPECT_TRUE(HasLocation(302, location_id));
 }
 
 TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -173,6 +173,93 @@ public:
         }
     }
 
+    void RegisterDefaultInstanceForReportEvent() {
+        auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+        ASSERT_EQ(expected_reg,
+                  cache_manager_->RegisterInstance(request_context_.get(),
+                                                   "default",
+                                                   "test_instance",
+                                                   64,
+                                                   createLocationSpecInfos(),
+                                                   createModelDeployment(),
+                                                   std::vector<LocationSpecGroup>()));
+    }
+
+    void SetupVineyardEventReportingBackend(const std::string &storage_name = "vineyard_default") {
+        auto vineyard_backend = std::make_shared<VineyardBackend>(metrics_registry_);
+        StorageConfig v6d_config;
+        v6d_config.set_global_unique_name(storage_name);
+        v6d_config.set_type(DataStorageType::DATA_STORAGE_TYPE_VINEYARD);
+        v6d_config.set_storage_spec(std::make_shared<VineyardStorageSpec>());
+        ASSERT_EQ(EC_OK, vineyard_backend->Open(v6d_config, "test_trace"));
+
+        auto dsm = registry_manager_->data_storage_manager_;
+        dsm->storage_map_[storage_name] = vineyard_backend;
+        registry_manager_->instance_group_configs_["default"]->set_event_reporting_storage_candidates({storage_name});
+    }
+
+    void AddNodeRegisterEvent(proto::meta::ReportEventRequest *req, const std::vector<std::string> &mediums) {
+        auto *reg = req->add_events();
+        reg->set_event_type(proto::meta::EVENT_NODE_REGISTER);
+        for (const auto &medium : mediums) {
+            reg->mutable_node_register()->add_mediums(medium);
+        }
+    }
+
+    void AddBlockSnapshotEvent(proto::meta::ReportEventRequest *req,
+                               const std::string &host,
+                               const std::string &medium,
+                               const std::vector<int64_t> &keys) {
+        auto *ev = req->add_events();
+        ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+        auto *snapshot = ev->mutable_block_snapshot();
+        snapshot->set_medium(medium);
+        for (auto key : keys) {
+            auto *block = snapshot->add_blocks();
+            block->set_block_key(std::to_string(key));
+            auto *spec = block->add_specs();
+            spec->set_name("tp0");
+            spec->set_uri("vineyard://" + host + "/" + medium + "/" + std::to_string(key));
+        }
+    }
+
+    proto::meta::ReportEventResponse ReportBlockSnapshot(const std::string &host,
+                                                         const std::string &medium,
+                                                         const std::vector<int64_t> &keys,
+                                                         bool register_node = false,
+                                                         const std::vector<std::string> &register_mediums = {}) {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        if (register_node) {
+            AddNodeRegisterEvent(&req, register_mediums.empty() ? std::vector<std::string>{medium} : register_mediums);
+        }
+        AddBlockSnapshotEvent(&req, host, medium, keys);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+        return resp;
+    }
+
+    CacheLocationMap GetLocationMapForKey(int64_t key) {
+        auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+        EXPECT_NE(nullptr, meta_searcher);
+        if (!meta_searcher) {
+            return {};
+        }
+        std::vector<CacheLocationMap> maps;
+        BlockMask bm = static_cast<size_t>(0);
+        EXPECT_EQ(EC_OK, meta_searcher->BatchGetLocation(request_context_.get(), {key}, bm, maps));
+        return maps.empty() ? CacheLocationMap{} : maps[0];
+    }
+
+    bool HasLocation(int64_t key, const std::string &location_id) {
+        auto location_map = GetLocationMapForKey(key);
+        return location_map.find(location_id) != location_map.end();
+    }
+
     std::unique_ptr<CacheManager> cache_manager_;
     std::shared_ptr<RegistryManager> registry_manager_;
     std::shared_ptr<RequestContext> request_context_;
@@ -2931,6 +3018,134 @@ TEST_F(CacheManagerTest, InvalidateInstanceMetricsInvokesCallback) {
 //   peer_A: {300,400,600}      → 3 keys
 //   peer_B: {300,400,500,600}  → 4 keys (winner)
 //   peer_C: {300}              → 1 key
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDiffsHostLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true);
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_TRUE(HasLocation(400, location_id));
+    EXPECT_FALSE(HasLocation(500, location_id));
+
+    ReportBlockSnapshot(host, "mem", {400, 500});
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_TRUE(HasLocation(400, location_id));
+    EXPECT_TRUE(HasLocation(500, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotEmptySnapshotDeletesOnlyTargetLocation) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host_a = "192.168.2.1:8080";
+    const std::string host_b = "192.168.2.2:8080";
+    const std::string loc_a = "kvs#v6d#mem#" + host_a;
+    const std::string loc_b = "kvs#v6d#mem#" + host_b;
+
+    ReportBlockSnapshot(host_a, "mem", {300, 400}, true);
+    ReportBlockSnapshot(host_b, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, loc_a));
+    ASSERT_TRUE(HasLocation(300, loc_b));
+    ASSERT_TRUE(HasLocation(400, loc_a));
+
+    ReportBlockSnapshot(host_a, "mem", {});
+    EXPECT_FALSE(HasLocation(300, loc_a));
+    EXPECT_FALSE(HasLocation(400, loc_a));
+    EXPECT_TRUE(HasLocation(300, loc_b));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string mem_loc = "kvs#v6d#mem#" + host;
+    const std::string ssd_loc = "kvs#v6d#ssd#" + host;
+
+    ReportBlockSnapshot(host, "mem", {300, 400}, true, {"mem", "ssd"});
+    ReportBlockSnapshot(host, "ssd", {300, 500});
+    ASSERT_TRUE(HasLocation(300, mem_loc));
+    ASSERT_TRUE(HasLocation(400, mem_loc));
+    ASSERT_TRUE(HasLocation(300, ssd_loc));
+    ASSERT_TRUE(HasLocation(500, ssd_loc));
+
+    ReportBlockSnapshot(host, "mem", {300});
+    EXPECT_TRUE(HasLocation(300, mem_loc));
+    EXPECT_FALSE(HasLocation(400, mem_loc));
+    EXPECT_TRUE(HasLocation(300, ssd_loc));
+    EXPECT_TRUE(HasLocation(500, ssd_loc));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotRejectsInvalidSnapshot) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"mem"});
+
+    auto *invalid_key = req.add_events();
+    invalid_key->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *invalid_snapshot = invalid_key->mutable_block_snapshot();
+    invalid_snapshot->set_medium("mem");
+    auto *invalid_block = invalid_snapshot->add_blocks();
+    invalid_block->set_block_key("not-an-int64");
+    invalid_block->add_specs()->set_name("tp0");
+
+    auto *empty_specs = req.add_events();
+    empty_specs->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *empty_specs_snapshot = empty_specs->mutable_block_snapshot();
+    empty_specs_snapshot->set_medium("mem");
+    empty_specs_snapshot->add_blocks()->set_block_key("301");
+
+    auto *missing_payload = req.add_events();
+    missing_payload->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, resp.header().status().code());
+    ASSERT_EQ(4, resp.item_results_size());
+    EXPECT_EQ(proto::meta::OK, resp.item_results(0));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(1));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(3));
+    EXPECT_FALSE(HasLocation(301, "kvs#v6d#mem#" + host));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotPartialFailureKeepsValidSnapshot) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = "kvs#v6d#mem#" + host;
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"mem"});
+    AddBlockSnapshotEvent(&req, host, "mem", {300});
+
+    auto *invalid = req.add_events();
+    invalid->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    invalid->mutable_block_snapshot()->set_medium("");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_PARTIAL_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::INTERNAL_ERROR, resp.header().status().code());
+    ASSERT_EQ(3, resp.item_results_size());
+    EXPECT_EQ(proto::meta::OK, resp.item_results(0));
+    EXPECT_EQ(proto::meta::OK, resp.item_results(1));
+    EXPECT_EQ(proto::meta::INVALID_ARGUMENT, resp.item_results(2));
+    EXPECT_TRUE(HasLocation(300, location_id));
+}
 
 TEST_F(CacheManagerTest, TestGetCacheLocationsByBackendWithBackendSelectors) {
     auto expected_reg = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -1,7 +1,12 @@
 #include <chrono>
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include "kv_cache_manager/common/jsonizable.h"
 #include "kv_cache_manager/common/request_context.h"
@@ -206,20 +211,92 @@ public:
         }
     }
 
+    using LocationScopeLabels = std::vector<std::pair<std::string, std::string>>;
+
+    void SetLocationScope(proto::meta::LocationScope *scope,
+                          const std::string &medium,
+                          const LocationScopeLabels &labels) {
+        scope->set_medium(medium);
+        for (const auto &label : labels) {
+            (*scope->mutable_labels())[label.first] = label.second;
+        }
+    }
+
+    std::string ExpectedReportEventLocationId(const std::string &host,
+                                              const std::string &medium,
+                                              const LocationScopeLabels &labels = {}) {
+        std::string location_id = "kvs#v6d#" + medium;
+        std::map<std::string, std::string> sorted_labels;
+        for (const auto &label : labels) {
+            sorted_labels[label.first] = label.second;
+        }
+        for (const auto &label : sorted_labels) {
+            location_id += ";" + label.first + "=" + label.second;
+        }
+        return location_id + "#" + host;
+    }
+
+    std::string ReportEventUri(const std::string &host,
+                               const std::string &medium,
+                               int64_t key,
+                               uint64_t size = 0,
+                               const std::string &suffix = "") {
+        std::string uri = "vineyard://" + host + "/" + medium + "/" + std::to_string(key) + suffix;
+        if (size > 0) {
+            uri += "?size=" + std::to_string(size);
+        }
+        return uri;
+    }
+
+    void AddBlockAddEvent(proto::meta::ReportEventRequest *req,
+                          const std::string &host,
+                          const std::string &medium,
+                          int64_t key,
+                          uint64_t size = 0,
+                          const LocationScopeLabels &labels = {},
+                          const std::string &suffix = "") {
+        auto *ev = req->add_events();
+        ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
+        auto *add = ev->mutable_block_add();
+        add->set_block_key(std::to_string(key));
+        SetLocationScope(add->mutable_location(), medium, labels);
+        auto *spec = add->add_specs();
+        spec->set_name("tp0");
+        spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
+    }
+
+    void AddBlockDeleteEvent(proto::meta::ReportEventRequest *req,
+                             const std::string &medium,
+                             int64_t key,
+                             const LocationScopeLabels &labels = {}) {
+        auto *ev = req->add_events();
+        ev->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
+        auto *del = ev->mutable_block_delete();
+        del->set_block_key(std::to_string(key));
+        SetLocationScope(del->mutable_location(), medium, labels);
+    }
+
     void AddBlockSnapshotEvent(proto::meta::ReportEventRequest *req,
                                const std::string &host,
                                const std::string &medium,
-                               const std::vector<int64_t> &keys) {
+                               const std::vector<int64_t> &keys,
+                               const LocationScopeLabels &labels = {},
+                               uint64_t size = 0,
+                               const std::string &suffix = "") {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
         auto *snapshot = ev->mutable_block_snapshot();
-        snapshot->set_medium(medium);
+        if (labels.empty()) {
+            snapshot->set_medium(medium);
+        } else {
+            SetLocationScope(snapshot->mutable_location(), medium, labels);
+        }
         for (auto key : keys) {
             auto *block = snapshot->add_blocks();
             block->set_block_key(std::to_string(key));
             auto *spec = block->add_specs();
             spec->set_name("tp0");
-            spec->set_uri("vineyard://" + host + "/" + medium + "/" + std::to_string(key));
+            spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
         }
     }
 
@@ -285,6 +362,12 @@ public:
             return "";
         }
         return views.front().location_specs().front().uri();
+    }
+
+    uint64_t GetStorageUsageByType(DataStorageType type) {
+        auto meta_indexer = cache_manager_->meta_indexer_manager()->GetMetaIndexer("test_instance");
+        EXPECT_NE(nullptr, meta_indexer);
+        return meta_indexer ? meta_indexer->GetStorageUsageByType(type) : 0;
     }
 
     std::unique_ptr<CacheManager> cache_manager_;
@@ -3177,6 +3260,241 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {
     EXPECT_FALSE(HasLocation(400, mem_loc));
     EXPECT_TRUE(HasLocation(300, ssd_loc));
     EXPECT_TRUE(HasLocation(500, ssd_loc));
+}
+
+TEST_F(CacheManagerTest, TestReportEventPreservesDeleteThenAddOrder) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    ReportBlockSnapshot(host, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddBlockDeleteEvent(&req, "mem", 300);
+    AddBlockAddEvent(&req, host, "mem", 300, 0, {}, "-recreated");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 0, "-recreated"), GetFirstSpecUri(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventSnapshotIsOrderingBarrier) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"mem"});
+        AddBlockSnapshotEvent(&req, host, "mem", {});
+        AddBlockAddEvent(&req, host, "mem", 300);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+        EXPECT_TRUE(HasLocation(300, location_id));
+    }
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockAddEvent(&req, host, "mem", 400);
+        AddBlockSnapshotEvent(&req, host, "mem", {});
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+        EXPECT_FALSE(HasLocation(300, location_id));
+        EXPECT_FALSE(HasLocation(400, location_id));
+    }
+}
+
+TEST_F(CacheManagerTest, TestReportEventLocationScopeSeparatesVllmGroups) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const LocationScopeLabels group0 = {{"group_idx", "0"}, {"dp_rank", "0"}};
+    const LocationScopeLabels group1 = {{"group_idx", "1"}, {"dp_rank", "0"}};
+    const std::string group0_loc = ExpectedReportEventLocationId(host, "gpu", group0);
+    const std::string group1_loc = ExpectedReportEventLocationId(host, "gpu", group1);
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"gpu"});
+        AddBlockSnapshotEvent(&req, host, "gpu", {300, 400}, group0);
+        AddBlockSnapshotEvent(&req, host, "gpu", {300}, group1);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    ASSERT_TRUE(HasLocation(300, group0_loc));
+    ASSERT_TRUE(HasLocation(400, group0_loc));
+    ASSERT_TRUE(HasLocation(300, group1_loc));
+
+    ReportBlockSnapshot(host, "gpu", {400}, false, {});
+    EXPECT_TRUE(HasLocation(300, group0_loc));
+    EXPECT_TRUE(HasLocation(400, group0_loc));
+    EXPECT_TRUE(HasLocation(300, group1_loc));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockSnapshotEvent(&req, host, "gpu", {400}, group0);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_FALSE(HasLocation(300, group0_loc));
+    EXPECT_TRUE(HasLocation(400, group0_loc));
+    EXPECT_TRUE(HasLocation(300, group1_loc));
+}
+
+TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+    const auto storage_type = DataStorageType::DATA_STORAGE_TYPE_VINEYARD;
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"mem"});
+        AddBlockAddEvent(&req, host, "mem", 300, 10, {}, "-old");
+        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(20, GetStorageUsageByType(storage_type));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 20, "-new"), GetFirstSpecUri(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(20, GetStorageUsageByType(storage_type));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockAddEvent(&req, host, "mem", 300, 35, {}, "-updated");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(35, GetStorageUsageByType(storage_type));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 35, "-updated"), GetFirstSpecUri(300, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 35, "-updated");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(35, GetStorageUsageByType(storage_type));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 50, "-snapshot");
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(50, GetStorageUsageByType(storage_type));
+    EXPECT_EQ(ReportEventUri(host, "mem", 300, 50, "-snapshot"), GetFirstSpecUri(300, location_id));
+
+    ReportBlockSnapshot(host, "mem", {});
+    EXPECT_EQ(0, GetStorageUsageByType(storage_type));
+    EXPECT_FALSE(HasLocation(300, location_id));
+}
+
+TEST_F(CacheManagerTest, TestReportEventDuplicateDeleteIsIdempotentForUsage) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+    const auto storage_type = DataStorageType::DATA_STORAGE_TYPE_VINEYARD;
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddNodeRegisterEvent(&req, {"mem"});
+        AddBlockAddEvent(&req, host, "mem", 300, 20);
+        AddBlockAddEvent(&req, host, "mem", 301, 20);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    ASSERT_EQ(40, GetStorageUsageByType(storage_type));
+    ASSERT_TRUE(HasLocation(300, location_id));
+    ASSERT_TRUE(HasLocation(301, location_id));
+
+    {
+        proto::meta::ReportEventRequest req;
+        req.set_instance_id("test_instance");
+        req.set_host_ip_port(host);
+        req.set_storage_type(proto::meta::ST_VINEYARD);
+        AddBlockDeleteEvent(&req, "mem", 300);
+        AddBlockDeleteEvent(&req, "mem", 300);
+
+        proto::meta::ReportEventResponse resp;
+        EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+        EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    }
+    EXPECT_EQ(20, GetStorageUsageByType(storage_type));
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_TRUE(HasLocation(301, location_id));
 }
 
 TEST_F(CacheManagerTest, TestReportEventBlockSnapshotRejectsInvalidSnapshot) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -211,29 +211,8 @@ public:
         }
     }
 
-    using LocationScopeLabels = std::vector<std::pair<std::string, std::string>>;
-
-    void SetLocationScope(proto::meta::LocationScope *scope,
-                          const std::string &medium,
-                          const LocationScopeLabels &labels) {
-        scope->set_medium(medium);
-        for (const auto &label : labels) {
-            (*scope->mutable_labels())[label.first] = label.second;
-        }
-    }
-
-    std::string ExpectedReportEventLocationId(const std::string &host,
-                                              const std::string &medium,
-                                              const LocationScopeLabels &labels = {}) {
-        std::string location_id = "kvs#v6d#" + medium;
-        std::map<std::string, std::string> sorted_labels;
-        for (const auto &label : labels) {
-            sorted_labels[label.first] = label.second;
-        }
-        for (const auto &label : sorted_labels) {
-            location_id += ";" + label.first + "=" + label.second;
-        }
-        return location_id + "#" + host;
+    std::string ExpectedReportEventLocationId(const std::string &host, const std::string &medium) {
+        return "kvs#v6d#" + medium + "#" + host;
     }
 
     std::string ReportEventUri(const std::string &host,
@@ -253,49 +232,48 @@ public:
                           const std::string &medium,
                           int64_t key,
                           uint64_t size = 0,
-                          const LocationScopeLabels &labels = {},
-                          const std::string &suffix = "") {
+                          const std::string &suffix = "",
+                          const std::string &spec_name = "tp0") {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_ADD);
         auto *add = ev->mutable_block_add();
         add->set_block_key(std::to_string(key));
-        SetLocationScope(add->mutable_location(), medium, labels);
+        add->set_medium(medium);
         auto *spec = add->add_specs();
-        spec->set_name("tp0");
+        spec->set_name(spec_name);
         spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
     }
 
     void AddBlockDeleteEvent(proto::meta::ReportEventRequest *req,
                              const std::string &medium,
                              int64_t key,
-                             const LocationScopeLabels &labels = {}) {
+                             const std::vector<std::string> &spec_names = {}) {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_DELETE);
         auto *del = ev->mutable_block_delete();
         del->set_block_key(std::to_string(key));
-        SetLocationScope(del->mutable_location(), medium, labels);
+        del->set_medium(medium);
+        for (const auto &spec_name : spec_names) {
+            del->add_spec_names(spec_name);
+        }
     }
 
     void AddBlockSnapshotEvent(proto::meta::ReportEventRequest *req,
                                const std::string &host,
                                const std::string &medium,
                                const std::vector<int64_t> &keys,
-                               const LocationScopeLabels &labels = {},
                                uint64_t size = 0,
-                               const std::string &suffix = "") {
+                               const std::string &suffix = "",
+                               const std::string &spec_name = "tp0") {
         auto *ev = req->add_events();
         ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
         auto *snapshot = ev->mutable_block_snapshot();
-        if (labels.empty()) {
-            snapshot->set_medium(medium);
-        } else {
-            SetLocationScope(snapshot->mutable_location(), medium, labels);
-        }
+        snapshot->set_medium(medium);
         for (auto key : keys) {
             auto *block = snapshot->add_blocks();
             block->set_block_key(std::to_string(key));
             auto *spec = block->add_specs();
-            spec->set_name("tp0");
+            spec->set_name(spec_name);
             spec->set_uri(ReportEventUri(host, medium, key, size, suffix));
         }
     }
@@ -3277,7 +3255,7 @@ TEST_F(CacheManagerTest, TestReportEventPreservesDeleteThenAddOrder) {
     req.set_host_ip_port(host);
     req.set_storage_type(proto::meta::ST_VINEYARD);
     AddBlockDeleteEvent(&req, "mem", 300);
-    AddBlockAddEvent(&req, host, "mem", 300, 0, {}, "-recreated");
+    AddBlockAddEvent(&req, host, "mem", 300, 0, "-recreated");
 
     proto::meta::ReportEventResponse resp;
     EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3324,15 +3302,48 @@ TEST_F(CacheManagerTest, TestReportEventSnapshotIsOrderingBarrier) {
     }
 }
 
-TEST_F(CacheManagerTest, TestReportEventLocationScopeSeparatesVllmGroups) {
+TEST_F(CacheManagerTest, TestReportEventLocationSpecNameKeepsFullAttentionSpecs) {
     RegisterDefaultInstanceForReportEvent();
     SetupVineyardEventReportingBackend();
 
     const std::string host = "192.168.2.1:8080";
-    const LocationScopeLabels group0 = {{"group_idx", "0"}, {"dp_rank", "0"}};
-    const LocationScopeLabels group1 = {{"group_idx", "1"}, {"dp_rank", "0"}};
-    const std::string group0_loc = ExpectedReportEventLocationId(host, "gpu", group0);
-    const std::string group1_loc = ExpectedReportEventLocationId(host, "gpu", group1);
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
+
+    proto::meta::ReportEventRequest req;
+    req.set_instance_id("test_instance");
+    req.set_host_ip_port(host);
+    req.set_storage_type(proto::meta::ST_VINEYARD);
+    AddNodeRegisterEvent(&req, {"gpu"});
+    auto *mixed_ev = req.add_events();
+    mixed_ev->set_event_type(proto::meta::EVENT_BLOCK_SNAPSHOT);
+    auto *mixed_snapshot = mixed_ev->mutable_block_snapshot();
+    mixed_snapshot->set_medium("gpu");
+    auto *mixed_block = mixed_snapshot->add_blocks();
+    mixed_block->set_block_key("300");
+    auto *full_spec = mixed_block->add_specs();
+    full_spec->set_name("full_attention:group=0:tp=0");
+    full_spec->set_uri(ReportEventUri(host, "gpu", 300));
+    auto *mamba_spec = mixed_block->add_specs();
+    mamba_spec->set_name("mamba_state:group=1");
+    mamba_spec->set_uri(ReportEventUri(host, "gpu", 300, 0, "-mamba"));
+    AddBlockSnapshotEvent(&req, host, "gpu", {400}, 0, "", "mamba_state:group=1");
+
+    proto::meta::ReportEventResponse resp;
+    EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
+    EXPECT_EQ(proto::meta::OK, resp.header().status().code());
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(400, location_id));
+    const auto &specs = GetLocationMapForKey(300).at(location_id)->location_specs();
+    ASSERT_EQ(1, specs.size());
+    EXPECT_EQ("full_attention:group=0:tp=0", specs[0].name());
+}
+
+TEST_F(CacheManagerTest, TestReportEventSkipsMambaStateSpecNames) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "gpu");
 
     {
         proto::meta::ReportEventRequest req;
@@ -3340,36 +3351,30 @@ TEST_F(CacheManagerTest, TestReportEventLocationScopeSeparatesVllmGroups) {
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
         AddNodeRegisterEvent(&req, {"gpu"});
-        AddBlockSnapshotEvent(&req, host, "gpu", {300, 400}, group0);
-        AddBlockSnapshotEvent(&req, host, "gpu", {300}, group1);
+        AddBlockAddEvent(&req, host, "gpu", 300, 0, "", "full_attention:group=0:tp=0");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
         EXPECT_EQ(proto::meta::OK, resp.header().status().code());
     }
-    ASSERT_TRUE(HasLocation(300, group0_loc));
-    ASSERT_TRUE(HasLocation(400, group0_loc));
-    ASSERT_TRUE(HasLocation(300, group1_loc));
-
-    ReportBlockSnapshot(host, "gpu", {400}, false, {});
-    EXPECT_TRUE(HasLocation(300, group0_loc));
-    EXPECT_TRUE(HasLocation(400, group0_loc));
-    EXPECT_TRUE(HasLocation(300, group1_loc));
+    ASSERT_TRUE(HasLocation(300, location_id));
 
     {
         proto::meta::ReportEventRequest req;
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockSnapshotEvent(&req, host, "gpu", {400}, group0);
+        AddBlockSnapshotEvent(&req, host, "gpu", {400}, 0, "", "mamba_state:group=1");
+        AddBlockAddEvent(&req, host, "gpu", 401, 0, "", "mamba_state:group=1");
+        AddBlockDeleteEvent(&req, "gpu", 300, {"mamba_state:group=1"});
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
         EXPECT_EQ(proto::meta::OK, resp.header().status().code());
     }
-    EXPECT_FALSE(HasLocation(300, group0_loc));
-    EXPECT_TRUE(HasLocation(400, group0_loc));
-    EXPECT_TRUE(HasLocation(300, group1_loc));
+    EXPECT_TRUE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(400, location_id));
+    EXPECT_FALSE(HasLocation(401, location_id));
 }
 
 TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
@@ -3386,8 +3391,8 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
         AddNodeRegisterEvent(&req, {"mem"});
-        AddBlockAddEvent(&req, host, "mem", 300, 10, {}, "-old");
-        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+        AddBlockAddEvent(&req, host, "mem", 300, 10, "-old");
+        AddBlockAddEvent(&req, host, "mem", 300, 20, "-new");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3401,7 +3406,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockAddEvent(&req, host, "mem", 300, 20, {}, "-new");
+        AddBlockAddEvent(&req, host, "mem", 300, 20, "-new");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3414,7 +3419,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockAddEvent(&req, host, "mem", 300, 35, {}, "-updated");
+        AddBlockAddEvent(&req, host, "mem", 300, 35, "-updated");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3428,7 +3433,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 35, "-updated");
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, 35, "-updated");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));
@@ -3441,7 +3446,7 @@ TEST_F(CacheManagerTest, TestReportEventUpsertUsageIsIdempotentAndDeltaBased) {
         req.set_instance_id("test_instance");
         req.set_host_ip_port(host);
         req.set_storage_type(proto::meta::ST_VINEYARD);
-        AddBlockSnapshotEvent(&req, host, "mem", {300}, {}, 50, "-snapshot");
+        AddBlockSnapshotEvent(&req, host, "mem", {300}, 50, "-snapshot");
 
         proto::meta::ReportEventResponse resp;
         EXPECT_EQ(EC_OK, cache_manager_->ReportEvent(request_context_.get(), &req, &resp));

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <map>
@@ -313,6 +314,17 @@ public:
     bool HasLocation(int64_t key, const std::string &location_id) {
         auto location_map = GetLocationMapForKey(key);
         return location_map.find(location_id) != location_map.end();
+    }
+
+    MetaSearcher::KeyVector GetLocationIndexKeys(const std::string &location_id) {
+        auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+        EXPECT_NE(nullptr, meta_searcher);
+        MetaSearcher::KeyVector keys;
+        if (!meta_searcher) {
+            return keys;
+        }
+        EXPECT_EQ(EC_OK, meta_searcher->GetKeysByLocationIndex(request_context_.get(), location_id, keys));
+        return keys;
     }
 
     std::string GetFirstSpecUri(int64_t key, const std::string &location_id) {
@@ -3216,6 +3228,47 @@ TEST_F(CacheManagerTest, TestReportEventBlockSnapshotEmptySnapshotDeletesOnlyTar
     EXPECT_FALSE(HasLocation(300, loc_a));
     EXPECT_FALSE(HasLocation(400, loc_a));
     EXPECT_TRUE(HasLocation(300, loc_b));
+}
+
+TEST_F(CacheManagerTest, TestReportEventBlockSnapshotFiltersStaleLocationIndex) {
+    RegisterDefaultInstanceForReportEvent();
+    SetupVineyardEventReportingBackend();
+
+    const std::string host = "192.168.2.1:8080";
+    const std::string location_id = ExpectedReportEventLocationId(host, "mem");
+
+    ReportBlockSnapshot(host, "mem", {300}, true);
+    ASSERT_TRUE(HasLocation(300, location_id));
+
+    auto meta_indexer = cache_manager_->meta_indexer_manager()->GetMetaIndexer("test_instance");
+    ASSERT_NE(nullptr, meta_indexer);
+    ASSERT_EQ(EC_OK, meta_indexer->AddKeysToLocationIndex(request_context_.get(), location_id, {777}));
+    EXPECT_FALSE(HasLocation(777, location_id));
+
+    auto *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> mismatched_locations = {
+        {{location_id,
+          DataStorageType::DATA_STORAGE_TYPE_NFS,
+          CLS_SERVING,
+          {LocationSpec("tp0", "file:///tmp/not-vineyard")}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(EC_OK,
+              meta_searcher->BatchUpsertLocations(request_context_.get(), {778}, mismatched_locations, per_key_ec));
+    ASSERT_EQ(1, per_key_ec.size());
+    ASSERT_EQ(EC_OK, per_key_ec[0]);
+    ASSERT_TRUE(HasLocation(778, location_id));
+
+    ReportBlockSnapshot(host, "mem", {});
+    EXPECT_FALSE(HasLocation(300, location_id));
+    EXPECT_FALSE(HasLocation(777, location_id));
+    EXPECT_TRUE(HasLocation(778, location_id));
+
+    auto indexed_keys = GetLocationIndexKeys(location_id);
+    EXPECT_EQ(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 300));
+    EXPECT_NE(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 777));
+    EXPECT_NE(indexed_keys.end(), std::find(indexed_keys.begin(), indexed_keys.end(), 778));
 }
 
 TEST_F(CacheManagerTest, TestReportEventBlockSnapshotDoesNotTouchOtherMedium) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -121,6 +121,69 @@ TEST_F(MetaSearcherTest, TestBatchAddLocation) {
     }
 }
 
+TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    const std::string loc_b = "kvs#v6d#mem#host_b:8080";
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts = {
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/11")}},
+            {loc_b, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://b/11")}},
+        },
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/12")}},
+        },
+        {
+            {loc_b, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://b/13")}},
+        },
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchUpsertLocations(request_context_.get(), {11, 12, 13}, upserts, per_key_ec));
+    ASSERT_EQ(3, per_key_ec.size());
+    EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[0]);
+    EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[1]);
+    EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[2]);
+
+    MetaSearcher::KeyVector indexed_keys;
+    EXPECT_EQ(ErrorCode::EC_BADARGS, meta_searcher_->GetKeysByLocationIndex("", indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{11, 12}), indexed_keys);
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
+
+    LocationIdsPerKey delete_loc_a = {{loc_a}, {loc_a}, {loc_a}};
+    std::vector<std::vector<ErrorCode>> delete_ecs;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(), {11, 12, 13}, delete_loc_a, delete_ecs));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    EXPECT_TRUE(indexed_keys.empty());
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
+
+    std::vector<std::vector<MetaSearcher::LocationCADTask>> cad_tasks = {{{loc_b, CLS_SERVING}}};
+    std::vector<std::vector<ErrorCode>> cad_ecs;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchCADLocationStatus(request_context_.get(), {11}, cad_tasks, cad_ecs));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{13}), indexed_keys);
+
+    std::vector<ErrorCode> delete_results;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchDeleteLocation(request_context_.get(), {13}, {loc_b}, delete_results));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    EXPECT_TRUE(indexed_keys.empty());
+
+    auto generated_loc = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, {LocationSpec("nfs", "file:///tmp/generated?size=1")});
+    std::vector<std::string> generated_ids;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchAddLocation(request_context_.get(), {14}, {generated_loc}, generated_ids));
+    ASSERT_EQ(1, generated_ids.size());
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(generated_ids[0], indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{14}), indexed_keys);
+}
+
 TEST_F(MetaSearcherTest, TestBatchAddLocation2) {
     // 准备测试数据
     MetaSearcher::KeyVector keys = {1, 2, 3};

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -185,7 +185,7 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
     EXPECT_EQ((MetaSearcher::KeyVector{14}), indexed_keys);
 }
 
-TEST_F(MetaSearcherTest, TestLocationKeyIndexRebuildsFromMetaIndexer) {
+TEST_F(MetaSearcherTest, TestLocationKeyIndexPersistsAcrossSearcherInstances) {
     const std::string loc_a = "kvs#v6d#mem#host_a:8080";
     const std::string loc_b = "kvs#v6d#mem#host_b:8080";
 

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -146,32 +146,32 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
     EXPECT_EQ(ErrorCode::EC_OK, per_key_ec[2]);
 
     MetaSearcher::KeyVector indexed_keys;
-    EXPECT_EQ(ErrorCode::EC_BADARGS, meta_searcher_->GetKeysByLocationIndex("", indexed_keys));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    EXPECT_EQ(ErrorCode::EC_BADARGS, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), "", indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{11, 12}), indexed_keys);
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
 
     LocationIdsPerKey delete_loc_a = {{loc_a}, {loc_a}, {loc_a}};
     std::vector<std::vector<ErrorCode>> delete_ecs;
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchDeleteLocations(request_context_.get(), {11, 12, 13}, delete_loc_a, delete_ecs));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_a, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
     EXPECT_TRUE(indexed_keys.empty());
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{11, 13}), indexed_keys);
 
     std::vector<std::vector<MetaSearcher::LocationCADTask>> cad_tasks = {{{loc_b, CLS_SERVING}}};
     std::vector<std::vector<ErrorCode>> cad_ecs;
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchCADLocationStatus(request_context_.get(), {11}, cad_tasks, cad_ecs));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{13}), indexed_keys);
 
     std::vector<ErrorCode> delete_results;
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchDeleteLocation(request_context_.get(), {13}, {loc_b}, delete_results));
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(loc_b, indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_b, indexed_keys));
     EXPECT_TRUE(indexed_keys.empty());
 
     auto generated_loc = MetaSearcherTestHelper::CreateCacheLocation(
@@ -180,8 +180,43 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexMaintainedByLocationMutations) {
     ASSERT_EQ(ErrorCode::EC_OK,
               meta_searcher_->BatchAddLocation(request_context_.get(), {14}, {generated_loc}, generated_ids));
     ASSERT_EQ(1, generated_ids.size());
-    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(generated_ids[0], indexed_keys));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->GetKeysByLocationIndex(request_context_.get(), generated_ids[0], indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{14}), indexed_keys);
+}
+
+TEST_F(MetaSearcherTest, TestLocationKeyIndexRebuildsFromMetaIndexer) {
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    const std::string loc_b = "kvs#v6d#mem#host_b:8080";
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts = {
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/21")}},
+            {loc_b, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://b/21")}},
+        },
+        {
+            {loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/22")}},
+        },
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchUpsertLocations(request_context_.get(), {21, 22}, upserts, per_key_ec));
+
+    auto rebuilt_searcher =
+        std::make_shared<MetaSearcher>(meta_indexer_, dummy_check_loc_data_exist, dummy_submit_del_req);
+    MetaSearcher::KeyVector indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              rebuilt_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{21, 22}), indexed_keys);
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> new_upserts = {
+        {{loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/23")}}},
+    };
+    ASSERT_EQ(ErrorCode::EC_OK,
+              rebuilt_searcher->BatchUpsertLocations(request_context_.get(), {23}, new_upserts, per_key_ec));
+    ASSERT_EQ(ErrorCode::EC_OK,
+              rebuilt_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{21, 22, 23}), indexed_keys);
 }
 
 TEST_F(MetaSearcherTest, TestBatchAddLocation2) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -46,9 +46,10 @@ public:
 
     void TearDown() override {}
 
-    std::shared_ptr<MetaStorageBackendConfig> ConstructMetaStorageBackendConfig() {
+    std::shared_ptr<MetaStorageBackendConfig> ConstructMetaStorageBackendConfig(
+        const std::string &path_suffix = "meta_local_backend_file_1") {
         auto meta_storage_backend_config = std::make_shared<MetaStorageBackendConfig>();
-        std::string local_path = GetPrivateTestRuntimeDataPath() + "meta_local_backend_file_1";
+        std::string local_path = GetPrivateTestRuntimeDataPath() + path_suffix;
         meta_storage_backend_config->SetStorageUri("file://" + local_path);
         std::error_code ec;
         bool exists = std::filesystem::exists(local_path, ec);
@@ -59,12 +60,14 @@ public:
         return meta_storage_backend_config;
     }
 
-    std::shared_ptr<MetaIndexer> CreateMetaIndexer() {
+    std::shared_ptr<MetaIndexer> CreateMetaIndexer(size_t max_key_count = 10000,
+                                                   int32_t mutex_shard_num = 32,
+                                                   const std::string &path_suffix = "meta_local_backend_file_1") {
         auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();
-        auto backend_config = ConstructMetaStorageBackendConfig();
+        auto backend_config = ConstructMetaStorageBackendConfig(path_suffix);
         meta_indexer_config->SetMetaStorageBackendConfig(backend_config);
-        meta_indexer_config->SetMutexShardNum(32);
-        meta_indexer_config->SetMaxKeyCount(10000);
+        meta_indexer_config->SetMutexShardNum(mutex_shard_num);
+        meta_indexer_config->SetMaxKeyCount(max_key_count);
         auto indexer = std::make_shared<MetaIndexer>();
         auto metaCachePolicyConfig = std::make_shared<MetaCachePolicyConfig>();
         metaCachePolicyConfig->SetCapacity(0);
@@ -217,6 +220,57 @@ TEST_F(MetaSearcherTest, TestLocationKeyIndexPersistsAcrossSearcherInstances) {
     ASSERT_EQ(ErrorCode::EC_OK,
               rebuilt_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
     EXPECT_EQ((MetaSearcher::KeyVector{21, 22, 23}), indexed_keys);
+}
+
+TEST_F(MetaSearcherTest, TestDeleteNoentKeepsLocationIndex) {
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    ASSERT_EQ(ErrorCode::EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), loc_a, {901}));
+
+    LocationIdsPerKey delete_loc_a = {{loc_a}};
+    std::vector<std::vector<ErrorCode>> delete_ecs;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchDeleteLocations(request_context_.get(), {901}, delete_loc_a, delete_ecs));
+    ASSERT_EQ(1, delete_ecs.size());
+    ASSERT_EQ(1, delete_ecs[0].size());
+    EXPECT_EQ(ErrorCode::EC_NOENT, delete_ecs[0][0]);
+
+    MetaSearcher::KeyVector indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK, meta_searcher_->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{901}), indexed_keys);
+}
+
+TEST_F(MetaSearcherTest, TestBatchUpsertLeavesOverIndexWhenMetaWriteFails) {
+    auto limited_indexer = CreateMetaIndexer(/*max_key_count=*/1,
+                                             /*mutex_shard_num=*/1,
+                                             "meta_local_backend_limited_capacity");
+    ASSERT_NE(nullptr, limited_indexer);
+    auto limited_searcher =
+        std::make_shared<MetaSearcher>(limited_indexer, dummy_check_loc_data_exist, dummy_submit_del_req);
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+
+    std::vector<std::vector<MetaSearcher::UpsertLocation>> upserts = {
+        {{loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/31")}}},
+        {{loc_a, DataStorageType::DATA_STORAGE_TYPE_VINEYARD, CLS_SERVING, {LocationSpec("tp0", "v6d://a/32")}}},
+    };
+    std::vector<ErrorCode> per_key_ec;
+    EXPECT_EQ(ErrorCode::EC_ERROR,
+              limited_searcher->BatchUpsertLocations(request_context_.get(), {31, 32}, upserts, per_key_ec));
+    ASSERT_EQ(2, per_key_ec.size());
+    EXPECT_EQ(ErrorCode::EC_NOSPC, per_key_ec[0]);
+    EXPECT_EQ(ErrorCode::EC_NOSPC, per_key_ec[1]);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask mask = static_cast<size_t>(0);
+    ASSERT_EQ(ErrorCode::EC_OK,
+              limited_searcher->BatchGetLocation(request_context_.get(), {31, 32}, mask, location_maps));
+    ASSERT_EQ(2, location_maps.size());
+    EXPECT_TRUE(location_maps[0].empty());
+    EXPECT_TRUE(location_maps[1].empty());
+
+    MetaSearcher::KeyVector indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              limited_searcher->GetKeysByLocationIndex(request_context_.get(), loc_a, indexed_keys));
+    EXPECT_EQ((MetaSearcher::KeyVector{31, 32}), indexed_keys);
 }
 
 TEST_F(MetaSearcherTest, TestBatchAddLocation2) {

--- a/kv_cache_manager/meta/meta_async_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_async_redis_backend.cc
@@ -9,6 +9,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/cache_location.h"
@@ -39,6 +40,7 @@ ErrorCode MetaAsyncRedisBackend::Init(const std::string &instance_id,
     instance_id_ = instance_id;
     cache_key_prefix_ = "kvcache:instance_" + instance_id_ + ":cache_";
     metadata_key_ = "kvcache:instance_" + instance_id_ + ":metadata";
+    location_index_key_prefix_ = "kvcache:instance_" + instance_id_ + ":locidx_";
 
     if (!config) {
         KVCM_LOG_ERROR("fail to init meta async redis backend, invalid nullptr config");
@@ -626,6 +628,94 @@ ErrorCode MetaAsyncRedisBackend::GetMetaData(FieldMap &out_field_map) noexcept {
         out_field_map = std::move(maps[0]);
     }
     return error_codes[0];
+}
+
+ErrorCode MetaAsyncRedisBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = read_client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "async redis add location index fail, fail to acquire client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SAdd({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaAsyncRedisBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                             const std::string &location_id,
+                                                             const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = read_client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "async redis remove location index fail, fail to acquire client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SRem({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaAsyncRedisBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    auto handle = read_client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "async redis get location index fail, fail to acquire client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    auto ec = handle->SMembers(location_index_key_prefix_ + location_id, members);
+    if (ec != EC_OK) {
+        return ec;
+    }
+    out_keys.reserve(members.size());
+    for (const auto &member : members) {
+        KeyType key = 0;
+        if (!StringUtil::StrToInt64(member.c_str(), key)) {
+            KVCM_LOG_WARN("async redis location index has invalid key member[%s], instance[%s], location_id[%s]",
+                          member.c_str(),
+                          instance_id_.c_str(),
+                          location_id.c_str());
+            out_keys.clear();
+            return EC_CORRUPTION;
+        }
+        out_keys.emplace_back(key);
+    }
+    return EC_OK;
 }
 
 // ==================== Sync ====================

--- a/kv_cache_manager/meta/meta_async_redis_backend.h
+++ b/kv_cache_manager/meta/meta_async_redis_backend.h
@@ -77,6 +77,15 @@ public:
     // ----- MetaData (sync passthrough) -----
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
     // ----- Sync -----
     bool Sync(const KeyTypeVec &keys) noexcept override;
@@ -104,6 +113,7 @@ private:
     std::string instance_id_;
     std::string cache_key_prefix_;
     std::string metadata_key_;
+    std::string location_index_key_prefix_;
     int64_t timeout_ms_ = 2000;
 
     // Async config

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/meta/meta_dummy_backend.h"
 
 #include <cinttypes>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -54,6 +55,7 @@ ErrorCode MetaDummyBackend::Open() noexcept {
 
     table_.Clear();
     metadata_.clear();
+    location_key_index_.clear();
     if (!enable_persistence_) {
         return ErrorCode::EC_OK;
     }
@@ -109,6 +111,9 @@ ErrorCode MetaDummyBackend::Open() noexcept {
                 auto loc = std::make_shared<CacheLocation>();
                 if (loc->FromJsonString(field_value)) {
                     item.locations[loc_id] = std::move(loc);
+                    if (!loc_id.empty()) {
+                        location_key_index_[loc_id].insert(key);
+                    }
                 }
             } else {
                 item.properties[field_name] = std::move(field_value);
@@ -473,6 +478,66 @@ ErrorCode MetaDummyBackend::GetMetaData(FieldMap &out_field_map) noexcept {
     }
     out_field_map = metadata_;
     return ErrorCode::EC_OK;
+}
+
+ErrorCode MetaDummyBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto &indexed_keys = location_key_index_[location_id];
+    for (const auto &key : keys) {
+        indexed_keys.insert(key);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaDummyBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    for (const auto &key : keys) {
+        iter->second.erase(key);
+    }
+    if (iter->second.empty()) {
+        location_key_index_.erase(iter);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaDummyBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    out_keys.reserve(iter->second.size());
+    for (const auto &key : iter->second) {
+        out_keys.push_back(key);
+    }
+    std::sort(out_keys.begin(), out_keys.end());
+    return EC_OK;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/concurrent_hash_map.h"
@@ -104,6 +106,15 @@ public:
 
     ErrorCode PutMetaData(const FieldMap &field_map) noexcept override;
     ErrorCode GetMetaData(FieldMap &out_field_map) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
 private:
     ErrorCode PersistToPath();
@@ -111,6 +122,7 @@ private:
     std::mutex mutex_;
     ConcurrentHashMap<KeyType, DummyItem> table_;
     FieldMap metadata_;
+    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
     std::string path_;
     bool enable_persistence_ = false;
 };

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -790,6 +790,45 @@ ErrorCode MetaIndexer::SampleReclaimKeys(RequestContext *request_context,
     return ec;
 }
 
+ErrorCode MetaIndexer::AddKeysToLocationIndex(RequestContext *request_context,
+                                              const std::string &location_id,
+                                              const KeyVector &keys) noexcept {
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    return backend_manager_->AddKeysToLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaIndexer::RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                                   const std::string &location_id,
+                                                   const KeyVector &keys) noexcept {
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    return backend_manager_->RemoveKeysFromLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaIndexer::GetKeysByLocationIndex(RequestContext *request_context,
+                                              const std::string &location_id,
+                                              KeyVector &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    auto ec = backend_manager_->GetKeysByLocationIndex(request_context, location_id, out_keys);
+    if (ec == EC_OK) {
+        std::sort(out_keys.begin(), out_keys.end());
+        out_keys.erase(std::unique(out_keys.begin(), out_keys.end()), out_keys.end());
+    }
+    return ec;
+}
+
 size_t MetaIndexer::GetKeyCount() const noexcept { return key_count_.load(); }
 
 size_t MetaIndexer::GetMaxKeyCount() const noexcept { return max_key_count_; }

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -101,6 +101,15 @@ public:
     ErrorCode RandomSample(RequestContext *request_context, const size_t count, KeyVector &out_keys) const noexcept;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyVector &out_keys) const noexcept;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyVector &keys) noexcept;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyVector &keys) noexcept;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyVector &out_keys) noexcept;
 
     void PersistMetaData() noexcept;
     size_t GetKeyCount() const noexcept;

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -106,6 +106,10 @@ ErrorCode MetaLocalBackend::Close() noexcept {
     }
     cache_.reset();
     cache_item_helper_.reset();
+    {
+        std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+        location_key_index_.clear();
+    }
     KVCM_LOG_INFO("local backend close ok");
     return EC_OK;
 }
@@ -665,6 +669,66 @@ ErrorCode MetaLocalBackend::SampleReclaimKeys(RequestContext * /*request_context
 ErrorCode MetaLocalBackend::PutMetaData(const FieldMap & /*field_maps*/) noexcept { return EC_OK; }
 
 ErrorCode MetaLocalBackend::GetMetaData(FieldMap & /*field_maps*/) noexcept { return EC_NOENT; }
+
+ErrorCode MetaLocalBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto &indexed_keys = location_key_index_[location_id];
+    for (const auto &key : keys) {
+        indexed_keys.insert(key);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaLocalBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    for (const auto &key : keys) {
+        iter->second.erase(key);
+    }
+    if (iter->second.empty()) {
+        location_key_index_.erase(iter);
+    }
+    return EC_OK;
+}
+
+ErrorCode MetaLocalBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    std::lock_guard<std::mutex> lock(location_key_index_mutex_);
+    auto iter = location_key_index_.find(location_id);
+    if (iter == location_key_index_.end()) {
+        return EC_OK;
+    }
+    out_keys.reserve(iter->second.size());
+    for (const auto &key : iter->second) {
+        out_keys.push_back(key);
+    }
+    std::sort(out_keys.begin(), out_keys.end());
+    return EC_OK;
+}
 
 size_t MetaLocalBackend::GetMemUsage() const noexcept { return cache_->GetUsage(); }
 

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -4,10 +4,13 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "kv_cache_manager/common/cache/advanced_cache.h"
@@ -167,6 +170,15 @@ public:
     // meta data
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
     size_t GetMemUsage() const noexcept override;
     int64_t GetOldestAccessTime() const noexcept override;
@@ -209,6 +221,8 @@ private:
     uint32_t shard_mask_ = 0;
     size_t sample_times_ = 0;
     std::shared_ptr<RevisitIntervalHistogram> revisit_histogram_;
+    mutable std::mutex location_key_index_mutex_;
+    std::unordered_map<std::string, std::unordered_set<KeyType>> location_key_index_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_redis_backend.cc
@@ -2,6 +2,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
@@ -27,6 +28,7 @@ ErrorCode MetaRedisBackend::Init(const std::string &instance_id,
     instance_id_ = instance_id;
     cache_key_prefix_ = "kvcache:instance_" + instance_id_ + ":cache_";
     metadata_key_ = "kvcache:instance_" + instance_id_ + ":metadata";
+    location_index_key_prefix_ = "kvcache:instance_" + instance_id_ + ":locidx_";
 
     if (!config) {
         KVCM_LOG_ERROR("fail to init meta redis backend, invalid nullptr config");
@@ -479,6 +481,94 @@ ErrorCode MetaRedisBackend::GetMetaData(FieldMap &out_field_map) noexcept {
         out_field_map = std::move(maps[0]);
     }
     return error_codes[0];
+}
+
+ErrorCode MetaRedisBackend::AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "add location index fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SAdd({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaRedisBackend::RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                        const std::string &location_id,
+                                                        const KeyTypeVec &keys) noexcept {
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    if (keys.empty()) {
+        return EC_OK;
+    }
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "remove location index fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    members.reserve(keys.size());
+    for (const auto &key : keys) {
+        members.emplace_back(std::to_string(key));
+    }
+    auto error_codes = handle->SRem({location_index_key_prefix_ + location_id}, {members});
+    if (error_codes.empty()) {
+        return EC_ERROR;
+    }
+    return error_codes[0];
+}
+
+ErrorCode MetaRedisBackend::GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                                   const std::string &location_id,
+                                                   KeyTypeVec &out_keys) noexcept {
+    out_keys.clear();
+    if (location_id.empty()) {
+        return EC_BADARGS;
+    }
+    auto handle = client_pool_->AcquireClient(timeout_ms_);
+    if (!handle) {
+        KVCM_INTERVAL_LOG_WARN(
+            10, "get location index fail, fail to acquire redis client, instance[%s]", instance_id_.c_str());
+        return EC_TIMEOUT;
+    }
+    std::vector<std::string> members;
+    auto ec = handle->SMembers(location_index_key_prefix_ + location_id, members);
+    if (ec != EC_OK) {
+        return ec;
+    }
+    out_keys.reserve(members.size());
+    for (const auto &member : members) {
+        KeyType key = 0;
+        if (!StringUtil::StrToInt64(member.c_str(), key)) {
+            KVCM_LOG_WARN("location index has invalid key member[%s], instance[%s], location_id[%s]",
+                          member.c_str(),
+                          instance_id_.c_str(),
+                          location_id.c_str());
+            out_keys.clear();
+            return EC_CORRUPTION;
+        }
+        out_keys.emplace_back(key);
+    }
+    return EC_OK;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_redis_backend.h
+++ b/kv_cache_manager/meta/meta_redis_backend.h
@@ -81,6 +81,15 @@ public:
     // ----- Metadata APIs -----
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept override;
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyTypeVec &keys) noexcept override;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyTypeVec &keys) noexcept override;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyTypeVec &out_keys) noexcept override;
 
 private:
     // virtual for test
@@ -92,6 +101,7 @@ private:
     std::string instance_id_;
     std::string cache_key_prefix_;
     std::string metadata_key_;
+    std::string location_index_key_prefix_;
     int64_t timeout_ms_ = 1000;
 };
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -244,6 +244,34 @@ public:
     // @return EC_OK 成功；EC_NOENT 无元数据；EC_ERROR 读取失败
     virtual ErrorCode GetMetaData(FieldMap &field_maps) noexcept = 0;
 
+    // =====================================================================
+    // Location Index APIs — derived secondary index for snapshot diff
+    // =====================================================================
+
+    // Add keys to the persistent secondary index:
+    //   location_id -> set(block_key)
+    // This index is not the source of truth. CacheMeta remains authoritative.
+    virtual ErrorCode AddKeysToLocationIndex(RequestContext * /*request_context*/,
+                                             const std::string & /*location_id*/,
+                                             const KeyTypeVec & /*keys*/) noexcept {
+        return EC_UNIMPLEMENTED;
+    }
+
+    // Remove keys from the persistent secondary index. Idempotent.
+    virtual ErrorCode RemoveKeysFromLocationIndex(RequestContext * /*request_context*/,
+                                                  const std::string & /*location_id*/,
+                                                  const KeyTypeVec & /*keys*/) noexcept {
+        return EC_UNIMPLEMENTED;
+    }
+
+    // Read candidate block keys from the persistent secondary index.
+    // Callers must verify every candidate against CacheMeta before using it.
+    virtual ErrorCode GetKeysByLocationIndex(RequestContext * /*request_context*/,
+                                             const std::string & /*location_id*/,
+                                             KeyTypeVec & /*out_keys*/) noexcept {
+        return EC_UNIMPLEMENTED;
+    }
+
     // Synchronously flush pending writes for the given keys.
     // Returns true if all writes persisted successfully, false on failure/timeout.
     // Default: no-op (sync backends have no pending writes).

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -728,6 +728,34 @@ ErrorCode MetaStorageBackendManager::GetMetaData(FieldMap &field_maps) noexcept 
     return persistent_backend_->GetMetaData(field_maps);
 }
 
+ErrorCode MetaStorageBackendManager::AddKeysToLocationIndex(RequestContext *request_context,
+                                                            const std::string &location_id,
+                                                            const KeyVector &keys) noexcept {
+    if (!persistent_backend_) {
+        return EC_ERROR;
+    }
+    return persistent_backend_->AddKeysToLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaStorageBackendManager::RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                                                 const std::string &location_id,
+                                                                 const KeyVector &keys) noexcept {
+    if (!persistent_backend_) {
+        return EC_ERROR;
+    }
+    return persistent_backend_->RemoveKeysFromLocationIndex(request_context, location_id, keys);
+}
+
+ErrorCode MetaStorageBackendManager::GetKeysByLocationIndex(RequestContext *request_context,
+                                                            const std::string &location_id,
+                                                            KeyVector &out_keys) noexcept {
+    out_keys.clear();
+    if (!persistent_backend_) {
+        return EC_ERROR;
+    }
+    return persistent_backend_->GetKeysByLocationIndex(request_context, location_id, out_keys);
+}
+
 bool MetaStorageBackendManager::Sync(const KeyVector &keys) noexcept {
     if (!persistent_backend_) {
         return true;

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -87,6 +87,16 @@ public:
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept;
 
+    ErrorCode AddKeysToLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     const KeyVector &keys) noexcept;
+    ErrorCode RemoveKeysFromLocationIndex(RequestContext *request_context,
+                                          const std::string &location_id,
+                                          const KeyVector &keys) noexcept;
+    ErrorCode GetKeysByLocationIndex(RequestContext *request_context,
+                                     const std::string &location_id,
+                                     KeyVector &out_keys) noexcept;
+
     // Synchronously flush pending writes for the given keys to persistent storage.
     // Returns true on success, false on failure/timeout.
     bool Sync(const KeyVector &keys) noexcept;

--- a/kv_cache_manager/meta/test/meta_async_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_async_redis_backend_test.cc
@@ -1,4 +1,6 @@
 #include <atomic>
+#include <map>
+#include <set>
 #include <thread>
 
 #include "kv_cache_manager/common/redis_client.h"
@@ -194,6 +196,76 @@ TEST_F(MetaAsyncRedisBackendTest, TestDeleteLocations) {
     auto results = backend_->DeleteLocations(nullptr, keys, location_ids);
     ASSERT_EQ(1, results.size());
     ASSERT_EQ(EC_OK, results[0]);
+}
+
+TEST_F(MetaAsyncRedisBackendTest, TestLocationIndexPassthrough) {
+    config_->SetStorageUri("redis://user:pass@host:6379/?async_queue_count=1&async_max_batch=64&async_wait_us=1000"
+                           "&async_max_size=1000&async_drain_ms=2000&client_min_pool_size=1&client_max_pool_size=1");
+    std::map<std::string, std::set<std::string>> redis_sets;
+    EXPECT_CALL(*backend_, CreateRedisClient()).WillRepeatedly(Invoke([this, &redis_sets]() {
+        StandardUri empty_uri;
+        auto mock = std::make_shared<::testing::NiceMock<MockRedisClient>>(empty_uri);
+        ON_CALL(*mock, IsContextOk()).WillByDefault(Return(true));
+        ON_CALL(*mock, Reconnect()).WillByDefault(Return(true));
+        ON_CALL(*mock, TryExecPipeline(_)).WillByDefault(Invoke([this, &redis_sets](const std::vector<CmdArgs> &cmds) {
+            std::vector<ReplyUPtr> replies;
+            replies.reserve(cmds.size());
+            for (const auto &cmd : cmds) {
+                if (cmd.size() >= 3 && cmd[0] == "SADD") {
+                    auto &members = redis_sets[cmd[1]];
+                    int64_t added = 0;
+                    for (size_t i = 2; i < cmd.size(); ++i) {
+                        added += members.insert(cmd[i]).second ? 1 : 0;
+                    }
+                    replies.emplace_back(MakeFakeReplyInteger(added));
+                } else if (cmd.size() >= 3 && cmd[0] == "SREM") {
+                    auto &members = redis_sets[cmd[1]];
+                    int64_t removed = 0;
+                    for (size_t i = 2; i < cmd.size(); ++i) {
+                        removed += members.erase(cmd[i]);
+                    }
+                    replies.emplace_back(MakeFakeReplyInteger(removed));
+                } else if (cmd.size() == 2 && cmd[0] == "SMEMBERS") {
+                    std::vector<std::optional<std::string>> members;
+                    for (const auto &member : redis_sets[cmd[1]]) {
+                        members.emplace_back(member);
+                    }
+                    replies.emplace_back(MakeFakeReplyArrayString(members));
+                } else {
+                    replies.emplace_back(MakeFakeReplyInteger(1));
+                }
+            }
+            return replies;
+        }));
+        return mock;
+    }));
+
+    ASSERT_EQ(EC_OK, backend_->Init("test_instance", config_));
+    ASSERT_EQ(EC_OK, backend_->Open());
+
+    KeyTypeVec out_keys = {999};
+    EXPECT_EQ(EC_BADARGS, backend_->AddKeysToLocationIndex(nullptr, "", {}));
+    EXPECT_EQ(EC_BADARGS, backend_->RemoveKeysFromLocationIndex(nullptr, "", {}));
+    EXPECT_EQ(EC_BADARGS, backend_->AddKeysToLocationIndex(nullptr, "", {1}));
+    EXPECT_EQ(EC_BADARGS, backend_->RemoveKeysFromLocationIndex(nullptr, "", {1}));
+    EXPECT_EQ(EC_BADARGS, backend_->GetKeysByLocationIndex(nullptr, "", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, backend_->AddKeysToLocationIndex(nullptr, "loc_a", {3, 1, 3}));
+    ASSERT_EQ(EC_OK, backend_->AddKeysToLocationIndex(nullptr, "loc_b", {2}));
+    ASSERT_EQ(EC_OK, backend_->GetKeysByLocationIndex(nullptr, "loc_a", out_keys));
+    EXPECT_EQ((KeyTypeVec{1, 3}), out_keys);
+    ASSERT_EQ(EC_OK, backend_->GetKeysByLocationIndex(nullptr, "loc_b", out_keys));
+    EXPECT_EQ((KeyTypeVec{2}), out_keys);
+
+    ASSERT_EQ(EC_OK, backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {1, 404}));
+    ASSERT_EQ(EC_OK, backend_->GetKeysByLocationIndex(nullptr, "loc_a", out_keys));
+    EXPECT_EQ((KeyTypeVec{3}), out_keys);
+
+    redis_sets["kvcache:instance_test_instance:locidx_loc_bad"].insert("not-int64");
+    out_keys = {999};
+    EXPECT_EQ(EC_CORRUPTION, backend_->GetKeysByLocationIndex(nullptr, "loc_bad", out_keys));
+    EXPECT_TRUE(out_keys.empty());
 }
 
 TEST_F(MetaAsyncRedisBackendTest, TestWriteEmptyKeys) {

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -103,6 +103,60 @@ TEST_F(MetaDummyBackendTest, TestSimple) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaDummyBackendTest, TestLocationIndexRebuildsFromPersistentCacheMeta) {
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_storage_backend_->Init("test_instance_location_index_rebuild", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    const std::string loc_a = "kvs#v6d#mem#host_a:8080";
+    const std::string loc_b = "kvs#v6d#mem#host_b:8080";
+
+    CacheLocationMapVector locations(2);
+    locations[0][loc_a] = std::make_shared<CacheLocation>(loc_a,
+                                                          CLS_SERVING,
+                                                          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+                                                          1,
+                                                          std::vector<LocationSpec>{
+                                                              LocationSpec("tp0", "v6d://host_a:8080/11")});
+    locations[0][loc_b] = std::make_shared<CacheLocation>(loc_b,
+                                                          CLS_SERVING,
+                                                          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+                                                          1,
+                                                          std::vector<LocationSpec>{
+                                                              LocationSpec("tp0", "v6d://host_b:8080/11")});
+    locations[1][loc_a] = std::make_shared<CacheLocation>(loc_a,
+                                                          CLS_SERVING,
+                                                          DataStorageType::DATA_STORAGE_TYPE_VINEYARD,
+                                                          1,
+                                                          std::vector<LocationSpec>{
+                                                              LocationSpec("tp0", "v6d://host_a:8080/12")});
+    PropertyMapVector properties(2);
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put(nullptr, {11, 12}, locations, properties));
+
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_storage_backend_->AddKeysToLocationIndex(nullptr, loc_a, {11, 12, 999}));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->AddKeysToLocationIndex(nullptr, loc_b, {11}));
+
+    MetaStorageBackend::KeyTypeVec indexed_keys;
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, loc_a, indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11, 12, 999}), indexed_keys);
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+
+    ConstructMetaStorageBackend();
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_storage_backend_->Init("test_instance_location_index_rebuild", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, loc_a, indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11, 12}), indexed_keys);
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, loc_b, indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11}), indexed_keys);
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaDummyBackendTest, TestInit) {
     // invalid config
     ASSERT_NE(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -201,6 +201,43 @@ TEST_F(MetaIndexerTest, TestMakeBatches2) {
     ASSERT_EQ(expected_indexs, covered_indexs);
 }
 
+TEST_F(MetaIndexerTest, TestLocationIndexWrapper) {
+    std::string configStr = R"({
+        "max_key_count" : 100,
+        "mutex_shard_num" : 8,
+        "batch_key_size" : 2,
+        "meta_storage_backend_config" : { "storage_type" : "local" },
+        "meta_cache_policy_config" : { "capacity" : 0 }
+    })";
+    ASSERT_EQ(EC_OK, InitIndexer(configStr));
+
+    KeyVector keys = {3, 1, 3, 2};
+    KeyVector out_keys = {999};
+
+    EXPECT_EQ(EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "", {}));
+    EXPECT_EQ(EC_OK, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "", {}));
+    EXPECT_EQ(EC_BADARGS, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "loc_a", keys));
+    ASSERT_EQ(EC_OK, meta_indexer_->AddKeysToLocationIndex(request_context_.get(), "loc_b", {5}));
+
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{1, 2, 3}), out_keys);
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_b", out_keys));
+    EXPECT_EQ((KeyVector{5}), out_keys);
+
+    EXPECT_EQ(EC_OK, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {2, 999}));
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{1, 3}), out_keys);
+
+    EXPECT_EQ(EC_OK, meta_indexer_->RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {1, 3}));
+    ASSERT_EQ(EC_OK, meta_indexer_->GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+}
+
 TEST_F(MetaIndexerTest, TestLocalSimple) {
     std::string configStr = R"({
         "max_key_count" : 100,

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -90,6 +90,34 @@ TEST_F(MetaLocalBackendTest, TestSimple) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaLocalBackendTest, TestLocationIndex) {
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_location_index", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    MetaStorageBackend::KeyTypeVec indexed_keys;
+    ASSERT_EQ(EC_BADARGS, meta_storage_backend_->AddKeysToLocationIndex(nullptr, "", {1}));
+    ASSERT_EQ(EC_BADARGS, meta_storage_backend_->RemoveKeysFromLocationIndex(nullptr, "", {1}));
+    ASSERT_EQ(EC_BADARGS, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "", indexed_keys));
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->AddKeysToLocationIndex(nullptr, "loc_a", {3, 1, 1}));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->AddKeysToLocationIndex(nullptr, "loc_b", {2}));
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_a", indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{1, 3}), indexed_keys);
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_b", indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{2}), indexed_keys);
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {1, 100}));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_a", indexed_keys));
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{3}), indexed_keys);
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {3}));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->GetKeysByLocationIndex(nullptr, "loc_a", indexed_keys));
+    ASSERT_TRUE(indexed_keys.empty());
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestInit) {
     // invalid config
     ASSERT_EQ(EC_BADARGS, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));

--- a/kv_cache_manager/meta/test/meta_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <thread>
 
 #include "kv_cache_manager/common/redis_client.h"
@@ -133,6 +134,56 @@ TEST_F(MetaRedisBackendTest, TestOpenAndClose) {
         ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
         ASSERT_EQ(EC_ERROR, meta_redis_backend_->Open());
     }
+}
+
+TEST_F(MetaRedisBackendTest, TestLocationIndex) {
+    EXPECT_CALL(*meta_redis_backend_, CreateRedisClient()).WillRepeatedly(Invoke([]() {
+        StandardUri empty_storage_uri;
+        auto mock_redis_client = std::make_unique<MockRedisClient>(empty_storage_uri);
+        EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> sadd_replies;
+        sadd_replies.emplace_back(MakeFakeReplyInteger(2));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SADD"),
+                                                            StrEq("kvcache:instance_instance_0:locidx_loc_a"),
+                                                            StrEq("11"),
+                                                            StrEq("12")))))
+            .WillOnce(Return(ByMove(std::move(sadd_replies))));
+
+        std::vector<ReplyUPtr> smembers_replies;
+        smembers_replies.emplace_back(MakeFakeReplyArrayString({"12", "11"}));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(
+                        ElementsAre(StrEq("SMEMBERS"), StrEq("kvcache:instance_instance_0:locidx_loc_a")))))
+            .WillOnce(Return(ByMove(std::move(smembers_replies))));
+
+        std::vector<ReplyUPtr> srem_replies;
+        srem_replies.emplace_back(MakeFakeReplyInteger(1));
+        EXPECT_CALL(*mock_redis_client,
+                    TryExecPipeline(ElementsAre(ElementsAre(StrEq("SREM"),
+                                                            StrEq("kvcache:instance_instance_0:locidx_loc_a"),
+                                                            StrEq("11")))))
+            .WillOnce(Return(ByMove(std::move(srem_replies))));
+        return mock_redis_client;
+    }));
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
+
+    ASSERT_EQ(EC_BADARGS,
+              meta_redis_backend_->AddKeysToLocationIndex(nullptr, "", MetaStorageBackend::KeyTypeVec{11}));
+    ASSERT_EQ(EC_OK,
+              meta_redis_backend_->AddKeysToLocationIndex(nullptr, "loc_a", MetaStorageBackend::KeyTypeVec{11, 12}));
+
+    MetaStorageBackend::KeyTypeVec keys;
+    ASSERT_EQ(EC_OK, meta_redis_backend_->GetKeysByLocationIndex(nullptr, "loc_a", keys));
+    std::sort(keys.begin(), keys.end());
+    ASSERT_EQ((MetaStorageBackend::KeyTypeVec{11, 12}), keys);
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->RemoveKeysFromLocationIndex(nullptr, "loc_a", {11}));
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
 
 TEST_F(MetaRedisBackendTest, TestSimple) {

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -146,6 +146,57 @@ TEST_F(MetaStorageBackendManagerTest, TestInitDualBackend) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
+TEST_F(MetaStorageBackendManagerTest, TestLocationIndexSingleBackendRoundTrip) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_locidx_single";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_locidx_single", MakeSingleConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+
+    KeyVector out_keys = {999};
+    EXPECT_EQ(EC_OK, mgr.AddKeysToLocationIndex(request_context_.get(), "loc_a", {3, 1, 1}));
+    EXPECT_EQ(EC_OK, mgr.AddKeysToLocationIndex(request_context_.get(), "loc_b", {2}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{1, 3}), out_keys);
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_b", out_keys));
+    EXPECT_EQ((KeyVector{2}), out_keys);
+
+    EXPECT_EQ(EC_OK, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {1, 404}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{3}), out_keys);
+
+    EXPECT_EQ(EC_OK, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {3}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestLocationIndexDualBackendRoundTrip) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_locidx_dual";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_locidx_dual", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    KeyVector out_keys = {999};
+    EXPECT_EQ(EC_BADARGS, mgr.AddKeysToLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "", {1}));
+    EXPECT_EQ(EC_BADARGS, mgr.GetKeysByLocationIndex(request_context_.get(), "", out_keys));
+    EXPECT_TRUE(out_keys.empty());
+
+    ASSERT_EQ(EC_OK, mgr.AddKeysToLocationIndex(request_context_.get(), "loc_a", {10, 20, 10}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{10, 20}), out_keys);
+
+    ASSERT_EQ(EC_OK, mgr.RemoveKeysFromLocationIndex(request_context_.get(), "loc_a", {10}));
+    ASSERT_EQ(EC_OK, mgr.GetKeysByLocationIndex(request_context_.get(), "loc_a", out_keys));
+    EXPECT_EQ((KeyVector{20}), out_keys);
+
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
 // --- Put/Get: CacheLocation serialization round-trip --------------------------
 
 TEST_F(MetaStorageBackendManagerTest, TestPutAndGetLocationsRoundTrip) {

--- a/kv_cache_manager/mrc/BUILD
+++ b/kv_cache_manager/mrc/BUILD
@@ -1,0 +1,130 @@
+package(default_visibility = ["//visibility:public"])
+
+# Observation-only online MRC (theoretical hit rate) components.
+# The algorithm layer below depends on nothing but std; keep it that way so
+# it stays reusable and trivially testable.
+cc_library(
+    name = "online_mrc_config",
+    hdrs = ["online_mrc_config.h"],
+)
+
+cc_library(
+    name = "mrc_profiler",
+    srcs = [
+        "lite_hit_core.cc",
+        "mrc_profiler.cc",
+    ],
+    hdrs = [
+        "lite_hit_core.h",
+        "mrc_profiler.h",
+    ],
+)
+
+cc_library(
+    name = "hit_curve_projector",
+    srcs = ["hit_curve_projector.cc"],
+    hdrs = ["hit_curve_projector.h"],
+)
+
+# Separate research/reference implementation. The production online path uses
+# the request-level exact LiteHit core above, not per-block sampling.
+cc_library(
+    name = "reuse_distance_tracker",
+    srcs = ["reuse_distance_tracker.cc"],
+    hdrs = ["reuse_distance_tracker.h"],
+)
+
+cc_library(
+    name = "mrc_event_consumer",
+    srcs = [
+        "mrc_event_consumer.cc",
+    ],
+    hdrs = [
+        "mrc_event_consumer.h",
+    ],
+    deps = [
+        ":mrc_profiler",
+        ":online_mrc_config",
+        "//kv_cache_manager/common:logger",
+        "//kv_cache_manager/common:loop_thread",
+        "//kv_cache_manager/event:event_publisher",
+        "//kv_cache_manager/event/spec_events",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "@rapidjson",
+    ],
+)
+
+cc_library(
+    name = "online_mrc_registry",
+    srcs = [
+        "online_mrc_registry.cc",
+        "online_mrc_trace_receiver.cc",
+    ],
+    hdrs = [
+        "online_mrc_registry.h",
+        "online_mrc_trace_receiver.h",
+    ],
+    deps = [
+        ":mrc_profiler",
+        ":online_mrc_config",
+        "//kv_cache_manager/common:logger",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "@rapidjson",
+    ],
+)
+
+cc_library(
+    name = "online_mrc_fact_stream",
+    srcs = [
+        "kvcm_event_stream_client.cc",
+        "online_mrc_fact_registry.cc",
+    ],
+    hdrs = [
+        "kvcm_event_stream_client.h",
+        "online_mrc_fact_registry.h",
+    ],
+    deps = [
+        ":online_mrc_config",
+        "//kv_cache_manager/common:logger",
+        "//kv_cache_manager/common:service_discovery",
+        "//kv_cache_manager/common:service_discovery_factory",
+        "//kv_cache_manager/common:string_util",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/optimizer:online_optimizer_manager",
+        "//kv_cache_manager/optimizer/config:online_optimizer_config",
+        "//kv_cache_manager/optimizer/config:optimizer_registry_manager",
+        "//kv_cache_manager/optimizer/liteHit:hit_curve",
+        "//kv_cache_manager/optimizer/liteHit:lite_hit",
+        "//kv_cache_manager/optimizer/liteHit:request_preprocess",
+        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+    ],
+)
+
+cc_library(
+    name = "optimizer_trace_forwarder",
+    srcs = ["optimizer_trace_forwarder.cc"],
+    hdrs = ["optimizer_trace_forwarder.h"],
+    deps = [
+        ":online_mrc_config",
+        "//kv_cache_manager/common:logger",
+        "//kv_cache_manager/common:loop_thread",
+        "//kv_cache_manager/common:string_util",
+        "//kv_cache_manager/event:event_publisher",
+        "//kv_cache_manager/event/spec_events",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/protocol/protobuf:service_cc_grpc",
+        "@grpc//:grpc++",
+    ],
+)
+
+# Offline replay harness: validates the online MRC engine against formal
+# LiteHit results on the same trace (P1c acceptance). Not part of any server.
+cc_binary(
+    name = "mrc_replay_main",
+    srcs = [
+        "tools/mrc_replay_main.cc",
+    ],
+    deps = [
+        ":mrc_profiler",
+    ],
+)

--- a/kv_cache_manager/mrc/hit_curve_projector.cc
+++ b/kv_cache_manager/mrc/hit_curve_projector.cc
@@ -1,0 +1,28 @@
+#include "kv_cache_manager/mrc/hit_curve_projector.h"
+
+#include <algorithm>
+
+namespace kv_cache_manager {
+
+HitCurveProjection
+HitCurveProjector::Project(const std::deque<MrcRequestFact> &facts, uint64_t capacity_blocks, int32_t block_size) {
+    HitCurveProjection result;
+    if (block_size <= 0) {
+        return result;
+    }
+    for (const auto &fact : facts) {
+        if (fact.input_token_len <= 0) {
+            continue;
+        }
+        const uint64_t input_tokens = static_cast<uint64_t>(fact.input_token_len);
+        const uint64_t hit_blocks = static_cast<uint64_t>(
+            std::upper_bound(fact.thresholds.begin(), fact.thresholds.end(), capacity_blocks) -
+            fact.thresholds.begin());
+        result.total_tokens += input_tokens;
+        result.hit_tokens +=
+            std::min<uint64_t>(hit_blocks * static_cast<uint64_t>(block_size), input_tokens);
+    }
+    return result;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/hit_curve_projector.h
+++ b/kv_cache_manager/mrc/hit_curve_projector.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <vector>
+
+namespace kv_cache_manager {
+
+// Capacity-independent result of one LiteHit request. Facts are snapshots of
+// completed calculations and are currently retained for the process lifetime.
+struct MrcRequestFact {
+    int64_t input_token_len = 0;
+    std::vector<uint64_t> thresholds;
+};
+
+struct HitCurveProjection {
+    uint64_t total_tokens = 0;
+    uint64_t hit_tokens = 0;
+
+    double hit_rate() const {
+        return total_tokens == 0 ? 0.0 : static_cast<double>(hit_tokens) / total_tokens;
+    }
+};
+
+// Projects capacity-independent request facts onto a configured capacity.
+// Keeping this separate from LiteHit makes capacity points reporting
+// parameters instead of part of the simulation state.
+class HitCurveProjector {
+public:
+    static HitCurveProjection
+    Project(const std::deque<MrcRequestFact> &facts, uint64_t capacity_blocks, int32_t block_size);
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/kvcm_event_stream_client.cc
+++ b/kv_cache_manager/mrc/kvcm_event_stream_client.cc
@@ -1,0 +1,647 @@
+#include "kv_cache_manager/mrc/kvcm_event_stream_client.h"
+
+#include <algorithm>
+#include <array>
+#include <arpa/inet.h>
+#include <chrono>
+#include <cstring>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits>
+#include <map>
+#include <netdb.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <utility>
+
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/service_discovery_factory.h"
+#include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/mrc/online_mrc_fact_registry.h"
+
+namespace kv_cache_manager {
+namespace {
+
+constexpr uint8_t kMessageHello = 1;
+constexpr uint8_t kMessageEventBatch = 2;
+constexpr uint32_t kProtocolVersion = 1;
+constexpr int kMaxPollWaitMs = 1000;
+
+constexpr char kMetricDiscoveredEndpoints[] = "online_mrc.discovered_endpoints";
+constexpr char kMetricActiveConnections[] = "online_mrc.active_connections";
+constexpr char kMetricReconnects[] = "online_mrc.reconnects";
+constexpr char kMetricDecodeErrors[] = "online_mrc.decode_errors";
+constexpr char kMetricReceivedBatches[] = "online_mrc.received_batches";
+constexpr char kMetricReceiverQueueSize[] = "online_mrc.receiver_queue_size";
+constexpr char kMetricReceiverQueueBytes[] = "online_mrc.receiver_queue_bytes";
+constexpr char kMetricReceiverQueueCapacityBatches[] = "online_mrc.receiver_queue_capacity_batches";
+constexpr char kMetricReceiverDroppedBatches[] = "online_mrc.receiver_dropped_batches";
+constexpr char kMetricReceiverRejectedBatches[] = "online_mrc.receiver_rejected_batches";
+
+std::string EndpointKey(const ServiceEndpoint &endpoint) {
+    return endpoint.host.empty() ? endpoint.ip + ":" + std::to_string(endpoint.port) : endpoint.host;
+}
+
+bool SameEndpoint(const ServiceEndpoint &lhs, const ServiceEndpoint &rhs) {
+    return lhs.ip == rhs.ip && lhs.port == rhs.port;
+}
+
+bool ConfigureNonBlockingFd(int fd) {
+    const int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0) {
+        return false;
+    }
+    const int fd_flags = fcntl(fd, F_GETFD, 0);
+    return fd_flags >= 0 && fcntl(fd, F_SETFD, fd_flags | FD_CLOEXEC) == 0;
+}
+
+bool BuildHelloFrame(const std::string &optimizer_id, std::vector<uint8_t> &frame) {
+    proto::optimizer::OptimizerHello hello;
+    hello.set_protocol_version(kProtocolVersion);
+    hello.set_optimizer_id(optimizer_id);
+    std::string payload;
+    if (!hello.SerializeToString(&payload)) {
+        return false;
+    }
+    const uint32_t frame_length = static_cast<uint32_t>(payload.size() + 1);
+    const uint32_t network_length = htonl(frame_length);
+    frame.resize(sizeof(network_length) + frame_length);
+    std::memcpy(frame.data(), &network_length, sizeof(network_length));
+    frame[sizeof(network_length)] = kMessageHello;
+    std::memcpy(frame.data() + sizeof(network_length) + 1, payload.data(), payload.size());
+    return true;
+}
+
+} // namespace
+
+class KvcmEventStreamClient::Connection {
+public:
+    enum class State { Disconnected, Connecting, SendingHello, Reading };
+
+    explicit Connection(ServiceEndpoint value)
+        : endpoint(std::move(value)), next_retry(std::chrono::steady_clock::now()) {}
+
+    ~Connection() {
+        if (fd >= 0) {
+            close(fd);
+        }
+    }
+
+    ServiceEndpoint endpoint;
+    int fd = -1;
+    State state = State::Disconnected;
+    std::chrono::steady_clock::time_point next_retry;
+    std::chrono::steady_clock::time_point connect_deadline;
+    std::vector<uint8_t> write_buffer;
+    size_t write_offset = 0;
+    std::vector<uint8_t> read_buffer;
+    size_t read_offset = 0;
+    uint64_t attempt_count = 0;
+    bool active_counted = false;
+};
+
+KvcmEventStreamClient::KvcmEventStreamClient(const OnlineMrcConfig &config,
+                                             std::shared_ptr<OnlineMrcFactRegistry> fact_registry,
+                                             std::shared_ptr<MetricsRegistry> metrics_registry)
+    : config_(config)
+    , fact_registry_(std::move(fact_registry))
+    , metrics_registry_(std::move(metrics_registry))
+    , optimizer_id_(StringUtil::GenerateRandomString(32)) {}
+
+KvcmEventStreamClient::~KvcmEventStreamClient() {
+    Stop();
+    if (wake_read_fd_ >= 0) {
+        close(wake_read_fd_);
+        wake_read_fd_ = -1;
+    }
+    if (wake_write_fd_ >= 0) {
+        close(wake_write_fd_);
+        wake_write_fd_ = -1;
+    }
+}
+
+bool KvcmEventStreamClient::Init() {
+    discovery_ = ServiceDiscoveryFactory::CreateServiceDiscovery(config_.kvcm_service_discovery_url);
+    if (!discovery_) {
+        KVCM_LOG_ERROR("online mrc stream: failed to initialize KVCM service discovery[%s]",
+                       config_.kvcm_service_discovery_url.c_str());
+        return false;
+    }
+    if (!fact_registry_) {
+        return false;
+    }
+    if (wake_read_fd_ >= 0 && wake_write_fd_ >= 0) {
+        return true;
+    }
+    int wake_fds[2] = {-1, -1};
+    if (pipe(wake_fds) != 0 || !ConfigureNonBlockingFd(wake_fds[0]) || !ConfigureNonBlockingFd(wake_fds[1])) {
+        if (wake_fds[0] >= 0) {
+            close(wake_fds[0]);
+        }
+        if (wake_fds[1] >= 0) {
+            close(wake_fds[1]);
+        }
+        KVCM_LOG_ERROR("online mrc stream: failed to create event-loop wake pipe, errno=%d", errno);
+        return false;
+    }
+    wake_read_fd_ = wake_fds[0];
+    wake_write_fd_ = wake_fds[1];
+    return true;
+}
+
+bool KvcmEventStreamClient::Start() {
+    if (!discovery_ || !fact_registry_ || wake_read_fd_ < 0 || wake_write_fd_ < 0) {
+        return false;
+    }
+    bool expected = false;
+    if (!running_.compare_exchange_strong(expected, true)) {
+        return true;
+    }
+    applied_endpoints_generation_ = std::numeric_limits<uint64_t>::max();
+    ingress_stopped_.store(false, std::memory_order_release);
+    consumer_thread_ = std::thread(&KvcmEventStreamClient::ConsumerLoop, this);
+    event_loop_thread_ = std::thread(&KvcmEventStreamClient::EventLoop, this);
+    discovery_thread_ = std::thread(&KvcmEventStreamClient::DiscoveryLoop, this);
+    return true;
+}
+
+void KvcmEventStreamClient::Stop() {
+    if (!running_.exchange(false)) {
+        return;
+    }
+    wait_cv_.notify_all();
+    WakeEventLoop();
+    if (discovery_thread_.joinable()) {
+        discovery_thread_.join();
+    }
+    if (event_loop_thread_.joinable()) {
+        event_loop_thread_.join();
+    }
+    ingress_stopped_.store(true, std::memory_order_release);
+    queue_cv_.notify_all();
+    if (consumer_thread_.joinable()) {
+        consumer_thread_.join();
+    }
+}
+
+void KvcmEventStreamClient::WakeEventLoop() {
+    if (wake_write_fd_ < 0) {
+        return;
+    }
+    const uint8_t byte = 1;
+    ssize_t rc;
+    do {
+        rc = write(wake_write_fd_, &byte, sizeof(byte));
+    } while (rc < 0 && errno == EINTR);
+}
+
+void KvcmEventStreamClient::DrainWakePipe() {
+    std::array<uint8_t, 64> buffer{};
+    while (true) {
+        const ssize_t rc = read(wake_read_fd_, buffer.data(), buffer.size());
+        if (rc > 0) {
+            continue;
+        }
+        if (rc < 0 && errno == EINTR) {
+            continue;
+        }
+        return;
+    }
+}
+
+bool KvcmEventStreamClient::Enqueue(proto::optimizer::CacheEventBatch batch, uint64_t wire_bytes) {
+    std::lock_guard<std::mutex> guard(queue_mutex_);
+    const size_t limit = static_cast<size_t>(std::max<int64_t>(config_.receiver_queue_max_batches, 1));
+    if (queue_.size() >= limit) {
+        dropped_batches_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+    queue_.push_back(QueuedBatch{std::move(batch), wire_bytes});
+    queue_bytes_ += wire_bytes;
+    queue_cv_.notify_one();
+    return true;
+}
+
+void KvcmEventStreamClient::ConsumerLoop() {
+    while (true) {
+        QueuedBatch queued;
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            queue_cv_.wait(lock, [this]() { return ingress_stopped_.load(std::memory_order_acquire) || !queue_.empty(); });
+            if (queue_.empty()) {
+                if (ingress_stopped_.load(std::memory_order_acquire)) {
+                    break;
+                }
+                continue;
+            }
+            queued = std::move(queue_.front());
+            queue_.pop_front();
+            queue_bytes_ -= queued.wire_bytes;
+        }
+        if (!fact_registry_->Observe(queued.batch)) {
+            rejected_batches_.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+}
+
+void KvcmEventStreamClient::DiscoveryLoop() {
+    while (running_) {
+        std::vector<ServiceEndpoint> endpoints;
+        if (discovery_->GetAllEndpoints(endpoints)) {
+            UpdateDesiredEndpoints(endpoints);
+        } else {
+            KVCM_LOG_WARN("online mrc stream: failed to discover KVCM endpoints");
+        }
+        std::unique_lock<std::mutex> lock(wait_mutex_);
+        wait_cv_.wait_for(lock,
+                          std::chrono::milliseconds(std::max<int64_t>(config_.discovery_refresh_interval_ms, 1)),
+                          [this]() { return !running_; });
+        if (running_) {
+            discovery_->Refresh();
+        }
+    }
+}
+
+void KvcmEventStreamClient::UpdateDesiredEndpoints(const std::vector<ServiceEndpoint> &endpoints) {
+    std::unordered_map<std::string, ServiceEndpoint> desired;
+    for (const auto &endpoint : endpoints) {
+        if (endpoint.healthy && !endpoint.ip.empty() && endpoint.port > 0) {
+            desired[EndpointKey(endpoint)] = endpoint;
+        }
+    }
+    discovered_endpoints_.store(desired.size(), std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> guard(desired_endpoints_mutex_);
+        desired_endpoints_ = std::move(desired);
+        ++desired_endpoints_generation_;
+    }
+    WakeEventLoop();
+}
+
+void KvcmEventStreamClient::ApplyDesiredEndpoints() {
+    std::unordered_map<std::string, ServiceEndpoint> desired;
+    uint64_t generation = 0;
+    {
+        std::lock_guard<std::mutex> guard(desired_endpoints_mutex_);
+        if (applied_endpoints_generation_ == desired_endpoints_generation_) {
+            return;
+        }
+        desired = desired_endpoints_;
+        generation = desired_endpoints_generation_;
+    }
+
+    for (auto it = connections_.begin(); it != connections_.end();) {
+        const auto desired_it = desired.find(it->first);
+        if (desired_it == desired.end()) {
+            Disconnect(*it->second, false);
+            it = connections_.erase(it);
+            continue;
+        }
+        if (!SameEndpoint(it->second->endpoint, desired_it->second)) {
+            Disconnect(*it->second, false);
+            it->second->endpoint = desired_it->second;
+            it->second->attempt_count = 0;
+            it->second->next_retry = std::chrono::steady_clock::now();
+        }
+        ++it;
+    }
+    for (auto &[key, endpoint] : desired) {
+        if (connections_.count(key) == 0) {
+            connections_.emplace(key, std::make_unique<Connection>(std::move(endpoint)));
+        }
+    }
+    managed_connections_.store(connections_.size(), std::memory_order_relaxed);
+    applied_endpoints_generation_ = generation;
+}
+
+void KvcmEventStreamClient::BeginConnect(Connection &connection) {
+    if (connection.state != Connection::State::Disconnected || connection.fd >= 0) {
+        return;
+    }
+    if (connection.attempt_count > 0) {
+        reconnects_.fetch_add(1, std::memory_order_relaxed);
+    }
+    ++connection.attempt_count;
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_NUMERICHOST;
+    addrinfo *result = nullptr;
+    const std::string port = std::to_string(connection.endpoint.port);
+    if (getaddrinfo(connection.endpoint.ip.c_str(), port.c_str(), &hints, &result) != 0) {
+        Disconnect(connection, true);
+        return;
+    }
+
+    for (addrinfo *address = result; address && running_; address = address->ai_next) {
+        const int fd = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
+        if (fd < 0) {
+            continue;
+        }
+        if (!ConfigureNonBlockingFd(fd)) {
+            close(fd);
+            continue;
+        }
+#ifdef SO_NOSIGPIPE
+        const int no_sigpipe = 1;
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe));
+#endif
+        const int rc = connect(fd, address->ai_addr, address->ai_addrlen);
+        if (rc == 0 || (rc < 0 && errno == EINPROGRESS)) {
+            connection.fd = fd;
+            if (rc == 0) {
+                connection.state = Connection::State::SendingHello;
+                if (!BuildHelloFrame(optimizer_id_, connection.write_buffer)) {
+                    Disconnect(connection, true);
+                }
+            } else {
+                connection.state = Connection::State::Connecting;
+                connection.connect_deadline =
+                    std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(std::max<int64_t>(config_.connect_timeout_ms, 1));
+            }
+            freeaddrinfo(result);
+            return;
+        }
+        close(fd);
+    }
+    freeaddrinfo(result);
+    Disconnect(connection, true);
+}
+
+bool KvcmEventStreamClient::FinishConnect(Connection &connection) {
+    int socket_error = 0;
+    socklen_t error_length = sizeof(socket_error);
+    if (getsockopt(connection.fd, SOL_SOCKET, SO_ERROR, &socket_error, &error_length) != 0 || socket_error != 0) {
+        return false;
+    }
+    connection.state = Connection::State::SendingHello;
+    connection.write_offset = 0;
+    return BuildHelloFrame(optimizer_id_, connection.write_buffer);
+}
+
+bool KvcmEventStreamClient::FlushHello(Connection &connection) {
+    while (connection.write_offset < connection.write_buffer.size()) {
+        int flags = 0;
+#ifdef MSG_NOSIGNAL
+        flags = MSG_NOSIGNAL;
+#endif
+        const ssize_t rc = send(connection.fd,
+                                connection.write_buffer.data() + connection.write_offset,
+                                connection.write_buffer.size() - connection.write_offset,
+                                flags);
+        if (rc > 0) {
+            connection.write_offset += static_cast<size_t>(rc);
+            continue;
+        }
+        if (rc < 0 && errno == EINTR) {
+            continue;
+        }
+        if (rc < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            return true;
+        }
+        return false;
+    }
+    connection.write_buffer.clear();
+    connection.write_offset = 0;
+    connection.state = Connection::State::Reading;
+    connection.active_counted = true;
+    active_connections_.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+bool KvcmEventStreamClient::DecodeBufferedFrames(Connection &connection) {
+    while (connection.read_buffer.size() - connection.read_offset >= sizeof(uint32_t)) {
+        uint32_t network_length = 0;
+        std::memcpy(&network_length, connection.read_buffer.data() + connection.read_offset, sizeof(network_length));
+        const uint32_t frame_length = ntohl(network_length);
+        if (frame_length < 1 || frame_length > static_cast<uint64_t>(std::max<int64_t>(config_.max_frame_bytes, 1))) {
+            decode_errors_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        const size_t wire_bytes = sizeof(network_length) + static_cast<size_t>(frame_length);
+        if (connection.read_buffer.size() - connection.read_offset < wire_bytes) {
+            break;
+        }
+        const uint8_t *frame = connection.read_buffer.data() + connection.read_offset + sizeof(network_length);
+        if (frame[0] != kMessageEventBatch) {
+            decode_errors_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        proto::optimizer::CacheEventBatch batch;
+        if (!batch.ParseFromArray(frame + 1, static_cast<int>(frame_length - 1))) {
+            decode_errors_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        received_batches_.fetch_add(1, std::memory_order_relaxed);
+        Enqueue(std::move(batch), wire_bytes);
+        connection.read_offset += wire_bytes;
+    }
+
+    if (connection.read_offset == connection.read_buffer.size()) {
+        connection.read_buffer.clear();
+        connection.read_offset = 0;
+    } else if (connection.read_offset >= 64 * 1024 || connection.read_offset * 2 >= connection.read_buffer.size()) {
+        connection.read_buffer.erase(connection.read_buffer.begin(),
+                                     connection.read_buffer.begin() + static_cast<std::ptrdiff_t>(connection.read_offset));
+        connection.read_offset = 0;
+    }
+    return true;
+}
+
+bool KvcmEventStreamClient::ReadAvailableFrames(Connection &connection) {
+    std::array<uint8_t, 64 * 1024> buffer{};
+    while (true) {
+        const ssize_t rc = recv(connection.fd, buffer.data(), buffer.size(), 0);
+        if (rc > 0) {
+            connection.read_buffer.insert(connection.read_buffer.end(), buffer.begin(), buffer.begin() + rc);
+            if (!DecodeBufferedFrames(connection)) {
+                return false;
+            }
+            continue;
+        }
+        if (rc == 0) {
+            return false;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return true;
+        }
+        return false;
+    }
+}
+
+void KvcmEventStreamClient::Disconnect(Connection &connection, bool schedule_retry) {
+    if (connection.active_counted) {
+        active_connections_.fetch_sub(1, std::memory_order_relaxed);
+        connection.active_counted = false;
+    }
+    if (connection.fd >= 0) {
+        close(connection.fd);
+        connection.fd = -1;
+    }
+    connection.state = Connection::State::Disconnected;
+    connection.write_buffer.clear();
+    connection.write_offset = 0;
+    connection.read_buffer.clear();
+    connection.read_offset = 0;
+    if (schedule_retry && running_) {
+        connection.next_retry =
+            std::chrono::steady_clock::now() +
+            std::chrono::milliseconds(std::max<int64_t>(config_.reconnect_interval_ms, 1));
+    } else {
+        connection.next_retry = std::chrono::steady_clock::time_point::max();
+    }
+}
+
+void KvcmEventStreamClient::HandleConnectionEvent(Connection &connection, short revents) {
+    if (revents & POLLNVAL) {
+        Disconnect(connection, true);
+        return;
+    }
+    if (connection.state == Connection::State::Connecting) {
+        if (revents & (POLLOUT | POLLERR | POLLHUP)) {
+            if (!FinishConnect(connection)) {
+                Disconnect(connection, true);
+            }
+        }
+        return;
+    }
+    if (connection.state == Connection::State::SendingHello) {
+        if (revents & (POLLERR | POLLHUP)) {
+            Disconnect(connection, true);
+            return;
+        }
+        if ((revents & POLLOUT) && !FlushHello(connection)) {
+            Disconnect(connection, true);
+        }
+        return;
+    }
+    if (connection.state == Connection::State::Reading) {
+        if ((revents & POLLIN) && !ReadAvailableFrames(connection)) {
+            Disconnect(connection, true);
+            return;
+        }
+        if (revents & (POLLERR | POLLHUP)) {
+            Disconnect(connection, true);
+        }
+    }
+}
+
+int KvcmEventStreamClient::ComputePollTimeoutMs() const {
+    const auto now = std::chrono::steady_clock::now();
+    auto deadline = now + std::chrono::milliseconds(kMaxPollWaitMs);
+    for (const auto &[_, connection] : connections_) {
+        if (connection->state == Connection::State::Disconnected) {
+            deadline = std::min(deadline, connection->next_retry);
+        } else if (connection->state == Connection::State::Connecting) {
+            deadline = std::min(deadline, connection->connect_deadline);
+        }
+    }
+    if (deadline <= now) {
+        return 0;
+    }
+    const auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+    return static_cast<int>(std::min<int64_t>(timeout, kMaxPollWaitMs));
+}
+
+void KvcmEventStreamClient::EventLoop() {
+    while (running_) {
+        ApplyDesiredEndpoints();
+        const auto now = std::chrono::steady_clock::now();
+        for (auto &[_, connection] : connections_) {
+            if (connection->state == Connection::State::Disconnected && connection->next_retry <= now) {
+                BeginConnect(*connection);
+            }
+        }
+
+        std::vector<pollfd> poll_fds;
+        std::vector<Connection *> polled_connections;
+        poll_fds.push_back(pollfd{wake_read_fd_, POLLIN, 0});
+        for (auto &[_, connection] : connections_) {
+            if (connection->fd < 0) {
+                continue;
+            }
+            short events = 0;
+            if (connection->state == Connection::State::Connecting ||
+                connection->state == Connection::State::SendingHello) {
+                events = POLLOUT;
+            } else if (connection->state == Connection::State::Reading) {
+                events = POLLIN;
+            }
+            poll_fds.push_back(pollfd{connection->fd, events, 0});
+            polled_connections.push_back(connection.get());
+        }
+
+        const int rc = poll(poll_fds.data(), poll_fds.size(), ComputePollTimeoutMs());
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            KVCM_LOG_WARN("online mrc stream: event-loop poll failed, errno=%d", errno);
+            continue;
+        }
+        if (poll_fds[0].revents & POLLIN) {
+            DrainWakePipe();
+        }
+        if (!running_) {
+            break;
+        }
+        for (size_t i = 0; i < polled_connections.size(); ++i) {
+            if (poll_fds[i + 1].revents != 0) {
+                HandleConnectionEvent(*polled_connections[i], poll_fds[i + 1].revents);
+            }
+        }
+
+        const auto after_poll = std::chrono::steady_clock::now();
+        for (auto &[_, connection] : connections_) {
+            if (connection->state == Connection::State::Connecting && connection->connect_deadline <= after_poll) {
+                Disconnect(*connection, true);
+            }
+        }
+    }
+
+    for (auto &[_, connection] : connections_) {
+        Disconnect(*connection, false);
+    }
+    connections_.clear();
+    managed_connections_.store(0, std::memory_order_relaxed);
+}
+
+void KvcmEventStreamClient::ReportMetrics() {
+    if (!metrics_registry_) {
+        return;
+    }
+    size_t queue_size = 0;
+    uint64_t queue_bytes = 0;
+    {
+        std::lock_guard<std::mutex> guard(queue_mutex_);
+        queue_size = queue_.size();
+        queue_bytes = queue_bytes_;
+    }
+    const MetricsTags tags;
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricDiscoveredEndpoints, tags, discovered_endpoints_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricActiveConnections, tags, active_connections_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReconnects, tags, reconnects_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricDecodeErrors, tags, decode_errors_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReceivedBatches, tags, received_batches_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReceiverQueueSize, tags, queue_size);
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReceiverQueueBytes, tags, queue_bytes);
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_,
+                          kMetricReceiverQueueCapacityBatches,
+                          tags,
+                          std::max<int64_t>(config_.receiver_queue_max_batches, 1));
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReceiverDroppedBatches, tags, dropped_batches_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReceiverRejectedBatches, tags, rejected_batches_.load());
+}
+
+size_t KvcmEventStreamClient::ConnectionCount() const {
+    return managed_connections_.load(std::memory_order_relaxed);
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/kvcm_event_stream_client.h
+++ b/kv_cache_manager/mrc/kvcm_event_stream_client.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "kv_cache_manager/common/service_discovery.h"
+#include "kv_cache_manager/mrc/online_mrc_config.h"
+#include "kv_cache_manager/protocol/protobuf/optimizer_service.pb.h"
+
+namespace kv_cache_manager {
+
+class MetricsRegistry;
+class OnlineMrcFactRegistry;
+class ServiceDiscovery;
+
+// Optimizer-side client: discovers every KVCM node, actively connects to each
+// one, sends HELLO, and then only reads CacheEventBatch frames. KVCM never
+// needs to discover or configure an optimizer endpoint in this mode.
+class KvcmEventStreamClient {
+public:
+    KvcmEventStreamClient(const OnlineMrcConfig &config,
+                          std::shared_ptr<OnlineMrcFactRegistry> fact_registry,
+                          std::shared_ptr<MetricsRegistry> metrics_registry);
+    ~KvcmEventStreamClient();
+
+    bool Init();
+    bool Start();
+    void Stop();
+    void ReportMetrics();
+
+    size_t ConnectionCount() const;
+
+private:
+    class Connection;
+
+    struct QueuedBatch {
+        proto::optimizer::CacheEventBatch batch;
+        uint64_t wire_bytes = 0;
+    };
+
+    void DiscoveryLoop();
+    void UpdateDesiredEndpoints(const std::vector<ServiceEndpoint> &endpoints);
+    void EventLoop();
+    void ApplyDesiredEndpoints();
+    void WakeEventLoop();
+    void DrainWakePipe();
+    void BeginConnect(Connection &connection);
+    void HandleConnectionEvent(Connection &connection, short revents);
+    bool FinishConnect(Connection &connection);
+    bool FlushHello(Connection &connection);
+    bool ReadAvailableFrames(Connection &connection);
+    bool DecodeBufferedFrames(Connection &connection);
+    void Disconnect(Connection &connection, bool schedule_retry);
+    int ComputePollTimeoutMs() const;
+    bool Enqueue(proto::optimizer::CacheEventBatch batch, uint64_t wire_bytes);
+    void ConsumerLoop();
+
+    OnlineMrcConfig config_;
+    std::shared_ptr<OnlineMrcFactRegistry> fact_registry_;
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::unique_ptr<ServiceDiscovery> discovery_;
+    std::string optimizer_id_;
+
+    // desired_endpoints_ is published by the discovery thread. The event-loop
+    // thread is the sole owner of connections_ and every socket state change.
+    mutable std::mutex desired_endpoints_mutex_;
+    std::unordered_map<std::string, ServiceEndpoint> desired_endpoints_;
+    uint64_t desired_endpoints_generation_ = 0;
+    uint64_t applied_endpoints_generation_ = 0;
+    std::unordered_map<std::string, std::unique_ptr<Connection>> connections_;
+    std::thread discovery_thread_;
+    std::thread event_loop_thread_;
+    std::thread consumer_thread_;
+    int wake_read_fd_ = -1;
+    int wake_write_fd_ = -1;
+    mutable std::mutex wait_mutex_;
+    std::condition_variable wait_cv_;
+    mutable std::mutex queue_mutex_;
+    std::condition_variable queue_cv_;
+    std::deque<QueuedBatch> queue_;
+    // Sum of serialized on-wire frame bytes waiting in queue_. This is a
+    // stable pressure signal, not an allocator/RSS measurement.
+    uint64_t queue_bytes_ = 0;
+    std::atomic<bool> running_{false};
+    std::atomic<bool> ingress_stopped_{true};
+
+    std::atomic<uint64_t> discovered_endpoints_{0};
+    std::atomic<uint64_t> managed_connections_{0};
+    std::atomic<uint64_t> active_connections_{0};
+    std::atomic<uint64_t> reconnects_{0};
+    std::atomic<uint64_t> decode_errors_{0};
+    std::atomic<uint64_t> received_batches_{0};
+    std::atomic<uint64_t> dropped_batches_{0};
+    std::atomic<uint64_t> rejected_batches_{0};
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/lite_hit_core.cc
+++ b/kv_cache_manager/mrc/lite_hit_core.cc
@@ -1,0 +1,152 @@
+#include "kv_cache_manager/mrc/lite_hit_core.h"
+
+#include <algorithm>
+
+namespace kv_cache_manager {
+
+namespace {
+// Snapshot entry: 0 = cold; otherwise required_blocks (reuse distance + 1).
+constexpr uint64_t kCold = 0;
+} // namespace
+
+LiteHitCore::LiteHitCore(int64_t initial_capacity, int64_t max_tracked_blocks)
+    : max_tracked_blocks_(max_tracked_blocks) {
+    capacity_ = std::max<int64_t>(initial_capacity, 16);
+    if (max_tracked_blocks_ > 0) {
+        capacity_ = std::min(capacity_, std::max<int64_t>(max_tracked_blocks_ * 2, 16));
+    }
+    tree_.assign(capacity_ + 1, 0);
+}
+
+void LiteHitCore::ProcessRequest(const std::vector<int64_t> &block_keys, std::vector<uint64_t> &out_thresholds) {
+    if (block_keys.empty()) {
+        return;
+    }
+
+    // Phase 1: prefix hit curve against the request-start snapshot.
+    snapshot_required_.clear();
+    for (const int64_t key : block_keys) {
+        auto [it, inserted] = snapshot_required_.emplace(key, kCold);
+        if (!inserted) {
+            continue;
+        }
+        const auto previous = last_pos_.find(key);
+        if (previous != last_pos_.end()) {
+            const uint64_t distance =
+                static_cast<uint64_t>(static_cast<int64_t>(last_pos_.size()) - FenwickPrefixSum(previous->second));
+            it->second = distance + 1; // required_blocks
+        }
+    }
+
+    uint64_t prefix_required = 0;
+    uint64_t last_threshold = 0;
+    for (const int64_t key : block_keys) {
+        const uint64_t required = snapshot_required_.at(key);
+        if (required == kCold) {
+            break; // a cold key stops every capacity's prefix
+        }
+        prefix_required = std::max(prefix_required, required);
+        // Keep thresholds strictly increasing (defensive for duplicate keys,
+        // pessimistic never optimistic — mirrors the offline core).
+        const uint64_t threshold = std::max(prefix_required, last_threshold + 1);
+        out_thresholds.push_back(threshold);
+        last_threshold = threshold;
+    }
+
+    // Phase 2: commit tail-to-head so the chain head ends most recent and
+    // the LRU victim is always a chain leaf.
+    first_occurrence_.clear();
+    for (size_t i = block_keys.size(); i > 0; --i) {
+        first_occurrence_[block_keys[i - 1]] = i - 1;
+    }
+    for (const auto &[key, _] : first_occurrence_) {
+        const auto previous = last_pos_.find(key);
+        if (previous != last_pos_.end()) {
+            FenwickAdd(previous->second, -1);
+            pos_to_key_.erase(previous->second);
+            last_pos_.erase(previous);
+        }
+    }
+    for (size_t i = block_keys.size(); i > 0; --i) {
+        const int64_t key = block_keys[i - 1];
+        if (first_occurrence_.at(key) != i - 1) {
+            continue;
+        }
+        EnsureSlot();
+        last_pos_[key] = next_pos_;
+        pos_to_key_[next_pos_] = key;
+        FenwickAdd(next_pos_, 1);
+        ++next_pos_;
+        TrimToLimit();
+    }
+}
+
+void LiteHitCore::Reset() {
+    next_pos_ = 1;
+    std::fill(tree_.begin(), tree_.end(), 0);
+    last_pos_.clear();
+    pos_to_key_.clear();
+    snapshot_required_.clear();
+    first_occurrence_.clear();
+}
+
+void LiteHitCore::TrimToLimit() {
+    while (max_tracked_blocks_ > 0 && static_cast<int64_t>(last_pos_.size()) > max_tracked_blocks_) {
+        const auto oldest = pos_to_key_.begin();
+        FenwickAdd(oldest->first, -1);
+        last_pos_.erase(oldest->second);
+        pos_to_key_.erase(oldest);
+    }
+}
+
+void LiteHitCore::EnsureSlot() {
+    if (next_pos_ > capacity_) {
+        Compact();
+    }
+}
+
+void LiteHitCore::Compact() {
+    std::vector<std::pair<int64_t, int64_t>> entries; // (position, key)
+    entries.reserve(last_pos_.size());
+    for (const auto &[key, pos] : last_pos_) {
+        entries.emplace_back(pos, key);
+    }
+    std::sort(entries.begin(), entries.end());
+
+    if (static_cast<int64_t>(entries.size()) * 2 > capacity_) {
+        capacity_ *= 2;
+    }
+    tree_.assign(capacity_ + 1, 0);
+    pos_to_key_.clear();
+    next_pos_ = 1;
+    for (const auto &[pos, key] : entries) {
+        last_pos_[key] = next_pos_;
+        pos_to_key_[next_pos_] = key;
+        FenwickAdd(next_pos_, 1);
+        ++next_pos_;
+    }
+}
+
+void LiteHitCore::FenwickAdd(int64_t pos, int64_t delta) {
+    for (; pos <= capacity_; pos += pos & (-pos)) {
+        tree_[pos] += delta;
+    }
+}
+
+int64_t LiteHitCore::FenwickPrefixSum(int64_t pos) const {
+    int64_t sum = 0;
+    for (; pos > 0; pos -= pos & (-pos)) {
+        sum += tree_[pos];
+    }
+    return sum;
+}
+
+int64_t LiteHitCore::memory_usage_bytes() const {
+    constexpr int64_t kEstimatedHashEntryOverheadBytes = 48;
+    constexpr int64_t kEstimatedTreeEntryOverheadBytes = 48;
+    return static_cast<int64_t>(tree_.capacity() * sizeof(int64_t)) +
+           static_cast<int64_t>(last_pos_.size()) *
+               (kEstimatedHashEntryOverheadBytes + kEstimatedTreeEntryOverheadBytes);
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/lite_hit_core.h
+++ b/kv_cache_manager/mrc/lite_hit_core.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+namespace kv_cache_manager {
+
+// Exact replication of the offline LiteHit Fenwick core's request-level
+// semantics (kvs-profiler `LiteHit`), so online results stay directly
+// comparable with the formal offline MRC reports:
+//
+//   Phase 1: the request's prefix hit curve is evaluated against the
+//     request-start LRU snapshot. A cold key stops the prefix for every
+//     capacity. Block i of the surviving prefix hits at capacity C iff
+//     C >= threshold(i), where threshold is the running max of each
+//     block's required_blocks (reuse distance + 1) kept strictly
+//     increasing.
+//   Phase 2: every complete block is committed tail-to-head, so a chain
+//     head is always newer than its resident descendants and the global
+//     LRU victim is always a leaf (vLLM free-queue / SGLang radix cache
+//     eviction order).
+//
+// Not thread-safe; callers serialize access externally.
+class LiteHitCore {
+public:
+    // max_tracked_blocks bounds the exact LRU stack. Results remain exact for
+    // every simulated capacity <= max_tracked_blocks: entries older than that
+    // cannot hit at any reported capacity and are therefore safe to forget.
+    // A non-positive value keeps the historical unbounded behavior and is
+    // intended only for offline validation.
+    explicit LiteHitCore(int64_t initial_capacity = 4096, int64_t max_tracked_blocks = 0);
+
+    LiteHitCore(const LiteHitCore &) = delete;
+    LiteHitCore &operator=(const LiteHitCore &) = delete;
+
+    // Process one request (all complete blocks, request order). Appends one
+    // capacity threshold (in blocks, >= 1) per prefix hit block to
+    // out_thresholds: the block hits an LRU cache of capacity C iff
+    // C >= threshold. Cold and post-miss blocks emit nothing.
+    void ProcessRequest(const std::vector<int64_t> &block_keys, std::vector<uint64_t> &out_thresholds);
+
+    // Clears request history while retaining allocated buffers. Used when an
+    // instance's metadata changes and its old hit curve is no longer valid.
+    void Reset();
+
+    int64_t unique_blocks() const { return static_cast<int64_t>(last_pos_.size()); }
+    int64_t max_tracked_blocks() const { return max_tracked_blocks_; }
+    int64_t memory_usage_bytes() const;
+
+private:
+    void FenwickAdd(int64_t pos, int64_t delta);
+    int64_t FenwickPrefixSum(int64_t pos) const;
+    void EnsureSlot();
+    void Compact();
+    void TrimToLimit();
+
+    int64_t capacity_ = 0;
+    int64_t next_pos_ = 1;
+    int64_t max_tracked_blocks_ = 0;
+    std::vector<int64_t> tree_;
+    std::unordered_map<int64_t, int64_t> last_pos_;
+    std::map<int64_t, int64_t> pos_to_key_;
+
+    // Scratch buffers reused across requests.
+    std::unordered_map<int64_t, uint64_t> snapshot_required_;
+    std::unordered_map<int64_t, size_t> first_occurrence_;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/mrc_event_consumer.cc
+++ b/kv_cache_manager/mrc/mrc_event_consumer.cc
@@ -1,0 +1,321 @@
+#include "kv_cache_manager/mrc/mrc_event_consumer.h"
+
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/loop_thread.h"
+#include "kv_cache_manager/event/spec_events/optimizer_event.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+constexpr char kMetricTheoreticalHitRate[] = "online_mrc.theoretical_hit_rate";
+constexpr char kMetricMaxTrackedHitRate[] = "online_mrc.max_tracked_hit_rate";
+constexpr char kMetricTrackedBlocks[] = "online_mrc.tracked_blocks";
+constexpr char kMetricTrackedCapacityBlocks[] = "online_mrc.tracked_capacity_blocks";
+constexpr char kMetricExactCoverage[] = "online_mrc.exact_coverage";
+constexpr char kMetricMemoryBytes[] = "online_mrc.memory_bytes";
+constexpr char kMetricDroppedEvents[] = "online_mrc.dropped_events";
+constexpr char kMetricTrackedInstances[] = "online_mrc.tracked_instances";
+constexpr char kMetricQueueSize[] = "online_mrc.queue_size";
+
+constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
+
+std::string FormatCapacityGb(double capacity_gb) {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%g", capacity_gb);
+    return buf;
+}
+
+int64_t NowUs() {
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+} // namespace
+
+OnlineMrcEventConsumer::OnlineMrcEventConsumer(const OnlineMrcConfig &config,
+                                               std::shared_ptr<MetricsRegistry> metrics_registry,
+                                               BytesPerBlockResolver bytes_per_block_resolver)
+    : config_(config)
+    , metrics_registry_(std::move(metrics_registry))
+    , bytes_per_block_resolver_(std::move(bytes_per_block_resolver)) {}
+
+OnlineMrcEventConsumer::~OnlineMrcEventConsumer() {
+    if (running_) {
+        Stop();
+    }
+}
+
+bool OnlineMrcEventConsumer::Init(const std::string & /*config*/) {
+    InitBasicQueue(static_cast<size_t>(config_.queue_max_size));
+    running_ = true;
+    worker_ = std::thread(&OnlineMrcEventConsumer::WorkerThread, this);
+    report_thread_ = LoopThread::CreateLoopThread([this]() { ReportMetrics(); },
+                                                  config_.report_interval_seconds * 1000000,
+                                                  "online_mrc_report");
+    if (!report_thread_) {
+        KVCM_LOG_ERROR("online mrc: create report loop thread failed");
+        Stop();
+        return false;
+    }
+    KVCM_LOG_INFO("online mrc consumer started: max_tracked_blocks=%" PRId64 " window_seconds=%" PRId64
+                  " report_interval_seconds=%" PRId64,
+                  config_.max_tracked_blocks,
+                  config_.window_seconds,
+                  config_.report_interval_seconds);
+    return true;
+}
+
+bool OnlineMrcEventConsumer::Publish(const std::shared_ptr<BaseEvent> &event) {
+    if (!running_ || !event) {
+        return false;
+    }
+    // Only the read-path access stream matters for the theoretical hit rate.
+    if (std::dynamic_pointer_cast<CacheGetEvent>(event) == nullptr) {
+        return true;
+    }
+    // BasicEnqueue drops (and counts) when the queue is full: observation
+    // quality degrades but the request path is never blocked.
+    BasicEnqueue(event);
+    return true;
+}
+
+bool OnlineMrcEventConsumer::Stop() {
+    if (!running_) {
+        return true;
+    }
+    running_ = false;
+    if (report_thread_) {
+        report_thread_->Stop();
+        report_thread_.reset();
+    }
+    ClearBasicQueue();
+    if (basic_queue_) {
+        basic_queue_->queue_cv.notify_all();
+    }
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+    return true;
+}
+
+void OnlineMrcEventConsumer::WorkerThread() {
+    while (running_) {
+        BasicWait();
+
+        std::shared_ptr<BaseEvent> event;
+        while (BasicDequeue(event)) {
+            auto cache_get_event = std::dynamic_pointer_cast<CacheGetEvent>(event);
+            if (!cache_get_event) {
+                continue;
+            }
+            const auto &keys = cache_get_event->get_keys();
+            if (keys.empty()) {
+                continue;
+            }
+            auto lane = GetOrCreateLane(cache_get_event->event_source());
+            if (!lane) {
+                continue;
+            }
+            std::lock_guard<std::mutex> guard(lane->mutex);
+            lane->profiler.Observe(keys, NowUs());
+        }
+    }
+}
+
+std::shared_ptr<OnlineMrcEventConsumer::Lane> OnlineMrcEventConsumer::GetOrCreateLane(const std::string &instance_id) {
+    if (instance_id.empty()) {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> guard(lanes_mutex_);
+    auto it = lanes_.find(instance_id);
+    if (it != lanes_.end()) {
+        return it->second;
+    }
+    if (static_cast<int32_t>(lanes_.size()) >= config_.max_instances) {
+        if (!lane_overflow_logged_) {
+            lane_overflow_logged_ = true;
+            KVCM_LOG_WARN("online mrc: instance lane limit[%d] reached, instance[%s] and later newcomers are ignored",
+                          config_.max_instances,
+                          instance_id.c_str());
+        }
+        return nullptr;
+    }
+    MrcProfiler::Options options;
+    options.max_tracked_blocks = config_.max_tracked_blocks;
+    options.window_seconds = config_.window_seconds;
+    auto lane = std::make_shared<Lane>(options);
+    lanes_[instance_id] = lane;
+    KVCM_LOG_INFO("online mrc: start profiling instance[%s]", instance_id.c_str());
+    return lane;
+}
+
+int64_t OnlineMrcEventConsumer::ResolveBytesPerBlock(const std::string &instance_id, Lane &lane) {
+    if (lane.bytes_per_block > 0) {
+        return lane.bytes_per_block;
+    }
+    if (bytes_per_block_resolver_) {
+        const int64_t resolved = bytes_per_block_resolver_(instance_id);
+        if (resolved > 0) {
+            lane.bytes_per_block = resolved;
+            return resolved;
+        }
+    }
+    return config_.default_bytes_per_block;
+}
+
+void OnlineMrcEventConsumer::ReportMetrics() {
+    if (!metrics_registry_) {
+        return;
+    }
+
+    std::map<std::string, std::shared_ptr<Lane>> lanes_copy;
+    {
+        std::lock_guard<std::mutex> guard(lanes_mutex_);
+        lanes_copy = lanes_;
+    }
+
+    const MetricsTags empty_tags;
+    REPORT_DYNAMIC_GAUGE_(
+        metrics_registry_, kMetricDroppedEvents, empty_tags, static_cast<double>(BasicDroppedCount()));
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricQueueSize, empty_tags, static_cast<double>(BasicQueueSize()));
+    REPORT_DYNAMIC_GAUGE_(
+        metrics_registry_, kMetricTrackedInstances, empty_tags, static_cast<double>(lanes_copy.size()));
+
+    for (const auto &[instance_id, lane] : lanes_copy) {
+        std::lock_guard<std::mutex> guard(lane->mutex);
+
+        const int64_t bytes_per_block = ResolveBytesPerBlock(instance_id, *lane);
+
+        MetricsTags instance_tags{{"instance_id", instance_id}};
+        REPORT_DYNAMIC_GAUGE_(
+            metrics_registry_, kMetricTrackedBlocks, instance_tags, static_cast<double>(lane->profiler.tracked_blocks()));
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_,
+                              kMetricTrackedCapacityBlocks,
+                              instance_tags,
+                              static_cast<double>(lane->profiler.tracked_capacity_blocks()));
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_,
+                              kMetricMemoryBytes,
+                              instance_tags,
+                              static_cast<double>(lane->profiler.memory_usage_bytes()));
+
+        if (bytes_per_block <= 0) {
+            // Cannot translate the GB grid into blocks yet; retried next round.
+            continue;
+        }
+        std::vector<double> capacity_blocks;
+        capacity_blocks.reserve(config_.capacity_gb_grid.size());
+        for (const double capacity_gb : config_.capacity_gb_grid) {
+            capacity_blocks.push_back(capacity_gb * kGiB / static_cast<double>(bytes_per_block));
+        }
+
+        const auto report_scope = [&](const char *scope, const MrcProfiler::Snapshot &snapshot) {
+            MetricsTags scope_tags = instance_tags;
+            scope_tags["scope"] = scope;
+            REPORT_DYNAMIC_GAUGE_(
+                metrics_registry_, kMetricMaxTrackedHitRate, scope_tags, snapshot.max_tracked_hit_rate);
+            for (size_t i = 0; i < config_.capacity_gb_grid.size(); ++i) {
+                MetricsTags point_tags = scope_tags;
+                point_tags["capacity_gb"] = FormatCapacityGb(config_.capacity_gb_grid[i]);
+                const bool covered = snapshot.hit_rates[i] >= 0.0;
+                REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricExactCoverage, point_tags, covered ? 1.0 : 0.0);
+                if (covered) {
+                    REPORT_DYNAMIC_GAUGE_(
+                        metrics_registry_, kMetricTheoreticalHitRate, point_tags, snapshot.hit_rates[i]);
+                }
+            }
+        };
+
+        MrcProfiler::Snapshot snapshot;
+        lane->profiler.QueryCumulative(capacity_blocks, snapshot);
+        report_scope("cumulative", snapshot);
+        if (lane->profiler.QueryWindow(capacity_blocks, snapshot)) {
+            report_scope("window", snapshot);
+        }
+    }
+}
+
+std::string OnlineMrcEventConsumer::DumpCurvesJson() const {
+    std::map<std::string, std::shared_ptr<Lane>> lanes_copy;
+    {
+        std::lock_guard<std::mutex> guard(lanes_mutex_);
+        lanes_copy = lanes_;
+    }
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+    const auto write_curve = [&writer](const std::vector<MrcProfiler::CurvePoint> &points, int64_t bytes_per_block) {
+        writer.StartArray();
+        for (const auto &point : points) {
+            writer.StartObject();
+            writer.Key("capacity_blocks");
+            writer.Double(point.capacity_blocks);
+            if (bytes_per_block > 0) {
+                writer.Key("capacity_gb");
+                writer.Double(point.capacity_blocks * static_cast<double>(bytes_per_block) / kGiB);
+            }
+            writer.Key("hit_rate");
+            writer.Double(point.hit_rate);
+            writer.EndObject();
+        }
+        writer.EndArray();
+    };
+
+    writer.StartObject();
+    writer.Key("instances");
+    writer.StartArray();
+    for (const auto &[instance_id, lane] : lanes_copy) {
+        std::lock_guard<std::mutex> guard(lane->mutex);
+        writer.StartObject();
+        writer.Key("instance_id");
+        writer.String(instance_id.c_str());
+        writer.Key("bytes_per_block");
+        writer.Int64(lane->bytes_per_block);
+        writer.Key("engine");
+        writer.String("lite_hit_exact_bounded");
+        writer.Key("tracked_blocks");
+        writer.Int64(lane->profiler.tracked_blocks());
+        writer.Key("tracked_capacity_blocks");
+        writer.Int64(lane->profiler.tracked_capacity_blocks());
+        writer.Key("memory_bytes");
+        writer.Int64(lane->profiler.memory_usage_bytes());
+
+        MrcProfiler::Snapshot snapshot;
+        lane->profiler.QueryCumulative({}, snapshot);
+        writer.Key("cumulative");
+        writer.StartObject();
+        writer.Key("total_accesses");
+        writer.Double(snapshot.total_accesses);
+        writer.Key("max_tracked_hit_rate");
+        writer.Double(snapshot.max_tracked_hit_rate);
+        writer.Key("curve");
+        write_curve(lane->profiler.DumpCurve(/*cumulative=*/true), lane->bytes_per_block);
+        writer.EndObject();
+
+        if (lane->profiler.QueryWindow({}, snapshot)) {
+            writer.Key("window");
+            writer.StartObject();
+            writer.Key("total_accesses");
+            writer.Double(snapshot.total_accesses);
+            writer.Key("max_tracked_hit_rate");
+            writer.Double(snapshot.max_tracked_hit_rate);
+            writer.Key("curve");
+            write_curve(lane->profiler.DumpCurve(/*cumulative=*/false), lane->bytes_per_block);
+            writer.EndObject();
+        }
+        writer.EndObject();
+    }
+    writer.EndArray();
+    writer.EndObject();
+    return buffer.GetString();
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/mrc_event_consumer.h
+++ b/kv_cache_manager/mrc/mrc_event_consumer.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "kv_cache_manager/event/event_publisher.h"
+#include "kv_cache_manager/mrc/mrc_profiler.h"
+#include "kv_cache_manager/mrc/online_mrc_config.h"
+
+namespace kv_cache_manager {
+
+class LoopThread;
+class MetricsRegistry;
+
+// Observation-only online MRC pipeline.
+//
+// Registered on the EventManager next to the log publisher, it consumes
+// CacheGetEvent (the same access stream the offline trace replay uses),
+// feeds each instance's block keys into a per-instance MrcProfiler on a
+// single background thread, and periodically reports theoretical hit rate
+// gauges to the MetricsRegistry. Nothing reads its state on the request
+// path; dropping events under pressure only degrades observation quality.
+class OnlineMrcEventConsumer : public EventPublisher {
+public:
+    // Resolves bytes-per-block for an instance (sum of location spec sizes).
+    // Returns 0 when unknown; the consumer retries on later report rounds and
+    // falls back to config.default_bytes_per_block.
+    using BytesPerBlockResolver = std::function<int64_t(const std::string &instance_id)>;
+
+    OnlineMrcEventConsumer(const OnlineMrcConfig &config,
+                           std::shared_ptr<MetricsRegistry> metrics_registry,
+                           BytesPerBlockResolver bytes_per_block_resolver);
+    ~OnlineMrcEventConsumer() override;
+
+    bool Init(const std::string &config) override;
+    bool Publish(const std::shared_ptr<BaseEvent> &event) override;
+    bool Stop() override;
+
+    // Full per-instance curves as a JSON document (debug endpoint).
+    std::string DumpCurvesJson() const;
+
+private:
+    struct Lane {
+        explicit Lane(const MrcProfiler::Options &options) : profiler(options) {}
+        mutable std::mutex mutex;
+        MrcProfiler profiler;
+        int64_t bytes_per_block = 0; // resolved lazily; 0 = unknown
+    };
+
+    void WorkerThread();
+    void ReportMetrics();
+    std::shared_ptr<Lane> GetOrCreateLane(const std::string &instance_id);
+    int64_t ResolveBytesPerBlock(const std::string &instance_id, Lane &lane);
+
+    OnlineMrcConfig config_;
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    BytesPerBlockResolver bytes_per_block_resolver_;
+
+    std::thread worker_;
+    std::shared_ptr<LoopThread> report_thread_;
+
+    mutable std::mutex lanes_mutex_;
+    std::map<std::string, std::shared_ptr<Lane>> lanes_;
+    bool lane_overflow_logged_ = false;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/mrc_profiler.cc
+++ b/kv_cache_manager/mrc/mrc_profiler.cc
@@ -1,0 +1,145 @@
+#include "kv_cache_manager/mrc/mrc_profiler.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace kv_cache_manager {
+
+namespace {
+
+int64_t NormalizeMaxTrackedBlocks(int64_t value) { return value > 0 ? value : 65536; }
+
+} // namespace
+
+MrcProfiler::Histogram::Histogram(int64_t max_capacity)
+    : max_capacity_blocks(std::max<int64_t>(max_capacity, 1))
+    , fenwick(static_cast<size_t>(max_capacity_blocks) + 1, 0) {}
+
+void MrcProfiler::Histogram::AddThreshold(uint64_t threshold) {
+    if (threshold == 0 || threshold > static_cast<uint64_t>(max_capacity_blocks)) {
+        return;
+    }
+    for (size_t i = static_cast<size_t>(threshold); i < fenwick.size(); i += i & (~i + 1)) {
+        ++fenwick[i];
+    }
+}
+
+void MrcProfiler::Histogram::Reset() {
+    std::fill(fenwick.begin(), fenwick.end(), 0);
+    total_accesses = 0;
+}
+
+uint64_t MrcProfiler::Histogram::HitsAt(uint64_t capacity_blocks) const {
+    size_t i = static_cast<size_t>(std::min<uint64_t>(capacity_blocks, max_capacity_blocks));
+    uint64_t hits = 0;
+    for (; i > 0; i -= i & (~i + 1)) {
+        hits += fenwick[i];
+    }
+    return hits;
+}
+
+MrcProfiler::MrcProfiler(const Options &options)
+    : options_(options)
+    , core_(std::min<int64_t>(NormalizeMaxTrackedBlocks(options.max_tracked_blocks), 4096),
+            NormalizeMaxTrackedBlocks(options.max_tracked_blocks))
+    , window_(NormalizeMaxTrackedBlocks(options.max_tracked_blocks))
+    , completed_window_(NormalizeMaxTrackedBlocks(options.max_tracked_blocks))
+    , cumulative_(NormalizeMaxTrackedBlocks(options.max_tracked_blocks)) {
+    options_.max_tracked_blocks = NormalizeMaxTrackedBlocks(options.max_tracked_blocks);
+}
+
+void MrcProfiler::Observe(const std::vector<int64_t> &keys, int64_t now_us) {
+    if (keys.empty()) {
+        return;
+    }
+    RotateWindowIfNeeded(now_us);
+    thresholds_.clear();
+    core_.ProcessRequest(keys, thresholds_);
+    window_.AddAccesses(keys.size());
+    cumulative_.AddAccesses(keys.size());
+    for (const uint64_t threshold : thresholds_) {
+        window_.AddThreshold(threshold);
+        cumulative_.AddThreshold(threshold);
+    }
+}
+
+void MrcProfiler::RotateWindowIfNeeded(int64_t now_us) {
+    if (window_start_us_ < 0) {
+        window_start_us_ = now_us;
+        return;
+    }
+    if (options_.window_seconds <= 0) {
+        return;
+    }
+    const int64_t window_us = options_.window_seconds * 1000000;
+    if (now_us - window_start_us_ >= window_us) {
+        completed_window_ = window_;
+        has_completed_window_ = true;
+        window_.Reset();
+        window_start_us_ = now_us;
+    }
+}
+
+void MrcProfiler::FillSnapshot(const Histogram &hist,
+                               const std::vector<double> &capacity_blocks,
+                               Snapshot &out) const {
+    out.total_accesses = static_cast<double>(hist.total_accesses);
+    out.hit_rates.assign(capacity_blocks.size(), 0.0);
+    if (hist.total_accesses == 0) {
+        out.max_tracked_hit_rate = 0;
+        return;
+    }
+    const double denominator = static_cast<double>(hist.total_accesses);
+    out.max_tracked_hit_rate = static_cast<double>(hist.HitsAt(options_.max_tracked_blocks)) / denominator;
+    for (size_t i = 0; i < capacity_blocks.size(); ++i) {
+        if (capacity_blocks[i] < 1.0 || capacity_blocks[i] > static_cast<double>(options_.max_tracked_blocks)) {
+            out.hit_rates[i] = -1.0; // explicitly outside the exact coverage boundary
+            continue;
+        }
+        const auto capacity = static_cast<uint64_t>(std::floor(capacity_blocks[i]));
+        out.hit_rates[i] = static_cast<double>(hist.HitsAt(capacity)) / denominator;
+    }
+}
+
+bool MrcProfiler::QueryWindow(const std::vector<double> &capacity_blocks, Snapshot &out) const {
+    if (!has_completed_window_) {
+        return false;
+    }
+    FillSnapshot(completed_window_, capacity_blocks, out);
+    return true;
+}
+
+void MrcProfiler::QueryCumulative(const std::vector<double> &capacity_blocks, Snapshot &out) const {
+    FillSnapshot(cumulative_, capacity_blocks, out);
+}
+
+std::vector<MrcProfiler::CurvePoint> MrcProfiler::DumpCurveFrom(const Histogram &hist) const {
+    std::vector<CurvePoint> points;
+    if (hist.total_accesses == 0) {
+        return points;
+    }
+    uint64_t previous_hits = 0;
+    for (int64_t capacity = 1; capacity <= options_.max_tracked_blocks; ++capacity) {
+        const uint64_t hits = hist.HitsAt(static_cast<uint64_t>(capacity));
+        if (hits == previous_hits) {
+            continue;
+        }
+        points.push_back(
+            {static_cast<double>(capacity), static_cast<double>(hits) / static_cast<double>(hist.total_accesses)});
+        previous_hits = hits;
+    }
+    return points;
+}
+
+std::vector<MrcProfiler::CurvePoint> MrcProfiler::DumpCurve(bool cumulative) const {
+    return DumpCurveFrom(cumulative ? cumulative_ : completed_window_);
+}
+
+int64_t MrcProfiler::memory_usage_bytes() const {
+    return core_.memory_usage_bytes() + static_cast<int64_t>(thresholds_.capacity() * sizeof(uint64_t)) +
+           static_cast<int64_t>((window_.fenwick.capacity() + completed_window_.fenwick.capacity() +
+                                 cumulative_.fenwick.capacity()) *
+                                sizeof(uint64_t));
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/mrc_profiler.h
+++ b/kv_cache_manager/mrc/mrc_profiler.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "kv_cache_manager/mrc/lite_hit_core.h"
+
+namespace kv_cache_manager {
+
+// Exact, request-level online MRC profiler for one instance lane.
+//
+// Each Observe call is one complete prefix request. LiteHitCore evaluates the
+// prefix against the request-start LRU snapshot and commits the request
+// tail-to-head, matching the formal offline LiteHit engine. The LRU stack is
+// capped at max_tracked_blocks; this does not approximate points at or below
+// that capacity because older entries are misses for all such points.
+//
+// Not thread-safe; callers serialize access externally.
+class MrcProfiler {
+public:
+    struct Options {
+        int64_t max_tracked_blocks = 65536;
+        int64_t window_seconds = 3600;
+    };
+
+    struct Snapshot {
+        double total_accesses = 0;
+        // Hit rate at max_tracked_blocks. This is a finite-capacity bound, not
+        // an infinite-capacity compulsory-miss estimate.
+        double max_tracked_hit_rate = 0;
+        std::vector<double> hit_rates;
+    };
+
+    struct CurvePoint {
+        double capacity_blocks = 0;
+        double hit_rate = 0;
+    };
+
+    explicit MrcProfiler(const Options &options);
+
+    MrcProfiler(const MrcProfiler &) = delete;
+    MrcProfiler &operator=(const MrcProfiler &) = delete;
+
+    // One complete request, in prefix order.
+    void Observe(const std::vector<int64_t> &keys, int64_t now_us);
+
+    bool QueryWindow(const std::vector<double> &capacity_blocks, Snapshot &out) const;
+    void QueryCumulative(const std::vector<double> &capacity_blocks, Snapshot &out) const;
+    std::vector<CurvePoint> DumpCurve(bool cumulative) const;
+
+    int64_t tracked_blocks() const { return core_.unique_blocks(); }
+    int64_t tracked_capacity_blocks() const { return options_.max_tracked_blocks; }
+    int64_t memory_usage_bytes() const;
+
+private:
+    struct Histogram {
+        explicit Histogram(int64_t max_capacity_blocks = 1);
+
+        void AddThreshold(uint64_t threshold);
+        void AddAccesses(uint64_t count) { total_accesses += count; }
+        void Reset();
+        uint64_t HitsAt(uint64_t capacity_blocks) const;
+
+        int64_t max_capacity_blocks = 1;
+        std::vector<uint64_t> fenwick;
+        uint64_t total_accesses = 0;
+    };
+
+    void RotateWindowIfNeeded(int64_t now_us);
+    void FillSnapshot(const Histogram &hist,
+                      const std::vector<double> &capacity_blocks,
+                      Snapshot &out) const;
+    std::vector<CurvePoint> DumpCurveFrom(const Histogram &hist) const;
+
+    Options options_;
+    LiteHitCore core_;
+    std::vector<uint64_t> thresholds_;
+
+    Histogram window_;
+    Histogram completed_window_;
+    bool has_completed_window_ = false;
+    int64_t window_start_us_ = -1;
+    Histogram cumulative_;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/online_mrc_config.h
+++ b/kv_cache_manager/mrc/online_mrc_config.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace kv_cache_manager {
+
+// Configuration for the observation-only online MRC profiler.
+// All fields have conservative defaults; the feature is off unless
+// explicitly enabled via server config.
+struct OnlineMrcConfig {
+    bool enable = false;
+    // Largest capacity (in blocks) for which the exact online curve is
+    // maintained. The LRU state is safely truncated below this boundary, so
+    // memory is bounded while every reported point <= the limit stays exact.
+    int64_t max_tracked_blocks = 65536;
+    // Tumbling window length for the "recent window" curve.
+    int64_t window_seconds = 3600;
+    // Interval of the full Facts -> MRC projection. Lightweight connection and
+    // queue metrics continue to use the optimizer metrics report interval.
+    int64_t report_interval_seconds = 60;
+    // Capacity grid (GB) at which theoretical hit rate gauges are reported.
+    std::vector<double> capacity_gb_grid = {64, 128, 256, 340, 512, 1024};
+    // Fallback bytes-per-block when the instance info lookup fails;
+    // 0 means "skip GB-based gauges until the lookup succeeds".
+    int64_t default_bytes_per_block = 0;
+    // Upper bound of concurrently profiled instances. Facts within every
+    // accepted instance are retained for the process lifetime without a
+    // count or time bound.
+    int32_t max_instances = 256;
+    // Bound of the pending event queue (events, not keys).
+    int64_t queue_max_size = 10000;
+    // Optimizer-side ingress queue bound (RPC batches).
+    int64_t receiver_queue_max_batches = 1024;
+    // Release lanes with no observed request for this duration; 0 disables.
+    int64_t idle_expire_seconds = 86400;
+
+    // The optimizer discovers and connects to all KVCM nodes itself. When the
+    // feature is enabled this URL is required; KVCM never needs an optimizer
+    // endpoint.
+    std::string kvcm_service_discovery_url;
+    int64_t discovery_refresh_interval_ms = 30000;
+    int64_t connect_timeout_ms = 500;
+    int64_t reconnect_interval_ms = 1000;
+    int64_t max_frame_bytes = 8 * 1024 * 1024;
+
+};
+
+struct OptimizerTraceForwarderConfig {
+    bool enable = false;
+    std::string endpoint;
+    std::string cluster;
+    int64_t queue_max_size = 10000;
+    int64_t max_batch_keys = 8192;
+    int64_t rpc_timeout_ms = 200;
+    int64_t report_interval_seconds = 10;
+    // Empty keeps the historical "all instances" behavior. Production
+    // canaries should set exact instance IDs so a shared KVCM deployment does
+    // not forward unrelated models into the observation stream.
+    std::unordered_set<std::string> instance_allowlist;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/online_mrc_fact_registry.cc
+++ b/kv_cache_manager/mrc/online_mrc_fact_registry.cc
@@ -1,0 +1,486 @@
+#include "kv_cache_manager/mrc/online_mrc_fact_registry.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <exception>
+#include <limits>
+
+#include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/optimizer/config/optimizer_instance_group.h"
+#include "kv_cache_manager/optimizer/config/optimizer_instance_info.h"
+#include "kv_cache_manager/optimizer/config/optimizer_registry_manager.h"
+#include "kv_cache_manager/optimizer/liteHit/request_preprocess.h"
+#include "kv_cache_manager/optimizer/online_runtime/online_optimizer_manager.h"
+
+namespace kv_cache_manager {
+namespace {
+
+constexpr char kMetricTheoreticalHitRate[] = "online_mrc.theoretical_hit_rate";
+constexpr char kMetricFactCount[] = "online_mrc.fact_count";
+constexpr char kMetricFactMemoryBytes[] = "online_mrc.fact_memory_bytes";
+constexpr char kMetricLiteHitMemoryBytes[] = "online_mrc.lite_hit_memory_bytes";
+constexpr char kMetricInstanceMemoryBytes[] = "online_mrc.instance_memory_bytes";
+constexpr char kMetricTotalMemoryBytes[] = "online_mrc.total_memory_bytes";
+constexpr char kMetricProjectionDurationUs[] = "online_mrc.projection_duration_us";
+constexpr char kMetricProjectionFactScans[] = "online_mrc.projection_fact_scans";
+constexpr char kMetricTrackedInstances[] = "online_mrc.tracked_instances";
+constexpr char kMetricTrackedGroups[] = "online_mrc.tracked_groups";
+constexpr char kMetricGroupInstances[] = "online_mrc.group_instances";
+constexpr char kMetricOutOfOrderEvents[] = "online_mrc.out_of_order_events";
+constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
+
+std::string FormatDouble(double value) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%g", value);
+    return buffer;
+}
+
+OptimizerInstanceInfo ToInstanceInfo(const proto::optimizer::CacheEventBatch &batch) {
+    const auto &meta = batch.instance_meta();
+    std::vector<LocationSpecInfo> specs;
+    specs.reserve(meta.location_spec_infos_size());
+    for (const auto &spec : meta.location_spec_infos()) {
+        specs.emplace_back(spec.name(), spec.size());
+    }
+
+    std::vector<LocationSpecGroup> spec_groups;
+    spec_groups.reserve(meta.location_spec_groups_size());
+    for (const auto &group : meta.location_spec_groups()) {
+        spec_groups.emplace_back(group.name(), std::vector<std::string>(group.spec_names().begin(),
+                                                                       group.spec_names().end()));
+    }
+
+    const auto &state = meta.optimizer_state_info();
+    return OptimizerInstanceInfo(batch.instance_group(),
+                                 batch.instance_id(),
+                                 meta.block_size(),
+                                 specs,
+                                 spec_groups,
+                                 meta.linear_step(),
+                                 OptimizerStateInfo(state.full_location_spec_group_name(),
+                                                    state.linear_location_spec_group_name()));
+}
+
+bool SameFormalGroup(const OptimizerInstanceGroup &lhs, const OptimizerInstanceGroup &rhs) {
+    return lhs.name() == rhs.name() && lhs.capacity_gb() == rhs.capacity_gb() &&
+           lhs.eviction_policy() == rhs.eviction_policy() && lhs.shared_group_quota() == rhs.shared_group_quota() &&
+           lhs.enable_theoretical_max_cache() == rhs.enable_theoretical_max_cache() &&
+           lhs.ttl_seconds() == rhs.ttl_seconds() && lhs.enable_prefix_hash() == rhs.enable_prefix_hash();
+}
+
+} // namespace
+
+OnlineMrcFactRegistry::OnlineMrcFactRegistry(const OnlineMrcConfig &config,
+                                             const std::vector<OptimizerInstanceGroup> &instance_groups,
+                                             std::shared_ptr<MetricsRegistry> metrics_registry,
+                                             std::shared_ptr<OnlineOptimizerManager> manager)
+    : config_(config),
+      instance_groups_(instance_groups),
+      metrics_registry_(std::move(metrics_registry)),
+      manager_(std::move(manager)),
+      capacity_gb_grid_(config.capacity_gb_grid) {}
+
+bool OnlineMrcFactRegistry::Init() {
+    if (!manager_ || !manager_->registry_manager() || !ValidateCapacityGrid(config_.capacity_gb_grid) ||
+        instance_groups_.empty()) {
+        KVCM_LOG_ERROR("online mrc: manager, projection grid, and formal instance groups are required");
+        return false;
+    }
+
+    std::vector<OptimizerInstanceGroup> desired_groups;
+    desired_groups.reserve(instance_groups_.size());
+    for (const auto &group : instance_groups_) {
+        std::string invalid_fields;
+        if (!group.ValidateRequiredFields(invalid_fields) || !group.enable_prefix_hash()) {
+            KVCM_LOG_ERROR("online mrc: invalid formal group[%s] or enable_prefix_hash is not true: %s",
+                           group.name().c_str(),
+                           invalid_fields.c_str());
+            return false;
+        }
+        const auto existing = manager_->registry_manager()->GetInstanceGroup(group.name());
+        if (existing && !SameFormalGroup(*existing, group)) {
+            KVCM_LOG_ERROR("online mrc: formal group[%s] already exists with different configuration; refusing to "
+                           "modify it",
+                           group.name().c_str());
+            return false;
+        }
+        desired_groups.push_back(group);
+    }
+
+    for (const auto &group : desired_groups) {
+        if (!manager_->registry_manager()->GetInstanceGroup(group.name())) {
+            const ErrorCode ec = manager_->CreateInstanceGroup(group);
+            if (ec != EC_OK) {
+                KVCM_LOG_ERROR("online mrc: CreateInstanceGroup[%s] failed, ec=%d",
+                               group.name().c_str(),
+                               static_cast<int>(ec));
+                return false;
+            }
+        }
+    }
+    {
+        std::lock_guard<std::mutex> guard(contexts_mutex_);
+        for (const auto &group : desired_groups) {
+            groups_.emplace(group.name(), GroupContext{});
+        }
+        initialized_ = true;
+    }
+    return true;
+}
+
+bool OnlineMrcFactRegistry::RegisterFormalInstance(const proto::optimizer::CacheEventBatch &batch,
+                                                   std::string &serialized_instance_info,
+                                                   RegisterInstanceResult &result) {
+    if (!manager_ || batch.instance_meta().linear_step() != 0) {
+        KVCM_LOG_WARN("online mrc: instance[%s] requires full-only metadata (linear_step=0)",
+                      batch.instance_id().c_str());
+        return false;
+    }
+    const OptimizerInstanceInfo instance_info = ToInstanceInfo(batch);
+    serialized_instance_info = instance_info.ToJsonString();
+
+    bool same_active_instance = false;
+    const ErrorCode state_ec = manager_->GetInstanceState(batch.instance_id(), [&](const InstanceState &state) {
+        if (state.instance_info && state.instance_info->ToJsonString() == serialized_instance_info) {
+            same_active_instance = true;
+            result.size_full_only = state.size_full_only;
+            result.size_full_linear = state.size_full_linear;
+        }
+    });
+    if (state_ec == EC_OK && same_active_instance && result.size_full_only > 0) {
+        return true;
+    }
+
+    const ErrorCode ec = manager_->RegisterInstance(instance_info, result);
+    if (ec != EC_OK || result.size_full_only <= 0) {
+        KVCM_LOG_ERROR("online mrc: formal RegisterInstance[%s] failed, ec=%d size_full_only=%ld",
+                       batch.instance_id().c_str(),
+                       static_cast<int>(ec),
+                       static_cast<long>(result.size_full_only));
+        return false;
+    }
+    return true;
+}
+
+std::shared_ptr<OnlineMrcFactRegistry::InstanceContext>
+OnlineMrcFactRegistry::RegisterOrGetInstance(const proto::optimizer::CacheEventBatch &batch) {
+    std::lock_guard<std::mutex> guard(contexts_mutex_);
+    const auto existing = contexts_.find(batch.instance_id());
+    if (existing != contexts_.end()) {
+        return existing->second;
+    }
+    if (!initialized_ || groups_.find(batch.instance_group()) == groups_.end()) {
+        KVCM_LOG_WARN("online mrc: reject instance[%s] from unconfigured formal group[%s]",
+                      batch.instance_id().c_str(),
+                      batch.instance_group().c_str());
+        return nullptr;
+    }
+    if (static_cast<int32_t>(contexts_.size()) >= config_.max_instances) {
+        KVCM_LOG_WARN("online mrc: instance limit[%d] reached, reject instance[%s]",
+                      config_.max_instances,
+                      batch.instance_id().c_str());
+        return nullptr;
+    }
+
+    RegisterInstanceResult register_result;
+    std::string serialized_instance_info;
+    if (!RegisterFormalInstance(batch, serialized_instance_info, register_result)) {
+        return nullptr;
+    }
+    const auto formal_group = manager_->registry_manager()->GetInstanceGroup(batch.instance_group());
+    if (!formal_group) {
+        return nullptr;
+    }
+
+    auto context = std::make_shared<InstanceContext>();
+    context->instance_id = batch.instance_id();
+    context->instance_group = batch.instance_group();
+    context->serialized_instance_info = std::move(serialized_instance_info);
+    context->block_size = batch.instance_meta().block_size();
+    context->block_bytes = register_result.size_full_only;
+    context->enable_prefix_hash = formal_group->enable_prefix_hash();
+    contexts_.emplace(context->instance_id, context);
+    groups_.at(context->instance_group).instance_ids.emplace(context->instance_id);
+    return context;
+}
+
+void OnlineMrcFactRegistry::MoveInstanceToGroup(const std::string &instance_id,
+                                                const std::string &old_group,
+                                                const std::string &new_group) {
+    if (old_group == new_group) {
+        return;
+    }
+    std::lock_guard<std::mutex> guard(contexts_mutex_);
+    const auto old_it = groups_.find(old_group);
+    if (old_it != groups_.end()) {
+        old_it->second.instance_ids.erase(instance_id);
+    }
+    groups_.at(new_group).instance_ids.emplace(instance_id);
+}
+
+bool OnlineMrcFactRegistry::Observe(const proto::optimizer::CacheEventBatch &batch) {
+    if (batch.instance_id().empty() || batch.instance_group().empty() || !batch.has_instance_meta() ||
+        batch.events().empty()) {
+        return false;
+    }
+
+    auto context = RegisterOrGetInstance(batch);
+    if (!context) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(context->mutex);
+    const std::string candidate_info = ToInstanceInfo(batch).ToJsonString();
+    if (candidate_info != context->serialized_instance_info) {
+        {
+            std::lock_guard<std::mutex> contexts_guard(contexts_mutex_);
+            if (groups_.find(batch.instance_group()) == groups_.end()) {
+                KVCM_LOG_WARN("online mrc: reject metadata change for instance[%s] to unconfigured group[%s]",
+                              batch.instance_id().c_str(),
+                              batch.instance_group().c_str());
+                return false;
+            }
+        }
+        RegisterInstanceResult register_result;
+        std::string serialized_instance_info;
+        if (!RegisterFormalInstance(batch, serialized_instance_info, register_result)) {
+            return false;
+        }
+        const auto formal_group = manager_->registry_manager()->GetInstanceGroup(batch.instance_group());
+        if (!formal_group) {
+            return false;
+        }
+        MoveInstanceToGroup(context->instance_id, context->instance_group, batch.instance_group());
+        context->instance_group = batch.instance_group();
+        context->serialized_instance_info = std::move(serialized_instance_info);
+        context->block_size = batch.instance_meta().block_size();
+        context->block_bytes = register_result.size_full_only;
+        context->enable_prefix_hash = formal_group->enable_prefix_hash();
+        context->lite_hit.Reset();
+        context->facts.clear();
+        context->last_timestamp_ns = 0;
+        context->out_of_order_events = 0;
+        ++context->meta_generation;
+    }
+
+    struct PreparedEvent {
+        int64_t timestamp_ns = 0;
+        NormalizedRequest request;
+    };
+    std::vector<PreparedEvent> prepared;
+    prepared.reserve(batch.events_size());
+    try {
+        for (const auto &event : batch.events()) {
+            PreparedEvent item;
+            item.timestamp_ns = event.timestamp_ns();
+            item.request = NormalizeRequest(std::vector<int64_t>(event.block_keys().begin(), event.block_keys().end()),
+                                            event.input_token_len(),
+                                            static_cast<uint64_t>(context->block_size),
+                                            context->enable_prefix_hash);
+            prepared.push_back(std::move(item));
+        }
+    } catch (const std::exception &e) {
+        KVCM_LOG_WARN("online mrc: reject invalid batch for instance[%s]: %s",
+                      batch.instance_id().c_str(),
+                      e.what());
+        return false;
+    }
+
+    for (auto &event : prepared) {
+        if (event.timestamp_ns < context->last_timestamp_ns) {
+            ++context->out_of_order_events;
+            continue;
+        }
+        context->last_timestamp_ns = event.timestamp_ns;
+        StoredFact fact;
+        fact.input_token_len = event.request.input_token_len;
+        fact.fact = context->lite_hit.ProcessRequest(event.request.block_keys);
+        context->facts.push_back(std::move(fact));
+    }
+    return true;
+}
+
+void OnlineMrcFactRegistry::ReportMetrics() {
+    if (!metrics_registry_) {
+        return;
+    }
+    const auto projection_start = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> projection_guard(projection_mutex_);
+    for (const char *metric_name :
+         {kMetricTheoreticalHitRate,
+          kMetricFactCount,
+          kMetricFactMemoryBytes,
+          kMetricLiteHitMemoryBytes,
+          kMetricInstanceMemoryBytes,
+          kMetricGroupInstances,
+          kMetricOutOfOrderEvents}) {
+        const auto data = metrics_registry_->GetMetricsData(metric_name);
+        if (data) {
+            data->RemoveByTagFilter({});
+        }
+    }
+
+    std::map<std::string, std::shared_ptr<InstanceContext>> contexts;
+    std::map<std::string, size_t> group_sizes;
+    {
+        std::lock_guard<std::mutex> guard(contexts_mutex_);
+        contexts = contexts_;
+        for (const auto &[name, group] : groups_) {
+            group_sizes.emplace(name, group.instance_ids.size());
+        }
+    }
+    const MetricsTags empty_tags;
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricTrackedInstances, empty_tags, contexts.size());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricTrackedGroups, empty_tags, group_sizes.size());
+    for (const auto &[group, instance_count] : group_sizes) {
+        const MetricsTags group_tags{{"instance_group", group}};
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricGroupInstances, group_tags, instance_count);
+    }
+
+    uint64_t total_memory_bytes = 0;
+    uint64_t projection_fact_scans = 0;
+    for (const auto &[_, context] : contexts) {
+        std::lock_guard<std::mutex> guard(context->mutex);
+        MetricsTags instance_tags{{"instance_group", context->instance_group},
+                                  {"instance_id", context->instance_id},
+                                  {"meta_generation", std::to_string(context->meta_generation)}};
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricFactCount, instance_tags, context->facts.size());
+        const uint64_t fact_memory_bytes = FactMemoryBytes(context->facts);
+        const uint64_t lite_hit_memory_bytes = context->lite_hit.memory_usage_bytes();
+        const uint64_t instance_memory_bytes = fact_memory_bytes + lite_hit_memory_bytes;
+        total_memory_bytes += instance_memory_bytes;
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricFactMemoryBytes, instance_tags, fact_memory_bytes);
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricLiteHitMemoryBytes, instance_tags, lite_hit_memory_bytes);
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricInstanceMemoryBytes, instance_tags, instance_memory_bytes);
+        REPORT_DYNAMIC_GAUGE_(
+            metrics_registry_, kMetricOutOfOrderEvents, instance_tags, context->out_of_order_events);
+        for (const double capacity_gb : capacity_gb_grid_) {
+            projection_fact_scans += context->facts.size();
+            const uint64_t capacity_bytes = static_cast<uint64_t>(capacity_gb * kGiB);
+            uint64_t total_tokens = 0;
+            uint64_t hit_tokens = 0;
+            for (const auto &stored : context->facts) {
+                const uint64_t hit_blocks = HitCurveProjector::ProjectBytes(
+                    stored.fact, capacity_bytes, static_cast<uint64_t>(context->block_bytes));
+                total_tokens += stored.input_token_len;
+                hit_tokens += std::min<uint64_t>(
+                    hit_blocks * static_cast<uint64_t>(context->block_size), stored.input_token_len);
+            }
+            MetricsTags tags = instance_tags;
+            tags["capacity_gb"] = FormatDouble(capacity_gb);
+            const double hit_rate = total_tokens == 0 ? 0.0 : static_cast<double>(hit_tokens) / total_tokens;
+            REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricTheoreticalHitRate, tags, hit_rate);
+        }
+    }
+    const auto projection_end = std::chrono::steady_clock::now();
+    const auto projection_duration_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(projection_end - projection_start).count();
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricTotalMemoryBytes, empty_tags, total_memory_bytes);
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricProjectionDurationUs, empty_tags, projection_duration_us);
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricProjectionFactScans, empty_tags, projection_fact_scans);
+}
+
+uint64_t OnlineMrcFactRegistry::FactMemoryBytes(const std::deque<StoredFact> &facts) {
+    // Account for live Fact payload and reserved hit-curve storage. std::deque
+    // implementation slack and allocator metadata are intentionally excluded;
+    // process RSS remains the authoritative OOM signal.
+    uint64_t bytes = sizeof(facts) + static_cast<uint64_t>(facts.size()) * sizeof(StoredFact);
+    for (const auto &stored : facts) {
+        bytes += static_cast<uint64_t>(stored.fact.hit_curve.capacity()) * sizeof(HitCurveSegment);
+    }
+    return bytes;
+}
+
+size_t OnlineMrcFactRegistry::InstanceCount() const {
+    std::lock_guard<std::mutex> guard(contexts_mutex_);
+    return contexts_.size();
+}
+
+size_t OnlineMrcFactRegistry::GroupCount() const {
+    std::lock_guard<std::mutex> guard(contexts_mutex_);
+    return groups_.size();
+}
+
+size_t OnlineMrcFactRegistry::GroupInstanceCount(const std::string &instance_group) const {
+    std::lock_guard<std::mutex> guard(contexts_mutex_);
+    const auto it = groups_.find(instance_group);
+    return it == groups_.end() ? 0 : it->second.instance_ids.size();
+}
+
+size_t OnlineMrcFactRegistry::FactCount(const std::string &instance_id) const {
+    std::shared_ptr<InstanceContext> context;
+    {
+        std::lock_guard<std::mutex> guard(contexts_mutex_);
+        const auto it = contexts_.find(instance_id);
+        if (it == contexts_.end()) {
+            return 0;
+        }
+        context = it->second;
+    }
+    std::lock_guard<std::mutex> guard(context->mutex);
+    return context->facts.size();
+}
+
+uint64_t OnlineMrcFactRegistry::MetaGeneration(const std::string &instance_id) const {
+    std::shared_ptr<InstanceContext> context;
+    {
+        std::lock_guard<std::mutex> guard(contexts_mutex_);
+        const auto it = contexts_.find(instance_id);
+        if (it == contexts_.end()) {
+            return 0;
+        }
+        context = it->second;
+    }
+    std::lock_guard<std::mutex> guard(context->mutex);
+    return context->meta_generation;
+}
+
+bool OnlineMrcFactRegistry::ValidateCapacityGrid(const std::vector<double> &capacity_gb_grid) {
+    if (capacity_gb_grid.empty()) {
+        return false;
+    }
+    double previous = 0.0;
+    for (const double capacity_gb : capacity_gb_grid) {
+        if (!std::isfinite(capacity_gb) || capacity_gb <= previous ||
+            capacity_gb > static_cast<double>(std::numeric_limits<int64_t>::max()) / kGiB) {
+            return false;
+        }
+        previous = capacity_gb;
+    }
+    return true;
+}
+
+bool OnlineMrcFactRegistry::UpdateCapacityGrid(const std::vector<double> &capacity_gb_grid) {
+    if (!ValidateCapacityGrid(capacity_gb_grid)) {
+        return false;
+    }
+    std::lock_guard<std::mutex> guard(projection_mutex_);
+    if (capacity_gb_grid_ == capacity_gb_grid) {
+        return true;
+    }
+    capacity_gb_grid_ = capacity_gb_grid;
+    ++projection_generation_;
+    if (metrics_registry_) {
+        const auto hit_rate_data = metrics_registry_->GetMetricsData(kMetricTheoreticalHitRate);
+        if (hit_rate_data) {
+            hit_rate_data->RemoveByTagFilter({});
+        }
+    }
+    return true;
+}
+
+std::vector<double> OnlineMrcFactRegistry::CapacityGrid() const {
+    std::lock_guard<std::mutex> guard(projection_mutex_);
+    return capacity_gb_grid_;
+}
+
+uint64_t OnlineMrcFactRegistry::ProjectionGeneration() const {
+    std::lock_guard<std::mutex> guard(projection_mutex_);
+    return projection_generation_;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/online_mrc_fact_registry.h
+++ b/kv_cache_manager/mrc/online_mrc_fact_registry.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/mrc/online_mrc_config.h"
+#include "kv_cache_manager/optimizer/config/optimizer_instance_group.h"
+#include "kv_cache_manager/optimizer/liteHit/hit_curve.h"
+#include "kv_cache_manager/optimizer/liteHit/lite_hit.h"
+#include "kv_cache_manager/protocol/protobuf/optimizer_service.pb.h"
+
+namespace kv_cache_manager {
+
+class MetricsRegistry;
+class OnlineOptimizerManager;
+struct RegisterInstanceResult;
+
+// Optimizer-owned online MRC facts. Groups and instances are registered in
+// the formal OnlineOptimizerManager/OptimizerRegistryManager. Request facts
+// stay process-memory-only and are retained without a count or time limit.
+class OnlineMrcFactRegistry {
+public:
+    OnlineMrcFactRegistry(const OnlineMrcConfig &config,
+                          const std::vector<OptimizerInstanceGroup> &instance_groups,
+                          std::shared_ptr<MetricsRegistry> metrics_registry,
+                          std::shared_ptr<OnlineOptimizerManager> manager);
+
+    // Creates every configured formal group before the stream starts.
+    bool Init();
+
+    bool Observe(const proto::optimizer::CacheEventBatch &batch);
+    void ReportMetrics();
+
+    size_t InstanceCount() const;
+    size_t GroupCount() const;
+    size_t GroupInstanceCount(const std::string &instance_group) const;
+    size_t FactCount(const std::string &instance_id) const;
+    uint64_t MetaGeneration(const std::string &instance_id) const;
+
+    // Changes only the reporting projection grid. Existing formal groups,
+    // LiteHit state, and all request facts remain unchanged.
+    bool UpdateCapacityGrid(const std::vector<double> &capacity_gb_grid);
+    std::vector<double> CapacityGrid() const;
+    uint64_t ProjectionGeneration() const;
+
+private:
+    struct StoredFact {
+        uint64_t input_token_len = 0;
+        RequestFact fact;
+    };
+
+    struct InstanceContext {
+        mutable std::mutex mutex;
+        std::string instance_id;
+        std::string instance_group;
+        std::string serialized_instance_info;
+        uint64_t meta_generation = 1;
+        int64_t last_timestamp_ns = 0;
+        uint64_t out_of_order_events = 0;
+        int32_t block_size = 0;
+        int64_t block_bytes = 0;
+        bool enable_prefix_hash = true;
+        LiteHit lite_hit;
+        std::deque<StoredFact> facts;
+    };
+
+    struct GroupContext {
+        std::set<std::string> instance_ids;
+    };
+
+    std::shared_ptr<InstanceContext> RegisterOrGetInstance(const proto::optimizer::CacheEventBatch &batch);
+    bool RegisterFormalInstance(const proto::optimizer::CacheEventBatch &batch,
+                                std::string &serialized_instance_info,
+                                RegisterInstanceResult &result);
+    void MoveInstanceToGroup(const std::string &instance_id,
+                             const std::string &old_group,
+                             const std::string &new_group);
+    static bool ValidateCapacityGrid(const std::vector<double> &capacity_gb_grid);
+    static uint64_t FactMemoryBytes(const std::deque<StoredFact> &facts);
+
+    OnlineMrcConfig config_;
+    std::vector<OptimizerInstanceGroup> instance_groups_;
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::shared_ptr<OnlineOptimizerManager> manager_;
+    mutable std::mutex contexts_mutex_;
+    std::map<std::string, std::shared_ptr<InstanceContext>> contexts_;
+    std::map<std::string, GroupContext> groups_;
+    bool initialized_ = false;
+
+    mutable std::mutex projection_mutex_;
+    std::vector<double> capacity_gb_grid_;
+    uint64_t projection_generation_ = 1;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/online_mrc_registry.cc
+++ b/kv_cache_manager/mrc/online_mrc_registry.cc
@@ -1,0 +1,326 @@
+#include "kv_cache_manager/mrc/online_mrc_registry.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+namespace kv_cache_manager {
+namespace {
+
+constexpr char kMetricTheoreticalHitRate[] = "online_mrc.theoretical_hit_rate";
+constexpr char kMetricMaxTrackedHitRate[] = "online_mrc.max_tracked_hit_rate";
+constexpr char kMetricTrackedBlocks[] = "online_mrc.tracked_blocks";
+constexpr char kMetricTrackedCapacityBlocks[] = "online_mrc.tracked_capacity_blocks";
+constexpr char kMetricMemoryBytes[] = "online_mrc.memory_bytes";
+constexpr char kMetricExactCoverage[] = "online_mrc.exact_coverage";
+constexpr char kMetricStreamComplete[] = "online_mrc.stream_complete";
+constexpr char kMetricSequenceGaps[] = "online_mrc.sequence_gaps";
+constexpr char kMetricSourceSwitches[] = "online_mrc.source_switches";
+constexpr char kMetricDroppedSpans[] = "online_mrc.dropped_spans";
+constexpr char kMetricDroppedKeys[] = "online_mrc.dropped_keys";
+constexpr char kMetricOutOfOrderSpans[] = "online_mrc.out_of_order_spans";
+constexpr char kMetricTrackedInstances[] = "online_mrc.tracked_instances";
+constexpr char kMetricReceiverQueueSize[] = "online_mrc.receiver_queue_size";
+constexpr char kMetricReceiverDroppedBatches[] = "online_mrc.receiver_dropped_batches";
+
+constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
+
+int64_t SteadyNowUs() {
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+std::string FormatCapacityGb(double capacity_gb) {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%g", capacity_gb);
+    return buf;
+}
+
+} // namespace
+
+OnlineMrcRegistry::Lane::Lane(const OnlineMrcConfig &config, OnlineMrcSpan span)
+    : profiler(MrcProfiler::Options{config.max_tracked_blocks, config.window_seconds})
+    , cluster(std::move(span.cluster))
+    , instance_group(std::move(span.instance_group))
+    , instance_id(std::move(span.instance_id))
+    , source_id(std::move(span.source_id))
+    , bytes_per_block(span.bytes_per_block)
+    , last_observed_steady_us(SteadyNowUs()) {}
+
+OnlineMrcRegistry::OnlineMrcRegistry(const OnlineMrcConfig &config,
+                                     std::shared_ptr<MetricsRegistry> metrics_registry)
+    : config_(config), metrics_registry_(std::move(metrics_registry)) {}
+
+std::shared_ptr<OnlineMrcRegistry::Lane> OnlineMrcRegistry::GetOrCreateLane(OnlineMrcSpan span) {
+    if (span.instance_id.empty()) {
+        return nullptr;
+    }
+    const LaneKey key{span.cluster, span.instance_id};
+    std::lock_guard<std::mutex> guard(lanes_mutex_);
+    auto it = lanes_.find(key);
+    if (it != lanes_.end()) {
+        return it->second;
+    }
+    if (static_cast<int32_t>(lanes_.size()) >= config_.max_instances) {
+        if (!lane_overflow_logged_) {
+            lane_overflow_logged_ = true;
+            KVCM_LOG_WARN("online mrc: lane limit[%d] reached; new instance[%s/%s] ignored",
+                          config_.max_instances,
+                          span.cluster.c_str(),
+                          span.instance_id.c_str());
+        }
+        return nullptr;
+    }
+    auto lane = std::make_shared<Lane>(config_, std::move(span));
+    lanes_.emplace(key, lane);
+    return lane;
+}
+
+bool OnlineMrcRegistry::Observe(OnlineMrcSpan span) {
+    auto lane = GetOrCreateLane(span);
+    if (!lane) {
+        RecordDropped(1, span.keys.size());
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(lane->mutex);
+    if (span.bytes_per_block > 0) {
+        if (lane->bytes_per_block == 0) {
+            lane->bytes_per_block = span.bytes_per_block;
+        } else if (lane->bytes_per_block != span.bytes_per_block) {
+            // A capacity-axis change makes old and new GB points
+            // incomparable. Keep the original axis and mark the stream.
+            ++lane->source_switches;
+        }
+    }
+    if (!span.instance_group.empty()) {
+        lane->instance_group = span.instance_group;
+    }
+
+    if (span.sequence_number > 0) {
+        if (!span.source_id.empty() && !lane->source_id.empty() && span.source_id != lane->source_id) {
+            ++lane->source_switches;
+            lane->source_id = span.source_id;
+            lane->last_sequence_number = 0;
+        } else if (lane->source_id.empty()) {
+            lane->source_id = span.source_id;
+        }
+        if (lane->last_sequence_number > 0 && span.sequence_number <= lane->last_sequence_number) {
+            out_of_order_spans_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        if (lane->last_sequence_number > 0 && span.sequence_number != lane->last_sequence_number + 1) {
+            lane->sequence_gaps += span.sequence_number - lane->last_sequence_number - 1;
+        }
+        lane->last_sequence_number = span.sequence_number;
+    }
+
+    lane->last_observed_steady_us = SteadyNowUs();
+    lane->profiler.Observe(span.keys, span.event_time_us > 0 ? span.event_time_us : lane->last_observed_steady_us);
+    return true;
+}
+
+void OnlineMrcRegistry::RecordDropped(uint64_t spans, uint64_t keys) {
+    dropped_spans_.fetch_add(spans, std::memory_order_relaxed);
+    dropped_keys_.fetch_add(keys, std::memory_order_relaxed);
+}
+
+void OnlineMrcRegistry::ReportIngressMetrics(size_t queue_size, uint64_t dropped_batches) {
+    if (!metrics_registry_) {
+        return;
+    }
+    const MetricsTags tags;
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReceiverQueueSize, tags, queue_size);
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricReceiverDroppedBatches, tags, dropped_batches);
+}
+
+size_t OnlineMrcRegistry::LaneCount() const {
+    std::lock_guard<std::mutex> guard(lanes_mutex_);
+    return lanes_.size();
+}
+
+void OnlineMrcRegistry::ExpireIdleLanes(int64_t now_steady_us) {
+    if (config_.idle_expire_seconds <= 0) {
+        return;
+    }
+    const int64_t expire_before = now_steady_us - config_.idle_expire_seconds * 1000000;
+    std::vector<LaneKey> expired;
+    {
+        std::lock_guard<std::mutex> guard(lanes_mutex_);
+        for (const auto &[key, lane] : lanes_) {
+            std::lock_guard<std::mutex> lane_guard(lane->mutex);
+            if (lane->last_observed_steady_us < expire_before) {
+                expired.push_back(key);
+            }
+        }
+        for (const auto &key : expired) {
+            lanes_.erase(key);
+        }
+    }
+    if (metrics_registry_) {
+        for (const auto &[cluster, instance_id] : expired) {
+            MetricsTags tags{{"cluster", cluster}, {"instance_id", instance_id}};
+            metrics_registry_->RemoveByTagFilter(tags);
+        }
+    }
+}
+
+void OnlineMrcRegistry::ReportMetrics() {
+    if (!metrics_registry_) {
+        return;
+    }
+    ExpireIdleLanes(SteadyNowUs());
+
+    std::map<LaneKey, std::shared_ptr<Lane>> lanes;
+    {
+        std::lock_guard<std::mutex> guard(lanes_mutex_);
+        lanes = lanes_;
+    }
+
+    const MetricsTags empty_tags;
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricTrackedInstances, empty_tags, lanes.size());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricDroppedSpans, empty_tags, dropped_spans_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricDroppedKeys, empty_tags, dropped_keys_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricOutOfOrderSpans, empty_tags, out_of_order_spans_.load());
+
+    for (const auto &entry : lanes) {
+        const auto &lane = entry.second;
+        std::lock_guard<std::mutex> guard(lane->mutex);
+        MetricsTags instance_tags{{"cluster", lane->cluster},
+                                  {"instance_group", lane->instance_group},
+                                  {"instance_id", lane->instance_id}};
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricTrackedBlocks, instance_tags, lane->profiler.tracked_blocks());
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_,
+                              kMetricTrackedCapacityBlocks,
+                              instance_tags,
+                              lane->profiler.tracked_capacity_blocks());
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricMemoryBytes, instance_tags, lane->profiler.memory_usage_bytes());
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricSequenceGaps, instance_tags, lane->sequence_gaps);
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricSourceSwitches, instance_tags, lane->source_switches);
+        REPORT_DYNAMIC_GAUGE_(metrics_registry_,
+                              kMetricStreamComplete,
+                              instance_tags,
+                              (lane->sequence_gaps == 0 && lane->source_switches == 0 &&
+                               dropped_spans_.load(std::memory_order_relaxed) == 0)
+                                  ? 1.0
+                                  : 0.0);
+
+        if (lane->bytes_per_block <= 0) {
+            continue;
+        }
+        std::vector<double> capacity_blocks;
+        for (const double capacity_gb : config_.capacity_gb_grid) {
+            capacity_blocks.push_back(capacity_gb * kGiB / lane->bytes_per_block);
+        }
+        const auto report = [&](const char *scope, const MrcProfiler::Snapshot &snapshot) {
+            MetricsTags scope_tags = instance_tags;
+            scope_tags["scope"] = scope;
+            REPORT_DYNAMIC_GAUGE_(
+                metrics_registry_, kMetricMaxTrackedHitRate, scope_tags, snapshot.max_tracked_hit_rate);
+            for (size_t i = 0; i < capacity_blocks.size(); ++i) {
+                MetricsTags tags = scope_tags;
+                tags["capacity_gb"] = FormatCapacityGb(config_.capacity_gb_grid[i]);
+                const bool covered = snapshot.hit_rates[i] >= 0;
+                REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricExactCoverage, tags, covered ? 1.0 : 0.0);
+                if (covered) {
+                    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricTheoreticalHitRate, tags, snapshot.hit_rates[i]);
+                }
+            }
+        };
+        MrcProfiler::Snapshot snapshot;
+        lane->profiler.QueryCumulative(capacity_blocks, snapshot);
+        report("cumulative", snapshot);
+        if (lane->profiler.QueryWindow(capacity_blocks, snapshot)) {
+            report("window", snapshot);
+        }
+    }
+}
+
+std::string OnlineMrcRegistry::DumpCurvesJson() const {
+    std::map<LaneKey, std::shared_ptr<Lane>> lanes;
+    {
+        std::lock_guard<std::mutex> guard(lanes_mutex_);
+        lanes = lanes_;
+    }
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    writer.StartObject();
+    writer.Key("engine");
+    writer.String("lite_hit_exact_bounded");
+    writer.Key("dropped_spans");
+    writer.Uint64(dropped_spans_.load());
+    writer.Key("dropped_keys");
+    writer.Uint64(dropped_keys_.load());
+    writer.Key("instances");
+    writer.StartArray();
+    for (const auto &entry : lanes) {
+        const auto &lane = entry.second;
+        std::lock_guard<std::mutex> guard(lane->mutex);
+        writer.StartObject();
+        writer.Key("cluster");
+        writer.String(lane->cluster.c_str());
+        writer.Key("instance_group");
+        writer.String(lane->instance_group.c_str());
+        writer.Key("instance_id");
+        writer.String(lane->instance_id.c_str());
+        writer.Key("bytes_per_block");
+        writer.Int64(lane->bytes_per_block);
+        writer.Key("tracked_capacity_blocks");
+        writer.Int64(lane->profiler.tracked_capacity_blocks());
+        writer.Key("tracked_blocks");
+        writer.Int64(lane->profiler.tracked_blocks());
+        writer.Key("memory_bytes");
+        writer.Int64(lane->profiler.memory_usage_bytes());
+        writer.Key("stream_complete");
+        writer.Bool(lane->sequence_gaps == 0 && lane->source_switches == 0 &&
+                    dropped_spans_.load(std::memory_order_relaxed) == 0);
+        writer.Key("sequence_gaps");
+        writer.Uint64(lane->sequence_gaps);
+
+        const auto write_scope = [&](const char *name, bool cumulative) {
+            MrcProfiler::Snapshot snapshot;
+            if (!cumulative && !lane->profiler.QueryWindow({}, snapshot)) {
+                return;
+            }
+            if (cumulative) {
+                lane->profiler.QueryCumulative({}, snapshot);
+            }
+            writer.Key(name);
+            writer.StartObject();
+            writer.Key("total_accesses");
+            writer.Double(snapshot.total_accesses);
+            writer.Key("max_tracked_hit_rate");
+            writer.Double(snapshot.max_tracked_hit_rate);
+            writer.Key("curve");
+            writer.StartArray();
+            for (const auto &point : lane->profiler.DumpCurve(cumulative)) {
+                writer.StartObject();
+                writer.Key("capacity_blocks");
+                writer.Double(point.capacity_blocks);
+                if (lane->bytes_per_block > 0) {
+                    writer.Key("capacity_gb");
+                    writer.Double(point.capacity_blocks * lane->bytes_per_block / kGiB);
+                }
+                writer.Key("hit_rate");
+                writer.Double(point.hit_rate);
+                writer.EndObject();
+            }
+            writer.EndArray();
+            writer.EndObject();
+        };
+        write_scope("cumulative", true);
+        write_scope("window", false);
+        writer.EndObject();
+    }
+    writer.EndArray();
+    writer.EndObject();
+    return buffer.GetString();
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/online_mrc_registry.h
+++ b/kv_cache_manager/mrc/online_mrc_registry.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "kv_cache_manager/mrc/mrc_profiler.h"
+#include "kv_cache_manager/mrc/online_mrc_config.h"
+
+namespace kv_cache_manager {
+
+class MetricsRegistry;
+
+struct OnlineMrcSpan {
+    std::string cluster;
+    std::string instance_group;
+    std::string instance_id;
+    std::string source_id;
+    int64_t bytes_per_block = 0;
+    int64_t event_time_us = 0;
+    uint64_t sequence_number = 0;
+    std::vector<int64_t> keys;
+};
+
+struct OnlineMrcBatch {
+    std::vector<OnlineMrcSpan> spans;
+    uint64_t dropped_spans = 0;
+    uint64_t dropped_keys = 0;
+};
+
+// Observation-only lane registry shared by the in-process validation path and
+// the external optimizer service. It has no control-plane or quota API.
+class OnlineMrcRegistry {
+public:
+    OnlineMrcRegistry(const OnlineMrcConfig &config, std::shared_ptr<MetricsRegistry> metrics_registry);
+
+    bool Observe(OnlineMrcSpan span);
+    void RecordDropped(uint64_t spans, uint64_t keys);
+    void ReportMetrics();
+    void ReportIngressMetrics(size_t queue_size, uint64_t dropped_batches);
+    std::string DumpCurvesJson() const;
+
+    size_t LaneCount() const;
+    uint64_t dropped_spans() const { return dropped_spans_.load(std::memory_order_relaxed); }
+
+private:
+    struct Lane {
+        Lane(const OnlineMrcConfig &config, OnlineMrcSpan span);
+
+        mutable std::mutex mutex;
+        MrcProfiler profiler;
+        std::string cluster;
+        std::string instance_group;
+        std::string instance_id;
+        std::string source_id;
+        int64_t bytes_per_block = 0;
+        int64_t last_observed_steady_us = 0;
+        uint64_t last_sequence_number = 0;
+        uint64_t sequence_gaps = 0;
+        uint64_t source_switches = 0;
+    };
+
+    using LaneKey = std::pair<std::string, std::string>; // (cluster, instance_id)
+
+    std::shared_ptr<Lane> GetOrCreateLane(OnlineMrcSpan span);
+    void ExpireIdleLanes(int64_t now_steady_us);
+
+    OnlineMrcConfig config_;
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+
+    mutable std::mutex lanes_mutex_;
+    std::map<LaneKey, std::shared_ptr<Lane>> lanes_;
+    bool lane_overflow_logged_ = false;
+
+    std::atomic<uint64_t> dropped_spans_{0};
+    std::atomic<uint64_t> dropped_keys_{0};
+    std::atomic<uint64_t> out_of_order_spans_{0};
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/online_mrc_trace_receiver.cc
+++ b/kv_cache_manager/mrc/online_mrc_trace_receiver.cc
@@ -1,0 +1,79 @@
+#include "kv_cache_manager/mrc/online_mrc_trace_receiver.h"
+
+#include <algorithm>
+
+namespace kv_cache_manager {
+
+OnlineMrcTraceReceiver::OnlineMrcTraceReceiver(std::shared_ptr<OnlineMrcRegistry> registry,
+                                               int64_t queue_max_batches)
+    : registry_(std::move(registry))
+    , queue_max_batches_(static_cast<size_t>(std::max<int64_t>(queue_max_batches, 1))) {}
+
+OnlineMrcTraceReceiver::~OnlineMrcTraceReceiver() { Stop(); }
+
+bool OnlineMrcTraceReceiver::Start() {
+    bool expected = false;
+    if (!running_.compare_exchange_strong(expected, true)) {
+        return true;
+    }
+    worker_ = std::thread(&OnlineMrcTraceReceiver::WorkerLoop, this);
+    return true;
+}
+
+void OnlineMrcTraceReceiver::Stop() {
+    if (!running_.exchange(false)) {
+        return;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
+bool OnlineMrcTraceReceiver::Enqueue(OnlineMrcBatch batch) {
+    if (!running_) {
+        return false;
+    }
+    {
+        std::lock_guard<std::mutex> guard(mutex_);
+        if (queue_.size() >= queue_max_batches_) {
+            dropped_batches_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        queue_.push_back(std::move(batch));
+    }
+    cv_.notify_one();
+    return true;
+}
+
+size_t OnlineMrcTraceReceiver::queue_size() const {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return queue_.size();
+}
+
+void OnlineMrcTraceReceiver::WorkerLoop() {
+    while (true) {
+        OnlineMrcBatch batch;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this]() { return !running_ || !queue_.empty(); });
+            if (queue_.empty()) {
+                if (!running_) {
+                    break;
+                }
+                continue;
+            }
+            batch = std::move(queue_.front());
+            queue_.pop_front();
+        }
+        if (!registry_) {
+            continue;
+        }
+        registry_->RecordDropped(batch.dropped_spans, batch.dropped_keys);
+        for (auto &span : batch.spans) {
+            registry_->Observe(std::move(span));
+        }
+    }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/online_mrc_trace_receiver.h
+++ b/kv_cache_manager/mrc/online_mrc_trace_receiver.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "kv_cache_manager/mrc/online_mrc_registry.h"
+
+namespace kv_cache_manager {
+
+// Bounded optimizer-side ingress queue. RPC handlers only validate/copy and
+// enqueue; exact Fenwick work runs on this dedicated observation thread.
+class OnlineMrcTraceReceiver {
+public:
+    OnlineMrcTraceReceiver(std::shared_ptr<OnlineMrcRegistry> registry, int64_t queue_max_batches);
+    ~OnlineMrcTraceReceiver();
+
+    bool Start();
+    void Stop();
+    bool Enqueue(OnlineMrcBatch batch);
+
+    size_t queue_size() const;
+    uint64_t dropped_batches() const { return dropped_batches_.load(std::memory_order_relaxed); }
+
+private:
+    void WorkerLoop();
+
+    std::shared_ptr<OnlineMrcRegistry> registry_;
+    size_t queue_max_batches_ = 1;
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::deque<OnlineMrcBatch> queue_;
+    std::thread worker_;
+    std::atomic<bool> running_{false};
+    std::atomic<uint64_t> dropped_batches_{0};
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/optimizer_trace_forwarder.cc
+++ b/kv_cache_manager/mrc/optimizer_trace_forwarder.cc
@@ -1,0 +1,216 @@
+#include "kv_cache_manager/mrc/optimizer_trace_forwarder.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cinttypes>
+
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+
+#include "kv_cache_manager/common/logger.h"
+#include "kv_cache_manager/common/loop_thread.h"
+#include "kv_cache_manager/common/string_util.h"
+#include "kv_cache_manager/event/spec_events/optimizer_event.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+namespace kv_cache_manager {
+namespace {
+
+constexpr char kMetricDroppedEvents[] = "optimizer_forwarder.dropped_events";
+constexpr char kMetricDroppedKeys[] = "optimizer_forwarder.dropped_keys";
+constexpr char kMetricSendFailures[] = "optimizer_forwarder.send_failures";
+constexpr char kMetricQueueSize[] = "optimizer_forwarder.queue_size";
+constexpr char kMetricSentSpans[] = "optimizer_forwarder.sent_spans_total";
+constexpr char kMetricSentKeys[] = "optimizer_forwarder.sent_keys_total";
+constexpr char kMetricFilteredSpans[] = "optimizer_forwarder.filtered_spans_total";
+constexpr char kMetricFilteredKeys[] = "optimizer_forwarder.filtered_keys_total";
+
+} // namespace
+
+OptimizerTraceForwarder::OptimizerTraceForwarder(const OptimizerTraceForwarderConfig &config,
+                                                 std::shared_ptr<MetricsRegistry> metrics_registry,
+                                                 MetadataResolver metadata_resolver)
+    : config_(config)
+    , metrics_registry_(std::move(metrics_registry))
+    , metadata_resolver_(std::move(metadata_resolver))
+    , source_id_(StringUtil::GenerateRandomString(32)) {}
+
+OptimizerTraceForwarder::~OptimizerTraceForwarder() {
+    if (running_) {
+        Stop();
+    }
+}
+
+bool OptimizerTraceForwarder::Init(const std::string &) {
+    if (config_.endpoint.empty()) {
+        KVCM_LOG_ERROR("optimizer forwarder: endpoint is empty");
+        return false;
+    }
+    InitBasicQueue(static_cast<size_t>(std::max<int64_t>(config_.queue_max_size, 1)));
+    stub_ = proto::optimizer::OptimizerService::NewStub(
+        grpc::CreateChannel(config_.endpoint, grpc::InsecureChannelCredentials()));
+    if (!stub_) {
+        return false;
+    }
+    running_ = true;
+    worker_ = std::thread(&OptimizerTraceForwarder::WorkerLoop, this);
+    report_thread_ = LoopThread::CreateLoopThread([this]() { ReportMetrics(); },
+                                                  std::max<int64_t>(config_.report_interval_seconds, 1) * 1000000,
+                                                  "optimizer_forwarder_report");
+    if (!report_thread_) {
+        Stop();
+        return false;
+    }
+    KVCM_LOG_INFO("optimizer trace forwarder started: endpoint[%s] queue[%" PRId64 "] max_batch_keys[%" PRId64 "]",
+                  config_.endpoint.c_str(),
+                  config_.queue_max_size,
+                  config_.max_batch_keys);
+    return true;
+}
+
+bool OptimizerTraceForwarder::Publish(const std::shared_ptr<BaseEvent> &event) {
+    if (!running_ || !event) {
+        return false;
+    }
+    auto cache_get = std::dynamic_pointer_cast<CacheGetEvent>(event);
+    if (!cache_get || cache_get->get_keys().empty()) {
+        return true;
+    }
+    if (!config_.instance_allowlist.empty() &&
+        config_.instance_allowlist.count(cache_get->event_source()) == 0) {
+        filtered_spans_.fetch_add(1, std::memory_order_relaxed);
+        filtered_keys_.fetch_add(cache_get->get_keys().size(), std::memory_order_relaxed);
+        return true;
+    }
+    if (!BasicEnqueue(event)) {
+        dropped_spans_.fetch_add(1, std::memory_order_relaxed);
+        dropped_keys_.fetch_add(cache_get->get_keys().size(), std::memory_order_relaxed);
+    }
+    // A drop is an observation-quality event, not an EventManager delivery
+    // failure. Returning true avoids a warning on every saturated request.
+    return true;
+}
+
+bool OptimizerTraceForwarder::Stop() {
+    if (!running_.exchange(false)) {
+        return true;
+    }
+    if (report_thread_) {
+        report_thread_->Stop();
+        report_thread_.reset();
+    }
+    if (basic_queue_) {
+        basic_queue_->queue_cv.notify_all();
+    }
+    backoff_cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+    ClearBasicQueue();
+    return true;
+}
+
+void OptimizerTraceForwarder::WorkerLoop() {
+    while (running_) {
+        BasicWait();
+        proto::optimizer::ReportAccessTraceRequest request;
+        request.set_cluster(config_.cluster);
+        request.set_trace_id(source_id_);
+
+        int64_t batch_keys = 0;
+        std::shared_ptr<BaseEvent> event;
+        while (BasicDequeue(event)) {
+            auto cache_get = std::dynamic_pointer_cast<CacheGetEvent>(event);
+            if (!cache_get || cache_get->get_keys().empty()) {
+                continue;
+            }
+            auto metadata_it = metadata_by_instance_.find(cache_get->event_source());
+            if (metadata_it == metadata_by_instance_.end() || metadata_it->second.bytes_per_block <= 0) {
+                const auto metadata = metadata_resolver_ ? metadata_resolver_(cache_get->event_source())
+                                                         : OptimizerTraceInstanceMetadata{};
+                metadata_it = metadata_by_instance_.insert_or_assign(cache_get->event_source(), metadata).first;
+            }
+            const auto &metadata = metadata_it->second;
+            if (metadata.bytes_per_block <= 0) {
+                dropped_spans_.fetch_add(1, std::memory_order_relaxed);
+                dropped_keys_.fetch_add(cache_get->get_keys().size(), std::memory_order_relaxed);
+                continue;
+            }
+            auto *span = request.add_spans();
+            span->set_instance_group(metadata.instance_group);
+            span->set_instance_id(cache_get->event_source());
+            span->set_block_size(metadata.block_size);
+            span->set_bytes_per_block(metadata.bytes_per_block);
+            span->set_event_time_us(cache_get->event_trigger_time_us());
+            span->set_source_id(source_id_);
+            span->set_sequence_number(++next_sequence_by_instance_[cache_get->event_source()]);
+            for (const int64_t key : cache_get->get_keys()) {
+                span->add_keys(key);
+            }
+            batch_keys += cache_get->get_keys().size();
+            if (batch_keys >= std::max<int64_t>(config_.max_batch_keys, 1)) {
+                break;
+            }
+        }
+        if (request.spans().empty()) {
+            continue;
+        }
+        const uint64_t dropped_spans = dropped_spans_.load(std::memory_order_relaxed);
+        const uint64_t dropped_keys = dropped_keys_.load(std::memory_order_relaxed);
+        request.set_dropped_spans(dropped_spans - acknowledged_dropped_spans_);
+        request.set_dropped_keys(dropped_keys - acknowledged_dropped_keys_);
+        if (Send(request)) {
+            acknowledged_dropped_spans_ = dropped_spans;
+            acknowledged_dropped_keys_ = dropped_keys;
+            consecutive_send_failures_ = 0;
+        } else {
+            ++consecutive_send_failures_;
+            const int64_t shift = std::min<int64_t>(consecutive_send_failures_ - 1, 5);
+            const auto delay = std::chrono::seconds(std::min<int64_t>(int64_t{1} << shift, 30));
+            std::unique_lock<std::mutex> lock(backoff_mutex_);
+            backoff_cv_.wait_for(lock, delay, [this]() { return !running_; });
+        }
+    }
+}
+
+bool OptimizerTraceForwarder::Send(proto::optimizer::ReportAccessTraceRequest &request) {
+    grpc::ClientContext context;
+    context.set_deadline(std::chrono::system_clock::now() +
+                         std::chrono::milliseconds(std::max<int64_t>(config_.rpc_timeout_ms, 1)));
+    proto::optimizer::CommonResponse response;
+    const grpc::Status status = stub_->ReportAccessTrace(&context, request, &response);
+    if (!status.ok() || response.header().status().code() != proto::optimizer::OK) {
+        send_failures_.fetch_add(1, std::memory_order_relaxed);
+        uint64_t keys = 0;
+        for (const auto &span : request.spans()) {
+            keys += span.keys_size();
+        }
+        dropped_spans_.fetch_add(request.spans_size(), std::memory_order_relaxed);
+        dropped_keys_.fetch_add(keys, std::memory_order_relaxed);
+        return false;
+    }
+    uint64_t keys = 0;
+    for (const auto &span : request.spans()) {
+        keys += span.keys_size();
+    }
+    sent_spans_.fetch_add(request.spans_size(), std::memory_order_relaxed);
+    sent_keys_.fetch_add(keys, std::memory_order_relaxed);
+    return true;
+}
+
+void OptimizerTraceForwarder::ReportMetrics() {
+    if (!metrics_registry_) {
+        return;
+    }
+    const MetricsTags tags;
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricDroppedEvents, tags, dropped_spans_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricDroppedKeys, tags, dropped_keys_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricSendFailures, tags, send_failures_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricQueueSize, tags, BasicQueueSize());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricSentSpans, tags, sent_spans_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricSentKeys, tags, sent_keys_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricFilteredSpans, tags, filtered_spans_.load());
+    REPORT_DYNAMIC_GAUGE_(metrics_registry_, kMetricFilteredKeys, tags, filtered_keys_.load());
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/optimizer_trace_forwarder.h
+++ b/kv_cache_manager/mrc/optimizer_trace_forwarder.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "kv_cache_manager/event/event_publisher.h"
+#include "kv_cache_manager/mrc/online_mrc_config.h"
+#include "kv_cache_manager/protocol/protobuf/optimizer_service.grpc.pb.h"
+
+namespace kv_cache_manager {
+
+class LoopThread;
+class MetricsRegistry;
+
+struct OptimizerTraceInstanceMetadata {
+    std::string instance_group;
+    int32_t block_size = 0;
+    int64_t bytes_per_block = 0;
+};
+
+// KVCM-side best-effort forwarder. Publish performs only filtering and a
+// bounded queue insertion; serialization, batching and RPC run on its worker.
+class OptimizerTraceForwarder : public EventPublisher {
+public:
+    using MetadataResolver =
+        std::function<OptimizerTraceInstanceMetadata(const std::string &instance_id)>;
+
+    OptimizerTraceForwarder(const OptimizerTraceForwarderConfig &config,
+                            std::shared_ptr<MetricsRegistry> metrics_registry,
+                            MetadataResolver metadata_resolver);
+    ~OptimizerTraceForwarder() override;
+
+    bool Init(const std::string &config) override;
+    bool Publish(const std::shared_ptr<BaseEvent> &event) override;
+    bool Stop() override;
+
+private:
+    void WorkerLoop();
+    bool Send(proto::optimizer::ReportAccessTraceRequest &request);
+    void ReportMetrics();
+
+    OptimizerTraceForwarderConfig config_;
+    std::shared_ptr<MetricsRegistry> metrics_registry_;
+    MetadataResolver metadata_resolver_;
+    std::unique_ptr<proto::optimizer::OptimizerService::Stub> stub_;
+    std::thread worker_;
+    std::shared_ptr<LoopThread> report_thread_;
+    std::string source_id_;
+    std::unordered_map<std::string, uint64_t> next_sequence_by_instance_;
+    std::unordered_map<std::string, OptimizerTraceInstanceMetadata> metadata_by_instance_;
+    std::mutex backoff_mutex_;
+    std::condition_variable backoff_cv_;
+    int64_t consecutive_send_failures_ = 0;
+
+    std::atomic<uint64_t> dropped_keys_{0};
+    std::atomic<uint64_t> dropped_spans_{0};
+    std::atomic<uint64_t> sent_spans_{0};
+    std::atomic<uint64_t> sent_keys_{0};
+    std::atomic<uint64_t> send_failures_{0};
+    std::atomic<uint64_t> filtered_spans_{0};
+    std::atomic<uint64_t> filtered_keys_{0};
+    uint64_t acknowledged_dropped_spans_ = 0;
+    uint64_t acknowledged_dropped_keys_ = 0;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/reuse_distance_tracker.cc
+++ b/kv_cache_manager/mrc/reuse_distance_tracker.cc
@@ -1,0 +1,84 @@
+#include "kv_cache_manager/mrc/reuse_distance_tracker.h"
+
+#include <algorithm>
+
+namespace kv_cache_manager {
+
+ReuseDistanceTracker::ReuseDistanceTracker(int64_t initial_capacity) {
+    capacity_ = std::max<int64_t>(initial_capacity, 16);
+    tree_.assign(capacity_ + 1, 0);
+}
+
+int64_t ReuseDistanceTracker::Access(int64_t key) {
+    int64_t distance = -1;
+    auto it = last_pos_.find(key);
+    if (it != last_pos_.end()) {
+        const int64_t pos = it->second;
+        // Distinct keys accessed after this key's last access: every live key
+        // occupies exactly one position, so count live positions above pos.
+        distance = static_cast<int64_t>(last_pos_.size()) - FenwickPrefixSum(pos);
+        FenwickAdd(pos, -1);
+        last_pos_.erase(it);
+    }
+    if (next_pos_ > capacity_) {
+        Compact();
+    }
+    last_pos_[key] = next_pos_;
+    FenwickAdd(next_pos_, 1);
+    ++next_pos_;
+    return distance;
+}
+
+bool ReuseDistanceTracker::Erase(int64_t key) {
+    auto it = last_pos_.find(key);
+    if (it == last_pos_.end()) {
+        return false;
+    }
+    FenwickAdd(it->second, -1);
+    last_pos_.erase(it);
+    return true;
+}
+
+int64_t ReuseDistanceTracker::memory_usage_bytes() const {
+    // Coarse estimate: Fenwick array plus per-entry hash map overhead
+    // (bucket pointer + node with key, value and next pointer).
+    constexpr int64_t kEstimatedMapEntryOverheadBytes = 48;
+    return static_cast<int64_t>(tree_.capacity() * sizeof(int64_t)) +
+           static_cast<int64_t>(last_pos_.size()) * kEstimatedMapEntryOverheadBytes;
+}
+
+void ReuseDistanceTracker::FenwickAdd(int64_t pos, int64_t delta) {
+    for (; pos <= capacity_; pos += pos & (-pos)) {
+        tree_[pos] += delta;
+    }
+}
+
+int64_t ReuseDistanceTracker::FenwickPrefixSum(int64_t pos) const {
+    int64_t sum = 0;
+    for (; pos > 0; pos -= pos & (-pos)) {
+        sum += tree_[pos];
+    }
+    return sum;
+}
+
+void ReuseDistanceTracker::Compact() {
+    std::vector<std::pair<int64_t, int64_t>> entries; // (position, key), ordered by recency
+    entries.reserve(last_pos_.size());
+    for (const auto &[key, pos] : last_pos_) {
+        entries.emplace_back(pos, key);
+    }
+    std::sort(entries.begin(), entries.end());
+
+    if (static_cast<int64_t>(entries.size()) * 2 > capacity_) {
+        capacity_ *= 2;
+    }
+    tree_.assign(capacity_ + 1, 0);
+    next_pos_ = 1;
+    for (const auto &[pos, key] : entries) {
+        last_pos_[key] = next_pos_;
+        FenwickAdd(next_pos_, 1);
+        ++next_pos_;
+    }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/reuse_distance_tracker.h
+++ b/kv_cache_manager/mrc/reuse_distance_tracker.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace kv_cache_manager {
+
+// Exact LRU stack distance tracker (Olken's algorithm).
+// Maintains a Fenwick tree (binary indexed tree) over logical access
+// positions plus a key -> last position map. Each Access() returns the
+// number of distinct keys touched since the key's previous access in
+// O(log n); an LRU cache of capacity C blocks hits iff distance < C.
+// Position space is compacted in place once exhausted, so memory stays
+// proportional to the live key count regardless of stream length.
+class ReuseDistanceTracker {
+public:
+    explicit ReuseDistanceTracker(int64_t initial_capacity = 1024);
+
+    ReuseDistanceTracker(const ReuseDistanceTracker &) = delete;
+    ReuseDistanceTracker &operator=(const ReuseDistanceTracker &) = delete;
+
+    // Record one access. Returns the LRU stack distance (distinct keys
+    // accessed since this key's last access), or -1 for a first-time access.
+    int64_t Access(int64_t key);
+
+    // Remove a key from the stack (used by the sampler when tightening its
+    // threshold). Returns true if the key was tracked.
+    bool Erase(int64_t key);
+
+    int64_t size() const { return static_cast<int64_t>(last_pos_.size()); }
+    int64_t memory_usage_bytes() const;
+
+private:
+    void FenwickAdd(int64_t pos, int64_t delta);
+    int64_t FenwickPrefixSum(int64_t pos) const;
+    // Reassign live keys to positions 1..n, growing the tree when more than
+    // half of the position space is still live.
+    void Compact();
+
+    int64_t capacity_ = 0;                        // usable position slots
+    int64_t next_pos_ = 1;                        // next free position (1-based)
+    std::vector<int64_t> tree_;                   // Fenwick tree, size capacity_ + 1
+    std::unordered_map<int64_t, int64_t> last_pos_; // key -> position
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/test/BUILD
+++ b/kv_cache_manager/mrc/test/BUILD
@@ -1,0 +1,93 @@
+package(default_visibility = ["//visibility:private"])
+
+cc_test(
+    name = "ReuseDistanceTrackerTest",
+    srcs = [
+        "reuse_distance_tracker_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/mrc:reuse_distance_tracker",
+    ],
+)
+
+cc_test(
+    name = "MrcProfilerTest",
+    srcs = [
+        "mrc_profiler_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/mrc:mrc_profiler",
+    ],
+)
+
+cc_test(
+    name = "LiteHitCoreTest",
+    srcs = [
+        "lite_hit_core_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/mrc:mrc_profiler",
+    ],
+)
+
+cc_test(
+    name = "MrcEventConsumerTest",
+    srcs = [
+        "mrc_event_consumer_test.cc",
+    ],
+    copts = ["-fno-access-control"],
+    data = [],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/event:event_publisher",
+        "//kv_cache_manager/event/spec_events",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/mrc:mrc_event_consumer",
+    ],
+)
+
+cc_test(
+    name = "OnlineMrcRegistryTest",
+    srcs = ["online_mrc_registry_test.cc"],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/mrc:online_mrc_registry",
+    ],
+)
+
+cc_test(
+    name = "OptimizerTraceForwarderTest",
+    srcs = ["optimizer_trace_forwarder_test.cc"],
+    copts = ["-fno-access-control"],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/mrc:optimizer_trace_forwarder",
+    ],
+)
+
+cc_test(
+    name = "OnlineMrcFactStreamTest",
+    srcs = ["online_mrc_fact_stream_test.cc"],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/metrics:metrics_registry",
+        "//kv_cache_manager/metrics:prometheus_exporter",
+        "//kv_cache_manager/mrc:online_mrc_fact_stream",
+        "//kv_cache_manager/optimizer:online_optimizer_manager",
+        "//kv_cache_manager/optimizer/config:optimizer_registry_manager",
+        "//kv_cache_manager/optimizer/liteHit:hit_curve",
+        "//kv_cache_manager/optimizer/liteHit:lite_hit",
+        "//kv_cache_manager/optimizer/liteHit:request_preprocess",
+        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+    ],
+)

--- a/kv_cache_manager/mrc/test/lite_hit_core_test.cc
+++ b/kv_cache_manager/mrc/test/lite_hit_core_test.cc
@@ -1,0 +1,123 @@
+#include "kv_cache_manager/mrc/lite_hit_core.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "kv_cache_manager/common/unittest.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+// Hits at capacity C = number of thresholds <= C.
+int64_t HitsAt(const std::vector<uint64_t> &thresholds, uint64_t capacity) {
+    int64_t hits = 0;
+    for (const uint64_t t : thresholds) {
+        hits += (t <= capacity) ? 1 : 0;
+    }
+    return hits;
+}
+
+std::vector<int64_t> Chain(int64_t base, int n) {
+    // Prefix-chained ids: distinct per (base, position).
+    std::vector<int64_t> keys;
+    keys.reserve(n);
+    for (int i = 0; i < n; ++i) {
+        keys.push_back(base * 100000 + i);
+    }
+    return keys;
+}
+
+} // namespace
+
+TEST(LiteHitCoreTest, ColdRequestEmitsNothing) {
+    LiteHitCore core;
+    std::vector<uint64_t> thresholds;
+    core.ProcessRequest(Chain(1, 10), thresholds);
+    EXPECT_TRUE(thresholds.empty());
+    EXPECT_EQ(10, core.unique_blocks());
+}
+
+TEST(LiteHitCoreTest, RepeatedScanThresholdsAreOneToN) {
+    // Identical request replayed: block j requires exactly j resident blocks
+    // (LiteHit projection: hits(C) = min(C, N) per repeat).
+    LiteHitCore core;
+    std::vector<uint64_t> thresholds;
+    const auto request = Chain(1, 100);
+    core.ProcessRequest(request, thresholds);
+    ASSERT_TRUE(thresholds.empty());
+
+    core.ProcessRequest(request, thresholds);
+    ASSERT_EQ(100u, thresholds.size());
+    for (size_t i = 0; i < thresholds.size(); ++i) {
+        EXPECT_EQ(i + 1, thresholds[i]);
+    }
+    EXPECT_EQ(16, HitsAt(thresholds, 16));
+    EXPECT_EQ(100, HitsAt(thresholds, 4096));
+}
+
+TEST(LiteHitCoreTest, ColdKeyStopsPrefixForEveryCapacity) {
+    LiteHitCore core;
+    std::vector<uint64_t> thresholds;
+    const auto request = Chain(1, 4);
+    core.ProcessRequest(request, thresholds);
+
+    // Same 2-block prefix, then a diverging (cold) suffix, then a resident
+    // block again: the prefix stops at the cold key and never revives.
+    std::vector<int64_t> mixed = {request[0], request[1], 999999, request[2]};
+    thresholds.clear();
+    core.ProcessRequest(mixed, thresholds);
+    EXPECT_EQ(2u, thresholds.size());
+}
+
+TEST(LiteHitCoreTest, LeafFirstCommitKeepsChainHeadNewest) {
+    LiteHitCore core;
+    std::vector<uint64_t> thresholds;
+    // Two chains A(4) and B(4); replay A: its head must need fewer resident
+    // blocks than its tail (head committed last = newest).
+    const auto chain_a = Chain(1, 4);
+    const auto chain_b = Chain(2, 4);
+    core.ProcessRequest(chain_a, thresholds);
+    core.ProcessRequest(chain_b, thresholds);
+    ASSERT_TRUE(thresholds.empty());
+
+    core.ProcessRequest(chain_a, thresholds);
+    ASSERT_EQ(4u, thresholds.size());
+    // A committed before B: A's head has 4 B-blocks plus deeper A-blocks in
+    // front of it. Thresholds must be non-decreasing along the chain and the
+    // deepest block requires the full working set.
+    for (size_t i = 1; i < thresholds.size(); ++i) {
+        EXPECT_GE(thresholds[i], thresholds[i - 1]);
+    }
+    EXPECT_EQ(8u, thresholds.back());
+}
+
+TEST(LiteHitCoreTest, SurvivesPositionCompaction) {
+    LiteHitCore core(/*initial_capacity=*/32);
+    std::vector<uint64_t> thresholds;
+    // Push far more distinct blocks than the initial position space.
+    for (int r = 0; r < 100; ++r) {
+        core.ProcessRequest(Chain(r + 10, 8), thresholds);
+    }
+    // A recent chain must still be resident with small thresholds.
+    thresholds.clear();
+    core.ProcessRequest(Chain(109, 8), thresholds);
+    ASSERT_EQ(8u, thresholds.size());
+    EXPECT_EQ(8u, thresholds.back());
+}
+
+TEST(LiteHitCoreTest, BoundedStackStaysExactInsideTrackingCapacity) {
+    LiteHitCore bounded(/*initial_capacity=*/16, /*max_tracked_blocks=*/4);
+    std::vector<uint64_t> thresholds;
+    bounded.ProcessRequest(Chain(1, 8), thresholds);
+    EXPECT_EQ(4, bounded.unique_blocks());
+
+    thresholds.clear();
+    bounded.ProcessRequest(Chain(1, 8), thresholds);
+    ASSERT_EQ(4u, thresholds.size());
+    for (size_t i = 0; i < thresholds.size(); ++i) {
+        EXPECT_EQ(i + 1, thresholds[i]);
+    }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/test/mrc_event_consumer_test.cc
+++ b/kv_cache_manager/mrc/test/mrc_event_consumer_test.cc
@@ -1,0 +1,126 @@
+#include "kv_cache_manager/mrc/mrc_event_consumer.h"
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include <thread>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/event/spec_events/optimizer_event.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+std::shared_ptr<CacheGetEvent> MakeCacheGetEvent(const std::string &instance_id, const std::vector<int64_t> &keys) {
+    auto event = std::make_shared<CacheGetEvent>(instance_id);
+    event->SetEventTriggerTime();
+    event->SetAddtionalArgs("prefix_match", keys, /*tokens=*/{}, BlockMask(), /*sw_size=*/0, {});
+    return event;
+}
+
+OnlineMrcConfig MakeConfig() {
+    OnlineMrcConfig config;
+    config.enable = true;
+    config.max_tracked_blocks = 1024;
+    config.window_seconds = 3600;
+    config.report_interval_seconds = 3600; // reporting triggered manually in tests
+    config.capacity_gb_grid = {1, 2};
+    config.max_instances = 4;
+    config.queue_max_size = 1024;
+    return config;
+}
+
+// Wait until the worker thread drains the queue.
+void WaitForDrain(OnlineMrcEventConsumer &consumer) {
+    for (int i = 0; i < 200 && consumer.BasicQueueSize() > 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    // One extra tick: the last event may still be inside Observe().
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+}
+
+} // namespace
+
+TEST(OnlineMrcEventConsumerTest, ConsumesCacheGetEventsAndReportsGauges) {
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto consumer = std::make_shared<OnlineMrcEventConsumer>(
+        MakeConfig(), metrics_registry, [](const std::string &) -> int64_t { return 1024 * 1024; });
+    ASSERT_TRUE(consumer->Init(""));
+
+    consumer->Publish(MakeCacheGetEvent("instance_a", {1, 2, 3}));
+    consumer->Publish(MakeCacheGetEvent("instance_a", {1, 2, 3}));
+    consumer->Publish(MakeCacheGetEvent("instance_b", {7, 8}));
+    WaitForDrain(*consumer);
+
+    consumer->ReportMetrics();
+
+    // Cumulative hit rate for instance_a at 1GB (1024 blocks of 1MB):
+    // 6 accesses, 3 hits.
+    auto data = metrics_registry->GetMetricsData("online_mrc.theoretical_hit_rate");
+    ASSERT_NE(nullptr, data);
+    MetricsTags tags{{"instance_id", "instance_a"}, {"scope", "cumulative"}, {"capacity_gb", "1"}};
+    auto gauge = data->GetGauge(tags);
+    ASSERT_TRUE(gauge.has_value());
+    EXPECT_NEAR(0.5, gauge->Get(), 1e-9);
+
+    // Quality gauges present.
+    EXPECT_NE(nullptr, metrics_registry->GetMetricsData("online_mrc.tracked_blocks"));
+    EXPECT_NE(nullptr, metrics_registry->GetMetricsData("online_mrc.tracked_instances"));
+
+    EXPECT_TRUE(consumer->Stop());
+}
+
+TEST(OnlineMrcEventConsumerTest, IgnoresNonCacheGetEvents) {
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto consumer = std::make_shared<OnlineMrcEventConsumer>(
+        MakeConfig(), metrics_registry, [](const std::string &) -> int64_t { return 0; });
+    ASSERT_TRUE(consumer->Init(""));
+
+    auto write_event = std::make_shared<FinishWriteCacheEvent>("instance_a");
+    EXPECT_TRUE(consumer->Publish(write_event)); // accepted but not enqueued
+    EXPECT_EQ(0u, consumer->BasicQueueSize());
+
+    EXPECT_TRUE(consumer->Stop());
+}
+
+TEST(OnlineMrcEventConsumerTest, RespectsInstanceLaneLimit) {
+    auto config = MakeConfig();
+    config.max_instances = 1;
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto consumer = std::make_shared<OnlineMrcEventConsumer>(
+        config, metrics_registry, [](const std::string &) -> int64_t { return 0; });
+    ASSERT_TRUE(consumer->Init(""));
+
+    consumer->Publish(MakeCacheGetEvent("instance_a", {1}));
+    consumer->Publish(MakeCacheGetEvent("instance_b", {2}));
+    WaitForDrain(*consumer);
+
+    {
+        std::lock_guard<std::mutex> guard(consumer->lanes_mutex_);
+        EXPECT_EQ(1u, consumer->lanes_.size());
+        EXPECT_EQ(1u, consumer->lanes_.count("instance_a"));
+    }
+    EXPECT_TRUE(consumer->Stop());
+}
+
+TEST(OnlineMrcEventConsumerTest, DumpCurvesJsonContainsInstances) {
+    auto metrics_registry = std::make_shared<MetricsRegistry>();
+    auto consumer = std::make_shared<OnlineMrcEventConsumer>(
+        MakeConfig(), metrics_registry, [](const std::string &) -> int64_t { return 4096; });
+    ASSERT_TRUE(consumer->Init(""));
+
+    consumer->Publish(MakeCacheGetEvent("instance_a", {1, 2, 3, 1, 2, 3}));
+    WaitForDrain(*consumer);
+    consumer->ReportMetrics(); // resolves bytes_per_block
+
+    const std::string json = consumer->DumpCurvesJson();
+    EXPECT_NE(std::string::npos, json.find("\"instance_a\""));
+    EXPECT_NE(std::string::npos, json.find("\"cumulative\""));
+    EXPECT_NE(std::string::npos, json.find("\"curve\""));
+
+    EXPECT_TRUE(consumer->Stop());
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/test/mrc_profiler_test.cc
+++ b/kv_cache_manager/mrc/test/mrc_profiler_test.cc
@@ -1,0 +1,154 @@
+#include "kv_cache_manager/mrc/mrc_profiler.h"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <list>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+#include "kv_cache_manager/common/unittest.h"
+
+namespace kv_cache_manager {
+namespace {
+
+class NaiveRequestLru {
+public:
+    explicit NaiveRequestLru(int64_t capacity) : capacity_(capacity) {}
+
+    int64_t Process(const std::vector<int64_t> &keys) {
+        int64_t prefix_hits = 0;
+        for (const int64_t key : keys) {
+            if (index_.find(key) == index_.end()) {
+                break;
+            }
+            ++prefix_hits;
+        }
+        for (auto it = keys.rbegin(); it != keys.rend(); ++it) {
+            auto current = index_.find(*it);
+            if (current != index_.end()) {
+                lru_.erase(current->second);
+                index_.erase(current);
+            }
+            lru_.push_front(*it);
+            index_[*it] = lru_.begin();
+            while (static_cast<int64_t>(lru_.size()) > capacity_) {
+                index_.erase(lru_.back());
+                lru_.pop_back();
+            }
+        }
+        return prefix_hits;
+    }
+
+private:
+    int64_t capacity_;
+    std::list<int64_t> lru_;
+    std::unordered_map<int64_t, std::list<int64_t>::iterator> index_;
+};
+
+std::vector<int64_t> Chain(int64_t prefix, int length) {
+    std::vector<int64_t> keys;
+    for (int i = 0; i < length; ++i) {
+        keys.push_back(prefix * 1000 + i);
+    }
+    return keys;
+}
+
+} // namespace
+
+TEST(MrcProfilerTest, MatchesNaiveRequestLevelLruAtEveryTrackedCapacity) {
+    MrcProfiler::Options options;
+    options.max_tracked_blocks = 64;
+    options.window_seconds = 0;
+    MrcProfiler profiler(options);
+
+    std::vector<double> capacities;
+    std::vector<NaiveRequestLru> references;
+    std::vector<int64_t> hits;
+    for (int capacity = 1; capacity <= 64; ++capacity) {
+        capacities.push_back(capacity);
+        references.emplace_back(capacity);
+        hits.push_back(0);
+    }
+
+    std::mt19937_64 rng(20260810);
+    std::uniform_int_distribution<int64_t> prefix_dist(0, 99);
+    std::uniform_int_distribution<int> length_dist(1, 16);
+    int64_t total_blocks = 0;
+    for (int request = 0; request < 20000; ++request) {
+        const auto keys = Chain(prefix_dist(rng), length_dist(rng));
+        total_blocks += keys.size();
+        for (size_t i = 0; i < references.size(); ++i) {
+            hits[i] += references[i].Process(keys);
+        }
+        profiler.Observe(keys, request);
+    }
+
+    MrcProfiler::Snapshot snapshot;
+    profiler.QueryCumulative(capacities, snapshot);
+    ASSERT_EQ(capacities.size(), snapshot.hit_rates.size());
+    EXPECT_DOUBLE_EQ(static_cast<double>(total_blocks), snapshot.total_accesses);
+    for (size_t i = 0; i < capacities.size(); ++i) {
+        EXPECT_DOUBLE_EQ(static_cast<double>(hits[i]) / total_blocks, snapshot.hit_rates[i])
+            << "capacity " << capacities[i];
+    }
+    EXPECT_DOUBLE_EQ(snapshot.hit_rates.back(), snapshot.max_tracked_hit_rate);
+}
+
+TEST(MrcProfilerTest, MarksCapacitiesBeyondExactBoundaryUnavailable) {
+    MrcProfiler::Options options;
+    options.max_tracked_blocks = 8;
+    options.window_seconds = 0;
+    MrcProfiler profiler(options);
+    profiler.Observe(Chain(1, 12), 0);
+    profiler.Observe(Chain(1, 12), 1);
+
+    MrcProfiler::Snapshot snapshot;
+    profiler.QueryCumulative({1, 8, 9, 1024}, snapshot);
+    EXPECT_GE(snapshot.hit_rates[0], 0.0);
+    EXPECT_GE(snapshot.hit_rates[1], 0.0);
+    EXPECT_EQ(-1.0, snapshot.hit_rates[2]);
+    EXPECT_EQ(-1.0, snapshot.hit_rates[3]);
+    EXPECT_LE(profiler.tracked_blocks(), 8);
+}
+
+TEST(MrcProfilerTest, WindowRotationKeepsLruWarm) {
+    MrcProfiler::Options options;
+    options.max_tracked_blocks = 16;
+    options.window_seconds = 60;
+    MrcProfiler profiler(options);
+    const auto request = Chain(1, 4);
+
+    MrcProfiler::Snapshot snapshot;
+    profiler.Observe(request, 0);
+    EXPECT_FALSE(profiler.QueryWindow({4}, snapshot));
+    profiler.Observe(request, 61 * 1000000LL);
+    ASSERT_TRUE(profiler.QueryWindow({4}, snapshot));
+    EXPECT_DOUBLE_EQ(4.0, snapshot.total_accesses);
+    EXPECT_DOUBLE_EQ(0.0, snapshot.hit_rates[0]);
+
+    profiler.QueryCumulative({4}, snapshot);
+    EXPECT_DOUBLE_EQ(8.0, snapshot.total_accesses);
+    EXPECT_DOUBLE_EQ(0.5, snapshot.hit_rates[0]);
+}
+
+TEST(MrcProfilerTest, DumpCurveIsMonotonic) {
+    MrcProfiler::Options options;
+    options.max_tracked_blocks = 64;
+    options.window_seconds = 0;
+    MrcProfiler profiler(options);
+    for (int i = 0; i < 1000; ++i) {
+        // Keep the complete hot working set below the 64-block tracking cap;
+        // otherwise a valid all-miss workload is allowed to produce no curve
+        // points at all.
+        profiler.Observe(Chain(i % 4, 1 + i % 12), i);
+    }
+    const auto points = profiler.DumpCurve(true);
+    ASSERT_FALSE(points.empty());
+    for (size_t i = 1; i < points.size(); ++i) {
+        EXPECT_GT(points[i].capacity_blocks, points[i - 1].capacity_blocks);
+        EXPECT_GT(points[i].hit_rate, points[i - 1].hit_rate);
+    }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/test/online_mrc_fact_stream_test.cc
+++ b/kv_cache_manager/mrc/test/online_mrc_fact_stream_test.cc
@@ -1,0 +1,584 @@
+#include <arpa/inet.h>
+#include <atomic>
+#include <chrono>
+#include <poll.h>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/metrics/prometheus_exporter.h"
+#include "kv_cache_manager/mrc/kvcm_event_stream_client.h"
+#include "kv_cache_manager/mrc/online_mrc_fact_registry.h"
+#include "kv_cache_manager/optimizer/config/optimizer_registry_manager.h"
+#include "kv_cache_manager/optimizer/liteHit/hit_curve.h"
+#include "kv_cache_manager/optimizer/liteHit/lite_hit.h"
+#include "kv_cache_manager/optimizer/liteHit/request_preprocess.h"
+#include "kv_cache_manager/optimizer/online_runtime/online_optimizer_manager.h"
+
+namespace kv_cache_manager {
+namespace {
+
+OnlineMrcConfig MakeConfig() {
+    OnlineMrcConfig config;
+    config.enable = true;
+    config.capacity_gb_grid = {2};
+    config.max_instances = 1;
+    config.receiver_queue_max_batches = 4;
+    config.discovery_refresh_interval_ms = 20;
+    config.connect_timeout_ms = 100;
+    config.reconnect_interval_ms = 20;
+    config.max_frame_bytes = 1024 * 1024;
+    return config;
+}
+
+std::vector<OptimizerInstanceGroup> MakeFormalGroups() {
+    std::vector<OptimizerInstanceGroup> groups;
+    for (const std::string &name : {"group_a", "group_b"}) {
+        OptimizerInstanceGroup group;
+        group.set_name(name);
+        group.set_capacity_gb({2});
+        group.set_enable_prefix_hash(true);
+        groups.push_back(std::move(group));
+    }
+    return groups;
+}
+
+std::shared_ptr<OnlineOptimizerManager> MakeManager() {
+    auto formal_registry = std::make_shared<OptimizerRegistryManager>("");
+    if (!formal_registry->Init()) {
+        return nullptr;
+    }
+    return std::make_shared<OnlineOptimizerManager>(formal_registry);
+}
+
+proto::optimizer::CacheEventBatch MakeBatch(int32_t block_size = 2) {
+    proto::optimizer::CacheEventBatch batch;
+    batch.set_instance_id("instance_a");
+    batch.set_instance_group("group_a");
+    auto *meta = batch.mutable_instance_meta();
+    meta->set_block_size(block_size);
+    auto *spec = meta->add_location_spec_infos();
+    spec->set_name("full_spec");
+    spec->set_size(1024LL * 1024 * 1024);
+    auto *group = meta->add_location_spec_groups();
+    group->set_name("full_group");
+    group->add_spec_names("full_spec");
+    meta->mutable_optimizer_state_info()->set_full_location_spec_group_name("full_group");
+
+    auto *event = batch.add_events();
+    event->set_event_id("event_a");
+    event->set_timestamp_ns(1);
+    event->set_input_token_len(static_cast<int64_t>(block_size) * 3);
+    event->add_block_keys(1);
+    event->add_block_keys(2);
+    event->add_block_keys(3);
+    return batch;
+}
+
+bool ReadAll(int fd, void *data, size_t size) {
+    auto *bytes = static_cast<uint8_t *>(data);
+    size_t received = 0;
+    while (received < size) {
+        const ssize_t rc = recv(fd, bytes + received, size - received, 0);
+        if (rc <= 0) {
+            return false;
+        }
+        received += static_cast<size_t>(rc);
+    }
+    return true;
+}
+
+bool WriteAll(int fd, const void *data, size_t size) {
+    const auto *bytes = static_cast<const uint8_t *>(data);
+    size_t written = 0;
+    while (written < size) {
+        const ssize_t rc = send(fd, bytes + written, size - written, 0);
+        if (rc <= 0) {
+            return false;
+        }
+        written += static_cast<size_t>(rc);
+    }
+    return true;
+}
+
+int CreateLoopbackListener(int &port) {
+    const int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = 0;
+    if (bind(fd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0 || listen(fd, 4) != 0) {
+        close(fd);
+        return -1;
+    }
+    socklen_t address_length = sizeof(address);
+    if (getsockname(fd, reinterpret_cast<sockaddr *>(&address), &address_length) != 0) {
+        close(fd);
+        return -1;
+    }
+    port = ntohs(address.sin_port);
+    return fd;
+}
+
+int AcceptWithTimeout(int listen_fd, int timeout_ms = 3000) {
+    pollfd poll_fd{listen_fd, POLLIN, 0};
+    if (poll(&poll_fd, 1, timeout_ms) <= 0 || !(poll_fd.revents & POLLIN)) {
+        return -1;
+    }
+    return accept(listen_fd, nullptr, nullptr);
+}
+
+bool ReadHelloFrame(int fd) {
+    uint32_t network_length = 0;
+    if (!ReadAll(fd, &network_length, sizeof(network_length))) {
+        return false;
+    }
+    std::vector<uint8_t> frame(ntohl(network_length));
+    if (!ReadAll(fd, frame.data(), frame.size()) || frame.empty() || frame.front() != 1) {
+        return false;
+    }
+    proto::optimizer::OptimizerHello hello;
+    return hello.ParseFromArray(frame.data() + 1, static_cast<int>(frame.size() - 1)) &&
+           hello.protocol_version() == 1 && !hello.optimizer_id().empty();
+}
+
+bool WriteBatchFrame(int fd, const proto::optimizer::CacheEventBatch &batch) {
+    std::string payload;
+    if (!batch.SerializeToString(&payload)) {
+        return false;
+    }
+    const uint32_t event_length = htonl(static_cast<uint32_t>(payload.size() + 1));
+    const uint8_t event_type = 2;
+    return WriteAll(fd, &event_length, sizeof(event_length)) && WriteAll(fd, &event_type, sizeof(event_type)) &&
+           WriteAll(fd, payload.data(), payload.size());
+}
+
+} // namespace
+
+TEST(OnlineMrcFactRegistryTest, KeepsAllFactsAndSeparatesMetadataGenerations) {
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    OnlineMrcFactRegistry registry(MakeConfig(), MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(registry.Init());
+
+    ASSERT_TRUE(registry.Observe(MakeBatch()));
+    ASSERT_TRUE(registry.Observe(MakeBatch()));
+    ASSERT_TRUE(registry.Observe(MakeBatch()));
+    EXPECT_EQ(3u, registry.FactCount("instance_a"));
+
+    registry.ReportMetrics();
+    auto hit_data = metrics->GetMetricsData("online_mrc.theoretical_hit_rate");
+    ASSERT_NE(nullptr, hit_data);
+    MetricsTags tags{
+        {"instance_group", "group_a"}, {"instance_id", "instance_a"}, {"meta_generation", "1"}, {"capacity_gb", "2"}};
+    auto hit = hit_data->GetGauge(tags);
+    ASSERT_TRUE(hit.has_value());
+    EXPECT_DOUBLE_EQ(4.0 / 9.0, hit->Get());
+
+    MetricsTags instance_tags{
+        {"instance_group", "group_a"}, {"instance_id", "instance_a"}, {"meta_generation", "1"}};
+    auto fact_memory = metrics->GetMetricsData("online_mrc.fact_memory_bytes")->GetGauge(instance_tags);
+    auto lite_hit_memory = metrics->GetMetricsData("online_mrc.lite_hit_memory_bytes")->GetGauge(instance_tags);
+    auto instance_memory = metrics->GetMetricsData("online_mrc.instance_memory_bytes")->GetGauge(instance_tags);
+    ASSERT_TRUE(fact_memory.has_value());
+    ASSERT_TRUE(lite_hit_memory.has_value());
+    ASSERT_TRUE(instance_memory.has_value());
+    EXPECT_GT(fact_memory->Get(), 0.0);
+    EXPECT_GT(lite_hit_memory->Get(), 0.0);
+    EXPECT_DOUBLE_EQ(fact_memory->Get() + lite_hit_memory->Get(), instance_memory->Get());
+
+    auto total_memory = metrics->GetMetricsData("online_mrc.total_memory_bytes")->GetGauge({});
+    auto projection_duration = metrics->GetMetricsData("online_mrc.projection_duration_us")->GetGauge({});
+    auto projection_scans = metrics->GetMetricsData("online_mrc.projection_fact_scans")->GetGauge({});
+    ASSERT_TRUE(total_memory.has_value());
+    ASSERT_TRUE(projection_duration.has_value());
+    ASSERT_TRUE(projection_scans.has_value());
+    EXPECT_DOUBLE_EQ(instance_memory->Get(), total_memory->Get());
+    EXPECT_GE(projection_duration->Get(), 0.0);
+    EXPECT_DOUBLE_EQ(3.0, projection_scans->Get());
+
+    const std::string prometheus = PrometheusExporter::Expose(*metrics, "kvcm_optimizer");
+    EXPECT_NE(std::string::npos, prometheus.find("kvcm_optimizer_online_mrc_fact_memory_bytes"));
+    EXPECT_NE(std::string::npos, prometheus.find("kvcm_optimizer_online_mrc_lite_hit_memory_bytes"));
+    EXPECT_NE(std::string::npos, prometheus.find("kvcm_optimizer_online_mrc_total_memory_bytes"));
+    EXPECT_NE(std::string::npos, prometheus.find("kvcm_optimizer_online_mrc_projection_duration_us"));
+
+    ASSERT_TRUE(registry.Observe(MakeBatch(/*block_size=*/4)));
+    EXPECT_EQ(2u, registry.MetaGeneration("instance_a"));
+    EXPECT_EQ(1u, registry.FactCount("instance_a"));
+}
+
+TEST(OnlineMrcFactRegistryTest, DropsOutOfOrderEventsWithinOneInstance) {
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    OnlineMrcFactRegistry registry(MakeConfig(), MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(registry.Init());
+
+    auto newest = MakeBatch();
+    newest.mutable_events(0)->set_timestamp_ns(20);
+    ASSERT_TRUE(registry.Observe(newest));
+
+    auto stale = MakeBatch();
+    stale.mutable_events(0)->set_timestamp_ns(19);
+    ASSERT_TRUE(registry.Observe(stale));
+    EXPECT_EQ(1u, registry.FactCount("instance_a"));
+
+    registry.ReportMetrics();
+    auto order_data = metrics->GetMetricsData("online_mrc.out_of_order_events");
+    ASSERT_NE(nullptr, order_data);
+    MetricsTags tags{{"instance_group", "group_a"}, {"instance_id", "instance_a"}, {"meta_generation", "1"}};
+    auto out_of_order = order_data->GetGauge(tags);
+    ASSERT_TRUE(out_of_order.has_value());
+    EXPECT_DOUBLE_EQ(1.0, out_of_order->Get());
+}
+
+TEST(OnlineMrcFactRegistryTest, PrefixHashesKeysBeforeUpdatingLiteHit) {
+    auto config = MakeConfig();
+    config.capacity_gb_grid = {4};
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    OnlineMrcFactRegistry registry(config, MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(registry.Init());
+
+    const auto observe = [&](int64_t timestamp_ns, std::initializer_list<int64_t> raw_keys) {
+        auto batch = MakeBatch();
+        auto *event = batch.mutable_events(0);
+        event->set_timestamp_ns(timestamp_ns);
+        event->set_input_token_len(4);
+        event->clear_block_keys();
+        for (const int64_t key : raw_keys) {
+            event->add_block_keys(key);
+        }
+        ASSERT_TRUE(registry.Observe(batch));
+    };
+
+    observe(1, {1, 2});
+    observe(2, {3, 2});
+    observe(3, {1, 4});
+    observe(4, {1, 2});
+
+    registry.ReportMetrics();
+    auto hit_data = metrics->GetMetricsData("online_mrc.theoretical_hit_rate");
+    ASSERT_NE(nullptr, hit_data);
+    MetricsTags tags{
+        {"instance_group", "group_a"}, {"instance_id", "instance_a"}, {"meta_generation", "1"}, {"capacity_gb", "4"}};
+    auto hit = hit_data->GetGauge(tags);
+    ASSERT_TRUE(hit.has_value());
+    // Re-hashing the raw key sequence makes the second key depend on its
+    // prefix. Without normalization, the second request would refresh key 2
+    // under the wrong prefix and this value would be 3/8 instead of 2/8.
+    EXPECT_DOUBLE_EQ(0.25, hit->Get());
+}
+
+TEST(OnlineMrcFactRegistryTest, MatchesFormalOfflineLiteHitOnTheSameCompleteTrace) {
+    auto config = MakeConfig();
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    OnlineMrcFactRegistry online(config, MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(online.Init());
+
+    LiteHit offline;
+    uint64_t offline_total_tokens = 0;
+    uint64_t offline_hit_tokens = 0;
+    const std::vector<std::vector<int64_t>> requests{{1, 2, 3}, {1, 2, 4}, {5, 2, 3}, {1, 2, 3}};
+    int64_t timestamp_ns = 1;
+    for (const auto &raw_keys : requests) {
+        auto batch = MakeBatch();
+        auto *event = batch.mutable_events(0);
+        event->set_timestamp_ns(timestamp_ns++);
+        event->clear_block_keys();
+        for (const int64_t key : raw_keys) {
+            event->add_block_keys(key);
+        }
+        ASSERT_TRUE(online.Observe(batch));
+
+        const NormalizedRequest normalized = NormalizeRequest(raw_keys, 6, 2, true);
+        const RequestFact fact = offline.ProcessRequest(normalized.block_keys);
+        const uint64_t hit_blocks = HitCurveProjector::ProjectBytes(fact, 2ULL * 1024 * 1024 * 1024, 1024ULL * 1024 * 1024);
+        offline_total_tokens += normalized.input_token_len;
+        offline_hit_tokens += std::min<uint64_t>(hit_blocks * 2, normalized.input_token_len);
+    }
+
+    online.ReportMetrics();
+    const auto hit_data = metrics->GetMetricsData("online_mrc.theoretical_hit_rate");
+    ASSERT_NE(nullptr, hit_data);
+    const MetricsTags tags{
+        {"instance_group", "group_a"}, {"instance_id", "instance_a"}, {"meta_generation", "1"}, {"capacity_gb", "2"}};
+    const auto online_hit = hit_data->GetGauge(tags);
+    ASSERT_TRUE(online_hit.has_value());
+    EXPECT_DOUBLE_EQ(static_cast<double>(offline_hit_tokens) / offline_total_tokens, online_hit->Get());
+}
+
+TEST(OnlineMrcFactRegistryTest, AutoCreatesGroupsAndMovesInstanceMembership) {
+    auto manager = MakeManager();
+    OnlineMrcFactRegistry registry(MakeConfig(), MakeFormalGroups(), nullptr, manager);
+    ASSERT_TRUE(registry.Init());
+
+    ASSERT_TRUE(registry.Observe(MakeBatch()));
+    EXPECT_EQ(2u, registry.GroupCount());
+    EXPECT_EQ(1u, registry.GroupInstanceCount("group_a"));
+    const auto formal_group = manager->registry_manager()->GetInstanceGroup("group_a");
+    ASSERT_NE(nullptr, formal_group);
+    EXPECT_TRUE(formal_group->enable_prefix_hash());
+    OptimizerInstanceGroup round_trip_group;
+    ASSERT_TRUE(round_trip_group.FromJsonString(formal_group->ToJsonString()));
+    EXPECT_TRUE(round_trip_group.enable_prefix_hash());
+    EXPECT_EQ(EC_OK, manager->GetInstanceState("instance_a", [](const InstanceState &) {}));
+
+    auto moved = MakeBatch();
+    moved.set_instance_group("group_b");
+    moved.mutable_events(0)->set_timestamp_ns(2);
+    ASSERT_TRUE(registry.Observe(moved));
+    EXPECT_EQ(2u, registry.GroupCount());
+    EXPECT_EQ(0u, registry.GroupInstanceCount("group_a"));
+    EXPECT_EQ(1u, registry.GroupInstanceCount("group_b"));
+    EXPECT_EQ(2u, registry.MetaGeneration("instance_a"));
+    EXPECT_EQ(1u, registry.FactCount("instance_a"));
+}
+
+TEST(OnlineMrcFactRegistryTest, CreatesFormalGroupsAtInitAndRejectsUnknownGroup) {
+    auto manager = MakeManager();
+    OnlineMrcFactRegistry registry(MakeConfig(), MakeFormalGroups(), nullptr, manager);
+    ASSERT_TRUE(registry.Init());
+    ASSERT_NE(nullptr, manager->registry_manager()->GetInstanceGroup("group_a"));
+    ASSERT_NE(nullptr, manager->registry_manager()->GetInstanceGroup("group_b"));
+
+    auto unknown = MakeBatch();
+    unknown.set_instance_group("not_configured");
+    EXPECT_FALSE(registry.Observe(unknown));
+    EXPECT_EQ(nullptr, manager->registry_manager()->GetInstanceInfo("instance_a"));
+}
+
+TEST(OnlineMrcFactRegistryTest, RefusesToModifyAnExistingDifferentFormalGroup) {
+    auto manager = MakeManager();
+    OptimizerInstanceGroup existing;
+    existing.set_name("group_a");
+    existing.set_capacity_gb({99});
+    existing.set_enable_prefix_hash(false);
+    ASSERT_EQ(EC_OK, manager->CreateInstanceGroup(existing));
+
+    OnlineMrcFactRegistry registry(MakeConfig(), MakeFormalGroups(), nullptr, manager);
+    EXPECT_FALSE(registry.Init());
+    const auto unchanged = manager->registry_manager()->GetInstanceGroup("group_a");
+    ASSERT_NE(nullptr, unchanged);
+    EXPECT_EQ((std::vector<double>{99}), unchanged->capacity_gb());
+    EXPECT_FALSE(unchanged->enable_prefix_hash());
+    EXPECT_EQ(nullptr, manager->registry_manager()->GetInstanceGroup("group_b"));
+}
+
+TEST(OnlineMrcFactRegistryTest, HotUpdatesCapacityGridWithoutResettingFacts) {
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    OnlineMrcFactRegistry registry(MakeConfig(), MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(registry.Init());
+    ASSERT_TRUE(registry.Observe(MakeBatch()));
+    registry.ReportMetrics();
+
+    auto hit_data = metrics->GetMetricsData("online_mrc.theoretical_hit_rate");
+    ASSERT_NE(nullptr, hit_data);
+    MetricsTags old_tags{
+        {"instance_group", "group_a"}, {"instance_id", "instance_a"}, {"meta_generation", "1"}, {"capacity_gb", "2"}};
+    ASSERT_TRUE(hit_data->GetGauge(old_tags).has_value());
+
+    ASSERT_TRUE(registry.UpdateCapacityGrid({1, 4}));
+    EXPECT_EQ((std::vector<double>{1, 4}), registry.CapacityGrid());
+    EXPECT_EQ(2u, registry.ProjectionGeneration());
+    EXPECT_EQ(1u, registry.FactCount("instance_a"));
+    EXPECT_EQ(1u, registry.MetaGeneration("instance_a"));
+    EXPECT_FALSE(hit_data->GetGauge(old_tags).has_value());
+
+    registry.ReportMetrics();
+    MetricsTags new_tags = old_tags;
+    new_tags["capacity_gb"] = "4";
+    EXPECT_TRUE(hit_data->GetGauge(new_tags).has_value());
+
+    EXPECT_FALSE(registry.UpdateCapacityGrid({4, 1}));
+    EXPECT_FALSE(registry.UpdateCapacityGrid({}));
+    EXPECT_EQ(2u, registry.ProjectionGeneration());
+    EXPECT_EQ((std::vector<double>{1, 4}), registry.CapacityGrid());
+}
+
+TEST(KvcmEventStreamClientTest, OptimizerDiscoversConnectsSendsHelloAndReceivesBatch) {
+    const int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = 0;
+    ASSERT_EQ(0, bind(listen_fd, reinterpret_cast<sockaddr *>(&address), sizeof(address)));
+    ASSERT_EQ(0, listen(listen_fd, 1));
+    socklen_t address_length = sizeof(address);
+    ASSERT_EQ(0, getsockname(listen_fd, reinterpret_cast<sockaddr *>(&address), &address_length));
+    const int port = ntohs(address.sin_port);
+
+    std::atomic<bool> received_hello{false};
+    std::thread server([&]() {
+        const int client_fd = accept(listen_fd, nullptr, nullptr);
+        if (client_fd < 0) {
+            return;
+        }
+        uint32_t network_length = 0;
+        if (!ReadAll(client_fd, &network_length, sizeof(network_length))) {
+            close(client_fd);
+            return;
+        }
+        std::vector<uint8_t> hello_frame(ntohl(network_length));
+        if (!ReadAll(client_fd, hello_frame.data(), hello_frame.size()) || hello_frame.empty() ||
+            hello_frame.front() != 1) {
+            close(client_fd);
+            return;
+        }
+        proto::optimizer::OptimizerHello hello;
+        received_hello = hello.ParseFromArray(hello_frame.data() + 1, static_cast<int>(hello_frame.size() - 1)) &&
+                         hello.protocol_version() == 1 && !hello.optimizer_id().empty();
+
+        std::string payload;
+        MakeBatch().SerializeToString(&payload);
+        const uint32_t event_length = htonl(static_cast<uint32_t>(payload.size() + 1));
+        const uint8_t event_type = 2;
+        // Deliberately fragment the frame header to exercise partial reads.
+        WriteAll(client_fd, &event_length, 2);
+        WriteAll(client_fd, reinterpret_cast<const uint8_t *>(&event_length) + 2, 2);
+        WriteAll(client_fd, &event_type, 1);
+        WriteAll(client_fd, payload.data(), payload.size());
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        close(client_fd);
+    });
+
+    auto config = MakeConfig();
+    config.kvcm_service_discovery_url = "static://127.0.0.1:" + std::to_string(port);
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    auto facts = std::make_shared<OnlineMrcFactRegistry>(config, MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(facts->Init());
+    KvcmEventStreamClient client(config, facts, metrics);
+    ASSERT_TRUE(client.Init());
+    ASSERT_TRUE(client.Start());
+    for (int i = 0; i < 200 && facts->FactCount("instance_a") == 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    EXPECT_TRUE(received_hello.load());
+    EXPECT_EQ(1u, facts->FactCount("instance_a"));
+    client.ReportMetrics();
+    const MetricsTags empty_tags;
+    auto queue_bytes = metrics->GetMetricsData("online_mrc.receiver_queue_bytes")->GetGauge(empty_tags);
+    auto queue_capacity =
+        metrics->GetMetricsData("online_mrc.receiver_queue_capacity_batches")->GetGauge(empty_tags);
+    ASSERT_TRUE(queue_bytes.has_value());
+    ASSERT_TRUE(queue_capacity.has_value());
+    EXPECT_DOUBLE_EQ(0.0, queue_bytes->Get());
+    EXPECT_DOUBLE_EQ(4.0, queue_capacity->Get());
+    client.Stop();
+    server.join();
+    close(listen_fd);
+}
+
+TEST(KvcmEventStreamClientTest, OneEventLoopConnectsToAllDiscoveredNodes) {
+    int port_a = 0;
+    int port_b = 0;
+    const int listen_a = CreateLoopbackListener(port_a);
+    const int listen_b = CreateLoopbackListener(port_b);
+    ASSERT_GE(listen_a, 0);
+    ASSERT_GE(listen_b, 0);
+
+    std::atomic<int> hello_count{0};
+    const auto serve = [&](int listen_fd, const std::string &event_id) {
+        const int client_fd = AcceptWithTimeout(listen_fd);
+        if (client_fd < 0) {
+            return;
+        }
+        if (ReadHelloFrame(client_fd)) {
+            hello_count.fetch_add(1);
+            auto batch = MakeBatch();
+            batch.mutable_events(0)->set_event_id(event_id);
+            WriteBatchFrame(client_fd, batch);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        close(client_fd);
+    };
+    std::thread server_a(serve, listen_a, "event_a");
+    std::thread server_b(serve, listen_b, "event_b");
+
+    auto config = MakeConfig();
+    config.kvcm_service_discovery_url = "static://127.0.0.1:" + std::to_string(port_a) + ",127.0.0.1:" +
+                                        std::to_string(port_b);
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    auto facts = std::make_shared<OnlineMrcFactRegistry>(config, MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(facts->Init());
+    KvcmEventStreamClient client(config, facts, metrics);
+    ASSERT_TRUE(client.Init());
+    ASSERT_TRUE(client.Start());
+    for (int i = 0; i < 500 && facts->FactCount("instance_a") < 2; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    EXPECT_EQ(2, hello_count.load());
+    EXPECT_EQ(2u, facts->FactCount("instance_a"));
+    EXPECT_EQ(2u, client.ConnectionCount());
+
+    client.Stop();
+    server_a.join();
+    server_b.join();
+    close(listen_a);
+    close(listen_b);
+}
+
+TEST(KvcmEventStreamClientTest, EventLoopReconnectsWithoutPerEndpointThreads) {
+    int port = 0;
+    const int listen_fd = CreateLoopbackListener(port);
+    ASSERT_GE(listen_fd, 0);
+
+    std::atomic<int> hello_count{0};
+    std::thread server([&]() {
+        const int first_fd = AcceptWithTimeout(listen_fd);
+        if (first_fd < 0) {
+            return;
+        }
+        if (ReadHelloFrame(first_fd)) {
+            hello_count.fetch_add(1);
+        }
+        close(first_fd);
+
+        const int second_fd = AcceptWithTimeout(listen_fd);
+        if (second_fd < 0) {
+            return;
+        }
+        if (ReadHelloFrame(second_fd)) {
+            hello_count.fetch_add(1);
+            WriteBatchFrame(second_fd, MakeBatch());
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        close(second_fd);
+    });
+
+    auto config = MakeConfig();
+    config.kvcm_service_discovery_url = "static://127.0.0.1:" + std::to_string(port);
+    auto metrics = std::make_shared<MetricsRegistry>();
+    auto manager = MakeManager();
+    auto facts = std::make_shared<OnlineMrcFactRegistry>(config, MakeFormalGroups(), metrics, manager);
+    ASSERT_TRUE(facts->Init());
+    KvcmEventStreamClient client(config, facts, metrics);
+    ASSERT_TRUE(client.Init());
+    ASSERT_TRUE(client.Start());
+    for (int i = 0; i < 1000 && facts->FactCount("instance_a") == 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    EXPECT_EQ(2, hello_count.load());
+    EXPECT_EQ(1u, facts->FactCount("instance_a"));
+
+    client.ReportMetrics();
+    auto reconnects = metrics->GetMetricsData("online_mrc.reconnects")->GetGauge({});
+    ASSERT_TRUE(reconnects.has_value());
+    EXPECT_GE(reconnects->Get(), 1.0);
+
+    client.Stop();
+    server.join();
+    close(listen_fd);
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/test/online_mrc_registry_test.cc
+++ b/kv_cache_manager/mrc/test/online_mrc_registry_test.cc
@@ -1,0 +1,119 @@
+#include "kv_cache_manager/mrc/online_mrc_registry.h"
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/mrc/online_mrc_trace_receiver.h"
+
+namespace kv_cache_manager {
+namespace {
+
+OnlineMrcConfig MakeConfig() {
+    OnlineMrcConfig config;
+    config.enable = true;
+    config.max_tracked_blocks = 64;
+    config.window_seconds = 0;
+    config.capacity_gb_grid = {1};
+    config.max_instances = 4;
+    config.receiver_queue_max_batches = 4;
+    config.idle_expire_seconds = 0;
+    return config;
+}
+
+OnlineMrcSpan MakeSpan(uint64_t sequence, std::vector<int64_t> keys) {
+    OnlineMrcSpan span;
+    span.cluster = "cluster_a";
+    span.instance_group = "group_a";
+    span.instance_id = "instance_a";
+    span.source_id = "source_a";
+    span.bytes_per_block = 32LL * 1024 * 1024;
+    span.event_time_us = sequence;
+    span.sequence_number = sequence;
+    span.keys = std::move(keys);
+    return span;
+}
+
+} // namespace
+
+TEST(OnlineMrcRegistryTest, ReportsExactCurveAndSequenceQuality) {
+    auto metrics = std::make_shared<MetricsRegistry>();
+    OnlineMrcRegistry registry(MakeConfig(), metrics);
+    ASSERT_TRUE(registry.Observe(MakeSpan(1, {1, 2, 3})));
+    ASSERT_TRUE(registry.Observe(MakeSpan(3, {1, 2, 3})));
+    registry.ReportMetrics();
+
+    auto hit_data = metrics->GetMetricsData("online_mrc.theoretical_hit_rate");
+    ASSERT_NE(nullptr, hit_data);
+    MetricsTags hit_tags{{"cluster", "cluster_a"},
+                         {"instance_group", "group_a"},
+                         {"instance_id", "instance_a"},
+                         {"scope", "cumulative"},
+                         {"capacity_gb", "1"}};
+    auto hit = hit_data->GetGauge(hit_tags);
+    ASSERT_TRUE(hit.has_value());
+    EXPECT_DOUBLE_EQ(0.5, hit->Get());
+
+    auto quality_data = metrics->GetMetricsData("online_mrc.stream_complete");
+    ASSERT_NE(nullptr, quality_data);
+    MetricsTags quality_tags{{"cluster", "cluster_a"},
+                             {"instance_group", "group_a"},
+                             {"instance_id", "instance_a"}};
+    auto quality = quality_data->GetGauge(quality_tags);
+    ASSERT_TRUE(quality.has_value());
+    EXPECT_DOUBLE_EQ(0.0, quality->Get());
+}
+
+TEST(OnlineMrcRegistryTest, ReceiverMovesBatchesOffRpcThread) {
+    auto registry = std::make_shared<OnlineMrcRegistry>(MakeConfig(), nullptr);
+    OnlineMrcTraceReceiver receiver(registry, 4);
+    ASSERT_TRUE(receiver.Start());
+
+    OnlineMrcBatch batch;
+    batch.spans.push_back(MakeSpan(1, {1, 2, 3}));
+    ASSERT_TRUE(receiver.Enqueue(std::move(batch)));
+    for (int i = 0; i < 100 && registry->LaneCount() == 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    EXPECT_EQ(1u, registry->LaneCount());
+    receiver.Stop();
+}
+
+TEST(OnlineMrcRegistryTest, DebugDumpDeclaresBoundedExactEngine) {
+    OnlineMrcRegistry registry(MakeConfig(), nullptr);
+    ASSERT_TRUE(registry.Observe(MakeSpan(1, {1, 2, 3})));
+    ASSERT_TRUE(registry.Observe(MakeSpan(2, {1, 2, 3})));
+    const std::string json = registry.DumpCurvesJson();
+    EXPECT_NE(std::string::npos, json.find("lite_hit_exact_bounded"));
+    EXPECT_NE(std::string::npos, json.find("instance_a"));
+    EXPECT_NE(std::string::npos, json.find("tracked_capacity_blocks"));
+}
+
+TEST(OnlineMrcRegistryTest, KnownGlobalDropConservativelyMarksStreamIncomplete) {
+    auto metrics = std::make_shared<MetricsRegistry>();
+    OnlineMrcRegistry registry(MakeConfig(), metrics);
+    ASSERT_TRUE(registry.Observe(MakeSpan(1, {1, 2, 3})));
+    registry.RecordDropped(1, 3);
+    registry.ReportMetrics();
+    registry.ReportIngressMetrics(2, 1);
+
+    MetricsTags lane_tags{{"cluster", "cluster_a"},
+                          {"instance_group", "group_a"},
+                          {"instance_id", "instance_a"}};
+    auto quality_data = metrics->GetMetricsData("online_mrc.stream_complete");
+    ASSERT_NE(nullptr, quality_data);
+    auto quality = quality_data->GetGauge(lane_tags);
+    ASSERT_TRUE(quality.has_value());
+    EXPECT_DOUBLE_EQ(0.0, quality->Get());
+
+    auto ingress_data = metrics->GetMetricsData("online_mrc.receiver_queue_size");
+    ASSERT_NE(nullptr, ingress_data);
+    const MetricsTags empty_tags;
+    auto queue_size = ingress_data->GetGauge(empty_tags);
+    ASSERT_TRUE(queue_size.has_value());
+    EXPECT_DOUBLE_EQ(2.0, queue_size->Get());
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/test/optimizer_trace_forwarder_test.cc
+++ b/kv_cache_manager/mrc/test/optimizer_trace_forwarder_test.cc
@@ -1,0 +1,51 @@
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/event/spec_events/optimizer_event.h"
+#include "kv_cache_manager/mrc/optimizer_trace_forwarder.h"
+
+namespace kv_cache_manager {
+namespace {
+
+std::shared_ptr<CacheGetEvent> MakeCacheGetEvent(const std::string &instance_id,
+                                                 const std::vector<int64_t> &keys) {
+    auto event = std::make_shared<CacheGetEvent>(instance_id);
+    event->SetAddtionalArgs("query", keys, {}, {}, 0, {});
+    return event;
+}
+
+} // namespace
+
+TEST(OptimizerTraceForwarderTest, FiltersBeforeBoundedQueue) {
+    OptimizerTraceForwarderConfig config;
+    config.instance_allowlist = {"model-a"};
+    OptimizerTraceForwarder forwarder(config, nullptr, nullptr);
+    forwarder.InitBasicQueue(4);
+    forwarder.running_ = true;
+
+    EXPECT_TRUE(forwarder.Publish(MakeCacheGetEvent("model-b", {1, 2, 3})));
+    EXPECT_EQ(0u, forwarder.BasicQueueSize());
+    EXPECT_EQ(1u, forwarder.filtered_spans_.load());
+    EXPECT_EQ(3u, forwarder.filtered_keys_.load());
+
+    EXPECT_TRUE(forwarder.Publish(MakeCacheGetEvent("model-a", {4, 5})));
+    EXPECT_EQ(1u, forwarder.BasicQueueSize());
+    EXPECT_EQ(1u, forwarder.filtered_spans_.load());
+
+    forwarder.running_ = false;
+    forwarder.ClearBasicQueue();
+}
+
+TEST(OptimizerTraceForwarderTest, EmptyAllowlistPreservesAllInstances) {
+    OptimizerTraceForwarderConfig config;
+    OptimizerTraceForwarder forwarder(config, nullptr, nullptr);
+    forwarder.InitBasicQueue(4);
+    forwarder.running_ = true;
+
+    EXPECT_TRUE(forwarder.Publish(MakeCacheGetEvent("model-b", {1})));
+    EXPECT_EQ(1u, forwarder.BasicQueueSize());
+    EXPECT_EQ(0u, forwarder.filtered_spans_.load());
+
+    forwarder.running_ = false;
+    forwarder.ClearBasicQueue();
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/test/reuse_distance_tracker_test.cc
+++ b/kv_cache_manager/mrc/test/reuse_distance_tracker_test.cc
@@ -1,0 +1,103 @@
+#include "kv_cache_manager/mrc/reuse_distance_tracker.h"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+
+#include "kv_cache_manager/common/unittest.h"
+
+namespace kv_cache_manager {
+
+namespace {
+
+// Naive reference: recency list scan, O(n) per access.
+class NaiveStackDistance {
+public:
+    int64_t Access(int64_t key) {
+        auto it = std::find(recency_.begin(), recency_.end(), key);
+        int64_t distance = -1;
+        if (it != recency_.end()) {
+            distance = std::distance(recency_.begin(), it);
+            recency_.erase(it);
+        }
+        recency_.insert(recency_.begin(), key);
+        return distance;
+    }
+
+    bool Erase(int64_t key) {
+        auto it = std::find(recency_.begin(), recency_.end(), key);
+        if (it == recency_.end()) {
+            return false;
+        }
+        recency_.erase(it);
+        return true;
+    }
+
+private:
+    std::vector<int64_t> recency_; // MRU first
+};
+
+} // namespace
+
+TEST(ReuseDistanceTrackerTest, BasicDistances) {
+    ReuseDistanceTracker tracker;
+    // First accesses are cold.
+    EXPECT_EQ(-1, tracker.Access(1));
+    EXPECT_EQ(-1, tracker.Access(2));
+    EXPECT_EQ(-1, tracker.Access(3));
+    // Immediate re-access: no distinct key in between.
+    EXPECT_EQ(0, tracker.Access(3));
+    // 1 was followed by {2, 3}.
+    EXPECT_EQ(2, tracker.Access(1));
+    // 2 was followed by {3, 1}.
+    EXPECT_EQ(2, tracker.Access(2));
+    EXPECT_EQ(3, tracker.size());
+}
+
+TEST(ReuseDistanceTrackerTest, EraseRemovesFromStack) {
+    ReuseDistanceTracker tracker;
+    tracker.Access(1);
+    tracker.Access(2);
+    tracker.Access(3);
+    EXPECT_TRUE(tracker.Erase(2));
+    EXPECT_FALSE(tracker.Erase(2));
+    // Only 3 stands between the two accesses of 1 now.
+    EXPECT_EQ(1, tracker.Access(1));
+    EXPECT_EQ(2, tracker.size());
+}
+
+TEST(ReuseDistanceTrackerTest, MatchesNaiveOnRandomTraceWithCompaction) {
+    // Tiny initial capacity to force many Compact() rounds.
+    ReuseDistanceTracker tracker(/*initial_capacity=*/16);
+    NaiveStackDistance naive;
+
+    std::mt19937_64 rng(20260806);
+    std::uniform_int_distribution<int64_t> key_dist(0, 199);
+    std::uniform_int_distribution<int> op_dist(0, 9);
+
+    for (int i = 0; i < 20000; ++i) {
+        const int64_t key = key_dist(rng);
+        if (op_dist(rng) == 0) {
+            EXPECT_EQ(naive.Erase(key), tracker.Erase(key)) << "step " << i;
+        } else {
+            EXPECT_EQ(naive.Access(key), tracker.Access(key)) << "step " << i;
+        }
+    }
+}
+
+TEST(ReuseDistanceTrackerTest, MatchesNaiveOnZipfLikeTrace) {
+    ReuseDistanceTracker tracker(/*initial_capacity=*/64);
+    NaiveStackDistance naive;
+
+    // Zipf-ish skew via squaring a uniform variate.
+    std::mt19937_64 rng(42);
+    std::uniform_real_distribution<double> uniform(0.0, 1.0);
+    for (int i = 0; i < 20000; ++i) {
+        const double u = uniform(rng);
+        const int64_t key = static_cast<int64_t>(u * u * 500);
+        EXPECT_EQ(naive.Access(key), tracker.Access(key)) << "step " << i;
+    }
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/mrc/tools/mrc_replay_main.cc
+++ b/kv_cache_manager/mrc/tools/mrc_replay_main.cc
@@ -1,0 +1,212 @@
+// Offline replay harness for the online MRC engine (kv_cache_manager/mrc).
+//
+// Purpose: validate the online engine against the formal offline LiteHit
+// Fenwick results on the same CacheBoard trace window (P1c acceptance).
+//
+// Input (stdin), one line per request, rows must be in trace order:
+//   <lane_id>\t<hex_key>,<hex_key>,...
+// where lane_id is "deployment/pod" and hex keys are the 256-token block
+// hashes straight from the enriched trace (parsed as uint64).
+//
+// Two exact engines run side by side per lane:
+//   - exact:   LiteHitCore (request-level prefix hit + leaf-first commit,
+//              replicating the offline LiteHit semantics) with per-grid-point
+//              counters. Expected to be bit-exact vs the formal per-instance
+//              `points`.
+//   - online:  the bounded production MrcProfiler. It must match exact at
+//              every capacity <= max_capacity_blocks.
+//
+// Output: single JSON document on --output path.
+#include <algorithm>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "kv_cache_manager/mrc/lite_hit_core.h"
+#include "kv_cache_manager/mrc/mrc_profiler.h"
+
+namespace {
+
+struct Options {
+    int64_t max_capacity_blocks = 4096;
+    int64_t capacity_step_blocks = 16;
+    std::string output = "mrc-replay.json";
+};
+
+struct Lane {
+    kv_cache_manager::LiteHitCore exact{1 << 16};
+    // exact_bucket[i] counts prefix-hit thresholds t with
+    // grid[i-1] < t <= grid[i]; prefix sums give exact hit counts at each
+    // grid capacity (a block hits capacity C iff C >= t).
+    std::vector<int64_t> exact_bucket;
+    std::unique_ptr<kv_cache_manager::MrcProfiler> online;
+    int64_t total_blocks = 0;
+};
+
+// Prefix-chained block keys, replicating the offline LiteHit preprocessing
+// (`PrefixHashNext`) and matching KVCM's chained GenKeyVector semantics: a
+// block's identity embeds its whole prefix.
+int64_t PrefixHashNext(int64_t previous_hash, int64_t raw_value) {
+    const uint64_t hash = static_cast<uint64_t>(previous_hash);
+    const uint64_t value = static_cast<uint64_t>(raw_value);
+    constexpr uint64_t kGoldenRatio = 0x9e3779b97f4a7c15ULL;
+    const uint64_t rhs = value + kGoldenRatio + (hash << 12) + (hash >> 32);
+    return static_cast<int64_t>(hash ^ rhs);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto next = [&](int64_t &v) { v = (i + 1 < argc) ? strtoll(argv[++i], nullptr, 10) : v; };
+        if (arg == "--max-capacity-blocks") {
+            next(options.max_capacity_blocks);
+        } else if (arg == "--capacity-step-blocks") {
+            next(options.capacity_step_blocks);
+        } else if (arg == "--output") {
+            if (i + 1 < argc) {
+                options.output = argv[++i];
+            }
+        } else {
+            fprintf(stderr, "unknown arg: %s\n", arg.c_str());
+            return 2;
+        }
+    }
+
+    // Capacity grid: 0, step, 2*step, ..., max (matches the formal run).
+    std::vector<int64_t> grid;
+    for (int64_t c = 0; c <= options.max_capacity_blocks; c += options.capacity_step_blocks) {
+        grid.push_back(c);
+    }
+
+    kv_cache_manager::MrcProfiler::Options online_options;
+    online_options.max_tracked_blocks = options.max_capacity_blocks;
+    online_options.window_seconds = 0;
+
+    std::unordered_map<std::string, std::unique_ptr<Lane>> lanes;
+
+    std::string line;
+    std::vector<int64_t> keys;
+    std::vector<uint64_t> thresholds;
+    int64_t row_count = 0;
+    while (std::getline(std::cin, line)) {
+        const size_t tab = line.find('\t');
+        if (tab == std::string::npos || tab == 0) {
+            continue;
+        }
+        auto &lane_ptr = lanes[line.substr(0, tab)];
+        if (!lane_ptr) {
+            lane_ptr = std::make_unique<Lane>();
+            lane_ptr->exact_bucket.assign(grid.size() + 1, 0); // +1: threshold > max grid
+            lane_ptr->online = std::make_unique<kv_cache_manager::MrcProfiler>(online_options);
+        }
+        Lane &lane = *lane_ptr;
+
+        keys.clear();
+        const char *p = line.c_str() + tab + 1;
+        int64_t prefix = 0;
+        while (*p != '\0') {
+            char *end = nullptr;
+            const uint64_t key = strtoull(p, &end, 16);
+            if (end == p) {
+                break;
+            }
+            prefix = PrefixHashNext(prefix, static_cast<int64_t>(key));
+            keys.push_back(prefix);
+            p = (*end == ',') ? end + 1 : end;
+        }
+        if (keys.empty()) {
+            continue;
+        }
+
+        lane.total_blocks += static_cast<int64_t>(keys.size());
+        thresholds.clear();
+        lane.exact.ProcessRequest(keys, thresholds);
+        for (const uint64_t threshold : thresholds) {
+            // Hit at capacity C iff C >= threshold: first grid index with
+            // grid[idx] >= threshold.
+            const auto it =
+                std::lower_bound(grid.begin(), grid.end(), static_cast<int64_t>(threshold));
+            ++lane.exact_bucket[static_cast<size_t>(it - grid.begin())];
+        }
+        lane.online->Observe(keys, /*now_us=*/0);
+
+        if (++row_count % 1000000 == 0) {
+            fprintf(stderr, "processed %" PRId64 " rows, %zu lanes\n", row_count, lanes.size());
+        }
+    }
+
+    FILE *out = fopen(options.output.c_str(), "w");
+    if (out == nullptr) {
+        fprintf(stderr, "cannot open output %s\n", options.output.c_str());
+        return 1;
+    }
+    fprintf(out,
+            "{\n\"schema_version\": 2,\n\"engine\": \"kvcm-online-mrc replay (formal exact + bounded online exact)\",\n");
+    fprintf(out,
+            "\"max_capacity_blocks\": %" PRId64 ",\n\"capacity_step_blocks\": %" PRId64 ",\n",
+            options.max_capacity_blocks,
+            options.capacity_step_blocks);
+    fprintf(out, "\"capacities_blocks\": [");
+    for (size_t i = 0; i < grid.size(); ++i) {
+        fprintf(out, "%s%" PRId64, i ? "," : "", grid[i]);
+    }
+    fprintf(out, "],\n\"lanes\": [\n");
+
+    std::vector<double> grid_double(grid.begin(), grid.end());
+    bool first_lane = true;
+    for (const auto &[lane_id, lane] : lanes) {
+        if (!first_lane) {
+            fprintf(out, ",\n");
+        }
+        first_lane = false;
+
+        fprintf(out,
+                "{\"instance_id\": \"%s\", \"total_blocks\": %" PRId64 ", \"unique_blocks\": %" PRId64 ",\n",
+                lane_id.c_str(),
+                lane->total_blocks,
+                lane->exact.unique_blocks());
+
+        // Exact hit counts per grid capacity: prefix sums of the buckets.
+        // exact_bucket[i] holds thresholds in (grid[i-1], grid[i]]; capacity
+        // grid[i] therefore hits everything in buckets 0..i.
+        fprintf(out, " \"exact_hit_blocks\": [");
+        int64_t cumulative = 0;
+        for (size_t i = 0; i < grid.size(); ++i) {
+            cumulative += lane->exact_bucket[i];
+            fprintf(out, "%s%" PRId64, i ? "," : "", cumulative);
+        }
+        fprintf(out, "],\n");
+
+        kv_cache_manager::MrcProfiler::Snapshot snapshot;
+        lane->online->QueryCumulative(grid_double, snapshot);
+        fprintf(out,
+                " \"online_exact\": {\"tracked_blocks\": %" PRId64
+                ", \"memory_bytes\": %" PRId64
+                ", \"max_tracked_hit_rate\": %.17g, \"hit_rate\": [",
+                lane->online->tracked_blocks(),
+                lane->online->memory_usage_bytes(),
+                snapshot.max_tracked_hit_rate);
+        for (size_t i = 0; i < snapshot.hit_rates.size(); ++i) {
+            // max_digits10 preserves the exact binary double across the JSON
+            // round trip, so replay_compare does not confuse formatting loss
+            // with an online/offline MRC mismatch.
+            fprintf(out, "%s%.17g", i ? "," : "", snapshot.hit_rates[i]);
+        }
+        fprintf(out, "]}}");
+    }
+    fprintf(out, "\n]\n}\n");
+    fclose(out);
+
+    fprintf(stderr, "done: %" PRId64 " rows, %zu lanes -> %s\n", row_count, lanes.size(), options.output.c_str());
+    return 0;
+}

--- a/kv_cache_manager/mrc/tools/replay_compare.py
+++ b/kv_cache_manager/mrc/tools/replay_compare.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Compare mrc_replay_main output against the formal LiteHit result.
+
+Usage:
+    replay_compare.py --formal formal-litehit-7model-h23.json \
+        --replay a.replay.json [b.replay.json ...] [--scope full_day] \
+        [--output compare.json]
+
+Per matched instance it checks:
+  * exact engine: hit_blocks at every shared capacity grid point must match
+    the formal LiteHit counts (bit-exact expectation);
+  * bounded online engine: hit counts must match the formal exact result at
+    every capacity inside its configured tracking boundary.
+"""
+import argparse
+import json
+
+
+def load_replay_lanes(paths):
+    lanes = {}
+    grids = set()
+    for path in paths:
+        with open(path) as f:
+            doc = json.load(f)
+        grids.add(tuple(doc["capacities_blocks"]))
+        for lane in doc["lanes"]:
+            lanes[lane["instance_id"]] = lane
+    if len(grids) != 1:
+        raise SystemExit("replay files use different capacity grids")
+    return lanes, list(grids.pop())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--formal", required=True)
+    ap.add_argument("--replay", nargs="+", required=True)
+    ap.add_argument("--scope", default="full_day", choices=["full_day", "steady_state"])
+    ap.add_argument("--output", default="")
+    args = ap.parse_args()
+
+    with open(args.formal) as f:
+        formal = json.load(f)
+    lanes, grid = load_replay_lanes(args.replay)
+
+    formal_caps = formal["capacities_blocks"]
+    shared_caps = [c for c in formal_caps if c in set(grid)]
+    grid_index = {c: i for i, c in enumerate(grid)}
+
+    matched = 0
+    missing = []
+    exact_mismatch_instances = 0
+    exact_mismatch_points = 0
+    total_points = 0
+    block_count_mismatches = []
+    online_mismatch_points = 0
+    per_instance = []
+
+    for inst in formal["instances"]:
+        instance_id = inst["instance_id"]
+        lane = lanes.get(instance_id)
+        if lane is None:
+            missing.append(instance_id)
+            continue
+        matched += 1
+        fd = inst[args.scope]
+
+        if fd["full_blocks"] != lane["total_blocks"]:
+            block_count_mismatches.append(
+                {"instance_id": instance_id, "formal": fd["full_blocks"], "replay": lane["total_blocks"]}
+            )
+
+        formal_points = {p["quota_blocks"]: p for p in fd["points"]}
+        inst_mismatch = 0
+        inst_online_mismatch = 0
+        for cap in shared_caps:
+            fp = formal_points.get(cap)
+            if fp is None:
+                continue
+            total_points += 1
+            idx = grid_index[cap]
+            exact_hits = lane["exact_hit_blocks"][idx]
+            if exact_hits != fp["hit_blocks"]:
+                inst_mismatch += 1
+                exact_mismatch_points += 1
+            total = lane["total_blocks"]
+            if total > 0 and cap > 0:
+                online_rate = lane["online_exact"]["hit_rate"][idx]
+                # The profiler's rate is an integer hit count divided by the
+                # same total block count. Reconstruct that integer before the
+                # comparison so JSON floating-point formatting cannot turn an
+                # otherwise bit-exact result into a false mismatch.
+                online_hits = round(online_rate * total)
+                if online_hits != exact_hits:
+                    inst_online_mismatch += 1
+                    online_mismatch_points += 1
+        if inst_mismatch:
+            exact_mismatch_instances += 1
+        per_instance.append(
+            {
+                "instance_id": instance_id,
+                "total_blocks": lane["total_blocks"],
+                "exact_mismatch_points": inst_mismatch,
+                "online_mismatch_points": inst_online_mismatch,
+                "tracked_blocks": lane["online_exact"]["tracked_blocks"],
+            }
+        )
+
+    summary = {
+        "formal_instances": len(formal["instances"]),
+        "matched": matched,
+        "missing_in_replay": len(missing),
+        "block_count_mismatches": len(block_count_mismatches),
+        "exact": {
+            "compared_points": total_points,
+            "mismatch_points": exact_mismatch_points,
+            "mismatch_instances": exact_mismatch_instances,
+            "bit_exact": exact_mismatch_points == 0 and len(block_count_mismatches) == 0,
+        },
+        "bounded_online_exact": {"mismatch_points": online_mismatch_points,
+                                 "bit_exact": online_mismatch_points == 0},
+    }
+    print(json.dumps(summary, indent=2))
+    if missing[:5]:
+        print("missing sample:", missing[:5])
+    if block_count_mismatches[:3]:
+        print("block mismatch sample:", block_count_mismatches[:3])
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(
+                {"summary": summary, "missing": missing, "block_count_mismatches": block_count_mismatches,
+                 "per_instance": per_instance},
+                f,
+                indent=1,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kv_cache_manager/mrc/tools/replay_preprocess.py
+++ b/kv_cache_manager/mrc/tools/replay_preprocess.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Preprocess CacheBoard enriched traces for mrc_replay_main.
+
+Reads one ``*.enriched.jsonl`` stream on stdin (decompress .zst upstream via
+``zstd -dc``) and emits one line per request on stdout:
+
+    <timestamp_ns>\t<service>/<pod>\t<hex_key>,<hex_key>,...
+
+The formal LiteHit runner stable-sorts each replay bucket by timestamp before
+replaying, so pipe the output through a stable numeric sort and strip the
+first column before feeding mrc_replay_main:
+
+    ... | sort -t$'\t' -k1,1n -s | cut -f2-
+
+Semantics mirror the formal LiteHit run (formal-litehit-7model-h23.json):
+  * rows with ambiguous service (len != 1) or ambiguous pod (len != 1) are
+    dropped and counted separately;
+  * only full 256-token blocks count: keys = input_block_hash_ids[:input_length // 256];
+  * timestamp_ns uses the same int64 truncation as the runner.
+
+Counters are printed to stderr as JSON for cross-checking against the formal
+result's ``counters`` section.
+"""
+import json
+import sys
+
+BLOCK_TOKENS = 256
+
+
+def main() -> int:
+    input_rows = 0
+    valid_rows = 0
+    ambiguous_service = 0
+    ambiguous_pod = 0
+    invalid_rows = 0
+    emitted_blocks = 0
+
+    out = sys.stdout
+    for line in sys.stdin:
+        input_rows += 1
+        try:
+            row = json.loads(line)
+            services = row["service_names"]
+            pods = row["pods"]
+            hashes = row["input_block_hash_ids"]
+            input_length = int(row["input_length"])
+            timestamp_ns = int(float(row["timestamp"]) * 1.0e9)
+        except (KeyError, ValueError, json.JSONDecodeError):
+            invalid_rows += 1
+            continue
+        if len(services) != 1:
+            ambiguous_service += 1
+            continue
+        if len(pods) != 1:
+            ambiguous_pod += 1
+            continue
+        valid_rows += 1
+        n_full = input_length // BLOCK_TOKENS
+        if n_full <= 0:
+            continue
+        keys = hashes[:n_full]
+        if not keys:
+            continue
+        emitted_blocks += len(keys)
+        out.write(str(timestamp_ns))
+        out.write("\t")
+        out.write(services[0])
+        out.write("/")
+        out.write(pods[0])
+        out.write("\t")
+        out.write(",".join(keys))
+        out.write("\n")
+
+    print(
+        json.dumps(
+            {
+                "input_rows": input_rows,
+                "valid_rows": valid_rows,
+                "ambiguous_service": ambiguous_service,
+                "ambiguous_pod": ambiguous_pod,
+                "invalid_rows": invalid_rows,
+                "emitted_blocks": emitted_blocks,
+            }
+        ),
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kv_cache_manager/optimizer/BUILD
+++ b/kv_cache_manager/optimizer/BUILD
@@ -105,6 +105,7 @@ cc_library(
         ":optimizer_metrics_collector",
         ":optimizer_metrics_reporter",
         "//kv_cache_manager/common",
+        "//kv_cache_manager/mrc:online_mrc_fact_stream",
         "//kv_cache_manager/optimizer/config:online_optimizer_config",
         "//kv_cache_manager/optimizer/config:optimizer_registry_manager",
         "//kv_cache_manager/protocol/protobuf:service_cc_proto",
@@ -149,7 +150,7 @@ cc_library(
         "//kv_cache_manager/metrics:metrics_registry",
         "//kv_cache_manager/metrics:prometheus_exporter",
         "//kv_cache_manager/protocol/protobuf:service_cc_proto",
-        "//kv_cache_manager/service/http_service",
+        "//kv_cache_manager/service/http_service:coro_http_service",
     ],
 )
 
@@ -165,6 +166,8 @@ cc_library(
         "//kv_cache_manager/common",
         "//kv_cache_manager/common:env_util",
         "//kv_cache_manager/common:string_util",
+        "//kv_cache_manager/mrc:online_mrc_config",
+        "//kv_cache_manager/optimizer/config:online_optimizer_config",
     ],
 )
 
@@ -190,6 +193,7 @@ cc_library(
         "//kv_cache_manager/common",
         "//kv_cache_manager/metrics:metrics_registry",
         "//kv_cache_manager/optimizer/config:optimizer_registry_manager",
+        "//kv_cache_manager/mrc:online_mrc_fact_stream",
         "@grpc//:grpc++",
     ],
 )

--- a/kv_cache_manager/optimizer/config/optimizer_instance_group.cc
+++ b/kv_cache_manager/optimizer/config/optimizer_instance_group.cc
@@ -19,6 +19,7 @@ bool OptimizerInstanceGroup::FromRapidValue(const rapidjson::Value &rapid_value)
     KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "shared_group_quota", shared_group_quota_, false);
     KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "enable_theoretical_max_cache", enable_theoretical_max_cache_, false);
     KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "ttl_seconds", ttl_seconds_, int64_t(0));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "enable_prefix_hash", enable_prefix_hash_, false);
     SortCapacities();
     return true;
 }
@@ -32,6 +33,7 @@ void OptimizerInstanceGroup::ToRapidWriter(rapidjson::Writer<rapidjson::StringBu
     Put(writer, "shared_group_quota", shared_group_quota_);
     Put(writer, "enable_theoretical_max_cache", enable_theoretical_max_cache_);
     Put(writer, "ttl_seconds", ttl_seconds_);
+    Put(writer, "enable_prefix_hash", enable_prefix_hash_);
 }
 
 bool OptimizerInstanceGroup::ValidateRequiredFields(std::string &invalid_fields) const {

--- a/kv_cache_manager/optimizer/config/optimizer_instance_group.h
+++ b/kv_cache_manager/optimizer/config/optimizer_instance_group.h
@@ -25,6 +25,7 @@ public:
     bool shared_group_quota() const { return shared_group_quota_; }
     bool enable_theoretical_max_cache() const { return enable_theoretical_max_cache_; }
     int64_t ttl_seconds() const { return ttl_seconds_; }
+    bool enable_prefix_hash() const { return enable_prefix_hash_; }
 
     void set_name(const std::string &v) { name_ = v; }
     void set_capacity_gb(const std::vector<double> &v) {
@@ -35,6 +36,7 @@ public:
     void set_shared_group_quota(bool v) { shared_group_quota_ = v; }
     void set_enable_theoretical_max_cache(bool v) { enable_theoretical_max_cache_ = v; }
     void set_ttl_seconds(int64_t v) { ttl_seconds_ = v; }
+    void set_enable_prefix_hash(bool v) { enable_prefix_hash_ = v; }
 
 private:
     void SortCapacities();
@@ -45,6 +47,7 @@ private:
     bool shared_group_quota_ = false;
     bool enable_theoretical_max_cache_ = false;
     int64_t ttl_seconds_ = 0;
+    bool enable_prefix_hash_ = false;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/BUILD
+++ b/kv_cache_manager/optimizer/liteHit/BUILD
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "dynamic_fenwick_tree",
+    srcs = ["dynamic_fenwick_tree.cc"],
+    hdrs = ["dynamic_fenwick_tree.h"],
+)
+
+cc_library(
+    name = "hit_curve",
+    srcs = ["hit_curve.cc"],
+    hdrs = ["hit_curve.h"],
+)
+
+cc_library(
+    name = "request_preprocess",
+    srcs = ["request_preprocess.cc"],
+    hdrs = ["request_preprocess.h"],
+)
+
+cc_library(
+    name = "lite_hit",
+    srcs = ["lite_hit.cc"],
+    hdrs = ["lite_hit.h"],
+    deps = [
+        ":dynamic_fenwick_tree",
+        ":hit_curve",
+    ],
+)

--- a/kv_cache_manager/optimizer/liteHit/dynamic_fenwick_tree.cc
+++ b/kv_cache_manager/optimizer/liteHit/dynamic_fenwick_tree.cc
@@ -1,0 +1,54 @@
+#include "kv_cache_manager/optimizer/liteHit/dynamic_fenwick_tree.h"
+
+#include <limits>
+
+namespace kv_cache_manager {
+namespace {
+
+uint64_t SaturatingMultiply(uint64_t lhs, uint64_t rhs) {
+    if (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return lhs * rhs;
+}
+
+} // namespace
+
+DynamicFenwickTree::DynamicFenwickTree() : tree_(1, 0) {}
+
+void DynamicFenwickTree::AppendZero() {
+    const std::size_t new_index = tree_.size();
+    const std::size_t low_bit = new_index & (~new_index + 1);
+    const uint64_t range_value = PrefixSum(new_index - 1) - PrefixSum(new_index - low_bit);
+    tree_.push_back(static_cast<int64_t>(range_value));
+}
+
+void DynamicFenwickTree::Add(std::size_t index, int64_t delta) {
+    while (index > 0 && index < tree_.size()) {
+        tree_[index] += delta;
+        index += index & (~index + 1);
+    }
+}
+
+uint64_t DynamicFenwickTree::PrefixSum(std::size_t index) const {
+    if (index >= tree_.size()) {
+        index = tree_.size() - 1;
+    }
+    int64_t result = 0;
+    while (index > 0) {
+        result += tree_[index];
+        index -= index & (~index + 1);
+    }
+    return static_cast<uint64_t>(result);
+}
+
+void DynamicFenwickTree::Clear() {
+    std::vector<int64_t> empty_tree(1, 0);
+    tree_.swap(empty_tree);
+}
+
+uint64_t DynamicFenwickTree::memory_usage_bytes() const {
+    return SaturatingMultiply(static_cast<uint64_t>(tree_.capacity()), sizeof(tree_[0]));
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/dynamic_fenwick_tree.h
+++ b/kv_cache_manager/optimizer/liteHit/dynamic_fenwick_tree.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace kv_cache_manager {
+
+class DynamicFenwickTree {
+public:
+    DynamicFenwickTree();
+
+    void AppendZero();
+    void Add(std::size_t index, int64_t delta);
+    uint64_t PrefixSum(std::size_t index) const;
+    std::size_t size() const { return tree_.size() - 1; }
+    void Clear();
+    uint64_t memory_usage_bytes() const;
+
+private:
+    std::vector<int64_t> tree_;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/hit_curve.cc
+++ b/kv_cache_manager/optimizer/liteHit/hit_curve.cc
@@ -1,0 +1,31 @@
+#include "kv_cache_manager/optimizer/liteHit/hit_curve.h"
+
+#include <algorithm>
+
+namespace kv_cache_manager {
+
+uint64_t HitCurveProjector::ProjectBlocks(const RequestFact &fact, uint64_t capacity_blocks) {
+    uint64_t hits = 0;
+    for (const HitCurveSegment &segment : fact.hit_curve) {
+        if (segment.start_required_blocks > capacity_blocks) {
+            break;
+        }
+        const uint64_t reachable = capacity_blocks - segment.start_required_blocks + 1;
+        hits += std::min(segment.run_length, reachable);
+    }
+    return hits;
+}
+
+uint64_t HitCurveProjector::ProjectBytes(const RequestFact &fact, uint64_t capacity_bytes, uint64_t block_bytes) {
+    return ProjectBlocks(fact, capacity_bytes / block_bytes);
+}
+
+uint64_t HitCurveProjector::ProjectInfinite(const RequestFact &fact) {
+    uint64_t hits = 0;
+    for (const HitCurveSegment &segment : fact.hit_curve) {
+        hits += segment.run_length;
+    }
+    return hits;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/hit_curve.h
+++ b/kv_cache_manager/optimizer/liteHit/hit_curve.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace kv_cache_manager {
+
+struct HitCurveSegment {
+    uint64_t start_required_blocks = 0;
+    uint64_t run_length = 0;
+
+    bool operator==(const HitCurveSegment &other) const {
+        return start_required_blocks == other.start_required_blocks && run_length == other.run_length;
+    }
+};
+
+// Capacity-independent result for one request.
+struct RequestFact {
+    std::vector<HitCurveSegment> hit_curve;
+};
+
+class HitCurveProjector {
+public:
+    static uint64_t ProjectBlocks(const RequestFact &fact, uint64_t capacity_blocks);
+    static uint64_t ProjectBytes(const RequestFact &fact, uint64_t capacity_bytes, uint64_t block_bytes);
+    static uint64_t ProjectInfinite(const RequestFact &fact);
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.cc
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.cc
@@ -1,0 +1,134 @@
+#include "kv_cache_manager/optimizer/liteHit/lite_hit.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace kv_cache_manager {
+namespace {
+
+constexpr std::size_t kCompactionSlackPositions = 4096;
+
+} // namespace
+
+RequestFact LiteHit::ProcessRequest(const std::vector<int64_t> &block_keys) {
+    RequestFact fact = BuildHitCurve(block_keys);
+    CommitRequest(block_keys);
+    MaybeCompactPositions();
+    return fact;
+}
+
+RequestFact LiteHit::BuildHitCurve(const std::vector<int64_t> &block_keys) const {
+    RequestFact fact;
+    if (block_keys.empty()) {
+        return fact;
+    }
+
+    std::unordered_map<int64_t, SnapshotEntry> snapshot_entries;
+    snapshot_entries.reserve(block_keys.size());
+    for (int64_t block_key : block_keys) {
+        auto [entry_it, inserted] = snapshot_entries.emplace(block_key, SnapshotEntry{});
+        if (!inserted) {
+            continue;
+        }
+        const auto previous = last_positions_.find(block_key);
+        if (previous != last_positions_.end()) {
+            entry_it->second.is_resident = true;
+            entry_it->second.required_blocks = ReuseDistance(previous->second) + 1;
+        }
+    }
+
+    uint64_t prefix_required_blocks = 0;
+    uint64_t last_encoded_threshold = 0;
+    for (int64_t block_key : block_keys) {
+        const SnapshotEntry &entry = snapshot_entries.at(block_key);
+        if (!entry.is_resident) {
+            break;
+        }
+        prefix_required_blocks = std::max(prefix_required_blocks, entry.required_blocks);
+        const uint64_t threshold = std::max(prefix_required_blocks, last_encoded_threshold + 1);
+        if (!fact.hit_curve.empty() &&
+            fact.hit_curve.back().start_required_blocks + fact.hit_curve.back().run_length == threshold) {
+            fact.hit_curve.back().run_length++;
+        } else {
+            fact.hit_curve.push_back(HitCurveSegment{threshold, 1});
+        }
+        last_encoded_threshold = threshold;
+    }
+    return fact;
+}
+
+void LiteHit::CommitRequest(const std::vector<int64_t> &block_keys) {
+    if (block_keys.empty()) {
+        return;
+    }
+
+    std::unordered_map<int64_t, std::size_t> first_occurrence;
+    first_occurrence.reserve(block_keys.size());
+    for (std::size_t i = block_keys.size(); i > 0; --i) {
+        first_occurrence[block_keys[i - 1]] = i - 1;
+    }
+    for (const auto &[block_key, _] : first_occurrence) {
+        const auto previous = last_positions_.find(block_key);
+        if (previous != last_positions_.end()) {
+            fenwick_.Add(previous->second, -1);
+            last_positions_.erase(previous);
+        }
+    }
+    for (std::size_t i = block_keys.size(); i > 0; --i) {
+        const int64_t block_key = block_keys[i - 1];
+        if (first_occurrence.at(block_key) != i - 1) {
+            continue;
+        }
+        fenwick_.AppendZero();
+        const std::size_t current_position = fenwick_.size();
+        fenwick_.Add(current_position, 1);
+        last_positions_[block_key] = current_position;
+    }
+}
+
+void LiteHit::MaybeCompactPositions() {
+    const std::size_t active_positions = last_positions_.size();
+    if (fenwick_.size() <= kCompactionSlackPositions) {
+        return;
+    }
+    const std::size_t positions_over_slack = fenwick_.size() - kCompactionSlackPositions;
+    if (active_positions >= (positions_over_slack + 1) / 2) {
+        return;
+    }
+
+    std::vector<std::pair<std::size_t, int64_t>> ordered_positions;
+    ordered_positions.reserve(active_positions);
+    for (const auto &[block_key, position] : last_positions_) {
+        ordered_positions.emplace_back(position, block_key);
+    }
+    std::sort(ordered_positions.begin(), ordered_positions.end());
+
+    DynamicFenwickTree compacted_fenwick;
+    for (const auto &[_, block_key] : ordered_positions) {
+        compacted_fenwick.AppendZero();
+        const std::size_t compacted_position = compacted_fenwick.size();
+        compacted_fenwick.Add(compacted_position, 1);
+        last_positions_[block_key] = compacted_position;
+    }
+    fenwick_ = std::move(compacted_fenwick);
+}
+
+uint64_t LiteHit::ReuseDistance(std::size_t previous_position) const {
+    return fenwick_.PrefixSum(fenwick_.size()) - fenwick_.PrefixSum(previous_position);
+}
+
+void LiteHit::Reset() {
+    fenwick_.Clear();
+    last_positions_.clear();
+}
+
+uint64_t LiteHit::memory_usage_bytes() const {
+    uint64_t bytes = fenwick_.memory_usage_bytes();
+    bytes += static_cast<uint64_t>(last_positions_.bucket_count()) * sizeof(void *);
+    constexpr uint64_t kEstimatedHashNodeOverhead = sizeof(void *) * 2;
+    bytes += static_cast<uint64_t>(last_positions_.size()) *
+             (sizeof(std::pair<const int64_t, std::size_t>) + kEstimatedHashNodeOverhead);
+    return bytes;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/lite_hit.h
+++ b/kv_cache_manager/optimizer/liteHit/lite_hit.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "kv_cache_manager/optimizer/liteHit/dynamic_fenwick_tree.h"
+#include "kv_cache_manager/optimizer/liteHit/hit_curve.h"
+
+namespace kv_cache_manager {
+
+// Exact, capacity-independent LRU replay core shared by online and offline.
+class LiteHit {
+public:
+    LiteHit() = default;
+
+    RequestFact ProcessRequest(const std::vector<int64_t> &block_keys);
+    void Reset();
+
+    uint64_t current_unique_blocks() const { return static_cast<uint64_t>(last_positions_.size()); }
+    uint64_t memory_usage_bytes() const;
+
+private:
+    struct SnapshotEntry {
+        bool is_resident = false;
+        uint64_t required_blocks = 0;
+    };
+
+    RequestFact BuildHitCurve(const std::vector<int64_t> &block_keys) const;
+    void CommitRequest(const std::vector<int64_t> &block_keys);
+    void MaybeCompactPositions();
+    uint64_t ReuseDistance(std::size_t previous_position) const;
+
+    DynamicFenwickTree fenwick_;
+    std::unordered_map<int64_t, std::size_t> last_positions_;
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/request_preprocess.cc
+++ b/kv_cache_manager/optimizer/liteHit/request_preprocess.cc
@@ -1,0 +1,68 @@
+#include "kv_cache_manager/optimizer/liteHit/request_preprocess.h"
+
+#include <stdexcept>
+
+namespace kv_cache_manager {
+
+int64_t PrefixHashNext(int64_t previous_hash, int64_t raw_value) {
+    const uint64_t hash = static_cast<uint64_t>(previous_hash);
+    const uint64_t value = static_cast<uint64_t>(raw_value);
+    constexpr uint64_t kGoldenRatio = 0x9e3779b97f4a7c15ULL;
+    const uint64_t rhs = value + kGoldenRatio + (hash << 12) + (hash >> 32);
+    return static_cast<int64_t>(hash ^ rhs);
+}
+
+std::vector<int64_t> ApplyPrefixHash(const std::vector<int64_t> &raw_keys) {
+    std::vector<int64_t> prefix_keys;
+    prefix_keys.reserve(raw_keys.size());
+    int64_t hash = 0;
+    for (int64_t raw_key : raw_keys) {
+        hash = PrefixHashNext(hash, raw_key);
+        prefix_keys.push_back(hash);
+    }
+    return prefix_keys;
+}
+
+NormalizedRequest NormalizeRequest(const std::vector<int64_t> &block_keys,
+                                   int64_t input_token_len,
+                                   uint64_t block_size_tokens,
+                                   bool enable_prefix_hash,
+                                   uint64_t trace_block_size_tokens) {
+    if (block_size_tokens == 0) {
+        throw std::invalid_argument("NormalizeRequest block_size_tokens must be positive");
+    }
+    if (input_token_len < 0) {
+        throw std::invalid_argument("NormalizeRequest input_token_len must not be negative");
+    }
+    if (trace_block_size_tokens == 0) {
+        trace_block_size_tokens = block_size_tokens;
+    }
+    if (block_size_tokens % trace_block_size_tokens != 0) {
+        throw std::invalid_argument(
+            "NormalizeRequest block_size_tokens must be a multiple of the trace block size (coarsening only)");
+    }
+
+    NormalizedRequest normalized;
+    normalized.input_token_len = input_token_len > 0
+                                     ? static_cast<uint64_t>(input_token_len)
+                                     : static_cast<uint64_t>(block_keys.size()) * trace_block_size_tokens;
+    const uint64_t expected_trace_blocks = normalized.input_token_len / trace_block_size_tokens;
+    if (expected_trace_blocks != static_cast<uint64_t>(block_keys.size())) {
+        throw std::invalid_argument(
+            "NormalizeRequest block_keys must contain exactly floor(input_token_len / trace_block_size) blocks");
+    }
+
+    std::vector<int64_t> chained = enable_prefix_hash ? ApplyPrefixHash(block_keys) : block_keys;
+    const uint64_t stride = block_size_tokens / trace_block_size_tokens;
+    if (stride == 1) {
+        normalized.block_keys = std::move(chained);
+        return normalized;
+    }
+    normalized.block_keys.reserve(chained.size() / stride);
+    for (std::size_t i = stride - 1; i < chained.size(); i += stride) {
+        normalized.block_keys.push_back(chained[i]);
+    }
+    return normalized;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/liteHit/request_preprocess.h
+++ b/kv_cache_manager/optimizer/liteHit/request_preprocess.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace kv_cache_manager {
+
+int64_t PrefixHashNext(int64_t previous_hash, int64_t raw_value);
+std::vector<int64_t> ApplyPrefixHash(const std::vector<int64_t> &raw_keys);
+
+struct NormalizedRequest {
+    std::vector<int64_t> block_keys;
+    uint64_t input_token_len = 0;
+};
+
+NormalizedRequest NormalizeRequest(const std::vector<int64_t> &block_keys,
+                                   int64_t input_token_len,
+                                   uint64_t block_size_tokens,
+                                   bool enable_prefix_hash,
+                                   uint64_t trace_block_size_tokens = 0);
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/service/grpc/optimizer_service_grpc.cc
+++ b/kv_cache_manager/optimizer/service/grpc/optimizer_service_grpc.cc
@@ -129,4 +129,14 @@ grpc::Status OptimizerServiceGRpc::ResetStats(grpc::ServerContext *context,
     return grpc::Status::OK;
 }
 
+grpc::Status OptimizerServiceGRpc::UpdateOnlineMrcProjectionConfig(
+    grpc::ServerContext *context,
+    const proto::optimizer::UpdateOnlineMrcProjectionConfigRequest *request,
+    proto::optimizer::UpdateOnlineMrcProjectionConfigResponse *response) {
+    RequestContext request_context(request->trace_id(), MakeCollector(metrics_registry_));
+    request_context.set_client_ip(ExtractIpFromPeer(context->peer()));
+    service_impl_->UpdateOnlineMrcProjectionConfig(&request_context, request, response);
+    return grpc::Status::OK;
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/service/grpc/optimizer_service_grpc.h
+++ b/kv_cache_manager/optimizer/service/grpc/optimizer_service_grpc.h
@@ -62,6 +62,11 @@ public:
                             const proto::optimizer::OptimizerResetStatsRequest *request,
                             proto::optimizer::OptimizerResetStatsResponse *response) override;
 
+    grpc::Status UpdateOnlineMrcProjectionConfig(
+        grpc::ServerContext *context,
+        const proto::optimizer::UpdateOnlineMrcProjectionConfigRequest *request,
+        proto::optimizer::UpdateOnlineMrcProjectionConfigResponse *response) override;
+
 private:
     std::shared_ptr<OptimizerServiceImpl> service_impl_;
     std::shared_ptr<MetricsRegistry> metrics_registry_;

--- a/kv_cache_manager/optimizer/service/http/optimizer_service_http.cc
+++ b/kv_cache_manager/optimizer/service/http/optimizer_service_http.cc
@@ -72,6 +72,11 @@ void OptimizerServiceHttp::RegisterHandler() {
         Post, "/api/optimizer/listInstances", OptimizerListInstances, OptimizerListInstances, ListInstances);
     REGISTER_HTTP_HANDLER_FOR_OPTIMIZER_SERVICE(
         Post, "/api/optimizer/resetStats", OptimizerResetStats, OptimizerResetStats, ResetStats);
+    REGISTER_HTTP_HANDLER_FOR_OPTIMIZER_SERVICE(Post,
+                                                "/api/optimizer/updateOnlineMrcProjectionConfig",
+                                                UpdateOnlineMrcProjectionConfig,
+                                                UpdateOnlineMrcProjectionConfig,
+                                                UpdateOnlineMrcProjectionConfig);
 }
 
 // InstanceGroup CRUD
@@ -166,6 +171,15 @@ void OptimizerServiceHttp::ResetStats(coro_http::coro_http_connection *http_conn
     RequestContext request_context(request->trace_id(), MakeCollector(metrics_registry_));
     request_context.set_client_ip(CoroHttpService::GetHttpClientIp(http_conn));
     service_impl_->ResetStats(&request_context, request, response);
+}
+
+void OptimizerServiceHttp::UpdateOnlineMrcProjectionConfig(
+    coro_http::coro_http_connection *http_conn,
+    proto::optimizer::UpdateOnlineMrcProjectionConfigRequest *request,
+    proto::optimizer::UpdateOnlineMrcProjectionConfigResponse *response) {
+    RequestContext request_context(request->trace_id(), MakeCollector(metrics_registry_));
+    request_context.set_client_ip(CoroHttpService::GetHttpClientIp(http_conn));
+    service_impl_->UpdateOnlineMrcProjectionConfig(&request_context, request, response);
 }
 
 void OptimizerServiceHttp::RegisterPrometheusEndpoint(std::shared_ptr<MetricsRegistry> registry,

--- a/kv_cache_manager/optimizer/service/http/optimizer_service_http.h
+++ b/kv_cache_manager/optimizer/service/http/optimizer_service_http.h
@@ -9,7 +9,6 @@
 namespace kv_cache_manager {
 
 class OptimizerServiceImpl;
-
 class OptimizerServiceHttp : public CoroHttpService {
 public:
     OptimizerServiceHttp(std::shared_ptr<OptimizerServiceImpl> service_impl,
@@ -66,6 +65,11 @@ public:
     void ResetStats(coro_http::coro_http_connection *http_conn,
                     proto::optimizer::OptimizerResetStatsRequest *request,
                     proto::optimizer::OptimizerResetStatsResponse *response);
+
+    void UpdateOnlineMrcProjectionConfig(
+        coro_http::coro_http_connection *http_conn,
+        proto::optimizer::UpdateOnlineMrcProjectionConfigRequest *request,
+        proto::optimizer::UpdateOnlineMrcProjectionConfigResponse *response);
 
 private:
     std::shared_ptr<OptimizerServiceImpl> service_impl_;

--- a/kv_cache_manager/optimizer/service/online_optimizer_server.cc
+++ b/kv_cache_manager/optimizer/service/online_optimizer_server.cc
@@ -7,6 +7,8 @@
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
+#include "kv_cache_manager/mrc/kvcm_event_stream_client.h"
+#include "kv_cache_manager/mrc/online_mrc_fact_registry.h"
 #include "kv_cache_manager/optimizer/config/optimizer_registry_manager.h"
 #include "kv_cache_manager/optimizer/online_runtime/online_optimizer_manager.h"
 #include "kv_cache_manager/optimizer/service/grpc/optimizer_service_grpc.h"
@@ -33,6 +35,10 @@ bool OnlineOptimizerServer::Init(const std::string &config_file, const EnvironMa
         KVCM_LOG_ERROR("Failed to override config from environ");
         return false;
     }
+    if (!config_.Check()) {
+        KVCM_LOG_ERROR("Invalid optimizer server config");
+        return false;
+    }
 
     // Create registry first, then manager holds it
     registry_manager_ = std::make_shared<OptimizerRegistryManager>(config_.registry_storage_uri());
@@ -56,7 +62,23 @@ bool OnlineOptimizerServer::Init(const std::string &config_file, const EnvironMa
         KVCM_LOG_WARN("KMonitor init failed, kmonitor metrics disabled");
     }
 
-    service_impl_ = std::make_shared<OptimizerServiceImpl>(manager_, metrics_reporter_);
+    if (config_.online_mrc_config().enable) {
+        online_mrc_fact_registry_ = std::make_shared<OnlineMrcFactRegistry>(
+            config_.online_mrc_config(), config_.online_mrc_instance_groups(), metrics_registry_, manager_);
+        if (!online_mrc_fact_registry_->Init()) {
+            KVCM_LOG_ERROR("Failed to create online MRC formal instance groups");
+            return false;
+        }
+        kvcm_event_stream_client_ = std::make_shared<KvcmEventStreamClient>(
+            config_.online_mrc_config(), online_mrc_fact_registry_, metrics_registry_);
+        if (!kvcm_event_stream_client_->Init()) {
+            KVCM_LOG_ERROR("Failed to initialize optimizer-side KVCM event stream client");
+            return false;
+        }
+    }
+
+    service_impl_ =
+        std::make_shared<OptimizerServiceImpl>(manager_, metrics_reporter_, online_mrc_fact_registry_);
 
     KVCM_LOG_INFO("OnlineOptimizerServer initialized");
     return true;
@@ -112,6 +134,11 @@ bool OnlineOptimizerServer::Start() {
     if (!InitHttpServer())
         return false;
 
+    if (kvcm_event_stream_client_ && !kvcm_event_stream_client_->Start()) {
+        KVCM_LOG_ERROR("Failed to start optimizer-side KVCM event stream client");
+        return false;
+    }
+
     running_ = true;
 
     if (recovery_needed_) {
@@ -163,6 +190,9 @@ void OnlineOptimizerServer::DoStop() {
     if (metrics_thread_.joinable()) {
         metrics_thread_.join();
     }
+    if (kvcm_event_stream_client_) {
+        kvcm_event_stream_client_->Stop();
+    }
     if (metrics_reporter_) {
         metrics_reporter_->ShutdownKmonitor();
     }
@@ -177,10 +207,20 @@ void OnlineOptimizerServer::WaitForShutdown() {
 }
 
 void OnlineOptimizerServer::MetricsReportLoop() {
+    auto next_mrc_report = std::chrono::steady_clock::now() +
+                           std::chrono::seconds(config_.online_mrc_config().report_interval_seconds);
     while (running_) {
         std::this_thread::sleep_for(std::chrono::milliseconds(config_.metrics_report_interval_ms()));
         if (!running_)
             break;
+        const auto now = std::chrono::steady_clock::now();
+        if (online_mrc_fact_registry_ && now >= next_mrc_report) {
+            online_mrc_fact_registry_->ReportMetrics();
+            next_mrc_report = now + std::chrono::seconds(config_.online_mrc_config().report_interval_seconds);
+        }
+        if (kvcm_event_stream_client_) {
+            kvcm_event_stream_client_->ReportMetrics();
+        }
         metrics_reporter_->ReportInterval();
     }
 }

--- a/kv_cache_manager/optimizer/service/online_optimizer_server.h
+++ b/kv_cache_manager/optimizer/service/online_optimizer_server.h
@@ -19,6 +19,8 @@ class OptimizerServiceHttp;
 class OptimizerRegistryManager;
 class OptimizerMetricsReporter;
 class MetricsRegistry;
+class OnlineMrcFactRegistry;
+class KvcmEventStreamClient;
 
 class OnlineOptimizerServer {
 public:
@@ -51,6 +53,8 @@ private:
     std::shared_ptr<OptimizerRegistryManager> registry_manager_;
     std::shared_ptr<OptimizerMetricsReporter> metrics_reporter_;
     std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::shared_ptr<OnlineMrcFactRegistry> online_mrc_fact_registry_;
+    std::shared_ptr<KvcmEventStreamClient> kvcm_event_stream_client_;
 
     std::unique_ptr<grpc::Server> grpc_server_;
     std::thread http_thread_;

--- a/kv_cache_manager/optimizer/service/online_optimizer_server_config.cc
+++ b/kv_cache_manager/optimizer/service/online_optimizer_server_config.cc
@@ -1,11 +1,29 @@
 #include "kv_cache_manager/optimizer/service/online_optimizer_server_config.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 #include "kv_cache_manager/common/env_util.h"
 #include "kv_cache_manager/common/string_util.h"
 
 namespace kv_cache_manager {
+namespace {
+
+class OnlineMrcGroupsConfig : public Jsonizable {
+public:
+    bool FromRapidValue(const rapidjson::Value &value) override {
+        KVCM_JSON_GET_MACRO(value, "instance_groups", instance_groups);
+        return true;
+    }
+
+    void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override {
+        Put(writer, "instance_groups", instance_groups);
+    }
+
+    std::vector<OptimizerInstanceGroup> instance_groups;
+};
+
+} // namespace
 
 // clang-format off
 std::unordered_map<std::string, OnlineOptimizerServerConfig::SettingFunction>
@@ -50,6 +68,67 @@ std::unordered_map<std::string, OnlineOptimizerServerConfig::SettingFunction>
          config->io_thread_num_ = std::stoi(value);
          return true;
      }},
+    {"optimizer.online_mrc.enable",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.enable = value == "true";
+         return true;
+     }},
+    {"optimizer.online_mrc.capacity_gb_grid",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         auto grid = StringUtil::ParseBucketBoundaries(value);
+         if (grid.empty()) return false;
+         config->online_mrc_config_.capacity_gb_grid = std::move(grid);
+         return true;
+     }},
+    {"optimizer.online_mrc.report_interval_seconds",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.report_interval_seconds = std::stol(value);
+         return true;
+     }},
+    {"optimizer.online_mrc.instance_groups",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         OnlineMrcGroupsConfig parsed;
+         if (!parsed.FromJsonString("{\"instance_groups\":" + value + "}") || parsed.instance_groups.empty()) {
+             return false;
+         }
+         config->online_mrc_instance_groups_ = std::move(parsed.instance_groups);
+         return true;
+     }},
+    {"optimizer.online_mrc.max_instances",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.max_instances = std::stoi(value);
+         return true;
+     }},
+    {"optimizer.online_mrc.receiver_queue_max_batches",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.receiver_queue_max_batches = std::stol(value);
+         return true;
+     }},
+    {"optimizer.online_mrc.kvcm_service_discovery_url",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.kvcm_service_discovery_url = value;
+         return true;
+     }},
+    {"optimizer.online_mrc.discovery_refresh_interval_ms",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.discovery_refresh_interval_ms = std::stol(value);
+         return true;
+     }},
+    {"optimizer.online_mrc.connect_timeout_ms",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.connect_timeout_ms = std::stol(value);
+         return true;
+     }},
+    {"optimizer.online_mrc.reconnect_interval_ms",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.reconnect_interval_ms = std::stol(value);
+         return true;
+     }},
+    {"optimizer.online_mrc.max_frame_bytes",
+     [](const std::string &value, OnlineOptimizerServerConfig *config) {
+         config->online_mrc_config_.max_frame_bytes = std::stol(value);
+         return true;
+     }},
 };
 // clang-format on
 
@@ -62,6 +141,39 @@ bool OnlineOptimizerServerConfig::FromRapidValue(const rapidjson::Value &rapid_v
     KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "enable_prometheus", enable_prometheus_, true);
     KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "prometheus_prefix", prometheus_prefix_, std::string("kvcm_optimizer"));
     KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "io_thread_num", io_thread_num_, int32_t(4));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "online_mrc_enable", online_mrc_config_.enable, false);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "online_mrc_capacity_gb_grid",
+                                online_mrc_config_.capacity_gb_grid,
+                                std::vector<double>({64, 128, 256, 340, 512, 1024}));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "online_mrc_report_interval_seconds",
+                                online_mrc_config_.report_interval_seconds,
+                                int64_t(60));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "online_mrc_instance_groups",
+                                online_mrc_instance_groups_,
+                                std::vector<OptimizerInstanceGroup>());
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "online_mrc_max_instances", online_mrc_config_.max_instances, int32_t(256));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "online_mrc_receiver_queue_max_batches",
+                                online_mrc_config_.receiver_queue_max_batches,
+                                int64_t(1024));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "online_mrc_kvcm_service_discovery_url",
+                                online_mrc_config_.kvcm_service_discovery_url,
+                                std::string(""));
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "online_mrc_discovery_refresh_interval_ms",
+                                online_mrc_config_.discovery_refresh_interval_ms,
+                                int64_t(30000));
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "online_mrc_connect_timeout_ms", online_mrc_config_.connect_timeout_ms, int64_t(500));
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "online_mrc_reconnect_interval_ms", online_mrc_config_.reconnect_interval_ms, int64_t(1000));
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "online_mrc_max_frame_bytes", online_mrc_config_.max_frame_bytes, int64_t(8 * 1024 * 1024));
     return true;
 }
 
@@ -74,6 +186,17 @@ void OnlineOptimizerServerConfig::ToRapidWriter(rapidjson::Writer<rapidjson::Str
     Put(writer, "enable_prometheus", enable_prometheus_);
     Put(writer, "prometheus_prefix", prometheus_prefix_);
     Put(writer, "io_thread_num", io_thread_num_);
+    Put(writer, "online_mrc_enable", online_mrc_config_.enable);
+    Put(writer, "online_mrc_capacity_gb_grid", online_mrc_config_.capacity_gb_grid);
+    Put(writer, "online_mrc_report_interval_seconds", online_mrc_config_.report_interval_seconds);
+    Put(writer, "online_mrc_instance_groups", online_mrc_instance_groups_);
+    Put(writer, "online_mrc_max_instances", online_mrc_config_.max_instances);
+    Put(writer, "online_mrc_receiver_queue_max_batches", online_mrc_config_.receiver_queue_max_batches);
+    Put(writer, "online_mrc_kvcm_service_discovery_url", online_mrc_config_.kvcm_service_discovery_url);
+    Put(writer, "online_mrc_discovery_refresh_interval_ms", online_mrc_config_.discovery_refresh_interval_ms);
+    Put(writer, "online_mrc_connect_timeout_ms", online_mrc_config_.connect_timeout_ms);
+    Put(writer, "online_mrc_reconnect_interval_ms", online_mrc_config_.reconnect_interval_ms);
+    Put(writer, "online_mrc_max_frame_bytes", online_mrc_config_.max_frame_bytes);
 }
 
 bool OnlineOptimizerServerConfig::OverrideFromEnviron(const EnvironMap &environ) {
@@ -101,6 +224,48 @@ bool OnlineOptimizerServerConfig::OverrideFromEnviron(const EnvironMap &environ)
         }
     }
     return success;
+}
+
+bool OnlineOptimizerServerConfig::Check() const {
+    if (rpc_port_ < 1 || rpc_port_ > 65535 || http_port_ < 1 || http_port_ > 65535 ||
+        metrics_report_interval_ms_ <= 0 || io_thread_num_ <= 0) {
+        fprintf(stderr, "Invalid optimizer server port/thread/report settings\n");
+        return false;
+    }
+    if (!online_mrc_config_.enable) {
+        return true;
+    }
+    if (online_mrc_config_.report_interval_seconds <= 0 || online_mrc_config_.max_instances <= 0 ||
+        online_mrc_config_.receiver_queue_max_batches <= 0 ||
+        online_mrc_config_.capacity_gb_grid.empty() || online_mrc_instance_groups_.empty()) {
+        fprintf(stderr, "Invalid optimizer online MRC bounds\n");
+        return false;
+    }
+    if (online_mrc_config_.kvcm_service_discovery_url.empty() ||
+        online_mrc_config_.discovery_refresh_interval_ms <= 0 || online_mrc_config_.connect_timeout_ms <= 0 ||
+        online_mrc_config_.reconnect_interval_ms <= 0 || online_mrc_config_.max_frame_bytes <= 1) {
+        fprintf(stderr, "Invalid optimizer-initiated online MRC stream settings\n");
+        return false;
+    }
+    double previous = 0;
+    for (const double capacity_gb : online_mrc_config_.capacity_gb_grid) {
+        if (capacity_gb <= previous) {
+            fprintf(stderr, "optimizer online MRC capacity grid must be positive and strictly increasing\n");
+            return false;
+        }
+        previous = capacity_gb;
+    }
+    std::unordered_set<std::string> unique_groups;
+    for (const auto &group : online_mrc_instance_groups_) {
+        std::string invalid_fields;
+        if (!group.ValidateRequiredFields(invalid_fields) || !group.enable_prefix_hash() ||
+            !unique_groups.emplace(group.name()).second) {
+            fprintf(stderr,
+                    "optimizer online MRC instance groups must be valid, unique, and enable_prefix_hash=true\n");
+            return false;
+        }
+    }
+    return true;
 }
 
 void OnlineOptimizerServerConfig::UpdateEnviron(EnvironMap &environ) {

--- a/kv_cache_manager/optimizer/service/online_optimizer_server_config.h
+++ b/kv_cache_manager/optimizer/service/online_optimizer_server_config.h
@@ -4,8 +4,11 @@
 #include <functional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "kv_cache_manager/common/jsonizable.h"
+#include "kv_cache_manager/mrc/online_mrc_config.h"
+#include "kv_cache_manager/optimizer/config/optimizer_instance_group.h"
 
 namespace kv_cache_manager {
 
@@ -21,6 +24,7 @@ public:
     void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
 
     bool OverrideFromEnviron(const EnvironMap &environ);
+    bool Check() const;
 
     int32_t rpc_port() const { return rpc_port_; }
     int32_t http_port() const { return http_port_; }
@@ -30,6 +34,10 @@ public:
     bool enable_prometheus() const { return enable_prometheus_; }
     const std::string &prometheus_prefix() const { return prometheus_prefix_; }
     int32_t io_thread_num() const { return io_thread_num_; }
+    const OnlineMrcConfig &online_mrc_config() const { return online_mrc_config_; }
+    const std::vector<OptimizerInstanceGroup> &online_mrc_instance_groups() const {
+        return online_mrc_instance_groups_;
+    }
 
 private:
     void UpdateEnviron(EnvironMap &environ);
@@ -42,6 +50,8 @@ private:
     bool enable_prometheus_ = true;
     std::string prometheus_prefix_ = "kvcm_optimizer";
     int32_t io_thread_num_ = 4;
+    OnlineMrcConfig online_mrc_config_;
+    std::vector<OptimizerInstanceGroup> online_mrc_instance_groups_;
 
     using SettingFunction = std::function<bool(const std::string &, OnlineOptimizerServerConfig *)>;
     static std::unordered_map<std::string, SettingFunction> kSettingsMap;

--- a/kv_cache_manager/optimizer/service/optimizer_service_impl.cc
+++ b/kv_cache_manager/optimizer/service/optimizer_service_impl.cc
@@ -3,6 +3,7 @@
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/mrc/online_mrc_fact_registry.h"
 #include "kv_cache_manager/optimizer/config/optimizer_instance_group.h"
 #include "kv_cache_manager/optimizer/config/optimizer_instance_info.h"
 #include "kv_cache_manager/optimizer/config/optimizer_registry_manager.h"
@@ -37,6 +38,7 @@ OptimizerInstanceGroup ConvertProtoToInstanceGroup(const proto::optimizer::Optim
     group.set_shared_group_quota(pb.shared_group_quota());
     group.set_enable_theoretical_max_cache(pb.enable_theoretical_max_cache());
     group.set_ttl_seconds(pb.ttl_seconds());
+    group.set_enable_prefix_hash(pb.enable_prefix_hash());
     return group;
 }
 
@@ -49,6 +51,7 @@ void ConvertInstanceGroupToProto(const OptimizerInstanceGroup &group,
     pb->set_shared_group_quota(group.shared_group_quota());
     pb->set_ttl_seconds(group.ttl_seconds());
     pb->set_enable_theoretical_max_cache(group.enable_theoretical_max_cache());
+    pb->set_enable_prefix_hash(group.enable_prefix_hash());
     if (group.eviction_policy() == "lru") {
         pb->set_eviction_policy(proto::optimizer::OPTIMIZER_EVICTION_POLICY_LRU);
     } else {
@@ -92,8 +95,11 @@ void SetErrorOnCollector(RequestContext *request_context, ErrorCode ec) {
 } // namespace
 
 OptimizerServiceImpl::OptimizerServiceImpl(std::shared_ptr<OnlineOptimizerManager> manager,
-                                           std::shared_ptr<OptimizerMetricsReporter> metrics_reporter)
-    : manager_(std::move(manager)), metrics_reporter_(std::move(metrics_reporter)) {}
+                                           std::shared_ptr<OptimizerMetricsReporter> metrics_reporter,
+                                           std::shared_ptr<OnlineMrcFactRegistry> online_mrc_fact_registry)
+    : manager_(std::move(manager)),
+      metrics_reporter_(std::move(metrics_reporter)),
+      online_mrc_fact_registry_(std::move(online_mrc_fact_registry)) {}
 
 // InstanceGroup CRUD
 
@@ -391,6 +397,31 @@ void OptimizerServiceImpl::ResetStats(RequestContext *request_context,
 
     if (ec == EC_OK && metrics_reporter_) {
         metrics_reporter_->RemoveInstanceMetrics(instance_id);
+    }
+
+    SetPbResponseHeader(response->mutable_header(), ec);
+    request_context->set_status_code(static_cast<int>(ec));
+    SetErrorOnCollector(request_context, ec);
+}
+
+void OptimizerServiceImpl::UpdateOnlineMrcProjectionConfig(
+    RequestContext *request_context,
+    const proto::optimizer::UpdateOnlineMrcProjectionConfigRequest *request,
+    proto::optimizer::UpdateOnlineMrcProjectionConfigResponse *response) {
+    request_context->set_api_name("UpdateOnlineMrcProjectionConfig");
+    OptimizerCallGuard guard(request_context, metrics_reporter_.get());
+
+    ErrorCode ec = EC_UNIMPLEMENTED;
+    if (online_mrc_fact_registry_) {
+        const std::vector<double> capacity_gb_grid(request->capacity_gb_grid().begin(),
+                                                   request->capacity_gb_grid().end());
+        ec = online_mrc_fact_registry_->UpdateCapacityGrid(capacity_gb_grid) ? EC_OK : EC_BADARGS;
+        if (ec == EC_OK) {
+            for (const double capacity_gb : online_mrc_fact_registry_->CapacityGrid()) {
+                response->add_capacity_gb_grid(capacity_gb);
+            }
+            response->set_projection_generation(online_mrc_fact_registry_->ProjectionGeneration());
+        }
     }
 
     SetPbResponseHeader(response->mutable_header(), ec);

--- a/kv_cache_manager/optimizer/service/optimizer_service_impl.h
+++ b/kv_cache_manager/optimizer/service/optimizer_service_impl.h
@@ -7,6 +7,7 @@
 namespace kv_cache_manager {
 
 class OnlineOptimizerManager;
+class OnlineMrcFactRegistry;
 class OptimizerMetricsReporter;
 class OptimizerRegistryManager;
 class RequestContext;
@@ -14,7 +15,8 @@ class RequestContext;
 class OptimizerServiceImpl {
 public:
     OptimizerServiceImpl(std::shared_ptr<OnlineOptimizerManager> manager,
-                         std::shared_ptr<OptimizerMetricsReporter> metrics_reporter);
+                         std::shared_ptr<OptimizerMetricsReporter> metrics_reporter,
+                         std::shared_ptr<OnlineMrcFactRegistry> online_mrc_fact_registry = nullptr);
     ~OptimizerServiceImpl() = default;
 
     OptimizerServiceImpl(const OptimizerServiceImpl &) = delete;
@@ -67,9 +69,15 @@ public:
                     const proto::optimizer::OptimizerResetStatsRequest *request,
                     proto::optimizer::OptimizerResetStatsResponse *response);
 
+    void UpdateOnlineMrcProjectionConfig(
+        RequestContext *request_context,
+        const proto::optimizer::UpdateOnlineMrcProjectionConfigRequest *request,
+        proto::optimizer::UpdateOnlineMrcProjectionConfigResponse *response);
+
 private:
     std::shared_ptr<OnlineOptimizerManager> manager_;
     std::shared_ptr<OptimizerMetricsReporter> metrics_reporter_;
+    std::shared_ptr<OnlineMrcFactRegistry> online_mrc_fact_registry_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/test/BUILD
+++ b/kv_cache_manager/optimizer/test/BUILD
@@ -204,9 +204,10 @@ cc_test(
     copts = ["-fno-access-control"],
     deps = [
         "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/mrc:online_mrc_config",
+        "//kv_cache_manager/mrc:online_mrc_fact_stream",
         "//kv_cache_manager/optimizer:online_optimizer_manager",
         "//kv_cache_manager/optimizer:optimizer_service_impl",
-        "//kv_cache_manager/optimizer/config",
         "//kv_cache_manager/optimizer/config:optimizer_registry_manager",
         "//kv_cache_manager/protocol/protobuf:service_cc_proto",
     ],

--- a/kv_cache_manager/optimizer/test/online_optimizer_server_config_test.cc
+++ b/kv_cache_manager/optimizer/test/online_optimizer_server_config_test.cc
@@ -134,4 +134,73 @@ TEST_F(OnlineOptimizerServerConfigTest, UnderscoreEnvKeyFallback) {
     EXPECT_EQ(8888, config.http_port());
 }
 
+TEST_F(OnlineOptimizerServerConfigTest, OnlineMrcDefaultsOffAndValid) {
+    OnlineOptimizerServerConfig config;
+    EXPECT_FALSE(config.online_mrc_config().enable);
+    EXPECT_EQ(60, config.online_mrc_config().report_interval_seconds);
+    EXPECT_TRUE(config.Check());
+}
+
+TEST_F(OnlineOptimizerServerConfigTest, OnlineMrcRequiresKvcmServiceDiscovery) {
+    OnlineOptimizerServerConfig config;
+    ASSERT_TRUE(config.FromJsonString(R"({
+        "online_mrc_enable": true
+    })"));
+    EXPECT_FALSE(config.Check());
+}
+
+TEST_F(OnlineOptimizerServerConfigTest, OnlineMrcEnvironmentOverrides) {
+    OnlineOptimizerServerConfig config;
+    std::unordered_map<std::string, std::string> environ = {
+        {"optimizer.online_mrc.enable", "true"},
+        {"optimizer.online_mrc.kvcm_service_discovery_url", "static://127.0.0.1:19000"},
+        {"optimizer.online_mrc.capacity_gb_grid", "1,2,4"},
+        {"optimizer.online_mrc.report_interval_seconds", "120"},
+        {"optimizer.online_mrc.instance_groups",
+         R"([{"name":"group_a","capacity_gb":[1,2,4],"enable_prefix_hash":true},{"name":"group_b","capacity_gb":[8],"enable_prefix_hash":true}])"},
+    };
+    ASSERT_TRUE(config.OverrideFromEnviron(environ));
+    EXPECT_TRUE(config.online_mrc_config().enable);
+    EXPECT_EQ("static://127.0.0.1:19000", config.online_mrc_config().kvcm_service_discovery_url);
+    EXPECT_EQ((std::vector<double>{1, 2, 4}), config.online_mrc_config().capacity_gb_grid);
+    EXPECT_EQ(120, config.online_mrc_config().report_interval_seconds);
+    ASSERT_EQ(2u, config.online_mrc_instance_groups().size());
+    EXPECT_EQ("group_a", config.online_mrc_instance_groups()[0].name());
+    EXPECT_EQ("group_b", config.online_mrc_instance_groups()[1].name());
+    EXPECT_TRUE(config.online_mrc_instance_groups()[0].enable_prefix_hash());
+    EXPECT_TRUE(config.Check());
+}
+
+TEST_F(OnlineOptimizerServerConfigTest, OptimizerInitiatedStreamConfiguration) {
+    OnlineOptimizerServerConfig config;
+    std::unordered_map<std::string, std::string> environ = {
+        {"optimizer.online_mrc.enable", "true"},
+        {"optimizer.online_mrc.kvcm_service_discovery_url", "static://127.0.0.1:19000"},
+        {"optimizer.online_mrc.instance_groups",
+         R"([{"name":"group_a","capacity_gb":[1],"enable_prefix_hash":true}])"},
+        {"optimizer.online_mrc.discovery_refresh_interval_ms", "1000"},
+        {"optimizer.online_mrc.connect_timeout_ms", "200"},
+        {"optimizer.online_mrc.reconnect_interval_ms", "300"},
+        {"optimizer.online_mrc.max_frame_bytes", "4096"},
+    };
+    ASSERT_TRUE(config.OverrideFromEnviron(environ));
+    EXPECT_EQ("static://127.0.0.1:19000", config.online_mrc_config().kvcm_service_discovery_url);
+    EXPECT_EQ(1000, config.online_mrc_config().discovery_refresh_interval_ms);
+    EXPECT_EQ(200, config.online_mrc_config().connect_timeout_ms);
+    EXPECT_EQ(300, config.online_mrc_config().reconnect_interval_ms);
+    EXPECT_EQ(4096, config.online_mrc_config().max_frame_bytes);
+    EXPECT_TRUE(config.Check());
+}
+
+TEST_F(OnlineOptimizerServerConfigTest, OnlineMrcRejectsGroupWithoutPrefixHash) {
+    OnlineOptimizerServerConfig config;
+    std::unordered_map<std::string, std::string> environ = {
+        {"optimizer.online_mrc.enable", "true"},
+        {"optimizer.online_mrc.kvcm_service_discovery_url", "static://127.0.0.1:19000"},
+        {"optimizer.online_mrc.instance_groups", R"([{"name":"group_a","capacity_gb":[1]}])"},
+    };
+    ASSERT_TRUE(config.OverrideFromEnviron(environ));
+    EXPECT_FALSE(config.Check());
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/optimizer/test/optimizer_config_test.cc
+++ b/kv_cache_manager/optimizer/test/optimizer_config_test.cc
@@ -18,6 +18,7 @@ TEST_F(OptimizerInstanceGroupTest, DefaultValues) {
     EXPECT_EQ("lru", group.eviction_policy());
     EXPECT_FALSE(group.shared_group_quota());
     EXPECT_FALSE(group.enable_theoretical_max_cache());
+    EXPECT_FALSE(group.enable_prefix_hash());
     EXPECT_EQ(0, group.ttl_seconds());
 }
 
@@ -28,6 +29,7 @@ TEST_F(OptimizerInstanceGroupTest, SerializeDeserialize) {
     group.set_ttl_seconds(3600);
     group.set_shared_group_quota(true);
     group.set_enable_theoretical_max_cache(true);
+    group.set_enable_prefix_hash(true);
 
     std::string json = group.ToJsonString();
 
@@ -42,6 +44,7 @@ TEST_F(OptimizerInstanceGroupTest, SerializeDeserialize) {
     EXPECT_EQ(3600, group2.ttl_seconds());
     EXPECT_TRUE(group2.shared_group_quota());
     EXPECT_TRUE(group2.enable_theoretical_max_cache());
+    EXPECT_TRUE(group2.enable_prefix_hash());
 }
 
 TEST_F(OptimizerInstanceGroupTest, ValidateEmptyName) {

--- a/kv_cache_manager/optimizer/test/optimizer_service_impl_test.cc
+++ b/kv_cache_manager/optimizer/test/optimizer_service_impl_test.cc
@@ -1,5 +1,7 @@
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/mrc/online_mrc_config.h"
+#include "kv_cache_manager/mrc/online_mrc_fact_registry.h"
 #include "kv_cache_manager/optimizer/config/optimizer_registry_manager.h"
 #include "kv_cache_manager/optimizer/online_runtime/online_optimizer_manager.h"
 #include "kv_cache_manager/optimizer/service/optimizer_service_impl.h"
@@ -593,6 +595,47 @@ TEST_F(OptimizerServiceImplTest, RegisterInstanceUnsupportedIndexerType) {
     RegisterInstanceResult result;
     ErrorCode ec = manager_->RegisterInstance(info, result);
     EXPECT_EQ(EC_BADARGS, ec);
+}
+
+TEST_F(OptimizerServiceImplTest, UpdateOnlineMrcProjectionConfig) {
+    OnlineMrcConfig config;
+    config.capacity_gb_grid = {2};
+    auto facts = std::make_shared<OnlineMrcFactRegistry>(config, std::vector<OptimizerInstanceGroup>{}, nullptr, manager_);
+    auto service = std::make_shared<OptimizerServiceImpl>(manager_, nullptr, facts);
+
+    proto::optimizer::UpdateOnlineMrcProjectionConfigRequest request;
+    request.set_trace_id("mrc-grid-update");
+    request.add_capacity_gb_grid(1);
+    request.add_capacity_gb_grid(4);
+    proto::optimizer::UpdateOnlineMrcProjectionConfigResponse response;
+    RequestContext context("mrc-grid-update", nullptr);
+    service->UpdateOnlineMrcProjectionConfig(&context, &request, &response);
+
+    EXPECT_EQ(proto::optimizer::OK, response.header().status().code());
+    ASSERT_EQ(2, response.capacity_gb_grid_size());
+    EXPECT_DOUBLE_EQ(1, response.capacity_gb_grid(0));
+    EXPECT_DOUBLE_EQ(4, response.capacity_gb_grid(1));
+    EXPECT_EQ(2u, response.projection_generation());
+
+    proto::optimizer::UpdateOnlineMrcProjectionConfigRequest invalid_request;
+    invalid_request.set_trace_id("invalid-mrc-grid-update");
+    invalid_request.add_capacity_gb_grid(4);
+    invalid_request.add_capacity_gb_grid(1);
+    proto::optimizer::UpdateOnlineMrcProjectionConfigResponse invalid_response;
+    service->UpdateOnlineMrcProjectionConfig(&context, &invalid_request, &invalid_response);
+    EXPECT_EQ(proto::optimizer::INVALID_ARGUMENT, invalid_response.header().status().code());
+    EXPECT_EQ(2u, facts->ProjectionGeneration());
+}
+
+TEST_F(OptimizerServiceImplTest, UpdateOnlineMrcProjectionConfigIsUnsupportedWhenObserverIsDisabled) {
+    proto::optimizer::UpdateOnlineMrcProjectionConfigRequest request;
+    request.set_trace_id("disabled-mrc-grid-update");
+    request.add_capacity_gb_grid(1);
+    proto::optimizer::UpdateOnlineMrcProjectionConfigResponse response;
+    RequestContext context("disabled-mrc-grid-update", nullptr);
+
+    service_->UpdateOnlineMrcProjectionConfig(&context, &request, &response);
+    EXPECT_EQ(proto::optimizer::UNSUPPORTED, response.header().status().code());
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -55,28 +55,39 @@ enum ReportEventType {
     EVENT_BLOCK_DELETE = 3;  // V6D deleted a block locally
     EVENT_HOST_DOWN = 4;     // V6D node is going down (graceful or detected)
     EVENT_HEARTBEAT = 5;     // V6D periodic heartbeat
+    EVENT_BLOCK_SNAPSHOT = 6; // Reporter sends the full block set for one host/medium
 }
 
-message NodeRegisterParams {
+message NodeRegisterEventParams {
     repeated string mediums = 1; // mediums supported by the node, e.g. ["mem","disk"]
 }
 
-message BlockAddParams {
+message BlockAddEventParams {
     string block_key = 1; // int64 as string
     string uri = 2;       // deprecated, use specs instead
     string medium = 3;    // e.g. "mem"/"disk"/"ssd"/"hbm"
     repeated LocationSpec specs = 4;
 }
 
-message BlockDeleteParams {
+message BlockDeleteEventParams {
     string block_key = 1;
     string medium = 2;
 }
 
-message HostDownParams {
+message BlockSnapshotItem {
+    string block_key = 1;
+    repeated LocationSpec specs = 2;
 }
 
-message HeartbeatParams {
+message BlockSnapshotEventParams {
+    string medium = 1;
+    repeated BlockSnapshotItem blocks = 2;
+}
+
+message HostDownEventParams {
+}
+
+message HeartbeatEventParams {
     // KVCM only refreshes last_heartbeat; system_status is opaque observability data
     map<string, string> system_status = 1;
 }
@@ -84,11 +95,12 @@ message HeartbeatParams {
 message EventItem {
     ReportEventType event_type = 1;
     oneof event_params {
-        NodeRegisterParams node_register = 2;
-        BlockAddParams block_add = 3;
-        BlockDeleteParams block_delete = 4;
-        HostDownParams host_down = 5;
-        HeartbeatParams heartbeat = 6;
+        NodeRegisterEventParams node_register = 2;
+        BlockAddEventParams block_add = 3;
+        BlockDeleteEventParams block_delete = 4;
+        HostDownEventParams host_down = 5;
+        HeartbeatEventParams heartbeat = 6;
+        BlockSnapshotEventParams block_snapshot = 7;
     }
 }
 

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -51,9 +51,11 @@ enum StorageType {
 // ReportEvent is the ingestion API used by cache subscribers. A subscriber
 // normalizes engine-specific cache signals (for example RTP-LLM full cache
 // snapshots or vLLM KV events) into block-level mutations on one storage
-// system. `storage_type` names that large storage/cache system; LocationScope
-// identifies one diffable location namespace inside it; LocationSpec describes
-// where the block lives within that namespace.
+// system. `storage_type` names that large storage/cache system; `medium`
+// identifies one diffable cache namespace under the reporter host; LocationSpec
+// describes where each cache component of the block lives. KVCM currently
+// matches only full-attention specs and ignores mamba-state specs by
+// LocationSpec.name.
 
 enum ReportEventType {
     EVENT_UNSPECIFIED = 0;
@@ -65,13 +67,6 @@ enum ReportEventType {
     EVENT_BLOCK_SNAPSHOT = 6; // Reporter sends the full block set for one host/medium
 }
 
-message LocationScope {
-    string medium = 1; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
-    // Optional identity dimensions within a medium, e.g. {"dp_rank":"0", "group_idx":"1"}.
-    // KVCM sorts these labels and folds them into the location id.
-    map<string, string> labels = 2;
-}
-
 message NodeRegisterEventParams {
     repeated string mediums = 1; // mediums supported by the node, e.g. ["mem","disk"]
 }
@@ -79,15 +74,16 @@ message NodeRegisterEventParams {
 message BlockAddEventParams {
     string block_key = 1; // int64 as string
     string uri = 2;       // deprecated, use specs instead
-    string medium = 3;    // deprecated compatibility field; use location.medium instead
+    string medium = 3;    // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
     repeated LocationSpec specs = 4;
-    LocationScope location = 5;
 }
 
 message BlockDeleteEventParams {
     string block_key = 1;
-    string medium = 2; // deprecated compatibility field; use location.medium instead
-    LocationScope location = 3;
+    string medium = 2; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
+    // Optional. When set, KVCM applies the delete only if these component names
+    // contain a full-attention spec; mamba-state-only deletes are ignored.
+    repeated string spec_names = 3;
 }
 
 message BlockSnapshotItem {
@@ -96,9 +92,8 @@ message BlockSnapshotItem {
 }
 
 message BlockSnapshotEventParams {
-    string medium = 1; // deprecated compatibility field; use location.medium instead
+    string medium = 1; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
     repeated BlockSnapshotItem blocks = 2;
-    LocationScope location = 3;
 }
 
 message HostDownEventParams {

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -46,16 +46,30 @@ enum StorageType {
     ST_VINEYARD = 7;
 }
 
-// ---- V6D event reporting ----
+// ---- Cache event reporting ----
+//
+// ReportEvent is the ingestion API used by cache subscribers. A subscriber
+// normalizes engine-specific cache signals (for example RTP-LLM full cache
+// snapshots or vLLM KV events) into block-level mutations on one storage
+// system. `storage_type` names that large storage/cache system; LocationScope
+// identifies one diffable location namespace inside it; LocationSpec describes
+// where the block lives within that namespace.
 
 enum ReportEventType {
     EVENT_UNSPECIFIED = 0;
-    EVENT_NODE_REGISTER = 1; // V6D node starts up and registers with KVCM
-    EVENT_BLOCK_ADD = 2;     // V6D stored a new block locally
-    EVENT_BLOCK_DELETE = 3;  // V6D deleted a block locally
-    EVENT_HOST_DOWN = 4;     // V6D node is going down (graceful or detected)
-    EVENT_HEARTBEAT = 5;     // V6D periodic heartbeat
+    EVENT_NODE_REGISTER = 1; // Reporter node starts up and registers with KVCM
+    EVENT_BLOCK_ADD = 2;     // Reporter stored a block in one location
+    EVENT_BLOCK_DELETE = 3;  // Reporter removed a block from one location
+    EVENT_HOST_DOWN = 4;     // Reporter node is going down (graceful or detected)
+    EVENT_HEARTBEAT = 5;     // Reporter periodic heartbeat
     EVENT_BLOCK_SNAPSHOT = 6; // Reporter sends the full block set for one host/medium
+}
+
+message LocationScope {
+    string medium = 1; // cache tier/namespace, e.g. "mem", "disk", "gpu", "hbm"
+    // Optional identity dimensions within a medium, e.g. {"dp_rank":"0", "group_idx":"1"}.
+    // KVCM sorts these labels and folds them into the location id.
+    map<string, string> labels = 2;
 }
 
 message NodeRegisterEventParams {
@@ -65,13 +79,15 @@ message NodeRegisterEventParams {
 message BlockAddEventParams {
     string block_key = 1; // int64 as string
     string uri = 2;       // deprecated, use specs instead
-    string medium = 3;    // e.g. "mem"/"disk"/"ssd"/"hbm"
+    string medium = 3;    // deprecated compatibility field; use location.medium instead
     repeated LocationSpec specs = 4;
+    LocationScope location = 5;
 }
 
 message BlockDeleteEventParams {
     string block_key = 1;
-    string medium = 2;
+    string medium = 2; // deprecated compatibility field; use location.medium instead
+    LocationScope location = 3;
 }
 
 message BlockSnapshotItem {
@@ -80,8 +96,9 @@ message BlockSnapshotItem {
 }
 
 message BlockSnapshotEventParams {
-    string medium = 1;
+    string medium = 1; // deprecated compatibility field; use location.medium instead
     repeated BlockSnapshotItem blocks = 2;
+    LocationScope location = 3;
 }
 
 message HostDownEventParams {
@@ -109,7 +126,7 @@ message ReportEventRequest {
     string instance_id = 2;
     string host_ip_port = 3;
     repeated EventItem events = 4;
-    StorageType storage_type = 5; // required: declares the reporter's storage type
+    StorageType storage_type = 5; // required: declares the reporter's storage/cache system
 }
 
 message ReportEventResponse {

--- a/kv_cache_manager/protocol/protobuf/optimizer_service.proto
+++ b/kv_cache_manager/protocol/protobuf/optimizer_service.proto
@@ -62,6 +62,7 @@ message OptimizerInstanceGroupProto {
     bool shared_group_quota = 4;         // true 表示 group 内 instance 共享容量预算
     int64 ttl_seconds = 5;               // TTL 秒数，0 表示不启用 TTL
     bool enable_theoretical_max_cache = 6; // 是否启用 theoretical/max cache
+    bool enable_prefix_hash = 7; // 是否把每块原始 key 统一转换为滚动前缀 key
 }
 
 // InstanceGroup 增删改查
@@ -225,6 +226,72 @@ message OptimizerResetStatsResponse {
     CommonResponseHeader header = 1;
 }
 
+// Observation-only access trace ingestion. One span is one complete prefix
+// request; keys must not be sampled or split because LiteHit evaluates the
+// request against one request-start LRU snapshot.
+message AccessTraceSpan {
+    string instance_group = 1;
+    string instance_id = 2;
+    int32 block_size = 3;
+    int64 bytes_per_block = 4;
+    repeated int64 keys = 5;
+    int64 event_time_us = 6;
+    string source_id = 7;
+    uint64 sequence_number = 8;
+}
+
+message ReportAccessTraceRequest {
+    string trace_id = 1;
+    string cluster = 2; // required; combines with instance_id for lane isolation
+    repeated AccessTraceSpan spans = 3;
+    uint64 dropped_spans = 4;
+    uint64 dropped_keys = 5;
+}
+
+// Lightweight stream used when optimizer discovers and
+// connects to every KVCM node. The TCP envelope is:
+//   [4-byte network-order frame length][1-byte message type][protobuf payload]
+// Message type 1 carries OptimizerHello; type 2 carries CacheEventBatch.
+message OptimizerHello {
+    uint32 protocol_version = 1;
+    string optimizer_id = 2;
+}
+
+message MrcInstanceMeta {
+    int32 block_size = 1;
+    repeated LocationSpecInfo location_spec_infos = 2;
+    repeated LocationSpecGroup location_spec_groups = 3;
+    OptimizerStateInfo optimizer_state_info = 4;
+    int32 linear_step = 5;
+}
+
+message CacheGetEventItem {
+    string event_id = 1;
+    int64 timestamp_ns = 2;
+    repeated int64 block_keys = 3; // complete-block keys in request order; optimizer normalizes with prefix hash
+    int64 input_token_len = 4;
+}
+
+message CacheEventBatch {
+    string instance_id = 1;
+    string instance_group = 2;
+    MrcInstanceMeta instance_meta = 3;
+    repeated CacheGetEventItem events = 4;
+}
+
+// MRC projection configuration. Updating the capacity grid
+// never resets the accumulated request facts or makes quota decisions.
+message UpdateOnlineMrcProjectionConfigRequest {
+    string trace_id = 1;
+    repeated double capacity_gb_grid = 2;
+}
+
+message UpdateOnlineMrcProjectionConfigResponse {
+    CommonResponseHeader header = 1;
+    repeated double capacity_gb_grid = 2;
+    uint64 projection_generation = 3;
+}
+
 service OptimizerService {
     // InstanceGroup 管理
     rpc CreateInstanceGroup(CreateInstanceGroupRequest) returns (CommonResponse);
@@ -242,4 +309,12 @@ service OptimizerService {
     // 在线 TraceQuery
     rpc TraceQuery(TraceQueryRequest) returns (TraceQueryResponse);
     rpc ResetStats(OptimizerResetStatsRequest) returns (OptimizerResetStatsResponse);
+
+    // Fire-and-forget from KVCM's background forwarder. The response only
+    // acknowledges admission to the optimizer-side bounded queue.
+    rpc ReportAccessTrace(ReportAccessTraceRequest) returns (CommonResponse);
+
+    // Runtime update for the observation-only online MRC projection grid.
+    rpc UpdateOnlineMrcProjectionConfig(UpdateOnlineMrcProjectionConfigRequest)
+        returns (UpdateOnlineMrcProjectionConfigResponse);
 }


### PR DESCRIPTION
## Summary

Introduce an Optimizer-side online MRC observation path that consumes live
`CacheEventBatch` streams and reports theoretical cache hit curves without
participating in scheduling or request handling.

## Changes

- Discover all healthy KVCM endpoints and maintain their connections with one
  non-blocking `poll` event loop.
- Send `HELLO` after connecting and decode framed messages in the
  `[4-byte length][1-byte type][protobuf payload]` format.
- Add independent endpoint lifecycle management, topology reconciliation,
  reconnect backoff, frame validation, and a bounded consumer queue.
- Create configured instance groups in the formal Optimizer Registry and
  formally register instances when their first event arrives.
- Detect instance metadata changes and rebuild the corresponding LiteHit state.
- Retain all Request Facts in process memory without a count or time limit.
- Project the stored Facts onto the configured capacity grid every 60 seconds.
- Report connection, reconnect, decoding, queue, dropped-event, Fact memory,
  LiteHit memory, out-of-order event, and projection-cost metrics.
- Add focused tests for configuration, formal Registry integration, metadata
  changes, framed stream decoding, service discovery, reconnect, and metrics.

## Behavior and safety

- The feature is disabled by default.
- Online MRC results are observation-only. Request handling, eviction, quota,
  and scheduling logic do not consume them.
- Instance Group configuration and `OptimizerInstanceInfo` use the formal
  Registry and are persisted.
- Request Facts, LiteHit/Fenwick state, timestamps, and metadata generations
  remain process-local and are not persisted.
- All KVCM connections share one event-loop thread.

## Validation

- `bazel test //kv_cache_manager/mrc/test:OnlineMrcFactStreamTest //kv_cache_manager/optimizer/test:OnlineOptimizerServerConfigTest --test_output=errors`
- `bazel build //kv_cache_manager/optimizer:online_optimizer_server //kv_cache_manager/optimizer:online_optimizer_server_main`
