### PR TITLE
[py_connector] introduce ruff + ty static quality gates for py_connector

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# Local hooks for the Python connectors under kv_cache_manager/py_connector.
+#
+# All hooks are `language: system` and deliberately install nothing:
+# when a tool (ruff / ty) is not on PATH the hook exits 0 silently, and
+# without pre-commit itself no hook runs at all. Developers who want the
+# gate see kv_cache_manager/py_connector/README.md for setup.
+repos:
+  - repo: local
+    hooks:
+      - id: py-connector-ruff-check
+        name: ruff check (py_connector)
+        entry: "sh -c 'command -v ruff >/dev/null 2>&1 || exit 0; cd kv_cache_manager/py_connector && exec ruff check .'"
+        language: system
+        pass_filenames: false
+        files: ^kv_cache_manager/py_connector/.*\.py$
+      - id: py-connector-ruff-format
+        name: ruff format --check (py_connector)
+        entry: "sh -c 'command -v ruff >/dev/null 2>&1 || exit 0; cd kv_cache_manager/py_connector && exec ruff format --check .'"
+        language: system
+        pass_filenames: false
+        files: ^kv_cache_manager/py_connector/.*\.py$
+      - id: py-connector-ty
+        name: ty check (py_connector)
+        entry: "sh -c 'command -v ty >/dev/null 2>&1 || exit 0; cd kv_cache_manager/py_connector && exec ty check'"
+        language: system
+        pass_filenames: false
+        files: ^kv_cache_manager/py_connector/.*\.py$

--- a/kv_cache_manager/py_connector/README.md
+++ b/kv_cache_manager/py_connector/README.md
@@ -1,0 +1,70 @@
+# py_connector
+
+Python-side connectors between serving engines and KVCM:
+
+- `vllm/` — vLLM v1 KV connector (scheduler + worker roles)
+- `sglang/` — SGLang hicache storage backend
+- `trtllm/` — TensorRT-LLM KV cache connector (example)
+- `common/` — engine-agnostic plumbing (manager HTTP client, TP coordinator)
+- `kernel/` — Triton gather/scatter kernels
+- `test/` — pure-logic unit tests (no GPU / vLLM / pybind needed)
+
+## Static checks (ruff + ty)
+
+All Python under this directory is gated by three checks, configured in
+`ruff.toml` / `ty.toml` next to this file. Run them manually from here:
+
+```bash
+cd kv_cache_manager/py_connector
+ruff check .            # lint: ANN (annotations) + F (pyflakes)
+ruff format --check .   # formatting
+ty check                # type checking
+```
+
+Install the tools any way you like, e.g. `uv tool install ruff ty` or
+`pip install ruff ty`. Both are dev-only tools and intentionally absent
+from every runtime dependency list (`BUILD` / `requirements.txt`).
+
+### Type environment
+
+`ty` resolves third-party imports against the Python environment it
+discovers: a virtualenv named `.venv` in this directory or any parent
+(typically the repository root; it is git-ignored). Build one containing
+the engine you work on, e.g. for the vLLM connector:
+
+```bash
+uv venv .venv --python 3.12
+uv pip install --python .venv/bin/python 'vllm==0.26.0' requests orjson pydantic
+```
+
+Extra packages per subpackage (install `--no-deps` to keep the pinned
+vLLM intact):
+
+- `sglang/` needs `sglang` (tested with 0.5.19; `--no-deps` avoids it
+  resolving its own vLLM pin).
+- `trtllm/` has no pip-installable source distribution: copy the
+  `tensorrt_llm` package of a TensorRT-LLM checkout (v1.2.x) into the
+  same site-packages
+  (`cp -r <TensorRT-LLM>/tensorrt_llm .venv/lib/python3.12/site-packages/`).
+
+A few imports cannot be resolved statically and carry inline
+`# ty: ignore[unresolved-import]` comments where that is permanent:
+
+- compiled modules without stubs: `kvcm_py_client` (pybind11) and
+  `tensorrt_llm.bindings`;
+- `_version_info`, generated into the wheel at build time (bazel
+  `version_info_py`), absent from a source checkout;
+- version-compatibility branches for older vLLM (0.22 / 0.23 era) and
+  older SGLang import paths.
+
+### pre-commit (optional)
+
+`.pre-commit-config.yaml` at the repository root defines local hooks that
+run the three checks over `kv_cache_manager/py_connector/` only. The
+hooks are `language: system`: when `ruff` / `ty` are not on PATH they
+exit 0 silently, and without `pre-commit` itself nothing runs at all.
+
+```bash
+pip install pre-commit   # or: uv tool install pre-commit
+pre-commit install       # opt in
+```

--- a/kv_cache_manager/py_connector/common/logger.py
+++ b/kv_cache_manager/py_connector/common/logger.py
@@ -16,7 +16,7 @@ _DEFAULT_LEVEL = logging.WARNING
 _ENV_VAR = "KVCM_LOG_LEVEL"
 
 
-def set_log_level(level_str: str):
+def set_log_level(level_str: str) -> None:
     """Set KVCM logger level from a string like 'DEBUG', 'INFO', 'WARNING'.
 
     Falls back to WARNING if the level string is invalid or empty.
@@ -24,14 +24,17 @@ def set_log_level(level_str: str):
     if not level_str:
         logger.setLevel(_DEFAULT_LEVEL)
         return
-    level = logging.getLevelName(level_str.upper())
+    # The str -> int overload is deprecated, but getLevelNamesMapping()
+    # would raise the wheel's python_requires (>= 3.9); the fallback below
+    # already handles the non-int answers.
+    level = logging.getLevelName(level_str.upper())  # ty: ignore[deprecated]
     if not isinstance(level, int):
         logger.warning("Invalid log level '%s', falling back to WARNING", level_str)
         level = _DEFAULT_LEVEL
     logger.setLevel(level)
 
 
-def configure_log_level(param_level: str = ""):
+def configure_log_level(param_level: str = "") -> None:
     """Apply log level with priority: env var > param > default(WARNING).
 
     Args:

--- a/kv_cache_manager/py_connector/common/logger.py
+++ b/kv_cache_manager/py_connector/common/logger.py
@@ -7,7 +7,8 @@ handler = logging.StreamHandler()
 handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter(
     "[KVCM] %(levelname)s %(asctime)s [%(filename)s:%(lineno)d] %(message)s",
-    "%m-%d %H:%M:%S")
+    "%m-%d %H:%M:%S",
+)
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 

--- a/kv_cache_manager/py_connector/common/logger.py
+++ b/kv_cache_manager/py_connector/common/logger.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
@@ -34,7 +35,7 @@ def set_log_level(level_str: str) -> None:
     logger.setLevel(level)
 
 
-def configure_log_level(param_level: str = "") -> None:
+def configure_log_level(param_level: Optional[str] = "") -> None:
     """Apply log level with priority: env var > param > default(WARNING).
 
     Args:

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -27,9 +27,7 @@ class KvCacheManagerProtocolError(requests.RequestException, AssertionError):
 
 class KvCacheManagerClient:
     @classmethod
-    def from_connector_config(
-        cls, config: Mapping[str, Any]
-    ) -> "KvCacheManagerClient":
+    def from_connector_config(cls, config: Mapping[str, Any]) -> "KvCacheManagerClient":
         """Create a client from the shared connector configuration surface."""
         return cls(
             config["manager_uri"],
@@ -48,11 +46,18 @@ class KvCacheManagerClient:
             request_timeout_seconds=config.get("request_timeout_seconds", 1.0),
         )
 
-    def __init__(self, base_url, *, instance_id="", auto_discover_leader=False, leader_retry_count=1,
-                 leader_retry_base_interval_seconds=0.005,
-                 discovery_refresh_interval_seconds=30,
-                 min_discover_interval_seconds=1,
-                 request_timeout_seconds=1.0):
+    def __init__(
+        self,
+        base_url,
+        *,
+        instance_id="",
+        auto_discover_leader=False,
+        leader_retry_count=1,
+        leader_retry_base_interval_seconds=0.005,
+        discovery_refresh_interval_seconds=30,
+        min_discover_interval_seconds=1,
+        request_timeout_seconds=1.0,
+    ):
         """
         Args:
             base_url: Manager HTTP(S) address or a service-discovery URL. When
@@ -67,7 +72,10 @@ class KvCacheManagerClient:
             raise ValueError("request_timeout_seconds must be positive")
 
         self.session = requests.Session()
-        self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
         self._resource_lock = threading.Lock()
         self._session_close_claimed = False
         self._service_discovery_close_claimed = False
@@ -106,7 +114,7 @@ class KvCacheManagerClient:
             self._rollback_construction()
             raise
 
-        self.base_url = resolved_url.rstrip('/')
+        self.base_url = resolved_url.rstrip("/")
 
         # Manager route settings
         self._instance_id = instance_id
@@ -126,16 +134,21 @@ class KvCacheManagerClient:
             try:
                 self._refresh_manager_route()
             except Exception as e:
-                logger.warning("Initial leader discovery failed, keeping original base_url %s: %s",
-                               self.base_url, e)
+                logger.warning(
+                    "Initial leader discovery failed, keeping original base_url %s: %s",
+                    self.base_url,
+                    e,
+                )
 
         # One route-refresh thread serves both modes. Leader discovery wakes
         # periodically; service-discovery-only mode waits for transport failures.
         if self._auto_discover_leader or self._service_discovery is not None:
             try:
                 self._refresh_thread = threading.Thread(
-                    target=self._route_refresh_loop, daemon=True,
-                    name="kvcm-route-refresh")
+                    target=self._route_refresh_loop,
+                    daemon=True,
+                    name="kvcm-route-refresh",
+                )
                 self._refresh_thread.start()
             except BaseException:
                 # The caller cannot close an object whose constructor failed.
@@ -145,7 +158,7 @@ class KvCacheManagerClient:
 
     @staticmethod
     def _is_http_url(url):
-        return url.startswith(('http://', 'https://'))
+        return url.startswith(("http://", "https://"))
 
     @staticmethod
     def _endpoint_url(endpoint: ServiceEndpoint):
@@ -161,7 +174,7 @@ class KvCacheManagerClient:
     @staticmethod
     def _get_status_code(response_data):
         """Extract status code from a standard API response."""
-        return response_data.get('header', {}).get('status', {}).get('code')
+        return response_data.get("header", {}).get("status", {}).get("code")
 
     def _refresh_manager_route(self, force_service_refresh=False):
         """Refresh the Manager route through service and optional leader discovery."""
@@ -190,7 +203,7 @@ class KvCacheManagerClient:
         """Resolve and switch to the leader. Must be called under _route_lock."""
         try:
             resp = requests.post(
-                url + '/api/getClusterInfo',
+                url + "/api/getClusterInfo",
                 json={
                     "trace_id": f"leader_discovery_{time.monotonic()}",
                     "instance_id": self._instance_id,
@@ -203,28 +216,42 @@ class KvCacheManagerClient:
             return False
 
         if resp.status_code != 200:
-            logger.warning("Leader discovery to %s returned status %d", url, resp.status_code)
+            logger.warning(
+                "Leader discovery to %s returned status %d", url, resp.status_code
+            )
             return False
 
         try:
             data = resp.json()
         except Exception as e:
-            logger.warning("Leader discovery response from %s is not valid JSON: %s", url, e)
+            logger.warning(
+                "Leader discovery response from %s is not valid JSON: %s", url, e
+            )
             return False
 
-        if self._get_status_code(data) != 'OK':
-            msg = data.get('header', {}).get('status', {}).get('message', 'unknown')
+        if self._get_status_code(data) != "OK":
+            msg = data.get("header", {}).get("status", {}).get("message", "unknown")
             logger.warning("Leader discovery from %s returned error: %s", url, msg)
             return False
 
-        leader_ep = data.get('leader_endpoint')
-        if not leader_ep or not leader_ep.get('host') or not leader_ep.get('meta_http_port'):
-            logger.warning("Leader discovery from %s: leader_endpoint missing or incomplete", url)
+        leader_ep = data.get("leader_endpoint")
+        if (
+            not leader_ep
+            or not leader_ep.get("host")
+            or not leader_ep.get("meta_http_port")
+        ):
+            logger.warning(
+                "Leader discovery from %s: leader_endpoint missing or incomplete", url
+            )
             return False
 
         new_url = f"http://{leader_ep['host']}:{leader_ep['meta_http_port']}"
         if new_url != self.base_url:
-            logger.info("Leader discovered: switching base_url from %s to %s", self.base_url, new_url)
+            logger.info(
+                "Leader discovered: switching base_url from %s to %s",
+                self.base_url,
+                new_url,
+            )
             self.base_url = new_url
         return True
 
@@ -284,14 +311,14 @@ class KvCacheManagerClient:
         """Helper method to make HTTP requests to the service"""
         url = self.base_url + endpoint
 
-        if method == 'POST':
+        if method == "POST":
             response = self.session.post(
                 url,
                 json=data,
                 headers=self.headers,
                 timeout=self._request_timeout_seconds,
             )
-        elif method == 'GET':
+        elif method == "GET":
             response = self.session.get(
                 url,
                 params=data,
@@ -303,8 +330,9 @@ class KvCacheManagerClient:
 
         return response
 
-    def _check_response(self, endpoint, response, response_data,
-                        check_business_status=True):
+    def _check_response(
+        self, endpoint, response, response_data, check_business_status=True
+    ):
         """Validate transport/envelope and optionally the Manager status."""
         if response.status_code != 200:
             raise KvCacheManagerHTTPError(
@@ -316,21 +344,21 @@ class KvCacheManagerClient:
             raise KvCacheManagerProtocolError(
                 f"Response from {endpoint} is not a JSON object"
             )
-        header = response_data.get('header')
+        header = response_data.get("header")
         if not isinstance(header, dict):
             raise KvCacheManagerProtocolError(
                 f"Response from {endpoint} missing a valid 'header' field"
             )
-        status = header.get('status')
-        if not isinstance(status, dict) or not status.get('code'):
+        status = header.get("status")
+        if not isinstance(status, dict) or not status.get("code"):
             raise KvCacheManagerProtocolError(
                 f"Response from {endpoint} missing a valid 'header.status' field"
             )
 
-        if check_business_status and status['code'] != "OK":
+        if check_business_status and status["code"] != "OK":
             raise AssertionError(
-                f"Request to {endpoint} failed with error: "
-                f"{status.get('message', '')}")
+                f"Request to {endpoint} failed with error: {status.get('message', '')}"
+            )
 
     def _make_api_request(self, endpoint, data=None, check_response=True):
         """Helper method to make POST requests to API endpoints and optionally validate response"""
@@ -338,7 +366,7 @@ class KvCacheManagerClient:
 
         while True:
             try:
-                response = self._make_request('POST', endpoint, data)
+                response = self._make_request("POST", endpoint, data)
             except (requests.ConnectionError, requests.Timeout):
                 # Never retry the current request after a transport failure: without
                 # a response, the client cannot know whether Manager applied it, and
@@ -365,20 +393,31 @@ class KvCacheManagerClient:
             )
 
             # SERVER_NOT_LEADER handling: rediscover leader and retry with backoff
-            if self._auto_discover_leader and self._get_status_code(response_data) == 'SERVER_NOT_LEADER':
+            if (
+                self._auto_discover_leader
+                and self._get_status_code(response_data) == "SERVER_NOT_LEADER"
+            ):
                 if retries_left > 0:
                     retries_left -= 1
                     attempt = self._leader_retry_count - retries_left  # 1-based
-                    sleep_time = self._leader_retry_base_interval * attempt + random.uniform(
-                        0, self._leader_retry_base_interval)
-                    logger.warning("Request to %s returned SERVER_NOT_LEADER, "
-                                   "retrying after %.3fs (retries left: %d)",
-                                   endpoint, sleep_time, retries_left)
+                    sleep_time = (
+                        self._leader_retry_base_interval * attempt
+                        + random.uniform(0, self._leader_retry_base_interval)
+                    )
+                    logger.warning(
+                        "Request to %s returned SERVER_NOT_LEADER, "
+                        "retrying after %.3fs (retries left: %d)",
+                        endpoint,
+                        sleep_time,
+                        retries_left,
+                    )
                     time.sleep(sleep_time)
                     if self._refresh_manager_route():
                         continue
                 if retries_left <= 0:
-                    logger.error("All leader discovery retries exhausted for %s", endpoint)
+                    logger.error(
+                        "All leader discovery retries exhausted for %s", endpoint
+                    )
 
             if check_response:
                 self._check_response(endpoint, response, response_data)
@@ -387,51 +426,53 @@ class KvCacheManagerClient:
 
     def register_instance(self, data, check_response=True):
         """Register an instance with the service"""
-        return self._make_api_request('/api/registerInstance', data, check_response)
+        return self._make_api_request("/api/registerInstance", data, check_response)
 
     def get_instance_info(self, data, check_response=True):
         """Get information about a registered instance"""
-        return self._make_api_request('/api/getInstanceInfo', data, check_response)
+        return self._make_api_request("/api/getInstanceInfo", data, check_response)
 
     def get_cache_meta(self, data, check_response=True):
         """Get cache metadata for specified block keys"""
-        return self._make_api_request('/api/getCacheMeta', data, check_response)
+        return self._make_api_request("/api/getCacheMeta", data, check_response)
 
     def get_cache_location(self, data, check_response=True):
         """Get cache location for specified block keys"""
-        return self._make_api_request('/api/getCacheLocation', data, check_response)
+        return self._make_api_request("/api/getCacheLocation", data, check_response)
 
     def get_cache_location_len(self, data, check_response=True):
         """Get the number of cache locations matching the specified block keys"""
-        return self._make_api_request('/api/getCacheLocationLen', data, check_response)
+        return self._make_api_request("/api/getCacheLocationLen", data, check_response)
 
     def get_cache_locations_by_backend(self, data, check_response=True):
         """Get cache locations selected independently for each storage backend."""
-        return self._make_api_request('/api/getCacheLocationsByBackend', data, check_response)
+        return self._make_api_request(
+            "/api/getCacheLocationsByBackend", data, check_response
+        )
 
     def start_write_cache(self, data, check_response=True):
         """Start writing cache data"""
-        return self._make_api_request('/api/startWriteCache', data, check_response)
+        return self._make_api_request("/api/startWriteCache", data, check_response)
 
     def finish_write_cache(self, data, check_response=True):
         """Finish writing cache data"""
-        return self._make_api_request('/api/finishWriteCache', data, check_response)
+        return self._make_api_request("/api/finishWriteCache", data, check_response)
 
     def remove_cache(self, data, check_response=True):
         """Remove cache data for specified block keys"""
-        return self._make_api_request('/api/removeCache', data, check_response)
+        return self._make_api_request("/api/removeCache", data, check_response)
 
     def report_event(self, data, check_response=True):
         """Report node, cache block, host-down, or heartbeat events."""
-        return self._make_api_request('/api/reportEvent', data, check_response)
+        return self._make_api_request("/api/reportEvent", data, check_response)
 
     def trim_cache(self, data, check_response=True):
         """Trim cache data based on specified strategy"""
-        return self._make_api_request('/api/trimCache', data, check_response)
+        return self._make_api_request("/api/trimCache", data, check_response)
 
     def get_cluster_info(self, data, check_response=True):
         """Get cluster info including leader endpoint (leader discovery API)"""
-        return self._make_api_request('/api/getClusterInfo', data, check_response)
+        return self._make_api_request("/api/getClusterInfo", data, check_response)
 
     def _close_session_once(self):
         with self._resource_lock:

--- a/kv_cache_manager/py_connector/common/manager_client.py
+++ b/kv_cache_manager/py_connector/common/manager_client.py
@@ -1,7 +1,7 @@
 import random
 import threading
 import time
-from typing import Any, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
 
 import requests
 
@@ -48,16 +48,16 @@ class KvCacheManagerClient:
 
     def __init__(
         self,
-        base_url,
+        base_url: str,
         *,
-        instance_id="",
-        auto_discover_leader=False,
-        leader_retry_count=1,
-        leader_retry_base_interval_seconds=0.005,
-        discovery_refresh_interval_seconds=30,
-        min_discover_interval_seconds=1,
-        request_timeout_seconds=1.0,
-    ):
+        instance_id: str = "",
+        auto_discover_leader: bool = False,
+        leader_retry_count: int = 1,
+        leader_retry_base_interval_seconds: float = 0.005,
+        discovery_refresh_interval_seconds: float = 30,
+        min_discover_interval_seconds: float = 1,
+        request_timeout_seconds: float = 1.0,
+    ) -> None:
         """
         Args:
             base_url: Manager HTTP(S) address or a service-discovery URL. When
@@ -157,26 +157,26 @@ class KvCacheManagerClient:
                 raise
 
     @staticmethod
-    def _is_http_url(url):
+    def _is_http_url(url: str) -> bool:
         return url.startswith(("http://", "https://"))
 
     @staticmethod
-    def _endpoint_url(endpoint: ServiceEndpoint):
+    def _endpoint_url(endpoint: ServiceEndpoint) -> str:
         """Build a Manager URL from the host:port-only HTTP endpoint contract."""
         return f"http://{endpoint.host}"
 
-    def _close_service_discovery(self):
+    def _close_service_discovery(self) -> None:
         discovery = self._service_discovery
         self._service_discovery = None
         if discovery is not None:
             discovery.close()
 
     @staticmethod
-    def _get_status_code(response_data):
+    def _get_status_code(response_data: Mapping[str, Any]) -> Any:
         """Extract status code from a standard API response."""
         return response_data.get("header", {}).get("status", {}).get("code")
 
-    def _refresh_manager_route(self, force_service_refresh=False):
+    def _refresh_manager_route(self, force_service_refresh: bool = False) -> bool:
         """Refresh the Manager route through service and optional leader discovery."""
         snapshot = self.base_url
         with self._route_lock:
@@ -199,7 +199,7 @@ class KvCacheManagerClient:
             finally:
                 self._last_route_refresh_time = time.monotonic()
 
-    def _do_discover_leader(self, url):
+    def _do_discover_leader(self, url: str) -> bool:
         """Resolve and switch to the leader. Must be called under _route_lock."""
         try:
             resp = requests.post(
@@ -255,7 +255,7 @@ class KvCacheManagerClient:
             self.base_url = new_url
         return True
 
-    def _resolve_discovery_url(self, force_refresh=False):
+    def _resolve_discovery_url(self, force_refresh: bool = False) -> str:
         """Resolve a fresh leader-discovery seed, falling back to the initial one."""
         if self._service_discovery is not None:
             try:
@@ -278,7 +278,7 @@ class KvCacheManagerClient:
                 )
         return self._discovery_url
 
-    def _route_refresh_loop(self):
+    def _route_refresh_loop(self) -> None:
         """Background daemon for periodic leader and event-driven route refresh."""
         try:
             while not self._closed.is_set():
@@ -307,7 +307,12 @@ class KvCacheManagerClient:
         finally:
             self._close_deferred_service_discovery()
 
-    def _make_request(self, method, endpoint, data=None):
+    def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[Mapping[str, Any]] = None,
+    ) -> requests.Response:
         """Helper method to make HTTP requests to the service"""
         url = self.base_url + endpoint
 
@@ -331,8 +336,12 @@ class KvCacheManagerClient:
         return response
 
     def _check_response(
-        self, endpoint, response, response_data, check_business_status=True
-    ):
+        self,
+        endpoint: str,
+        response: requests.Response,
+        response_data: Any,
+        check_business_status: bool = True,
+    ) -> None:
         """Validate transport/envelope and optionally the Manager status."""
         if response.status_code != 200:
             raise KvCacheManagerHTTPError(
@@ -360,7 +369,12 @@ class KvCacheManagerClient:
                 f"Request to {endpoint} failed with error: {status.get('message', '')}"
             )
 
-    def _make_api_request(self, endpoint, data=None, check_response=True):
+    def _make_api_request(
+        self,
+        endpoint: str,
+        data: Optional[Mapping[str, Any]] = None,
+        check_response: bool = True,
+    ) -> Dict[str, Any]:
         """Helper method to make POST requests to API endpoints and optionally validate response"""
         retries_left = self._leader_retry_count if self._auto_discover_leader else 0
 
@@ -424,64 +438,88 @@ class KvCacheManagerClient:
 
             return response_data
 
-    def register_instance(self, data, check_response=True):
+    def register_instance(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Register an instance with the service"""
         return self._make_api_request("/api/registerInstance", data, check_response)
 
-    def get_instance_info(self, data, check_response=True):
+    def get_instance_info(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Get information about a registered instance"""
         return self._make_api_request("/api/getInstanceInfo", data, check_response)
 
-    def get_cache_meta(self, data, check_response=True):
+    def get_cache_meta(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Get cache metadata for specified block keys"""
         return self._make_api_request("/api/getCacheMeta", data, check_response)
 
-    def get_cache_location(self, data, check_response=True):
+    def get_cache_location(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Get cache location for specified block keys"""
         return self._make_api_request("/api/getCacheLocation", data, check_response)
 
-    def get_cache_location_len(self, data, check_response=True):
+    def get_cache_location_len(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Get the number of cache locations matching the specified block keys"""
         return self._make_api_request("/api/getCacheLocationLen", data, check_response)
 
-    def get_cache_locations_by_backend(self, data, check_response=True):
+    def get_cache_locations_by_backend(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Get cache locations selected independently for each storage backend."""
         return self._make_api_request(
             "/api/getCacheLocationsByBackend", data, check_response
         )
 
-    def start_write_cache(self, data, check_response=True):
+    def start_write_cache(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Start writing cache data"""
         return self._make_api_request("/api/startWriteCache", data, check_response)
 
-    def finish_write_cache(self, data, check_response=True):
+    def finish_write_cache(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Finish writing cache data"""
         return self._make_api_request("/api/finishWriteCache", data, check_response)
 
-    def remove_cache(self, data, check_response=True):
+    def remove_cache(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Remove cache data for specified block keys"""
         return self._make_api_request("/api/removeCache", data, check_response)
 
-    def report_event(self, data, check_response=True):
+    def report_event(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Report node, cache block, host-down, or heartbeat events."""
         return self._make_api_request("/api/reportEvent", data, check_response)
 
-    def trim_cache(self, data, check_response=True):
+    def trim_cache(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Trim cache data based on specified strategy"""
         return self._make_api_request("/api/trimCache", data, check_response)
 
-    def get_cluster_info(self, data, check_response=True):
+    def get_cluster_info(
+        self, data: Mapping[str, Any], check_response: bool = True
+    ) -> Dict[str, Any]:
         """Get cluster info including leader endpoint (leader discovery API)"""
         return self._make_api_request("/api/getClusterInfo", data, check_response)
 
-    def _close_session_once(self):
+    def _close_session_once(self) -> None:
         with self._resource_lock:
             if self._session_close_claimed:
                 return
             self._session_close_claimed = True
         self.session.close()
 
-    def _rollback_construction(self):
+    def _rollback_construction(self) -> None:
         try:
             self.close()
         except BaseException:
@@ -490,7 +528,9 @@ class KvCacheManagerClient:
                 exc_info=True,
             )
 
-    def _request_service_discovery_close(self, refresh_thread):
+    def _request_service_discovery_close(
+        self, refresh_thread: Optional[threading.Thread]
+    ) -> None:
         discovery = None
         with self._resource_lock:
             if (
@@ -511,7 +551,7 @@ class KvCacheManagerClient:
         if discovery is not None:
             discovery.close()
 
-    def _close_deferred_service_discovery(self):
+    def _close_deferred_service_discovery(self) -> None:
         discovery = None
         with self._resource_lock:
             self._refresh_worker_cleanup_reached = True
@@ -533,7 +573,7 @@ class KvCacheManagerClient:
                     exc_info=True,
                 )
 
-    def close(self):
+    def close(self) -> None:
         """Close the HTTP session, discovery client, and background refresh thread."""
         self._closed.set()
         self._refresh_event.set()

--- a/kv_cache_manager/py_connector/common/service_discovery.py
+++ b/kv_cache_manager/py_connector/common/service_discovery.py
@@ -18,6 +18,7 @@ from typing import List, Optional
 @dataclass
 class ServiceEndpoint:
     """统一的服务端点信息。"""
+
     ip: str
     port: int
     host: str  # f"{ip}:{port}"

--- a/kv_cache_manager/py_connector/common/service_discovery.py
+++ b/kv_cache_manager/py_connector/common/service_discovery.py
@@ -12,7 +12,8 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from types import TracebackType
+from typing import List, Optional, Type
 
 
 @dataclass
@@ -52,9 +53,14 @@ class ServiceDiscovery(ABC):
     def close(self) -> None:
         """释放底层资源；默认无操作，子类按需实现。"""
 
-    def __enter__(self):
+    def __enter__(self) -> "ServiceDiscovery":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
         self.close()
         return False

--- a/kv_cache_manager/py_connector/common/service_discovery_factory.py
+++ b/kv_cache_manager/py_connector/common/service_discovery_factory.py
@@ -41,7 +41,7 @@ def _parse_url(url: str) -> Optional[Tuple[str, str, Dict[str, str]]]:
         logger.error(f"invalid service discovery url, missing scheme: {url!r}")
         return None
     scheme = url[:sep]
-    rest = url[sep + 3:]
+    rest = url[sep + 3 :]
     if not rest:
         logger.error(f"invalid service discovery url, empty body: {url!r}")
         return None
@@ -93,10 +93,13 @@ def create_service_discovery(url: str) -> Optional[ServiceDiscovery]:
         from kv_cache_manager.py_connector.common.static_service_discovery import (
             StaticServiceDiscovery,
         )
+
         try:
             return StaticServiceDiscovery(body)
         except Exception as e:
-            logger.error(f"failed to create StaticServiceDiscovery for url={url!r}: {e}")
+            logger.error(
+                f"failed to create StaticServiceDiscovery for url={url!r}: {e}"
+            )
             return None
 
     if scheme == _SCHEME_SPECTRUM:
@@ -111,7 +114,7 @@ def create_service_discovery(url: str) -> Optional[ServiceDiscovery]:
                 f"SpectrumServiceDiscovery not available (requires internal build), url={url!r}"
             )
             return None
-        
+
         cache_ttl = _get_int_param(params, "cache_time", 30)
         # URL 里 timeout 单位是毫秒（与 C++ 端对齐），Python SDK 用秒，这里换算。
         timeout_ms = _get_int_param(params, "timeout", 0)
@@ -132,7 +135,9 @@ def create_service_discovery(url: str) -> Optional[ServiceDiscovery]:
             logger.error(f"Spectrum service discovery not available: {e}")
             return None
         except Exception as e:
-            logger.error(f"failed to create SpectrumServiceDiscovery for url={url!r}: {e}")
+            logger.error(
+                f"failed to create SpectrumServiceDiscovery for url={url!r}: {e}"
+            )
             return None
 
     if scheme == _SCHEME_VIPSERVER:

--- a/kv_cache_manager/py_connector/common/static_service_discovery.py
+++ b/kv_cache_manager/py_connector/common/static_service_discovery.py
@@ -13,7 +13,6 @@ URL 形式（由工厂解析后注入）::
 import threading
 from typing import List, Optional, Sequence
 
-from kv_cache_manager.py_connector.common.logger import logger
 from kv_cache_manager.py_connector.common.service_discovery import (
     ServiceDiscovery,
     ServiceEndpoint,
@@ -65,7 +64,7 @@ class StaticServiceDiscovery(ServiceDiscovery):
         host_list: Optional[str] = None,
         *,
         endpoints: Optional[Sequence[ServiceEndpoint]] = None,
-    ):
+    ) -> None:
         if endpoints is not None:
             parsed: List[ServiceEndpoint] = list(endpoints)
         elif host_list is not None:

--- a/kv_cache_manager/py_connector/common/static_service_discovery.py
+++ b/kv_cache_manager/py_connector/common/static_service_discovery.py
@@ -28,13 +28,15 @@ def parse_host_port_list(host_list: str) -> List[ServiceEndpoint]:
     if not host_list:
         raise ValueError("host_list is empty")
     endpoints: List[ServiceEndpoint] = []
-    for token in host_list.split(','):
+    for token in host_list.split(","):
         token = token.strip()
         if not token:
             continue
-        if ':' not in token:
-            raise ValueError(f"static endpoint missing host:port format, token={token!r}")
-        host, _, port_str = token.partition(':')
+        if ":" not in token:
+            raise ValueError(
+                f"static endpoint missing host:port format, token={token!r}"
+            )
+        host, _, port_str = token.partition(":")
         if not host or not port_str:
             raise ValueError(f"static endpoint missing host or port, token={token!r}")
         if not port_str.isdigit():
@@ -44,7 +46,9 @@ def parse_host_port_list(host_list: str) -> List[ServiceEndpoint]:
             raise ValueError(f"static endpoint port out of range, token={token!r}")
         endpoints.append(ServiceEndpoint(ip=host, port=port, host=f"{host}:{port}"))
     if not endpoints:
-        raise ValueError(f"static endpoint list is empty after parsing, raw={host_list!r}")
+        raise ValueError(
+            f"static endpoint list is empty after parsing, raw={host_list!r}"
+        )
     return endpoints
 
 

--- a/kv_cache_manager/py_connector/common/tp_coordinator.py
+++ b/kv_cache_manager/py_connector/common/tp_coordinator.py
@@ -36,7 +36,9 @@ class LoadBlockFinishedEvent:
     type: str = "LoadBlockFinishedEvent"
 
 
-CoordinateEventUnion = Union[SendBlockFinishedEvent, LoadBlockFinishedEvent, SendBlockStartEvent]
+CoordinateEventUnion = Union[
+    SendBlockFinishedEvent, LoadBlockFinishedEvent, SendBlockStartEvent
+]
 
 
 @dataclass
@@ -67,7 +69,7 @@ class CoordinateMsgSerializer:
         return CoordinateMessage(
             send_time=msg_dict["send_time"],
             create_time=msg_dict["create_time"],
-            content=content
+            content=content,
         )
 
 
@@ -106,13 +108,17 @@ class SaveContext:
 
 
 class TpCoordinatorServer:
-    def __init__(self, host_ip: str, base_port: int, tp_world_size: int, on_finished_callback):
+    def __init__(
+        self, host_ip: str, base_port: int, tp_world_size: int, on_finished_callback
+    ):
         self._host_ip = host_ip
         self._base_port = base_port
         self._tp_world_size = tp_world_size
 
         self._coordinator_running = True
-        self._coordinator_thread = threading.Thread(target=self.coordinator_routine, daemon=True)
+        self._coordinator_thread = threading.Thread(
+            target=self.coordinator_routine, daemon=True
+        )
         self._coordinator_thread.start()
 
         self._finished_loading = []
@@ -134,7 +140,9 @@ class TpCoordinatorServer:
         # Buffer for SendBlockFinishedEvent that arrives before SendBlockStartEvent
         pending_save_finishes: Dict[RunningId, List[SendBlockFinishedEvent]] = {}
 
-        def complete_save_if_ready(save_id: RunningId, write_session_id: str, request_id: str):
+        def complete_save_if_ready(
+            save_id: RunningId, write_session_id: str, request_id: str
+        ):
             save_context = running_save.get(save_id)
             if save_context is None:
                 return
@@ -151,7 +159,9 @@ class TpCoordinatorServer:
             try:
                 msg = CoordinateMsgSerializer.loads(raw_msg)
             except Exception as e:
-                logger.warning("[coordinator] received msg load failed: %s, error: %s", raw_msg, e)
+                logger.warning(
+                    "[coordinator] received msg load failed: %s, error: %s", raw_msg, e
+                )
                 continue
 
             if isinstance(msg.content, SendBlockStartEvent):
@@ -163,9 +173,13 @@ class TpCoordinatorServer:
                 # Merge any buffered finish events that arrived before this start
                 if save_id in pending_save_finishes:
                     for finish_event in pending_save_finishes.pop(save_id):
-                        running_save[save_id].add_new_rank(finish_event.tp_rank, finish_event.is_success_list)
+                        running_save[save_id].add_new_rank(
+                            finish_event.tp_rank, finish_event.is_success_list
+                        )
 
-                complete_save_if_ready(save_id, content.write_session_id, content.request_id)
+                complete_save_if_ready(
+                    save_id, content.write_session_id, content.request_id
+                )
 
             elif isinstance(msg.content, SendBlockFinishedEvent):
                 content: SendBlockFinishedEvent = msg.content
@@ -177,8 +191,12 @@ class TpCoordinatorServer:
                         pending_save_finishes[save_id] = []
                     pending_save_finishes[save_id].append(content)
                 else:
-                    running_save[save_id].add_new_rank(content.tp_rank, content.is_success_list)
-                    complete_save_if_ready(save_id, content.write_session_id, content.request_id)
+                    running_save[save_id].add_new_rank(
+                        content.tp_rank, content.is_success_list
+                    )
+                    complete_save_if_ready(
+                        save_id, content.write_session_id, content.request_id
+                    )
             elif isinstance(msg.content, LoadBlockFinishedEvent):
                 content: LoadBlockFinishedEvent = msg.content
                 load_id = RunningId(str(content.epoch), content.request_id)

--- a/kv_cache_manager/py_connector/common/tp_coordinator.py
+++ b/kv_cache_manager/py_connector/common/tp_coordinator.py
@@ -1,8 +1,9 @@
 import orjson
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import List, Any, Union, Dict
+from typing import Any, Dict, List, Set, Tuple, Union
 
 import zmq
 
@@ -13,7 +14,8 @@ from kv_cache_manager.py_connector.common.logger import logger
 class SendBlockStartEvent:
     request_id: str
     write_session_id: str
-    locations: list = field(default_factory=list)
+    # Manager CacheLocation dicts, one per block to save.
+    locations: List[Dict[str, Any]] = field(default_factory=list)
     type: str = "SendBlockStartEvent"
 
 
@@ -48,7 +50,7 @@ class CoordinateMessage:
     create_time: float = field(default_factory=time.time)
 
 
-msg_type_mapping = {
+msg_type_mapping: Dict[str, type] = {
     "SendBlockStartEvent": SendBlockStartEvent,
     "SendBlockFinishedEvent": SendBlockFinishedEvent,
     "LoadBlockFinishedEvent": LoadBlockFinishedEvent,
@@ -81,36 +83,41 @@ class RunningId:
 
 @dataclass()
 class LoadContext:
-    finished_rank: set = field(default_factory=set)
+    finished_rank: Set[int] = field(default_factory=set)
 
-    def add_new_rank(self, tp_rank):
+    def add_new_rank(self, tp_rank: int) -> None:
         if tp_rank in self.finished_rank:
             return
         self.finished_rank.add(tp_rank)
 
-    def get_size(self):
+    def get_size(self) -> int:
         return len(self.finished_rank)
 
 
 @dataclass
 class SaveContext:
-    locations: list
-    result_per_rank: Dict[int, List[Any]] = field(default_factory=dict)
+    # Manager CacheLocation dicts, one per block to save.
+    locations: List[Dict[str, Any]]
+    result_per_rank: Dict[int, List[bool]] = field(default_factory=dict)
     success_mask: List[bool] = field(default_factory=list)
 
-    def add_new_rank(self, tp_rank, is_successes):
+    def add_new_rank(self, tp_rank: int, is_successes: List[bool]) -> None:
         if tp_rank in self.result_per_rank:
             return
         self.result_per_rank[tp_rank] = is_successes
 
-    def get_size(self):
+    def get_size(self) -> int:
         return len(self.result_per_rank)
 
 
 class TpCoordinatorServer:
     def __init__(
-        self, host_ip: str, base_port: int, tp_world_size: int, on_finished_callback
-    ):
+        self,
+        host_ip: str,
+        base_port: int,
+        tp_world_size: int,
+        on_finished_callback: Callable[[str, SaveContext], None],
+    ) -> None:
         self._host_ip = host_ip
         self._base_port = base_port
         self._tp_world_size = tp_world_size
@@ -128,7 +135,7 @@ class TpCoordinatorServer:
         self._finished_saving_lock = threading.Lock()
         self._on_finished_callback = on_finished_callback
 
-    def coordinator_routine(self):
+    def coordinator_routine(self) -> None:
         context = zmq.Context()
         socket = context.socket(zmq.PULL)
         port = self._base_port
@@ -142,7 +149,7 @@ class TpCoordinatorServer:
 
         def complete_save_if_ready(
             save_id: RunningId, write_session_id: str, request_id: str
-        ):
+        ) -> None:
             save_context = running_save.get(save_id)
             if save_context is None:
                 return
@@ -214,7 +221,7 @@ class TpCoordinatorServer:
             else:
                 logger.warning("[coordinator] received wrong msg: %s", msg)
 
-    def get_finished_tasks(self):
+    def get_finished_tasks(self) -> Tuple[List[str], List[str]]:
         finished_saving = []
         finished_loading = []
         if len(self._finished_loading) > 0:
@@ -229,7 +236,7 @@ class TpCoordinatorServer:
             self._finished_saving_lock.release()
         return finished_saving, finished_loading
 
-    def get_failed_loading_block_idxs(self):
+    def get_failed_loading_block_idxs(self) -> Set[int]:
         if len(self._failed_loading_block_idxs) == 0:
             return set()
         self._finished_loading_lock.acquire()
@@ -240,7 +247,7 @@ class TpCoordinatorServer:
 
 
 class TpCoordinatorClient:
-    def __init__(self, host_ip, port):
+    def __init__(self, host_ip: str, port: int) -> None:
         self._host_ip = host_ip
         self._port = port
         self._lock = threading.Lock()
@@ -251,6 +258,6 @@ class TpCoordinatorClient:
         socket.connect("tcp://%s:%d" % (self._host_ip, self._port))
         self._socket = socket
 
-    def send(self, param: bytes):
+    def send(self, param: bytes) -> None:
         with self._lock:
             self._socket.send(param)

--- a/kv_cache_manager/py_connector/common/utils.py
+++ b/kv_cache_manager/py_connector/common/utils.py
@@ -1,5 +1,5 @@
 import hashlib
 
 
-def calc_md5_hash(input: str):
+def calc_md5_hash(input: str) -> str:
     return hashlib.md5(input.encode()).hexdigest()

--- a/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
@@ -30,14 +30,14 @@ on AttentionTransferGroup.kv_layout; the GPU test in test/kernel checks
 both modes element-wise against naive torch indexing.
 """
 
-from typing import List, Optional, Union
+from typing import Any, List
 
 import torch
 import triton
 import triton.language as tl
 
 
-def pytorch_dtype_to_triton_dtype(torch_dtype):
+def pytorch_dtype_to_triton_dtype(torch_dtype: torch.dtype) -> Any:
     """
     Converts a PyTorch dtype to a Triton language dtype.
     """
@@ -66,10 +66,10 @@ def pytorch_dtype_to_triton_dtype(torch_dtype):
 
 @triton.jit
 def kv_cache_batch_gather_kernel(
-    kv_cache_ptrs_ptr,  # 指针数组基址 [num_layers * kv_count]
-    dst_ptr,  # 输出缓冲区 (pinned host memory)
-    block_token_indices_ptr,  # [total_blocks, num_tokens_per_block]
-    dst_block_indices_ptr,  # [total_blocks]
+    kv_cache_ptrs_ptr: torch.Tensor,  # 指针数组基址 [num_layers * kv_count]
+    dst_ptr: torch.Tensor,  # 输出缓冲区 (pinned host memory)
+    block_token_indices_ptr: torch.Tensor,  # [total_blocks, num_tokens_per_block]
+    dst_block_indices_ptr: torch.Tensor,  # [total_blocks]
     total_blocks: int,  # 需要处理的总block数
     NUM_TOKENS_PER_BLOCK: tl.constexpr,
     NUM_DIMS_PER_TOKEN: tl.constexpr,
@@ -79,7 +79,7 @@ def kv_cache_batch_gather_kernel(
     kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
     block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
     local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
-):
+) -> None:
     NUM_DIMS_PER_BLOCK = NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
 
     # Determine if using strided layout
@@ -173,7 +173,7 @@ def batch_gather_kv_caches(
     kv_stride: int = 0,  # stride between K and V (for V pointers)
     block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
     local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
-):
+) -> None:
     # 配置参数
     total_blocks = len(dst_block_indices)
     total_kv_caches_ptr = kv_caches_ptrs_tensor.size(0)
@@ -210,10 +210,10 @@ def batch_gather_kv_caches(
 
 @triton.jit
 def kv_cache_batch_scatter_kernel(
-    kv_cache_ptrs_ptr,  # 指针数组基址 [num_layers * kv_count]
-    src_ptr,  # 源缓冲区 (pinned host memory)
-    block_token_indices_ptr,  # [total_blocks, num_tokens_per_block]
-    src_block_indices_ptr,  # [total_blocks]
+    kv_cache_ptrs_ptr: torch.Tensor,  # 指针数组基址 [num_layers * kv_count]
+    src_ptr: torch.Tensor,  # 源缓冲区 (pinned host memory)
+    block_token_indices_ptr: torch.Tensor,  # [total_blocks, num_tokens_per_block]
+    src_block_indices_ptr: torch.Tensor,  # [total_blocks]
     total_blocks: int,  # 需要处理的总block数
     NUM_TOKENS_PER_BLOCK: tl.constexpr,
     NUM_DIMS_PER_TOKEN: tl.constexpr,
@@ -223,7 +223,7 @@ def kv_cache_batch_scatter_kernel(
     kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
     block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
     local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
-):
+) -> None:
     NUM_DIMS_PER_BLOCK = NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
 
     # Determine if using strided layout
@@ -318,7 +318,7 @@ def batch_scatter_kv_caches(
     kv_stride: int = 0,  # stride between K and V (for V pointers)
     block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
     local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
-):
+) -> None:
     # 配置参数
     total_blocks = len(src_block_indices)
     total_kv_caches_ptr = kv_caches_ptrs_tensor.size(0)

--- a/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
@@ -165,7 +165,7 @@ def batch_gather_kv_caches(
     kv_caches_ptrs_tensor: torch.Tensor,
     # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
     dst_tensor: torch.Tensor,
-    block_token_indices: List[int],  # List of token positions to gather
+    block_token_indices: List[List[int]],  # token slots per block
     dst_block_indices: List[int],  # List of dst block indices
     num_tokens_per_block: int,
     dim_size_per_token_per_layer: int,
@@ -310,7 +310,7 @@ def batch_scatter_kv_caches(
     kv_caches_ptrs_tensor: torch.Tensor,
     # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
     src_tensor: torch.Tensor,  # 注意：src_tensor在PCIE连接的host DRAM上 (pinned memory)
-    block_token_indices: List[int],  # List of token positions to scatter to
+    block_token_indices: List[List[int]],  # token slots per block
     src_block_indices: List[int],  # List of src block indices
     num_tokens_per_block: int,
     dim_size_per_token_per_layer: int,

--- a/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
@@ -52,8 +52,10 @@ def pytorch_dtype_to_triton_dtype(torch_dtype):
         torch.int32: tl.int32,
         torch.int64: tl.int64,
         torch.uint8: tl.uint8,
-        torch.float8_e4m3fn: tl.float8e4nv if hasattr(tl, 'float8e4nv') else tl.float8e4b8,
-        torch.bool: tl.int1
+        torch.float8_e4m3fn: tl.float8e4nv
+        if hasattr(tl, "float8e4nv")
+        else tl.float8e4b8,
+        torch.bool: tl.int1,
     }
 
     triton_dtype = dtype_mapping.get(torch_dtype)
@@ -64,25 +66,27 @@ def pytorch_dtype_to_triton_dtype(torch_dtype):
 
 @triton.jit
 def kv_cache_batch_gather_kernel(
-        kv_cache_ptrs_ptr,  # 指针数组基址 [num_layers * kv_count]
-        dst_ptr,  # 输出缓冲区 (pinned host memory)
-        block_token_indices_ptr,  # [total_blocks, num_tokens_per_block]
-        dst_block_indices_ptr,  # [total_blocks]
-        total_blocks: int,  # 需要处理的总block数
-        NUM_TOKENS_PER_BLOCK: tl.constexpr,
-        NUM_DIMS_PER_TOKEN: tl.constexpr,
-        NUM_KVCACHE_PTRS: tl.constexpr,  # num_layers * kv_count
-        BLOCK_SIZE: tl.constexpr,  # 隐藏维度分块大小
-        DTYPE: tl.constexpr = tl.float16,
-        kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
-        block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
-        local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
+    kv_cache_ptrs_ptr,  # 指针数组基址 [num_layers * kv_count]
+    dst_ptr,  # 输出缓冲区 (pinned host memory)
+    block_token_indices_ptr,  # [total_blocks, num_tokens_per_block]
+    dst_block_indices_ptr,  # [total_blocks]
+    total_blocks: int,  # 需要处理的总block数
+    NUM_TOKENS_PER_BLOCK: tl.constexpr,
+    NUM_DIMS_PER_TOKEN: tl.constexpr,
+    NUM_KVCACHE_PTRS: tl.constexpr,  # num_layers * kv_count
+    BLOCK_SIZE: tl.constexpr,  # 隐藏维度分块大小
+    DTYPE: tl.constexpr = tl.float16,
+    kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
+    block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
+    local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
 ):
     NUM_DIMS_PER_BLOCK = NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
-    
+
     # Determine if using strided layout
-    USE_STRIDED: tl.constexpr = (block_stride != 0)
-    EFFECTIVE_LOCAL_BLOCK_SIZE: tl.constexpr = local_block_size if local_block_size > 0 else NUM_TOKENS_PER_BLOCK
+    USE_STRIDED: tl.constexpr = block_stride != 0
+    EFFECTIVE_LOCAL_BLOCK_SIZE: tl.constexpr = (
+        local_block_size if local_block_size > 0 else NUM_TOKENS_PER_BLOCK
+    )
 
     pid = tl.program_id(0)
     grid_size = tl.num_programs(0)  # 实际grid大小 (如3)
@@ -94,10 +98,7 @@ def kv_cache_batch_gather_kernel(
 
         # 2. 预计算当前block在dst中的基础偏移 (元素为单位)
         block_offset = (
-                dst_block_idx
-                * NUM_KVCACHE_PTRS
-                * NUM_TOKENS_PER_BLOCK
-                * NUM_DIMS_PER_TOKEN
+            dst_block_idx * NUM_KVCACHE_PTRS * NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
         )
 
         # 3. 遍历所有KV缓存指针 (k/v for each layer)
@@ -105,7 +106,9 @@ def kv_cache_batch_gather_kernel(
             # 3.1 加载当前层的KV缓存基地址
             # Note: For non-MLA, pointer array is [K0, V0, K1, V1, ...]
             # V pointer is already V's base (tensor[1].data_ptr()), no need to add kv_stride
-            kvcache_ptr = tl.load(kv_cache_ptrs_ptr + ptr_idx).to(tl.pointer_type(DTYPE))
+            kvcache_ptr = tl.load(kv_cache_ptrs_ptr + ptr_idx).to(
+                tl.pointer_type(DTYPE)
+            )
 
             # 3.2 计算当前层在dst中的基础偏移
             layer_offset = block_offset + ptr_idx * NUM_DIMS_PER_BLOCK
@@ -124,9 +127,11 @@ def kv_cache_batch_gather_kernel(
                 # 计算对应的源地址
                 token_gather_mask = token_idx_in_block < NUM_TOKENS_PER_BLOCK
                 global_token_idx = tl.load(
-                    block_token_indices_ptr + block_idx * NUM_TOKENS_PER_BLOCK + token_idx_in_block,
+                    block_token_indices_ptr
+                    + block_idx * NUM_TOKENS_PER_BLOCK
+                    + token_idx_in_block,
                     mask=token_gather_mask,
-                    other=0
+                    other=0,
                 )
 
                 # 从HBM的KV缓存加载数据
@@ -136,11 +141,18 @@ def kv_cache_batch_gather_kernel(
                     # V pointer already includes kv_stride offset, so no need to add it again
                     kv_block_idx = global_token_idx // EFFECTIVE_LOCAL_BLOCK_SIZE
                     token_in_kv_block = global_token_idx % EFFECTIVE_LOCAL_BLOCK_SIZE
-                    strided_offset = kv_block_idx * block_stride + token_in_kv_block * NUM_DIMS_PER_TOKEN
+                    strided_offset = (
+                        kv_block_idx * block_stride
+                        + token_in_kv_block * NUM_DIMS_PER_TOKEN
+                    )
                     src_ptrs = kvcache_ptr + strided_offset + dim_idx_in_token
                 else:
                     # Contiguous layout: flat indexing
-                    src_ptrs = kvcache_ptr + global_token_idx * NUM_DIMS_PER_TOKEN + dim_idx_in_token
+                    src_ptrs = (
+                        kvcache_ptr
+                        + global_token_idx * NUM_DIMS_PER_TOKEN
+                        + dim_idx_in_token
+                    )
                 load_mask = mask & token_gather_mask
                 data = tl.load(src_ptrs, mask=load_mask, other=0.0)
                 # 大块连续写入 host memory (PCIe优化)
@@ -149,18 +161,18 @@ def kv_cache_batch_gather_kernel(
 
 
 def batch_gather_kv_caches(
-        # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
-        kv_caches_ptrs_tensor: torch.Tensor,
-        # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
-        dst_tensor: torch.Tensor,
-        block_token_indices: List[int],  # List of token positions to gather
-        dst_block_indices: List[int],  # List of dst block indices
-        num_tokens_per_block: int,
-        dim_size_per_token_per_layer: int,
-        sm_count: int = 3,
-        kv_stride: int = 0,  # stride between K and V (for V pointers)
-        block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
-        local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
+    # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
+    kv_caches_ptrs_tensor: torch.Tensor,
+    # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
+    dst_tensor: torch.Tensor,
+    block_token_indices: List[int],  # List of token positions to gather
+    dst_block_indices: List[int],  # List of dst block indices
+    num_tokens_per_block: int,
+    dim_size_per_token_per_layer: int,
+    sm_count: int = 3,
+    kv_stride: int = 0,  # stride between K and V (for V pointers)
+    block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
+    local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
 ):
     # 配置参数
     total_blocks = len(dst_block_indices)
@@ -168,10 +180,12 @@ def batch_gather_kv_caches(
     grid = (sm_count,)  # 限制SM数量
 
     device = kv_caches_ptrs_tensor.device
-    block_token_indices_tensor = torch.tensor(block_token_indices, dtype=torch.int32, device="cpu").to(device,
-                                                                                                       non_blocking=True)
-    dst_block_indices_tensor = torch.tensor(dst_block_indices, dtype=torch.int32, device="cpu").to(device,
-                                                                                                   non_blocking=True)
+    block_token_indices_tensor = torch.tensor(
+        block_token_indices, dtype=torch.int32, device="cpu"
+    ).to(device, non_blocking=True)
+    dst_block_indices_tensor = torch.tensor(
+        dst_block_indices, dtype=torch.int32, device="cpu"
+    ).to(device, non_blocking=True)
 
     kv_cache_batch_gather_kernel[grid](
         kv_caches_ptrs_tensor,
@@ -187,32 +201,36 @@ def batch_gather_kv_caches(
         num_warps=32,
         kv_stride=kv_stride,
         block_stride=block_stride,
-        local_block_size=local_block_size if local_block_size > 0 else num_tokens_per_block,
+        local_block_size=local_block_size
+        if local_block_size > 0
+        else num_tokens_per_block,
     )
     # TODO autotune num_warps and BLOCK_SIZE
 
 
 @triton.jit
 def kv_cache_batch_scatter_kernel(
-        kv_cache_ptrs_ptr,  # 指针数组基址 [num_layers * kv_count]
-        src_ptr,  # 源缓冲区 (pinned host memory)
-        block_token_indices_ptr,  # [total_blocks, num_tokens_per_block]
-        src_block_indices_ptr,  # [total_blocks]
-        total_blocks: int,  # 需要处理的总block数
-        NUM_TOKENS_PER_BLOCK: tl.constexpr,
-        NUM_DIMS_PER_TOKEN: tl.constexpr,
-        NUM_KVCACHE_PTRS: tl.constexpr,  # num_layers * kv_count
-        BLOCK_SIZE: tl.constexpr,  # 隐藏维度分块大小
-        DTYPE: tl.constexpr = tl.float16,
-        kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
-        block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
-        local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
+    kv_cache_ptrs_ptr,  # 指针数组基址 [num_layers * kv_count]
+    src_ptr,  # 源缓冲区 (pinned host memory)
+    block_token_indices_ptr,  # [total_blocks, num_tokens_per_block]
+    src_block_indices_ptr,  # [total_blocks]
+    total_blocks: int,  # 需要处理的总block数
+    NUM_TOKENS_PER_BLOCK: tl.constexpr,
+    NUM_DIMS_PER_TOKEN: tl.constexpr,
+    NUM_KVCACHE_PTRS: tl.constexpr,  # num_layers * kv_count
+    BLOCK_SIZE: tl.constexpr,  # 隐藏维度分块大小
+    DTYPE: tl.constexpr = tl.float16,
+    kv_stride: tl.constexpr = 0,  # stride between K and V (for V pointers)
+    block_stride: tl.constexpr = 0,  # stride between blocks (0 = use flat indexing)
+    local_block_size: tl.constexpr = 0,  # actual block size in tensor (0 = use NUM_TOKENS_PER_BLOCK)
 ):
     NUM_DIMS_PER_BLOCK = NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
-    
+
     # Determine if using strided layout
-    USE_STRIDED: tl.constexpr = (block_stride != 0)
-    EFFECTIVE_LOCAL_BLOCK_SIZE: tl.constexpr = local_block_size if local_block_size > 0 else NUM_TOKENS_PER_BLOCK
+    USE_STRIDED: tl.constexpr = block_stride != 0
+    EFFECTIVE_LOCAL_BLOCK_SIZE: tl.constexpr = (
+        local_block_size if local_block_size > 0 else NUM_TOKENS_PER_BLOCK
+    )
 
     pid = tl.program_id(0)
     grid_size = tl.num_programs(0)  # 实际grid大小 (如3)
@@ -224,10 +242,7 @@ def kv_cache_batch_scatter_kernel(
 
         # 2. 预计算当前block在src中的基础偏移 (元素为单位)
         block_offset = (
-                src_block_idx
-                * NUM_KVCACHE_PTRS
-                * NUM_TOKENS_PER_BLOCK
-                * NUM_DIMS_PER_TOKEN
+            src_block_idx * NUM_KVCACHE_PTRS * NUM_TOKENS_PER_BLOCK * NUM_DIMS_PER_TOKEN
         )
 
         # 3. 遍历所有KV缓存指针 (k/v for each layer)
@@ -235,7 +250,9 @@ def kv_cache_batch_scatter_kernel(
             # 3.1 加载当前层的KV缓存基地址
             # Note: For non-MLA, pointer array is [K0, V0, K1, V1, ...]
             # V pointer is already V's base (tensor[1].data_ptr()), no need to add kv_stride
-            kvcache_ptr = tl.load(kv_cache_ptrs_ptr + ptr_idx).to(tl.pointer_type(DTYPE))
+            kvcache_ptr = tl.load(kv_cache_ptrs_ptr + ptr_idx).to(
+                tl.pointer_type(DTYPE)
+            )
 
             # 3.2 计算当前层在src中的基础偏移
             layer_offset = block_offset + ptr_idx * NUM_DIMS_PER_BLOCK
@@ -254,9 +271,11 @@ def kv_cache_batch_scatter_kernel(
                 # 计算对应的目的地址
                 token_gather_mask = token_idx_in_block < NUM_TOKENS_PER_BLOCK
                 global_token_idx = tl.load(
-                    block_token_indices_ptr + block_idx * NUM_TOKENS_PER_BLOCK + token_idx_in_block,
+                    block_token_indices_ptr
+                    + block_idx * NUM_TOKENS_PER_BLOCK
+                    + token_idx_in_block,
                     mask=token_gather_mask,
-                    other=0
+                    other=0,
                 )
 
                 load_mask = mask & token_gather_mask
@@ -271,27 +290,34 @@ def kv_cache_batch_scatter_kernel(
                     # V pointer already includes kv_stride offset, so no need to add it again
                     kv_block_idx = global_token_idx // EFFECTIVE_LOCAL_BLOCK_SIZE
                     token_in_kv_block = global_token_idx % EFFECTIVE_LOCAL_BLOCK_SIZE
-                    strided_offset = kv_block_idx * block_stride + token_in_kv_block * NUM_DIMS_PER_TOKEN
+                    strided_offset = (
+                        kv_block_idx * block_stride
+                        + token_in_kv_block * NUM_DIMS_PER_TOKEN
+                    )
                     dst_ptrs = kvcache_ptr + strided_offset + dim_idx_in_token
                 else:
                     # Contiguous layout: flat indexing
-                    dst_ptrs = kvcache_ptr + global_token_idx * NUM_DIMS_PER_TOKEN + dim_idx_in_token
+                    dst_ptrs = (
+                        kvcache_ptr
+                        + global_token_idx * NUM_DIMS_PER_TOKEN
+                        + dim_idx_in_token
+                    )
                 tl.store(dst_ptrs, data, mask=load_mask)
 
 
 def batch_scatter_kv_caches(
-        # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
-        kv_caches_ptrs_tensor: torch.Tensor,
-        # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
-        src_tensor: torch.Tensor,  # 注意：src_tensor在PCIE连接的host DRAM上 (pinned memory)
-        block_token_indices: List[int],  # List of token positions to scatter to
-        src_block_indices: List[int],  # List of src block indices
-        num_tokens_per_block: int,
-        dim_size_per_token_per_layer: int,
-        sm_count: int = 3,
-        kv_stride: int = 0,  # stride between K and V (for V pointers)
-        block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
-        local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
+    # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
+    kv_caches_ptrs_tensor: torch.Tensor,
+    # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
+    src_tensor: torch.Tensor,  # 注意：src_tensor在PCIE连接的host DRAM上 (pinned memory)
+    block_token_indices: List[int],  # List of token positions to scatter to
+    src_block_indices: List[int],  # List of src block indices
+    num_tokens_per_block: int,
+    dim_size_per_token_per_layer: int,
+    sm_count: int = 3,
+    kv_stride: int = 0,  # stride between K and V (for V pointers)
+    block_stride: int = 0,  # stride between blocks (0 = use flat indexing)
+    local_block_size: int = 0,  # actual block size in tensor (0 = use num_tokens_per_block)
 ):
     # 配置参数
     total_blocks = len(src_block_indices)
@@ -324,5 +350,7 @@ def batch_scatter_kv_caches(
         num_warps=32,
         kv_stride=kv_stride,
         block_stride=block_stride,
-        local_block_size=local_block_size if local_block_size > 0 else num_tokens_per_block,
+        local_block_size=local_block_size
+        if local_block_size > 0
+        else num_tokens_per_block,
     )

--- a/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/batch_gather_scatter_helper.py
@@ -30,7 +30,7 @@ on AttentionTransferGroup.kv_layout; the GPU test in test/kernel checks
 both modes element-wise against naive torch indexing.
 """
 
-from typing import Any, List
+from typing import Any, List, Union
 
 import torch
 import triton
@@ -165,7 +165,9 @@ def batch_gather_kv_caches(
     kv_caches_ptrs_tensor: torch.Tensor,
     # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
     dst_tensor: torch.Tensor,
-    block_token_indices: List[List[int]],  # token slots per block
+    # Row-major [total_blocks, num_tokens_per_block] slots; nested per
+    # block or already flat -- torch.tensor flattens both identically.
+    block_token_indices: Union[List[List[int]], List[int]],
     dst_block_indices: List[int],  # List of dst block indices
     num_tokens_per_block: int,
     dim_size_per_token_per_layer: int,
@@ -310,7 +312,9 @@ def batch_scatter_kv_caches(
     kv_caches_ptrs_tensor: torch.Tensor,
     # Shape [block_num, num_layers * kv_num, num_tokens_per_block, dim_size_per_token_per_layer]
     src_tensor: torch.Tensor,  # 注意：src_tensor在PCIE连接的host DRAM上 (pinned memory)
-    block_token_indices: List[List[int]],  # token slots per block
+    # Row-major [total_blocks, num_tokens_per_block] slots; nested per
+    # block or already flat -- torch.tensor flattens both identically.
+    block_token_indices: Union[List[List[int]], List[int]],
     src_block_indices: List[int],  # List of src block indices
     num_tokens_per_block: int,
     dim_size_per_token_per_layer: int,

--- a/kv_cache_manager/py_connector/kernel/gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/gather_scatter_helper.py
@@ -9,15 +9,15 @@ from triton.language import static_print
 
 @triton.jit
 def kv_cache_scatter_kernel(
-        # Pointers to KV cache tensors (flattened into one array)
-        kv_cache_ptrs_ptr,  # pointer to array of pointers (size num_layers)
-        source_ptr,  # pointer to source tensor (num_layers, 2, num_tokens, hidden_size)
-        token_indices_ptr,  # pointer to token indices
-        num_tokens_in_block,  # length of token_indices
-        hidden_size,  # hidden dimension size
-        total_token_in_kvcache,  # sequence length in KV cache
-        num_layers,  # number of layers
-        BLOCK_SIZE: tl.constexpr,
+    # Pointers to KV cache tensors (flattened into one array)
+    kv_cache_ptrs_ptr,  # pointer to array of pointers (size num_layers)
+    source_ptr,  # pointer to source tensor (num_layers, 2, num_tokens, hidden_size)
+    token_indices_ptr,  # pointer to token indices
+    num_tokens_in_block,  # length of token_indices
+    hidden_size,  # hidden dimension size
+    total_token_in_kvcache,  # sequence length in KV cache
+    num_layers,  # number of layers
+    BLOCK_SIZE: tl.constexpr,
 ):
     # Get the current program's layer index and token position
     layer_idx = tl.program_id(0)
@@ -38,8 +38,12 @@ def kv_cache_scatter_kernel(
         return
 
     # Calculate source offsets (for both K and V)
-    source_offset_k = (layer_idx * num_tokens_in_block * 2 + 0 * num_tokens_in_block + token_pos) * hidden_size
-    source_offset_v = (1 * num_tokens_in_block + layer_idx * num_tokens_in_block * 2 + token_pos) * hidden_size
+    source_offset_k = (
+        layer_idx * num_tokens_in_block * 2 + 0 * num_tokens_in_block + token_pos
+    ) * hidden_size
+    source_offset_v = (
+        1 * num_tokens_in_block + layer_idx * num_tokens_in_block * 2 + token_pos
+    ) * hidden_size
 
     # Calculate target offsets (for both K and V)
     target_offset_k = (0 * total_token_in_kvcache + token_idx) * hidden_size
@@ -60,15 +64,15 @@ def kv_cache_scatter_kernel(
 
 @triton.jit
 def kv_cache_gather_kernel(
-        # Pointers to KV cache tensors (flattened into one array)
-        kv_cache_ptrs_ptr,  # pointer to array of pointers (size num_layers)
-        dst_ptr,  # pointer to dst tensor (num_layers, 2, num_tokens, hidden_size)
-        token_indices_ptr,  # pointer to token indices
-        num_tokens_in_block,  # length of token_indices
-        hidden_size,  # hidden dimension size
-        total_token_in_kvcache,  # sequence length in KV cache
-        num_layers,  # number of layers
-        BLOCK_SIZE: tl.constexpr,
+    # Pointers to KV cache tensors (flattened into one array)
+    kv_cache_ptrs_ptr,  # pointer to array of pointers (size num_layers)
+    dst_ptr,  # pointer to dst tensor (num_layers, 2, num_tokens, hidden_size)
+    token_indices_ptr,  # pointer to token indices
+    num_tokens_in_block,  # length of token_indices
+    hidden_size,  # hidden dimension size
+    total_token_in_kvcache,  # sequence length in KV cache
+    num_layers,  # number of layers
+    BLOCK_SIZE: tl.constexpr,
 ):
     # Get the current program's layer index and token position
     layer_idx = tl.program_id(0)
@@ -89,8 +93,12 @@ def kv_cache_gather_kernel(
         return
 
     # Calculate dst offsets (for both K and V)
-    dst_offset_k = (layer_idx * num_tokens_in_block * 2 + 0 * num_tokens_in_block + token_pos) * hidden_size
-    dst_offset_v = (layer_idx * num_tokens_in_block * 2 + 1 * num_tokens_in_block + token_pos) * hidden_size
+    dst_offset_k = (
+        layer_idx * num_tokens_in_block * 2 + 0 * num_tokens_in_block + token_pos
+    ) * hidden_size
+    dst_offset_v = (
+        layer_idx * num_tokens_in_block * 2 + 1 * num_tokens_in_block + token_pos
+    ) * hidden_size
 
     # Calculate kvcache offsets (for both K and V)
     kvcache_offset_k = (0 * total_token_in_kvcache + token_idx) * hidden_size
@@ -108,11 +116,11 @@ def kv_cache_gather_kernel(
 
 
 def scatter_kv_caches(
-        kv_caches_ptrs: torch.Tensor,
-        # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
-        total_token_in_kvcache: int,  # total token in kv cache
-        src_tensor: torch.Tensor,  # Shape [num_layers, 2, num_tokens_in_block, hidden_size]
-        token_indices: List[int],  # List of token positions to update
+    kv_caches_ptrs: torch.Tensor,
+    # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
+    total_token_in_kvcache: int,  # total token in kv cache
+    src_tensor: torch.Tensor,  # Shape [num_layers, 2, num_tokens_in_block, hidden_size]
+    token_indices: List[int],  # List of token positions to update
 ):
     assert len(kv_caches_ptrs) == src_tensor.shape[0], "Number of layers mismatch"
     num_layers = len(kv_caches_ptrs)
@@ -121,7 +129,9 @@ def scatter_kv_caches(
 
     # Prepare device tensors
     device = kv_caches_ptrs.device
-    token_indices_tensor = torch.tensor(token_indices, dtype=torch.int32, device="cpu").to(device, non_blocking=True)
+    token_indices_tensor = torch.tensor(
+        token_indices, dtype=torch.int32, device="cpu"
+    ).to(device, non_blocking=True)
 
     # Calculate grid size
     grid = (num_layers, num_tokens_in_block)
@@ -141,11 +151,11 @@ def scatter_kv_caches(
 
 
 def gather_kv_caches(
-        kv_caches_ptrs: torch.Tensor,
-        # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
-        total_token_in_kvcache: int,  # total token in kv cache
-        dst_tensor: torch.Tensor,  # Shape [num_layers, 2, num_tokens_in_block, hidden_size]
-        token_indices: List[int],  # List of token positions to update
+    kv_caches_ptrs: torch.Tensor,
+    # List of KV cache tensors ptr (each shape [2, total_token_in_kvcache, hidden_size])
+    total_token_in_kvcache: int,  # total token in kv cache
+    dst_tensor: torch.Tensor,  # Shape [num_layers, 2, num_tokens_in_block, hidden_size]
+    token_indices: List[int],  # List of token positions to update
 ):
     assert kv_caches_ptrs.shape[0] == dst_tensor.shape[0], "Number of layers mismatch"
     num_layers = kv_caches_ptrs.shape[0]
@@ -153,7 +163,9 @@ def gather_kv_caches(
     hidden_size = dst_tensor.shape[-1]
     # Prepare device tensors
     device = kv_caches_ptrs.device
-    token_indices_tensor = torch.tensor(token_indices, dtype=torch.int32, device="cpu").to(device, non_blocking=True)
+    token_indices_tensor = torch.tensor(
+        token_indices, dtype=torch.int32, device="cpu"
+    ).to(device, non_blocking=True)
 
     # Calculate grid size
     grid = (num_layers, num_tokens_in_block)
@@ -184,7 +196,9 @@ class CopyBufferAllocator:
         # 使用 Condition 变量实现线程同步与阻塞等待
         self._cond = threading.Condition()
         need_pin = self.device.type == "cpu"
-        self._raw_buffer = torch.empty([max_count] + shape, dtype=dtype, device=device, pin_memory=need_pin)
+        self._raw_buffer = torch.empty(
+            [max_count] + shape, dtype=dtype, device=device, pin_memory=need_pin
+        )
         self._raw_buffer.zero_()
 
         self._free_idx_list = [i for i in range(max_count)]
@@ -225,7 +239,7 @@ class CopyBufferAllocator:
             del self._free_idx_list[-count:]
             return result
 
-    def get_buffer_by_idx(self, indices :List[int]):
+    def get_buffer_by_idx(self, indices: List[int]):
         result = []
         for idx in indices:
             result.append(self._free_buffer_list[idx])
@@ -243,7 +257,9 @@ class CopyBufferAllocator:
 
             n = len(buffers)
             if self._inuse_count < n:
-                raise RuntimeError(f"Trying to free {n} buffers, but only {self._inuse_count} are in use")
+                raise RuntimeError(
+                    f"Trying to free {n} buffers, but only {self._inuse_count} are in use"
+                )
 
             self._inuse_count -= n
             self._free_idx_list.extend(buffers)
@@ -252,8 +268,13 @@ class CopyBufferAllocator:
             self._cond.notify_all()
 
 
-def generate_test_data(num_layers=64, total_token_in_kvcache=1024, num_tokens_in_block=128, hidden_size=4096,
-                       device="cuda"):
+def generate_test_data(
+    num_layers=64,
+    total_token_in_kvcache=1024,
+    num_tokens_in_block=128,
+    hidden_size=4096,
+    device="cuda",
+):
     # 生成KV caches (不连续的tensor列表)
     kv_caches = []
     for _ in range(num_layers):
@@ -262,15 +283,21 @@ def generate_test_data(num_layers=64, total_token_in_kvcache=1024, num_tokens_in
         kv_caches.append(cache)
 
     # 生成source tensor [num_layers, 2, num_tokens_in_block, hidden_size]
-    source_tensor = torch.randn(num_layers, 2, num_tokens_in_block, hidden_size, device=device)
+    source_tensor = torch.randn(
+        num_layers, 2, num_tokens_in_block, hidden_size, device=device
+    )
 
     # 生成token indices (确保不重复且在有效范围内)
-    token_indices = torch.randperm(total_token_in_kvcache)[:num_tokens_in_block].tolist()
+    token_indices = torch.randperm(total_token_in_kvcache)[
+        :num_tokens_in_block
+    ].tolist()
 
     return kv_caches, source_tensor, token_indices
 
 
-def reference_impl(kv_caches: List[torch.Tensor], source_tensor: torch.Tensor, token_indices: List[int]):
+def reference_impl(
+    kv_caches: List[torch.Tensor], source_tensor: torch.Tensor, token_indices: List[int]
+):
     """参考实现，用于验证正确性"""
     for layer_idx in range(len(kv_caches)):
         kv_caches[layer_idx][:, token_indices, :] = source_tensor[layer_idx]
@@ -289,7 +316,7 @@ def main():
         num_layers=num_layers,
         total_token_in_kvcache=total_token_in_kvcache,
         num_tokens_in_block=num_tokens_in_block,
-        hidden_size=hidden_size
+        hidden_size=hidden_size,
     )
 
     # 创建用于参考实现的拷贝
@@ -298,21 +325,25 @@ def main():
     # 运行参考实现
     reference_impl(kv_caches_ref, source_tensor, token_indices)
 
-    kv_cache_ptrs = torch.tensor([cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64)
+    kv_cache_ptrs = torch.tensor(
+        [cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64
+    )
     # 运行我们的实现
-    scatter_kv_caches(kv_cache_ptrs, total_token_in_kvcache, source_tensor, token_indices)
+    scatter_kv_caches(
+        kv_cache_ptrs, total_token_in_kvcache, source_tensor, token_indices
+    )
 
     # 验证结果
     for layer_idx in range(num_layers):
         torch.testing.assert_close(
             kv_caches[layer_idx][0],
             kv_caches_ref[layer_idx][0],
-            msg=f"Layer {layer_idx} key mismatch"
+            msg=f"Layer {layer_idx} key mismatch",
         )
         torch.testing.assert_close(
             kv_caches[layer_idx][1],
             kv_caches_ref[layer_idx][1],
-            msg=f"Layer {layer_idx} value mismatch"
+            msg=f"Layer {layer_idx} value mismatch",
         )
     print("Correctness test passed!")
 

--- a/kv_cache_manager/py_connector/kernel/gather_scatter_helper.py
+++ b/kv_cache_manager/py_connector/kernel/gather_scatter_helper.py
@@ -1,24 +1,24 @@
-from typing import List, Optional, Union
+from typing import List, Tuple
+
 import threading
 
 import torch
 import triton
 import triton.language as tl
-from triton.language import static_print
 
 
 @triton.jit
 def kv_cache_scatter_kernel(
     # Pointers to KV cache tensors (flattened into one array)
-    kv_cache_ptrs_ptr,  # pointer to array of pointers (size num_layers)
-    source_ptr,  # pointer to source tensor (num_layers, 2, num_tokens, hidden_size)
-    token_indices_ptr,  # pointer to token indices
-    num_tokens_in_block,  # length of token_indices
-    hidden_size,  # hidden dimension size
-    total_token_in_kvcache,  # sequence length in KV cache
-    num_layers,  # number of layers
+    kv_cache_ptrs_ptr: torch.Tensor,  # pointer to array of pointers (size num_layers)
+    source_ptr: torch.Tensor,  # pointer to source tensor (num_layers, 2, num_tokens, hidden_size)
+    token_indices_ptr: torch.Tensor,  # pointer to token indices
+    num_tokens_in_block: int,  # length of token_indices
+    hidden_size: int,  # hidden dimension size
+    total_token_in_kvcache: int,  # sequence length in KV cache
+    num_layers: int,  # number of layers
     BLOCK_SIZE: tl.constexpr,
-):
+) -> None:
     # Get the current program's layer index and token position
     layer_idx = tl.program_id(0)
     token_pos = tl.program_id(1)
@@ -65,15 +65,15 @@ def kv_cache_scatter_kernel(
 @triton.jit
 def kv_cache_gather_kernel(
     # Pointers to KV cache tensors (flattened into one array)
-    kv_cache_ptrs_ptr,  # pointer to array of pointers (size num_layers)
-    dst_ptr,  # pointer to dst tensor (num_layers, 2, num_tokens, hidden_size)
-    token_indices_ptr,  # pointer to token indices
-    num_tokens_in_block,  # length of token_indices
-    hidden_size,  # hidden dimension size
-    total_token_in_kvcache,  # sequence length in KV cache
-    num_layers,  # number of layers
+    kv_cache_ptrs_ptr: torch.Tensor,  # pointer to array of pointers (size num_layers)
+    dst_ptr: torch.Tensor,  # pointer to dst tensor (num_layers, 2, num_tokens, hidden_size)
+    token_indices_ptr: torch.Tensor,  # pointer to token indices
+    num_tokens_in_block: int,  # length of token_indices
+    hidden_size: int,  # hidden dimension size
+    total_token_in_kvcache: int,  # sequence length in KV cache
+    num_layers: int,  # number of layers
     BLOCK_SIZE: tl.constexpr,
-):
+) -> None:
     # Get the current program's layer index and token position
     layer_idx = tl.program_id(0)
     token_pos = tl.program_id(1)
@@ -121,7 +121,7 @@ def scatter_kv_caches(
     total_token_in_kvcache: int,  # total token in kv cache
     src_tensor: torch.Tensor,  # Shape [num_layers, 2, num_tokens_in_block, hidden_size]
     token_indices: List[int],  # List of token positions to update
-):
+) -> None:
     assert len(kv_caches_ptrs) == src_tensor.shape[0], "Number of layers mismatch"
     num_layers = len(kv_caches_ptrs)
     num_tokens_in_block = len(token_indices)
@@ -156,7 +156,7 @@ def gather_kv_caches(
     total_token_in_kvcache: int,  # total token in kv cache
     dst_tensor: torch.Tensor,  # Shape [num_layers, 2, num_tokens_in_block, hidden_size]
     token_indices: List[int],  # List of token positions to update
-):
+) -> None:
     assert kv_caches_ptrs.shape[0] == dst_tensor.shape[0], "Number of layers mismatch"
     num_layers = kv_caches_ptrs.shape[0]
     num_tokens_in_block = len(token_indices)
@@ -185,7 +185,9 @@ def gather_kv_caches(
 
 
 class CopyBufferAllocator:
-    def __init__(self, device, dtype, shape: List[int], max_count: int):
+    def __init__(
+        self, device: torch.device, dtype: torch.dtype, shape: List[int], max_count: int
+    ) -> None:
         if max_count <= 0:
             raise ValueError("max_count must be positive")
 
@@ -239,13 +241,13 @@ class CopyBufferAllocator:
             del self._free_idx_list[-count:]
             return result
 
-    def get_buffer_by_idx(self, indices: List[int]):
+    def get_buffer_by_idx(self, indices: List[int]) -> List[torch.Tensor]:
         result = []
         for idx in indices:
             result.append(self._free_buffer_list[idx])
         return result
 
-    def free_buffer(self, buffers: List[int]):
+    def free_buffer(self, buffers: List[int]) -> None:
 
         if not buffers:
             return  # 空列表，直接返回
@@ -269,12 +271,12 @@ class CopyBufferAllocator:
 
 
 def generate_test_data(
-    num_layers=64,
-    total_token_in_kvcache=1024,
-    num_tokens_in_block=128,
-    hidden_size=4096,
-    device="cuda",
-):
+    num_layers: int = 64,
+    total_token_in_kvcache: int = 1024,
+    num_tokens_in_block: int = 128,
+    hidden_size: int = 4096,
+    device: str = "cuda",
+) -> Tuple[List[torch.Tensor], torch.Tensor, List[int]]:
     # 生成KV caches (不连续的tensor列表)
     kv_caches = []
     for _ in range(num_layers):
@@ -297,13 +299,13 @@ def generate_test_data(
 
 def reference_impl(
     kv_caches: List[torch.Tensor], source_tensor: torch.Tensor, token_indices: List[int]
-):
+) -> None:
     """参考实现，用于验证正确性"""
     for layer_idx in range(len(kv_caches)):
         kv_caches[layer_idx][:, token_indices, :] = source_tensor[layer_idx]
 
 
-def main():
+def main() -> None:
     """测试算子实现的正确性"""
     torch.manual_seed(42)
     num_layers = 4  # 测试时减少层数以加快速度

--- a/kv_cache_manager/py_connector/ruff.toml
+++ b/kv_cache_manager/py_connector/ruff.toml
@@ -1,0 +1,15 @@
+# Lint & format rules for the kv_cache_manager Python connectors.
+# Scope: this directory only, so the rest of the repository is unaffected.
+# Mirrors the team's standard ruff setting (select ANN + F, ANN401 off).
+target-version = "py312"
+
+[lint]
+select = ["ANN", "F"]
+ignore = ["ANN401"]
+
+[lint.per-file-ignores]
+# Tests carry no annotations. They live in test/ and as flat test*.py
+# scripts next to the connectors they exercise (sglang/, trtllm/).
+"test/**" = ["ANN"]
+"**/test_*.py" = ["ANN"]
+"**/test.py" = ["ANN"]

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -1,8 +1,7 @@
 import hashlib
 import logging
-import math
 import uuid
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 import time
 import json
 
@@ -25,7 +24,8 @@ except ImportError:
     pass
 if StorageMetrics is None:
     try:
-        from sglang.srt.metrics.collector import StorageMetrics
+        # Older sglang versions kept StorageMetrics here.
+        from sglang.srt.metrics.collector import StorageMetrics  # ty: ignore[unresolved-import]
     except ImportError:
         raise ImportError(
             "Cannot import StorageMetrics from sglang. "
@@ -34,14 +34,20 @@ if StorageMetrics is None:
             "Please check your sglang version is compatible."
         )
 from sglang.srt.distributed import get_tp_group
+
+# get_attention_tp_group moved in newer sglang versions.
 from sglang.srt.layers.dp_attention import (
-    get_attention_tp_group,
+    get_attention_tp_group,  # ty: ignore[unresolved-import]
     is_dp_attention_enabled,
 )
 
 from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
-from kv_cache_manager.client.pybind import kvcm_py_client
-from kv_cache_manager.py_connector.common._version_info import (
+
+# kvcm_py_client is the compiled pybind11 client; it ships no type stubs.
+from kv_cache_manager.client.pybind import kvcm_py_client  # ty: ignore[unresolved-import]
+
+# Stamped into the wheel at build time; absent in a source checkout.
+from kv_cache_manager.py_connector.common._version_info import (  # ty: ignore[unresolved-import]
     FULL_VERSION,
     GIT_COMMIT,
     BUILD_TIME,
@@ -51,7 +57,7 @@ logger = logging.getLogger(__name__)
 
 
 class HiCacheKVCM(HiCacheStorage):
-    def __init__(self, storage_config: HiCacheStorageConfig, kwargs):
+    def __init__(self, storage_config: HiCacheStorageConfig, kwargs: Any) -> None:
         logger.warning(
             "KVCM sglang connector version: %s (commit: %s, build: %s)",
             FULL_VERSION,
@@ -60,7 +66,9 @@ class HiCacheKVCM(HiCacheStorage):
         )
         self.storage_config = storage_config
         # --hicache-storage-backend-extra-config '{"k":"v"}'
-        self.extra_config = self.storage_config.extra_config
+        # HiCacheStorageConfig types extra_config as Optional; sglang always
+        # provides it for a hicache storage backend.
+        self.extra_config: Dict[str, Any] = self.storage_config.extra_config  # ty: ignore[invalid-assignment]
 
         # deployment
         self.instance_group = self.extra_config["instance_group"]
@@ -70,7 +78,9 @@ class HiCacheKVCM(HiCacheStorage):
             self.extra_config
         )
 
-        self.registered_pools = {}
+        # PoolName -> the pool object; sglang's pool classes expose more than
+        # the HostKVCache base (e.g. get_page_buffer_meta), hence Any.
+        self.registered_pools: Dict[Any, Any] = {}
 
         self.prefetch_pgs = []
         self.backup_pgs = []
@@ -83,7 +93,7 @@ class HiCacheKVCM(HiCacheStorage):
         # "interface_v1": 1 in --hicache-storage-backend-extra-config.
         self.extra_config.setdefault("interface_v1", 1)
 
-    def _init_kvcm_client(self):
+    def _init_kvcm_client(self) -> None:
         # parallelism
         self.tp_rank = self.storage_config.tp_rank
         self.tp_size = self.storage_config.tp_size
@@ -293,7 +303,7 @@ class HiCacheKVCM(HiCacheStorage):
             "kvcm_py_client.TransferClient.Create failed"
         )
 
-    def parse_hf3fs_configs(self, storage_configs):
+    def parse_hf3fs_configs(self, storage_configs: str) -> List[Dict[str, Any]]:
         hf3fs_configs = []
         storage_configs_json = json.loads(storage_configs)
         for storage_config in storage_configs_json:
@@ -314,11 +324,14 @@ class HiCacheKVCM(HiCacheStorage):
             hf3fs_configs.append(hf3fs_config)
         return hf3fs_configs
 
-    def register_mem_pool_host(self, mem_pool_host: HostKVCache):
-        self.mem_pool_host = mem_pool_host
+    def register_mem_pool_host(self, mem_pool_host: HostKVCache) -> None:
+        # The pool objects expose more than the HostKVCache base
+        # (get_page_buffer_meta & co).
+        self.mem_pool_host: Any = mem_pool_host
         # Extract all pools from HostPoolGroup.entries if available
         if hasattr(mem_pool_host, "entries"):
-            for entry in mem_pool_host.entries:
+            # HostPoolGroup; sglang types entries as object.
+            for entry in mem_pool_host.entries:  # ty: ignore[not-iterable]
                 self.registered_pools[entry.name] = entry.host_pool
                 logger.info(
                     "register_mem_pool_host: found pool entry name=%s, "
@@ -339,7 +352,9 @@ class HiCacheKVCM(HiCacheStorage):
         )
         self._init_kvcm_client()
 
-    def register_mem_host_pool_v2(self, host_pool: HostKVCache, host_pool_name):
+    def register_mem_host_pool_v2(
+        self, host_pool: HostKVCache, host_pool_name: str
+    ) -> None:
         # All pools already extracted from HostPoolGroup in register_mem_pool_host,
         # so this is a no-op for KVCM connector.
         pass
@@ -560,7 +575,7 @@ class HiCacheKVCM(HiCacheStorage):
             )
             return [False] * len_new
         else:
-            recv = [None, None, None, None]
+            recv: List[Any] = [None, None, None, None]
             torch.distributed.broadcast_object_list(
                 recv, src=0, group=self.storage_tp_group
             )
@@ -831,7 +846,7 @@ class HiCacheKVCM(HiCacheStorage):
                     results[transfer.name] = [False] * len(keys)
                     continue
                 else:
-                    recv = [None]
+                    recv: List[Any] = [None]
                     torch.distributed.broadcast_object_list(
                         recv, src=0, group=self.storage_tp_group
                     )
@@ -1063,8 +1078,10 @@ class HiCacheKVCM(HiCacheStorage):
             logger.error(f"batch_exists_v2 failed: {trace_id=} {e=}")
             return PoolTransferResult.empty()
 
-    def get_stats(self):
-        storage_metrics = StorageMetrics()
+    def get_stats(self) -> Any:
+        # StorageMetrics is a class by the time the module finishes its
+        # import fallback chain; ty cannot prove the None path unreachable.
+        storage_metrics = StorageMetrics()  # ty: ignore[call-non-callable]
         storage_metrics.prefetch_pgs.extend(self.prefetch_pgs)
         storage_metrics.backup_pgs.extend(self.backup_pgs)
         storage_metrics.prefetch_bandwidth.extend(self.prefetch_bandwidth)
@@ -1096,8 +1113,8 @@ class HiCacheKVCM(HiCacheStorage):
         return str(uuid.uuid1())
 
     def _sha256_to_int64(self, data: str) -> int:
-        data = data.encode("utf-8")
-        hash_digest = hashlib.sha256(data).digest()
+        data = data.encode("utf-8")  # ty: ignore[invalid-assignment]
+        hash_digest = hashlib.sha256(data).digest()  # ty: ignore[invalid-argument-type]
         hash_int64 = int.from_bytes(hash_digest[:8], "big", signed=True)
         return hash_int64
 
@@ -1194,7 +1211,7 @@ class HiCacheKVCM(HiCacheStorage):
         save_indices = [(i - len_prefix) for i in save_indices if i >= len_prefix]
         return save_indices, prefix_write_count
 
-    def _extract_single_spec_uri(self, location, spec_name: str):
+    def _extract_single_spec_uri(self, location: dict, spec_name: str) -> Optional[str]:
         """Extract the URI for a named spec from a single location dict."""
         for spec in location.get("location_specs", []):
             if spec["name"] == spec_name and spec.get("uri"):
@@ -1232,8 +1249,8 @@ class HiCacheKVCM(HiCacheStorage):
         return 0
 
     def _prepare_extra_pool_buffers(
-        self, ptr_list, size_list, components_per_page: int
-    ):
+        self, ptr_list: List[int], size_list: List[int], components_per_page: int
+    ) -> List[kvcm_py_client.BlockBuffer]:
         """Convert get_page_buffer_meta output to BlockBuffer list.
 
         Each logical page maps to `components_per_page` IOVs in a single BlockBuffer.
@@ -1262,7 +1279,12 @@ class HiCacheKVCM(HiCacheStorage):
             return self.indexer_location_spec_name
         return None
 
-    def _check_pool_spec_existence(self, locations, kv_hit_pages, transfer):
+    def _check_pool_spec_existence(
+        self,
+        locations: List[dict],
+        kv_hit_pages: int,
+        transfer: PoolTransfer,
+    ) -> int:
         """Check how many pages have the extra pool's spec.
 
         Returns the number of contiguous prefix pages that satisfy
@@ -1273,7 +1295,7 @@ class HiCacheKVCM(HiCacheStorage):
         if spec_name is None:
             return kv_hit_pages
 
-        def has_spec(loc):
+        def has_spec(loc: dict) -> bool:
             return any(
                 spec["name"] == spec_name for spec in loc.get("location_specs", [])
             )

--- a/kv_cache_manager/py_connector/sglang/connector.py
+++ b/kv_cache_manager/py_connector/sglang/connector.py
@@ -17,6 +17,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolHitPolicy,
 )
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
+
 StorageMetrics = None
 try:
     from sglang.srt.observability.metrics_collector import StorageMetrics
@@ -33,18 +34,30 @@ if StorageMetrics is None:
             "Please check your sglang version is compatible."
         )
 from sglang.srt.distributed import get_tp_group
-from sglang.srt.layers.dp_attention import get_attention_tp_group, is_dp_attention_enabled
+from sglang.srt.layers.dp_attention import (
+    get_attention_tp_group,
+    is_dp_attention_enabled,
+)
 
 from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
 from kv_cache_manager.client.pybind import kvcm_py_client
-from kv_cache_manager.py_connector.common._version_info import FULL_VERSION, GIT_COMMIT, BUILD_TIME
+from kv_cache_manager.py_connector.common._version_info import (
+    FULL_VERSION,
+    GIT_COMMIT,
+    BUILD_TIME,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class HiCacheKVCM(HiCacheStorage):
     def __init__(self, storage_config: HiCacheStorageConfig, kwargs):
-        logger.warning("KVCM sglang connector version: %s (commit: %s, build: %s)", FULL_VERSION, GIT_COMMIT, BUILD_TIME)
+        logger.warning(
+            "KVCM sglang connector version: %s (commit: %s, build: %s)",
+            FULL_VERSION,
+            GIT_COMMIT,
+            BUILD_TIME,
+        )
         self.storage_config = storage_config
         # --hicache-storage-backend-extra-config '{"k":"v"}'
         self.extra_config = self.storage_config.extra_config
@@ -78,7 +91,11 @@ class HiCacheKVCM(HiCacheStorage):
         self.dp_size = 1
         self.pp_size = 1
 
-        tp_group = (get_attention_tp_group().cpu_group if is_dp_attention_enabled() else get_tp_group().cpu_group)
+        tp_group = (
+            get_attention_tp_group().cpu_group
+            if is_dp_attention_enabled()
+            else get_tp_group().cpu_group
+        )
         self.tp_world_size = torch.distributed.get_world_size(group=tp_group)
         if self.tp_world_size > 1:
             group_ranks = torch.distributed.get_process_group_ranks(tp_group)
@@ -98,17 +115,25 @@ class HiCacheKVCM(HiCacheStorage):
 
         # Detect extra pools early — _tp_rank_to_spec_name depends on these.
         self.has_mamba = PoolName.MAMBA in self.registered_pools
-        self.has_indexer = getattr(PoolName, "INDEXER", None) is not None and PoolName.INDEXER in self.registered_pools
+        self.has_indexer = (
+            getattr(PoolName, "INDEXER", None) is not None
+            and PoolName.INDEXER in self.registered_pools
+        )
 
         self.location_spec_size = kv_pool.get_size_per_token() * self.block_size
-        self.location_spec_infos = [{
-            "name": self._tp_rank_to_spec_name(rank),
-            "size": self.location_spec_size,
-        } for rank in range(self.tp_size)]
+        self.location_spec_infos = [
+            {
+                "name": self._tp_rank_to_spec_name(rank),
+                "size": self.location_spec_size,
+            }
+            for rank in range(self.tp_size)
+        ]
 
         # LocationSpecGroup: KV specs always prepared, but only sent when
         # extra pools exist (backward compat with older managers).
-        kv_spec_names = [self._tp_rank_to_spec_name(rank) for rank in range(self.tp_size)]
+        kv_spec_names = [
+            self._tp_rank_to_spec_name(rank) for rank in range(self.tp_size)
+        ]
         self.location_spec_groups = []
 
         # Mamba/Linear specs
@@ -118,14 +143,20 @@ class HiCacheKVCM(HiCacheStorage):
             linear_spec_names = []
             for rank in range(self.tp_size):
                 name = self._tp_rank_to_linear_spec_name(rank)
-                self.location_spec_infos.append({"name": name, "size": self.mamba_spec_size})
+                self.location_spec_infos.append(
+                    {"name": name, "size": self.mamba_spec_size}
+                )
                 linear_spec_names.append(name)
             mamba_spec_rank = 0 if self.is_mla_model else self.tp_rank
-            self.mamba_location_spec_name = self._tp_rank_to_linear_spec_name(mamba_spec_rank)
-            self.location_spec_groups.append({
-                "name": self._get_extra_pool_spec_group(PoolName.MAMBA),
-                "spec_names": linear_spec_names,
-            })
+            self.mamba_location_spec_name = self._tp_rank_to_linear_spec_name(
+                mamba_spec_rank
+            )
+            self.location_spec_groups.append(
+                {
+                    "name": self._get_extra_pool_spec_group(PoolName.MAMBA),
+                    "spec_names": linear_spec_names,
+                }
+            )
 
         # Indexer specs (NSA/DSA)
         if self.has_indexer:
@@ -134,20 +165,29 @@ class HiCacheKVCM(HiCacheStorage):
             indexer_spec_names = []
             for rank in range(self.tp_size):
                 name = self._tp_rank_to_indexer_spec_name(rank)
-                self.location_spec_infos.append({"name": name, "size": self.indexer_spec_size})
+                self.location_spec_infos.append(
+                    {"name": name, "size": self.indexer_spec_size}
+                )
                 indexer_spec_names.append(name)
             indexer_spec_rank = 0 if self.is_mla_model else self.tp_rank
-            self.indexer_location_spec_name = self._tp_rank_to_indexer_spec_name(indexer_spec_rank)
-            self.location_spec_groups.append({
-                "name": self._get_extra_pool_spec_group(PoolName.INDEXER),
-                "spec_names": indexer_spec_names,
-            })
+            self.indexer_location_spec_name = self._tp_rank_to_indexer_spec_name(
+                indexer_spec_rank
+            )
+            self.location_spec_groups.append(
+                {
+                    "name": self._get_extra_pool_spec_group(PoolName.INDEXER),
+                    "spec_names": indexer_spec_names,
+                }
+            )
 
         if self.location_spec_groups:
-            self.location_spec_groups.insert(0, {
-                "name": self._get_kv_spec_group(),
-                "spec_names": kv_spec_names,
-            })
+            self.location_spec_groups.insert(
+                0,
+                {
+                    "name": self._get_kv_spec_group(),
+                    "spec_names": kv_spec_names,
+                },
+            )
 
         self.deployment = {
             "model_name": self.model_name,
@@ -225,11 +265,13 @@ class HiCacheKVCM(HiCacheStorage):
                 self.location_spec_name: self.location_spec_size,
                 **(
                     {self.mamba_location_spec_name: self.mamba_spec_size}
-                    if self.has_mamba else {}
+                    if self.has_mamba
+                    else {}
                 ),
                 **(
                     {self.indexer_location_spec_name: self.indexer_spec_size}
-                    if self.has_indexer else {}
+                    if self.has_indexer
+                    else {}
                 ),
             },
         }
@@ -247,14 +289,18 @@ class HiCacheKVCM(HiCacheStorage):
         self.transfer_client = kvcm_py_client.TransferClient.Create(
             self.transfer_client_config, self.init_params
         )
-        assert self.transfer_client is not None, "kvcm_py_client.TransferClient.Create failed"
+        assert self.transfer_client is not None, (
+            "kvcm_py_client.TransferClient.Create failed"
+        )
 
     def parse_hf3fs_configs(self, storage_configs):
         hf3fs_configs = []
         storage_configs_json = json.loads(storage_configs)
         for storage_config in storage_configs_json:
             storage_type = storage_config["type"]
-            if storage_type not in ("hf3fs", "vcns_hf3fs") or not storage_config.get("is_available", True):
+            if storage_type not in ("hf3fs", "vcns_hf3fs") or not storage_config.get(
+                "is_available", True
+            ):
                 continue
             hf3fs_config = {
                 "type": storage_type,
@@ -271,7 +317,7 @@ class HiCacheKVCM(HiCacheStorage):
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
         self.mem_pool_host = mem_pool_host
         # Extract all pools from HostPoolGroup.entries if available
-        if hasattr(mem_pool_host, 'entries'):
+        if hasattr(mem_pool_host, "entries"):
             for entry in mem_pool_host.entries:
                 self.registered_pools[entry.name] = entry.host_pool
                 logger.info(
@@ -279,7 +325,7 @@ class HiCacheKVCM(HiCacheStorage):
                     "host_pool type=%s, is_anchor=%s",
                     entry.name,
                     type(entry.host_pool).__name__,
-                    getattr(entry, 'is_primary_index_anchor', None),
+                    getattr(entry, "is_primary_index_anchor", None),
                 )
         else:
             self.registered_pools[PoolName.KV] = mem_pool_host
@@ -324,7 +370,9 @@ class HiCacheKVCM(HiCacheStorage):
             return [False] * len_new
 
         # Data transfer preparation
-        buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
+        buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(
+            host_indices
+        )
         buffer_matched = matched * self.kv_factor
         buffer_ptrs = buffer_ptrs[:buffer_matched]
         buffer_sizes = buffer_sizes[:buffer_matched]
@@ -338,10 +386,12 @@ class HiCacheKVCM(HiCacheStorage):
         result = self.transfer_client.LoadKvCaches(uris, buffers)
         end_time = time.perf_counter()
         self.prefetch_pgs.append(matched)
-        self.prefetch_bandwidth.append(matched * self.location_spec_size / (1 << 30) / (end_time - start_time))
+        self.prefetch_bandwidth.append(
+            matched * self.location_spec_size / (1 << 30) / (end_time - start_time)
+        )
         logger.debug(f"LoadKvCaches {result=}")
 
-        flag = (result == kvcm_py_client.ClientErrorCode.ER_OK)
+        flag = result == kvcm_py_client.ClientErrorCode.ER_OK
         if not flag:
             logger.error(f"{result}")
         return [flag] * len_new
@@ -354,7 +404,12 @@ class HiCacheKVCM(HiCacheStorage):
     ) -> List[bool]:
         trace_id = self._get_trace_id()
         try:
-            result = self._batch_get(keys=keys, host_indices=host_indices, trace_id=trace_id, extra_info=extra_info)
+            result = self._batch_get(
+                keys=keys,
+                host_indices=host_indices,
+                trace_id=trace_id,
+                extra_info=extra_info,
+            )
             return result
         except Exception as e:
             logger.error(f"batch_get_v1 failed: {trace_id=} {e=}")
@@ -402,8 +457,16 @@ class HiCacheKVCM(HiCacheStorage):
 
                 ptr_list, size_list = pool.get_page_buffer_meta(transfer.host_indices)
                 components = self._get_extra_pool_components_per_page(transfer.name)
-                ptr_list = [p for i, p in enumerate(ptr_list) if (i // components) in valid_indices]
-                size_list = [s for i, s in enumerate(size_list) if (i // components) in valid_indices]
+                ptr_list = [
+                    p
+                    for i, p in enumerate(ptr_list)
+                    if (i // components) in valid_indices
+                ]
+                size_list = [
+                    s
+                    for i, s in enumerate(size_list)
+                    if (i // components) in valid_indices
+                ]
                 buffers = self._prepare_extra_pool_buffers(
                     ptr_list, size_list, components
                 )
@@ -412,12 +475,15 @@ class HiCacheKVCM(HiCacheStorage):
                 start_time = time.perf_counter()
                 load_result = self.transfer_client.LoadKvCaches(uris, buffers)
                 end_time = time.perf_counter()
-                flag = (load_result == kvcm_py_client.ClientErrorCode.ER_OK)
+                flag = load_result == kvcm_py_client.ClientErrorCode.ER_OK
                 if flag:
                     spec_size = self._get_extra_pool_spec_size(transfer.name)
                     self.prefetch_pgs.append(len(valid_indices))
                     self.prefetch_bandwidth.append(
-                        len(valid_indices) * spec_size / (1 << 30) / (end_time - start_time)
+                        len(valid_indices)
+                        * spec_size
+                        / (1 << 30)
+                        / (end_time - start_time)
                     )
                 per_key = [False] * len(keys)
                 for idx in valid_indices:
@@ -454,15 +520,19 @@ class HiCacheKVCM(HiCacheStorage):
 
         # Prepare keys
         block_keys, len_prefix, len_new = self._prepare_block_keys(keys, extra_info)
-        local_len_new = len_new        # Preserve local key count for return value
-        local_hash = hash((len_prefix, len_new, *block_keys))  # Hash covers prefix/new boundary + all keys
+        local_len_new = len_new  # Preserve local key count for return value
+        local_hash = hash(
+            (len_prefix, len_new, *block_keys)
+        )  # Hash covers prefix/new boundary + all keys
 
         # Start write cache
         if self.tp_rank == 0:
             start_trace_id = f"start-{trace_id}"
             # When extra pools exist, use KV spec group to write KV specs only
             has_extra_pools = self.has_mamba or self.has_indexer
-            location_spec_group_names = [self._get_kv_spec_group()] * len(block_keys) if has_extra_pools else []
+            location_spec_group_names = (
+                [self._get_kv_spec_group()] * len(block_keys) if has_extra_pools else []
+            )
             request = {
                 "trace_id": start_trace_id,
                 "instance_id": self.instance_id,
@@ -479,11 +549,15 @@ class HiCacheKVCM(HiCacheStorage):
 
             if self.tp_world_size > 1 and not self.is_mla_model:
                 torch.distributed.broadcast_object_list(
-                    [result, len_prefix, len_new, local_hash], src=0, group=self.storage_tp_group
+                    [result, len_prefix, len_new, local_hash],
+                    src=0,
+                    group=self.storage_tp_group,
                 )
         elif self.is_mla_model:
-            logger.warning(f"_batch_set called on non-rank-0 (tp_rank={self.tp_rank}) "
-                           f"for MLA model; only rank 0 should write. Returning all False.")
+            logger.warning(
+                f"_batch_set called on non-rank-0 (tp_rank={self.tp_rank}) "
+                f"for MLA model; only rank 0 should write. Returning all False."
+            )
             return [False] * len_new
         else:
             recv = [None, None, None, None]
@@ -503,9 +577,11 @@ class HiCacheKVCM(HiCacheStorage):
         # flags so NCCL doesn't hang.
         skip_transfer = False
         if self.tp_rank != 0 and local_hash != rank0_hash:
-            logger.warning(f"_batch_set: local block_keys hash ({local_hash}) != "
-                           f"rank 0 hash ({rank0_hash}), inputs diverged across TP ranks. "
-                           f"local_block_keys={block_keys}")
+            logger.warning(
+                f"_batch_set: local block_keys hash ({local_hash}) != "
+                f"rank 0 hash ({rank0_hash}), inputs diverged across TP ranks. "
+                f"local_block_keys={block_keys}"
+            )
             skip_transfer = True
 
         if result is None:
@@ -520,8 +596,10 @@ class HiCacheKVCM(HiCacheStorage):
 
         # None means truly broken manager data — treat as write failure.
         if parsed is None:
-            logger.warning(f"_batch_set: inconsistent block_mask from manager, "
-                           f"aborting write session {write_session_id}")
+            logger.warning(
+                f"_batch_set: inconsistent block_mask from manager, "
+                f"aborting write session {write_session_id}"
+            )
             if self.tp_rank == 0:
                 # Mark all locations as failed so manager cleans them up.
                 try:
@@ -530,7 +608,9 @@ class HiCacheKVCM(HiCacheStorage):
                             "trace_id": finish_trace_id,
                             "instance_id": self.instance_id,
                             "write_session_id": write_session_id,
-                            "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
+                            "success_blocks": {
+                                "bool_masks": {"values": [False] * len(locations)}
+                            },
                         }
                     )
                 except Exception as e:
@@ -549,7 +629,9 @@ class HiCacheKVCM(HiCacheStorage):
                             "trace_id": finish_trace_id,
                             "instance_id": self.instance_id,
                             "write_session_id": write_session_id,
-                            "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
+                            "success_blocks": {
+                                "bool_masks": {"values": [False] * len(locations)}
+                            },
                         }
                     )
                 except Exception as e:
@@ -571,25 +653,41 @@ class HiCacheKVCM(HiCacheStorage):
             # This rank's block_keys diverged from rank 0 — writing would
             # corrupt storage. Keep per_block_flags as all-zero and still
             # participate in all_reduce below.
-            logger.warning("_batch_set: skipping data transfer on this rank due to input divergence")
+            logger.warning(
+                "_batch_set: skipping data transfer on this rank due to input divergence"
+            )
         else:
             try:
-                buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(host_indices)
+                buffer_ptrs, buffer_sizes = self.mem_pool_host.get_page_buffer_meta(
+                    host_indices
+                )
                 local_block_count = len(buffer_ptrs) // self.kv_factor
 
                 # Determine which save_indices have local data available
                 valid_save_mask = [(idx < local_block_count) for idx in save_indices]
-                valid_save_set = set(idx for idx, valid in zip(save_indices, valid_save_mask) if valid)
+                valid_save_set = set(
+                    idx for idx, valid in zip(save_indices, valid_save_mask) if valid
+                )
                 num_valid = sum(valid_save_mask)
 
                 if num_valid > 0:
-                    buffer_ptrs = [ptr for i, ptr in enumerate(buffer_ptrs)
-                                   if (i // self.kv_factor) in valid_save_set]
-                    buffer_sizes = [sz for i, sz in enumerate(buffer_sizes)
-                                    if (i // self.kv_factor) in valid_save_set]
+                    buffer_ptrs = [
+                        ptr
+                        for i, ptr in enumerate(buffer_ptrs)
+                        if (i // self.kv_factor) in valid_save_set
+                    ]
+                    buffer_sizes = [
+                        sz
+                        for i, sz in enumerate(buffer_sizes)
+                        if (i // self.kv_factor) in valid_save_set
+                    ]
 
                     # Extract URIs only for blocks with local data
-                    valid_locations = [loc for loc, valid in zip(new_locations, valid_save_mask) if valid]
+                    valid_locations = [
+                        loc
+                        for loc, valid in zip(new_locations, valid_save_mask)
+                        if valid
+                    ]
                     uris = self._extract_uris(valid_locations)
                     buffers = self._prepare_buffers(buffer_ptrs, buffer_sizes)
                     assert len(uris) == len(buffers)
@@ -599,10 +697,15 @@ class HiCacheKVCM(HiCacheStorage):
                     result = self.transfer_client.SaveKvCaches(uris, buffers)
                     end_time = time.perf_counter()
                     self.backup_pgs.append(num_valid)
-                    self.backup_bandwidth.append(num_valid * self.location_spec_size / (1 << 30) / (end_time - start_time))
+                    self.backup_bandwidth.append(
+                        num_valid
+                        * self.location_spec_size
+                        / (1 << 30)
+                        / (end_time - start_time)
+                    )
                     logger.debug(f"SaveKvCaches {result=}")
 
-                    transfer_ok = (result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
+                    transfer_ok = result[0] == kvcm_py_client.ClientErrorCode.ER_OK
                     if not transfer_ok:
                         logger.error(f"SaveKvCaches error: {result}")
                 else:
@@ -650,11 +753,10 @@ class HiCacheKVCM(HiCacheStorage):
         # local keys don't match rank 0's — return all False.
         if skip_transfer:
             return [False] * local_len_new
-        block_flag_map = {save_indices[j]: new_block_success[j] for j in range(unmatched)}
-        result_list = [
-            block_flag_map.get(i, True)
-            for i in range(local_len_new)
-        ]
+        block_flag_map = {
+            save_indices[j]: new_block_success[j] for j in range(unmatched)
+        }
+        result_list = [block_flag_map.get(i, True) for i in range(local_len_new)]
         return result_list
 
     def batch_set_v1(
@@ -665,7 +767,12 @@ class HiCacheKVCM(HiCacheStorage):
     ) -> List[bool]:
         trace_id = self._get_trace_id()
         try:
-            result = self._batch_set(keys=keys, host_indices=host_indices, trace_id=trace_id, extra_info=extra_info)
+            result = self._batch_set(
+                keys=keys,
+                host_indices=host_indices,
+                trace_id=trace_id,
+                extra_info=extra_info,
+            )
             return result
         except Exception as e:
             logger.error(f"batch_set_v1 failed: {trace_id=} {e=}")
@@ -708,15 +815,19 @@ class HiCacheKVCM(HiCacheStorage):
                     try:
                         write_result = self._manager_client.start_write_cache(request)
                     except Exception as e:
-                        logger.error(f"start_write_cache failed on rank 0: {trace_id=} {e=}")
+                        logger.error(
+                            f"start_write_cache failed on rank 0: {trace_id=} {e=}"
+                        )
                         write_result = None
                     if self.tp_world_size > 1 and not self.is_mla_model:
                         torch.distributed.broadcast_object_list(
                             [write_result], src=0, group=self.storage_tp_group
                         )
                 elif self.is_mla_model:
-                    logger.warning(f"batch_set_v2 called on non-rank-0 (tp_rank={self.tp_rank}) "
-                                   f"for MLA model; only rank 0 should write. Returning all False.")
+                    logger.warning(
+                        f"batch_set_v2 called on non-rank-0 (tp_rank={self.tp_rank}) "
+                        f"for MLA model; only rank 0 should write. Returning all False."
+                    )
                     results[transfer.name] = [False] * len(keys)
                     continue
                 else:
@@ -737,16 +848,24 @@ class HiCacheKVCM(HiCacheStorage):
                 parsed = self._parse_block_mask(block_mask, 0, len(keys))
 
                 if parsed is None:
-                    logger.warning(f"batch_set_v2: inconsistent block_mask from manager, "
-                                   f"aborting write session {write_session_id}")
+                    logger.warning(
+                        f"batch_set_v2: inconsistent block_mask from manager, "
+                        f"aborting write session {write_session_id}"
+                    )
                     if self.tp_rank == 0:
                         try:
-                            self._manager_client.finish_write_cache({
-                                "trace_id": finish_trace_id,
-                                "instance_id": self.instance_id,
-                                "write_session_id": write_session_id,
-                                "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
-                            })
+                            self._manager_client.finish_write_cache(
+                                {
+                                    "trace_id": finish_trace_id,
+                                    "instance_id": self.instance_id,
+                                    "write_session_id": write_session_id,
+                                    "success_blocks": {
+                                        "bool_masks": {
+                                            "values": [False] * len(locations)
+                                        }
+                                    },
+                                }
+                            )
                         except Exception as e:
                             logger.error(f"finish_write_cache failed: {e}")
                     results[transfer.name] = [False] * len(keys)
@@ -758,12 +877,18 @@ class HiCacheKVCM(HiCacheStorage):
                 if unmatched == 0:
                     if self.tp_rank == 0:
                         try:
-                            self._manager_client.finish_write_cache({
-                                "trace_id": finish_trace_id,
-                                "instance_id": self.instance_id,
-                                "write_session_id": write_session_id,
-                                "success_blocks": {"bool_masks": {"values": [False] * len(locations)}},
-                            })
+                            self._manager_client.finish_write_cache(
+                                {
+                                    "trace_id": finish_trace_id,
+                                    "instance_id": self.instance_id,
+                                    "write_session_id": write_session_id,
+                                    "success_blocks": {
+                                        "bool_masks": {
+                                            "values": [False] * len(locations)
+                                        }
+                                    },
+                                }
+                            )
                         except Exception as e:
                             logger.error(f"finish_write_cache failed: {e}")
                     results[transfer.name] = [True] * len(keys)
@@ -775,11 +900,21 @@ class HiCacheKVCM(HiCacheStorage):
                 # Wrapped in try-except so that every rank always reaches the
                 # all_reduce below, preventing cross-rank NCCL/gloo hangs.
                 try:
-                    ptr_list, size_list = pool.get_page_buffer_meta(transfer.host_indices)
+                    ptr_list, size_list = pool.get_page_buffer_meta(
+                        transfer.host_indices
+                    )
                     components = self._get_extra_pool_components_per_page(transfer.name)
                     save_set = set(save_indices)
-                    ptr_list = [p for i, p in enumerate(ptr_list) if (i // components) in save_set]
-                    size_list = [s for i, s in enumerate(size_list) if (i // components) in save_set]
+                    ptr_list = [
+                        p
+                        for i, p in enumerate(ptr_list)
+                        if (i // components) in save_set
+                    ]
+                    size_list = [
+                        s
+                        for i, s in enumerate(size_list)
+                        if (i // components) in save_set
+                    ]
 
                     uris = []
                     for loc in locations:
@@ -793,7 +928,7 @@ class HiCacheKVCM(HiCacheStorage):
                     start_time = time.perf_counter()
                     save_result = self.transfer_client.SaveKvCaches(uris, buffers)
                     end_time = time.perf_counter()
-                    flag = (save_result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
+                    flag = save_result[0] == kvcm_py_client.ClientErrorCode.ER_OK
                     if flag:
                         spec_size = self._get_extra_pool_spec_size(transfer.name)
                         self.backup_pgs.append(unmatched)
@@ -803,7 +938,9 @@ class HiCacheKVCM(HiCacheStorage):
                     if not flag:
                         logger.error(f"SaveKvCaches v2 error: {transfer.name}")
                 except Exception as e:
-                    logger.error(f"Data transfer v2 (SaveKvCaches) failed: {transfer.name} {e}")
+                    logger.error(
+                        f"Data transfer v2 (SaveKvCaches) failed: {transfer.name} {e}"
+                    )
                     flag = False
 
                 if self.tp_world_size > 1 and not self.is_mla_model:
@@ -818,12 +955,16 @@ class HiCacheKVCM(HiCacheStorage):
                 finish_mask = [flag] * len(locations)
                 if self.tp_rank == 0:
                     try:
-                        self._manager_client.finish_write_cache({
-                            "trace_id": finish_trace_id,
-                            "instance_id": self.instance_id,
-                            "write_session_id": write_session_id,
-                            "success_blocks": {"bool_masks": {"values": finish_mask}},
-                        })
+                        self._manager_client.finish_write_cache(
+                            {
+                                "trace_id": finish_trace_id,
+                                "instance_id": self.instance_id,
+                                "write_session_id": write_session_id,
+                                "success_blocks": {
+                                    "bool_masks": {"values": finish_mask}
+                                },
+                            }
+                        )
                     except Exception as e:
                         logger.error(f"finish_write_cache failed: {e}")
 
@@ -862,7 +1003,9 @@ class HiCacheKVCM(HiCacheStorage):
     ) -> int:
         trace_id = self._get_trace_id()
         try:
-            result = self._batch_exists(keys=keys, trace_id=trace_id, extra_info=extra_info)
+            result = self._batch_exists(
+                keys=keys, trace_id=trace_id, extra_info=extra_info
+            )
             return result
         except Exception as e:
             logger.error(f"batch_exists failed: {trace_id=} {e=}")
@@ -906,7 +1049,7 @@ class HiCacheKVCM(HiCacheStorage):
             final_pages = kv_hit_pages
 
             # Check extra pool spec existence
-            for transfer in (pool_transfers or []):
+            for transfer in pool_transfers or []:
                 if final_pages == 0:
                     break
                 boundary = self._check_pool_spec_existence(
@@ -959,7 +1102,8 @@ class HiCacheKVCM(HiCacheStorage):
         return hash_int64
 
     def _prepare_block_keys(
-            self, keys: List[str], extra_info: Optional[HiCacheStorageExtraInfo] = None) -> tuple[List[int], int, int]:
+        self, keys: List[str], extra_info: Optional[HiCacheStorageExtraInfo] = None
+    ) -> tuple[List[int], int, int]:
         """Prepare block keys and return them along with the prefix offset."""
         prefix_keys = (
             extra_info.prefix_keys
@@ -967,9 +1111,7 @@ class HiCacheKVCM(HiCacheStorage):
             else []
         )
         block_keys = prefix_keys + keys
-        block_keys = [
-            self._sha256_to_int64(block_key) for block_key in block_keys
-        ]
+        block_keys = [self._sha256_to_int64(block_key) for block_key in block_keys]
         return block_keys, len(prefix_keys), len(keys)
 
     def _extract_uris(self, locations: List[dict]) -> List[str]:
@@ -981,7 +1123,9 @@ class HiCacheKVCM(HiCacheStorage):
                     uris.append(location_spec["uri"])
         return uris
 
-    def _prepare_buffers(self, buffer_ptrs: List[int], buffer_sizes: List[int]) -> List[kvcm_py_client.BlockBuffer]:
+    def _prepare_buffers(
+        self, buffer_ptrs: List[int], buffer_sizes: List[int]
+    ) -> List[kvcm_py_client.BlockBuffer]:
         """Prepare buffers for data transfer."""
         buffers = []
         for i in range(0, len(buffer_ptrs), self.kv_factor):
@@ -998,7 +1142,9 @@ class HiCacheKVCM(HiCacheStorage):
             buffers.append(buffer)
         return buffers
 
-    def _parse_block_mask(self, block_mask: dict, len_prefix: int, len_new: int) -> Optional[tuple[List[int], int]]:
+    def _parse_block_mask(
+        self, block_mask: dict, len_prefix: int, len_new: int
+    ) -> Optional[tuple[List[int], int]]:
         """Parse block_mask from manager to determine which new-block indices need writing.
 
         Returns:
@@ -1017,8 +1163,10 @@ class HiCacheKVCM(HiCacheStorage):
             if offset < len_prefix:
                 # Best-effort: prefix blocks [offset, len_prefix) can't be written
                 # by sglang (no data available), but new blocks can still proceed.
-                logger.warning(f"_parse_block_mask: offset {offset} < len_prefix {len_prefix}, "
-                               "prefix blocks will be skipped (best-effort)")
+                logger.warning(
+                    f"_parse_block_mask: offset {offset} < len_prefix {len_prefix}, "
+                    "prefix blocks will be skipped (best-effort)"
+                )
                 prefix_write_count = len_prefix - offset
                 save_indices.extend(range(len_prefix, len_prefix + len_new))
             else:
@@ -1028,15 +1176,21 @@ class HiCacheKVCM(HiCacheStorage):
             bool_masks = block_mask.get("bool_masks", {}).get("values", [])
             if len(bool_masks) < len_prefix + len_new:
                 # Incomplete mask data from manager.
-                logger.warning(f"_parse_block_mask: bool_masks length {len(bool_masks)} < "
-                               f"expected {len_prefix + len_new}, treating as inconsistent state")
+                logger.warning(
+                    f"_parse_block_mask: bool_masks length {len(bool_masks)} < "
+                    f"expected {len_prefix + len_new}, treating as inconsistent state"
+                )
                 return None
             prefix_write_count = sum(1 for v in bool_masks[:len_prefix] if not v)
             if prefix_write_count > 0:
-                logger.warning(f"_parse_block_mask: {prefix_write_count} prefix blocks "
-                               "not cached in bool_masks, will be skipped (best-effort)")
+                logger.warning(
+                    f"_parse_block_mask: {prefix_write_count} prefix blocks "
+                    "not cached in bool_masks, will be skipped (best-effort)"
+                )
             max_index = max([i for i, x in enumerate(bool_masks) if not x], default=-1)
-            save_indices.extend([i for i in range(len_prefix, max_index + 1) if not bool_masks[i]])
+            save_indices.extend(
+                [i for i in range(len_prefix, max_index + 1) if not bool_masks[i]]
+            )
         save_indices = [(i - len_prefix) for i in save_indices if i >= len_prefix]
         return save_indices, prefix_write_count
 
@@ -1077,8 +1231,9 @@ class HiCacheKVCM(HiCacheStorage):
             return self.indexer_spec_size
         return 0
 
-
-    def _prepare_extra_pool_buffers(self, ptr_list, size_list, components_per_page: int):
+    def _prepare_extra_pool_buffers(
+        self, ptr_list, size_list, components_per_page: int
+    ):
         """Convert get_page_buffer_meta output to BlockBuffer list.
 
         Each logical page maps to `components_per_page` IOVs in a single BlockBuffer.

--- a/kv_cache_manager/py_connector/sglang/test.py
+++ b/kv_cache_manager/py_connector/sglang/test.py
@@ -7,6 +7,7 @@ import signal
 import time
 import os
 import atexit
+from typing import Any
 import requests
 import torch
 import torch.multiprocessing as mp
@@ -61,7 +62,7 @@ manager_log_dir = os.environ.get("KVCM_LOG_DIR", "/root/KVCacheManager/logs")
 proc = None
 
 
-def _stop_manager():
+def _stop_manager(*args: Any) -> None:
     """Stop the KV Cache Manager process."""
     global proc
     if proc and proc.poll() is None:

--- a/kv_cache_manager/py_connector/sglang/test.py
+++ b/kv_cache_manager/py_connector/sglang/test.py
@@ -7,7 +7,7 @@ import signal
 import time
 import os
 import atexit
-from typing import Any
+from typing import Any, cast
 import requests
 import torch
 import torch.multiprocessing as mp
@@ -17,7 +17,11 @@ from sglang.srt.mem_cache.hicache_storage import (
 )
 from sglang.srt.mem_cache.utils import get_hash_str
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
-from sglang.srt.mem_cache.memory_pool_host import MHATokenToKVPoolHost
+
+# MHATokenToKVPoolHost moved in newer sglang versions.
+from sglang.srt.mem_cache.memory_pool_host import (
+    MHATokenToKVPoolHost,  # ty: ignore[unresolved-import]
+)
 from sglang.srt.distributed import (
     init_distributed_environment,
     initialize_model_parallel,
@@ -158,7 +162,7 @@ def test():
     host_indices = []
 
     for i in range(0, 1024, page_size):
-        block_hash = get_hash_str(token_ids[i : i + page_size], block_hash)
+        block_hash = cast(str, get_hash_str(token_ids[i : i + page_size], block_hash))
         block_hashes.append(block_hash)
         host_indices.extend(range(i, i + page_size))
 
@@ -310,7 +314,9 @@ def test_fault_injection(storage_backend):
     fi_block_hash = None
     fi_host_indices = []
     for i in range(0, 1024, page_size):
-        fi_block_hash = get_hash_str(fi_token_ids[i : i + page_size], fi_block_hash)
+        fi_block_hash = cast(
+            str, get_hash_str(fi_token_ids[i : i + page_size], fi_block_hash)
+        )
         fi_block_hashes.append(fi_block_hash)
         fi_host_indices.extend(range(i + 4096, i + 4096 + page_size))
 
@@ -504,7 +510,7 @@ def _multi_rank_worker(rank, world_size, init_port):
         def __init__(self, cpu_group):
             self.cpu_group = cpu_group
 
-    _ps._TP = _GlooTPGroup(
+    _ps._TP = _GlooTPGroup(  # ty: ignore[invalid-assignment]
         torch.distributed.new_group(list(range(world_size)), backend="gloo")
     )
 
@@ -561,11 +567,11 @@ def _multi_rank_worker(rank, world_size, init_port):
     mr_hash = None
     mr_indices = []
     for i in range(0, mr_max_total_num_tokens, page_size):
-        mr_hash = get_hash_str(mr_token_ids[i : i + page_size], mr_hash)
+        mr_hash = cast(str, get_hash_str(mr_token_ids[i : i + page_size], mr_hash))
         mr_hashes.append(mr_hash)
         mr_indices.extend(range(i, i + page_size))
 
-    debug_client = DebugServiceClient(debug_uri) if rank == 0 else None
+    debug_client: Any = DebugServiceClient(debug_uri) if rank == 0 else None
 
     # ------------------------------------------------------------------
     # MR-1: Normal multi-rank set
@@ -742,7 +748,7 @@ def _multi_rank_worker(rank, world_size, init_port):
         h8 = []
         _h = None
         for i in range(0, len(diverge_ids), page_size):
-            _h = get_hash_str(diverge_ids[i : i + page_size], _h)
+            _h = cast(str, get_hash_str(diverge_ids[i : i + page_size], _h))
             h8.append(_h)
 
     idx8 = mr_indices[30 * page_size : 33 * page_size]  # 3 blocks

--- a/kv_cache_manager/py_connector/sglang/test.py
+++ b/kv_cache_manager/py_connector/sglang/test.py
@@ -1,4 +1,5 @@
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 
 import subprocess
@@ -38,7 +39,9 @@ hicache_mem_layout = "page_first_direct"
 
 manager_uri = os.environ.get("KVCM_MANAGER_URI", "http://127.0.0.1:6382")
 manager_http_port = int(manager_uri.rsplit(":", 1)[-1])
-debug_uri = os.environ.get("KVCM_DEBUG_URI", f"http://127.0.0.1:{manager_http_port + 3000}")
+debug_uri = os.environ.get(
+    "KVCM_DEBUG_URI", f"http://127.0.0.1:{manager_http_port + 3000}"
+)
 
 manager_bin = os.environ.get(
     "KVCM_MANAGER_BIN",
@@ -83,12 +86,17 @@ def _start_manager():
     subprocess.run(f"rm -rf {manager_log_dir}/*", shell=True, check=False)
 
     # Start the manager process (with debug service enabled for fault injection)
-    proc = subprocess.Popen([
-        manager_bin,
-        "-c", manager_server_conf,
-        "-l", manager_logger_conf,
-        "--env", "kvcm.service.enable_debug_service=true",
-    ])
+    proc = subprocess.Popen(
+        [
+            manager_bin,
+            "-c",
+            manager_server_conf,
+            "-l",
+            manager_logger_conf,
+            "--env",
+            "kvcm.service.enable_debug_service=true",
+        ]
+    )
 
     # Register cleanup handlers
     signal.signal(signal.SIGINT, _stop_manager)
@@ -149,7 +157,7 @@ def test():
     host_indices = []
 
     for i in range(0, 1024, page_size):
-        block_hash = get_hash_str(token_ids[i: i + page_size], block_hash)
+        block_hash = get_hash_str(token_ids[i : i + page_size], block_hash)
         block_hashes.append(block_hash)
         host_indices.extend(range(i, i + page_size))
 
@@ -163,18 +171,22 @@ def test():
 
     # Test 1: Basic set/get operations
     block_hashes_0 = block_hashes[:10]
-    host_indices_0 = host_indices[:(10 * page_size)]
+    host_indices_0 = host_indices[: (10 * page_size)]
 
     # Verify blocks don't exist initially
     assert storage_backend.batch_exists(block_hashes_0) == 0
 
     # Set blocks and verify they exist
-    set_result = storage_backend.batch_set_v1(block_hashes_0, torch.tensor(host_indices_0))
+    set_result = storage_backend.batch_set_v1(
+        block_hashes_0, torch.tensor(host_indices_0)
+    )
     assert all(set_result)
     assert storage_backend.batch_exists(block_hashes_0) == len(block_hashes_0)
 
     # Get blocks and verify data integrity
-    get_result = storage_backend.batch_get_v1(block_hashes_0, torch.tensor(host_indices_0))
+    get_result = storage_backend.batch_get_v1(
+        block_hashes_0, torch.tensor(host_indices_0)
+    )
     assert all(get_result)
 
     # Verify data in KV buffer
@@ -190,26 +202,32 @@ def test():
     prefix_keys_1 = block_hashes_0
     extra_info_1 = HiCacheStorageExtraInfo(prefix_keys=prefix_keys_1)
     block_hashes_1 = block_hashes[10:20]
-    host_indices_1 = host_indices[(10 * page_size):(20 * page_size)]
+    host_indices_1 = host_indices[(10 * page_size) : (20 * page_size)]
 
     # Verify blocks don't exist initially
     assert storage_backend.batch_exists(block_hashes_1, extra_info_1) == 0
 
     # Set blocks with prefix and verify they exist
-    set_result = storage_backend.batch_set_v1(block_hashes_1, torch.tensor(host_indices_1), extra_info_1)
+    set_result = storage_backend.batch_set_v1(
+        block_hashes_1, torch.tensor(host_indices_1), extra_info_1
+    )
     assert all(set_result)
-    assert storage_backend.batch_exists(block_hashes_1, extra_info_1) == len(block_hashes_1)
+    assert storage_backend.batch_exists(block_hashes_1, extra_info_1) == len(
+        block_hashes_1
+    )
 
     # Test 3: Get with different prefix
     prefix_keys_2 = block_hashes[:5]
     extra_info_2 = HiCacheStorageExtraInfo(prefix_keys=prefix_keys_2)
     block_hashes_2 = block_hashes[5:15]
-    host_indices_2 = host_indices[(5 * page_size):(15 * page_size)]
+    host_indices_2 = host_indices[(5 * page_size) : (15 * page_size)]
     index_shift = 1024
     host_indices_2 = [v + index_shift for v in host_indices_2]
 
     # Get blocks with different prefix
-    get_result = storage_backend.batch_get_v1(block_hashes_2, torch.tensor(host_indices_2), extra_info_2)
+    get_result = storage_backend.batch_get_v1(
+        block_hashes_2, torch.tensor(host_indices_2), extra_info_2
+    )
     assert all(get_result)
 
     # Verify data in KV buffer
@@ -218,7 +236,9 @@ def test():
         token_id = i % page_size
         bf16_i = torch.tensor(i - index_shift, dtype=torch.bfloat16)
         tensor_i = mem_pool_host.kv_buffer[:, page_id, :, token_id]
-        assert torch.mean(tensor_i).item() == bf16_i, f"{torch.mean(tensor_i).item()=} == {bf16_i=}"
+        assert torch.mean(tensor_i).item() == bf16_i, (
+            f"{torch.mean(tensor_i).item()=} == {bf16_i=}"
+        )
         assert torch.std(tensor_i).item() == 0
 
     return storage_backend
@@ -230,20 +250,30 @@ class DebugServiceClient:
     def __init__(self, base_url):
         self.base_url = base_url
         self.session = requests.Session()
-        self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
 
     def _make_request(self, endpoint, data=None):
         url = self.base_url + endpoint
         response = self.session.post(url, json=data, headers=self.headers)
         response_data = response.json()
-        assert response.status_code == 200, \
+        assert response.status_code == 200, (
             f"Debug API {endpoint} failed: {response.status_code}"
-        assert response_data.get('header', {}).get('status', {}).get('code') == 'OK', \
+        )
+        assert response_data.get("header", {}).get("status", {}).get("code") == "OK", (
             f"Debug API {endpoint} error: {response_data}"
+        )
         return response_data
 
-    def inject_fault(self, api_name, fault_type="INTERNAL_ERROR",
-                     strategy="ALWAYS", trigger_at_call=None):
+    def inject_fault(
+        self,
+        api_name,
+        fault_type="INTERNAL_ERROR",
+        strategy="ALWAYS",
+        trigger_at_call=None,
+    ):
         data = {
             "api_name": api_name,
             "fault_type": fault_type,
@@ -251,13 +281,13 @@ class DebugServiceClient:
         }
         if trigger_at_call is not None:
             data["trigger_at_call"] = trigger_at_call
-        return self._make_request('/api/injectFault', data)
+        return self._make_request("/api/injectFault", data)
 
     def remove_fault(self, api_name):
-        return self._make_request('/api/removeFault', {"api_name": api_name})
+        return self._make_request("/api/removeFault", {"api_name": api_name})
 
     def clear_faults(self):
-        return self._make_request('/api/clearFaults', {})
+        return self._make_request("/api/clearFaults", {})
 
     def close(self):
         self.session.close()
@@ -279,7 +309,7 @@ def test_fault_injection(storage_backend):
     fi_block_hash = None
     fi_host_indices = []
     for i in range(0, 1024, page_size):
-        fi_block_hash = get_hash_str(fi_token_ids[i:i + page_size], fi_block_hash)
+        fi_block_hash = get_hash_str(fi_token_ids[i : i + page_size], fi_block_hash)
         fi_block_hashes.append(fi_block_hash)
         fi_host_indices.extend(range(i + 4096, i + 4096 + page_size))
 
@@ -293,12 +323,14 @@ def test_fault_injection(storage_backend):
         debug_client.inject_fault("StartWriteCache")
 
         hashes = fi_block_hashes[:5]
-        indices = fi_host_indices[:(5 * page_size)]
-        set_result = storage_backend.batch_set_v1(
-            hashes, torch.tensor(indices))
-        assert all(r is False for r in set_result), \
+        indices = fi_host_indices[: (5 * page_size)]
+        set_result = storage_backend.batch_set_v1(hashes, torch.tensor(indices))
+        assert all(r is False for r in set_result), (
             f"FI-1 FAILED: expected all False, got {set_result}"
-        logger.info("FI-1 PASSED: StartWriteCache fault → batch_set_v1 returns all False")
+        )
+        logger.info(
+            "FI-1 PASSED: StartWriteCache fault → batch_set_v1 returns all False"
+        )
 
         debug_client.remove_fault("StartWriteCache")
 
@@ -308,19 +340,20 @@ def test_fault_injection(storage_backend):
         logger.info("=== FI-2: GetCacheLocation ALWAYS fault (batch_get) ===")
         debug_client.inject_fault("GetCacheLocation")
 
-        get_result = storage_backend.batch_get_v1(
-            hashes, torch.tensor(indices))
-        assert all(r is False for r in get_result), \
+        get_result = storage_backend.batch_get_v1(hashes, torch.tensor(indices))
+        assert all(r is False for r in get_result), (
             f"FI-2 FAILED: expected all False, got {get_result}"
-        logger.info("FI-2 PASSED: GetCacheLocation fault → batch_get_v1 returns all False")
+        )
+        logger.info(
+            "FI-2 PASSED: GetCacheLocation fault → batch_get_v1 returns all False"
+        )
 
         # ----------------------------------------------------------
         # Test FI-3: GetCacheLocation ALWAYS fault (batch_exists)
         # ----------------------------------------------------------
         logger.info("=== FI-3: GetCacheLocation ALWAYS fault (batch_exists) ===")
         exists_result = storage_backend.batch_exists(hashes)
-        assert exists_result == 0, \
-            f"FI-3 FAILED: expected 0, got {exists_result}"
+        assert exists_result == 0, f"FI-3 FAILED: expected 0, got {exists_result}"
         logger.info("FI-3 PASSED: GetCacheLocation fault → batch_exists returns 0")
 
         debug_client.remove_fault("GetCacheLocation")
@@ -337,12 +370,14 @@ def test_fault_injection(storage_backend):
         debug_client.inject_fault("FinishWriteCache")
 
         fi4_hashes = fi_block_hashes[10:15]
-        fi4_indices = fi_host_indices[(10 * page_size):(15 * page_size)]
-        set_result = storage_backend.batch_set_v1(
-            fi4_hashes, torch.tensor(fi4_indices))
-        assert all(r is False for r in set_result), \
+        fi4_indices = fi_host_indices[(10 * page_size) : (15 * page_size)]
+        set_result = storage_backend.batch_set_v1(fi4_hashes, torch.tensor(fi4_indices))
+        assert all(r is False for r in set_result), (
             f"FI-4 FAILED: expected all False, got {set_result}"
-        logger.info("FI-4 PASSED: FinishWriteCache fault → batch_set_v1 returns all False")
+        )
+        logger.info(
+            "FI-4 PASSED: FinishWriteCache fault → batch_set_v1 returns all False"
+        )
 
         debug_client.remove_fault("FinishWriteCache")
 
@@ -357,29 +392,31 @@ def test_fault_injection(storage_backend):
         # The blocks were never successfully written during fault tests,
         # so batch_exists and batch_get should report miss.
         exists_result = storage_backend.batch_exists(hashes)
-        assert exists_result == 0, \
+        assert exists_result == 0, (
             f"FI-5 FAILED: expected 0 (not cached), got {exists_result}"
+        )
 
-        get_result = storage_backend.batch_get_v1(
-            hashes, torch.tensor(indices))
-        assert all(r is False for r in get_result), \
+        get_result = storage_backend.batch_get_v1(hashes, torch.tensor(indices))
+        assert all(r is False for r in get_result), (
             f"FI-5 FAILED: expected all False (cache miss), got {get_result}"
+        )
 
         # Now set should succeed.
-        set_result = storage_backend.batch_set_v1(
-            hashes, torch.tensor(indices))
-        assert all(set_result), \
+        set_result = storage_backend.batch_set_v1(hashes, torch.tensor(indices))
+        assert all(set_result), (
             f"FI-5 FAILED: expected all True after clearing faults, got {set_result}"
+        )
 
         # After successful set, get should hit.
-        get_result = storage_backend.batch_get_v1(
-            hashes, torch.tensor(indices))
-        assert all(get_result), \
+        get_result = storage_backend.batch_get_v1(hashes, torch.tensor(indices))
+        assert all(get_result), (
             f"FI-5 FAILED: expected all True (cache hit), got {get_result}"
+        )
 
         exists_result = storage_backend.batch_exists(hashes)
-        assert exists_result == len(hashes), \
+        assert exists_result == len(hashes), (
             f"FI-5 FAILED: expected {len(hashes)}, got {exists_result}"
+        )
         logger.info("FI-5 PASSED: get miss → set → get hit after clearing faults")
 
         # ----------------------------------------------------------
@@ -392,12 +429,16 @@ def test_fault_injection(storage_backend):
         prefix_keys = fi_block_hashes[:5]
         extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
         suffix_hashes = fi_block_hashes[5:10]
-        suffix_indices = fi_host_indices[(5 * page_size):(10 * page_size)]
+        suffix_indices = fi_host_indices[(5 * page_size) : (10 * page_size)]
         set_result = storage_backend.batch_set_v1(
-            suffix_hashes, torch.tensor(suffix_indices), extra_info)
-        assert all(r is False for r in set_result), \
+            suffix_hashes, torch.tensor(suffix_indices), extra_info
+        )
+        assert all(r is False for r in set_result), (
             f"FI-6 FAILED: expected all False, got {set_result}"
-        logger.info("FI-6 PASSED: StartWriteCache fault with prefix → returns all False")
+        )
+        logger.info(
+            "FI-6 PASSED: StartWriteCache fault with prefix → returns all False"
+        )
 
         debug_client.remove_fault("StartWriteCache")
 
@@ -408,17 +449,20 @@ def test_fault_injection(storage_backend):
         debug_client.inject_fault("GetCacheLocation")
 
         get_result = storage_backend.batch_get_v1(
-            suffix_hashes, torch.tensor(suffix_indices), extra_info)
-        assert all(r is False for r in get_result), \
+            suffix_hashes, torch.tensor(suffix_indices), extra_info
+        )
+        assert all(r is False for r in get_result), (
             f"FI-7 FAILED: expected all False, got {get_result}"
-        logger.info("FI-7 PASSED: GetCacheLocation fault with prefix → returns all False")
+        )
+        logger.info(
+            "FI-7 PASSED: GetCacheLocation fault with prefix → returns all False"
+        )
 
         debug_client.remove_fault("GetCacheLocation")
 
     finally:
         debug_client.clear_faults()
         debug_client.close()
-
 
 
 # ---------------------------------------------------------------------------
@@ -455,6 +499,7 @@ def _multi_rank_worker(rank, world_size, init_port):
 
     class _GlooTPGroup:
         """Minimal stand-in for GroupCoordinator (gloo only)."""
+
         def __init__(self, cpu_group):
             self.cpu_group = cpu_group
 
@@ -515,7 +560,7 @@ def _multi_rank_worker(rank, world_size, init_port):
     mr_hash = None
     mr_indices = []
     for i in range(0, mr_max_total_num_tokens, page_size):
-        mr_hash = get_hash_str(mr_token_ids[i:i + page_size], mr_hash)
+        mr_hash = get_hash_str(mr_token_ids[i : i + page_size], mr_hash)
         mr_hashes.append(mr_hash)
         mr_indices.extend(range(i, i + page_size))
 
@@ -525,7 +570,7 @@ def _multi_rank_worker(rank, world_size, init_port):
     # MR-1: Normal multi-rank set
     # ------------------------------------------------------------------
     h1 = mr_hashes[:5]
-    idx1 = mr_indices[:5 * page_size]
+    idx1 = mr_indices[: 5 * page_size]
     torch.distributed.barrier()
     result = storage_backend.batch_set_v1(h1, torch.tensor(idx1))
     assert all(result), f"MR-1 rank {rank}: expected all True, got {result}"
@@ -548,7 +593,7 @@ def _multi_rank_worker(rank, world_size, init_port):
     #   With the fix, both ranks return [False] gracefully.
     # ------------------------------------------------------------------
     h3 = mr_hashes[5:10]
-    idx3 = mr_indices[5 * page_size:10 * page_size]
+    idx3 = mr_indices[5 * page_size : 10 * page_size]
 
     torch.distributed.barrier()
     if rank == 0:
@@ -556,8 +601,9 @@ def _multi_rank_worker(rank, world_size, init_port):
     torch.distributed.barrier()
 
     result = storage_backend.batch_set_v1(h3, torch.tensor(idx3))
-    assert all(r is False for r in result), \
+    assert all(r is False for r in result), (
         f"MR-3 rank {rank}: expected all False, got {result}"
+    )
 
     torch.distributed.barrier()
     if rank == 0:
@@ -572,7 +618,7 @@ def _multi_rank_worker(rank, world_size, init_port):
     #   This is a known inconsistency. We verify no hang occurs.
     # ------------------------------------------------------------------
     h4 = mr_hashes[15:20]
-    idx4 = mr_indices[15 * page_size:20 * page_size]
+    idx4 = mr_indices[15 * page_size : 20 * page_size]
 
     torch.distributed.barrier()
     if rank == 0:
@@ -581,8 +627,9 @@ def _multi_rank_worker(rank, world_size, init_port):
 
     result = storage_backend.batch_set_v1(h4, torch.tensor(idx4))
     if rank == 0:
-        assert all(r is False for r in result), \
+        assert all(r is False for r in result), (
             f"MR-4 rank 0: expected all False, got {result}"
+        )
     logger.info(f"[Rank {rank}] MR-4: result = {result}")
 
     torch.distributed.barrier()
@@ -596,7 +643,7 @@ def _multi_rank_worker(rank, world_size, init_port):
     #   Clear faults, verify set -> get works on all ranks.
     # ------------------------------------------------------------------
     h5 = mr_hashes[20:25]
-    idx5 = mr_indices[20 * page_size:25 * page_size]
+    idx5 = mr_indices[20 * page_size : 25 * page_size]
 
     torch.distributed.barrier()
     if rank == 0:
@@ -622,9 +669,9 @@ def _multi_rank_worker(rank, world_size, init_port):
     # ------------------------------------------------------------------
     h6 = mr_hashes[25:30]
     if rank == 0:
-        idx6 = mr_indices[25 * page_size:30 * page_size]  # 5 blocks
+        idx6 = mr_indices[25 * page_size : 30 * page_size]  # 5 blocks
     else:
-        idx6 = mr_indices[25 * page_size:28 * page_size]  # 3 blocks
+        idx6 = mr_indices[25 * page_size : 28 * page_size]  # 3 blocks
 
     torch.distributed.barrier()
     result = storage_backend.batch_set_v1(h6, torch.tensor(idx6))
@@ -632,10 +679,12 @@ def _multi_rank_worker(rank, world_size, init_port):
     # Both ranks should get [True, True, True, False, False]:
     # blocks 0-2 succeeded on all ranks, blocks 3-4 only rank 0 had data
     assert len(result) == 5, f"MR-6 rank {rank}: expected 5 results, got {len(result)}"
-    assert result[:3] == [True, True, True], \
+    assert result[:3] == [True, True, True], (
         f"MR-6 rank {rank}: first 3 blocks should be True, got {result[:3]}"
-    assert result[3:] == [False, False], \
+    )
+    assert result[3:] == [False, False], (
         f"MR-6 rank {rank}: last 2 blocks should be False, got {result[3:]}"
+    )
 
     torch.distributed.barrier()
     logger.info(f"[Rank {rank}] MR-6 PASSED: per-block best-effort")
@@ -649,13 +698,13 @@ def _multi_rank_worker(rank, world_size, init_port):
     #   After all_reduce(MIN): blocks [0,1] succeed, block [2] fails.
     #   Verifies prefix best-effort + per-block MIN in multi-rank.
     # ------------------------------------------------------------------
-    prefix_keys_7 = mr_hashes[5:8]    # 3 blocks never written → not in cache
-    h7 = mr_hashes[8:11]              # 3 new blocks
+    prefix_keys_7 = mr_hashes[5:8]  # 3 blocks never written → not in cache
+    h7 = mr_hashes[8:11]  # 3 new blocks
 
     if rank == 0:
-        idx7 = mr_indices[8 * page_size:11 * page_size]   # 3 blocks of data
+        idx7 = mr_indices[8 * page_size : 11 * page_size]  # 3 blocks of data
     else:
-        idx7 = mr_indices[8 * page_size:10 * page_size]   # 2 blocks of data
+        idx7 = mr_indices[8 * page_size : 10 * page_size]  # 2 blocks of data
 
     extra_info_7 = HiCacheStorageExtraInfo(prefix_keys=prefix_keys_7)
 
@@ -666,10 +715,12 @@ def _multi_rank_worker(rank, world_size, init_port):
     # Rank 0 writes blocks [0,1,2]; Rank 1 writes blocks [0,1] only.
     # all_reduce(MIN) → [1,1,0]. Result for new keys: [True, True, False]
     assert len(result) == 3, f"MR-7 rank {rank}: expected 3 results, got {len(result)}"
-    assert result[:2] == [True, True], \
+    assert result[:2] == [True, True], (
         f"MR-7 rank {rank}: first 2 blocks should be True, got {result[:2]}"
-    assert result[2] == False, \
+    )
+    assert result[2] == False, (
         f"MR-7 rank {rank}: last block should be False, got {result[2]}"
+    )
 
     torch.distributed.barrier()
     logger.info(f"[Rank {rank}] MR-7 PASSED: prefix best-effort multi-rank")
@@ -690,17 +741,18 @@ def _multi_rank_worker(rank, world_size, init_port):
         h8 = []
         _h = None
         for i in range(0, len(diverge_ids), page_size):
-            _h = get_hash_str(diverge_ids[i:i + page_size], _h)
+            _h = get_hash_str(diverge_ids[i : i + page_size], _h)
             h8.append(_h)
 
-    idx8 = mr_indices[30 * page_size:33 * page_size]  # 3 blocks
+    idx8 = mr_indices[30 * page_size : 33 * page_size]  # 3 blocks
 
     torch.distributed.barrier()
     result = storage_backend.batch_set_v1(h8, torch.tensor(idx8))
 
     assert len(result) == 3, f"MR-8 rank {rank}: expected 3 results, got {len(result)}"
-    assert all(r is False for r in result), \
+    assert all(r is False for r in result), (
         f"MR-8 rank {rank}: expected all False (input diverged), got {result}"
+    )
 
     torch.distributed.barrier()
     logger.info(f"[Rank {rank}] MR-8 PASSED: input divergence → all False")

--- a/kv_cache_manager/py_connector/sglang/test_indexer.py
+++ b/kv_cache_manager/py_connector/sglang/test_indexer.py
@@ -3,7 +3,9 @@
 Requires a running KV Cache Manager process and CUDA device.
 Mirrors test_linear.py structure but replaces Mamba with Indexer.
 """
+
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 
 import subprocess
@@ -90,11 +92,15 @@ def _stop_manager():
 def _start_manager():
     global proc
     subprocess.run("rm -rf /root/KVCacheManager/logs/*", shell=True, check=False)
-    proc = subprocess.Popen([
-        f"{kvcm_home}/bin/kv_cache_manager_bin",
-        "-c", f"{kvcm_home}/etc/default_server_config.conf",
-        "-l", f"{kvcm_home}/etc/default_logger_config.conf"
-    ])
+    proc = subprocess.Popen(
+        [
+            f"{kvcm_home}/bin/kv_cache_manager_bin",
+            "-c",
+            f"{kvcm_home}/etc/default_server_config.conf",
+            "-l",
+            f"{kvcm_home}/etc/default_logger_config.conf",
+        ]
+    )
     signal.signal(signal.SIGINT, _stop_manager)
     signal.signal(signal.SIGTERM, _stop_manager)
     atexit.register(_stop_manager)
@@ -106,6 +112,7 @@ def _start_manager():
 # Mock Indexer Pool
 # ============================================================
 
+
 class MockIndexerPoolHost:
     """Lightweight mock of NSAIndexerPoolHost for testing.
 
@@ -114,8 +121,15 @@ class MockIndexerPoolHost:
     so the connector can do zero-copy I/O.
     """
 
-    def __init__(self, page_num, page_size_val, layer_num_val,
-                 index_head_dim, quant_block_size, dtype):
+    def __init__(
+        self,
+        page_num,
+        page_size_val,
+        layer_num_val,
+        index_head_dim,
+        quant_block_size,
+        dtype,
+    ):
         self.page_num = page_num
         self.page_size = page_size_val
         self.layer_num = layer_num_val
@@ -126,8 +140,7 @@ class MockIndexerPoolHost:
         self.layout = "page_first_direct"
 
         self.indexer_size_per_token = (
-            index_head_dim
-            + index_head_dim // quant_block_size * 4
+            index_head_dim + index_head_dim // quant_block_size * 4
         )
         self.indexer_page_stride_size = (
             self.indexer_size_per_token * page_size_val * dtype.itemsize
@@ -143,9 +156,7 @@ class MockIndexerPoolHost:
 
     def get_size_per_token(self):
         return (
-            self.indexer_size_per_token
-            * self.layer_num
-            * self.indexer_dtype.itemsize
+            self.indexer_size_per_token * self.layer_num * self.indexer_dtype.itemsize
         )
 
     def get_page_buffer_meta(self, indices):
@@ -157,9 +168,7 @@ class MockIndexerPoolHost:
         indices = indices.tolist()
         ptr_list = []
         page_stride_bytes = (
-            self.layer_num
-            * self.indexer_page_stride_size
-            * self.indexer_dtype.itemsize
+            self.layer_num * self.indexer_page_stride_size * self.indexer_dtype.itemsize
         )
         base_ptr = self.index_k_with_scale_buffer.data_ptr()
         for i in range(0, len(indices), self.page_size):
@@ -171,6 +180,7 @@ class MockIndexerPoolHost:
 # ============================================================
 # Setup helpers
 # ============================================================
+
 
 def _create_pools():
     device_pool = MHATokenToKVPool(
@@ -252,7 +262,7 @@ def _create_indexer_backend(kv_pool_host, indexer_pool, instance_id, num_blocks=
     block_hash = None
     kv_host_indices = []
     for i in range(0, num_blocks * page_size, page_size):
-        block_hash = get_hash_str(token_ids[i:i + page_size], block_hash)
+        block_hash = get_hash_str(token_ids[i : i + page_size], block_hash)
         block_hashes.append(block_hash)
         kv_host_indices.extend(range(i, i + page_size))
 
@@ -281,11 +291,11 @@ def _fill_indexer_buffer(indexer_pool, num_blocks):
 # Tests
 # ============================================================
 
+
 def test_indexer_hybrid(kv_pool_host, indexer_pool):
     """Basic hybrid: set_v2 (Indexer) + set_v1 (KV), then exists_v2, get_v2 with data verification."""
-    (storage_backend,
-     block_hashes, kv_host_indices, indexer_host_indices) = _create_indexer_backend(
-        kv_pool_host, indexer_pool, "indexer_hybrid_0"
+    (storage_backend, block_hashes, kv_host_indices, indexer_host_indices) = (
+        _create_indexer_backend(kv_pool_host, indexer_pool, "indexer_hybrid_0")
     )
     num_blocks = len(block_hashes)
 
@@ -335,18 +345,17 @@ def test_indexer_hybrid(kv_pool_host, indexer_pool):
     )
 
     for i in range(num_blocks):
-        assert torch.equal(
-            indexer_pool.index_k_with_scale_buffer[i], orig_buf[i]
-        ), f"Indexer data mismatch at page {i}"
+        assert torch.equal(indexer_pool.index_k_with_scale_buffer[i], orig_buf[i]), (
+            f"Indexer data mismatch at page {i}"
+        )
 
     logger.info("test_indexer_hybrid passed!")
 
 
 def test_indexer_write_kv_only(kv_pool_host, indexer_pool):
     """Write KV only -> batch_exists_v2 shows KV hit but Indexer boundary=0."""
-    (storage_backend,
-     block_hashes, kv_host_indices, indexer_host_indices) = _create_indexer_backend(
-        kv_pool_host, indexer_pool, "indexer_kv_only_0"
+    (storage_backend, block_hashes, kv_host_indices, indexer_host_indices) = (
+        _create_indexer_backend(kv_pool_host, indexer_pool, "indexer_kv_only_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
@@ -381,9 +390,8 @@ def test_indexer_write_kv_only(kv_pool_host, indexer_pool):
 
 def test_indexer_write_indexer_only(kv_pool_host, indexer_pool):
     """Write Indexer only (no KV) -> kv_hit_pages should be 0."""
-    (storage_backend,
-     block_hashes, kv_host_indices, indexer_host_indices) = _create_indexer_backend(
-        kv_pool_host, indexer_pool, "indexer_only_0"
+    (storage_backend, block_hashes, kv_host_indices, indexer_host_indices) = (
+        _create_indexer_backend(kv_pool_host, indexer_pool, "indexer_only_0")
     )
     num_blocks = len(block_hashes)
     _fill_indexer_buffer(indexer_pool, num_blocks)
@@ -407,9 +415,8 @@ def test_indexer_write_indexer_only(kv_pool_host, indexer_pool):
 
 def test_indexer_kv_first_then_indexer(kv_pool_host, indexer_pool):
     """Write KV first, then Indexer. Both should succeed and verify data."""
-    (storage_backend,
-     block_hashes, kv_host_indices, indexer_host_indices) = _create_indexer_backend(
-        kv_pool_host, indexer_pool, "indexer_cross_order_0"
+    (storage_backend, block_hashes, kv_host_indices, indexer_host_indices) = (
+        _create_indexer_backend(kv_pool_host, indexer_pool, "indexer_cross_order_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
@@ -464,18 +471,17 @@ def test_indexer_kv_first_then_indexer(kv_pool_host, indexer_pool):
     assert all(get_v2_result[PoolName.INDEXER])
 
     for i in range(num_blocks):
-        assert torch.equal(
-            indexer_pool.index_k_with_scale_buffer[i], orig_buf[i]
-        ), f"Indexer data mismatch at page {i}"
+        assert torch.equal(indexer_pool.index_k_with_scale_buffer[i], orig_buf[i]), (
+            f"Indexer data mismatch at page {i}"
+        )
 
     logger.info("test_indexer_kv_first_then_indexer passed!")
 
 
 def test_indexer_full_round_trip(kv_pool_host, indexer_pool):
     """Complete write-clear-read-verify cycle for both KV and Indexer."""
-    (storage_backend,
-     block_hashes, kv_host_indices, indexer_host_indices) = _create_indexer_backend(
-        kv_pool_host, indexer_pool, "indexer_full_rt_0"
+    (storage_backend, block_hashes, kv_host_indices, indexer_host_indices) = (
+        _create_indexer_backend(kv_pool_host, indexer_pool, "indexer_full_rt_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
@@ -519,8 +525,12 @@ def test_indexer_full_round_trip(kv_pool_host, indexer_pool):
         actual = torch.mean(tensor_i).item()
         expected = bf16_i.item()
         if actual != expected:
-            print(f"[KV-VERIFY] i={i} page_id={page_id} token_id={token_id} actual={actual} expected={expected} tensor_shape={tensor_i.shape} sample={tensor_i.flatten()[:5]}")
-            assert False, f"KV data mismatch at i={i}: actual={actual} expected={expected}"
+            print(
+                f"[KV-VERIFY] i={i} page_id={page_id} token_id={token_id} actual={actual} expected={expected} tensor_shape={tensor_i.shape} sample={tensor_i.flatten()[:5]}"
+            )
+            assert False, (
+                f"KV data mismatch at i={i}: actual={actual} expected={expected}"
+            )
 
     # Verify Indexer
     for i in range(num_blocks):
@@ -534,24 +544,21 @@ def test_indexer_full_round_trip(kv_pool_host, indexer_pool):
 def test_indexer_all_pages_policy(kv_pool_host, indexer_pool):
     """Test ALL_PAGES boundary: only write Indexer for last N blocks,
     ALL_PAGES should truncate at first missing page."""
-    (storage_backend,
-     block_hashes, kv_host_indices, indexer_host_indices) = _create_indexer_backend(
-        kv_pool_host, indexer_pool, "indexer_allpages_0"
+    (storage_backend, block_hashes, kv_host_indices, indexer_host_indices) = (
+        _create_indexer_backend(kv_pool_host, indexer_pool, "indexer_allpages_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
     _fill_indexer_buffer(indexer_pool, num_blocks)
 
     # Write all KV blocks
-    set_v1 = storage_backend.batch_set_v1(
-        block_hashes, torch.tensor(kv_host_indices)
-    )
+    set_v1 = storage_backend.batch_set_v1(block_hashes, torch.tensor(kv_host_indices))
     assert all(set_v1)
 
     # Write Indexer only for last 3 blocks
     trailing_n = 3
     trailing_keys = block_hashes[-trailing_n:]
-    trailing_indexer_indices = indexer_host_indices[-trailing_n * page_size:]
+    trailing_indexer_indices = indexer_host_indices[-trailing_n * page_size :]
     trailing_transfer = PoolTransfer(
         name=PoolName.INDEXER,
         host_indices=torch.tensor(trailing_indexer_indices),
@@ -609,9 +616,10 @@ def test_indexer_partial_write_buffer_indexing(kv_pool_host, indexer_pool):
     num_blocks = 6
     first_n = 3
 
-    (storage_backend,
-     block_hashes, kv_host_indices, indexer_host_indices) = _create_indexer_backend(
-        kv_pool_host, indexer_pool, "indexer_partial_idx_0", num_blocks=num_blocks
+    (storage_backend, block_hashes, kv_host_indices, indexer_host_indices) = (
+        _create_indexer_backend(
+            kv_pool_host, indexer_pool, "indexer_partial_idx_0", num_blocks=num_blocks
+        )
     )
 
     _fill_indexer_buffer(indexer_pool, num_blocks)
@@ -619,7 +627,7 @@ def test_indexer_partial_write_buffer_indexing(kv_pool_host, indexer_pool):
     # Step 1: Write Indexer for first 3 blocks — all new, save_indices = [0,1,2]
     first_transfer = PoolTransfer(
         name=PoolName.INDEXER,
-        host_indices=torch.tensor(indexer_host_indices[:first_n * page_size]),
+        host_indices=torch.tensor(indexer_host_indices[: first_n * page_size]),
         keys=block_hashes[:first_n],
         hit_policy=PoolHitPolicy.ALL_PAGES,
     )
@@ -654,11 +662,8 @@ def test_indexer_partial_write_buffer_indexing(kv_pool_host, indexer_pool):
     # Step 4: Verify each page has its own correct data (not swapped).
     # With the old bug, pages 3-5 would contain data from pages 0-2.
     for i in range(num_blocks):
-        assert torch.equal(
-            indexer_pool.index_k_with_scale_buffer[i], orig_buf[i]
-        ), (
-            f"Indexer mismatch at page {i}: "
-            f"expected fill value {(i + 1) % 256}"
+        assert torch.equal(indexer_pool.index_k_with_scale_buffer[i], orig_buf[i]), (
+            f"Indexer mismatch at page {i}: expected fill value {(i + 1) % 256}"
         )
 
     logger.info("test_indexer_partial_write_buffer_indexing passed!")

--- a/kv_cache_manager/py_connector/sglang/test_indexer.py
+++ b/kv_cache_manager/py_connector/sglang/test_indexer.py
@@ -13,6 +13,7 @@ import signal
 import time
 import os
 import atexit
+from typing import Any
 from types import SimpleNamespace
 
 import torch
@@ -74,7 +75,7 @@ kvcm_home = os.environ.get("KVCM_HOME", "/home/admin/kv_cache_manager")
 proc = None
 
 
-def _stop_manager():
+def _stop_manager(*args: Any) -> None:
     global proc
     if proc and proc.poll() is None:
         proc.terminate()

--- a/kv_cache_manager/py_connector/sglang/test_indexer.py
+++ b/kv_cache_manager/py_connector/sglang/test_indexer.py
@@ -13,20 +13,23 @@ import signal
 import time
 import os
 import atexit
-from typing import Any
+from typing import Any, cast
 from types import SimpleNamespace
 
 import torch
 from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageConfig,
-    HiCacheStorageExtraInfo,
     PoolName,
     PoolTransfer,
     PoolHitPolicy,
 )
 from sglang.srt.mem_cache.utils import get_hash_str
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
-from sglang.srt.mem_cache.memory_pool_host import MHATokenToKVPoolHost
+
+# MHATokenToKVPoolHost moved in newer sglang versions.
+from sglang.srt.mem_cache.memory_pool_host import (
+    MHATokenToKVPoolHost,  # ty: ignore[unresolved-import]
+)
 from sglang.srt.distributed import (
     init_distributed_environment,
     initialize_model_parallel,
@@ -256,14 +259,14 @@ def _create_indexer_backend(kv_pool_host, indexer_pool, instance_id, num_blocks=
     )
 
     storage_backend = HiCacheKVCM(storage_config, {})
-    storage_backend.register_mem_pool_host(host_pool_group)
+    storage_backend.register_mem_pool_host(host_pool_group)  # ty: ignore[invalid-argument-type]
 
     token_ids = list(range(num_blocks * page_size))
     block_hashes = []
     block_hash = None
     kv_host_indices = []
     for i in range(0, num_blocks * page_size, page_size):
-        block_hash = get_hash_str(token_ids[i : i + page_size], block_hash)
+        block_hash = cast(str, get_hash_str(token_ids[i : i + page_size], block_hash))
         block_hashes.append(block_hash)
         kv_host_indices.extend(range(i, i + page_size))
 

--- a/kv_cache_manager/py_connector/sglang/test_linear.py
+++ b/kv_cache_manager/py_connector/sglang/test_linear.py
@@ -2,7 +2,9 @@
 
 Requires a running KV Cache Manager process and CUDA device.
 """
+
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 
 import subprocess
@@ -97,11 +99,15 @@ def _start_manager():
     global proc
     subprocess.run("rm -rf /root/KVCacheManager/logs/*", shell=True, check=False)
 
-    proc = subprocess.Popen([
-        f"{kvcm_home}/bin/kv_cache_manager_bin",
-        "-c", f"{kvcm_home}/etc/default_server_config.conf",
-        "-l", f"{kvcm_home}/etc/default_logger_config.conf"
-    ])
+    proc = subprocess.Popen(
+        [
+            f"{kvcm_home}/bin/kv_cache_manager_bin",
+            "-c",
+            f"{kvcm_home}/etc/default_server_config.conf",
+            "-l",
+            f"{kvcm_home}/etc/default_logger_config.conf",
+        ]
+    )
 
     signal.signal(signal.SIGINT, _stop_manager)
     signal.signal(signal.SIGTERM, _stop_manager)
@@ -214,7 +220,7 @@ def _create_hybrid_backend(kv_pool_host, mamba_pool, instance_id, num_blocks=10)
     block_hash = None
     kv_host_indices = []
     for i in range(0, num_blocks * page_size, page_size):
-        block_hash = get_hash_str(token_ids[i:i + page_size], block_hash)
+        block_hash = get_hash_str(token_ids[i : i + page_size], block_hash)
         block_hashes.append(block_hash)
         kv_host_indices.extend(range(i, i + page_size))
 
@@ -249,8 +255,9 @@ def _fill_mamba_buffer(mamba_pool):
 def test_hybrid(kv_pool_host, mamba_pool):
     """Basic hybrid test (migrated from test.py):
     set_v2 (Mamba) + set_v1 (KV), then exists_v2, get_v2 with data verification."""
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(kv_pool_host, mamba_pool,"hybrid_0")
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(kv_pool_host, mamba_pool, "hybrid_0")
+    )
     num_blocks = len(block_hashes)
 
     _fill_kv_buffer(kv_pool_host, num_blocks)
@@ -303,22 +310,21 @@ def test_hybrid(kv_pool_host, mamba_pool):
     )
 
     for i in range(num_blocks):
-        assert torch.allclose(
-            mamba_pool.temporal_buffer[i], orig_temporal[i]
-        ), f"Temporal data mismatch at page {i}"
+        assert torch.allclose(mamba_pool.temporal_buffer[i], orig_temporal[i]), (
+            f"Temporal data mismatch at page {i}"
+        )
         for j, conv_buf in enumerate(mamba_pool.conv_buffer):
-            assert torch.allclose(
-                conv_buf[i], orig_conv[j][i]
-            ), f"Conv {j} data mismatch at page {i}"
+            assert torch.allclose(conv_buf[i], orig_conv[j][i]), (
+                f"Conv {j} data mismatch at page {i}"
+            )
 
     logger.info("test_hybrid passed!")
 
 
 def test_write_kv_only_then_exists_v2(kv_pool_host, mamba_pool):
     """Write KV only (no Mamba) -> batch_exists_v2 shows KV hit but Mamba boundary=0."""
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(kv_pool_host, mamba_pool,
-        "linear_kv_only_0"
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(kv_pool_host, mamba_pool, "linear_kv_only_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
@@ -358,9 +364,8 @@ def test_write_mamba_only_then_exists_v2(kv_pool_host, mamba_pool):
     KV ("Full") spec presence.  Since only Linear spec was written,
     kv_hit_pages should be 0 and final_pages should be 0.
     """
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(kv_pool_host, mamba_pool,
-        "linear_mamba_only_0"
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(kv_pool_host, mamba_pool, "linear_mamba_only_0")
     )
     num_blocks = len(block_hashes)
     _fill_mamba_buffer(mamba_pool)
@@ -388,9 +393,8 @@ def test_write_mamba_only_then_exists_v2(kv_pool_host, mamba_pool):
 
 def test_kv_then_mamba_cross_order(kv_pool_host, mamba_pool):
     """Write KV first, then Mamba (reverse order of test_hybrid). Both should succeed."""
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(kv_pool_host, mamba_pool,
-        "linear_cross_order_0"
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(kv_pool_host, mamba_pool, "linear_cross_order_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
@@ -456,9 +460,8 @@ def test_kv_then_mamba_cross_order(kv_pool_host, mamba_pool):
 
 def test_full_hybrid_round_trip(kv_pool_host, mamba_pool):
     """Complete write-clear-read-verify cycle for both KV and Mamba."""
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(kv_pool_host, mamba_pool,
-        "linear_full_rt_0"
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(kv_pool_host, mamba_pool, "linear_full_rt_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
@@ -516,18 +519,15 @@ def test_full_hybrid_round_trip(kv_pool_host, mamba_pool):
 
 def test_trailing_pages_policy(kv_pool_host, mamba_pool):
     """Test TRAILING_PAGES boundary: only write Mamba for last N blocks."""
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(kv_pool_host, mamba_pool,
-        "linear_trailing_0"
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(kv_pool_host, mamba_pool, "linear_trailing_0")
     )
     num_blocks = len(block_hashes)
     _fill_kv_buffer(kv_pool_host, num_blocks)
     _fill_mamba_buffer(mamba_pool)
 
     # Write all KV blocks
-    set_v1 = storage_backend.batch_set_v1(
-        block_hashes, torch.tensor(kv_host_indices)
-    )
+    set_v1 = storage_backend.batch_set_v1(block_hashes, torch.tensor(kv_host_indices))
     assert all(set_v1)
 
     # Write Mamba only for last 3 blocks
@@ -592,9 +592,10 @@ def test_partial_write_buffer_indexing(kv_pool_host, mamba_pool):
     num_blocks = 6
     first_n = 3
 
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(
-        kv_pool_host, mamba_pool, "linear_partial_idx_0", num_blocks=num_blocks
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(
+            kv_pool_host, mamba_pool, "linear_partial_idx_0", num_blocks=num_blocks
+        )
     )
 
     _fill_mamba_buffer(mamba_pool)
@@ -641,26 +642,23 @@ def test_partial_write_buffer_indexing(kv_pool_host, mamba_pool):
     # Step 4: Verify each page has its own correct data (not swapped).
     # With the old bug, pages 3-5 would contain data from pages 0-2.
     for i in range(num_blocks):
-        assert torch.allclose(
-            mamba_pool.temporal_buffer[i], orig_temporal[i]
-        ), (
+        assert torch.allclose(mamba_pool.temporal_buffer[i], orig_temporal[i]), (
             f"Temporal mismatch at page {i}: "
             f"got {mamba_pool.temporal_buffer[i].flatten()[0].item()}, "
             f"expected {orig_temporal[i].flatten()[0].item()}"
         )
         for j, conv_buf in enumerate(mamba_pool.conv_buffer):
-            assert torch.allclose(
-                conv_buf[i], orig_conv[j][i]
-            ), f"Conv {j} mismatch at page {i}"
+            assert torch.allclose(conv_buf[i], orig_conv[j][i]), (
+                f"Conv {j} mismatch at page {i}"
+            )
 
     logger.info("test_partial_write_buffer_indexing passed!")
 
 
 def test_non_mamba_pool_transfer_returns_false(kv_pool_host, mamba_pool):
     """Non-MAMBA pool transfers in batch_set_v2 / batch_get_v2 return all False."""
-    (storage_backend,
-     block_hashes, kv_host_indices, mamba_host_indices) = _create_hybrid_backend(kv_pool_host, mamba_pool,
-        "linear_non_mamba_0"
+    (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
+        _create_hybrid_backend(kv_pool_host, mamba_pool, "linear_non_mamba_0")
     )
 
     # Use a non-MAMBA pool name

--- a/kv_cache_manager/py_connector/sglang/test_linear.py
+++ b/kv_cache_manager/py_connector/sglang/test_linear.py
@@ -12,20 +12,24 @@ import signal
 import time
 import os
 import atexit
-from typing import Any
+from typing import Any, cast
 from types import SimpleNamespace
 
 import torch
 from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageConfig,
-    HiCacheStorageExtraInfo,
     PoolName,
     PoolTransfer,
     PoolHitPolicy,
 )
 from sglang.srt.mem_cache.utils import get_hash_str
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, MambaPool
-from sglang.srt.mem_cache.memory_pool_host import MHATokenToKVPoolHost, MambaPoolHost
+
+# MHATokenToKVPoolHost / MambaPoolHost moved in newer sglang versions.
+from sglang.srt.mem_cache.memory_pool_host import (
+    MHATokenToKVPoolHost,  # ty: ignore[unresolved-import]
+    MambaPoolHost,  # ty: ignore[unresolved-import]
+)
 from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
 from sglang.srt.distributed import (
     init_distributed_environment,
@@ -213,7 +217,7 @@ def _create_hybrid_backend(kv_pool_host, mamba_pool, instance_id, num_blocks=10)
     )
 
     storage_backend = HiCacheKVCM(storage_config, {})
-    storage_backend.register_mem_pool_host(host_pool_group)
+    storage_backend.register_mem_pool_host(host_pool_group)  # ty: ignore[invalid-argument-type]
 
     # Generate test data
     token_ids = list(range(num_blocks * page_size))
@@ -221,7 +225,7 @@ def _create_hybrid_backend(kv_pool_host, mamba_pool, instance_id, num_blocks=10)
     block_hash = None
     kv_host_indices = []
     for i in range(0, num_blocks * page_size, page_size):
-        block_hash = get_hash_str(token_ids[i : i + page_size], block_hash)
+        block_hash = cast(str, get_hash_str(token_ids[i : i + page_size], block_hash))
         block_hashes.append(block_hash)
         kv_host_indices.extend(range(i, i + page_size))
 
@@ -368,7 +372,6 @@ def test_write_mamba_only_then_exists_v2(kv_pool_host, mamba_pool):
     (storage_backend, block_hashes, kv_host_indices, mamba_host_indices) = (
         _create_hybrid_backend(kv_pool_host, mamba_pool, "linear_mamba_only_0")
     )
-    num_blocks = len(block_hashes)
     _fill_mamba_buffer(mamba_pool)
 
     # Write Mamba only

--- a/kv_cache_manager/py_connector/sglang/test_linear.py
+++ b/kv_cache_manager/py_connector/sglang/test_linear.py
@@ -12,6 +12,7 @@ import signal
 import time
 import os
 import atexit
+from typing import Any
 from types import SimpleNamespace
 
 import torch
@@ -76,7 +77,7 @@ kvcm_home = os.environ.get("KVCM_HOME", "/home/admin/kv_cache_manager")
 proc = None
 
 
-def _stop_manager():
+def _stop_manager(*args: Any) -> None:
     """Stop the KV Cache Manager process."""
     global proc
     if proc and proc.poll() is None:

--- a/kv_cache_manager/py_connector/test/kernel/test_batch_gather_scatter.py
+++ b/kv_cache_manager/py_connector/test/kernel/test_batch_gather_scatter.py
@@ -31,7 +31,7 @@ def test_batch_gather_kv_caches():
             total_token_in_kvcache,
             hidden_size_per_token_per_layer,
             device="cuda",
-            dtype=torch.bfloat16
+            dtype=torch.bfloat16,
         )
         # 将K和V分开添加到列表中，这样每个都是单独的指针
         kv_caches.append(cache[0])  # K
@@ -39,9 +39,7 @@ def test_batch_gather_kv_caches():
 
     # 创建KV缓存指针tensor - 现在应该有num_layers * 2个指针
     kv_caches_ptrs_tensor = torch.tensor(
-        [cache.data_ptr() for cache in kv_caches],
-        device="cuda",
-        dtype=torch.int64
+        [cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64
     )
 
     # 更新num_kvcache_ptrs为正确的值
@@ -56,7 +54,7 @@ def test_batch_gather_kv_caches():
         hidden_size_per_token_per_layer,
         device="cpu",
         dtype=torch.bfloat16,
-        pin_memory=True
+        pin_memory=True,
     )
     dst_tensor.zero_()
 
@@ -65,7 +63,9 @@ def test_batch_gather_kv_caches():
     block_token_indices = []
     for block_idx in range(total_blocks):
         # 每个block的token indices需要在[0, total_token_in_kvcache)范围内
-        block_indices = torch.randperm(total_token_in_kvcache)[:num_tokens_per_block].tolist()
+        block_indices = torch.randperm(total_token_in_kvcache)[
+            :num_tokens_per_block
+        ].tolist()
         block_token_indices.extend(block_indices)
 
     # 生成dst block indices
@@ -96,22 +96,36 @@ def test_batch_gather_kv_caches():
             token_idx = block_token_indices[start_idx + token_pos]
             for layer_idx in range(num_layers):
                 # 检查K值 - K存储在layer_idx*2的位置
-                gathered_k = dst_tensor[dst_block_idx, layer_idx * 2, token_pos, :]  # 当前block，第layer_idx层，K部分
+                gathered_k = dst_tensor[
+                    dst_block_idx, layer_idx * 2, token_pos, :
+                ]  # 当前block，第layer_idx层，K部分
                 # 注意：现在kv_caches是已分离的K和V，K在偶数索引(0, 2, 4...)
                 expected_k = kv_caches_cpu[layer_idx * 2][token_idx, :]  # 对应的原始K值
                 # expected_k = expected_k.to(device=gathered_k.device)
-                torch.testing.assert_close(gathered_k, expected_k,
-                                           msg="Mismatch in K values for block {}, layer {}, token {} {} {}".format(
-                                               block_idx, layer_idx, token_idx, gathered_k, expected_k))
+                torch.testing.assert_close(
+                    gathered_k,
+                    expected_k,
+                    msg="Mismatch in K values for block {}, layer {}, token {} {} {}".format(
+                        block_idx, layer_idx, token_idx, gathered_k, expected_k
+                    ),
+                )
 
                 # 检查V值 - V存储在layer_idx*2+1的位置
-                gathered_v = dst_tensor[dst_block_idx, layer_idx * 2 + 1, token_pos, :]  # 当前block，第layer_idx层，V部分
+                gathered_v = dst_tensor[
+                    dst_block_idx, layer_idx * 2 + 1, token_pos, :
+                ]  # 当前block，第layer_idx层，V部分
                 # 注意：现在kv_caches是已分离的K和V，V在奇数索引(1, 3, 5...)
-                expected_v = kv_caches_cpu[layer_idx * 2 + 1][token_idx, :]  # 对应的原始V值
+                expected_v = kv_caches_cpu[layer_idx * 2 + 1][
+                    token_idx, :
+                ]  # 对应的原始V值
                 # expected_v = expected_v.to(device=gathered_v.device)
-                torch.testing.assert_close(gathered_v, expected_v,
-                                           msg="Mismatch in V values for block {}, layer {}, token {}".format(
-                                               block_idx, layer_idx, token_idx))
+                torch.testing.assert_close(
+                    gathered_v,
+                    expected_v,
+                    msg="Mismatch in V values for block {}, layer {}, token {}".format(
+                        block_idx, layer_idx, token_idx
+                    ),
+                )
 
     print("Batch gather KV caches test passed!")
 
@@ -141,7 +155,7 @@ def test_batch_gather_kv_caches_with_reference():
             total_token_in_kvcache,
             hidden_size_per_token_per_layer,
             device="cuda",
-            dtype=torch.bfloat16
+            dtype=torch.bfloat16,
         )
         original_caches.append(cache.clone())  # 保存原始值用于验证
 
@@ -157,7 +171,7 @@ def test_batch_gather_kv_caches_with_reference():
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
         device="cuda",
-        dtype=torch.bfloat16
+        dtype=torch.bfloat16,
     )
 
     # 创建目标tensor用于参考实现
@@ -167,14 +181,16 @@ def test_batch_gather_kv_caches_with_reference():
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
         device="cuda",
-        dtype=torch.bfloat16
+        dtype=torch.bfloat16,
     )
 
     # 为每个block生成token indices
     all_block_token_indices = []
     block_token_indices_per_block = []
     for block_idx in range(total_blocks):
-        block_indices = torch.randperm(total_token_in_kvcache)[:num_tokens_per_block].tolist()
+        block_indices = torch.randperm(total_token_in_kvcache)[
+            :num_tokens_per_block
+        ].tolist()
         all_block_token_indices.extend(block_indices)
         block_token_indices_per_block.append(block_indices)
 
@@ -182,9 +198,7 @@ def test_batch_gather_kv_caches_with_reference():
 
     # 调用批量gather函数
     kv_caches_ptrs_tensor = torch.tensor(
-        [cache.data_ptr() for cache in kv_caches],
-        device="cuda",
-        dtype=torch.int64
+        [cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64
     )
 
     batch_gather_kv_caches(
@@ -194,7 +208,7 @@ def test_batch_gather_kv_caches_with_reference():
         dst_block_indices,
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
-        num_layers * kv_count  # 修正参数
+        num_layers * kv_count,  # 修正参数
     )
 
     # 使用PyTorch实现参考实现
@@ -205,15 +219,22 @@ def test_batch_gather_kv_caches_with_reference():
             for layer_idx in range(num_layers):
                 # 计算参考实现结果 - K值
                 reference_k = original_caches[layer_idx][0, token_idx, :]
-                reference_dst_tensor[dst_block_idx, layer_idx * 2, token_pos, :] = reference_k
+                reference_dst_tensor[dst_block_idx, layer_idx * 2, token_pos, :] = (
+                    reference_k
+                )
 
                 # 计算参考实现结果 - V值
                 reference_v = original_caches[layer_idx][1, token_idx, :]
-                reference_dst_tensor[dst_block_idx, layer_idx * 2 + 1, token_pos, :] = reference_v
+                reference_dst_tensor[dst_block_idx, layer_idx * 2 + 1, token_pos, :] = (
+                    reference_v
+                )
 
     # 直接比较整个dst_tensor和参考实现的结果
-    torch.testing.assert_close(dst_tensor, reference_dst_tensor,
-                               msg="Mismatch between kernel and reference implementation for dst_tensor")
+    torch.testing.assert_close(
+        dst_tensor,
+        reference_dst_tensor,
+        msg="Mismatch between kernel and reference implementation for dst_tensor",
+    )
 
     print("Batch gather KV caches test with reference passed!")
 
@@ -241,7 +262,7 @@ def test_batch_gather_edge_cases():
             total_token_in_kvcache,
             hidden_size_per_token_per_layer,
             device="cuda",
-            dtype=torch.bfloat16
+            dtype=torch.bfloat16,
         )
         # 将K和V分开添加到列表中，这样每个都是单独的指针
         kv_caches.append(cache[0])  # K
@@ -255,7 +276,7 @@ def test_batch_gather_edge_cases():
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
         device="cuda",
-        dtype=torch.bfloat16
+        dtype=torch.bfloat16,
     )
 
     # 定义token indices和block indices
@@ -265,15 +286,14 @@ def test_batch_gather_edge_cases():
     # 保存特定位置的原始值用于验证
     # cache[0]是K，cache[1]是V，我们已经将它们分离到不同的tensor中
     original_cache = torch.stack(
-        [kv_caches[0], kv_caches[1]])  # 重新构成[2, total_token_in_kvcache, hidden_size_per_token_per_layer]
+        [kv_caches[0], kv_caches[1]]
+    )  # 重新构成[2, total_token_in_kvcache, hidden_size_per_token_per_layer]
     expected_k = original_cache[0, 5, :].clone()  # 第0层，K部分，位置5
     expected_v = original_cache[1, 5, :].clone()  # 第0层，V部分，位置5
 
     # 调用批量gather函数
     kv_caches_ptrs_tensor = torch.tensor(
-        [cache.data_ptr() for cache in kv_caches],
-        device="cuda",
-        dtype=torch.int64
+        [cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64
     )
 
     batch_gather_kv_caches(
@@ -283,17 +303,19 @@ def test_batch_gather_edge_cases():
         dst_block_indices,
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
-        num_layers * kv_count  # 修正参数
+        num_layers * kv_count,  # 修正参数
     )
 
     # 验证结果
     actual_k = dst_tensor[0, 0, 0, :]  # 第0个block，第0个指针(K)，第0个token位置
     actual_v = dst_tensor[0, 1, 0, :]  # 第0个block，第1个指针(V)，第0个token位置
 
-    torch.testing.assert_close(expected_k, actual_k,
-                               msg="Mismatch in K values for edge case")
-    torch.testing.assert_close(expected_v, actual_v,
-                               msg="Mismatch in V values for edge case")
+    torch.testing.assert_close(
+        expected_k, actual_k, msg="Mismatch in K values for edge case"
+    )
+    torch.testing.assert_close(
+        expected_v, actual_v, msg="Mismatch in V values for edge case"
+    )
 
     print("Gather edge case test passed!")
 
@@ -322,7 +344,7 @@ def test_batch_scatter_kv_caches():
             total_token_in_kvcache,
             hidden_size_per_token_per_layer,
             device="cuda",
-            dtype=torch.bfloat16
+            dtype=torch.bfloat16,
         )
         original_caches.append(cache.clone())  # 保存零值作为原始状态
         # 将K和V分开添加到列表中，这样每个都是单独的指针
@@ -331,9 +353,7 @@ def test_batch_scatter_kv_caches():
 
     # 创建KV缓存指针tensor
     kv_caches_ptrs_tensor = torch.tensor(
-        [cache.data_ptr() for cache in kv_caches],
-        device="cuda",
-        dtype=torch.int64
+        [cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64
     )
 
     # 创建源tensor，包含要scatter的数据
@@ -345,12 +365,14 @@ def test_batch_scatter_kv_caches():
         hidden_size_per_token_per_layer,
         device="cpu",  # 注意：scatter函数期望host memory (pinned memory)
         dtype=torch.bfloat16,
-        pin_memory=True  # 设置为pinned memory
+        pin_memory=True,  # 设置为pinned memory
     )
 
     # 生成block token indices
     # 每个block有num_tokens_per_block个token，总共total_blocks个block
-    block_token_indices = torch.randperm(total_token_in_kvcache)[:num_tokens_per_block * total_blocks].tolist()
+    block_token_indices = torch.randperm(total_token_in_kvcache)[
+        : num_tokens_per_block * total_blocks
+    ].tolist()
 
     # 生成src block indices
     src_block_indices = torch.randperm(total_buffer_blocks)[:total_blocks].tolist()
@@ -363,7 +385,7 @@ def test_batch_scatter_kv_caches():
         src_block_indices,
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
-        sm_count=3
+        sm_count=3,
     )
 
     kv_caches_cpu = []
@@ -379,18 +401,34 @@ def test_batch_scatter_kv_caches():
             token_idx = block_token_indices[start_idx + token_pos]
             for layer_idx in range(num_layers):
                 # 检查K值
-                scattered_k = kv_caches_cpu[layer_idx * 2][token_idx, :]  # 层layer_idx的K部分
-                expected_k = src_tensor[src_block_idx, layer_idx * 2, token_pos, :].cpu()  # 对应的源K值
-                torch.testing.assert_close(scattered_k, expected_k,
-                                           msg="Mismatch in K values for block {}, layer {}, token {}".format(
-                                               block_idx, layer_idx, token_idx))
+                scattered_k = kv_caches_cpu[layer_idx * 2][
+                    token_idx, :
+                ]  # 层layer_idx的K部分
+                expected_k = src_tensor[
+                    src_block_idx, layer_idx * 2, token_pos, :
+                ].cpu()  # 对应的源K值
+                torch.testing.assert_close(
+                    scattered_k,
+                    expected_k,
+                    msg="Mismatch in K values for block {}, layer {}, token {}".format(
+                        block_idx, layer_idx, token_idx
+                    ),
+                )
 
                 # 检查V值
-                scattered_v = kv_caches_cpu[layer_idx * 2 + 1][token_idx, :]  # 层layer_idx的V部分
-                expected_v = src_tensor[src_block_idx, layer_idx * 2 + 1, token_pos, :].cpu()  # 对应的源V值
-                torch.testing.assert_close(scattered_v, expected_v,
-                                           msg="Mismatch in V values for block {}, layer {}, token {}".format(
-                                               block_idx, layer_idx, token_idx))
+                scattered_v = kv_caches_cpu[layer_idx * 2 + 1][
+                    token_idx, :
+                ]  # 层layer_idx的V部分
+                expected_v = src_tensor[
+                    src_block_idx, layer_idx * 2 + 1, token_pos, :
+                ].cpu()  # 对应的源V值
+                torch.testing.assert_close(
+                    scattered_v,
+                    expected_v,
+                    msg="Mismatch in V values for block {}, layer {}, token {}".format(
+                        block_idx, layer_idx, token_idx
+                    ),
+                )
 
     print("Batch scatter KV caches test passed!")
 
@@ -419,7 +457,7 @@ def test_batch_scatter_kv_caches_with_reference():
             total_token_in_kvcache,
             hidden_size_per_token_per_layer,
             device="cuda",
-            dtype=torch.bfloat16
+            dtype=torch.bfloat16,
         )
         original_caches.append(cache.clone())  # 保存原始值用于验证
         # 将K和V分开添加到列表中，这样每个都是单独的指针
@@ -434,11 +472,13 @@ def test_batch_scatter_kv_caches_with_reference():
         hidden_size_per_token_per_layer,
         device="cpu",  # scatter函数期望host memory
         dtype=torch.bfloat16,
-        pin_memory=True  # 设置为pinned memory
+        pin_memory=True,  # 设置为pinned memory
     )
 
     # 为每个block生成token indices
-    all_block_token_indices = torch.randperm(total_token_in_kvcache)[:num_tokens_per_block * total_blocks].tolist()
+    all_block_token_indices = torch.randperm(total_token_in_kvcache)[
+        : num_tokens_per_block * total_blocks
+    ].tolist()
 
     src_block_indices = torch.randperm(total_buffer_blocks)[:total_blocks].tolist()
 
@@ -450,7 +490,7 @@ def test_batch_scatter_kv_caches_with_reference():
             total_token_in_kvcache,
             hidden_size_per_token_per_layer,
             device="cuda",
-            dtype=torch.bfloat16
+            dtype=torch.bfloat16,
         )
         # 将K和V分开添加到列表中，这样每个都是单独的指针
         reference_kv_caches.append(cache[0])  # K
@@ -458,9 +498,7 @@ def test_batch_scatter_kv_caches_with_reference():
 
     # 调用批量scatter函数
     kv_caches_ptrs_tensor = torch.tensor(
-        [cache.data_ptr() for cache in kv_caches],
-        device="cuda",
-        dtype=torch.int64
+        [cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64
     )
 
     batch_scatter_kv_caches(
@@ -470,7 +508,7 @@ def test_batch_scatter_kv_caches_with_reference():
         src_block_indices,
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
-        sm_count=3
+        sm_count=3,
     )
 
     # 使用PyTorch实现参考实现
@@ -481,17 +519,30 @@ def test_batch_scatter_kv_caches_with_reference():
             token_idx = all_block_token_indices[start_idx + token_pos]
             for layer_idx in range(num_layers):
                 # 参考实现 - 更新K值
-                src_k = src_tensor[src_block_idx, layer_idx * 2, token_pos, :].to(device=reference_kv_caches[layer_idx * 2].device, dtype=reference_kv_caches[layer_idx * 2].dtype)
+                src_k = src_tensor[src_block_idx, layer_idx * 2, token_pos, :].to(
+                    device=reference_kv_caches[layer_idx * 2].device,
+                    dtype=reference_kv_caches[layer_idx * 2].dtype,
+                )
                 reference_kv_caches[layer_idx * 2][token_idx, :] = src_k
 
                 # 参考实现 - 更新V值
-                src_v = src_tensor[src_block_idx, layer_idx * 2 + 1, token_pos, :].to(device=reference_kv_caches[layer_idx * 2 + 1].device, dtype=reference_kv_caches[layer_idx * 2 + 1].dtype)
+                src_v = src_tensor[src_block_idx, layer_idx * 2 + 1, token_pos, :].to(
+                    device=reference_kv_caches[layer_idx * 2 + 1].device,
+                    dtype=reference_kv_caches[layer_idx * 2 + 1].dtype,
+                )
                 reference_kv_caches[layer_idx * 2 + 1][token_idx, :] = src_v
 
     # 直接比较整个KV缓存和参考实现的结果
-    for idx, (actual_cache, reference_cache) in enumerate(zip(kv_caches, reference_kv_caches)):
-        torch.testing.assert_close(actual_cache, reference_cache,
-                                   msg="Mismatch between kernel and reference implementation for kvcache index {}".format(idx))
+    for idx, (actual_cache, reference_cache) in enumerate(
+        zip(kv_caches, reference_kv_caches)
+    ):
+        torch.testing.assert_close(
+            actual_cache,
+            reference_cache,
+            msg="Mismatch between kernel and reference implementation for kvcache index {}".format(
+                idx
+            ),
+        )
 
     print("Batch scatter KV caches test with reference passed!")
 
@@ -519,7 +570,7 @@ def test_batch_scatter_edge_cases():
             total_token_in_kvcache,
             hidden_size_per_token_per_layer,
             device="cuda",
-            dtype=torch.bfloat16
+            dtype=torch.bfloat16,
         )
         original_caches.append(cache.clone())  # 保存原始值用于验证
         # 将K和V分开添加到列表中，这样每个都是单独的指针
@@ -534,7 +585,7 @@ def test_batch_scatter_edge_cases():
         hidden_size_per_token_per_layer,
         device="cpu",  # scatter函数期望host memory
         dtype=torch.bfloat16,
-        pin_memory=True  # 设置为pinned memory
+        pin_memory=True,  # 设置为pinned memory
     )
 
     # 定义token indices和block indices
@@ -542,14 +593,16 @@ def test_batch_scatter_edge_cases():
     src_block_indices = [0]  # 只有一个block，位置为0
 
     # 保存源tensor的值用于验证
-    expected_k = src_tensor[0, 0, 0, :].clone()  # 第0个block，第0个指针(K)，第0个token位置
-    expected_v = src_tensor[0, 1, 0, :].clone()  # 第0个block，第1个指针(V)，第0个token位置
+    expected_k = src_tensor[
+        0, 0, 0, :
+    ].clone()  # 第0个block，第0个指针(K)，第0个token位置
+    expected_v = src_tensor[
+        0, 1, 0, :
+    ].clone()  # 第0个block，第1个指针(V)，第0个token位置
 
     # 调用批量scatter函数
     kv_caches_ptrs_tensor = torch.tensor(
-        [cache.data_ptr() for cache in kv_caches],
-        device="cuda",
-        dtype=torch.int64
+        [cache.data_ptr() for cache in kv_caches], device="cuda", dtype=torch.int64
     )
 
     batch_scatter_kv_caches(
@@ -559,20 +612,26 @@ def test_batch_scatter_edge_cases():
         src_block_indices,
         num_tokens_per_block,
         hidden_size_per_token_per_layer,
-        sm_count=3
+        sm_count=3,
     )
 
     # 验证结果
     actual_k = kv_caches[0][5, :]  # 位置5的K值
     actual_v = kv_caches[1][5, :]  # 位置5的V值
 
-    expected_k_converted = expected_k.cpu().to(device=actual_k.device, dtype=actual_k.dtype)
-    expected_v_converted = expected_v.cpu().to(device=actual_v.device, dtype=actual_v.dtype)
+    expected_k_converted = expected_k.cpu().to(
+        device=actual_k.device, dtype=actual_k.dtype
+    )
+    expected_v_converted = expected_v.cpu().to(
+        device=actual_v.device, dtype=actual_v.dtype
+    )
 
-    torch.testing.assert_close(expected_k_converted, actual_k,
-                               msg="Mismatch in K values for edge case")
-    torch.testing.assert_close(expected_v_converted, actual_v,
-                               msg="Mismatch in V values for edge case")
+    torch.testing.assert_close(
+        expected_k_converted, actual_k, msg="Mismatch in K values for edge case"
+    )
+    torch.testing.assert_close(
+        expected_v_converted, actual_v, msg="Mismatch in V values for edge case"
+    )
 
     print("Scatter edge case test passed!")
 

--- a/kv_cache_manager/py_connector/test/kernel/test_strided_gather_scatter.py
+++ b/kv_cache_manager/py_connector/test/kernel/test_strided_gather_scatter.py
@@ -21,17 +21,38 @@ from kv_cache_manager.py_connector.kernel.batch_gather_scatter_helper import (
 )
 
 
-def _make_paged_caches(num_layers, num_blocks, local_block_size, dims_per_token,
-                       pad_tokens, device, dtype, fill_random=True):
+def _make_paged_caches(
+    num_layers,
+    num_blocks,
+    local_block_size,
+    dims_per_token,
+    pad_tokens,
+    device,
+    dtype,
+    fill_random=True,
+):
     """Per-layer paged caches shaped (num_blocks, padded_tokens, dims) where
     padded_tokens = local_block_size + pad_tokens. block_stride (in elements)
     is padded_tokens * dims_per_token."""
     caches = []
     for _ in range(num_layers):
-        t = torch.randn(num_blocks, local_block_size + pad_tokens, dims_per_token,
-                        device=device, dtype=dtype) if fill_random else \
-            torch.zeros(num_blocks, local_block_size + pad_tokens, dims_per_token,
-                        device=device, dtype=dtype)
+        t = (
+            torch.randn(
+                num_blocks,
+                local_block_size + pad_tokens,
+                dims_per_token,
+                device=device,
+                dtype=dtype,
+            )
+            if fill_random
+            else torch.zeros(
+                num_blocks,
+                local_block_size + pad_tokens,
+                dims_per_token,
+                device=device,
+                dtype=dtype,
+            )
+        )
         caches.append(t)
     return caches
 
@@ -45,10 +66,10 @@ def _ref_slot(cache, flat_token_idx, local_block_size):
 class TestStridedGatherScatter(unittest.TestCase):
     # (local_block_size, pad_tokens, tokens_per_manager_block)
     CASES = [
-        (16, 0, 16),   # strided == flat geometry (stride still exercised)
-        (16, 4, 16),   # padded pages: gap between blocks
+        (16, 0, 16),  # strided == flat geometry (stride still exercised)
+        (16, 4, 16),  # padded pages: gap between blocks
         (64, 0, 528),  # hybrid attention: manager block spans many kv blocks
-        (64, 8, 48),   # padded + manager block not aligned to kv block
+        (64, 8, 48),  # padded + manager block not aligned to kv block
     ]
 
     def setUp(self):
@@ -72,22 +93,43 @@ class TestStridedGatherScatter(unittest.TestCase):
         for local_bs, pad, tokens_per_block in self.CASES:
             with self.subTest(local_bs=local_bs, pad=pad, tpb=tokens_per_block):
                 caches = _make_paged_caches(
-                    self.num_layers, self.num_kv_blocks, local_bs, self.dims,
-                    pad, self.device, self.dtype)
+                    self.num_layers,
+                    self.num_kv_blocks,
+                    local_bs,
+                    self.dims,
+                    pad,
+                    self.device,
+                    self.dtype,
+                )
                 block_stride = caches[0].stride(0)
                 self.assertEqual(block_stride, (local_bs + pad) * self.dims)
-                ptrs = torch.tensor([c.data_ptr() for c in caches],
-                                    device=self.device, dtype=torch.int64)
+                ptrs = torch.tensor(
+                    [c.data_ptr() for c in caches],
+                    device=self.device,
+                    dtype=torch.int64,
+                )
                 num_mb = 4
                 token_indices = self._indices(num_mb, tokens_per_block, local_bs)
                 dst_block_indices = [2, 0, 3, 1]
-                dst = torch.zeros(num_mb, self.num_layers, tokens_per_block,
-                                  self.dims, device="cpu", dtype=self.dtype,
-                                  pin_memory=True)
+                dst = torch.zeros(
+                    num_mb,
+                    self.num_layers,
+                    tokens_per_block,
+                    self.dims,
+                    device="cpu",
+                    dtype=self.dtype,
+                    pin_memory=True,
+                )
                 batch_gather_kv_caches(
-                    ptrs, dst, token_indices, dst_block_indices,
-                    tokens_per_block, self.dims,
-                    block_stride=block_stride, local_block_size=local_bs)
+                    ptrs,
+                    dst,
+                    token_indices,
+                    dst_block_indices,
+                    tokens_per_block,
+                    self.dims,
+                    block_stride=block_stride,
+                    local_block_size=local_bs,
+                )
                 torch.cuda.synchronize()
 
                 caches_cpu = [c.cpu() for c in caches]
@@ -98,33 +140,56 @@ class TestStridedGatherScatter(unittest.TestCase):
                             want = _ref_slot(caches_cpu[layer], flat_idx, local_bs)
                             got = dst[dst_block_indices[mb], layer, pos, :]
                             torch.testing.assert_close(
-                                got, want,
+                                got,
+                                want,
                                 msg=f"gather mismatch mb={mb} pos={pos} "
-                                    f"layer={layer} flat={flat_idx}")
+                                f"layer={layer} flat={flat_idx}",
+                            )
 
     def test_scatter_strided_matches_reference(self):
         for local_bs, pad, tokens_per_block in self.CASES:
             with self.subTest(local_bs=local_bs, pad=pad, tpb=tokens_per_block):
                 caches = _make_paged_caches(
-                    self.num_layers, self.num_kv_blocks, local_bs, self.dims,
-                    pad, self.device, self.dtype, fill_random=False)
+                    self.num_layers,
+                    self.num_kv_blocks,
+                    local_bs,
+                    self.dims,
+                    pad,
+                    self.device,
+                    self.dtype,
+                    fill_random=False,
+                )
                 # Sentinel in the padding region: scatter must never touch it.
                 sentinel = 123.0
                 if pad:
                     for c in caches:
                         c[:, local_bs:, :] = sentinel
                 block_stride = caches[0].stride(0)
-                ptrs = torch.tensor([c.data_ptr() for c in caches],
-                                    device=self.device, dtype=torch.int64)
+                ptrs = torch.tensor(
+                    [c.data_ptr() for c in caches],
+                    device=self.device,
+                    dtype=torch.int64,
+                )
                 num_mb = 4
                 token_indices = self._indices(num_mb, tokens_per_block, local_bs)
                 src_block_indices = [1, 3, 0, 2]
-                src = torch.randn(num_mb, self.num_layers, tokens_per_block,
-                                  self.dims, dtype=self.dtype).pin_memory()
+                src = torch.randn(
+                    num_mb,
+                    self.num_layers,
+                    tokens_per_block,
+                    self.dims,
+                    dtype=self.dtype,
+                ).pin_memory()
                 batch_scatter_kv_caches(
-                    ptrs, src, token_indices, src_block_indices,
-                    tokens_per_block, self.dims,
-                    block_stride=block_stride, local_block_size=local_bs)
+                    ptrs,
+                    src,
+                    token_indices,
+                    src_block_indices,
+                    tokens_per_block,
+                    self.dims,
+                    block_stride=block_stride,
+                    local_block_size=local_bs,
+                )
                 torch.cuda.synchronize()
 
                 caches_cpu = [c.cpu() for c in caches]
@@ -135,43 +200,80 @@ class TestStridedGatherScatter(unittest.TestCase):
                             got = _ref_slot(caches_cpu[layer], flat_idx, local_bs)
                             want = src[src_block_indices[mb], layer, pos, :]
                             torch.testing.assert_close(
-                                got, want,
+                                got,
+                                want,
                                 msg=f"scatter mismatch mb={mb} pos={pos} "
-                                    f"layer={layer} flat={flat_idx}")
+                                f"layer={layer} flat={flat_idx}",
+                            )
                 if pad:
                     for layer, c in enumerate(caches_cpu):
                         self.assertTrue(
                             bool((c[:, local_bs:, :] == sentinel).all()),
-                            f"scatter wrote into the padding of layer {layer}")
+                            f"scatter wrote into the padding of layer {layer}",
+                        )
 
     def test_gather_scatter_roundtrip_strided(self):
         """Scattering gathered data into zeroed caches must reproduce exactly
         the gathered slots (and only them)."""
         local_bs, pad, tokens_per_block = 64, 8, 48
         src_caches = _make_paged_caches(
-            self.num_layers, self.num_kv_blocks, local_bs, self.dims,
-            pad, self.device, self.dtype)
+            self.num_layers,
+            self.num_kv_blocks,
+            local_bs,
+            self.dims,
+            pad,
+            self.device,
+            self.dtype,
+        )
         dst_caches = _make_paged_caches(
-            self.num_layers, self.num_kv_blocks, local_bs, self.dims,
-            pad, self.device, self.dtype, fill_random=False)
+            self.num_layers,
+            self.num_kv_blocks,
+            local_bs,
+            self.dims,
+            pad,
+            self.device,
+            self.dtype,
+            fill_random=False,
+        )
         block_stride = src_caches[0].stride(0)
-        src_ptrs = torch.tensor([c.data_ptr() for c in src_caches],
-                                device=self.device, dtype=torch.int64)
-        dst_ptrs = torch.tensor([c.data_ptr() for c in dst_caches],
-                                device=self.device, dtype=torch.int64)
+        src_ptrs = torch.tensor(
+            [c.data_ptr() for c in src_caches], device=self.device, dtype=torch.int64
+        )
+        dst_ptrs = torch.tensor(
+            [c.data_ptr() for c in dst_caches], device=self.device, dtype=torch.int64
+        )
         num_mb = 3
         token_indices = self._indices(num_mb, tokens_per_block, local_bs)
-        buf = torch.zeros(num_mb, self.num_layers, tokens_per_block, self.dims,
-                          device="cpu", dtype=self.dtype, pin_memory=True)
+        buf = torch.zeros(
+            num_mb,
+            self.num_layers,
+            tokens_per_block,
+            self.dims,
+            device="cpu",
+            dtype=self.dtype,
+            pin_memory=True,
+        )
         batch_gather_kv_caches(
-            src_ptrs, buf, token_indices, list(range(num_mb)),
-            tokens_per_block, self.dims,
-            block_stride=block_stride, local_block_size=local_bs)
+            src_ptrs,
+            buf,
+            token_indices,
+            list(range(num_mb)),
+            tokens_per_block,
+            self.dims,
+            block_stride=block_stride,
+            local_block_size=local_bs,
+        )
         torch.cuda.synchronize()
         batch_scatter_kv_caches(
-            dst_ptrs, buf, token_indices, list(range(num_mb)),
-            tokens_per_block, self.dims,
-            block_stride=block_stride, local_block_size=local_bs)
+            dst_ptrs,
+            buf,
+            token_indices,
+            list(range(num_mb)),
+            tokens_per_block,
+            self.dims,
+            block_stride=block_stride,
+            local_block_size=local_bs,
+        )
         torch.cuda.synchronize()
         src_cpu = [c.cpu() for c in src_caches]
         dst_cpu = [c.cpu() for c in dst_caches]
@@ -179,7 +281,8 @@ class TestStridedGatherScatter(unittest.TestCase):
             for layer in range(self.num_layers):
                 torch.testing.assert_close(
                     _ref_slot(dst_cpu[layer], flat_idx, local_bs),
-                    _ref_slot(src_cpu[layer], flat_idx, local_bs))
+                    _ref_slot(src_cpu[layer], flat_idx, local_bs),
+                )
 
 
 if __name__ == "__main__":

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -3,26 +3,29 @@
 import json
 import sys
 import types
+from typing import Any
 import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
 
 # ── Mock unavailable modules before importing connector ──────────────
-_mock_metrics = types.ModuleType("sglang.srt.metrics")
-_mock_collector = types.ModuleType("sglang.srt.metrics.collector")
+_mock_metrics: Any = types.ModuleType("sglang.srt.metrics")
+_mock_collector: Any = types.ModuleType("sglang.srt.metrics.collector")
 _mock_collector.StorageMetrics = MagicMock
 _mock_metrics.collector = _mock_collector
 sys.modules.setdefault("sglang.srt.metrics", _mock_metrics)
 sys.modules.setdefault("sglang.srt.metrics.collector", _mock_collector)
 
-_mock_pybind = types.ModuleType("kv_cache_manager.client.pybind")
+_mock_pybind: Any = types.ModuleType("kv_cache_manager.client.pybind")
 _mock_kvcm = MagicMock()
 _mock_kvcm.ClientErrorCode.ER_OK = 0
 _mock_pybind.kvcm_py_client = _mock_kvcm
 sys.modules["kv_cache_manager.client.pybind"] = _mock_pybind
 
-_mock_version = types.ModuleType("kv_cache_manager.py_connector.common._version_info")
+_mock_version: Any = types.ModuleType(
+    "kv_cache_manager.py_connector.common._version_info"
+)
 _mock_version.FULL_VERSION = "0.0.0-test"
 _mock_version.GIT_COMMIT = "test"
 _mock_version.BUILD_TIME = "test"

--- a/kv_cache_manager/py_connector/test/test_batch_set_return.py
+++ b/kv_cache_manager/py_connector/test/test_batch_set_return.py
@@ -1,4 +1,5 @@
 """Unit tests for _batch_set return value: 1:1 positional mapping with input keys."""
+
 import json
 import sys
 import types
@@ -25,7 +26,9 @@ _mock_version = types.ModuleType("kv_cache_manager.py_connector.common._version_
 _mock_version.FULL_VERSION = "0.0.0-test"
 _mock_version.GIT_COMMIT = "test"
 _mock_version.BUILD_TIME = "test"
-sys.modules.setdefault("kv_cache_manager.py_connector.common._version_info", _mock_version)
+sys.modules.setdefault(
+    "kv_cache_manager.py_connector.common._version_info", _mock_version
+)
 
 from kv_cache_manager.py_connector.sglang.connector import HiCacheKVCM  # noqa: E402
 
@@ -35,10 +38,17 @@ def _make_obj(cls):
     return cls.__new__(cls)
 
 
-def _build_connector(*, tp_rank=0, tp_world_size=1, kv_factor=2,
-                     instance_id="test", location_spec_name="tp_0",
-                     location_spec_size=4096, write_timeout_seconds=30,
-                     is_mla_model=False):
+def _build_connector(
+    *,
+    tp_rank=0,
+    tp_world_size=1,
+    kv_factor=2,
+    instance_id="test",
+    location_spec_name="tp_0",
+    location_spec_size=4096,
+    write_timeout_seconds=30,
+    is_mla_model=False,
+):
     """Build a HiCacheKVCM with attributes set manually (bypass __init__)."""
     obj = _make_obj(HiCacheKVCM)
     obj.tp_rank = tp_rank
@@ -107,16 +117,14 @@ class TestBatchSetReturnValue(unittest.TestCase):
 
         # offset=2 means indices [2,3,4] need saving (relative: [2,3,4])
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(3)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(3)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-2",
             "block_mask": {"offset": 2},  # first 2 (prefix=0, so key 0,1) cached
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=True)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=True)
 
         result = c._batch_set(keys, torch.zeros(5), trace_id="t2")
 
@@ -130,16 +138,14 @@ class TestBatchSetReturnValue(unittest.TestCase):
         keys = ["k0", "k1", "k2", "k3", "k4"]
 
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(3)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(3)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-3",
             "block_mask": {"offset": 2},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=False)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=False)
 
         result = c._batch_set(keys, torch.zeros(5), trace_id="t3")
 
@@ -153,16 +159,14 @@ class TestBatchSetReturnValue(unittest.TestCase):
         keys = ["k0", "k1", "k2"]
 
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(3)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(3)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-4",
             "block_mask": {"offset": 0},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=True)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=True)
 
         result = c._batch_set(keys, torch.zeros(3), trace_id="t4")
 
@@ -175,16 +179,14 @@ class TestBatchSetReturnValue(unittest.TestCase):
         keys = ["k0", "k1", "k2"]
 
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(3)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(3)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-5",
             "block_mask": {"offset": 0},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=False)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=False)
 
         result = c._batch_set(keys, torch.zeros(3), trace_id="t5")
 
@@ -200,22 +202,21 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # block_mask offset=5 means save from index 5 onward
         # relative save_indices = [5-3, 6-3] = [2, 3]
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(2)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(2)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-6",
             "block_mask": {"offset": 5},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=True)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=True)
 
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1", "p2"]
 
-        result = c._batch_set(keys, torch.zeros(4), trace_id="t6",
-                              extra_info=extra_info)
+        result = c._batch_set(
+            keys, torch.zeros(4), trace_id="t6", extra_info=extra_info
+        )
 
         self.assertEqual(len(result), len(keys))
         # key 0,1 (k3,k4) → True (no write needed)
@@ -231,20 +232,14 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # indices [0,1,2,3,4] → masks [False, True, False, True, False]
         # save_indices (need write): [0, 2, 4]
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(3)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(3)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-7",
-            "block_mask": {
-                "bool_masks": {
-                    "values": [False, True, False, True, False]
-                }
-            },
+            "block_mask": {"bool_masks": {"values": [False, True, False, True, False]}},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=True)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=True)
 
         result = c._batch_set(keys, torch.zeros(5), trace_id="t7")
 
@@ -262,20 +257,14 @@ class TestBatchSetReturnValue(unittest.TestCase):
         keys = ["k0", "k1", "k2", "k3", "k4"]
 
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(3)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(3)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-8",
-            "block_mask": {
-                "bool_masks": {
-                    "values": [False, True, False, True, False]
-                }
-            },
+            "block_mask": {"bool_masks": {"values": [False, True, False, True, False]}},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=False)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=False)
 
         result = c._batch_set(keys, torch.zeros(5), trace_id="t8")
 
@@ -298,22 +287,21 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # prefix_write_count=2, save_indices=[0,1,2]
         # locations: 5 entries (2 prefix + 3 new)
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(5)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(5)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-9",
             "block_mask": {"offset": 1},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=True)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=True)
 
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1", "p2"]
 
-        result = c._batch_set(keys, torch.zeros(3), trace_id="t9",
-                              extra_info=extra_info)
+        result = c._batch_set(
+            keys, torch.zeros(3), trace_id="t9", extra_info=extra_info
+        )
 
         self.assertEqual(len(result), len(keys))
         # All new blocks written successfully
@@ -331,22 +319,21 @@ class TestBatchSetReturnValue(unittest.TestCase):
         keys = ["k3", "k4", "k5"]
 
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(5)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(5)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-10",
             "block_mask": {"offset": 1},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=False)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=False)
 
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1", "p2"]
 
-        result = c._batch_set(keys, torch.zeros(3), trace_id="t10",
-                              extra_info=extra_info)
+        result = c._batch_set(
+            keys, torch.zeros(3), trace_id="t10", extra_info=extra_info
+        )
 
         self.assertEqual(len(result), len(keys))
         # New blocks write failed
@@ -368,26 +355,21 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # prefix_write_count=1, save_indices=[0,2] (k2 and k4)
         # locations: 3 entries (1 prefix + 2 new)
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(3)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(3)
         ]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-11",
-            "block_mask": {
-                "bool_masks": {
-                    "values": [True, False, False, True, False]
-                }
-            },
+            "block_mask": {"bool_masks": {"values": [True, False, False, True, False]}},
         }
-        c = self._setup_connector(start_write_result=result_from_manager,
-                                  save_ok=True)
+        c = self._setup_connector(start_write_result=result_from_manager, save_ok=True)
 
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1"]
 
-        result = c._batch_set(keys, torch.zeros(3), trace_id="t11",
-                              extra_info=extra_info)
+        result = c._batch_set(
+            keys, torch.zeros(3), trace_id="t11", extra_info=extra_info
+        )
 
         self.assertEqual(len(result), len(keys))
         # k2: write succeeded, k3: cached, k4: write succeeded
@@ -408,25 +390,20 @@ class TestBatchSetReturnValue(unittest.TestCase):
         #   p0:True p1:False(prefix,skip) k2:True(cached) k3:True(cached)
         # prefix_write_count=1, save_indices=[] (all new cached)
         # locations: 1 entry (for p1 only)
-        locations = [
-            {"location_specs": [{"name": "tp_0", "uri": "uri_0"}]}
-        ]
+        locations = [{"location_specs": [{"name": "tp_0", "uri": "uri_0"}]}]
         result_from_manager = {
             "locations": locations,
             "write_session_id": "ws-12",
-            "block_mask": {
-                "bool_masks": {
-                    "values": [True, False, True, True]
-                }
-            },
+            "block_mask": {"bool_masks": {"values": [True, False, True, True]}},
         }
         c = self._setup_connector(start_write_result=result_from_manager)
 
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1"]
 
-        result = c._batch_set(keys, torch.zeros(2), trace_id="t12",
-                              extra_info=extra_info)
+        result = c._batch_set(
+            keys, torch.zeros(2), trace_id="t12", extra_info=extra_info
+        )
 
         self.assertEqual(len(result), len(keys))
         # All new blocks are cached → True
@@ -446,11 +423,7 @@ class TestBatchSetReturnValue(unittest.TestCase):
         result_from_manager = {
             "locations": [],
             "write_session_id": "ws-13",
-            "block_mask": {
-                "bool_masks": {
-                    "values": [True]
-                }
-            },
+            "block_mask": {"bool_masks": {"values": [True]}},
         }
         c = self._setup_connector(start_write_result=result_from_manager)
 
@@ -467,11 +440,7 @@ class TestBatchSetReturnValue(unittest.TestCase):
         result_from_manager = {
             "locations": [],
             "write_session_id": "ws-14",
-            "block_mask": {
-                "bool_masks": {
-                    "values": []
-                }
-            },
+            "block_mask": {"bool_masks": {"values": []}},
         }
         c = self._setup_connector(start_write_result=result_from_manager)
 
@@ -488,8 +457,7 @@ class TestBatchSetReturnValue(unittest.TestCase):
 
         # All 5 keys need writing (offset=0), 5 locations
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(5)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(5)
         ]
         result_from_manager = {
             "locations": locations,
@@ -503,7 +471,7 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # This simulates a rank that has fewer local blocks available.
         # local_block_count = 6 // 2 = 3, so only save_indices [0,1,2] are valid.
         c.mem_pool_host.get_page_buffer_meta.return_value = (
-            list(range(6)),           # 6 ptrs → 3 blocks
+            list(range(6)),  # 6 ptrs → 3 blocks
             [c.location_spec_size] * 6,
         )
 
@@ -535,8 +503,7 @@ class TestBatchSetReturnValue(unittest.TestCase):
 
         # All 4 keys need writing (offset=0)
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(4)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(4)
         ]
         result_from_manager = {
             "locations": locations,
@@ -579,8 +546,7 @@ class TestBatchSetReturnValue(unittest.TestCase):
         # prefix_write_count=1, save_indices=[0,1,2,3]
         # locations: 5 entries (1 prefix + 4 new)
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(5)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(5)
         ]
         result_from_manager = {
             "locations": locations,
@@ -606,8 +572,9 @@ class TestBatchSetReturnValue(unittest.TestCase):
         extra_info = MagicMock()
         extra_info.prefix_keys = ["p0", "p1"]
 
-        result = c._batch_set(keys, torch.zeros(4), trace_id="t17",
-                              extra_info=extra_info)
+        result = c._batch_set(
+            keys, torch.zeros(4), trace_id="t17", extra_info=extra_info
+        )
 
         self.assertEqual(len(result), len(keys))
         # k2(idx0): local data + success → True
@@ -651,11 +618,13 @@ class TestSkipTransfer(unittest.TestCase):
     @staticmethod
     def _broadcast_side_effect(result, len_prefix, len_new, input_hash):
         """Return a side_effect that fills the recv list with rank 0's data."""
+
         def _side_effect(tensor_list, src, group):
             tensor_list[0] = result
             tensor_list[1] = len_prefix
             tensor_list[2] = len_new
             tensor_list[3] = input_hash
+
         return _side_effect
 
     @staticmethod
@@ -677,7 +646,8 @@ class TestSkipTransfer(unittest.TestCase):
         rank0_len_prefix, rank0_len_new = 0, 3
         rank0_hash = self._rank0_hash(
             ["rank0_k0", "rank0_k1", "rank0_k2"],
-            rank0_len_prefix, rank0_len_new,
+            rank0_len_prefix,
+            rank0_len_new,
         )
         rank0_result = {
             "locations": [],
@@ -686,7 +656,10 @@ class TestSkipTransfer(unittest.TestCase):
         }
 
         bcast = self._broadcast_side_effect(
-            rank0_result, rank0_len_prefix, rank0_len_new, rank0_hash,
+            rank0_result,
+            rank0_len_prefix,
+            rank0_len_new,
+            rank0_hash,
         )
         with patch("torch.distributed.broadcast_object_list", side_effect=bcast):
             result = c._batch_set(local_keys, torch.zeros(3), trace_id="t19")
@@ -705,11 +678,11 @@ class TestSkipTransfer(unittest.TestCase):
         rank0_len_prefix, rank0_len_new = 0, 4
         rank0_hash = self._rank0_hash(
             ["rank0_k0", "rank0_k1", "rank0_k2", "rank0_k3"],
-            rank0_len_prefix, rank0_len_new,
+            rank0_len_prefix,
+            rank0_len_new,
         )
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(2)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(2)
         ]
         rank0_result = {
             "locations": locations,
@@ -718,12 +691,17 @@ class TestSkipTransfer(unittest.TestCase):
         }
 
         bcast = self._broadcast_side_effect(
-            rank0_result, rank0_len_prefix, rank0_len_new, rank0_hash,
+            rank0_result,
+            rank0_len_prefix,
+            rank0_len_new,
+            rank0_hash,
         )
 
         # all_reduce is a no-op (keeps all-zero flags)
-        with patch("torch.distributed.broadcast_object_list", side_effect=bcast), \
-             patch("torch.distributed.all_reduce"):
+        with (
+            patch("torch.distributed.broadcast_object_list", side_effect=bcast),
+            patch("torch.distributed.all_reduce"),
+        ):
             result = c._batch_set(local_keys, torch.zeros(4), trace_id="t20")
 
         self.assertEqual(len(result), 4)
@@ -742,12 +720,12 @@ class TestSkipTransfer(unittest.TestCase):
         rank0_len_prefix, rank0_len_new = 3, 3
         rank0_hash = self._rank0_hash(
             ["rank0_p0", "rank0_p1", "rank0_p2", "rank0_k3", "rank0_k4", "rank0_k5"],
-            rank0_len_prefix, rank0_len_new,
+            rank0_len_prefix,
+            rank0_len_new,
         )
         # offset=1 < len_prefix=3 → prefix best-effort path, all 5 blocks in locations
         locations = [
-            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]}
-            for i in range(5)
+            {"location_specs": [{"name": "tp_0", "uri": f"uri_{i}"}]} for i in range(5)
         ]
         rank0_result = {
             "locations": locations,
@@ -756,13 +734,19 @@ class TestSkipTransfer(unittest.TestCase):
         }
 
         bcast = self._broadcast_side_effect(
-            rank0_result, rank0_len_prefix, rank0_len_new, rank0_hash,
+            rank0_result,
+            rank0_len_prefix,
+            rank0_len_new,
+            rank0_hash,
         )
 
-        with patch("torch.distributed.broadcast_object_list", side_effect=bcast), \
-             patch("torch.distributed.all_reduce"):
-            result = c._batch_set(local_keys, torch.zeros(3), trace_id="t21",
-                                  extra_info=local_extra)
+        with (
+            patch("torch.distributed.broadcast_object_list", side_effect=bcast),
+            patch("torch.distributed.all_reduce"),
+        ):
+            result = c._batch_set(
+                local_keys, torch.zeros(3), trace_id="t21", extra_info=local_extra
+            )
 
         self.assertEqual(len(result), 3)
         self.assertEqual(result, [False, False, False])
@@ -775,32 +759,39 @@ class TestParseHf3fsConfigs(unittest.TestCase):
         c.write_iov_block_size = 1048576
         c.iov_size = 4294967296
 
-        storage_configs = json.dumps([
-            {
-                "type": "vcns_hf3fs",
-                "is_available": True,
-                "global_unique_name": "vcns_3fs",
-                "storage_spec": {
-                    "cluster_name": "vcns_3fs",
+        storage_configs = json.dumps(
+            [
+                {
+                    "type": "vcns_hf3fs",
+                    "is_available": True,
+                    "global_unique_name": "vcns_3fs",
+                    "storage_spec": {
+                        "cluster_name": "vcns_3fs",
+                        "mountpoint": "/data/",
+                        "root_dir": "instance-root/",
+                        "key_count_per_file": 8,
+                        "remote_host": "127.0.0.1",
+                        "remote_port": 9081,
+                        "meta_storage_uri": "redis://example",
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(
+            c.parse_hf3fs_configs(storage_configs),
+            [
+                {
+                    "type": "vcns_hf3fs",
                     "mountpoint": "/data/",
                     "root_dir": "instance-root/",
-                    "key_count_per_file": 8,
-                    "remote_host": "127.0.0.1",
-                    "remote_port": 9081,
-                    "meta_storage_uri": "redis://example",
-                },
-            }
-        ])
-
-        self.assertEqual(c.parse_hf3fs_configs(storage_configs), [{
-            "type": "vcns_hf3fs",
-            "mountpoint": "/data/",
-            "root_dir": "instance-root/",
-            "read_iov_block_size": 0,
-            "read_iov_size": 4294967296,
-            "write_iov_block_size": 1048576,
-            "write_iov_size": 4294967296,
-        }])
+                    "read_iov_block_size": 0,
+                    "read_iov_size": 4294967296,
+                    "write_iov_block_size": 1048576,
+                    "write_iov_size": 4294967296,
+                }
+            ],
+        )
 
     def test_unavailable_vcns_hf3fs_is_ignored(self):
         c = _build_connector()
@@ -808,17 +799,19 @@ class TestParseHf3fsConfigs(unittest.TestCase):
         c.write_iov_block_size = 0
         c.iov_size = 1024
 
-        storage_configs = json.dumps([
-            {
-                "type": "vcns_hf3fs",
-                "is_available": False,
-                "global_unique_name": "vcns_3fs",
-                "storage_spec": {
-                    "mountpoint": "/data/",
-                    "root_dir": "instance-root/",
-                },
-            }
-        ])
+        storage_configs = json.dumps(
+            [
+                {
+                    "type": "vcns_hf3fs",
+                    "is_available": False,
+                    "global_unique_name": "vcns_3fs",
+                    "storage_spec": {
+                        "mountpoint": "/data/",
+                        "root_dir": "instance-root/",
+                    },
+                }
+            ]
+        )
 
         self.assertEqual(c.parse_hf3fs_configs(storage_configs), [])
 
@@ -833,8 +826,11 @@ class TestMLASkipTPSync(unittest.TestCase):
     def _make_mla_rank0(self):
         """MLA connector at rank 0 in a 2-rank setup."""
         c = _build_connector(
-            tp_rank=0, tp_world_size=2, kv_factor=1,
-            location_spec_name="tp_0_full", is_mla_model=True,
+            tp_rank=0,
+            tp_world_size=2,
+            kv_factor=1,
+            location_spec_name="tp_0_full",
+            is_mla_model=True,
         )
         c.storage_tp_group = MagicMock()
         return c
@@ -862,8 +858,10 @@ class TestMLASkipTPSync(unittest.TestCase):
         c = self._make_mla_rank0()
         self._setup_write(c)
 
-        with patch("torch.distributed.broadcast_object_list") as mock_bcast, \
-             patch("torch.distributed.all_reduce") as mock_allreduce:
+        with (
+            patch("torch.distributed.broadcast_object_list") as mock_bcast,
+            patch("torch.distributed.all_reduce") as mock_allreduce,
+        ):
             result = c._batch_set(["k0", "k1", "k2"], torch.zeros(3), trace_id="mla1")
 
         self.assertEqual(result, [True, True, True])
@@ -876,8 +874,10 @@ class TestMLASkipTPSync(unittest.TestCase):
         c = self._make_mla_rank0()
         self._setup_write(c, save_ok=False)
 
-        with patch("torch.distributed.broadcast_object_list") as mock_bcast, \
-             patch("torch.distributed.all_reduce") as mock_allreduce:
+        with (
+            patch("torch.distributed.broadcast_object_list") as mock_bcast,
+            patch("torch.distributed.all_reduce") as mock_allreduce,
+        ):
             result = c._batch_set(["k0", "k1", "k2"], torch.zeros(3), trace_id="mla2")
 
         self.assertEqual(result, [False, False, False])
@@ -902,8 +902,10 @@ class TestMLASkipTPSync(unittest.TestCase):
         c = self._make_mla_rank0()
         self._setup_write(c, num_keys=4)
 
-        with patch("torch.distributed.broadcast_object_list"), \
-             patch("torch.distributed.all_reduce"):
+        with (
+            patch("torch.distributed.broadcast_object_list"),
+            patch("torch.distributed.all_reduce"),
+        ):
             c._batch_set(["k0", "k1", "k2", "k3"], torch.zeros(4), trace_id="mla4")
 
         # SaveKvCaches should be called with 4 URIs (1 per page, not 8)

--- a/kv_cache_manager/py_connector/test/test_block_translation.py
+++ b/kv_cache_manager/py_connector/test/test_block_translation.py
@@ -10,34 +10,50 @@ import unittest
 
 from kv_cache_manager.py_connector.test.vllm_stubs import make_connector
 from kv_cache_manager.py_connector.vllm.transfer_types import (
-    AttentionTransferGroup, KVLayout, StateTransferGroup)
+    AttentionTransferGroup,
+    KVLayout,
+    StateTransferGroup,
+)
 
 
 def _make_group(group_bs, kernel_bs=0, is_attention=True):
-    common = dict(group_idx=0, spec_name="tp0_g0", layer_names=["layer0"],
-                  block_size=group_bs, per_block_bytes=0, layer_num=1)
+    common = dict(
+        group_idx=0,
+        spec_name="tp0_g0",
+        layer_names=["layer0"],
+        block_size=group_bs,
+        per_block_bytes=0,
+        layer_num=1,
+    )
     if is_attention:
         return AttentionTransferGroup(
-            kv_layout=KVLayout.PACKED_4D, kvcache_ptr_tensor_gpu=None,
-            num_kv_ptrs=1, per_token_dim=8, kernel_block_size=kernel_bs,
-            block_stride=0, **common)
-    return StateTransferGroup(
-        block_view_tensors=[], page_size_bytes=0, **common)
+            kv_layout=KVLayout.PACKED_4D,
+            kvcache_ptr_tensor_gpu=None,
+            num_kv_ptrs=1,
+            per_token_dim=8,
+            kernel_block_size=kernel_bs,
+            block_stride=0,
+            **common,
+        )
+    return StateTransferGroup(block_view_tensors=[], page_size_bytes=0, **common)
 
 
-def _ref_attn_token_indices(manager_bs, group_bs, kernel_bs, manager_block_idxes,
-                            block_table):
+def _ref_attn_token_indices(
+    manager_bs, group_bs, kernel_bs, manager_block_idxes, block_table
+):
     """Brute-force reference: walk every token of every manager block and map it
     through the block hierarchy step by step."""
     out = []
     for mb in manager_block_idxes:
         slots = []
         for tok in range(mb * manager_bs, (mb + 1) * manager_bs):
-            group_block = tok // group_bs          # logical block in group table
+            group_block = tok // group_bs  # logical block in group table
             tok_in_group = tok - group_block * group_bs
             kernel_in_group = tok_in_group // kernel_bs
             tok_in_kernel = tok_in_group - kernel_in_group * kernel_bs
-            physical = block_table[group_block] * (group_bs // kernel_bs) + kernel_in_group
+            physical = (
+                block_table[group_block] * (group_bs // kernel_bs) + kernel_in_group
+            )
             slots.append(physical * kernel_bs + tok_in_kernel)
         out.append(slots)
     return out
@@ -56,17 +72,18 @@ def _ref_state_block_ids(manager_bs, group_bs, manager_block_idxes, block_table)
 class TestAttnTokenIndices(unittest.TestCase):
     # (manager_bs, group_bs, kernel_bs): ratio=1, ratio>1, manager != group.
     CASES = [
-        (16, 16, 16),    # full attention default: all equal
-        (32, 16, 16),    # preferred_block_size > vllm block size
+        (16, 16, 16),  # full attention default: all equal
+        (32, 16, 16),  # preferred_block_size > vllm block size
         (528, 528, 64),  # hybrid: group block spans several kernel blocks
-        (528, 528, 528), # hybrid with kernel == group
-        (48, 16, 8),     # manager > group > kernel
+        (528, 528, 528),  # hybrid with kernel == group
+        (48, 16, 8),  # manager > group > kernel
     ]
 
     def test_against_reference(self):
         for manager_bs, group_bs, kernel_bs in self.CASES:
-            with self.subTest(manager_bs=manager_bs, group_bs=group_bs,
-                              kernel_bs=kernel_bs):
+            with self.subTest(
+                manager_bs=manager_bs, group_bs=group_bs, kernel_bs=kernel_bs
+            ):
                 conn = make_connector(manager_block_size=manager_bs)
                 group = _make_group(group_bs, kernel_bs)
                 # Enough non-trivially permuted blocks for 4 manager blocks.
@@ -75,7 +92,8 @@ class TestAttnTokenIndices(unittest.TestCase):
                 mbis = [0, 1, 3]
                 got = conn._attn_token_indices(group, mbis, block_table)
                 want = _ref_attn_token_indices(
-                    manager_bs, group_bs, kernel_bs, mbis, block_table)
+                    manager_bs, group_bs, kernel_bs, mbis, block_table
+                )
                 self.assertEqual(got, want)
 
     def test_manual_example(self):

--- a/kv_cache_manager/py_connector/test/test_block_translation.py
+++ b/kv_cache_manager/py_connector/test/test_block_translation.py
@@ -7,6 +7,7 @@ reference implementation, token by token.
 """
 
 import unittest
+from typing import Any, Dict
 
 from kv_cache_manager.py_connector.test.vllm_stubs import make_connector
 from kv_cache_manager.py_connector.vllm.transfer_types import (
@@ -17,7 +18,7 @@ from kv_cache_manager.py_connector.vllm.transfer_types import (
 
 
 def _make_group(group_bs, kernel_bs=0, is_attention=True):
-    common = dict(
+    common: Dict[str, Any] = dict(
         group_idx=0,
         spec_name="tp0_g0",
         layer_names=["layer0"],
@@ -28,7 +29,8 @@ def _make_group(group_bs, kernel_bs=0, is_attention=True):
     if is_attention:
         return AttentionTransferGroup(
             kv_layout=KVLayout.PACKED_4D,
-            kvcache_ptr_tensor_gpu=None,
+            # No real device pointers in the pure translation tests.
+            kvcache_ptr_tensor_gpu=None,  # ty: ignore[invalid-argument-type]
             num_kv_ptrs=1,
             per_token_dim=8,
             kernel_block_size=kernel_bs,

--- a/kv_cache_manager/py_connector/test/test_data_transfer_results.py
+++ b/kv_cache_manager/py_connector/test/test_data_transfer_results.py
@@ -20,10 +20,11 @@ from kv_cache_manager.py_connector.test import vllm_stubs  # noqa: F401 (stubs)
 
 import torch
 from kv_cache_manager.py_connector.vllm.data_transfer import (
-    DataTransferManager, MultiResult)
+    DataTransferManager,
+    MultiResult,
+)
 from kv_cache_manager.py_connector.vllm.transfer_types import KVLayout
-from kv_cache_manager.py_connector.common.tp_coordinator import (
-    CoordinateMsgSerializer)
+from kv_cache_manager.py_connector.common.tp_coordinator import CoordinateMsgSerializer
 
 
 class TestMultiResult(unittest.TestCase):
@@ -94,8 +95,16 @@ class TestSaveDoneCallback(unittest.TestCase):
         # Block b is saved only if both groups succeeded for b.
         dtm = _make_dtm()
         cb = dtm.create_save_done_callback("req", 0, "sess", num_blocks=3)
-        cb([True, True, False,   # group 0
-            True, False, True])  # group 1
+        cb(
+            [
+                True,
+                True,
+                False,  # group 0
+                True,
+                False,
+                True,
+            ]
+        )  # group 1
         evt = _sent_event(dtm)
         self.assertEqual(evt.type, "SendBlockFinishedEvent")
         self.assertEqual(evt.write_session_id, "sess")
@@ -112,9 +121,18 @@ class TestLoadDoneCallback(unittest.TestCase):
     def test_multi_group_failure_merge(self):
         dtm = _make_dtm()
         cb = dtm.create_load_done_callback(
-            "req", 0, epoch=7, block_ids=[10, 20, 30], num_blocks=3)
-        cb([True, False, True,    # group 0
-            True, True, False])   # group 1
+            "req", 0, epoch=7, block_ids=[10, 20, 30], num_blocks=3
+        )
+        cb(
+            [
+                True,
+                False,
+                True,  # group 0
+                True,
+                True,
+                False,
+            ]
+        )  # group 1
         evt = _sent_event(dtm)
         self.assertEqual(evt.type, "LoadBlockFinishedEvent")
         self.assertEqual(evt.epoch, 7)
@@ -124,7 +142,8 @@ class TestLoadDoneCallback(unittest.TestCase):
     def test_all_success_reports_empty(self):
         dtm = _make_dtm()
         cb = dtm.create_load_done_callback(
-            "req", 0, epoch=0, block_ids=[10, 20], num_blocks=2)
+            "req", 0, epoch=0, block_ids=[10, 20], num_blocks=2
+        )
         cb([True, True, True, True])
         self.assertEqual(_sent_event(dtm).failed_block_idxs, [])
 
@@ -133,7 +152,8 @@ class TestLoadDoneCallback(unittest.TestCase):
         # must be swallowed (empty failed list) but the finished event still sent.
         dtm = _make_dtm()
         cb = dtm.create_load_done_callback(
-            "req", 0, epoch=1, block_ids=[], num_blocks=2, report_failures=False)
+            "req", 0, epoch=1, block_ids=[], num_blocks=2, report_failures=False
+        )
         cb([False, True])
         evt = _sent_event(dtm)
         self.assertEqual(evt.type, "LoadBlockFinishedEvent")
@@ -156,20 +176,38 @@ class TestNullStateBlocks(unittest.TestCase):
     @staticmethod
     def _state_group():
         from kv_cache_manager.py_connector.vllm.transfer_types import StateTransferGroup
+
         return StateTransferGroup(
-            group_idx=0, spec_name="tp0_g0",
-            layer_names=["m0"], block_size=528, per_block_bytes=1024,
-            layer_num=1, block_view_tensors=[], page_size_bytes=1024)
+            group_idx=0,
+            spec_name="tp0_g0",
+            layer_names=["m0"],
+            block_size=528,
+            per_block_bytes=1024,
+            layer_num=1,
+            block_view_tensors=[],
+            page_size_bytes=1024,
+        )
 
     @staticmethod
     def _attn_group():
-        from kv_cache_manager.py_connector.vllm.transfer_types import AttentionTransferGroup
+        from kv_cache_manager.py_connector.vllm.transfer_types import (
+            AttentionTransferGroup,
+        )
+
         return AttentionTransferGroup(
-            group_idx=1, spec_name="tp0_g1",
-            layer_names=["a0"], block_size=528, per_block_bytes=1024,
-            layer_num=1, kv_layout=KVLayout.PACKED_4D,
-            kvcache_ptr_tensor_gpu=None, num_kv_ptrs=1, per_token_dim=8,
-            kernel_block_size=528, block_stride=0)
+            group_idx=1,
+            spec_name="tp0_g1",
+            layer_names=["a0"],
+            block_size=528,
+            per_block_bytes=1024,
+            layer_num=1,
+            kv_layout=KVLayout.PACKED_4D,
+            kvcache_ptr_tensor_gpu=None,
+            num_kv_ptrs=1,
+            per_token_dim=8,
+            kernel_block_size=528,
+            block_stride=0,
+        )
 
     def _run(self, method, **kwargs):
         dtm = _make_dtm()
@@ -180,48 +218,55 @@ class TestNullStateBlocks(unittest.TestCase):
 
     def test_save_null_state_blocks_abstain_not_succeed(self):
         # No state and (consistently) no location for it: the group abstains.
-        flat = self._run("save_task",
-                         remote_uris=[None, None],
-                         block_token_indices=None,
-                         block_ids=[0, 0],
-                         ready_event=None)
+        flat = self._run(
+            "save_task",
+            remote_uris=[None, None],
+            block_token_indices=None,
+            block_ids=[0, 0],
+            ready_event=None,
+        )
         self.assertEqual(flat, [None, None])
 
     def test_save_null_state_with_location_fails(self):
         # The manager allocated a state location but vLLM has no state to put
         # there: publishing it would advertise unwritten bytes.
-        flat = self._run("save_task",
-                         remote_uris=["u0", None],
-                         block_token_indices=None,
-                         block_ids=[0, 0],
-                         ready_event=None)
+        flat = self._run(
+            "save_task",
+            remote_uris=["u0", None],
+            block_token_indices=None,
+            block_ids=[0, 0],
+            ready_event=None,
+        )
         self.assertEqual(flat, [False, None])
 
     def test_save_real_state_without_location_fails(self):
         # A state exists but was not announced: it cannot be published.
-        flat = self._run("save_task",
-                         remote_uris=[None],
-                         block_token_indices=None,
-                         block_ids=[7],
-                         ready_event=None)
+        flat = self._run(
+            "save_task",
+            remote_uris=[None],
+            block_token_indices=None,
+            block_ids=[7],
+            ready_event=None,
+        )
         self.assertEqual(flat, [False])
 
     def test_load_null_state_targets_abstain(self):
         # vLLM does not need a state for these blocks (only the block ending
         # the reused prefix does), whatever the manager published.
-        flat = self._run("load_task",
-                         remote_uris=["u0", "u1", "u2"],
-                         block_token_indices=None,
-                         block_ids=[0, 0, 0])
+        flat = self._run(
+            "load_task",
+            remote_uris=["u0", "u1", "u2"],
+            block_token_indices=None,
+            block_ids=[0, 0, 0],
+        )
         self.assertEqual(flat, [None, None, None])
 
     def test_load_real_target_without_location_fails(self):
         # vLLM needs this state but nothing was published for it: the request
         # must not run on an unwritten state.
-        flat = self._run("load_task",
-                         remote_uris=[None],
-                         block_token_indices=None,
-                         block_ids=[9])
+        flat = self._run(
+            "load_task", remote_uris=[None], block_token_indices=None, block_ids=[9]
+        )
         self.assertEqual(flat, [False])
 
     def test_attention_block_without_location_fails(self):
@@ -230,8 +275,8 @@ class TestNullStateBlocks(unittest.TestCase):
         # buffers stay aligned with the URI list.
         dtm = _make_dtm()
         skipped, failed = dtm._save_dispositions(
-            self._attn_group(), remote_uris=["u0", None, "u2"],
-            block_ids=None, n=3)
+            self._attn_group(), remote_uris=["u0", None, "u2"], block_ids=None, n=3
+        )
         self.assertEqual((skipped, failed), (set(), {1}))
 
     def test_save_dispositions_state_group(self):
@@ -241,8 +286,11 @@ class TestNullStateBlocks(unittest.TestCase):
         # block2: no state but published -> fail
         # block3: state but unpublished  -> fail
         skipped, failed = dtm._save_dispositions(
-            self._state_group(), remote_uris=[None, "u1", "u2", None],
-            block_ids=[0, 5, 0, 6], n=4)
+            self._state_group(),
+            remote_uris=[None, "u1", "u2", None],
+            block_ids=[0, 5, 0, 6],
+            n=4,
+        )
         self.assertEqual(skipped, {0})
         self.assertEqual(failed, {2, 3})
 
@@ -260,13 +308,14 @@ class TestTaskCrashReporting(unittest.TestCase):
 
     def _run_crashing(self, method):
         from unittest.mock import patch
+
         dtm = _make_dtm()
         results = {}
         mr = MultiResult(1, lambda flat: results.setdefault("flat", flat))
         group = self._state_group()
-        kwargs = dict(remote_uris=["u0", "u1"],
-                      block_token_indices=None,
-                      block_ids=[5, 6])
+        kwargs = dict(
+            remote_uris=["u0", "u1"], block_token_indices=None, block_ids=[5, 6]
+        )
         crash = "_%s_valid_blocks" % method.split("_")[0]
         with patch.object(dtm, crash, side_effect=RuntimeError("boom")):
             if method == "save_task":
@@ -291,8 +340,16 @@ class TestAbstainedVerdicts(unittest.TestCase):
     def test_save_abstain_does_not_mask_other_group(self):
         dtm = _make_dtm()
         cb = dtm.create_save_done_callback("req", 0, "sess", num_blocks=3)
-        cb([None, None, True,    # state group: only block 2 had a state
-            True, False, True])  # attention group
+        cb(
+            [
+                None,
+                None,
+                True,  # state group: only block 2 had a state
+                True,
+                False,
+                True,
+            ]
+        )  # attention group
         # Block 0 rides on attention alone, block 1 fails there, block 2 both.
         self.assertEqual(_sent_event(dtm).is_success_list, [True, False, True])
 
@@ -305,15 +362,25 @@ class TestAbstainedVerdicts(unittest.TestCase):
     def test_load_abstain_does_not_mask_other_group(self):
         dtm = _make_dtm()
         cb = dtm.create_load_done_callback(
-            "req", 0, epoch=3, block_ids=[10, 20, 30], num_blocks=3)
-        cb([None, None, False,   # state group: block 2 needed a state, failed
-            True, True, True])   # attention group
+            "req", 0, epoch=3, block_ids=[10, 20, 30], num_blocks=3
+        )
+        cb(
+            [
+                None,
+                None,
+                False,  # state group: block 2 needed a state, failed
+                True,
+                True,
+                True,
+            ]
+        )  # attention group
         self.assertEqual(_sent_event(dtm).failed_block_idxs, [30])
 
     def test_load_all_groups_abstain_counts_as_failure(self):
         dtm = _make_dtm()
         cb = dtm.create_load_done_callback(
-            "req", 0, epoch=0, block_ids=[11], num_blocks=1)
+            "req", 0, epoch=0, block_ids=[11], num_blocks=1
+        )
         cb([None])
         self.assertEqual(_sent_event(dtm).failed_block_idxs, [11])
 
@@ -333,15 +400,16 @@ class TestStagingPool(unittest.TestCase):
 
     def _pool(self, max_blocks=8, block_bytes=16):
         from kv_cache_manager.py_connector.vllm.data_transfer import _StagingPool
+
         return _StagingPool(torch.device("cpu"), block_bytes, max_blocks)
 
     def test_roundtrip_and_merge(self):
         pool = self._pool()
         a = pool.acquire(3)
-        b = pool.acquire(5)          # exact fit of the remainder
+        b = pool.acquire(5)  # exact fit of the remainder
         self.assertEqual((a, b), (0, 3))
         pool.release(a, 3)
-        pool.release(b, 5)           # neighbours must merge back to one run
+        pool.release(b, 5)  # neighbours must merge back to one run
         self.assertEqual(pool._runs, [[0, 8]])
         self.assertEqual(pool.acquire(8), 0)  # full capacity usable again
 
@@ -349,14 +417,14 @@ class TestStagingPool(unittest.TestCase):
         pool = self._pool()
         a, b, c = pool.acquire(2), pool.acquire(2), pool.acquire(2)
         self.assertEqual((a, b, c), (0, 2, 4))
-        pool.release(a, 2)           # free: [0,2) and [6,8)
+        pool.release(a, 2)  # free: [0,2) and [6,8)
         pool.release(c, 2)
         # 5 free blocks in total but no contiguous run of 5: blocks.
         with ThreadPoolExecutor(max_workers=1) as ex:
             fut = ex.submit(pool.acquire, 5)
             time.sleep(0.2)
             self.assertFalse(fut.done(), "fragmented pool must block")
-            pool.release(b, 2)       # glues [0,8) back together
+            pool.release(b, 2)  # glues [0,8) back together
             self.assertEqual(fut.result(timeout=5), 0)
 
     def test_blocking_acquire_wakes_on_release(self):
@@ -374,8 +442,10 @@ class TestStagingPool(unittest.TestCase):
         with self.assertRaises(ValueError):
             pool.acquire(5)
 
-    @unittest.skipIf("torch" in vllm_stubs.STUBBED,
-                     "needs a real torch tensor (stubbed in the open-source CI)")
+    @unittest.skipIf(
+        "torch" in vllm_stubs.STUBBED,
+        "needs a real torch tensor (stubbed in the open-source CI)",
+    )
     def test_views_slice_the_same_run(self):
         pool = self._pool(max_blocks=8, block_bytes=16)
         start = pool.acquire(3)
@@ -392,15 +462,17 @@ class TestStagingPool(unittest.TestCase):
         from types import SimpleNamespace
         from unittest.mock import patch
         from kv_cache_manager.py_connector.vllm.data_transfer import _StagingPool
+
         with patch("torch.empty") as empty:
-            _StagingPool(SimpleNamespace(type="cuda"),
-                         per_block_bytes=16, max_blocks=8)
-        self.assertEqual(empty.call_count, 1,
-                         "pool must own exactly one backing allocation")
+            _StagingPool(SimpleNamespace(type="cuda"), per_block_bytes=16, max_blocks=8)
+        self.assertEqual(
+            empty.call_count, 1, "pool must own exactly one backing allocation"
+        )
         kwargs = empty.call_args.kwargs
         self.assertEqual(kwargs.get("device"), "cpu")
-        self.assertTrue(kwargs.get("pin_memory"),
-                        "pool backing memory must be pinned for zero-copy")
+        self.assertTrue(
+            kwargs.get("pin_memory"), "pool backing memory must be pinned for zero-copy"
+        )
 
 
 class TestPoolByteCap(unittest.TestCase):
@@ -415,37 +487,36 @@ class TestPoolByteCap(unittest.TestCase):
 
     def _f(self, configured, need, block_bytes, max_bytes):
         from kv_cache_manager.py_connector.vllm.data_transfer import (
-            _effective_pool_blocks)
+            _effective_pool_blocks,
+        )
+
         return _effective_pool_blocks(configured, need, block_bytes, max_bytes)
 
     def test_full_attention_blocks_keep_the_configured_count(self):
         # 1024 x 0.875 MiB ~= 896 MiB <= 1 GiB cap: unchanged sizing (the
         # validated origin/main concurrency of 8 full tasks in flight).
-        self.assertEqual(
-            self._f(1024, 128, 917_504, 2**30), 1024)
+        self.assertEqual(self._f(1024, 128, 917_504, 2**30), 1024)
 
     def test_hybrid_blocks_cap_by_bytes(self):
         # 17.3 MiB blocks: 1024 would pin ~17.3 GiB per group; a cap that
         # allows more than one task batch caps to cap // block_bytes.
         block_bytes = 17_301_504
         self.assertEqual(
-            self._f(1024, 128, block_bytes, 8 * 2**30),
-            8 * 2**30 // block_bytes)
+            self._f(1024, 128, block_bytes, 8 * 2**30), 8 * 2**30 // block_bytes
+        )
 
     def test_hybrid_default_cap_floors_at_one_task_batch(self):
         # With the 1 GiB default the byte cap alone would allow only 62
         # blocks (< one 128-block task batch); the batch must still fit
         # contiguously, so the effective size is the batch -- the same
         # configuration the staging-removal campaign validated for hybrid.
-        self.assertEqual(
-            self._f(1024, 128, 17_301_504, 2**30), 128)
+        self.assertEqual(self._f(1024, 128, 17_301_504, 2**30), 128)
 
     def test_one_task_batch_always_fits(self):
         # Even when the byte cap is smaller than one task batch, the batch
         # must still fit contiguously (contiguity invariant); the caller
         # warns that the cap was exceeded.
-        self.assertEqual(
-            self._f(1024, 128, 17_301_504, 128 * 1024), 128)
+        self.assertEqual(self._f(1024, 128, 17_301_504, 128 * 1024), 128)
 
     def test_byte_cap_can_only_shrink_not_grow(self):
         # A configured count below the byte cap is authoritative.

--- a/kv_cache_manager/py_connector/test/test_data_transfer_results.py
+++ b/kv_cache_manager/py_connector/test/test_data_transfer_results.py
@@ -202,7 +202,8 @@ class TestNullStateBlocks(unittest.TestCase):
             per_block_bytes=1024,
             layer_num=1,
             kv_layout=KVLayout.PACKED_4D,
-            kvcache_ptr_tensor_gpu=None,
+            # No real device pointers in the pure plumbing tests.
+            kvcache_ptr_tensor_gpu=None,  # ty: ignore[invalid-argument-type]
             num_kv_ptrs=1,
             per_token_dim=8,
             kernel_block_size=528,
@@ -464,7 +465,12 @@ class TestStagingPool(unittest.TestCase):
         from kv_cache_manager.py_connector.vllm.data_transfer import _StagingPool
 
         with patch("torch.empty") as empty:
-            _StagingPool(SimpleNamespace(type="cuda"), per_block_bytes=16, max_blocks=8)
+            # duck-typed device stand-in
+            _StagingPool(
+                SimpleNamespace(type="cuda"),  # ty: ignore[invalid-argument-type]
+                per_block_bytes=16,
+                max_blocks=8,
+            )
         self.assertEqual(
             empty.call_count, 1, "pool must own exactly one backing allocation"
         )

--- a/kv_cache_manager/py_connector/test/test_kv_layouts.py
+++ b/kv_cache_manager/py_connector/test/test_kv_layouts.py
@@ -24,7 +24,10 @@ import unittest
 from kv_cache_manager.py_connector.test.vllm_stubs import make_connector
 from kv_cache_manager.py_connector.vllm.vllm_common import AttentionGroupMeta
 from kv_cache_manager.py_connector.vllm.v1_connector import (
-    attn_kv_views, ensure_hybrid_supported, GroupMeta)
+    attn_kv_views,
+    ensure_hybrid_supported,
+    GroupMeta,
+)
 from kv_cache_manager.py_connector.vllm.transfer_types import KVLayout
 
 ITEMSIZE = 2  # bf16/fp16
@@ -59,19 +62,29 @@ class FakeTensor:
         return self._base + self._offset * ITEMSIZE
 
     def permute(self, *dims):
-        return FakeTensor([self.shape[d] for d in dims],
-                          [self._strides[d] for d in dims],
-                          self._offset, self._base)
+        return FakeTensor(
+            [self.shape[d] for d in dims],
+            [self._strides[d] for d in dims],
+            self._offset,
+            self._base,
+        )
 
     def __getitem__(self, idx):
         if isinstance(idx, int):  # t[i]: drop dim 0
-            return FakeTensor(self.shape[1:], self._strides[1:],
-                              self._offset + idx * self._strides[0], self._base)
+            return FakeTensor(
+                self.shape[1:],
+                self._strides[1:],
+                self._offset + idx * self._strides[0],
+                self._base,
+            )
         if isinstance(idx, tuple) and idx[0] == slice(None) and isinstance(idx[1], int):
             # t[:, i]: drop dim 1
-            return FakeTensor(self.shape[:1] + self.shape[2:],
-                              self._strides[:1] + self._strides[2:],
-                              self._offset + idx[1] * self._strides[1], self._base)
+            return FakeTensor(
+                self.shape[:1] + self.shape[2:],
+                self._strides[:1] + self._strides[2:],
+                self._offset + idx[1] * self._strides[1],
+                self._base,
+            )
         raise TypeError(f"unsupported index {idx!r}")
 
 
@@ -97,9 +110,9 @@ class TestAttnKvViews(unittest.TestCase):
         self.assertIs(layout, KVLayout.PACKED_4D)
         self.assertEqual(len(views), 1)
         v = views[0]
-        self.assertEqual(v.shape, (10, 16, 4, 256))          # (n, b, h, 2d)
+        self.assertEqual(v.shape, (10, 16, 4, 256))  # (n, b, h, 2d)
         self.assertEqual(v.stride(), (16 * 4 * 256, 4 * 256, 256, 1))
-        self.assertEqual(v.data_ptr(), BASE_PTR)             # storage base
+        self.assertEqual(v.data_ptr(), BASE_PTR)  # storage base
 
     def test_kv_first_5d(self):
         views, layout = attn_kv_views(kv_first_5d())
@@ -111,8 +124,7 @@ class TestAttnKvViews(unittest.TestCase):
             self.assertEqual(view.stride(), (16 * 4 * 128, 4 * 128, 128, 1))
         self.assertEqual(k.data_ptr(), BASE_PTR)
         # V base = K base + num_blocks * block * h * d elements.
-        self.assertEqual(v.data_ptr() - k.data_ptr(),
-                         10 * 16 * 4 * 128 * ITEMSIZE)
+        self.assertEqual(v.data_ptr() - k.data_ptr(), 10 * 16 * 4 * 128 * ITEMSIZE)
 
     def test_n_first_5d(self):
         views, layout = attn_kv_views(n_first_5d())
@@ -124,14 +136,13 @@ class TestAttnKvViews(unittest.TestCase):
             # K and V of one block are interleaved: the block stride covers
             # both halves while the inner page stays token-major.
             self.assertEqual(view.stride(), (2 * 16 * 4 * 128, 4 * 128, 128, 1))
-        self.assertEqual(v.data_ptr() - k.data_ptr(),
-                         16 * 4 * 128 * ITEMSIZE)
+        self.assertEqual(v.data_ptr() - k.data_ptr(), 16 * 4 * 128 * ITEMSIZE)
 
     def test_unrecognized_layouts_fail_fast(self):
         bad = [
-            FakeTensor.contiguous([10, 16, 4]),           # 3-D
+            FakeTensor.contiguous([10, 16, 4]),  # 3-D
             FakeTensor.contiguous([10, 2, 16, 4, 128, 2]),  # 6-D
-            FakeTensor.contiguous([10, 16, 2, 4, 128]),   # 5-D, K/V dim misplaced
+            FakeTensor.contiguous([10, 16, 2, 4, 128]),  # 5-D, K/V dim misplaced
         ]
         for t in bad:
             with self.subTest(shape=t.shape):
@@ -153,8 +164,9 @@ def _make_group_conn():
 
 
 def _attn_meta(layer_names, block_size=16):
-    return AttentionGroupMeta(group_idx=0, layer_names=layer_names,
-                               block_size=block_size, per_block_bytes=0)
+    return AttentionGroupMeta(
+        group_idx=0, layer_names=layer_names, block_size=block_size, per_block_bytes=0
+    )
 
 
 class TestBuildTransferGroup(unittest.TestCase):
@@ -166,6 +178,7 @@ class TestBuildTransferGroup(unittest.TestCase):
     def _build(self, kv_caches):
         import unittest.mock as mock
         import kv_cache_manager.py_connector.vllm.connector_worker as wc
+
         conn = _make_group_conn()
         captured = []
 
@@ -177,7 +190,8 @@ class TestBuildTransferGroup(unittest.TestCase):
 
         with mock.patch.object(wc.torch, "tensor", side_effect=fake_tensor):
             g = conn._build_attention_group(
-                _attn_meta(list(kv_caches.keys())), kv_caches)
+                _attn_meta(list(kv_caches.keys())), kv_caches
+            )
         return g, captured
 
     def test_packed_one_ptr_per_layer(self):
@@ -198,8 +212,9 @@ class TestBuildTransferGroup(unittest.TestCase):
         self.assertEqual(g.per_token_dim, 4 * 128)
         self.assertEqual(g.block_stride, 0)  # each half is flat token-major
         v_off = 10 * 16 * 4 * 128 * ITEMSIZE
-        self.assertEqual(ptrs, [BASE_PTR, BASE_PTR + v_off,
-                                2 * BASE_PTR, 2 * BASE_PTR + v_off])
+        self.assertEqual(
+            ptrs, [BASE_PTR, BASE_PTR + v_off, 2 * BASE_PTR, 2 * BASE_PTR + v_off]
+        )
 
     def test_n_first_strided_blocks(self):
         kv = {"l0": n_first_5d(base=BASE_PTR)}
@@ -219,9 +234,13 @@ class TestBuildTransferGroup(unittest.TestCase):
 class _BlockedScheduler:
     """Mimics vLLM <= 0.22.x: external loads are asserted away."""
 
-    def _mamba_block_aligned_split(self, request, num_new_tokens,
-                                   num_new_local_computed_tokens=0,
-                                   num_external_computed_tokens=0):
+    def _mamba_block_aligned_split(
+        self,
+        request,
+        num_new_tokens,
+        num_new_local_computed_tokens=0,
+        num_external_computed_tokens=0,
+    ):
         assert num_external_computed_tokens == 0, (
             "External KV connector is not verified yet"
         )
@@ -230,20 +249,32 @@ class _BlockedScheduler:
 class _OpenScheduler:
     """Mimics vLLM >= 0.23.0: the split handles external tokens."""
 
-    def _mamba_block_aligned_split(self, request, num_new_tokens,
-                                   num_new_local_computed_tokens=0,
-                                   num_external_computed_tokens=0):
+    def _mamba_block_aligned_split(
+        self,
+        request,
+        num_new_tokens,
+        num_new_local_computed_tokens=0,
+        num_external_computed_tokens=0,
+    ):
         return num_new_tokens
 
 
 # Method exists but inspect.getsource fails (frozen / bytecode-only vLLM):
 # compiled from a string, so there is no source file to read.
 _exec_ns = {}
-exec(compile("def _mamba_block_aligned_split(self, *a, **kw):\n    pass\n",
-             "<kvcm-test-no-source>", "exec"), _exec_ns)
+exec(
+    compile(
+        "def _mamba_block_aligned_split(self, *a, **kw):\n    pass\n",
+        "<kvcm-test-no-source>",
+        "exec",
+    ),
+    _exec_ns,
+)
 _SourcelessScheduler = type(
-    "_SourcelessScheduler", (),
-    {"_mamba_block_aligned_split": _exec_ns["_mamba_block_aligned_split"]})
+    "_SourcelessScheduler",
+    (),
+    {"_mamba_block_aligned_split": _exec_ns["_mamba_block_aligned_split"]},
+)
 
 
 class TestHybridGate(unittest.TestCase):
@@ -254,8 +285,12 @@ class TestHybridGate(unittest.TestCase):
         mod.Scheduler = cls
         old = sys.modules.get(self.MOD)
         sys.modules[self.MOD] = mod
-        self.addCleanup(lambda: (sys.modules.pop(self.MOD, None),
-                                 old and sys.modules.__setitem__(self.MOD, old)))
+        self.addCleanup(
+            lambda: (
+                sys.modules.pop(self.MOD, None),
+                old and sys.modules.__setitem__(self.MOD, old),
+            )
+        )
 
     def test_old_vllm_hybrid_raises_gracefully(self):
         self._with_scheduler(_BlockedScheduler)

--- a/kv_cache_manager/py_connector/test/test_kv_layouts.py
+++ b/kv_cache_manager/py_connector/test/test_kv_layouts.py
@@ -19,6 +19,7 @@ Runs without torch: a minimal FakeTensor models the strided-view semantics
 
 import sys
 import types
+from typing import Any
 import unittest
 
 from kv_cache_manager.py_connector.test.vllm_stubs import make_connector
@@ -26,7 +27,6 @@ from kv_cache_manager.py_connector.vllm.vllm_common import AttentionGroupMeta
 from kv_cache_manager.py_connector.vllm.v1_connector import (
     attn_kv_views,
     ensure_hybrid_supported,
-    GroupMeta,
 )
 from kv_cache_manager.py_connector.vllm.transfer_types import KVLayout
 
@@ -158,7 +158,8 @@ class TestAttnKvViews(unittest.TestCase):
 
 def _make_group_conn():
     conn = make_connector(manager_block_size=16)
-    conn._self_spec_names = ["tp0_g0"]
+    # list instead of the production dict: group_idx == position here.
+    conn._self_spec_names = ["tp0_g0"]  # ty: ignore[invalid-assignment]
     conn._device = "cpu"
     return conn
 
@@ -281,7 +282,7 @@ class TestHybridGate(unittest.TestCase):
     MOD = "vllm.v1.core.sched.scheduler"
 
     def _with_scheduler(self, cls):
-        mod = types.ModuleType(self.MOD)
+        mod: Any = types.ModuleType(self.MOD)
         mod.Scheduler = cls
         old = sys.modules.get(self.MOD)
         sys.modules[self.MOD] = mod

--- a/kv_cache_manager/py_connector/test/test_location_query.py
+++ b/kv_cache_manager/py_connector/test/test_location_query.py
@@ -63,8 +63,8 @@ class LocationQueryFanoutTest(unittest.TestCase):
 
     def _manager(self, async_mode=True):
         return LocationQueryManager(
-            self.client, self.executor, "inst",
-            async_get_cache_location=async_mode)
+            self.client, self.executor, "inst", async_get_cache_location=async_mode
+        )
 
     def _await_answer(self, lqm, offset):
         """Pump the hook until the slot answers; assert the client was hit."""
@@ -95,13 +95,15 @@ class LocationQueryFanoutTest(unittest.TestCase):
         for _ in range(5):  # scheduler re-asks while the query is on the wire
             self.assertIsNone(lqm.get_locations_for_query(self.req, 0))
         time.sleep(0.2)
-        self.assertEqual(self.client.calls, 1,
-                         "re-asks while in flight must not issue new queries")
+        self.assertEqual(
+            self.client.calls, 1, "re-asks while in flight must not issue new queries"
+        )
 
         self._gate(0).set()
         self.assertEqual(self._await_answer(lqm, 0), ["loc0", "loc1"])
-        self.assertEqual(self.client.calls, 1,
-                         "cached answer must be served without a new query")
+        self.assertEqual(
+            self.client.calls, 1, "cached answer must be served without a new query"
+        )
 
     # ------------------------------------------------------------------ #
     # Supersession: a different offset is a different query
@@ -124,14 +126,17 @@ class LocationQueryFanoutTest(unittest.TestCase):
         # older offset's in-flight query -- and once superseded, the older
         # offset is no longer addressable: asking it again supersedes back.
         lqm = self._manager()
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))   # RPC #1
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))   # RPC #2
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # RPC #1
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))  # RPC #2
         self.assertEqual(self.client.calls, 2)
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))   # same key: dedup
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))  # same key: dedup
         self.assertEqual(self.client.calls, 2)
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))   # older offset
-        self.assertEqual(self.client.calls, 3,                        # supersedes back
-                         "asking the superseded offset must re-issue, not serve")
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # older offset
+        self.assertEqual(
+            self.client.calls,
+            3,  # supersedes back
+            "asking the superseded offset must re-issue, not serve",
+        )
 
     def test_superseded_answer_is_not_served_at_its_offset(self):
         # offset 0 answered, then superseded by offset 8: even when offset 8
@@ -141,10 +146,10 @@ class LocationQueryFanoutTest(unittest.TestCase):
         self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # submit
         self._gate(0).set()
         self.assertEqual(self._await_answer(lqm, 0), ["loc0", "loc1"])
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))   # supersede
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))  # supersede
         self._gate(1).set()
         self.assertEqual(self._await_answer(lqm, 8), ["loc0", "loc1"])
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))   # fresh RPC
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # fresh RPC
         self._gate(2)  # wait until the fresh query reaches the client
         self.assertEqual(self.client.calls, 3)
 
@@ -155,9 +160,9 @@ class LocationQueryFanoutTest(unittest.TestCase):
         # Old ask answered first: its answer must be dropped, the new slot
         # stays in flight until its own answer lands.
         lqm = self._manager()
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))   # RPC #1
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))   # RPC #2
-        self._gate(0).set()                                    # old answers
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # RPC #1
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))  # RPC #2
+        self._gate(0).set()  # old answers
         deadline = time.time() + 5
         while time.time() < deadline and self.client.calls < 2:
             time.sleep(0.01)
@@ -172,14 +177,17 @@ class LocationQueryFanoutTest(unittest.TestCase):
         # overwrite the new slot's answer.
         lqm = self._manager()
         self.client.answers = [["old_answers"], ["new_answers"]]
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))   # RPC #1
-        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))   # RPC #2
-        self._gate(1).set()                                    # new answers
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # RPC #1
+        self.assertIsNone(lqm.get_locations_for_query(self.req, 8))  # RPC #2
+        self._gate(1).set()  # new answers
         self.assertEqual(self._await_answer(lqm, 8), ["new_answers"])
-        self._gate(0).set()                                    # old answers late
+        self._gate(0).set()  # old answers late
         time.sleep(0.2)
-        self.assertEqual(lqm.get_locations_for_query(self.req, 8), ["new_answers"],
-                         "the superseded ask must not overwrite the new slot")
+        self.assertEqual(
+            lqm.get_locations_for_query(self.req, 8),
+            ["new_answers"],
+            "the superseded ask must not overwrite the new slot",
+        )
 
     # ------------------------------------------------------------------ #
     # Failure and sync mode
@@ -207,8 +215,7 @@ class LocationQueryFanoutTest(unittest.TestCase):
             time.sleep(0.01)
         # The next ask re-issues instead of waiting forever on a dead slot.
         restore = GatedClient.get_cache_location
-        self.client.get_cache_location = \
-            lambda request: restore(self.client, request)
+        self.client.get_cache_location = lambda request: restore(self.client, request)
         self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # re-issue
         self._gate(0).set()
         self.assertEqual(self._await_answer(lqm, 0), ["loc0", "loc1"])
@@ -242,8 +249,7 @@ class LocationQueryFanoutTest(unittest.TestCase):
         self.assertEqual(self._await_answer(lqm, 0), ["loc0", "loc1"])
         # Well inside the horizon: re-asks keep serving the cached answer.
         for _ in range(3):
-            self.assertEqual(lqm.get_locations_for_query(self.req, 0),
-                             ["loc0", "loc1"])
+            self.assertEqual(lqm.get_locations_for_query(self.req, 0), ["loc0", "loc1"])
         self.assertEqual(self.client.calls, 1)
         self.assertEqual(lqm.stale_supersede_count, 0)
 
@@ -264,10 +270,10 @@ class LocationQueryFanoutTest(unittest.TestCase):
         self._gate(0).set()
         self._await_answer(lqm, 0)
         self._expire(lqm)
-        lqm.store_result("r1", ["loc0"])     # the hook's clamp, post-answer
+        lqm.store_result("r1", ["loc0"])  # the hook's clamp, post-answer
         self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # expired: miss
         self._gate(1).set()
-        self._await_answer(lqm, 0)           # re-answered fresh
+        self._await_answer(lqm, 0)  # re-answered fresh
         self.assertEqual(lqm.consume_locations("r1"), (["loc0", "loc1"], 0))
 
     # ------------------------------------------------------------------ #
@@ -288,7 +294,7 @@ class LocationQueryFanoutTest(unittest.TestCase):
         # resurrect a slot for a request vLLM already moved past.
         lqm = self._manager()
         self.assertIsNone(lqm.get_locations_for_query(self.req, 0))
-        self.assertIsNone(lqm.consume_locations("r1"))   # pops the in-flight slot
+        self.assertIsNone(lqm.consume_locations("r1"))  # pops the in-flight slot
         self._gate(0).set()
         time.sleep(0.2)
         with lqm._lock:
@@ -307,8 +313,9 @@ class LocationQueryFanoutTest(unittest.TestCase):
         self._gate(0).set()
         time.sleep(0.2)
         with lqm._lock:
-            self.assertNotIn("r1", lqm._queries,
-                             "a late answer must not resurrect the slot")
+            self.assertNotIn(
+                "r1", lqm._queries, "a late answer must not resurrect the slot"
+            )
 
 
 if __name__ == "__main__":

--- a/kv_cache_manager/py_connector/test/test_location_query.py
+++ b/kv_cache_manager/py_connector/test/test_location_query.py
@@ -63,7 +63,10 @@ class LocationQueryFanoutTest(unittest.TestCase):
 
     def _manager(self, async_mode=True):
         return LocationQueryManager(
-            self.client, self.executor, "inst", async_get_cache_location=async_mode
+            self.client,  # ty: ignore[invalid-argument-type]  (test double)
+            self.executor,
+            "inst",
+            async_get_cache_location=async_mode,
         )
 
     def _await_answer(self, lqm, offset):
@@ -205,7 +208,7 @@ class LocationQueryFanoutTest(unittest.TestCase):
         def boom(request):
             raise RuntimeError("manager down")
 
-        self.client.get_cache_location = boom
+        self.client.get_cache_location = boom  # ty: ignore[invalid-assignment]
         self.assertIsNone(lqm.get_locations_for_query(self.req, 0))
         deadline = time.time() + 10  # failure pops the slot asynchronously
         while time.time() < deadline:
@@ -215,7 +218,9 @@ class LocationQueryFanoutTest(unittest.TestCase):
             time.sleep(0.01)
         # The next ask re-issues instead of waiting forever on a dead slot.
         restore = GatedClient.get_cache_location
-        self.client.get_cache_location = lambda request: restore(self.client, request)
+        self.client.get_cache_location = (  # ty: ignore[invalid-assignment]
+            lambda request: restore(self.client, request)
+        )
         self.assertIsNone(lqm.get_locations_for_query(self.req, 0))  # re-issue
         self._gate(0).set()
         self.assertEqual(self._await_answer(lqm, 0), ["loc0", "loc1"])

--- a/kv_cache_manager/py_connector/test/test_logger.py
+++ b/kv_cache_manager/py_connector/test/test_logger.py
@@ -13,6 +13,7 @@ class TestSetLogLevel(unittest.TestCase):
     def setUp(self):
         # Re-import logger module for each test to get fresh state
         import kv_cache_manager.py_connector.common.logger as logger_mod
+
         self.logger_mod = logger_mod
 
     def test_set_debug_level(self):
@@ -53,12 +54,14 @@ class TestEnvironmentVariable(unittest.TestCase):
     def test_env_var_debug(self):
         with patch.dict(os.environ, {"KVCM_LOG_LEVEL": "DEBUG"}):
             import kv_cache_manager.py_connector.common.logger as logger_mod
+
             importlib.reload(logger_mod)
             self.assertEqual(logger_mod.logger.level, logging.DEBUG)
 
     def test_env_var_info(self):
         with patch.dict(os.environ, {"KVCM_LOG_LEVEL": "INFO"}):
             import kv_cache_manager.py_connector.common.logger as logger_mod
+
             importlib.reload(logger_mod)
             self.assertEqual(logger_mod.logger.level, logging.INFO)
 
@@ -67,18 +70,21 @@ class TestEnvironmentVariable(unittest.TestCase):
         env.pop("KVCM_LOG_LEVEL", None)
         with patch.dict(os.environ, env, clear=True):
             import kv_cache_manager.py_connector.common.logger as logger_mod
+
             importlib.reload(logger_mod)
             self.assertEqual(logger_mod.logger.level, logging.WARNING)
 
     def test_env_var_invalid_falls_back_to_warning(self):
         with patch.dict(os.environ, {"KVCM_LOG_LEVEL": "GARBAGE"}):
             import kv_cache_manager.py_connector.common.logger as logger_mod
+
             importlib.reload(logger_mod)
             self.assertEqual(logger_mod.logger.level, logging.WARNING)
 
     def tearDown(self):
         # Restore default level after env var tests
         import kv_cache_manager.py_connector.common.logger as logger_mod
+
         importlib.reload(logger_mod)
 
 
@@ -87,6 +93,7 @@ class TestConfigureLogLevel(unittest.TestCase):
 
     def setUp(self):
         import kv_cache_manager.py_connector.common.logger as logger_mod
+
         self.logger_mod = logger_mod
 
     def test_env_var_takes_priority_over_param(self):
@@ -117,6 +124,7 @@ class TestConfigureLogLevel(unittest.TestCase):
 
     def tearDown(self):
         import kv_cache_manager.py_connector.common.logger as logger_mod
+
         importlib.reload(logger_mod)
 
 

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -3,7 +3,7 @@
 import threading
 import time
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import requests
 
@@ -467,8 +467,10 @@ class TestLeaderDiscoveryInit(unittest.TestCase):
         client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=True)
         try:
             self.assertIsNotNone(client._refresh_thread)
-            self.assertTrue(client._refresh_thread.is_alive())
-            self.assertTrue(client._refresh_thread.daemon)
+            self.assertTrue(
+                client._refresh_thread.is_alive()  # ty: ignore[unresolved-attribute]
+            )
+            self.assertTrue(client._refresh_thread.daemon)  # ty: ignore[unresolved-attribute]
         finally:
             client.close()
 
@@ -541,7 +543,9 @@ class TestServerNotLeaderRetry(unittest.TestCase):
         )
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             result = client.register_instance({"trace_id": "test"})
             self.assertEqual(result["result"], "success")
             # First call returns NOT_LEADER, second succeeds
@@ -572,7 +576,9 @@ class TestServerNotLeaderRetry(unittest.TestCase):
             return _make_mock_response(_not_leader_response())
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             with self.assertRaises(AssertionError) as ctx:
                 client.register_instance({"trace_id": "test"})
             self.assertIn("Current node is not the leader", str(ctx.exception))
@@ -591,7 +597,9 @@ class TestServerNotLeaderRetry(unittest.TestCase):
             return _make_mock_response(_not_leader_response())
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             with self.assertRaises(AssertionError) as ctx:
                 client.register_instance({"trace_id": "test"})
             self.assertIn("Current node is not the leader", str(ctx.exception))
@@ -639,7 +647,9 @@ class TestConnectionErrorHandling(unittest.TestCase):
             raise requests.ConnectionError("Connection refused")
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             client._refresh_event.clear()
 
             with self.assertRaises(requests.ConnectionError):
@@ -662,7 +672,9 @@ class TestConnectionErrorHandling(unittest.TestCase):
             raise requests.ConnectionError("Connection refused")
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             with self.assertRaises(requests.ConnectionError):
                 client.register_instance({"trace_id": "test"})
             # _refresh_event should NOT be set
@@ -686,7 +698,9 @@ class TestConnectionErrorHandling(unittest.TestCase):
                     min_discover_interval_seconds=0,
                 )
                 discovery = client._service_discovery
-                discovery.refresh = MagicMock(wraps=discovery.refresh)
+                discovery.refresh = MagicMock(  # ty: ignore[invalid-assignment]
+                    wraps=discovery.refresh  # ty: ignore[unresolved-attribute]
+                )
                 client.session.post = MagicMock(side_effect=error)
                 route_refreshed = threading.Event()
                 original_refresh = client._refresh_manager_route
@@ -697,7 +711,9 @@ class TestConnectionErrorHandling(unittest.TestCase):
                     finally:
                         route_refreshed.set()
 
-                client._refresh_manager_route = refresh_and_signal
+                client._refresh_manager_route = (  # ty: ignore[invalid-assignment]
+                    refresh_and_signal
+                )
                 try:
                     with self.assertRaises(type(error)):
                         client.register_instance({"trace_id": "test"})
@@ -707,7 +723,7 @@ class TestConnectionErrorHandling(unittest.TestCase):
                         "route refresh did not finish after the transport failure",
                     )
                     self.assertEqual(client.base_url, "http://10.0.0.2:8080")
-                    discovery.refresh.assert_called_once_with()
+                    discovery.refresh.assert_called_once_with()  # ty: ignore[unresolved-attribute]
                     mock_discovery_post.assert_not_called()
                 finally:
                     client.close()
@@ -792,9 +808,9 @@ class TestCloseLifecycle(unittest.TestCase):
         )
         client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=True)
 
-        self.assertTrue(client._refresh_thread.is_alive())
+        self.assertTrue(client._refresh_thread.is_alive())  # ty: ignore[unresolved-attribute]
         client.close()
-        self.assertFalse(client._refresh_thread.is_alive())
+        self.assertFalse(client._refresh_thread.is_alive())  # ty: ignore[unresolved-attribute]
         self.assertTrue(client._closed.is_set())
 
     def test_close_without_discovery(self):
@@ -880,7 +896,6 @@ class TestThreadSafety(unittest.TestCase):
     def test_concurrent_discover_dedup(self, mock_post):
         """Concurrent Manager route refresh calls should dedup via lock."""
         actual_discover_count = [0]
-        original_post = mock_post
 
         def slow_post(*args, **kwargs):
             actual_discover_count[0] += 1
@@ -945,7 +960,9 @@ class TestGetClusterInfoPublicApi(unittest.TestCase):
             return _make_mock_response(expected)
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             result = client.get_cluster_info({"trace_id": "test"})
             self.assertEqual(result["leader_node_id"], "node-0")
             self.assertIn("leader_endpoint", result)
@@ -1069,7 +1086,9 @@ class TestNormalApiStillWorks(unittest.TestCase):
             return _make_mock_response(ok_resp)
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             result = client.register_instance({"trace_id": "t1"})
             self.assertEqual(result["header"]["status"]["code"], "OK")
         finally:
@@ -1087,7 +1106,9 @@ class TestNormalApiStillWorks(unittest.TestCase):
             return _make_mock_response(ok_resp)
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             result = client.get_cache_location({"trace_id": "t1"})
             self.assertEqual(result["header"]["status"]["code"], "OK")
         finally:
@@ -1111,7 +1132,9 @@ class TestNormalApiStillWorks(unittest.TestCase):
             return _make_mock_response(error_resp)
 
         try:
-            client.session.post = mock_session_post
+            client.session.post = (  # ty: ignore[invalid-assignment]
+                mock_session_post
+            )
             result = client.register_instance({"trace_id": "t1"}, check_response=False)
             self.assertEqual(result["header"]["status"]["code"], "INTERNAL_ERROR")
         finally:

--- a/kv_cache_manager/py_connector/test/test_manager_client.py
+++ b/kv_cache_manager/py_connector/test/test_manager_client.py
@@ -221,11 +221,13 @@ class TestRequestTimeout(unittest.TestCase):
                     )
 
     def test_connector_config_forwards_request_timeout(self):
-        client = KvCacheManagerClient.from_connector_config({
-            "manager_uri": "http://10.0.0.1:8080",
-            "instance_id": "connector-instance",
-            "request_timeout_seconds": 3.5,
-        })
+        client = KvCacheManagerClient.from_connector_config(
+            {
+                "manager_uri": "http://10.0.0.1:8080",
+                "instance_id": "connector-instance",
+                "request_timeout_seconds": 3.5,
+            }
+        )
         try:
             self.assertEqual(client._instance_id, "connector-instance")
             self.assertEqual(client._request_timeout_seconds, 3.5)
@@ -233,9 +235,11 @@ class TestRequestTimeout(unittest.TestCase):
             client.close()
 
     def test_connector_config_uses_request_timeout_default(self):
-        client = KvCacheManagerClient.from_connector_config({
-            "manager_uri": "http://10.0.0.1:8080",
-        })
+        client = KvCacheManagerClient.from_connector_config(
+            {
+                "manager_uri": "http://10.0.0.1:8080",
+            }
+        )
         try:
             self.assertEqual(client._request_timeout_seconds, 1.0)
         finally:
@@ -304,14 +308,16 @@ class TestResponseClassification(unittest.TestCase):
 
     def test_manager_business_error_keeps_assertion_contract(self):
         self.client.session.post = MagicMock(
-            return_value=_make_mock_response({
-                "header": {
-                    "status": {
-                        "code": "INVALID_ARGUMENT",
-                        "message": "bad request",
+            return_value=_make_mock_response(
+                {
+                    "header": {
+                        "status": {
+                            "code": "INVALID_ARGUMENT",
+                            "message": "bad request",
+                        }
                     }
                 }
-            })
+            )
         )
 
         with self.assertRaises(AssertionError) as caught:
@@ -338,7 +344,9 @@ class TestLeaderDiscoveryInit(unittest.TestCase):
     @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
     def test_init_discovers_leader_and_switches(self, mock_post):
         """Init should discover leader via getClusterInfo and switch base_url."""
-        mock_post.return_value = _make_mock_response(_cluster_info_response("10.0.0.99", 9090))
+        mock_post.return_value = _make_mock_response(
+            _cluster_info_response("10.0.0.99", 9090)
+        )
 
         client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=True)
         try:
@@ -353,7 +361,9 @@ class TestLeaderDiscoveryInit(unittest.TestCase):
     @patch("kv_cache_manager.py_connector.common.manager_client.requests.post")
     def test_init_discovery_includes_instance_id(self, mock_post):
         """Discovery request should include instance_id in the request body."""
-        mock_post.return_value = _make_mock_response(_cluster_info_response("10.0.0.99", 9090))
+        mock_post.return_value = _make_mock_response(
+            _cluster_info_response("10.0.0.99", 9090)
+        )
 
         client = KvCacheManagerClient(
             "http://10.0.0.1:8080",
@@ -423,7 +433,11 @@ class TestLeaderDiscoveryInit(unittest.TestCase):
         """leader_endpoint with missing host should keep original base_url."""
         resp_data = {
             "header": {"status": {"code": "OK", "message": ""}},
-            "leader_endpoint": {"node_id": "node-0", "host": "", "meta_http_port": 8080},
+            "leader_endpoint": {
+                "node_id": "node-0",
+                "host": "",
+                "meta_http_port": 8080,
+            },
         }
         mock_post.return_value = _make_mock_response(resp_data)
 
@@ -435,7 +449,9 @@ class TestLeaderDiscoveryInit(unittest.TestCase):
 
     def test_init_auto_discover_disabled(self):
         """auto_discover_leader=False should not start discovery or background thread."""
-        client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=False)
+        client = KvCacheManagerClient(
+            "http://10.0.0.1:8080", auto_discover_leader=False
+        )
         try:
             self.assertEqual(client.base_url, "http://10.0.0.1:8080")
             self.assertIsNone(client._refresh_thread)
@@ -464,7 +480,9 @@ class TestDiscoveryAlwaysUsesSeedUrl(unittest.TestCase):
     def test_discover_uses_discovery_url_not_base_url(self, mock_post):
         """After switching to leader, re-discovery should still query the seed url."""
         # Init: discover leader, switch base_url to 10.0.0.99:9090
-        mock_post.return_value = _make_mock_response(_cluster_info_response("10.0.0.99", 9090))
+        mock_post.return_value = _make_mock_response(
+            _cluster_info_response("10.0.0.99", 9090)
+        )
         client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=True)
         self.assertEqual(client.base_url, "http://10.0.0.99:9090")
         self.assertEqual(client._discovery_url, "http://10.0.0.1:8080")
@@ -781,7 +799,9 @@ class TestCloseLifecycle(unittest.TestCase):
 
     def test_close_without_discovery(self):
         """close() should work fine when auto_discover_leader=False."""
-        client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=False)
+        client = KvCacheManagerClient(
+            "http://10.0.0.1:8080", auto_discover_leader=False
+        )
         client.close()  # Should not raise
         self.assertTrue(client._closed.is_set())
 
@@ -966,9 +986,7 @@ class TestMetaServiceApiWrappers(unittest.TestCase):
         self, mock_make_api_request
     ):
         """Backend-aware lookup should use getCacheLocationsByBackend."""
-        mock_make_api_request.return_value = _ok_response_json(
-            {"key_locations": []}
-        )
+        mock_make_api_request.return_value = _ok_response_json({"key_locations": []})
         client = KvCacheManagerClient("http://10.0.0.1:8080")
         self.addCleanup(client.close)
         request = {
@@ -1059,7 +1077,9 @@ class TestNormalApiStillWorks(unittest.TestCase):
 
     def test_api_works_without_discovery(self):
         """API calls should work with auto_discover_leader=False."""
-        client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=False)
+        client = KvCacheManagerClient(
+            "http://10.0.0.1:8080", auto_discover_leader=False
+        )
 
         ok_resp = _ok_response_json({"locations": []})
 
@@ -1082,7 +1102,9 @@ class TestNormalApiStillWorks(unittest.TestCase):
         client = KvCacheManagerClient("http://10.0.0.1:8080", auto_discover_leader=True)
 
         error_resp = {
-            "header": {"status": {"code": "INTERNAL_ERROR", "message": "something broke"}}
+            "header": {
+                "status": {"code": "INTERNAL_ERROR", "message": "something broke"}
+            }
         }
 
         def mock_session_post(url, **kwargs):

--- a/kv_cache_manager/py_connector/test/test_scheduler_state.py
+++ b/kv_cache_manager/py_connector/test/test_scheduler_state.py
@@ -17,12 +17,12 @@ Covers, against fake vLLM SchedulerOutput / Request objects:
 import unittest
 from dataclasses import dataclass, field
 from types import SimpleNamespace
+from typing import Any, Dict
 from unittest.mock import MagicMock
 
 from kv_cache_manager.py_connector.test.vllm_stubs import (
     make_connector,
     make_connector_scheduler,
-    GroupMeta,
 )
 from kv_cache_manager.py_connector.vllm.connector_scheduler import RequestLedger
 from kv_cache_manager.py_connector.vllm.vllm_common import (
@@ -30,7 +30,6 @@ from kv_cache_manager.py_connector.vllm.vllm_common import (
     StateGroupMeta,
     parse_groups,
 )
-from kv_cache_manager.py_connector.vllm.v1_connector import TairKvCacheConnector
 from kv_cache_manager.py_connector.vllm.metadata import (
     SaveRequest,
     LoadRequest,
@@ -339,7 +338,7 @@ class TestStateCompleteMask(unittest.TestCase):
 
     def _req(self, tables):
         return RequestLedger(
-            vllm_request=FakeRequest("r0", []),
+            vllm_request=FakeRequest("r0", []),  # ty: ignore[invalid-argument-type]
             block_ids_per_group=tables,
             has_saved_block_num=0,
         )
@@ -550,8 +549,10 @@ class TestParseGroups(unittest.TestCase):
 
         return SimpleNamespace(
             layer_names=layers,
-            kv_cache_spec=FullAttentionSpec(
-                block_size, page_size_bytes, page_size_padded=page_size_padded
+            kv_cache_spec=FullAttentionSpec(  # ty: ignore[missing-argument]
+                block_size,
+                page_size_bytes,  # ty: ignore[too-many-positional-arguments]
+                page_size_padded=page_size_padded,
             ),
         )
 
@@ -559,7 +560,11 @@ class TestParseGroups(unittest.TestCase):
         from vllm.v1.kv_cache_interface import MambaSpec
 
         return SimpleNamespace(
-            layer_names=layers, kv_cache_spec=MambaSpec(block_size, page_size_bytes)
+            layer_names=layers,
+            kv_cache_spec=MambaSpec(  # ty: ignore[missing-argument]
+                block_size,
+                page_size_bytes,  # ty: ignore[invalid-argument-type]
+            ),
         )
 
     def test_full_attention_single_group(self):
@@ -712,7 +717,7 @@ class TestSkippedGroupIndexing(unittest.TestCase):
     def test_num_allocated_blocks_ignores_skipped_group(self):
         conn = self._skipped_group0_connector()
         ledger = RequestLedger(
-            vllm_request=FakeRequest("r0", list(range(64))),
+            vllm_request=FakeRequest("r0", list(range(64))),  # ty: ignore[invalid-argument-type]
             # Drafter table (group 0) lags with 1 block; attention has 4.
             block_ids_per_group=[[100], [200, 201, 202, 203]],
             has_saved_block_num=0,
@@ -737,7 +742,7 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         ]
         conn._num_groups = 2
         ledger = RequestLedger(
-            vllm_request=FakeRequest("r0", []),
+            vllm_request=FakeRequest("r0", []),  # ty: ignore[invalid-argument-type]
             block_ids_per_group=[[9], [1, 2, 3], [4, 5]],
             has_saved_block_num=0,
         )
@@ -746,7 +751,7 @@ class TestSkippedGroupIndexing(unittest.TestCase):
     def test_num_allocated_blocks_empty(self):
         conn = self._skipped_group0_connector()
         ledger = RequestLedger(
-            vllm_request=FakeRequest("r0", []),
+            vllm_request=FakeRequest("r0", []),  # ty: ignore[invalid-argument-type]
             block_ids_per_group=[],
             has_saved_block_num=0,
         )
@@ -756,7 +761,9 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         # Exactly one vLLM block table: the transferred group is 0 and the
         # failure report maps manager blocks into its table.
         conn = make_connector(manager_block_size=self.MBS)
-        conn._extra_config = SimpleNamespace(block_per_load_task=8)
+        conn._extra_config = (  # ty: ignore[invalid-assignment]
+            SimpleNamespace(block_per_load_task=8)
+        )
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
@@ -785,7 +792,9 @@ class TestSkippedGroupIndexing(unittest.TestCase):
             )
         ]
         conn._num_groups = 1
-        conn._extra_config = SimpleNamespace(block_per_load_task=8)
+        conn._extra_config = (  # ty: ignore[invalid-assignment]
+            SimpleNamespace(block_per_load_task=8)
+        )
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
@@ -808,7 +817,9 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         # vLLM block tables, attention-only, still breaks the single-table
         # recovery unpack -- must not be reported.
         conn = make_connector(manager_block_size=self.MBS, num_groups=2)
-        conn._extra_config = SimpleNamespace(block_per_load_task=8)
+        conn._extra_config = (  # ty: ignore[invalid-assignment]
+            SimpleNamespace(block_per_load_task=8)
+        )
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
@@ -830,7 +841,9 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         conn = make_connector(
             manager_block_size=self.MBS, num_groups=1, num_state_groups=1
         )
-        conn._extra_config = SimpleNamespace(block_per_load_task=8)
+        conn._extra_config = (  # ty: ignore[invalid-assignment]
+            SimpleNamespace(block_per_load_task=8)
+        )
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
@@ -862,7 +875,9 @@ class TestSkippedGroupIndexing(unittest.TestCase):
             )
         ]
         conn._num_groups = 1
-        conn._extra_config = SimpleNamespace(block_per_load_task=8)
+        conn._extra_config = (  # ty: ignore[invalid-assignment]
+            SimpleNamespace(block_per_load_task=8)
+        )
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
@@ -944,7 +959,7 @@ class TestBuildConnectorMeta(unittest.TestCase):
         )
 
     def _preempted_step(self, conn, req, use_legacy):
-        kwargs = dict(
+        kwargs: Dict[str, Any] = dict(
             cached_req_ids=["r0"], num_scheduled={"r0": 0}, new_block_ids=[[[200, 201]]]
         )
         if use_legacy:
@@ -972,7 +987,7 @@ class TestBuildConnectorMeta(unittest.TestCase):
                 conn = make_scheduler_connector(mbs=self.MBS)
                 req, _ = self._new_request(conn, "r0", 40, 3)
                 before = [list(t) for t in conn._tracked["r0"].block_ids_per_group]
-                kwargs = dict(
+                kwargs: Dict[str, Any] = dict(
                     cached_req_ids=["r0"], num_scheduled={"r0": 0}, new_block_ids=[None]
                 )
                 if use_legacy:

--- a/kv_cache_manager/py_connector/test/test_scheduler_state.py
+++ b/kv_cache_manager/py_connector/test/test_scheduler_state.py
@@ -20,13 +20,22 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from kv_cache_manager.py_connector.test.vllm_stubs import (
-    make_connector, make_connector_scheduler, GroupMeta)
+    make_connector,
+    make_connector_scheduler,
+    GroupMeta,
+)
 from kv_cache_manager.py_connector.vllm.connector_scheduler import RequestLedger
 from kv_cache_manager.py_connector.vllm.vllm_common import (
-    AttentionGroupMeta, StateGroupMeta, parse_groups)
+    AttentionGroupMeta,
+    StateGroupMeta,
+    parse_groups,
+)
 from kv_cache_manager.py_connector.vllm.v1_connector import TairKvCacheConnector
 from kv_cache_manager.py_connector.vllm.metadata import (
-    SaveRequest, LoadRequest, TairKvCacheConnectorMetadata)
+    SaveRequest,
+    LoadRequest,
+    TairKvCacheConnectorMetadata,
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -47,18 +56,28 @@ class FakeRequest:
         return self.prompt_token_ids + self.output_token_ids
 
 
-def make_scheduler_connector(mbs=16, vllm_bs=None, locations=None,
-                             num_groups=1, num_state_groups=0, tp_size=1):
+def make_scheduler_connector(
+    mbs=16, vllm_bs=None, locations=None, num_groups=1, num_state_groups=0, tp_size=1
+):
     """ConnectorScheduler with the scheduler-loop state and a mocked query manager."""
     return make_connector_scheduler(
-        manager_block_size=mbs, vllm_block_size=vllm_bs,
-        num_groups=num_groups, num_state_groups=num_state_groups,
-        tp_size=tp_size, locations=locations)
+        manager_block_size=mbs,
+        vllm_block_size=vllm_bs,
+        num_groups=num_groups,
+        num_state_groups=num_state_groups,
+        tp_size=tp_size,
+        locations=locations,
+    )
 
 
-def fake_scheduler_output(new_reqs=(), cached_req_ids=(), num_scheduled=None,
-                          new_block_ids=(), resumed_req_ids=frozenset(),
-                          legacy_resumed=None):
+def fake_scheduler_output(
+    new_reqs=(),
+    cached_req_ids=(),
+    num_scheduled=None,
+    new_block_ids=(),
+    resumed_req_ids=frozenset(),
+    legacy_resumed=None,
+):
     """Build a fake SchedulerOutput. legacy_resumed switches the cached-reqs
     container to the pre-0.26 interface (resumed_from_preemption list, no
     resumed_req_ids attribute)."""
@@ -82,16 +101,20 @@ def fake_scheduler_output(new_reqs=(), cached_req_ids=(), num_scheduled=None,
 
 
 def make_locations(n):
-    return [{"location_specs": [{"name": "tp0_g0", "uri": f"file://blk{i}"}]}
-            for i in range(n)]
+    return [
+        {"location_specs": [{"name": "tp0_g0", "uri": f"file://blk{i}"}]}
+        for i in range(n)
+    ]
 
 
 def alloc(conn, req, ext_tokens, blocks):
     """Simulate update_state_after_alloc: vLLM allocated blocks (per group)
     for a match of ext_tokens."""
     conn.update_state_after_alloc(
-        req, SimpleNamespace(get_block_ids=lambda: [list(b) for b in blocks]),
-        ext_tokens)
+        req,
+        SimpleNamespace(get_block_ids=lambda: [list(b) for b in blocks]),
+        ext_tokens,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -102,7 +125,8 @@ class TestGetNumNewMatchedTokens(unittest.TestCase):
 
     def _run(self, prompt_len, num_computed, num_locations):
         conn = make_scheduler_connector(
-            mbs=self.MBS, locations=make_locations(num_locations))
+            mbs=self.MBS, locations=make_locations(num_locations)
+        )
         conn._location_query_manager.last_computed_blocks = num_computed // self.MBS
         req = FakeRequest("r0", list(range(prompt_len)))
         matched, async_load = conn.get_num_new_matched_tokens(req, num_computed)
@@ -115,10 +139,12 @@ class TestGetNumNewMatchedTokens(unittest.TestCase):
         self.assertEqual(conn._waiting_to_load_requests, [])
         req = FakeRequest("r0", list(range(4 * self.MBS + 5)))
         alloc(conn, req, matched, [[100, 101, 102, 103]])
-        self.assertEqual(conn._waiting_to_load_requests[0].manager_block_idxes,
-                         [0, 1, 2, 3])
-        self.assertEqual(conn._waiting_to_load_requests[0].all_block_ids,
-                         [[100, 101, 102, 103]])
+        self.assertEqual(
+            conn._waiting_to_load_requests[0].manager_block_idxes, [0, 1, 2, 3]
+        )
+        self.assertEqual(
+            conn._waiting_to_load_requests[0].all_block_ids, [[100, 101, 102, 103]]
+        )
 
     def test_full_hit_capped_to_leave_one_token(self):
         # Prompt is exactly 4 manager blocks, all externally cached: the last
@@ -127,8 +153,9 @@ class TestGetNumNewMatchedTokens(unittest.TestCase):
         self.assertEqual(matched, 3 * self.MBS)
         req = FakeRequest("r0", list(range(4 * self.MBS)))
         alloc(conn, req, matched, [[100, 101, 102]])
-        self.assertEqual(conn._waiting_to_load_requests[0].manager_block_idxes,
-                         [0, 1, 2])
+        self.assertEqual(
+            conn._waiting_to_load_requests[0].manager_block_idxes, [0, 1, 2]
+        )
         # The ledger counts only the blocks actually treated as hit.
         self.assertEqual(conn._tracked["r0"].has_saved_block_num, 3)
 
@@ -204,8 +231,11 @@ class TestGetNumNewMatchedTokens(unittest.TestCase):
         # invalid-block recovery only), so no explicit signal exists: any
         # allocation for an external hint burns the match conservatively.
         conn = make_scheduler_connector(
-            mbs=self.MBS, num_groups=1, num_state_groups=1,
-            locations=hybrid_locations([True, True]))
+            mbs=self.MBS,
+            num_groups=1,
+            num_state_groups=1,
+            locations=hybrid_locations([True, True]),
+        )
         req = FakeRequest("r0", list(range(4 * self.MBS + 5)))
         matched, _ = conn.get_num_new_matched_tokens(req, 0)
         self.assertEqual(matched, 2 * self.MBS)
@@ -234,7 +264,8 @@ class TestGetNumNewMatchedTokens(unittest.TestCase):
         # Two transferred attention groups: the same multi-table shape, the
         # same one-shot burn, despite the model being attention-only.
         conn = make_scheduler_connector(
-            mbs=self.MBS, num_groups=2, locations=make_locations(2))
+            mbs=self.MBS, num_groups=2, locations=make_locations(2)
+        )
         req = FakeRequest("r0", list(range(4 * self.MBS + 5)))
         matched, _ = conn.get_num_new_matched_tokens(req, 0)
         self.assertEqual(matched, 2 * self.MBS)
@@ -272,10 +303,12 @@ def hybrid_locations(coverage, tp_size=1, num_attn=1, num_state=1):
     for complete in coverage:
         names = [f"tp{r}_g{g}" for r in range(tp_size) for g in range(num_attn)]
         if complete:
-            names += [f"tp{r}_g{num_attn + g}"
-                      for r in range(tp_size) for g in range(num_state)]
-        locs.append({"location_specs": [{"name": n, "uri": f"u_{n}"}
-                                        for n in names]})
+            names += [
+                f"tp{r}_g{num_attn + g}"
+                for r in range(tp_size)
+                for g in range(num_state)
+            ]
+        locs.append({"location_specs": [{"name": n, "uri": f"u_{n}"} for n in names]})
     return locs
 
 
@@ -294,9 +327,9 @@ class TestSpecGroups(unittest.TestCase):
         self.assertEqual(sorted(groups), ["attn", "full"])
         # attn: the attention spec of every rank; full: every group of every rank.
         self.assertEqual(groups["attn"], ["tp0_g0", "tp1_g0"])
-        self.assertEqual(groups["full"],
-                         ["tp0_g0", "tp0_g1", "tp0_g2",
-                          "tp1_g0", "tp1_g1", "tp1_g2"])
+        self.assertEqual(
+            groups["full"], ["tp0_g0", "tp0_g1", "tp0_g2", "tp1_g0", "tp1_g1", "tp1_g2"]
+        )
 
 
 class TestStateCompleteMask(unittest.TestCase):
@@ -305,39 +338,40 @@ class TestStateCompleteMask(unittest.TestCase):
     none. This mask is what start_write_cache announces per key."""
 
     def _req(self, tables):
-        return RequestLedger(vllm_request=FakeRequest("r0", []),
-                             block_ids_per_group=tables,
-                             has_saved_block_num=0)
+        return RequestLedger(
+            vllm_request=FakeRequest("r0", []),
+            block_ids_per_group=tables,
+            has_saved_block_num=0,
+        )
 
     def test_full_attention_is_always_complete(self):
         conn = make_connector_scheduler(manager_block_size=16, num_groups=1)
         req = self._req([[7, 0, 9]])
-        self.assertEqual(conn._state_complete_mask(req, range(3)),
-                         [True, True, True])
+        self.assertEqual(conn._state_complete_mask(req, range(3)), [True, True, True])
 
     def test_null_state_blocks_are_incomplete(self):
-        conn = make_connector_scheduler(manager_block_size=16, num_groups=1,
-                                   num_state_groups=1)
+        conn = make_connector_scheduler(
+            manager_block_size=16, num_groups=1, num_state_groups=1
+        )
         # State table: blocks 0 and 2 are null (no state), block 1 is real.
         req = self._req([[100, 101, 102], [0, 55, 0]])
-        self.assertEqual(conn._state_complete_mask(req, range(3)),
-                         [False, True, False])
+        self.assertEqual(conn._state_complete_mask(req, range(3)), [False, True, False])
 
     def test_all_state_groups_must_have_state(self):
-        conn = make_connector_scheduler(manager_block_size=16, num_groups=1,
-                                   num_state_groups=2)
+        conn = make_connector_scheduler(
+            manager_block_size=16, num_groups=1, num_state_groups=2
+        )
         # Block 1 has a state in group 1 but not in group 2 -> incomplete.
         req = self._req([[100, 101], [7, 8], [7, 0]])
-        self.assertEqual(conn._state_complete_mask(req, range(2)),
-                         [True, False])
+        self.assertEqual(conn._state_complete_mask(req, range(2)), [True, False])
 
     def test_short_state_table_is_incomplete(self):
         # A state table that does not reach the block cannot prove a state.
-        conn = make_connector_scheduler(manager_block_size=16, num_groups=1,
-                                   num_state_groups=1)
+        conn = make_connector_scheduler(
+            manager_block_size=16, num_groups=1, num_state_groups=1
+        )
         req = self._req([[100, 101], [55]])
-        self.assertEqual(conn._state_complete_mask(req, range(2)),
-                         [True, False])
+        self.assertEqual(conn._state_complete_mask(req, range(2)), [True, False])
 
 
 class TestExternalHitTruncation(unittest.TestCase):
@@ -347,33 +381,38 @@ class TestExternalHitTruncation(unittest.TestCase):
 
     MBS = 16
 
-    def _matched(self, coverage, prompt_len=None, num_state_groups=1,
-                 tp_size=1):
+    def _matched(self, coverage, prompt_len=None, num_state_groups=1, tp_size=1):
         conn = make_scheduler_connector(
-            mbs=self.MBS, num_state_groups=num_state_groups, tp_size=tp_size,
-            locations=hybrid_locations(coverage, tp_size=tp_size,
-                                       num_state=num_state_groups))
-        req = FakeRequest("r0", list(range(prompt_len or
-                                          (len(coverage) + 2) * self.MBS)))
+            mbs=self.MBS,
+            num_state_groups=num_state_groups,
+            tp_size=tp_size,
+            locations=hybrid_locations(
+                coverage, tp_size=tp_size, num_state=num_state_groups
+            ),
+        )
+        req = FakeRequest(
+            "r0", list(range(prompt_len or (len(coverage) + 2) * self.MBS))
+        )
         matched, _ = conn.get_num_new_matched_tokens(req, 0)
         if matched:
-            alloc(conn, req, matched, [[100 + i for i in range(
-                matched // self.MBS + 1)]])
+            alloc(
+                conn, req, matched, [[100 + i for i in range(matched // self.MBS + 1)]]
+            )
         return conn, matched
 
     def test_truncates_to_last_state_complete_block(self):
         conn, matched = self._matched([True, True, False, False])
         self.assertEqual(matched, 2 * self.MBS)
-        self.assertEqual(conn._waiting_to_load_requests[0].manager_block_idxes,
-                         [0, 1])
+        self.assertEqual(conn._waiting_to_load_requests[0].manager_block_idxes, [0, 1])
 
     def test_interior_gap_is_kept(self):
         # Only the *end* of the match must carry state; earlier state-less
         # blocks are fine (their state is never read).
         conn, matched = self._matched([True, False, True, False])
         self.assertEqual(matched, 3 * self.MBS)
-        self.assertEqual(conn._waiting_to_load_requests[0].manager_block_idxes,
-                         [0, 1, 2])
+        self.assertEqual(
+            conn._waiting_to_load_requests[0].manager_block_idxes, [0, 1, 2]
+        )
 
     def test_no_state_anywhere_drops_the_match(self):
         conn, matched = self._matched([False, False, False])
@@ -388,11 +427,11 @@ class TestExternalHitTruncation(unittest.TestCase):
     def test_every_rank_must_have_the_state(self):
         # tp2: block 1 has the state spec of rank 0 only -- rank 1 would read
         # nothing, so the block cannot end the match.
-        conn = make_scheduler_connector(mbs=self.MBS, num_state_groups=1,
-                                        tp_size=2)
+        conn = make_scheduler_connector(mbs=self.MBS, num_state_groups=1, tp_size=2)
         locs = hybrid_locations([True, True], tp_size=2, num_state=1)
         locs[1]["location_specs"] = [
-            s for s in locs[1]["location_specs"] if s["name"] != "tp1_g1"]
+            s for s in locs[1]["location_specs"] if s["name"] != "tp1_g1"
+        ]
         conn._location_query_manager.locations = locs
         conn._location_query_manager.in_flight = False
         req = FakeRequest("r0", list(range(6 * self.MBS)))
@@ -410,8 +449,7 @@ class TestExternalHitTruncation(unittest.TestCase):
     def test_truncation_runs_before_the_full_hit_cap(self):
         # Prompt is exactly 3 blocks; coverage allows 3 but the last carries no
         # state -> truncate to 2, and the full-hit cap then has nothing to drop.
-        conn, matched = self._matched([True, True, False],
-                                      prompt_len=3 * self.MBS)
+        conn, matched = self._matched([True, True, False], prompt_len=3 * self.MBS)
         self.assertEqual(matched, 2 * self.MBS)
 
     def test_full_hit_cap_retruncates_to_state_complete(self):
@@ -421,14 +459,15 @@ class TestExternalHitTruncation(unittest.TestCase):
         # drops block 2, and the new match end (block 1) has no state. The
         # match must be re-truncated -- loading it would end a hybrid request
         # on a state nobody wrote, unreportably (report_failures=False).
-        conn, matched = self._matched([True, False, True],
-                                      prompt_len=3 * self.MBS)
+        conn, matched = self._matched([True, False, True], prompt_len=3 * self.MBS)
         self.assertEqual(matched, self.MBS)
-        self.assertEqual(conn._waiting_to_load_requests[0].manager_block_idxes,
-                         [0])
+        self.assertEqual(conn._waiting_to_load_requests[0].manager_block_idxes, [0])
         end = max(conn._waiting_to_load_requests[0].manager_block_idxes)
-        self.assertTrue(conn._location_covers_states(
-            conn._waiting_to_load_requests[0].need_load_locations[end]))
+        self.assertTrue(
+            conn._location_covers_states(
+                conn._waiting_to_load_requests[0].need_load_locations[end]
+            )
+        )
 
 
 class TestStartWriteCacheSpecGroups(unittest.TestCase):
@@ -439,10 +478,13 @@ class TestStartWriteCacheSpecGroups(unittest.TestCase):
     def _conn(self, num_state_groups):
         conn = make_scheduler_connector(mbs=16, num_state_groups=num_state_groups)
         conn._extra_config = SimpleNamespace(
-            instance_id="inst", write_timeout_seconds=30)
+            instance_id="inst", write_timeout_seconds=30
+        )
         conn._manager_client = MagicMock()
         conn._manager_client.start_write_cache.return_value = {
-            "locations": [], "write_session_id": "sess"}
+            "locations": [],
+            "write_session_id": "sess",
+        }
         return conn
 
     def _request_sent(self, conn):
@@ -451,10 +493,11 @@ class TestStartWriteCacheSpecGroups(unittest.TestCase):
 
     def test_hybrid_sends_per_key_group_names(self):
         conn = self._conn(num_state_groups=1)
-        conn.start_save_kvcache_async("r0", list(range(48)), 3,
-                                      [True, False, True])
-        self.assertEqual(self._request_sent(conn)["location_spec_group_names"],
-                         ["full", "attn", "full"])
+        conn.start_save_kvcache_async("r0", list(range(48)), 3, [True, False, True])
+        self.assertEqual(
+            self._request_sent(conn)["location_spec_group_names"],
+            ["full", "attn", "full"],
+        )
 
     def test_full_attention_omits_group_names(self):
         conn = self._conn(num_state_groups=0)
@@ -476,18 +519,15 @@ class TestParseBlockMask(unittest.TestCase):
 
     def test_offset_branch(self):
         resp = {"block_mask": {"offset": 2}}
-        self.assertEqual(
-            self.conn.parse_block_mask_to_save_indices(resp, 5), [2, 3, 4])
+        self.assertEqual(self.conn.parse_block_mask_to_save_indices(resp, 5), [2, 3, 4])
 
     def test_offset_zero(self):
         resp = {"block_mask": {"offset": 0}}
-        self.assertEqual(
-            self.conn.parse_block_mask_to_save_indices(resp, 3), [0, 1, 2])
+        self.assertEqual(self.conn.parse_block_mask_to_save_indices(resp, 3), [0, 1, 2])
 
     def test_bool_masks_branch(self):
         resp = {"block_mask": {"bool_masks": {"values": [True, False, True, False]}}}
-        self.assertEqual(
-            self.conn.parse_block_mask_to_save_indices(resp, 4), [1, 3])
+        self.assertEqual(self.conn.parse_block_mask_to_save_indices(resp, 4), [1, 3])
 
     def test_missing_mask(self):
         self.assertEqual(self.conn.parse_block_mask_to_save_indices({}, 3), [])
@@ -503,24 +543,30 @@ class TestParseGroups(unittest.TestCase):
     def _parse(self, groups, mbs):
         return parse_groups(self._kv_cache_config(groups), mbs)
 
-    def _attn_group(self, layers, block_size=16, page_size_bytes=32768,
-                    page_size_padded=None):
+    def _attn_group(
+        self, layers, block_size=16, page_size_bytes=32768, page_size_padded=None
+    ):
         from vllm.v1.kv_cache_interface import FullAttentionSpec
+
         return SimpleNamespace(
             layer_names=layers,
-            kv_cache_spec=FullAttentionSpec(block_size, page_size_bytes,
-                                            page_size_padded=page_size_padded))
+            kv_cache_spec=FullAttentionSpec(
+                block_size, page_size_bytes, page_size_padded=page_size_padded
+            ),
+        )
 
     def _mamba_group(self, layers, block_size=528, page_size_bytes=1024):
         from vllm.v1.kv_cache_interface import MambaSpec
+
         return SimpleNamespace(
-            layer_names=layers,
-            kv_cache_spec=MambaSpec(block_size, page_size_bytes))
+            layer_names=layers, kv_cache_spec=MambaSpec(block_size, page_size_bytes)
+        )
 
     def test_full_attention_single_group(self):
         mbs = 32
         metas = self._parse(
-            [self._attn_group(["l0", "l1"], block_size=16, page_size_bytes=32768)], mbs)
+            [self._attn_group(["l0", "l1"], block_size=16, page_size_bytes=32768)], mbs
+        )
         self.assertEqual(len(metas), 1)
         m = metas[0]
         self.assertIsInstance(m, AttentionGroupMeta)
@@ -534,19 +580,25 @@ class TestParseGroups(unittest.TestCase):
         # die on the 'first attention tensor' lookup with an obscure
         # StopIteration; refuse it explicitly in parse_groups instead.
         with self.assertRaisesRegex(
-                NotImplementedError, "pure-mamba / attention-free models"):
+            NotImplementedError, "pure-mamba / attention-free models"
+        ):
             self._parse([self._mamba_group(["m0"])], mbs=528)
 
     def test_hybrid_multi_group(self):
         mbs = 528
-        metas = self._parse([
-            self._mamba_group(["m0", "m1"], page_size_bytes=1000),
-            self._mamba_group(["m2"], page_size_bytes=2000),
-            self._attn_group(["a0"], block_size=528, page_size_bytes=528 * 64),
-        ], mbs)
+        metas = self._parse(
+            [
+                self._mamba_group(["m0", "m1"], page_size_bytes=1000),
+                self._mamba_group(["m2"], page_size_bytes=2000),
+                self._attn_group(["a0"], block_size=528, page_size_bytes=528 * 64),
+            ],
+            mbs,
+        )
         self.assertEqual([m.group_idx for m in metas], [0, 1, 2])
-        self.assertEqual([type(m).__name__ for m in metas],
-                         ['StateGroupMeta', 'StateGroupMeta', 'AttentionGroupMeta'])
+        self.assertEqual(
+            [type(m).__name__ for m in metas],
+            ["StateGroupMeta", "StateGroupMeta", "AttentionGroupMeta"],
+        )
         self.assertEqual(metas[0].per_block_bytes, 1000 * 2)  # page * layers
         self.assertEqual(metas[1].per_block_bytes, 2000)
         self.assertEqual(metas[2].per_block_bytes, 64 * 528)  # per_token * mbs
@@ -555,8 +607,7 @@ class TestParseGroups(unittest.TestCase):
         mbs = 16
         eagle = self._attn_group(["drafter"])
         eagle.is_eagle_group = True
-        metas = self._parse(
-            [eagle, self._attn_group(["a0"])], mbs)
+        metas = self._parse([eagle, self._attn_group(["a0"])], mbs)
         self.assertEqual(len(metas), 1)
         self.assertEqual(metas[0].layer_names, ["a0"])
         self.assertEqual(metas[0].group_idx, 1)  # group_idx keeps vLLM numbering
@@ -567,8 +618,16 @@ class TestParseGroups(unittest.TestCase):
         # the compact real_page_size_bytes.
         mbs = 16
         metas = self._parse(
-            [self._attn_group(["l0", "l1"], block_size=16,
-                              page_size_bytes=32768, page_size_padded=40960)], mbs)
+            [
+                self._attn_group(
+                    ["l0", "l1"],
+                    block_size=16,
+                    page_size_bytes=32768,
+                    page_size_padded=40960,
+                )
+            ],
+            mbs,
+        )
         # per_token = 32768 // 16 = 2048 (not 40960 // 16 = 2560).
         self.assertEqual(metas[0].per_block_bytes, 2048 * 16 * 2)
 
@@ -576,8 +635,9 @@ class TestParseGroups(unittest.TestCase):
         # A padded spec that exposes no real_page_size_bytes cannot be sized
         # correctly -- must refuse, not silently over-allocate.
         mbs = 16
-        group = self._attn_group(["l0"], block_size=16,
-                                 page_size_bytes=32768, page_size_padded=40960)
+        group = self._attn_group(
+            ["l0"], block_size=16, page_size_bytes=32768, page_size_padded=40960
+        )
         del group.kv_cache_spec.real_page_size_bytes
         with self.assertRaises(NotImplementedError):
             self._parse([group], mbs)
@@ -622,8 +682,7 @@ class TestParseGroups(unittest.TestCase):
 
     def test_no_usable_groups_is_refused(self):
         mbs = 16
-        with self.assertRaisesRegex(NotImplementedError,
-                                    "no usable kv cache groups"):
+        with self.assertRaisesRegex(NotImplementedError, "no usable kv cache groups"):
             self._parse([], mbs)
 
 
@@ -642,9 +701,11 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         """ConnectorScheduler where vLLM group 0 is a skipped drafter and group 1
         is the transferred attention group."""
         conn = make_connector_scheduler(manager_block_size=self.MBS)
-        conn._group_metas = [AttentionGroupMeta(
-            group_idx=1, layer_names=["a0"],
-            block_size=self.MBS, per_block_bytes=0)]
+        conn._group_metas = [
+            AttentionGroupMeta(
+                group_idx=1, layer_names=["a0"], block_size=self.MBS, per_block_bytes=0
+            )
+        ]
         conn._num_groups = 1
         return conn
 
@@ -654,7 +715,8 @@ class TestSkippedGroupIndexing(unittest.TestCase):
             vllm_request=FakeRequest("r0", list(range(64))),
             # Drafter table (group 0) lags with 1 block; attention has 4.
             block_ids_per_group=[[100], [200, 201, 202, 203]],
-            has_saved_block_num=0)
+            has_saved_block_num=0,
+        )
         self.assertEqual(conn._num_allocated_blocks(ledger), 4)
 
     def test_num_allocated_blocks_still_mins_transferred_groups(self):
@@ -662,24 +724,32 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         # taken over the transferred ones only.
         conn = make_connector_scheduler(manager_block_size=self.MBS)
         conn._group_metas = [
-            AttentionGroupMeta(group_idx=1, layer_names=["a0"],
-                               block_size=self.MBS, per_block_bytes=0),
-            StateGroupMeta(group_idx=2, layer_names=["m0"],
-                           block_size=self.MBS, per_block_bytes=0,
-                           page_size_bytes=0),
+            AttentionGroupMeta(
+                group_idx=1, layer_names=["a0"], block_size=self.MBS, per_block_bytes=0
+            ),
+            StateGroupMeta(
+                group_idx=2,
+                layer_names=["m0"],
+                block_size=self.MBS,
+                per_block_bytes=0,
+                page_size_bytes=0,
+            ),
         ]
         conn._num_groups = 2
         ledger = RequestLedger(
             vllm_request=FakeRequest("r0", []),
             block_ids_per_group=[[9], [1, 2, 3], [4, 5]],
-            has_saved_block_num=0)
+            has_saved_block_num=0,
+        )
         self.assertEqual(conn._num_allocated_blocks(ledger), 2)
 
     def test_num_allocated_blocks_empty(self):
         conn = self._skipped_group0_connector()
-        ledger = RequestLedger(vllm_request=FakeRequest("r0", []),
-                               block_ids_per_group=[],
-                               has_saved_block_num=0)
+        ledger = RequestLedger(
+            vllm_request=FakeRequest("r0", []),
+            block_ids_per_group=[],
+            has_saved_block_num=0,
+        )
         self.assertEqual(conn._num_allocated_blocks(ledger), 0)
 
     def test_single_group_reports_failures_against_group0_table(self):
@@ -690,10 +760,14 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
-        meta.add_load_request(LoadRequest(
-            req_id="r0", manager_block_idxes=[0, 1],
-            need_load_locations=[{"location_specs": []}] * 2,
-            all_block_ids=[[10, 11, 12]]))
+        meta.add_load_request(
+            LoadRequest(
+                req_id="r0",
+                manager_block_idxes=[0, 1],
+                need_load_locations=[{"location_specs": []}] * 2,
+                all_block_ids=[[10, 11, 12]],
+            )
+        )
         conn.start_load_kv(MagicMock(), meta)
         args, kwargs = conn._data_transfer.create_load_done_callback.call_args
         self.assertEqual(args[3], [10, 11])  # report_ids from group 0's table
@@ -705,19 +779,25 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         # so reporting would crash the scheduler. Failures must NOT be
         # reported for this shape even though the model is attention-only.
         conn = make_connector(manager_block_size=self.MBS)
-        conn._group_metas = [AttentionGroupMeta(
-            group_idx=1, layer_names=["a0"],
-            block_size=self.MBS, per_block_bytes=0)]
+        conn._group_metas = [
+            AttentionGroupMeta(
+                group_idx=1, layer_names=["a0"], block_size=self.MBS, per_block_bytes=0
+            )
+        ]
         conn._num_groups = 1
         conn._extra_config = SimpleNamespace(block_per_load_task=8)
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
-        meta.add_load_request(LoadRequest(
-            req_id="r0", manager_block_idxes=[0, 1],
-            need_load_locations=[{"location_specs": []}] * 2,
-            # Group 0 (drafter) has a lagging 1-entry table.
-            all_block_ids=[[999], [10, 11]]))
+        meta.add_load_request(
+            LoadRequest(
+                req_id="r0",
+                manager_block_idxes=[0, 1],
+                need_load_locations=[{"location_specs": []}] * 2,
+                # Group 0 (drafter) has a lagging 1-entry table.
+                all_block_ids=[[999], [10, 11]],
+            )
+        )
         conn.start_load_kv(MagicMock(), meta)
         args, kwargs = conn._data_transfer.create_load_done_callback.call_args
         self.assertEqual(args[3], [])  # no report ids when not reporting
@@ -732,10 +812,14 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
-        meta.add_load_request(LoadRequest(
-            req_id="r0", manager_block_idxes=[0],
-            need_load_locations=[{"location_specs": []}],
-            all_block_ids=[[10], [20]]))
+        meta.add_load_request(
+            LoadRequest(
+                req_id="r0",
+                manager_block_idxes=[0],
+                need_load_locations=[{"location_specs": []}],
+                all_block_ids=[[10], [20]],
+            )
+        )
         conn.start_load_kv(MagicMock(), meta)
         args, kwargs = conn._data_transfer.create_load_done_callback.call_args
         self.assertEqual(args[3], [])
@@ -743,16 +827,21 @@ class TestSkippedGroupIndexing(unittest.TestCase):
 
     def test_hybrid_shape_disables_failure_reporting(self):
         # Attention + mamba: two vLLM block tables, the original hybrid case.
-        conn = make_connector(manager_block_size=self.MBS,
-                              num_groups=1, num_state_groups=1)
+        conn = make_connector(
+            manager_block_size=self.MBS, num_groups=1, num_state_groups=1
+        )
         conn._extra_config = SimpleNamespace(block_per_load_task=8)
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
-        meta.add_load_request(LoadRequest(
-            req_id="r0", manager_block_idxes=[0],
-            need_load_locations=[{"location_specs": []}],
-            all_block_ids=[[10], [20]]))
+        meta.add_load_request(
+            LoadRequest(
+                req_id="r0",
+                manager_block_idxes=[0],
+                need_load_locations=[{"location_specs": []}],
+                all_block_ids=[[10], [20]],
+            )
+        )
         conn.start_load_kv(MagicMock(), meta)
         args, kwargs = conn._data_transfer.create_load_done_callback.call_args
         self.assertEqual(args[3], [])
@@ -763,18 +852,28 @@ class TestSkippedGroupIndexing(unittest.TestCase):
         # token-granular recovery math upstream cannot consume state block
         # ids; the worker must fail loudly instead of reporting nonsense.
         conn = make_connector(manager_block_size=self.MBS)
-        conn._group_metas = [StateGroupMeta(
-            group_idx=0, layer_names=["m0"],
-            block_size=self.MBS, per_block_bytes=0, page_size_bytes=0)]
+        conn._group_metas = [
+            StateGroupMeta(
+                group_idx=0,
+                layer_names=["m0"],
+                block_size=self.MBS,
+                per_block_bytes=0,
+                page_size_bytes=0,
+            )
+        ]
         conn._num_groups = 1
         conn._extra_config = SimpleNamespace(block_per_load_task=8)
         conn._data_transfer = MagicMock()
         conn._plan_group_transfers = MagicMock(return_value=None)
         meta = TairKvCacheConnectorMetadata(epoch=0)
-        meta.add_load_request(LoadRequest(
-            req_id="r0", manager_block_idxes=[0],
-            need_load_locations=[{"location_specs": []}],
-            all_block_ids=[[10]]))
+        meta.add_load_request(
+            LoadRequest(
+                req_id="r0",
+                manager_block_idxes=[0],
+                need_load_locations=[{"location_specs": []}],
+                all_block_ids=[[10]],
+            )
+        )
         with self.assertRaises(AssertionError):
             conn.start_load_kv(MagicMock(), meta)
 
@@ -785,8 +884,7 @@ class TestSkippedGroupIndexing(unittest.TestCase):
 class TestBuildConnectorMeta(unittest.TestCase):
     MBS = 16
 
-    def _new_request(self, conn, req_id, num_tokens, num_blocks,
-                     num_locations=0):
+    def _new_request(self, conn, req_id, num_tokens, num_blocks, num_locations=0):
         """Simulate the scheduler flow for a fresh request: query, alloc, then
         one build_connector_meta step."""
         conn._location_query_manager.locations = make_locations(num_locations)
@@ -795,17 +893,18 @@ class TestBuildConnectorMeta(unittest.TestCase):
         matched, _ = conn.get_num_new_matched_tokens(req, 0)
         block_ids = [list(range(100, 100 + num_blocks))]
         conn.update_state_after_alloc(
-            req, SimpleNamespace(get_block_ids=lambda: block_ids), matched)
+            req, SimpleNamespace(get_block_ids=lambda: block_ids), matched
+        )
         out = fake_scheduler_output(
-            new_reqs=[SimpleNamespace(req_id=req_id, block_ids=block_ids)])
+            new_reqs=[SimpleNamespace(req_id=req_id, block_ids=block_ids)]
+        )
         return req, conn.build_connector_meta(out)
 
     def test_new_request_full_state(self):
         conn = make_scheduler_connector(mbs=self.MBS)
         req, meta = self._new_request(conn, "r0", 40, 3)
         # The ledger absorbed the first allocation's block table.
-        self.assertEqual(conn._tracked["r0"].block_ids_per_group,
-                         [[100, 101, 102]])
+        self.assertEqual(conn._tracked["r0"].block_ids_per_group, [[100, 101, 102]])
         # 40 tokens / 3 blocks -> min(40, 48)//16 = 2 blocks to save.
         conn._http_executor.submit.assert_called_once()
         args = conn._http_executor.submit.call_args[0]
@@ -831,20 +930,23 @@ class TestBuildConnectorMeta(unittest.TestCase):
         # Step 2: 8 decode tokens, no new blocks (PR #23262: may be None).
         req.output_token_ids = list(range(1000, 1008))
         out = fake_scheduler_output(
-            cached_req_ids=["r0"], num_scheduled={"r0": 8}, new_block_ids=[None])
+            cached_req_ids=["r0"], num_scheduled={"r0": 8}, new_block_ids=[None]
+        )
         conn.build_connector_meta(out)
         # Step 3: 2 more tokens with a new block -> table grows.
         req.output_token_ids = list(range(1000, 1010))
         out = fake_scheduler_output(
-            cached_req_ids=["r0"], num_scheduled={"r0": 2},
-            new_block_ids=[[[103]]])
+            cached_req_ids=["r0"], num_scheduled={"r0": 2}, new_block_ids=[[[103]]]
+        )
         conn.build_connector_meta(out)
-        self.assertEqual(conn._tracked["r0"].block_ids_per_group,
-                         [[100, 101, 102, 103]])
+        self.assertEqual(
+            conn._tracked["r0"].block_ids_per_group, [[100, 101, 102, 103]]
+        )
 
     def _preempted_step(self, conn, req, use_legacy):
-        kwargs = dict(cached_req_ids=["r0"], num_scheduled={"r0": 0},
-                      new_block_ids=[[[200, 201]]])
+        kwargs = dict(
+            cached_req_ids=["r0"], num_scheduled={"r0": 0}, new_block_ids=[[[200, 201]]]
+        )
         if use_legacy:
             kwargs["legacy_resumed"] = [True]
         else:
@@ -858,8 +960,7 @@ class TestBuildConnectorMeta(unittest.TestCase):
                 req, _ = self._new_request(conn, "r0", 40, 3)
                 self._preempted_step(conn, req, use_legacy)
                 # Resume replaces (not extends) the block table.
-                self.assertEqual(conn._tracked["r0"].block_ids_per_group,
-                                 [[200, 201]])
+                self.assertEqual(conn._tracked["r0"].block_ids_per_group, [[200, 201]])
 
     def test_resumed_with_none_new_blocks_keeps_the_recorded_table(self):
         # A resumed request whose new_block_ids is None (upstream
@@ -870,17 +971,16 @@ class TestBuildConnectorMeta(unittest.TestCase):
             with self.subTest(legacy=use_legacy):
                 conn = make_scheduler_connector(mbs=self.MBS)
                 req, _ = self._new_request(conn, "r0", 40, 3)
-                before = [list(t) for t in
-                          conn._tracked["r0"].block_ids_per_group]
-                kwargs = dict(cached_req_ids=["r0"], num_scheduled={"r0": 0},
-                              new_block_ids=[None])
+                before = [list(t) for t in conn._tracked["r0"].block_ids_per_group]
+                kwargs = dict(
+                    cached_req_ids=["r0"], num_scheduled={"r0": 0}, new_block_ids=[None]
+                )
                 if use_legacy:
                     kwargs["legacy_resumed"] = [True]
                 else:
                     kwargs["resumed_req_ids"] = {"r0"}
                 conn.build_connector_meta(fake_scheduler_output(**kwargs))
-                self.assertEqual(conn._tracked["r0"].block_ids_per_group,
-                                 before)
+                self.assertEqual(conn._tracked["r0"].block_ids_per_group, before)
 
     def test_save_threshold_grows_incrementally(self):
         conn = make_scheduler_connector(mbs=self.MBS)
@@ -889,7 +989,8 @@ class TestBuildConnectorMeta(unittest.TestCase):
         # 8 more tokens -> 48 total, table full at 3 blocks -> third block saves.
         req.output_token_ids = list(range(1000, 1008))
         out = fake_scheduler_output(
-            cached_req_ids=["r0"], num_scheduled={"r0": 8}, new_block_ids=[[[103]]])
+            cached_req_ids=["r0"], num_scheduled={"r0": 8}, new_block_ids=[[[103]]]
+        )
         conn.build_connector_meta(out)
         args = conn._http_executor.submit.call_args[0]
         self.assertEqual(args[3], 3)  # target_save_num
@@ -910,7 +1011,8 @@ class TestBuildConnectorMeta(unittest.TestCase):
         # request: block 2's last token id is still unknown.
         req.output_token_ids = list(range(1000, 1007))
         out = fake_scheduler_output(
-            cached_req_ids=["r0"], num_scheduled={"r0": 8}, new_block_ids=[[[103]]])
+            cached_req_ids=["r0"], num_scheduled={"r0": 8}, new_block_ids=[[[103]]]
+        )
         conn.build_connector_meta(out)
         conn._http_executor.submit.assert_not_called()
         self.assertEqual(conn._tracked["r0"].has_saved_block_num, 2)
@@ -919,7 +1021,8 @@ class TestBuildConnectorMeta(unittest.TestCase):
         # with a token list that really holds 48 ids.
         req.output_token_ids = list(range(1000, 1008))
         out = fake_scheduler_output(
-            cached_req_ids=["r0"], num_scheduled={"r0": 1}, new_block_ids=[[[]]])
+            cached_req_ids=["r0"], num_scheduled={"r0": 1}, new_block_ids=[[[]]]
+        )
         conn.build_connector_meta(out)
         args = conn._http_executor.submit.call_args[0]
         self.assertEqual(args[3], 3)  # target_save_num
@@ -942,7 +1045,8 @@ class TestBuildConnectorMeta(unittest.TestCase):
         # request already finished, a FinishRequest is emitted and state dropped.
         with conn._waiting_to_save_requests_lock:
             conn._waiting_to_save_requests.append(
-                SaveRequest("r0", make_locations(2), [0, 1], "sess"))
+                SaveRequest("r0", make_locations(2), [0, 1], "sess")
+            )
         meta = conn.build_connector_meta(fake_scheduler_output())
         self.assertEqual(len(meta.to_save_requests), 1)
         self.assertEqual([f.req_id for f in meta.to_finish_requests], ["r0"])
@@ -953,7 +1057,8 @@ class TestBuildConnectorMeta(unittest.TestCase):
         req, _ = self._new_request(conn, "r0", 40, 3)
         with conn._waiting_to_save_requests_lock:
             conn._waiting_to_save_requests.append(
-                SaveRequest("r0", make_locations(2), [0, 1], "sess"))
+                SaveRequest("r0", make_locations(2), [0, 1], "sess")
+            )
         conn.build_connector_meta(fake_scheduler_output())
         keep, extra = conn.request_finished(req, [])
         self.assertTrue(keep)
@@ -971,17 +1076,19 @@ class TestBuildConnectorMeta(unittest.TestCase):
     # without a test failing.
     def test_finish_reports_hit_accounting(self):
         conn = make_scheduler_connector(mbs=self.MBS)
-        req, _ = self._new_request(conn, "r0", 4 * self.MBS + 5, 4,
-                                   num_locations=3)
+        req, _ = self._new_request(conn, "r0", 4 * self.MBS + 5, 4, num_locations=3)
         # No saves in flight: finish reports the accounting immediately.
         conn._tracked["r0"].scheduled_saving_count = 0
         conn._tracked["r0"].sent_saving_count = 0
         keep, extra = conn.request_finished(req, [])
         self.assertTrue(keep)
-        self.assertEqual(extra, {
-            "local_matched_token_num": 0,
-            "remote_matched_token_num": 3 * self.MBS,
-        })
+        self.assertEqual(
+            extra,
+            {
+                "local_matched_token_num": 0,
+                "remote_matched_token_num": 3 * self.MBS,
+            },
+        )
         self.assertIsInstance(extra["local_matched_token_num"], int)
         self.assertIsInstance(extra["remote_matched_token_num"], int)
 
@@ -990,14 +1097,16 @@ class TestBuildConnectorMeta(unittest.TestCase):
         # consumes kv_transfer_params from whichever output finishes the
         # request.
         conn = make_scheduler_connector(mbs=self.MBS)
-        req, _ = self._new_request(conn, "r0", 4 * self.MBS + 5, 4,
-                                   num_locations=3)
+        req, _ = self._new_request(conn, "r0", 4 * self.MBS + 5, 4, num_locations=3)
         keep, extra = conn.request_finished(req, [])
         self.assertTrue(keep)
-        self.assertEqual(extra, {
-            "local_matched_token_num": 0,
-            "remote_matched_token_num": 3 * self.MBS,
-        })
+        self.assertEqual(
+            extra,
+            {
+                "local_matched_token_num": 0,
+                "remote_matched_token_num": 3 * self.MBS,
+            },
+        )
 
     def test_hit_accounting_follows_the_last_match_answer(self):
         # A re-ask with a grown local hit overwrites the accounting (the
@@ -1007,21 +1116,22 @@ class TestBuildConnectorMeta(unittest.TestCase):
         req = FakeRequest("r0", list(range(4 * self.MBS + 5)))
         conn._location_query_manager.locations = make_locations(3)
         conn._location_query_manager.in_flight = False
-        conn.get_num_new_matched_tokens(req, 0)   # answer: 3 blocks
-        self.assertEqual(conn._tracked["r0"].remote_matched_token_num,
-                         3 * self.MBS)
+        conn.get_num_new_matched_tokens(req, 0)  # answer: 3 blocks
+        self.assertEqual(conn._tracked["r0"].remote_matched_token_num, 3 * self.MBS)
         # Re-ask at a grown offset: local hit counted, remote re-answered.
         conn._location_query_manager.locations = make_locations(2)
         conn._location_query_manager.in_flight = False
         conn.get_num_new_matched_tokens(req, self.MBS)
         self.assertEqual(conn._tracked["r0"].local_matched_token_num, self.MBS)
-        self.assertEqual(conn._tracked["r0"].remote_matched_token_num,
-                         2 * self.MBS)
+        self.assertEqual(conn._tracked["r0"].remote_matched_token_num, 2 * self.MBS)
 
     def test_hit_accounting_burned_match_zeroes_remote(self):
         conn = make_scheduler_connector(
-            mbs=self.MBS, num_groups=1, num_state_groups=1,
-            locations=hybrid_locations([True, True]))
+            mbs=self.MBS,
+            num_groups=1,
+            num_state_groups=1,
+            locations=hybrid_locations([True, True]),
+        )
         req = FakeRequest("r0", list(range(4 * self.MBS + 5)))
         conn.get_num_new_matched_tokens(req, 0)
         alloc(conn, req, 2 * self.MBS, [[100, 101], [50, 51]])

--- a/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
+++ b/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
@@ -4,6 +4,7 @@
 import sys
 import unittest
 from types import ModuleType
+from typing import Any
 
 try:
     from unittest.mock import patch
@@ -47,8 +48,8 @@ class _FakeSpectrumServiceDiscovery:
         return None
 
 
-def _fake_spectrum_module():
-    module = ModuleType(_SPECTRUM_MODULE)
+def _fake_spectrum_module() -> Any:
+    module: Any = ModuleType(_SPECTRUM_MODULE)
     module.SpectrumServiceDiscovery = _FakeSpectrumServiceDiscovery
     return module
 
@@ -64,13 +65,15 @@ class TestParseUrl(unittest.TestCase):
         self.assertIsNone(_parse_url("static://"))
 
     def test_static_no_query(self):
-        scheme, body, params = _parse_url("static://10.0.0.1:8080,10.0.0.2:9090")
+        scheme, body, params = _parse_url(  # ty: ignore[not-iterable]
+            "static://10.0.0.1:8080,10.0.0.2:9090"
+        )
         self.assertEqual(scheme, "static")
         self.assertEqual(body, "10.0.0.1:8080,10.0.0.2:9090")
         self.assertEqual(params, {})
 
     def test_spectrum_with_query(self):
-        scheme, body, params = _parse_url(
+        scheme, body, params = _parse_url(  # ty: ignore[not-iterable]
             "spectrum://v-ad2d143d?cache_time=30&retry_time=3&timeout=5000"
         )
         self.assertEqual(scheme, "spectrum")
@@ -81,7 +84,9 @@ class TestParseUrl(unittest.TestCase):
         )
 
     def test_vipserver_with_single_param(self):
-        scheme, body, params = _parse_url("vipserver://my.domain.vipserver?timeout=10")
+        scheme, body, params = _parse_url(  # ty: ignore[not-iterable]
+            "vipserver://my.domain.vipserver?timeout=10"
+        )
         self.assertEqual(scheme, "vipserver")
         self.assertEqual(body, "my.domain.vipserver")
         self.assertEqual(params, {"timeout": "10"})
@@ -118,7 +123,9 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         self.assertIsNone(create_service_discovery("vipserver://pace.meta.vipserver"))
 
     def test_static_url_success(self):
-        discovery = create_service_discovery("static://10.0.0.1:8080,10.0.0.2:9090")
+        discovery: Any = create_service_discovery(
+            "static://10.0.0.1:8080,10.0.0.2:9090"
+        )
         self.assertIsNotNone(discovery)
         self.assertEqual(discovery.get_type(), "Static")
         endpoints = discovery.get_all_endpoints()
@@ -134,8 +141,10 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         self.assertIsNone(create_service_discovery("static://10.0.0.1:abc"))
 
     def test_spectrum_url_passes_config_to_discovery(self):
-        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
-            discovery = create_service_discovery(
+        with patch.dict(  # ty: ignore[unresolved-attribute]
+            sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}
+        ):
+            discovery: Any = create_service_discovery(
                 "spectrum://v-ad2d143d?cache_time=10&retry_time=2&timeout=3000"
             )
 
@@ -152,8 +161,10 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         self.assertIsNone(create_service_discovery("spectrum://"))
 
     def test_spectrum_url_passes_custom_port(self):
-        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
-            discovery = create_service_discovery(
+        with patch.dict(  # ty: ignore[unresolved-attribute]
+            sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}
+        ):
+            discovery: Any = create_service_discovery(
                 "spectrum://v-port?cache_time=10&retry_time=2&timeout=3000&port=12348"
             )
 
@@ -162,8 +173,10 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         discovery.close()
 
     def test_spectrum_body_is_forwarded_to_implementation(self):
-        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
-            discovery = create_service_discovery(
+        with patch.dict(  # ty: ignore[unresolved-attribute]
+            sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}
+        ):
+            discovery: Any = create_service_discovery(
                 "spectrum://virtual-service:opaque-suffix?cache_time=10"
             )
 
@@ -176,8 +189,10 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         discovery.close()
 
     def test_spectrum_url_uses_default_port_override(self):
-        with patch.dict(sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}):
-            discovery = create_service_discovery(
+        with patch.dict(  # ty: ignore[unresolved-attribute]
+            sys.modules, {_SPECTRUM_MODULE: _fake_spectrum_module()}
+        ):
+            discovery: Any = create_service_discovery(
                 "spectrum://v-no-port?cache_time=10&retry_time=2&timeout=3000"
             )
 

--- a/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
+++ b/kv_cache_manager/py_connector/test/test_service_discovery_factory.py
@@ -4,6 +4,7 @@
 import sys
 import unittest
 from types import ModuleType
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -139,8 +140,8 @@ class TestCreateServiceDiscovery(unittest.TestCase):
             )
 
         self.assertIsNotNone(discovery)
-        self.assertEqual(discovery.get_type(), 'Spectrum')
-        self.assertEqual(discovery.virtual_service_id, 'v-ad2d143d')
+        self.assertEqual(discovery.get_type(), "Spectrum")
+        self.assertEqual(discovery.virtual_service_id, "v-ad2d143d")
         self.assertEqual(discovery.cache_ttl, 10)
         self.assertEqual(discovery.retry_count, 2)
         self.assertEqual(discovery.refresh_timeout, 3)  # 3000 ms → 3 s
@@ -185,5 +186,5 @@ class TestCreateServiceDiscovery(unittest.TestCase):
         discovery.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/kv_cache_manager/py_connector/test/test_tp_coordinator.py
+++ b/kv_cache_manager/py_connector/test/test_tp_coordinator.py
@@ -5,7 +5,6 @@ import time
 import unittest
 import socket as socket_module
 
-import zmq
 
 from kv_cache_manager.py_connector.common.tp_coordinator import (
     CoordinateMessage,

--- a/kv_cache_manager/py_connector/test/test_tp_coordinator.py
+++ b/kv_cache_manager/py_connector/test/test_tp_coordinator.py
@@ -20,7 +20,7 @@ from kv_cache_manager.py_connector.common.tp_coordinator import (
 def _find_free_port():
     """Find a free TCP port."""
     with socket_module.socket(socket_module.AF_INET, socket_module.SOCK_STREAM) as s:
-        s.bind(('', 0))
+        s.bind(("", 0))
         return s.getsockname()[1]
 
 
@@ -29,7 +29,7 @@ def _wait_for_server(port, timeout=5.0):
     start = time.time()
     while time.time() - start < timeout:
         try:
-            with socket_module.create_connection(('127.0.0.1', port), timeout=0.1):
+            with socket_module.create_connection(("127.0.0.1", port), timeout=0.1):
                 time.sleep(0.05)  # Extra time for coordinator to enter recv loop
                 return True
         except (ConnectionRefusedError, socket_module.timeout):
@@ -157,7 +157,9 @@ class TestTpCoordinatorOutOfOrder(unittest.TestCase):
         )
         self.client.send(CoordinateMsgSerializer.dumps(start_msg))
 
-        self.assertTrue(self.callback_event.wait(timeout=5), "Callback not triggered after start")
+        self.assertTrue(
+            self.callback_event.wait(timeout=5), "Callback not triggered after start"
+        )
         self.assertEqual(len(self.callback_results), 1)
         session_id, save_context = self.callback_results[0]
         self.assertEqual(session_id, "session-1")

--- a/kv_cache_manager/py_connector/test/vllm_stubs.py
+++ b/kv_cache_manager/py_connector/test/vllm_stubs.py
@@ -85,7 +85,8 @@ def _stub_third_party():
     if "orjson" not in sys.modules and not _importable("orjson"):
         orjson = _module("orjson")
         orjson.dumps = lambda obj: json.dumps(
-            obj, default=lambda o: o.__dict__).encode()
+            obj, default=lambda o: o.__dict__
+        ).encode()
         orjson.loads = json.loads
 
 
@@ -165,8 +166,9 @@ def _install_stubs():
             self.real_page_size_bytes = page_size_bytes
             # Mirror vLLM's AttentionSpec: page_size_bytes returns the padded
             # size when padding is set.
-            self.page_size_bytes = (page_size_padded if page_size_padded
-                                    is not None else page_size_bytes)
+            self.page_size_bytes = (
+                page_size_padded if page_size_padded is not None else page_size_bytes
+            )
 
     class MambaSpec:
         def __init__(self, block_size, page_size_bytes):
@@ -192,32 +194,41 @@ _install_stubs()
 
 # Import after stubs are in place.
 from kv_cache_manager.py_connector.vllm.vllm_common import (  # noqa: E402
-    AttentionGroupMeta, GroupMeta, StateGroupMeta)
+    AttentionGroupMeta,
+    GroupMeta,
+    StateGroupMeta,
+)
 from kv_cache_manager.py_connector.vllm.connector_scheduler import ConnectorScheduler  # noqa: E402
 from kv_cache_manager.py_connector.vllm.connector_worker import ConnectorWorker  # noqa: E402
 
 
-def _make_group_metas(num_groups: int, num_state_groups: int,
-                      block_size: int) -> list:
+def _make_group_metas(num_groups: int, num_state_groups: int, block_size: int) -> list:
     """Attention groups first, then mamba-style state groups; group_idx is the
     vLLM group index (what block tables are indexed by)."""
     return [
-        AttentionGroupMeta(group_idx=i, layer_names=[f"l{i}"],
-                           block_size=block_size, per_block_bytes=0)
+        AttentionGroupMeta(
+            group_idx=i, layer_names=[f"l{i}"], block_size=block_size, per_block_bytes=0
+        )
         for i in range(num_groups)
     ] + [
-        StateGroupMeta(group_idx=num_groups + i, layer_names=[f"m{i}"],
-                       block_size=block_size, per_block_bytes=0,
-                       page_size_bytes=0)
+        StateGroupMeta(
+            group_idx=num_groups + i,
+            layer_names=[f"m{i}"],
+            block_size=block_size,
+            per_block_bytes=0,
+            page_size_bytes=0,
+        )
         for i in range(num_state_groups)
     ]
 
 
-def make_connector(manager_block_size: int = 16,
-                   vllm_block_size: Optional[int] = None,
-                   num_groups: int = 1,
-                   num_state_groups: int = 0,
-                   tp_size: int = 1) -> ConnectorWorker:
+def make_connector(
+    manager_block_size: int = 16,
+    vllm_block_size: Optional[int] = None,
+    num_groups: int = 1,
+    num_state_groups: int = 0,
+    tp_size: int = 1,
+) -> ConnectorWorker:
     """Build a bare ConnectorWorker (no __init__) with the minimal state used by
     the pure translation logic under test (block index translation, transfer
     group building).
@@ -234,10 +245,12 @@ def make_connector(manager_block_size: int = 16,
     conn._self_spec_names = {}
     conn._device = "cpu"
     conn._group_metas = _make_group_metas(
-        num_groups, num_state_groups, conn._vllm_block_size)
+        num_groups, num_state_groups, conn._vllm_block_size
+    )
     conn._num_groups = len(conn._group_metas)
-    conn._state_group_idxs = [m.group_idx for m in conn._group_metas
-                              if isinstance(m, StateGroupMeta)]
+    conn._state_group_idxs = [
+        m.group_idx for m in conn._group_metas if isinstance(m, StateGroupMeta)
+    ]
     return conn
 
 
@@ -271,31 +284,37 @@ class FakeLocationQueries:
         self._stored = None
 
 
-def make_connector_scheduler(manager_block_size: int = 16,
-                        vllm_block_size: Optional[int] = None,
-                        num_groups: int = 1,
-                        num_state_groups: int = 0,
-                        tp_size: int = 1,
-                        locations=None) -> ConnectorScheduler:
+def make_connector_scheduler(
+    manager_block_size: int = 16,
+    vllm_block_size: Optional[int] = None,
+    num_groups: int = 1,
+    num_state_groups: int = 0,
+    tp_size: int = 1,
+    locations=None,
+) -> ConnectorScheduler:
     """Build a bare ConnectorScheduler (no __init__) with the scheduler-loop state
     build_connector_meta and friends need, plus a FakeLocationQueries
     answering ``locations`` (None means "still in flight")."""
     from unittest.mock import MagicMock
+
     core = ConnectorScheduler.__new__(ConnectorScheduler)
     core._manager_block_size = manager_block_size
     core._vllm_block_size = vllm_block_size or manager_block_size
     core._tp_size = tp_size
     core._group_metas = _make_group_metas(
-        num_groups, num_state_groups, core._vllm_block_size)
+        num_groups, num_state_groups, core._vllm_block_size
+    )
     core._num_groups = len(core._group_metas)
-    core._state_group_idxs = [m.group_idx for m in core._group_metas
-                              if isinstance(m, StateGroupMeta)]
+    core._state_group_idxs = [
+        m.group_idx for m in core._group_metas if isinstance(m, StateGroupMeta)
+    ]
     core._epoch = 0
     core._tracked = {}
     core._load_failed = set()
     core._load_attempted = set()
     core._waiting_to_load_requests = []
     import threading
+
     core._waiting_to_save_requests_lock = threading.Lock()
     core._waiting_to_save_requests = []
     core._waiting_to_finish_requests = []

--- a/kv_cache_manager/py_connector/test/vllm_stubs.py
+++ b/kv_cache_manager/py_connector/test/vllm_stubs.py
@@ -13,7 +13,7 @@ import importlib.util
 import json
 import sys
 import types
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 #: Modules this run replaced with stand-ins (empty when the real deps are
@@ -22,7 +22,10 @@ from unittest.mock import MagicMock
 STUBBED: set = set()
 
 
-def _module(name: str) -> types.ModuleType:
+def _module(name: str) -> Any:
+    """Return (or register) the stub module; Any because the whole point of
+    this helper is dynamic attribute injection that no static type
+    describes."""
     mod = sys.modules.get(name)
     if mod is None:
         mod = types.ModuleType(name)
@@ -195,7 +198,6 @@ _install_stubs()
 # Import after stubs are in place.
 from kv_cache_manager.py_connector.vllm.vllm_common import (  # noqa: E402
     AttentionGroupMeta,
-    GroupMeta,
     StateGroupMeta,
 )
 from kv_cache_manager.py_connector.vllm.connector_scheduler import ConnectorScheduler  # noqa: E402
@@ -239,16 +241,21 @@ def make_connector(
     truncation)."""
     conn = ConnectorWorker.__new__(ConnectorWorker)
     conn._manager_block_size = manager_block_size
-    conn._vllm_block_size = vllm_block_size or manager_block_size
+    # Extra harness attributes the worker itself never declares.
+    conn._vllm_block_size = (  # ty: ignore[unresolved-attribute]
+        vllm_block_size or manager_block_size
+    )
     conn._tp_size = tp_size
     conn._tp_rank = 0
     conn._self_spec_names = {}
     conn._device = "cpu"
     conn._group_metas = _make_group_metas(
-        num_groups, num_state_groups, conn._vllm_block_size
+        num_groups,
+        num_state_groups,
+        conn._vllm_block_size,  # ty: ignore[unresolved-attribute]
     )
     conn._num_groups = len(conn._group_metas)
-    conn._state_group_idxs = [
+    conn._state_group_idxs = [  # ty: ignore[unresolved-attribute]
         m.group_idx for m in conn._group_metas if isinstance(m, StateGroupMeta)
     ]
     return conn
@@ -261,15 +268,16 @@ class FakeLocationQueries:
     hook's clamped result (store_result) is what the allocation consumes;
     the offset recorded at get time travels with it."""
 
-    def __init__(self, locations=None):
+    def __init__(self, locations: Optional[list] = None) -> None:
         self.locations = locations
         self.in_flight = locations is None
-        self._stored = None
+        self._stored: Any = None
         self.last_computed_blocks = 0
 
-    def get_locations_for_query(self, request, computed_blocks):
+    def get_locations_for_query(self, request: Any, computed_blocks: int) -> Any:
         self.last_computed_blocks = computed_blocks
-        return None if self.in_flight else list(self.locations)
+        # list(self.locations) is only reached when not in flight.
+        return None if self.in_flight else list(self.locations)  # ty: ignore[invalid-argument-type]
 
     def store_result(self, req_id, locations):
         self._stored = list(locations)
@@ -323,5 +331,7 @@ def make_connector_scheduler(
     core._http_executor = MagicMock()
     core._manager_client = MagicMock()
     core._coordinator_client = MagicMock()
-    core._location_query_manager = FakeLocationQueries(locations)
+    core._location_query_manager = (  # ty: ignore[invalid-assignment]
+        FakeLocationQueries(locations)
+    )
     return core

--- a/kv_cache_manager/py_connector/test/vllm_stubs.py
+++ b/kv_cache_manager/py_connector/test/vllm_stubs.py
@@ -81,6 +81,9 @@ def _stub_third_party():
         req.Session = MagicMock(name="requests.Session")
         req.post = MagicMock(name="requests.post")
         req.get = MagicMock(name="requests.get")
+        # manager_client's annotations reference requests.Response, which is
+        # evaluated at import time even when never called.
+        req.Response = MagicMock(name="requests.Response")
 
     # orjson is used functionally (CoordinateMsgSerializer round trips), so
     # the stand-in must actually (de)serialize; stdlib json handles the

--- a/kv_cache_manager/py_connector/trtllm/connector.py
+++ b/kv_cache_manager/py_connector/trtllm/connector.py
@@ -1,30 +1,31 @@
 # https://github.com/NVIDIA/TensorRT-LLM/blob/v1.2.0rc0/examples/llm-api/llm_kv_cache_connector.py
 
-import os
-import sys
-from dataclasses import dataclass, field
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import json
 import logging
-import uuid
 import math
+import os
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple
 
-import click
 import torch
-
-from tensorrt_llm import LLM, SamplingParams, logger
+import torch.distributed as dist
 from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
     KvCacheConnectorScheduler,
     KvCacheConnectorWorker,
     SchedulerOutput,
 )
-from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
-from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig, TorchLlmArgs
-import torch.distributed as dist
+
+# tensorrt_llm.bindings is compiled only; it ships no type stubs.
+from tensorrt_llm.bindings.internal.batch_manager import (  # ty: ignore[unresolved-import]
+    LlmRequest,
+)
+from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 
 from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
-from kv_cache_manager.client.pybind import kvcm_py_client
+
+# kvcm_py_client is the compiled pybind11 client; it ships no type stubs.
+from kv_cache_manager.client.pybind import kvcm_py_client  # ty: ignore[unresolved-import]
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ logger = logging.getLogger(__name__)
 KVCM_CONFIG_PATH_KEY = "KVCM_CONFIG_PATH"
 
 
-def init_kvcm_config():
+def init_kvcm_config() -> Dict[str, Any]:
     kvcm_config_path = os.environ.get(KVCM_CONFIG_PATH_KEY)
     assert kvcm_config_path is not None, f"env {KVCM_CONFIG_PATH_KEY} is needed"
     logger.info(f"{kvcm_config_path=}")
@@ -53,14 +54,20 @@ def init_kvcm_config():
     return kvcm_config
 
 
-def init_kvcm_meta_client(llm_args: TorchLlmArgs):
+def init_kvcm_meta_client(
+    llm_args: TorchLlmArgs,
+) -> Tuple[Dict[str, Any], KvCacheManagerClient]:
     kvcm_config = init_kvcm_config()
     manager_client = KvCacheManagerClient.from_connector_config(kvcm_config)
     logger.info("kvcm manager_client initialized")
     return kvcm_config, manager_client
 
 
-def init_kvcm_transfer_client(llm_args, kvcm_config, extra_config):
+def init_kvcm_transfer_client(
+    llm_args: TorchLlmArgs,
+    kvcm_config: Dict[str, Any],
+    extra_config: Dict[str, Any],
+) -> Any:
     location_spec_name = extra_config["location_spec_name"]
     location_spec_size = extra_config["location_spec_size"]
     register_response = extra_config["register_response"]
@@ -122,17 +129,19 @@ def tp_rank_to_spec_name(tp_rank: int) -> str:
 
 @dataclass
 class KVCMKvCacheConnectorMetadata:
-    # [locations, block_ids]
-    load: list[tuple[list[str], list[int]]] = field(default_factory=list)
+    # [locations (manager CacheLocation dicts), block_ids]
+    load: list[tuple[list[dict], list[int]]] = field(default_factory=list)
     # [locations, block_ids, write_session_id]
-    save: list[tuple[list[str], list[int], str]] = field(default_factory=list)
+    save: list[tuple[list[dict], list[int], str]] = field(default_factory=list)
 
 
 class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
-    def __init__(self, llm_args: TorchLlmArgs):
+    def __init__(self, llm_args: TorchLlmArgs) -> None:
         super().__init__(llm_args)
 
-        self.kv_cache_tensor = None
+        # torch.Tensor once register_kv_caches ran; every use below is
+        # order-guarded by the connector contract.
+        self.kv_cache_tensor: Any = None
 
         self.kvcm_config, self.manager_client = init_kvcm_meta_client(self._llm_args)
 
@@ -140,15 +149,20 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
         self.instance_id = self.kvcm_config["instance_id"]
 
         self.write_timeout_seconds = self.kvcm_config.get("write_timeout_seconds", 30)
+        # The base class types the bound connector metadata as a plain
+        # object; ours always carries the KVCM payload below.
+        self._metadata: KVCMKvCacheConnectorMetadata
 
-    def register_kv_caches(self, kv_cache_tensor: torch.Tensor):
+    def register_kv_caches(self, kv_cache_tensor: torch.Tensor) -> None:
         assert self.kv_cache_tensor is None, "KV cache tensor already registered"
         self.kv_cache_tensor = kv_cache_tensor
         extra_config = self._register_kvcm()
         self._init_kvcm_transfer_client(extra_config)
 
-    def _register_kvcm(self):
-        mapping = self._llm_args.parallel_config.to_mapping()
+    def _register_kvcm(self) -> Dict[str, Any]:
+        # to_mapping() is typed as a plain Mapping; the parallel config
+        # fields are accessed dynamically.
+        mapping: Any = self._llm_args.parallel_config.to_mapping()
         if not dist.is_initialized():
             master_ip = os.getenv("KVCM_CONNECTOR_ADDR", "localhost")
             master_port = os.getenv("KVCM_CONNECTOR_PORT", "6688")
@@ -213,12 +227,12 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
         }
         return extra_config
 
-    def _init_kvcm_transfer_client(self, extra_config):
+    def _init_kvcm_transfer_client(self, extra_config: Dict[str, Any]) -> None:
         self.transfer_client = init_kvcm_transfer_client(
             self._llm_args, self.kvcm_config, extra_config
         )
 
-    def start_load_kv(self, stream: torch.cuda.Stream):
+    def start_load_kv(self, stream: torch.cuda.Stream) -> None:
         for locations, block_ids in self._metadata.load:
             uris = self._extract_uris(locations)
             buffers, cpu_tensors = self._prepare_buffers(block_ids)
@@ -227,13 +241,13 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
             for block_id, cpu_tensor in zip(block_ids, cpu_tensors):
                 self.kv_cache_tensor[block_id].copy_(cpu_tensor, non_blocking=False)
 
-    def wait_for_layer_load(self, layer_idx: int, stream: torch.cuda.Stream):
+    def wait_for_layer_load(self, layer_idx: int, stream: torch.cuda.Stream) -> None:
         pass
 
-    def save_kv_layer(self, layer_idx: int, stream: torch.cuda.Stream):
+    def save_kv_layer(self, layer_idx: int, stream: torch.cuda.Stream) -> None:
         pass
 
-    def wait_for_save(self, stream: torch.cuda.Stream):
+    def wait_for_save(self, stream: torch.cuda.Stream) -> None:
 
         # Make sure the forward pass is complete before beginning our save.
         stream.synchronize()
@@ -274,7 +288,7 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
 
     def _prepare_buffers(
         self, block_ids: list[int]
-    ) -> list[kvcm_py_client.BlockBuffer]:
+    ) -> tuple[list[kvcm_py_client.BlockBuffer], list[torch.Tensor]]:
         buffers = []
         cpu_tensors = []
         for block_id in block_ids:
@@ -302,7 +316,7 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
 
 
 class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
-    def __init__(self, llm_args: TorchLlmArgs):
+    def __init__(self, llm_args: TorchLlmArgs) -> None:
         super().__init__(llm_args)
 
         self.block_size = self._llm_args.kv_cache_config.tokens_per_block
@@ -314,7 +328,9 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
 
         self.write_timeout_seconds = self.kvcm_config.get("write_timeout_seconds", 30)
 
-    def build_connector_meta(self, scheduler_output: SchedulerOutput):
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVCMKvCacheConnectorMetadata:
         # NOTE: This is a simplified implementation, and does not work with chunked prefill.
 
         metadata = KVCMKvCacheConnectorMetadata()
@@ -405,8 +421,8 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
             for i in range(0, len(tokens), self.block_size)
         ]
 
-    def _parse_block_mask(self, block_mask: dict, len_block_keys: int) -> int:
-        save_indices = None
+    def _parse_block_mask(self, block_mask: dict, len_block_keys: int) -> list[int]:
+        save_indices: list[int] = []
         if "offset" in block_mask:
             offset = block_mask["offset"]
             save_indices = list(range(offset, len_block_keys))
@@ -476,5 +492,7 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
         # We don't do any asynchronous saving, so always return False
         return False
 
-    def update_state_after_alloc(self, request: LlmRequest, block_ids: list[int]):
+    def update_state_after_alloc(
+        self, request: LlmRequest, block_ids: list[int]
+    ) -> None:
         pass

--- a/kv_cache_manager/py_connector/trtllm/connector.py
+++ b/kv_cache_manager/py_connector/trtllm/connector.py
@@ -370,8 +370,14 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
                 write_session_id = result["write_session_id"]
                 block_mask = result["block_mask"]
             except Exception as e:
-                logger.error(f"get_cache_location {e=}, {get_request=}")
-                len_locations = 0
+                # Best-effort: skip saving this request (mirrors the error
+                # handling of get_num_new_matched_tokens) instead of crashing
+                # the scheduler loop.
+                logger.error(
+                    f"start_write_cache failed for request {req.request_id}, "
+                    f"skip saving: {e=}"
+                )
+                continue
 
             save_indices = self._parse_block_mask(block_mask, len(block_keys))
             assert len(store_locations) == len(save_indices)

--- a/kv_cache_manager/py_connector/trtllm/connector.py
+++ b/kv_cache_manager/py_connector/trtllm/connector.py
@@ -15,7 +15,10 @@ import torch
 
 from tensorrt_llm import LLM, SamplingParams, logger
 from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
-    KvCacheConnectorScheduler, KvCacheConnectorWorker, SchedulerOutput)
+    KvCacheConnectorScheduler,
+    KvCacheConnectorWorker,
+    SchedulerOutput,
+)
 from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
 from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig, TorchLlmArgs
 import torch.distributed as dist
@@ -40,7 +43,7 @@ def init_kvcm_config():
     logger.info(f"{kvcm_config_path=}")
 
     try:
-        with open(kvcm_config_path, 'r', encoding='utf-8') as f:
+        with open(kvcm_config_path, "r", encoding="utf-8") as f:
             kvcm_config = json.load(f)
     except FileNotFoundError:
         raise FileNotFoundError(f"KVCM config file not found at {kvcm_config_path}")
@@ -126,7 +129,6 @@ class KVCMKvCacheConnectorMetadata:
 
 
 class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
-
     def __init__(self, llm_args: TorchLlmArgs):
         super().__init__(llm_args)
 
@@ -151,10 +153,12 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
             master_ip = os.getenv("KVCM_CONNECTOR_ADDR", "localhost")
             master_port = os.getenv("KVCM_CONNECTOR_PORT", "6688")
             init_method = f"tcp://{master_ip}:{master_port}"
-            dist.init_process_group(backend="nccl",
-                                    init_method=init_method,
-                                    world_size=mapping.world_size,
-                                    rank=mapping.rank)
+            dist.init_process_group(
+                backend="nccl",
+                init_method=init_method,
+                world_size=mapping.world_size,
+                rank=mapping.rank,
+            )
         self.cpu_tp_group = dist.new_group(mapping.tp_group, backend="gloo")
 
         self.tp_rank = mapping.tp_rank
@@ -173,14 +177,21 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
         # https://github.com/NVIDIA/TensorRT-LLM/blob/v1.2.0rc0/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp#L828
         # self.kv_cache_tensor.shape = {mNumPrimaryBlocks, pool.numLayers, mKVFactor, blockSize}
         assert self.kv_cache_tensor.shape[2] == (
-            1 if self.kvcm_config["use_mla"] else 2)  # mKVFactor == (1 if use_mla else 2)
+            1 if self.kvcm_config["use_mla"] else 2
+        )  # mKVFactor == (1 if use_mla else 2)
         # https://github.com/NVIDIA/TensorRT-LLM/blob/v1.2.0rc0/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h#L543
         # blockSize = (numKvHeads * sizePerHead * tokensPerBlock)
-        location_spec_size = math.prod(self.kv_cache_tensor.shape[1:]) * self.kv_cache_tensor.dtype.itemsize
-        location_spec_infos = [{
-            "name": tp_rank_to_spec_name(rank),
-            "size": location_spec_size,
-        } for rank in range(mapping.tp_size)]
+        location_spec_size = (
+            math.prod(self.kv_cache_tensor.shape[1:])
+            * self.kv_cache_tensor.dtype.itemsize
+        )
+        location_spec_infos = [
+            {
+                "name": tp_rank_to_spec_name(rank),
+                "size": location_spec_size,
+            }
+            for rank in range(mapping.tp_size)
+        ]
 
         register_request = {
             "trace_id": get_trace_id(),
@@ -204,7 +215,8 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
 
     def _init_kvcm_transfer_client(self, extra_config):
         self.transfer_client = init_kvcm_transfer_client(
-            self._llm_args, self.kvcm_config, extra_config)
+            self._llm_args, self.kvcm_config, extra_config
+        )
 
     def start_load_kv(self, stream: torch.cuda.Stream):
         for locations, block_ids in self._metadata.load:
@@ -231,7 +243,7 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
             buffers, _ = self._prepare_buffers(block_ids)
             result = self.transfer_client.SaveKvCaches(uris, buffers)
             logger.debug(f"SaveKvCaches {result=}")
-            flag = (result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
+            flag = result[0] == kvcm_py_client.ClientErrorCode.ER_OK
             if self.tp_world_size > 1:
                 flag_tensor = torch.tensor(flag, dtype=torch.int)
                 dist.all_reduce(
@@ -243,12 +255,14 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
 
             if self.tp_rank == 0:
                 finish_mask = [flag] * len(locations)
-                self.manager_client.finish_write_cache({
-                    "trace_id": get_trace_id(),
-                    "instance_id": self.instance_id,
-                    "write_session_id": write_session_id,
-                    "success_blocks": {"bool_masks": {"values": finish_mask}},
-                })
+                self.manager_client.finish_write_cache(
+                    {
+                        "trace_id": get_trace_id(),
+                        "instance_id": self.instance_id,
+                        "write_session_id": write_session_id,
+                        "success_blocks": {"bool_masks": {"values": finish_mask}},
+                    }
+                )
 
     def _extract_uris(self, locations: list[dict]) -> list[str]:
         uris = []
@@ -258,7 +272,9 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
                     uris.append(location_spec["uri"])
         return uris
 
-    def _prepare_buffers(self, block_ids: list[int]) -> list[kvcm_py_client.BlockBuffer]:
+    def _prepare_buffers(
+        self, block_ids: list[int]
+    ) -> list[kvcm_py_client.BlockBuffer]:
         buffers = []
         cpu_tensors = []
         for block_id in block_ids:
@@ -279,14 +295,13 @@ class KVCMKvCacheConnectorWorker(KvCacheConnectorWorker):
         return buffers, cpu_tensors
 
     def get_finished(
-            self, finished_gen_req_ids: list[int],
-            started_loading_req_ids: list[int]) -> tuple[list[int], list[int]]:
+        self, finished_gen_req_ids: list[int], started_loading_req_ids: list[int]
+    ) -> tuple[list[int], list[int]]:
 
         return [], []
 
 
 class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
-
     def __init__(self, llm_args: TorchLlmArgs):
         super().__init__(llm_args)
 
@@ -312,20 +327,33 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
             num_computed_blocks = req.computed_position // self.block_size
             block_ids = req.new_block_ids
 
-            load_locations, computed_hashes, remaining_hashes = self.pending_loads[req.request_id]
+            load_locations, computed_hashes, remaining_hashes = self.pending_loads[
+                req.request_id
+            ]
             assert num_computed_blocks == len(computed_hashes)
             assert len(load_locations) == len(remaining_hashes)
 
             metadata.load.append(
-                (load_locations, [
-                    block_ids[block_pos] for block_pos in range(
-                        num_computed_blocks, num_computed_blocks + len(load_locations))]))
+                (
+                    load_locations,
+                    [
+                        block_ids[block_pos]
+                        for block_pos in range(
+                            num_computed_blocks,
+                            num_computed_blocks + len(load_locations),
+                        )
+                    ],
+                )
+            )
 
             # Break up the remainder of the token sequence into chunks.
             chunks = self._chunk_tokens(req.new_tokens)
 
-            new_chunks = [chunk for chunk in chunks[len(computed_hashes) +
-                                                    len(remaining_hashes):] if len(chunk) == self.block_size]
+            new_chunks = [
+                chunk
+                for chunk in chunks[len(computed_hashes) + len(remaining_hashes) :]
+                if len(chunk) == self.block_size
+            ]
             new_hashes = [self._hash_tokens(chunk) for chunk in new_chunks]
             block_keys = computed_hashes + remaining_hashes + new_hashes
             request = {
@@ -348,9 +376,14 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
             save_indices = self._parse_block_mask(block_mask, len(block_keys))
             assert len(store_locations) == len(save_indices)
 
-            metadata.save.append((store_locations, [block_ids[block_pos]
-                                 for block_pos in save_indices], write_session_id))
-        
+            metadata.save.append(
+                (
+                    store_locations,
+                    [block_ids[block_pos] for block_pos in save_indices],
+                    write_session_id,
+                )
+            )
+
         logger.info(f"{metadata=}")
 
         self.pending_loads = {}
@@ -362,7 +395,7 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
 
     def _chunk_tokens(self, tokens: list[int]) -> list[list[int]]:
         return [
-            tokens[i:i + self.block_size]
+            tokens[i : i + self.block_size]
             for i in range(0, len(tokens), self.block_size)
         ]
 
@@ -374,12 +407,14 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
         else:
             # False: need to store
             bool_masks = block_mask.get("bool_masks", {}).get("values", [])
-            save_indices = [idx for idx, is_saved in enumerate(bool_masks) if not is_saved]
+            save_indices = [
+                idx for idx, is_saved in enumerate(bool_masks) if not is_saved
+            ]
         return save_indices
 
     def get_num_new_matched_tokens(
-            self, request: LlmRequest,
-            num_computed_tokens: int) -> tuple[int, bool]:
+        self, request: LlmRequest, num_computed_tokens: int
+    ) -> tuple[int, bool]:
         self.pending_loads[request.request_id] = [[], [], []]
 
         # Don't bother with sequences with partial matches.
@@ -388,10 +423,9 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
 
         computed_blocks = num_computed_tokens // self.block_size
 
-        computed_tokens = request.get_tokens(0)[:computed_blocks * self.block_size]
+        computed_tokens = request.get_tokens(0)[: computed_blocks * self.block_size]
         # Get all the tokens that don't have a cache hit on device.
-        remaining_tokens = request.get_tokens(0)[computed_blocks *
-                                                 self.block_size:]
+        remaining_tokens = request.get_tokens(0)[computed_blocks * self.block_size :]
 
         computed_chunks = self._chunk_tokens(computed_tokens)
         remaining_chunks = self._chunk_tokens(remaining_tokens)
@@ -421,7 +455,9 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
         self.pending_loads[request.request_id][1].extend(computed_hashes)
         if len_locations > 0:
             self.pending_loads[request.request_id][0].extend(locations)
-            self.pending_loads[request.request_id][2].extend(remaining_hashes[:len(locations)])
+            self.pending_loads[request.request_id][2].extend(
+                remaining_hashes[: len(locations)]
+            )
 
         logger.info(
             f"KV CONNECTOR: Matched {len_locations} blocks for request {request.request_id}"
@@ -430,11 +466,9 @@ class KVCMKvCacheConnectorLeader(KvCacheConnectorScheduler):
 
         return len_locations * self.block_size, False
 
-    def request_finished(self, request: LlmRequest,
-                         cache_block_ids: list[int]) -> bool:
+    def request_finished(self, request: LlmRequest, cache_block_ids: list[int]) -> bool:
         # We don't do any asynchronous saving, so always return False
         return False
 
-    def update_state_after_alloc(self, request: LlmRequest,
-                                 block_ids: list[int]):
+    def update_state_after_alloc(self, request: LlmRequest, block_ids: list[int]):
         pass

--- a/kv_cache_manager/py_connector/trtllm/test.py
+++ b/kv_cache_manager/py_connector/trtllm/test.py
@@ -1,4 +1,5 @@
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 
 import os
@@ -13,7 +14,10 @@ import torch
 
 from tensorrt_llm import LLM, SamplingParams, logger
 from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
-    KvCacheConnectorScheduler, KvCacheConnectorWorker, SchedulerOutput)
+    KvCacheConnectorScheduler,
+    KvCacheConnectorWorker,
+    SchedulerOutput,
+)
 from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
 from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig, TorchLlmArgs
 
@@ -22,6 +26,7 @@ from kv_cache_manager.py_connector.trtllm.connector import (
     KVCMKvCacheConnectorLeader,
     KVCMKvCacheConnectorWorker,
 )
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,7 +38,6 @@ def init_kvcm_config():
         "manager_uri": "http://127.0.0.1:6382",
         "instance_group": "default",
         "instance_id": "0",
-
         "use_mla": False,
         "dtype": "torch.bfloat16",
     }
@@ -45,12 +49,14 @@ def init_kvcm_config():
 @click.command()
 @click.argument("model", type=str)
 def main(model: str):
-    sys.path.append(os.path.join(
-        os.path.dirname(__file__),
-        "..",
-    ))
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+        )
+    )
 
-    this_module = __file__[__file__.rfind("/") + 1:__file__.rfind(".py")]
+    this_module = __file__[__file__.rfind("/") + 1 : __file__.rfind(".py")]
 
     init_kvcm_config()
 
@@ -62,18 +68,21 @@ def main(model: str):
 
     tensor_parallel_size = 2
 
-    llm = LLM(model=model,
-              tensor_parallel_size=tensor_parallel_size,
-              backend="pytorch",
-              cuda_graph_config=None,
-              kv_connector_config=kv_connector_config)
+    llm = LLM(
+        model=model,
+        tensor_parallel_size=tensor_parallel_size,
+        backend="pytorch",
+        cuda_graph_config=None,
+        kv_connector_config=kv_connector_config,
+    )
 
     test_text = (
         "Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “and what is the use of a book,” thought Alice “without pictures or conversations?”"
         "Nvidia Corporation is an American technology company headquartered in Santa Clara, California."
         "Founded in 1993 by Jensen Huang, Chris Malachowsky, and Curtis Priem, it develops graphics processing units (GPUs), "
         "system on a chips (SoCs), and application programming interfaces (APIs) for data science, high-performance computing, "
-        "and mobile and automotive applications. Tell me about the company.")
+        "and mobile and automotive applications. Tell me about the company."
+    )
 
     sampling_params = SamplingParams(max_tokens=32)
 
@@ -85,11 +94,13 @@ def main(model: str):
 
     del llm
 
-    llm = LLM(model=model,
-              tensor_parallel_size=tensor_parallel_size,
-              backend="pytorch",
-              cuda_graph_config=None,
-              kv_connector_config=kv_connector_config)
+    llm = LLM(
+        model=model,
+        tensor_parallel_size=tensor_parallel_size,
+        backend="pytorch",
+        cuda_graph_config=None,
+        kv_connector_config=kv_connector_config,
+    )
 
     output = llm.generate([test_text], sampling_params)
     text1 = output[0].outputs[0].text

--- a/kv_cache_manager/py_connector/trtllm/test.py
+++ b/kv_cache_manager/py_connector/trtllm/test.py
@@ -4,24 +4,17 @@ logging.basicConfig(level=logging.DEBUG)
 
 import os
 import sys
-from dataclasses import dataclass, field
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import json
 
 import click
-import torch
 
-from tensorrt_llm import LLM, SamplingParams, logger
-from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
-    KvCacheConnectorScheduler,
-    KvCacheConnectorWorker,
-    SchedulerOutput,
-)
-from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
-from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig, TorchLlmArgs
+from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm.llmapi.llm_args import KvCacheConnectorConfig
 
-from kv_cache_manager.py_connector.trtllm.connector import (
+# The two connector classes are re-exported for TensorRT-LLM:
+# KvCacheConnectorConfig loads this module by name and resolves them from
+# its namespace.
+from kv_cache_manager.py_connector.trtllm.connector import (  # noqa: F401
     KVCM_CONFIG_PATH_KEY,
     KVCMKvCacheConnectorLeader,
     KVCMKvCacheConnectorWorker,
@@ -87,7 +80,8 @@ def main(model: str):
     sampling_params = SamplingParams(max_tokens=32)
 
     output = llm.generate([test_text], sampling_params)
-    text0 = output[0].outputs[0].text
+    # RequestOutput is subscriptable at runtime; its type stubs are not.
+    text0 = output[0].outputs[0].text  # ty: ignore[not-subscriptable]
 
     logger.info(f"First output: {text0}")
     logger.info("Loading new LLM instance...")
@@ -103,7 +97,8 @@ def main(model: str):
     )
 
     output = llm.generate([test_text], sampling_params)
-    text1 = output[0].outputs[0].text
+    # See above.
+    text1 = output[0].outputs[0].text  # ty: ignore[not-subscriptable]
 
     logger.info(f"Second output (using connector cache): {text1}")
 

--- a/kv_cache_manager/py_connector/ty.toml
+++ b/kv_cache_manager/py_connector/ty.toml
@@ -10,6 +10,14 @@
 extra-paths = ["../.."]
 python = "../../.venv"
 
+# Several inline ignores are deliberately state-dependent: a fresh source
+# checkout and a built worktree resolve different module sets (the
+# build-generated _version_info, the compiled kvcm_py_client, older-vLLM
+# compatibility branches). Reporting unused ignores would make the gate
+# depend on the build state, so the notice is off.
+[rules]
+unused-ignore-comment = "ignore"
+
 # Triton kernels: ty cannot model the @triton.jit DSL -- constexpr
 # parameters, their defaults, and launch options such as num_warps all
 # surface as argument-type noise. Suppress only those rule classes here.

--- a/kv_cache_manager/py_connector/ty.toml
+++ b/kv_cache_manager/py_connector/ty.toml
@@ -9,3 +9,10 @@
 [environment]
 extra-paths = ["../.."]
 python = "../../.venv"
+
+# Triton kernels: ty cannot model the @triton.jit DSL -- constexpr
+# parameters, their defaults, and launch options such as num_warps all
+# surface as argument-type noise. Suppress only those rule classes here.
+[[overrides]]
+include = ["kernel/**"]
+rules = { invalid-argument-type = "ignore", invalid-parameter-default = "ignore", unknown-argument = "ignore" }

--- a/kv_cache_manager/py_connector/ty.toml
+++ b/kv_cache_manager/py_connector/ty.toml
@@ -1,0 +1,11 @@
+# Type-check config for the kv_cache_manager Python connectors.
+# Scope: this directory only; run ty from here (`cd kv_cache_manager/py_connector && ty check`)
+# so that this file and the relative paths below resolve as intended.
+#
+# The Python environment is pinned to the repository-root `.venv` (see
+# README.md "Type environment" for how to build it): the checks and the
+# annotations target vLLM 0.26.0's types, and a pinned environment keeps
+# them reproducible regardless of any activated virtualenv.
+[environment]
+extra-paths = ["../.."]
+python = "../../.venv"

--- a/kv_cache_manager/py_connector/vllm/connector_scheduler.py
+++ b/kv_cache_manager/py_connector/vllm/connector_scheduler.py
@@ -23,13 +23,28 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from kv_cache_manager.py_connector.common.logger import logger
 from kv_cache_manager.py_connector.common.tp_coordinator import (
-    CoordinateMsgSerializer, CoordinateMessage, SendBlockStartEvent, TpCoordinatorClient)
-from kv_cache_manager.py_connector.vllm.location_query_manager import LocationQueryManager
+    CoordinateMsgSerializer,
+    CoordinateMessage,
+    SendBlockStartEvent,
+    TpCoordinatorClient,
+)
+from kv_cache_manager.py_connector.vllm.location_query_manager import (
+    LocationQueryManager,
+)
 from kv_cache_manager.py_connector.vllm.metadata import (
-    FinishRequest, LoadRequest, SaveRequest, TairKvCacheConnectorMetadata)
+    FinishRequest,
+    LoadRequest,
+    SaveRequest,
+    TairKvCacheConnectorMetadata,
+)
 from kv_cache_manager.py_connector.vllm.vllm_common import (
-    ATTN_ONLY_SPEC_GROUP, ALL_SPEC_GROUP, GroupMeta, StateGroupMeta,
-    build_spec_groups, spec_name)
+    ATTN_ONLY_SPEC_GROUP,
+    ALL_SPEC_GROUP,
+    GroupMeta,
+    StateGroupMeta,
+    build_spec_groups,
+    spec_name,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -46,6 +61,7 @@ class RequestLedger:
     read from it on demand (all_token_ids) and only its length is tracked
     here. ``has_saved_block_num`` anchors the incremental saves: blocks are
     saved once as the computed prefix crosses manager-block boundaries."""
+
     vllm_request: "Request"
     # Per kv_cache_group block table, in each group's own block_size units.
     block_ids_per_group: List[List[int]]
@@ -69,14 +85,22 @@ class RequestLedger:
 class ConnectorScheduler:
     """State and hooks for the scheduler-role connector instance."""
 
-    def __init__(self, extra_config, group_metas: List[GroupMeta],
-                 manager_block_size: int, vllm_block_size: int, tp_size: int,
-                 manager_client, coordinator_client: TpCoordinatorClient):
+    def __init__(
+        self,
+        extra_config,
+        group_metas: List[GroupMeta],
+        manager_block_size: int,
+        vllm_block_size: int,
+        tp_size: int,
+        manager_client,
+        coordinator_client: TpCoordinatorClient,
+    ):
         self._extra_config = extra_config
         self._group_metas = group_metas
         self._num_groups = len(group_metas)
-        self._state_group_idxs = [m.group_idx for m in group_metas
-                                  if isinstance(m, StateGroupMeta)]
+        self._state_group_idxs = [
+            m.group_idx for m in group_metas if isinstance(m, StateGroupMeta)
+        ]
         self._manager_block_size = manager_block_size
         self._vllm_block_size = vllm_block_size
         self._tp_size = tp_size
@@ -84,11 +108,16 @@ class ConnectorScheduler:
         self._coordinator_client = coordinator_client
 
         self._epoch = 0
-        self._http_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="kvcm_http_")
+        self._http_executor = ThreadPoolExecutor(
+            max_workers=4, thread_name_prefix="kvcm_http_"
+        )
         self._location_query_manager = LocationQueryManager(
-            manager_client, self._http_executor, extra_config.instance_id,
+            manager_client,
+            self._http_executor,
+            extra_config.instance_id,
             extra_config.async_get_cache_location,
-            extra_config.location_query_max_age_seconds)
+            extra_config.location_query_max_age_seconds,
+        )
 
         self._tracked: Dict[str, RequestLedger] = {}
         self._waiting_to_load_requests: List[LoadRequest] = []
@@ -118,7 +147,9 @@ class ConnectorScheduler:
                 return meta.block_size
         raise KeyError(f"no such transferred group: {group_idx}")
 
-    def _state_complete_mask(self, ledger: RequestLedger, manager_block_idxes) -> List[bool]:
+    def _state_complete_mask(
+        self, ledger: RequestLedger, manager_block_idxes
+    ) -> List[bool]:
         """Per manager block: does *every* state group hold a real state?
 
         vLLM's block table is the ground truth: in "align" mode a manager block
@@ -150,8 +181,10 @@ class ConnectorScheduler:
         min would permanently understate how many blocks are saveable."""
         if not ledger.block_ids_per_group:
             return 0
-        return min(len(ledger.block_ids_per_group[meta.group_idx])
-                   for meta in self._group_metas)
+        return min(
+            len(ledger.block_ids_per_group[meta.group_idx])
+            for meta in self._group_metas
+        )
 
     # ------------------------------------------------------------------ #
     # External matching
@@ -165,9 +198,11 @@ class ConnectorScheduler:
         which is what makes the sparsity visible here.
         """
         names = {spec.get("name") for spec in location.get("location_specs", [])}
-        return all(spec_name(rank, group_idx) in names
-                   for rank in range(self._tp_size)
-                   for group_idx in self._state_group_idxs)
+        return all(
+            spec_name(rank, group_idx) in names
+            for rank in range(self._tp_size)
+            for group_idx in self._state_group_idxs
+        )
 
     def _external_match_burned(self, req_id: str) -> bool:
         """Has this request lost its option of an external match?
@@ -203,8 +238,9 @@ class ConnectorScheduler:
             return False
         return len(ledger.block_ids_per_group) > 1
 
-    def get_num_new_matched_tokens(self, request: "Request",
-                                   num_computed_tokens: int) -> Tuple[Optional[int], bool]:
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> Tuple[Optional[int], bool]:
         """Answer vLLM's per-request question: beyond the ``num_computed_tokens``
         it already has, how many more tokens can the external KV supply?
 
@@ -227,8 +263,10 @@ class ConnectorScheduler:
             # recompute. For this request the external match is burned --
             # see _external_match_burned for which signal burned it. Whatever
             # is left, vLLM recomputes locally.
-            logger.warning("req:%s re-queried after an external load attempt, "
-                           "skip external match", req_id)
+            logger.warning(
+                "req:%s re-queried after an external load attempt, skip external match",
+                req_id,
+            )
             # Hit accounting: this re-ask answers "no external match";
             # the local hit stands, the remote hit is spent.
             ledger = self._tracked.get(req_id)
@@ -239,13 +277,14 @@ class ConnectorScheduler:
 
         computed_blocks = num_computed_tokens // self._manager_block_size
         need_load_locations = self._location_query_manager.get_locations_for_query(
-            request, computed_blocks)
+            request, computed_blocks
+        )
         if need_load_locations is None:
             return None, False
 
         need_load_locations = self._safe_external_prefix(
-            req_id, need_load_locations,
-            num_computed_tokens, request.num_tokens)
+            req_id, need_load_locations, num_computed_tokens, request.num_tokens
+        )
         # Cache the clamped answer: the allocation consumes exactly this.
         self._location_query_manager.store_result(req_id, need_load_locations)
         new_matched_count = len(need_load_locations) * self._manager_block_size
@@ -264,8 +303,13 @@ class ConnectorScheduler:
         logger.info("req:%s matched %d external tokens", req_id, new_matched_count)
         return new_matched_count, new_matched_count > 0
 
-    def _safe_external_prefix(self, req_id: str, locations: List[dict],
-                              num_computed_tokens: int, num_tokens: int) -> List[dict]:
+    def _safe_external_prefix(
+        self,
+        req_id: str,
+        locations: List[dict],
+        num_computed_tokens: int,
+        num_tokens: int,
+    ) -> List[dict]:
         """Clamp an external match to the longest prefix vLLM can resume from.
 
         Two constraints, both only ever trimming the tail, so the answer is
@@ -284,7 +328,10 @@ class ConnectorScheduler:
         """
         # Cap: how many leading blocks may be matched at all.
         limit = len(locations)
-        while limit and num_computed_tokens + limit * self._manager_block_size >= num_tokens:
+        while (
+            limit
+            and num_computed_tokens + limit * self._manager_block_size >= num_tokens
+        ):
             limit -= 1
         # Within that allowance the match may only end on a block carrying
         # the recurrent state: scan for the last one.
@@ -293,13 +340,18 @@ class ConnectorScheduler:
             if self._location_covers_states(location):
                 keep = i + 1
         if keep < len(locations):
-            logger.info("req:%s truncated external match from %d to %d blocks "
-                        "(full-hit cap / no recurrent state at the end)",
-                        req_id, len(locations), keep)
+            logger.info(
+                "req:%s truncated external match from %d to %d blocks "
+                "(full-hit cap / no recurrent state at the end)",
+                req_id,
+                len(locations),
+                keep,
+            )
         return locations[:keep]
 
-    def update_state_after_alloc(self, request: "Request", blocks: "KVCacheBlocks",
-                                 num_external_tokens: int):
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
         """First (or re-) allocation: record the ledger and ship the load.
 
         The block tables arrive here whole, once per allocation; increments
@@ -333,7 +385,8 @@ class ConnectorScheduler:
                 f"req {req_id}: allocated for {num_external_tokens} external "
                 f"tokens but no cached location query exists; the match hook "
                 f"did not answer, or its answer was consumed/invalidated "
-                f"before this allocation")
+                f"before this allocation"
+            )
         locations, computed_blocks = consumed
         # Blocks were allocated for an external hit: the request is now
         # spending its external load (burns hybrid re-queries).
@@ -342,12 +395,14 @@ class ConnectorScheduler:
             return
         total_remote_blocks = computed_blocks + len(locations)
         ledger.has_saved_block_num = total_remote_blocks
-        self._waiting_to_load_requests.append(LoadRequest(
-            req_id=req_id,
-            manager_block_idxes=list(range(computed_blocks, total_remote_blocks)),
-            need_load_locations=locations,
-            all_block_ids=[list(b) for b in ledger.block_ids_per_group],
-        ))
+        self._waiting_to_load_requests.append(
+            LoadRequest(
+                req_id=req_id,
+                manager_block_idxes=list(range(computed_blocks, total_remote_blocks)),
+                need_load_locations=locations,
+                all_block_ids=[list(b) for b in ledger.block_ids_per_group],
+            )
+        )
 
     def update_connector_output(self, connector_output: "KVConnectorOutput"):
         """Consume the worker's step output: mark requests whose external
@@ -362,16 +417,24 @@ class ConnectorScheduler:
         if not invalid:
             return
         for req_id, ledger in self._tracked.items():
-            if any(b in invalid
-                   for group_ids in ledger.block_ids_per_group for b in group_ids):
+            if any(
+                b in invalid
+                for group_ids in ledger.block_ids_per_group
+                for b in group_ids
+            ):
                 self._load_failed.add(req_id)
-                logger.warning("req:%s external load failed (invalid blocks "
-                               "reached its block table)", req_id)
+                logger.warning(
+                    "req:%s external load failed (invalid blocks "
+                    "reached its block table)",
+                    req_id,
+                )
 
     # ------------------------------------------------------------------ #
     # Per-step metadata assembly and saving orchestration
     # ------------------------------------------------------------------ #
-    def build_connector_meta(self, scheduler_output: "SchedulerOutput") -> TairKvCacheConnectorMetadata:
+    def build_connector_meta(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> TairKvCacheConnectorMetadata:
         """Assemble one engine step's envelope (see TairKvCacheConnectorMetadata).
 
         Two sources feed the envelope: vLLM's scheduling output for this step
@@ -411,7 +474,8 @@ class ConnectorScheduler:
                 logger.warning(
                     "scheduled new req %s has no ledger (hook-order "
                     "contract broken?); its block table is not recorded",
-                    vllm_req.req_id)
+                    vllm_req.req_id,
+                )
                 continue
             ledger.block_ids_per_group = [list(b) for b in vllm_req.block_ids]
 
@@ -426,8 +490,11 @@ class ConnectorScheduler:
                 logger.warning(
                     "scheduled cached req %s has no ledger (resumed=%s, "
                     "scheduled_tokens=%d); its block increments are not "
-                    "recorded", req_id, resumed,
-                    scheduler_output.num_scheduled_tokens[req_id])
+                    "recorded",
+                    req_id,
+                    resumed,
+                    scheduler_output.num_scheduled_tokens[req_id],
+                )
                 continue
 
             if hasattr(cached_reqs, "resumed_req_ids"):
@@ -445,8 +512,9 @@ class ConnectorScheduler:
             if resumed:
                 ledger.block_ids_per_group = [list(b) for b in new_block_ids]
             else:
-                for group_ids, new_ids in zip(ledger.block_ids_per_group,
-                                              new_block_ids):
+                for group_ids, new_ids in zip(
+                    ledger.block_ids_per_group, new_block_ids
+                ):
                     group_ids.extend(new_ids)
 
     def _dispatch_incremental_saves(self) -> None:
@@ -469,26 +537,36 @@ class ConnectorScheduler:
             # the whole session. The allocated cap still bounds the other
             # way: under chunked prefill all_token_ids runs ahead of the
             # computed KV.
-            target_save_num = min(
-                len(ledger.vllm_request.all_token_ids),
-                self._num_allocated_blocks(ledger) * self._vllm_block_size) \
+            target_save_num = (
+                min(
+                    len(ledger.vllm_request.all_token_ids),
+                    self._num_allocated_blocks(ledger) * self._vllm_block_size,
+                )
                 // self._manager_block_size
+            )
             if target_save_num > ledger.has_saved_block_num:
-                logger.info("req:%s incremental save: %d -> %d blocks "
-                            "(tokens=%d, allocated=%d)",
-                            ledger.vllm_request.request_id,
-                            ledger.has_saved_block_num, target_save_num,
-                            len(ledger.vllm_request.all_token_ids),
-                            self._num_allocated_blocks(ledger))
+                logger.info(
+                    "req:%s incremental save: %d -> %d blocks "
+                    "(tokens=%d, allocated=%d)",
+                    ledger.vllm_request.request_id,
+                    ledger.has_saved_block_num,
+                    target_save_num,
+                    len(ledger.vllm_request.all_token_ids),
+                    self._num_allocated_blocks(ledger),
+                )
                 ledger.scheduled_saving_count += 1
                 # Per-block state completeness must be read here, in the
                 # scheduler loop: it comes from vLLM's block table, which the
                 # http_executor thread would race against later steps.
                 self._http_executor.submit(
-                    self.start_save_kvcache_async, ledger.vllm_request.request_id,
-                    ledger.vllm_request.all_token_ids[:target_save_num * self._manager_block_size],
+                    self.start_save_kvcache_async,
+                    ledger.vllm_request.request_id,
+                    ledger.vllm_request.all_token_ids[
+                        : target_save_num * self._manager_block_size
+                    ],
                     target_save_num,
-                    self._state_complete_mask(ledger, range(target_save_num)))
+                    self._state_complete_mask(ledger, range(target_save_num)),
+                )
             ledger.has_saved_block_num = target_save_num
 
     def _collect_load_instructions(self, meta: TairKvCacheConnectorMetadata) -> None:
@@ -515,7 +593,9 @@ class ConnectorScheduler:
         for save_req in new_save_reqs:
             ledger = self._tracked.get(save_req.req_id)
             if ledger is None:
-                logger.warning("request %s is not tracked, skip saving", save_req.req_id)
+                logger.warning(
+                    "request %s is not tracked, skip saving", save_req.req_id
+                )
                 continue
             # Snapshot the ledger for the worker: the gather translates
             # manager blocks into physical slots through these tables, and
@@ -523,8 +603,10 @@ class ConnectorScheduler:
             save_req.all_block_ids = [list(b) for b in ledger.block_ids_per_group]
             meta.add_save_request(save_req)
             ledger.sent_saving_count += 1
-            if (ledger.need_report_after_saving_finished and
-                    ledger.scheduled_saving_count == ledger.sent_saving_count):
+            if (
+                ledger.need_report_after_saving_finished
+                and ledger.scheduled_saving_count == ledger.sent_saving_count
+            ):
                 self._retire_request(save_req.req_id)
 
         self.handle_canceled_save_req()
@@ -545,8 +627,9 @@ class ConnectorScheduler:
         self._load_attempted.discard(req_id)
         self._location_query_manager.invalidate(req_id)
 
-    def start_save_kvcache_async(self, req_id, token_ids, target_save_num,
-                                 state_complete_mask):
+    def start_save_kvcache_async(
+        self, req_id, token_ids, target_save_num, state_complete_mask
+    ):
         """Ask the manager for write locations for a request's first
         ``target_save_num`` manager blocks.
 
@@ -565,14 +648,20 @@ class ConnectorScheduler:
         }
         if self._state_group_idxs:
             assert len(state_complete_mask) == target_save_num, (
-                f"state mask {len(state_complete_mask)} != {target_save_num} blocks")
+                f"state mask {len(state_complete_mask)} != {target_save_num} blocks"
+            )
             request["location_spec_group_names"] = [
                 ALL_SPEC_GROUP if complete else ATTN_ONLY_SPEC_GROUP
-                for complete in state_complete_mask]
+                for complete in state_complete_mask
+            ]
             if not all(state_complete_mask):
-                logger.info("req:%s saving %d/%d blocks without a recurrent "
-                            "state (attention specs only)", req_id,
-                            state_complete_mask.count(False), target_save_num)
+                logger.info(
+                    "req:%s saving %d/%d blocks without a recurrent "
+                    "state (attention specs only)",
+                    req_id,
+                    state_complete_mask.count(False),
+                    target_save_num,
+                )
         try:
             response = self._manager_client.start_write_cache(request)
         except Exception as e:
@@ -586,40 +675,65 @@ class ConnectorScheduler:
         mask = response.get("block_mask") or {}
         if "bool_masks" in mask:
             values = mask["bool_masks"].get("values", [])
-            mask_summary = (f"bool_masks offset={mask['bool_masks'].get('offset')} "
-                            f"total={len(values)} "
-                            f"existing={sum(1 for v in values if v)}")
+            mask_summary = (
+                f"bool_masks offset={mask['bool_masks'].get('offset')} "
+                f"total={len(values)} "
+                f"existing={sum(1 for v in values if v)}"
+            )
         else:
             mask_summary = f"offset={mask.get('offset')}"
-        logger.info("req:%s save session %s: block_mask %s locations=%d",
-                    req_id, write_session_id[:8], mask_summary, len(locations))
-        logger.debug("req:%s save session %s: block_mask=%s locations=%d",
-                     req_id, write_session_id[:8],
-                     response.get("block_mask"), len(locations))
+        logger.info(
+            "req:%s save session %s: block_mask %s locations=%d",
+            req_id,
+            write_session_id[:8],
+            mask_summary,
+            len(locations),
+        )
+        logger.debug(
+            "req:%s save session %s: block_mask=%s locations=%d",
+            req_id,
+            write_session_id[:8],
+            response.get("block_mask"),
+            len(locations),
+        )
 
         if not locations:
             try:
-                self._manager_client.finish_write_cache({
-                    "trace_id": "finish_%s" % write_session_id[:8],
-                    "instance_id": self._extra_config.instance_id,
-                    "write_session_id": write_session_id,
-                    "success_blocks": {"bool_masks": {"offset": 0}},
-                })
+                self._manager_client.finish_write_cache(
+                    {
+                        "trace_id": "finish_%s" % write_session_id[:8],
+                        "instance_id": self._extra_config.instance_id,
+                        "write_session_id": write_session_id,
+                        "success_blocks": {"bool_masks": {"offset": 0}},
+                    }
+                )
             except Exception as e:
-                logger.warning("finish_write_cache failed, session: %s, error: %s",
-                               write_session_id, e)
+                logger.warning(
+                    "finish_write_cache failed, session: %s, error: %s",
+                    write_session_id,
+                    e,
+                )
             with self._canceled_save_request_ids_lock:
                 self._canceled_save_request_ids.append(req_id)
             return
 
-        need_block_idx = self.parse_block_mask_to_save_indices(response, target_save_num)
-        message = CoordinateMessage(time.time(), SendBlockStartEvent(
-            request_id=req_id, write_session_id=write_session_id, locations=locations))
+        need_block_idx = self.parse_block_mask_to_save_indices(
+            response, target_save_num
+        )
+        message = CoordinateMessage(
+            time.time(),
+            SendBlockStartEvent(
+                request_id=req_id,
+                write_session_id=write_session_id,
+                locations=locations,
+            ),
+        )
         self._coordinator_client.send(CoordinateMsgSerializer.dumps(message))
 
         with self._waiting_to_save_requests_lock:
-            self._waiting_to_save_requests.append(SaveRequest(
-                req_id, locations, need_block_idx, write_session_id))
+            self._waiting_to_save_requests.append(
+                SaveRequest(req_id, locations, need_block_idx, write_session_id)
+            )
 
     def handle_canceled_save_req(self):
         with self._canceled_save_request_ids_lock:
@@ -633,15 +747,19 @@ class ConnectorScheduler:
                 logger.warning("canceled save for unknown request %s, skip", req_id)
                 continue
             ledger.sent_saving_count += 1
-            if (ledger.need_report_after_saving_finished and
-                    ledger.scheduled_saving_count == ledger.sent_saving_count):
+            if (
+                ledger.need_report_after_saving_finished
+                and ledger.scheduled_saving_count == ledger.sent_saving_count
+            ):
                 self._retire_request(req_id)
 
     def get_finished_count(self):
         # Only rank0 reports finished requests.
         return 1
 
-    def parse_block_mask_to_save_indices(self, response: dict, target_save_num: int) -> List[int]:
+    def parse_block_mask_to_save_indices(
+        self, response: dict, target_save_num: int
+    ) -> List[int]:
         block_mask = response.get("block_mask", {})
         if "offset" in block_mask:
             return list(range(block_mask["offset"], target_save_num))
@@ -652,12 +770,13 @@ class ConnectorScheduler:
     # Request finish
     # ------------------------------------------------------------------ #
     def request_finished_all_groups(
-            self, request: "Request",
-            block_ids: Tuple[List[int], ...]) -> Tuple[bool, Optional[dict]]:
+        self, request: "Request", block_ids: Tuple[List[int], ...]
+    ) -> Tuple[bool, Optional[dict]]:
         return self._finish_request(request)
 
-    def request_finished(self, request: "Request",
-                         block_ids: List[int]) -> Tuple[bool, Optional[dict]]:
+    def request_finished(
+        self, request: "Request", block_ids: List[int]
+    ) -> Tuple[bool, Optional[dict]]:
         return self._finish_request(request)
 
     def _finish_request(self, request: "Request") -> Tuple[bool, Optional[dict]]:

--- a/kv_cache_manager/py_connector/vllm/connector_scheduler.py
+++ b/kv_cache_manager/py_connector/vllm/connector_scheduler.py
@@ -17,17 +17,19 @@ speak the vllm_common vocabulary.
 
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 from kv_cache_manager.py_connector.common.logger import logger
+from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
 from kv_cache_manager.py_connector.common.tp_coordinator import (
     CoordinateMsgSerializer,
     CoordinateMessage,
     SendBlockStartEvent,
     TpCoordinatorClient,
 )
+from kv_cache_manager.py_connector.vllm.config import TairKvCacheConnectorExtraConfig
 from kv_cache_manager.py_connector.vllm.location_query_manager import (
     LocationQueryManager,
 )
@@ -87,14 +89,14 @@ class ConnectorScheduler:
 
     def __init__(
         self,
-        extra_config,
+        extra_config: TairKvCacheConnectorExtraConfig,
         group_metas: List[GroupMeta],
         manager_block_size: int,
         vllm_block_size: int,
         tp_size: int,
-        manager_client,
+        manager_client: KvCacheManagerClient,
         coordinator_client: TpCoordinatorClient,
-    ):
+    ) -> None:
         self._extra_config = extra_config
         self._group_metas = group_metas
         self._num_groups = len(group_metas)
@@ -130,7 +132,7 @@ class ConnectorScheduler:
         self._load_failed: set = set()
         self._load_attempted: set = set()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         self._location_query_manager.shutdown()
         self._http_executor.shutdown(wait=False)
 
@@ -148,7 +150,7 @@ class ConnectorScheduler:
         raise KeyError(f"no such transferred group: {group_idx}")
 
     def _state_complete_mask(
-        self, ledger: RequestLedger, manager_block_idxes
+        self, ledger: RequestLedger, manager_block_idxes: Sequence[int]
     ) -> List[bool]:
         """Per manager block: does *every* state group hold a real state?
 
@@ -351,7 +353,7 @@ class ConnectorScheduler:
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
-    ):
+    ) -> None:
         """First (or re-) allocation: record the ledger and ship the load.
 
         The block tables arrive here whole, once per allocation; increments
@@ -404,7 +406,7 @@ class ConnectorScheduler:
             )
         )
 
-    def update_connector_output(self, connector_output: "KVConnectorOutput"):
+    def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
         """Consume the worker's step output: mark requests whose external
         load failed, at request granularity.
 
@@ -561,7 +563,9 @@ class ConnectorScheduler:
                 self._http_executor.submit(
                     self.start_save_kvcache_async,
                     ledger.vllm_request.request_id,
-                    ledger.vllm_request.all_token_ids[
+                    # vLLM types all_token_ids as list[ConstantList | int];
+                    # at runtime it only ever holds ints.
+                    ledger.vllm_request.all_token_ids[  # ty: ignore[invalid-argument-type]
                         : target_save_num * self._manager_block_size
                     ],
                     target_save_num,
@@ -628,8 +632,12 @@ class ConnectorScheduler:
         self._location_query_manager.invalidate(req_id)
 
     def start_save_kvcache_async(
-        self, req_id, token_ids, target_save_num, state_complete_mask
-    ):
+        self,
+        req_id: str,
+        token_ids: List[int],
+        target_save_num: int,
+        state_complete_mask: List[bool],
+    ) -> None:
         """Ask the manager for write locations for a request's first
         ``target_save_num`` manager blocks.
 
@@ -735,7 +743,7 @@ class ConnectorScheduler:
                 SaveRequest(req_id, locations, need_block_idx, write_session_id)
             )
 
-    def handle_canceled_save_req(self):
+    def handle_canceled_save_req(self) -> None:
         with self._canceled_save_request_ids_lock:
             canceled = self._canceled_save_request_ids
             self._canceled_save_request_ids = []
@@ -753,7 +761,7 @@ class ConnectorScheduler:
             ):
                 self._retire_request(req_id)
 
-    def get_finished_count(self):
+    def get_finished_count(self) -> int:
         # Only rank0 reports finished requests.
         return 1
 

--- a/kv_cache_manager/py_connector/vllm/connector_worker.py
+++ b/kv_cache_manager/py_connector/vllm/connector_worker.py
@@ -20,16 +20,33 @@ from vllm.distributed import get_tensor_model_parallel_rank
 
 from kv_cache_manager.py_connector.common.logger import logger
 from kv_cache_manager.py_connector.common.tp_coordinator import (
-    SaveContext, TpCoordinatorClient, TpCoordinatorServer)
+    SaveContext,
+    TpCoordinatorClient,
+    TpCoordinatorServer,
+)
 from kv_cache_manager.py_connector.vllm.data_transfer import (
-    MultiResult, DataTransferManager, _get_device_module)
+    MultiResult,
+    DataTransferManager,
+    _get_device_module,
+)
 from kv_cache_manager.py_connector.vllm.metadata import (
-    FinishRequest, TairKvCacheConnectorMetadata)
+    FinishRequest,
+    TairKvCacheConnectorMetadata,
+)
 from kv_cache_manager.py_connector.vllm.transfer_types import (
-    AttentionTransferGroup, KVCacheInfo, StateTransferGroup, TransferGroup,
-    TransferPlan)
+    AttentionTransferGroup,
+    KVCacheInfo,
+    StateTransferGroup,
+    TransferGroup,
+    TransferPlan,
+)
 from kv_cache_manager.py_connector.vllm.vllm_common import (
-    AttentionGroupMeta, GroupMeta, StateGroupMeta, attn_kv_views, spec_name)
+    AttentionGroupMeta,
+    GroupMeta,
+    StateGroupMeta,
+    attn_kv_views,
+    spec_name,
+)
 
 if typing.TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
@@ -39,10 +56,17 @@ if typing.TYPE_CHECKING:
 class ConnectorWorker:
     """State and hooks for the worker-role connector instance (one per TP rank)."""
 
-    def __init__(self, extra_config, group_metas: List[GroupMeta],
-                 manager_block_size: int, tp_size: int, host_ip: str,
-                 manager_client, coordinator_client: TpCoordinatorClient,
-                 register_response: dict):
+    def __init__(
+        self,
+        extra_config,
+        group_metas: List[GroupMeta],
+        manager_block_size: int,
+        tp_size: int,
+        host_ip: str,
+        manager_client,
+        coordinator_client: TpCoordinatorClient,
+        register_response: dict,
+    ):
         self._extra_config = extra_config
         self._group_metas = group_metas
         self._num_groups = len(group_metas)
@@ -62,7 +86,8 @@ class ConnectorWorker:
         port = extra_config.coordinator_base_port
         if self._tp_rank == 0:
             self._coordinator_server = TpCoordinatorServer(
-                host_ip, port, tp_size, self.on_save_finished)
+                host_ip, port, tp_size, self.on_save_finished
+            )
 
         self._self_spec_names = {
             meta.group_idx: spec_name(self._tp_rank, meta.group_idx)
@@ -93,16 +118,26 @@ class ConnectorWorker:
         }
         init_params = kvcm_py_client.InitParams()
         init_params.role_type = kvcm_py_client.RoleType.WORKER
-        init_params.self_location_spec_name = self._self_spec_names[self._group_metas[0].group_idx]
+        init_params.self_location_spec_name = self._self_spec_names[
+            self._group_metas[0].group_idx
+        ]
         init_params.storage_configs = f"{self._storage_configs}"
         transfer_client_config = json.dumps(transfer_client_json)
         logger.info("transfer_client_config: %s", transfer_client_config)
         self._transfer_client = kvcm_py_client.TransferClient.Create(
-            transfer_client_config, init_params)
-        assert self._transfer_client is not None, "kvcm_py_client.TransferClient.Create failed"
+            transfer_client_config, init_params
+        )
+        assert self._transfer_client is not None, (
+            "kvcm_py_client.TransferClient.Create failed"
+        )
         logger.warning(
             "TairKvCacheConnector worker inited, tp rank: %d/%d, host: %s:%d, groups: %d",
-            self._tp_rank, self._tp_size, host_ip, port, self._num_groups)
+            self._tp_rank,
+            self._tp_size,
+            host_ip,
+            port,
+            self._num_groups,
+        )
 
     # ------------------------------------------------------------------ #
     # Storage config plumbing
@@ -114,15 +149,17 @@ class ConnectorWorker:
             if storage_config["type"] == "vcns_hf3fs":
                 storage_config["type"] = "hf3fs"
             if storage_config["type"] == "hf3fs" and storage_config["is_available"]:
-                hf3fs_configs.append({
-                    "type": storage_config["type"],
-                    "mountpoint": storage_config["storage_spec"]["mountpoint"],
-                    "root_dir": storage_config["storage_spec"]["root_dir"],
-                    "read_iov_block_size": self._extra_config.read_iov_block_size,
-                    "read_iov_size": self._iov_size,
-                    "write_iov_block_size": self._extra_config.write_iov_block_size,
-                    "write_iov_size": self._iov_size,
-                })
+                hf3fs_configs.append(
+                    {
+                        "type": storage_config["type"],
+                        "mountpoint": storage_config["storage_spec"]["mountpoint"],
+                        "root_dir": storage_config["storage_spec"]["root_dir"],
+                        "read_iov_block_size": self._extra_config.read_iov_block_size,
+                        "read_iov_size": self._iov_size,
+                        "write_iov_block_size": self._extra_config.write_iov_block_size,
+                        "write_iov_size": self._iov_size,
+                    }
+                )
         self._storage_configs = json.dumps(storage_configs_json)
         return hf3fs_configs
 
@@ -131,10 +168,12 @@ class ConnectorWorker:
     # ------------------------------------------------------------------ #
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         self._kv_caches = kv_caches
-        first_attn = next(kv_caches[name]
-                          for meta in self._group_metas
-                          if isinstance(meta, AttentionGroupMeta)
-                          for name in meta.layer_names)
+        first_attn = next(
+            kv_caches[name]
+            for meta in self._group_metas
+            if isinstance(meta, AttentionGroupMeta)
+            for name in meta.layer_names
+        )
         self._dtype = first_attn.dtype
         self._device = first_attn.device
         self._device_mod = _get_device_module(self._device)
@@ -154,21 +193,31 @@ class ConnectorWorker:
             dtype=self._dtype,
         )
         self._data_transfer = DataTransferManager(
-            self._kvcache_info, self._manager_block_size,
-            self._transfer_client, self._coordinator_client, self._extra_config)
+            self._kvcache_info,
+            self._manager_block_size,
+            self._transfer_client,
+            self._coordinator_client,
+            self._extra_config,
+        )
 
-        logger.warning("register_kv_caches done: %s", [
-            (g.spec_name, type(g).__name__, g.layer_num, g.per_block_bytes)
-            for g in groups])
+        logger.warning(
+            "register_kv_caches done: %s",
+            [
+                (g.spec_name, type(g).__name__, g.layer_num, g.per_block_bytes)
+                for g in groups
+            ],
+        )
 
-    def _build_attention_group(self, meta: AttentionGroupMeta,
-                               kv_caches) -> AttentionTransferGroup:
+    def _build_attention_group(
+        self, meta: AttentionGroupMeta, kv_caches
+    ) -> AttentionTransferGroup:
         spec = self._self_spec_names[meta.group_idx]
         tensors = [kv_caches[name] for name in meta.layer_names]
         ref = tensors[0]
         for t in tensors:
-            assert t.shape == ref.shape and t.stride() == ref.stride(), \
+            assert t.shape == ref.shape and t.stride() == ref.stride(), (
                 "attention layers in one group must share shape/stride"
+            )
         # Normalize the layout into per-pointer token-major views of shape
         # (num_blocks, kernel_block_size, heads, content_dim); everything
         # below is layout-independent. Split-K/V layouts (vllm <= 0.25.x)
@@ -177,17 +226,19 @@ class ConnectorWorker:
         ref_views, kv_layout = attn_kv_views(ref)
         view = ref_views[0]
         kernel_block_size = view.shape[1]
-        assert meta.block_size % kernel_block_size == 0, \
-            f"group block size {meta.block_size} not a multiple of kernel " \
+        assert meta.block_size % kernel_block_size == 0, (
+            f"group block size {meta.block_size} not a multiple of kernel "
             f"block size {kernel_block_size}"
+        )
         per_token_dim = view.shape[2] * view.shape[3]  # heads * content_dim
         # The gather/scatter kernel needs token-major memory inside a page:
         # logical dims (blk, tok, head, dim) contiguous within a block. This
         # is vLLM's NHD order; HND would interleave heads across tokens.
         for v in ref_views:
-            assert v.stride()[1:] == (per_token_dim, v.shape[3], 1), \
-                f"kv cache page not token-major: shape={tuple(v.shape)} " \
+            assert v.stride()[1:] == (per_token_dim, v.shape[3], 1), (
+                f"kv cache page not token-major: shape={tuple(v.shape)} "
                 f"stride={v.stride()}; set VLLM_KV_CACHE_LAYOUT=NHD"
+            )
         # Non-flat block layouts (page_size_padded gaps, or split K/V
         # interleaved per block as in the 5-D N-first layout) go through the
         # kernel's strided path. Stride 0 = fast flat indexing.
@@ -197,7 +248,9 @@ class ConnectorWorker:
         # [L0, L1, ...] for the packed layout; each view's data_ptr() is its
         # own storage base, so the kernel never adds a K->V offset.
         ptrs = [v.data_ptr() for t in tensors for v in attn_kv_views(t)[0]]
-        ptr_tensor = torch.tensor(ptrs, dtype=torch.int64, device="cpu").to(self._device)
+        ptr_tensor = torch.tensor(ptrs, dtype=torch.int64, device="cpu").to(
+            self._device
+        )
         return AttentionTransferGroup(
             group_idx=meta.group_idx,
             spec_name=spec,
@@ -213,25 +266,29 @@ class ConnectorWorker:
             block_stride=block_stride,
         )
 
-    def _build_state_group(self, meta: StateGroupMeta,
-                           kv_caches) -> StateTransferGroup:
+    def _build_state_group(self, meta: StateGroupMeta, kv_caches) -> StateTransferGroup:
         # Mamba/state group: each layer is a list[Tensor] sharing one storage;
         # rebuild a (num_blocks, page_size_bytes) byte view for opaque copy.
         spec = self._self_spec_names[meta.group_idx]
         block_views = []
         for name in meta.layer_names:
             states = kv_caches[name]
-            assert isinstance(states, (list, tuple)) and len(states) > 0, \
+            assert isinstance(states, (list, tuple)) and len(states) > 0, (
                 f"state layer {name} should be a list of tensors"
+            )
             storage = states[0].untyped_storage()
             for st in states[1:]:
-                assert st.untyped_storage().data_ptr() == storage.data_ptr(), \
+                assert st.untyped_storage().data_ptr() == storage.data_ptr(), (
                     f"state layer {name}: tensors do not share storage"
+                )
             num_blocks = states[0].shape[0]
             need = num_blocks * meta.page_size_bytes
-            assert storage.nbytes() >= need, \
+            assert storage.nbytes() >= need, (
                 f"state layer {name}: storage {storage.nbytes()} < {need}"
-            byte_view = torch.tensor([], dtype=torch.uint8, device=self._device).set_(storage)
+            )
+            byte_view = torch.tensor([], dtype=torch.uint8, device=self._device).set_(
+                storage
+            )
             block_views.append(byte_view[:need].view(num_blocks, meta.page_size_bytes))
         return StateTransferGroup(
             group_idx=meta.group_idx,
@@ -247,8 +304,9 @@ class ConnectorWorker:
     # ------------------------------------------------------------------ #
     # Block index translation
     # ------------------------------------------------------------------ #
-    def _attn_token_indices(self, group: AttentionTransferGroup, manager_block_idxes,
-                            block_table) -> List[List[int]]:
+    def _attn_token_indices(
+        self, group: AttentionTransferGroup, manager_block_idxes, block_table
+    ) -> List[List[int]]:
         """Map manager blocks to flat token slots of one attention group.
 
         Three-tier hierarchy:
@@ -268,15 +326,17 @@ class ConnectorWorker:
                 tok = base + i
                 logical = tok // gbs
                 assert logical < len(block_table), (
-                    f"group block {logical} out of range (len={len(block_table)})")
+                    f"group block {logical} out of range (len={len(block_table)})"
+                )
                 off = tok % gbs
                 phys = block_table[logical] * ratio + off // kbs
                 idxs.append(phys * kbs + off % kbs)
             out.append(idxs)
         return out
 
-    def _state_block_ids(self, group: StateTransferGroup, manager_block_idxes,
-                         block_table) -> List[int]:
+    def _state_block_ids(
+        self, group: StateTransferGroup, manager_block_idxes, block_table
+    ) -> List[int]:
         """Map manager blocks to block ids of a state (mamba) group.
 
         State is stored once per group block and covers the whole prefix up to
@@ -295,7 +355,8 @@ class ConnectorWorker:
         for mb in manager_block_idxes:
             logical = ((mb + 1) * mbs - 1) // gbs
             assert logical < len(block_table), (
-                f"group block {logical} out of range (len={len(block_table)})")
+                f"group block {logical} out of range (len={len(block_table)})"
+            )
             out.append(block_table[logical])
         return out
 
@@ -311,13 +372,18 @@ class ConnectorWorker:
             n = len(plan.uris)
             for i in range(0, n, per_task):
                 end = min(n, i + per_task)
-                yield (plan.group,
-                       plan.uris[i:end],
-                       plan.token_indices[i:end] if plan.token_indices is not None else None,
-                       plan.block_ids[i:end] if plan.block_ids is not None else None)
+                yield (
+                    plan.group,
+                    plan.uris[i:end],
+                    plan.token_indices[i:end]
+                    if plan.token_indices is not None
+                    else None,
+                    plan.block_ids[i:end] if plan.block_ids is not None else None,
+                )
 
-    def _plan_group_transfers(self, locations, manager_block_idxes,
-                              block_ids_per_group) -> Optional[List[TransferPlan]]:
+    def _plan_group_transfers(
+        self, locations, manager_block_idxes, block_ids_per_group
+    ) -> Optional[List[TransferPlan]]:
         """Build the per-group TransferPlans for a set of manager blocks.
 
         ``uris`` is positionally aligned with ``manager_block_idxes`` and may
@@ -330,15 +396,17 @@ class ConnectorWorker:
         """
         num_blocks = len(manager_block_idxes)
         if len(locations) != num_blocks:
-            logger.warning("%d locations for %d blocks, skip transfer",
-                           len(locations), num_blocks)
+            logger.warning(
+                "%d locations for %d blocks, skip transfer", len(locations), num_blocks
+            )
             return None
         # One pass over the locations: per block, map spec name -> uri. The
         # per-group extraction below then reads by name instead of rescanning
         # every location's spec list for every group.
         per_block_uri_maps = [
             {s["name"]: s["uri"] for s in location.get("location_specs", [])}
-            for location in locations]
+            for location in locations
+        ]
         self._check_block_table_covers(block_ids_per_group)
         plans = []
         for group in self._kvcache_info.groups:
@@ -346,15 +414,25 @@ class ConnectorWorker:
             # block_ids_per_group is indexed by the vLLM group index.
             block_table = block_ids_per_group[group.group_idx]
             if isinstance(group, AttentionTransferGroup):
-                plans.append(TransferPlan(
-                    group=group, uris=uris,
-                    token_indices=self._attn_token_indices(
-                        group, manager_block_idxes, block_table)))
+                plans.append(
+                    TransferPlan(
+                        group=group,
+                        uris=uris,
+                        token_indices=self._attn_token_indices(
+                            group, manager_block_idxes, block_table
+                        ),
+                    )
+                )
             else:
-                plans.append(TransferPlan(
-                    group=group, uris=uris,
-                    block_ids=self._state_block_ids(
-                        group, manager_block_idxes, block_table)))
+                plans.append(
+                    TransferPlan(
+                        group=group,
+                        uris=uris,
+                        block_ids=self._state_block_ids(
+                            group, manager_block_idxes, block_table
+                        ),
+                    )
+                )
         return plans
 
     def _check_block_table_covers(self, block_ids_per_group) -> None:
@@ -370,17 +448,24 @@ class ConnectorWorker:
         assert len(block_ids_per_group) > need, (
             f"block table has {len(block_ids_per_group)} groups but the "
             f"connector transfers vLLM group {need}; the group-index "
-            f"alignment between vLLM and this connector is broken")
+            f"alignment between vLLM and this connector is broken"
+        )
 
-    def start_load_kv(self, forward_context: "ForwardContext",
-                      meta: TairKvCacheConnectorMetadata, **kwargs) -> None:
+    def start_load_kv(
+        self,
+        forward_context: "ForwardContext",
+        meta: TairKvCacheConnectorMetadata,
+        **kwargs,
+    ) -> None:
         for load_req in meta.to_load_requests:
             if not load_req.need_load_locations:
                 continue
             num_blocks = len(load_req.manager_block_idxes)
             plans = self._plan_group_transfers(
-                load_req.need_load_locations, load_req.manager_block_idxes,
-                load_req.all_block_ids)
+                load_req.need_load_locations,
+                load_req.manager_block_idxes,
+                load_req.all_block_ids,
+            )
 
             # Report failures against the block table vLLM can act on: map each
             # manager block to the logical block holding its first token. vLLM
@@ -417,18 +502,26 @@ class ConnectorWorker:
                 assert isinstance(only, AttentionGroupMeta), (
                     f"single vLLM block table but the transferred group is "
                     f"{type(only).__name__}, not attention; cannot report "
-                    f"invalid blocks")
+                    f"invalid blocks"
+                )
                 assert only.group_idx == 0, (
                     f"single vLLM block table but the transferred group is "
-                    f"group {only.group_idx}; group-index alignment broken")
+                    f"group {only.group_idx}; group-index alignment broken"
+                )
                 table = load_req.all_block_ids[0]
                 gbs = only.block_size
-                report_ids = [table[(mb * self._manager_block_size) // gbs]
-                              for mb in load_req.manager_block_idxes]
+                report_ids = [
+                    table[(mb * self._manager_block_size) // gbs]
+                    for mb in load_req.manager_block_idxes
+                ]
             done_cb = self._data_transfer.create_load_done_callback(
-                load_req.req_id, self._tp_rank, meta.epoch,
-                copy.copy(report_ids), num_blocks,
-                report_failures=report_failures)
+                load_req.req_id,
+                self._tp_rank,
+                meta.epoch,
+                copy.copy(report_ids),
+                num_blocks,
+                report_failures=report_failures,
+            )
 
             if plans is None:
                 # Nothing submitted; report the whole load as failed.
@@ -436,18 +529,25 @@ class ConnectorWorker:
                 mr.submit_result(0, [False] * num_blocks * self._num_groups)
                 continue
 
-            chunks = list(self._iter_task_chunks(
-                plans, self._extra_config.block_per_load_task))
+            chunks = list(
+                self._iter_task_chunks(plans, self._extra_config.block_per_load_task)
+            )
             multi_result = MultiResult(len(chunks), done_cb)
             for task_idx, chunk in enumerate(chunks):
                 self._data_transfer.submit_task(
-                    self._data_transfer.load_task, multi_result, task_idx, *chunk)
+                    self._data_transfer.load_task, multi_result, task_idx, *chunk
+                )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         pass
 
-    def save_kv_layer(self, layer_name: str, kv_layer: torch.Tensor,
-                      attn_metadata: "AttentionMetadata", **kwargs) -> None:
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: "AttentionMetadata",
+        **kwargs,
+    ) -> None:
         pass
 
     def wait_for_save(self, meta: TairKvCacheConnectorMetadata):
@@ -459,50 +559,70 @@ class ConnectorWorker:
         for save_req in meta.to_save_requests:
             num_blocks = len(save_req.manager_block_idxes)
             plans = self._plan_group_transfers(
-                save_req.target_locations, save_req.manager_block_idxes,
-                save_req.all_block_ids)
+                save_req.target_locations,
+                save_req.manager_block_idxes,
+                save_req.all_block_ids,
+            )
 
             done_cb = self._data_transfer.create_save_done_callback(
-                save_req.req_id, self._tp_rank, save_req.write_session_id, num_blocks)
+                save_req.req_id, self._tp_rank, save_req.write_session_id, num_blocks
+            )
 
             if plans is None:
                 mr = MultiResult(1, done_cb)
                 mr.submit_result(0, [False] * num_blocks * self._num_groups)
                 continue
 
-            chunks = list(self._iter_task_chunks(
-                plans, self._extra_config.block_per_save_task))
+            chunks = list(
+                self._iter_task_chunks(plans, self._extra_config.block_per_save_task)
+            )
             multi_result = MultiResult(len(chunks), done_cb)
             for task_idx, chunk in enumerate(chunks):
                 self._data_transfer.submit_task(
-                    self._data_transfer.save_task, multi_result, task_idx,
-                    *chunk, ready_event)
+                    self._data_transfer.save_task,
+                    multi_result,
+                    task_idx,
+                    *chunk,
+                    ready_event,
+                )
             if self._tp_rank == 0:
                 # One session in flight; the coordinator's completion event
                 # for this req decrements it (see get_finished).
-                self._pending_saves[save_req.req_id] = \
+                self._pending_saves[save_req.req_id] = (
                     self._pending_saves.get(save_req.req_id, 0) + 1
+                )
 
     def on_save_finished(self, write_session_id: str, save_context: SaveContext):
         for block_idx in range(len(save_context.locations)):
-            fully_saved = all(save_context.result_per_rank[rank][block_idx]
-                              for rank in range(self._tp_size))
+            fully_saved = all(
+                save_context.result_per_rank[rank][block_idx]
+                for rank in range(self._tp_size)
+            )
             save_context.success_mask.append(fully_saved)
-        logger.debug("finish_write_cache mask:%s session:%s",
-                     save_context.success_mask, write_session_id)
+        logger.debug(
+            "finish_write_cache mask:%s session:%s",
+            save_context.success_mask,
+            write_session_id,
+        )
         try:
-            self._manager_client.finish_write_cache({
-                "trace_id": "finish_%s" % write_session_id[:8],
-                "instance_id": self._extra_config.instance_id,
-                "write_session_id": write_session_id,
-                "success_blocks": {"bool_masks": {"values": save_context.success_mask}},
-            })
+            self._manager_client.finish_write_cache(
+                {
+                    "trace_id": "finish_%s" % write_session_id[:8],
+                    "instance_id": self._extra_config.instance_id,
+                    "write_session_id": write_session_id,
+                    "success_blocks": {
+                        "bool_masks": {"values": save_context.success_mask}
+                    },
+                }
+            )
         except Exception as e:
-            logger.warning("finish_write_cache failed, session: %s, error: %s",
-                           write_session_id, e)
+            logger.warning(
+                "finish_write_cache failed, session: %s, error: %s", write_session_id, e
+            )
 
-    def get_finished(self, finished_req_ids: set,
-                     meta: TairKvCacheConnectorMetadata) -> Tuple[Optional[set], Optional[set]]:
+    def get_finished(
+        self, finished_req_ids: set, meta: TairKvCacheConnectorMetadata
+    ) -> Tuple[Optional[set], Optional[set]]:
         """Report request completion to vLLM.
 
         A request is reported once its last save session has settled on the
@@ -517,7 +637,9 @@ class ConnectorWorker:
             return None, None
 
         finished_saving = []
-        finished_saving_tasks, finished_loading_tasks = self._coordinator_server.get_finished_tasks()
+        finished_saving_tasks, finished_loading_tasks = (
+            self._coordinator_server.get_finished_tasks()
+        )
         for req_id in finished_saving_tasks:
             remaining = self._pending_saves.get(req_id, 0) - 1
             if remaining > 0:

--- a/kv_cache_manager/py_connector/vllm/connector_worker.py
+++ b/kv_cache_manager/py_connector/vllm/connector_worker.py
@@ -11,28 +11,28 @@ shell.
 import copy
 import json
 import typing
-from typing import List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
 
-from kv_cache_manager.client.pybind import kvcm_py_client
+# kvcm_py_client is the compiled pybind11 client; it ships no type stubs.
+from kv_cache_manager.client.pybind import kvcm_py_client  # ty: ignore[unresolved-import]
 
 import torch
 from vllm.distributed import get_tensor_model_parallel_rank
 
 from kv_cache_manager.py_connector.common.logger import logger
+from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
 from kv_cache_manager.py_connector.common.tp_coordinator import (
     SaveContext,
     TpCoordinatorClient,
     TpCoordinatorServer,
 )
+from kv_cache_manager.py_connector.vllm.config import TairKvCacheConnectorExtraConfig
 from kv_cache_manager.py_connector.vllm.data_transfer import (
     MultiResult,
     DataTransferManager,
     _get_device_module,
 )
-from kv_cache_manager.py_connector.vllm.metadata import (
-    FinishRequest,
-    TairKvCacheConnectorMetadata,
-)
+from kv_cache_manager.py_connector.vllm.metadata import TairKvCacheConnectorMetadata
 from kv_cache_manager.py_connector.vllm.transfer_types import (
     AttentionTransferGroup,
     KVCacheInfo,
@@ -50,7 +50,10 @@ from kv_cache_manager.py_connector.vllm.vllm_common import (
 
 if typing.TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
-    from vllm.attention import AttentionMetadata
+
+    # vllm.attention no longer exists in vLLM >= 0.26; kept for the older
+    # eras this connector supports.
+    from vllm.attention import AttentionMetadata  # ty: ignore[unresolved-import]
 
 
 class ConnectorWorker:
@@ -58,15 +61,15 @@ class ConnectorWorker:
 
     def __init__(
         self,
-        extra_config,
+        extra_config: TairKvCacheConnectorExtraConfig,
         group_metas: List[GroupMeta],
         manager_block_size: int,
         tp_size: int,
         host_ip: str,
-        manager_client,
+        manager_client: KvCacheManagerClient,
         coordinator_client: TpCoordinatorClient,
-        register_response: dict,
-    ):
+        register_response: Dict[str, Any],
+    ) -> None:
         self._extra_config = extra_config
         self._group_metas = group_metas
         self._num_groups = len(group_metas)
@@ -82,7 +85,9 @@ class ConnectorWorker:
         self._finish_pending: set = set()
 
         self._tp_rank = get_tensor_model_parallel_rank()
-        self._device_mod = None
+        # torch device module (torch.cuda / torch.musa / ...), set in
+        # register_kv_caches; Any because the module surface is dynamic.
+        self._device_mod: Any = None
         port = extra_config.coordinator_base_port
         if self._tp_rank == 0:
             self._coordinator_server = TpCoordinatorServer(
@@ -142,8 +147,8 @@ class ConnectorWorker:
     # ------------------------------------------------------------------ #
     # Storage config plumbing
     # ------------------------------------------------------------------ #
-    def parse_hf3fs_configs(self, storage_configs):
-        hf3fs_configs = []
+    def parse_hf3fs_configs(self, storage_configs: str) -> List[Dict[str, Any]]:
+        hf3fs_configs: List[Dict[str, Any]] = []
         storage_configs_json = json.loads(storage_configs)
         for storage_config in storage_configs_json:
             if storage_config["type"] == "vcns_hf3fs":
@@ -166,7 +171,7 @@ class ConnectorWorker:
     # ------------------------------------------------------------------ #
     # KV cache registration
     # ------------------------------------------------------------------ #
-    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+    def register_kv_caches(self, kv_caches: Dict[str, Any]) -> None:
         self._kv_caches = kv_caches
         first_attn = next(
             kv_caches[name]
@@ -183,7 +188,11 @@ class ConnectorWorker:
             if isinstance(meta, AttentionGroupMeta):
                 groups.append(self._build_attention_group(meta, kv_caches))
             else:
-                groups.append(self._build_state_group(meta, kv_caches))
+                # parse_groups only produces attention/state GroupMetas;
+                # ty cannot infer that the complement is StateGroupMeta.
+                groups.append(
+                    self._build_state_group(meta, kv_caches)  # ty: ignore[invalid-argument-type]
+                )
 
         self._kvcache_info = KVCacheInfo(
             tp_rank=self._tp_rank,
@@ -209,7 +218,7 @@ class ConnectorWorker:
         )
 
     def _build_attention_group(
-        self, meta: AttentionGroupMeta, kv_caches
+        self, meta: AttentionGroupMeta, kv_caches: Dict[str, Any]
     ) -> AttentionTransferGroup:
         spec = self._self_spec_names[meta.group_idx]
         tensors = [kv_caches[name] for name in meta.layer_names]
@@ -266,7 +275,9 @@ class ConnectorWorker:
             block_stride=block_stride,
         )
 
-    def _build_state_group(self, meta: StateGroupMeta, kv_caches) -> StateTransferGroup:
+    def _build_state_group(
+        self, meta: StateGroupMeta, kv_caches: Dict[str, Any]
+    ) -> StateTransferGroup:
         # Mamba/state group: each layer is a list[Tensor] sharing one storage;
         # rebuild a (num_blocks, page_size_bytes) byte view for opaque copy.
         spec = self._self_spec_names[meta.group_idx]
@@ -305,7 +316,10 @@ class ConnectorWorker:
     # Block index translation
     # ------------------------------------------------------------------ #
     def _attn_token_indices(
-        self, group: AttentionTransferGroup, manager_block_idxes, block_table
+        self,
+        group: AttentionTransferGroup,
+        manager_block_idxes: Sequence[int],
+        block_table: List[int],
     ) -> List[List[int]]:
         """Map manager blocks to flat token slots of one attention group.
 
@@ -335,7 +349,10 @@ class ConnectorWorker:
         return out
 
     def _state_block_ids(
-        self, group: StateTransferGroup, manager_block_idxes, block_table
+        self,
+        group: StateTransferGroup,
+        manager_block_idxes: Sequence[int],
+        block_table: List[int],
     ) -> List[int]:
         """Map manager blocks to block ids of a state (mamba) group.
 
@@ -363,7 +380,16 @@ class ConnectorWorker:
     # ------------------------------------------------------------------ #
     # Load / save
     # ------------------------------------------------------------------ #
-    def _iter_task_chunks(self, plans: List[TransferPlan], per_task: int):
+    def _iter_task_chunks(
+        self, plans: List[TransferPlan], per_task: int
+    ) -> Iterator[
+        Tuple[
+            TransferGroup,
+            List[Optional[str]],
+            Optional[List[List[int]]],
+            Optional[List[int]],
+        ]
+    ]:
         """Slice each plan's blocks into per-task chunks.
 
         Pure generator: the task index is the consumer's concern (enumerate
@@ -382,7 +408,10 @@ class ConnectorWorker:
                 )
 
     def _plan_group_transfers(
-        self, locations, manager_block_idxes, block_ids_per_group
+        self,
+        locations: List[Dict[str, Any]],
+        manager_block_idxes: Sequence[int],
+        block_ids_per_group: List[List[int]],
     ) -> Optional[List[TransferPlan]]:
         """Build the per-group TransferPlans for a set of manager blocks.
 
@@ -424,18 +453,22 @@ class ConnectorWorker:
                     )
                 )
             else:
+                # KVCacheInfo groups are only attention or state groups;
+                # ty cannot infer that the complement is StateTransferGroup.
                 plans.append(
                     TransferPlan(
                         group=group,
                         uris=uris,
                         block_ids=self._state_block_ids(
-                            group, manager_block_idxes, block_table
+                            group,  # ty: ignore[invalid-argument-type]
+                            manager_block_idxes,
+                            block_table,
                         ),
                     )
                 )
         return plans
 
-    def _check_block_table_covers(self, block_ids_per_group) -> None:
+    def _check_block_table_covers(self, block_ids_per_group: List[List[int]]) -> None:
         """``block_ids_per_group`` is indexed by the raw vLLM group index --
         a guarantee vLLM provides today
         (https://github.com/vllm-project/vllm/blob/v0.26.0/vllm/v1/core/sched/output.py,
@@ -455,7 +488,7 @@ class ConnectorWorker:
         self,
         forward_context: "ForwardContext",
         meta: TairKvCacheConnectorMetadata,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         for load_req in meta.to_load_requests:
             if not load_req.need_load_locations:
@@ -546,11 +579,11 @@ class ConnectorWorker:
         layer_name: str,
         kv_layer: torch.Tensor,
         attn_metadata: "AttentionMetadata",
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         pass
 
-    def wait_for_save(self, meta: TairKvCacheConnectorMetadata):
+    def wait_for_save(self, meta: TairKvCacheConnectorMetadata) -> None:
         if not meta.to_save_requests:
             return
         ready_event = self._device_mod.Event()
@@ -592,7 +625,9 @@ class ConnectorWorker:
                     self._pending_saves.get(save_req.req_id, 0) + 1
                 )
 
-    def on_save_finished(self, write_session_id: str, save_context: SaveContext):
+    def on_save_finished(
+        self, write_session_id: str, save_context: SaveContext
+    ) -> None:
         for block_idx in range(len(save_context.locations)):
             fully_saved = all(
                 save_context.result_per_rank[rank][block_idx]

--- a/kv_cache_manager/py_connector/vllm/data_transfer.py
+++ b/kv_cache_manager/py_connector/vllm/data_transfer.py
@@ -20,10 +20,14 @@ data path, so the connector competes with the engine for exactly zero HBM.
 
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, List, Optional, Set, Tuple
 
 import torch
-from kv_cache_manager.client.pybind import kvcm_py_client
+
+# kvcm_py_client is the compiled pybind11 client; it ships no type stubs.
+from kv_cache_manager.client.pybind import kvcm_py_client  # ty: ignore[unresolved-import]
 
 from kv_cache_manager.py_connector.common.tp_coordinator import (
     CoordinateMsgSerializer,
@@ -33,16 +37,16 @@ from kv_cache_manager.py_connector.common.tp_coordinator import (
     LoadBlockFinishedEvent,
 )
 from kv_cache_manager.py_connector.common.logger import logger
+from kv_cache_manager.py_connector.vllm.config import TairKvCacheConnectorExtraConfig
 from kv_cache_manager.py_connector.vllm.transfer_types import (
     AttentionTransferGroup,
     KVCacheInfo,
-    StateTransferGroup,
     TransferGroup,
 )
 from kv_cache_manager.py_connector.kernel import batch_gather_scatter_helper
 
 
-def _get_device_module(device=None):
+def _get_device_module(device: Optional[torch.device] = None) -> Any:
     """Return the torch device module matching the runtime device."""
     if device is not None and hasattr(torch, "get_device_module"):
         return torch.get_device_module(device)
@@ -74,7 +78,9 @@ class _StagingPool:
     an accepted trade-off for removing the GPU staging copy.
     """
 
-    def __init__(self, device, per_block_bytes: int, max_blocks: int):
+    def __init__(
+        self, device: torch.device, per_block_bytes: int, max_blocks: int
+    ) -> None:
         if max_blocks <= 0:
             raise ValueError("staging pool must have at least one block slot")
         self.block_bytes = per_block_bytes
@@ -141,14 +147,16 @@ class MultiResult:
     callback once every task has reported. Each result is a list[bool] aligned
     with the manager blocks the task handled (in submission order)."""
 
-    def __init__(self, size: int, callback):
+    def __init__(
+        self, size: int, callback: Callable[[List[Optional[bool]]], None]
+    ) -> None:
         self._size = size
-        self._results = [None] * size
+        self._results: List[Optional[Sequence[Optional[bool]]]] = [None] * size
         self._lock = threading.Lock()
         self._finished_num = 0
         self._callback = callback
 
-    def submit_result(self, idx: int, result):
+    def submit_result(self, idx: int, result: Sequence[Optional[bool]]) -> None:
         with self._lock:
             assert self._results[idx] is None
             self._results[idx] = result
@@ -164,7 +172,9 @@ class MultiResult:
                 self._callback(flat)
 
 
-def _effective_pool_blocks(configured, need, block_bytes, max_bytes):
+def _effective_pool_blocks(
+    configured: int, need: int, block_bytes: int, max_bytes: int
+) -> int:
     """Blocks per staging-pool group under the per-group pinned-RAM ceiling.
 
     min(configured, max_bytes // block_bytes), floored at one full task
@@ -182,10 +192,10 @@ class DataTransferManager:
         self,
         kvcache_info: KVCacheInfo,
         manager_block_size: int,
-        transfer_client,
+        transfer_client: Any,
         coordinator_client: TpCoordinatorClient,
-        extra_config,
-    ):
+        extra_config: TairKvCacheConnectorExtraConfig,
+    ) -> None:
         self._info = kvcache_info
         self._manager_block_size = manager_block_size
         self._transfer_client = transfer_client
@@ -247,21 +257,25 @@ class DataTransferManager:
                 pool.max_blocks * pool.block_bytes / 2**20,
             )
 
-        def _init_worker():
+        def _init_worker() -> None:
             self._device_mod.set_device(self._device)
 
         self._io_executor = ThreadPoolExecutor(
             max_workers=32, thread_name_prefix="kvcm_io_", initializer=_init_worker
         )
 
-    def submit_task(self, func, *args, **kwargs):
+    def submit_task(
+        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Future:
         return self._io_executor.submit(func, *args, **kwargs)
 
     # ------------------------------------------------------------------ #
     # BlockBuffer helper
     # ------------------------------------------------------------------ #
     @staticmethod
-    def _make_block_buffers(base_ptr: int, per_block_bytes: int, count: int):
+    def _make_block_buffers(
+        base_ptr: int, per_block_bytes: int, count: int
+    ) -> List[kvcm_py_client.BlockBuffer]:
         buffers = []
         for i in range(count):
             buf = kvcm_py_client.BlockBuffer()
@@ -280,13 +294,13 @@ class DataTransferManager:
     def save_task(
         self,
         multi_result: MultiResult,
-        task_idx,
+        task_idx: int,
         group: TransferGroup,
-        remote_uris,
-        block_token_indices,
-        block_ids,
-        ready_event,
-    ):
+        remote_uris: List[Optional[str]],
+        block_token_indices: Optional[List[List[int]]],
+        block_ids: Optional[List[int]],
+        ready_event: Any,
+    ) -> None:
         """Gather one group's manager blocks from HBM and save them.
 
         block_token_indices: attention -> list[list[int]] flat token slots per block.
@@ -335,7 +349,13 @@ class DataTransferManager:
             ok_mask = [False] * n
         multi_result.submit_result(task_idx, ok_mask)
 
-    def _save_dispositions(self, group: TransferGroup, remote_uris, block_ids, n):
+    def _save_dispositions(
+        self,
+        group: TransferGroup,
+        remote_uris: List[Optional[str]],
+        block_ids: Optional[List[int]],
+        n: int,
+    ) -> Tuple[Set[int], Set[int]]:
         """Split the task's blocks into (abstained, failed); the rest transfer.
 
         A state group abstains for a manager block exactly when vLLM's block
@@ -363,7 +383,7 @@ class DataTransferManager:
             return set(), failed
         skipped, failed = set(), set()
         for i in range(n):
-            is_null = block_ids[i] == 0
+            is_null = block_ids[i] == 0  # ty: ignore[not-subscriptable]
             has_uri = remote_uris[i] is not None
             if is_null and not has_uri:
                 skipped.add(i)
@@ -394,7 +414,12 @@ class DataTransferManager:
         return skipped, failed
 
     @staticmethod
-    def _load_skipped_blocks(group: TransferGroup, remote_uris, block_ids, n) -> set:
+    def _load_skipped_blocks(
+        group: TransferGroup,
+        remote_uris: List[Optional[str]],
+        block_ids: Optional[List[int]],
+        n: int,
+    ) -> Set[int]:
         """Blocks this group has nothing to load into.
 
         Asymmetric with the save side on purpose: on load, a null target means
@@ -415,7 +440,8 @@ class DataTransferManager:
                     n,
                 )
             return set()
-        skipped = {i for i in range(n) if block_ids[i] == 0}
+        # State tasks always carry block ids (see _iter_task_chunks).
+        skipped = {i for i in range(n) if block_ids[i] == 0}  # ty: ignore[not-subscriptable]
         if skipped:
             logger.debug(
                 "load group %s: %d/%d blocks need no state",
@@ -427,14 +453,14 @@ class DataTransferManager:
 
     def _save_valid_blocks(
         self,
-        group,
-        remote_uris,
-        block_token_indices,
-        block_ids,
-        ready_event,
-        valid,
-        ok_mask,
-    ):
+        group: TransferGroup,
+        remote_uris: List[Optional[str]],
+        block_token_indices: Optional[List[List[int]]],
+        block_ids: Optional[List[int]],
+        ready_event: Any,
+        valid: List[int],
+        ok_mask: List[Optional[bool]],
+    ) -> None:
         uris = [remote_uris[i] for i in valid]
         assert all(uri is not None for uri in uris), (
             f"group {group.spec_name}: save batch contains a block without a "
@@ -463,7 +489,8 @@ class DataTransferManager:
                     batch_gather_scatter_helper.batch_gather_kv_caches(
                         group.kvcache_ptr_tensor_gpu,
                         view,
-                        [block_token_indices[i] for i in valid],
+                        # Attention tasks always carry token indices.
+                        [block_token_indices[i] for i in valid],  # ty: ignore[not-subscriptable]
                         list(range(len(valid))),
                         self._manager_block_size,
                         group.per_token_dim,
@@ -471,13 +498,17 @@ class DataTransferManager:
                         local_block_size=group.kernel_block_size,
                     )
                 else:
+                    # State tasks always carry block ids and state views
+                    # (see _iter_task_chunks).
                     for out_i, i in enumerate(valid):
                         for layer_idx in range(group.layer_num):
                             dst = (
                                 out_i * group.layer_num + layer_idx
-                            ) * group.page_size_bytes
-                            cpu_buffer[dst : dst + group.page_size_bytes].copy_(
-                                group.block_view_tensors[layer_idx][block_ids[i]],
+                            ) * group.page_size_bytes  # ty: ignore[unresolved-attribute]
+                            cpu_buffer[dst : dst + group.page_size_bytes].copy_(  # ty: ignore[unresolved-attribute]
+                                group.block_view_tensors[layer_idx][  # ty: ignore[unresolved-attribute]
+                                    block_ids[i]  # ty: ignore[not-subscriptable]
+                                ],
                                 non_blocking=True,
                             )
                 done = self._device_mod.Event()
@@ -506,7 +537,13 @@ class DataTransferManager:
         finally:
             pool.release(start, len(valid))
 
-    def create_save_done_callback(self, req_id, tp_rank, write_session_id, num_blocks):
+    def create_save_done_callback(
+        self,
+        req_id: str,
+        tp_rank: int,
+        write_session_id: str,
+        num_blocks: int,
+    ) -> Callable[[List[Optional[bool]]], None]:
         """block success = AND across all groups that had data for the block.
 
         Task results are ordered group0[blocks], group1[blocks], ... so a
@@ -517,7 +554,7 @@ class DataTransferManager:
         be published.
         """
 
-        def cb(flat):
+        def cb(flat: List[Optional[bool]]) -> None:
             is_success = [None] * num_blocks
             for i, ok in enumerate(flat):
                 if ok is None:
@@ -545,12 +582,12 @@ class DataTransferManager:
     def load_task(
         self,
         multi_result: MultiResult,
-        task_idx,
+        task_idx: int,
         group: TransferGroup,
-        remote_uris,
-        block_token_indices,
-        block_ids,
-    ):
+        remote_uris: List[Optional[str]],
+        block_token_indices: Optional[List[List[int]]],
+        block_ids: Optional[List[int]],
+    ) -> None:
         """Load one group's manager blocks from storage into HBM.
 
         Mirror of ``save_task``: ``remote_uris`` is positionally aligned with
@@ -589,7 +626,12 @@ class DataTransferManager:
         multi_result.submit_result(task_idx, ok_mask)
 
     def _load_valid_blocks(
-        self, group, remote_uris, block_token_indices, block_ids, valid
+        self,
+        group: TransferGroup,
+        remote_uris: List[Optional[str]],
+        block_token_indices: Optional[List[List[int]]],
+        block_ids: Optional[List[int]],
+        valid: List[int],
     ) -> bool:
         pool = self._pools[group.spec_name]
         start = pool.acquire(len(valid))
@@ -620,7 +662,9 @@ class DataTransferManager:
                         batch_gather_scatter_helper.batch_scatter_kv_caches(
                             group.kvcache_ptr_tensor_gpu,
                             view,
-                            [block_token_indices[i] for i in valid],
+                            # Attention tasks always carry token indices
+                            # (see _iter_task_chunks).
+                            [block_token_indices[i] for i in valid],  # ty: ignore[not-subscriptable]
                             list(range(len(valid))),
                             self._manager_block_size,
                             group.per_token_dim,
@@ -628,13 +672,17 @@ class DataTransferManager:
                             local_block_size=group.kernel_block_size,
                         )
                     else:
+                        # State tasks always carry block ids and state views
+                        # (see _iter_task_chunks).
                         for out_i, i in enumerate(valid):
                             for layer_idx in range(group.layer_num):
                                 src = (
                                     out_i * group.layer_num + layer_idx
-                                ) * group.page_size_bytes
-                                group.block_view_tensors[layer_idx][block_ids[i]].copy_(
-                                    cpu_buffer[src : src + group.page_size_bytes],
+                                ) * group.page_size_bytes  # ty: ignore[unresolved-attribute]
+                                group.block_view_tensors[layer_idx][  # ty: ignore[unresolved-attribute]
+                                    block_ids[i]  # ty: ignore[not-subscriptable]
+                                ].copy_(
+                                    cpu_buffer[src : src + group.page_size_bytes],  # ty: ignore[unresolved-attribute]
                                     non_blocking=True,
                                 )
                     done = self._device_mod.Event()
@@ -656,8 +704,14 @@ class DataTransferManager:
             pool.release(start, len(valid))
 
     def create_load_done_callback(
-        self, req_id, tp_rank, epoch, block_ids, num_blocks, report_failures=True
-    ):
+        self,
+        req_id: str,
+        tp_rank: int,
+        epoch: int,
+        block_ids: List[int],
+        num_blocks: int,
+        report_failures: bool = True,
+    ) -> Callable[[List[Optional[bool]]], None]:
         """A manager block is loaded only if every group that had data for it
         succeeded.
 
@@ -675,7 +729,7 @@ class DataTransferManager:
         may produce corrupt output -- the contained alternative to an
         engine-wide crash. See start_load_kv for the full trade-off."""
 
-        def cb(flat):
+        def cb(flat: List[Optional[bool]]) -> None:
             merged = [None] * num_blocks
             for i, ok in enumerate(flat):
                 if ok is None:

--- a/kv_cache_manager/py_connector/vllm/data_transfer.py
+++ b/kv_cache_manager/py_connector/vllm/data_transfer.py
@@ -26,12 +26,19 @@ import torch
 from kv_cache_manager.client.pybind import kvcm_py_client
 
 from kv_cache_manager.py_connector.common.tp_coordinator import (
-    CoordinateMsgSerializer, TpCoordinatorClient, CoordinateMessage,
-    SendBlockFinishedEvent, LoadBlockFinishedEvent,
+    CoordinateMsgSerializer,
+    TpCoordinatorClient,
+    CoordinateMessage,
+    SendBlockFinishedEvent,
+    LoadBlockFinishedEvent,
 )
 from kv_cache_manager.py_connector.common.logger import logger
 from kv_cache_manager.py_connector.vllm.transfer_types import (
-    AttentionTransferGroup, KVCacheInfo, StateTransferGroup, TransferGroup)
+    AttentionTransferGroup,
+    KVCacheInfo,
+    StateTransferGroup,
+    TransferGroup,
+)
 from kv_cache_manager.py_connector.kernel import batch_gather_scatter_helper
 
 
@@ -42,6 +49,7 @@ def _get_device_module(device=None):
     try:
         if hasattr(torch, "musa") and torch.musa.is_available():
             import torch_musa  # noqa: F401
+
             return torch.musa
     except Exception:
         pass
@@ -75,8 +83,9 @@ class _StagingPool:
         total = max_blocks * per_block_bytes
         # Pinned host memory needs a CUDA context; on other devices (tests,
         # CPU-only runs) fall back to pageable memory.
-        self._cpu = torch.empty(total, dtype=torch.uint8, device="cpu",
-                                pin_memory=(device.type == "cuda"))
+        self._cpu = torch.empty(
+            total, dtype=torch.uint8, device="cpu", pin_memory=(device.type == "cuda")
+        )
         # Free runs as [start, start+len) block ranges, kept sorted by start.
         self._runs = [[0, max_blocks]]
 
@@ -89,7 +98,8 @@ class _StagingPool:
             raise ValueError(
                 f"staging task of {n} blocks exceeds the pool capacity "
                 f"{self.max_blocks}; raise staging_pool_blocks or shrink "
-                f"block_per_save_task/block_per_load_task")
+                f"block_per_save_task/block_per_load_task"
+            )
         with self._cond:
             while True:
                 for i, (start, length) in enumerate(self._runs):
@@ -123,7 +133,7 @@ class _StagingPool:
 
     def cpu_view(self, start: int, n: int) -> torch.Tensor:
         b = self.block_bytes
-        return self._cpu[start * b:(start + n) * b]
+        return self._cpu[start * b : (start + n) * b]
 
 
 class MultiResult:
@@ -168,8 +178,14 @@ def _effective_pool_blocks(configured, need, block_bytes, max_bytes):
 
 
 class DataTransferManager:
-    def __init__(self, kvcache_info: KVCacheInfo, manager_block_size: int,
-                 transfer_client, coordinator_client: TpCoordinatorClient, extra_config):
+    def __init__(
+        self,
+        kvcache_info: KVCacheInfo,
+        manager_block_size: int,
+        transfer_client,
+        coordinator_client: TpCoordinatorClient,
+        extra_config,
+    ):
         self._info = kvcache_info
         self._manager_block_size = manager_block_size
         self._transfer_client = transfer_client
@@ -181,15 +197,15 @@ class DataTransferManager:
         self._load_stream = self._device_mod.Stream()
 
         pool_blocks = extra_config.staging_pool_blocks
-        need = max(extra_config.block_per_save_task,
-                   extra_config.block_per_load_task)
+        need = max(extra_config.block_per_save_task, extra_config.block_per_load_task)
         if pool_blocks < need:
             raise ValueError(
                 f"staging_pool_blocks={pool_blocks} is smaller than the "
                 f"largest task batch ({need}); one task stages its whole "
                 f"batch contiguously, so the pool must cover it -- raise "
                 f"staging_pool_blocks or shrink block_per_save_task/"
-                f"block_per_load_task")
+                f"block_per_load_task"
+            )
         # One pool per group: block shapes differ between attention and state
         # groups. The pool is pinned host memory only -- the kernel reaches it
         # over PCIe -- so the connector's device-memory footprint is zero.
@@ -201,31 +217,42 @@ class DataTransferManager:
         self._pools = {}
         for g in kvcache_info.groups:
             blocks = _effective_pool_blocks(
-                pool_blocks, need, g.per_block_bytes,
-                extra_config.staging_pool_max_bytes_per_group)
+                pool_blocks,
+                need,
+                g.per_block_bytes,
+                extra_config.staging_pool_max_bytes_per_group,
+            )
             if blocks < pool_blocks:
                 logger.warning(
                     "staging pool %s: %d blocks x %d bytes would pin "
                     "%.1f GiB; capped to %d blocks (%.1f MiB) by "
                     "staging_pool_max_bytes_per_group=%d",
-                    g.spec_name, pool_blocks, g.per_block_bytes,
-                    pool_blocks * g.per_block_bytes / 2**30, blocks,
+                    g.spec_name,
+                    pool_blocks,
+                    g.per_block_bytes,
+                    pool_blocks * g.per_block_bytes / 2**30,
+                    blocks,
                     blocks * g.per_block_bytes / 2**20,
-                    extra_config.staging_pool_max_bytes_per_group)
+                    extra_config.staging_pool_max_bytes_per_group,
+                )
             self._pools[g.spec_name] = _StagingPool(
-                self._device, g.per_block_bytes, blocks)
+                self._device, g.per_block_bytes, blocks
+            )
         for name, pool in self._pools.items():
-            logger.info("staging pool %s: %d blocks x %d bytes "
-                        "(pinned %.1f MiB, GPU 0)",
-                        name, pool.max_blocks,
-                        pool.block_bytes,
-                        pool.max_blocks * pool.block_bytes / 2**20)
+            logger.info(
+                "staging pool %s: %d blocks x %d bytes (pinned %.1f MiB, GPU 0)",
+                name,
+                pool.max_blocks,
+                pool.block_bytes,
+                pool.max_blocks * pool.block_bytes / 2**20,
+            )
 
         def _init_worker():
             self._device_mod.set_device(self._device)
 
         self._io_executor = ThreadPoolExecutor(
-            max_workers=32, thread_name_prefix="kvcm_io_", initializer=_init_worker)
+            max_workers=32, thread_name_prefix="kvcm_io_", initializer=_init_worker
+        )
 
     def submit_task(self, func, *args, **kwargs):
         return self._io_executor.submit(func, *args, **kwargs)
@@ -250,8 +277,16 @@ class DataTransferManager:
     # ------------------------------------------------------------------ #
     # Save
     # ------------------------------------------------------------------ #
-    def save_task(self, multi_result: MultiResult, task_idx, group: TransferGroup,
-                  remote_uris, block_token_indices, block_ids, ready_event):
+    def save_task(
+        self,
+        multi_result: MultiResult,
+        task_idx,
+        group: TransferGroup,
+        remote_uris,
+        block_token_indices,
+        block_ids,
+        ready_event,
+    ):
         """Gather one group's manager blocks from HBM and save them.
 
         block_token_indices: attention -> list[list[int]] flat token slots per block.
@@ -279,15 +314,24 @@ class DataTransferManager:
             valid = [i for i in range(n) if i not in skipped and i not in failed]
             ok_mask = [None if i in skipped else False for i in range(n)]
             if valid:
-                self._save_valid_blocks(group, remote_uris,
-                                        block_token_indices, block_ids,
-                                        ready_event, valid, ok_mask)
+                self._save_valid_blocks(
+                    group,
+                    remote_uris,
+                    block_token_indices,
+                    block_ids,
+                    ready_event,
+                    valid,
+                    ok_mask,
+                )
         except Exception:
             # Fail the whole task: partially transferred blocks are unknown, so
             # report conservatively -- never publish a block we cannot vouch
             # for (abstentions included; that only costs hit rate, not truth).
-            logger.exception("save task crashed group=%s blocks=%d, failing them all",
-                             group.spec_name, n)
+            logger.exception(
+                "save task crashed group=%s blocks=%d, failing them all",
+                group.spec_name,
+                n,
+            )
             ok_mask = [False] * n
         multi_result.submit_result(task_idx, ok_mask)
 
@@ -309,9 +353,13 @@ class DataTransferManager:
         if isinstance(group, AttentionTransferGroup):
             failed = {i for i in range(n) if remote_uris[i] is None}
             if failed:
-                logger.warning("save group %s: %d/%d attention blocks have no "
-                               "location, failing them", group.spec_name,
-                               len(failed), n)
+                logger.warning(
+                    "save group %s: %d/%d attention blocks have no "
+                    "location, failing them",
+                    group.spec_name,
+                    len(failed),
+                    n,
+                )
             return set(), failed
         skipped, failed = set(), set()
         for i in range(n):
@@ -321,18 +369,28 @@ class DataTransferManager:
                 skipped.add(i)
             elif is_null:
                 failed.add(i)
-                logger.warning("save group %s: block %d has a location but no "
-                               "materialized state; failing it instead of "
-                               "publishing bytes the model never produced",
-                               group.spec_name, i)
+                logger.warning(
+                    "save group %s: block %d has a location but no "
+                    "materialized state; failing it instead of "
+                    "publishing bytes the model never produced",
+                    group.spec_name,
+                    i,
+                )
             elif not has_uri:
                 failed.add(i)
-                logger.warning("save group %s: block %d has a materialized "
-                               "state but no location to write it to; failing it",
-                               group.spec_name, i)
+                logger.warning(
+                    "save group %s: block %d has a materialized "
+                    "state but no location to write it to; failing it",
+                    group.spec_name,
+                    i,
+                )
         if skipped:
-            logger.debug("save group %s: %d/%d blocks carry no state "
-                         "(not published)", group.spec_name, len(skipped), n)
+            logger.debug(
+                "save group %s: %d/%d blocks carry no state (not published)",
+                group.spec_name,
+                len(skipped),
+                n,
+            )
         return skipped, failed
 
     @staticmethod
@@ -349,22 +407,39 @@ class DataTransferManager:
         if isinstance(group, AttentionTransferGroup):
             missing = sum(uri is None for uri in remote_uris)
             if missing:
-                logger.warning("load group %s: %d/%d attention blocks have no "
-                               "location, failing them", group.spec_name, missing, n)
+                logger.warning(
+                    "load group %s: %d/%d attention blocks have no "
+                    "location, failing them",
+                    group.spec_name,
+                    missing,
+                    n,
+                )
             return set()
         skipped = {i for i in range(n) if block_ids[i] == 0}
         if skipped:
-            logger.debug("load group %s: %d/%d blocks need no state",
-                         group.spec_name, len(skipped), n)
+            logger.debug(
+                "load group %s: %d/%d blocks need no state",
+                group.spec_name,
+                len(skipped),
+                n,
+            )
         return skipped
 
-    def _save_valid_blocks(self, group, remote_uris,
-                           block_token_indices, block_ids, ready_event,
-                           valid, ok_mask):
+    def _save_valid_blocks(
+        self,
+        group,
+        remote_uris,
+        block_token_indices,
+        block_ids,
+        ready_event,
+        valid,
+        ok_mask,
+    ):
         uris = [remote_uris[i] for i in valid]
-        assert all(uri is not None for uri in uris), \
-            f"group {group.spec_name}: save batch contains a block without a " \
+        assert all(uri is not None for uri in uris), (
+            f"group {group.spec_name}: save batch contains a block without a "
             f"location; _save_dispositions must have failed it"
+        )
         # Wait for the engine's forward pass *before* taking a pool slot:
         # the slot is needed only for the gather + SDK transfer, so holding
         # it while the model still runs only extends the pool occupancy and
@@ -380,33 +455,47 @@ class DataTransferManager:
                 # directly over PCIe; no device-side staging copy exists.
                 if isinstance(group, AttentionTransferGroup):
                     view = cpu_buffer.view(self._info.dtype).view(
-                        len(valid), group.num_kv_ptrs,
-                        self._manager_block_size, group.per_token_dim)
+                        len(valid),
+                        group.num_kv_ptrs,
+                        self._manager_block_size,
+                        group.per_token_dim,
+                    )
                     batch_gather_scatter_helper.batch_gather_kv_caches(
-                        group.kvcache_ptr_tensor_gpu, view,
+                        group.kvcache_ptr_tensor_gpu,
+                        view,
                         [block_token_indices[i] for i in valid],
-                        list(range(len(valid))), self._manager_block_size,
+                        list(range(len(valid))),
+                        self._manager_block_size,
                         group.per_token_dim,
                         block_stride=group.block_stride,
-                        local_block_size=group.kernel_block_size)
+                        local_block_size=group.kernel_block_size,
+                    )
                 else:
                     for out_i, i in enumerate(valid):
                         for layer_idx in range(group.layer_num):
-                            dst = (out_i * group.layer_num + layer_idx) * group.page_size_bytes
-                            cpu_buffer[dst:dst + group.page_size_bytes].copy_(
+                            dst = (
+                                out_i * group.layer_num + layer_idx
+                            ) * group.page_size_bytes
+                            cpu_buffer[dst : dst + group.page_size_bytes].copy_(
                                 group.block_view_tensors[layer_idx][block_ids[i]],
-                                non_blocking=True)
+                                non_blocking=True,
+                            )
                 done = self._device_mod.Event()
                 done.record(self._save_stream)
             done.synchronize()
 
             buffers = self._make_block_buffers(
-                cpu_buffer.data_ptr(), group.per_block_bytes, len(valid))
+                cpu_buffer.data_ptr(), group.per_block_bytes, len(valid)
+            )
             result = self._transfer_client.SaveKvCaches(uris, buffers)
-            ok = (result[0] == kvcm_py_client.ClientErrorCode.ER_OK)
+            ok = result[0] == kvcm_py_client.ClientErrorCode.ER_OK
             if not ok:
-                logger.warning("save task failed group=%s uris=%d result=%s",
-                               group.spec_name, len(uris), result)
+                logger.warning(
+                    "save task failed group=%s uris=%d result=%s",
+                    group.spec_name,
+                    len(uris),
+                    result,
+                )
             for i in valid:
                 ok_mask[i] = ok
         except BaseException:
@@ -427,6 +516,7 @@ class DataTransferManager:
         block whose every group is None was never written at all and must not
         be published.
         """
+
         def cb(flat):
             is_success = [None] * num_blocks
             for i, ok in enumerate(flat):
@@ -436,17 +526,31 @@ class DataTransferManager:
                 is_success[b] = ok if is_success[b] is None else (is_success[b] and ok)
             # No group wrote anything for the block -> nothing to publish.
             is_success = [bool(ok) for ok in is_success]
-            msg = CoordinateMessage(time.time(), SendBlockFinishedEvent(
-                request_id=req_id, tp_rank=tp_rank,
-                write_session_id=write_session_id, is_success_list=is_success))
+            msg = CoordinateMessage(
+                time.time(),
+                SendBlockFinishedEvent(
+                    request_id=req_id,
+                    tp_rank=tp_rank,
+                    write_session_id=write_session_id,
+                    is_success_list=is_success,
+                ),
+            )
             self._coordinator_client.send(CoordinateMsgSerializer.dumps(msg))
+
         return cb
 
     # ------------------------------------------------------------------ #
     # Load
     # ------------------------------------------------------------------ #
-    def load_task(self, multi_result: MultiResult, task_idx, group: TransferGroup,
-                  remote_uris, block_token_indices, block_ids):
+    def load_task(
+        self,
+        multi_result: MultiResult,
+        task_idx,
+        group: TransferGroup,
+        remote_uris,
+        block_token_indices,
+        block_ids,
+    ):
         """Load one group's manager blocks from storage into HBM.
 
         Mirror of ``save_task``: ``remote_uris`` is positionally aligned with
@@ -464,36 +568,43 @@ class DataTransferManager:
             skipped = self._load_skipped_blocks(group, remote_uris, block_ids, n)
             # A block we must restore but nothing was published for cannot be
             # loaded; fail it without letting it shift the staging batch.
-            failed = {i for i in range(n)
-                      if i not in skipped and remote_uris[i] is None}
+            failed = {
+                i for i in range(n) if i not in skipped and remote_uris[i] is None
+            }
             valid = [i for i in range(n) if i not in skipped and i not in failed]
             ok_mask = [None if i in skipped else False for i in range(n)]
             if valid:
-                ok = self._load_valid_blocks(group, remote_uris,
-                                             block_token_indices, block_ids,
-                                             valid)
+                ok = self._load_valid_blocks(
+                    group, remote_uris, block_token_indices, block_ids, valid
+                )
                 for i in valid:
                     ok_mask[i] = ok
         except Exception:
-            logger.exception("load task crashed group=%s blocks=%d, failing them all",
-                             group.spec_name, n)
+            logger.exception(
+                "load task crashed group=%s blocks=%d, failing them all",
+                group.spec_name,
+                n,
+            )
             ok_mask = [False] * n
         multi_result.submit_result(task_idx, ok_mask)
 
-    def _load_valid_blocks(self, group, remote_uris, block_token_indices,
-                           block_ids, valid) -> bool:
+    def _load_valid_blocks(
+        self, group, remote_uris, block_token_indices, block_ids, valid
+    ) -> bool:
         pool = self._pools[group.spec_name]
         start = pool.acquire(len(valid))
         try:
             cpu_buffer = pool.cpu_view(start, len(valid))
-            buffers = self._make_block_buffers(cpu_buffer.data_ptr(),
-                                               group.per_block_bytes, len(valid))
+            buffers = self._make_block_buffers(
+                cpu_buffer.data_ptr(), group.per_block_bytes, len(valid)
+            )
             uris = [remote_uris[i] for i in valid]
-            assert all(uri is not None for uri in uris), \
-                f"group {group.spec_name}: load batch contains a block without a " \
+            assert all(uri is not None for uri in uris), (
+                f"group {group.spec_name}: load batch contains a block without a "
                 f"location; load_task must have failed it"
+            )
             result = self._transfer_client.LoadKvCaches(uris, buffers)
-            ok = (result == kvcm_py_client.ClientErrorCode.ER_OK)
+            ok = result == kvcm_py_client.ClientErrorCode.ER_OK
             if ok:
                 with self._device_mod.stream(self._load_stream):
                     # Scatter straight out of the pinned host slot: the
@@ -501,28 +612,41 @@ class DataTransferManager:
                     # memory directly over PCIe; no device-side staging copy.
                     if isinstance(group, AttentionTransferGroup):
                         view = cpu_buffer.view(self._info.dtype).view(
-                            len(valid), group.num_kv_ptrs,
-                            self._manager_block_size, group.per_token_dim)
+                            len(valid),
+                            group.num_kv_ptrs,
+                            self._manager_block_size,
+                            group.per_token_dim,
+                        )
                         batch_gather_scatter_helper.batch_scatter_kv_caches(
-                            group.kvcache_ptr_tensor_gpu, view,
+                            group.kvcache_ptr_tensor_gpu,
+                            view,
                             [block_token_indices[i] for i in valid],
-                            list(range(len(valid))), self._manager_block_size,
+                            list(range(len(valid))),
+                            self._manager_block_size,
                             group.per_token_dim,
                             block_stride=group.block_stride,
-                            local_block_size=group.kernel_block_size)
+                            local_block_size=group.kernel_block_size,
+                        )
                     else:
                         for out_i, i in enumerate(valid):
                             for layer_idx in range(group.layer_num):
-                                src = (out_i * group.layer_num + layer_idx) * group.page_size_bytes
+                                src = (
+                                    out_i * group.layer_num + layer_idx
+                                ) * group.page_size_bytes
                                 group.block_view_tensors[layer_idx][block_ids[i]].copy_(
-                                    cpu_buffer[src:src + group.page_size_bytes],
-                                    non_blocking=True)
+                                    cpu_buffer[src : src + group.page_size_bytes],
+                                    non_blocking=True,
+                                )
                     done = self._device_mod.Event()
                     done.record(self._load_stream)
                 done.synchronize()
             else:
-                logger.warning("load task failed group=%s uris=%d result=%s",
-                               group.spec_name, len(uris), result)
+                logger.warning(
+                    "load task failed group=%s uris=%d result=%s",
+                    group.spec_name,
+                    len(uris),
+                    result,
+                )
             return ok
         except BaseException:
             # Drain the stream before the slots go back (as in save).
@@ -531,8 +655,9 @@ class DataTransferManager:
         finally:
             pool.release(start, len(valid))
 
-    def create_load_done_callback(self, req_id, tp_rank, epoch, block_ids, num_blocks,
-                                  report_failures=True):
+    def create_load_done_callback(
+        self, req_id, tp_rank, epoch, block_ids, num_blocks, report_failures=True
+    ):
         """A manager block is loaded only if every group that had data for it
         succeeded.
 
@@ -549,6 +674,7 @@ class DataTransferManager:
         failure is logged, vLLM keeps the partially loaded KV, and the request
         may produce corrupt output -- the contained alternative to an
         engine-wide crash. See start_load_kv for the full trade-off."""
+
         def cb(flat):
             merged = [None] * num_blocks
             for i, ok in enumerate(flat):
@@ -560,13 +686,28 @@ class DataTransferManager:
             merged = [bool(ok) for ok in merged]
             failed = []
             if report_failures:
-                failed = [block_ids[i] for i in range(min(num_blocks, len(block_ids)))
-                          if not merged[i]]
+                failed = [
+                    block_ids[i]
+                    for i in range(min(num_blocks, len(block_ids)))
+                    if not merged[i]
+                ]
             elif not all(merged):
-                logger.warning("load failed for %d/%d blocks of req %s (hybrid: "
-                               "not reporting invalid block ids)",
-                               merged.count(False), num_blocks, req_id)
-            msg = CoordinateMessage(time.time(), LoadBlockFinishedEvent(
-                request_id=req_id, tp_rank=tp_rank, epoch=epoch, failed_block_idxs=failed))
+                logger.warning(
+                    "load failed for %d/%d blocks of req %s (hybrid: "
+                    "not reporting invalid block ids)",
+                    merged.count(False),
+                    num_blocks,
+                    req_id,
+                )
+            msg = CoordinateMessage(
+                time.time(),
+                LoadBlockFinishedEvent(
+                    request_id=req_id,
+                    tp_rank=tp_rank,
+                    epoch=epoch,
+                    failed_block_idxs=failed,
+                ),
+            )
             self._coordinator_client.send(CoordinateMsgSerializer.dumps(msg))
+
         return cb

--- a/kv_cache_manager/py_connector/vllm/data_transfer.py
+++ b/kv_cache_manager/py_connector/vllm/data_transfer.py
@@ -147,16 +147,14 @@ class MultiResult:
     callback once every task has reported. Each result is a list[bool] aligned
     with the manager blocks the task handled (in submission order)."""
 
-    def __init__(
-        self, size: int, callback: Callable[[List[Optional[bool]]], None]
-    ) -> None:
+    def __init__(self, size: int, callback: Callable[[List[Any]], None]) -> None:
         self._size = size
-        self._results: List[Optional[Sequence[Optional[bool]]]] = [None] * size
+        self._results: List[Optional[Sequence[Any]]] = [None] * size
         self._lock = threading.Lock()
         self._finished_num = 0
         self._callback = callback
 
-    def submit_result(self, idx: int, result: Sequence[Optional[bool]]) -> None:
+    def submit_result(self, idx: int, result: Sequence[Any]) -> None:
         with self._lock:
             assert self._results[idx] is None
             self._results[idx] = result

--- a/kv_cache_manager/py_connector/vllm/location_query_manager.py
+++ b/kv_cache_manager/py_connector/vllm/location_query_manager.py
@@ -58,8 +58,8 @@ class _Query:
 
     key: QueryCacheKey
     version: int = 0
-    locations: list = None          # None until the manager answered
-    ask_time: float = 0.0           # monotonic clock, at query issue
+    locations: list = None  # None until the manager answered
+    ask_time: float = 0.0  # monotonic clock, at query issue
 
 
 class LocationQueryManager:
@@ -72,9 +72,14 @@ class LocationQueryManager:
     and the query re-issued.
     """
 
-    def __init__(self, manager_client: KvCacheManagerClient, http_executor,
-                 instance_id: str, async_get_cache_location: bool,
-                 max_answer_age_s: float = 1.0):
+    def __init__(
+        self,
+        manager_client: KvCacheManagerClient,
+        http_executor,
+        instance_id: str,
+        async_get_cache_location: bool,
+        max_answer_age_s: float = 1.0,
+    ):
         self._manager_client = manager_client
         self._http_executor = http_executor
         self._instance_id = instance_id
@@ -95,7 +100,8 @@ class LocationQueryManager:
             req_id=request.request_id,
             query_type=QUERY_TYPE,
             token_length=len(request.prompt_token_ids),
-            computed_blocks=computed_blocks)
+            computed_blocks=computed_blocks,
+        )
 
     def _fetch_from_manager(self, request, computed_blocks: int):
         """Run the actual GetCacheLocation call (http thread or inline)."""
@@ -116,8 +122,11 @@ class LocationQueryManager:
             try:
                 locations = self._fetch_from_manager(request, key.computed_blocks)
             except Exception as e:
-                logger.warning("get_cache_location error, request_id: %s, error: %s",
-                               request.request_id, e)
+                logger.warning(
+                    "get_cache_location error, request_id: %s, error: %s",
+                    request.request_id,
+                    e,
+                )
                 with self._lock:
                     # Drop the slot: the next match hook re-issues the query.
                     if self._queries.get(request.request_id) is q:
@@ -131,9 +140,12 @@ class LocationQueryManager:
                     # answer of a dead ask must never write into the new
                     # slot (late answers only win against older asks, never
                     # against newer ones).
-                    logger.debug("get_cache_location answer dropped: request %s "
-                                 "query v%d was superseded",
-                                 request.request_id, q.version)
+                    logger.debug(
+                        "get_cache_location answer dropped: request %s "
+                        "query v%d was superseded",
+                        request.request_id,
+                        q.version,
+                    )
 
         self._http_executor.submit(run)
 
@@ -162,14 +174,20 @@ class LocationQueryManager:
                     return q.locations
                 # Expired: a miss. Old answers are never served.
                 self.stale_supersede_count += 1
-                logger.info("req:%s location answer expired after %.3fs "
-                            "(max %.3fs); re-querying", req_id, age,
-                            self._max_answer_age_s)
+                logger.info(
+                    "req:%s location answer expired after %.3fs "
+                    "(max %.3fs); re-querying",
+                    req_id,
+                    age,
+                    self._max_answer_age_s,
+                )
             # First ask, a different offset, or an expired answer: the
             # newest ask supersedes.
-            q = _Query(key=key,
-                       version=q.version + 1 if q is not None else 0,
-                       ask_time=time.monotonic())
+            q = _Query(
+                key=key,
+                version=q.version + 1 if q is not None else 0,
+                ask_time=time.monotonic(),
+            )
             self._queries[req_id] = q
 
         if self._async_get_cache_location:
@@ -178,8 +196,9 @@ class LocationQueryManager:
         try:
             locations = self._fetch_from_manager(request, computed_blocks)
         except Exception as e:
-            logger.warning("get_cache_location error, request_id: %s, error: %s",
-                           req_id, e)
+            logger.warning(
+                "get_cache_location error, request_id: %s, error: %s", req_id, e
+            )
             with self._lock:
                 if self._queries.get(req_id) is q:
                     self._queries.pop(req_id, None)

--- a/kv_cache_manager/py_connector/vllm/location_query_manager.py
+++ b/kv_cache_manager/py_connector/vllm/location_query_manager.py
@@ -33,11 +33,15 @@ only -- correctness never depends on it.
 
 import threading
 import time
+from concurrent.futures import Executor
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from kv_cache_manager.py_connector.common.manager_client import KvCacheManagerClient
 from kv_cache_manager.py_connector.common.logger import logger
+
+if TYPE_CHECKING:
+    from vllm.v1.request import Request
 
 QUERY_TYPE = "QT_PREFIX_MATCH"
 
@@ -58,7 +62,8 @@ class _Query:
 
     key: QueryCacheKey
     version: int = 0
-    locations: list = None  # None until the manager answered
+    # None until the manager answered.
+    locations: Optional[List[dict]] = None
     ask_time: float = 0.0  # monotonic clock, at query issue
 
 
@@ -75,11 +80,11 @@ class LocationQueryManager:
     def __init__(
         self,
         manager_client: KvCacheManagerClient,
-        http_executor,
+        http_executor: Executor,
         instance_id: str,
         async_get_cache_location: bool,
         max_answer_age_s: float = 1.0,
-    ):
+    ) -> None:
         self._manager_client = manager_client
         self._http_executor = http_executor
         self._instance_id = instance_id
@@ -91,19 +96,23 @@ class LocationQueryManager:
         # Hits refused for age and re-fetched.
         self.stale_supersede_count = 0
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         pass
 
     @staticmethod
-    def _key(request, computed_blocks: int) -> QueryCacheKey:
+    def _key(request: "Request", computed_blocks: int) -> QueryCacheKey:
         return QueryCacheKey(
             req_id=request.request_id,
             query_type=QUERY_TYPE,
-            token_length=len(request.prompt_token_ids),
+            # vLLM types prompt_token_ids as Optional; a live Request
+            # always carries its prompt.
+            token_length=len(request.prompt_token_ids),  # ty: ignore[invalid-argument-type]
             computed_blocks=computed_blocks,
         )
 
-    def _fetch_from_manager(self, request, computed_blocks: int):
+    def _fetch_from_manager(
+        self, request: "Request", computed_blocks: int
+    ) -> List[dict]:
         """Run the actual GetCacheLocation call (http thread or inline)."""
         get_request = {
             "trace_id": request.request_id,
@@ -117,8 +126,8 @@ class LocationQueryManager:
         logger.debug("get_kvcache_location result: %s", result)
         return result["locations"]
 
-    def _query_async(self, request, key: QueryCacheKey, q: _Query) -> None:
-        def run():
+    def _query_async(self, request: "Request", key: QueryCacheKey, q: _Query) -> None:
+        def run() -> None:
             try:
                 locations = self._fetch_from_manager(request, key.computed_blocks)
             except Exception as e:
@@ -149,7 +158,9 @@ class LocationQueryManager:
 
         self._http_executor.submit(run)
 
-    def get_locations_for_query(self, request, computed_blocks: int) -> Optional[list]:
+    def get_locations_for_query(
+        self, request: "Request", computed_blocks: int
+    ) -> Optional[List[dict]]:
         """Ask (or re-ask) for the request's external match at this offset.
 
         Returns the locations when a fresh answer is already cached for
@@ -208,7 +219,7 @@ class LocationQueryManager:
                 q.locations = locations
         return locations
 
-    def store_result(self, req_id: str, locations: list) -> None:
+    def store_result(self, req_id: str, locations: List[dict]) -> None:
         """Overwrite the cached answer (the match hook clamps it to a
         vLLM-safe prefix before the allocation consumes it). The slot is
         necessarily the query the hook just got its answer from: the hook
@@ -218,7 +229,7 @@ class LocationQueryManager:
             if q is not None:
                 q.locations = locations
 
-    def consume_locations(self, req_id: str) -> Optional[Tuple[list, int]]:
+    def consume_locations(self, req_id: str) -> Optional[Tuple[List[dict], int]]:
         """Pop the request's answered query: (locations, computed_blocks),
         or None when nothing is cached (no query was issued / still in
         flight / already consumed)."""

--- a/kv_cache_manager/py_connector/vllm/metadata.py
+++ b/kv_cache_manager/py_connector/vllm/metadata.py
@@ -61,7 +61,9 @@ class TairKvCacheConnectorMetadata(KVConnectorMetadata):
         self.to_finish_requests.append(finish_request)
 
     def __repr__(self):
-        return (f"TairKvCacheConnectorMetadata(epoch={self.epoch}, "
-                f"load={len(self.to_load_requests)}, "
-                f"save={len(self.to_save_requests)}, "
-                f"finish={len(self.to_finish_requests)})")
+        return (
+            f"TairKvCacheConnectorMetadata(epoch={self.epoch}, "
+            f"load={len(self.to_load_requests)}, "
+            f"save={len(self.to_save_requests)}, "
+            f"finish={len(self.to_finish_requests)})"
+        )

--- a/kv_cache_manager/py_connector/vllm/metadata.py
+++ b/kv_cache_manager/py_connector/vllm/metadata.py
@@ -45,22 +45,22 @@ class TairKvCacheConnectorMetadata(KVConnectorMetadata):
     to_finish_requests (get_finished). Every instruction is self-contained
     -- the worker keeps no per-request mirror of scheduler state."""
 
-    def __init__(self, epoch: int):
+    def __init__(self, epoch: int) -> None:
         self.epoch = epoch
         self.to_load_requests: List[LoadRequest] = []
         self.to_save_requests: List[SaveRequest] = []
         self.to_finish_requests: List[FinishRequest] = []
 
-    def add_load_request(self, request: LoadRequest):
+    def add_load_request(self, request: LoadRequest) -> None:
         self.to_load_requests.append(request)
 
-    def add_save_request(self, save_request: SaveRequest):
+    def add_save_request(self, save_request: SaveRequest) -> None:
         self.to_save_requests.append(save_request)
 
-    def add_finish_request(self, finish_request: FinishRequest):
+    def add_finish_request(self, finish_request: FinishRequest) -> None:
         self.to_finish_requests.append(finish_request)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"TairKvCacheConnectorMetadata(epoch={self.epoch}, "
             f"load={len(self.to_load_requests)}, "

--- a/kv_cache_manager/py_connector/vllm/transfer_types.py
+++ b/kv_cache_manager/py_connector/vllm/transfer_types.py
@@ -103,7 +103,8 @@ class TransferPlan:
     hole means is the task's disposition logic (see data_transfer)."""
 
     group: TransferGroup
-    uris: List
+    # None where a block carries no data for this group's spec.
+    uris: List[Optional[str]]
     # Attention groups: flat token slots per manager block (gather/scatter).
     token_indices: Optional[List[List[int]]] = None
     # State groups: source/target state block id per manager block.

--- a/kv_cache_manager/py_connector/vllm/transfer_types.py
+++ b/kv_cache_manager/py_connector/vllm/transfer_types.py
@@ -38,9 +38,9 @@ class KVLayout(Enum):
     isolation prevents such mixing in practice.
     """
 
-    SPLIT_KV_5D_KV_FIRST = "split_kv_5d_kv_first"   # (2, num_blocks, block, H, D)
-    SPLIT_KV_5D_N_FIRST = "split_kv_5d_n_first"     # (num_blocks, 2, block, H, D)
-    PACKED_4D = "packed_4d"                         # (num_blocks, H, block, 2D)
+    SPLIT_KV_5D_KV_FIRST = "split_kv_5d_kv_first"  # (2, num_blocks, block, H, D)
+    SPLIT_KV_5D_N_FIRST = "split_kv_5d_n_first"  # (num_blocks, 2, block, H, D)
+    PACKED_4D = "packed_4d"  # (num_blocks, H, block, 2D)
 
 
 @dataclass(frozen=True)

--- a/kv_cache_manager/py_connector/vllm/v1_connector.py
+++ b/kv_cache_manager/py_connector/vllm/v1_connector.py
@@ -58,7 +58,13 @@ try:
         BUILD_TIME,
     )
 except ImportError:
-    FULL_VERSION, GIT_COMMIT, BUILD_TIME = "dev", "source", "source"
+    # The literals clash with the generated module's when a built
+    # worktree makes the import above resolvable.
+    FULL_VERSION, GIT_COMMIT, BUILD_TIME = (
+        "dev",  # ty: ignore[invalid-assignment]
+        "source",  # ty: ignore[invalid-assignment]
+        "source",
+    )
 
 from kv_cache_manager.py_connector.vllm.config import TairKvCacheConnectorExtraConfig
 from kv_cache_manager.py_connector.vllm.connector_scheduler import ConnectorScheduler

--- a/kv_cache_manager/py_connector/vllm/v1_connector.py
+++ b/kv_cache_manager/py_connector/vllm/v1_connector.py
@@ -48,7 +48,10 @@ from kv_cache_manager.py_connector.common.logger import logger, configure_log_le
 try:
     # Stamped into the wheel at build time; absent in a source checkout.
     from kv_cache_manager.py_connector.common._version_info import (
-        FULL_VERSION, GIT_COMMIT, BUILD_TIME)
+        FULL_VERSION,
+        GIT_COMMIT,
+        BUILD_TIME,
+    )
 except ImportError:
     FULL_VERSION, GIT_COMMIT, BUILD_TIME = "dev", "source", "source"
 
@@ -57,8 +60,14 @@ from kv_cache_manager.py_connector.vllm.connector_scheduler import ConnectorSche
 from kv_cache_manager.py_connector.vllm.connector_worker import ConnectorWorker
 from kv_cache_manager.py_connector.vllm.metadata import TairKvCacheConnectorMetadata
 from kv_cache_manager.py_connector.vllm.vllm_common import (
-    GroupMeta, StateGroupMeta, attn_kv_views, build_spec_groups,
-    ensure_hybrid_supported, parse_groups, spec_name)
+    GroupMeta,
+    StateGroupMeta,
+    attn_kv_views,
+    build_spec_groups,
+    ensure_hybrid_supported,
+    parse_groups,
+    spec_name,
+)
 
 if typing.TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
@@ -70,45 +79,64 @@ if typing.TYPE_CHECKING:
 # Compatibility re-exports: tests and the e2e harness import these from
 # v1_connector (their original home before the role split).
 __all__ = [
-    "TairKvCacheConnector", "attn_kv_views", "ensure_hybrid_supported",
-    "GroupMeta", "spec_name", "build_spec_groups", "parse_groups",
+    "TairKvCacheConnector",
+    "attn_kv_views",
+    "ensure_hybrid_supported",
+    "GroupMeta",
+    "spec_name",
+    "build_spec_groups",
+    "parse_groups",
 ]
 
 
 class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
-
     # ------------------------------------------------------------------ #
     # Init / registration (role-agnostic)
     # ------------------------------------------------------------------ #
-    def __init__(self, vllm_config: "VllmConfig", role: KVConnectorRole,
-                 kv_cache_config: Optional["KVCacheConfig"] = None):
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: Optional["KVCacheConfig"] = None,
+    ):
         super().__init__(vllm_config, role, kv_cache_config)
-        assert kv_cache_config is not None, \
+        assert kv_cache_config is not None, (
             "TairKvCacheConnector requires vLLM to pass kv_cache_config (vllm >= 0.11.1)"
+        )
 
-        logger.warning("KVCM vllm connector version: %s (commit: %s, build: %s)",
-                       FULL_VERSION, GIT_COMMIT, BUILD_TIME)
+        logger.warning(
+            "KVCM vllm connector version: %s (commit: %s, build: %s)",
+            FULL_VERSION,
+            GIT_COMMIT,
+            BUILD_TIME,
+        )
 
         extra_config = TairKvCacheConnectorExtraConfig(
-            **vllm_config.kv_transfer_config.kv_connector_extra_config)
+            **vllm_config.kv_transfer_config.kv_connector_extra_config
+        )
         configure_log_level(extra_config.log_level)
 
         model_config = vllm_config.model_config
         assert vllm_config.parallel_config.pipeline_parallel_size == 1
         if getattr(model_config, "use_mla", False):
-            raise NotImplementedError("MLA models are not supported by TairKvCacheConnector")
+            raise NotImplementedError(
+                "MLA models are not supported by TairKvCacheConnector"
+            )
 
         self._vllm_block_size = vllm_config.cache_config.block_size
         self._tp_size = vllm_config.parallel_config.tensor_parallel_size
         self._kv_dtype = get_kv_cache_torch_dtype(
-            vllm_config.cache_config.cache_dtype, model_config.dtype)
+            vllm_config.cache_config.cache_dtype, model_config.dtype
+        )
 
         # Manager block size: attention KV is token-granular and can be re-blocked,
         # but mamba state exists once per scheduler block, so hybrid models must
         # keep manager block == scheduler block.
         manager_block_size = self._vllm_block_size
         self._has_state_groups = any(
-            isinstance(g.kv_cache_spec, MambaSpec) for g in kv_cache_config.kv_cache_groups)
+            isinstance(g.kv_cache_spec, MambaSpec)
+            for g in kv_cache_config.kv_cache_groups
+        )
         if self._has_state_groups:
             ensure_hybrid_supported(force=extra_config.force_hybrid_support)
         if extra_config.preferred_block_size != 0:
@@ -116,8 +144,10 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
                 if extra_config.preferred_block_size != self._vllm_block_size:
                     logger.warning(
                         "preferred_block_size=%d ignored for hybrid model: mamba state is "
-                        "per scheduler block (%d)", extra_config.preferred_block_size,
-                        self._vllm_block_size)
+                        "per scheduler block (%d)",
+                        extra_config.preferred_block_size,
+                        self._vllm_block_size,
+                    )
             else:
                 manager_block_size = extra_config.preferred_block_size
         self._manager_block_size = manager_block_size
@@ -135,7 +165,8 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
         logger.info("deployment: %s, groups: %s", deployment, self._group_metas)
 
         self._manager_client = KvCacheManagerClient.from_connector_config(
-            extra_config.model_dump())
+            extra_config.model_dump()
+        )
         host_ip = get_ip()
 
         register_request = {
@@ -146,7 +177,8 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
             "block_size": manager_block_size,
             "location_spec_infos": [
                 {"name": spec_name(rank, meta.group_idx), "size": meta.per_block_bytes}
-                for rank in range(self._tp_size) for meta in self._group_metas
+                for rank in range(self._tp_size)
+                for meta in self._group_metas
             ],
         }
         spec_groups = build_spec_groups(self._group_metas, self._tp_size)
@@ -162,20 +194,33 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
         self.connector_worker: Optional[ConnectorWorker] = None
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler = ConnectorScheduler(
-                extra_config, self._group_metas, manager_block_size,
-                self._vllm_block_size, self._tp_size, self._manager_client,
-                TpCoordinatorClient(host_ip, extra_config.coordinator_base_port))
+                extra_config,
+                self._group_metas,
+                manager_block_size,
+                self._vllm_block_size,
+                self._tp_size,
+                self._manager_client,
+                TpCoordinatorClient(host_ip, extra_config.coordinator_base_port),
+            )
             logger.warning(
                 "TairKvCacheConnector scheduler inited, extra_config: %r, "
                 "manager block size: %d, vllm block size: %d, groups: %d",
-                extra_config.model_dump(), manager_block_size,
-                self._vllm_block_size, len(self._group_metas))
+                extra_config.model_dump(),
+                manager_block_size,
+                self._vllm_block_size,
+                len(self._group_metas),
+            )
         else:
             self.connector_worker = ConnectorWorker(
-                extra_config, self._group_metas, manager_block_size,
-                self._tp_size, host_ip, self._manager_client,
+                extra_config,
+                self._group_metas,
+                manager_block_size,
+                self._tp_size,
+                host_ip,
+                self._manager_client,
                 TpCoordinatorClient(host_ip, extra_config.coordinator_base_port),
-                register_response)
+                register_response,
+            )
 
     def shutdown(self):
         if self.connector_scheduler is not None:
@@ -186,28 +231,31 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
     # ------------------------------------------------------------------ #
     # Scheduler hooks (called on the scheduler-role instance)
     # ------------------------------------------------------------------ #
-    def get_num_new_matched_tokens(self, request: "Request",
-                                   num_computed_tokens: int):
+    def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
-            request, num_computed_tokens)
+            request, num_computed_tokens
+        )
 
-    def update_state_after_alloc(self, request: "Request", blocks: "KVCacheBlocks",
-                                 num_external_tokens: int):
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
         assert self.connector_scheduler is not None
         self.connector_scheduler.update_state_after_alloc(
-            request, blocks, num_external_tokens)
+            request, blocks, num_external_tokens
+        )
 
     def update_connector_output(self, connector_output: KVConnectorOutput):
         assert self.connector_scheduler is not None
         self.connector_scheduler.update_connector_output(connector_output)
 
-    def build_connector_meta(self, scheduler_output: SchedulerOutput) -> KVConnectorMetadata:
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.build_connector_meta(scheduler_output)
 
-    def request_finished_all_groups(self, request: "Request",
-                                    block_ids) -> tuple:
+    def request_finished_all_groups(self, request: "Request", block_ids) -> tuple:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished_all_groups(request, block_ids)
 
@@ -240,16 +288,20 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
         self.connector_worker.start_load_kv(
-            forward_context, self._get_connector_metadata(), **kwargs)
+            forward_context, self._get_connector_metadata(), **kwargs
+        )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         assert self.connector_worker is not None
         self.connector_worker.wait_for_layer_load(layer_name)
 
-    def save_kv_layer(self, layer_name: str, kv_layer,
-                      attn_metadata: "AttentionMetadata", **kwargs) -> None:
+    def save_kv_layer(
+        self, layer_name: str, kv_layer, attn_metadata: "AttentionMetadata", **kwargs
+    ) -> None:
         assert self.connector_worker is not None
-        self.connector_worker.save_kv_layer(layer_name, kv_layer, attn_metadata, **kwargs)
+        self.connector_worker.save_kv_layer(
+            layer_name, kv_layer, attn_metadata, **kwargs
+        )
 
     def wait_for_save(self):
         assert self.connector_worker is not None
@@ -258,7 +310,8 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
     def get_finished(self, finished_req_ids: set):
         assert self.connector_worker is not None
         return self.connector_worker.get_finished(
-            finished_req_ids, self._get_connector_metadata())
+            finished_req_ids, self._get_connector_metadata()
+        )
 
     def get_block_ids_with_load_errors(self) -> set:
         assert self.connector_worker is not None

--- a/kv_cache_manager/py_connector/vllm/v1_connector.py
+++ b/kv_cache_manager/py_connector/vllm/v1_connector.py
@@ -18,8 +18,9 @@ hybrid gate) lives in vllm_common.py.
 """
 
 import typing
+from typing import Any, Dict, List, Optional, Tuple
 
-from typing import Optional
+import torch
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -34,8 +35,11 @@ try:
     from vllm.utils.torch_utils import get_kv_cache_torch_dtype
     from vllm.utils.network_utils import get_ip
 except ImportError:
-    # vllm <= v0.11.0
-    from vllm.utils import get_kv_cache_torch_dtype, get_ip
+    # vllm <= v0.11.0; these names left vllm.utils in newer vLLM.
+    from vllm.utils import (
+        get_kv_cache_torch_dtype,  # ty: ignore[unresolved-import]
+        get_ip,  # ty: ignore[unresolved-import]
+    )
 
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import MambaSpec
@@ -46,8 +50,9 @@ from kv_cache_manager.py_connector.common.tp_coordinator import TpCoordinatorCli
 from kv_cache_manager.py_connector.common.logger import logger, configure_log_level
 
 try:
-    # Stamped into the wheel at build time; absent in a source checkout.
-    from kv_cache_manager.py_connector.common._version_info import (
+    # Stamped into the wheel at build time (bazel version_info_py);
+    # absent in a source checkout.
+    from kv_cache_manager.py_connector.common._version_info import (  # ty: ignore[unresolved-import]
         FULL_VERSION,
         GIT_COMMIT,
         BUILD_TIME,
@@ -58,10 +63,8 @@ except ImportError:
 from kv_cache_manager.py_connector.vllm.config import TairKvCacheConnectorExtraConfig
 from kv_cache_manager.py_connector.vllm.connector_scheduler import ConnectorScheduler
 from kv_cache_manager.py_connector.vllm.connector_worker import ConnectorWorker
-from kv_cache_manager.py_connector.vllm.metadata import TairKvCacheConnectorMetadata
 from kv_cache_manager.py_connector.vllm.vllm_common import (
     GroupMeta,
-    StateGroupMeta,
     attn_kv_views,
     build_spec_groups,
     ensure_hybrid_supported,
@@ -71,7 +74,10 @@ from kv_cache_manager.py_connector.vllm.vllm_common import (
 
 if typing.TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
-    from vllm.attention import AttentionMetadata
+
+    # vllm.attention no longer exists in vLLM >= 0.26; kept for the older
+    # eras this connector supports.
+    from vllm.attention import AttentionMetadata  # ty: ignore[unresolved-import]
     from vllm.v1.request import Request
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -98,8 +104,14 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
         vllm_config: "VllmConfig",
         role: KVConnectorRole,
         kv_cache_config: Optional["KVCacheConfig"] = None,
-    ):
-        super().__init__(vllm_config, role, kv_cache_config)
+    ) -> None:
+        # The base signature declares kv_cache_config non-Optional; the
+        # assert right after enforces our stricter contract.
+        super().__init__(
+            vllm_config,
+            role,
+            kv_cache_config,  # ty: ignore[invalid-argument-type]
+        )
         assert kv_cache_config is not None, (
             "TairKvCacheConnector requires vLLM to pass kv_cache_config (vllm >= 0.11.1)"
         )
@@ -111,8 +123,10 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
             BUILD_TIME,
         )
 
+        # A KV connector is always created from a kv_transfer_config; vLLM
+        # types the field as Optional.
         extra_config = TairKvCacheConnectorExtraConfig(
-            **vllm_config.kv_transfer_config.kv_connector_extra_config
+            **vllm_config.kv_transfer_config.kv_connector_extra_config  # ty: ignore[unresolved-attribute]
         )
         configure_log_level(extra_config.log_level)
 
@@ -222,7 +236,7 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
                 register_response,
             )
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         if self.connector_scheduler is not None:
             self.connector_scheduler.shutdown()
         self._manager_client.close()
@@ -231,7 +245,9 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
     # ------------------------------------------------------------------ #
     # Scheduler hooks (called on the scheduler-role instance)
     # ------------------------------------------------------------------ #
-    def get_num_new_matched_tokens(self, request: "Request", num_computed_tokens: int):
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> Tuple[Optional[int], bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
             request, num_computed_tokens
@@ -239,13 +255,13 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
-    ):
+    ) -> None:
         assert self.connector_scheduler is not None
         self.connector_scheduler.update_state_after_alloc(
             request, blocks, num_external_tokens
         )
 
-    def update_connector_output(self, connector_output: KVConnectorOutput):
+    def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         assert self.connector_scheduler is not None
         self.connector_scheduler.update_connector_output(connector_output)
 
@@ -255,11 +271,15 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.build_connector_meta(scheduler_output)
 
-    def request_finished_all_groups(self, request: "Request", block_ids) -> tuple:
+    def request_finished_all_groups(
+        self, request: "Request", block_ids: Tuple[List[int], ...]
+    ) -> Tuple[bool, Optional[dict]]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished_all_groups(request, block_ids)
 
-    def request_finished(self, request: "Request", block_ids) -> tuple:
+    def request_finished(
+        self, request: "Request", block_ids: List[int]
+    ) -> Tuple[bool, Optional[dict]]:
         # Only reached on vLLM versions without SupportsHMA dispatch
         # (https://github.com/vllm-project/vllm/blob/v0.26.0/vllm/v1/core/sched/scheduler.py#L2513
         # -- upstream plans to deprecate this path). Kept as a shim for the
@@ -268,14 +288,14 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
 
-    def get_finished_count(self):
+    def get_finished_count(self) -> int:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_finished_count()
 
     # ------------------------------------------------------------------ #
     # Worker hooks (called on each worker-role instance)
     # ------------------------------------------------------------------ #
-    def register_kv_caches(self, kv_caches: dict):
+    def register_kv_caches(self, kv_caches: Dict[str, Any]) -> None:
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)
 
@@ -285,10 +305,14 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
         # to replay here.
         super().bind_connector_metadata(connector_metadata)
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
         assert self.connector_worker is not None
+        # _get_connector_metadata is typed with vLLM's base metadata type;
+        # this connector only ever binds its own subclass.
         self.connector_worker.start_load_kv(
-            forward_context, self._get_connector_metadata(), **kwargs
+            forward_context,
+            self._get_connector_metadata(),  # ty: ignore[invalid-argument-type]
+            **kwargs,
         )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -296,21 +320,32 @@ class TairKvCacheConnector(KVConnectorBase_V1, SupportsHMA):
         self.connector_worker.wait_for_layer_load(layer_name)
 
     def save_kv_layer(
-        self, layer_name: str, kv_layer, attn_metadata: "AttentionMetadata", **kwargs
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: "AttentionMetadata",
+        **kwargs: Any,
     ) -> None:
         assert self.connector_worker is not None
         self.connector_worker.save_kv_layer(
             layer_name, kv_layer, attn_metadata, **kwargs
         )
 
-    def wait_for_save(self):
+    def wait_for_save(self) -> None:
         assert self.connector_worker is not None
-        self.connector_worker.wait_for_save(self._get_connector_metadata())
+        # See start_load_kv: the bound metadata is always our subclass.
+        self.connector_worker.wait_for_save(
+            self._get_connector_metadata(),  # ty: ignore[invalid-argument-type]
+        )
 
-    def get_finished(self, finished_req_ids: set):
+    def get_finished(
+        self, finished_req_ids: set
+    ) -> Tuple[Optional[set], Optional[set]]:
         assert self.connector_worker is not None
+        # See start_load_kv: the bound metadata is always our subclass.
         return self.connector_worker.get_finished(
-            finished_req_ids, self._get_connector_metadata()
+            finished_req_ids,
+            self._get_connector_metadata(),  # ty: ignore[invalid-argument-type]
         )
 
     def get_block_ids_with_load_errors(self) -> set:

--- a/kv_cache_manager/py_connector/vllm/vllm_common.py
+++ b/kv_cache_manager/py_connector/vllm/vllm_common.py
@@ -63,12 +63,18 @@ def build_spec_groups(group_metas: List["GroupMeta"], tp_size: int) -> List[dict
     attn_specs = sorted(
         spec_name(rank, meta.group_idx)
         for rank in range(tp_size)
-        for meta in group_metas if isinstance(meta, AttentionGroupMeta))
+        for meta in group_metas
+        if isinstance(meta, AttentionGroupMeta)
+    )
     all_specs = sorted(
         spec_name(rank, meta.group_idx)
-        for rank in range(tp_size) for meta in group_metas)
-    return [{"name": ATTN_ONLY_SPEC_GROUP, "spec_names": attn_specs},
-            {"name": ALL_SPEC_GROUP, "spec_names": all_specs}]
+        for rank in range(tp_size)
+        for meta in group_metas
+    )
+    return [
+        {"name": ATTN_ONLY_SPEC_GROUP, "spec_names": attn_specs},
+        {"name": ALL_SPEC_GROUP, "spec_names": all_specs},
+    ]
 
 
 @dataclass(frozen=True)
@@ -109,17 +115,21 @@ def parse_groups(kv_cache_config, manager_block_size: int) -> List[GroupMeta]:
     metas = []
     for idx, group in enumerate(kv_cache_config.kv_cache_groups):
         if getattr(group, "is_eagle_group", False):
-            logger.warning("skip eagle group %d (%d layers)", idx, len(group.layer_names))
+            logger.warning(
+                "skip eagle group %d (%d layers)", idx, len(group.layer_names)
+            )
             continue
         spec = group.kv_cache_spec
         if isinstance(spec, MambaSpec):
-            metas.append(StateGroupMeta(
-                group_idx=idx,
-                layer_names=list(group.layer_names),
-                block_size=spec.block_size,
-                per_block_bytes=spec.page_size_bytes * len(group.layer_names),
-                page_size_bytes=spec.page_size_bytes,
-            ))
+            metas.append(
+                StateGroupMeta(
+                    group_idx=idx,
+                    layer_names=list(group.layer_names),
+                    block_size=spec.block_size,
+                    per_block_bytes=spec.page_size_bytes * len(group.layer_names),
+                    page_size_bytes=spec.page_size_bytes,
+                )
+            )
         elif isinstance(spec, FullAttentionSpec):
             # FullAttentionSpec doubles as the merged spec of hybrid
             # SWA/chunked-attention models (vLLM merges window layers into
@@ -132,7 +142,8 @@ def parse_groups(kv_cache_config, manager_block_size: int) -> List[GroupMeta]:
                         f"group {idx}: FullAttentionSpec has {window_field}="
                         f"{getattr(spec, window_field)}; sliding-window / "
                         f"chunked attention KV is not full-prefix and is "
-                        f"not yet supported by TairKvCacheConnector")
+                        f"not yet supported by TairKvCacheConnector"
+                    )
             # Attention KV is token-granular; scale from the spec's page size
             # to the manager block size. Use the *compact* page size:
             # spec.page_size_bytes returns page_size_padded when set, which
@@ -147,23 +158,28 @@ def parse_groups(kv_cache_config, manager_block_size: int) -> List[GroupMeta]:
                         f"group {idx}: page_size_padded="
                         f"{spec.page_size_padded} but this vLLM exposes no "
                         f"real_page_size_bytes to recover the compact page "
-                        f"size; padded attention layouts are unsupported here")
+                        f"size; padded attention layouts are unsupported here"
+                    )
                 compact_page_bytes = spec.page_size_bytes
             per_token_bytes = compact_page_bytes // spec.block_size
-            metas.append(AttentionGroupMeta(
-                group_idx=idx,
-                layer_names=list(group.layer_names),
-                block_size=spec.block_size,
-                per_block_bytes=per_token_bytes * manager_block_size * len(group.layer_names),
-            ))
+            metas.append(
+                AttentionGroupMeta(
+                    group_idx=idx,
+                    layer_names=list(group.layer_names),
+                    block_size=spec.block_size,
+                    per_block_bytes=per_token_bytes
+                    * manager_block_size
+                    * len(group.layer_names),
+                )
+            )
         else:
             raise NotImplementedError(
-                f"Unsupported kv cache spec {type(spec).__name__} in group {idx}")
+                f"Unsupported kv cache spec {type(spec).__name__} in group {idx}"
+            )
     if not metas:
         # Every group was skipped (all-EAGLE config or an empty group list):
         # nothing to transfer, refuse explicitly instead of asserting.
-        raise NotImplementedError(
-            "no usable kv cache groups (all groups skipped?)")
+        raise NotImplementedError("no usable kv cache groups (all groups skipped?)")
     if not any(isinstance(m, AttentionGroupMeta) for m in metas):
         # Pure-mamba / attention-free models have no attention KV to
         # transfer; the register_kv_caches path would fail obscurely later
@@ -171,7 +187,8 @@ def parse_groups(kv_cache_config, manager_block_size: int) -> List[GroupMeta]:
         raise NotImplementedError(
             "pure-mamba / attention-free models are not supported: "
             "TairKvCacheConnector transfers full-attention or hybrid "
-            "(attention + mamba) KV caches only")
+            "(attention + mamba) KV caches only"
+        )
     return metas
 
 
@@ -205,7 +222,8 @@ def attn_kv_views(ref: torch.Tensor) -> tuple:
         if kv_first and n_first:
             raise NotImplementedError(
                 f"ambiguous kv layout {tuple(ref.shape)}: cannot tell the K/V "
-                f"dim from a num_blocks dim of size 2")
+                f"dim from a num_blocks dim of size 2"
+            )
         if kv_first:
             return [ref[0], ref[1]], KVLayout.SPLIT_KV_5D_KV_FIRST
         if n_first:
@@ -213,7 +231,8 @@ def attn_kv_views(ref: torch.Tensor) -> tuple:
     raise NotImplementedError(
         f"unrecognized kv cache layout {tuple(ref.shape)}; expected the packed "
         f"4-D (vllm >= 0.26.0) or one of the split K/V 5-D layouts "
-        f"(vllm <= 0.25.x)")
+        f"(vllm <= 0.25.x)"
+    )
 
 
 def _hybrid_external_load_supported() -> Optional[bool]:
@@ -233,12 +252,14 @@ def _hybrid_external_load_supported() -> Optional[bool]:
     """
     try:
         from vllm.v1.core.sched.scheduler import Scheduler
+
         method = Scheduler._mamba_block_aligned_split
     except (ImportError, AttributeError):
         # No such method: the blocking assert was removed/refactored away.
         return True
     try:
         import inspect
+
         src = inspect.getsource(method)
     except Exception:
         return None  # method exists but cannot be inspected
@@ -262,7 +283,8 @@ def ensure_hybrid_supported(force: bool = False):
                 "force_hybrid_support=true: skipping the hybrid external-load "
                 "capability probe; if this vLLM's scheduler still asserts "
                 "'External KV connector is not verified yet' the first "
-                "external match will crash it")
+                "external match will crash it"
+            )
             return
         raise NotImplementedError(
             "TairKvCacheConnector: cannot verify that this vLLM supports "
@@ -270,12 +292,14 @@ def ensure_hybrid_supported(force: bool = False):
             "Scheduler._mamba_block_aligned_split exists but its source is "
             "unavailable, so the vllm <= 0.22.x blocking assert cannot be "
             "ruled out. If you know this vLLM is >= 0.23.0, set "
-            "kv_connector_extra_config {\"force_hybrid_support\": true} to "
-            "bypass this check.")
+            'kv_connector_extra_config {"force_hybrid_support": true} to '
+            "bypass this check."
+        )
     raise NotImplementedError(
         "TairKvCacheConnector: this vLLM version cannot combine hybrid "
         "(mamba) models with an external KV connector -- its scheduler "
         "asserts num_external_computed_tokens == 0 in "
         "_mamba_block_aligned_split ('External KV connector is not "
         "verified yet'). Upgrade to vLLM >= 0.23.0 for hybrid model "
-        "support; full-attention models are unaffected.")
+        "support; full-attention models are unaffected."
+    )

--- a/kv_cache_manager/py_connector/vllm/vllm_common.py
+++ b/kv_cache_manager/py_connector/vllm/vllm_common.py
@@ -8,8 +8,8 @@ and the thin connector shell (v1_connector) build on this module; nothing
 here may import them.
 """
 
-from dataclasses import dataclass, field
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
@@ -19,6 +19,9 @@ from kv_cache_manager.py_connector.common.logger import logger
 from kv_cache_manager.py_connector.vllm.transfer_types import (
     KVLayout,
 )
+
+if TYPE_CHECKING:
+    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 # Spec group names advertised at registration and used per key in
 # start_write_cache. See build_spec_groups for the semantics.
@@ -107,7 +110,9 @@ class StateGroupMeta(GroupMeta):
     page_size_bytes: int = 0
 
 
-def parse_groups(kv_cache_config, manager_block_size: int) -> List[GroupMeta]:
+def parse_groups(
+    kv_cache_config: "KVCacheConfig", manager_block_size: int
+) -> List[GroupMeta]:
     """Derive the transferable GroupMeta list from vLLM's KVCacheConfig
     (https://github.com/vllm-project/vllm/blob/v0.26.0/vllm/v1/kv_cache_interface.py#L952:
     kv_cache_groups holds one KVCacheGroupSpec per block table, each with its
@@ -266,7 +271,7 @@ def _hybrid_external_load_supported() -> Optional[bool]:
     return "External KV connector is not verified yet" not in src
 
 
-def ensure_hybrid_supported(force: bool = False):
+def ensure_hybrid_supported(force: bool = False) -> None:
     """Fail fast with a clear message when a hybrid (mamba) model is served on
     a vLLM whose scheduler rejects external KV loads (vllm <= 0.22.x).
 


### PR DESCRIPTION
## Summary

Introduces static quality gates for all Python under `kv_cache_manager/py_connector`: **ruff** (lint + format) and **ty** (type checking), plus complete type annotations. Zero business-logic changes by default; the two latent bugs the scan surfaced are fixed in dedicated commits (itemized below).

## Setting and scope

- Rules follow the team's established setting: lint with `select = ["ANN", "F"]`, `ignore = ["ANN401"]`, target py312; ruff format applied across the whole py_connector.
- Tests are exempt from ANN — both the `test/` directory and the flat `test*.py` scripts next to the connectors (`sglang/`, `trtllm/`); both shapes are covered via `ruff.toml` per-file-ignores.
- Scope is every py_connector subpackage: `vllm/` `sglang/` `trtllm/` `common/` `kernel/` `test/`. The configs (`ruff.toml` / `ty.toml`) live under `py_connector/` and only affect that directory; the only root-level addition is `.pre-commit-config.yaml`.
- ruff / ty are dev-only tools and **never enter runtime dependencies**: no `BUILD`, `open_source/deps/pip.bzl` or `requirements.txt` was touched.
- ty's type environment targets vllm 0.26.0; `ty.toml` pins python to the repository-root `.venv` so the result is independent of whichever virtualenv happens to be activated. Import drift on the vLLM 0.22.1 / 0.23.0 compatibility branches and older sglang is explicitly ignored inline (`# ty: ignore[unresolved-import]`), each with its reason.
- pre-commit is opt-in: local hooks (`language: system`) that silently skip (exit 0) when ruff / ty are missing; without pre-commit itself, nothing runs at all.

## Type environment setup

See `kv_cache_manager/py_connector/README.md`. In short:

```bash
uv venv .venv --python 3.12
uv pip install --python .venv/bin/python 'vllm==0.26.0' requests orjson pydantic
uv pip install --python .venv/bin/python --no-deps 'sglang==0.5.19'   # for sglang/
cp -r <TensorRT-LLM 1.2.x checkout>/tensorrt_llm .venv/lib/python3.12/site-packages/  # for trtllm/
```

sglang is installed `--no-deps` so it cannot resolve its own vLLM pin over 0.26.0; tensorrt_llm has no pip source distribution, so its Python package is dropped into site-packages. Stubless compiled modules (`kvcm_py_client`, `tensorrt_llm.bindings`) and the build-generated `_version_info` cannot be resolved statically; their import sites carry inline ignore comments.

## Behavior changes (itemized, hard requirement)

| Commit | Found by | Problem | Fix | Behavior change? |
|---|---|---|---|---|
| `ae20ccbf` | ty `invalid-argument-type` on `signal.signal` | `_stop_manager()` in the three sglang test scripts takes no arguments but is registered as a SIGINT/SIGTERM handler; Python invokes handlers as `handler(signum, frame)`, so delivering either signal raised TypeError instead of stopping the manager process | accepts `*args` to serve both callers (signal with args, atexit without) | **Yes**, signal path only (previously crashed); the atexit path is unchanged |
| `8b7211f9` | ruff F821 undefined `get_request` | the except handler of trtllm `build_connector_meta` was copied from the sibling `get_num_new_matched_tokens`: the log line references `get_request` (immediate NameError) and `store_locations` / `write_session_id` / `block_mask` are only bound inside the try, so the failure path crashed with a second NameError right after | logs the actual request context and skips saving that request, mirroring the best-effort handling of `get_num_new_matched_tokens` | **Yes**, start_write_cache failure path only (previously crashed the scheduler; now skips the save); the success path is unchanged |

Everything else is annotations, formatting, import cleanup and inline ignores. Verified with an AST-normalized comparison against `origin/main` (annotations, docstrings and `typing.cast` wrappers stripped): of the 36 changed files, only the bugfix files above, one dead-assignment removal (`original_post` in `test_manager_client.py`, F841) and two runtime-inert `TYPE_CHECKING` import blocks differ semantically.

## Commit structure (review guide)

1. `d6a10fb4` scaffolding: ruff.toml / ty.toml / .pre-commit-config.yaml / README
2. `59ca311d` one-shot ruff format (35 files, pure format diff, `--stat` friendly)
3. ANN batches per directory: `2aae955c` vllm → `5c682703` common → `dae67fbb` kernel → `ef5d2de8` sglang → `33d3bb72` trtllm → `837dd782` test cleanup; each batch leaves its directory's `ruff check` clean
4. Two bugfixes (table above, one bug per commit)
5. `154dbe57` makes the ty gate independent of the worktree build state (build artifacts change the resolvable module set; unused-ignore notices off, fallback-branch ignore added, verified in both states)

## Verification

- `ruff check` / `ruff format --check` / `ty check`: zero diagnostics over py_connector (verified in both the fresh-source and post-kvbuild worktree states).
- bazel unit tests (`kvtest unit`): 5/5; GPU kernel tests: bazel `test_strided_gather_scatter` plus pytest `test_batch_gather_scatter` (6 tests) — the triton kernel parameter annotations are GPU-verified inert (triton parses annotations as strings and only reacts to `constexpr` / `const`).
- Non-bazel test files under pytest: `test_manager_client` / `test_tp_coordinator` / `test_logger` / `test_service_discovery_factory`, 90 tests passed.
- `kvtest e2e --env vllm-0.26.0 --model hybrid`: **all 9 scenarios green** (basic / concurrent / tp / partial_hit / full_hit / multi_turn / cross_request_prefix / load_failure / mutation), per-block bit-exact.
- `test_batch_set_return` requires a full sglang runtime and is unchanged in that regard (collection fails identically before and after this series in an sglang-less environment).
