### PR TITLE
[manager] fix cache location selection across backends

### DIFF
--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -1595,20 +1595,21 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
         }
     }
 
-    auto is_cold_storage = [](const BackendSelector &selector) {
-        return selector.backend_type == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL ||
-               selector.backend_type == DataStorageType::DATA_STORAGE_TYPE_NFS;
+    auto needs_base_hits = [](const BackendSelector &selector) {
+        return selector.backend_type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2 &&
+               (selector.strategy == LocationSelectStrategy::LSS_V6D_PREFIX ||
+                selector.strategy == LocationSelectStrategy::LSS_V6D_COVERAGE);
     };
     std::vector<BackendSelector> ordered_selectors = selectors;
-    std::stable_partition(ordered_selectors.begin(), ordered_selectors.end(), is_cold_storage);
+    std::stable_partition(ordered_selectors.begin(),
+                          ordered_selectors.end(),
+                          [&needs_base_hits](const BackendSelector &selector) { return !needs_base_hits(selector); });
 
-    std::vector<bool> cold_base_hits(query_keys.size(), false);
+    std::vector<bool> base_hits(query_keys.size(), false);
     for (const auto &selector : ordered_selectors) {
         DataStorageType target_type = selector.backend_type;
 
-        if (target_type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2 &&
-            (selector.strategy == LocationSelectStrategy::LSS_V6D_PREFIX ||
-             selector.strategy == LocationSelectStrategy::LSS_V6D_COVERAGE)) {
+        if (needs_base_hits(selector)) {
             // --- event report cross-key selection ---
             bool is_prefix = (selector.strategy == LocationSelectStrategy::LSS_V6D_PREFIX);
 
@@ -1651,9 +1652,9 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
             // Select best peer
             V6DPeerSelection selection;
             if (is_prefix) {
-                selection = SelectV6DByCombinedPrefix(cold_base_hits, remote_peer_candidates);
+                selection = SelectV6DByCombinedPrefix(base_hits, remote_peer_candidates);
             } else {
-                selection = SelectV6DByIncrementalCoverage(cold_base_hits, remote_peer_candidates);
+                selection = SelectV6DByIncrementalCoverage(base_hits, remote_peer_candidates);
             }
 
             // Populate results for covered keys
@@ -1672,7 +1673,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
             }
 
         } else {
-            // --- Per-key independent selection (WEIGHTED_RANDOM or other non-event-report) ---
+            // --- Per-key selection that does not depend on base hits ---
             for (size_t i = 0; i < query_keys.size(); ++i) {
                 const std::string_view requested_spec_name =
                     requested_spec_names.empty() ? std::string_view{} : requested_spec_names[query_to_output_index[i]];
@@ -1719,9 +1720,7 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 merged->set_spec_size(specs.size());
                 merged->set_location_specs(std::move(specs));
                 out_locations[query_to_output_index[i]].push_back(std::move(merged));
-                if (is_cold_storage(selector)) {
-                    cold_base_hits[i] = true;
-                }
+                base_hits[i] = true;
             }
         }
     }

--- a/kv_cache_manager/manager/meta_searcher.cc
+++ b/kv_cache_manager/manager/meta_searcher.cc
@@ -350,6 +350,107 @@ SelectV6DByCoverage(const std::vector<size_t> &candidate_indices,
     return best;
 }
 
+V6DPeerSelection
+SelectV6DByCombinedPrefix(const std::vector<bool> &base_hits,
+                          const std::unordered_map<size_t, std::vector<std::string>> &remote_peer_candidates) {
+    size_t first_required_index = 0;
+    while (first_required_index < base_hits.size() && base_hits[first_required_index]) {
+        ++first_required_index;
+    }
+
+    auto first_required_candidates = remote_peer_candidates.end();
+    if (first_required_index < base_hits.size()) {
+        first_required_candidates = remote_peer_candidates.find(first_required_index);
+    }
+    if (first_required_index == base_hits.size() || first_required_candidates == remote_peer_candidates.end() ||
+        first_required_candidates->second.empty()) {
+        // Every peer has the same combined prefix when all keys are base hits
+        // or no peer can cover the first base miss. Preserve the existing
+        // tie-break by choosing the peer with the most V6D hits inside that
+        // guaranteed prefix, then by peer address.
+        std::vector<size_t> guaranteed_prefix_indices;
+        guaranteed_prefix_indices.reserve(first_required_index);
+        for (size_t key_index = 0; key_index < first_required_index; ++key_index) {
+            guaranteed_prefix_indices.push_back(key_index);
+        }
+        return SelectV6DByCoverage(guaranteed_prefix_indices, remote_peer_candidates);
+    }
+
+    // Only peers covering the first base miss can extend the guaranteed
+    // prefix. A peer absent there always loses to every peer present there.
+    std::map<std::string, std::vector<bool>> peer_hits;
+    for (const auto &peer_address : first_required_candidates->second) {
+        peer_hits.try_emplace(peer_address, base_hits.size(), false);
+    }
+    for (const auto &[key_index, peer_addresses] : remote_peer_candidates) {
+        for (const auto &peer_address : peer_addresses) {
+            auto peer_it = peer_hits.find(peer_address);
+            if (peer_it != peer_hits.end()) {
+                peer_it->second[key_index] = true;
+            }
+        }
+    }
+
+    V6DPeerSelection best;
+    size_t best_prefix_size = 0;
+    for (const auto &[peer_address, hits] : peer_hits) {
+        std::vector<size_t> peer_covered_indices;
+        size_t prefix_size = 0;
+        for (size_t key_index = 0; key_index < base_hits.size(); ++key_index) {
+            if (!base_hits[key_index] && !hits[key_index]) {
+                break;
+            }
+            ++prefix_size;
+            if (hits[key_index]) {
+                peer_covered_indices.push_back(key_index);
+            }
+        }
+        if (peer_covered_indices.empty()) {
+            continue;
+        }
+        if (prefix_size > best_prefix_size ||
+            (prefix_size == best_prefix_size && peer_covered_indices.size() > best.covered_indices.size()) ||
+            (prefix_size == best_prefix_size && peer_covered_indices.size() == best.covered_indices.size() &&
+             (best.peer_addr.empty() || peer_address < best.peer_addr))) {
+            best_prefix_size = prefix_size;
+            best.peer_addr = peer_address;
+            best.covered_indices = std::move(peer_covered_indices);
+        }
+    }
+    return best;
+}
+
+V6DPeerSelection
+SelectV6DByIncrementalCoverage(const std::vector<bool> &base_hits,
+                               const std::unordered_map<size_t, std::vector<std::string>> &remote_peer_candidates) {
+    std::map<std::string, std::vector<size_t>> peer_to_indices;
+    for (const auto &[key_index, peer_addresses] : remote_peer_candidates) {
+        for (const auto &peer_address : peer_addresses) {
+            peer_to_indices[peer_address].push_back(key_index);
+        }
+    }
+
+    V6DPeerSelection best;
+    size_t best_incremental_hit_count = 0;
+    for (auto &[peer_address, peer_covered_indices] : peer_to_indices) {
+        const size_t incremental_hit_count =
+            std::count_if(peer_covered_indices.begin(), peer_covered_indices.end(), [&base_hits](size_t key_index) {
+                return !base_hits[key_index];
+            });
+        if (incremental_hit_count > best_incremental_hit_count ||
+            (incremental_hit_count == best_incremental_hit_count &&
+             peer_covered_indices.size() > best.covered_indices.size()) ||
+            (incremental_hit_count == best_incremental_hit_count &&
+             peer_covered_indices.size() == best.covered_indices.size() &&
+             (best.peer_addr.empty() || peer_address < best.peer_addr))) {
+            best_incremental_hit_count = incremental_hit_count;
+            best.peer_addr = peer_address;
+            best.covered_indices = peer_covered_indices;
+        }
+    }
+    return best;
+}
+
 CacheLocationMap FilterValidLocations(const CacheLocationMap &location_map,
                                       CheckLocDataExistFunc check_loc_data_exist,
                                       std::vector<std::string> &out_prune_loc_ids) {
@@ -1494,7 +1595,15 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
         }
     }
 
-    for (const auto &selector : selectors) {
+    auto is_cold_storage = [](const BackendSelector &selector) {
+        return selector.backend_type == DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL ||
+               selector.backend_type == DataStorageType::DATA_STORAGE_TYPE_NFS;
+    };
+    std::vector<BackendSelector> ordered_selectors = selectors;
+    std::stable_partition(ordered_selectors.begin(), ordered_selectors.end(), is_cold_storage);
+
+    std::vector<bool> cold_base_hits(query_keys.size(), false);
+    for (const auto &selector : ordered_selectors) {
         DataStorageType target_type = selector.backend_type;
 
         if (target_type == DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2 &&
@@ -1504,29 +1613,27 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
             bool is_prefix = (selector.strategy == LocationSelectStrategy::LSS_V6D_PREFIX);
 
             // Candidate enumeration
-            std::vector<size_t> candidate_indices;
             std::unordered_map<size_t, std::vector<std::string>> remote_peer_candidates;
             // key_idx -> peer_addr -> CacheLocationConstPtr (for reverse lookup)
             std::unordered_map<size_t, std::unordered_map<std::string, CacheLocationConstPtr>> key_peer_to_location;
 
-            bool stop_vineyard = false;
             for (size_t i = 0; i < query_keys.size(); ++i) {
-                if (stop_vineyard)
-                    break;
-
                 const auto &vmap = valid_maps[i];
                 const std::string_view requested_spec_name =
                     requested_spec_names.empty() ? std::string_view{} : requested_spec_names[query_to_output_index[i]];
                 std::vector<std::string> vineyard_addrs;
 
                 for (const auto &[id, loc] : vmap) {
-                    if (loc->type() != target_type)
+                    if (loc->type() != target_type) {
                         continue;
-                    if (!MatchesRequestedSpec(*loc, requested_spec_name))
+                    }
+                    if (!MatchesRequestedSpec(*loc, requested_spec_name)) {
                         continue;
+                    }
                     std::string addr = ExtractPeerAddrFromLocation(*loc, requested_spec_name);
-                    if (addr.empty())
+                    if (addr.empty()) {
                         continue;
+                    }
                     // Dedup: only add if not already present
                     if (key_peer_to_location[i].find(addr) == key_peer_to_location[i].end()) {
                         vineyard_addrs.push_back(addr);
@@ -1535,33 +1642,31 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 }
 
                 if (vineyard_addrs.empty()) {
-                    if (is_prefix) {
-                        stop_vineyard = true;
-                    }
                     continue;
                 }
 
                 remote_peer_candidates[i] = std::move(vineyard_addrs);
-                candidate_indices.push_back(i);
             }
 
             // Select best peer
             V6DPeerSelection selection;
             if (is_prefix) {
-                selection = SelectV6DByPrefix(candidate_indices, remote_peer_candidates);
+                selection = SelectV6DByCombinedPrefix(cold_base_hits, remote_peer_candidates);
             } else {
-                selection = SelectV6DByCoverage(candidate_indices, remote_peer_candidates);
+                selection = SelectV6DByIncrementalCoverage(cold_base_hits, remote_peer_candidates);
             }
 
             // Populate results for covered keys
             if (!selection.peer_addr.empty()) {
                 for (size_t idx : selection.covered_indices) {
                     auto peer_it = key_peer_to_location.find(idx);
-                    if (peer_it == key_peer_to_location.end())
+                    if (peer_it == key_peer_to_location.end()) {
                         continue;
+                    }
                     auto loc_it = peer_it->second.find(selection.peer_addr);
-                    if (loc_it == peer_it->second.end())
+                    if (loc_it == peer_it->second.end()) {
                         continue;
+                    }
                     out_locations[query_to_output_index[idx]].push_back(loc_it->second);
                 }
             }
@@ -1578,25 +1683,29 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                         filtered.try_emplace(id, loc);
                     }
                 }
-                if (filtered.empty())
+                if (filtered.empty()) {
                     continue;
+                }
 
                 std::vector<std::string> unused_prune_ids;
                 auto winner = policy->SelectForMatch(filtered, nullptr, unused_prune_ids);
-                if (!winner || winner->id().empty() || winner->location_specs().empty())
+                if (!winner || winner->id().empty() || winner->location_specs().empty()) {
                     continue;
+                }
 
                 // Merge specs from same data storage (same logic as SelectAndMergeForMatch)
                 std::map<std::string, LocationSpec> merged_specs;
                 for (const auto &[id, loc] : filtered) {
-                    if (!policy->IsSameDataStorage(*loc, *winner))
+                    if (!policy->IsSameDataStorage(*loc, *winner)) {
                         continue;
+                    }
                     for (const auto &spec : loc->location_specs()) {
                         merged_specs.try_emplace(spec.name(), spec);
                     }
                 }
-                if (merged_specs.empty())
+                if (merged_specs.empty()) {
                     continue;
+                }
 
                 auto merged = std::make_shared<CacheLocation>();
                 merged->set_id(winner->id() + "_merged");
@@ -1610,6 +1719,9 @@ ErrorCode MetaSearcher::BatchGetBestLocationByBackend(RequestContext *request_co
                 merged->set_spec_size(specs.size());
                 merged->set_location_specs(std::move(specs));
                 out_locations[query_to_output_index[i]].push_back(std::move(merged));
+                if (is_cold_storage(selector)) {
+                    cold_base_hits[i] = true;
+                }
             }
         }
     }
@@ -3489,7 +3601,6 @@ ErrorCode MetaSearcher::BatchDeleteLocations(RequestContext *request_context,
     }
     return result.ec;
 }
-
 
 ErrorCode
 MetaSearcher::VisitAllLocations(RequestContext *request_context, size_t scan_batch_size, LocationVisitor visitor) {

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -1109,8 +1109,8 @@ TEST_F(CacheManagerTest, TestStartWriteCacheSpecGroupNamesWithTokenIdsOnly) {
         tokens.push_back(i);
     }
     const std::vector<std::string> group_names{"full", "attn", "full"};
-    auto [ec, info] = cache_manager_->StartWriteCache(
-        request_context_.get(), "token_only_sg", {}, tokens, group_names, 100000000);
+    auto [ec, info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "token_only_sg", {}, tokens, group_names, 100000000);
     ASSERT_EQ(EC_OK, ec);
     const auto &locs = info.locations().cache_locations_view();
     ASSERT_EQ(3u, locs.size());
@@ -1122,8 +1122,8 @@ TEST_F(CacheManagerTest, TestStartWriteCacheSpecGroupNamesWithTokenIdsOnly) {
     ASSERT_EQ("tp0_attn", locs[1].location_specs()[0].name());
 
     // A mismatched length must still be rejected.
-    auto [ec_bad, info_bad] = cache_manager_->StartWriteCache(
-        request_context_.get(), "token_only_sg", {}, tokens, {"full"}, 100000000);
+    auto [ec_bad, info_bad] =
+        cache_manager_->StartWriteCache(request_context_.get(), "token_only_sg", {}, tokens, {"full"}, 100000000);
     ASSERT_NE(EC_OK, ec_bad);
 }
 
@@ -1139,18 +1139,19 @@ TEST_F(CacheManagerTest, TestStartWriteCacheRecordWriteBytes) {
                                                std::vector<LocationSpecGroup>()));
     // 取出统计的写入量
     auto get_write_bytes = [&]() {
-        return metrics_registry_->GetCounter("data_storage.write_bytes_dispatched_total",
-                                             {{"type", ToString(kDefaultStorageType)},
-                                              {"unique_name", "nfs_01"}}).Get();
+        return metrics_registry_
+            ->GetCounter("data_storage.write_bytes_dispatched_total",
+                         {{"type", ToString(kDefaultStorageType)}, {"unique_name", "nfs_01"}})
+            .Get();
     };
     // 成功写入
     std::vector<int64_t> keys{1, 2, 3};
     auto [ec, start_write_cache_info] =
         cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 1000);
     ASSERT_EQ(EC_OK, ec);
-    ASSERT_EQ(3 * 4 * 512, get_write_bytes());  // 验证写入量
+    ASSERT_EQ(3 * 4 * 512, get_write_bytes()); // 验证写入量
 
-    {// 部分写入成功场景，不新增写入量，写入量统计放在 BatchAddLoation 成功之后
+    { // 部分写入成功场景，不新增写入量，写入量统计放在 BatchAddLoation 成功之后
         auto meta_indexer = cache_manager_->meta_indexer_manager_->GetMetaIndexer("test_instance");
         ASSERT_TRUE(meta_indexer);
 
@@ -1158,7 +1159,7 @@ TEST_F(CacheManagerTest, TestStartWriteCacheRecordWriteBytes) {
         const auto orig_batch_size = meta_indexer->batch_key_size_;
         const auto orig_max_key_count = meta_indexer->max_key_count_;
         meta_indexer->batch_key_size_ = 1;
-        meta_indexer->max_key_count_ = meta_indexer->GetKeyCount() + 1;  // 已写入的key_count + 1，确保已经写入的是成功的
+        meta_indexer->max_key_count_ = meta_indexer->GetKeyCount() + 1; // 已写入的key_count + 1，确保已经写入的是成功的
 
         std::vector<int64_t> keys{1001, 1002};
         while (meta_indexer->GetMutexShardIndex(keys[0]) == meta_indexer->GetMutexShardIndex(keys[1])) {
@@ -1169,19 +1170,19 @@ TEST_F(CacheManagerTest, TestStartWriteCacheRecordWriteBytes) {
             cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 1000);
         EXPECT_EQ(EC_PARTIAL_OK, ec);
         EXPECT_TRUE(start_write_cache_info.locations().cache_locations_view().empty());
-        ASSERT_EQ(3 * 4 * 512, get_write_bytes());  // 验证写入量
+        ASSERT_EQ(3 * 4 * 512, get_write_bytes()); // 验证写入量
 
         // 恢复现场
         meta_indexer->batch_key_size_ = orig_batch_size;
         meta_indexer->max_key_count_ = orig_max_key_count;
     }
 
-    {// 重复写入
+    { // 重复写入
         std::vector<int64_t> keys{1, 2};
         auto [ec, start_write_cache_info] =
             cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
         ASSERT_EQ(EC_OK, ec);
-        ASSERT_EQ(3 * 4 * 512, get_write_bytes());  // 验证写入量
+        ASSERT_EQ(3 * 4 * 512, get_write_bytes()); // 验证写入量
     }
 }
 
@@ -7825,7 +7826,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
         }
     }
 
-    // --- Test 2: EVENT_REPORT PREFIX + NFS (NFS on 300,500,700 should not affect event report peer selection) ---
+    // --- Test 2: EVENT_REPORT PREFIX + NFS compose one complete prefix ---
     {
         std::vector<BackendSelector> selectors = {
             {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
@@ -7844,12 +7845,14 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
         ASSERT_EQ(EC_OK, ec);
         ASSERT_EQ(5u, locs.size());
 
-        // peer_B wins with prefix=4 (keys 300,400,500,600)
+        // Both peer_A and peer_B compose a full prefix with NFS. peer_B wins
+        // because it covers more keys itself (300,400,500,600).
         // key 300 (index 0): event report + NFS = 2
         {
             const auto &kl = locs[0].cache_locations_view();
             ASSERT_EQ(2u, kl.size());
-            EXPECT_NE(std::string::npos, kl[0].location_specs()[0].uri().find("192.168.1.2"));
+            EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, kl[0].type());
+            EXPECT_NE(std::string::npos, kl[1].location_specs()[0].uri().find("192.168.1.2"));
         }
         // key 400 (index 1): event report only = 1 (no NFS for 400)
         {
@@ -7862,7 +7865,8 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
         {
             const auto &kl = locs[2].cache_locations_view();
             ASSERT_EQ(2u, kl.size());
-            EXPECT_NE(std::string::npos, kl[0].location_specs()[0].uri().find("192.168.1.2"));
+            EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, kl[0].type());
+            EXPECT_NE(std::string::npos, kl[1].location_specs()[0].uri().find("192.168.1.2"));
         }
         // key 600 (index 3): event report only = 1 (no NFS for 600)
         {
@@ -7879,7 +7883,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
         }
     }
 
-    // --- Test 3: EVENT_REPORT COVERAGE + NFS (NFS presence does not affect event report coverage selection) ---
+    // --- Test 3: EVENT_REPORT COVERAGE scores only hits beyond the NFS base ---
     {
         std::vector<BackendSelector> selectors = {
             {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
@@ -7898,15 +7902,18 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
         ASSERT_EQ(EC_OK, ec);
         ASSERT_EQ(5u, locs.size());
 
-        // peer_B covers most keys (300,400,500,600) = 4
+        // peer_A and peer_B each add 400 and 600 beyond the NFS base. peer_B
+        // wins the tie because it covers more keys itself.
         // key 300 (index 0): event report + NFS = 2
         ASSERT_EQ(2u, locs[0].cache_locations_view().size());
-        EXPECT_NE(std::string::npos, locs[0].cache_locations_view()[0].location_specs()[0].uri().find("192.168.1.2"));
+        EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, locs[0].cache_locations_view()[0].type());
+        EXPECT_NE(std::string::npos, locs[0].cache_locations_view()[1].location_specs()[0].uri().find("192.168.1.2"));
         // key 400 (index 1): event report only = 1
         ASSERT_EQ(1u, locs[1].cache_locations_view().size());
         EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, locs[1].cache_locations_view()[0].type());
         // key 500 (index 2): event report + NFS = 2
         ASSERT_EQ(2u, locs[2].cache_locations_view().size());
+        EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, locs[2].cache_locations_view()[0].type());
         // key 600 (index 3): event report only = 1
         ASSERT_EQ(1u, locs[3].cache_locations_view().size());
         EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, locs[3].cache_locations_view()[0].type());
@@ -7947,7 +7954,7 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
         EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, locs[4].cache_locations_view()[0].type());
     }
 
-    // --- Test 5: PREFIX stops when first key has no event report, but NFS still works ---
+    // --- Test 5: NFS at the first key lets PREFIX continue with one peer ---
     // keys = {700, 300, 400}; NFS exists for 700 and 300, not for 400
     {
         std::vector<int64_t> keys_no_er_first = {700, 300, 400};
@@ -7967,15 +7974,18 @@ TEST_F(CacheManagerTest, TestGetCacheLocationsByBackend) {
                                                                      selectors);
         ASSERT_EQ(EC_OK, ec);
         ASSERT_EQ(3u, locs.size());
-        // EVENT_REPORT PREFIX stops at key 700 → no event report for any key
         // key 700 (index 0): NFS only = 1
         ASSERT_EQ(1u, locs[0].cache_locations_view().size());
         EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, locs[0].cache_locations_view()[0].type());
-        // key 300 (index 1): NFS only = 1 (event report blocked by prefix)
-        ASSERT_EQ(1u, locs[1].cache_locations_view().size());
+        // key 300 (index 1): peer_A + NFS = 2
+        ASSERT_EQ(2u, locs[1].cache_locations_view().size());
         EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_NFS, locs[1].cache_locations_view()[0].type());
-        // key 400 (index 2): nothing (no event report from prefix, no NFS written)
-        EXPECT_TRUE(locs[2].cache_locations_view().empty());
+        EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, locs[1].cache_locations_view()[1].type());
+        EXPECT_NE(std::string::npos, locs[1].cache_locations_view()[1].location_specs()[0].uri().find("192.168.1.1"));
+        // key 400 (index 2): peer_A continues the combined prefix
+        ASSERT_EQ(1u, locs[2].cache_locations_view().size());
+        EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, locs[2].cache_locations_view()[0].type());
+        EXPECT_NE(std::string::npos, locs[2].cache_locations_view()[0].location_specs()[0].uri().find("192.168.1.1"));
     }
 
     // --- Test 6: COVERAGE skips keys with no event report, NFS fills gaps independently ---

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -4308,21 +4308,23 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
 
 class BatchGetBestLocationByBackendTest : public MetaSearcherTest {
 protected:
-    void AddTairLocations(const MetaSearcher::KeyVector &keys) {
+    void AddServingLocations(const MetaSearcher::KeyVector &keys, DataStorageType type, const std::string &uri) {
         for (int64_t key : keys) {
-            auto tair_loc = MetaSearcherTestHelper::CreateCacheLocation(
-                DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL,
-                1,
-                {MetaSearcherTestHelper::CreateLocationSpec("tp0", "tair://host_t:6379/tp0")});
+            auto location = MetaSearcherTestHelper::CreateCacheLocation(
+                type, 1, {MetaSearcherTestHelper::CreateLocationSpec("tp0", uri)});
             std::vector<std::string> out_ids;
             ASSERT_EQ(
                 ErrorCode::EC_OK,
-                BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), {key}, {tair_loc}, out_ids));
+                BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), {key}, {location}, out_ids));
             std::vector<std::vector<MetaSearcher::LocationUpdateTask>> tasks = {{{out_ids[0], CLS_SERVING}}};
             std::vector<std::vector<ErrorCode>> results;
             ASSERT_EQ(ErrorCode::EC_OK,
                       meta_searcher_->BatchUpdateLocationStatus(request_context_.get(), {key}, tasks, results));
         }
+    }
+
+    void AddTairLocations(const MetaSearcher::KeyVector &keys) {
+        AddServingLocations(keys, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, "tair://host_t:6379/tp0");
     }
 
     void AddRequestedSpecMatrixEventReportPeer() {
@@ -4518,6 +4520,67 @@ TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixComposesWithTairBaseH
         EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, out[key_index][1]->type());
         EXPECT_NE(out[key_index][1]->location_specs()[0].uri().find("peer_a"), std::string::npos);
     }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixComposesWithIndependentBackendsInEitherSelectorOrder) {
+    AddServingLocations(
+        {80004}, DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, "pace://host_s/tp0?size=1&media_type=5");
+    AddServingLocations(
+        {80004}, DataStorageType::DATA_STORAGE_TYPE_HF3FS, "hf3fs:///tmp/base-hit?offset=0&length=1&size=1");
+
+    const MetaSearcher::KeyVector keys = {80004, 80000, 80001};
+    for (const DataStorageType base_type :
+         {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL_SSD, DataStorageType::DATA_STORAGE_TYPE_HF3FS}) {
+        const std::vector<std::vector<BackendSelector>> selector_orders = {
+            {
+                {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+                {base_type, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+            },
+            {
+                {base_type, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+                {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+            },
+        };
+        for (const auto &selectors : selector_orders) {
+            LocationsPerKey out;
+            ASSERT_EQ(
+                ErrorCode::EC_OK,
+                meta_searcher_->BatchGetBestLocationByBackend(request_context_.get(), keys, out, &policy_, selectors));
+
+            ASSERT_EQ(keys.size(), out.size());
+            ASSERT_EQ(1u, out[0].size());
+            EXPECT_EQ(base_type, out[0][0]->type());
+            for (size_t key_index = 1; key_index < keys.size(); ++key_index) {
+                ASSERT_EQ(1u, out[key_index].size());
+                EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, out[key_index][0]->type());
+                EXPECT_NE(out[key_index][0]->location_specs()[0].uri().find("peer_a"), std::string::npos);
+            }
+        }
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixDoesNotCountSpecFilteredLocationAsBaseHit) {
+    AddRequestedSpecMatrixEventReportPeer();
+    AddTairLocations({82000, 82001, 82002});
+
+    const MetaSearcher::KeyVector keys = {82000, 82001, 82002};
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+        {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(
+                  request_context_.get(), keys, out, &policy_, selectors, {"linear_1", "linear_1", "linear_1"}));
+
+    ASSERT_EQ(keys.size(), out.size());
+    ASSERT_EQ(1u, out[0].size());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, out[0][0]->type());
+    EXPECT_TRUE(std::any_of(out[0][0]->location_specs().begin(),
+                            out[0][0]->location_specs().end(),
+                            [](const LocationSpec &spec) { return spec.name() == "linear_1"; }));
+    EXPECT_TRUE(out[1].empty());
+    EXPECT_TRUE(out[2].empty());
 }
 
 TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixPreservesV6DHitsBeforeUnfillableGap) {

--- a/kv_cache_manager/manager/test/meta_searcher_test.cc
+++ b/kv_cache_manager/manager/test/meta_searcher_test.cc
@@ -455,8 +455,8 @@ public:
         EXPECT_EQ(EC_OK, cache->Init("test", cache_config));
         EXPECT_EQ(EC_OK, cache->Open());
         meta_indexer_->backend_manager_->cache_backend_ = std::move(cache);
-        meta_indexer_->backend_manager_->recover_state_.store(
-            MetaStorageBackendManager::RecoverState::kRunning, std::memory_order_release);
+        meta_indexer_->backend_manager_->recover_state_.store(MetaStorageBackendManager::RecoverState::kRunning,
+                                                              std::memory_order_release);
         return backend;
     }
 
@@ -2068,13 +2068,13 @@ TEST_F(MetaSearcherTest, TestMaintenanceDeleteSyncsPendingWriteBeforeExpectedVal
     std::vector<std::vector<ErrorCode>> delete_results;
     EXPECT_EQ(EC_OK,
               meta_searcher_->BatchDeleteLocations(request_context_.get(),
-                                                    {key},
-                                                    {{location_id}},
-                                                    delete_results,
-                                                    {{old_location->ToJsonString()}},
-                                                    false,
-                                                    false,
-                                                    true));
+                                                   {key},
+                                                   {{location_id}},
+                                                   delete_results,
+                                                   {{old_location->ToJsonString()}},
+                                                   false,
+                                                   false,
+                                                   true));
     EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), delete_results);
     EXPECT_EQ((std::vector<std::string>{"sync", "read"}), backend->Events());
 
@@ -2110,13 +2110,13 @@ TEST_F(MetaSearcherTest, TestMaintenanceDeleteSyncsAcceptedDeleteBeforeShardFenc
     std::vector<std::vector<ErrorCode>> delete_results;
     EXPECT_EQ(EC_OK,
               meta_searcher_->BatchDeleteLocations(request_context_.get(),
-                                                    {key},
-                                                    {{location_id}},
-                                                    delete_results,
-                                                    {{location->ToJsonString()}},
-                                                    false,
-                                                    false,
-                                                    true));
+                                                   {key},
+                                                   {{location_id}},
+                                                   delete_results,
+                                                   {{location->ToJsonString()}},
+                                                   false,
+                                                   false,
+                                                   true));
     EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
     EXPECT_EQ((std::vector<std::string>{"sync", "read", "delete_key", "sync"}), backend->Events());
 }
@@ -2143,13 +2143,13 @@ TEST_F(MetaSearcherTest, TestCachedMaintenanceDeleteUsesHotMutationInsteadOfPost
     std::vector<std::vector<ErrorCode>> delete_results;
     EXPECT_EQ(EC_OK,
               meta_searcher_->BatchDeleteLocations(request_context_.get(),
-                                                    {key},
-                                                    {{location_id}},
-                                                    delete_results,
-                                                    {{location->ToJsonString()}},
-                                                    false,
-                                                    false,
-                                                    true));
+                                                   {key},
+                                                   {{location_id}},
+                                                   delete_results,
+                                                   {{location->ToJsonString()}},
+                                                   false,
+                                                   false,
+                                                   true));
     EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
     EXPECT_EQ((std::vector<std::string>{"sync", "read", "delete_key"}), backend->Events());
 }
@@ -2167,12 +2167,10 @@ TEST_F(MetaSearcherTest, TestMaintenanceDeleteAccountsAcceptedMutationWhenPostSy
          {LocationSpec("linear_0", "event_report://post-sync-failure:8080/mem?size=17")}},
     }};
     std::vector<ErrorCode> per_key_ec;
-    ASSERT_EQ(EC_OK,
-              meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {key}, merge_tasks, per_key_ec));
+    ASSERT_EQ(EC_OK, meta_searcher_->BatchMergeLocationSpecs(request_context_.get(), {key}, merge_tasks, per_key_ec));
     ASSERT_EQ((std::vector<ErrorCode>{EC_OK}), per_key_ec);
     ASSERT_EQ(1u, meta_indexer_->GetKeyCount());
-    ASSERT_EQ(17u,
-              meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
+    ASSERT_EQ(17u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
 
     std::vector<CacheLocationMap> location_maps;
     BlockMask mask;
@@ -2184,15 +2182,10 @@ TEST_F(MetaSearcherTest, TestMaintenanceDeleteAccountsAcceptedMutationWhenPostSy
     backend->ResetEvents();
     backend->FailSyncCall(2);
     std::vector<std::vector<ErrorCode>> delete_results;
-    EXPECT_EQ(EC_ERROR,
-              meta_searcher_->BatchDeleteLocations(request_context_.get(),
-                                                    {key},
-                                                    {{location_id}},
-                                                    delete_results,
-                                                    {{expected_value}},
-                                                    true,
-                                                    true,
-                                                    true));
+    EXPECT_EQ(
+        EC_ERROR,
+        meta_searcher_->BatchDeleteLocations(
+            request_context_.get(), {key}, {{location_id}}, delete_results, {{expected_value}}, true, true, true));
     EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
     EXPECT_EQ((std::vector<std::string>{"sync", "read", "delete_key", "sync"}), backend->Events());
     EXPECT_EQ(0u, meta_indexer_->GetKeyCount());
@@ -2202,15 +2195,10 @@ TEST_F(MetaSearcherTest, TestMaintenanceDeleteAccountsAcceptedMutationWhenPostSy
     // is visible, that retry converges as NOENT and must not account twice.
     backend->FailSyncCall(0);
     backend->ResetEvents();
-    EXPECT_EQ(EC_OK,
-              meta_searcher_->BatchDeleteLocations(request_context_.get(),
-                                                    {key},
-                                                    {{location_id}},
-                                                    delete_results,
-                                                    {{expected_value}},
-                                                    true,
-                                                    true,
-                                                    true));
+    EXPECT_EQ(
+        EC_OK,
+        meta_searcher_->BatchDeleteLocations(
+            request_context_.get(), {key}, {{location_id}}, delete_results, {{expected_value}}, true, true, true));
     EXPECT_EQ((std::vector<std::vector<ErrorCode>>{{EC_NOENT}}), delete_results);
     EXPECT_EQ(0u, meta_indexer_->GetKeyCount());
     EXPECT_EQ(0u, meta_indexer_->GetStorageUsageByType(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2));
@@ -2244,9 +2232,10 @@ TEST_F(MetaSearcherTest, TestConditionalDeleteDoesNotRemoveRefreshedStableLocati
 
     LocationIdsPerKey location_ids = {{location_id}};
     std::vector<std::vector<ErrorCode>> delete_results;
-    ASSERT_EQ(EC_OK,
-              meta_searcher_->BatchDeleteLocations(
-                  request_context_.get(), keys, location_ids, delete_results, {{stale_expected_value}}, true, true, true));
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchDeleteLocations(
+            request_context_.get(), keys, location_ids, delete_results, {{stale_expected_value}}, true, true, true));
     ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_MISMATCH}}), delete_results);
 
     ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
@@ -2256,11 +2245,18 @@ TEST_F(MetaSearcherTest, TestConditionalDeleteDoesNotRemoveRefreshedStableLocati
 
     const std::string current_expected_value = location_maps[0].at(location_id)->ToJsonString();
     ASSERT_EQ(EC_BADARGS,
-              meta_searcher_->BatchDeleteLocations(
-                  request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}, {}}, true, true, true));
-    ASSERT_EQ(EC_OK,
-              meta_searcher_->BatchDeleteLocations(
-                  request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}}, true, true, true));
+              meta_searcher_->BatchDeleteLocations(request_context_.get(),
+                                                   keys,
+                                                   location_ids,
+                                                   delete_results,
+                                                   {{current_expected_value}, {}},
+                                                   true,
+                                                   true,
+                                                   true));
+    ASSERT_EQ(
+        EC_OK,
+        meta_searcher_->BatchDeleteLocations(
+            request_context_.get(), keys, location_ids, delete_results, {{current_expected_value}}, true, true, true));
     ASSERT_EQ((std::vector<std::vector<ErrorCode>>{{EC_OK}}), delete_results);
 
     ASSERT_EQ(EC_OK, meta_searcher_->BatchGetLocation(request_context_.get(), keys, mask, location_maps));
@@ -4312,6 +4308,23 @@ TEST_F(MetaSearcherTest, TestBatchGetMergesSpecsByStorageType) {
 
 class BatchGetBestLocationByBackendTest : public MetaSearcherTest {
 protected:
+    void AddTairLocations(const MetaSearcher::KeyVector &keys) {
+        for (int64_t key : keys) {
+            auto tair_loc = MetaSearcherTestHelper::CreateCacheLocation(
+                DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL,
+                1,
+                {MetaSearcherTestHelper::CreateLocationSpec("tp0", "tair://host_t:6379/tp0")});
+            std::vector<std::string> out_ids;
+            ASSERT_EQ(
+                ErrorCode::EC_OK,
+                BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), {key}, {tair_loc}, out_ids));
+            std::vector<std::vector<MetaSearcher::LocationUpdateTask>> tasks = {{{out_ids[0], CLS_SERVING}}};
+            std::vector<std::vector<ErrorCode>> results;
+            ASSERT_EQ(ErrorCode::EC_OK,
+                      meta_searcher_->BatchUpdateLocationStatus(request_context_.get(), {key}, tasks, results));
+        }
+    }
+
     void AddRequestedSpecMatrixEventReportPeer() {
         // The requested spec is deliberately the second spec in the first
         // and third locations. The middle key has the same reporter but only
@@ -4433,19 +4446,7 @@ protected:
         ASSERT_EQ(ec, ErrorCode::EC_OK);
 
         // Tair locations for all 5 keys
-        MetaSearcher::KeyVector tair_keys = {80000, 80001, 80002, 80003, 80004};
-        for (int64_t key : tair_keys) {
-            auto tair_loc = MetaSearcherTestHelper::CreateCacheLocation(
-                DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL,
-                1,
-                {MetaSearcherTestHelper::CreateLocationSpec("tp0", "tair://host_t:6379/tp0")});
-            std::vector<std::string> out_ids;
-            ec = BatchAddLocationForTest(meta_searcher_.get(), request_context_.get(), {key}, {tair_loc}, out_ids);
-            ASSERT_EQ(ec, ErrorCode::EC_OK);
-            std::vector<std::vector<MetaSearcher::LocationUpdateTask>> tasks = {{{out_ids[0], CLS_SERVING}}};
-            std::vector<std::vector<ErrorCode>> results;
-            meta_searcher_->BatchUpdateLocationStatus(request_context_.get(), {key}, tasks, results);
-        }
+        AddTairLocations({80000, 80001, 80002, 80003, 80004});
         recording_backend_->ResetReadLog();
     }
 
@@ -4495,6 +4496,107 @@ TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageStrategy) {
         EXPECT_NE(out[i][0]->location_specs()[0].uri().find("peer_b"), std::string::npos);
     }
     EXPECT_TRUE(out[4].empty());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixComposesWithTairBaseHits) {
+    const MetaSearcher::KeyVector keys = {80004, 80000, 80001};
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+        {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+    };
+
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(request_context_.get(), keys, out, &policy_, selectors));
+
+    ASSERT_EQ(keys.size(), out.size());
+    ASSERT_EQ(1u, out[0].size());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, out[0][0]->type());
+    for (size_t key_index = 1; key_index < keys.size(); ++key_index) {
+        ASSERT_EQ(2u, out[key_index].size());
+        EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, out[key_index][0]->type());
+        EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, out[key_index][1]->type());
+        EXPECT_NE(out[key_index][1]->location_specs()[0].uri().find("peer_a"), std::string::npos);
+    }
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportPrefixPreservesV6DHitsBeforeUnfillableGap) {
+    const MetaSearcher::KeyVector keys = {80000, 85000, 80001};
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_PREFIX},
+        {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+    };
+
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(request_context_.get(), keys, out, &policy_, selectors));
+
+    ASSERT_EQ(keys.size(), out.size());
+    ASSERT_EQ(2u, out[0].size());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, out[0][0]->type());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, out[0][1]->type());
+    EXPECT_NE(out[0][1]->location_specs()[0].uri().find("peer_a"), std::string::npos);
+    EXPECT_TRUE(out[1].empty());
+    ASSERT_EQ(1u, out[2].size());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, out[2][0]->type());
+}
+
+TEST_F(BatchGetBestLocationByBackendTest, EventReportCoverageMaximizesHitsBeyondTairBase) {
+    std::vector<std::vector<MetaSearcher::MergeLocationSpecsTask>> upserts = {
+        {
+            {"kvs#event_report_l2#mem#peer_a:8080",
+             DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+             CLS_SERVING,
+             {LocationSpec("tp0", "event_report://peer_a:8080/tp0")}},
+        },
+        {
+            {"kvs#event_report_l2#mem#peer_a:8080",
+             DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+             CLS_SERVING,
+             {LocationSpec("tp0", "event_report://peer_a:8080/tp0")}},
+        },
+        {
+            {"kvs#event_report_l2#mem#peer_a:8080",
+             DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+             CLS_SERVING,
+             {LocationSpec("tp0", "event_report://peer_a:8080/tp0")}},
+            {"kvs#event_report_l2#mem#peer_b:8080",
+             DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+             CLS_SERVING,
+             {LocationSpec("tp0", "event_report://peer_b:8080/tp0")}},
+        },
+        {
+            {"kvs#event_report_l2#mem#peer_b:8080",
+             DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2,
+             CLS_SERVING,
+             {LocationSpec("tp0", "event_report://peer_b:8080/tp0")}},
+        },
+    };
+    std::vector<ErrorCode> per_key_ec;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchMergeLocationSpecs(
+                  request_context_.get(), {84000, 84001, 84002, 84003}, upserts, per_key_ec));
+    AddTairLocations({84000, 84001, 84002});
+
+    const MetaSearcher::KeyVector keys = {84000, 84001, 84002, 84003};
+    const std::vector<BackendSelector> selectors = {
+        {DataStorageType::DATA_STORAGE_TYPE_EVENT_REPORT_L2, LocationSelectStrategy::LSS_V6D_COVERAGE},
+        {DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, LocationSelectStrategy::LSS_WEIGHTED_RANDOM},
+    };
+    LocationsPerKey out;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher_->BatchGetBestLocationByBackend(request_context_.get(), keys, out, &policy_, selectors));
+
+    ASSERT_EQ(keys.size(), out.size());
+    ASSERT_EQ(1u, out[0].size());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, out[0][0]->type());
+    ASSERT_EQ(1u, out[1].size());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, out[1][0]->type());
+    ASSERT_EQ(2u, out[2].size());
+    EXPECT_EQ(DataStorageType::DATA_STORAGE_TYPE_TAIR_MEMPOOL, out[2][0]->type());
+    EXPECT_NE(out[2][1]->location_specs()[0].uri().find("peer_b"), std::string::npos);
+    ASSERT_EQ(1u, out[3].size());
+    EXPECT_NE(out[3][0]->location_specs()[0].uri().find("peer_b"), std::string::npos);
 }
 
 TEST_F(BatchGetBestLocationByBackendTest, BlockMaskSkipsMetadataReadsAndPreservesOutputPositions) {


### PR DESCRIPTION
## 背景

当冷存储（Tair Mempool / NFS）与 EventReport L2（V6D）组合查询时，原先各后端独立参与选址，冷存储已有命中不会参与 V6D peer 的前缀或覆盖率计算，可能导致选中的 peer 无法形成最长连续前缀，或没有补足最多的冷存储缺口。

## 改动

- 将冷存储 selector 稳定地排在 EventReport L2 之前，记录每个查询 key 的基础命中。
- PREFIX 策略按“冷存储命中 + 单个 V6D peer 命中”选择最长连续组合前缀，并保留确定性的覆盖数与地址 tie-break。
- COVERAGE 策略优先选择能够补足最多冷存储未命中 key 的 peer。
- 补充并更新组合前缀、不可填补缺口和增量覆盖率等单元测试场景。

## 职责与调用关系

`MetaSearcher::BatchGetBestLocationByBackend` 负责按后端选择策略为一批 cache key 组合最佳位置。典型调用路径为 `MetaService → CacheManager::GetCacheLocationsByBackend → MetaSearcher::BatchGetBestLocationByBackend`。本次改动只调整 manager 层的组合选址逻辑，不修改外部接口或协议。

## 验证

- 本次会话仅创建 PR，未重新运行测试。
- PR 中已包含相关单元测试改动，等待 CI 验证。

---

## Background

When cold storage (Tair Mempool / NFS) and EventReport L2 (V6D) are queried together, backend selection was previously evaluated independently. Existing cold-storage hits were not considered when selecting a V6D peer by prefix or coverage, which could select a peer that does not form the longest continuous prefix or fill the most cold-storage misses.

## Changes

- Stably evaluate cold-storage selectors before EventReport L2 and track the base hit for each query key.
- For PREFIX, select the peer that maximizes the continuous combined prefix across cold-storage and V6D hits, while preserving deterministic coverage and address tie-breaks.
- For COVERAGE, prefer the peer that fills the largest number of keys not already hit by cold storage.
- Add and update unit-test scenarios for combined prefixes, unfillable gaps, and incremental coverage.

## Responsibility and call path

`MetaSearcher::BatchGetBestLocationByBackend` composes the best locations for a batch of cache keys according to backend selection strategies. The typical call path is `MetaService → CacheManager::GetCacheLocationsByBackend → MetaSearcher::BatchGetBestLocationByBackend`. This change only adjusts composition logic in the manager layer and does not change external APIs or protocols.

## Validation

- Tests were not rerun in this PR-creation session.
- The PR includes relevant unit-test changes and awaits CI validation.