### PR TITLE
[client] add missing <stdexcept>/<string> includes to hf3fs_cuda_util.h

### DIFF
--- a/kv_cache_manager/client/src/internal/sdk/hf3fs_cuda_util.h
+++ b/kv_cache_manager/client/src/internal/sdk/hf3fs_cuda_util.h
@@ -4,6 +4,8 @@
 
 #ifdef USING_CUDA
 #include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
 #define CHECK_CUDA_ERROR(cuda_call)                                                                                    \
     do {                                                                                                               \
         cudaError_t err = (cuda_call);                                                                                 \


### PR DESCRIPTION
## Summary
- `CHECK_CUDA_ERROR` in `hf3fs_cuda_util.h` uses `std::runtime_error` and `std::string` but only included `<cuda_runtime.h>`, relying on transitive includes
- gcc>=13 (e.g. the noble toolchain) no longer pulls them in via the CUDA header chain; add the two missing includes

## Testing
- closed-source `client_with_cuda` build on gcc-13/noble fails without this, passes with it (21.7K actions)