### PR TITLE
[manager] add migration admission strategy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [后台扫描 GC](design/cache_garbage_collector.md) - 基于 authoritative cursor 的后台全量巡检；V1 清理长期 orphan WRITING 和普通 SERVING storage-missing，并提供无副作用读取、精确值条件 CAS 与 HA 生命周期
 - [CacheReclaimer 跨 Instance 公平逐出](design/cache_reclaimer_instance_fairness.md) - 按 Instance 用量分配采样与逐出预算，并与异步 credit 协同
 - [EventReport 主动回收纳入后台扫描 GC](design/event_report_background_gc.md) - 由 EventReportBackend 提供状态驱动的批量判定，复用统一 GC round 回收 stale snapshot 与 down host metadata
+- [基于访问特征的迁移准入策略](design/migration_admission_strategy.md) - 面向 Copy/Mark 下沉候选，以类型化特征和可扩展策略降低低层写量与 DWPD
 
 ### 开发文档
 - [开发指南](develop/README.md) - 开发者入门指南和开发环境配置

--- a/docs/design/migration_admission_strategy.md
+++ b/docs/design/migration_admission_strategy.md
@@ -1,0 +1,1406 @@
+# 基于访问特征的迁移准入策略设计
+
+| 项目 | 内容 |
+|---|---|
+| 状态 | V1 已实现；202 远端编译、定向回归和 Dummy E2E 已通过，待代码评审与 SHADOW 灰度验证 |
+| 更新时间 | 2026-09-02 |
+| 上游基线 | `origin/main` HEAD `6a163f93`（包含 #281 squash merge 与跨 Instance 公平驱逐）；实现分支 `rc/feat/write-admission-strategy` 已 rebase 到该提交 |
+| 上位设计 | 《KVCM 多层存储》：触发模式与 Copy/Mark 执行方式正交，准入用于降低下沉写量、缓解低层介质 DWPD；不提供硬写入预算 |
+| 涉及模块 | `service`、`manager`、`meta`、`config`、`metrics`、`protocol`、`kvcm_ops` |
+| 相关文档 | [模块架构与关联关系](module_architecture.md)、[CacheReclaimer 异步删除与过度逐出优化](cache_reclaimer_async_delete.md)、[后台扫描 GC](cache_garbage_collector.md)、[EventReport 主动回收纳入后台扫描 GC](event_report_background_gc.md) |
+
+## 1. 摘要
+
+本文中的“准入”只回答一个问题：
+
+> 一个已经存在于高层存储、正准备向低层存储下沉的 block，是否值得产生这次迁移写入？
+
+它不控制普通新 block 是否允许写入缓存，也不改变首次写入热层的 `StartWriteCache` 行为。
+
+多层存储有两种迁移执行方式：
+
+1. **Copy**：`MigrationManager` 创建目标 WRITING location，并调用 `DataStorageBackend::Copy`；
+2. **Mark + StartWriteCache**：先给 block 写入 tiered target Mark，后续 `StartWriteCache` 消费 Mark，引导推理引擎在目标低层补写副本。
+
+无论最终使用 Copy 还是 Mark，都应在分发前经过同一次迁移价值准入。第一阶段采用简单策略：只有最近 X 秒内发生过 metadata touch 的候选才值得下沉；“至少被业务访问 N 次”作为后续策略之一，不将整个抽象绑定在时间和次数两个固定字段上。
+
+Recent-access 是价值过滤器，只能概率性降低低层写量和 DWPD，不是写入速率或每日写入量的硬预算。若后续需要保证 target 的 byte rate、daily bytes 或 DWPD 上限，应增加独立的 target write budget，并让 Copy 与 Mark 共享预算；该能力不属于 V1。
+
+V1 的核心落点是当前两条触发链路共用的 `MigrationManager::DispatchMigrationBatch`。分发前先以 NoTouch 方式取得候选的 location 和 policy-required features（V1 为访问时间）快照，再作价值判断：
+
+```text
+Reclaimer / Admin MigrateCache
+        -> migration candidates
+        -> NoTouch migration snapshot // location + required features
+        -> MigrationAdmissionPolicy      // 新增：值不值得迁移
+        -> Reclaimer 合格集合排序/预算截断
+        -> CheckCopyAdmission            // 现有：能不能安全执行
+        -> Copy 源 lease / 条件 Mark
+```
+
+被价值准入拒绝的 block：
+
+- 不提交 Copy；
+- 不写入 tiered Mark；
+- 不创建目标 WRITING metadata；
+- 不产生低层存储写入；
+- Reclaimer 仍可按原有回收策略删除高层副本。
+
+当前实现同时落地了 ENFORCE 所需的执行安全与可观测性前置：Copy source-generation lease、reservation 后 NoTouch 重检、partial-spec Copy、条件 Mark/逐 key outcome、统一 dispatch outcome、backend capability/readiness gate、`kvcm_ops` 配置透传，以及按缺失 specs 统计的 Copy/Mark 字节指标。普通无 Mark 的 `StartWriteCache` 不进入价值准入；它只延续已有热层写入语义。
+
+## 2. 需求背景
+
+多层存储希望扩大总体容量、延长有复用价值的 KV Cache 生命周期，同时需要降低 SSD 等低层介质的无效写入、缓解 DWPD 压力。
+
+Reclaimer 在高层水位达到迁移阈值时，会从高层选出较冷的 block。如果所有候选都无条件下沉，写入后从未复用、未来也不太可能命中的 block 仍会消耗低层容量和写寿命。
+
+迁移准入位于“选出候选”和“执行迁移”之间：
+
+```text
+触发：水位 / 外部 API / 后续策略
+                |
+                v
+候选池：采样 + 初步 LRU 排序
+                |
+                v
+价值准入：是否值得下沉          <- 本文
+                |
+                v
+合格集合：最终 LRU 排序 + 预算截断
+                |
+                v
+执行准入：源/目标/任务状态是否合法 <- 当前已有
+                |
+          +-----+-----+
+          |           |
+         Copy        Mark
+```
+
+触发模式与执行方式正交：
+
+- Reclaimer 水位触发可以选择 Copy 或 Mark；
+- Admin/API 触发可以选择 Copy 或 Mark；
+- Copy 失败后可以按现有逻辑 fallback 到 Mark；
+- 准入结论不因执行方式不同而改变。
+
+## 3. 设计范围
+
+### 3.1 V1 目标
+
+1. 在 Copy/Mark 分发前，对每个迁移候选做最近访问时间准入。
+2. Reclaimer 和 Admin/API 迁移共用同一套策略和统计口径。
+3. 准入策略默认关闭，不因缺省配置改变价值过滤结果；NoTouch 和 Admin route 校验的独立影响在兼容性章节显式说明。
+4. 支持 SHADOW 和 ENFORCE；SHADOW 在 feature 异常时保持现有迁移行为，先观测预计减少的下沉 block/bytes，再灰度拒绝。
+5. 准入本身使用 NoTouch 读取，不得反向刷新访问时间。
+6. Copy 和 Mark 使用同一次准入结果；Copy fallback Mark 不重复判断。
+7. Mark 一旦写入，后续 `StartWriteCache` 只负责兑现迁移意图，不重新做热度准入。
+8. 保持 Instance 隔离和现有 group 级 Copy 并发限制；Copy reservation 同时保护精确的源 Location，避免迁移期间被维护删除。
+9. 迁移选样、prepare、Mark 去重等内部操作不得把候选 block 伪造成“刚被业务访问”。
+10. 把访问信号采集、单策略判断和迁移分发解耦；未来新增访问次数、复访间隔、模型分数或策略组合时，不修改 `MigrationManager` 的 Copy/Mark 主流程。
+11. Reclaimer 扩大候选池，在最终 NoTouch 快照上先做价值过滤，再在合格集合内按 LRU 排序并截取迁移预算，避免最冷但超窗的候选长期占满 batch。
+12. Mark 写入采用条件 RMW 并返回逐 key outcome；预查询只用于减少 I/O，不承担并发正确性。
+13. ENFORCE 由 backend capability 和运行时 recency warmup gate 保护，不能只依赖人工灰度约定。
+
+### 3.2 V1 非目标
+
+1. 不限制全新 block 正常写入热层。
+2. 不对普通 `StartWriteCache` 返回 admission rejection，也不新增 connector mask。
+3. 不实现访问次数、衰减计数或复杂预测模型。
+4. 不改变“合格候选内优先迁移较冷 block”的原则、迁移水位、Copy/Mark 优先级和 retention 策略；V1 会调整候选池截断与价值过滤的先后顺序。
+5. 不持久化新的访问历史，也不跨 Manager 复制进程内统计。
+6. 不把所有系统中的 admission 统一成通用规则引擎。
+7. V1 不实现在没有 Mark 的情况下由 `StartWriteCache` 主动发现迁移机会；该能力留作后续演进。
+8. 不将准入扩展到高层内部的普通写入、副本修复或 Reclaimer 直接删除；它只管理 source -> target 的下沉/迁移写入。
+9. 不提供 target byte token bucket、每日写入预算或硬 DWPD 上限；这些属于独立的写入预算控制层。
+
+## 4. 当前实现基线
+
+### 4.1 当前迁移链路
+
+#### Reclaimer 水位触发
+
+`CacheReclaimer` 当前行为：
+
+1. 按 migration strategy 的 source storage 水位判断是否触发；
+2. `DoKeySampling` 采样，并通过普通 `GetProperties(PROPERTY_LRU_TIME)` 取排序信号；
+3. `MakeBatchByLRU` 选择最冷的一批 block；
+4. 投递 `AsyncMigrationPrepareJob`；
+5. worker fresh-read 当前配置，并通过普通 `BatchGetLocation` 读 location；
+6. 进入 `MigrationManager::DispatchMigrationBatch`；
+7. Copy 优先，Copy 失败时可 fallback Mark。
+
+#### Admin/API 触发
+
+`MigrationManager::MigrateCache` 当前行为：
+
+1. 显式 block keys 优先，否则按 rule 采样；
+2. 通过普通 `BatchGetLocation` 批量读取 location map；
+3. 进入同一个 `DispatchMigrationBatch`；
+4. 返回 accepted/rejected 计数。
+
+因此 `DispatchMigrationBatch` 是 Reclaimer 与 API 两路的第一个稳定公共分发点，也是 V1 统一价值准入的推荐位置。但不能只在这里多读一次 NoTouch 时间：上游普通 `GetProperties` 和 `BatchGetLocation` 已经会 touch metadata，使最终读到的时间变成“迁移流程刚访问过”。V1 必须同时修正这些准入前置读取。
+
+### 4.2 当前已有的是“执行准入”
+
+`MigrationManager::CheckCopyAdmission` 已经检查：
+
+- 同一 Instance/block 是否已有活跃 Copy；
+- source storage 是否存在 SERVING location；
+- target storage 是否已有覆盖所需 specs 的 SERVING location；
+- target storage 是否已有 WRITING location。
+
+`DataStorageSelector` 和 `CheckTargetStorageAdmission` 还负责：
+
+- target storage 是否注册、启用、可写；
+- Instance Group 和 storage type quota 是否允许分配。
+
+这些规则回答“现在能不能安全执行、是否还需要迁移”，并不回答“这个 block 是否有复用价值、值不值得消耗一次低层写入”。
+
+### 4.3 基线缺少的价值准入抽象与 V1 落点
+
+上游基线中，`MigrationManager` 没有对应的价值策略抽象。原有 admission 逻辑主要内嵌在 `MigrationManager::CheckCopyAdmission` 和 `DispatchMigrationBatch` 中，处理的是执行安全而不是迁移价值。
+
+V1 已在 `MigrationManager` 内部实现 `MigrationAdmissionPolicy` 领域接口、recent-access leaf、typed feature collector 和 factory。它们是 manager 的内部子组件，不构成新的架构模块或对外生产入口；现有 `CheckCopyAdmission` 保持执行安全职责，避免把访问策略、I/O 状态和任务状态混在一个方法中。
+
+### 4.4 当前访问时间和次数能力
+
+| 能力 | 当前状态 | V1/V2 结论 |
+|---|---|---|
+| `PROPERTY_LRU_TIME` | Local metadata item 维护最后 touch 时间；Reclaimer 已用于 LRU 排序 | V1 可复用，但必须明确 NoTouch 和近似语义 |
+| `RevisitIntervalHistogram` | 聚合访问间隔分布 | 不能回答某个 block 是否准入 |
+| `PROPERTY_HIT_COUNT` | 只有属性名和通用属性存取能力 | V2 前必须新增真实业务计数 |
+| 当前基线 NoTouch | 已有 cache NoTouch、maintenance scan、定向 location 读/存在性检查/删除和 location-level maintenance RMW | V1 在其上补齐通用 NoTouch property/snapshot，并接入完整迁移决策链 |
+
+迁移候选一定是已经存在 source location 的 block，因此不存在“查询 miss 没有 metadata、导致新 key 永远无法 bootstrap”的问题。V1 不需要为查询 miss 建立独立访问索引。
+
+### 4.5 上游基线存在、V1 已一并封闭的上线前置问题
+
+价值准入不能替代迁移执行本身的并发保护。上游基线有三类与 ENFORCE 上线直接相关的问题：
+
+1. `DispatchMigrationBatch` 从 location snapshot 生成 `src_location_id`、`src_create_time` 和 `src_specs` 后，`BatchSubmit` 直接使用这些值创建目标并提交 Copy；源端只在 Copy 完成后再次检查。snapshot 与 Copy 完成之间，Reclaimer/GC 仍可能删除源 Location，导致目标已经发生写入后因 `source_lost` 被丢弃。
+2. Mark 去重查询与真正的 Mark RMW 不是一个原子操作；Copy fallback Mark 会进一步扩大窗口。当前 modifier 还会无条件覆盖 target/deadline，并且批量调用方拿不到可靠的逐 key 提交结果。
+3. `kvcm_ops` 当前 `CacheConfig` 未完整解析和输出 `migration_config`。更新无关字段时可能把服务端已有迁移配置清空，而 Registry 更新采用完整对象替换语义。
+
+第 1、2 项是原有迁移路径已经存在的竞态，不是 recent-access policy 新制造的。V1 已分别用 source-generation lease + reservation 后重检、条件 Mark + 逐 key outcome 封闭；`kvcm_ops` 也已补齐 `migration_config` 和未知字段的 round-trip。它们仍应作为 ENFORCE 上线回归与灰度验收项。
+
+## 5. 准入语义
+
+### 5.1 准入对象
+
+准入对象必须同时满足：
+
+1. 已被 Reclaimer、Admin/API 或未来迁移触发器选为候选；
+2. 在当前 Instance 的 source storage 上存在可用于迁移的 metadata/location；
+3. 目标是从 source storage 向 strategy 指定的 target storage 下沉或补副本。
+
+普通新 block 的流程不属于准入对象：
+
+```text
+StartWriteCache:
+    if 有有效 tiered Mark:
+        写 Mark 指定的 target storage       // 兑现已准入迁移
+    else if 已有普通可用副本:
+        skip
+    else:
+        写默认热层 storage                  // 新 block 正常写，不做迁移准入
+```
+
+### 5.2 V1：最近访问时间策略
+
+V1 配置中唯一 policy 为 `admission.policies[0].recent_access.window_seconds = X`。对候选 block：
+
+```text
+age = now_us - last_access_time_us
+
+feature available && last_access_time 合法:
+    0 <= age <= X  -> ACCEPT
+    age > X         -> REJECT(not_recent)
+feature missing / invalid / unsupported / read-error:
+    UNKNOWN
+```
+
+含义是：只把“虽然已经进入 Reclaimer 的冷候选集合，但在配置窗口内仍发生过 metadata touch”的 block 下沉到低层，完全陈旧或无法证明近期 touch 的 block 不消耗本轮低层迁移写入。
+
+V1 的最近访问时间是一个启发式信号，不等价于“至少被业务读取过一次”：
+
+- metadata 创建、普通 Upsert/RMW 等路径当前可能刷新时间；
+- 进程恢复或 cache 回填可能重新建立 item 的时间；
+- 因此 V1 可能放过少量从未被业务复用、但刚发生内部 mutation 的 block。
+
+因此 V1 应对外称为“recent metadata-touch TTL 启发式策略”，不能宣称它已经准确识别“至少被业务访问过一次”或真实业务热度。这也是 V2 仍需要独立业务访问计数的原因。
+
+SHADOW 阶段除预计接受率和预计字节外，还应评估准入 cohort 后续是否产生 cold-tier hit。若线上无法低成本逐 key 追踪，可对候选采样并通过事件/离线关联计算；不能只用 metadata touch 命中率证明策略有效。
+
+### 5.3 未知或异常 feature
+
+迁移是可选优化，ENFORCE 无法确认价值时优先保护低层写量；SHADOW 则必须保持现有执行行为，只记录预计结果：
+
+location 是执行迁移的必要数据，feature 只是价值判断输入，两者的读取状态不能合并成一个模糊的 snapshot 成败：
+
+| 状态 | SHADOW | ENFORCE |
+|---|---|---|
+| location 单 key 不可用 | 该 key 不进入执行准入 | 该 key 不进入执行准入 |
+| location 整批 transport/shape 失败 | 停止本批；Admin 返回非 OK，Reclaimer 记录基础设施错误 | 同 SHADOW |
+| policy 所需 feature 缺失 | 记录 UNKNOWN/`feature_missing`，但 location 可用时继续现有执行路径 | UNKNOWN，拒绝该 key |
+| feature 解析失败或取值非法 | 记录 UNKNOWN/`feature_invalid`，但继续现有执行路径 | UNKNOWN，拒绝该 key |
+| backend 不支持所需 feature | 记录 UNKNOWN/`feature_unsupported`，但继续现有执行路径 | 不允许进入 ENFORCE；运行时发现则 route NOT_READY |
+| feature provider/read transport 失败 | 记录 projected UNKNOWN/`feature_read_error`，但继续现有执行路径 | 该 key 记为 snapshot `FAILED`，Admin 返回非成功/部分成功；不伪装成普通 value reject |
+| V1 时间来自未来或发生溢出 | 记录 UNKNOWN/`feature_invalid`，但继续现有执行路径 | UNKNOWN，拒绝该 key |
+| policy 输出 shape/contract 错误且 location 仍可信 | 记录内部错误并继续现有执行路径 | 停止本批并显式报错，不计为普通 value reject |
+
+SHADOW 必须保持行为中性：只要 location 数据仍可信，feature 或 policy 自身的故障不能改变现有迁移结果。ENFORCE 对 feature missing/invalid 等 value UNKNOWN 采用 fail-closed，因为错误放行会增加低层写入；location、feature transport 和 snapshot shape 等基础设施错误属于执行失败，不得伪装成普通策略拒绝。
+
+### 5.4 同一准入结果覆盖 Copy 和 Mark
+
+价值准入发生在 Copy/Mark 分类之前：
+
+- ACCEPT 后，按 strategy 选择 Copy 或 Mark；
+- REJECT 后，两种方式都不能执行；
+- Copy 提交失败 fallback Mark 时复用原 ACCEPT 结论；
+- 已经成功写入 Mark 后，不在 `StartWriteCache` 再次检查最近访问时间。
+
+Mark 本身是一个已经通过准入的迁移意图。其时效性由 `mark.timeout_ms` 控制；如果到期仍未被 `StartWriteCache` 消费，按现有机制清理。
+
+## 6. 总体设计
+
+```mermaid
+flowchart TD
+    R[CacheReclaimer 水位触发] --> C[NoTouch 扩大采样 + 候选池]
+    A[Admin MigrateCache] --> C2[显式 keys / NoTouch rule 采样]
+    C --> P[FeatureCollector: NoTouch Migration Snapshot]
+    C2 --> P
+
+    P --> V[MigrationAdmissionPolicy 价值准入]
+    V -->|ENFORCE REJECT / UNKNOWN| J[仅计数，不 Copy、不 Mark]
+    V -->|SHADOW location-valid / ENFORCE ACCEPT| O[Reclaimer 排序/预算；Admin 保持请求顺序]
+    O --> E[CheckCopyAdmission 执行准入]
+    E -->|REJECT| K[按现有原因拒绝]
+    E -->|ACCEPT| D{执行方式}
+
+    D -->|Copy| SL[源 Location lease + 精确重检]
+    SL --> CP[BatchSubmit / DataStorageBackend::Copy]
+    D -->|Mark| MK[条件 Mark RMW]
+    CP -->|提交失败且允许 Mark| MK
+    MK --> SW[后续 StartWriteCache 消费 Mark]
+    SW --> FW[FinishWriteCache 成功后清 Mark]
+```
+
+### 6.1 模块职责
+
+| 模块 | 职责 |
+|---|---|
+| `CacheReclaimer` | 水位触发、NoTouch 扩大采样和候选池构建；不实现价值策略。Reclaimer/GC 删除路径必须识别活跃 Copy 的源 Location lease |
+| `MigrationManager` | 唯一的迁移准入生产入口；解析 immutable route/admission 配置，内部完成 feature 采集、policy 判断和 mode 处理，对 Reclaimer 合格集合最终排序/截断，再编排执行准入、源 lease 与 Copy/条件 Mark 分发 |
+| `MetaIndexer` / backend | 提供通用的批量 NoTouch property 读取、location + property 组合读取及彼此独立的状态；通过统一 access intent 支持 mutation NoTouch |
+| `config` | 在每条 migration route 上配置 mode 和类型化 policy 列表；V1 列表中只能有一个 recent-access policy |
+| `protocol` / `service` / `kvcm_ops` | 负责配置的 proto/JSON 转换、校验和 round-trip；不执行准入算法 |
+| `metrics` | 记录 candidate、shadow/enforce accept/reject、feature/readiness 状态、分阶段 outcome、预计/实际字节和 source-lost 浪费写 |
+| `CacheManager::StartWriteCache` | 只消费已准入 Mark；普通热层写入行为不变 |
+
+这里按架构模块划分职责，不把 `MigrationAdmissionPolicy`、feature collector 或 factory 单列成与 `manager` 平级的模块。它们都由 `MigrationManager` 私有拥有；可以为控制文件规模和纯逻辑单测拆成 manager 目录下的 internal 文件，但编译进现有 `migration_manager` target，不提供跨模块 API。
+
+依赖仍保持 `service -> manager -> meta -> config` 的现有方向。Reclaimer、service 和 meta 都不能直接构造或调用 policy；Meta 层只暴露中性的 NoTouch 数据结果，不得引用 policy 或其他 manager 内部类型。
+
+### 6.2 MigrationManager 内部策略抽象
+
+V1 不建设跨业务的通用规则引擎，但在 `MigrationManager` 内部为“迁移价值准入”提供稳定扩展点。首期只实现一个 recent-access leaf，不实现 Composite；内部边界仍分为三层：
+
+```text
+FeatureCollector  --批量 NoTouch-->  typed features
+                                              |
+Policy           --单一规则------->  ACCEPT / REJECT / UNKNOWN
+                                              |
+MigrationManager --mode----------->  SHADOW 记录 / ENFORCE 过滤
+```
+
+核心类型建议为：
+
+```cpp
+enum class MigrationAdmissionFeature : uint8_t {
+    kLastAccessTime = 0,
+    kBusinessAccessCount = 1, // V2 启用
+    kFeatureCount,
+};
+using MigrationAdmissionFeatureSet =
+    std::bitset<static_cast<size_t>(MigrationAdmissionFeature::kFeatureCount)>;
+
+inline MigrationAdmissionFeatureSet FeatureSetOf(
+    MigrationAdmissionFeature feature) {
+    MigrationAdmissionFeatureSet features;
+    features.set(static_cast<size_t>(feature));
+    return features;
+}
+
+enum class ObservedFeatureStatus {
+    kAvailable,
+    kMissing,
+    kInvalid,
+    kUnsupported,
+    kReadError,
+};
+
+struct ObservedFeature {
+    ObservedFeatureStatus status = ObservedFeatureStatus::kMissing;
+    std::variant<std::monostate, int64_t, uint64_t, double> value;
+};
+
+class MigrationCandidateFeatures {
+public:
+    const ObservedFeature &Get(MigrationAdmissionFeature feature) const;
+
+    template <typename T>
+    std::optional<T> GetAvailableValue(MigrationAdmissionFeature feature) const;
+
+private:
+    std::array<ObservedFeature,
+               static_cast<size_t>(MigrationAdmissionFeature::kFeatureCount)> values_;
+};
+
+struct MigrationAdmissionContext {
+    int64_t now_us = 0;
+};
+
+enum class MigrationAdmissionVerdict {
+    kAccept,
+    kReject,
+    kUnknown,
+};
+
+enum class MigrationAdmissionPolicyType {
+    kRecentAccess,
+    kMinimumBusinessAccessCount, // V2 启用
+};
+
+enum class MigrationAdmissionReason {
+    kSatisfied,
+    kNotRecent,
+    kInsufficientBusinessAccessCount, // V2 启用
+    kFeatureMissing,
+    kFeatureInvalid,
+    kFeatureUnsupported,
+    kFeatureReadError,
+};
+
+struct MigrationAdmissionDecision {
+    MigrationAdmissionVerdict verdict = MigrationAdmissionVerdict::kUnknown;
+    MigrationAdmissionPolicyType policy_type = MigrationAdmissionPolicyType::kRecentAccess;
+    MigrationAdmissionReason reason = MigrationAdmissionReason::kFeatureMissing;
+};
+
+class MigrationAdmissionPolicy {
+public:
+    virtual ~MigrationAdmissionPolicy() = default;
+    virtual MigrationAdmissionFeatureSet RequiredFeatures() const noexcept = 0;
+    virtual std::vector<MigrationAdmissionDecision>
+    EvaluateBatch(const std::vector<MigrationCandidateFeatures> &features,
+                  const MigrationAdmissionContext &context) const = 0;
+};
+```
+
+以上类型属于 manager-internal API，不是对外模块接口。具体实现可以放在 `migration_admission_internal.{h,cc}`，也可以在规模较小时留在 `migration_manager.cc`；二者只有物理组织差异，不改变其由 `MigrationManager` 所有的语义边界。不建议做成 `MigrationManager` 的 C++ nested class：嵌套并不会增强模块隔离，反而会让多个 leaf、factory 和纯策略测试更笨重。
+
+策略扩展方向：
+
+- V1 `RecentAccessAdmissionPolicy(window)` 只声明 `kLastAccessTime`；
+- V2 `MinimumBusinessAccessCountPolicy(min_count)` 只声明 `kBusinessAccessCount`；
+- 后续的复访间隔、衰减热度、生命周期或模型分数策略，通过新 feature 和 leaf policy 扩展。
+
+`MigrationCandidateFeatures` 是类型化 feature bag，不固定暴露 `last_access_time` / `hit_count` 成员。底层用 enum-indexed array 和受限 variant，避免 per-key hash/string 分配；leaf 通过 feature id + 期望值类型读取，类型不匹配统一视为 `kInvalid`。Collector 保证 `kAvailable` 时 variant 必须是该 feature 声明的类型，其他 status 使用 `monostate`。新增 feature 只需扩展 enum/value type 和 collector descriptor，不改 policy 接口或 dispatch snapshot 形状。
+
+Policy 接口以 batch 为粒度，输出必须与输入一一对齐。V1 recency 和后续 count leaf 只需逐 key 计算；batch 接口同时避免 per-key virtual call，并为未来的分位数或相对排名策略保留能力。这些策略仍只能决定迁移价值，不接管 Copy/Mark 执行，也不承担 target 写入预算。接口使用项目 C++17 已支持的 `const std::vector<...> &`，不额外引入 C++20 `std::span` 依赖。
+
+`EvaluateBatch` 返回需要分配内存的 `std::vector`，因此不能声明 `noexcept`；否则分配失败或实现意外抛出会直接 `std::terminate`。若实现阶段要求全链路无异常，应改为调用方预分配输出并返回显式错误，而不是在会分配的接口上保留 `noexcept`。
+
+`RequiredFeatures()` 是策略与采集层之间的唯一依赖。`MigrationAdmissionFeatureCollector` 一次批量获取当前 policy 声明的信号；策略不直接识别 property name、MetaIndexer 或数据来源。feature -> source/property/parser 映射只存在于 collector。未来启用组合时，collector 再对多个 policy 的 feature 求并集，接口无需改变。
+
+V1 collector 只需要 MetaIndexer provider。未来如果模型分数或其他 feature 来自非 metadata 数据源，在 collector 内增加受控 provider adapter，但 policy 仍只消费 typed feature bag，不直接发起 I/O。
+
+manager-internal 的 `MigrationAdmissionPolicyFactory` 将类型化配置构造为 immutable policy；一个 batch 内复用同一实例，不做 per-key 对象分配。V1 factory 只注册 `RecentAccessAdmissionPolicy`，不提前实现 Composite、动态脚本、反射或通用 plugin ABI；未知策略配置直接校验失败。
+
+公开配置仍使用类型化 `policies` 列表以保留 protobuf/JSON 的扩展形状，但 V1 严格校验列表长度等于 1，且只能是 `recent_access`，不公开 `match_mode`。等第二个可用策略落地时，再增加默认值为 ALL 的 `match_mode` 和 manager-internal Composite；这不会改变 feature、policy 或 dispatch 的现有边界。
+
+扩展契约如下：
+
+| 扩展场景 | 需要新增或修改 | 必须保持不变 |
+|---|---|---|
+| 新策略复用已有 feature | leaf config/proto、policy 实现、factory 注册、单测 | feature collector、dispatch、Copy/Mark、mode 处理 |
+| 新策略依赖新 feature | feature id/type/collector descriptor，再加上 leaf config、policy、factory 和单测 | dispatch snapshot 形状、Copy/Mark、`StartWriteCache` |
+| 首次启用策略组合 | `match_mode` 配置、Composite 实现及真值表测试 | leaf 与 feature provider、迁移执行状态机 |
+
+因此“访问次数”不是写进 `MigrationManager` 的一个新分支，而只是第二行扩展场景的一个实例；是否和 recency 组合则在该策略真正上线时一并实现。
+
+SHADOW/ENFORCE 不是 leaf policy 的责任：
+
+- DISABLED：不构造/执行 policy，不采集额外 feature；
+- SHADOW：计算结果但实际放行，UNKNOWN 按“预计 fail-closed 拒绝”记录；
+- ENFORCE：只有 ACCEPT 放行，REJECT/UNKNOWN 都拒绝迁移。
+
+`MigrationAdmissionPolicy` 及其实现不持有 `RegistryManager`、`MetaIndexer` 或 backend，不负责 Copy/Mark。这样可以：
+
+- 用确定输入直接测试边界；
+- 避免策略类越过 manager/meta 模块边界；
+- 后续增加单策略或策略组合时，不改动 dispatch；
+- 保持 `MigrationManager` 是唯一迁移生命周期管理中心。
+
+### 6.3 与现有 CheckCopyAdmission 的关系
+
+两层准入不能合并：
+
+| 层次 | 回答的问题 | 典型拒绝原因 |
+|---|---|---|
+| Value admission（新增） | 值不值得写入低层？ | leaf 不满足、所需 feature 未知/非法 |
+| Execution admission（已有并需补强） | 当前是否还需要且能安全执行？ | 已有任务、源不存在、目标已有 SERVING/WRITING、源 lease/重检失败 |
+| Target admission（已有） | 目标 storage 是否可写？ | 未注册、不可用、group/type quota 超限 |
+
+推荐顺序：
+
+1. target route/config 基础校验；
+2. batch NoTouch 读取 location + policy-required features 的同一份最终快照；
+3. value admission；
+4. Reclaimer 触发时，ENFORCE 对 ACCEPT 子集按最终快照中的 LRU 时间排序并截取迁移预算；SHADOW/DISABLED 保持候选池的初步 LRU 顺序，避免 policy/feature 故障改变现有选择。Admin 显式 keys 保持请求顺序；
+5. 使用快照中的 location 执行 `CheckCopyAdmission`；
+6. Copy 分支先原子 reservation，并把 `(instance_id, block_key, source_location_id, source_create_time)` 注册为源 Location lease；reservation 后、分配目标 URI/WRITING metadata 前，用 NoTouch 精确重检源 id/status/create_time；
+7. Mark 分支使用条件 RMW；预查询只作优化；
+8. BatchSubmit 继续保留 lifecycle、task dedup、target admission 和 group concurrency 硬限制；所有可能删除普通 Location 的维护路径在最终删除前检查源 lease。
+
+第 6 步的重检可以避免为已经失效的 snapshot 分配目标，但它本身不能封闭重检后的竞态。真正封闭竞态的是第 6、8 步组成的 lease 协议：只要 Copy task 仍处于 preparing/running/completing，自动维护删除就不能移除同一代源 Location。
+
+### 6.4 Dispatch 输入与配置快照
+
+当前 `DispatchMigrationBatch` 接收由上游准备的平行 `batch` 和 `loc_maps`。这使最终 location 读取落在 Reclaimer/Admin 两条分支中，也允许新调用方向 dispatch 传入已被 touch 的结果。
+
+V1 应从共享 dispatch 公开入口移除 `loc_maps` 参数，只传 keys 和 `DispatchBatchParams`。`DispatchMigrationBatch` 内部通过 NoTouch `GetForMaintenance` 组装每 key 快照，再进入价值准入：
+
+```cpp
+struct MigrationCandidateSnapshot {
+    int64_t block_key = 0;
+    CacheLocationMap locations;
+    ErrorCode location_ec = EC_OK;
+    MigrationCandidateFeatures features;
+};
+
+DispatchBatchResult DispatchMigrationBatch(
+    const std::string &trace_id,
+    const std::string &instance_id,
+    const std::string &src_name,
+    const std::string &dst_name,
+    const std::vector<int64_t> &block_keys,
+    const DispatchBatchParams &params);
+```
+
+`MigrationCandidateSnapshot` 是 manager 层内部值，不作为上游入参。这样每个 key 的 location 状态、类型化 features 和读取状态始终对齐，且不能绕过共享的 NoTouch prepare/value-admission 阶段。feature 状态保存在各 `ObservedFeature` 中，不用 `location_ec` 代替。
+
+`DispatchBatchParams` 增加四类 immutable 输入：
+
+- 当前 source -> target route 的 `MigrationAdmissionConfig` 值拷贝；
+- 触发来源 `RECLAIMER` / `ADMIN`，用于 metrics 和审计；
+- 与 keys 对齐的可选 pending location id 排除集；Reclaimer 传入已投递删除的 location，Admin 传空。这些 id 在 NoTouch snapshot 取回后、`CheckCopyAdmission` 前过滤。
+- 可选的本批迁移动作预算。Reclaimer 传 `batching_size`，在价值过滤后的合格集合上截断；Admin 显式 keys 默认不做 LRU 重排，其执行数量仍受请求大小、Copy concurrency 和 target admission 限制。
+
+具体传递规则：
+
+1. Reclaimer async worker 像现在一样 fresh-read group config，精确匹配 source/target route，再把该 route 的 admission 值拷贝传入 dispatch；
+2. Admin `MigrateCache` 由 `CacheManager` 在已取得的 group config 中精确匹配 source/target route，将同一份配置传给 `MigrationManager`；
+3. V1 不允许 Admin 在找不到 route 时隐式使用 DISABLED 绕过准入；未匹配 route 的 source/target 请求返回 `EC_BADARGS`；
+4. 配置读取后在分发期间发生更新，当前 batch 使用旧快照，下一 batch 生效。
+
+第 3 条会收紧当前 Admin 可指定任意已注册 target 的行为，但能保证所有下沉写入都有可解释的 route 和准入口径。若评审确认必须保留任意 target，则需新增 group 级 default admission，不能以缺省 DISABLED 代替。
+
+### 6.5 源 Location migration lease
+
+当前活跃 Copy task 已保存 `src_location_id` 和 `src_create_time`，V1 不需要另建一套独立租约存储；应把 task reservation 明确定义为源 Location lease，并向删除路径暴露精确查询，例如：
+
+```cpp
+bool HasActiveCopySourceLocation(
+    const std::string &instance_id,
+    int64_t block_key,
+    const std::string &location_id,
+    int64_t create_time) const;
+```
+
+lease contract：
+
+1. `ReservePreparingTaskLocked` 成功时获取 lease；同一个 task reservation 同时承担 per-block Copy 去重和源保护，不增加第二个生命周期表。
+2. reservation 后立即通过 NoTouch 读取精确重检 source id、`CLS_SERVING` 和 create_time；失败则在任何目标分配前回滚 task/lease。
+3. Reclaimer、GC 以及其他会删除普通 Location 的自动维护路径，必须在真正的 metadata CAS/物理删除前检查 lease。只在候选采样时检查不够，因为删除请求可能早于 lease 入队、晚于 lease 获取后才执行。
+4. 已经排队的删除请求若在执行时发现 lease，必须跳过或延后，并重新读取状态，不能继续使用旧删除快照。
+5. Copy 成功后仍保留现有 source id/status/create_time 完成检查。目标 promote 为 SERVING 后，task owner 才能先结束源保护，再按精确 generation 条件删除 retention 指定的源；通用删除路径不能借此获得绕过 lease 的能力。
+6. promote、失败、取消、prepare 回滚和超时等所有 terminal path 都必须释放 lease。若 task-owned 源删除异步执行，释放与提交条件删除的顺序必须保证目标已经 SERVING，且删除仍校验 source id/create_time。
+7. 显式管理删除若被定义为强制操作，应先取消并收敛对应 Copy，再删除源；不能静默绕过 lease。
+
+该 lease 保护的是“Copy 读取期间源数据仍有效”，不是长期 pin。需记录 source-lease conflict、deferred delete、lease duration 和 `migration_copy_source_lost_written_bytes_total`，以发现任务泄漏或异常写放大。
+
+### 6.6 预计文件级改动
+
+| 区域 | 主要文件 | 设计改动 |
+|---|---|---|
+| Manager 内部准入 | `manager/migration_admission_internal.{h,cc}`（可选新增）、`manager/migration_manager.{h,cc}`、`manager/BUILD` | 在 manager 内定义 feature/status/verdict/reason、collector、recent-access policy 和 factory；共享 dispatch 组装 snapshot、处理 mode、排序/截断后再 Copy/Mark。internal 文件编译进现有 `migration_manager` target，不新增公共模块或生产入口 |
+| 迁移并发与触发 | `manager/cache_reclaimer.{h,cc}`、`manager/cache_garbage_collector.{h,cc}`、`manager/cache_manager.{h,cc}`、`manager/migration_manager.{h,cc}` | Reclaimer 构建扩大候选池；Reclaimer/GC 删除识别源 lease；Admin/Reclaimer 解析 route；Mark 改条件 RMW 和逐 key outcome；普通 StartWrite 不加价值准入 |
+| NoTouch meta | `meta/meta_indexer.{h,cc}`、`meta/meta_storage_backend*`、`meta/meta_local_backend*`、`meta/types.h`、`meta/BUILD` | 复用现有 maintenance scan、定向 location 读/删和 RMW；新增通用 NoTouch property/combined snapshot 及分组件状态；扩展共享 block-property RMW 在同一锁内读取现有 properties、条件修改并返回逐 key commit 结果；以端到端 access intent 补齐 block-property/location upsert 不刷新 access time 的能力 |
+| 配置与协议 | `config/migration_strategy.{h,cc}`、`protocol/protobuf/admin_service.proto`、`service/util/manager_message_proto_util.*`、`package/kvcm_ops` | 增加 route admission 配置、校验、默认值和完整 round-trip |
+| 可观测性 | `metrics/metrics_collector.*`、manager/reclaimer metrics 注册点 | 新增 value-admission、readiness、分阶段 outcome、source lease/浪费写与 NoTouch 异常指标，与现有 execution admission 分开 |
+| 测试 | 上述模块 `test/` 和必要的 `integration_test/reclaimer` | 覆盖配置、NoTouch、纯策略、两个触发入口、Copy/Mark/StartWrite 集成语义 |
+
+## 7. NoTouch 访问特征采集
+
+### 7.1 为什么整条迁移决策链都必须 NoTouch
+
+当前 `MetaIndexer::GetProperties(..., PROPERTY_LRU_TIME)` 最终可能走普通 Local Get。普通 Get 会先返回旧时间，再把 item touch 到当前时间。
+
+这会导致：
+
+1. 本轮判断虽然拿到旧值，下一轮却把 admission 自己当成一次新访问；
+2. 一个持续被 Reclaimer/准入扫描但没有业务读取的 block，会被周期性“保鲜”；
+3. 未来 hit count 如果挂在同一 touch 语义上，也会被虚增。
+
+只把最后一次 admission 读取改成 NoTouch 仍然不正确。当前在到达公共 dispatch 前已经有两个污染点：
+
+1. `CacheReclaimer::DoKeySampling` 的普通 `GetProperties(PROPERTY_LRU_TIME)`；
+2. `RunAsyncMigrationPrepare` 和 `MigrateCache` 的普通 `MetaSearcher::BatchGetLocation`。
+
+若这两处任一保留 touch，最终准入读到的就是“迁移流程自己刚访问过”，候选几乎都会通过窗口。
+
+最新基线已经有 `ApplyToEntryNoTouch`、maintenance scan 和定向 location NoTouch 读取，但尚没有面向显式 keys、可读取任意 property 的公开接口，也没有 location + property 的组合快照。V1 应在现有 maintenance read stack 上补充以下中性接口，而不是另建平行机制，更不能让 meta 层识别 `MigrationAdmissionFeature` 或返回 manager 层的 `MigrationCandidateFeatures`：
+
+```cpp
+// 迁移候选 LRU 排序使用，不需要读 location body。
+MetaIndexer::Result MetaIndexer::GetPropertiesForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const std::vector<std::string> &property_names,
+    PropertyMapVector &out_properties) noexcept;
+
+struct MaintenanceGetResult {
+    // 两个 Result 的 error_codes 均与输入 keys 对齐。
+    // Local 单 backend 的底层读失败通常会同时反映在二者；
+    // cached/dual backend 允许 location 成功而 volatile property provider 失败。
+    MetaIndexer::Result locations;
+    MetaIndexer::Result properties;
+};
+
+// 最终 prepare 使用；一次获取执行准入的 location
+// 和价值准入的 property，避免先普通 GetLocation 再读时间。
+MaintenanceGetResult MetaIndexer::GetForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const std::vector<std::string> &property_names,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept;
+```
+
+`GetPropertiesForMaintenance` 继续返回 meta 层现有 `Result`；组合接口返回两个彼此独立的 `Result`，分别说明 location 和 property component 的 aggregate/per-key 状态。`MigrationAdmissionFeatureCollector` 根据 `RequiredFeatures()` 将 feature 映射为 property 集合，再按 key 将 meta 结果转换为 `MigrationCandidateSnapshot`，从而保持 `manager -> meta` 的单向依赖。
+
+状态拆分不是要求 Local backend 做两次读取。Local 仍应在一个 `ApplyToEntryNoTouch` callback 中取得同 key 的 location 与 property，只是把读取/投影结果分别表达；cached/dual backend 在 persistent location 成功、hot-cache volatile property 失败时，则可以准确返回“location available + feature read error”。
+
+实现上应扩展现有 `MetaLocalBackend::GetForOneKeyForMaintenance`，使其像普通 `GetForOneKey` 一样支持 `field_names` 和 property 输出，并继续在一次 `ApplyToEntryNoTouch` callback 中取得同 key 的 location 与 property。`GetPropertiesForMaintenance` 和 `GetForMaintenance` 共享该底层实现，不复制第三套读取逻辑。
+
+接口 contract：
+
+- Local backend 使用 `ApplyToEntryNoTouch`；
+- 不改变 LRU 链表位置和 `last_access_time_`；
+- 不触发 revisit histogram；
+- 不新增/回填 miss item；
+- `property_names` 允许为空，此时 `GetForMaintenance` 退化为 location-only NoTouch 读取，供 DISABLED mode 使用；
+- cached/dual backend 遵循当前在线 point-read 的 view 选择：正常运行时读 hot view，恢复阶段是否 fallback persistent 沿用现有读语义，但任何 fallback 都不得回填/碰热 hot cache；persistent 只能提供 location/持久化 property，不能伪造进程内 LRU 时间；
+- hot view miss 或 backend 不支持进程内 LRU 时间时，该 feature 按 missing/unknown 返回，不得用当前时间兜底；
+- `out_locations`、`out_properties`、`locations.error_codes` 和 `properties.error_codes` 必须与输入 keys 一一对齐；某个 component 发生 shape mismatch 时先补齐该 component 的空输出和 `EC_MISMATCH`，不得破坏另一个已可信 component 的对齐；
+- property 缺失使用“property result 成功但 map 中无该字段”表达；provider 不支持或读取失败使用明确错误，由 collector 分别转换为 `kMissing`、`kUnsupported` 或 `kReadError`；
+- location component 不可信时该 key 不能迁移；仅 property component 不可信时，按 5.3 的 SHADOW/ENFORCE 语义处理。
+
+`GetForMaintenance` 是最终准入授权的数据源，其 location 同时供后续 `CheckCopyAdmission` 使用。不允许在它之前通过普通 `BatchGetLocation` “预取” location。
+
+现有 `ScanLocationsForMaintenance` 是 GC 的 cursor 扫描接口，dual-backend 下只遍历 hot view；现有 `GetLocationsFromPersistent` 是物理删除等场景的 source-of-truth 读取。两者都不能直接代替迁移准入的显式-key组合快照：前者不是 point read，后者拿不到 hot-cache 的访问时间且可能与在线迁移 view 不同。
+
+### 7.2 迁移内部 touch 审计
+
+V1 的最小正确性边界不只是一个新查询：
+
+| 迁移内部路径 | 当前/预期问题 | V1 要求 |
+|---|---|---|
+| `SampleReclaimKeys` | Local 直接看 LRU 结构，本身不应 touch | 保持 NoTouch |
+| `DoKeySampling -> GetProperties` | 普通 Get 会刷新候选 | 迁移采样改用 `GetPropertiesForMaintenance` |
+| async/Admin prepare -> `BatchGetLocation` | 在价值准入前已刷新 | 以 `GetForMaintenance` 取代 |
+| value admission 读取 | 若单独用普通 Get，会影响下轮 | 复用同一份 NoTouch 快照 |
+| Copy reservation 后/完成前 source generation 重检 | 当前完成检查走普通 location Get，会刷新时间 | 两次都使用 location-only `GetForMaintenance`，校验 id/status/create_time |
+| Mark dedup/query | 本轮决策后仍可能刷新下轮信号 | 改用 NoTouch property query |
+| Mark add/clear | 当前走 block-property 普通 RMW，会刷新访问时间 | 共享 RMW 端到端传递 `MetaAccessIntent::kMaintenanceNoTouch` |
+| Copy location 状态迁移 | 现有 location maintenance RMW 已支持 NoTouch 读取/删除，但 `MA_OK` upsert 仍走普通 Upsert | 扩展现有 RMW 的 access intent，使 location upsert 也不刷新访问时间 |
+| `StartWriteCache` / `FinishWriteCache` | 属于真实写链路，V1 仍可使最近时间变新 | 作为 V1 近似语义保留；V2 不得将其计为业务 hit |
+
+`DoKeySampling` 还被 Reclaimer 删除路径使用。实现时可将它参数化为 `AccessMode::kNoTouchMaintenance`，或拆出迁移专用采样函数；不能让迁移路径继续调普通 `GetProperties`。
+
+最新基线的 `ReadModifyWriteLocationsForMaintenance` 已复用普通 location RMW 的 shard lock、modifier、计费和写入框架，迁移不应再创建第二套 RMW 状态机。但它当前只在定向读取和删除分支选择 maintenance backend；`MA_OK` 仍通过普通 `ExecuteRmwUpsert -> Upsert`，Local backend 会刷新 `last_access_time_`。因此“已有 maintenance RMW”不等于 Mark/Copy 的所有 mutation 已经 NoTouch。
+
+这里的 NoTouch 指“不更新访问/LRU/未来 hit-count 记账”，不是禁止 metadata 变更。Mark 和 Copy 状态机仍然需要写 property/location；实现必须在现有 RMW 内端到端传递统一 access intent，只抑制 access bookkeeping，不改变 shard lock、CAS、Sync 和计费语义。
+
+建议意图至少区分：
+
+```cpp
+enum class MetaAccessIntent {
+    kBusinessRead,       // 更新时间；V2 可增加业务 hit count
+    kBusinessWrite,      // V1 可更新时间；V2 不增加业务 hit count
+    kMaintenanceNoTouch, // 时间、LRU、revisit 和未来 hit count 均不更新
+};
+```
+
+intent 必须从 `MetaIndexer` RMW 入口一路传到 `ExecuteRmwUpsert`、backend Upsert 和 Local item callback，并在持有同一 item 锁时决定是否 touch。禁止采用“先保存 access time，mutation 后再恢复”的实现：恢复动作可能覆盖 mutation 期间发生的真实并发业务访问。相同原则同时适用于 Mark property、Location Upsert/CAS 和未来访问次数。
+
+### 7.3 最新上游基线 / #281 的作用边界
+
+#281 已以 squash commit `6a163f93` 合入 main。最新实现不再为 EventReport 维护一套专用 compare-delete/receipt 状态机，而是把 NoTouch 能力收敛进共享 metadata 读写框架，当前已有：
+
+- cache 层 `ApplyToEntryNoTouch`；
+- `ScanLocationsForMaintenance`；
+- backend 层定向 `GetLocationsForMaintenance`、`ExistsLocationForMaintenance` 和 `DeleteLocationsForMaintenance`；
+- `MetaIndexer::ReadModifyWriteLocationsForMaintenance`；
+- `MetaSearcher::BatchDeleteLocations(..., maintenance_no_touch=true)`。
+
+因此 V1 没有另建 maintenance RMW 状态机，而是在上述共享实现上补齐并接入迁移链路：
+
+| 基线缺口 | V1 实现状态 |
+|---|---|
+| 任意 properties 的 NoTouch point read | 已增加 `GetPropertiesForMaintenance` |
+| location + properties 的显式-key快照 | 已增加 `GetForMaintenance`，location/feature 分别返回逐 key 状态 |
+| Reclaimer LRU 采样 | 已改为 NoTouch，并扩大候选池后过滤、排序、截断 |
+| async/Admin migration prepare | 已移除上游普通 `BatchGetLocation`，统一由 dispatch 取最终 NoTouch 快照 |
+| Copy source generation 重检 | reservation 后使用 location-only maintenance read 校验 id/status/create_time |
+| Mark query | 已改为 NoTouch property query |
+| Mark/Copy mutation | 已通过 `MetaAccessIntent::kMaintenanceNoTouch` 贯通 RMW/upsert |
+
+#281 的 main squash commit 只增强了可复用的 meta 基础能力，并未自动覆盖迁移生产路径；本实现分支才完成表 7.2 的迁移 touch 审计与接入。main 同时已合入跨 Instance 公平驱逐：普通回收继续使用其显式 per-instance sampling/batching budget，迁移准入构建完整候选池时复用同一个 `MakeBatchByLRUWithSize` 排序实现，但不改变公平回收预算的分配与消费。
+
+对访问时间，已接入 maintenance API 的 GC/EventReport 路径不会再把内部操作伪装成新访问。对访问次数，当前仍没有业务命中自动累加，所以不能说该 PR “修正了正在运行的 count”；它只是建立了 maintenance 操作不应计入访问的边界。未来实现业务计数时，必须让相同 access intent 同时控制时间与 count。
+
+### 7.4 现有 LRU 时间的局限
+
+`PROPERTY_LRU_TIME` 当前更接近“最后一次 metadata touch”，不是严格的“最后一次用户命中”：
+
+- 新建、Upsert 和部分 RMW 会更新；
+- 进程重启/恢复后的时间连续性有限；
+- cached backend item 不驻留时可能没有可靠的进程内时间；
+- 不同 backend 对该 synthetic property 的支持能力可能不同。
+
+V1 接受它作为低成本近似，但必须：
+
+1. 先跑 SHADOW 验证 false accept 规模和准入 cohort 的后续 cold-tier hit；
+2. 通过代码暴露 backend/property capability，不支持可靠时间的 route 不能进入 ENFORCE；
+3. 记录 recency epoch，并由运行时 gate 保证 Leader 切换、恢复或进程启动后至少积累一个完整 window；
+4. 通过 V2 的业务访问计数解决“是否真正复用过”的精确判断。
+
+### 7.5 Backend capability 与运行时 warmup gate
+
+“先跑 SHADOW、启动后等待一个 window”不能只写成运维约定。Meta 层应以中性 property 语义暴露能力和有效数据起点，例如：
+
+```cpp
+enum class MaintenancePropertyCapability {
+    kUnsupported,
+    kProcessLocalVolatile,
+    kDurableAcrossRecovery,
+};
+
+struct MaintenancePropertyReadiness {
+    MaintenancePropertyCapability capability;
+    int64_t valid_since_steady_us = 0;
+    uint64_t generation = 0;
+};
+
+MaintenancePropertyReadiness GetMaintenancePropertyReadiness(
+    const std::string &property_name) const noexcept;
+```
+
+Meta 层不识别 `MigrationAdmissionFeature`；manager/collector 把 `kLastAccessTime` 映射到 `PROPERTY_LRU_TIME`，再解释 capability。`valid_since_steady_us` 在进程启动、Leader generation 变化、hot cache 重建或其他破坏时间连续性的恢复事件后重置。warmup 时长使用 monotonic/steady clock，不能受 wall clock 回拨影响；policy 的 access age 仍按 `PROPERTY_LRU_TIME` 的 wall-clock 口径计算并校验未来时间。
+
+ENFORCE readiness 规则：
+
+1. 静态不支持 NoTouch property 或时间语义的 backend，配置校验/激活时拒绝 ENFORCE；SHADOW 可运行并记录 unsupported。
+2. process-local 时间只有在 `steady_now - valid_since_steady >= window` 时 ready；窗口被调大后按新窗口重新判断。
+3. runtime gate 每个 batch 都检查，不能只在配置写入时检查，因为已存在的 ENFORCE 配置会跨进程重启继续存在。
+4. ENFORCE route 未 ready 时进入显式 `NOT_READY`/suspended 状态：不把所有 key 计成普通 UNKNOWN reject。Admin 返回非 OK readiness 错误，Reclaimer 跳过该 route 并记录 reason。
+5. SHADOW 未 ready 时仍执行原有迁移，只记录预计 UNKNOWN 和 readiness 状态，保持行为中性。
+6. `kDurableAcrossRecovery` 只有在 backend 确实保存同一时间口径并通过恢复测试后才能免 warmup，不能仅因 property 可读取就宣称 durable。
+
+必须提供 route/instance 级 readiness gauge、not-ready reason 和 epoch age，防止 ENFORCE 因重启或误配置静默停止全部迁移。
+
+## 8. 详细流程
+
+### 8.1 Reclaimer 水位触发
+
+```text
+TryMigrateOnGroup
+  -> 水位超过 migration threshold
+  -> DoKeySampling(NoTouch LRU property)
+  -> 构建并保留扩大候选池（不先截断到 batching_size）
+  -> SubmitAsyncMigrationPrepare
+  -> worker fresh-read route/admission config
+  -> FeatureCollector NoTouch(location + required features)
+  -> MigrationAdmissionPolicy
+  -> SHADOW 保留 location-valid 候选 / ENFORCE 保留 ACCEPT
+  -> ENFORCE 合格集合按最终 last-access 排序；SHADOW 保持初步 LRU 顺序
+  -> 截取 batching_size 动作预算
+  -> 用快照 location 进入 CheckCopyAdmission
+  -> Copy / Mark
+```
+
+最终准入必须在 async worker 的 fresh-read 阶段执行，不能只依赖 Reclaimer cron 线程采样时携带的旧时间。cron 采样时间只用于构建候选池和初步排序，不能跨异步边界作为最终授权。ENFORCE 通过 recent-access 的候选都具有合法 fresh 时间，再在该集合中最终排序；SHADOW/DISABLED 不让 policy feature 影响实际选择，保持候选池输入顺序。
+
+被准入拒绝的 block 不打 Mark、不 Copy。高层水位若继续上升，原有 Reclaimer 仍可在 reclaim threshold 处直接逐出它。
+
+V1 复用当前已经采到的 `sampling_size` 个 key 作为候选池，把 `batching_size` 仅作为最终动作预算。实现必须保留排序后的 vector 顺序，dedup set 只用于判重，不能再从 `unordered_set` 反向生成无序 batch。ENFORCE 过滤后从同一候选池继续取下一名合格候选，直到填满预算或候选池耗尽；不会因为最冷的前 N 个全部超窗就直接产生空 batch。
+
+扩大 pool 会把最终 NoTouch location/property 读取从原来的 `batching_size` 放大到至多 `sampling_size`，因此必须保持有界、继续走 MetaIndexer batch，并观测 prepare latency/bytes。DISABLED 可只提交初步排序后的前 `batching_size`，不承担额外读取；SHADOW/ENFORCE 才使用完整 bounded pool。若 admission 配置在 pool 构建后变化，本轮使用已构建输入，下一轮按新 mode 调整，不做同步重采样。
+
+配置应保证 SHADOW/ENFORCE 的 candidate pool 明显大于动作预算，并记录 pool size、value-qualified size、最终 dispatched size 和 budget-unfilled reason。候选池耗尽后本轮不再做无界重采样；若仍频繁选中相同拒绝项，可后续增加短期 cooldown，但 cooldown 不是 V1 正确性的前提。
+
+### 8.2 Admin/API 触发
+
+```text
+MigrateCache
+  -> 显式 block keys 或 rule 采样
+  -> 精确解析 source/target route + admission config
+  -> FeatureCollector NoTouch(location + required features)
+  -> policy value admission
+  -> 用快照 location 做 execution admission
+  -> Copy / Mark
+  -> legacy accepted/rejected + outcome_counts
+```
+
+默认情况下，显式 keys 和 rule 候选都经过准入，保证所有 Copy/Mark 下沉迁移共享同一价值过滤口径。该口径用于降低预计写量，不构成 DWPD 硬预算。
+
+当前 Admin 允许显式指定任意已注册 target；V1 改为必须命中精确 source/target migration route，原因和备选见 6.4。
+
+是否允许管理员显式 force bypass 是待评审项。若需要，应新增显式且可审计的 request 字段和 metrics，不能通过“显式 keys 默认绕过”形成隐式后门。
+
+### 8.3 Copy 路径
+
+只有 value admission 和 execution admission 都 ACCEPT 的 block 才能：
+
+1. 进入 BatchSubmit task reservation，并以快照中的 source id/create_time 获取源 Location lease；
+2. reservation 后以 NoTouch 精确重检 source id、`CLS_SERVING` 和 create_time；
+3. 分配目标 URI；
+4. 创建目标 WRITING metadata；
+5. 调用 backend Copy；
+6. Copy 期间自动维护删除路径持续识别 lease；
+7. 成功后再次检查 source generation，目标转 SERVING，并按 retention 处理源端；
+8. 所有成功、失败、取消和超时出口释放 task/lease。
+
+价值拒绝发生在以上状态变化之前，不需要新增清理或回滚。reservation 后的源重检失败也必须发生在目标分配前；但只有删除路径共同遵守 lease 才能封闭重检后的竞态，单独增加一次重读不够。
+
+### 8.4 Mark + StartWriteCache 路径
+
+只有准入通过的 block 才尝试写 tiered Mark。Mark dedup 查询改为 NoTouch，且只作为减少 RMW 的优化；并发正确性由同一个条件 RMW 保证：
+
+当前 `ReadModifyWriteBlock` 的 modifier 只拿到 location ids，拿不到现有 Mark properties，不能直接实现以下条件语义。V1 必须扩展共享 block-property RMW：在同一 shard/item lock 内读取现有 target/deadline，把 existing properties 传给 modifier，并在同一临界区内完成条件 Upsert。不能退化成“先 `GetProperties`、再普通 RMW”，否则仍然是 check-then-write 竞态。
+
+| RMW 中看到的当前 Mark | 行为 | outcome |
+|---|---|---|
+| 不存在或已过期 | 写入当前 target/deadline | `INSERTED` |
+| 有效且 target 相同 | 保留原 Mark，不隐式续期 | `ALREADY_SAME_TARGET` |
+| 有效且 target 不同 | 不覆盖 | `CONFLICT_DIFFERENT_TARGET` |
+| malformed | fail-closed，不覆盖 | `MALFORMED_EXISTING_MARK` |
+| block 不存在 | 不创建空 metadata | `BLOCK_NOT_FOUND` |
+| read/write 失败 | 不宣称成功 | `READ_ERROR` / `WRITE_ERROR` |
+
+Copy fallback Mark 复用原 value ACCEPT 结论，但必须进入同一个条件 RMW，不能因为 fallback 绕过冲突检查。是否允许同 target 延长 deadline 如有需求应设计成显式操作；V1 默认不续期，避免周期性 Reclaimer 让 Mark 永不过期。
+
+`MarkForTieredWrite` 返回与 keys 对齐的逐 key outcome。modifier 只能表达计划动作，不能在 backend commit 前把 key 标记为成功；最终 inserted/already/conflict/error 必须结合 MetaIndexer 的逐 key 写结果计算。Dispatch、metrics、expiry queue 和 event 只按实际 outcome 更新，不能因整批 `EC_OK` 就把所有请求 key 计为成功。
+
+成功存在 Mark 后：
+
+1. `StartWriteCache` 读取 Mark；
+2. target storage 尚无所需 SERVING/WRITING coverage 时，返回目标低层 location；
+3. `FinishWriteCache` 成功后按 mark clear policy 清理；
+4. 长时间未消费则由 mark timeout 清理。
+
+`StartWriteCache` 不重新检查访问窗口。否则一个已经通过迁移准入的 Mark 可能因排队时间变长被拒绝，Copy 和 Mark 将出现不一致语义。
+
+Mark 的查询、新增和清理属于迁移管理操作，不得更新下一轮准入所依赖的访问信号。`StartWriteCache` / `FinishWriteCache` 本身的 V1 近似语义不在本阶段改动。
+
+Mark 在未来何时、写入多少低层字节取决于 `StartWriteCache` 的实际缺失 coverage，准入时不能把 source 总大小当成已经发生的写量。实际 target 写字节应在 Start/FinishWrite 链路按成功写入 specs 记录。
+
+### 8.5 后续 StartWrite 主动识别迁移
+
+上位设计允许未来在重复 `StartWriteCache` 时直接调用算法，决定是否为已有 block 在低层补副本。
+
+该能力不属于 V1。后续实现时必须满足：
+
+- 只对已有 source location 的 block 调用迁移准入；
+- 全新 block 仍写默认热层；
+- 复用同一个 `MigrationAdmissionPolicy`；
+- 生成一个显式迁移决策/Mark，再走现有 target 和 FinishWrite 状态机；
+- 不把普通 StartWrite 的所有 key 直接交给迁移准入。
+
+## 9. 配置设计
+
+准入配置属于具体 source -> target migration route，应放在每条 `MigrationStrategy` 下：
+
+```json
+{
+  "migration_config": {
+    "copy_max_concurrency": 4,
+    "strategies": [
+      {
+        "source_storage_name": "pace_mempool_01",
+        "target_storage_name": "pace_ssd_01",
+        "trigger_threshold": 0.70,
+        "methods": {
+          "copy": {"enabled": true},
+          "mark": {"enabled": true, "timeout_ms": 60000}
+        },
+        "retention": "DELETE_SOURCE",
+        "admission": {
+          "mode": "SHADOW",
+          "policies": [
+            {
+              "recent_access": {
+                "window_seconds": 3600
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+| 字段 | 默认值 | 说明 |
+|---|---:|---|
+| `admission.mode` | `DISABLED` | `DISABLED`、`SHADOW`、`ENFORCE` |
+| `admission.policies` | `[]` | 类型化策略列表；V1 在 SHADOW/ENFORCE 时必须且只能有一个 `recent_access` |
+| `admission.policies[].recent_access.window_seconds` | 无 | V1 策略；必须大于 0 |
+
+建议在 `config/migration_strategy.h` 增加类型化配置，由 `MigrationStrategy` 持有：
+
+```cpp
+enum class MigrationAdmissionMode {
+    DISABLED = 0,
+    SHADOW = 1,
+    ENFORCE = 2,
+};
+
+struct RecentAccessAdmissionConfig {
+    int64_t window_seconds = 0;
+};
+
+using MigrationAdmissionLeafConfig =
+    std::variant<RecentAccessAdmissionConfig /*, future configs... */>;
+
+class MigrationAdmissionConfig : public Jsonizable {
+public:
+    MigrationAdmissionMode mode() const;
+    const std::vector<MigrationAdmissionLeafConfig> &policies() const;
+    // FromRapidValue / ToRapidWriter / ValidateRequiredFields
+};
+```
+
+`admin_service.proto` 中使用 `repeated MigrationAdmissionPolicyConfig policies`，每个 policy config 以 `oneof` 承载 `recent_access`、未来的 `minimum_business_access_count` 等类型。V1 保留 repeated 的 wire shape，但校验长度只能为 1；`match_mode` 等到第二个真实策略落地时再新增，避免首期同时实现无实际用途的 Composite。`manager_message_proto_util`、HTTP/GRPC 配置接口和 `kvcm_ops` 同步处理。这是配置面变更，不是普通 `StartWriteCache` 数据面协议变更。
+
+兼容规则：
+
+- 老配置缺少 admission 时等价于 DISABLED；
+- DISABLED 不构造 policy、不读取额外 feature，不改变候选的价值准入结果；迁移内部 location/Mark 改用 NoTouch 是独立的准确性修正，在 DISABLED 下也保留；
+- SHADOW 读取并计算策略，但仍让候选进入现有执行准入；
+- ENFORCE 才从 Copy/Mark 候选中删除 policy REJECT/UNKNOWN 的 key；
+- SHADOW/ENFORCE 下 policies 为空、长度不等于 1、未知/empty oneof、非 recent-access 类型或参数非法，配置校验失败；
+- V1 只接受一个 `recent_access` leaf，配置形状和内部 policy/factory 为后续策略保留扩展点，但不实现组合；
+- JSON/proto/`kvcm_ops` Create/Update/Get/List 必须完整 round-trip；
+- Admin source/target 必须精确匹配一条 route，不匹配时不得用默认 DISABLED 继续分发；
+- 同一 route 配置动态更新后，下一批 dispatch 使用新值。
+
+`kvcm_ops` round-trip 是配置投放的 P0 前置，不只是配套测试。修复必须保证：从服务端读取含 `migration_config` 的 InstanceGroup，修改任意无关字段，再序列化并 Update 后，原有 strategies、copy concurrency、mark clear policy、admission 及客户端尚不认识的可透传字段均不丢失。可以采用完整类型化模型加 unknown-field passthrough，但不能继续用只认识部分字段的 `CacheConfig` 重建整个对象。
+
+推荐配置与运行时状态迁移：
+
+```text
+DISABLED -> SHADOW -> capability READY + 至少观察一个 window -> ENFORCE
+ENFORCE -> SHADOW / DISABLED：下一批立即停止价值拒绝
+ENFORCE --进程/Leader/恢复导致 epoch 重置--> NOT_READY(suspended) --满一个 window--> ENFORCE
+```
+
+静态不支持所需 property 的 backend 拒绝 ENFORCE 配置/激活；动态 warmup 未满足时由每批 runtime gate 进入 NOT_READY，不能依赖操作者记得手工切回 SHADOW。
+
+## 10. 算法
+
+### 10.1 Batch value admission
+
+```text
+EvaluateMigrationValueAdmission(admission_config, keys):
+    if mode == ENFORCE and runtime readiness != READY:
+        return ROUTE_NOT_READY // 不是逐 key value reject
+
+    policy = null when mode == DISABLED
+             else MigrationAdmissionPolicyFactory.Build(admission_config)
+    required_features = empty when policy == null
+                        else policy.RequiredFeatures()
+    read = feature_collector.CollectNoTouch(keys, required_features)
+    if location transport/shape error:
+        return SNAPSHOT_INFRA_ERROR // 所有 mode 都不能安全执行
+
+    snapshots = build aligned location + typed feature statuses
+    if mode == DISABLED:
+        return every location-valid snapshot without value filtering
+
+    context.now_us = current_time_us once
+    decisions = policy.EvaluateBatch(snapshots.features, context)
+    if decisions.size != snapshots.size:
+        record policy contract error
+        if mode == SHADOW:
+            return every location-valid snapshot // 保持现有行为
+        return POLICY_CONTRACT_ERROR
+
+    if mode == SHADOW:
+        report projected decisions; UNKNOWN projects to fail-closed reject
+        return every location-valid snapshot to execution admission
+
+    return only snapshots whose verdict == ACCEPT
+```
+
+组合读取的两个 component 独立处理：location transport/shape 失败意味着无法安全执行，所有 mode 停止对应 key/批次；property 缺失/非法转换为 value UNKNOWN，property transport 失败在 SHADOW 中转换为 projected UNKNOWN 并继续，在 ENFORCE 中转换为 snapshot `FAILED` 并停止对应 key。Admin 的 snapshot/readiness/policy-contract 基础设施错误返回非 OK/partial header，不能计入普通 rejected。
+
+V1 recent-access leaf 使用与 `PROPERTY_LRU_TIME` 相同的微秒 wall-clock 口径。读取 once-per-batch `now`；将 seconds 换算为 microseconds 和做减法前都使用 checked arithmetic，对负值、未来时间和整数溢出返回 UNKNOWN/invalid reason。
+
+### 10.2 Dispatch
+
+```text
+DispatchMigrationBatch(block_keys, params):
+    if pending-location shape is neither empty nor aligned with block_keys:
+        return without metadata I/O
+
+    value_result = EvaluateMigrationValueAdmission(
+        params.admission, block_keys)
+    if value_result is infrastructure/readiness error:
+        return explicit batch error without Copy/Mark
+
+    value_candidates = value_result.execution_candidates
+    if params.trigger == RECLAIMER:
+        if mode == ENFORCE:
+            stable-sort ACCEPT candidates by fresh last-access ascending
+        else:
+            preserve provisional NoTouch LRU order from candidate pool
+        truncate to params.action_budget
+
+    for candidate in value_candidates:
+        remove params.pending_location_ids from candidate.locations
+        execution = CheckCopyAdmission(candidate.locations, ...)
+        if execution rejected:
+            report execution reason
+            continue
+
+        if copy enabled and slot available:
+            prepare Copy request with exact source generation
+        else if mark enabled:
+            prepare conditional Mark
+
+    BatchSubmit(copy requests):
+        atomically reserve task/source lease
+        NoTouch recheck source id/status/create_time
+        only then allocate target and submit Copy
+    Copy submit failure -> fallback admitted keys to Mark
+    ConditionalMarkForTieredWrite(mark keys) -> per-key outcomes
+    aggregate final per-key stage/reason/outcome
+```
+
+`EvaluateMigrationValueAdmission` 是 `DispatchMigrationBatch` 内部的 NoTouch prepare/value-admission 阶段，不是新增另一个可被 Reclaimer/Admin 分别绕过的生产入口。Reclaimer 的动作预算在 value filter 之后截断，Copy concurrency 则继续在 BatchSubmit reservation 内作原子硬限制；两者不能混为一项。
+
+## 11. 并发、HA 与失败语义
+
+1. policy 无 I/O、无可变状态，只消费当前 batch 的 typed features、evaluation context 和 immutable policy config。
+2. Local backend 对单 key 的 NoTouch snapshot 在同一 entry callback 中取 location 和 property；cached/dual backend 遵循在线 point-read 的 view/recovery 选择，可能组合 persistent location 与 hot-cache feature，不承诺跨 backend 事务快照，但必须分别返回两部分状态，也不得把 fallback 伪装成近期访问。
+3. NoTouch snapshot 与 task reservation 之间不建立事务。Copy 先用 snapshot 做快速 execution check；reservation 获取源 lease 后再 NoTouch 重检源 generation，随后由删除路径在整个 task 生命周期内遵守 lease。单次重检不能替代 lease。
+4. 源 lease 的匹配维度至少是 `(instance_id, block_key, location_id, create_time)`。相同 id 被复用时不能保护新一代 Location；pending delete 在最终执行时也必须重新检查 lease。
+5. 临界窗口内一次业务访问与价值准入并发，允许该 block 本轮多迁移或少迁移一次，后续轮次会重新判断；maintenance mutation 不得通过保存/恢复时间覆盖这次真实访问。
+6. Instance 相同 block key 不能共享 features、lease 或结果。
+7. Leader 切换/进程重启可能重置进程内 LRU 时间；runtime readiness gate 重置 epoch，并让已有 ENFORCE route 进入显式 NOT_READY，而不是依靠人工操作或把所有 key 静默记为 UNKNOWN reject。
+8. location 基础设施读取失败不创建 Copy reservation、Mark 或 WRITING metadata；feature/policy 失败在 SHADOW 下继续 location-valid 的现有迁移，在 ENFORCE 下 fail-closed。
+9. Copy/Mark 的现有 lifecycle barrier、draining gate、task reservation 和 target quota gate 保持不变；task reservation 扩展承担源 lease。条件 Mark RMW 是最终并发判定点，dedup query 不是。
+10. Mark modifier 计划成功不等于 backend commit 成功；所有统计、事件、expiry 和 Admin outcome 使用逐 key commit 结果。
+11. 配置在读取后发生变化时，本 batch 使用已取得的 immutable strategy snapshot；下一 batch 生效，但 runtime readiness 仍在执行时检查。
+12. recent-access 不限制 byte rate 或 daily bytes；Copy concurrency 也只限制并发任务数。需要硬 DWPD 保证时必须增加独立、Copy/Mark 共享的 target write budget。
+
+## 12. 可观测性
+
+### 12.1 统一 outcome 模型
+
+每个候选在 dispatch 内维护分阶段 outcome，不能只用一个 bool 表示“接受/拒绝”：
+
+| 阶段 | 代表 outcome | 终态分类 | 说明 |
+|---|---|---|---|
+| Snapshot/readiness | `ROUTE_NOT_READY`、`LOCATION_READ_ERROR`、`FEATURE_READ_ERROR`、`SNAPSHOT_SHAPE_ERROR` | `FAILED` | 基础设施/运行时状态，不计为 value reject；错误使 Admin header 非 OK/partial |
+| Value | `VALUE_REJECT_NOT_RECENT` | `REJECTED` | ENFORCE 的策略拒绝 |
+| Value | `VALUE_UNKNOWN_*` | SHADOW 仅 projected；ENFORCE 为 `REJECTED` | SHADOW 实际继续执行，不能提前成为终态 |
+| Execution | `SOURCE_NOT_FOUND`、`TARGET_ALREADY_COVERED`、`ALREADY_MIGRATING`、quota/target reject | `REJECTED` | 与 value reason 分开 |
+| Copy prepare | `SOURCE_RECHECK_FAILED`、reservation/target create/add-location 失败 | `REJECTED` 或 `FAILED` | 状态不再满足属于 rejected，I/O/基础设施错误属于 failed；允许时可继续 fallback Mark |
+| Copy dispatch | `COPY_SUBMITTED` | `ACCEPTED` | 仅表示已提交，异步完成结果另记 |
+| Mark | `INSERTED` | `ACCEPTED` | 实际新增 Mark |
+| Mark | `ALREADY_SAME_TARGET` | `NOOP_ALREADY_SATISFIED` | 不续期、不算新增 Mark |
+| Mark | `CONFLICT_DIFFERENT_TARGET`、`MALFORMED_EXISTING_MARK`、`BLOCK_NOT_FOUND` | `REJECTED` | 不覆盖现有状态 |
+| Mark | `READ_ERROR`、`WRITE_ERROR` | `FAILED` | 使用逐 key commit 结果 |
+| Async Copy completion | `COPY_SUCCEEDED`、`COPY_FAILED`、`SOURCE_LOST_AFTER_WRITE` | 异步结果 | 不回写同步 Admin 响应，但必须进入 metrics/event |
+
+若 Copy 提交失败后 Mark fallback 成功，候选同步终态是 `ACCEPTED/MARK_INSERTED`，同时保留 Copy submit failure 的阶段指标。`accepted`、`rejected`、`noop`、`failed` 四类同步终态应覆盖全部输入候选；不要用 `total - accepted` 推导 rejected。
+
+### 12.2 指标
+
+V1 已实现以下指标：
+
+| 指标 | 主要 tags | 含义 |
+|---|---|---|
+| `migration_admission_candidates_total` | trigger, src, dst, mode | 进入价值准入的候选数 |
+| `migration_admission_accepted_total` | trigger, src, dst, mode | 实际或 shadow 预计接受数 |
+| `migration_admission_rejected_total` | trigger, src, dst, mode, reason | 实际或 shadow 预计拒绝数 |
+| `migration_admission_policy_evaluations_total` | trigger, src, dst, policy, verdict, reason | policy 结果；V1 只有 recent-access |
+| `migration_admission_feature_status_total` | src, dst, feature, status | feature 的 available/missing/invalid/unsupported/read-error 数 |
+| `migration_admission_access_age_seconds` | trigger, src, dst | Prometheus histogram；recent-access leaf 的候选访问年龄分布 |
+| `migration_admission_read_error_total` | src, dst, component, reason | location/property NoTouch 读取和 shape 异常 |
+| `migration_admission_readiness` | instance, src, dst, feature | 0/1 runtime readiness gauge；reason 由独立低基数 counter 记录 |
+| `migration_admission_readiness_not_ready_total` | instance, src, dst, feature, reason | ENFORCE 因 capability/warmup 未就绪而暂停的批次数 |
+| `migration_candidate_pool_total` | src, dst, stage | sampled/value-qualified/dispatched 候选量 |
+| `migration_dispatch_outcomes_total` | trigger, src, dst, stage, class, reason, terminal | 统一分阶段 outcome；terminal=true 的总数应与输入候选数相等 |
+| `migration_dispatch_invariant_errors_total` | trigger, src, dst, mode, reason | outcome 终态数量等内部不变量异常 |
+| `migration_source_lease_conflicts_total` | src, dst, deleter | 删除因活跃源 lease 被延后/跳过的次数 |
+| `migration_source_lease_duration_seconds` | src, dst | Prometheus histogram；lease 生命周期分布 |
+| `migration_copy_planned_bytes_total` | src, dst, decision | Copy 预计接受/拒绝字节，按目标缺失 specs 计算 |
+| `migration_copy_planned_bytes_unknown_specs_total` | src, dst, decision | Copy projected/dispatched 中无法可靠解析大小的 spec 数 |
+| `migration_mark_eligible_source_bytes_total` | src, dst, decision | Mark 候选缺失 specs 的 source 字节上界，不代表实际写入 |
+| `migration_mark_eligible_source_bytes_unknown_specs_total` | src, dst, decision | Mark eligible 上界中无法可靠解析大小的 spec 数 |
+| `migration_copy_source_lost_written_bytes_total` | src, dst | Copy 已产生目标写后因 source_lost 丢弃的浪费字节 |
+
+拒绝原因至少包括：
+
+- `not_recent`；
+- `feature_missing`；
+- `feature_invalid`；
+- `feature_unsupported`；
+- `feature_read_error`；
+- 现有 execution reasons 继续使用独立指标，不混入 value reason。
+
+### 12.3 字节口径
+
+1. Copy planned bytes 基于同一 snapshot 的 source specs 和 target coverage，只累加目标尚未由 SERVING/WRITING specs 覆盖的部分；`decision=value_accept/value_reject` 是价值准入阶段的只读投影，`decision=dispatched` 才表示已经交给 `BatchSubmit`。Copy request 本身也只携带这些缺失 specs，不能在 partial coverage 场景复制整个 source block。
+2. spec 缺失大小或解析失败时不猜测为 0 或全量，累加 `bytes_unknown` 并从精确 projected bytes 中排除。
+3. 对 value reject 的 Copy projected bytes 可用 snapshot 做只读 coverage 计算，但不得因此创建 task/target 或发起额外普通 Get。
+4. Mark 在准入时还没有发生低层数据写，只能记录 eligible source bytes 上界；V1 不侵入 Start/FinishWrite 增加一套专用指标，实际目标写量复用 `data_storage.write_bytes_dispatched_total`，并结合 FinishWrite/location 最终状态判断结果。
+5. Copy executor 接受后的 dispatched bytes、backend 实际 bytes 和因 `source_lost` 丢弃的 bytes 分开，不能用 admission projected bytes 替代实际 DWPD 数据。
+
+联动观察：
+
+- `migration.copy_bytes_total`；
+- marks added/consumed/expired；
+- target storage `write_bytes_dispatched_total`；
+- source reclaim/delete block 数；
+- any-tier、hot-tier、cold-tier hit rate；
+- target storage 水位和 DWPD；
+- Reclaimer migration prepare backlog。
+
+SHADOW 还需对采样 admission cohort 观察后续 cold-tier hit/bytes hit，至少能区分“metadata touch 后被预计接受”与“之后真的在冷层复用”。
+
+日志按 route、policy type 和 reason 限频聚合，不打印 block key 明细。窗口、阈值或模型名不作为 metric tag，避免高基数。
+
+## 13. 兼容性与灰度
+
+### 13.1 API/connector
+
+- 普通 `StartWriteCacheRequest/Response` 不新增字段；
+- connector 不需要识别 admission rejection；
+- Mark 已通过准入后，connector 仍按现有 block mask 和 location 写入；
+- `MigrateCacheResponse.accepted/rejected` 为兼容旧调用方保留：`accepted` 仍表示实际提交 Copy 或实际新增 Mark 的数量，`rejected` 继续作为“未产生新分发”的 legacy 汇总，因此可能包含策略/执行拒绝、already-satisfied no-op 和失败，不能再作为精确原因口径；
+- 新增聚合 `outcome_counts`，按稳定的 protobuf enum stage/class/reason 返回第 12 章定义的互斥终态和必要的中间阶段结果，并用 `terminal` 区分；所有 `terminal=true` 的 count 之和等于输入候选数。不使用自由字符串、不返回 block key 明细；新调用方以该字段为权威口径；
+- location snapshot 整批失败、route NOT_READY、policy contract error 等基础设施问题返回非 OK header，不伪装成普通 rejected；若分发已经产生部分副作用，则同时返回实际 outcome counts，禁止把整批覆盖成成功；
+- Admin 请求的 `method` 仍决定本次用 Copy、Mark 或 BOTH；匹配到的 route 提供 admission 配置和 Mark timeout，本文不把 route `methods.enabled` 重定义为 Admin 权限列表；
+- Admin source/target 未匹配 route 从“可迁移到任意已注册 target”改为 `EC_BADARGS`，属于明确的管理面兼容性改变；
+- 聚合 reason 是 V1 必需；若需要逐 key reason 或 block key 明细，另行扩展 Admin API，不在 V1 返回。
+
+建议的 additive proto 形状如下，现有字段号和语义保留：
+
+```proto
+enum MigrationOutcomeStage {
+    MIGRATION_OUTCOME_STAGE_UNSPECIFIED = 0;
+    MIGRATION_OUTCOME_STAGE_SNAPSHOT = 1;
+    MIGRATION_OUTCOME_STAGE_VALUE = 2;
+    MIGRATION_OUTCOME_STAGE_EXECUTION = 3;
+    MIGRATION_OUTCOME_STAGE_COPY = 4;
+    MIGRATION_OUTCOME_STAGE_MARK = 5;
+}
+
+enum MigrationOutcomeClass {
+    MIGRATION_OUTCOME_CLASS_UNSPECIFIED = 0;
+    MIGRATION_OUTCOME_CLASS_ACCEPTED = 1;
+    MIGRATION_OUTCOME_CLASS_REJECTED = 2;
+    MIGRATION_OUTCOME_CLASS_NOOP_ALREADY_SATISFIED = 3;
+    MIGRATION_OUTCOME_CLASS_FAILED = 4;
+}
+
+enum MigrationOutcomeReason {
+    MIGRATION_OUTCOME_REASON_UNSPECIFIED = 0;
+    MIGRATION_OUTCOME_REASON_NOT_RECENT = 1;
+    MIGRATION_OUTCOME_REASON_FEATURE_MISSING = 2;
+    MIGRATION_OUTCOME_REASON_FEATURE_INVALID = 3;
+    MIGRATION_OUTCOME_REASON_FEATURE_UNSUPPORTED = 4;
+    MIGRATION_OUTCOME_REASON_FEATURE_READ_ERROR = 5;
+    MIGRATION_OUTCOME_REASON_ROUTE_NOT_READY = 6;
+    MIGRATION_OUTCOME_REASON_LOCATION_READ_ERROR = 7;
+    MIGRATION_OUTCOME_REASON_SNAPSHOT_SHAPE_ERROR = 8;
+    MIGRATION_OUTCOME_REASON_SOURCE_NOT_FOUND = 9;
+    MIGRATION_OUTCOME_REASON_TARGET_ALREADY_COVERED = 10;
+    MIGRATION_OUTCOME_REASON_ALREADY_MIGRATING = 11;
+    MIGRATION_OUTCOME_REASON_TARGET_REJECTED = 12;
+    MIGRATION_OUTCOME_REASON_SOURCE_RECHECK_FAILED = 13;
+    MIGRATION_OUTCOME_REASON_COPY_SUBMITTED = 14;
+    MIGRATION_OUTCOME_REASON_COPY_SUBMIT_FAILED = 15;
+    MIGRATION_OUTCOME_REASON_MARK_INSERTED = 16;
+    MIGRATION_OUTCOME_REASON_MARK_ALREADY_SAME_TARGET = 17;
+    MIGRATION_OUTCOME_REASON_MARK_CONFLICT_DIFFERENT_TARGET = 18;
+    MIGRATION_OUTCOME_REASON_MARK_MALFORMED = 19;
+    MIGRATION_OUTCOME_REASON_BLOCK_NOT_FOUND = 20;
+    MIGRATION_OUTCOME_REASON_MARK_READ_ERROR = 21;
+    MIGRATION_OUTCOME_REASON_MARK_WRITE_ERROR = 22;
+    MIGRATION_OUTCOME_REASON_POLICY_CONTRACT_ERROR = 23;
+    MIGRATION_OUTCOME_REASON_BUDGET_EXHAUSTED = 24;
+    MIGRATION_OUTCOME_REASON_VALUE_ACCEPTED = 25;
+    MIGRATION_OUTCOME_REASON_NO_EXECUTION_METHOD = 26;
+    MIGRATION_OUTCOME_REASON_COPY_SLOT_EXHAUSTED = 27;
+    MIGRATION_OUTCOME_REASON_DISPATCH_NOT_AVAILABLE = 28;
+}
+
+message MigrationOutcomeCount {
+    MigrationOutcomeStage stage = 1;
+    MigrationOutcomeClass outcome_class = 2;
+    MigrationOutcomeReason reason = 3;
+    int64 count = 4;
+    bool terminal = 5;
+}
+
+message MigrateCacheResponse {
+    CommonResponseHeader header = 1;
+    int64 accepted = 2; // legacy projection
+    int64 rejected = 3; // legacy not-dispatched projection
+    repeated MigrationOutcomeCount outcome_counts = 4;
+}
+```
+
+### 13.2 灰度步骤
+
+1. 先修复并验证 `kvcm_ops` 对现有 `migration_config` 的完整 round-trip，禁止旧工具清空迁移配置；
+2. 部署端到端 AccessIntent、分组件 NoTouch snapshot、源 Location lease、条件 Mark/逐 key outcome 和 policy，所有 route 保持 DISABLED；
+3. 验证 DISABLED 不读取 policy feature、不改变价值过滤结果，同时确认选样/prepare/Mark/Copy 管理不再刷新访问时间，源 lease 不泄漏，Mark outcome 与实际 commit 对齐；
+4. 部署 backend capability、recency epoch 和 runtime readiness gate；盘点现有 Admin source/target，在收紧 route 校验前补齐配置；
+5. 单 route 开 SHADOW，注入 feature provider 故障，确认 location 可用时迁移行为与现网一致；
+6. 至少观察一个完整 window，核对 capability/readiness、时间缺失率、预计拒绝率、候选池填充率、Copy planned bytes 和 Mark eligible bytes；
+7. 校验实际 target 写字节/DWPD、source-lost 浪费写与 admission cohort 后续 cold-tier hit 的收益曲线；
+8. 仅对 runtime READY 的小流量 route 切 ENFORCE；
+9. 比较低层实际写量、迁移成功率、源端直接回收量和 any-tier/cold-tier hit rate；
+10. 异常时切回 SHADOW/DISABLED，下一批立即停止实际价值拒绝；重启导致 NOT_READY 时验证 route 显式 suspended 并可在 warmup 后恢复。
+
+## 14. 测试计划
+
+### 14.1 Config
+
+1. 缺省 admission 等价于 DISABLED；
+2. mode/repeated oneof policies 的 JSON 和 proto round-trip；
+3. `kvcm_ops` Get 后修改无关字段再 Update，完整保留已有 migration strategies、copy concurrency、mark clear policy、admission 和 unknown passthrough 字段；
+4. 非法 mode、空 policies、长度大于 1、未知/empty oneof、V1 非 recent-access policy 和非法参数被拒绝；
+5. 不同 route 使用各自 admission 配置。
+6. Admin 精确命中 route 时传递值拷贝，未命中时返回 `EC_BADARGS`。
+
+### 14.2 NoTouch feature collection
+
+1. location、property、两个 component 的 per-key error 与输入 keys 一一对应；
+2. 读取前后 `last_access_time` 不变；
+3. 不改变 LRU 次序；
+4. 不更新 revisit histogram；
+5. miss 不创建/回填 item；
+6. cached/dual backend 遵循在线 point-read 的 hot/recovery view 选择，persistent fallback 不回填、不碰热，也不伪装成近期访问；覆盖 location 成功而 volatile property provider 失败的分离状态；
+7. unsupported/missing/parse/read error 分别转换为稳定状态；
+8. 相同 key 的不同 Instance 严格隔离；
+9. 迁移采样不调普通 `GetProperties`，prepare 及 Copy source reservation/completion 重检不调普通 `BatchGetLocation`；
+10. Mark dedup/add/clear 和 Copy metadata 状态迁移不更新访问时间。
+11. collector 只请求当前 policy 的 `RequiredFeatures()`，不采集未用 feature；
+12. meta property 缺失、不支持、解析错误和读取错误分别转换为稳定的 typed feature status。
+13. feature bag 按 id 读取正确值，期望类型不匹配时返回 invalid，不把原始 property string 传入 policy。
+14. 扩展后的 block/property 与 location-upsert maintenance RMW 使用 `kMaintenanceNoTouch` 时不改变 `last_access_time_`，同时保持现有 CAS、计费和 per-key 结果语义；
+15. maintenance mutation 与真实 `kBusinessRead` 并发时，不覆盖业务访问产生的新时间或未来 count；测试禁止通过保存/恢复 access time 伪造 NoTouch；
+16. `kBusinessRead`、`kBusinessWrite`、`kMaintenanceNoTouch` 在同一 Local item 锁内产生各自预期的 time/revisit/count 行为。
+
+### 14.3 Policy / Factory
+
+1. `RecentAccessAdmissionPolicy::RequiredFeatures()` 只返回 last-access-time；
+2. 窗口内 ACCEPT，`age == window` ACCEPT，超窗 REJECT；
+3. future time、溢出、缺失、不支持、读取错误返回 UNKNOWN 及稳定 reason；
+4. leaf `EvaluateBatch` 输出与输入顺序/数量一致，重复 key 不导致错位；
+5. factory 对每个类型化 config 构造正确 leaf，未知/非法 config 不产生部分 policy；
+6. V1 factory 只构造 recent-access，不实现或隐式接受 Composite；
+7. DISABLED 不执行 policy，SHADOW 不实际过滤，ENFORCE 只放行 ACCEPT；
+8. feature/policy 故障且 location 可用时 SHADOW 保持现有行为，ENFORCE fail-closed；
+9. 单 batch 复用 immutable policy，无 per-key policy 对象分配；
+10. `EvaluateBatch` 接口不声明 `noexcept`；若改为预分配输出，则覆盖显式容量/错误返回路径。
+
+### 14.4 MigrationManager
+
+1. Reclaimer 和 API 均经过同一 value policy；
+2. value reject 不调用 `CheckCopyAdmission`、BatchSubmit 或 Mark；
+3. value accept 后仍执行 source/target/task 检查；Copy reservation 后重检精确 source generation；
+4. Copy 和 Mark 使用相同 value result；
+5. Copy 提交失败 fallback Mark 不重复价值准入，但仍进入条件 Mark RMW；
+6. Mark dedup query 只作优化；查询与写入间并发出现同 target/different target Mark 时，条件 RMW 分别返回 already/conflict 且不覆盖；
+7. target quota/unavailable 仍由 target admission 拒绝；
+8. group Copy 原子并发限制不被绕过；
+9. 每个输入 key 得到互斥同步终态；legacy accepted/rejected、outcome_counts 和 reason metrics 按定义聚合。
+10. DISABLED 不请求额外 feature，SHADOW/ENFORCE 只请求 policy 声明的 feature；
+11. location 整批 shape/transport 失败不进入 Copy/Mark 并返回基础设施错误；property transport 失败在 SHADOW 继续并记录 projected UNKNOWN，在 ENFORCE 记为 snapshot failed、返回非成功/部分成功且不计普通 rejected；property 缺失/非法才按 value UNKNOWN fail-closed；
+12. Reclaimer 从扩大候选池中过滤后补足下一名合格候选，并在合格集合内按 fresh LRU 排序；候选池耗尽后停止，不做无界重采样；
+13. pending-location 排除集 shape 错误时在 metadata I/O 前整批拒绝，正常时在 execution admission 前过滤对应 location。
+14. policy 返回 decision shape 错误时，SHADOW 继续 location-valid 的现有迁移，ENFORCE 返回显式 contract error 且不产生 Copy/Mark 副作用；
+15. source lease 在 preparing/running/completing 全周期阻止 Reclaimer/GC 删除精确 source generation；同 id 不同 create_time 不被误保护；
+16. snapshot 后、reservation 前已经排队的删除，在最终执行时看到新 lease 并延后；reservation 后源重检失败不分配 URI、不创建 WRITING metadata；
+17. promote、prepare rollback、Copy 失败、取消、超时和 shutdown 均释放 source lease，无永久 pin；
+18. Mark batch 混合 INSERTED/ALREADY/CONFLICT/NOT_FOUND/WRITE_ERROR 时，返回、expiry、event 和 metrics 只按逐 key commit outcome 更新；
+19. Copy 成功后 source_lost 会清理目标并记录实际浪费写字节，不把它算成 value reject。
+
+### 14.5 StartWrite/集成
+
+1. 全新 block 未配置 Mark 时正常写热层；
+2. 已有普通副本且无 Mark 时保持原 skip 行为；
+3. 已准入 Mark 被 `StartWriteCache` 正常消费；
+4. Mark 消费时不重新检查最近访问窗口；
+5. `min_replica_count` 满足时，有效 Mark 仍按现有优先级补目标层；
+6. spec group 只补 target 缺失 coverage；
+7. FinishWrite 成功/失败和 mark clear policy 保持现状；
+8. ENFORCE 能降低 target write bytes，且普通热层写量不受影响。
+9. Mark eligible source bytes 与 Start/FinishWrite 实际 target bytes 分开，partial spec coverage 只统计缺失 specs。
+
+### 14.6 Capability / warmup / HA
+
+1. unsupported backend 拒绝 ENFORCE 激活，SHADOW 仍执行原迁移并记录 unsupported；
+2. process-local recency epoch 未满 window 时 ENFORCE route 为 NOT_READY，Admin 返回非 OK、Reclaimer 跳过且不生成大量普通 UNKNOWN reject；
+3. 进程重启、Leader generation 变化和 hot cache 重建会重置 epoch；满一个 window 后自动恢复 READY；
+4. 动态增大 window 会重新触发 readiness 判断；缩小 window 不伪造历史时间；
+5. durable capability 只有通过恢复连续性测试的 backend 才可免 warmup；
+6. readiness gauge、reason counter 和 epoch age 与实际 route 状态一致。
+
+### 14.7 API / outcome / bytes
+
+1. snapshot/readiness 基础设施整批失败返回非 OK header，不混入普通 rejected；
+2. legacy accepted/rejected 保持兼容投影，新 `outcome_counts` 能区分 value、execution、Copy、Mark、noop 和 failed；
+3. Copy fallback Mark 成功时同步终态为 accepted/Mark，同时保留 Copy failure 阶段指标；
+4. Copy request 和 planned bytes 都仅包含目标缺失 specs；大小未知进入 unknown-spec counter；
+5. Mark eligible bytes 不计入实际 target write，实际写量复用 storage 写入指标并结合 FinishWrite/location 状态观察；
+6. source-lost-after-write 单独记录浪费字节。
+
+### 14.8 本次实现验证记录
+
+2026-09-02 在 202 的专用容器中完成验证；本机未执行编译。实现分支已 rebase 到 `origin/main@6a163f93`，验证使用 rebase 后的完整差异并实际构建 `kv_cache_manager_bin`：
+
+1. 14 个定向 Bazel test target 一次性全部通过，覆盖 config、policy、MigrationManager、CacheReclaimer、CacheManager、SchedulePlanExecutor、MetaSearcher、Local/Dummy/Dual meta backend、AdminService 和 `kvcm_ops` round-trip；
+2. `CacheManagerTest` 整个 target 以 `--runs_per_test=3` 复跑通过（30 个 shard run）。首次联合回归中出现过一次 `TestStartWriteCacheRecordWriteBytes` 断言失败；对纯 `origin/main@6a163f93` 使用相同 internal stub 和参数做隔离对照，同一断言 3/3 复现，确认它不是本分支引入的回归；
+3. Dummy tiered-storage 默认模式运行 12 个场景：6 个 Admin/写路径场景通过，6 个 Reclaimer gated 场景按预期跳过；开启 `KVCM_TIERED_RUN_RECLAIMER_E2E=1` 后 11 个通过，1 个 F-25 场景按文档 intentional skip；
+4. main 的公平回收让 Reclaimer 能在 spec-group Admin 用例的两次手工 Copy 之间合法完成剩余 Copy，使第二次 Admin 请求返回 `SOURCE_NOT_FOUND`。这是外部 E2E harness 未隔离两个迁移 actor 的竞态；参照相邻 Admin Copy 用例，验证时仅在远端临时将该 route 的 `trigger_threshold` 设为 `0.99`，确保 Admin 是唯一迁移者。此 harness 调整不进入实现提交；
+5. E2E 覆盖 Admin Copy/Mark、spec-group partial coverage、Mark 消费/清理，以及 Reclaimer Copy、DELETE_SOURCE、KEEP_BOTH、BOTH fallback 和 Mark expiry；
+6. rebase 前的 `//kv_cache_manager/...` 回归共 114 个 test target：111 个通过、1 个按配置跳过，2 个失败已在干净基线复现为 internal PACE stub 类型问题。rebase 后尝试重跑全量时，main 新增的 Python external repository 依赖未在 202 新 output base 中缓存，清华 PyPI 镜像对 `requests==2.32.5` 返回 HTTP 403，已有 internal output base 又缺少新的 `orjson` repository，因此全量 target 在 analysis/fetch 阶段被环境阻断，不宣称 rebase 后的全量回归已通过；
+7. 以上是 Dummy backend 的功能与状态机回归，不替代生产 SHADOW 数据观测、真实 PACE 写量验证或 DWPD 评估。
+
+## 15. V2 及后续：扩展访问策略
+
+### 15.1 业务访问次数与策略组合
+
+“至少被业务访问 N 次”只是未来迁移价值判断的一个 leaf policy，不是下一代准入框架本身。它应以 `MinimumBusinessAccessCountPolicy` 接入：
+
+```cpp
+class MinimumBusinessAccessCountPolicy final : public MigrationAdmissionPolicy {
+public:
+    MigrationAdmissionFeatureSet RequiredFeatures() const noexcept override {
+        return FeatureSetOf(MigrationAdmissionFeature::kBusinessAccessCount);
+    }
+
+    std::vector<MigrationAdmissionDecision>
+    EvaluateBatch(const std::vector<MigrationCandidateFeatures> &features,
+                  const MigrationAdmissionContext &context) const override;
+};
+```
+
+接入该 leaf 时只需：
+
+1. 实现可靠的 `business_access_count` 生产和 NoTouch 采集；
+2. 在 config/proto `oneof` 中增加 `minimum_business_access_count` 参数；
+3. 在 factory 中注册新 leaf；
+4. 增加 leaf 测试；只有需要与 recency 同时启用时才增加 Composite 和组合测试。
+
+`MigrationManager`、`DispatchMigrationBatch`、Copy/Mark 路径和 mode 处理不变。第二个策略真正可用时，再在 admission 中新增默认值为 `ALL` 的 `match_mode`，并实现一层、不可递归嵌套的 Composite：
+
+- ALL：任一子策略 REJECT 则 REJECT；全部 ACCEPT 才 ACCEPT；其余 UNKNOWN；
+- ANY：任一子策略 ACCEPT 则 ACCEPT；全部 REJECT 才 REJECT；其余 UNKNOWN；
+- primary reason 按配置顺序选取第一个决定性结果，保证 metrics 可聚合；
+- collector 对各 policy 的 `RequiredFeatures()` 求并集，仍只做一次 batch collection。
+
+例如未来可配置：
+
+```json
+{
+  "admission": {
+    "mode": "ENFORCE",
+    "match_mode": "ALL",
+    "policies": [
+      {"recent_access": {"window_seconds": 3600}},
+      {"minimum_business_access_count": {"minimum_count": 1}}
+    ]
+  }
+}
+```
+
+该示例表示“最近一小时内访问过，且累计至少一次业务命中”。如改为 ANY，则任一策略满足即可准入。
+
+当前 `PROPERTY_HIT_COUNT` 只是属性名，没有生产路径在访问时自动加一。增加 count leaf 前必须先定义和实现：
+
+1. 只在用户侧有效 block 查询时计数；
+2. StartWrite、FinishWrite、GC、Reclaimer、Migration、ReportEvent、Admin 查询不计数；
+3. 一次 batch 中重复 key 是否只计一次；
+4. miss 是否计数；迁移候选已有 metadata，推荐只统计对现有 block 的业务查询；
+5. counter 是否饱和、是否衰减；
+6. 是否持久化；上位设计允许为性能选择不持久化；
+7. Leader 切换和进程重启后的清零语义。
+
+不要直接在普通 metadata Get 的公共入口无条件 `PROPERTY_HIT_COUNT++`。应通过显式 access intent 或业务查询专用更新入口实现，否则内部读仍会污染次数。
+
+### 15.2 硬写入预算是独立控制层
+
+若未来验收目标从“降低写量”升级为“保证 target byte rate、daily bytes 或 DWPD 上限”，应在 value admission 之后、实际执行之前增加 target write budget，而不是把预算伪装成另一个价值 policy：
+
+- Copy 按目标缺失 specs 的计划字节申请 token，提交失败/取消按明确规则退还；
+- Mark 必须在“打标时预留并随 timeout 释放”与“StartWrite 实际写入时扣费”之间定义一致语义；仅限制 Copy concurrency 不能覆盖 Mark；
+- Copy 与 Mark、Admin 与 Reclaimer 必须共享同一 target 预算；
+- daily budget、token bucket、持久化/HA 和超卖容忍度需要独立设计与测试。
+
+该控制层回答“当前还有多少写入额度”，与本文 policy 回答的“这个 block 值不值得迁移”正交，不纳入 V1。
+
+## 16. 备选方案与取舍
+
+| 方案 | 优点 | 问题 | 结论 |
+|---|---|---|---|
+| 在所有 StartWrite 上做准入 | 实现入口看似统一 | 会阻止普通新 block 热层写入，偏离多层存储目标 | 不采用 |
+| 仅 Reclaimer 做准入 | 改动较小 | Admin/API 可绕过，Copy/Mark 口径分裂 | 不采用 |
+| 在共享 `DispatchMigrationBatch` 内、执行分发前统一做价值准入 | Reclaimer/API、Copy/Mark 统一 | 需要 batch NoTouch snapshot | V1 推荐 |
+| 把热度判断塞进 `CheckCopyAdmission` | 文件改动少 | 价值策略与执行安全耦合，难配置和测试 | 不采用 |
+| 在 `MigrationManager` 中硬编码 recency/count `if` | V1 最快 | 每新增访问策略都要修改分发主流程，无法独立组合/测试 | 不采用 |
+| 把原始 `PropertyMap<string,string>` 传给策略 | 接口看似通用 | property 名、解析和错误语义泄漏进策略，难做类型安全演进 | 不采用 |
+| typed features + policy + factory，第二个策略落地后再加 Composite | 新策略不修改 dispatch，支持按需采集并保留组合扩展点 | 比单个函数多少量领域类型 | 推荐 |
+| 只把最终访问时间查询改为 NoTouch | 改动小 | 上游采样/location 读取已经把候选碰热 | 不采用 |
+| maintenance mutation 保存并恢复 access time | 表面上少改接口 | 会覆盖并发真实业务访问 | 不采用；必须端到端 AccessIntent |
+| 只在 Copy reservation 后重检一次源 Location | 能过滤部分 stale snapshot | 重检后删除仍可竞态，无法保护已排队删除 | 不单独采用；重检与源 lease 同时实现 |
+| Mark 先查询再无条件写 | 常态下减少重复写 | 查询与写之间可被并发覆盖，fallback 窗口更大 | 不采用；查询只优化，条件 RMW 保正确性 |
+| 先截最冷 N 个再做 recent-access | 实现改动小 | 超窗候选占满 batch，合格候选饥饿 | 不采用；扩大候选池后过滤、排序、截断 |
+| Mark 消费时再次准入 | 决策更新鲜 | Copy/Mark 语义不一致，已写 Mark 可能无法兑现 | 不采用 |
+| 每次访问持久化时间/次数 | 跨 Leader 连续 | 增加高频 metadata 写，反向制造写压力 | V1 不采用 |
+| V1 同时实现 target byte token bucket | 可提供硬写入额度 | Copy/Mark 预算、退款、HA 是独立复杂状态机 | 不纳入 V1；硬预算另行设计 |
+
+## 17. 灰度前待确认决策
+
+核心 V1 代码已经按本文默认选择实现；开放 ENFORCE 或确定生产参数前仍需确认：
+
+1. **Admin 显式 block keys 是否允许 force bypass**：本文默认不绕过；如需运维强制迁移，增加显式、可审计字段。
+2. **Admin 任意 target 的兼容性**：本文选择精确 route 校验；如必须保留当前能力，先设计 group 级 default admission，不能默认绕过。
+3. **Backend capability matrix**：逐 backend 确认 `PROPERTY_LRU_TIME` 属于 unsupported、process-local volatile 还是 durable；未完成验证的 route 只能 SHADOW。warmup 行为已确定由 runtime epoch gate 保证，不再作为人工约定。
+4. **Reclaimer candidate pool 大小**：V1 复用现有 sampling pool 并在过滤后截断；具体 sampling/batching 比例由 SHADOW qualified ratio 和空预算比例确定，不能默认二者相等。
+5. **显式强制删除与 source lease**：本文默认先取消并收敛 Copy 再删除；若管理面需要无条件覆盖，必须确认可接受 Copy 浪费写并提供审计指标。
+6. **V1 的窗口默认值**：不拍固定值，由 route 级 SHADOW age 分布、实际 target write bytes 和 cold-tier hit 收益确定。
+7. **未来 StartWrite 主动迁移是否纳入下一阶段**：若做，只对已有 source location 使用同一策略，不能扩展到普通新 block。
+
+第 1～3 项会影响外部行为或 ENFORCE 可用范围，必须在开放 ENFORCE 前确认；NoTouch、AccessIntent、源 lease、条件 Mark、outcome 和 `kvcm_ops` round-trip 等前置能力已经实现，应先在 DISABLED/SHADOW 下完成回归和数据验证。

--- a/docs/design/migration_admission_strategy.md
+++ b/docs/design/migration_admission_strategy.md
@@ -366,11 +366,6 @@ enum class MigrationAdmissionVerdict {
     kUnknown,
 };
 
-enum class MigrationAdmissionPolicyType {
-    kRecentAccess,
-    kMinimumBusinessAccessCount, // V2 启用
-};
-
 enum class MigrationAdmissionReason {
     kSatisfied,
     kNotRecent,
@@ -383,7 +378,6 @@ enum class MigrationAdmissionReason {
 
 struct MigrationAdmissionDecision {
     MigrationAdmissionVerdict verdict = MigrationAdmissionVerdict::kUnknown;
-    MigrationAdmissionPolicyType policy_type = MigrationAdmissionPolicyType::kRecentAccess;
     MigrationAdmissionReason reason = MigrationAdmissionReason::kFeatureMissing;
 };
 
@@ -524,9 +518,11 @@ lease contract：
 2. reservation 后立即通过 NoTouch 读取精确重检 source id、`CLS_SERVING` 和 create_time；失败则在任何目标分配前回滚 task/lease。
 3. Reclaimer、GC 以及其他会删除普通 Location 的自动维护路径，必须在真正的 metadata CAS/物理删除前检查 lease。只在候选采样时检查不够，因为删除请求可能早于 lease 入队、晚于 lease 获取后才执行。
 4. 已经排队的删除请求若在执行时发现 lease，必须跳过或延后，并重新读取状态，不能继续使用旧删除快照。
-5. Copy 成功后仍保留现有 source id/status/create_time 完成检查。目标 promote 为 SERVING 后，task owner 才能先结束源保护，再按精确 generation 条件删除 retention 指定的源；通用删除路径不能借此获得绕过 lease 的能力。
+5. Copy 成功后仍保留现有 source id/status/create_time 完成检查。目标 promote 为 SERVING 后，task owner 才能先结束源保护，再按精确 generation 条件删除 retention 指定的源；generation 条件必须在改变 Location status 的同一次 metadata RMW/CAS 内比较，不能只在 CAS 前读取并比较。通用删除路径不能借此获得绕过 lease 的能力。
 6. promote、失败、取消、prepare 回滚和超时等所有 terminal path 都必须释放 lease。若 task-owned 源删除异步执行，释放与提交条件删除的顺序必须保证目标已经 SERVING，且删除仍校验 source id/create_time。
 7. 显式管理删除若被定义为强制操作，应先取消并收敛对应 Copy，再删除源；不能静默绕过 lease。
+
+`create_time == 0` 是升级前 Location 可能存在的合法 legacy generation，不是“未提供”或通配符。prepared Copy 必须精确携带并比较 0；只有兼容性的单条 `Submit` 在明确未携带 prepared source snapshot 时，才从 reservation 后的 NoTouch 重检结果绑定当前 generation。
 
 该 lease 保护的是“Copy 读取期间源数据仍有效”，不是长期 pin。需记录 source-lease conflict、deferred delete、lease duration 和 `migration_copy_source_lost_written_bytes_total`，以发现任务泄漏或异常写放大。
 
@@ -708,16 +704,18 @@ MaintenancePropertyReadiness GetMaintenancePropertyReadiness(
     const std::string &property_name) const noexcept;
 ```
 
-Meta 层不识别 `MigrationAdmissionFeature`；manager/collector 把 `kLastAccessTime` 映射到 `PROPERTY_LRU_TIME`，再解释 capability。`valid_since_steady_us` 在进程启动、Leader generation 变化、hot cache 重建或其他破坏时间连续性的恢复事件后重置。warmup 时长使用 monotonic/steady clock，不能受 wall clock 回拨影响；policy 的 access age 仍按 `PROPERTY_LRU_TIME` 的 wall-clock 口径计算并校验未来时间。
+Meta 层不识别 `MigrationAdmissionFeature`；manager/collector 把 `kLastAccessTime` 映射到 `PROPERTY_LRU_TIME`，再解释 capability。`valid_since_steady_us` 在进程启动、Leader generation 变化、hot cache 重建或其他破坏时间连续性的恢复事件后重置。cached/dual backend 的异步 persistent-to-local 恢复期间必须保持为 0；恢复成功后才发布新 epoch，并从该时刻重新等待完整 window，不能把异步回填时间算进 warmup。warmup 时长使用 monotonic/steady clock，不能受 wall clock 回拨影响；policy 的 access age 仍按 `PROPERTY_LRU_TIME` 的 wall-clock 口径计算并校验未来时间。
 
 ENFORCE readiness 规则：
 
 1. 静态不支持 NoTouch property 或时间语义的 backend，配置校验/激活时拒绝 ENFORCE；SHADOW 可运行并记录 unsupported。
-2. process-local 时间只有在 `steady_now - valid_since_steady >= window` 时 ready；窗口被调大后按新窗口重新判断。
+2. process-local 时间只有在 backend 恢复完成、`valid_since_steady > 0` 且 `steady_now - valid_since_steady >= window` 时 ready；窗口被调大后按新窗口重新判断。
 3. runtime gate 每个 batch 都检查，不能只在配置写入时检查，因为已存在的 ENFORCE 配置会跨进程重启继续存在。
 4. ENFORCE route 未 ready 时进入显式 `NOT_READY`/suspended 状态：不把所有 key 计成普通 UNKNOWN reject。Admin 返回非 OK readiness 错误，Reclaimer 跳过该 route 并记录 reason。
 5. SHADOW 未 ready 时仍执行原有迁移，只记录预计 UNKNOWN 和 readiness 状态，保持行为中性。
 6. `kDurableAcrossRecovery` 只有在 backend 确实保存同一时间口径并通过恢复测试后才能免 warmup，不能仅因 property 可读取就宣称 durable。
+
+V1 的配置激活门禁按 `MetaIndexerConfig` 判断：纯 `local`，以及 `cached` 且有效 `cache_type` 为 `local`（缺省亦为 `local`）支持 recent-access；纯 Redis/async Redis/dummy 或 cached 的非 Local cache 不允许激活 ENFORCE。该静态门禁不替代每批 runtime readiness 检查。
 
 必须提供 route/instance 级 readiness gauge、not-ready reason 和 epoch age，防止 ENFORCE 因重启或误配置静默停止全部迁移。
 
@@ -784,6 +782,8 @@ MigrateCache
 8. 所有成功、失败、取消和超时出口释放 task/lease。
 
 价值拒绝发生在以上状态变化之前，不需要新增清理或回滚。reservation 后的源重检失败也必须发生在目标分配前；但只有删除路径共同遵守 lease 才能封闭重检后的竞态，单独增加一次重读不够。
+
+一次 Copy request 只绑定一个精确的 source Location generation。若同一 block 的多个 source Location 分别包含尚未覆盖的 specs，本轮选择第一个可执行 source 并只复制它的缺失 specs；后续迁移轮次基于更新后的 target coverage 再选择下一个 source。这是增量覆盖语义，不会把未选 source 的 specs 当作已经迁移。
 
 ### 8.4 Mark + StartWriteCache 路径
 
@@ -899,6 +899,7 @@ public:
 
 - 老配置缺少 admission 时等价于 DISABLED；
 - DISABLED 不构造 policy、不读取额外 feature，不改变候选的价值准入结果；迁移内部 location/Mark 改用 NoTouch 是独立的准确性修正，在 DISABLED 下也保留；
+- DISABLED 可保留一个参数合法的 dormant policy，便于先下发策略再切 SHADOW；该 policy 仍需校验并完整 round-trip，但在 mode 切换前不构造、不读取 feature；
 - SHADOW 读取并计算策略，但仍让候选进入现有执行准入；
 - ENFORCE 才从 Copy/Mark 候选中删除 policy REJECT/UNKNOWN 的 key；
 - SHADOW/ENFORCE 下 policies 为空、长度不等于 1、未知/empty oneof、非 recent-access 类型或参数非法，配置校验失败；
@@ -1007,7 +1008,7 @@ DispatchMigrationBatch(block_keys, params):
 1. policy 无 I/O、无可变状态，只消费当前 batch 的 typed features、evaluation context 和 immutable policy config。
 2. Local backend 对单 key 的 NoTouch snapshot 在同一 entry callback 中取 location 和 property；cached/dual backend 遵循在线 point-read 的 view/recovery 选择，可能组合 persistent location 与 hot-cache feature，不承诺跨 backend 事务快照，但必须分别返回两部分状态，也不得把 fallback 伪装成近期访问。
 3. NoTouch snapshot 与 task reservation 之间不建立事务。Copy 先用 snapshot 做快速 execution check；reservation 获取源 lease 后再 NoTouch 重检源 generation，随后由删除路径在整个 task 生命周期内遵守 lease。单次重检不能替代 lease。
-4. 源 lease 的匹配维度至少是 `(instance_id, block_key, location_id, create_time)`。相同 id 被复用时不能保护新一代 Location；pending delete 在最终执行时也必须重新检查 lease。
+4. 源 lease 的匹配维度至少是 `(instance_id, block_key, location_id, create_time)`。相同 id 被复用时不能保护新一代 Location；pending delete 在最终执行时也必须重新检查 lease，并在改变状态的同一次 CAS/RMW 内比较 expected create_time。legacy generation 0 同样精确匹配，不能被解释为“忽略 generation”。
 5. 临界窗口内一次业务访问与价值准入并发，允许该 block 本轮多迁移或少迁移一次，后续轮次会重新判断；maintenance mutation 不得通过保存/恢复时间覆盖这次真实访问。
 6. Instance 相同 block key 不能共享 features、lease 或结果。
 7. Leader 切换/进程重启可能重置进程内 LRU 时间；runtime readiness gate 重置 epoch，并让已有 ENFORCE route 进入显式 NOT_READY，而不是依靠人工操作或把所有 key 静默记为 UNKNOWN reject。
@@ -1255,6 +1256,7 @@ message MigrateCacheResponse {
 17. promote、prepare rollback、Copy 失败、取消、超时和 shutdown 均释放 source lease，无永久 pin；
 18. Mark batch 混合 INSERTED/ALREADY/CONFLICT/NOT_FOUND/WRITE_ERROR 时，返回、expiry、event 和 metrics 只按逐 key commit outcome 更新；
 19. Copy 成功后 source_lost 会清理目标并记录实际浪费写字节，不把它算成 value reject。
+20. prepared source generation 为 legacy 0 时可正常提交、完成和条件删除；同 id 被替换成其他 generation 时，最终删除 CAS 必须失败且不能删除替代 Location。
 
 ### 14.5 StartWrite/集成
 
@@ -1272,7 +1274,7 @@ message MigrateCacheResponse {
 
 1. unsupported backend 拒绝 ENFORCE 激活，SHADOW 仍执行原迁移并记录 unsupported；
 2. process-local recency epoch 未满 window 时 ENFORCE route 为 NOT_READY，Admin 返回非 OK、Reclaimer 跳过且不生成大量普通 UNKNOWN reject；
-3. 进程重启、Leader generation 变化和 hot cache 重建会重置 epoch；满一个 window 后自动恢复 READY；
+3. 进程重启、Leader generation 变化和 hot cache 重建会重置 epoch；异步恢复期间 epoch 保持无效，恢复完成后重新起算，满一个 window 后自动恢复 READY；
 4. 动态增大 window 会重新触发 readiness 判断；缩小 window 不伪造历史时间；
 5. durable capability 只有通过恢复连续性测试的 backend 才可免 warmup；
 6. readiness gauge、reason counter 和 epoch age 与实际 route 状态一致。
@@ -1295,8 +1297,9 @@ message MigrateCacheResponse {
 3. Dummy tiered-storage 默认模式运行 12 个场景：6 个 Admin/写路径场景通过，6 个 Reclaimer gated 场景按预期跳过；开启 `KVCM_TIERED_RUN_RECLAIMER_E2E=1` 后 11 个通过，1 个 F-25 场景按文档 intentional skip；
 4. main 的公平回收让 Reclaimer 能在 spec-group Admin 用例的两次手工 Copy 之间合法完成剩余 Copy，使第二次 Admin 请求返回 `SOURCE_NOT_FOUND`。这是外部 E2E harness 未隔离两个迁移 actor 的竞态；参照相邻 Admin Copy 用例，验证时仅在远端临时将该 route 的 `trigger_threshold` 设为 `0.99`，确保 Admin 是唯一迁移者。此 harness 调整不进入实现提交；
 5. E2E 覆盖 Admin Copy/Mark、spec-group partial coverage、Mark 消费/清理，以及 Reclaimer Copy、DELETE_SOURCE、KEEP_BOTH、BOTH fallback 和 Mark expiry；
-6. rebase 前的 `//kv_cache_manager/...` 回归共 114 个 test target：111 个通过、1 个按配置跳过，2 个失败已在干净基线复现为 internal PACE stub 类型问题。rebase 后尝试重跑全量时，main 新增的 Python external repository 依赖未在 202 新 output base 中缓存，清华 PyPI 镜像对 `requests==2.32.5` 返回 HTTP 403，已有 internal output base 又缺少新的 `orjson` repository，因此全量 target 在 analysis/fetch 阶段被环境阻断，不宣称 rebase 后的全量回归已通过；
-7. 以上是 Dummy backend 的功能与状态机回归，不替代生产 SHADOW 数据观测、真实 PACE 写量验证或 DWPD 评估。
+6. 针对 review 修复，在同一 202 容器重跑 config、MetaIndexer、MetaLocalBackend、MetaSearcher、MigrationManager、SchedulePlanExecutor、CacheReclaimer 和 metrics 8 个 target，全部通过；补充零代际精确匹配反例后再次单独运行 `MigrationManagerTest` 通过，并重新构建 `//kv_cache_manager:kv_cache_manager_bin` 成功；
+7. rebase 前的 `//kv_cache_manager/...` 回归共 114 个 test target：111 个通过、1 个按配置跳过，2 个失败已在干净基线复现为 internal PACE stub 类型问题。rebase 后尝试重跑全量时，main 新增的 Python external repository 依赖未在 202 新 output base 中缓存，清华 PyPI 镜像对 `requests==2.32.5` 返回 HTTP 403，已有 internal output base 又缺少新的 `orjson` repository，因此全量 target 在 analysis/fetch 阶段被环境阻断，不宣称 rebase 后的全量回归已通过；
+8. 以上是 Dummy backend 的功能与状态机回归，不替代生产 SHADOW 数据观测、真实 PACE 写量验证或 DWPD 评估。
 
 ## 15. V2 及后续：扩展访问策略
 

--- a/kv_cache_manager/config/BUILD
+++ b/kv_cache_manager/config/BUILD
@@ -88,6 +88,7 @@ cc_library(
         "//kv_cache_manager/common",
         "//kv_cache_manager/common:concurrent_hash_map",
         "//kv_cache_manager/common:redis_client",
+        "//kv_cache_manager/common:standard_uri",
         "//kv_cache_manager/data_storage",
         "//kv_cache_manager/protocol/protobuf:service_cc_proto",
     ],

--- a/kv_cache_manager/config/cache_config.cc
+++ b/kv_cache_manager/config/cache_config.cc
@@ -1,6 +1,49 @@
 #include "kv_cache_manager/config/cache_config.h"
 
+#include "kv_cache_manager/common/standard_uri.h"
+
 namespace kv_cache_manager {
+
+namespace {
+
+bool HasEnforcedMigrationAdmission(const MigrationConfig &migration_config) {
+    for (const auto &strategy : migration_config.strategies()) {
+        if (strategy != nullptr && strategy->admission().mode() == MigrationAdmissionMode::ENFORCE) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Recent-access is currently backed by the process-local metadata cache. Keep
+// this configuration check in config (rather than depending on meta) and let
+// the runtime readiness gate handle recovery/warmup state.
+bool SupportsRecentAccessAdmission(const std::shared_ptr<MetaIndexerConfig> &meta_indexer_config) {
+    if (meta_indexer_config == nullptr || meta_indexer_config->GetMetaStorageBackendConfig() == nullptr) {
+        return false;
+    }
+    const auto &backend_config = meta_indexer_config->GetMetaStorageBackendConfig();
+    if (backend_config->GetStorageType() == "local") {
+        return true;
+    }
+    if (backend_config->GetStorageType() != "cached") {
+        return false;
+    }
+
+    const std::string &storage_uri = backend_config->GetStorageUri();
+    if (storage_uri.empty()) {
+        // MetaStorageBackendManager defaults cached mode to redis/local.
+        return true;
+    }
+    const StandardUri uri = StandardUri::FromUri(storage_uri);
+    if (!uri.Valid()) {
+        return false;
+    }
+    const std::string cache_type = uri.GetParam("cache_type");
+    return cache_type.empty() || cache_type == "local";
+}
+
+} // namespace
 
 CacheConfig::~CacheConfig() = default;
 
@@ -39,6 +82,10 @@ bool CacheConfig::ValidateRequiredFields(std::string &invalid_fields) const {
     }
     if (!migration_config_.ValidateRequiredFields(local_invalid_fields)) {
         valid = false;
+    }
+    if (HasEnforcedMigrationAdmission(migration_config_) && !SupportsRecentAccessAdmission(meta_indexer_config_)) {
+        valid = false;
+        local_invalid_fields += "{migration_admission:{unsupported_meta_backend}}";
     }
     if (!valid) {
         invalid_fields += "{CacheConfig: " + local_invalid_fields + "}";

--- a/kv_cache_manager/config/migration_strategy.cc
+++ b/kv_cache_manager/config/migration_strategy.cc
@@ -1,6 +1,7 @@
 #include "kv_cache_manager/config/migration_strategy.h"
 
 #include <cmath>
+#include <limits>
 #include <set>
 
 namespace kv_cache_manager {
@@ -13,7 +14,138 @@ bool IsValidMigrationRetention(MigrationRetention retention) {
            retention == MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH;
 }
 
+bool IsValidMigrationAdmissionMode(MigrationAdmissionMode mode) {
+    return mode == MigrationAdmissionMode::DISABLED || mode == MigrationAdmissionMode::SHADOW ||
+           mode == MigrationAdmissionMode::ENFORCE;
+}
+
 } // namespace
+
+RecentAccessAdmissionConfig::~RecentAccessAdmissionConfig() = default;
+
+bool RecentAccessAdmissionConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
+    KVCM_JSON_GET_MACRO(rapid_value, "window_seconds", window_seconds_);
+    return true;
+}
+
+void RecentAccessAdmissionConfig::ToRapidWriter(
+    rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
+    Put(writer, "window_seconds", window_seconds_);
+}
+
+bool RecentAccessAdmissionConfig::ValidateRequiredFields(std::string &invalid_fields) const {
+    if (window_seconds_ > 0 && window_seconds_ <= std::numeric_limits<int64_t>::max() / (1000 * 1000)) {
+        return true;
+    }
+    invalid_fields += "{RecentAccessAdmissionConfig:{window_seconds}}";
+    return false;
+}
+
+MigrationAdmissionPolicyConfig::~MigrationAdmissionPolicyConfig() = default;
+
+MigrationAdmissionPolicyConfig::MigrationAdmissionPolicyConfig(
+    const MigrationAdmissionPolicyConfig &other) {
+    if (other.recent_access_ != nullptr) {
+        recent_access_ = std::make_shared<RecentAccessAdmissionConfig>(*other.recent_access_);
+    }
+}
+
+MigrationAdmissionPolicyConfig &MigrationAdmissionPolicyConfig::operator=(
+    const MigrationAdmissionPolicyConfig &other) {
+    if (this == &other) {
+        return *this;
+    }
+    recent_access_ = other.recent_access_ == nullptr
+                         ? nullptr
+                         : std::make_shared<RecentAccessAdmissionConfig>(*other.recent_access_);
+    return *this;
+}
+
+bool MigrationAdmissionPolicyConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "recent_access", recent_access_, std::shared_ptr<RecentAccessAdmissionConfig>());
+    return true;
+}
+
+void MigrationAdmissionPolicyConfig::ToRapidWriter(
+    rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
+    if (recent_access_ != nullptr) {
+        Put(writer, "recent_access", recent_access_);
+    }
+}
+
+bool MigrationAdmissionPolicyConfig::ValidateRequiredFields(std::string &invalid_fields) const {
+    if (recent_access_ == nullptr) {
+        invalid_fields += "{MigrationAdmissionPolicyConfig:{empty_policy}}";
+        return false;
+    }
+    return recent_access_->ValidateRequiredFields(invalid_fields);
+}
+
+MigrationAdmissionConfig::~MigrationAdmissionConfig() = default;
+
+MigrationAdmissionConfig::MigrationAdmissionConfig(const MigrationAdmissionConfig &other)
+    : mode_(other.mode_) {
+    policies_.reserve(other.policies_.size());
+    for (const auto &policy : other.policies_) {
+        policies_.push_back(policy == nullptr ? nullptr : std::make_shared<MigrationAdmissionPolicyConfig>(*policy));
+    }
+}
+
+MigrationAdmissionConfig &MigrationAdmissionConfig::operator=(const MigrationAdmissionConfig &other) {
+    if (this == &other) {
+        return *this;
+    }
+    mode_ = other.mode_;
+    policies_.clear();
+    policies_.reserve(other.policies_.size());
+    for (const auto &policy : other.policies_) {
+        policies_.push_back(policy == nullptr ? nullptr : std::make_shared<MigrationAdmissionPolicyConfig>(*policy));
+    }
+    return *this;
+}
+
+bool MigrationAdmissionConfig::FromRapidValue(const rapidjson::Value &rapid_value) {
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "mode", mode_, MigrationAdmissionMode::DISABLED);
+    KVCM_JSON_GET_DEFAULT_MACRO(
+        rapid_value, "policies", policies_, std::vector<std::shared_ptr<MigrationAdmissionPolicyConfig>>{});
+    return true;
+}
+
+void MigrationAdmissionConfig::ToRapidWriter(
+    rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept {
+    Put(writer, "mode", mode_);
+    Put(writer, "policies", policies_);
+}
+
+bool MigrationAdmissionConfig::ValidateRequiredFields(std::string &invalid_fields) const {
+    bool valid = true;
+    std::string local_invalid_fields;
+    if (!IsValidMigrationAdmissionMode(mode_)) {
+        valid = false;
+        local_invalid_fields += "{mode}";
+    }
+    if (policies_.size() > 1 ||
+        (mode_ != MigrationAdmissionMode::DISABLED && policies_.size() != 1)) {
+        valid = false;
+        local_invalid_fields += "{policies_count}";
+    }
+    for (const auto &policy : policies_) {
+        if (policy == nullptr) {
+            valid = false;
+            local_invalid_fields += "{policies:null_entry}";
+            continue;
+        }
+        if (!policy->ValidateRequiredFields(local_invalid_fields)) {
+            valid = false;
+        }
+    }
+    if (!valid) {
+        invalid_fields += "{MigrationAdmissionConfig:" + local_invalid_fields + "}";
+    }
+    return valid;
+}
 
 MigrationCopyMethod::~MigrationCopyMethod() = default;
 
@@ -60,6 +192,7 @@ bool MigrationStrategy::FromRapidValue(const rapidjson::Value &rapid_value) {
     KVCM_JSON_GET_MACRO(rapid_value, "trigger_threshold", trigger_threshold_);
     KVCM_JSON_GET_MACRO(rapid_value, "methods", methods_);
     KVCM_JSON_GET_MACRO(rapid_value, "retention", retention_);
+    KVCM_JSON_GET_DEFAULT_MACRO(rapid_value, "admission", admission_, MigrationAdmissionConfig{});
     return true;
 }
 
@@ -69,6 +202,7 @@ void MigrationStrategy::ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer>
     Put(writer, "trigger_threshold", trigger_threshold_);
     Put(writer, "methods", methods_);
     Put(writer, "retention", retention_);
+    Put(writer, "admission", admission_);
 }
 
 bool MigrationStrategy::ValidateRequiredFields(std::string &invalid_fields) const {
@@ -108,6 +242,9 @@ bool MigrationStrategy::ValidateRequiredFields(std::string &invalid_fields) cons
     if (methods_.copy().enabled() && retention_ == MigrationRetention::MIGRATION_RETENTION_UNSPECIFIED) {
         valid = false;
         local_invalid_fields += "{retention}";
+    }
+    if (!admission_.ValidateRequiredFields(local_invalid_fields)) {
+        valid = false;
     }
     if (!valid) {
         invalid_fields += "{MigrationStrategy: " + local_invalid_fields + "}";

--- a/kv_cache_manager/config/migration_strategy.cc
+++ b/kv_cache_manager/config/migration_strategy.cc
@@ -126,8 +126,11 @@ bool MigrationAdmissionConfig::ValidateRequiredFields(std::string &invalid_field
         valid = false;
         local_invalid_fields += "{mode}";
     }
-    if (policies_.size() > 1 ||
-        (mode_ != MigrationAdmissionMode::DISABLED && policies_.size() != 1)) {
+    // DISABLED may carry one validated dormant policy so operators can stage
+    // policy parameters before switching to SHADOW. The factory intentionally
+    // avoids constructing it until the mode is enabled, while JSON/proto keep
+    // round-tripping the configuration.
+    if (policies_.size() > 1 || (mode_ != MigrationAdmissionMode::DISABLED && policies_.size() != 1)) {
         valid = false;
         local_invalid_fields += "{policies_count}";
     }

--- a/kv_cache_manager/config/migration_strategy.h
+++ b/kv_cache_manager/config/migration_strategy.h
@@ -22,6 +22,76 @@ enum class MigrationMarkClearPolicy {
     CLEAR_ON_FULL_BLOCK_COVERED = 1, // target CacheLocation 覆盖完整 block 后清标
 };
 
+// 迁移价值准入模式。准入只作用于 source -> target 的迁移写入，不影响普通热层写入。
+enum class MigrationAdmissionMode {
+    DISABLED = 0,
+    SHADOW = 1,
+    ENFORCE = 2,
+};
+
+class RecentAccessAdmissionConfig : public Jsonizable {
+public:
+    RecentAccessAdmissionConfig() = default;
+    explicit RecentAccessAdmissionConfig(int64_t window_seconds)
+        : window_seconds_(window_seconds) {}
+    ~RecentAccessAdmissionConfig() override;
+
+    int64_t window_seconds() const { return window_seconds_; }
+    void set_window_seconds(int64_t window_seconds) { window_seconds_ = window_seconds; }
+
+    bool FromRapidValue(const rapidjson::Value &rapid_value) override;
+    void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
+    bool ValidateRequiredFields(std::string &invalid_fields) const;
+
+private:
+    int64_t window_seconds_ = 0;
+};
+
+// V1 的公开配置保留 oneof 风格的 leaf 容器，但只接受 recent_access。
+// 第二个真实策略落地前不公开组合语义。
+class MigrationAdmissionPolicyConfig : public Jsonizable {
+public:
+    MigrationAdmissionPolicyConfig() = default;
+    MigrationAdmissionPolicyConfig(const MigrationAdmissionPolicyConfig &other);
+    MigrationAdmissionPolicyConfig &operator=(const MigrationAdmissionPolicyConfig &other);
+    ~MigrationAdmissionPolicyConfig() override;
+
+    const std::shared_ptr<RecentAccessAdmissionConfig> &recent_access() const { return recent_access_; }
+    void set_recent_access(const std::shared_ptr<RecentAccessAdmissionConfig> &recent_access) {
+        recent_access_ = recent_access;
+    }
+
+    bool FromRapidValue(const rapidjson::Value &rapid_value) override;
+    void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
+    bool ValidateRequiredFields(std::string &invalid_fields) const;
+
+private:
+    std::shared_ptr<RecentAccessAdmissionConfig> recent_access_;
+};
+
+class MigrationAdmissionConfig : public Jsonizable {
+public:
+    MigrationAdmissionConfig() = default;
+    MigrationAdmissionConfig(const MigrationAdmissionConfig &other);
+    MigrationAdmissionConfig &operator=(const MigrationAdmissionConfig &other);
+    ~MigrationAdmissionConfig() override;
+
+    MigrationAdmissionMode mode() const { return mode_; }
+    const std::vector<std::shared_ptr<MigrationAdmissionPolicyConfig>> &policies() const { return policies_; }
+    void set_mode(MigrationAdmissionMode mode) { mode_ = mode; }
+    void set_policies(const std::vector<std::shared_ptr<MigrationAdmissionPolicyConfig>> &policies) {
+        policies_ = policies;
+    }
+
+    bool FromRapidValue(const rapidjson::Value &rapid_value) override;
+    void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
+    bool ValidateRequiredFields(std::string &invalid_fields) const;
+
+private:
+    MigrationAdmissionMode mode_ = MigrationAdmissionMode::DISABLED;
+    std::vector<std::shared_ptr<MigrationAdmissionPolicyConfig>> policies_;
+};
+
 // Copy 执行方式：通过 DataStorageBackend::Copy 把数据复制到目标 storage。
 class MigrationCopyMethod : public Jsonizable {
 public:
@@ -100,6 +170,8 @@ public:
     const MigrationMethods &methods() const { return methods_; }
     MigrationMethods &mutable_methods() { return methods_; }
     MigrationRetention retention() const { return retention_; }
+    const MigrationAdmissionConfig &admission() const { return admission_; }
+    MigrationAdmissionConfig &mutable_admission() { return admission_; }
 
     // Setters
     void set_source_storage_name(const std::string &name) { source_storage_name_ = name; }
@@ -107,6 +179,7 @@ public:
     void set_trigger_threshold(double trigger_threshold) { trigger_threshold_ = trigger_threshold; }
     void set_methods(const MigrationMethods &methods) { methods_ = methods; }
     void set_retention(MigrationRetention retention) { retention_ = retention; }
+    void set_admission(const MigrationAdmissionConfig &admission) { admission_ = admission; }
 
     bool FromRapidValue(const rapidjson::Value &rapid_value) override;
     void ToRapidWriter(rapidjson::Writer<rapidjson::StringBuffer> &writer) const noexcept override;
@@ -118,6 +191,7 @@ private:
     double trigger_threshold_ = 0.0;
     MigrationMethods methods_;
     MigrationRetention retention_ = MigrationRetention::MIGRATION_RETENTION_UNSPECIFIED;
+    MigrationAdmissionConfig admission_;
 };
 
 class MigrationConfig : public Jsonizable {

--- a/kv_cache_manager/config/test/instance_group_test.cc
+++ b/kv_cache_manager/config/test/instance_group_test.cc
@@ -193,6 +193,46 @@ TEST_F(InstanceGroupTest, ProtoRoundTripWithoutBuckets) {
     EXPECT_TRUE(restored.revisit_interval_buckets().empty());
 }
 
+TEST_F(InstanceGroupTest, CacheConfigProtoRoundTripPreservesMigrationAdmission) {
+    CacheConfig original;
+    // CacheConfigToProto expects a structurally valid CacheConfig.  The
+    // admission assertions below only exercise migration_config, but the
+    // surrounding reclaim config must still be present.
+    original.set_reclaim_strategy(std::make_shared<CacheReclaimStrategy>());
+    auto strategy = std::make_shared<MigrationStrategy>();
+    strategy->set_source_storage_name("hot");
+    strategy->set_target_storage_name("cold");
+    strategy->set_trigger_threshold(0.7);
+    strategy->mutable_methods().mutable_copy().set_enabled(true);
+    strategy->set_retention(MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH);
+    MigrationAdmissionConfig admission;
+    admission.set_mode(MigrationAdmissionMode::SHADOW);
+    auto policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+    policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(3600));
+    admission.set_policies({policy});
+    strategy->set_admission(admission);
+    original.set_migration_strategies({strategy});
+
+    proto::admin::CacheConfig proto_config;
+    ProtoConvert::CacheConfigToProto(original, &proto_config);
+    ASSERT_EQ(1, proto_config.migration_config().strategies_size());
+    const auto &proto_admission = proto_config.migration_config().strategies(0).admission();
+    EXPECT_EQ(proto::admin::MIGRATION_ADMISSION_SHADOW, proto_admission.mode());
+    ASSERT_EQ(1, proto_admission.policies_size());
+    ASSERT_TRUE(proto_admission.policies(0).has_recent_access());
+    EXPECT_EQ(3600, proto_admission.policies(0).recent_access().window_seconds());
+
+    CacheConfig restored;
+    ProtoConvert::CacheConfigFromProto(&proto_config, restored);
+    ASSERT_EQ(1u, restored.migration_strategies().size());
+    const auto &restored_admission = restored.migration_strategies()[0]->admission();
+    EXPECT_EQ(MigrationAdmissionMode::SHADOW, restored_admission.mode());
+    ASSERT_EQ(1u, restored_admission.policies().size());
+    ASSERT_NE(nullptr, restored_admission.policies()[0]);
+    ASSERT_NE(nullptr, restored_admission.policies()[0]->recent_access());
+    EXPECT_EQ(3600, restored_admission.policies()[0]->recent_access()->window_seconds());
+}
+
 TEST_F(InstanceGroupTest, EventReportStorageSpecProtoRoundTripPreservesSnapshotSettings) {
     proto::admin::StorageConfig legacy_proto_config;
     legacy_proto_config.set_global_unique_name("legacy_event_report");

--- a/kv_cache_manager/config/test/migration_strategy_test.cc
+++ b/kv_cache_manager/config/test/migration_strategy_test.cc
@@ -50,6 +50,12 @@ TEST_F(MigrationStrategyTest, TestRoundTrip) {
     methods.mutable_mark().set_timeout_ms(12345);
     strategy.set_methods(methods);
     strategy.set_retention(MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH);
+    MigrationAdmissionConfig admission;
+    admission.set_mode(MigrationAdmissionMode::SHADOW);
+    auto policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+    policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(3600));
+    admission.set_policies({policy});
+    strategy.set_admission(admission);
 
     MigrationStrategy parsed;
     ASSERT_TRUE(parsed.FromJsonString(strategy.ToJsonString()));
@@ -60,6 +66,43 @@ TEST_F(MigrationStrategyTest, TestRoundTrip) {
     ASSERT_TRUE(parsed.methods().mark().enabled());
     ASSERT_EQ(12345, parsed.methods().mark().timeout_ms());
     ASSERT_EQ(MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH, parsed.retention());
+    ASSERT_EQ(MigrationAdmissionMode::SHADOW, parsed.admission().mode());
+    ASSERT_EQ(1u, parsed.admission().policies().size());
+    ASSERT_EQ(3600, parsed.admission().policies()[0]->recent_access()->window_seconds());
+}
+
+TEST_F(MigrationStrategyTest, TestAdmissionDefaultsAndValidation) {
+    MigrationStrategy disabled;
+    disabled.set_source_storage_name("hot");
+    disabled.set_target_storage_name("cold");
+    disabled.set_trigger_threshold(0.7);
+    disabled.mutable_methods().mutable_mark().set_enabled(true);
+    std::string invalid_fields;
+    ASSERT_TRUE(disabled.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+    ASSERT_EQ(MigrationAdmissionMode::DISABLED, disabled.admission().mode());
+    ASSERT_TRUE(disabled.admission().policies().empty());
+
+    MigrationAdmissionConfig enabled_without_policy;
+    enabled_without_policy.set_mode(MigrationAdmissionMode::ENFORCE);
+    invalid_fields.clear();
+    EXPECT_FALSE(enabled_without_policy.ValidateRequiredFields(invalid_fields));
+    EXPECT_NE(std::string::npos, invalid_fields.find("policies_count"));
+
+    MigrationAdmissionConfig invalid_window;
+    invalid_window.set_mode(MigrationAdmissionMode::SHADOW);
+    auto policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+    policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(0));
+    invalid_window.set_policies({policy});
+    invalid_fields.clear();
+    EXPECT_FALSE(invalid_window.ValidateRequiredFields(invalid_fields));
+    EXPECT_NE(std::string::npos, invalid_fields.find("window_seconds"));
+
+    MigrationAdmissionConfig valid;
+    valid.set_mode(MigrationAdmissionMode::ENFORCE);
+    policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(60));
+    valid.set_policies({policy});
+    invalid_fields.clear();
+    EXPECT_TRUE(valid.ValidateRequiredFields(invalid_fields)) << invalid_fields;
 }
 
 // 校验：各类非法配置都应被拒绝

--- a/kv_cache_manager/config/test/migration_strategy_test.cc
+++ b/kv_cache_manager/config/test/migration_strategy_test.cc
@@ -82,6 +82,20 @@ TEST_F(MigrationStrategyTest, TestAdmissionDefaultsAndValidation) {
     ASSERT_EQ(MigrationAdmissionMode::DISABLED, disabled.admission().mode());
     ASSERT_TRUE(disabled.admission().policies().empty());
 
+    // DISABLED may retain one valid dormant policy for staged rollout. It is
+    // validated and round-tripped, but is not evaluated until the mode changes.
+    MigrationAdmissionConfig dormant;
+    auto dormant_policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+    dormant_policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(60));
+    dormant.set_policies({dormant_policy});
+    invalid_fields.clear();
+    ASSERT_TRUE(dormant.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+    MigrationAdmissionConfig dormant_parsed;
+    ASSERT_TRUE(dormant_parsed.FromJsonString(dormant.ToJsonString()));
+    ASSERT_EQ(MigrationAdmissionMode::DISABLED, dormant_parsed.mode());
+    ASSERT_EQ(1u, dormant_parsed.policies().size());
+    ASSERT_EQ(60, dormant_parsed.policies()[0]->recent_access()->window_seconds());
+
     MigrationAdmissionConfig enabled_without_policy;
     enabled_without_policy.set_mode(MigrationAdmissionMode::ENFORCE);
     invalid_fields.clear();
@@ -103,6 +117,59 @@ TEST_F(MigrationStrategyTest, TestAdmissionDefaultsAndValidation) {
     valid.set_policies({policy});
     invalid_fields.clear();
     EXPECT_TRUE(valid.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+}
+
+TEST_F(MigrationStrategyTest, TestCacheConfigGatesEnforceByMetaBackendCapability) {
+    const auto make_cache_config =
+        [](MigrationAdmissionMode mode, const std::string &storage_type, const std::string &storage_uri = "") {
+            CacheConfig cache_config;
+            cache_config.set_cache_prefer_strategy(CachePreferStrategy::CPS_ALWAYS_TAIR_MEMPOOL);
+            cache_config.set_reclaim_strategy(std::make_shared<CacheReclaimStrategy>());
+            cache_config.reclaim_strategy()->set_storage_unique_name("hot");
+
+            auto meta_indexer_config = std::make_shared<MetaIndexerConfig>();
+            meta_indexer_config->GetMetaStorageBackendConfig()->SetStorageType(storage_type);
+            meta_indexer_config->GetMetaStorageBackendConfig()->SetStorageUri(storage_uri);
+            cache_config.set_meta_indexer_config(meta_indexer_config);
+
+            auto strategy = std::make_shared<MigrationStrategy>();
+            strategy->set_source_storage_name("hot");
+            strategy->set_target_storage_name("cold");
+            strategy->set_trigger_threshold(0.7);
+            strategy->mutable_methods().mutable_copy().set_enabled(true);
+            strategy->set_retention(MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE);
+            strategy->mutable_admission().set_mode(mode);
+            auto policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+            policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(60));
+            strategy->mutable_admission().set_policies({policy});
+            cache_config.set_migration_strategies({strategy});
+            return cache_config;
+        };
+
+    std::string invalid_fields;
+    auto local = make_cache_config(MigrationAdmissionMode::ENFORCE, "local");
+    EXPECT_TRUE(local.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+
+    invalid_fields.clear();
+    auto cached_local = make_cache_config(
+        MigrationAdmissionMode::ENFORCE, "cached", "redis://127.0.0.1:6379?persistent_type=redis&cache_type=local");
+    EXPECT_TRUE(cached_local.ValidateRequiredFields(invalid_fields)) << invalid_fields;
+
+    invalid_fields.clear();
+    auto redis = make_cache_config(MigrationAdmissionMode::ENFORCE, "redis");
+    EXPECT_FALSE(redis.ValidateRequiredFields(invalid_fields));
+    EXPECT_NE(std::string::npos, invalid_fields.find("unsupported_meta_backend"));
+
+    invalid_fields.clear();
+    auto cached_nonlocal = make_cache_config(
+        MigrationAdmissionMode::ENFORCE, "cached", "redis://127.0.0.1:6379?persistent_type=redis&cache_type=dummy");
+    EXPECT_FALSE(cached_nonlocal.ValidateRequiredFields(invalid_fields));
+    EXPECT_NE(std::string::npos, invalid_fields.find("unsupported_meta_backend"));
+
+    // SHADOW remains behavior-neutral and may observe unsupported features as UNKNOWN.
+    invalid_fields.clear();
+    auto shadow_redis = make_cache_config(MigrationAdmissionMode::SHADOW, "redis");
+    EXPECT_TRUE(shadow_redis.ValidateRequiredFields(invalid_fields)) << invalid_fields;
 }
 
 // 校验：各类非法配置都应被拒绝

--- a/kv_cache_manager/manager/BUILD
+++ b/kv_cache_manager/manager/BUILD
@@ -150,8 +150,15 @@ cc_library(
 
 cc_library(
     name = "migration_manager",
-    srcs = ["migration_manager.cc"],
-    hdrs = ["migration_manager.h"],
+    srcs = [
+        "migration_admission_internal.cc",
+        "migration_manager.cc",
+    ],
+    hdrs = [
+        "migration_admission_internal.h",
+        "migration_manager.h",
+        "migration_outcome.h",
+    ],
     deps = [
         ":data_storage_selector",
         ":meta_searcher",

--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1591,29 +1591,24 @@ CacheManager::MigrateCacheResult CacheManager::MigrateCache(RequestContext *requ
     const auto configured_copy_concurrency = cache_config->migration_copy_max_concurrency();
     const std::size_t copy_max_concurrency =
         configured_copy_concurrency > 0 ? static_cast<std::size_t>(configured_copy_concurrency) : 0;
-    int64_t mark_timeout_ms = MigrationMarkMethod::kDefaultTimeoutMs;
-
-    // IsTieredMigrationEnabled 以“group 至少有一条 migration strategy”作为写路径消费 Mark 的
-    // group 级开关，因此无 strategy 时打标会成为“成功的 no-op”，这里直接拒绝。Admin 显式 target
-    // 不受 strategy route 约束；精确匹配到 enabled Mark route 只影响下方 timeout 的选择。
-    if (do_mark) {
-        const bool has_migration_strategy = !cache_config->migration_strategies().empty();
-        if (!has_migration_strategy) {
-            result.ec = EC_BADARGS;
-            result.message = "MARK/BOTH requires a migration strategy configured on the instance group: " + instance_id;
-            return result;
-        }
-
-        // Admin 保留显式指定任意已注册 target 的能力。精确匹配到启用 Mark 的 strategy 时复用其
-        // timeout；没有匹配 route 时仍允许迁移，并使用默认 timeout。
-        for (const auto &strategy : cache_config->migration_strategies()) {
-            if (strategy != nullptr && strategy->source_storage_name() == src_name &&
-                strategy->target_storage_name() == dst_name && strategy->methods().mark().enabled()) {
-                mark_timeout_ms = strategy->methods().mark().timeout_ms();
-                break;
+    std::shared_ptr<MigrationStrategy> matched_route;
+    for (const auto &strategy : cache_config->migration_strategies()) {
+        if (strategy != nullptr && strategy->source_storage_name() == src_name &&
+            strategy->target_storage_name() == dst_name) {
+            if (matched_route != nullptr) {
+                result.ec = EC_CONFIG_ERROR;
+                result.message = "duplicate migration route: " + src_name + " -> " + dst_name;
+                return result;
             }
+            matched_route = strategy;
         }
     }
+    if (matched_route == nullptr) {
+        result.ec = EC_BADARGS;
+        result.message = "migration route not configured: " + src_name + " -> " + dst_name;
+        return result;
+    }
+    const int64_t mark_timeout_ms = matched_route->methods().mark().timeout_ms();
 
     // 前置通过 → 委派编排。meta_indexer 已取得并校验，直接传入避免二次查找。
     const auto domain = migration_manager_->MigrateCache(request_context,
@@ -1628,10 +1623,13 @@ CacheManager::MigrateCacheResult CacheManager::MigrateCache(RequestContext *requ
                                                          explicit_block_keys,
                                                          sample_count,
                                                          copy_max_concurrency,
-                                                         mark_timeout_ms);
+                                                         mark_timeout_ms,
+                                                         matched_route->retention(),
+                                                         matched_route->admission());
     result.ec = domain.ec;
     result.accepted = domain.accepted;
     result.rejected = domain.rejected;
+    result.outcome_counts = domain.outcome_counts;
     result.message = domain.message;
     return result;
 }

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -21,6 +21,7 @@
 #include "kv_cache_manager/manager/cache_reclaimer.h"
 #include "kv_cache_manager/manager/data_storage_selector.h"
 #include "kv_cache_manager/manager/meta_searcher.h"
+#include "kv_cache_manager/manager/migration_outcome.h"
 #include "kv_cache_manager/manager/select_location_policy.h"
 #include "kv_cache_manager/manager/write_location_manager.h"
 #include "kv_cache_manager/protocol/protobuf/meta_service.pb.h"
@@ -195,6 +196,7 @@ public:
         ErrorCode ec = EC_OK;
         int64_t accepted = 0;
         int64_t rejected = 0;
+        MigrationOutcomeCounts outcome_counts;
         std::string message;
     };
     // do_copy/do_mark 由 method 翻译而来；explicit_block_keys 非空则优先，否则按 sample_count 采样。

--- a/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
+++ b/kv_cache_manager/manager/cache_manager_metrics_recorder.cc
@@ -130,7 +130,7 @@ void CacheManagerMetricsRecorder::RecorderLoop() {
                 group_byte_size += byte_size;
                 const int64_t oldest_access_time = meta_indexer->GetOldestAccessTime();
                 int64_t max_lru_age_us = 0;
-                if (oldest_access_time < INT64_MAX) {
+                if (oldest_access_time > 0 && oldest_access_time < INT64_MAX) {
                     max_lru_age_us = TimestampUtil::GetCurrentTimeUs() - oldest_access_time;
                 }
                 auto write_stats = meta_indexer->GetAsyncWriteStats();

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -1184,7 +1184,8 @@ bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext>
         if (cancelled->load(std::memory_order_relaxed) || (bounded_waves && (!IsRunning() || IsPaused()))) {
             return ErrorCode::EC_ERROR;
         }
-        if (const auto res = meta_indexer->GetProperties(request_context.get(), keys, {PROPERTY_LRU_TIME}, maps);
+        if (const auto res =
+                meta_indexer->GetPropertiesForMaintenance(request_context.get(), keys, {PROPERTY_LRU_TIME}, maps);
             res.ec != ErrorCode::EC_OK) {
             LOG_WITH_ID(WARN,
                         "get properties failed, error code: [%d], proceed with empty lru_time",
@@ -1422,22 +1423,24 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
         key_tp_vec.emplace_back(k, lru_ts);
     }
 
-    if (sampled_keys.size() > batching_size) {
-        std::sort(key_tp_vec.begin(),
-                  key_tp_vec.end(),
-                  [](const std::pair<std::int64_t, std::int64_t> &a,
-                     const std::pair<std::int64_t, std::int64_t> &b) -> bool { return a.second < b.second; });
-    }
+    std::stable_sort(key_tp_vec.begin(),
+                     key_tp_vec.end(),
+                     [](const std::pair<std::int64_t, std::int64_t> &a,
+                        const std::pair<std::int64_t, std::int64_t> &b) -> bool { return a.second < b.second; });
 
     // constitute the batch to be submitted for deleting
     // the first N timestamp would be picked out
     const std::size_t effective_batch_size = std::min(batching_size, sampled_keys.size());
-    std::unordered_set<std::int64_t> deduped_batch;
+    std::unordered_set<std::int64_t> seen_keys;
+    seen_keys.reserve(effective_batch_size);
+    out_batch.clear();
+    out_batch.reserve(effective_batch_size);
     const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
     int64_t age_sum = 0;
     int64_t age_count = 0;
     for (const auto &[key, tp] : key_tp_vec) {
-        if (auto [_, r] = deduped_batch.insert(key); r) {
+        if (seen_keys.insert(key).second) {
+            out_batch.push_back(key);
             if (tp > 0) {
                 const int64_t age = now_us - tp;
                 out_lru_age_stats.min_us = std::min(out_lru_age_stats.min_us, age);
@@ -1445,13 +1448,13 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
                 age_sum += age;
                 ++age_count;
             }
-            if (deduped_batch.size() == effective_batch_size) {
+            if (out_batch.size() == effective_batch_size) {
                 break;
             }
         }
     }
 
-    if (deduped_batch.empty()) {
+    if (out_batch.empty()) {
         out_batch.clear();
         out_lru_age_stats.Clear();
         return true;
@@ -1463,13 +1466,13 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
         out_lru_age_stats.Clear();
     }
 
-    if (deduped_batch.size() < batching_size) {
-        if (deduped_batch.size() != sampled_keys.size()) {
+    if (out_batch.size() < batching_size) {
+        if (out_batch.size() != sampled_keys.size()) {
             // sampled_keys contains duplicated keys, log the event
             LOG_WITH_ID(DEBUG,
                         "shortened batch size (likely duplicated keys sampled), final batch size: [%zu], "
                         "sampled keys size: [%zu], intended batching size: [%zu]",
-                        deduped_batch.size(),
+                        out_batch.size(),
                         sampled_keys.size(),
                         batching_size);
         } else {
@@ -1479,13 +1482,12 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
             LOG_WITH_ID(DEBUG,
                         "shortened batch size, final batch size: [%zu], "
                         "sampled keys size: [%zu], intended batching size: [%zu]",
-                        deduped_batch.size(),
+                        out_batch.size(),
                         sampled_keys.size(),
                         batching_size);
         }
     }
 
-    out_batch.assign(deduped_batch.begin(), deduped_batch.end());
     return true;
 }
 
@@ -1815,7 +1817,8 @@ void CacheReclaimer::TryMigrateOnGroup(
         bool ok = false;
         std::vector<std::int64_t> batch;
     };
-    std::unordered_map<std::string, CachedMigrationBatch> migration_batch_cache;
+    std::unordered_map<std::string, CachedMigrationBatch> limited_migration_batch_cache;
+    std::unordered_map<std::string, CachedMigrationBatch> full_migration_pool_cache;
     const auto configured_copy_concurrency = cache_config->migration_copy_max_concurrency();
     const std::size_t max_concurrent_copy =
         configured_copy_concurrency > 0 ? static_cast<std::size_t>(configured_copy_concurrency) : 0;
@@ -1894,10 +1897,13 @@ void CacheReclaimer::TryMigrateOnGroup(
             if (copy_enabled && !mark_enabled && available_copy_slots == 0) {
                 break;
             }
-            auto &cached = migration_batch_cache[instance_info->instance_id()];
+            const bool full_candidate_pool = strategy->admission().mode() != MigrationAdmissionMode::DISABLED;
+            auto &batch_cache = full_candidate_pool ? full_migration_pool_cache : limited_migration_batch_cache;
+            auto &cached = batch_cache[instance_info->instance_id()];
             if (!cached.built) {
                 cached.built = true;
-                cached.ok = BuildMigrationCandidateBatch(request_context, instance_info, cached.batch);
+                cached.ok =
+                    BuildMigrationCandidateBatch(request_context, instance_info, full_candidate_pool, cached.batch);
             }
             if (!cached.ok || cached.batch.empty()) {
                 continue;
@@ -1912,6 +1918,7 @@ void CacheReclaimer::TryMigrateOnGroup(
 
 bool CacheReclaimer::BuildMigrationCandidateBatch(const std::shared_ptr<RequestContext> &request_context,
                                                   const std::shared_ptr<const InstanceInfo> &instance_info,
+                                                  bool full_candidate_pool,
                                                   std::vector<std::int64_t> &out_batch) noexcept {
     out_batch.clear();
     if (instance_info == nullptr) {
@@ -1925,7 +1932,17 @@ bool CacheReclaimer::BuildMigrationCandidateBatch(const std::shared_ptr<RequestC
         return false;
     }
     AgeStats lru_age_stats;
-    if (!MakeBatchByLRU(request_context.get(), instance_info, keys, maps, out_batch, lru_age_stats)) {
+    const bool batch_made = full_candidate_pool
+                                ? MakeBatchByLRUWithSize(request_context.get(),
+                                                         instance_info,
+                                                         keys,
+                                                         maps,
+                                                         std::numeric_limits<std::size_t>::max(),
+                                                         out_batch,
+                                                         lru_age_stats)
+                                : MakeBatchByLRU(
+                                      request_context.get(), instance_info, keys, maps, out_batch, lru_age_stats);
+    if (!batch_made) {
         return false;
     }
     return true;
@@ -1979,6 +1996,7 @@ bool CacheReclaimer::SubmitMigrationPrepareJob(const std::shared_ptr<RequestCont
     job.source_storage_name = src_name;
     job.target_storage_name = dst_name;
     job.block_keys = batch;
+    job.action_budget = batching_size_.load();
     // pending_locations_ 由 Reclaimer cron 单线程维护。这里只复制与本 batch 相关的前缀范围；
     // executor worker 不得读取 CacheReclaimer 的任何可变状态。
     job.pending_location_ids_by_block = SnapshotPendingLocations(ins_id, batch);

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -1466,7 +1466,7 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
         out_lru_age_stats.Clear();
     }
 
-    if (out_batch.size() < batching_size) {
+    if (batching_size != std::numeric_limits<std::size_t>::max() && out_batch.size() < batching_size) {
         if (out_batch.size() != sampled_keys.size()) {
             // sampled_keys contains duplicated keys, log the event
             LOG_WITH_ID(DEBUG,

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -677,6 +677,7 @@ private:
 
     bool BuildMigrationCandidateBatch(const std::shared_ptr<RequestContext> &request_context,
                                       const std::shared_ptr<const InstanceInfo> &instance_info,
+                                      bool full_candidate_pool,
                                       std::vector<std::int64_t> &out_batch) noexcept;
 
     std::vector<std::vector<std::string>> SnapshotPendingLocations(const std::string &instance_id,

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -2075,7 +2075,8 @@ ErrorCode MetaSearcher::BatchGetLocation(RequestContext *request_context,
 ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
                                          const KeyVector &keys,
                                          const CacheLocationVector &locations,
-                                         std::vector<AddLocationResult> &out_results) {
+                                         std::vector<AddLocationResult> &out_results,
+                                         bool maintenance_no_touch) {
     out_results.assign(keys.size(), AddLocationResult{});
     if (keys.size() != locations.size()) {
         for (auto &result : out_results) {
@@ -2135,7 +2136,9 @@ ErrorCode MetaSearcher::BatchAddLocation(RequestContext *request_context,
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerReadModifyWriteBlock);
-    auto result = meta_indexer_->ReadModifyWriteBlock(request_context, keys, modifier);
+    auto result = maintenance_no_touch
+                      ? meta_indexer_->ReadModifyWriteBlockForMaintenance(request_context, keys, modifier)
+                      : meta_indexer_->ReadModifyWriteBlock(request_context, keys, modifier);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteBlock);
 
     ErrorCode aggregate_ec = result.ec;
@@ -3217,7 +3220,8 @@ ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
                                                const KeyVector &keys,
                                                const std::vector<std::vector<LocationCASTask>> &batch_tasks,
                                                std::vector<std::vector<ErrorCode>> &out_batch_results,
-                                               bool refresh_cache_from_persistent) {
+                                               bool refresh_cache_from_persistent,
+                                               bool maintenance_no_touch) {
 
     if (keys.size() != batch_tasks.size()) {
         return EC_BADARGS;
@@ -3280,8 +3284,11 @@ ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
 
     auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
-    auto result = meta_indexer_->ReadModifyWriteLocation(
-        request_context, keys, location_ids_per_key, modifier, true, refresh_cache_from_persistent);
+    auto result = maintenance_no_touch
+                      ? meta_indexer_->ReadModifyWriteLocationsForMaintenance(
+                            request_context, keys, location_ids_per_key, modifier, true, refresh_cache_from_persistent)
+                      : meta_indexer_->ReadModifyWriteLocation(
+                            request_context, keys, location_ids_per_key, modifier, true, refresh_cache_from_persistent);
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, MetaSearcherIndexerReadModifyWriteLocation);
     out_batch_results = std::move(result.per_location_error_codes);
 

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -3265,6 +3265,8 @@ ErrorCode MetaSearcher::BatchCASLocationStatus(RequestContext *request_context,
             const auto &task = batch_tasks[key_index][loc_index];
             if ((!task.expected_location_value.empty() &&
                  locs[loc_index]->ToJsonString() != task.expected_location_value) ||
+                (task.expected_create_time.has_value() &&
+                 locs[loc_index]->create_time() != *task.expected_create_time) ||
                 locs[loc_index]->status() != task.old_status) {
                 modifier_ecs[loc_index] = ErrorCode::EC_MISMATCH;
             } else {

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -322,6 +322,10 @@ public:
         // This closes the gap between a cleanup scan and its status CAS when
         // a stable location id is refreshed by a newer snapshot.
         std::string expected_location_value;
+        // Optional generation checked in the same metadata RMW as the status
+        // transition. Zero is a valid legacy generation, so absence must be
+        // represented separately instead of using zero as a sentinel.
+        std::optional<int64_t> expected_create_time;
     };
     ErrorCode BatchCASLocationStatus(RequestContext *request_context,
                                      const KeyVector &keys,

--- a/kv_cache_manager/manager/meta_searcher.h
+++ b/kv_cache_manager/manager/meta_searcher.h
@@ -125,7 +125,8 @@ public:
     ErrorCode BatchAddLocation(RequestContext *request_context,
                                const KeyVector &keys,
                                const CacheLocationVector &locations,
-                               std::vector<AddLocationResult> &out_results);
+                               std::vector<AddLocationResult> &out_results,
+                               bool maintenance_no_touch = false);
     struct AddLocationRollbackPlan {
         // Confirmed-successful items (EC_OK + non-empty location id). The
         // caller submits these to the standard location delete pipeline.
@@ -326,7 +327,8 @@ public:
                                      const KeyVector &keys,
                                      const std::vector<std::vector<LocationCASTask>> &batch_tasks,
                                      std::vector<std::vector<ErrorCode>> &out_batch_results,
-                                     bool refresh_cache_from_persistent = false);
+                                     bool refresh_cache_from_persistent = false,
+                                     bool maintenance_no_touch = false);
     struct LocationCADTask {
         std::string location_id;
         CacheLocationStatus expect_status;

--- a/kv_cache_manager/manager/migration_admission_internal.cc
+++ b/kv_cache_manager/manager/migration_admission_internal.cc
@@ -1,0 +1,114 @@
+#include "kv_cache_manager/manager/migration_admission_internal.h"
+
+#include <limits>
+
+namespace kv_cache_manager {
+
+namespace {
+
+constexpr std::int64_t kMicrosPerSecond = 1000 * 1000;
+
+MigrationAdmissionReason StatusToReason(ObservedFeatureStatus status) noexcept {
+    switch (status) {
+    case ObservedFeatureStatus::kMissing:
+        return MigrationAdmissionReason::kFeatureMissing;
+    case ObservedFeatureStatus::kInvalid:
+        return MigrationAdmissionReason::kFeatureInvalid;
+    case ObservedFeatureStatus::kUnsupported:
+        return MigrationAdmissionReason::kFeatureUnsupported;
+    case ObservedFeatureStatus::kReadError:
+        return MigrationAdmissionReason::kFeatureReadError;
+    case ObservedFeatureStatus::kAvailable:
+        break;
+    }
+    return MigrationAdmissionReason::kFeatureInvalid;
+}
+
+} // namespace
+
+MigrationAdmissionFeatureSet FeatureSetOf(MigrationAdmissionFeature feature) noexcept {
+    MigrationAdmissionFeatureSet features;
+    const auto index = static_cast<std::size_t>(feature);
+    if (index < features.size()) {
+        features.set(index);
+    }
+    return features;
+}
+
+const ObservedFeature &MigrationCandidateFeatures::Get(MigrationAdmissionFeature feature) const noexcept {
+    static const ObservedFeature invalid{ObservedFeatureStatus::kInvalid, std::monostate{}};
+    const auto index = static_cast<std::size_t>(feature);
+    return index < values_.size() ? values_[index] : invalid;
+}
+
+void MigrationCandidateFeatures::Set(MigrationAdmissionFeature feature, ObservedFeature observed) noexcept {
+    const auto index = static_cast<std::size_t>(feature);
+    if (index < values_.size()) {
+        values_[index] = std::move(observed);
+    }
+}
+
+MigrationAdmissionFeatureSet RecentAccessAdmissionPolicy::RequiredFeatures() const noexcept {
+    return FeatureSetOf(MigrationAdmissionFeature::kLastAccessTime);
+}
+
+std::vector<MigrationAdmissionDecision>
+RecentAccessAdmissionPolicy::EvaluateBatch(const std::vector<MigrationCandidateFeatures> &features,
+                                           const MigrationAdmissionContext &context) const {
+    std::vector<MigrationAdmissionDecision> decisions;
+    decisions.reserve(features.size());
+    for (const auto &candidate : features) {
+        MigrationAdmissionDecision decision;
+        const auto &observed = candidate.Get(MigrationAdmissionFeature::kLastAccessTime);
+        if (observed.status != ObservedFeatureStatus::kAvailable) {
+            decision.reason = StatusToReason(observed.status);
+            decisions.push_back(decision);
+            continue;
+        }
+        const auto last_access_time =
+            candidate.GetAvailableValue<std::int64_t>(MigrationAdmissionFeature::kLastAccessTime);
+        if (!last_access_time || *last_access_time <= 0 || context.now_us <= 0 ||
+            *last_access_time > context.now_us || window_us_ <= 0) {
+            decision.reason = MigrationAdmissionReason::kFeatureInvalid;
+            decisions.push_back(decision);
+            continue;
+        }
+        const std::int64_t age_us = context.now_us - *last_access_time;
+        if (age_us <= window_us_) {
+            decision.verdict = MigrationAdmissionVerdict::kAccept;
+            decision.reason = MigrationAdmissionReason::kSatisfied;
+        } else {
+            decision.verdict = MigrationAdmissionVerdict::kReject;
+            decision.reason = MigrationAdmissionReason::kNotRecent;
+        }
+        decisions.push_back(decision);
+    }
+    return decisions;
+}
+
+std::unique_ptr<MigrationAdmissionPolicy>
+MigrationAdmissionPolicyFactory::Build(const MigrationAdmissionConfig &config,
+                                       std::string &error_message) {
+    error_message.clear();
+    if (config.mode() == MigrationAdmissionMode::DISABLED) {
+        return nullptr;
+    }
+    if (config.mode() != MigrationAdmissionMode::SHADOW &&
+        config.mode() != MigrationAdmissionMode::ENFORCE) {
+        error_message = "migration admission mode is invalid";
+        return nullptr;
+    }
+    if (config.policies().size() != 1 || config.policies().front() == nullptr ||
+        config.policies().front()->recent_access() == nullptr) {
+        error_message = "V1 admission requires exactly one recent_access policy";
+        return nullptr;
+    }
+    const std::int64_t window_seconds = config.policies().front()->recent_access()->window_seconds();
+    if (window_seconds <= 0 || window_seconds > std::numeric_limits<std::int64_t>::max() / kMicrosPerSecond) {
+        error_message = "recent_access.window_seconds is invalid or overflows microseconds";
+        return nullptr;
+    }
+    return std::make_unique<RecentAccessAdmissionPolicy>(window_seconds * kMicrosPerSecond);
+}
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/migration_admission_internal.h
+++ b/kv_cache_manager/manager/migration_admission_internal.h
@@ -74,11 +74,6 @@ enum class MigrationAdmissionVerdict {
     kUnknown,
 };
 
-enum class MigrationAdmissionPolicyType {
-    kRecentAccess,
-    kMinimumBusinessAccessCount,
-};
-
 enum class MigrationAdmissionReason {
     kSatisfied,
     kNotRecent,
@@ -91,7 +86,6 @@ enum class MigrationAdmissionReason {
 
 struct MigrationAdmissionDecision {
     MigrationAdmissionVerdict verdict = MigrationAdmissionVerdict::kUnknown;
-    MigrationAdmissionPolicyType policy_type = MigrationAdmissionPolicyType::kRecentAccess;
     MigrationAdmissionReason reason = MigrationAdmissionReason::kFeatureMissing;
 };
 

--- a/kv_cache_manager/manager/migration_admission_internal.h
+++ b/kv_cache_manager/manager/migration_admission_internal.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <array>
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "kv_cache_manager/config/migration_strategy.h"
+
+namespace kv_cache_manager {
+
+// MigrationManager-owned value-admission vocabulary. These types intentionally
+// do not depend on MetaIndexer or any storage backend.
+enum class MigrationAdmissionFeature : std::uint8_t {
+    kLastAccessTime = 0,
+    kBusinessAccessCount = 1,
+    kFeatureCount,
+};
+
+using MigrationAdmissionFeatureSet =
+    std::bitset<static_cast<std::size_t>(MigrationAdmissionFeature::kFeatureCount)>;
+
+MigrationAdmissionFeatureSet FeatureSetOf(MigrationAdmissionFeature feature) noexcept;
+
+enum class ObservedFeatureStatus {
+    kAvailable,
+    kMissing,
+    kInvalid,
+    kUnsupported,
+    kReadError,
+};
+
+struct ObservedFeature {
+    ObservedFeatureStatus status = ObservedFeatureStatus::kMissing;
+    std::variant<std::monostate, std::int64_t, std::uint64_t, double> value;
+};
+
+class MigrationCandidateFeatures {
+public:
+    const ObservedFeature &Get(MigrationAdmissionFeature feature) const noexcept;
+    void Set(MigrationAdmissionFeature feature, ObservedFeature observed) noexcept;
+
+    template <typename T>
+    std::optional<T> GetAvailableValue(MigrationAdmissionFeature feature) const noexcept {
+        const auto &observed = Get(feature);
+        if (observed.status != ObservedFeatureStatus::kAvailable) {
+            return std::nullopt;
+        }
+        const auto *value = std::get_if<T>(&observed.value);
+        if (value == nullptr) {
+            return std::nullopt;
+        }
+        return *value;
+    }
+
+private:
+    std::array<ObservedFeature,
+               static_cast<std::size_t>(MigrationAdmissionFeature::kFeatureCount)>
+        values_{};
+};
+
+struct MigrationAdmissionContext {
+    std::int64_t now_us = 0;
+};
+
+enum class MigrationAdmissionVerdict {
+    kAccept,
+    kReject,
+    kUnknown,
+};
+
+enum class MigrationAdmissionPolicyType {
+    kRecentAccess,
+    kMinimumBusinessAccessCount,
+};
+
+enum class MigrationAdmissionReason {
+    kSatisfied,
+    kNotRecent,
+    kInsufficientBusinessAccessCount,
+    kFeatureMissing,
+    kFeatureInvalid,
+    kFeatureUnsupported,
+    kFeatureReadError,
+};
+
+struct MigrationAdmissionDecision {
+    MigrationAdmissionVerdict verdict = MigrationAdmissionVerdict::kUnknown;
+    MigrationAdmissionPolicyType policy_type = MigrationAdmissionPolicyType::kRecentAccess;
+    MigrationAdmissionReason reason = MigrationAdmissionReason::kFeatureMissing;
+};
+
+class MigrationAdmissionPolicy {
+public:
+    virtual ~MigrationAdmissionPolicy() = default;
+    virtual MigrationAdmissionFeatureSet RequiredFeatures() const noexcept = 0;
+    virtual std::vector<MigrationAdmissionDecision>
+    EvaluateBatch(const std::vector<MigrationCandidateFeatures> &features,
+                  const MigrationAdmissionContext &context) const = 0;
+};
+
+class RecentAccessAdmissionPolicy final : public MigrationAdmissionPolicy {
+public:
+    explicit RecentAccessAdmissionPolicy(std::int64_t window_us)
+        : window_us_(window_us) {}
+
+    MigrationAdmissionFeatureSet RequiredFeatures() const noexcept override;
+    std::vector<MigrationAdmissionDecision>
+    EvaluateBatch(const std::vector<MigrationCandidateFeatures> &features,
+                  const MigrationAdmissionContext &context) const override;
+
+private:
+    std::int64_t window_us_ = 0;
+};
+
+class MigrationAdmissionPolicyFactory {
+public:
+    static std::unique_ptr<MigrationAdmissionPolicy>
+    Build(const MigrationAdmissionConfig &config, std::string &error_message);
+};
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -1,8 +1,10 @@
 #include "kv_cache_manager/manager/migration_manager.h"
 
 #include <algorithm>
+#include <array>
 #include <charconv>
 #include <chrono>
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <tuple>
@@ -23,6 +25,7 @@
 #include "kv_cache_manager/event/spec_events/migration_event.h"
 #include "kv_cache_manager/manager/data_storage_selector.h"
 #include "kv_cache_manager/manager/meta_searcher.h"
+#include "kv_cache_manager/manager/migration_admission_internal.h"
 #include "kv_cache_manager/meta/cache_location.h"
 #include "kv_cache_manager/meta/common.h"
 #include "kv_cache_manager/meta/meta_indexer.h"
@@ -169,6 +172,29 @@ struct MarkInfo {
     bool expired = false;
 };
 
+struct SpecByteSummary {
+    std::uint64_t bytes = 0;
+    std::uint64_t unknown_specs = 0;
+};
+
+SpecByteSummary SummarizeSpecBytes(const std::vector<LocationSpec> &specs) noexcept {
+    SpecByteSummary summary;
+    for (const auto &spec : specs) {
+        const DataStorageUri uri(spec.uri());
+        const std::string size_value = uri.Valid() ? uri.GetParam("size") : std::string{};
+        std::uint64_t size = 0;
+        const auto [ptr, ec] =
+            std::from_chars(size_value.data(), size_value.data() + size_value.size(), size);
+        if (size_value.empty() || ec != std::errc{} || ptr != size_value.data() + size_value.size() ||
+            size > std::numeric_limits<std::uint64_t>::max() - summary.bytes) {
+            ++summary.unknown_specs;
+            continue;
+        }
+        summary.bytes += size;
+    }
+    return summary;
+}
+
 static MarkInfo ParseMarkFromProperties(const PropertyMap &props, int64_t now_ms) {
     MarkInfo info;
     auto tit = props.find(MigrationManager::PROPERTY_TIERED_WRITE_TARGET);
@@ -226,6 +252,225 @@ std::vector<const CacheLocation *> FindLocationsOnStorage(const CacheLocationMap
     }
     return locations;
 }
+
+std::vector<LocationSpec> FindFirstUncoveredSourceSpecs(const CacheLocationMap &loc_map,
+                                                        const std::string &src_storage_name,
+                                                        const std::string &dst_storage_name) {
+    const auto covered = CollectCoveredSpecNames(
+        loc_map, dst_storage_name, {CacheLocationStatus::CLS_SERVING, CacheLocationStatus::CLS_WRITING});
+    for (const auto *source :
+         FindLocationsOnStorage(loc_map, src_storage_name, {CacheLocationStatus::CLS_SERVING})) {
+        std::vector<LocationSpec> missing_specs;
+        missing_specs.reserve(source->location_specs().size());
+        std::copy_if(source->location_specs().begin(),
+                     source->location_specs().end(),
+                     std::back_inserter(missing_specs),
+                     [&covered](const LocationSpec &spec) { return covered.count(spec.name()) == 0; });
+        if (!missing_specs.empty()) {
+            return missing_specs;
+        }
+    }
+    return {};
+}
+
+void AddOutcome(MigrationOutcomeCounts &outcomes,
+                MigrationOutcomeStage stage,
+                MigrationOutcomeClass outcome_class,
+                MigrationOutcomeReason reason,
+                int64_t count,
+                bool terminal) {
+    if (count <= 0) {
+        return;
+    }
+    const auto existing = std::find_if(outcomes.begin(), outcomes.end(), [&](const MigrationOutcomeCount &item) {
+        return item.stage == stage && item.outcome_class == outcome_class && item.reason == reason &&
+               item.terminal == terminal;
+    });
+    if (existing != outcomes.end()) {
+        existing->count += count;
+        return;
+    }
+    outcomes.push_back(MigrationOutcomeCount{stage, outcome_class, reason, count, terminal});
+}
+
+MigrationOutcomeReason ToOutcomeReason(MigrationAdmissionReason reason) noexcept {
+    switch (reason) {
+    case MigrationAdmissionReason::kSatisfied:
+        return MigrationOutcomeReason::kValueAccepted;
+    case MigrationAdmissionReason::kNotRecent:
+        return MigrationOutcomeReason::kNotRecent;
+    case MigrationAdmissionReason::kFeatureMissing:
+        return MigrationOutcomeReason::kFeatureMissing;
+    case MigrationAdmissionReason::kFeatureInvalid:
+        return MigrationOutcomeReason::kFeatureInvalid;
+    case MigrationAdmissionReason::kFeatureUnsupported:
+        return MigrationOutcomeReason::kFeatureUnsupported;
+    case MigrationAdmissionReason::kFeatureReadError:
+        return MigrationOutcomeReason::kFeatureReadError;
+    case MigrationAdmissionReason::kInsufficientBusinessAccessCount:
+        return MigrationOutcomeReason::kFeatureInvalid;
+    }
+    return MigrationOutcomeReason::kUnspecified;
+}
+
+MigrationOutcomeReason ToOutcomeReason(MigrationManager::CopyAdmissionStatus status) noexcept {
+    switch (status) {
+    case MigrationManager::CopyAdmissionStatus::kAlreadyMigrating:
+        return MigrationOutcomeReason::kAlreadyMigrating;
+    case MigrationManager::CopyAdmissionStatus::kTargetServingExists:
+    case MigrationManager::CopyAdmissionStatus::kTargetWritingExists:
+        return MigrationOutcomeReason::kTargetAlreadyCovered;
+    case MigrationManager::CopyAdmissionStatus::kSourceServingNotFound:
+        return MigrationOutcomeReason::kSourceNotFound;
+    case MigrationManager::CopyAdmissionStatus::kAccept:
+        break;
+    }
+    return MigrationOutcomeReason::kUnspecified;
+}
+
+MigrationOutcomeReason CopySubmitOutcomeReason(ErrorCode ec) noexcept {
+    switch (ec) {
+    case EC_NOENT:
+    case EC_MISMATCH:
+        return MigrationOutcomeReason::kSourceRecheckFailed;
+    case EC_EXIST:
+        return MigrationOutcomeReason::kAlreadyMigrating;
+    case EC_OUT_OF_LIMIT:
+        return MigrationOutcomeReason::kCopySlotExhausted;
+    case EC_NOSPC:
+        return MigrationOutcomeReason::kTargetRejected;
+    default:
+        return MigrationOutcomeReason::kCopySubmitFailed;
+    }
+}
+
+const char *TriggerName(MigrationManager::DispatchBatchParams::Trigger trigger) noexcept {
+    return trigger == MigrationManager::DispatchBatchParams::Trigger::kReclaimer ? "reclaimer" : "admin";
+}
+
+const char *AdmissionModeName(MigrationAdmissionMode mode) noexcept {
+    switch (mode) {
+    case MigrationAdmissionMode::DISABLED:
+        return "disabled";
+    case MigrationAdmissionMode::SHADOW:
+        return "shadow";
+    case MigrationAdmissionMode::ENFORCE:
+        return "enforce";
+    }
+    return "unknown";
+}
+
+const char *OutcomeStageName(MigrationOutcomeStage stage) noexcept {
+    switch (stage) {
+    case MigrationOutcomeStage::kSnapshot:
+        return "snapshot";
+    case MigrationOutcomeStage::kValue:
+        return "value";
+    case MigrationOutcomeStage::kExecution:
+        return "execution";
+    case MigrationOutcomeStage::kCopy:
+        return "copy";
+    case MigrationOutcomeStage::kMark:
+        return "mark";
+    }
+    return "unknown";
+}
+
+const char *OutcomeClassName(MigrationOutcomeClass outcome_class) noexcept {
+    switch (outcome_class) {
+    case MigrationOutcomeClass::kAccepted:
+        return "accepted";
+    case MigrationOutcomeClass::kRejected:
+        return "rejected";
+    case MigrationOutcomeClass::kNoopAlreadySatisfied:
+        return "noop_already_satisfied";
+    case MigrationOutcomeClass::kFailed:
+        return "failed";
+    }
+    return "unknown";
+}
+
+const char *OutcomeReasonName(MigrationOutcomeReason reason) noexcept {
+    switch (reason) {
+    case MigrationOutcomeReason::kUnspecified:
+        return "unspecified";
+    case MigrationOutcomeReason::kNotRecent:
+        return "not_recent";
+    case MigrationOutcomeReason::kFeatureMissing:
+        return "feature_missing";
+    case MigrationOutcomeReason::kFeatureInvalid:
+        return "feature_invalid";
+    case MigrationOutcomeReason::kFeatureUnsupported:
+        return "feature_unsupported";
+    case MigrationOutcomeReason::kFeatureReadError:
+        return "feature_read_error";
+    case MigrationOutcomeReason::kRouteNotReady:
+        return "route_not_ready";
+    case MigrationOutcomeReason::kLocationReadError:
+        return "location_read_error";
+    case MigrationOutcomeReason::kSnapshotShapeError:
+        return "snapshot_shape_error";
+    case MigrationOutcomeReason::kSourceNotFound:
+        return "source_not_found";
+    case MigrationOutcomeReason::kTargetAlreadyCovered:
+        return "target_already_covered";
+    case MigrationOutcomeReason::kAlreadyMigrating:
+        return "already_migrating";
+    case MigrationOutcomeReason::kTargetRejected:
+        return "target_rejected";
+    case MigrationOutcomeReason::kSourceRecheckFailed:
+        return "source_recheck_failed";
+    case MigrationOutcomeReason::kCopySubmitted:
+        return "copy_submitted";
+    case MigrationOutcomeReason::kCopySubmitFailed:
+        return "copy_submit_failed";
+    case MigrationOutcomeReason::kMarkInserted:
+        return "mark_inserted";
+    case MigrationOutcomeReason::kMarkAlreadySameTarget:
+        return "mark_already_same_target";
+    case MigrationOutcomeReason::kMarkConflictDifferentTarget:
+        return "mark_conflict_different_target";
+    case MigrationOutcomeReason::kMarkMalformed:
+        return "mark_malformed";
+    case MigrationOutcomeReason::kBlockNotFound:
+        return "block_not_found";
+    case MigrationOutcomeReason::kMarkReadError:
+        return "mark_read_error";
+    case MigrationOutcomeReason::kMarkWriteError:
+        return "mark_write_error";
+    case MigrationOutcomeReason::kPolicyContractError:
+        return "policy_contract_error";
+    case MigrationOutcomeReason::kBudgetExhausted:
+        return "budget_exhausted";
+    case MigrationOutcomeReason::kValueAccepted:
+        return "value_accepted";
+    case MigrationOutcomeReason::kNoExecutionMethod:
+        return "no_execution_method";
+    case MigrationOutcomeReason::kCopySlotExhausted:
+        return "copy_slot_exhausted";
+    case MigrationOutcomeReason::kDispatchNotAvailable:
+        return "dispatch_not_available";
+    }
+    return "unknown";
+}
+
+const char *FeatureStatusName(MigrationOutcomeReason reason) noexcept {
+    switch (reason) {
+    case MigrationOutcomeReason::kFeatureMissing:
+        return "missing";
+    case MigrationOutcomeReason::kFeatureInvalid:
+        return "invalid";
+    case MigrationOutcomeReason::kFeatureUnsupported:
+        return "unsupported";
+    case MigrationOutcomeReason::kFeatureReadError:
+        return "read_error";
+    case MigrationOutcomeReason::kNotRecent:
+    case MigrationOutcomeReason::kValueAccepted:
+        return "available";
+    default:
+        return nullptr;
+    }
+}
 } // namespace
 
 // Mark 持久化属性名（block 级 property）。带 inner 前缀避免与业务属性冲突。
@@ -263,6 +508,200 @@ MigrationManager::MigrationManager(std::shared_ptr<SchedulePlanExecutor> schedul
         m_marks_expired_total_ = metrics_registry_->GetCounter("migration.marks_expired_total");
         m_mark_query_errors_total_ = metrics_registry_->GetCounter("migration.mark_query_errors_total");
     }
+}
+
+void MigrationManager::AddCounterMetric(const std::string &name,
+                                        MetricsTags tags,
+                                        std::uint64_t value) const noexcept {
+    if (!metrics_enabled_ || metrics_registry_ == nullptr || value == 0) {
+        return;
+    }
+    try {
+        metrics_registry_->GetCounter(name, tags) += value;
+    } catch (const std::exception &e) {
+        KVCM_LOG_WARN("record migration metric %s failed: %s", name.c_str(), e.what());
+    } catch (...) { KVCM_LOG_WARN("record migration metric %s failed with unknown error", name.c_str()); }
+}
+
+void MigrationManager::SetGaugeMetric(const std::string &name, MetricsTags tags, double value) const noexcept {
+    if (!metrics_enabled_ || metrics_registry_ == nullptr) {
+        return;
+    }
+    try {
+        metrics_registry_->GetGauge(name, tags) = value;
+    } catch (const std::exception &e) {
+        KVCM_LOG_WARN("record migration gauge %s failed: %s", name.c_str(), e.what());
+    } catch (...) { KVCM_LOG_WARN("record migration gauge %s failed with unknown error", name.c_str()); }
+}
+
+void MigrationManager::ObserveAdmissionAccessAge(const std::string &src_name,
+                                                 const std::string &dst_name,
+                                                 const DispatchBatchParams &params,
+                                                 std::int64_t age_us) const noexcept {
+    if (!metrics_enabled_ || metrics_registry_ == nullptr || age_us < 0) {
+        return;
+    }
+    try {
+        static constexpr std::array<std::int64_t, 8> kBucketSeconds = {
+            1, 10, 60, 5 * 60, 60 * 60, 6 * 60 * 60, 24 * 60 * 60, 7 * 24 * 60 * 60};
+        static constexpr const char *kFamily = "migration_admission_access_age_seconds";
+        static constexpr const char *kBucket = "migration_admission_access_age_seconds_bucket";
+        static constexpr const char *kSum = "migration_admission_access_age_seconds_sum";
+        static constexpr const char *kCount = "migration_admission_access_age_seconds_count";
+        metrics_registry_->RegisterHistogramFamily(kFamily);
+        metrics_registry_->MapMetricToFamily(kBucket, kFamily);
+        metrics_registry_->MapMetricToFamily(kSum, kFamily);
+        metrics_registry_->MapMetricToFamily(kCount, kFamily);
+
+        MetricsTags tags{{"trigger", TriggerName(params.trigger)}, {"src", src_name}, {"dst", dst_name}};
+        for (const auto boundary_seconds : kBucketSeconds) {
+            if (age_us <= boundary_seconds * 1000 * 1000) {
+                auto bucket_tags = tags;
+                bucket_tags["le"] = std::to_string(boundary_seconds);
+                ++metrics_registry_->GetCounter(kBucket, bucket_tags);
+            }
+        }
+        auto infinite_tags = tags;
+        infinite_tags["le"] = "+Inf";
+        ++metrics_registry_->GetCounter(kBucket, infinite_tags);
+        metrics_registry_->GetCounter(kSum, tags) += static_cast<std::uint64_t>(age_us);
+        ++metrics_registry_->GetCounter(kCount, tags);
+    } catch (const std::exception &e) {
+        KVCM_LOG_WARN("record migration admission access age failed: %s", e.what());
+    } catch (...) { KVCM_LOG_WARN("record migration admission access age failed with unknown error"); }
+}
+
+void MigrationManager::ObserveSourceLeaseDuration(const std::string &src_name,
+                                                  const std::string &dst_name,
+                                                  std::int64_t duration_us) const noexcept {
+    if (!metrics_enabled_ || metrics_registry_ == nullptr || duration_us < 0) {
+        return;
+    }
+    try {
+        static constexpr std::array<std::int64_t, 7> kBucketSeconds = {1, 10, 60, 5 * 60, 30 * 60, 60 * 60, 6 * 60 * 60};
+        static constexpr const char *kFamily = "migration_source_lease_duration_seconds";
+        static constexpr const char *kBucket = "migration_source_lease_duration_seconds_bucket";
+        static constexpr const char *kSum = "migration_source_lease_duration_seconds_sum";
+        static constexpr const char *kCount = "migration_source_lease_duration_seconds_count";
+        metrics_registry_->RegisterHistogramFamily(kFamily);
+        metrics_registry_->MapMetricToFamily(kBucket, kFamily);
+        metrics_registry_->MapMetricToFamily(kSum, kFamily);
+        metrics_registry_->MapMetricToFamily(kCount, kFamily);
+
+        MetricsTags tags{{"src", src_name}, {"dst", dst_name}};
+        for (const auto boundary_seconds : kBucketSeconds) {
+            if (duration_us <= boundary_seconds * 1000 * 1000) {
+                auto bucket_tags = tags;
+                bucket_tags["le"] = std::to_string(boundary_seconds);
+                ++metrics_registry_->GetCounter(kBucket, bucket_tags);
+            }
+        }
+        auto infinite_tags = tags;
+        infinite_tags["le"] = "+Inf";
+        ++metrics_registry_->GetCounter(kBucket, infinite_tags);
+        metrics_registry_->GetCounter(kSum, tags) += static_cast<std::uint64_t>(duration_us);
+        ++metrics_registry_->GetCounter(kCount, tags);
+    } catch (const std::exception &e) {
+        KVCM_LOG_WARN("record migration source lease duration failed: %s", e.what());
+    } catch (...) { KVCM_LOG_WARN("record migration source lease duration failed with unknown error"); }
+}
+
+MigrationManager::DispatchBatchResult MigrationManager::FinalizeDispatchMetrics(
+    const std::string &instance_id,
+    const std::string &src_name,
+    const std::string &dst_name,
+    std::size_t candidate_count,
+    const DispatchBatchParams &params,
+    DispatchBatchResult result) const {
+    MetricsTags route_tags{{"trigger", TriggerName(params.trigger)},
+                           {"src", src_name},
+                           {"dst", dst_name},
+                           {"mode", AdmissionModeName(params.admission.mode())}};
+    AddCounterMetric("migration_admission_candidates_total", route_tags, candidate_count);
+
+    auto pool_tags = route_tags;
+    pool_tags.erase("trigger");
+    pool_tags.erase("mode");
+    pool_tags["stage"] = "sampled";
+    AddCounterMetric("migration_candidate_pool_total", pool_tags, candidate_count);
+
+    std::int64_t terminal_count = 0;
+    std::int64_t dispatched_count = 0;
+    for (const auto &outcome : result.outcome_counts) {
+        auto outcome_tags = route_tags;
+        outcome_tags.erase("mode");
+        outcome_tags["stage"] = OutcomeStageName(outcome.stage);
+        outcome_tags["class"] = OutcomeClassName(outcome.outcome_class);
+        outcome_tags["reason"] = OutcomeReasonName(outcome.reason);
+        outcome_tags["terminal"] = outcome.terminal ? "true" : "false";
+        AddCounterMetric("migration_dispatch_outcomes_total", std::move(outcome_tags), outcome.count);
+
+        if (outcome.terminal) {
+            terminal_count += outcome.count;
+            if (outcome.outcome_class == MigrationOutcomeClass::kAccepted) {
+                dispatched_count += outcome.count;
+            }
+        }
+        if (outcome.stage == MigrationOutcomeStage::kValue &&
+            outcome.reason != MigrationOutcomeReason::kPolicyContractError) {
+            auto policy_tags = route_tags;
+            policy_tags.erase("mode");
+            policy_tags["policy"] = "recent_access";
+            policy_tags["reason"] = OutcomeReasonName(outcome.reason);
+            if (outcome.outcome_class == MigrationOutcomeClass::kAccepted) {
+                policy_tags["verdict"] = "accept";
+                AddCounterMetric("migration_admission_accepted_total", route_tags, outcome.count);
+            } else {
+                policy_tags["verdict"] = outcome.reason == MigrationOutcomeReason::kNotRecent ? "reject" : "unknown";
+                auto rejected_tags = route_tags;
+                rejected_tags["reason"] = OutcomeReasonName(outcome.reason);
+                AddCounterMetric("migration_admission_rejected_total", std::move(rejected_tags), outcome.count);
+            }
+            AddCounterMetric("migration_admission_policy_evaluations_total", std::move(policy_tags), outcome.count);
+        }
+        // Feature transport failures are snapshot failures in ENFORCE and
+        // projected policy UNKNOWNs in SHADOW. Record feature availability
+        // independently of the stage so both shapes share one metric.
+        if (const char *feature_status = FeatureStatusName(outcome.reason); feature_status != nullptr) {
+            MetricsTags feature_tags{{"src", src_name},
+                                     {"dst", dst_name},
+                                     {"feature", "last_access_time"},
+                                     {"status", feature_status}};
+            AddCounterMetric("migration_admission_feature_status_total", std::move(feature_tags), outcome.count);
+        }
+
+        const char *read_component = nullptr;
+        if (outcome.reason == MigrationOutcomeReason::kLocationReadError) {
+            read_component = "location";
+        } else if (outcome.reason == MigrationOutcomeReason::kSnapshotShapeError) {
+            read_component = "snapshot";
+        } else if (outcome.reason == MigrationOutcomeReason::kFeatureReadError) {
+            read_component = "property";
+        }
+        if (read_component != nullptr) {
+            MetricsTags read_tags{{"src", src_name},
+                                  {"dst", dst_name},
+                                  {"component", read_component},
+                                  {"reason", OutcomeReasonName(outcome.reason)}};
+            AddCounterMetric("migration_admission_read_error_total", std::move(read_tags), outcome.count);
+        }
+    }
+
+    pool_tags["stage"] = "dispatched";
+    AddCounterMetric("migration_candidate_pool_total", std::move(pool_tags), dispatched_count);
+    if (terminal_count != static_cast<std::int64_t>(candidate_count)) {
+        auto invariant_tags = route_tags;
+        invariant_tags["reason"] = "terminal_count_mismatch";
+        AddCounterMetric("migration_dispatch_invariant_errors_total", std::move(invariant_tags));
+        KVCM_LOG_ERROR("migration dispatch terminal outcome mismatch for instance %s, route %s -> %s: candidates %zu, "
+                       "terminal %lld",
+                       instance_id.c_str(),
+                       src_name.c_str(),
+                       dst_name.c_str(),
+                       candidate_count,
+                       static_cast<long long>(terminal_count));
+    }
+    return result;
 }
 
 void MigrationManager::UpdateActiveTasksGauge() {
@@ -334,6 +773,23 @@ void MigrationManager::Start() {
         return; // already running
     }
     async_prepare_generation_.fetch_add(1, std::memory_order_acq_rel);
+    if (meta_indexer_manager_ != nullptr) {
+        for (const auto &[unused_instance_id, indexer] : meta_indexer_manager_->GetIndexers()) {
+            (void)unused_instance_id;
+            if (indexer != nullptr) {
+                indexer->ResetMaintenancePropertyReadinessEpoch();
+            }
+        }
+    }
+    if (schedule_plan_executor_ != nullptr) {
+        schedule_plan_executor_->SetSourceLocationLeaseChecker(
+            [this](const std::string &instance_id,
+                   int64_t block_key,
+                   const std::string &location_id,
+                   int64_t create_time) {
+                return HasActiveCopySourceLocation(instance_id, block_key, location_id, create_time);
+            });
+    }
     accepting_copy_submissions_.store(true, std::memory_order_release);
     monitor_thread_ = std::thread([this]() { MonitorLoop(); });
     KVCM_LOG_INFO("MigrationManager started");
@@ -369,6 +825,14 @@ void MigrationManager::Stop() {
         active_tasks_by_instance_.clear();
         UpdateActiveTasksGauge();
     }
+    // Keep the checker installed until every lifecycle-protected submit and
+    // monitor completion has stopped and the active lease table is empty.
+    // Clearing it earlier opens a shutdown-only window in which an already
+    // admitted submit still prepares Copy while delete admission no longer
+    // recognizes its source lease.
+    if (schedule_plan_executor_ != nullptr) {
+        schedule_plan_executor_->SetSourceLocationLeaseChecker({});
+    }
     if (dropped > 0) {
         KVCM_LOG_WARN("MigrationManager stopped with %zu active copy task(s) dropped; "
                       "WRITING dst locations will be reclaimed as orphans",
@@ -399,27 +863,28 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
     }
 
     // 1. 读取源 location specs + create_time。
-    // 如果调用方已在 admission 阶段取得 src_specs，直接使用并跳过冗余 BatchGetLocation；
-    // public 单条 Submit 仍允许不带快照，此时在这里重读源 location。private BatchSubmit 不走本函数。
+    // 如果调用方已在 admission 阶段取得 src_specs，直接使用并跳过冗余读取；
+    // public 单条 Submit 仍允许不带快照，此时也必须通过 NoTouch 接口重读源 location。
     const std::vector<LocationSpec> *src_specs_ptr = nullptr;
     int64_t src_create_time = 0;
     if (!request.src_specs.empty()) {
         src_specs_ptr = &request.src_specs;
         src_create_time = request.src_create_time;
     } else {
-        MetaSearcher meta_searcher_for_src(indexer);
-        auto ctx_for_src =
-            std::make_shared<RequestContext>(trace_id.empty() ? "migration_prepare" : trace_id);
-        std::vector<CacheLocationMap> location_maps;
-        BlockMask empty_mask;
-        ErrorCode ec =
-            meta_searcher_for_src.BatchGetLocation(ctx_for_src.get(), {request.block_key}, empty_mask, location_maps);
-        if (ec != EC_OK || location_maps.empty()) {
-            KVCM_LOG_WARN("[%s] BatchGetLocation failed for block_key %ld, ec %d",
+        RequestContext source_context(trace_id.empty() ? "migration_prepare" : trace_id);
+        CacheLocationMapVector location_maps;
+        PropertyMapVector unused_properties;
+        const auto source_read = indexer->GetForMaintenance(
+            &source_context, {request.block_key}, {}, location_maps, unused_properties);
+        const ErrorCode source_ec = source_read.locations.error_codes.size() == 1
+                                        ? source_read.locations.error_codes.front()
+                                        : EC_MISMATCH;
+        if (source_ec != EC_OK || location_maps.size() != 1) {
+            KVCM_LOG_WARN("[%s] NoTouch source location read failed for block_key %ld, ec %d",
                           trace_id.c_str(),
                           request.block_key,
-                          ec);
-            return EC_NOENT;
+                          source_ec);
+            return source_ec == EC_NOENT ? EC_NOENT : EC_ERROR;
         }
         auto src_iter = location_maps[0].find(request.src_location_id);
         if (src_iter == location_maps[0].end()) {
@@ -516,7 +981,8 @@ ErrorCode MigrationManager::PrepareCopyTask(const std::string &trace_id,
         dst_location->push_location_spec(std::move(spec));
     }
     std::vector<MetaSearcher::AddLocationResult> add_results;
-    ErrorCode ec = meta_searcher.BatchAddLocation(ctx.get(), {request.block_key}, {dst_location}, add_results);
+    ErrorCode ec =
+        meta_searcher.BatchAddLocation(ctx.get(), {request.block_key}, {dst_location}, add_results, true);
     if (add_results.size() != 1) {
         KVCM_LOG_WARN("[%s] BatchAddLocation returned unexpected result count for block_key %ld: expected 1, got %zu; "
                       "retaining allocated URIs",
@@ -581,11 +1047,15 @@ ErrorCode MigrationManager::Submit(const std::string &trace_id, MigrationRequest
     if (GetIndexer(request.instance_id) == nullptr) {
         return EC_INSTANCE_NOT_EXIST;
     }
+    if (schedule_plan_executor_ == nullptr) {
+        return EC_ERROR;
+    }
     if (const auto target_ec = CheckTargetStorageAdmission(
             trace_id, request.instance_group_name, request.instance_id, request.dst_storage_name);
         target_ec != EC_OK) {
         return target_ec;
     }
+    auto source_lease_guard = schedule_plan_executor_->AcquireSourceLocationLeaseReservationGuard();
     {
         std::lock_guard<std::mutex> submission_lock(copy_submission_mutex_);
         // shared lock 可能排在一次 Stop 后才拿到，必须在真正准入点复查。
@@ -612,6 +1082,60 @@ ErrorCode MigrationManager::Submit(const std::string &trace_id, MigrationRequest
             return EC_EXIST;
         }
     }
+
+    // Reservation and this exact NoTouch recheck are atomic with respect to
+    // every automatic delete admission. Once the guard is released, the
+    // active task's (id, create_time) source lease makes later deletes skip it.
+    auto indexer = GetIndexer(request.instance_id);
+    CacheLocationMapVector source_location_maps;
+    PropertyMapVector unused_properties;
+    RequestContext source_recheck_context(trace_id.empty() ? "migration_source_recheck" : trace_id);
+    const auto source_read = indexer->GetForMaintenance(&source_recheck_context,
+                                                        {request.block_key},
+                                                        {},
+                                                        source_location_maps,
+                                                        unused_properties);
+    ErrorCode source_check_ec = EC_OK;
+    const CacheLocation *source_location = nullptr;
+    if (source_read.locations.error_codes.size() != 1 || source_location_maps.size() != 1) {
+        source_check_ec = EC_ERROR;
+    } else if (source_read.locations.error_codes[0] != EC_OK) {
+        source_check_ec = source_read.locations.error_codes[0] == EC_NOENT
+                              ? EC_NOENT
+                              : source_read.locations.error_codes[0];
+    } else {
+        const auto source_iter = source_location_maps[0].find(request.src_location_id);
+        if (source_iter != source_location_maps[0].end() && source_iter->second != nullptr) {
+            source_location = source_iter->second.get();
+        } else {
+            source_check_ec = EC_NOENT;
+        }
+    }
+    const bool source_matches = source_location != nullptr && source_location->status() == CLS_SERVING &&
+                                source_location->create_time() > 0 &&
+                                (request.src_create_time <= 0 ||
+                                 request.src_create_time == source_location->create_time());
+    if (source_check_ec != EC_OK || !source_matches || source_location->location_specs().empty()) {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        RemovePreparingTaskLocked(request.instance_id, request.block_key);
+        return source_check_ec != EC_OK ? source_check_ec : EC_MISMATCH;
+    }
+    request.src_create_time = source_location->create_time();
+    request.src_specs = source_location->location_specs();
+    {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        const auto instance_iter = active_tasks_by_instance_.find(request.instance_id);
+        if (instance_iter == active_tasks_by_instance_.end()) {
+            return EC_ERROR;
+        }
+        const auto task_iter = instance_iter->second.find(request.block_key);
+        if (task_iter == instance_iter->second.end() || task_iter->second.state != CopyTaskState::kPreparing) {
+            RemovePreparingTaskLocked(request.instance_id, request.block_key);
+            return EC_ERROR;
+        }
+        task_iter->second.src_create_time = request.src_create_time;
+    }
+    source_lease_guard.unlock();
     auto release_preparing = [&]() {
         std::lock_guard<std::mutex> lock(task_mutex_);
         RemovePreparingTaskLocked(request.instance_id, request.block_key);
@@ -771,7 +1295,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
                                     return request.instance_id == first_req.instance_id &&
                                            request.dst_storage_name == first_req.dst_storage_name &&
                                            !request.src_location_id.empty() && !request.src_storage_name.empty() &&
-                                           !request.src_specs.empty();
+                                           !request.src_specs.empty() && request.src_create_time > 0;
                                 });
     if (!prepared_batch) {
         KVCM_LOG_WARN(
@@ -804,6 +1328,13 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
         }
         return collect_results();
     }
+    if (schedule_plan_executor_ == nullptr) {
+        for (auto &item : items) {
+            item.MarkFailed(EC_ERROR);
+        }
+        return collect_results();
+    }
+    auto source_lease_guard = schedule_plan_executor_->AcquireSourceLocationLeaseReservationGuard();
 
     // ---- phase 0: group 级 Copy 硬限流 + per-block dedup + draining gate + preparing reservation ----
     // 所有 eligible item 必须在释放短准入锁、执行任何 batch Create/AddLocation 前进入
@@ -876,6 +1407,57 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
         release_all_preparing();
         return collect_results();
     }
+
+    // ---- phase 0.5: exact source generation recheck, before target allocation ----
+    // The reservation guard is still held, so delete admission cannot pass
+    // its lease check and CAS between this read and lease publication.
+    KeyVector source_recheck_keys;
+    std::vector<BatchCopyItem *> source_recheck_items;
+    for (auto &item : items) {
+        if (item.eligible) {
+            source_recheck_keys.push_back(item.request.block_key);
+            source_recheck_items.push_back(&item);
+        }
+    }
+    if (!source_recheck_keys.empty()) {
+        CacheLocationMapVector source_location_maps;
+        PropertyMapVector unused_properties;
+        RequestContext source_recheck_context(trace_id.empty() ? "migration_batch_source_recheck" : trace_id);
+        const auto source_read = indexer->GetForMaintenance(&source_recheck_context,
+                                                            source_recheck_keys,
+                                                            {},
+                                                            source_location_maps,
+                                                            unused_properties);
+        const bool shape_ok = source_read.locations.error_codes.size() == source_recheck_items.size() &&
+                              source_location_maps.size() == source_recheck_items.size();
+        for (size_t i = 0; i < source_recheck_items.size(); ++i) {
+            auto &item = *source_recheck_items[i];
+            ErrorCode source_check_ec = EC_OK;
+            const CacheLocation *source_location = nullptr;
+            if (!shape_ok) {
+                source_check_ec = EC_ERROR;
+            } else if (source_read.locations.error_codes[i] != EC_OK) {
+                source_check_ec = source_read.locations.error_codes[i] == EC_NOENT
+                                      ? EC_NOENT
+                                      : source_read.locations.error_codes[i];
+            } else {
+                const auto source_iter = source_location_maps[i].find(item.request.src_location_id);
+                if (source_iter != source_location_maps[i].end() && source_iter->second != nullptr) {
+                    source_location = source_iter->second.get();
+                } else {
+                    source_check_ec = EC_NOENT;
+                }
+            }
+            if (source_check_ec != EC_OK || source_location == nullptr ||
+                source_location->status() != CLS_SERVING ||
+                source_location->create_time() != item.request.src_create_time) {
+                item.MarkFailed(source_check_ec != EC_OK ? source_check_ec : EC_MISMATCH);
+                release_preparing(item);
+            }
+        }
+    }
+    source_lease_guard.unlock();
+
     auto dst_backend = data_storage_manager_ ? data_storage_manager_->GetDataStorageBackend(first_req.dst_storage_name)
                                              : nullptr;
     if (!dst_backend) {
@@ -1024,7 +1606,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
         MetaSearcher meta_searcher(indexer);
         std::vector<MetaSearcher::AddLocationResult> add_results;
         ErrorCode add_ec =
-            meta_searcher.BatchAddLocation(batch_ctx.get(), add_block_keys, add_locations, add_results);
+            meta_searcher.BatchAddLocation(batch_ctx.get(), add_block_keys, add_locations, add_results, true);
         if (add_results.size() != add_items.size()) {
             KVCM_LOG_WARN("[%s] BatchAddLocation returned unexpected result count for migration batch: expected %zu, "
                           "got %zu, aggregate ec %d; retaining allocated URIs",
@@ -1194,12 +1776,13 @@ bool MigrationManager::IsSourceLocationServing(const CopyTaskContext &ctx) const
         return false;
     }
 
-    MetaSearcher meta_searcher(indexer);
     auto rc = std::make_shared<RequestContext>("migration_check_source");
     std::vector<CacheLocationMap> location_maps;
-    BlockMask empty_mask;
-    ErrorCode ec = meta_searcher.BatchGetLocation(rc.get(), {ctx.block_key}, empty_mask, location_maps);
-    if (ec != EC_OK || location_maps.empty()) {
+    PropertyMapVector unused_properties;
+    const auto read_result =
+        indexer->GetForMaintenance(rc.get(), {ctx.block_key}, {}, location_maps, unused_properties);
+    if (read_result.locations.error_codes.size() != 1 || read_result.locations.error_codes[0] != EC_OK ||
+        location_maps.size() != 1) {
         return false;
     }
     auto iter = location_maps[0].find(ctx.src_location_id);
@@ -1225,6 +1808,11 @@ void MigrationManager::CompleteCopyTaskAsFailed(const CopyTaskContext &ctx, cons
                                     .count();
     if (metrics_enabled_) {
         ++m_tasks_completed_failed_;
+    }
+    if (fail_reason == "source_lost") {
+        AddCounterMetric("migration_copy_source_lost_written_bytes_total",
+                         {{"src", ctx.src_storage_name}, {"dst", ctx.dst_storage_name}},
+                         ctx.total_bytes);
     }
     if (event_manager_ != nullptr) {
         auto ev = std::make_shared<MigrationCompletedEvent>(ctx.instance_id);
@@ -1282,7 +1870,8 @@ void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
         std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks{
             {MetaSearcher::LocationCASTask{ctx.dst_location_id, CLS_WRITING, CLS_SERVING}}};
         std::vector<std::vector<ErrorCode>> cas_results;
-        ErrorCode ec = meta_searcher.BatchCASLocationStatus(rc.get(), {block_key}, cas_tasks, cas_results);
+        ErrorCode ec =
+            meta_searcher.BatchCASLocationStatus(rc.get(), {block_key}, cas_tasks, cas_results, false, true);
         promoted = (ec == EC_OK && !cas_results.empty() && !cas_results[0].empty() && cas_results[0][0] == EC_OK);
     }
 
@@ -1300,15 +1889,14 @@ void MigrationManager::OnTaskSuccess(const std::string &instance_id, int64_t blo
         ClearTieredWriteMarkIfMatchInternal(ctx.instance_id, block_key, ctx.mark_target, ctx.mark_deadline_ms);
     }
 
-    // 按 retention 处理源端。
-    if (ctx.retention == MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE) {
-        SubmitSourceLocationDelete(ctx);
-    }
-
-    // 最后移除活跃任务。
+    // 先释放 active task/source lease，再提交带 create_time generation guard
+    // 的源删除。否则删除 admission 会正确地把本任务自己的源删除也挡掉。
     {
         std::lock_guard<std::mutex> lock(task_mutex_);
         RemoveActiveTaskLocked(ctx.instance_id, block_key);
+    }
+    if (ctx.retention == MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE) {
+        SubmitSourceLocationDelete(ctx);
     }
     stat_copy_completed_.fetch_add(1, std::memory_order_relaxed);
     const int64_t duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1386,6 +1974,7 @@ void MigrationManager::SubmitSourceLocationDelete(const CopyTaskContext &ctx) {
     del_req.instance_id = ctx.instance_id;
     del_req.block_keys = {ctx.block_key};
     del_req.location_ids = {{ctx.src_location_id}};
+    del_req.expected_location_create_times = {{ctx.src_create_time}};
     schedule_plan_executor_->SubmitNonBlocking(del_req, ScheduleTaskClass::kMigrationContinuation);
 }
 
@@ -1441,8 +2030,25 @@ ErrorCode MigrationManager::MarkForTieredWrite(const std::string &instance_id,
                                                const std::vector<int64_t> &block_keys,
                                                const std::string &dst_storage_name,
                                                int64_t timeout_ms) {
+    return MarkForTieredWriteDetailed(instance_id, block_keys, dst_storage_name, timeout_ms).ec;
+}
+
+MigrationManager::MarkWriteResult MigrationManager::MarkForTieredWriteDetailed(
+    const std::string &instance_id,
+    const std::vector<int64_t> &block_keys,
+    const std::string &dst_storage_name,
+    int64_t timeout_ms) {
+    MarkWriteResult write_result;
+    write_result.outcomes.resize(block_keys.size());
     if (dst_storage_name.empty() || block_keys.empty()) {
-        return EC_OK;
+        if (dst_storage_name.empty() && !block_keys.empty()) {
+            write_result.ec = EC_BADARGS;
+            for (auto &outcome : write_result.outcomes) {
+                outcome.status = MarkWriteStatus::kWriteError;
+                outcome.ec = EC_BADARGS;
+            }
+        }
+        return write_result;
     }
     // 新 Mark 只写入当前可分配的 target；已存在 Mark 遇到 quota 满或 unavailable 时由消费
     // 路径暂时忽略并保留，待容量/可用性恢复后自愈。
@@ -1453,7 +2059,12 @@ ErrorCode MigrationManager::MarkForTieredWrite(const std::string &instance_id,
                       dst_storage_name.c_str(),
                       instance_id.c_str(),
                       target_ec);
-        return target_ec;
+        write_result.ec = target_ec;
+        for (auto &outcome : write_result.outcomes) {
+            outcome.status = MarkWriteStatus::kWriteError;
+            outcome.ec = target_ec;
+        }
+        return write_result;
     }
     if (timeout_ms <= 0) {
         timeout_ms = MigrationMarkMethod::kDefaultTimeoutMs;
@@ -1461,48 +2072,94 @@ ErrorCode MigrationManager::MarkForTieredWrite(const std::string &instance_id,
     auto indexer = GetIndexer(instance_id);
     if (indexer == nullptr) {
         KVCM_LOG_WARN("MarkForTieredWrite: meta indexer not found for instance %s", instance_id.c_str());
-        return EC_INSTANCE_NOT_EXIST;
+        write_result.ec = EC_INSTANCE_NOT_EXIST;
+        for (auto &outcome : write_result.outcomes) {
+            outcome.status = MarkWriteStatus::kReadError;
+            outcome.ec = EC_INSTANCE_NOT_EXIST;
+        }
+        return write_result;
     }
     const int64_t now_ms = TimestampUtil::GetCurrentTimeMs();
     if (timeout_ms > std::numeric_limits<int64_t>::max() - now_ms) {
         KVCM_LOG_WARN(
             "MarkForTieredWrite: timeout %ld overflows deadline for instance %s", timeout_ms, instance_id.c_str());
-        return EC_BADARGS;
+        write_result.ec = EC_BADARGS;
+        for (auto &outcome : write_result.outcomes) {
+            outcome.status = MarkWriteStatus::kWriteError;
+            outcome.ec = EC_BADARGS;
+        }
+        return write_result;
     }
     const int64_t deadline_ms = now_ms + timeout_ms;
-    // 记录实际成功打标的 key index，供 stat/expiry/event 仅按 actual 口径更新。
-    // modifier 在 RMW 批次内按 global_idx 回调，顺序对齐 block_keys。
-    std::vector<bool> mark_succeeded(block_keys.size(), false);
-    // RMW：只写 property（out_new_locations 留空，不动 location）。不存在的 block 跳过（不给空 block 打标）。
-    auto modifier = [&dst_storage_name, deadline_ms, &mark_succeeded](const LocationIdVector & /*existing*/,
-                                                                     ErrorCode get_ec,
-                                                                     size_t idx,
-                                                                     PropertyMap &upsert_property_map,
-                                                                     CacheLocationMap & /*out_new*/) -> ModifierResult {
+    // 条件判断和 property 写入共享同一个 metadata shard 临界区。预查询只用于减少 I/O，
+    // 不承担并发正确性；modifier 只记录计划结果，最终以逐 key backend commit 为准。
+    auto modifier = [&dst_storage_name, now_ms, deadline_ms, &write_result](
+                        const LocationIdVector & /*existing*/,
+                        const PropertyMap &existing_properties,
+                        ErrorCode get_ec,
+                        size_t idx,
+                        PropertyMap &upsert_property_map,
+                        CacheLocationMap & /*out_new*/) -> ModifierResult {
+        auto &outcome = write_result.outcomes[idx];
         if (get_ec == EC_NOENT) {
+            outcome.status = MarkWriteStatus::kBlockNotFound;
+            outcome.ec = EC_NOENT;
             return {MA_SKIP, EC_OK};
         }
         if (get_ec != EC_OK) {
+            outcome.status = MarkWriteStatus::kReadError;
+            outcome.ec = get_ec;
             return {MA_FAIL, get_ec};
+        }
+        const MarkInfo existing_mark = ParseMarkFromProperties(existing_properties, now_ms);
+        if (existing_mark.malformed) {
+            outcome.status = MarkWriteStatus::kMalformedExistingMark;
+            return {MA_SKIP, EC_OK};
+        }
+        if (!existing_mark.target.empty() && !existing_mark.expired) {
+            outcome.status = existing_mark.target == dst_storage_name
+                                 ? MarkWriteStatus::kAlreadySameTarget
+                                 : MarkWriteStatus::kConflictDifferentTarget;
+            return {MA_SKIP, EC_OK};
         }
         upsert_property_map[PROPERTY_TIERED_WRITE_TARGET] = dst_storage_name;
         upsert_property_map[PROPERTY_TIERED_WRITE_DEADLINE_MS] = std::to_string(deadline_ms);
-        if (idx < mark_succeeded.size()) {
-            mark_succeeded[idx] = true;
-        }
+        outcome.status = MarkWriteStatus::kInserted;
         return {MA_OK, EC_OK};
     };
     RequestContext rc("migration_mark");
     KeyVector keys(block_keys.begin(), block_keys.end());
-    auto result = indexer->ReadModifyWriteBlock(&rc, keys, modifier);
-    // stat/expiry/event 按实际成功数更新（actual 口径），不再用 block_keys.size()（request 口径）。
-    const size_t actual_marked = static_cast<size_t>(std::count(mark_succeeded.begin(), mark_succeeded.end(), true));
+    auto result = indexer->ReadModifyWriteBlockPropertiesForMaintenance(
+        &rc, keys, {PROPERTY_TIERED_WRITE_TARGET, PROPERTY_TIERED_WRITE_DEADLINE_MS}, modifier);
+
+    size_t actual_marked = 0;
+    size_t io_error_count = 0;
+    for (size_t i = 0; i < write_result.outcomes.size(); ++i) {
+        auto &outcome = write_result.outcomes[i];
+        const ErrorCode commit_ec = i < result.error_codes.size() ? result.error_codes[i] : EC_MISMATCH;
+        if (outcome.status == MarkWriteStatus::kInserted && commit_ec != EC_OK) {
+            outcome.status = MarkWriteStatus::kWriteError;
+            outcome.ec = commit_ec;
+        }
+        if (outcome.status == MarkWriteStatus::kReadError && outcome.ec == EC_OK) {
+            outcome.ec = commit_ec != EC_OK ? commit_ec : (result.ec == EC_OK ? EC_ERROR : result.ec);
+        }
+        if (outcome.status == MarkWriteStatus::kInserted) {
+            ++actual_marked;
+        } else if (outcome.status == MarkWriteStatus::kReadError ||
+                   outcome.status == MarkWriteStatus::kWriteError) {
+            ++io_error_count;
+        }
+    }
+    write_result.ec = io_error_count == 0
+                          ? EC_OK
+                          : (io_error_count == write_result.outcomes.size() ? EC_ERROR : EC_PARTIAL_OK);
     if (actual_marked > 0) {
         stat_marks_added_.fetch_add(actual_marked, std::memory_order_relaxed);
     }
     UpdateMarksActiveGauge();
     for (size_t i = 0; i < block_keys.size(); ++i) {
-        if (!mark_succeeded[i]) {
+        if (write_result.outcomes[i].status != MarkWriteStatus::kInserted) {
             continue;
         }
         EnqueueMarkExpiry(instance_id, block_keys[i], dst_storage_name, deadline_ms);
@@ -1513,7 +2170,7 @@ ErrorCode MigrationManager::MarkForTieredWrite(const std::string &instance_id,
             event_manager_->Publish(ev);
         }
     }
-    return result.ec;
+    return write_result;
 }
 
 bool MigrationManager::ClearTieredWriteMarkIfMatch(const std::string &instance_id,
@@ -1538,9 +2195,7 @@ std::string MigrationManager::GetTieredWriteTarget(const std::string &instance_i
     return (ec == EC_OK && !results.empty() && results[0].HasValidMark()) ? results[0].target : std::string();
 }
 
-// match 检查在 RMW modifier 闭包内执行（shard lock 保原子），不需要外部 mark_mutex_。
-// modifier 内通过捕获的 indexer 读 GetProperties（GetProperties 不走 shard lock，不死锁），
-// 读-比较-写三步在同一个 shard lock 内完成，与 BatchCASLocationStatus 同模式。
+// match 检查与写空值在同一个 maintenance block/property RMW 内完成；读取和写入均不 touch。
 bool MigrationManager::ClearTieredWriteMarkIfMatchInternal(const std::string &instance_id,
                                                            int64_t block_key,
                                                            const std::string &expected_target,
@@ -1557,9 +2212,10 @@ bool MigrationManager::ClearTieredWriteMarkIfMatchInternal(const std::string &in
         return false;
     }
 
-    bool cleared = false;
-    auto modifier = [&indexer, block_key, &expected_target, expected_deadline_ms, expect_malformed, &cleared](
+    bool planned_clear = false;
+    auto modifier = [&expected_target, expected_deadline_ms, expect_malformed, &planned_clear](
                         const LocationIdVector & /*existing*/,
+                        const PropertyMap &existing_properties,
                         ErrorCode get_ec,
                         size_t /*idx*/,
                         PropertyMap &upsert_property_map,
@@ -1567,26 +2223,23 @@ bool MigrationManager::ClearTieredWriteMarkIfMatchInternal(const std::string &in
         if (get_ec != EC_OK) {
             return {MA_SKIP, EC_OK};
         }
-        RequestContext check_rc("migration_match_clear_check");
-        PropertyMapVector check_props;
-        const auto check_result = indexer->GetProperties(&check_rc, {block_key},
-            {PROPERTY_TIERED_WRITE_TARGET, PROPERTY_TIERED_WRITE_DEADLINE_MS}, check_props);
-        if (check_result.ec != EC_OK || check_result.error_codes.size() != 1 || check_result.error_codes[0] != EC_OK ||
-            check_props.size() != 1) {
-            return {MA_SKIP, EC_OK};
-        }
-        auto mark = ParseMarkFromProperties(check_props[0], 0);
+        const auto mark = ParseMarkFromProperties(existing_properties, 0);
         if (mark.target != expected_target ||
             (expect_malformed ? !mark.malformed : mark.deadline_ms != expected_deadline_ms)) {
             return {MA_SKIP, EC_OK};
         }
         upsert_property_map[PROPERTY_TIERED_WRITE_TARGET] = "";
         upsert_property_map[PROPERTY_TIERED_WRITE_DEADLINE_MS] = "";
-        cleared = true;
+        planned_clear = true;
         return {MA_OK, EC_OK};
     };
     RequestContext rc("migration_conditional_clear_mark");
-    indexer->ReadModifyWriteBlock(&rc, {block_key}, modifier);
+    const auto rmw_result = indexer->ReadModifyWriteBlockPropertiesForMaintenance(
+        &rc,
+        {block_key},
+        {PROPERTY_TIERED_WRITE_TARGET, PROPERTY_TIERED_WRITE_DEADLINE_MS},
+        modifier);
+    const bool cleared = planned_clear && rmw_result.error_codes.size() == 1 && rmw_result.error_codes[0] == EC_OK;
     if (cleared && !expect_malformed) {
         stat_marks_cleared_.fetch_add(1, std::memory_order_relaxed);
         UpdateMarksActiveGauge();
@@ -1644,8 +2297,8 @@ ErrorCode MigrationManager::BatchGetTieredWriteTargets(const std::string &instan
     RequestContext rc("migration_query_mark_batch");
     KeyVector keys(block_keys.begin(), block_keys.end());
     PropertyMapVector props;
-    const auto query_result =
-        indexer->GetProperties(&rc, keys, {PROPERTY_TIERED_WRITE_TARGET, PROPERTY_TIERED_WRITE_DEADLINE_MS}, props);
+    const auto query_result = indexer->GetPropertiesForMaintenance(
+        &rc, keys, {PROPERTY_TIERED_WRITE_TARGET, PROPERTY_TIERED_WRITE_DEADLINE_MS}, props);
     if (query_result.error_codes.size() != block_keys.size() || props.size() != block_keys.size()) {
         KVCM_LOG_WARN("mark query result shape mismatch for instance %s: keys %zu, per_key_ec %zu, props %zu, "
                       "aggregate ec %d",
@@ -1854,6 +2507,7 @@ bool MigrationManager::ReservePreparingTaskLocked(const MigrationRequest &reques
     ctx.dst_storage_name = request.dst_storage_name;
     ctx.retention = request.retention;
     ctx.state = CopyTaskState::kPreparing;
+    ctx.source_lease_start_time = std::chrono::steady_clock::now();
     // InsertActiveTaskLocked 在同一个 task_mutex_ 临界区内完成存在性检查与插入，避免 check-then-insert 窗口。
     return InsertActiveTaskLocked(std::move(ctx));
 }
@@ -1867,7 +2521,9 @@ bool MigrationManager::UpdatePreparingTaskLocked(const CopyTaskContext &ctx) {
     if (task_iter == instance_iter->second.end() || task_iter->second.state != CopyTaskState::kPreparing) {
         return false;
     }
+    const auto source_lease_start_time = task_iter->second.source_lease_start_time;
     task_iter->second = ctx;
+    task_iter->second.source_lease_start_time = source_lease_start_time;
     task_iter->second.state = CopyTaskState::kPreparing;
     return true;
 }
@@ -1903,14 +2559,24 @@ bool MigrationManager::RemoveActiveTaskLocked(const std::string &instance_id, in
     if (instance_iter == active_tasks_by_instance_.end()) {
         return false;
     }
-    const size_t erased = instance_iter->second.erase(block_key);
-    if (erased == 0) {
+    const auto task_iter = instance_iter->second.find(block_key);
+    if (task_iter == instance_iter->second.end()) {
         return false;
     }
+    const CopyTaskContext removed_task = task_iter->second;
+    instance_iter->second.erase(task_iter);
     if (instance_iter->second.empty()) {
         active_tasks_by_instance_.erase(instance_iter); // 内层空则收回外层，避免 stale 空 map
     }
     UpdateActiveTasksGauge();
+    if (removed_task.source_lease_start_time.time_since_epoch().count() != 0) {
+        const auto lease_duration_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                           std::chrono::steady_clock::now() -
+                                           removed_task.source_lease_start_time)
+                                           .count();
+        ObserveSourceLeaseDuration(
+            removed_task.src_storage_name, removed_task.dst_storage_name, lease_duration_us);
+    }
     return true;
 }
 
@@ -2001,6 +2667,40 @@ bool MigrationManager::HasActiveCopyTargetLocation(const std::string &instance_i
         return true;
     }
     return task.dst_location_id == location_id;
+}
+
+bool MigrationManager::HasActiveCopySourceLocation(const std::string &instance_id,
+                                                   int64_t block_key,
+                                                   const std::string &location_id,
+                                                   int64_t create_time) const {
+    if (location_id.empty() || create_time <= 0) {
+        return false;
+    }
+    std::string src_storage_name;
+    std::string dst_storage_name;
+    bool leased = false;
+    {
+        std::lock_guard<std::mutex> lock(task_mutex_);
+        const auto instance_iter = active_tasks_by_instance_.find(instance_id);
+        if (instance_iter == active_tasks_by_instance_.end()) {
+            return false;
+        }
+        const auto task_iter = instance_iter->second.find(block_key);
+        if (task_iter == instance_iter->second.end()) {
+            return false;
+        }
+        const CopyTaskContext &task = task_iter->second;
+        leased = task.src_location_id == location_id && task.src_create_time == create_time;
+        if (leased) {
+            src_storage_name = task.src_storage_name;
+            dst_storage_name = task.dst_storage_name;
+        }
+    }
+    if (leased) {
+        AddCounterMetric("migration_source_lease_conflicts_total",
+                         {{"src", src_storage_name}, {"dst", dst_storage_name}, {"deleter", "scheduled_delete"}});
+    }
+    return leased;
 }
 
 size_t MigrationManager::ActiveTaskCountUnsafe() const {
@@ -2131,7 +2831,13 @@ MigrationManager::CopyAdmission MigrationManager::CheckCopyAdmission(const std::
             continue;
         }
         // 该 source 既未被 SERVING 也未被 SERVING∪WRITING 联合覆盖 → 需要 copy。
-        return {CopyAdmissionStatus::kAccept, src_loc};
+        std::vector<LocationSpec> missing_specs;
+        missing_specs.reserve(src_loc->location_specs().size());
+        std::copy_if(src_loc->location_specs().begin(),
+                     src_loc->location_specs().end(),
+                     std::back_inserter(missing_specs),
+                     [&all_covered](const LocationSpec &spec) { return all_covered.count(spec.name()) == 0; });
+        return {CopyAdmissionStatus::kAccept, src_loc, std::move(missing_specs)};
     }
 
     // 循环走完未 return kAccept：每个 source 都被 serving∪writing 覆盖。
@@ -2167,6 +2873,17 @@ MigrationManager::SelectMigrationCandidateKeys(RequestContext *request_context,
         KVCM_LOG_WARN("[%s] MigrateCache sample keys failed, ec %d", trace_id.c_str(), ec);
         return {ec, {}};
     }
+    // Sampling backends may return the same block more than once. Preserve
+    // first-seen order so a block consumes one action/Copy slot and receives
+    // exactly one terminal outcome, just like explicit Admin keys and the
+    // Reclaimer candidate builder.
+    std::unordered_set<int64_t> seen;
+    seen.reserve(candidate_keys.size());
+    candidate_keys.erase(
+        std::remove_if(candidate_keys.begin(),
+                       candidate_keys.end(),
+                       [&seen](int64_t block_key) { return !seen.insert(block_key).second; }),
+        candidate_keys.end());
     return {EC_OK, std::move(candidate_keys)};
 }
 
@@ -2313,34 +3030,6 @@ void MigrationManager::RunAsyncMigrationPrepare(AsyncMigrationPrepareJob job, st
             return {};
         }
 
-        const auto indexer = meta_indexer_manager_->GetMetaIndexer(job.instance_id);
-        if (!indexer) {
-            return {};
-        }
-        MetaSearcher meta_searcher(indexer);
-        std::vector<CacheLocationMap> loc_maps;
-        BlockMask empty_mask;
-        if (meta_searcher.BatchGetLocation(request_context.get(), job.block_keys, empty_mask, loc_maps) != EC_OK ||
-            loc_maps.size() != job.block_keys.size()) {
-            return {};
-        }
-
-        for (std::size_t block_idx = 0; block_idx < loc_maps.size(); ++block_idx) {
-            if (job.pending_location_ids_by_block[block_idx].empty()) {
-                continue;
-            }
-            const std::unordered_set<std::string> pending_ids(job.pending_location_ids_by_block[block_idx].begin(),
-                                                              job.pending_location_ids_by_block[block_idx].end());
-            auto &loc_map = loc_maps[block_idx];
-            for (auto it = loc_map.begin(); it != loc_map.end();) {
-                if (pending_ids.count(it->first) > 0) {
-                    it = loc_map.erase(it);
-                } else {
-                    ++it;
-                }
-            }
-        }
-
         const auto configured_copy_concurrency = cache_config->migration_copy_max_concurrency();
         const std::size_t max_concurrent_copy =
             configured_copy_concurrency > 0 ? static_cast<std::size_t>(configured_copy_concurrency) : 0;
@@ -2352,13 +3041,15 @@ void MigrationManager::RunAsyncMigrationPrepare(AsyncMigrationPrepareJob job, st
         params.max_copy_slots = max_concurrent_copy > active_copy_count ? max_concurrent_copy - active_copy_count : 0;
         params.retention = current_strategy->retention();
         params.mark_timeout_ms = current_strategy->methods().mark().timeout_ms();
-        params.dedup_marks = true;
+        params.admission = current_strategy->admission();
+        params.trigger = DispatchBatchParams::Trigger::kReclaimer;
+        params.action_budget = job.action_budget;
+        params.pending_location_ids_by_block = std::move(job.pending_location_ids_by_block);
         return DispatchMigrationBatchWithLifecycleLockHeld(job.trace_id,
                                                             job.instance_id,
                                                             job.source_storage_name,
                                                             job.target_storage_name,
                                                             job.block_keys,
-                                                            loc_maps,
                                                             params);
     };
 
@@ -2387,7 +3078,9 @@ MigrationManager::MigrateResult MigrationManager::MigrateCache(RequestContext *r
                                                               const std::vector<int64_t> &explicit_block_keys,
                                                               int64_t sample_count,
                                                               std::size_t copy_max_concurrency,
-                                                              int64_t mark_timeout_ms) {
+                                                              int64_t mark_timeout_ms,
+                                                              MigrationRetention retention,
+                                                              const MigrationAdmissionConfig &admission_config) {
     MigrateResult result;
 
     // meta_indexer 由 facade 保证非空（instance 存在性已前置校验）；防御性再查一次。
@@ -2406,7 +3099,6 @@ MigrationManager::MigrateResult MigrationManager::MigrateCache(RequestContext *r
         return result;
     }
 
-    const int64_t total = static_cast<int64_t>(candidate_keys.size());
     if (candidate_keys.empty()) {
         result.ec = EC_OK;
         result.accepted = 0;
@@ -2415,30 +3107,25 @@ MigrationManager::MigrateResult MigrationManager::MigrateCache(RequestContext *r
         return result;
     }
 
-    // 2. 取各 block 的 location，准入过滤（在源 storage 上、SERVING、未在迁移中、目标无副本）。
-    MetaSearcher meta_searcher(meta_indexer);
-    std::vector<CacheLocationMap> loc_maps;
-    BlockMask empty_mask;
-    if (const auto ec = meta_searcher.BatchGetLocation(request_context, candidate_keys, empty_mask, loc_maps);
-        ec != EC_OK || loc_maps.size() != candidate_keys.size()) {
-        result.ec = EC_ERROR;
-        result.message = "get cache location failed";
-        return result;
-    }
-
     // 准入、分发和 fallback 委派共享 DispatchMigrationBatch。
     DispatchBatchParams params;
     params.do_copy = do_copy;
     params.do_mark = do_mark;
     params.copy_limit = CopyConcurrencyLimit{instance_group_name, copy_max_concurrency};
+    params.retention = retention;
     params.mark_timeout_ms = mark_timeout_ms;
-    const auto dispatch =
-        DispatchMigrationBatch(trace_id, instance_id, src_name, dst_name, candidate_keys, loc_maps, params);
+    params.admission = admission_config;
+    params.trigger = DispatchBatchParams::Trigger::kAdmin;
+    const auto dispatch = DispatchMigrationBatch(trace_id, instance_id, src_name, dst_name, candidate_keys, params);
 
-    result.ec = EC_OK;
+    result.ec = dispatch.ec;
     result.accepted = dispatch.copy_submitted + dispatch.mark_submitted;
-    result.rejected = total - result.accepted;
-    result.message = "migrate cache dispatched";
+    // Legacy projection: rejected means "did not create a new Copy/Mark" and
+    // therefore includes precise rejected/noop/failed terminal classes. New
+    // callers should use outcome_counts for the authoritative breakdown.
+    result.rejected = dispatch.rejected + dispatch.noop + dispatch.failed;
+    result.outcome_counts = dispatch.outcome_counts;
+    result.message = dispatch.ec == EC_OK ? "migrate cache dispatched" : "migration dispatch failed";
     return result;
 }
 
@@ -2448,23 +3135,50 @@ MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatch(
     const std::string &src_name,
     const std::string &dst_name,
     const std::vector<int64_t> &batch,
-    const std::vector<CacheLocationMap> &loc_maps,
     const DispatchBatchParams &params) {
     DispatchBatchResult result;
-    if (batch.empty() || loc_maps.size() != batch.size()) {
-        return result;
+    if (batch.empty()) {
+        return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
+    }
+    if (!params.pending_location_ids_by_block.empty() &&
+        params.pending_location_ids_by_block.size() != batch.size()) {
+        result.ec = EC_BADARGS;
+        result.failed = static_cast<int64_t>(batch.size());
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kSnapshot,
+                   MigrationOutcomeClass::kFailed,
+                   MigrationOutcomeReason::kSnapshotShapeError,
+                   result.failed,
+                   true);
+        return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
     }
     if (!accepting_copy_submissions_.load(std::memory_order_acquire)) {
-        return result;
+        result.ec = EC_ERROR;
+        result.failed = static_cast<int64_t>(batch.size());
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kSnapshot,
+                   MigrationOutcomeClass::kFailed,
+                   MigrationOutcomeReason::kDispatchNotAvailable,
+                   result.failed,
+                   true);
+        return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
     }
     // Copy 与 Mark 必须位于同一个 leader-lifecycle barrier 内。否则 Stop 可能在异步 Job
     // 完成 fresh read 后关闭 Copy gate，但 Job 仍继续写入 Mark。
     std::shared_lock<std::shared_mutex> lifecycle_lock(copy_submission_lifecycle_mutex_);
     if (!accepting_copy_submissions_.load(std::memory_order_acquire)) {
-        return result;
+        result.ec = EC_ERROR;
+        result.failed = static_cast<int64_t>(batch.size());
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kSnapshot,
+                   MigrationOutcomeClass::kFailed,
+                   MigrationOutcomeReason::kDispatchNotAvailable,
+                   result.failed,
+                   true);
+        return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
     }
     return DispatchMigrationBatchWithLifecycleLockHeld(
-        trace_id, instance_id, src_name, dst_name, batch, loc_maps, params);
+        trace_id, instance_id, src_name, dst_name, batch, params);
 }
 
 MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatchWithLifecycleLockHeld(
@@ -2473,45 +3187,351 @@ MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatchWi
     const std::string &src_name,
     const std::string &dst_name,
     const std::vector<int64_t> &batch,
-    const std::vector<CacheLocationMap> &loc_maps,
     const DispatchBatchParams &params) {
     DispatchBatchResult result;
-    if (batch.empty() || loc_maps.size() != batch.size()) {
+    if (batch.empty()) {
         return result;
     }
+    if (!params.pending_location_ids_by_block.empty() &&
+        params.pending_location_ids_by_block.size() != batch.size()) {
+        result.ec = EC_BADARGS;
+        result.failed = static_cast<int64_t>(batch.size());
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kSnapshot,
+                   MigrationOutcomeClass::kFailed,
+                   MigrationOutcomeReason::kSnapshotShapeError,
+                   result.failed,
+                   true);
+        return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
+    }
+    const auto indexer = GetIndexer(instance_id);
+    if (indexer == nullptr) {
+        result.ec = EC_INSTANCE_NOT_EXIST;
+        result.failed = static_cast<int64_t>(batch.size());
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kSnapshot,
+                   MigrationOutcomeClass::kFailed,
+                   MigrationOutcomeReason::kDispatchNotAvailable,
+                   result.failed,
+                   true);
+        return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
+    }
 
-    // 10a: mark 去重用 batch 查询替代逐 block IsMarkedForTieredWrite（N 次 meta 往返 → 1 次）。
-    std::unordered_set<int64_t> already_marked;
-    std::unordered_set<int64_t> mark_query_failed;
-    if (params.do_mark && params.dedup_marks) {
-        std::vector<MarkQueryResult> mark_results;
-        const auto mark_query_ec = BatchGetTieredWriteTargets(instance_id, batch, mark_results);
-        if (mark_query_ec != EC_OK) {
-            KVCM_LOG_WARN("[%s] mark dedup query partially failed for instance %s, ec %d; failed keys will retry",
+    std::string policy_error;
+    auto policy = MigrationAdmissionPolicyFactory::Build(params.admission, policy_error);
+    if (params.admission.mode() != MigrationAdmissionMode::DISABLED && policy == nullptr) {
+        KVCM_LOG_WARN("[%s] invalid migration admission policy for %s -> %s: %s",
+                      trace_id.c_str(),
+                      src_name.c_str(),
+                      dst_name.c_str(),
+                      policy_error.c_str());
+        if (params.admission.mode() != MigrationAdmissionMode::SHADOW) {
+            result.ec = EC_CONFIG_ERROR;
+            result.failed = static_cast<int64_t>(batch.size());
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kValue,
+                       MigrationOutcomeClass::kFailed,
+                       MigrationOutcomeReason::kPolicyContractError,
+                       result.failed,
+                       true);
+            return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
+        }
+        // SHADOW is behavior-neutral even when a malformed/recovered config
+        // reaches this defensive runtime check. Record the projected fault and
+        // continue through the legacy location/execution path.
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kValue,
+                   MigrationOutcomeClass::kFailed,
+                   MigrationOutcomeReason::kPolicyContractError,
+                   static_cast<int64_t>(batch.size()),
+                   false);
+    }
+
+    const MigrationAdmissionFeatureSet required_features =
+        policy ? policy->RequiredFeatures() : MigrationAdmissionFeatureSet{};
+    std::vector<std::string> property_names;
+    bool last_access_provider_ready = true;
+    if (required_features.test(static_cast<size_t>(MigrationAdmissionFeature::kLastAccessTime))) {
+        property_names.push_back(PROPERTY_LRU_TIME);
+        const auto readiness = indexer->GetMaintenancePropertyReadiness(PROPERTY_LRU_TIME);
+        last_access_provider_ready = readiness.capability == MaintenancePropertyCapability::kDurableAcrossRecovery;
+        if (readiness.capability == MaintenancePropertyCapability::kProcessLocalVolatile) {
+            const auto &policies = params.admission.policies();
+            const int64_t window_seconds = policies.empty() || policies.front() == nullptr ||
+                                                   policies.front()->recent_access() == nullptr
+                                               ? 0
+                                               : policies.front()->recent_access()->window_seconds();
+            const int64_t steady_now = TimestampUtil::GetSteadyTimeUs();
+            const bool window_valid = window_seconds > 0 &&
+                                      window_seconds <= std::numeric_limits<int64_t>::max() / (1000 * 1000);
+            last_access_provider_ready = window_valid && readiness.valid_since_steady_us > 0 &&
+                                         steady_now >= readiness.valid_since_steady_us &&
+                                         steady_now - readiness.valid_since_steady_us >=
+                                             window_seconds * 1000 * 1000;
+        }
+        MetricsTags readiness_tags{{"instance", instance_id},
+                                   {"src", src_name},
+                                   {"dst", dst_name},
+                                   {"feature", "last_access_time"}};
+        SetGaugeMetric("migration_admission_readiness", readiness_tags, last_access_provider_ready ? 1.0 : 0.0);
+        if (!last_access_provider_ready) {
+            readiness_tags["reason"] =
+                readiness.capability == MaintenancePropertyCapability::kUnsupported ? "unsupported" : "warmup";
+            AddCounterMetric("migration_admission_readiness_not_ready_total", std::move(readiness_tags));
+        }
+        if (params.admission.mode() == MigrationAdmissionMode::ENFORCE && !last_access_provider_ready) {
+            result.ec = readiness.capability == MaintenancePropertyCapability::kUnsupported ? EC_CONFIG_ERROR
+                                                                                             : EC_ERROR;
+            result.failed = static_cast<int64_t>(batch.size());
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kSnapshot,
+                       MigrationOutcomeClass::kFailed,
+                       MigrationOutcomeReason::kRouteNotReady,
+                       result.failed,
+                       true);
+            KVCM_LOG_WARN("[%s] migration admission route not ready for instance %s, src %s, dst %s, "
+                          "capability %d, generation %llu",
                           trace_id.c_str(),
                           instance_id.c_str(),
-                          mark_query_ec);
-        }
-        for (std::size_t i = 0; i < batch.size() && i < mark_results.size(); ++i) {
-            if (mark_results[i].HasValidMark()) {
-                already_marked.insert(batch[i]);
-            } else if (mark_results[i].IsReadError()) {
-                // 无法确认已有 mark 时不覆盖未知状态，留待下一轮 reclaimer 重试。
-                mark_query_failed.insert(batch[i]);
-            }
+                          src_name.c_str(),
+                          dst_name.c_str(),
+                          static_cast<int>(readiness.capability),
+                          static_cast<unsigned long long>(readiness.generation));
+            return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
         }
     }
 
-    // 准入过滤 + 收集 copy / mark 候选
+    CacheLocationMapVector location_maps;
+    PropertyMapVector property_maps;
+    RequestContext snapshot_context(trace_id.empty() ? "migration_admission_snapshot" : trace_id);
+    const auto snapshot_result =
+        indexer->GetForMaintenance(&snapshot_context, batch, property_names, location_maps, property_maps);
+    if (snapshot_result.locations.error_codes.size() != batch.size() || location_maps.size() != batch.size() ||
+        snapshot_result.properties.error_codes.size() != batch.size() || property_maps.size() != batch.size()) {
+        result.ec = EC_MISMATCH;
+        result.failed = static_cast<int64_t>(batch.size());
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kSnapshot,
+                   MigrationOutcomeClass::kFailed,
+                   MigrationOutcomeReason::kSnapshotShapeError,
+                   result.failed,
+                   true);
+        return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
+    }
+
+    struct PreparedCandidate {
+        size_t original_index = 0;
+        int64_t block_key = 0;
+        CacheLocationMap locations;
+        MigrationCandidateFeatures features;
+        int64_t last_access_time_us = 0;
+    };
+    std::vector<PreparedCandidate> location_valid_candidates;
+    std::vector<MigrationCandidateFeatures> policy_inputs;
+    location_valid_candidates.reserve(batch.size());
+    policy_inputs.reserve(batch.size());
+    int64_t hard_location_failures = 0;
+    int64_t hard_feature_failures = 0;
+    const int64_t admission_now_us = TimestampUtil::GetCurrentTimeUs();
+    for (size_t i = 0; i < batch.size(); ++i) {
+        const ErrorCode location_ec = snapshot_result.locations.error_codes[i];
+        if (location_ec != EC_OK) {
+            if (location_ec == EC_NOENT) {
+                ++result.rejected;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kSnapshot,
+                           MigrationOutcomeClass::kRejected,
+                           MigrationOutcomeReason::kSourceNotFound,
+                           1,
+                           true);
+            } else {
+                ++result.failed;
+                ++hard_location_failures;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kSnapshot,
+                           MigrationOutcomeClass::kFailed,
+                           MigrationOutcomeReason::kLocationReadError,
+                           1,
+                           true);
+            }
+            continue;
+        }
+        PreparedCandidate candidate;
+        candidate.original_index = i;
+        candidate.block_key = batch[i];
+        candidate.locations = std::move(location_maps[i]);
+        bool terminal_feature_failure = false;
+
+        if (required_features.test(static_cast<size_t>(MigrationAdmissionFeature::kLastAccessTime))) {
+            ObservedFeature feature;
+            if (!last_access_provider_ready) {
+                feature.status = ObservedFeatureStatus::kUnsupported;
+            } else if (snapshot_result.properties.error_codes[i] == EC_NOENT) {
+                // In a dual backend, location may be recovered from the
+                // persistent side while process-local recency remains
+                // intentionally unavailable. That is a missing feature, not
+                // an infrastructure read failure.
+                feature.status = ObservedFeatureStatus::kMissing;
+            } else if (snapshot_result.properties.error_codes[i] != EC_OK) {
+                feature.status = ObservedFeatureStatus::kReadError;
+                if (params.admission.mode() == MigrationAdmissionMode::ENFORCE) {
+                    ++hard_feature_failures;
+                    ++result.failed;
+                    terminal_feature_failure = true;
+                    AddOutcome(result.outcome_counts,
+                               MigrationOutcomeStage::kSnapshot,
+                               MigrationOutcomeClass::kFailed,
+                               MigrationOutcomeReason::kFeatureReadError,
+                               1,
+                               true);
+                }
+            } else {
+                const auto property = property_maps[i].find(PROPERTY_LRU_TIME);
+                if (property == property_maps[i].end()) {
+                    feature.status = ObservedFeatureStatus::kMissing;
+                } else if (const auto value = ParsePositiveInt64(property->second); value.has_value()) {
+                    feature.status = ObservedFeatureStatus::kAvailable;
+                    feature.value = *value;
+                    candidate.last_access_time_us = *value;
+                    if (*value <= admission_now_us) {
+                        ObserveAdmissionAccessAge(src_name, dst_name, params, admission_now_us - *value);
+                    }
+                } else {
+                    feature.status = ObservedFeatureStatus::kInvalid;
+                }
+            }
+            candidate.features.Set(MigrationAdmissionFeature::kLastAccessTime, std::move(feature));
+        }
+        if (terminal_feature_failure) {
+            continue;
+        }
+        policy_inputs.push_back(candidate.features);
+        location_valid_candidates.push_back(std::move(candidate));
+    }
+    const int64_t hard_snapshot_failures = hard_location_failures + hard_feature_failures;
+    if (hard_snapshot_failures > 0) {
+        result.ec = hard_snapshot_failures == static_cast<int64_t>(batch.size()) ? EC_ERROR : EC_PARTIAL_OK;
+    }
+
+    std::vector<MigrationAdmissionDecision> decisions;
+    if (policy != nullptr) {
+        decisions = policy->EvaluateBatch(policy_inputs, MigrationAdmissionContext{admission_now_us});
+        if (decisions.size() != location_valid_candidates.size()) {
+            if (params.admission.mode() == MigrationAdmissionMode::ENFORCE) {
+                result.ec = EC_ERROR;
+                result.failed += static_cast<int64_t>(location_valid_candidates.size());
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kValue,
+                           MigrationOutcomeClass::kFailed,
+                           MigrationOutcomeReason::kPolicyContractError,
+                           static_cast<int64_t>(location_valid_candidates.size()),
+                           true);
+                return FinalizeDispatchMetrics(
+                    instance_id, src_name, dst_name, batch.size(), params, std::move(result));
+            }
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kValue,
+                       MigrationOutcomeClass::kFailed,
+                       MigrationOutcomeReason::kPolicyContractError,
+                       static_cast<int64_t>(location_valid_candidates.size()),
+                       false);
+            decisions.clear();
+        }
+    }
+
+    std::vector<PreparedCandidate> execution_candidates;
+    execution_candidates.reserve(location_valid_candidates.size());
+    for (size_t i = 0; i < location_valid_candidates.size(); ++i) {
+        const bool has_decision = i < decisions.size();
+        if (has_decision) {
+            const bool accepted = decisions[i].verdict == MigrationAdmissionVerdict::kAccept;
+            const bool terminal = params.admission.mode() == MigrationAdmissionMode::ENFORCE && !accepted;
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kValue,
+                       accepted ? MigrationOutcomeClass::kAccepted : MigrationOutcomeClass::kRejected,
+                       ToOutcomeReason(decisions[i].reason),
+                       1,
+                       terminal);
+            if (params.do_copy) {
+                const auto projected_specs = FindFirstUncoveredSourceSpecs(
+                    location_valid_candidates[i].locations, src_name, dst_name);
+                const auto projected = SummarizeSpecBytes(projected_specs);
+                const MetricsTags byte_tags{{"src", src_name},
+                                             {"dst", dst_name},
+                                             {"decision", accepted ? "value_accept" : "value_reject"}};
+                AddCounterMetric("migration_copy_planned_bytes_total", byte_tags, projected.bytes);
+                AddCounterMetric(
+                    "migration_copy_planned_bytes_unknown_specs_total", byte_tags, projected.unknown_specs);
+            }
+        }
+        if (params.admission.mode() == MigrationAdmissionMode::ENFORCE &&
+            (!has_decision || decisions[i].verdict != MigrationAdmissionVerdict::kAccept)) {
+            ++result.rejected;
+            continue;
+        }
+        execution_candidates.push_back(std::move(location_valid_candidates[i]));
+    }
+    AddCounterMetric("migration_candidate_pool_total",
+                     {{"src", src_name}, {"dst", dst_name}, {"stage", "value_qualified"}},
+                     execution_candidates.size());
+    if (params.trigger == DispatchBatchParams::Trigger::kReclaimer &&
+        params.admission.mode() == MigrationAdmissionMode::ENFORCE) {
+        std::stable_sort(execution_candidates.begin(),
+                         execution_candidates.end(),
+                         [](const PreparedCandidate &lhs, const PreparedCandidate &rhs) {
+                             return lhs.last_access_time_us < rhs.last_access_time_us;
+                         });
+    }
+    if (params.trigger == DispatchBatchParams::Trigger::kReclaimer &&
+        execution_candidates.size() > params.action_budget) {
+        const int64_t budget_rejected =
+            static_cast<int64_t>(execution_candidates.size() - params.action_budget);
+        result.rejected += budget_rejected;
+        AddOutcome(result.outcome_counts,
+                   MigrationOutcomeStage::kExecution,
+                   MigrationOutcomeClass::kRejected,
+                   MigrationOutcomeReason::kBudgetExhausted,
+                   budget_rejected,
+                   true);
+        execution_candidates.resize(params.action_budget);
+    }
+
+    // Execution admission consumes the exact locations from the same final
+    // NoTouch snapshot. Pending reclaimer deletions are filtered only now,
+    // after the aligned snapshot has been built.
     std::vector<MigrationRequest> copy_reqs;
     std::vector<int64_t> copy_block_keys;
     std::vector<int64_t> mark_keys;
-    for (std::size_t i = 0; i < batch.size(); ++i) {
-        const int64_t block_key = batch[i];
-        const auto admission = CheckCopyAdmission(instance_id, block_key, loc_maps[i], src_name, dst_name);
+    std::unordered_map<int64_t, SpecByteSummary> eligible_spec_bytes_by_block;
+    for (auto &candidate : execution_candidates) {
+        if (!params.pending_location_ids_by_block.empty()) {
+            for (const auto &pending_id : params.pending_location_ids_by_block[candidate.original_index]) {
+                candidate.locations.erase(pending_id);
+            }
+        }
+        const int64_t block_key = candidate.block_key;
+        const auto admission = CheckCopyAdmission(instance_id, block_key, candidate.locations, src_name, dst_name);
         if (admission.status != CopyAdmissionStatus::kAccept || admission.src_location == nullptr) {
+            ++result.rejected;
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kExecution,
+                       MigrationOutcomeClass::kRejected,
+                       ToOutcomeReason(admission.status),
+                       1,
+                       true);
             continue;
         }
+        if (admission.missing_specs.empty()) {
+            ++result.rejected;
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kExecution,
+                       MigrationOutcomeClass::kRejected,
+                       MigrationOutcomeReason::kTargetAlreadyCovered,
+                       1,
+                       true);
+            continue;
+        }
+        eligible_spec_bytes_by_block[block_key] = SummarizeSpecBytes(admission.missing_specs);
         if (params.do_copy && copy_reqs.size() < params.max_copy_slots) {
             MigrationRequest req;
             req.instance_group_name = params.copy_limit.instance_group_name;
@@ -2521,38 +3541,197 @@ MigrationManager::DispatchBatchResult MigrationManager::DispatchMigrationBatchWi
             req.src_storage_name = src_name;
             req.dst_storage_name = dst_name;
             req.retention = params.retention;
-            req.src_specs = admission.src_location->location_specs();
+            req.src_specs = admission.missing_specs;
             req.src_create_time = admission.src_location->create_time();
             copy_block_keys.push_back(block_key);
             copy_reqs.push_back(std::move(req));
+            const auto &planned = eligible_spec_bytes_by_block[block_key];
+            const MetricsTags byte_tags{{"src", src_name}, {"dst", dst_name}, {"decision", "dispatched"}};
+            AddCounterMetric("migration_copy_planned_bytes_total", byte_tags, planned.bytes);
+            AddCounterMetric(
+                "migration_copy_planned_bytes_unknown_specs_total", byte_tags, planned.unknown_specs);
             continue; // Copy 优先：已进入 copy 的 block 不再重复 mark。
         }
-        if (params.do_mark && already_marked.count(block_key) == 0 && mark_query_failed.count(block_key) == 0) {
+        if (params.do_mark) {
             mark_keys.push_back(block_key);
+        } else {
+            ++result.rejected;
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kExecution,
+                       MigrationOutcomeClass::kRejected,
+                       params.do_copy ? MigrationOutcomeReason::kCopySlotExhausted
+                                      : MigrationOutcomeReason::kNoExecutionMethod,
+                       1,
+                       true);
         }
     }
 
     // 分发
     if (!copy_reqs.empty()) {
         const auto results = BatchSubmit(trace_id, std::move(copy_reqs), params.copy_limit, true);
-        for (std::size_t i = 0; i < results.size(); ++i) {
+        const std::size_t aligned_result_count = std::min(results.size(), copy_block_keys.size());
+        for (std::size_t i = 0; i < aligned_result_count; ++i) {
             if (results[i] == EC_OK) {
                 ++result.copy_submitted;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kCopy,
+                           MigrationOutcomeClass::kAccepted,
+                           MigrationOutcomeReason::kCopySubmitted,
+                           1,
+                           true);
             } else {
                 ++result.copy_failed;
                 if (params.do_mark && i < copy_block_keys.size()) {
+                    AddOutcome(result.outcome_counts,
+                               MigrationOutcomeStage::kCopy,
+                               MigrationOutcomeClass::kFailed,
+                               CopySubmitOutcomeReason(results[i]),
+                               1,
+                               false);
                     mark_keys.push_back(copy_block_keys[i]); // copy 失败时 fallback 到 mark
+                } else if (results[i] == EC_OUT_OF_LIMIT || results[i] == EC_EXIST ||
+                           results[i] == EC_NOENT || results[i] == EC_NOSPC) {
+                    // 并发额度、重复任务、源状态或目标配额已不满足都是
+                    // execution/target admission reject，不是基础设施故障。这也保证
+                    // legacy accepted/rejected 响应不会遗漏这些候选。
+                    ++result.rejected;
+                    AddOutcome(result.outcome_counts,
+                               MigrationOutcomeStage::kCopy,
+                               MigrationOutcomeClass::kRejected,
+                               CopySubmitOutcomeReason(results[i]),
+                               1,
+                               true);
+                } else {
+                    ++result.failed;
+                    AddOutcome(result.outcome_counts,
+                               MigrationOutcomeStage::kCopy,
+                               MigrationOutcomeClass::kFailed,
+                               CopySubmitOutcomeReason(results[i]),
+                               1,
+                               true);
                 }
             }
         }
-    }
-    if (params.do_mark && !mark_keys.empty()) {
-        const auto mark_ec = MarkForTieredWrite(instance_id, mark_keys, dst_name, params.mark_timeout_ms);
-        if (mark_ec == EC_OK) {
-            result.mark_submitted = static_cast<int64_t>(mark_keys.size());
+        if (aligned_result_count < copy_block_keys.size()) {
+            const int64_t missing_results = static_cast<int64_t>(copy_block_keys.size() - aligned_result_count);
+            result.failed += missing_results;
+            result.ec = result.ec == EC_OK ? EC_MISMATCH : EC_ERROR;
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kCopy,
+                       MigrationOutcomeClass::kFailed,
+                       MigrationOutcomeReason::kCopySubmitFailed,
+                       missing_results,
+                       true);
         }
     }
-    return result;
+    if (params.do_mark && !mark_keys.empty()) {
+        std::uint64_t mark_eligible_bytes = 0;
+        std::uint64_t mark_unknown_specs = 0;
+        for (const auto block_key : mark_keys) {
+            if (const auto summary = eligible_spec_bytes_by_block.find(block_key);
+                summary != eligible_spec_bytes_by_block.end()) {
+                mark_unknown_specs += summary->second.unknown_specs;
+                if (summary->second.bytes > std::numeric_limits<std::uint64_t>::max() - mark_eligible_bytes) {
+                    ++mark_unknown_specs;
+                } else {
+                    mark_eligible_bytes += summary->second.bytes;
+                }
+            }
+        }
+        const MetricsTags byte_tags{{"src", src_name}, {"dst", dst_name}, {"decision", "eligible"}};
+        AddCounterMetric("migration_mark_eligible_source_bytes_total", byte_tags, mark_eligible_bytes);
+        AddCounterMetric(
+            "migration_mark_eligible_source_bytes_unknown_specs_total", byte_tags, mark_unknown_specs);
+        const auto mark_result =
+            MarkForTieredWriteDetailed(instance_id, mark_keys, dst_name, params.mark_timeout_ms);
+        const std::size_t aligned_outcome_count = std::min(mark_result.outcomes.size(), mark_keys.size());
+        for (std::size_t i = 0; i < aligned_outcome_count; ++i) {
+            const auto &outcome = mark_result.outcomes[i];
+            switch (outcome.status) {
+            case MarkWriteStatus::kInserted:
+                ++result.mark_submitted;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kAccepted,
+                           MigrationOutcomeReason::kMarkInserted,
+                           1,
+                           true);
+                break;
+            case MarkWriteStatus::kAlreadySameTarget:
+                ++result.noop;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kNoopAlreadySatisfied,
+                           MigrationOutcomeReason::kMarkAlreadySameTarget,
+                           1,
+                           true);
+                break;
+            case MarkWriteStatus::kConflictDifferentTarget:
+                ++result.rejected;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kRejected,
+                           MigrationOutcomeReason::kMarkConflictDifferentTarget,
+                           1,
+                           true);
+                break;
+            case MarkWriteStatus::kMalformedExistingMark:
+                ++result.rejected;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kRejected,
+                           MigrationOutcomeReason::kMarkMalformed,
+                           1,
+                           true);
+                break;
+            case MarkWriteStatus::kBlockNotFound:
+                ++result.rejected;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kRejected,
+                           MigrationOutcomeReason::kBlockNotFound,
+                           1,
+                           true);
+                break;
+            case MarkWriteStatus::kWriteError:
+                ++result.failed;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kFailed,
+                           MigrationOutcomeReason::kMarkWriteError,
+                           1,
+                           true);
+                break;
+            case MarkWriteStatus::kReadError:
+                ++result.failed;
+                AddOutcome(result.outcome_counts,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kFailed,
+                           MigrationOutcomeReason::kMarkReadError,
+                           1,
+                           true);
+                break;
+            }
+        }
+        if (aligned_outcome_count < mark_keys.size()) {
+            const int64_t missing_outcomes = static_cast<int64_t>(mark_keys.size() - aligned_outcome_count);
+            result.failed += missing_outcomes;
+            result.ec = result.ec == EC_OK ? EC_MISMATCH : EC_ERROR;
+            AddOutcome(result.outcome_counts,
+                       MigrationOutcomeStage::kMark,
+                       MigrationOutcomeClass::kFailed,
+                       MigrationOutcomeReason::kMarkWriteError,
+                       missing_outcomes,
+                       true);
+        }
+        if (mark_result.ec != EC_OK) {
+            result.ec = result.ec == EC_OK ? mark_result.ec : EC_ERROR;
+        }
+    }
+    if (result.failed > 0) {
+        result.ec = result.failed == static_cast<int64_t>(batch.size()) ? EC_ERROR : EC_PARTIAL_OK;
+    }
+    return FinalizeDispatchMetrics(instance_id, src_name, dst_name, batch.size(), params, std::move(result));
 }
 
 MigrationManager::MigrationStats MigrationManager::GetStats() const {

--- a/kv_cache_manager/manager/migration_manager.cc
+++ b/kv_cache_manager/manager/migration_manager.cc
@@ -1111,10 +1111,15 @@ ErrorCode MigrationManager::Submit(const std::string &trace_id, MigrationRequest
             source_check_ec = EC_NOENT;
         }
     }
-    const bool source_matches = source_location != nullptr && source_location->status() == CLS_SERVING &&
-                                source_location->create_time() > 0 &&
-                                (request.src_create_time <= 0 ||
-                                 request.src_create_time == source_location->create_time());
+    // A prepared request always carries an exact generation, including the
+    // legacy value zero. An unprepared public Submit binds to the generation
+    // returned by this recheck; zero must not act as a wildcard for prepared
+    // requests or a same-id replacement could be accepted accidentally.
+    const bool has_prepared_source_snapshot = !request.src_specs.empty();
+    const bool source_matches =
+        source_location != nullptr && source_location->status() == CLS_SERVING &&
+        (!has_prepared_source_snapshot ||
+         (request.src_create_time >= 0 && request.src_create_time == source_location->create_time()));
     if (source_check_ec != EC_OK || !source_matches || source_location->location_specs().empty()) {
         std::lock_guard<std::mutex> lock(task_mutex_);
         RemovePreparingTaskLocked(request.instance_id, request.block_key);
@@ -1295,7 +1300,7 @@ std::vector<ErrorCode> MigrationManager::BatchSubmit(const std::string &trace_id
                                     return request.instance_id == first_req.instance_id &&
                                            request.dst_storage_name == first_req.dst_storage_name &&
                                            !request.src_location_id.empty() && !request.src_storage_name.empty() &&
-                                           !request.src_specs.empty() && request.src_create_time > 0;
+                                           !request.src_specs.empty() && request.src_create_time >= 0;
                                 });
     if (!prepared_batch) {
         KVCM_LOG_WARN(

--- a/kv_cache_manager/manager/migration_manager.h
+++ b/kv_cache_manager/manager/migration_manager.h
@@ -20,6 +20,7 @@
 
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/config/migration_strategy.h"
+#include "kv_cache_manager/manager/migration_outcome.h"
 #include "kv_cache_manager/manager/schedule_plan_executor.h"
 #include "kv_cache_manager/meta/cache_location.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
@@ -119,11 +120,34 @@ public:
     void OnTaskFailed(const std::string &instance_id, int64_t block_key, ErrorCode reason);
 
     // ---- Mark 路径（MetaIndexer 持久化：block 级 property，随元数据落 Redis + local cache） ----
-    // 打标/清标走 ReadModifyWriteBlock 只写 property（不动 location）；查标走 GetProperties。
+    // 打标/清标走 maintenance NoTouch block-property RMW（不动 location）；查标走
+    // GetPropertiesForMaintenance，不把迁移状态维护记成业务访问。
     ErrorCode MarkForTieredWrite(const std::string &instance_id,
                                  const std::vector<int64_t> &block_keys,
                                  const std::string &dst_storage_name,
                                  int64_t timeout_ms = MigrationMarkMethod::kDefaultTimeoutMs);
+    enum class MarkWriteStatus {
+        kInserted,
+        kAlreadySameTarget,
+        kConflictDifferentTarget,
+        kMalformedExistingMark,
+        kBlockNotFound,
+        kReadError,
+        kWriteError,
+    };
+    struct MarkWriteOutcome {
+        MarkWriteStatus status = MarkWriteStatus::kReadError;
+        ErrorCode ec = EC_OK;
+    };
+    struct MarkWriteResult {
+        ErrorCode ec = EC_OK;
+        std::vector<MarkWriteOutcome> outcomes;
+    };
+    MarkWriteResult MarkForTieredWriteDetailed(
+        const std::string &instance_id,
+        const std::vector<int64_t> &block_keys,
+        const std::string &dst_storage_name,
+        int64_t timeout_ms = MigrationMarkMethod::kDefaultTimeoutMs);
     bool IsMarkedForTieredWrite(const std::string &instance_id, int64_t block_key);
     std::string GetTieredWriteTarget(const std::string &instance_id, int64_t block_key);
     // 按 expected target+deadline 条件清除 mark（不匹配则不清，防止清掉同 block 新 mark）。
@@ -175,6 +199,10 @@ public:
     bool HasActiveCopyTargetLocation(const std::string &instance_id,
                                      int64_t block_key,
                                      const std::string &location_id) const;
+    bool HasActiveCopySourceLocation(const std::string &instance_id,
+                                     int64_t block_key,
+                                     const std::string &location_id,
+                                     int64_t create_time) const;
     size_t ActiveTaskCount() const;
     // 按任务提交时记录的 instance group 统计活跃 Copy，用于统一的 group 级硬限流。
     size_t ActiveTaskCountForGroup(const std::string &instance_group_name) const;
@@ -202,11 +230,14 @@ public:
     struct CopyAdmission {
         CopyAdmissionStatus status = CopyAdmissionStatus::kAccept;
         const CacheLocation *src_location = nullptr; // 仅 kAccept 时有效
+        // 目标 SERVING/WRITING 联合 coverage 尚未覆盖的 source specs。
+        // Dispatch 只复制这些 specs，避免 partial coverage 下重复写低层。
+        std::vector<LocationSpec> missing_specs;
     };
 
     // 在某个候选 block 上做 Copy 准入判断（无副作用）。
     // - instance_id/block_key：候选 block 的实例作用域与 block id；
-    // - loc_map：该 block 当前所有 CacheLocation（来自 MetaSearcher::BatchGetLocation）；
+    // - loc_map：该 block 当前所有 CacheLocation（来自共享 NoTouch snapshot）；
     // - src_storage_name / dst_storage_name：迁移源/目标 storage 的 unique name。
     CopyAdmission CheckCopyAdmission(const std::string &instance_id,
                                      int64_t block_key,
@@ -215,14 +246,15 @@ public:
                                      const std::string &dst_storage_name) const;
 
     // ---- 编排入口（API 触发，供 CacheManager::MigrateCache 薄 facade 调用）----
-    // 承载迁移编排本身：候选选择 + location 批查(MetaSearcher) + 逐 block 准入(CheckCopyAdmission)
-    // + Copy(BatchSubmit)/Mark(MarkForTieredWrite) 分发与 copy 失败回落 + accepted/rejected 统计。
+    // 承载迁移编排本身：候选选择 + NoTouch location/feature 快照 + value/execution 准入
+    // + Copy(BatchSubmit)/条件 Mark 分发与 copy 失败回落 + 分阶段 outcome 统计。
     // 前置条件（instance 存在、meta_indexer 非空、target 已注册、group 有 strategy）由 facade
     // 完成后再调本方法；meta_indexer 由调用方传入（facade 已按 instance 取得并做非空校验）。
     struct MigrateResult {
         ErrorCode ec = EC_OK;
         int64_t accepted = 0;
         int64_t rejected = 0;
+        MigrationOutcomeCounts outcome_counts;
         std::string message;
     };
     MigrateResult MigrateCache(RequestContext *request_context,
@@ -237,13 +269,16 @@ public:
                                const std::vector<int64_t> &explicit_block_keys,
                                int64_t sample_count,
                                std::size_t copy_max_concurrency,
-                               int64_t mark_timeout_ms);
+                               int64_t mark_timeout_ms,
+                               MigrationRetention retention,
+                               const MigrationAdmissionConfig &admission_config);
 
     // ---- 共享迁移分发（Admin MigrateCache 与 CacheReclaimer 两路共用）----
-    // 对已准备好的 (batch, loc_maps) 执行：逐 block 准入(CheckCopyAdmission) + copy/mark 分类
-    // + BatchSubmit + copy 失败回落 mark + MarkForTieredWrite。
-    // 两路差异通过 params 参数化（copy slot 限制 / retention / mark timeout / mark 去重）。
+    // 对 keys 做共享 NoTouch snapshot、value/execution 准入、Copy/Mark 分类、BatchSubmit、
+    // Copy 失败回落条件 Mark；上游不能传入已被 touch 或错位的 location。
+    // 两路差异通过 params 参数化（copy slot 限制 / retention / mark timeout / trigger/budget）。
     struct DispatchBatchParams {
+        enum class Trigger { kAdmin, kReclaimer };
         bool do_copy = false;
         bool do_mark = false;
         // max_copy_slots 是调用方本批次的提前剪枝；copy_limit 是 BatchSubmit 内的原子硬限制。
@@ -251,12 +286,20 @@ public:
         CopyConcurrencyLimit copy_limit;
         MigrationRetention retention = MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE;
         int64_t mark_timeout_ms = MigrationMarkMethod::kDefaultTimeoutMs;
-        bool dedup_marks = false; // true=跳过已打标的 block（reclaimer 用；Admin 显式指定 block 不需要）
+        MigrationAdmissionConfig admission;
+        Trigger trigger = Trigger::kAdmin;
+        std::size_t action_budget = SIZE_MAX;
+        std::vector<std::vector<std::string>> pending_location_ids_by_block;
     };
     struct DispatchBatchResult {
+        ErrorCode ec = EC_OK;
         int64_t copy_submitted = 0;
         int64_t copy_failed = 0;
         int64_t mark_submitted = 0;
+        int64_t rejected = 0;
+        int64_t noop = 0;
+        int64_t failed = 0;
+        MigrationOutcomeCounts outcome_counts;
     };
 
     // Reclaimer 只在其单线程中选择候选并生成 pending-delete 快照；Job 跨异步边界后完全
@@ -269,6 +312,7 @@ public:
         std::string target_storage_name;
         std::vector<int64_t> block_keys;
         std::vector<std::vector<std::string>> pending_location_ids_by_block;
+        std::size_t action_budget = SIZE_MAX;
         std::function<void(const DispatchBatchResult &)> on_dispatched;
     };
 
@@ -283,7 +327,6 @@ public:
                                               const std::string &src_name,
                                               const std::string &dst_name,
                                               const std::vector<int64_t> &batch,
-                                              const std::vector<CacheLocationMap> &loc_maps,
                                               const DispatchBatchParams &params);
 
     // ---- 统计 ----
@@ -325,6 +368,7 @@ private:
         std::string dst_storage_name;
         std::string dst_location_id;
         MigrationRetention retention = MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE;
+        std::chrono::steady_clock::time_point source_lease_start_time;
         std::chrono::steady_clock::time_point submit_time;
         uint64_t total_bytes = 0;              // 源端各 spec 字节数之和（取自 uri size 参数）
         std::string mark_target;               // 提交时 mark 的 target（空=无 mark，用于 match-clear）
@@ -450,12 +494,26 @@ private:
                                                                     const std::string &src_name,
                                                                     const std::string &dst_name,
                                                                     const std::vector<int64_t> &batch,
-                                                                    const std::vector<CacheLocationMap> &loc_maps,
                                                                     const DispatchBatchParams &params);
     ErrorCode CheckTargetStorageAdmission(const std::string &trace_id,
                                           const std::string &instance_group_name,
                                           const std::string &instance_id,
                                           const std::string &target_storage_name) const;
+    void AddCounterMetric(const std::string &name, MetricsTags tags, std::uint64_t value = 1) const noexcept;
+    void SetGaugeMetric(const std::string &name, MetricsTags tags, double value) const noexcept;
+    void ObserveAdmissionAccessAge(const std::string &src_name,
+                                   const std::string &dst_name,
+                                   const DispatchBatchParams &params,
+                                   std::int64_t age_us) const noexcept;
+    void ObserveSourceLeaseDuration(const std::string &src_name,
+                                    const std::string &dst_name,
+                                    std::int64_t duration_us) const noexcept;
+    DispatchBatchResult FinalizeDispatchMetrics(const std::string &instance_id,
+                                                const std::string &src_name,
+                                                const std::string &dst_name,
+                                                std::size_t candidate_count,
+                                                const DispatchBatchParams &params,
+                                                DispatchBatchResult result) const;
 
     std::shared_ptr<SchedulePlanExecutor> schedule_plan_executor_;
     std::shared_ptr<MetaIndexerManager> meta_indexer_manager_;

--- a/kv_cache_manager/manager/migration_manager.h
+++ b/kv_cache_manager/manager/migration_manager.h
@@ -67,6 +67,8 @@ public:
         // DispatchMigrationBatch 生成的 prepared request 必须非空；单条 Submit 可留空，由
         // PrepareCopyTask 兼容性地重读 meta。
         std::vector<LocationSpec> src_specs;
+        // Exact source generation for prepared requests. Zero is valid for
+        // legacy locations and must not be treated as an omitted guard.
         int64_t src_create_time = 0;
     };
 
@@ -363,7 +365,8 @@ private:
         std::string instance_id;
         int64_t block_key = 0;
         std::string src_location_id;
-        int64_t src_create_time = 0; // 提交时源 location 的 create_time，OnTaskSuccess 比对以防 id 复用
+        // 提交时源 location 的精确 generation（legacy 0 也有效），用于防止 location id 复用。
+        int64_t src_create_time = 0;
         std::string src_storage_name;
         std::string dst_storage_name;
         std::string dst_location_id;

--- a/kv_cache_manager/manager/migration_outcome.h
+++ b/kv_cache_manager/manager/migration_outcome.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace kv_cache_manager {
+
+// Stable manager-layer vocabulary for explaining one migration dispatch batch.
+// Protocol conversion stays in service; manager code does not depend on protobuf.
+enum class MigrationOutcomeStage : std::uint8_t {
+    kSnapshot,
+    kValue,
+    kExecution,
+    kCopy,
+    kMark,
+};
+
+enum class MigrationOutcomeClass : std::uint8_t {
+    kAccepted,
+    kRejected,
+    kNoopAlreadySatisfied,
+    kFailed,
+};
+
+enum class MigrationOutcomeReason : std::uint8_t {
+    kUnspecified,
+    kNotRecent,
+    kFeatureMissing,
+    kFeatureInvalid,
+    kFeatureUnsupported,
+    kFeatureReadError,
+    kRouteNotReady,
+    kLocationReadError,
+    kSnapshotShapeError,
+    kSourceNotFound,
+    kTargetAlreadyCovered,
+    kAlreadyMigrating,
+    kTargetRejected,
+    kSourceRecheckFailed,
+    kCopySubmitted,
+    kCopySubmitFailed,
+    kMarkInserted,
+    kMarkAlreadySameTarget,
+    kMarkConflictDifferentTarget,
+    kMarkMalformed,
+    kBlockNotFound,
+    kMarkReadError,
+    kMarkWriteError,
+    kPolicyContractError,
+    kBudgetExhausted,
+    kValueAccepted,
+    kNoExecutionMethod,
+    kCopySlotExhausted,
+    kDispatchNotAvailable,
+};
+
+struct MigrationOutcomeCount {
+    MigrationOutcomeStage stage = MigrationOutcomeStage::kSnapshot;
+    MigrationOutcomeClass outcome_class = MigrationOutcomeClass::kFailed;
+    MigrationOutcomeReason reason = MigrationOutcomeReason::kUnspecified;
+    std::int64_t count = 0;
+    // Exactly one terminal outcome is emitted for every input candidate. Other
+    // entries retain projected SHADOW decisions or a failed Copy before a
+    // successful Mark fallback.
+    bool terminal = false;
+};
+
+using MigrationOutcomeCounts = std::vector<MigrationOutcomeCount>;
+
+} // namespace kv_cache_manager

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -122,6 +122,16 @@ SchedulePlanExecutor::SchedulePlanExecutor(unsigned int thread_count,
                   thread_count,
                   migration_worker_budget_);
 }
+
+void SchedulePlanExecutor::SetSourceLocationLeaseChecker(SourceLocationLeaseChecker checker) {
+    std::unique_lock<std::shared_mutex> lock(source_location_lease_mutex_);
+    source_location_lease_checker_ = std::move(checker);
+}
+
+std::unique_lock<std::shared_mutex> SchedulePlanExecutor::AcquireSourceLocationLeaseReservationGuard() {
+    return std::unique_lock<std::shared_mutex>(source_location_lease_mutex_);
+}
+
 void SchedulePlanExecutor::Stop() {
     KVCM_LOG_DEBUG("Stopping SchedulePlanExecutor...");
     std::vector<std::function<void()>> cancel_tasks;
@@ -453,103 +463,11 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::SubmitMetaDelete(const Cach
     KVCM_LOG_DEBUG("Submitting meta delete task for instance_id: %s, block_keys count: %zu",
                    task.instance_id.c_str(),
                    task.block_keys.size());
-
     auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
-    std::future<PlanExecuteResult> future = promise->get_future();
-
-    if (stop_) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped.");
-        return future;
-    }
-
-    // 1. sync set block status to deleting
-    const std::shared_ptr<MetaIndexer> indexer = meta_manager_->GetMetaIndexer(task.instance_id);
-    if (indexer == nullptr) {
-        HandleErrorPromise(promise, ErrorCode::EC_NOENT, "MetaIndexer %s not found", task.instance_id.c_str());
-        return future;
-    }
-
-    MetaSearcher meta_searcher(indexer);
-
-    std::vector<CacheLocationMap> location_maps;
-    BlockMask empty_mask;
-    auto request_context = std::make_shared<RequestContext>("schedule_plan_executor_call");
-    ErrorCode get_locations_ec =
-        meta_searcher.BatchGetLocation(request_context.get(), task.block_keys, empty_mask, location_maps);
-    if (get_locations_ec != ErrorCode::EC_OK) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "Failed to get block locations");
-        return future;
-    }
-
-    std::vector<int64_t> batch_cas_block_keys;
-    std::vector<std::vector<MetaSearcher::LocationCASTask>> batch_cas_tasks;
-    for (size_t block_key_idx = 0; block_key_idx < task.block_keys.size(); ++block_key_idx) {
-        std::vector<MetaSearcher::LocationCASTask> cas_tasks;
-        for (const auto &loc_kv : location_maps[block_key_idx]) {
-            if (!loc_kv.second) {
-                continue;
-            }
-            cas_tasks.push_back({loc_kv.first, loc_kv.second->status(), CLS_DELETING});
-        }
-        if (cas_tasks.empty()) {
-            continue;
-        }
-        batch_cas_block_keys.emplace_back(task.block_keys[block_key_idx]);
-        batch_cas_tasks.emplace_back(std::move(cas_tasks));
-    }
-
-    if (batch_cas_block_keys.empty()) {
-        promise->set_value({ErrorCode::EC_OK, ""});
-        return future;
-    }
-
-    std::vector<std::vector<ErrorCode>> cas_results;
-    ErrorCode update_ec =
-        meta_searcher.BatchCASLocationStatus(request_context.get(), batch_cas_block_keys, batch_cas_tasks, cas_results);
-    if (update_ec != ErrorCode::EC_OK) {
-        KVCM_LOG_DEBUG("Location status BatchCASLocationStatus not ok, ec: %d", update_ec);
-    }
-
-    std::string error_message;
-    CacheLocationDelRequest actual_task{task.instance_id, {}, {}, task.delay};
-    if (!FillActualTask(batch_cas_block_keys, batch_cas_tasks, cas_results, actual_task, error_message)) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "FillActualTask error: %s", error_message.c_str());
-        return future;
-    }
-    if (actual_task.block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
-        return future;
-    }
-
-    // Sync: ensure CAS(→DELETING) is persisted before scheduling Phase 2.
-    if (!indexer->Sync(actual_task.block_keys)) {
-        HandleErrorPromise(promise,
-                           ErrorCode::EC_ERROR,
-                           "Sync failed or timed out for location delete, instance[%s]",
-                           task.instance_id.c_str());
-        return future;
-    }
-
-    KVCM_LOG_DEBUG("Location statuses updated, submitting task to worker pool with delay: %lld microseconds",
-                   static_cast<long long>(task.delay.count()));
-
-    auto execute_task = [this, promise, actual_task]() {
-        try {
-            promise->set_value(DoLocationDelTask(actual_task));
-        } catch (const std::exception &e) {
-            HandleErrorPromise(promise, ErrorCode::EC_ERROR, "location delete task threw exception: %s", e.what());
-        } catch (...) {
-            HandleErrorPromise(promise, ErrorCode::EC_ERROR, "location delete task threw unknown exception");
-        }
-    };
-    auto cancel_task = [promise]() {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before task execution.");
-    };
-    bool submit_result = this->SubmitRaw(execute_task, task.delay, cancel_task, task_class);
-    if (!submit_result) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "submit task failed");
-        return future;
-    }
+    auto future = promise->get_future();
+    auto completion = std::make_shared<PromiseCompletion>(promise);
+    RunDeleteAdmission(
+        completion, task.delay, [this, &task]() { return PrepareDeleteTask(task); }, task_class);
     return future;
 }
 
@@ -601,36 +519,45 @@ bool SchedulePlanExecutor::FillActualTask(
 }
 SchedulePlanExecutor::LocationDelAdmissionResult
 SchedulePlanExecutor::PrepareDeleteTask(const CacheMetaDelRequest &task) {
-    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false);
+    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, nullptr, task.delay, false);
 }
 
 SchedulePlanExecutor::LocationDelAdmissionResult
 SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
     if (task.block_keys.size() != task.location_ids.size() ||
-        (!task.expected_location_values.empty() && task.block_keys.size() != task.expected_location_values.size())) {
+        (!task.expected_location_values.empty() && task.block_keys.size() != task.expected_location_values.size()) ||
+        (!task.expected_location_create_times.empty() &&
+         task.block_keys.size() != task.expected_location_create_times.size())) {
         LocationDelAdmissionResult admission_result;
         admission_result.result = MakeErrorResult(
-            ErrorCode::EC_BADARGS, "block_keys, location_ids and expected_location_values sizes do not match");
+            ErrorCode::EC_BADARGS,
+            "block_keys, location_ids and optional expected location guards sizes do not match");
         return admission_result;
     }
-    if (!task.expected_location_values.empty()) {
+    if (!task.expected_location_values.empty() || !task.expected_location_create_times.empty()) {
         for (size_t i = 0; i < task.location_ids.size(); ++i) {
-            if (task.location_ids[i].size() != task.expected_location_values[i].size()) {
+            if ((!task.expected_location_values.empty() &&
+                 task.location_ids[i].size() != task.expected_location_values[i].size()) ||
+                (!task.expected_location_create_times.empty() &&
+                 task.location_ids[i].size() != task.expected_location_create_times[i].size())) {
                 LocationDelAdmissionResult admission_result;
                 admission_result.result = MakeErrorResult(
                     ErrorCode::EC_BADARGS,
                     StringUtil::FormatString(
-                        "location_ids and expected_location_values sizes do not match at index %zu", i));
+                        "location_ids and expected location guards sizes do not match at index %zu", i));
                 return admission_result;
             }
         }
     }
     const auto *expected_location_values =
         task.expected_location_values.empty() ? nullptr : &task.expected_location_values;
+    const auto *expected_location_create_times =
+        task.expected_location_create_times.empty() ? nullptr : &task.expected_location_create_times;
     auto result = PrepareDeleteTaskImpl(task.instance_id,
                                         task.block_keys,
                                         &task.location_ids,
                                         expected_location_values,
+                                        expected_location_create_times,
                                         task.delay,
                                         task.authoritative_read);
     result.actual_task.metadata_only = task.metadata_only;
@@ -642,6 +569,7 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                                             const std::vector<int64_t> &block_keys,
                                             const std::vector<std::vector<std::string>> *target_location_ids,
                                             const std::vector<std::vector<std::string>> *expected_location_values,
+                                            const std::vector<std::vector<int64_t>> *expected_location_create_times,
                                             std::chrono::microseconds delay,
                                             bool authoritative_read) {
     LocationDelAdmissionResult admission_result;
@@ -651,6 +579,7 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
         admission_result.result = MakeErrorResult(ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped.");
         return admission_result;
     }
+    std::shared_lock<std::shared_mutex> source_lease_guard(source_location_lease_mutex_);
     std::shared_ptr<MetaIndexer> indexer = meta_manager_->GetMetaIndexer(instance_id);
     if (!indexer) {
         admission_result.result = MakeErrorResult(
@@ -660,7 +589,6 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
 
     MetaSearcher meta_searcher(indexer);
     std::vector<CacheLocationMap> location_maps;
-    BlockMask empty_mask;
     auto request_context = std::make_shared<RequestContext>("schedule_plan_executor_call");
     ErrorCode get_locations_ec = ErrorCode::EC_OK;
     if (authoritative_read) {
@@ -676,7 +604,19 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
             }
         }
     } else {
-        get_locations_ec = meta_searcher.BatchGetLocation(request_context.get(), block_keys, empty_mask, location_maps);
+        PropertyMapVector unused_properties;
+        const auto get_result =
+            indexer->GetForMaintenance(request_context.get(), block_keys, {}, location_maps, unused_properties);
+        if (get_result.locations.error_codes.size() != block_keys.size()) {
+            get_locations_ec = ErrorCode::EC_ERROR;
+        } else {
+            for (const ErrorCode ec : get_result.locations.error_codes) {
+                if (ec != ErrorCode::EC_OK && ec != ErrorCode::EC_NOENT) {
+                    get_locations_ec = ErrorCode::EC_ERROR;
+                    break;
+                }
+            }
+        }
     }
     if (get_locations_ec != ErrorCode::EC_OK) {
         admission_result.result = MakeErrorResult(
@@ -707,6 +647,13 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                                                     (*expected_location_values)[block_key_idx][i]);
             }
         }
+        std::unordered_map<std::string, int64_t> expected_create_times_by_location;
+        if (expected_location_create_times != nullptr) {
+            for (size_t i = 0; i < (*target_location_ids)[block_key_idx].size(); ++i) {
+                expected_create_times_by_location.emplace((*target_location_ids)[block_key_idx][i],
+                                                          (*expected_location_create_times)[block_key_idx][i]);
+            }
+        }
         auto block_key = block_keys[block_key_idx];
         auto &location_map = location_maps[block_key_idx];
         std::vector<MetaSearcher::LocationCASTask> location_cas_tasks;
@@ -720,6 +667,16 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
             }
             if (target_location_ids != nullptr && target_ids.find(location.id()) == target_ids.end()) {
                 continue;
+            }
+            if (source_location_lease_checker_ &&
+                source_location_lease_checker_(instance_id, block_key, location.id(), location.create_time())) {
+                continue;
+            }
+            if (expected_location_create_times != nullptr) {
+                const auto expected = expected_create_times_by_location.find(location.id());
+                if (expected == expected_create_times_by_location.end() || location.create_time() != expected->second) {
+                    continue;
+                }
             }
             std::string expected_location_value;
             if (expected_location_values != nullptr) {
@@ -746,7 +703,8 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
 
     std::vector<std::vector<ErrorCode>> batch_results;
     ErrorCode update_ec = meta_searcher.BatchCASLocationStatus(
-        request_context.get(), batch_cas_block_keys, batch_cas_tasks, batch_results, authoritative_read);
+        request_context.get(), batch_cas_block_keys, batch_cas_tasks, batch_results, authoritative_read, true);
+    source_lease_guard.unlock();
     if (update_ec != ErrorCode::EC_OK) {
         KVCM_LOG_DEBUG("Location status BatchCASLocationStatus not ok, ec: %d", update_ec);
     }

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -5,6 +5,7 @@
 #include <exception>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <tuple>
 #include <unordered_map>
@@ -672,11 +673,13 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                 source_location_lease_checker_(instance_id, block_key, location.id(), location.create_time())) {
                 continue;
             }
+            std::optional<int64_t> expected_create_time;
             if (expected_location_create_times != nullptr) {
                 const auto expected = expected_create_times_by_location.find(location.id());
-                if (expected == expected_create_times_by_location.end() || location.create_time() != expected->second) {
+                if (expected == expected_create_times_by_location.end()) {
                     continue;
                 }
+                expected_create_time = expected->second;
             }
             std::string expected_location_value;
             if (expected_location_values != nullptr) {
@@ -689,7 +692,8 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
             location_cas_tasks.push_back({location.id(),
                                           location.status(),
                                           CacheLocationStatus::CLS_DELETING,
-                                          std::move(expected_location_value)});
+                                          std::move(expected_location_value),
+                                          expected_create_time});
         }
         if (location_cas_tasks.empty()) {
             continue;

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <shared_mutex>
 #include <thread>
 #include <vector>
 
@@ -59,6 +60,10 @@ struct CacheLocationDelRequest {
     // Optional serialized values observed by the submitter, parallel to
     // location_ids. A location is reclaimed only if it is still unchanged.
     std::vector<std::vector<std::string>> expected_location_values;
+    // Optional create_time generation guard, parallel to location_ids. It is
+    // used by migration-owned source deletion after the active source lease
+    // is released, preventing a reused location id from being reclaimed.
+    std::vector<std::vector<int64_t>> expected_location_create_times;
     // Event-report metadata describes externally owned cache. Its reconciliation
     // cleanup must remove only KVCM metadata and never call the URI backend.
     bool metadata_only{false};
@@ -126,6 +131,8 @@ struct ScheduledTask {
 
 class SchedulePlanExecutor {
 public:
+    using SourceLocationLeaseChecker =
+        std::function<bool(const std::string &, int64_t, const std::string &, int64_t)>;
     explicit SchedulePlanExecutor(unsigned int thread_count,
                                   const std::shared_ptr<MetaIndexerManager> &meta_manager,
                                   const std::shared_ptr<DataStorageManager> &storage_manager,
@@ -150,6 +157,12 @@ public:
                     std::chrono::microseconds delay = std::chrono::microseconds(0),
                     std::function<void()> cancel_task = {});
 
+    void SetSourceLocationLeaseChecker(SourceLocationLeaseChecker checker);
+    // Migration holds the unique side from reservation through its NoTouch
+    // source recheck. Delete admission holds the shared side from its read
+    // through status CAS, closing both possible interleavings.
+    std::unique_lock<std::shared_mutex> AcquireSourceLocationLeaseReservationGuard();
+
 private:
     struct PromiseCompletion;
     struct LocationDelAdmissionResult {
@@ -171,6 +184,8 @@ private:
     std::mutex queue_mutex_;
     std::condition_variable condition_;
     std::atomic<uint64_t> sequence_counter_{0};
+    std::shared_mutex source_location_lease_mutex_;
+    SourceLocationLeaseChecker source_location_lease_checker_;
 
     void WorkerRoutine();
 
@@ -194,6 +209,7 @@ private:
                           const std::vector<int64_t> &block_keys,
                           const std::vector<std::vector<std::string>> *target_location_ids,
                           const std::vector<std::vector<std::string>> *expected_location_values,
+                          const std::vector<std::vector<int64_t>> *expected_location_create_times,
                           std::chrono::microseconds delay,
                           bool authoritative_read = false);
     void RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,

--- a/kv_cache_manager/manager/test/BUILD
+++ b/kv_cache_manager/manager/test/BUILD
@@ -91,6 +91,16 @@ cc_test(
 )
 
 cc_test(
+    name = "MigrationAdmissionInternalTest",
+    srcs = ["migration_admission_internal_test.cc"],
+    linkstatic = True,
+    deps = [
+        "//kv_cache_manager/common:unittest",
+        "//kv_cache_manager/manager:migration_manager",
+    ],
+)
+
+cc_test(
     name = "MetaSearcherTest",
     srcs = [
         "meta_searcher_test.cc",

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -9459,6 +9459,7 @@ TEST_F(CacheManagerTest, TestMigrationTargetsRespectGroupQuota) {
     request.src_storage_name = "hot_01";
     request.dst_storage_name = "cold_01";
     request.src_specs = {LocationSpec("tp0", "dummy://hot_01/source?size=1")};
+    request.src_create_time = 1;
     const auto results = cache_manager_->migration_manager()->BatchSubmit("target-quota", {request});
     ASSERT_EQ(1u, results.size());
     EXPECT_EQ(EC_NOSPC, results[0]);
@@ -10095,7 +10096,7 @@ TEST_F(CacheManagerTest, TestAdminMarkUsesMatchingStrategyTimeout) {
     EXPECT_LE(marks[0].deadline_ms, after_deadline);
 }
 
-TEST_F(CacheManagerTest, TestAdminMarkAllowsUnmatchedTargetWithDefaultTimeout) {
+TEST_F(CacheManagerTest, TestAdminMarkRejectsUnmatchedTargetRoute) {
     EnableTieredMigrationStrategy("default", "hot_01", "cold_01", 3000);
     cache_manager_->StartMigrationManager();
     ASSERT_TRUE(RegisterDummyStorage("cold_02"));
@@ -10121,7 +10122,6 @@ TEST_F(CacheManagerTest, TestAdminMarkAllowsUnmatchedTargetWithDefaultTimeout) {
     ASSERT_EQ(EC_OK,
               meta_searcher->BatchUpdateLocationStatus(request_context_.get(), {1}, status_tasks, status_results));
 
-    const auto before = std::chrono::system_clock::now();
     const auto result = cache_manager_->MigrateCache(request_context_.get(),
                                                      "admin-mark-unmatched-target",
                                                      "admin_mark_unmatched_target",
@@ -10131,9 +10131,8 @@ TEST_F(CacheManagerTest, TestAdminMarkAllowsUnmatchedTargetWithDefaultTimeout) {
                                                      true,
                                                      {1},
                                                      0);
-    const auto after = std::chrono::system_clock::now();
-    ASSERT_EQ(EC_OK, result.ec);
-    ASSERT_EQ(1, result.accepted);
+    ASSERT_EQ(EC_BADARGS, result.ec);
+    ASSERT_EQ(0, result.accepted);
     ASSERT_EQ(0, result.rejected);
 
     std::vector<MigrationManager::MarkQueryResult> marks;
@@ -10141,16 +10140,7 @@ TEST_F(CacheManagerTest, TestAdminMarkAllowsUnmatchedTargetWithDefaultTimeout) {
         EC_OK,
         cache_manager_->migration_manager()->BatchGetTieredWriteTargets("admin_mark_unmatched_target", {1}, marks));
     ASSERT_EQ(1u, marks.size());
-    ASSERT_TRUE(marks[0].HasValidMark());
-    EXPECT_EQ("cold_02", marks[0].target);
-    const auto before_deadline =
-        std::chrono::duration_cast<std::chrono::milliseconds>(before.time_since_epoch()).count() +
-        MigrationMarkMethod::kDefaultTimeoutMs;
-    const auto after_deadline =
-        std::chrono::duration_cast<std::chrono::milliseconds>(after.time_since_epoch()).count() +
-        MigrationMarkMethod::kDefaultTimeoutMs;
-    EXPECT_GE(marks[0].deadline_ms, before_deadline);
-    EXPECT_LE(marks[0].deadline_ms, after_deadline);
+    ASSERT_FALSE(marks[0].HasValidMark());
 }
 
 TEST_F(CacheManagerTest, TestFinishWriteCacheFullBlockPolicyKeepsPartialMark) {

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -340,6 +340,15 @@ MetaIndexer::Result MetaIndexer_GetProperties_stub(void *obj,
     return result;
 }
 
+MetaIndexer::Result MetaIndexer_GetPropertiesForMaintenance_stub(
+    void *obj,
+    RequestContext *rc,
+    const KeyVector &k,
+    const std::vector<std::string> &p,
+    PropertyMapVector &out_properties) noexcept {
+    return MetaIndexer_GetProperties_stub(obj, rc, k, p, out_properties);
+}
+
 /* ---------------- MetaIndexer_RandomSample_stub ---------------- */
 
 std::chrono::milliseconds mi_randsample_delay{0};
@@ -449,6 +458,36 @@ ErrorCode MetaSearcher_BatchGetLocation_stub(void *obj,
     return batch_get_loc_result;
 }
 
+MetaIndexer::MaintenanceGetResult MetaIndexer_GetForMaintenance_stub(
+    void * /*obj*/,
+    RequestContext * /*rc*/,
+    const KeyVector &keys,
+    const std::vector<std::string> & /*property_names*/,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
+    if (batch_get_loc_result == EC_OK && batch_get_loc_out_maps.size() == keys.size()) {
+        out_locations = batch_get_loc_out_maps;
+    } else {
+        out_locations.assign(keys.size(), CacheLocationMap{});
+    }
+    if (get_result == EC_OK && get_out_properties.size() == keys.size()) {
+        out_properties = get_out_properties;
+    } else {
+        out_properties.assign(keys.size(), PropertyMap{});
+    }
+
+    MetaIndexer::MaintenanceGetResult result(keys.size());
+    if (batch_get_loc_result != EC_OK) {
+        result.locations.ec = batch_get_loc_result;
+        std::fill(result.locations.error_codes.begin(), result.locations.error_codes.end(), batch_get_loc_result);
+    }
+    if (get_result != EC_OK) {
+        result.properties.ec = get_result;
+        std::fill(result.properties.error_codes.begin(), result.properties.error_codes.end(), get_result);
+    }
+    return result;
+}
+
 std::vector<MigrationManager::MigrationRequest> captured_copy_reqs;
 std::vector<std::vector<MigrationManager::MigrationRequest>> captured_copy_req_batches;
 std::vector<MigrationManager::CopyConcurrencyLimit> captured_copy_limits;
@@ -466,6 +505,8 @@ public:
                   SchedulePlanExecutor_SubmitAsync_stub);
         stub_.set(ADDR(MetaIndexerManager, GetMetaIndexer), MetaIndexerManager_GetMetaIndexer_stub);
         stub_.set(ADDR(MetaIndexer, GetProperties), MetaIndexer_GetProperties_stub);
+        stub_.set(ADDR(MetaIndexer, GetPropertiesForMaintenance), MetaIndexer_GetPropertiesForMaintenance_stub);
+        stub_.set(ADDR(MetaIndexer, GetForMaintenance), MetaIndexer_GetForMaintenance_stub);
         stub_.set(ADDR(MetaIndexer, RandomSample), MetaIndexer_RandomSample_stub);
         stub_.set(ADDR(MetaIndexer, SampleReclaimKeys), MetaIndexer_SampleReclaimKeys_stub);
         stub_.set(ADDR(MetaIndexer, GetKeyCount), MetaIndexer_GetKeyCount_stub);
@@ -667,6 +708,8 @@ public:
         stub_.reset(static_cast<spe_submit_async_loc>(ADDR(SchedulePlanExecutor, SubmitAsync)));
         stub_.reset(ADDR(MetaIndexerManager, GetMetaIndexer));
         stub_.reset(ADDR(MetaIndexer, GetProperties));
+        stub_.reset(ADDR(MetaIndexer, GetPropertiesForMaintenance));
+        stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
         stub_.reset(ADDR(MetaIndexer, RandomSample));
         stub_.reset(ADDR(MetaIndexer, SampleReclaimKeys));
         stub_.reset(ADDR(MetaIndexer, GetKeyCount));
@@ -5789,11 +5832,8 @@ CacheLocationConstPtr MakeServingLoc(const std::string &id, const std::string &s
 //   12             -> 仅在 other_storage(非源)
 //   13             -> hot_01 + cold_01(目标已有 WRITING location)
 //   40             -> 仅在 hot_02
-ErrorCode MigrateTest_BatchGetLocation_stub(void *obj,
-                                            RequestContext *rc,
-                                            const std::vector<std::int64_t> &kv,
-                                            const BlockMask &bm,
-                                            std::vector<CacheLocationMap> &out_loc_maps) {
+void BuildMigrateTestLocationMaps(const std::vector<std::int64_t> &kv,
+                                  std::vector<CacheLocationMap> &out_loc_maps) {
     ++batch_get_loc_call_counter;
     out_loc_maps.clear();
     for (const auto k : kv) {
@@ -5838,7 +5878,18 @@ ErrorCode MigrateTest_BatchGetLocation_stub(void *obj,
         }
         out_loc_maps.emplace_back(std::move(m));
     }
-    return ErrorCode::EC_OK;
+}
+
+MetaIndexer::MaintenanceGetResult MigrateTest_GetForMaintenance_stub(
+    void * /*obj*/,
+    RequestContext * /*rc*/,
+    const KeyVector &keys,
+    const std::vector<std::string> & /*property_names*/,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
+    BuildMigrateTestLocationMaps(keys, out_locations);
+    out_properties.assign(keys.size(), PropertyMap{});
+    return MetaIndexer::MaintenanceGetResult(keys.size());
 }
 
 namespace {
@@ -5847,18 +5898,21 @@ std::condition_variable async_prepare_read_cv;
 bool async_prepare_read_started = false;
 bool release_async_prepare_read = false;
 
-ErrorCode BlockingMigrateTest_BatchGetLocation_stub(void *obj,
-                                                    RequestContext *rc,
-                                                    const std::vector<std::int64_t> &kv,
-                                                    const BlockMask &bm,
-                                                    std::vector<CacheLocationMap> &out_loc_maps) {
+MetaIndexer::MaintenanceGetResult BlockingMigrateTest_GetForMaintenance_stub(
+    void *obj,
+    RequestContext *rc,
+    const KeyVector &keys,
+    const std::vector<std::string> &property_names,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
     {
         std::unique_lock<std::mutex> lock(async_prepare_read_mutex);
         async_prepare_read_started = true;
         async_prepare_read_cv.notify_all();
         async_prepare_read_cv.wait(lock, []() { return release_async_prepare_read; });
     }
-    return MigrateTest_BatchGetLocation_stub(obj, rc, kv, bm, out_loc_maps);
+    return MigrateTest_GetForMaintenance_stub(
+        obj, rc, keys, property_names, out_locations, out_properties);
 }
 } // namespace
 
@@ -5876,17 +5930,23 @@ std::vector<ErrorCode> MigrationManager_BatchSubmit_stub(void *obj,
     return std::vector<ErrorCode>(requests.size(), ErrorCode::EC_OK);
 }
 
-ErrorCode MigrationManager_MarkForTieredWrite_stub(void *obj,
-                                                   const std::string &instance_id,
-                                                   const std::vector<std::int64_t> &block_keys,
-                                                   const std::string &dst_storage_name,
-                                                   int64_t timeout_ms) {
+MigrationManager::MarkWriteResult MigrationManager_MarkForTieredWriteDetailed_stub(
+    void *obj,
+    const std::string &instance_id,
+    const std::vector<std::int64_t> &block_keys,
+    const std::string &dst_storage_name,
+    int64_t timeout_ms) {
     static_cast<void>(obj);
     static_cast<void>(instance_id);
     static_cast<void>(timeout_ms);
     captured_mark_keys = block_keys;
     captured_mark_target = dst_storage_name;
-    return ErrorCode::EC_OK;
+    MigrationManager::MarkWriteResult result;
+    result.outcomes.resize(block_keys.size());
+    for (auto &outcome : result.outcomes) {
+        outcome.status = MigrationManager::MarkWriteStatus::kInserted;
+    }
+    return result;
 }
 
 std::vector<std::int64_t> captured_async_prepare_keys;
@@ -5915,12 +5975,13 @@ MakeStrategy(const std::string &src, const std::string &dst, bool copy_enabled, 
 
 TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareDispatch) {
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
-    stub_.set(ADDR(MigrationManager, MarkForTieredWrite), MigrationManager_MarkForTieredWrite_stub);
+    stub_.set(ADDR(MigrationManager, MarkForTieredWriteDetailed),
+              MigrationManager_MarkForTieredWriteDetailed_stub);
 
     cache_reclaimer_->job_state_flag_ = true; // 让 IsRunning() 为真，无需启动 cron 线程
 
     const auto ins_info = InstanceInfoFactory();
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     const auto configure_strategy = [&](const MigrationStrategy &strategy, const std::size_t copy_limit) {
         auto instance_group = InstanceGroupFactory();
         auto config = std::make_shared<CacheConfig>();
@@ -5940,6 +6001,7 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareDispatch) {
 
         const auto strategy = MakeStrategy("hot_01", "cold_01", /*copy*/ true, /*mark*/ false);
         configure_strategy(strategy, 5);
+        ASSERT_EQ(EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 4));
         ASSERT_TRUE(cache_reclaimer_->SubmitMigrationPrepareJob(request_context_, ins_info, strategy, batch));
         ASSERT_TRUE(WaitForAsyncMigrationIdle());
 
@@ -5976,6 +6038,7 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareDispatch) {
 
         const auto strategy = MakeStrategy("hot_01", "cold_01", /*copy*/ true, /*mark*/ false);
         configure_strategy(strategy, 2);
+        ASSERT_EQ(EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 2));
         ASSERT_TRUE(cache_reclaimer_->SubmitMigrationPrepareJob(request_context_, ins_info, strategy, batch));
         ASSERT_TRUE(WaitForAsyncMigrationIdle());
 
@@ -5996,6 +6059,7 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareDispatch) {
 
         const auto strategy = MakeStrategy("hot_01", "cold_01", /*copy*/ false, /*mark*/ true);
         configure_strategy(strategy, 1);
+        ASSERT_EQ(EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 1));
         ASSERT_TRUE(cache_reclaimer_->SubmitMigrationPrepareJob(request_context_, ins_info, strategy, batch));
         ASSERT_TRUE(WaitForAsyncMigrationIdle());
 
@@ -6015,6 +6079,7 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareDispatch) {
 
         const auto strategy = MakeStrategy("hot_01", "cold_01", /*copy*/ true, /*mark*/ true);
         configure_strategy(strategy, 2);
+        ASSERT_EQ(EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 3));
         ASSERT_TRUE(cache_reclaimer_->SubmitMigrationPrepareJob(request_context_, ins_info, strategy, batch));
         ASSERT_TRUE(WaitForAsyncMigrationIdle());
 
@@ -6031,9 +6096,9 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareDispatch) {
         ASSERT_EQ("cold_01", captured_mark_target);
     }
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
-    stub_.reset(ADDR(MigrationManager, MarkForTieredWrite));
+    stub_.reset(ADDR(MigrationManager, MarkForTieredWriteDetailed));
 }
 
 TEST_F(CacheReclaimerTest, TestReclaimAdmissionExcludesVictimFromSameRoundMigration) {
@@ -6137,7 +6202,7 @@ TEST_F(CacheReclaimerTest, TestFairReclaimStillRunsMigrationBelowReclaimThreshol
 }
 
 TEST_F(CacheReclaimerTest, TestAsyncMigrationPendingSnapshotRemainsBlockScoped) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
     cache_reclaimer_->job_state_flag_ = true;
 
@@ -6159,6 +6224,7 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPendingSnapshotRemainsBlockScoped) 
     cache_reclaimer_->pending_locations_.insert({ins_info->instance_id(), 62, "dst_62"});
 
     captured_copy_reqs.clear();
+    ASSERT_EQ(EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 3));
     ASSERT_TRUE(cache_reclaimer_->SubmitMigrationPrepareJob(request_context_, ins_info, strategy, {60, 61, 62}));
     ASSERT_TRUE(WaitForAsyncMigrationIdle());
 
@@ -6166,7 +6232,7 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPendingSnapshotRemainsBlockScoped) 
     EXPECT_EQ(61, captured_copy_reqs[0].block_key);
     EXPECT_EQ(62, captured_copy_reqs[1].block_key);
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
 }
 
@@ -6228,9 +6294,10 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareCoalescesAndRevalidatesStrat
 }
 
 TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareRejectsAmbiguousRoute) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
-    stub_.set(ADDR(MigrationManager, MarkForTieredWrite), MigrationManager_MarkForTieredWrite_stub);
+    stub_.set(ADDR(MigrationManager, MarkForTieredWriteDetailed),
+              MigrationManager_MarkForTieredWriteDetailed_stub);
 
     const auto ins_info = InstanceInfoFactory();
     const auto copy_strategy = MakeStrategy("hot_01", "cold_01", /*copy*/ true, /*mark*/ false);
@@ -6264,9 +6331,9 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationPrepareRejectsAmbiguousRoute) {
     EXPECT_TRUE(captured_copy_reqs.empty());
     EXPECT_TRUE(captured_mark_keys.empty());
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
-    stub_.reset(ADDR(MigrationManager, MarkForTieredWrite));
+    stub_.reset(ADDR(MigrationManager, MarkForTieredWriteDetailed));
 }
 
 TEST_F(CacheReclaimerTest, TestMigrationManagerStopWaitsForRunningAsyncPrepare) {
@@ -6286,7 +6353,7 @@ TEST_F(CacheReclaimerTest, TestMigrationManagerStopWaitsForRunningAsyncPrepare) 
         async_prepare_read_started = false;
         release_async_prepare_read = false;
     }
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), BlockingMigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), BlockingMigrateTest_GetForMaintenance_stub);
 
     MigrationManager::AsyncMigrationPrepareJob job;
     job.trace_id = request_context_->trace_id();
@@ -6331,7 +6398,7 @@ TEST_F(CacheReclaimerTest, TestMigrationManagerStopWaitsForRunningAsyncPrepare) 
 }
 
 TEST_F(CacheReclaimerTest, TestQueuedAsyncMigrationFromPreviousGenerationIsDiscarded) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
 
     const auto ins_info = InstanceInfoFactory();
@@ -6393,7 +6460,7 @@ TEST_F(CacheReclaimerTest, TestQueuedAsyncMigrationFromPreviousGenerationIsDisca
     ASSERT_EQ(1u, captured_copy_req_batches[0].size());
     EXPECT_EQ(10, captured_copy_req_batches[0][0].block_key);
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
 }
 
@@ -6467,7 +6534,7 @@ TEST_F(CacheReclaimerTest, TestPendingLocationSnapshotIsScopedByInstanceAndBlock
 }
 
 TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupAccountsForPendingPrepareAcrossTicks) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
     cache_reclaimer_->job_state_flag_ = true;
     rm_->data_storage_manager_ = dsm_;
@@ -6549,12 +6616,12 @@ TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupAccountsForPendingPrepareAcrossT
     EXPECT_EQ(0, sampled_when_full) << "a full pending budget must prune before candidate sampling";
     EXPECT_TRUE(became_idle);
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
 }
 
 TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupReusesSampledBatchAcrossStrategies) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
 
     cache_reclaimer_->job_state_flag_ = true;
@@ -6622,15 +6689,16 @@ TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupReusesSampledBatchAcrossStrategi
         ASSERT_EQ(2u, limit.max_concurrency);
     }
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
 }
 
 // 水位低于 trigger_threshold 时 TryMigrateOnGroup 不下发任何 copy/mark。
 TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupSkipsBelowThreshold) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
-    stub_.set(ADDR(MigrationManager, MarkForTieredWrite), MigrationManager_MarkForTieredWrite_stub);
+    stub_.set(ADDR(MigrationManager, MarkForTieredWriteDetailed),
+              MigrationManager_MarkForTieredWriteDetailed_stub);
 
     cache_reclaimer_->job_state_flag_ = true;
     rm_->data_storage_manager_ = dsm_;
@@ -6677,16 +6745,17 @@ TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupSkipsBelowThreshold) {
     ASSERT_EQ(0, sample_reclaim_call_counter); // 未触发采样
     ASSERT_EQ(0, batch_get_loc_call_counter);
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
-    stub_.reset(ADDR(MigrationManager, MarkForTieredWrite));
+    stub_.reset(ADDR(MigrationManager, MarkForTieredWriteDetailed));
 }
 
 // quota 中不含源 storage 对应 type 时（capacity<=0），TryMigrateOnGroup 跳过该 strategy。
 TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupSkipsWhenNoCapacity) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
-    stub_.set(ADDR(MigrationManager, MarkForTieredWrite), MigrationManager_MarkForTieredWrite_stub);
+    stub_.set(ADDR(MigrationManager, MarkForTieredWriteDetailed),
+              MigrationManager_MarkForTieredWriteDetailed_stub);
 
     cache_reclaimer_->job_state_flag_ = true;
     rm_->data_storage_manager_ = dsm_;
@@ -6730,14 +6799,14 @@ TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupSkipsWhenNoCapacity) {
     ASSERT_EQ(0, sample_reclaim_call_counter);
     ASSERT_EQ(0, batch_get_loc_call_counter);
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
-    stub_.reset(ADDR(MigrationManager, MarkForTieredWrite));
+    stub_.reset(ADDR(MigrationManager, MarkForTieredWriteDetailed));
 }
 
 // VCNS_HF3FS 在水位/用量统计上归并到 HF3FS；迁移策略查 source type quota 时也应一致归并。
 TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupNormalizesVcnsSourceTypeForQuota) {
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     stub_.set(ADDR(MigrationManager, BatchSubmit), MigrationManager_BatchSubmit_stub);
 
     cache_reclaimer_->job_state_flag_ = true;
@@ -6783,7 +6852,7 @@ TEST_F(CacheReclaimerTest, TestTryMigrateOnGroupNormalizesVcnsSourceTypeForQuota
     ASSERT_EQ(50, captured_copy_reqs[0].block_key);
     ASSERT_EQ("hot_vcns", captured_copy_reqs[0].src_storage_name);
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
 }
 
@@ -6815,10 +6884,11 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationCopyFailureFallsBackToMark) {
     captured_mark_keys.clear();
     captured_mark_target.clear();
 
-    stub_.set(ADDR(MetaSearcher, BatchGetLocation), MigrateTest_BatchGetLocation_stub);
+    stub_.set(ADDR(MetaIndexer, GetForMaintenance), MigrateTest_GetForMaintenance_stub);
     // 用部分失败的 BatchSubmit stub
     stub_.set(ADDR(MigrationManager, BatchSubmit), BatchSubmit_PartialFail_stub);
-    stub_.set(ADDR(MigrationManager, MarkForTieredWrite), MigrationManager_MarkForTieredWrite_stub);
+    stub_.set(ADDR(MigrationManager, MarkForTieredWriteDetailed),
+              MigrationManager_MarkForTieredWriteDetailed_stub);
 
     // batch = {20, 21, 22}：全部合格，group copy slots 足够。
     const std::vector<std::int64_t> batch = {20, 21, 22};
@@ -6832,6 +6902,7 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationCopyFailureFallsBackToMark) {
     instance_group->set_cache_config(config);
     EnableAsyncMigration(instance_group, ins_info);
 
+    ASSERT_EQ(EC_OK, cache_reclaimer_->SetBatchingSize(request_context_.get(), 3));
     ASSERT_TRUE(cache_reclaimer_->SubmitMigrationPrepareJob(request_context_, ins_info, strategy, batch));
     ASSERT_TRUE(WaitForAsyncMigrationIdle());
 
@@ -6842,9 +6913,9 @@ TEST_F(CacheReclaimerTest, TestAsyncMigrationCopyFailureFallsBackToMark) {
     ASSERT_EQ(21, captured_mark_keys[0]);
     ASSERT_EQ("cold_01", captured_mark_target);
 
-    stub_.reset(ADDR(MetaSearcher, BatchGetLocation));
+    stub_.reset(ADDR(MetaIndexer, GetForMaintenance));
     stub_.reset(ADDR(MigrationManager, BatchSubmit));
-    stub_.reset(ADDR(MigrationManager, MarkForTieredWrite));
+    stub_.reset(ADDR(MigrationManager, MarkForTieredWriteDetailed));
 }
 
 // multi-cold union：多个 cold SERVING location 联合覆盖 hot 的多 specs 时允许删除 hot。

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -3802,6 +3802,41 @@ TEST_F(MetaSearcherTest, TestBatchCASLocationStatusChecksExactLocationValue) {
     ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), results);
 }
 
+TEST_F(MetaSearcherTest, TestBatchCASLocationStatusChecksCreateTimeInsideRmw) {
+    MetaSearcher::KeyVector keys = {151};
+    auto location = MetaSearcherTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS, 1, MetaSearcherTestHelper::CreateDefaultLocationSpecs());
+    CacheLocationVector locations = {location};
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(EC_OK,
+              BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), keys, locations, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    const int64_t create_time = location_maps[0].at(location_ids[0])->create_time();
+    ASSERT_GT(create_time, 0);
+
+    std::vector<std::vector<MetaSearcher::LocationCASTask>> mismatch_tasks = {{
+        MetaSearcher::LocationCASTask{location_ids[0], CLS_WRITING, CLS_DELETING, "", create_time + 1},
+    }};
+    std::vector<std::vector<ErrorCode>> results;
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchCASLocationStatus(request_context_.get(), keys, mismatch_tasks, results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), results);
+
+    location_maps.clear();
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    ASSERT_EQ(CLS_WRITING, location_maps[0].at(location_ids[0])->status());
+
+    std::vector<std::vector<MetaSearcher::LocationCASTask>> matching_tasks = {{
+        MetaSearcher::LocationCASTask{location_ids[0], CLS_WRITING, CLS_DELETING, "", create_time},
+    }};
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchCASLocationStatus(request_context_.get(), keys, matching_tasks, results));
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), results);
+}
+
 TEST_F(MetaSearcherTest, TestBatchCADLocationStatus) {
     // 准备测试数据
     MetaSearcher::KeyVector keys = {400, 500, 600};

--- a/kv_cache_manager/manager/test/migration_admission_internal_test.cc
+++ b/kv_cache_manager/manager/test/migration_admission_internal_test.cc
@@ -1,0 +1,87 @@
+#include <limits>
+
+#include "kv_cache_manager/common/unittest.h"
+#include "kv_cache_manager/manager/migration_admission_internal.h"
+
+using namespace kv_cache_manager;
+
+namespace {
+
+MigrationCandidateFeatures LastAccess(ObservedFeatureStatus status, std::int64_t value = 0) {
+    MigrationCandidateFeatures features;
+    ObservedFeature observed;
+    observed.status = status;
+    if (status == ObservedFeatureStatus::kAvailable) {
+        observed.value = value;
+    }
+    features.Set(MigrationAdmissionFeature::kLastAccessTime, std::move(observed));
+    return features;
+}
+
+MigrationAdmissionConfig RecentAccessConfig(MigrationAdmissionMode mode, std::int64_t window_seconds) {
+    MigrationAdmissionConfig config;
+    config.set_mode(mode);
+    auto policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+    policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(window_seconds));
+    config.set_policies({policy});
+    return config;
+}
+
+} // namespace
+
+TEST(MigrationAdmissionInternalTest, RecentAccessBoundariesAndUnknownReasons) {
+    RecentAccessAdmissionPolicy policy(10 * 1000 * 1000);
+    const MigrationAdmissionContext context{100 * 1000 * 1000};
+    const auto decisions = policy.EvaluateBatch(
+        {LastAccess(ObservedFeatureStatus::kAvailable, 95 * 1000 * 1000),
+         LastAccess(ObservedFeatureStatus::kAvailable, 90 * 1000 * 1000),
+         LastAccess(ObservedFeatureStatus::kAvailable, 89 * 1000 * 1000),
+         LastAccess(ObservedFeatureStatus::kAvailable, 101 * 1000 * 1000),
+         LastAccess(ObservedFeatureStatus::kMissing),
+         LastAccess(ObservedFeatureStatus::kUnsupported),
+         LastAccess(ObservedFeatureStatus::kReadError)},
+        context);
+
+    ASSERT_EQ(7u, decisions.size());
+    EXPECT_EQ(MigrationAdmissionVerdict::kAccept, decisions[0].verdict);
+    EXPECT_EQ(MigrationAdmissionVerdict::kAccept, decisions[1].verdict);
+    EXPECT_EQ(MigrationAdmissionVerdict::kReject, decisions[2].verdict);
+    EXPECT_EQ(MigrationAdmissionReason::kNotRecent, decisions[2].reason);
+    EXPECT_EQ(MigrationAdmissionReason::kFeatureInvalid, decisions[3].reason);
+    EXPECT_EQ(MigrationAdmissionReason::kFeatureMissing, decisions[4].reason);
+    EXPECT_EQ(MigrationAdmissionReason::kFeatureUnsupported, decisions[5].reason);
+    EXPECT_EQ(MigrationAdmissionReason::kFeatureReadError, decisions[6].reason);
+}
+
+TEST(MigrationAdmissionInternalTest, AvailableFeatureWithWrongTypeIsInvalid) {
+    MigrationCandidateFeatures features;
+    features.Set(MigrationAdmissionFeature::kLastAccessTime,
+                 ObservedFeature{ObservedFeatureStatus::kAvailable, std::uint64_t{10}});
+    RecentAccessAdmissionPolicy policy(10);
+    const auto decisions = policy.EvaluateBatch({features}, MigrationAdmissionContext{20});
+    ASSERT_EQ(1u, decisions.size());
+    EXPECT_EQ(MigrationAdmissionVerdict::kUnknown, decisions[0].verdict);
+    EXPECT_EQ(MigrationAdmissionReason::kFeatureInvalid, decisions[0].reason);
+}
+
+TEST(MigrationAdmissionInternalTest, FactoryOnlyBuildsValidRecentAccess) {
+    std::string error;
+    auto disabled = MigrationAdmissionPolicyFactory::Build(MigrationAdmissionConfig{}, error);
+    EXPECT_EQ(nullptr, disabled);
+    EXPECT_TRUE(error.empty());
+
+    auto policy = MigrationAdmissionPolicyFactory::Build(
+        RecentAccessConfig(MigrationAdmissionMode::SHADOW, 1), error);
+    ASSERT_NE(nullptr, policy);
+    EXPECT_TRUE(policy->RequiredFeatures().test(
+        static_cast<std::size_t>(MigrationAdmissionFeature::kLastAccessTime)));
+
+    auto overflow = RecentAccessConfig(MigrationAdmissionMode::ENFORCE,
+                                       std::numeric_limits<std::int64_t>::max());
+    EXPECT_EQ(nullptr, MigrationAdmissionPolicyFactory::Build(overflow, error));
+    EXPECT_FALSE(error.empty());
+
+    auto invalid_mode = RecentAccessConfig(static_cast<MigrationAdmissionMode>(99), 1);
+    EXPECT_EQ(nullptr, MigrationAdmissionPolicyFactory::Build(invalid_mode, error));
+    EXPECT_FALSE(error.empty());
+}

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <future>
 #include <limits>
+#include <map>
 #include <mutex>
 #include <optional>
 #include <thread>
@@ -196,6 +197,90 @@ MetaIndexer::Result GetProperties_stub(void * /*obj*/,
 }
 } // namespace mark_query_result_stub
 
+namespace admission_dispatch_stub {
+MaintenancePropertyReadiness g_readiness;
+std::map<int64_t, CacheLocationMap> g_locations;
+std::map<int64_t, PropertyMap> g_properties;
+std::map<int64_t, ErrorCode> g_location_errors;
+std::map<int64_t, ErrorCode> g_property_errors;
+int g_snapshot_calls = 0;
+
+void Reset() {
+    g_readiness = {MaintenancePropertyCapability::kDurableAcrossRecovery, 0, 1};
+    g_locations.clear();
+    g_properties.clear();
+    g_location_errors.clear();
+    g_property_errors.clear();
+    g_snapshot_calls = 0;
+}
+
+MaintenancePropertyReadiness GetReadiness_stub(void * /*obj*/, const std::string & /*property_name*/) noexcept {
+    return g_readiness;
+}
+
+MetaIndexer::MaintenanceGetResult GetForMaintenance_stub(
+    void * /*obj*/,
+    RequestContext * /*request_context*/,
+    const KeyVector &keys,
+    const std::vector<std::string> & /*property_names*/,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
+    ++g_snapshot_calls;
+    out_locations.clear();
+    out_properties.clear();
+    out_locations.reserve(keys.size());
+    out_properties.reserve(keys.size());
+    MetaIndexer::MaintenanceGetResult result(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const auto location = g_locations.find(keys[i]);
+        out_locations.push_back(location == g_locations.end() ? CacheLocationMap{} : location->second);
+        const auto property = g_properties.find(keys[i]);
+        out_properties.push_back(property == g_properties.end() ? PropertyMap{} : property->second);
+        if (const auto error = g_location_errors.find(keys[i]); error != g_location_errors.end()) {
+            result.locations.error_codes[i] = error->second;
+        }
+        if (const auto error = g_property_errors.find(keys[i]); error != g_property_errors.end()) {
+            result.properties.error_codes[i] = error->second;
+        }
+    }
+    return result;
+}
+} // namespace admission_dispatch_stub
+
+MigrationAdmissionConfig RecentAccessAdmission(MigrationAdmissionMode mode, int64_t window_seconds) {
+    MigrationAdmissionConfig config;
+    config.set_mode(mode);
+    auto policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+    policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(window_seconds));
+    config.set_policies({policy});
+    return config;
+}
+
+int64_t OutcomeCount(const MigrationManager::DispatchBatchResult &result,
+                     MigrationOutcomeStage stage,
+                     MigrationOutcomeClass outcome_class,
+                     MigrationOutcomeReason reason,
+                     bool terminal) {
+    int64_t count = 0;
+    for (const auto &outcome : result.outcome_counts) {
+        if (outcome.stage == stage && outcome.outcome_class == outcome_class && outcome.reason == reason &&
+            outcome.terminal == terminal) {
+            count += outcome.count;
+        }
+    }
+    return count;
+}
+
+int64_t TerminalOutcomeCount(const MigrationManager::DispatchBatchResult &result) {
+    int64_t count = 0;
+    for (const auto &outcome : result.outcome_counts) {
+        if (outcome.terminal) {
+            count += outcome.count;
+        }
+    }
+    return count;
+}
+
 namespace preparing_reservation_stub {
 MigrationManager *g_manager = nullptr;
 std::vector<std::pair<std::string, int64_t>> g_expected_reservations;
@@ -267,6 +352,23 @@ MetaIndexer::Result ReadModifyWriteBlockFail_stub(void * /*obj*/,
                                                   const BlockIdsOnlyModifierFunc & /*modifier*/) noexcept {
     MetaIndexer::Result result(EC_ERROR);
     result.error_codes.assign(keys.size(), EC_ERROR);
+    return result;
+}
+
+MetaIndexer::Result ReadModifyWriteBlockPartial_stub(void * /*obj*/,
+                                                     RequestContext * /*rc*/,
+                                                     const KeyVector &keys,
+                                                     const BlockIdsOnlyModifierFunc &modifier) noexcept {
+    MetaIndexer::Result result(keys.size() > 1 ? EC_PARTIAL_OK : EC_OK);
+    result.error_codes.assign(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        PropertyMap properties;
+        CacheLocationMap new_locations;
+        static_cast<void>(modifier({"source_location"}, EC_OK, i, properties, new_locations));
+    }
+    if (keys.size() > 1) {
+        result.error_codes[1] = EC_NOSPC;
+    }
     return result;
 }
 
@@ -479,6 +581,16 @@ public:
         return (it == maps[0].end()) ? nullptr : it->second;
     }
 
+    CacheLocationMap GetLocationMap(int64_t block_key) {
+        auto request_context = std::make_shared<RequestContext>("get_location_map");
+        MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kInstance));
+        CacheLocationMapVector maps;
+        BlockMask empty_mask;
+        EXPECT_EQ(EC_OK, meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, maps));
+        EXPECT_EQ(1u, maps.size());
+        return maps.empty() ? CacheLocationMap{} : maps.front();
+    }
+
     size_t LocationCount(int64_t block_key) {
         auto rc = std::make_shared<RequestContext>("loc_count");
         MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kInstance));
@@ -585,7 +697,7 @@ TEST_F(MigrationManagerTest, TestBatchGetTieredWriteTargetsPreservesPartialResul
         {},
     };
     Stub stub;
-    stub.set(ADDR(MetaIndexer, GetProperties), mark_query_result_stub::GetProperties_stub);
+    stub.set(ADDR(MetaIndexer, GetPropertiesForMaintenance), mark_query_result_stub::GetProperties_stub);
 
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
     std::vector<MigrationManager::MarkQueryResult> results;
@@ -612,7 +724,7 @@ TEST_F(MigrationManagerTest, TestBatchGetTieredWriteTargetsReportsAllReadFailure
     mark_query_result_stub::g_per_key_ecs = {EC_ERROR, EC_ERROR};
     mark_query_result_stub::g_properties = {{}, {}};
     Stub stub;
-    stub.set(ADDR(MetaIndexer, GetProperties), mark_query_result_stub::GetProperties_stub);
+    stub.set(ADDR(MetaIndexer, GetPropertiesForMaintenance), mark_query_result_stub::GetProperties_stub);
 
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
     std::vector<MigrationManager::MarkQueryResult> results;
@@ -636,7 +748,7 @@ TEST_F(MigrationManagerTest, TestBatchGetTieredWriteTargetsDistinguishesBlockNot
     mark_query_result_stub::g_per_key_ecs = {EC_NOENT, EC_OK};
     mark_query_result_stub::g_properties = {{}, {}};
     Stub stub;
-    stub.set(ADDR(MetaIndexer, GetProperties), mark_query_result_stub::GetProperties_stub);
+    stub.set(ADDR(MetaIndexer, GetPropertiesForMaintenance), mark_query_result_stub::GetProperties_stub);
 
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
     std::vector<MigrationManager::MarkQueryResult> results;
@@ -657,7 +769,7 @@ TEST_F(MigrationManagerTest, TestBatchGetTieredWriteTargetsRejectsMisalignedOutp
     mark_query_result_stub::g_per_key_ecs = {EC_OK, EC_OK};
     mark_query_result_stub::g_properties = {{{MigrationManager::PROPERTY_TIERED_WRITE_TARGET, "stale"}}};
     Stub stub;
-    stub.set(ADDR(MetaIndexer, GetProperties), mark_query_result_stub::GetProperties_stub);
+    stub.set(ADDR(MetaIndexer, GetPropertiesForMaintenance), mark_query_result_stub::GetProperties_stub);
 
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
     MigrationManager::MarkQueryResult stale;
@@ -719,8 +831,14 @@ TEST_F(MigrationManagerTest, TestMalformedCleanupDoesNotClearValidRefresh) {
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
     ASSERT_FALSE(mgr.ClearTieredWriteMarkIfMatch(kInstance, 200, "cold_01", 0));
     ASSERT_EQ("cold_01", GetRawTieredWriteTarget(200));
-    // 模拟查询已拿到 malformed target 后，另一线程把它刷新成同 target 的合法 Mark。
-    ASSERT_EQ(EC_OK, mgr.MarkForTieredWrite(kInstance, {200}, "cold_01", 10000));
+    const auto malformed_write = mgr.MarkForTieredWriteDetailed(kInstance, {200}, "cold_01", 10000);
+    ASSERT_EQ(EC_OK, malformed_write.ec);
+    ASSERT_EQ(1u, malformed_write.outcomes.size());
+    ASSERT_EQ(MigrationManager::MarkWriteStatus::kMalformedExistingMark, malformed_write.outcomes[0].status);
+
+    // 模拟查询已拿到 malformed target 后，另一条 metadata 链路把它
+    // 修复成同 target 的合法 Mark。条件 Mark 自身不会覆盖 malformed 现状。
+    SetRawMark(200, "cold_01", std::to_string(TimestampUtil::GetCurrentTimeMs() + 10000));
     ASSERT_FALSE(mgr.ClearTieredWriteMarkIfMatchInternal(kInstance, 200, "cold_01", 0));
 
     std::vector<MigrationManager::MarkQueryResult> results;
@@ -804,8 +922,16 @@ TEST_F(MigrationManagerTest, TestClearMarkDoesNotClobberNewerMark) {
     const auto old_deadline = snap[0].deadline_ms;
     ASSERT_GT(old_deadline, 0);
 
-    // 覆盖：打 mark B: target=cold_02（模拟新一轮迁移打了不同目标的 mark）
-    ASSERT_EQ(ErrorCode::EC_OK, mgr.MarkForTieredWrite(kInstance, {1}, "cold_02"));
+    // 条件 Mark 不允许新 route 覆盖已有的不同 target。
+    const auto conflict = mgr.MarkForTieredWriteDetailed(kInstance, {1}, "cold_02");
+    ASSERT_EQ(ErrorCode::EC_OK, conflict.ec);
+    ASSERT_EQ(1u, conflict.outcomes.size());
+    ASSERT_EQ(MigrationManager::MarkWriteStatus::kConflictDifferentTarget, conflict.outcomes[0].status);
+    ASSERT_EQ("cold_01", mgr.GetTieredWriteTarget(kInstance, 1));
+
+    // 模拟另一条 metadata 链路已经将 Mark 更新为 B。
+    const auto new_deadline = TimestampUtil::GetCurrentTimeMs() + 10000;
+    SetRawMark(1, "cold_02", std::to_string(new_deadline));
     ASSERT_EQ("cold_02", mgr.GetTieredWriteTarget(kInstance, 1));
 
     // 用 mark A 的快照做 match-clear → 不应匹配（当前 mark 是 B）
@@ -930,20 +1056,30 @@ TEST_F(MigrationManagerTest, TestMarkExpiresByBackgroundCleanup) {
     mgr.Stop();
 }
 
-TEST_F(MigrationManagerTest, TestExpiredCleanupDoesNotClearRefreshedMark) {
+TEST_F(MigrationManagerTest, TestSameTargetMarkDoesNotRenewDeadline) {
     ASSERT_TRUE(CreateMetaIndexer(kInstance));
     ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "mark_refresh_hot/"));
     ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "mark_refresh_cold/"));
     CreateSourceLocation(7, "hot_01", false, "g");
 
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
-    mgr.Start();
-    ASSERT_EQ(ErrorCode::EC_OK, mgr.MarkForTieredWrite(kInstance, {7}, "cold_01", /*timeout_ms*/ 1));
-    ASSERT_EQ(ErrorCode::EC_OK, mgr.MarkForTieredWrite(kInstance, {7}, "cold_01", /*timeout_ms*/ 10000));
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    ASSERT_TRUE(mgr.IsMarkedForTieredWrite(kInstance, 7));
-    ASSERT_EQ("cold_01", mgr.GetTieredWriteTarget(kInstance, 7));
-    mgr.Stop();
+    ASSERT_EQ(ErrorCode::EC_OK, mgr.MarkForTieredWrite(kInstance, {7}, "cold_01", /*timeout_ms*/ 50));
+    std::vector<MigrationManager::MarkQueryResult> before;
+    ASSERT_EQ(EC_OK, mgr.BatchGetTieredWriteTargets(kInstance, {7}, before));
+    ASSERT_EQ(1u, before.size());
+    ASSERT_TRUE(before[0].HasValidMark());
+
+    const auto duplicate = mgr.MarkForTieredWriteDetailed(kInstance, {7}, "cold_01", /*timeout_ms*/ 10000);
+    ASSERT_EQ(EC_OK, duplicate.ec);
+    ASSERT_EQ(1u, duplicate.outcomes.size());
+    ASSERT_EQ(MigrationManager::MarkWriteStatus::kAlreadySameTarget, duplicate.outcomes[0].status);
+    std::vector<MigrationManager::MarkQueryResult> after;
+    ASSERT_EQ(EC_OK, mgr.BatchGetTieredWriteTargets(kInstance, {7}, after));
+    ASSERT_EQ(before[0].deadline_ms, after[0].deadline_ms);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    ASSERT_FALSE(mgr.IsMarkedForTieredWrite(kInstance, 7));
+    ASSERT_TRUE(GetRawTieredWriteTarget(7).empty());
 }
 
 // ============ Submit 参数校验 ============
@@ -1136,7 +1272,7 @@ TEST_F(MigrationManagerTest, TestSubmitThenSuccessSourceLost) {
 
     int64_t block_key = 250;
     std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "data");
-    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
     mgr.DebugEnableCopySubmissionsForTest();
     MigrationManager::MigrationRequest req;
     req.instance_id = kInstance;
@@ -1148,6 +1284,15 @@ TEST_F(MigrationManagerTest, TestSubmitThenSuccessSourceLost) {
     ASSERT_EQ(ErrorCode::EC_OK, mgr.Submit("t", req));
     std::string dst_loc = mgr.GetActiveTaskDstLocation(kInstance, block_key);
     ASSERT_EQ(CLS_WRITING, GetLocationStatus(block_key, dst_loc));
+    const auto source = GetLocation(block_key, src_loc);
+    ASSERT_NE(nullptr, source);
+    ASSERT_TRUE(mgr.HasActiveCopySourceLocation(kInstance, block_key, src_loc, source->create_time()));
+    ASSERT_FALSE(mgr.HasActiveCopySourceLocation(kInstance, block_key, src_loc, source->create_time() + 1));
+    ASSERT_EQ(1u,
+              metrics_registry_
+                  ->GetCounter("migration_source_lease_conflicts_total",
+                               {{"src", "hot_01"}, {"dst", "cold_01"}, {"deleter", "scheduled_delete"}})
+                  .Get());
 
     // Copy 字节完成后、收尾前源 location 已被其他路径删掉，目标副本应作废。
     DeleteLocationMeta(block_key, src_loc);
@@ -1162,6 +1307,16 @@ TEST_F(MigrationManagerTest, TestSubmitThenSuccessSourceLost) {
     ASSERT_EQ(1u, stats.copy_submitted);
     ASSERT_EQ(0u, stats.copy_completed);
     ASSERT_EQ(1u, stats.copy_failed);
+    ASSERT_EQ(4u,
+              metrics_registry_
+                  ->GetCounter("migration_copy_source_lost_written_bytes_total",
+                               {{"src", "hot_01"}, {"dst", "cold_01"}})
+                  .Get());
+    ASSERT_EQ(1u,
+              metrics_registry_
+                  ->GetCounter("migration_source_lease_duration_seconds_count",
+                               {{"src", "hot_01"}, {"dst", "cold_01"}})
+                  .Get());
 }
 
 // Submit 时 PrepareCopyTask 应记录 src_create_time。当源 location 的 create_time 与记录不匹配时
@@ -1855,7 +2010,8 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationFailureReleasesPreparingReserva
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
     mgr.DebugEnableCopySubmissionsForTest();
     Stub stub;
-    stub.set(ADDR(MetaIndexer, ReadModifyWriteBlock), preparing_reservation_stub::ReadModifyWriteBlockFail_stub);
+    stub.set(ADDR(MetaIndexer, ReadModifyWriteBlockForMaintenance),
+             preparing_reservation_stub::ReadModifyWriteBlockFail_stub);
 
     const auto results = mgr.BatchSubmit("batch_add_location_failure", {req});
     ASSERT_EQ(1u, results.size());
@@ -1872,31 +2028,27 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCo
     ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "reserve_partial_add_hot/"));
     ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "reserve_partial_add_cold/"));
 
-    auto indexer = meta_manager_->GetMetaIndexer(kInstance);
-    ASSERT_NE(nullptr, indexer);
-    indexer->batch_key_size_ = 1;
-    indexer->max_key_count_ = 1;
-
-    std::vector<int64_t> block_keys{814, 815};
-    // batch_key_size is a soft limit: every key in one mutex shard remains
-    // in the same batch. Select two shards using this indexer's runtime hash
-    // seed so max_key_count=1 deterministically exercises one successful
-    // batch followed by one capacity failure.
-    while (indexer->GetMutexShardIndex(block_keys[0]) == indexer->GetMutexShardIndex(block_keys[1])) {
-        ++block_keys[1];
-    }
+    const std::vector<int64_t> block_keys{814, 815};
     auto make_request = [&](int64_t block_key) {
+        const auto src_location_id = CreateSourceLocation(block_key, "hot_01", true, "partial-add");
+        const auto src = GetLocation(block_key, src_location_id);
+        EXPECT_NE(nullptr, src);
         MigrationManager::MigrationRequest req;
         req.instance_group_name = "group_a";
         req.instance_id = kInstance;
         req.block_key = block_key;
-        req.src_location_id = "src_" + std::to_string(block_key);
+        req.src_location_id = src_location_id;
+        req.src_create_time = src == nullptr ? 0 : src->create_time();
         req.src_storage_name = "hot_01";
         req.dst_storage_name = "cold_01";
-        req.src_specs = {
-            LocationSpec("TP0", "dummy://hot_01/src_" + std::to_string(block_key) + "?size=4")};
+        if (src != nullptr) {
+            req.src_specs = src->location_specs();
+        }
         return req;
     };
+
+    auto first = make_request(block_keys[0]);
+    auto second = make_request(block_keys[1]);
 
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_, nullptr);
     mgr.DebugEnableCopySubmissionsForTest();
@@ -1906,31 +2058,33 @@ TEST_F(MigrationManagerTest, TestBatchAddLocationPartialFailureKeepsSuccessfulCo
     Stub stub;
     stub.set(ADDR(DataStorageManager, Create), preparing_reservation_stub::Create_stub);
     stub.set(ADDR(DataStorageManager, Delete), preparing_reservation_stub::Delete_stub);
+    stub.set(ADDR(MetaIndexer, ReadModifyWriteBlockForMaintenance),
+             preparing_reservation_stub::ReadModifyWriteBlockPartial_stub);
     stub.set(static_cast<preparing_reservation_stub::CopySubmitLocation>(ADDR(SchedulePlanExecutor, Submit)),
              preparing_reservation_stub::CopySubmitPending_stub);
 
-    const auto results =
-        mgr.BatchSubmit("batch_add_location_partial", {make_request(block_keys[0]), make_request(block_keys[1])});
+    const auto results = mgr.BatchSubmit("batch_add_location_partial", {std::move(first), std::move(second)});
     ASSERT_EQ(2u, results.size());
-    ASSERT_TRUE((results[0] == EC_OK && results[1] == EC_NOSPC) ||
-                (results[1] == EC_OK && results[0] == EC_NOSPC));
+    ASSERT_EQ(EC_OK, results[0]);
+    ASSERT_EQ(EC_NOSPC, results[1]);
 
-    const std::size_t success_index = results[0] == EC_OK ? 0 : 1;
-    const std::size_t failed_index = 1 - success_index;
+    constexpr std::size_t success_index = 0;
+    constexpr std::size_t failed_index = 1;
     EXPECT_TRUE(mgr.HasMigrationTask(kInstance, block_keys[success_index]));
     EXPECT_FALSE(mgr.HasMigrationTask(kInstance, block_keys[failed_index]));
     EXPECT_EQ(1u, mgr.ActiveTaskCount());
     EXPECT_EQ(1u, preparing_reservation_stub::g_pending_copy_promises.size());
+    // Stub 只注入逐 key commit 结果，不落目标 metadata；两个 block 都保留原有源副本。
     EXPECT_EQ(1u, LocationCount(block_keys[success_index]));
-    EXPECT_EQ(0u, LocationCount(block_keys[failed_index]));
+    EXPECT_EQ(1u, LocationCount(block_keys[failed_index]));
     ASSERT_EQ(1u, preparing_reservation_stub::g_deleted_uris.size());
     EXPECT_NE(std::string::npos,
               preparing_reservation_stub::g_deleted_uris.front().ToUriString().find(
                   StringUtil::Uint64ToHex(block_keys[failed_index])));
 
-    // 统一口径：add 成功项已提交 executor（stub pending future），计入其 4 字节；
+    // 统一口径：add 成功项已提交 executor（stub pending future），计入其实际字节；
     // add 失败项（EC_NOSPC）已回滚且未提交，不计入。
-    EXPECT_EQ(4u,
+    EXPECT_EQ(std::string("partial-add").size(),
               metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total",
                                             {{"type", ToString(DataStorageType::DATA_STORAGE_TYPE_DUMMY)},
                                              {"unique_name", "cold_01"}})
@@ -2343,6 +2497,14 @@ TEST_F(MigrationManagerTest, TestBatchSubmitHeteroSpecCreateFailNoOrphan) {
     ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "orphan_hot/"));
     ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "orphan_cold/"));
 
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    mgr.DebugEnableCopySubmissionsForTest();
+
+    // 单 block,两个不同 size 的 spec → 落到两个 create_group。
+    const std::string src_location_id = CreateSourceLocation(700, "hot_01", true, "heterogeneous-source");
+    const auto src_location = GetLocation(700, src_location_id);
+    ASSERT_NE(nullptr, src_location);
+
     orphan_cleanup_stub::g_created_uris.clear();
     orphan_cleanup_stub::g_deleted_uris.clear();
     orphan_cleanup_stub::g_create_call_count = 0;
@@ -2350,14 +2512,11 @@ TEST_F(MigrationManagerTest, TestBatchSubmitHeteroSpecCreateFailNoOrphan) {
     stub.set(ADDR(DataStorageManager, Create), orphan_cleanup_stub::Create_stub);
     stub.set(ADDR(DataStorageManager, Delete), orphan_cleanup_stub::Delete_stub);
 
-    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
-    mgr.DebugEnableCopySubmissionsForTest();
-
-    // 单 block,两个不同 size 的 spec → 落到两个 create_group。
     MigrationManager::MigrationRequest req;
     req.instance_id = kInstance;
     req.block_key = 700;
-    req.src_location_id = "src_700";
+    req.src_location_id = src_location_id;
+    req.src_create_time = src_location->create_time();
     req.src_storage_name = "hot_01";
     req.dst_storage_name = "cold_01";
     req.src_specs = {
@@ -2401,6 +2560,7 @@ TEST_F(MigrationManagerTest, TestBatchSubmitShortCreateResultRollsBackWholeGroup
         request.instance_id = kInstance;
         request.block_key = block_key;
         request.src_location_id = src_location_id;
+        request.src_create_time = src_location->create_time();
         request.src_storage_name = "hot_01";
         request.dst_storage_name = "cold_01";
         request.src_specs = src_location->location_specs();
@@ -2445,6 +2605,7 @@ TEST_F(MigrationManagerTest, TestBatchSubmitLongCreateResultDeletesEveryReturned
         request.instance_id = kInstance;
         request.block_key = block_key;
         request.src_location_id = src_location_id;
+        request.src_create_time = src_location->create_time();
         request.src_storage_name = "hot_01";
         request.dst_storage_name = "cold_01";
         request.src_specs = src_location->location_specs();
@@ -2697,8 +2858,14 @@ CacheLocationConstPtr MakeLocationWithSpecs(const std::string &id,
 
 } // namespace
 
-TEST_F(MigrationManagerTest, TestDispatchSkipsMarkWhenDedupQueryFails) {
+TEST_F(MigrationManagerTest, TestDispatchDoesNotDependOnTouchingMarkPrequery) {
     ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "dispatch_mark_hot"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "dispatch_mark_cold"));
+    CreateSourceLocation(1, "hot_01", true, "payload");
+
+    // V1 的 Mark 正确性由最终条件 RMW 保证，Dispatch 不再做会 touch
+    // metadata 的预查询。即使旧 GetProperties 路径失败，也不应阻断 Mark。
     mark_query_result_stub::Reset();
     mark_query_result_stub::g_aggregate_ec = EC_ERROR;
     mark_query_result_stub::g_per_key_ecs = {EC_ERROR};
@@ -2706,21 +2873,279 @@ TEST_F(MigrationManagerTest, TestDispatchSkipsMarkWhenDedupQueryFails) {
     Stub stub;
     stub.set(ADDR(MetaIndexer, GetProperties), mark_query_result_stub::GetProperties_stub);
 
-    CacheLocationMap loc_map;
-    auto src_loc = MakeLocation("loc_src", "hot_01", CLS_SERVING);
-    loc_map[src_loc->id()] = src_loc;
     MigrationManager::DispatchBatchParams params;
     params.do_mark = true;
-    params.dedup_marks = true;
 
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
     mgr.DebugEnableCopySubmissionsForTest();
-    const auto result =
-        mgr.DispatchMigrationBatch("mark_query_error", kInstance, "hot_01", "cold_01", {1}, {loc_map}, params);
+    const auto result = mgr.DispatchMigrationBatch(
+        "mark_query_error", kInstance, "hot_01", "cold_01", {1}, params);
 
+    ASSERT_EQ(1, result.mark_submitted);
+    ASSERT_EQ(1u, mgr.GetStats().marks_added);
+}
+
+TEST_F(MigrationManagerTest, TestShadowFeatureFailureKeepsLegacyDispatchBehavior) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "shadow_feature_hot"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "shadow_feature_cold"));
+    for (const int64_t block_key : {11, 12}) {
+        CreateSourceLocation(block_key, "hot_01", false, "payload");
+    }
+
+    admission_dispatch_stub::Reset();
+    for (const int64_t block_key : {11, 12}) {
+        admission_dispatch_stub::g_locations[block_key] = GetLocationMap(block_key);
+        admission_dispatch_stub::g_property_errors[block_key] = EC_ERROR;
+    }
+    Stub stub;
+    stub.set(ADDR(MetaIndexer, GetMaintenancePropertyReadiness), admission_dispatch_stub::GetReadiness_stub);
+    stub.set(ADDR(MetaIndexer, GetForMaintenance), admission_dispatch_stub::GetForMaintenance_stub);
+
+    MigrationManager::DispatchBatchParams params;
+    params.do_mark = true;
+    params.admission = RecentAccessAdmission(MigrationAdmissionMode::SHADOW, 10);
+    MigrationManager manager(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    manager.DebugEnableCopySubmissionsForTest();
+
+    const auto result =
+        manager.DispatchMigrationBatch("shadow_feature_error", kInstance, "hot_01", "cold_01", {11, 12}, params);
+
+    ASSERT_EQ(EC_OK, result.ec);
+    ASSERT_EQ(2, result.mark_submitted);
+    ASSERT_EQ(0, result.rejected);
+    ASSERT_EQ(0, result.failed);
+    ASSERT_EQ(2, TerminalOutcomeCount(result));
+    ASSERT_EQ(2,
+              OutcomeCount(result,
+                           MigrationOutcomeStage::kValue,
+                           MigrationOutcomeClass::kRejected,
+                           MigrationOutcomeReason::kFeatureReadError,
+                           false));
+    ASSERT_EQ(2,
+              OutcomeCount(result,
+                           MigrationOutcomeStage::kMark,
+                           MigrationOutcomeClass::kAccepted,
+                           MigrationOutcomeReason::kMarkInserted,
+                           true));
+    const MetricsTags route_tags{{"trigger", "admin"},
+                                 {"src", "hot_01"},
+                                 {"dst", "cold_01"},
+                                 {"mode", "shadow"}};
+    ASSERT_EQ(2u, metrics_registry_->GetCounter("migration_admission_candidates_total", route_tags).Get());
+    ASSERT_EQ(2u,
+              metrics_registry_
+                  ->GetCounter("migration_admission_rejected_total",
+                               {{"trigger", "admin"},
+                                {"src", "hot_01"},
+                                {"dst", "cold_01"},
+                                {"mode", "shadow"},
+                                {"reason", "feature_read_error"}})
+                  .Get());
+    ASSERT_EQ(2u,
+              metrics_registry_
+                  ->GetCounter("migration_admission_feature_status_total",
+                               {{"src", "hot_01"},
+                                {"dst", "cold_01"},
+                                {"feature", "last_access_time"},
+                                {"status", "read_error"}})
+                  .Get());
+    ASSERT_EQ(14u,
+              metrics_registry_
+                  ->GetCounter("migration_mark_eligible_source_bytes_total",
+                               {{"src", "hot_01"}, {"dst", "cold_01"}, {"decision", "eligible"}})
+                  .Get());
+}
+
+TEST_F(MigrationManagerTest, TestEnforceFiltersValueUnknownAndNotRecentBeforeMark) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "enforce_value_hot"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "enforce_value_cold"));
+    for (const int64_t block_key : {21, 22, 23}) {
+        CreateSourceLocation(block_key, "hot_01", false, "payload");
+    }
+
+    admission_dispatch_stub::Reset();
+    for (const int64_t block_key : {21, 22, 23}) {
+        admission_dispatch_stub::g_locations[block_key] = GetLocationMap(block_key);
+    }
+    const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
+    admission_dispatch_stub::g_properties[21][PROPERTY_LRU_TIME] = std::to_string(now_us - 1000 * 1000);
+    admission_dispatch_stub::g_properties[22][PROPERTY_LRU_TIME] = std::to_string(now_us - 30 * 1000 * 1000);
+    // block 23 simulates a dual-backend hot miss: location is available from
+    // persistent metadata, while process-local LRU explicitly stays missing.
+    admission_dispatch_stub::g_property_errors[23] = EC_NOENT;
+    Stub stub;
+    stub.set(ADDR(MetaIndexer, GetMaintenancePropertyReadiness), admission_dispatch_stub::GetReadiness_stub);
+    stub.set(ADDR(MetaIndexer, GetForMaintenance), admission_dispatch_stub::GetForMaintenance_stub);
+
+    MigrationManager::DispatchBatchParams params;
+    params.do_mark = true;
+    params.admission = RecentAccessAdmission(MigrationAdmissionMode::ENFORCE, 10);
+    MigrationManager manager(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    manager.DebugEnableCopySubmissionsForTest();
+
+    const auto result =
+        manager.DispatchMigrationBatch("enforce_value", kInstance, "hot_01", "cold_01", {21, 22, 23}, params);
+
+    ASSERT_EQ(EC_OK, result.ec);
+    ASSERT_EQ(1, result.mark_submitted);
+    ASSERT_EQ(2, result.rejected);
+    ASSERT_EQ(3, TerminalOutcomeCount(result));
+    ASSERT_EQ(1,
+              OutcomeCount(result,
+                           MigrationOutcomeStage::kValue,
+                           MigrationOutcomeClass::kRejected,
+                           MigrationOutcomeReason::kNotRecent,
+                           true));
+    ASSERT_EQ(1,
+              OutcomeCount(result,
+                           MigrationOutcomeStage::kValue,
+                           MigrationOutcomeClass::kRejected,
+                           MigrationOutcomeReason::kFeatureMissing,
+                           true));
+    ASSERT_TRUE(manager.IsMarkedForTieredWrite(kInstance, 21));
+    ASSERT_FALSE(manager.IsMarkedForTieredWrite(kInstance, 22));
+    ASSERT_FALSE(manager.IsMarkedForTieredWrite(kInstance, 23));
+    ASSERT_EQ(1u,
+              metrics_registry_
+                  ->GetCounter("migration_admission_accepted_total",
+                               {{"trigger", "admin"},
+                                {"src", "hot_01"},
+                                {"dst", "cold_01"},
+                                {"mode", "enforce"}})
+                  .Get());
+    ASSERT_EQ(1u,
+              metrics_registry_
+                  ->GetCounter("migration_candidate_pool_total",
+                               {{"src", "hot_01"}, {"dst", "cold_01"}, {"stage", "value_qualified"}})
+                  .Get());
+    ASSERT_EQ(2u,
+              metrics_registry_
+                  ->GetCounter("migration_admission_access_age_seconds_count",
+                               {{"trigger", "admin"}, {"src", "hot_01"}, {"dst", "cold_01"}})
+                  .Get());
+}
+
+TEST_F(MigrationManagerTest, TestEnforceFeatureReadFailureReturnsInfrastructureError) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "enforce_read_error_hot"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "enforce_read_error_cold"));
+    CreateSourceLocation(24, "hot_01", false, "payload");
+
+    admission_dispatch_stub::Reset();
+    admission_dispatch_stub::g_locations[24] = GetLocationMap(24);
+    admission_dispatch_stub::g_property_errors[24] = EC_ERROR;
+    Stub stub;
+    stub.set(ADDR(MetaIndexer, GetMaintenancePropertyReadiness), admission_dispatch_stub::GetReadiness_stub);
+    stub.set(ADDR(MetaIndexer, GetForMaintenance), admission_dispatch_stub::GetForMaintenance_stub);
+
+    MigrationManager::DispatchBatchParams params;
+    params.do_mark = true;
+    params.admission = RecentAccessAdmission(MigrationAdmissionMode::ENFORCE, 10);
+    MigrationManager manager(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    manager.DebugEnableCopySubmissionsForTest();
+
+    const auto result =
+        manager.DispatchMigrationBatch("enforce_feature_read_error", kInstance, "hot_01", "cold_01", {24}, params);
+
+    ASSERT_EQ(EC_ERROR, result.ec);
     ASSERT_EQ(0, result.mark_submitted);
-    ASSERT_EQ(0u, mgr.GetStats().marks_added);
-    ASSERT_EQ(1u, metrics_registry_->GetCounter("migration.mark_query_errors_total").Get());
+    ASSERT_EQ(0, result.rejected);
+    ASSERT_EQ(1, result.failed);
+    ASSERT_EQ(1, TerminalOutcomeCount(result));
+    ASSERT_EQ(1,
+              OutcomeCount(result,
+                           MigrationOutcomeStage::kSnapshot,
+                           MigrationOutcomeClass::kFailed,
+                           MigrationOutcomeReason::kFeatureReadError,
+                           true));
+    ASSERT_FALSE(manager.IsMarkedForTieredWrite(kInstance, 24));
+}
+
+TEST_F(MigrationManagerTest, TestEnforceNotReadyStopsBeforeSnapshotAndMark) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "not_ready_hot"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "not_ready_cold"));
+    CreateSourceLocation(31, "hot_01", false, "payload");
+
+    admission_dispatch_stub::Reset();
+    admission_dispatch_stub::g_readiness = {MaintenancePropertyCapability::kProcessLocalVolatile,
+                                            TimestampUtil::GetSteadyTimeUs(),
+                                            9};
+    admission_dispatch_stub::g_locations[31] = GetLocationMap(31);
+    Stub stub;
+    stub.set(ADDR(MetaIndexer, GetMaintenancePropertyReadiness), admission_dispatch_stub::GetReadiness_stub);
+    stub.set(ADDR(MetaIndexer, GetForMaintenance), admission_dispatch_stub::GetForMaintenance_stub);
+
+    MigrationManager::DispatchBatchParams params;
+    params.do_mark = true;
+    params.admission = RecentAccessAdmission(MigrationAdmissionMode::ENFORCE, 3600);
+    MigrationManager manager(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    manager.DebugEnableCopySubmissionsForTest();
+
+    const auto result =
+        manager.DispatchMigrationBatch("enforce_not_ready", kInstance, "hot_01", "cold_01", {31}, params);
+
+    ASSERT_NE(EC_OK, result.ec);
+    ASSERT_EQ(1, result.failed);
+    ASSERT_EQ(1, TerminalOutcomeCount(result));
+    ASSERT_EQ(1,
+              OutcomeCount(result,
+                           MigrationOutcomeStage::kSnapshot,
+                           MigrationOutcomeClass::kFailed,
+                           MigrationOutcomeReason::kRouteNotReady,
+                           true));
+    ASSERT_EQ(0, admission_dispatch_stub::g_snapshot_calls);
+    ASSERT_FALSE(manager.IsMarkedForTieredWrite(kInstance, 31));
+    ASSERT_EQ(0.0,
+              metrics_registry_
+                  ->GetGauge("migration_admission_readiness",
+                             {{"instance", kInstance},
+                              {"src", "hot_01"},
+                              {"dst", "cold_01"},
+                              {"feature", "last_access_time"}})
+                  .Get());
+    ASSERT_EQ(1u,
+              metrics_registry_
+                  ->GetCounter("migration_admission_readiness_not_ready_total",
+                               {{"instance", kInstance},
+                                {"src", "hot_01"},
+                                {"dst", "cold_01"},
+                                {"feature", "last_access_time"},
+                                {"reason", "warmup"}})
+                  .Get());
+}
+
+TEST_F(MigrationManagerTest, TestMalformedShadowPolicyIsBehaviorNeutralAtRuntime) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "shadow_contract_hot"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "shadow_contract_cold"));
+    CreateSourceLocation(41, "hot_01", false, "payload");
+
+    admission_dispatch_stub::Reset();
+    admission_dispatch_stub::g_locations[41] = GetLocationMap(41);
+    Stub stub;
+    stub.set(ADDR(MetaIndexer, GetForMaintenance), admission_dispatch_stub::GetForMaintenance_stub);
+
+    MigrationManager::DispatchBatchParams params;
+    params.do_mark = true;
+    params.admission.set_mode(MigrationAdmissionMode::SHADOW); // intentionally missing leaf policy
+    MigrationManager manager(schedule_plan_executor_, meta_manager_, data_storage_manager_, metrics_registry_);
+    manager.DebugEnableCopySubmissionsForTest();
+
+    const auto result = manager.DispatchMigrationBatch(
+        "shadow_policy_contract", kInstance, "hot_01", "cold_01", {41}, params);
+
+    ASSERT_EQ(EC_OK, result.ec);
+    ASSERT_EQ(1, result.mark_submitted);
+    ASSERT_EQ(1, TerminalOutcomeCount(result));
+    ASSERT_EQ(1,
+              OutcomeCount(result,
+                           MigrationOutcomeStage::kValue,
+                           MigrationOutcomeClass::kFailed,
+                           MigrationOutcomeReason::kPolicyContractError,
+                           false));
 }
 
 TEST_F(MigrationManagerTest, TestCheckCopyAdmission) {
@@ -2801,6 +3226,7 @@ TEST_F(MigrationManagerTest, TestCheckCopyAdmissionAllowsPartialTarget) {
         ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, adm.status);
         ASSERT_NE(nullptr, adm.src_location);
         ASSERT_EQ("loc_src_l1", adm.src_location->id());
+        ASSERT_EQ(2u, adm.missing_specs.size());
     }
 
     {
@@ -2813,6 +3239,20 @@ TEST_F(MigrationManagerTest, TestCheckCopyAdmissionAllowsPartialTarget) {
         const auto adm = mgr.CheckCopyAdmission(kInstance, /*block_key*/ 7, loc_map, src, dst);
         ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kTargetServingExists, adm.status);
         ASSERT_EQ(nullptr, adm.src_location);
+        ASSERT_TRUE(adm.missing_specs.empty());
+    }
+
+    {
+        CacheLocationMap loc_map;
+        auto src_loc = MakeLocationWithSpecs("loc_src", src, CLS_SERVING, {"tp0", "tp1"});
+        auto dst_loc = MakeLocationWithSpecs("loc_dst", dst, CLS_SERVING, {"tp0"});
+        loc_map[src_loc->id()] = src_loc;
+        loc_map[dst_loc->id()] = dst_loc;
+
+        const auto adm = mgr.CheckCopyAdmission(kInstance, /*block_key*/ 8, loc_map, src, dst);
+        ASSERT_EQ(MigrationManager::CopyAdmissionStatus::kAccept, adm.status);
+        ASSERT_EQ(1u, adm.missing_specs.size());
+        ASSERT_EQ("tp1", adm.missing_specs.front().name());
     }
 }
 

--- a/kv_cache_manager/manager/test/migration_manager_test.cc
+++ b/kv_cache_manager/manager/test/migration_manager_test.cc
@@ -581,6 +581,30 @@ public:
         return (it == maps[0].end()) ? nullptr : it->second;
     }
 
+    void SetLocationCreateTimeForTest(int64_t block_key, const std::string &location_id, int64_t create_time) {
+        auto indexer = meta_manager_->GetMetaIndexer(kInstance);
+        ASSERT_NE(nullptr, indexer);
+        auto modifier = [create_time](const std::vector<ErrorCode> &get_ecs,
+                                      const LocationIdVector &location_ids,
+                                      size_t /*key_index*/,
+                                      CacheLocationVector &locations,
+                                      PropertyMap & /*upsert_properties*/) -> LocationModifierResult {
+            if (get_ecs.size() != 1 || location_ids.size() != 1 || locations.size() != 1 || get_ecs[0] != EC_OK ||
+                locations[0] == nullptr) {
+                return {MA_FAIL, {EC_MISMATCH}};
+            }
+            auto replacement = std::make_shared<CacheLocation>(*locations[0]);
+            replacement->set_create_time(create_time);
+            locations[0] = std::move(replacement);
+            return {MA_OK, {EC_OK}};
+        };
+        RequestContext rc("set_location_create_time_for_test");
+        const auto result =
+            indexer->ReadModifyWriteLocationsForMaintenance(&rc, {block_key}, {{location_id}}, modifier, false);
+        ASSERT_EQ(EC_OK, result.ec);
+        ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), result.per_location_error_codes);
+    }
+
     CacheLocationMap GetLocationMap(int64_t block_key) {
         auto request_context = std::make_shared<RequestContext>("get_location_map");
         MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kInstance));
@@ -1365,15 +1389,20 @@ TEST_F(MigrationManagerTest, TestSubmitThenSuccessSourceCreateTimeMismatch) {
     ASSERT_EQ(1u, mgr.GetStats().copy_failed);
 }
 
-// create_time=0 边界：源和 ctx 都默认 0，0==0 应视为匹配并正常 promote。
+// create_time=0 边界：模拟升级前持久化的 legacy Location。零是一个明确的旧 generation，
+// 不应被当作缺失字段或通配符。
 TEST_F(MigrationManagerTest, TestSubmitThenSuccessSourceCreateTimeZeroMatches) {
     ASSERT_TRUE(CreateMetaIndexer(kInstance));
     ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "ct0_hot/"));
     ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "ct0_cold/"));
 
     int64_t block_key = 270;
-    // create_time=0(默认,不设)
     std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "data");
+    // BatchAddLocation 会为新 Location 自动赋时；显式改回 0 才能真实覆盖 legacy 数据。
+    SetLocationCreateTimeForTest(block_key, src_loc, 0);
+    const auto source = GetLocation(block_key, src_loc);
+    ASSERT_NE(nullptr, source);
+    ASSERT_EQ(0, source->create_time());
     MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
     mgr.DebugEnableCopySubmissionsForTest();
     MigrationManager::MigrationRequest req;
@@ -1393,6 +1422,67 @@ TEST_F(MigrationManagerTest, TestSubmitThenSuccessSourceCreateTimeZeroMatches) {
     ASSERT_EQ(1u, mgr.GetStats().copy_completed);
     ASSERT_EQ(0u, mgr.GetStats().copy_failed);
     ASSERT_EQ(CLS_SERVING, GetLocationStatus(block_key, src_loc));
+}
+
+TEST_F(MigrationManagerTest, TestBatchSubmitAcceptsLegacyZeroSourceGeneration) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "batch_ct0_hot/"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "batch_ct0_cold/"));
+
+    const int64_t block_key = 271;
+    const std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "data");
+    SetLocationCreateTimeForTest(block_key, src_loc, 0);
+    const auto source = GetLocation(block_key, src_loc);
+    ASSERT_NE(nullptr, source);
+    ASSERT_EQ(0, source->create_time());
+
+    MigrationManager::MigrationRequest request;
+    request.instance_id = kInstance;
+    request.block_key = block_key;
+    request.src_location_id = src_loc;
+    request.src_storage_name = "hot_01";
+    request.dst_storage_name = "cold_01";
+    request.retention = MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE;
+    request.src_specs = source->location_specs();
+    request.src_create_time = source->create_time();
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    mgr.DebugEnableCopySubmissionsForTest();
+    const auto results = mgr.BatchSubmit("legacy_zero_generation", {request});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), results);
+
+    mgr.OnTaskSuccess(kInstance, block_key);
+    ASSERT_EQ(1u, mgr.GetStats().copy_completed);
+    ASSERT_TRUE(WaitFor([&]() { return GetLocationStatus(block_key, src_loc) == CLS_NOT_FOUND; }));
+}
+
+TEST_F(MigrationManagerTest, TestBatchSubmitDoesNotTreatZeroSourceGenerationAsWildcard) {
+    ASSERT_TRUE(CreateMetaIndexer(kInstance));
+    ASSERT_TRUE(CreateDummyStorage("hot_01", GetPrivateTestRuntimeDataPath() + "batch_ct0_mismatch_hot/"));
+    ASSERT_TRUE(CreateDummyStorage("cold_01", GetPrivateTestRuntimeDataPath() + "batch_ct0_mismatch_cold/"));
+
+    const int64_t block_key = 272;
+    const std::string src_loc = CreateSourceLocation(block_key, "hot_01", true, "data");
+    const auto source = GetLocation(block_key, src_loc);
+    ASSERT_NE(nullptr, source);
+    ASSERT_GT(source->create_time(), 0);
+
+    MigrationManager::MigrationRequest request;
+    request.instance_id = kInstance;
+    request.block_key = block_key;
+    request.src_location_id = src_loc;
+    request.src_storage_name = "hot_01";
+    request.dst_storage_name = "cold_01";
+    request.retention = MigrationRetention::MIGRATION_RETENTION_DELETE_SOURCE;
+    request.src_specs = source->location_specs();
+    request.src_create_time = 0;
+
+    MigrationManager mgr(schedule_plan_executor_, meta_manager_, data_storage_manager_);
+    mgr.DebugEnableCopySubmissionsForTest();
+    const auto results = mgr.BatchSubmit("zero_generation_is_exact", {request});
+    ASSERT_EQ((std::vector<ErrorCode>{EC_MISMATCH}), results);
+    EXPECT_FALSE(mgr.HasMigrationTask(kInstance, block_key));
+    EXPECT_EQ(CLS_SERVING, GetLocationStatus(block_key, src_loc));
 }
 
 TEST_F(MigrationManagerTest, TestSubmitThenFail) {

--- a/kv_cache_manager/meta/meta_cache_base_backend.h
+++ b/kv_cache_manager/meta/meta_cache_base_backend.h
@@ -60,6 +60,15 @@ public:
                                           const PropertyMapVector &properties,
                                           const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;
 
+    virtual std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          const CacheLocationMapVector &locations,
+                                          const PropertyMapVector &properties,
+                                          const std::vector<ErrorCode> &previous_error_codes,
+                                          MetaAccessIntent /*intent*/) noexcept {
+        return Upsert(request_context, keys, locations, properties, previous_error_codes);
+    }
+
     virtual std::vector<ErrorCode> Delete(RequestContext *request_context,
                                           const KeyTypeVec &keys,
                                           const std::vector<ErrorCode> &previous_error_codes) noexcept = 0;

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -182,10 +182,18 @@ std::vector<ErrorCode> MetaDummyBackend::Put(RequestContext * /*request_context*
     return results;
 }
 
-std::vector<ErrorCode> MetaDummyBackend::Upsert(RequestContext * /*request_context*/,
+std::vector<ErrorCode> MetaDummyBackend::Upsert(RequestContext *request_context,
                                                 const KeyTypeVec &keys,
                                                 const CacheLocationMapVector &locations,
                                                 const PropertyMapVector &properties) noexcept {
+    return Upsert(request_context, keys, locations, properties, MetaAccessIntent::kBusinessWrite);
+}
+
+std::vector<ErrorCode> MetaDummyBackend::Upsert(RequestContext * /*request_context*/,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties,
+                                                MetaAccessIntent intent) noexcept {
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     std::lock_guard<std::mutex> guard(mutex_);
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -196,13 +204,17 @@ std::vector<ErrorCode> MetaDummyBackend::Upsert(RequestContext * /*request_conte
             for (const auto &[prop_name, prop_value] : properties[i]) {
                 existing.properties[prop_name] = prop_value;
             }
-            existing.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            if (intent != MetaAccessIntent::kMaintenanceNoTouch) {
+                existing.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            }
         });
         if (!found) {
             DummyItem item;
             item.locations = locations[i];
             item.properties = properties[i];
-            item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            if (intent != MetaAccessIntent::kMaintenanceNoTouch) {
+                item.properties[PROPERTY_LRU_TIME] = std::to_string(TimestampUtil::GetCurrentTimeUs());
+            }
             table_.Upsert(keys[i], std::move(item));
         }
     }
@@ -321,6 +333,29 @@ std::vector<std::vector<ErrorCode>> MetaDummyBackend::GetLocations(RequestContex
     return results;
 }
 
+std::vector<std::vector<ErrorCode>> MetaDummyBackend::GetLocationsForMaintenance(
+    RequestContext * /*request_context*/,
+    const KeyTypeVec &keys,
+    const LocationIdsPerKey &location_ids,
+    LocationsPerKey &out_locations) noexcept {
+    std::vector<std::vector<ErrorCode>> results(keys.size());
+    out_locations.assign(keys.size(), CacheLocationVector{});
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i].assign(location_ids[i].size(), EC_NOENT);
+        out_locations[i].resize(location_ids[i].size());
+        table_.FindAndApply(keys[i], [&](const DummyItem &item) {
+            for (size_t j = 0; j < location_ids[i].size(); ++j) {
+                const auto location = item.locations.find(location_ids[i][j]);
+                if (location != item.locations.end()) {
+                    out_locations[i][j] = location->second;
+                    results[i][j] = EC_OK;
+                }
+            }
+        });
+    }
+    return results;
+}
+
 std::vector<ErrorCode> MetaDummyBackend::GetLocationIds(RequestContext * /*request_context*/,
                                                         const KeyTypeVec &keys,
                                                         LocationIdsPerKey &out_location_ids) noexcept {
@@ -378,6 +413,56 @@ std::vector<ErrorCode> MetaDummyBackend::GetProperties(RequestContext * /*reques
         }
     }
     return results;
+}
+
+std::vector<ErrorCode> MetaDummyBackend::GetPropertiesForMaintenance(
+    RequestContext * /*request_context*/,
+    const KeyTypeVec &keys,
+    const std::vector<std::string> &field_names,
+    PropertyMapVector &out_properties) noexcept {
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    out_properties.assign(keys.size(), PropertyMap{});
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = table_.FindAndApply(keys[i], [&](const DummyItem &item) {
+            for (const auto &field_name : field_names) {
+                if (const auto property = item.properties.find(field_name); property != item.properties.end()) {
+                    out_properties[i].emplace(property->first, property->second);
+                }
+            }
+        });
+        if (!found) {
+            results[i] = EC_NOENT;
+        }
+    }
+    return results;
+}
+
+MaintenanceReadResult MetaDummyBackend::GetForMaintenance(
+    RequestContext * /*request_context*/,
+    const KeyTypeVec &keys,
+    const std::vector<std::string> &field_names,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
+    MaintenanceReadResult result;
+    result.location_error_codes.assign(keys.size(), EC_OK);
+    result.property_error_codes.assign(keys.size(), EC_OK);
+    out_locations.assign(keys.size(), CacheLocationMap{});
+    out_properties.assign(keys.size(), PropertyMap{});
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = table_.FindAndApply(keys[i], [&](const DummyItem &item) {
+            out_locations[i] = item.locations;
+            for (const auto &field_name : field_names) {
+                if (const auto property = item.properties.find(field_name); property != item.properties.end()) {
+                    out_properties[i].emplace(property->first, property->second);
+                }
+            }
+        });
+        if (!found) {
+            result.location_error_codes[i] = EC_NOENT;
+            result.property_error_codes[i] = EC_NOENT;
+        }
+    }
+    return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -51,6 +51,11 @@ public:
                                   const KeyTypeVec &keys,
                                   const CacheLocationMapVector &locations,
                                   const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties,
+                                  MetaAccessIntent intent) noexcept override;
     std::vector<ErrorCode> Delete(RequestContext *request_context, const KeyTypeVec &keys) noexcept override;
     std::vector<ErrorCode> DeleteLocations(RequestContext *request_context,
                                            const KeyTypeVec &keys,
@@ -71,6 +76,10 @@ public:
                                                      const KeyTypeVec &keys,
                                                      const LocationIdsPerKey &location_ids,
                                                      LocationsPerKey &out_locations) noexcept override;
+    std::vector<std::vector<ErrorCode>> GetLocationsForMaintenance(RequestContext *request_context,
+                                                                   const KeyTypeVec &keys,
+                                                                   const LocationIdsPerKey &location_ids,
+                                                                   LocationsPerKey &out_locations) noexcept override;
     std::vector<ErrorCode> GetLocationIds(RequestContext *request_context,
                                           const KeyTypeVec &keys,
                                           LocationIdsPerKey &out_location_ids) noexcept override;
@@ -81,6 +90,15 @@ public:
                                          const KeyTypeVec &keys,
                                          const std::vector<std::string> &field_names,
                                          PropertyMapVector &out_properties) noexcept override;
+    std::vector<ErrorCode> GetPropertiesForMaintenance(RequestContext *request_context,
+                                                       const KeyTypeVec &keys,
+                                                       const std::vector<std::string> &field_names,
+                                                       PropertyMapVector &out_properties) noexcept override;
+    MaintenanceReadResult GetForMaintenance(RequestContext *request_context,
+                                            const KeyTypeVec &keys,
+                                            const std::vector<std::string> &field_names,
+                                            CacheLocationMapVector &out_locations,
+                                            PropertyMapVector &out_properties) noexcept override;
 
     // =====================================================================
     // Key-level APIs

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -184,6 +184,7 @@ ErrorCode MetaIndexer::Init(const std::string &instance_id, const std::shared_pt
         KVCM_LOG_ERROR("instance[%s] recover metadata failed, ec[%d]", instance_id_.c_str(), ec);
         return ec;
     }
+    ResetMaintenancePropertyReadinessEpoch();
     KVCM_LOG_INFO("instance[%s] meta indexer init success, mutex shard num[%lu], mutex hash seed[%" PRIu64
                   "], max key count[%lu], "
                   "batch key size[%lu], key_count[%lu], persist_metadata_interval_time_ms[%zu], storage usage data[%s]",
@@ -304,7 +305,8 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwUpsert(const std::string &tra
                                                           const KeyVector &all_keys,
                                                           RmwStats &stats,
                                                           Result &result,
-                                                          bool preserve_existing_updates_when_full) noexcept {
+                                                          bool preserve_existing_updates_when_full,
+                                                          MetaAccessIntent intent) noexcept {
     if (upsert_batch.batch_keys.empty()) {
         return {0, 0};
     }
@@ -362,7 +364,7 @@ std::pair<int32_t, int32_t> MetaIndexer::ExecuteRmwUpsert(const std::string &tra
     }
     if (upsert_ecs.empty() || !existing_update_positions.empty()) {
         const int64_t begin = TimestampUtil::GetCurrentTimeUs();
-        std::vector<ErrorCode> backend_ecs = backend_manager_->Upsert(request_context, *backend_batch);
+        std::vector<ErrorCode> backend_ecs = backend_manager_->Upsert(request_context, *backend_batch, intent);
         stats.upsert_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin;
         if (existing_update_positions.empty()) {
             upsert_ecs = std::move(backend_ecs);
@@ -613,6 +615,162 @@ MetaIndexer::Result MetaIndexer::ReadModifyWriteBlock(RequestContext *request_co
     return result;
 }
 
+MetaIndexer::Result MetaIndexer::ReadModifyWriteBlockPropertiesForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const std::vector<std::string> &property_names,
+    const BlockPropertyModifierFunc &modifier) noexcept {
+    if (keys.empty()) {
+        return Result(EC_OK);
+    }
+    const auto &trace_id = request_context->trace_id();
+    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
+
+    auto ephemeral_metrics_registry = std::make_shared<MetricsRegistry>();
+    auto ephemeral_metrics_collector = std::make_shared<ServiceMetricsCollector>(ephemeral_metrics_registry);
+    ephemeral_metrics_collector->Init();
+    auto ephemeral_request_context =
+        std::make_shared<RequestContext>("read_modify_write_block_properties_for_maintenance",
+                                         ephemeral_metrics_collector);
+
+    static LocationIdsPerKey empty_location_ids;
+    static CacheLocationMapVector empty_locations;
+    static PropertyMapVector empty_properties;
+    std::vector<BatchMetaData> batches = MakeBatches(keys, empty_location_ids, empty_locations, empty_properties);
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_batch_num, batches.size());
+
+    Result result(keys.size());
+    int32_t error_count = 0;
+    RmwStats stats;
+    for (auto &batch : batches) {
+        ScopedBatchLock lock(*this, batch.batch_shard_indexs, &stats.lock_wait_time_us);
+        const KeyVector &batch_keys = batch.batch_keys;
+        CacheLocationMapVector existing_locations;
+        PropertyMapVector existing_properties;
+        const int64_t begin_get = TimestampUtil::GetCurrentTimeUs();
+        MaintenanceReadResult get_results = backend_manager_->GetForMaintenance(ephemeral_request_context.get(),
+                                                                                 batch_keys,
+                                                                                 property_names,
+                                                                                 existing_locations,
+                                                                                 existing_properties);
+        stats.get_io_time_us += TimestampUtil::GetCurrentTimeUs() - begin_get;
+        if (get_results.location_error_codes.size() != batch_keys.size() ||
+            get_results.property_error_codes.size() != batch_keys.size() ||
+            existing_locations.size() != batch_keys.size() || existing_properties.size() != batch_keys.size()) {
+            PREFIX_INDEXER_LOG(ERROR,
+                               "maintenance block RMW result size mismatch, keys[%zu], location_ecs[%zu], "
+                               "property_ecs[%zu], locations[%zu], properties[%zu]",
+                               batch_keys.size(),
+                               get_results.location_error_codes.size(),
+                               get_results.property_error_codes.size(),
+                               existing_locations.size(),
+                               existing_properties.size());
+            for (const int32_t global_idx : batch.batch_indexs) {
+                result.error_codes[global_idx] = EC_MISMATCH;
+            }
+            error_count += static_cast<int32_t>(batch.batch_indexs.size());
+            result.ec = EC_MISMATCH;
+            continue;
+        }
+
+        BatchMetaData upsert_batch;
+        BatchMetaData delete_batch;
+        std::vector<int32_t> put_global_indexs;
+        for (size_t i = 0; i < batch_keys.size(); ++i) {
+            const int32_t global_idx = batch.batch_indexs[i];
+            const ErrorCode location_ec = get_results.location_error_codes[i];
+            const ErrorCode property_ec = get_results.property_error_codes[i];
+            ErrorCode get_ec = EC_OK;
+            if (location_ec == EC_NOENT && property_ec == EC_NOENT) {
+                get_ec = EC_NOENT;
+            } else if (location_ec != EC_OK || property_ec != EC_OK) {
+                get_ec = location_ec == property_ec ? location_ec : EC_MISMATCH;
+            }
+
+            LocationIdVector existing_location_ids;
+            if (location_ec == EC_OK) {
+                existing_location_ids.reserve(existing_locations[i].size());
+                for (const auto &[location_id, unused_location] : existing_locations[i]) {
+                    (void)unused_location;
+                    existing_location_ids.emplace_back(location_id);
+                }
+            }
+
+            PropertyMap upsert_property_map;
+            CacheLocationMap out_new_locations;
+            const auto [action, modifier_ec] = modifier(existing_location_ids,
+                                                        existing_properties[i],
+                                                        get_ec,
+                                                        static_cast<size_t>(global_idx),
+                                                        upsert_property_map,
+                                                        out_new_locations);
+            if (action == MA_OK) {
+                if (get_ec != EC_OK && get_ec != EC_NOENT) {
+                    result.error_codes[global_idx] = get_ec;
+                    ++error_count;
+                    continue;
+                }
+                upsert_batch.batch_keys.emplace_back(batch_keys[i]);
+                upsert_batch.batch_indexs.emplace_back(global_idx);
+                upsert_batch.batch_locations.emplace_back(std::move(out_new_locations));
+                upsert_batch.batch_properties.emplace_back(std::move(upsert_property_map));
+                if (get_ec == EC_NOENT) {
+                    put_global_indexs.emplace_back(global_idx);
+                }
+            } else if (action == MA_DELETE && modifier_ec == EC_OK) {
+                delete_batch.batch_keys.emplace_back(batch_keys[i]);
+                delete_batch.batch_indexs.emplace_back(global_idx);
+            } else if (modifier_ec != EC_OK) {
+                result.error_codes[global_idx] = modifier_ec;
+                ++error_count;
+            }
+        }
+
+        const auto [upsert_errors, put_success_count] = ExecuteRmwUpsert(trace_id,
+                                                                         ephemeral_request_context.get(),
+                                                                         upsert_batch,
+                                                                         put_global_indexs,
+                                                                         keys,
+                                                                         stats,
+                                                                         result,
+                                                                         false,
+                                                                         MetaAccessIntent::kMaintenanceNoTouch);
+        const auto [delete_errors, delete_success_count] = ExecuteRmwDelete(trace_id,
+                                                                            ephemeral_request_context.get(),
+                                                                            delete_batch,
+                                                                            keys,
+                                                                            stats,
+                                                                            result,
+                                                                            true);
+        error_count += upsert_errors + delete_errors;
+        AdjustKeyCountMeta(put_success_count - delete_success_count);
+    }
+
+    EmitRmwMetrics(request_context->metrics_collector(), stats, keys.size());
+    ProcessErrorResult(trace_id, kRmwMetaOperation, error_count, keys.size(), result);
+    return result;
+}
+
+MetaIndexer::Result MetaIndexer::ReadModifyWriteBlockForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const BlockIdsOnlyModifierFunc &modifier) noexcept {
+    auto adapter = [&modifier](const LocationIdVector &existing_location_ids,
+                               const PropertyMap & /*existing_properties*/,
+                               ErrorCode get_ec,
+                               size_t key_index,
+                               PropertyMap &upsert_property_map,
+                               CacheLocationMap &out_new_locations) -> ModifierResult {
+        return modifier(existing_location_ids,
+                        get_ec,
+                        key_index,
+                        upsert_property_map,
+                        out_new_locations);
+    };
+    return ReadModifyWriteBlockPropertiesForMaintenance(request_context, keys, {}, adapter);
+}
+
 MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocation(RequestContext *request_context,
                                                                  const KeyVector &keys,
                                                                  const LocationIdsPerKey &location_ids,
@@ -634,9 +792,16 @@ MetaIndexer::ReadModifyWriteLocationsForMaintenance(RequestContext *request_cont
                                                     const KeyVector &keys,
                                                     const LocationIdsPerKey &location_ids,
                                                     const LocationModifierFunc &modifier,
-                                                    bool adjust_reclaimed_key_count) noexcept {
-    return ReadModifyWriteLocationImpl(
-        request_context, keys, location_ids, modifier, adjust_reclaimed_key_count, false, false, true);
+                                                    bool adjust_reclaimed_key_count,
+                                                    bool refresh_cache_from_persistent) noexcept {
+    return ReadModifyWriteLocationImpl(request_context,
+                                       keys,
+                                       location_ids,
+                                       modifier,
+                                       adjust_reclaimed_key_count,
+                                       false,
+                                       refresh_cache_from_persistent,
+                                       true);
 }
 
 MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteTargetLocations(RequestContext *request_context,
@@ -913,7 +1078,10 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
                                                                        keys,
                                                                        stats,
                                                                        rmw_result,
-                                                                       track_created_key_count);
+                                                                       track_created_key_count,
+                                                                       maintenance_no_touch
+                                                                           ? MetaAccessIntent::kMaintenanceNoTouch
+                                                                           : MetaAccessIntent::kBusinessWrite);
         (void)upsert_errs;
         for (const auto &global_index : upsert_batch.batch_indexs) {
             if (rmw_result.error_codes[global_index] != EC_OK) {
@@ -1881,6 +2049,103 @@ MetaIndexer::Result MetaIndexer::GetProperties(RequestContext *request_context,
     int32_t error_count = ProcessErrorCodes(trace_id, error_codes, {}, keys, kGetMetaOperation, result);
     ProcessErrorResult(trace_id, kGetMetaOperation, error_count, keys.size(), result);
     return result;
+}
+
+MetaIndexer::Result MetaIndexer::GetPropertiesForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const std::vector<std::string> &property_names,
+    PropertyMapVector &out_properties) noexcept {
+    if (keys.empty()) {
+        out_properties.clear();
+        return Result(EC_OK);
+    }
+    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
+    const auto &trace_id = request_context->trace_id();
+    const int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
+    std::vector<ErrorCode> error_codes = backend_manager_->GetPropertiesForMaintenance(
+        request_context, keys, property_names, out_properties);
+    if (error_codes.size() != keys.size() || out_properties.size() != keys.size()) {
+        PREFIX_INDEXER_LOG(ERROR,
+                           "GetPropertiesForMaintenance result size mismatch, keys[%zu], ecs[%zu], properties[%zu]",
+                           keys.size(),
+                           error_codes.size(),
+                           out_properties.size());
+        error_codes.assign(keys.size(), EC_MISMATCH);
+        out_properties.assign(keys.size(), PropertyMap{});
+    }
+    KVCM_METRICS_COLLECTOR_SET_METRICS(
+        service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
+    Result result(keys.size());
+    const int32_t error_count = ProcessErrorCodes(trace_id, error_codes, {}, keys, kGetMetaOperation, result);
+    ProcessErrorResult(trace_id, kGetMetaOperation, error_count, keys.size(), result);
+    return result;
+}
+
+MetaIndexer::MaintenanceGetResult MetaIndexer::GetForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const std::vector<std::string> &property_names,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
+    if (keys.empty()) {
+        out_locations.clear();
+        out_properties.clear();
+        return MaintenanceGetResult(EC_OK);
+    }
+    auto *service_metrics_collector = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
+    KVCM_METRICS_COLLECTOR_SET_METRICS(service_metrics_collector, meta_indexer, query_key_count, keys.size());
+    const auto &trace_id = request_context->trace_id();
+    const int64_t begin_get_io_time = TimestampUtil::GetCurrentTimeUs();
+    MaintenanceReadResult backend_result = backend_manager_->GetForMaintenance(
+        request_context, keys, property_names, out_locations, out_properties);
+    if (backend_result.location_error_codes.size() != keys.size() || out_locations.size() != keys.size()) {
+        PREFIX_INDEXER_LOG(ERROR,
+                           "GetForMaintenance location result size mismatch, keys[%zu], ecs[%zu], locations[%zu]",
+                           keys.size(),
+                           backend_result.location_error_codes.size(),
+                           out_locations.size());
+        backend_result.location_error_codes.assign(keys.size(), EC_MISMATCH);
+        out_locations.assign(keys.size(), CacheLocationMap{});
+    }
+    if (backend_result.property_error_codes.size() != keys.size() || out_properties.size() != keys.size()) {
+        PREFIX_INDEXER_LOG(ERROR,
+                           "GetForMaintenance property result size mismatch, keys[%zu], ecs[%zu], properties[%zu]",
+                           keys.size(),
+                           backend_result.property_error_codes.size(),
+                           out_properties.size());
+        backend_result.property_error_codes.assign(keys.size(), EC_MISMATCH);
+        out_properties.assign(keys.size(), PropertyMap{});
+    }
+    KVCM_METRICS_COLLECTOR_SET_METRICS(
+        service_metrics_collector, meta_indexer, get_io_time_us, TimestampUtil::GetCurrentTimeUs() - begin_get_io_time);
+
+    MaintenanceGetResult result(keys.size());
+    const int32_t location_error_count = ProcessErrorCodes(
+        trace_id, backend_result.location_error_codes, {}, keys, kGetMetaOperation, result.locations);
+    ProcessErrorResult(trace_id, kGetMetaOperation, location_error_count, keys.size(), result.locations);
+    const int32_t property_error_count = ProcessErrorCodes(
+        trace_id, backend_result.property_error_codes, {}, keys, kGetMetaOperation, result.properties);
+    ProcessErrorResult(trace_id, kGetMetaOperation, property_error_count, keys.size(), result.properties);
+    return result;
+}
+
+MaintenancePropertyReadiness
+MetaIndexer::GetMaintenancePropertyReadiness(const std::string &property_name) const noexcept {
+    MaintenancePropertyReadiness readiness;
+    if (!backend_manager_) {
+        return readiness;
+    }
+    readiness.capability = backend_manager_->GetMaintenancePropertyCapability(property_name);
+    readiness.valid_since_steady_us = maintenance_valid_since_steady_us_.load(std::memory_order_acquire);
+    readiness.generation = maintenance_readiness_generation_.load(std::memory_order_acquire);
+    return readiness;
+}
+
+void MetaIndexer::ResetMaintenancePropertyReadinessEpoch() noexcept {
+    maintenance_valid_since_steady_us_.store(TimestampUtil::GetSteadyTimeUs(), std::memory_order_release);
+    maintenance_readiness_generation_.fetch_add(1, std::memory_order_acq_rel);
 }
 
 ErrorCode MetaIndexer::Scan(RequestContext *request_context,

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -2138,13 +2138,46 @@ MetaIndexer::GetMaintenancePropertyReadiness(const std::string &property_name) c
         return readiness;
     }
     readiness.capability = backend_manager_->GetMaintenancePropertyCapability(property_name);
-    readiness.valid_since_steady_us = maintenance_valid_since_steady_us_.load(std::memory_order_acquire);
+    if (readiness.capability == MaintenancePropertyCapability::kProcessLocalVolatile) {
+        // A cached backend opens before its asynchronous persistent-to-local
+        // recovery finishes. Do not let that time count toward recency
+        // warmup: late backfills receive process-local timestamps and must age
+        // for a full window after recovery is known complete.
+        if (backend_manager_->GetRecoverState() != MetaStorageBackendManager::RecoverState::kRunning) {
+            if (maintenance_valid_since_steady_us_.exchange(0, std::memory_order_acq_rel) != 0) {
+                maintenance_readiness_generation_.fetch_add(1, std::memory_order_acq_rel);
+            }
+            readiness.valid_since_steady_us = 0;
+            readiness.generation = maintenance_readiness_generation_.load(std::memory_order_acquire);
+            return readiness;
+        }
+        int64_t valid_since = maintenance_valid_since_steady_us_.load(std::memory_order_acquire);
+        if (valid_since == 0) {
+            const int64_t recovery_complete_epoch = std::max<int64_t>(1, TimestampUtil::GetSteadyTimeUs());
+            int64_t expected = 0;
+            if (maintenance_valid_since_steady_us_.compare_exchange_strong(
+                    expected, recovery_complete_epoch, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                maintenance_readiness_generation_.fetch_add(1, std::memory_order_acq_rel);
+                valid_since = recovery_complete_epoch;
+            } else {
+                valid_since = expected;
+            }
+        }
+        readiness.valid_since_steady_us = valid_since;
+    } else {
+        readiness.valid_since_steady_us = maintenance_valid_since_steady_us_.load(std::memory_order_acquire);
+    }
     readiness.generation = maintenance_readiness_generation_.load(std::memory_order_acquire);
     return readiness;
 }
 
 void MetaIndexer::ResetMaintenancePropertyReadinessEpoch() noexcept {
-    maintenance_valid_since_steady_us_.store(TimestampUtil::GetSteadyTimeUs(), std::memory_order_release);
+    int64_t valid_since = 0;
+    if (backend_manager_ == nullptr ||
+        backend_manager_->GetRecoverState() == MetaStorageBackendManager::RecoverState::kRunning) {
+        valid_since = std::max<int64_t>(1, TimestampUtil::GetSteadyTimeUs());
+    }
+    maintenance_valid_since_steady_us_.store(valid_since, std::memory_order_release);
     maintenance_readiness_generation_.fetch_add(1, std::memory_order_acq_rel);
 }
 

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -304,8 +304,10 @@ private:
     std::shared_ptr<QueryExecutor> query_executor_;
 
     std::atomic<int64_t> key_count_ = {0};
-    std::atomic<int64_t> maintenance_valid_since_steady_us_ = {0};
-    std::atomic<uint64_t> maintenance_readiness_generation_ = {0};
+    // Mutable because the first readiness query after asynchronous cache
+    // recovery publishes a conservative epoch without changing logical meta.
+    mutable std::atomic<int64_t> maintenance_valid_since_steady_us_ = {0};
+    mutable std::atomic<uint64_t> maintenance_readiness_generation_ = {0};
     int64_t last_persist_metadata_time_ = 0;
     int64_t persist_metadata_interval_time_ms_ = 0;
     size_t max_key_count_ = MetaIndexerConfig::kDefaultMaxKeyCount;

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -38,6 +38,13 @@ public:
         explicit Result(size_t count) : ec(EC_OK), error_codes(count, EC_OK) {}
     };
 
+    struct MaintenanceGetResult {
+        Result locations;
+        Result properties;
+        explicit MaintenanceGetResult(ErrorCode error_code) : locations(error_code), properties(error_code) {}
+        explicit MaintenanceGetResult(size_t count) : locations(count), properties(count) {}
+    };
+
     // Per-(key, location_id) result for location-granularity APIs.
     struct LocationResult {
         ErrorCode ec = EC_OK;
@@ -103,6 +110,13 @@ public:
     Result ReadModifyWriteBlock(RequestContext *request_context,
                                 const KeyVector &keys,
                                 const BlockIdsOnlyModifierFunc &modifier) noexcept;
+    Result ReadModifyWriteBlockForMaintenance(RequestContext *request_context,
+                                              const KeyVector &keys,
+                                              const BlockIdsOnlyModifierFunc &modifier) noexcept;
+    Result ReadModifyWriteBlockPropertiesForMaintenance(RequestContext *request_context,
+                                                        const KeyVector &keys,
+                                                        const std::vector<std::string> &property_names,
+                                                        const BlockPropertyModifierFunc &modifier) noexcept;
     // Location-level RMW: modifier sees per-key CacheLocation vector.
     LocationResult ReadModifyWriteLocation(RequestContext *request_context,
                                            const KeyVector &keys,
@@ -114,7 +128,8 @@ public:
                                                           const KeyVector &keys,
                                                           const LocationIdsPerKey &location_ids,
                                                           const LocationModifierFunc &modifier,
-                                                          bool adjust_reclaimed_key_count = true) noexcept;
+                                                          bool adjust_reclaimed_key_count = true,
+                                                          bool refresh_cache_from_persistent = false) noexcept;
     // Targeted upsert RMW that also distinguishes a brand-new key from an
     // existing key missing the requested location. This lets ReportEvent
     // create or merge locations in one shard-lock/read/write pass while
@@ -163,6 +178,18 @@ public:
                          const KeyVector &keys,
                          const std::vector<std::string> &property_names,
                          PropertyMapVector &out_properties) noexcept;
+    Result GetPropertiesForMaintenance(RequestContext *request_context,
+                                       const KeyVector &keys,
+                                       const std::vector<std::string> &property_names,
+                                       PropertyMapVector &out_properties) noexcept;
+    MaintenanceGetResult GetForMaintenance(RequestContext *request_context,
+                                           const KeyVector &keys,
+                                           const std::vector<std::string> &property_names,
+                                           CacheLocationMapVector &out_locations,
+                                           PropertyMapVector &out_properties) noexcept;
+    [[nodiscard]] MaintenancePropertyReadiness
+    GetMaintenancePropertyReadiness(const std::string &property_name) const noexcept;
+    void ResetMaintenancePropertyReadinessEpoch() noexcept;
     ErrorCode Scan(RequestContext *request_context,
                    const std::string &cursor,
                    const size_t limit,
@@ -258,7 +285,8 @@ private:
                                                  const KeyVector &all_keys,
                                                  RmwStats &stats,
                                                  Result &result,
-                                                 bool preserve_existing_updates_when_full = false) noexcept;
+                                                 bool preserve_existing_updates_when_full = false,
+                                                 MetaAccessIntent intent = MetaAccessIntent::kBusinessWrite) noexcept;
     // Returns {error_count, delete_success_count}.
     std::pair<int32_t, int32_t> ExecuteRmwDelete(const std::string &trace_id,
                                                  RequestContext *request_context,
@@ -276,6 +304,8 @@ private:
     std::shared_ptr<QueryExecutor> query_executor_;
 
     std::atomic<int64_t> key_count_ = {0};
+    std::atomic<int64_t> maintenance_valid_since_steady_us_ = {0};
+    std::atomic<uint64_t> maintenance_readiness_generation_ = {0};
     int64_t last_persist_metadata_time_ = 0;
     int64_t persist_metadata_interval_time_ms_ = 0;
     size_t max_key_count_ = MetaIndexerConfig::kDefaultMaxKeyCount;

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -172,9 +172,12 @@ ErrorCode MetaLocalBackend::Close() noexcept {
 
 ErrorCode MetaLocalBackend::CreateAndInsert(std::string_view key_sv,
                                             const CacheLocationMap &locations,
-                                            const PropertyMap &properties) {
+                                            const PropertyMap &properties,
+                                            MetaAccessIntent intent) {
     MetaMemCacheItem *item = MetaMemCacheItem::Create(locations, properties);
-    item->TouchAccessTime();
+    if (intent != MetaAccessIntent::kMaintenanceNoTouch) {
+        item->TouchAccessTime();
+    }
     size_t charge = item->Size();
     // We must pass &handle (not nullptr) so that when strict_capacity_limit
     // is enabled and capacity is exceeded, Insert returns EC_NOSPC instead
@@ -332,9 +335,59 @@ ErrorCode MetaLocalBackend::UpsertSingleLocationForOneKey(KeyType key,
 // Per-key helpers
 // ---------------------------------------------------------------------------
 
-ErrorCode
-MetaLocalBackend::UpsertForOneKey(KeyType key, const CacheLocationMap &locations, const PropertyMap &properties) {
+ErrorCode MetaLocalBackend::UpsertForOneKey(KeyType key,
+                                            const CacheLocationMap &locations,
+                                            const PropertyMap &properties,
+                                            MetaAccessIntent intent) {
     std::string_view key_sv = KeyToView(key);
+    if (intent == MetaAccessIntent::kMaintenanceNoTouch) {
+        ErrorCode result = EC_OK;
+        const bool found = cache_->ApplyToEntryNoTouch(
+            key_sv,
+            [&](Cache::ObjectPtr value, size_t /*charge*/, const Cache::CacheItemHelper * /*helper*/) -> ssize_t {
+                if (value == nullptr) {
+                    result = EC_ERROR;
+                    return 0;
+                }
+                auto *item = static_cast<MetaMemCacheItem *>(value);
+                ssize_t charge_delta = 0;
+                std::unique_lock lock(item->GetMutex());
+                auto &existing_locations = item->GetMutableLocations();
+                for (const auto &[location_id, location] : locations) {
+                    const auto existing = existing_locations.find(location_id);
+                    const ssize_t new_usage =
+                        location ? static_cast<ssize_t>(location->EstimateMemUsage()) : 0;
+                    if (existing == existing_locations.end()) {
+                        charge_delta +=
+                            static_cast<ssize_t>(sizeof(void *) * 4 + location_id.size()) + new_usage;
+                        existing_locations.emplace(location_id, location);
+                    } else {
+                        const ssize_t old_usage = existing->second
+                                                      ? static_cast<ssize_t>(existing->second->EstimateMemUsage())
+                                                      : 0;
+                        existing->second = location;
+                        charge_delta += new_usage - old_usage;
+                    }
+                }
+                auto &existing_properties = item->GetMutableProperties();
+                for (const auto &[name, value_string] : properties) {
+                    const auto existing = existing_properties.find(name);
+                    if (existing == existing_properties.end()) {
+                        charge_delta += static_cast<ssize_t>(sizeof(void *) * 4 + name.size() + value_string.size());
+                        existing_properties.emplace(name, value_string);
+                    } else {
+                        charge_delta += static_cast<ssize_t>(value_string.size()) -
+                                        static_cast<ssize_t>(existing->second.size());
+                        existing->second = value_string;
+                    }
+                }
+                return charge_delta;
+            });
+        if (found) {
+            return result;
+        }
+        return CreateAndInsert(key_sv, locations, properties, intent);
+    }
     ErrorCode update_ec = UpdateInPlace(key_sv, locations, properties);
     if (update_ec != EC_OK && update_ec != EC_NOENT) {
         KVCM_LOG_ERROR("local backend fail to update key[%ld] in upsert, ec[%d]", key, update_ec);
@@ -343,7 +396,7 @@ MetaLocalBackend::UpsertForOneKey(KeyType key, const CacheLocationMap &locations
     if (update_ec == EC_OK) {
         return EC_OK;
     }
-    ErrorCode insert_ec = CreateAndInsert(key_sv, locations, properties);
+    ErrorCode insert_ec = CreateAndInsert(key_sv, locations, properties, intent);
     if (insert_ec != EC_OK) {
         KVCM_LOG_ERROR("local backend fail to insert key[%ld] in upsert, ec[%d]", key, insert_ec);
         return insert_ec;
@@ -480,6 +533,24 @@ std::vector<ErrorCode> MetaLocalBackend::Upsert(RequestContext * /*request_conte
     assert(missing_count == handles.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         results[i] = CreateAndInsert(key_views[i], locations[i], properties[i]);
+    }
+    return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::Upsert(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties,
+                                                MetaAccessIntent intent) noexcept {
+    if (intent != MetaAccessIntent::kMaintenanceNoTouch) {
+        return Upsert(request_context, keys, locations, properties);
+    }
+    if (keys.size() != locations.size() || keys.size() != properties.size()) {
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = UpsertForOneKey(keys[i], locations[i], properties[i], intent);
     }
     return results;
 }
@@ -719,6 +790,28 @@ std::vector<ErrorCode> MetaLocalBackend::Upsert(RequestContext *request_context,
     return results;
 }
 
+std::vector<ErrorCode> MetaLocalBackend::Upsert(RequestContext *request_context,
+                                                const KeyTypeVec &keys,
+                                                const CacheLocationMapVector &locations,
+                                                const PropertyMapVector &properties,
+                                                const std::vector<ErrorCode> &previous_error_codes,
+                                                MetaAccessIntent intent) noexcept {
+    if (intent != MetaAccessIntent::kMaintenanceNoTouch) {
+        return Upsert(request_context, keys, locations, properties, previous_error_codes);
+    }
+    if (keys.size() != locations.size() || keys.size() != properties.size() ||
+        keys.size() != previous_error_codes.size()) {
+        return std::vector<ErrorCode>(keys.size(), EC_BADARGS);
+    }
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] = previous_error_codes[i] == EC_OK
+                         ? UpsertForOneKey(keys[i], locations[i], properties[i], intent)
+                         : previous_error_codes[i];
+    }
+    return results;
+}
+
 std::vector<ErrorCode> MetaLocalBackend::Delete(RequestContext *request_context,
                                                 const KeyTypeVec &keys,
                                                 const std::vector<ErrorCode> &previous_error_codes) noexcept {
@@ -808,7 +901,9 @@ ErrorCode MetaLocalBackend::GetForOneKey(KeyType key,
 }
 
 ErrorCode MetaLocalBackend::GetForOneKeyForMaintenance(KeyType key,
+                                                       const std::vector<std::string> *field_names,
                                                        CacheLocationMap *out_location_map,
+                                                       PropertyMap *out_property_map,
                                                        std::vector<LocationId> *out_location_ids) {
     ErrorCode result = EC_OK;
     const bool found = cache_->ApplyToEntryNoTouch(
@@ -828,6 +923,25 @@ ErrorCode MetaLocalBackend::GetForOneKeyForMaintenance(KeyType key,
                 out_location_ids->reserve(locations.size());
                 for (const auto &[location_id, _] : locations) {
                     out_location_ids->push_back(location_id);
+                }
+            }
+            if (out_property_map) {
+                const int64_t stored_time = item->GetLastAccessTime();
+                if (field_names) {
+                    const auto &properties = item->GetProperties();
+                    for (const auto &field_name : *field_names) {
+                        if (field_name == PROPERTY_LRU_TIME) {
+                            (*out_property_map)[PROPERTY_LRU_TIME] = std::to_string(stored_time);
+                            continue;
+                        }
+                        const auto property = properties.find(field_name);
+                        if (property != properties.end()) {
+                            out_property_map->emplace(property->first, property->second);
+                        }
+                    }
+                } else {
+                    *out_property_map = item->GetProperties();
+                    (*out_property_map)[PROPERTY_LRU_TIME] = std::to_string(stored_time);
                 }
             }
             return 0;
@@ -1210,7 +1324,7 @@ std::vector<ErrorCode> MetaLocalBackend::GetLocationIdsForMaintenance(RequestCon
     std::vector<ErrorCode> results(keys.size(), EC_OK);
     out_location_ids.resize(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
-        results[i] = GetForOneKeyForMaintenance(keys[i], nullptr, &out_location_ids[i]);
+        results[i] = GetForOneKeyForMaintenance(keys[i], nullptr, nullptr, nullptr, &out_location_ids[i]);
     }
     return results;
 }
@@ -1277,6 +1391,40 @@ std::vector<ErrorCode> MetaLocalBackend::GetProperties(RequestContext * /*reques
         results[i] = GetForOneKey(keys[i], &field_names, nullptr, &out_properties[i], nullptr);
     }
     return results;
+}
+
+std::vector<ErrorCode> MetaLocalBackend::GetPropertiesForMaintenance(
+    RequestContext * /*request_context*/,
+    const KeyTypeVec &keys,
+    const std::vector<std::string> &field_names,
+    PropertyMapVector &out_properties) noexcept {
+    out_properties.assign(keys.size(), PropertyMap{});
+    std::vector<ErrorCode> results(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        results[i] =
+            GetForOneKeyForMaintenance(keys[i], &field_names, nullptr, &out_properties[i], nullptr);
+    }
+    return results;
+}
+
+MaintenanceReadResult MetaLocalBackend::GetForMaintenance(
+    RequestContext * /*request_context*/,
+    const KeyTypeVec &keys,
+    const std::vector<std::string> &field_names,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
+    out_locations.assign(keys.size(), CacheLocationMap{});
+    out_properties.assign(keys.size(), PropertyMap{});
+    MaintenanceReadResult result;
+    result.location_error_codes.assign(keys.size(), EC_OK);
+    result.property_error_codes.assign(keys.size(), EC_OK);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const ErrorCode ec = GetForOneKeyForMaintenance(
+            keys[i], &field_names, &out_locations[i], &out_properties[i], nullptr);
+        result.location_error_codes[i] = ec;
+        result.property_error_codes[i] = ec;
+    }
+    return result;
 }
 
 std::vector<ErrorCode> MetaLocalBackend::Exists(RequestContext * /*request_context*/,
@@ -1384,7 +1532,7 @@ ErrorCode MetaLocalBackend::ScanLocationsForMaintenance(RequestContext * /*reque
         // then pins the exact shard operation without promoting the entry.
         for (const KeyType key : shard_keys) {
             CacheLocationMap locations;
-            const ErrorCode ec = GetForOneKeyForMaintenance(key, &locations, nullptr);
+            const ErrorCode ec = GetForOneKeyForMaintenance(key, nullptr, &locations, nullptr, nullptr);
             out.keys.push_back(key);
             out.locations.emplace_back(std::move(locations));
             out.location_results.push_back(ec);

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -355,16 +355,14 @@ ErrorCode MetaLocalBackend::UpsertForOneKey(KeyType key,
                 auto &existing_locations = item->GetMutableLocations();
                 for (const auto &[location_id, location] : locations) {
                     const auto existing = existing_locations.find(location_id);
-                    const ssize_t new_usage =
-                        location ? static_cast<ssize_t>(location->EstimateMemUsage()) : 0;
+                    const ssize_t new_usage = location ? static_cast<ssize_t>(location->EstimateMemUsage()) : 0;
                     if (existing == existing_locations.end()) {
                         charge_delta +=
-                            static_cast<ssize_t>(sizeof(void *) * 4 + location_id.size()) + new_usage;
+                            static_cast<ssize_t>(MetaMemCacheItem::EstimateLocationEntryUsage(location_id, location));
                         existing_locations.emplace(location_id, location);
                     } else {
-                        const ssize_t old_usage = existing->second
-                                                      ? static_cast<ssize_t>(existing->second->EstimateMemUsage())
-                                                      : 0;
+                        const ssize_t old_usage =
+                            existing->second ? static_cast<ssize_t>(existing->second->EstimateMemUsage()) : 0;
                         existing->second = location;
                         charge_delta += new_usage - old_usage;
                     }

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -134,6 +134,11 @@ public:
                                   const KeyTypeVec &keys,
                                   const CacheLocationMapVector &locations,
                                   const PropertyMapVector &properties) noexcept override;
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties,
+                                  MetaAccessIntent intent) noexcept override;
     std::vector<ErrorCode> UpsertSingleLocations(RequestContext *request_context,
                                                  const KeyTypeVec &keys,
                                                  const LocationIdRefVector &location_ids,
@@ -173,6 +178,12 @@ public:
                                   const CacheLocationMapVector &locations,
                                   const PropertyMapVector &properties,
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  const KeyTypeVec &keys,
+                                  const CacheLocationMapVector &locations,
+                                  const PropertyMapVector &properties,
+                                  const std::vector<ErrorCode> &previous_error_codes,
+                                  MetaAccessIntent intent) noexcept override;
     std::vector<ErrorCode> Delete(RequestContext *request_context,
                                   const KeyTypeVec &keys,
                                   const std::vector<ErrorCode> &previous_error_codes) noexcept override;
@@ -244,6 +255,15 @@ public:
                                          const KeyTypeVec &keys,
                                          const std::vector<std::string> &field_names,
                                          PropertyMapVector &out_properties) noexcept override;
+    std::vector<ErrorCode> GetPropertiesForMaintenance(RequestContext *request_context,
+                                                       const KeyTypeVec &keys,
+                                                       const std::vector<std::string> &field_names,
+                                                       PropertyMapVector &out_properties) noexcept override;
+    MaintenanceReadResult GetForMaintenance(RequestContext *request_context,
+                                            const KeyTypeVec &keys,
+                                            const std::vector<std::string> &field_names,
+                                            CacheLocationMapVector &out_locations,
+                                            PropertyMapVector &out_properties) noexcept override;
     std::vector<ErrorCode> Exists(RequestContext *request_context,
                                   const KeyTypeVec &keys,
                                   std::vector<bool> &out_is_exist_vec) noexcept override;
@@ -293,8 +313,10 @@ private:
     }
 
     size_t CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys);
-    ErrorCode
-    CreateAndInsert(std::string_view key_sv, const CacheLocationMap &locations, const PropertyMap &properties);
+    ErrorCode CreateAndInsert(std::string_view key_sv,
+                              const CacheLocationMap &locations,
+                              const PropertyMap &properties,
+                              MetaAccessIntent intent = MetaAccessIntent::kBusinessWrite);
     ErrorCode
     CreateAndInsertIfAbsent(std::string_view key_sv, const CacheLocationMap &locations, const PropertyMap &properties);
     ErrorCode
@@ -318,7 +340,10 @@ private:
                                                  std::vector<ErrorCode> &out_results,
                                                  SingleLocationRmwScratch &scratch,
                                                  bool retain_handles) noexcept;
-    ErrorCode UpsertForOneKey(KeyType key, const CacheLocationMap &locations, const PropertyMap &properties);
+    ErrorCode UpsertForOneKey(KeyType key,
+                              const CacheLocationMap &locations,
+                              const PropertyMap &properties,
+                              MetaAccessIntent intent = MetaAccessIntent::kBusinessWrite);
     ErrorCode DeleteForOneKey(KeyType key);
     ErrorCode DeleteLocationsForOneKey(KeyType key, const std::vector<LocationId> &location_ids);
     // Unified read helper. Fetches data from cache for a single key.
@@ -334,7 +359,9 @@ private:
                            PropertyMap *out_property_map,
                            std::vector<LocationId> *out_location_ids);
     ErrorCode GetForOneKeyForMaintenance(KeyType key,
+                                         const std::vector<std::string> *field_names,
                                          CacheLocationMap *out_location_map,
+                                         PropertyMap *out_property_map,
                                          std::vector<LocationId> *out_location_ids);
 
     std::shared_ptr<Cache::CacheItemHelper> cache_item_helper_;

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -81,6 +81,16 @@ public:
                                           const CacheLocationMapVector &locations,
                                           const PropertyMapVector &properties) noexcept = 0;
 
+    // Intent-aware counterpart used by shared RMW code. Backends without
+    // process-local access bookkeeping can safely reuse ordinary Upsert.
+    virtual std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                          const KeyTypeVec &keys,
+                                          const CacheLocationMapVector &locations,
+                                          const PropertyMapVector &properties,
+                                          MetaAccessIntent /*intent*/) noexcept {
+        return Upsert(request_context, keys, locations, properties);
+    }
+
     // Allocation-light one-location upsert used by pure-local targeted RMW.
     // The default adapter preserves backend semantics; local memory overrides
     // it to avoid constructing one temporary unordered_map per key.
@@ -377,6 +387,26 @@ public:
                                                  const KeyTypeVec &keys,
                                                  const std::vector<std::string> &field_names,
                                                  PropertyMapVector &out_properties) noexcept = 0;
+
+    virtual std::vector<ErrorCode>
+    GetPropertiesForMaintenance(RequestContext *request_context,
+                                const KeyTypeVec &keys,
+                                const std::vector<std::string> &field_names,
+                                PropertyMapVector &out_properties) noexcept {
+        return GetProperties(request_context, keys, field_names, out_properties);
+    }
+
+    virtual MaintenanceReadResult GetForMaintenance(RequestContext *request_context,
+                                                     const KeyTypeVec &keys,
+                                                     const std::vector<std::string> &field_names,
+                                                     CacheLocationMapVector &out_locations,
+                                                     PropertyMapVector &out_properties) noexcept {
+        MaintenanceReadResult result;
+        result.location_error_codes = GetLocations(request_context, keys, out_locations);
+        result.property_error_codes =
+            GetPropertiesForMaintenance(request_context, keys, field_names, out_properties);
+        return result;
+    }
 
     // 检查 key 是否存在。
     // @param request_context   请求上下文；可为 nullptr

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -549,7 +549,8 @@ std::vector<ErrorCode> MetaStorageBackendManager::Put(RequestContext *request_co
 }
 
 std::vector<ErrorCode> MetaStorageBackendManager::Upsert(RequestContext *request_context,
-                                                         BatchMetaData &batch) noexcept {
+                                                         BatchMetaData &batch,
+                                                         MetaAccessIntent intent) noexcept {
     const KeyVector &keys = batch.batch_keys;
     batch.EnsureLocationsAndPropertiesResized();
     CacheLocationMapVector &locations = batch.batch_locations;
@@ -563,7 +564,7 @@ std::vector<ErrorCode> MetaStorageBackendManager::Upsert(RequestContext *request
         }
     }
     std::vector<ErrorCode> persistent_results =
-        persistent_backend_->Upsert(request_context, keys, locations, properties);
+        persistent_backend_->Upsert(request_context, keys, locations, properties, intent);
     if (persistent_results.size() != keys.size()) {
         KVCM_LOG_ERROR("persistent Upsert results[%lu] mismatch keys[%lu]", persistent_results.size(), keys.size());
         return std::vector<ErrorCode>(keys.size(), EC_ERROR);
@@ -572,7 +573,8 @@ std::vector<ErrorCode> MetaStorageBackendManager::Upsert(RequestContext *request
         return persistent_results;
     }
     const int64_t cache_begin = TimestampUtil::GetCurrentTimeUs();
-    auto results = cache_backend_->Upsert(request_context, keys, locations, properties, persistent_results);
+    auto results =
+        cache_backend_->Upsert(request_context, keys, locations, properties, persistent_results, intent);
     if (request_context) {
         auto *mc = dynamic_cast<ServiceMetricsCollector *>(request_context->metrics_collector());
         KVCM_METRICS_COLLECTOR_SET_METRICS(
@@ -1741,6 +1743,175 @@ std::vector<ErrorCode> MetaStorageBackendManager::GetProperties(RequestContext *
         }
     }
     return results;
+}
+
+std::vector<ErrorCode> MetaStorageBackendManager::GetPropertiesForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const std::vector<std::string> &field_names,
+    PropertyMapVector &out_properties) noexcept {
+    if (!cache_backend_) {
+        return persistent_backend_->GetPropertiesForMaintenance(request_context, keys, field_names, out_properties);
+    }
+
+    std::vector<ErrorCode> results =
+        cache_backend_->GetPropertiesForMaintenance(request_context, keys, field_names, out_properties);
+    if (results.size() != keys.size() || out_properties.size() != keys.size()) {
+        KVCM_LOG_ERROR("cache maintenance properties results[%zu] properties[%zu] mismatch keys[%zu]",
+                       results.size(),
+                       out_properties.size(),
+                       keys.size());
+        results.assign(keys.size(), EC_MISMATCH);
+        out_properties.assign(keys.size(), PropertyMap{});
+    }
+    const bool requires_process_local_lru =
+        std::find(field_names.begin(), field_names.end(), PROPERTY_LRU_TIME) != field_names.end() &&
+        GetMaintenancePropertyCapability(PROPERTY_LRU_TIME) ==
+            MaintenancePropertyCapability::kProcessLocalVolatile;
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning ||
+        requires_process_local_lru) {
+        // A cache miss means process-local recency is unknown. Persistent
+        // metadata may still contain a field with the same name, but it does
+        // not belong to the current recency epoch and must not authorize an
+        // ENFORCE decision.
+        return results;
+    }
+
+    // Recovery fallback is read-only: unlike online Get, maintenance reads
+    // must never hydrate or promote the hot cache as a side effect.
+    auto [missing_keys, missing_indices] = CollectMissingKeys(keys, results);
+    if (missing_keys.empty()) {
+        return results;
+    }
+    PropertyMapVector persistent_properties;
+    std::vector<ErrorCode> persistent_results = persistent_backend_->GetPropertiesForMaintenance(
+        request_context, missing_keys, field_names, persistent_properties);
+    if (persistent_results.size() != missing_keys.size() || persistent_properties.size() != missing_keys.size()) {
+        KVCM_LOG_ERROR("persistent maintenance properties results[%zu] properties[%zu] mismatch keys[%zu]",
+                       persistent_results.size(),
+                       persistent_properties.size(),
+                       missing_keys.size());
+        for (const size_t original_idx : missing_indices) {
+            results[original_idx] = EC_MISMATCH;
+            out_properties[original_idx].clear();
+        }
+        return results;
+    }
+    for (size_t i = 0; i < missing_indices.size(); ++i) {
+        const size_t original_idx = missing_indices[i];
+        results[original_idx] = persistent_results[i];
+        if (persistent_results[i] == EC_OK) {
+            out_properties[original_idx] = std::move(persistent_properties[i]);
+        }
+    }
+    return results;
+}
+
+MaintenanceReadResult MetaStorageBackendManager::GetForMaintenance(
+    RequestContext *request_context,
+    const KeyVector &keys,
+    const std::vector<std::string> &field_names,
+    CacheLocationMapVector &out_locations,
+    PropertyMapVector &out_properties) noexcept {
+    if (!cache_backend_) {
+        return persistent_backend_->GetForMaintenance(
+            request_context, keys, field_names, out_locations, out_properties);
+    }
+
+    MaintenanceReadResult results =
+        cache_backend_->GetForMaintenance(request_context, keys, field_names, out_locations, out_properties);
+    const bool location_shape_ok =
+        results.location_error_codes.size() == keys.size() && out_locations.size() == keys.size();
+    const bool property_shape_ok =
+        results.property_error_codes.size() == keys.size() && out_properties.size() == keys.size();
+    if (!location_shape_ok) {
+        KVCM_LOG_ERROR("cache maintenance locations results[%zu] values[%zu] mismatch keys[%zu]",
+                       results.location_error_codes.size(),
+                       out_locations.size(),
+                       keys.size());
+        results.location_error_codes.assign(keys.size(), EC_MISMATCH);
+        out_locations.assign(keys.size(), CacheLocationMap{});
+    }
+    if (!property_shape_ok) {
+        KVCM_LOG_ERROR("cache maintenance properties results[%zu] values[%zu] mismatch keys[%zu]",
+                       results.property_error_codes.size(),
+                       out_properties.size(),
+                       keys.size());
+        results.property_error_codes.assign(keys.size(), EC_MISMATCH);
+        out_properties.assign(keys.size(), PropertyMap{});
+    }
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        return results;
+    }
+
+    const bool requires_process_local_lru =
+        std::find(field_names.begin(), field_names.end(), PROPERTY_LRU_TIME) != field_names.end() &&
+        GetMaintenancePropertyCapability(PROPERTY_LRU_TIME) ==
+            MaintenancePropertyCapability::kProcessLocalVolatile;
+
+    // Fetch the union once, then merge each component independently. A
+    // feature failure must not erase a valid location result (SHADOW relies
+    // on that distinction), and neither component is backfilled into cache.
+    KeyTypeVec missing_keys;
+    std::vector<size_t> missing_indices;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (results.location_error_codes[i] == EC_NOENT ||
+            (!requires_process_local_lru && results.property_error_codes[i] == EC_NOENT)) {
+            missing_keys.push_back(keys[i]);
+            missing_indices.push_back(i);
+        }
+    }
+    if (missing_keys.empty()) {
+        return results;
+    }
+
+    CacheLocationMapVector persistent_locations;
+    PropertyMapVector persistent_properties;
+    MaintenanceReadResult persistent_results = persistent_backend_->GetForMaintenance(
+        request_context, missing_keys, field_names, persistent_locations, persistent_properties);
+    const bool persistent_location_shape_ok = persistent_results.location_error_codes.size() == missing_keys.size() &&
+                                              persistent_locations.size() == missing_keys.size();
+    const bool persistent_property_shape_ok = persistent_results.property_error_codes.size() == missing_keys.size() &&
+                                              persistent_properties.size() == missing_keys.size();
+    for (size_t i = 0; i < missing_indices.size(); ++i) {
+        const size_t original_idx = missing_indices[i];
+        if (results.location_error_codes[original_idx] == EC_NOENT) {
+            if (!persistent_location_shape_ok) {
+                results.location_error_codes[original_idx] = EC_MISMATCH;
+                out_locations[original_idx].clear();
+            } else {
+                results.location_error_codes[original_idx] = persistent_results.location_error_codes[i];
+                if (persistent_results.location_error_codes[i] == EC_OK) {
+                    out_locations[original_idx] = std::move(persistent_locations[i]);
+                }
+            }
+        }
+        if (!requires_process_local_lru && results.property_error_codes[original_idx] == EC_NOENT) {
+            if (!persistent_property_shape_ok) {
+                results.property_error_codes[original_idx] = EC_MISMATCH;
+                out_properties[original_idx].clear();
+            } else {
+                results.property_error_codes[original_idx] = persistent_results.property_error_codes[i];
+                if (persistent_results.property_error_codes[i] == EC_OK) {
+                    out_properties[original_idx] = std::move(persistent_properties[i]);
+                }
+            }
+        }
+    }
+    return results;
+}
+
+MaintenancePropertyCapability MetaStorageBackendManager::GetMaintenancePropertyCapability(
+    const std::string &property_name) const noexcept {
+    if (property_name != PROPERTY_LRU_TIME) {
+        return MaintenancePropertyCapability::kUnsupported;
+    }
+    const MetaStorageBackend *authoritative_backend =
+        cache_backend_ ? static_cast<const MetaStorageBackend *>(cache_backend_.get()) : persistent_backend_.get();
+    if (dynamic_cast<const MetaLocalBackend *>(authoritative_backend) != nullptr) {
+        return MaintenancePropertyCapability::kProcessLocalVolatile;
+    }
+    return MaintenancePropertyCapability::kUnsupported;
 }
 
 std::vector<ErrorCode> MetaStorageBackendManager::Exists(RequestContext *request_context,

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -47,7 +47,9 @@ public:
     // ----- Write APIs -----
     // Put / Upsert merge CacheLocations into batch.batch_properties in place.
     std::vector<ErrorCode> Put(RequestContext *request_context, BatchMetaData &batch) noexcept;
-    std::vector<ErrorCode> Upsert(RequestContext *request_context, BatchMetaData &batch) noexcept;
+    std::vector<ErrorCode> Upsert(RequestContext *request_context,
+                                  BatchMetaData &batch,
+                                  MetaAccessIntent intent = MetaAccessIntent::kBusinessWrite) noexcept;
     std::vector<ErrorCode> UpsertSingleLocations(RequestContext *request_context,
                                                  const KeyVector &keys,
                                                  const LocationIdRefVector &location_ids,
@@ -139,6 +141,17 @@ public:
                                          const KeyVector &keys,
                                          const std::vector<std::string> &field_names,
                                          PropertyMapVector &out_properties) noexcept;
+    std::vector<ErrorCode> GetPropertiesForMaintenance(RequestContext *request_context,
+                                                       const KeyVector &keys,
+                                                       const std::vector<std::string> &field_names,
+                                                       PropertyMapVector &out_properties) noexcept;
+    MaintenanceReadResult GetForMaintenance(RequestContext *request_context,
+                                            const KeyVector &keys,
+                                            const std::vector<std::string> &field_names,
+                                            CacheLocationMapVector &out_locations,
+                                            PropertyMapVector &out_properties) noexcept;
+    MaintenancePropertyCapability
+    GetMaintenancePropertyCapability(const std::string &property_name) const noexcept;
     std::vector<ErrorCode>
     Exists(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_is_exist_vec) noexcept;
 

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -341,6 +341,59 @@ TEST_F(MetaDummyBackendTest, TestMaintenanceScanReturnsLocationsWithoutTouchingL
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaDummyBackendTest, TestMaintenanceReadAndMutationDoNotTouchLru) {
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_maintenance_point_read", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id("loc_1");
+    CacheLocationMapVector locations(1);
+    locations[0].emplace(location->id(), location);
+    PropertyMapVector properties(1);
+    properties[0]["p0"] = "v0";
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK}),
+              meta_storage_backend_->Put(nullptr, {1}, locations, properties));
+
+    auto *backend = static_cast<MetaDummyBackend *>(meta_storage_backend_.get());
+    int64_t lru_before = 0;
+    ASSERT_TRUE(backend->table_.FindAndApply(
+        1, [&lru_before](const DummyItem &item) { lru_before = std::stoll(item.properties.at(PROPERTY_LRU_TIME)); }));
+
+    PropertyMapVector read_properties;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              backend->GetPropertiesForMaintenance(nullptr, {1}, {PROPERTY_LRU_TIME, "p0"}, read_properties));
+    ASSERT_EQ("v0", read_properties[0].at("p0"));
+    ASSERT_EQ(std::to_string(lru_before), read_properties[0].at(PROPERTY_LRU_TIME));
+
+    CacheLocationMapVector read_locations;
+    const auto snapshot =
+        backend->GetForMaintenance(nullptr, {1}, {PROPERTY_LRU_TIME}, read_locations, read_properties);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), snapshot.location_error_codes);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), snapshot.property_error_codes);
+    ASSERT_EQ(1u, read_locations[0].count("loc_1"));
+
+    LocationsPerKey selected_locations;
+    ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}),
+              backend->GetLocationsForMaintenance(nullptr, {1}, {{"loc_1"}}, selected_locations));
+
+    PropertyMapVector updates(1);
+    updates[0]["mark"] = "cold";
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              backend->Upsert(nullptr,
+                              {1},
+                              CacheLocationMapVector(1),
+                              updates,
+                              MetaAccessIntent::kMaintenanceNoTouch));
+
+    int64_t lru_after = 0;
+    ASSERT_TRUE(backend->table_.FindAndApply(1, [&](const DummyItem &item) {
+        lru_after = std::stoll(item.properties.at(PROPERTY_LRU_TIME));
+        EXPECT_EQ("cold", item.properties.at("mark"));
+    }));
+    EXPECT_EQ(lru_before, lru_after);
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaDummyBackendTest, TestRandomSample) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());

--- a/kv_cache_manager/meta/test/meta_indexer_test.cc
+++ b/kv_cache_manager/meta/test/meta_indexer_test.cc
@@ -175,6 +175,33 @@ TEST_F(MetaIndexerTest, TestInit) {
     ASSERT_EQ(EC_CONFIG_ERROR, InitIndexer(configStr));
 }
 
+TEST_F(MetaIndexerTest, TestMaintenanceReadinessEpochStartsAfterRecovery) {
+    const std::string configStr = R"({
+        "max_key_count" : 100, "mutex_shard_num" : 8,
+        "meta_storage_backend_config" : { "storage_type" : "local" },
+        "meta_cache_policy_config" : {}
+    })";
+    ASSERT_EQ(EC_OK, InitIndexer(configStr));
+
+    auto readiness = meta_indexer_->GetMaintenancePropertyReadiness(PROPERTY_LRU_TIME);
+    ASSERT_EQ(MaintenancePropertyCapability::kProcessLocalVolatile, readiness.capability);
+    ASSERT_GT(readiness.valid_since_steady_us, 0);
+
+    meta_indexer_->backend_manager_->recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover,
+                                                          std::memory_order_release);
+    meta_indexer_->ResetMaintenancePropertyReadinessEpoch();
+    const uint64_t recovering_generation = meta_indexer_->maintenance_readiness_generation_.load();
+    readiness = meta_indexer_->GetMaintenancePropertyReadiness(PROPERTY_LRU_TIME);
+    EXPECT_EQ(0, readiness.valid_since_steady_us);
+    EXPECT_EQ(recovering_generation, readiness.generation);
+
+    meta_indexer_->backend_manager_->recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning,
+                                                          std::memory_order_release);
+    readiness = meta_indexer_->GetMaintenancePropertyReadiness(PROPERTY_LRU_TIME);
+    EXPECT_GT(readiness.valid_since_steady_us, 0);
+    EXPECT_GT(readiness.generation, recovering_generation);
+}
+
 TEST_F(MetaIndexerTest, TestProcessErrorCodesRejectsAbnormalResultCount) {
     const KeyVector keys = {11, 22, 33};
 

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -770,6 +770,29 @@ TEST_F(MetaLocalBackendTest, TestMaintenanceTargetReadAndDeleteDoNotTouchAccessT
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaLocalBackendTest, TestMaintenanceUpsertChargesCompleteLocationEntry) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_maintenance_upsert_charge", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "seed"}}}));
+    auto *backend = GetLocalBackend();
+    const size_t usage_before = backend->GetMemUsage();
+
+    auto location = std::make_shared<CacheLocation>();
+    location->set_id("maintenance_location");
+    location->set_status(CacheLocationStatus::CLS_SERVING);
+    CacheLocationMapVector locations(1);
+    locations[0].emplace(location->id(), location);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              backend->Upsert(nullptr, {1}, locations, PropertyMapVector(1), MetaAccessIntent::kMaintenanceNoTouch));
+
+    EXPECT_EQ(usage_before + MetaMemCacheItem::EstimateLocationEntryUsage(location->id(), location),
+              backend->GetMemUsage());
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestSampleReclaimKeys) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_instance_0", meta_storage_backend_config_));
     ASSERT_EQ(EC_OK, meta_storage_backend_->Open());

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -1421,6 +1421,42 @@ TEST_F(MetaStorageBackendManagerTest, TestRecoverReadFallbackToPersistent) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
+TEST_F(MetaStorageBackendManagerTest, TestMaintenanceSnapshotKeepsProcessLocalLruUnknownOnCacheMiss) {
+    const std::string path = GetPrivateTestRuntimeDataPath() + "mgr_maintenance_process_local_lru";
+    std::filesystem::remove(path);
+    MetaStorageBackendManager mgr;
+    ASSERT_EQ(EC_OK, mgr.Init("inst_maintenance_process_local_lru", MakeDualConfig(path)));
+    ASSERT_EQ(EC_OK, mgr.Open());
+    WaitRunning(mgr);
+
+    const KeyVector keys{22};
+    auto persistent_only = MakeBatch(keys);
+    SerializeLocationsIntoProperties(persistent_only);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              mgr.persistent_backend_->Put(nullptr,
+                                           persistent_only.batch_keys,
+                                           persistent_only.batch_locations,
+                                           persistent_only.batch_properties));
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover,
+                             std::memory_order_release);
+
+    CacheLocationMapVector locations;
+    PropertyMapVector properties;
+    const auto result =
+        mgr.GetForMaintenance(nullptr, keys, {PROPERTY_LRU_TIME}, locations, properties);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), result.location_error_codes);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_NOENT}), result.property_error_codes);
+    ASSERT_EQ(1u, locations.size());
+    ASSERT_EQ(1u, locations[0].count("loc_22"));
+    ASSERT_EQ(1u, properties.size());
+    EXPECT_TRUE(properties[0].empty());
+
+    std::vector<bool> cache_exists;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->Exists(nullptr, keys, cache_exists));
+    ASSERT_EQ((std::vector<bool>{false}), cache_exists);
+    ASSERT_EQ(EC_OK, mgr.Close());
+}
+
 // --- Recover phase: writes dual-write; Delete records tombstone --------------
 
 TEST_F(MetaStorageBackendManagerTest, TestRecoverWriteDualWriteAndDeleteTombstone) {

--- a/kv_cache_manager/meta/types.h
+++ b/kv_cache_manager/meta/types.h
@@ -42,6 +42,35 @@ using FieldMapVec = std::vector<FieldMap>;
 using PropertyMap = FieldMap;
 using PropertyMapVector = std::vector<PropertyMap>;
 
+// Access bookkeeping intent shared by meta reads and mutations. Maintenance
+// operations may still change metadata, but must not promote the LRU entry,
+// refresh last-access time, update revisit metrics or future business-hit data.
+enum class MetaAccessIntent : std::uint8_t {
+    kBusinessRead,
+    kBusinessWrite,
+    kMaintenanceNoTouch,
+};
+
+enum class MaintenancePropertyCapability : std::uint8_t {
+    kUnsupported,
+    kProcessLocalVolatile,
+    kDurableAcrossRecovery,
+};
+
+struct MaintenancePropertyReadiness {
+    MaintenancePropertyCapability capability = MaintenancePropertyCapability::kUnsupported;
+    std::int64_t valid_since_steady_us = 0;
+    std::uint64_t generation = 0;
+};
+
+// Backend-level component results for a no-touch point read. Both vectors are
+// positional with the input keys; location and property failures are kept
+// separate so SHADOW mode can remain behavior-neutral on feature failures.
+struct MaintenanceReadResult {
+    std::vector<ErrorCode> location_error_codes;
+    std::vector<ErrorCode> property_error_codes;
+};
+
 // ---------- Location primitives ----------
 using LocationId = std::string;
 using LocationIdVector = std::vector<LocationId>;
@@ -92,6 +121,16 @@ using BlockIdsOnlyModifierFunc = std::function<ModifierResult(const LocationIdVe
                                                               size_t /*key_index*/,
                                                               PropertyMap & /*upsert_property_map*/,
                                                               CacheLocationMap & /*out_new_locations*/)>;
+
+// Block/property maintenance RMW. Existing values are read under the
+// MetaIndexer shard lock and the resulting upsert is committed without touch.
+using BlockPropertyModifierFunc =
+    std::function<ModifierResult(const LocationIdVector & /*existing_location_ids*/,
+                                 const PropertyMap & /*existing_properties*/,
+                                 ErrorCode /*get_ec*/,
+                                 size_t /*key_index*/,
+                                 PropertyMap & /*upsert_property_map*/,
+                                 CacheLocationMap & /*out_new_locations*/)>;
 
 // Note: an earlier `BlockModifierFunc` variant (sees the entire CacheLocationMap
 // of one block_key) was removed because nothing in the codebase ever used

--- a/kv_cache_manager/protocol/protobuf/admin_service.proto
+++ b/kv_cache_manager/protocol/protobuf/admin_service.proto
@@ -251,6 +251,28 @@ message MigrationMethodConfigs {
     MigrationMarkMethodConfig mark = 2;
 }
 
+enum MigrationAdmissionMode {
+    MIGRATION_ADMISSION_DISABLED = 0;
+    MIGRATION_ADMISSION_SHADOW = 1;
+    MIGRATION_ADMISSION_ENFORCE = 2;
+}
+
+message RecentAccessAdmissionConfig {
+    int64 window_seconds = 1;
+}
+
+message MigrationAdmissionPolicyConfig {
+    oneof policy {
+        RecentAccessAdmissionConfig recent_access = 1;
+    }
+}
+
+message MigrationAdmissionConfig {
+    MigrationAdmissionMode mode = 1;
+    // V1 requires exactly one recent_access policy in SHADOW/ENFORCE.
+    repeated MigrationAdmissionPolicyConfig policies = 2;
+}
+
 // 单条迁移规则，绑定一个源 storage
 message MigrationStrategy {
     string source_storage_name = 1;   // 源 storage（热层）unique name
@@ -258,6 +280,7 @@ message MigrationStrategy {
     double trigger_threshold = 3;     // 水位触发阈值（迁移区间下界），如 0.70
     MigrationMethodConfigs method_configs = 4;
     MigrationRetention retention = 5;
+    MigrationAdmissionConfig admission = 6;
 }
 
 message MigrationConfig {
@@ -447,10 +470,70 @@ message MigrateCacheRequest {
     MigrationMethod method = 7;    // COPY / MARK / BOTH
 }
 
+enum MigrationOutcomeStage {
+    MIGRATION_OUTCOME_STAGE_UNSPECIFIED = 0;
+    MIGRATION_OUTCOME_STAGE_SNAPSHOT = 1;
+    MIGRATION_OUTCOME_STAGE_VALUE = 2;
+    MIGRATION_OUTCOME_STAGE_EXECUTION = 3;
+    MIGRATION_OUTCOME_STAGE_COPY = 4;
+    MIGRATION_OUTCOME_STAGE_MARK = 5;
+}
+
+enum MigrationOutcomeClass {
+    MIGRATION_OUTCOME_CLASS_UNSPECIFIED = 0;
+    MIGRATION_OUTCOME_CLASS_ACCEPTED = 1;
+    MIGRATION_OUTCOME_CLASS_REJECTED = 2;
+    MIGRATION_OUTCOME_CLASS_NOOP_ALREADY_SATISFIED = 3;
+    MIGRATION_OUTCOME_CLASS_FAILED = 4;
+}
+
+enum MigrationOutcomeReason {
+    MIGRATION_OUTCOME_REASON_UNSPECIFIED = 0;
+    MIGRATION_OUTCOME_REASON_NOT_RECENT = 1;
+    MIGRATION_OUTCOME_REASON_FEATURE_MISSING = 2;
+    MIGRATION_OUTCOME_REASON_FEATURE_INVALID = 3;
+    MIGRATION_OUTCOME_REASON_FEATURE_UNSUPPORTED = 4;
+    MIGRATION_OUTCOME_REASON_FEATURE_READ_ERROR = 5;
+    MIGRATION_OUTCOME_REASON_ROUTE_NOT_READY = 6;
+    MIGRATION_OUTCOME_REASON_LOCATION_READ_ERROR = 7;
+    MIGRATION_OUTCOME_REASON_SNAPSHOT_SHAPE_ERROR = 8;
+    MIGRATION_OUTCOME_REASON_SOURCE_NOT_FOUND = 9;
+    MIGRATION_OUTCOME_REASON_TARGET_ALREADY_COVERED = 10;
+    MIGRATION_OUTCOME_REASON_ALREADY_MIGRATING = 11;
+    MIGRATION_OUTCOME_REASON_TARGET_REJECTED = 12;
+    MIGRATION_OUTCOME_REASON_SOURCE_RECHECK_FAILED = 13;
+    MIGRATION_OUTCOME_REASON_COPY_SUBMITTED = 14;
+    MIGRATION_OUTCOME_REASON_COPY_SUBMIT_FAILED = 15;
+    MIGRATION_OUTCOME_REASON_MARK_INSERTED = 16;
+    MIGRATION_OUTCOME_REASON_MARK_ALREADY_SAME_TARGET = 17;
+    MIGRATION_OUTCOME_REASON_MARK_CONFLICT_DIFFERENT_TARGET = 18;
+    MIGRATION_OUTCOME_REASON_MARK_MALFORMED = 19;
+    MIGRATION_OUTCOME_REASON_BLOCK_NOT_FOUND = 20;
+    MIGRATION_OUTCOME_REASON_MARK_READ_ERROR = 21;
+    MIGRATION_OUTCOME_REASON_MARK_WRITE_ERROR = 22;
+    MIGRATION_OUTCOME_REASON_POLICY_CONTRACT_ERROR = 23;
+    MIGRATION_OUTCOME_REASON_BUDGET_EXHAUSTED = 24;
+    MIGRATION_OUTCOME_REASON_VALUE_ACCEPTED = 25;
+    MIGRATION_OUTCOME_REASON_NO_EXECUTION_METHOD = 26;
+    MIGRATION_OUTCOME_REASON_COPY_SLOT_EXHAUSTED = 27;
+    MIGRATION_OUTCOME_REASON_DISPATCH_NOT_AVAILABLE = 28;
+}
+
+message MigrationOutcomeCount {
+    MigrationOutcomeStage stage = 1;
+    MigrationOutcomeClass outcome_class = 2;
+    MigrationOutcomeReason reason = 3;
+    int64 count = 4;
+    bool terminal = 5;
+}
+
 message MigrateCacheResponse {
     CommonResponseHeader header = 1;
     int64 accepted = 2; // 接受并投递的 block 数
-    int64 rejected = 3; // 被准入策略 / 校验拒绝的 block 数
+    // Legacy “未产生新 Copy/Mark”汇总；包含 reject、already-satisfied no-op 和 failed。
+    // 精确口径使用 outcome_counts。
+    int64 rejected = 3;
+    repeated MigrationOutcomeCount outcome_counts = 4;
 }
 
 message ModelDeployment {

--- a/kv_cache_manager/service/admin_service_impl.cc
+++ b/kv_cache_manager/service/admin_service_impl.cc
@@ -75,8 +75,107 @@
     } while (0)
 
 namespace {
+namespace proto = kv_cache_manager::proto;
+using kv_cache_manager::MigrationOutcomeClass;
+using kv_cache_manager::MigrationOutcomeReason;
+using kv_cache_manager::MigrationOutcomeStage;
+
 kv_cache_manager::proto::admin::ErrorCode ToAdminPbError(kv_cache_manager::ErrorCode ec) {
     return kv_cache_manager::ToPbError<kv_cache_manager::proto::admin::ErrorCode>(ec);
+}
+
+proto::admin::MigrationOutcomeStage ToPbMigrationOutcomeStage(MigrationOutcomeStage stage) {
+    switch (stage) {
+    case MigrationOutcomeStage::kSnapshot:
+        return proto::admin::MIGRATION_OUTCOME_STAGE_SNAPSHOT;
+    case MigrationOutcomeStage::kValue:
+        return proto::admin::MIGRATION_OUTCOME_STAGE_VALUE;
+    case MigrationOutcomeStage::kExecution:
+        return proto::admin::MIGRATION_OUTCOME_STAGE_EXECUTION;
+    case MigrationOutcomeStage::kCopy:
+        return proto::admin::MIGRATION_OUTCOME_STAGE_COPY;
+    case MigrationOutcomeStage::kMark:
+        return proto::admin::MIGRATION_OUTCOME_STAGE_MARK;
+    }
+    return proto::admin::MIGRATION_OUTCOME_STAGE_UNSPECIFIED;
+}
+
+proto::admin::MigrationOutcomeClass ToPbMigrationOutcomeClass(MigrationOutcomeClass outcome_class) {
+    switch (outcome_class) {
+    case MigrationOutcomeClass::kAccepted:
+        return proto::admin::MIGRATION_OUTCOME_CLASS_ACCEPTED;
+    case MigrationOutcomeClass::kRejected:
+        return proto::admin::MIGRATION_OUTCOME_CLASS_REJECTED;
+    case MigrationOutcomeClass::kNoopAlreadySatisfied:
+        return proto::admin::MIGRATION_OUTCOME_CLASS_NOOP_ALREADY_SATISFIED;
+    case MigrationOutcomeClass::kFailed:
+        return proto::admin::MIGRATION_OUTCOME_CLASS_FAILED;
+    }
+    return proto::admin::MIGRATION_OUTCOME_CLASS_UNSPECIFIED;
+}
+
+proto::admin::MigrationOutcomeReason ToPbMigrationOutcomeReason(MigrationOutcomeReason reason) {
+    switch (reason) {
+    case MigrationOutcomeReason::kUnspecified:
+        return proto::admin::MIGRATION_OUTCOME_REASON_UNSPECIFIED;
+    case MigrationOutcomeReason::kNotRecent:
+        return proto::admin::MIGRATION_OUTCOME_REASON_NOT_RECENT;
+    case MigrationOutcomeReason::kFeatureMissing:
+        return proto::admin::MIGRATION_OUTCOME_REASON_FEATURE_MISSING;
+    case MigrationOutcomeReason::kFeatureInvalid:
+        return proto::admin::MIGRATION_OUTCOME_REASON_FEATURE_INVALID;
+    case MigrationOutcomeReason::kFeatureUnsupported:
+        return proto::admin::MIGRATION_OUTCOME_REASON_FEATURE_UNSUPPORTED;
+    case MigrationOutcomeReason::kFeatureReadError:
+        return proto::admin::MIGRATION_OUTCOME_REASON_FEATURE_READ_ERROR;
+    case MigrationOutcomeReason::kRouteNotReady:
+        return proto::admin::MIGRATION_OUTCOME_REASON_ROUTE_NOT_READY;
+    case MigrationOutcomeReason::kLocationReadError:
+        return proto::admin::MIGRATION_OUTCOME_REASON_LOCATION_READ_ERROR;
+    case MigrationOutcomeReason::kSnapshotShapeError:
+        return proto::admin::MIGRATION_OUTCOME_REASON_SNAPSHOT_SHAPE_ERROR;
+    case MigrationOutcomeReason::kSourceNotFound:
+        return proto::admin::MIGRATION_OUTCOME_REASON_SOURCE_NOT_FOUND;
+    case MigrationOutcomeReason::kTargetAlreadyCovered:
+        return proto::admin::MIGRATION_OUTCOME_REASON_TARGET_ALREADY_COVERED;
+    case MigrationOutcomeReason::kAlreadyMigrating:
+        return proto::admin::MIGRATION_OUTCOME_REASON_ALREADY_MIGRATING;
+    case MigrationOutcomeReason::kTargetRejected:
+        return proto::admin::MIGRATION_OUTCOME_REASON_TARGET_REJECTED;
+    case MigrationOutcomeReason::kSourceRecheckFailed:
+        return proto::admin::MIGRATION_OUTCOME_REASON_SOURCE_RECHECK_FAILED;
+    case MigrationOutcomeReason::kCopySubmitted:
+        return proto::admin::MIGRATION_OUTCOME_REASON_COPY_SUBMITTED;
+    case MigrationOutcomeReason::kCopySubmitFailed:
+        return proto::admin::MIGRATION_OUTCOME_REASON_COPY_SUBMIT_FAILED;
+    case MigrationOutcomeReason::kMarkInserted:
+        return proto::admin::MIGRATION_OUTCOME_REASON_MARK_INSERTED;
+    case MigrationOutcomeReason::kMarkAlreadySameTarget:
+        return proto::admin::MIGRATION_OUTCOME_REASON_MARK_ALREADY_SAME_TARGET;
+    case MigrationOutcomeReason::kMarkConflictDifferentTarget:
+        return proto::admin::MIGRATION_OUTCOME_REASON_MARK_CONFLICT_DIFFERENT_TARGET;
+    case MigrationOutcomeReason::kMarkMalformed:
+        return proto::admin::MIGRATION_OUTCOME_REASON_MARK_MALFORMED;
+    case MigrationOutcomeReason::kBlockNotFound:
+        return proto::admin::MIGRATION_OUTCOME_REASON_BLOCK_NOT_FOUND;
+    case MigrationOutcomeReason::kMarkReadError:
+        return proto::admin::MIGRATION_OUTCOME_REASON_MARK_READ_ERROR;
+    case MigrationOutcomeReason::kMarkWriteError:
+        return proto::admin::MIGRATION_OUTCOME_REASON_MARK_WRITE_ERROR;
+    case MigrationOutcomeReason::kPolicyContractError:
+        return proto::admin::MIGRATION_OUTCOME_REASON_POLICY_CONTRACT_ERROR;
+    case MigrationOutcomeReason::kBudgetExhausted:
+        return proto::admin::MIGRATION_OUTCOME_REASON_BUDGET_EXHAUSTED;
+    case MigrationOutcomeReason::kValueAccepted:
+        return proto::admin::MIGRATION_OUTCOME_REASON_VALUE_ACCEPTED;
+    case MigrationOutcomeReason::kNoExecutionMethod:
+        return proto::admin::MIGRATION_OUTCOME_REASON_NO_EXECUTION_METHOD;
+    case MigrationOutcomeReason::kCopySlotExhausted:
+        return proto::admin::MIGRATION_OUTCOME_REASON_COPY_SLOT_EXHAUSTED;
+    case MigrationOutcomeReason::kDispatchNotAvailable:
+        return proto::admin::MIGRATION_OUTCOME_REASON_DISPATCH_NOT_AVAILABLE;
+    }
+    return proto::admin::MIGRATION_OUTCOME_REASON_UNSPECIFIED;
 }
 
 bool HasUniqueEventReportOwnerPerType(const std::shared_ptr<kv_cache_manager::RegistryManager> &registry_manager,
@@ -602,6 +701,14 @@ void AdminServiceImpl::MigrateCache(RequestContext *request_context,
 
     response->set_accepted(result.accepted);
     response->set_rejected(result.rejected);
+    for (const auto &outcome : result.outcome_counts) {
+        auto *pb_outcome = response->add_outcome_counts();
+        pb_outcome->set_stage(ToPbMigrationOutcomeStage(outcome.stage));
+        pb_outcome->set_outcome_class(ToPbMigrationOutcomeClass(outcome.outcome_class));
+        pb_outcome->set_reason(ToPbMigrationOutcomeReason(outcome.reason));
+        pb_outcome->set_count(outcome.count);
+        pb_outcome->set_terminal(outcome.terminal);
+    }
     status->set_code(result.ec == EC_OK ? proto::admin::OK : ToAdminPbError(result.ec));
     status->set_message(result.message);
     request_context->set_status_code(status->code());

--- a/kv_cache_manager/service/test/admin_service_impl_test.cc
+++ b/kv_cache_manager/service/test/admin_service_impl_test.cc
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -44,6 +45,31 @@ ErrorCode BatchAddLocationForTest(MetaSearcher *meta_searcher,
         out_location_ids.push_back(result.location_id);
     }
     return ec;
+}
+
+int64_t OutcomeCount(const proto::admin::MigrateCacheResponse &response,
+                     proto::admin::MigrationOutcomeStage stage,
+                     proto::admin::MigrationOutcomeClass outcome_class,
+                     proto::admin::MigrationOutcomeReason reason,
+                     bool terminal) {
+    int64_t count = 0;
+    for (const auto &outcome : response.outcome_counts()) {
+        if (outcome.stage() == stage && outcome.outcome_class() == outcome_class && outcome.reason() == reason &&
+            outcome.terminal() == terminal) {
+            count += outcome.count();
+        }
+    }
+    return count;
+}
+
+int64_t TerminalOutcomeCount(const proto::admin::MigrateCacheResponse &response) {
+    int64_t count = 0;
+    for (const auto &outcome : response.outcome_counts()) {
+        if (outcome.terminal()) {
+            count += outcome.count();
+        }
+    }
+    return count;
 }
 } // namespace
 
@@ -251,6 +277,24 @@ TEST_F(AdminServiceImplTest, TestExplicitBlockKeysCopy) {
     ASSERT_EQ(proto::admin::OK, resp.header().status().code());
     ASSERT_EQ(2, resp.accepted());
     ASSERT_EQ(1, resp.rejected());
+    ASSERT_EQ(3, TerminalOutcomeCount(resp));
+    ASSERT_EQ(2,
+              OutcomeCount(resp,
+                           proto::admin::MIGRATION_OUTCOME_STAGE_COPY,
+                           proto::admin::MIGRATION_OUTCOME_CLASS_ACCEPTED,
+                           proto::admin::MIGRATION_OUTCOME_REASON_COPY_SUBMITTED,
+                           true));
+    ASSERT_EQ(1,
+              OutcomeCount(resp,
+                           proto::admin::MIGRATION_OUTCOME_STAGE_SNAPSHOT,
+                           proto::admin::MIGRATION_OUTCOME_CLASS_REJECTED,
+                           proto::admin::MIGRATION_OUTCOME_REASON_SOURCE_NOT_FOUND,
+                           true));
+    ASSERT_EQ(32u,
+              metrics_registry_
+                  ->GetCounter("migration_copy_planned_bytes_total",
+                               {{"src", "hot_01"}, {"dst", "cold_01"}, {"decision", "dispatched"}})
+                  .Get());
     ASSERT_TRUE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 101));
     ASSERT_TRUE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 102));
     ASSERT_FALSE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 103));
@@ -336,6 +380,18 @@ TEST_F(AdminServiceImplTest, TestAdminAndReclaimerCopyShareGroupConcurrencyLimit
     SeedServingSource(141);
     SeedServingSource(142);
 
+    auto indexer = cache_manager_->meta_indexer_manager()->GetMetaIndexer(kInstance);
+    ASSERT_NE(nullptr, indexer);
+    MetaSearcher meta_searcher(indexer);
+    RequestContext source_context("admin_reclaimer_source_snapshot");
+    std::vector<CacheLocationMap> source_maps;
+    BlockMask source_mask;
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(&source_context, {142}, source_mask, source_maps));
+    ASSERT_EQ(1u, source_maps.size());
+    ASSERT_EQ(1u, source_maps[0].size());
+    const auto reclaimer_source = source_maps[0].begin()->second;
+    ASSERT_NE(nullptr, reclaimer_source);
+
     auto admin_req = MakeReq(proto::admin::MIGRATION_METHOD_COPY, {141});
     proto::admin::MigrateCacheResponse admin_resp;
 
@@ -345,10 +401,11 @@ TEST_F(AdminServiceImplTest, TestAdminAndReclaimerCopyShareGroupConcurrencyLimit
     reclaimer_req.instance_group_name = "default";
     reclaimer_req.instance_id = kInstance;
     reclaimer_req.block_key = 142;
-    reclaimer_req.src_location_id = "reclaimer_src_142";
+    reclaimer_req.src_location_id = reclaimer_source->id();
     reclaimer_req.src_storage_name = "hot_01";
     reclaimer_req.dst_storage_name = "cold_01";
-    reclaimer_req.src_specs = {LocationSpec("tp0", "dummy://hot_01/reclaimer_142?size=16")};
+    reclaimer_req.src_specs = reclaimer_source->location_specs();
+    reclaimer_req.src_create_time = reclaimer_source->create_time();
 
     std::vector<ErrorCode> reclaimer_results;
     std::atomic<int> ready{0};
@@ -428,6 +485,31 @@ TEST_F(AdminServiceImplTest, TestExplicitBlockKeysMark) {
     ASSERT_EQ("cold_01", cache_manager_->migration_manager()->GetTieredWriteTarget(kInstance, 201));
 }
 
+TEST_F(AdminServiceImplTest, TestRepeatedMarkReturnsNoopOutcomeWithoutRenewing) {
+    SeedServingSource(204);
+
+    auto request_context = std::make_shared<RequestContext>("mark_noop_outcome");
+    auto request = MakeReq(proto::admin::MIGRATION_METHOD_MARK, {204});
+    proto::admin::MigrateCacheResponse first;
+    admin_->MigrateCache(request_context.get(), &request, &first);
+    ASSERT_EQ(proto::admin::OK, first.header().status().code());
+    ASSERT_EQ(1, first.accepted());
+    ASSERT_EQ(1, TerminalOutcomeCount(first));
+
+    proto::admin::MigrateCacheResponse second;
+    admin_->MigrateCache(request_context.get(), &request, &second);
+    ASSERT_EQ(proto::admin::OK, second.header().status().code());
+    ASSERT_EQ(0, second.accepted());
+    ASSERT_EQ(1, second.rejected()); // legacy projection keeps not-dispatched semantics
+    ASSERT_EQ(1, TerminalOutcomeCount(second));
+    ASSERT_EQ(1,
+              OutcomeCount(second,
+                           proto::admin::MIGRATION_OUTCOME_STAGE_MARK,
+                           proto::admin::MIGRATION_OUTCOME_CLASS_NOOP_ALREADY_SATISFIED,
+                           proto::admin::MIGRATION_OUTCOME_REASON_MARK_ALREADY_SAME_TARGET,
+                           true));
+}
+
 TEST_F(AdminServiceImplTest, TestExplicitBlockKeysMarkCountsUniqueBlocks) {
     SeedServingSource(211);
     SeedServingSource(212);
@@ -478,8 +560,9 @@ TEST_F(AdminServiceImplTest, TestBothRejectedWhenNoMigrationStrategy) {
     ASSERT_FALSE(cache_manager_->migration_manager()->IsMarkedForTieredWrite(kInstance, 811));
 }
 
-// COPY-only 不创建 mark，无需 strategy；即使 group 无 strategy 也应正常工作（证明拒绝只作用于 do_mark）。
-TEST_F(AdminServiceImplTest, TestCopyAllowedWithoutMigrationStrategy) {
+// 所有下沉路径（包括 COPY-only）都必须精确命中 route，不允许以缺省
+// DISABLED 绕过路由配置和准入。
+TEST_F(AdminServiceImplTest, TestCopyRejectedWithoutMigrationStrategy) {
     SetDefaultMigrationStrategy(false);
     SeedServingSource(821);
 
@@ -488,9 +571,53 @@ TEST_F(AdminServiceImplTest, TestCopyAllowedWithoutMigrationStrategy) {
     proto::admin::MigrateCacheResponse resp;
     admin_->MigrateCache(rc.get(), &req, &resp);
 
-    ASSERT_EQ(proto::admin::OK, resp.header().status().code());
-    ASSERT_EQ(1, resp.accepted());
-    ASSERT_TRUE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 821));
+    ASSERT_EQ(proto::admin::INVALID_ARGUMENT, resp.header().status().code());
+    ASSERT_EQ(0, resp.accepted());
+    ASSERT_FALSE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 821));
+}
+
+TEST_F(AdminServiceImplTest, TestAdminMethodComesFromRequestAfterRouteMatch) {
+    auto cache_config = registry_manager_->instance_group_configs_.at("default")->cache_config_;
+    ASSERT_EQ(1u, cache_config->migration_strategies().size());
+    auto route = cache_config->migration_strategies().front();
+    ASSERT_NE(nullptr, route);
+    MigrationMethods reclaimer_methods;
+    reclaimer_methods.mutable_copy().set_enabled(false);
+    reclaimer_methods.mutable_mark().set_enabled(true);
+    route->set_methods(reclaimer_methods);
+
+    SeedServingSource(822);
+    auto request_context = std::make_shared<RequestContext>("admin_request_method");
+    auto request = MakeReq(proto::admin::MIGRATION_METHOD_COPY, {822});
+    proto::admin::MigrateCacheResponse response;
+    admin_->MigrateCache(request_context.get(), &request, &response);
+
+    // Route methods control automatic Reclaimer dispatch.  Once Admin has
+    // matched an exact route, its explicit request method remains authoritative.
+    ASSERT_EQ(proto::admin::OK, response.header().status().code());
+    ASSERT_EQ(1, response.accepted());
+    ASSERT_TRUE(cache_manager_->migration_manager()->HasMigrationTask(kInstance, 822));
+}
+
+TEST_F(AdminServiceImplTest, TestAdminCopyUsesMatchedRouteRetention) {
+    auto cache_config = registry_manager_->instance_group_configs_.at("default")->cache_config_;
+    ASSERT_EQ(1u, cache_config->migration_strategies().size());
+    auto route = cache_config->migration_strategies().front();
+    ASSERT_NE(nullptr, route);
+    route->set_retention(MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH);
+
+    SeedServingSource(823);
+    auto request_context = std::make_shared<RequestContext>("admin_route_retention");
+    auto request = MakeReq(proto::admin::MIGRATION_METHOD_COPY, {823});
+    proto::admin::MigrateCacheResponse response;
+    admin_->MigrateCache(request_context.get(), &request, &response);
+
+    ASSERT_EQ(proto::admin::OK, response.header().status().code());
+    ASSERT_EQ(1, response.accepted());
+    auto manager = cache_manager_->migration_manager();
+    std::lock_guard<std::mutex> lock(manager->task_mutex_);
+    ASSERT_EQ(MigrationRetention::MIGRATION_RETENTION_KEEP_BOTH,
+              manager->active_tasks_by_instance_.at(kInstance).at(823).retention);
 }
 
 TEST_F(AdminServiceImplTest, TestExplicitBlockKeysBothPrefersCopy) {

--- a/kv_cache_manager/service/util/manager_message_proto_util.cc
+++ b/kv_cache_manager/service/util/manager_message_proto_util.cc
@@ -272,6 +272,16 @@ void ProtoConvert::CacheConfigToProto(const CacheConfig &cache_config_info,
             migration_strategy->methods().mark().timeout_ms());
         proto_migration_strategy->set_retention(
             static_cast<proto::admin::MigrationRetention>(migration_strategy->retention()));
+        auto *proto_admission = proto_migration_strategy->mutable_admission();
+        proto_admission->set_mode(
+            static_cast<proto::admin::MigrationAdmissionMode>(migration_strategy->admission().mode()));
+        for (const auto &policy : migration_strategy->admission().policies()) {
+            if (policy == nullptr || policy->recent_access() == nullptr) {
+                continue;
+            }
+            proto_admission->add_policies()->mutable_recent_access()->set_window_seconds(
+                policy->recent_access()->window_seconds());
+        }
     }
 }
 
@@ -360,6 +370,20 @@ void ProtoConvert::CacheConfigFromProto(const proto::admin::CacheConfig *proto_c
         }
         migration_strategy->set_methods(methods);
         migration_strategy->set_retention(static_cast<MigrationRetention>(proto_migration_strategy.retention()));
+        MigrationAdmissionConfig admission;
+        admission.set_mode(static_cast<MigrationAdmissionMode>(proto_migration_strategy.admission().mode()));
+        std::vector<std::shared_ptr<MigrationAdmissionPolicyConfig>> policies;
+        policies.reserve(proto_migration_strategy.admission().policies_size());
+        for (const auto &proto_policy : proto_migration_strategy.admission().policies()) {
+            auto policy = std::make_shared<MigrationAdmissionPolicyConfig>();
+            if (proto_policy.has_recent_access()) {
+                policy->set_recent_access(std::make_shared<RecentAccessAdmissionConfig>(
+                    proto_policy.recent_access().window_seconds()));
+            }
+            policies.push_back(std::move(policy));
+        }
+        admission.set_policies(policies);
+        migration_strategy->set_admission(admission);
         migration_strategies.push_back(migration_strategy);
     }
     cache_config_info.set_migration_strategies(migration_strategies);

--- a/package/kvcm_ops/kvcm/instance_group/util.py
+++ b/package/kvcm_ops/kvcm/instance_group/util.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 import math
 from ..common.json_data import *
 from ..common.common_args import *
@@ -318,18 +319,25 @@ class CacheConfig(JsonData):
     def __init__(self,
                  data_storage_strategy: str = "CPS_PREFER_3FS",
                  reclaim_strategy: ReclaimStrategy = ReclaimStrategy(),
-                 meta_indexer_config: MetaIndexerConfig = MetaIndexerConfig()):
+                 meta_indexer_config: MetaIndexerConfig = MetaIndexerConfig(),
+                 extra_fields=None):
         self._data_storage_strategy = data_storage_strategy
         self._reclaim_strategy = reclaim_strategy
         self._meta_indexer_config = meta_indexer_config
+        # Preserve server fields that this client version does not model. In
+        # particular migration_config (including admission and future leaves)
+        # must survive a read-modify-update of an unrelated setting.
+        self._extra_fields = copy.deepcopy(extra_fields) if extra_fields is not None else {}
         self.check()
 
     def to_json_data(self) -> dict:
-        return {
+        result = copy.deepcopy(self._extra_fields)
+        result.update({
             "reclaim_strategy": self._reclaim_strategy.to_json_data(),
             "data_storage_strategy": self._data_storage_strategy,
             "meta_indexer_config": self._meta_indexer_config.to_json_data()
-        }
+        })
+        return result
 
     def check(self) -> bool:
         _data_storage_strategy = self._data_storage_strategy.upper()
@@ -348,13 +356,18 @@ class CacheConfig(JsonData):
 
     @classmethod
     def from_json_data(cls, json_data: dict):
+        data_storage_strategy = "CPS_PREFER_3FS"
+        reclaim_strategy = ReclaimStrategy()
+        meta_indexer_config = MetaIndexerConfig()
         if JsonData.expect_exist("data_storage_strategy", json_data, str):
             data_storage_strategy = json_data["data_storage_strategy"]
         if JsonData.expect_exist("reclaim_strategy", json_data, dict):
             reclaim_strategy = ReclaimStrategy.from_json_data(json_data["reclaim_strategy"])
         if JsonData.expect_exist("meta_indexer_config", json_data, dict):
             meta_indexer_config = MetaIndexerConfig.from_json_data(json_data["meta_indexer_config"])
-        return cls(data_storage_strategy, reclaim_strategy, meta_indexer_config)
+        known_fields = {"data_storage_strategy", "reclaim_strategy", "meta_indexer_config"}
+        extra_fields = {key: value for key, value in json_data.items() if key not in known_fields}
+        return cls(data_storage_strategy, reclaim_strategy, meta_indexer_config, extra_fields)
 
 
 # Aligned with server-side StringUtil::ParseBucketBoundaries: comma separated,

--- a/package/kvcm_ops/test/storage_util_test.py
+++ b/package/kvcm_ops/test/storage_util_test.py
@@ -22,6 +22,33 @@ from kvcm_ops.kvcm.storage.update_storage import create_update_storage_data
 from kvcm_ops.kvcm.instance_group.util import CacheConfig
 
 
+class CacheConfigRoundTripTest(unittest.TestCase):
+    def test_migration_config_and_unknown_fields_are_preserved(self):
+        raw = CacheConfig().to_json_data()
+        raw["migration_config"] = {
+            "copy_max_concurrency": 3,
+            "mark_clear_policy": "MIGRATION_MARK_CLEAR_ON_NEXT_WRITE_SUCCESS",
+            "strategies": [{
+                "source_storage_name": "hot_01",
+                "target_storage_name": "cold_01",
+                "admission": {
+                    "mode": "MIGRATION_ADMISSION_SHADOW",
+                    "policies": [{"recent_access": {"window_seconds": "3600", "future_leaf": 7}}],
+                },
+            }],
+            "future_config": {"enabled": True},
+        }
+        raw["future_cache_field"] = {"value": 9}
+
+        parsed = CacheConfig.from_json_data(raw)
+        parsed._meta_indexer_config._max_key_count = 123
+        serialized = parsed.to_json_data()
+
+        self.assertEqual(raw["migration_config"], serialized["migration_config"])
+        self.assertEqual(raw["future_cache_field"], serialized["future_cache_field"])
+        self.assertEqual(123, serialized["meta_indexer_config"]["max_key_count"])
+
+
 class EventReportStorageArgsTest(unittest.TestCase):
     def _parse_args(self, *args):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Background

This PR adds access-feature-based value admission to tiered-storage migration. It only decides whether an existing block in an upper tier is worth migrating to a lower tier through Copy or Mark. It does not affect normal first writes to the hot tier.

V1 provides a recent-access policy: only candidates with a metadata touch inside the configured time window are admitted. This is a value filter that probabilistically reduces lower-tier writes; it is not a hard byte-rate, daily-byte, or DWPD budget.

## Main changes

- Add route-level `DISABLED` / `SHADOW` / `ENFORCE` admission configuration and a recent-access window, including proto/JSON validation and complete `kvcm_ops` round-trip support.
- Add typed features, policy, and factory abstractions inside `MigrationManager`, allowing future access-count or other leaf policies without changing the Copy/Mark dispatch flow.
- Unify Reclaimer and Admin through `DispatchMigrationBatch`; obtain locations and policy-required features in one NoTouch snapshot before value admission and the existing execution admission.
- Propagate maintenance access intent through sampling, prepare, and Mark/Copy RMW paths so migration maintenance does not refresh LRU timestamps.
- Add ENFORCE prerequisites: Copy source-generation leases and post-reservation revalidation, partial-spec Copy, conditional Mark with per-key outcomes, and backend capability/readiness warmup gates.
- Add a unified migration outcome model and admission/Copy/Mark metrics. Planned byte accounting includes only target-missing specs.
- Integrate with the cross-instance fair reclamation already on main: normal reclamation retains its per-instance budget, while admission-enabled migration expands only its candidate pool before LRU ordering and action-budget truncation.

## Compatibility and scope

- Admission defaults to `DISABLED`. Normal `StartWriteCache` behavior is unchanged; only a previously admitted Mark is consumed by a later write.
- Admin `MigrateCache` must match an explicit source -> target route and can no longer bypass admission through an implicit `DISABLED` fallback.
- `PROPERTY_LRU_TIME` represents the latest metadata touch, not a true business hit or proof of reuse. Business access counts and hard write budgets are outside V1.
- ENFORCE still requires production SHADOW observation, backend capability verification, and recency warmup.

## Validation

All builds and tests were run in the dedicated container on host 202; no local compilation was performed.

- All 14 targeted Bazel test targets passed, covering config, policy, manager, meta backends, service, and `kvcm_ops`.
- Review-follow-up regression: 8 focused C++ test targets passed; after adding the zero-generation mismatch case, `MigrationManagerTest` passed again, and `//kv_cache_manager:kv_cache_manager_bin` rebuilt successfully.
- `CacheManagerTest --runs_per_test=3` passed (30 shard runs). A legacy assertion failure observed once in the initial combined run reproduced 3/3 on clean `origin/main@6a163f93`.
- Dummy tiered-storage E2E: 6 passed / 6 expected skips in default mode; 11 passed / 1 intentional F-25 skip with the Reclaimer gate enabled. For the spec-group Admin case, the route threshold was transiently set to `0.99` on the remote harness to isolate manual Admin Copy from the fair Reclaimer on main; that harness adjustment is not part of this PR.
- The post-rebase full `//kv_cache_manager/...` run was blocked during analysis/fetch by the remote dependency environment: the Tsinghua PyPI mirror returned HTTP 403 for `requests==2.32.5`, while the existing output base lacked the new `orjson` repository from main. This PR does not claim a passing post-rebase full suite.

## Suggested review order

1. `docs/design/migration_admission_strategy.md` for semantics, scope, failure behavior, and rollout prerequisites.
2. `kv_cache_manager/config/migration_strategy.*` and `migration_admission_internal.*` for configuration and policy abstractions.
3. `kv_cache_manager/meta/*` for NoTouch snapshots, capabilities, and access intent.
4. `migration_manager.*`, `schedule_plan_executor.*`, and `cache_reclaimer.*` for shared dispatch, source leases, conditional Mark, and action budgets.
5. Protocol/service/`kvcm_ops` and tests for public outcomes, round-trip behavior, and regression coverage.

Please pay particular attention to source-lease lifetime, SHADOW fail-open behavior for feature failures, end-to-end maintenance access-intent propagation, and per-key terminal outcomes for Copy fallback Mark.