### PR TITLE
[kvcm_ops] support instance_group revisit_interval_buckets

### DIFF
--- a/docs/api/admin_service.md
+++ b/docs/api/admin_service.md
@@ -112,9 +112,6 @@ curl -g -vvv -X POST http://localhost:6492/api/listStorage \
 ```
 
 ## Create Instance Group
-
-Optional field `revisit_interval_buckets`: comma-separated, strictly increasing positive numbers in seconds (e.g. `"1,5,30,60"`), customizing bucket boundaries for instance revisit-interval statistics. If omitted or empty, the server-side default boundaries are used. In `updateInstanceGroup`, an omitted field keeps the existing server-side value; an empty string clears it back to the default.
-
 ```bash
 curl -g -vvv -X POST http://localhost:6492/api/createInstanceGroup \
   -H "Content-Type: application/json" \
@@ -162,7 +159,6 @@ curl -g -vvv -X POST http://localhost:6492/api/createInstanceGroup \
             }
         },
         "user_data": "test user data",
-        "revisit_interval_buckets": "1,5,30,60",
         "version": 1
     }
 }'
@@ -270,7 +266,6 @@ curl -g -vvv -X POST http://localhost:6492/api/updateInstanceGroup \
             }
         },
         "user_data": "test user data",
-        "revisit_interval_buckets": "1,5,30,60",
         "version": 2
     },
     "current_version": 1

--- a/docs/api/admin_service.md
+++ b/docs/api/admin_service.md
@@ -112,6 +112,9 @@ curl -g -vvv -X POST http://localhost:6492/api/listStorage \
 ```
 
 ## Create Instance Group
+
+Optional field `revisit_interval_buckets`: comma-separated, strictly increasing positive numbers in seconds (e.g. `"1,5,30,60"`), customizing bucket boundaries for instance revisit-interval statistics. If omitted or empty, the server-side default boundaries are used. In `updateInstanceGroup`, an omitted field keeps the existing server-side value; an empty string clears it back to the default.
+
 ```bash
 curl -g -vvv -X POST http://localhost:6492/api/createInstanceGroup \
   -H "Content-Type: application/json" \
@@ -159,6 +162,7 @@ curl -g -vvv -X POST http://localhost:6492/api/createInstanceGroup \
             }
         },
         "user_data": "test user data",
+        "revisit_interval_buckets": "1,5,30,60",
         "version": 1
     }
 }'
@@ -266,6 +270,7 @@ curl -g -vvv -X POST http://localhost:6492/api/updateInstanceGroup \
             }
         },
         "user_data": "test user data",
+        "revisit_interval_buckets": "1,5,30,60",
         "version": 2
     },
     "current_version": 1

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -168,6 +168,10 @@ grep -E "DoPut|DoGet|Alloc failed|Init|SdkWrapper" kv_cache_manager_client.log
 
 githooks中已经添加了C++等语言的格式化脚本，请确保开发环境安装了clang-format、autopep8、buildifier。（开发镜像均已预装）。
 
+## Proto 修改
+
+修改 `kv_cache_manager/protocol/protobuf` 下的 proto 定义时，请遵循 [Proto 文件修改指南](proto_modification_guide.md)，并同步完成其中列出的适配步骤（例如修改 AdminService 接口定义时需适配 `package/kvcm_ops` 运维 CLI）。
+
 ## 提交要求
 
 提交前检查和 commit message 格式见 [Commit 要求](commit_requirements.md)。

--- a/docs/develop/proto_modification_guide.md
+++ b/docs/develop/proto_modification_guide.md
@@ -153,6 +153,12 @@ bazel test //kv_cache_manager/xxxx:xxxx
 - RTP-LLM C++客户端: kv_cache_manager/client
 - vLLM等Python客户端：kv_cache_manager/py_connector
 
+### 8. （如果是修改AdminService）同步适配 kvcm_ops 运维 CLI
+
+- 工具位置：`package/kvcm_ops`
+- 若 InstanceGroup / Storage 等管理对象新增或变更字段，需同步更新对应的 Python 模型（如 `kvcm/instance_group/util.py`）的构造、校验与 JSON 序列化/反序列化，以及相关 create/update 命令参数。
+- 否则 kvcm_ops 的 update 流程（GET → 整体 PUT）会静默丢弃服务端已有字段，导致配置被意外清空。
+
 ## 注意事项
 
 1. **字段编号**：在proto文件中添加新字段时，使用递增的字段编号，避免重复使用已存在的编号。

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -1,3 +1,5 @@
+// 修改本文件前请阅读 docs/develop/proto_modification_guide.md（Proto 文件修改指南），并同步完成其中列出的适配步骤。
+
 syntax = "proto3";
 
 package kv_cache_manager.proto.admin;

--- a/kv_cache_manager/protocol/protobuf/debug_service.proto
+++ b/kv_cache_manager/protocol/protobuf/debug_service.proto
@@ -1,3 +1,5 @@
+// 修改本文件前请阅读 docs/develop/proto_modification_guide.md（Proto 文件修改指南），并同步完成其中列出的适配步骤。
+
 syntax = "proto3";
 
 package kv_cache_manager.proto.debug;

--- a/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/kv_meta_service.proto
@@ -1,3 +1,5 @@
+// 修改本文件前请阅读 docs/develop/proto_modification_guide.md（Proto 文件修改指南），并同步完成其中列出的适配步骤。
+
 syntax = "proto3";
 
 package kv_cache_manager.proto.kv_meta;

--- a/kv_cache_manager/protocol/protobuf/meta_service.proto
+++ b/kv_cache_manager/protocol/protobuf/meta_service.proto
@@ -1,3 +1,5 @@
+// 修改本文件前请阅读 docs/develop/proto_modification_guide.md（Proto 文件修改指南），并同步完成其中列出的适配步骤。
+
 syntax = "proto3";
 
 package kv_cache_manager.proto.meta;

--- a/kv_cache_manager/protocol/protobuf/optimizer_service.proto
+++ b/kv_cache_manager/protocol/protobuf/optimizer_service.proto
@@ -1,3 +1,5 @@
+// 修改本文件前请阅读 docs/develop/proto_modification_guide.md（Proto 文件修改指南），并同步完成其中列出的适配步骤。
+
 syntax = "proto3";
 
 package kv_cache_manager.proto.optimizer;

--- a/package/kvcm_ops/BUILD
+++ b/package/kvcm_ops/BUILD
@@ -29,3 +29,9 @@ py_test(
     srcs = ["test/storage_util_test.py"],
     deps = [":kvcm_ops_lib"],
 )
+
+py_test(
+    name = "instance_group_revisit_buckets_test",
+    srcs = ["test/instance_group_revisit_buckets_test.py"],
+    deps = [":kvcm_ops_lib"],
+)

--- a/package/kvcm_ops/kvcm/instance_group/create_instance_group.py
+++ b/package/kvcm_ops/kvcm/instance_group/create_instance_group.py
@@ -92,7 +92,8 @@ def create_instance_group(args) -> InstanceGroup:
                                    user_data=args.user_data,
                                    version=1,
                                    extra_info=args.extra_info,
-                                   event_report_storage_candidates=args.event_report_storage_candidates)
+                                   event_report_storage_candidates=args.event_report_storage_candidates,
+                                   revisit_interval_buckets=args.revisit_interval_buckets)
     return instance_group
 
 

--- a/package/kvcm_ops/kvcm/instance_group/update_instance_group.py
+++ b/package/kvcm_ops/kvcm/instance_group/update_instance_group.py
@@ -60,6 +60,8 @@ def main():
         current._extra_info = json.dumps(existing, ensure_ascii=False)
     if hasattr(args, "event_report_storage_candidates"):
         current._event_report_storage_candidates = args.event_report_storage_candidates
+    if hasattr(args, "revisit_interval_buckets"):
+        current._revisit_interval_buckets = args.revisit_interval_buckets
     current.check()
     current_version = current._version
     current._version += 1

--- a/package/kvcm_ops/kvcm/instance_group/util.py
+++ b/package/kvcm_ops/kvcm/instance_group/util.py
@@ -1,4 +1,5 @@
 import argparse
+import math
 from ..common.json_data import *
 from ..common.common_args import *
 
@@ -333,6 +334,36 @@ class CacheConfig(JsonData):
         return cls(data_storage_strategy, reclaim_strategy, meta_indexer_config)
 
 
+# Aligned with server-side StringUtil::ParseBucketBoundaries: comma separated,
+# each token must fully parse to a finite positive number, strictly ascending.
+def parse_bucket_boundaries(value: str):
+    boundaries = []
+    for token in value.split(","):
+        token = token.strip()
+        if not token:
+            raise ValueError(f"empty token in bucket boundaries: '{value}'")
+        try:
+            number = float(token)
+        except ValueError as exc:
+            raise ValueError(f"invalid number '{token}' in bucket boundaries: '{value}'") from exc
+        if not math.isfinite(number) or number <= 0:
+            raise ValueError(f"bucket boundary '{token}' must be a finite positive number: '{value}'")
+        if boundaries and number <= boundaries[-1]:
+            raise ValueError(f"bucket boundaries must be strictly ascending: '{value}'")
+        boundaries.append(number)
+    return boundaries
+
+
+def revisit_interval_buckets_value(value: str) -> str:
+    if value == "":
+        return ""  # empty means server-side default buckets
+    try:
+        parse_bucket_boundaries(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid revisit_interval_buckets: {exc}") from exc
+    return ",".join(token.strip() for token in value.split(","))
+
+
 class InstanceGroup(JsonData):
     def __init__(self,
                  name: str,
@@ -345,6 +376,7 @@ class InstanceGroup(JsonData):
                  version: int = 1,
                  extra_info: str = "",
                  event_report_storage_candidates=None,
+                 revisit_interval_buckets: str = "",
                  ):
         self._name = name
         self._storage_candidates = storage_candidates
@@ -356,6 +388,7 @@ class InstanceGroup(JsonData):
         self._version = version
         self._extra_info = extra_info
         self._event_report_storage_candidates = event_report_storage_candidates or []
+        self._revisit_interval_buckets = revisit_interval_buckets
         self.check()
 
     def check(self):
@@ -367,6 +400,11 @@ class InstanceGroup(JsonData):
                 json.loads(self._extra_info)
             except json.JSONDecodeError as exc:
                 raise RuntimeError(f"extra_info must be valid JSON, got: '{self._extra_info}'") from exc
+        if self._revisit_interval_buckets:
+            try:
+                parse_bucket_boundaries(self._revisit_interval_buckets)
+            except ValueError as exc:
+                raise RuntimeError(f"revisit_interval_buckets invalid: {exc}") from exc
         self._instance_group_quota.check()
         self._cache_config.check()
 
@@ -381,6 +419,7 @@ class InstanceGroup(JsonData):
             "user_data": self._user_data,
             "version": self._version,
             "extra_info": self._extra_info,
+            "revisit_interval_buckets": self._revisit_interval_buckets,
         }
         if self._event_report_storage_candidates:
             data["event_report_storage_candidates"] = self._event_report_storage_candidates
@@ -406,8 +445,10 @@ class InstanceGroup(JsonData):
             version = int(json_data["version"])
         extra_info = json_data.get("extra_info", "")
         event_report_storage_candidates = json_data.get("event_report_storage_candidates", [])
+        revisit_interval_buckets = json_data.get("revisit_interval_buckets", "")
         return cls(name, storage_candidates, instance_group_quota, quota_group_name, max_instance_count,
-                   cache_config, user_data, version, extra_info, event_report_storage_candidates)
+                   cache_config, user_data, version, extra_info, event_report_storage_candidates,
+                   revisit_interval_buckets)
 
 # create or update
 
@@ -561,6 +602,17 @@ def parse_instance_group_args(is_create: bool):
         type=split_strs,
         default=[] if is_create else argparse.SUPPRESS,
         help="event_report_storage_candidates, eg. event_report_default or event_report_g1,event_report_g2"
+    )
+
+    parser.add_argument(
+        "--revisit_interval_buckets",
+        type=revisit_interval_buckets_value,
+        default="" if is_create else argparse.SUPPRESS,
+        help=(
+            "revisit_interval_buckets, comma separated positive numbers in strictly "
+            "ascending order, eg. 1,5,30,60. Empty string clears it to server default. "
+            "On update, omit to keep the server-side value."
+        )
     )
 
     args = parser.parse_args()

--- a/package/kvcm_ops/test/instance_group_revisit_buckets_test.py
+++ b/package/kvcm_ops/test/instance_group_revisit_buckets_test.py
@@ -1,0 +1,217 @@
+import argparse
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+# Bazel keeps sources under package/kvcm_ops while the wheel exposes kvcm_ops
+# as a top-level namespace package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from kvcm_ops.kvcm.instance_group.util import (
+    InstanceGroup,
+    InstanceGroupQuota,
+    StorageQuota,
+    parse_bucket_boundaries,
+    parse_instance_group_args,
+    revisit_interval_buckets_value,
+)
+from kvcm_ops.kvcm.instance_group import update_instance_group
+
+
+def _make_instance_group(revisit_interval_buckets=""):
+    quota = InstanceGroupQuota(1000, [StorageQuota("ST_NFS", 100)])
+    return InstanceGroup(
+        name="g1",
+        storage_candidates=["nfs_01"],
+        instance_group_quota=quota,
+        quota_group_name="default_quota_group",
+        revisit_interval_buckets=revisit_interval_buckets,
+    )
+
+
+def _get_response(revisit_interval_buckets=None):
+    instance_group = {
+        "name": "g1",
+        "storage_candidates": ["nfs_01"],
+        "global_quota_group_name": "default_quota_group",
+        "max_instance_count": 100,
+        "quota": {
+            "capacity": 30000000000,
+            "quota_config": [{"storage_type": "ST_NFS", "capacity": "10000000000"}],
+        },
+        "cache_config": {
+            "reclaim_strategy": {
+                "storage_unique_name": "nfs_01",
+                "reclaim_policy": "POLICY_LRU",
+                "trigger_strategy": {"used_size": 0, "used_percentage": 0.8},
+                "trigger_period_seconds": 60,
+                "reclaim_step_size": 1,
+                "reclaim_step_percentage": 10,
+                "delay_before_delete_ms": 1000,
+            },
+            "data_storage_strategy": "CPS_PREFER_3FS",
+            "meta_indexer_config": {
+                "max_key_count": 10000,
+                "mutex_shard_num": 1024,
+                "batch_key_size": 128,
+                "meta_storage_backend_config": {"storage_type": "local", "storage_uri": ""},
+                "meta_cache_policy_config": {
+                    "type": "LRU",
+                    "capacity": 100000,
+                    "cache_shard_bits": 0,
+                    "high_pri_pool_ratio": 0.0,
+                },
+            },
+        },
+        "user_data": "",
+        "version": 1,
+    }
+    if revisit_interval_buckets is not None:
+        instance_group["revisit_interval_buckets"] = revisit_interval_buckets
+    return {
+        "header": {"status": {"code": "OK"}},
+        "instance_group": instance_group,
+    }
+
+
+class ParseBucketBoundariesTest(unittest.TestCase):
+    def test_valid_boundaries(self):
+        self.assertEqual([1.0, 5.0, 30.0, 60.0], parse_bucket_boundaries("1,5,30,60"))
+        self.assertEqual([0.5, 1.5, 5.0], parse_bucket_boundaries("0.5,1.5,5.0"))
+
+    def test_whitespace_around_tokens_is_allowed(self):
+        self.assertEqual([1.0, 5.0, 30.0], parse_bucket_boundaries(" 1 , 5 , 30 "))
+
+    def test_single_boundary(self):
+        self.assertEqual([60.0], parse_bucket_boundaries("60"))
+
+    def test_invalid_values_are_rejected(self):
+        invalid_values = (
+            "5,1,30",      # not ascending
+            "1,5,5,30",    # duplicate
+            "-1,5,30",     # negative
+            "0,5,30",      # zero
+            "1s,5,30",     # trailing chars
+            "abc,5,30",    # non numeric
+            "1,,5",        # empty token
+            ",1,5",        # leading comma
+            "1,5,",        # trailing comma
+            "inf",         # not finite
+            "nan",         # not finite
+            " ",           # whitespace only
+        )
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value):
+                with self.assertRaises(ValueError):
+                    parse_bucket_boundaries(invalid_value)
+
+
+class RevisitIntervalBucketsValueTest(unittest.TestCase):
+    def test_valid_value_is_normalized(self):
+        self.assertEqual("1,5,30", revisit_interval_buckets_value(" 1 , 5 ,30 "))
+
+    def test_empty_string_clears_to_server_default(self):
+        self.assertEqual("", revisit_interval_buckets_value(""))
+
+    def test_invalid_value_raises_argument_type_error(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            revisit_interval_buckets_value("5,1,30")
+
+
+class InstanceGroupModelTest(unittest.TestCase):
+    def test_field_defaults_to_empty(self):
+        group = _make_instance_group()
+        self.assertEqual("", group.to_json_data()["revisit_interval_buckets"])
+
+    def test_json_round_trip_preserves_field(self):
+        group = _make_instance_group("1,5,30,60")
+        restored = InstanceGroup.from_json_data(group.to_json_data())
+        self.assertEqual("1,5,30,60", restored.to_json_data()["revisit_interval_buckets"])
+
+    def test_missing_json_field_defaults_to_empty(self):
+        data = _make_instance_group("1,5,30").to_json_data()
+        del data["revisit_interval_buckets"]
+        restored = InstanceGroup.from_json_data(data)
+        self.assertEqual("", restored.to_json_data()["revisit_interval_buckets"])
+
+    def test_check_rejects_invalid_field(self):
+        group = _make_instance_group("1,5,30")
+        group._revisit_interval_buckets = "5,1,30"
+        with self.assertRaises(RuntimeError):
+            group.check()
+
+    def test_constructor_rejects_invalid_field(self):
+        with self.assertRaises(RuntimeError):
+            _make_instance_group("1,,5")
+
+
+class ParseInstanceGroupArgsTest(unittest.TestCase):
+    def _parse(self, is_create, *extra_args):
+        argv = ["prog", "--name", "g1"]
+        if is_create:
+            argv += ["--storage_candidates", "nfs_01"]
+        argv += list(extra_args)
+        with patch("sys.argv", argv):
+            return parse_instance_group_args(is_create=is_create)
+
+    def test_create_defaults_to_empty(self):
+        args = self._parse(True)
+        self.assertEqual("", args.revisit_interval_buckets)
+
+    def test_create_accepts_and_normalizes_value(self):
+        args = self._parse(True, "--revisit_interval_buckets", " 1 ,5 , 30")
+        self.assertEqual("1,5,30", args.revisit_interval_buckets)
+
+    def test_create_accepts_explicit_empty(self):
+        args = self._parse(True, "--revisit_interval_buckets", "")
+        self.assertEqual("", args.revisit_interval_buckets)
+
+    def test_create_rejects_invalid_value(self):
+        with self.assertRaises(SystemExit):
+            self._parse(True, "--revisit_interval_buckets", "5,1,30")
+
+    def test_update_omitted_keeps_no_attribute(self):
+        args = self._parse(is_create=False)
+        self.assertFalse(hasattr(args, "revisit_interval_buckets"))
+
+    def test_update_accepts_explicit_value(self):
+        args = self._parse(False, "--revisit_interval_buckets", "2,10,60")
+        self.assertEqual("2,10,60", args.revisit_interval_buckets)
+
+    def test_update_accepts_explicit_empty(self):
+        args = self._parse(False, "--revisit_interval_buckets", "")
+        self.assertEqual("", args.revisit_interval_buckets)
+
+    def test_update_rejects_invalid_value(self):
+        with self.assertRaises(SystemExit):
+            self._parse(False, "--revisit_interval_buckets", "abc")
+
+
+class UpdateInstanceGroupTest(unittest.TestCase):
+    def _run_update(self, server_buckets, *extra_args):
+        with patch("sys.argv", ["prog", "--name", "g1", *extra_args]), \
+             patch.object(update_instance_group, "http_post") as mock_http_post:
+            mock_http_post.side_effect = [
+                _get_response(server_buckets),
+                {"header": {"status": {"code": "OK"}}},
+            ]
+            update_instance_group.main()
+            request = mock_http_post.call_args_list[1].args[2]
+            return request["instance_group"]["revisit_interval_buckets"]
+
+    def test_omitted_preserves_server_value(self):
+        self.assertEqual("1,5,30", self._run_update("1,5,30", "--user_data", "changed"))
+
+    def test_explicit_value_overrides_server_value(self):
+        self.assertEqual("2,10,60", self._run_update("1,5,30", "--revisit_interval_buckets", "2,10,60"))
+
+    def test_explicit_empty_clears_server_value(self):
+        self.assertEqual("", self._run_update("1,5,30", "--revisit_interval_buckets", ""))
+
+    def test_missing_server_field_stays_empty_when_omitted(self):
+        self.assertEqual("", self._run_update(None, "--user_data", "changed"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- kvcm_ops CLI gains full `revisit_interval_buckets` support for instance_group: model construction/check/serialization/deserialization preserve the field, fixing the silent field drop in the GET→PUT update flow
- `create_instance_group` / `update_instance_group` add `--revisit_interval_buckets` with client-side validation aligned with server-side `StringUtil::ParseBucketBoundaries` (comma separated, finite positive numbers, strictly ascending; empty string clears to server default; on update, omitting keeps the server-side value)
- Adds 24 unit tests registered as a bazel py_test

## Test plan
- [x] bazel py_test instance_group_revisit_buckets_test 24/24 passed
- [x] existing storage_util_test 17/17 passed
- [x] CLI spot-check: help text, invalid inputs rejected at argparse layer, valid values normalized
