### PR TITLE
[data_storage] reduce EventReportBackend lock contention

### DIFF
--- a/kv_cache_manager/data_storage/event_report_backend.cc
+++ b/kv_cache_manager/data_storage/event_report_backend.cc
@@ -27,7 +27,7 @@ namespace {
 
 std::string GenerateSnapshotVersionToken() {
     std::array<unsigned char, 16> bytes{};
-    std::random_device random;
+    thread_local std::random_device random;
     for (auto &byte : bytes) {
         byte = static_cast<unsigned char>(random());
     }
@@ -55,7 +55,10 @@ EventReportBackend::~EventReportBackend() {
 
 std::shared_ptr<EventReportBackend::LifecycleFence>
 EventReportBackend::GetOrCreateLifecycleFence(const ReporterSnapshotKey &reporter_key) {
-    std::lock_guard<std::mutex> lock(lifecycle_fences_mutex_);
+    if (const auto fence = FindLifecycleFence(reporter_key)) {
+        return fence;
+    }
+    std::unique_lock<std::shared_mutex> lock(lifecycle_fences_mutex_);
     auto &fence = lifecycle_fences_[reporter_key];
     if (!fence) {
         fence = std::make_shared<LifecycleFence>();
@@ -65,9 +68,43 @@ EventReportBackend::GetOrCreateLifecycleFence(const ReporterSnapshotKey &reporte
 
 std::shared_ptr<EventReportBackend::LifecycleFence>
 EventReportBackend::FindLifecycleFence(const ReporterSnapshotKey &reporter_key) const {
-    std::lock_guard<std::mutex> lock(lifecycle_fences_mutex_);
+    std::shared_lock<std::shared_mutex> lock(lifecycle_fences_mutex_);
     const auto it = lifecycle_fences_.find(reporter_key);
     return it == lifecycle_fences_.end() ? nullptr : it->second;
+}
+
+std::vector<std::shared_ptr<EventReportBackend::LifecycleFence>> EventReportBackend::GetLifecycleFences() const {
+    std::shared_lock<std::shared_mutex> lock(lifecycle_fences_mutex_);
+    std::vector<std::shared_ptr<LifecycleFence>> fences;
+    fences.reserve(lifecycle_fences_.size());
+    for (const auto &entry : lifecycle_fences_) {
+        if (entry.second) {
+            fences.push_back(entry.second);
+        }
+    }
+    return fences;
+}
+
+std::string EventReportBackend::ReserveSnapshotVersionToken(const ReporterSnapshotKey &reporter_key) {
+    for (;;) {
+        std::string token = GenerateSnapshotVersionToken();
+        std::unique_lock<std::shared_mutex> lock(snapshot_token_owners_mutex_);
+        if (snapshot_token_owners_.emplace(token, reporter_key).second) {
+            return token;
+        }
+    }
+}
+
+void EventReportBackend::ReleaseSnapshotVersionToken(const ReporterSnapshotKey &reporter_key,
+                                                     const std::string &token) {
+    if (token.empty()) {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> lock(snapshot_token_owners_mutex_);
+    const auto it = snapshot_token_owners_.find(token);
+    if (it != snapshot_token_owners_.end() && it->second == reporter_key) {
+        snapshot_token_owners_.erase(it);
+    }
 }
 
 // --- DataStorageBackend interface ---
@@ -85,7 +122,12 @@ void EventReportBackend::SetAvailable(bool available) {
         ResetMaintenanceRecoveryGrace();
     }
     if (!available) {
-        snapshot_state_cv_.notify_all();
+        for (const auto &fence : GetLifecycleFences()) {
+            // Synchronize with the waiter's check-to-wait transition. The
+            // atomic availability flag alone cannot prevent a lost wakeup.
+            std::lock_guard<std::mutex> state_lock(fence->state_mutex);
+            fence->snapshot_state_cv.notify_all();
+        }
     }
 }
 
@@ -178,16 +220,7 @@ ErrorCode EventReportBackend::Close() {
     if (liveness_checker_thread_.joinable()) {
         liveness_checker_thread_.join();
     }
-    std::vector<std::shared_ptr<LifecycleFence>> fence_refs;
-    {
-        std::lock_guard<std::mutex> fences_guard(lifecycle_fences_mutex_);
-        fence_refs.reserve(lifecycle_fences_.size());
-        for (const auto &entry : lifecycle_fences_) {
-            if (entry.second) {
-                fence_refs.push_back(entry.second);
-            }
-        }
-    }
+    auto fence_refs = GetLifecycleFences();
 
     // Never wait for a lifecycle fence while holding lifecycle_fences_mutex_.
     // Cleanup deliberately takes lifecycle -> metadata, while a metadata RMW
@@ -204,16 +237,25 @@ ErrorCode EventReportBackend::Close() {
         std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
         instance_nodes_.clear();
         node_generation_.clear();
-        snapshot_versions_.clear();
+    }
+    for (const auto &fence : fence_refs) {
+        {
+            std::lock_guard<std::mutex> state_lock(fence->state_mutex);
+            fence->registered = false;
+            fence->snapshot_state = {};
+        }
+        fence->snapshot_state_cv.notify_all();
+    }
+    {
+        std::unique_lock<std::shared_mutex> token_lock(snapshot_token_owners_mutex_);
         snapshot_token_owners_.clear();
     }
     {
-        std::lock_guard<std::mutex> fences_guard(lifecycle_fences_mutex_);
+        std::unique_lock<std::shared_mutex> fences_guard(lifecycle_fences_mutex_);
         lifecycle_fences_.clear();
     }
     fence_locks.clear();
     fence_refs.clear();
-    snapshot_state_cv_.notify_all();
     {
         std::lock_guard<std::mutex> lock(cleanup_cb_mutex_);
         cleanup_callback_ = nullptr;
@@ -253,6 +295,7 @@ ErrorCode EventReportBackend::RegisterNode(const std::string &instance_id,
         return EC_INSTANCE_NOT_EXIST;
     }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    std::lock_guard<std::mutex> state_lock(lifecycle_fence->state_mutex);
     auto &host_map = instance_nodes_[instance_id];
     auto it = host_map.find(host_ip_port);
     ++node_generation_[instance_id][host_ip_port];
@@ -261,6 +304,7 @@ ErrorCode EventReportBackend::RegisterNode(const std::string &instance_id,
     int64_t now_ms = NowMillis();
     if (it != host_map.end()) {
         auto &info = *it->second;
+        info.lifecycle_fence = lifecycle_fence;
         for (const auto &m : mediums) {
             if (std::find(info.mediums.begin(), info.mediums.end(), m) == info.mediums.end()) {
                 info.mediums.push_back(m);
@@ -281,6 +325,7 @@ ErrorCode EventReportBackend::RegisterNode(const std::string &instance_id,
     }
 
     auto info = std::make_unique<NodeInfo>();
+    info->lifecycle_fence = lifecycle_fence;
     info->last_heartbeat_ms.store(now_ms, std::memory_order_relaxed);
     info->available.store(true, std::memory_order_relaxed);
     info->unavailable_since_ms.store(0, std::memory_order_relaxed);
@@ -369,11 +414,13 @@ ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_i
         return EC_INSTANCE_NOT_EXIST;
     }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    std::lock_guard<std::mutex> state_lock(lifecycle_fence->state_mutex);
     auto &host_map = instance_nodes_[instance_id];
     if (auto it = host_map.find(host_ip_port); it != host_map.end()) {
         // Another request may have created the node between the fast-path
         // check and acquiring the lifecycle lock.
         merge_mediums(*it->second);
+        it->second->lifecycle_fence = lifecycle_fence;
         lifecycle_fence->generation = node_generation_[instance_id][host_ip_port];
         lifecycle_fence->registered = true;
         return EC_OK;
@@ -387,6 +434,7 @@ ErrorCode EventReportBackend::EnsureNodeRegistered(const std::string &instance_i
     lifecycle_fence->generation = generation;
     lifecycle_fence->registered = true;
     auto info = std::make_unique<NodeInfo>();
+    info->lifecycle_fence = lifecycle_fence;
     info->last_heartbeat_ms.store(NowMillis(), std::memory_order_relaxed);
     info->available.store(true, std::memory_order_relaxed);
     info->unavailable_since_ms.store(0, std::memory_order_relaxed);
@@ -413,10 +461,7 @@ ErrorCode EventReportBackend::UnregisterNode(const std::string &instance_id, con
         return EC_INSTANCE_NOT_EXIST;
     }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
-    const ErrorCode ec = UnregisterNodeLocked(instance_id, host_ip_port);
-    lifecycle_fence->generation = node_generation_[instance_id][host_ip_port];
-    lifecycle_fence->registered = false;
-    return ec;
+    return UnregisterNodeLocked(instance_id, host_ip_port, *lifecycle_fence);
 }
 
 ErrorCode EventReportBackend::UnregisterNodeForHostDown(const std::string &instance_id,
@@ -430,15 +475,21 @@ ErrorCode EventReportBackend::UnregisterNodeForHostDown(const std::string &insta
     }
     std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     out_generation = node_generation_[instance_id][host_ip_port];
-    lifecycle_fence->generation = out_generation;
-    lifecycle_fence->registered = false;
     const auto instance_it = instance_nodes_.find(instance_id);
     if (instance_it == instance_nodes_.end() || instance_it->second.find(host_ip_port) == instance_it->second.end()) {
         // HOST_DOWN is explicitly idempotent. Keep the tombstone generation
         // above, but do not emit the generic missing-node warning.
+        std::unique_lock<std::mutex> state_lock(lifecycle_fence->state_mutex);
+        lifecycle_fence->generation = out_generation;
+        lifecycle_fence->registered = false;
+        ReleaseSnapshotVersionToken(reporter_key, lifecycle_fence->snapshot_state.committed);
+        ReleaseSnapshotVersionToken(reporter_key, lifecycle_fence->snapshot_state.in_flight);
+        lifecycle_fence->snapshot_state = {};
+        state_lock.unlock();
+        lifecycle_fence->snapshot_state_cv.notify_all();
         return EC_OK;
     }
-    return UnregisterNodeLocked(instance_id, host_ip_port);
+    return UnregisterNodeLocked(instance_id, host_ip_port, *lifecycle_fence);
 }
 
 ErrorCode EventReportBackend::UnregisterNodeIfGeneration(const std::string &instance_id,
@@ -462,14 +513,22 @@ ErrorCode EventReportBackend::UnregisterNodeIfGeneration(const std::string &inst
     if (current_generation != expected_generation) {
         return EC_MISMATCH;
     }
-    const ErrorCode ec = UnregisterNodeLocked(instance_id, host_ip_port);
-    lifecycle_fence->generation = current_generation;
-    lifecycle_fence->registered = false;
-    return ec;
+    return UnregisterNodeLocked(instance_id, host_ip_port, *lifecycle_fence);
 }
 
-ErrorCode EventReportBackend::UnregisterNodeLocked(const std::string &instance_id, const std::string &host_ip_port) {
+ErrorCode EventReportBackend::UnregisterNodeLocked(const std::string &instance_id,
+                                                   const std::string &host_ip_port,
+                                                   LifecycleFence &lifecycle_fence) {
     node_generation_[instance_id].try_emplace(host_ip_port, 0);
+    std::unique_lock<std::mutex> state_lock(lifecycle_fence.state_mutex);
+    lifecycle_fence.generation = node_generation_[instance_id][host_ip_port];
+    lifecycle_fence.registered = false;
+    const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
+    ReleaseSnapshotVersionToken(reporter_key, lifecycle_fence.snapshot_state.committed);
+    ReleaseSnapshotVersionToken(reporter_key, lifecycle_fence.snapshot_state.in_flight);
+    lifecycle_fence.snapshot_state = {};
+    state_lock.unlock();
+    lifecycle_fence.snapshot_state_cv.notify_all();
     auto inst_it = instance_nodes_.find(instance_id);
     if (inst_it == instance_nodes_.end()) {
         KVCM_LOG_WARN("EventReportBackend: instance [%s] not found for unregister node [%s]",
@@ -495,13 +554,6 @@ ErrorCode EventReportBackend::UnregisterNodeLocked(const std::string &instance_i
         }
     }
     inst_it->second.erase(it);
-    const ReporterSnapshotKey reporter_key{instance_id, host_ip_port};
-    const auto snapshot_it = snapshot_versions_.find(reporter_key);
-    if (snapshot_it != snapshot_versions_.end() && !snapshot_it->second.committed.empty()) {
-        snapshot_token_owners_.erase(snapshot_it->second.committed);
-    }
-    snapshot_versions_.erase(reporter_key);
-    snapshot_state_cv_.notify_all();
     KVCM_LOG_INFO("EventReportBackend: node [%s] unregistered from storage [%s] for instance [%s]",
                   host_ip_port.c_str(),
                   config_.global_unique_name().c_str(),
@@ -540,6 +592,7 @@ ErrorCode EventReportBackend::OnHeartbeat(const std::string &instance_id,
         return EC_INSTANCE_NOT_EXIST;
     }
     std::unique_lock<std::shared_mutex> nodes_lock(nodes_mutex_);
+    std::unique_lock<std::mutex> state_lock(lifecycle_fence->state_mutex);
     auto &host_map = instance_nodes_[instance_id];
     auto it = host_map.find(host_ip_port);
     if (it == host_map.end()) {
@@ -555,6 +608,7 @@ ErrorCode EventReportBackend::OnHeartbeat(const std::string &instance_id,
         lifecycle_fence->generation = generation;
         lifecycle_fence->registered = true;
         auto new_info = std::make_unique<NodeInfo>();
+        new_info->lifecycle_fence = lifecycle_fence;
         new_info->last_heartbeat_ms.store(NowMillis(), std::memory_order_relaxed);
         new_info->available.store(true, std::memory_order_relaxed);
         new_info->unavailable_since_ms.store(0, std::memory_order_relaxed);
@@ -569,6 +623,7 @@ ErrorCode EventReportBackend::OnHeartbeat(const std::string &instance_id,
                       generation);
     }
     auto &info = *it->second;
+    info.lifecycle_fence = lifecycle_fence;
     int64_t now_ms = NowMillis();
     info.last_heartbeat_ms.store(now_ms, std::memory_order_release);
     bool prev = info.available.exchange(true, std::memory_order_relaxed);
@@ -587,6 +642,7 @@ ErrorCode EventReportBackend::OnHeartbeat(const std::string &instance_id,
     }
     lifecycle_fence->generation = node_generation_[instance_id][host_ip_port];
     lifecycle_fence->registered = true;
+    state_lock.unlock();
     PublishHeartbeatStatus(info, system_status, nodes_lock);
     return EC_OK;
 }
@@ -620,15 +676,13 @@ void EventReportBackend::PublishHeartbeatStatus(NodeInfo &info,
                                                 const std::map<std::string, std::string> &system_status,
                                                 std::unique_lock<std::shared_mutex> &nodes_lock) {
     std::unique_lock<std::mutex> status_lock(info.status_mutex);
-    const std::map<std::string, std::string> previous_system_status = info.last_system_status;
-    info.last_system_status = system_status;
-    const auto metrics_tags = info.metrics_tags;
 
     // Lock handoff: status_mutex now serializes this publication with
     // SetNodeUnavailable's gauge reset, while the lifecycle lease pins
     // NodeInfo. Release the global node-table lock before slower metric work.
     nodes_lock.unlock();
     if (metrics_registry_) {
+        const auto &metrics_tags = info.metrics_tags;
         const auto parse_gauge = [](const std::string &value, double &out) {
             if (value.empty()) {
                 return false;
@@ -642,7 +696,7 @@ void EventReportBackend::PublishHeartbeatStatus(NodeInfo &info,
         // prior numeric gauge when the next heartbeat omits it or changes it
         // to a non-numeric value; otherwise stale values would survive and a
         // later unregister could no longer discover the omitted key.
-        for (const auto &[name, previous_value] : previous_system_status) {
+        for (const auto &[name, previous_value] : info.last_system_status) {
             double ignored_previous = 0.0;
             if (!parse_gauge(previous_value, ignored_previous)) {
                 continue;
@@ -662,6 +716,7 @@ void EventReportBackend::PublishHeartbeatStatus(NodeInfo &info,
             }
         }
     }
+    info.last_system_status = system_status;
 }
 
 void EventReportBackend::SetNodeUnavailable(const std::string &instance_id, const std::string &host_ip_port) {
@@ -859,29 +914,37 @@ std::vector<bool> EventReportBackend::MightExist(const std::vector<DataStorageUr
     }
     std::vector<bool> result;
     result.reserve(storage_uris.size());
-    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
     for (const auto &uri : storage_uris) {
         SnapshotUriInfo info;
         if (!SnapshotUriUtils::ParseSnapshotUriInfo(uri, info)) {
             result.push_back(false);
             continue;
         }
-        const auto owner_it = snapshot_token_owners_.find(info.version);
-        if (owner_it == snapshot_token_owners_.end()) {
-            result.push_back(false);
-            continue;
+        ReporterSnapshotKey reporter_key;
+        {
+            std::shared_lock<std::shared_mutex> token_lock(snapshot_token_owners_mutex_);
+            const auto owner_it = snapshot_token_owners_.find(info.version);
+            if (owner_it == snapshot_token_owners_.end()) {
+                result.push_back(false);
+                continue;
+            }
+            reporter_key = owner_it->second;
         }
-        const ReporterSnapshotKey &reporter_key = owner_it->second;
-        const auto state_it = snapshot_versions_.find(reporter_key);
+        std::shared_lock<std::shared_mutex> nodes_lock(nodes_mutex_);
         const auto instance_it = instance_nodes_.find(reporter_key.instance_id);
-        if (state_it == snapshot_versions_.end() || state_it->second.committed != info.version ||
-            instance_it == instance_nodes_.end()) {
+        if (instance_it == instance_nodes_.end()) {
             result.push_back(false);
             continue;
         }
         const auto node_it = instance_it->second.find(reporter_key.host_ip_port);
-        result.push_back(node_it != instance_it->second.end() && node_it->second &&
-                         node_it->second->available.load(std::memory_order_relaxed));
+        if (node_it == instance_it->second.end() || !node_it->second ||
+            !node_it->second->available.load(std::memory_order_relaxed)) {
+            result.push_back(false);
+            continue;
+        }
+        const auto &lifecycle_fence = *node_it->second->lifecycle_fence;
+        std::lock_guard<std::mutex> state_lock(lifecycle_fence.state_mutex);
+        result.push_back(lifecycle_fence.snapshot_state.committed == info.version);
     }
     return result;
 }
@@ -959,61 +1022,45 @@ ErrorCode EventReportBackend::BeginDeltaMutation(const ReporterSnapshotKey &repo
     if (reporter_key.instance_id.empty() || reporter_key.host_ip_port.empty()) {
         return EC_BADARGS;
     }
-    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
     if (!AcceptingReports()) {
         return EC_INSTANCE_NOT_EXIST;
     }
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return EC_SNAPSHOT_REQUIRED;
+    }
+    std::unique_lock<std::mutex> lock(lifecycle_fence->state_mutex);
     const int64_t snapshot_wait_timeout_ms = snapshot_delta_drain_timeout_ms_;
     const bool snapshot_finished =
-        snapshot_state_cv_.wait_for(lock, std::chrono::milliseconds(snapshot_wait_timeout_ms), [&] {
-            auto it = snapshot_versions_.find(reporter_key);
-            return !AcceptingReports() || it == snapshot_versions_.end() || it->second.in_flight.empty();
+        lifecycle_fence->snapshot_state_cv.wait_for(lock, std::chrono::milliseconds(snapshot_wait_timeout_ms), [&] {
+            return !AcceptingReports() || !lifecycle_fence->registered ||
+                   lifecycle_fence->snapshot_state.in_flight.empty();
         });
     if (!snapshot_finished) {
         return EC_SNAPSHOT_IN_PROGRESS;
     }
-    // Close()/dynamic disable can wake this waiter by clearing the snapshot
-    // state.  Admission was checked before wait_for() released nodes_mutex_,
-    // so check again before creating or incrementing any mutation state.
+    // Close()/dynamic disable or unregister can wake this waiter. Recheck the
+    // reporter-local predicate before creating or incrementing mutation state.
     if (!AcceptingReports()) {
         return EC_INSTANCE_NOT_EXIST;
     }
-    auto state_it = snapshot_versions_.find(reporter_key);
-    if (state_it == snapshot_versions_.end() || state_it->second.committed.empty()) {
-        const auto instance_it = instance_nodes_.find(reporter_key.instance_id);
-        if (instance_it == instance_nodes_.end() ||
-            instance_it->second.find(reporter_key.host_ip_port) == instance_it->second.end()) {
-            return EC_SNAPSHOT_REQUIRED;
-        }
-
-        auto token_in_use = [this](const std::string &token) {
-            if (snapshot_token_owners_.count(token) > 0) {
-                return true;
-            }
-            return std::any_of(snapshot_versions_.begin(), snapshot_versions_.end(), [&token](const auto &entry) {
-                return entry.second.in_flight == token;
-            });
-        };
-        std::string candidate;
-        do {
-            candidate = GenerateSnapshotVersionToken();
-        } while (token_in_use(candidate));
-        auto &new_state = snapshot_versions_[reporter_key];
-        new_state.committed = candidate;
-        snapshot_token_owners_[candidate] = reporter_key;
-        state_it = snapshot_versions_.find(reporter_key);
+    if (!lifecycle_fence->registered) {
+        return EC_SNAPSHOT_REQUIRED;
+    }
+    auto &state = lifecycle_fence->snapshot_state;
+    if (state.committed.empty()) {
+        state.committed = ReserveSnapshotVersionToken(reporter_key);
         if (out_created_generation) {
             *out_created_generation = true;
         }
     }
-    auto &state = state_it->second;
     if (state.active_delta_mutations == std::numeric_limits<uint64_t>::max()) {
         return EC_ERROR;
     }
     ++state.active_delta_mutations;
     out_committed_version = state.committed;
     if (out_lifecycle_generation) {
-        *out_lifecycle_generation = node_generation_[reporter_key.instance_id][reporter_key.host_ip_port];
+        *out_lifecycle_generation = lifecycle_fence->generation;
     }
     return EC_OK;
 }
@@ -1021,10 +1068,17 @@ ErrorCode EventReportBackend::BeginDeltaMutation(const ReporterSnapshotKey &repo
 void EventReportBackend::EndDeltaMutation(const ReporterSnapshotKey &reporter_key,
                                           uint64_t lifecycle_generation,
                                           const std::string &expected_snapshot_version) {
-    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
-    auto it = snapshot_versions_.find(reporter_key);
-    if (it != snapshot_versions_.end() && !expected_snapshot_version.empty() &&
-        it->second.committed != expected_snapshot_version) {
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        KVCM_LOG_DEBUG("EventReportBackend: delta mutation lease ended after reporter lifecycle changed, "
+                       "instance [%s] host [%s]",
+                       reporter_key.instance_id.c_str(),
+                       reporter_key.host_ip_port.c_str());
+        return;
+    }
+    std::unique_lock<std::mutex> lock(lifecycle_fence->state_mutex);
+    auto &state = lifecycle_fence->snapshot_state;
+    if (!expected_snapshot_version.empty() && state.committed != expected_snapshot_version) {
         // HOST_DOWN removes snapshot state before an already-admitted delta
         // necessarily reaches its final metadata lease. If the reporter is
         // then registered again, a new delta can recreate state at the same
@@ -1034,16 +1088,9 @@ void EventReportBackend::EndDeltaMutation(const ReporterSnapshotKey &reporter_ke
                        reporter_key.host_ip_port.c_str());
         return;
     }
-    if (it == snapshot_versions_.end() || it->second.active_delta_mutations == 0) {
-        const auto generation_it = node_generation_.find(reporter_key.instance_id);
-        const auto node_it = instance_nodes_.find(reporter_key.instance_id);
-        const bool lifecycle_ended =
-            generation_it == node_generation_.end() ||
-            generation_it->second.find(reporter_key.host_ip_port) == generation_it->second.end() ||
-            (lifecycle_generation != 0 &&
-             generation_it->second.at(reporter_key.host_ip_port) != lifecycle_generation) ||
-            node_it == instance_nodes_.end() ||
-            node_it->second.find(reporter_key.host_ip_port) == node_it->second.end();
+    if (state.active_delta_mutations == 0) {
+        const bool lifecycle_ended = !lifecycle_fence->registered ||
+                                     (lifecycle_generation != 0 && lifecycle_fence->generation != lifecycle_generation);
         if (lifecycle_ended) {
             KVCM_LOG_DEBUG("EventReportBackend: delta mutation lease ended after reporter lifecycle changed, "
                            "instance [%s] host [%s]",
@@ -1056,11 +1103,11 @@ void EventReportBackend::EndDeltaMutation(const ReporterSnapshotKey &reporter_ke
                        reporter_key.host_ip_port.c_str());
         return;
     }
-    --it->second.active_delta_mutations;
-    const bool drained = it->second.active_delta_mutations == 0;
+    --state.active_delta_mutations;
+    const bool notify_snapshot = state.active_delta_mutations == 0 && !state.in_flight.empty();
     lock.unlock();
-    if (drained) {
-        snapshot_state_cv_.notify_all();
+    if (notify_snapshot) {
+        lifecycle_fence->snapshot_state_cv.notify_all();
     }
 }
 
@@ -1079,18 +1126,15 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
     // epoch after this transition; it can never delete across the boundary.
     const auto lifecycle_fence = GetOrCreateLifecycleFence(reporter_key);
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
-    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
+    std::unique_lock<std::mutex> lock(lifecycle_fence->state_mutex);
     if (!AcceptingReports()) {
         return EC_INSTANCE_NOT_EXIST;
     }
-    const auto instance_it = instance_nodes_.find(reporter_key.instance_id);
-    if (instance_it == instance_nodes_.end() ||
-        instance_it->second.find(reporter_key.host_ip_port) == instance_it->second.end() ||
-        !lifecycle_fence->registered) {
+    if (!lifecycle_fence->registered) {
         return EC_SNAPSHOT_REQUIRED;
     }
     const uint64_t admitted_lifecycle_generation = lifecycle_fence->generation;
-    auto &state = snapshot_versions_[reporter_key];
+    auto &state = lifecycle_fence->snapshot_state;
     if (!state.in_flight.empty()) {
         return EC_SNAPSHOT_IN_PROGRESS;
     }
@@ -1102,17 +1146,7 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
             return EC_SNAPSHOT_RATE_LIMITED;
         }
     }
-    auto token_in_use = [this](const std::string &token) {
-        if (snapshot_token_owners_.count(token) > 0) {
-            return true;
-        }
-        return std::any_of(snapshot_versions_.begin(), snapshot_versions_.end(), [&token](const auto &entry) {
-            return entry.second.in_flight == token;
-        });
-    };
-    do {
-        out_candidate_version = GenerateSnapshotVersionToken();
-    } while (token_in_use(out_candidate_version));
+    out_candidate_version = ReserveSnapshotVersionToken(reporter_key);
     // Close the reporter's write gate before waiting for already admitted
     // deltas. Deltas arriving from this point wait until commit or abort.
     ++state.attempt_epoch;
@@ -1123,35 +1157,34 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
     lifecycle_lock.unlock();
     const int64_t delta_drain_timeout_ms = snapshot_delta_drain_timeout_ms_;
     const bool deltas_drained =
-        snapshot_state_cv_.wait_for(lock, std::chrono::milliseconds(delta_drain_timeout_ms), [&] {
-            auto it = snapshot_versions_.find(reporter_key);
-            return !AcceptingReports() || it == snapshot_versions_.end() ||
-                   it->second.in_flight != out_candidate_version || it->second.active_delta_mutations == 0;
+        lifecycle_fence->snapshot_state_cv.wait_for(lock, std::chrono::milliseconds(delta_drain_timeout_ms), [&] {
+            return !AcceptingReports() || !lifecycle_fence->registered || state.in_flight != out_candidate_version ||
+                   state.active_delta_mutations == 0;
         });
-    // The wait releases nodes_mutex_.  If the backend was retired or disabled
+    // The wait releases the reporter state mutex. If the backend was retired or disabled
     // meanwhile, do not return a usable candidate.  Close() has already
     // cleared the state; for a dynamic disable, reopen the reporter write gate
     // explicitly so a later re-enable is not stuck behind this abandoned
     // candidate.
     if (!AcceptingReports()) {
-        auto it = snapshot_versions_.find(reporter_key);
-        if (it != snapshot_versions_.end() && it->second.in_flight == out_candidate_version) {
-            it->second.in_flight.clear();
+        if (state.in_flight == out_candidate_version) {
+            state.in_flight.clear();
+            ReleaseSnapshotVersionToken(reporter_key, out_candidate_version);
         }
         out_candidate_version.clear();
         lock.unlock();
-        snapshot_state_cv_.notify_all();
+        lifecycle_fence->snapshot_state_cv.notify_all();
         return EC_INSTANCE_NOT_EXIST;
     }
     if (!deltas_drained) {
-        auto it = snapshot_versions_.find(reporter_key);
-        const uint64_t active_delta_mutations = it == snapshot_versions_.end() ? 0 : it->second.active_delta_mutations;
-        if (it != snapshot_versions_.end() && it->second.in_flight == out_candidate_version) {
-            it->second.in_flight.clear();
+        const uint64_t active_delta_mutations = state.active_delta_mutations;
+        if (state.in_flight == out_candidate_version) {
+            state.in_flight.clear();
+            ReleaseSnapshotVersionToken(reporter_key, out_candidate_version);
         }
         out_candidate_version.clear();
         lock.unlock();
-        snapshot_state_cv_.notify_all();
+        lifecycle_fence->snapshot_state_cv.notify_all();
         KVCM_LOG_WARN("EventReportBackend: snapshot admission timed out after %" PRId64 "ms waiting for %" PRIu64
                       " active delta mutation(s), instance [%s] host [%s]; "
                       "candidate aborted and write gate reopened",
@@ -1161,8 +1194,7 @@ ErrorCode EventReportBackend::BeginSnapshot(const ReporterSnapshotKey &reporter_
                       reporter_key.host_ip_port.c_str());
         return EC_SNAPSHOT_IN_PROGRESS;
     }
-    auto it = snapshot_versions_.find(reporter_key);
-    if (it == snapshot_versions_.end() || it->second.in_flight != out_candidate_version) {
+    if (!lifecycle_fence->registered || state.in_flight != out_candidate_version) {
         out_candidate_version.clear();
         return EC_SNAPSHOT_REQUIRED;
     }
@@ -1259,17 +1291,14 @@ ErrorCode EventReportBackend::AcquireSnapshotCleanupLease(const ReporterSnapshot
     // without creating the lifecycle->metadata / metadata->lifecycle
     // inversion that forces delta mutations to use try_lock.
     auto lease = std::make_shared<std::shared_lock<std::shared_mutex>>(lifecycle_fence->mutex);
-    if (!AcceptingReports() || !lifecycle_fence->registered || lifecycle_fence->generation != expected_generation) {
-        return EC_MISMATCH;
-    }
-
     // BeginSnapshot publishes a new attempt epoch under the lifecycle writer
     // before releasing it. Holding the read lease here therefore makes this
     // validation atomic with respect to every later snapshot admission.
-    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
-    const auto state_it = snapshot_versions_.find(reporter_key);
-    if (state_it == snapshot_versions_.end() || state_it->second.committed != expected_snapshot_version ||
-        (expected_attempt_epoch != 0 && state_it->second.attempt_epoch != expected_attempt_epoch)) {
+    std::lock_guard<std::mutex> state_lock(lifecycle_fence->state_mutex);
+    const auto &state = lifecycle_fence->snapshot_state;
+    if (!AcceptingReports() || !lifecycle_fence->registered || lifecycle_fence->generation != expected_generation ||
+        state.committed != expected_snapshot_version ||
+        (expected_attempt_epoch != 0 && state.attempt_epoch != expected_attempt_epoch)) {
         return EC_MISMATCH;
     }
     out_lease = std::move(lease);
@@ -1354,9 +1383,10 @@ EventReportBackend::ProbeLocationsForMaintenance(const std::vector<MaintenanceLo
                 continue;
             }
 
-            const auto state_it = snapshot_versions_.find(reporter_key);
-            if (state_it == snapshot_versions_.end() || state_it->second.committed.empty() ||
-                !state_it->second.strict_query_visibility) {
+            const auto &lifecycle_fence = *node->lifecycle_fence;
+            std::lock_guard<std::mutex> state_lock(lifecycle_fence.state_mutex);
+            const auto &state = lifecycle_fence.snapshot_state;
+            if (state.committed.empty() || !state.strict_query_visibility) {
                 // Before the first successful complete snapshot, after a
                 // failed attempt, or while recovering, historical metadata is
                 // intentionally queryable. Its generation is not a deletion
@@ -1376,8 +1406,10 @@ EventReportBackend::ProbeLocationsForMaintenance(const std::vector<MaintenanceLo
                 // A structurally valid URI without s_version is legacy
                 // metadata. It is stale only when no sibling spec carries the
                 // committed or in-flight generation.
-                contains_current = contains_current || version == state_it->second.committed ||
-                                   (!state_it->second.in_flight.empty() && version == state_it->second.in_flight);
+                if (version == state.committed || (!state.in_flight.empty() && version == state.in_flight)) {
+                    contains_current = true;
+                    break;
+                }
             }
             if (contains_current) {
                 result.decision = MaintenanceCleanupDecision::kKeep;
@@ -1388,21 +1420,13 @@ EventReportBackend::ProbeLocationsForMaintenance(const std::vector<MaintenanceLo
                 continue;
             }
 
-            uint64_t generation = 0;
-            const auto generation_instance_it = node_generation_.find(probe.instance_id);
-            if (generation_instance_it != node_generation_.end()) {
-                const auto generation_it = generation_instance_it->second.find(reporter_key.host_ip_port);
-                if (generation_it != generation_instance_it->second.end()) {
-                    generation = generation_it->second;
-                }
-            }
             result.decision = MaintenanceCleanupDecision::kDeleteMetadata;
             result.token = MaintenanceCleanupToken{
                 .reason = MaintenanceCleanupReason::kStaleSnapshot,
                 .reporter_key = std::move(reporter_key),
-                .lifecycle_generation = generation,
-                .committed_version = state_it->second.committed,
-                .snapshot_attempt_epoch = state_it->second.attempt_epoch,
+                .lifecycle_generation = lifecycle_fence.generation,
+                .committed_version = state.committed,
+                .snapshot_attempt_epoch = state.attempt_epoch,
             };
             continue;
         }
@@ -1483,11 +1507,10 @@ EventReportBackend::AcquireMaintenanceCleanupLease(const MaintenanceCleanupToken
         if (!lifecycle_fence->registered || lifecycle_fence->generation != token.lifecycle_generation) {
             return CleanupLeaseAcquireResult::kStale;
         }
-        std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
-        const auto state_it = snapshot_versions_.find(token.reporter_key);
-        if (state_it == snapshot_versions_.end() || !state_it->second.strict_query_visibility ||
-            state_it->second.committed != token.committed_version ||
-            state_it->second.attempt_epoch != token.snapshot_attempt_epoch) {
+        std::lock_guard<std::mutex> state_lock(lifecycle_fence->state_mutex);
+        const auto &state = lifecycle_fence->snapshot_state;
+        if (!state.strict_query_visibility || state.committed != token.committed_version ||
+            state.attempt_epoch != token.snapshot_attempt_epoch) {
             return CleanupLeaseAcquireResult::kStale;
         }
         out_lease = std::move(lease);
@@ -1519,21 +1542,22 @@ bool EventReportBackend::CommitSnapshotVersion(const ReporterSnapshotKey &report
     if (!SnapshotUriUtils::IsValidSnapshotVersionToken(version)) {
         return false;
     }
-    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
-    auto it = snapshot_versions_.find(reporter_key);
-    if (it == snapshot_versions_.end() || it->second.in_flight != version) {
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
         return false;
     }
-    if (!it->second.committed.empty()) {
-        snapshot_token_owners_.erase(it->second.committed);
+    std::unique_lock<std::mutex> lock(lifecycle_fence->state_mutex);
+    auto &state = lifecycle_fence->snapshot_state;
+    if (state.in_flight != version) {
+        return false;
     }
-    it->second.committed = version;
-    it->second.in_flight.clear();
-    it->second.last_commit_ms = NowMillis();
-    it->second.strict_query_visibility = true;
-    snapshot_token_owners_[version] = reporter_key;
+    ReleaseSnapshotVersionToken(reporter_key, state.committed);
+    state.committed = version;
+    state.in_flight.clear();
+    state.last_commit_ms = NowMillis();
+    state.strict_query_visibility = true;
     lock.unlock();
-    snapshot_state_cv_.notify_all();
+    lifecycle_fence->snapshot_state_cv.notify_all();
     return true;
 }
 
@@ -1551,24 +1575,28 @@ void EventReportBackend::AbortSnapshotVersion(const ReporterSnapshotKey &reporte
         return;
     }
     std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_fence->mutex);
-    std::unique_lock<std::shared_mutex> lock(nodes_mutex_);
-    auto it = snapshot_versions_.find(reporter_key);
-    if (it != snapshot_versions_.end() && it->second.in_flight == version) {
-        it->second.in_flight.clear();
+    std::unique_lock<std::mutex> lock(lifecycle_fence->state_mutex);
+    auto &state = lifecycle_fence->snapshot_state;
+    if (state.in_flight == version) {
+        state.in_flight.clear();
         // Candidate metadata is written in place. Once an admitted attempt
         // aborts, accepting only committed could hide locations already
         // replaced with the failed candidate. Stay soft until a later
         // successful complete snapshot restores an authoritative fence.
-        it->second.strict_query_visibility = false;
+        state.strict_query_visibility = false;
+        ReleaseSnapshotVersionToken(reporter_key, version);
         lock.unlock();
-        snapshot_state_cv_.notify_all();
+        lifecycle_fence->snapshot_state_cv.notify_all();
     }
 }
 
 std::string EventReportBackend::GetSnapshotVersion(const ReporterSnapshotKey &reporter_key) const {
-    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
-    auto it = snapshot_versions_.find(reporter_key);
-    return it == snapshot_versions_.end() ? std::string{} : it->second.committed;
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return {};
+    }
+    std::unique_lock<std::mutex> lock(lifecycle_fence->state_mutex);
+    return lifecycle_fence->snapshot_state.committed;
 }
 
 void EventReportBackend::GetSnapshotVersionTokens(const ReporterSnapshotKey &reporter_key,
@@ -1576,12 +1604,13 @@ void EventReportBackend::GetSnapshotVersionTokens(const ReporterSnapshotKey &rep
                                                   std::string &out_in_flight) const {
     out_committed.clear();
     out_in_flight.clear();
-    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
-    const auto it = snapshot_versions_.find(reporter_key);
-    if (it != snapshot_versions_.end()) {
-        out_committed = it->second.committed;
-        out_in_flight = it->second.in_flight;
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return;
     }
+    std::lock_guard<std::mutex> lock(lifecycle_fence->state_mutex);
+    out_committed = lifecycle_fence->snapshot_state.committed;
+    out_in_flight = lifecycle_fence->snapshot_state.in_flight;
 }
 
 bool EventReportBackend::GetQueryVisibilityState(const ReporterSnapshotKey &reporter_key,
@@ -1602,11 +1631,10 @@ bool EventReportBackend::GetQueryVisibilityState(const ReporterSnapshotKey &repo
         !node_it->second->available.load(std::memory_order_relaxed)) {
         return false;
     }
-    const auto state_it = snapshot_versions_.find(reporter_key);
-    if (state_it != snapshot_versions_.end()) {
-        out_strict = state_it->second.strict_query_visibility;
-        out_committed = state_it->second.committed;
-    }
+    const auto &lifecycle_fence = *node_it->second->lifecycle_fence;
+    std::lock_guard<std::mutex> state_lock(lifecycle_fence.state_mutex);
+    out_strict = lifecycle_fence.snapshot_state.strict_query_visibility;
+    out_committed = lifecycle_fence.snapshot_state.committed;
     return true;
 }
 
@@ -1625,20 +1653,24 @@ void EventReportBackend::GetQueryVisibilitySnapshot(const std::string &instance_
         if (!node || !node->available.load(std::memory_order_relaxed)) {
             continue;
         }
+        const auto &lifecycle_fence = *node->lifecycle_fence;
         QueryVisibilityState state;
-        const auto version_it = snapshot_versions_.find({instance_id, host_ip_port});
-        if (version_it != snapshot_versions_.end()) {
-            state.strict = version_it->second.strict_query_visibility;
-            state.committed_version = version_it->second.committed;
+        {
+            std::lock_guard<std::mutex> state_lock(lifecycle_fence.state_mutex);
+            state.strict = lifecycle_fence.snapshot_state.strict_query_visibility;
+            state.committed_version = lifecycle_fence.snapshot_state.committed;
         }
         out_snapshot.emplace(host_ip_port, std::move(state));
     }
 }
 
 uint64_t EventReportBackend::GetSnapshotAttemptEpoch(const ReporterSnapshotKey &reporter_key) const {
-    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
-    const auto it = snapshot_versions_.find(reporter_key);
-    return it == snapshot_versions_.end() ? 0 : it->second.attempt_epoch;
+    const auto lifecycle_fence = FindLifecycleFence(reporter_key);
+    if (!lifecycle_fence) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(lifecycle_fence->state_mutex);
+    return lifecycle_fence->snapshot_state.attempt_epoch;
 }
 
 void EventReportBackend::SetSnapshotMinIntervalMsForTest(int64_t interval_ms) {

--- a/kv_cache_manager/data_storage/event_report_backend.h
+++ b/kv_cache_manager/data_storage/event_report_backend.h
@@ -204,7 +204,7 @@ public:
                                   std::string &out_committed,
                                   std::string &out_in_flight) const;
     // Returns whether the reporter is currently queryable and exposes the
-    // process-local committed visibility state under the same node-table lock.
+    // process-local committed visibility state under node-table and reporter-state locks.
     // Strict mode is entered only by a successful complete snapshot. Before
     // that, after restart, or after an admitted snapshot aborts, callers
     // accept all well-formed historical generations to avoid false negatives.
@@ -230,16 +230,49 @@ private:
     bool AcceptingReports() const { return !retired_.load(std::memory_order_acquire) && (!IsOpen() || IsAvailable()); }
     bool Retired() const { return retired_.load(std::memory_order_acquire); }
 
+    struct SnapshotVersionState {
+        // Process-local reporter state, not a distributed lock. KVCM restart
+        // clears this state; the first valid delta or snapshot rebuilds it.
+        std::string committed;
+        std::string in_flight;
+        // Monotonically advances for every admitted snapshot attempt,
+        // including attempts that later abort. Async cleanup captures this
+        // value so an older task cannot reclaim writes from a later attempt.
+        uint64_t attempt_epoch = 0;
+        uint64_t active_delta_mutations = 0;
+        int64_t last_commit_ms = 0;
+        // A successful complete snapshot proves that committed is an
+        // authoritative query fence. An admitted snapshot failure switches
+        // back to soft visibility because in-place candidate writes may have
+        // replaced committed metadata. Process-local recovery also starts
+        // soft until the next successful snapshot.
+        bool strict_query_visibility = false;
+    };
+
     struct LifecycleFence {
+        // Writers of generation/registered hold both mutex exclusively and
+        // state_mutex, so readers need either lock. Snapshot/delta state is
+        // protected by state_mutex, independently of the node-table lock.
         mutable std::shared_mutex mutex;
+        mutable std::mutex state_mutex;
+        std::condition_variable snapshot_state_cv;
         uint64_t generation = 0;
         bool registered = false;
+        SnapshotVersionState snapshot_state;
     };
     std::shared_ptr<LifecycleFence> GetOrCreateLifecycleFence(const ReporterSnapshotKey &reporter_key);
     std::shared_ptr<LifecycleFence> FindLifecycleFence(const ReporterSnapshotKey &reporter_key) const;
-    ErrorCode UnregisterNodeLocked(const std::string &instance_id, const std::string &host_ip_port);
+    std::vector<std::shared_ptr<LifecycleFence>> GetLifecycleFences() const;
+    std::string ReserveSnapshotVersionToken(const ReporterSnapshotKey &reporter_key);
+    void ReleaseSnapshotVersionToken(const ReporterSnapshotKey &reporter_key, const std::string &token);
+    ErrorCode UnregisterNodeLocked(const std::string &instance_id,
+                                   const std::string &host_ip_port,
+                                   LifecycleFence &lifecycle_fence);
     struct NodeInfo {
         std::string instance_id;
+        // Published nodes always own a registered fence. nodes_mutex_ pins
+        // both during queries, without a separate lifecycle-map lookup.
+        std::shared_ptr<LifecycleFence> lifecycle_fence;
         std::atomic<int64_t> last_heartbeat_ms{0};
         std::atomic<bool> available{true};
         std::atomic<int64_t> unavailable_since_ms{0};
@@ -281,9 +314,9 @@ private:
     mutable std::shared_mutex nodes_mutex_;
     // Final metadata writes may already hold a MetaIndexer lock, while host
     // cleanup deliberately holds a lifecycle lease before taking metadata
-    // locks. A per-reporter fence prevents that inversion from becoming a
-    // deadlock without making unrelated reporters fail one another's writes.
-    mutable std::mutex lifecycle_fences_mutex_;
+    // locks. Each stable per-reporter fence also owns snapshot/delta state, so
+    // unrelated reporters never contend on the node-table lock for admission.
+    mutable std::shared_mutex lifecycle_fences_mutex_;
     std::unordered_map<ReporterSnapshotKey, std::shared_ptr<LifecycleFence>, ReporterSnapshotKeyHash> lifecycle_fences_;
     // instance_id -> (host_ip_port -> NodeInfo)
     std::unordered_map<std::string, std::unordered_map<std::string, std::unique_ptr<NodeInfo>>> instance_nodes_;
@@ -298,30 +331,10 @@ private:
     // grace, EventReport probes return unknown while other shared-GC rules
     // continue to run.
     std::atomic<int64_t> maintenance_recovery_deadline_ms_{0};
-    struct SnapshotVersionState {
-        // Process-local reporter state, not a distributed lock. KVCM restart
-        // clears this state; the first valid delta or snapshot rebuilds it.
-        std::string committed;
-        std::string in_flight;
-        // Monotonically advances for every admitted snapshot attempt,
-        // including attempts that later abort. Async cleanup captures this
-        // value so an older task cannot reclaim writes from a later attempt.
-        uint64_t attempt_epoch = 0;
-        uint64_t active_delta_mutations = 0;
-        int64_t last_commit_ms = 0;
-        // A successful complete snapshot proves that committed is an
-        // authoritative query fence. An admitted snapshot failure switches
-        // back to soft visibility because in-place candidate writes may have
-        // replaced committed metadata. Process-local recovery also starts
-        // soft until the next successful snapshot.
-        bool strict_query_visibility = false;
-    };
-    std::unordered_map<ReporterSnapshotKey, SnapshotVersionState, ReporterSnapshotKeyHash> snapshot_versions_;
-    // Resolves an opaque committed token back to the reporter whose liveness
-    // must also be checked by the context-free MightExist interface.
-    // Guarded by nodes_mutex_ together with snapshot_versions_.
+    // Resolves every reserved (committed or in-flight) token back to its
+    // reporter. MightExist additionally validates that the token is committed.
+    mutable std::shared_mutex snapshot_token_owners_mutex_;
     std::unordered_map<std::string, ReporterSnapshotKey> snapshot_token_owners_;
-    std::condition_variable_any snapshot_state_cv_;
     int64_t snapshot_min_interval_ms_ = EventReportStorageSpec::kDefaultSnapshotMinIntervalMs;
     int64_t snapshot_delta_drain_timeout_ms_ = EventReportStorageSpec::kDefaultSnapshotDeltaDrainTimeoutMs;
 

--- a/kv_cache_manager/data_storage/test/event_report_backend_test.cc
+++ b/kv_cache_manager/data_storage/test/event_report_backend_test.cc
@@ -153,6 +153,136 @@ TEST_F(EventReportBackendTest, CloseInterruptsLongLivenessWait) {
     EXPECT_LT(close_elapsed, 2s);
 }
 
+TEST_F(EventReportBackendTest, DeltaAndVersionPathsDoNotWaitForGlobalNodeTableLock) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 60000), "trace"));
+    const ReporterSnapshotKey reporter_key{"test_inst", "10.0.0.1:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+
+    std::string initial_version;
+    uint64_t lifecycle_generation = 0;
+    ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, initial_version, &lifecycle_generation));
+    backend.EndDeltaMutation(reporter_key, lifecycle_generation, initial_version);
+
+    std::unique_lock<std::shared_mutex> nodes_guard(backend.nodes_mutex_);
+    auto wait_without_node_lock = [&](auto &future) {
+        const auto status = future.wait_for(200ms);
+        if (status != std::future_status::ready) {
+            nodes_guard.unlock();
+            future.wait();
+        }
+        return status;
+    };
+
+    auto snapshot_future = std::async(std::launch::async, [&] { return backend.GetSnapshotVersion(reporter_key); });
+    ASSERT_EQ(std::future_status::ready, wait_without_node_lock(snapshot_future));
+    EXPECT_EQ(initial_version, snapshot_future.get());
+
+    auto begin_future = std::async(std::launch::async, [&] {
+        std::string version;
+        uint64_t generation = 0;
+        const ErrorCode ec = backend.BeginDeltaMutation(reporter_key, version, &generation);
+        return std::make_tuple(ec, std::move(version), generation);
+    });
+    ASSERT_EQ(std::future_status::ready, wait_without_node_lock(begin_future));
+    auto [begin_ec, version, generation] = begin_future.get();
+    ASSERT_EQ(EC_OK, begin_ec);
+    EXPECT_EQ(initial_version, version);
+    EXPECT_EQ(lifecycle_generation, generation);
+
+    auto end_future =
+        std::async(std::launch::async, [&] { backend.EndDeltaMutation(reporter_key, generation, version); });
+    ASSERT_EQ(std::future_status::ready, wait_without_node_lock(end_future));
+    end_future.get();
+    nodes_guard.unlock();
+}
+
+TEST(EventReportBackendSnapshotTest, ReporterStateLockDoesNotBlockOtherReporterDeltas) {
+    EventReportBackend backend(nullptr);
+    const ReporterSnapshotKey reporter_a{"instance-a", "10.0.0.1:8080"};
+    const ReporterSnapshotKey reporter_b{"instance-a", "10.0.0.2:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_a.instance_id, reporter_a.host_ip_port, {"mem"}));
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_b.instance_id, reporter_b.host_ip_port, {"mem"}));
+    const auto fence = backend.FindLifecycleFence(reporter_a);
+    std::unique_lock<std::mutex> state_lock(fence->state_mutex);
+    auto delta = std::async(std::launch::async, [&] {
+        std::string version;
+        uint64_t generation = 0;
+        const auto ec = backend.BeginDeltaMutation(reporter_b, version, &generation);
+        if (ec == EC_OK) {
+            EXPECT_EQ(version, backend.GetSnapshotVersion(reporter_b));
+            backend.EndDeltaMutation(reporter_b, generation, version);
+        }
+        return ec;
+    });
+    const auto status = delta.wait_for(1s);
+    state_lock.unlock();
+    EXPECT_EQ(std::future_status::ready, status);
+    EXPECT_EQ(EC_OK, delta.get());
+}
+
+TEST_F(EventReportBackendTest, ReporterStateAndLifecycleMapLocksBlockUntilReleased) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 60000), "trace"));
+    const ReporterSnapshotKey reporter_key{"test_inst", "10.0.0.1:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+    const uint64_t lifecycle_generation =
+        backend.GetNodeGeneration(reporter_key.instance_id, reporter_key.host_ip_port);
+    const auto lifecycle_fence = backend.FindLifecycleFence(reporter_key);
+    ASSERT_NE(nullptr, lifecycle_fence);
+
+    std::unique_lock<std::mutex> reporter_state_guard(lifecycle_fence->state_mutex);
+    auto snapshot_future = std::async(std::launch::async, [&] { return backend.GetSnapshotVersion(reporter_key); });
+    EXPECT_EQ(std::future_status::timeout, snapshot_future.wait_for(50ms));
+    reporter_state_guard.unlock();
+    EXPECT_TRUE(snapshot_future.get().empty());
+    std::unique_lock<std::shared_mutex> lifecycle_guard(backend.lifecycle_fences_mutex_);
+    auto lease_future = std::async(std::launch::async, [&] {
+        EventReportBackend::LifecycleMutationLease lease;
+        return backend.AcquireLifecycleMutationLease(reporter_key, lifecycle_generation, lease);
+    });
+    EXPECT_EQ(std::future_status::timeout, lease_future.wait_for(50ms));
+    lifecycle_guard.unlock();
+    EXPECT_EQ(EC_OK, lease_future.get());
+}
+
+TEST(EventReportBackendSnapshotTest, LifecycleValidationAndSteadyHeartbeatDoNotWaitForSnapshotState) {
+    EventReportBackend backend(nullptr);
+    const ReporterSnapshotKey reporter{"instance-a", "10.0.0.1:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    const auto fence = backend.FindLifecycleFence(reporter);
+    const auto generation = fence->generation;
+    {
+        std::unique_lock<std::mutex> state_lock(fence->state_mutex);
+        auto readers = std::async(std::launch::async, [&] {
+            EventReportBackend::LifecycleMutationLease lease;
+            EXPECT_EQ(EC_OK, backend.AcquireLifecycleMutationLease(reporter, generation, lease));
+            lease.reset();
+            EXPECT_EQ(EC_NODE_NOT_REGISTERED, backend.AcquireLifecycleMutationLease(reporter, generation + 1, lease));
+            EXPECT_EQ(EC_NODE_NOT_REGISTERED, backend.CommitSnapshotVersionIfGeneration(reporter, "", generation + 1));
+            EXPECT_EQ(EC_MISMATCH, backend.AcquireLifecycleCleanupLease(reporter, generation, lease));
+            EXPECT_EQ(EC_OK, backend.OnHeartbeat(reporter.instance_id, reporter.host_ip_port, {}));
+        });
+        const auto status = readers.wait_for(1s);
+        state_lock.unlock();
+        EXPECT_EQ(std::future_status::ready, status);
+        readers.get();
+    }
+    ASSERT_EQ(EC_OK, backend.UnregisterNode(reporter.instance_id, reporter.host_ip_port));
+    std::unique_lock<std::mutex> state_lock(fence->state_mutex);
+    auto cleanup = std::async(std::launch::async, [&] {
+        EventReportBackend::LifecycleMutationLease lease;
+        EXPECT_EQ(EC_OK, backend.AcquireLifecycleCleanupLease(reporter, generation, lease));
+        lease.reset();
+        EXPECT_EQ(EC_MISMATCH, backend.AcquireLifecycleCleanupLease(reporter, generation + 1, lease));
+        EXPECT_EQ(EC_NODE_NOT_REGISTERED, backend.AcquireLifecycleMutationLease(reporter, generation, lease));
+    });
+    const auto status = cleanup.wait_for(1s);
+    state_lock.unlock();
+    EXPECT_EQ(std::future_status::ready, status);
+    cleanup.get();
+}
+
 // (2) RegisterNode / UnregisterNode
 TEST_F(EventReportBackendTest, RegisterNodeWithMediums) {
     EventReportBackend backend(metrics_registry_);
@@ -856,6 +986,68 @@ TEST_F(EventReportBackendTest, MetricsGaugesAreIsolatedByEventReportType) {
     ASSERT_EQ(EC_OK, l2_backend.Close());
 }
 
+TEST_F(EventReportBackendTest, UnavailableWaitsForHeartbeatPublicationBeforeClearingNewGauges) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(60000, 120000, 60000), "trace"));
+    const ReporterSnapshotKey reporter{"test_inst", "10.0.0.10:9600"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    ASSERT_EQ(EC_OK, backend.OnHeartbeat(reporter.instance_id, reporter.host_ip_port, {{"old_metric", "1"}}));
+    const auto &info = *backend.instance_nodes_.at(reporter.instance_id).at(reporter.host_ip_port);
+    const MetricsTags tags = info.metrics_tags;
+    auto old_data = metrics_registry_->GetMetricsData("event_report.old_metric");
+
+    // Hold metric publication after the nodes -> status lock handoff. The
+    // unavailable transition must clear the newly published full snapshot.
+    std::unique_lock<std::mutex> metrics_lock(metrics_registry_->mutex_);
+    auto heartbeat = std::async(std::launch::async, [&] {
+        return backend.OnHeartbeat(reporter.instance_id, reporter.host_ip_port, {{"new_metric", "42"}});
+    });
+    bool publishing = false;
+    const auto deadline = std::chrono::steady_clock::now() + 1s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::unique_lock<std::mutex> status_lock(info.status_mutex, std::try_to_lock);
+        if (!status_lock.owns_lock()) {
+            publishing = true;
+            break;
+        }
+        std::this_thread::yield();
+    }
+    EXPECT_TRUE(publishing);
+    auto unavailable = std::async(std::launch::async, [&] {
+        backend.SetNodeUnavailable(reporter.instance_id, reporter.host_ip_port);
+    });
+    const auto unavailable_deadline = std::chrono::steady_clock::now() + 1s;
+    while (info.available.load() && std::chrono::steady_clock::now() < unavailable_deadline) {
+        std::this_thread::yield();
+    }
+    EXPECT_FALSE(info.available.load());
+    EXPECT_EQ(std::future_status::timeout, unavailable.wait_for(20ms));
+    metrics_lock.unlock();
+    EXPECT_EQ(EC_OK, heartbeat.get());
+    unavailable.get();
+
+    EXPECT_FALSE(old_data->GetGauge(tags).has_value());
+    auto new_data = metrics_registry_->GetMetricsData("event_report.new_metric");
+    ASSERT_NE(nullptr, new_data);
+    auto gauge = new_data->GetGauge(tags);
+    ASSERT_TRUE(gauge.has_value());
+    EXPECT_DOUBLE_EQ(0.0, gauge->Get());
+    EXPECT_EQ((std::map<std::string, std::string>{{"new_metric", "42"}}), info.last_system_status);
+    EXPECT_EQ(tags, info.metrics_tags);
+}
+
+TEST(EventReportBackendSnapshotTest, HeartbeatWithoutMetricsReplacesAndClearsStatus) {
+    EventReportBackend backend(nullptr);
+    const ReporterSnapshotKey reporter{"instance-a", "10.0.0.1:8080"};
+    ASSERT_EQ(EC_OK, backend.OnHeartbeat(reporter.instance_id, reporter.host_ip_port, {{"version", "v1"}}));
+    const auto &info = *backend.instance_nodes_.at(reporter.instance_id).at(reporter.host_ip_port);
+    EXPECT_EQ("v1", info.last_system_status.at("version"));
+    ASSERT_EQ(EC_OK, backend.OnHeartbeat(reporter.instance_id, reporter.host_ip_port, {{"load", "2"}}));
+    EXPECT_EQ((std::map<std::string, std::string>{{"load", "2"}}), info.last_system_status);
+    ASSERT_EQ(EC_OK, backend.OnHeartbeat(reporter.instance_id, reporter.host_ip_port, {}));
+    EXPECT_TRUE(info.last_system_status.empty());
+}
+
 TEST_F(EventReportBackendTest, SetNodeUnavailableZerosGauges) {
     EventReportBackend backend(metrics_registry_);
     ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 50), "trace"));
@@ -986,6 +1178,13 @@ TEST(EventReportBackendSnapshotTest, RegisteredReporterFirstDeltaCreatesReusable
     ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, second));
     EXPECT_EQ(first, second);
     backend.EndDeltaMutation(reporter_key);
+
+    // An idle delta no longer notifies the CV. A later snapshot must still
+    // observe the already-drained count without waiting for a notification.
+    std::string candidate;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter_key, candidate, retry_after_ms));
+    EXPECT_TRUE(backend.CommitSnapshotVersion(reporter_key, candidate));
 }
 
 TEST(EventReportBackendSnapshotTest, ConcurrentFirstDeltasPublishExactlyOneReusableVersion) {
@@ -1225,11 +1424,17 @@ TEST(EventReportBackendSnapshotTest, QueryVisibilitySnapshotIsInstanceScopedAndE
     EXPECT_EQ(strict_version, snapshot.at(strict_reporter.host_ip_port).committed_version);
     EXPECT_EQ(0u, snapshot.count(other_instance.host_ip_port));
 
+    std::string next_version;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(strict_reporter, next_version, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(strict_reporter, next_version));
+    EXPECT_EQ(strict_version, snapshot.at(strict_reporter.host_ip_port).committed_version);
+
     backend.SetNodeUnavailable(soft_reporter.instance_id, soft_reporter.host_ip_port);
     backend.GetQueryVisibilitySnapshot("instance-a", snapshot);
     ASSERT_EQ(1u, snapshot.size());
     EXPECT_EQ(0u, snapshot.count(soft_reporter.host_ip_port));
     EXPECT_EQ(1u, snapshot.count(strict_reporter.host_ip_port));
+    EXPECT_EQ(next_version, snapshot.at(strict_reporter.host_ip_port).committed_version);
 
     ASSERT_EQ(EC_OK, backend.UnregisterNode(strict_reporter.instance_id, strict_reporter.host_ip_port));
     backend.GetQueryVisibilitySnapshot("instance-a", snapshot);
@@ -1255,6 +1460,47 @@ TEST(EventReportBackendSnapshotTest, SnapshotTokensAreNeverReusedAcrossAttempts)
         }
     }
     EXPECT_EQ(128u, observed.size());
+}
+
+TEST(EventReportBackendSnapshotTest, ConcurrentReportersReserveAndReleaseSnapshotTokens) {
+    EventReportBackend backend(nullptr);
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    constexpr size_t kReporters = 8;
+    constexpr size_t kAttempts = 16;
+    std::vector<ReporterSnapshotKey> reporters;
+    for (size_t i = 0; i < kReporters; ++i) {
+        reporters.push_back({"instance-a", "host-" + std::to_string(i)});
+        ASSERT_EQ(EC_OK, backend.RegisterNode(reporters.back().instance_id, reporters.back().host_ip_port, {"mem"}));
+    }
+    std::vector<std::vector<std::string>> tokens(kReporters);
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < kReporters; ++i) {
+        threads.emplace_back([&, i] {
+            for (size_t attempt = 0; attempt < kAttempts; ++attempt) {
+                std::string token;
+                uint64_t retry_after_ms = 0;
+                ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporters[i], token, retry_after_ms));
+                tokens[i].push_back(token);
+                if (attempt % 2 == 0) {
+                    ASSERT_TRUE(backend.CommitSnapshotVersion(reporters[i], token));
+                } else {
+                    backend.AbortSnapshotVersion(reporters[i], token);
+                }
+            }
+        });
+    }
+    for (auto &thread : threads) {
+        thread.join();
+    }
+    std::set<std::string> observed;
+    for (const auto &reporter_tokens : tokens) {
+        observed.insert(reporter_tokens.begin(), reporter_tokens.end());
+    }
+    EXPECT_EQ(kReporters * kAttempts, observed.size());
+    ASSERT_EQ(kReporters, backend.snapshot_token_owners_.size());
+    for (const auto &reporter : reporters) {
+        EXPECT_EQ(reporter, backend.snapshot_token_owners_.at(backend.GetSnapshotVersion(reporter)));
+    }
 }
 
 TEST(EventReportBackendSnapshotTest, SnapshotAndDeltaWaitForEachOther) {
@@ -1774,7 +2020,6 @@ TEST(EventReportBackendSnapshotTest, UnregisterForcesFullSnapshotAgain) {
     uint64_t retry_after_ms = 0;
     EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginSnapshot(scope, rejected_token, retry_after_ms));
     EXPECT_TRUE(rejected_token.empty());
-    EXPECT_EQ(0u, backend.snapshot_versions_.count(scope));
 
     ASSERT_EQ(EC_OK, backend.RegisterNode(instance_id, host, {"hbm", "dram"}));
     std::string token;
@@ -1786,7 +2031,6 @@ TEST(EventReportBackendSnapshotTest, UnregisterForcesFullSnapshotAgain) {
     EXPECT_TRUE(backend.GetSnapshotVersion(scope).empty());
     EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginSnapshot(scope, rejected_token, retry_after_ms));
     EXPECT_TRUE(rejected_token.empty());
-    EXPECT_EQ(0u, backend.snapshot_versions_.count(scope));
     std::string committed;
     EXPECT_EQ(EC_SNAPSHOT_REQUIRED, backend.BeginDeltaMutation(scope, committed));
 }
@@ -1837,11 +2081,17 @@ TEST(EventReportBackendSnapshotTest, StaleDeltaEndCannotDrainReregisteredLifecyc
     EventReportBackend backend(nullptr);
     const ReporterSnapshotKey reporter_key{"delta-incarnation", "10.0.0.73:8080"};
     ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+    const auto lifecycle_fence = backend.FindLifecycleFence(reporter_key);
+    ASSERT_NE(nullptr, lifecycle_fence);
+    const auto active_delta_mutations = [&] {
+        std::lock_guard<std::mutex> lock(lifecycle_fence->state_mutex);
+        return lifecycle_fence->snapshot_state.active_delta_mutations;
+    };
 
     std::string old_token;
     uint64_t old_generation = 0;
     ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, old_token, &old_generation));
-    ASSERT_EQ(1u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+    ASSERT_EQ(1u, active_delta_mutations());
 
     ASSERT_EQ(EC_OK, backend.UnregisterNode(reporter_key.instance_id, reporter_key.host_ip_port));
     ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
@@ -1850,13 +2100,13 @@ TEST(EventReportBackendSnapshotTest, StaleDeltaEndCannotDrainReregisteredLifecyc
     ASSERT_EQ(EC_OK, backend.BeginDeltaMutation(reporter_key, new_token, &new_generation));
     ASSERT_NE(old_token, new_token);
     ASSERT_NE(old_generation, new_generation);
-    ASSERT_EQ(1u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+    ASSERT_EQ(1u, active_delta_mutations());
 
     backend.EndDeltaMutation(reporter_key, old_generation, old_token);
-    EXPECT_EQ(1u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+    EXPECT_EQ(1u, active_delta_mutations());
 
     backend.EndDeltaMutation(reporter_key, new_generation, new_token);
-    EXPECT_EQ(0u, backend.snapshot_versions_[reporter_key].active_delta_mutations);
+    EXPECT_EQ(0u, active_delta_mutations());
 }
 
 TEST(EventReportBackendSnapshotTest, StableLocationIdHasNoSnapshotGeneration) {
@@ -2017,6 +2267,45 @@ TEST(EventReportBackendSnapshotTest, MightExistRequiresCurrentTokenAndAvailableR
     EXPECT_EQ((std::vector<bool>{false}), backend.MightExist({DataStorageUri(replacement_uri)}));
 }
 
+TEST(EventReportBackendSnapshotTest, VisibilityQueriesDoNotWaitForLifecycleMapLock) {
+    EventReportBackend backend(nullptr);
+    backend.SetSnapshotMinIntervalMsForTest(0);
+    const ReporterSnapshotKey reporter{"instance-a", "10.0.0.1:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    std::string committed, in_flight;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter, committed, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(reporter, committed));
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter, in_flight, retry_after_ms));
+    std::string committed_uri, in_flight_uri;
+    const std::string raw_uri = "event_report://physical-cache:9600/mem";
+    ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(raw_uri, committed, committed_uri));
+    ASSERT_TRUE(SnapshotUriUtils::AddSnapshotVersionToUri(raw_uri, in_flight, in_flight_uri));
+
+    std::unique_lock<std::shared_mutex> map_lock(backend.lifecycle_fences_mutex_);
+    auto queries = std::async(std::launch::async, [&] {
+        bool strict = false;
+        std::string version;
+        EXPECT_TRUE(backend.GetQueryVisibilityState(reporter, strict, version));
+        EXPECT_TRUE(strict);
+        EXPECT_EQ(committed, version);
+        EXPECT_EQ((std::vector<bool>{true, false}),
+                  backend.MightExist({DataStorageUri(committed_uri), DataStorageUri(in_flight_uri)}));
+        EventReportBackend::QueryVisibilitySnapshot snapshot;
+        backend.GetQueryVisibilitySnapshot(reporter.instance_id, snapshot);
+        ASSERT_EQ(1u, snapshot.size());
+        EXPECT_EQ(committed, snapshot.at(reporter.host_ip_port).committed_version);
+        backend.SetNodeUnavailable(reporter.instance_id, reporter.host_ip_port);
+        EXPECT_FALSE(backend.GetQueryVisibilityState(reporter, strict, version));
+        EXPECT_EQ((std::vector<bool>{false}), backend.MightExist({DataStorageUri(committed_uri)}));
+    });
+    const auto status = queries.wait_for(1s);
+    map_lock.unlock();
+    EXPECT_EQ(std::future_status::ready, status);
+    queries.get();
+    backend.AbortSnapshotVersion(reporter, in_flight);
+}
+
 TEST_F(EventReportBackendTest, MightExistFollowsAutomaticLivenessAndFullReporterLifecycle) {
     EventReportBackend backend(metrics_registry_);
     ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 80, /*grace*/ 250, /*tick*/ 10), "trace"));
@@ -2158,6 +2447,7 @@ TEST_F(EventReportBackendTest, MaintenanceProbeUsesCurrentSnapshotAndFailsClosed
         {reporter.instance_id, location_id, {"event_report://physical-cache:9600/mem"}},
         {reporter.instance_id, "malformed-location-id", {old_uri}},
         {reporter.instance_id, location_id, {malformed_legacy_uri}},
+        {reporter.instance_id, location_id, {malformed_uri, current_uri}},
     };
     const auto results = backend.ProbeLocationsForMaintenance(probes);
     ASSERT_EQ(probes.size(), results.size());
@@ -2174,6 +2464,7 @@ TEST_F(EventReportBackendTest, MaintenanceProbeUsesCurrentSnapshotAndFailsClosed
     EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kReporterIdentityMalformed, results[6].unknown_reason);
     EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kUnknown, results[7].decision);
     EXPECT_EQ(EventReportBackend::MaintenanceProbeUnknownReason::kLocationMalformed, results[7].unknown_reason);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, results[8].decision);
 
     EventReportBackend::LifecycleMutationLease lease;
     EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
@@ -2183,10 +2474,12 @@ TEST_F(EventReportBackendTest, MaintenanceProbeUsesCurrentSnapshotAndFailsClosed
     std::string next_version;
     uint64_t retry_after_ms = 0;
     ASSERT_EQ(EC_OK, BeginSnapshotForRegisteredReporter(backend, reporter, next_version, retry_after_ms));
-    const auto in_flight_result =
-        backend.ProbeLocationsForMaintenance({{reporter.instance_id, location_id, {versioned_uri(next_version)}}});
-    ASSERT_EQ(1u, in_flight_result.size());
+    const auto in_flight_result = backend.ProbeLocationsForMaintenance(
+        {{reporter.instance_id, location_id, {versioned_uri(next_version), malformed_uri}},
+         {reporter.instance_id, location_id, {malformed_uri, versioned_uri(next_version)}}});
+    ASSERT_EQ(2u, in_flight_result.size());
     EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, in_flight_result[0].decision);
+    EXPECT_EQ(EventReportBackend::MaintenanceCleanupDecision::kKeep, in_flight_result[1].decision);
 
     const auto candidate_before_abort =
         backend.ProbeLocationsForMaintenance({{reporter.instance_id, location_id, {old_uri}}});
@@ -2214,6 +2507,32 @@ TEST_F(EventReportBackendTest, MaintenanceProbeUsesCurrentSnapshotAndFailsClosed
     EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kStale,
               backend.AcquireMaintenanceCleanupLease(candidate_before_abort[0].token, lease));
     ASSERT_EQ(EC_OK, backend.Close());
+}
+
+TEST_F(EventReportBackendTest, MaintenanceCleanupLeaseDoesNotWaitForGlobalNodeTableLock) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 60000), "trace"));
+    const ReporterSnapshotKey reporter{"instance-a", "10.0.0.93:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter.instance_id, reporter.host_ip_port, {"mem"}));
+    std::string version;
+    uint64_t retry_after_ms = 0;
+    ASSERT_EQ(EC_OK, backend.BeginSnapshot(reporter, version, retry_after_ms));
+    ASSERT_TRUE(backend.CommitSnapshotVersion(reporter, version));
+    const auto results = backend.ProbeLocationsForMaintenance({{reporter.instance_id,
+                                                                backend.BuildLocationId("mem", reporter.host_ip_port),
+                                                                {"event_report://physical-cache:9600/mem"}}});
+    ASSERT_EQ(1u, results.size());
+    ASSERT_EQ(EventReportBackend::MaintenanceCleanupDecision::kDeleteMetadata, results[0].decision);
+
+    std::unique_lock<std::shared_mutex> nodes_lock(backend.nodes_mutex_);
+    auto cleanup = std::async(std::launch::async, [&] {
+        EventReportBackend::LifecycleMutationLease lease;
+        return backend.AcquireMaintenanceCleanupLease(results[0].token, lease);
+    });
+    const auto status = cleanup.wait_for(1s);
+    nodes_lock.unlock();
+    EXPECT_EQ(std::future_status::ready, status);
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired, cleanup.get());
 }
 
 TEST_F(EventReportBackendTest, MaintenanceProbeRespectsUnavailableDownAndRecoveryLifecycle) {
@@ -2300,8 +2619,7 @@ TEST_F(EventReportBackendTest, MaintenanceBackendLeaseFencesDynamicDisable) {
     ASSERT_EQ(EC_OK, backend.Open(MakeConfig(), "trace"));
 
     EventReportBackend::MaintenanceBackendLease lease;
-    ASSERT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
-              backend.AcquireMaintenanceBackendLease(lease));
+    ASSERT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired, backend.AcquireMaintenanceBackendLease(lease));
 
     std::promise<void> disable_started;
     auto disable = std::async(std::launch::async, [&backend, &disable_started] {
@@ -2315,11 +2633,9 @@ TEST_F(EventReportBackendTest, MaintenanceBackendLeaseFencesDynamicDisable) {
     disable.get();
     EXPECT_FALSE(backend.Available());
 
-    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kBusy,
-              backend.AcquireMaintenanceBackendLease(lease));
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kBusy, backend.AcquireMaintenanceBackendLease(lease));
     backend.SetAvailable(true);
-    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired,
-              backend.AcquireMaintenanceBackendLease(lease));
+    EXPECT_EQ(EventReportBackend::CleanupLeaseAcquireResult::kAcquired, backend.AcquireMaintenanceBackendLease(lease));
     lease.reset();
     ASSERT_EQ(EC_OK, backend.Close());
 }
@@ -2439,7 +2755,36 @@ TEST(EventReportBackendSnapshotTest, CloseUnblocksSnapshotAndDeltaWaiters) {
     }
 }
 
-TEST_F(EventReportBackendTest, DisableWhileSnapshotDrainsAbortsCandidateAndReopensGate) {
+TEST_F(EventReportBackendTest, DisableSynchronizesWithReporterWaitTransition) {
+    EventReportBackend backend(metrics_registry_);
+    ASSERT_EQ(EC_OK, backend.Open(MakeConfig(/*hb*/ 5000, /*grace*/ 10000, /*tick*/ 60000), "disable_wait_transition"));
+    const ReporterSnapshotKey reporter_key{"instance-disable", "10.0.0.72:8080"};
+    ASSERT_EQ(EC_OK, backend.RegisterNode(reporter_key.instance_id, reporter_key.host_ip_port, {"mem"}));
+    const auto fence = backend.FindLifecycleFence(reporter_key);
+
+    std::unique_lock<std::mutex> state_lock(fence->state_mutex);
+    // Model a waiter that checked availability under state_mutex but has not
+    // yet atomically released the mutex and entered condition-variable wait.
+    EXPECT_TRUE(backend.AcceptingReports());
+    auto disable = std::async(std::launch::async, [&] { backend.SetAvailable(false); });
+    const auto deadline = std::chrono::steady_clock::now() + 1s;
+    while (backend.IsAvailable() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    EXPECT_FALSE(backend.IsAvailable());
+    EXPECT_EQ(std::future_status::timeout, disable.wait_for(20ms));
+
+    // Do not recheck the predicate here: the notification must survive the
+    // check-to-wait window, not merely be observed at the drain timeout.
+    const auto wake_status = fence->snapshot_state_cv.wait_for(state_lock, 1s);
+    state_lock.unlock();
+    EXPECT_EQ(std::cv_status::no_timeout, wake_status);
+    EXPECT_EQ(std::future_status::ready, disable.wait_for(1s));
+    disable.get();
+    ASSERT_EQ(EC_OK, backend.Close());
+}
+
+TEST_F(EventReportBackendTest, DisableUnblocksSnapshotAndDeltaWaitersAndReopensGate) {
     EventReportBackend backend(metrics_registry_);
     ASSERT_EQ(EC_OK,
               backend.Open(MakeConfig(/*hb*/ 5000,
@@ -2475,11 +2820,19 @@ TEST_F(EventReportBackendTest, DisableWhileSnapshotDrainsAbortsCandidateAndReope
     } while (std::chrono::steady_clock::now() < in_flight_deadline);
     ASSERT_FALSE(observed_in_flight.empty());
 
+    std::string waiting_delta_version;
+    auto waiting_delta =
+        std::async(std::launch::async, [&] { return backend.BeginDeltaMutation(reporter_key, waiting_delta_version); });
+    ASSERT_EQ(std::future_status::timeout, waiting_delta.wait_for(20ms));
+
     DataStorageBackend &backend_base = backend;
     backend_base.SetAvailable(false);
     ASSERT_EQ(std::future_status::ready, waiting_snapshot.wait_for(1s));
     EXPECT_EQ(EC_INSTANCE_NOT_EXIST, waiting_snapshot.get());
     EXPECT_TRUE(candidate.empty());
+    ASSERT_EQ(std::future_status::ready, waiting_delta.wait_for(1s));
+    EXPECT_EQ(EC_INSTANCE_NOT_EXIST, waiting_delta.get());
+    EXPECT_TRUE(waiting_delta_version.empty());
 
     backend_base.SetAvailable(true);
     backend.EndDeltaMutation(reporter_key);


### PR DESCRIPTION
- Isolate snapshot/delta state and waiters per reporter; share lifecycle-map reads.
- Separate token ownership locking and reuse thread-local random devices.
- Reduce heartbeat copies, query lookups and GC URI scans.
- Synchronize disable notifications to prevent lost wakeups.
- Extend concurrency, lifecycle and snapshot regression coverage.