### PR TITLE
[build] bootstrap KVCM resources from environment variables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [ReportEvent 增量上报与权威快照设计](design/report_event_snapshot_uri_version.md) - 增量/快照协同、提交屏障、故障恢复、性能取舍与 Subscriber 集成
 - [ReportEvent / GetHostCacheState 小 block 性能记录](design/report_event_performance.md) - local/Redis 指标解释、锁与可见性语义、有界并发、容量基准及后续优化边界
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
+- [KVCM 环境变量启动与自动初始化](design/kvcm_env_startup_bootstrap.md) - 环境变量配置、Storage/Instance Group 映射及参数变化后的更新行为
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
 - [后台扫描 GC](design/cache_garbage_collector.md) - 基于 authoritative cursor 的后台全量巡检；V1 清理长期 orphan WRITING 和普通 SERVING storage-missing，并提供无副作用读取、精确值条件 CAS 与 HA 生命周期
 

--- a/docs/design/kvcm_env_startup_bootstrap.md
+++ b/docs/design/kvcm_env_startup_bootstrap.md
@@ -1,0 +1,215 @@
+# KVCM 环境变量启动与自动初始化设计
+
+## 1. 说明
+
+KVCM 的 EventReport 接入需要预先创建 L1.5/L2 Storage 和 Instance Group。当前发布包通过默认入口 `start_server.sh` 启动 KVCM，并在本机 Leader 上自动执行 `python3 -m kvcm_ops bootstrap`，根据环境变量创建或更新这些资源。
+
+本文主要说明：
+
+- 部署时需要配置哪些环境变量。
+- 环境变量如何生成 Storage 和 Instance Group。
+- 环境变量变化后，已有资源如何更新。
+
+## 2. 启动与生效关系
+
+```text
+Docker ENTRYPOINT
+  └─ start_server.sh
+      ├─ 启动 kv_cache_manager_bin
+      ├─ 等待本机 Admin HTTP 健康
+      └─ python3 -m kvcm_ops bootstrap
+          ├─ 解析环境变量
+          ├─ 检查本机是否为 Leader
+          ├─ 创建或更新 Storage
+          ├─ 创建或更新 Instance Group
+          └─ 回读并校验受管字段
+```
+
+单机和高可用部署都只访问本机 `http://127.0.0.1:6492`。Follower 不修改配置，也不查找或访问 Leader；Follower 晋升为 Leader 后执行相同的幂等 bootstrap。
+
+## 3. 核心环境变量
+
+| 环境变量 | 是否必填 | 说明 |
+|---|---|---|
+| `KVCM_ENABLE_SUBSCRIBER_EVENT_REPORT` | 是 | 布尔值，只接受 `true`/`false`；控制 L1.5 Storage |
+| `KVCM_ENABLE_V6D_EVENT_REPORT` | 是 | 布尔值，只接受 `true`/`false`；控制 L2 Storage |
+| `KVCM_INSTANCE_GROUP_NAME` | 开启任一上报时 | Instance Group 名称 |
+| `KVCM_EVENT_REPORT_L1P5_STORAGE_NAME` | subscriber 开启时 | L1.5 Storage 名称 |
+| `KVCM_EVENT_REPORT_L2_STORAGE_NAME` | V6D 开启时 | L2 Storage 名称 |
+| `KVCM_META_STORAGE_TYPE` | 开启任一上报时 | Meta Storage 类型，支持 `redis`、`cached` |
+| `KVCM_META_STORAGE_URI` | 开启任一上报时 | `redis://...` URI，包含 Redis 连接信息和统一 query 参数 |
+| `KVCM_METADATA_BACKEND_MODE` | 否 | 1～4 的整数；设置时写入 `extra_info.metadata_backend_mode` |
+
+两个上报开关都为 `false` 时，只启动 KVCM，不创建或更新 Storage/Instance Group。此时除两个开关外，其他 bootstrap 环境变量可以不提供。
+
+## 4. Meta Storage 配置
+
+### 4.1 Storage 类型与 URI 分开配置
+
+原手工命令：
+
+```text
+--meta_storage_backend_config 'cached,redis://...'
+```
+
+对应环境变量：
+
+```text
+KVCM_META_STORAGE_TYPE=cached
+KVCM_META_STORAGE_URI=redis://...
+```
+
+`KVCM_META_STORAGE_URI` 必须包含：
+
+- Redis host。
+- 1～65535 范围内的端口。
+- 唯一且非空的 `cluster_name` query 参数。
+
+为了兼容已有 `kvcm_registry_storage_uri` 和 `create_instance_group --meta_storage_backend_config`，密码中的原始 `#` 可以保持原写法。bootstrap 只在内部校验副本中处理 `#`，最终写入 Instance Group 的 URI 与环境变量原字符串完全一致。
+
+### 4.2 Instance Group 参数
+
+以下参数统一写在 `KVCM_META_STORAGE_URI` query 中；未提供时使用默认值：
+
+| 参数 | 默认值 | 约束 | 写入位置 |
+|---|---:|---|---|
+| `max_instance_count` | 512 | 正整数 | Instance Group |
+| `quota_capacity` | 2087740652912 | 正整数，单位为字节 | Group quota 及主 Storage quota |
+| `max_key_count` | 1000000000 | 正整数 | MetaIndexer |
+| `mutex_shard_num` | 131072 | 正整数且为 2 的幂 | MetaIndexer |
+| `batch_key_size` | 1024 | 正整数 | MetaIndexer |
+| `search_cache_capacity` | 10240 | 正整数，单位为 MB | 新建 Group 的 Meta Cache Policy |
+| `search_cache_shard_bits` | 6 | 非负整数 | 新建 Group 的 Meta Cache Policy |
+
+当前实现更新已有 Instance Group 时不覆盖已有 Meta Cache Policy，因此 `search_cache_capacity` 和 `search_cache_shard_bits` 只影响新建 Group。
+
+### 4.3 EventReport Storage 参数
+
+以下可选正整数参数也写在 URI query 中，并应用到受管的 L1.5/L2 Storage：
+
+- `heartbeat_timeout_ms`
+- `cleanup_grace_ms`
+- `liveness_check_interval_ms`
+- `snapshot_min_interval_ms`
+
+同名 Storage 已存在时，只更新这些受管字段，保留 `event_report` 中其他字段。
+
+### 4.4 Redis 及异步队列参数
+
+以下参数由 bootstrap 做数值校验，并随原始 URI 传给 Meta Storage Backend：
+
+- 正整数：`timeout_ms`、`async_queue_count`、`async_max_batch`、`async_wait_us`、`async_max_size`、`async_sync_timeout_ms`、`async_drain_ms`、`client_max_pool_size`、`sample_times`。
+- 非负整数：`db`、`async_enqueue_timeout_ms`、`client_min_pool_size`、`num_shard_bits`。
+- `async_queue_count` 最大为 2048。
+
+`retry_count`、`persistent_type`、`cache_type` 等其他参数不由 bootstrap 解释，但会保留在 URI 中并传给 KVCM。
+
+完整 URI 属于 secret。bootstrap 不主动打印用户名、密码、query 或完整 URI；成功日志只包含 Meta Storage 类型和 Redis host/port。
+
+## 5. Subscriber 与 V6D 组合
+
+| Subscriber | V6D | 创建的 Storage | 主 Storage / quota | EventReport candidates |
+|---|---|---|---|---|
+| 开 | 关 | L1.5 | L1.5 | L1.5 |
+| 关 | 开 | L2 | L2 | L2 |
+| 开 | 开 | L1.5、L2 | L1.5 | L1.5、L2 |
+| 关 | 关 | 不创建 | 不配置 | 不配置 |
+
+主 Storage 同时用于 `storage_candidates`、quota 类型和 `reclaim_strategy.storage_unique_name`。
+
+`KVCM_METADATA_BACKEND_MODE` 与 subscriber/V6D 开关没有绑定关系。设置时写入或更新 `extra_info.metadata_backend_mode`；未设置时不管理该字段，并保留已有 `extra_info` 内容。
+
+## 6. 完整配置示例
+
+以下示例同时启用 subscriber 和 V6D。账号、密码、地址和 cluster name 均为示例值：
+
+```json
+{
+  "KVCM_ENABLE_SUBSCRIBER_EVENT_REPORT": "true",
+  "KVCM_ENABLE_V6D_EVENT_REPORT": "true",
+  "KVCM_INSTANCE_GROUP_NAME": "example_group",
+  "KVCM_EVENT_REPORT_L1P5_STORAGE_NAME": "example_l1p5",
+  "KVCM_EVENT_REPORT_L2_STORAGE_NAME": "example_l2",
+  "KVCM_META_STORAGE_TYPE": "cached",
+  "KVCM_METADATA_BACKEND_MODE": "4",
+  "KVCM_META_STORAGE_URI": "redis://default:example#password@redis.example.com:6379?timeout_ms=1000&retry_count=3&cluster_name=example_cluster&num_shard_bits=18&sample_times=1024&persistent_type=async_redis&cache_type=local&async_queue_count=16&async_max_batch=1024000&async_max_size=1024000&async_enqueue_timeout_ms=10&async_wait_us=1000000&max_instance_count=512&quota_capacity=2087740652912&max_key_count=1000000000&mutex_shard_num=131072&batch_key_size=1024"
+}
+```
+
+生成结果：
+
+- L1.5 Storage：`example_l1p5`。
+- L2 Storage：`example_l2`。
+- Instance Group：`example_group`。
+- 主 Storage 和 quota：L1.5。
+- EventReport candidates：L1.5、L2。
+- Meta Storage：`cached`，底层 URI 为环境变量中的完整 Redis URI。
+- `extra_info.metadata_backend_mode=4`。
+
+## 7. 环境变量变化后的行为
+
+bootstrap 不会先删除全部旧资源再重建，而是读取现有配置后按变化类型处理：
+
+| 变化 | 行为 |
+|---|---|
+| URI、quota、MetaIndexer 参数变化 | 原地更新当前 Instance Group |
+| Storage 参数变化但名称相同 | 原地更新对应 Storage |
+| Storage 名称变化 | 创建新 Storage，切换 Group 引用，保留旧 Storage |
+| Instance Group 名称变化 | 创建新 Group，保留旧 Group |
+| `KVCM_METADATA_BACKEND_MODE` 修改 | 原地更新当前 Group 中的该字段，保留其他 `extra_info` |
+| `KVCM_METADATA_BACKEND_MODE` 删除 | 不再管理该字段，保留 Group 中已有值 |
+| 两个上报开关都改为 `false` | 跳过初始化，不主动删除已有 Storage 或 Group |
+
+### 7.1 只修改 L2 Storage 名称
+
+假设原配置为：
+
+```text
+L1.5 = storage_l1p5
+L2   = storage_l2
+Group candidates = [storage_l1p5, storage_l2]
+```
+
+只把 L2 名称改为 `storage_l2_new` 后：
+
+```text
+创建 storage_l2_new
+保留 storage_l1p5
+保留旧 storage_l2
+Group candidates 更新为 [storage_l1p5, storage_l2_new]
+```
+
+L1.5 Storage 没有变化，因此不会重新创建或更新。
+
+### 7.2 Instance Group 受管字段
+
+更新已有 Group 时，bootstrap 覆盖：
+
+- `storage_candidates`
+- `event_report_storage_candidates`
+- `max_instance_count`
+- quota
+- reclaim Storage
+- `max_key_count`、`mutex_shard_num`、`batch_key_size`
+- `meta_storage_backend_config`
+- 设置了环境变量时的 `extra_info.metadata_backend_mode`
+
+已有 `user_data`、quota group、Meta Cache Policy 和其他扩展字段保持不变。
+
+Group 更新采用版本控制：读取当前版本，使用 `version + 1` 更新；遇到版本冲突时重新读取并重试。更新完成后重新读取 Storage 和 Group，校验所有受管字段。
+
+旧 Storage 和旧 Group 不自动删除，因为它们可能仍被其他 Group、实例或人工配置引用。如需清理，由用户确认引用关系后手动删除。
+
+## 8. 配置错误和重试
+
+环境变量缺失、格式非法、Admin API 失败或回读不一致时：
+
+- bootstrap 输出包含失败阶段、异常类型、异常消息和 Python 堆栈的 ERROR 日志。
+- 首次失败后等待 5 秒重试，最多重试 2 次，即一次启动周期最多执行 3 次失败尝试。
+- 重试耗尽后停止本次自动 bootstrap，但 KVCM 继续运行。
+- 用户可以进入容器手动执行 `kvcm_ops` 命令。
+- 容器重启后重新执行环境变量初始化并重新获得重试机会。
+
+Follower 等待和执行中失去 Leader 身份不算配置失败，不消耗上述重试次数。
+
+bootstrap Python 日志位于容器标准输出/标准错误；KVCM C++ 处理 Admin API 时产生的 `KVCM_LOG_xxx` 仍写入 `kv_cache_manager.log`。

--- a/package/kvcm_ops/BUILD
+++ b/package/kvcm_ops/BUILD
@@ -29,3 +29,9 @@ py_test(
     srcs = ["test/storage_util_test.py"],
     deps = [":kvcm_ops_lib"],
 )
+
+py_test(
+    name = "bootstrap_test",
+    srcs = ["test/bootstrap_test.py"],
+    deps = [":kvcm_ops_lib"],
+)

--- a/package/kvcm_ops/BUILD
+++ b/package/kvcm_ops/BUILD
@@ -19,6 +19,9 @@ py_wheel(
     name = "kvcm_ops_wheel",
     distribution = "kvcm_ops",
     python_tag = "py3",
+    requires = [
+        "requests>=2.31.0,<3",
+    ],
     strip_path_prefixes = ["package"],
     version = "0.1.0",
     deps = [":kvcm_ops_lib"],

--- a/package/kvcm_ops/__main__.py
+++ b/package/kvcm_ops/__main__.py
@@ -23,6 +23,8 @@ COMMANDS = {
     "update_storage": "kvcm_ops.kvcm.storage.update_storage",
     "remove_storage": "kvcm_ops.kvcm.storage.remove_storage",
 
+    "bootstrap": "kvcm_ops.kvcm.bootstrap",
+
     "trace_key": "kvcm_ops.trace.trace_key",
     "trace_uri": "kvcm_ops.trace.trace_uri",
 
@@ -79,6 +81,8 @@ def main():
     remove_storage
   storage types (for add_storage/update_storage):
     nfs / pace / pace_ssd / 3fs / event_report_l1p5 / event_report_l2
+  bootstrap:
+    bootstrap
   trace:
     trace_key
     trace_uri

--- a/package/kvcm_ops/kvcm/bootstrap.py
+++ b/package/kvcm_ops/kvcm/bootstrap.py
@@ -1,0 +1,645 @@
+import copy
+import json
+import logging
+import os
+import time
+from urllib.parse import parse_qs, urlsplit
+
+from .common.http_helper import http_post
+from .instance_group.util import (
+    CacheConfig,
+    InstanceGroup,
+    InstanceGroupQuota,
+    MetaCachePolicyConfig,
+    MetaIndexerConfig,
+    MetaStorageBackendConfig,
+    ReclaimStrategy,
+    StorageQuota,
+)
+
+
+LOGGER = logging.getLogger("kvcm_ops.bootstrap")
+
+DEFAULT_ADMIN_URL = "http://127.0.0.1:6492"
+DEFAULT_MAX_INSTANCE_COUNT = 512
+DEFAULT_QUOTA_CAPACITY = 2087740652912
+DEFAULT_MAX_KEY_COUNT = 1000000000
+DEFAULT_MUTEX_SHARD_NUM = 131072
+DEFAULT_BATCH_KEY_SIZE = 1024
+DEFAULT_SEARCH_CACHE_CAPACITY = 10 * 1024
+DEFAULT_SEARCH_CACHE_SHARD_BITS = 6
+INSTANCE_GROUP_UPDATE_RETRIES = 3
+FOLLOWER_EXIT_CODE = 2
+
+BOOTSTRAP_QUERY_KEYS = {
+    "max_instance_count",
+    "quota_capacity",
+    "max_key_count",
+    "mutex_shard_num",
+    "batch_key_size",
+    "search_cache_capacity",
+    "search_cache_shard_bits",
+}
+
+EVENT_REPORT_QUERY_KEYS = {
+    "heartbeat_timeout_ms",
+    "cleanup_grace_ms",
+    "liveness_check_interval_ms",
+    "snapshot_min_interval_ms",
+}
+
+POSITIVE_PASSTHROUGH_QUERY_KEYS = {
+    "timeout_ms",
+    "async_queue_count",
+    "async_max_batch",
+    "async_wait_us",
+    "async_max_size",
+    "async_sync_timeout_ms",
+    "async_drain_ms",
+    "client_max_pool_size",
+    "sample_times",
+}
+
+NON_NEGATIVE_PASSTHROUGH_QUERY_KEYS = {
+    "db",
+    "async_enqueue_timeout_ms",
+    "client_min_pool_size",
+    "num_shard_bits",
+}
+
+
+class BootstrapError(RuntimeError):
+    pass
+
+
+class NotLeaderError(BootstrapError):
+    pass
+
+
+class BootstrapConfig:
+    def __init__(self):
+        self.subscriber_enabled = False
+        self.v6d_enabled = False
+        self.instance_group_name = ""
+        self.l1p5_storage_name = ""
+        self.l2_storage_name = ""
+        self.meta_storage_type = ""
+        self.meta_storage_uri = ""
+        self.metadata_backend_mode = None
+        self.max_instance_count = DEFAULT_MAX_INSTANCE_COUNT
+        self.quota_capacity = DEFAULT_QUOTA_CAPACITY
+        self.max_key_count = DEFAULT_MAX_KEY_COUNT
+        self.mutex_shard_num = DEFAULT_MUTEX_SHARD_NUM
+        self.batch_key_size = DEFAULT_BATCH_KEY_SIZE
+        self.search_cache_capacity = DEFAULT_SEARCH_CACHE_CAPACITY
+        self.search_cache_shard_bits = DEFAULT_SEARCH_CACHE_SHARD_BITS
+        self.event_report_spec = {}
+        self.redis_host = ""
+        self.redis_port = 0
+
+    @property
+    def enabled(self):
+        return self.subscriber_enabled or self.v6d_enabled
+
+    @property
+    def primary_storage_name(self):
+        if self.subscriber_enabled:
+            return self.l1p5_storage_name
+        return self.l2_storage_name
+
+    @property
+    def primary_storage_type(self):
+        if self.subscriber_enabled:
+            return "ST_EVENT_REPORT_L1P5"
+        return "ST_EVENT_REPORT_L2"
+
+    @property
+    def event_report_storage_names(self):
+        names = []
+        if self.subscriber_enabled:
+            names.append(self.l1p5_storage_name)
+        if self.v6d_enabled:
+            names.append(self.l2_storage_name)
+        return names
+
+
+def _parse_bool(environ, name):
+    value = environ.get(name)
+    if value is None:
+        raise BootstrapError("{} is required and must be true or false".format(name))
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise BootstrapError("{} must be true or false".format(name))
+
+
+def _require_non_empty(environ, name):
+    value = environ.get(name, "").strip()
+    if not value:
+        raise BootstrapError("{} is required".format(name))
+    return value
+
+
+def _single_query_value(query, name):
+    values = query.get(name)
+    if not values:
+        return None
+    if len(values) != 1:
+        raise BootstrapError("storage URI query parameter {} must appear once".format(name))
+    if values[0] == "":
+        raise BootstrapError("storage URI query parameter {} must not be empty".format(name))
+    return values[0]
+
+
+def _positive_query_int(query, name, default, allow_zero=False):
+    raw_value = _single_query_value(query, name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        raise BootstrapError("storage URI query parameter {} must be an integer".format(name))
+    if value < 0 or (value == 0 and not allow_zero):
+        comparator = "non-negative" if allow_zero else "positive"
+        raise BootstrapError("storage URI query parameter {} must be {}".format(name, comparator))
+    return value
+
+
+def _parse_storage_uri(uri):
+    try:
+        parsed = urlsplit(uri)
+    except ValueError:
+        raise BootstrapError("KVCM_META_STORAGE_URI is not a valid URI")
+    if parsed.scheme.lower() != "redis":
+        raise BootstrapError("KVCM_META_STORAGE_URI scheme must be redis")
+    if not parsed.hostname:
+        raise BootstrapError("KVCM_META_STORAGE_URI must include a host")
+    if parsed.fragment:
+        raise BootstrapError("KVCM_META_STORAGE_URI must not contain a fragment; URI-encode credentials")
+    try:
+        port = parsed.port
+    except ValueError:
+        raise BootstrapError("KVCM_META_STORAGE_URI contains an invalid port")
+    if port is None or port <= 0 or port > 65535:
+        raise BootstrapError("KVCM_META_STORAGE_URI must include a port in range 1..65535")
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    cluster_name = _single_query_value(query, "cluster_name")
+    if cluster_name is None:
+        raise BootstrapError("KVCM_META_STORAGE_URI must include cluster_name")
+    return parsed.hostname, port, query
+
+
+def _validate_passthrough_query(query):
+    for name in POSITIVE_PASSTHROUGH_QUERY_KEYS:
+        _positive_query_int(query, name, None)
+    for name in NON_NEGATIVE_PASSTHROUGH_QUERY_KEYS:
+        _positive_query_int(query, name, None, allow_zero=True)
+    queue_count = _positive_query_int(query, "async_queue_count", None)
+    if queue_count is not None and queue_count > 2048:
+        raise BootstrapError("storage URI query parameter async_queue_count must not exceed 2048")
+
+
+def parse_environment(environ=None):
+    environ = os.environ if environ is None else environ
+    config = BootstrapConfig()
+    config.subscriber_enabled = _parse_bool(environ, "KVCM_ENABLE_SUBSCRIBER_EVENT_REPORT")
+    config.v6d_enabled = _parse_bool(environ, "KVCM_ENABLE_V6D_EVENT_REPORT")
+
+    mode_value = environ.get("KVCM_METADATA_BACKEND_MODE", "").strip()
+    if mode_value:
+        try:
+            config.metadata_backend_mode = int(mode_value)
+        except ValueError:
+            raise BootstrapError("KVCM_METADATA_BACKEND_MODE must be an integer in range 1..4")
+        if config.metadata_backend_mode < 1 or config.metadata_backend_mode > 4:
+            raise BootstrapError("KVCM_METADATA_BACKEND_MODE must be an integer in range 1..4")
+
+    if not config.enabled:
+        return config
+
+    config.instance_group_name = _require_non_empty(environ, "KVCM_INSTANCE_GROUP_NAME")
+    if config.subscriber_enabled:
+        config.l1p5_storage_name = _require_non_empty(
+            environ, "KVCM_EVENT_REPORT_L1P5_STORAGE_NAME")
+    if config.v6d_enabled:
+        config.l2_storage_name = _require_non_empty(
+            environ, "KVCM_EVENT_REPORT_L2_STORAGE_NAME")
+
+    config.meta_storage_type = _require_non_empty(environ, "KVCM_META_STORAGE_TYPE").lower()
+    if config.meta_storage_type not in ("redis", "cached"):
+        raise BootstrapError("KVCM_META_STORAGE_TYPE must be redis or cached")
+    config.meta_storage_uri = _require_non_empty(environ, "KVCM_META_STORAGE_URI")
+    config.redis_host, config.redis_port, query = _parse_storage_uri(config.meta_storage_uri)
+    _validate_passthrough_query(query)
+
+    config.max_instance_count = _positive_query_int(
+        query, "max_instance_count", DEFAULT_MAX_INSTANCE_COUNT)
+    config.quota_capacity = _positive_query_int(
+        query, "quota_capacity", DEFAULT_QUOTA_CAPACITY)
+    config.max_key_count = _positive_query_int(
+        query, "max_key_count", DEFAULT_MAX_KEY_COUNT)
+    config.mutex_shard_num = _positive_query_int(
+        query, "mutex_shard_num", DEFAULT_MUTEX_SHARD_NUM)
+    if config.mutex_shard_num & (config.mutex_shard_num - 1):
+        raise BootstrapError("storage URI query parameter mutex_shard_num must be a power of two")
+    config.batch_key_size = _positive_query_int(
+        query, "batch_key_size", DEFAULT_BATCH_KEY_SIZE)
+    config.search_cache_capacity = _positive_query_int(
+        query, "search_cache_capacity", DEFAULT_SEARCH_CACHE_CAPACITY)
+    config.search_cache_shard_bits = _positive_query_int(
+        query, "search_cache_shard_bits", DEFAULT_SEARCH_CACHE_SHARD_BITS, allow_zero=True)
+
+    for name in EVENT_REPORT_QUERY_KEYS:
+        raw_value = _single_query_value(query, name)
+        if raw_value is None:
+            continue
+        config.event_report_spec[name] = _positive_query_int(query, name, None)
+    return config
+
+
+def _status_code(response):
+    return response.get("header", {}).get("status", {}).get("code")
+
+
+def _status_message(response):
+    return response.get("header", {}).get("status", {}).get("message", "unknown error")
+
+
+class AdminClient:
+    def __init__(self, host=DEFAULT_ADMIN_URL):
+        self.host = host.rstrip("/")
+        self._trace_counter = 0
+
+    def _trace_id(self, operation):
+        self._trace_counter += 1
+        return "bootstrap_{}_{}_{}".format(operation, int(time.time() * 1000), self._trace_counter)
+
+    def post(self, api, data, operation):
+        try:
+            response = http_post(self.host, api, data, False)
+        except Exception as exc:
+            raise BootstrapError(
+                "Admin API {} transport failed: {}: {}".format(
+                    operation, type(exc).__name__, exc))
+        code = _status_code(response)
+        if code in ("SERVER_NOT_LEADER", 9):
+            raise NotLeaderError("Admin API {} rejected because this node is not leader".format(operation))
+        if code not in ("OK", 1):
+            raise BootstrapError(
+                "Admin API {} failed with status code {}: {}".format(
+                    operation, code, _status_message(response)))
+        return response
+
+    def check_health(self):
+        return self.post(
+            "/api/checkHealth",
+            {"trace_id": self._trace_id("check_health")},
+            "checkHealth",
+        )
+
+    def list_storage(self):
+        response = self.post(
+            "/api/listStorage",
+            {"trace_id": self._trace_id("list_storage")},
+            "listStorage",
+        )
+        return response.get("storage", [])
+
+    def add_storage(self, storage):
+        self.post(
+            "/api/addStorage",
+            {"trace_id": self._trace_id("add_storage"), "storage": storage},
+            "addStorage",
+        )
+
+    def update_storage(self, storage):
+        self.post(
+            "/api/updateStorage",
+            {
+                "trace_id": self._trace_id("update_storage"),
+                "storage": storage,
+                "force_update": False,
+            },
+            "updateStorage",
+        )
+
+    def list_instance_groups(self):
+        response = self.post(
+            "/api/listInstanceGroup",
+            {"trace_id": self._trace_id("list_group")},
+            "listInstanceGroup",
+        )
+        return response.get("instance_group", [])
+
+    def create_instance_group(self, instance_group):
+        self.post(
+            "/api/createInstanceGroup",
+            {
+                "trace_id": self._trace_id("create_group"),
+                "instance_group": instance_group,
+            },
+            "createInstanceGroup",
+        )
+
+    def update_instance_group(self, instance_group, current_version):
+        self.post(
+            "/api/updateInstanceGroup",
+            {
+                "trace_id": self._trace_id("update_group"),
+                "instance_group": instance_group,
+                "current_version": current_version,
+            },
+            "updateInstanceGroup",
+        )
+
+
+def _storage_type_for_name(config, name):
+    if name == config.l1p5_storage_name:
+        return "ST_EVENT_REPORT_L1P5"
+    return "ST_EVENT_REPORT_L2"
+
+
+def _new_storage(config, name, storage_type, existing=None):
+    event_report = {}
+    if existing is not None and isinstance(existing.get("event_report"), dict):
+        event_report.update(existing["event_report"])
+    event_report.update(config.event_report_spec)
+    return {
+        "global_unique_name": name,
+        "storage_type": storage_type,
+        "event_report": event_report,
+        "check_storage_available_when_open": True,
+    }
+
+
+def _storage_matches(config, current, storage_type):
+    if current.get("storage_type") != storage_type:
+        return False
+    current_spec = current.get("event_report", {})
+    for key, value in config.event_report_spec.items():
+        if _as_int(current_spec.get(key, -1)) != value:
+            return False
+    return True
+
+
+def ensure_storages(client, config):
+    current_by_name = {
+        storage.get("global_unique_name"): storage
+        for storage in client.list_storage()
+    }
+    for name in config.event_report_storage_names:
+        storage_type = _storage_type_for_name(config, name)
+        current = current_by_name.get(name)
+        if current is None:
+            client.add_storage(_new_storage(config, name, storage_type))
+            LOGGER.info("created managed storage %s", name)
+        elif not _storage_matches(config, current, storage_type):
+            client.update_storage(_new_storage(config, name, storage_type, current))
+            LOGGER.info("updated managed storage %s", name)
+
+
+def _build_new_instance_group(config):
+    quota = InstanceGroupQuota(
+        config.quota_capacity,
+        [StorageQuota(config.primary_storage_type, config.quota_capacity)],
+    )
+    reclaim_strategy = ReclaimStrategy(storage_unique_name=config.primary_storage_name)
+    meta_storage = MetaStorageBackendConfig(config.meta_storage_type, config.meta_storage_uri)
+    meta_cache = MetaCachePolicyConfig(
+        capacity=config.search_cache_capacity,
+        cache_shard_bits=config.search_cache_shard_bits,
+    )
+    meta_indexer = MetaIndexerConfig(
+        max_key_count=config.max_key_count,
+        mutex_shard_num=config.mutex_shard_num,
+        batch_key_size=config.batch_key_size,
+        meta_storage_backend_config=meta_storage,
+        meta_cache_policy_config=meta_cache,
+    )
+    cache_config = CacheConfig(
+        reclaim_strategy=reclaim_strategy,
+        meta_indexer_config=meta_indexer,
+    )
+    extra_info = ""
+    if config.metadata_backend_mode is not None:
+        extra_info = json.dumps(
+            {"metadata_backend_mode": config.metadata_backend_mode},
+            sort_keys=True,
+        )
+    return InstanceGroup(
+        name=config.instance_group_name,
+        storage_candidates=[config.primary_storage_name],
+        instance_group_quota=quota,
+        quota_group_name="default_quota_group",
+        max_instance_count=config.max_instance_count,
+        cache_config=cache_config,
+        user_data=config.instance_group_name,
+        version=1,
+        extra_info=extra_info,
+        event_report_storage_candidates=config.event_report_storage_names,
+    ).to_json_data()
+
+
+def _as_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _extra_info_object(value):
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return copy.deepcopy(value)
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        raise BootstrapError("existing instance group extra_info is not valid JSON")
+    if not isinstance(parsed, dict):
+        raise BootstrapError("existing instance group extra_info must be a JSON object")
+    return parsed
+
+
+def _apply_managed_group_fields(current, config):
+    updated = copy.deepcopy(current)
+    updated["storage_candidates"] = [config.primary_storage_name]
+    updated["event_report_storage_candidates"] = config.event_report_storage_names
+    updated["max_instance_count"] = config.max_instance_count
+    updated["quota"] = {
+        "capacity": config.quota_capacity,
+        "quota_config": [
+            {
+                "storage_type": config.primary_storage_type,
+                "capacity": config.quota_capacity,
+            }
+        ],
+    }
+    cache_config = updated.setdefault("cache_config", {})
+    reclaim_strategy = cache_config.setdefault("reclaim_strategy", {})
+    reclaim_strategy["storage_unique_name"] = config.primary_storage_name
+    meta_indexer = cache_config.setdefault("meta_indexer_config", {})
+    meta_indexer["max_key_count"] = config.max_key_count
+    meta_indexer["mutex_shard_num"] = config.mutex_shard_num
+    meta_indexer["batch_key_size"] = config.batch_key_size
+    meta_indexer["meta_storage_backend_config"] = {
+        "storage_type": config.meta_storage_type,
+        "storage_uri": config.meta_storage_uri,
+    }
+    if config.metadata_backend_mode is not None:
+        extra_info = _extra_info_object(updated.get("extra_info", ""))
+        extra_info["metadata_backend_mode"] = config.metadata_backend_mode
+        updated["extra_info"] = json.dumps(extra_info, sort_keys=True, ensure_ascii=False)
+    return updated
+
+
+def _managed_group_view(group, config):
+    cache_config = group.get("cache_config", {})
+    reclaim_strategy = cache_config.get("reclaim_strategy", {})
+    meta_indexer = cache_config.get("meta_indexer_config", {})
+    meta_storage = meta_indexer.get("meta_storage_backend_config", {})
+    quota = group.get("quota", {})
+    quota_config = quota.get("quota_config", [])
+    normalized_quota = []
+    for item in quota_config:
+        normalized_quota.append({
+            "storage_type": item.get("storage_type"),
+            "capacity": _as_int(item.get("capacity")),
+        })
+    view = {
+        "storage_candidates": group.get("storage_candidates", []),
+        "event_report_storage_candidates": group.get("event_report_storage_candidates", []),
+        "max_instance_count": _as_int(group.get("max_instance_count")),
+        "quota": {
+            "capacity": _as_int(quota.get("capacity")),
+            "quota_config": normalized_quota,
+        },
+        "reclaim_storage": reclaim_strategy.get("storage_unique_name"),
+        "max_key_count": _as_int(meta_indexer.get("max_key_count")),
+        "mutex_shard_num": _as_int(meta_indexer.get("mutex_shard_num")),
+        "batch_key_size": _as_int(meta_indexer.get("batch_key_size")),
+        "meta_storage_type": meta_storage.get("storage_type"),
+        "meta_storage_uri": meta_storage.get("storage_uri"),
+    }
+    if config.metadata_backend_mode is not None:
+        view["metadata_backend_mode"] = _extra_info_object(
+            group.get("extra_info", "")).get("metadata_backend_mode")
+    return view
+
+
+def _find_group(groups, name):
+    for group in groups:
+        if group.get("name") == name:
+            return group
+    return None
+
+
+def ensure_instance_group(client, config):
+    desired_new = _build_new_instance_group(config)
+    for attempt in range(INSTANCE_GROUP_UPDATE_RETRIES):
+        current = _find_group(client.list_instance_groups(), config.instance_group_name)
+        if current is None:
+            try:
+                client.create_instance_group(desired_new)
+                LOGGER.info("created managed instance group %s", config.instance_group_name)
+                return
+            except NotLeaderError:
+                raise
+            except BootstrapError:
+                if attempt + 1 == INSTANCE_GROUP_UPDATE_RETRIES:
+                    raise
+                time.sleep(0.2 * (attempt + 1))
+                continue
+
+        updated = _apply_managed_group_fields(current, config)
+        if _managed_group_view(current, config) == _managed_group_view(updated, config):
+            return
+        current_version = _as_int(current.get("version"))
+        if not isinstance(current_version, int):
+            raise BootstrapError("existing instance group version is invalid")
+        updated["version"] = current_version + 1
+        try:
+            client.update_instance_group(updated, current_version)
+            LOGGER.info("updated managed instance group %s", config.instance_group_name)
+            return
+        except NotLeaderError:
+            raise
+        except BootstrapError:
+            if attempt + 1 == INSTANCE_GROUP_UPDATE_RETRIES:
+                raise
+            time.sleep(0.2 * (attempt + 1))
+
+    raise BootstrapError("instance group update retries exhausted")
+
+
+def verify_bootstrap(client, config):
+    storage_by_name = {
+        storage.get("global_unique_name"): storage
+        for storage in client.list_storage()
+    }
+    for name in config.event_report_storage_names:
+        storage_type = _storage_type_for_name(config, name)
+        current = storage_by_name.get(name)
+        if current is None or not _storage_matches(config, current, storage_type):
+            raise BootstrapError("managed storage verification failed for {}".format(name))
+
+    current = _find_group(client.list_instance_groups(), config.instance_group_name)
+    if current is None:
+        raise BootstrapError("managed instance group verification failed: group is missing")
+    desired = _build_new_instance_group(config)
+    if _managed_group_view(current, config) != _managed_group_view(desired, config):
+        raise BootstrapError("managed instance group verification failed: fields differ")
+
+
+def bootstrap_once(config, client):
+    if not config.enabled:
+        LOGGER.info("event reporting is disabled; bootstrap skipped")
+        return True
+    health = client.check_health()
+    if not health.get("is_health", False):
+        raise BootstrapError("local KVCM Admin service is not healthy")
+    if not health.get("is_leader", False):
+        LOGGER.info("local KVCM is follower; bootstrap skipped")
+        return False
+    ensure_storages(client, config)
+    ensure_instance_group(client, config)
+    verify_bootstrap(client, config)
+    LOGGER.info(
+        "bootstrap verified for group %s using meta storage %s at %s:%s",
+        config.instance_group_name,
+        config.meta_storage_type,
+        config.redis_host,
+        config.redis_port,
+    )
+    return True
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        config = parse_environment()
+        if not bootstrap_once(config, AdminClient()):
+            return FOLLOWER_EXIT_CODE
+        return 0
+    except NotLeaderError:
+        LOGGER.info("local KVCM lost leadership during bootstrap; retry later")
+        return FOLLOWER_EXIT_CODE
+    except BootstrapError as exc:
+        LOGGER.exception("bootstrap failed: %s: %s", type(exc).__name__, exc)
+        return 1
+    except Exception as exc:
+        LOGGER.exception(
+            "bootstrap failed with unexpected %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/package/kvcm_ops/kvcm/bootstrap.py
+++ b/package/kvcm_ops/kvcm/bootstrap.py
@@ -169,15 +169,16 @@ def _positive_query_int(query, name, default, allow_zero=False):
 
 def _parse_storage_uri(uri):
     try:
-        parsed = urlsplit(uri)
+        # KVCM StandardUri treats '#' in user-info as a literal character.
+        # Escape it only in the validation copy so the original URI is passed
+        # unchanged to KVCM and remains compatible with existing deployments.
+        parsed = urlsplit(uri.replace("#", "%23"))
     except ValueError:
         raise BootstrapError("KVCM_META_STORAGE_URI is not a valid URI")
     if parsed.scheme.lower() != "redis":
         raise BootstrapError("KVCM_META_STORAGE_URI scheme must be redis")
     if not parsed.hostname:
         raise BootstrapError("KVCM_META_STORAGE_URI must include a host")
-    if parsed.fragment:
-        raise BootstrapError("KVCM_META_STORAGE_URI must not contain a fragment; URI-encode credentials")
     try:
         port = parsed.port
     except ValueError:

--- a/package/kvcm_ops/test/bootstrap_test.py
+++ b/package/kvcm_ops/test/bootstrap_test.py
@@ -127,6 +127,26 @@ class EnvironmentParsingTest(unittest.TestCase):
         with self.assertRaisesRegex(BootstrapError, "power of two"):
             parse_environment(environ)
 
+    def test_raw_hash_in_password_is_supported_and_preserved(self):
+        environ = dict(BASE_ENV)
+        raw_uri = (
+            "redis://user:p#ss@redis.example:6379/?cluster_name=test"
+            "&timeout_ms=1000&max_instance_count=512"
+        )
+        environ["KVCM_META_STORAGE_URI"] = raw_uri
+
+        config = parse_environment(environ)
+        group = _build_new_instance_group(config)
+
+        self.assertEqual("redis.example", config.redis_host)
+        self.assertEqual(6379, config.redis_port)
+        self.assertEqual(raw_uri, config.meta_storage_uri)
+        self.assertEqual(
+            raw_uri,
+            group["cache_config"]["meta_indexer_config"]
+            ["meta_storage_backend_config"]["storage_uri"],
+        )
+
     def test_metadata_backend_mode_is_optional_and_bounded(self):
         config = parse_environment(dict(BASE_ENV))
         self.assertIsNone(config.metadata_backend_mode)

--- a/package/kvcm_ops/test/bootstrap_test.py
+++ b/package/kvcm_ops/test/bootstrap_test.py
@@ -1,0 +1,314 @@
+import copy
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from kvcm_ops.kvcm.bootstrap import (  # noqa: E402
+    BootstrapError,
+    AdminClient,
+    _apply_managed_group_fields,
+    _build_new_instance_group,
+    _managed_group_view,
+    bootstrap_once,
+    ensure_instance_group,
+    parse_environment,
+)
+
+
+BASE_ENV = {
+    "KVCM_ENABLE_SUBSCRIBER_EVENT_REPORT": "true",
+    "KVCM_ENABLE_V6D_EVENT_REPORT": "true",
+    "KVCM_INSTANCE_GROUP_NAME": "event-group",
+    "KVCM_EVENT_REPORT_L1P5_STORAGE_NAME": "event-l1p5",
+    "KVCM_EVENT_REPORT_L2_STORAGE_NAME": "event-l2",
+    "KVCM_META_STORAGE_TYPE": "cached",
+    "KVCM_META_STORAGE_URI": (
+        "redis://user:p%40ss@redis.example:6379/?cluster_name=test"
+        "&max_instance_count=512&quota_capacity=2087740652912"
+        "&max_key_count=1000000000&mutex_shard_num=131072&batch_key_size=1024"
+        "&async_queue_count=8&heartbeat_timeout_ms=30000"
+    ),
+}
+
+
+class FakeAdminClient:
+    def __init__(self, is_leader=True):
+        self.is_leader = is_leader
+        self.storages = []
+        self.groups = []
+        self.add_calls = 0
+        self.update_storage_calls = 0
+        self.create_group_calls = 0
+        self.update_group_calls = 0
+        self.version_conflicts_remaining = 0
+
+    def check_health(self):
+        return {"is_health": True, "is_leader": self.is_leader}
+
+    def list_storage(self):
+        return copy.deepcopy(self.storages)
+
+    def add_storage(self, storage):
+        self.add_calls += 1
+        self.storages.append(copy.deepcopy(storage))
+
+    def update_storage(self, storage):
+        self.update_storage_calls += 1
+        self.storages = [
+            copy.deepcopy(storage)
+            if item["global_unique_name"] == storage["global_unique_name"] else item
+            for item in self.storages
+        ]
+
+    def list_instance_groups(self):
+        return copy.deepcopy(self.groups)
+
+    def create_instance_group(self, instance_group):
+        self.create_group_calls += 1
+        self.groups.append(copy.deepcopy(instance_group))
+
+    def update_instance_group(self, instance_group, current_version):
+        self.update_group_calls += 1
+        if self.version_conflicts_remaining > 0:
+            self.version_conflicts_remaining -= 1
+            raise BootstrapError("version conflict")
+        for index, current in enumerate(self.groups):
+            if current["name"] == instance_group["name"]:
+                if int(current["version"]) != current_version:
+                    raise BootstrapError("version conflict")
+                self.groups[index] = copy.deepcopy(instance_group)
+                return
+        raise BootstrapError("group missing")
+
+
+class EnvironmentParsingTest(unittest.TestCase):
+    def test_dual_report_configuration(self):
+        config = parse_environment(dict(BASE_ENV))
+
+        self.assertEqual("event-l1p5", config.primary_storage_name)
+        self.assertEqual(
+            ["event-l1p5", "event-l2"],
+            config.event_report_storage_names,
+        )
+        self.assertEqual(512, config.max_instance_count)
+        self.assertEqual(2087740652912, config.quota_capacity)
+        self.assertEqual(30000, config.event_report_spec["heartbeat_timeout_ms"])
+
+    def test_four_report_switch_combinations(self):
+        for subscriber, v6d, expected in (
+            (False, False, []),
+            (True, False, ["event-l1p5"]),
+            (False, True, ["event-l2"]),
+            (True, True, ["event-l1p5", "event-l2"]),
+        ):
+            with self.subTest(subscriber=subscriber, v6d=v6d):
+                environ = dict(BASE_ENV)
+                environ["KVCM_ENABLE_SUBSCRIBER_EVENT_REPORT"] = str(subscriber).lower()
+                environ["KVCM_ENABLE_V6D_EVENT_REPORT"] = str(v6d).lower()
+                config = parse_environment(environ)
+                self.assertEqual(expected, config.event_report_storage_names)
+
+    def test_invalid_boolean_is_rejected(self):
+        environ = dict(BASE_ENV)
+        environ["KVCM_ENABLE_V6D_EVENT_REPORT"] = "yes"
+
+        with self.assertRaisesRegex(BootstrapError, "must be true or false"):
+            parse_environment(environ)
+
+    def test_mutex_shards_must_be_power_of_two(self):
+        environ = dict(BASE_ENV)
+        environ["KVCM_META_STORAGE_URI"] = environ["KVCM_META_STORAGE_URI"].replace(
+            "mutex_shard_num=131072", "mutex_shard_num=7")
+
+        with self.assertRaisesRegex(BootstrapError, "power of two"):
+            parse_environment(environ)
+
+    def test_metadata_backend_mode_is_optional_and_bounded(self):
+        config = parse_environment(dict(BASE_ENV))
+        self.assertIsNone(config.metadata_backend_mode)
+
+        for mode in range(1, 5):
+            environ = dict(BASE_ENV)
+            environ["KVCM_METADATA_BACKEND_MODE"] = str(mode)
+            self.assertEqual(mode, parse_environment(environ).metadata_backend_mode)
+
+        environ = dict(BASE_ENV)
+        environ["KVCM_METADATA_BACKEND_MODE"] = "5"
+        with self.assertRaisesRegex(BootstrapError, "range 1..4"):
+            parse_environment(environ)
+
+    def test_uri_error_does_not_expose_credentials(self):
+        environ = dict(BASE_ENV)
+        secret = "do-not-log-this"
+        environ["KVCM_META_STORAGE_URI"] = "redis://user:{}@redis.example/".format(secret)
+
+        with self.assertRaises(BootstrapError) as context:
+            parse_environment(environ)
+        self.assertNotIn(secret, str(context.exception))
+
+
+class ErrorReportingTest(unittest.TestCase):
+    @patch("kvcm_ops.kvcm.bootstrap.http_post")
+    def test_admin_transport_error_keeps_exception_details(self, mock_http_post):
+        mock_http_post.side_effect = RuntimeError("connection refused")
+
+        with self.assertRaises(BootstrapError) as context:
+            AdminClient().post("/api/listStorage", {}, "listStorage")
+
+        self.assertIn("listStorage", str(context.exception))
+        self.assertIn("RuntimeError", str(context.exception))
+        self.assertIn("connection refused", str(context.exception))
+
+
+class DesiredConfigurationTest(unittest.TestCase):
+    def test_v6d_only_uses_l2_for_primary_and_quota(self):
+        environ = dict(BASE_ENV)
+        environ["KVCM_ENABLE_SUBSCRIBER_EVENT_REPORT"] = "false"
+        config = parse_environment(environ)
+
+        group = _build_new_instance_group(config)
+
+        self.assertEqual(["event-l2"], group["storage_candidates"])
+        self.assertEqual(["event-l2"], group["event_report_storage_candidates"])
+        self.assertEqual(
+            "ST_EVENT_REPORT_L2",
+            group["quota"]["quota_config"][0]["storage_type"],
+        )
+
+    def test_update_preserves_unmanaged_fields_and_extra_info(self):
+        environ = dict(BASE_ENV)
+        environ["KVCM_METADATA_BACKEND_MODE"] = "4"
+        config = parse_environment(environ)
+        current = _build_new_instance_group(config)
+        current["user_data"] = "keep-user-data"
+        current["revisit_interval_buckets"] = "1,5,30"
+        current["extra_info"] = '{"keep":"value","metadata_backend_mode":2}'
+
+        updated = _apply_managed_group_fields(current, config)
+
+        self.assertEqual("keep-user-data", updated["user_data"])
+        self.assertEqual("1,5,30", updated["revisit_interval_buckets"])
+        self.assertEqual(
+            {"keep": "value", "metadata_backend_mode": 4},
+            __import__("json").loads(updated["extra_info"]),
+        )
+
+    def test_unset_metadata_mode_preserves_existing_value(self):
+        config = parse_environment(dict(BASE_ENV))
+        current = _build_new_instance_group(config)
+        current["extra_info"] = '{"metadata_backend_mode":3,"keep":true}'
+
+        updated = _apply_managed_group_fields(current, config)
+
+        self.assertEqual(current["extra_info"], updated["extra_info"])
+
+
+class BootstrapReconciliationTest(unittest.TestCase):
+    def test_first_run_creates_and_second_run_is_idempotent(self):
+        config = parse_environment(dict(BASE_ENV))
+        client = FakeAdminClient()
+
+        self.assertTrue(bootstrap_once(config, client))
+        self.assertTrue(bootstrap_once(config, client))
+
+        self.assertEqual(2, client.add_calls)
+        self.assertEqual(0, client.update_storage_calls)
+        self.assertEqual(1, client.create_group_calls)
+        self.assertEqual(0, client.update_group_calls)
+        expected = _managed_group_view(_build_new_instance_group(config), config)
+        self.assertEqual(expected, _managed_group_view(client.groups[0], config))
+
+    def test_follower_does_not_write(self):
+        config = parse_environment(dict(BASE_ENV))
+        client = FakeAdminClient(is_leader=False)
+
+        self.assertFalse(bootstrap_once(config, client))
+
+        self.assertEqual([], client.storages)
+        self.assertEqual([], client.groups)
+
+    def test_same_storage_name_updates_storage_in_place(self):
+        config = parse_environment(dict(BASE_ENV))
+        client = FakeAdminClient()
+        bootstrap_once(config, client)
+        client.storages[0]["event_report"]["heartbeat_timeout_ms"] = 1
+
+        bootstrap_once(config, client)
+
+        self.assertEqual(1, client.update_storage_calls)
+        self.assertEqual(2, len(client.storages))
+        self.assertEqual(
+            30000,
+            client.storages[0]["event_report"]["heartbeat_timeout_ms"],
+        )
+
+    def test_storage_name_change_creates_new_and_keeps_old_storage(self):
+        config = parse_environment(dict(BASE_ENV))
+        client = FakeAdminClient()
+        bootstrap_once(config, client)
+        environ = dict(BASE_ENV)
+        environ["KVCM_EVENT_REPORT_L2_STORAGE_NAME"] = "event-l2-new"
+        updated_config = parse_environment(environ)
+
+        bootstrap_once(updated_config, client)
+
+        self.assertEqual(
+            {"event-l1p5", "event-l2", "event-l2-new"},
+            {storage["global_unique_name"] for storage in client.storages},
+        )
+        self.assertEqual(
+            ["event-l1p5", "event-l2-new"],
+            client.groups[0]["event_report_storage_candidates"],
+        )
+
+    def test_instance_group_name_change_creates_new_and_keeps_old_group(self):
+        config = parse_environment(dict(BASE_ENV))
+        client = FakeAdminClient()
+        bootstrap_once(config, client)
+        environ = dict(BASE_ENV)
+        environ["KVCM_INSTANCE_GROUP_NAME"] = "event-group-new"
+
+        bootstrap_once(parse_environment(environ), client)
+
+        self.assertEqual(
+            {"event-group", "event-group-new"},
+            {group["name"] for group in client.groups},
+        )
+
+    def test_uri_change_updates_group_in_place(self):
+        config = parse_environment(dict(BASE_ENV))
+        client = FakeAdminClient()
+        bootstrap_once(config, client)
+        environ = dict(BASE_ENV)
+        environ["KVCM_META_STORAGE_URI"] = environ["KVCM_META_STORAGE_URI"].replace(
+            "cluster_name=test", "cluster_name=test-new")
+
+        bootstrap_once(parse_environment(environ), client)
+
+        self.assertEqual(1, client.create_group_calls)
+        self.assertEqual(1, client.update_group_calls)
+        self.assertIn(
+            "cluster_name=test-new",
+            client.groups[0]["cache_config"]["meta_indexer_config"]
+            ["meta_storage_backend_config"]["storage_uri"],
+        )
+
+    def test_version_conflict_is_retried(self):
+        config = parse_environment(dict(BASE_ENV))
+        client = FakeAdminClient()
+        bootstrap_once(config, client)
+        client.groups[0]["max_instance_count"] = 1
+        client.version_conflicts_remaining = 1
+
+        ensure_instance_group(client, config)
+
+        self.assertEqual(2, client.update_group_calls)
+        self.assertEqual(512, client.groups[0]["max_instance_count"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package/script/start_server.sh
+++ b/package/script/start_server.sh
@@ -11,6 +11,10 @@ CONFIG_PATH=$ROOT_PATH/etc
 DEFAULT_SERVER_CONFIG=$CONFIG_PATH/default_server_config.conf
 DEFAULT_LOGGER_CONFIG=$CONFIG_PATH/default_logger_config.conf
 BINARY=$BINARY_PATH/kv_cache_manager_bin
+BOOTSTRAP_RETRY_INTERVAL_SECONDS=5
+BOOTSTRAP_MAX_RETRIES=2
+BOOTSTRAP_FOLLOWER_EXIT_CODE=2
+server_pid=""
 
 function configure_jemalloc() {
     if [ "${KVCM_USE_JEMALLOC:-1}" = "0" ]; then
@@ -72,10 +76,85 @@ function start_server() {
     exec $BINARY -c $DEFAULT_SERVER_CONFIG -l $DEFAULT_LOGGER_CONFIG "$@"
 }
 
+function forward_signal() {
+    local signal=$1
+    if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+        kill "-$signal" "$server_pid" 2>/dev/null || true
+    fi
+}
+
+function wait_for_admin_health() {
+    while kill -0 "$server_pid" 2>/dev/null; do
+        if command -v curl >/dev/null 2>&1; then
+            if curl -fsS --max-time 2 http://127.0.0.1:6492/api/healthy >/dev/null 2>&1; then
+                return 0
+            fi
+        elif python3 -c 'import requests,sys; r=requests.get("http://127.0.0.1:6492/api/healthy", timeout=2); sys.exit(0 if r.status_code == 200 else 1)' >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+function wait_for_bootstrap_retry() {
+    local elapsed=0
+    while [ "$elapsed" -lt "$BOOTSTRAP_RETRY_INTERVAL_SECONDS" ]; do
+        if ! kill -0 "$server_pid" 2>/dev/null; then
+            return 1
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 0
+}
+
+function run_bootstrap_monitor() {
+    if ! wait_for_admin_health; then
+        return 0
+    fi
+
+    local retry_count=0
+    while kill -0 "$server_pid" 2>/dev/null; do
+        local bootstrap_status=0
+        python3 -m kvcm_ops bootstrap || bootstrap_status=$?
+        if [ "$bootstrap_status" -eq 0 ]; then
+            return 0
+        fi
+        if [ "$bootstrap_status" -eq "$BOOTSTRAP_FOLLOWER_EXIT_CODE" ]; then
+            if ! wait_for_bootstrap_retry; then
+                return 0
+            fi
+            continue
+        fi
+        if [ "$retry_count" -ge "$BOOTSTRAP_MAX_RETRIES" ]; then
+            echo "ERROR: KVCM bootstrap failed after $BOOTSTRAP_MAX_RETRIES retries; automatic bootstrap stopped and KVCM remains running" >&2
+            return 0
+        fi
+        retry_count=$((retry_count + 1))
+        echo "ERROR: KVCM bootstrap failed; retry $retry_count/$BOOTSTRAP_MAX_RETRIES in $BOOTSTRAP_RETRY_INTERVAL_SECONDS seconds" >&2
+        if ! wait_for_bootstrap_retry; then
+            return 0
+        fi
+    done
+}
+
 function main() {
     configure_jemalloc
     install_kvcm_ops
-    start_server "$@"
+
+    start_server "$@" &
+    server_pid=$!
+
+    trap 'forward_signal TERM' TERM
+    trap 'forward_signal INT' INT
+
+    run_bootstrap_monitor
+
+    wait "$server_pid"
+    return $?
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary
- bootstrap KVCM storage and instance-group resources from environment variables after the Admin API becomes healthy
- reconcile resources only on the leader, verify managed fields, and retry bootstrap failures twice with a 5-second interval
- keep KVCM running after bootstrap retries are exhausted so operators can configure resources manually

## Testing
- //package/kvcm_ops:bootstrap_test
- //package:kv_cache_manager_server build
- external KVCM full test suite: 111 passed, 1 skipped
- internal KVCM full test suite: 110 passed, 1 skipped; the remaining failures are existing environment/behavior issues