### PR TITLE
[service] optimize protobuf JSON conversion

### DIFF
--- a/docs/develop/proto_modification_guide.md
+++ b/docs/develop/proto_modification_guide.md
@@ -150,12 +150,16 @@ HTML-safe 的 `\uXXXX` 形式；两种 JSON 解析后得到相同字符串，且
 因此快路径输出只能作为 JSON 或日志 JSON 消费，不能未经 HTML 层转义就直接嵌入可执行的
 `<script>` 内容。
 
-`ProtoMessageJsonUtilTest.TestFastCodecSupportsAllProtocolMessages` 会检查所有当前协议消息。
-新增 `kv_cache_manager/protocol/protobuf/*.proto` 协议文件时，必须同时在该测试的 `protocol_files`
+`FastProtoJsonCodecConformanceTest.TestAllRegisteredProtocolMessagesMatchProtobufJsonSemantics` 会检查所有
+当前协议消息。测试通过 Reflection 构造空消息及多组包含边界值、转义字符串、repeated、map、wrapper、
+oneof 和嵌套 message 的确定性样本，并以 protobuf 3.8 通用 JSON 实现作为 oracle，检查快路径输出的
+JSON 语义相同、两边输出均可由另一边解析回原消息。
+
+新增 `kv_cache_manager/protocol/protobuf/*.proto` 协议文件时，必须同时在该测试的 `kProtocolFiles`
 数组中加入新文件的 `FileDescriptor`（通常通过新文件中任一顶层 message 的 `descriptor()->file()`
-取得），并包含对应的生成 `.pb.h`。否则即使新文件使用了快路径尚未覆盖的字段类型，该测试也无法
-发现。仅在已有协议文件中增删 message 或字段时，不需要手工登记 message，测试会遍历文件内全部
-顶层 message，并递归检查其嵌套类型。
+取得），并包含对应的生成 `.pb.h`。否则即使新文件使用了快路径尚未覆盖的字段类型或行为，该测试也
+无法发现。仅在已有协议文件中增删 message 或字段时，不需要手工登记 message，测试会遍历文件内全部
+顶层 message，并递归构造其嵌套类型。
 
 不在列表内的类型仍会回退到 protobuf 3.8 的通用 JSON 实现，功能不受影响，但 access log
 等热点路径无法获得加速。引入例如 `bytes`、其他 map 形态或其他 well-known type 时，应同时补充

--- a/docs/develop/proto_modification_guide.md
+++ b/docs/develop/proto_modification_guide.md
@@ -138,7 +138,8 @@ ASSERT_EQ(reclaim1.delay_before_delete_ms(), reclaim2.delay_before_delete_ms());
 `ProtoMessageJsonUtil` 会对 KVCM 当前协议使用的类型直接做 protobuf Reflection 与 RapidJSON
 之间的转换。新增或修改字段时需要确认其类型是否在以下支持范围内：
 
-- `int32`、`uint32`、`int64`、`uint64`、`float`、`double`、`bool`、`string` 和 enum；
+- `int32`、`uint32`、`int64`、`uint64`、`float`、`double`、`bool`、`string` 和普通 enum
+  （不含 `google.protobuf.NullValue`）；
 - 普通嵌套 message、repeated 和 oneof；
 - `map<string, string>`；
 - `google.protobuf.Int32Value` 和 `google.protobuf.Int64Value`。

--- a/docs/develop/proto_modification_guide.md
+++ b/docs/develop/proto_modification_guide.md
@@ -144,6 +144,12 @@ ASSERT_EQ(reclaim1.delay_before_delete_ms(), reclaim2.delay_before_delete_ms());
 - `map<string, string>`；
 - `google.protobuf.Int32Value` 和 `google.protobuf.Int64Value`。
 
+快路径承诺 protobuf JSON 的解析语义兼容，不承诺与 protobuf 3.8 的输出逐字节相同。特别是
+RapidJSON 会直接输出字符串中的 `<`、`>` 和部分合法 Unicode 字符，而 protobuf 3.8 会将它们写成
+HTML-safe 的 `\uXXXX` 形式；两种 JSON 解析后得到相同字符串，且该差异不会触发通用实现回退。
+因此快路径输出只能作为 JSON 或日志 JSON 消费，不能未经 HTML 层转义就直接嵌入可执行的
+`<script>` 内容。
+
 `ProtoMessageJsonUtilTest.TestFastCodecSupportsAllProtocolMessages` 会检查所有当前协议消息。
 新增 `kv_cache_manager/protocol/protobuf/*.proto` 协议文件时，必须同时在该测试的 `protocol_files`
 数组中加入新文件的 `FileDescriptor`（通常通过新文件中任一顶层 message 的 `descriptor()->file()`

--- a/docs/develop/proto_modification_guide.md
+++ b/docs/develop/proto_modification_guide.md
@@ -133,6 +133,21 @@ reclaim_strategy->set_delay_before_delete_ms(0);  // 设置新字段
 ASSERT_EQ(reclaim1.delay_before_delete_ms(), reclaim2.delay_before_delete_ms());  // 验证新字段
 ```
 
+#### 4.1 检查 Protobuf JSON 快路径兼容性
+
+`ProtoMessageJsonUtil` 会对 KVCM 当前协议使用的类型直接做 protobuf Reflection 与 RapidJSON
+之间的转换。新增或修改字段时需要确认其类型是否在以下支持范围内：
+
+- `int32`、`uint32`、`int64`、`uint64`、`float`、`double`、`bool`、`string` 和 enum；
+- 普通嵌套 message、repeated 和 oneof；
+- `map<string, string>`；
+- `google.protobuf.Int32Value` 和 `google.protobuf.Int64Value`。
+
+`ProtoMessageJsonUtilTest.TestFastCodecSupportsAllProtocolMessages` 会检查所有当前协议消息。
+不在列表内的类型仍会回退到 protobuf 3.8 的通用 JSON 实现，功能不受影响，但 access log
+等热点路径无法获得加速。引入例如 `bytes`、其他 map 形态或其他 well-known type 时，应同时补充
+`FastProtoJsonCodec` 的实现与兼容性测试，或者在评审中明确接受相关 message 回退，并调整上述测试。
+
 ### 5. 构建和测试
 
 完成上述修改后，执行以下步骤验证修改是否正确：

--- a/docs/develop/proto_modification_guide.md
+++ b/docs/develop/proto_modification_guide.md
@@ -144,6 +144,12 @@ ASSERT_EQ(reclaim1.delay_before_delete_ms(), reclaim2.delay_before_delete_ms());
 - `google.protobuf.Int32Value` 和 `google.protobuf.Int64Value`。
 
 `ProtoMessageJsonUtilTest.TestFastCodecSupportsAllProtocolMessages` 会检查所有当前协议消息。
+新增 `kv_cache_manager/protocol/protobuf/*.proto` 协议文件时，必须同时在该测试的 `protocol_files`
+数组中加入新文件的 `FileDescriptor`（通常通过新文件中任一顶层 message 的 `descriptor()->file()`
+取得），并包含对应的生成 `.pb.h`。否则即使新文件使用了快路径尚未覆盖的字段类型，该测试也无法
+发现。仅在已有协议文件中增删 message 或字段时，不需要手工登记 message，测试会遍历文件内全部
+顶层 message，并递归检查其嵌套类型。
+
 不在列表内的类型仍会回退到 protobuf 3.8 的通用 JSON 实现，功能不受影响，但 access log
 等热点路径无法获得加速。引入例如 `bytes`、其他 map 形态或其他 well-known type 时，应同时补充
 `FastProtoJsonCodec` 的实现与兼容性测试，或者在评审中明确接受相关 message 回退，并调整上述测试。

--- a/kv_cache_manager/service/util/BUILD
+++ b/kv_cache_manager/service/util/BUILD
@@ -7,12 +7,19 @@ config_setting(
 
 cc_library(
     name = "proto_message_json_util",
-    srcs = ["proto_message_json_util.cc"],
-    hdrs = ["proto_message_json_util.h"],
+    srcs = [
+        "fast_proto_json_codec.cc",
+        "proto_message_json_util.cc",
+    ],
+    hdrs = [
+        "fast_proto_json_codec.h",
+        "proto_message_json_util.h",
+    ],
     include_prefix = "service/util",
     deps = [
         ":grpc_wrapper",
         "//kv_cache_manager/common",
+        "@rapidjson",
     ],
 )
 

--- a/kv_cache_manager/service/util/fast_proto_json_codec.cc
+++ b/kv_cache_manager/service/util/fast_proto_json_codec.cc
@@ -3,6 +3,7 @@
 #include <charconv>
 #include <cmath>
 #include <cstdint>
+#include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/strutil.h>
 #include <limits>
 #include <memory>
@@ -67,10 +68,14 @@ bool SupportsDescriptor(const Descriptor *descriptor, std::unordered_set<const D
             field->is_extension()) {
             return false;
         }
+        if (field->cpp_type() == FieldDescriptor::CPPTYPE_ENUM &&
+            field->enum_type()->full_name() == "google.protobuf.NullValue") {
+            return false;
+        }
         if (field->is_map()) {
             const Descriptor *entry = field->message_type();
-            if (!entry || entry->field_count() != 2 || entry->field(0)->cpp_type() != FieldDescriptor::CPPTYPE_STRING ||
-                entry->field(1)->cpp_type() != FieldDescriptor::CPPTYPE_STRING) {
+            if (!entry || entry->field_count() != 2 || entry->field(0)->type() != FieldDescriptor::TYPE_STRING ||
+                entry->field(1)->type() != FieldDescriptor::TYPE_STRING) {
                 return false;
             }
             continue;
@@ -193,6 +198,9 @@ bool WriteFieldValue(
         const std::string &value =
             repeated ? reflection->GetRepeatedStringReference(message, field, repeated_index, &scratch)
                      : reflection->GetStringReference(message, field, &scratch);
+        if (!::google::protobuf::internal::IsStructurallyValidUTF8(value)) {
+            return false;
+        }
         writer.String(value.data(), static_cast<rapidjson::SizeType>(value.size()));
         return true;
     }
@@ -221,6 +229,10 @@ bool WriteMap(const Message &message, const FieldDescriptor *field, JsonWriter &
         std::string value_scratch;
         const std::string &key = entry_reflection->GetStringReference(entry, key_field, &key_scratch);
         const std::string &value = entry_reflection->GetStringReference(entry, value_field, &value_scratch);
+        if (!::google::protobuf::internal::IsStructurallyValidUTF8(key) ||
+            !::google::protobuf::internal::IsStructurallyValidUTF8(value)) {
+            return false;
+        }
         writer.Key(key.data(), static_cast<rapidjson::SizeType>(key.size()));
         writer.String(value.data(), static_cast<rapidjson::SizeType>(value.size()));
     }
@@ -415,7 +427,14 @@ bool ParseScalarValue(const rapidjson::Value &value, Message *message, const Fie
             const auto *enum_value =
                 field->enum_type()->FindValueByName(std::string(value.GetString(), value.GetStringLength()));
             if (!enum_value) {
-                return true; // ignore_unknown_fields also ignores unknown enum names
+                int32_t enum_number = 0;
+                if (!ParseIntegerString(value, &enum_number)) {
+                    return true; // ignore_unknown_fields also ignores unknown enum names
+                }
+                enum_value = field->enum_type()->FindValueByNumber(enum_number);
+                if (!enum_value) {
+                    return true; // protobuf ignores unknown quoted enum numbers
+                }
             }
             number = enum_value->number();
         } else if (value.IsInt()) {

--- a/kv_cache_manager/service/util/fast_proto_json_codec.cc
+++ b/kv_cache_manager/service/util/fast_proto_json_codec.cc
@@ -1,0 +1,591 @@
+#include "fast_proto_json_codec.h"
+
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <google/protobuf/stubs/strutil.h>
+#include <limits>
+#include <memory>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace kv_cache_manager {
+namespace {
+
+using ::google::protobuf::Descriptor;
+using ::google::protobuf::FieldDescriptor;
+using ::google::protobuf::Message;
+using ::google::protobuf::Reflection;
+using JsonWriter = rapidjson::Writer<rapidjson::StringBuffer>;
+
+constexpr int kMaxNestingDepth = 100;
+
+enum class WrapperKind {
+    kNone,
+    kInt32,
+    kInt64,
+    kUnsupportedWellKnownType,
+};
+
+WrapperKind GetWrapperKind(const Descriptor *descriptor) {
+    const std::string &name = descriptor->full_name();
+    if (name == "google.protobuf.Int32Value") {
+        return WrapperKind::kInt32;
+    }
+    if (name == "google.protobuf.Int64Value") {
+        return WrapperKind::kInt64;
+    }
+    if (name.compare(0, sizeof("google.protobuf.") - 1, "google.protobuf.") == 0) {
+        return WrapperKind::kUnsupportedWellKnownType;
+    }
+    return WrapperKind::kNone;
+}
+
+bool SupportsDescriptor(const Descriptor *descriptor, std::unordered_set<const Descriptor *> &visited) {
+    if (!descriptor || descriptor->file()->syntax() != ::google::protobuf::FileDescriptor::SYNTAX_PROTO3) {
+        return false;
+    }
+
+    const WrapperKind wrapper_kind = GetWrapperKind(descriptor);
+    if (wrapper_kind == WrapperKind::kInt32 || wrapper_kind == WrapperKind::kInt64) {
+        return true;
+    }
+    if (wrapper_kind == WrapperKind::kUnsupportedWellKnownType || descriptor->extension_range_count() != 0) {
+        return false;
+    }
+    if (!visited.insert(descriptor).second) {
+        return true;
+    }
+
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const FieldDescriptor *field = descriptor->field(i);
+        if (field->type() == FieldDescriptor::TYPE_BYTES || field->type() == FieldDescriptor::TYPE_GROUP ||
+            field->is_extension()) {
+            return false;
+        }
+        if (field->is_map()) {
+            const Descriptor *entry = field->message_type();
+            if (!entry || entry->field_count() != 2 || entry->field(0)->cpp_type() != FieldDescriptor::CPPTYPE_STRING ||
+                entry->field(1)->cpp_type() != FieldDescriptor::CPPTYPE_STRING) {
+                return false;
+            }
+            continue;
+        }
+        if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE &&
+            !SupportsDescriptor(field->message_type(), visited)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void WriteRawNumber(const std::string &number, JsonWriter &writer) {
+    writer.RawValue(number.data(), static_cast<rapidjson::SizeType>(number.size()), rapidjson::kNumberType);
+}
+
+void WriteInt64(int64_t value, JsonWriter &writer) {
+    const std::string number = std::to_string(value);
+    writer.String(number.data(), static_cast<rapidjson::SizeType>(number.size()));
+}
+
+void WriteUInt64(uint64_t value, JsonWriter &writer) {
+    const std::string number = std::to_string(value);
+    writer.String(number.data(), static_cast<rapidjson::SizeType>(number.size()));
+}
+
+void WriteDouble(double value, JsonWriter &writer) {
+    if (std::isfinite(value)) {
+        WriteRawNumber(::google::protobuf::SimpleDtoa(value), writer);
+    } else if (std::isnan(value)) {
+        writer.String("NaN");
+    } else if (value > 0) {
+        writer.String("Infinity");
+    } else {
+        writer.String("-Infinity");
+    }
+}
+
+void WriteFloat(float value, JsonWriter &writer) {
+    if (std::isfinite(value)) {
+        WriteRawNumber(::google::protobuf::SimpleFtoa(value), writer);
+    } else if (std::isnan(value)) {
+        writer.String("NaN");
+    } else if (value > 0) {
+        writer.String("Infinity");
+    } else {
+        writer.String("-Infinity");
+    }
+}
+
+bool WriteMessage(const Message &message, JsonWriter &writer, int depth);
+
+bool WriteWrapper(const Message &message, WrapperKind kind, JsonWriter &writer) {
+    const Reflection *reflection = message.GetReflection();
+    const FieldDescriptor *value_field = message.GetDescriptor()->FindFieldByName("value");
+    if (!value_field) {
+        return false;
+    }
+    if (kind == WrapperKind::kInt32) {
+        writer.Int(reflection->GetInt32(message, value_field));
+        return true;
+    }
+    if (kind == WrapperKind::kInt64) {
+        WriteInt64(reflection->GetInt64(message, value_field), writer);
+        return true;
+    }
+    return false;
+}
+
+bool WriteFieldValue(
+    const Message &message, const FieldDescriptor *field, int repeated_index, JsonWriter &writer, int depth) {
+    const Reflection *reflection = message.GetReflection();
+    const bool repeated = repeated_index >= 0;
+    switch (field->cpp_type()) {
+    case FieldDescriptor::CPPTYPE_INT32:
+        writer.Int(repeated ? reflection->GetRepeatedInt32(message, field, repeated_index)
+                            : reflection->GetInt32(message, field));
+        return true;
+    case FieldDescriptor::CPPTYPE_UINT32:
+        writer.Uint(repeated ? reflection->GetRepeatedUInt32(message, field, repeated_index)
+                             : reflection->GetUInt32(message, field));
+        return true;
+    case FieldDescriptor::CPPTYPE_INT64:
+        WriteInt64(repeated ? reflection->GetRepeatedInt64(message, field, repeated_index)
+                            : reflection->GetInt64(message, field),
+                   writer);
+        return true;
+    case FieldDescriptor::CPPTYPE_UINT64:
+        WriteUInt64(repeated ? reflection->GetRepeatedUInt64(message, field, repeated_index)
+                             : reflection->GetUInt64(message, field),
+                    writer);
+        return true;
+    case FieldDescriptor::CPPTYPE_DOUBLE:
+        WriteDouble(repeated ? reflection->GetRepeatedDouble(message, field, repeated_index)
+                             : reflection->GetDouble(message, field),
+                    writer);
+        return true;
+    case FieldDescriptor::CPPTYPE_FLOAT:
+        WriteFloat(repeated ? reflection->GetRepeatedFloat(message, field, repeated_index)
+                            : reflection->GetFloat(message, field),
+                   writer);
+        return true;
+    case FieldDescriptor::CPPTYPE_BOOL:
+        writer.Bool(repeated ? reflection->GetRepeatedBool(message, field, repeated_index)
+                             : reflection->GetBool(message, field));
+        return true;
+    case FieldDescriptor::CPPTYPE_ENUM: {
+        const int enum_number = repeated ? reflection->GetRepeatedEnumValue(message, field, repeated_index)
+                                         : reflection->GetEnumValue(message, field);
+        const auto *enum_value = field->enum_type()->FindValueByNumber(enum_number);
+        if (enum_value) {
+            writer.String(enum_value->name().data(), static_cast<rapidjson::SizeType>(enum_value->name().size()));
+        } else {
+            writer.Int(enum_number);
+        }
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_STRING: {
+        std::string scratch;
+        const std::string &value =
+            repeated ? reflection->GetRepeatedStringReference(message, field, repeated_index, &scratch)
+                     : reflection->GetStringReference(message, field, &scratch);
+        writer.String(value.data(), static_cast<rapidjson::SizeType>(value.size()));
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_MESSAGE: {
+        const Message &nested = repeated ? reflection->GetRepeatedMessage(message, field, repeated_index)
+                                         : reflection->GetMessage(message, field);
+        const WrapperKind kind = GetWrapperKind(nested.GetDescriptor());
+        return kind == WrapperKind::kNone ? WriteMessage(nested, writer, depth + 1)
+                                          : WriteWrapper(nested, kind, writer);
+    }
+    }
+    return false;
+}
+
+bool WriteMap(const Message &message, const FieldDescriptor *field, JsonWriter &writer, int depth) {
+    const Reflection *reflection = message.GetReflection();
+    const Descriptor *entry_descriptor = field->message_type();
+    const FieldDescriptor *key_field = entry_descriptor->field(0);
+    const FieldDescriptor *value_field = entry_descriptor->field(1);
+    writer.StartObject();
+    const int size = reflection->FieldSize(message, field);
+    for (int i = 0; i < size; ++i) {
+        const Message &entry = reflection->GetRepeatedMessage(message, field, i);
+        const Reflection *entry_reflection = entry.GetReflection();
+        std::string key_scratch;
+        std::string value_scratch;
+        const std::string &key = entry_reflection->GetStringReference(entry, key_field, &key_scratch);
+        const std::string &value = entry_reflection->GetStringReference(entry, value_field, &value_scratch);
+        writer.Key(key.data(), static_cast<rapidjson::SizeType>(key.size()));
+        writer.String(value.data(), static_cast<rapidjson::SizeType>(value.size()));
+    }
+    writer.EndObject();
+    return depth <= kMaxNestingDepth;
+}
+
+bool WriteMessage(const Message &message, JsonWriter &writer, int depth) {
+    if (depth > kMaxNestingDepth) {
+        return false;
+    }
+    const Descriptor *descriptor = message.GetDescriptor();
+    const Reflection *reflection = message.GetReflection();
+    writer.StartObject();
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const FieldDescriptor *field = descriptor->field(i);
+        if (field->is_repeated()) {
+            writer.Key(field->name().data(), static_cast<rapidjson::SizeType>(field->name().size()));
+            if (field->is_map()) {
+                if (!WriteMap(message, field, writer, depth + 1)) {
+                    return false;
+                }
+                continue;
+            }
+            writer.StartArray();
+            const int size = reflection->FieldSize(message, field);
+            for (int j = 0; j < size; ++j) {
+                if (!WriteFieldValue(message, field, j, writer, depth)) {
+                    return false;
+                }
+            }
+            writer.EndArray();
+            continue;
+        }
+
+        if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE || field->containing_oneof()) {
+            if (!reflection->HasField(message, field)) {
+                continue;
+            }
+        }
+        writer.Key(field->name().data(), static_cast<rapidjson::SizeType>(field->name().size()));
+        if (!WriteFieldValue(message, field, -1, writer, depth)) {
+            return false;
+        }
+    }
+    writer.EndObject();
+    return true;
+}
+
+template <typename Integer>
+bool ParseIntegerString(const rapidjson::Value &value, Integer *result) {
+    if (!value.IsString()) {
+        return false;
+    }
+    const char *begin = value.GetString();
+    const char *end = begin + value.GetStringLength();
+    const auto parsed = std::from_chars(begin, end, *result);
+    return parsed.ec == std::errc() && parsed.ptr == end;
+}
+
+const FieldDescriptor *FindJsonField(const Descriptor *descriptor, const char *name, size_t length) {
+    const std::string field_name(name, length);
+    if (const FieldDescriptor *field = descriptor->FindFieldByName(field_name)) {
+        return field;
+    }
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const FieldDescriptor *field = descriptor->field(i);
+        if (field->json_name() == field_name) {
+            return field;
+        }
+    }
+    return nullptr;
+}
+
+bool ParseMessageValue(const rapidjson::Value &value, Message *message, int depth);
+
+bool ParseWrapperValue(const rapidjson::Value &value, Message *message, WrapperKind kind) {
+    const Reflection *reflection = message->GetReflection();
+    const FieldDescriptor *field = message->GetDescriptor()->FindFieldByName("value");
+    if (!field) {
+        return false;
+    }
+    if (kind == WrapperKind::kInt32) {
+        int32_t result = 0;
+        if (value.IsInt()) {
+            result = value.GetInt();
+        } else if (!ParseIntegerString(value, &result)) {
+            return false;
+        }
+        reflection->SetInt32(message, field, result);
+        return true;
+    }
+    if (kind == WrapperKind::kInt64) {
+        int64_t result = 0;
+        if (value.IsInt64()) {
+            result = value.GetInt64();
+        } else if (value.IsUint64() &&
+                   value.GetUint64() <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+            result = static_cast<int64_t>(value.GetUint64());
+        } else if (!ParseIntegerString(value, &result)) {
+            return false;
+        }
+        reflection->SetInt64(message, field, result);
+        return true;
+    }
+    return false;
+}
+
+bool ParseScalarValue(const rapidjson::Value &value, Message *message, const FieldDescriptor *field, bool repeated) {
+    const Reflection *reflection = message->GetReflection();
+    switch (field->cpp_type()) {
+    case FieldDescriptor::CPPTYPE_INT32: {
+        int32_t result = 0;
+        if (value.IsInt()) {
+            result = value.GetInt();
+        } else if (!ParseIntegerString(value, &result)) {
+            return false;
+        }
+        repeated ? reflection->AddInt32(message, field, result) : reflection->SetInt32(message, field, result);
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_UINT32: {
+        uint32_t result = 0;
+        if (value.IsUint()) {
+            result = value.GetUint();
+        } else if (!ParseIntegerString(value, &result)) {
+            return false;
+        }
+        repeated ? reflection->AddUInt32(message, field, result) : reflection->SetUInt32(message, field, result);
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_INT64: {
+        int64_t result = 0;
+        if (value.IsInt64()) {
+            result = value.GetInt64();
+        } else if (value.IsUint64() &&
+                   value.GetUint64() <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+            result = static_cast<int64_t>(value.GetUint64());
+        } else if (!ParseIntegerString(value, &result)) {
+            return false;
+        }
+        repeated ? reflection->AddInt64(message, field, result) : reflection->SetInt64(message, field, result);
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_UINT64: {
+        uint64_t result = 0;
+        if (value.IsUint64()) {
+            result = value.GetUint64();
+        } else if (!ParseIntegerString(value, &result)) {
+            return false;
+        }
+        repeated ? reflection->AddUInt64(message, field, result) : reflection->SetUInt64(message, field, result);
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_DOUBLE:
+    case FieldDescriptor::CPPTYPE_FLOAT: {
+        double result = 0;
+        if (value.IsNumber()) {
+            result = value.GetDouble();
+        } else if (value.IsString() && value.GetStringLength() == 3 &&
+                   std::string(value.GetString(), value.GetStringLength()) == "NaN") {
+            result = std::numeric_limits<double>::quiet_NaN();
+        } else if (value.IsString() && std::string(value.GetString(), value.GetStringLength()) == "Infinity") {
+            result = std::numeric_limits<double>::infinity();
+        } else if (value.IsString() && std::string(value.GetString(), value.GetStringLength()) == "-Infinity") {
+            result = -std::numeric_limits<double>::infinity();
+        } else {
+            return false;
+        }
+        if (field->cpp_type() == FieldDescriptor::CPPTYPE_DOUBLE) {
+            repeated ? reflection->AddDouble(message, field, result) : reflection->SetDouble(message, field, result);
+        } else {
+            const float float_result = static_cast<float>(result);
+            if (std::isfinite(result) && !std::isfinite(float_result)) {
+                return false;
+            }
+            repeated ? reflection->AddFloat(message, field, float_result)
+                     : reflection->SetFloat(message, field, float_result);
+        }
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_BOOL:
+        if (!value.IsBool()) {
+            return false;
+        }
+        repeated ? reflection->AddBool(message, field, value.GetBool())
+                 : reflection->SetBool(message, field, value.GetBool());
+        return true;
+    case FieldDescriptor::CPPTYPE_ENUM: {
+        int number = 0;
+        if (value.IsString()) {
+            const auto *enum_value =
+                field->enum_type()->FindValueByName(std::string(value.GetString(), value.GetStringLength()));
+            if (!enum_value) {
+                return true; // ignore_unknown_fields also ignores unknown enum names
+            }
+            number = enum_value->number();
+        } else if (value.IsInt()) {
+            number = value.GetInt();
+        } else {
+            return false;
+        }
+        repeated ? reflection->AddEnumValue(message, field, number) : reflection->SetEnumValue(message, field, number);
+        return true;
+    }
+    case FieldDescriptor::CPPTYPE_STRING:
+        if (!value.IsString()) {
+            return false;
+        }
+        if (repeated) {
+            reflection->AddString(message, field, std::string(value.GetString(), value.GetStringLength()));
+        } else {
+            reflection->SetString(message, field, std::string(value.GetString(), value.GetStringLength()));
+        }
+        return true;
+    case FieldDescriptor::CPPTYPE_MESSAGE:
+        return false;
+    }
+    return false;
+}
+
+bool ParseMapValue(const rapidjson::Value &value, Message *message, const FieldDescriptor *field) {
+    if (!value.IsObject()) {
+        return false;
+    }
+    const Descriptor *entry_descriptor = field->message_type();
+    const FieldDescriptor *key_field = entry_descriptor->field(0);
+    const FieldDescriptor *value_field = entry_descriptor->field(1);
+    const Reflection *reflection = message->GetReflection();
+    std::unordered_set<std::string> keys;
+    for (auto member = value.MemberBegin(); member != value.MemberEnd(); ++member) {
+        if (!member->value.IsString()) {
+            return false;
+        }
+        std::string key(member->name.GetString(), member->name.GetStringLength());
+        if (!keys.insert(key).second) {
+            return false;
+        }
+        Message *entry = reflection->AddMessage(message, field);
+        const Reflection *entry_reflection = entry->GetReflection();
+        entry_reflection->SetString(entry, key_field, key);
+        entry_reflection->SetString(
+            entry, value_field, std::string(member->value.GetString(), member->value.GetStringLength()));
+    }
+    return true;
+}
+
+bool ParseFieldValue(
+    const rapidjson::Value &value, Message *message, const FieldDescriptor *field, bool repeated, int depth) {
+    if (field->cpp_type() != FieldDescriptor::CPPTYPE_MESSAGE) {
+        return ParseScalarValue(value, message, field, repeated);
+    }
+
+    const WrapperKind kind = GetWrapperKind(field->message_type());
+    Message *nested = repeated ? message->GetReflection()->AddMessage(message, field)
+                               : message->GetReflection()->MutableMessage(message, field);
+    return kind == WrapperKind::kNone ? ParseMessageValue(value, nested, depth + 1)
+                                      : ParseWrapperValue(value, nested, kind);
+}
+
+bool ParseMessageValue(const rapidjson::Value &value, Message *message, int depth) {
+    if (!value.IsObject() || depth > kMaxNestingDepth) {
+        return false;
+    }
+    const Descriptor *descriptor = message->GetDescriptor();
+    const Reflection *reflection = message->GetReflection();
+    std::vector<bool> seen_fields(descriptor->field_count(), false);
+    std::vector<const FieldDescriptor *> seen_oneofs(descriptor->oneof_decl_count(), nullptr);
+
+    for (auto member = value.MemberBegin(); member != value.MemberEnd(); ++member) {
+        const FieldDescriptor *field =
+            FindJsonField(descriptor, member->name.GetString(), member->name.GetStringLength());
+        if (!field) {
+            continue;
+        }
+        if (seen_fields[field->index()]) {
+            return false;
+        }
+        seen_fields[field->index()] = true;
+        if (member->value.IsNull()) {
+            continue;
+        }
+
+        if (const auto *oneof = field->containing_oneof()) {
+            const FieldDescriptor *&seen = seen_oneofs[oneof->index()];
+            if (seen && seen != field) {
+                return false;
+            }
+            seen = field;
+        }
+        if (field->is_map()) {
+            if (!ParseMapValue(member->value, message, field)) {
+                return false;
+            }
+            continue;
+        }
+        if (field->is_repeated()) {
+            if (!member->value.IsArray()) {
+                return false;
+            }
+            reflection->ClearField(message, field);
+            for (auto item = member->value.Begin(); item != member->value.End(); ++item) {
+                if (item->IsNull() || !ParseFieldValue(*item, message, field, true, depth)) {
+                    return false;
+                }
+            }
+            continue;
+        }
+        if (!ParseFieldValue(member->value, message, field, false, depth)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+bool FastProtoJsonCodec::Supports(const Descriptor *descriptor) {
+    std::unordered_set<const Descriptor *> visited;
+    return SupportsDescriptor(descriptor, visited);
+}
+
+bool FastProtoJsonCodec::TryToJson(const Message &message, std::string &json) {
+    if (!Supports(message.GetDescriptor())) {
+        return false;
+    }
+    rapidjson::StringBuffer buffer;
+    JsonWriter writer(buffer);
+    const WrapperKind kind = GetWrapperKind(message.GetDescriptor());
+    const bool success =
+        kind == WrapperKind::kNone ? WriteMessage(message, writer, 0) : WriteWrapper(message, kind, writer);
+    if (!success || !writer.IsComplete()) {
+        return false;
+    }
+    // protobuf 3.8's MessageToJsonString appends through StringOutputStream;
+    // preserve that observable behavior for callers reusing an output string.
+    json.append(buffer.GetString(), buffer.GetSize());
+    return true;
+}
+
+bool FastProtoJsonCodec::TryFromJson(std::string_view json, Message *message) {
+    if (!message || !Supports(message->GetDescriptor())) {
+        return false;
+    }
+    rapidjson::Document document;
+    document.Parse<rapidjson::kParseValidateEncodingFlag>(json.data(), json.size());
+    if (document.HasParseError()) {
+        return false;
+    }
+
+    // Parse transactionally so a rejected fast-path shape and a failing
+    // protobuf fallback preserve the caller's original message. Allocating
+    // the temporary on the same arena keeps the successful swap cheap for
+    // HTTP request-scoped messages.
+    auto *arena = message->GetArena();
+    Message *parsed = message->New(arena);
+    std::unique_ptr<Message> heap_parsed(arena ? nullptr : parsed);
+    const WrapperKind kind = GetWrapperKind(parsed->GetDescriptor());
+    const bool success =
+        kind == WrapperKind::kNone ? ParseMessageValue(document, parsed, 0) : ParseWrapperValue(document, parsed, kind);
+    if (!success) {
+        return false;
+    }
+    message->GetReflection()->Swap(message, parsed);
+    return true;
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/service/util/fast_proto_json_codec.cc
+++ b/kv_cache_manager/service/util/fast_proto_json_codec.cc
@@ -8,6 +8,8 @@
 #include <limits>
 #include <memory>
 #include <rapidjson/document.h>
+#include <rapidjson/memorystream.h>
+#include <rapidjson/reader.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 #include <string>
@@ -24,6 +26,80 @@ using ::google::protobuf::Reflection;
 using JsonWriter = rapidjson::Writer<rapidjson::StringBuffer>;
 
 constexpr int kMaxNestingDepth = 100;
+
+template <typename Handler>
+class DepthLimitedJsonHandler {
+public:
+    explicit DepthLimitedJsonHandler(Handler &handler) : handler_(handler) {}
+
+    bool Null() { return handler_.Null(); }
+    bool Bool(bool value) { return handler_.Bool(value); }
+    bool Int(int value) { return handler_.Int(value); }
+    bool Uint(unsigned value) { return handler_.Uint(value); }
+    bool Int64(int64_t value) { return handler_.Int64(value); }
+    bool Uint64(uint64_t value) { return handler_.Uint64(value); }
+    bool Double(double value) { return handler_.Double(value); }
+    bool RawNumber(const char *value, rapidjson::SizeType length, bool copy) {
+        return handler_.RawNumber(value, length, copy);
+    }
+    bool String(const char *value, rapidjson::SizeType length, bool copy) {
+        return handler_.String(value, length, copy);
+    }
+    bool Key(const char *value, rapidjson::SizeType length, bool copy) { return handler_.Key(value, length, copy); }
+
+    bool StartObject() { return StartContainer(&Handler::StartObject); }
+    bool EndObject(rapidjson::SizeType member_count) {
+        const bool success = handler_.EndObject(member_count);
+        --depth_;
+        return success;
+    }
+    bool StartArray() { return StartContainer(&Handler::StartArray); }
+    bool EndArray(rapidjson::SizeType element_count) {
+        const bool success = handler_.EndArray(element_count);
+        --depth_;
+        return success;
+    }
+
+private:
+    bool StartContainer(bool (Handler::*start)()) {
+        if (depth_ >= kMaxNestingDepth) {
+            return false;
+        }
+        ++depth_;
+        if ((handler_.*start)()) {
+            return true;
+        }
+        --depth_;
+        return false;
+    }
+
+    Handler &handler_;
+    int depth_ = 0;
+};
+
+class DepthLimitedDomGenerator {
+public:
+    explicit DepthLimitedDomGenerator(std::string_view json) : json_(json) {}
+
+    template <typename Handler>
+    bool operator()(Handler &handler) {
+        rapidjson::MemoryStream input(json_.data(), json_.size());
+        rapidjson::Reader reader;
+        DepthLimitedJsonHandler<Handler> depth_limited_handler(handler);
+        // The handler stops before the reader can descend past the same
+        // bounded depth, so neither the DOM nor the recursive reader stack is
+        // allowed to grow with adversarial input.
+        const auto result = reader.Parse<rapidjson::kParseValidateEncodingFlag>(input, depth_limited_handler);
+        success_ = !result.IsError();
+        return success_;
+    }
+
+    bool success() const { return success_; }
+
+private:
+    std::string_view json_;
+    bool success_ = false;
+};
 
 enum class WrapperKind {
     kNone,
@@ -585,8 +661,9 @@ bool FastProtoJsonCodec::TryFromJson(std::string_view json, Message *message) {
         return false;
     }
     rapidjson::Document document;
-    document.Parse<rapidjson::kParseValidateEncodingFlag>(json.data(), json.size());
-    if (document.HasParseError()) {
+    DepthLimitedDomGenerator generator(json);
+    document.Populate(generator);
+    if (!generator.success()) {
         return false;
     }
 

--- a/kv_cache_manager/service/util/fast_proto_json_codec.h
+++ b/kv_cache_manager/service/util/fast_proto_json_codec.h
@@ -9,7 +9,10 @@ namespace kv_cache_manager {
 
 // Direct protobuf reflection <-> RapidJSON codec for the protobuf JSON shapes
 // used by KVCM. Callers must fall back to protobuf's JSON utility when the
-// descriptor or input shape is unsupported.
+// descriptor or input shape is unsupported. The fast serializer preserves
+// protobuf JSON semantics, but intentionally uses RapidJSON's normal string
+// escaping rather than protobuf 3.8's byte-for-byte HTML-safe escaping. Its
+// output must be consumed as JSON, not embedded directly into executable HTML.
 class FastProtoJsonCodec {
 public:
     static bool Supports(const ::google::protobuf::Descriptor *descriptor);

--- a/kv_cache_manager/service/util/fast_proto_json_codec.h
+++ b/kv_cache_manager/service/util/fast_proto_json_codec.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include <string>
+#include <string_view>
+
+namespace kv_cache_manager {
+
+// Direct protobuf reflection <-> RapidJSON codec for the protobuf JSON shapes
+// used by KVCM. Callers must fall back to protobuf's JSON utility when the
+// descriptor or input shape is unsupported.
+class FastProtoJsonCodec {
+public:
+    static bool Supports(const ::google::protobuf::Descriptor *descriptor);
+    static bool TryToJson(const ::google::protobuf::Message &message, std::string &json);
+    static bool TryFromJson(std::string_view json, ::google::protobuf::Message *message);
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/service/util/proto_message_json_util.cc
+++ b/kv_cache_manager/service/util/proto_message_json_util.cc
@@ -2,6 +2,7 @@
 
 #include <google/protobuf/util/json_util.h>
 
+#include "fast_proto_json_codec.h"
 #include "kv_cache_manager/common/logger.h"
 
 namespace kv_cache_manager {
@@ -29,6 +30,9 @@ bool ProtoMessageJsonUtil::ToJson(const ::google::protobuf::Message *message, st
     if (!message) {
         return false;
     }
+    if (FastProtoJsonCodec::TryToJson(*message, json)) {
+        return true;
+    }
     static ::google::protobuf::util::JsonPrintOptions option = CreateJsonPrintOption();
     auto status = google::protobuf::util::MessageToJsonString(*message, &json, option);
     return status.ok();
@@ -38,6 +42,11 @@ bool ProtoMessageJsonUtil::FromJson(std::string_view json, ::google::protobuf::M
     if (!message) {
         return false;
     }
+    if (FastProtoJsonCodec::TryFromJson(json, message)) {
+        return true;
+    }
+    // The fast parser can reject compatible but uncommon JSON shapes. The
+    // protobuf parser remains the compatibility oracle for those inputs.
     static ::google::protobuf::util::JsonParseOptions option = CreateJsonParseOption();
     const google::protobuf::StringPiece input(json.data(), static_cast<ptrdiff_t>(json.size()));
     auto status = google::protobuf::util::JsonStringToMessage(input, message, option);

--- a/kv_cache_manager/service/util/test/BUILD
+++ b/kv_cache_manager/service/util/test/BUILD
@@ -2,6 +2,17 @@ load("//bazel:tf_proto.bzl", "tf_proto_library_cc")
 
 package(default_visibility = ["//visibility:private"])
 
+cc_binary(
+    name = "proto_message_json_benchmark",
+    srcs = ["proto_message_json_benchmark.cc"],
+    tags = ["manual"],
+    deps = [
+        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+        "//kv_cache_manager/service/util:proto_message_json_util",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
 cc_test(
     name = "ProtoMessageJsonUtilTest",
     srcs = [

--- a/kv_cache_manager/service/util/test/BUILD
+++ b/kv_cache_manager/service/util/test/BUILD
@@ -30,6 +30,18 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "FastProtoJsonCodecConformanceTest",
+    srcs = ["fast_proto_json_codec_conformance_test.cc"],
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/protocol/protobuf:service_cc_proto",
+        "//kv_cache_manager/service/util:proto_message_json_util",
+        "@com_google_protobuf//:protobuf",
+        "@rapidjson",
+    ],
+)
+
 tf_proto_library_cc(
     name = "service_util_test",
     srcs = [

--- a/kv_cache_manager/service/util/test/fast_proto_json_codec_conformance_test.cc
+++ b/kv_cache_manager/service/util/test/fast_proto_json_codec_conformance_test.cc
@@ -1,0 +1,295 @@
+#include <cstdint>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/util/json_util.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <limits>
+#include <memory>
+#include <rapidjson/document.h>
+#include <string>
+#include <string_view>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/protocol/protobuf/admin_service.pb.h"
+#include "kv_cache_manager/protocol/protobuf/debug_service.pb.h"
+#include "kv_cache_manager/protocol/protobuf/kv_meta_service.pb.h"
+#include "kv_cache_manager/protocol/protobuf/meta_service.pb.h"
+#include "kv_cache_manager/protocol/protobuf/optimizer_service.pb.h"
+#include "service/util/fast_proto_json_codec.h"
+
+namespace kv_cache_manager {
+namespace {
+
+using ::google::protobuf::Descriptor;
+using ::google::protobuf::FieldDescriptor;
+using ::google::protobuf::FileDescriptor;
+using ::google::protobuf::Message;
+using ::google::protobuf::Reflection;
+
+constexpr int kPopulatedCaseCount = 8;
+constexpr int kGeneratedMessageDepth = 3;
+
+// This list is the only manual coverage registry. Everything else is derived
+// from descriptors so adding a message or field to a registered file becomes
+// part of the differential test automatically.
+const FileDescriptor *const kProtocolFiles[] = {
+    proto::admin::Status::descriptor()->file(),
+    proto::debug::Status::descriptor()->file(),
+    proto::kv_meta::Status::descriptor()->file(),
+    proto::meta::Status::descriptor()->file(),
+    proto::optimizer::Status::descriptor()->file(),
+};
+
+uint32_t DeriveCase(uint32_t test_case, int field_number, int repeated_index = -1) {
+    return test_case * 37U + static_cast<uint32_t>(field_number) * 17U +
+           static_cast<uint32_t>(repeated_index + 1) * 13U;
+}
+
+std::string StringValue(uint32_t test_case, int repeated_index) {
+    const std::string suffix = ":" + std::to_string(repeated_index);
+    switch (test_case % kPopulatedCaseCount) {
+    case 0:
+        return "plain" + suffix;
+    case 1:
+        return "";
+    case 2:
+        return "quote:\" slash:\\ newline:\n" + suffix;
+    case 3:
+        return "unicode:雪" + suffix;
+    case 4:
+        return std::string("nul\0value", 9) + suffix;
+    case 5:
+        return "</script><value>" + suffix;
+    case 6:
+        return "18446744073709551615" + suffix;
+    default:
+        return " spaces and tabs\t" + suffix;
+    }
+}
+
+void SetScalarValue(Message *message, const FieldDescriptor *field, uint32_t test_case, bool repeated) {
+    const Reflection *reflection = message->GetReflection();
+    switch (field->cpp_type()) {
+    case FieldDescriptor::CPPTYPE_INT32: {
+        constexpr int32_t values[] = {
+            0, 1, -1, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(), 42, -42, 1000000};
+        const int32_t value = values[test_case % kPopulatedCaseCount];
+        repeated ? reflection->AddInt32(message, field, value) : reflection->SetInt32(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_UINT32: {
+        constexpr uint32_t values[] = {0, 1, std::numeric_limits<uint32_t>::max(), 42, 1000000, 7, 255, 65535};
+        const uint32_t value = values[test_case % kPopulatedCaseCount];
+        repeated ? reflection->AddUInt32(message, field, value) : reflection->SetUInt32(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_INT64: {
+        constexpr int64_t values[] = {0,
+                                      1,
+                                      -1,
+                                      std::numeric_limits<int64_t>::min(),
+                                      std::numeric_limits<int64_t>::max(),
+                                      9007199254740991LL,
+                                      -9007199254740991LL,
+                                      1000000000000LL};
+        const int64_t value = values[test_case % kPopulatedCaseCount];
+        repeated ? reflection->AddInt64(message, field, value) : reflection->SetInt64(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_UINT64: {
+        constexpr uint64_t values[] = {0,
+                                       1,
+                                       std::numeric_limits<uint64_t>::max(),
+                                       42,
+                                       9007199254740991ULL,
+                                       9007199254740992ULL,
+                                       1000000000000ULL,
+                                       4294967296ULL};
+        const uint64_t value = values[test_case % kPopulatedCaseCount];
+        repeated ? reflection->AddUInt64(message, field, value) : reflection->SetUInt64(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_DOUBLE: {
+        constexpr double values[] = {0.0,
+                                     1.0,
+                                     -1.0,
+                                     0.1,
+                                     -12345.5,
+                                     std::numeric_limits<double>::min(),
+                                     std::numeric_limits<double>::max(),
+                                     9007199254740992.0};
+        const double value = values[test_case % kPopulatedCaseCount];
+        repeated ? reflection->AddDouble(message, field, value) : reflection->SetDouble(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_FLOAT: {
+        constexpr float values[] = {0.0F,
+                                    1.0F,
+                                    -1.0F,
+                                    0.1F,
+                                    -12345.5F,
+                                    std::numeric_limits<float>::min(),
+                                    std::numeric_limits<float>::max(),
+                                    16777216.0F};
+        const float value = values[test_case % kPopulatedCaseCount];
+        repeated ? reflection->AddFloat(message, field, value) : reflection->SetFloat(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_BOOL: {
+        const bool value = test_case % 2 != 0;
+        repeated ? reflection->AddBool(message, field, value) : reflection->SetBool(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_ENUM: {
+        const auto *enum_type = field->enum_type();
+        const int value = enum_type->value(test_case % enum_type->value_count())->number();
+        repeated ? reflection->AddEnumValue(message, field, value) : reflection->SetEnumValue(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_STRING: {
+        const std::string value = StringValue(test_case, repeated ? 1 : -1);
+        repeated ? reflection->AddString(message, field, value) : reflection->SetString(message, field, value);
+        return;
+    }
+    case FieldDescriptor::CPPTYPE_MESSAGE:
+        return;
+    }
+}
+
+void PopulateMessage(Message *message, uint32_t test_case, int depth);
+
+void PopulateMap(Message *message, const FieldDescriptor *field, uint32_t test_case) {
+    const Reflection *reflection = message->GetReflection();
+    const int entry_count = 1 + static_cast<int>(test_case % 2);
+    for (int i = 0; i < entry_count; ++i) {
+        Message *entry = reflection->AddMessage(message, field);
+        const Descriptor *entry_descriptor = entry->GetDescriptor();
+        const Reflection *entry_reflection = entry->GetReflection();
+        const uint32_t entry_case = DeriveCase(test_case, field->number(), i);
+        entry_reflection->SetString(entry, entry_descriptor->field(0), StringValue(entry_case, i));
+        entry_reflection->SetString(entry, entry_descriptor->field(1), StringValue(entry_case + 1, i));
+    }
+}
+
+void PopulateField(Message *message, const FieldDescriptor *field, uint32_t test_case, int depth) {
+    if (field->is_map()) {
+        PopulateMap(message, field, test_case);
+        return;
+    }
+
+    const Reflection *reflection = message->GetReflection();
+    if (field->is_repeated()) {
+        const int value_count = 1 + static_cast<int>(test_case % 2);
+        for (int i = 0; i < value_count; ++i) {
+            const uint32_t value_case = DeriveCase(test_case, field->number(), i);
+            if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
+                if (depth < kGeneratedMessageDepth) {
+                    PopulateMessage(reflection->AddMessage(message, field), value_case, depth + 1);
+                }
+            } else {
+                SetScalarValue(message, field, value_case, true);
+            }
+        }
+        return;
+    }
+
+    if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
+        if (depth < kGeneratedMessageDepth) {
+            PopulateMessage(reflection->MutableMessage(message, field), test_case, depth + 1);
+        }
+        return;
+    }
+    SetScalarValue(message, field, test_case, false);
+}
+
+void PopulateMessage(Message *message, uint32_t test_case, int depth) {
+    const Descriptor *descriptor = message->GetDescriptor();
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const FieldDescriptor *field = descriptor->field(i);
+        if (field->containing_oneof()) {
+            const auto *oneof = field->containing_oneof();
+            if (field != oneof->field(test_case % oneof->field_count())) {
+                continue;
+            }
+        }
+        PopulateField(message, field, DeriveCase(test_case, field->number()), depth);
+    }
+}
+
+bool ProtobufToJson(const Message &message, std::string *json) {
+    google::protobuf::util::JsonPrintOptions options;
+    options.always_print_primitive_fields = true;
+    options.preserve_proto_field_names = true;
+    return google::protobuf::util::MessageToJsonString(message, json, options).ok();
+}
+
+bool ProtobufFromJson(std::string_view json, Message *message) {
+    google::protobuf::util::JsonParseOptions options;
+    options.ignore_unknown_fields = true;
+    const google::protobuf::StringPiece input(json.data(), static_cast<ptrdiff_t>(json.size()));
+    return google::protobuf::util::JsonStringToMessage(input, message, options).ok();
+}
+
+bool JsonSemanticallyEquals(std::string_view lhs, std::string_view rhs) {
+    rapidjson::Document lhs_document;
+    rapidjson::Document rhs_document;
+    lhs_document.Parse<rapidjson::kParseValidateEncodingFlag>(lhs.data(), lhs.size());
+    rhs_document.Parse<rapidjson::kParseValidateEncodingFlag>(rhs.data(), rhs.size());
+    return !lhs_document.HasParseError() && !rhs_document.HasParseError() && lhs_document == rhs_document;
+}
+
+void VerifyConformance(const Message &source) {
+    std::string protobuf_json;
+    std::string fast_json;
+    ASSERT_TRUE(ProtobufToJson(source, &protobuf_json));
+    ASSERT_TRUE(FastProtoJsonCodec::TryToJson(source, fast_json));
+
+    // Protobuf is the independent oracle. Different escaping and object
+    // member order are allowed; parsed JSON values must still be identical.
+    EXPECT_TRUE(JsonSemanticallyEquals(protobuf_json, fast_json))
+        << "protobuf JSON: " << protobuf_json << "\nfast JSON: " << fast_json;
+
+    std::unique_ptr<Message> protobuf_from_fast(source.New());
+    ASSERT_TRUE(ProtobufFromJson(fast_json, protobuf_from_fast.get())) << fast_json;
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(source, *protobuf_from_fast));
+
+    std::unique_ptr<Message> fast_from_protobuf(source.New());
+    ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(protobuf_json, fast_from_protobuf.get())) << protobuf_json;
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(source, *fast_from_protobuf));
+}
+
+} // namespace
+
+class FastProtoJsonCodecConformanceTest : public TESTBASE {};
+
+TEST_F(FastProtoJsonCodecConformanceTest, TestAllRegisteredProtocolMessagesMatchProtobufJsonSemantics) {
+    int verified_message_cases = 0;
+    for (const FileDescriptor *file : kProtocolFiles) {
+        SCOPED_TRACE(file->name());
+        for (int i = 0; i < file->message_type_count(); ++i) {
+            const Descriptor *descriptor = file->message_type(i);
+            SCOPED_TRACE(descriptor->full_name());
+            ASSERT_TRUE(FastProtoJsonCodec::Supports(descriptor));
+
+            const Message *prototype = google::protobuf::MessageFactory::generated_factory()->GetPrototype(descriptor);
+            ASSERT_NE(nullptr, prototype);
+
+            // The empty case covers default values and absent fields. Eight
+            // populated cases rotate every current oneof arm and exercise
+            // boundary/escaped scalar, repeated, map, wrapper and nested values.
+            std::unique_ptr<Message> empty_message(prototype->New());
+            VerifyConformance(*empty_message);
+            ++verified_message_cases;
+            for (uint32_t test_case = 0; test_case < kPopulatedCaseCount; ++test_case) {
+                SCOPED_TRACE("populated case " + std::to_string(test_case));
+                std::unique_ptr<Message> message(prototype->New());
+                PopulateMessage(message.get(), test_case, 0);
+                VerifyConformance(*message);
+                ++verified_message_cases;
+            }
+        }
+    }
+    EXPECT_GT(verified_message_cases, 0);
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/service/util/test/proto_message_json_benchmark.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_benchmark.cc
@@ -1,0 +1,199 @@
+#include <chrono>
+#include <cstdlib>
+#include <google/protobuf/stubs/stringpiece.h>
+#include <google/protobuf/util/json_util.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "kv_cache_manager/protocol/protobuf/meta_service.pb.h"
+#include "service/util/fast_proto_json_codec.h"
+
+namespace kv_cache_manager {
+namespace {
+
+constexpr int kKeyCount = 4096;
+constexpr int kIterations = 20;
+volatile size_t benchmark_sink = 0;
+
+::google::protobuf::util::JsonPrintOptions CreateJsonPrintOptions() {
+    ::google::protobuf::util::JsonPrintOptions options;
+    options.add_whitespace = false;
+    options.always_print_primitive_fields = true;
+    options.always_print_enums_as_ints = false;
+    options.preserve_proto_field_names = true;
+    return options;
+}
+
+::google::protobuf::util::JsonParseOptions CreateJsonParseOptions() {
+    ::google::protobuf::util::JsonParseOptions options;
+    options.ignore_unknown_fields = true;
+    options.case_insensitive_enum_parsing = false;
+    return options;
+}
+
+bool GenericToJson(const ::google::protobuf::Message &message, std::string *json) {
+    static const auto options = CreateJsonPrintOptions();
+    return ::google::protobuf::util::MessageToJsonString(message, json, options).ok();
+}
+
+bool GenericFromJson(const std::string &json, ::google::protobuf::Message *message) {
+    static const auto options = CreateJsonParseOptions();
+    const ::google::protobuf::StringPiece input(json.data(), static_cast<ptrdiff_t>(json.size()));
+    return ::google::protobuf::util::JsonStringToMessage(input, message, options).ok();
+}
+
+proto::meta::GetCacheLocationsByBackendRequest CreateRequest() {
+    proto::meta::GetCacheLocationsByBackendRequest request;
+    request.set_trace_id("trace-access-log-benchmark");
+    request.set_instance_id("instance-production-shaped");
+    request.set_query_type(proto::meta::QT_BATCH_GET);
+    request.mutable_block_mask()->set_offset(0);
+    request.set_sw_size(128);
+    request.add_location_spec_names("full_attention");
+    request.add_location_spec_names("mamba_state");
+    auto *threefs = request.add_backend_selectors();
+    threefs->set_backend_type(proto::meta::ST_3FS);
+    threefs->set_strategy(proto::meta::LSS_V6D_PREFIX);
+    auto *mempool = request.add_backend_selectors();
+    mempool->set_backend_type(proto::meta::ST_TAIRMEMPOOL);
+    mempool->set_strategy(proto::meta::LSS_WEIGHTED_RANDOM);
+
+    // The access-log hot case contains 4K 64-bit block keys and the matching
+    // token ids. Large decimal block keys reproduce the observed ~100-KiB
+    // request JSON rather than benchmarking a tiny synthetic message.
+    constexpr int64_t kFirstBlockKey = 8000000000000000000LL;
+    for (int i = 0; i < kKeyCount; ++i) {
+        request.add_block_keys(kFirstBlockKey + i);
+        request.add_token_ids(i);
+    }
+    return request;
+}
+
+proto::meta::GetCacheLocationsByBackendResponse CreateResponse() {
+    proto::meta::GetCacheLocationsByBackendResponse response;
+    response.mutable_header()->mutable_status()->set_code(proto::meta::OK);
+    response.mutable_header()->mutable_status()->set_message("");
+    response.mutable_header()->set_request_id("request-access-log-benchmark");
+    response.mutable_header()->set_tracer_result("lookup=complete");
+
+    for (int i = 0; i < kKeyCount; ++i) {
+        auto *locations = response.add_key_locations();
+        // A mostly-miss batch with sparse cache hits matches the response
+        // shape that makes repeated nested reflection work visible.
+        if (i % 16 != 0) {
+            continue;
+        }
+        auto *location = locations->add_locations();
+        location->set_type(i % 32 == 0 ? proto::meta::ST_3FS : proto::meta::ST_TAIRMEMPOOL);
+        location->set_spec_size(2);
+        auto *attention = location->add_location_specs();
+        attention->set_name("full_attention");
+        attention->set_uri("3fs://cache-cluster/model/layer?offset=1048576&size=2097152");
+        auto *mamba = location->add_location_specs();
+        mamba->set_name("mamba_state");
+        mamba->set_uri("pace://cache-node/block?offset=0&size=262144&media_type=1");
+    }
+    return response;
+}
+
+template <typename Operation>
+double MeasureMicros(Operation operation) {
+    for (int i = 0; i < 2; ++i) {
+        operation();
+    }
+    const auto begin = std::chrono::steady_clock::now();
+    for (int i = 0; i < kIterations; ++i) {
+        operation();
+    }
+    const auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::micro>(end - begin).count() / kIterations;
+}
+
+template <typename MessageType>
+bool VerifyEquivalent(const MessageType &message, const char *fixture_name, std::string *json) {
+    std::string generic_json;
+    std::string fast_json;
+    if (!GenericToJson(message, &generic_json) || !FastProtoJsonCodec::TryToJson(message, fast_json)) {
+        std::cerr << fixture_name << ": serialization failed\n";
+        return false;
+    }
+    if (generic_json != fast_json) {
+        std::cerr << fixture_name << ": fast JSON differs from protobuf JSON\n";
+        return false;
+    }
+
+    MessageType generic_message;
+    MessageType fast_message;
+    if (!GenericFromJson(generic_json, &generic_message) ||
+        !FastProtoJsonCodec::TryFromJson(generic_json, &fast_message)) {
+        std::cerr << fixture_name << ": parsing failed\n";
+        return false;
+    }
+    if (!::google::protobuf::util::MessageDifferencer::Equals(message, generic_message) ||
+        !::google::protobuf::util::MessageDifferencer::Equals(message, fast_message)) {
+        std::cerr << fixture_name << ": parsed protobuf differs from source\n";
+        return false;
+    }
+    *json = std::move(generic_json);
+    return true;
+}
+
+template <typename MessageType>
+void RunBenchmark(const MessageType &message, const std::string &json, const char *fixture_name) {
+    const double generic_to_json = MeasureMicros([&] {
+        std::string output;
+        if (!GenericToJson(message, &output)) {
+            std::abort();
+        }
+        benchmark_sink += output.size();
+    });
+    const double fast_to_json = MeasureMicros([&] {
+        std::string output;
+        if (!FastProtoJsonCodec::TryToJson(message, output)) {
+            std::abort();
+        }
+        benchmark_sink += output.size();
+    });
+    const double generic_from_json = MeasureMicros([&] {
+        MessageType output;
+        if (!GenericFromJson(json, &output)) {
+            std::abort();
+        }
+        benchmark_sink += output.GetDescriptor()->field_count();
+    });
+    const double fast_from_json = MeasureMicros([&] {
+        MessageType output;
+        if (!FastProtoJsonCodec::TryFromJson(json, &output)) {
+            std::abort();
+        }
+        benchmark_sink += output.GetDescriptor()->field_count();
+    });
+
+    std::cout << fixture_name << " (" << json.size() << " bytes, " << kKeyCount << " keys)\n"
+              << "  PB -> JSON  protobuf=" << generic_to_json << " us  fast=" << fast_to_json
+              << " us  speedup=" << generic_to_json / fast_to_json << "x\n"
+              << "  JSON -> PB  protobuf=" << generic_from_json << " us  fast=" << fast_from_json
+              << " us  speedup=" << generic_from_json / fast_from_json << "x\n";
+}
+
+} // namespace
+} // namespace kv_cache_manager
+
+int main() {
+    using namespace kv_cache_manager;
+    const auto request = CreateRequest();
+    const auto response = CreateResponse();
+    std::string request_json;
+    std::string response_json;
+    if (!VerifyEquivalent(request, "GetCacheLocationsByBackendRequest", &request_json) ||
+        !VerifyEquivalent(response, "GetCacheLocationsByBackendResponse", &response_json)) {
+        return 1;
+    }
+
+    std::cout << std::fixed << std::setprecision(1);
+    RunBenchmark(request, request_json, "GetCacheLocationsByBackendRequest");
+    RunBenchmark(response, response_json, "GetCacheLocationsByBackendResponse");
+    return benchmark_sink == 0 ? 1 : 0;
+}

--- a/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
@@ -616,7 +616,7 @@ TEST_F(ProtoMessageJsonUtilTest, TestReportEventLargeInSituJsonParserPreservesEs
     EXPECT_FALSE(ReportEventJsonParser::FromMutableNullTerminatedJson(raw_nul.data(), raw_nul.size(), &fast));
 }
 
-TEST_F(ProtoMessageJsonUtilTest, TestReportEventJsonParserCompatibilityCorpusMatchesGenericParser) {
+TEST_F(ProtoMessageJsonUtilTest, TestReportEventJsonParserCompatibilityCorpusMatchesProtobufParser) {
     struct CompatibilityCase {
         const char *name;
         std::string json;
@@ -663,15 +663,31 @@ TEST_F(ProtoMessageJsonUtilTest, TestReportEventJsonParserCompatibilityCorpusMat
 
     for (const auto &test_case : cases) {
         SCOPED_TRACE(test_case.name);
+        proto::meta::ReportEventRequest protobuf_parsed;
+        const bool protobuf_ok = ProtobufFromJson(test_case.json, &protobuf_parsed);
+
+        // The fast codec may conservatively reject a compatible shape, but it
+        // must never accept input with semantics different from protobuf.
+        proto::meta::ReportEventRequest fast_codec_parsed;
+        const bool fast_codec_ok = FastProtoJsonCodec::TryFromJson(test_case.json, &fast_codec_parsed);
+        if (fast_codec_ok) {
+            ASSERT_TRUE(protobuf_ok);
+            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_parsed, fast_codec_parsed));
+        }
+
         proto::meta::ReportEventRequest generic;
         const bool generic_ok = ProtoMessageJsonUtil::FromJson(test_case.json, &generic);
+        EXPECT_EQ(protobuf_ok, generic_ok);
+        if (protobuf_ok && generic_ok) {
+            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_parsed, generic));
+        }
 
         proto::meta::ReportEventRequest compatible;
         compatible.set_trace_id("must-be-cleared");
         const bool compatible_ok = ReportEventJsonParser::FromJson(test_case.json, &compatible);
-        EXPECT_EQ(generic_ok, compatible_ok);
-        if (generic_ok && compatible_ok) {
-            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(generic, compatible));
+        EXPECT_EQ(protobuf_ok, compatible_ok);
+        if (protobuf_ok && compatible_ok) {
+            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_parsed, compatible));
         }
 
         // Exercise the HTTP-only in-situ path as well. Appending an ignored
@@ -691,16 +707,30 @@ TEST_F(ProtoMessageJsonUtilTest, TestReportEventJsonParserCompatibilityCorpusMat
         large_json.append(40 * 1024, 'p');
         large_json += R"json("})json";
 
+        proto::meta::ReportEventRequest protobuf_large;
+        const bool protobuf_large_ok = ProtobufFromJson(large_json, &protobuf_large);
+        EXPECT_EQ(protobuf_ok, protobuf_large_ok);
+
+        proto::meta::ReportEventRequest fast_codec_large;
+        const bool fast_codec_large_ok = FastProtoJsonCodec::TryFromJson(large_json, &fast_codec_large);
+        if (fast_codec_large_ok) {
+            ASSERT_TRUE(protobuf_large_ok);
+            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_large, fast_codec_large));
+        }
+
         proto::meta::ReportEventRequest generic_large;
         const bool generic_large_ok = ProtoMessageJsonUtil::FromJson(large_json, &generic_large);
-        EXPECT_EQ(generic_ok, generic_large_ok);
+        EXPECT_EQ(protobuf_large_ok, generic_large_ok);
+        if (protobuf_large_ok && generic_large_ok) {
+            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_large, generic_large));
+        }
 
         proto::meta::ReportEventRequest mutable_compatible;
         const bool mutable_ok = ReportEventJsonParser::FromMutableNullTerminatedJson(
             large_json.data(), large_json.size(), &mutable_compatible);
-        EXPECT_EQ(generic_large_ok, mutable_ok);
-        if (generic_large_ok && mutable_ok) {
-            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(generic_large, mutable_compatible));
+        EXPECT_EQ(protobuf_large_ok, mutable_ok);
+        if (protobuf_large_ok && mutable_ok) {
+            EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_large, mutable_compatible));
         }
     }
 }

--- a/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
@@ -1,21 +1,167 @@
 #include <algorithm>
+#include <limits>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "google/protobuf/arena.h"
+#include "google/protobuf/util/json_util.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/protocol/protobuf/admin_service.pb.h"
+#include "kv_cache_manager/protocol/protobuf/debug_service.pb.h"
+#include "kv_cache_manager/protocol/protobuf/kv_meta_service.pb.h"
 #include "kv_cache_manager/protocol/protobuf/meta_service.pb.h"
+#include "kv_cache_manager/protocol/protobuf/optimizer_service.pb.h"
 #include "kv_cache_manager/service/util/manager_message_proto_util.h"
 #include "kv_cache_manager/service/util/report_event_json_parser.h"
+#include "service/util/fast_proto_json_codec.h"
 #include "service/util/proto_message_json_util.h"
 #include "service/util/test/service_util_test.pb.h"
 
 namespace kv_cache_manager {
 
+namespace {
+
+bool ProtobufToJson(const google::protobuf::Message &message, std::string *json) {
+    google::protobuf::util::JsonPrintOptions options;
+    options.always_print_primitive_fields = true;
+    options.preserve_proto_field_names = true;
+    return google::protobuf::util::MessageToJsonString(message, json, options).ok();
+}
+
+bool ProtobufFromJson(std::string_view json, google::protobuf::Message *message) {
+    google::protobuf::util::JsonParseOptions options;
+    options.ignore_unknown_fields = true;
+    const google::protobuf::StringPiece input(json.data(), static_cast<ptrdiff_t>(json.size()));
+    return google::protobuf::util::JsonStringToMessage(input, message, options).ok();
+}
+
+} // namespace
+
 class ProtoMessageJsonUtilTest : public TESTBASE {
 public:
 };
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecSupportsAllProtocolMessages) {
+    const google::protobuf::FileDescriptor *protocol_files[] = {
+        proto::admin::Status::descriptor()->file(),
+        proto::debug::Status::descriptor()->file(),
+        proto::kv_meta::Status::descriptor()->file(),
+        proto::meta::Status::descriptor()->file(),
+        proto::optimizer::Status::descriptor()->file(),
+    };
+    for (const auto *file : protocol_files) {
+        SCOPED_TRACE(file->name());
+        for (int i = 0; i < file->message_type_count(); ++i) {
+            SCOPED_TRACE(file->message_type(i)->full_name());
+            const auto *descriptor = file->message_type(i);
+            ASSERT_TRUE(FastProtoJsonCodec::Supports(descriptor));
+
+            const auto *prototype = google::protobuf::MessageFactory::generated_factory()->GetPrototype(descriptor);
+            ASSERT_NE(nullptr, prototype);
+            std::unique_ptr<google::protobuf::Message> message(prototype->New());
+            std::string protobuf_json;
+            std::string fast_json;
+            ASSERT_TRUE(ProtobufToJson(*message, &protobuf_json));
+            ASSERT_TRUE(FastProtoJsonCodec::TryToJson(*message, fast_json));
+            EXPECT_EQ(protobuf_json, fast_json);
+        }
+    }
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecHandlesCurrentMapAndWrapperTypes) {
+    proto::meta::ReportEventRequest event_request;
+    auto *event = event_request.add_events();
+    event->set_event_type(proto::meta::EVENT_HEARTBEAT);
+    (*event->mutable_heartbeat()->mutable_system_status())["state"] = "ready";
+    (*event->mutable_heartbeat()->mutable_system_status())["load"] = "7";
+
+    std::string event_json;
+    ASSERT_TRUE(FastProtoJsonCodec::TryToJson(event_request, event_json));
+    std::string protobuf_event_json;
+    ASSERT_TRUE(ProtobufToJson(event_request, &protobuf_event_json));
+    EXPECT_EQ(protobuf_event_json, event_json);
+    proto::meta::ReportEventRequest parsed_event;
+    ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(event_json, &parsed_event));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(event_request, parsed_event));
+
+    proto::admin::MigrationMarkMethodConfig wrapper_message;
+    wrapper_message.set_enabled(true);
+    wrapper_message.mutable_timeout_ms()->set_value(1234567890123LL);
+    std::string wrapper_json;
+    ASSERT_TRUE(FastProtoJsonCodec::TryToJson(wrapper_message, wrapper_json));
+    EXPECT_EQ(R"({"enabled":true,"timeout_ms":"1234567890123"})", wrapper_json);
+    proto::admin::MigrationMarkMethodConfig parsed_wrapper;
+    ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(wrapper_json, &parsed_wrapper));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(wrapper_message, parsed_wrapper));
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestUnsupportedTypeFallsBackToProtobufJsonUtil) {
+    UnsupportedBytesMessage message;
+    message.set_value(std::string("\0\1\2", 3));
+    EXPECT_FALSE(FastProtoJsonCodec::Supports(message.GetDescriptor()));
+
+    std::string json;
+    ASSERT_TRUE(ProtoMessageJsonUtil::ToJson(&message, json));
+    EXPECT_EQ(R"({"value":"AAEC"})", json);
+
+    UnsupportedBytesMessage parsed;
+    ASSERT_TRUE(ProtoMessageJsonUtil::FromJson(json, &parsed));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(message, parsed));
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecParsesArenaMessageTransactionally) {
+    google::protobuf::Arena arena;
+    auto *request = google::protobuf::Arena::CreateMessage<proto::meta::GetCacheLocationsByBackendRequest>(&arena);
+    request->set_trace_id("before");
+    ASSERT_NE(nullptr, request->GetArena());
+
+    ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(
+        R"({"trace_id":"after","instance_id":"instance","query_type":"QT_BATCH_GET","block_keys":["1","2"]})",
+        request));
+    EXPECT_EQ("after", request->trace_id());
+    EXPECT_EQ(2, request->block_keys_size());
+
+    EXPECT_FALSE(FastProtoJsonCodec::TryFromJson(R"({"block_keys":["invalid"]})", request));
+    EXPECT_EQ("after", request->trace_id());
+    EXPECT_EQ(2, request->block_keys_size());
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecMatchesProtobufForScalarEdgeCases) {
+    SimpleMessage source;
+    source.set_int32value(std::numeric_limits<int32_t>::min());
+    source.set_uint32value(std::numeric_limits<uint32_t>::max());
+    source.set_int64value(std::numeric_limits<int64_t>::min());
+    source.set_uint64value(std::numeric_limits<uint64_t>::max());
+    source.set_doublevalue(std::numeric_limits<double>::infinity());
+    source.set_floatvalue(-std::numeric_limits<float>::infinity());
+    source.set_boolvalue(true);
+    constexpr char kSpecialString[] = "quote:\" slash:\\ newline:\n nul:\0 unicode:雪";
+    source.set_stringvalue(kSpecialString, sizeof(kSpecialString) - 1);
+
+    std::string protobuf_json;
+    std::string fast_json;
+    ASSERT_TRUE(ProtobufToJson(source, &protobuf_json));
+    ASSERT_TRUE(FastProtoJsonCodec::TryToJson(source, fast_json));
+    EXPECT_EQ(protobuf_json, fast_json);
+
+    const std::string compatible_json =
+        R"({"int32Value":"-2147483648","uint32Value":"4294967295","int64Value":-9223372036854775808,"uint64Value":"18446744073709551615","doubleValue":"Infinity","floatValue":"-Infinity","boolValue":true,"stringValue":"unicode:\u96ea","future":{"ignored":true}})";
+    SimpleMessage protobuf_parsed;
+    SimpleMessage fast_parsed;
+    ASSERT_TRUE(ProtobufFromJson(compatible_json, &protobuf_parsed));
+    ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(compatible_json, &fast_parsed));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_parsed, fast_parsed));
+
+    SimpleMessage invalid_utf8;
+    invalid_utf8.set_stringvalue(std::string(1, static_cast<char>(0xff)));
+    std::string protobuf_invalid_json;
+    std::string fast_invalid_json;
+    EXPECT_EQ(ProtobufToJson(invalid_utf8, &protobuf_invalid_json),
+              FastProtoJsonCodec::TryToJson(invalid_utf8, fast_invalid_json));
+}
 
 TEST_F(ProtoMessageJsonUtilTest, TestToJsonSimple) {
     { // Empty msg
@@ -60,6 +206,15 @@ TEST_F(ProtoMessageJsonUtilTest, TestToJsonNullPtr) {
     std::string json;
     ASSERT_FALSE(ProtoMessageJsonUtil::ToJson(nullptr, json));
     ASSERT_EQ("", json);
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestToJsonPreservesProtobufAppendBehavior) {
+    SimpleMessage message;
+    std::string json = "prefix:";
+    ASSERT_TRUE(ProtoMessageJsonUtil::ToJson(&message, json));
+    EXPECT_EQ("prefix:{\"int32Value\":0,\"uint32Value\":0,\"int64Value\":\"0\",\"uint64Value\":\"0\","
+              "\"doubleValue\":0,\"floatValue\":0,\"boolValue\":false,\"stringValue\":\"\"}",
+              json);
 }
 
 TEST_F(ProtoMessageJsonUtilTest, TestToJsonEnum) {
@@ -270,13 +425,17 @@ TEST_F(ProtoMessageJsonUtilTest, TestFromJsonSimple) {
 TEST_F(ProtoMessageJsonUtilTest, TestFromJsonError) {
     {
         SimpleMessage msg;
+        msg.set_int32value(123);
         std::string json = "{\"int32Value\":111,";
         ASSERT_FALSE(ProtoMessageJsonUtil::FromJson(json, &msg));
+        EXPECT_EQ(123, msg.int32value());
     }
     {
         SimpleMessage msg;
+        msg.set_int32value(123);
         std::string json = "{\"int32Value\":\"not_int\"}";
         ASSERT_FALSE(ProtoMessageJsonUtil::FromJson(json, &msg));
+        EXPECT_EQ(123, msg.int32value());
     }
 }
 

--- a/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
@@ -98,7 +98,7 @@ TEST_F(ProtoMessageJsonUtilTest, TestFastCodecHandlesCurrentMapAndWrapperTypes) 
     EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(wrapper_message, parsed_wrapper));
 }
 
-TEST_F(ProtoMessageJsonUtilTest, TestUnsupportedTypeFallsBackToProtobufJsonUtil) {
+TEST_F(ProtoMessageJsonUtilTest, TestUnsupportedTypesFallBackToProtobufJsonUtil) {
     UnsupportedBytesMessage message;
     message.set_value(std::string("\0\1\2", 3));
     EXPECT_FALSE(FastProtoJsonCodec::Supports(message.GetDescriptor()));
@@ -110,6 +110,30 @@ TEST_F(ProtoMessageJsonUtilTest, TestUnsupportedTypeFallsBackToProtobufJsonUtil)
     UnsupportedBytesMessage parsed;
     ASSERT_TRUE(ProtoMessageJsonUtil::FromJson(json, &parsed));
     EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(message, parsed));
+
+    UnsupportedMapBytesMessage map_bytes;
+    (*map_bytes.mutable_value())["key"] = std::string("\0\1\2", 3);
+    EXPECT_FALSE(FastProtoJsonCodec::Supports(map_bytes.GetDescriptor()));
+    std::string protobuf_map_json;
+    std::string compatible_map_json;
+    ASSERT_TRUE(ProtobufToJson(map_bytes, &protobuf_map_json));
+    ASSERT_TRUE(ProtoMessageJsonUtil::ToJson(&map_bytes, compatible_map_json));
+    EXPECT_EQ(protobuf_map_json, compatible_map_json);
+    UnsupportedMapBytesMessage parsed_map_bytes;
+    ASSERT_TRUE(ProtoMessageJsonUtil::FromJson(compatible_map_json, &parsed_map_bytes));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(map_bytes, parsed_map_bytes));
+
+    UnsupportedNullValueMessage null_value;
+    null_value.set_value(google::protobuf::NULL_VALUE);
+    EXPECT_FALSE(FastProtoJsonCodec::Supports(null_value.GetDescriptor()));
+    std::string protobuf_null_json;
+    std::string compatible_null_json;
+    ASSERT_TRUE(ProtobufToJson(null_value, &protobuf_null_json));
+    ASSERT_TRUE(ProtoMessageJsonUtil::ToJson(&null_value, compatible_null_json));
+    EXPECT_EQ(protobuf_null_json, compatible_null_json);
+    UnsupportedNullValueMessage parsed_null_value;
+    ASSERT_TRUE(ProtoMessageJsonUtil::FromJson(compatible_null_json, &parsed_null_value));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(null_value, parsed_null_value));
 }
 
 TEST_F(ProtoMessageJsonUtilTest, TestFastCodecParsesArenaMessageTransactionally) {
@@ -159,8 +183,17 @@ TEST_F(ProtoMessageJsonUtilTest, TestFastCodecMatchesProtobufForScalarEdgeCases)
     invalid_utf8.set_stringvalue(std::string(1, static_cast<char>(0xff)));
     std::string protobuf_invalid_json;
     std::string fast_invalid_json;
-    EXPECT_EQ(ProtobufToJson(invalid_utf8, &protobuf_invalid_json),
-              FastProtoJsonCodec::TryToJson(invalid_utf8, fast_invalid_json));
+    std::string compatible_invalid_json;
+    ASSERT_TRUE(ProtobufToJson(invalid_utf8, &protobuf_invalid_json));
+    EXPECT_FALSE(FastProtoJsonCodec::TryToJson(invalid_utf8, fast_invalid_json));
+    EXPECT_TRUE(fast_invalid_json.empty());
+    ASSERT_TRUE(ProtoMessageJsonUtil::ToJson(&invalid_utf8, compatible_invalid_json));
+    EXPECT_EQ(protobuf_invalid_json, compatible_invalid_json);
+
+    proto::meta::ReportEventRequest invalid_map_utf8;
+    auto *heartbeat = invalid_map_utf8.add_events()->mutable_heartbeat();
+    (*heartbeat->mutable_system_status())["state"] = std::string(1, static_cast<char>(0xff));
+    EXPECT_FALSE(FastProtoJsonCodec::TryToJson(invalid_map_utf8, fast_invalid_json));
 }
 
 TEST_F(ProtoMessageJsonUtilTest, TestToJsonSimple) {
@@ -627,6 +660,8 @@ TEST_F(ProtoMessageJsonUtilTest, TestReportEventJsonParserCompatibilityCorpusMat
          R"json({"trace_id":"t","instance_id":"i","host_ip_port":"h:1","events":[{"event_type":"EVENT_BLOCK_ADD","block_add":{"block_key":"1","medium":"mem","specs":[{"name":"tp0","uri":"event_report://h:1/mem?size=1"}]}}],"storage_type":"ST_EVENT_REPORT_L2"})json"},
         {"camel_case_and_numeric_enums",
          R"json({"traceId":"t","instanceId":"i","hostIpPort":"h:1","events":[{"eventType":5,"heartbeat":{"systemStatus":{"state":"ready"}}}],"storageType":8})json"},
+        {"quoted_numeric_enums",
+         R"json({"trace_id":"t","instance_id":"i","host_ip_port":"h:1","events":[{"event_type":"5","heartbeat":{"system_status":{"state":"ready"}}}],"storage_type":"8"})json"},
         {"known_null_fields",
          R"json({"trace_id":null,"instance_id":"i","host_ip_port":"h:1","events":null,"storage_type":null})json"},
         {"unknown_enum_names",

--- a/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
@@ -10,10 +10,7 @@
 #include "google/protobuf/util/message_differencer.h"
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/protocol/protobuf/admin_service.pb.h"
-#include "kv_cache_manager/protocol/protobuf/debug_service.pb.h"
-#include "kv_cache_manager/protocol/protobuf/kv_meta_service.pb.h"
 #include "kv_cache_manager/protocol/protobuf/meta_service.pb.h"
-#include "kv_cache_manager/protocol/protobuf/optimizer_service.pb.h"
 #include "kv_cache_manager/service/util/manager_message_proto_util.h"
 #include "kv_cache_manager/service/util/report_event_json_parser.h"
 #include "service/util/fast_proto_json_codec.h"
@@ -63,33 +60,6 @@ std::string JsonWithUnknownArrayNesting(int depth) {
 class ProtoMessageJsonUtilTest : public TESTBASE {
 public:
 };
-
-TEST_F(ProtoMessageJsonUtilTest, TestFastCodecSupportsAllProtocolMessages) {
-    const google::protobuf::FileDescriptor *protocol_files[] = {
-        proto::admin::Status::descriptor()->file(),
-        proto::debug::Status::descriptor()->file(),
-        proto::kv_meta::Status::descriptor()->file(),
-        proto::meta::Status::descriptor()->file(),
-        proto::optimizer::Status::descriptor()->file(),
-    };
-    for (const auto *file : protocol_files) {
-        SCOPED_TRACE(file->name());
-        for (int i = 0; i < file->message_type_count(); ++i) {
-            SCOPED_TRACE(file->message_type(i)->full_name());
-            const auto *descriptor = file->message_type(i);
-            ASSERT_TRUE(FastProtoJsonCodec::Supports(descriptor));
-
-            const auto *prototype = google::protobuf::MessageFactory::generated_factory()->GetPrototype(descriptor);
-            ASSERT_NE(nullptr, prototype);
-            std::unique_ptr<google::protobuf::Message> message(prototype->New());
-            std::string protobuf_json;
-            std::string fast_json;
-            ASSERT_TRUE(ProtobufToJson(*message, &protobuf_json));
-            ASSERT_TRUE(FastProtoJsonCodec::TryToJson(*message, fast_json));
-            EXPECT_EQ(protobuf_json, fast_json);
-        }
-    }
-}
 
 TEST_F(ProtoMessageJsonUtilTest, TestFastCodecHandlesCurrentMapAndWrapperTypes) {
     proto::meta::ReportEventRequest event_request;

--- a/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
+++ b/kv_cache_manager/service/util/test/proto_message_json_util_test.cc
@@ -38,6 +38,26 @@ bool ProtobufFromJson(std::string_view json, google::protobuf::Message *message)
     return google::protobuf::util::JsonStringToMessage(input, message, options).ok();
 }
 
+std::string JsonWithUnknownObjectNesting(int depth) {
+    std::string json = R"({"stringValue":"after","unknown":)";
+    for (int i = 0; i < depth; ++i) {
+        json += R"({"next":)";
+    }
+    json += "null";
+    json.append(depth, '}');
+    json += '}';
+    return json;
+}
+
+std::string JsonWithUnknownArrayNesting(int depth) {
+    std::string json = R"({"stringValue":"after","unknown":)";
+    json.append(depth, '[');
+    json += "null";
+    json.append(depth, ']');
+    json += '}';
+    return json;
+}
+
 } // namespace
 
 class ProtoMessageJsonUtilTest : public TESTBASE {
@@ -151,6 +171,66 @@ TEST_F(ProtoMessageJsonUtilTest, TestFastCodecParsesArenaMessageTransactionally)
     EXPECT_FALSE(FastProtoJsonCodec::TryFromJson(R"({"block_keys":["invalid"]})", request));
     EXPECT_EQ("after", request->trace_id());
     EXPECT_EQ(2, request->block_keys_size());
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecBoundsDomNestingBeforeTraversingUnknownFields) {
+    // The root object counts as one level, matching protobuf 3.8's default
+    // maximum of 100 nested JSON objects.
+    const std::string supported_depth = JsonWithUnknownObjectNesting(99);
+    SimpleMessage protobuf_supported;
+    SimpleMessage fast_supported;
+    ASSERT_TRUE(ProtobufFromJson(supported_depth, &protobuf_supported));
+    ASSERT_TRUE(FastProtoJsonCodec::TryFromJson(supported_depth, &fast_supported));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_supported, fast_supported));
+
+    const std::string excessive_object_depth = JsonWithUnknownObjectNesting(100);
+    SimpleMessage protobuf_rejected;
+    EXPECT_FALSE(ProtobufFromJson(excessive_object_depth, &protobuf_rejected));
+    SimpleMessage fast_rejected;
+    fast_rejected.set_stringvalue("before");
+    EXPECT_FALSE(FastProtoJsonCodec::TryFromJson(excessive_object_depth, &fast_rejected));
+    EXPECT_EQ("before", fast_rejected.stringvalue());
+
+    // Protobuf 3.8 does not count arrays in its object recursion limit. The
+    // fast DOM parser bounds both container kinds and delegates this uncommon
+    // shape to protobuf, preserving the public API behavior without building
+    // an arbitrarily deep DOM.
+    const std::string excessive_array_depth = JsonWithUnknownArrayNesting(4096);
+    SimpleMessage protobuf_array;
+    ASSERT_TRUE(ProtobufFromJson(excessive_array_depth, &protobuf_array));
+    SimpleMessage fast_array;
+    fast_array.set_stringvalue("before");
+    EXPECT_FALSE(FastProtoJsonCodec::TryFromJson(excessive_array_depth, &fast_array));
+    EXPECT_EQ("before", fast_array.stringvalue());
+
+    SimpleMessage compatible_array;
+    compatible_array.set_stringvalue("before");
+    ASSERT_TRUE(ProtoMessageJsonUtil::FromJson(excessive_array_depth, &compatible_array));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(protobuf_array, compatible_array));
+}
+
+TEST_F(ProtoMessageJsonUtilTest, TestFastCodecPreservesJsonSemanticsWithoutHtmlSafeEscaping) {
+    SimpleMessage source;
+    source.set_stringvalue("</script><value>");
+
+    std::string protobuf_json;
+    std::string fast_json;
+    ASSERT_TRUE(ProtobufToJson(source, &protobuf_json));
+    ASSERT_TRUE(FastProtoJsonCodec::TryToJson(source, fast_json));
+    EXPECT_NE(protobuf_json, fast_json);
+    EXPECT_NE(std::string::npos, protobuf_json.find(R"(\u003c/script\u003e)"));
+    EXPECT_NE(std::string::npos, fast_json.find("</script>"));
+
+    SimpleMessage protobuf_parsed;
+    SimpleMessage fast_parsed;
+    ASSERT_TRUE(ProtobufFromJson(protobuf_json, &protobuf_parsed));
+    ASSERT_TRUE(ProtobufFromJson(fast_json, &fast_parsed));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(source, protobuf_parsed));
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(source, fast_parsed));
+
+    std::string compatible_json;
+    ASSERT_TRUE(ProtoMessageJsonUtil::ToJson(&source, compatible_json));
+    EXPECT_EQ(fast_json, compatible_json);
 }
 
 TEST_F(ProtoMessageJsonUtilTest, TestFastCodecMatchesProtobufForScalarEdgeCases) {

--- a/kv_cache_manager/service/util/test/service_util_test.proto
+++ b/kv_cache_manager/service/util/test/service_util_test.proto
@@ -34,3 +34,7 @@ message RepeatMessage {
     repeated EnumMessage enumMsgVec = 3;
     repeated OneOfMeaaage oneOfVec = 4;
 }
+
+message UnsupportedBytesMessage {
+    bytes value = 1;
+}

--- a/kv_cache_manager/service/util/test/service_util_test.proto
+++ b/kv_cache_manager/service/util/test/service_util_test.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
+
 message SimpleMessage {
     int32 int32Value = 1;
     uint32 uint32Value = 2;
@@ -37,4 +39,12 @@ message RepeatMessage {
 
 message UnsupportedBytesMessage {
     bytes value = 1;
+}
+
+message UnsupportedMapBytesMessage {
+    map<string, bytes> value = 1;
+}
+
+message UnsupportedNullValueMessage {
+    google.protobuf.NullValue value = 1;
 }


### PR DESCRIPTION
## 背景

`ProtoMessageJsonUtil` 是 HTTP/gRPC access log 使用的 protobuf JSON 转换入口。项目当前使用的 protobuf 3.8 通用 JSON 实现在大 repeated 字段和深层嵌套 message 上开销较高。本 PR 在不升级 protobuf、也不为每个接口维护独立 codec 的前提下优化这条热点路径。

## 方案

- 新增集中的 `FastProtoJsonCodec`：PB → JSON 使用 protobuf Reflection 直接写入 RapidJSON Writer，JSON → PB 使用 RapidJSON DOM 解析后通过 Reflection 填充消息。
- 在使用快路径前递归检查完整 descriptor；不支持的 descriptor 整体回退到 protobuf JSON util，兼容但不常见的 JSON 输入形态也由原实现兜底。
- 反序列化先写入临时消息，成功后再交换，保证失败时不修改调用方消息，并支持 arena message。
- DOM 在建树前限制最多 100 层 JSON container；超过限制时停止快路径并交给 protobuf 通用实现，避免对恶意深层输入建立无界 DOM。
- 新增独立的 `FastProtoJsonCodecConformanceTest`，以 protobuf 3.8 通用 JSON 实现作为 oracle，而不是依赖快路径自身的实现细节。
- 增加基于 `GetCacheLocationsByBackendRequest` / `GetCacheLocationsByBackendResponse`、4096 keys 的 benchmark，保留为可重复验证的手工 target。

## 兼容性与边界

快路径覆盖当前协议使用的标量、enum、嵌套 message、repeated、oneof、`map<string, string>`、`Int32Value` 和 `Int64Value`。`bytes`、其他 map 形态和其他 well-known type 等未覆盖类型会整条消息回退。现有 `ProtoMessageJsonUtil` API 与 protobuf JSON 选项保持不变：输出 primitive 默认值并保留 proto field name，输入忽略未知字段。

快路径承诺 protobuf JSON 的解析语义兼容，但不复现 protobuf 3.8 的 HTML-safe 字节级转义。RapidJSON 可能直接输出字符串中的 `<`、`>` 和合法 Unicode，而 protobuf 3.8 会输出 `\uXXXX`；两者解析后字符串相同，因此不会触发回退。快路径输出用于 JSON/access log 消费，不应未经 HTML 层转义直接嵌入可执行的 `<script>` 内容。

## 正确性证据

`FastProtoJsonCodecConformanceTest` 自动遍历登记协议文件中的全部顶层 message，并通过 Reflection 构造确定性样本。目前覆盖 203 个 message，每个验证 1 个空样本和 8 个填充样本，共 1827 组，包含：

- 数值默认值和边界值；
- 普通字符串、引号/反斜线/换行、Unicode、NUL 和 `</script>`；
- repeated 的空、单元素和多元素形态；
- 当前 map、wrapper、嵌套 message 以及所有 oneof 分支。

每个样本验证四个不变量：

1. 完整 descriptor 被快路径明确支持；
2. protobuf JSON 与 fast JSON 解析成 DOM 后语义相同，允许转义形式和 object member 顺序不同；
3. protobuf 解析器能够解析 fast JSON，并还原原始 PB；
4. fast 解析器能够解析 protobuf JSON，并还原原始 PB。

这是一组面向当前线上协议形态的确定性差分测试，不宣称穷举所有任意 JSON 输入。非 canonical JSON、兼容输入和回退行为继续由现有 compatibility corpus 覆盖。生产 codec 与测试 oracle 相互独立，因此 reviewer 可以主要确认支持范围和上述不变量，无需把整个 `fast_proto_json_codec.cc` 当作第二套 protobuf JSON 规范逐行验证。

新增 `kv_cache_manager/protocol/protobuf/*.proto` 文件时，只需把新文件的 `FileDescriptor` 加入测试的 `kProtocolFiles`；已有协议文件内新增 message 或字段会自动进入覆盖。

建议 reviewer 重点关注：

1. descriptor 支持范围和整体回退边界是否足够保守；
2. conformance test 的四个不变量及样本覆盖是否符合线上契约；
3. HTML-safe 转义与 DOM 深度限制是否作为显式边界可以接受。

## 验证

- `bazel test //kv_cache_manager/service/... --test_output=errors`：8/8 tests passed；conformance test 约 0.1 秒。
- `bazel run //kv_cache_manager/service/util/test:proto_message_json_benchmark`：benchmark 启动前验证 fixture 的 JSON 与反序列化 PB 等价；表格取连续 3 次运行的中位数。

| Message | Direction | protobuf 3.8 | fast codec | Speedup |
| --- | --- | ---: | ---: | ---: |
| Request, 118053 bytes | PB → JSON | 1431.7 us | 485.1 us | 3.0x |
| Request, 118053 bytes | JSON → PB | 2639.6 us | 805.0 us | 3.3x |
| Response, 130448 bytes | PB → JSON | 4335.3 us | 606.7 us | 7.1x |
| Response, 130448 bytes | JSON → PB | 4365.9 us | 1526.6 us | 2.9x |

### 真实 access log 离线重放

另外使用百万级真实线上 access record（数百万 request/response payload、数 GB JSON）进行本地离线重放。每个 payload 都以 protobuf 3.8 为 oracle，验证实际 JSON 的双解析结果一致，并将两边序列化输出交叉解析回原 PB。结果未发现语义差异，也没有出现 fast parse/serialize 回退；在这批数据上，两种序列化输出逐字节相同，未实际触发 HTML-safe escaping 差异。

计时使用仓库默认的 opt/O2 构建，提前解压数据，交替执行 generic/fast 以降低顺序偏差；只统计 codec 调用，不包含外层 access log 解析和文件 IO。以下为本机单次重放结果，绝对耗时仅供参考，speedup 用于同机相对比较。

| Operation | protobuf 3.8 total | fast codec total | Speedup |
| --- | ---: | ---: | ---: |
| JSON → PB | ~154 s | ~62 s | 2.50x |
| PB → JSON | ~225 s | ~31 s | 7.18x |
| Combined | ~380 s | ~93 s | 4.08x |

热点 payload 表现：

| Payload | JSON → PB avg (protobuf → fast) | Speedup | PB → JSON avg (protobuf → fast) | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `ReportEvent` request | 132.52 → 52.81 µs | 2.51x | 229.33 → 26.63 µs | 8.61x |
| `StartWriteCache` request | 24.10 → 9.94 µs | 2.43x | 23.46 → 5.28 µs | 4.44x |
| `StartWriteCache` response | 59.68 → 21.07 µs | 2.83x | 73.08 → 15.64 µs | 4.67x |
| `FinishWriteCache` request | 15.95 → 5.77 µs | 2.76x | 19.58 → 2.33 µs | 8.39x |
| `FinishWriteCache` response | 13.27 → 4.47 µs | 2.97x | 19.13 → 2.05 µs | 9.33x |
| `GetCacheLocationsByBackend` request | 2,118.89 → 648.31 µs | 3.27x | 1,516.63 → 429.14 µs | 3.53x |
| `GetCacheLocationsByBackend` response | 7,613.31 → 2,920.43 µs | 2.61x | 10,999.26 → 1,270.83 µs | 8.66x |

---

## Background

`ProtoMessageJsonUtil` is the protobuf JSON conversion entry point used by HTTP/gRPC access logs. The generic protobuf 3.8 JSON implementation has significant overhead for large repeated fields and deeply nested messages. This PR optimizes the hot path without upgrading protobuf or maintaining a separate codec for every API.

## Approach

- Add a centralized `FastProtoJsonCodec`: PB → JSON writes directly from protobuf Reflection to a RapidJSON Writer, while JSON → PB parses with RapidJSON DOM and populates the message through Reflection.
- Recursively validate the complete descriptor before using the fast path. Unsupported descriptors fall back for the whole message, and compatible but uncommon JSON input shapes are delegated to the original protobuf JSON utility.
- Parse into a temporary message and swap only after success, preserving the caller message on failure and supporting arena messages.
- Bound JSON containers to 100 levels before building the DOM. Deeper inputs stop the fast path and delegate to protobuf, preventing an unbounded DOM for adversarial input.
- Add an independent `FastProtoJsonCodecConformanceTest` that uses protobuf 3.8's generic JSON implementation as the oracle instead of relying on fast-codec implementation details.
- Add a repeatable manual benchmark using `GetCacheLocationsByBackendRequest` / `GetCacheLocationsByBackendResponse` with 4096 keys.

## Compatibility and boundaries

The fast path covers the scalar types, enums, nested messages, repeated fields, oneofs, `map<string, string>`, `Int32Value`, and `Int64Value` used by current protocols. Unsupported types such as `bytes`, other map shapes, and other well-known types fall back for the whole message. The existing `ProtoMessageJsonUtil` API and protobuf JSON options remain unchanged: primitive defaults are emitted, proto field names are preserved, and unknown input fields are ignored.

The fast path guarantees protobuf JSON parsing semantics, but intentionally does not reproduce protobuf 3.8's byte-for-byte HTML-safe escaping. RapidJSON may emit `<`, `>`, and valid Unicode directly where protobuf 3.8 emits `\uXXXX`; both decode to the same string, so this does not trigger fallback. Fast output is intended for JSON/access-log consumers and must not be embedded directly into executable `<script>` content without HTML-layer escaping.

## Correctness evidence

`FastProtoJsonCodecConformanceTest` automatically walks every top-level message in the registered protocol files and generates deterministic messages through protobuf Reflection. It currently covers 203 messages with one empty and eight populated cases each—1827 cases total—including:

- Numeric defaults and boundaries;
- Plain strings, quotes/backslashes/newlines, Unicode, NUL, and `</script>`;
- Empty, single-element, and multi-element repeated fields;
- Current maps, wrappers, nested messages, and every oneof arm.

Every generated case checks four invariants:

1. The complete descriptor is explicitly eligible for the fast path;
2. Protobuf JSON and fast JSON produce semantically equal DOM values, while allowing different escaping and object-member order;
3. The protobuf parser accepts fast JSON and reconstructs the source PB;
4. The fast parser accepts protobuf JSON and reconstructs the source PB.

This is a deterministic differential test for the current production protocol shapes, not a claim to exhaust every arbitrary JSON input. Existing compatibility corpora continue to cover non-canonical inputs, accepted aliases, and fallback behavior. Because the production codec and test oracle are independent, reviewers can focus on the supported contract and these invariants instead of treating `fast_proto_json_codec.cc` as a second protobuf JSON specification that must be verified line by line.

When adding a new `kv_cache_manager/protocol/protobuf/*.proto` file, only its `FileDescriptor` must be added to `kProtocolFiles`; new messages or fields in already registered files are covered automatically.

Suggested reviewer focus:

1. Whether descriptor eligibility and whole-message fallback boundaries are conservative enough;
2. Whether the four conformance invariants and generated samples match the production contract;
3. Whether HTML-safe escaping and DOM depth are acceptable as explicit boundaries.

## Validation

- `bazel test //kv_cache_manager/service/... --test_output=errors`: 8/8 tests passed; the conformance test takes about 0.1 seconds.
- `bazel run //kv_cache_manager/service/util/test:proto_message_json_benchmark`: the benchmark validates equivalent fixture JSON and parsed protobuf messages before timing; the table reports the median of three consecutive runs.

| Message | Direction | protobuf 3.8 | fast codec | Speedup |
| --- | --- | ---: | ---: | ---: |
| Request, 118053 bytes | PB → JSON | 1431.7 us | 485.1 us | 3.0x |
| Request, 118053 bytes | JSON → PB | 2639.6 us | 805.0 us | 3.3x |
| Response, 130448 bytes | PB → JSON | 4335.3 us | 606.7 us | 7.1x |
| Response, 130448 bytes | JSON → PB | 4365.9 us | 1526.6 us | 2.9x |

### Production access-log replay

A local offline replay was also run over production access logs at the scale of millions of records, millions of request/response payloads, and several GiB of JSON. Every payload used protobuf 3.8 as the oracle: both parsers had to produce the same PB, and both serialized outputs were cross-parsed back to the source PB. The replay found no semantic mismatches and no fast parse/serialize fallbacks. For this corpus, both serializers were also byte-for-byte identical, so the explicit HTML-safe escaping difference was not exercised by observed values.

Timing used the repository's default opt/O2 build, pre-extracted data, and alternating generic/fast execution order to reduce ordering bias. It measures codec calls only, excluding outer access-log parsing and file I/O. Absolute times are from a single local replay; speedups are same-machine relative comparisons.

| Operation | protobuf 3.8 total | fast codec total | Speedup |
| --- | ---: | ---: | ---: |
| JSON → PB | ~154 s | ~62 s | 2.50x |
| PB → JSON | ~225 s | ~31 s | 7.18x |
| Combined | ~380 s | ~93 s | 4.08x |

Hot-path payloads:

| Payload | JSON → PB avg (protobuf → fast) | Speedup | PB → JSON avg (protobuf → fast) | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `ReportEvent` request | 132.52 → 52.81 µs | 2.51x | 229.33 → 26.63 µs | 8.61x |
| `StartWriteCache` request | 24.10 → 9.94 µs | 2.43x | 23.46 → 5.28 µs | 4.44x |
| `StartWriteCache` response | 59.68 → 21.07 µs | 2.83x | 73.08 → 15.64 µs | 4.67x |
| `FinishWriteCache` request | 15.95 → 5.77 µs | 2.76x | 19.58 → 2.33 µs | 8.39x |
| `FinishWriteCache` response | 13.27 → 4.47 µs | 2.97x | 19.13 → 2.05 µs | 9.33x |
| `GetCacheLocationsByBackend` request | 2,118.89 → 648.31 µs | 3.27x | 1,516.63 → 429.14 µs | 3.53x |
| `GetCacheLocationsByBackend` response | 7,613.31 → 2,920.43 µs | 2.61x | 10,999.26 → 1,270.83 µs | 8.66x |

