### PR TITLE
[manager] add safe asynchronous CopyGA

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [ReportEvent / GetHostCacheState 小 block 性能记录](design/report_event_performance.md) - local/Redis 指标解释、锁与可见性语义、有界并发、容量基准及后续优化边界
 - [高可用与选主机制](design/ha_leader_elector.md) - HA 架构、LeaderElector 状态机、CoordinationBackend、Leader 发现
 - [CacheReclaimer 异步删除与过度逐出优化](design/cache_reclaimer_async_delete.md) - 异步删除生命周期、in-flight credit、反压与无进展退避
+- [KVCM × PACE CopyGA 异步化设计](design/async_copyga.md) - 复用 PACE 现有异步接口的 KVCM 端到端异步方案、持久 guard fencing、drain-safe 回收、quarantine 容量门控与恢复
 - [后台扫描 GC](design/cache_garbage_collector.md) - 基于 authoritative cursor 的后台全量巡检；V1 清理长期 orphan WRITING 和普通 SERVING storage-missing，并提供无副作用读取、精确值条件 CAS 与 HA 生命周期
 - [CacheReclaimer 跨 Instance 公平逐出](design/cache_reclaimer_instance_fairness.md) - 按 Instance 用量分配采样与逐出预算，并与异步 credit 协同
 - [EventReport 主动回收纳入后台扫描 GC](design/event_report_background_gc.md) - 由 EventReportBackend 提供状态驱动的批量判定，复用统一 GC round 回收 stale snapshot 与 down host metadata

--- a/docs/api/admin_service.md
+++ b/docs/api/admin_service.md
@@ -340,6 +340,49 @@ curl -g -vvv -X POST http://localhost:6492/api/removeCache \
 }'
 ```
 
+## List Async Copy Quarantine
+
+Lists asynchronous Copy operations whose remote drain cannot yet be proven. An empty
+`instance_group_name` lists every group. This API is read-only; timeout or record age does not make a target safe to
+reuse.
+
+```bash
+curl -g -vvv -X POST http://localhost:6492/api/listAsyncCopyQuarantine \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "trace_id": "list_async_copy_quarantine_01",
+    "instance_group_name": "test_group"
+}'
+```
+
+Each returned record identifies the exact operation, source and target locations, backend task IDs, guarded bytes,
+guard timestamps and the last error.
+
+## Break-glass Release Async Copy
+
+This is a privileged recovery API for an `UNKNOWN` asynchronous Copy guard. Use it only after an independent external
+fencing procedure proves that the old remote operation can never resume writing its target. Operator confirmation or
+elapsed time alone is not sufficient evidence. The request is rejected unless all evidence fields are non-empty and
+`external_fencing_confirmed` is `true`.
+
+```bash
+curl -g -vvv -X POST http://localhost:6492/api/breakGlassReleaseAsyncCopy \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "trace_id": "break_glass_async_copy_01",
+    "operation_id": "operation-id-from-list-api",
+    "operator_name": "operator-name",
+    "external_fencing_evidence": "change-ticket-or-fencing-record",
+    "external_fencing_confirmed": true
+}'
+```
+
+The Manager performs an exact compare-and-set on operation ID and guard state, writes an audit log, and only then
+releases the quarantined target. See [KVCM × PACE CopyGA asynchronous design](../design/async_copyga.md) for the guard,
+recovery and rollback contract.
+
 ## Register Instance
 ```bash
 curl -g -vvv -X POST http://localhost:6492/api/registerInstance \

--- a/docs/design/async_copyga.md
+++ b/docs/design/async_copyga.md
@@ -2,692 +2,218 @@
 
 | 项目 | 内容 |
 |---|---|
-| 状态 | V1 代码完成，202 Linux 编译与定向单测通过；集群联调和故障演练待完成 |
-| 决策日期 | 2026-08-24 |
-| V1 范围 | KVCM 端到端异步化；PACE Meta/Provider/tair-mempool 零代码改动，KVCM 内源 PACE adapter 复用现有异步 API |
-| 涉及模块 | `service`、`manager`、`meta`、`config`、`data_storage`、`metrics`、`protocol` |
-| KVCM 审计基线 | `fix/reclaimer-exclude-report-event@0d0371a18faa` |
-| PACE 审计基线 | `bugfix/pace-tiered-storage-lightweight-safety@084d88703bd5` |
-| 性能依据 | [压测环境 CopyGA 百毫秒延迟差异分析](../../integration_test/tiered_storage/docs/performance/16_COPYGA_LATENCY_GAP_ANALYSIS_2026-08-21.md) |
-| 相关问题 | [永久 Copy 失败源隔离与换源缺陷](../../integration_test/tiered_storage/docs/operations/15_KVCM_PERMANENT_COPY_FAILURE_SOURCE_QUARANTINE_2026-08-19.md) |
+| 状态 | V1 已实现，默认关闭；需要 backend 显式声明异步能力 |
+| 默认模式 | `MIGRATION_COPY_SYNC` |
+| 异步模式 | `MIGRATION_COPY_ASYNC_REQUIRED` |
+| 改造范围 | KVCM 通用异步 Copy 框架、持久化 Copy Guard、恢复、回收保护、反压与配置 |
+| Backend 依赖 | submit/query/cancel、稳定 task ID，以及可靠的 `terminal` / `safe_to_reuse_dst` 语义 |
+| 核心不变量 | 只有 `terminal && safe_to_reuse_dst` 才能自动删除或复用目标 |
 
-本文记录 CopyGA 异步化的背景、改造前基线、已选方案、当前 V1 实现、安全契约、验收标准以及明确
-暂缓的工作。后续实现若改变本文中的状态机、回收条件、故障语义或模块边界，必须同步更新本文。
+本文是异步 CopyGA 的权威设计文档。它描述公开的接口与配置、持久状态机、失败语义和上线约束，
+不记录特定部署环境、内部仓库分支或一次性测试过程。
 
-## 1. 结论摘要
+## 1. 背景
 
-真实推理请求使用的 KVCache block 为 68 MiB 和 136 MiB，远大于早期 microbenchmark 使用的
-4 MiB。压测中 Provider 的 CopyGA 完成时间约为：
+### 1.1 为什么需要异步化
 
-| 尺寸 | 典型完成时间 | 有效吞吐 |
-|---:|---:|---:|
-| 4 MiB（按当前吞吐折算，非实测） | 约 7.5～8.3 ms | 约 0.5 GiB/s |
-| 68 MiB | 约 127～139 ms | 约 484～536 MiB/s |
-| 136 MiB | 约 259～281 ms | 约 484～525 MiB/s |
+早期 CopyGA 测试主要使用 4 MiB block，单次耗时通常只有数毫秒。真实 KVCache block 可能达到
+68 MiB 或 136 MiB，物理 Copy 耗时随数据量近似线性增长，进入数百毫秒量级。
 
-68 MiB 到 136 MiB 的延迟接近线性翻倍。当前证据表明，200～300 ms 首先是 100MB+ payload 的真实
-数据搬运成本，不是单纯把 KVCM 外层排队误算进 RT。异步化不会降低单次 Copy 的物理耗时；它首先
-建立可跨重启恢复、可证明安全回收的目标生命周期契约，其次才是释放 KVCM 共享执行线程、HTTP
-client 和存储生命周期锁。`copy_max_concurrency=1` 时，同一个 Instance Group 的 Copy 吞吐不会因为
-异步化本身提高；V1 的主要收益是安全地解除长期占用，并为后续受控提高并发打基础。
+同步路径会让以下资源等待完整物理 Copy：
 
-本设计作出以下核心决策：
+- Migration executor worker；
+- storage backend 调用栈；
+- PACE HTTP client；
+- `DataStorageManager` 的 backend 生命周期锁；
+- 同一 Instance Group 的 Copy slot。
 
-1. **V1 只改 KVCM，PACE 不改代码。** KVCM 使用 PACE 已有的 submit/query/cancel API，停止调用
-   `/v1/api/copy_ga/batch_sync`。
-2. **KVCM 的共享 worker 只做本地异步准入。** PACE HTTP submit、轮询和取消由
-   `TairMempoolBackend` 的专用 Copy coordinator 执行。
-3. **自动回收以 `terminal && safe_to_reuse_dst` 为唯一凭证。** timeout、`not_found`、响应丢失和
-   PACE 重启均不能授权删除或复用目标 GA；唯一例外是有独立外部 fencing 证明并完整审计的
-   break-glass 运维动作，它不进入自动策略。
-4. **不追求跨故障 exactly-once，采用 fail-closed。** 当前 PACE 没有调用方幂等 ID；无法确认是否
-   受理的目标进入 quarantine，宁可暂时占用容量，也不能与迟到写并发复用。
-5. **当前并发受 Group task concurrency、在途字节和 quarantine 容量约束。** quarantine 的
-   operations/bytes 达到配置上限后，新的异步 operation 被硬拒绝；基于 unknown 比例或连续 unknown
-   的持久化 circuit breaker 尚未实现，列为上线增强项，不能把容量 gate 描述成完整熔断器。
-6. **保留同步路径作为功能级回滚能力。** 同一 operation 一旦异步提交，不允许中途回退到同步 Copy，
-   避免对同一目标重复搬运；二进制回滚是另一条更严格的路径，必须先 drain 到持久 guard 数为零。
+把调用移到后台不会降低物理搬运耗时，但可以缩短 KVCM 共享执行资源的占用，并为后续安全提高
+Copy 并发建立基础。
 
-PACE Provider 当前固定使用 256 个 HTTP server 线程；在首发 `copy_max_concurrency=1`、一个逻辑
-operation 通常只有少量 URI pair 的条件下，单次 Copy 等待 200～300 ms 只占极少量 handler，不构成
-当前集群的健康风险。此时真正的限制是迁移吞吐是否追得上热层写入，而不是 Provider HTTP 线程数。
-因此 PACE Provider 真异步是有触发条件的扩展性优化，不是 V1 或当前 benchmark 的前置修复。
+### 1.2 改造前调用链
 
-### 1.1 当前实现快照
+```text
+MigrationManager
+  -> SchedulePlanExecutor
+    -> DataStorageManager::Copy()
+      -> backend synchronous Copy
+        -> wait for remote data movement
+      <- per-item ErrorCode
+    <- future ready
+  -> publish or delete target
+```
 
-| 能力 | 当前状态 |
-|---|---|
-| KVCM `SYNC` / `ASYNC_REQUIRED` 模式与配置校验 | 已实现 |
-| 开源仓通用 async backend 框架 | 已实现；基类 `SupportsAsyncCopy()` 默认 `false`，单独编译本仓时异步 PACE 分支不可达 |
-| KVCM 内源 PACE submit/query/cancel adapter | 已在内源 `8cac0396` 实现 `SupportsAsyncCopy()` override 及 coordinator；未修改 tair-mempool 服务端 |
-| `TairMempoolBackend` 本地异步 handoff 与后台收敛 | 已实现；单 coordinator 线程，进程内最多 1024 个 operation |
-| 持久 `migration_copy_guard`、严格 CAS、Leader 恢复 | 已实现；跃迁同时校验 operation/state，CAS 已生效但 Sync 未确认时仅重试 Sync |
-| target fencing，以及通过目标 guard 保护其精确 source identity | 已实现于 Reclaimer、后台 GC 和普通删除路径 |
-| quarantine 容量 gate、只读列表、外部 fencing 后的 break-glass | 已实现；自动 reconcile 和持久化 rate breaker 未实现 |
-| 永久失败源退避与优先换源 | 已实现于同步/异步共用准入层；当前为进程内有界状态 |
-| 202 Linux 编译与定向单测 | 本轮评审修正已在 202 隔离容器通过开源仓 8/8 定向目标、内源 PACE adapter 1/1 及两种组合的主二进制构建；详见 13.2 |
-| 集群 same/cross-provider 冒烟、故障注入与长压 | 待执行 |
+同步返回只表达“本次调用结束”。当 HTTP timeout、连接中断或远端重启发生时，KVCM 无法仅凭
+`ErrorCode` 判断远端是否仍会写目标。如果此时立即删除并复用目标，迟到写可能破坏其他数据。
 
-因此本文中的“必须”同时包含两类语义：已经落到 V1 代码中的安全契约，以及仍需在 Phase C/未来版本
-完成的上线门槛。各节会明确标注，不能仅凭设计目标推导某项能力已经实现。
+### 1.3 三层异步边界
 
-## 2. 术语与能力边界
+本文区分三个层次：
 
-本文区分三种容易混淆的“异步”：
-
-| 名称 | 含义 | 当前状态 |
+| 层次 | 含义 | V1 |
 |---|---|---|
-| KVCM 控制面异步 | Reclaimer/MigrationManager 提交迁移后不阻塞调用线程 | 已具备 |
-| PACE 提交异步 | `/copy_ga/batch` 返回 task ID，调用方后续查询 | 已具备，V1 复用 |
-| PACE 执行真异步 | Meta/Provider 在受理后不占用普通 worker/HTTP handler 等待物理 Copy | 当前不具备，V1 暂缓 |
+| KVCM executor 异步 | executor 只完成本地 handoff，不等待远端 Copy | 已实现 |
+| backend coordinator 异步 | backend 后台 submit、query、cancel 并收敛结果 | 由支持异步的 backend 实现 |
+| Provider 数据面异步 | Provider handler 不等待物理 Copy | 不在本次范围 |
 
-PACE task 的几个字段具有严格含义：
+Provider 内部是否异步不会改变 KVCM 的安全模型。只要远端可能在 API 返回后继续写，KVCM 就必须
+持有目标 fence，直到取得明确的 drain 证明。
 
-- `terminal`：客户端可见状态已经收敛，不再变化；
-- `drained`：commit owner 已证明此后不会继续写目标 GA；
-- `safe_to_reuse_dst`：当前实现等价于 `terminal && drained`，表示调用方可以安全回收目标；
-- `unknown_final`：控制面对账已经停止，但没有 drain 证明，目标必须隔离；
-- `not_found`：只说明当前 task registry 中没有记录，不证明 Provider 没有继续写目标。
+## 2. 目标与非目标
 
-本文中的 operation 是 KVCM 一次逻辑迁移；一个 operation 可以包含多个 PACE task，每个 task 对应
-一个 source/destination URI pair。
+### 2.1 目标
 
-`migration_copy_guard` 是跨重启的生命周期权威；现有 `MigrationManager::CopyTaskState` 只负责当前
-进程内的调度、取消与 completion 认领。两者不一致时必须以持久 guard 的更保守状态决定是否允许
-回收，不能用内存表为空推导远端任务已经结束。
+1. executor 在 backend 接受本地 handoff 后立即释放。
+2. 同步 backend 行为保持不变；异步能力必须显式 opt-in。
+3. 远端 task ID、source identity、target identity 和字节数可跨 Leader 恢复。
+4. timeout、cancel、重启和响应丢失均采用 fail-closed 语义。
+5. Reclaimer、后台 GC 和普通删除路径都不能回收未决目标。
+6. operation、在途字节和 quarantine 容量均有硬上限。
+7. 同一 operation 只选择一种执行模式，不在异步提交后回退到同步 Copy。
 
-## 3. 改造前基线与问题
+### 2.2 非目标
 
-### 3.1 改造前同步调用链
+1. 不降低单次物理 Copy 的数据面耗时。
+2. 不改变所有 backend 的 `Copy()` 同步契约。
+3. 不把 timeout、task age 或 HTTP 状态码解释为目标可复用证明。
+4. 不实现跨 Location 的分布式事务。
+5. 不保证远端 submit exactly-once；没有幂等键时，响应不确定必须隔离。
+6. 不自动删除无法证明安全的 quarantine 目标。
+7. 不在本次改造中实现 Provider 的异步执行队列或全局字节 admission。
+
+## 3. 安全模型
+
+### 3.1 术语
+
+| 术语 | 含义 |
+|---|---|
+| operation | KVCM 一次逻辑 Copy，可能包含多个 URI pair |
+| item | operation 中的一对 source/destination URI |
+| local handoff | backend coordinator 接受本地任务，不代表远端已受理 |
+| remote acceptance | 远端明确返回完整 task ID 集 |
+| terminal | task 不再继续状态迁移 |
+| safe to reuse | 远端保证不会再读写目标，可以删除或复用 |
+| guard | 写入目标 `CacheLocation` 的持久化 Copy fence |
+| quarantine | 无法取得安全证明而保留的目标及其 guard |
+
+### 3.2 核心不变量
+
+1. **自动回收凭据唯一。**
+
+   ```text
+   may_reuse_destination = terminal && safe_to_reuse_dst
+   ```
+
+   `ErrorCode`、timeout、cancel ACK、task `not_found`、进程退出和等待时长都不能替代该条件。
+
+2. **成功发布也要求安全终态。** 所有 item 必须同时满足：
+
+   ```text
+   outcome == success && terminal && safe_to_reuse_dst
+   ```
+
+3. **提交不确定时不得重发。** 如果 request 可能已送达，但没有拿到完整 task ID 集，目标进入
+   quarantine。重复 POST 可能让两组 task 并发写同一目标。
+
+4. **source 和 target 同时受保护。** target guard 存在期间：
+
+   - 目标不能被普通删除、Reclaimer 或 GC 回收；
+   - guard 中记录的精确 source `location_id + create_time` 不能先被淘汰；
+   - 同一 block 到同一 target storage 不得重复提交。
+
+5. **未知 schema 必须 fail-closed。** 显式存在但无法解析的 guard 不能被静默降级为普通
+   `CLS_WRITING` Location。
+
+6. **回收判断不读取诊断错误码。** `AsyncCopyItemResult::error` 只用于日志、指标和分类；
+   publish/delete 只读取 `outcome + terminal + safe_to_reuse_dst`。
+
+### 3.3 Backend 的纵深校验
+
+远端通常会同时返回 `terminal`、`drained` 和 `safe_to_reuse_dst`。PACE adapter 应重新计算：
+
+```text
+effective_safe =
+    terminal &&
+    drained &&
+    server_safe_to_reuse_dst
+```
+
+这可以避免版本偏斜或服务端派生字段错误直接授权目标复用。通用 KVCM 层只消费最终的
+`safe_to_reuse_dst`。
+
+## 4. 方案选择
+
+### 4.1 候选方案
+
+| 方案 | 结果 | 原因 |
+|---|---|---|
+| `batch_sync` + timeout 后内存对账 | 未采用 | 正常路径仍长时间占用 worker、client 和锁；响应不确定时缺少可靠恢复身份 |
+| async submit/query + 纯内存 operation | 未采用 | 能释放 worker，但切主后丢失 task ID、fence 和容量 accounting |
+| async submit/query + 持久 Copy Guard | 采用 | 同时解决资源占用、HA 恢复和目标安全回收 |
+
+因此仓库只有 `SYNC` 和 `ASYNC_REQUIRED` 两种模式，不存在
+`ASYNC_MEMORY_RECONCILE` 等第三种运行模式。
+
+### 4.2 总体架构
 
 ```mermaid
 flowchart TD
-    R[CacheReclaimer / Admin MigrateCache]
+    R[Reclaimer or Admin migration]
     M[MigrationManager]
-    E[SchedulePlanExecutor shared worker]
-    D[DataStorageManager::Copy]
-    B[TairMempoolBackend::Copy]
-    C[PaceServiceClient::BatchSyncCopyGA]
-    PM[PACE Meta batch_sync]
-    PP[Provider WriteRemote + SSD commit]
+    A[Validate size and reserve credits]
+    G[Persist WRITING target and Copy Guard]
+    E[SchedulePlanExecutor]
+    D[DataStorageManager]
+    B[Async-capable backend coordinator]
+    S[Remote submit]
+    Q[Remote query and cancel]
+    F[Completion future]
+    O{Aggregate outcome}
+    P[Promote target]
+    C[Delete safe failed target]
+    U[Keep quarantined target]
 
-    R --> M --> E --> D --> B --> C --> PM --> PP
-    PP -->|physical completion| PM --> C --> B --> D --> E --> M
+    R --> M --> A --> G --> E --> D --> B
+    B --> S --> Q --> F --> O
+    O -->|all success and safe| P
+    O -->|all terminal and safe, any failure| C
+    O -->|ambiguous or unsafe| U
 ```
 
-异步 V1 落地前，各层行为如下：
+### 4.3 组件职责
 
-1. `MigrationManager` 创建目标 GA 和 `CLS_WRITING` 目标 Location，然后向
-   `SchedulePlanExecutor` 提交 Copy，自己通过 future 等待结果。
-2. `SchedulePlanExecutor::DoCopyTask()` 在共享 worker 中同步调用 `DataStorageManager::Copy()`。
-3. `DataStorageBackend::Copy()` 的接口契约要求返回时 Copy 已经完成。
-4. `DataStorageManager::Copy()` 在整个后端调用期间持有 `rw_lock_` 的 shared lock。
-5. `TairMempoolBackend::Copy()` 获取一个 PACE client handle，同步调用
-   `/v1/api/copy_ga/batch_sync`。
-6. PACE 的同步接口内部虽然复用 submit/query 状态机，但 HTTP 调用仍然等到真实 Copy 完成。
-
-因此改造前实现不是阻塞推理请求线程，而是长时间占用 KVCM 的共享迁移执行资源。随着 block 变大和
-并发提升，会出现：
-
-- migration continuation worker 被 200～300 ms 的 I/O 占用；
-- PACE client handle 长时间不归还；
-- Storage update/unregister 等待 `DataStorageManager` 的锁；
-- Copy 排队和完成 future 数量增加；
-- cancel、shutdown、切主和 storage close 难以安全收敛；
-- 共享 executor 的其它 continuation 任务可能被间接延迟。
-
-基线默认 `SchedulePlanExecutor` 有 2 个 worker，migration worker budget 为 1。因此在
-`copy_max_concurrency=1` 下，一次 136 MiB Copy 会占满 100% 的 migration worker budget 约
-259～281 ms，但不会占满全部 executor worker。这也是为什么 V1 不能把收益描述成“提高 Group C1
-吞吐”：它释放的是唯一 migration slot，并改善 storage close、切主和未来扩并发的生命周期基础。
-
-### 3.2 KVCM 改造前生命周期缺口
-
-改造前 `MigrationManager` 的 active task 和 pending future 都在内存中。停止时会清空 active task，遗留
-的 `CLS_WRITING` 目标交给 Reclaimer 作为 orphan 回收。Reclaimer 和后台 GC 虽然都会通过
-`HasActiveCopyTargetLocation()` 排除当前进程内的 active target，但该 hook 仍是易失内存状态：
-`MigrationManager::Stop()` 清表或 Leader 重启后，它不能继续保护远端仍在执行的 Copy。后台 GC 当前
-默认关闭；但一旦启用，其 `IsOrphanWriting()` 会纯按创建时间判断 orphan，默认 grace period 为
-24 小时、最小为 1 小时。Reclaimer 则可能更早处理 orphan，因此两条路径都属于 Phase A 的 P0 fencing。
-同步 Copy 下，future 消失通常意味着进程内调用也一起结束；切换为远端异步后，这个假设不再成立：
-KVCM 退出时 PACE 可能仍在写目标。
-
-后台 GC 删除时已经携带 `expected_location_values` 做精确值条件删除；在全新版本中，guard 状态变化
-会改变 Location JSON，使在途旧删除请求自动失效。这是把 guard 放入 Location JSON 的正面依据，
-但它不是旧二进制兼容保证：`CacheLocation::ToRapidWriter()` 逐字段序列化，旧代码读写新 Location
-时会静默丢弃未知 guard 字段，甚至可能把它重新识别为普通 orphan。因此 Reclaimer 和 GC 都必须直接
-读取持久 guard 进行 fencing，不能只依赖 active table 或创建时间。
-
-改造前失败结果也只有 `ErrorCode`，无法表达以下差异：
-
-- 明确失败并且目标已经 drained；
-- 请求超时，但服务端可能已经受理；
-- task registry 中找不到任务；
-- PACE 已经发布 `unknown_final`；
-- 可以安全删除目标，或必须隔离目标。
-
-如果把这些情况都折叠成 `EC_ERROR` 并沿用“失败即删除目标”，会产生目标 GA 被迟到任务继续写入、
-同时又被重新分配给其它请求的风险。
-
-### 3.3 PACE 当前异步接口
-
-PACE 已提供以下接口：
-
-```text
-POST /v1/api/copy_ga/batch          submit
-GET  /v1/api/copy_ga/batch          query
-POST /v1/api/copy_ga/cancel         cancel
-POST /v1/api/copy_ga/batch_sync     synchronous wrapper
-```
-
-现有 task 状态机已经包含 `terminal`、`drained`、`safe_to_reuse_dst`、cancel、deadline、Provider
-status reconciliation 和 `unknown_final`，足以支持低并发、受控的 KVCM V1。
-
-但当前所谓异步只发生在 Meta 的 HTTP 边界：
-
-- Meta 将 node-pair group 放入普通 `MetaThreadPool`，worker 内仍然 `syncAwait`；
-- Provider handler 在 `WriteRemote` 后仍等待 completion 和 SSD commit；
-- Meta task registry、Provider status registry 都主要存在于进程内；
-- 没有 caller-provided idempotency key；
-- admission 主要按操作数限制，没有全局 in-flight bytes 限制；
-- batch query 逐 task reconciliation，依赖调用方轮询。
-
-更准确的当前调用时序是：
-
-```text
-KVCM submit
-  -> PACE Meta 返回 task ID
-  -> Meta 后台 worker 调 Provider /api/copy_ga
-  -> Provider 发起 callback 型 WriteRemote
-  -> Provider handler 同步等待最多 30 秒
-       -> 30 秒内完成：直接返回 terminal success/failure
-       -> 30 秒内未完成：返回 202，terminal observer 后台更新 registry
-  -> KVCM query Meta；Meta 必要时再 query Provider status
-```
-
-`WriteRemote` 数据面本身已经是 callback 异步实现，但 Provider 的 `CopyGA` handler 使用
-`CallbackWaiter::SetAndAwaitCallback()` 的条件变量等待 completion。默认等待预算为 30 秒，可通过
-`TAIR_MEMPOOL_COPY_GA_WAIT_TIMEOUT_MS` 调整。当前 68/136 MiB 的 127～281 ms Copy 远低于该预算，
-因此正常压测路径通常由 Provider 直接返回终态，而不是先返回 202；`202 + status` 主要是长尾或故障
-路径。
-
-#### 3.3.1 Provider 同步等待配置
-
-| 项目 | 当前定义 |
+| 组件 | 职责 |
 |---|---|
-| 配置项 | `TAIR_MEMPOOL_COPY_GA_WAIT_TIMEOUT_MS` |
-| 生效组件 | PACE Provider |
-| 默认值 | `30000` ms |
-| 合法范围 | `1～55000` ms；未配置、非整数或越界时回退到默认 `30000` ms |
-| 读取方式 | `CopyGAWaitTimeout()` 内以进程级 `static const` 读取；修改后需要重启 Provider |
-| 控制语义 | Provider `/api/copy_ga` handler 等待 `WriteRemote` completion 的本地同步预算 |
-| 到期行为 | 当前 terminal protocol 下返回 HTTP 202；物理 Copy 和 terminal observer 继续运行，Meta 后续查询 status |
-| 不控制 | 物理 Copy 的 `commit_timeout_ms`、Meta 60 秒 Provider HTTP timeout、Meta 120 秒 reconciliation 窗口 |
-
-部署示例：
-
-```text
-TAIR_MEMPOOL_COPY_GA_WAIT_TIMEOUT_MS=5000
-```
-
-该值由 `dfcf43f16f3afe7218039dc8ca48e82e13b687cb`（`fix(copy): publish explicit CopyGA result after
-backend commit`）引入；此前 `2c6fea124c6d6dcb224a1db7b5676ba88d36e7d2` 首次让 Provider handler
-等待真实 IO completion，但沿用 `CallbackWaiter` 的固定 1 秒预算。后续
-`89d11eb31a9d1243c4b37bbfe00c6a6743951471`（`fix(copy): bound and drain timed out CopyGA tasks`）
-增加 Provider status registry 和 HTTP 202 语义，才使“本地等待到期”不再等同于“物理 Copy 失败”。因此
-下调该配置以前必须确认 Provider 和 Meta 都已部署 terminal/status 协议，不能把同样策略直接应用到
-旧 Provider。
-
-30 秒是为了覆盖 backend queue 和 sync 长尾，同时保持低于 Meta 对 Provider 的 60 秒 HTTP timeout；
-它不是根据当前 100 MiB 级 Copy 的 200～300 ms P99 量化得到的 deadline。作为“同步等待 → 202 异步
-接管”的切换阈值，当前建议先配置为 5 秒，并观测 Copy P99.9、HTTP 202 比例、terminal 收敛时间和
-unknown/quarantine 数量；有足够数据证明 P99.9 明显低于 1 秒后，再评估降到 3 秒。降低本配置只应
-提前释放 handler，不应联动缩短 `commit_timeout_ms` 或 reconciliation/registry retention。
-
-Provider HTTP server 的 `META_SERVER_THREAD_NUM` 当前固定为 256。KVCM 的
-`copy_max_concurrency` 是 Instance Group 级**逻辑 operation**硬限制：task 从 preparing、远端 submit、
-polling 到 KVCM 最终 promote/safe-failure/unknown 收尾期间都占用 slot，PACE 返回 task ID 不会释放
-slot。因此正常慢 Copy 会把压力反向传回 KVCM，而不是让同一 Group 无界地向 PACE 排队：
-
-```text
-PACE 变慢
-  -> 当前 KVCM operation 更久不终止
-  -> Group Copy slot 保持占用
-  -> Reclaimer 不再提交新的物理 Copy
-  -> 热层下沉吞吐降低，水位继续上升
-  -> 可能更早进入 reclaim/写入反压，而不是首先拖垮 Provider HTTP
-```
-
-一个 operation 可以包含多个 URI pair，所以 `copy_max_concurrency=1` 不严格等于一个 Provider HTTP
-请求；若一个 block 有两个 location spec，则最多可同时形成两个 PACE Copy task。即使按两个 task 估算，
-也只占约 `2 / 256 < 1%` 的 Provider HTTP 线程；C8、每个 operation 两个 item 时约为
-`16 / 256 = 6.25%`。在当前单 Group C1/C2 范围内，SSD/网络吞吐、PACE 数据面队列和 KVCM 下沉速率
-更可能先成为瓶颈，不能仅凭 200～300 ms handler 等待推导 Provider 健康会受影响。
-
-上述反压有三个边界：
-
-1. `copy_max_concurrency` 不是 PACE 全局限制；多个 Instance Group、多个 KVCM 集群、手工 CopyGA 和
-   其它调用方会在同一 Provider 汇聚。
-2. operation 进入 unknown 后会从 active credit 原子转入 quarantine credit，活跃 slot 随之释放；旧
-   PACE task 在没有 drain 证明时理论上仍可能运行。KVCM 可以在 quarantine 未达到 ops/bytes 硬上限前
-   接受新 operation，因此真实物理在途数可能是 `active + quarantine`，而不只等于
-   `copy_max_concurrency`。
-3. Provider 在返回 202 后只通过进程内 terminal observer 更新 registry，Meta 侧主要由调用方 query
-   驱动 reconciliation；KVCM coordinator 停止轮询、Meta/Provider 重启或 status TTL 到期都会把任务
-   推向 unknown/quarantine，而不是自动恢复成安全失败。
-
-当前 Provider 的最终成功、字节数和 latency 指标主要在 handler 观察到终态时记录；若 handler 先返回
-202、completion 后到，terminal observer 会更新 registry，但长尾任务的最终指标可能不完整。该问题
-影响可观测性，不改变 `terminal && drained` 的回收安全语义；只有真异步改造时才需要把 exactly-once
-终态 metrics 一并迁移到 completion owner。
-
-当前审计基线还有以下容量和保留边界：Meta Copy task registry 默认最多 100,000 条，terminal task
-从“发布客户端可见终态”开始保留 30 分钟；Provider status registry 默认保留 600 秒，Meta 的 Provider
-reconciliation 默认窗口为 120 秒。V1 必须持续、有界地查询 active task，不能把 task ID 当成永久可
-恢复句柄。这里不存在简单的 `operation_deadline < 30min` 单一约束；正确约束分为：
-
-```text
-P99_remote_execution + queue/retry/poll_margin < copy_operation_deadline
-max_KVCM_recovery_outage + poll_interval < PACE_terminal_retention
-PACE_provider_reconcile_timeout < Provider_status_TTL
-```
-
-第一条保证正常任务不被过早转 unknown，第二条保证 KVCM 在 PACE 已经完成后仍有机会读到终态，第三条
-保证 Meta 对账窗口内 Provider 状态仍可查询。任何 deadline 或 retention 过期都不构成 drain 证明；
-超出窗口得到 `not_found` 时仍按 unknown 处理。
-
-V1 接受这些限制，并通过 KVCM 低并发和 fail-closed 策略控制风险；它不把现有 PACE API 描述成
-最终的生产级真异步实现。
-
-### 3.4 代码依据
-
-以下位置构成当前判断的主要源码依据，行号变化时应按函数名定位：
-
-| 组件 | 位置 | 改造前行为/审计依据 |
-|---|---|---|
-| KVCM backend 契约 | `kv_cache_manager/data_storage/data_storage_backend.h` `Copy()` | 同步返回，逐项结果长度必须与输入一致 |
-| KVCM storage manager | `kv_cache_manager/data_storage/data_storage_manager.cc` `Copy()` | 持 shared `rw_lock_` 调用 backend |
-| KVCM executor | `kv_cache_manager/manager/schedule_plan_executor.cc` `DoCopyTask()` | 共享 worker 同步等待 backend Copy |
-| KVCM migration | `kv_cache_manager/manager/migration_manager.cc` `Submit()`、`MonitorLoop()`、`Stop()` | future 在内存中轮询；Stop 清 active task，WRITING 交给 orphan 回收 |
-| KVCM Reclaimer | `kv_cache_manager/manager/cache_reclaimer.cc` orphan WRITING 判断 | 通过内存 active target 排除迁移目标；重启/清表后 fencing 消失 |
-| KVCM 后台 GC | `kv_cache_manager/manager/cache_garbage_collector.cc` `IsOrphanWriting()`、`BuildDeleteRequest()` | orphan 判定按年龄；另查内存 active target，并使用 Location 精确值条件删除 |
-| KVCM Location 序列化 | `kv_cache_manager/meta/cache_location.h` `ToRapidWriter()` | 逐字段序列化；旧二进制会丢弃未知 guard 字段 |
-| KVCM size 解析 | `kv_cache_manager/manager/migration_manager.cc`、`manager/meta_searcher.cc` | URI `size` 缺失/非法时可静默保留 0；`BatchAddLocation()` 还有未初始化局部值风险 |
-| KVCM storage lifecycle | `data_storage_manager.cc` `UnRegisterStorage()`、`config/registry_manager.cc` `RemoveStorage()` | 已调用 backend `Close()`；但当前先删持久配置再 unregister，Close 失败会造成配置/运行态不一致 |
-| 内源 PACE client | `internal_source/kv_cache_manager/data_storage/pace_service_client.cc` `BatchSyncCopyGA()` | 仅封装 `/copy_ga/batch_sync`，HTTP helper 丢弃非 200/204 状态细节 |
-| 内源 PACE backend | `internal_source/kv_cache_manager/data_storage/tair_mempool_backend.cc` `Copy()` | 同步持有 client handle，并按输入下标合并结果 |
-| PACE Meta API | `tair-mempool/include/meta_service/node_management_service.h` | 已定义 submit/query/cancel 与 terminal/drained 字段 |
-| PACE Meta executor | `tair-mempool/src/meta_service/node_management_service.cpp` `SubmitBatchCopyGA()` | node-pair group 进入普通线程池，worker 内 `syncAwait` |
-| PACE Provider | `tair-mempool/src/listener/meta_restful_server.cpp` CopyGA handler | `WriteRemote` 后以 `SetAndAwaitCallback()` 最多等待默认 30 秒；未终态时返回 202 |
-| PACE Provider HTTP server | `tair-mempool/include/listener/meta_restful_server.h` `META_SERVER_THREAD_NUM` | 当前固定 256 个 HTTP 线程；C1/C2 下少量 200～300 ms 等待不是健康瓶颈 |
-| KVCM Group Copy gate | `kv_cache_manager/manager/migration_manager.cc` `BatchSubmit()` | `copy_max_concurrency` 按完整逻辑 operation 生命周期占用，不在 PACE submit 后提前释放 |
-
-内源路径以 `KVCacheManager` 仓库为根，PACE 路径以 `tair-mempool` 仓库为根。本文只记录跨仓契约，
-实现时双方分支必须重新核对响应 schema 和默认配置。
-
-## 4. 设计目标与非目标
-
-### 4.1 V1 目标
-
-1. 建立可支撑后续高并发的持久目标生命周期契约：自动路径只有远端终态且有 drain 证明时才允许
-   回收目标。
-2. 让 KVCM 共享 `SchedulePlanExecutor` worker 不再等待 100MB+ 的物理 Copy。
-3. 保持现有 `CLS_WRITING -> CLS_SERVING` 的发布屏障；数据没有安全完成前绝不对读路径可见。
-4. 在成功、失败、超时、取消、响应丢失和 `not_found` 下定义唯一、保守的目标 GA 生命周期。
-5. 支持 KVCM 重启/切主后识别未完成异步 operation；能恢复的继续查询，不能恢复的隔离。
-6. 对 Group Copy concurrency、在途字节和 quarantine operations/bytes 实施有界反压；进程级
-   operation 上限由 backend 固定为 1024。unknown rate、轮询 QPS 和持久化 breaker 属于后续增强。
-7. 保持同步 Copy 路径可用，并分别定义 feature 关闭和二进制回滚的安全门槛。
-8. 先提供 unknown、inflight、quarantine 与失败源计数；进一步拆分本地排队、PACE submit、远端执行
-   和端到端完成时间的完整 metrics 属于上线观测增强。
-
-### 4.2 V1 非目标
-
-1. 不降低单次 68/136 MiB Copy 的物理 RT。
-2. 不修改 PACE Meta 或 Provider 代码。
-3. 不实现 PACE 内部 worker/handler 真异步。
-4. 不承诺提交响应丢失后的 exactly-once；缺少 PACE 幂等 ID 时只能安全隔离。
-5. 不调整 PACE placement、链路池、SSD backend 或 Copy 数据算法。
-6. 不在异步状态机里特殊处理永久失效源；本次同时在同步/异步共用的准入层独立交付有界退避和
-   优先换源，但不做 topology epoch、权威删源或持久 source quarantine。
-7. 不在 V1 引入 callback、消息队列或跨组件事件推送，仍使用有界 polling。
-
-## 5. 设计决策记录
-
-### D1：V1 复用 PACE 当前异步 API，PACE 零代码改动
-
-**决定：** 使用 `/copy_ga/batch`、`/copy_ga/batch` query 和 `/copy_ga/cancel`，不等待 Provider 真异步
-改造。
-
-**原因：** 已有接口已经返回 task ID 和 drain 安全字段，KVCM 可以先建立持久目标生命周期并解除共享
-worker 长等待，能够满足低并发 V1。Provider 当前有 256 个 HTTP 线程；C1 且每个 operation 两个 item
-时只占约两个 handler，200～300 ms 等待对整体健康的影响可以忽略。先修改 Provider 会扩大双方联调
-范围和发布风险，却不能提高 C1 下同一 Group 的物理迁移吞吐。
-
-**代价：** PACE 内部线程仍可能等待 200～300 ms；并发能力受现有线程池、HTTP handler 和 IO 吞吐
-限制。该代价在当前 C1/C2 下可接受；V1 不能据此无条件提高到大规模并发，也不能把 KVCM 的 Group
-gate 当成 PACE 面向所有调用方的全局 admission。
-
-### D2：异步能力由 backend 显式暴露，不改变同步 `Copy()` 语义
-
-**决定：** 保留 `DataStorageBackend::Copy()`；新增可选的 `CopyAsync()` 能力。不能把现有 `Copy()`
-悄悄改成“提交成功即返回”，否则所有旧调用方都会错误地把未完成目标视为成功。
-
-不支持原生异步的后端继续使用同步接口。启用 `ASYNC_REQUIRED` 时，目标后端不支持异步必须明确拒绝，
-不得静默降级。
-
-### D3：PACE backend 自己负责 submit/query/cancel 和完成收敛
-
-**决定：** `TairMempoolBackend` 拥有专用 Copy coordinator、队列和轮询器；
-`SchedulePlanExecutor` 只完成本地有界准入并拿到最终 future。
-
-当前 V1 使用一个 coordinator 线程串行执行 submit/query/cancel，进程内 operation 硬上限为 1024。
-这保证了共享 executor 不再等待物理 Copy。单线程只串行化控制面 HTTP 调用；已经 submit 的多个 PACE
-物理任务仍可在远端重叠执行。若控制面 HTTP 本身成为瓶颈，再在 Phase C 容量验证后把 coordinator 扩为
-有界 worker pool。
-
-**原因：** PACE task ID、HTTP schema、polling 和 cancel 都是后端协议细节，不应泄漏给通用
-`MigrationManager`。同时避免把轮询任务重新放回共享 executor。
-
-开源仓仅定义通用契约，`DataStorageBackend::SupportsAsyncCopy()` 默认返回 `false`；
-`open_source/TairMempoolBackend` 是无 PACE 实现的 stub，不会让该分支变得可达。真正的
-override 和 PACE 响应映射在内源 `8cac0396 [data_storage] add asynchronous PACE copy
-coordinator`，必须作为独立的下游实现评审和测试。当前映射表如下：
-
-| PACE 观测 | KVCM outcome | `terminal` | `safe_to_reuse_dst` | 处置 |
-|---|---|---:|---:|---|
-| submit 返回完整 task ID 集 | 未终止 | false | false | guard `Submitting -> Active`，继续 query |
-| submit 返回可解析的明确 error，未发布 task | failed | true | true | 允许清理目标 |
-| submit transport/schema 失败或 task ID 不完整 | unknown | false | false | quarantine，不得回收 |
-| query/cancel 所有 item 均 terminal + safe，且 outcome 均 success | success | true | true | promote 目标 |
-| query/cancel 所有 item 均 terminal + safe，至少一项 failed/cancelled | failed/cancelled | true | true | 不 promote，允许清理目标 |
-| 任一 item 非 terminal/非 safe，或 query/not_found/deadline 后仍无 drain 证明 | unknown | false | false | quarantine，不得回收 |
-
-`ErrorCode` 只用于日志/指标；即使它与 outcome 矛盾，Manager 的回收决策也只看
-`terminal && safe_to_reuse_dst`。
-
-### D4：V1 保留 MigrationManager 的 future 边界
-
-**决定：** backend coordinator 在远端 task 终态时完成 promise，`MigrationManager` 仍接收一个最终
-future。V1 不同时重写所有 manager completion 流程。
-
-completion 收尾以 operation 粒度 mutex 串行化 submit-acceptance、Cancel 和终态回调，不再用
-全局 guard mutex 阻塞无关 operation。每个 operation 在进程内还有唯一 credit ledger：
-inflight 只能向 released 或 quarantine 迁移一次，从而即使 Cancel 与 completion 竞争也不会
-双重扣减字节额度或制造 phantom quarantine。
-
-**后续：** 当 operation 数明显增加时，把当前 deque + `wait_for` 轮询改成 completion queue/event，
-见第 14 节。
-
-### D5：目标 Location 保存持久化 Copy guard，并作为跨重启权威
-
-**决定：** 在目标 `CacheLocation` 的内部 JSON 模型中增加可选 `migration_copy_guard`；保持目标状态为
-`CLS_WRITING`，不新增对外暴露的 `CLS_QUARANTINED`。
-
-当前字段如下（代码中的时间字段使用微秒）：
-
-```cpp
-enum class MigrationCopyGuardState {
-    kSubmitting,  // PACE submit 结果尚未可靠持久化
-    kActive,      // task_ids 已持久化，可查询
-    kCancelling,  // 不再允许 promote，等待 drain
-    kUnknown,     // 无法证明 drain，只允许人工/未来恢复流程处理
-};
-
-struct MigrationCopyGuard {
-    uint32_t schema_version = 1;
-    std::string operation_id;
-    MigrationCopyGuardState state;
-    std::string source_location_id;
-    int64_t source_location_create_time;
-    std::string source_storage_name;
-    std::string target_storage_name;
-    MigrationRetention retention;
-    uint64_t total_bytes;
-    std::vector<std::string> backend_task_ids;
-    int64_t create_time_us;
-    int64_t update_time_us;
-    std::string last_error;
-};
-```
-
-该字段只用于 Manager 内部恢复、Reclaimer/GC fencing，不进入 client/connector 的公开
-`CacheLocation` proto。持久 guard 是“目标是否允许回收”的跨重启权威，现有内存
-`CopyTaskState` 只负责本进程内的调度与 completion 认领。
-
-选择 Location JSON 而不是现有 `__mig_tier_target__` block property 的原因是：Reclaimer 和后台 GC
-扫描时天然取得 Location；当前 `MaintenanceScanBatch` 不携带 block property。后台 GC 已使用
-`expected_location_values` 做精确值条件删除，因此 guard 的状态跃迁会改变序列化值，使新版本中已在途
-的旧删除请求因 expected value 不匹配而失效。这是额外安全网，但不能替代扫描阶段的显式 guard 判断。
-
-Reclaimer 和后台 GC 都必须直接检查持久 guard，并在有任意非安全终止 guard 时跳过回收；现有
-`HasActiveCopyTargetLocation()` 仅作为本进程内的快速索引，不能成为正确性依据。后台 GC 不需要新增
-对 MigrationManager 的依赖边，直接从已经读取的 Location JSON 判断即可。
-
-当前实现只接受 `schema_version == 1`、已知 state 且 operation_id 非空的 guard。JSON 中显式存在但
-无法解码、schema 更高、state 未知或字段不完整时，Location 整体解析失败；Leader 恢复扫描遇到此类
-错误会阻止恢复成功，而不是把它静默当成普通 WRITING Location。
-
-`CacheLocation::ToRapidWriter()` 是逐字段序列化，旧二进制不是“无害忽略”未知字段，而是可能在任意
-读-改-写路径静默擦除 guard。因此兼容规则是：
-
-- 异步 feature 只能在全部 Manager 节点升级、旧 Leader 不再可能接管后开启；
-- 关闭 feature 不等于允许降级 binary，恢复/fencing 代码必须继续运行；
-- **任何二进制回滚前，必须停止新异步 submit，并确认全局持久 guard 数为零**；
-- 当前二进制遇到高于自身能力的 `schema_version` 时必须 fail-closed：禁止 promote、删除、复用或重写
-  该 Location，并触发版本不兼容告警；
-- 若无法 drain 到零，只能继续运行能理解 guard 的版本。把 guard 改成独立 key 也不能单独解决旧版本
-  安全问题，除非旧 Reclaimer/GC 同样被改为读取该 key。
-
-除初次创建 `kSubmitting` 外，所有 guard 状态跃迁都必须同时用 `operation_id + expected_state` 做条件
-更新，禁止只凭 operation ID 把已经持久化的 `kUnknown` 回退为 `kCancelling`。终态发布使用一次条件
-metadata mutation 原子地完成“目标变为 `SERVING` 或被安全删除”与“清除 guard”，不能形成已发布目标仍
-长期带 guard 的中间态。
-
-条件 mutation 已生效但 `MetaIndexer::Sync()` 超时时，语义是“最终状态可能已经持久、durability ACK
-未知”，不能当成普通业务失败，也不能再次执行 CAS、重新 Copy 或创建 phantom quarantine。当前实现
-保留已完成的 backend result 和终态 action，只重试 `Sync()`；在 durability 确认前 operation credit
-仍由同一个 operation ledger 持有。
-
-### D6：先做无副作用 credit reservation，再持久化 `kSubmitting`，最后发 POST
-
-**决定：** 操作顺序固定为：
-
-```text
-parse and validate every source size
-  -> reserve group active/byte credits
-  -> allocate dst
-  -> add CLS_WRITING dst
-  -> CAS + Sync kSubmitting guard
-  -> activate local task
-  -> hand off operation to backend coordinator
-  -> POST PACE batch
-  -> persist task_ids and transition to kActive
-```
-
-reservation 是 Manager 本地 accounting，不产生远端副作用。credit 不足时直接拒绝，不分配 GA、不写
-metadata；目标分配或 guard 写入失败时，在确认 backend handoff/POST 尚未发生的前提下回滚目标并释放
-credit。guard 持久化成功后，operation 持有 inflight credit，直到安全终止，或原子转入独立 quarantine
-计量。backend handoff 明确拒绝、且确认没有远端副作用时，也走 definite pre-submit rollback，不制造
-虚假的 UNKNOWN quarantine。
-
-如果进程在 guard 持久化后、POST 前退出，会留下保守的 `kSubmitting` quarantine；如果 POST 已被
-PACE 接受但响应丢失，仍留下同样的 quarantine。由于 PACE 当前不支持按 KVCM operation ID 查询，
-这两个场景无法自动区分。该顺序避免常见本地拒绝路径白分配 GA、白写 metadata，同时保持“POST 前
-guard 必须落盘”的安全屏障。
-
-### D7：未知状态 fail-closed，不自动重试同一目标
-
-**决定：** submit transport timeout、响应无法解析、task `not_found`、`unknown_final`、PACE 重启或恢复
-查询超时，都进入 `kUnknown`：
-
-- 不 promote；
-- 不删除或复用目标 GA；
-- 不对同一个目标自动重新 submit；
-- 保留 source；
-- 告警并进入隔离容量统计。
-
-重新迁移必须创建新的目标和新的 operation，且需受永久失败源 backoff/quarantine 控制。不能对旧
-目标直接重试，否则服务端第一次请求仍可能迟到写入。
-
-### D8：只有 PACE 明确的 drain 证明才能回收目标
-
-**决定：**
-
-```text
-success && terminal && safe_to_reuse_dst
-    -> WRITING target CAS to SERVING
-
-non-success && terminal && safe_to_reuse_dst
-    -> delete target location and GA
-
-otherwise
-    -> keep WRITING + guard, quarantine
-```
-
-不能用 HTTP 失败、KVCM deadline、cancel ACK、Provider incarnation 变化或等待足够久替代 drain 证明。
-本节约束所有自动路径；9.4 的 break-glass 必须先取得独立的外部 fencing 证明，并作为特权、受审计的
-异常流程存在，不能被 Reclaimer/GC 调用。
-
-### D9：异步期间同时保护 source 和 target
-
-**决定：** active/恢复中的 guard 同时保护 target 和它引用的精确 source identity：
-
-- target pin 防止 Reclaimer/GC 把 `CLS_WRITING` 目标当 orphan；
-- Reclaimer、后台 GC 和普通 metadata 删除路径在扫描同一 block 时，若发现 sibling target guard 引用
-  某个 source，则跳过该精确 source；
-- source 身份使用 `location_id + create_time`，防止 ID 复用误保护新 Location。
-
-当前实现没有把独立 guard 字段写入 source Location；source 保护来自目标 Location 中持久化的
-`source_location_id + source_location_create_time`，以及当前进程 active task 的快速索引。Leader 恢复先
-扫描所有 target guard，再允许迁移准入；回收路径每次从同一 block 的 sibling target guard 重建判断。
-
-这里仍有一个已知窄竞态：若普通 source 删除在 guard 建立前已经完成候选准入和 expected-value 快照，
-随后才执行 CAS，目标 guard 的新增不会改变 source JSON，因此该旧 CAS 仍可能成功。当前所有新删除
-请求都使用精确 Location value CAS，且扫描阶段会识别 guard，但这不能消除“已在途旧 CAS”窗口。若
-Phase C 故障注入证明该窗口可达，后续必须把 source pin 持久化到 source JSON，或用单次原子 RMW 同时
-安装 source/target fence；当前版本不能宣称拥有跨两个 Location 的原子 source pin。
-
-### D10：任务数、字节数与 quarantine 三重反压
-
-**当前实现：** 保留 Instance Group 级 `copy_max_concurrency`，并新增：
-
-- Instance Group 级 `copy_max_inflight_bytes`；
-- Instance Group 级 `copy_max_quarantine_operations` 和 `copy_max_quarantine_bytes`；
-- `TairMempoolBackend` 进程内最多 1024 个异步 operation；
-- 单 coordinator 线程天然限制 submit/query/cancel 的同时执行数。
-
-异步 feature 开启时必须显式配置正数的 byte limit；不允许用 0 表示无限。任一 source URI 的 `size`
-缺失、非法、为 0，或求和溢出时必须在 reservation 前拒绝，不能按 0 或“保守猜测值”继续。首轮保持
-`copy_max_concurrency=1`，在 68/136 MiB 真实尺寸下完成验收后才允许升到 2。
-
-当 quarantine bytes/operations 达到阈值时，受影响 Group 的新异步 operation 被硬拒绝；
-`ASYNC_REQUIRED` 下不得自动回退到同步接口。该容量 gate 能阻止继续突破已配置隔离容量，但它还不是
-一个完整 circuit breaker：unknown 比例/连续 unknown、持久化 open 状态、恢复水位和 half-open probe
-均未实现。
-
-operation 转 `kUnknown` 时，当前实现会在同一个本地 accounting 临界区把 op/bytes 从 inflight credit
-转移到 quarantine credit，避免先释放后补记或双重计量。重启恢复会扫描持久 guard，重建 inflight 与
-quarantine 基线。unknown rate breaker 的 open 状态、原因和 `opened_at` 持久化属于未来工作。
-
-### D11：同步和异步模式只在 operation 边界切换
-
-**决定：** feature gate 支持 `SYNC` 和 `ASYNC_REQUIRED`：
-
-- 新 operation 按当时配置选择模式；
-- 已经进入 `kSubmitting/kActive/kCancelling/kUnknown` 的 operation 必须沿异步恢复链收敛；
-- 从异步回滚到同步前，先停止新异步准入并等待 active operation drain；unknown quarantine 不阻止
-  关闭功能，但必须继续受 Reclaimer/GC 保护；
-- 从新二进制回滚到不识别 guard 的旧二进制前，必须额外确认持久 guard 数为零。
-
-不得在异步 POST 结果不明确时回退调用 `/batch_sync`，否则可能双写同一目标。
-
-### D12：未选择方案
-
-| 方案 | 未作为 V1 最终方案的原因 | 可保留用途 |
-|---|---|---|
-| 把现有 `/batch_sync` 放入独立线程池 | 只能把阻塞从共享 worker 移到专用 worker，仍长期占用线程和 client handle，也没有远端 task 恢复语义 | 异步 V1 未完成前的短期隔离措施 |
-| 把 URL 改成 `/batch`，submit 成功就完成 future | 把“任务已创建”误当成“数据已复制”，会提前 promote 未完成目标 | 禁止 |
-| 任何错误都删除目标 | timeout、`not_found` 和响应丢失都可能伴随迟到写，存在 GA 复用冲突 | 仅适用于明确未产生远端任务或已有 drain 证明 |
-| 对 ambiguous submit 自动重试同一目标 | PACE 当前没有 caller idempotency key，可能形成两个任务并发写同一目标 | PACE 幂等能力完成后重新评估 |
-| 由 `SchedulePlanExecutor` 直接负责 HTTP polling | PACE 协议细节上浮到 manager，共享 executor 再次被轮询污染 | 禁止；polling 归 backend coordinator |
-| 等 PACE Provider 真异步完成后再改 KVCM | 会把双方改造绑定为一个大版本，而当前 submit/query API 已足够解除 KVCM 长等待 | PACE 真异步独立作为后续优化 |
-| 引入跨组件 callback/message queue | 改动和运维面过大，当前低并发 polling 足够 | poll 成为瓶颈后再评估 |
-
-PACE 的 sync wrapper 在 timeout 后也会 cancel/query，并可能返回 task IDs 与 outcome unknown；把它搬到
-独立线程池只能隔离线程，不能自动获得目标 drain 证明或重启恢复语义。
-
-### D13：`concurrency=1` 的收益与独立同步线程池取舍
-
-V1 首发维持 C1，不是为了提高同一 Group 的 Copy 吞吐，而是先验证生命周期契约。基于当前默认
-2 个 executor worker、migration worker budget 为 1，以及 136 MiB Copy 约 259～281 ms，可作如下
-对比：
-
-| 维度 | 当前同步路径（C1） | `/batch_sync` 独立线程池（C1） | 完整异步 V1（C1） |
-|---|---|---|---|
-| 同一 Group Copy 吞吐 | 受单次物理 Copy RT 限制 | 基本不变 | 基本不变 |
-| migration worker 占用 | 唯一 migration slot 被占约 259～281 ms | 仅提交到专用池，但专用线程持续阻塞 | 仅本地 handoff 时间 |
-| PACE client handle | 持有完整 Copy RT | 仍持有完整 Copy RT | submit/query 间可按 coordinator 设计复用或归还 |
-| Provider HTTP handler | 每个 URI pair 等待完整 Copy RT；C1、两个 item 时约占 `2/256` | 不变 | 不变；V1 只异步化 KVCM，未改 Provider |
-| `DataStorageManager` 生命周期锁 | 持有完整 backend 调用 | 若只搬线程仍然长持 | 仅取得 backend `shared_ptr` |
-| KVCM 重启后的远端 task 恢复 | 无 | 无；sync wrapper timeout 仍可能 outcome unknown | 有持久 guard + task IDs + query/cancel |
-| 安全提高到 C8/C16 的基础 | 无 | 只有线程隔离，没有目标生命周期和 bytes 反压 | 有，但仍需 PACE 容量验收 |
-
-因此，若系统长期只运行 C1～C2，独立同步线程池是更便宜的短期隔离措施；它不能解决远端任务重启
-恢复、ambiguous outcome、storage close 和目标安全回收。选择完整异步 V1 的理由是这些生命周期问题
-本身必须解决，并为后续并发扩展建立契约，而不是宣称 C1 下吞吐会提升。
-
-从 PACE 侧看，当前 C1 的主要故障表现也不是 HTTP 线程池耗尽，而是 Copy 吞吐小于热层写入吞吐后，
-KVCM slot 长期占用、下沉停滞和水位继续上升。只有多个 Group/caller 汇聚、unknown/quarantine 旧任务
-与新 active 任务重叠，或显著提高 concurrency 后，Provider handler/Meta worker 才可能成为优先问题。
-
-## 6. V1 总体架构
-
-```mermaid
-flowchart TD
-    R[Reclaimer / Admin MigrateCache]
-    M[MigrationManager]
-    A[Validate size + reserve credits]
-    G[Persist CLS_WRITING + Copy Guard]
-    E[SchedulePlanExecutor short admission]
-    B[TairMempoolBackend CopyCoordinator]
-    Q[Bounded local queue]
-    S[PACE Submit /copy_ga/batch]
-    P[Batch poll with backoff]
-    C[Completion promise]
-    O{Outcome}
-    V[CAS target SERVING]
-    D[Delete drained target]
-    U[Keep WRITING + Unknown quarantine]
-
-    R --> M --> A --> G --> E --> B --> Q --> S --> P --> C --> O
-    O -->|success + safe| V
-    O -->|failed/cancelled/timedout + safe| D
-    O -->|not safe / not found / ambiguous| U
-```
-
-一次正常迁移的顺序为：
-
-1. `MigrationManager` 严格解析全部 source URI 的正数 `size`，检查求和溢出，并取得 op/byte
-   reservation；失败时不分配目标、不写 metadata。
-2. 分配目标 URI，创建 `CLS_WRITING` Location，再以精确 CAS + `Sync` 安装 `kSubmitting` guard；guard
-   中记录 source 的精确 identity，供所有回收路径 fencing。
-3. `SchedulePlanExecutor` 调用 `DataStorageManager::CopyAsync()`；该调用只把已 reservation 的 operation
-   交给 backend 有界队列，立即返回最终 future，不执行远端 HTTP。
-4. Copy coordinator 获取 PACE client，向 `/copy_ga/batch` 提交，并严格校验 task ID 数量和顺序。
-5. 成功拿到 task IDs 后，按 operation_id 和目标 Location 身份条件更新 guard 为 `kActive`。
-6. coordinator 按批次轮询。每次响应必须保留 HTTP status、task state、outcome、terminal、drained 和
-   `safe_to_reuse_dst`，不能提前折叠成 `ErrorCode`。
-7. 所有 item 收敛后，coordinator exactly-once 完成 promise。
-8. `MigrationManager` 沿现有完成认领逻辑收尾；成功前再次确认 source 的
-   `location_id + create_time + CLS_SERVING`。
-9. 成功时原子地把目标从 `WRITING` 转为 `SERVING` 并清 guard；安全失败时删除目标；未知时保留 guard。
-
-## 7. KVCM 接口设计
-
-### 7.1 通用异步 Copy 结果
-
-当前在 `data_storage` 定义：
+| `MigrationManager` | admission、guard 状态机、credit、恢复和最终 metadata CAS |
+| `SchedulePlanExecutor` | 创建执行计划并完成短本地 handoff |
+| `DataStorageManager` | capability 检查、backend 转发和生命周期管理 |
+| async backend | submit/query/cancel、polling、响应校验和 exactly-once completion |
+| Reclaimer / GC | 直接读取持久 guard 并跳过受保护 Location |
+| Admin API | quarantine 只读查询和受审计的 break-glass |
+
+## 5. 正常执行流程
+
+一次异步迁移按以下顺序执行：
+
+1. 解析所有 source URI 的正数 `size`，校验 item 数量和总和溢出。
+2. 在任何外部副作用前申请 operation 和 byte reservation。
+3. 分配目标 URI，创建非 SERVING 的 `CLS_WRITING` Location。
+4. 通过精确 CAS 写入 `MCGS_SUBMITTING` guard，并执行 metadata durability barrier。
+5. executor 调用 `DataStorageManager::CopyAsync()` 完成本地 handoff。
+6. backend coordinator 向远端 submit，并通过独立 callback 返回 acceptance 和完整 task ID 集。
+7. KVCM 以 operation ID 和 guard state 为条件，把 guard 更新为 `MCGS_ACTIVE`。
+8. backend 按退避间隔 query；需要取消时发送 cancel intent，但继续 query。
+9. completion exactly once 返回逐 item 结果。
+10. `MigrationManager` 重新校验 source identity，并认领唯一终态 owner。
+11. 所有 item success+safe 时，原子地把目标改为 `CLS_SERVING` 并清 guard。
+12. 所有 item terminal+safe 但存在失败时，删除目标。
+13. 任一 item 不安全或结果不确定时，把 guard 改为 `MCGS_UNKNOWN` 并计入 quarantine。
+
+本地 queue 拒绝发生在远端 POST 前，可以安全回滚。POST 之后的任何不确定都必须保留目标。
+
+## 6. 通用异步接口
+
+### 6.1 结果模型
 
 ```cpp
 enum class AsyncCopyOutcome {
@@ -698,773 +224,507 @@ enum class AsyncCopyOutcome {
 };
 
 struct AsyncCopyItemResult {
-    AsyncCopyOutcome outcome = AsyncCopyOutcome::kUnknown;
-    bool terminal = false;
-    bool safe_to_reuse_dst = false;
-    ErrorCode error = EC_ERROR;  // only for diagnostics/metrics/backoff
+    AsyncCopyOutcome outcome;
+    ErrorCode error;                 // diagnostic only
+    bool terminal;
+    bool safe_to_reuse_dst;
     std::string backend_task_id;
     std::string detail;
 };
 
 struct AsyncCopyBatchResult {
-    ErrorCode status = EC_UNKNOWN;
+    ErrorCode status;
     std::vector<AsyncCopyItemResult> items;
     std::string detail;
 };
+```
 
-struct AsyncCopyRemoteSubmitResult {
-    ErrorCode status = EC_UNKNOWN;
-    bool accepted = false;
-    bool acceptance_unknown = false;
+Batch success 必须由逐 item 条件聚合，不能只读取 backend aggregate status。
+
+### 6.2 两阶段受理
+
+`CopyAsync()` 返回只表示 local handoff：
+
+```cpp
+struct AsyncCopySubmitResult {
+    ErrorCode status;
+    bool accepted;
+    bool acceptance_unknown;
     std::string operation_id;
     std::vector<std::string> backend_task_ids;
     std::string detail;
 };
+```
 
-struct AsyncCopySubmitResult {
-    ErrorCode status = EC_UNIMPLEMENTED;
-    bool accepted = false;  // 仅表示已交给本地 coordinator
-    bool acceptance_unknown = false;
-    std::string operation_id;
-    std::string detail;
+远端 acceptance 通过 `AsyncCopyRemoteSubmitCompletion` 独立返回。两者不能混淆：
+
+- local `accepted=true`：coordinator 接管了任务；
+- remote `accepted=true`：远端返回了完整 task ID 集；
+- `acceptance_unknown=true`：请求可能产生远端副作用，但没有权威 handle。
+
+### 6.3 Backend 能力
+
+```cpp
+class DataStorageBackend {
+public:
+    virtual bool SupportsAsyncCopy() const;
+
+    virtual AsyncCopySubmitResult CopyAsync(
+        const std::vector<DataStorageUri>& src,
+        const std::vector<DataStorageUri>& dst,
+        const std::string& operation_id,
+        const std::string& trace_id,
+        const AsyncCopyOptions& options,
+        AsyncCopyRemoteSubmitCompletion remote_submit_completion,
+        AsyncCopyCompletion completion);
+
+    virtual AsyncCopySubmitResult ResumeAsyncCopy(
+        const std::vector<std::string>& backend_task_ids,
+        size_t expected_items,
+        const std::string& operation_id,
+        const std::string& trace_id,
+        const AsyncCopyOptions& options,
+        AsyncCopyCompletion completion);
+
+    virtual ErrorCode RequestCancelAsyncCopy(
+        const std::string& operation_id);
 };
 ```
 
-Backend 接口：
+基类默认不支持异步。开源仓中的异步框架只有在具体 backend override
+`SupportsAsyncCopy()` 后才可达；`ASYNC_REQUIRED` 遇到不支持的 backend 必须明确失败，不能静默
+回退同步。
 
-```cpp
-virtual bool SupportsAsyncCopy() const { return false; }
+`ResumeAsyncCopy()` 只能重新 query 已有 task ID，绝不能发起第二次物理 Copy。
 
-virtual AsyncCopySubmitResult CopyAsync(
-    const std::vector<DataStorageUri>& src_uris,
-    const std::vector<DataStorageUri>& dst_uris,
-    const std::string& operation_id,
-    const std::string& trace_id,
-    const AsyncCopyOptions& options,
-    AsyncCopyRemoteSubmitCompletion remote_submit_completion,
-    AsyncCopyCompletion completion);
+### 6.4 DataStorageManager 生命周期
 
-virtual AsyncCopySubmitResult ResumeAsyncCopy(...);
-virtual ErrorCode RequestCancelAsyncCopy(const std::string& operation_id);
-```
+`DataStorageManager::CopyAsync()` 在锁内只查找并取得 backend `shared_ptr`，随后释放锁。远端
+submit 和 completion callback 持有该强引用，避免长时间持有 manager 锁。
 
-Group op/byte credits 由 `MigrationManager` 在分配目标前保留；backend 本地 queue admission 在
-`CopyAsync()` 内以 mutex 原子完成。`DataStorageManager::CopyAsync()` 只短暂持 manager shared lock 取得
-backend `shared_ptr`，然后把该 `shared_ptr` 捕获到 remote-submit 与 final completion callback 中作为
-生命周期 lease，不跨远端 HTTP 持有 manager lock。
+storage unregister/update 必须先确认没有 active 或 quarantined guard。存在引用时拒绝删除 backend
+配置，因为新 Leader 恢复需要相同 backend。进程 shutdown 可以 detach coordinator，但不能把未决
+任务合成为安全失败。
 
-`accepted=true` 只代表 KVCM 本地 coordinator 已接管 operation，不代表 PACE 已受理。PACE POST 的
-受理状态和 task IDs 通过独立 `remote_submit_completion` 返回，最终 terminal/drain 结果通过
-`completion` 返回；`SchedulePlanExecutor` 把这两路 callback 转成 Manager 现有 future 边界。每条路径
-必须 exactly-once 收敛，异常不得留下永久不 ready 的 future。
+## 7. 持久 Copy Guard
 
-`outcome + terminal + safe_to_reuse_dst` 是发布和回收判断的唯一语义输入。`ErrorCode` 只用于日志、
-metrics、重试/backoff 分类，禁止用 `EC_OK/EC_ERROR` 单独决定 promote、删除或 GA 复用。
+### 7.1 为什么放在 CacheLocation
 
-### 7.2 PaceServiceClient
+Guard 写入目标 `CacheLocation` JSON，因此：
 
-新增三个方法：
+- Reclaimer 和后台 GC 无需依赖 `MigrationManager` 内存表；
+- Leader 切换后仍能恢复；
+- guard 状态跃迁会改变 Location 的完整值，使 GC 在途的
+  `expected_location_values` 条件删除自动失效；
+- source identity 与目标生命周期绑定在同一权威记录中。
 
-```cpp
-SubmitBatchCopyGA(...);
-QueryBatchCopyGA(task_ids, ...);
-CancelBatchCopyGA(task_ids, ...);
-```
+旧二进制的逐字段反序列化可能擦除未知字段，因此产生过 guard 后不能直接回滚到不识别它的版本。
 
-HTTP helper 改为返回结构化结果：
+### 7.2 Guard 内容
 
-```cpp
-struct HttpResult {
-    CURLcode curl_code;
-    long http_status;
-    std::string body;
-};
-```
+`MigrationCopyGuard` 至少持久化：
 
-不能继续用当前 `bool HttpRequest()` 丢弃 HTTP 状态。异步安全判断至少需要区分：
+- schema version 和 operation ID；
+- guard state；
+- source `location_id + create_time + storage_name`；
+- target storage；
+- migration retention；
+- total bytes；
+- backend task IDs；
+- create/update time 和 last error。
 
-- 明确的接口拒绝；
-- 连接前失败；
-- request body 可能已经发送后的 timeout/reset；
-- 200 查询结果；
-- 404 task not found；
-- 429/503 反压；
-- 无法解析的响应。
+显式存在但 schema 非当前版本、状态未知或 operation ID 为空的 guard 必须解析失败，不能当成“无 guard”。
 
-任何无法证明“PACE 未产生 task”的 submit 失败都按 acceptance unknown 处理。
-
-Query 必须逐 item 解析，不能只依据 PACE batch response 的 aggregate `summary.failed`。当前 PACE 会把
-`not_found` 计入 failed summary，但对应 item 同时明确给出 `terminal=false`、`drained=false`、
-`safe_to_reuse_dst=false` 和 `outcome=unknown`；若只读取 aggregate，KVCM 会错误删除仍可能被写入的
-目标。
-
-### 7.3 TairMempoolBackend coordinator
-
-Coordinator 至少包含：
-
-- bounded admission queue；
-- operation_id 到 task IDs、输入下标和 promise 的映射；
-- 单独的 submit/query/cancel 执行资源；当前为一个 coordinator 线程；
-- inflight operation/bytes accounting；
-- exactly-once completion；
-- stop admission、cancel request 和 drain 协议；
-- polling backoff；
-- unknown quarantine 回调。
-
-PACE client handle 只按单次 submit/query/cancel HTTP 请求租用，请求返回后立即归还；poll backoff 和
-远端物理执行期间不得持续占有 handle，否则异步化只释放了 executor，没有释放 client pool 压力。
-
-当前 polling interval 来自 Group 配置，默认从 20 ms 逐步退避到 1000 ms；一次 operation 的 task IDs
-作为一个 batch query。poll jitter、跨 operation query 合并和显式 QPS limiter 尚未实现。由于当前只有
-一个 coordinator 线程，这些能力应与未来并发提升一起评估。
-
-### 7.4 DataStorageManager 和 backend 生命周期
-
-`DataStorageManager::CopyAsync()` 只在 `rw_lock_` 内查找并取得 backend 的 `shared_ptr`，随后释放锁。
-remote-submit 和 completion callback 捕获该强引用，直到 exactly-once completion。
-
-通用 `DataStorageBackend::Close()` 契约保持不变；lease、coordinator drain 和 cancel/query 逻辑只在
-`TairMempoolBackend::Close()` 内实现，避免 V1 把所有 backend 都拖入改造。现有
-`DataStorageManager::UnRegisterStorage()` 已经调用 backend `Close()` 并传播非 OK 结果。
-
-当前 `TairMempoolBackend::Close()` 语义为：
-
-1. 关闭新异步准入；
-2. 对尚未向 PACE 提交的任务明确失败并完成 promise；
-3. 对已经提交的任务发 cancel request，但不把 cancel ACK 当作 drained；
-4. 对已提交任务做一次 cancel/query 收敛；没有 drain 证明的任务通过 completion 转为 `kUnknown`；
-5. coordinator 清空并退出后 `Close()` 返回。
-
-普通 storage unregister/update 在调用 `Close()` 前先通过
-`MigrationManager::HasAsyncCopyStorageReference()` 检查 active/quarantine guard；存在引用时
-`UnRegisterStorage()` 返回 `EC_EXIST`，因此不会走进会把任务转 unknown 的 shutdown 路径。当前没有
-单独的 configurable close grace 或 `EC_BUSY`。
-
-进程 shutdown 与 storage unregister 必须区分：shutdown 可以在 guard 已持久化后销毁本进程 backend，
-因为 Registry 配置仍在，新 Leader 可重建 backend 并恢复；unregister/update 会删除恢复所需配置，
-所以有任意引用 guard 时必须拒绝。
-
-`RegistryManager::RemoveStorage()` 已调整为先成功 `UnRegisterStorage()`，再删除持久配置；如果存在
-active/quarantine 引用或 backend Close 失败，配置会保留。`UpdateStorage()` 复用 Remove + Add，继承
-该顺序。未来若引入长时间 close drain，可再增加更明确的 retryable busy error；V1 不修改通用 backend
-契约。
-
-## 8. 状态机与回收契约
-
-### 8.1 KVCM operation 状态
+### 7.3 状态机
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Submitting: persist guard before POST
-    Submitting --> Active: task_ids persisted
-    Submitting --> Unknown: acceptance ambiguous
-    Submitting --> SafeFailure: definite pre-POST handoff rejection
-    Active --> Cancelling: cancel requested
-    Active --> Success: all success + safe
-    Active --> SafeFailure: non-success + safe
-    Active --> Unknown: not_found / unknown_final / query ambiguity
-    Cancelling --> SafeFailure: cancelled/timedout + safe
-    Cancelling --> Unknown: no drain proof
-    Success --> [*]: promote and clear guard
-    SafeFailure --> [*]: delete target
-    Unknown --> Unknown: quarantine until explicit recovery
+    [*] --> SUBMITTING: guard persisted before POST
+    SUBMITTING --> ACTIVE: complete task IDs persisted
+    SUBMITTING --> DONE: definite rejection without remote side effect
+    SUBMITTING --> UNKNOWN: remote acceptance ambiguous
+    ACTIVE --> ACTIVE: pending or retryable query failure
+    ACTIVE --> CANCELLING: cancel intent persisted
+    CANCELLING --> CANCELLING: cancel ACK or task still pending
+    ACTIVE --> DONE: all items terminal and safe
+    CANCELLING --> DONE: all items terminal and safe
+    ACTIVE --> UNKNOWN: result cannot be proven safe
+    CANCELLING --> UNKNOWN: result cannot be proven safe
+    UNKNOWN --> UNKNOWN: automatic paths remain fenced
 ```
 
-持久 guard 与现有进程内状态的职责映射如下：
+`DONE` 不是持久 guard state。成功时目标 promote 与 clear guard 在一次条件更新中完成；安全失败时
+删除目标。内存 task 状态只负责调度，持久 guard 才是恢复和回收的权威。
 
-| 持久 `MigrationCopyGuardState` | 可能对应的内存 `CopyTaskState` | 权威职责 |
-|---|---|---|
-| `kSubmitting` | `kPreparing` / `kRunning` | POST 是否可能发生尚未形成可恢复 task IDs；跨重启必须保守隔离 |
-| `kActive` | `kRunning` | task IDs 已持久化，可重建轮询 operation |
-| `kCancelling` | `kPrepareCancelling` / `kCancelling` | 禁止 promote，等待 drain 证明 |
-| `kUnknown` | 可无对应内存 task | 远端最终状态不可证，必须持续 fencing/quarantine |
-| 无 guard | `kCompleting` 后完成，或无 active task | 只有 promote 或安全删除完成后才允许无 guard |
+所有 guard 跃迁必须同时校验：
 
-持久 guard 决定恢复与回收权限；内存状态只决定当前进程中谁负责 prepare、cancel 和 completion，仍应在
-Stop 时清空，避免 stale active table 永久阻塞回收。正常运行中，每次会改变回收权限的内存跃迁都必须先
-或原子地落到 guard；若两者不一致，选择更保守的 guard 语义并告警。新 Leader 只从 guard 重建内存态，
-不能反向用空内存表清除 guard。
+- operation ID；
+- expected guard state；
+- 目标 Location identity/value。
 
-### 8.2 失败矩阵
+这样 cancel、completion 和恢复线程不能互相覆盖状态。若 CAS 已生效但 durability barrier 超时，只能
+重试 barrier，不能重复 CAS、Copy、删除或 quarantine。
 
-| 场景 | KVCM 判断 | target | source | 是否自动重试 |
-|---|---|---|---|---|
-| Group active/byte credit 拒绝 | definite failure | 未分配 | 保留 | 可新建 operation |
-| 目标已分配但 guard 未发布，且确认未发 POST | definite failure | 回滚删除 | 保留 | 可新建 operation |
-| guard 已发布但 coordinator handoff 明确失败，且确认未发 POST | definite failure | 条件删除 guard/目标 | 保留 | 可新建 operation |
-| PACE 明确在建 task 前拒绝整个 batch | definite failure | 删除 | 保留 | 受 backoff 控制 |
-| submit transport timeout/reset | acceptance unknown | quarantine | 保留并由 target guard 精确引用保护 | 否 |
-| task pending/linking/copying/draining | running | 保持 WRITING 并由 guard fencing | 由 target guard 的精确引用保护 | 否 |
-| 全部 success，terminal + safe | success | promote SERVING | 按 retention | 不需要 |
-| failed，terminal + safe | safe failure | 删除 | 保留 | 按错误分类/backoff |
-| cancelled/timed_out，terminal + safe | safe cancellation | 删除 | 保留 | 由上层决定 |
-| `unknown_final` | unknown | quarantine | 保留 | 否 |
-| query `not_found` | unknown | quarantine | 保留 | 否 |
-| KVCM deadline 到期但 PACE 未终态 | cancelling/unknown | cancel 后继续 query；无 drain 则 quarantine | 保留 | 否 |
-| KVCM 重启，guard 有 task IDs | recoverable | 恢复 query | 从 guard 恢复精确引用保护 | 否 |
-| KVCM 重启，guard 仅为 Submitting | unknown | quarantine | 从 guard 恢复精确引用保护 | 否 |
-| PACE Meta/Provider 重启导致状态丢失 | unknown | quarantine | 保留 | 否 |
+## 8. 结果与失败语义
 
-### 8.3 多 item batch 语义
+### 8.1 Operation 聚合
 
-一个目标 `CacheLocation` 的全部 `location_specs` 是统一发布单元。只有所有 item 都 success + safe 才能
-promote。任一 item 失败时：
+| 逐 item 结果 | Operation 动作 |
+|---|---|
+| 全部 success + terminal + safe | promote 目标 |
+| 全部 terminal + safe，至少一个非 success | Copy 失败并删除目标 |
+| 任一非 terminal 或 safe=false | 继续 query；到 deadline 后 cancel，再无法确认则 quarantine |
+| `not_found` / `unknown` | quarantine |
+| HTTP/解析错误 | 保持原状态并退避重试 |
+| item 数量、顺序或 task ID 不匹配 | unknown，不能部分采信 |
 
-- 如果所有已受理 item 都已经 terminal + safe，可以删除整个目标；
-- 如果存在任一 unknown/non-drained item，整个目标进入 quarantine；
-- 不允许只发布成功的部分 spec；
-- result 数量与输入数量不一致按 unknown 处理，不能越界合并或视为普通失败。
+一个 Location 内的多 item 采用全有或全无语义。V1 不做部分发布或部分清理。
 
-这同时要求修复当前 `TairMempoolBackend::Copy()` 在 `batch_results` 短于 `valid_indices` 时直接按下标
-合并的防御性缺口。
+### 8.2 Submit ambiguity
 
-## 9. Cancel、shutdown、切主与恢复
+只有能证明 POST 没有产生远端副作用时，才允许安全回滚，例如本地参数校验失败或 local admission
+拒绝。
 
-### 9.1 Cancel
+以下情况必须按 acceptance unknown：
 
-用户取消的含义是“不再 publish 目标”，不承诺立即中止 Provider 的物理搬运：
+- request 可能已经写出后发生 timeout/reset；
+- response body 丢失或无法完整解析；
+- task ID 数量不足、为空或重复；
+- transport 未完整结束，即使缓冲区中存在看似可解析的 error body。
 
-1. guard 转为 `kCancelling`；
-2. coordinator 调用 PACE cancel；
-3. 即使后续收到 success，也不 promote；
-4. 继续查询直到 `safe_to_reuse_dst=true` 后删除目标；
-5. deadline 内没有 drain 证明则转 `kUnknown`。
+当前协议没有 caller-provided idempotency key，因此上述情况不能自动重发。
 
-Cancel 与 completion 共享同一个 operation 粒度 transition mutex。两者竞争时只有一个路径能从当前
-guard state 认领终态：若 Cancel 已先把 guard 持久化为 `kCancelling`，迟到 success 只能按 cancelling
-语义收尾，禁止 promote；若 completion 已认领终态，Cancel 不得再次释放 credit、改写 guard 或创建
-quarantine。operation credit 由 operation ID ledger 保证最多释放/转 quarantine 一次。
+### 8.3 Query 与 cancel
 
-### 9.2 KVCM 停止和 HA 切主
+Query 必须逐项校验 task identity。HTTP 404 或 task `not_found` 只表示当前 registry 找不到记录，
+不表示目标已经 drained。
 
-当前有序停止顺序为：
+Cancel 只表达意图：
 
-1. 关闭新的 migration admission；
-2. lifecycle barrier 等待已经进入 prepare/enqueue 的提交返回；
-3. 停止 monitor；
-4. 把仍 active 的原生异步 guard 转为 `kUnknown` 并计入 quarantine；
-5. 清空进程内 active table；后续 backend Close 会停止 coordinator，已提交但没有 drain 证明的任务
-   继续按 unknown 收敛。
+- `EC_OK` 表示 coordinator 接受 cancel request；
+- cancel ACK 不是 terminal 证明；
+- cancel 后继续 query；
+- 如果迟到结果为 success+safe，允许 success 胜出。
 
-因此当前“有序 Stop”是 fail-closed 停机，不承诺把 active task 无缝交给下一 Leader；它会主动降级为
-UNKNOWN quarantine。只有进程崩溃、旧 Leader 未执行 Stop，且持久 guard 已是 `kActive/kCancelling`、
-task IDs 完整时，新 Leader 才能重新 attach 到 PACE task。若 HA 切主要求无 quarantine 的平滑交接，
-需要在未来增加有界 drain/lease handoff，而不能宣称 V1 已具备。
+Cancel 与 completion 共享唯一终态 owner，credit 只能释放或转 quarantine 一次。
 
-新 Leader 启动时：
+### 8.4 Timeout
 
-1. 暂停 Reclaimer、后台 GC 和新的 migration submit；
-2. 扫描带 `migration_copy_guard` 的 WRITING Location；
-3. 重建 operation 表和 quarantine accounting；回收路径从 target guard 恢复精确 source/target fencing；
-4. `kActive/kCancelling` 且有 task IDs 的 operation 继续 query；
-5. `kSubmitting/kUnknown` 保持 quarantine；
-6. recovery barrier 完成后再启动 Reclaimer 和 GC。
+四类时间彼此独立：
 
-恢复逻辑属于持久 guard 的安全解释器，不受 async submit feature gate 控制：即使配置已切回 `SYNC`，
-只要旧 guard 仍可能存在就必须执行。当前扫描采用每批 256 条、批间暂停 2 ms、整轮最长 5 分钟的有界
-策略；先完成全量扫描、形状校验、operation 去重和 group/instance/backend 校验，再一次性替换内存
-inflight/quarantine accounting，避免半轮失败留下“看似恢复完成”的局部状态。当前 Meta maintenance
-接口不支持按 guard/status 服务端过滤，所以仍是一次全量扫描；后续若规模证明不可接受，应新增持久
-guard 索引，而不是提供跳过恢复的开关。
+| 时间 | 语义 |
+|---|---|
+| connect timeout | 单次控制请求建立连接的预算 |
+| submit timeout | 单次 submit HTTP 总预算 |
+| query timeout | 单次 query/cancel HTTP 总预算 |
+| operation deadline | KVCM 自动跟踪正常完成的总预算 |
 
-扫描、全量校验或 Manager 启动任一关键阶段失败时，节点不能持有 Leader lease 却永久关闭 leader-only
-API。当前 Server 会禁用 leader-only 请求、主动 demote，并把下一次 campaign 至少推迟 5 秒，让其它
-节点接管或在外部依赖恢复后重试。单个已有 task 无法 attach 时则 fail-closed 转 quarantine，不阻断其它
-guard 的恢复。backend 的瞬时 `Available()==false` 不能被当成 task 不存在；Manager 仍调用
-`ResumeAsyncCopy()`，由 backend query 返回权威的 running/terminal/unknown 结果。
+任一 timeout 都不是 drain 证明。Query timeout 只影响本轮 poll；operation deadline 到期后请求 cancel，
+若仍无安全终态则 quarantine。
 
-### 9.3 Reclaimer 和 GC
+## 9. 恢复、关闭与回收
 
-以下 Location 绝不能作为普通 orphan 删除：
+### 9.1 Leader 恢复
 
-- 带非终止 `migration_copy_guard` 的目标；
-- 带 `kUnknown` guard 的 quarantine 目标；
-- 被同一 block 任一 target guard 引用的 source `location_id + create_time`。
+新 Leader 在开放 leader-only 请求和启动 Reclaimer/GC 前扫描 guarded Location：
 
-两条回收路径都必须在候选生成阶段直接读取 guard：
+1. 有界分页扫描全部 Instance；
+2. 校验 guard schema、identity、bytes 和 Group 配置；
+3. 重建 active/quarantine operation 与 byte accounting；
+4. 对 `ACTIVE/CANCELLING` 且 task ID 完整的记录调用 `ResumeAsyncCopy()`；
+5. 无法恢复的记录转为 `UNKNOWN`，保持 fence；
+6. 全部扫描和校验成功后一次性发布恢复结果。
 
-| 路径 | 改造前保护 | 当前 V1 保护 |
-|---|---|---|
-| Reclaimer | `HasActiveCopyTargetLocation()` 内存 hook | guard 存在且未安全终止时直接跳过；内存 hook 仅作快速路径 |
-| 后台 GC | orphan 年龄 + 同一内存 hook | `IsOrphanWriting()`/候选生成显式排除 guard，不得仅凭 24h 年龄删除 |
+恢复失败不能发布部分 accounting，也不能让节点持有 Leader lease 却不提供服务；服务端应主动 demote
+并由其他节点重试。
 
-普通 `SchedulePlanExecutor` metadata 删除也执行同样检查：跳过 guarded target，以及 target guard 指向的
-精确 source，并使用完整序列化 Location value 做条件删除。第 D9 节记录的“guard 建立前已经准入的旧
-source CAS”仍是已知窗口，不能由本节检查推导出跨 Location 原子性。
+Backend 暂时 unavailable 与 backend 不存在语义不同。恢复已有 task 时仍应尝试 query，不能因为一次
+availability probe 失败就丢失恢复路径。
 
-后台 GC 的 `expected_location_values` 条件删除继续保留：guard 在扫描后发生任意状态跃迁时，旧 expected
-value 必须返回 mismatch。该机制是并发安全网，不是 guard fencing 的替代品。V1 不允许仅凭 guard 年龄、
-KVCM deadline 或 PACE task retention 自动解除 quarantine。
+### 9.2 Shutdown 与 storage close
 
-### 9.4 Quarantine 运维出口
+受控 shutdown 的顺序是：
 
-当前 V1 已提供 HTTP/gRPC 两个最小接口：
+1. 停止新 leader-only 请求；
+2. 停止 Reclaimer/GC；
+3. 停止 MigrationManager 接受新 operation；
+4. detach 已持久化 task ID 的 backend job；
+5. 由新 Leader 从 guard 重新接管。
 
-1. 按 Instance Group/operation 列出 guard，展示 source/target、task IDs、字节数、状态、年龄和最后一次
-   query 结果；
-2. 对 `kUnknown` guard 执行 break-glass release；请求必须携带非空 operator 和外部 fencing evidence，
-   服务端以 operation ID/state 做精确 CAS，并写 error 级审计日志；
-3. 不提供“仅按年龄批量删除”命令。
+已经提交且 task ID 已持久化的 job 不应在 Close 时逐个串行 cancel，也不应被批量标成
+`UNKNOWN`。仍处于 `SUBMITTING` 且没有 task ID 的 operation 必须 fail-closed。
 
-当前**没有**手工 reconcile、普通 safe-release 或服务端自动验证外部证据的能力。对永远无法获得 drain
-证明的记录，break-glass 的调用者必须先取得外部 fencing 证据，例如所有相关旧
-   Provider incarnation 已永久停止且目标 storage/segment generation 已失效，能够证明旧 operation
-   不可能在恢复后继续写。接口中的 evidence 字符串是审计材料，不是由 KVCM 验证出的安全证明。
+### 9.3 Reclaimer 与后台 GC
 
-“人工确认”本身不是安全证明。没有外部 fencing 时只能查看并继续 quarantine。手工 reconcile 与取得
-`terminal && safe_to_reuse_dst` 后的普通安全释放，仍应作为生产上线前的运维增强补齐。
+两条路径的 fencing 机制不同：
+
+| 路径 | Fence 来源 |
+|---|---|
+| Reclaimer | 读取目标 guard，并保护 target 与精确 source identity |
+| 后台 GC | 直接读取 Location JSON 中的 guard |
+
+GC 不能仅凭 `CLS_WRITING` 年龄删除 guarded target。Guard 状态变化后，旧
+`expected_location_values` 应使条件删除失败。
+
+### 9.4 Quarantine
+
+`MCGS_UNKNOWN` 表示 KVCM 无法证明目标可回收：
+
+- source 保持可服务；
+- target 保持非 SERVING；
+- operation/bytes 计入 quarantine；
+- 自动路径不再 submit 同一目标；
+- 容量达到 gate 后停止新的异步 Copy，但允许已有任务继续收敛。
+
+最小运维接口包括：
+
+- 按 Instance Group 列出 quarantine；
+- 查看 operation、task IDs、source/target、bytes 和最后错误；
+- 只有取得独立外部 fencing 证明后，才允许受审计的 break-glass release。
+
+Break-glass 不是自动恢复策略。按年龄、重试次数或人工点击本身都不能构成 drain 证明。
+
+### 9.5 二进制回滚
+
+关闭异步模式不会清除已有 guard。回滚到不识别 guard 的二进制前必须：
+
+1. 停止新异步 submit；
+2. 等待 active operation 收敛；
+3. 处理全部 quarantine；
+4. 扫描确认全局 guard count 为 0；
+5. 再执行 binary rollback。
 
 ## 10. 反压与调度
 
-### 10.1 为什么不能只限制 task 数
+### 10.1 Credit
 
-4 MiB、68 MiB 和 136 MiB 在当前接口中都算一个 Copy task，但其资源成本相差 17～34 倍。只使用
-`copy_max_concurrency` 会让配置对真实 IO 压力失真。
-
-当前 V1 实际维护以下 accounting/gate：
+仅限制 `copy_max_concurrency` 不足以约束大 block。V1 同时维护：
 
 ```text
-group_active_copy_ops        // 复用 copy_max_concurrency
-group_inflight_bytes
-group_quarantine_ops
-group_quarantine_bytes
-backend_process_operations   // 固定上限 1024
+active_operations
+active_bytes
+quarantine_operations
+quarantine_bytes
 ```
 
-尚未实现独立的 process queued bytes/inflight bytes、poll QPS limiter 或可配置 backend queue limit。
-
-字节口径使用 operation 中所有 source URI 的 `size` 之和。当前
-`MigrationManager::PrepareCopyTask()`/batch prepare 把 `spec_size` 初始化为 0 后调用返回 `void` 的
-`StandardUri::GetParamAs()`；参数缺失或解析失败会静默保留 0。`MetaSearcher::BatchAddLocation()` 还有
-`spec_sz` 未初始化后参与累加的现存风险。Phase A 必须先统一修正这些路径：
-
-- 每个 source URI 必须包含可完整解析的正整数 `size`；
-- 同时校验 `CacheLocation::spec_size == location_specs.size()`，并逐个验证每个 spec URI 的 size；
-- 求和必须检查 `uint64_t` 溢出及 `size_t` 截断；
-- 缺失、非法、为 0、溢出一律在 reservation 前返回 `EC_BADARGS` 或等价明确错误；
-- 不允许按 0 绕过，也不使用“保守最大值”继续分配，因为这会让 credit 和实际目标容量产生不可解释的
-  偏差。
-
-准确 bytes 校验完成后才取得 Group active/byte reservation；reservation 失败必须是零 GA、零 metadata
-副作用。
-
-### 10.2 初始部署参数
-
-首轮参数原则：
-
-- `copy_max_concurrency=1`；
-- `copy_max_inflight_bytes` 至少覆盖一个最大业务 block，但只允许一个 136 MiB operation 在途；
-- 通过 Group concurrency/bytes 把正常 backlog 保持在很小范围；backend 固定 1024 上限只是最终
-  fail-safe，不能把 1024 当成目标排队深度；
-- polling 使用退避，不采用 PACE sync wrapper 的 1 ms 高频轮询；
-- 提高并发前必须完成第 13 节的 68/136 MiB 并发矩阵。
-
-文档不固化 512 MiB 或 1 GiB 等生产值；最终值必须根据最大 block、Provider 数、SSD/网络吞吐和前台
-延迟验收确定。配置必须记录当时最大 block 假设。
-
-### 10.3 无进展退避与当前容量 gate
-
-当普通 byte/op credit 用尽或 backend queue 拒绝时，Reclaimer 本轮视为无进展并按正常周期退避。
-不能因为水位仍超阈值就零间隔持续 submit。
-
-quarantine 与普通 credit 不同：当前达到 `copy_max_quarantine_operations/bytes` 后，
-`ReserveAsyncCopyCredit()` 会硬拒绝受影响 Group 的新异步 operation；已有 query/cancel/completion 不受
-影响。安全释放使 accounting 回到阈值以下后，准入自动恢复。
-
-这只是基于当前隔离容量的硬 gate，并非持久 circuit breaker：窗口 unknown 比例、连续 unknown、
-`opened_at/reason` 持久化、PACE health probe、显式 reset 和 half-open 均未实现。在这些能力补齐前，
-不能声称“错误风暴即使尚未耗尽 quarantine 配额也会被主动熔断”；生产参数应把 quarantine 上限设成
-可承受的保守值，并对 unknown 增量告警。
-
-### 10.4 PACE task registry 容量
-
-Meta 默认最多保留 100,000 个 Copy task，terminal 记录从终态发布后继续保留 30 分钟。稳态近似为：
+推荐准入顺序：
 
 ```text
-retained_terminal_task_records ~= terminal_item_completion_rate_per_second * 1800
+validate source sizes
+  -> reserve operation and byte credits
+  -> allocate destination
+  -> persist SUBMITTING guard
+  -> local backend handoff
+  -> remote submit
 ```
 
-例如 68 MiB 单 item 在 127～139 ms、并发 8 且完全跑满时，理想完成率约 58～63 item/s，对应约
-104k～113k 条 30 分钟保留记录，已经可能超过默认上限；真实 operation 若包含多个 item，还要按 item
-数放大。因此提高并发前必须同时核算 registry 容量、终态保留时长和全体调用方流量，不能只看 SSD
-吞吐。
+size 缺失、非法、为 0 或求和溢出时必须在副作用前拒绝。Operation 从 active 转 quarantine 时，credit
+转移必须原子，不能先释放 active 再增加 quarantine。
 
-PACE batch submit 在发布 task 前原子检查容量；如果 KVCM 收到并成功解析明确的“registry capacity
-不足”响应，这是没有发布该 batch task 的 definite rejection，可以安全回滚尚未提交的目标。若 HTTP
-响应丢失、timeout 或无法解析，仍按 acceptance unknown，不得把后续 `not_found` 当成未受理证明。
+### 10.2 Coordinator
 
-### 10.5 Metadata 写放大
+Backend coordinator 应具备：
 
-异步 guard 会增加条件 metadata 写，必须在提高并发前量化：
+- 有界 local queue；
+- operation ID 到 task ID 的映射；
+- polling backoff；
+- 批量/分片 query；
+- exactly-once callback；
+- stop admission 和 graceful detach。
 
-| 路径 | 正常 happy path 的 Location mutation |
-|---|---:|
-| 当前同步 Copy | 2 次：新增 WRITING；最终 CAS 为 SERVING |
-| 异步 Copy | 3 次：新增 WRITING+Submitting；持久化 task IDs/Active；最终 CAS 为 SERVING 并清 guard |
+一个 coordinator 线程串行发送同步 HTTP 时，最坏轮询时间会随 operation 数增长。Backend 应合并同一
+轮到期 task，限制 query URL 长度，并让实际 admission 与
+`operation_deadline / query_timeout` 的可处理规模匹配。提高 Copy 并发前必须验证 queue wait、poll
+周期和 timeout 比例。
 
-因此 happy path 不是笼统的“2 倍 + N”，而是从 2 次增至 3 次，约 1.5 倍。cancel、Unknown、恢复和人工
-reconcile 只在状态真实跃迁时增加写；纯 polling 不得每轮刷新 `updated_at_ms` 或重写相同 guard，否则
-高频 query 会把控制面读放大变成 metadata 写风暴。压测必须单独统计 guard transition write QPS、CAS
-mismatch 和 meta backend P99。
+### 10.3 失败源退避
 
-## 11. 配置与兼容性
-
-当前 migration config 已增加：
-
-| 配置 | 含义 | 当前校验/默认值 |
-|---|---|---|
-| `copy_execution_mode` | `SYNC` / `ASYNC_REQUIRED` | 默认 `SYNC` |
-| `copy_max_inflight_bytes` | Group 在途 Copy 字节上限 | 异步模式必须显式为正数 |
-| `copy_max_quarantine_operations` | Group 隔离 operation 容量 gate | 异步模式必须显式为正数 |
-| `copy_max_quarantine_bytes` | Group 隔离目标字节容量 gate | 异步模式必须显式为正数 |
-| `copy_operation_deadline_ms` | KVCM 自动对账上限 | 默认 600000 ms；不能授权回收 |
-| `copy_poll_initial_interval_ms` | 首次/初始 query interval | 默认 20 ms |
-| `copy_poll_max_interval_ms` | polling 退避上限 | 默认 1000 ms，必须小于 deadline |
-
-以下配置尚不存在，不能写入部署配置假定它们生效：可配置 queued operations/bytes、
-`copy_shutdown_grace_ms`、unknown rate window/min samples/max rate、连续 unknown 阈值、breaker recovery
-ratio 和显式 reset。backend operation 上限当前是代码内固定的 1024。
-
-deadline/retention 的配置约束为：
+`node not found` 等失败不应让 Reclaimer 持续选择同一旧 source。同步和异步路径共用
+`MigrationManager` 的进程内失败记录，key 为：
 
 ```text
-normal_copy_P99 + queue_retry_poll_margin < copy_operation_deadline_ms
-max_expected_KVCM_recovery_outage + copy_poll_max_interval_ms
-    < PACE_terminal_retention_ms
-PACE_reconcile_timeout_ms < Provider_status_TTL_ms
+(instance_id, block_key, source_location_id,
+ source_create_time, target_storage_name)
 ```
 
-其中 terminal retention 从终态发布开始计时，不能把
-`copy_operation_deadline_ms < PACE_terminal_retention_ms` 当成充分或必要条件。配置校验无法证明外部
-PACE 参数时至少告警并输出两侧实际值。
+失败后使用有上限的指数退避；存在其他完整副本时优先换源，所有候选都在 backoff 时本轮不分配目标、
+不 submit。由于 backend 错误分类仍可能不够精确，V1 不据此自动删除 source，也不持久化“永久失效”
+结论。
 
-兼容规则：
+## 11. 配置
 
-- 配置缺失时保持同步行为；
-- `ASYNC_REQUIRED` 遇到不支持异步的 backend 必须拒绝并告警；
-- 旧节点仍可能成为 Leader 时不得开启异步；
-- 关闭异步 feature 不清理既有 guard；恢复逻辑必须始终编译并运行；
-- 回滚到不识别 guard 的旧二进制前，必须通过全局 `guard_count == 0` 运维 gate；当前没有单独的
-  rollback-gate API，需要先扫描/list 确认所有实例无 guard；
-- `operation_deadline` 只停止自动控制面对账，不代表目标安全。
+### 11.1 MigrationConfig
+
+| 字段 | 默认值 | 说明 |
+|---|---:|---|
+| `copy_execution_mode` | `SYNC` | `SYNC` / `ASYNC_REQUIRED` |
+| `copy_max_concurrency` | 1 | Group Copy operation 并发 |
+| `copy_max_inflight_bytes` | 0 | 异步模式必须显式为正 |
+| `copy_max_quarantine_operations` | 0 | 异步模式必须显式为正 |
+| `copy_max_quarantine_bytes` | 0 | 异步模式必须显式为正 |
+| `copy_operation_deadline_ms` | 600000 | 自动跟踪总预算 |
+| `copy_poll_initial_interval_ms` | 20 | 初始 poll 间隔 |
+| `copy_poll_max_interval_ms` | 1000 | 最大 poll 间隔 |
+| `copy_connect_timeout_ms` | 1000 | 建连预算 |
+| `copy_submit_timeout_ms` | 3000 | submit 总预算 |
+| `copy_query_timeout_ms` | 3000 | query/cancel 总预算 |
+
+### 11.2 校验约束
+
+```text
+0 < poll_initial <= poll_max < operation_deadline
+0 < connect <= submit < operation_deadline
+0 < connect <= query < operation_deadline
+16 * max(submit, query) <= operation_deadline
+```
+
+`ASYNC_REQUIRED` 还要求三个容量 gate 都为正。配置校验保证单次控制请求不会吃掉大部分 operation
+deadline，但不能替代部署容量评估。
+
+外部协议还需要满足：
+
+```text
+normal_copy_P99 + queue_and_poll_margin < operation_deadline
+max_expected_leader_outage + poll_max
+    < remote_terminal_record_retention
+```
+
+远端 terminal retention 从任务终态发布开始计时，不能简单用
+`operation_deadline < retention` 代替完整约束。
+
+Storage 自身的 `timeout` 继续控制 Create/Delete/health 和同步 Copy 等旧调用；三个 async HTTP timeout
+只作用于异步控制请求，不应通过全局下调 storage timeout 来替代。
 
 ## 12. 可观测性
 
-当前实现提供两层观测：
+### 12.1 当前核心指标
 
-| 当前观测 | 说明 |
-|---|---|
-| `MigrationStats.async_copy_unknown` | 本进程累计进入 unknown 的异步 operation |
-| `MigrationStats.async_copy_inflight_operations/bytes` | 当前 Group 汇总后的在途数量/字节 |
-| `MigrationStats.async_copy_quarantine_operations/bytes` | 当前恢复/运行时重建的隔离数量/字节 |
-| `MigrationStats.source_*` | 失败源登记、抑制、换源、无可用源和当前 entry 数 |
-| `migration.source_failures_recorded_total` 等低基数指标 | 失败源修复的 registry counter/gauge |
-| quarantine list API | 逐 operation 查看持久 guard、task IDs、字节和错误 |
+- active operation/bytes；
+- quarantine operation/bytes；
+- async unknown 累计数；
+- source failure recorded/suppressed/alternate-selected/no-eligible-source；
+- 当前 source failure entry 数；
+- quarantine list API。
 
-以下细分指标仍是后续工作：本地 handoff/queue wait、PACE submit RT、远端 execution/end-to-end RT、
-poll QPS/result、task-not-found、按状态 guard 数、guard transition/CAS mismatch、recovery/cancel 分类，以及
-持久 breaker 状态。当前代码没有 `migration.copy_circuit_breaker_*`，不能以不存在的指标作为上线 gate。
+### 12.2 日志字段
 
-日志统一携带：
+状态转换日志至少包含：
 
 ```text
 instance_group, instance_id, block_key, operation_id,
-source_location_id, target_location_id,
-pace_task_ids, bytes, state, terminal, safe_to_reuse_dst, trace_id
+source_location_id, source_create_time, target_location_id,
+backend_task_ids, bytes, guard_state, outcome,
+terminal, safe_to_reuse_dst, trace_id
 ```
 
-不得把 PACE submit RT 当作 Copy RT。端到端分析继续区分：本地 queue、submit、PACE execution、poll
-收敛和 KVCM promote/delete。Provider `write_remote_us` 仍是物理数据路径的主要指标。
-
-## 13. 测试与验收
-
-### 13.1 设计验收清单
-
-下列条目是完整验收清单，不等同于“全部已经自动化”。已落地的核心路径由 13.2 列出的开源仓测试和
-内源下游 adapter 测试分别覆盖；
-标为未来的条目不得作为当前 V1 能力声明。
-
-1. `CopyAsync()` 本地准入成功后立即返回，不等待模拟远端 completion。
-2. Group byte/op reservation 拒绝时不分配 GA、不写 metadata、不发 PACE 请求；backend 本地 handoff
-   拒绝发生在 guard 后，但必须证明未 POST，并安全回滚而不是进入 remote UNKNOWN。
-3. submit task ID 数量或类型错误按 unknown 收敛，不越界合并。
-4. success 但 `safe_to_reuse_dst=false` 不 promote。
-5. failed/cancelled/timedout 但未 drained 不删除目标。
-6. `not_found` 和 transport ambiguity 创建/保留 `kUnknown` guard。
-7. promise 在成功、异常、stop 和 cancel 所有路径 exactly-once 完成。
-8. target guard 与精确 source identity 使用 Instance 隔离及 location create_time；另做已准入 source CAS
-   窄竞态故障注入。
-9. 清空 `MigrationManager` active table 后，guarded WRITING 仍分别被 Reclaimer 和 GC 直接排除。
-10. GC 扫描后 guard 状态跃迁会使 `expected_location_values` 条件删除返回 mismatch。
-11. source URI `size` 缺失、非法、为 0、求和溢出，或 `spec_size` 与 specs 数量不一致时，在任何副作用
-    前拒绝。
-12. quarantine 达到 ops/bytes 阈值后硬停新 submit，已有 query/completion 仍可收敛；unknown rate
-    breaker 为未来工作。
-13. storage unregister 在 active/quarantine operation 存在时返回 `EC_EXIST`；backend close 失败时持久
-    storage 配置不能先被删除。
-14. `ErrorCode` 与 `AsyncCopyOutcome` 冲突时，回收判断只服从 outcome/terminal/safe 三元组。
-15. binary rollback 前通过扫描/list 验证 guard 为零；专用自动 gate 为未来工作。
-16. 新版本所有 Location read-modify-write/序列化路径都完整保留 guard 和 `schema_version`；未知 guard
-    schema 必须 fail-closed。
-17. breaker 打开状态跨进程重启保持，并在低水位、PACE probe 和显式 reset 后关闭（未来工作）。
-18. Cancel 与 completion 并发时只有一个终态 owner，credit 只释放或转 quarantine 一次，迟到 success
-    不得越过已经持久化的 `kCancelling` promote。
-19. 终态 CAS 已生效而 `Sync()` 首次失败时，只重试 durability barrier；不得重复 CAS、Copy、清理或
-    生成 phantom quarantine。
-20. Leader recovery 能从持久 guard 重建 active/quarantine accounting；扫描准备、全量校验或 attach
-    任一失败都不得发布部分 accounting，Server 必须 demote 而不是持租约 wedge。
-21. backend 暂时 `Available()==false` 时，恢复路径仍调用 `ResumeAsyncCopy()` 查询已有 task，不能直接
-    合成为 `EC_NOENT`/unknown。
-
-### 13.2 202 Linux 编译与定向单测结果
-
-验证必须遵循 `integration_test/tiered_storage` 的流程，只在 202 测试机的隔离容器源码目录执行，
-**不在 macOS 本机编译**。2026-08-25 已在独立验证目录
-`/flash/airfan-validation/kvcm-async-copy-review-20260825-r1/` 完成本轮重跑；同步到 202 的 14 个改动
-文件均先与本地逐文件核对 SHA-256，容器内仅对改动行执行 clang-format，格式结果再用 patch 回写本地。
-
-验证分为两个彼此独立的组合：
-
-1. 开源仓 `stub_source -> open_source`：验证通用 async framework、manager/meta/service 修正和同步
-   fallback；主二进制构建完成 1488 个 action，随后 8 个定向测试目标全部通过。
-2. 内源 `stub_source -> internal_source@8cac0396`：该源码快照的 adapter 关键文件与 202 容器逐文件
-   SHA-256 一致；验证真正可达的 PACE async adapter，并再次构建生产形态主二进制。202 隔离容器没有
-   公司 Git SSH 私钥，因此构建仅通过 `--override_repository` 复用 202 当天已有的只读依赖快照；没有
-   修改 WORKSPACE、产品源码或依赖版本。
-
-开源仓 in-tree 验证目标：
-
-```text
-//kv_cache_manager:kv_cache_manager_bin                                     PASS (build)
-//kv_cache_manager/data_storage/test:DataStorageManagerTest                 PASS
-//kv_cache_manager/meta/test:meta_dummy_backend_test                        PASS
-//kv_cache_manager/manager/test:MetaSearcherTest                            PASS
-//kv_cache_manager/manager/test:SchedulePlanExecutorTest                    PASS
-//kv_cache_manager/manager/test:MigrationManagerTest                        PASS
-//kv_cache_manager/manager/test:CacheReclaimerTest                          PASS
-//kv_cache_manager/manager/test:CacheGarbageCollectorTest                   PASS
-//kv_cache_manager/service/test:AdminServiceImplTest                        PASS
-```
-
-内源下游 adapter 验证目标（不属于本开源仓源码树）：
-
-```text
-//stub_source/kv_cache_manager/data_storage/test:TairMempoolAsyncBackendTest PASS (1/1)
-//kv_cache_manager:kv_cache_manager_bin                                     PASS (internal production build)
-```
-
-其中 `MigrationManagerTest` 额外覆盖 `UNKNOWN` guard 的 break-glass 精确 CAS、quarantine
-计量释放及缺失 operation/证据拒绝；`AdminServiceImplTest` 覆盖 quarantine 列表字段映射、Group 过滤和
-`external_fencing_confirmed=true` 强校验。它们只证明 KVCM 运维出口的代码契约，不能替代 Phase C 中
-由操作者实际取得外部 fencing 证据的故障演练。
-
-开源仓测试覆盖通用状态机、guard 严格 CAS/schema fail-closed、pre-submit 失败不误入 quarantine、
-cancel/completion 终态 owner、CAS 已生效但 Sync 未确认、恢复 accounting、Reclaimer/GC/普通删除
-fencing，以及失败源退避/换源的实际 `OnTaskFailed()` 接线。PACE submit/query/cancel 响应到
-`terminal/safe_to_reuse_dst` 的最承重映射只由内源 `TairMempoolAsyncBackendTest` 覆盖，不能把该下游
-suite 写成本仓自动化证据。
-
-现有内源 legacy `TairMempoolBackendTest` 在该组合基线上引用了外源尚不存在的
-`DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD` enum，属于两个基线间的既有契约不一致，未用合并另一条 42 文件
-SSD 分支的方式绕过。生产主二进制和本次新增的专用 async backend suite 均已通过；合并前仍需由基线
-维护者统一该 enum 后再恢复 legacy target 全量验证。
-
-### 13.3 待执行故障注入
-
-1. PACE 接受 submit 后丢弃响应。
-2. task 创建后 query 返回 404。
-3. Copy 中重启 KVCM Leader，并由新 Leader 恢复 query。
-4. Copy 中重启 PACE Meta 或 Provider，验证目标进入 quarantine 而非删除。
-5. cancel before submit、during copy、completion race。
-6. KVCM deadline 后 Provider 迟到 success。
-7. storage update/unregister 与 Copy 并发。
-8. executor/coordinator shutdown 时本地 queued、远端 active 和 unknown 三类任务分别收敛。
-9. mixed result batch：部分 success、部分 failed、部分 unknown。
-10. 后台 GC grace period 到期且 active table 为空，guarded target 仍不得删除。
-11. quarantine list 与 break-glass 审计流程；普通 reconcile/safe-release 实现后再补对应自动化。
+高频 polling 使用 DEBUG 或采样，状态跃迁和 quarantine 使用 INFO/WARN。
+
+不要把 submit RT 当成 Copy RT。性能分析应分别观察：
+
+- local queue wait；
+- submit HTTP；
+- remote execution；
+- poll convergence；
+- metadata promote/delete。
+
+## 13. 测试
+
+### 13.1 自动化范围
+
+通用框架测试至少覆盖：
+
+1. backend capability 和 local handoff；
+2. pre-submit 拒绝无远端副作用；
+3. size 缺失、非法、溢出和 item 数不一致；
+4. guard schema、状态跃迁和严格 CAS；
+5. success/safe、safe failure、unknown 的聚合；
+6. cancel/completion 竞争和 exactly-once credit；
+7. Leader recovery、resume 和恢复失败；
+8. Reclaimer、GC 和普通删除 fencing；
+9. quarantine capacity gate 与 break-glass 前置校验；
+10. source failure backoff 与 alternate source；
+11. config JSON/proto round-trip 和 timeout 约束；
+12. binary build。
+
+具体 PACE adapter 还应覆盖：
+
+- submit/query/cancel 响应 shape 与 task identity；
+- transport ambiguity；
+- query URL 分片或批量合并；
+- deadline/cancel 后继续收敛；
+- close detach；
+- task `not_found`；
+- same-provider 和 cross-provider payload 校验。
+
+### 13.2 故障注入
+
+上线前至少验证：
+
+1. 远端接受 submit 后丢失响应；
+2. task 创建后 query 返回 `not_found`；
+3. Copy 中切换 KVCM Leader；
+4. Copy 中重启远端 metadata 或 Provider；
+5. cancel 与 completion 竞争；
+6. deadline 后迟到 success；
+7. storage update/unregister 与 Copy 并发；
+8. mixed-result batch；
+9. guard 年龄超过 GC grace period；
+10. quarantine list 和 break-glass 审计。
+
+所有测试共享一个硬断言：没有 `terminal && safe_to_reuse_dst` 时，普通业务、Reclaimer、GC、
+shutdown 和恢复路径都不得删除或复用目标。
+
+## 14. 上线与兼容
+
+### 14.1 上线顺序
+
+1. 升级所有可能成为 Leader 的 KVCM 节点。
+2. 保持 `MIGRATION_COPY_SYNC` 验证兼容性。
+3. 确认目标 backend `SupportsAsyncCopy()`。
+4. 为一个 Instance Group 配置 operation/byte/quarantine gate。
+5. 开启 `MIGRATION_COPY_ASYNC_REQUIRED`，从 concurrency 1 开始。
+6. 完成正常、跨 Provider、cancel、切主和远端重启验证。
+7. 观察 active/quarantine、远端 registry 容量和前台延迟。
+8. 前一级稳定后再提高并发。
+
+### 14.2 兼容规则
+
+- 配置缺失时保持同步行为；
+- 异步 backend 不可用时 `ASYNC_REQUIRED` 明确失败；
+- 旧节点仍可能成为 Leader 时不得开启异步；
+- 同一 operation 异步提交后不能回退到同步；
+- 关闭 feature 不清理 guard；
+- binary rollback 前必须确认 guard 为零；
+- 所有 Location 读改写路径必须保留 guard。
+
+## 15. 已知限制与未来工作
+
+V1 已建立 KVCM 端的持久 fence 和异步控制面，但仍有以下限制：
+
+- 没有 caller-provided idempotency key，submit ambiguity 只能 quarantine；
+- 远端 task registry 若不持久化，重启后可能返回 `not_found`；
+- source pin 与 target guard 不是跨两个 Location 的原子事务；
+- quarantine 只有查询和 break-glass，没有自动权威对账；
+- source failure backoff 为进程内状态，且错误分类仍是聚合 `ErrorCode`；
+- 单 coordinator 的控制请求吞吐需要随并发单独验收；
+- Provider 是否异步、是否具备全局 ops/bytes admission 不由本方案保证。
+
+后续工作按实际指标触发：
+
+1. 远端支持 caller request ID 幂等和按 operation 查询；
+2. task registry 持久化并引入 topology/provider epoch；
+3. Provider 增加 ops/bytes admission 和有界队列；
+4. query 改为 POST body、long-poll 或完成事件；
+5. KVCM 增加 completion queue、持久 unknown-rate breaker 和普通 safe-release；
+6. 引入权威 stale-source 清理机制。
+
+在这些能力完成前，不能声明：
 
-核心自动化断言为：**没有 `safe_to_reuse_dst=true` 时，任何普通业务、Reclaimer、GC、shutdown 或恢复
-路径都不得删除或复用目标 GA。** 唯一不受此断言覆盖的是 9.4 定义的特权 break-glass；它必须先有
-独立外部 fencing 证明并留下完整审计，不得被自动触发。
-
-### 13.4 待执行性能与稳定性验收
-
-测试矩阵：
-
-- 4 MiB、68 MiB、136 MiB；
-- same-provider、cross-provider；
-- Copy concurrency 1、2、4；更高并发只有前一级通过后才执行；
-- 空闲环境和真实推理压测环境；
-- 持续 30 分钟和长稳测试。
-
-验收关注：
-
-- `SchedulePlanExecutor` worker 占用时间从物理 Copy RT 降为本地准入时间；
-- 前台 KVCM API 和共享 continuation 的 P99 不因 Copy RT 线性增长；
-- payload 校验、SSD commit、source retention 正确；
-- queue、线程、FD、内存和 task registry 有界；
-- 没有未知任务被误删，没有 quarantine 未计量；
-- quarantine operations/bytes 容量 gate 能阻断新的 submit，且不会阻断已有 task 的安全收敛；若上线
-  要求错误率熔断，再验证未来的持久 unknown-rate breaker；
-- concurrency 提升带来的聚合吞吐收益大于前台延迟和 PACE 饱和代价。
-
-## 14. 明确暂缓的未来工作
-
-### 14.1 PACE Provider 真异步返回
-
-**当前不做。** 未来让 Provider 在 `WriteRemote` 成功受理后返回 HTTP 202，由已有 terminal observer 在
-后台更新 Provider registry。Meta 收到 non-terminal 后进入 draining，通过 status 对账。
-
-该改动可以释放 Provider HTTP handler 和 Meta 普通 worker，但必须补齐 LinkPool/fallback 路径的资源
-所有权和终态 metrics。它解决的是 PACE 控制面在高并发下的资源效率，不降低 68/136 MiB 的物理
-Copy RT，也不会自动提高 C1 的 Group 吞吐。
-
-当前无需仅因“单次 Copy 为 200～300 ms”启动该改造：Provider 有 256 个 HTTP 线程，首发 C1 且少量
-item 时 handler 占用低于 1%，KVCM active slot 又会持续到 PACE 终态，不会在正常路径无界提交。评估
-时应优先用实测的 concurrent handler、Meta queue wait、Provider HTTP pool utilization、健康/节点管理
-请求 P99，以及 `active + quarantine` 物理在途数，而不是只看单次 Copy RT。
-
-触发条件包括：
-
-- 多个 Instance Group、KVCM 集群或其它 CopyGA caller 汇聚，使 KVCM 的单 Group gate 无法代表 PACE
-  全局负载；
-- `active + quarantine` 物理在途任务持续增长，或需要把 Copy concurrency 提升到当前 PACE 普通
-  线程池无法承载的水平；
-- Meta/Provider handler 饱和或 queue wait 成为端到端 RT 的主要部分；
-- Copy 明显影响 PACE 健康检查、节点管理或其它控制请求。
-
-### 14.2 caller-provided idempotency key
-
-**当前不做。** PACE 后续接受 KVCM `operation_id/client_request_id`，相同 ID 幂等返回原 task IDs，并支持
-按 request ID 查询。
-
-完成后可自动处理“PACE 已受理但 submit response 丢失”的窗口，显著减少 `kSubmitting` quarantine。
-
-触发条件包括：submit ambiguity/quarantine 在真实运行中出现，或业务要求自动恢复而不能接受人工清理。
-
-### 14.3 PACE task 持久化与拓扑 epoch
-
-**当前不做。** Meta/Provider task registry 后续需要可恢复 operation ledger，并把 topology/provider
-epoch 纳入 task 和 GA 身份。这样 PACE 重启后才能区分仍可恢复、明确失败和永久失效。
-
-触发条件包括：要求 PACE Meta/Provider 滚动升级对在途 Copy 透明，或 task `not_found` 成为主要
-quarantine 来源。
-
-### 14.4 PACE ops + bytes admission
-
-**当前不做。** PACE Meta 和 Provider 后续增加全局、每 Provider、每 node-pair 的在途任务数与字节数
-限制，使用 bounded queue，并在产生副作用前返回 429/503 和 `retry_after_ms`。
-
-V1 由 KVCM 控制负载；当出现多个 KVCM caller、绕过 KVCM 的 Copy 调用方或 PACE 自身需要故障隔离时，
-该能力变为必需。
-
-### 14.5 更高效的状态通知
-
-**当前不做。** 后续可增加 POST batch-status、operation aggregate、long-poll 或完成事件，替代 GET URL
-拼接和高频 polling。
-
-触发条件包括：poll QPS、URL 长度、逐 task reconciliation 或 Meta CPU 成为瓶颈。
-
-### 14.6 KVCM completion queue
-
-V1 为减少改动继续使用最终 future。operation 数量提升后，将 `MigrationManager::MonitorLoop()` 的
-deque round-robin `wait_for` 改为 backend completion queue + condition variable，避免 O(N) 空轮询。
-
-### 14.7 Quarantine 自动化对账与容量治理
-
-V1 已实现最小只读列表、要求 operator/evidence 的 break-glass，以及 quarantine operations/bytes 容量
-gate。手工 reconcile、取得 drain 证明后的普通 safe-release、服务端 fencing evidence 校验、持久化
-unknown-rate circuit breaker、自动恢复、容量预测和批量治理仍是后续工作。任何“按年龄自动删除”都
-必须有新的 drain 证明，不能仅依赖超时或人工点击。
-
-### 14.8 永久失败源隔离与自动换源
-
-Copy 异步化只改变执行和生命周期，不应把 `node not found` 等失败源被反复选择的问题隐含在
-异步状态机里处理。该问题已作为独立 V1 落在同步/异步路径共用的 `MigrationManager` 准入层：按
-`(instance, block, location id, create time, target storage)` 记录进程内失败状态，使用 5 秒起步、
-30 分钟封顶的指数退避；存在其它完整副本时优先换源，全部候选仍在 backoff 时本轮不分配目标、
-不提交 Copy。
-
-由于当前 PACE 错误仍被折叠为聚合 `ErrorCode`，V1 不自动删除 source，也不持久化“永久失效”结论。
-rich error、topology epoch、持久 quarantine 和权威 stale-location 清理继续保留为未来工作。详见
-[永久 Copy 失败源隔离与换源缺陷](../../integration_test/tiered_storage/docs/operations/15_KVCM_PERMANENT_COPY_FAILURE_SOURCE_QUARANTINE_2026-08-19.md)。
-
-## 15. 分阶段交付计划
-
-### Phase A：安全基础（代码与定向单测完成）
-
-- rich `AsyncCopyOutcome` 和 `safe_to_reuse_dst`；
-- `migration_copy_guard` 及条件更新；
-- target guard，以及由 sibling target guard 派生的精确 source fencing；
-- Reclaimer 与后台 GC 分别直接读取 guard fencing，并保留 expected-value 条件删除；
-- 明确 persistent guard 与 volatile `CopyTaskState` 的权威映射；
-- 修复所有相关 URI `size` 解析、未初始化值、正数校验和溢出检查；
-- Group op/byte reservation；pre-submit 明确失败安全回滚；
-- feature gate、byte/quarantine 配置与容量 gate；
-- guard/quarantine stats、最小 list/break-glass 审计接口；
-- operation/state 双条件 CAS、operation 粒度 transition 串行化和唯一 credit ledger；
-- CAS 已生效但 Sync 未确认时仅重试 durability barrier；
-- 有界 recovery 扫描、全量校验后原子重建 accounting，以及恢复失败主动 demote；
-- 二进制回滚前 guard 清零的运维约束。
-
-尚未完成的安全增强是跨 Location 原子 source pin、持久 rate breaker、普通 reconcile/safe-release 和专用
-binary rollback gate；其上线要求按第 9、10、13、16 节执行，不能被“Phase A 代码完成”掩盖。
-
-### Phase B：KVCM 原生异步（代码与定向单测完成）
-
-- `PaceServiceClient` submit/query/cancel；
-- `TairMempoolBackend` coordinator；
-- `DataStorageManager`/backend lifecycle lease；
-- storage Close 失败时 Registry 配置删除顺序/补偿修复；
-- `SchedulePlanExecutor` 短准入；
-- cancel、fail-closed shutdown、Leader recovery；
-- 202 Linux 主二进制构建、开源仓定向 suite 与内源 PACE adapter suite。
-
-集群故障注入和性能验证属于 Phase C，尚未完成。
-
-### Phase C：受控上线
-
-- 全 Manager 节点升级，确认旧 Leader 不会接管；
-- `copy_execution_mode=SYNC` 下先验证兼容；
-- 单个 Instance Group 开启 `ASYNC_REQUIRED`；
-- concurrency 1 运行 same/cross smoke 和真实 68/136 MiB 压测；
-- 演练 crash recovery、Stop→UNKNOWN、quarantine list、break-glass 审计和容量 gate；
-- 在生产开启前决定是否补齐普通 reconcile/safe-release 与持久 rate breaker；
-- 观察 quarantine、PACE task registry 估算/实值、前台延迟和资源水位；
-- 验证关闭 feature 后 guard 仍受保护，并演练 guard 清零后的二进制回滚 gate；
-- 通过后再评估 concurrency 2。
-
-### Phase D：按证据启动 PACE 后续改造
-
-只有第 14 节的触发条件成立时，才分别启动 Provider 真异步、幂等、持久化、字节 admission 或状态
-通知工作，不把它们作为 V1 的隐含依赖。
-
-## 16. 已知限制与上线声明
-
-完成 Phase C 前，以下是“代码能力声明”，不是“已上线验证声明”：
-
-- KVCM 共享迁移 worker 不再等待完整 CopyGA 物理执行；
-- KVCM 对远端异步任务使用 drain-safe 的目标生命周期；
-- Reclaimer 和后台 GC 不会因进程内 active table 丢失或 WRITING 年龄到期而回收 guarded target；
-- quarantine 有进程内重建计量、operations/bytes 容量 gate、只读列表和受审计的 break-glass 出口；
-- 低并发下可以安全复用 PACE 现有异步接口。
-
-不能声明：
-
-- PACE 内部已经完全非阻塞；
-- 136 MiB Copy RT 已降到 10 ms；
-- submit response 丢失可以自动 exactly-once 恢复；
-- PACE 重启对在途 Copy 透明；
-- C1 下同一 Group Copy 吞吐会因异步化自动提高；
+- timeout 或 `not_found` 后目标可以自动回收；
+- 远端重启对在途 Copy 完全透明；
 - 可以无条件提高 Copy 并发；
-- 当前有并行 HTTP submit/query worker pool（单 coordinator 只能串行控制请求，远端物理任务可重叠）；
-- 已有持久化 unknown-rate circuit breaker、手工 reconcile 或普通 safe-release；
-- 有序 Stop 能无 quarantine 地把 active operation 交给新 Leader；
-- source pin 与 target guard 是跨两个 Location 的原子事务；
-- 存在持久 guard 时可以回滚到不识别 guard 的旧二进制；
-- `not_found` 表示目标可以回收。
+- 异步化会降低物理 Copy RT；
+- 存在 guard 时可以回滚到不识别 guard 的旧二进制。
 
-V1 的核心取舍是：**用最小 PACE 改动先建立可恢复、可证明回收的目标生命周期契约，同时解除 KVCM
-长阻塞；对无法证明 drain 的场景以有上限、有运维出口的 quarantine 换取数据安全。** 后续是否继续改
-PACE，由真实并发、线程池饱和、task registry 容量、unknown 比例和运维恢复目标驱动，而不是在本轮
-一次性扩大改造范围。
+V1 的取舍是：复用现有远端异步任务协议，先解除 KVCM 长阻塞，并用持久 guard、恢复、容量 gate 和
+fail-closed quarantine 保证目标生命周期安全。更深的 Provider 改造由真实负载和故障数据决定。

--- a/docs/design/async_copyga.md
+++ b/docs/design/async_copyga.md
@@ -1,0 +1,1470 @@
+# KVCM × PACE CopyGA 异步化设计
+
+| 项目 | 内容 |
+|---|---|
+| 状态 | V1 代码完成，202 Linux 编译与定向单测通过；集群联调和故障演练待完成 |
+| 决策日期 | 2026-08-24 |
+| V1 范围 | KVCM 端到端异步化；PACE Meta/Provider/tair-mempool 零代码改动，KVCM 内源 PACE adapter 复用现有异步 API |
+| 涉及模块 | `service`、`manager`、`meta`、`config`、`data_storage`、`metrics`、`protocol` |
+| KVCM 审计基线 | `fix/reclaimer-exclude-report-event@0d0371a18faa` |
+| PACE 审计基线 | `bugfix/pace-tiered-storage-lightweight-safety@084d88703bd5` |
+| 性能依据 | [压测环境 CopyGA 百毫秒延迟差异分析](../../integration_test/tiered_storage/docs/performance/16_COPYGA_LATENCY_GAP_ANALYSIS_2026-08-21.md) |
+| 相关问题 | [永久 Copy 失败源隔离与换源缺陷](../../integration_test/tiered_storage/docs/operations/15_KVCM_PERMANENT_COPY_FAILURE_SOURCE_QUARANTINE_2026-08-19.md) |
+
+本文记录 CopyGA 异步化的背景、改造前基线、已选方案、当前 V1 实现、安全契约、验收标准以及明确
+暂缓的工作。后续实现若改变本文中的状态机、回收条件、故障语义或模块边界，必须同步更新本文。
+
+## 1. 结论摘要
+
+真实推理请求使用的 KVCache block 为 68 MiB 和 136 MiB，远大于早期 microbenchmark 使用的
+4 MiB。压测中 Provider 的 CopyGA 完成时间约为：
+
+| 尺寸 | 典型完成时间 | 有效吞吐 |
+|---:|---:|---:|
+| 4 MiB（按当前吞吐折算，非实测） | 约 7.5～8.3 ms | 约 0.5 GiB/s |
+| 68 MiB | 约 127～139 ms | 约 484～536 MiB/s |
+| 136 MiB | 约 259～281 ms | 约 484～525 MiB/s |
+
+68 MiB 到 136 MiB 的延迟接近线性翻倍。当前证据表明，200～300 ms 首先是 100MB+ payload 的真实
+数据搬运成本，不是单纯把 KVCM 外层排队误算进 RT。异步化不会降低单次 Copy 的物理耗时；它首先
+建立可跨重启恢复、可证明安全回收的目标生命周期契约，其次才是释放 KVCM 共享执行线程、HTTP
+client 和存储生命周期锁。`copy_max_concurrency=1` 时，同一个 Instance Group 的 Copy 吞吐不会因为
+异步化本身提高；V1 的主要收益是安全地解除长期占用，并为后续受控提高并发打基础。
+
+本设计作出以下核心决策：
+
+1. **V1 只改 KVCM，PACE 不改代码。** KVCM 使用 PACE 已有的 submit/query/cancel API，停止调用
+   `/v1/api/copy_ga/batch_sync`。
+2. **KVCM 的共享 worker 只做本地异步准入。** PACE HTTP submit、轮询和取消由
+   `TairMempoolBackend` 的专用 Copy coordinator 执行。
+3. **自动回收以 `terminal && safe_to_reuse_dst` 为唯一凭证。** timeout、`not_found`、响应丢失和
+   PACE 重启均不能授权删除或复用目标 GA；唯一例外是有独立外部 fencing 证明并完整审计的
+   break-glass 运维动作，它不进入自动策略。
+4. **不追求跨故障 exactly-once，采用 fail-closed。** 当前 PACE 没有调用方幂等 ID；无法确认是否
+   受理的目标进入 quarantine，宁可暂时占用容量，也不能与迟到写并发复用。
+5. **当前并发受 Group task concurrency、在途字节和 quarantine 容量约束。** quarantine 的
+   operations/bytes 达到配置上限后，新的异步 operation 被硬拒绝；基于 unknown 比例或连续 unknown
+   的持久化 circuit breaker 尚未实现，列为上线增强项，不能把容量 gate 描述成完整熔断器。
+6. **保留同步路径作为功能级回滚能力。** 同一 operation 一旦异步提交，不允许中途回退到同步 Copy，
+   避免对同一目标重复搬运；二进制回滚是另一条更严格的路径，必须先 drain 到持久 guard 数为零。
+
+PACE Provider 当前固定使用 256 个 HTTP server 线程；在首发 `copy_max_concurrency=1`、一个逻辑
+operation 通常只有少量 URI pair 的条件下，单次 Copy 等待 200～300 ms 只占极少量 handler，不构成
+当前集群的健康风险。此时真正的限制是迁移吞吐是否追得上热层写入，而不是 Provider HTTP 线程数。
+因此 PACE Provider 真异步是有触发条件的扩展性优化，不是 V1 或当前 benchmark 的前置修复。
+
+### 1.1 当前实现快照
+
+| 能力 | 当前状态 |
+|---|---|
+| KVCM `SYNC` / `ASYNC_REQUIRED` 模式与配置校验 | 已实现 |
+| 开源仓通用 async backend 框架 | 已实现；基类 `SupportsAsyncCopy()` 默认 `false`，单独编译本仓时异步 PACE 分支不可达 |
+| KVCM 内源 PACE submit/query/cancel adapter | 已在内源 `8cac0396` 实现 `SupportsAsyncCopy()` override 及 coordinator；未修改 tair-mempool 服务端 |
+| `TairMempoolBackend` 本地异步 handoff 与后台收敛 | 已实现；单 coordinator 线程，进程内最多 1024 个 operation |
+| 持久 `migration_copy_guard`、严格 CAS、Leader 恢复 | 已实现；跃迁同时校验 operation/state，CAS 已生效但 Sync 未确认时仅重试 Sync |
+| target fencing，以及通过目标 guard 保护其精确 source identity | 已实现于 Reclaimer、后台 GC 和普通删除路径 |
+| quarantine 容量 gate、只读列表、外部 fencing 后的 break-glass | 已实现；自动 reconcile 和持久化 rate breaker 未实现 |
+| 永久失败源退避与优先换源 | 已实现于同步/异步共用准入层；当前为进程内有界状态 |
+| 202 Linux 编译与定向单测 | 本轮评审修正已在 202 隔离容器通过开源仓 8/8 定向目标、内源 PACE adapter 1/1 及两种组合的主二进制构建；详见 13.2 |
+| 集群 same/cross-provider 冒烟、故障注入与长压 | 待执行 |
+
+因此本文中的“必须”同时包含两类语义：已经落到 V1 代码中的安全契约，以及仍需在 Phase C/未来版本
+完成的上线门槛。各节会明确标注，不能仅凭设计目标推导某项能力已经实现。
+
+## 2. 术语与能力边界
+
+本文区分三种容易混淆的“异步”：
+
+| 名称 | 含义 | 当前状态 |
+|---|---|---|
+| KVCM 控制面异步 | Reclaimer/MigrationManager 提交迁移后不阻塞调用线程 | 已具备 |
+| PACE 提交异步 | `/copy_ga/batch` 返回 task ID，调用方后续查询 | 已具备，V1 复用 |
+| PACE 执行真异步 | Meta/Provider 在受理后不占用普通 worker/HTTP handler 等待物理 Copy | 当前不具备，V1 暂缓 |
+
+PACE task 的几个字段具有严格含义：
+
+- `terminal`：客户端可见状态已经收敛，不再变化；
+- `drained`：commit owner 已证明此后不会继续写目标 GA；
+- `safe_to_reuse_dst`：当前实现等价于 `terminal && drained`，表示调用方可以安全回收目标；
+- `unknown_final`：控制面对账已经停止，但没有 drain 证明，目标必须隔离；
+- `not_found`：只说明当前 task registry 中没有记录，不证明 Provider 没有继续写目标。
+
+本文中的 operation 是 KVCM 一次逻辑迁移；一个 operation 可以包含多个 PACE task，每个 task 对应
+一个 source/destination URI pair。
+
+`migration_copy_guard` 是跨重启的生命周期权威；现有 `MigrationManager::CopyTaskState` 只负责当前
+进程内的调度、取消与 completion 认领。两者不一致时必须以持久 guard 的更保守状态决定是否允许
+回收，不能用内存表为空推导远端任务已经结束。
+
+## 3. 改造前基线与问题
+
+### 3.1 改造前同步调用链
+
+```mermaid
+flowchart TD
+    R[CacheReclaimer / Admin MigrateCache]
+    M[MigrationManager]
+    E[SchedulePlanExecutor shared worker]
+    D[DataStorageManager::Copy]
+    B[TairMempoolBackend::Copy]
+    C[PaceServiceClient::BatchSyncCopyGA]
+    PM[PACE Meta batch_sync]
+    PP[Provider WriteRemote + SSD commit]
+
+    R --> M --> E --> D --> B --> C --> PM --> PP
+    PP -->|physical completion| PM --> C --> B --> D --> E --> M
+```
+
+异步 V1 落地前，各层行为如下：
+
+1. `MigrationManager` 创建目标 GA 和 `CLS_WRITING` 目标 Location，然后向
+   `SchedulePlanExecutor` 提交 Copy，自己通过 future 等待结果。
+2. `SchedulePlanExecutor::DoCopyTask()` 在共享 worker 中同步调用 `DataStorageManager::Copy()`。
+3. `DataStorageBackend::Copy()` 的接口契约要求返回时 Copy 已经完成。
+4. `DataStorageManager::Copy()` 在整个后端调用期间持有 `rw_lock_` 的 shared lock。
+5. `TairMempoolBackend::Copy()` 获取一个 PACE client handle，同步调用
+   `/v1/api/copy_ga/batch_sync`。
+6. PACE 的同步接口内部虽然复用 submit/query 状态机，但 HTTP 调用仍然等到真实 Copy 完成。
+
+因此改造前实现不是阻塞推理请求线程，而是长时间占用 KVCM 的共享迁移执行资源。随着 block 变大和
+并发提升，会出现：
+
+- migration continuation worker 被 200～300 ms 的 I/O 占用；
+- PACE client handle 长时间不归还；
+- Storage update/unregister 等待 `DataStorageManager` 的锁；
+- Copy 排队和完成 future 数量增加；
+- cancel、shutdown、切主和 storage close 难以安全收敛；
+- 共享 executor 的其它 continuation 任务可能被间接延迟。
+
+基线默认 `SchedulePlanExecutor` 有 2 个 worker，migration worker budget 为 1。因此在
+`copy_max_concurrency=1` 下，一次 136 MiB Copy 会占满 100% 的 migration worker budget 约
+259～281 ms，但不会占满全部 executor worker。这也是为什么 V1 不能把收益描述成“提高 Group C1
+吞吐”：它释放的是唯一 migration slot，并改善 storage close、切主和未来扩并发的生命周期基础。
+
+### 3.2 KVCM 改造前生命周期缺口
+
+改造前 `MigrationManager` 的 active task 和 pending future 都在内存中。停止时会清空 active task，遗留
+的 `CLS_WRITING` 目标交给 Reclaimer 作为 orphan 回收。Reclaimer 和后台 GC 虽然都会通过
+`HasActiveCopyTargetLocation()` 排除当前进程内的 active target，但该 hook 仍是易失内存状态：
+`MigrationManager::Stop()` 清表或 Leader 重启后，它不能继续保护远端仍在执行的 Copy。后台 GC 当前
+默认关闭；但一旦启用，其 `IsOrphanWriting()` 会纯按创建时间判断 orphan，默认 grace period 为
+24 小时、最小为 1 小时。Reclaimer 则可能更早处理 orphan，因此两条路径都属于 Phase A 的 P0 fencing。
+同步 Copy 下，future 消失通常意味着进程内调用也一起结束；切换为远端异步后，这个假设不再成立：
+KVCM 退出时 PACE 可能仍在写目标。
+
+后台 GC 删除时已经携带 `expected_location_values` 做精确值条件删除；在全新版本中，guard 状态变化
+会改变 Location JSON，使在途旧删除请求自动失效。这是把 guard 放入 Location JSON 的正面依据，
+但它不是旧二进制兼容保证：`CacheLocation::ToRapidWriter()` 逐字段序列化，旧代码读写新 Location
+时会静默丢弃未知 guard 字段，甚至可能把它重新识别为普通 orphan。因此 Reclaimer 和 GC 都必须直接
+读取持久 guard 进行 fencing，不能只依赖 active table 或创建时间。
+
+改造前失败结果也只有 `ErrorCode`，无法表达以下差异：
+
+- 明确失败并且目标已经 drained；
+- 请求超时，但服务端可能已经受理；
+- task registry 中找不到任务；
+- PACE 已经发布 `unknown_final`；
+- 可以安全删除目标，或必须隔离目标。
+
+如果把这些情况都折叠成 `EC_ERROR` 并沿用“失败即删除目标”，会产生目标 GA 被迟到任务继续写入、
+同时又被重新分配给其它请求的风险。
+
+### 3.3 PACE 当前异步接口
+
+PACE 已提供以下接口：
+
+```text
+POST /v1/api/copy_ga/batch          submit
+GET  /v1/api/copy_ga/batch          query
+POST /v1/api/copy_ga/cancel         cancel
+POST /v1/api/copy_ga/batch_sync     synchronous wrapper
+```
+
+现有 task 状态机已经包含 `terminal`、`drained`、`safe_to_reuse_dst`、cancel、deadline、Provider
+status reconciliation 和 `unknown_final`，足以支持低并发、受控的 KVCM V1。
+
+但当前所谓异步只发生在 Meta 的 HTTP 边界：
+
+- Meta 将 node-pair group 放入普通 `MetaThreadPool`，worker 内仍然 `syncAwait`；
+- Provider handler 在 `WriteRemote` 后仍等待 completion 和 SSD commit；
+- Meta task registry、Provider status registry 都主要存在于进程内；
+- 没有 caller-provided idempotency key；
+- admission 主要按操作数限制，没有全局 in-flight bytes 限制；
+- batch query 逐 task reconciliation，依赖调用方轮询。
+
+更准确的当前调用时序是：
+
+```text
+KVCM submit
+  -> PACE Meta 返回 task ID
+  -> Meta 后台 worker 调 Provider /api/copy_ga
+  -> Provider 发起 callback 型 WriteRemote
+  -> Provider handler 同步等待最多 30 秒
+       -> 30 秒内完成：直接返回 terminal success/failure
+       -> 30 秒内未完成：返回 202，terminal observer 后台更新 registry
+  -> KVCM query Meta；Meta 必要时再 query Provider status
+```
+
+`WriteRemote` 数据面本身已经是 callback 异步实现，但 Provider 的 `CopyGA` handler 使用
+`CallbackWaiter::SetAndAwaitCallback()` 的条件变量等待 completion。默认等待预算为 30 秒，可通过
+`TAIR_MEMPOOL_COPY_GA_WAIT_TIMEOUT_MS` 调整。当前 68/136 MiB 的 127～281 ms Copy 远低于该预算，
+因此正常压测路径通常由 Provider 直接返回终态，而不是先返回 202；`202 + status` 主要是长尾或故障
+路径。
+
+#### 3.3.1 Provider 同步等待配置
+
+| 项目 | 当前定义 |
+|---|---|
+| 配置项 | `TAIR_MEMPOOL_COPY_GA_WAIT_TIMEOUT_MS` |
+| 生效组件 | PACE Provider |
+| 默认值 | `30000` ms |
+| 合法范围 | `1～55000` ms；未配置、非整数或越界时回退到默认 `30000` ms |
+| 读取方式 | `CopyGAWaitTimeout()` 内以进程级 `static const` 读取；修改后需要重启 Provider |
+| 控制语义 | Provider `/api/copy_ga` handler 等待 `WriteRemote` completion 的本地同步预算 |
+| 到期行为 | 当前 terminal protocol 下返回 HTTP 202；物理 Copy 和 terminal observer 继续运行，Meta 后续查询 status |
+| 不控制 | 物理 Copy 的 `commit_timeout_ms`、Meta 60 秒 Provider HTTP timeout、Meta 120 秒 reconciliation 窗口 |
+
+部署示例：
+
+```text
+TAIR_MEMPOOL_COPY_GA_WAIT_TIMEOUT_MS=5000
+```
+
+该值由 `dfcf43f16f3afe7218039dc8ca48e82e13b687cb`（`fix(copy): publish explicit CopyGA result after
+backend commit`）引入；此前 `2c6fea124c6d6dcb224a1db7b5676ba88d36e7d2` 首次让 Provider handler
+等待真实 IO completion，但沿用 `CallbackWaiter` 的固定 1 秒预算。后续
+`89d11eb31a9d1243c4b37bbfe00c6a6743951471`（`fix(copy): bound and drain timed out CopyGA tasks`）
+增加 Provider status registry 和 HTTP 202 语义，才使“本地等待到期”不再等同于“物理 Copy 失败”。因此
+下调该配置以前必须确认 Provider 和 Meta 都已部署 terminal/status 协议，不能把同样策略直接应用到
+旧 Provider。
+
+30 秒是为了覆盖 backend queue 和 sync 长尾，同时保持低于 Meta 对 Provider 的 60 秒 HTTP timeout；
+它不是根据当前 100 MiB 级 Copy 的 200～300 ms P99 量化得到的 deadline。作为“同步等待 → 202 异步
+接管”的切换阈值，当前建议先配置为 5 秒，并观测 Copy P99.9、HTTP 202 比例、terminal 收敛时间和
+unknown/quarantine 数量；有足够数据证明 P99.9 明显低于 1 秒后，再评估降到 3 秒。降低本配置只应
+提前释放 handler，不应联动缩短 `commit_timeout_ms` 或 reconciliation/registry retention。
+
+Provider HTTP server 的 `META_SERVER_THREAD_NUM` 当前固定为 256。KVCM 的
+`copy_max_concurrency` 是 Instance Group 级**逻辑 operation**硬限制：task 从 preparing、远端 submit、
+polling 到 KVCM 最终 promote/safe-failure/unknown 收尾期间都占用 slot，PACE 返回 task ID 不会释放
+slot。因此正常慢 Copy 会把压力反向传回 KVCM，而不是让同一 Group 无界地向 PACE 排队：
+
+```text
+PACE 变慢
+  -> 当前 KVCM operation 更久不终止
+  -> Group Copy slot 保持占用
+  -> Reclaimer 不再提交新的物理 Copy
+  -> 热层下沉吞吐降低，水位继续上升
+  -> 可能更早进入 reclaim/写入反压，而不是首先拖垮 Provider HTTP
+```
+
+一个 operation 可以包含多个 URI pair，所以 `copy_max_concurrency=1` 不严格等于一个 Provider HTTP
+请求；若一个 block 有两个 location spec，则最多可同时形成两个 PACE Copy task。即使按两个 task 估算，
+也只占约 `2 / 256 < 1%` 的 Provider HTTP 线程；C8、每个 operation 两个 item 时约为
+`16 / 256 = 6.25%`。在当前单 Group C1/C2 范围内，SSD/网络吞吐、PACE 数据面队列和 KVCM 下沉速率
+更可能先成为瓶颈，不能仅凭 200～300 ms handler 等待推导 Provider 健康会受影响。
+
+上述反压有三个边界：
+
+1. `copy_max_concurrency` 不是 PACE 全局限制；多个 Instance Group、多个 KVCM 集群、手工 CopyGA 和
+   其它调用方会在同一 Provider 汇聚。
+2. operation 进入 unknown 后会从 active credit 原子转入 quarantine credit，活跃 slot 随之释放；旧
+   PACE task 在没有 drain 证明时理论上仍可能运行。KVCM 可以在 quarantine 未达到 ops/bytes 硬上限前
+   接受新 operation，因此真实物理在途数可能是 `active + quarantine`，而不只等于
+   `copy_max_concurrency`。
+3. Provider 在返回 202 后只通过进程内 terminal observer 更新 registry，Meta 侧主要由调用方 query
+   驱动 reconciliation；KVCM coordinator 停止轮询、Meta/Provider 重启或 status TTL 到期都会把任务
+   推向 unknown/quarantine，而不是自动恢复成安全失败。
+
+当前 Provider 的最终成功、字节数和 latency 指标主要在 handler 观察到终态时记录；若 handler 先返回
+202、completion 后到，terminal observer 会更新 registry，但长尾任务的最终指标可能不完整。该问题
+影响可观测性，不改变 `terminal && drained` 的回收安全语义；只有真异步改造时才需要把 exactly-once
+终态 metrics 一并迁移到 completion owner。
+
+当前审计基线还有以下容量和保留边界：Meta Copy task registry 默认最多 100,000 条，terminal task
+从“发布客户端可见终态”开始保留 30 分钟；Provider status registry 默认保留 600 秒，Meta 的 Provider
+reconciliation 默认窗口为 120 秒。V1 必须持续、有界地查询 active task，不能把 task ID 当成永久可
+恢复句柄。这里不存在简单的 `operation_deadline < 30min` 单一约束；正确约束分为：
+
+```text
+P99_remote_execution + queue/retry/poll_margin < copy_operation_deadline
+max_KVCM_recovery_outage + poll_interval < PACE_terminal_retention
+PACE_provider_reconcile_timeout < Provider_status_TTL
+```
+
+第一条保证正常任务不被过早转 unknown，第二条保证 KVCM 在 PACE 已经完成后仍有机会读到终态，第三条
+保证 Meta 对账窗口内 Provider 状态仍可查询。任何 deadline 或 retention 过期都不构成 drain 证明；
+超出窗口得到 `not_found` 时仍按 unknown 处理。
+
+V1 接受这些限制，并通过 KVCM 低并发和 fail-closed 策略控制风险；它不把现有 PACE API 描述成
+最终的生产级真异步实现。
+
+### 3.4 代码依据
+
+以下位置构成当前判断的主要源码依据，行号变化时应按函数名定位：
+
+| 组件 | 位置 | 改造前行为/审计依据 |
+|---|---|---|
+| KVCM backend 契约 | `kv_cache_manager/data_storage/data_storage_backend.h` `Copy()` | 同步返回，逐项结果长度必须与输入一致 |
+| KVCM storage manager | `kv_cache_manager/data_storage/data_storage_manager.cc` `Copy()` | 持 shared `rw_lock_` 调用 backend |
+| KVCM executor | `kv_cache_manager/manager/schedule_plan_executor.cc` `DoCopyTask()` | 共享 worker 同步等待 backend Copy |
+| KVCM migration | `kv_cache_manager/manager/migration_manager.cc` `Submit()`、`MonitorLoop()`、`Stop()` | future 在内存中轮询；Stop 清 active task，WRITING 交给 orphan 回收 |
+| KVCM Reclaimer | `kv_cache_manager/manager/cache_reclaimer.cc` orphan WRITING 判断 | 通过内存 active target 排除迁移目标；重启/清表后 fencing 消失 |
+| KVCM 后台 GC | `kv_cache_manager/manager/cache_garbage_collector.cc` `IsOrphanWriting()`、`BuildDeleteRequest()` | orphan 判定按年龄；另查内存 active target，并使用 Location 精确值条件删除 |
+| KVCM Location 序列化 | `kv_cache_manager/meta/cache_location.h` `ToRapidWriter()` | 逐字段序列化；旧二进制会丢弃未知 guard 字段 |
+| KVCM size 解析 | `kv_cache_manager/manager/migration_manager.cc`、`manager/meta_searcher.cc` | URI `size` 缺失/非法时可静默保留 0；`BatchAddLocation()` 还有未初始化局部值风险 |
+| KVCM storage lifecycle | `data_storage_manager.cc` `UnRegisterStorage()`、`config/registry_manager.cc` `RemoveStorage()` | 已调用 backend `Close()`；但当前先删持久配置再 unregister，Close 失败会造成配置/运行态不一致 |
+| 内源 PACE client | `internal_source/kv_cache_manager/data_storage/pace_service_client.cc` `BatchSyncCopyGA()` | 仅封装 `/copy_ga/batch_sync`，HTTP helper 丢弃非 200/204 状态细节 |
+| 内源 PACE backend | `internal_source/kv_cache_manager/data_storage/tair_mempool_backend.cc` `Copy()` | 同步持有 client handle，并按输入下标合并结果 |
+| PACE Meta API | `tair-mempool/include/meta_service/node_management_service.h` | 已定义 submit/query/cancel 与 terminal/drained 字段 |
+| PACE Meta executor | `tair-mempool/src/meta_service/node_management_service.cpp` `SubmitBatchCopyGA()` | node-pair group 进入普通线程池，worker 内 `syncAwait` |
+| PACE Provider | `tair-mempool/src/listener/meta_restful_server.cpp` CopyGA handler | `WriteRemote` 后以 `SetAndAwaitCallback()` 最多等待默认 30 秒；未终态时返回 202 |
+| PACE Provider HTTP server | `tair-mempool/include/listener/meta_restful_server.h` `META_SERVER_THREAD_NUM` | 当前固定 256 个 HTTP 线程；C1/C2 下少量 200～300 ms 等待不是健康瓶颈 |
+| KVCM Group Copy gate | `kv_cache_manager/manager/migration_manager.cc` `BatchSubmit()` | `copy_max_concurrency` 按完整逻辑 operation 生命周期占用，不在 PACE submit 后提前释放 |
+
+内源路径以 `KVCacheManager` 仓库为根，PACE 路径以 `tair-mempool` 仓库为根。本文只记录跨仓契约，
+实现时双方分支必须重新核对响应 schema 和默认配置。
+
+## 4. 设计目标与非目标
+
+### 4.1 V1 目标
+
+1. 建立可支撑后续高并发的持久目标生命周期契约：自动路径只有远端终态且有 drain 证明时才允许
+   回收目标。
+2. 让 KVCM 共享 `SchedulePlanExecutor` worker 不再等待 100MB+ 的物理 Copy。
+3. 保持现有 `CLS_WRITING -> CLS_SERVING` 的发布屏障；数据没有安全完成前绝不对读路径可见。
+4. 在成功、失败、超时、取消、响应丢失和 `not_found` 下定义唯一、保守的目标 GA 生命周期。
+5. 支持 KVCM 重启/切主后识别未完成异步 operation；能恢复的继续查询，不能恢复的隔离。
+6. 对 Group Copy concurrency、在途字节和 quarantine operations/bytes 实施有界反压；进程级
+   operation 上限由 backend 固定为 1024。unknown rate、轮询 QPS 和持久化 breaker 属于后续增强。
+7. 保持同步 Copy 路径可用，并分别定义 feature 关闭和二进制回滚的安全门槛。
+8. 先提供 unknown、inflight、quarantine 与失败源计数；进一步拆分本地排队、PACE submit、远端执行
+   和端到端完成时间的完整 metrics 属于上线观测增强。
+
+### 4.2 V1 非目标
+
+1. 不降低单次 68/136 MiB Copy 的物理 RT。
+2. 不修改 PACE Meta 或 Provider 代码。
+3. 不实现 PACE 内部 worker/handler 真异步。
+4. 不承诺提交响应丢失后的 exactly-once；缺少 PACE 幂等 ID 时只能安全隔离。
+5. 不调整 PACE placement、链路池、SSD backend 或 Copy 数据算法。
+6. 不在异步状态机里特殊处理永久失效源；本次同时在同步/异步共用的准入层独立交付有界退避和
+   优先换源，但不做 topology epoch、权威删源或持久 source quarantine。
+7. 不在 V1 引入 callback、消息队列或跨组件事件推送，仍使用有界 polling。
+
+## 5. 设计决策记录
+
+### D1：V1 复用 PACE 当前异步 API，PACE 零代码改动
+
+**决定：** 使用 `/copy_ga/batch`、`/copy_ga/batch` query 和 `/copy_ga/cancel`，不等待 Provider 真异步
+改造。
+
+**原因：** 已有接口已经返回 task ID 和 drain 安全字段，KVCM 可以先建立持久目标生命周期并解除共享
+worker 长等待，能够满足低并发 V1。Provider 当前有 256 个 HTTP 线程；C1 且每个 operation 两个 item
+时只占约两个 handler，200～300 ms 等待对整体健康的影响可以忽略。先修改 Provider 会扩大双方联调
+范围和发布风险，却不能提高 C1 下同一 Group 的物理迁移吞吐。
+
+**代价：** PACE 内部线程仍可能等待 200～300 ms；并发能力受现有线程池、HTTP handler 和 IO 吞吐
+限制。该代价在当前 C1/C2 下可接受；V1 不能据此无条件提高到大规模并发，也不能把 KVCM 的 Group
+gate 当成 PACE 面向所有调用方的全局 admission。
+
+### D2：异步能力由 backend 显式暴露，不改变同步 `Copy()` 语义
+
+**决定：** 保留 `DataStorageBackend::Copy()`；新增可选的 `CopyAsync()` 能力。不能把现有 `Copy()`
+悄悄改成“提交成功即返回”，否则所有旧调用方都会错误地把未完成目标视为成功。
+
+不支持原生异步的后端继续使用同步接口。启用 `ASYNC_REQUIRED` 时，目标后端不支持异步必须明确拒绝，
+不得静默降级。
+
+### D3：PACE backend 自己负责 submit/query/cancel 和完成收敛
+
+**决定：** `TairMempoolBackend` 拥有专用 Copy coordinator、队列和轮询器；
+`SchedulePlanExecutor` 只完成本地有界准入并拿到最终 future。
+
+当前 V1 使用一个 coordinator 线程串行执行 submit/query/cancel，进程内 operation 硬上限为 1024。
+这保证了共享 executor 不再等待物理 Copy。单线程只串行化控制面 HTTP 调用；已经 submit 的多个 PACE
+物理任务仍可在远端重叠执行。若控制面 HTTP 本身成为瓶颈，再在 Phase C 容量验证后把 coordinator 扩为
+有界 worker pool。
+
+**原因：** PACE task ID、HTTP schema、polling 和 cancel 都是后端协议细节，不应泄漏给通用
+`MigrationManager`。同时避免把轮询任务重新放回共享 executor。
+
+开源仓仅定义通用契约，`DataStorageBackend::SupportsAsyncCopy()` 默认返回 `false`；
+`open_source/TairMempoolBackend` 是无 PACE 实现的 stub，不会让该分支变得可达。真正的
+override 和 PACE 响应映射在内源 `8cac0396 [data_storage] add asynchronous PACE copy
+coordinator`，必须作为独立的下游实现评审和测试。当前映射表如下：
+
+| PACE 观测 | KVCM outcome | `terminal` | `safe_to_reuse_dst` | 处置 |
+|---|---|---:|---:|---|
+| submit 返回完整 task ID 集 | 未终止 | false | false | guard `Submitting -> Active`，继续 query |
+| submit 返回可解析的明确 error，未发布 task | failed | true | true | 允许清理目标 |
+| submit transport/schema 失败或 task ID 不完整 | unknown | false | false | quarantine，不得回收 |
+| query/cancel 所有 item 均 terminal + safe，且 outcome 均 success | success | true | true | promote 目标 |
+| query/cancel 所有 item 均 terminal + safe，至少一项 failed/cancelled | failed/cancelled | true | true | 不 promote，允许清理目标 |
+| 任一 item 非 terminal/非 safe，或 query/not_found/deadline 后仍无 drain 证明 | unknown | false | false | quarantine，不得回收 |
+
+`ErrorCode` 只用于日志/指标；即使它与 outcome 矛盾，Manager 的回收决策也只看
+`terminal && safe_to_reuse_dst`。
+
+### D4：V1 保留 MigrationManager 的 future 边界
+
+**决定：** backend coordinator 在远端 task 终态时完成 promise，`MigrationManager` 仍接收一个最终
+future。V1 不同时重写所有 manager completion 流程。
+
+completion 收尾以 operation 粒度 mutex 串行化 submit-acceptance、Cancel 和终态回调，不再用
+全局 guard mutex 阻塞无关 operation。每个 operation 在进程内还有唯一 credit ledger：
+inflight 只能向 released 或 quarantine 迁移一次，从而即使 Cancel 与 completion 竞争也不会
+双重扣减字节额度或制造 phantom quarantine。
+
+**后续：** 当 operation 数明显增加时，把当前 deque + `wait_for` 轮询改成 completion queue/event，
+见第 14 节。
+
+### D5：目标 Location 保存持久化 Copy guard，并作为跨重启权威
+
+**决定：** 在目标 `CacheLocation` 的内部 JSON 模型中增加可选 `migration_copy_guard`；保持目标状态为
+`CLS_WRITING`，不新增对外暴露的 `CLS_QUARANTINED`。
+
+当前字段如下（代码中的时间字段使用微秒）：
+
+```cpp
+enum class MigrationCopyGuardState {
+    kSubmitting,  // PACE submit 结果尚未可靠持久化
+    kActive,      // task_ids 已持久化，可查询
+    kCancelling,  // 不再允许 promote，等待 drain
+    kUnknown,     // 无法证明 drain，只允许人工/未来恢复流程处理
+};
+
+struct MigrationCopyGuard {
+    uint32_t schema_version = 1;
+    std::string operation_id;
+    MigrationCopyGuardState state;
+    std::string source_location_id;
+    int64_t source_location_create_time;
+    std::string source_storage_name;
+    std::string target_storage_name;
+    MigrationRetention retention;
+    uint64_t total_bytes;
+    std::vector<std::string> backend_task_ids;
+    int64_t create_time_us;
+    int64_t update_time_us;
+    std::string last_error;
+};
+```
+
+该字段只用于 Manager 内部恢复、Reclaimer/GC fencing，不进入 client/connector 的公开
+`CacheLocation` proto。持久 guard 是“目标是否允许回收”的跨重启权威，现有内存
+`CopyTaskState` 只负责本进程内的调度与 completion 认领。
+
+选择 Location JSON 而不是现有 `__mig_tier_target__` block property 的原因是：Reclaimer 和后台 GC
+扫描时天然取得 Location；当前 `MaintenanceScanBatch` 不携带 block property。后台 GC 已使用
+`expected_location_values` 做精确值条件删除，因此 guard 的状态跃迁会改变序列化值，使新版本中已在途
+的旧删除请求因 expected value 不匹配而失效。这是额外安全网，但不能替代扫描阶段的显式 guard 判断。
+
+Reclaimer 和后台 GC 都必须直接检查持久 guard，并在有任意非安全终止 guard 时跳过回收；现有
+`HasActiveCopyTargetLocation()` 仅作为本进程内的快速索引，不能成为正确性依据。后台 GC 不需要新增
+对 MigrationManager 的依赖边，直接从已经读取的 Location JSON 判断即可。
+
+当前实现只接受 `schema_version == 1`、已知 state 且 operation_id 非空的 guard。JSON 中显式存在但
+无法解码、schema 更高、state 未知或字段不完整时，Location 整体解析失败；Leader 恢复扫描遇到此类
+错误会阻止恢复成功，而不是把它静默当成普通 WRITING Location。
+
+`CacheLocation::ToRapidWriter()` 是逐字段序列化，旧二进制不是“无害忽略”未知字段，而是可能在任意
+读-改-写路径静默擦除 guard。因此兼容规则是：
+
+- 异步 feature 只能在全部 Manager 节点升级、旧 Leader 不再可能接管后开启；
+- 关闭 feature 不等于允许降级 binary，恢复/fencing 代码必须继续运行；
+- **任何二进制回滚前，必须停止新异步 submit，并确认全局持久 guard 数为零**；
+- 当前二进制遇到高于自身能力的 `schema_version` 时必须 fail-closed：禁止 promote、删除、复用或重写
+  该 Location，并触发版本不兼容告警；
+- 若无法 drain 到零，只能继续运行能理解 guard 的版本。把 guard 改成独立 key 也不能单独解决旧版本
+  安全问题，除非旧 Reclaimer/GC 同样被改为读取该 key。
+
+除初次创建 `kSubmitting` 外，所有 guard 状态跃迁都必须同时用 `operation_id + expected_state` 做条件
+更新，禁止只凭 operation ID 把已经持久化的 `kUnknown` 回退为 `kCancelling`。终态发布使用一次条件
+metadata mutation 原子地完成“目标变为 `SERVING` 或被安全删除”与“清除 guard”，不能形成已发布目标仍
+长期带 guard 的中间态。
+
+条件 mutation 已生效但 `MetaIndexer::Sync()` 超时时，语义是“最终状态可能已经持久、durability ACK
+未知”，不能当成普通业务失败，也不能再次执行 CAS、重新 Copy 或创建 phantom quarantine。当前实现
+保留已完成的 backend result 和终态 action，只重试 `Sync()`；在 durability 确认前 operation credit
+仍由同一个 operation ledger 持有。
+
+### D6：先做无副作用 credit reservation，再持久化 `kSubmitting`，最后发 POST
+
+**决定：** 操作顺序固定为：
+
+```text
+parse and validate every source size
+  -> reserve group active/byte credits
+  -> allocate dst
+  -> add CLS_WRITING dst
+  -> CAS + Sync kSubmitting guard
+  -> activate local task
+  -> hand off operation to backend coordinator
+  -> POST PACE batch
+  -> persist task_ids and transition to kActive
+```
+
+reservation 是 Manager 本地 accounting，不产生远端副作用。credit 不足时直接拒绝，不分配 GA、不写
+metadata；目标分配或 guard 写入失败时，在确认 backend handoff/POST 尚未发生的前提下回滚目标并释放
+credit。guard 持久化成功后，operation 持有 inflight credit，直到安全终止，或原子转入独立 quarantine
+计量。backend handoff 明确拒绝、且确认没有远端副作用时，也走 definite pre-submit rollback，不制造
+虚假的 UNKNOWN quarantine。
+
+如果进程在 guard 持久化后、POST 前退出，会留下保守的 `kSubmitting` quarantine；如果 POST 已被
+PACE 接受但响应丢失，仍留下同样的 quarantine。由于 PACE 当前不支持按 KVCM operation ID 查询，
+这两个场景无法自动区分。该顺序避免常见本地拒绝路径白分配 GA、白写 metadata，同时保持“POST 前
+guard 必须落盘”的安全屏障。
+
+### D7：未知状态 fail-closed，不自动重试同一目标
+
+**决定：** submit transport timeout、响应无法解析、task `not_found`、`unknown_final`、PACE 重启或恢复
+查询超时，都进入 `kUnknown`：
+
+- 不 promote；
+- 不删除或复用目标 GA；
+- 不对同一个目标自动重新 submit；
+- 保留 source；
+- 告警并进入隔离容量统计。
+
+重新迁移必须创建新的目标和新的 operation，且需受永久失败源 backoff/quarantine 控制。不能对旧
+目标直接重试，否则服务端第一次请求仍可能迟到写入。
+
+### D8：只有 PACE 明确的 drain 证明才能回收目标
+
+**决定：**
+
+```text
+success && terminal && safe_to_reuse_dst
+    -> WRITING target CAS to SERVING
+
+non-success && terminal && safe_to_reuse_dst
+    -> delete target location and GA
+
+otherwise
+    -> keep WRITING + guard, quarantine
+```
+
+不能用 HTTP 失败、KVCM deadline、cancel ACK、Provider incarnation 变化或等待足够久替代 drain 证明。
+本节约束所有自动路径；9.4 的 break-glass 必须先取得独立的外部 fencing 证明，并作为特权、受审计的
+异常流程存在，不能被 Reclaimer/GC 调用。
+
+### D9：异步期间同时保护 source 和 target
+
+**决定：** active/恢复中的 guard 同时保护 target 和它引用的精确 source identity：
+
+- target pin 防止 Reclaimer/GC 把 `CLS_WRITING` 目标当 orphan；
+- Reclaimer、后台 GC 和普通 metadata 删除路径在扫描同一 block 时，若发现 sibling target guard 引用
+  某个 source，则跳过该精确 source；
+- source 身份使用 `location_id + create_time`，防止 ID 复用误保护新 Location。
+
+当前实现没有把独立 guard 字段写入 source Location；source 保护来自目标 Location 中持久化的
+`source_location_id + source_location_create_time`，以及当前进程 active task 的快速索引。Leader 恢复先
+扫描所有 target guard，再允许迁移准入；回收路径每次从同一 block 的 sibling target guard 重建判断。
+
+这里仍有一个已知窄竞态：若普通 source 删除在 guard 建立前已经完成候选准入和 expected-value 快照，
+随后才执行 CAS，目标 guard 的新增不会改变 source JSON，因此该旧 CAS 仍可能成功。当前所有新删除
+请求都使用精确 Location value CAS，且扫描阶段会识别 guard，但这不能消除“已在途旧 CAS”窗口。若
+Phase C 故障注入证明该窗口可达，后续必须把 source pin 持久化到 source JSON，或用单次原子 RMW 同时
+安装 source/target fence；当前版本不能宣称拥有跨两个 Location 的原子 source pin。
+
+### D10：任务数、字节数与 quarantine 三重反压
+
+**当前实现：** 保留 Instance Group 级 `copy_max_concurrency`，并新增：
+
+- Instance Group 级 `copy_max_inflight_bytes`；
+- Instance Group 级 `copy_max_quarantine_operations` 和 `copy_max_quarantine_bytes`；
+- `TairMempoolBackend` 进程内最多 1024 个异步 operation；
+- 单 coordinator 线程天然限制 submit/query/cancel 的同时执行数。
+
+异步 feature 开启时必须显式配置正数的 byte limit；不允许用 0 表示无限。任一 source URI 的 `size`
+缺失、非法、为 0，或求和溢出时必须在 reservation 前拒绝，不能按 0 或“保守猜测值”继续。首轮保持
+`copy_max_concurrency=1`，在 68/136 MiB 真实尺寸下完成验收后才允许升到 2。
+
+当 quarantine bytes/operations 达到阈值时，受影响 Group 的新异步 operation 被硬拒绝；
+`ASYNC_REQUIRED` 下不得自动回退到同步接口。该容量 gate 能阻止继续突破已配置隔离容量，但它还不是
+一个完整 circuit breaker：unknown 比例/连续 unknown、持久化 open 状态、恢复水位和 half-open probe
+均未实现。
+
+operation 转 `kUnknown` 时，当前实现会在同一个本地 accounting 临界区把 op/bytes 从 inflight credit
+转移到 quarantine credit，避免先释放后补记或双重计量。重启恢复会扫描持久 guard，重建 inflight 与
+quarantine 基线。unknown rate breaker 的 open 状态、原因和 `opened_at` 持久化属于未来工作。
+
+### D11：同步和异步模式只在 operation 边界切换
+
+**决定：** feature gate 支持 `SYNC` 和 `ASYNC_REQUIRED`：
+
+- 新 operation 按当时配置选择模式；
+- 已经进入 `kSubmitting/kActive/kCancelling/kUnknown` 的 operation 必须沿异步恢复链收敛；
+- 从异步回滚到同步前，先停止新异步准入并等待 active operation drain；unknown quarantine 不阻止
+  关闭功能，但必须继续受 Reclaimer/GC 保护；
+- 从新二进制回滚到不识别 guard 的旧二进制前，必须额外确认持久 guard 数为零。
+
+不得在异步 POST 结果不明确时回退调用 `/batch_sync`，否则可能双写同一目标。
+
+### D12：未选择方案
+
+| 方案 | 未作为 V1 最终方案的原因 | 可保留用途 |
+|---|---|---|
+| 把现有 `/batch_sync` 放入独立线程池 | 只能把阻塞从共享 worker 移到专用 worker，仍长期占用线程和 client handle，也没有远端 task 恢复语义 | 异步 V1 未完成前的短期隔离措施 |
+| 把 URL 改成 `/batch`，submit 成功就完成 future | 把“任务已创建”误当成“数据已复制”，会提前 promote 未完成目标 | 禁止 |
+| 任何错误都删除目标 | timeout、`not_found` 和响应丢失都可能伴随迟到写，存在 GA 复用冲突 | 仅适用于明确未产生远端任务或已有 drain 证明 |
+| 对 ambiguous submit 自动重试同一目标 | PACE 当前没有 caller idempotency key，可能形成两个任务并发写同一目标 | PACE 幂等能力完成后重新评估 |
+| 由 `SchedulePlanExecutor` 直接负责 HTTP polling | PACE 协议细节上浮到 manager，共享 executor 再次被轮询污染 | 禁止；polling 归 backend coordinator |
+| 等 PACE Provider 真异步完成后再改 KVCM | 会把双方改造绑定为一个大版本，而当前 submit/query API 已足够解除 KVCM 长等待 | PACE 真异步独立作为后续优化 |
+| 引入跨组件 callback/message queue | 改动和运维面过大，当前低并发 polling 足够 | poll 成为瓶颈后再评估 |
+
+PACE 的 sync wrapper 在 timeout 后也会 cancel/query，并可能返回 task IDs 与 outcome unknown；把它搬到
+独立线程池只能隔离线程，不能自动获得目标 drain 证明或重启恢复语义。
+
+### D13：`concurrency=1` 的收益与独立同步线程池取舍
+
+V1 首发维持 C1，不是为了提高同一 Group 的 Copy 吞吐，而是先验证生命周期契约。基于当前默认
+2 个 executor worker、migration worker budget 为 1，以及 136 MiB Copy 约 259～281 ms，可作如下
+对比：
+
+| 维度 | 当前同步路径（C1） | `/batch_sync` 独立线程池（C1） | 完整异步 V1（C1） |
+|---|---|---|---|
+| 同一 Group Copy 吞吐 | 受单次物理 Copy RT 限制 | 基本不变 | 基本不变 |
+| migration worker 占用 | 唯一 migration slot 被占约 259～281 ms | 仅提交到专用池，但专用线程持续阻塞 | 仅本地 handoff 时间 |
+| PACE client handle | 持有完整 Copy RT | 仍持有完整 Copy RT | submit/query 间可按 coordinator 设计复用或归还 |
+| Provider HTTP handler | 每个 URI pair 等待完整 Copy RT；C1、两个 item 时约占 `2/256` | 不变 | 不变；V1 只异步化 KVCM，未改 Provider |
+| `DataStorageManager` 生命周期锁 | 持有完整 backend 调用 | 若只搬线程仍然长持 | 仅取得 backend `shared_ptr` |
+| KVCM 重启后的远端 task 恢复 | 无 | 无；sync wrapper timeout 仍可能 outcome unknown | 有持久 guard + task IDs + query/cancel |
+| 安全提高到 C8/C16 的基础 | 无 | 只有线程隔离，没有目标生命周期和 bytes 反压 | 有，但仍需 PACE 容量验收 |
+
+因此，若系统长期只运行 C1～C2，独立同步线程池是更便宜的短期隔离措施；它不能解决远端任务重启
+恢复、ambiguous outcome、storage close 和目标安全回收。选择完整异步 V1 的理由是这些生命周期问题
+本身必须解决，并为后续并发扩展建立契约，而不是宣称 C1 下吞吐会提升。
+
+从 PACE 侧看，当前 C1 的主要故障表现也不是 HTTP 线程池耗尽，而是 Copy 吞吐小于热层写入吞吐后，
+KVCM slot 长期占用、下沉停滞和水位继续上升。只有多个 Group/caller 汇聚、unknown/quarantine 旧任务
+与新 active 任务重叠，或显著提高 concurrency 后，Provider handler/Meta worker 才可能成为优先问题。
+
+## 6. V1 总体架构
+
+```mermaid
+flowchart TD
+    R[Reclaimer / Admin MigrateCache]
+    M[MigrationManager]
+    A[Validate size + reserve credits]
+    G[Persist CLS_WRITING + Copy Guard]
+    E[SchedulePlanExecutor short admission]
+    B[TairMempoolBackend CopyCoordinator]
+    Q[Bounded local queue]
+    S[PACE Submit /copy_ga/batch]
+    P[Batch poll with backoff]
+    C[Completion promise]
+    O{Outcome}
+    V[CAS target SERVING]
+    D[Delete drained target]
+    U[Keep WRITING + Unknown quarantine]
+
+    R --> M --> A --> G --> E --> B --> Q --> S --> P --> C --> O
+    O -->|success + safe| V
+    O -->|failed/cancelled/timedout + safe| D
+    O -->|not safe / not found / ambiguous| U
+```
+
+一次正常迁移的顺序为：
+
+1. `MigrationManager` 严格解析全部 source URI 的正数 `size`，检查求和溢出，并取得 op/byte
+   reservation；失败时不分配目标、不写 metadata。
+2. 分配目标 URI，创建 `CLS_WRITING` Location，再以精确 CAS + `Sync` 安装 `kSubmitting` guard；guard
+   中记录 source 的精确 identity，供所有回收路径 fencing。
+3. `SchedulePlanExecutor` 调用 `DataStorageManager::CopyAsync()`；该调用只把已 reservation 的 operation
+   交给 backend 有界队列，立即返回最终 future，不执行远端 HTTP。
+4. Copy coordinator 获取 PACE client，向 `/copy_ga/batch` 提交，并严格校验 task ID 数量和顺序。
+5. 成功拿到 task IDs 后，按 operation_id 和目标 Location 身份条件更新 guard 为 `kActive`。
+6. coordinator 按批次轮询。每次响应必须保留 HTTP status、task state、outcome、terminal、drained 和
+   `safe_to_reuse_dst`，不能提前折叠成 `ErrorCode`。
+7. 所有 item 收敛后，coordinator exactly-once 完成 promise。
+8. `MigrationManager` 沿现有完成认领逻辑收尾；成功前再次确认 source 的
+   `location_id + create_time + CLS_SERVING`。
+9. 成功时原子地把目标从 `WRITING` 转为 `SERVING` 并清 guard；安全失败时删除目标；未知时保留 guard。
+
+## 7. KVCM 接口设计
+
+### 7.1 通用异步 Copy 结果
+
+当前在 `data_storage` 定义：
+
+```cpp
+enum class AsyncCopyOutcome {
+    kSuccess,
+    kFailed,
+    kCancelled,
+    kUnknown,
+};
+
+struct AsyncCopyItemResult {
+    AsyncCopyOutcome outcome = AsyncCopyOutcome::kUnknown;
+    bool terminal = false;
+    bool safe_to_reuse_dst = false;
+    ErrorCode error = EC_ERROR;  // only for diagnostics/metrics/backoff
+    std::string backend_task_id;
+    std::string detail;
+};
+
+struct AsyncCopyBatchResult {
+    ErrorCode status = EC_UNKNOWN;
+    std::vector<AsyncCopyItemResult> items;
+    std::string detail;
+};
+
+struct AsyncCopyRemoteSubmitResult {
+    ErrorCode status = EC_UNKNOWN;
+    bool accepted = false;
+    bool acceptance_unknown = false;
+    std::string operation_id;
+    std::vector<std::string> backend_task_ids;
+    std::string detail;
+};
+
+struct AsyncCopySubmitResult {
+    ErrorCode status = EC_UNIMPLEMENTED;
+    bool accepted = false;  // 仅表示已交给本地 coordinator
+    bool acceptance_unknown = false;
+    std::string operation_id;
+    std::string detail;
+};
+```
+
+Backend 接口：
+
+```cpp
+virtual bool SupportsAsyncCopy() const { return false; }
+
+virtual AsyncCopySubmitResult CopyAsync(
+    const std::vector<DataStorageUri>& src_uris,
+    const std::vector<DataStorageUri>& dst_uris,
+    const std::string& operation_id,
+    const std::string& trace_id,
+    const AsyncCopyOptions& options,
+    AsyncCopyRemoteSubmitCompletion remote_submit_completion,
+    AsyncCopyCompletion completion);
+
+virtual AsyncCopySubmitResult ResumeAsyncCopy(...);
+virtual ErrorCode RequestCancelAsyncCopy(const std::string& operation_id);
+```
+
+Group op/byte credits 由 `MigrationManager` 在分配目标前保留；backend 本地 queue admission 在
+`CopyAsync()` 内以 mutex 原子完成。`DataStorageManager::CopyAsync()` 只短暂持 manager shared lock 取得
+backend `shared_ptr`，然后把该 `shared_ptr` 捕获到 remote-submit 与 final completion callback 中作为
+生命周期 lease，不跨远端 HTTP 持有 manager lock。
+
+`accepted=true` 只代表 KVCM 本地 coordinator 已接管 operation，不代表 PACE 已受理。PACE POST 的
+受理状态和 task IDs 通过独立 `remote_submit_completion` 返回，最终 terminal/drain 结果通过
+`completion` 返回；`SchedulePlanExecutor` 把这两路 callback 转成 Manager 现有 future 边界。每条路径
+必须 exactly-once 收敛，异常不得留下永久不 ready 的 future。
+
+`outcome + terminal + safe_to_reuse_dst` 是发布和回收判断的唯一语义输入。`ErrorCode` 只用于日志、
+metrics、重试/backoff 分类，禁止用 `EC_OK/EC_ERROR` 单独决定 promote、删除或 GA 复用。
+
+### 7.2 PaceServiceClient
+
+新增三个方法：
+
+```cpp
+SubmitBatchCopyGA(...);
+QueryBatchCopyGA(task_ids, ...);
+CancelBatchCopyGA(task_ids, ...);
+```
+
+HTTP helper 改为返回结构化结果：
+
+```cpp
+struct HttpResult {
+    CURLcode curl_code;
+    long http_status;
+    std::string body;
+};
+```
+
+不能继续用当前 `bool HttpRequest()` 丢弃 HTTP 状态。异步安全判断至少需要区分：
+
+- 明确的接口拒绝；
+- 连接前失败；
+- request body 可能已经发送后的 timeout/reset；
+- 200 查询结果；
+- 404 task not found；
+- 429/503 反压；
+- 无法解析的响应。
+
+任何无法证明“PACE 未产生 task”的 submit 失败都按 acceptance unknown 处理。
+
+Query 必须逐 item 解析，不能只依据 PACE batch response 的 aggregate `summary.failed`。当前 PACE 会把
+`not_found` 计入 failed summary，但对应 item 同时明确给出 `terminal=false`、`drained=false`、
+`safe_to_reuse_dst=false` 和 `outcome=unknown`；若只读取 aggregate，KVCM 会错误删除仍可能被写入的
+目标。
+
+### 7.3 TairMempoolBackend coordinator
+
+Coordinator 至少包含：
+
+- bounded admission queue；
+- operation_id 到 task IDs、输入下标和 promise 的映射；
+- 单独的 submit/query/cancel 执行资源；当前为一个 coordinator 线程；
+- inflight operation/bytes accounting；
+- exactly-once completion；
+- stop admission、cancel request 和 drain 协议；
+- polling backoff；
+- unknown quarantine 回调。
+
+PACE client handle 只按单次 submit/query/cancel HTTP 请求租用，请求返回后立即归还；poll backoff 和
+远端物理执行期间不得持续占有 handle，否则异步化只释放了 executor，没有释放 client pool 压力。
+
+当前 polling interval 来自 Group 配置，默认从 20 ms 逐步退避到 1000 ms；一次 operation 的 task IDs
+作为一个 batch query。poll jitter、跨 operation query 合并和显式 QPS limiter 尚未实现。由于当前只有
+一个 coordinator 线程，这些能力应与未来并发提升一起评估。
+
+### 7.4 DataStorageManager 和 backend 生命周期
+
+`DataStorageManager::CopyAsync()` 只在 `rw_lock_` 内查找并取得 backend 的 `shared_ptr`，随后释放锁。
+remote-submit 和 completion callback 捕获该强引用，直到 exactly-once completion。
+
+通用 `DataStorageBackend::Close()` 契约保持不变；lease、coordinator drain 和 cancel/query 逻辑只在
+`TairMempoolBackend::Close()` 内实现，避免 V1 把所有 backend 都拖入改造。现有
+`DataStorageManager::UnRegisterStorage()` 已经调用 backend `Close()` 并传播非 OK 结果。
+
+当前 `TairMempoolBackend::Close()` 语义为：
+
+1. 关闭新异步准入；
+2. 对尚未向 PACE 提交的任务明确失败并完成 promise；
+3. 对已经提交的任务发 cancel request，但不把 cancel ACK 当作 drained；
+4. 对已提交任务做一次 cancel/query 收敛；没有 drain 证明的任务通过 completion 转为 `kUnknown`；
+5. coordinator 清空并退出后 `Close()` 返回。
+
+普通 storage unregister/update 在调用 `Close()` 前先通过
+`MigrationManager::HasAsyncCopyStorageReference()` 检查 active/quarantine guard；存在引用时
+`UnRegisterStorage()` 返回 `EC_EXIST`，因此不会走进会把任务转 unknown 的 shutdown 路径。当前没有
+单独的 configurable close grace 或 `EC_BUSY`。
+
+进程 shutdown 与 storage unregister 必须区分：shutdown 可以在 guard 已持久化后销毁本进程 backend，
+因为 Registry 配置仍在，新 Leader 可重建 backend 并恢复；unregister/update 会删除恢复所需配置，
+所以有任意引用 guard 时必须拒绝。
+
+`RegistryManager::RemoveStorage()` 已调整为先成功 `UnRegisterStorage()`，再删除持久配置；如果存在
+active/quarantine 引用或 backend Close 失败，配置会保留。`UpdateStorage()` 复用 Remove + Add，继承
+该顺序。未来若引入长时间 close drain，可再增加更明确的 retryable busy error；V1 不修改通用 backend
+契约。
+
+## 8. 状态机与回收契约
+
+### 8.1 KVCM operation 状态
+
+```mermaid
+stateDiagram-v2
+    [*] --> Submitting: persist guard before POST
+    Submitting --> Active: task_ids persisted
+    Submitting --> Unknown: acceptance ambiguous
+    Submitting --> SafeFailure: definite pre-POST handoff rejection
+    Active --> Cancelling: cancel requested
+    Active --> Success: all success + safe
+    Active --> SafeFailure: non-success + safe
+    Active --> Unknown: not_found / unknown_final / query ambiguity
+    Cancelling --> SafeFailure: cancelled/timedout + safe
+    Cancelling --> Unknown: no drain proof
+    Success --> [*]: promote and clear guard
+    SafeFailure --> [*]: delete target
+    Unknown --> Unknown: quarantine until explicit recovery
+```
+
+持久 guard 与现有进程内状态的职责映射如下：
+
+| 持久 `MigrationCopyGuardState` | 可能对应的内存 `CopyTaskState` | 权威职责 |
+|---|---|---|
+| `kSubmitting` | `kPreparing` / `kRunning` | POST 是否可能发生尚未形成可恢复 task IDs；跨重启必须保守隔离 |
+| `kActive` | `kRunning` | task IDs 已持久化，可重建轮询 operation |
+| `kCancelling` | `kPrepareCancelling` / `kCancelling` | 禁止 promote，等待 drain 证明 |
+| `kUnknown` | 可无对应内存 task | 远端最终状态不可证，必须持续 fencing/quarantine |
+| 无 guard | `kCompleting` 后完成，或无 active task | 只有 promote 或安全删除完成后才允许无 guard |
+
+持久 guard 决定恢复与回收权限；内存状态只决定当前进程中谁负责 prepare、cancel 和 completion，仍应在
+Stop 时清空，避免 stale active table 永久阻塞回收。正常运行中，每次会改变回收权限的内存跃迁都必须先
+或原子地落到 guard；若两者不一致，选择更保守的 guard 语义并告警。新 Leader 只从 guard 重建内存态，
+不能反向用空内存表清除 guard。
+
+### 8.2 失败矩阵
+
+| 场景 | KVCM 判断 | target | source | 是否自动重试 |
+|---|---|---|---|---|
+| Group active/byte credit 拒绝 | definite failure | 未分配 | 保留 | 可新建 operation |
+| 目标已分配但 guard 未发布，且确认未发 POST | definite failure | 回滚删除 | 保留 | 可新建 operation |
+| guard 已发布但 coordinator handoff 明确失败，且确认未发 POST | definite failure | 条件删除 guard/目标 | 保留 | 可新建 operation |
+| PACE 明确在建 task 前拒绝整个 batch | definite failure | 删除 | 保留 | 受 backoff 控制 |
+| submit transport timeout/reset | acceptance unknown | quarantine | 保留并由 target guard 精确引用保护 | 否 |
+| task pending/linking/copying/draining | running | 保持 WRITING 并由 guard fencing | 由 target guard 的精确引用保护 | 否 |
+| 全部 success，terminal + safe | success | promote SERVING | 按 retention | 不需要 |
+| failed，terminal + safe | safe failure | 删除 | 保留 | 按错误分类/backoff |
+| cancelled/timed_out，terminal + safe | safe cancellation | 删除 | 保留 | 由上层决定 |
+| `unknown_final` | unknown | quarantine | 保留 | 否 |
+| query `not_found` | unknown | quarantine | 保留 | 否 |
+| KVCM deadline 到期但 PACE 未终态 | cancelling/unknown | cancel 后继续 query；无 drain 则 quarantine | 保留 | 否 |
+| KVCM 重启，guard 有 task IDs | recoverable | 恢复 query | 从 guard 恢复精确引用保护 | 否 |
+| KVCM 重启，guard 仅为 Submitting | unknown | quarantine | 从 guard 恢复精确引用保护 | 否 |
+| PACE Meta/Provider 重启导致状态丢失 | unknown | quarantine | 保留 | 否 |
+
+### 8.3 多 item batch 语义
+
+一个目标 `CacheLocation` 的全部 `location_specs` 是统一发布单元。只有所有 item 都 success + safe 才能
+promote。任一 item 失败时：
+
+- 如果所有已受理 item 都已经 terminal + safe，可以删除整个目标；
+- 如果存在任一 unknown/non-drained item，整个目标进入 quarantine；
+- 不允许只发布成功的部分 spec；
+- result 数量与输入数量不一致按 unknown 处理，不能越界合并或视为普通失败。
+
+这同时要求修复当前 `TairMempoolBackend::Copy()` 在 `batch_results` 短于 `valid_indices` 时直接按下标
+合并的防御性缺口。
+
+## 9. Cancel、shutdown、切主与恢复
+
+### 9.1 Cancel
+
+用户取消的含义是“不再 publish 目标”，不承诺立即中止 Provider 的物理搬运：
+
+1. guard 转为 `kCancelling`；
+2. coordinator 调用 PACE cancel；
+3. 即使后续收到 success，也不 promote；
+4. 继续查询直到 `safe_to_reuse_dst=true` 后删除目标；
+5. deadline 内没有 drain 证明则转 `kUnknown`。
+
+Cancel 与 completion 共享同一个 operation 粒度 transition mutex。两者竞争时只有一个路径能从当前
+guard state 认领终态：若 Cancel 已先把 guard 持久化为 `kCancelling`，迟到 success 只能按 cancelling
+语义收尾，禁止 promote；若 completion 已认领终态，Cancel 不得再次释放 credit、改写 guard 或创建
+quarantine。operation credit 由 operation ID ledger 保证最多释放/转 quarantine 一次。
+
+### 9.2 KVCM 停止和 HA 切主
+
+当前有序停止顺序为：
+
+1. 关闭新的 migration admission；
+2. lifecycle barrier 等待已经进入 prepare/enqueue 的提交返回；
+3. 停止 monitor；
+4. 把仍 active 的原生异步 guard 转为 `kUnknown` 并计入 quarantine；
+5. 清空进程内 active table；后续 backend Close 会停止 coordinator，已提交但没有 drain 证明的任务
+   继续按 unknown 收敛。
+
+因此当前“有序 Stop”是 fail-closed 停机，不承诺把 active task 无缝交给下一 Leader；它会主动降级为
+UNKNOWN quarantine。只有进程崩溃、旧 Leader 未执行 Stop，且持久 guard 已是 `kActive/kCancelling`、
+task IDs 完整时，新 Leader 才能重新 attach 到 PACE task。若 HA 切主要求无 quarantine 的平滑交接，
+需要在未来增加有界 drain/lease handoff，而不能宣称 V1 已具备。
+
+新 Leader 启动时：
+
+1. 暂停 Reclaimer、后台 GC 和新的 migration submit；
+2. 扫描带 `migration_copy_guard` 的 WRITING Location；
+3. 重建 operation 表和 quarantine accounting；回收路径从 target guard 恢复精确 source/target fencing；
+4. `kActive/kCancelling` 且有 task IDs 的 operation 继续 query；
+5. `kSubmitting/kUnknown` 保持 quarantine；
+6. recovery barrier 完成后再启动 Reclaimer 和 GC。
+
+恢复逻辑属于持久 guard 的安全解释器，不受 async submit feature gate 控制：即使配置已切回 `SYNC`，
+只要旧 guard 仍可能存在就必须执行。当前扫描采用每批 256 条、批间暂停 2 ms、整轮最长 5 分钟的有界
+策略；先完成全量扫描、形状校验、operation 去重和 group/instance/backend 校验，再一次性替换内存
+inflight/quarantine accounting，避免半轮失败留下“看似恢复完成”的局部状态。当前 Meta maintenance
+接口不支持按 guard/status 服务端过滤，所以仍是一次全量扫描；后续若规模证明不可接受，应新增持久
+guard 索引，而不是提供跳过恢复的开关。
+
+扫描、全量校验或 Manager 启动任一关键阶段失败时，节点不能持有 Leader lease 却永久关闭 leader-only
+API。当前 Server 会禁用 leader-only 请求、主动 demote，并把下一次 campaign 至少推迟 5 秒，让其它
+节点接管或在外部依赖恢复后重试。单个已有 task 无法 attach 时则 fail-closed 转 quarantine，不阻断其它
+guard 的恢复。backend 的瞬时 `Available()==false` 不能被当成 task 不存在；Manager 仍调用
+`ResumeAsyncCopy()`，由 backend query 返回权威的 running/terminal/unknown 结果。
+
+### 9.3 Reclaimer 和 GC
+
+以下 Location 绝不能作为普通 orphan 删除：
+
+- 带非终止 `migration_copy_guard` 的目标；
+- 带 `kUnknown` guard 的 quarantine 目标；
+- 被同一 block 任一 target guard 引用的 source `location_id + create_time`。
+
+两条回收路径都必须在候选生成阶段直接读取 guard：
+
+| 路径 | 改造前保护 | 当前 V1 保护 |
+|---|---|---|
+| Reclaimer | `HasActiveCopyTargetLocation()` 内存 hook | guard 存在且未安全终止时直接跳过；内存 hook 仅作快速路径 |
+| 后台 GC | orphan 年龄 + 同一内存 hook | `IsOrphanWriting()`/候选生成显式排除 guard，不得仅凭 24h 年龄删除 |
+
+普通 `SchedulePlanExecutor` metadata 删除也执行同样检查：跳过 guarded target，以及 target guard 指向的
+精确 source，并使用完整序列化 Location value 做条件删除。第 D9 节记录的“guard 建立前已经准入的旧
+source CAS”仍是已知窗口，不能由本节检查推导出跨 Location 原子性。
+
+后台 GC 的 `expected_location_values` 条件删除继续保留：guard 在扫描后发生任意状态跃迁时，旧 expected
+value 必须返回 mismatch。该机制是并发安全网，不是 guard fencing 的替代品。V1 不允许仅凭 guard 年龄、
+KVCM deadline 或 PACE task retention 自动解除 quarantine。
+
+### 9.4 Quarantine 运维出口
+
+当前 V1 已提供 HTTP/gRPC 两个最小接口：
+
+1. 按 Instance Group/operation 列出 guard，展示 source/target、task IDs、字节数、状态、年龄和最后一次
+   query 结果；
+2. 对 `kUnknown` guard 执行 break-glass release；请求必须携带非空 operator 和外部 fencing evidence，
+   服务端以 operation ID/state 做精确 CAS，并写 error 级审计日志；
+3. 不提供“仅按年龄批量删除”命令。
+
+当前**没有**手工 reconcile、普通 safe-release 或服务端自动验证外部证据的能力。对永远无法获得 drain
+证明的记录，break-glass 的调用者必须先取得外部 fencing 证据，例如所有相关旧
+   Provider incarnation 已永久停止且目标 storage/segment generation 已失效，能够证明旧 operation
+   不可能在恢复后继续写。接口中的 evidence 字符串是审计材料，不是由 KVCM 验证出的安全证明。
+
+“人工确认”本身不是安全证明。没有外部 fencing 时只能查看并继续 quarantine。手工 reconcile 与取得
+`terminal && safe_to_reuse_dst` 后的普通安全释放，仍应作为生产上线前的运维增强补齐。
+
+## 10. 反压与调度
+
+### 10.1 为什么不能只限制 task 数
+
+4 MiB、68 MiB 和 136 MiB 在当前接口中都算一个 Copy task，但其资源成本相差 17～34 倍。只使用
+`copy_max_concurrency` 会让配置对真实 IO 压力失真。
+
+当前 V1 实际维护以下 accounting/gate：
+
+```text
+group_active_copy_ops        // 复用 copy_max_concurrency
+group_inflight_bytes
+group_quarantine_ops
+group_quarantine_bytes
+backend_process_operations   // 固定上限 1024
+```
+
+尚未实现独立的 process queued bytes/inflight bytes、poll QPS limiter 或可配置 backend queue limit。
+
+字节口径使用 operation 中所有 source URI 的 `size` 之和。当前
+`MigrationManager::PrepareCopyTask()`/batch prepare 把 `spec_size` 初始化为 0 后调用返回 `void` 的
+`StandardUri::GetParamAs()`；参数缺失或解析失败会静默保留 0。`MetaSearcher::BatchAddLocation()` 还有
+`spec_sz` 未初始化后参与累加的现存风险。Phase A 必须先统一修正这些路径：
+
+- 每个 source URI 必须包含可完整解析的正整数 `size`；
+- 同时校验 `CacheLocation::spec_size == location_specs.size()`，并逐个验证每个 spec URI 的 size；
+- 求和必须检查 `uint64_t` 溢出及 `size_t` 截断；
+- 缺失、非法、为 0、溢出一律在 reservation 前返回 `EC_BADARGS` 或等价明确错误；
+- 不允许按 0 绕过，也不使用“保守最大值”继续分配，因为这会让 credit 和实际目标容量产生不可解释的
+  偏差。
+
+准确 bytes 校验完成后才取得 Group active/byte reservation；reservation 失败必须是零 GA、零 metadata
+副作用。
+
+### 10.2 初始部署参数
+
+首轮参数原则：
+
+- `copy_max_concurrency=1`；
+- `copy_max_inflight_bytes` 至少覆盖一个最大业务 block，但只允许一个 136 MiB operation 在途；
+- 通过 Group concurrency/bytes 把正常 backlog 保持在很小范围；backend 固定 1024 上限只是最终
+  fail-safe，不能把 1024 当成目标排队深度；
+- polling 使用退避，不采用 PACE sync wrapper 的 1 ms 高频轮询；
+- 提高并发前必须完成第 13 节的 68/136 MiB 并发矩阵。
+
+文档不固化 512 MiB 或 1 GiB 等生产值；最终值必须根据最大 block、Provider 数、SSD/网络吞吐和前台
+延迟验收确定。配置必须记录当时最大 block 假设。
+
+### 10.3 无进展退避与当前容量 gate
+
+当普通 byte/op credit 用尽或 backend queue 拒绝时，Reclaimer 本轮视为无进展并按正常周期退避。
+不能因为水位仍超阈值就零间隔持续 submit。
+
+quarantine 与普通 credit 不同：当前达到 `copy_max_quarantine_operations/bytes` 后，
+`ReserveAsyncCopyCredit()` 会硬拒绝受影响 Group 的新异步 operation；已有 query/cancel/completion 不受
+影响。安全释放使 accounting 回到阈值以下后，准入自动恢复。
+
+这只是基于当前隔离容量的硬 gate，并非持久 circuit breaker：窗口 unknown 比例、连续 unknown、
+`opened_at/reason` 持久化、PACE health probe、显式 reset 和 half-open 均未实现。在这些能力补齐前，
+不能声称“错误风暴即使尚未耗尽 quarantine 配额也会被主动熔断”；生产参数应把 quarantine 上限设成
+可承受的保守值，并对 unknown 增量告警。
+
+### 10.4 PACE task registry 容量
+
+Meta 默认最多保留 100,000 个 Copy task，terminal 记录从终态发布后继续保留 30 分钟。稳态近似为：
+
+```text
+retained_terminal_task_records ~= terminal_item_completion_rate_per_second * 1800
+```
+
+例如 68 MiB 单 item 在 127～139 ms、并发 8 且完全跑满时，理想完成率约 58～63 item/s，对应约
+104k～113k 条 30 分钟保留记录，已经可能超过默认上限；真实 operation 若包含多个 item，还要按 item
+数放大。因此提高并发前必须同时核算 registry 容量、终态保留时长和全体调用方流量，不能只看 SSD
+吞吐。
+
+PACE batch submit 在发布 task 前原子检查容量；如果 KVCM 收到并成功解析明确的“registry capacity
+不足”响应，这是没有发布该 batch task 的 definite rejection，可以安全回滚尚未提交的目标。若 HTTP
+响应丢失、timeout 或无法解析，仍按 acceptance unknown，不得把后续 `not_found` 当成未受理证明。
+
+### 10.5 Metadata 写放大
+
+异步 guard 会增加条件 metadata 写，必须在提高并发前量化：
+
+| 路径 | 正常 happy path 的 Location mutation |
+|---|---:|
+| 当前同步 Copy | 2 次：新增 WRITING；最终 CAS 为 SERVING |
+| 异步 Copy | 3 次：新增 WRITING+Submitting；持久化 task IDs/Active；最终 CAS 为 SERVING 并清 guard |
+
+因此 happy path 不是笼统的“2 倍 + N”，而是从 2 次增至 3 次，约 1.5 倍。cancel、Unknown、恢复和人工
+reconcile 只在状态真实跃迁时增加写；纯 polling 不得每轮刷新 `updated_at_ms` 或重写相同 guard，否则
+高频 query 会把控制面读放大变成 metadata 写风暴。压测必须单独统计 guard transition write QPS、CAS
+mismatch 和 meta backend P99。
+
+## 11. 配置与兼容性
+
+当前 migration config 已增加：
+
+| 配置 | 含义 | 当前校验/默认值 |
+|---|---|---|
+| `copy_execution_mode` | `SYNC` / `ASYNC_REQUIRED` | 默认 `SYNC` |
+| `copy_max_inflight_bytes` | Group 在途 Copy 字节上限 | 异步模式必须显式为正数 |
+| `copy_max_quarantine_operations` | Group 隔离 operation 容量 gate | 异步模式必须显式为正数 |
+| `copy_max_quarantine_bytes` | Group 隔离目标字节容量 gate | 异步模式必须显式为正数 |
+| `copy_operation_deadline_ms` | KVCM 自动对账上限 | 默认 600000 ms；不能授权回收 |
+| `copy_poll_initial_interval_ms` | 首次/初始 query interval | 默认 20 ms |
+| `copy_poll_max_interval_ms` | polling 退避上限 | 默认 1000 ms，必须小于 deadline |
+
+以下配置尚不存在，不能写入部署配置假定它们生效：可配置 queued operations/bytes、
+`copy_shutdown_grace_ms`、unknown rate window/min samples/max rate、连续 unknown 阈值、breaker recovery
+ratio 和显式 reset。backend operation 上限当前是代码内固定的 1024。
+
+deadline/retention 的配置约束为：
+
+```text
+normal_copy_P99 + queue_retry_poll_margin < copy_operation_deadline_ms
+max_expected_KVCM_recovery_outage + copy_poll_max_interval_ms
+    < PACE_terminal_retention_ms
+PACE_reconcile_timeout_ms < Provider_status_TTL_ms
+```
+
+其中 terminal retention 从终态发布开始计时，不能把
+`copy_operation_deadline_ms < PACE_terminal_retention_ms` 当成充分或必要条件。配置校验无法证明外部
+PACE 参数时至少告警并输出两侧实际值。
+
+兼容规则：
+
+- 配置缺失时保持同步行为；
+- `ASYNC_REQUIRED` 遇到不支持异步的 backend 必须拒绝并告警；
+- 旧节点仍可能成为 Leader 时不得开启异步；
+- 关闭异步 feature 不清理既有 guard；恢复逻辑必须始终编译并运行；
+- 回滚到不识别 guard 的旧二进制前，必须通过全局 `guard_count == 0` 运维 gate；当前没有单独的
+  rollback-gate API，需要先扫描/list 确认所有实例无 guard；
+- `operation_deadline` 只停止自动控制面对账，不代表目标安全。
+
+## 12. 可观测性
+
+当前实现提供两层观测：
+
+| 当前观测 | 说明 |
+|---|---|
+| `MigrationStats.async_copy_unknown` | 本进程累计进入 unknown 的异步 operation |
+| `MigrationStats.async_copy_inflight_operations/bytes` | 当前 Group 汇总后的在途数量/字节 |
+| `MigrationStats.async_copy_quarantine_operations/bytes` | 当前恢复/运行时重建的隔离数量/字节 |
+| `MigrationStats.source_*` | 失败源登记、抑制、换源、无可用源和当前 entry 数 |
+| `migration.source_failures_recorded_total` 等低基数指标 | 失败源修复的 registry counter/gauge |
+| quarantine list API | 逐 operation 查看持久 guard、task IDs、字节和错误 |
+
+以下细分指标仍是后续工作：本地 handoff/queue wait、PACE submit RT、远端 execution/end-to-end RT、
+poll QPS/result、task-not-found、按状态 guard 数、guard transition/CAS mismatch、recovery/cancel 分类，以及
+持久 breaker 状态。当前代码没有 `migration.copy_circuit_breaker_*`，不能以不存在的指标作为上线 gate。
+
+日志统一携带：
+
+```text
+instance_group, instance_id, block_key, operation_id,
+source_location_id, target_location_id,
+pace_task_ids, bytes, state, terminal, safe_to_reuse_dst, trace_id
+```
+
+不得把 PACE submit RT 当作 Copy RT。端到端分析继续区分：本地 queue、submit、PACE execution、poll
+收敛和 KVCM promote/delete。Provider `write_remote_us` 仍是物理数据路径的主要指标。
+
+## 13. 测试与验收
+
+### 13.1 设计验收清单
+
+下列条目是完整验收清单，不等同于“全部已经自动化”。已落地的核心路径由 13.2 列出的开源仓测试和
+内源下游 adapter 测试分别覆盖；
+标为未来的条目不得作为当前 V1 能力声明。
+
+1. `CopyAsync()` 本地准入成功后立即返回，不等待模拟远端 completion。
+2. Group byte/op reservation 拒绝时不分配 GA、不写 metadata、不发 PACE 请求；backend 本地 handoff
+   拒绝发生在 guard 后，但必须证明未 POST，并安全回滚而不是进入 remote UNKNOWN。
+3. submit task ID 数量或类型错误按 unknown 收敛，不越界合并。
+4. success 但 `safe_to_reuse_dst=false` 不 promote。
+5. failed/cancelled/timedout 但未 drained 不删除目标。
+6. `not_found` 和 transport ambiguity 创建/保留 `kUnknown` guard。
+7. promise 在成功、异常、stop 和 cancel 所有路径 exactly-once 完成。
+8. target guard 与精确 source identity 使用 Instance 隔离及 location create_time；另做已准入 source CAS
+   窄竞态故障注入。
+9. 清空 `MigrationManager` active table 后，guarded WRITING 仍分别被 Reclaimer 和 GC 直接排除。
+10. GC 扫描后 guard 状态跃迁会使 `expected_location_values` 条件删除返回 mismatch。
+11. source URI `size` 缺失、非法、为 0、求和溢出，或 `spec_size` 与 specs 数量不一致时，在任何副作用
+    前拒绝。
+12. quarantine 达到 ops/bytes 阈值后硬停新 submit，已有 query/completion 仍可收敛；unknown rate
+    breaker 为未来工作。
+13. storage unregister 在 active/quarantine operation 存在时返回 `EC_EXIST`；backend close 失败时持久
+    storage 配置不能先被删除。
+14. `ErrorCode` 与 `AsyncCopyOutcome` 冲突时，回收判断只服从 outcome/terminal/safe 三元组。
+15. binary rollback 前通过扫描/list 验证 guard 为零；专用自动 gate 为未来工作。
+16. 新版本所有 Location read-modify-write/序列化路径都完整保留 guard 和 `schema_version`；未知 guard
+    schema 必须 fail-closed。
+17. breaker 打开状态跨进程重启保持，并在低水位、PACE probe 和显式 reset 后关闭（未来工作）。
+18. Cancel 与 completion 并发时只有一个终态 owner，credit 只释放或转 quarantine 一次，迟到 success
+    不得越过已经持久化的 `kCancelling` promote。
+19. 终态 CAS 已生效而 `Sync()` 首次失败时，只重试 durability barrier；不得重复 CAS、Copy、清理或
+    生成 phantom quarantine。
+20. Leader recovery 能从持久 guard 重建 active/quarantine accounting；扫描准备、全量校验或 attach
+    任一失败都不得发布部分 accounting，Server 必须 demote 而不是持租约 wedge。
+21. backend 暂时 `Available()==false` 时，恢复路径仍调用 `ResumeAsyncCopy()` 查询已有 task，不能直接
+    合成为 `EC_NOENT`/unknown。
+
+### 13.2 202 Linux 编译与定向单测结果
+
+验证必须遵循 `integration_test/tiered_storage` 的流程，只在 202 测试机的隔离容器源码目录执行，
+**不在 macOS 本机编译**。2026-08-25 已在独立验证目录
+`/flash/airfan-validation/kvcm-async-copy-review-20260825-r1/` 完成本轮重跑；同步到 202 的 14 个改动
+文件均先与本地逐文件核对 SHA-256，容器内仅对改动行执行 clang-format，格式结果再用 patch 回写本地。
+
+验证分为两个彼此独立的组合：
+
+1. 开源仓 `stub_source -> open_source`：验证通用 async framework、manager/meta/service 修正和同步
+   fallback；主二进制构建完成 1488 个 action，随后 8 个定向测试目标全部通过。
+2. 内源 `stub_source -> internal_source@8cac0396`：该源码快照的 adapter 关键文件与 202 容器逐文件
+   SHA-256 一致；验证真正可达的 PACE async adapter，并再次构建生产形态主二进制。202 隔离容器没有
+   公司 Git SSH 私钥，因此构建仅通过 `--override_repository` 复用 202 当天已有的只读依赖快照；没有
+   修改 WORKSPACE、产品源码或依赖版本。
+
+开源仓 in-tree 验证目标：
+
+```text
+//kv_cache_manager:kv_cache_manager_bin                                     PASS (build)
+//kv_cache_manager/data_storage/test:DataStorageManagerTest                 PASS
+//kv_cache_manager/meta/test:meta_dummy_backend_test                        PASS
+//kv_cache_manager/manager/test:MetaSearcherTest                            PASS
+//kv_cache_manager/manager/test:SchedulePlanExecutorTest                    PASS
+//kv_cache_manager/manager/test:MigrationManagerTest                        PASS
+//kv_cache_manager/manager/test:CacheReclaimerTest                          PASS
+//kv_cache_manager/manager/test:CacheGarbageCollectorTest                   PASS
+//kv_cache_manager/service/test:AdminServiceImplTest                        PASS
+```
+
+内源下游 adapter 验证目标（不属于本开源仓源码树）：
+
+```text
+//stub_source/kv_cache_manager/data_storage/test:TairMempoolAsyncBackendTest PASS (1/1)
+//kv_cache_manager:kv_cache_manager_bin                                     PASS (internal production build)
+```
+
+其中 `MigrationManagerTest` 额外覆盖 `UNKNOWN` guard 的 break-glass 精确 CAS、quarantine
+计量释放及缺失 operation/证据拒绝；`AdminServiceImplTest` 覆盖 quarantine 列表字段映射、Group 过滤和
+`external_fencing_confirmed=true` 强校验。它们只证明 KVCM 运维出口的代码契约，不能替代 Phase C 中
+由操作者实际取得外部 fencing 证据的故障演练。
+
+开源仓测试覆盖通用状态机、guard 严格 CAS/schema fail-closed、pre-submit 失败不误入 quarantine、
+cancel/completion 终态 owner、CAS 已生效但 Sync 未确认、恢复 accounting、Reclaimer/GC/普通删除
+fencing，以及失败源退避/换源的实际 `OnTaskFailed()` 接线。PACE submit/query/cancel 响应到
+`terminal/safe_to_reuse_dst` 的最承重映射只由内源 `TairMempoolAsyncBackendTest` 覆盖，不能把该下游
+suite 写成本仓自动化证据。
+
+现有内源 legacy `TairMempoolBackendTest` 在该组合基线上引用了外源尚不存在的
+`DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD` enum，属于两个基线间的既有契约不一致，未用合并另一条 42 文件
+SSD 分支的方式绕过。生产主二进制和本次新增的专用 async backend suite 均已通过；合并前仍需由基线
+维护者统一该 enum 后再恢复 legacy target 全量验证。
+
+### 13.3 待执行故障注入
+
+1. PACE 接受 submit 后丢弃响应。
+2. task 创建后 query 返回 404。
+3. Copy 中重启 KVCM Leader，并由新 Leader 恢复 query。
+4. Copy 中重启 PACE Meta 或 Provider，验证目标进入 quarantine 而非删除。
+5. cancel before submit、during copy、completion race。
+6. KVCM deadline 后 Provider 迟到 success。
+7. storage update/unregister 与 Copy 并发。
+8. executor/coordinator shutdown 时本地 queued、远端 active 和 unknown 三类任务分别收敛。
+9. mixed result batch：部分 success、部分 failed、部分 unknown。
+10. 后台 GC grace period 到期且 active table 为空，guarded target 仍不得删除。
+11. quarantine list 与 break-glass 审计流程；普通 reconcile/safe-release 实现后再补对应自动化。
+
+核心自动化断言为：**没有 `safe_to_reuse_dst=true` 时，任何普通业务、Reclaimer、GC、shutdown 或恢复
+路径都不得删除或复用目标 GA。** 唯一不受此断言覆盖的是 9.4 定义的特权 break-glass；它必须先有
+独立外部 fencing 证明并留下完整审计，不得被自动触发。
+
+### 13.4 待执行性能与稳定性验收
+
+测试矩阵：
+
+- 4 MiB、68 MiB、136 MiB；
+- same-provider、cross-provider；
+- Copy concurrency 1、2、4；更高并发只有前一级通过后才执行；
+- 空闲环境和真实推理压测环境；
+- 持续 30 分钟和长稳测试。
+
+验收关注：
+
+- `SchedulePlanExecutor` worker 占用时间从物理 Copy RT 降为本地准入时间；
+- 前台 KVCM API 和共享 continuation 的 P99 不因 Copy RT 线性增长；
+- payload 校验、SSD commit、source retention 正确；
+- queue、线程、FD、内存和 task registry 有界；
+- 没有未知任务被误删，没有 quarantine 未计量；
+- quarantine operations/bytes 容量 gate 能阻断新的 submit，且不会阻断已有 task 的安全收敛；若上线
+  要求错误率熔断，再验证未来的持久 unknown-rate breaker；
+- concurrency 提升带来的聚合吞吐收益大于前台延迟和 PACE 饱和代价。
+
+## 14. 明确暂缓的未来工作
+
+### 14.1 PACE Provider 真异步返回
+
+**当前不做。** 未来让 Provider 在 `WriteRemote` 成功受理后返回 HTTP 202，由已有 terminal observer 在
+后台更新 Provider registry。Meta 收到 non-terminal 后进入 draining，通过 status 对账。
+
+该改动可以释放 Provider HTTP handler 和 Meta 普通 worker，但必须补齐 LinkPool/fallback 路径的资源
+所有权和终态 metrics。它解决的是 PACE 控制面在高并发下的资源效率，不降低 68/136 MiB 的物理
+Copy RT，也不会自动提高 C1 的 Group 吞吐。
+
+当前无需仅因“单次 Copy 为 200～300 ms”启动该改造：Provider 有 256 个 HTTP 线程，首发 C1 且少量
+item 时 handler 占用低于 1%，KVCM active slot 又会持续到 PACE 终态，不会在正常路径无界提交。评估
+时应优先用实测的 concurrent handler、Meta queue wait、Provider HTTP pool utilization、健康/节点管理
+请求 P99，以及 `active + quarantine` 物理在途数，而不是只看单次 Copy RT。
+
+触发条件包括：
+
+- 多个 Instance Group、KVCM 集群或其它 CopyGA caller 汇聚，使 KVCM 的单 Group gate 无法代表 PACE
+  全局负载；
+- `active + quarantine` 物理在途任务持续增长，或需要把 Copy concurrency 提升到当前 PACE 普通
+  线程池无法承载的水平；
+- Meta/Provider handler 饱和或 queue wait 成为端到端 RT 的主要部分；
+- Copy 明显影响 PACE 健康检查、节点管理或其它控制请求。
+
+### 14.2 caller-provided idempotency key
+
+**当前不做。** PACE 后续接受 KVCM `operation_id/client_request_id`，相同 ID 幂等返回原 task IDs，并支持
+按 request ID 查询。
+
+完成后可自动处理“PACE 已受理但 submit response 丢失”的窗口，显著减少 `kSubmitting` quarantine。
+
+触发条件包括：submit ambiguity/quarantine 在真实运行中出现，或业务要求自动恢复而不能接受人工清理。
+
+### 14.3 PACE task 持久化与拓扑 epoch
+
+**当前不做。** Meta/Provider task registry 后续需要可恢复 operation ledger，并把 topology/provider
+epoch 纳入 task 和 GA 身份。这样 PACE 重启后才能区分仍可恢复、明确失败和永久失效。
+
+触发条件包括：要求 PACE Meta/Provider 滚动升级对在途 Copy 透明，或 task `not_found` 成为主要
+quarantine 来源。
+
+### 14.4 PACE ops + bytes admission
+
+**当前不做。** PACE Meta 和 Provider 后续增加全局、每 Provider、每 node-pair 的在途任务数与字节数
+限制，使用 bounded queue，并在产生副作用前返回 429/503 和 `retry_after_ms`。
+
+V1 由 KVCM 控制负载；当出现多个 KVCM caller、绕过 KVCM 的 Copy 调用方或 PACE 自身需要故障隔离时，
+该能力变为必需。
+
+### 14.5 更高效的状态通知
+
+**当前不做。** 后续可增加 POST batch-status、operation aggregate、long-poll 或完成事件，替代 GET URL
+拼接和高频 polling。
+
+触发条件包括：poll QPS、URL 长度、逐 task reconciliation 或 Meta CPU 成为瓶颈。
+
+### 14.6 KVCM completion queue
+
+V1 为减少改动继续使用最终 future。operation 数量提升后，将 `MigrationManager::MonitorLoop()` 的
+deque round-robin `wait_for` 改为 backend completion queue + condition variable，避免 O(N) 空轮询。
+
+### 14.7 Quarantine 自动化对账与容量治理
+
+V1 已实现最小只读列表、要求 operator/evidence 的 break-glass，以及 quarantine operations/bytes 容量
+gate。手工 reconcile、取得 drain 证明后的普通 safe-release、服务端 fencing evidence 校验、持久化
+unknown-rate circuit breaker、自动恢复、容量预测和批量治理仍是后续工作。任何“按年龄自动删除”都
+必须有新的 drain 证明，不能仅依赖超时或人工点击。
+
+### 14.8 永久失败源隔离与自动换源
+
+Copy 异步化只改变执行和生命周期，不应把 `node not found` 等失败源被反复选择的问题隐含在
+异步状态机里处理。该问题已作为独立 V1 落在同步/异步路径共用的 `MigrationManager` 准入层：按
+`(instance, block, location id, create time, target storage)` 记录进程内失败状态，使用 5 秒起步、
+30 分钟封顶的指数退避；存在其它完整副本时优先换源，全部候选仍在 backoff 时本轮不分配目标、
+不提交 Copy。
+
+由于当前 PACE 错误仍被折叠为聚合 `ErrorCode`，V1 不自动删除 source，也不持久化“永久失效”结论。
+rich error、topology epoch、持久 quarantine 和权威 stale-location 清理继续保留为未来工作。详见
+[永久 Copy 失败源隔离与换源缺陷](../../integration_test/tiered_storage/docs/operations/15_KVCM_PERMANENT_COPY_FAILURE_SOURCE_QUARANTINE_2026-08-19.md)。
+
+## 15. 分阶段交付计划
+
+### Phase A：安全基础（代码与定向单测完成）
+
+- rich `AsyncCopyOutcome` 和 `safe_to_reuse_dst`；
+- `migration_copy_guard` 及条件更新；
+- target guard，以及由 sibling target guard 派生的精确 source fencing；
+- Reclaimer 与后台 GC 分别直接读取 guard fencing，并保留 expected-value 条件删除；
+- 明确 persistent guard 与 volatile `CopyTaskState` 的权威映射；
+- 修复所有相关 URI `size` 解析、未初始化值、正数校验和溢出检查；
+- Group op/byte reservation；pre-submit 明确失败安全回滚；
+- feature gate、byte/quarantine 配置与容量 gate；
+- guard/quarantine stats、最小 list/break-glass 审计接口；
+- operation/state 双条件 CAS、operation 粒度 transition 串行化和唯一 credit ledger；
+- CAS 已生效但 Sync 未确认时仅重试 durability barrier；
+- 有界 recovery 扫描、全量校验后原子重建 accounting，以及恢复失败主动 demote；
+- 二进制回滚前 guard 清零的运维约束。
+
+尚未完成的安全增强是跨 Location 原子 source pin、持久 rate breaker、普通 reconcile/safe-release 和专用
+binary rollback gate；其上线要求按第 9、10、13、16 节执行，不能被“Phase A 代码完成”掩盖。
+
+### Phase B：KVCM 原生异步（代码与定向单测完成）
+
+- `PaceServiceClient` submit/query/cancel；
+- `TairMempoolBackend` coordinator；
+- `DataStorageManager`/backend lifecycle lease；
+- storage Close 失败时 Registry 配置删除顺序/补偿修复；
+- `SchedulePlanExecutor` 短准入；
+- cancel、fail-closed shutdown、Leader recovery；
+- 202 Linux 主二进制构建、开源仓定向 suite 与内源 PACE adapter suite。
+
+集群故障注入和性能验证属于 Phase C，尚未完成。
+
+### Phase C：受控上线
+
+- 全 Manager 节点升级，确认旧 Leader 不会接管；
+- `copy_execution_mode=SYNC` 下先验证兼容；
+- 单个 Instance Group 开启 `ASYNC_REQUIRED`；
+- concurrency 1 运行 same/cross smoke 和真实 68/136 MiB 压测；
+- 演练 crash recovery、Stop→UNKNOWN、quarantine list、break-glass 审计和容量 gate；
+- 在生产开启前决定是否补齐普通 reconcile/safe-release 与持久 rate breaker；
+- 观察 quarantine、PACE task registry 估算/实值、前台延迟和资源水位；
+- 验证关闭 feature 后 guard 仍受保护，并演练 guard 清零后的二进制回滚 gate；
+- 通过后再评估 concurrency 2。
+
+### Phase D：按证据启动 PACE 后续改造
+
+只有第 14 节的触发条件成立时，才分别启动 Provider 真异步、幂等、持久化、字节 admission 或状态
+通知工作，不把它们作为 V1 的隐含依赖。
+
+## 16. 已知限制与上线声明
+
+完成 Phase C 前，以下是“代码能力声明”，不是“已上线验证声明”：
+
+- KVCM 共享迁移 worker 不再等待完整 CopyGA 物理执行；
+- KVCM 对远端异步任务使用 drain-safe 的目标生命周期；
+- Reclaimer 和后台 GC 不会因进程内 active table 丢失或 WRITING 年龄到期而回收 guarded target；
+- quarantine 有进程内重建计量、operations/bytes 容量 gate、只读列表和受审计的 break-glass 出口；
+- 低并发下可以安全复用 PACE 现有异步接口。
+
+不能声明：
+
+- PACE 内部已经完全非阻塞；
+- 136 MiB Copy RT 已降到 10 ms；
+- submit response 丢失可以自动 exactly-once 恢复；
+- PACE 重启对在途 Copy 透明；
+- C1 下同一 Group Copy 吞吐会因异步化自动提高；
+- 可以无条件提高 Copy 并发；
+- 当前有并行 HTTP submit/query worker pool（单 coordinator 只能串行控制请求，远端物理任务可重叠）；
+- 已有持久化 unknown-rate circuit breaker、手工 reconcile 或普通 safe-release；
+- 有序 Stop 能无 quarantine 地把 active operation 交给新 Leader；
+- source pin 与 target guard 是跨两个 Location 的原子事务；
+- 存在持久 guard 时可以回滚到不识别 guard 的旧二进制；
+- `not_found` 表示目标可以回收。
+
+V1 的核心取舍是：**用最小 PACE 改动先建立可恢复、可证明回收的目标生命周期契约，同时解除 KVCM
+长阻塞；对无法证明 drain 的场景以有上限、有运维出口的 quarantine 换取数据安全。** 后续是否继续改
+PACE，由真实并发、线程池饱和、task registry 容量、unknown 比例和运维恢复目标驱动，而不是在本轮
+一次性扩大改造范围。

--- a/kv_cache_manager/config/cache_config.h
+++ b/kv_cache_manager/config/cache_config.h
@@ -65,6 +65,23 @@ public:
     const MigrationConfig &migration_config() const { return migration_config_; }
     int64_t migration_copy_max_concurrency() const { return migration_config_.copy_max_concurrency(); }
     MigrationMarkClearPolicy migration_mark_clear_policy() const { return migration_config_.mark_clear_policy(); }
+    MigrationCopyExecutionMode migration_copy_execution_mode() const {
+        return migration_config_.copy_execution_mode();
+    }
+    uint64_t migration_copy_max_inflight_bytes() const { return migration_config_.copy_max_inflight_bytes(); }
+    int64_t migration_copy_max_quarantine_operations() const {
+        return migration_config_.copy_max_quarantine_operations();
+    }
+    uint64_t migration_copy_max_quarantine_bytes() const { return migration_config_.copy_max_quarantine_bytes(); }
+    int64_t migration_copy_operation_deadline_ms() const {
+        return migration_config_.copy_operation_deadline_ms();
+    }
+    int64_t migration_copy_poll_initial_interval_ms() const {
+        return migration_config_.copy_poll_initial_interval_ms();
+    }
+    int64_t migration_copy_poll_max_interval_ms() const {
+        return migration_config_.copy_poll_max_interval_ms();
+    }
     // Setters
     void set_reclaim_strategy(const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy) {
         reclaim_strategy_ = reclaim_strategy;
@@ -83,6 +100,27 @@ public:
     }
     void set_migration_mark_clear_policy(MigrationMarkClearPolicy migration_mark_clear_policy) {
         migration_config_.set_mark_clear_policy(migration_mark_clear_policy);
+    }
+    void set_migration_copy_execution_mode(MigrationCopyExecutionMode value) {
+        migration_config_.set_copy_execution_mode(value);
+    }
+    void set_migration_copy_max_inflight_bytes(uint64_t value) {
+        migration_config_.set_copy_max_inflight_bytes(value);
+    }
+    void set_migration_copy_max_quarantine_operations(int64_t value) {
+        migration_config_.set_copy_max_quarantine_operations(value);
+    }
+    void set_migration_copy_max_quarantine_bytes(uint64_t value) {
+        migration_config_.set_copy_max_quarantine_bytes(value);
+    }
+    void set_migration_copy_operation_deadline_ms(int64_t value) {
+        migration_config_.set_copy_operation_deadline_ms(value);
+    }
+    void set_migration_copy_poll_initial_interval_ms(int64_t value) {
+        migration_config_.set_copy_poll_initial_interval_ms(value);
+    }
+    void set_migration_copy_poll_max_interval_ms(int64_t value) {
+        migration_config_.set_copy_poll_max_interval_ms(value);
     }
     void set_migration_config(const MigrationConfig &migration_config) {
         migration_config_ = migration_config;

--- a/kv_cache_manager/config/cache_config.h
+++ b/kv_cache_manager/config/cache_config.h
@@ -82,6 +82,9 @@ public:
     int64_t migration_copy_poll_max_interval_ms() const {
         return migration_config_.copy_poll_max_interval_ms();
     }
+    int64_t migration_copy_connect_timeout_ms() const { return migration_config_.copy_connect_timeout_ms(); }
+    int64_t migration_copy_submit_timeout_ms() const { return migration_config_.copy_submit_timeout_ms(); }
+    int64_t migration_copy_query_timeout_ms() const { return migration_config_.copy_query_timeout_ms(); }
     // Setters
     void set_reclaim_strategy(const std::shared_ptr<CacheReclaimStrategy> &reclaim_strategy) {
         reclaim_strategy_ = reclaim_strategy;
@@ -121,6 +124,15 @@ public:
     }
     void set_migration_copy_poll_max_interval_ms(int64_t value) {
         migration_config_.set_copy_poll_max_interval_ms(value);
+    }
+    void set_migration_copy_connect_timeout_ms(int64_t value) {
+        migration_config_.set_copy_connect_timeout_ms(value);
+    }
+    void set_migration_copy_submit_timeout_ms(int64_t value) {
+        migration_config_.set_copy_submit_timeout_ms(value);
+    }
+    void set_migration_copy_query_timeout_ms(int64_t value) {
+        migration_config_.set_copy_query_timeout_ms(value);
     }
     void set_migration_config(const MigrationConfig &migration_config) {
         migration_config_ = migration_config;

--- a/kv_cache_manager/config/migration_strategy.cc
+++ b/kv_cache_manager/config/migration_strategy.cc
@@ -126,6 +126,24 @@ bool MigrationConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
                                 "mark_clear_policy",
                                 mark_clear_policy_,
                                 MigrationMarkClearPolicy::CLEAR_ON_NEXT_WRITE_SUCCESS);
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "copy_execution_mode", copy_execution_mode_, MigrationCopyExecutionMode::SYNC);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "copy_max_inflight_bytes", copy_max_inflight_bytes_, uint64_t{0});
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "copy_max_quarantine_operations", copy_max_quarantine_operations_, int64_t{0});
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "copy_max_quarantine_bytes", copy_max_quarantine_bytes_, uint64_t{0});
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "copy_operation_deadline_ms",
+                                copy_operation_deadline_ms_,
+                                MigrationConfig::kDefaultCopyOperationDeadlineMs);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "copy_poll_initial_interval_ms",
+                                copy_poll_initial_interval_ms_,
+                                MigrationConfig::kDefaultCopyPollInitialIntervalMs);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "copy_poll_max_interval_ms",
+                                copy_poll_max_interval_ms_,
+                                MigrationConfig::kDefaultCopyPollMaxIntervalMs);
     KVCM_JSON_GET_MACRO(rapid_value, "strategies", strategies_);
     return true;
 }
@@ -133,6 +151,13 @@ bool MigrationConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
 void MigrationConfig::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
     Put(writer, "copy_max_concurrency", copy_max_concurrency_);
     Put(writer, "mark_clear_policy", mark_clear_policy_);
+    Put(writer, "copy_execution_mode", copy_execution_mode_);
+    Put(writer, "copy_max_inflight_bytes", copy_max_inflight_bytes_);
+    Put(writer, "copy_max_quarantine_operations", copy_max_quarantine_operations_);
+    Put(writer, "copy_max_quarantine_bytes", copy_max_quarantine_bytes_);
+    Put(writer, "copy_operation_deadline_ms", copy_operation_deadline_ms_);
+    Put(writer, "copy_poll_initial_interval_ms", copy_poll_initial_interval_ms_);
+    Put(writer, "copy_poll_max_interval_ms", copy_poll_max_interval_ms_);
     Put(writer, "strategies", strategies_);
 }
 
@@ -148,6 +173,23 @@ bool MigrationConfig::ValidateRequiredFields(std::string &invalid_fields) const 
         mark_clear_policy_ != MigrationMarkClearPolicy::CLEAR_ON_FULL_BLOCK_COVERED) {
         valid = false;
         local_invalid_fields += "{mark_clear_policy}";
+    }
+    if (copy_execution_mode_ != MigrationCopyExecutionMode::SYNC &&
+        copy_execution_mode_ != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        valid = false;
+        local_invalid_fields += "{copy_execution_mode}";
+    }
+    if (copy_operation_deadline_ms_ <= 0 || copy_poll_initial_interval_ms_ <= 0 ||
+        copy_poll_max_interval_ms_ < copy_poll_initial_interval_ms_ ||
+        copy_poll_max_interval_ms_ >= copy_operation_deadline_ms_) {
+        valid = false;
+        local_invalid_fields += "{copy_async_timing}";
+    }
+    if (copy_execution_mode_ == MigrationCopyExecutionMode::ASYNC_REQUIRED &&
+        (copy_max_inflight_bytes_ == 0 || copy_max_quarantine_operations_ <= 0 ||
+         copy_max_quarantine_bytes_ == 0)) {
+        valid = false;
+        local_invalid_fields += "{copy_async_limits}";
     }
     for (const auto &strategy : strategies_) {
         if (strategy == nullptr) {

--- a/kv_cache_manager/config/migration_strategy.cc
+++ b/kv_cache_manager/config/migration_strategy.cc
@@ -144,6 +144,18 @@ bool MigrationConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
                                 "copy_poll_max_interval_ms",
                                 copy_poll_max_interval_ms_,
                                 MigrationConfig::kDefaultCopyPollMaxIntervalMs);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "copy_connect_timeout_ms",
+                                copy_connect_timeout_ms_,
+                                MigrationConfig::kDefaultCopyConnectTimeoutMs);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "copy_submit_timeout_ms",
+                                copy_submit_timeout_ms_,
+                                MigrationConfig::kDefaultCopySubmitTimeoutMs);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value,
+                                "copy_query_timeout_ms",
+                                copy_query_timeout_ms_,
+                                MigrationConfig::kDefaultCopyQueryTimeoutMs);
     KVCM_JSON_GET_MACRO(rapid_value, "strategies", strategies_);
     return true;
 }
@@ -158,6 +170,9 @@ void MigrationConfig::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &
     Put(writer, "copy_operation_deadline_ms", copy_operation_deadline_ms_);
     Put(writer, "copy_poll_initial_interval_ms", copy_poll_initial_interval_ms_);
     Put(writer, "copy_poll_max_interval_ms", copy_poll_max_interval_ms_);
+    Put(writer, "copy_connect_timeout_ms", copy_connect_timeout_ms_);
+    Put(writer, "copy_submit_timeout_ms", copy_submit_timeout_ms_);
+    Put(writer, "copy_query_timeout_ms", copy_query_timeout_ms_);
     Put(writer, "strategies", strategies_);
 }
 
@@ -184,6 +199,17 @@ bool MigrationConfig::ValidateRequiredFields(std::string &invalid_fields) const 
         copy_poll_max_interval_ms_ >= copy_operation_deadline_ms_) {
         valid = false;
         local_invalid_fields += "{copy_async_timing}";
+    }
+    if (copy_connect_timeout_ms_ <= 0 || copy_submit_timeout_ms_ < copy_connect_timeout_ms_ ||
+        copy_query_timeout_ms_ < copy_connect_timeout_ms_ ||
+        copy_submit_timeout_ms_ >= copy_operation_deadline_ms_ ||
+        copy_query_timeout_ms_ >= copy_operation_deadline_ms_ ||
+        copy_submit_timeout_ms_ >
+            copy_operation_deadline_ms_ / MigrationConfig::kMinCopyHttpTimeoutWindowsPerDeadline ||
+        copy_query_timeout_ms_ >
+            copy_operation_deadline_ms_ / MigrationConfig::kMinCopyHttpTimeoutWindowsPerDeadline) {
+        valid = false;
+        local_invalid_fields += "{copy_async_http_timing}";
     }
     if (copy_execution_mode_ == MigrationCopyExecutionMode::ASYNC_REQUIRED &&
         (copy_max_inflight_bytes_ == 0 || copy_max_quarantine_operations_ <= 0 ||

--- a/kv_cache_manager/config/migration_strategy.h
+++ b/kv_cache_manager/config/migration_strategy.h
@@ -22,6 +22,11 @@ enum class MigrationMarkClearPolicy {
     CLEAR_ON_FULL_BLOCK_COVERED = 1, // target CacheLocation 覆盖完整 block 后清标
 };
 
+enum class MigrationCopyExecutionMode {
+    SYNC = 0,
+    ASYNC_REQUIRED = 1,
+};
+
 // Copy 执行方式：通过 DataStorageBackend::Copy 把数据复制到目标 storage。
 class MigrationCopyMethod : public Jsonizable {
 public:
@@ -123,6 +128,9 @@ private:
 class MigrationConfig : public Jsonizable {
 public:
     static constexpr int64_t kDefaultCopyMaxConcurrency = 1;
+    static constexpr int64_t kDefaultCopyOperationDeadlineMs = 10 * 60 * 1000;
+    static constexpr int64_t kDefaultCopyPollInitialIntervalMs = 20;
+    static constexpr int64_t kDefaultCopyPollMaxIntervalMs = 1000;
 
     MigrationConfig() = default;
     ~MigrationConfig() override;
@@ -131,6 +139,13 @@ public:
     const std::vector<std::shared_ptr<MigrationStrategy>> &strategies() const { return strategies_; }
     int64_t copy_max_concurrency() const { return copy_max_concurrency_; }
     MigrationMarkClearPolicy mark_clear_policy() const { return mark_clear_policy_; }
+    MigrationCopyExecutionMode copy_execution_mode() const { return copy_execution_mode_; }
+    uint64_t copy_max_inflight_bytes() const { return copy_max_inflight_bytes_; }
+    int64_t copy_max_quarantine_operations() const { return copy_max_quarantine_operations_; }
+    uint64_t copy_max_quarantine_bytes() const { return copy_max_quarantine_bytes_; }
+    int64_t copy_operation_deadline_ms() const { return copy_operation_deadline_ms_; }
+    int64_t copy_poll_initial_interval_ms() const { return copy_poll_initial_interval_ms_; }
+    int64_t copy_poll_max_interval_ms() const { return copy_poll_max_interval_ms_; }
 
     void set_strategies(const std::vector<std::shared_ptr<MigrationStrategy>> &strategies) {
         strategies_ = strategies;
@@ -141,6 +156,13 @@ public:
     void set_mark_clear_policy(MigrationMarkClearPolicy mark_clear_policy) {
         mark_clear_policy_ = mark_clear_policy;
     }
+    void set_copy_execution_mode(MigrationCopyExecutionMode value) { copy_execution_mode_ = value; }
+    void set_copy_max_inflight_bytes(uint64_t value) { copy_max_inflight_bytes_ = value; }
+    void set_copy_max_quarantine_operations(int64_t value) { copy_max_quarantine_operations_ = value; }
+    void set_copy_max_quarantine_bytes(uint64_t value) { copy_max_quarantine_bytes_ = value; }
+    void set_copy_operation_deadline_ms(int64_t value) { copy_operation_deadline_ms_ = value; }
+    void set_copy_poll_initial_interval_ms(int64_t value) { copy_poll_initial_interval_ms_ = value; }
+    void set_copy_poll_max_interval_ms(int64_t value) { copy_poll_max_interval_ms_ = value; }
 
     bool FromRapidValue(const rapidjson::Value &rapid_value) override;
     void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
@@ -150,6 +172,13 @@ private:
     std::vector<std::shared_ptr<MigrationStrategy>> strategies_;
     int64_t copy_max_concurrency_ = kDefaultCopyMaxConcurrency;
     MigrationMarkClearPolicy mark_clear_policy_ = MigrationMarkClearPolicy::CLEAR_ON_NEXT_WRITE_SUCCESS;
+    MigrationCopyExecutionMode copy_execution_mode_ = MigrationCopyExecutionMode::SYNC;
+    uint64_t copy_max_inflight_bytes_ = 0;
+    int64_t copy_max_quarantine_operations_ = 0;
+    uint64_t copy_max_quarantine_bytes_ = 0;
+    int64_t copy_operation_deadline_ms_ = kDefaultCopyOperationDeadlineMs;
+    int64_t copy_poll_initial_interval_ms_ = kDefaultCopyPollInitialIntervalMs;
+    int64_t copy_poll_max_interval_ms_ = kDefaultCopyPollMaxIntervalMs;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/config/migration_strategy.h
+++ b/kv_cache_manager/config/migration_strategy.h
@@ -131,6 +131,13 @@ public:
     static constexpr int64_t kDefaultCopyOperationDeadlineMs = 10 * 60 * 1000;
     static constexpr int64_t kDefaultCopyPollInitialIntervalMs = 20;
     static constexpr int64_t kDefaultCopyPollMaxIntervalMs = 1000;
+    static constexpr int64_t kDefaultCopyConnectTimeoutMs = 1000;
+    static constexpr int64_t kDefaultCopySubmitTimeoutMs = 3000;
+    static constexpr int64_t kDefaultCopyQueryTimeoutMs = 3000;
+    // Keep one control-plane request from consuming most of the operation
+    // deadline. This guarantees at least sixteen timeout windows for a C1
+    // coordinator; shared-backend concurrency still needs a deployment gate.
+    static constexpr int64_t kMinCopyHttpTimeoutWindowsPerDeadline = 16;
 
     MigrationConfig() = default;
     ~MigrationConfig() override;
@@ -146,6 +153,9 @@ public:
     int64_t copy_operation_deadline_ms() const { return copy_operation_deadline_ms_; }
     int64_t copy_poll_initial_interval_ms() const { return copy_poll_initial_interval_ms_; }
     int64_t copy_poll_max_interval_ms() const { return copy_poll_max_interval_ms_; }
+    int64_t copy_connect_timeout_ms() const { return copy_connect_timeout_ms_; }
+    int64_t copy_submit_timeout_ms() const { return copy_submit_timeout_ms_; }
+    int64_t copy_query_timeout_ms() const { return copy_query_timeout_ms_; }
 
     void set_strategies(const std::vector<std::shared_ptr<MigrationStrategy>> &strategies) {
         strategies_ = strategies;
@@ -163,6 +173,9 @@ public:
     void set_copy_operation_deadline_ms(int64_t value) { copy_operation_deadline_ms_ = value; }
     void set_copy_poll_initial_interval_ms(int64_t value) { copy_poll_initial_interval_ms_ = value; }
     void set_copy_poll_max_interval_ms(int64_t value) { copy_poll_max_interval_ms_ = value; }
+    void set_copy_connect_timeout_ms(int64_t value) { copy_connect_timeout_ms_ = value; }
+    void set_copy_submit_timeout_ms(int64_t value) { copy_submit_timeout_ms_ = value; }
+    void set_copy_query_timeout_ms(int64_t value) { copy_query_timeout_ms_ = value; }
 
     bool FromRapidValue(const rapidjson::Value &rapid_value) override;
     void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
@@ -179,6 +192,9 @@ private:
     int64_t copy_operation_deadline_ms_ = kDefaultCopyOperationDeadlineMs;
     int64_t copy_poll_initial_interval_ms_ = kDefaultCopyPollInitialIntervalMs;
     int64_t copy_poll_max_interval_ms_ = kDefaultCopyPollMaxIntervalMs;
+    int64_t copy_connect_timeout_ms_ = kDefaultCopyConnectTimeoutMs;
+    int64_t copy_submit_timeout_ms_ = kDefaultCopySubmitTimeoutMs;
+    int64_t copy_query_timeout_ms_ = kDefaultCopyQueryTimeoutMs;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/config/registry_manager.cc
+++ b/kv_cache_manager/config/registry_manager.cc
@@ -172,10 +172,14 @@ ErrorCode RegistryManager::DisableStorage(RequestContext *request_context, const
 
 ErrorCode RegistryManager::RemoveStorage(RequestContext *request_context, const std::string &global_unique_name) {
     const auto &trace_id = request_context->request_id();
-    auto ec = LoadAndDelete(kRegistryStorageKey, global_unique_name);
-    RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, ec, "load and delete storage failed");
-    ec = data_storage_manager_->UnRegisterStorage(global_unique_name);
+    // Drain/close the runtime backend before deleting the durable config.
+    // Async Copy recovery needs that config to recreate the PACE client; the
+    // old order could lose the only recovery route when Close returned busy or
+    // failed with in-flight operations.
+    auto ec = data_storage_manager_->UnRegisterStorage(global_unique_name);
     RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, ec, "remove storage failed");
+    ec = LoadAndDelete(kRegistryStorageKey, global_unique_name);
+    RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, ec, "load and delete storage failed after backend close");
     PREFIX_LOG_S(INFO, "remove storage OK");
     return ec;
 }

--- a/kv_cache_manager/config/registry_manager.cc
+++ b/kv_cache_manager/config/registry_manager.cc
@@ -176,10 +176,30 @@ ErrorCode RegistryManager::RemoveStorage(RequestContext *request_context, const 
     // Async Copy recovery needs that config to recreate the PACE client; the
     // old order could lose the only recovery route when Close returned busy or
     // failed with in-flight operations.
+    const auto backend = data_storage_manager_->GetDataStorageBackend(global_unique_name);
+    if (!backend) {
+        RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, EC_NOENT, "remove storage failed: runtime backend not found");
+    }
+    const StorageConfig storage_config = backend->GetStorageConfig();
     auto ec = data_storage_manager_->UnRegisterStorage(global_unique_name);
     RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, ec, "remove storage failed");
     ec = LoadAndDelete(kRegistryStorageKey, global_unique_name);
-    RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, ec, "load and delete storage failed after backend close");
+    if (ec != EC_OK) {
+        // The durable registry still contains this storage. Restore the runtime
+        // backend so the current leader matches the state that the next leader
+        // will recover, and so a retry can make progress instead of failing
+        // permanently with EC_NOENT.
+        const auto rollback_ec =
+            data_storage_manager_->RegisterStorage(request_context, global_unique_name, storage_config);
+        if (rollback_ec != EC_OK) {
+            PREFIX_LOG_S(ERROR,
+                         "load and delete storage failed after backend close, and runtime rollback failed, "
+                         "delete ec[%d] rollback ec[%d]",
+                         static_cast<int>(ec),
+                         static_cast<int>(rollback_ec));
+        }
+        RETURN_IF_EC_NOT_OK_WITH_LOG_S(WARN, ec, "load and delete storage failed after backend close");
+    }
     PREFIX_LOG_S(INFO, "remove storage OK");
     return ec;
 }

--- a/kv_cache_manager/config/test/instance_group_test.cc
+++ b/kv_cache_manager/config/test/instance_group_test.cc
@@ -193,6 +193,54 @@ TEST_F(InstanceGroupTest, ProtoRoundTripWithoutBuckets) {
     EXPECT_TRUE(restored.revisit_interval_buckets().empty());
 }
 
+TEST_F(InstanceGroupTest, ProtoRoundTripPreservesAsyncCopyHttpTimeouts) {
+    InstanceGroup original;
+    original.set_name("test_group");
+    original.set_storage_candidates({"local"});
+    original.set_global_quota_group_name("default");
+    original.set_max_instance_count(10);
+    original.set_version(1);
+
+    auto cache_config = std::make_shared<CacheConfig>();
+    cache_config->set_reclaim_strategy(std::make_shared<CacheReclaimStrategy>());
+    cache_config->set_migration_copy_connect_timeout_ms(750);
+    cache_config->set_migration_copy_submit_timeout_ms(2500);
+    cache_config->set_migration_copy_query_timeout_ms(2800);
+    original.set_cache_config(cache_config);
+
+    proto::admin::InstanceGroup proto_msg;
+    ProtoConvert::InstanceGroupToProto(original, &proto_msg);
+    ASSERT_TRUE(proto_msg.has_cache_config());
+    ASSERT_TRUE(proto_msg.cache_config().has_migration_config());
+    const auto &migration_config = proto_msg.cache_config().migration_config();
+    ASSERT_TRUE(migration_config.has_copy_connect_timeout_ms());
+    ASSERT_TRUE(migration_config.has_copy_submit_timeout_ms());
+    ASSERT_TRUE(migration_config.has_copy_query_timeout_ms());
+    EXPECT_EQ(750, migration_config.copy_connect_timeout_ms().value());
+    EXPECT_EQ(2500, migration_config.copy_submit_timeout_ms().value());
+    EXPECT_EQ(2800, migration_config.copy_query_timeout_ms().value());
+
+    InstanceGroup restored;
+    ProtoConvert::InstanceGroupFromProto(&proto_msg, restored);
+    ASSERT_NE(nullptr, restored.cache_config());
+    EXPECT_EQ(750, restored.cache_config()->migration_copy_connect_timeout_ms());
+    EXPECT_EQ(2500, restored.cache_config()->migration_copy_submit_timeout_ms());
+    EXPECT_EQ(2800, restored.cache_config()->migration_copy_query_timeout_ms());
+
+    proto_msg.mutable_cache_config()->mutable_migration_config()->clear_copy_connect_timeout_ms();
+    proto_msg.mutable_cache_config()->mutable_migration_config()->clear_copy_submit_timeout_ms();
+    proto_msg.mutable_cache_config()->mutable_migration_config()->clear_copy_query_timeout_ms();
+    InstanceGroup restored_legacy;
+    ProtoConvert::InstanceGroupFromProto(&proto_msg, restored_legacy);
+    ASSERT_NE(nullptr, restored_legacy.cache_config());
+    EXPECT_EQ(MigrationConfig::kDefaultCopyConnectTimeoutMs,
+              restored_legacy.cache_config()->migration_copy_connect_timeout_ms());
+    EXPECT_EQ(MigrationConfig::kDefaultCopySubmitTimeoutMs,
+              restored_legacy.cache_config()->migration_copy_submit_timeout_ms());
+    EXPECT_EQ(MigrationConfig::kDefaultCopyQueryTimeoutMs,
+              restored_legacy.cache_config()->migration_copy_query_timeout_ms());
+}
+
 TEST_F(InstanceGroupTest, EventReportStorageSpecProtoRoundTripPreservesSnapshotSettings) {
     proto::admin::StorageConfig legacy_proto_config;
     legacy_proto_config.set_global_unique_name("legacy_event_report");

--- a/kv_cache_manager/config/test/migration_strategy_test.cc
+++ b/kv_cache_manager/config/test/migration_strategy_test.cc
@@ -183,6 +183,9 @@ TEST_F(MigrationStrategyTest, TestInCacheConfig) {
         "migration_config": {
             "copy_max_concurrency": 6,
             "mark_clear_policy": 1,
+            "copy_connect_timeout_ms": 750,
+            "copy_submit_timeout_ms": 2500,
+            "copy_query_timeout_ms": 2800,
             "strategies": [
                 {
                     "source_storage_name": "pace_mempool_01",
@@ -204,6 +207,9 @@ TEST_F(MigrationStrategyTest, TestInCacheConfig) {
     ASSERT_TRUE(cache_config.FromJsonString(json));
     ASSERT_EQ(6, cache_config.migration_copy_max_concurrency());
     ASSERT_EQ(MigrationMarkClearPolicy::CLEAR_ON_FULL_BLOCK_COVERED, cache_config.migration_mark_clear_policy());
+    ASSERT_EQ(750, cache_config.migration_copy_connect_timeout_ms());
+    ASSERT_EQ(2500, cache_config.migration_copy_submit_timeout_ms());
+    ASSERT_EQ(2800, cache_config.migration_copy_query_timeout_ms());
     ASSERT_EQ(2u, cache_config.migration_strategies().size());
     ASSERT_EQ("pace_mempool_01", cache_config.migration_strategies()[0]->source_storage_name());
     ASSERT_EQ("pace_ssd_02", cache_config.migration_strategies()[1]->target_storage_name());
@@ -214,6 +220,9 @@ TEST_F(MigrationStrategyTest, TestInCacheConfig) {
     ASSERT_TRUE(parsed.FromJsonString(cache_config.ToJsonString()));
     ASSERT_EQ(6, parsed.migration_copy_max_concurrency());
     ASSERT_EQ(MigrationMarkClearPolicy::CLEAR_ON_FULL_BLOCK_COVERED, parsed.migration_mark_clear_policy());
+    ASSERT_EQ(750, parsed.migration_copy_connect_timeout_ms());
+    ASSERT_EQ(2500, parsed.migration_copy_submit_timeout_ms());
+    ASSERT_EQ(2800, parsed.migration_copy_query_timeout_ms());
     ASSERT_EQ(2u, parsed.migration_strategies().size());
     ASSERT_DOUBLE_EQ(0.70, parsed.migration_strategies()[0]->trigger_threshold());
     ASSERT_EQ(120000, parsed.migration_strategies()[1]->methods().mark().timeout_ms());
@@ -228,7 +237,64 @@ TEST_F(MigrationStrategyTest, TestInCacheConfig) {
     ASSERT_TRUE(no_migration.FromJsonString(json2));
     ASSERT_EQ(CacheConfig::kDefaultMigrationCopyMaxConcurrency, no_migration.migration_copy_max_concurrency());
     ASSERT_EQ(MigrationMarkClearPolicy::CLEAR_ON_NEXT_WRITE_SUCCESS, no_migration.migration_mark_clear_policy());
+    ASSERT_EQ(MigrationConfig::kDefaultCopyConnectTimeoutMs,
+              no_migration.migration_copy_connect_timeout_ms());
+    ASSERT_EQ(MigrationConfig::kDefaultCopySubmitTimeoutMs,
+              no_migration.migration_copy_submit_timeout_ms());
+    ASSERT_EQ(MigrationConfig::kDefaultCopyQueryTimeoutMs, no_migration.migration_copy_query_timeout_ms());
     ASSERT_TRUE(no_migration.migration_strategies().empty());
+}
+
+TEST_F(MigrationStrategyTest, TestMigrationConfigRejectsInvalidAsyncHttpTiming) {
+    const auto expect_invalid = [](const MigrationConfig &config) {
+        std::string invalid_fields;
+        EXPECT_FALSE(config.ValidateRequiredFields(invalid_fields));
+        EXPECT_NE(std::string::npos, invalid_fields.find("copy_async_http_timing"));
+    };
+
+    MigrationConfig config;
+    std::string invalid_fields;
+    ASSERT_TRUE(config.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+
+    config.set_copy_connect_timeout_ms(0);
+    expect_invalid(config);
+
+    config = MigrationConfig();
+    config.set_copy_submit_timeout_ms(config.copy_connect_timeout_ms() - 1);
+    expect_invalid(config);
+
+    config = MigrationConfig();
+    config.set_copy_query_timeout_ms(config.copy_connect_timeout_ms() - 1);
+    expect_invalid(config);
+
+    config = MigrationConfig();
+    config.set_copy_operation_deadline_ms(config.copy_submit_timeout_ms());
+    expect_invalid(config);
+
+    config = MigrationConfig();
+    config.set_copy_operation_deadline_ms(config.copy_query_timeout_ms());
+    expect_invalid(config);
+
+    config = MigrationConfig();
+    config.set_copy_submit_timeout_ms(
+        config.copy_operation_deadline_ms() /
+            MigrationConfig::kMinCopyHttpTimeoutWindowsPerDeadline +
+        1);
+    expect_invalid(config);
+
+    config = MigrationConfig();
+    config.set_copy_query_timeout_ms(
+        config.copy_operation_deadline_ms() /
+            MigrationConfig::kMinCopyHttpTimeoutWindowsPerDeadline +
+        1);
+    expect_invalid(config);
+
+    config = MigrationConfig();
+    config.set_copy_operation_deadline_ms(
+        config.copy_query_timeout_ms() *
+        MigrationConfig::kMinCopyHttpTimeoutWindowsPerDeadline);
+    invalid_fields.clear();
+    EXPECT_TRUE(config.ValidateRequiredFields(invalid_fields)) << invalid_fields;
 }
 
 TEST_F(MigrationStrategyTest, TestCacheConfigRejectsInvalidMigrationCopyConcurrency) {

--- a/kv_cache_manager/data_storage/data_storage_backend.h
+++ b/kv_cache_manager/data_storage/data_storage_backend.h
@@ -53,9 +53,17 @@ struct AsyncCopyBatchResult {
 };
 
 struct AsyncCopyOptions {
+    static constexpr int64_t kMinHttpTimeoutWindowsPerDeadline = 16;
+
     int64_t operation_deadline_ms = 10 * 60 * 1000;
     int64_t initial_poll_interval_ms = 20;
     int64_t max_poll_interval_ms = 1000;
+    // Per-request control-plane budgets.  They are deliberately independent
+    // from the end-to-end operation deadline: an HTTP timeout never proves
+    // that a remote Copy task is terminal or that its destination is safe.
+    int64_t connect_timeout_ms = 1000;
+    int64_t submit_timeout_ms = 3000;
+    int64_t query_timeout_ms = 3000;
 };
 
 using AsyncCopyCompletion = std::function<void(AsyncCopyBatchResult)>;

--- a/kv_cache_manager/data_storage/data_storage_backend.h
+++ b/kv_cache_manager/data_storage/data_storage_backend.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/data_storage/common_define.h"
@@ -12,6 +15,81 @@
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
 namespace kv_cache_manager {
+
+enum class AsyncCopyOutcome : int32_t {
+    kSuccess = 0,
+    kFailed = 1,
+    kCancelled = 2,
+    kUnknown = 3,
+};
+
+// `error` is diagnostic only.  Target reuse is authorized exclusively by
+// `terminal && safe_to_reuse_dst`; callers must never infer safety from an
+// ErrorCode, timeout, task age or HTTP status.
+struct AsyncCopyItemResult {
+    AsyncCopyOutcome outcome = AsyncCopyOutcome::kUnknown;
+    ErrorCode error = EC_UNKNOWN;
+    bool terminal = false;
+    bool safe_to_reuse_dst = false;
+    std::string backend_task_id;
+    std::string detail;
+};
+
+struct AsyncCopyBatchResult {
+    ErrorCode status = EC_UNKNOWN;
+    std::vector<AsyncCopyItemResult> items;
+    std::string detail;
+
+    bool AllSucceeded() const {
+        return !items.empty() && std::all_of(items.begin(), items.end(), [](const auto &item) {
+            return item.terminal && item.safe_to_reuse_dst && item.outcome == AsyncCopyOutcome::kSuccess;
+        });
+    }
+    bool AllTerminalAndSafe() const {
+        return !items.empty() && std::all_of(items.begin(), items.end(), [](const auto &item) {
+            return item.terminal && item.safe_to_reuse_dst;
+        });
+    }
+};
+
+struct AsyncCopyOptions {
+    int64_t operation_deadline_ms = 10 * 60 * 1000;
+    int64_t initial_poll_interval_ms = 20;
+    int64_t max_poll_interval_ms = 1000;
+};
+
+using AsyncCopyCompletion = std::function<void(AsyncCopyBatchResult)>;
+
+// Result of the short remote submission phase.  This is deliberately
+// separate from AsyncCopySubmitResult: CopyAsync() returns after a local
+// coordinator handoff, while this result reports whether PACE accepted the
+// POST and supplies the durable task handles needed for leader recovery.
+struct AsyncCopyRemoteSubmitResult {
+    ErrorCode status = EC_UNKNOWN;
+    bool accepted = false;
+    // True means the POST may have reached PACE but KVCM did not receive an
+    // authoritative task handle set.  The destination must remain fenced.
+    bool acceptance_unknown = false;
+    std::string operation_id;
+    std::vector<std::string> backend_task_ids;
+    std::string detail;
+};
+
+using AsyncCopyRemoteSubmitCompletion = std::function<void(AsyncCopyRemoteSubmitResult)>;
+
+struct AsyncCopySubmitResult {
+    ErrorCode status = EC_UNIMPLEMENTED;
+    // This flag acknowledges only the local coordinator handoff.  Remote PACE
+    // acceptance is reported later through AsyncCopyRemoteSubmitCompletion.
+    bool accepted = false;
+    // Kept for backends that cannot make local handoff atomic.  Native PACE
+    // asynchronous copy always returns false here because no POST happens
+    // before the handoff result is returned.
+    bool acceptance_unknown = false;
+    std::string operation_id;
+    std::vector<std::string> backend_task_ids;
+    std::string detail;
+};
 
 class DataStorageBackend {
 public:
@@ -69,6 +147,58 @@ public:
                                         const std::vector<DataStorageUri> &dst_uris,
                                         const std::string &trace_id) {
         return std::vector<ErrorCode>(src_uris.size(), EC_UNIMPLEMENTED);
+    }
+
+    virtual bool SupportsAsyncCopy() const { return false; }
+
+    // Native asynchronous copy.  A successful return means the backend owns
+    // the completion callback and will invoke it exactly once.  A rejected
+    // request has no remote side effect unless acceptance_unknown is true.
+    virtual AsyncCopySubmitResult CopyAsync(const std::vector<DataStorageUri> &src_uris,
+                                            const std::vector<DataStorageUri> &dst_uris,
+                                            const std::string &operation_id,
+                                            const std::string &trace_id,
+                                            const AsyncCopyOptions &options,
+                                            AsyncCopyRemoteSubmitCompletion remote_submit_completion,
+                                            AsyncCopyCompletion completion) {
+        (void)dst_uris;
+        (void)operation_id;
+        (void)trace_id;
+        (void)options;
+        (void)remote_submit_completion;
+        (void)completion;
+        AsyncCopySubmitResult result;
+        result.status = src_uris.empty() ? EC_BADARGS : EC_UNIMPLEMENTED;
+        result.detail = "backend does not support asynchronous copy";
+        return result;
+    }
+
+    // Reattach a recovered KVCM operation to backend task handles that were
+    // durably recorded before a leader restart.  This must query existing
+    // tasks only; it must never issue a second physical Copy.
+    virtual AsyncCopySubmitResult ResumeAsyncCopy(const std::vector<std::string> &backend_task_ids,
+                                                  size_t expected_items,
+                                                  const std::string &operation_id,
+                                                  const std::string &trace_id,
+                                                  const AsyncCopyOptions &options,
+                                                  AsyncCopyCompletion completion) {
+        (void)backend_task_ids;
+        (void)expected_items;
+        (void)trace_id;
+        (void)options;
+        (void)completion;
+        AsyncCopySubmitResult result;
+        result.operation_id = operation_id;
+        result.status = EC_UNIMPLEMENTED;
+        result.detail = "backend does not support asynchronous copy recovery";
+        return result;
+    }
+
+    // Best-effort request only.  EC_OK means the coordinator accepted the
+    // cancellation intent, not that PACE proved the target drained.
+    virtual ErrorCode RequestCancelAsyncCopy(const std::string &operation_id) {
+        (void)operation_id;
+        return EC_UNIMPLEMENTED;
     }
 
 protected:

--- a/kv_cache_manager/data_storage/data_storage_manager.cc
+++ b/kv_cache_manager/data_storage/data_storage_manager.cc
@@ -129,6 +129,11 @@ ErrorCode DataStorageManager::UnRegisterStorage(const std::string &name) {
         KVCM_LOG_WARN("UnRegisterStorage failed, name: %s not exist", name.c_str());
         return EC_NOENT;
     }
+    if (async_copy_reference_checker_ && async_copy_reference_checker_(name)) {
+        KVCM_LOG_WARN("UnRegisterStorage rejected: storage %s is referenced by an active or quarantined async Copy",
+                      name.c_str());
+        return EC_EXIST;
+    }
     auto ec = iter->second->Close();
     if (ec != EC_OK) {
         KVCM_LOG_WARN("UnRegisterStorage failed, name: %s, type: %d, close storage backend failed with error code: %d",
@@ -139,6 +144,11 @@ ErrorCode DataStorageManager::UnRegisterStorage(const std::string &name) {
     }
     storage_map_.erase(iter);
     return ec;
+}
+
+void DataStorageManager::SetAsyncCopyReferenceChecker(std::function<bool(const std::string &)> checker) {
+    std::unique_lock<std::shared_mutex> lock(rw_lock_);
+    async_copy_reference_checker_ = std::move(checker);
 }
 
 ErrorCode DataStorageManager::DoCleanup() {
@@ -270,6 +280,151 @@ std::vector<ErrorCode> DataStorageManager::Copy(RequestContext *request_context,
     }
     auto storage_backend = iter->second;
     return storage_backend->Copy(src_uris, dst_uris, trace_id);
+}
+
+bool DataStorageManager::SupportsAsyncCopy(const std::string &unique_name) const {
+    std::shared_ptr<DataStorageBackend> storage_backend;
+    {
+        std::shared_lock<std::shared_mutex> lock(rw_lock_);
+        const auto iter = storage_map_.find(unique_name);
+        if (iter == storage_map_.end()) {
+            return false;
+        }
+        storage_backend = iter->second;
+    }
+    return storage_backend != nullptr && storage_backend->SupportsAsyncCopy();
+}
+
+AsyncCopySubmitResult DataStorageManager::CopyAsync(RequestContext *request_context,
+                                                    const std::string &unique_name,
+                                                    const std::vector<DataStorageUri> &src_uris,
+                                                    const std::vector<DataStorageUri> &dst_uris,
+                                                    const std::string &operation_id,
+                                                    const AsyncCopyOptions &options,
+                                                    AsyncCopyRemoteSubmitCompletion remote_submit_completion,
+                                                    AsyncCopyCompletion completion) {
+    SPAN_TRACER(request_context);
+    AsyncCopySubmitResult rejected;
+    rejected.operation_id = operation_id;
+    if (src_uris.size() != dst_uris.size() || src_uris.empty() || !remote_submit_completion || !completion) {
+        rejected.status = EC_BADARGS;
+        rejected.detail = "invalid asynchronous copy input";
+        return rejected;
+    }
+
+    std::shared_ptr<DataStorageBackend> storage_backend;
+    {
+        // The shared_ptr is the backend lifetime lease.  Do not retain the
+        // manager lock across remote submit/poll; Disable/Unregister must not
+        // block behind the duration of a physical CopyGA operation.
+        std::shared_lock<std::shared_mutex> lock(rw_lock_);
+        const auto iter = storage_map_.find(unique_name);
+        if (iter == storage_map_.end() || !iter->second) {
+            rejected.status = EC_NOENT;
+            rejected.detail = "storage does not exist";
+            return rejected;
+        }
+        storage_backend = iter->second;
+        if (!storage_backend->Available()) {
+            rejected.status = EC_NOENT;
+            rejected.detail = "storage is unavailable";
+            return rejected;
+        }
+    }
+
+    if (!storage_backend->SupportsAsyncCopy()) {
+        rejected.status = EC_UNIMPLEMENTED;
+        rejected.detail = "storage backend does not support asynchronous copy";
+        return rejected;
+    }
+    const std::string trace_id = request_context ? request_context->trace_id() : std::string();
+    // Keep the backend alive until the exactly-once completion callback.  The
+    // local shared_ptr above only protects the submit call itself; without the
+    // capture an unregister could destroy the coordinator while PACE is still
+    // executing the operation.
+    auto completion_with_backend_lease =
+        [storage_backend, completion = std::move(completion)](AsyncCopyBatchResult result) mutable {
+            completion(std::move(result));
+        };
+    auto remote_submit_with_backend_lease =
+        [storage_backend,
+         remote_submit_completion = std::move(remote_submit_completion)](AsyncCopyRemoteSubmitResult result) mutable {
+            remote_submit_completion(std::move(result));
+        };
+    return storage_backend->CopyAsync(src_uris,
+                                      dst_uris,
+                                      operation_id,
+                                      trace_id,
+                                      options,
+                                      std::move(remote_submit_with_backend_lease),
+                                      std::move(completion_with_backend_lease));
+}
+
+AsyncCopySubmitResult DataStorageManager::ResumeAsyncCopy(RequestContext *request_context,
+                                                          const std::string &unique_name,
+                                                          const std::vector<std::string> &backend_task_ids,
+                                                          size_t expected_items,
+                                                          const std::string &operation_id,
+                                                          const AsyncCopyOptions &options,
+                                                          AsyncCopyCompletion completion) {
+    SPAN_TRACER(request_context);
+    AsyncCopySubmitResult rejected;
+    rejected.operation_id = operation_id;
+    if (backend_task_ids.empty() || expected_items == 0 || operation_id.empty() || !completion) {
+        rejected.status = EC_BADARGS;
+        rejected.detail = "invalid asynchronous copy recovery input";
+        return rejected;
+    }
+    std::shared_ptr<DataStorageBackend> storage_backend;
+    {
+        std::shared_lock<std::shared_mutex> lock(rw_lock_);
+        const auto iter = storage_map_.find(unique_name);
+        if (iter == storage_map_.end() || !iter->second) {
+            rejected.status = EC_NOENT;
+            rejected.detail = "recovery storage does not exist";
+            return rejected;
+        }
+        storage_backend = iter->second;
+    }
+    // Recovery/query is a control-plane operation over already-issued backend
+    // task IDs.  Data-path Available()==false is commonly transient and must
+    // not be collapsed into permanent EC_NOENT/UNKNOWN quarantine.  Let the
+    // concrete coordinator resume/query the task and report an authoritative
+    // terminal or unknown result instead.  The shared_ptr lease keeps the
+    // backend alive while it does so.
+    if (!storage_backend->SupportsAsyncCopy()) {
+        rejected.status = EC_UNIMPLEMENTED;
+        rejected.detail = "storage backend does not support asynchronous copy recovery";
+        return rejected;
+    }
+    const std::string trace_id = request_context ? request_context->trace_id() : std::string();
+    auto completion_with_backend_lease =
+        [storage_backend, completion = std::move(completion)](AsyncCopyBatchResult result) mutable {
+            completion(std::move(result));
+        };
+    return storage_backend->ResumeAsyncCopy(backend_task_ids,
+                                            expected_items,
+                                            operation_id,
+                                            trace_id,
+                                            options,
+                                            std::move(completion_with_backend_lease));
+}
+
+ErrorCode DataStorageManager::RequestCancelAsyncCopy(const std::string &unique_name,
+                                                     const std::string &operation_id) {
+    if (operation_id.empty()) {
+        return EC_BADARGS;
+    }
+    std::shared_ptr<DataStorageBackend> storage_backend;
+    {
+        std::shared_lock<std::shared_mutex> lock(rw_lock_);
+        const auto iter = storage_map_.find(unique_name);
+        if (iter == storage_map_.end() || !iter->second) {
+            return EC_NOENT;
+        }
+        storage_backend = iter->second;
+    }
+    return storage_backend->RequestCancelAsyncCopy(operation_id);
 }
 
 std::vector<bool> DataStorageManager::Exist(const std::string &unique_name,

--- a/kv_cache_manager/data_storage/data_storage_manager.h
+++ b/kv_cache_manager/data_storage/data_storage_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <shared_mutex>
@@ -35,6 +36,7 @@ public:
     ErrorCode
     RegisterStorage(RequestContext *request_context, const std::string &name, const StorageConfig &storage_config);
     ErrorCode UnRegisterStorage(const std::string &name);
+    void SetAsyncCopyReferenceChecker(std::function<bool(const std::string &)> checker);
     ErrorCode DoCleanup();
 
     std::vector<std::pair<ErrorCode, DataStorageUri>> Create(RequestContext *request_context,
@@ -53,6 +55,23 @@ public:
                                 const std::string &unique_name,
                                 const std::vector<DataStorageUri> &src_uris,
                                 const std::vector<DataStorageUri> &dst_uris);
+    bool SupportsAsyncCopy(const std::string &unique_name) const;
+    AsyncCopySubmitResult CopyAsync(RequestContext *request_context,
+                                    const std::string &unique_name,
+                                    const std::vector<DataStorageUri> &src_uris,
+                                    const std::vector<DataStorageUri> &dst_uris,
+                                    const std::string &operation_id,
+                                    const AsyncCopyOptions &options,
+                                    AsyncCopyRemoteSubmitCompletion remote_submit_completion,
+                                    AsyncCopyCompletion completion);
+    AsyncCopySubmitResult ResumeAsyncCopy(RequestContext *request_context,
+                                          const std::string &unique_name,
+                                          const std::vector<std::string> &backend_task_ids,
+                                          size_t expected_items,
+                                          const std::string &operation_id,
+                                          const AsyncCopyOptions &options,
+                                          AsyncCopyCompletion completion);
+    ErrorCode RequestCancelAsyncCopy(const std::string &unique_name, const std::string &operation_id);
     std::vector<bool>
     Exist(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris, bool fastpath = false);
     std::vector<ErrorCode> Lock(const std::string &unique_name, const std::vector<DataStorageUri> &storage_uris);
@@ -76,6 +95,7 @@ private:
     // stroage unique name -> storage_backend
     std::map<std::string, std::shared_ptr<DataStorageBackend>> storage_map_;
     std::shared_ptr<MetricsRegistry> metrics_registry_;
+    std::function<bool(const std::string &)> async_copy_reference_checker_;
 };
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
+++ b/kv_cache_manager/data_storage/test/data_storage_manager_test.cc
@@ -86,6 +86,72 @@ TEST_F(DataStorageManagerTest, TestCopyRejectsMismatchedUris) {
     }
 }
 
+TEST_F(DataStorageManagerTest, TestResumeAsyncCopyQueriesTemporarilyUnavailableBackend) {
+    class TemporarilyUnavailableAsyncBackend : public DataStorageBackend {
+    public:
+        TemporarilyUnavailableAsyncBackend(std::shared_ptr<MetricsRegistry> metrics_registry, bool &resume_called)
+            : DataStorageBackend(std::move(metrics_registry)), resume_called_(resume_called) {}
+
+        DataStorageType GetType() override { return DataStorageType::DATA_STORAGE_TYPE_DUMMY; }
+        bool Available() override { return false; }
+        double GetStorageUsageRatio(const std::string &) const override { return 0.0; }
+        ErrorCode DoOpen(const StorageConfig &, const std::string &) override { return EC_OK; }
+        ErrorCode Close() override { return EC_OK; }
+        std::vector<std::pair<ErrorCode, DataStorageUri>>
+        Create(const std::vector<std::string> &, size_t, const std::string &, std::function<void()>) override {
+            return {};
+        }
+        std::vector<ErrorCode>
+        Delete(const std::vector<DataStorageUri> &uris, const std::string &, std::function<void()>) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        std::vector<bool> Exist(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<bool>(uris.size(), true);
+        }
+        std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        bool SupportsAsyncCopy() const override { return true; }
+        AsyncCopySubmitResult ResumeAsyncCopy(const std::vector<std::string> &backend_task_ids,
+                                              size_t expected_items,
+                                              const std::string &operation_id,
+                                              const std::string &,
+                                              const AsyncCopyOptions &,
+                                              AsyncCopyCompletion) override {
+            resume_called_ = true;
+            AsyncCopySubmitResult result;
+            result.status = backend_task_ids.size() == expected_items ? EC_OK : EC_MISMATCH;
+            result.accepted = result.status == EC_OK;
+            result.operation_id = operation_id;
+            return result;
+        }
+
+    private:
+        bool &resume_called_;
+    };
+
+    DataStorageManager data_storage_manager(metrics_registry_);
+    bool resume_called = false;
+    data_storage_manager.storage_map_["temporarily-unavailable"] =
+        std::make_shared<TemporarilyUnavailableAsyncBackend>(metrics_registry_, resume_called);
+
+    RequestContext request_context("resume-temporarily-unavailable");
+    auto result = data_storage_manager.ResumeAsyncCopy(&request_context,
+                                                       "temporarily-unavailable",
+                                                       {"pace-task-1"},
+                                                       1,
+                                                       "operation-1",
+                                                       AsyncCopyOptions{},
+                                                       [](AsyncCopyBatchResult) {});
+    EXPECT_TRUE(resume_called);
+    EXPECT_EQ(EC_OK, result.status);
+    EXPECT_TRUE(result.accepted);
+    EXPECT_EQ("operation-1", result.operation_id);
+}
+
 TEST_F(DataStorageManagerTest, TestOptionalBackendsFollowBuildConfig) {
     DataStorageManager data_storage_manager(metrics_registry_);
 

--- a/kv_cache_manager/manager/cache_garbage_collector.cc
+++ b/kv_cache_manager/manager/cache_garbage_collector.cc
@@ -786,8 +786,17 @@ CacheGarbageCollector::ScanDeleteActions CacheGarbageCollector::BuildDeleteActio
             }
             continue;
         }
+        const auto &location_map = batch.locations[i];
         for (const auto &[location_id, location] : batch.locations[i]) {
             if (!location || location_id.empty() || location->id().empty() || location_id != location->id()) {
+                continue;
+            }
+            if (location->has_migration_copy_guard()) {
+                // The guard is persistent and therefore remains authoritative
+                // even after MigrationManager's in-memory active table is lost.
+                continue;
+            }
+            if (FindPersistentMigrationSourcePin(*location, location_map) != nullptr) {
                 continue;
             }
 
@@ -1111,7 +1120,8 @@ bool CacheGarbageCollector::IsOrphanWriting(const std::string &map_location_id,
                                             const CacheLocation &location,
                                             const int64_t now_us) const noexcept {
     if (map_location_id.empty() || location.id().empty() || map_location_id != location.id() ||
-        location.status() != CLS_WRITING || location.create_time() <= 0 || now_us < location.create_time()) {
+        location.status() != CLS_WRITING || location.has_migration_copy_guard() || location.create_time() <= 0 ||
+        now_us < location.create_time()) {
         return false;
     }
     const int64_t age_us = now_us - location.create_time();

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -650,11 +650,21 @@ ErrorCode CacheManager::RemoveInstance(RequestContext *request_context,
             }
             if (!migration_manager_->GetActiveBlockKeysForInstance(instance_id).empty()) {
                 KVCM_LOG_WARN("[%s] RemoveInstance drain timeout (%dms) for instance %s, "
-                              "proceeding with trim; residual WRITING targets will be orphan-cleaned",
+                              "refusing removal while asynchronous Copy state is still owned",
                               trace_id.c_str(),
                               kDrainTimeoutMs,
                               instance_id.c_str());
             }
+        }
+        // A quarantined guard is intentionally invisible to the active task
+        // table, and an accepted physical cleanup may outlive task completion.
+        // Removing the registry entry here would make those durable guards
+        // undiscoverable on the next leader and could close their backend while
+        // it is still being used. Keep the instance registered until every
+        // active/quarantined/cleanup reference has drained.
+        if (migration_manager_->HasAsyncCopyInstanceReference(instance_id)) {
+            PREFIX_LOG(WARN, "remove instance rejected: asynchronous Copy reference remains");
+            return EC_EXIST;
         }
     }
 

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -489,6 +489,11 @@ bool CacheManager::Init(int32_t schedule_plan_executor_thread_count,
     // Invariant: migration_manager_ is always constructed here. Feature enablement is a per
     // instance-group property (IsTieredMigrationEnabled), never expressed via pointer nullness.
     assert(migration_manager_ != nullptr);
+    registry_manager_->data_storage_manager()->SetAsyncCopyReferenceChecker(
+        [weak_manager = std::weak_ptr<MigrationManager>(migration_manager_)](const std::string &storage_name) {
+            const auto manager = weak_manager.lock();
+            return manager && manager->HasAsyncCopyStorageReference(storage_name);
+        });
 
     cache_garbage_collector_ = std::make_shared<CacheGarbageCollector>(std::move(cache_gc_config),
                                                                        registry_manager_,
@@ -1538,7 +1543,7 @@ void CacheManager::JoinCacheGarbageCollector() {
     }
 }
 
-void CacheManager::StartMigrationManager() { migration_manager_->Start(); }
+ErrorCode CacheManager::StartMigrationManager() { return migration_manager_->Start(); }
 void CacheManager::StopMigrationManager() { migration_manager_->Stop(); }
 
 CacheManager::MigrateCacheResult CacheManager::MigrateCache(RequestContext *request_context,

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -231,7 +231,7 @@ public:
     void JoinCacheGarbageCollector();
 
     // 多层存储迁移控制面随 leader 生命周期启停（OnBecomeLeader/OnNoLongerLeader）。
-    void StartMigrationManager();
+    ErrorCode StartMigrationManager();
     void StopMigrationManager();
 
     std::shared_ptr<MetaIndexerManager> meta_indexer_manager() { return meta_indexer_manager_; }

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -1632,6 +1632,12 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
                 if (is_pending_location(block_key, loc.id())) {
                     continue;
                 }
+                if (loc.has_migration_copy_guard()) {
+                    continue;
+                }
+                if (FindPersistentMigrationSourcePin(loc, loc_map) != nullptr) {
+                    continue;
+                }
                 const bool is_active_copy_target =
                     loc.status() == CacheLocationStatus::CLS_WRITING && migration_manager_ != nullptr &&
                     migration_manager_->HasActiveCopyTargetLocation(ins_id, block_key, loc.id());
@@ -1668,6 +1674,18 @@ bool CacheReclaimer::FilterLocID(RequestContext *request_context,
             }
             if (is_pending_location(block_key, loc.id())) {
                 METRICS_(cache_reclaimer, duplicate_pending_location_filtered_count) += 1;
+                continue;
+            }
+            if (loc.has_migration_copy_guard()) {
+                // Persistent Copy ownership fence.  The process-local active
+                // target hook below is only an optimization and cannot replace
+                // this check after restart/leader switch.
+                continue;
+            }
+            if (FindPersistentMigrationSourcePin(loc, loc_map) != nullptr) {
+                // An async operation can still need this exact source after a
+                // leader restart.  The target guard is the durable source pin;
+                // do not let pressure eviction race its completion/reconcile.
                 continue;
             }
             // a location is eligible for eviction if:
@@ -2205,7 +2223,9 @@ void CacheReclaimer::HandleDelRes() noexcept {
             bool terminal = false;
             ErrorCode result_code = ErrorCode::EC_ERROR;
             try {
-                const auto [ec, err_msg] = it->fut_.get();
+                const auto result = it->fut_.get();
+                const auto ec = result.status;
+                const auto &err_msg = result.error_message;
                 terminal = true;
                 result_code = ec;
                 if (ec != ErrorCode::EC_OK) {

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -3261,13 +3261,27 @@ ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
             const auto &task = batch_tasks[key_index][loc_index];
             if ((!task.expected_location_value.empty() &&
                  locs[loc_index]->ToJsonString() != task.expected_location_value) ||
-                locs[loc_index]->status() != task.old_status) {
+                locs[loc_index]->status() != task.old_status ||
+                (task.expected_migration_copy_guard_absent &&
+                 locs[loc_index]->has_migration_copy_guard()) ||
+                (!task.expected_operation_id.empty() &&
+                 (!locs[loc_index]->has_migration_copy_guard() ||
+                  locs[loc_index]->migration_copy_guard().operation_id() != task.expected_operation_id)) ||
+                (task.expected_migration_copy_guard_state != MigrationCopyGuardState::MCGS_NONE &&
+                 (!locs[loc_index]->has_migration_copy_guard() ||
+                  locs[loc_index]->migration_copy_guard().state() !=
+                      task.expected_migration_copy_guard_state))) {
                 modifier_ecs[loc_index] = ErrorCode::EC_MISMATCH;
             } else {
                 updated = true;
                 // COW: copy the location, modify the copy, replace the pointer
                 auto new_loc = std::make_shared<CacheLocation>(*locs[loc_index]);
                 new_loc->set_status(task.new_status);
+                if (task.clear_migration_copy_guard) {
+                    new_loc->clear_migration_copy_guard();
+                } else if (task.new_migration_copy_guard) {
+                    new_loc->set_migration_copy_guard(*task.new_migration_copy_guard);
+                }
                 locs[loc_index] = std::move(new_loc);
             }
         }

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -321,6 +321,17 @@ public:
         // This closes the gap between a cleanup scan and its status CAS when
         // a stable location id is refreshed by a newer snapshot.
         std::string expected_location_value;
+        // Optional guard ownership check/mutation.  If expected_operation_id is
+        // non-empty, the location must carry that exact operation guard.
+        std::string expected_operation_id;
+        // Optional state check used by destructive/manual transitions.  NONE
+        // means no state predicate.
+        MigrationCopyGuardState expected_migration_copy_guard_state = MigrationCopyGuardState::MCGS_NONE;
+        // Used only when installing the first SUBMITTING guard.  The target
+        // must still be unowned; never overwrite another operation's fence.
+        bool expected_migration_copy_guard_absent = false;
+        bool clear_migration_copy_guard = false;
+        std::shared_ptr<MigrationCopyGuard> new_migration_copy_guard;
     };
     ErrorCode BatchCASLocationStatus(RequestContext *request_context,
                                      const KeyVector &keys,

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -668,6 +668,9 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
             options.operation_deadline_ms = group->cache_config()->migration_copy_operation_deadline_ms();
             options.initial_poll_interval_ms = group->cache_config()->migration_copy_poll_initial_interval_ms();
             options.max_poll_interval_ms = group->cache_config()->migration_copy_poll_max_interval_ms();
+            options.connect_timeout_ms = group->cache_config()->migration_copy_connect_timeout_ms();
+            options.submit_timeout_ms = group->cache_config()->migration_copy_submit_timeout_ms();
+            options.query_timeout_ms = group->cache_config()->migration_copy_query_timeout_ms();
         }
         for (const auto &instance : instances) {
             if (!instance) {
@@ -3927,6 +3930,9 @@ void MigrationManager::RunAsyncMigrationPrepare(AsyncMigrationPrepareJob job, st
         params.async_copy_options.operation_deadline_ms = cache_config->migration_copy_operation_deadline_ms();
         params.async_copy_options.initial_poll_interval_ms = cache_config->migration_copy_poll_initial_interval_ms();
         params.async_copy_options.max_poll_interval_ms = cache_config->migration_copy_poll_max_interval_ms();
+        params.async_copy_options.connect_timeout_ms = cache_config->migration_copy_connect_timeout_ms();
+        params.async_copy_options.submit_timeout_ms = cache_config->migration_copy_submit_timeout_ms();
+        params.async_copy_options.query_timeout_ms = cache_config->migration_copy_query_timeout_ms();
         params.mark_timeout_ms = current_strategy->methods().mark().timeout_ms();
         params.dedup_marks = true;
         return DispatchMigrationBatchWithLifecycleLockHeld(job.trace_id,
@@ -4018,6 +4024,9 @@ MigrationManager::MigrateResult MigrationManager::MigrateCache(RequestContext *r
             params.async_copy_options.initial_poll_interval_ms =
                 cache_config->migration_copy_poll_initial_interval_ms();
             params.async_copy_options.max_poll_interval_ms = cache_config->migration_copy_poll_max_interval_ms();
+            params.async_copy_options.connect_timeout_ms = cache_config->migration_copy_connect_timeout_ms();
+            params.async_copy_options.submit_timeout_ms = cache_config->migration_copy_submit_timeout_ms();
+            params.async_copy_options.query_timeout_ms = cache_config->migration_copy_query_timeout_ms();
         }
     }
     const auto dispatch =

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -15,6 +15,7 @@
 #include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/cache_config.h"
+#include "kv_cache_manager/config/instance_group.h"
 #include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
@@ -30,9 +31,18 @@
 
 namespace kv_cache_manager {
 
+static_assert(MigrationConfig::kMinCopyHttpTimeoutWindowsPerDeadline ==
+                  AsyncCopyOptions::kMinHttpTimeoutWindowsPerDeadline,
+              "async Copy HTTP timeout ratio defaults must remain aligned");
+
 namespace {
 constexpr auto kMonitorIdleSleep = std::chrono::milliseconds(50);
 constexpr auto kFutureWaitTime = std::chrono::microseconds(200);
+constexpr auto kGuardSyncRetryInterval = std::chrono::milliseconds(100);
+constexpr auto kGuardSyncRetryIdleSleep = std::chrono::milliseconds(5);
+constexpr int64_t kAsyncGuardRecoveryScanBatchSize = 256;
+constexpr auto kAsyncGuardRecoveryScanPause = std::chrono::milliseconds(2);
+constexpr auto kAsyncGuardRecoveryMaxDuration = std::chrono::minutes(5);
 
 struct AddLocationRollbackItem {
     int64_t block_key = 0;
@@ -160,6 +170,36 @@ std::optional<int64_t> ParsePositiveInt64(const std::string &value) {
     return parsed;
 }
 
+std::optional<uint64_t> ParsePositiveUriSize(const DataStorageUri &uri) {
+    if (!uri.Valid() || !uri.HasParam("size")) {
+        return std::nullopt;
+    }
+    const std::string value = uri.GetParam("size");
+    uint64_t parsed = 0;
+    const char *begin = value.data();
+    const char *end = begin + value.size();
+    const auto [ptr, ec] = std::from_chars(begin, end, parsed);
+    if (ec != std::errc{} || ptr != end || parsed == 0) {
+        return std::nullopt;
+    }
+    return parsed;
+}
+
+std::optional<uint64_t> SumSourceUriSizes(const std::vector<LocationSpec> &specs) {
+    if (specs.empty()) {
+        return std::nullopt;
+    }
+    uint64_t total = 0;
+    for (const auto &spec : specs) {
+        const auto size = ParsePositiveUriSize(DataStorageUri(spec.uri()));
+        if (!size.has_value() || total > std::numeric_limits<uint64_t>::max() - *size) {
+            return std::nullopt;
+        }
+        total += *size;
+    }
+    return total;
+}
+
 // mark property 解析结果。target 为空表示无标记或已清；target 非空时 deadline
 // 必须是合法正整数，malformed 表示缺失、非数字、越界或非正值；expired 表示已过期待清理。
 struct MarkInfo {
@@ -273,15 +313,15 @@ MigrationManager::MigrationManager(std::shared_ptr<SchedulePlanExecutor> schedul
         m_tasks_active_ = metrics_registry_->GetGauge("migration.tasks_active");
         m_copy_bytes_total_ = metrics_registry_->GetCounter("migration.copy_bytes_total");
         m_copy_duration_ms_ = metrics_registry_->GetGauge("migration.copy_duration_ms");
-        m_marks_active_ = metrics_registry_->GetGauge("migration.marks_active");
-        m_marks_consumed_total_ = metrics_registry_->GetCounter("migration.marks_consumed_total");
-        m_marks_expired_total_ = metrics_registry_->GetCounter("migration.marks_expired_total");
-        m_mark_query_errors_total_ = metrics_registry_->GetCounter("migration.mark_query_errors_total");
         m_source_failures_recorded_total_ = metrics_registry_->GetCounter("migration.source_failures_recorded_total");
         m_source_retries_suppressed_total_ = metrics_registry_->GetCounter("migration.source_retries_suppressed_total");
         m_source_switches_total_ = metrics_registry_->GetCounter("migration.source_switches_total");
         m_no_usable_source_total_ = metrics_registry_->GetCounter("migration.no_usable_source_total");
         m_source_failure_entries_ = metrics_registry_->GetGauge("migration.source_failure_entries");
+        m_marks_active_ = metrics_registry_->GetGauge("migration.marks_active");
+        m_marks_consumed_total_ = metrics_registry_->GetCounter("migration.marks_consumed_total");
+        m_marks_expired_total_ = metrics_registry_->GetCounter("migration.marks_expired_total");
+        m_mark_query_errors_total_ = metrics_registry_->GetCounter("migration.mark_query_errors_total");
     }
 }
 
@@ -353,16 +393,517 @@ ErrorCode MigrationManager::CheckTargetStorageAdmission(const std::string &trace
     return EC_OK;
 }
 
-void MigrationManager::Start() {
+bool MigrationManager::ReserveAsyncCopyCredit(const MigrationRequest &request, uint64_t total_bytes) {
+    if (request.copy_execution_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        return true;
+    }
+    if (request.instance_group_name.empty() || request.async_operation_id.empty() || total_bytes == 0 ||
+        request.copy_max_inflight_bytes == 0 || request.copy_max_quarantine_operations <= 0 ||
+        request.copy_max_quarantine_bytes == 0) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+    if (async_copy_inflight_operation_ids_.count(request.async_operation_id) > 0 ||
+        async_copy_quarantine_by_operation_.count(request.async_operation_id) > 0) {
+        return false;
+    }
+    auto &usage = async_copy_usage_by_group_[request.instance_group_name];
+    if (usage.quarantine_operations >= static_cast<uint64_t>(request.copy_max_quarantine_operations) ||
+        usage.quarantine_bytes >= request.copy_max_quarantine_bytes ||
+        total_bytes > request.copy_max_inflight_bytes ||
+        usage.inflight_bytes > request.copy_max_inflight_bytes - total_bytes) {
+        return false;
+    }
+    async_copy_inflight_operation_ids_.insert(request.async_operation_id);
+    ++usage.inflight_operations;
+    usage.inflight_bytes += total_bytes;
+    return true;
+}
+
+void MigrationManager::ReleaseAsyncCopyCredit(const CopyTaskContext &ctx) {
+    if (!ctx.async_credit_active || ctx.instance_group_name.empty() || ctx.async_operation_id.empty()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+    if (async_copy_inflight_operation_ids_.erase(ctx.async_operation_id) == 0) {
+        return;
+    }
+    const auto iter = async_copy_usage_by_group_.find(ctx.instance_group_name);
+    if (iter == async_copy_usage_by_group_.end()) {
+        return;
+    }
+    auto &usage = iter->second;
+    usage.inflight_operations = usage.inflight_operations > 0 ? usage.inflight_operations - 1 : 0;
+    usage.inflight_bytes = usage.inflight_bytes >= ctx.total_bytes ? usage.inflight_bytes - ctx.total_bytes : 0;
+    if (usage.inflight_operations == 0 && usage.inflight_bytes == 0 && usage.quarantine_operations == 0 &&
+        usage.quarantine_bytes == 0) {
+        async_copy_usage_by_group_.erase(iter);
+    }
+}
+
+void MigrationManager::MoveAsyncCopyCreditToQuarantine(const CopyTaskContext &ctx, const std::string &reason) {
+    if (!ctx.async_credit_active || ctx.instance_group_name.empty()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+    if (ctx.async_operation_id.empty() || async_copy_quarantine_by_operation_.count(ctx.async_operation_id) > 0 ||
+        async_copy_inflight_operation_ids_.erase(ctx.async_operation_id) == 0) {
+        return;
+    }
+    MigrationCopyGuard guard;
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_UNKNOWN);
+    guard.set_operation_id(ctx.async_operation_id);
+    guard.set_source_location_id(ctx.src_location_id);
+    guard.set_source_location_create_time(ctx.src_create_time);
+    guard.set_source_storage_name(ctx.src_storage_name);
+    guard.set_target_storage_name(ctx.dst_storage_name);
+    guard.set_migration_retention(static_cast<int32_t>(ctx.retention));
+    guard.set_total_bytes(ctx.total_bytes);
+    guard.set_backend_task_ids(ctx.async_backend_task_ids);
+    guard.set_create_time_us(ctx.async_guard_create_time_us > 0 ? ctx.async_guard_create_time_us : now_us);
+    guard.set_update_time_us(now_us);
+    guard.set_last_error(reason);
+    async_copy_quarantine_by_operation_.emplace(
+        ctx.async_operation_id,
+        AsyncCopyQuarantineRecord{
+            ctx.instance_group_name, ctx.instance_id, ctx.block_key, ctx.dst_location_id, std::move(guard)});
+    auto &usage = async_copy_usage_by_group_[ctx.instance_group_name];
+    usage.inflight_operations = usage.inflight_operations > 0 ? usage.inflight_operations - 1 : 0;
+    usage.inflight_bytes = usage.inflight_bytes >= ctx.total_bytes ? usage.inflight_bytes - ctx.total_bytes : 0;
+    ++usage.quarantine_operations;
+    if (usage.quarantine_bytes <= std::numeric_limits<uint64_t>::max() - ctx.total_bytes) {
+        usage.quarantine_bytes += ctx.total_bytes;
+    } else {
+        usage.quarantine_bytes = std::numeric_limits<uint64_t>::max();
+    }
+}
+
+bool MigrationManager::RestoreAsyncCopyInflightCredit(const CopyTaskContext &ctx) {
+    if (!ctx.async_credit_active || ctx.instance_group_name.empty() || ctx.async_operation_id.empty()) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+    if (!async_copy_inflight_operation_ids_.insert(ctx.async_operation_id).second) {
+        return false;
+    }
+    auto &usage = async_copy_usage_by_group_[ctx.instance_group_name];
+    ++usage.inflight_operations;
+    usage.inflight_bytes = usage.inflight_bytes <= std::numeric_limits<uint64_t>::max() - ctx.total_bytes
+                               ? usage.inflight_bytes + ctx.total_bytes
+                               : std::numeric_limits<uint64_t>::max();
+    return true;
+}
+
+std::vector<MigrationManager::AsyncCopyQuarantineRecord>
+MigrationManager::ListAsyncCopyQuarantine(const std::string &instance_group_name) const {
+    std::vector<AsyncCopyQuarantineRecord> records;
+    std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+    records.reserve(async_copy_quarantine_by_operation_.size());
+    for (const auto &[_, record] : async_copy_quarantine_by_operation_) {
+        if (instance_group_name.empty() || record.instance_group_name == instance_group_name) {
+            records.push_back(record);
+        }
+    }
+    std::sort(records.begin(), records.end(), [](const auto &lhs, const auto &rhs) {
+        if (lhs.instance_group_name != rhs.instance_group_name) {
+            return lhs.instance_group_name < rhs.instance_group_name;
+        }
+        if (lhs.instance_id != rhs.instance_id) {
+            return lhs.instance_id < rhs.instance_id;
+        }
+        if (lhs.block_key != rhs.block_key) {
+            return lhs.block_key < rhs.block_key;
+        }
+        return lhs.guard.operation_id() < rhs.guard.operation_id();
+    });
+    return records;
+}
+
+ErrorCode MigrationManager::BreakGlassReleaseAsyncCopy(const std::string &operation_id,
+                                                        const std::string &operator_name,
+                                                        const std::string &external_fencing_evidence) {
+    if (operation_id.empty() || operator_name.empty() || external_fencing_evidence.empty()) {
+        return EC_BADARGS;
+    }
+    AsyncCopyQuarantineRecord record;
+    {
+        std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+        const auto iter = async_copy_quarantine_by_operation_.find(operation_id);
+        if (iter == async_copy_quarantine_by_operation_.end()) {
+            return EC_NOENT;
+        }
+        record = iter->second;
+    }
+    if (record.guard.state() != MigrationCopyGuardState::MCGS_UNKNOWN) {
+        return EC_MISMATCH;
+    }
+    auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(record.instance_id) : nullptr;
+    if (!indexer) {
+        return EC_INSTANCE_NOT_EXIST;
+    }
+    MetaSearcher meta_searcher(indexer);
+    auto request_context = std::make_shared<RequestContext>("migration_break_glass_release");
+    MetaSearcher::LocationCASTask task;
+    task.location_id = record.target_location_id;
+    task.old_status = CLS_WRITING;
+    task.new_status = CLS_DELETING;
+    task.expected_operation_id = operation_id;
+    task.expected_migration_copy_guard_state = MigrationCopyGuardState::MCGS_UNKNOWN;
+    task.clear_migration_copy_guard = true;
+    std::vector<std::vector<ErrorCode>> results;
+    const auto ec = meta_searcher.BatchCASLocationStatus(
+        request_context.get(), {record.block_key}, {{std::move(task)}}, results, true);
+    if (ec != EC_OK) {
+        return ec;
+    }
+    if (results.size() != 1 || results[0].size() != 1) {
+        return EC_MISMATCH;
+    }
+    if (results[0][0] != EC_OK) {
+        return results[0][0];
+    }
+    if (!indexer->Sync({record.block_key})) {
+        return EC_ERROR;
+    }
+
+    CopyTaskContext ctx;
+    ctx.instance_group_name = record.instance_group_name;
+    ctx.instance_id = record.instance_id;
+    ctx.block_key = record.block_key;
+    ctx.dst_location_id = record.target_location_id;
+    SubmitPreparedTargetLocationDelete(ctx);
+    {
+        std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+        const auto iter = async_copy_quarantine_by_operation_.find(operation_id);
+        if (iter != async_copy_quarantine_by_operation_.end()) {
+            auto usage_iter = async_copy_usage_by_group_.find(iter->second.instance_group_name);
+            if (usage_iter != async_copy_usage_by_group_.end()) {
+                auto &usage = usage_iter->second;
+                usage.quarantine_operations = usage.quarantine_operations > 0 ? usage.quarantine_operations - 1 : 0;
+                usage.quarantine_bytes = usage.quarantine_bytes >= iter->second.guard.total_bytes()
+                                             ? usage.quarantine_bytes - iter->second.guard.total_bytes()
+                                             : 0;
+                if (usage.inflight_operations == 0 && usage.inflight_bytes == 0 &&
+                    usage.quarantine_operations == 0 && usage.quarantine_bytes == 0) {
+                    async_copy_usage_by_group_.erase(usage_iter);
+                }
+            }
+            async_copy_quarantine_by_operation_.erase(iter);
+        }
+    }
+    KVCM_LOG_ERROR("BREAK_GLASS asynchronous Copy quarantine released after external fencing: "
+                   "operator %s operation_id %s instance %s block_key %lld target_location %s evidence %s",
+                   operator_name.c_str(),
+                   operation_id.c_str(),
+                   record.instance_id.c_str(),
+                   static_cast<long long>(record.block_key),
+                   record.target_location_id.c_str(),
+                   external_fencing_evidence.c_str());
+    return EC_OK;
+}
+
+bool MigrationManager::HasAsyncCopyStorageReference(const std::string &storage_name) const {
+    if (storage_name.empty()) {
+        return false;
+    }
+    {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        for (const auto &[_, tasks] : active_tasks_by_instance_) {
+            for (const auto &[__, ctx] : tasks) {
+                if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED &&
+                    (ctx.src_storage_name == storage_name || ctx.dst_storage_name == storage_name)) {
+                    return true;
+                }
+            }
+        }
+    }
+    std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+    return std::any_of(async_copy_quarantine_by_operation_.begin(),
+                       async_copy_quarantine_by_operation_.end(),
+                       [&storage_name](const auto &entry) {
+                           const auto &guard = entry.second.guard;
+                           return guard.source_storage_name() == storage_name ||
+                                  guard.target_storage_name() == storage_name;
+                       });
+}
+
+bool MigrationManager::RecoverAsyncCopyGuards() {
+    if (!registry_manager_ || !meta_indexer_manager_ || !schedule_plan_executor_) {
+        return true;
+    }
+    struct RecoveryCandidate {
+        CopyTaskContext ctx;
+        MigrationCopyGuard guard;
+        size_t expected_items = 0;
+        AsyncCopyOptions options;
+    };
+    std::vector<RecoveryCandidate> candidates;
+    const auto recovery_started_at = std::chrono::steady_clock::now();
+    uint64_t scanned_batches = 0;
+    uint64_t scanned_keys = 0;
+    auto request_context = std::make_shared<RequestContext>("migration_async_guard_recovery");
+    auto [groups_ec, groups] = registry_manager_->ListInstanceGroup(request_context.get());
+    if (groups_ec != EC_OK) {
+        KVCM_LOG_ERROR("asynchronous Copy guard recovery failed to list instance groups, ec %d",
+                       static_cast<int>(groups_ec));
+        return false;
+    }
+    for (const auto &group : groups) {
+        if (!group) {
+            continue;
+        }
+        auto [instances_ec, instances] =
+            registry_manager_->ListInstanceInfo(request_context.get(), group->name());
+        if (instances_ec != EC_OK) {
+            KVCM_LOG_ERROR("asynchronous Copy guard recovery failed to list instances for group %s, ec %d",
+                           group->name().c_str(),
+                           static_cast<int>(instances_ec));
+            return false;
+        }
+        AsyncCopyOptions options;
+        if (group->cache_config()) {
+            options.operation_deadline_ms = group->cache_config()->migration_copy_operation_deadline_ms();
+            options.initial_poll_interval_ms = group->cache_config()->migration_copy_poll_initial_interval_ms();
+            options.max_poll_interval_ms = group->cache_config()->migration_copy_poll_max_interval_ms();
+        }
+        for (const auto &instance : instances) {
+            if (!instance) {
+                continue;
+            }
+            auto indexer = meta_indexer_manager_->GetMetaIndexer(instance->instance_id());
+            if (!indexer) {
+                KVCM_LOG_ERROR("asynchronous Copy guard recovery missing indexer for instance %s",
+                               instance->instance_id().c_str());
+                return false;
+            }
+            std::string cursor = SCAN_BASE_CURSOR;
+            do {
+                if (std::chrono::steady_clock::now() - recovery_started_at >= kAsyncGuardRecoveryMaxDuration) {
+                    KVCM_LOG_ERROR("asynchronous Copy guard recovery exceeded its %lld ms startup budget: "
+                                   "batches %llu keys %llu",
+                                   static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                              kAsyncGuardRecoveryMaxDuration)
+                                                              .count()),
+                                   static_cast<unsigned long long>(scanned_batches),
+                                   static_cast<unsigned long long>(scanned_keys));
+                    return false;
+                }
+                MaintenanceScanBatch batch;
+                const auto scan_ec = indexer->ScanLocationsForMaintenance(
+                    request_context.get(), cursor, kAsyncGuardRecoveryScanBatchSize, batch);
+                if (scan_ec != EC_OK || batch.keys.size() != batch.locations.size() ||
+                    batch.keys.size() != batch.location_results.size()) {
+                    KVCM_LOG_ERROR("asynchronous Copy guard recovery scan failed for instance %s cursor %s ec %d",
+                                   instance->instance_id().c_str(),
+                                   cursor.c_str(),
+                                   static_cast<int>(scan_ec));
+                    return false;
+                }
+                ++scanned_batches;
+                scanned_keys += batch.keys.size();
+                for (size_t i = 0; i < batch.keys.size(); ++i) {
+                    if (batch.location_results[i] == EC_NOENT) {
+                        continue;
+                    }
+                    if (batch.location_results[i] != EC_OK) {
+                        // A malformed/future migration guard is rejected by
+                        // CacheLocation parsing.  Silently skipping that block
+                        // would enable admission while its durable ownership
+                        // fence is not understood by this binary.  Keep leader
+                        // startup fail-closed and require operator/version
+                        // intervention.
+                        KVCM_LOG_ERROR("asynchronous Copy guard recovery cannot decode block metadata: "
+                                       "instance %s block_key %lld ec %d",
+                                       instance->instance_id().c_str(),
+                                       static_cast<long long>(batch.keys[i]),
+                                       static_cast<int>(batch.location_results[i]));
+                        return false;
+                    }
+                    for (const auto &[location_id, location] : batch.locations[i]) {
+                        if (!location || !location->has_migration_copy_guard()) {
+                            continue;
+                        }
+                        const auto &guard = location->migration_copy_guard();
+                        CopyTaskContext ctx;
+                        ctx.instance_group_name = group->name();
+                        ctx.instance_id = instance->instance_id();
+                        ctx.block_key = batch.keys[i];
+                        ctx.src_location_id = guard.source_location_id();
+                        ctx.src_create_time = guard.source_location_create_time();
+                        ctx.src_storage_name = guard.source_storage_name();
+                        ctx.dst_storage_name = guard.target_storage_name();
+                        ctx.dst_location_id = location_id;
+                        ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+                        ctx.async_operation_id = guard.operation_id();
+                        ctx.async_backend_task_ids = guard.backend_task_ids();
+                        ctx.async_guard_create_time_us = guard.create_time_us();
+                        ctx.async_credit_active = true;
+                        ctx.async_transition_mutex = std::make_shared<std::mutex>();
+                        ctx.total_bytes = guard.total_bytes();
+                        ctx.submit_time = std::chrono::steady_clock::now();
+                        const auto retention = static_cast<MigrationRetention>(guard.migration_retention());
+                        ctx.retention = retention == MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE ||
+                                                retention == MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH
+                                            ? retention
+                                            : MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH;
+                        candidates.push_back(
+                            RecoveryCandidate{std::move(ctx), guard, location->location_specs().size(), options});
+                    }
+                }
+                cursor = batch.next_cursor;
+                if (cursor != SCAN_BASE_CURSOR) {
+                    std::this_thread::sleep_for(kAsyncGuardRecoveryScanPause);
+                }
+            } while (cursor != SCAN_BASE_CURSOR);
+        }
+    }
+
+    // Validate the complete recovery set before replacing the in-memory
+    // accounting tables.  A partial rebuild would either double-charge an
+    // operation or lose its capacity fence.
+    {
+        std::unordered_set<std::string> operation_ids;
+        operation_ids.reserve(candidates.size());
+        for (const auto &candidate : candidates) {
+            if (candidate.ctx.instance_group_name.empty() || candidate.ctx.instance_id.empty() ||
+                candidate.ctx.dst_location_id.empty() || candidate.ctx.total_bytes == 0 ||
+                candidate.ctx.async_operation_id.empty() ||
+                !operation_ids.insert(candidate.ctx.async_operation_id).second) {
+                KVCM_LOG_ERROR("asynchronous Copy guard recovery found invalid candidate: group %s instance %s "
+                               "block %lld target %s operation %s bytes %llu",
+                               candidate.ctx.instance_group_name.c_str(),
+                               candidate.ctx.instance_id.c_str(),
+                               static_cast<long long>(candidate.ctx.block_key),
+                               candidate.ctx.dst_location_id.c_str(),
+                               candidate.ctx.async_operation_id.c_str(),
+                               static_cast<unsigned long long>(candidate.ctx.total_bytes));
+                return false;
+            }
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+        async_copy_usage_by_group_.clear();
+        async_copy_quarantine_by_operation_.clear();
+        async_copy_inflight_operation_ids_.clear();
+    }
+    size_t resumed = 0;
+    size_t quarantined = 0;
+    for (auto &candidate : candidates) {
+        auto &ctx = candidate.ctx;
+        const auto state = candidate.guard.state();
+        if (!RestoreAsyncCopyInflightCredit(ctx)) {
+            KVCM_LOG_ERROR("asynchronous Copy guard recovery found duplicate/invalid operation id %s",
+                           ctx.async_operation_id.c_str());
+            return false;
+        }
+        const bool recoverable =
+            (state == MigrationCopyGuardState::MCGS_ACTIVE ||
+             state == MigrationCopyGuardState::MCGS_CANCELLING) &&
+            !ctx.async_operation_id.empty() && !ctx.src_storage_name.empty() && ctx.total_bytes > 0 &&
+            candidate.expected_items > 0 &&
+            ctx.async_backend_task_ids.size() == candidate.expected_items;
+        if (!recoverable) {
+            if (state != MigrationCopyGuardState::MCGS_UNKNOWN) {
+                UpdateAsyncCopyGuard(ctx,
+                                     state,
+                                     MigrationCopyGuardState::MCGS_UNKNOWN,
+                                     ctx.async_backend_task_ids,
+                                     "leader_recovery_cannot_resume_guard");
+            }
+            MoveAsyncCopyCreditToQuarantine(ctx, "leader_recovery_cannot_resume_guard");
+            ++quarantined;
+            continue;
+        }
+        ctx.state = state == MigrationCopyGuardState::MCGS_CANCELLING ? CopyTaskState::kCancelling
+                                                                      : CopyTaskState::kRunning;
+        bool inserted = false;
+        {
+            std::lock_guard<std::mutex> lock(task_mutex_);
+            inserted = InsertActiveTaskLocked(ctx);
+        }
+        if (!inserted) {
+            UpdateAsyncCopyGuard(ctx,
+                                 state,
+                                 MigrationCopyGuardState::MCGS_UNKNOWN,
+                                 ctx.async_backend_task_ids,
+                                 "leader_recovery_duplicate_block_operation");
+            MoveAsyncCopyCreditToQuarantine(ctx, "leader_recovery_duplicate_block_operation");
+            ++quarantined;
+            continue;
+        }
+        const int64_t age_ms = candidate.guard.create_time_us() > 0
+                                   ? std::max<int64_t>(0,
+                                                       (TimestampUtil::GetCurrentTimeUs() -
+                                                        candidate.guard.create_time_us()) /
+                                                           1000)
+                                   : 0;
+        const int64_t minimum_deadline = candidate.options.max_poll_interval_ms + 1;
+        candidate.options.operation_deadline_ms =
+            std::max(minimum_deadline, candidate.options.operation_deadline_ms - age_ms);
+        auto submit = schedule_plan_executor_->ResumeAsyncCopy(ctx.src_storage_name,
+                                                               ctx.async_backend_task_ids,
+                                                               candidate.expected_items,
+                                                               ctx.async_operation_id,
+                                                               candidate.options);
+        if (!submit.submit_result.accepted || !submit.future.valid()) {
+            CompleteCopyTaskAsUnknown(ctx,
+                                      submit.submit_result.detail.empty()
+                                          ? "leader_recovery_backend_rejected_resume"
+                                          : submit.submit_result.detail);
+            ++quarantined;
+            continue;
+        }
+        if (state == MigrationCopyGuardState::MCGS_CANCELLING) {
+            schedule_plan_executor_->RequestCancelAsyncCopy(ctx.src_storage_name, ctx.async_operation_id);
+        }
+        {
+            std::lock_guard<std::mutex> lock(pending_mutex_);
+            pending_copies_.push_back(
+                PendingCopy{ctx.instance_id, ctx.block_key, std::move(submit.future), true});
+        }
+        ++resumed;
+    }
+    if (resumed > 0) {
+        pending_cv_.notify_all();
+    }
+    KVCM_LOG_INFO("asynchronous Copy guard recovery completed: batches %llu keys %llu discovered %zu resumed %zu "
+                  "quarantined %zu",
+                  static_cast<unsigned long long>(scanned_batches),
+                  static_cast<unsigned long long>(scanned_keys),
+                  candidates.size(),
+                  resumed,
+                  quarantined);
+    return true;
+}
+
+ErrorCode MigrationManager::Start() {
     std::unique_lock<std::shared_mutex> lifecycle_lock(copy_submission_lifecycle_mutex_);
     bool expected = false;
     if (!running_.compare_exchange_strong(expected, true)) {
-        return; // already running
+        return EC_OK; // already running
     }
     async_prepare_generation_.fetch_add(1, std::memory_order_acq_rel);
-    accepting_copy_submissions_.store(true, std::memory_order_release);
+    accepting_copy_submissions_.store(false, std::memory_order_release);
     monitor_thread_ = std::thread([this]() { MonitorLoop(); });
+    if (!RecoverAsyncCopyGuards()) {
+        // Guard-aware Reclaimer/GC fencing remains safe, but opening migration
+        // admission before the source-of-truth scan succeeds could create more
+        // operations without a complete quarantine budget.
+        KVCM_LOG_ERROR("MigrationManager guard recovery failed; new Copy submissions remain disabled");
+        running_.store(false, std::memory_order_release);
+        pending_cv_.notify_all();
+        if (monitor_thread_.joinable()) {
+            monitor_thread_.join();
+        }
+        return EC_ERROR;
+    }
+    accepting_copy_submissions_.store(true, std::memory_order_release);
     KVCM_LOG_INFO("MigrationManager started");
+    return EC_OK;
 }
 
 void MigrationManager::Stop() {
@@ -385,20 +926,103 @@ void MigrationManager::Stop() {
     if (monitor_thread_.joinable()) {
         monitor_thread_.join();
     }
-    // 退出时丢弃活跃任务表：futures 已随 MonitorLoop 退出释放，不再有人驱动 OnTaskSuccess/OnTaskFailed，
-    // 残留条目会让 HasMigrationTask/ActiveTaskCount/HasActiveCopyTargetLocation 永远 stale。
-    // 半成品的 WRITING 目标 location 由 Reclaimer 走孤儿清理路径回收。
+    // Monitor 已停止，丢弃旧 Leader 的 future。这些 future 只是进程内 completion
+    // channel；持久 guard + backend task ids 才是切主后的恢复权威。若不清空，同一
+    // Manager 重新 Start 后会同时处理 stale future 和恢复出来的新 future。
+    size_t dropped_pending = 0;
+    {
+        std::lock_guard<std::mutex> lock(pending_mutex_);
+        dropped_pending = pending_copies_.size();
+        pending_copies_.clear();
+    }
+
+    // 退出时丢弃进程内活跃任务表。同步任务沿用孤儿 WRITING 清理；原生异步任务若已
+    // 持久完整 task ids，则保留 ACTIVE/CANCELLING guard 交给新 Leader Resume，不将一次
+    // graceful demotion 伪造成远端 outcome unknown。只有缺少恢复句柄的 SUBMITTING 任务
+    // 才 fail-closed 转 UNKNOWN quarantine。
     size_t dropped = 0;
+    size_t detached = 0;
+    size_t quarantined = 0;
+    std::vector<CopyTaskContext> dropped_contexts;
     {
         std::lock_guard<std::mutex> lock(task_mutex_);
         dropped = ActiveTaskCountUnsafe();
+        dropped_contexts.reserve(dropped);
+        for (const auto &[_, tasks] : active_tasks_by_instance_) {
+            for (const auto &[__, ctx] : tasks) {
+                dropped_contexts.push_back(ctx);
+            }
+        }
         active_tasks_by_instance_.clear();
         UpdateActiveTasksGauge();
     }
+    for (const auto &ctx : dropped_contexts) {
+        if (ctx.copy_execution_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+            continue;
+        }
+        if (ctx.async_guard_finalization_pending_sync) {
+            // A successful durability retry must also execute the already
+            // claimed terminal action (source retention, target cleanup and
+            // credit release).  Merely calling Sync here would strand those
+            // side effects forever because the durable guard has already been
+            // cleared and the next leader has nothing left to recover.
+            if (!ResumePendingGuardFinalization(ctx)) {
+                // The final CAS may already have promoted/deleted the target and
+                // cleared its guard.  Rewriting UNKNOWN here could regress that
+                // terminal state.  Leave the durable outcome untouched: either
+                // the terminal CAS is present, or the prior fenced guard will be
+                // recovered by the next leader.
+                KVCM_LOG_ERROR("MigrationManager stopped with guard finalization durability still unknown: "
+                               "instance %s block_key %lld operation_id %s",
+                               ctx.instance_id.c_str(),
+                               static_cast<long long>(ctx.block_key),
+                               ctx.async_operation_id.c_str());
+                stat_async_copy_unknown_.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                KVCM_LOG_WARN("MigrationManager stopped after completing a previously applied guard finalization: "
+                              "instance %s block_key %lld operation_id %s",
+                              ctx.instance_id.c_str(),
+                              static_cast<long long>(ctx.block_key),
+                              ctx.async_operation_id.c_str());
+            }
+            continue;
+        }
+
+        const auto expected_guard_state = ExpectedGuardState(ctx);
+        const bool recoverable_after_detach =
+            !ctx.async_backend_task_ids.empty() &&
+            (expected_guard_state == MigrationCopyGuardState::MCGS_ACTIVE ||
+             expected_guard_state == MigrationCopyGuardState::MCGS_CANCELLING);
+        if (recoverable_after_detach) {
+            // Do not cancel the PACE task and do not mutate the durable guard.
+            // DataStorage backend Close() drops its local coordinator job; the
+            // next Leader reconstructs accounting and attaches with these ids.
+            ++detached;
+            KVCM_LOG_INFO("MigrationManager detached recoverable asynchronous Copy on stop: "
+                          "instance %s block_key %lld operation_id %s tasks %zu state %d",
+                          ctx.instance_id.c_str(),
+                          static_cast<long long>(ctx.block_key),
+                          ctx.async_operation_id.c_str(),
+                          ctx.async_backend_task_ids.size(),
+                          static_cast<int>(expected_guard_state));
+            continue;
+        }
+        UpdateAsyncCopyGuard(ctx,
+                             expected_guard_state,
+                             MigrationCopyGuardState::MCGS_UNKNOWN,
+                             ctx.async_backend_task_ids,
+                             "manager_stopped_before_authoritative_completion");
+        MoveAsyncCopyCreditToQuarantine(ctx, "manager_stopped_before_authoritative_completion");
+        stat_async_copy_unknown_.fetch_add(1, std::memory_order_relaxed);
+        ++quarantined;
+    }
     if (dropped > 0) {
-        KVCM_LOG_WARN("MigrationManager stopped with %zu active copy task(s) dropped; "
-                      "WRITING dst locations will be reclaimed as orphans",
-                      dropped);
+        KVCM_LOG_WARN("MigrationManager stopped with %zu active copy task(s) and %zu pending future(s) dropped; "
+                      "asynchronous detached %zu quarantined %zu",
+                      dropped,
+                      dropped_pending,
+                      detached,
+                      quarantined);
     } else {
         KVCM_LOG_INFO("MigrationManager stopped");
     }
@@ -479,6 +1103,13 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
     }
 
     const auto &src_specs = *src_specs_ptr;
+    const auto total_bytes_result = SumSourceUriSizes(src_specs);
+    if (!total_bytes_result.has_value()) {
+        KVCM_LOG_WARN("[%s] source location %s has a missing, zero, invalid, or overflowing URI size",
+                      trace_id.c_str(),
+                      request.src_location_id.c_str());
+        return EC_BADARGS;
+    }
 
     // 2. 目标 storage 类型。
     auto dst_backend = data_storage_manager_->GetDataStorageBackend(request.dst_storage_name);
@@ -496,7 +1127,7 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
     out_src_uris.clear();
     out_dst_uris.clear();
     std::vector<DataStorageUri> allocated_for_rollback;
-    std::uint64_t total_bytes = 0;
+    const std::uint64_t total_bytes = *total_bytes_result;
 
     auto rollback = [&]() {
         if (!allocated_for_rollback.empty()) {
@@ -511,9 +1142,12 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
             rollback();
             return EC_ERROR;
         }
-        std::uint64_t spec_size = 0;
-        src_uri.GetParamAs<std::uint64_t>("size", spec_size);
-        total_bytes += spec_size;
+        const auto spec_size_result = ParsePositiveUriSize(src_uri);
+        if (!spec_size_result.has_value()) {
+            rollback();
+            return EC_BADARGS;
+        }
+        const std::uint64_t spec_size = *spec_size_result;
 
         std::string dst_key =
             request.instance_id + "/" + src_spec.name() + "/" + StringUtil::Uint64ToHex(request.block_key);
@@ -581,6 +1215,8 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
     out_ctx.dst_storage_name = request.dst_storage_name;
     out_ctx.dst_location_id = add_result.location_id;
     out_ctx.retention = request.retention;
+    out_ctx.copy_execution_mode = request.copy_execution_mode;
+    out_ctx.async_operation_id = request.async_operation_id;
     out_ctx.total_bytes = total_bytes;
     return EC_OK;
 }
@@ -611,6 +1247,10 @@ ErrorCode MigrationManager::Submit(const std::string &trace_id, MigrationRequest
             trace_id, request.instance_group_name, request.instance_id, request.dst_storage_name);
         target_ec != EC_OK) {
         return target_ec;
+    }
+    if (request.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        const auto results = BatchSubmit(trace_id, {std::move(request)}, CopyConcurrencyLimit(), true);
+        return results.empty() ? EC_ERROR : results.front();
     }
     {
         std::lock_guard<std::mutex> submission_lock(copy_submission_mutex_);
@@ -765,6 +1405,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
         ErrorCode result = EC_ERROR;
         bool eligible = true;
         bool reservation_active = false;
+        bool async_credit_active = false;
         std::vector<DataStorageUri> src_uris;
         std::vector<DataStorageUri> dst_uris;
         std::vector<LocationSpec> dst_specs;
@@ -810,6 +1451,34 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
         return collect_results();
     }
 
+    const auto batch_mode = first_req.copy_execution_mode;
+    if (batch_mode != MigrationCopyExecutionMode::SYNC &&
+        batch_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        for (auto &item : items) {
+            item.MarkFailed(EC_BADARGS);
+        }
+        return collect_results();
+    }
+    for (auto &item : items) {
+        if (item.request.copy_execution_mode != batch_mode) {
+            item.MarkFailed(EC_BADARGS);
+            continue;
+        }
+        const auto total_bytes = SumSourceUriSizes(item.request.src_specs);
+        if (!total_bytes.has_value()) {
+            KVCM_LOG_WARN("[%s] reject migration block %lld: source URI size is missing, zero, invalid, or overflowed",
+                          trace_id.c_str(),
+                          static_cast<long long>(item.request.block_key));
+            item.MarkFailed(EC_BADARGS);
+            continue;
+        }
+        item.total_bytes = *total_bytes;
+        if (batch_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED &&
+            item.request.async_operation_id.empty()) {
+            item.request.async_operation_id = StringUtil::GenerateRandomString(32);
+        }
+    }
+
     // Stop 的 lifecycle barrier 与 Submit 相同：快检拒绝 shutdown 后的新调用；shared lock 覆盖本函数
     // 余下生命周期，但不串行其他 Submit/BatchSubmit。
     if (!accepting_copy_submissions_.load(std::memory_order_acquire)) {
@@ -830,27 +1499,65 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
         }
         return collect_results();
     }
+    if (batch_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        std::unordered_set<std::string> checked_source_storages;
+        for (const auto &item : items) {
+            if (!item.eligible || !checked_source_storages.insert(item.request.src_storage_name).second) {
+                continue;
+            }
+            if (!data_storage_manager_ ||
+                !data_storage_manager_->SupportsAsyncCopy(item.request.src_storage_name)) {
+                KVCM_LOG_WARN(
+                    "[%s] reject ASYNC_REQUIRED migration: source storage %s has no native async Copy capability",
+                    trace_id.c_str(),
+                    item.request.src_storage_name.c_str());
+                for (auto &candidate : items) {
+                    if (candidate.eligible) {
+                        candidate.MarkFailed(EC_UNIMPLEMENTED);
+                    }
+                }
+                return collect_results();
+            }
+        }
+    }
 
     // ---- phase 0: group 级 Copy 硬限流 + per-block dedup + draining gate + preparing reservation ----
     // 所有 eligible item 必须在释放短准入锁、执行任何 batch Create/AddLocation 前进入
     // active 表。copy_submission_mutex_ 只串行本 phase 的 gate；后续 backend/meta I/O 可跨 instance 并行。
     // MarkFailed 只收拢 result/eligible。reservation 必须等 URI/Location rollback 完成后再释放，
     // 避免失败 item 尚在清理目标资源时，同 block 的新 Submit 已经进入并与旧清理相互覆盖。
-    auto release_preparing = [&](BatchCopyItem &item) {
-        if (!item.reservation_active) {
+    auto release_async_credit = [&](BatchCopyItem &item) {
+        if (!item.async_credit_active) {
             return;
         }
-        std::lock_guard<std::mutex> lock(task_mutex_);
-        RemovePreparingTaskLocked(item.request.instance_id, item.request.block_key);
-        item.reservation_active = false;
+        CopyTaskContext credit;
+        credit.instance_group_name = item.request.instance_group_name;
+        credit.async_operation_id = item.request.async_operation_id;
+        credit.total_bytes = item.total_bytes;
+        credit.async_credit_active = true;
+        ReleaseAsyncCopyCredit(credit);
+        item.async_credit_active = false;
+    };
+    auto release_preparing = [&](BatchCopyItem &item) {
+        if (item.reservation_active) {
+            std::lock_guard<std::mutex> lock(task_mutex_);
+            RemovePreparingTaskLocked(item.request.instance_id, item.request.block_key);
+            item.reservation_active = false;
+        }
+        release_async_credit(item);
     };
     auto release_all_preparing = [&]() {
-        std::lock_guard<std::mutex> lock(task_mutex_);
-        for (auto &item : items) {
-            if (item.reservation_active) {
-                RemovePreparingTaskLocked(item.request.instance_id, item.request.block_key);
-                item.reservation_active = false;
+        {
+            std::lock_guard<std::mutex> lock(task_mutex_);
+            for (auto &item : items) {
+                if (item.reservation_active) {
+                    RemovePreparingTaskLocked(item.request.instance_id, item.request.block_key);
+                    item.reservation_active = false;
+                }
             }
+        }
+        for (auto &item : items) {
+            release_async_credit(item);
         }
     };
     {
@@ -890,6 +1597,15 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             item.reservation_active = true;
             if (copy_limit.enabled()) {
                 --available_group_slots;
+            }
+            if (request.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+                if (!ReserveAsyncCopyCredit(request, item.total_bytes)) {
+                    RemovePreparingTaskLocked(request.instance_id, request.block_key);
+                    item.reservation_active = false;
+                    item.MarkFailed(EC_OUT_OF_LIMIT);
+                    continue;
+                }
+                item.async_credit_active = true;
             }
         }
     }
@@ -931,9 +1647,12 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
                 item.MarkFailed(EC_ERROR);
                 break;
             }
-            std::uint64_t spec_size = 0;
-            src_uri.GetParamAs<std::uint64_t>("size", spec_size);
-            item.total_bytes += spec_size;
+            const auto spec_size_result = ParsePositiveUriSize(src_uri);
+            if (!spec_size_result.has_value()) {
+                item.MarkFailed(EC_BADARGS);
+                break;
+            }
+            const std::uint64_t spec_size = *spec_size_result;
             std::string dst_key = req.instance_id + "/" + req.src_specs[s].name() + "/" +
                                   StringUtil::Uint64ToHex(req.block_key);
             create_groups[spec_size].push_back({i, s, std::move(dst_key), std::move(src_uri)});
@@ -1102,6 +1821,12 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             ctx.dst_storage_name = req.dst_storage_name;
             ctx.dst_location_id = add_result.location_id;
             ctx.retention = req.retention;
+            ctx.copy_execution_mode = req.copy_execution_mode;
+            ctx.async_operation_id = req.async_operation_id;
+            ctx.async_credit_active = item.async_credit_active;
+            if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+                ctx.async_transition_mutex = std::make_shared<std::mutex>();
+            }
             ctx.total_bytes = item.total_bytes;
             bind_items.push_back(&item);
         }
@@ -1155,18 +1880,48 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
                 }
             }
 
+            // The persistent guard is installed only after AddLocation and
+            // before any remote POST.  This keeps ordinary AddLocation
+            // rollback guard-free while preserving the no-unfenced-submit
+            // invariant.
+            if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+                ctx.async_guard_create_time_us = TimestampUtil::GetCurrentTimeUs();
+                if (UpdateAsyncCopyGuard(
+                        ctx, MigrationCopyGuardState::MCGS_NONE, MigrationCopyGuardState::MCGS_SUBMITTING, {}, "") !=
+                    GuardMutationResult::kAppliedDurably) {
+                    item->reservation_active = false;
+                    item->async_credit_active = false;
+                    // No executor/backend handoff and therefore no remote POST
+                    // has happened yet.  A failed persistence fence is a
+                    // definite pre-submit rollback, not an unknown remote
+                    // operation.  Treating it as UNKNOWN would consume
+                    // quarantine forever for a task that never existed.
+                    CompleteCopyTaskAsFailed(ctx, "guard_install_failed_before_submit", false);
+                    item->MarkFailed(EC_ERROR);
+                    continue;
+                }
+            }
+
             bool task_running = false;
             {
                 std::lock_guard<std::mutex> lock(task_mutex_);
                 task_running = UpdatePreparingTaskLocked(ctx) && MarkTaskRunningLocked(ctx.instance_id, ctx.block_key);
                 if (task_running) {
                     item->reservation_active = false; // 已成为正式 active task，不能再由 preparing guard 清理
+                    item->async_credit_active = false; // credit ownership moved into the active task context
                 }
             }
             if (!task_running) {
-                SubmitTargetLocationDelete(ctx);
+                if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+                    item->reservation_active = false;
+                    item->async_credit_active = false;
+                    CompleteCopyTaskAsFailed(ctx, "task_activation_failed_before_submit", false);
+                } else {
+                    SubmitTargetLocationDelete(ctx);
+                    item->MarkFailed(EC_ERROR);
+                    release_preparing(*item);
+                }
                 item->MarkFailed(EC_ERROR);
-                release_preparing(*item);
                 continue;
             }
 
@@ -1177,18 +1932,63 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             copy_req.src_uris = std::move(item->src_uris);
             copy_req.dst_uris = std::move(item->dst_uris);
 
-            std::future<PlanExecuteResult> future = schedule_plan_executor_->Submit(copy_req);
+            std::future<PlanExecuteResult> future;
+            std::future<AsyncCopyRemoteSubmitResult> remote_submit_future;
+            bool native_async = false;
+            if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+                auto async_submit = schedule_plan_executor_->SubmitAsyncCopy(
+                    copy_req, ctx.async_operation_id, req.async_copy_options);
+                future = std::move(async_submit.future);
+                if (!async_submit.submit_result.accepted) {
+                    if (async_submit.submit_result.acceptance_unknown) {
+                        OnTaskUnknown(ctx.instance_id,
+                                      ctx.block_key,
+                                      async_submit.submit_result.detail.empty() ? "copy_submit_acceptance_unknown"
+                                                                                : async_submit.submit_result.detail);
+                    } else {
+                        OnTaskFailedInternal(ctx.instance_id,
+                                             ctx.block_key,
+                                             async_submit.submit_result.status,
+                                             async_submit.submit_result.detail.empty()
+                                                 ? "copy_submit_rejected"
+                                                 : async_submit.submit_result.detail,
+                                             false,
+                                             false);
+                    }
+                    item->MarkFailed(async_submit.submit_result.status);
+                    continue;
+                }
+                if (!async_submit.remote_submit_future.valid()) {
+                    OnTaskUnknown(ctx.instance_id, ctx.block_key, "copy_submit_missing_remote_acceptance_channel");
+                    item->MarkFailed(EC_ERROR);
+                    continue;
+                }
+                remote_submit_future = std::move(async_submit.remote_submit_future);
+                native_async = true;
+            } else {
+                future = schedule_plan_executor_->Submit(copy_req);
+            }
             if (!future.valid()) {
-                SubmitTargetLocationDelete(ctx);
-                std::lock_guard<std::mutex> lock(task_mutex_);
-                RemoveActiveTaskLocked(ctx.instance_id, ctx.block_key);
+                if (native_async) {
+                    // accepted=true means the remote operation may already be
+                    // running.  Losing the completion channel is not a safe
+                    // failure and must never authorize target reuse.
+                    OnTaskUnknown(ctx.instance_id, ctx.block_key, "copy_submit_invalid_future_after_acceptance");
+                } else {
+                    CompleteCopyTaskAsFailed(ctx, "copy_submit_invalid_future");
+                }
                 item->MarkFailed(EC_ERROR);
                 continue;
             }
 
             {
                 std::lock_guard<std::mutex> lock(pending_mutex_);
-                pending_copies_.push_back(PendingCopy{ctx.instance_id, ctx.block_key, std::move(future)});
+                PendingCopy pending{ctx.instance_id, ctx.block_key, std::move(future), native_async};
+                if (native_async) {
+                    pending.remote_submit_future = std::move(remote_submit_future);
+                    pending.remote_submit_processed = false;
+                }
+                pending_copies_.push_back(std::move(pending));
             }
             pending_cv_.notify_one();
 
@@ -1212,6 +2012,28 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
     // preparing item 都不应泄漏到函数返回之后。
     release_all_preparing();
     return collect_results();
+}
+
+bool MigrationManager::IsSourceLocationServing(const CopyTaskContext &ctx) const {
+    auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
+    if (!indexer) {
+        return false;
+    }
+
+    MetaSearcher meta_searcher(indexer);
+    auto rc = std::make_shared<RequestContext>("migration_check_source");
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ErrorCode ec = meta_searcher.BatchGetLocation(rc.get(), {ctx.block_key}, empty_mask, location_maps);
+    if (ec != EC_OK || location_maps.empty()) {
+        return false;
+    }
+    auto iter = location_maps[0].find(ctx.src_location_id);
+    if (iter == location_maps[0].end() || iter->second == nullptr) {
+        return false;
+    }
+    // id + status + create_time 三者同时匹配，防止 id 复用导致误判新 location 为原始源。
+    return iter->second->status() == CLS_SERVING && iter->second->create_time() == ctx.src_create_time;
 }
 
 MigrationManager::CopySourceFailureKey MigrationManager::MakeCopySourceFailureKey(const CopyTaskContext &ctx) {
@@ -1342,31 +2164,297 @@ MigrationManager::GetCopySourceFailure(const std::string &instance_id,
         true, now < iter->second.retry_after, iter->second.consecutive_failures, iter->second.last_error};
 }
 
-bool MigrationManager::IsSourceLocationServing(const CopyTaskContext &ctx) const {
-    auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
-    if (!indexer) {
-        return false;
+MigrationCopyGuardState MigrationManager::ExpectedGuardState(const CopyTaskContext &ctx) {
+    if (ctx.state == CopyTaskState::kCancelling || ctx.completion_was_cancelling) {
+        return MigrationCopyGuardState::MCGS_CANCELLING;
     }
-
-    MetaSearcher meta_searcher(indexer);
-    auto rc = std::make_shared<RequestContext>("migration_check_source");
-    std::vector<CacheLocationMap> location_maps;
-    BlockMask empty_mask;
-    ErrorCode ec = meta_searcher.BatchGetLocation(rc.get(), {ctx.block_key}, empty_mask, location_maps);
-    if (ec != EC_OK || location_maps.empty()) {
-        return false;
-    }
-    auto iter = location_maps[0].find(ctx.src_location_id);
-    if (iter == location_maps[0].end() || iter->second == nullptr) {
-        return false;
-    }
-    // id + status + create_time 三者同时匹配，防止 id 复用导致误判新 location 为原始源。
-    return iter->second->status() == CLS_SERVING &&
-           iter->second->create_time() == ctx.src_create_time;
+    return ctx.async_backend_task_ids.empty() ? MigrationCopyGuardState::MCGS_SUBMITTING
+                                              : MigrationCopyGuardState::MCGS_ACTIVE;
 }
 
-void MigrationManager::CompleteCopyTaskAsFailed(const CopyTaskContext &ctx, const std::string &fail_reason) {
-    SubmitTargetLocationDelete(ctx);
+std::shared_ptr<std::mutex> MigrationManager::GetAsyncTransitionMutex(const std::string &instance_id,
+                                                                      int64_t block_key) const {
+    std::lock_guard<std::mutex> lock(task_mutex_);
+    const auto instance_iter = active_tasks_by_instance_.find(instance_id);
+    if (instance_iter == active_tasks_by_instance_.end()) {
+        return nullptr;
+    }
+    const auto task_iter = instance_iter->second.find(block_key);
+    return task_iter == instance_iter->second.end() ? nullptr : task_iter->second.async_transition_mutex;
+}
+
+void MigrationManager::MarkGuardFinalizationPendingSync(const CopyTaskContext &ctx,
+                                                        CopyCompletionAction action,
+                                                        const std::string &reason) {
+    std::lock_guard<std::mutex> lock(task_mutex_);
+    const auto instance_iter = active_tasks_by_instance_.find(ctx.instance_id);
+    if (instance_iter == active_tasks_by_instance_.end()) {
+        return;
+    }
+    const auto task_iter = instance_iter->second.find(ctx.block_key);
+    if (task_iter == instance_iter->second.end() || task_iter->second.async_operation_id != ctx.async_operation_id ||
+        task_iter->second.state != CopyTaskState::kCompleting) {
+        return;
+    }
+    task_iter->second.async_guard_finalization_pending_sync = true;
+    task_iter->second.completion_was_cancelling = ctx.completion_was_cancelling;
+    task_iter->second.async_guard_pending_action = action;
+    task_iter->second.async_guard_pending_reason = reason;
+}
+
+MigrationManager::GuardMutationResult
+MigrationManager::UpdateAsyncCopyGuard(const CopyTaskContext &ctx,
+                                       MigrationCopyGuardState expected_state,
+                                       MigrationCopyGuardState state,
+                                       const std::vector<std::string> &backend_task_ids,
+                                       const std::string &last_error) {
+    if (ctx.copy_execution_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        return GuardMutationResult::kAppliedDurably;
+    }
+    auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
+    if (!indexer || ctx.async_operation_id.empty() || ctx.dst_location_id.empty()) {
+        return GuardMutationResult::kNotApplied;
+    }
+
+    MigrationCopyGuard guard;
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(state);
+    guard.set_operation_id(ctx.async_operation_id);
+    guard.set_source_location_id(ctx.src_location_id);
+    guard.set_source_location_create_time(ctx.src_create_time);
+    guard.set_source_storage_name(ctx.src_storage_name);
+    guard.set_target_storage_name(ctx.dst_storage_name);
+    guard.set_migration_retention(static_cast<int32_t>(ctx.retention));
+    guard.set_total_bytes(ctx.total_bytes);
+    guard.set_backend_task_ids(backend_task_ids);
+    guard.set_create_time_us(ctx.async_guard_create_time_us > 0 ? ctx.async_guard_create_time_us : now_us);
+    guard.set_update_time_us(now_us);
+    guard.set_last_error(last_error);
+
+    MetaSearcher meta_searcher(indexer);
+    auto request_context = std::make_shared<RequestContext>("migration_update_async_guard");
+    MetaSearcher::LocationCASTask task;
+    task.location_id = ctx.dst_location_id;
+    task.old_status = CLS_WRITING;
+    task.new_status = CLS_WRITING;
+    if (expected_state == MigrationCopyGuardState::MCGS_NONE) {
+        task.expected_migration_copy_guard_absent = true;
+    } else {
+        task.expected_operation_id = ctx.async_operation_id;
+        task.expected_migration_copy_guard_state = expected_state;
+    }
+    task.new_migration_copy_guard = std::make_shared<MigrationCopyGuard>(std::move(guard));
+    std::vector<std::vector<ErrorCode>> results;
+    const auto ec = meta_searcher.BatchCASLocationStatus(
+        request_context.get(), {ctx.block_key}, {{std::move(task)}}, results);
+    const bool updated =
+        ec == EC_OK && results.size() == 1 && results[0].size() == 1 && results[0][0] == EC_OK;
+    if (!updated) {
+        return GuardMutationResult::kNotApplied;
+    }
+    // ReadModifyWriteLocation may first update the local/async layer.  A guard
+    // is not a crash fence until the exact block has reached persistent meta.
+    return indexer->Sync({ctx.block_key}) ? GuardMutationResult::kAppliedDurably
+                                          : GuardMutationResult::kAppliedDurabilityUnknown;
+}
+
+MigrationManager::GuardMutationResult MigrationManager::FinalizeAsyncCopyGuard(const CopyTaskContext &ctx,
+                                                                               MigrationCopyGuardState expected_state,
+                                                                               CacheLocationStatus new_status) {
+    if (ctx.copy_execution_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        return GuardMutationResult::kAppliedDurably;
+    }
+    auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
+    if (!indexer || ctx.async_operation_id.empty() || ctx.dst_location_id.empty()) {
+        return GuardMutationResult::kNotApplied;
+    }
+    if (ctx.async_guard_finalization_pending_sync) {
+        return indexer->Sync({ctx.block_key}) ? GuardMutationResult::kAppliedDurably
+                                              : GuardMutationResult::kAppliedDurabilityUnknown;
+    }
+    MetaSearcher meta_searcher(indexer);
+    auto request_context = std::make_shared<RequestContext>("migration_finalize_async_guard");
+    MetaSearcher::LocationCASTask task;
+    task.location_id = ctx.dst_location_id;
+    task.old_status = CLS_WRITING;
+    task.new_status = new_status;
+    task.expected_operation_id = ctx.async_operation_id;
+    task.expected_migration_copy_guard_state = expected_state;
+    task.clear_migration_copy_guard = true;
+    std::vector<std::vector<ErrorCode>> results;
+    const auto ec = meta_searcher.BatchCASLocationStatus(
+        request_context.get(), {ctx.block_key}, {{std::move(task)}}, results);
+    const bool updated =
+        ec == EC_OK && results.size() == 1 && results[0].size() == 1 && results[0][0] == EC_OK;
+    if (!updated) {
+        return GuardMutationResult::kNotApplied;
+    }
+    return indexer->Sync({ctx.block_key}) ? GuardMutationResult::kAppliedDurably
+                                          : GuardMutationResult::kAppliedDurabilityUnknown;
+}
+
+bool MigrationManager::PersistRemoteAsyncCopyAcceptance(
+    const std::string &instance_id,
+    int64_t block_key,
+    const AsyncCopyRemoteSubmitResult &remote_result,
+    CopyTaskContext &out_ctx,
+    bool &out_cancel_requested) {
+    out_ctx = CopyTaskContext{};
+    out_cancel_requested = false;
+    if (!remote_result.accepted || remote_result.operation_id.empty() ||
+        remote_result.backend_task_ids.empty()) {
+        return false;
+    }
+
+    // Cancel() and completion take this operation's mutex too.  Unrelated Copy
+    // operations remain parallel, while a late submit response can never
+    // overwrite MCGS_CANCELLING with MCGS_ACTIVE.
+    auto transition_mutex = GetAsyncTransitionMutex(instance_id, block_key);
+    if (!transition_mutex) {
+        return false;
+    }
+    std::lock_guard<std::mutex> transition_lock(*transition_mutex);
+    {
+        std::lock_guard<std::mutex> task_lock(task_mutex_);
+        const auto instance_iter = active_tasks_by_instance_.find(instance_id);
+        if (instance_iter == active_tasks_by_instance_.end()) {
+            return false;
+        }
+        const auto task_iter = instance_iter->second.find(block_key);
+        if (task_iter == instance_iter->second.end() ||
+            task_iter->second.copy_execution_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED ||
+            task_iter->second.async_operation_id != remote_result.operation_id ||
+            (task_iter->second.state != CopyTaskState::kRunning &&
+             task_iter->second.state != CopyTaskState::kCancelling)) {
+            return false;
+        }
+        out_ctx = task_iter->second;
+        out_ctx.async_backend_task_ids = remote_result.backend_task_ids;
+        out_cancel_requested = task_iter->second.state == CopyTaskState::kCancelling;
+    }
+
+    const auto expected_state =
+        out_cancel_requested ? MigrationCopyGuardState::MCGS_CANCELLING : MigrationCopyGuardState::MCGS_SUBMITTING;
+    const auto guard_state = out_cancel_requested ? MigrationCopyGuardState::MCGS_CANCELLING
+                                                   : MigrationCopyGuardState::MCGS_ACTIVE;
+    const auto guard_result = UpdateAsyncCopyGuard(out_ctx,
+                                                   expected_state,
+                                                   guard_state,
+                                                   out_ctx.async_backend_task_ids,
+                                                   out_cancel_requested ? "cancel_requested" : "");
+
+    {
+        std::lock_guard<std::mutex> task_lock(task_mutex_);
+        const auto instance_iter = active_tasks_by_instance_.find(instance_id);
+        if (instance_iter == active_tasks_by_instance_.end()) {
+            return false;
+        }
+        const auto task_iter = instance_iter->second.find(block_key);
+        if (task_iter == instance_iter->second.end() ||
+            task_iter->second.async_operation_id != remote_result.operation_id ||
+            (task_iter->second.state != CopyTaskState::kRunning &&
+             task_iter->second.state != CopyTaskState::kCancelling)) {
+            return false;
+        }
+        task_iter->second.async_backend_task_ids = remote_result.backend_task_ids;
+        out_ctx = task_iter->second;
+    }
+    return guard_result == GuardMutationResult::kAppliedDurably;
+}
+
+void MigrationManager::SubmitPreparedTargetLocationDelete(const CopyTaskContext &ctx) {
+    if (!schedule_plan_executor_ || ctx.dst_location_id.empty()) {
+        return;
+    }
+    CacheLocationDelRequest del_req;
+    del_req.instance_id = ctx.instance_id;
+    del_req.block_keys = {ctx.block_key};
+    del_req.location_ids = {{ctx.dst_location_id}};
+    del_req.prepared_deleting = true;
+    schedule_plan_executor_->SubmitNonBlocking(del_req, ScheduleTaskClass::kMigrationContinuation);
+}
+
+void MigrationManager::CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, const std::string &fail_reason) {
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        UpdateAsyncCopyGuard(ctx,
+                             ExpectedGuardState(ctx),
+                             MigrationCopyGuardState::MCGS_UNKNOWN,
+                             ctx.async_backend_task_ids,
+                             fail_reason);
+        MoveAsyncCopyCreditToQuarantine(ctx, fail_reason);
+    }
+    {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        RemoveActiveTaskLocked(ctx.instance_id, ctx.block_key);
+    }
+    stat_copy_failed_.fetch_add(1, std::memory_order_relaxed);
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        stat_async_copy_unknown_.fetch_add(1, std::memory_order_relaxed);
+    }
+    const int64_t duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                    std::chrono::steady_clock::now() - ctx.submit_time)
+                                    .count();
+    if (metrics_enabled_) {
+        ++m_tasks_completed_failed_;
+    }
+    if (event_manager_ != nullptr) {
+        auto ev = std::make_shared<MigrationCompletedEvent>(ctx.instance_id);
+        ev->SetEventTriggerTime();
+        ev->SetAdditionalArgs(ctx.block_key,
+                              ctx.src_storage_name,
+                              ctx.dst_storage_name,
+                              duration_ms,
+                              ctx.total_bytes,
+                              false,
+                              fail_reason);
+        event_manager_->Publish(ev);
+    }
+    KVCM_LOG_ERROR("migration asynchronous Copy entered quarantine: instance %s block_key %lld dst_loc %s "
+                   "operation_id %s reason %s",
+                   ctx.instance_id.c_str(),
+                   static_cast<long long>(ctx.block_key),
+                   ctx.dst_location_id.c_str(),
+                   ctx.async_operation_id.c_str(),
+                   fail_reason.c_str());
+}
+
+bool MigrationManager::CompleteCopyTaskAsFailed(const CopyTaskContext &ctx,
+                                                const std::string &fail_reason,
+                                                bool remote_side_effect_possible) {
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        const auto finalize_result = FinalizeAsyncCopyGuard(ctx, ExpectedGuardState(ctx), CLS_DELETING);
+        if (finalize_result == GuardMutationResult::kAppliedDurabilityUnknown && remote_side_effect_possible) {
+            MarkGuardFinalizationPendingSync(ctx, CopyCompletionAction::kFailed, fail_reason);
+            return false;
+        }
+        if (finalize_result != GuardMutationResult::kAppliedDurably) {
+            if (remote_side_effect_possible) {
+                CompleteCopyTaskAsUnknown(ctx, "guard_finalize_failed:" + fail_reason);
+                return true;
+            }
+            // The caller proves no backend handoff/POST occurred.  It is safe
+            // to attempt ordinary target cleanup even if the SUBMITTING guard
+            // CAS/Sync outcome is ambiguous.  The delete executor itself
+            // still refuses a guard it can observe, so this can leak capacity
+            // on a persistent-meta outage but can never recycle a remotely
+            // writable destination.  Recovery will quarantine any durable
+            // residual guard after restart.
+            KVCM_LOG_WARN("pre-submit async Copy guard cleanup was not durably finalized: instance %s "
+                          "block_key %lld dst_loc %s operation_id %s reason %s",
+                          ctx.instance_id.c_str(),
+                          static_cast<long long>(ctx.block_key),
+                          ctx.dst_location_id.c_str(),
+                          ctx.async_operation_id.c_str(),
+                          fail_reason.c_str());
+            SubmitTargetLocationDelete(ctx);
+        } else {
+            SubmitPreparedTargetLocationDelete(ctx);
+        }
+        ReleaseAsyncCopyCredit(ctx);
+    } else {
+        SubmitTargetLocationDelete(ctx);
+    }
     {
         std::lock_guard<std::mutex> lock(task_mutex_);
         RemoveActiveTaskLocked(ctx.instance_id, ctx.block_key);
@@ -1392,70 +2480,49 @@ void MigrationManager::CompleteCopyTaskAsFailed(const CopyTaskContext &ctx, cons
                               fail_reason);
         event_manager_->Publish(ev);
     }
+    KVCM_LOG_WARN("migration failed: instance %s block_key %lld dst_loc %s reason %s",
+                  ctx.instance_id.c_str(),
+                  static_cast<long long>(ctx.block_key),
+                  ctx.dst_location_id.c_str(),
+                  fail_reason.c_str());
+    return true;
 }
 
-void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t block_key) {
-    CopyTaskContext ctx;
-    ClaimResult claim;
-    {
-        std::lock_guard<std::mutex> lock(task_mutex_);
-        claim = ClaimForCompletionLocked(instance_id, block_key, ctx);
-    }
-    if (claim == ClaimResult::kNotFound || claim == ClaimResult::kBusyCompleting) {
-        return; // 已处理过 / 完成认领中
-    }
-    if (claim == ClaimResult::kBusyPreparing) {
-        KVCM_LOG_WARN("ignore premature migration success callback for preparing task: instance %s block_key %ld",
-                      instance_id.c_str(),
-                      block_key);
-        return;
-    }
-
-    if (claim == ClaimResult::kWasCancelling) {
-        // 用户已取消。copy 虽成功也丢弃：不 promote、不删源，删掉仍为 WRITING 的目标半成品。
-        CompleteCancelledTask(ctx);
-        return;
-    }
-    // kClaimedRunning：状态已在锁内置 kCompleting，并发 Cancel 会走 busy 分支。
-
-    // backend 已明确完成 Copy，说明这条 source->target 路由至少在本次可用；即使后续因为
-    // source metadata 并发变化或 target promote 失败而按任务失败收尾，也不应继承旧的 Copy 退避。
-    ClearCopySourceFailure(ctx);
-
-    if (!IsSourceLocationServing(ctx)) {
-        KVCM_LOG_WARN("migration source lost, block_key %ld src_loc %s, discard dst_loc %s",
-                      block_key,
-                      ctx.src_location_id.c_str(),
-                      ctx.dst_location_id.c_str());
-        CompleteCopyTaskAsFailed(ctx, "source_lost");
-        return;
-    }
-
-    // CAS 目标 location WRITING -> SERVING。
-    auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
+bool MigrationManager::CompleteCopyTaskAsSucceeded(const CopyTaskContext &ctx) {
     bool promoted = false;
-    if (indexer) {
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        const auto finalize_result = FinalizeAsyncCopyGuard(ctx, ExpectedGuardState(ctx), CLS_SERVING);
+        if (finalize_result == GuardMutationResult::kAppliedDurabilityUnknown) {
+            MarkGuardFinalizationPendingSync(ctx, CopyCompletionAction::kSuccess);
+            return false;
+        }
+        if (finalize_result == GuardMutationResult::kNotApplied) {
+            CompleteCopyTaskAsUnknown(ctx, "guard_finalize_failed:promote");
+            return true;
+        }
+        promoted = true;
+    } else if (auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
+               indexer) {
         MetaSearcher meta_searcher(indexer);
         auto rc = std::make_shared<RequestContext>("migration_on_success");
         std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
             {MetaSearcher::LocationCASTask{ctx.dst_location_id, CLS_WRITING, CLS_SERVING}}};
         std::vector<std::vector<ErrorCode>> cas_results;
-        ErrorCode ec = meta_searcher.BatchCASLocationStatus(rc.get(), {block_key}, cas_tasks, cas_results);
+        ErrorCode ec = meta_searcher.BatchCASLocationStatus(rc.get(), {ctx.block_key}, cas_tasks, cas_results);
         promoted = (ec == EC_OK && !cas_results.empty() && !cas_results[0].empty() && cas_results[0][0] == EC_OK);
     }
 
     if (!promoted) {
         // 目标提升失败：清理目标半成品，源端保持不动（数据未受损），按失败收尾。
         KVCM_LOG_WARN("migration promote dst location failed, block_key %ld dst_loc %s, treat as failed",
-                      block_key,
+                      ctx.block_key,
                       ctx.dst_location_id.c_str());
-        CompleteCopyTaskAsFailed(ctx, "promote_failed");
-        return;
+        return CompleteCopyTaskAsFailed(ctx, "promote_failed");
     }
 
     // 按提交时快照的 mark target/deadline 做条件清除，避免清掉后续同 block 新 mark。
     if (!ctx.mark_target.empty()) {
-        ClearTieredWriteMarkIfMatchInternal(ctx.instance_id, block_key, ctx.mark_target, ctx.mark_deadline_ms);
+        ClearTieredWriteMarkIfMatchInternal(ctx.instance_id, ctx.block_key, ctx.mark_target, ctx.mark_deadline_ms);
     }
 
     // 按 retention 处理源端。
@@ -1463,10 +2530,12 @@ void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
         SubmitSourceLocationDelete(ctx);
     }
 
+    ReleaseAsyncCopyCredit(ctx);
+
     // 最后移除活跃任务。
     {
         std::lock_guard<std::mutex> lock(task_mutex_);
-        RemoveActiveTaskLocked(ctx.instance_id, block_key);
+        RemoveActiveTaskLocked(ctx.instance_id, ctx.block_key);
     }
     stat_copy_completed_.fetch_add(1, std::memory_order_relaxed);
     const int64_t duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1481,17 +2550,41 @@ void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
         auto ev = std::make_shared<MigrationCompletedEvent>(ctx.instance_id);
         ev->SetEventTriggerTime();
         ev->SetAdditionalArgs(
-            block_key, ctx.src_storage_name, ctx.dst_storage_name, duration_ms, ctx.total_bytes, true, "");
+            ctx.block_key, ctx.src_storage_name, ctx.dst_storage_name, duration_ms, ctx.total_bytes, true, "");
         event_manager_->Publish(ev);
     }
     KVCM_LOG_INFO("migration completed: instance %s block_key %ld dst_loc %s retention %d",
                   ctx.instance_id.c_str(),
-                  block_key,
+                  ctx.block_key,
                   ctx.dst_location_id.c_str(),
                   static_cast<int>(ctx.retention));
+    return true;
 }
 
-void MigrationManager::OnTaskFailed(const std::string &instance_id, int64_t block_key, ErrorCode reason) {
+bool MigrationManager::ResumePendingGuardFinalization(const CopyTaskContext &ctx) {
+    switch (ctx.async_guard_pending_action) {
+    case CopyCompletionAction::kSuccess:
+        return CompleteCopyTaskAsSucceeded(ctx);
+    case CopyCompletionAction::kFailed:
+        return CompleteCopyTaskAsFailed(ctx, ctx.async_guard_pending_reason);
+    case CopyCompletionAction::kCancelled:
+        return CompleteCancelledTask(ctx);
+    case CopyCompletionAction::kNone:
+        KVCM_LOG_ERROR("guard Sync retry is missing its completion action: instance %s block_key %lld operation %s",
+                       ctx.instance_id.c_str(),
+                       static_cast<long long>(ctx.block_key),
+                       ctx.async_operation_id.c_str());
+        CompleteCopyTaskAsUnknown(ctx, "guard_sync_retry_missing_action");
+        return true;
+    }
+    return true;
+}
+
+bool MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t block_key) {
+    std::unique_lock<std::mutex> transition_lock;
+    if (auto transition_mutex = GetAsyncTransitionMutex(instance_id, block_key)) {
+        transition_lock = std::unique_lock<std::mutex>(*transition_mutex);
+    }
     CopyTaskContext ctx;
     ClaimResult claim;
     {
@@ -1499,30 +2592,110 @@ void MigrationManager::OnTaskFailed(const std::string &instance_id, int64_t bloc
         claim = ClaimForCompletionLocked(instance_id, block_key, ctx);
     }
     if (claim == ClaimResult::kNotFound || claim == ClaimResult::kBusyCompleting) {
-        return;
+        return true; // 已处理过 / 完成认领中
+    }
+    if (claim == ClaimResult::kBusyPreparing) {
+        KVCM_LOG_WARN("ignore premature migration success callback for preparing task: instance %s block_key %ld",
+                      instance_id.c_str(),
+                      block_key);
+        return true;
+    }
+    if (claim == ClaimResult::kRetryingGuardSync) {
+        return ResumePendingGuardFinalization(ctx);
+    }
+    if (claim == ClaimResult::kWasCancelling) {
+        // 用户已取消。copy 虽成功也丢弃：不 promote、不删源，删掉仍为 WRITING 的目标半成品。
+        return CompleteCancelledTask(ctx);
+    }
+    // kClaimedRunning：状态已在锁内置 kCompleting，并发 Cancel 会走 busy 分支。
+
+    // backend 已明确完成 Copy，说明这条 source->target 路由至少在本次可用；即使后续因为
+    // source metadata 并发变化或 target promote 失败而按任务失败收尾，也不应继承旧的 Copy 退避。
+    ClearCopySourceFailure(ctx);
+
+    if (!IsSourceLocationServing(ctx)) {
+        KVCM_LOG_WARN("migration source lost, block_key %ld src_loc %s, discard dst_loc %s",
+                      block_key,
+                      ctx.src_location_id.c_str(),
+                      ctx.dst_location_id.c_str());
+        return CompleteCopyTaskAsFailed(ctx, "source_lost");
+    }
+    return CompleteCopyTaskAsSucceeded(ctx);
+}
+
+bool MigrationManager::OnTaskFailed(const std::string &instance_id, int64_t block_key, ErrorCode reason) {
+    return OnTaskFailedInternal(
+        instance_id, block_key, reason, "copy_failed:" + std::to_string(static_cast<int>(reason)), true, true);
+}
+
+bool MigrationManager::OnTaskFailedInternal(const std::string &instance_id,
+                                            int64_t block_key,
+                                            ErrorCode reason,
+                                            const std::string &fail_reason,
+                                            bool remote_side_effect_possible,
+                                            bool record_source_failure) {
+    std::unique_lock<std::mutex> transition_lock;
+    if (auto transition_mutex = GetAsyncTransitionMutex(instance_id, block_key)) {
+        transition_lock = std::unique_lock<std::mutex>(*transition_mutex);
+    }
+    CopyTaskContext ctx;
+    ClaimResult claim;
+    {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        claim = ClaimForCompletionLocked(instance_id, block_key, ctx);
+    }
+    if (claim == ClaimResult::kNotFound || claim == ClaimResult::kBusyCompleting) {
+        return true;
     }
     if (claim == ClaimResult::kBusyPreparing) {
         KVCM_LOG_WARN("ignore premature migration failure callback for preparing task: instance %s block_key %ld",
                       instance_id.c_str(),
                       block_key);
-        return;
+        return true;
+    }
+    if (claim == ClaimResult::kRetryingGuardSync) {
+        return ResumePendingGuardFinalization(ctx);
     }
     if (claim == ClaimResult::kWasCancelling) {
         // 已取消，无论 copy 结果如何一律按取消收尾（清 WRITING 目标，记 cancelled 终态）。
-        CompleteCancelledTask(ctx);
-        return;
+        return CompleteCancelledTask(ctx);
     }
 
     // 失败：CAS 目标 WRITING -> DELETING 并删除目标半成品，源端不动。
     // 必须先登记 source 退避，再从 active table 移除任务，避免 admission 在两步之间重新选中同一源。
-    RecordCopySourceFailure(ctx, reason);
-    const std::string fail_reason = "copy_failed:" + std::to_string(static_cast<int>(reason));
-    CompleteCopyTaskAsFailed(ctx, fail_reason);
-    KVCM_LOG_WARN("migration failed: instance %s block_key %ld dst_loc %s reason %d",
-                  ctx.instance_id.c_str(),
-                  block_key,
-                  ctx.dst_location_id.c_str(),
-                  reason);
+    if (record_source_failure) {
+        RecordCopySourceFailure(ctx, reason);
+    }
+    return CompleteCopyTaskAsFailed(ctx, fail_reason, remote_side_effect_possible);
+}
+
+bool MigrationManager::OnTaskUnknown(const std::string &instance_id, int64_t block_key, const std::string &reason) {
+    std::unique_lock<std::mutex> transition_lock;
+    if (auto transition_mutex = GetAsyncTransitionMutex(instance_id, block_key)) {
+        transition_lock = std::unique_lock<std::mutex>(*transition_mutex);
+    }
+    CopyTaskContext ctx;
+    ClaimResult claim;
+    {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        claim = ClaimForCompletionLocked(instance_id, block_key, ctx);
+    }
+    if (claim == ClaimResult::kNotFound || claim == ClaimResult::kBusyCompleting) {
+        return true;
+    }
+    if (claim == ClaimResult::kBusyPreparing) {
+        KVCM_LOG_WARN("ignore premature unknown Copy callback for preparing task: instance %s block_key %lld",
+                      instance_id.c_str(),
+                      static_cast<long long>(block_key));
+        return true;
+    }
+    if (claim == ClaimResult::kRetryingGuardSync) {
+        return ResumePendingGuardFinalization(ctx);
+    }
+    // Unknown ownership supersedes a concurrent cancel request: without a
+    // terminal+drained proof, cancellation must not authorize target reuse.
+    CompleteCopyTaskAsUnknown(ctx, reason.empty() ? "copy_completion_unknown" : reason);
+    return true;
 }
 
 void MigrationManager::SubmitTargetLocationDelete(const CopyTaskContext &ctx) {
@@ -1571,20 +2744,101 @@ void MigrationManager::MonitorLoop() {
         if (!has_cell) {
             continue;
         }
-
-        auto status = cell.future.wait_for(kFutureWaitTime);
-        if (status != std::future_status::ready) {
-            // 尚未完成，放回队尾稍后再查。
-            std::lock_guard<std::mutex> lock(pending_mutex_);
-            pending_copies_.push_back(std::move(cell));
+        if (cell.completed_result.has_value() && std::chrono::steady_clock::now() < cell.completion_retry_after) {
+            {
+                std::lock_guard<std::mutex> lock(pending_mutex_);
+                pending_copies_.push_back(std::move(cell));
+            }
+            // Avoid a tight loop when this is the only pending operation.  No
+            // task/guard lock is held while waiting for persistent metadata.
+            std::this_thread::sleep_for(kGuardSyncRetryIdleSleep);
             continue;
         }
 
-        PlanExecuteResult result = cell.future.get();
+        if (cell.native_async && !cell.remote_submit_processed) {
+            if (!cell.remote_submit_future.valid()) {
+                OnTaskUnknown(cell.instance_id, cell.block_key, "copy_submit_acceptance_channel_lost");
+                continue;
+            }
+            const auto remote_status = cell.remote_submit_future.wait_for(kFutureWaitTime);
+            if (remote_status != std::future_status::ready) {
+                std::lock_guard<std::mutex> lock(pending_mutex_);
+                pending_copies_.push_back(std::move(cell));
+                continue;
+            }
+
+            AsyncCopyRemoteSubmitResult remote_result = cell.remote_submit_future.get();
+            if (!remote_result.accepted) {
+                if (remote_result.acceptance_unknown) {
+                    OnTaskUnknown(cell.instance_id,
+                                  cell.block_key,
+                                  remote_result.detail.empty() ? "copy_submit_acceptance_unknown"
+                                                               : remote_result.detail);
+                } else {
+                    const bool completed = OnTaskFailedInternal(cell.instance_id,
+                                                                cell.block_key,
+                                                                remote_result.status,
+                                                                remote_result.detail.empty() ? "copy_submit_rejected"
+                                                                                             : remote_result.detail,
+                                                                false,
+                                                                false);
+                    if (!completed) {
+                        cell.remote_submit_processed = true;
+                        cell.completed_result =
+                            PlanExecuteResult{remote_result.status, remote_result.detail, true, true};
+                        cell.completion_retry_after = std::chrono::steady_clock::now() + kGuardSyncRetryInterval;
+                        std::lock_guard<std::mutex> lock(pending_mutex_);
+                        pending_copies_.push_back(std::move(cell));
+                    }
+                }
+                continue;
+            }
+
+            CopyTaskContext accepted_ctx;
+            bool cancel_requested = false;
+            if (!PersistRemoteAsyncCopyAcceptance(cell.instance_id,
+                                                  cell.block_key,
+                                                  remote_result,
+                                                  accepted_ctx,
+                                                  cancel_requested)) {
+                if (!accepted_ctx.src_storage_name.empty() && schedule_plan_executor_) {
+                    schedule_plan_executor_->RequestCancelAsyncCopy(accepted_ctx.src_storage_name,
+                                                                    remote_result.operation_id);
+                }
+                OnTaskUnknown(cell.instance_id, cell.block_key, "guard_activate_failed_after_remote_submit");
+                continue;
+            }
+            if (cancel_requested && schedule_plan_executor_) {
+                schedule_plan_executor_->RequestCancelAsyncCopy(accepted_ctx.src_storage_name,
+                                                                accepted_ctx.async_operation_id);
+            }
+            cell.remote_submit_processed = true;
+        }
+
+        if (!cell.completed_result.has_value()) {
+            auto status = cell.future.wait_for(kFutureWaitTime);
+            if (status != std::future_status::ready) {
+                // 尚未完成，放回队尾稍后再查。
+                std::lock_guard<std::mutex> lock(pending_mutex_);
+                pending_copies_.push_back(std::move(cell));
+                continue;
+            }
+            cell.completed_result = cell.future.get();
+        }
+
+        const PlanExecuteResult &result = *cell.completed_result;
+        bool completed = true;
         if (result.status == EC_OK) {
-            OnTaskSuccess(cell.instance_id, cell.block_key);
+            completed = OnTaskSuccess(cell.instance_id, cell.block_key);
+        } else if (cell.native_async && (!result.terminal || !result.safe_to_reuse_dst)) {
+            completed = OnTaskUnknown(cell.instance_id, cell.block_key, result.error_message);
         } else {
-            OnTaskFailed(cell.instance_id, cell.block_key, result.status);
+            completed = OnTaskFailed(cell.instance_id, cell.block_key, result.status);
+        }
+        if (!completed) {
+            cell.completion_retry_after = std::chrono::steady_clock::now() + kGuardSyncRetryInterval;
+            std::lock_guard<std::mutex> lock(pending_mutex_);
+            pending_copies_.push_back(std::move(cell));
         }
     }
 
@@ -1913,10 +3167,24 @@ void MigrationManager::ProcessExpiredMarks() {
     }
 }
 
-void MigrationManager::CompleteCancelledTask(const CopyTaskContext &ctx) {
+bool MigrationManager::CompleteCancelledTask(const CopyTaskContext &ctx) {
     // 取消任务的延迟收尾（monitor 线程，认领到 kWasCancelling 时调用）。
     // 目标此时仍为 WRITING（cancelling 任务从未被 promote）；CAS WRITING->DELETING 删半成品，源端不动。
-    SubmitTargetLocationDelete(ctx);
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        const auto finalize_result = FinalizeAsyncCopyGuard(ctx, ExpectedGuardState(ctx), CLS_DELETING);
+        if (finalize_result == GuardMutationResult::kAppliedDurabilityUnknown) {
+            MarkGuardFinalizationPendingSync(ctx, CopyCompletionAction::kCancelled, "cancelled");
+            return false;
+        }
+        if (finalize_result == GuardMutationResult::kNotApplied) {
+            CompleteCopyTaskAsUnknown(ctx, "cancel_guard_finalize_failed");
+            return true;
+        }
+        SubmitPreparedTargetLocationDelete(ctx);
+        ReleaseAsyncCopyCredit(ctx);
+    } else {
+        SubmitTargetLocationDelete(ctx);
+    }
     {
         std::lock_guard<std::mutex> lock(task_mutex_);
         RemoveActiveTaskLocked(ctx.instance_id, ctx.block_key);
@@ -1946,6 +3214,7 @@ void MigrationManager::CompleteCancelledTask(const CopyTaskContext &ctx) {
                   ctx.instance_id.c_str(),
                   ctx.block_key,
                   ctx.dst_location_id.c_str());
+    return true;
 }
 
 ErrorCode MigrationManager::Cancel(const std::string &instance_id, int64_t block_key) {
@@ -1953,9 +3222,59 @@ ErrorCode MigrationManager::Cancel(const std::string &instance_id, int64_t block
     // 边界停止进入 copy、清目标并释放 reservation；running 取消仍等待 future 完成后由 monitor 收尾。
     // 两种 cancelling 期间任务都保留在活跃表，继续挡重复 Submit 并保护 WRITING 目标。
     CancelResult result;
+    CopyTaskContext cancelling_ctx;
+    bool persist_async_cancelling = false;
+    // Serialize this operation's in-memory cancellation transition and durable
+    // guard update with submit acceptance and completion finalization.
+    std::unique_lock<std::mutex> guard_transition_lock;
+    if (auto transition_mutex = GetAsyncTransitionMutex(instance_id, block_key)) {
+        guard_transition_lock = std::unique_lock<std::mutex>(*transition_mutex);
+    }
     {
         std::lock_guard<std::mutex> lock(task_mutex_);
         result = MarkCancellingLocked(instance_id, block_key);
+        if (result == CancelResult::kMarked) {
+            const auto instance_iter = active_tasks_by_instance_.find(instance_id);
+            if (instance_iter != active_tasks_by_instance_.end()) {
+                const auto task_iter = instance_iter->second.find(block_key);
+                if (task_iter != instance_iter->second.end() &&
+                    task_iter->second.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+                    cancelling_ctx = task_iter->second;
+                    persist_async_cancelling = true;
+                }
+            }
+        }
+    }
+    if (persist_async_cancelling &&
+        UpdateAsyncCopyGuard(cancelling_ctx,
+                             cancelling_ctx.async_backend_task_ids.empty() ? MigrationCopyGuardState::MCGS_SUBMITTING
+                                                                           : MigrationCopyGuardState::MCGS_ACTIVE,
+                             MigrationCopyGuardState::MCGS_CANCELLING,
+                             cancelling_ctx.async_backend_task_ids,
+                             "cancel_requested") != GuardMutationResult::kAppliedDurably) {
+        // The in-memory cancellation must not outrun its persistent fence.
+        // Drop ownership into fail-closed quarantine; a late completion can no
+        // longer publish or release the target through this process.
+        CompleteCopyTaskAsUnknown(cancelling_ctx, "cancel_guard_persist_failed");
+        return EC_ERROR;
+    }
+    if (guard_transition_lock.owns_lock()) {
+        guard_transition_lock.unlock();
+    }
+    if (persist_async_cancelling && schedule_plan_executor_) {
+        const auto cancel_ec = schedule_plan_executor_->RequestCancelAsyncCopy(
+            cancelling_ctx.src_storage_name, cancelling_ctx.async_operation_id);
+        if (cancel_ec != EC_OK) {
+            // The persistent state is already CANCELLING.  A failed immediate
+            // signal is not a drain proof; the coordinator keeps polling and
+            // will retry cancellation at its deadline.
+            KVCM_LOG_WARN("[cancel] async coordinator did not accept cancellation immediately: "
+                          "instance %s block_key %lld operation_id %s ec %d",
+                          instance_id.c_str(),
+                          static_cast<long long>(block_key),
+                          cancelling_ctx.async_operation_id.c_str(),
+                          static_cast<int>(cancel_ec));
+        }
     }
     switch (result) {
     case CancelResult::kNotFound:
@@ -1998,6 +3317,9 @@ bool MigrationManager::InsertActiveTaskLocked(CopyTaskContext ctx) {
     if (instance_tasks.count(block_key) > 0) {
         return false; // 已存在：调用方决定如何处理（回滚等）
     }
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED && !ctx.async_transition_mutex) {
+        ctx.async_transition_mutex = std::make_shared<std::mutex>();
+    }
     instance_tasks[block_key] = std::move(ctx);
     UpdateActiveTasksGauge();
     return true;
@@ -2013,12 +3335,17 @@ bool MigrationManager::ReservePreparingTaskLocked(const MigrationRequest &reques
     ctx.src_storage_name = request.src_storage_name;
     ctx.dst_storage_name = request.dst_storage_name;
     ctx.retention = request.retention;
+    ctx.copy_execution_mode = request.copy_execution_mode;
+    ctx.async_operation_id = request.async_operation_id;
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        ctx.async_transition_mutex = std::make_shared<std::mutex>();
+    }
     ctx.state = CopyTaskState::kPreparing;
     // InsertActiveTaskLocked 在同一个 task_mutex_ 临界区内完成存在性检查与插入，避免 check-then-insert 窗口。
     return InsertActiveTaskLocked(std::move(ctx));
 }
 
-bool MigrationManager::UpdatePreparingTaskLocked(const CopyTaskContext &ctx) {
+bool MigrationManager::UpdatePreparingTaskLocked(CopyTaskContext &ctx) {
     auto instance_iter = active_tasks_by_instance_.find(ctx.instance_id);
     if (instance_iter == active_tasks_by_instance_.end()) {
         return false;
@@ -2026,6 +3353,15 @@ bool MigrationManager::UpdatePreparingTaskLocked(const CopyTaskContext &ctx) {
     auto task_iter = instance_iter->second.find(ctx.block_key);
     if (task_iter == instance_iter->second.end() || task_iter->second.state != CopyTaskState::kPreparing) {
         return false;
+    }
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        // Preserve the mutex published with the preparing reservation.  A
+        // Cancel caller may already hold a shared_ptr to it while waiting for
+        // task_mutex_; replacing it would split one operation across locks.
+        if (!task_iter->second.async_transition_mutex) {
+            task_iter->second.async_transition_mutex = std::make_shared<std::mutex>();
+        }
+        ctx.async_transition_mutex = task_iter->second.async_transition_mutex;
     }
     task_iter->second = ctx;
     task_iter->second.state = CopyTaskState::kPreparing;
@@ -2095,10 +3431,16 @@ MigrationManager::ClaimResult MigrationManager::ClaimForCompletionLocked(const s
         return ClaimResult::kBusyPreparing;
     }
     if (task.state == CopyTaskState::kCancelling) {
+        task.state = CopyTaskState::kCompleting;
+        task.completion_was_cancelling = true;
         out_ctx = task; // 交由 CompleteCancelledTask 收尾（删 WRITING 目标、不 promote）
         return ClaimResult::kWasCancelling;
     }
     if (task.state == CopyTaskState::kCompleting) {
+        if (task.async_guard_finalization_pending_sync) {
+            out_ctx = task;
+            return ClaimResult::kRetryingGuardSync;
+        }
         return ClaimResult::kBusyCompleting; // 防御：完成路径仅单一 monitor 线程，正常不会重入
     }
     task.state = CopyTaskState::kCompleting; // 认领：此后并发 Cancel 走 busy 分支
@@ -2273,12 +3615,13 @@ MigrationManager::CopyAdmission MigrationManager::CheckCopyAdmission(const std::
     // 按目标 storage 上多个 location 的联合覆盖判断，替代旧的 per-location 全覆盖。
     // 建索引一次 O(L·S),之后 per-source O(S) set lookup。
     const auto serving_covered = CollectCoveredSpecNames(loc_map, dst_storage_name, {CacheLocationStatus::CLS_SERVING});
-    const auto all_covered =
-        CollectCoveredSpecNames(loc_map, dst_storage_name, {CacheLocationStatus::CLS_SERVING, CacheLocationStatus::CLS_WRITING});
+    const auto all_covered = CollectCoveredSpecNames(
+        loc_map, dst_storage_name, {CacheLocationStatus::CLS_SERVING, CacheLocationStatus::CLS_WRITING});
 
     auto specs_covered_by = [](const CacheLocation &src, const std::unordered_set<std::string> &covered) {
-        return std::all_of(src.location_specs().begin(), src.location_specs().end(),
-                           [&covered](const auto &spec) { return covered.count(spec.name()) > 0; });
+        return std::all_of(src.location_specs().begin(), src.location_specs().end(), [&covered](const auto &spec) {
+            return covered.count(spec.name()) > 0;
+        });
     };
 
     struct EligibleSource {
@@ -2577,6 +3920,13 @@ void MigrationManager::RunAsyncMigrationPrepare(AsyncMigrationPrepareJob job, st
         const auto active_copy_count = ActiveTaskCountForGroup(job.instance_group_name);
         params.max_copy_slots = max_concurrent_copy > active_copy_count ? max_concurrent_copy - active_copy_count : 0;
         params.retention = current_strategy->retention();
+        params.copy_execution_mode = cache_config->migration_copy_execution_mode();
+        params.copy_max_inflight_bytes = cache_config->migration_copy_max_inflight_bytes();
+        params.copy_max_quarantine_operations = cache_config->migration_copy_max_quarantine_operations();
+        params.copy_max_quarantine_bytes = cache_config->migration_copy_max_quarantine_bytes();
+        params.async_copy_options.operation_deadline_ms = cache_config->migration_copy_operation_deadline_ms();
+        params.async_copy_options.initial_poll_interval_ms = cache_config->migration_copy_poll_initial_interval_ms();
+        params.async_copy_options.max_poll_interval_ms = cache_config->migration_copy_poll_max_interval_ms();
         params.mark_timeout_ms = current_strategy->methods().mark().timeout_ms();
         params.dedup_marks = true;
         return DispatchMigrationBatchWithLifecycleLockHeld(job.trace_id,
@@ -2658,6 +4008,18 @@ MigrationManager::MigrateResult MigrationManager::MigrateCache(RequestContext *r
     params.do_mark = do_mark;
     params.copy_limit = CopyConcurrencyLimit{instance_group_name, copy_max_concurrency};
     params.mark_timeout_ms = mark_timeout_ms;
+    if (registry_manager_) {
+        if (const auto cache_config = registry_manager_->GetCacheConfig(instance_group_name); cache_config) {
+            params.copy_execution_mode = cache_config->migration_copy_execution_mode();
+            params.copy_max_inflight_bytes = cache_config->migration_copy_max_inflight_bytes();
+            params.copy_max_quarantine_operations = cache_config->migration_copy_max_quarantine_operations();
+            params.copy_max_quarantine_bytes = cache_config->migration_copy_max_quarantine_bytes();
+            params.async_copy_options.operation_deadline_ms = cache_config->migration_copy_operation_deadline_ms();
+            params.async_copy_options.initial_poll_interval_ms =
+                cache_config->migration_copy_poll_initial_interval_ms();
+            params.async_copy_options.max_poll_interval_ms = cache_config->migration_copy_poll_max_interval_ms();
+        }
+    }
     const auto dispatch =
         DispatchMigrationBatch(trace_id, instance_id, src_name, dst_name, candidate_keys, loc_maps, params);
 
@@ -2747,6 +4109,11 @@ MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatchWi
             req.src_storage_name = src_name;
             req.dst_storage_name = dst_name;
             req.retention = params.retention;
+            req.copy_execution_mode = params.copy_execution_mode;
+            req.copy_max_inflight_bytes = params.copy_max_inflight_bytes;
+            req.copy_max_quarantine_operations = params.copy_max_quarantine_operations;
+            req.copy_max_quarantine_bytes = params.copy_max_quarantine_bytes;
+            req.async_copy_options = params.async_copy_options;
             req.src_specs = admission.src_location->location_specs();
             req.src_create_time = admission.src_location->create_time();
             copy_block_keys.push_back(block_key);
@@ -2791,6 +4158,7 @@ MigrationManager::MigrationStats MigrationManager::GetStats() const {
     stats.source_retries_suppressed = stat_source_retries_suppressed_.load(std::memory_order_relaxed);
     stats.source_switches = stat_source_switches_.load(std::memory_order_relaxed);
     stats.no_usable_source = stat_no_usable_source_.load(std::memory_order_relaxed);
+    stats.async_copy_unknown = stat_async_copy_unknown_.load(std::memory_order_relaxed);
     stats.marks_added = stat_marks_added_.load(std::memory_order_relaxed);
     stats.marks_cleared = stat_marks_cleared_.load(std::memory_order_relaxed);
     {
@@ -2800,6 +4168,15 @@ MigrationManager::MigrationStats MigrationManager::GetStats() const {
     {
         std::lock_guard<std::mutex> lock(copy_source_failure_mutex_);
         stats.source_failure_entries = copy_source_failures_.size();
+    }
+    {
+        std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+        for (const auto &[_, usage] : async_copy_usage_by_group_) {
+            stats.async_copy_inflight_operations += usage.inflight_operations;
+            stats.async_copy_inflight_bytes += usage.inflight_bytes;
+            stats.async_copy_quarantine_operations += usage.quarantine_operations;
+            stats.async_copy_quarantine_bytes += usage.quarantine_bytes;
+        }
     }
     // 持久化方案下无内存表，active_marks 为 best-effort 近似（added - cleared）。
     const uint64_t added = stats.marks_added;

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -40,6 +40,7 @@ constexpr auto kMonitorIdleSleep = std::chrono::milliseconds(50);
 constexpr auto kFutureWaitTime = std::chrono::microseconds(200);
 constexpr auto kGuardSyncRetryInterval = std::chrono::milliseconds(100);
 constexpr auto kGuardSyncRetryIdleSleep = std::chrono::milliseconds(5);
+constexpr auto kLocationCleanupRetryInterval = std::chrono::seconds(1);
 constexpr int64_t kAsyncGuardRecoveryScanBatchSize = 256;
 constexpr auto kAsyncGuardRecoveryScanPause = std::chrono::milliseconds(2);
 constexpr auto kAsyncGuardRecoveryMaxDuration = std::chrono::minutes(5);
@@ -231,8 +232,7 @@ static MarkInfo ParseMarkFromProperties(const PropertyMap &props, int64_t now_ms
 
 // 收集目标 storage 上指定 status 的 location 联合覆盖的 spec name 集合。
 // 一次 O(L·S) 扫描替代旧的 per-location 全覆盖判断（O(L²·S²)）。
-std::unordered_set<std::string> CollectCoveredSpecNames(
-    const CacheLocationMap &loc_map,
+std::unordered_set<std::string> CollectCoveredSpecNames(const CacheLocationMap &loc_map,
     const std::string &storage_name,
     std::initializer_list<CacheLocationStatus> statuses) {
     std::unordered_set<std::string> covered;
@@ -357,8 +357,8 @@ ErrorCode MigrationManager::CheckTargetStorageAdmission(const std::string &trace
     }
     std::string group_name = instance_group_name;
     if (group_name.empty() && registry_manager_ != nullptr) {
-        auto request_context = std::make_shared<RequestContext>(
-            trace_id.empty() ? "migration_target_admission" : trace_id);
+        auto request_context =
+            std::make_shared<RequestContext>(trace_id.empty() ? "migration_target_admission" : trace_id);
         const auto instance_info = registry_manager_->GetInstanceInfo(request_context.get(), instance_id);
         if (instance_info == nullptr) {
             return EC_INSTANCE_NOT_EXIST;
@@ -366,8 +366,8 @@ ErrorCode MigrationManager::CheckTargetStorageAdmission(const std::string &trace
         group_name = instance_info->instance_group_name();
     }
     if (data_storage_selector_ != nullptr && !group_name.empty()) {
-        auto request_context = std::make_shared<RequestContext>(
-            trace_id.empty() ? "migration_target_admission" : trace_id);
+        auto request_context =
+            std::make_shared<RequestContext>(trace_id.empty() ? "migration_target_admission" : trace_id);
         const auto admissions =
             data_storage_selector_->CheckExplicitWriteTargets(request_context.get(), group_name, {target_storage_name});
         if (admissions.size() != 1 || !admissions[0].Allowed()) {
@@ -409,9 +409,19 @@ bool MigrationManager::ReserveAsyncCopyCredit(const MigrationRequest &request, u
         return false;
     }
     auto &usage = async_copy_usage_by_group_[request.instance_group_name];
-    if (usage.quarantine_operations >= static_cast<uint64_t>(request.copy_max_quarantine_operations) ||
-        usage.quarantine_bytes >= request.copy_max_quarantine_bytes ||
-        total_bytes > request.copy_max_inflight_bytes ||
+    const uint64_t max_quarantine_operations = static_cast<uint64_t>(request.copy_max_quarantine_operations);
+    // Every inflight operation may have to fail closed into quarantine. Reserve
+    // that worst-case capacity at admission time; checking only the already
+    // quarantined usage lets a wave of concurrent failures exceed the advertised
+    // hard limits by the entire inflight set.
+    const bool quarantine_operation_exhausted =
+        usage.quarantine_operations >= max_quarantine_operations ||
+        usage.inflight_operations >= max_quarantine_operations - usage.quarantine_operations;
+    const bool quarantine_bytes_exhausted =
+        total_bytes > request.copy_max_quarantine_bytes ||
+        usage.quarantine_bytes > request.copy_max_quarantine_bytes - total_bytes ||
+        usage.inflight_bytes > request.copy_max_quarantine_bytes - total_bytes - usage.quarantine_bytes;
+    if (quarantine_operation_exhausted || quarantine_bytes_exhausted || total_bytes > request.copy_max_inflight_bytes ||
         usage.inflight_bytes > request.copy_max_inflight_bytes - total_bytes) {
         return false;
     }
@@ -461,6 +471,8 @@ void MigrationManager::MoveAsyncCopyCreditToQuarantine(const CopyTaskContext &ct
     guard.set_source_storage_name(ctx.src_storage_name);
     guard.set_target_storage_name(ctx.dst_storage_name);
     guard.set_migration_retention(static_cast<int32_t>(ctx.retention));
+    guard.set_mark_target(ctx.mark_target);
+    guard.set_mark_deadline_ms(ctx.mark_deadline_ms);
     guard.set_total_bytes(ctx.total_bytes);
     guard.set_backend_task_ids(ctx.async_backend_task_ids);
     guard.set_create_time_us(ctx.async_guard_create_time_us > 0 ? ctx.async_guard_create_time_us : now_us);
@@ -556,17 +568,35 @@ ErrorCode MigrationManager::BreakGlassReleaseAsyncCopy(const std::string &operat
     std::vector<std::vector<ErrorCode>> results;
     const auto ec = meta_searcher.BatchCASLocationStatus(
         request_context.get(), {record.block_key}, {{std::move(task)}}, results, true);
-    if (ec != EC_OK) {
-        return ec;
-    }
-    if (results.size() != 1 || results[0].size() != 1) {
-        return EC_MISMATCH;
-    }
-    if (results[0][0] != EC_OK) {
+    const auto transition_is_persistent = [&]() {
+        CacheLocationMapVector location_maps;
+        const auto get_result =
+            indexer->GetLocationsFromPersistent(request_context.get(), {record.block_key}, location_maps);
+        if (get_result.error_codes.size() != 1 || get_result.error_codes[0] != EC_OK || location_maps.size() != 1) {
+            return false;
+        }
+        const auto location_iter = location_maps[0].find(record.target_location_id);
+        return location_iter != location_maps[0].end() && location_iter->second &&
+               location_iter->second->status() == CLS_DELETING && !location_iter->second->has_migration_copy_guard();
+    };
+    const bool cas_applied = ec == EC_OK && results.size() == 1 && results[0].size() == 1 && results[0][0] == EC_OK;
+    if (cas_applied) {
+        // Sync timeout is an ambiguous durability result, not proof that the
+        // transition failed. Re-read the persistent backend before returning;
+        // otherwise a retry would CAS guarded WRITING after the first attempt
+        // had already durably produced guard-free DELETING and cleanup would
+        // be stranded forever.
+        if (!indexer->Sync({record.block_key}) && !transition_is_persistent()) {
+            return EC_ERROR;
+        }
+    } else if (!transition_is_persistent()) {
+        if (ec != EC_OK) {
+            return ec;
+        }
+        if (results.size() != 1 || results[0].size() != 1) {
+            return EC_MISMATCH;
+        }
         return results[0][0];
-    }
-    if (!indexer->Sync({record.block_key})) {
-        return EC_ERROR;
     }
 
     CopyTaskContext ctx;
@@ -574,6 +604,7 @@ ErrorCode MigrationManager::BreakGlassReleaseAsyncCopy(const std::string &operat
     ctx.instance_id = record.instance_id;
     ctx.block_key = record.block_key;
     ctx.dst_location_id = record.target_location_id;
+    ctx.dst_storage_name = record.guard.target_storage_name();
     SubmitPreparedTargetLocationDelete(ctx);
     {
         std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
@@ -586,8 +617,8 @@ ErrorCode MigrationManager::BreakGlassReleaseAsyncCopy(const std::string &operat
                 usage.quarantine_bytes = usage.quarantine_bytes >= iter->second.guard.total_bytes()
                                              ? usage.quarantine_bytes - iter->second.guard.total_bytes()
                                              : 0;
-                if (usage.inflight_operations == 0 && usage.inflight_bytes == 0 &&
-                    usage.quarantine_operations == 0 && usage.quarantine_bytes == 0) {
+                if (usage.inflight_operations == 0 && usage.inflight_bytes == 0 && usage.quarantine_operations == 0 &&
+                    usage.quarantine_bytes == 0) {
                     async_copy_usage_by_group_.erase(usage_iter);
                 }
             }
@@ -620,14 +651,47 @@ bool MigrationManager::HasAsyncCopyStorageReference(const std::string &storage_n
             }
         }
     }
-    std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
-    return std::any_of(async_copy_quarantine_by_operation_.begin(),
-                       async_copy_quarantine_by_operation_.end(),
-                       [&storage_name](const auto &entry) {
-                           const auto &guard = entry.second.guard;
-                           return guard.source_storage_name() == storage_name ||
-                                  guard.target_storage_name() == storage_name;
-                       });
+    {
+        std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+        if (std::any_of(async_copy_quarantine_by_operation_.begin(),
+                        async_copy_quarantine_by_operation_.end(),
+                        [&storage_name](const auto &entry) {
+                            const auto &guard = entry.second.guard;
+                            return guard.source_storage_name() == storage_name ||
+                                   guard.target_storage_name() == storage_name;
+                        })) {
+            return true;
+        }
+    }
+    std::lock_guard<std::mutex> cleanup_lock(pending_cleanup_mutex_);
+    return std::any_of(pending_location_cleanups_.begin(),
+                       pending_location_cleanups_.end(),
+                       [&storage_name](const auto &cleanup) { return cleanup.storage_name == storage_name; });
+}
+
+bool MigrationManager::HasAsyncCopyInstanceReference(const std::string &instance_id) const {
+    if (instance_id.empty()) {
+        return false;
+    }
+    {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        const auto iter = active_tasks_by_instance_.find(instance_id);
+        if (iter != active_tasks_by_instance_.end() && !iter->second.empty()) {
+            return true;
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+        if (std::any_of(async_copy_quarantine_by_operation_.begin(),
+                        async_copy_quarantine_by_operation_.end(),
+                        [&instance_id](const auto &entry) { return entry.second.instance_id == instance_id; })) {
+            return true;
+        }
+    }
+    std::lock_guard<std::mutex> cleanup_lock(pending_cleanup_mutex_);
+    return std::any_of(pending_location_cleanups_.begin(),
+                       pending_location_cleanups_.end(),
+                       [&instance_id](const auto &cleanup) { return cleanup.instance_id == instance_id; });
 }
 
 bool MigrationManager::RecoverAsyncCopyGuards() {
@@ -655,8 +719,7 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
         if (!group) {
             continue;
         }
-        auto [instances_ec, instances] =
-            registry_manager_->ListInstanceInfo(request_context.get(), group->name());
+        auto [instances_ec, instances] = registry_manager_->ListInstanceInfo(request_context.get(), group->name());
         if (instances_ec != EC_OK) {
             KVCM_LOG_ERROR("asynchronous Copy guard recovery failed to list instances for group %s, ec %d",
                            group->name().c_str(),
@@ -746,6 +809,8 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
                         ctx.async_credit_active = true;
                         ctx.async_transition_mutex = std::make_shared<std::mutex>();
                         ctx.total_bytes = guard.total_bytes();
+                        ctx.mark_target = guard.mark_target();
+                        ctx.mark_deadline_ms = guard.mark_deadline_ms();
                         ctx.submit_time = std::chrono::steady_clock::now();
                         const auto retention = static_cast<MigrationRetention>(guard.migration_retention());
                         ctx.retention = retention == MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE ||
@@ -768,13 +833,19 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
     // accounting tables.  A partial rebuild would either double-charge an
     // operation or lose its capacity fence.
     {
-        std::unordered_set<std::string> operation_ids;
-        operation_ids.reserve(candidates.size());
-        for (const auto &candidate : candidates) {
+        std::unordered_map<std::string, std::string> operation_identities;
+        operation_identities.reserve(candidates.size());
+        std::vector<RecoveryCandidate> deduplicated;
+        deduplicated.reserve(candidates.size());
+        for (auto &candidate : candidates) {
+            const std::string identity = candidate.ctx.instance_id + "\x1f" + std::to_string(candidate.ctx.block_key) +
+                                         "\x1f" + candidate.ctx.dst_location_id + "\x1f" +
+                                         candidate.guard.ToJsonString();
+            const auto [identity_iter, inserted] =
+                operation_identities.emplace(candidate.ctx.async_operation_id, identity);
             if (candidate.ctx.instance_group_name.empty() || candidate.ctx.instance_id.empty() ||
                 candidate.ctx.dst_location_id.empty() || candidate.ctx.total_bytes == 0 ||
-                candidate.ctx.async_operation_id.empty() ||
-                !operation_ids.insert(candidate.ctx.async_operation_id).second) {
+                candidate.ctx.async_operation_id.empty() || (!inserted && identity_iter->second != identity)) {
                 KVCM_LOG_ERROR("asynchronous Copy guard recovery found invalid candidate: group %s instance %s "
                                "block %lld target %s operation %s bytes %llu",
                                candidate.ctx.instance_group_name.c_str(),
@@ -785,7 +856,18 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
                                static_cast<unsigned long long>(candidate.ctx.total_bytes));
                 return false;
             }
+            if (!inserted) {
+                KVCM_LOG_DEBUG("deduplicate asynchronous Copy guard returned by maintenance scan: "
+                               "instance %s block %lld target %s operation %s",
+                               candidate.ctx.instance_id.c_str(),
+                               static_cast<long long>(candidate.ctx.block_key),
+                               candidate.ctx.dst_location_id.c_str(),
+                               candidate.ctx.async_operation_id.c_str());
+                continue;
+            }
+            deduplicated.push_back(std::move(candidate));
         }
+        candidates = std::move(deduplicated);
     }
     {
         std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
@@ -804,45 +886,52 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
             return false;
         }
         const bool recoverable =
-            (state == MigrationCopyGuardState::MCGS_ACTIVE ||
-             state == MigrationCopyGuardState::MCGS_CANCELLING) &&
+            (state == MigrationCopyGuardState::MCGS_ACTIVE || state == MigrationCopyGuardState::MCGS_CANCELLING) &&
             !ctx.async_operation_id.empty() && !ctx.src_storage_name.empty() && ctx.total_bytes > 0 &&
-            candidate.expected_items > 0 &&
-            ctx.async_backend_task_ids.size() == candidate.expected_items;
+            candidate.expected_items > 0 && ctx.async_backend_task_ids.size() == candidate.expected_items;
         if (!recoverable) {
             if (state != MigrationCopyGuardState::MCGS_UNKNOWN) {
-                UpdateAsyncCopyGuard(ctx,
-                                     state,
-                                     MigrationCopyGuardState::MCGS_UNKNOWN,
-                                     ctx.async_backend_task_ids,
-                                     "leader_recovery_cannot_resume_guard");
+                const auto update_result = UpdateAsyncCopyGuard(ctx,
+                                                                state,
+                                                                MigrationCopyGuardState::MCGS_UNKNOWN,
+                                                                ctx.async_backend_task_ids,
+                                                                "leader_recovery_cannot_resume_guard");
+                if (update_result != GuardMutationResult::kAppliedDurably) {
+                    KVCM_LOG_ERROR("asynchronous Copy recovery could not durably quarantine operation %s",
+                                   ctx.async_operation_id.c_str());
+                    return false;
+                }
             }
             MoveAsyncCopyCreditToQuarantine(ctx, "leader_recovery_cannot_resume_guard");
             ++quarantined;
             continue;
         }
-        ctx.state = state == MigrationCopyGuardState::MCGS_CANCELLING ? CopyTaskState::kCancelling
-                                                                      : CopyTaskState::kRunning;
+        ctx.state =
+            state == MigrationCopyGuardState::MCGS_CANCELLING ? CopyTaskState::kCancelling : CopyTaskState::kRunning;
         bool inserted = false;
         {
             std::lock_guard<std::mutex> lock(task_mutex_);
             inserted = InsertActiveTaskLocked(ctx);
         }
         if (!inserted) {
-            UpdateAsyncCopyGuard(ctx,
-                                 state,
-                                 MigrationCopyGuardState::MCGS_UNKNOWN,
-                                 ctx.async_backend_task_ids,
-                                 "leader_recovery_duplicate_block_operation");
+            const auto update_result = UpdateAsyncCopyGuard(ctx,
+                                                            state,
+                                                            MigrationCopyGuardState::MCGS_UNKNOWN,
+                                                            ctx.async_backend_task_ids,
+                                                            "leader_recovery_duplicate_block_operation");
+            if (update_result != GuardMutationResult::kAppliedDurably) {
+                KVCM_LOG_ERROR("asynchronous Copy recovery could not durably quarantine duplicate block "
+                               "operation %s",
+                               ctx.async_operation_id.c_str());
+                return false;
+            }
             MoveAsyncCopyCreditToQuarantine(ctx, "leader_recovery_duplicate_block_operation");
             ++quarantined;
             continue;
         }
-        const int64_t age_ms = candidate.guard.create_time_us() > 0
-                                   ? std::max<int64_t>(0,
-                                                       (TimestampUtil::GetCurrentTimeUs() -
-                                                        candidate.guard.create_time_us()) /
-                                                           1000)
+        const int64_t age_ms =
+            candidate.guard.create_time_us() > 0
+                ? std::max<int64_t>(0, (TimestampUtil::GetCurrentTimeUs() - candidate.guard.create_time_us()) / 1000)
                                    : 0;
         const int64_t minimum_deadline = candidate.options.max_poll_interval_ms + 1;
         candidate.options.operation_deadline_ms =
@@ -853,10 +942,14 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
                                                                ctx.async_operation_id,
                                                                candidate.options);
         if (!submit.submit_result.accepted || !submit.future.valid()) {
-            CompleteCopyTaskAsUnknown(ctx,
+            if (!CompleteCopyTaskAsUnknown(ctx,
                                       submit.submit_result.detail.empty()
                                           ? "leader_recovery_backend_rejected_resume"
-                                          : submit.submit_result.detail);
+                                               : submit.submit_result.detail)) {
+                KVCM_LOG_ERROR("asynchronous Copy recovery could not durably publish UNKNOWN operation %s",
+                               ctx.async_operation_id.c_str());
+                return false;
+            }
             ++quarantined;
             continue;
         }
@@ -866,7 +959,7 @@ bool MigrationManager::RecoverAsyncCopyGuards() {
         {
             std::lock_guard<std::mutex> lock(pending_mutex_);
             pending_copies_.push_back(
-                PendingCopy{ctx.instance_id, ctx.block_key, std::move(submit.future), true});
+                PendingCopy{ctx.instance_id, ctx.block_key, candidate.expected_items, std::move(submit.future), true});
         }
         ++resumed;
     }
@@ -891,19 +984,33 @@ ErrorCode MigrationManager::Start() {
     }
     async_prepare_generation_.fetch_add(1, std::memory_order_acq_rel);
     accepting_copy_submissions_.store(false, std::memory_order_release);
-    monitor_thread_ = std::thread([this]() { MonitorLoop(); });
     if (!RecoverAsyncCopyGuards()) {
         // Guard-aware Reclaimer/GC fencing remains safe, but opening migration
         // admission before the source-of-truth scan succeeds could create more
         // operations without a complete quarantine budget.
         KVCM_LOG_ERROR("MigrationManager guard recovery failed; new Copy submissions remain disabled");
         running_.store(false, std::memory_order_release);
-        pending_cv_.notify_all();
-        if (monitor_thread_.joinable()) {
-            monitor_thread_.join();
+        {
+            std::lock_guard<std::mutex> lock(pending_mutex_);
+            pending_copies_.clear();
+        }
+        {
+            std::lock_guard<std::mutex> lock(task_mutex_);
+            active_tasks_by_instance_.clear();
+            UpdateActiveTasksGauge();
+        }
+        {
+            std::lock_guard<std::mutex> lock(async_copy_usage_mutex_);
+            async_copy_usage_by_group_.clear();
+            async_copy_quarantine_by_operation_.clear();
+            async_copy_inflight_operation_ids_.clear();
         }
         return EC_ERROR;
     }
+    // Recovery first installs every in-memory reservation and pending future.
+    // Starting the monitor earlier would let a fast completion remove the first
+    // reservation before a duplicate durable guard for the same block is seen.
+    monitor_thread_ = std::thread([this]() { MonitorLoop(); });
     accepting_copy_submissions_.store(true, std::memory_order_release);
     KVCM_LOG_INFO("MigrationManager started");
     return EC_OK;
@@ -932,11 +1039,72 @@ void MigrationManager::Stop() {
     // Monitor 已停止，丢弃旧 Leader 的 future。这些 future 只是进程内 completion
     // channel；持久 guard + backend task ids 才是切主后的恢复权威。若不清空，同一
     // Manager 重新 Start 后会同时处理 stale future 和恢复出来的新 future。
-    size_t dropped_pending = 0;
+    std::deque<PendingCopy> dropped_pending_copies;
     {
         std::lock_guard<std::mutex> lock(pending_mutex_);
-        dropped_pending = pending_copies_.size();
-        pending_copies_.clear();
+        dropped_pending_copies.swap(pending_copies_);
+    }
+    const size_t dropped_pending = dropped_pending_copies.size();
+    size_t harvested_remote_submits = 0;
+    size_t finalized_remote_rejections = 0;
+    for (auto &cell : dropped_pending_copies) {
+        if (!cell.native_async || cell.remote_submit_processed || !cell.remote_submit_future.valid() ||
+            cell.remote_submit_future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+            continue;
+        }
+        try {
+            auto remote_result = cell.remote_submit_future.get();
+            if (!remote_result.accepted) {
+                if (!remote_result.acceptance_unknown) {
+                    const bool completed = OnTaskFailedInternal(
+                        cell.instance_id,
+                        cell.block_key,
+                        remote_result.status,
+                        remote_result.detail.empty() ? "copy_submit_rejected_during_stop" : remote_result.detail,
+                        false,
+                        false);
+                    if (completed) {
+                        ++finalized_remote_rejections;
+                    } else {
+                        KVCM_LOG_WARN("MigrationManager stop retained a definitively rejected submit while its guard "
+                                      "finalization awaits durable confirmation: instance %s block_key %lld",
+                                      cell.instance_id.c_str(),
+                                      static_cast<long long>(cell.block_key));
+                    }
+                }
+                continue;
+            }
+            CopyTaskContext accepted_ctx;
+            bool cancel_requested = false;
+            if (!PersistRemoteAsyncCopyAcceptance(cell.instance_id,
+                                                  cell.block_key,
+                                                  cell.expected_items,
+                                                  remote_result,
+                                                  accepted_ctx,
+                                                  cancel_requested)) {
+                if (!accepted_ctx.src_storage_name.empty() && schedule_plan_executor_) {
+                    schedule_plan_executor_->RequestCancelAsyncCopy(accepted_ctx.src_storage_name,
+                                                                    remote_result.operation_id);
+                }
+                KVCM_LOG_ERROR("MigrationManager stop could not persist ready remote-submit handles: "
+                               "instance %s block_key %lld operation %s handles %zu expected %zu",
+                               cell.instance_id.c_str(),
+                               static_cast<long long>(cell.block_key),
+                               remote_result.operation_id.c_str(),
+                               remote_result.backend_task_ids.size(),
+                               cell.expected_items);
+                continue;
+            }
+            ++harvested_remote_submits;
+            if (cancel_requested && schedule_plan_executor_) {
+                schedule_plan_executor_->RequestCancelAsyncCopy(accepted_ctx.src_storage_name,
+                                                                accepted_ctx.async_operation_id);
+            }
+        } catch (const std::exception &e) {
+            KVCM_LOG_ERROR("MigrationManager stop failed to harvest remote-submit future: %s", e.what());
+        } catch (...) {
+            KVCM_LOG_ERROR("MigrationManager stop failed to harvest remote-submit future with unknown exception");
+        }
     }
 
     // 退出时丢弃进程内活跃任务表。同步任务沿用孤儿 WRITING 清理；原生异步任务若已
@@ -963,12 +1131,11 @@ void MigrationManager::Stop() {
         if (ctx.copy_execution_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
             continue;
         }
-        if (ctx.async_guard_finalization_pending_sync) {
+        if (ctx.async_guard_pending_action != CopyCompletionAction::kNone) {
             // A successful durability retry must also execute the already
             // claimed terminal action (source retention, target cleanup and
-            // credit release).  Merely calling Sync here would strand those
-            // side effects forever because the durable guard has already been
-            // cleared and the next leader has nothing left to recover.
+            // credit release/quarantine publication).  Merely dropping the
+            // in-memory action here would strand those side effects forever.
             if (!ResumePendingGuardFinalization(ctx)) {
                 // The final CAS may already have promoted/deleted the target and
                 // cleared its guard.  Rewriting UNKNOWN here could regress that
@@ -993,8 +1160,7 @@ void MigrationManager::Stop() {
 
         const auto expected_guard_state = ExpectedGuardState(ctx);
         const bool recoverable_after_detach =
-            !ctx.async_backend_task_ids.empty() &&
-            (expected_guard_state == MigrationCopyGuardState::MCGS_ACTIVE ||
+            !ctx.async_backend_task_ids.empty() && (expected_guard_state == MigrationCopyGuardState::MCGS_ACTIVE ||
              expected_guard_state == MigrationCopyGuardState::MCGS_CANCELLING);
         if (recoverable_after_detach) {
             // Do not cancel the PACE task and do not mutate the durable guard.
@@ -1010,20 +1176,36 @@ void MigrationManager::Stop() {
                           static_cast<int>(expected_guard_state));
             continue;
         }
-        UpdateAsyncCopyGuard(ctx,
+        const auto guard_result = UpdateAsyncCopyGuard(ctx,
                              expected_guard_state,
                              MigrationCopyGuardState::MCGS_UNKNOWN,
                              ctx.async_backend_task_ids,
                              "manager_stopped_before_authoritative_completion");
+        if (guard_result == GuardMutationResult::kAppliedDurably || HasDurableUnknownGuard(ctx)) {
         MoveAsyncCopyCreditToQuarantine(ctx, "manager_stopped_before_authoritative_completion");
         stat_async_copy_unknown_.fetch_add(1, std::memory_order_relaxed);
         ++quarantined;
+        } else {
+            // Runtime quarantine is only a projection of durable UNKNOWN.  A
+            // new leader will rescan the still-fenced guard and retry the
+            // transition; publishing a process-local record here would make
+            // break-glass unable to match persistent meta.
+            KVCM_LOG_ERROR("MigrationManager stop could not durably persist UNKNOWN guard: instance %s "
+                           "block_key %lld operation_id %s mutation_result %d",
+                           ctx.instance_id.c_str(),
+                           static_cast<long long>(ctx.block_key),
+                           ctx.async_operation_id.c_str(),
+                           static_cast<int>(guard_result));
+        }
     }
     if (dropped > 0) {
         KVCM_LOG_WARN("MigrationManager stopped with %zu active copy task(s) and %zu pending future(s) dropped; "
-                      "asynchronous detached %zu quarantined %zu",
+                      "remote submits harvested %zu definite rejections finalized %zu asynchronous detached %zu "
+                      "quarantined %zu",
                       dropped,
                       dropped_pending,
+                      harvested_remote_submits,
+                      finalized_remote_rejections,
                       detached,
                       quarantined);
     } else {
@@ -1061,17 +1243,14 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
         src_create_time = request.src_create_time;
     } else {
         MetaSearcher meta_searcher_for_src(indexer);
-        auto ctx_for_src =
-            std::make_shared<RequestContext>(trace_id.empty() ? "migration_prepare" : trace_id);
+        auto ctx_for_src = std::make_shared<RequestContext>(trace_id.empty() ? "migration_prepare" : trace_id);
         std::vector<CacheLocationMap> location_maps;
         BlockMask empty_mask;
         ErrorCode ec =
             meta_searcher_for_src.BatchGetLocation(ctx_for_src.get(), {request.block_key}, empty_mask, location_maps);
         if (ec != EC_OK || location_maps.empty()) {
-            KVCM_LOG_WARN("[%s] BatchGetLocation failed for block_key %ld, ec %d",
-                          trace_id.c_str(),
-                          request.block_key,
-                          ec);
+            KVCM_LOG_WARN(
+                "[%s] BatchGetLocation failed for block_key %ld, ec %d", trace_id.c_str(), request.block_key, ec);
             return EC_NOENT;
         }
         auto src_iter = location_maps[0].find(request.src_location_id);
@@ -1094,9 +1273,7 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
             return EC_MISMATCH;
         }
         if (src_location.location_specs().empty()) {
-            KVCM_LOG_WARN("[%s] source location %s has no specs",
-                          trace_id.c_str(),
-                          request.src_location_id.c_str());
+            KVCM_LOG_WARN("[%s] source location %s has no specs", trace_id.c_str(), request.src_location_id.c_str());
             return EC_ERROR;
         }
         request.src_specs = src_location.location_specs();
@@ -1358,7 +1535,7 @@ ErrorCode MigrationManager::Submit(const std::string &trace_id, MigrationRequest
 
     {
         std::lock_guard<std::mutex> lock(pending_mutex_);
-        pending_copies_.push_back(PendingCopy{ctx.instance_id, ctx.block_key, std::move(future)});
+        pending_copies_.push_back(PendingCopy{ctx.instance_id, ctx.block_key, 0, std::move(future)});
     }
     pending_cv_.notify_one();
 
@@ -1455,8 +1632,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
     }
 
     const auto batch_mode = first_req.copy_execution_mode;
-    if (batch_mode != MigrationCopyExecutionMode::SYNC &&
-        batch_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+    if (batch_mode != MigrationCopyExecutionMode::SYNC && batch_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
         for (auto &item : items) {
             item.MarkFailed(EC_BADARGS);
         }
@@ -1476,8 +1652,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             continue;
         }
         item.total_bytes = *total_bytes;
-        if (batch_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED &&
-            item.request.async_operation_id.empty()) {
+        if (batch_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED && item.request.async_operation_id.empty()) {
             item.request.async_operation_id = StringUtil::GenerateRandomString(32);
         }
     }
@@ -1508,8 +1683,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             if (!item.eligible || !checked_source_storages.insert(item.request.src_storage_name).second) {
                 continue;
             }
-            if (!data_storage_manager_ ||
-                !data_storage_manager_->SupportsAsyncCopy(item.request.src_storage_name)) {
+            if (!data_storage_manager_ || !data_storage_manager_->SupportsAsyncCopy(item.request.src_storage_name)) {
                 KVCM_LOG_WARN(
                     "[%s] reject ASYNC_REQUIRED migration: source storage %s has no native async Copy capability",
                     trace_id.c_str(),
@@ -1621,8 +1795,8 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
         release_all_preparing();
         return collect_results();
     }
-    auto dst_backend = data_storage_manager_ ? data_storage_manager_->GetDataStorageBackend(first_req.dst_storage_name)
-                                             : nullptr;
+    auto dst_backend =
+        data_storage_manager_ ? data_storage_manager_->GetDataStorageBackend(first_req.dst_storage_name) : nullptr;
     if (!dst_backend) {
         release_all_preparing();
         return collect_results();
@@ -1656,8 +1830,8 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
                 break;
             }
             const std::uint64_t spec_size = *spec_size_result;
-            std::string dst_key = req.instance_id + "/" + req.src_specs[s].name() + "/" +
-                                  StringUtil::Uint64ToHex(req.block_key);
+            std::string dst_key =
+                req.instance_id + "/" + req.src_specs[s].name() + "/" + StringUtil::Uint64ToHex(req.block_key);
             create_groups[spec_size].push_back({i, s, std::move(dst_key), std::move(src_uri)});
         }
     }
@@ -1713,8 +1887,8 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             if (create_results[j].first == EC_OK) {
                 item.src_uris.push_back(e.src_uri);
                 item.dst_uris.push_back(create_results[j].second);
-                item.dst_specs.emplace_back(
-                    item.request.src_specs[e.spec_idx].name(), create_results[j].second.ToUriString());
+                item.dst_specs.emplace_back(item.request.src_specs[e.spec_idx].name(),
+                                            create_results[j].second.ToUriString());
             } else {
                 item.MarkFailed(EC_ERROR);
             }
@@ -1771,8 +1945,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
     if (!add_block_keys.empty()) {
         MetaSearcher meta_searcher(indexer);
         std::vector<MetaSearcher::AddLocationResult> add_results;
-        ErrorCode add_ec =
-            meta_searcher.BatchAddLocation(batch_ctx.get(), add_block_keys, add_locations, add_results);
+        ErrorCode add_ec = meta_searcher.BatchAddLocation(batch_ctx.get(), add_block_keys, add_locations, add_results);
         if (add_results.size() != add_items.size()) {
             KVCM_LOG_WARN("[%s] BatchAddLocation returned unexpected result count for migration batch: expected %zu, "
                           "got %zu, aggregate ec %d; retaining allocated URIs",
@@ -1903,6 +2076,17 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
                     item->MarkFailed(EC_ERROR);
                     continue;
                 }
+                // The source snapshot predates destination allocation and
+                // guard persistence. Re-read both the hot view and persistent
+                // meta after the pin exists; once this succeeds, all later
+                // deletion admission observes the durable source pin.
+                if (!IsSourceLocationServing(ctx)) {
+                    item->reservation_active = false;
+                    item->async_credit_active = false;
+                    CompleteCopyTaskAsFailed(ctx, "source_changed_after_guard_install", false);
+                    item->MarkFailed(EC_MISMATCH);
+                    continue;
+                }
             }
 
             bool task_running = false;
@@ -1939,8 +2123,8 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
             std::future<AsyncCopyRemoteSubmitResult> remote_submit_future;
             bool native_async = false;
             if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
-                auto async_submit = schedule_plan_executor_->SubmitAsyncCopy(
-                    copy_req, ctx.async_operation_id, req.async_copy_options);
+                auto async_submit =
+                    schedule_plan_executor_->SubmitAsyncCopy(copy_req, ctx.async_operation_id, req.async_copy_options);
                 future = std::move(async_submit.future);
                 if (!async_submit.submit_result.accepted) {
                     if (async_submit.submit_result.acceptance_unknown) {
@@ -1986,7 +2170,8 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
 
             {
                 std::lock_guard<std::mutex> lock(pending_mutex_);
-                PendingCopy pending{ctx.instance_id, ctx.block_key, std::move(future), native_async};
+                PendingCopy pending{
+                    ctx.instance_id, ctx.block_key, copy_req.src_uris.size(), std::move(future), native_async};
                 if (native_async) {
                     pending.remote_submit_future = std::move(remote_submit_future);
                     pending.remote_submit_processed = false;
@@ -2023,20 +2208,35 @@ bool MigrationManager::IsSourceLocationServing(const CopyTaskContext &ctx) const
         return false;
     }
 
-    MetaSearcher meta_searcher(indexer);
+    const auto matches_snapshot = [&ctx](const std::vector<CacheLocationMap> &location_maps) {
+        if (location_maps.size() != 1) {
+            return false;
+        }
+        const auto iter = location_maps[0].find(ctx.src_location_id);
+        // id + status + create_time 三者同时匹配，防止 id 复用导致误判新 location 为原始源。
+        return iter != location_maps[0].end() && iter->second != nullptr && iter->second->status() == CLS_SERVING &&
+               iter->second->create_time() == ctx.src_create_time;
+    };
+
     auto rc = std::make_shared<RequestContext>("migration_check_source");
-    std::vector<CacheLocationMap> location_maps;
+    MetaSearcher meta_searcher(indexer);
+    std::vector<CacheLocationMap> hot_locations;
     BlockMask empty_mask;
-    ErrorCode ec = meta_searcher.BatchGetLocation(rc.get(), {ctx.block_key}, empty_mask, location_maps);
-    if (ec != EC_OK || location_maps.empty()) {
+    if (meta_searcher.BatchGetLocation(rc.get(), {ctx.block_key}, empty_mask, hot_locations) != EC_OK ||
+        !matches_snapshot(hot_locations)) {
         return false;
     }
-    auto iter = location_maps[0].find(ctx.src_location_id);
-    if (iter == location_maps[0].end() || iter->second == nullptr) {
-        return false;
+    if (ctx.copy_execution_mode != MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        return true;
     }
-    // id + status + create_time 三者同时匹配，防止 id 复用导致误判新 location 为原始源。
-    return iter->second->status() == CLS_SERVING && iter->second->create_time() == ctx.src_create_time;
+
+    // A delete CAS may already be visible in the hot layer but not yet durable,
+    // or persistent meta may have advanced while a stale cache entry remains.
+    // Requiring both views closes both halves of the pre-guard deletion race.
+    std::vector<CacheLocationMap> persistent_locations;
+    const auto persistent_result = indexer->GetLocationsFromPersistent(rc.get(), {ctx.block_key}, persistent_locations);
+    return persistent_result.error_codes.size() == 1 && persistent_result.error_codes[0] == EC_OK &&
+           matches_snapshot(persistent_locations);
 }
 
 MigrationManager::CopySourceFailureKey MigrationManager::MakeCopySourceFailureKey(const CopyTaskContext &ctx) {
@@ -2205,6 +2405,28 @@ void MigrationManager::MarkGuardFinalizationPendingSync(const CopyTaskContext &c
     task_iter->second.async_guard_pending_reason = reason;
 }
 
+void MigrationManager::MarkUnknownGuardPersistencePending(const CopyTaskContext &ctx,
+                                                          const std::string &reason,
+                                                          bool sync_only) {
+    std::lock_guard<std::mutex> lock(task_mutex_);
+    const auto instance_iter = active_tasks_by_instance_.find(ctx.instance_id);
+    if (instance_iter == active_tasks_by_instance_.end()) {
+        return;
+    }
+    const auto task_iter = instance_iter->second.find(ctx.block_key);
+    if (task_iter == instance_iter->second.end() || task_iter->second.async_operation_id != ctx.async_operation_id) {
+        return;
+    }
+    // Retain the active owner and its inflight credit until persistent meta
+    // itself authorizes publishing the runtime quarantine record.
+    task_iter->second.state = CopyTaskState::kCompleting;
+    task_iter->second.completion_was_cancelling =
+        ctx.completion_was_cancelling || ctx.state == CopyTaskState::kCancelling;
+    task_iter->second.async_guard_finalization_pending_sync = sync_only;
+    task_iter->second.async_guard_pending_action = CopyCompletionAction::kUnknown;
+    task_iter->second.async_guard_pending_reason = reason;
+}
+
 MigrationManager::GuardMutationResult
 MigrationManager::UpdateAsyncCopyGuard(const CopyTaskContext &ctx,
                                        MigrationCopyGuardState expected_state,
@@ -2229,6 +2451,8 @@ MigrationManager::UpdateAsyncCopyGuard(const CopyTaskContext &ctx,
     guard.set_source_storage_name(ctx.src_storage_name);
     guard.set_target_storage_name(ctx.dst_storage_name);
     guard.set_migration_retention(static_cast<int32_t>(ctx.retention));
+    guard.set_mark_target(ctx.mark_target);
+    guard.set_mark_deadline_ms(ctx.mark_deadline_ms);
     guard.set_total_bytes(ctx.total_bytes);
     guard.set_backend_task_ids(backend_task_ids);
     guard.set_create_time_us(ctx.async_guard_create_time_us > 0 ? ctx.async_guard_create_time_us : now_us);
@@ -2249,10 +2473,9 @@ MigrationManager::UpdateAsyncCopyGuard(const CopyTaskContext &ctx,
     }
     task.new_migration_copy_guard = std::make_shared<MigrationCopyGuard>(std::move(guard));
     std::vector<std::vector<ErrorCode>> results;
-    const auto ec = meta_searcher.BatchCASLocationStatus(
-        request_context.get(), {ctx.block_key}, {{std::move(task)}}, results);
-    const bool updated =
-        ec == EC_OK && results.size() == 1 && results[0].size() == 1 && results[0][0] == EC_OK;
+    const auto ec =
+        meta_searcher.BatchCASLocationStatus(request_context.get(), {ctx.block_key}, {{std::move(task)}}, results);
+    const bool updated = ec == EC_OK && results.size() == 1 && results[0].size() == 1 && results[0][0] == EC_OK;
     if (!updated) {
         return GuardMutationResult::kNotApplied;
     }
@@ -2286,10 +2509,9 @@ MigrationManager::GuardMutationResult MigrationManager::FinalizeAsyncCopyGuard(c
     task.expected_migration_copy_guard_state = expected_state;
     task.clear_migration_copy_guard = true;
     std::vector<std::vector<ErrorCode>> results;
-    const auto ec = meta_searcher.BatchCASLocationStatus(
-        request_context.get(), {ctx.block_key}, {{std::move(task)}}, results);
-    const bool updated =
-        ec == EC_OK && results.size() == 1 && results[0].size() == 1 && results[0][0] == EC_OK;
+    const auto ec =
+        meta_searcher.BatchCASLocationStatus(request_context.get(), {ctx.block_key}, {{std::move(task)}}, results);
+    const bool updated = ec == EC_OK && results.size() == 1 && results[0].size() == 1 && results[0][0] == EC_OK;
     if (!updated) {
         return GuardMutationResult::kNotApplied;
     }
@@ -2297,16 +2519,15 @@ MigrationManager::GuardMutationResult MigrationManager::FinalizeAsyncCopyGuard(c
                                           : GuardMutationResult::kAppliedDurabilityUnknown;
 }
 
-bool MigrationManager::PersistRemoteAsyncCopyAcceptance(
-    const std::string &instance_id,
+bool MigrationManager::PersistRemoteAsyncCopyAcceptance(const std::string &instance_id,
     int64_t block_key,
+    size_t expected_items,
     const AsyncCopyRemoteSubmitResult &remote_result,
     CopyTaskContext &out_ctx,
     bool &out_cancel_requested) {
     out_ctx = CopyTaskContext{};
     out_cancel_requested = false;
-    if (!remote_result.accepted || remote_result.operation_id.empty() ||
-        remote_result.backend_task_ids.empty()) {
+    if (!remote_result.accepted || remote_result.operation_id.empty()) {
         return false;
     }
 
@@ -2337,15 +2558,27 @@ bool MigrationManager::PersistRemoteAsyncCopyAcceptance(
         out_cancel_requested = task_iter->second.state == CopyTaskState::kCancelling;
     }
 
+    // Populate out_ctx before rejecting a malformed accepted response so the
+    // caller can still request cancellation through the correct backend.  Do
+    // not persist ACTIVE unless every copied item has exactly one recovery
+    // handle; a partial set cannot be resumed safely after leader change.
+    if (expected_items == 0 || remote_result.backend_task_ids.size() != expected_items) {
+        return false;
+    }
+
     const auto expected_state =
         out_cancel_requested ? MigrationCopyGuardState::MCGS_CANCELLING : MigrationCopyGuardState::MCGS_SUBMITTING;
-    const auto guard_state = out_cancel_requested ? MigrationCopyGuardState::MCGS_CANCELLING
-                                                   : MigrationCopyGuardState::MCGS_ACTIVE;
+    const auto guard_state =
+        out_cancel_requested ? MigrationCopyGuardState::MCGS_CANCELLING : MigrationCopyGuardState::MCGS_ACTIVE;
     const auto guard_result = UpdateAsyncCopyGuard(out_ctx,
                                                    expected_state,
                                                    guard_state,
                                                    out_ctx.async_backend_task_ids,
                                                    out_cancel_requested ? "cancel_requested" : "");
+
+    if (guard_result != GuardMutationResult::kAppliedDurably) {
+        return false;
+    }
 
     {
         std::lock_guard<std::mutex> task_lock(task_mutex_);
@@ -2363,7 +2596,7 @@ bool MigrationManager::PersistRemoteAsyncCopyAcceptance(
         task_iter->second.async_backend_task_ids = remote_result.backend_task_ids;
         out_ctx = task_iter->second;
     }
-    return guard_result == GuardMutationResult::kAppliedDurably;
+    return true;
 }
 
 void MigrationManager::SubmitPreparedTargetLocationDelete(const CopyTaskContext &ctx) {
@@ -2375,16 +2608,144 @@ void MigrationManager::SubmitPreparedTargetLocationDelete(const CopyTaskContext 
     del_req.block_keys = {ctx.block_key};
     del_req.location_ids = {{ctx.dst_location_id}};
     del_req.prepared_deleting = true;
-    schedule_plan_executor_->SubmitNonBlocking(del_req, ScheduleTaskClass::kMigrationContinuation);
+    TrackLocationCleanup(ctx.instance_id,
+                         ctx.dst_storage_name,
+                         del_req,
+                         schedule_plan_executor_->SubmitLocationDelete(del_req,
+                                                                       ScheduleTaskClass::kMigrationContinuation));
 }
 
-void MigrationManager::CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, const std::string &fail_reason) {
+void MigrationManager::TrackLocationCleanup(const std::string &instance_id,
+                                            const std::string &storage_name,
+                                            CacheLocationDelRequest request,
+                                            std::future<PlanExecuteResult> future) {
+    if (storage_name.empty() || !future.valid()) {
+        KVCM_LOG_ERROR("cannot track asynchronous Copy location cleanup: instance %s storage %s valid_future %d",
+                       instance_id.c_str(),
+                       storage_name.c_str(),
+                       static_cast<int>(future.valid()));
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(pending_cleanup_mutex_);
+        pending_location_cleanups_.push_back(
+            PendingLocationCleanup{instance_id, storage_name, std::move(request), std::move(future), {}, 0});
+    }
+    pending_cv_.notify_one();
+}
+
+void MigrationManager::ProcessCompletedLocationCleanups() {
+    const auto now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(pending_cleanup_mutex_);
+    for (auto iter = pending_location_cleanups_.begin(); iter != pending_location_cleanups_.end();) {
+        if (!iter->future.valid()) {
+            if (now < iter->retry_after) {
+                ++iter;
+                continue;
+            }
+            if (!schedule_plan_executor_) {
+                iter->retry_after = now + kLocationCleanupRetryInterval;
+                ++iter;
+                continue;
+            }
+            iter->request.authoritative_read = true;
+            iter->request.resume_deleting = true;
+            iter->future =
+                schedule_plan_executor_->SubmitLocationDelete(iter->request, ScheduleTaskClass::kMigrationContinuation);
+            ++iter->retry_count;
+            KVCM_LOG_WARN("retry asynchronous Copy location cleanup: instance %s storage %s retry %u",
+                          iter->instance_id.c_str(),
+                          iter->storage_name.c_str(),
+                          iter->retry_count);
+            ++iter;
+            continue;
+        }
+        if (iter->future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+            ++iter;
+            continue;
+        }
+
+        bool completed = false;
+        std::string failure_detail;
+        ErrorCode failure_ec = EC_ERROR;
+        try {
+            const auto result = iter->future.get();
+            completed = result.status == EC_OK;
+            failure_ec = result.status;
+            failure_detail = result.error_message;
+        } catch (const std::exception &e) {
+            failure_detail = e.what();
+        } catch (...) {
+            failure_detail = "unknown cleanup future exception";
+        }
+        if (completed) {
+            iter = pending_location_cleanups_.erase(iter);
+            continue;
+        }
+
+        // get() invalidates the future. Keep this record (and therefore the
+        // backend/instance reference) while a bounded-delay retry is pending.
+        iter->retry_after = now + kLocationCleanupRetryInterval;
+        KVCM_LOG_WARN("asynchronous Copy location cleanup retained for retry: instance %s storage %s ec %d "
+                      "detail %s retry %u",
+                      iter->instance_id.c_str(),
+                      iter->storage_name.c_str(),
+                      static_cast<int>(failure_ec),
+                      failure_detail.c_str(),
+                      iter->retry_count);
+        ++iter;
+    }
+}
+
+bool MigrationManager::HasDurableUnknownGuard(const CopyTaskContext &ctx) const {
+    auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
+    if (!indexer || ctx.dst_location_id.empty() || ctx.async_operation_id.empty()) {
+        return false;
+    }
+    auto request_context = std::make_shared<RequestContext>("migration_reconcile_unknown_guard");
+    std::vector<CacheLocationMap> locations;
+    const auto result = indexer->GetLocationsFromPersistent(request_context.get(), {ctx.block_key}, locations);
+    if (result.error_codes.size() != 1 || result.error_codes[0] != EC_OK || locations.size() != 1) {
+        return false;
+    }
+    const auto location_iter = locations[0].find(ctx.dst_location_id);
+    return location_iter != locations[0].end() && location_iter->second != nullptr &&
+           location_iter->second->has_migration_copy_guard() &&
+           location_iter->second->migration_copy_guard().operation_id() == ctx.async_operation_id &&
+           location_iter->second->migration_copy_guard().state() == MigrationCopyGuardState::MCGS_UNKNOWN;
+}
+
+bool MigrationManager::CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, const std::string &fail_reason) {
     if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
-        UpdateAsyncCopyGuard(ctx,
-                             ExpectedGuardState(ctx),
-                             MigrationCopyGuardState::MCGS_UNKNOWN,
-                             ctx.async_backend_task_ids,
-                             fail_reason);
+        GuardMutationResult guard_result = GuardMutationResult::kNotApplied;
+        if (ctx.async_guard_pending_action == CopyCompletionAction::kUnknown &&
+            ctx.async_guard_finalization_pending_sync) {
+            auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
+            guard_result = indexer && indexer->Sync({ctx.block_key}) ? GuardMutationResult::kAppliedDurably
+                                                                     : GuardMutationResult::kAppliedDurabilityUnknown;
+        } else {
+            guard_result = UpdateAsyncCopyGuard(ctx,
+                                                ExpectedGuardState(ctx),
+                                                MigrationCopyGuardState::MCGS_UNKNOWN,
+                                                ctx.async_backend_task_ids,
+                                                fail_reason);
+        }
+        if (guard_result != GuardMutationResult::kAppliedDurably && HasDurableUnknownGuard(ctx)) {
+            guard_result = GuardMutationResult::kAppliedDurably;
+        }
+        if (guard_result != GuardMutationResult::kAppliedDurably) {
+            MarkUnknownGuardPersistencePending(
+                ctx, fail_reason, guard_result == GuardMutationResult::kAppliedDurabilityUnknown);
+            KVCM_LOG_ERROR("migration asynchronous Copy retained until UNKNOWN guard is durable: instance %s "
+                           "block_key %lld dst_loc %s operation_id %s mutation_result %d reason %s",
+                           ctx.instance_id.c_str(),
+                           static_cast<long long>(ctx.block_key),
+                           ctx.dst_location_id.c_str(),
+                           ctx.async_operation_id.c_str(),
+                           static_cast<int>(guard_result),
+                           fail_reason.c_str());
+            return false;
+        }
         MoveAsyncCopyCreditToQuarantine(ctx, fail_reason);
     }
     {
@@ -2395,8 +2756,8 @@ void MigrationManager::CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, con
     if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
         stat_async_copy_unknown_.fetch_add(1, std::memory_order_relaxed);
     }
-    const int64_t duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::steady_clock::now() - ctx.submit_time)
+    const int64_t duration_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - ctx.submit_time)
                                     .count();
     if (metrics_enabled_) {
         ++m_tasks_completed_failed_;
@@ -2420,6 +2781,7 @@ void MigrationManager::CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, con
                    ctx.dst_location_id.c_str(),
                    ctx.async_operation_id.c_str(),
                    fail_reason.c_str());
+    return true;
 }
 
 bool MigrationManager::CompleteCopyTaskAsFailed(const CopyTaskContext &ctx,
@@ -2433,8 +2795,7 @@ bool MigrationManager::CompleteCopyTaskAsFailed(const CopyTaskContext &ctx,
         }
         if (finalize_result != GuardMutationResult::kAppliedDurably) {
             if (remote_side_effect_possible) {
-                CompleteCopyTaskAsUnknown(ctx, "guard_finalize_failed:" + fail_reason);
-                return true;
+                return CompleteCopyTaskAsUnknown(ctx, "guard_finalize_failed:" + fail_reason);
             }
             // The caller proves no backend handoff/POST occurred.  It is safe
             // to attempt ordinary target cleanup even if the SUBMITTING guard
@@ -2465,8 +2826,8 @@ bool MigrationManager::CompleteCopyTaskAsFailed(const CopyTaskContext &ctx,
     stat_copy_failed_.fetch_add(1, std::memory_order_relaxed);
     // 失败路径也填真实 duration（提交到失败的耗时），而非硬编码 0，
     // 便于区分"快速失败"与"跑很久才失败"。
-    const int64_t duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::steady_clock::now() - ctx.submit_time)
+    const int64_t duration_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - ctx.submit_time)
                                     .count();
     if (metrics_enabled_) {
         ++m_tasks_completed_failed_;
@@ -2500,8 +2861,7 @@ bool MigrationManager::CompleteCopyTaskAsSucceeded(const CopyTaskContext &ctx) {
             return false;
         }
         if (finalize_result == GuardMutationResult::kNotApplied) {
-            CompleteCopyTaskAsUnknown(ctx, "guard_finalize_failed:promote");
-            return true;
+            return CompleteCopyTaskAsUnknown(ctx, "guard_finalize_failed:promote");
         }
         promoted = true;
     } else if (auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
@@ -2541,8 +2901,8 @@ bool MigrationManager::CompleteCopyTaskAsSucceeded(const CopyTaskContext &ctx) {
         RemoveActiveTaskLocked(ctx.instance_id, ctx.block_key);
     }
     stat_copy_completed_.fetch_add(1, std::memory_order_relaxed);
-    const int64_t duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::steady_clock::now() - ctx.submit_time)
+    const int64_t duration_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - ctx.submit_time)
                                     .count();
     if (metrics_enabled_) {
         ++m_tasks_completed_success_;
@@ -2572,13 +2932,15 @@ bool MigrationManager::ResumePendingGuardFinalization(const CopyTaskContext &ctx
         return CompleteCopyTaskAsFailed(ctx, ctx.async_guard_pending_reason);
     case CopyCompletionAction::kCancelled:
         return CompleteCancelledTask(ctx);
+    case CopyCompletionAction::kUnknown:
+        return CompleteCopyTaskAsUnknown(
+            ctx, ctx.async_guard_pending_reason.empty() ? "copy_completion_unknown" : ctx.async_guard_pending_reason);
     case CopyCompletionAction::kNone:
         KVCM_LOG_ERROR("guard Sync retry is missing its completion action: instance %s block_key %lld operation %s",
                        ctx.instance_id.c_str(),
                        static_cast<long long>(ctx.block_key),
                        ctx.async_operation_id.c_str());
-        CompleteCopyTaskAsUnknown(ctx, "guard_sync_retry_missing_action");
-        return true;
+        return CompleteCopyTaskAsUnknown(ctx, "guard_sync_retry_missing_action");
     }
     return true;
 }
@@ -2603,7 +2965,7 @@ bool MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
                       block_key);
         return true;
     }
-    if (claim == ClaimResult::kRetryingGuardSync) {
+    if (claim == ClaimResult::kRetryingGuardTransition) {
         return ResumePendingGuardFinalization(ctx);
     }
     if (claim == ClaimResult::kWasCancelling) {
@@ -2656,7 +3018,7 @@ bool MigrationManager::OnTaskFailedInternal(const std::string &instance_id,
                       block_key);
         return true;
     }
-    if (claim == ClaimResult::kRetryingGuardSync) {
+    if (claim == ClaimResult::kRetryingGuardTransition) {
         return ResumePendingGuardFinalization(ctx);
     }
     if (claim == ClaimResult::kWasCancelling) {
@@ -2692,13 +3054,12 @@ bool MigrationManager::OnTaskUnknown(const std::string &instance_id, int64_t blo
                       static_cast<long long>(block_key));
         return true;
     }
-    if (claim == ClaimResult::kRetryingGuardSync) {
+    if (claim == ClaimResult::kRetryingGuardTransition) {
         return ResumePendingGuardFinalization(ctx);
     }
     // Unknown ownership supersedes a concurrent cancel request: without a
     // terminal+drained proof, cancellation must not authorize target reuse.
-    CompleteCopyTaskAsUnknown(ctx, reason.empty() ? "copy_completion_unknown" : reason);
-    return true;
+    return CompleteCopyTaskAsUnknown(ctx, reason.empty() ? "copy_completion_unknown" : reason);
 }
 
 void MigrationManager::SubmitTargetLocationDelete(const CopyTaskContext &ctx) {
@@ -2711,7 +3072,15 @@ void MigrationManager::SubmitTargetLocationDelete(const CopyTaskContext &ctx) {
     del_req.instance_id = ctx.instance_id;
     del_req.block_keys = {ctx.block_key};
     del_req.location_ids = {{ctx.dst_location_id}};
-    schedule_plan_executor_->SubmitNonBlocking(del_req, ScheduleTaskClass::kMigrationContinuation);
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        TrackLocationCleanup(
+            ctx.instance_id,
+                             ctx.dst_storage_name,
+            del_req,
+            schedule_plan_executor_->SubmitLocationDelete(del_req, ScheduleTaskClass::kMigrationContinuation));
+    } else {
+        schedule_plan_executor_->SubmitNonBlocking(del_req, ScheduleTaskClass::kMigrationContinuation);
+    }
 }
 
 void MigrationManager::SubmitSourceLocationDelete(const CopyTaskContext &ctx) {
@@ -2722,12 +3091,21 @@ void MigrationManager::SubmitSourceLocationDelete(const CopyTaskContext &ctx) {
     del_req.instance_id = ctx.instance_id;
     del_req.block_keys = {ctx.block_key};
     del_req.location_ids = {{ctx.src_location_id}};
-    schedule_plan_executor_->SubmitNonBlocking(del_req, ScheduleTaskClass::kMigrationContinuation);
+    if (ctx.copy_execution_mode == MigrationCopyExecutionMode::ASYNC_REQUIRED) {
+        TrackLocationCleanup(
+            ctx.instance_id,
+                             ctx.src_storage_name,
+            del_req,
+            schedule_plan_executor_->SubmitLocationDelete(del_req, ScheduleTaskClass::kMigrationContinuation));
+    } else {
+        schedule_plan_executor_->SubmitNonBlocking(del_req, ScheduleTaskClass::kMigrationContinuation);
+    }
 }
 
 void MigrationManager::MonitorLoop() {
     while (running_.load(std::memory_order_relaxed)) {
         ProcessExpiredMarks();
+        ProcessCompletedLocationCleanups();
 
         PendingCopy cell;
         bool has_cell = false;
@@ -2801,6 +3179,7 @@ void MigrationManager::MonitorLoop() {
             bool cancel_requested = false;
             if (!PersistRemoteAsyncCopyAcceptance(cell.instance_id,
                                                   cell.block_key,
+                                                  cell.expected_items,
                                                   remote_result,
                                                   accepted_ctx,
                                                   cancel_requested)) {
@@ -2845,9 +3224,9 @@ void MigrationManager::MonitorLoop() {
         }
     }
 
-    // 退出时排空剩余 future（不再驱动状态流转，仅释放）。
-    std::lock_guard<std::mutex> lock(pending_mutex_);
-    pending_copies_.clear();
+    // Stop() owns the final handoff of pending futures.  A ready remote-submit
+    // future may contain the only recoverable PACE task handles, so the monitor
+    // must not discard process-local channels on its way out.
 }
 
 std::shared_ptr<MetaIndexer> MigrationManager::GetIndexer(const std::string &instance_id) const {
@@ -2863,8 +3242,7 @@ ErrorCode MigrationManager::MarkForTieredWrite(const std::string &instance_id,
     }
     // 新 Mark 只写入当前可分配的 target；已存在 Mark 遇到 quota 满或 unavailable 时由消费
     // 路径暂时忽略并保留，待容量/可用性恢复后自愈。
-    const auto target_ec =
-        CheckTargetStorageAdmission("mark_for_tiered_write", "", instance_id, dst_storage_name);
+    const auto target_ec = CheckTargetStorageAdmission("mark_for_tiered_write", "", instance_id, dst_storage_name);
     if (target_ec != EC_OK) {
         KVCM_LOG_WARN("MarkForTieredWrite: target storage [%s] is not writable, skip marking (instance %s, ec %d)",
                       dst_storage_name.c_str(),
@@ -2891,7 +3269,8 @@ ErrorCode MigrationManager::MarkForTieredWrite(const std::string &instance_id,
     // modifier 在 RMW 批次内按 global_idx 回调，顺序对齐 block_keys。
     std::vector<bool> mark_succeeded(block_keys.size(), false);
     // RMW：只写 property（out_new_locations 留空，不动 location）。不存在的 block 跳过（不给空 block 打标）。
-    auto modifier = [&dst_storage_name, deadline_ms, &mark_succeeded](const LocationIdVector & /*existing*/,
+    auto modifier =
+        [&dst_storage_name, deadline_ms, &mark_succeeded](const LocationIdVector & /*existing*/,
                                                                      ErrorCode get_ec,
                                                                      size_t idx,
                                                                      PropertyMap &upsert_property_map,
@@ -2986,8 +3365,8 @@ bool MigrationManager::ClearTieredWriteMarkIfMatchInternal(const std::string &in
         }
         RequestContext check_rc("migration_match_clear_check");
         PropertyMapVector check_props;
-        const auto check_result = indexer->GetProperties(&check_rc, {block_key},
-            {PROPERTY_TIERED_WRITE_TARGET, PROPERTY_TIERED_WRITE_DEADLINE_MS}, check_props);
+        const auto check_result = indexer->GetProperties(
+            &check_rc, {block_key}, {PROPERTY_TIERED_WRITE_TARGET, PROPERTY_TIERED_WRITE_DEADLINE_MS}, check_props);
         if (check_result.ec != EC_OK || check_result.error_codes.size() != 1 || check_result.error_codes[0] != EC_OK ||
             check_props.size() != 1) {
             return {MA_SKIP, EC_OK};
@@ -3180,8 +3559,7 @@ bool MigrationManager::CompleteCancelledTask(const CopyTaskContext &ctx) {
             return false;
         }
         if (finalize_result == GuardMutationResult::kNotApplied) {
-            CompleteCopyTaskAsUnknown(ctx, "cancel_guard_finalize_failed");
-            return true;
+            return CompleteCopyTaskAsUnknown(ctx, "cancel_guard_finalize_failed");
         }
         SubmitPreparedTargetLocationDelete(ctx);
         ReleaseAsyncCopyCredit(ctx);
@@ -3195,8 +3573,8 @@ bool MigrationManager::CompleteCancelledTask(const CopyTaskContext &ctx) {
     stat_copy_cancelled_.fetch_add(1, std::memory_order_relaxed);
     // cancelled 是与 success/failed 对称的终态：在实际清理时计数，保持 submitted==success+failed+cancelled。
     // 被取消任务无论底层 copy 成/败一律记 cancelled（用户意图优先）。
-    const int64_t duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::steady_clock::now() - ctx.submit_time)
+    const int64_t duration_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - ctx.submit_time)
                                     .count();
     if (metrics_enabled_) {
         ++m_tasks_completed_cancelled_;
@@ -3265,8 +3643,8 @@ ErrorCode MigrationManager::Cancel(const std::string &instance_id, int64_t block
         guard_transition_lock.unlock();
     }
     if (persist_async_cancelling && schedule_plan_executor_) {
-        const auto cancel_ec = schedule_plan_executor_->RequestCancelAsyncCopy(
-            cancelling_ctx.src_storage_name, cancelling_ctx.async_operation_id);
+        const auto cancel_ec = schedule_plan_executor_->RequestCancelAsyncCopy(cancelling_ctx.src_storage_name,
+                                                                               cancelling_ctx.async_operation_id);
         if (cancel_ec != EC_OK) {
             // The persistent state is already CANCELLING.  A failed immediate
             // signal is not a drain proof; the coordinator keeps polling and
@@ -3288,9 +3666,8 @@ ErrorCode MigrationManager::Cancel(const std::string &instance_id, int64_t block
                       block_key);
         return EC_OK;
     case CancelResult::kBusyCompleting:
-        KVCM_LOG_INFO("[cancel] instance %s block_key %ld already completing, cancel too late",
-                      instance_id.c_str(),
-                      block_key);
+        KVCM_LOG_INFO(
+            "[cancel] instance %s block_key %ld already completing, cancel too late", instance_id.c_str(), block_key);
         return EC_EXIST; // 完成中，取消太晚；迁移将照常完成
     case CancelResult::kMarked:
         KVCM_LOG_INFO("[cancel] instance %s block_key %ld marked cancelling; cleanup deferred to copy completion",
@@ -3440,9 +3817,9 @@ MigrationManager::ClaimResult MigrationManager::ClaimForCompletionLocked(const s
         return ClaimResult::kWasCancelling;
     }
     if (task.state == CopyTaskState::kCompleting) {
-        if (task.async_guard_finalization_pending_sync) {
+        if (task.async_guard_pending_action != CopyCompletionAction::kNone) {
             out_ctx = task;
-            return ClaimResult::kRetryingGuardSync;
+            return ClaimResult::kRetryingGuardTransition;
         }
         return ClaimResult::kBusyCompleting; // 防御：完成路径仅单一 monitor 线程，正常不会重入
     }
@@ -3636,6 +4013,7 @@ MigrationManager::CopyAdmission MigrationManager::CheckCopyAdmission(const std::
     bool all_sources_covered_by_serving = true;
     std::size_t uncovered_source_count = 0;
     std::size_t suppressed_source_count = 0;
+    std::size_t pinned_source_count = 0;
     std::vector<EligibleSource> eligible_sources;
     for (const auto *src_loc : src_locations) {
         if (specs_covered_by(*src_loc, serving_covered)) {
@@ -3647,6 +4025,17 @@ MigrationManager::CopyAdmission MigrationManager::CheckCopyAdmission(const std::
         }
         // 该 source 既未被 SERVING 也未被 SERVING∪WRITING 联合覆盖 → 需要 copy。
         ++uncovered_source_count;
+        // A durable guard pins the exact source identity until that operation
+        // reaches a proven terminal state or an operator releases quarantine.
+        // Starting another route from the same source could later succeed with
+        // DELETE_SOURCE while deletion is still fenced by the first guard,
+        // leaving retention work with no durable retry owner.  Defer the second
+        // migration instead; after the guard is cleared, ordinary sampling can
+        // select this source again and DELETE_SOURCE can complete normally.
+        if (FindPersistentMigrationSourcePin(*src_loc, loc_map) != nullptr) {
+            ++pinned_source_count;
+            continue;
+        }
         const auto failure = GetCopySourceFailure(instance_id, block_key, *src_loc, dst_storage_name, now);
         if (failure.suppressed) {
             ++suppressed_source_count;
@@ -3706,6 +4095,10 @@ MigrationManager::CopyAdmission MigrationManager::CheckCopyAdmission(const std::
         return {CopyAdmissionStatus::kSourceRetrySuppressed, nullptr};
     }
 
+    if (pinned_source_count > 0) {
+        return {CopyAdmissionStatus::kSourcePinnedByGuard, nullptr};
+    }
+
     // 循环走完未 return kAccept：每个 source 都被 serving∪writing 覆盖。
     if (all_sources_covered_by_serving) {
         return {CopyAdmissionStatus::kTargetServingExists, nullptr};
@@ -3744,9 +4137,7 @@ MigrationManager::SelectMigrationCandidateKeys(RequestContext *request_context,
 
 std::size_t MigrationManager::AsyncMigrationPrepareKeyHash::operator()(const AsyncMigrationPrepareKey &key) const {
     std::size_t seed = std::hash<std::uint64_t>{}(key.generation);
-    const auto combine = [&seed](std::size_t value) {
-        seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    };
+    const auto combine = [&seed](std::size_t value) { seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2); };
     combine(std::hash<std::string>{}(key.instance_group_name));
     combine(std::hash<std::string>{}(key.instance_id));
     combine(std::hash<std::string>{}(key.source_storage_name));
@@ -3759,11 +4150,9 @@ std::size_t MigrationManager::PendingAsyncMigrationPrepareCountForTest() const {
     return pending_async_prepare_jobs_.size();
 }
 
-std::size_t
-MigrationManager::PendingAsyncMigrationPrepareCountForGroup(const std::string &instance_group_name) const {
+std::size_t MigrationManager::PendingAsyncMigrationPrepareCountForGroup(const std::string &instance_group_name) const {
     std::lock_guard<std::mutex> lock(async_prepare_mutex_);
-    return static_cast<std::size_t>(
-        std::count_if(pending_async_prepare_jobs_.begin(),
+    return static_cast<std::size_t>(std::count_if(pending_async_prepare_jobs_.begin(),
                       pending_async_prepare_jobs_.end(),
                       [&instance_group_name](const AsyncMigrationPrepareKey &key) {
                           return key.instance_group_name == instance_group_name;
@@ -3784,11 +4173,8 @@ bool MigrationManager::SubmitAsyncMigrationPrepare(AsyncMigrationPrepareJob job)
     }
 
     const auto generation = async_prepare_generation_.load(std::memory_order_acquire);
-    AsyncMigrationPrepareKey key{generation,
-                                 job.instance_group_name,
-                                 job.instance_id,
-                                 job.source_storage_name,
-                                 job.target_storage_name};
+    AsyncMigrationPrepareKey key{
+        generation, job.instance_group_name, job.instance_id, job.source_storage_name, job.target_storage_name};
     {
         std::lock_guard<std::mutex> lock(async_prepare_mutex_);
         if (!accepting_copy_submissions_.load(std::memory_order_acquire) ||
@@ -4039,8 +4425,8 @@ MigrationManager::MigrateResult MigrationManager::MigrateCache(RequestContext *r
     return result;
 }
 
-MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatch(
-    const std::string &trace_id,
+MigrationManager::DispatchBatchResult
+MigrationManager::DispatchMigrationBatch(const std::string &trace_id,
     const std::string &instance_id,
     const std::string &src_name,
     const std::string &dst_name,
@@ -4064,8 +4450,8 @@ MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatch(
         trace_id, instance_id, src_name, dst_name, batch, loc_maps, params);
 }
 
-MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatchWithLifecycleLockHeld(
-    const std::string &trace_id,
+MigrationManager::DispatchBatchResult
+MigrationManager::DispatchMigrationBatchWithLifecycleLockHeld(const std::string &trace_id,
     const std::string &instance_id,
     const std::string &src_name,
     const std::string &dst_name,

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -226,11 +226,26 @@ std::vector<const CacheLocation *> FindLocationsOnStorage(const CacheLocationMap
     }
     return locations;
 }
+
+template <typename T>
+void HashCombine(std::size_t &seed, const T &value) {
+    seed ^= std::hash<T>{}(value) + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
+}
 } // namespace
 
 // Mark 持久化属性名（block 级 property）。带 inner 前缀避免与业务属性冲突。
 const std::string MigrationManager::PROPERTY_TIERED_WRITE_TARGET = "__mig_tier_target__";
 const std::string MigrationManager::PROPERTY_TIERED_WRITE_DEADLINE_MS = "__mig_tier_deadline_ms__";
+
+std::size_t MigrationManager::CopySourceFailureKeyHash::operator()(const CopySourceFailureKey &key) const {
+    std::size_t seed = 0;
+    HashCombine(seed, key.instance_id);
+    HashCombine(seed, key.block_key);
+    HashCombine(seed, key.location_id);
+    HashCombine(seed, key.location_create_time);
+    HashCombine(seed, key.target_storage_name);
+    return seed;
+}
 
 MigrationManager::MigrationManager(std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor,
                                    std::shared_ptr<MetaIndexerManager> meta_indexer_manager,
@@ -262,6 +277,11 @@ MigrationManager::MigrationManager(std::shared_ptr<SchedulePlanExecutor> schedul
         m_marks_consumed_total_ = metrics_registry_->GetCounter("migration.marks_consumed_total");
         m_marks_expired_total_ = metrics_registry_->GetCounter("migration.marks_expired_total");
         m_mark_query_errors_total_ = metrics_registry_->GetCounter("migration.mark_query_errors_total");
+        m_source_failures_recorded_total_ = metrics_registry_->GetCounter("migration.source_failures_recorded_total");
+        m_source_retries_suppressed_total_ = metrics_registry_->GetCounter("migration.source_retries_suppressed_total");
+        m_source_switches_total_ = metrics_registry_->GetCounter("migration.source_switches_total");
+        m_no_usable_source_total_ = metrics_registry_->GetCounter("migration.no_usable_source_total");
+        m_source_failure_entries_ = metrics_registry_->GetGauge("migration.source_failure_entries");
     }
 }
 
@@ -277,6 +297,12 @@ void MigrationManager::UpdateMarksActiveGauge() {
         const int64_t added = static_cast<int64_t>(stat_marks_added_.load(std::memory_order_relaxed));
         const int64_t cleared = static_cast<int64_t>(stat_marks_cleared_.load(std::memory_order_relaxed));
         m_marks_active_ = static_cast<double>(added > cleared ? added - cleared : 0);
+    }
+}
+
+void MigrationManager::UpdateCopySourceFailureGaugeLocked() {
+    if (metrics_enabled_) {
+        m_source_failure_entries_ = static_cast<double>(copy_source_failures_.size());
     }
 }
 
@@ -1188,6 +1214,134 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
     return collect_results();
 }
 
+MigrationManager::CopySourceFailureKey MigrationManager::MakeCopySourceFailureKey(const CopyTaskContext &ctx) {
+    return CopySourceFailureKey{
+        ctx.instance_id, ctx.block_key, ctx.src_location_id, ctx.src_create_time, ctx.dst_storage_name};
+}
+
+MigrationManager::CopySourceFailureKey
+MigrationManager::MakeCopySourceFailureKey(const std::string &instance_id,
+                                           int64_t block_key,
+                                           const CacheLocation &source,
+                                           const std::string &target_storage_name) {
+    return CopySourceFailureKey{instance_id, block_key, source.id(), source.create_time(), target_storage_name};
+}
+
+std::chrono::milliseconds MigrationManager::ComputeCopySourceBackoff(const CopySourceFailureKey &key,
+                                                                     uint32_t consecutive_failures) {
+    int64_t delay_ms = kCopySourceInitialBackoff.count();
+    uint32_t remaining_doublings = consecutive_failures > 0 ? consecutive_failures - 1 : 0;
+    while (remaining_doublings-- > 0 && delay_ms < kCopySourceMaxBackoff.count()) {
+        delay_ms = std::min(kCopySourceMaxBackoff.count(), delay_ms * 2);
+    }
+
+    // 0~25% 的稳定 jitter，避免大量 stale location 在同一个 retry deadline 上形成惊群。
+    // 使用 identity + failure count 的稳定 hash，便于故障复现，同时不引入共享随机数锁。
+    const int64_t jitter_window_ms = delay_ms / 4;
+    if (jitter_window_ms > 0 && delay_ms < kCopySourceMaxBackoff.count()) {
+        std::size_t jitter_seed = CopySourceFailureKeyHash{}(key);
+        HashCombine(jitter_seed, consecutive_failures);
+        const int64_t jitter_ms = static_cast<int64_t>(jitter_seed % static_cast<std::size_t>(jitter_window_ms + 1));
+        delay_ms = std::min(kCopySourceMaxBackoff.count(), delay_ms + jitter_ms);
+    }
+    return std::chrono::milliseconds(delay_ms);
+}
+
+void MigrationManager::PruneCopySourceFailuresLocked(std::chrono::steady_clock::time_point now) {
+    while (!copy_source_failure_history_.empty()) {
+        const auto &oldest = copy_source_failure_history_.front();
+        const bool expired = now - oldest.failure_time >= kCopySourceFailureRetention;
+        const bool over_capacity = copy_source_failures_.size() > kMaxCopySourceFailureEntries;
+        if (!expired && !over_capacity) {
+            break;
+        }
+
+        auto iter = copy_source_failures_.find(oldest.key);
+        if (iter != copy_source_failures_.end() && iter->second.last_failure_time == oldest.failure_time) {
+            copy_source_failures_.erase(iter);
+        }
+        copy_source_failure_history_.pop_front();
+    }
+
+    // 同一 source 的每次失败都会留下一个过期队列节点。正常 backoff 下增长很慢，但测试直调或
+    // 异常回调风暴仍可能制造大量 stale 节点；超过硬上限时按 map 当前快照重建一次队列。
+    if (copy_source_failure_history_.size() > kMaxCopySourceFailureHistoryEntries) {
+        std::vector<CopySourceFailureHistoryEntry> compacted;
+        compacted.reserve(copy_source_failures_.size());
+        for (const auto &[key, state] : copy_source_failures_) {
+            compacted.push_back(CopySourceFailureHistoryEntry{key, state.last_failure_time});
+        }
+        std::sort(compacted.begin(), compacted.end(), [](const auto &lhs, const auto &rhs) {
+            return lhs.failure_time < rhs.failure_time;
+        });
+        copy_source_failure_history_ = std::deque<CopySourceFailureHistoryEntry>(compacted.begin(), compacted.end());
+    }
+}
+
+void MigrationManager::RecordCopySourceFailure(const CopyTaskContext &ctx, ErrorCode reason) {
+    const auto key = MakeCopySourceFailureKey(ctx);
+    const auto now = std::chrono::steady_clock::now();
+    uint32_t failure_count = 0;
+    std::chrono::milliseconds backoff{0};
+    {
+        std::lock_guard<std::mutex> lock(copy_source_failure_mutex_);
+        PruneCopySourceFailuresLocked(now);
+
+        auto &state = copy_source_failures_[key];
+        if (state.consecutive_failures < std::numeric_limits<uint32_t>::max()) {
+            ++state.consecutive_failures;
+        }
+        failure_count = state.consecutive_failures;
+        backoff = ComputeCopySourceBackoff(key, failure_count);
+        state.last_error = reason;
+        state.last_failure_time = now;
+        state.retry_after = now + backoff;
+        copy_source_failure_history_.push_back(CopySourceFailureHistoryEntry{key, now});
+
+        PruneCopySourceFailuresLocked(now);
+        UpdateCopySourceFailureGaugeLocked();
+    }
+
+    stat_source_failures_recorded_.fetch_add(1, std::memory_order_relaxed);
+    if (metrics_enabled_) {
+        ++m_source_failures_recorded_total_;
+    }
+    KVCM_LOG_WARN("migration Copy source enters retry backoff: instance %s block_key %lld source_location %s "
+                  "source_create_time %lld target_storage %s reason %d consecutive_failures %u backoff_ms %lld",
+                  ctx.instance_id.c_str(),
+                  static_cast<long long>(ctx.block_key),
+                  ctx.src_location_id.c_str(),
+                  static_cast<long long>(ctx.src_create_time),
+                  ctx.dst_storage_name.c_str(),
+                  static_cast<int>(reason),
+                  failure_count,
+                  static_cast<long long>(backoff.count()));
+}
+
+void MigrationManager::ClearCopySourceFailure(const CopyTaskContext &ctx) {
+    const auto key = MakeCopySourceFailureKey(ctx);
+    std::lock_guard<std::mutex> lock(copy_source_failure_mutex_);
+    if (copy_source_failures_.erase(key) > 0) {
+        UpdateCopySourceFailureGaugeLocked();
+    }
+}
+
+MigrationManager::CopySourceFailureSnapshot
+MigrationManager::GetCopySourceFailure(const std::string &instance_id,
+                                       int64_t block_key,
+                                       const CacheLocation &source,
+                                       const std::string &target_storage_name,
+                                       std::chrono::steady_clock::time_point now) const {
+    const auto key = MakeCopySourceFailureKey(instance_id, block_key, source, target_storage_name);
+    std::lock_guard<std::mutex> lock(copy_source_failure_mutex_);
+    auto iter = copy_source_failures_.find(key);
+    if (iter == copy_source_failures_.end() || now - iter->second.last_failure_time >= kCopySourceFailureRetention) {
+        return {};
+    }
+    return CopySourceFailureSnapshot{
+        true, now < iter->second.retry_after, iter->second.consecutive_failures, iter->second.last_error};
+}
+
 bool MigrationManager::IsSourceLocationServing(const CopyTaskContext &ctx) const {
     auto indexer = meta_indexer_manager_ ? meta_indexer_manager_->GetMetaIndexer(ctx.instance_id) : nullptr;
     if (!indexer) {
@@ -1263,6 +1417,10 @@ void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
         return;
     }
     // kClaimedRunning：状态已在锁内置 kCompleting，并发 Cancel 会走 busy 分支。
+
+    // backend 已明确完成 Copy，说明这条 source->target 路由至少在本次可用；即使后续因为
+    // source metadata 并发变化或 target promote 失败而按任务失败收尾，也不应继承旧的 Copy 退避。
+    ClearCopySourceFailure(ctx);
 
     if (!IsSourceLocationServing(ctx)) {
         KVCM_LOG_WARN("migration source lost, block_key %ld src_loc %s, discard dst_loc %s",
@@ -1356,6 +1514,8 @@ void MigrationManager::OnTaskFailed(const std::string &instance_id, int64_t bloc
     }
 
     // 失败：CAS 目标 WRITING -> DELETING 并删除目标半成品，源端不动。
+    // 必须先登记 source 退避，再从 active table 移除任务，避免 admission 在两步之间重新选中同一源。
+    RecordCopySourceFailure(ctx, reason);
     const std::string fail_reason = "copy_failed:" + std::to_string(static_cast<int>(reason));
     CompleteCopyTaskAsFailed(ctx, fail_reason);
     KVCM_LOG_WARN("migration failed: instance %s block_key %ld dst_loc %s reason %d",
@@ -2121,7 +2281,16 @@ MigrationManager::CopyAdmission MigrationManager::CheckCopyAdmission(const std::
                            [&covered](const auto &spec) { return covered.count(spec.name()) > 0; });
     };
 
+    struct EligibleSource {
+        const CacheLocation *location = nullptr;
+        CopySourceFailureSnapshot failure;
+    };
+
+    const auto now = std::chrono::steady_clock::now();
     bool all_sources_covered_by_serving = true;
+    std::size_t uncovered_source_count = 0;
+    std::size_t suppressed_source_count = 0;
+    std::vector<EligibleSource> eligible_sources;
     for (const auto *src_loc : src_locations) {
         if (specs_covered_by(*src_loc, serving_covered)) {
             continue;
@@ -2131,7 +2300,64 @@ MigrationManager::CopyAdmission MigrationManager::CheckCopyAdmission(const std::
             continue;
         }
         // 该 source 既未被 SERVING 也未被 SERVING∪WRITING 联合覆盖 → 需要 copy。
-        return {CopyAdmissionStatus::kAccept, src_loc};
+        ++uncovered_source_count;
+        const auto failure = GetCopySourceFailure(instance_id, block_key, *src_loc, dst_storage_name, now);
+        if (failure.suppressed) {
+            ++suppressed_source_count;
+            continue;
+        }
+        eligible_sources.push_back(EligibleSource{src_loc, failure});
+    }
+
+    if (!eligible_sources.empty()) {
+        // 优先选择从未失败的 source；都失败过时选择连续失败次数更少的 source。这样即使
+        // Reclaimer 周期长于首次 backoff，已知坏源也不会在健康副本之前被反复选中。
+        const auto selected = std::min_element(
+            eligible_sources.begin(), eligible_sources.end(), [](const EligibleSource &lhs, const EligibleSource &rhs) {
+                if (lhs.failure.consecutive_failures != rhs.failure.consecutive_failures) {
+                    return lhs.failure.consecutive_failures < rhs.failure.consecutive_failures;
+                }
+                return lhs.location->id() < rhs.location->id();
+            });
+
+        const bool switched_source =
+            uncovered_source_count > 1 &&
+            (suppressed_source_count > 0 ||
+             std::any_of(eligible_sources.begin(), eligible_sources.end(), [&](const auto &item) {
+                 return item.location != selected->location &&
+                        item.failure.consecutive_failures > selected->failure.consecutive_failures;
+             }));
+        if (switched_source) {
+            stat_source_switches_.fetch_add(1, std::memory_order_relaxed);
+            if (metrics_enabled_) {
+                ++m_source_switches_total_;
+            }
+            KVCM_LOG_INFO("migration admission switches Copy source: instance %s block_key %lld target_storage %s "
+                          "selected_source %s selected_prior_failures %u suppressed_sources %zu",
+                          instance_id.c_str(),
+                          static_cast<long long>(block_key),
+                          dst_storage_name.c_str(),
+                          selected->location->id().c_str(),
+                          selected->failure.consecutive_failures,
+                          suppressed_source_count);
+        }
+        if (suppressed_source_count > 0) {
+            stat_source_retries_suppressed_.fetch_add(suppressed_source_count, std::memory_order_relaxed);
+            if (metrics_enabled_) {
+                m_source_retries_suppressed_total_ += suppressed_source_count;
+            }
+        }
+        return {CopyAdmissionStatus::kAccept, selected->location};
+    }
+
+    if (suppressed_source_count > 0) {
+        stat_source_retries_suppressed_.fetch_add(suppressed_source_count, std::memory_order_relaxed);
+        stat_no_usable_source_.fetch_add(1, std::memory_order_relaxed);
+        if (metrics_enabled_) {
+            m_source_retries_suppressed_total_ += suppressed_source_count;
+            ++m_no_usable_source_total_;
+        }
+        return {CopyAdmissionStatus::kSourceRetrySuppressed, nullptr};
     }
 
     // 循环走完未 return kAccept：每个 source 都被 serving∪writing 覆盖。
@@ -2561,11 +2787,19 @@ MigrationManager::MigrationStats MigrationManager::GetStats() const {
     stats.copy_completed = stat_copy_completed_.load(std::memory_order_relaxed);
     stats.copy_failed = stat_copy_failed_.load(std::memory_order_relaxed);
     stats.copy_cancelled = stat_copy_cancelled_.load(std::memory_order_relaxed);
+    stats.source_failures_recorded = stat_source_failures_recorded_.load(std::memory_order_relaxed);
+    stats.source_retries_suppressed = stat_source_retries_suppressed_.load(std::memory_order_relaxed);
+    stats.source_switches = stat_source_switches_.load(std::memory_order_relaxed);
+    stats.no_usable_source = stat_no_usable_source_.load(std::memory_order_relaxed);
     stats.marks_added = stat_marks_added_.load(std::memory_order_relaxed);
     stats.marks_cleared = stat_marks_cleared_.load(std::memory_order_relaxed);
     {
         std::lock_guard<std::mutex> lock(task_mutex_);
         stats.active_copy_tasks = ActiveTaskCountUnsafe();
+    }
+    {
+        std::lock_guard<std::mutex> lock(copy_source_failure_mutex_);
+        stats.source_failure_entries = copy_source_failures_.size();
     }
     // 持久化方案下无内存表，active_marks 为 best-effort 近似（added - cleared）。
     const uint64_t added = stats.marks_added;

--- a/kv_cache_manager/manager/migration_manager.h
+++ b/kv_cache_manager/manager/migration_manager.h
@@ -144,6 +144,7 @@ public:
                                          const std::string &operator_name,
                                          const std::string &external_fencing_evidence);
     bool HasAsyncCopyStorageReference(const std::string &storage_name) const;
+    bool HasAsyncCopyInstanceReference(const std::string &instance_id) const;
 
     // ---- Copy 路径 ----
     // 同步完成"建目标 location + 提交 copy 任务"，copy 字节复制异步执行；
@@ -240,6 +241,7 @@ public:
         kTargetWritingExists,   // 目标 storage 上存在 WRITING 副本（可能为其他迁移半成品）
         kSourceServingNotFound, // 源 storage 上没有 SERVING 副本，无可复制源
         kSourceRetrySuppressed, // 尚未被目标覆盖的源均处于失败退避，当前不应再次提交 Copy
+        kSourcePinnedByGuard,   // 源被另一条持久异步 Copy guard 钉住，不能并行派生新迁移
     };
 
     struct CopyAdmission {
@@ -373,6 +375,7 @@ private:
         kSuccess,
         kFailed,
         kCancelled,
+        kUnknown,
     };
 
     // 单个活跃 Copy 任务的上下文。
@@ -455,12 +458,26 @@ private:
     struct PendingCopy {
         std::string instance_id;
         int64_t block_key = 0;
+        size_t expected_items = 0;
         std::future<PlanExecuteResult> future;
         bool native_async = false;
         std::future<AsyncCopyRemoteSubmitResult> remote_submit_future;
         bool remote_submit_processed = true;
         std::optional<PlanExecuteResult> completed_result;
         std::chrono::steady_clock::time_point completion_retry_after{};
+    };
+
+    // An async Copy is not fully cleaned up when its target/source metadata is
+    // merely queued for deletion. Keep a reference until the executor finishes
+    // the physical delete so RemoveStorage cannot close the backend underneath
+    // the cleanup task.
+    struct PendingLocationCleanup {
+        std::string instance_id;
+        std::string storage_name;
+        CacheLocationDelRequest request;
+        std::future<PlanExecuteResult> future;
+        std::chrono::steady_clock::time_point retry_after{};
+        uint32_t retry_count = 0;
     };
 
     struct ExpiringMark {
@@ -500,7 +517,8 @@ private:
                               bool remote_side_effect_possible,
                               bool record_source_failure);
     bool CompleteCopyTaskAsSucceeded(const CopyTaskContext &ctx);
-    void CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, const std::string &fail_reason);
+    bool CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, const std::string &fail_reason);
+    bool HasDurableUnknownGuard(const CopyTaskContext &ctx) const;
     GuardMutationResult UpdateAsyncCopyGuard(const CopyTaskContext &ctx,
                                              MigrationCopyGuardState expected_state,
                                              MigrationCopyGuardState state,
@@ -514,13 +532,20 @@ private:
     void MarkGuardFinalizationPendingSync(const CopyTaskContext &ctx,
                                           CopyCompletionAction action,
                                           const std::string &reason = "");
+    void MarkUnknownGuardPersistencePending(const CopyTaskContext &ctx, const std::string &reason, bool sync_only);
     bool ResumePendingGuardFinalization(const CopyTaskContext &ctx);
     bool PersistRemoteAsyncCopyAcceptance(const std::string &instance_id,
                                           int64_t block_key,
+                                          size_t expected_items,
                                           const AsyncCopyRemoteSubmitResult &remote_result,
                                           CopyTaskContext &out_ctx,
                                           bool &out_cancel_requested);
     void SubmitPreparedTargetLocationDelete(const CopyTaskContext &ctx);
+    void TrackLocationCleanup(const std::string &instance_id,
+                              const std::string &storage_name,
+                              CacheLocationDelRequest request,
+                              std::future<PlanExecuteResult> future);
+    void ProcessCompletedLocationCleanups();
     bool ReserveAsyncCopyCredit(const MigrationRequest &request, uint64_t total_bytes);
     void ReleaseAsyncCopyCredit(const CopyTaskContext &ctx);
     void MoveAsyncCopyCreditToQuarantine(const CopyTaskContext &ctx, const std::string &reason);
@@ -592,14 +617,15 @@ private:
     enum class ClaimResult {
         kClaimedRunning,
         kWasCancelling,
-        kRetryingGuardSync,
+        kRetryingGuardTransition,
         kBusyPreparing,
         kBusyCompleting,
         kNotFound,
     };
     // monitor 完成路径认领：kRunning→置 kCompleting 并拷 ctx（kClaimedRunning）；
     // kCancelling→置 kCompleting，记住 cancellation owner 并返回 kWasCancelling，交由
-    // CompleteCancelledTask 唯一收尾。已应用终态 CAS 但 Sync 未确认时返回 kRetryingGuardSync。
+    // CompleteCancelledTask 唯一收尾。已认领收尾但 guard 跃迁或其 Sync 屏障尚未
+    // 持久确认时返回 kRetryingGuardTransition。
     ClaimResult ClaimForCompletionLocked(const std::string &instance_id, int64_t block_key, CopyTaskContext &out_ctx);
     enum class CancelResult { kMarked, kMarkedPreparing, kAlreadyCancelling, kBusyCompleting, kNotFound };
     // 外部 Cancel 认领：kPreparing→kPrepareCancelling（由提交线程清理）；
@@ -682,6 +708,8 @@ private:
     std::mutex pending_mutex_;
     std::condition_variable pending_cv_;
     std::deque<PendingCopy> pending_copies_;
+    mutable std::mutex pending_cleanup_mutex_;
+    std::deque<PendingLocationCleanup> pending_location_cleanups_;
 
     std::mutex mark_expiry_mutex_;
     std::priority_queue<ExpiringMark, std::vector<ExpiringMark>, ExpiringMarkGreater> mark_expiry_queue_;

--- a/kv_cache_manager/manager/migration_manager.h
+++ b/kv_cache_manager/manager/migration_manager.h
@@ -10,6 +10,7 @@
 #include <initializer_list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <shared_mutex>
 #include <string>
@@ -45,7 +46,9 @@ class RequestContext;
  *     供写路径批量查询并由 StartWriteCache 消费。打标天然随元数据持久化，
  *     crash 后自动可见（继续按持久化的 Mark 迁移）。
  *
- * 不引入新状态机（复用 CLS_WRITING）；crash 恢复交给 Reclaimer 孤儿检测。
+ * 同步路径沿用 CLS_WRITING；原生异步路径额外在 CacheLocation 中持久化
+ * migration_copy_guard。guard 是跨重启的回收权威：没有 terminal + drained
+ * 证明时目标只能 quarantine，不能交给 Reclaimer/GC 当普通 orphan 回收。
  * MigrationManager 维护一个活跃任务集合（instance_id + block_key）用于防重复迁移与并发预算统计。
  *
  * 线程模型：Reclaimer 的 Prepare 与所有 Copy/迁移 cleanup 在共享 SchedulePlanExecutor 中执行，
@@ -62,6 +65,12 @@ public:
         std::string src_storage_name; // 执行 Copy 的 backend（一期 = 源 storage 的 unique name）
         std::string dst_storage_name; // 目标 storage（冷层）
         MigrationRetention retention = MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE;
+        MigrationCopyExecutionMode copy_execution_mode = MigrationCopyExecutionMode::SYNC;
+        uint64_t copy_max_inflight_bytes = 0;
+        int64_t copy_max_quarantine_operations = 0;
+        uint64_t copy_max_quarantine_bytes = 0;
+        AsyncCopyOptions async_copy_options;
+        std::string async_operation_id;
         // admission 已定位的源 location 信息，避免批量提交时冗余 BatchGetLocation。
         // DispatchMigrationBatch 生成的 prepared request 必须非空；单条 Submit 可留空，由
         // PrepareCopyTask 兼容性地重读 meta。
@@ -90,11 +99,24 @@ public:
         uint64_t source_retries_suppressed = 0;
         uint64_t source_switches = 0;
         uint64_t no_usable_source = 0;
+        uint64_t async_copy_unknown = 0;
+        uint64_t async_copy_inflight_operations = 0;
+        uint64_t async_copy_inflight_bytes = 0;
+        uint64_t async_copy_quarantine_operations = 0;
+        uint64_t async_copy_quarantine_bytes = 0;
         uint64_t marks_added = 0;
         uint64_t marks_cleared = 0;
         size_t active_copy_tasks = 0;
         size_t source_failure_entries = 0;
         size_t active_marks = 0;
+    };
+
+    struct AsyncCopyQuarantineRecord {
+        std::string instance_group_name;
+        std::string instance_id;
+        int64_t block_key = 0;
+        std::string target_location_id;
+        MigrationCopyGuard guard;
     };
 
     MigrationManager(std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor,
@@ -109,8 +131,19 @@ public:
     MigrationManager(const MigrationManager &) = delete;
     MigrationManager &operator=(const MigrationManager &) = delete;
 
-    void Start();
+    ErrorCode Start();
     void Stop();
+
+    // Persistent quarantine is rebuilt before new migration admission on
+    // every leader start.  Listing is read-only.  Break-glass release is an
+    // explicitly fenced operation and requires non-empty operator/evidence;
+    // ordinary timeout/age is never accepted as evidence.
+    std::vector<AsyncCopyQuarantineRecord>
+    ListAsyncCopyQuarantine(const std::string &instance_group_name = "") const;
+    ErrorCode BreakGlassReleaseAsyncCopy(const std::string &operation_id,
+                                         const std::string &operator_name,
+                                         const std::string &external_fencing_evidence);
+    bool HasAsyncCopyStorageReference(const std::string &storage_name) const;
 
     // ---- Copy 路径 ----
     // 同步完成"建目标 location + 提交 copy 任务"，copy 字节复制异步执行；
@@ -120,8 +153,12 @@ public:
     ErrorCode Submit(const std::string &trace_id, MigrationRequest request);
 
     // ---- copy 任务完成回调（监控线程驱动，亦可供测试直接调用） ----
-    void OnTaskSuccess(const std::string &instance_id, int64_t block_key);
-    void OnTaskFailed(const std::string &instance_id, int64_t block_key, ErrorCode reason);
+    // Return false only when a guard CAS was applied but its persistent Sync
+    // barrier is still unconfirmed.  MonitorLoop retains the completed backend
+    // result and retries the barrier without reissuing the CAS or the Copy.
+    bool OnTaskSuccess(const std::string &instance_id, int64_t block_key);
+    bool OnTaskFailed(const std::string &instance_id, int64_t block_key, ErrorCode reason);
+    bool OnTaskUnknown(const std::string &instance_id, int64_t block_key, const std::string &reason);
 
     // ---- Mark 路径（MetaIndexer 持久化：block 级 property，随元数据落 Redis + local cache） ----
     // 打标/清标走 ReadModifyWriteBlock 只写 property（不动 location）；查标走 GetProperties。
@@ -198,11 +235,11 @@ public:
     // ---- Copy 准入策略（CacheReclaimer / AdminServiceImpl 共用） ----
     enum class CopyAdmissionStatus {
         kAccept,
-        kAlreadyMigrating,       // 该 block_key 已有活跃 Copy 任务
-        kTargetServingExists,    // 目标 storage 上已存在 SERVING 副本
-        kTargetWritingExists,    // 目标 storage 上存在 WRITING 副本（可能为其他迁移半成品）
-        kSourceServingNotFound,  // 源 storage 上没有 SERVING 副本，无可复制源
-        kSourceRetrySuppressed,  // 尚未被目标覆盖的源均处于失败退避，当前不应再次提交 Copy
+        kAlreadyMigrating,      // 该 block_key 已有活跃 Copy 任务
+        kTargetServingExists,   // 目标 storage 上已存在 SERVING 副本
+        kTargetWritingExists,   // 目标 storage 上存在 WRITING 副本（可能为其他迁移半成品）
+        kSourceServingNotFound, // 源 storage 上没有 SERVING 副本，无可复制源
+        kSourceRetrySuppressed, // 尚未被目标覆盖的源均处于失败退避，当前不应再次提交 Copy
     };
 
     struct CopyAdmission {
@@ -256,6 +293,11 @@ public:
         std::size_t max_copy_slots = SIZE_MAX;
         CopyConcurrencyLimit copy_limit;
         MigrationRetention retention = MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE;
+        MigrationCopyExecutionMode copy_execution_mode = MigrationCopyExecutionMode::SYNC;
+        uint64_t copy_max_inflight_bytes = 0;
+        int64_t copy_max_quarantine_operations = 0;
+        uint64_t copy_max_quarantine_bytes = 0;
+        AsyncCopyOptions async_copy_options;
         int64_t mark_timeout_ms = MigrationMarkMethod::kDefaultTimeoutMs;
         bool dedup_marks = false; // true=跳过已打标的 block（reclaimer 用；Admin 显式指定 block 不需要）
     };
@@ -320,6 +362,19 @@ private:
     //   kCancelling —— 外部已请求取消，收尾推迟到 future 完成时由 monitor 执行（删 WRITING 目标、不 promote）。
     enum class CopyTaskState { kPreparing, kPrepareCancelling, kRunning, kCompleting, kCancelling };
 
+    enum class GuardMutationResult {
+        kNotApplied,
+        kAppliedDurably,
+        kAppliedDurabilityUnknown,
+    };
+
+    enum class CopyCompletionAction {
+        kNone,
+        kSuccess,
+        kFailed,
+        kCancelled,
+    };
+
     // 单个活跃 Copy 任务的上下文。
     struct CopyTaskContext {
         std::string instance_group_name;
@@ -331,10 +386,28 @@ private:
         std::string dst_storage_name;
         std::string dst_location_id;
         MigrationRetention retention = MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE;
+        MigrationCopyExecutionMode copy_execution_mode = MigrationCopyExecutionMode::SYNC;
+        std::string async_operation_id;
+        std::vector<std::string> async_backend_task_ids;
+        int64_t async_guard_create_time_us = 0;
+        bool async_credit_active = false;
+        // Guard transitions are serialized per operation.  The mutex is shared
+        // by copied task snapshots so Cancel, remote-acceptance persistence and
+        // completion cannot concurrently finalize the same operation, while
+        // unrelated operations remain parallel.
+        std::shared_ptr<std::mutex> async_transition_mutex;
+        // A final status CAS has already changed the logical Location, but the
+        // persistent Sync barrier timed out.  Retried completion must only call
+        // Sync; reissuing the CAS would observe the new status and manufacture
+        // a false UNKNOWN/quarantine record.
+        bool async_guard_finalization_pending_sync = false;
+        bool completion_was_cancelling = false;
+        CopyCompletionAction async_guard_pending_action = CopyCompletionAction::kNone;
+        std::string async_guard_pending_reason;
         std::chrono::steady_clock::time_point submit_time;
-        uint64_t total_bytes = 0;              // 源端各 spec 字节数之和（取自 uri size 参数）
-        std::string mark_target;               // 提交时 mark 的 target（空=无 mark，用于 match-clear）
-        int64_t mark_deadline_ms = 0;          // 提交时 mark 的 deadline（用于 match-clear）
+        uint64_t total_bytes = 0;     // 源端各 spec 字节数之和（取自 uri size 参数）
+        std::string mark_target;      // 提交时 mark 的 target（空=无 mark，用于 match-clear）
+        int64_t mark_deadline_ms = 0; // 提交时 mark 的 deadline（用于 match-clear）
         CopyTaskState state = CopyTaskState::kRunning; // 收尾认领状态
     };
 
@@ -383,6 +456,11 @@ private:
         std::string instance_id;
         int64_t block_key = 0;
         std::future<PlanExecuteResult> future;
+        bool native_async = false;
+        std::future<AsyncCopyRemoteSubmitResult> remote_submit_future;
+        bool remote_submit_processed = true;
+        std::optional<PlanExecuteResult> completed_result;
+        std::chrono::steady_clock::time_point completion_retry_after{};
     };
 
     struct ExpiringMark {
@@ -412,7 +490,42 @@ private:
     void SubmitSourceLocationDelete(const CopyTaskContext &ctx);
     // Copy 成功回调收尾前，确认源 location 仍可作为有效源副本。
     bool IsSourceLocationServing(const CopyTaskContext &ctx) const;
-    void CompleteCopyTaskAsFailed(const CopyTaskContext &ctx, const std::string &fail_reason);
+    bool CompleteCopyTaskAsFailed(const CopyTaskContext &ctx,
+                                  const std::string &fail_reason,
+                                  bool remote_side_effect_possible = true);
+    bool OnTaskFailedInternal(const std::string &instance_id,
+                              int64_t block_key,
+                              ErrorCode reason,
+                              const std::string &fail_reason,
+                              bool remote_side_effect_possible,
+                              bool record_source_failure);
+    bool CompleteCopyTaskAsSucceeded(const CopyTaskContext &ctx);
+    void CompleteCopyTaskAsUnknown(const CopyTaskContext &ctx, const std::string &fail_reason);
+    GuardMutationResult UpdateAsyncCopyGuard(const CopyTaskContext &ctx,
+                                             MigrationCopyGuardState expected_state,
+                                             MigrationCopyGuardState state,
+                                             const std::vector<std::string> &backend_task_ids,
+                                             const std::string &last_error);
+    GuardMutationResult FinalizeAsyncCopyGuard(const CopyTaskContext &ctx,
+                                               MigrationCopyGuardState expected_state,
+                                               CacheLocationStatus new_status);
+    static MigrationCopyGuardState ExpectedGuardState(const CopyTaskContext &ctx);
+    std::shared_ptr<std::mutex> GetAsyncTransitionMutex(const std::string &instance_id, int64_t block_key) const;
+    void MarkGuardFinalizationPendingSync(const CopyTaskContext &ctx,
+                                          CopyCompletionAction action,
+                                          const std::string &reason = "");
+    bool ResumePendingGuardFinalization(const CopyTaskContext &ctx);
+    bool PersistRemoteAsyncCopyAcceptance(const std::string &instance_id,
+                                          int64_t block_key,
+                                          const AsyncCopyRemoteSubmitResult &remote_result,
+                                          CopyTaskContext &out_ctx,
+                                          bool &out_cancel_requested);
+    void SubmitPreparedTargetLocationDelete(const CopyTaskContext &ctx);
+    bool ReserveAsyncCopyCredit(const MigrationRequest &request, uint64_t total_bytes);
+    void ReleaseAsyncCopyCredit(const CopyTaskContext &ctx);
+    void MoveAsyncCopyCreditToQuarantine(const CopyTaskContext &ctx, const std::string &reason);
+    bool RestoreAsyncCopyInflightCredit(const CopyTaskContext &ctx);
+    bool RecoverAsyncCopyGuards();
     void RecordCopySourceFailure(const CopyTaskContext &ctx, ErrorCode reason);
     void ClearCopySourceFailure(const CopyTaskContext &ctx);
     CopySourceFailureSnapshot GetCopySourceFailure(const std::string &instance_id,
@@ -464,7 +577,7 @@ private:
     bool ReservePreparingTaskLocked(const MigrationRequest &request);
     // 将 PrepareCopyTask 产出的完整上下文（尤其 dst_location_id）绑定到既有 preparing 占位；
     // 不改变状态。仅当对应 entry 仍为 kPreparing 时成功。
-    bool UpdatePreparingTaskLocked(const CopyTaskContext &ctx);
+    bool UpdatePreparingTaskLocked(CopyTaskContext &ctx);
     // kPreparing -> kRunning；其他状态一律失败，避免覆盖并发状态转换。
     bool MarkTaskRunningLocked(const std::string &instance_id, int64_t block_key);
     // 仅移除仍由提交线程持有的 kPreparing/kPrepareCancelling entry，避免失败清理误删已进入
@@ -476,9 +589,17 @@ private:
     bool HasActiveTaskLocked(const std::string &instance_id, int64_t block_key) const;
 
     // ---- 收尾认领（均要求调用方持有 task_mutex_）----
-    enum class ClaimResult { kClaimedRunning, kWasCancelling, kBusyPreparing, kBusyCompleting, kNotFound };
+    enum class ClaimResult {
+        kClaimedRunning,
+        kWasCancelling,
+        kRetryingGuardSync,
+        kBusyPreparing,
+        kBusyCompleting,
+        kNotFound,
+    };
     // monitor 完成路径认领：kRunning→置 kCompleting 并拷 ctx（kClaimedRunning）；
-    // kCancelling→拷 ctx 返回 kWasCancelling（不改状态，交由 CompleteCancelledTask 收尾）。
+    // kCancelling→置 kCompleting，记住 cancellation owner 并返回 kWasCancelling，交由
+    // CompleteCancelledTask 唯一收尾。已应用终态 CAS 但 Sync 未确认时返回 kRetryingGuardSync。
     ClaimResult ClaimForCompletionLocked(const std::string &instance_id, int64_t block_key, CopyTaskContext &out_ctx);
     enum class CancelResult { kMarked, kMarkedPreparing, kAlreadyCancelling, kBusyCompleting, kNotFound };
     // 外部 Cancel 认领：kPreparing→kPrepareCancelling（由提交线程清理）；
@@ -486,7 +607,7 @@ private:
     CancelResult MarkCancellingLocked(const std::string &instance_id, int64_t block_key);
     // 取消任务的延迟收尾（monitor 线程，入口不持锁）：删 WRITING 目标（源不动）+ 移除活跃任务
     // + cancelled 终态 metric/event/log。仅由 OnTaskSuccess/OnTaskFailed 在认领到 kWasCancelling 时调用。
-    void CompleteCancelledTask(const CopyTaskContext &ctx);
+    bool CompleteCancelledTask(const CopyTaskContext &ctx);
 
     struct AsyncMigrationPrepareKey {
         std::uint64_t generation = 0;
@@ -544,6 +665,19 @@ private:
     std::unordered_map<CopySourceFailureKey, CopySourceFailureState, CopySourceFailureKeyHash> copy_source_failures_;
     std::deque<CopySourceFailureHistoryEntry> copy_source_failure_history_;
 
+    struct AsyncCopyGroupUsage {
+        uint64_t inflight_operations = 0;
+        uint64_t inflight_bytes = 0;
+        uint64_t quarantine_operations = 0;
+        uint64_t quarantine_bytes = 0;
+    };
+    mutable std::mutex async_copy_usage_mutex_;
+    // Exact operation-id ledger makes inflight -> released/quarantine credit a
+    // one-way, exactly-once transition even if an error path is retried.
+    std::unordered_set<std::string> async_copy_inflight_operation_ids_;
+    std::unordered_map<std::string, AsyncCopyGroupUsage> async_copy_usage_by_group_;
+    std::unordered_map<std::string, AsyncCopyQuarantineRecord> async_copy_quarantine_by_operation_;
+
     // 监控线程待处理队列。
     std::mutex pending_mutex_;
     std::condition_variable pending_cv_;
@@ -581,6 +715,7 @@ private:
     mutable std::atomic<uint64_t> stat_source_retries_suppressed_{0};
     mutable std::atomic<uint64_t> stat_source_switches_{0};
     mutable std::atomic<uint64_t> stat_no_usable_source_{0};
+    std::atomic<uint64_t> stat_async_copy_unknown_{0};
     std::atomic<uint64_t> stat_marks_added_{0};
     std::atomic<uint64_t> stat_marks_cleared_{0};
 

--- a/kv_cache_manager/manager/migration_manager.h
+++ b/kv_cache_manager/manager/migration_manager.h
@@ -86,9 +86,14 @@ public:
         uint64_t copy_completed = 0;
         uint64_t copy_failed = 0;
         uint64_t copy_cancelled = 0;
+        uint64_t source_failures_recorded = 0;
+        uint64_t source_retries_suppressed = 0;
+        uint64_t source_switches = 0;
+        uint64_t no_usable_source = 0;
         uint64_t marks_added = 0;
         uint64_t marks_cleared = 0;
         size_t active_copy_tasks = 0;
+        size_t source_failure_entries = 0;
         size_t active_marks = 0;
     };
 
@@ -197,6 +202,7 @@ public:
         kTargetServingExists,    // 目标 storage 上已存在 SERVING 副本
         kTargetWritingExists,    // 目标 storage 上存在 WRITING 副本（可能为其他迁移半成品）
         kSourceServingNotFound,  // 源 storage 上没有 SERVING 副本，无可复制源
+        kSourceRetrySuppressed,  // 尚未被目标覆盖的源均处于失败退避，当前不应再次提交 Copy
     };
 
     struct CopyAdmission {
@@ -332,6 +338,46 @@ private:
         CopyTaskState state = CopyTaskState::kRunning; // 收尾认领状态
     };
 
+    // Copy 后端当前只向 MigrationManager 返回聚合 ErrorCode，无法可靠区分 source 永久失效、
+    // target 故障和瞬态网络错误。因此 V1 不删除源元数据，而是按完整 source identity + target
+    // 记录有界失败退避。target 也进入 key，避免一个冷层故障污染同一源到其它目标的迁移。
+    struct CopySourceFailureKey {
+        std::string instance_id;
+        int64_t block_key = 0;
+        std::string location_id;
+        int64_t location_create_time = 0;
+        std::string target_storage_name;
+
+        bool operator==(const CopySourceFailureKey &other) const {
+            return instance_id == other.instance_id && block_key == other.block_key &&
+                   location_id == other.location_id && location_create_time == other.location_create_time &&
+                   target_storage_name == other.target_storage_name;
+        }
+    };
+
+    struct CopySourceFailureKeyHash {
+        std::size_t operator()(const CopySourceFailureKey &key) const;
+    };
+
+    struct CopySourceFailureState {
+        uint32_t consecutive_failures = 0;
+        ErrorCode last_error = EC_UNKNOWN;
+        std::chrono::steady_clock::time_point last_failure_time;
+        std::chrono::steady_clock::time_point retry_after;
+    };
+
+    struct CopySourceFailureHistoryEntry {
+        CopySourceFailureKey key;
+        std::chrono::steady_clock::time_point failure_time;
+    };
+
+    struct CopySourceFailureSnapshot {
+        bool known = false;
+        bool suppressed = false;
+        uint32_t consecutive_failures = 0;
+        ErrorCode last_error = EC_UNKNOWN;
+    };
+
     // 监控线程待处理的 copy future。
     struct PendingCopy {
         std::string instance_id;
@@ -367,6 +413,22 @@ private:
     // Copy 成功回调收尾前，确认源 location 仍可作为有效源副本。
     bool IsSourceLocationServing(const CopyTaskContext &ctx) const;
     void CompleteCopyTaskAsFailed(const CopyTaskContext &ctx, const std::string &fail_reason);
+    void RecordCopySourceFailure(const CopyTaskContext &ctx, ErrorCode reason);
+    void ClearCopySourceFailure(const CopyTaskContext &ctx);
+    CopySourceFailureSnapshot GetCopySourceFailure(const std::string &instance_id,
+                                                   int64_t block_key,
+                                                   const CacheLocation &source,
+                                                   const std::string &target_storage_name,
+                                                   std::chrono::steady_clock::time_point now) const;
+    static CopySourceFailureKey MakeCopySourceFailureKey(const CopyTaskContext &ctx);
+    static CopySourceFailureKey MakeCopySourceFailureKey(const std::string &instance_id,
+                                                         int64_t block_key,
+                                                         const CacheLocation &source,
+                                                         const std::string &target_storage_name);
+    static std::chrono::milliseconds ComputeCopySourceBackoff(const CopySourceFailureKey &key,
+                                                              uint32_t consecutive_failures);
+    void PruneCopySourceFailuresLocked(std::chrono::steady_clock::time_point now);
+    void UpdateCopySourceFailureGaugeLocked();
 
     void MonitorLoop();
 
@@ -470,6 +532,18 @@ private:
     mutable std::mutex task_mutex_;
     std::unordered_map<std::string, std::unordered_map<int64_t, CopyTaskContext>> active_tasks_by_instance_;
 
+    // Source failure suppression is intentionally process-local in V1. It prevents a live Leader from
+    // hot-looping on the same stale GA and lets admission select another source. A Manager process restart
+    // permits one fresh probe; persistent quarantine requires a future authoritative topology epoch/error.
+    static constexpr std::size_t kMaxCopySourceFailureEntries = 100000;
+    static constexpr std::size_t kMaxCopySourceFailureHistoryEntries = 2 * kMaxCopySourceFailureEntries;
+    static constexpr std::chrono::milliseconds kCopySourceInitialBackoff{5000};
+    static constexpr std::chrono::milliseconds kCopySourceMaxBackoff{30 * 60 * 1000};
+    static constexpr std::chrono::hours kCopySourceFailureRetention{24};
+    mutable std::mutex copy_source_failure_mutex_;
+    std::unordered_map<CopySourceFailureKey, CopySourceFailureState, CopySourceFailureKeyHash> copy_source_failures_;
+    std::deque<CopySourceFailureHistoryEntry> copy_source_failure_history_;
+
     // 监控线程待处理队列。
     std::mutex pending_mutex_;
     std::condition_variable pending_cv_;
@@ -503,6 +577,10 @@ private:
     std::atomic<uint64_t> stat_copy_completed_{0};
     std::atomic<uint64_t> stat_copy_failed_{0};
     std::atomic<uint64_t> stat_copy_cancelled_{0};
+    std::atomic<uint64_t> stat_source_failures_recorded_{0};
+    mutable std::atomic<uint64_t> stat_source_retries_suppressed_{0};
+    mutable std::atomic<uint64_t> stat_source_switches_{0};
+    mutable std::atomic<uint64_t> stat_no_usable_source_{0};
     std::atomic<uint64_t> stat_marks_added_{0};
     std::atomic<uint64_t> stat_marks_cleared_{0};
 
@@ -514,6 +592,11 @@ private:
     Gauge m_tasks_active_;
     Counter m_copy_bytes_total_;
     Gauge m_copy_duration_ms_;
+    Counter m_source_failures_recorded_total_;
+    mutable Counter m_source_retries_suppressed_total_;
+    mutable Counter m_source_switches_total_;
+    mutable Counter m_no_usable_source_total_;
+    Gauge m_source_failure_entries_;
     Gauge m_marks_active_;
     Counter m_marks_consumed_total_;
     Counter m_marks_expired_total_; // 超时过期清除的 mark（与 consumed 区分：浪费 vs 有效消费）

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <exception>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <set>
@@ -342,6 +343,7 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
 
     // delete storage uris
     auto request_context = std::make_shared<RequestContext>("location_del_task_trace");
+    bool all_physical_deletes_succeeded = true;
     for (const auto &storage_uris_pair : delete_uris_by_unique_name) {
         const std::string &storage_unique_name = storage_uris_pair.first;
         const std::vector<DataStorageUri> &storage_uris = storage_uris_pair.second;
@@ -350,15 +352,16 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             data_storage_manager_->Delete(request_context.get(), storage_unique_name, storage_uris, nullptr);
         if (delete_results.size() != storage_uris.size()) {
             result.status = ErrorCode::EC_PARTIAL_OK;
+            all_physical_deletes_succeeded = false;
             result.error_message = StringUtil::FormatString(
                 "storage delete result size %zu != request size %zu", delete_results.size(), storage_uris.size());
             KVCM_LOG_WARN("%s", result.error_message.c_str());
         }
         const auto result_count = std::min(delete_results.size(), storage_uris.size());
         for (size_t i = 0; i < result_count; ++i) {
-            if (delete_results[i] != ErrorCode::EC_OK) {
-                // 这里存储删除报错暂且不管，报个warn表示哪个storageUri删失败了
+            if (delete_results[i] != ErrorCode::EC_OK && delete_results[i] != ErrorCode::EC_NOENT) {
                 result.status = ErrorCode::EC_PARTIAL_OK;
+                all_physical_deletes_succeeded = false;
                 KVCM_LOG_WARN("storage delete failed, instance[%s] storage[%s] uri[%s] ec[%d]",
                               task.instance_id.c_str(),
                               storage_unique_name.c_str(),
@@ -366,6 +369,19 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
                               static_cast<int>(delete_results[i]));
             }
         }
+    }
+
+    if (!all_physical_deletes_succeeded) {
+        // CLS_DELETING metadata is the retry anchor.  Never CAD it while any
+        // URI may still exist; the owner retains the storage reference and
+        // resubmits this exact cleanup through resume_deleting admission.
+        if (result.error_message.empty()) {
+            result.error_message = "one or more physical storage deletes failed";
+        }
+        KVCM_LOG_WARN("retain %zu CLS_DELETING location(s) after physical delete failure for instance %s",
+                      total_locations_to_delete,
+                      task.instance_id.c_str());
+        return result;
     }
 
     // delete locations
@@ -508,8 +524,7 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::SubmitMetaDelete(const Cach
                               guard->operation_id().c_str());
                 continue;
             }
-            cas_tasks.push_back(
-                {loc_kv.first, loc_kv.second->status(), CLS_DELETING, loc_kv.second->ToJsonString()});
+            cas_tasks.push_back({loc_kv.first, loc_kv.second->status(), CLS_DELETING, loc_kv.second->ToJsonString()});
         }
         if (cas_tasks.empty()) {
             continue;
@@ -621,7 +636,7 @@ bool SchedulePlanExecutor::FillActualTask(
 }
 SchedulePlanExecutor::LocationDelAdmissionResult
 SchedulePlanExecutor::PrepareDeleteTask(const CacheMetaDelRequest &task) {
-    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false, false);
+    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false, false, false);
 }
 
 SchedulePlanExecutor::LocationDelAdmissionResult
@@ -653,7 +668,8 @@ SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
                                         expected_location_values,
                                         task.delay,
                                         task.authoritative_read,
-                                        task.prepared_deleting);
+                                        task.prepared_deleting,
+                                        task.resume_deleting);
     result.actual_task.metadata_only = task.metadata_only;
     return result;
 }
@@ -665,7 +681,8 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                                             const std::vector<std::vector<std::string>> *expected_location_values,
                                             std::chrono::microseconds delay,
                                             bool authoritative_read,
-                                            bool prepared_deleting) {
+                                            bool prepared_deleting,
+                                            bool resume_deleting) {
     LocationDelAdmissionResult admission_result;
     admission_result.actual_task = CacheLocationDelRequest{instance_id, {}, {}, delay};
 
@@ -727,8 +744,7 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                     (target_location_ids != nullptr && target_ids.count(location_id) == 0)) {
                     continue;
                 }
-                if (const auto *guard =
-                        FindPersistentMigrationSourcePin(*location_ptr, location_maps[block_key_idx])) {
+                if (const auto *guard = FindPersistentMigrationSourcePin(*location_ptr, location_maps[block_key_idx])) {
                     KVCM_LOG_INFO("skip prepared deletion of migration source pinned by guarded target: instance %s "
                                   "block_key %ld location %s operation %s",
                                   instance_id.c_str(),
@@ -747,13 +763,12 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
         if (admission_result.actual_task.block_keys.empty()) {
             return admission_result;
         }
-        if (!indexer->Sync(admission_result.actual_task.block_keys)) {
-            admission_result.result = MakeErrorResult(
-                EC_ERROR,
-                StringUtil::FormatString(
-                    "Sync failed or timed out for prepared location delete, instance[%s]", instance_id.c_str()));
-            return admission_result;
-        }
+        // prepared_deleting is used only after the caller has durably changed
+        // the exact location to CLS_DELETING and cleared its Copy guard.  There
+        // is no metadata mutation to flush here.  A second Sync could fail after
+        // the authoritative transition already succeeded and strand a
+        // guard-free CLS_DELETING location without ever scheduling its physical
+        // cleanup.
         admission_result.needs_physical_delete = true;
         return admission_result;
     }
@@ -777,12 +792,27 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
         auto block_key = block_keys[block_key_idx];
         auto &location_map = location_maps[block_key_idx];
         std::vector<MetaSearcher::LocationCASTask> location_cas_tasks;
+        std::vector<std::string> already_deleting_location_ids;
         for (const auto &loc_kv : location_map) {
             if (!loc_kv.second) {
                 continue;
             }
             const auto &location = *loc_kv.second;
             if (location.status() == CacheLocationStatus::CLS_DELETING) {
+                if (!resume_deleting || location.has_migration_copy_guard() ||
+                    (target_location_ids != nullptr && target_ids.find(location.id()) == target_ids.end())) {
+                    continue;
+                }
+                if (const auto *guard = FindPersistentMigrationSourcePin(location, location_map)) {
+                    KVCM_LOG_INFO("skip resumed deletion of migration source pinned by guarded target: instance %s "
+                                  "block_key %ld location %s operation %s",
+                                  instance_id.c_str(),
+                                  block_key,
+                                  location.id().c_str(),
+                                  guard->operation_id().c_str());
+                    continue;
+                }
+                already_deleting_location_ids.push_back(location.id());
                 continue;
             }
             // Persistent guards are the cross-restart ownership authority.
@@ -828,6 +858,10 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                                           CacheLocationStatus::CLS_DELETING,
                                           std::move(expected_location_value)});
         }
+        if (!already_deleting_location_ids.empty()) {
+            admission_result.actual_task.block_keys.push_back(block_key);
+            admission_result.actual_task.location_ids.push_back(std::move(already_deleting_location_ids));
+        }
         if (location_cas_tasks.empty()) {
             continue;
         }
@@ -835,6 +869,7 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
         batch_cas_tasks.emplace_back(std::move(location_cas_tasks));
     }
     if (batch_cas_block_keys.empty()) {
+        admission_result.needs_physical_delete = !admission_result.actual_task.block_keys.empty();
         return admission_result;
     }
 
@@ -846,22 +881,39 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
     }
 
     std::string error_message;
-    if (!FillActualTask(
-            batch_cas_block_keys, batch_cas_tasks, batch_results, admission_result.actual_task, error_message)) {
+    CacheLocationDelRequest transitioned_task{instance_id, {}, {}, delay};
+    if (!FillActualTask(batch_cas_block_keys, batch_cas_tasks, batch_results, transitioned_task, error_message)) {
         admission_result.result = MakeErrorResult(
             ErrorCode::EC_ERROR, StringUtil::FormatString("FillActualTask error: %s", error_message.c_str()));
         return admission_result;
     }
-    if (admission_result.actual_task.block_keys.empty()) {
+    if (transitioned_task.block_keys.empty()) {
+        admission_result.needs_physical_delete = !admission_result.actual_task.block_keys.empty();
         return admission_result;
     }
 
-    if (!indexer->Sync(admission_result.actual_task.block_keys)) {
+    if (!indexer->Sync(transitioned_task.block_keys)) {
         admission_result.result =
             MakeErrorResult(ErrorCode::EC_ERROR,
                             StringUtil::FormatString("Sync failed or timed out for location delete, instance[%s]",
                                                      instance_id.c_str()));
         return admission_result;
+    }
+
+    for (size_t i = 0; i < transitioned_task.block_keys.size(); ++i) {
+        const auto block_key = transitioned_task.block_keys[i];
+        auto existing = std::find(
+            admission_result.actual_task.block_keys.begin(), admission_result.actual_task.block_keys.end(), block_key);
+        if (existing == admission_result.actual_task.block_keys.end()) {
+            admission_result.actual_task.block_keys.push_back(block_key);
+            admission_result.actual_task.location_ids.push_back(std::move(transitioned_task.location_ids[i]));
+            continue;
+        }
+        const auto index = static_cast<size_t>(existing - admission_result.actual_task.block_keys.begin());
+        auto &ids = admission_result.actual_task.location_ids[index];
+        ids.insert(ids.end(),
+                   std::make_move_iterator(transitioned_task.location_ids[i].begin()),
+                   std::make_move_iterator(transitioned_task.location_ids[i].end()));
     }
 
     admission_result.needs_physical_delete = true;
@@ -1297,8 +1349,8 @@ AsyncCopyExecuteSubmitResult SchedulePlanExecutor::SubmitAsyncCopy(const CacheLo
     auto remote_submit_promise = std::make_shared<std::promise<AsyncCopyRemoteSubmitResult>>();
     result.remote_submit_future = remote_submit_promise->get_future();
     auto remote_submit_completed = std::make_shared<std::atomic<bool>>(false);
-    auto complete_remote_submit =
-        [remote_submit_promise, remote_submit_completed](AsyncCopyRemoteSubmitResult remote_result) noexcept {
+    auto complete_remote_submit = [remote_submit_promise,
+                                   remote_submit_completed](AsyncCopyRemoteSubmitResult remote_result) noexcept {
             if (remote_submit_completed->exchange(true, std::memory_order_acq_rel)) {
                 KVCM_LOG_ERROR("asynchronous Copy remote-submit promise completed more than once");
                 return;
@@ -1391,8 +1443,7 @@ AsyncCopyExecuteSubmitResult SchedulePlanExecutor::SubmitAsyncCopy(const CacheLo
     return result;
 }
 
-AsyncCopyExecuteSubmitResult SchedulePlanExecutor::ResumeAsyncCopy(
-    const std::string &storage_name,
+AsyncCopyExecuteSubmitResult SchedulePlanExecutor::ResumeAsyncCopy(const std::string &storage_name,
     const std::vector<std::string> &backend_task_ids,
     size_t expected_items,
     const std::string &operation_id,
@@ -1440,9 +1491,7 @@ AsyncCopyExecuteSubmitResult SchedulePlanExecutor::ResumeAsyncCopy(
                 plan_result.terminal = false;
                 plan_result.safe_to_reuse_dst = false;
                 plan_result.error_message = StringUtil::FormatString(
-                    "recovered async Copy returned %zu items, expected %zu",
-                    batch_result.items.size(),
-                    expected_items);
+                    "recovered async Copy returned %zu items, expected %zu", batch_result.items.size(), expected_items);
             } else if (batch_result.AllSucceeded()) {
                 plan_result.status = EC_OK;
             } else if (plan_result.terminal && plan_result.safe_to_reuse_dst) {

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -485,11 +485,31 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::SubmitMetaDelete(const Cach
     std::vector<std::vector<MetaSearcher::LocationCASTask>> batch_cas_tasks;
     for (size_t block_key_idx = 0; block_key_idx < task.block_keys.size(); ++block_key_idx) {
         std::vector<MetaSearcher::LocationCASTask> cas_tasks;
-        for (const auto &loc_kv : location_maps[block_key_idx]) {
+        const auto &location_map = location_maps[block_key_idx];
+        for (const auto &loc_kv : location_map) {
             if (!loc_kv.second) {
                 continue;
             }
-            cas_tasks.push_back({loc_kv.first, loc_kv.second->status(), CLS_DELETING});
+            if (loc_kv.second->has_migration_copy_guard()) {
+                KVCM_LOG_INFO("skip guarded migration target during meta delete: instance %s block_key %ld "
+                              "location %s operation %s",
+                              task.instance_id.c_str(),
+                              task.block_keys[block_key_idx],
+                              loc_kv.second->id().c_str(),
+                              loc_kv.second->migration_copy_guard().operation_id().c_str());
+                continue;
+            }
+            if (const auto *guard = FindPersistentMigrationSourcePin(*loc_kv.second, location_map)) {
+                KVCM_LOG_INFO("skip migration source pinned by guarded target during meta delete: instance %s "
+                              "block_key %ld location %s operation %s",
+                              task.instance_id.c_str(),
+                              task.block_keys[block_key_idx],
+                              loc_kv.second->id().c_str(),
+                              guard->operation_id().c_str());
+                continue;
+            }
+            cas_tasks.push_back(
+                {loc_kv.first, loc_kv.second->status(), CLS_DELETING, loc_kv.second->ToJsonString()});
         }
         if (cas_tasks.empty()) {
             continue;
@@ -601,7 +621,7 @@ bool SchedulePlanExecutor::FillActualTask(
 }
 SchedulePlanExecutor::LocationDelAdmissionResult
 SchedulePlanExecutor::PrepareDeleteTask(const CacheMetaDelRequest &task) {
-    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false);
+    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false, false);
 }
 
 SchedulePlanExecutor::LocationDelAdmissionResult
@@ -632,7 +652,8 @@ SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
                                         &task.location_ids,
                                         expected_location_values,
                                         task.delay,
-                                        task.authoritative_read);
+                                        task.authoritative_read,
+                                        task.prepared_deleting);
     result.actual_task.metadata_only = task.metadata_only;
     return result;
 }
@@ -643,7 +664,8 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                                             const std::vector<std::vector<std::string>> *target_location_ids,
                                             const std::vector<std::vector<std::string>> *expected_location_values,
                                             std::chrono::microseconds delay,
-                                            bool authoritative_read) {
+                                            bool authoritative_read,
+                                            bool prepared_deleting) {
     LocationDelAdmissionResult admission_result;
     admission_result.actual_task = CacheLocationDelRequest{instance_id, {}, {}, delay};
 
@@ -691,6 +713,51 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
         return admission_result;
     }
 
+    if (prepared_deleting) {
+        for (size_t block_key_idx = 0; block_key_idx < block_keys.size(); ++block_key_idx) {
+            std::unordered_set<std::string> target_ids;
+            if (target_location_ids != nullptr) {
+                target_ids.insert((*target_location_ids)[block_key_idx].begin(),
+                                  (*target_location_ids)[block_key_idx].end());
+            }
+            std::vector<std::string> selected;
+            for (const auto &[location_id, location_ptr] : location_maps[block_key_idx]) {
+                if (!location_ptr || location_ptr->status() != CLS_DELETING ||
+                    location_ptr->has_migration_copy_guard() ||
+                    (target_location_ids != nullptr && target_ids.count(location_id) == 0)) {
+                    continue;
+                }
+                if (const auto *guard =
+                        FindPersistentMigrationSourcePin(*location_ptr, location_maps[block_key_idx])) {
+                    KVCM_LOG_INFO("skip prepared deletion of migration source pinned by guarded target: instance %s "
+                                  "block_key %ld location %s operation %s",
+                                  instance_id.c_str(),
+                                  block_keys[block_key_idx],
+                                  location_ptr->id().c_str(),
+                                  guard->operation_id().c_str());
+                    continue;
+                }
+                selected.push_back(location_id);
+            }
+            if (!selected.empty()) {
+                admission_result.actual_task.block_keys.push_back(block_keys[block_key_idx]);
+                admission_result.actual_task.location_ids.push_back(std::move(selected));
+            }
+        }
+        if (admission_result.actual_task.block_keys.empty()) {
+            return admission_result;
+        }
+        if (!indexer->Sync(admission_result.actual_task.block_keys)) {
+            admission_result.result = MakeErrorResult(
+                EC_ERROR,
+                StringUtil::FormatString(
+                    "Sync failed or timed out for prepared location delete, instance[%s]", instance_id.c_str()));
+            return admission_result;
+        }
+        admission_result.needs_physical_delete = true;
+        return admission_result;
+    }
+
     std::vector<int64_t> batch_cas_block_keys;
     std::vector<std::vector<MetaSearcher::LocationCASTask>> batch_cas_tasks;
     // A null target list represents CacheMetaDelRequest and selects every non-deleting location.
@@ -718,6 +785,28 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
             if (location.status() == CacheLocationStatus::CLS_DELETING) {
                 continue;
             }
+            // Persistent guards are the cross-restart ownership authority.
+            // Ordinary business deletion, Reclaimer and GC may not convert a
+            // guarded target to DELETING, regardless of its age or the state of
+            // the process-local active table.
+            if (location.has_migration_copy_guard()) {
+                KVCM_LOG_INFO("skip guarded migration target during location delete: instance %s block_key %ld "
+                              "location %s operation %s",
+                              instance_id.c_str(),
+                              block_key,
+                              location.id().c_str(),
+                              location.migration_copy_guard().operation_id().c_str());
+                continue;
+            }
+            if (const auto *guard = FindPersistentMigrationSourcePin(location, location_map)) {
+                KVCM_LOG_INFO("skip migration source pinned by guarded target during location delete: instance %s "
+                              "block_key %ld location %s operation %s",
+                              instance_id.c_str(),
+                              block_key,
+                              location.id().c_str(),
+                              guard->operation_id().c_str());
+                continue;
+            }
             if (target_location_ids != nullptr && target_ids.find(location.id()) == target_ids.end()) {
                 continue;
             }
@@ -728,6 +817,11 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                     continue; // stable location was refreshed after the cleanup scan
                 }
                 expected_location_value = expected->second;
+            } else {
+                // Always bind the status transition to the exact location
+                // snapshot.  A refresh between admission and CAS must not be
+                // deleted as if it were the older object.
+                expected_location_value = location.ToJsonString();
             }
             location_cas_tasks.push_back({location.id(),
                                           location.status(),
@@ -1191,6 +1285,190 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationC
         return future;
     }
     return future;
+}
+
+AsyncCopyExecuteSubmitResult SchedulePlanExecutor::SubmitAsyncCopy(const CacheLocationCopyRequest &task,
+                                                                   const std::string &operation_id,
+                                                                   const AsyncCopyOptions &options) {
+    AsyncCopyExecuteSubmitResult result;
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    result.future = promise->get_future();
+    auto completion = std::make_shared<PromiseCompletion>(promise);
+    auto remote_submit_promise = std::make_shared<std::promise<AsyncCopyRemoteSubmitResult>>();
+    result.remote_submit_future = remote_submit_promise->get_future();
+    auto remote_submit_completed = std::make_shared<std::atomic<bool>>(false);
+    auto complete_remote_submit =
+        [remote_submit_promise, remote_submit_completed](AsyncCopyRemoteSubmitResult remote_result) noexcept {
+            if (remote_submit_completed->exchange(true, std::memory_order_acq_rel)) {
+                KVCM_LOG_ERROR("asynchronous Copy remote-submit promise completed more than once");
+                return;
+            }
+            try {
+                remote_submit_promise->set_value(std::move(remote_result));
+            } catch (const std::exception &e) {
+                KVCM_LOG_ERROR("complete asynchronous Copy remote-submit promise failed: %s", e.what());
+            } catch (...) {
+                KVCM_LOG_ERROR("complete asynchronous Copy remote-submit promise failed with unknown exception");
+            }
+        };
+
+    auto reject_before_handoff = [&](ErrorCode status, const std::string &detail) {
+        AsyncCopyRemoteSubmitResult remote_result;
+        remote_result.status = status;
+        remote_result.operation_id = operation_id;
+        remote_result.detail = detail;
+        complete_remote_submit(std::move(remote_result));
+    };
+
+    if (stop_) {
+        result.submit_result.status = EC_ERROR;
+        result.submit_result.operation_id = operation_id;
+        result.submit_result.detail = "SchedulePlanExecutor stopped";
+        reject_before_handoff(result.submit_result.status, result.submit_result.detail);
+        completion->Complete(EC_ERROR, result.submit_result.detail);
+        return result;
+    }
+    if (task.src_uris.empty() || task.src_uris.size() != task.dst_uris.size() || operation_id.empty()) {
+        result.submit_result.status = EC_BADARGS;
+        result.submit_result.operation_id = operation_id;
+        result.submit_result.detail = "invalid asynchronous copy request";
+        reject_before_handoff(result.submit_result.status, result.submit_result.detail);
+        completion->Complete(EC_BADARGS, result.submit_result.detail);
+        return result;
+    }
+
+    auto request_context = std::make_shared<RequestContext>("location_async_copy_submit");
+    result.submit_result = data_storage_manager_->CopyAsync(
+        request_context.get(),
+        task.exec_storage_name,
+        task.src_uris,
+        task.dst_uris,
+        operation_id,
+        options,
+        complete_remote_submit,
+        [completion, expected_items = task.src_uris.size()](AsyncCopyBatchResult batch_result) mutable {
+            PlanExecuteResult plan_result;
+            plan_result.status = batch_result.status;
+            plan_result.error_message = std::move(batch_result.detail);
+            plan_result.terminal = batch_result.items.size() == expected_items &&
+                                   std::all_of(batch_result.items.begin(), batch_result.items.end(), [](const auto &x) {
+                                       return x.terminal;
+                                   });
+            plan_result.safe_to_reuse_dst = batch_result.items.size() == expected_items &&
+                                            std::all_of(batch_result.items.begin(),
+                                                        batch_result.items.end(),
+                                                        [](const auto &x) { return x.safe_to_reuse_dst; });
+            if (batch_result.items.size() != expected_items) {
+                plan_result.status = EC_MISMATCH;
+                plan_result.terminal = false;
+                plan_result.safe_to_reuse_dst = false;
+                plan_result.error_message = StringUtil::FormatString(
+                    "async Copy returned %zu items, expected %zu", batch_result.items.size(), expected_items);
+            } else if (batch_result.AllSucceeded()) {
+                plan_result.status = EC_OK;
+            } else if (plan_result.terminal && plan_result.safe_to_reuse_dst) {
+                plan_result.status = EC_PARTIAL_OK;
+            } else {
+                plan_result.status = EC_ERROR;
+            }
+            completion->Complete(std::move(plan_result));
+        });
+
+    if (!result.submit_result.accepted) {
+        AsyncCopyRemoteSubmitResult remote_result;
+        remote_result.status = result.submit_result.status;
+        remote_result.acceptance_unknown = result.submit_result.acceptance_unknown;
+        remote_result.operation_id = operation_id;
+        remote_result.detail = result.submit_result.detail;
+        complete_remote_submit(std::move(remote_result));
+        PlanExecuteResult rejected;
+        rejected.status = result.submit_result.status;
+        rejected.error_message = result.submit_result.detail;
+        rejected.terminal = !result.submit_result.acceptance_unknown;
+        rejected.safe_to_reuse_dst = !result.submit_result.acceptance_unknown;
+        completion->Complete(std::move(rejected));
+    }
+    return result;
+}
+
+AsyncCopyExecuteSubmitResult SchedulePlanExecutor::ResumeAsyncCopy(
+    const std::string &storage_name,
+    const std::vector<std::string> &backend_task_ids,
+    size_t expected_items,
+    const std::string &operation_id,
+    const AsyncCopyOptions &options) {
+    AsyncCopyExecuteSubmitResult result;
+    auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    result.future = promise->get_future();
+    auto completion = std::make_shared<PromiseCompletion>(promise);
+    if (stop_) {
+        result.submit_result.status = EC_ERROR;
+        result.submit_result.operation_id = operation_id;
+        result.submit_result.detail = "SchedulePlanExecutor stopped";
+        completion->Complete(EC_ERROR, result.submit_result.detail);
+        return result;
+    }
+    if (storage_name.empty() || backend_task_ids.empty() || expected_items == 0 || operation_id.empty()) {
+        result.submit_result.status = EC_BADARGS;
+        result.submit_result.operation_id = operation_id;
+        result.submit_result.detail = "invalid asynchronous copy recovery request";
+        completion->Complete(EC_BADARGS, result.submit_result.detail);
+        return result;
+    }
+    auto request_context = std::make_shared<RequestContext>("location_async_copy_recover");
+    result.submit_result = data_storage_manager_->ResumeAsyncCopy(
+        request_context.get(),
+        storage_name,
+        backend_task_ids,
+        expected_items,
+        operation_id,
+        options,
+        [completion, expected_items](AsyncCopyBatchResult batch_result) mutable {
+            PlanExecuteResult plan_result;
+            plan_result.status = batch_result.status;
+            plan_result.error_message = std::move(batch_result.detail);
+            plan_result.terminal = batch_result.items.size() == expected_items &&
+                                   std::all_of(batch_result.items.begin(), batch_result.items.end(), [](const auto &x) {
+                                       return x.terminal;
+                                   });
+            plan_result.safe_to_reuse_dst = batch_result.items.size() == expected_items &&
+                                            std::all_of(batch_result.items.begin(),
+                                                        batch_result.items.end(),
+                                                        [](const auto &x) { return x.safe_to_reuse_dst; });
+            if (batch_result.items.size() != expected_items) {
+                plan_result.status = EC_MISMATCH;
+                plan_result.terminal = false;
+                plan_result.safe_to_reuse_dst = false;
+                plan_result.error_message = StringUtil::FormatString(
+                    "recovered async Copy returned %zu items, expected %zu",
+                    batch_result.items.size(),
+                    expected_items);
+            } else if (batch_result.AllSucceeded()) {
+                plan_result.status = EC_OK;
+            } else if (plan_result.terminal && plan_result.safe_to_reuse_dst) {
+                plan_result.status = EC_PARTIAL_OK;
+            } else {
+                plan_result.status = EC_ERROR;
+            }
+            completion->Complete(std::move(plan_result));
+        });
+    if (!result.submit_result.accepted) {
+        PlanExecuteResult rejected;
+        rejected.status = result.submit_result.status;
+        rejected.error_message = result.submit_result.detail;
+        rejected.terminal = false;
+        rejected.safe_to_reuse_dst = false;
+        completion->Complete(std::move(rejected));
+    }
+    return result;
+}
+
+ErrorCode SchedulePlanExecutor::RequestCancelAsyncCopy(const std::string &storage_name,
+                                                       const std::string &operation_id) {
+    if (stop_ || !data_storage_manager_) {
+        return EC_ERROR;
+    }
+    return data_storage_manager_->RequestCancelAsyncCopy(storage_name, operation_id);
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/data_storage/data_storage_backend.h"
 #include "kv_cache_manager/data_storage/data_storage_uri.h"
 #include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/manager/meta_searcher.h"
@@ -42,8 +43,12 @@ struct CacheMetaDelRequest {
 };
 
 struct PlanExecuteResult {
-    ErrorCode status;
+    ErrorCode status{EC_UNKNOWN};
     std::string error_message;
+    // Sync operations use the safe defaults below.  Native async Copy overrides
+    // them from the backend result.  ErrorCode never authorizes target reuse.
+    bool terminal{true};
+    bool safe_to_reuse_dst{true};
 };
 
 struct AsyncDeleteSubmitResult {
@@ -65,6 +70,11 @@ struct CacheLocationDelRequest {
     // GC physical deletion revalidates against the persistent source of truth
     // and refreshes candidate keys into the hot cache before CAS.
     bool authoritative_read{false};
+    // Internal migration-finalization path only: metadata has already been
+    // conditionally moved to CLS_DELETING and its guard cleared after a remote
+    // `terminal && safe_to_reuse_dst` proof.  Skip the ordinary status CAS and
+    // continue with physical delete + CAD.
+    bool prepared_deleting{false};
 };
 
 struct EventReportMetadataDeleteTarget {
@@ -96,6 +106,15 @@ struct CacheLocationCopyRequest {
     std::vector<DataStorageUri> src_uris; // 源端各 spec 的 uri
     std::vector<DataStorageUri> dst_uris; // 目标端各 spec 预分配的 uri（与 src_uris 一一对应）
     std::chrono::microseconds delay{std::chrono::seconds(0)};
+};
+
+struct AsyncCopyExecuteSubmitResult {
+    AsyncCopySubmitResult submit_result;
+    // Becomes ready after the backend coordinator finishes the short PACE
+    // submit phase.  MigrationManager must persist task ids before treating
+    // the terminal completion future as recoverable.
+    std::future<AsyncCopyRemoteSubmitResult> remote_submit_future;
+    std::future<PlanExecuteResult> future;
 };
 
 // 任务类别同时定义 ready task 的调度优先级。Migration continuation 已经持有活跃
@@ -136,6 +155,15 @@ public:
     std::future<PlanExecuteResult> Submit(const CacheMetaDelRequest &task);
     std::future<PlanExecuteResult> Submit(const CacheLocationDelRequest &task);
     std::future<PlanExecuteResult> Submit(const CacheLocationCopyRequest &task);
+    AsyncCopyExecuteSubmitResult SubmitAsyncCopy(const CacheLocationCopyRequest &task,
+                                                 const std::string &operation_id,
+                                                 const AsyncCopyOptions &options);
+    AsyncCopyExecuteSubmitResult ResumeAsyncCopy(const std::string &storage_name,
+                                                 const std::vector<std::string> &backend_task_ids,
+                                                 size_t expected_items,
+                                                 const std::string &operation_id,
+                                                 const AsyncCopyOptions &options);
+    ErrorCode RequestCancelAsyncCopy(const std::string &storage_name, const std::string &operation_id);
     AsyncDeleteSubmitResult SubmitAsync(const CacheMetaDelRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const CacheLocationDelRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const EventReportMetadataDelRequest &task);
@@ -195,7 +223,8 @@ private:
                           const std::vector<std::vector<std::string>> *target_location_ids,
                           const std::vector<std::vector<std::string>> *expected_location_values,
                           std::chrono::microseconds delay,
-                          bool authoritative_read = false);
+                          bool authoritative_read = false,
+                          bool prepared_deleting = false);
     void RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,
                             std::chrono::microseconds delay,
                             const std::function<LocationDelAdmissionResult()> &prepare,

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -75,6 +75,10 @@ struct CacheLocationDelRequest {
     // `terminal && safe_to_reuse_dst` proof.  Skip the ordinary status CAS and
     // continue with physical delete + CAD.
     bool prepared_deleting{false};
+    // Retry a previously submitted delete without assuming whether its status
+    // transition reached persistent meta. Admission accepts an already
+    // CLS_DELETING location or performs the ordinary exact-snapshot CAS.
+    bool resume_deleting{false};
 };
 
 struct EventReportMetadataDeleteTarget {
@@ -167,6 +171,8 @@ public:
     AsyncDeleteSubmitResult SubmitAsync(const CacheMetaDelRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const CacheLocationDelRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const EventReportMetadataDelRequest &task);
+    std::future<PlanExecuteResult> SubmitLocationDelete(const CacheLocationDelRequest &task,
+                                                        ScheduleTaskClass task_class);
 
     bool SubmitNonBlocking(const CacheMetaDelRequest &req, ScheduleTaskClass task_class = ScheduleTaskClass::kSystem);
     bool SubmitNonBlocking(const CacheLocationDelRequest &req,
@@ -224,7 +230,8 @@ private:
                           const std::vector<std::vector<std::string>> *expected_location_values,
                           std::chrono::microseconds delay,
                           bool authoritative_read = false,
-                          bool prepared_deleting = false);
+                          bool prepared_deleting = false,
+                          bool resume_deleting = false);
     void RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,
                             std::chrono::microseconds delay,
                             const std::function<LocationDelAdmissionResult()> &prepare,
@@ -232,8 +239,6 @@ private:
     AsyncDeleteSubmitResult SubmitDeleteTaskAsync(std::chrono::microseconds delay,
                                                   std::function<LocationDelAdmissionResult()> prepare);
     std::future<PlanExecuteResult> SubmitMetaDelete(const CacheMetaDelRequest &task, ScheduleTaskClass task_class);
-    std::future<PlanExecuteResult> SubmitLocationDelete(const CacheLocationDelRequest &task,
-                                                        ScheduleTaskClass task_class);
     PlanExecuteResult DoLocationDelTask(const CacheLocationDelRequest &task);
     PlanExecuteResult DoEventReportMetadataDelTask(const EventReportMetadataDelRequest &task);
     void DoCopyTask(const std::shared_ptr<std::promise<PlanExecuteResult>> &promise,

--- a/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
+++ b/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
@@ -1257,6 +1257,44 @@ TEST_F(CacheGarbageCollectorTest, ActiveMigrationCopyTargetIsNotCollected) {
     EXPECT_EQ(2, gc->get_cache_gc_candidate_count_metrics());
 }
 
+TEST_F(CacheGarbageCollectorTest, PersistentCopyGuardFencesTargetAndExactSourceWithoutActiveTask) {
+    auto config = DefaultConfig();
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    const int64_t source_create_time = now_us - 100;
+    const std::string source_uri = "dummy://pace_dram/source?size=1";
+    might_exist_by_uri[source_uri] = false;
+
+    auto source = MakeStoredLocation(
+        "source_location", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {source_uri});
+    source->set_create_time(source_create_time);
+    auto target = MakeLocation(
+        "target_location", CLS_WRITING, now_us - config.orphan_writing_grace_period_ms * 1000 - 1);
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_UNKNOWN);
+    guard.set_operation_id("operation-after-restart");
+    guard.set_source_location_id(source->id());
+    guard.set_source_location_create_time(source_create_time);
+    guard.set_source_storage_name("pace_dram");
+    guard.set_target_storage_name("pace_ssd");
+    guard.set_total_bytes(1);
+    target->set_migration_copy_guard(guard);
+
+    CacheLocationMap locations;
+    locations[source->id()] = source;
+    locations[target->id()] = target;
+    const auto request =
+        gc->BuildDeleteActions("instance_a", MakeBatch(SCAN_BASE_CURSOR, {10}, {locations}), now_us)
+            .executor_request;
+
+    EXPECT_TRUE(request.block_keys.empty());
+    EXPECT_TRUE(might_exist_calls.empty());
+    EXPECT_FALSE(gc->IsOrphanWriting(target->id(), *target, now_us));
+}
+
 TEST_F(CacheGarbageCollectorTest, MissingScannedKeyIsNotCountedAsOperationError) {
     auto gc = MakeGc(DefaultConfig());
     PrepareForSingleStep(*gc);

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -405,6 +405,21 @@ MetaIndexer_SampleReclaimKeys_stub(void *obj, RequestContext *rc, const std::int
     return result;
 }
 
+/* ---------------- MetaIndexer_ScanLocationsForMaintenance_stub ---------------- */
+
+ErrorCode MetaIndexer_ScanLocationsForMaintenance_stub(void *,
+                                                       RequestContext *,
+                                                       const std::string &,
+                                                       std::size_t,
+                                                       MaintenanceScanBatch &out) noexcept {
+    // MigrationManager::Start performs a source-of-truth guard recovery scan.
+    // This fixture intentionally uses an uninitialized dummy MetaIndexer, so
+    // expose an empty, completed scan unless an individual test overrides it.
+    out.Clear();
+    out.next_cursor = SCAN_BASE_CURSOR;
+    return ErrorCode::EC_OK;
+}
+
 /* ---------------- MetaIndexer KeyCount stubs ---------------- */
 
 std::size_t key_count;
@@ -468,6 +483,7 @@ public:
         stub_.set(ADDR(MetaIndexer, GetProperties), MetaIndexer_GetProperties_stub);
         stub_.set(ADDR(MetaIndexer, RandomSample), MetaIndexer_RandomSample_stub);
         stub_.set(ADDR(MetaIndexer, SampleReclaimKeys), MetaIndexer_SampleReclaimKeys_stub);
+        stub_.set(ADDR(MetaIndexer, ScanLocationsForMaintenance), MetaIndexer_ScanLocationsForMaintenance_stub);
         stub_.set(ADDR(MetaIndexer, GetKeyCount), MetaIndexer_GetKeyCount_stub);
         stub_.set(ADDR(MetaIndexer, GetMaxKeyCount), MetaIndexer_GetMaxKeyCount_stub);
         stub_.set(ADDR(MetaIndexer, PersistMetaData), MetaIndexer_PersistMetaData_stub);
@@ -669,6 +685,7 @@ public:
         stub_.reset(ADDR(MetaIndexer, GetProperties));
         stub_.reset(ADDR(MetaIndexer, RandomSample));
         stub_.reset(ADDR(MetaIndexer, SampleReclaimKeys));
+        stub_.reset(ADDR(MetaIndexer, ScanLocationsForMaintenance));
         stub_.reset(ADDR(MetaIndexer, GetKeyCount));
         stub_.reset(ADDR(MetaIndexer, GetMaxKeyCount));
         stub_.reset(ADDR(MetaIndexer, PersistMetaData));
@@ -831,6 +848,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     stub_.reset(ADDR(MetaIndexer, GetProperties));
     stub_.reset(ADDR(MetaIndexer, RandomSample));
     stub_.reset(ADDR(MetaIndexer, SampleReclaimKeys));
+    stub_.reset(ADDR(MetaIndexer, ScanLocationsForMaintenance));
     stub_.reset(ADDR(MetaIndexer, GetKeyCount));
     stub_.reset(ADDR(MetaIndexer, GetMaxKeyCount));
     stub_.reset(ADDR(MetaIndexer, PersistMetaData));
@@ -5558,6 +5576,47 @@ TEST_F(CacheReclaimerTest, TestFilterLocIDSkipsActiveWritingLocations) {
     EXPECT_EQ("orphan_writing", out[1][0]);
     EXPECT_TRUE(out[2].empty()) << "active client write location should not be treated as orphan";
     EXPECT_TRUE(out[3].empty()) << "preparing copy target should be protected before location id is bound";
+}
+
+TEST_F(CacheReclaimerTest, TestFilterLocIDHonorsPersistentCopyGuardWithoutActiveTask) {
+    const auto ins_info = InstanceInfoFactory();
+    const int64_t source_create_time = 123;
+    auto source = std::make_shared<CacheLocation>(
+        "persistent_source",
+        CacheLocationStatus::CLS_SERVING,
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://hot/persistent_source")});
+    source->set_create_time(source_create_time);
+    auto target = std::make_shared<CacheLocation>(
+        "persistent_target",
+        CacheLocationStatus::CLS_WRITING,
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/persistent_target")});
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_UNKNOWN);
+    guard.set_operation_id("persistent-operation");
+    guard.set_source_location_id(source->id());
+    guard.set_source_location_create_time(source_create_time);
+    guard.set_source_storage_name("hot");
+    guard.set_target_storage_name("cold");
+    target->set_migration_copy_guard(guard);
+
+    CacheLocationMap loc_map;
+    loc_map.emplace(source->id(), source);
+    loc_map.emplace(target->id(), target);
+    batch_get_loc_out_maps = {loc_map};
+    batch_get_loc_result = ErrorCode::EC_OK;
+
+    CacheReclaimer::WaterLevelExceed wl;
+    wl.SetGroupBytesWaterLevelExceed(true);
+    std::vector<std::vector<std::string>> out;
+    CacheReclaimer::AgeStats age_stats;
+    ASSERT_TRUE(FilterLocations(ins_info, {46}, wl, out, age_stats));
+    ASSERT_EQ(1u, out.size());
+    EXPECT_TRUE(out[0].empty()) << "persistent guard must fence both target and exact source after restart";
 }
 
 /* -------- keep_both 分层淘汰优先级（多副本保冷弃热）stub + test -------- */

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -3802,6 +3802,123 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusChecksExactLocationValue) {
     ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), results);
 }
 
+TEST_F(MetaSearcherTest, TestMigrationCopyGuardExactOwnershipAndRoundTrip) {
+    const MetaSearcher::KeyVector keys = {151};
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(
+                  meta_searcher_.get(), request_context_.get(), keys, {location}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+
+    MigrationCopyGuard submitting;
+    submitting.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    submitting.set_state(MigrationCopyGuardState::MCGS_SUBMITTING);
+    submitting.set_operation_id("operation-151");
+    submitting.set_source_location_id("source-151");
+    submitting.set_source_location_create_time(12345);
+    submitting.set_source_storage_name("pace_dram");
+    submitting.set_target_storage_name("pace_ssd");
+    submitting.set_total_bytes(4096);
+    submitting.set_create_time_us(100);
+    submitting.set_update_time_us(100);
+
+    MetaSearcher::LocationCASTask install;
+    install.location_id = location_ids[0];
+    install.old_status = CLS_WRITING;
+    install.new_status = CLS_WRITING;
+    install.expected_migration_copy_guard_absent = true;
+    install.new_migration_copy_guard = std::make_shared<MigrationCopyGuard>(submitting);
+    std::vector<std::vector<ErrorCode>> results;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchCASLocationStatus(request_context_.get(), keys, {{install}}, results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), results);
+    ASSERT_TRUE(meta_indexer_->Sync(keys));
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    const auto guarded = location_maps[0].at(location_ids[0]);
+    ASSERT_TRUE(guarded->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_SUBMITTING, guarded->migration_copy_guard().state());
+    EXPECT_EQ("operation-151", guarded->migration_copy_guard().operation_id());
+    EXPECT_EQ("source-151", guarded->migration_copy_guard().source_location_id());
+    EXPECT_EQ(4096u, guarded->migration_copy_guard().total_bytes());
+
+    // A second operation cannot steal the first operation's target.
+    MigrationCopyGuard other = submitting;
+    other.set_operation_id("operation-other");
+    auto duplicate_install = install;
+    duplicate_install.new_migration_copy_guard = std::make_shared<MigrationCopyGuard>(other);
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchCASLocationStatus(
+                  request_context_.get(), keys, {{duplicate_install}}, results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), results);
+
+    // Only the exact owner and expected state may attach PACE task handles.
+    MigrationCopyGuard active = submitting;
+    active.set_state(MigrationCopyGuardState::MCGS_ACTIVE);
+    active.set_backend_task_ids({"pace-task-151"});
+    active.set_update_time_us(200);
+    MetaSearcher::LocationCASTask activate;
+    activate.location_id = location_ids[0];
+    activate.old_status = CLS_WRITING;
+    activate.new_status = CLS_WRITING;
+    activate.expected_operation_id = "wrong-operation";
+    activate.expected_migration_copy_guard_state = MigrationCopyGuardState::MCGS_SUBMITTING;
+    activate.new_migration_copy_guard = std::make_shared<MigrationCopyGuard>(active);
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchCASLocationStatus(request_context_.get(), keys, {{activate}}, results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), results);
+
+    activate.expected_operation_id = "operation-151";
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchCASLocationStatus(request_context_.get(), keys, {{activate}}, results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), results);
+
+    MetaSearcher::LocationCASTask finalize;
+    finalize.location_id = location_ids[0];
+    finalize.old_status = CLS_WRITING;
+    finalize.new_status = CLS_SERVING;
+    finalize.expected_operation_id = "operation-151";
+    finalize.expected_migration_copy_guard_state = MigrationCopyGuardState::MCGS_ACTIVE;
+    finalize.clear_migration_copy_guard = true;
+    ASSERT_EQ(EC_OK,
+              meta_searcher_->BatchCASLocationStatus(request_context_.get(), keys, {{finalize}}, results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), results);
+
+    location_maps.clear();
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    const auto serving = location_maps[0].at(location_ids[0]);
+    EXPECT_EQ(CLS_SERVING, serving->status());
+    EXPECT_FALSE(serving->has_migration_copy_guard());
+}
+
+TEST_F(MetaSearcherTest, TestExplicitMalformedOrFutureMigrationGuardFailsClosed) {
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+    std::string base = location->ToJsonString();
+    ASSERT_FALSE(base.empty());
+    ASSERT_EQ('}', base.back());
+    base.pop_back();
+
+    CacheLocation parsed;
+    EXPECT_FALSE(parsed.FromJsonString(base + R"(,"migration_copy_guard":{}})"));
+    EXPECT_FALSE(parsed.FromJsonString(
+        base +
+        R"(,"migration_copy_guard":{"schema_version":2,"state":2,"operation_id":"future-op"}})"));
+    EXPECT_FALSE(parsed.FromJsonString(
+        base +
+        R"(,"migration_copy_guard":{"schema_version":1,"state":99,"operation_id":"bad-state"}})"));
+
+    // A fully understood fence still round-trips normally.
+    EXPECT_TRUE(parsed.FromJsonString(
+        base +
+        R"(,"migration_copy_guard":{"schema_version":1,"state":1,"operation_id":"known-op"}})"));
+    EXPECT_TRUE(parsed.has_migration_copy_guard());
+    EXPECT_EQ("known-op", parsed.migration_copy_guard().operation_id());
+}
+
 TEST_F(MetaSearcherTest, TestBatchCADLocationStatus) {
     // 准备测试数据
     MetaSearcher::KeyVector keys = {400, 500, 600};

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <filesystem>
@@ -12,8 +13,12 @@
 #include "kv_cache_manager/common/request_context.h"
 #include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/config/cache_config.h"
+#include "kv_cache_manager/config/instance_group.h"
+#include "kv_cache_manager/config/instance_info.h"
 #include "kv_cache_manager/config/meta_indexer_config.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
+#include "kv_cache_manager/config/registry_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_manager.h"
 #include "kv_cache_manager/data_storage/data_storage_uri.h"
 #include "kv_cache_manager/event/event_manager.h"
@@ -44,7 +49,61 @@ ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
     }
     return ec;
 }
+
+std::atomic<int> g_guard_sync_call_count{0};
+
+bool FailFirstGuardSyncStub(void * /*obj*/, const KeyVector & /*keys*/) noexcept {
+    return g_guard_sync_call_count.fetch_add(1, std::memory_order_acq_rel) > 0;
+}
 } // namespace
+
+namespace async_guard_recovery_stub {
+std::vector<std::shared_ptr<const InstanceGroup>> groups;
+std::vector<std::shared_ptr<const InstanceInfo>> instances;
+ErrorCode list_groups_result = EC_OK;
+ErrorCode list_instances_result = EC_OK;
+size_t resume_calls = 0;
+std::string resumed_storage;
+std::string resumed_operation_id;
+std::vector<std::string> resumed_task_ids;
+
+std::pair<ErrorCode, std::vector<std::shared_ptr<const InstanceGroup>>>
+ListInstanceGroupStub(void * /*obj*/, RequestContext * /*request_context*/) {
+    return {list_groups_result, groups};
+}
+
+std::pair<ErrorCode, std::vector<std::shared_ptr<const InstanceInfo>>>
+ListInstanceInfoStub(void * /*obj*/, RequestContext * /*request_context*/, const std::string &group_name) {
+    std::vector<std::shared_ptr<const InstanceInfo>> filtered;
+    for (const auto &instance : instances) {
+        if (instance && instance->instance_group_name() == group_name) {
+            filtered.push_back(instance);
+        }
+    }
+    return {list_instances_result, filtered};
+}
+
+AsyncCopyExecuteSubmitResult ResumeAsyncCopyStub(void * /*obj*/,
+                                                 const std::string &storage_name,
+                                                 const std::vector<std::string> &backend_task_ids,
+                                                 size_t /*expected_items*/,
+                                                 const std::string &operation_id,
+                                                 const AsyncCopyOptions & /*options*/) {
+    ++resume_calls;
+    resumed_storage = storage_name;
+    resumed_operation_id = operation_id;
+    resumed_task_ids = backend_task_ids;
+    AsyncCopyExecuteSubmitResult result;
+    result.submit_result.status = EC_OK;
+    result.submit_result.accepted = true;
+    result.submit_result.operation_id = operation_id;
+    result.submit_result.backend_task_ids = backend_task_ids;
+    auto completion = std::make_shared<std::promise<PlanExecuteResult>>();
+    result.future = completion->get_future();
+    completion->set_value(PlanExecuteResult{EC_OK, "", true, true});
+    return result;
+}
+} // namespace async_guard_recovery_stub
 
 // ---- orphan cleanup 测试用 DataStorageManager::Create/Delete 存根 ----
 // 复现"异构 size spec 分散到多个 create_group、某 group 失败使 block ineligible、
@@ -3027,6 +3086,590 @@ TEST_F(MigrationManagerTest, TestCopySuccessClearsSourceFailureBackoff) {
     EXPECT_EQ(0u, mgr.GetStats().source_failure_entries);
 }
 
+TEST_F(MigrationManagerTest, TestGuardRecoveryRebuildsQuarantineAndFailsBeforeClearingOnScanSetupError) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 859;
+    constexpr uint64_t total_bytes = 7;
+    const std::string operation_id = "recovered-unknown-operation";
+
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_UNKNOWN);
+    guard.set_operation_id(operation_id);
+    guard.set_source_location_id("recovered-source");
+    guard.set_source_location_create_time(1);
+    guard.set_source_storage_name("hot_01");
+    guard.set_target_storage_name("cold_01");
+    guard.set_total_bytes(total_bytes);
+    guard.set_backend_task_ids({"pace-recovered-task"});
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_guard_recovery_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/recovered?size=7")});
+    target->set_migration_copy_guard(guard);
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    auto group = std::make_shared<InstanceGroup>();
+    group->set_name("recovery-group");
+    group->set_cache_config(std::make_shared<CacheConfig>());
+    auto instance = std::make_shared<InstanceInfo>();
+    instance->set_instance_id(kInstance);
+    instance->set_instance_group_name(group->name());
+    async_guard_recovery_stub::groups = {group};
+    async_guard_recovery_stub::instances = {instance};
+    async_guard_recovery_stub::list_groups_result = EC_OK;
+    async_guard_recovery_stub::list_instances_result = EC_OK;
+
+    Stub stub;
+    stub.set(ADDR(RegistryManager, ListInstanceGroup), async_guard_recovery_stub::ListInstanceGroupStub);
+    stub.set(ADDR(RegistryManager, ListInstanceInfo), async_guard_recovery_stub::ListInstanceInfoStub);
+    auto registry = std::make_shared<RegistryManager>("", metrics_registry_);
+    MigrationManager mgr(
+        schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, nullptr, registry);
+
+    ASSERT_TRUE(mgr.RecoverAsyncCopyGuards());
+    const auto quarantined = mgr.ListAsyncCopyQuarantine(group->name());
+    ASSERT_EQ(1u, quarantined.size());
+    EXPECT_EQ(operation_id, quarantined[0].guard.operation_id());
+    EXPECT_EQ(total_bytes, mgr.GetStats().async_copy_quarantine_bytes);
+    EXPECT_EQ(0u, mgr.GetStats().async_copy_inflight_operations);
+
+    // A later setup/list failure must return before replacing the previously
+    // rebuilt accounting tables; leader code will demote instead of serving a
+    // false-empty quarantine view.
+    async_guard_recovery_stub::list_groups_result = EC_ERROR;
+    EXPECT_FALSE(mgr.RecoverAsyncCopyGuards());
+    EXPECT_EQ(1u, mgr.ListAsyncCopyQuarantine(group->name()).size());
+
+    async_guard_recovery_stub::groups.clear();
+    async_guard_recovery_stub::instances.clear();
+    async_guard_recovery_stub::list_groups_result = EC_OK;
+    async_guard_recovery_stub::list_instances_result = EC_OK;
+}
+
+TEST_F(MigrationManagerTest, TestGuardRecoveryResumesActiveTaskWithPersistedHandles) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 860;
+    const std::string operation_id = "recovered-active-operation";
+    const std::vector<std::string> task_ids = {"pace-recovered-active-task"};
+
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_ACTIVE);
+    guard.set_operation_id(operation_id);
+    guard.set_source_location_id("recovered-active-source");
+    guard.set_source_location_create_time(1);
+    guard.set_source_storage_name("hot_01");
+    guard.set_target_storage_name("cold_01");
+    guard.set_total_bytes(7);
+    guard.set_backend_task_ids(task_ids);
+    guard.set_create_time_us(TimestampUtil::GetCurrentTimeUs());
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_guard_recovery_active_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/recovered-active?size=7")});
+    target->set_migration_copy_guard(guard);
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    auto group = std::make_shared<InstanceGroup>();
+    group->set_name("recovery-active-group");
+    group->set_cache_config(std::make_shared<CacheConfig>());
+    auto instance = std::make_shared<InstanceInfo>();
+    instance->set_instance_id(kInstance);
+    instance->set_instance_group_name(group->name());
+    async_guard_recovery_stub::groups = {group};
+    async_guard_recovery_stub::instances = {instance};
+    async_guard_recovery_stub::list_groups_result = EC_OK;
+    async_guard_recovery_stub::list_instances_result = EC_OK;
+    async_guard_recovery_stub::resume_calls = 0;
+    async_guard_recovery_stub::resumed_storage.clear();
+    async_guard_recovery_stub::resumed_operation_id.clear();
+    async_guard_recovery_stub::resumed_task_ids.clear();
+
+    Stub stub;
+    stub.set(ADDR(RegistryManager, ListInstanceGroup), async_guard_recovery_stub::ListInstanceGroupStub);
+    stub.set(ADDR(RegistryManager, ListInstanceInfo), async_guard_recovery_stub::ListInstanceInfoStub);
+    stub.set(ADDR(SchedulePlanExecutor, ResumeAsyncCopy), async_guard_recovery_stub::ResumeAsyncCopyStub);
+    auto registry = std::make_shared<RegistryManager>("", metrics_registry_);
+    MigrationManager mgr(
+        schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, nullptr, registry);
+
+    ASSERT_TRUE(mgr.RecoverAsyncCopyGuards());
+    EXPECT_EQ(1u, async_guard_recovery_stub::resume_calls);
+    EXPECT_EQ("hot_01", async_guard_recovery_stub::resumed_storage);
+    EXPECT_EQ(operation_id, async_guard_recovery_stub::resumed_operation_id);
+    EXPECT_EQ(task_ids, async_guard_recovery_stub::resumed_task_ids);
+    EXPECT_TRUE(mgr.HasMigrationTask(kInstance, block_key));
+    EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(group->name()).empty());
+    EXPECT_EQ(1u, mgr.GetStats().async_copy_inflight_operations);
+
+    async_guard_recovery_stub::groups.clear();
+    async_guard_recovery_stub::instances.clear();
+}
+
+TEST_F(MigrationManagerTest, TestRemoteAsyncAcceptancePersistsActiveTaskHandles) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "async_accept_hot/"));
+    const int64_t block_key = 86;
+    const std::string source_id = CreateSourceLocation(block_key, "hot_01", false, "payload");
+    const auto source = GetLocation(block_key, source_id);
+    ASSERT_TRUE(source);
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_accept_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/target?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+    ASSERT_EQ(1u, target_ids.size());
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = source_id;
+    ctx.src_create_time = source->create_time();
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "async-operation-86";
+    ctx.async_guard_create_time_us = 100;
+    ctx.total_bytes = 7;
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(
+                  ctx, MigrationCopyGuardState::MCGS_NONE, MigrationCopyGuardState::MCGS_SUBMITTING, {}, ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+
+    AsyncCopyRemoteSubmitResult remote;
+    remote.status = EC_OK;
+    remote.accepted = true;
+    remote.operation_id = ctx.async_operation_id;
+    remote.backend_task_ids = {"pace-task-86"};
+    MigrationManager::CopyTaskContext accepted_ctx;
+    bool cancel_requested = true;
+    ASSERT_TRUE(mgr.PersistRemoteAsyncCopyAcceptance(
+        kInstance, block_key, remote, accepted_ctx, cancel_requested));
+    EXPECT_FALSE(cancel_requested);
+    EXPECT_EQ(remote.backend_task_ids, accepted_ctx.async_backend_task_ids);
+
+    const auto guarded_target = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(guarded_target);
+    ASSERT_TRUE(guarded_target->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_ACTIVE, guarded_target->migration_copy_guard().state());
+    EXPECT_EQ(remote.backend_task_ids, guarded_target->migration_copy_guard().backend_task_ids());
+}
+
+TEST_F(MigrationManagerTest, TestCancellationBeforeRemoteAcceptanceCannotBeOverwrittenByActive) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "async_cancel_hot/"));
+    const int64_t block_key = 87;
+    const std::string source_id = CreateSourceLocation(block_key, "hot_01", false, "payload");
+    const auto source = GetLocation(block_key, source_id);
+    ASSERT_TRUE(source);
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_cancel_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/target?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = source_id;
+    ctx.src_create_time = source->create_time();
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "async-operation-87";
+    ctx.async_guard_create_time_us = 100;
+    ctx.total_bytes = 7;
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(
+                  ctx, MigrationCopyGuardState::MCGS_NONE, MigrationCopyGuardState::MCGS_SUBMITTING, {}, ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+
+    ASSERT_EQ(EC_OK, mgr.Cancel(kInstance, block_key));
+    AsyncCopyRemoteSubmitResult remote;
+    remote.status = EC_OK;
+    remote.accepted = true;
+    remote.operation_id = ctx.async_operation_id;
+    remote.backend_task_ids = {"pace-task-87"};
+    MigrationManager::CopyTaskContext accepted_ctx;
+    bool cancel_requested = false;
+    ASSERT_TRUE(mgr.PersistRemoteAsyncCopyAcceptance(
+        kInstance, block_key, remote, accepted_ctx, cancel_requested));
+    EXPECT_TRUE(cancel_requested);
+
+    // Every non-initial guard transition checks both operation-id and state.
+    // A stale ACTIVE writer must not regress the durable CANCELLING intent.
+    EXPECT_EQ(MigrationManager::GuardMutationResult::kNotApplied,
+              mgr.UpdateAsyncCopyGuard(accepted_ctx,
+                                       MigrationCopyGuardState::MCGS_ACTIVE,
+                                       MigrationCopyGuardState::MCGS_UNKNOWN,
+                                       remote.backend_task_ids,
+                                       "stale-active-writer"));
+
+    const auto guarded_target = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(guarded_target);
+    ASSERT_TRUE(guarded_target->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_CANCELLING, guarded_target->migration_copy_guard().state());
+    EXPECT_EQ(remote.backend_task_ids, guarded_target->migration_copy_guard().backend_task_ids());
+}
+
+TEST_F(MigrationManagerTest, TestCancelAndCompletionHaveExactlyOneTerminalOwner) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "async_race_cold/"));
+    constexpr int64_t block_key = 871;
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_cancel_completion_race");
+    auto target =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                        1,
+                                        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold_01/race?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "group-race";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = "source-race";
+    ctx.src_create_time = 1;
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "async-operation-race";
+    ctx.async_backend_task_ids = {"pace-task-race"};
+    ctx.async_credit_active = true;
+    ctx.total_bytes = 7;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(ctx,
+                                       MigrationCopyGuardState::MCGS_NONE,
+                                       MigrationCopyGuardState::MCGS_ACTIVE,
+                                       ctx.async_backend_task_ids,
+                                       ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    ASSERT_TRUE(mgr.RestoreAsyncCopyInflightCredit(ctx));
+
+    const auto transition_mutex = mgr.GetAsyncTransitionMutex(kInstance, block_key);
+    ASSERT_TRUE(transition_mutex);
+    std::unique_lock<std::mutex> hold_transition(*transition_mutex);
+    std::atomic<int> ready{0};
+    auto cancel = std::async(std::launch::async, [&]() {
+        ready.fetch_add(1, std::memory_order_release);
+        return mgr.Cancel(kInstance, block_key);
+    });
+    auto completion = std::async(std::launch::async, [&]() {
+        ready.fetch_add(1, std::memory_order_release);
+        return mgr.OnTaskFailed(kInstance, block_key, EC_ERROR);
+    });
+    while (ready.load(std::memory_order_acquire) != 2) {
+        std::this_thread::yield();
+    }
+    hold_transition.unlock();
+
+    const ErrorCode cancel_result = cancel.get();
+    EXPECT_TRUE(cancel_result == EC_OK || cancel_result == EC_EXIST || cancel_result == EC_NOENT);
+    EXPECT_TRUE(completion.get());
+    EXPECT_FALSE(mgr.HasMigrationTask(kInstance, block_key));
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(1u, stats.copy_failed + stats.copy_cancelled);
+    EXPECT_EQ(0u, stats.async_copy_inflight_operations);
+    EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
+
+    const auto persisted = GetLocation(block_key, target_ids[0]);
+    if (persisted) {
+        EXPECT_EQ(CLS_DELETING, persisted->status());
+        EXPECT_FALSE(persisted->has_migration_copy_guard());
+    }
+}
+
+TEST_F(MigrationManagerTest, TestAppliedFinalizationRetriesOnlySyncWithoutPhantomQuarantine) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "async_sync_retry_hot/"));
+    constexpr int64_t block_key = 872;
+    const std::string source_id = CreateSourceLocation(block_key, "hot_01", false, "payload");
+    const auto source = GetLocation(block_key, source_id);
+    ASSERT_TRUE(source);
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_guard_sync_retry");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/sync-retry?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "group-sync-retry";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = source_id;
+    ctx.src_create_time = source->create_time();
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.retention = MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH;
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "async-operation-sync-retry";
+    ctx.async_backend_task_ids = {"pace-task-sync-retry"};
+    ctx.async_credit_active = true;
+    ctx.total_bytes = 7;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(ctx,
+                                       MigrationCopyGuardState::MCGS_NONE,
+                                       MigrationCopyGuardState::MCGS_ACTIVE,
+                                       ctx.async_backend_task_ids,
+                                       ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    ASSERT_TRUE(mgr.RestoreAsyncCopyInflightCredit(ctx));
+
+    Stub stub;
+    g_guard_sync_call_count.store(0, std::memory_order_release);
+    stub.set(ADDR(MetaIndexer, Sync), FailFirstGuardSyncStub);
+
+    EXPECT_FALSE(mgr.OnTaskSuccess(kInstance, block_key));
+    const auto applied = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(applied);
+    EXPECT_EQ(CLS_SERVING, applied->status());
+    EXPECT_FALSE(applied->has_migration_copy_guard());
+    EXPECT_TRUE(mgr.HasMigrationTask(kInstance, block_key));
+    EXPECT_EQ(1u, mgr.GetStats().async_copy_inflight_operations);
+    EXPECT_EQ(0u, mgr.GetStats().async_copy_quarantine_operations);
+
+    EXPECT_TRUE(mgr.OnTaskSuccess(kInstance, block_key));
+    EXPECT_FALSE(mgr.HasMigrationTask(kInstance, block_key));
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(1u, stats.copy_completed);
+    EXPECT_EQ(0u, stats.copy_failed);
+    EXPECT_EQ(0u, stats.async_copy_unknown);
+    EXPECT_EQ(0u, stats.async_copy_inflight_operations);
+    EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
+}
+
+TEST_F(MigrationManagerTest, TestDefinitePreSubmitFailureDoesNotEnterRemoteUnknownQuarantine) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 88;
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("pre_submit_failure_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/target?size=7")});
+    MigrationCopyGuard other_guard;
+    other_guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    other_guard.set_state(MigrationCopyGuardState::MCGS_SUBMITTING);
+    other_guard.set_operation_id("persisted-other-operation");
+    target->set_migration_copy_guard(other_guard);
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "group-88";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = "source-88";
+    ctx.src_create_time = 88;
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "never-submitted-operation";
+    ctx.async_credit_active = true;
+    ctx.total_bytes = 7;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    mgr.RestoreAsyncCopyInflightCredit(ctx);
+    ASSERT_EQ(1u, mgr.GetStats().async_copy_inflight_operations);
+
+    // The exact-owner finalize intentionally fails because the persisted
+    // guard belongs to another operation.  Since no backend handoff happened,
+    // this must release local admission credit without inventing a remote
+    // UNKNOWN operation or deleting the other owner's target.
+    mgr.CompleteCopyTaskAsFailed(ctx, "guard_install_failed_before_submit", false);
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(0u, stats.async_copy_inflight_operations);
+    EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
+    EXPECT_EQ(0u, stats.async_copy_unknown);
+    EXPECT_EQ(0u, stats.active_copy_tasks);
+
+    const auto persisted = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(persisted);
+    ASSERT_TRUE(persisted->has_migration_copy_guard());
+    EXPECT_EQ("persisted-other-operation", persisted->migration_copy_guard().operation_id());
+    EXPECT_EQ(CLS_WRITING, persisted->status());
+}
+
+TEST_F(MigrationManagerTest, TestBreakGlassReleaseRequiresUnknownGuardAndClearsQuarantine) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "break_glass_cold/"));
+    constexpr int64_t block_key = 89;
+    constexpr uint64_t total_bytes = 7;
+    const std::string operation_id = "async-operation-89";
+    const std::string group_name = "group-89";
+
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_UNKNOWN);
+    guard.set_operation_id(operation_id);
+    guard.set_source_location_id("source-89");
+    guard.set_source_location_create_time(89);
+    guard.set_source_storage_name("hot_01");
+    guard.set_target_storage_name("cold_01");
+    guard.set_total_bytes(total_bytes);
+    guard.set_backend_task_ids({"pace-task-89"});
+    guard.set_last_error("remote_terminal_state_unknown");
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("break_glass_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold_01/target-89?size=7")});
+    target->set_migration_copy_guard(guard);
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+    ASSERT_EQ(1u, target_ids.size());
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    {
+        std::lock_guard<std::mutex> lock(mgr.async_copy_usage_mutex_);
+        mgr.async_copy_quarantine_by_operation_.emplace(
+            operation_id,
+            MigrationManager::AsyncCopyQuarantineRecord{
+                group_name, kInstance, block_key, target_ids[0], guard});
+        auto &usage = mgr.async_copy_usage_by_group_[group_name];
+        usage.quarantine_operations = 1;
+        usage.quarantine_bytes = total_bytes;
+    }
+
+    ASSERT_EQ(1u, mgr.ListAsyncCopyQuarantine(group_name).size());
+    EXPECT_EQ(EC_BADARGS, mgr.BreakGlassReleaseAsyncCopy(operation_id, "", "ticket-89"));
+    EXPECT_EQ(EC_NOENT, mgr.BreakGlassReleaseAsyncCopy("missing-operation", "operator-89", "ticket-89"));
+    EXPECT_EQ(EC_OK, mgr.BreakGlassReleaseAsyncCopy(operation_id, "operator-89", "ticket-89"));
+    EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(group_name).empty());
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
+    EXPECT_EQ(0u, stats.async_copy_quarantine_bytes);
+
+    // The exact-owner CAS must clear the durable guard before the asynchronous
+    // target deletion is handed to SchedulePlanExecutor.  Depending on worker
+    // timing the location is either already gone or observably DELETING, but it
+    // must never remain a reusable WRITING location with a silently erased guard.
+    const auto released = GetLocation(block_key, target_ids[0]);
+    if (released) {
+        EXPECT_EQ(CLS_DELETING, released->status());
+        EXPECT_FALSE(released->has_migration_copy_guard());
+    }
+}
+
+TEST_F(MigrationManagerTest, TestBreakGlassRejectsPersistentStateOrOperationMismatch) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("break_glass_mismatch_targets");
+
+    auto make_guard = [](const std::string &operation_id, MigrationCopyGuardState state) {
+        MigrationCopyGuard guard;
+        guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+        guard.set_state(state);
+        guard.set_operation_id(operation_id);
+        guard.set_source_location_id("source-mismatch");
+        guard.set_source_location_create_time(1);
+        guard.set_source_storage_name("hot_01");
+        guard.set_target_storage_name("cold_01");
+        guard.set_total_bytes(7);
+        guard.set_backend_task_ids({"pace-task-mismatch"});
+        return guard;
+    };
+    auto active_target =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+                                        1,
+                                        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/active?size=7")});
+    active_target->set_migration_copy_guard(make_guard("active-state-operation", MigrationCopyGuardState::MCGS_ACTIVE));
+    auto other_owner_target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/other-owner?size=7")});
+    other_owner_target->set_migration_copy_guard(
+        make_guard("persistent-other-operation", MigrationCopyGuardState::MCGS_UNKNOWN));
+
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(
+        EC_OK,
+        BatchAddLocationForTest(&searcher, rc.get(), {890, 891}, {active_target, other_owner_target}, target_ids));
+    ASSERT_EQ(2u, target_ids.size());
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    const auto active_record_guard = make_guard("active-state-operation", MigrationCopyGuardState::MCGS_UNKNOWN);
+    const auto wrong_owner_record_guard = make_guard("recorded-operation", MigrationCopyGuardState::MCGS_UNKNOWN);
+    {
+        std::lock_guard<std::mutex> lock(mgr.async_copy_usage_mutex_);
+        mgr.async_copy_quarantine_by_operation_.emplace(
+            "active-state-operation",
+            MigrationManager::AsyncCopyQuarantineRecord{
+                "group-mismatch", kInstance, 890, target_ids[0], active_record_guard});
+        mgr.async_copy_quarantine_by_operation_.emplace(
+            "recorded-operation",
+            MigrationManager::AsyncCopyQuarantineRecord{
+                "group-mismatch", kInstance, 891, target_ids[1], wrong_owner_record_guard});
+        auto &usage = mgr.async_copy_usage_by_group_["group-mismatch"];
+        usage.quarantine_operations = 2;
+        usage.quarantine_bytes = 14;
+    }
+
+    EXPECT_EQ(EC_MISMATCH,
+              mgr.BreakGlassReleaseAsyncCopy("active-state-operation", "operator", "external-terminal-proof"));
+    EXPECT_EQ(EC_MISMATCH, mgr.BreakGlassReleaseAsyncCopy("recorded-operation", "operator", "external-terminal-proof"));
+    EXPECT_EQ(2u, mgr.ListAsyncCopyQuarantine("group-mismatch").size());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_ACTIVE, GetLocation(890, target_ids[0])->migration_copy_guard().state());
+    EXPECT_EQ("persistent-other-operation", GetLocation(891, target_ids[1])->migration_copy_guard().operation_id());
+}
+
 // 多个 target location 分别覆盖不同 specs，联合覆盖完整时不应 kAccept。
 TEST_F(MigrationManagerTest, TestCheckCopyAdmissionUnionCoverage) {
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
@@ -3134,6 +3777,120 @@ TEST_F(MigrationManagerTest, TestStopDropsActiveTasks) {
     ASSERT_FALSE(mgr.HasMigrationTask(kInstance, 1001));
     ASSERT_EQ(0u, mgr.ActiveTaskCount());
     mgr.Stop();
+}
+
+TEST_F(MigrationManagerTest, TestStopDetachesRecoverableAsyncCopyWithoutQuarantine) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 1003;
+    constexpr uint64_t total_bytes = 7;
+    const std::string operation_id = "stop-detach-operation";
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("stop_detach_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/stop-detach?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+    ASSERT_EQ(1u, target_ids.size());
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    ASSERT_EQ(EC_OK, mgr.Start());
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "stop-detach-group";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = "stop-detach-source";
+    ctx.src_create_time = 1;
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = operation_id;
+    ctx.async_backend_task_ids = {"pace-stop-detach-task"};
+    ctx.async_credit_active = true;
+    ctx.async_guard_create_time_us = TimestampUtil::GetCurrentTimeUs();
+    ctx.total_bytes = total_bytes;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(ctx,
+                                       MigrationCopyGuardState::MCGS_NONE,
+                                       MigrationCopyGuardState::MCGS_ACTIVE,
+                                       ctx.async_backend_task_ids,
+                                       ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    ASSERT_TRUE(mgr.RestoreAsyncCopyInflightCredit(ctx));
+
+    mgr.Stop();
+
+    EXPECT_EQ(0u, mgr.ActiveTaskCount());
+    EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(ctx.instance_group_name).empty());
+    const auto persisted = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(persisted);
+    ASSERT_TRUE(persisted->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_ACTIVE, persisted->migration_copy_guard().state());
+    EXPECT_EQ(operation_id, persisted->migration_copy_guard().operation_id());
+    EXPECT_EQ(ctx.async_backend_task_ids, persisted->migration_copy_guard().backend_task_ids());
+}
+
+TEST_F(MigrationManagerTest, TestStopQuarantinesSubmittingAsyncCopyWithoutTaskIds) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 1004;
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("stop_submitting_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/stop-submitting?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+    ASSERT_EQ(1u, target_ids.size());
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    ASSERT_EQ(EC_OK, mgr.Start());
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "stop-submitting-group";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = "stop-submitting-source";
+    ctx.src_create_time = 1;
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "stop-submitting-operation";
+    ctx.async_credit_active = true;
+    ctx.async_guard_create_time_us = TimestampUtil::GetCurrentTimeUs();
+    ctx.total_bytes = 7;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(ctx,
+                                       MigrationCopyGuardState::MCGS_NONE,
+                                       MigrationCopyGuardState::MCGS_SUBMITTING,
+                                       {},
+                                       ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    ASSERT_TRUE(mgr.RestoreAsyncCopyInflightCredit(ctx));
+
+    mgr.Stop();
+
+    const auto quarantined = mgr.ListAsyncCopyQuarantine(ctx.instance_group_name);
+    ASSERT_EQ(1u, quarantined.size());
+    EXPECT_EQ(ctx.async_operation_id, quarantined[0].guard.operation_id());
+    const auto persisted = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(persisted);
+    ASSERT_TRUE(persisted->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_UNKNOWN, persisted->migration_copy_guard().state());
 }
 
 // GetActiveBlockKeysForInstance 返回指定 instance 的活跃 block_key 列表（用于 drain 前 BatchCancel）。

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -55,6 +55,8 @@ std::atomic<int> g_guard_sync_call_count{0};
 bool FailFirstGuardSyncStub(void * /*obj*/, const KeyVector & /*keys*/) noexcept {
     return g_guard_sync_call_count.fetch_add(1, std::memory_order_acq_rel) > 0;
 }
+
+bool AlwaysFailGuardSyncStub(void * /*obj*/, const KeyVector & /*keys*/) noexcept { return false; }
 } // namespace
 
 namespace async_guard_recovery_stub {
@@ -225,8 +227,8 @@ std::vector<std::pair<ErrorCode, DataStorageUri>> Create_stub(void * /*obj*/,
             results.emplace_back(EC_ERROR, DataStorageUri{});
             continue;
         }
-        results.emplace_back(
-            EC_OK, DataStorageUri("dummy://" + name + "/" + keys[i] + "?size=" + std::to_string(size)));
+        results.emplace_back(EC_OK,
+                             DataStorageUri("dummy://" + name + "/" + keys[i] + "?size=" + std::to_string(size)));
     }
     return results;
 }
@@ -491,8 +493,7 @@ public:
             loc->set_create_time(create_time);
         }
         std::vector<std::string> ids;
-        EXPECT_EQ(
-            ErrorCode::EC_OK, BatchAddLocationForTest(&meta_searcher, rc.get(), {block_key}, {loc}, ids));
+        EXPECT_EQ(ErrorCode::EC_OK, BatchAddLocationForTest(&meta_searcher, rc.get(), {block_key}, {loc}, ids));
         EXPECT_EQ(1u, ids.size());
         // BatchAddLocation 写入 CLS_WRITING，CAS 到 SERVING 模拟一个已就绪的源副本。
         std::vector<std::vector<MetaSearcher::LocationCASTask>> cas{
@@ -587,7 +588,8 @@ public:
         auto rc = std::make_shared<RequestContext>("delete_location_meta");
         MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kInstance));
         std::vector<std::vector<ErrorCode>> results;
-        ASSERT_EQ(ErrorCode::EC_OK, meta_searcher.BatchDeleteLocations(rc.get(), {block_key}, {{location_id}}, results));
+        ASSERT_EQ(ErrorCode::EC_OK,
+                  meta_searcher.BatchDeleteLocations(rc.get(), {block_key}, {{location_id}}, results));
     }
 
     template <typename Pred>
@@ -850,7 +852,8 @@ TEST_F(MigrationManagerTest, TestClearMarkDoesNotClobberNewerMark) {
     auto event_manager = std::make_shared<EventManager>();
     ASSERT_TRUE(event_manager->Init());
     ASSERT_TRUE(event_manager->RegisterPublisher("capture", event_publisher));
-    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, event_manager);
+    MigrationManager mgr(
+        schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, event_manager);
     mgr.Start();
 
     // 打 mark A: target=cold_01
@@ -934,11 +937,7 @@ TEST_F(MigrationManagerTest, TestMarkConsumedEventIncludesTargetStorage) {
     ASSERT_TRUE(event_manager->Init());
     auto publisher = std::make_shared<CaptureEventPublisher>();
     ASSERT_TRUE(event_manager->RegisterPublisher("capture", publisher));
-    MigrationManager mgr(schedule_plan_executor_,
-                         meta_manager_,
-                         data_storage_manager_,
-                         nullptr,
-                         event_manager);
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, nullptr, event_manager);
 
     ASSERT_EQ(ErrorCode::EC_OK, mgr.MarkForTieredWrite(kInstance, {4}, "cold_01"));
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -1455,16 +1454,14 @@ TEST_F(MigrationManagerTest, TestCancelWhileCompletingIsTooLate) {
     // 直接把状态置 kCompleting，模拟 monitor 正在收尾的窗口（测试经 -fno-access-control 访问私有）。
     {
         std::lock_guard<std::mutex> lock(mgr.task_mutex_);
-        mgr.active_tasks_by_instance_[kInstance][block_key].state =
-            MigrationManager::CopyTaskState::kCompleting;
+        mgr.active_tasks_by_instance_[kInstance][block_key].state = MigrationManager::CopyTaskState::kCompleting;
     }
     ASSERT_EQ(ErrorCode::EC_EXIST, mgr.Cancel(kInstance, block_key)); // 太晚
 
     // 复位为 kRunning 让完成路径正常收尾（验证迁移照常完成）。
     {
         std::lock_guard<std::mutex> lock(mgr.task_mutex_);
-        mgr.active_tasks_by_instance_[kInstance][block_key].state =
-            MigrationManager::CopyTaskState::kRunning;
+        mgr.active_tasks_by_instance_[kInstance][block_key].state = MigrationManager::CopyTaskState::kRunning;
     }
     mgr.OnTaskSuccess(kInstance, block_key);
     ASSERT_EQ(CLS_SERVING, GetLocationStatus(block_key, dst_loc)); // 正常提升
@@ -1877,8 +1874,9 @@ TEST_F(MigrationManagerTest, TestBatchReservesAllBeforeCreateAndDeduplicates) {
     Stub stub;
     stub.set(ADDR(DataStorageManager, Create), preparing_reservation_stub::Create_stub);
 
-    auto results = mgr.BatchSubmit(
-        "batch_preparing_reservation", {first, duplicate, second}, MigrationManager::CopyConcurrencyLimit{"group_a", 2});
+    auto results = mgr.BatchSubmit("batch_preparing_reservation",
+                                   {first, duplicate, second},
+                                   MigrationManager::CopyConcurrencyLimit{"group_a", 2});
     ASSERT_EQ(3u, results.size());
     ASSERT_EQ(EC_OK, results[0]);
     ASSERT_EQ(EC_EXIST, results[1]);
@@ -1954,8 +1952,7 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCo
         req.src_location_id = "src_" + std::to_string(block_key);
         req.src_storage_name = "hot_01";
         req.dst_storage_name = "cold_01";
-        req.src_specs = {
-            LocationSpec("TP0", "dummy://hot_01/src_" + std::to_string(block_key) + "?size=4")};
+        req.src_specs = {LocationSpec("TP0", "dummy://hot_01/src_" + std::to_string(block_key) + "?size=4")};
         return req;
     };
 
@@ -1973,8 +1970,7 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCo
     const auto results =
         mgr.BatchSubmit("batch_add_location_partial", {make_request(block_keys[0]), make_request(block_keys[1])});
     ASSERT_EQ(2u, results.size());
-    ASSERT_TRUE((results[0] == EC_OK && results[1] == EC_NOSPC) ||
-                (results[1] == EC_OK && results[0] == EC_NOSPC));
+    ASSERT_TRUE((results[0] == EC_OK && results[1] == EC_NOSPC) || (results[1] == EC_OK && results[0] == EC_NOSPC));
 
     const std::size_t success_index = results[0] == EC_OK ? 0 : 1;
     const std::size_t failed_index = 1 - success_index;
@@ -1991,10 +1987,11 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCo
 
     // 统一口径：add 成功项已提交 executor（stub pending future），计入其 4 字节；
     // add 失败项（EC_NOSPC）已回滚且未提交，不计入。
-    EXPECT_EQ(4u,
-              metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total",
-                                            {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)},
-                                             {"unique_name", "cold_01"}})
+    EXPECT_EQ(
+        4u,
+        metrics_registry_
+            ->GetCounter("data_storage.write_bytes_dispatched_total",
+                         {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)}, {"unique_name", "cold_01"}})
                   .Get());
 }
 
@@ -2236,8 +2233,8 @@ TEST_F(MigrationManagerTest, TestConcurrentBatchSubmitDoesNotOverissueGroupLimit
         return;
     }
 
-    auto second =
-        std::async(std::launch::async, [&]() { return mgr.BatchSubmit("concurrent_limit_second", {second_req}, limit); });
+    auto second = std::async(std::launch::async,
+                             [&]() { return mgr.BatchSubmit("concurrent_limit_second", {second_req}, limit); });
     const auto second_status_before_release = second.wait_for(std::chrono::seconds(5));
     const int create_calls_before_release = submission_concurrency_stub::CreateCallCount();
     submission_concurrency_stub::ReleaseFirstCreate();
@@ -2257,10 +2254,8 @@ TEST_F(MigrationManagerTest, TestConcurrentBatchSubmitDoesNotOverissueGroupLimit
 TEST_F(MigrationManagerTest, TestBatchSubmitSuccessDoesNotClearMarkForDifferentTarget) {
     ASSERT_TRUE(CreateMetaIndexer(kInstance));
     ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "batch_mark_mismatch_hot/"));
-    ASSERT_TRUE(
-        CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "batch_mark_mismatch_cold_01/"));
-    ASSERT_TRUE(
-        CreateDummyStorage("cold_02", GetPrivateTestRuntimeDataPath() + "batch_mark_mismatch_cold_02/"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "batch_mark_mismatch_cold_01/"));
+    ASSERT_TRUE(CreateDummyStorage("cold_02", GetPrivateTestRuntimeDataPath() + "batch_mark_mismatch_cold_02/"));
 
     const int64_t block_key = 850;
     const std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "batch-data");
@@ -2303,8 +2298,7 @@ TEST_F(MigrationManagerTest, TestBatchSubmitMarkSnapshotsStayAlignedPerItem) {
     ASSERT_TRUE(CreateDummyStorage("cold_02", GetPrivateTestRuntimeDataPath() + "batch_mark_align_cold_02/"));
 
     auto make_prepared_request = [&](int64_t block_key) {
-        const std::string src_location_id =
-            CreateSourceLocation(block_key, "hot_01", true, "batch-mark-align");
+        const std::string src_location_id = CreateSourceLocation(block_key, "hot_01", true, "batch-mark-align");
         const auto src_location = GetLocation(block_key, src_location_id);
         EXPECT_NE(nullptr, src_location);
 
@@ -2566,11 +2560,8 @@ TEST_F(MigrationManagerTest, TestMetricsAndEvents) {
     auto event_manager = std::make_shared<EventManager>();
     event_manager->Init();
     // 注入 metrics_registry_ + event_manager（启用可观测）
-    MigrationManager mgr(schedule_plan_executor_,
-                         meta_manager_,
-                         data_storage_manager_,
-                         metrics_registry_,
-                         event_manager);
+    MigrationManager mgr(
+        schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, event_manager);
 
     // ---- Mark 指标 ----（持久化方案：先建出 block 1/2）
     CreateSourceLocation(1, "hot_01", false, "a");
@@ -2597,11 +2588,9 @@ TEST_F(MigrationManagerTest, TestMetricsAndEvents) {
     ASSERT_DOUBLE_EQ(1.0, metrics_registry_->GetGauge("migration.tasks_active").Get());
 
     mgr.OnTaskSuccess(kInstance, block_key);
-    ASSERT_EQ(1u,
-              metrics_registry_->GetCounter("migration.tasks_completed_total", {{"status", "success"}}).Get());
+    ASSERT_EQ(1u, metrics_registry_->GetCounter("migration.tasks_completed_total", {{"status", "success"}}).Get());
     ASSERT_DOUBLE_EQ(0.0, metrics_registry_->GetGauge("migration.tasks_active").Get());
-    ASSERT_EQ(static_cast<uint64_t>(content.size()),
-              metrics_registry_->GetCounter("migration.copy_bytes_total").Get());
+    ASSERT_EQ(static_cast<uint64_t>(content.size()), metrics_registry_->GetCounter("migration.copy_bytes_total").Get());
 
     // ---- 失败计数 ----
     const int64_t block_key2 = 1001;
@@ -2620,18 +2609,15 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
     ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "m_hot/"));
     ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "m_cold/"));
 
-    MigrationManager mgr(schedule_plan_executor_,
-                         meta_manager_,
-                         data_storage_manager_,
-                         metrics_registry_,
-                         nullptr);
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, nullptr);
 
     mgr.DebugEnableCopySubmissionsForTest();
 
     auto get_write_bytes = [&]() {
-        return metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total",
-                              {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)},
-                               {"unique_name", "cold_01"}}).Get();
+        return metrics_registry_
+            ->GetCounter("data_storage.write_bytes_dispatched_total",
+                         {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)}, {"unique_name", "cold_01"}})
+            .Get();
     };
 
     // 场景1：成功复制
@@ -2721,17 +2707,16 @@ TEST_F(MigrationManagerTest, TestCopyWriteBytesRecorded) {
         ASSERT_EQ(40u, get_write_bytes());
         ASSERT_EQ(10u, metrics_registry_->GetCounter("migration.copy_bytes_total").Get()); // 源丢失按失败收尾，不涨
     }
-
 }
 
 // ============ Copy 准入策略：CheckCopyAdmission ============
 
 namespace {
 
-CacheLocationConstPtr MakeLocation(const std::string &id,
-                                   const std::string &storage_name,
-                                   CacheLocationStatus status,
-                                   int64_t create_time = 0) {
+std::shared_ptr<CacheLocation> MakeLocation(const std::string &id,
+                                            const std::string &storage_name,
+                                            CacheLocationStatus status,
+                                            int64_t create_time = 0) {
     std::string uri = "dummy://" + storage_name + "/blk?size=8";
     auto loc = std::make_shared<CacheLocation>(
         DataStorageType::DATA_STORAGE_TYPE_DUMMY, 1, std::vector<LocationSpec>{LocationSpec("TP0", uri)});
@@ -3059,6 +3044,37 @@ TEST_F(MigrationManagerTest, TestCopyFailureIdentityDoesNotPoisonRecreatedLocati
     ASSERT_EQ(old_source.get(), other_target.src_location);
 }
 
+TEST_F(MigrationManagerTest, TestPersistentGuardPinsSourceAgainstAnotherMigrationRoute) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    constexpr int64_t block_key = 831;
+    auto source = MakeLocation("pinned-source", "hot_01", CLS_SERVING, 100);
+    auto guarded_target = MakeLocation("guarded-target", "archive_01", CLS_WRITING, 200);
+
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_UNKNOWN);
+    guard.set_operation_id("pinned-source-operation");
+    guard.set_source_location_id(source->id());
+    guard.set_source_location_create_time(source->create_time());
+    guard.set_source_storage_name("hot_01");
+    guard.set_target_storage_name("archive_01");
+    guard.set_total_bytes(7);
+    guarded_target->set_migration_copy_guard(guard);
+
+    CacheLocationMap loc_map;
+    loc_map[source->id()] = source;
+    loc_map[guarded_target->id()] = guarded_target;
+
+    const auto pinned = mgr.CheckCopyAdmission(kInstance, block_key, loc_map, "hot_01", "cold_01");
+    EXPECT_EQ(MigrationManager::CopyAdmissionStatus::kSourcePinnedByGuard, pinned.status);
+    EXPECT_EQ(nullptr, pinned.src_location);
+
+    guarded_target->clear_migration_copy_guard();
+    const auto released = mgr.CheckCopyAdmission(kInstance, block_key, loc_map, "hot_01", "cold_01");
+    EXPECT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, released.status);
+    EXPECT_EQ(source.get(), released.src_location);
+}
+
 TEST_F(MigrationManagerTest, TestCopySuccessClearsSourceFailureBackoff) {
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
     const std::string src = "hot_01";
@@ -3084,6 +3100,71 @@ TEST_F(MigrationManagerTest, TestCopySuccessClearsSourceFailureBackoff) {
     const auto admission = mgr.CheckCopyAdmission(kInstance, block_key, loc_map, src, dst);
     EXPECT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, admission.status);
     EXPECT_EQ(0u, mgr.GetStats().source_failure_entries);
+}
+
+TEST_F(MigrationManagerTest, TestAsyncAdmissionReservesWorstCaseQuarantineCapacity) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::MigrationRequest request;
+    request.instance_group_name = "quarantine-reservation-group";
+    request.async_operation_id = "quarantine-reservation-1";
+    request.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    request.copy_max_inflight_bytes = 1000;
+    request.copy_max_quarantine_operations = 2;
+    request.copy_max_quarantine_bytes = 200;
+
+    ASSERT_TRUE(mgr.ReserveAsyncCopyCredit(request, 100));
+
+    request.async_operation_id = "quarantine-reservation-too-large";
+    EXPECT_FALSE(mgr.ReserveAsyncCopyCredit(request, 101));
+
+    request.async_operation_id = "quarantine-reservation-2";
+    ASSERT_TRUE(mgr.ReserveAsyncCopyCredit(request, 100));
+
+    request.async_operation_id = "quarantine-reservation-3";
+    EXPECT_FALSE(mgr.ReserveAsyncCopyCredit(request, 1));
+
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(2u, stats.async_copy_inflight_operations);
+    EXPECT_EQ(200u, stats.async_copy_inflight_bytes);
+}
+
+TEST_F(MigrationManagerTest, TestCleanupFutureRetainsStorageAndInstanceReferencesUntilReady) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    std::promise<PlanExecuteResult> cleanup_promise;
+    CacheLocationDelRequest request;
+    request.instance_id = kInstance;
+    mgr.TrackLocationCleanup(kInstance, "cold_01", request, cleanup_promise.get_future());
+
+    EXPECT_TRUE(mgr.HasAsyncCopyStorageReference("cold_01"));
+    EXPECT_TRUE(mgr.HasAsyncCopyInstanceReference(kInstance));
+
+    cleanup_promise.set_value(PlanExecuteResult{EC_OK, ""});
+    mgr.ProcessCompletedLocationCleanups();
+
+    EXPECT_FALSE(mgr.HasAsyncCopyStorageReference("cold_01"));
+    EXPECT_FALSE(mgr.HasAsyncCopyInstanceReference(kInstance));
+}
+
+TEST_F(MigrationManagerTest, TestFailedCleanupRetainsReferenceAndSchedulesRetry) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    std::promise<PlanExecuteResult> cleanup_promise;
+    CacheLocationDelRequest request;
+    request.instance_id = kInstance;
+    mgr.TrackLocationCleanup(kInstance, "cold_01", request, cleanup_promise.get_future());
+
+    cleanup_promise.set_value(PlanExecuteResult{EC_PARTIAL_OK, "physical delete failed"});
+    mgr.ProcessCompletedLocationCleanups();
+    ASSERT_TRUE(mgr.HasAsyncCopyStorageReference("cold_01"));
+    ASSERT_TRUE(mgr.HasAsyncCopyInstanceReference(kInstance));
+    ASSERT_EQ(1u, mgr.pending_location_cleanups_.size());
+    EXPECT_FALSE(mgr.pending_location_cleanups_.front().future.valid());
+
+    mgr.pending_location_cleanups_.front().retry_after = std::chrono::steady_clock::time_point{};
+    mgr.ProcessCompletedLocationCleanups();
+    ASSERT_EQ(1u, mgr.pending_location_cleanups_.size());
+    EXPECT_TRUE(mgr.pending_location_cleanups_.front().future.valid());
+    EXPECT_TRUE(mgr.pending_location_cleanups_.front().request.resume_deleting);
+    EXPECT_TRUE(mgr.pending_location_cleanups_.front().request.authoritative_read);
 }
 
 TEST_F(MigrationManagerTest, TestGuardRecoveryRebuildsQuarantineAndFailsBeforeClearingOnScanSetupError) {
@@ -3165,6 +3246,8 @@ TEST_F(MigrationManagerTest, TestGuardRecoveryResumesActiveTaskWithPersistedHand
     guard.set_source_location_create_time(1);
     guard.set_source_storage_name("hot_01");
     guard.set_target_storage_name("cold_01");
+    guard.set_mark_target("cold_01");
+    guard.set_mark_deadline_ms(123456789);
     guard.set_total_bytes(7);
     guard.set_backend_task_ids(task_ids);
     guard.set_create_time_us(TimestampUtil::GetCurrentTimeUs());
@@ -3208,8 +3291,64 @@ TEST_F(MigrationManagerTest, TestGuardRecoveryResumesActiveTaskWithPersistedHand
     EXPECT_EQ(operation_id, async_guard_recovery_stub::resumed_operation_id);
     EXPECT_EQ(task_ids, async_guard_recovery_stub::resumed_task_ids);
     EXPECT_TRUE(mgr.HasMigrationTask(kInstance, block_key));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        const auto &recovered = mgr.active_tasks_by_instance_.at(kInstance).at(block_key);
+        EXPECT_EQ("cold_01", recovered.mark_target);
+        EXPECT_EQ(123456789, recovered.mark_deadline_ms);
+    }
     EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(group->name()).empty());
     EXPECT_EQ(1u, mgr.GetStats().async_copy_inflight_operations);
+
+    async_guard_recovery_stub::groups.clear();
+    async_guard_recovery_stub::instances.clear();
+}
+
+TEST_F(MigrationManagerTest, TestGuardRecoveryFailsWhenUnknownTransitionIsNotDurable) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 861;
+
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_SUBMITTING);
+    guard.set_operation_id("recovery-undurable-unknown-operation");
+    guard.set_source_location_id("recovery-undurable-source");
+    guard.set_source_location_create_time(1);
+    guard.set_source_storage_name("hot_01");
+    guard.set_target_storage_name("cold_01");
+    guard.set_total_bytes(7);
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("recovery_undurable_unknown_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/recovery-undurable?size=7")});
+    target->set_migration_copy_guard(guard);
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    auto group = std::make_shared<InstanceGroup>();
+    group->set_name("recovery-undurable-group");
+    group->set_cache_config(std::make_shared<CacheConfig>());
+    auto instance = std::make_shared<InstanceInfo>();
+    instance->set_instance_id(kInstance);
+    instance->set_instance_group_name(group->name());
+    async_guard_recovery_stub::groups = {group};
+    async_guard_recovery_stub::instances = {instance};
+    async_guard_recovery_stub::list_groups_result = EC_OK;
+    async_guard_recovery_stub::list_instances_result = EC_OK;
+
+    Stub stub;
+    stub.set(ADDR(RegistryManager, ListInstanceGroup), async_guard_recovery_stub::ListInstanceGroupStub);
+    stub.set(ADDR(RegistryManager, ListInstanceInfo), async_guard_recovery_stub::ListInstanceInfoStub);
+    stub.set(ADDR(MetaIndexer, Sync), AlwaysFailGuardSyncStub);
+    auto registry = std::make_shared<RegistryManager>("", metrics_registry_);
+    MigrationManager mgr(
+        schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, nullptr, registry);
+
+    EXPECT_FALSE(mgr.RecoverAsyncCopyGuards());
+    EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(group->name()).empty());
 
     async_guard_recovery_stub::groups.clear();
     async_guard_recovery_stub::instances.clear();
@@ -3225,8 +3364,8 @@ TEST_F(MigrationManagerTest, TestRemoteAsyncAcceptancePersistsActiveTaskHandles)
 
     MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
     auto rc = std::make_shared<RequestContext>("async_accept_target");
-    auto target = std::make_shared<CacheLocation>(
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+    auto target =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
         1,
         std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/target?size=7")});
     std::vector<std::string> target_ids;
@@ -3259,11 +3398,23 @@ TEST_F(MigrationManagerTest, TestRemoteAsyncAcceptancePersistsActiveTaskHandles)
     remote.status = EC_OK;
     remote.accepted = true;
     remote.operation_id = ctx.async_operation_id;
-    remote.backend_task_ids = {"pace-task-86"};
     MigrationManager::CopyTaskContext accepted_ctx;
     bool cancel_requested = true;
-    ASSERT_TRUE(mgr.PersistRemoteAsyncCopyAcceptance(
-        kInstance, block_key, remote, accepted_ctx, cancel_requested));
+
+    remote.backend_task_ids = {"pace-task-86", "unexpected-extra-handle"};
+    EXPECT_FALSE(mgr.PersistRemoteAsyncCopyAcceptance(kInstance, block_key, 1, remote, accepted_ctx, cancel_requested));
+    EXPECT_EQ(remote.backend_task_ids, accepted_ctx.async_backend_task_ids);
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        EXPECT_TRUE(mgr.active_tasks_by_instance_.at(kInstance).at(block_key).async_backend_task_ids.empty());
+    }
+    const auto submitting_target = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(submitting_target);
+    ASSERT_TRUE(submitting_target->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_SUBMITTING, submitting_target->migration_copy_guard().state());
+
+    remote.backend_task_ids = {"pace-task-86"};
+    ASSERT_TRUE(mgr.PersistRemoteAsyncCopyAcceptance(kInstance, block_key, 1, remote, accepted_ctx, cancel_requested));
     EXPECT_FALSE(cancel_requested);
     EXPECT_EQ(remote.backend_task_ids, accepted_ctx.async_backend_task_ids);
 
@@ -3272,6 +3423,45 @@ TEST_F(MigrationManagerTest, TestRemoteAsyncAcceptancePersistsActiveTaskHandles)
     ASSERT_TRUE(guarded_target->has_migration_copy_guard());
     EXPECT_EQ(MigrationCopyGuardState::MCGS_ACTIVE, guarded_target->migration_copy_guard().state());
     EXPECT_EQ(remote.backend_task_ids, guarded_target->migration_copy_guard().backend_task_ids());
+}
+
+TEST_F(MigrationManagerTest, TestAsyncSourceIsRevalidatedAfterPersistentGuardInstall) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "async_source_pin_hot/"));
+    constexpr int64_t block_key = 861;
+    const std::string source_id = CreateSourceLocation(block_key, "hot_01", false, "payload");
+    const auto source = GetLocation(block_key, source_id);
+    ASSERT_TRUE(source);
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_source_pin_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/source-pin-target?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = source_id;
+    ctx.src_create_time = source->create_time();
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "async-source-pin-operation";
+    ctx.async_guard_create_time_us = TimestampUtil::GetCurrentTimeUs();
+    ctx.total_bytes = 7;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(
+                  ctx, MigrationCopyGuardState::MCGS_NONE, MigrationCopyGuardState::MCGS_SUBMITTING, {}, ""));
+    EXPECT_TRUE(mgr.IsSourceLocationServing(ctx));
+
+    DeleteLocationMeta(block_key, source_id);
+    EXPECT_FALSE(mgr.IsSourceLocationServing(ctx));
 }
 
 TEST_F(MigrationManagerTest, TestCancellationBeforeRemoteAcceptanceCannotBeOverwrittenByActive) {
@@ -3284,8 +3474,8 @@ TEST_F(MigrationManagerTest, TestCancellationBeforeRemoteAcceptanceCannotBeOverw
 
     MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
     auto rc = std::make_shared<RequestContext>("async_cancel_target");
-    auto target = std::make_shared<CacheLocation>(
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+    auto target =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
         1,
         std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/target?size=7")});
     std::vector<std::string> target_ids;
@@ -3321,8 +3511,7 @@ TEST_F(MigrationManagerTest, TestCancellationBeforeRemoteAcceptanceCannotBeOverw
     remote.backend_task_ids = {"pace-task-87"};
     MigrationManager::CopyTaskContext accepted_ctx;
     bool cancel_requested = false;
-    ASSERT_TRUE(mgr.PersistRemoteAsyncCopyAcceptance(
-        kInstance, block_key, remote, accepted_ctx, cancel_requested));
+    ASSERT_TRUE(mgr.PersistRemoteAsyncCopyAcceptance(kInstance, block_key, 1, remote, accepted_ctx, cancel_requested));
     EXPECT_TRUE(cancel_requested);
 
     // Every non-initial guard transition checks both operation-id and state.
@@ -3487,13 +3676,84 @@ TEST_F(MigrationManagerTest, TestAppliedFinalizationRetriesOnlySyncWithoutPhanto
     EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
 }
 
+TEST_F(MigrationManagerTest, TestUnknownWaitsForDurableGuardTransitionBeforePublication) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 873;
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("async_unknown_sync_retry");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/unknown-sync-retry?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "group-unknown-sync-retry";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = "source-unknown-sync-retry";
+    ctx.src_create_time = 1;
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "async-operation-unknown-sync-retry";
+    ctx.async_backend_task_ids = {"pace-task-unknown-sync-retry"};
+    ctx.async_credit_active = true;
+    ctx.total_bytes = 7;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(ctx,
+                                       MigrationCopyGuardState::MCGS_NONE,
+                                       MigrationCopyGuardState::MCGS_CANCELLING,
+                                       ctx.async_backend_task_ids,
+                                       ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    ASSERT_TRUE(mgr.RestoreAsyncCopyInflightCredit(ctx));
+
+    EXPECT_FALSE(mgr.OnTaskUnknown(kInstance, block_key, "remote outcome unknown"));
+    EXPECT_TRUE(mgr.HasMigrationTask(kInstance, block_key));
+    auto stats = mgr.GetStats();
+    EXPECT_EQ(1u, stats.async_copy_inflight_operations);
+    EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
+    EXPECT_EQ(0u, stats.async_copy_unknown);
+
+    const auto applied = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(applied);
+    ASSERT_TRUE(applied->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_CANCELLING, applied->migration_copy_guard().state());
+
+    // Simulate reconciliation restoring the state expected by this runtime
+    // owner. The retained completion must retry the transition rather than
+    // having already published an unmatched quarantine record.
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(ctx,
+                                       MigrationCopyGuardState::MCGS_CANCELLING,
+                                       MigrationCopyGuardState::MCGS_ACTIVE,
+                                       ctx.async_backend_task_ids,
+                                       ""));
+
+    EXPECT_TRUE(mgr.OnTaskUnknown(kInstance, block_key, "remote outcome unknown"));
+    EXPECT_FALSE(mgr.HasMigrationTask(kInstance, block_key));
+    stats = mgr.GetStats();
+    EXPECT_EQ(0u, stats.async_copy_inflight_operations);
+    EXPECT_EQ(1u, stats.async_copy_quarantine_operations);
+    EXPECT_EQ(1u, stats.async_copy_unknown);
+}
+
 TEST_F(MigrationManagerTest, TestDefinitePreSubmitFailureDoesNotEnterRemoteUnknownQuarantine) {
     ASSERT_TRUE(CreateMetaIndexer(kInstance));
     constexpr int64_t block_key = 88;
     MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
     auto rc = std::make_shared<RequestContext>("pre_submit_failure_target");
-    auto target = std::make_shared<CacheLocation>(
-        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+    auto target =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
         1,
         std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/target?size=7")});
     MigrationCopyGuard other_guard;
@@ -3581,8 +3841,7 @@ TEST_F(MigrationManagerTest, TestBreakGlassReleaseRequiresUnknownGuardAndClearsQ
         std::lock_guard<std::mutex> lock(mgr.async_copy_usage_mutex_);
         mgr.async_copy_quarantine_by_operation_.emplace(
             operation_id,
-            MigrationManager::AsyncCopyQuarantineRecord{
-                group_name, kInstance, block_key, target_ids[0], guard});
+            MigrationManager::AsyncCopyQuarantineRecord{group_name, kInstance, block_key, target_ids[0], guard});
         auto &usage = mgr.async_copy_usage_by_group_[group_name];
         usage.quarantine_operations = 1;
         usage.quarantine_bytes = total_bytes;
@@ -3591,7 +3850,11 @@ TEST_F(MigrationManagerTest, TestBreakGlassReleaseRequiresUnknownGuardAndClearsQ
     ASSERT_EQ(1u, mgr.ListAsyncCopyQuarantine(group_name).size());
     EXPECT_EQ(EC_BADARGS, mgr.BreakGlassReleaseAsyncCopy(operation_id, "", "ticket-89"));
     EXPECT_EQ(EC_NOENT, mgr.BreakGlassReleaseAsyncCopy("missing-operation", "operator-89", "ticket-89"));
+    g_guard_sync_call_count.store(0, std::memory_order_release);
+    Stub sync_stub;
+    sync_stub.set(ADDR(MetaIndexer, Sync), FailFirstGuardSyncStub);
     EXPECT_EQ(EC_OK, mgr.BreakGlassReleaseAsyncCopy(operation_id, "operator-89", "ticket-89"));
+    EXPECT_EQ(1, g_guard_sync_call_count.load(std::memory_order_acquire));
     EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(group_name).empty());
     const auto stats = mgr.GetStats();
     EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
@@ -3871,11 +4134,8 @@ TEST_F(MigrationManagerTest, TestStopQuarantinesSubmittingAsyncCopyWithoutTaskId
     ctx.submit_time = std::chrono::steady_clock::now();
     ctx.state = MigrationManager::CopyTaskState::kRunning;
     ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
-              mgr.UpdateAsyncCopyGuard(ctx,
-                                       MigrationCopyGuardState::MCGS_NONE,
-                                       MigrationCopyGuardState::MCGS_SUBMITTING,
-                                       {},
-                                       ""));
+              mgr.UpdateAsyncCopyGuard(
+                  ctx, MigrationCopyGuardState::MCGS_NONE, MigrationCopyGuardState::MCGS_SUBMITTING, {}, ""));
     {
         std::lock_guard<std::mutex> lock(mgr.task_mutex_);
         ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
@@ -3891,6 +4151,156 @@ TEST_F(MigrationManagerTest, TestStopQuarantinesSubmittingAsyncCopyWithoutTaskId
     ASSERT_TRUE(persisted);
     ASSERT_TRUE(persisted->has_migration_copy_guard());
     EXPECT_EQ(MigrationCopyGuardState::MCGS_UNKNOWN, persisted->migration_copy_guard().state());
+}
+
+TEST_F(MigrationManagerTest, TestStopHarvestsReadyRemoteSubmitHandlesBeforeDetach) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 1005;
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("stop_harvest_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/stop-harvest?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "stop-harvest-group";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = "stop-harvest-source";
+    ctx.src_create_time = 1;
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "stop-harvest-operation";
+    ctx.async_credit_active = true;
+    ctx.async_guard_create_time_us = TimestampUtil::GetCurrentTimeUs();
+    ctx.total_bytes = 7;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(
+                  ctx, MigrationCopyGuardState::MCGS_NONE, MigrationCopyGuardState::MCGS_SUBMITTING, {}, ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    ASSERT_TRUE(mgr.RestoreAsyncCopyInflightCredit(ctx));
+
+    auto completion_promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto remote_submit_promise = std::make_shared<std::promise<AsyncCopyRemoteSubmitResult>>();
+    AsyncCopyRemoteSubmitResult remote;
+    remote.status = EC_OK;
+    remote.accepted = true;
+    remote.operation_id = ctx.async_operation_id;
+    remote.backend_task_ids = {"pace-stop-harvest-task"};
+    remote_submit_promise->set_value(remote);
+    {
+        std::lock_guard<std::mutex> lock(mgr.pending_mutex_);
+        MigrationManager::PendingCopy pending;
+        pending.instance_id = kInstance;
+        pending.block_key = block_key;
+        pending.expected_items = 1;
+        pending.future = completion_promise->get_future();
+        pending.native_async = true;
+        pending.remote_submit_future = remote_submit_promise->get_future();
+        pending.remote_submit_processed = false;
+        mgr.pending_copies_.push_back(std::move(pending));
+    }
+
+    // Exercise Stop's handoff directly without racing a monitor thread.
+    mgr.running_.store(true, std::memory_order_release);
+    mgr.Stop();
+
+    EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(ctx.instance_group_name).empty());
+    const auto persisted = GetLocation(block_key, target_ids[0]);
+    ASSERT_TRUE(persisted);
+    ASSERT_TRUE(persisted->has_migration_copy_guard());
+    EXPECT_EQ(MigrationCopyGuardState::MCGS_ACTIVE, persisted->migration_copy_guard().state());
+    EXPECT_EQ(remote.backend_task_ids, persisted->migration_copy_guard().backend_task_ids());
+}
+
+TEST_F(MigrationManagerTest, TestStopFinalizesDefinitivelyRejectedRemoteSubmit) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    constexpr int64_t block_key = 1006;
+
+    MetaSearcher searcher(meta_manager_->GetMetaIndexer(kInstance));
+    auto rc = std::make_shared<RequestContext>("stop_rejected_submit_target");
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("TP0", "dummy://cold/stop-rejected-submit?size=7")});
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&searcher, rc.get(), {block_key}, {target}, target_ids));
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_group_name = "stop-rejected-submit-group";
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = "stop-rejected-submit-source";
+    ctx.src_create_time = 1;
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.dst_location_id = target_ids[0];
+    ctx.copy_execution_mode = MigrationCopyExecutionMode::ASYNC_REQUIRED;
+    ctx.async_operation_id = "stop-rejected-submit-operation";
+    ctx.async_credit_active = true;
+    ctx.async_guard_create_time_us = TimestampUtil::GetCurrentTimeUs();
+    ctx.total_bytes = 7;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ASSERT_EQ(MigrationManager::GuardMutationResult::kAppliedDurably,
+              mgr.UpdateAsyncCopyGuard(
+                  ctx, MigrationCopyGuardState::MCGS_NONE, MigrationCopyGuardState::MCGS_SUBMITTING, {}, ""));
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+    ASSERT_TRUE(mgr.RestoreAsyncCopyInflightCredit(ctx));
+
+    auto completion_promise = std::make_shared<std::promise<PlanExecuteResult>>();
+    auto remote_submit_promise = std::make_shared<std::promise<AsyncCopyRemoteSubmitResult>>();
+    AsyncCopyRemoteSubmitResult remote;
+    remote.status = EC_ERROR;
+    remote.accepted = false;
+    remote.acceptance_unknown = false;
+    remote.operation_id = ctx.async_operation_id;
+    remote.detail = "definite remote rejection";
+    remote_submit_promise->set_value(remote);
+    {
+        std::lock_guard<std::mutex> lock(mgr.pending_mutex_);
+        MigrationManager::PendingCopy pending;
+        pending.instance_id = kInstance;
+        pending.block_key = block_key;
+        pending.expected_items = 1;
+        pending.future = completion_promise->get_future();
+        pending.native_async = true;
+        pending.remote_submit_future = remote_submit_promise->get_future();
+        pending.remote_submit_processed = false;
+        mgr.pending_copies_.push_back(std::move(pending));
+    }
+
+    mgr.running_.store(true, std::memory_order_release);
+    mgr.Stop();
+
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(1u, stats.copy_failed);
+    EXPECT_EQ(0u, stats.async_copy_unknown);
+    EXPECT_EQ(0u, stats.async_copy_inflight_operations);
+    EXPECT_EQ(0u, stats.async_copy_quarantine_operations);
+    EXPECT_EQ(0u, stats.active_copy_tasks);
+    EXPECT_TRUE(mgr.ListAsyncCopyQuarantine(ctx.instance_group_name).empty());
+    const auto persisted = GetLocation(block_key, target_ids[0]);
+    if (persisted) {
+        EXPECT_EQ(CLS_DELETING, persisted->status());
+        EXPECT_FALSE(persisted->has_migration_copy_guard());
+    }
 }
 
 // GetActiveBlockKeysForInstance 返回指定 instance 的活跃 block_key 列表（用于 drain 前 BatchCancel）。

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -1269,6 +1269,8 @@ TEST_F(MigrationManagerTest, TestSubmitThenFail) {
     ASSERT_EQ(CLS_SERVING, GetLocationStatus(block_key, src_loc));
     ASSERT_TRUE(mgr.IsMarkedForTieredWrite(kInstance, block_key));
     ASSERT_EQ(1u, mgr.GetStats().copy_failed);
+    ASSERT_EQ(1u, mgr.GetStats().source_failures_recorded);
+    ASSERT_EQ(1u, mgr.GetStats().source_failure_entries);
 }
 
 // ============ Cancel 任务状态机（认领 + 延迟收尾） ============
@@ -2669,13 +2671,14 @@ namespace {
 
 CacheLocationConstPtr MakeLocation(const std::string &id,
                                    const std::string &storage_name,
-                                   CacheLocationStatus status) {
+                                   CacheLocationStatus status,
+                                   int64_t create_time = 0) {
     std::string uri = "dummy://" + storage_name + "/blk?size=8";
-    auto loc = std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_DUMMY,
-                                               1,
-                                               std::vector<LocationSpec>{LocationSpec("TP0", uri)});
+    auto loc = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY, 1, std::vector<LocationSpec>{LocationSpec("TP0", uri)});
     loc->set_id(id);
     loc->set_status(status);
+    loc->set_create_time(create_time);
     return loc;
 }
 
@@ -2833,6 +2836,195 @@ TEST_F(MigrationManagerTest, TestCheckCopyAdmissionTriesNextSourceLocation) {
     ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, adm.status);
     ASSERT_NE(nullptr, adm.src_location);
     ASSERT_EQ("loc_src_l1", adm.src_location->id());
+}
+
+TEST_F(MigrationManagerTest, TestCopyFailureBackoffSwitchesToHealthySource) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    const std::string src = "hot_01";
+    const std::string dst = "cold_01";
+    const int64_t block_key = 81;
+
+    auto failed_source = MakeLocation("loc_failed", src, CLS_SERVING, 100);
+    auto healthy_source = MakeLocation("loc_healthy", src, CLS_SERVING, 200);
+
+    MigrationManager::CopyTaskContext failed_ctx;
+    failed_ctx.instance_id = kInstance;
+    failed_ctx.block_key = block_key;
+    failed_ctx.src_location_id = failed_source->id();
+    failed_ctx.src_create_time = failed_source->create_time();
+    failed_ctx.src_storage_name = src;
+    failed_ctx.dst_storage_name = dst;
+    mgr.RecordCopySourceFailure(failed_ctx, EC_PARTIAL_OK);
+
+    CacheLocationMap loc_map;
+    loc_map[failed_source->id()] = failed_source;
+    loc_map[healthy_source->id()] = healthy_source;
+    const auto admission = mgr.CheckCopyAdmission(kInstance, block_key, loc_map, src, dst);
+
+    ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, admission.status);
+    ASSERT_NE(nullptr, admission.src_location);
+    EXPECT_EQ(healthy_source->id(), admission.src_location->id());
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(1u, stats.source_failures_recorded);
+    EXPECT_EQ(1u, stats.source_retries_suppressed);
+    EXPECT_EQ(1u, stats.source_switches);
+    EXPECT_EQ(1u, stats.source_failure_entries);
+    EXPECT_EQ(0u, stats.no_usable_source);
+}
+
+TEST_F(MigrationManagerTest, TestTaskFailureHooksSourceBackoffBeforeRemovingActiveTask) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    auto failed_source = MakeLocation("loc_failed_hook", "hot_01", CLS_SERVING, 100);
+    auto healthy_source = MakeLocation("loc_healthy_hook", "hot_01", CLS_SERVING, 200);
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_id = kInstance;
+    ctx.block_key = 810;
+    ctx.src_location_id = failed_source->id();
+    ctx.src_create_time = failed_source->create_time();
+    ctx.src_storage_name = "hot_01";
+    ctx.dst_storage_name = "cold_01";
+    ctx.state = MigrationManager::CopyTaskState::kRunning;
+    ctx.submit_time = std::chrono::steady_clock::now();
+    {
+        std::lock_guard<std::mutex> lock(mgr.task_mutex_);
+        ASSERT_TRUE(mgr.InsertActiveTaskLocked(ctx));
+    }
+
+    mgr.OnTaskFailed(kInstance, ctx.block_key, EC_NOENT);
+    EXPECT_FALSE(mgr.HasMigrationTask(kInstance, ctx.block_key));
+
+    CacheLocationMap loc_map;
+    loc_map.emplace(failed_source->id(), failed_source);
+    loc_map.emplace(healthy_source->id(), healthy_source);
+    const auto admission =
+        mgr.CheckCopyAdmission(kInstance, ctx.block_key, loc_map, ctx.src_storage_name, ctx.dst_storage_name);
+    ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, admission.status);
+    ASSERT_NE(nullptr, admission.src_location);
+    EXPECT_EQ(healthy_source->id(), admission.src_location->id());
+}
+
+TEST_F(MigrationManagerTest, TestFailedSourceStaysLowerPriorityAfterBackoffExpires) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    const std::string src = "hot_01";
+    const std::string dst = "cold_01";
+    const int64_t block_key = 85;
+
+    auto failed_source = MakeLocation("loc_failed", src, CLS_SERVING, 100);
+    auto healthy_source = MakeLocation("loc_healthy", src, CLS_SERVING, 200);
+
+    MigrationManager::CopyTaskContext failed_ctx;
+    failed_ctx.instance_id = kInstance;
+    failed_ctx.block_key = block_key;
+    failed_ctx.src_location_id = failed_source->id();
+    failed_ctx.src_create_time = failed_source->create_time();
+    failed_ctx.src_storage_name = src;
+    failed_ctx.dst_storage_name = dst;
+    mgr.RecordCopySourceFailure(failed_ctx, EC_PARTIAL_OK);
+
+    // Reclaimer 的采样周期可能长于首次 5s backoff。即使退避窗口已经结束，存在从未失败的
+    // 完整副本时也应优先换源，而不是因为坏源再次 eligible 就回到 unordered_map 的随机顺序。
+    const auto failed_key = mgr.MakeCopySourceFailureKey(failed_ctx);
+    {
+        std::lock_guard<std::mutex> lock(mgr.copy_source_failure_mutex_);
+        auto iter = mgr.copy_source_failures_.find(failed_key);
+        ASSERT_NE(mgr.copy_source_failures_.end(), iter);
+        iter->second.retry_after = std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+    }
+
+    CacheLocationMap loc_map;
+    loc_map[failed_source->id()] = failed_source;
+    loc_map[healthy_source->id()] = healthy_source;
+    const auto admission = mgr.CheckCopyAdmission(kInstance, block_key, loc_map, src, dst);
+
+    ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, admission.status);
+    ASSERT_NE(nullptr, admission.src_location);
+    EXPECT_EQ(healthy_source->id(), admission.src_location->id());
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(0u, stats.source_retries_suppressed);
+    EXPECT_EQ(1u, stats.source_switches);
+}
+
+TEST_F(MigrationManagerTest, TestCopyFailureBackoffStopsRetryWhenNoAlternativeSource) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    const std::string src = "hot_01";
+    const std::string dst = "cold_01";
+    const int64_t block_key = 82;
+    auto failed_source = MakeLocation("loc_failed", src, CLS_SERVING, 100);
+
+    MigrationManager::CopyTaskContext failed_ctx;
+    failed_ctx.instance_id = kInstance;
+    failed_ctx.block_key = block_key;
+    failed_ctx.src_location_id = failed_source->id();
+    failed_ctx.src_create_time = failed_source->create_time();
+    failed_ctx.src_storage_name = src;
+    failed_ctx.dst_storage_name = dst;
+    mgr.RecordCopySourceFailure(failed_ctx, EC_PARTIAL_OK);
+
+    CacheLocationMap loc_map;
+    loc_map[failed_source->id()] = failed_source;
+    const auto admission = mgr.CheckCopyAdmission(kInstance, block_key, loc_map, src, dst);
+
+    EXPECT_EQ(MigrationManager::CopyAdmissionStatus::kSourceRetrySuppressed, admission.status);
+    EXPECT_EQ(nullptr, admission.src_location);
+    const auto stats = mgr.GetStats();
+    EXPECT_EQ(1u, stats.source_retries_suppressed);
+    EXPECT_EQ(1u, stats.no_usable_source);
+}
+
+TEST_F(MigrationManagerTest, TestCopyFailureIdentityDoesNotPoisonRecreatedLocationOrOtherTarget) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    const std::string src = "hot_01";
+    const int64_t block_key = 83;
+    auto old_source = MakeLocation("loc_reused", src, CLS_SERVING, 100);
+
+    MigrationManager::CopyTaskContext failed_ctx;
+    failed_ctx.instance_id = kInstance;
+    failed_ctx.block_key = block_key;
+    failed_ctx.src_location_id = old_source->id();
+    failed_ctx.src_create_time = old_source->create_time();
+    failed_ctx.src_storage_name = src;
+    failed_ctx.dst_storage_name = "cold_01";
+    mgr.RecordCopySourceFailure(failed_ctx, EC_PARTIAL_OK);
+
+    CacheLocationMap recreated_map;
+    auto recreated_source = MakeLocation("loc_reused", src, CLS_SERVING, 101);
+    recreated_map[recreated_source->id()] = recreated_source;
+    const auto recreated = mgr.CheckCopyAdmission(kInstance, block_key, recreated_map, src, "cold_01");
+    ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, recreated.status);
+    ASSERT_EQ(recreated_source.get(), recreated.src_location);
+
+    CacheLocationMap old_map;
+    old_map[old_source->id()] = old_source;
+    const auto other_target = mgr.CheckCopyAdmission(kInstance, block_key, old_map, src, "archive_01");
+    ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, other_target.status);
+    ASSERT_EQ(old_source.get(), other_target.src_location);
+}
+
+TEST_F(MigrationManagerTest, TestCopySuccessClearsSourceFailureBackoff) {
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    const std::string src = "hot_01";
+    const std::string dst = "cold_01";
+    const int64_t block_key = 84;
+    auto source = MakeLocation("loc_source", src, CLS_SERVING, 100);
+
+    MigrationManager::CopyTaskContext ctx;
+    ctx.instance_id = kInstance;
+    ctx.block_key = block_key;
+    ctx.src_location_id = source->id();
+    ctx.src_create_time = source->create_time();
+    ctx.src_storage_name = src;
+    ctx.dst_storage_name = dst;
+    mgr.RecordCopySourceFailure(ctx, EC_PARTIAL_OK);
+
+    CacheLocationMap loc_map;
+    loc_map[source->id()] = source;
+    EXPECT_EQ(MigrationManager::CopyAdmissionStatus::kSourceRetrySuppressed,
+              mgr.CheckCopyAdmission(kInstance, block_key, loc_map, src, dst).status);
+
+    mgr.ClearCopySourceFailure(ctx);
+    const auto admission = mgr.CheckCopyAdmission(kInstance, block_key, loc_map, src, dst);
+    EXPECT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, admission.status);
+    EXPECT_EQ(0u, mgr.GetStats().source_failure_entries);
 }
 
 // 多个 target location 分别覆盖不同 specs，联合覆盖完整时不应 kAccept。

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -42,6 +42,8 @@ bool MetaIndexer_Sync_stub(void *obj, const KeyVector &keys) noexcept {
     return true;
 }
 
+bool MetaIndexer_Sync_fail_stub(void * /*obj*/, const KeyVector & /*keys*/) noexcept { return false; }
+
 std::shared_ptr<MetaIndexer> MetaIndexerManager_GetMetaIndexer_throw_stub(void *obj, const std::string &instance_id) {
     (void)obj;
     (void)instance_id;
@@ -353,21 +355,19 @@ TEST_F(SchedulePlanExecutorTest, TestMetaDeleteSkipsGuardedTargetAndItsExactSour
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
     constexpr int64_t block_key = 201;
 
-    auto source = std::make_shared<CacheLocation>(
-        DataStorageType::DATA_STORAGE_TYPE_NFS,
+    auto source =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         std::vector<LocationSpec>{SchedulePlanExecutorTestHelper::CreateLocationSpec(
             "TP0", "nfs://nfs_01/guarded_source")});
     source->set_status(CLS_SERVING);
     std::vector<std::string> source_ids;
-    ASSERT_EQ(EC_OK,
-              BatchAddLocationForTest(
-                  &meta_searcher, request_context.get(), {block_key}, {source}, source_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {source}, source_ids));
     ASSERT_EQ(1u, source_ids.size());
     std::vector<std::vector<ErrorCode>> source_cas_results;
-    ASSERT_EQ(EC_OK,
-              meta_searcher.BatchCASLocationStatus(
-                  request_context.get(),
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher.BatchCASLocationStatus(request_context.get(),
                   {block_key},
                   {{MetaSearcher::LocationCASTask{source_ids[0], CLS_WRITING, CLS_SERVING}}},
                   source_cas_results));
@@ -375,13 +375,11 @@ TEST_F(SchedulePlanExecutorTest, TestMetaDeleteSkipsGuardedTargetAndItsExactSour
 
     std::vector<CacheLocationMap> location_maps;
     BlockMask empty_mask;
-    ASSERT_EQ(EC_OK,
-              meta_searcher.BatchGetLocation(
-                  request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
     const auto persisted_source = location_maps[0].at(source_ids[0]);
 
-    auto target = std::make_shared<CacheLocation>(
-        DataStorageType::DATA_STORAGE_TYPE_NFS,
+    auto target =
+        std::make_shared<CacheLocation>(DataStorageType::DATA_STORAGE_TYPE_NFS,
         1,
         std::vector<LocationSpec>{SchedulePlanExecutorTestHelper::CreateLocationSpec(
             "TP0", "nfs://nfs_01/guarded_target")});
@@ -395,11 +393,10 @@ TEST_F(SchedulePlanExecutorTest, TestMetaDeleteSkipsGuardedTargetAndItsExactSour
     guard.set_target_storage_name("nfs_01");
     target->set_migration_copy_guard(guard);
     std::vector<std::string> target_ids;
-    ASSERT_EQ(EC_OK,
-              BatchAddLocationForTest(
-                  &meta_searcher, request_context.get(), {block_key}, {target}, target_ids));
+    ASSERT_EQ(EC_OK, BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {target}, target_ids));
 
-    const auto result = executor.Submit(CacheMetaDelRequest{
+    const auto result = executor
+                            .Submit(CacheMetaDelRequest{
                                             .instance_id = kTestInstanceName,
                                             .block_keys = {block_key},
                                         })
@@ -407,9 +404,7 @@ TEST_F(SchedulePlanExecutorTest, TestMetaDeleteSkipsGuardedTargetAndItsExactSour
     ASSERT_EQ(EC_OK, result.status);
 
     location_maps.clear();
-    ASSERT_EQ(EC_OK,
-              meta_searcher.BatchGetLocation(
-                  request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
     ASSERT_EQ(2u, location_maps[0].size());
     EXPECT_EQ(CLS_SERVING, location_maps[0].at(source_ids[0])->status());
     EXPECT_EQ(CLS_WRITING, location_maps[0].at(target_ids[0])->status());
@@ -1079,6 +1074,88 @@ TEST_F(SchedulePlanExecutorTest, TestEventReportMetadataDeleteRejectsInvalidRequ
     EXPECT_FALSE(submit_result.future.valid());
 }
 
+TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteFailureRetainsMetadataForResume) {
+    ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+
+    class FailFirstDeleteBackend : public DataStorageBackend {
+    public:
+        FailFirstDeleteBackend() : DataStorageBackend(nullptr) {
+            config_.set_type(DataStorageType::DATA_STORAGE_TYPE_DUMMY);
+            config_.set_global_unique_name("retry_delete");
+            SetOpen(true);
+            SetAvailable(true);
+        }
+        DataStorageType GetType() override { return DataStorageType::DATA_STORAGE_TYPE_DUMMY; }
+        bool Available() override { return true; }
+        double GetStorageUsageRatio(const std::string &) const override { return 0.0; }
+        const StorageConfig &GetStorageConfig() override { return config_; }
+        ErrorCode DoOpen(const StorageConfig &, const std::string &) override { return EC_OK; }
+        ErrorCode Close() override { return EC_OK; }
+        std::vector<std::pair<ErrorCode, DataStorageUri>>
+        Create(const std::vector<std::string> &, size_t, const std::string &, std::function<void()>) override {
+            return {};
+        }
+        std::vector<ErrorCode>
+        Delete(const std::vector<DataStorageUri> &uris, const std::string &, std::function<void()>) override {
+            const auto result = delete_calls_++ == 0 ? EC_ERROR : EC_OK;
+            return std::vector<ErrorCode>(uris.size(), result);
+        }
+        std::vector<bool> Exist(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<bool>(uris.size(), true);
+        }
+        std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        std::atomic<size_t> delete_calls_{0};
+
+    private:
+        StorageConfig config_;
+    };
+
+    auto backend = std::make_shared<FailFirstDeleteBackend>();
+    data_storage_manager_->storage_map_["retry_delete"] = backend;
+    auto request_context = std::make_shared<RequestContext>("physical_delete_retry");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    constexpr int64_t block_key = 703;
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("tp0", "dummy://retry_delete/cache/block703?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {location}, location_ids));
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheLocationDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {block_key},
+        .location_ids = {{location_ids.front()}},
+    };
+    const auto first = executor.SubmitLocationDelete(request, ScheduleTaskClass::kMigrationContinuation).get();
+    EXPECT_EQ(EC_PARTIAL_OK, first.status);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_EQ(1u, location_maps.front().size());
+    EXPECT_EQ(CLS_DELETING, location_maps.front().at(location_ids.front())->status());
+
+    request.authoritative_read = true;
+    request.resume_deleting = true;
+    const auto retry = executor.SubmitLocationDelete(request, ScheduleTaskClass::kMigrationContinuation).get();
+    EXPECT_EQ(EC_OK, retry.status) << retry.error_message;
+    EXPECT_EQ(2u, backend->delete_calls_.load());
+
+    location_maps.clear();
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    EXPECT_TRUE(location_maps.front().empty());
+}
+
 // 测试CacheLocationDelRequest的Submit方法 - 非存在实例
 TEST_F(SchedulePlanExecutorTest, TestSubmitLocationDelRequestNonExistInstance) {
     CreateMetaIndexer(kTestInstanceName, "local");
@@ -1222,6 +1299,50 @@ TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncAdmissionRunsOnWorkerAndReturnsQ
     release_blocker.set_value();
     const auto result = submit_result.future.get();
     EXPECT_TRUE(result.status == ErrorCode::EC_OK || result.status == ErrorCode::EC_PARTIAL_OK) << result.error_message;
+}
+
+TEST_F(SchedulePlanExecutorTest, TestPreparedDeleteDoesNotDependOnRedundantSync) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+
+    auto request_context = std::make_shared<RequestContext>("prepared_delete_without_sync");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    auto location = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY,
+        1,
+        std::vector<LocationSpec>{LocationSpec("test_loc", "dummy://cold/prepared-delete?size=1")});
+    location->set_status(CacheLocationStatus::CLS_DELETING);
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {905}, {location}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+    std::vector<std::vector<ErrorCode>> cas_results;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchCASLocationStatus(
+                  request_context.get(),
+                  {905},
+                  {{MetaSearcher::LocationCASTask{location_ids.front(), CLS_WRITING, CLS_DELETING}}},
+                  cas_results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), cas_results);
+
+    Stub stub;
+    stub.set(ADDR(MetaIndexer, Sync), MetaIndexer_Sync_fail_stub);
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheLocationDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {905},
+        .location_ids = {{location_ids.front()}},
+        .metadata_only = true,
+        .prepared_deleting = true,
+    };
+    auto result = executor.SubmitLocationDelete(request, ScheduleTaskClass::kMigrationContinuation).get();
+    EXPECT_EQ(ErrorCode::EC_OK, result.status) << result.error_message;
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {905}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    EXPECT_TRUE(location_maps.front().empty());
 }
 
 TEST_F(SchedulePlanExecutorTest, TestSubmitAsyncMetaSelectsAllLocationsAndSkipsDeleting) {

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -344,6 +344,77 @@ TEST_F(SchedulePlanExecutorTest, TestSetStatusToDeleting) {
     // 等待任务完成 (即使DataStorageManager为nullptr，任务也会完成，只是存储删除会失败)
     future.get();
 }
+
+TEST_F(SchedulePlanExecutorTest, TestMetaDeleteSkipsGuardedTargetAndItsExactSource) {
+    ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(EC_OK, CreateDataStorage());
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    auto request_context = std::make_shared<RequestContext>("guarded_source_delete");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    constexpr int64_t block_key = 201;
+
+    auto source = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        std::vector<LocationSpec>{SchedulePlanExecutorTestHelper::CreateLocationSpec(
+            "TP0", "nfs://nfs_01/guarded_source")});
+    source->set_status(CLS_SERVING);
+    std::vector<std::string> source_ids;
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(
+                  &meta_searcher, request_context.get(), {block_key}, {source}, source_ids));
+    ASSERT_EQ(1u, source_ids.size());
+    std::vector<std::vector<ErrorCode>> source_cas_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher.BatchCASLocationStatus(
+                  request_context.get(),
+                  {block_key},
+                  {{MetaSearcher::LocationCASTask{source_ids[0], CLS_WRITING, CLS_SERVING}}},
+                  source_cas_results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), source_cas_results);
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK,
+              meta_searcher.BatchGetLocation(
+                  request_context.get(), {block_key}, empty_mask, location_maps));
+    const auto persisted_source = location_maps[0].at(source_ids[0]);
+
+    auto target = std::make_shared<CacheLocation>(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        std::vector<LocationSpec>{SchedulePlanExecutorTestHelper::CreateLocationSpec(
+            "TP0", "nfs://nfs_01/guarded_target")});
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_ACTIVE);
+    guard.set_operation_id("guarded-delete-operation");
+    guard.set_source_location_id(persisted_source->id());
+    guard.set_source_location_create_time(persisted_source->create_time());
+    guard.set_source_storage_name("nfs_01");
+    guard.set_target_storage_name("nfs_01");
+    target->set_migration_copy_guard(guard);
+    std::vector<std::string> target_ids;
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(
+                  &meta_searcher, request_context.get(), {block_key}, {target}, target_ids));
+
+    const auto result = executor.Submit(CacheMetaDelRequest{
+                                            .instance_id = kTestInstanceName,
+                                            .block_keys = {block_key},
+                                        })
+                            .get();
+    ASSERT_EQ(EC_OK, result.status);
+
+    location_maps.clear();
+    ASSERT_EQ(EC_OK,
+              meta_searcher.BatchGetLocation(
+                  request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(2u, location_maps[0].size());
+    EXPECT_EQ(CLS_SERVING, location_maps[0].at(source_ids[0])->status());
+    EXPECT_EQ(CLS_WRITING, location_maps[0].at(target_ids[0])->status());
+    EXPECT_TRUE(location_maps[0].at(target_ids[0])->has_migration_copy_guard());
+}
 // 测试一个block_key对应多个location的情况
 TEST_F(SchedulePlanExecutorTest, TestMultipleLocationsPerBlockKey) {
     // 创建 MetaIndexer

--- a/kv_cache_manager/meta/cache_location.cc
+++ b/kv_cache_manager/meta/cache_location.cc
@@ -39,7 +39,8 @@ CacheLocation::CacheLocation(const CacheLocation &other)
     , spec_size_(other.spec_size_)
     , create_time_(other.create_time_)
     , location_specs_(other.location_specs_)
-    , validated_total_size_(other.validated_total_size_) {
+    , validated_total_size_(other.validated_total_size_)
+    , migration_copy_guard_(other.migration_copy_guard_) {
     if (const auto *owned = std::get_if<std::string>(&other.id_)) {
         id_.emplace<std::string>(*owned);
     } else {

--- a/kv_cache_manager/meta/cache_location.h
+++ b/kv_cache_manager/meta/cache_location.h
@@ -68,6 +68,122 @@ enum CacheLocationStatus : int32_t {
     CLS_DELETING = 4,
 };
 
+// Persistent ownership fence for an asynchronous migration target.  The guard lives
+// in the CacheLocation JSON so both Reclaimer and the background GC can make the
+// correct decision after a Manager restart, when the process-local active task table
+// is no longer available.
+enum class MigrationCopyGuardState : int32_t {
+    MCGS_NONE = 0,
+    MCGS_SUBMITTING = 1,
+    MCGS_ACTIVE = 2,
+    MCGS_CANCELLING = 3,
+    MCGS_UNKNOWN = 4,
+};
+
+class MigrationCopyGuard : public Jsonizable {
+public:
+    static constexpr uint32_t kCurrentSchemaVersion = 1;
+
+    MigrationCopyGuard() = default;
+    ~MigrationCopyGuard() override = default;
+
+    // A serialized guard is a safety fence, not an optional best-effort hint.
+    // Only the exact schema understood by this binary and a known state may be
+    // interpreted.  CacheLocation::FromRapidValue rejects an explicitly
+    // present but invalid/future guard, so callers fail closed instead of
+    // silently treating the target as an ordinary WRITING location.
+    bool present() const {
+        return schema_version_ == kCurrentSchemaVersion && IsKnownState(state_) && !operation_id_.empty();
+    }
+    uint32_t schema_version() const { return schema_version_; }
+    MigrationCopyGuardState state() const { return state_; }
+    const std::string &operation_id() const { return operation_id_; }
+    const std::string &source_location_id() const { return source_location_id_; }
+    int64_t source_location_create_time() const { return source_location_create_time_; }
+    const std::string &source_storage_name() const { return source_storage_name_; }
+    const std::string &target_storage_name() const { return target_storage_name_; }
+    int32_t migration_retention() const { return migration_retention_; }
+    uint64_t total_bytes() const { return total_bytes_; }
+    const std::vector<std::string> &backend_task_ids() const { return backend_task_ids_; }
+    int64_t create_time_us() const { return create_time_us_; }
+    int64_t update_time_us() const { return update_time_us_; }
+    const std::string &last_error() const { return last_error_; }
+
+    void set_schema_version(uint32_t value) { schema_version_ = value; }
+    void set_state(MigrationCopyGuardState value) { state_ = value; }
+    void set_operation_id(std::string value) { operation_id_ = std::move(value); }
+    void set_source_location_id(std::string value) { source_location_id_ = std::move(value); }
+    void set_source_location_create_time(int64_t value) { source_location_create_time_ = value; }
+    void set_source_storage_name(std::string value) { source_storage_name_ = std::move(value); }
+    void set_target_storage_name(std::string value) { target_storage_name_ = std::move(value); }
+    void set_migration_retention(int32_t value) { migration_retention_ = value; }
+    void set_total_bytes(uint64_t value) { total_bytes_ = value; }
+    void set_backend_task_ids(std::vector<std::string> value) { backend_task_ids_ = std::move(value); }
+    void set_create_time_us(int64_t value) { create_time_us_ = value; }
+    void set_update_time_us(int64_t value) { update_time_us_ = value; }
+    void set_last_error(std::string value) { last_error_ = std::move(value); }
+
+    static bool IsKnownState(MigrationCopyGuardState state) {
+        return state == MigrationCopyGuardState::MCGS_SUBMITTING ||
+               state == MigrationCopyGuardState::MCGS_ACTIVE ||
+               state == MigrationCopyGuardState::MCGS_CANCELLING ||
+               state == MigrationCopyGuardState::MCGS_UNKNOWN;
+    }
+
+    void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override {
+        Put(writer, "schema_version", schema_version_);
+        Put(writer, "state", state_);
+        Put(writer, "operation_id", operation_id_);
+        Put(writer, "source_location_id", source_location_id_);
+        Put(writer, "source_location_create_time", source_location_create_time_);
+        Put(writer, "source_storage_name", source_storage_name_);
+        Put(writer, "target_storage_name", target_storage_name_);
+        Put(writer, "migration_retention", migration_retention_);
+        Put(writer, "total_bytes", total_bytes_);
+        Put(writer, "backend_task_ids", backend_task_ids_);
+        Put(writer, "create_time_us", create_time_us_);
+        Put(writer, "update_time_us", update_time_us_);
+        Put(writer, "last_error", last_error_);
+    }
+
+    bool FromRapidValue(const rapidjson::Value &rapid_value) override {
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "schema_version", schema_version_, uint32_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "state", state_, MigrationCopyGuardState::MCGS_NONE);
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "operation_id", operation_id_, std::string());
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "source_location_id", source_location_id_, std::string());
+        KVCM_JSON_GET_DEFAULT_MACRO(
+            rapid_value, "source_location_create_time", source_location_create_time_, int64_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "source_storage_name", source_storage_name_, std::string());
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "target_storage_name", target_storage_name_, std::string());
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "migration_retention", migration_retention_, int32_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "total_bytes", total_bytes_, uint64_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(
+            rapid_value, "backend_task_ids", backend_task_ids_, std::vector<std::string>());
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "create_time_us", create_time_us_, int64_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "update_time_us", update_time_us_, int64_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "last_error", last_error_, std::string());
+        return true;
+    }
+
+private:
+    uint32_t schema_version_ = 0;
+    MigrationCopyGuardState state_ = MigrationCopyGuardState::MCGS_NONE;
+    std::string operation_id_;
+    std::string source_location_id_;
+    int64_t source_location_create_time_ = 0;
+    std::string source_storage_name_;
+    std::string target_storage_name_;
+    // Stored as the public enum's numeric value to keep meta independent from
+    // config headers.  Unknown/missing values recover conservatively as
+    // KEEP_BOTH.
+    int32_t migration_retention_ = 0;
+    uint64_t total_bytes_ = 0;
+    std::vector<std::string> backend_task_ids_;
+    int64_t create_time_us_ = 0;
+    int64_t update_time_us_ = 0;
+    std::string last_error_;
+};
+
 using BlockMaskVector = std::vector<bool>;
 using BlockMaskOffset = size_t;
 
@@ -129,6 +245,9 @@ public:
         Put(writer, "spec_size", spec_size_);
         Put(writer, "create_time", create_time_);
         Put(writer, "location_specs", location_specs_);
+        if (migration_copy_guard_.present()) {
+            Put(writer, "migration_copy_guard", migration_copy_guard_);
+        }
     }
 
     bool FromRapidValue(const rapidjson::Value &rapid_value) override {
@@ -141,6 +260,16 @@ public:
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "spec_size", spec_size_, size_t{0});
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "create_time", create_time_, int64_t{0});
         KVCM_JSON_GET_MACRO(rapid_value, "location_specs", location_specs_);
+        const bool serialized_guard_present =
+            rapid_value.IsObject() && rapid_value.HasMember("migration_copy_guard");
+        KVCM_JSON_GET_DEFAULT_MACRO(
+            rapid_value, "migration_copy_guard", migration_copy_guard_, MigrationCopyGuard());
+        if (serialized_guard_present && !migration_copy_guard_.present()) {
+            // Reject malformed and future-schema fences.  Returning a normal
+            // unguarded CacheLocation here would let old maintenance paths
+            // reclaim a target whose remote Copy outcome is still unknown.
+            return false;
+        }
         return true;
     }
 
@@ -176,6 +305,8 @@ public:
     [[nodiscard]] bool HasValidatedLocationSpecs() const noexcept {
         return validated_total_size_ != kUnknownValidatedTotalSize;
     }
+    void set_migration_copy_guard(const MigrationCopyGuard &guard) { migration_copy_guard_ = guard; }
+    void clear_migration_copy_guard() { migration_copy_guard_ = MigrationCopyGuard(); }
 
     [[nodiscard]] const std::vector<LocationSpec> &location_specs() const { return location_specs_; }
     [[nodiscard]] std::vector<LocationSpec> &mutable_location_specs() {
@@ -197,10 +328,25 @@ public:
     [[nodiscard]] DataStorageType type() const { return type_; }
     [[nodiscard]] size_t spec_size() const { return spec_size_; }
     [[nodiscard]] int64_t create_time() const { return create_time_; }
+    [[nodiscard]] bool has_migration_copy_guard() const { return migration_copy_guard_.present(); }
+    [[nodiscard]] const MigrationCopyGuard &migration_copy_guard() const { return migration_copy_guard_; }
     [[nodiscard]] size_t EstimateMemUsage() const {
         size_t usage = sizeof(CacheLocation) + id().size();
         for (const auto &spec : location_specs_) {
             usage += sizeof(LocationSpec) + spec.name().size() + spec.uri().size();
+        }
+        if (migration_copy_guard_.present()) {
+            // sizeof(CacheLocation) already includes the value member
+            // MigrationCopyGuard (including its vector object).  Count only
+            // heap-owned strings and the vector's dynamically allocated string
+            // elements here.
+            usage += migration_copy_guard_.operation_id().size() + migration_copy_guard_.source_location_id().size() +
+                     migration_copy_guard_.source_storage_name().size() +
+                     migration_copy_guard_.target_storage_name().size() + migration_copy_guard_.last_error().size();
+            usage += migration_copy_guard_.backend_task_ids().size() * sizeof(std::string);
+            for (const auto &task_id : migration_copy_guard_.backend_task_ids()) {
+                usage += task_id.size();
+            }
         }
         return usage;
     }
@@ -221,6 +367,7 @@ private:
     // retained specs are also proven valid. It is intentionally not
     // serialized, so recovered values fail closed and validate again.
     std::uint64_t validated_total_size_ = kUnknownValidatedTotalSize;
+    MigrationCopyGuard migration_copy_guard_;
 };
 
 using CacheLocationConstPtr = std::shared_ptr<const CacheLocation>;
@@ -285,5 +432,25 @@ struct CompactLocationsPerKey {
 
     void FinishKey() { offsets.push_back(values.size()); }
 };
+
+// A target guard pins the exact source identity used by the asynchronous
+// operation.  Legacy/malformed schema-v1 guards may have no create_time; fail
+// closed in that case and pin by location id rather than allowing one deletion
+// path to disagree with another.
+inline const MigrationCopyGuard *FindPersistentMigrationSourcePin(const CacheLocation &candidate,
+                                                                  const CacheLocationMap &location_map) {
+    for (const auto &[_, target] : location_map) {
+        if (!target || !target->has_migration_copy_guard()) {
+            continue;
+        }
+        const auto &guard = target->migration_copy_guard();
+        if (guard.source_location_id() == candidate.id() &&
+            (guard.source_location_create_time() <= 0 ||
+             guard.source_location_create_time() == candidate.create_time())) {
+            return &guard;
+        }
+    }
+    return nullptr;
+}
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/cache_location.h
+++ b/kv_cache_manager/meta/cache_location.h
@@ -103,6 +103,8 @@ public:
     const std::string &source_storage_name() const { return source_storage_name_; }
     const std::string &target_storage_name() const { return target_storage_name_; }
     int32_t migration_retention() const { return migration_retention_; }
+    const std::string &mark_target() const { return mark_target_; }
+    int64_t mark_deadline_ms() const { return mark_deadline_ms_; }
     uint64_t total_bytes() const { return total_bytes_; }
     const std::vector<std::string> &backend_task_ids() const { return backend_task_ids_; }
     int64_t create_time_us() const { return create_time_us_; }
@@ -117,6 +119,8 @@ public:
     void set_source_storage_name(std::string value) { source_storage_name_ = std::move(value); }
     void set_target_storage_name(std::string value) { target_storage_name_ = std::move(value); }
     void set_migration_retention(int32_t value) { migration_retention_ = value; }
+    void set_mark_target(std::string value) { mark_target_ = std::move(value); }
+    void set_mark_deadline_ms(int64_t value) { mark_deadline_ms_ = value; }
     void set_total_bytes(uint64_t value) { total_bytes_ = value; }
     void set_backend_task_ids(std::vector<std::string> value) { backend_task_ids_ = std::move(value); }
     void set_create_time_us(int64_t value) { create_time_us_ = value; }
@@ -139,6 +143,8 @@ public:
         Put(writer, "source_storage_name", source_storage_name_);
         Put(writer, "target_storage_name", target_storage_name_);
         Put(writer, "migration_retention", migration_retention_);
+        Put(writer, "mark_target", mark_target_);
+        Put(writer, "mark_deadline_ms", mark_deadline_ms_);
         Put(writer, "total_bytes", total_bytes_);
         Put(writer, "backend_task_ids", backend_task_ids_);
         Put(writer, "create_time_us", create_time_us_);
@@ -156,6 +162,8 @@ public:
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "source_storage_name", source_storage_name_, std::string());
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "target_storage_name", target_storage_name_, std::string());
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "migration_retention", migration_retention_, int32_t{0});
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "mark_target", mark_target_, std::string());
+        KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "mark_deadline_ms", mark_deadline_ms_, int64_t{0});
         KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "total_bytes", total_bytes_, uint64_t{0});
         KVCM_JSON_GET_DEFAULT_MACRO(
             rapid_value, "backend_task_ids", backend_task_ids_, std::vector<std::string>());
@@ -177,6 +185,8 @@ private:
     // config headers.  Unknown/missing values recover conservatively as
     // KEEP_BOTH.
     int32_t migration_retention_ = 0;
+    std::string mark_target_;
+    int64_t mark_deadline_ms_ = 0;
     uint64_t total_bytes_ = 0;
     std::vector<std::string> backend_task_ids_;
     int64_t create_time_us_ = 0;
@@ -342,7 +352,8 @@ public:
             // elements here.
             usage += migration_copy_guard_.operation_id().size() + migration_copy_guard_.source_location_id().size() +
                      migration_copy_guard_.source_storage_name().size() +
-                     migration_copy_guard_.target_storage_name().size() + migration_copy_guard_.last_error().size();
+                     migration_copy_guard_.target_storage_name().size() +
+                     migration_copy_guard_.mark_target().size() + migration_copy_guard_.last_error().size();
             usage += migration_copy_guard_.backend_task_ids().size() * sizeof(std::string);
             for (const auto &task_id : migration_copy_guard_.backend_task_ids()) {
                 usage += task_id.size();

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -107,9 +107,20 @@ ErrorCode MetaDummyBackend::Open() noexcept {
             if (field_name.rfind(PROPERTY_LOCATION_PREFIX, 0) == 0) {
                 std::string loc_id = field_name.substr(PROPERTY_LOCATION_PREFIX.size());
                 auto loc = std::make_shared<CacheLocation>();
-                if (loc->FromJsonString(field_value)) {
-                    item.locations[loc_id] = std::move(loc);
+                if (!loc->FromJsonString(field_value)) {
+                    // A malformed/future migration guard is an ownership fence
+                    // this binary cannot interpret.  Silently dropping it and
+                    // later rewriting the whole persistence file would erase
+                    // the fence, so fail the complete Open instead.
+                    KVCM_LOG_ERROR("parse persisted CacheLocation failed, path: [%s], key: [%s], location: [%s]",
+                                   path_.c_str(),
+                                   k.c_str(),
+                                   loc_id.c_str());
+                    table_.Clear();
+                    metadata_.clear();
+                    return ErrorCode::EC_CORRUPTION;
                 }
+                item.locations[loc_id] = std::move(loc);
             } else {
                 item.properties[field_name] = std::move(field_value);
             }

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -1,11 +1,15 @@
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
+#include <map>
 #include <string>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/jsonizable.h"
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
+#include "kv_cache_manager/meta/cache_location.h"
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_dummy_backend.h"
 #include "kv_cache_manager/meta/test/meta_storage_backend_test_base.h"
@@ -136,6 +140,46 @@ TEST_F(MetaDummyBackendTest, TestInit) {
     // invalid config
     ASSERT_NE(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", /*config*/ nullptr));
     ASSERT_NE(ErrorCode::EC_OK, meta_storage_backend_->Init(/*instance_id*/ "", meta_storage_backend_config_));
+}
+
+TEST_F(MetaDummyBackendTest, TestFutureGuardFailsOpenInsteadOfBeingSilentlyErased) {
+    const std::string instance_id = "future_guard_instance";
+    const std::string base_path = GetPrivateTestRuntimeDataPath() + "_meta_dummy_backend_future_guard";
+    const std::string persistence_path = base_path + "_" + instance_id;
+    std::filesystem::remove(persistence_path);
+
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_ACTIVE);
+    guard.set_operation_id("future-guard-operation");
+    CacheLocation location(
+        DataStorageType::DATA_STORAGE_TYPE_DUMMY, 1, {LocationSpec("TP0", "dummy://future-guard?size=7")});
+    location.set_id("future-guard-location");
+    location.set_status(CLS_WRITING);
+    location.set_migration_copy_guard(guard);
+    std::string serialized_location = location.ToJsonString();
+    const std::string current_schema =
+        "\"schema_version\":" + std::to_string(MigrationCopyGuard::kCurrentSchemaVersion);
+    const auto schema_pos = serialized_location.find(current_schema);
+    ASSERT_NE(std::string::npos, schema_pos);
+    serialized_location.replace(schema_pos,
+                                current_schema.size(),
+                                "\"schema_version\":" + std::to_string(MigrationCopyGuard::kCurrentSchemaVersion + 1));
+
+    FieldMap fields{{PROPERTY_LOCATION_PREFIX + location.id(), serialized_location}};
+    std::map<std::string, std::string> persisted{{"1", Jsonizable::ToJsonString(fields)}};
+    {
+        std::ofstream output(persistence_path);
+        ASSERT_TRUE(output.is_open());
+        output << Jsonizable::ToJsonString(persisted);
+    }
+
+    auto config = std::make_shared<MetaStorageBackendConfig>();
+    config->SetStorageUri("file://" + base_path);
+    auto backend = std::make_shared<MetaDummyBackend>();
+    ASSERT_EQ(EC_OK, backend->Init(instance_id, config));
+    EXPECT_EQ(EC_CORRUPTION, backend->Open());
+    std::filesystem::remove(persistence_path);
 }
 
 TEST_F(MetaDummyBackendTest, TestPut) {

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -276,6 +276,9 @@ message MigrationConfig {
     google.protobuf.Int64Value copy_operation_deadline_ms = 8;
     google.protobuf.Int64Value copy_poll_initial_interval_ms = 9;
     google.protobuf.Int64Value copy_poll_max_interval_ms = 10;
+    google.protobuf.Int64Value copy_connect_timeout_ms = 11;
+    google.protobuf.Int64Value copy_submit_timeout_ms = 12;
+    google.protobuf.Int64Value copy_query_timeout_ms = 13;
 }
 
 enum CachePreferStrategy {

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -232,6 +232,11 @@ enum MigrationMarkClearPolicy {
     MIGRATION_MARK_CLEAR_ON_FULL_BLOCK_COVERED = 1; // target CacheLocation 覆盖完整 block 后清标
 }
 
+enum MigrationCopyExecutionMode {
+    MIGRATION_COPY_SYNC = 0;
+    MIGRATION_COPY_ASYNC_REQUIRED = 1;
+}
+
 // 执行方式配置（Config 后缀用于区分 MigrationMethod 请求枚举）。
 
 // Copy 执行方式配置：通过 DataStorageBackend::Copy 把数据复制到目标 storage
@@ -264,6 +269,13 @@ message MigrationConfig {
     repeated MigrationStrategy strategies = 1; // 多层存储迁移规则，per-storage
     google.protobuf.Int32Value copy_max_concurrency = 2; // instance group 级 Copy 并发上限
     MigrationMarkClearPolicy mark_clear_policy = 3; // instance group 级 Mark 清理策略
+    MigrationCopyExecutionMode copy_execution_mode = 4;
+    google.protobuf.UInt64Value copy_max_inflight_bytes = 5;
+    google.protobuf.Int64Value copy_max_quarantine_operations = 6;
+    google.protobuf.UInt64Value copy_max_quarantine_bytes = 7;
+    google.protobuf.Int64Value copy_operation_deadline_ms = 8;
+    google.protobuf.Int64Value copy_poll_initial_interval_ms = 9;
+    google.protobuf.Int64Value copy_poll_max_interval_ms = 10;
 }
 
 enum CachePreferStrategy {
@@ -451,6 +463,43 @@ message MigrateCacheResponse {
     CommonResponseHeader header = 1;
     int64 accepted = 2; // 接受并投递的 block 数
     int64 rejected = 3; // 被准入策略 / 校验拒绝的 block 数
+}
+
+// Fail-closed asynchronous Copy targets that cannot yet prove remote drain.
+message ListAsyncCopyQuarantineRequest {
+    string trace_id = 1;
+    string instance_group_name = 2; // empty = all groups
+}
+
+message AsyncCopyQuarantineRecord {
+    string instance_group_name = 1;
+    string instance_id = 2;
+    int64 block_key = 3;
+    string target_location_id = 4;
+    int32 guard_state = 5;
+    string operation_id = 6;
+    string source_location_id = 7;
+    int64 source_location_create_time = 8;
+    string source_storage_name = 9;
+    string target_storage_name = 10;
+    uint64 total_bytes = 11;
+    repeated string backend_task_ids = 12;
+    int64 create_time_us = 13;
+    int64 update_time_us = 14;
+    string last_error = 15;
+}
+
+message ListAsyncCopyQuarantineResponse {
+    CommonResponseHeader header = 1;
+    repeated AsyncCopyQuarantineRecord records = 2;
+}
+
+message BreakGlassReleaseAsyncCopyRequest {
+    string trace_id = 1;
+    string operation_id = 2;
+    string operator_name = 3;
+    string external_fencing_evidence = 4;
+    bool external_fencing_confirmed = 5;
 }
 
 message ModelDeployment {
@@ -652,6 +701,8 @@ service AdminService {
     rpc RemoveCache(RemoveCacheRequest) returns (CommonResponse);
     // 跨存储层迁移指定 block 的 cache（Copy / Mark），支持显式 block_keys 或规则采样
     rpc MigrateCache(MigrateCacheRequest) returns (MigrateCacheResponse);
+    rpc ListAsyncCopyQuarantine(ListAsyncCopyQuarantineRequest) returns (ListAsyncCopyQuarantineResponse);
+    rpc BreakGlassReleaseAsyncCopy(BreakGlassReleaseAsyncCopyRequest) returns (CommonResponse);
     // 增删改查instance信息
     rpc RegisterInstance(RegisterInstanceRequest) returns (CommonResponse);
     rpc RemoveInstance(RemoveInstanceRequest) returns (CommonResponse);

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -22,6 +22,7 @@
 #include "kv_cache_manager/data_storage/event_report_backend.h"
 #include "kv_cache_manager/manager/cache_manager.h"
 #include "kv_cache_manager/manager/cache_manager_metrics_recorder.h"
+#include "kv_cache_manager/manager/migration_manager.h"
 #include "kv_cache_manager/metrics/metrics_lifecycle.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "kv_cache_manager/metrics/metrics_reporter.h"
@@ -618,6 +619,72 @@ void AdminServiceImpl::MigrateCache(RequestContext *request_context,
                   static_cast<int>(method),
                   static_cast<long long>(result.accepted),
                   static_cast<long long>(result.rejected));
+}
+
+void AdminServiceImpl::ListAsyncCopyQuarantine(
+    RequestContext *request_context,
+    const proto::admin::ListAsyncCopyQuarantineRequest *request,
+    proto::admin::ListAsyncCopyQuarantineResponse *response) {
+    API_CALL_GUARD("ListAsyncCopyQuarantine", true);
+    auto *status = response->mutable_header()->mutable_status();
+    auto migration_manager = cache_manager_ ? cache_manager_->migration_manager() : nullptr;
+    if (!migration_manager) {
+        status->set_code(proto::admin::INTERNAL_ERROR);
+        status->set_message("MigrationManager is unavailable");
+        request_context->set_status_code(status->code());
+        return;
+    }
+    const auto records = migration_manager->ListAsyncCopyQuarantine(request->instance_group_name());
+    for (const auto &record : records) {
+        auto *out = response->add_records();
+        out->set_instance_group_name(record.instance_group_name);
+        out->set_instance_id(record.instance_id);
+        out->set_block_key(record.block_key);
+        out->set_target_location_id(record.target_location_id);
+        const auto &guard = record.guard;
+        out->set_guard_state(static_cast<int32_t>(guard.state()));
+        out->set_operation_id(guard.operation_id());
+        out->set_source_location_id(guard.source_location_id());
+        out->set_source_location_create_time(guard.source_location_create_time());
+        out->set_source_storage_name(guard.source_storage_name());
+        out->set_target_storage_name(guard.target_storage_name());
+        out->set_total_bytes(guard.total_bytes());
+        for (const auto &task_id : guard.backend_task_ids()) {
+            out->add_backend_task_ids(task_id);
+        }
+        out->set_create_time_us(guard.create_time_us());
+        out->set_update_time_us(guard.update_time_us());
+        out->set_last_error(guard.last_error());
+    }
+    status->set_code(proto::admin::OK);
+    status->set_message("Asynchronous Copy quarantine listed successfully");
+    request_context->set_status_code(status->code());
+}
+
+void AdminServiceImpl::BreakGlassReleaseAsyncCopy(
+    RequestContext *request_context,
+    const proto::admin::BreakGlassReleaseAsyncCopyRequest *request,
+    proto::admin::CommonResponse *response) {
+    API_CALL_GUARD("BreakGlassReleaseAsyncCopy", true);
+    auto *status = response->mutable_header()->mutable_status();
+    if (request->operation_id().empty() || request->operator_name().empty() ||
+        request->external_fencing_evidence().empty() || !request->external_fencing_confirmed()) {
+        status->set_code(proto::admin::INVALID_ARGUMENT);
+        status->set_message(
+            "operation_id, operator_name, external_fencing_evidence and external_fencing_confirmed=true are required");
+        request_context->set_status_code(status->code());
+        return;
+    }
+    auto migration_manager = cache_manager_ ? cache_manager_->migration_manager() : nullptr;
+    const auto ec = migration_manager
+                        ? migration_manager->BreakGlassReleaseAsyncCopy(request->operation_id(),
+                                                                       request->operator_name(),
+                                                                       request->external_fencing_evidence())
+                        : EC_ERROR;
+    status->set_code(ec == EC_OK ? proto::admin::OK : ToAdminPbError(ec));
+    status->set_message(ec == EC_OK ? "Asynchronous Copy quarantine released after external fencing"
+                                    : "Failed to release asynchronous Copy quarantine");
+    request_context->set_status_code(status->code());
 }
 
 // Instance相关接口实现

--- a/kv_cache_manager/service/admin_service_impl.h
+++ b/kv_cache_manager/service/admin_service_impl.h
@@ -68,6 +68,12 @@ public:
     void MigrateCache(RequestContext *request_context,
                       const proto::admin::MigrateCacheRequest *request,
                       proto::admin::MigrateCacheResponse *response);
+    void ListAsyncCopyQuarantine(RequestContext *request_context,
+                                 const proto::admin::ListAsyncCopyQuarantineRequest *request,
+                                 proto::admin::ListAsyncCopyQuarantineResponse *response);
+    void BreakGlassReleaseAsyncCopy(RequestContext *request_context,
+                                    const proto::admin::BreakGlassReleaseAsyncCopyRequest *request,
+                                    proto::admin::CommonResponse *response);
 
     void RegisterInstance(RequestContext *request_context,
                           const proto::admin::RegisterInstanceRequest *request,

--- a/kv_cache_manager/service/grpc_service/admin_service_grpc.cc
+++ b/kv_cache_manager/service/grpc_service/admin_service_grpc.cc
@@ -36,6 +36,8 @@ void AdminServiceGRpc::Init() {
     MAKE_SERVICE_METRICS_COLLECTOR(GetCacheMeta);
     MAKE_SERVICE_METRICS_COLLECTOR(RemoveCache);
     MAKE_SERVICE_METRICS_COLLECTOR(MigrateCache);
+    MAKE_SERVICE_METRICS_COLLECTOR(ListAsyncCopyQuarantine);
+    MAKE_SERVICE_METRICS_COLLECTOR(BreakGlassReleaseAsyncCopy);
 
     // for instance APIs
     MAKE_SERVICE_METRICS_COLLECTOR(RegisterInstance);
@@ -175,6 +177,24 @@ grpc::Status AdminServiceGRpc::MigrateCache(grpc::ServerContext *context,
                                             proto::admin::MigrateCacheResponse *response) {
     API_CONTEXT_INIT_GRPC(MigrateCache)
     admin_service_impl_->MigrateCache(request_context, request, response);
+    return grpc::Status::OK;
+}
+
+grpc::Status AdminServiceGRpc::ListAsyncCopyQuarantine(
+    grpc::ServerContext *context,
+    const proto::admin::ListAsyncCopyQuarantineRequest *request,
+    proto::admin::ListAsyncCopyQuarantineResponse *response) {
+    API_CONTEXT_INIT_GRPC(ListAsyncCopyQuarantine)
+    admin_service_impl_->ListAsyncCopyQuarantine(request_context, request, response);
+    return grpc::Status::OK;
+}
+
+grpc::Status AdminServiceGRpc::BreakGlassReleaseAsyncCopy(
+    grpc::ServerContext *context,
+    const proto::admin::BreakGlassReleaseAsyncCopyRequest *request,
+    proto::admin::CommonResponse *response) {
+    API_CONTEXT_INIT_GRPC(BreakGlassReleaseAsyncCopy)
+    admin_service_impl_->BreakGlassReleaseAsyncCopy(request_context, request, response);
     return grpc::Status::OK;
 }
 

--- a/kv_cache_manager/service/grpc_service/admin_service_grpc.h
+++ b/kv_cache_manager/service/grpc_service/admin_service_grpc.h
@@ -61,6 +61,14 @@ public:
     grpc::Status MigrateCache(grpc::ServerContext *context,
                               const proto::admin::MigrateCacheRequest *request,
                               proto::admin::MigrateCacheResponse *response) override;
+    grpc::Status ListAsyncCopyQuarantine(
+        grpc::ServerContext *context,
+        const proto::admin::ListAsyncCopyQuarantineRequest *request,
+        proto::admin::ListAsyncCopyQuarantineResponse *response) override;
+    grpc::Status BreakGlassReleaseAsyncCopy(
+        grpc::ServerContext *context,
+        const proto::admin::BreakGlassReleaseAsyncCopyRequest *request,
+        proto::admin::CommonResponse *response) override;
     grpc::Status RegisterInstance(grpc::ServerContext *context,
                                   const proto::admin::RegisterInstanceRequest *request,
                                   proto::admin::CommonResponse *response) override;
@@ -135,6 +143,8 @@ private:
     KVCM_DECLARE_METRICS_COLLECTOR_(GetCacheMeta);
     KVCM_DECLARE_METRICS_COLLECTOR_(RemoveCache);
     KVCM_DECLARE_METRICS_COLLECTOR_(MigrateCache);
+    KVCM_DECLARE_METRICS_COLLECTOR_(ListAsyncCopyQuarantine);
+    KVCM_DECLARE_METRICS_COLLECTOR_(BreakGlassReleaseAsyncCopy);
 
     // for instance APIs
     KVCM_DECLARE_METRICS_COLLECTOR_(RegisterInstance);

--- a/kv_cache_manager/service/http_service/admin_service_http.cc
+++ b/kv_cache_manager/service/http_service/admin_service_http.cc
@@ -49,6 +49,8 @@ void AdminServiceHttp::Init() {
     MAKE_SERVICE_METRICS_COLLECTOR(GetCacheMeta);
     MAKE_SERVICE_METRICS_COLLECTOR(RemoveCache);
     MAKE_SERVICE_METRICS_COLLECTOR(MigrateCache);
+    MAKE_SERVICE_METRICS_COLLECTOR(ListAsyncCopyQuarantine);
+    MAKE_SERVICE_METRICS_COLLECTOR(BreakGlassReleaseAsyncCopy);
 
     // for instance APIs
     MAKE_SERVICE_METRICS_COLLECTOR(RegisterInstance);
@@ -104,6 +106,16 @@ void AdminServiceHttp::RegisterHandler() {
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, getCacheMeta, GetCacheMeta, GetCacheMeta, GetCacheMeta);
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, removeCache, RemoveCache, Common, RemoveCache);
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, migrateCache, MigrateCache, MigrateCache, MigrateCache);
+    REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post,
+                                            listAsyncCopyQuarantine,
+                                            ListAsyncCopyQuarantine,
+                                            ListAsyncCopyQuarantine,
+                                            ListAsyncCopyQuarantine);
+    REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post,
+                                            breakGlassReleaseAsyncCopy,
+                                            BreakGlassReleaseAsyncCopy,
+                                            Common,
+                                            BreakGlassReleaseAsyncCopy);
 
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, registerInstance, RegisterInstance, Common, RegisterInstance);
     REGISTER_HTTP_HANDLER_FOR_ADMIN_SERVICE(Post, removeInstance, RemoveInstance, Common, RemoveInstance);
@@ -332,6 +344,24 @@ CoroHttpService::CachedJsonResponse AdminServiceHttp::MigrateCache(coro_http::co
                   request->instance_id().c_str());
 
     admin_service_impl_->MigrateCache(request_context, request, response);
+    return request_context->TakeReusableResponseJson();
+}
+
+CoroHttpService::CachedJsonResponse AdminServiceHttp::ListAsyncCopyQuarantine(
+    coro_http::coro_http_connection *http_conn,
+    proto::admin::ListAsyncCopyQuarantineRequest *request,
+    proto::admin::ListAsyncCopyQuarantineResponse *response) {
+    API_CONTEXT_INIT_HTTP(ListAsyncCopyQuarantine)
+    admin_service_impl_->ListAsyncCopyQuarantine(request_context, request, response);
+    return request_context->TakeReusableResponseJson();
+}
+
+CoroHttpService::CachedJsonResponse AdminServiceHttp::BreakGlassReleaseAsyncCopy(
+    coro_http::coro_http_connection *http_conn,
+    proto::admin::BreakGlassReleaseAsyncCopyRequest *request,
+    proto::admin::CommonResponse *response) {
+    API_CONTEXT_INIT_HTTP(BreakGlassReleaseAsyncCopy)
+    admin_service_impl_->BreakGlassReleaseAsyncCopy(request_context, request, response);
     return request_context->TakeReusableResponseJson();
 }
 

--- a/kv_cache_manager/service/http_service/admin_service_http.h
+++ b/kv_cache_manager/service/http_service/admin_service_http.h
@@ -68,6 +68,12 @@ public:
     CachedJsonResponse MigrateCache(coro_http::coro_http_connection *http_conn,
                                     proto::admin::MigrateCacheRequest *request,
                                     proto::admin::MigrateCacheResponse *response);
+    CachedJsonResponse ListAsyncCopyQuarantine(coro_http::coro_http_connection *http_conn,
+                                               proto::admin::ListAsyncCopyQuarantineRequest *request,
+                                               proto::admin::ListAsyncCopyQuarantineResponse *response);
+    CachedJsonResponse BreakGlassReleaseAsyncCopy(coro_http::coro_http_connection *http_conn,
+                                                 proto::admin::BreakGlassReleaseAsyncCopyRequest *request,
+                                                 proto::admin::CommonResponse *response);
 
     CachedJsonResponse RegisterInstance(coro_http::coro_http_connection *http_conn,
                                         proto::admin::RegisterInstanceRequest *request,
@@ -148,6 +154,8 @@ private:
     KVCM_DECLARE_METRICS_COLLECTOR_(GetCacheMeta);
     KVCM_DECLARE_METRICS_COLLECTOR_(RemoveCache);
     KVCM_DECLARE_METRICS_COLLECTOR_(MigrateCache);
+    KVCM_DECLARE_METRICS_COLLECTOR_(ListAsyncCopyQuarantine);
+    KVCM_DECLARE_METRICS_COLLECTOR_(BreakGlassReleaseAsyncCopy);
 
     // for instance APIs
     KVCM_DECLARE_METRICS_COLLECTOR_(RegisterInstance);

--- a/kv_cache_manager/service/server.cc
+++ b/kv_cache_manager/service/server.cc
@@ -1,5 +1,6 @@
 #include "kv_cache_manager/service/server.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <grpcpp/grpcpp.h>
 
@@ -31,6 +32,10 @@
 #include "kv_cache_manager/service/meta_service_impl.h"
 
 namespace kv_cache_manager {
+
+namespace {
+constexpr int64_t kLeaderRecoveryFailureCampaignBackoffMs = 5000;
+}
 
 bool Server::Init(const ServerConfig &config) {
     KVCM_LOG_INFO("begin server init...\n");
@@ -121,6 +126,7 @@ void Server::OnBecomeLeader() {
     ErrorCode ec = registry_manager_->DoRecover();
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("registry_manager recover failed");
+        AbortLeaderRecovery("registry_manager", ec);
         return;
     }
 
@@ -136,19 +142,45 @@ void Server::OnBecomeLeader() {
     ec = cache_manager_->DoRecover();
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("cache_manager recover failed");
+        AbortLeaderRecovery("cache_manager", ec);
+        return;
+    }
+    // MigrationManager performs the persistent async-Copy guard recovery
+    // barrier synchronously.  Reclaimer and GC must not run before that scan
+    // has rebuilt active/query and quarantine accounting.
+    ec = cache_manager_->StartMigrationManager();
+    if (ec != EC_OK) {
+        KVCM_LOG_ERROR("migration manager guard recovery/start failed, ec[%d]", static_cast<int>(ec));
+        AbortLeaderRecovery("migration_manager", ec);
         return;
     }
     ec = cache_manager_->StartCacheGarbageCollector();
     if (ec != EC_OK) {
         KVCM_LOG_ERROR("cache garbage collector start failed, ec[%d]", static_cast<int>(ec));
+        AbortLeaderRecovery("cache_garbage_collector", ec);
         return;
     }
     cache_manager_->ResumeReclaimer();
-    cache_manager_->StartMigrationManager();
 
     meta_impl_->EnableLeaderOnlyRequests();
     admin_impl_->EnableLeaderOnlyRequests();
     KVCM_LOG_INFO("recover end");
+}
+
+void Server::AbortLeaderRecovery(const char *stage, ErrorCode ec) {
+    // Keeping the lease while leader-only APIs remain disabled creates a
+    // wedged cluster.  Fail this promotion attempt explicitly and delay this
+    // node's next campaign so another replica can recover.  The normal demote
+    // callback performs whatever partial cleanup is needed.
+    meta_impl_->DisableLeaderOnlyRequests();
+    admin_impl_->DisableLeaderOnlyRequests();
+    const int64_t current_backoff = leader_elector_->GetForbidCampaignLeaderTimeMs();
+    leader_elector_->SetForbidCampaignLeaderTimeMs(std::max(current_backoff, kLeaderRecoveryFailureCampaignBackoffMs));
+    KVCM_LOG_ERROR("leader recovery aborted at stage %s, ec[%d]; demoting with campaign backoff %lld ms",
+                   stage,
+                   static_cast<int>(ec),
+                   static_cast<long long>(leader_elector_->GetForbidCampaignLeaderTimeMs()));
+    leader_elector_->Demote();
 }
 
 void Server::OnNoLongerLeader() {

--- a/kv_cache_manager/service/server.h
+++ b/kv_cache_manager/service/server.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <thread>
 
+#include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/service/server_config.h"
 
@@ -50,6 +51,7 @@ private:
 
     void OnBecomeLeader();
     void OnNoLongerLeader();
+    void AbortLeaderRecovery(const char *stage, ErrorCode ec);
 
 private:
     const std::string kLeaderLockKey = "_TAIR_KVCM_LEADER_KEY";

--- a/kv_cache_manager/service/test/admin_service_impl_test.cc
+++ b/kv_cache_manager/service/test/admin_service_impl_test.cc
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -623,4 +624,70 @@ TEST_F(AdminServiceImplTest, TestExplicitBlockKeysRejectsDstAlreadyHasCopy) {
     ASSERT_FALSE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 701));
     ASSERT_FALSE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 702));
     ASSERT_TRUE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 703));
+}
+
+TEST_F(AdminServiceImplTest, TestAsyncCopyQuarantineListAndBreakGlassValidation) {
+    auto migration_manager = cache_manager_->migration_manager();
+    ASSERT_NE(nullptr, migration_manager);
+
+    MigrationCopyGuard guard;
+    guard.set_schema_version(MigrationCopyGuard::kCurrentSchemaVersion);
+    guard.set_state(MigrationCopyGuardState::MCGS_UNKNOWN);
+    guard.set_operation_id("admin-operation-801");
+    guard.set_source_location_id("admin-source-801");
+    guard.set_source_location_create_time(801);
+    guard.set_source_storage_name("hot_01");
+    guard.set_target_storage_name("cold_01");
+    guard.set_total_bytes(16);
+    guard.set_backend_task_ids({"pace-admin-task-801"});
+    guard.set_create_time_us(1000);
+    guard.set_update_time_us(2000);
+    guard.set_last_error("remote_state_unknown");
+    {
+        std::lock_guard<std::mutex> lock(migration_manager->async_copy_usage_mutex_);
+        migration_manager->async_copy_quarantine_by_operation_.emplace(
+            guard.operation_id(),
+            MigrationManager::AsyncCopyQuarantineRecord{
+                "default", kInstance, 801, "admin-target-801", guard});
+    }
+
+    auto rc = std::make_shared<RequestContext>("list_async_copy_quarantine");
+    proto::admin::ListAsyncCopyQuarantineRequest list_request;
+    list_request.set_trace_id("list-801");
+    list_request.set_instance_group_name("default");
+    proto::admin::ListAsyncCopyQuarantineResponse list_response;
+    admin_->ListAsyncCopyQuarantine(rc.get(), &list_request, &list_response);
+
+    ASSERT_EQ(proto::admin::OK, list_response.header().status().code());
+    ASSERT_EQ(1, list_response.records_size());
+    const auto &record = list_response.records(0);
+    EXPECT_EQ("default", record.instance_group_name());
+    EXPECT_EQ(kInstance, record.instance_id());
+    EXPECT_EQ(801, record.block_key());
+    EXPECT_EQ("admin-target-801", record.target_location_id());
+    EXPECT_EQ(static_cast<int32_t>(MigrationCopyGuardState::MCGS_UNKNOWN), record.guard_state());
+    EXPECT_EQ(guard.operation_id(), record.operation_id());
+    EXPECT_EQ(guard.backend_task_ids()[0], record.backend_task_ids(0));
+    EXPECT_EQ(guard.last_error(), record.last_error());
+
+    proto::admin::ListAsyncCopyQuarantineRequest filtered_request;
+    filtered_request.set_trace_id("list-filtered-801");
+    filtered_request.set_instance_group_name("another-group");
+    proto::admin::ListAsyncCopyQuarantineResponse filtered_response;
+    admin_->ListAsyncCopyQuarantine(rc.get(), &filtered_request, &filtered_response);
+    EXPECT_EQ(proto::admin::OK, filtered_response.header().status().code());
+    EXPECT_EQ(0, filtered_response.records_size());
+
+    proto::admin::BreakGlassReleaseAsyncCopyRequest release_request;
+    release_request.set_trace_id("release-801");
+    release_request.set_operation_id(guard.operation_id());
+    release_request.set_operator_name("operator-801");
+    release_request.set_external_fencing_evidence("ticket-801");
+    // Merely supplying text evidence is insufficient: the operator must make
+    // the explicit external-fencing assertion before the service calls Manager.
+    release_request.set_external_fencing_confirmed(false);
+    proto::admin::CommonResponse release_response;
+    admin_->BreakGlassReleaseAsyncCopy(rc.get(), &release_request, &release_response);
+    EXPECT_EQ(proto::admin::INVALID_ARGUMENT, release_response.header().status().code());
+    EXPECT_EQ(1u, migration_manager->ListAsyncCopyQuarantine("default").size());
 }

--- a/kv_cache_manager/service/util/fast_proto_json_codec.cc
+++ b/kv_cache_manager/service/util/fast_proto_json_codec.cc
@@ -105,6 +105,7 @@ enum class WrapperKind {
     kNone,
     kInt32,
     kInt64,
+    kUInt64,
     kUnsupportedWellKnownType,
 };
 
@@ -115,6 +116,9 @@ WrapperKind GetWrapperKind(const Descriptor *descriptor) {
     }
     if (name == "google.protobuf.Int64Value") {
         return WrapperKind::kInt64;
+    }
+    if (name == "google.protobuf.UInt64Value") {
+        return WrapperKind::kUInt64;
     }
     if (name.compare(0, sizeof("google.protobuf.") - 1, "google.protobuf.") == 0) {
         return WrapperKind::kUnsupportedWellKnownType;
@@ -128,7 +132,8 @@ bool SupportsDescriptor(const Descriptor *descriptor, std::unordered_set<const D
     }
 
     const WrapperKind wrapper_kind = GetWrapperKind(descriptor);
-    if (wrapper_kind == WrapperKind::kInt32 || wrapper_kind == WrapperKind::kInt64) {
+    if (wrapper_kind == WrapperKind::kInt32 || wrapper_kind == WrapperKind::kInt64 ||
+        wrapper_kind == WrapperKind::kUInt64) {
         return true;
     }
     if (wrapper_kind == WrapperKind::kUnsupportedWellKnownType || descriptor->extension_range_count() != 0) {
@@ -216,6 +221,10 @@ bool WriteWrapper(const Message &message, WrapperKind kind, JsonWriter &writer) 
     }
     if (kind == WrapperKind::kInt64) {
         WriteInt64(reflection->GetInt64(message, value_field), writer);
+        return true;
+    }
+    if (kind == WrapperKind::kUInt64) {
+        WriteUInt64(reflection->GetUInt64(message, value_field), writer);
         return true;
     }
     return false;
@@ -412,6 +421,16 @@ bool ParseWrapperValue(const rapidjson::Value &value, Message *message, WrapperK
             return false;
         }
         reflection->SetInt64(message, field, result);
+        return true;
+    }
+    if (kind == WrapperKind::kUInt64) {
+        uint64_t result = 0;
+        if (value.IsUint64()) {
+            result = value.GetUint64();
+        } else if (!ParseIntegerString(value, &result)) {
+            return false;
+        }
+        reflection->SetUInt64(message, field, result);
         return true;
     }
     return false;

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -257,6 +257,20 @@ void ProtoConvert::CacheConfigToProto(const CacheConfig &cache_config_info,
     migration_config->mutable_copy_max_concurrency()->set_value(cache_config_info.migration_copy_max_concurrency());
     migration_config->set_mark_clear_policy(
         static_cast<proto::admin::MigrationMarkClearPolicy>(cache_config_info.migration_mark_clear_policy()));
+    migration_config->set_copy_execution_mode(
+        static_cast<proto::admin::MigrationCopyExecutionMode>(cache_config_info.migration_copy_execution_mode()));
+    migration_config->mutable_copy_max_inflight_bytes()->set_value(
+        cache_config_info.migration_copy_max_inflight_bytes());
+    migration_config->mutable_copy_max_quarantine_operations()->set_value(
+        cache_config_info.migration_copy_max_quarantine_operations());
+    migration_config->mutable_copy_max_quarantine_bytes()->set_value(
+        cache_config_info.migration_copy_max_quarantine_bytes());
+    migration_config->mutable_copy_operation_deadline_ms()->set_value(
+        cache_config_info.migration_copy_operation_deadline_ms());
+    migration_config->mutable_copy_poll_initial_interval_ms()->set_value(
+        cache_config_info.migration_copy_poll_initial_interval_ms());
+    migration_config->mutable_copy_poll_max_interval_ms()->set_value(
+        cache_config_info.migration_copy_poll_max_interval_ms());
     for (const auto &migration_strategy : cache_config_info.migration_strategies()) {
         if (migration_strategy == nullptr) {
             continue;
@@ -309,6 +323,32 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
     }
     cache_config_info.set_migration_mark_clear_policy(
         static_cast<MigrationMarkClearPolicy>(proto_migration_config.mark_clear_policy()));
+    cache_config_info.set_migration_copy_execution_mode(
+        static_cast<MigrationCopyExecutionMode>(proto_migration_config.copy_execution_mode()));
+    cache_config_info.set_migration_copy_max_inflight_bytes(
+        proto_migration_config.has_copy_max_inflight_bytes()
+            ? proto_migration_config.copy_max_inflight_bytes().value()
+            : 0);
+    cache_config_info.set_migration_copy_max_quarantine_operations(
+        proto_migration_config.has_copy_max_quarantine_operations()
+            ? proto_migration_config.copy_max_quarantine_operations().value()
+            : 0);
+    cache_config_info.set_migration_copy_max_quarantine_bytes(
+        proto_migration_config.has_copy_max_quarantine_bytes()
+            ? proto_migration_config.copy_max_quarantine_bytes().value()
+            : 0);
+    cache_config_info.set_migration_copy_operation_deadline_ms(
+        proto_migration_config.has_copy_operation_deadline_ms()
+            ? proto_migration_config.copy_operation_deadline_ms().value()
+            : MigrationConfig::kDefaultCopyOperationDeadlineMs);
+    cache_config_info.set_migration_copy_poll_initial_interval_ms(
+        proto_migration_config.has_copy_poll_initial_interval_ms()
+            ? proto_migration_config.copy_poll_initial_interval_ms().value()
+            : MigrationConfig::kDefaultCopyPollInitialIntervalMs);
+    cache_config_info.set_migration_copy_poll_max_interval_ms(
+        proto_migration_config.has_copy_poll_max_interval_ms()
+            ? proto_migration_config.copy_poll_max_interval_ms().value()
+            : MigrationConfig::kDefaultCopyPollMaxIntervalMs);
 
     // 转换meta_indexer_config
     auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -271,6 +271,12 @@ void ProtoConvert::CacheConfigToProto(const CacheConfig &cache_config_info,
         cache_config_info.migration_copy_poll_initial_interval_ms());
     migration_config->mutable_copy_poll_max_interval_ms()->set_value(
         cache_config_info.migration_copy_poll_max_interval_ms());
+    migration_config->mutable_copy_connect_timeout_ms()->set_value(
+        cache_config_info.migration_copy_connect_timeout_ms());
+    migration_config->mutable_copy_submit_timeout_ms()->set_value(
+        cache_config_info.migration_copy_submit_timeout_ms());
+    migration_config->mutable_copy_query_timeout_ms()->set_value(
+        cache_config_info.migration_copy_query_timeout_ms());
     for (const auto &migration_strategy : cache_config_info.migration_strategies()) {
         if (migration_strategy == nullptr) {
             continue;
@@ -349,6 +355,18 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
         proto_migration_config.has_copy_poll_max_interval_ms()
             ? proto_migration_config.copy_poll_max_interval_ms().value()
             : MigrationConfig::kDefaultCopyPollMaxIntervalMs);
+    cache_config_info.set_migration_copy_connect_timeout_ms(
+        proto_migration_config.has_copy_connect_timeout_ms()
+            ? proto_migration_config.copy_connect_timeout_ms().value()
+            : MigrationConfig::kDefaultCopyConnectTimeoutMs);
+    cache_config_info.set_migration_copy_submit_timeout_ms(
+        proto_migration_config.has_copy_submit_timeout_ms()
+            ? proto_migration_config.copy_submit_timeout_ms().value()
+            : MigrationConfig::kDefaultCopySubmitTimeoutMs);
+    cache_config_info.set_migration_copy_query_timeout_ms(
+        proto_migration_config.has_copy_query_timeout_ms()
+            ? proto_migration_config.copy_query_timeout_ms().value()
+            : MigrationConfig::kDefaultCopyQueryTimeoutMs);
 
     // 转换meta_indexer_config
     auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();

--- a/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <string>
@@ -86,6 +87,54 @@ TEST_F(ProtoMessageJsonUtilTest, TestFastCodecHandlesCurrentMapAndWrapperTypes) 
     proto::admin::MigrationMarkMethodConfig parsed_wrapper;
     ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(wrapper_json, &parsed_wrapper));
     EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(wrapper_message, parsed_wrapper));
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecHandlesUnsignedMigrationLimits) {
+    for (const uint64_t value : {uint64_t{0}, uint64_t{42}, std::numeric_limits<uint64_t>::max()}) {
+        SCOPED_TRACE(value);
+        proto::admin::MigrationConfig message;
+        message.mutable_copy_max_inflight_bytes()->set_value(value);
+        message.mutable_copy_max_quarantine_bytes()->set_value(value);
+        ASSERT_TRUE(FastProtoJsonCodec::Supports(message.GetDescriptor()));
+
+        std::string json;
+        std::string protobuf_json;
+        ASSERT_TRUE(FastProtoJsonCodec::TryToJson(message, json));
+        ASSERT_TRUE(ProtobufToJson(message, &protobuf_json));
+        EXPECT_EQ(protobuf_json, json);
+        EXPECT_NE(std::string::npos, json.find("\"copy_max_inflight_bytes\":\"" + std::to_string(value) + "\""));
+
+        proto::admin::MigrationConfig parsed;
+        ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(json, &parsed));
+        EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(message, parsed));
+    }
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecParsesUnsignedWrapperPresenceAndBoundaries) {
+    for (const char *json : {R"({})",
+                             R"({"copy_max_inflight_bytes":null})",
+                             R"({"copy_max_inflight_bytes":0})",
+                             R"({"copy_max_inflight_bytes":"0"})",
+                             R"({"copy_max_inflight_bytes":18446744073709551615})",
+                             R"({"copyMaxInflightBytes":"18446744073709551615"})"}) {
+        SCOPED_TRACE(json);
+        proto::admin::MigrationConfig expected;
+        proto::admin::MigrationConfig actual;
+        ASSERT_TRUE(ProtobufFromJson(json, &expected));
+        ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(json, &actual));
+        EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(expected, actual));
+    }
+
+    for (const char *json : {R"({"copy_max_inflight_bytes":-1})",
+                             R"({"copy_max_inflight_bytes":"-1"})",
+                             R"({"copy_max_inflight_bytes":"18446744073709551616"})",
+                             R"({"copy_max_inflight_bytes":true})"}) {
+        SCOPED_TRACE(json);
+        proto::admin::MigrationConfig parsed;
+        parsed.mutable_copy_max_inflight_bytes()->set_value(42);
+        EXPECT_FALSE(FastProtoJsonCodec::TryFromJson(json, &parsed));
+        EXPECT_EQ(42u, parsed.copy_max_inflight_bytes().value());
+    }
 }
 
 TEST_F(ProtoMessageJsonUtilTest, TestUnsupportedTypesFallBackToProtobufJsonUtil) {


### PR DESCRIPTION
## Summary

- add an opt-in asynchronous CopyGA contract and a persistent migration guard that keeps source and destination locations fenced across leader changes
- fail closed unless the backend proves the operation is terminal and the destination is safe to reuse; add bounded recovery, cancellation, quarantine inspection, and break-glass release paths
- back off repeatedly failing source locations, and expose bounded submit/query HTTP timing controls for downstream async backends

## Safety model

- a guarded destination cannot be reclaimed by normal deletion, Reclaimer, or background GC
- the exact source location used by an in-flight copy remains pinned
- timeouts, ambiguous submit results, lost task records, and incomplete cancellation never authorize destination reuse
- recovery runs before leader-only traffic is enabled, with bounded scanning and explicit degraded-state reporting

Async execution remains backend opt-in through `SupportsAsyncCopy()`. Existing open-source storage backends keep their current synchronous behavior until they provide an implementation.

## Validation

Validated on the final branch rebased onto the latest `main`:

- `instance_group_test`
- `migration_strategy_test`
- `DataStorageManagerTest`
- `meta_dummy_backend_test`
- `MetaSearcherTest`
- `SchedulePlanExecutorTest`
- `MigrationManagerTest`
- `CacheReclaimerTest`
- `CacheGarbageCollectorTest`
- `AdminServiceImplTest`
- `//kv_cache_manager:kv_cache_manager_bin`

The downstream PACE backend adapter and final end-to-end smoke validation are tracked separately.
