### PR TITLE
[manager] reduce cache GC deletion log noise

### DIFF
--- a/docs/design/cache_garbage_collector.md
+++ b/docs/design/cache_garbage_collector.md
@@ -470,7 +470,9 @@ V1 只保留能回答“是否在扫描、发现了什么、删除是否卡住�
 | `cache_gc.inflight_delete_age_ms` | Gauge | 最老在途 Future 的年龄，无任务时为 0 |
 | `cache_gc.round_duration_ms` | Gauge | 最近一个 active round 耗时 |
 
-round 和结果日志包含 `round_id`、`instance_id`、target 数、result；扫描错误日志额外包含 cursor 和 error stage。正常逐 key 扫描不打 INFO，block/location 明细只在诊断级日志中输出，避免 GC 自身制造日志压力。
+每个 Instance 扫描完成后输出一次 INFO，包含扫描 key 数、batch 数、按原因成功提交的 Location 数和 inflight 限流 tick 数。`submitted_locations` 表示提交数量，不代表异步删除已完成；总数与 reason 明细由同一次遍历生成。正常 action 完成不逐条打印日志。
+
+GC 将 `MightExist` 已确认缺失的 URI 传给 Executor，跳过这些 URI 的物理删除并继续清理 metadata；`Delete` 返回 `EC_NOENT` 也视为幂等成功。真实存储删除失败由 Executor 按 URI 记录 WARN，包含 instance、storage、URI 和错误码。`PlanExecuteResult.error_logged` 仅在结果中的所有失败已有诊断时置为 true，GC 始终记录结果指标，但只对尚未记录的错误输出 action WARN；准入失败、worker 异常和 EventReport metadata 清理异常因此仍可见。扫描错误日志另带 cursor 和 error stage。
 
 上述固定指标和带 `reason/status/stage` 标签的指标族同时进入本地 registry、Prometheus 和 KMonitor；KMonitor 周期上报直接遍历 registry 中已 touched 的 series，避免另维护一份易遗漏的标签枚举。
 

--- a/kv_cache_manager/manager/cache_garbage_collector.cc
+++ b/kv_cache_manager/manager/cache_garbage_collector.cc
@@ -748,31 +748,33 @@ void CacheGarbageCollector::CompleteRound() noexcept {
     next_round_at_ = now + std::chrono::milliseconds(config_.round_pause_ms);
 }
 
-void CacheGarbageCollector::LogInstanceScanSummary(const InstanceScanEntry &entry) const noexcept {
-    const auto reason_count = [&entry](const char *reason) {
-        const auto it = entry.submitted_location_counts.find(reason);
-        return it == entry.submitted_location_counts.end() ? size_t{0} : it->second;
-    };
+std::pair<size_t, std::string>
+CacheGarbageCollector::BuildSubmittedLocationSummary(const std::map<std::string, size_t> &reason_counts) {
     size_t submitted_location_count = 0;
-    for (const auto &[reason, count] : entry.submitted_location_counts) {
-        (void)reason;
+    std::string reason_summary;
+    for (const auto &[reason, count] : reason_counts) {
+        if (!reason_summary.empty()) {
+            reason_summary += ',';
+        }
+        reason_summary += reason + '=' + std::to_string(count);
         submitted_location_count += count;
     }
+    return {submitted_location_count, reason_summary};
+}
+
+void CacheGarbageCollector::LogInstanceScanSummary(const InstanceScanEntry &entry) const noexcept {
+    const auto [submitted_location_count, reason_summary] =
+        BuildSubmittedLocationSummary(entry.submitted_location_counts);
     KVCM_LOG_INFO(
         "cache gc instance scan completed, round[%lu] group[%s] instance[%s] scanned_keys[%zu] scan_batches[%zu] "
-        "submitted_locations[%zu] reasons[orphan_writing=%zu,storage_missing=%zu,event_report_stale_snapshot=%zu,"
-        "event_report_down_host=%zu,event_report_recovery_absent_host=%zu] inflight_throttled_ticks[%zu]",
+        "submitted_locations[%zu] reasons[%s] inflight_throttled_ticks[%zu]",
         round_id_,
         entry.instance_group.c_str(),
         entry.instance_id.c_str(),
         entry.scanned_key_count,
         entry.scan_batch_count,
         submitted_location_count,
-        reason_count(kOrphanWritingReason),
-        reason_count(kStorageMissingReason),
-        reason_count(kEventReportStaleSnapshotReason),
-        reason_count(kEventReportDownHostReason),
-        reason_count(kEventReportRecoveryAbsentHostReason),
+        reason_summary.c_str(),
         entry.inflight_throttled_tick_count);
 }
 

--- a/kv_cache_manager/manager/cache_garbage_collector.cc
+++ b/kv_cache_manager/manager/cache_garbage_collector.cc
@@ -137,6 +137,7 @@ const char *MaintenanceUnknownReasonName(EventReportBackend::MaintenanceProbeUnk
 struct DeleteCandidate {
     std::string expected_location_value;
     CandidateReason reason{CandidateReason::kOrphanWriting};
+    std::set<std::string> confirmed_missing_uris;
     std::shared_ptr<EventReportBackend> event_report_backend;
     std::string event_report_backend_unique_name;
     std::optional<EventReportBackend::MaintenanceCleanupToken> event_report_cleanup_token;
@@ -145,7 +146,7 @@ struct DeleteCandidate {
 struct ServingProbe {
     CandidateKey key;
     CacheLocationConstPtr location;
-    bool storage_missing{false};
+    std::set<std::string> confirmed_missing_uris;
 };
 
 struct StorageProbeBatch {
@@ -346,6 +347,9 @@ void CacheGarbageCollector::RunOneTick() noexcept {
         }
         PollInflightDeletes();
         if (inflight_deletes_.size() >= config_.max_inflight_delete_requests) {
+            if (round_active_ && instance_index_ < instances_.size()) {
+                ++instances_[instance_index_].inflight_throttled_tick_count;
+            }
             return;
         }
         if (stop_requested_.load(std::memory_order_acquire)) {
@@ -411,6 +415,8 @@ void CacheGarbageCollector::RunOneTick() noexcept {
         }
 
         entry.scan_failure_count = 0;
+        entry.scanned_key_count += batch.keys.size();
+        ++entry.scan_batch_count;
         METRICS_(cache_gc, scan_key_count) += batch.keys.size();
         entry.cursor = batch.next_cursor;
         if (stop_requested_.load(std::memory_order_acquire)) {
@@ -418,7 +424,7 @@ void CacheGarbageCollector::RunOneTick() noexcept {
         }
         ScanDeleteActions actions = BuildDeleteActions(entry.instance_id, batch, TimestampUtil::GetCurrentTimeUs());
         const std::string instance_id = entry.instance_id;
-        AdvanceInstance(entry.cursor == SCAN_BASE_CURSOR);
+        const bool scan_completed = entry.cursor == SCAN_BASE_CURSOR;
 
         if (stop_requested_.load(std::memory_order_acquire)) {
             return;
@@ -426,7 +432,8 @@ void CacheGarbageCollector::RunOneTick() noexcept {
 
         auto submit_and_track = [&](auto &request,
                                     std::vector<PendingLocationKey> request_targets,
-                                    const char *action_name) {
+                                    const char *action_name,
+                                    const std::map<std::string, size_t> &reason_counts) {
             if (request_targets.empty() || inflight_deletes_.size() >= config_.max_inflight_delete_requests) {
                 return false;
             }
@@ -505,6 +512,9 @@ void CacheGarbageCollector::RunOneTick() noexcept {
                 return false;
             }
             METRICS_(cache_gc, delete_target_count) += request_targets.size();
+            for (const auto &[reason, count] : reason_counts) {
+                entry.submitted_location_counts[reason] += count;
+            }
             return true;
         };
 
@@ -514,7 +524,8 @@ void CacheGarbageCollector::RunOneTick() noexcept {
                 physical_targets.push_back({instance_id, actions.executor_request.block_keys[i], location_id});
             }
         }
-        submit_and_track(actions.executor_request, std::move(physical_targets), "physical_delete");
+        submit_and_track(
+            actions.executor_request, std::move(physical_targets), "physical_delete", actions.executor_reason_counts);
 
         std::vector<PendingLocationKey> event_report_targets;
         for (size_t i = 0; i < actions.event_report_request.block_keys.size(); ++i) {
@@ -532,9 +543,16 @@ void CacheGarbageCollector::RunOneTick() noexcept {
                 }
             }
         } else {
-            submit_and_track(actions.event_report_request, std::move(event_report_targets), "event_report_metadata");
+            submit_and_track(actions.event_report_request,
+                             std::move(event_report_targets),
+                             "event_report_metadata",
+                             actions.event_report_reason_counts);
         }
         UpdateInflightDeleteMetrics();
+        if (scan_completed) {
+            LogInstanceScanSummary(entry);
+        }
+        AdvanceInstance(scan_completed);
     } catch (const std::exception &e) {
         RecordOperationError("tick_exception");
         KVCM_LOG_ERROR("cache gc tick threw exception: %s", e.what());
@@ -611,13 +629,7 @@ void CacheGarbageCollector::PollInflightDeletes() noexcept {
             }
             const PlanExecuteResult result = it->future.get();
             RecordDeleteResult(std::to_string(static_cast<int>(result.status)));
-            if (result.status == EC_OK) {
-                KVCM_LOG_DEBUG("cache gc action completed, round[%lu] instance[%s] action[%s] targets[%zu]",
-                               round_id,
-                               instance_id.c_str(),
-                               action_name.c_str(),
-                               target_count);
-            } else {
+            if (result.status != EC_OK) {
                 KVCM_LOG_WARN(
                     "cache gc action completed with status[%d], round[%lu] instance[%s] action[%s] targets[%zu] "
                     "error[%s]",
@@ -736,6 +748,34 @@ void CacheGarbageCollector::CompleteRound() noexcept {
     next_round_at_ = now + std::chrono::milliseconds(config_.round_pause_ms);
 }
 
+void CacheGarbageCollector::LogInstanceScanSummary(const InstanceScanEntry &entry) const noexcept {
+    const auto reason_count = [&entry](const char *reason) {
+        const auto it = entry.submitted_location_counts.find(reason);
+        return it == entry.submitted_location_counts.end() ? size_t{0} : it->second;
+    };
+    size_t submitted_location_count = 0;
+    for (const auto &[reason, count] : entry.submitted_location_counts) {
+        (void)reason;
+        submitted_location_count += count;
+    }
+    KVCM_LOG_INFO(
+        "cache gc instance scan completed, round[%lu] group[%s] instance[%s] scanned_keys[%zu] scan_batches[%zu] "
+        "submitted_locations[%zu] reasons[orphan_writing=%zu,storage_missing=%zu,event_report_stale_snapshot=%zu,"
+        "event_report_down_host=%zu,event_report_recovery_absent_host=%zu] inflight_throttled_ticks[%zu]",
+        round_id_,
+        entry.instance_group.c_str(),
+        entry.instance_id.c_str(),
+        entry.scanned_key_count,
+        entry.scan_batch_count,
+        submitted_location_count,
+        reason_count(kOrphanWritingReason),
+        reason_count(kStorageMissingReason),
+        reason_count(kEventReportStaleSnapshotReason),
+        reason_count(kEventReportDownHostReason),
+        reason_count(kEventReportRecoveryAbsentHostReason),
+        entry.inflight_throttled_tick_count);
+}
+
 void CacheGarbageCollector::AdvanceInstance(bool completed_current) noexcept {
     if (instances_.empty() || instance_index_ >= instances_.size()) {
         CompleteRound();
@@ -798,7 +838,10 @@ CacheGarbageCollector::ScanDeleteActions CacheGarbageCollector::BuildDeleteActio
                     continue;
                 }
                 candidates.emplace(candidate_key,
-                                   DeleteCandidate{location->ToJsonString(), CandidateReason::kOrphanWriting});
+                                   DeleteCandidate{
+                                       .expected_location_value = location->ToJsonString(),
+                                       .reason = CandidateReason::kOrphanWriting,
+                                   });
                 continue;
             }
 
@@ -871,7 +914,7 @@ CacheGarbageCollector::ScanDeleteActions CacheGarbageCollector::BuildDeleteActio
             }
 
             const size_t serving_probe_index = serving_probes.size();
-            serving_probes.push_back({candidate_key, location, false});
+            serving_probes.push_back({candidate_key, location});
             for (auto &[storage_name, uri] : parsed_uris) {
                 auto &probe_batch = storage_probe_batches[{storage_name, storage_type}];
                 probe_batch.uris.emplace_back(std::move(uri));
@@ -930,7 +973,8 @@ CacheGarbageCollector::ScanDeleteActions CacheGarbageCollector::BuildDeleteActio
                 }
                 for (size_t i = 0; i < might_exist.size(); ++i) {
                     if (!might_exist[i]) {
-                        serving_probes[probe_batch.serving_probe_indexes[offset + i]].storage_missing = true;
+                        serving_probes[probe_batch.serving_probe_indexes[offset + i]].confirmed_missing_uris.insert(
+                            uris[i].ToUriString());
                     }
                 }
             }
@@ -1018,9 +1062,13 @@ CacheGarbageCollector::ScanDeleteActions CacheGarbageCollector::BuildDeleteActio
     }
 
     for (auto &probe : serving_probes) {
-        if (probe.storage_missing) {
+        if (!probe.confirmed_missing_uris.empty()) {
             candidates.emplace(std::move(probe.key),
-                               DeleteCandidate{probe.location->ToJsonString(), CandidateReason::kStorageMissing});
+                               DeleteCandidate{
+                                   .expected_location_value = probe.location->ToJsonString(),
+                                   .reason = CandidateReason::kStorageMissing,
+                                   .confirmed_missing_uris = std::move(probe.confirmed_missing_uris),
+                               });
         }
     }
 
@@ -1082,10 +1130,14 @@ CacheGarbageCollector::ScanDeleteActions CacheGarbageCollector::BuildDeleteActio
                 .cleanup_token = candidate.event_report_cleanup_token.value(),
             });
             event_report_selected_keys.insert(block_key);
+            ++actions.event_report_reason_counts[CandidateReasonName(candidate.reason)];
         } else {
             auto &block_targets = executor_targets[block_key];
             block_targets.location_ids.push_back(location_id);
             block_targets.expected_location_values.push_back(candidate.expected_location_value);
+            actions.executor_request.confirmed_missing_uris.insert(candidate.confirmed_missing_uris.begin(),
+                                                                   candidate.confirmed_missing_uris.end());
+            ++actions.executor_reason_counts[CandidateReasonName(candidate.reason)];
         }
         ++selected;
     }

--- a/kv_cache_manager/manager/cache_garbage_collector.cc
+++ b/kv_cache_manager/manager/cache_garbage_collector.cc
@@ -629,7 +629,7 @@ void CacheGarbageCollector::PollInflightDeletes() noexcept {
             }
             const PlanExecuteResult result = it->future.get();
             RecordDeleteResult(std::to_string(static_cast<int>(result.status)));
-            if (result.status != EC_OK) {
+            if (result.status != EC_OK && !result.error_logged) {
                 KVCM_LOG_WARN(
                     "cache gc action completed with status[%d], round[%lu] instance[%s] action[%s] targets[%zu] "
                     "error[%s]",
@@ -762,7 +762,7 @@ CacheGarbageCollector::BuildSubmittedLocationSummary(const std::map<std::string,
     return {submitted_location_count, reason_summary};
 }
 
-void CacheGarbageCollector::LogInstanceScanSummary(const InstanceScanEntry &entry) const noexcept {
+void CacheGarbageCollector::LogInstanceScanSummary(const InstanceScanEntry &entry) const {
     const auto [submitted_location_count, reason_summary] =
         BuildSubmittedLocationSummary(entry.submitted_location_counts);
     KVCM_LOG_INFO(

--- a/kv_cache_manager/manager/cache_garbage_collector.h
+++ b/kv_cache_manager/manager/cache_garbage_collector.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "kv_cache_manager/common/error_code.h"
@@ -165,6 +166,8 @@ private:
     void ReleasePendingLocations(const InflightDelete &inflight) noexcept;
     bool BeginRound();
     void CompleteRound() noexcept;
+    static std::pair<size_t, std::string>
+    BuildSubmittedLocationSummary(const std::map<std::string, size_t> &reason_counts);
     void LogInstanceScanSummary(const InstanceScanEntry &entry) const noexcept;
     void AdvanceInstance(bool completed_current) noexcept;
     ScanDeleteActions

--- a/kv_cache_manager/manager/cache_garbage_collector.h
+++ b/kv_cache_manager/manager/cache_garbage_collector.h
@@ -103,6 +103,10 @@ private:
         std::string cursor{SCAN_BASE_CURSOR};
         bool completed{false};
         size_t scan_failure_count{0};
+        size_t scanned_key_count{0};
+        size_t scan_batch_count{0};
+        size_t inflight_throttled_tick_count{0};
+        std::map<std::string, size_t> submitted_location_counts;
 
         bool operator<(const InstanceScanEntry &other) const {
             return std::tie(instance_group, instance_id) < std::tie(other.instance_group, other.instance_id);
@@ -149,6 +153,8 @@ private:
     struct ScanDeleteActions {
         CacheLocationDelRequest executor_request;
         EventReportMetadataDelRequest event_report_request;
+        std::map<std::string, size_t> executor_reason_counts;
+        std::map<std::string, size_t> event_report_reason_counts;
     };
 
     void RunOneTick() noexcept;
@@ -159,6 +165,7 @@ private:
     void ReleasePendingLocations(const InflightDelete &inflight) noexcept;
     bool BeginRound();
     void CompleteRound() noexcept;
+    void LogInstanceScanSummary(const InstanceScanEntry &entry) const noexcept;
     void AdvanceInstance(bool completed_current) noexcept;
     ScanDeleteActions
     BuildDeleteActions(const std::string &instance_id, const MaintenanceScanBatch &batch, int64_t now_us);

--- a/kv_cache_manager/manager/cache_garbage_collector.h
+++ b/kv_cache_manager/manager/cache_garbage_collector.h
@@ -168,7 +168,7 @@ private:
     void CompleteRound() noexcept;
     static std::pair<size_t, std::string>
     BuildSubmittedLocationSummary(const std::map<std::string, size_t> &reason_counts);
-    void LogInstanceScanSummary(const InstanceScanEntry &entry) const noexcept;
+    void LogInstanceScanSummary(const InstanceScanEntry &entry) const;
     void AdvanceInstance(bool completed_current) noexcept;
     ScanDeleteActions
     BuildDeleteActions(const std::string &instance_id, const MaintenanceScanBatch &batch, int64_t now_us);

--- a/kv_cache_manager/manager/cache_reclaimer.cc
+++ b/kv_cache_manager/manager/cache_reclaimer.cc
@@ -2205,14 +2205,15 @@ void CacheReclaimer::HandleDelRes() noexcept {
             bool terminal = false;
             ErrorCode result_code = ErrorCode::EC_ERROR;
             try {
-                const auto [ec, err_msg] = it->fut_.get();
+                const auto result = it->fut_.get();
+                const auto ec = result.status;
                 terminal = true;
                 result_code = ec;
                 if (ec != ErrorCode::EC_OK) {
                     LOG_WITH_ID(WARN,
                                 "reclaim request execute failed, error_code: [%d], error message: [%s]",
                                 static_cast<std::int32_t>(ec),
-                                err_msg.c_str());
+                                result.error_message.c_str());
                 } else {
                     METRICS_(cache_reclaimer, block_del_count) += it->blk_count_;
                     METRICS_(cache_reclaimer, location_del_count) += it->loc_count_;

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -324,6 +324,9 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
                 for (const auto &loc_spec : iter->second->location_specs()) {
                     DataStorageUri uri(loc_spec.uri());
                     if (uri.Valid()) {
+                        if (task.confirmed_missing_uris.find(uri.ToUriString()) != task.confirmed_missing_uris.end()) {
+                            continue;
+                        }
                         std::string storage_unique_name = uri.GetHostName();
                         delete_uris_by_unique_name[storage_unique_name].emplace_back(uri);
                     }
@@ -355,16 +358,30 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             KVCM_LOG_WARN("%s", result.error_message.c_str());
         }
         const auto result_count = std::min(delete_results.size(), storage_uris.size());
+        size_t failed_count = 0;
+        size_t first_failed_index = 0;
         for (size_t i = 0; i < result_count; ++i) {
-            if (delete_results[i] != ErrorCode::EC_OK) {
-                // 这里存储删除报错暂且不管，报个warn表示哪个storageUri删失败了
-                result.status = ErrorCode::EC_PARTIAL_OK;
-                KVCM_LOG_WARN("storage delete failed, instance[%s] storage[%s] uri[%s] ec[%d]",
-                              task.instance_id.c_str(),
-                              storage_unique_name.c_str(),
-                              storage_uris[i].ToUriString().c_str(),
-                              static_cast<int>(delete_results[i]));
+            if (delete_results[i] != ErrorCode::EC_OK && delete_results[i] != ErrorCode::EC_NOENT) {
+                if (failed_count == 0) {
+                    first_failed_index = i;
+                }
+                ++failed_count;
             }
+        }
+        if (failed_count > 0) {
+            result.status = ErrorCode::EC_PARTIAL_OK;
+            const std::string failure_message = StringUtil::FormatString(
+                "storage delete failed, instance[%s] storage[%s] failed[%zu] total[%zu] first_uri[%s] first_ec[%d]",
+                task.instance_id.c_str(),
+                storage_unique_name.c_str(),
+                failed_count,
+                storage_uris.size(),
+                storage_uris[first_failed_index].ToUriString().c_str(),
+                static_cast<int>(delete_results[first_failed_index]));
+            if (result.error_message.empty()) {
+                result.error_message = failure_message;
+            }
+            KVCM_LOG_WARN("%s", failure_message.c_str());
         }
     }
 
@@ -404,8 +421,6 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             }
         }
     }
-    KVCM_LOG_DEBUG("DoDelLocationTask completed successfully for instance_id: %s", task.instance_id.c_str());
-
     return result;
 }
 
@@ -634,6 +649,7 @@ SchedulePlanExecutor::PrepareDeleteTask(const CacheLocationDelRequest &task) {
                                         task.delay,
                                         task.authoritative_read);
     result.actual_task.metadata_only = task.metadata_only;
+    result.actual_task.confirmed_missing_uris = task.confirmed_missing_uris;
     return result;
 }
 

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -324,7 +324,8 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
                 for (const auto &loc_spec : iter->second->location_specs()) {
                     DataStorageUri uri(loc_spec.uri());
                     if (uri.Valid()) {
-                        if (task.confirmed_missing_uris.find(uri.ToUriString()) != task.confirmed_missing_uris.end()) {
+                        if (!task.confirmed_missing_uris.empty() &&
+                            task.confirmed_missing_uris.find(uri.ToUriString()) != task.confirmed_missing_uris.end()) {
                             continue;
                         }
                         std::string storage_unique_name = uri.GetHostName();
@@ -353,8 +354,12 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             data_storage_manager_->Delete(request_context.get(), storage_unique_name, storage_uris, nullptr);
         if (delete_results.size() != storage_uris.size()) {
             result.status = ErrorCode::EC_PARTIAL_OK;
-            result.error_message = StringUtil::FormatString(
-                "storage delete result size %zu != request size %zu", delete_results.size(), storage_uris.size());
+            result.error_message =
+                StringUtil::FormatString("storage delete result size %zu != request size %zu, instance[%s] storage[%s]",
+                                         delete_results.size(),
+                                         storage_uris.size(),
+                                         task.instance_id.c_str(),
+                                         storage_unique_name.c_str());
             KVCM_LOG_WARN("%s", result.error_message.c_str());
         }
         const auto result_count = std::min(delete_results.size(), storage_uris.size());
@@ -366,6 +371,11 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
                     first_failed_index = i;
                 }
                 ++failed_count;
+                KVCM_LOG_WARN("storage delete failed, instance[%s] storage[%s] uri[%s] ec[%d]",
+                              task.instance_id.c_str(),
+                              storage_unique_name.c_str(),
+                              storage_uris[i].ToUriString().c_str(),
+                              static_cast<int>(delete_results[i]));
             }
         }
         if (failed_count > 0) {
@@ -381,7 +391,6 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             if (result.error_message.empty()) {
                 result.error_message = failure_message;
             }
-            KVCM_LOG_WARN("%s", failure_message.c_str());
         }
     }
 
@@ -393,7 +402,8 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
         if (delete_meta_ec != ErrorCode::EC_OK || delete_meta_results.size() != batch_cad_tasks.size()) {
             result.status = ErrorCode::EC_PARTIAL_OK;
             result.error_message =
-                StringUtil::FormatString("location CAD failed, ec: %d, result size %zu != task size %zu",
+                StringUtil::FormatString("location CAD failed, instance[%s] ec: %d, result size %zu != task size %zu",
+                                         task.instance_id.c_str(),
                                          static_cast<int>(delete_meta_ec),
                                          delete_meta_results.size(),
                                          batch_cad_tasks.size());
@@ -404,16 +414,18 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             auto &results = delete_meta_results[block_key_idx];
             if (results.size() != batch_cad_tasks[block_key_idx].size()) {
                 result.status = ErrorCode::EC_PARTIAL_OK;
-                KVCM_LOG_WARN("location CAD result size %zu != task size %zu for block key %ld",
+                KVCM_LOG_WARN("location CAD result size %zu != task size %zu, instance[%s] block key %ld",
                               results.size(),
                               batch_cad_tasks[block_key_idx].size(),
+                              task.instance_id.c_str(),
                               block_keys_to_delete[block_key_idx]);
             }
             const auto location_result_count = std::min(results.size(), batch_cad_tasks[block_key_idx].size());
             for (size_t location_idx = 0; location_idx < location_result_count; location_idx++) {
                 if (results[location_idx] != ErrorCode::EC_OK) {
                     result.status = ErrorCode::EC_PARTIAL_OK;
-                    KVCM_LOG_WARN("Failed to CAD meta key %ld, location: %s, error_code: %d",
+                    KVCM_LOG_WARN("Failed to CAD meta, instance[%s] key %ld, location: %s, error_code: %d",
+                                  task.instance_id.c_str(),
                                   block_keys_to_delete[block_key_idx],
                                   batch_cad_tasks[block_key_idx][location_idx].location_id.c_str(),
                                   static_cast<int>(results[location_idx]));
@@ -421,6 +433,9 @@ PlanExecuteResult SchedulePlanExecutor::DoLocationDelTask(const CacheLocationDel
             }
         }
     }
+    // All storage/CAD failures above have detailed diagnostics. Early returns
+    // and worker exceptions keep the default false so callers still log them.
+    result.error_logged = result.status != ErrorCode::EC_OK;
     return result;
 }
 

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -65,6 +65,10 @@ struct CacheLocationDelRequest {
     // GC physical deletion revalidates against the persistent source of truth
     // and refreshes candidate keys into the hot cache before CAS.
     bool authoritative_read{false};
+    // URIs that the submitter has already confirmed absent. Physical deletion
+    // skips these idempotently while still deleting any remaining specs in the
+    // same Location.
+    std::set<std::string> confirmed_missing_uris;
 };
 
 struct EventReportMetadataDeleteTarget {

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -44,6 +44,9 @@ struct CacheMetaDelRequest {
 struct PlanExecuteResult {
     ErrorCode status;
     std::string error_message;
+    // True only when every failure in this result has already been logged.
+    // Callers can retain result metrics without repeating the diagnostics.
+    bool error_logged{false};
 };
 
 struct AsyncDeleteSubmitResult {

--- a/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
+++ b/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
@@ -1046,8 +1046,8 @@ TEST_F(CacheGarbageCollectorTest, ServingMissingSpecIsBatchedAndSubmittedWithExa
         MakeStoredLocation("second_missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_b_uri});
 
     const auto batch = MakeBatch(SCAN_BASE_CURSOR, {10, 20}, {first_locations, second_locations});
-    const CacheLocationDelRequest request =
-        gc->BuildDeleteActions("instance_a", batch, TimestampUtil::GetCurrentTimeUs()).executor_request;
+    const auto actions = gc->BuildDeleteActions("instance_a", batch, TimestampUtil::GetCurrentTimeUs());
+    const CacheLocationDelRequest &request = actions.executor_request;
 
     EXPECT_EQ((KeyVector{10, 20}), request.block_keys);
     EXPECT_EQ((std::vector<std::vector<std::string>>{{"old_writing", "serving_missing"}, {"second_missing"}}),
@@ -1056,6 +1056,9 @@ TEST_F(CacheGarbageCollectorTest, ServingMissingSpecIsBatchedAndSubmittedWithExa
                                                       first_locations.at("serving_missing")->ToJsonString()},
                                                      {second_locations.at("second_missing")->ToJsonString()}}),
               request.expected_location_values);
+    EXPECT_EQ((std::set<std::string>{missing_a_uri, missing_b_uri}), request.confirmed_missing_uris);
+    EXPECT_EQ(1u, actions.executor_reason_counts.at("orphan_writing"));
+    EXPECT_EQ(2u, actions.executor_reason_counts.at("storage_missing"));
 
     ASSERT_EQ(2, might_exist_calls.size());
     const auto storage_a_call =
@@ -1292,6 +1295,38 @@ TEST_F(CacheGarbageCollectorTest, TickScansOneBatchAndSubmitsConditionalAsyncDel
     EXPECT_TRUE(submitted_requests.front().authoritative_read);
     EXPECT_EQ(1, gc->inflight_deletes_.size());
     EXPECT_EQ(1, gc->pending_locations_.size());
+}
+
+TEST_F(CacheGarbageCollectorTest, TickTracksPerInstanceScanAndSubmittedReasonSummary) {
+    auto config = DefaultConfig();
+    config.scan_batch_size = 10;
+    config.max_inflight_delete_requests = 1;
+    submit_mode = SubmitMode::kPending;
+    const std::string missing_uri = "dummy://storage_a/missing?size=1";
+    might_exist_by_uri[missing_uri] = false;
+
+    CacheLocationMap locations;
+    locations["old_writing"] = MakeLocation("old_writing", CLS_WRITING, OldCreateTimeUs(config, 1));
+    locations["serving_missing"] =
+        MakeStoredLocation("serving_missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_uri});
+    scan_responses["instance_a"] = {{EC_OK, MakeBatch("next_cursor", {100}, {locations})}};
+
+    auto gc = MakeGc(config);
+    PrepareForSingleStep(*gc);
+    gc->RunOneTick();
+
+    ASSERT_EQ(1u, gc->instances_.size());
+    const auto &entry = gc->instances_.front();
+    EXPECT_EQ(1u, entry.scanned_key_count);
+    EXPECT_EQ(1u, entry.scan_batch_count);
+    EXPECT_EQ(1u, entry.submitted_location_counts.at("orphan_writing"));
+    EXPECT_EQ(1u, entry.submitted_location_counts.at("storage_missing"));
+    EXPECT_EQ(0u, entry.inflight_throttled_tick_count);
+
+    gc->RunOneTick();
+    EXPECT_EQ(1u, gc->instances_.front().inflight_throttled_tick_count);
+    ASSERT_TRUE(pending_delete_promise);
+    pending_delete_promise->set_value({EC_OK, ""});
 }
 
 TEST_F(CacheGarbageCollectorTest, ScanFailureRetriesSameCursorWithoutBusyLoop) {

--- a/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
+++ b/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
@@ -1329,6 +1329,16 @@ TEST_F(CacheGarbageCollectorTest, TickTracksPerInstanceScanAndSubmittedReasonSum
     pending_delete_promise->set_value({EC_OK, ""});
 }
 
+TEST_F(CacheGarbageCollectorTest, SubmittedLocationSummaryIncludesEveryReason) {
+    const auto [submitted_location_count, reason_summary] = CacheGarbageCollector::BuildSubmittedLocationSummary({
+        {"orphan_writing", 90},
+        {"future_reason", 10},
+    });
+
+    EXPECT_EQ(100u, submitted_location_count);
+    EXPECT_EQ("future_reason=10,orphan_writing=90", reason_summary);
+}
+
 TEST_F(CacheGarbageCollectorTest, ScanFailureRetriesSameCursorWithoutBusyLoop) {
     scan_responses["instance_a"] = {
         {EC_ERROR, {}},

--- a/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
+++ b/kv_cache_manager/manager/test/cache_garbage_collector_test.cc
@@ -4,6 +4,7 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <new>
 #include <set>
 #include <shared_mutex>
 #include <stdexcept>
@@ -52,6 +53,15 @@ struct MightExistCall {
     std::vector<DataStorageUri> uris;
     bool fastpath{false};
 };
+
+std::atomic<size_t> gc_action_warn_count{0};
+void CountGcActionWarnings(int level, const char *, int, const char *func, const char *, ...) {
+    if (level == Logger::LEVEL_WARN && std::string(func) == "PollInflightDeletes") {
+        ++gc_action_warn_count;
+    }
+}
+
+std::pair<size_t, std::string> ThrowScanSummaryStub(const std::map<std::string, size_t> &) { throw std::bad_alloc(); }
 
 enum class SubmitMode {
     kReadyOk,
@@ -1023,11 +1033,15 @@ TEST_F(CacheGarbageCollectorTest, ServingMissingSpecIsBatchedAndSubmittedWithExa
     const std::string existing_a_uri = "dummy://storage_a/existing_a?size=1";
     const std::string existing_b_uri = "dummy://storage_a/existing_b?size=1";
     const std::string missing_b_uri = "dummy://storage_b/missing_b?size=1";
+    const std::string orphan_uri = "dummy://storage_a/orphan?size=1";
     might_exist_by_uri[missing_a_uri] = false;
     might_exist_by_uri[missing_b_uri] = false;
 
     CacheLocationMap first_locations;
-    first_locations["old_writing"] = MakeLocation("old_writing", CLS_WRITING, OldCreateTimeUs(config, /*extra_us=*/1));
+    auto orphan =
+        MakeStoredLocation("old_writing", CLS_WRITING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {orphan_uri});
+    orphan->set_create_time(OldCreateTimeUs(config, /*extra_us=*/1));
+    first_locations["old_writing"] = orphan;
     first_locations["serving_missing"] = MakeStoredLocation(
         "serving_missing", CLS_SERVING, DataStorageType::DATA_STORAGE_TYPE_DUMMY, {missing_a_uri, existing_a_uri});
     first_locations["serving_existing"] =
@@ -1694,6 +1708,71 @@ TEST_F(CacheGarbageCollectorTest, FuturePartialAndExceptionAreTerminal) {
     EXPECT_TRUE(gc->inflight_deletes_.empty());
     EXPECT_TRUE(gc->pending_locations_.empty());
     EXPECT_EQ(3, scan_calls.size());
+}
+
+TEST_F(CacheGarbageCollectorTest, CompletedActionsWarnOnlyForUnloggedErrorsAndAlwaysRecordResults) {
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+    stub_.set(ADDR(LoggerBroker, Log), CountGcActionWarnings);
+    gc_action_warn_count = 0;
+
+    const auto complete_action = [&](const std::string &action_name, PlanExecuteResult result) {
+        std::promise<PlanExecuteResult> promise;
+        auto future = promise.get_future();
+        promise.set_value(std::move(result));
+        const CacheGarbageCollector::PendingLocationKey key{"instance_a", 1, "location"};
+        gc->pending_locations_.insert(key);
+        gc->inflight_deletes_.push_back({
+            .round_id = 1,
+            .instance_id = "instance_a",
+            .action_name = action_name,
+            .target_count = 1,
+            .submitted_at = CacheGarbageCollector::Clock::now(),
+            .pending_locations = {key},
+            .future = std::move(future),
+        });
+        gc->PollInflightDeletes();
+        EXPECT_TRUE(gc->inflight_deletes_.empty());
+        EXPECT_TRUE(gc->pending_locations_.empty());
+        EXPECT_EQ(0, gc->get_cache_gc_inflight_delete_count_metrics());
+    };
+
+    complete_action("physical_delete", {EC_PARTIAL_OK, "storage failure already logged", true});
+    EXPECT_EQ(0u, gc_action_warn_count.load());
+    complete_action("physical_delete", {EC_PARTIAL_OK, "unlogged partial failure"});
+    EXPECT_EQ(1u, gc_action_warn_count.load());
+    complete_action("physical_delete", {EC_ERROR, "worker or admission failure"});
+    EXPECT_EQ(2u, gc_action_warn_count.load());
+    complete_action("event_report_metadata", {EC_ERROR, "metadata cleanup failure"});
+    EXPECT_EQ(3u, gc_action_warn_count.load());
+    complete_action("physical_delete", {EC_OK, ""});
+    EXPECT_EQ(3u, gc_action_warn_count.load());
+    for (const auto &[status, count] :
+         std::vector<std::pair<ErrorCode, size_t>>{{EC_PARTIAL_OK, 2}, {EC_ERROR, 2}, {EC_OK, 1}}) {
+        EXPECT_EQ(count,
+                  metrics_registry_
+                      ->GetCounter("cache_gc.delete_result_count",
+                                   MetricsTags{{"status", std::to_string(static_cast<int>(status))}})
+                      .Get());
+    }
+}
+
+TEST_F(CacheGarbageCollectorTest, ScanSummaryAllocationFailureIsHandledByTick) {
+    auto gc = MakeGc(DefaultConfig());
+    PrepareForSingleStep(*gc);
+    stub_.set(ADDR(CacheGarbageCollector, BuildSubmittedLocationSummary), ThrowScanSummaryStub);
+
+    gc->RunOneTick();
+    EXPECT_EQ(1,
+              metrics_registry_->GetCounter("cache_gc.operation_error_count", MetricsTags{{"stage", "tick_exception"}})
+                  .Get());
+    EXPECT_TRUE(gc->round_active_);
+    EXPECT_EQ(0, gc->get_cache_gc_scan_round_count_metrics());
+
+    stub_.reset(ADDR(CacheGarbageCollector, BuildSubmittedLocationSummary));
+    gc->RunOneTick();
+    EXPECT_FALSE(gc->round_active_);
+    EXPECT_EQ(1, gc->get_cache_gc_scan_round_count_metrics());
 }
 
 TEST_F(CacheGarbageCollectorTest, SnapshotPreservesInstanceIsolationAndCooldown) {

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -851,6 +851,122 @@ TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBack
     EXPECT_EQ(1u, delete_calls.load());
 }
 
+TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentlyAndAggregatesFailures) {
+    ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+
+    class RecordingDeleteBackend : public DataStorageBackend {
+    public:
+        RecordingDeleteBackend() : DataStorageBackend(nullptr) {
+            config_.set_type(DataStorageType::DATA_STORAGE_TYPE_DUMMY);
+            config_.set_global_unique_name("gc_delete_backend");
+            SetOpen(true);
+            SetAvailable(true);
+        }
+        DataStorageType GetType() override { return DataStorageType::DATA_STORAGE_TYPE_DUMMY; }
+        bool Available() override { return true; }
+        double GetStorageUsageRatio(const std::string &) const override { return 0.0; }
+        const StorageConfig &GetStorageConfig() override { return config_; }
+        ErrorCode DoOpen(const StorageConfig &, const std::string &) override { return EC_OK; }
+        ErrorCode Close() override { return EC_OK; }
+        std::vector<std::pair<ErrorCode, DataStorageUri>>
+        Create(const std::vector<std::string> &, size_t, const std::string &, std::function<void()>) override {
+            return {};
+        }
+        std::vector<ErrorCode>
+        Delete(const std::vector<DataStorageUri> &uris, const std::string &, std::function<void()>) override {
+            delete_batches.push_back(uris);
+            return std::vector<ErrorCode>(uris.size(), delete_result);
+        }
+        std::vector<bool> Exist(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<bool>(uris.size(), true);
+        }
+        std::vector<ErrorCode> Lock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+        std::vector<ErrorCode> UnLock(const std::vector<DataStorageUri> &uris) override {
+            return std::vector<ErrorCode>(uris.size(), EC_OK);
+        }
+
+        ErrorCode delete_result{EC_OK};
+        std::vector<std::vector<DataStorageUri>> delete_batches;
+
+    private:
+        StorageConfig config_;
+    };
+
+    auto backend = std::make_shared<RecordingDeleteBackend>();
+    data_storage_manager_->storage_map_["gc_delete_backend"] = backend;
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    RequestContext context("gc_physical_delete_test");
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+
+    const auto add_location = [&](int64_t block_key, const std::vector<std::string> &uris) {
+        std::vector<LocationSpec> specs;
+        for (size_t i = 0; i < uris.size(); ++i) {
+            specs.emplace_back("tp" + std::to_string(i), uris[i]);
+        }
+        const auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+            DataStorageType::DATA_STORAGE_TYPE_DUMMY, specs.size(), specs);
+        std::vector<std::string> location_ids;
+        EXPECT_EQ(EC_OK, BatchAddLocationForTest(&meta_searcher, &context, {block_key}, {location}, location_ids));
+        EXPECT_EQ(1u, location_ids.size());
+        return location_ids.empty() ? std::string{} : location_ids.front();
+    };
+    const auto expect_location_deleted = [&](int64_t block_key) {
+        std::vector<CacheLocationMap> locations;
+        BlockMask empty_mask;
+        EXPECT_EQ(EC_OK, meta_searcher.BatchGetLocation(&context, {block_key}, empty_mask, locations));
+        ASSERT_EQ(1u, locations.size());
+        EXPECT_TRUE(locations.front().empty());
+    };
+
+    const std::string missing_uri = "dummy://gc_delete_backend/missing?size=1";
+    const std::string existing_uri = "dummy://gc_delete_backend/existing?size=1";
+    const int64_t mixed_block_key = 710;
+    const std::string mixed_location_id = add_location(mixed_block_key, {missing_uri, existing_uri});
+    CacheLocationDelRequest mixed_request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {mixed_block_key},
+        .location_ids = {{mixed_location_id}},
+        .confirmed_missing_uris = {missing_uri},
+    };
+    const auto mixed_result = executor.Submit(mixed_request).get();
+    ASSERT_EQ(EC_OK, mixed_result.status) << mixed_result.error_message;
+    ASSERT_EQ(1u, backend->delete_batches.size());
+    ASSERT_EQ(1u, backend->delete_batches.front().size());
+    EXPECT_EQ(existing_uri, backend->delete_batches.front().front().ToUriString());
+    expect_location_deleted(mixed_block_key);
+
+    backend->delete_result = EC_NOENT;
+    const std::string noent_uri = "dummy://gc_delete_backend/already_deleted?size=1";
+    const int64_t noent_block_key = 711;
+    const std::string noent_location_id = add_location(noent_block_key, {noent_uri});
+    const auto noent_result = executor
+                                  .Submit(CacheLocationDelRequest{
+                                      .instance_id = kTestInstanceName,
+                                      .block_keys = {noent_block_key},
+                                      .location_ids = {{noent_location_id}},
+                                  })
+                                  .get();
+    EXPECT_EQ(EC_OK, noent_result.status) << noent_result.error_message;
+    expect_location_deleted(noent_block_key);
+
+    backend->delete_result = EC_ERROR;
+    const std::string error_uri = "dummy://gc_delete_backend/error?size=1";
+    const int64_t error_block_key = 712;
+    const std::string error_location_id = add_location(error_block_key, {error_uri});
+    const auto error_result = executor
+                                  .Submit(CacheLocationDelRequest{
+                                      .instance_id = kTestInstanceName,
+                                      .block_keys = {error_block_key},
+                                      .location_ids = {{error_location_id}},
+                                  })
+                                  .get();
+    EXPECT_EQ(EC_PARTIAL_OK, error_result.status);
+    EXPECT_NE(std::string::npos, error_result.error_message.find("failed[1]"));
+    expect_location_deleted(error_block_key);
+}
+
 TEST_F(SchedulePlanExecutorTest, TestEventReportMetadataDeleteRevalidatesTokenOnWorker) {
     ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
     auto backend = CreateEventReportStorage("event_report_l2");

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -1,8 +1,11 @@
 #include <atomic>
 #include <condition_variable>
+#include <cstdarg>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -28,6 +31,37 @@ std::atomic<bool> sync_completed{false};
 std::atomic<bool> release_sync{true};
 std::atomic<std::int64_t> sync_delay_ms{0};
 std::atomic<std::size_t> sync_thread_hash{0};
+
+// Only the deletion worker writes these entries; tests read them after its Future completes.
+std::vector<std::string> physical_delete_warnings;
+void CapturePhysicalDeleteWarnings(int level, const char *, int, const char *func, const char *format, ...) {
+    if (level != Logger::LEVEL_WARN || std::string(func) != "DoLocationDelTask") {
+        return;
+    }
+    char message[4096];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(message, sizeof(message), format, args);
+    va_end(args);
+    physical_delete_warnings.emplace_back(message);
+}
+
+Stub *cas_refresh_stub = nullptr;
+std::string location_to_refresh_during_cas;
+ErrorCode RefreshLocationBeforeCas(void *obj,
+                                   RequestContext *context,
+                                   const KeyVector &keys,
+                                   const std::vector<std::vector<MetaSearcher::LocationCASTask>> &tasks,
+                                   std::vector<std::vector<ErrorCode>> &results,
+                                   bool authoritative_read) {
+    cas_refresh_stub->reset(ADDR(MetaSearcher, BatchCASLocationStatus));
+    auto *searcher = static_cast<MetaSearcher *>(obj);
+    std::vector<std::vector<ErrorCode>> update_results;
+    EXPECT_EQ(EC_OK,
+              searcher->BatchUpdateLocationStatus(
+                  context, {keys.front()}, {{{location_to_refresh_during_cas, CLS_WRITING}}}, update_results));
+    return searcher->BatchCASLocationStatus(context, keys, tasks, results, authoritative_read);
+}
 
 bool MetaIndexer_Sync_stub(void *obj, const KeyVector &keys) noexcept {
     (void)obj;
@@ -851,14 +885,14 @@ TEST_F(SchedulePlanExecutorTest, TestMetadataOnlyLocationDeleteSkipsPhysicalBack
     EXPECT_EQ(1u, delete_calls.load());
 }
 
-TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentlyAndAggregatesFailures) {
+TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentlyAndLogsRealFailures) {
     ASSERT_EQ(EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
 
     class RecordingDeleteBackend : public DataStorageBackend {
     public:
-        RecordingDeleteBackend() : DataStorageBackend(nullptr) {
+        explicit RecordingDeleteBackend(const std::string &name = "gc_delete_backend") : DataStorageBackend(nullptr) {
             config_.set_type(DataStorageType::DATA_STORAGE_TYPE_DUMMY);
-            config_.set_global_unique_name("gc_delete_backend");
+            config_.set_global_unique_name(name);
             SetOpen(true);
             SetAvailable(true);
         }
@@ -875,7 +909,15 @@ TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentl
         std::vector<ErrorCode>
         Delete(const std::vector<DataStorageUri> &uris, const std::string &, std::function<void()>) override {
             delete_batches.push_back(uris);
-            return std::vector<ErrorCode>(uris.size(), delete_result);
+            if (throw_on_delete) {
+                throw std::runtime_error("injected storage delete exception");
+            }
+            std::vector<ErrorCode> results;
+            for (const auto &uri : uris) {
+                const auto it = delete_results_by_uri.find(uri.ToUriString());
+                results.push_back(it == delete_results_by_uri.end() ? delete_result : it->second);
+            }
+            return results;
         }
         std::vector<bool> Exist(const std::vector<DataStorageUri> &uris) override {
             return std::vector<bool>(uris.size(), true);
@@ -888,30 +930,44 @@ TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentl
         }
 
         ErrorCode delete_result{EC_OK};
+        bool throw_on_delete{false};
+        std::map<std::string, ErrorCode> delete_results_by_uri;
         std::vector<std::vector<DataStorageUri>> delete_batches;
 
     private:
         StorageConfig config_;
     };
 
+    Stub log_stub;
+    physical_delete_warnings.clear();
+    log_stub.set(ADDR(LoggerBroker, Log), CapturePhysicalDeleteWarnings);
     auto backend = std::make_shared<RecordingDeleteBackend>();
     data_storage_manager_->storage_map_["gc_delete_backend"] = backend;
     MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
     RequestContext context("gc_physical_delete_test");
     SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
 
-    const auto add_location = [&](int64_t block_key, const std::vector<std::string> &uris) {
-        std::vector<LocationSpec> specs;
-        for (size_t i = 0; i < uris.size(); ++i) {
-            specs.emplace_back("tp" + std::to_string(i), uris[i]);
-        }
-        const auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
-            DataStorageType::DATA_STORAGE_TYPE_DUMMY, specs.size(), specs);
-        std::vector<std::string> location_ids;
-        EXPECT_EQ(EC_OK, BatchAddLocationForTest(&meta_searcher, &context, {block_key}, {location}, location_ids));
-        EXPECT_EQ(1u, location_ids.size());
-        return location_ids.empty() ? std::string{} : location_ids.front();
-    };
+    const auto add_location =
+        [&](int64_t block_key, const std::vector<std::string> &uris, CacheLocationStatus status = CLS_SERVING) {
+            std::vector<LocationSpec> specs;
+            for (size_t i = 0; i < uris.size(); ++i) {
+                specs.emplace_back("tp" + std::to_string(i), uris[i]);
+            }
+            const auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+                DataStorageType::DATA_STORAGE_TYPE_DUMMY, specs.size(), specs);
+            std::vector<std::string> location_ids;
+            EXPECT_EQ(EC_OK, BatchAddLocationForTest(&meta_searcher, &context, {block_key}, {location}, location_ids));
+            EXPECT_EQ(1u, location_ids.size());
+            if (location_ids.empty()) {
+                return std::string{};
+            }
+            // BatchAddLocation always initializes metadata as WRITING.
+            std::vector<std::vector<ErrorCode>> update_results;
+            EXPECT_EQ(EC_OK,
+                      meta_searcher.BatchUpdateLocationStatus(
+                          &context, {block_key}, {{{location_ids.front(), status}}}, update_results));
+            return location_ids.front();
+        };
     const auto expect_location_deleted = [&](int64_t block_key) {
         std::vector<CacheLocationMap> locations;
         BlockMask empty_mask;
@@ -935,7 +991,81 @@ TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentl
     ASSERT_EQ(1u, backend->delete_batches.size());
     ASSERT_EQ(1u, backend->delete_batches.front().size());
     EXPECT_EQ(existing_uri, backend->delete_batches.front().front().ToUriString());
+    EXPECT_FALSE(mixed_result.error_logged);
+    EXPECT_TRUE(physical_delete_warnings.empty());
     expect_location_deleted(mixed_block_key);
+
+    // When every spec is absent, metadata is still removed without calling Delete.
+    const int64_t missing_block_key = 713;
+    const std::string missing_location_id = add_location(missing_block_key, {missing_uri});
+    const auto missing_result = executor
+                                    .Submit(CacheLocationDelRequest{
+                                        .instance_id = kTestInstanceName,
+                                        .block_keys = {missing_block_key},
+                                        .location_ids = {{missing_location_id}},
+                                        .confirmed_missing_uris = {missing_uri},
+                                    })
+                                    .get();
+    EXPECT_EQ(EC_OK, missing_result.status);
+    EXPECT_EQ(1u, backend->delete_batches.size());
+    EXPECT_TRUE(physical_delete_warnings.empty());
+    expect_location_deleted(missing_block_key);
+
+    // A mixed GC batch must still physically delete orphan WRITING data.
+    const int64_t orphan_block_key = 714;
+    const std::string orphan_uri = "dummy://gc_delete_backend/orphan?size=1";
+    const std::string orphan_location_id = add_location(orphan_block_key, {orphan_uri}, CLS_WRITING);
+    const std::string missing_sibling_id = add_location(orphan_block_key, {missing_uri});
+    auto orphan_submission = executor.SubmitAsync(CacheLocationDelRequest{
+        .instance_id = kTestInstanceName,
+        .block_keys = {orphan_block_key},
+        .location_ids = {{orphan_location_id, missing_sibling_id}},
+        .authoritative_read = true,
+        .confirmed_missing_uris = {missing_uri},
+    });
+    ASSERT_TRUE(orphan_submission.accepted);
+    EXPECT_EQ(EC_OK, orphan_submission.future.get().status);
+    ASSERT_EQ(2u, backend->delete_batches.size());
+    ASSERT_EQ(1u, backend->delete_batches.back().size());
+    EXPECT_EQ(orphan_uri, backend->delete_batches.back().front().ToUriString());
+    expect_location_deleted(orphan_block_key);
+
+    // Refresh one Location between the worker's read and CAS. Only the unchanged
+    // Location is admitted; its existing spec still needs Delete.
+    const int64_t partial_block_key = 715;
+    const std::string refreshed_uri = "dummy://gc_delete_backend/refreshed?size=1";
+    const std::string unchanged_id = add_location(partial_block_key, {missing_uri, existing_uri});
+    const std::string refreshed_id = add_location(partial_block_key, {refreshed_uri});
+    CacheLocationMapVector before;
+    BlockMask empty_mask;
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(&context, {partial_block_key}, empty_mask, before));
+    ASSERT_EQ(1u, before.size());
+    CacheLocationDelRequest partial_request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {partial_block_key},
+        .location_ids = {{unchanged_id, refreshed_id}},
+        .expected_location_values = {{before.front().at(unchanged_id)->ToJsonString(),
+                                      before.front().at(refreshed_id)->ToJsonString()}},
+        .authoritative_read = true,
+        .confirmed_missing_uris = {missing_uri, refreshed_uri},
+    };
+    Stub cas_stub;
+    cas_refresh_stub = &cas_stub;
+    location_to_refresh_during_cas = refreshed_id;
+    cas_stub.set(ADDR(MetaSearcher, BatchCASLocationStatus), RefreshLocationBeforeCas);
+    auto partial_submission = executor.SubmitAsync(partial_request);
+    ASSERT_TRUE(partial_submission.accepted);
+    EXPECT_EQ(EC_OK, partial_submission.future.get().status);
+    cas_refresh_stub = nullptr;
+    ASSERT_EQ(3u, backend->delete_batches.size());
+    ASSERT_EQ(1u, backend->delete_batches.back().size());
+    EXPECT_EQ(existing_uri, backend->delete_batches.back().front().ToUriString());
+    CacheLocationMapVector after;
+    ASSERT_EQ(EC_OK, meta_searcher.BatchGetLocation(&context, {partial_block_key}, empty_mask, after));
+    ASSERT_EQ(1u, after.size());
+    ASSERT_EQ(1u, after.front().size());
+    EXPECT_EQ(CLS_WRITING, after.front().at(refreshed_id)->status());
+    EXPECT_TRUE(physical_delete_warnings.empty());
 
     backend->delete_result = EC_NOENT;
     const std::string noent_uri = "dummy://gc_delete_backend/already_deleted?size=1";
@@ -949,12 +1079,20 @@ TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentl
                                   })
                                   .get();
     EXPECT_EQ(EC_OK, noent_result.status) << noent_result.error_message;
+    EXPECT_FALSE(noent_result.error_logged);
+    EXPECT_TRUE(physical_delete_warnings.empty());
     expect_location_deleted(noent_block_key);
 
     backend->delete_result = EC_ERROR;
     const std::string error_uri = "dummy://gc_delete_backend/error?size=1";
+    const std::string timeout_uri = "dummy://gc_delete_backend/timeout?size=1";
+    const std::string other_uri = "dummy://gc_other_backend/error?size=1";
+    backend->delete_results_by_uri[timeout_uri] = EC_TIMEOUT;
+    auto other_backend = std::make_shared<RecordingDeleteBackend>("gc_other_backend");
+    other_backend->delete_result = EC_ERROR;
+    data_storage_manager_->storage_map_["gc_other_backend"] = other_backend;
     const int64_t error_block_key = 712;
-    const std::string error_location_id = add_location(error_block_key, {error_uri});
+    const std::string error_location_id = add_location(error_block_key, {error_uri, timeout_uri, other_uri});
     const auto error_result = executor
                                   .Submit(CacheLocationDelRequest{
                                       .instance_id = kTestInstanceName,
@@ -963,8 +1101,43 @@ TEST_F(SchedulePlanExecutorTest, TestPhysicalDeleteHandlesMissingUrisIdempotentl
                                   })
                                   .get();
     EXPECT_EQ(EC_PARTIAL_OK, error_result.status);
-    EXPECT_NE(std::string::npos, error_result.error_message.find("failed[1]"));
+    EXPECT_TRUE(error_result.error_logged);
+    EXPECT_NE(std::string::npos, error_result.error_message.find("failed[2]"));
+    EXPECT_THAT(physical_delete_warnings,
+                UnorderedElementsAre(
+                    "storage delete failed, instance[" + kTestInstanceName + "] storage[gc_delete_backend] uri[" +
+                        error_uri + "] ec[" + std::to_string(EC_ERROR) + "]",
+                    "storage delete failed, instance[" + kTestInstanceName + "] storage[gc_delete_backend] uri[" +
+                        timeout_uri + "] ec[" + std::to_string(EC_TIMEOUT) + "]",
+                    "storage delete failed, instance[" + kTestInstanceName + "] storage[gc_other_backend] uri[" +
+                        other_uri + "] ec[" + std::to_string(EC_ERROR) + "]"));
     expect_location_deleted(error_block_key);
+
+    // Worker/admission errors have not been diagnosed by DoLocationDelTask.
+    // They must remain visible to GC even though ordinary Delete errors are logged.
+    backend->throw_on_delete = true;
+    const int64_t exception_block_key = 716;
+    const std::string exception_location_id = add_location(exception_block_key, {existing_uri});
+    auto exception_submission = executor.SubmitAsync(CacheLocationDelRequest{
+        .instance_id = kTestInstanceName,
+        .block_keys = {exception_block_key},
+        .location_ids = {{exception_location_id}},
+    });
+    ASSERT_TRUE(exception_submission.accepted);
+    const auto exception_result = exception_submission.future.get();
+    EXPECT_EQ(EC_ERROR, exception_result.status);
+    EXPECT_FALSE(exception_result.error_logged);
+    EXPECT_THAT(exception_result.error_message, HasSubstr("injected storage delete exception"));
+    EXPECT_EQ(3u, physical_delete_warnings.size());
+    const auto admission_error = executor
+                                     .Submit(CacheLocationDelRequest{
+                                         .instance_id = "missing_instance",
+                                         .block_keys = {1},
+                                         .location_ids = {{"missing_location"}},
+                                     })
+                                     .get();
+    EXPECT_EQ(EC_NOENT, admission_error.status);
+    EXPECT_FALSE(admission_error.error_logged);
 }
 
 TEST_F(SchedulePlanExecutorTest, TestEventReportMetadataDeleteRevalidatesTokenOnWorker) {


### PR DESCRIPTION
## 背景

Cache GC 在 `MightExist` 已确认部分 URI 不存在后，仍会将整条 Location 交给 executor 做物理删除。这会把“数据已不存在”放大为逐 URI 的 `storage delete failed` 日志。同时，正常 action 的完成日志粒度过细，缺少 instance 级扫描汇总。

## 改动

- 将已确认不存在的 URI 随 GC 删除请求传递给 executor，跳过这些 URI 的重复物理删除，同时继续清理 metadata；同一 Location 的其他 URI 仍正常删除。缺失集合为空时跳过 URI 字符串转换与集合查询。
- 将存储后端返回的 `EC_NOENT` 视为幂等成功。真实删除失败保留逐 URI WARN，包括 instance、storage、URI 和错误码，并在 action 结果中保留错误摘要。
- 通过 `PlanExecuteResult.error_logged` 标识已有完整诊断的失败。GC 始终记录结果指标，仅对尚未记录的错误打印 action WARN，保留准入、worker 和 EventReport metadata 清理异常；正常 action 不逐条打印日志。
- 每个 instance 扫描完成后打印一次 INFO 汇总，包括扫描 key 数、batch 数、按原因成功提交的 Location 数和 inflight 限流 tick 数。总数与 reason 明细在同一遍历中生成；汇总函数移除 `noexcept`，由已有 tick 级异常处理接住字符串构造异常。

汇总使用 `submitted_locations` 而不是 `deleted_locations`：删除由 executor 异步完成，并可能被 CAS 重校验拒绝，因此扫描线程只能准确统计已成功提交的任务。

---

## Background

After `MightExist` confirms that some URIs are absent, Cache GC still passes the whole Location to the executor for physical deletion. This turns the "already absent" case into per-URI `storage delete failed` logs. Successful action logs are also too granular, while no per-instance scan summary is available.

## Changes

- Propagate confirmed-missing URIs with GC deletion requests. The executor skips redundant physical deletion for those URIs while still removing metadata and deleting the remaining URIs in the same Location. Skip URI serialization and lookups when the missing set is empty.
- Treat storage `EC_NOENT` results as idempotent success. Preserve per-URI WARN diagnostics for genuine deletion failures, including instance, storage, URI, and error code, and retain an error summary in the action result.
- Use `PlanExecuteResult.error_logged` to identify failures with complete diagnostics already emitted. GC always records result metrics and emits action WARN logs only for unlogged errors, preserving admission, worker, and EventReport metadata cleanup failures. Successful actions are not logged individually.
- Emit one INFO summary after each instance scan, including scanned keys, batches, successfully submitted Locations by reason, and inflight-throttled ticks. Build the total and reason breakdown in the same traversal. Remove `noexcept` from the summary logger so the existing tick-level handler can catch string construction exceptions.

The summary reports `submitted_locations` rather than `deleted_locations`: deletion completes asynchronously and can be rejected by CAS revalidation, so the scan thread can only report accepted submissions accurately.
