### PR TITLE
[common] fix GCC 11 URI test compilation

### DIFF
--- a/kv_cache_manager/common/test/standard_uri_test.cc
+++ b/kv_cache_manager/common/test/standard_uri_test.cc
@@ -370,7 +370,7 @@ TEST_F(StandardUriTest, TestFileUri) {
 }
 
 TEST_F(StandardUriTest, TestSerializeWithExtraParamMatchesCanonicalMutation) {
-    for (const std::string &raw_uri : {
+    for (const char *raw_uri : {
              "event_report://host:8080/mem",
              "event_report://host:8080/mem?block=7&phase=add",
              "event_report://user@host:8080/mem?z=last&a=first",
@@ -414,7 +414,7 @@ TEST_F(StandardUriTest, TestInvalidPort) {
         ASSERT_EQ("127.0.0.1", redis_uri.GetHostName());
         ASSERT_EQ(0, redis_uri.GetPort()); // default 0
     }
-    for (const std::string &invalid_uri : {
+    for (const char *invalid_uri : {
              "redis://user:pw@127.0.0.1:abcd/",
              "redis://user:pw@127.0.0.1:-1/",
              "redis://user:pw@127.0.0.1:-0/",

--- a/kv_cache_manager/data_storage/test/snapshot_uri_utils_test.cc
+++ b/kv_cache_manager/data_storage/test/snapshot_uri_utils_test.cc
@@ -122,7 +122,7 @@ TEST_F(SnapshotUriUtilsTest, PrevalidatedStructureStillRejectsProtocolQueryAndBa
 
 TEST_F(SnapshotUriUtilsTest, AddSnapshotVersionRejectsInvalidPortWithoutCanonicalizingItAway) {
     constexpr const char *token = "0123456789abcdef0123456789abcdef";
-    for (const std::string &invalid_uri : {
+    for (const char *invalid_uri : {
              "event_report://physical-cache:not-a-port/mem?size=1",
              "event_report://physical-cache:-1/mem?size=1",
              "event_report://physical-cache:9223372036854775808/mem?size=1",


### PR DESCRIPTION
## Summary

- use `const char *` loop variables when iterating URI string literal lists
- preserve the existing URI inputs, assertions, and production behavior
- keep the default warning and `-Werror` configuration unchanged

## Testing

- `bazel test //kv_cache_manager/common/test:StandardUriTest`
- `bazel test //kv_cache_manager/data_storage/test:SnapshotUriUtilsTest`
- full unit, integration, client, and ASAN regression suites


在 GCC 11.5 环境下使用仓库默认 Bazel 配置直接执行时无法通过编译。

仓库 .bazelrc 默认启用 -c opt、-Wall 和 -Werror。测试代码中的 range-for 遍历字符串字面量列表时，列表元素类型是 const char *，循环变量却声明为 const std::string &。GCC 11 的 -Wrange-loop-construct 会诊断这种不同类型之间的隐式转换；在 -Werror 下该告警被提升为编译错误。

已知失败位置
kv_cache_manager/common/test/standard_uri_test.cc:373
kv_cache_manager/common/test/standard_uri_test.cc:417
kv_cache_manager/data_storage/test/snapshot_uri_utils_test.cc:125
涉及 Bazel 测试目标：

//kv_cache_manager/common/test:StandardUriTest
//kv_cache_manager/data_storage/test:SnapshotUriUtilsTest
