### PR TITLE
[manager] tune CacheReclaimer pending defaults

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,12 +114,12 @@ kvcm.meta_query.chunk_size=128
 kvcm.cache_reclaimer.inflight_delete_timeout_ms=60000
 
 # 单个 Instance Group × BaseStorageType 的未完成 Location 数和 bytes 上限。
-kvcm.cache_reclaimer.pending_location_limit_per_group_type=100000
-kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
+kvcm.cache_reclaimer.pending_location_limit_per_group_type=20000
+kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=1099511627776
 
 # 进程级未完成删除请求数和 bytes 上限。Future 终态前始终占用配额，credit 到期不返还。
 kvcm.cache_reclaimer.pending_delete_handler_limit=1024
-kvcm.cache_reclaimer.pending_bytes_limit=274877906944
+kvcm.cache_reclaimer.pending_bytes_limit=4398046511104
 
 # leader 后台 metadata GC，默认开启。处理超过 grace 的 CLS_WRITING、
 # MightExist 明确 missing 的普通 CLS_SERVING 以及 EventReport metadata 回收。

--- a/docs/design/cache_reclaimer_async_delete.md
+++ b/docs/design/cache_reclaimer_async_delete.md
@@ -3,7 +3,7 @@
 | 项目 | 内容 |
 |---|---|
 | 状态 | V1 已实现，包含 `CacheMetaDelRequest` 异步接口；未来扩展未纳入 |
-| 更新时间 | 2026-07-17 |
+| 更新时间 | 2026-09-03 |
 | 涉及模块 | `manager`、`meta`、`metrics`、`service` |
 | 关联需求 | [CacheReclaimer 过度逐出优化](https://project.aone.alibaba-inc.com/v2/project/2137612/req/74289896)、[Reclaimer 删除请求提交异步化改造](https://project.aone.alibaba-inc.com/v2/project/2137612/req/80484236) |
 | 历史参考 | [PR #161](https://github.com/alibaba/tair-kvcache/pull/161) |
@@ -416,10 +416,14 @@ V1 默认参数：
 | 配置 | 默认值 | 说明 |
 |---|---:|---|
 | `inflight_delete_timeout_ms` | 60000 | 删除 delay 之外允许 credit 继续生效的时间 |
-| `pending_location_limit_per_group_type` | 100000 | 单 Group × BaseStorageType 的 pending Location 上限 |
-| `pending_bytes_limit_per_group_type` | 64 GiB | 单 Group × BaseStorageType 的 pending bytes 上限 |
+| `pending_location_limit_per_group_type` | 20000 | 单 Group × BaseStorageType 的 pending Location 上限 |
+| `pending_bytes_limit_per_group_type` | 1 TiB | 单 Group × BaseStorageType 的 pending bytes 上限 |
 | `pending_delete_handler_limit` | 1024 | 进程级 pending 请求上限 |
-| `pending_bytes_limit` | 256 GiB | 进程级 pending bytes 上限 |
+| `pending_bytes_limit` | 4 TiB | 进程级 pending bytes 上限 |
+
+2026-09-03 调整默认值时，将单 Group × BaseStorageType 的 bytes 窗口从 64 GiB 放大到 1 TiB，避免大
+Location 场景过早被 bytes 限流；同时将 Location 数量上限从 100000 收紧到 20000，继续约束小 Location
+场景的并发删除规模。进程级 bytes 上限按原 1:4 比例同步设为 4 TiB，handler 上限保持 1024 不变。
 
 no-progress 默认复用 `cache_reclaimer_idle_interval_ms`；该值为 0 时使用 1ms 的安全下限。
 

--- a/kv_cache_manager/manager/cache_reclaimer.h
+++ b/kv_cache_manager/manager/cache_reclaimer.h
@@ -66,10 +66,10 @@ struct PlanExecuteResult;
 
 struct CacheReclaimerAsyncDeleteConfig {
     std::uint64_t inflight_delete_timeout_ms{60000};
-    std::uint64_t pending_location_limit_per_group_type{100000};
-    std::uint64_t pending_bytes_limit_per_group_type{64ULL * 1024 * 1024 * 1024};
+    std::uint64_t pending_location_limit_per_group_type{20000};
+    std::uint64_t pending_bytes_limit_per_group_type{1ULL * 1024 * 1024 * 1024 * 1024};
     std::uint64_t pending_delete_handler_limit{1024};
-    std::uint64_t pending_bytes_limit{256ULL * 1024 * 1024 * 1024};
+    std::uint64_t pending_bytes_limit{4ULL * 1024 * 1024 * 1024 * 1024};
 };
 
 /**

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -318,10 +318,10 @@ void ServerConfig::UpdateDefaultConfig() {
     cache_reclaimer_idle_interval_ms_ = 100;
     cache_reclaimer_worker_size_ = 16;
     cache_reclaimer_inflight_delete_timeout_ms_ = 60000;
-    cache_reclaimer_pending_location_limit_per_group_type_ = 100000;
-    cache_reclaimer_pending_bytes_limit_per_group_type_ = 64ULL * 1024 * 1024 * 1024;
+    cache_reclaimer_pending_location_limit_per_group_type_ = 20000;
+    cache_reclaimer_pending_bytes_limit_per_group_type_ = 1ULL * 1024 * 1024 * 1024 * 1024;
     cache_reclaimer_pending_delete_handler_limit_ = 1024;
-    cache_reclaimer_pending_bytes_limit_ = 256ULL * 1024 * 1024 * 1024;
+    cache_reclaimer_pending_bytes_limit_ = 4ULL * 1024 * 1024 * 1024 * 1024;
     cache_gc_enabled_ = true;
     cache_gc_scan_interval_ms_ = 1000;
     cache_gc_round_pause_ms_ = 2LL * 60 * 60 * 1000;

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -26,10 +26,10 @@ TEST_F(ServerConfigTest, TestSimple) {
         ASSERT_EQ(256u, config.GetMetaQueryParallelThreshold());
         ASSERT_EQ(128u, config.GetMetaQueryChunkSize());
         ASSERT_EQ(60000, config.GetCacheReclaimerInflightDeleteTimeoutMs());
-        ASSERT_EQ(100000, config.GetCacheReclaimerPendingLocationLimitPerGroupType());
-        ASSERT_EQ(64ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimitPerGroupType());
+        ASSERT_EQ(20000, config.GetCacheReclaimerPendingLocationLimitPerGroupType());
+        ASSERT_EQ(1ULL * 1024 * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimitPerGroupType());
         ASSERT_EQ(1024, config.GetCacheReclaimerPendingDeleteHandlerLimit());
-        ASSERT_EQ(256ULL * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimit());
+        ASSERT_EQ(4ULL * 1024 * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimit());
         ASSERT_TRUE(config.IsCacheGcEnabled());
         ASSERT_EQ(1000, config.GetCacheGcScanIntervalMs());
         ASSERT_EQ(7200000, config.GetCacheGcRoundPauseMs());

--- a/package/etc/default_server_config.conf
+++ b/package/etc/default_server_config.conf
@@ -82,12 +82,12 @@ kvcm.meta_query.chunk_size=128
 kvcm.cache_reclaimer.inflight_delete_timeout_ms=60000
 
 # 单个 Instance Group × Storage Type 的 pending Location 数与 bytes 上限
-kvcm.cache_reclaimer.pending_location_limit_per_group_type=100000
-kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=68719476736
+kvcm.cache_reclaimer.pending_location_limit_per_group_type=20000
+kvcm.cache_reclaimer.pending_bytes_limit_per_group_type=1099511627776
 
 # 进程级 pending 删除请求数与 bytes 上限
 kvcm.cache_reclaimer.pending_delete_handler_limit=1024
-kvcm.cache_reclaimer.pending_bytes_limit=274877906944
+kvcm.cache_reclaimer.pending_bytes_limit=4398046511104
 
 # 后台 metadata GC 默认开启，只在 leader 上运行。处理长期 WRITING、
 # MightExist 明确 missing 的普通 SERVING 以及 EventReport metadata 回收。


### PR DESCRIPTION
## 背景

#234 为防止异步删除期间重复选择 victim、造成过度逐出，引入了 per-Group/type 和进程级的 pending 数量与 bytes 限制。现有单 Group × BaseStorageType 64 GiB、进程级 256 GiB 的默认 bytes 窗口在大 Location workload 下会过早饱和，限制 Reclaimer 的删除提交吞吐。

默认值需要兼顾不同模型：放大 bytes 窗口以支持大 Location，同时收紧 pending Location 数量，继续为小 Location workload 保留明确的并发上界。

## 改动

- 将 `pending_location_limit_per_group_type` 从 100000 调整为 20000。
- 将 `pending_bytes_limit_per_group_type` 从 64 GiB 调整为 1 TiB。
- 保持进程级 `pending_delete_handler_limit` 为 1024。
- 将进程级 `pending_bytes_limit` 从 256 GiB 调整为 4 TiB，保持原有 1:4 比例。
- 同步 `CacheReclaimerAsyncDeleteConfig` fallback、`ServerConfig` fallback、包内默认配置、单元测试和文档。
- 补充设计说明，记录大/小 Location workload 之间的取舍。

本次只调整默认 admission 窗口，不改变异步删除、pending credit 或逐出选择逻辑。线上仍可按具体 workload 通过配置覆盖默认值。

---

## Background

#234 introduced per-Group/type and process-level pending count and byte limits to prevent repeatedly selecting the same victims and over-evicting while asynchronous deletions are still in flight. The existing defaults of 64 GiB per Group × BaseStorageType and 256 GiB process-wide can saturate too early for workloads with large Locations, limiting Reclaimer submission throughput.

The defaults also need to remain useful across model shapes: the byte window should be larger for large Locations, while a tighter pending Location count continues to provide an explicit concurrency bound for small-Location workloads.

## Changes

- Change `pending_location_limit_per_group_type` from 100000 to 20000.
- Change `pending_bytes_limit_per_group_type` from 64 GiB to 1 TiB.
- Keep the process-wide `pending_delete_handler_limit` at 1024.
- Change the process-wide `pending_bytes_limit` from 256 GiB to 4 TiB, preserving the existing 1:4 ratio.
- Keep the `CacheReclaimerAsyncDeleteConfig` fallback, `ServerConfig` fallback, packaged defaults, unit tests, and documentation aligned.
- Document the trade-off between large- and small-Location workloads.

This changes only the default admission windows. It does not alter asynchronous deletion, pending credit, or victim selection semantics. Deployments can continue to override these defaults for workload-specific tuning.

