### PR TITLE
[manager] add cache location lookup metrics

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -10,6 +10,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -89,6 +90,82 @@ namespace kv_cache_manager {
     } while (0)
 
 namespace {
+class LocationLookupMetricsGuard {
+public:
+    LocationLookupMetricsGuard(MetricsRegistry *registry,
+                               std::string api_name,
+                               std::string instance_id,
+                               std::size_t request_key_count)
+        : registry_(registry)
+        , api_name_(std::move(api_name))
+        , instance_id_(std::move(instance_id))
+        , request_key_count_(request_key_count) {}
+
+    ~LocationLookupMetricsGuard() {
+        if (!completed_) {
+            Complete(0, 0, 0, request_key_count_);
+        }
+    }
+
+    void SetRequestKeyCount(std::size_t count) { request_key_count_ = count; }
+
+    void Complete(std::size_t hit_count,
+                  std::size_t miss_count,
+                  std::size_t filtered_count,
+                  std::size_t error_count) {
+        try {
+            if (registry_ != nullptr) {
+                const MetricsTags base_tags{{"api_name", api_name_}, {"instance_id", instance_id_}};
+                ++registry_->GetCounter("manager.location_lookup.requests_total", base_tags);
+                if (request_key_count_ > 0) {
+                    registry_->GetCounter("manager.location_lookup.request_keys_total", base_tags) +=
+                        request_key_count_;
+                    const auto record = [this, &base_tags](const char *result, std::size_t count) {
+                        if (count == 0) {
+                            return;
+                        }
+                        auto tags = base_tags;
+                        tags.emplace("result", result);
+                        registry_->GetCounter("manager.location_lookup.keys_total", tags) += count;
+                    };
+                    record("hit", hit_count);
+                    record("miss", miss_count);
+                    record("filtered", filtered_count);
+                    record("error", error_count);
+                }
+            }
+        } catch (...) {
+            // Monitoring must never change the location-query result.
+        }
+        completed_ = true;
+    }
+
+private:
+    MetricsRegistry *registry_;
+    std::string api_name_;
+    std::string instance_id_;
+    std::size_t request_key_count_;
+    bool completed_ = false;
+};
+
+std::size_t CountUnmaskedKeys(const CacheManager::KeyVector &keys, const BlockMask &block_mask) {
+    std::size_t count = 0;
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        if (!IsIndexInMaskRange(block_mask, index)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::size_t CountLocations(const CacheLocationVector &locations, bool require_location_spec = false) {
+    return static_cast<std::size_t>(
+        std::count_if(locations.begin(), locations.end(), [require_location_spec](const auto &location) {
+            return location && !location->id().empty() &&
+                   (!require_location_spec || !location->location_specs().empty());
+        }));
+}
+
 CacheManager::KeyVector GenKeyVector(const CacheManager::TokenIdsVector &tokens, int64_t block_size) {
     std::vector<int64_t> block_keys;
     size_t total_blocks = tokens.size() / block_size;
@@ -760,22 +837,40 @@ ErrorCode CacheManager::PerformCacheLocationQuery(RequestContext *request_contex
                                                   const BlockMask &block_mask,
                                                   int32_t sw_size,
                                                   KeyVector &query_keys,
-                                                  CacheLocationVector &cache_locations) const {
+                                                  CacheLocationVector &cache_locations,
+                                                  std::size_t *out_lookup_error_key_count) const {
     SPAN_TRACER(request_context);
     const std::string &trace_id = request_context->trace_id();
+    if (out_lookup_error_key_count != nullptr) {
+        *out_lookup_error_key_count = 0;
+    }
     ErrorCode ec = EC_ERROR;
     if (!keys.empty()) {
         KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, request_key_count, keys.size());
-        ec = GetCacheLocationByQueryType(
-            meta_searcher, request_context, instance_id, query_type, keys, block_mask, sw_size, cache_locations);
+        ec = GetCacheLocationByQueryType(meta_searcher,
+                                         request_context,
+                                         instance_id,
+                                         query_type,
+                                         keys,
+                                         block_mask,
+                                         sw_size,
+                                         cache_locations,
+                                         out_lookup_error_key_count);
     } else {
         auto [ec_temp, block_size] = GetBlockSize(request_context, instance_id);
         RETURN_IF_EC_NOT_OK_WITH_LOG(WARN, ec_temp, "get block_size failed");
         auto gen_keys = GenKeyVector(tokens, block_size);
         KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, manager, request_key_count, gen_keys.size());
         query_keys = gen_keys;
-        ec = GetCacheLocationByQueryType(
-            meta_searcher, request_context, instance_id, query_type, gen_keys, block_mask, sw_size, cache_locations);
+        ec = GetCacheLocationByQueryType(meta_searcher,
+                                         request_context,
+                                         instance_id,
+                                         query_type,
+                                         gen_keys,
+                                         block_mask,
+                                         sw_size,
+                                         cache_locations,
+                                         out_lookup_error_key_count);
     }
     return ec;
 }
@@ -791,9 +886,19 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
                                const std::vector<std::string> &location_spec_names) {
     SPAN_TRACER(request_context);
     const std::string &trace_id = request_context->trace_id();
+    // Keep a valid instance alive until the dynamic metric write completes.
+    // RemoveInstance holds the same lifecycle fence exclusively before it
+    // purges instance-tagged series.
+    std::shared_lock<std::shared_mutex> metrics_lifecycle_guard(metrics_lifecycle_->mut_);
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     auto [ec, meta_searcher] = CheckInputAndGetMetaSearcher(request_context, instance_id, keys, tokens);
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, CacheLocationViewVecWrapper, "check input or get meta searcher failed");
+    if (registry_manager_->GetInstanceInfo(request_context, instance_id) == nullptr) {
+        RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
+            WARN, EC_INSTANCE_NOT_EXIST, CacheLocationViewVecWrapper, "instance not found");
+    }
+    LocationLookupMetricsGuard location_metrics(
+        metrics_registry_.get(), "GetCacheLocation", instance_id, keys.size());
     if (query_type == QueryType::QT_UNSPECIFIED) {
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, EC_ERROR, CacheLocationViewVecWrapper, "unknown query type");
     }
@@ -802,6 +907,7 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
                            : KVCM_METRICS_COLLECTOR_CHRONO_SCOPE(service_metrics_collector, ManagerPrefixMatch);
     CacheLocationVector cache_locations;
     KeyVector query_keys = keys;
+    std::size_t lookup_error_key_count = 0;
     ec = PerformCacheLocationQuery(request_context,
                                    service_metrics_collector,
                                    meta_searcher,
@@ -812,8 +918,13 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
                                    block_mask,
                                    sw_size,
                                    query_keys,
-                                   cache_locations);
+                                   cache_locations,
+                                   &lookup_error_key_count);
     query_scope = ChronoScopeGuard{};
+    const std::size_t lookup_key_count = query_type == QueryType::QT_PREFIX_MATCH
+                                             ? CountUnmaskedKeys(query_keys, block_mask)
+                                             : query_keys.size();
+    location_metrics.SetRequestKeyCount(lookup_key_count);
     // prefix_match_len: count actual hits (non-empty id), not total returned entries.
     // BatchGet/ReverseRollSW pad misses with empty CacheLocation objects.
     {
@@ -847,7 +958,16 @@ CacheManager::GetCacheLocation(RequestContext *request_context,
         query_counter += query_count;
         hit_counter += hit_count;
     }
+    const std::size_t pre_filter_hit_count = CountLocations(cache_locations);
     FilterLocationSpecByName(cache_locations, location_spec_names);
+    const std::size_t hit_count = CountLocations(cache_locations, !location_spec_names.empty());
+    const std::size_t filtered_count = pre_filter_hit_count - hit_count;
+    const std::size_t unresolved_count = lookup_key_count > pre_filter_hit_count
+                                             ? lookup_key_count - pre_filter_hit_count
+                                             : 0;
+    const std::size_t error_count = std::min(lookup_error_key_count, unresolved_count);
+    const std::size_t miss_count = unresolved_count - error_count;
+    location_metrics.Complete(hit_count, miss_count, filtered_count, error_count);
 
     auto cache_get_event = std::make_shared<CacheGetEvent>(instance_id);
     cache_get_event->SetEventTriggerTime();
@@ -886,9 +1006,16 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
                                          const std::vector<BackendSelector> &backend_selectors) {
     SPAN_TRACER(request_context);
     const std::string &trace_id = request_context->trace_id();
+    std::shared_lock<std::shared_mutex> metrics_lifecycle_guard(metrics_lifecycle_->mut_);
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     auto [ec, meta_searcher] = CheckInputAndGetMetaSearcher(request_context, instance_id, keys, tokens);
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, BatchLocationsView, "check input or get meta searcher failed");
+    auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);
+    if (instance_info == nullptr) {
+        RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, EC_INSTANCE_NOT_EXIST, BatchLocationsView, "instance not found");
+    }
+    LocationLookupMetricsGuard location_metrics(
+        metrics_registry_.get(), "GetCacheLocationsByBackend", instance_id, keys.size());
     if (query_type != QueryType::QT_BATCH_GET) {
         request_context->error_tracer()->AddErrorMsg("GetCacheLocationsByBackend only supports QT_BATCH_GET");
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
@@ -915,6 +1042,8 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
         RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(
             WARN, EC_BADARGS, BatchLocationsView, "block_mask must match the number of query keys");
     }
+    const std::size_t lookup_key_count = CountUnmaskedKeys(query_keys, block_mask);
+    location_metrics.SetRequestKeyCount(lookup_key_count);
 
     if (!location_spec_names.empty()) {
         if (location_spec_names.size() != query_keys.size() ||
@@ -966,13 +1095,15 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
     }
 
     LocationsPerKey locations_per_key;
+    std::vector<bool> had_usable_locations;
     ec = meta_searcher->BatchGetBestLocationByBackend(request_context,
                                                       query_keys,
                                                       locations_per_key,
                                                       policy.get(),
                                                       backend_selectors,
                                                       location_spec_names,
-                                                      block_mask);
+                                                      block_mask,
+                                                      &had_usable_locations);
     query_scope = ChronoScopeGuard{};
     // prefix_match_len: count keys with at least one hit (non-empty id).
     // Miss keys have empty CacheLocation objects with no id.
@@ -990,11 +1121,6 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
     }
     RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, ec, BatchLocationsView, "batch get multi locations failed");
 
-    auto instance_info = registry_manager_->GetInstanceInfo(request_context, instance_id);
-    if (instance_info == nullptr) {
-        request_context->error_tracer()->AddErrorMsg("instance not found");
-        RETURN_IF_EC_NOT_OK_WITH_TYPE_LOG(WARN, EC_INSTANCE_NOT_EXIST, BatchLocationsView, "instance not found");
-    }
     for (auto &key_locs : locations_per_key) {
         FillEmptyLocationSpecs(instance_info->location_spec_infos(), key_locs);
     }
@@ -1003,6 +1129,24 @@ CacheManager::GetCacheLocationsByBackend(RequestContext *request_context,
             FilterLocationSpecByName(locations_per_key[i], {location_spec_names[i]});
         }
     }
+
+    std::size_t hit_count = 0;
+    std::size_t filtered_count = 0;
+    for (std::size_t i = 0; i < locations_per_key.size(); ++i) {
+        if (IsIndexInMaskRange(block_mask, i)) {
+            continue;
+        }
+        if (CountLocations(locations_per_key[i], !location_spec_names.empty()) > 0) {
+            ++hit_count;
+        } else if (i < had_usable_locations.size() && had_usable_locations[i]) {
+            ++filtered_count;
+        }
+    }
+    const std::size_t classified_count = hit_count + filtered_count;
+    const std::size_t miss_count = lookup_key_count > classified_count
+                                       ? lookup_key_count - classified_count
+                                       : 0;
+    location_metrics.Complete(hit_count, miss_count, filtered_count, 0);
 
     auto cache_get_event = std::make_shared<CacheGetEvent>(instance_id);
     cache_get_event->SetEventTriggerTime();
@@ -4279,7 +4423,8 @@ ErrorCode CacheManager::GetCacheLocationByQueryType(MetaSearcher *meta_searcher,
                                                     const KeyVector &keys,
                                                     const BlockMask &block_mask,
                                                     int32_t sw_size,
-                                                    CacheLocationVector &cache_locations) const {
+                                                    CacheLocationVector &cache_locations,
+                                                    std::size_t *out_prefix_error_key_count) const {
     SPAN_TRACER(request_context);
     const std::string &trace_id = request_context->trace_id();
     auto policy = genSelectLocationPolicy(request_context, instance_id);
@@ -4293,7 +4438,8 @@ ErrorCode CacheManager::GetCacheLocationByQueryType(MetaSearcher *meta_searcher,
         break;
     }
     case QueryType::QT_PREFIX_MATCH: {
-        ec = meta_searcher->PrefixMatch(request_context, keys, block_mask, cache_locations, policy.get());
+        ec = meta_searcher->PrefixMatch(
+            request_context, keys, block_mask, cache_locations, policy.get(), out_prefix_error_key_count);
         break;
     }
     case QueryType::QT_REVERSE_ROLL_SW_MATCH: {

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -357,7 +357,8 @@ private:
                                           const KeyVector &keys,
                                           const BlockMask &block_mask,
                                           int32_t sw_size,
-                                          CacheLocationVector &cache_locations) const;
+                                          CacheLocationVector &cache_locations,
+                                          std::size_t *out_prefix_error_key_count = nullptr) const;
     ErrorCode PerformCacheLocationQuery(RequestContext *request_context,
                                         ServiceMetricsCollector *service_metrics_collector,
                                         MetaSearcher *meta_searcher,
@@ -368,7 +369,8 @@ private:
                                         const BlockMask &block_mask,
                                         int32_t sw_size,
                                         KeyVector &query_keys,
-                                        CacheLocationVector &cache_locations) const;
+                                        CacheLocationVector &cache_locations,
+                                        std::size_t *out_lookup_error_key_count = nullptr) const;
     std::unique_ptr<SelectLocationPolicy> genSelectLocationPolicy(RequestContext *request_context,
                                                                   const std::string &instance_id) const;
     CheckLocDataExistFunc GetCheckLocDataExistFunc(const std::string &instance_id) const;

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -1281,8 +1281,12 @@ std::string MetaSearcher::BatchErrorCodeToStr(const std::vector<std::vector<Erro
 ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_context,
                                                     const KeyVector &keys,
                                                     CacheLocationVector &out_locations,
-                                                    SelectLocationPolicy *policy) const {
+                                                    SelectLocationPolicy *policy,
+                                                    std::size_t *out_error_key_count) const {
     out_locations.clear();
+    if (out_error_key_count != nullptr) {
+        *out_error_key_count = 0;
+    }
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerGet);
@@ -1295,6 +1299,12 @@ ErrorCode MetaSearcher::PrefixMatchBestLocationImpl(RequestContext *request_cont
     std::size_t i = 0;
     for (; i != keys.size(); ++i) {
         if (result.error_codes[i] != ErrorCode::EC_OK) {
+            if (result.error_codes[i] != ErrorCode::EC_NOENT && out_error_key_count != nullptr) {
+                // Prefix matching cannot use the failed key or any following
+                // key. Preserve the legacy EC_OK response, but expose the
+                // unresolved suffix as a monitoring error instead of a miss.
+                *out_error_key_count = keys.size() - i;
+            }
             KVCM_LOG_DEBUG("prefix match end because Get keys[%lu](%lu) return %d", i, keys[i], result.error_codes[i]);
             break;
         }
@@ -1347,9 +1357,13 @@ ErrorCode MetaSearcher::PrefixMatch(RequestContext *request_context,
                                     const KeyVector &keys,
                                     const BlockMask &input_mask,
                                     CacheLocationVector &out_locations,
-                                    SelectLocationPolicy *policy) const {
+                                    SelectLocationPolicy *policy,
+                                    std::size_t *out_error_key_count) const {
     assert(policy != nullptr);
     SPAN_TRACER(request_context);
+    if (out_error_key_count != nullptr) {
+        *out_error_key_count = 0;
+    }
     KeyVector query_keys;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (!IsIndexInMaskRange(input_mask, i)) {
@@ -1363,7 +1377,8 @@ ErrorCode MetaSearcher::PrefixMatch(RequestContext *request_context,
     }
     // TODO: need to confirm shard lock range
     // TODO: use smaller batch if many prefix missed a lot
-    ErrorCode ec = PrefixMatchBestLocationImpl(request_context, query_keys, out_locations, policy);
+    ErrorCode ec = PrefixMatchBestLocationImpl(
+        request_context, query_keys, out_locations, policy, out_error_key_count);
     if (ec != EC_OK) {
         KVCM_LOG_DEBUG("PrefixMatchBestLocationImpl failed");
     }
@@ -1427,11 +1442,15 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                                                       SelectLocationPolicy *policy,
                                                       const std::vector<BackendSelector> &selectors,
                                                       const std::vector<std::string> &requested_spec_names,
-                                                      const BlockMask &input_mask) const {
+                                                      const BlockMask &input_mask,
+                                                      std::vector<bool> *out_had_usable_locations) const {
     assert(policy != nullptr);
     SPAN_TRACER(request_context);
     out_locations.clear();
     out_locations.resize(keys.size());
+    if (out_had_usable_locations != nullptr) {
+        out_had_usable_locations->assign(keys.size(), false);
+    }
     if (!requested_spec_names.empty() &&
         (requested_spec_names.size() != keys.size() ||
          std::any_of(requested_spec_names.begin(), requested_spec_names.end(), [](const std::string &name) {
@@ -1488,6 +1507,9 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
         }
         std::vector<std::string> prune_loc_ids;
         valid_maps[i] = FilterValidLocations(location_maps[i], check_loc_data_exist_func_, prune_loc_ids);
+        if (out_had_usable_locations != nullptr && !valid_maps[i].empty()) {
+            (*out_had_usable_locations)[query_to_output_index[i]] = true;
+        }
         if (!prune_loc_ids.empty()) {
             prune_keys.emplace_back(query_keys[i]);
             prune_loc_ids_vec.emplace_back(std::move(prune_loc_ids));

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -81,7 +81,8 @@ public:
                           const KeyVector &keys,
                           const BlockMask &input_mask,
                           CacheLocationVector &out_locations,
-                          SelectLocationPolicy *policy) const;
+                          SelectLocationPolicy *policy,
+                          std::size_t *out_error_key_count = nullptr) const;
     ErrorCode BatchGetBestLocation(RequestContext *request_context,
                                    const KeyVector &keys,
                                    CacheLocationVector &out_locations,
@@ -92,7 +93,8 @@ public:
                                             SelectLocationPolicy *policy,
                                             const std::vector<BackendSelector> &selectors,
                                             const std::vector<std::string> &requested_spec_names = {},
-                                            const BlockMask &input_mask = BlockMask{}) const;
+                                            const BlockMask &input_mask = BlockMask{},
+                                            std::vector<bool> *out_had_usable_locations = nullptr) const;
     ErrorCode ReverseRollSlideWindowMatch(RequestContext *request_context,
                                           const KeyVector &keys,
                                           int32_t sw_size,
@@ -386,7 +388,8 @@ private:
     ErrorCode PrefixMatchBestLocationImpl(RequestContext *request_context,
                                           const KeyVector &keys,
                                           CacheLocationVector &out_locations,
-                                          SelectLocationPolicy *policy) const;
+                                          SelectLocationPolicy *policy,
+                                          std::size_t *out_error_key_count) const;
 
     std::shared_ptr<MetaIndexer> meta_indexer_;
     CheckLocDataExistFunc check_loc_data_exist_func_;

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -222,6 +222,11 @@ public:
         fail_key_on_next_upsert_ = key;
     }
 
+    void FailKeyOnNextLocationRead(int64_t key) {
+        std::lock_guard<std::mutex> lock(control_mutex_);
+        fail_key_on_next_location_read_ = key;
+    }
+
     size_t GetSyncCallCount() {
         std::lock_guard<std::mutex> lock(control_mutex_);
         return sync_call_count_;
@@ -280,7 +285,22 @@ public:
                                         const KeyTypeVec &keys,
                                         CacheLocationMapVector &out_locations) noexcept override {
         MaybeBlockLocationRead();
-        return MetaLocalBackend::GetLocations(request_context, keys, out_locations);
+        auto results = MetaLocalBackend::GetLocations(request_context, keys, out_locations);
+        std::optional<int64_t> failed_key;
+        {
+            std::lock_guard<std::mutex> lock(control_mutex_);
+            failed_key = fail_key_on_next_location_read_;
+            fail_key_on_next_location_read_.reset();
+        }
+        if (failed_key.has_value()) {
+            for (size_t i = 0; i < keys.size(); ++i) {
+                if (keys[i] == failed_key.value()) {
+                    results[i] = EC_TIMEOUT;
+                    out_locations[i].clear();
+                }
+            }
+        }
+        return results;
     }
 
     std::vector<ErrorCode> GetLocationValues(RequestContext *request_context,
@@ -341,6 +361,7 @@ private:
     bool location_read_entered_ = false;
     bool release_location_read_ = false;
     std::optional<int64_t> fail_key_on_next_upsert_;
+    std::optional<int64_t> fail_key_on_next_location_read_;
     size_t sync_call_count_ = 0;
 };
 
@@ -1581,6 +1602,16 @@ TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters) {
     COPY_METRICS_(svc_collector.get(), manager, get_cache_location_hit_block_counter, hit_counter);
     EXPECT_EQ(6u, query_counter.Get());
     EXPECT_EQ(5u, hit_counter.Get());
+
+    const MetricsTags request_tags{{"api_name", "GetCacheLocation"}, {"instance_id", "test_instance"}};
+    auto hit_tags = request_tags;
+    hit_tags.emplace("result", "hit");
+    auto miss_tags = request_tags;
+    miss_tags.emplace("result", "miss");
+    EXPECT_EQ(2u, metrics_registry_->GetCounter("manager.location_lookup.requests_total", request_tags).Get());
+    EXPECT_EQ(6u, metrics_registry_->GetCounter("manager.location_lookup.request_keys_total", request_tags).Get());
+    EXPECT_EQ(5u, metrics_registry_->GetCounter("manager.location_lookup.keys_total", hit_tags).Get());
+    EXPECT_EQ(1u, metrics_registry_->GetCounter("manager.location_lookup.keys_total", miss_tags).Get());
 }
 
 TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters_BatchGet) {
@@ -1632,14 +1663,62 @@ TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters_BatchGet) {
     EXPECT_EQ(2u, hit_counter.Get());
 }
 
+TEST_F(CacheManagerTest, TestLocationLookupMetricsClassifyPrefixMetadataError) {
+    auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    ASSERT_EQ(expected,
+              cache_manager_->RegisterInstance(request_context_.get(),
+                                               "default",
+                                               "test_instance",
+                                               64,
+                                               createLocationSpecInfos(),
+                                               createModelDeployment(),
+                                               std::vector<LocationSpecGroup>()));
+    auto *controlled_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, controlled_backend);
+
+    std::vector<int64_t> keys{1, 2, 3};
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMaskOffset{3}));
+
+    controlled_backend->FailKeyOnNextLocationRead(2);
+    auto [ec, result] = cache_manager_->GetCacheLocation(request_context_.get(),
+                                                         "test_instance",
+                                                         CacheManager::QueryType::QT_PREFIX_MATCH,
+                                                         keys,
+                                                         {},
+                                                         BlockMaskOffset{0},
+                                                         0,
+                                                         {});
+    ASSERT_EQ(EC_OK, ec);
+    ASSERT_EQ(1u, result.cache_locations_view().size());
+
+    const MetricsTags request_tags{{"api_name", "GetCacheLocation"}, {"instance_id", "test_instance"}};
+    auto hit_tags = request_tags;
+    hit_tags.emplace("result", "hit");
+    auto miss_tags = request_tags;
+    miss_tags.emplace("result", "miss");
+    auto error_tags = request_tags;
+    error_tags.emplace("result", "error");
+    EXPECT_EQ(1u, metrics_registry_->GetCounter("manager.location_lookup.requests_total", request_tags).Get());
+    EXPECT_EQ(3u, metrics_registry_->GetCounter("manager.location_lookup.request_keys_total", request_tags).Get());
+    EXPECT_EQ(1u, metrics_registry_->GetCounter("manager.location_lookup.keys_total", hit_tags).Get());
+    EXPECT_EQ(0u, metrics_registry_->GetCounter("manager.location_lookup.keys_total", miss_tags).Get());
+    EXPECT_EQ(2u, metrics_registry_->GetCounter("manager.location_lookup.keys_total", error_tags).Get());
+}
+
 TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters_ErrorPath) {
     auto svc_collector = std::make_shared<ServiceMetricsCollector>(metrics_registry_);
     ASSERT_TRUE(svc_collector->Init());
     auto metrics_ctx = std::make_unique<RequestContext>("error_path_test", svc_collector);
 
-    // Query non-existent instance → should fail and NOT increment counters
+    // Invalid instance ids must not create unbounded instance-tagged series.
     std::vector<int64_t> query_keys{1, 2, 3};
     BlockMask block_mask = static_cast<size_t>(0);
+    const auto registry_size_before = metrics_registry_->GetSize();
     auto [ec, result] = cache_manager_->GetCacheLocation(metrics_ctx.get(),
                                                          "nonexistent_instance",
                                                          CacheManager::QueryType::QT_PREFIX_MATCH,
@@ -1650,11 +1729,100 @@ TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters_ErrorPath) {
                                                          {});
     EXPECT_NE(EC_OK, ec);
 
+    for (int index = 0; index < 64; ++index) {
+        EXPECT_NE(EC_OK,
+                  cache_manager_
+                      ->GetCacheLocation(metrics_ctx.get(),
+                                         "invalid_instance_" + std::to_string(index),
+                                         CacheManager::QueryType::QT_PREFIX_MATCH,
+                                         query_keys,
+                                         {},
+                                         block_mask,
+                                         0,
+                                         {})
+                      .first);
+    }
+
     Counter query_counter, hit_counter;
     COPY_METRICS_(svc_collector.get(), manager, get_cache_location_query_block_counter, query_counter);
     COPY_METRICS_(svc_collector.get(), manager, get_cache_location_hit_block_counter, hit_counter);
     EXPECT_EQ(0u, query_counter.Get());
     EXPECT_EQ(0u, hit_counter.Get());
+    EXPECT_EQ(registry_size_before, metrics_registry_->GetSize());
+    EXPECT_EQ(nullptr, metrics_registry_->GetMetricsData("manager.location_lookup.requests_total"));
+    EXPECT_EQ(nullptr, metrics_registry_->GetMetricsData("manager.location_lookup.request_keys_total"));
+    EXPECT_EQ(nullptr, metrics_registry_->GetMetricsData("manager.location_lookup.keys_total"));
+}
+
+TEST_F(CacheManagerTest, TestLocationLookupMetricsDoNotReappearAfterInstancePurge) {
+    auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
+    ASSERT_EQ(expected,
+              cache_manager_->RegisterInstance(request_context_.get(),
+                                               "default",
+                                               "test_instance",
+                                               64,
+                                               createLocationSpecInfos(),
+                                               createModelDeployment(),
+                                               std::vector<LocationSpecGroup>()));
+    auto *controlled_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, controlled_backend);
+    controlled_backend->BlockNextLocationRead();
+
+    auto query_future = std::async(std::launch::async, [manager = cache_manager_]() {
+        RequestContext context("location_lookup_lifecycle_query");
+        return manager->GetCacheLocation(&context,
+                                         "test_instance",
+                                         CacheManager::QueryType::QT_PREFIX_MATCH,
+                                         {1, 2, 3},
+                                         {},
+                                         BlockMaskOffset{0},
+                                         0,
+                                         {});
+    });
+    if (!controlled_backend->WaitUntilLocationReadEntered(std::chrono::seconds(2))) {
+        controlled_backend->ReleaseLocationRead();
+        FAIL() << "location query did not reach the controlled metadata read";
+    }
+
+    std::promise<void> purge_started;
+    auto purge_started_future = purge_started.get_future();
+    auto purge_future = std::async(std::launch::async,
+                                   [manager = cache_manager_, registry = registry_manager_, &purge_started]() {
+        purge_started.set_value();
+        std::unique_lock<std::shared_mutex> lifecycle_guard(manager->metrics_lifecycle()->mut_);
+        RequestContext remove_context("location_lookup_lifecycle_remove");
+        const auto ec = registry->RemoveInstance(&remove_context, "default", "test_instance");
+        manager->InvalidateInstanceMetrics("test_instance");
+        return ec;
+    });
+    purge_started_future.wait();
+    EXPECT_EQ(std::future_status::timeout, purge_future.wait_for(std::chrono::milliseconds(50)));
+
+    controlled_backend->ReleaseLocationRead();
+    EXPECT_EQ(EC_OK, query_future.get().first);
+    ASSERT_EQ(std::future_status::ready, purge_future.wait_for(std::chrono::seconds(2)));
+    EXPECT_EQ(EC_OK, purge_future.get());
+
+    RequestContext post_remove_context("location_lookup_after_remove");
+    EXPECT_EQ(EC_INSTANCE_NOT_EXIST,
+              cache_manager_
+                  ->GetCacheLocation(&post_remove_context,
+                                     "test_instance",
+                                     CacheManager::QueryType::QT_PREFIX_MATCH,
+                                     {1, 2, 3},
+                                     {},
+                                     BlockMaskOffset{0},
+                                     0,
+                                     {})
+                  .first);
+
+    std::vector<MetricsRegistry::metrics_tuple_t> all_metrics;
+    metrics_registry_->GetAllMetrics(all_metrics);
+    for (const auto &[name, tags, value] : all_metrics) {
+        (void) name;
+        (void) value;
+        EXPECT_EQ(tags.end(), tags.find("instance_id"));
+    }
 }
 
 TEST_F(CacheManagerTest, TestGetCacheLocationBatchGet) {
@@ -7698,6 +7866,21 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
     }
     {
         const BlockMask implicit_empty_mask = BlockMaskVector{};
+        const MetricsTags request_tags{{"api_name", "GetCacheLocationsByBackend"}, {"instance_id", instance_id}};
+        auto hit_tags = request_tags;
+        hit_tags.emplace("result", "hit");
+        auto miss_tags = request_tags;
+        miss_tags.emplace("result", "miss");
+        auto filtered_tags = request_tags;
+        filtered_tags.emplace("result", "filtered");
+        const auto requests_before =
+            metrics_registry_->GetCounter("manager.location_lookup.requests_total", request_tags).Get();
+        const auto request_keys_before =
+            metrics_registry_->GetCounter("manager.location_lookup.request_keys_total", request_tags).Get();
+        const auto hits_before = metrics_registry_->GetCounter("manager.location_lookup.keys_total", hit_tags).Get();
+        const auto misses_before = metrics_registry_->GetCounter("manager.location_lookup.keys_total", miss_tags).Get();
+        const auto filtered_before =
+            metrics_registry_->GetCounter("manager.location_lookup.keys_total", filtered_tags).Get();
         auto [ec, locs] = cache_manager_->GetCacheLocationsByBackend(request_context_.get(),
                                                                      instance_id,
                                                                      CacheManager::QueryType::QT_BATCH_GET,
@@ -7709,10 +7892,33 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
                                                                      nfs_selectors);
         EXPECT_EQ(EC_OK, ec);
         EXPECT_EQ(all_keys.size(), locs.size());
+        EXPECT_EQ(requests_before + 1,
+                  metrics_registry_->GetCounter("manager.location_lookup.requests_total", request_tags).Get());
+        EXPECT_EQ(request_keys_before + all_keys.size(),
+                  metrics_registry_->GetCounter("manager.location_lookup.request_keys_total", request_tags).Get());
+        EXPECT_EQ(hits_before + 3,
+                  metrics_registry_->GetCounter("manager.location_lookup.keys_total", hit_tags).Get());
+        EXPECT_EQ(misses_before,
+                  metrics_registry_->GetCounter("manager.location_lookup.keys_total", miss_tags).Get());
+        EXPECT_EQ(filtered_before + 2,
+                  metrics_registry_->GetCounter("manager.location_lookup.keys_total", filtered_tags).Get());
     }
 
     // Masked entries stay positionally aligned but do not expose a remote
     // location. Both vector and prefix-offset forms are supported.
+    const MetricsTags masked_request_tags{{"api_name", "GetCacheLocationsByBackend"}, {"instance_id", instance_id}};
+    auto masked_hit_tags = masked_request_tags;
+    masked_hit_tags.emplace("result", "hit");
+    auto masked_filtered_tags = masked_request_tags;
+    masked_filtered_tags.emplace("result", "filtered");
+    const auto masked_requests_before =
+        metrics_registry_->GetCounter("manager.location_lookup.requests_total", masked_request_tags).Get();
+    const auto masked_request_keys_before =
+        metrics_registry_->GetCounter("manager.location_lookup.request_keys_total", masked_request_tags).Get();
+    const auto masked_hits_before =
+        metrics_registry_->GetCounter("manager.location_lookup.keys_total", masked_hit_tags).Get();
+    const auto masked_filtered_before =
+        metrics_registry_->GetCounter("manager.location_lookup.keys_total", masked_filtered_tags).Get();
     for (const BlockMask &mask : std::vector<BlockMask>{
              BlockMaskVector{true, false, true, false, true},
              BlockMaskOffset{2},
@@ -7734,6 +7940,14 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
             }
         }
     }
+    EXPECT_EQ(masked_requests_before + 2,
+              metrics_registry_->GetCounter("manager.location_lookup.requests_total", masked_request_tags).Get());
+    EXPECT_EQ(masked_request_keys_before + 5,
+              metrics_registry_->GetCounter("manager.location_lookup.request_keys_total", masked_request_tags).Get());
+    EXPECT_EQ(masked_hits_before + 2,
+              metrics_registry_->GetCounter("manager.location_lookup.keys_total", masked_hit_tags).Get());
+    EXPECT_EQ(masked_filtered_before + 3,
+              metrics_registry_->GetCounter("manager.location_lookup.keys_total", masked_filtered_tags).Get());
 
     // --- Test 2: EVENT_REPORT PREFIX + NFS (NFS on 300,500,700 should not affect event report peer selection) ---
     {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -41,6 +41,7 @@
 #include "kv_cache_manager/meta/meta_local_backend.h"
 #include "kv_cache_manager/meta/utils.h"
 #include "kv_cache_manager/metrics/metrics_collector.h"
+#include "kv_cache_manager/metrics/metrics_lifecycle.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 #include "stub.h"
 
@@ -601,14 +602,15 @@ public:
         return snapshot_response.committed_snapshot_version();
     }
 
-    ControllableMetaLocalBackend *InstallControllableMetaBackend() {
-        auto indexer = cache_manager_->meta_indexer_manager_->GetMetaIndexer("test_instance");
+    ControllableMetaLocalBackend *
+    InstallControllableMetaBackend(const std::string &instance_id = "test_instance") {
+        auto indexer = cache_manager_->meta_indexer_manager_->GetMetaIndexer(instance_id);
         if (!indexer) {
             return nullptr;
         }
         auto config = std::make_shared<MetaStorageBackendConfig>();
         auto controlled = std::make_unique<ControllableMetaLocalBackend>();
-        if (controlled->Init("test_instance", config) != EC_OK || controlled->Open() != EC_OK) {
+        if (controlled->Init(instance_id, config) != EC_OK || controlled->Open() != EC_OK) {
             return nullptr;
         }
         auto *controlled_raw = controlled.get();
@@ -1755,23 +1757,25 @@ TEST_F(CacheManagerTest, TestGetCacheLocationHitRateCounters_ErrorPath) {
 }
 
 TEST_F(CacheManagerTest, TestLocationLookupMetricsDoNotReappearAfterInstancePurge) {
+    const std::string instance_id = "location_lookup_lifecycle_instance";
     auto expected = std::pair<ErrorCode, std::string>(EC_OK, default_storage_configs);
     ASSERT_EQ(expected,
               cache_manager_->RegisterInstance(request_context_.get(),
                                                "default",
-                                               "test_instance",
+                                               instance_id,
                                                64,
                                                createLocationSpecInfos(),
                                                createModelDeployment(),
                                                std::vector<LocationSpecGroup>()));
-    auto *controlled_backend = InstallControllableMetaBackend();
+    auto *controlled_backend = InstallControllableMetaBackend(instance_id);
     ASSERT_NE(nullptr, controlled_backend);
     controlled_backend->BlockNextLocationRead();
 
-    auto query_future = std::async(std::launch::async, [manager = cache_manager_]() {
+    CacheManager *manager = cache_manager_.get();
+    auto query_future = std::async(std::launch::async, [manager, instance_id]() {
         RequestContext context("location_lookup_lifecycle_query");
         return manager->GetCacheLocation(&context,
-                                         "test_instance",
+                                         instance_id,
                                          CacheManager::QueryType::QT_PREFIX_MATCH,
                                          {1, 2, 3},
                                          {},
@@ -1787,13 +1791,11 @@ TEST_F(CacheManagerTest, TestLocationLookupMetricsDoNotReappearAfterInstancePurg
     std::promise<void> purge_started;
     auto purge_started_future = purge_started.get_future();
     auto purge_future = std::async(std::launch::async,
-                                   [manager = cache_manager_, registry = registry_manager_, &purge_started]() {
+                                   [manager, instance_id, &purge_started]() {
         purge_started.set_value();
         std::unique_lock<std::shared_mutex> lifecycle_guard(manager->metrics_lifecycle()->mut_);
         RequestContext remove_context("location_lookup_lifecycle_remove");
-        const auto ec = registry->RemoveInstance(&remove_context, "default", "test_instance");
-        manager->InvalidateInstanceMetrics("test_instance");
-        return ec;
+        return manager->RemoveInstance(&remove_context, "default", instance_id);
     });
     purge_started_future.wait();
     EXPECT_EQ(std::future_status::timeout, purge_future.wait_for(std::chrono::milliseconds(50)));
@@ -1807,7 +1809,7 @@ TEST_F(CacheManagerTest, TestLocationLookupMetricsDoNotReappearAfterInstancePurg
     EXPECT_EQ(EC_INSTANCE_NOT_EXIST,
               cache_manager_
                   ->GetCacheLocation(&post_remove_context,
-                                     "test_instance",
+                                     instance_id,
                                      CacheManager::QueryType::QT_PREFIX_MATCH,
                                      {1, 2, 3},
                                      {},
@@ -1821,7 +1823,10 @@ TEST_F(CacheManagerTest, TestLocationLookupMetricsDoNotReappearAfterInstancePurg
     for (const auto &[name, tags, value] : all_metrics) {
         (void) name;
         (void) value;
-        EXPECT_EQ(tags.end(), tags.find("instance_id"));
+        auto instance_tag = tags.find("instance_id");
+        if (instance_tag != tags.end()) {
+            EXPECT_NE(instance_id, instance_tag->second);
+        }
     }
 }
 

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.cc
@@ -183,6 +183,10 @@ struct KmonitorMetricsReporter::Context {
     DECLARE_METRICS(cache_manager_instance, async_pipeline_error_count);
     DECLARE_METRICS(cache_manager_instance, max_lru_age_us);
 
+    DECLARE_METRICS(manager, location_lookup_keys_total);
+    DECLARE_METRICS(manager, location_lookup_requests_total);
+    DECLARE_METRICS(manager, location_lookup_request_keys_total);
+
     struct MapHashFunc {
         size_t operator()(const std::map<std::string, std::string> &m) const noexcept {
             size_t hash = 0;
@@ -456,6 +460,19 @@ bool KmonitorMetricsReporter::InitMetrics() {
     REGISTER_GAUGE_METRIC(cache_manager_instance, async_pipeline_error_count);
     REGISTER_GAUGE_METRIC(cache_manager_instance, max_lru_age_us);
 
+    ctx_->manager_location_lookup_keys_total_metrics.reset(
+        reporter->RegisterMetric("manager.location_lookup.keys_total", kmonitor::GAUGE, kmonitor::FATAL));
+    ctx_->manager_location_lookup_requests_total_metrics.reset(
+        reporter->RegisterMetric("manager.location_lookup.requests_total", kmonitor::GAUGE, kmonitor::FATAL));
+    ctx_->manager_location_lookup_request_keys_total_metrics.reset(
+        reporter->RegisterMetric("manager.location_lookup.request_keys_total", kmonitor::GAUGE, kmonitor::FATAL));
+    if (!ctx_->manager_location_lookup_keys_total_metrics ||
+        !ctx_->manager_location_lookup_requests_total_metrics ||
+        !ctx_->manager_location_lookup_request_keys_total_metrics) {
+        KVCM_LOG_ERROR("failed to register location lookup metrics");
+        return false;
+    }
+
     return true;
 }
 
@@ -602,6 +619,24 @@ void KmonitorMetricsReporter::ReportInterval() {
     if (!ctx_->kmonitor) {
         KVCM_LOG_WARN("kmonitor is null, ReportInterval ignored.");
         return;
+    }
+
+    if (metrics_registry_) {
+        const auto report_counter = [this](kmonitor::MutableMetric *metric, const char *name) {
+            if (metric == nullptr) {
+                return;
+            }
+            VisitCounterSamples(name, [this, metric](const MetricsTags &base_tags, double sample) {
+                const auto tags = ctx_->GetKmonitorTags(base_tags);
+                metric->Report(&tags, sample);
+            });
+        };
+        report_counter(ctx_->manager_location_lookup_keys_total_metrics.get(),
+                       "manager.location_lookup.keys_total");
+        report_counter(ctx_->manager_location_lookup_requests_total_metrics.get(),
+                       "manager.location_lookup.requests_total");
+        report_counter(ctx_->manager_location_lookup_request_keys_total_metrics.get(),
+                       "manager.location_lookup.request_keys_total");
     }
 
     do {
@@ -912,6 +947,25 @@ void KmonitorMetricsReporter::ReportInterval() {
             }
         }
     } while (false);
+}
+
+void KmonitorMetricsReporter::VisitCounterSamples(const char *name,
+                                                  const CounterSampleConsumer &consumer) const {
+    if (!metrics_registry_ || !consumer) {
+        return;
+    }
+    const auto data = metrics_registry_->GetMetricsData(name);
+    if (data == nullptr) {
+        return;
+    }
+    for (const auto &[tags, value] : data->GetMetricsValues()) {
+        if (!value || !value->touched.load(std::memory_order_relaxed) ||
+            !std::holds_alternative<CounterValue>(value->value)) {
+            continue;
+        }
+        consumer(tags,
+                 static_cast<double>(std::get<CounterValue>(value->value).load(std::memory_order_relaxed)));
+    }
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/metrics/kmonitor_metrics_reporter.h
+++ b/kv_cache_manager/metrics/kmonitor_metrics_reporter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include "kv_cache_manager/metrics/local_metrics_reporter.h"
@@ -17,7 +18,10 @@ public:
     void ReportInterval() override;
 
 private:
+    using CounterSampleConsumer = std::function<void(const MetricsTags &, double)>;
+
     bool InitMetrics();
+    void VisitCounterSamples(const char *name, const CounterSampleConsumer &consumer) const;
 
     struct Context;
     std::unique_ptr<Context> ctx_;

--- a/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
+++ b/kv_cache_manager/metrics/test/kmonitor_metrics_reporter_test.cc
@@ -1,4 +1,6 @@
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/config/registry_manager.h"
@@ -18,7 +20,7 @@ protected:
         registry_manager_ = std::make_shared<RegistryManager>("", metrics_registry_);
         cache_manager_ = std::make_shared<CacheManager>(metrics_registry_, registry_manager_);
         reporter_ = std::make_unique<KmonitorMetricsReporter>();
-        reporter_->Init(cache_manager_, metrics_registry_, "");
+        ASSERT_TRUE(reporter_->Init(cache_manager_, metrics_registry_, ""));
     }
 
     void TearDown() override {}
@@ -111,6 +113,15 @@ TEST_F(KmonitorMetricsReporterTest, TestReportInterval) {
         metrics_registry_->GetCounter("cache_gc.delete_result_count", {{"status", "0"}}) += 1;
         metrics_registry_->GetCounter("cache_gc.operation_error_count", {{"stage", "scan"}}) += 1;
         metrics_registry_->GetGauge("cache_gc.inflight_delete_count") = 2;
+        metrics_registry_->GetCounter(
+            "manager.location_lookup.keys_total",
+            {{"api_name", "GetCacheLocation"}, {"instance_id", "test_instance"}, {"result", "hit"}}) += 2;
+        metrics_registry_->GetCounter(
+            "manager.location_lookup.requests_total",
+            {{"api_name", "GetCacheLocation"}, {"instance_id", "test_instance"}}) += 1;
+        metrics_registry_->GetCounter(
+            "manager.location_lookup.request_keys_total",
+            {{"api_name", "GetCacheLocation"}, {"instance_id", "test_instance"}}) += 3;
         EXPECT_NO_FATAL_FAILURE(reporter_->ReportInterval());
     }
 
@@ -134,6 +145,22 @@ TEST_F(KmonitorMetricsReporterTest, TestReportInterval) {
         reporter_->metrics_registry_ = nullptr;
         EXPECT_NO_FATAL_FAILURE(reporter_->ReportInterval());
     }
+}
+
+TEST_F(KmonitorMetricsReporterTest, TestLocationLookupCounterSamplesKeepTagsAndValues) {
+    const MetricsTags hit_tags{{"api_name", "GetCacheLocation"},
+                               {"instance_id", "test_instance"},
+                               {"result", "hit"}};
+    metrics_registry_->GetCounter("manager.location_lookup.keys_total", hit_tags) += 7;
+
+    std::vector<std::pair<MetricsTags, double>> samples;
+    reporter_->VisitCounterSamples(
+        "manager.location_lookup.keys_total",
+        [&samples](const MetricsTags &tags, double value) { samples.emplace_back(tags, value); });
+
+    ASSERT_EQ(1u, samples.size());
+    EXPECT_EQ(hit_tags, samples.front().first);
+    EXPECT_EQ(7.0, samples.front().second);
 }
 
 TEST_F(KmonitorMetricsReporterTest, TestReportIntervalWriteBytes) {


### PR DESCRIPTION
## Summary

- add `manager.location_lookup.requests_total` to count valid location lookup requests
- add `manager.location_lookup.request_keys_total` to count queried cache block keys
- add `manager.location_lookup.keys_total`, split by `result=hit|miss|filtered|error`, to expose lookup outcomes
- report the new counters through the KMonitor reporter without changing existing metric fields
- keep per-instance metric collection aligned with the instance lifecycle and cover batch and masked-key lookup paths with tests

These counters provide the inputs needed to derive the cache-location hit rate in Grafana. The derived hit rate represents metadata location hits and does not imply that the cache payload was read successfully.

## Validation

- relevant manager and KMonitor reporter tests passed
- image build pipeline passed
- deployed the test image and confirmed that all three raw metrics are reported
- verified the request rate, queried-key rate, result-key rate, and derived location hit-rate panels in Grafana