### PR TITLE
[integration_test] poll complete metrics snapshots

### DIFF
--- a/integration_test/reclaimer/reclaiming_test.py
+++ b/integration_test/reclaimer/reclaiming_test.py
@@ -519,9 +519,6 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             "current_version": current_version,
         })
 
-        self._wait_metric_value(
-            "cache_reclaimer.pending_delete_handler_count", 1
-        )
         expected_group_type_tags = {
             "instance_group": self._instance_group_name,
             "storage_type": "file",
@@ -529,67 +526,36 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         expected_group_tags = {
             "instance_group": self._instance_group_name,
         }
-        inflight_metrics = {
-            "delete_submit_count": self._metric_value(
-                "cache_reclaimer.delete_submit_count"
-            ),
-            "pending_delete_handler_count": self._metric_value(
-                "cache_reclaimer.pending_delete_handler_count"
-            ),
-            "pending_location_count": self._metric_value(
-                "cache_reclaimer.pending_location_count"
-            ),
-            "pending_delete_bytes": self._metric_value(
-                "cache_reclaimer.pending_delete_bytes"
-            ),
-            "credited_delete_bytes": self._metric_value(
-                "cache_reclaimer.credited_delete_bytes"
-            ),
-            "predicted_deleted_key_count": self._metric_value(
-                "cache_reclaimer.predicted_deleted_key_count"
-            ),
-        }
-        logging.info("delayed reclaim in-flight metrics: %s", inflight_metrics)
-        self.assertEqual(inflight_metrics["delete_submit_count"], 1)
-        self.assertEqual(inflight_metrics["pending_delete_handler_count"], 1)
-        self.assertEqual(inflight_metrics["pending_location_count"], 4)
-        self.assertEqual(inflight_metrics["pending_delete_bytes"], 4 * 1024)
-        self.assertEqual(inflight_metrics["credited_delete_bytes"], 4 * 1024)
-        self.assertEqual(inflight_metrics["predicted_deleted_key_count"], 4)
-        self.assertEqual(
-            self._metric_value(
+        inflight_metrics = self._wait_metric_values([
+            ("cache_reclaimer.delete_submit_count", {}, 1),
+            ("cache_reclaimer.delete_complete_count", {}, 0),
+            ("cache_reclaimer.pending_delete_handler_count", {}, 1),
+            ("cache_reclaimer.pending_location_count", {}, 4),
+            ("cache_reclaimer.pending_delete_bytes", {}, 4 * 1024),
+            ("cache_reclaimer.credited_delete_bytes", {}, 4 * 1024),
+            ("cache_reclaimer.predicted_deleted_key_count", {}, 4),
+            (
                 "cache_reclaimer.pending_location_count",
                 expected_group_type_tags,
+                4,
             ),
-            4,
-        )
-        self.assertEqual(
-            self._metric_value(
+            (
                 "cache_reclaimer.pending_delete_bytes",
                 expected_group_type_tags,
+                4 * 1024,
             ),
-            4 * 1024,
-        )
-        self.assertEqual(
-            self._metric_value(
+            (
                 "cache_reclaimer.credited_delete_bytes",
                 expected_group_type_tags,
+                4 * 1024,
             ),
-            4 * 1024,
-        )
-        self.assertEqual(
-            self._metric_value(
+            (
                 "cache_reclaimer.predicted_deleted_key_count",
                 expected_group_tags,
+                4,
             ),
-            4,
-        )
-
-        self.assertEqual(
-            self._metric_value("cache_reclaimer.delete_complete_count"),
-            0,
-            "the end-to-end Future must remain pending during the delay",
-        )
+        ])
+        logging.info("delayed reclaim in-flight metrics: %s", inflight_metrics)
         self._wait_surviving_block_count(
             self._instance_id,
             range(12),
@@ -597,9 +563,39 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             timeout_s=2,
         )
 
-        self._wait_metric_value(
-            "cache_reclaimer.pending_delete_handler_count", 0, timeout_s=8
+        completed_metrics = self._wait_metric_values(
+            [
+                ("cache_reclaimer.delete_submit_count", {}, 1),
+                ("cache_reclaimer.delete_complete_count", {}, 1),
+                ("cache_reclaimer.pending_delete_handler_count", {}, 0),
+                ("cache_reclaimer.pending_location_count", {}, 0),
+                ("cache_reclaimer.pending_delete_bytes", {}, 0),
+                ("cache_reclaimer.credited_delete_bytes", {}, 0),
+                ("cache_reclaimer.predicted_deleted_key_count", {}, 0),
+                (
+                    "cache_reclaimer.pending_location_count",
+                    expected_group_type_tags,
+                    0,
+                ),
+                (
+                    "cache_reclaimer.pending_delete_bytes",
+                    expected_group_type_tags,
+                    0,
+                ),
+                (
+                    "cache_reclaimer.credited_delete_bytes",
+                    expected_group_type_tags,
+                    0,
+                ),
+                (
+                    "cache_reclaimer.predicted_deleted_key_count",
+                    expected_group_tags,
+                    0,
+                ),
+            ],
+            timeout_s=8,
         )
+        logging.info("delayed reclaim completed metrics: %s", completed_metrics)
 
         surviving_blocks = self._count_surviving_blocks(
             self._instance_id, range(12)
@@ -621,46 +617,6 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             12,
             "the delayed reclaim batch should still complete",
         )
-        self.assertEqual(
-            self._metric_value("cache_reclaimer.delete_submit_count"),
-            1,
-            "fresh credit should prevent admission of a second batch",
-        )
-        self.assertEqual(
-            self._metric_value("cache_reclaimer.delete_complete_count"), 1
-        )
-        for metric_name in (
-            "pending_delete_handler_count",
-            "pending_location_count",
-            "pending_delete_bytes",
-            "credited_delete_bytes",
-            "predicted_deleted_key_count",
-        ):
-            self.assertEqual(
-                self._metric_value(f"cache_reclaimer.{metric_name}"),
-                0,
-                f"{metric_name} should be released at Future completion",
-            )
-        for metric_name in (
-            "pending_location_count",
-            "pending_delete_bytes",
-            "credited_delete_bytes",
-        ):
-            self.assertEqual(
-                self._metric_value(
-                    f"cache_reclaimer.{metric_name}",
-                    expected_group_type_tags,
-                ),
-                0,
-                f"tagged {metric_name} should be released at Future completion",
-            )
-        self.assertEqual(
-            self._metric_value(
-                "cache_reclaimer.predicted_deleted_key_count",
-                expected_group_tags,
-            ),
-            0,
-        )
 
     def _wait_metric_value(
         self, metric_name, expected_value, tags=None, timeout_s=2
@@ -678,10 +634,13 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
         )
 
     def _metric_value(self, metric_name, tags=None):
-        expected_tags = tags or {}
         metrics = self._admin_client.get_metrics({
             "trace_id": self._trace_id + "_metrics",
         })["metrics"]
+        return self._metric_value_from_metrics(metrics, metric_name, tags)
+
+    def _metric_value_from_metrics(self, metrics, metric_name, tags=None):
+        expected_tags = tags or {}
         values = []
         for metric in metrics:
             if metric.get("metric_name") != metric_name:
@@ -708,6 +667,40 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             f"got {len(values)}",
         )
         return values[0]
+
+    def _wait_metric_values(self, expected_metrics, timeout_s=2):
+        deadline = time.monotonic() + timeout_s
+        expected_values = {
+            f"{metric_name} with tags {tags}": expected_value
+            for metric_name, tags, expected_value in expected_metrics
+        }
+        last_values = {}
+        while time.monotonic() < deadline:
+            metrics = self._admin_client.get_metrics({
+                "trace_id": self._trace_id + "_metrics",
+            })["metrics"]
+            last_values = {}
+            matched = True
+            for metric_name, tags, expected_value in expected_metrics:
+                metric_description = f"{metric_name} with tags {tags}"
+                try:
+                    actual_value = self._metric_value_from_metrics(
+                        metrics, metric_name, tags
+                    )
+                except self.failureException as error:
+                    last_values[metric_description] = str(error)
+                    matched = False
+                    continue
+                last_values[metric_description] = actual_value
+                if actual_value != expected_value:
+                    matched = False
+            if matched:
+                return last_values
+            time.sleep(0.05)
+        self.fail(
+            "metrics did not reach a matching snapshot; "
+            f"expected values: {expected_values}; last values: {last_values}"
+        )
 
     def _count_surviving_blocks(self, instance_id, block_keys):
         surviving_blocks = 0

--- a/integration_test/reclaimer/reclaiming_test.py
+++ b/integration_test/reclaimer/reclaiming_test.py
@@ -617,6 +617,11 @@ class ReclaimingTest(abc.ABC, TestBase, unittest.TestCase):
             12,
             "the delayed reclaim batch should still complete",
         )
+        self.assertEqual(
+            self._metric_value("cache_reclaimer.delete_submit_count"),
+            1,
+            "fresh credit should prevent admission of a second batch",
+        )
 
     def _wait_metric_value(
         self, metric_name, expected_value, tags=None, timeout_s=2


### PR DESCRIPTION
## 中文

### 背景与问题

`test_no_over_eviction_with_delay` 及其 key-count 变体用于验证两件事：延迟删除期间的 credit 能阻止额外回收批次，以及 Future 完成后临时 accounting 会被完整释放。

原测试先等待单个 `pending_delete_handler_count`，再通过多次独立的 `getMetrics` 请求读取其余指标。由于服务端按顺序更新 gauges，这些请求可能拼接出来自不同时间点的状态，在 ASAN 或较慢环境中更容易观察到合法转换过程中的中间态，从而产生误报。

### 修复方式

- 每轮轮询只获取一次完整的 `getMetrics` 响应，并从该响应中解析全部期望指标。
- 按 `metric_name` 和完整 tags 精确匹配，且要求唯一的数值序列，避免误取聚合或其他维度的数据。
- 仅当无 tag、`instance_group`、`instance_group + storage_type` 三个维度的整组指标在同一响应中同时满足预期时才认为状态成立。
- 在途态与完成态使用同一套快照校验；保留原有超时和轮询间隔，不增加固定 sleep。
- 保留存活 block 和“最终仍只提交一个 batch”的行为断言，避免稳定性修复削弱防过度回收覆盖。

### Review 重点

- `_wait_metric_values` 的每轮只发起一次请求，逐项解析过程不会再次获取 metrics。
- tags 使用完整集合相等，而非子集匹配。
- 缺失、重复或处于转换中的序列会继续轮询；超时时会报告全部期望值和最后一次观测值。
- 本 PR 只修改集成测试，不改变生产代码或回收行为。

### 验证

- `reclaiming_test` 通过。
- 两个 delayed reclaiming case 在 ASAN 下连续重复 5 轮通过。
- ASAN integration test suite 通过。
- 最终 review 小修后的格式与 Python 语法检查通过。

---

## English

### Background and failure mode

`test_no_over_eviction_with_delay` and its key-count variant verify two invariants: in-flight delete credit prevents an extra reclaim batch, and all temporary accounting is released when the Future completes.

Previously, the tests waited for `pending_delete_handler_count` and then fetched the remaining metrics through separate `getMetrics` requests. Because the server updates the gauges sequentially, those requests could combine observations from different points in time. ASAN and slower environments made it more likely to observe a valid intermediate transition and report a false failure.

### What changed

- Each polling attempt fetches exactly one complete `getMetrics` response and parses every expected metric from that response.
- Series are matched by `metric_name` and the exact full tag set, with uniqueness and numeric-value checks to avoid selecting an aggregate or a different dimension.
- A state is accepted only when the complete untagged, `instance_group`, and `instance_group + storage_type` metric sets match simultaneously in the same response.
- The same snapshot check covers both in-flight and completed states. Existing timeouts and polling intervals are preserved, with no fixed sleep added.
- The surviving-block and final single-batch assertions remain in place so the stability fix does not weaken over-reclamation coverage.

### Reviewer focus

- `_wait_metric_values` performs one request per attempt; per-metric parsing never refetches metrics.
- Tag matching uses full-set equality rather than subset matching.
- Missing, duplicate, or transitional series are retried, while timeout diagnostics include all expected values and the last observation.
- This PR changes integration-test observation logic only; production reclaim behavior is unchanged.

### Validation

- `reclaiming_test` passed.
- Both delayed-reclaiming cases passed five consecutive ASAN repetitions.
- The ASAN integration test suite passed.
- Formatting and Python syntax checks passed after the final review-only adjustment.
