### PR TITLE
[manager] make reclaim sampling non-intrusive and progressive

### DIFF
--- a/kv_cache_manager/common/cache/advanced_cache.h
+++ b/kv_cache_manager/common/cache/advanced_cache.h
@@ -490,6 +490,19 @@ public: // functions
         return 0;
     }
 
+    // Applies a callback to up to `count` oldest entries in one shard without
+    // marking them as hits or changing their LRU positions. The callback runs
+    // while the shard is locked and must not call back into this Cache.
+    // Returns the number of entries visited. The default implementation is
+    // unsupported and visits no entries.
+    virtual size_t ApplyToOldestEntriesInShard(
+        uint32_t /*shard_id*/,
+        size_t /*count*/,
+        const std::function<void(
+            const std::string_view &key, ObjectPtr obj, size_t charge, const CacheItemHelper *helper)> & /*callback*/) {
+        return 0;
+    }
+
     // Apply a callback to every entry in the specified shard. The callback
     // receives the key, object pointer, charge, and helper of each entry.
     // This allows callers to iterate over a single shard without touching
@@ -787,6 +800,15 @@ public:
             void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)> &callback)
         override {
         target_->ApplyToSingleShard(shard_id, callback);
+    }
+
+    size_t ApplyToOldestEntriesInShard(
+        uint32_t shard_id,
+        size_t count,
+        const std::function<
+            void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)> &callback)
+        override {
+        return target_->ApplyToOldestEntriesInShard(shard_id, count, callback);
     }
 
     bool ApplyToEntryNoTouch(

--- a/kv_cache_manager/common/cache/advanced_cache.h
+++ b/kv_cache_manager/common/cache/advanced_cache.h
@@ -490,12 +490,14 @@ public: // functions
         return 0;
     }
 
-    // Applies a callback to up to `count` oldest entries in one shard without
-    // marking them as hits or changing their LRU positions. The callback runs
-    // while the shard is locked and must not call back into this Cache.
-    // Returns the number of entries visited. The default implementation is
-    // unsupported and visits no entries.
-    virtual size_t ApplyToOldestEntriesInShard(
+    // Applies a callback to the next `count` entries in one shard's oldest-to-
+    // newest sampling scan. The scan cursor advances independently of LRU
+    // order, so repeated calls make progress without marking entries as hits
+    // or changing their LRU positions. A call may wrap at the newest end but
+    // visits each entry at most once. The callback runs while the shard is
+    // locked and must not call back into this Cache. Returns the number of
+    // entries visited. The default implementation is unsupported.
+    virtual size_t ApplyToNextOldestEntriesInShard(
         uint32_t /*shard_id*/,
         size_t /*count*/,
         const std::function<void(
@@ -802,13 +804,13 @@ public:
         target_->ApplyToSingleShard(shard_id, callback);
     }
 
-    size_t ApplyToOldestEntriesInShard(
+    size_t ApplyToNextOldestEntriesInShard(
         uint32_t shard_id,
         size_t count,
         const std::function<
             void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)> &callback)
         override {
-        return target_->ApplyToOldestEntriesInShard(shard_id, count, callback);
+        return target_->ApplyToNextOldestEntriesInShard(shard_id, count, callback);
     }
 
     bool ApplyToEntryNoTouch(

--- a/kv_cache_manager/common/cache/lru_cache.cc
+++ b/kv_cache_manager/common/cache/lru_cache.cc
@@ -849,6 +849,24 @@ size_t LRUCacheShard::GetOldestKeys(size_t count, std::vector<std::string> &out_
     return collected;
 }
 
+size_t LRUCacheShard::ApplyToOldestEntries(
+    size_t count,
+    const std::function<
+        void(const std::string_view &key, Cache::ObjectPtr value, size_t charge, const Cache::CacheItemHelper *helper)>
+        &callback) {
+    std::lock_guard<std::mutex> l(mutex_);
+    size_t visited = 0;
+    LRUHandle *current = lru_.next;
+    while (current != &lru_ && visited < count) {
+        if (current->InCache()) {
+            callback(current->key(), current->value, current->GetCharge(metadata_charge_policy_), current->helper);
+            ++visited;
+        }
+        current = current->next;
+    }
+    return visited;
+}
+
 void LRUCacheShard::SetTailChangeCallback(uint32_t shard_id, const Cache::TailChangeCallback &callback) {
     std::lock_guard<std::mutex> l(mutex_);
     shard_id_ = shard_id;
@@ -1161,6 +1179,18 @@ size_t LRUCache::GetOldestKeysInShard(uint32_t shard_id, size_t count, std::vect
         return 0;
     }
     return GetShard(shard_id).GetOldestKeys(count, out_keys);
+}
+
+size_t LRUCache::ApplyToOldestEntriesInShard(
+    uint32_t shard_id,
+    size_t count,
+    const std::function<
+        void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)> &callback) {
+    const uint32_t num_shards = GetNumShards();
+    if (shard_id >= num_shards || count == 0 || !callback) {
+        return 0;
+    }
+    return GetShard(shard_id).ApplyToOldestEntries(count, callback);
 }
 
 void LRUCache::SetTailChangeCallback(TailChangeCallback callback) {

--- a/kv_cache_manager/common/cache/lru_cache.cc
+++ b/kv_cache_manager/common/cache/lru_cache.cc
@@ -117,7 +117,7 @@ void LRUHandleTable::Resize() {
 
     uint32_t old_length = uint32_t{1} << length_bits_;
     int new_length_bits = length_bits_ + 1;
-    std::unique_ptr<LRUHandle *[]> new_list { new LRUHandle *[size_t{1} << new_length_bits] {} };
+    std::unique_ptr<LRUHandle *[]> new_list{new LRUHandle *[size_t{1} << new_length_bits] {}};
     [[maybe_unused]] uint32_t count = 0;
     for (uint32_t i = 0; i < old_length; i++) {
         LRUHandle *h = list_[i];
@@ -163,6 +163,7 @@ LRUCacheShard::LRUCacheShard(size_t capacity,
     // Make empty circular linked list.
     lru_.next = &lru_;
     lru_.prev = &lru_;
+    oldest_sampling_cursor_ = &lru_;
     lru_low_pri_ = &lru_;
     lru_bottom_pri_ = &lru_;
     SetCapacity(capacity);
@@ -258,6 +259,9 @@ void LRUCacheShard::LRU_Remove(LRUHandle *e) {
     assert(e->next != nullptr);
     assert(e->prev != nullptr);
     bool was_tail = (lru_.next == e);
+    if (oldest_sampling_cursor_ == e) {
+        oldest_sampling_cursor_ = e->next;
+    }
     if (lru_low_pri_ == e) {
         lru_low_pri_ = e->prev;
     }
@@ -849,21 +853,32 @@ size_t LRUCacheShard::GetOldestKeys(size_t count, std::vector<std::string> &out_
     return collected;
 }
 
-size_t LRUCacheShard::ApplyToOldestEntries(
+size_t LRUCacheShard::ApplyToNextOldestEntries(
     size_t count,
     const std::function<
         void(const std::string_view &key, Cache::ObjectPtr value, size_t charge, const Cache::CacheItemHelper *helper)>
         &callback) {
     std::lock_guard<std::mutex> l(mutex_);
     size_t visited = 0;
-    LRUHandle *current = lru_.next;
+    LRUHandle *current = oldest_sampling_cursor_;
+    if (current == &lru_) {
+        current = lru_.next;
+    }
+    LRUHandle *const start = current;
     while (current != &lru_ && visited < count) {
         if (current->InCache()) {
             callback(current->key(), current->value, current->GetCharge(metadata_charge_policy_), current->helper);
             ++visited;
         }
         current = current->next;
+        if (current == &lru_) {
+            current = lru_.next;
+        }
+        if (current == start) {
+            break;
+        }
     }
+    oldest_sampling_cursor_ = current;
     return visited;
 }
 
@@ -1181,7 +1196,7 @@ size_t LRUCache::GetOldestKeysInShard(uint32_t shard_id, size_t count, std::vect
     return GetShard(shard_id).GetOldestKeys(count, out_keys);
 }
 
-size_t LRUCache::ApplyToOldestEntriesInShard(
+size_t LRUCache::ApplyToNextOldestEntriesInShard(
     uint32_t shard_id,
     size_t count,
     const std::function<
@@ -1190,7 +1205,7 @@ size_t LRUCache::ApplyToOldestEntriesInShard(
     if (shard_id >= num_shards || count == 0 || !callback) {
         return 0;
     }
-    return GetShard(shard_id).ApplyToOldestEntries(count, callback);
+    return GetShard(shard_id).ApplyToNextOldestEntries(count, callback);
 }
 
 void LRUCache::SetTailChangeCallback(TailChangeCallback callback) {

--- a/kv_cache_manager/common/cache/lru_cache.h
+++ b/kv_cache_manager/common/cache/lru_cache.h
@@ -386,9 +386,11 @@ public: // other function definitions
     // Returns the number of keys actually collected.
     size_t GetOldestKeys(size_t count, std::vector<std::string> &out_keys);
 
-    // Applies `callback` to up to `count` oldest in-cache entries while
-    // holding the shard mutex. Does not promote or otherwise touch entries.
-    size_t ApplyToOldestEntries(
+    // Applies `callback` to the next `count` entries in an oldest-to-newest
+    // sampling scan while holding the shard mutex. A scan may wrap once but
+    // visits each entry at most once. The independent cursor is advanced
+    // without promoting or otherwise touching entries.
+    size_t ApplyToNextOldestEntries(
         size_t count,
         const std::function<void(
             const std::string_view &key, Cache::ObjectPtr value, size_t charge, const Cache::CacheItemHelper *helper)>
@@ -470,6 +472,11 @@ private:
     // LRU contains items which can be evicted, ie reference only by cache
     LRUHandle lru_;
 
+    // Next entry in the no-touch oldest-to-newest sampling scan. This pointer
+    // is protected by mutex_ and is advanced before a pointed-to LRU entry is
+    // unlinked, so it never outlives an entry.
+    LRUHandle *oldest_sampling_cursor_;
+
     // Pointer to head of low-pri pool in LRU list.
     LRUHandle *lru_low_pri_;
 
@@ -547,7 +554,7 @@ public:
     // Returns up to `count` oldest keys from the specified shard.
     size_t GetOldestKeysInShard(uint32_t shard_id, size_t count, std::vector<std::string> &out_keys) override;
 
-    size_t ApplyToOldestEntriesInShard(
+    size_t ApplyToNextOldestEntriesInShard(
         uint32_t shard_id,
         size_t count,
         const std::function<

--- a/kv_cache_manager/common/cache/lru_cache.h
+++ b/kv_cache_manager/common/cache/lru_cache.h
@@ -386,6 +386,14 @@ public: // other function definitions
     // Returns the number of keys actually collected.
     size_t GetOldestKeys(size_t count, std::vector<std::string> &out_keys);
 
+    // Applies `callback` to up to `count` oldest in-cache entries while
+    // holding the shard mutex. Does not promote or otherwise touch entries.
+    size_t ApplyToOldestEntries(
+        size_t count,
+        const std::function<void(
+            const std::string_view &key, Cache::ObjectPtr value, size_t charge, const Cache::CacheItemHelper *helper)>
+            &callback);
+
     // Set the shard id and tail-change callback for this shard.
     // The callback is invoked inside the shard mutex whenever the LRU tail changes.
     void SetTailChangeCallback(uint32_t shard_id, const Cache::TailChangeCallback &callback);
@@ -538,6 +546,13 @@ public:
 
     // Returns up to `count` oldest keys from the specified shard.
     size_t GetOldestKeysInShard(uint32_t shard_id, size_t count, std::vector<std::string> &out_keys) override;
+
+    size_t ApplyToOldestEntriesInShard(
+        uint32_t shard_id,
+        size_t count,
+        const std::function<
+            void(const std::string_view &key, ObjectPtr value, size_t charge, const CacheItemHelper *helper)> &callback)
+        override;
 
     // Register a callback invoked whenever the LRU tail of any shard changes.
     void SetTailChangeCallback(TailChangeCallback callback) override;

--- a/kv_cache_manager/common/test/lru_cache_test.cc
+++ b/kv_cache_manager/common/test/lru_cache_test.cc
@@ -64,6 +64,15 @@ public:
 
     void Erase(const std::string &key) { cache_->Erase(key, 0 /*hash*/); }
 
+    std::vector<std::string> ScanNextOldest(size_t count) {
+        std::vector<std::string> keys;
+        cache_->ApplyToNextOldestEntries(
+            count, [&keys](const std::string_view &key, Cache::ObjectPtr, size_t, const Cache::CacheItemHelper *) {
+                keys.emplace_back(key);
+            });
+        return keys;
+    }
+
     void ValidateLRUList(std::vector<std::string> keys,
                          size_t num_high_pri_pool_keys = 0,
                          size_t num_low_pri_pool_keys = 0,
@@ -178,6 +187,33 @@ TEST_F(LRUCacheTest, BasicLRU) {
     ValidateLRUList({"y", "e", "z", "d", "u"}, 0, 5);
     Insert("v");
     ValidateLRUList({"e", "z", "d", "u", "v"}, 0, 5);
+}
+
+TEST_F(LRUCacheTest, OldestSamplingCursorAdvancesAndWrapsWithoutChangingLruOrder) {
+    NewCache(5);
+    for (char ch = 'a'; ch <= 'e'; ++ch) {
+        Insert(ch);
+    }
+
+    EXPECT_EQ((std::vector<std::string>{"a", "b"}), ScanNextOldest(2));
+    ValidateLRUList({"a", "b", "c", "d", "e"}, 0, 5);
+    EXPECT_EQ((std::vector<std::string>{"c", "d"}), ScanNextOldest(2));
+    EXPECT_EQ((std::vector<std::string>{"e", "a"}), ScanNextOldest(2));
+    EXPECT_EQ((std::vector<std::string>{"b", "c"}), ScanNextOldest(2));
+    EXPECT_EQ((std::vector<std::string>{"d", "e", "a", "b", "c"}), ScanNextOldest(10));
+    ValidateLRUList({"a", "b", "c", "d", "e"}, 0, 5);
+}
+
+TEST_F(LRUCacheTest, OldestSamplingCursorAdvancesWhenNextEntryIsRemoved) {
+    NewCache(5);
+    for (char ch = 'a'; ch <= 'e'; ++ch) {
+        Insert(ch);
+    }
+
+    EXPECT_EQ((std::vector<std::string>{"a"}), ScanNextOldest(1));
+    Erase("b");
+    EXPECT_EQ((std::vector<std::string>{"c", "d"}), ScanNextOldest(2));
+    ValidateLRUList({"a", "c", "d", "e"}, 0, 4);
 }
 
 TEST_F(LRUCacheTest, BatchLookupAndReleasePreserveReferencesAndLruOrder) {

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -28,7 +28,6 @@
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
-#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/config/cache_config.h"
 #include "kv_cache_manager/config/cache_reclaim_strategy.h"
 #include "kv_cache_manager/config/instance_group.h"
@@ -58,8 +57,7 @@ namespace {
 
 struct KeySamplingResult {
     kv_cache_manager::ErrorCode ec;
-    std::shared_ptr<std::vector<std::int64_t>> keys;
-    std::shared_ptr<std::vector<std::map<std::string, std::string>>> maps;
+    std::shared_ptr<kv_cache_manager::ReclaimCandidateVector> candidates;
 };
 
 } // namespace
@@ -946,22 +944,21 @@ bool CacheReclaimer::ReclaimByLRUImpl(const std::shared_ptr<RequestContext> &req
     const std::string &ins_id = instance_info->instance_id();
     const std::string &ins_gr = instance_info->instance_group_name();
 
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
+    ReclaimCandidateVector candidates;
 
     // 1. get the sampled block keys and the LRU timestamp info from
     // the meta indexer
     const std::int64_t begin_tp_sample = TimestampUtil::GetSteadyTimeUs();
     const bool sampled = use_fair_budget
-                             ? DoKeySamplingWithSize(request_context, instance_info, sampling_size, true, keys, maps)
-                             : DoKeySampling(request_context, instance_info, keys, maps);
+                             ? DoKeySamplingWithSize(request_context, instance_info, sampling_size, true, candidates)
+                             : DoKeySampling(request_context, instance_info, candidates);
     if (!sampled) {
         LOG_WITH_ID(DEBUG, "key sampling failed");
         return false;
     }
     METRICS_(cache_reclaimer, reclaim_lru_sample_duration_us) =
         static_cast<double>(TimestampUtil::GetSteadyTimeUs() - begin_tp_sample);
-    LOG_WITH_ID(DEBUG, "[%zu] key(s) sampled", keys.size());
+    LOG_WITH_ID(DEBUG, "[%zu] reclaim candidate(s) sampled", candidates.size());
 
     // init the deleting request with content to be filled later
     // here the cache location form of deleting request is used to
@@ -976,8 +973,8 @@ bool CacheReclaimer::ReclaimByLRUImpl(const std::shared_ptr<RequestContext> &req
     const bool batch_made =
         use_fair_budget
             ? MakeBatchByLRUWithSize(
-                  request_context.get(), instance_info, keys, maps, batching_size, request.block_keys, lru_age_stats)
-            : MakeBatchByLRU(request_context.get(), instance_info, keys, maps, request.block_keys, lru_age_stats);
+                  request_context.get(), instance_info, candidates, batching_size, request.block_keys, lru_age_stats)
+            : MakeBatchByLRU(request_context.get(), instance_info, candidates, request.block_keys, lru_age_stats);
     if (!batch_made) {
         LOG_WITH_ID(DEBUG, "make batch failed");
         return false;
@@ -1130,17 +1127,15 @@ void CacheReclaimer::ReclaimCron() noexcept {
 
 bool CacheReclaimer::DoKeySampling(const std::shared_ptr<RequestContext> &request_context,
                                    const std::shared_ptr<const InstanceInfo> &instance_info,
-                                   std::vector<std::int64_t> &out_keys,
-                                   std::vector<std::map<std::string, std::string>> &out_maps) noexcept {
-    return DoKeySamplingWithSize(request_context, instance_info, 0, false, out_keys, out_maps);
+                                   ReclaimCandidateVector &out_candidates) noexcept {
+    return DoKeySamplingWithSize(request_context, instance_info, 0, false, out_candidates);
 }
 
 bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext> &request_context,
                                            const std::shared_ptr<const InstanceInfo> &instance_info,
                                            const std::size_t total_sampling_size,
                                            const bool bounded_waves,
-                                           std::vector<std::int64_t> &out_keys,
-                                           std::vector<std::map<std::string, std::string>> &out_maps) noexcept {
+                                           ReclaimCandidateVector &out_candidates) noexcept {
     const std::string &ins_id = instance_info->instance_id();
     const std::string &ins_gr = instance_info->instance_group_name();
 
@@ -1162,58 +1157,41 @@ bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext>
 
     auto cancelled = std::make_shared<std::atomic<bool>>(false);
     auto sample = [this, request_context, ins_id, ins_gr, meta_indexer, cancelled, bounded_waves](
-                      std::size_t sampling_sz,
-                      std::vector<std::int64_t> &keys,
-                      std::vector<std::map<std::string, std::string>> &maps) -> ErrorCode {
+                      const std::size_t sampling_sz, ReclaimCandidateVector &candidates) -> ErrorCode {
         if (cancelled->load(std::memory_order_relaxed) || (bounded_waves && (!IsRunning() || IsPaused()))) {
             return ErrorCode::EC_ERROR;
         }
-        if (const auto ec = meta_indexer->SampleReclaimKeys(request_context.get(), sampling_sz, keys);
+        if (const auto ec = meta_indexer->SampleReclaimCandidates(request_context.get(), sampling_sz, candidates);
             ec != ErrorCode::EC_OK) {
-            LOG_WITH_ID(WARN, "random sample failed, error code: [%d]", static_cast<std::int32_t>(ec));
+            LOG_WITH_ID(WARN, "reclaim candidate sampling failed, error code: [%d]", static_cast<std::int32_t>(ec));
             return ec;
         }
-        if (keys.empty()) {
-            LOG_WITH_ID(DEBUG, "random sample got empty keys");
+        if (candidates.empty()) {
+            LOG_WITH_ID(DEBUG, "reclaim candidate sampling got no candidates");
             return ErrorCode::EC_NOENT;
         }
-        if (keys.size() != sampling_sz) {
-            LOG_WITH_ID(DEBUG, "random sample key size mismatch, expect: [%zu], got: [%zu]", sampling_sz, keys.size());
+        if (candidates.size() != sampling_sz) {
+            LOG_WITH_ID(DEBUG,
+                        "reclaim candidate sample size mismatch, expect: [%zu], got: [%zu]",
+                        sampling_sz,
+                        candidates.size());
         }
-
         if (cancelled->load(std::memory_order_relaxed) || (bounded_waves && (!IsRunning() || IsPaused()))) {
             return ErrorCode::EC_ERROR;
-        }
-        if (const auto res = meta_indexer->GetProperties(request_context.get(), keys, {PROPERTY_LRU_TIME}, maps);
-            res.ec != ErrorCode::EC_OK) {
-            LOG_WITH_ID(WARN,
-                        "get properties failed, error code: [%d], proceed with empty lru_time",
-                        static_cast<std::int32_t>(res.ec));
-            maps.clear();
-            maps.resize(keys.size());
-        } else if (keys.size() != maps.size()) {
-            LOG_WITH_ID(
-                WARN, "num of sampled keys [%zu] and property maps [%zu] do not match", keys.size(), maps.size());
-            maps.clear();
-            maps.resize(keys.size());
         }
         return ErrorCode::EC_OK;
     };
 
-    out_keys.clear();
-    out_keys.reserve(total_sampling_sz);
-    out_maps.clear();
-    out_maps.reserve(total_sampling_sz);
+    out_candidates.clear();
+    out_candidates.reserve(total_sampling_sz);
     const std::size_t worker_sz = (total_sampling_sz + sampling_sz_per_task - 1) / sampling_sz_per_task;
     if (worker_sz == 1 && !bounded_waves) {
-        return sample(total_sampling_sz, out_keys, out_maps) == ErrorCode::EC_OK;
+        return sample(total_sampling_sz, out_candidates) == ErrorCode::EC_OK;
     }
 
     if (bounded_waves) {
-        std::vector<std::int64_t> sampled_keys;
-        sampled_keys.reserve(total_sampling_sz);
-        std::vector<std::map<std::string, std::string>> sampled_maps;
-        sampled_maps.reserve(total_sampling_sz);
+        ReclaimCandidateVector sampled_candidates;
+        sampled_candidates.reserve(total_sampling_sz);
 
         std::size_t sampling_sz_todo = total_sampling_sz;
         const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(future_timeout_ms_.load());
@@ -1238,17 +1216,14 @@ bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext>
                 futures.emplace_back(promise->get_future());
                 in_flight_sampling_tasks_.fetch_add(1);
                 SubmitTask([this, sample, sampling_sz, promise]() {
-                    std::vector<std::int64_t> keys;
-                    std::vector<std::map<std::string, std::string>> maps;
-                    const auto ec = sample(sampling_sz, keys, maps);
+                    ReclaimCandidateVector candidates;
+                    const auto ec = sample(sampling_sz, candidates);
                     in_flight_sampling_tasks_.fetch_sub(1);
                     if (ec != ErrorCode::EC_OK) {
-                        promise->set_value({ec, nullptr, nullptr});
+                        promise->set_value({ec, nullptr});
                     } else {
                         promise->set_value(
-                            {ErrorCode::EC_OK,
-                             std::make_shared<std::vector<std::int64_t>>(std::move(keys)),
-                             std::make_shared<std::vector<std::map<std::string, std::string>>>(std::move(maps))});
+                            {ErrorCode::EC_OK, std::make_shared<ReclaimCandidateVector>(std::move(candidates))});
                     }
                 });
                 sampling_sz_todo -= sampling_sz;
@@ -1275,23 +1250,18 @@ bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext>
                     cancelled->store(true, std::memory_order_relaxed);
                     break;
                 }
-                sampled_keys.insert(sampled_keys.end(),
-                                    std::make_move_iterator(key_sampling_result.keys->begin()),
-                                    std::make_move_iterator(key_sampling_result.keys->end()));
-                sampled_maps.insert(sampled_maps.end(),
-                                    std::make_move_iterator(key_sampling_result.maps->begin()),
-                                    std::make_move_iterator(key_sampling_result.maps->end()));
+                sampled_candidates.insert(sampled_candidates.end(),
+                                          std::make_move_iterator(key_sampling_result.candidates->begin()),
+                                          std::make_move_iterator(key_sampling_result.candidates->end()));
             }
             if (!wave_succeeded) {
                 cancelled->store(true, std::memory_order_relaxed);
-                out_keys.clear();
-                out_maps.clear();
+                out_candidates.clear();
                 return false;
             }
         }
 
-        out_keys = std::move(sampled_keys);
-        out_maps = std::move(sampled_maps);
+        out_candidates = std::move(sampled_candidates);
         return true;
     }
 
@@ -1312,17 +1282,13 @@ bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext>
         std::size_t sampling_sz = (i == worker_sz - 1) ? sampling_sz_todo : sampling_sz_per_task;
         in_flight_sampling_tasks_.fetch_add(1);
         SubmitTask([this, sample, sampling_sz, promise]() {
-            std::vector<std::int64_t> keys;
-            std::vector<std::map<std::string, std::string>> maps;
-            const auto ec = sample(sampling_sz, keys, maps);
+            ReclaimCandidateVector candidates;
+            const auto ec = sample(sampling_sz, candidates);
             in_flight_sampling_tasks_.fetch_sub(1);
             if (ec != ErrorCode::EC_OK) {
-                promise->set_value({ec, nullptr, nullptr});
+                promise->set_value({ec, nullptr});
             } else {
-                promise->set_value(
-                    {ErrorCode::EC_OK,
-                     std::make_shared<std::vector<std::int64_t>>(std::move(keys)),
-                     std::make_shared<std::vector<std::map<std::string, std::string>>>(std::move(maps))});
+                promise->set_value({ErrorCode::EC_OK, std::make_shared<ReclaimCandidateVector>(std::move(candidates))});
             }
         });
         sampling_sz_todo -= sampling_sz;
@@ -1347,12 +1313,9 @@ bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext>
             if (auto key_sampling_res = fut.get(); key_sampling_res.ec != ErrorCode::EC_OK) {
                 result = false;
             } else {
-                out_keys.insert(out_keys.end(),
-                                std::make_move_iterator(key_sampling_res.keys->begin()),
-                                std::make_move_iterator(key_sampling_res.keys->end()));
-                out_maps.insert(out_maps.end(),
-                                std::make_move_iterator(key_sampling_res.maps->begin()),
-                                std::make_move_iterator(key_sampling_res.maps->end()));
+                out_candidates.insert(out_candidates.end(),
+                                      std::make_move_iterator(key_sampling_res.candidates->begin()),
+                                      std::make_move_iterator(key_sampling_res.candidates->end()));
             }
         } else {
             result = false;
@@ -1368,19 +1331,17 @@ bool CacheReclaimer::DoKeySamplingWithSize(const std::shared_ptr<RequestContext>
 
 bool CacheReclaimer::MakeBatchByLRU(const RequestContext *request_context,
                                     const std::shared_ptr<const InstanceInfo> &instance_info,
-                                    const std::vector<std::int64_t> &sampled_keys,
-                                    const std::vector<std::map<std::string, std::string>> &property_maps,
+                                    const ReclaimCandidateVector &candidates,
                                     std::vector<std::int64_t> &out_batch,
                                     AgeStats &out_lru_age_stats) const noexcept {
     const std::size_t batching_size = batching_size_.load();
     return MakeBatchByLRUWithSize(
-        request_context, instance_info, sampled_keys, property_maps, batching_size, out_batch, out_lru_age_stats);
+        request_context, instance_info, candidates, batching_size, out_batch, out_lru_age_stats);
 }
 
 bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_context,
                                             const std::shared_ptr<const InstanceInfo> &instance_info,
-                                            const std::vector<std::int64_t> &sampled_keys,
-                                            const std::vector<std::map<std::string, std::string>> &property_maps,
+                                            const ReclaimCandidateVector &candidates,
                                             const std::size_t batching_size,
                                             std::vector<std::int64_t> &out_batch,
                                             AgeStats &out_lru_age_stats) const noexcept {
@@ -1390,39 +1351,16 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
         return true;
     }
 
-    // invariant:
-    // the 2 vectors' size must be guaranteed to be equal, and the
-    // content must be guaranteed to be correlative when iterated by
-    // index
-    assert(sampled_keys.size() == property_maps.size());
-
     const std::string &ins_id = instance_info->instance_id();
     const std::string &ins_gr = instance_info->instance_group_name();
 
     std::vector<std::pair<std::int64_t, std::int64_t>> key_tp_vec; // vector of {key, last_access_time}
-    key_tp_vec.reserve(sampled_keys.size());
-
-    for (std::size_t i = 0; i != sampled_keys.size(); ++i) {
-        const auto &k = sampled_keys[i];
-        const auto &m = property_maps[i];
-        int64_t lru_ts = 0;
-        // if PROPERTY_LRU_TIME is not found, use 0 as the timestamp, the reclaim strategy will degrade
-        if (const auto it = m.find(PROPERTY_LRU_TIME); it != m.end()) {
-            // the PROPERTY_LRU_TIME value is represented as an int64_t type
-            // timepoint string; parse them into integers
-            const auto &lru_ts_str = it->second;
-            if (!StringUtil::StrToInt64(lru_ts_str.c_str(), lru_ts)) {
-                INTERVAL_LOG_WITH_ID(
-                    WARN, 10000, "lru_time str [%s] to int64 failed, use 0 instead", lru_ts_str.c_str());
-                lru_ts = 0;
-            }
-        } else {
-            INTERVAL_LOG_WITH_ID(WARN, 10000, "PROPERTY_LRU_TIME not found, use 0 instead");
-        }
-        key_tp_vec.emplace_back(k, lru_ts);
+    key_tp_vec.reserve(candidates.size());
+    for (const auto &candidate : candidates) {
+        key_tp_vec.emplace_back(candidate.key, candidate.last_access_time_us);
     }
 
-    if (sampled_keys.size() > batching_size) {
+    if (candidates.size() > batching_size) {
         std::sort(key_tp_vec.begin(),
                   key_tp_vec.end(),
                   [](const std::pair<std::int64_t, std::int64_t> &a,
@@ -1431,7 +1369,7 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
 
     // constitute the batch to be submitted for deleting
     // the first N timestamp would be picked out
-    const std::size_t effective_batch_size = std::min(batching_size, sampled_keys.size());
+    const std::size_t effective_batch_size = std::min(batching_size, candidates.size());
     std::unordered_set<std::int64_t> deduped_batch;
     const int64_t now_us = TimestampUtil::GetCurrentTimeUs();
     int64_t age_sum = 0;
@@ -1464,23 +1402,23 @@ bool CacheReclaimer::MakeBatchByLRUWithSize(const RequestContext *request_contex
     }
 
     if (deduped_batch.size() < batching_size) {
-        if (deduped_batch.size() != sampled_keys.size()) {
-            // sampled_keys contains duplicated keys, log the event
+        if (deduped_batch.size() != candidates.size()) {
+            // candidates contains duplicated keys, log the event
             LOG_WITH_ID(DEBUG,
                         "shortened batch size (likely duplicated keys sampled), final batch size: [%zu], "
-                        "sampled keys size: [%zu], intended batching size: [%zu]",
+                        "candidate size: [%zu], intended batching size: [%zu]",
                         deduped_batch.size(),
-                        sampled_keys.size(),
+                        candidates.size(),
                         batching_size);
         } else {
-            // the batch size is equal to the size of sampled keys;
+            // the batch size is equal to the number of candidates;
             // * possibility 1: not enough keys sampled
             // * possibility 2: sampling_size_ < batching_size_
             LOG_WITH_ID(DEBUG,
                         "shortened batch size, final batch size: [%zu], "
-                        "sampled keys size: [%zu], intended batching size: [%zu]",
+                        "candidate size: [%zu], intended batching size: [%zu]",
                         deduped_batch.size(),
-                        sampled_keys.size(),
+                        candidates.size(),
                         batching_size);
         }
     }
@@ -1919,13 +1857,12 @@ bool CacheReclaimer::BuildMigrationCandidateBatch(const std::shared_ptr<RequestC
     }
 
     // 采样 + LRU 取最冷 batch（复用回收侧的采样与排序）。
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
-    if (!DoKeySampling(request_context, instance_info, keys, maps)) {
+    ReclaimCandidateVector candidates;
+    if (!DoKeySampling(request_context, instance_info, candidates)) {
         return false;
     }
     AgeStats lru_age_stats;
-    if (!MakeBatchByLRU(request_context.get(), instance_info, keys, maps, out_batch, lru_age_stats)) {
+    if (!MakeBatchByLRU(request_context.get(), instance_info, candidates, out_batch, lru_age_stats)) {
         return false;
     }
     return true;

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -23,6 +23,7 @@
 #include "kv_cache_manager/common/error_code.h"
 #include "kv_cache_manager/data_storage/storage_config.h"
 #include "kv_cache_manager/manager/schedule_plan_executor.h"
+#include "kv_cache_manager/meta/types.h"
 #include "kv_cache_manager/metrics/metrics_registry.h"
 
 namespace kv_cache_manager {
@@ -650,27 +651,23 @@ private:
     // below are helper routines for internal usage
     bool DoKeySampling(const std::shared_ptr<RequestContext> &request_context,
                        const std::shared_ptr<const InstanceInfo> &instance_info,
-                       std::vector<std::int64_t> &out_keys,
-                       std::vector<std::map<std::string, std::string>> &out_maps) noexcept;
+                       ReclaimCandidateVector &out_candidates) noexcept;
 
     bool DoKeySamplingWithSize(const std::shared_ptr<RequestContext> &request_context,
                                const std::shared_ptr<const InstanceInfo> &instance_info,
                                std::size_t total_sampling_size,
                                bool bounded_waves,
-                               std::vector<std::int64_t> &out_keys,
-                               std::vector<std::map<std::string, std::string>> &out_maps) noexcept;
+                               ReclaimCandidateVector &out_candidates) noexcept;
 
     bool MakeBatchByLRU(const RequestContext *request_context,
                         const std::shared_ptr<const InstanceInfo> &instance_info,
-                        const std::vector<std::int64_t> &sampled_keys,
-                        const std::vector<std::map<std::string, std::string>> &property_maps,
+                        const ReclaimCandidateVector &candidates,
                         std::vector<std::int64_t> &out_batch,
                         AgeStats &out_lru_age_stats) const noexcept;
 
     bool MakeBatchByLRUWithSize(const RequestContext *request_context,
                                 const std::shared_ptr<const InstanceInfo> &instance_info,
-                                const std::vector<std::int64_t> &sampled_keys,
-                                const std::vector<std::map<std::string, std::string>> &property_maps,
+                                const ReclaimCandidateVector &candidates,
                                 std::size_t batching_size,
                                 std::vector<std::int64_t> &out_batch,
                                 AgeStats &out_lru_age_stats) const noexcept;

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/config/cache_config.h"
 #include "kv_cache_manager/config/cache_reclaim_strategy.h"
@@ -316,12 +317,14 @@ std::shared_ptr<MetaIndexer> MetaIndexerManager_GetMetaIndexer_stub(void *obj, c
 std::chrono::milliseconds mi_getprop_delay{0};
 ErrorCode get_result;
 PropertyMapVector get_out_properties;
+std::atomic<int> mi_getprop_call_count{0};
 
 MetaIndexer::Result MetaIndexer_GetProperties_stub(void *obj,
                                                    RequestContext *rc,
                                                    const KeyVector &k,
                                                    const std::vector<std::string> &p,
                                                    PropertyMapVector &out_properties) noexcept {
+    ++mi_getprop_call_count;
     if (get_result == ErrorCode::EC_OK) {
         if (k.size() == get_out_properties.size()) {
             out_properties = get_out_properties;
@@ -362,7 +365,7 @@ MetaIndexer_RandomSample_stub(void *obj, RequestContext *rc, const std::size_t c
     return random_sample_result;
 }
 
-/* ---------------- MetaIndexer_SampleReclaimKeys_stub ---------------- */
+/* ---------------- MetaIndexer_SampleReclaimCandidates_stub ---------------- */
 
 std::chrono::milliseconds mi_sample_reclaim_delay{0};
 ErrorCode sample_reclaim_result;
@@ -374,8 +377,10 @@ int sample_reclaim_call_counter;
 std::mutex sample_reclaim_requests_mutex;
 std::vector<std::pair<std::string, std::int64_t>> sample_reclaim_requests;
 
-ErrorCode
-MetaIndexer_SampleReclaimKeys_stub(void *obj, RequestContext *rc, const std::int64_t c, KeyVector &out_keys) noexcept {
+ErrorCode MetaIndexer_SampleReclaimCandidates_stub(void *obj,
+                                                   RequestContext *rc,
+                                                   const std::int64_t c,
+                                                   ReclaimCandidateVector &out_candidates) noexcept {
     ++sample_reclaim_call_counter;
     ErrorCode result = sample_reclaim_result;
     std::chrono::milliseconds delay = mi_sample_reclaim_delay;
@@ -392,16 +397,32 @@ MetaIndexer_SampleReclaimKeys_stub(void *obj, RequestContext *rc, const std::int
         }
     }
     if (result == ErrorCode::EC_OK) {
+        KeyVector sampled_keys;
         if (c == static_cast<std::int64_t>(sample_reclaim_keys.size())) {
-            out_keys = sample_reclaim_keys;
+            sampled_keys = sample_reclaim_keys;
         } else if (c == 11) {
             // special case
-            out_keys = sample_reclaim_keys;
+            sampled_keys = sample_reclaim_keys;
         } else {
-            out_keys = KeyVector(c);
+            sampled_keys = KeyVector(c);
+        }
+        out_candidates.clear();
+        out_candidates.reserve(sampled_keys.size());
+        const bool properties_available =
+            get_result == ErrorCode::EC_OK && sampled_keys.size() == get_out_properties.size();
+        for (size_t i = 0; i < sampled_keys.size(); ++i) {
+            int64_t last_access_time_us = 0;
+            if (properties_available) {
+                const auto it = get_out_properties[i].find(PROPERTY_LRU_TIME);
+                if (it != get_out_properties[i].end()) {
+                    StringUtil::StrToInt64(it->second.c_str(), last_access_time_us);
+                }
+            }
+            out_candidates.push_back({sampled_keys[i], last_access_time_us});
         }
     }
     std::this_thread::sleep_for(delay);
+    std::this_thread::sleep_for(mi_getprop_delay);
     return result;
 }
 
@@ -467,7 +488,7 @@ public:
         stub_.set(ADDR(MetaIndexerManager, GetMetaIndexer), MetaIndexerManager_GetMetaIndexer_stub);
         stub_.set(ADDR(MetaIndexer, GetProperties), MetaIndexer_GetProperties_stub);
         stub_.set(ADDR(MetaIndexer, RandomSample), MetaIndexer_RandomSample_stub);
-        stub_.set(ADDR(MetaIndexer, SampleReclaimKeys), MetaIndexer_SampleReclaimKeys_stub);
+        stub_.set(ADDR(MetaIndexer, SampleReclaimCandidates), MetaIndexer_SampleReclaimCandidates_stub);
         stub_.set(ADDR(MetaIndexer, GetKeyCount), MetaIndexer_GetKeyCount_stub);
         stub_.set(ADDR(MetaIndexer, GetMaxKeyCount), MetaIndexer_GetMaxKeyCount_stub);
         stub_.set(ADDR(MetaIndexer, PersistMetaData), MetaIndexer_PersistMetaData_stub);
@@ -508,6 +529,7 @@ public:
         spe_submit_accepted_by_instance.clear();
         spe_submit_accepted_callback = {};
         get_result = ErrorCode::EC_OK;
+        mi_getprop_call_count.store(0);
         random_sample_result = ErrorCode::EC_OK;
         sample_reclaim_result = ErrorCode::EC_OK;
         batch_get_loc_result = ErrorCode::EC_OK;
@@ -668,7 +690,7 @@ public:
         stub_.reset(ADDR(MetaIndexerManager, GetMetaIndexer));
         stub_.reset(ADDR(MetaIndexer, GetProperties));
         stub_.reset(ADDR(MetaIndexer, RandomSample));
-        stub_.reset(ADDR(MetaIndexer, SampleReclaimKeys));
+        stub_.reset(ADDR(MetaIndexer, SampleReclaimCandidates));
         stub_.reset(ADDR(MetaIndexer, GetKeyCount));
         stub_.reset(ADDR(MetaIndexer, GetMaxKeyCount));
         stub_.reset(ADDR(MetaIndexer, PersistMetaData));
@@ -830,7 +852,7 @@ TEST_F(CacheReclaimerTest, TestStartStop) {
     stub_.reset(ADDR(MetaIndexerManager, GetMetaIndexer));
     stub_.reset(ADDR(MetaIndexer, GetProperties));
     stub_.reset(ADDR(MetaIndexer, RandomSample));
-    stub_.reset(ADDR(MetaIndexer, SampleReclaimKeys));
+    stub_.reset(ADDR(MetaIndexer, SampleReclaimCandidates));
     stub_.reset(ADDR(MetaIndexer, GetKeyCount));
     stub_.reset(ADDR(MetaIndexer, GetMaxKeyCount));
     stub_.reset(ADDR(MetaIndexer, PersistMetaData));
@@ -2317,40 +2339,24 @@ TEST_F(CacheReclaimerTest, TestReclaimByLRU04) {
     ASSERT_TRUE(VecContains(req.block_keys, 9)); // time point -> 2
 }
 
-TEST_F(CacheReclaimerTest, TestMetaIndexerGetPropertiesFailure) {
-    // set up test data
+TEST_F(CacheReclaimerTest, TestCandidateTimestampFailureDegradesToZeroWithoutGetPropertiesCall) {
     sample_reclaim_keys = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-
-    // configure the GetProperties stub to return an error
     get_result = ErrorCode::EC_ERROR;
+    cache_reclaimer_->sampling_size_.store(sample_reclaim_keys.size());
+    cache_reclaimer_->sampling_size_per_task_.store(sample_reclaim_keys.size());
 
-    // update the trigger strategy to trigger the reclaiming
-
-    // use instance 0 from setup()
-    // construct instance 1
-    const auto ins_info = InstanceInfoFactory();
-    ins_info->set_instance_id("test_instance_id_2");
-    instance_infos.emplace_back(ins_info);
-
-    instance_groups.clear();
-    const auto ins_group = InstanceGroupFactory();
-    ins_group->quota_.set_capacity(2048);
-    instance_groups.emplace_back(ins_group);
-
-    batch_get_loc_out_maps = std::vector<CacheLocationMap>(sample_reclaim_keys.size(), CacheLocationMap{});
-    ASSERT_EQ(ErrorCode::EC_OK, cache_reclaimer_->Start());
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
-    ASSERT_TRUE(cache_reclaimer_->IsRunning()); // the worker thread should still be running
-
-    cache_reclaimer_->Stop();
-
-    // no deletion requests should be submitted when GetProperties fails
-    ASSERT_TRUE(HasNoSubmittedDelRequests());
+    ReclaimCandidateVector candidates;
+    ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+    ASSERT_EQ(sample_reclaim_keys.size(), candidates.size());
+    for (size_t i = 0; i < candidates.size(); ++i) {
+        EXPECT_EQ(sample_reclaim_keys[i], candidates[i].key);
+        EXPECT_EQ(0, candidates[i].last_access_time_us);
+    }
+    EXPECT_EQ(0, mi_getprop_call_count.load());
 }
 
-TEST_F(CacheReclaimerTest, TestMetaIndexerSampleReclaimFailure) {
-    // configure the SampleReclaim stub to return an error
+TEST_F(CacheReclaimerTest, TestMetaIndexerSampleReclaimCandidatesFailure) {
+    // configure the SampleReclaimCandidates stub to return an error
     sample_reclaim_result = ErrorCode::EC_ERROR;
 
     // update the trigger strategy to trigger the reclaiming
@@ -4901,42 +4907,39 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
         cache_reclaimer_->sampling_size_.store(sample_reclaim_keys.size());
         cache_reclaimer_->sampling_size_per_task_.store(100);
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(sample_reclaim_keys.size(), keys.size());
-        ASSERT_EQ(get_out_properties.size(), maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(sample_reclaim_keys.size(), candidates.size());
+        for (size_t i = 0; i < candidates.size(); ++i) {
+            EXPECT_EQ(sample_reclaim_keys[i], candidates[i].key);
+            EXPECT_EQ(static_cast<int64_t>(i), candidates[i].last_access_time_us);
+        }
     }
 
     {
         cache_reclaimer_->sampling_size_.store(0);
         cache_reclaimer_->sampling_size_per_task_.store(100);
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
+        ReclaimCandidateVector candidates;
+        ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
     }
 
     {
         cache_reclaimer_->sampling_size_.store(sample_reclaim_keys.size());
         cache_reclaimer_->sampling_size_per_task_.store(0); // 0 means single thread key sampling
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(sample_reclaim_keys.size(), keys.size());
-        ASSERT_EQ(get_out_properties.size(), maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(sample_reclaim_keys.size(), candidates.size());
     }
     {
         // sampling_size <= sampling_size_per_task means single thread key sampling
         cache_reclaimer_->sampling_size_.store(1000);
         cache_reclaimer_->sampling_size_per_task_.store(1000);
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(1000, keys.size());
-        ASSERT_EQ(1000, maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(1000, candidates.size());
     }
 
     {
@@ -4945,11 +4948,9 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
         cache_reclaimer_->sampling_size_.store(1000);
         cache_reclaimer_->sampling_size_per_task_.store(100);
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(1000, keys.size());
-        ASSERT_EQ(1000, maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(1000, candidates.size());
         const auto requests = SampleReclaimRequestsSnapshot();
         ASSERT_EQ(10, requests.size());
         for (const auto &request : requests) {
@@ -4961,33 +4962,27 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
         cache_reclaimer_->sampling_size_.store(999);
         cache_reclaimer_->sampling_size_per_task_.store(99);
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(999, keys.size());
-        ASSERT_EQ(999, maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(999, candidates.size());
     }
 
     {
         cache_reclaimer_->sampling_size_.store(1001);
         cache_reclaimer_->sampling_size_per_task_.store(100);
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(1001, keys.size());
-        ASSERT_EQ(1001, maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(1001, candidates.size());
     }
 
     {
         cache_reclaimer_->sampling_size_.store(1);
         cache_reclaimer_->sampling_size_per_task_.store(999);
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(1, keys.size());
-        ASSERT_EQ(1, maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(1, candidates.size());
     }
 
     {
@@ -4999,11 +4994,9 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
         // the specially crafted size 11 would cause the mock func return 10 sampled keys
         // 10 * 9 + 1 = 91
 
-        std::vector<std::int64_t> keys;
-        std::vector<std::map<std::string, std::string>> maps;
-        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-        ASSERT_EQ(91, keys.size());
-        ASSERT_EQ(91, maps.size());
+        ReclaimCandidateVector candidates;
+        ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+        ASSERT_EQ(91, candidates.size());
     }
 }
 
@@ -5015,10 +5008,9 @@ TEST_F(CacheReclaimerTest, TestFairKeySamplingSubmitsBoundedWaves) {
     get_out_properties = {{{PROPERTY_LRU_TIME, "1"}}};
     mi_sample_reclaim_delay = std::chrono::milliseconds(300);
 
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
+    ReclaimCandidateVector candidates;
     auto sampling_future = std::async(std::launch::async, [&] {
-        return cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 5, true, keys, maps);
+        return cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 5, true, candidates);
     });
 
     // Before the first tasks can finish, only one wave (two tasks) may
@@ -5031,8 +5023,7 @@ TEST_F(CacheReclaimerTest, TestFairKeySamplingSubmitsBoundedWaves) {
         },
         std::chrono::milliseconds(200)));
     EXPECT_TRUE(sampling_future.get());
-    EXPECT_EQ(5, keys.size());
-    EXPECT_EQ(5, maps.size());
+    EXPECT_EQ(5, candidates.size());
 }
 
 TEST_F(CacheReclaimerTest, TestFairKeySamplingFailureClearsPartialWaveResults) {
@@ -5047,12 +5038,10 @@ TEST_F(CacheReclaimerTest, TestFairKeySamplingFailureClearsPartialWaveResults) {
         ErrorCode::EC_OK,
     };
 
-    std::vector<std::int64_t> keys = {999};
-    std::vector<std::map<std::string, std::string>> maps = {{{"stale", "value"}}};
+    ReclaimCandidateVector candidates = {{999, 999}};
     EXPECT_FALSE(
-        cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 5, true, keys, maps));
-    EXPECT_TRUE(keys.empty());
-    EXPECT_TRUE(maps.empty());
+        cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 5, true, candidates));
+    EXPECT_TRUE(candidates.empty());
     EXPECT_EQ(4, SampleReclaimRequestsSnapshot().size());
     EXPECT_EQ(0, cache_reclaimer_->in_flight_sampling_tasks_.load());
 }
@@ -5068,23 +5057,21 @@ TEST_F(CacheReclaimerTest, TestFairKeySamplingTimeoutClearsPartialWaveResults) {
         std::chrono::milliseconds{500},
     };
 
-    std::vector<std::int64_t> keys = {999};
-    std::vector<std::map<std::string, std::string>> maps = {{{"stale", "value"}}};
+    ReclaimCandidateVector candidates = {{999, 999}};
     const auto begin = std::chrono::steady_clock::now();
     EXPECT_FALSE(
-        cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 2, true, keys, maps));
+        cache_reclaimer_->DoKeySamplingWithSize(request_context_, instance_infos.front(), 2, true, candidates));
     const auto elapsed = std::chrono::steady_clock::now() - begin;
     EXPECT_LT(elapsed, std::chrono::milliseconds{300});
-    EXPECT_TRUE(keys.empty());
-    EXPECT_TRUE(maps.empty());
+    EXPECT_TRUE(candidates.empty());
     EXPECT_EQ(2, SampleReclaimRequestsSnapshot().size());
 
     ASSERT_TRUE(WaitUntil([this] { return cache_reclaimer_->in_flight_sampling_tasks_.load() == 0; },
                           std::chrono::milliseconds{1000}));
 }
 
-TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_SampleReclaimKeysHangs) {
-    // when SampleReclaimKeys blocks longer than the future timeout,
+TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_SampleReclaimCandidatesHangs) {
+    // when SampleReclaimCandidates blocks longer than the future timeout,
     // DoKeySampling should return false instead of blocking forever
     sample_reclaim_keys = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     get_out_properties = {
@@ -5108,11 +5095,10 @@ TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_SampleReclaimKeysHangs
     cache_reclaimer_->sampling_size_.store(10);
     cache_reclaimer_->sampling_size_per_task_.store(5);
 
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
+    ReclaimCandidateVector candidates;
 
     const auto t0 = std::chrono::steady_clock::now();
-    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
+    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
     const auto elapsed = std::chrono::steady_clock::now() - t0;
 
     // should return within the timeout budget (~50ms), not wait for the full 500ms task
@@ -5127,8 +5113,9 @@ TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_SampleReclaimKeysHangs
     }
 }
 
-TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_GetPropertiesHangs) {
-    // when GetProperties blocks longer than the future timeout,
+TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_CandidateTimestampReadHangs) {
+    // The backend's timestamp read remains covered by the combined candidate
+    // call and must not let DoKeySampling block past its future timeout.
     // DoKeySampling should return false instead of blocking forever
     sample_reclaim_keys = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     get_out_properties = {
@@ -5144,18 +5131,17 @@ TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_GetPropertiesHangs) {
         {{PROPERTY_LRU_TIME, "9"}},
     };
 
-    // set a very short future timeout (50ms) and a long GetProperties delay (500ms)
+    // set a very short future timeout (50ms) and a long timestamp read delay (500ms)
     cache_reclaimer_->future_timeout_ms_.store(50);
     mi_getprop_delay = std::chrono::milliseconds{500};
 
-    // use multi-thread path with sampling_size > batching_size to trigger GetProperties
+    // use multi-thread path so the candidate calls are bounded by futures
     cache_reclaimer_->sampling_size_.store(10);
     cache_reclaimer_->sampling_size_per_task_.store(5);
     cache_reclaimer_->batching_size_.store(1);
 
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
-    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
+    ReclaimCandidateVector candidates;
+    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
 
     // wait for background tasks to finish naturally
     while (cache_reclaimer_->in_flight_sampling_tasks_.load() > 0) {
@@ -5189,10 +5175,9 @@ TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_NoTimeoutOnFastTasks) 
     cache_reclaimer_->sampling_size_.store(10);
     cache_reclaimer_->sampling_size_per_task_.store(5);
 
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
-    ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
-    ASSERT_EQ(10u, keys.size());
+    ReclaimCandidateVector candidates;
+    ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
+    ASSERT_EQ(10u, candidates.size());
 
     // all tasks completed, in-flight should be zero
     ASSERT_EQ(0u, cache_reclaimer_->in_flight_sampling_tasks_.load());
@@ -5223,11 +5208,10 @@ TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_DeadlineBoundsAllFutur
     cache_reclaimer_->sampling_size_.store(10);
     cache_reclaimer_->sampling_size_per_task_.store(2); // 5 tasks
 
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
+    ReclaimCandidateVector candidates;
 
     const auto t0 = std::chrono::steady_clock::now();
-    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
+    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
     const auto elapsed = std::chrono::steady_clock::now() - t0;
 
     // should be bounded by ~100ms deadline, not 500ms (5 tasks * 100ms)
@@ -5264,12 +5248,11 @@ TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_WorkerSaturationGuard)
     cache_reclaimer_->sampling_size_.store(10);
     cache_reclaimer_->sampling_size_per_task_.store(5);
 
-    std::vector<std::int64_t> keys;
-    std::vector<std::map<std::string, std::string>> maps;
+    ReclaimCandidateVector candidates;
 
     // should immediately return false without submitting new work
     const auto t0 = std::chrono::steady_clock::now();
-    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
+    ASSERT_FALSE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), candidates));
     const auto elapsed = std::chrono::steady_clock::now() - t0;
     ASSERT_LT(elapsed, std::chrono::milliseconds(50));
 
@@ -5279,52 +5262,17 @@ TEST_F(CacheReclaimerTest, TestDoKeySamplingFutureTimeout_WorkerSaturationGuard)
 
 TEST_F(CacheReclaimerTest, TestDupKeys) {
     {
-        sample_reclaim_keys = {0, 0, 2, 3, 4, 5, 6, 7, 8, 9};
-        get_out_properties = {
-            {
-                {PROPERTY_LRU_TIME, "1"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "1"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "2"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "3"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "4"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "5"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "6"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "7"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "8"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-        };
-
-        cache_reclaimer_->sampling_size_.store(sample_reclaim_keys.size());
+        const ReclaimCandidateVector candidates = {
+            {0, 1}, {0, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}, {7, 7}, {8, 8}, {9, 9}};
+        cache_reclaimer_->sampling_size_.store(candidates.size());
         cache_reclaimer_->sampling_size_per_task_.store(100);
-        cache_reclaimer_->batching_size_.store(sample_reclaim_keys.size());
+        cache_reclaimer_->batching_size_.store(candidates.size());
 
-        std::vector<std::int64_t> keys(sample_reclaim_keys);
-        std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
         ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
-            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+            request_context_.get(), instance_infos.front(), candidates, batch, lru_age_stats));
         ASSERT_EQ(9, batch.size());
-        // keys 1..10 unique, lru_times 0..9; tp=0 excluded from stats, tp=1..9 included (9 entries)
         // ages: now_us-1, now_us-2, ..., now_us-9 → min=now_us-9, max=now_us-1, diff=8
         EXPECT_GT(lru_age_stats.min_us, 0);
         EXPECT_GT(lru_age_stats.max_us, 0);
@@ -5335,50 +5283,16 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
     }
 
     {
-        sample_reclaim_keys = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-        get_out_properties = {
-            {
-                {PROPERTY_LRU_TIME, "0"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "1"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "2"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "3"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "4"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "5"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "6"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "7"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "8"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-        };
-
-        cache_reclaimer_->sampling_size_.store(sample_reclaim_keys.size());
+        const ReclaimCandidateVector candidates = {
+            {1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}, {1, 6}, {1, 7}, {1, 8}, {1, 9}};
+        cache_reclaimer_->sampling_size_.store(candidates.size());
         cache_reclaimer_->sampling_size_per_task_.store(100);
         cache_reclaimer_->batching_size_.store(2);
 
-        std::vector<std::int64_t> keys(sample_reclaim_keys);
-        std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
         ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
-            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+            request_context_.get(), instance_infos.front(), candidates, batch, lru_age_stats));
         ASSERT_EQ(1, batch.size());
         // all keys are 1 (only 1 unique key), first occurrence has tp=0 → excluded
         // age_count=0 → Clear() called → all stats zeroed
@@ -5388,50 +5302,16 @@ TEST_F(CacheReclaimerTest, TestDupKeys) {
     }
 
     {
-        sample_reclaim_keys = {1, 1, 1, 1, 1, 1, 1, 2, 1, 1};
-        get_out_properties = {
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "10"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-            {
-                {PROPERTY_LRU_TIME, "9"},
-            },
-        };
-
-        cache_reclaimer_->sampling_size_.store(sample_reclaim_keys.size());
+        const ReclaimCandidateVector candidates = {
+            {1, 9}, {1, 9}, {1, 9}, {1, 9}, {1, 9}, {1, 9}, {1, 9}, {2, 10}, {1, 9}, {1, 9}};
+        cache_reclaimer_->sampling_size_.store(candidates.size());
         cache_reclaimer_->sampling_size_per_task_.store(100);
         cache_reclaimer_->batching_size_.store(2);
 
-        std::vector<std::int64_t> keys(sample_reclaim_keys);
-        std::vector<std::map<std::string, std::string>> maps(get_out_properties);
         std::vector<std::int64_t> batch;
         CacheReclaimer::AgeStats lru_age_stats;
         ASSERT_TRUE(cache_reclaimer_->MakeBatchByLRU(
-            request_context_.get(), instance_infos.front(), keys, maps, batch, lru_age_stats));
+            request_context_.get(), instance_infos.front(), candidates, batch, lru_age_stats));
         ASSERT_EQ(2, batch.size());
         // keys={1*7,2,1,1}, tp={9*7,10,9,9}; sorted → key=1(tp=9) then key=2(tp=10)
         // ages: now_us-9 and now_us-10 → min=now_us-10, max=now_us-9, diff=1

--- a/kv_cache_manager/meta/meta_async_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_async_redis_backend.cc
@@ -9,6 +9,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/cache_location.h"
@@ -609,6 +610,59 @@ ErrorCode MetaAsyncRedisBackend::SampleReclaimKeys(RequestContext * /*request_co
                                                    const int64_t count,
                                                    KeyTypeVec &out_keys) noexcept {
     return RandomSample(nullptr, count, out_keys);
+}
+
+ErrorCode MetaAsyncRedisBackend::SampleReclaimCandidates(RequestContext *request_context,
+                                                         const int64_t count,
+                                                         ReclaimCandidateVector &out_candidates) noexcept {
+    out_candidates.clear();
+    if (count <= 0) {
+        return EC_OK;
+    }
+    KeyTypeVec keys;
+    const ErrorCode sample_ec = RandomSample(request_context, count, keys);
+    if (sample_ec != EC_OK || keys.empty()) {
+        return sample_ec;
+    }
+
+    PropertyMapVector properties;
+    const std::vector<ErrorCode> property_results =
+        GetProperties(request_context, keys, {PROPERTY_LRU_TIME}, properties);
+    bool all_properties_available = property_results.size() == keys.size() && properties.size() == keys.size();
+    if (all_properties_available) {
+        for (const ErrorCode ec : property_results) {
+            if (ec != EC_OK) {
+                all_properties_available = false;
+                break;
+            }
+        }
+    }
+
+    out_candidates.reserve(keys.size());
+    if (!all_properties_available) {
+        KVCM_INTERVAL_LOG_WARN(10,
+                               "async redis sample reclaim candidate properties unavailable, use zero lru time, "
+                               "instance[%s]",
+                               instance_id_.c_str());
+        for (const KeyType key : keys) {
+            out_candidates.push_back({key, 0});
+        }
+        return EC_OK;
+    }
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        int64_t last_access_time_us = 0;
+        const auto it = properties[i].find(PROPERTY_LRU_TIME);
+        if (it == properties[i].end() || !StringUtil::StrToInt64(it->second.c_str(), last_access_time_us)) {
+            KVCM_INTERVAL_LOG_WARN(10,
+                                   "async redis sample reclaim candidate has missing or malformed lru time, "
+                                   "instance[%s]",
+                                   instance_id_.c_str());
+            last_access_time_us = 0;
+        }
+        out_candidates.push_back({keys[i], last_access_time_us});
+    }
+    return EC_OK;
 }
 
 ErrorCode MetaAsyncRedisBackend::PutMetaData(const FieldMap &field_map) noexcept {

--- a/kv_cache_manager/meta/meta_async_redis_backend.h
+++ b/kv_cache_manager/meta/meta_async_redis_backend.h
@@ -77,6 +77,9 @@ public:
     RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
+    ErrorCode SampleReclaimCandidates(RequestContext *request_context,
+                                      int64_t count,
+                                      ReclaimCandidateVector &out_candidates) noexcept override;
 
     // ----- MetaData (sync passthrough) -----
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;

--- a/kv_cache_manager/meta/meta_cache_base_backend.h
+++ b/kv_cache_manager/meta/meta_cache_base_backend.h
@@ -21,6 +21,14 @@ public:
     virtual size_t GetMemUsage() const noexcept = 0;
     virtual int64_t GetOldestAccessTime() const noexcept = 0;
 
+    // Reads current access timestamps from the hot cache without marking the
+    // keys as hits, updating revisit metrics, or changing LRU positions.
+    // EC_NOENT means the caller may fall back to the persistent layer.
+    virtual std::vector<ErrorCode>
+    GetLastAccessTimesForMaintenance(RequestContext *request_context,
+                                     const KeyTypeVec &keys,
+                                     std::vector<int64_t> &out_last_access_times) noexcept = 0;
+
     // 写入 locations + properties，仅当 key 在 cache 中不存在时才写入。
     // 若 key 已存在，返回 EC_OK 且不修改已有数据（幂等）。
     // @param request_context    请求上下文；可为 nullptr

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -492,7 +492,9 @@ ErrorCode MetaDummyBackend::SampleReclaimCandidates(RequestContext * /*request_c
         }
         int64_t last_access_time_us = 0;
         if (const auto it = item.properties.find(PROPERTY_LRU_TIME); it != item.properties.end()) {
-            StringUtil::StrToInt64(it->second.c_str(), last_access_time_us);
+            if (!StringUtil::StrToInt64(it->second.c_str(), last_access_time_us)) {
+                last_access_time_us = 0;
+            }
         }
         out_candidates.push_back({key, last_access_time_us});
         return true;

--- a/kv_cache_manager/meta/meta_dummy_backend.cc
+++ b/kv_cache_manager/meta/meta_dummy_backend.cc
@@ -479,6 +479,27 @@ ErrorCode MetaDummyBackend::SampleReclaimKeys(RequestContext *request_context,
     return RandomSample(request_context, count, out_keys);
 }
 
+ErrorCode MetaDummyBackend::SampleReclaimCandidates(RequestContext * /*request_context*/,
+                                                    const std::int64_t count,
+                                                    ReclaimCandidateVector &out_candidates) noexcept {
+    out_candidates.clear();
+    if (count <= 0) {
+        return EC_OK;
+    }
+    table_.ForEachKV([&](const KeyType &key, const DummyItem &item) {
+        if (static_cast<int64_t>(out_candidates.size()) >= count) {
+            return false;
+        }
+        int64_t last_access_time_us = 0;
+        if (const auto it = item.properties.find(PROPERTY_LRU_TIME); it != item.properties.end()) {
+            StringUtil::StrToInt64(it->second.c_str(), last_access_time_us);
+        }
+        out_candidates.push_back({key, last_access_time_us});
+        return true;
+    });
+    return EC_OK;
+}
+
 // ---------------------------------------------------------------------------
 // Metadata operations
 // ---------------------------------------------------------------------------

--- a/kv_cache_manager/meta/meta_dummy_backend.h
+++ b/kv_cache_manager/meta/meta_dummy_backend.h
@@ -101,6 +101,9 @@ public:
     ErrorCode RandomSample(RequestContext *request_context, std::int64_t count, KeyTypeVec &out_keys) noexcept override;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, std::int64_t count, KeyTypeVec &out_keys) noexcept override;
+    ErrorCode SampleReclaimCandidates(RequestContext *request_context,
+                                      std::int64_t count,
+                                      ReclaimCandidateVector &out_candidates) noexcept override;
 
     // =====================================================================
     // Metadata APIs

--- a/kv_cache_manager/meta/meta_indexer.cc
+++ b/kv_cache_manager/meta/meta_indexer.cc
@@ -958,13 +958,8 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
                 }
             }
         }
-        const auto [delete_errs, delete_success_count] = ExecuteRmwDelete(trace_id,
-                                                                          ephemeral_request_context.get(),
-                                                                          delete_batch,
-                                                                          keys,
-                                                                          stats,
-                                                                          rmw_result,
-                                                                          maintenance_no_touch);
+        const auto [delete_errs, delete_success_count] = ExecuteRmwDelete(
+            trace_id, ephemeral_request_context.get(), delete_batch, keys, stats, rmw_result, maintenance_no_touch);
         (void)delete_errs;
         const bool maintenance_delete_synced = !maintenance_no_touch || delete_batch.batch_keys.empty() ||
                                                !backend_manager_->RequiresMaintenancePostDeleteSync() ||
@@ -979,9 +974,8 @@ MetaIndexer::LocationResult MetaIndexer::ReadModifyWriteLocationImpl(RequestCont
             // accounting boundary, and replacing those results with TIMEOUT
             // would permanently leak usage when the delete has already been
             // applied and is therefore absent from the next scan.
-            PREFIX_INDEXER_LOG(WARN,
-                               "maintenance post-delete Sync failed for keys[%lu]",
-                               delete_batch.batch_keys.size());
+            PREFIX_INDEXER_LOG(
+                WARN, "maintenance post-delete Sync failed for keys[%lu]", delete_batch.batch_keys.size());
             for (const int32_t global_idx : delete_batch.batch_indexs) {
                 key_level_failures[global_idx] = true;
             }
@@ -1350,7 +1344,6 @@ MetaIndexer::ReadModifyWriteSingleTargetLocations(RequestContext *request_contex
     }
     return result;
 }
-
 
 MetaIndexer::Result
 MetaIndexer::Exist(RequestContext *request_context, const KeyVector &keys, std::vector<bool> &out_exists) noexcept {
@@ -1956,6 +1949,23 @@ ErrorCode MetaIndexer::SampleReclaimKeys(RequestContext *request_context,
                        instance_id_.c_str(),
                        count,
                        out_keys.size());
+    }
+    return ec;
+}
+
+ErrorCode MetaIndexer::SampleReclaimCandidates(RequestContext *request_context,
+                                               const int64_t count,
+                                               ReclaimCandidateVector &out_candidates) const noexcept {
+    out_candidates.clear();
+    if (count > 0) {
+        out_candidates.reserve(static_cast<size_t>(count));
+    }
+    const ErrorCode ec = backend_manager_->SampleReclaimCandidates(request_context, count, out_candidates);
+    if (ec != EC_OK) {
+        KVCM_LOG_ERROR("instance[%s] meta indexer sample reclaim candidates failed, count[%lu] candidate size[%lu]",
+                       instance_id_.c_str(),
+                       count,
+                       out_candidates.size());
     }
     return ec;
 }

--- a/kv_cache_manager/meta/meta_indexer.h
+++ b/kv_cache_manager/meta/meta_indexer.h
@@ -175,6 +175,9 @@ public:
     ErrorCode RandomSample(RequestContext *request_context, const size_t count, KeyVector &out_keys) const noexcept;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyVector &out_keys) const noexcept;
+    ErrorCode SampleReclaimCandidates(RequestContext *request_context,
+                                      int64_t count,
+                                      ReclaimCandidateVector &out_candidates) const noexcept;
 
     // Reuses the same bounded executor for CPU-only query projection/reduction.
     // Directly constructed test/indexer instances without an executor retain

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -85,6 +85,7 @@ ErrorCode MetaLocalBackend::Init(const std::string &instance_id,
     size_t capacity = META_LOCAL_BACKEND_DEFAULT_CAPACITY;
     int32_t num_shard_bits = META_LOCAL_BACKEND_DEFAULT_NUM_SHARD_BITS;
     sample_times_ = META_LOCAL_BACKEND_DEFAULT_SAMPLE_TIMES;
+    reclaim_sample_shard_cursor_.store(0, std::memory_order_relaxed);
 
     const std::string &storage_uri = config->GetStorageUri();
     if (!storage_uri.empty()) {
@@ -1495,14 +1496,50 @@ ErrorCode MetaLocalBackend::SampleReclaimCandidates(RequestContext * /*request_c
     }
 
     const size_t select_count = std::min(num_rounds, shard_times.size());
-    std::partial_sort(shard_times.begin(), shard_times.begin() + select_count, shard_times.end());
+    std::sort(shard_times.begin(), shard_times.end());
+    const size_t start =
+        reclaim_sample_shard_cursor_.fetch_add(select_count, std::memory_order_relaxed) % shard_times.size();
     int64_t remaining = count;
     for (size_t i = 0; i < select_count && remaining > 0; ++i) {
         const size_t batch = static_cast<size_t>(std::min(per_round_count, remaining));
-        const size_t collected = CollectOldestReclaimCandidatesFromShard(shard_times[i].second, batch, out_candidates);
+        const size_t shard_index = (start + i) % shard_times.size();
+        const size_t collected =
+            CollectNextReclaimCandidatesFromShard(shard_times[shard_index].second, batch, out_candidates);
         remaining -= static_cast<int64_t>(collected);
     }
     return EC_OK;
+}
+
+std::vector<ErrorCode>
+MetaLocalBackend::GetLastAccessTimesForMaintenance(RequestContext * /*request_context*/,
+                                                   const KeyTypeVec &keys,
+                                                   std::vector<int64_t> &out_last_access_times) noexcept {
+    out_last_access_times.assign(keys.size(), 0);
+    std::vector<ErrorCode> results(keys.size(), EC_NOENT);
+    if (!cache_) {
+        std::fill(results.begin(), results.end(), EC_ERROR);
+        return results;
+    }
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const bool found = cache_->ApplyToEntryNoTouch(
+            KeyToView(keys[i]),
+            [&results, &out_last_access_times, i](
+                Cache::ObjectPtr value, size_t /*charge*/, const Cache::CacheItemHelper * /*helper*/) -> ssize_t {
+                if (value == nullptr) {
+                    results[i] = EC_ERROR;
+                    return 0;
+                }
+                const auto *item = static_cast<const MetaMemCacheItem *>(value);
+                out_last_access_times[i] = item->GetLastAccessTime();
+                results[i] = EC_OK;
+                return 0;
+            });
+        if (!found) {
+            results[i] = EC_NOENT;
+        }
+    }
+    return results;
 }
 
 // return OK to avoid error in MetaIndexer::PersistMetaData()
@@ -1541,22 +1578,22 @@ size_t MetaLocalBackend::CollectOldestKeysFromShard(uint32_t shard_id, size_t co
     return string_keys.size();
 }
 
-size_t MetaLocalBackend::CollectOldestReclaimCandidatesFromShard(const uint32_t shard_id,
-                                                                 const size_t count,
-                                                                 ReclaimCandidateVector &out_candidates) {
+size_t MetaLocalBackend::CollectNextReclaimCandidatesFromShard(const uint32_t shard_id,
+                                                               const size_t count,
+                                                               ReclaimCandidateVector &out_candidates) {
     const size_t initial_size = out_candidates.size();
-    cache_->ApplyToOldestEntriesInShard(shard_id,
-                                        count,
-                                        [&out_candidates](const std::string_view &key,
-                                                          Cache::ObjectPtr value,
-                                                          size_t /*charge*/,
-                                                          const Cache::CacheItemHelper * /*helper*/) {
-                                            if (key.size() != sizeof(KeyType) || value == nullptr) {
-                                                return;
-                                            }
-                                            const auto *item = static_cast<const MetaMemCacheItem *>(value);
-                                            out_candidates.push_back({ViewToKey(key), item->GetLastAccessTime()});
-                                        });
+    cache_->ApplyToNextOldestEntriesInShard(shard_id,
+                                            count,
+                                            [&out_candidates](const std::string_view &key,
+                                                              Cache::ObjectPtr value,
+                                                              size_t /*charge*/,
+                                                              const Cache::CacheItemHelper * /*helper*/) {
+                                                if (key.size() != sizeof(KeyType) || value == nullptr) {
+                                                    return;
+                                                }
+                                                const auto *item = static_cast<const MetaMemCacheItem *>(value);
+                                                out_candidates.push_back({ViewToKey(key), item->GetLastAccessTime()});
+                                            });
     return out_candidates.size() - initial_size;
 }
 

--- a/kv_cache_manager/meta/meta_local_backend.cc
+++ b/kv_cache_manager/meta/meta_local_backend.cc
@@ -1466,6 +1466,45 @@ ErrorCode MetaLocalBackend::SampleReclaimKeys(RequestContext * /*request_context
     return EC_OK;
 }
 
+ErrorCode MetaLocalBackend::SampleReclaimCandidates(RequestContext * /*request_context*/,
+                                                    const int64_t count,
+                                                    ReclaimCandidateVector &out_candidates) noexcept {
+    out_candidates.clear();
+    if (!cache_) {
+        KVCM_LOG_ERROR("local backend not inited");
+        return EC_ERROR;
+    }
+    if (count <= 0) {
+        return EC_OK;
+    }
+
+    const size_t num_shards = shard_mask_ + 1;
+    size_t num_rounds = std::min(sample_times_, num_shards);
+    num_rounds = std::min(num_rounds, static_cast<size_t>(count));
+    const int64_t per_round_count = (count + static_cast<int64_t>(num_rounds) - 1) / static_cast<int64_t>(num_rounds);
+    std::vector<std::pair<int64_t, uint32_t>> shard_times;
+    shard_times.reserve(num_shards);
+    for (uint32_t shard_id = 0; shard_id < num_shards; ++shard_id) {
+        const int64_t access_time = shard_oldest_access_time_[shard_id].load(std::memory_order_relaxed);
+        if (access_time < INT64_MAX) {
+            shard_times.emplace_back(access_time, shard_id);
+        }
+    }
+    if (shard_times.empty()) {
+        return EC_OK;
+    }
+
+    const size_t select_count = std::min(num_rounds, shard_times.size());
+    std::partial_sort(shard_times.begin(), shard_times.begin() + select_count, shard_times.end());
+    int64_t remaining = count;
+    for (size_t i = 0; i < select_count && remaining > 0; ++i) {
+        const size_t batch = static_cast<size_t>(std::min(per_round_count, remaining));
+        const size_t collected = CollectOldestReclaimCandidatesFromShard(shard_times[i].second, batch, out_candidates);
+        remaining -= static_cast<int64_t>(collected);
+    }
+    return EC_OK;
+}
+
 // return OK to avoid error in MetaIndexer::PersistMetaData()
 ErrorCode MetaLocalBackend::PutMetaData(const FieldMap & /*field_maps*/) noexcept { return EC_OK; }
 
@@ -1500,6 +1539,25 @@ size_t MetaLocalBackend::CollectOldestKeysFromShard(uint32_t shard_id, size_t co
         }
     }
     return string_keys.size();
+}
+
+size_t MetaLocalBackend::CollectOldestReclaimCandidatesFromShard(const uint32_t shard_id,
+                                                                 const size_t count,
+                                                                 ReclaimCandidateVector &out_candidates) {
+    const size_t initial_size = out_candidates.size();
+    cache_->ApplyToOldestEntriesInShard(shard_id,
+                                        count,
+                                        [&out_candidates](const std::string_view &key,
+                                                          Cache::ObjectPtr value,
+                                                          size_t /*charge*/,
+                                                          const Cache::CacheItemHelper * /*helper*/) {
+                                            if (key.size() != sizeof(KeyType) || value == nullptr) {
+                                                return;
+                                            }
+                                            const auto *item = static_cast<const MetaMemCacheItem *>(value);
+                                            out_candidates.push_back({ViewToKey(key), item->GetLastAccessTime()});
+                                        });
+    return out_candidates.size() - initial_size;
 }
 
 } // namespace kv_cache_manager

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -276,6 +276,10 @@ public:
     ErrorCode SampleReclaimCandidates(RequestContext *request_context,
                                       int64_t count,
                                       ReclaimCandidateVector &out_candidates) noexcept override;
+    std::vector<ErrorCode>
+    GetLastAccessTimesForMaintenance(RequestContext *request_context,
+                                     const KeyTypeVec &keys,
+                                     std::vector<int64_t> &out_last_access_times) noexcept override;
 
     // meta data
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
@@ -297,7 +301,7 @@ private:
 
     size_t CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys);
     size_t
-    CollectOldestReclaimCandidatesFromShard(uint32_t shard_id, size_t count, ReclaimCandidateVector &out_candidates);
+    CollectNextReclaimCandidatesFromShard(uint32_t shard_id, size_t count, ReclaimCandidateVector &out_candidates);
     ErrorCode
     CreateAndInsert(std::string_view key_sv, const CacheLocationMap &locations, const PropertyMap &properties);
     ErrorCode
@@ -347,6 +351,7 @@ private:
     std::unique_ptr<std::atomic<int64_t>[]> shard_oldest_access_time_;
     uint32_t shard_mask_ = 0;
     size_t sample_times_ = 0;
+    std::atomic<size_t> reclaim_sample_shard_cursor_{0};
     std::shared_ptr<RevisitIntervalHistogram> revisit_histogram_;
 };
 

--- a/kv_cache_manager/meta/meta_local_backend.h
+++ b/kv_cache_manager/meta/meta_local_backend.h
@@ -273,6 +273,9 @@ public:
     ErrorCode SampleReclaimKeys(RequestContext *request_context,
                                 const int64_t count,
                                 std::vector<KeyType> &out_keys) noexcept override;
+    ErrorCode SampleReclaimCandidates(RequestContext *request_context,
+                                      int64_t count,
+                                      ReclaimCandidateVector &out_candidates) noexcept override;
 
     // meta data
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;
@@ -293,6 +296,8 @@ private:
     }
 
     size_t CollectOldestKeysFromShard(uint32_t shard_id, size_t count, std::vector<KeyType> &out_keys);
+    size_t
+    CollectOldestReclaimCandidatesFromShard(uint32_t shard_id, size_t count, ReclaimCandidateVector &out_candidates);
     ErrorCode
     CreateAndInsert(std::string_view key_sv, const CacheLocationMap &locations, const PropertyMap &properties);
     ErrorCode

--- a/kv_cache_manager/meta/meta_redis_backend.cc
+++ b/kv_cache_manager/meta/meta_redis_backend.cc
@@ -2,6 +2,7 @@
 
 #include "kv_cache_manager/common/logger.h"
 #include "kv_cache_manager/common/request_context.h"
+#include "kv_cache_manager/common/string_util.h"
 #include "kv_cache_manager/common/timestamp_util.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
@@ -473,6 +474,56 @@ ErrorCode MetaRedisBackend::SampleReclaimKeys(RequestContext * /*request_context
                                               const int64_t count,
                                               KeyTypeVec &out_keys) noexcept {
     return RandomSample(nullptr, count, out_keys);
+}
+
+ErrorCode MetaRedisBackend::SampleReclaimCandidates(RequestContext *request_context,
+                                                    const int64_t count,
+                                                    ReclaimCandidateVector &out_candidates) noexcept {
+    out_candidates.clear();
+    if (count <= 0) {
+        return EC_OK;
+    }
+    KeyTypeVec keys;
+    const ErrorCode sample_ec = RandomSample(request_context, count, keys);
+    if (sample_ec != EC_OK || keys.empty()) {
+        return sample_ec;
+    }
+
+    PropertyMapVector properties;
+    const std::vector<ErrorCode> property_results =
+        GetProperties(request_context, keys, {PROPERTY_LRU_TIME}, properties);
+    bool all_properties_available = property_results.size() == keys.size() && properties.size() == keys.size();
+    if (all_properties_available) {
+        for (const ErrorCode ec : property_results) {
+            if (ec != EC_OK) {
+                all_properties_available = false;
+                break;
+            }
+        }
+    }
+
+    out_candidates.reserve(keys.size());
+    if (!all_properties_available) {
+        KVCM_INTERVAL_LOG_WARN(10,
+                               "sample reclaim candidate properties unavailable, use zero lru time, instance[%s]",
+                               instance_id_.c_str());
+        for (const KeyType key : keys) {
+            out_candidates.push_back({key, 0});
+        }
+        return EC_OK;
+    }
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        int64_t last_access_time_us = 0;
+        const auto it = properties[i].find(PROPERTY_LRU_TIME);
+        if (it == properties[i].end() || !StringUtil::StrToInt64(it->second.c_str(), last_access_time_us)) {
+            KVCM_INTERVAL_LOG_WARN(
+                10, "sample reclaim candidate has missing or malformed lru time, instance[%s]", instance_id_.c_str());
+            last_access_time_us = 0;
+        }
+        out_candidates.push_back({keys[i], last_access_time_us});
+    }
+    return EC_OK;
 }
 
 // ---------------------------------------------------------------------------

--- a/kv_cache_manager/meta/meta_redis_backend.h
+++ b/kv_cache_manager/meta/meta_redis_backend.h
@@ -81,6 +81,9 @@ public:
     RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
     ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept override;
+    ErrorCode SampleReclaimCandidates(RequestContext *request_context,
+                                      int64_t count,
+                                      ReclaimCandidateVector &out_candidates) noexcept override;
 
     // ----- Metadata APIs -----
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept override;

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -452,11 +452,13 @@ public:
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
 
     // Samples reclaim candidates and returns the timestamp used for LRU
-    // ranking as part of the same backend operation. Implementations must not
+    // ranking as part of the same logical operation. Implementations must not
     // update access timestamps, promote entries in an LRU list, or observe a
-    // revisit interval. If sampling succeeds but a timestamp is unavailable
-    // or malformed, the candidate is returned with last_access_time_us == 0
-    // to preserve the reclaimer's historical best-effort degradation.
+    // revisit interval. A composite backend may merge a complete persistent
+    // key sample with newer no-touch cache timestamps. If sampling succeeds
+    // but a timestamp is unavailable or malformed, the candidate is returned
+    // with last_access_time_us == 0 to preserve the reclaimer's historical
+    // best-effort degradation.
     virtual ErrorCode SampleReclaimCandidates(RequestContext *request_context,
                                               int64_t count,
                                               ReclaimCandidateVector &out_candidates) noexcept = 0;

--- a/kv_cache_manager/meta/meta_storage_backend.h
+++ b/kv_cache_manager/meta/meta_storage_backend.h
@@ -451,6 +451,16 @@ public:
     virtual ErrorCode
     SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept = 0;
 
+    // Samples reclaim candidates and returns the timestamp used for LRU
+    // ranking as part of the same backend operation. Implementations must not
+    // update access timestamps, promote entries in an LRU list, or observe a
+    // revisit interval. If sampling succeeds but a timestamp is unavailable
+    // or malformed, the candidate is returned with last_access_time_us == 0
+    // to preserve the reclaimer's historical best-effort degradation.
+    virtual ErrorCode SampleReclaimCandidates(RequestContext *request_context,
+                                              int64_t count,
+                                              ReclaimCandidateVector &out_candidates) noexcept = 0;
+
     // =====================================================================
     // Metadata APIs — 用于持久化 MetaIndexer 自身的元信息（key_count、storage_usage 等）
     // =====================================================================

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -1873,14 +1873,57 @@ ErrorCode MetaStorageBackendManager::SampleReclaimCandidates(RequestContext *req
     if (count <= 0) {
         return EC_OK;
     }
-    // Select the backend once for both key sampling and timestamp collection.
-    // During recovery, the persistent backend remains the complete source of
-    // truth; after recovery, the hot cache owns the LRU ordering.
-    MetaStorageBackend *backend = persistent_backend_.get();
-    if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
-        backend = cache_backend_.get();
+    if (!cache_backend_) {
+        return persistent_backend_->SampleReclaimCandidates(request_context, count, out_candidates);
     }
-    return backend->SampleReclaimCandidates(request_context, count, out_candidates);
+
+    if (recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        return cache_backend_->SampleReclaimCandidates(request_context, count, out_candidates);
+    }
+
+    // The persistent layer is the only complete key source while recovery is
+    // still backfilling the hot cache. Its timestamps can be stale, however,
+    // so overlay every cache hit with the current in-memory timestamp using a
+    // no-touch exact-key lookup. Cache misses retain the persistent timestamp.
+    ErrorCode ec = persistent_backend_->SampleReclaimCandidates(request_context, count, out_candidates);
+    if (ec != EC_OK) {
+        out_candidates.clear();
+        return ec;
+    }
+    if (out_candidates.empty()) {
+        return EC_OK;
+    }
+
+    KeyTypeVec keys;
+    keys.reserve(out_candidates.size());
+    for (const auto &candidate : out_candidates) {
+        keys.push_back(candidate.key);
+    }
+
+    std::vector<int64_t> cache_access_times;
+    const std::vector<ErrorCode> cache_results =
+        cache_backend_->GetLastAccessTimesForMaintenance(request_context, keys, cache_access_times);
+    if (cache_results.size() != out_candidates.size() || cache_access_times.size() != out_candidates.size()) {
+        KVCM_LOG_ERROR("cache reclaim timestamp results[%lu] timestamps[%lu] mismatch candidates[%lu]",
+                       cache_results.size(),
+                       cache_access_times.size(),
+                       out_candidates.size());
+        out_candidates.clear();
+        return EC_ERROR;
+    }
+
+    for (size_t i = 0; i < out_candidates.size(); ++i) {
+        if (cache_results[i] == EC_OK) {
+            out_candidates[i].last_access_time_us = cache_access_times[i];
+        } else if (cache_results[i] != EC_NOENT) {
+            KVCM_LOG_ERROR("cache reclaim timestamp lookup failed, key[%ld] ec[%d]",
+                           out_candidates[i].key,
+                           static_cast<int>(cache_results[i]));
+            out_candidates.clear();
+            return cache_results[i];
+        }
+    }
+    return EC_OK;
 }
 
 ErrorCode MetaStorageBackendManager::PutMetaData(const FieldMap &field_maps) noexcept {

--- a/kv_cache_manager/meta/meta_storage_backend_manager.cc
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.cc
@@ -720,11 +720,10 @@ std::vector<ErrorCode> MetaStorageBackendManager::Delete(RequestContext *request
     return results;
 }
 
-std::vector<ErrorCode>
-MetaStorageBackendManager::DeleteLocationsForMaintenance(RequestContext *request_context,
-                                                         const KeyVector &keys,
-                                                         const LocationIdsPerKey &location_ids,
-                                                         int32_t &out_reclaimed_count) noexcept {
+std::vector<ErrorCode> MetaStorageBackendManager::DeleteLocationsForMaintenance(RequestContext *request_context,
+                                                                                const KeyVector &keys,
+                                                                                const LocationIdsPerKey &location_ids,
+                                                                                int32_t &out_reclaimed_count) noexcept {
     out_reclaimed_count = 0;
     if (keys.empty()) {
         return {};
@@ -899,7 +898,6 @@ MetaStorageBackendManager::DeleteLocationsForMaintenance(RequestContext *request
     }
     return results;
 }
-
 
 int32_t MetaStorageBackendManager::MaybeReclaimEmptyKeys(RequestContext *request_context,
                                                          const KeyVector &keys,
@@ -1866,6 +1864,23 @@ ErrorCode MetaStorageBackendManager::SampleReclaimKeys(RequestContext *request_c
         return cache_backend_->SampleReclaimKeys(request_context, count, out_keys);
     }
     return persistent_backend_->SampleReclaimKeys(request_context, count, out_keys);
+}
+
+ErrorCode MetaStorageBackendManager::SampleReclaimCandidates(RequestContext *request_context,
+                                                             const int64_t count,
+                                                             ReclaimCandidateVector &out_candidates) noexcept {
+    out_candidates.clear();
+    if (count <= 0) {
+        return EC_OK;
+    }
+    // Select the backend once for both key sampling and timestamp collection.
+    // During recovery, the persistent backend remains the complete source of
+    // truth; after recovery, the hot cache owns the LRU ordering.
+    MetaStorageBackend *backend = persistent_backend_.get();
+    if (cache_backend_ && recover_state_.load(std::memory_order_acquire) == RecoverState::kRunning) {
+        backend = cache_backend_.get();
+    }
+    return backend->SampleReclaimCandidates(request_context, count, out_candidates);
 }
 
 ErrorCode MetaStorageBackendManager::PutMetaData(const FieldMap &field_maps) noexcept {

--- a/kv_cache_manager/meta/meta_storage_backend_manager.h
+++ b/kv_cache_manager/meta/meta_storage_backend_manager.h
@@ -156,6 +156,9 @@ public:
                                           MaintenanceScanBatch &out) noexcept;
     ErrorCode RandomSample(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept;
     ErrorCode SampleReclaimKeys(RequestContext *request_context, const int64_t count, KeyTypeVec &out_keys) noexcept;
+    ErrorCode SampleReclaimCandidates(RequestContext *request_context,
+                                      int64_t count,
+                                      ReclaimCandidateVector &out_candidates) noexcept;
 
     ErrorCode PutMetaData(const FieldMap &field_maps) noexcept;
     ErrorCode GetMetaData(FieldMap &field_maps) noexcept;

--- a/kv_cache_manager/meta/test/meta_async_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_async_redis_backend_test.cc
@@ -37,6 +37,29 @@ private:
     std::string serialized_value_;
 };
 
+class ScriptedReclaimMetaAsyncRedisBackend : public MetaAsyncRedisBackend {
+public:
+    ErrorCode RandomSample(RequestContext *, const int64_t, KeyTypeVec &out_keys) noexcept override {
+        out_keys = sampled_keys;
+        return sample_result;
+    }
+
+    std::vector<ErrorCode> GetProperties(RequestContext *,
+                                         const KeyTypeVec &,
+                                         const std::vector<std::string> &field_names,
+                                         PropertyMapVector &out_properties) noexcept override {
+        requested_fields = field_names;
+        out_properties = properties;
+        return property_results;
+    }
+
+    ErrorCode sample_result = EC_OK;
+    KeyTypeVec sampled_keys;
+    std::vector<ErrorCode> property_results;
+    PropertyMapVector properties;
+    std::vector<std::string> requested_fields;
+};
+
 class MetaAsyncRedisBackendTest : public MetaStorageBackendTestBase, public RedisTestBase, public TESTBASE {
 public:
     void SetUp() override {
@@ -122,6 +145,35 @@ TEST_F(MetaAsyncRedisBackendTest, TestInitParams) {
     ASSERT_EQ(1000, backend_->batch_wait_timeout_us_);
     ASSERT_EQ(1000, backend_->queue_max_size_);
     ASSERT_EQ(2000, backend_->drain_timeout_ms_);
+}
+
+TEST_F(MetaAsyncRedisBackendTest, TestSampleReclaimCandidatesUsesReadOnlyTimestampQuery) {
+    ScriptedReclaimMetaAsyncRedisBackend backend;
+    backend.sampled_keys = {1, 2};
+    backend.property_results = {EC_OK, EC_OK};
+    backend.properties = {{{PROPERTY_LRU_TIME, "101"}}, {{PROPERTY_LRU_TIME, "malformed"}}};
+
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(EC_OK, backend.SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ((std::vector<std::string>{PROPERTY_LRU_TIME}), backend.requested_fields);
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(1, candidates[0].key);
+    EXPECT_EQ(101, candidates[0].last_access_time_us);
+    EXPECT_EQ(2, candidates[1].key);
+    EXPECT_EQ(0, candidates[1].last_access_time_us);
+}
+
+TEST_F(MetaAsyncRedisBackendTest, TestSampleReclaimCandidatesPropertyFailureDegradesAllTimestamps) {
+    ScriptedReclaimMetaAsyncRedisBackend backend;
+    backend.sampled_keys = {1, 2};
+    backend.property_results = {EC_ERROR, EC_OK};
+    backend.properties = {{{PROPERTY_LRU_TIME, "101"}}, {{PROPERTY_LRU_TIME, "202"}}};
+
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(EC_OK, backend.SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(0, candidates[0].last_access_time_us);
+    EXPECT_EQ(0, candidates[1].last_access_time_us);
 }
 
 TEST_F(MetaAsyncRedisBackendTest, TestInitInvalidAsyncConfig) {

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -377,6 +377,31 @@ TEST_F(MetaDummyBackendTest, TestRandomSample) {
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaDummyBackendTest, TestSampleReclaimCandidatesDegradesMalformedTimestampsToZero) {
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_storage_backend_->Init("test_reclaim_timestamp_parse", meta_storage_backend_config_));
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Open());
+
+    ASSERT_EQ((std::vector<ErrorCode>{ErrorCode::EC_OK, ErrorCode::EC_OK, ErrorCode::EC_OK}),
+              meta_storage_backend_->Put(nullptr, {1, 2, 3}, CacheLocationMapVector(3), PropertyMapVector(3)));
+    auto *backend = static_cast<MetaDummyBackend *>(meta_storage_backend_.get());
+    ASSERT_TRUE(
+        backend->table_.FindAndModify(1, [](DummyItem &item) { item.properties[PROPERTY_LRU_TIME] = "123bad"; }));
+    ASSERT_TRUE(backend->table_.FindAndModify(
+        2, [](DummyItem &item) { item.properties[PROPERTY_LRU_TIME] = "9223372036854775808"; }));
+    ASSERT_TRUE(backend->table_.FindAndModify(
+        3, [](DummyItem &item) { item.properties[PROPERTY_LRU_TIME] = "-9223372036854775809"; }));
+
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(ErrorCode::EC_OK, backend->SampleReclaimCandidates(nullptr, 3, candidates));
+    ASSERT_EQ(3, candidates.size());
+    for (const auto &candidate : candidates) {
+        EXPECT_EQ(0, candidate.last_access_time_us) << candidate.key;
+    }
+
+    ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaDummyBackendTest, TestRecover) {
     for (std::int32_t i = 0; i != 10; ++i) {
         ConstructMetaStorageBackend(); // new meta storage backend

--- a/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_dummy_backend_test.cc
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <filesystem>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -353,6 +354,25 @@ TEST_F(MetaDummyBackendTest, TestRandomSample) {
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 1, ErrorCode::EC_OK, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 2, ErrorCode::EC_OK, {1, 2});
     AssertSampleReclaimKeys(meta_storage_backend_.get(), /*count*/ 3, ErrorCode::EC_OK, {1, 2});
+
+    auto *backend = static_cast<MetaDummyBackend *>(meta_storage_backend_.get());
+    auto snapshot_lru_times = [backend]() {
+        std::map<KeyType, std::string> lru_times;
+        backend->table_.ForEachKV([&lru_times](const KeyType &key, const DummyItem &item) {
+            lru_times[key] = item.properties.at(PROPERTY_LRU_TIME);
+            return true;
+        });
+        return lru_times;
+    };
+    const auto lru_times_before = snapshot_lru_times();
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(ErrorCode::EC_OK, backend->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    for (const auto &candidate : candidates) {
+        ASSERT_TRUE(lru_times_before.count(candidate.key) > 0);
+        EXPECT_EQ(std::stoll(lru_times_before.at(candidate.key)), candidate.last_access_time_us);
+    }
+    EXPECT_EQ(lru_times_before, snapshot_lru_times());
 
     ASSERT_EQ(ErrorCode::EC_OK, meta_storage_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -786,6 +786,64 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimKeys) {
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }
 
+TEST_F(MetaLocalBackendTest, TestSampleReclaimCandidatesDoesNotTouchLruState) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_reclaim_candidates_no_touch", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    auto registry = std::make_shared<MetricsRegistry>();
+    auto histogram = std::make_shared<RevisitIntervalHistogram>();
+    ASSERT_TRUE(histogram->Init(registry, {1.0, 10.0}, "test_reclaim_candidates_no_touch"));
+    GetLocalBackend()->SetRevisitHistogram(histogram);
+
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {1}, {{{PROPERTY_URI, "uri1"}}}));
+    usleep(1000);
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              PutWithFieldMaps(meta_storage_backend_.get(), {2}, {{{PROPERTY_URI, "uri2"}}}));
+
+    auto snapshot_access_times = [backend = GetLocalBackend()]() {
+        std::map<KeyType, int64_t> access_times;
+        backend->cache_->ApplyToSingleShard(
+            0,
+            [&access_times](
+                const std::string_view &key, Cache::ObjectPtr value, size_t, const Cache::CacheItemHelper *) {
+                access_times[MetaLocalBackend::ViewToKey(key)] =
+                    static_cast<const MetaMemCacheItem *>(value)->GetLastAccessTime();
+            });
+        return access_times;
+    };
+
+    KeyVector order_before;
+    ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimKeys(nullptr, 2, order_before));
+    ASSERT_EQ((KeyVector{1, 2}), order_before);
+    const auto access_times_before = snapshot_access_times();
+    ASSERT_EQ(2, access_times_before.size());
+
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(1, candidates[0].key);
+    EXPECT_EQ(access_times_before.at(1), candidates[0].last_access_time_us);
+    EXPECT_EQ(2, candidates[1].key);
+    EXPECT_EQ(access_times_before.at(2), candidates[1].last_access_time_us);
+    EXPECT_EQ(0, histogram->GetCount());
+    EXPECT_EQ(access_times_before, snapshot_access_times());
+
+    KeyVector order_after;
+    ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimKeys(nullptr, 2, order_after));
+    EXPECT_EQ(order_before, order_after);
+
+    usleep(1000);
+    PropertyMapVector properties;
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
+              GetLocalBackend()->GetProperties(nullptr, {1}, {PROPERTY_URI}, properties));
+    EXPECT_EQ(1, histogram->GetCount());
+    EXPECT_GT(snapshot_access_times().at(1), access_times_before.at(1));
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
 TEST_F(MetaLocalBackendTest, TestMetaMemCacheItemFieldMap) {
     // Verify MetaMemCacheItem stores locations and properties separately.
     CacheLocationMap locations;

--- a/kv_cache_manager/meta/test/meta_local_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_local_backend_test.cc
@@ -4,6 +4,7 @@
 #include <thread>
 #include <vector>
 
+#include "kv_cache_manager/common/cache/lru_cache.h"
 #include "kv_cache_manager/common/unittest.h"
 #include "kv_cache_manager/config/meta_storage_backend_config.h"
 #include "kv_cache_manager/meta/common.h"
@@ -830,6 +831,15 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimCandidatesDoesNotTouchLruState) {
     EXPECT_EQ(0, histogram->GetCount());
     EXPECT_EQ(access_times_before, snapshot_access_times());
 
+    std::vector<int64_t> maintenance_times;
+    EXPECT_EQ((std::vector<ErrorCode>{EC_OK, EC_NOENT}),
+              GetLocalBackend()->GetLastAccessTimesForMaintenance(nullptr, {1, 3}, maintenance_times));
+    ASSERT_EQ(2, maintenance_times.size());
+    EXPECT_EQ(access_times_before.at(1), maintenance_times[0]);
+    EXPECT_EQ(0, maintenance_times[1]);
+    EXPECT_EQ(0, histogram->GetCount());
+    EXPECT_EQ(access_times_before, snapshot_access_times());
+
     KeyVector order_after;
     ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimKeys(nullptr, 2, order_after));
     EXPECT_EQ(order_before, order_after);
@@ -840,6 +850,125 @@ TEST_F(MetaLocalBackendTest, TestSampleReclaimCandidatesDoesNotTouchLruState) {
               GetLocalBackend()->GetProperties(nullptr, {1}, {PROPERTY_URI}, properties));
     EXPECT_EQ(1, histogram->GetCount());
     EXPECT_GT(snapshot_access_times().at(1), access_times_before.at(1));
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestSampleReclaimCandidatesAdvancesPastRejectedOldestPrefix) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_reclaim_candidates_progress", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    const KeyTypeVec keys{1, 2, 3, 4, 5, 6};
+    ASSERT_EQ(
+        std::vector<ErrorCode>(keys.size(), EC_OK),
+        meta_storage_backend_->Put(nullptr, keys, CacheLocationMapVector(keys.size()), PropertyMapVector(keys.size())));
+
+    // Model FilterLocID rejecting the first result without touching or
+    // deleting it. The next sampling call must still reach later keys.
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(1, candidates[0].key);
+    EXPECT_EQ(2, candidates[1].key);
+
+    ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(3, candidates[0].key);
+    EXPECT_EQ(4, candidates[1].key);
+
+    ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(5, candidates[0].key);
+    EXPECT_EQ(6, candidates[1].key);
+
+    ASSERT_EQ(EC_OK, GetLocalBackend()->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(1, candidates[0].key);
+    EXPECT_EQ(2, candidates[1].key);
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestConcurrentReclaimSamplingTasksCoverDistinctKeys) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=0&sample_times=1");
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Init("test_reclaim_candidates_multi_task", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    constexpr size_t kTaskCount = 10;
+    constexpr size_t kKeysPerTask = 100;
+    constexpr size_t kKeyCount = kTaskCount * kKeysPerTask;
+    KeyTypeVec keys;
+    keys.reserve(kKeyCount);
+    for (size_t i = 0; i < kKeyCount; ++i) {
+        keys.push_back(static_cast<KeyType>(i + 1));
+    }
+    ASSERT_EQ(
+        std::vector<ErrorCode>(keys.size(), EC_OK),
+        meta_storage_backend_->Put(nullptr, keys, CacheLocationMapVector(keys.size()), PropertyMapVector(keys.size())));
+
+    std::vector<ReclaimCandidateVector> task_candidates(kTaskCount);
+    std::vector<ErrorCode> task_results(kTaskCount, EC_ERROR);
+    std::vector<std::thread> tasks;
+    tasks.reserve(kTaskCount);
+    for (size_t i = 0; i < kTaskCount; ++i) {
+        tasks.emplace_back([backend = GetLocalBackend(), &task_candidates, &task_results, i]() {
+            task_results[i] = backend->SampleReclaimCandidates(nullptr, kKeysPerTask, task_candidates[i]);
+        });
+    }
+    for (auto &task : tasks) {
+        task.join();
+    }
+
+    std::set<KeyType> unique_keys;
+    for (size_t i = 0; i < kTaskCount; ++i) {
+        EXPECT_EQ(EC_OK, task_results[i]);
+        EXPECT_EQ(kKeysPerTask, task_candidates[i].size());
+        for (const auto &candidate : task_candidates[i]) {
+            unique_keys.insert(candidate.key);
+        }
+    }
+    EXPECT_EQ(kKeyCount, unique_keys.size());
+
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
+}
+
+TEST_F(MetaLocalBackendTest, TestReclaimSamplingAdvancesAcrossShards) {
+    meta_storage_backend_config_->SetStorageUri("local://?capacity=64&num_shard_bits=2&sample_times=1");
+    ASSERT_EQ(EC_OK,
+              meta_storage_backend_->Init("test_reclaim_candidates_shard_progress", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_storage_backend_->Open());
+
+    constexpr size_t kKeyCount = 64;
+    KeyTypeVec keys;
+    keys.reserve(kKeyCount);
+    for (size_t i = 0; i < kKeyCount; ++i) {
+        keys.push_back(static_cast<KeyType>(i + 1));
+    }
+    ASSERT_EQ(
+        std::vector<ErrorCode>(keys.size(), EC_OK),
+        meta_storage_backend_->Put(nullptr, keys, CacheLocationMapVector(keys.size()), PropertyMapVector(keys.size())));
+
+    auto *backend = GetLocalBackend();
+    auto shard_for_key = [backend](const KeyType key) {
+        const uint32_t hash =
+            lru_cache::LRUCacheShard::ComputeHash(MetaLocalBackend::KeyToView(key), backend->cache_->GetHashSeed());
+        return hash & backend->shard_mask_;
+    };
+    std::set<uint32_t> populated_shards;
+    for (const KeyType key : keys) {
+        populated_shards.insert(shard_for_key(key));
+    }
+    ASSERT_EQ(4, populated_shards.size());
+
+    std::set<uint32_t> sampled_shards;
+    for (size_t i = 0; i < populated_shards.size(); ++i) {
+        ReclaimCandidateVector candidates;
+        ASSERT_EQ(EC_OK, backend->SampleReclaimCandidates(nullptr, 1, candidates));
+        ASSERT_EQ(1, candidates.size());
+        sampled_shards.insert(shard_for_key(candidates.front().key));
+    }
+    EXPECT_EQ(populated_shards, sampled_shards);
 
     ASSERT_EQ(EC_OK, meta_storage_backend_->Close());
 }

--- a/kv_cache_manager/meta/test/meta_redis_backend_test.cc
+++ b/kv_cache_manager/meta/test/meta_redis_backend_test.cc
@@ -278,6 +278,86 @@ TEST_F(MetaRedisBackendTest, TestSimple) {
     ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
 }
 
+TEST_F(MetaRedisBackendTest, TestSampleReclaimCandidatesReadsTimestampsWithoutWrites) {
+    EXPECT_CALL(*meta_redis_backend_, CreateRedisClient()).WillOnce(Invoke([]() {
+        StandardUri empty_storage_uri;
+        auto mock_redis_client = std::make_unique<MockRedisClient>(empty_storage_uri);
+        EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> random_replies;
+        for (int i = 0; i < 20; ++i) {
+            random_replies.emplace_back(MakeFakeReply(REDIS_REPLY_STRING, "some_other_key"));
+        }
+        random_replies[0] = MakeFakeReply(REDIS_REPLY_STRING, "kvcache:instance_instance_0:cache_1");
+        random_replies[1] = MakeFakeReply(REDIS_REPLY_STRING, "kvcache:instance_instance_0:cache_2");
+        const std::vector<std::vector<std::string>> randomkey_commands(20, {"RANDOMKEY"});
+        EXPECT_CALL(*mock_redis_client, TryExecPipeline(ElementsAreArray(randomkey_commands)))
+            .WillOnce(Return(ByMove(std::move(random_replies))));
+
+        std::vector<ReplyUPtr> property_replies;
+        property_replies.emplace_back(MakeFakeReplyArrayString({"101"}));
+        property_replies.emplace_back(MakeFakeReplyArrayString({"malformed"}));
+        EXPECT_CALL(
+            *mock_redis_client,
+            TryExecPipeline(ElementsAre(
+                ElementsAre(StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_1"), StrEq(PROPERTY_LRU_TIME)),
+                ElementsAre(StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_2"), StrEq(PROPERTY_LRU_TIME)))))
+            .WillOnce(Return(ByMove(std::move(property_replies))));
+        return mock_redis_client;
+    }));
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(EC_OK, meta_redis_backend_->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(1, candidates[0].key);
+    EXPECT_EQ(101, candidates[0].last_access_time_us);
+    EXPECT_EQ(2, candidates[1].key);
+    EXPECT_EQ(0, candidates[1].last_access_time_us);
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
+}
+
+TEST_F(MetaRedisBackendTest, TestSampleReclaimCandidatesPropertyFailureDegradesAllTimestamps) {
+    EXPECT_CALL(*meta_redis_backend_, CreateRedisClient()).WillOnce(Invoke([]() {
+        StandardUri empty_storage_uri;
+        auto mock_redis_client = std::make_unique<MockRedisClient>(empty_storage_uri);
+        EXPECT_CALL(*mock_redis_client, IsContextOk()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*mock_redis_client, Reconnect()).WillRepeatedly(Return(true));
+
+        std::vector<ReplyUPtr> random_replies;
+        for (int i = 0; i < 20; ++i) {
+            random_replies.emplace_back(MakeFakeReply(REDIS_REPLY_STRING, "some_other_key"));
+        }
+        random_replies[0] = MakeFakeReply(REDIS_REPLY_STRING, "kvcache:instance_instance_0:cache_1");
+        random_replies[1] = MakeFakeReply(REDIS_REPLY_STRING, "kvcache:instance_instance_0:cache_2");
+        const std::vector<std::vector<std::string>> randomkey_commands(20, {"RANDOMKEY"});
+        EXPECT_CALL(*mock_redis_client, TryExecPipeline(ElementsAreArray(randomkey_commands)))
+            .WillOnce(Return(ByMove(std::move(random_replies))));
+
+        std::vector<ReplyUPtr> property_replies;
+        property_replies.emplace_back(MakeFakeReply(REDIS_REPLY_ERROR, "ERROR"));
+        property_replies.emplace_back(MakeFakeReplyArrayString({"202"}));
+        EXPECT_CALL(
+            *mock_redis_client,
+            TryExecPipeline(ElementsAre(
+                ElementsAre(StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_1"), StrEq(PROPERTY_LRU_TIME)),
+                ElementsAre(StrEq("HMGET"), StrEq("kvcache:instance_instance_0:cache_2"), StrEq(PROPERTY_LRU_TIME)))))
+            .WillOnce(Return(ByMove(std::move(property_replies))));
+        return mock_redis_client;
+    }));
+
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Init("instance_0", meta_storage_backend_config_));
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Open());
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(EC_OK, meta_redis_backend_->SampleReclaimCandidates(nullptr, 2, candidates));
+    ASSERT_EQ(2, candidates.size());
+    EXPECT_EQ(0, candidates[0].last_access_time_us);
+    EXPECT_EQ(0, candidates[1].last_access_time_us);
+    ASSERT_EQ(EC_OK, meta_redis_backend_->Close());
+}
+
 TEST_F(MetaRedisBackendTest, TestRedisError) {
     EXPECT_CALL(*meta_redis_backend_, CreateRedisClient()).WillOnce(Invoke([]() {
         StandardUri empty_storage_uri;

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -330,7 +330,10 @@ private:
 
 class RecordingReclaimBackend : public MetaLocalBackend {
 public:
-    explicit RecordingReclaimBackend(const KeyType key) : key_(key) {}
+    explicit RecordingReclaimBackend(const KeyType key,
+                                     const int64_t lookup_timestamp = 0,
+                                     const ErrorCode lookup_result = EC_OK)
+        : key_(key), lookup_timestamp_(lookup_timestamp), lookup_result_(lookup_result) {}
 
     ErrorCode
     SampleReclaimCandidates(RequestContext *, int64_t count, ReclaimCandidateVector &out_candidates) noexcept override {
@@ -343,10 +346,21 @@ public:
     }
 
     int calls() const { return calls_; }
+    int timestamp_lookup_calls() const { return timestamp_lookup_calls_; }
+
+    std::vector<ErrorCode> GetLastAccessTimesForMaintenance(
+        RequestContext *, const KeyTypeVec &keys, std::vector<int64_t> &out_last_access_times) noexcept override {
+        ++timestamp_lookup_calls_;
+        out_last_access_times.assign(keys.size(), lookup_timestamp_);
+        return std::vector<ErrorCode>(keys.size(), lookup_result_);
+    }
 
 private:
     KeyType key_;
+    int64_t lookup_timestamp_;
+    ErrorCode lookup_result_;
     int calls_ = 0;
+    int timestamp_lookup_calls_ = 0;
 };
 
 } // namespace
@@ -481,10 +495,10 @@ TEST_F(MetaStorageBackendManagerTest, TestInitDualBackend) {
     ASSERT_EQ(EC_OK, mgr.Close());
 }
 
-TEST_F(MetaStorageBackendManagerTest, TestSampleReclaimCandidatesUsesOneBackendForWholeOperation) {
+TEST_F(MetaStorageBackendManagerTest, TestSampleReclaimCandidatesUsesHotCacheTimeDuringRecovery) {
     MetaStorageBackendManager mgr;
     auto persistent = std::make_unique<RecordingReclaimBackend>(11);
-    auto cache = std::make_unique<RecordingReclaimBackend>(22);
+    auto cache = std::make_unique<RecordingReclaimBackend>(22, 999);
     auto *persistent_ptr = persistent.get();
     auto *cache_ptr = cache.get();
     mgr.persistent_backend_ = std::move(persistent);
@@ -495,15 +509,49 @@ TEST_F(MetaStorageBackendManagerTest, TestSampleReclaimCandidatesUsesOneBackendF
     ASSERT_EQ(EC_OK, mgr.SampleReclaimCandidates(nullptr, 1, candidates));
     ASSERT_EQ(1, candidates.size());
     EXPECT_EQ(11, candidates.front().key);
+    EXPECT_EQ(999, candidates.front().last_access_time_us);
     EXPECT_EQ(1, persistent_ptr->calls());
     EXPECT_EQ(0, cache_ptr->calls());
+    EXPECT_EQ(1, cache_ptr->timestamp_lookup_calls());
 
     mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning, std::memory_order_release);
     ASSERT_EQ(EC_OK, mgr.SampleReclaimCandidates(nullptr, 1, candidates));
     ASSERT_EQ(1, candidates.size());
     EXPECT_EQ(22, candidates.front().key);
+    EXPECT_EQ(220, candidates.front().last_access_time_us);
     EXPECT_EQ(1, persistent_ptr->calls());
     EXPECT_EQ(1, cache_ptr->calls());
+    EXPECT_EQ(1, cache_ptr->timestamp_lookup_calls());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestSampleReclaimCandidatesFallsBackForRecoveryCacheMiss) {
+    MetaStorageBackendManager mgr;
+    auto persistent = std::make_unique<RecordingReclaimBackend>(11);
+    auto cache = std::make_unique<RecordingReclaimBackend>(22, 0, EC_NOENT);
+    auto *cache_ptr = cache.get();
+    mgr.persistent_backend_ = std::move(persistent);
+    mgr.cache_backend_ = std::move(cache);
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover, std::memory_order_release);
+
+    ReclaimCandidateVector candidates;
+    ASSERT_EQ(EC_OK, mgr.SampleReclaimCandidates(nullptr, 1, candidates));
+    ASSERT_EQ(1, candidates.size());
+    EXPECT_EQ(11, candidates.front().key);
+    EXPECT_EQ(110, candidates.front().last_access_time_us);
+    EXPECT_EQ(1, cache_ptr->timestamp_lookup_calls());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestSampleReclaimCandidatesStopsOnRecoveryCacheReadFailure) {
+    MetaStorageBackendManager mgr;
+    auto persistent = std::make_unique<RecordingReclaimBackend>(11);
+    auto cache = std::make_unique<RecordingReclaimBackend>(22, 0, EC_ERROR);
+    mgr.persistent_backend_ = std::move(persistent);
+    mgr.cache_backend_ = std::move(cache);
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover, std::memory_order_release);
+
+    ReclaimCandidateVector candidates;
+    EXPECT_EQ(EC_ERROR, mgr.SampleReclaimCandidates(nullptr, 1, candidates));
+    EXPECT_TRUE(candidates.empty());
 }
 
 TEST_F(MetaStorageBackendManagerTest, TestInitIsTransactionalAndOneShot) {

--- a/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
+++ b/kv_cache_manager/meta/test/meta_storage_backend_manager_test.cc
@@ -328,6 +328,27 @@ private:
     std::shared_ptr<BackendLifecycleCalls> calls_;
 };
 
+class RecordingReclaimBackend : public MetaLocalBackend {
+public:
+    explicit RecordingReclaimBackend(const KeyType key) : key_(key) {}
+
+    ErrorCode
+    SampleReclaimCandidates(RequestContext *, int64_t count, ReclaimCandidateVector &out_candidates) noexcept override {
+        ++calls_;
+        out_candidates.clear();
+        if (count > 0) {
+            out_candidates.push_back({key_, key_ * 10});
+        }
+        return EC_OK;
+    }
+
+    int calls() const { return calls_; }
+
+private:
+    KeyType key_;
+    int calls_ = 0;
+};
+
 } // namespace
 
 class MetaStorageBackendManagerTest : public TESTBASE {
@@ -458,6 +479,31 @@ TEST_F(MetaStorageBackendManagerTest, TestInitDualBackend) {
     ASSERT_EQ(EC_OK, mgr.Open());
     WaitRunning(mgr);
     ASSERT_EQ(EC_OK, mgr.Close());
+}
+
+TEST_F(MetaStorageBackendManagerTest, TestSampleReclaimCandidatesUsesOneBackendForWholeOperation) {
+    MetaStorageBackendManager mgr;
+    auto persistent = std::make_unique<RecordingReclaimBackend>(11);
+    auto cache = std::make_unique<RecordingReclaimBackend>(22);
+    auto *persistent_ptr = persistent.get();
+    auto *cache_ptr = cache.get();
+    mgr.persistent_backend_ = std::move(persistent);
+    mgr.cache_backend_ = std::move(cache);
+
+    ReclaimCandidateVector candidates;
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover, std::memory_order_release);
+    ASSERT_EQ(EC_OK, mgr.SampleReclaimCandidates(nullptr, 1, candidates));
+    ASSERT_EQ(1, candidates.size());
+    EXPECT_EQ(11, candidates.front().key);
+    EXPECT_EQ(1, persistent_ptr->calls());
+    EXPECT_EQ(0, cache_ptr->calls());
+
+    mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning, std::memory_order_release);
+    ASSERT_EQ(EC_OK, mgr.SampleReclaimCandidates(nullptr, 1, candidates));
+    ASSERT_EQ(1, candidates.size());
+    EXPECT_EQ(22, candidates.front().key);
+    EXPECT_EQ(1, persistent_ptr->calls());
+    EXPECT_EQ(1, cache_ptr->calls());
 }
 
 TEST_F(MetaStorageBackendManagerTest, TestInitIsTransactionalAndOneShot) {
@@ -1070,14 +1116,12 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteMirrorsPersistentAndH
 
     int32_t reclaimed_count = 0;
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              mgr.DeleteLocationsForMaintenance(
-                  request_context_.get(), {888}, {{"loc_888"}}, reclaimed_count));
+              mgr.DeleteLocationsForMaintenance(request_context_.get(), {888}, {{"loc_888"}}, reclaimed_count));
     EXPECT_EQ(0, reclaimed_count);
 
     CacheLocationMapVector hot_locations;
     CacheLocationMapVector persistent_locations;
-    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              mgr.cache_backend_->GetLocations(nullptr, {888}, hot_locations));
+    ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), mgr.cache_backend_->GetLocations(nullptr, {888}, hot_locations));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
               mgr.persistent_backend_->GetLocations(nullptr, {888}, persistent_locations));
     ASSERT_EQ(1u, hot_locations.size());
@@ -1088,8 +1132,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteMirrorsPersistentAndH
     EXPECT_EQ(1u, persistent_locations[0].count("loc_second"));
 
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}),
-              mgr.DeleteLocationsForMaintenance(
-                  request_context_.get(), {888}, {{"loc_second"}}, reclaimed_count));
+              mgr.DeleteLocationsForMaintenance(request_context_.get(), {888}, {{"loc_second"}}, reclaimed_count));
     EXPECT_EQ(1, reclaimed_count);
     ASSERT_EQ(EC_OK, mgr.Close());
 }
@@ -1107,8 +1150,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteDefersDuringCachedRec
     mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRecover);
     int32_t reclaimed_count = 0;
     EXPECT_EQ((std::vector<ErrorCode>{EC_OUT_OF_LIMIT}),
-              mgr.DeleteLocationsForMaintenance(
-                  request_context_.get(), {889}, {{"loc_889"}}, reclaimed_count));
+              mgr.DeleteLocationsForMaintenance(request_context_.get(), {889}, {{"loc_889"}}, reclaimed_count));
     EXPECT_EQ(0, reclaimed_count);
 
     mgr.recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning);
@@ -1133,8 +1175,7 @@ TEST_F(MetaStorageBackendManagerTest, TestMaintenanceDeleteConvergesHotCopyAfter
 
     int32_t reclaimed_count = 0;
     EXPECT_EQ((std::vector<ErrorCode>{EC_OK}),
-              mgr.DeleteLocationsForMaintenance(
-                  request_context_.get(), {890}, {{"loc_890"}}, reclaimed_count));
+              mgr.DeleteLocationsForMaintenance(request_context_.get(), {890}, {{"loc_890"}}, reclaimed_count));
     EXPECT_EQ(1, reclaimed_count);
 
     CacheLocationMapVector hot_locations;

--- a/kv_cache_manager/meta/types.h
+++ b/kv_cache_manager/meta/types.h
@@ -35,6 +35,16 @@ using KeyVector = std::vector<KeyType>;
 // still reference the old `KeyTypeVec` spelling.
 using KeyTypeVec = KeyVector;
 
+// A key selected for LRU reclamation together with the access timestamp used
+// to rank it. A zero timestamp means that the backend could not provide a
+// usable value; callers preserve the historical best-effort behavior by
+// treating such candidates as the oldest entries.
+struct ReclaimCandidate {
+    KeyType key = 0;
+    int64_t last_access_time_us = 0;
+};
+using ReclaimCandidateVector = std::vector<ReclaimCandidate>;
+
 using FieldMap = std::map<std::string, std::string>;
 using FieldMapVec = std::vector<FieldMap>;
 


### PR DESCRIPTION
## 背景

Reclaimer 原先先采样 key，再通过通用 `GetProperties(LRU_TIME)` 读取排序时间。对于 LocalBackend，这个读取会更新访问时间并推进 LRU，导致采样动作本身把候选 key 变热，污染后续淘汰结果。

改为 no-touch 采样后，还需要处理两个相关边界：并发采样任务不能反复读取同一段本地 LRU 前缀；恢复期间不能仅使用持久层的旧访问时间淘汰已经在热缓存中被访问的 key。

## 改动

- 引入 `ReclaimCandidate {key, last_access_time_us}` 和 `SampleReclaimCandidates()`，贯通 backend、BackendManager、MetaIndexer 与 Reclaimer，使采样和排序依据由 backend 在同一逻辑操作中返回。
- LocalBackend 在 shard 锁内读取 key 与时间，不 touch LRU、不记录 revisit；通过 shard 轮转游标和 shard 内扫描游标，让多任务及后续轮次持续推进。单次扫描至多环绕一次且不重复 key。
- Redis/AsyncRedis 使用只读属性查询获取 `LRU_TIME`；缺失或非法时间保持历史 best-effort 语义并降级为 `0`。
- 恢复期间由 persistent backend 提供完整候选集，再用 hot cache 的精确 no-touch 时间覆盖命中项；cache miss 回退 persistent 时间，cache 读取错误则停止本次回收。
- Dummy backend 对 malformed/overflow 时间戳显式降级为 `0`。

## Reviewer 关注点

- LRU 扫描游标在删除、访问提升和 batch 路径下的生命周期。
- 恢复期 cache-first 时间覆盖以及 miss/error 的降级边界。
- 多任务采样覆盖率与最旧前缀被过滤时的推进能力。

## 验证

在隔离 Linux 容器、open-source dependency set、`--jobs=1` 下执行：

```bash
bazel test --jobs=1 --test_output=errors --test_tag_filters=-manual \
  //kv_cache_manager/common/test:LruCacheTest \
  //kv_cache_manager/meta/test:all \
  //kv_cache_manager/manager/test:CacheReclaimerTest \
  //kv_cache_manager/manager/test:MigrationManagerTest
```

共 13 个测试目标，全部通过。

---

## Background

The reclaimer previously sampled keys and then read `LRU_TIME` through the generic `GetProperties()` path. For LocalBackend, that read updates access time and promotes entries in the LRU, so sampling itself made candidate keys hot and distorted subsequent eviction decisions.

Once sampling became no-touch, two related edge cases also had to be addressed: concurrent sampling tasks must not repeatedly read the same local LRU prefix, and recovery must not rank hot cached keys solely by stale timestamps from the persistent layer.

## Changes

- Add `ReclaimCandidate {key, last_access_time_us}` and `SampleReclaimCandidates()` across backends, BackendManager, MetaIndexer, and Reclaimer, so each backend returns sampled keys and ranking timestamps as one logical operation.
- Read LocalBackend keys and timestamps under the shard lock without touching LRU state or recording revisit metrics. Rotating shard and per-shard scan cursors provide progress across tasks and rounds; each call wraps at most once and never repeats an entry within the call.
- Read `LRU_TIME` through read-only property queries in Redis/AsyncRedis. Missing or malformed timestamps preserve the historical best-effort behavior and degrade to `0`.
- During recovery, sample the complete candidate set from the persistent backend, then overlay cache hits with exact no-touch hot-cache timestamps. Cache misses retain persistent timestamps, while cache read errors abort the reclaim attempt.
- Explicitly degrade malformed and overflowing Dummy backend timestamps to `0`.

## Reviewer focus

- LRU scan-cursor lifetime across deletion, access promotion, and batch paths.
- Recovery-time cache-first timestamp overlay and its miss/error boundaries.
- Multi-task sampling coverage and progress when the oldest prefix is filtered out.

## Validation

Executed in an isolated Linux container with the open-source dependency set and `--jobs=1`:

```bash
bazel test --jobs=1 --test_output=errors --test_tag_filters=-manual \
  //kv_cache_manager/common/test:LruCacheTest \
  //kv_cache_manager/meta/test:all \
  //kv_cache_manager/manager/test:CacheReclaimerTest \
  //kv_cache_manager/manager/test:MigrationManagerTest
```

All 13 test targets passed.
