### PR TITLE
[data_storage] separate TairMempool SSD storage type

### DIFF
--- a/docs/BREAK_CHANGE.md
+++ b/docs/BREAK_CHANGE.md
@@ -2,6 +2,64 @@
 
 本文档记录需要调用方、部署配置或持久化状态协同升级的不兼容变更。升级前必须按对应条目的前置条件处理，不能仅替换 KVCM 二进制。
 
+## TairMempool SSD 独立 Storage Type
+
+Introduced by: PR #293
+
+TairMempool DRAM 继续使用 `ST_TAIRMEMPOOL`/`pace`，LocalSSD 新增
+`ST_TAIRMEMPOOL_SSD`/`pace_ssd`。两者仍共享 `pace://` 数据面协议，但 KVCM 从此分别统计
+quota 和类型水位，使 DRAM 高水位能够触发到 SSD 的自动迁移。
+
+### 不兼容内容
+
+- Proto/领域枚举新增 `ST_TAIRMEMPOOL_SSD = 9`，配置 JSON 新增持久化类型字符串
+  `"pace_ssd"`，写入策略新增 `CPS_ALWAYS_TAIR_MEMPOOL_SSD = 9` 和
+  `CPS_PREFER_TAIR_MEMPOOL_SSD = 10`。
+- 老 Worker Client 不认识 `pace_ssd`。Manager 把新 Storage 配置下发给老 Worker 后，老
+  Client 会把它解析为 UNKNOWN，并可能以 `ER_INVALID_SDKBACKEND_CONFIG` 结束整个
+  TransferClient 初始化，而不只是跳过 SSD backend。
+- 老 KVCM Server 不认识 Registry 中的 `"type":"pace_ssd"`。直接回滚旧二进制会导致该
+  Storage backend 恢复失败，Registry recovery 无法完成并持续重试。
+- Storage 类型属于持久化 CacheLocation 和用量账本的一部分，不支持同名 Storage 从
+  `pace` 原地改成 `pace_ssd`。服务端现在拒绝涉及 TairMempool DRAM/SSD 的原地类型变更；
+  修改 timeout、domain 等同类型参数仍可使用 `update_storage`。
+- 开源占位 backend 已按 `StorageConfig.type()` 返回类型。实际部署使用的 PACE backend 也
+  必须返回配置中的类型，并在构造 URI 时固定使用 `pace` scheme；若仍硬编码
+  `ST_TAIRMEMPOOL` 或使用 `ToString(GetType())` 构造 scheme，独立计量会静默失效或生成
+  不兼容的 `pace_ssd://` URI。
+
+### 启用前置条件和顺序
+
+1. 先升级所有 Worker Client，使其能够解析类型 9、创建对应 TairMempool SDK，并继续识别
+   `pace://` URI。在确认集群不存在老 Client 后再进入下一步。
+2. 升级全部 KVCM Server 和实际 PACE backend，确认 backend 的 `GetType()` 等于
+   `StorageConfig.type()`，DRAM/SSD 生成的 URI scheme 均为 `pace`。
+3. 为 SSD **新建不同名称**的 `pace_ssd` Storage。不要对已有 `pace` Storage 执行类型更新。
+   `kvcm_ops` 中 `add_storage pace` 只接受 media type 0/2；`pace_ssd` 子命令固定使用 media
+   type 5。`update_storage pace` 未指定 media type 时会读取并保留原 Storage 的 type/media，
+   包括旧的 `ST_TAIRMEMPOOL + media_type=5`，不会在修改 timeout 时静默改变介质或类型。
+   `pace` 与 `pace_ssd` 只能更新各自类型的 Storage，子命令与已注册类型不匹配时直接拒绝。
+4. 在每个启用迁移的 Instance Group 中，为 `pace` 与 `pace_ssd` 分别配置正数
+   `quota_config.capacity`。类型水位只遍历显式 quota；缺少源类型 quota 时迁移不会触发，
+   缺少 SSD quota 时 SSD 没有独立水位和类型容量保护。
+5. 迁移规则继续以 DRAM Storage 为 `source_storage_name`、新 SSD Storage 为
+   `target_storage_name`。SSD 只作迁移目标时无需加入 `storage_candidates`；直接写 SSD 时
+   才加入候选并选用 SSD 专用 CachePreferStrategy。
+6. 用空 Instance Group 或测试 Instance 验证一次 DRAM 写入与 DRAM→SSD 迁移：新 Location
+   分别记录 type 3/type 9，DRAM 用量下降、SSD 用量上升，且 Worker 能读写 `pace://` URI。
+
+旧的 `ST_TAIRMEMPOOL + media_type=5` 配置仍可读取并继续按旧类型计量，但不能通过原地改类型
+获得独立水位。迁移方式是新建 `pace_ssd` Storage，将新迁移流量切到它；旧 Storage 必须保留
+到历史 Location 排空，避免 GC/读取找不到原 backend。
+
+### 回滚说明
+
+创建任何 `pace_ssd` Registry 配置前，可以直接回滚，因为新类型尚未进入持久化状态。创建后
+不能直接换回不认识类型 9 的旧 Server/Client。回滚前必须停止新写入和迁移，删除或排空所有
+type 9 CacheLocation，确认其物理数据已清理，再删除 `pace_ssd` Storage 与相关 quota/迁移配置；
+之后才能回滚二进制。仅把新 Storage 改名或原地改回 `pace` 不能修复已有 Location 的类型和
+用量，且服务端会拒绝这种类型更新。
+
 ## Vineyard 事件上报升级为 EventReportBackend
 
 Introduced by: PR #249

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,7 +206,7 @@ timeout，因此不会使用配置数组顺序作为隐式优先级。
 ```TEXT
 {
     "storage_config": {
-        "type": "file", # 后端类型，可选值file,pace,mooncake,hf3fs,vcns_hf3fs
+        "type": "file", # 后端类型，可选值file,pace,pace_ssd,mooncake,hf3fs,vcns_hf3fs
         "global_unique_name": "nfs_01", # storage backend的名字，需要全局唯一
         "storage_spec": { # storage spec 需根据不同backend类型相应配置，TODO：具体每个type的spec配置文档
             "root_path": "/tmp/nfs/",
@@ -234,6 +234,10 @@ timeout，因此不会使用配置数组顺序作为隐式优先级。
                 {
                     "storage_type": "pace",
                     "capacity": 10000000000
+                },
+                {
+                    "storage_type": "pace_ssd",
+                    "capacity": 10000000000
                 }
             ]
         },
@@ -256,6 +260,8 @@ timeout，因此不会使用配置数组顺序作为隐式优先级。
             # CPS_PREFER_TAIR_MEMPOOL = 6,
             # CPS_ALWAYS_VCNS_3FS = 7,
             # CPS_PREFER_VCNS_3FS = 8,
+            # CPS_ALWAYS_TAIR_MEMPOOL_SSD = 9,
+            # CPS_PREFER_TAIR_MEMPOOL_SSD = 10,
             # };
             "cache_prefer_strategy": 2,
             "meta_indexer_config": {
@@ -282,6 +288,28 @@ timeout，因此不会使用配置数组顺序作为隐式优先级。
     }
 }
 ```
+
+TairMempool DRAM 使用 `pace`（proto `ST_TAIRMEMPOOL`），LocalSSD 使用
+`pace_ssd`（proto `ST_TAIRMEMPOOL_SSD`，同时要求 `media_type=5`）。两类 storage
+仍使用 `pace://` 数据面 URI，但 quota、类型水位和迁移触发用量分别统计。旧的
+`ST_TAIRMEMPOOL + media_type=5` 配置仍可读取，迁移到新类型后才能获得独立 SSD 水位。
+
+启用独立 SSD 类型时还需遵守以下配置约束：
+
+- 使用 `kvcm_ops add_storage ... pace_ssd` 创建一个新的、全局唯一的 Storage；不要把已有
+  `pace` Storage 原地更新为 `pace_ssd`。Storage 类型会写入 CacheLocation 和用量账本，
+  服务端会拒绝同名 Storage 的类型变更。
+- Instance Group 的 `quota.quota_config` 必须同时为 `pace` 和 `pace_ssd` 配置正容量。
+  类型水位只遍历这里显式出现的类型；缺少 `pace_ssd` 时不会形成 SSD 类型水位和容量上限，
+  缺少迁移源 `pace` 时迁移规则不会触发。
+- SSD 仅作为迁移目标时，不要求放入 `storage_candidates`；迁移规则按
+  `target_storage_name` 精确选择它。若需要把普通新写入直接落到 SSD，则必须把 SSD Storage
+  放入 `storage_candidates`，并使用 `CPS_ALWAYS_TAIR_MEMPOOL_SSD` 或
+  `CPS_PREFER_TAIR_MEMPOOL_SSD`。
+- `pace` 和 `pace_ssd` 的数据面 URI scheme 都是 `pace://`。`pace_ssd` 只用于配置、计量
+  和选择，不能生成 `pace_ssd://` URI。
+
+详细升级顺序和回滚限制见 [Breaking Changes](BREAK_CHANGE.md#tairmempool-ssd-独立-storage-type)。
 
 ## Logger Config
 

--- a/kv_cache_manager/client/src/internal/config/sdk_config.cc
+++ b/kv_cache_manager/client/src/internal/config/sdk_config.cc
@@ -103,7 +103,7 @@ std::string MooncakeSdkConfig::ToString() const {
     return oss.str();
 }
 
-TairMempoolSdkConfig::TairMempoolSdkConfig() { set_type(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL); }
+TairMempoolSdkConfig::TairMempoolSdkConfig(DataStorageType type) { set_type(type); }
 
 bool TairMempoolSdkConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
     return SdkBackendConfig::FromRapidValue(rapid_value);
@@ -146,7 +146,8 @@ bool SdkWrapperConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
                 sdk_backend_config = std::make_shared<MooncakeSdkConfig>();
                 break;
             case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL:
-                sdk_backend_config = std::make_shared<TairMempoolSdkConfig>();
+            case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD:
+                sdk_backend_config = std::make_shared<TairMempoolSdkConfig>(type);
                 break;
             case DataStorageType::DATA_STORAGE_TYPE_NFS:
                 sdk_backend_config = std::make_shared<NfsSdkConfig>();

--- a/kv_cache_manager/client/src/internal/config/sdk_config.h
+++ b/kv_cache_manager/client/src/internal/config/sdk_config.h
@@ -150,7 +150,7 @@ private:
 
 class TairMempoolSdkConfig : public SdkBackendConfig {
 public:
-    TairMempoolSdkConfig();
+    explicit TairMempoolSdkConfig(DataStorageType type = DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
     bool FromRapidValue(const rapidjson::Value &rapid_value) override;
     void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
 
@@ -205,6 +205,8 @@ private:
         {DataStorageType::DATA_STORAGE_TYPE_HF3FS, std::make_shared<Hf3fsSdkConfig>()},
         {DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS, std::make_shared<Hf3fsSdkConfig>()},
         {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, std::make_shared<TairMempoolSdkConfig>()},
+        {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD,
+         std::make_shared<TairMempoolSdkConfig>(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD)},
         {DataStorageType::DATA_STORAGE_TYPE_NFS, std::make_shared<NfsSdkConfig>()}};
     SdkTimeoutConfig timeout_config_;
 };

--- a/kv_cache_manager/client/src/internal/config/test/client_config_test.cc
+++ b/kv_cache_manager/client/src/internal/config/test/client_config_test.cc
@@ -54,8 +54,7 @@ TEST_F(ClientConfigTest, TestClientConfigTairMemPoolSuccess) {
     auto sdk_wrapper_config = client_config.sdk_wrapper_config();
     ASSERT_TRUE(sdk_wrapper_config);
     auto sdk_backend_configs_map = sdk_wrapper_config->sdk_backend_configs_map();
-    // 默认就加了3个
-    ASSERT_EQ(4, sdk_backend_configs_map.size());
+    ASSERT_EQ(5, sdk_backend_configs_map.size());
     auto tair_mempool_config = sdk_backend_configs_map[DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL];
     ASSERT_TRUE(tair_mempool_config);
     ASSERT_EQ("logs/pace_client.log", tair_mempool_config->sdk_log_file_path());

--- a/kv_cache_manager/client/src/internal/config/test/sdk_config_test.cc
+++ b/kv_cache_manager/client/src/internal/config/test/sdk_config_test.cc
@@ -107,11 +107,35 @@ TEST_F(SdkBackendConfigTest, TestSdkWrapperConfigGetSdkConfig) {
     auto tair_config = sdk_wrapper_config.GetSdkBackendConfig(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
     ASSERT_NE(tair_config, nullptr);
 
+    auto tair_ssd_config = sdk_wrapper_config.GetSdkBackendConfig(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD);
+    ASSERT_NE(tair_ssd_config, nullptr);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, tair_ssd_config->type());
+
     auto nfs_config = sdk_wrapper_config.GetSdkBackendConfig(DataStorageType::DATA_STORAGE_TYPE_NFS);
     ASSERT_NE(nfs_config, nullptr);
 
     auto unknown_config = sdk_wrapper_config.GetSdkBackendConfig(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN);
     ASSERT_EQ(unknown_config, nullptr);
+}
+
+TEST_F(SdkBackendConfigTest, TestSdkWrapperConfigParsesTairMempoolSsd) {
+    SdkWrapperConfig sdk_wrapper_config;
+    ASSERT_TRUE(sdk_wrapper_config.FromJsonString(R"({
+        "thread_num": 8,
+        "queue_size": 2000,
+        "sdk_backend_configs": [{
+            "type": "pace_ssd",
+            "sdk_log_file_path": "logs/pace_ssd_client.log",
+            "sdk_log_level": "INFO",
+            "spec_byte_sizes_per_block": {}
+        }],
+        "timeout_config": {"put_timeout_ms": 15000, "get_timeout_ms": 15000}
+    })"));
+
+    const auto config = sdk_wrapper_config.GetSdkBackendConfig(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD);
+    ASSERT_NE(nullptr, config);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, config->type());
+    EXPECT_EQ("logs/pace_ssd_client.log", config->sdk_log_file_path());
 }
 
 TEST_F(SdkBackendConfigTest, TestDuplicatedSdkConfig) {

--- a/kv_cache_manager/client/src/internal/sdk/sdk_factory.cc
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_factory.cc
@@ -26,6 +26,24 @@ std::shared_ptr<SdkInterface> SdkFactory::CreateSdk(const DataStorageType &type,
         KVCM_LOG_WARN("sdk_backend_config or storage_config is null");
         return nullptr;
     }
+    auto sdk = CreateSdkInstance(type);
+    if (!sdk) {
+        KVCM_LOG_WARN("unsupported sdk type: %s", ToString(type).c_str());
+        return nullptr;
+    }
+    auto ec = sdk->Init(sdk_backend_config, storage_config);
+    if (ec != ER_OK) {
+        KVCM_LOG_WARN("init sdk failed, type:%s, sdk backend config: %s, storage config: %s, errorcode: %d",
+                      ToString(type).c_str(),
+                      sdk_backend_config->ToJsonString().c_str(),
+                      storage_config->ToString().c_str(),
+                      ec);
+        return nullptr;
+    }
+    return sdk;
+}
+
+std::shared_ptr<SdkInterface> SdkFactory::CreateSdkInstance(const DataStorageType &type) {
     std::shared_ptr<SdkInterface> sdk;
     switch (type) {
 #ifdef ENABLE_HF3FS
@@ -43,6 +61,7 @@ std::shared_ptr<SdkInterface> SdkFactory::CreateSdk(const DataStorageType &type,
 #endif
 #ifdef ENABLE_TAIR_MEMPOOL
     case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL:
+    case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD:
         sdk = std::make_shared<TairMempoolSdk>();
         break;
 #endif
@@ -50,20 +69,6 @@ std::shared_ptr<SdkInterface> SdkFactory::CreateSdk(const DataStorageType &type,
         sdk = std::make_shared<LocalFileSdk>();
         break;
     default:
-        KVCM_LOG_WARN("unsupported sdk type: %s", ToString(type).c_str());
-        return nullptr;
-    }
-    if (!sdk) {
-        KVCM_LOG_WARN("create sdk failed, sdk is null, type:%s", ToString(type).c_str());
-        return nullptr;
-    }
-    auto ec = sdk->Init(sdk_backend_config, storage_config);
-    if (ec != ER_OK) {
-        KVCM_LOG_WARN("init sdk failed, type:%s, sdk backend config: %s, storage config: %s, errorcode: %d",
-                      ToString(type).c_str(),
-                      sdk_backend_config->ToJsonString().c_str(),
-                      storage_config->ToString().c_str(),
-                      ec);
         return nullptr;
     }
     return sdk;

--- a/kv_cache_manager/client/src/internal/sdk/sdk_factory.h
+++ b/kv_cache_manager/client/src/internal/sdk/sdk_factory.h
@@ -12,6 +12,9 @@ public:
     static std::shared_ptr<SdkInterface> CreateSdk(const DataStorageType &type,
                                                    const std::shared_ptr<SdkBackendConfig> &sdk_backend_config,
                                                    const std::shared_ptr<StorageConfig> &storage_config);
+
+private:
+    static std::shared_ptr<SdkInterface> CreateSdkInstance(const DataStorageType &type);
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/client/src/internal/sdk/test/BUILD
+++ b/kv_cache_manager/client/src/internal/sdk/test/BUILD
@@ -58,6 +58,16 @@ cc_test(
 )
 
 cc_test(
+    name = "SdkFactoryTest",
+    srcs = ["sdk_factory_test.cc"],
+    copts = ["-fno-access-control"],
+    deps = [
+        "//kv_cache_manager/client/src/internal/sdk",
+        "//kv_cache_manager/common:unittest",
+    ],
+)
+
+cc_test(
     name = "hf3fs_sdk_test",
     srcs = select({
         ":enable_hf3fs": [

--- a/kv_cache_manager/client/src/internal/sdk/test/sdk_factory_test.cc
+++ b/kv_cache_manager/client/src/internal/sdk/test/sdk_factory_test.cc
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include <typeinfo>
+
+#include "kv_cache_manager/client/src/internal/sdk/sdk_factory.h"
+#include "kv_cache_manager/common/unittest.h"
+
+using namespace kv_cache_manager;
+
+TEST(SdkFactoryTest, TairMempoolDramAndSsdCreateSameSdkType) {
+#ifdef ENABLE_TAIR_MEMPOOL
+    const auto dram_sdk = SdkFactory::CreateSdkInstance(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
+    const auto ssd_sdk = SdkFactory::CreateSdkInstance(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD);
+
+    ASSERT_NE(nullptr, dram_sdk);
+    ASSERT_NE(nullptr, ssd_sdk);
+    EXPECT_EQ(SdkType::TAIR_MEMPOOL, dram_sdk->Type());
+    EXPECT_EQ(SdkType::TAIR_MEMPOOL, ssd_sdk->Type());
+    EXPECT_EQ(typeid(*dram_sdk), typeid(*ssd_sdk));
+#else
+    GTEST_SKIP() << "TairMempool SDK is disabled";
+#endif
+}

--- a/kv_cache_manager/config/cache_config.h
+++ b/kv_cache_manager/config/cache_config.h
@@ -32,6 +32,8 @@ enum class CachePreferStrategy {
     CPS_PREFER_TAIR_MEMPOOL = 6,
     CPS_ALWAYS_VCNS_3FS = 7,
     CPS_PREFER_VCNS_3FS = 8,
+    CPS_ALWAYS_TAIR_MEMPOOL_SSD = 9,
+    CPS_PREFER_TAIR_MEMPOOL_SSD = 10,
 };
 
 /*

--- a/kv_cache_manager/config/registry_manager.cc
+++ b/kv_cache_manager/config/registry_manager.cc
@@ -186,6 +186,33 @@ ErrorCode RegistryManager::UpdateStorage(RequestContext *request_context,
     std::unique_lock<std::shared_mutex> lock(mutex_);
     const auto &trace_id = request_context->request_id();
     const auto &global_unique_name = storage_config.global_unique_name();
+    const auto current_backend = data_storage_manager_->GetDataStorageBackend(global_unique_name);
+    const auto current_type = current_backend == nullptr ? DataStorageType::DATA_STORAGE_TYPE_UNKNOWN
+                                                         : current_backend->GetStorageConfig().type();
+    if (current_backend != nullptr && current_type != storage_config.type() &&
+        (IsTairMempoolStorageType(current_type) || IsTairMempoolStorageType(storage_config.type()))) {
+        PREFIX_LOG_S(WARN,
+                     "update storage rejected: TairMempool storage type is immutable, current type: [%d], requested "
+                     "type: [%d]",
+                     static_cast<int>(current_type),
+                     static_cast<int>(storage_config.type()));
+        return EC_BADARGS;
+    }
+    if (current_backend != nullptr && IsTairMempoolStorageType(current_type) &&
+        IsTairMempoolStorageType(storage_config.type())) {
+        const auto current_spec =
+            std::dynamic_pointer_cast<TairMemPoolStorageSpec>(current_backend->GetStorageConfig().storage_spec());
+        const auto requested_spec = std::dynamic_pointer_cast<TairMemPoolStorageSpec>(storage_config.storage_spec());
+        if (current_spec == nullptr || requested_spec == nullptr ||
+            current_spec->media_type() != requested_spec->media_type()) {
+            PREFIX_LOG_S(WARN,
+                         "update storage rejected: TairMempool media type is immutable, current media type: [%d], "
+                         "requested media type: [%d]",
+                         current_spec == nullptr ? -1 : static_cast<int>(current_spec->media_type()),
+                         requested_spec == nullptr ? -1 : static_cast<int>(requested_spec->media_type()));
+            return EC_BADARGS;
+        }
+    }
     // 重建期间短暂不可用
     auto ec = RemoveStorage(request_context, global_unique_name);
     RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, ec, "update storage failed: remove storage failed");

--- a/kv_cache_manager/config/test/instance_group_test.cc
+++ b/kv_cache_manager/config/test/instance_group_test.cc
@@ -255,4 +255,43 @@ TEST_F(InstanceGroupTest, UnknownProtoStorageTypeFailsClosed) {
     EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN, location.type());
 }
 
+TEST_F(InstanceGroupTest, TairMempoolSsdStorageProtoRoundTripPreservesTypeAndMedia) {
+    auto spec = std::make_shared<TairMemPoolStorageSpec>();
+    spec->set_domain("pace.meta");
+    spec->set_timeout(5000);
+    spec->set_service_discovery_url("spectrum://pace-meta");
+    spec->set_media_type(kTairMemPoolMediaTypeSsd);
+    StorageConfig original(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, "pace_ssd_1", spec);
+
+    proto::admin::StorageConfig proto_config;
+    ProtoConvert::StorageConfigToProto(original, &proto_config);
+    ASSERT_TRUE(proto_config.has_tair_mem_pool());
+    EXPECT_EQ(proto::admin::ST_TAIRMEMPOOL_SSD, proto_config.storage_type());
+    EXPECT_EQ(kTairMemPoolMediaTypeSsd, proto_config.tair_mem_pool().media_type());
+
+    StorageConfig restored;
+    ProtoConvert::StorageFromProto(&proto_config, restored);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, restored.type());
+    const auto restored_spec = std::dynamic_pointer_cast<TairMemPoolStorageSpec>(restored.storage_spec());
+    ASSERT_NE(nullptr, restored_spec);
+    EXPECT_EQ(kTairMemPoolMediaTypeSsd, restored_spec->media_type());
+    EXPECT_EQ("spectrum://pace-meta", restored_spec->service_discovery_url());
+}
+
+TEST_F(InstanceGroupTest, LegacyTairMempoolProtoWithoutStorageTypeRemainsDramType) {
+    proto::admin::StorageConfig legacy;
+    legacy.set_global_unique_name("legacy_pace");
+    auto *spec = legacy.mutable_tair_mem_pool();
+    spec->set_domain("pace.meta");
+    spec->set_timeout(5000);
+    spec->set_media_type(kTairMemPoolMediaTypeSsd);
+
+    StorageConfig restored;
+    ProtoConvert::StorageFromProto(&legacy, restored);
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, restored.type());
+    const auto restored_spec = std::dynamic_pointer_cast<TairMemPoolStorageSpec>(restored.storage_spec());
+    ASSERT_NE(nullptr, restored_spec);
+    EXPECT_EQ(kTairMemPoolMediaTypeSsd, restored_spec->media_type());
+}
+
 } // namespace kv_cache_manager

--- a/kv_cache_manager/config/test/registry_manager_local_backend_test.cc
+++ b/kv_cache_manager/config/test/registry_manager_local_backend_test.cc
@@ -144,12 +144,60 @@ TEST_F(RegistryManagerLocalBackendTest, TestStorageManagement) {
         GetPrivateTestRuntimeDataPath() + "/new_nfs_root/",
         std::dynamic_pointer_cast<NfsStorageSpec>(updated_storage1->GetStorageConfig().storage_spec())->root_path());
 
+    // TairMempool type is persisted in CacheLocation and usage accounting; reject conversion in place.
+    StorageConfig changed_type_config(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, "storage1", nullptr);
+    ASSERT_EQ(EC_BADARGS, registry_manager_->UpdateStorage(request_context_.get(), changed_type_config, true));
+    updated_storage1 = registry_manager_->data_storage_manager()->GetDataStorageBackend("storage1");
+    ASSERT_TRUE(updated_storage1);
+    ASSERT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, updated_storage1->GetStorageConfig().type());
+
     // Test RemoveStorage
     auto ec_remove = registry_manager_->RemoveStorage(request_context_.get(), "storage2");
     ASSERT_EQ(EC_OK, ec_remove);
 
     storage2 = registry_manager_->data_storage_manager()->GetDataStorageBackend("storage2");
     ASSERT_FALSE(storage2);
+}
+
+TEST_F(RegistryManagerLocalBackendTest, TestTairMempoolMediaTypeIsImmutable) {
+    const std::string local_path = GetPrivateTestRuntimeDataPath() + "_registry_local_backend_tair_media_test";
+    ASSERT_TRUE(InitRegistryManager("local://" + local_path + "?cluster_name=test"));
+
+    auto verify_media_type_change_rejected = [this](const std::string &storage_name,
+                                                    uint16_t current_media_type,
+                                                    uint16_t requested_media_type) {
+        AddNfsStorage(storage_name, 1);
+        const auto backend = registry_manager_->data_storage_manager()->GetDataStorageBackend(storage_name);
+        ASSERT_TRUE(backend);
+
+        auto current_spec = std::make_shared<TairMemPoolStorageSpec>();
+        current_spec->set_domain("pace.meta");
+        current_spec->set_timeout(5000);
+        current_spec->set_media_type(current_media_type);
+        // This open-source test uses an NFS backend as a configured-backend holder because the
+        // open-source TairMempool backend is intentionally non-functional.
+        backend->config_ =
+            StorageConfig(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, storage_name, current_spec);
+
+        auto requested_spec = std::make_shared<TairMemPoolStorageSpec>(*current_spec);
+        requested_spec->set_media_type(requested_media_type);
+        StorageConfig requested_config(
+            DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, storage_name, requested_spec);
+        ASSERT_EQ(EC_BADARGS, registry_manager_->UpdateStorage(request_context_.get(), requested_config, true));
+
+        const auto unchanged_backend =
+            registry_manager_->data_storage_manager()->GetDataStorageBackend(storage_name);
+        ASSERT_EQ(backend, unchanged_backend);
+        const auto unchanged_spec =
+            std::dynamic_pointer_cast<TairMemPoolStorageSpec>(unchanged_backend->GetStorageConfig().storage_spec());
+        ASSERT_TRUE(unchanged_spec);
+        ASSERT_EQ(current_media_type, unchanged_spec->media_type());
+    };
+
+    verify_media_type_change_rejected(
+        "pace_dram", kTairMemPoolMediaTypeDram, kTairMemPoolMediaTypeSsd);
+    verify_media_type_change_rejected(
+        "pace_legacy_ssd", kTairMemPoolMediaTypeSsd, kTairMemPoolMediaTypeDram);
 }
 
 TEST_F(RegistryManagerLocalBackendTest, TestInstanceGroupManagement) {

--- a/kv_cache_manager/data_storage/data_storage_manager.cc
+++ b/kv_cache_manager/data_storage/data_storage_manager.cc
@@ -176,6 +176,7 @@ std::shared_ptr<DataStorageBackend> DataStorageManager::CreateStorageBackend(con
         return std::make_shared<MooncakeBackend>(metrics_registry_);
 #endif
     case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL:
+    case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD:
         return std::make_shared<TairMempoolBackend>(metrics_registry_);
     case DataStorageType::DATA_STORAGE_TYPE_NFS:
         return std::make_shared<NfsBackend>(metrics_registry_);

--- a/kv_cache_manager/data_storage/storage_config.cc
+++ b/kv_cache_manager/data_storage/storage_config.cc
@@ -164,6 +164,8 @@ std::string ToString(const DataStorageType &type) {
         return "mooncake";
     case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL:
         return "pace";
+    case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD:
+        return "pace_ssd";
     case DataStorageType::DATA_STORAGE_TYPE_NFS:
         return "file";
     case DataStorageType::DATA_STORAGE_TYPE_DUMMY:
@@ -186,6 +188,8 @@ DataStorageType ToDataStorageType(const std::string &type) {
         return DataStorageType::DATA_STORAGE_TYPE_MOONCAKE;
     } else if (type == "pace") {
         return DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL;
+    } else if (type == "pace_ssd") {
+        return DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD;
     } else if (type == "file") {
         return DataStorageType::DATA_STORAGE_TYPE_NFS;
     } else if (type == "dummy") {
@@ -363,7 +367,7 @@ bool StorageConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
         auto tmp = std::make_shared<MooncakeStorageSpec>();
         KVCM_JSON_GET_MACRO(rapid_value, "storage_spec", tmp);
         storage_spec_ = tmp;
-    } else if (type_ == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL) {
+    } else if (IsTairMempoolStorageType(type_)) {
         auto tmp = std::make_shared<TairMemPoolStorageSpec>();
         KVCM_JSON_GET_MACRO(rapid_value, "storage_spec", tmp);
         storage_spec_ = tmp;
@@ -399,6 +403,13 @@ bool StorageConfig::ValidateRequiredFields(std::string &invalid_fields) const {
     }
     if (storage_spec_ && !storage_spec_->ValidateRequiredFields(local_invalid_fields)) {
         valid = false;
+    }
+    if (type_ == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD) {
+        const auto tair_spec = std::dynamic_pointer_cast<TairMemPoolStorageSpec>(storage_spec_);
+        if (tair_spec == nullptr || tair_spec->media_type() != kTairMemPoolMediaTypeSsd) {
+            valid = false;
+            local_invalid_fields += "{tair_mempool_ssd_requires_media_type_5}";
+        }
     }
     if (!valid) {
         invalid_fields += "{StorageConfig: " + local_invalid_fields + "}";

--- a/kv_cache_manager/data_storage/storage_config.h
+++ b/kv_cache_manager/data_storage/storage_config.h
@@ -18,6 +18,9 @@ enum class DataStorageType : uint8_t {
     DATA_STORAGE_TYPE_DUMMY = 6,
     DATA_STORAGE_TYPE_EVENT_REPORT_L1P5 = 7,
     DATA_STORAGE_TYPE_EVENT_REPORT_L2 = 8,
+    // Keep the legacy TairMempool type for DRAM/backward compatibility and
+    // account explicit SSD locations independently for quota and water level.
+    DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD = 9,
     COUNT, // as sentinel, must be last
 };
 
@@ -35,6 +38,15 @@ constexpr bool IsEventReportStorageType(const DataStorageType &type) noexcept {
     return type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L1P5 ||
            type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2;
 }
+
+constexpr bool IsTairMempoolStorageType(const DataStorageType &type) noexcept {
+    return type == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL ||
+           type == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD;
+}
+
+// Storage type names are persisted in KVCM metadata, while both TairMempool
+// media types use the same PACE data-plane URI scheme.
+inline constexpr char kTairMempoolUriScheme[] = "pace";
 
 // help mapping sub storage type to base storage type
 // e.g., VCNS_HF3FS (sub) --> HF3FS (base)

--- a/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
+++ b/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
@@ -100,4 +100,17 @@ TEST_F(DataStorageManagerTest, TestOptionalBackendsFollowBuildConfig) {
 #else
     EXPECT_EQ(nullptr, data_storage_manager.CreateStorageBackend(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS));
 #endif
+
+    auto pace_ssd_backend =
+        data_storage_manager.CreateStorageBackend(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD);
+    ASSERT_NE(nullptr, pace_ssd_backend);
+    auto pace_ssd_spec = std::make_shared<TairMemPoolStorageSpec>();
+    pace_ssd_spec->set_domain("pace.meta");
+    pace_ssd_spec->set_timeout(5000);
+    pace_ssd_spec->set_media_type(kTairMemPoolMediaTypeSsd);
+    StorageConfig pace_ssd_config(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, "pace_ssd_1", pace_ssd_spec);
+    // Do not assert Open(): the open-source stub intentionally returns EC_ERROR,
+    // while the internal PACE backend can initialize successfully.
+    pace_ssd_backend->config_ = pace_ssd_config;
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, pace_ssd_backend->GetType());
 }

--- a/kv_cache_manager/data_storage/test/storage_config_test.cc
+++ b/kv_cache_manager/data_storage/test/storage_config_test.cc
@@ -205,3 +205,49 @@ TEST_F(StorageConfigTest, TestTairMemPoolStorageSpecRoundTrip) {
     EXPECT_EQ(parsed.service_discovery_url(), spec.service_discovery_url());
     EXPECT_EQ(parsed.media_type(), spec.media_type());
 }
+
+TEST_F(StorageConfigTest, TestTairMempoolSsdTypeRoundTripAndValidation) {
+    EXPECT_EQ("pace_ssd", ToString(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD));
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, ToDataStorageType("pace_ssd"));
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD,
+              ToBaseType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD));
+    EXPECT_STREQ("pace", kTairMempoolUriScheme);
+
+    auto spec = std::make_shared<TairMemPoolStorageSpec>();
+    spec->set_domain("pace.meta");
+    spec->set_timeout(5000);
+    spec->set_media_type(kTairMemPoolMediaTypeSsd);
+    StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, "pace_ssd_1", spec);
+
+    std::string invalid_fields;
+    ASSERT_TRUE(config.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+    const std::string json = config.ToJsonString();
+    EXPECT_NE(std::string::npos, json.find("\"type\":\"pace_ssd\""));
+    EXPECT_NE(std::string::npos, json.find("\"media_type\":5"));
+
+    StorageConfig restored;
+    ASSERT_TRUE(restored.FromJsonString(json));
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, restored.type());
+    const auto restored_spec = std::dynamic_pointer_cast<TairMemPoolStorageSpec>(restored.storage_spec());
+    ASSERT_NE(nullptr, restored_spec);
+    EXPECT_EQ(kTairMemPoolMediaTypeSsd, restored_spec->media_type());
+}
+
+TEST_F(StorageConfigTest, TestTairMempoolSsdTypeRequiresSsdMedia) {
+    auto spec = std::make_shared<TairMemPoolStorageSpec>();
+    spec->set_domain("pace.meta");
+    spec->set_timeout(5000);
+    spec->set_media_type(kTairMemPoolMediaTypeDram);
+    StorageConfig config(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, "pace_ssd_1", spec);
+
+    std::string invalid_fields;
+    EXPECT_FALSE(config.ValidateRequiredFields(invalid_fields));
+    EXPECT_NE(std::string::npos, invalid_fields.find("tair_mempool_ssd_requires_media_type_5"));
+
+    // Legacy TairMempool remains permissive so existing media_type=5
+    // configurations can be read during a rolling upgrade.
+    config.set_type(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
+    spec->set_media_type(kTairMemPoolMediaTypeSsd);
+    invalid_fields.clear();
+    EXPECT_TRUE(config.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+}

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -191,6 +191,9 @@ private:
     // slot 4: DATA_STORAGE_TYPE_NFS usage data
     // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
     // slot 6: DATA_STORAGE_TYPE_DUMMY usage data (testing only)
+    // slot 7: DATA_STORAGE_TYPE_EVENT_REPORT_L1P5 usage data
+    // slot 8: DATA_STORAGE_TYPE_EVENT_REPORT_L2 usage data
+    // slot 9: DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD usage data
     array_t_ grp_storage_usage_by_type_;
 };
 

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -458,6 +458,9 @@ private:
         // slot 4: DATA_STORAGE_TYPE_NFS exceed flag
         // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
         // slot 6: DATA_STORAGE_TYPE_DUMMY exceed flag (testing only)
+        // slot 7: DATA_STORAGE_TYPE_EVENT_REPORT_L1P5 exceed flag
+        // slot 8: DATA_STORAGE_TYPE_EVENT_REPORT_L2 exceed flag
+        // slot 9: DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD exceed flag
         array_t_ water_level_exceed_by_type_;
     };
 

--- a/kv_cache_manager/manager/data_storage_selector.cc
+++ b/kv_cache_manager/manager/data_storage_selector.cc
@@ -53,6 +53,7 @@ private:
     // slot 4: DATA_STORAGE_TYPE_NFS exceed availability flag
     // slot 5: DATA_STORAGE_TYPE_VCNS_HF3FS **UNUSED** (merged into HF3FS)
     // slot 6: DATA_STORAGE_TYPE_DUMMY availability flag (testing only)
+    // slot 9: DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD availability flag
     array_t_ storage_quota_avail_by_type_;
 };
 
@@ -61,6 +62,7 @@ DataStorageSelector::StorageQuotaAvail::StorageQuotaAvail() : storage_quota_avai
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_HF3FS)) = true;
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE)) = true;
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL)) = true;
+    storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD)) = true;
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_NFS)) = true;
     storage_quota_avail_by_type_.at(ToIndex(DataStorageType::DATA_STORAGE_TYPE_DUMMY)) = true;
 }
@@ -222,6 +224,10 @@ DataStorageSelector::Select(RequestContext const *request_context,
         return SelectByType(request_context, candidates, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, false);
     case CachePreferStrategy::CPS_PREFER_TAIR_MEMPOOL:
         return SelectByType(request_context, candidates, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, true);
+    case CachePreferStrategy::CPS_ALWAYS_TAIR_MEMPOOL_SSD:
+        return SelectByType(request_context, candidates, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, false);
+    case CachePreferStrategy::CPS_PREFER_TAIR_MEMPOOL_SSD:
+        return SelectByType(request_context, candidates, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, true);
     case CachePreferStrategy::CPS_UNSPECIFIED:
         // break; skipped intentionally
     default:

--- a/kv_cache_manager/manager/select_location_policy.h
+++ b/kv_cache_manager/manager/select_location_policy.h
@@ -77,6 +77,7 @@ protected:
         static constexpr uint32_t MOONCAKE = 3;
         static constexpr uint32_t THREEFS = 3;
         static constexpr uint32_t TAIR_MEMPOOL = 3;
+        static constexpr uint32_t TAIR_MEMPOOL_SSD = 3;
         static constexpr uint32_t DEFAULT = 1;
         static constexpr uint32_t VCNS_HF3FS = THREEFS;
         static constexpr uint32_t EVENT_REPORT = 10;
@@ -94,6 +95,7 @@ protected:
         StorageTypeWeights::DEFAULT,
         StorageTypeWeights::EVENT_REPORT,
         StorageTypeWeights::EVENT_REPORT,
+        StorageTypeWeights::TAIR_MEMPOOL_SSD,
     };
 
     WeightArray &storage_weights_ = default_storage_weights_;

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -1727,6 +1727,32 @@ TEST_F(CacheReclaimerTest, TestEventReportUsageDoesNotTriggerStorageTypeWaterLev
     EXPECT_FALSE(water_level->GetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
 }
 
+TEST_F(CacheReclaimerTest, TestTairMempoolDramAndSsdUseIndependentTypeWaterLevels) {
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, 90);
+    dummy_meta_indexer->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, 10);
+
+    const auto instance_group = InstanceGroupFactory();
+    instance_group->quota_.set_capacity(1000);
+    instance_group->quota_.set_quota_config({
+        QuotaConfig(100, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL),
+        QuotaConfig(100, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD),
+    });
+    instance_group->cache_config_->reclaim_strategy_->trigger_strategy_.set_used_percentage(0.8);
+    key_count = 0;
+    max_key_count = 100;
+
+    cache_reclaimer_->job_state_flag_ = true;
+    const auto water_level = cache_reclaimer_->GetWaterLevelExceed(request_context_.get(),
+                                                                   instance_group->name(),
+                                                                   instance_group->quota(),
+                                                                   instance_group->cache_config()->reclaim_strategy(),
+                                                                   instance_infos);
+    ASSERT_NE(nullptr, water_level);
+    EXPECT_FALSE(water_level->GetGeneralWaterLevelExceed());
+    EXPECT_TRUE(water_level->GetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL));
+    EXPECT_FALSE(water_level->GetWaterLevelExceedByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD));
+}
+
 TEST_F(CacheReclaimerTest, TestInsufficientSampledKeys) {
     sample_reclaim_keys = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     get_out_properties = {

--- a/kv_cache_manager/manager/test/data_storage_selector_test.cc
+++ b/kv_cache_manager/manager/test/data_storage_selector_test.cc
@@ -29,6 +29,7 @@
 #include "kv_cache_manager/meta/meta_indexer_manager.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "stub.h"
+#include "stub_source/kv_cache_manager/data_storage/tair_mempool_backend.h"
 
 using namespace kv_cache_manager;
 
@@ -278,6 +279,26 @@ TEST_F(DataStorageSelectorTest, TestCopyControl) {
     ASSERT_TRUE(std::is_move_constructible<DataStorageSelector>::value);
     ASSERT_TRUE(std::is_move_assignable<DataStorageSelector>::value);
     ASSERT_TRUE(std::is_swappable<DataStorageSelector>::value);
+}
+
+TEST_F(DataStorageSelectorTest, TestSelectTairMempoolSsdByExactType) {
+    const auto dram = std::make_shared<TairMempoolBackend>(metrics_registry_);
+    dram->config_ = StorageConfig(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, "pace_dram", nullptr);
+    const auto ssd = std::make_shared<TairMempoolBackend>(metrics_registry_);
+    ssd->config_ = StorageConfig(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, "pace_ssd", nullptr);
+    const std::vector<std::shared_ptr<DataStorageBackend>> candidates{dram, ssd};
+
+    auto selected = DataStorageSelector::Select(
+        request_context_.get(), candidates, CachePreferStrategy::CPS_ALWAYS_TAIR_MEMPOOL_SSD);
+    ASSERT_EQ(ssd, selected);
+
+    selected =
+        DataStorageSelector::Select(request_context_.get(), {dram}, CachePreferStrategy::CPS_ALWAYS_TAIR_MEMPOOL_SSD);
+    ASSERT_FALSE(selected);
+
+    selected =
+        DataStorageSelector::Select(request_context_.get(), {dram}, CachePreferStrategy::CPS_PREFER_TAIR_MEMPOOL_SSD);
+    ASSERT_EQ(dram, selected);
 }
 
 TEST_F(DataStorageSelectorTest, TestSelectCacheWriteStorageBackendAbnormal00) {

--- a/kv_cache_manager/meta/storage_usage_data.cc
+++ b/kv_cache_manager/meta/storage_usage_data.cc
@@ -99,8 +99,14 @@ std::uint64_t StorageUsageData::SubStorageUsageByType(const DataStorageType &typ
 void StorageUsageData::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
     for (size_t_ i = 0; i != storage_usage_by_type_.size(); ++i) {
         const auto type = static_cast<DataStorageType>(i);
+        const auto usage = storage_usage_by_type_.at(i).load();
+        // Preserve rollback compatibility until the new storage type is
+        // actually used. Older binaries reject unknown persisted JSON keys.
+        if (type == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD && usage == 0) {
+            continue;
+        }
         const std::string key = ToString(type);
-        Put(writer, key, storage_usage_by_type_.at(i).load());
+        Put(writer, key, usage);
     }
 }
 

--- a/kv_cache_manager/meta/storage_usage_data.h
+++ b/kv_cache_manager/meta/storage_usage_data.h
@@ -48,6 +48,7 @@ private:
     // slot 6: DATA_STORAGE_TYPE_DUMMY usage data (testing only)
     // slot 7: DATA_STORAGE_TYPE_EVENT_REPORT_L1P5 usage data
     // slot 8: DATA_STORAGE_TYPE_EVENT_REPORT_L2 usage data
+    // slot 9: DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD usage data
     array_t_ storage_usage_by_type_;
 };
 

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -882,7 +882,7 @@ TEST_F(MetaIndexerTest, TestMetadataPersistAndRecover) {
 
     // persist
     meta_indexer_->key_count_.store(3);
-    const std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700, 800};
+    const std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700, 800, 900};
     ASSERT_EQ(expected_usage_vec.size(), meta_indexer_->storage_usage_data_.storage_usage_by_type_.size());
     for (std::size_t i = 0; i != meta_indexer_->storage_usage_data_.storage_usage_by_type_.size(); ++i) {
         meta_indexer_->storage_usage_data_.storage_usage_by_type_.at(i).store(expected_usage_vec.at(i));
@@ -918,7 +918,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
         ASSERT_EQ(0, meta_indexer_->GetStorageUsage());
 
         auto type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0, 0, 900};
 
         type = DataStorageType::DATA_STORAGE_TYPE_HF3FS;
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
@@ -930,6 +930,9 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
 
         type = DataStorageType::DATA_STORAGE_TYPE_NFS;
+        meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
+
+        type = DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD;
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
 
         for (std::size_t i = 0; i != meta_indexer_->storage_usage_data_.storage_usage_by_type_.size(); ++i) {
@@ -948,6 +951,10 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
         type = DataStorageType::DATA_STORAGE_TYPE_NFS;
         ASSERT_EQ(expected_usage_vec.at(static_cast<std::size_t>(type)), meta_indexer_->GetStorageUsageByType(type));
 
+        type = DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD;
+        ASSERT_EQ(expected_usage_vec.at(static_cast<std::size_t>(type)), meta_indexer_->GetStorageUsageByType(type));
+        ASSERT_EQ(300, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL));
+
         std::uint64_t expect_usage = 0;
         for (const auto &v : expected_usage_vec) {
             expect_usage += v;
@@ -959,7 +966,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
     {
         meta_indexer_->storage_usage_data_.Reset();
         auto type = DataStorageType::DATA_STORAGE_TYPE_UNKNOWN;
-        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 100, 200, 300, 400, 0, 0, 0, 0, 900};
 
         type = DataStorageType::DATA_STORAGE_TYPE_HF3FS;
         meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
@@ -1000,12 +1007,20 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataManipulation) {
         ASSERT_EQ(expected_usage_vec.at(static_cast<std::size_t>(type)), meta_indexer_->GetStorageUsageByType(type));
         meta_indexer_->SubStorageUsageByType(type, 1024);         // would underflow
         ASSERT_EQ(0, meta_indexer_->GetStorageUsageByType(type)); // expect to be proper handled
+
+        type = DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD;
+        meta_indexer_->SetStorageUsageByType(type, expected_usage_vec.at(static_cast<std::size_t>(type)));
+        meta_indexer_->AddStorageUsageByType(type, 16);
+        ASSERT_EQ(expected_usage_vec.at(static_cast<std::size_t>(type)) + 16,
+                  meta_indexer_->GetStorageUsageByType(type));
+        meta_indexer_->SubStorageUsageByType(type, 16);
+        ASSERT_EQ(expected_usage_vec.at(static_cast<std::size_t>(type)), meta_indexer_->GetStorageUsageByType(type));
     }
 
     // test special case: DATA_STORAGE_TYPE_VCNS_HF3FS behavior as DATA_STORAGE_TYPE_HF3FS
     {
         meta_indexer_->storage_usage_data_.Reset();
-        std::vector<std::uint64_t> expected_usage_vec{0, 128, 0, 0, 0, 0, 0, 0, 0};
+        std::vector<std::uint64_t> expected_usage_vec{0, 128, 0, 0, 0, 0, 0, 0, 0, 0};
 
         meta_indexer_->SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS, 128);
         ASSERT_EQ(128, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS));
@@ -1040,7 +1055,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
     // Successful round-trip: serialize then deserialize
     {
-        std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700, 800};
+        std::vector<std::uint64_t> expected_usage_vec{1, 100, 200, 300, 400, 500, 600, 700, 800, 900};
 
         storage_usage_data.Reset();
         for (std::size_t i = 0; i != expected_usage_vec.size(); ++i) {
@@ -1049,7 +1064,7 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
         std::string serialized = storage_usage_data.Serialize();
         ASSERT_EQ(
-            R"({"unknown":1,"hf3fs":100,"mooncake":200,"pace":300,"file":400,"vcns_hf3fs":500,"dummy":600,"event_report_l1p5":700,"event_report_l2":800})",
+            R"({"unknown":1,"hf3fs":100,"mooncake":200,"pace":300,"file":400,"vcns_hf3fs":500,"dummy":600,"event_report_l1p5":700,"event_report_l2":800,"pace_ssd":900})",
             serialized);
 
         storage_usage_data.Reset();
@@ -1061,12 +1076,12 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
 
     // Legal input: keys in different order
     {
-        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         storage_usage_data.Reset();
         ASSERT_EQ(
             EC_OK,
             storage_usage_data.Deserialize(
-                R"({"event_report_l2":9,"event_report_l1p5":8,"dummy":7,"vcns_hf3fs":6,"file":5,"pace":4,"mooncake":3,"hf3fs":2,"unknown":1})"));
+                R"({"pace_ssd":10,"event_report_l2":9,"event_report_l1p5":8,"dummy":7,"vcns_hf3fs":6,"file":5,"pace":4,"mooncake":3,"hf3fs":2,"unknown":1})"));
         for (std::size_t i = 0; i != storage_usage_data.storage_usage_by_type_.size(); ++i) {
             ASSERT_EQ(expected_usage_vec.at(i), storage_usage_data.storage_usage_by_type_.at(i).load());
         }
@@ -1080,19 +1095,30 @@ TEST_F(MetaIndexerTest, TestStorageUsageDataSeriDeseri) {
         ASSERT_EQ(100, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_HF3FS));
         ASSERT_EQ(200, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_MOONCAKE));
         ASSERT_EQ(0, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL));
+        ASSERT_EQ(0, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD));
         ASSERT_EQ(0, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_NFS));
         ASSERT_EQ(0, storage_usage_data.GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_DUMMY));
     }
 
+    // Keep persisted metadata readable by older binaries until SSD accounting
+    // is actually used; a zero-valued new field is intentionally omitted.
+    {
+        storage_usage_data.Reset();
+        storage_usage_data.SetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, 10);
+        EXPECT_EQ(
+            R"({"unknown":0,"hf3fs":0,"mooncake":0,"pace":10,"file":0,"vcns_hf3fs":0,"dummy":0,"event_report_l1p5":0,"event_report_l2":0})",
+            storage_usage_data.Serialize());
+    }
+
     // Legal input: whitespace-padded JSON
     {
-        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        const std::vector<std::uint64_t> expected_usage_vec{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         storage_usage_data.Reset();
         ASSERT_EQ(EC_OK,
                   storage_usage_data.Deserialize("  "
                                                  "{\"unknown\":1,\"hf3fs\":2,\"mooncake\":3,\"pace\":4,\"file\":5,"
                                                  "\"vcns_hf3fs\":6,\"dummy\":7,\"event_report_l1p5\":8,"
-                                                 "\"event_report_l2\":9}  "));
+                                                 "\"event_report_l2\":9,\"pace_ssd\":10}  "));
         for (std::size_t i = 0; i != storage_usage_data.storage_usage_by_type_.size(); ++i) {
             ASSERT_EQ(expected_usage_vec.at(i), storage_usage_data.storage_usage_by_type_.at(i).load());
         }

--- a/kv_cache_manager/optimizer/pybind/py_optimizer_binding.cc
+++ b/kv_cache_manager/optimizer/pybind/py_optimizer_binding.cc
@@ -51,6 +51,7 @@ PYBIND11_MODULE(kvcm_py_optimizer, module) {
         .value("DATA_STORAGE_TYPE_HF3FS", kvcm::DataStorageType::DATA_STORAGE_TYPE_HF3FS)
         .value("DATA_STORAGE_TYPE_MOONCAKE", kvcm::DataStorageType::DATA_STORAGE_TYPE_MOONCAKE)
         .value("DATA_STORAGE_TYPE_TAIR_MEMPOOL", kvcm::DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL)
+        .value("DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD", kvcm::DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD)
         .value("DATA_STORAGE_TYPE_NFS", kvcm::DataStorageType::DATA_STORAGE_TYPE_NFS)
         .value("DATA_STORAGE_TYPE_VCNS_HF3FS", kvcm::DataStorageType::DATA_STORAGE_TYPE_VCNS_HF3FS)
         .finalize();

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -45,6 +45,7 @@ enum StorageType {
     ST_DUMMY = 6;
     ST_EVENT_REPORT_L1P5 = 7;
     ST_EVENT_REPORT_L2 = 8;
+    ST_TAIRMEMPOOL_SSD = 9;
 }
 
 enum QueryType {
@@ -136,7 +137,8 @@ message StorageConfig {
     }
     bool check_storage_available_when_open = 8;
     // 响应中用于标识存储类型；请求中通常由 oneof storage_spec 确定类型。
-    // 配置 EventReport storage 时必须显式指定 ST_EVENT_REPORT_L1P5 或 ST_EVENT_REPORT_L2。
+    // 配置 EventReport storage 时必须显式指定 ST_EVENT_REPORT_L1P5 或 ST_EVENT_REPORT_L2；
+    // 配置 TairMempool SSD 时必须显式指定 ST_TAIRMEMPOOL_SSD，并设置 media_type=5。
     StorageType storage_type = 11;
 }
 
@@ -266,6 +268,8 @@ enum CachePreferStrategy {
     CPS_PREFER_TAIR_MEMPOOL = 6;
     CPS_ALWAYS_VCNS_3FS = 7;
     CPS_PREFER_VCNS_3FS = 8;
+    CPS_ALWAYS_TAIR_MEMPOOL_SSD = 9;
+    CPS_PREFER_TAIR_MEMPOOL_SSD = 10;
 }
 
 message MetaStorageBackendConfig {

--- a/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
@@ -42,6 +42,7 @@ enum StorageType {
     ST_DUMMY = 6;
     ST_EVENT_REPORT_L1P5 = 7;
     ST_EVENT_REPORT_L2 = 8;
+    ST_TAIRMEMPOOL_SSD = 9;
 }
 
 // 使用URI统一多种存储表示，由client或者connector负责解析

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -53,6 +53,7 @@ enum StorageType {
     ST_DUMMY = 6;
     ST_EVENT_REPORT_L1P5 = 7;
     ST_EVENT_REPORT_L2 = 8;
+    ST_TAIRMEMPOOL_SSD = 9;
 }
 
 // ---- Cache event reporting ----

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -42,7 +42,7 @@ void ProtoConvert::StorageConfigToProto(const StorageConfig &storage_config,
         mooncake->set_protocol(mooncake_storage.protocol());
         mooncake->set_rdma_device(mooncake_storage.rdma_device());
         mooncake->set_master_service_entry(mooncake_storage.master_server_entry());
-    } else if (type == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL) {
+    } else if (IsTairMempoolStorageType(type)) {
         const auto &tair_mem_pool_storage =
             *std::dynamic_pointer_cast<TairMemPoolStorageSpec>(storage_config.storage_spec());
         // proto_storage_config->set_global_unique_name(tair_mem_pool_storage.get_global_unique_name());
@@ -51,6 +51,9 @@ void ProtoConvert::StorageConfigToProto(const StorageConfig &storage_config,
         tair_mem_pool->set_timeout(tair_mem_pool_storage.timeout());
         tair_mem_pool->set_service_discovery_url(tair_mem_pool_storage.service_discovery_url());
         tair_mem_pool->set_media_type(tair_mem_pool_storage.media_type());
+        proto::admin::StorageType proto_storage_type = proto::admin::ST_UNSPECIFIED;
+        ProtoConvert::DataStorageTypeToProto(type, &proto_storage_type);
+        proto_storage_config->set_storage_type(proto_storage_type);
     } else if (type == DataStorageType::DATA_STORAGE_TYPE_NFS) {
         const auto &nfs_storage = *std::dynamic_pointer_cast<NfsStorageSpec>(storage_config.storage_spec());
         auto *nfs = proto_storage_config->mutable_nfs();
@@ -128,7 +131,20 @@ void ProtoConvert::StorageFromProto(const proto::admin::StorageConfig *proto_sto
                                 ? std::numeric_limits<uint16_t>::max()
                                 : static_cast<uint16_t>(media_type));
         storage_config.set_storage_spec(std::make_shared<TairMemPoolStorageSpec>(spec));
-        storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
+        switch (proto_storage_config->storage_type()) {
+        case proto::admin::ST_UNSPECIFIED:
+        case proto::admin::ST_TAIRMEMPOOL:
+            storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL);
+            break;
+        case proto::admin::ST_TAIRMEMPOOL_SSD:
+            storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD);
+            break;
+        default:
+            storage_config.set_type(DataStorageType::DATA_STORAGE_TYPE_UNKNOWN);
+            KVCM_LOG_WARN("tair_mem_pool storage has incompatible storage_type [%d]",
+                          static_cast<int>(proto_storage_config->storage_type()));
+            break;
+        }
         break;
     }
     case proto::admin::StorageConfig::kNfs: {

--- a/kv_cache_manager/service/util/manager_message_proto_util.h
+++ b/kv_cache_manager/service/util/manager_message_proto_util.h
@@ -288,6 +288,10 @@ void ProtoConvert::DataStorageTypeToProto(const DataStorageType &data_storage_ty
         *proto_data_storage_type = T::ST_TAIRMEMPOOL;
         break;
     }
+    case DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD: {
+        *proto_data_storage_type = T::ST_TAIRMEMPOOL_SSD;
+        break;
+    }
     case DataStorageType::DATA_STORAGE_TYPE_UNKNOWN: {
         *proto_data_storage_type = T::ST_UNSPECIFIED;
         break;
@@ -342,6 +346,10 @@ void ProtoConvert::DataStorageTypeFromProto(const T proto_data_storage_type, Dat
     }
     case T::ST_TAIRMEMPOOL: {
         data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL;
+        break;
+    }
+    case T::ST_TAIRMEMPOOL_SSD: {
+        data_storage_type_info = DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD;
         break;
     }
     case T::ST_NFS: {

--- a/open_source/kv_cache_manager/data_storage/tair_mempool_backend.cc
+++ b/open_source/kv_cache_manager/data_storage/tair_mempool_backend.cc
@@ -23,7 +23,7 @@ TairMempoolBackend::TairMempoolBackend(std::shared_ptr<MetricsRegistry> metrics_
 
 TairMempoolBackend::~TairMempoolBackend() { KVCM_LOG_ERROR("no implementation for TairMempoolBackend"); }
 
-DataStorageType TairMempoolBackend::GetType() { return DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL; }
+DataStorageType TairMempoolBackend::GetType() { return config_.type(); }
 
 bool TairMempoolBackend::Available() {
     KVCM_LOG_ERROR("no implementation for TairMempoolBackend");

--- a/package/kvcm_ops/BUILD
+++ b/package/kvcm_ops/BUILD
@@ -12,6 +12,7 @@ py_library(
         "config_server/**/*.py",
         "*.py",
     ]),
+    deps = ["@pip_cpu//requests"],
 )
 
 py_wheel(

--- a/package/kvcm_ops/__main__.py
+++ b/package/kvcm_ops/__main__.py
@@ -78,7 +78,7 @@ def main():
     update_storage
     remove_storage
   storage types (for add_storage/update_storage):
-    nfs / pace / 3fs / event_report_l1p5 / event_report_l2
+    nfs / pace / pace_ssd / 3fs / event_report_l1p5 / event_report_l2
   trace:
     trace_key
     trace_uri

--- a/package/kvcm_ops/kvcm/instance_group/util.py
+++ b/package/kvcm_ops/kvcm/instance_group/util.py
@@ -22,6 +22,7 @@ class StorageQuota(JsonData):
         supported_types = [
             "ST_3FS",
             "ST_TAIRMEMPOOL",
+            "ST_TAIRMEMPOOL_SSD",
             "ST_NFS",
             "ST_EVENT_REPORT_L1P5",
             "ST_EVENT_REPORT_L2",
@@ -311,6 +312,7 @@ class CacheConfig(JsonData):
         valid_strategies = [
             "CPS_ALWAYS_3FS", "CPS_PREFER_3FS",
             "CPS_ALWAYS_TAIR_MEMPOOL", "CPS_PREFER_TAIR_MEMPOOL",
+            "CPS_ALWAYS_TAIR_MEMPOOL_SSD", "CPS_PREFER_TAIR_MEMPOOL_SSD",
             "CPS_ALWAYS_VCNS_3FS", "CPS_PREFER_VCNS_3FS",
         ]
         if _data_storage_strategy not in valid_strategies:
@@ -474,7 +476,9 @@ def parse_instance_group_args(is_create: bool):
             StorageQuota(
                 "ST_TAIRMEMPOOL",
                 10000000000)] if is_create else argparse.SUPPRESS,
-        help="quota_configs, eg. ST_NFS,10000000000;ST_3FS,10000000000;ST_TAIRMEMPOOL,10000000000")
+        help=(
+            "quota_configs, eg. ST_NFS,10000000000;ST_3FS,10000000000;"
+            "ST_TAIRMEMPOOL,10000000000;ST_TAIRMEMPOOL_SSD,10000000000"))
 
     parser.add_argument(
         "--reclaim_policy",
@@ -494,7 +498,10 @@ def parse_instance_group_args(is_create: bool):
         "--data_storage_strategy",
         type=str,
         default="CPS_PREFER_3FS" if is_create else argparse.SUPPRESS,
-        help="data_storage_strategy, only support CPS_ALWAYS_3FS|CPS_PREFER_3FS|CPS_ALWAYS_TAIR_MEMPOOL|CPS_PREFER_TAIR_MEMPOOL now"
+        help=(
+            "data_storage_strategy, supports 3FS, VCNS_3FS, TairMempool DRAM "
+            "and TairMempool SSD ALWAYS/PREFER strategies"
+        )
     )
 
     parser.add_argument(

--- a/package/kvcm_ops/kvcm/storage/_help.py
+++ b/package/kvcm_ops/kvcm/storage/_help.py
@@ -8,13 +8,15 @@ storage module:
         python3 -m kvcm_ops add_storage --help
         python3 -m kvcm_ops add_storage nfs --help
         python3 -m kvcm_ops add_storage pace --help
+        python3 -m kvcm_ops add_storage pace_ssd --help
         python3 -m kvcm_ops add_storage 3fs --help
 
         # add nfs storage, given "global_unique_name, root_path, key_kount_per_file"
         python3 -m kvcm_ops add_storage -u test_nfs_1 nfs -r /home/zhaotaonan.ztn/temp -k 16
 
         # add pace storage, given "global_unique_name, domain, timeout"
-        python3 -m kvcm_ops add_storage -u common_pace_storage pace -d 'http://pace-meta-service-bj-1.alibaba-inc.com' -t 30
+        python3 -m kvcm_ops add_storage -u common_pace_storage pace -d 'http://pace-meta-service-bj-1.alibaba-inc.com' -t 30 --media_type 2
+        python3 -m kvcm_ops add_storage -u common_pace_ssd_storage pace_ssd -d 'http://pace-meta-service-bj-1.alibaba-inc.com' -t 30
 
         # add 3fs storage, given "global_unique_name, cluster_name, mountpoint, root_dir, key_count_per_file, touch_file_when_create(default true)"
         python3 -m kvcm_ops add_storage -u common_3fs_storage 3fs -c '' -m '/3fs/stage/3fs/' -r "common_3fs" -k 16
@@ -27,8 +29,13 @@ storage module:
         python3 -m kvcm_ops update_storage --help
         python3 -m kvcm_ops update_storage nfs --help
         python3 -m kvcm_ops update_storage pace --help
+        python3 -m kvcm_ops update_storage pace_ssd --help
         python3 -m kvcm_ops update_storage 3fs --help
         python3 -m kvcm_ops update_storage -u test_nfs_1 nfs -r /home/zhaotaonan.ztn/temp -k 64
+        # omitting --media_type preserves the current PACE storage type/media, including legacy media_type=5
+        python3 -m kvcm_ops update_storage -u common_pace_storage pace -d 'http://pace-meta-service-bj-1.alibaba-inc.com' -t 60
+        # pace and pace_ssd only update storages registered with their respective storage type
+        python3 -m kvcm_ops update_storage -u common_pace_ssd_storage pace_ssd -d 'http://pace-meta-service-bj-1.alibaba-inc.com' -t 30
         python3 -m kvcm_ops update_storage -u test_vllm_1 event_report_l1p5 --heartbeat_timeout_ms 30000 --cleanup_grace_ms 300000 --liveness_check_interval_ms 5000 --snapshot_min_interval_ms 1000
     enable/disable storage:
         python3 -m kvcm_ops enable_storage --help

--- a/package/kvcm_ops/kvcm/storage/add_storage.py
+++ b/package/kvcm_ops/kvcm/storage/add_storage.py
@@ -28,6 +28,8 @@ def create_add_storage_data(args, storage_type: str, storage_spec: dict):
     }
     if storage_type == "event_report":
         storage["storage_type"] = args.event_report_storage_type
+    elif storage_type == "tair_mem_pool":
+        storage["storage_type"] = get_pace_storage_type(args.media_type)
     return {
         "trace_id": args.trace_id,
         "storage": storage

--- a/package/kvcm_ops/kvcm/storage/update_storage.py
+++ b/package/kvcm_ops/kvcm/storage/update_storage.py
@@ -1,3 +1,5 @@
+import copy
+
 from .util import *
 from ..common.http_helper import *
 from ...util.json_helper import *
@@ -21,7 +23,7 @@ curl -g -vvv -X POST http://localhost:56040/api/updateStorage \
 '''
 
 
-def create_update_storage_data(args, storage_type: str, storage_spec: dict):
+def create_update_storage_data(args, storage_type: str, storage_spec: dict, pace_storage_type=None):
     storage = {
         "global_unique_name": args.unique_name,
         storage_type: storage_spec,
@@ -29,11 +31,49 @@ def create_update_storage_data(args, storage_type: str, storage_spec: dict):
     }
     if storage_type == "event_report":
         storage["storage_type"] = args.event_report_storage_type
+    elif storage_type == "tair_mem_pool":
+        if pace_storage_type is None:
+            pace_storage_type = get_pace_storage_type(args.media_type)
+        storage["storage_type"] = pace_storage_type
     return {
         "trace_id": args.trace_id,
         "storage": storage,
         "force_update": False
     }
+
+
+def get_existing_pace_identity(host: str, trace_id: str, unique_name: str, verbose: bool):
+    result = http_post(host, "/api/listStorage", {"trace_id": trace_id}, verbose)
+    status_code = result.get("header", {}).get("status", {}).get("code")
+    if status_code not in ("OK", 1):
+        raise RuntimeError(
+            f"list storage failed while resolving existing PACE media type, status: {status_code}")
+
+    for storage in result.get("storage", []):
+        if storage.get("global_unique_name") != unique_name:
+            continue
+
+        storage_spec = storage.get("tair_mem_pool")
+        if not isinstance(storage_spec, dict):
+            raise RuntimeError(f"storage '{unique_name}' is not a PACE storage")
+
+        media_type = storage_spec.get("media_type", 0)
+        if type(media_type) is not int or media_type not in (0, 2, 5):
+            raise RuntimeError(f"storage '{unique_name}' has invalid PACE media_type: {media_type}")
+
+        storage_type = storage.get("storage_type", "ST_UNSPECIFIED")
+        if storage_type in ("ST_UNSPECIFIED", "ST_TAIRMEMPOOL"):
+            # Older Managers may omit the type. Preserve the legacy identity,
+            # including the historical ST_TAIRMEMPOOL + media_type=5 form.
+            return media_type, "ST_TAIRMEMPOOL"
+        if storage_type == "ST_TAIRMEMPOOL_SSD":
+            if media_type != 5:
+                raise RuntimeError(
+                    f"storage '{unique_name}' has ST_TAIRMEMPOOL_SSD but media_type is {media_type}, expected 5")
+            return media_type, storage_type
+        raise RuntimeError(f"storage '{unique_name}' has incompatible storage_type: {storage_type}")
+
+    raise RuntimeError(f"PACE storage '{unique_name}' does not exist")
 
 
 def http_post_and_print(host: str, data: dict, verbose: bool):
@@ -48,8 +88,23 @@ def handle_nfs(args):
 
 
 def handle_pace(args):
-    storage_spec = gen_pace_config_data(args)
-    data = create_update_storage_data(args, "tair_mem_pool", storage_spec)
+    media_type, pace_storage_type = get_existing_pace_identity(
+        args.host, args.trace_id, args.unique_name, args.verbose)
+    expected_storage_type = (
+        "ST_TAIRMEMPOOL_SSD" if args.storage_type == "pace_ssd" else "ST_TAIRMEMPOOL")
+    if pace_storage_type != expected_storage_type:
+        expected_subcommand = "pace_ssd" if pace_storage_type == "ST_TAIRMEMPOOL_SSD" else "pace"
+        raise RuntimeError(
+            f"storage '{args.unique_name}' has storage_type {pace_storage_type}; "
+            f"use the '{expected_subcommand}' subcommand to update it")
+
+    resolved_args = args
+    if args.media_type is None:
+        resolved_args = copy.copy(args)
+        resolved_args.media_type = media_type
+    storage_spec = gen_pace_config_data(resolved_args)
+    data = create_update_storage_data(
+        resolved_args, "tair_mem_pool", storage_spec, pace_storage_type=pace_storage_type)
     http_post_and_print(args.host, data, args.verbose)
 
 

--- a/package/kvcm_ops/kvcm/storage/util.py
+++ b/package/kvcm_ops/kvcm/storage/util.py
@@ -16,9 +16,18 @@ def gen_pace_config_data(args):
     storage_spec = {
         "domain": args.domain,
         "timeout": args.timeout,
-        "service_discovery_url": args.service_discovery_url
+        "service_discovery_url": args.service_discovery_url,
+        "media_type": args.media_type,
     }
     return storage_spec
+
+
+def get_pace_storage_type(media_type):
+    if media_type == 5:
+        return "ST_TAIRMEMPOOL_SSD"
+    if media_type in (0, 2):
+        return "ST_TAIRMEMPOOL"
+    raise ValueError(f"unsupported PACE media type: {media_type}")
 
 
 def gen_3fs_config_data(args):
@@ -57,11 +66,31 @@ def add_nfs_sub_parser(subparsers):
     return parser_nfs
 
 
-def add_pace_sub_parser(subparsers):
-    parser_pace = subparsers.add_parser('pace', help='PACE(tair memory pool) storage options')
-    parser_pace.add_argument('--domain', "-d", required=True, help='pace domain')
-    parser_pace.add_argument('--timeout', "-t", required=True, type=int, help='pace time out config')
-    parser_pace.add_argument(
+def add_pace_sub_parser(subparsers, media_type_default=0):
+    parser = subparsers.add_parser('pace', help='PACE DRAM/legacy storage options')
+    add_pace_common_args(parser)
+    parser.add_argument(
+        '--media_type',
+        type=int,
+        choices=[0, 2],
+        default=media_type_default,
+        help=(
+            'PACE media type: 0=legacy/default, 2=DRAM; '
+            'add defaults to 0, update omission preserves the existing value'))
+    return parser
+
+
+def add_pace_ssd_sub_parser(subparsers):
+    parser = subparsers.add_parser('pace_ssd', help='PACE LocalSSD storage options')
+    add_pace_common_args(parser)
+    parser.set_defaults(media_type=5)
+    return parser
+
+
+def add_pace_common_args(parser):
+    parser.add_argument('--domain', "-d", required=True, help='pace domain')
+    parser.add_argument('--timeout', "-t", required=True, type=int, help='pace time out config')
+    parser.add_argument(
         '--service_discovery_url',
         default="",
         help=(
@@ -71,7 +100,6 @@ def add_pace_sub_parser(subparsers):
             'static://10.0.0.1:8080,10.0.0.2:8080'
         ),
     )
-    return parser_pace
 
 
 def add_3fs_sub_parser(subparsers):
@@ -147,7 +175,9 @@ def add_or_update_main(method: str, handle_nfs, handle_pace, handle_3fs,
     subparsers.required = True
 
     parser_nfs = add_nfs_sub_parser(subparsers)
-    parser_pace = add_pace_sub_parser(subparsers)
+    media_type_default = None if method == "update_storage" else 0
+    parser_pace = add_pace_sub_parser(subparsers, media_type_default=media_type_default)
+    parser_pace_ssd = add_pace_ssd_sub_parser(subparsers)
     parser_3fs = add_3fs_sub_parser(subparsers)
     parser_event_report_l1p5 = add_event_report_sub_parser(
         subparsers,
@@ -162,6 +192,7 @@ def add_or_update_main(method: str, handle_nfs, handle_pace, handle_3fs,
 
     parser_nfs.set_defaults(func=handle_nfs)
     parser_pace.set_defaults(func=handle_pace)
+    parser_pace_ssd.set_defaults(func=handle_pace)
     parser_3fs.set_defaults(func=handle_3fs)
     parser_event_report_l1p5.set_defaults(func=handle_event_report)
     parser_event_report_l2.set_defaults(func=handle_event_report)

--- a/package/kvcm_ops/test/storage_util_test.py
+++ b/package/kvcm_ops/test/storage_util_test.py
@@ -1,7 +1,9 @@
 import argparse
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 # Bazel keeps sources under package/kvcm_ops while the wheel exposes kvcm_ops
 # as a top-level namespace package.
@@ -9,8 +11,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from kvcm_ops.kvcm.storage.util import (
     add_event_report_sub_parser,
+    add_pace_sub_parser,
+    add_pace_ssd_sub_parser,
     gen_event_report_config_data,
+    gen_pace_config_data,
+    get_pace_storage_type,
 )
+from kvcm_ops.kvcm.storage import update_storage
+from kvcm_ops.kvcm.storage.update_storage import create_update_storage_data
+from kvcm_ops.kvcm.instance_group.util import CacheConfig
 
 
 class EventReportStorageArgsTest(unittest.TestCase):
@@ -60,6 +69,162 @@ class EventReportStorageArgsTest(unittest.TestCase):
             with self.subTest(invalid_value=invalid_value):
                 with self.assertRaises(SystemExit):
                     self._parse_args("--snapshot_min_interval_ms", invalid_value)
+
+
+class PaceStorageArgsTest(unittest.TestCase):
+    def _parse_args(self, *args):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="storage_type", required=True)
+        add_pace_sub_parser(subparsers)
+        return parser.parse_args(["pace", "--domain", "pace.meta", "--timeout", "5000", *args])
+
+    def _parse_ssd_args(self, *args):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="storage_type", required=True)
+        add_pace_ssd_sub_parser(subparsers)
+        return parser.parse_args(["pace_ssd", "--domain", "pace.meta", "--timeout", "5000", *args])
+
+    def test_ssd_subcommand_sets_distinct_storage_type(self):
+        args = self._parse_ssd_args()
+        self.assertEqual(5, gen_pace_config_data(args)["media_type"])
+        self.assertEqual("ST_TAIRMEMPOOL_SSD", get_pace_storage_type(args.media_type))
+
+    def test_legacy_media_keeps_legacy_storage_type(self):
+        args = self._parse_args()
+        self.assertEqual(0, gen_pace_config_data(args)["media_type"])
+        self.assertEqual("ST_TAIRMEMPOOL", get_pace_storage_type(args.media_type))
+
+    def test_dram_media_keeps_legacy_storage_type(self):
+        args = self._parse_args("--media_type", "2")
+        self.assertEqual("ST_TAIRMEMPOOL", get_pace_storage_type(args.media_type))
+
+    def test_ssd_media_is_rejected_by_legacy_pace_subcommand(self):
+        with self.assertRaises(SystemExit):
+            self._parse_args("--media_type", "5")
+
+    def test_invalid_media_type_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            self._parse_args("--media_type", "7")
+
+    def test_update_can_distinguish_omitted_media_type(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="storage_type", required=True)
+        add_pace_sub_parser(subparsers, media_type_default=None)
+
+        args = parser.parse_args(["pace", "--domain", "pace.meta", "--timeout", "5000"])
+
+        self.assertIsNone(args.media_type)
+
+    def test_update_payload_always_carries_explicit_pace_storage_type(self):
+        for media_type, expected_type in ((0, "ST_TAIRMEMPOOL"), (2, "ST_TAIRMEMPOOL"),
+                                          (5, "ST_TAIRMEMPOOL_SSD")):
+            with self.subTest(media_type=media_type):
+                args = argparse.Namespace(unique_name="pace_storage", media_type=media_type, trace_id="test")
+                data = create_update_storage_data(args, "tair_mem_pool", {"media_type": media_type})
+                self.assertEqual(expected_type, data["storage"]["storage_type"])
+
+
+class PaceStorageUpdateTest(unittest.TestCase):
+    def _args(self, media_type=None, storage_type="pace"):
+        return SimpleNamespace(
+            domain="pace.meta",
+            host="http://manager",
+            media_type=media_type,
+            service_discovery_url="",
+            timeout=5000,
+            trace_id="trace",
+            unique_name="pace_storage",
+            verbose=False,
+            storage_type=storage_type,
+        )
+
+    @staticmethod
+    def _list_response(storage_type, media_type):
+        return {
+            "header": {"status": {"code": "OK"}},
+            "storage": [
+                {
+                    "global_unique_name": "pace_storage",
+                    "storage_type": storage_type,
+                    "tair_mem_pool": {
+                        "domain": "pace.meta",
+                        "timeout": 5000,
+                        "media_type": media_type,
+                    },
+                }
+            ],
+        }
+
+    @patch.object(update_storage, "http_post_and_print")
+    @patch.object(update_storage, "http_post")
+    def test_ssd_subcommand_preserves_ssd_type(self, mock_http_post, mock_post_and_print):
+        mock_http_post.return_value = self._list_response("ST_TAIRMEMPOOL_SSD", 5)
+
+        update_storage.handle_pace(self._args(media_type=5, storage_type="pace_ssd"))
+
+        request = mock_post_and_print.call_args.args[1]
+        self.assertEqual("ST_TAIRMEMPOOL_SSD", request["storage"]["storage_type"])
+        self.assertEqual(5, request["storage"]["tair_mem_pool"]["media_type"])
+
+    @patch.object(update_storage, "http_post_and_print")
+    @patch.object(update_storage, "http_post")
+    def test_omitted_media_type_preserves_legacy_media_5(self, mock_http_post, mock_post_and_print):
+        for storage_type in ("ST_UNSPECIFIED", "ST_TAIRMEMPOOL"):
+            with self.subTest(storage_type=storage_type):
+                mock_http_post.return_value = self._list_response(storage_type, 5)
+
+                update_storage.handle_pace(self._args())
+
+                request = mock_post_and_print.call_args.args[1]
+                self.assertEqual("ST_TAIRMEMPOOL", request["storage"]["storage_type"])
+                self.assertEqual(5, request["storage"]["tair_mem_pool"]["media_type"])
+
+    @patch.object(update_storage, "http_post_and_print")
+    @patch.object(update_storage, "http_post")
+    def test_explicit_legacy_media_type_preserves_legacy_type(self, mock_http_post, mock_post_and_print):
+        mock_http_post.return_value = self._list_response("ST_TAIRMEMPOOL", 2)
+
+        update_storage.handle_pace(self._args(media_type=2))
+
+        request = mock_post_and_print.call_args.args[1]
+        self.assertEqual("ST_TAIRMEMPOOL", request["storage"]["storage_type"])
+        self.assertEqual(2, request["storage"]["tair_mem_pool"]["media_type"])
+
+    @patch.object(update_storage, "http_post_and_print")
+    @patch.object(update_storage, "http_post")
+    def test_pace_subcommand_rejects_ssd_type(self, mock_http_post, mock_post_and_print):
+        mock_http_post.return_value = self._list_response("ST_TAIRMEMPOOL_SSD", 5)
+
+        with self.assertRaisesRegex(RuntimeError, "use the 'pace_ssd' subcommand"):
+            update_storage.handle_pace(self._args())
+
+        mock_post_and_print.assert_not_called()
+
+    @patch.object(update_storage, "http_post_and_print")
+    @patch.object(update_storage, "http_post")
+    def test_pace_ssd_subcommand_rejects_legacy_type(self, mock_http_post, mock_post_and_print):
+        mock_http_post.return_value = self._list_response("ST_TAIRMEMPOOL", 5)
+
+        with self.assertRaisesRegex(RuntimeError, "use the 'pace' subcommand"):
+            update_storage.handle_pace(self._args(media_type=5, storage_type="pace_ssd"))
+
+        mock_post_and_print.assert_not_called()
+
+    @patch.object(update_storage, "http_post_and_print")
+    @patch.object(update_storage, "http_post")
+    def test_omitted_media_type_rejects_missing_storage(self, mock_http_post, mock_post_and_print):
+        mock_http_post.return_value = {"header": {"status": {"code": "OK"}}, "storage": []}
+
+        with self.assertRaisesRegex(RuntimeError, "does not exist"):
+            update_storage.handle_pace(self._args())
+
+        mock_post_and_print.assert_not_called()
+
+
+class TairMempoolSsdPreferenceTest(unittest.TestCase):
+    def test_ssd_preference_is_accepted(self):
+        config = CacheConfig(data_storage_strategy="CPS_ALWAYS_TAIR_MEMPOOL_SSD")
+        self.assertEqual("CPS_ALWAYS_TAIR_MEMPOOL_SSD", config.to_json_data()["data_storage_strategy"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `ST_TAIRMEMPOOL_SSD` / `pace_ssd` as an independently accounted storage type, so DRAM high-watermark migration is not masked by idle SSD capacity
- add explicit SSD cache-preference strategies and a dedicated `kvcm_ops pace_ssd` command while keeping the data URI scheme as `pace://`
- reject in-place TairMempool DRAM/SSD type changes to protect persisted location and usage accounting
- document rollout, quota, worker upgrade, internal PACE backend, and rollback requirements

Legacy `pace` storage, including `media_type=5`, remains supported with the original merged `ST_TAIRMEMPOOL` accounting. Independent SSD accounting is enabled only by configuring `pace_ssd`.