### PR TITLE
[manager] skip empty spec storage allocation

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -2114,6 +2114,10 @@ ErrorCode CacheManager::CreateBySpec(RequestContext *request_context,
             }
         }
 
+        if (block_keys.empty()) {
+            continue;
+        }
+
         std::vector<std::pair<ErrorCode, DataStorageUri>> results = data_storage_manager->Create(
             request_context, unique_name, block_keys, spec_info.size(), []() { /* do nothing */ });
 


### PR DESCRIPTION
## Summary

- skip storage allocation for registered location specs that have no matching block keys
- avoid invalid PACE batch requests with `count=0` when StartWriteCache selects only a subset of location spec groups

## Testing

- not rerun after preparing the final commit; PR CI will validate the change
