### PR TITLE
[manager] reduce default reclaimer sampling size

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,9 @@ kvcm.meta_query.parallel_threshold=256
 # 每个并行任务一次领取的连续元素数，必须不大于 parallel_threshold。
 kvcm.meta_query.chunk_size=128
 
+# CacheReclaimer 单个有效 Instance 每轮最多采样的 key 数，默认 100。
+kvcm.cache_reclaimer.key_sampling_size_total=100
+
 # CacheReclaimer 删除 Future 在 delay 结束后可继续抵扣水位的最长时间；到期只关闭 credit，
 # 不取消底层删除。默认 60000ms。
 kvcm.cache_reclaimer.inflight_delete_timeout_ms=60000

--- a/kv_cache_manager/manager/cache_manager.h
+++ b/kv_cache_manager/manager/cache_manager.h
@@ -90,7 +90,7 @@ public:
     ~CacheManager();
 
     bool Init(int32_t schedule_plan_executor_thread_count = DEFAULT_SCHEDULE_PLAN_EXECUTOR_THREAD_COUNT,
-              uint64_t cache_reclaimer_key_sampling_size_total = 1000,
+              uint64_t cache_reclaimer_key_sampling_size_total = 100,
               uint64_t cache_reclaimer_key_sampling_size_per_task = 100,
               uint64_t cache_reclaimer_del_batch_size = 100,
               uint32_t cache_reclaimer_idle_interval_ms = 100,

--- a/kv_cache_manager/manager/test/cache_reclaimer_test.cc
+++ b/kv_cache_manager/manager/test/cache_reclaimer_test.cc
@@ -4940,6 +4940,8 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
     }
 
     {
+        // Keep an explicit non-default value that spans multiple sampling tasks.
+        ClearSampleReclaimRequests();
         cache_reclaimer_->sampling_size_.store(1000);
         cache_reclaimer_->sampling_size_per_task_.store(100);
 
@@ -4948,6 +4950,11 @@ TEST_F(CacheReclaimerTest, TestDoKeySampling) {
         ASSERT_TRUE(cache_reclaimer_->DoKeySampling(request_context_, instance_infos.front(), keys, maps));
         ASSERT_EQ(1000, keys.size());
         ASSERT_EQ(1000, maps.size());
+        const auto requests = SampleReclaimRequestsSnapshot();
+        ASSERT_EQ(10, requests.size());
+        for (const auto &request : requests) {
+            EXPECT_EQ(100, request.second);
+        }
     }
 
     {

--- a/kv_cache_manager/service/server_config.cc
+++ b/kv_cache_manager/service/server_config.cc
@@ -312,7 +312,7 @@ void ServerConfig::UpdateDefaultConfig() {
     meta_query_worker_count_ = 4;
     meta_query_parallel_threshold_ = 256;
     meta_query_chunk_size_ = 128;
-    cache_reclaimer_key_sampling_size_total_ = 1000;
+    cache_reclaimer_key_sampling_size_total_ = 100;
     cache_reclaimer_key_sampling_size_per_task_ = 100;
     cache_reclaimer_del_batch_size_ = 100;
     cache_reclaimer_idle_interval_ms_ = 100;

--- a/kv_cache_manager/service/test/server_config_test.cc
+++ b/kv_cache_manager/service/test/server_config_test.cc
@@ -25,6 +25,7 @@ TEST_F(ServerConfigTest, TestSimple) {
         ASSERT_EQ(4u, config.GetMetaQueryWorkerCount());
         ASSERT_EQ(256u, config.GetMetaQueryParallelThreshold());
         ASSERT_EQ(128u, config.GetMetaQueryChunkSize());
+        ASSERT_EQ(100, config.GetCacheReclaimerKeySamplingSizeTotal());
         ASSERT_EQ(60000, config.GetCacheReclaimerInflightDeleteTimeoutMs());
         ASSERT_EQ(20000, config.GetCacheReclaimerPendingLocationLimitPerGroupType());
         ASSERT_EQ(1ULL * 1024 * 1024 * 1024 * 1024, config.GetCacheReclaimerPendingBytesLimitPerGroupType());


### PR DESCRIPTION
将 kvcm.cache_reclaimer.key_sampling_size_total 的默认值从 1000 降至 100，并同步 CacheManager::Init 默认参数与配置文档。

- 在 ServerConfigTest 中固定验证默认值为 100
- 保留显式配置 1000、单任务采样量 100 的场景，并断言其拆分为 10 个采样任务，继续覆盖多线程采样路径
- 显式通过配置文件或环境变量设置的值不受默认值变更影响

验证：
- bazelisk test //kv_cache_manager/service/test:ServerConfigTest //kv_cache_manager/manager/test:CacheManagerTest //kv_cache_manager/manager/test:CacheReclaimerTest

---

Reduce the default value of kvcm.cache_reclaimer.key_sampling_size_total from 1000 to 100, and keep the CacheManager::Init default and configuration documentation aligned.

- Assert the new default value of 100 in ServerConfigTest
- Preserve the explicit 1000 total / 100 per-task scenario and assert that it is split into 10 sampling tasks, retaining coverage of the multi-threaded sampling path
- Explicit values supplied through configuration files or environment variables remain unaffected

Validation:
- bazelisk test //kv_cache_manager/service/test:ServerConfigTest //kv_cache_manager/manager/test:CacheManagerTest //kv_cache_manager/manager/test:CacheReclaimerTest