### PR TITLE
[manager] preserve deletion admission across concurrent writes

### DIFF
--- a/kv_cache_manager/manager/cache_manager.cc
+++ b/kv_cache_manager/manager/cache_manager.cc
@@ -1349,16 +1349,18 @@ CacheManager::FinishWriteCache(RequestContext *request_context,
     }
     std::vector<KeyType> success_batch_keys;
     std::vector<std::string> success_batch_location_ids;
-    std::vector<std::vector<MetaSearcher::LocationUpdateTask>> success_batch_update_tasks;
+    std::vector<std::vector<MetaSearcher::LocationCASTask>> success_batch_publish_tasks;
     CacheLocationDelRequest failed_del_request{.instance_id = instance_id, .delay = std::chrono::seconds(0)};
 
     for (size_t block_key_idx = 0; block_key_idx < location_info.keys.size(); block_key_idx++) {
         if (IsIndexInMaskRange(success_block_mask, block_key_idx)) {
-            // success
+            // success：只允许把本次写会话自己创建的 WRITING location 发布为 SERVING，
+            // 迟到的 Finish 不能把已经被逻辑删除（DELETING）的 location 复活。
             success_batch_keys.push_back(location_info.keys[block_key_idx]);
             success_batch_location_ids.push_back(location_info.location_ids[block_key_idx]);
-            success_batch_update_tasks.push_back(
-                {{location_info.location_ids[block_key_idx], CacheLocationStatus::CLS_SERVING}});
+            success_batch_publish_tasks.push_back({{location_info.location_ids[block_key_idx],
+                                                    CacheLocationStatus::CLS_WRITING,
+                                                    CacheLocationStatus::CLS_SERVING}});
         } else {
             // failed
             failed_del_request.block_keys.push_back(location_info.keys[block_key_idx]);
@@ -1372,11 +1374,38 @@ CacheManager::FinishWriteCache(RequestContext *request_context,
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_BEGIN(service_metrics_collector, ManagerBatchUpdateLocation);
     std::vector<std::vector<ErrorCode>> out_batch_results;
     if (!success_batch_keys.empty()) {
-        ec = meta_searcher->BatchUpdateLocationStatus(
-            request_context, success_batch_keys, success_batch_update_tasks, out_batch_results);
+        ec = meta_searcher->BatchCASLocationStatus(
+            request_context, success_batch_keys, success_batch_publish_tasks, out_batch_results);
         if (ec != EC_OK) {
             std::string detail_ec_str = MetaSearcher::BatchErrorCodeToStr(out_batch_results);
-            PREFIX_LOG(WARN, "update location status failed, ec: %d, ec_batches: %s", ec, detail_ec_str.c_str());
+            PREFIX_LOG(WARN, "publish location status failed, ec: %d, ec_batches: %s", ec, detail_ec_str.c_str());
+        }
+        // 聚合 ec 只表示 RMW 机制本身是否跑完；CAS 冲突（EC_MISMATCH）留在 per-location 结果里
+        // 且不会抬高聚合 ec，因此必须按下标对齐逐 location 判定发布结果，否则迟到的 Finish 会在
+        // 没有真正改状态的情况下静默返回成功。NOENT 与既有行为一致，按幂等成功处理（CAS 不会重建）。
+        ErrorCode first_publish_ec = EC_OK;
+        size_t publish_failed_count = 0;
+        for (size_t i = 0; i < success_batch_keys.size(); ++i) {
+            const ErrorCode location_ec = (i < out_batch_results.size() && !out_batch_results[i].empty())
+                                              ? out_batch_results[i][0]
+                                              : ErrorCode::EC_ERROR;
+            if (location_ec == EC_OK || location_ec == ErrorCode::EC_NOENT) {
+                continue;
+            }
+            ++publish_failed_count;
+            if (first_publish_ec == EC_OK) {
+                first_publish_ec = location_ec;
+            }
+        }
+        if (ec == EC_OK && publish_failed_count > 0) {
+            // 外层 transport/storage 失败优先保留；否则全部失败上报首个真实错误码，部分失败上报 PARTIAL_OK。
+            ec = publish_failed_count == success_batch_keys.size() ? first_publish_ec : ErrorCode::EC_PARTIAL_OK;
+            PREFIX_LOG(WARN,
+                       "publish location status rejected, failed: %zu/%zu, first ec: %d, ec: %d",
+                       publish_failed_count,
+                       success_batch_keys.size(),
+                       first_publish_ec,
+                       ec);
         }
     }
     KVCM_METRICS_COLLECTOR_CHRONO_MARK_END(service_metrics_collector, ManagerBatchUpdateLocation);
@@ -1476,7 +1505,12 @@ ErrorCode CacheManager::RemoveCache(RequestContext *request_context,
         auto gen_keys = GenKeyVector(tokens, block_size);
         request.block_keys = std::move(gen_keys);
     }
-    reclaimer_task_supervisor_->Submit(trace_id, std::move(request));
+    // Only the synchronous logical invalidation is awaited here: EC_OK means no
+    // requested location can be served any more. The physical reclamation of the
+    // admitted subset keeps running asynchronously under the supervisor, also
+    // when part of the batch could not be invalidated.
+    const ErrorCode admit_ec = reclaimer_task_supervisor_->SubmitLogicalDelete(trace_id, std::move(request));
+    RETURN_IF_EC_NOT_OK_WITH_LOG(WARN, admit_ec, "remove cache failed: logical invalidation incomplete");
     return EC_OK;
 }
 

--- a/kv_cache_manager/manager/reclaimer_task_supervisor.cc
+++ b/kv_cache_manager/manager/reclaimer_task_supervisor.cc
@@ -44,6 +44,35 @@ void ReclaimerTaskSupervisor::Submit(const std::string &trace_id, CacheMetaDelRe
     }
 }
 
+ErrorCode ReclaimerTaskSupervisor::SubmitLogicalDelete(const std::string &trace_id, CacheMetaDelRequest &&request) {
+    auto cell = std::make_shared<ReclaimerTaskSupervisorCell>();
+    cell->trace_id = trace_id;
+    cell->instance_id = request.instance_id;
+    LogicalDeleteAdmission admission;
+    cell->result = schedule_plan_executor_->Submit(request, admission);
+    if (cell->result.valid()) {
+        // Push whatever was admitted even on a partial failure: those blocks are
+        // already DELETING and their physical reclamation still needs watching.
+        cell_queue_.Push(cell);
+    } else {
+        KVCM_LOG_ERROR("Submit CacheMetaDelRequest instance_id[%s] trace_id[%s] failed",
+                       request.instance_id.c_str(),
+                       trace_id.c_str());
+    }
+    const ErrorCode logical_ec = admission.LogicalStatus();
+    if (logical_ec != EC_OK) {
+        KVCM_LOG_WARN("logical delete not fully admitted, instance_id[%s] trace_id[%s] ec[%d] requested[%zu] "
+                      "unresolved[%zu] message[%s]",
+                      cell->instance_id.c_str(),
+                      trace_id.c_str(),
+                      logical_ec,
+                      admission.requested_locations,
+                      admission.unresolved_locations,
+                      admission.error_message.c_str());
+    }
+    return logical_ec;
+}
+
 void ReclaimerTaskSupervisor::Submit(const std::string &trace_id, CacheLocationDelRequest &&request) {
     auto cell = std::make_shared<ReclaimerTaskSupervisorCell>();
     cell->trace_id = trace_id;

--- a/kv_cache_manager/manager/reclaimer_task_supervisor.h
+++ b/kv_cache_manager/manager/reclaimer_task_supervisor.h
@@ -17,6 +17,10 @@ public:
     void Start();
     void Submit(const std::string &trace_id, CacheMetaDelRequest &&request);
     void Submit(const std::string &trace_id, CacheLocationDelRequest &&request);
+    // Same submission as Submit(), but returns the logical invalidation result
+    // instead of dropping it. The physical delete keeps being supervised
+    // asynchronously exactly as before; this never waits for it.
+    ErrorCode SubmitLogicalDelete(const std::string &trace_id, CacheMetaDelRequest &&request);
 
 private:
     struct ReclaimerTaskSupervisorCell {

--- a/kv_cache_manager/manager/schedule_plan_executor.cc
+++ b/kv_cache_manager/manager/schedule_plan_executor.cc
@@ -62,6 +62,23 @@ const char *EventReportCleanupReasonName(EventReportBackend::MaintenanceCleanupR
 }
 } // namespace
 
+ErrorCode LogicalDeleteAdmission::LogicalStatus() const {
+    if (status != ErrorCode::EC_OK) {
+        return status;
+    }
+    if (unresolved_locations == 0) {
+        return ErrorCode::EC_OK;
+    }
+    const ErrorCode unresolved_ec = first_unresolved_ec != ErrorCode::EC_OK ? first_unresolved_ec : ErrorCode::EC_ERROR;
+    // Nothing invalidated at all reports the concrete reason; a partially
+    // invalidated batch reports EC_PARTIAL_OK, because the admitted subset is
+    // already owned by the physical delete pipeline. The caller only sees an
+    // aggregate status and cannot tell which locations failed, so retrying the
+    // whole batch stays allowed: re-invalidating an already-DELETING location
+    // is idempotent and simply re-arms its physical delete.
+    return unresolved_locations >= requested_locations ? unresolved_ec : ErrorCode::EC_PARTIAL_OK;
+}
+
 struct SchedulePlanExecutor::PromiseCompletion {
     explicit PromiseCompletion(std::shared_ptr<std::promise<PlanExecuteResult>> promise)
         : promise_(std::move(promise)) {}
@@ -448,108 +465,34 @@ std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheMetaDelRe
     return SubmitMetaDelete(task, ScheduleTaskClass::kSystem);
 }
 
+std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheMetaDelRequest &task,
+                                                            LogicalDeleteAdmission &admission) {
+    return SubmitMetaDelete(task, ScheduleTaskClass::kSystem, &admission);
+}
+
+// Shares the admission path with CacheLocationDelRequest instead of keeping a
+// second copy of it, but keeps the historical DELETING handling of the
+// synchronous meta submit: an already-DELETING location is re-CAS'd, Sync'd and
+// scheduled again. DELETING does not prove an owned physical task (an earlier
+// Sync failure, an enqueue rejection or a restart can strand it), and this
+// future promises physical completion, so it must not be resolved by someone
+// else's assumed job.
 std::future<PlanExecuteResult> SchedulePlanExecutor::SubmitMetaDelete(const CacheMetaDelRequest &task,
-                                                                      ScheduleTaskClass task_class) {
+                                                                      ScheduleTaskClass task_class,
+                                                                      LogicalDeleteAdmission *admission) {
     KVCM_LOG_DEBUG("Submitting meta delete task for instance_id: %s, block_keys count: %zu",
                    task.instance_id.c_str(),
                    task.block_keys.size());
 
     auto promise = std::make_shared<std::promise<PlanExecuteResult>>();
-    std::future<PlanExecuteResult> future = promise->get_future();
-
-    if (stop_) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped.");
-        return future;
-    }
-
-    // 1. sync set block status to deleting
-    const std::shared_ptr<MetaIndexer> indexer = meta_manager_->GetMetaIndexer(task.instance_id);
-    if (indexer == nullptr) {
-        HandleErrorPromise(promise, ErrorCode::EC_NOENT, "MetaIndexer %s not found", task.instance_id.c_str());
-        return future;
-    }
-
-    MetaSearcher meta_searcher(indexer);
-
-    std::vector<CacheLocationMap> location_maps;
-    BlockMask empty_mask;
-    auto request_context = std::make_shared<RequestContext>("schedule_plan_executor_call");
-    ErrorCode get_locations_ec =
-        meta_searcher.BatchGetLocation(request_context.get(), task.block_keys, empty_mask, location_maps);
-    if (get_locations_ec != ErrorCode::EC_OK) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "Failed to get block locations");
-        return future;
-    }
-
-    std::vector<int64_t> batch_cas_block_keys;
-    std::vector<std::vector<MetaSearcher::LocationCASTask>> batch_cas_tasks;
-    for (size_t block_key_idx = 0; block_key_idx < task.block_keys.size(); ++block_key_idx) {
-        std::vector<MetaSearcher::LocationCASTask> cas_tasks;
-        for (const auto &loc_kv : location_maps[block_key_idx]) {
-            if (!loc_kv.second) {
-                continue;
-            }
-            cas_tasks.push_back({loc_kv.first, loc_kv.second->status(), CLS_DELETING});
-        }
-        if (cas_tasks.empty()) {
-            continue;
-        }
-        batch_cas_block_keys.emplace_back(task.block_keys[block_key_idx]);
-        batch_cas_tasks.emplace_back(std::move(cas_tasks));
-    }
-
-    if (batch_cas_block_keys.empty()) {
-        promise->set_value({ErrorCode::EC_OK, ""});
-        return future;
-    }
-
-    std::vector<std::vector<ErrorCode>> cas_results;
-    ErrorCode update_ec =
-        meta_searcher.BatchCASLocationStatus(request_context.get(), batch_cas_block_keys, batch_cas_tasks, cas_results);
-    if (update_ec != ErrorCode::EC_OK) {
-        KVCM_LOG_DEBUG("Location status BatchCASLocationStatus not ok, ec: %d", update_ec);
-    }
-
-    std::string error_message;
-    CacheLocationDelRequest actual_task{task.instance_id, {}, {}, task.delay};
-    if (!FillActualTask(batch_cas_block_keys, batch_cas_tasks, cas_results, actual_task, error_message)) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "FillActualTask error: %s", error_message.c_str());
-        return future;
-    }
-    if (actual_task.block_keys.empty()) {
-        promise->set_value(PlanExecuteResult{ErrorCode::EC_OK, ""});
-        return future;
-    }
-
-    // Sync: ensure CAS(→DELETING) is persisted before scheduling Phase 2.
-    if (!indexer->Sync(actual_task.block_keys)) {
-        HandleErrorPromise(promise,
-                           ErrorCode::EC_ERROR,
-                           "Sync failed or timed out for location delete, instance[%s]",
-                           task.instance_id.c_str());
-        return future;
-    }
-
-    KVCM_LOG_DEBUG("Location statuses updated, submitting task to worker pool with delay: %lld microseconds",
-                   static_cast<long long>(task.delay.count()));
-
-    auto execute_task = [this, promise, actual_task]() {
-        try {
-            promise->set_value(DoLocationDelTask(actual_task));
-        } catch (const std::exception &e) {
-            HandleErrorPromise(promise, ErrorCode::EC_ERROR, "location delete task threw exception: %s", e.what());
-        } catch (...) {
-            HandleErrorPromise(promise, ErrorCode::EC_ERROR, "location delete task threw unknown exception");
-        }
-    };
-    auto cancel_task = [promise]() {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before task execution.");
-    };
-    bool submit_result = this->SubmitRaw(execute_task, task.delay, cancel_task, task_class);
-    if (!submit_result) {
-        HandleErrorPromise(promise, ErrorCode::EC_ERROR, "submit task failed");
-        return future;
-    }
+    auto future = promise->get_future();
+    auto completion = std::make_shared<PromiseCompletion>(promise);
+    RunDeleteAdmission(
+        completion,
+        task.delay,
+        [this, &task]() { return PrepareDeleteTask(task, /*strict_meta_delete=*/true); },
+        task_class,
+        admission);
     return future;
 }
 
@@ -558,7 +501,9 @@ bool SchedulePlanExecutor::FillActualTask(
     const std::vector<std::vector<MetaSearcher::LocationCASTask>> &batch_cas_tasks,
     const std::vector<std::vector<ErrorCode>> &batch_results,
     CacheLocationDelRequest &actual_task,
-    std::string &error_message) {
+    std::string &error_message,
+    std::size_t &unresolved_locations,
+    ErrorCode &first_unresolved_ec) {
 
     if (batch_results.size() != batch_cas_block_keys.size() || batch_results.size() != batch_cas_tasks.size()) {
         error_message = StringUtil::FormatString(
@@ -584,9 +529,19 @@ bool SchedulePlanExecutor::FillActualTask(
         std::vector<std::string> location_ids;
         for (size_t location_idx = 0; location_idx < results.size(); location_idx++) {
             if (results[location_idx] != EC_OK) {
-                KVCM_LOG_INFO("Location status CAS failed, block key: %ld, location_id: %s",
+                KVCM_LOG_INFO("Location status CAS failed, block key: %ld, location_id: %s, ec: %d",
                               batch_cas_block_keys[key_idx],
-                              batch_cas_tasks[key_idx][location_idx].location_id.c_str());
+                              batch_cas_tasks[key_idx][location_idx].location_id.c_str(),
+                              results[location_idx]);
+                // EC_NOENT means the location is already gone, which is exactly
+                // the state the caller asked for. Anything else leaves a block
+                // that is still reusable.
+                if (results[location_idx] != EC_NOENT) {
+                    ++unresolved_locations;
+                    if (first_unresolved_ec == ErrorCode::EC_OK) {
+                        first_unresolved_ec = results[location_idx];
+                    }
+                }
                 continue;
             }
             location_ids.push_back(batch_cas_tasks[key_idx][location_idx].location_id);
@@ -600,8 +555,9 @@ bool SchedulePlanExecutor::FillActualTask(
     return true;
 }
 SchedulePlanExecutor::LocationDelAdmissionResult
-SchedulePlanExecutor::PrepareDeleteTask(const CacheMetaDelRequest &task) {
-    return PrepareDeleteTaskImpl(task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false);
+SchedulePlanExecutor::PrepareDeleteTask(const CacheMetaDelRequest &task, bool strict_meta_delete) {
+    return PrepareDeleteTaskImpl(
+        task.instance_id, task.block_keys, nullptr, nullptr, task.delay, false, strict_meta_delete);
 }
 
 SchedulePlanExecutor::LocationDelAdmissionResult
@@ -643,7 +599,8 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                                             const std::vector<std::vector<std::string>> *target_location_ids,
                                             const std::vector<std::vector<std::string>> *expected_location_values,
                                             std::chrono::microseconds delay,
-                                            bool authoritative_read) {
+                                            bool authoritative_read,
+                                            bool strict_meta_delete) {
     LocationDelAdmissionResult admission_result;
     admission_result.actual_task = CacheLocationDelRequest{instance_id, {}, {}, delay};
 
@@ -663,8 +620,12 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
     BlockMask empty_mask;
     auto request_context = std::make_shared<RequestContext>("schedule_plan_executor_call");
     ErrorCode get_locations_ec = ErrorCode::EC_OK;
-    if (authoritative_read) {
-        const auto get_result = indexer->GetLocationsFromPersistent(request_context.get(), block_keys, location_maps);
+    if (authoritative_read || strict_meta_delete) {
+        // Explicit invalidation cannot interpret a failed read as an absent key.
+        // Preserve the cache policy; only authoritative callers bypass the cache.
+        const auto get_result =
+            authoritative_read ? indexer->GetLocationsFromPersistent(request_context.get(), block_keys, location_maps)
+                               : indexer->GetLocations(request_context.get(), block_keys, location_maps);
         if (get_result.error_codes.size() != block_keys.size()) {
             get_locations_ec = ErrorCode::EC_ERROR;
         } else {
@@ -693,7 +654,7 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
 
     std::vector<int64_t> batch_cas_block_keys;
     std::vector<std::vector<MetaSearcher::LocationCASTask>> batch_cas_tasks;
-    // A null target list represents CacheMetaDelRequest and selects every non-deleting location.
+    // A null target list represents CacheMetaDelRequest and selects every location.
     for (size_t block_key_idx = 0; block_key_idx < block_keys.size(); ++block_key_idx) {
         std::unordered_set<std::string> target_ids;
         if (target_location_ids != nullptr) {
@@ -715,17 +676,27 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
                 continue;
             }
             const auto &location = *loc_kv.second;
-            if (location.status() == CacheLocationStatus::CLS_DELETING) {
-                continue;
-            }
             if (target_location_ids != nullptr && target_ids.find(location.id()) == target_ids.end()) {
+                continue; // not part of this request, so neither requested nor unresolved
+            }
+            ++admission_result.requested_locations;
+            if (!strict_meta_delete && location.status() == CacheLocationStatus::CLS_DELETING) {
+                // Preserve the async meta / location admission behavior:
+                // already-DELETING locations are skipped. Synchronous meta
+                // submission instead re-arms them so retries can reclaim
+                // locations stranded by a previous Sync or enqueue failure.
                 continue;
             }
             std::string expected_location_value;
             if (expected_location_values != nullptr) {
                 const auto expected = expected_values_by_location.find(location.id());
                 if (expected == expected_values_by_location.end() || location.ToJsonString() != expected->second) {
-                    continue; // stable location was refreshed after the cleanup scan
+                    // stable location was refreshed after the cleanup scan
+                    ++admission_result.unresolved_locations;
+                    if (admission_result.first_unresolved_ec == ErrorCode::EC_OK) {
+                        admission_result.first_unresolved_ec = ErrorCode::EC_MISMATCH;
+                    }
+                    continue;
                 }
                 expected_location_value = expected->second;
             }
@@ -752,11 +723,23 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
     }
 
     std::string error_message;
-    if (!FillActualTask(
-            batch_cas_block_keys, batch_cas_tasks, batch_results, admission_result.actual_task, error_message)) {
+    if (!FillActualTask(batch_cas_block_keys,
+                        batch_cas_tasks,
+                        batch_results,
+                        admission_result.actual_task,
+                        error_message,
+                        admission_result.unresolved_locations,
+                        admission_result.first_unresolved_ec)) {
         admission_result.result = MakeErrorResult(
             ErrorCode::EC_ERROR, StringUtil::FormatString("FillActualTask error: %s", error_message.c_str()));
         return admission_result;
+    }
+    // The aggregate ec does not rise for a per-location EC_MISMATCH, but it does
+    // rise for hard backend errors. Never let one of those end up reported as a
+    // fully resolved batch just because the per-location view looked clean.
+    if (update_ec != ErrorCode::EC_OK && admission_result.unresolved_locations == 0) {
+        admission_result.unresolved_locations = 1;
+        admission_result.first_unresolved_ec = update_ec;
     }
     if (admission_result.actual_task.block_keys.empty()) {
         return admission_result;
@@ -777,12 +760,37 @@ SchedulePlanExecutor::PrepareDeleteTaskImpl(const std::string &instance_id,
 void SchedulePlanExecutor::RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,
                                               std::chrono::microseconds delay,
                                               const std::function<LocationDelAdmissionResult()> &prepare,
-                                              ScheduleTaskClass task_class) {
+                                              ScheduleTaskClass task_class,
+                                              LogicalDeleteAdmission *admission) {
+    if (admission != nullptr) {
+        // Pessimistic default: an admission that never reports back must not
+        // look like a clean logical invalidation.
+        *admission = LogicalDeleteAdmission{};
+        admission->status = ErrorCode::EC_ERROR;
+        admission->error_message = "location delete admission did not report";
+    }
     try {
         auto admission_result = prepare();
+        if (admission != nullptr) {
+            admission->status = admission_result.result.status;
+            admission->error_message = admission_result.result.error_message;
+            admission->requested_locations = admission_result.requested_locations;
+            admission->unresolved_locations = admission_result.unresolved_locations;
+            admission->first_unresolved_ec = admission_result.first_unresolved_ec;
+        }
         if (admission_result.result.status != ErrorCode::EC_OK || !admission_result.needs_physical_delete) {
             completion->Complete(std::move(admission_result.result));
             return;
+        }
+        if (admission != nullptr && admission_result.unresolved_locations != 0) {
+            // Partially admitted: the subset that did move to DELETING stays
+            // scheduled below. Stranding it would leak blocks that are already
+            // unreachable through the metadata.
+            KVCM_LOG_WARN("logical delete partially admitted, instance[%s] requested[%zu] unresolved[%zu] ec[%d]",
+                          admission_result.actual_task.instance_id.c_str(),
+                          admission_result.requested_locations,
+                          admission_result.unresolved_locations,
+                          admission_result.first_unresolved_ec);
         }
 
         KVCM_LOG_DEBUG("Location statuses updated, submitting task to worker pool with delay: %lld microseconds",
@@ -800,12 +808,31 @@ void SchedulePlanExecutor::RunDeleteAdmission(const std::shared_ptr<PromiseCompl
             completion->Complete(ErrorCode::EC_ERROR, "SchedulePlanExecutor stopped before physical delete.");
         };
         if (!SubmitRaw(execute_task, delay, cancel_task, task_class)) {
-            completion->Complete(ErrorCode::EC_ERROR, "submit physical delete task failed");
+            // The locations are DELETING but nothing owns their reclamation, and
+            // no GC path picks up a stranded DELETING. Report the logical phase
+            // as failed so the caller retries; the retry re-CAS'es DELETING ->
+            // DELETING and re-enqueues.
+            static constexpr char kEnqueueFailed[] = "submit physical delete task failed";
+            if (admission != nullptr) {
+                admission->status = ErrorCode::EC_ERROR;
+                admission->error_message = kEnqueueFailed;
+            }
+            completion->Complete(ErrorCode::EC_ERROR, kEnqueueFailed);
         }
     } catch (const std::exception &e) {
-        completion->Complete(ErrorCode::EC_ERROR,
-                             StringUtil::FormatString("location delete admission threw exception: %s", e.what()));
-    } catch (...) { completion->Complete(ErrorCode::EC_ERROR, "location delete admission threw unknown exception"); }
+        const std::string message = StringUtil::FormatString("location delete admission threw exception: %s", e.what());
+        if (admission != nullptr) {
+            admission->status = ErrorCode::EC_ERROR;
+            admission->error_message = message;
+        }
+        completion->Complete(ErrorCode::EC_ERROR, message);
+    } catch (...) {
+        if (admission != nullptr) {
+            admission->status = ErrorCode::EC_ERROR;
+            admission->error_message = "location delete admission threw unknown exception";
+        }
+        completion->Complete(ErrorCode::EC_ERROR, "location delete admission threw unknown exception");
+    }
 }
 
 std::future<PlanExecuteResult> SchedulePlanExecutor::Submit(const CacheLocationDelRequest &task) {

--- a/kv_cache_manager/manager/schedule_plan_executor.h
+++ b/kv_cache_manager/manager/schedule_plan_executor.h
@@ -51,6 +51,30 @@ struct AsyncDeleteSubmitResult {
     std::future<PlanExecuteResult> future;
 };
 
+// Outcome of the synchronous logical-invalidation phase of a delete request.
+// Physical reclamation stays asynchronous: the PlanExecuteResult future keeps
+// its existing "physical delete finished" contract and is not affected here.
+struct LogicalDeleteAdmission {
+    // Hard failure that aborted the whole request: unknown instance, stopped
+    // executor, metadata read failure or Sync failure.
+    ErrorCode status{ErrorCode::EC_OK};
+    std::string error_message;
+    // Locations this request tried to invalidate, and the subset that is still
+    // reusable afterwards. Counting instead of collapsing into a single code
+    // keeps the strictness decision with the caller: opportunistic cleanup and
+    // migration may ignore the counts, explicit invalidation must not.
+    std::size_t requested_locations{0};
+    std::size_t unresolved_locations{0};
+    // First per-location error behind unresolved_locations, typically
+    // EC_MISMATCH when a concurrent publish won the CAS.
+    ErrorCode first_unresolved_ec{ErrorCode::EC_OK};
+
+    // EC_OK only when every requested location is unavailable for reuse.
+    // EC_PARTIAL_OK when part of the batch was invalidated; the admitted subset
+    // stays physically scheduled either way.
+    ErrorCode LogicalStatus() const;
+};
+
 struct CacheLocationDelRequest {
     std::string instance_id;
     std::vector<int64_t> block_keys;
@@ -134,6 +158,10 @@ public:
     ~SchedulePlanExecutor();
 
     std::future<PlanExecuteResult> Submit(const CacheMetaDelRequest &task);
+    // Same submission, but also reports how the synchronous logical phase went.
+    // For callers that must answer "is this cache still reusable?" before the
+    // physical delete has run.
+    std::future<PlanExecuteResult> Submit(const CacheMetaDelRequest &task, LogicalDeleteAdmission &admission);
     std::future<PlanExecuteResult> Submit(const CacheLocationDelRequest &task);
     std::future<PlanExecuteResult> Submit(const CacheLocationCopyRequest &task);
     AsyncDeleteSubmitResult SubmitAsync(const CacheMetaDelRequest &task);
@@ -156,6 +184,12 @@ private:
         PlanExecuteResult result{ErrorCode::EC_OK, ""};
         CacheLocationDelRequest actual_task;
         bool needs_physical_delete{false};
+        // Per-location bookkeeping feeding LogicalDeleteAdmission. Recorded on
+        // every path so that no caller has to re-derive it, but never folded
+        // into `result`: the future must keep reporting physical completion.
+        std::size_t requested_locations{0};
+        std::size_t unresolved_locations{0};
+        ErrorCode first_unresolved_ec{ErrorCode::EC_OK};
     };
 
     std::shared_ptr<MetaIndexerManager> meta_manager_;
@@ -182,12 +216,22 @@ private:
     static bool IsMigrationTaskClass(ScheduleTaskClass task_class);
     static std::size_t TaskClassIndex(ScheduleTaskClass task_class);
     std::size_t WaitingTaskCountLocked() const;
+    // `unresolved_locations` / `first_unresolved_ec` accumulate the slots whose
+    // CAS did not take effect. Aggregate EC_OK from BatchCASLocationStatus does
+    // not imply every location moved to DELETING, so they cannot be inferred
+    // from the return value or from the filled task alone.
     static bool FillActualTask(const std::vector<int64_t> &batch_cas_block_keys,
                                const std::vector<std::vector<MetaSearcher::LocationCASTask>> &batch_cas_tasks,
                                const std::vector<std::vector<ErrorCode>> &batch_results,
                                CacheLocationDelRequest &actual_task,
-                               std::string &error_message);
-    LocationDelAdmissionResult PrepareDeleteTask(const CacheMetaDelRequest &task);
+                               std::string &error_message,
+                               std::size_t &unresolved_locations,
+                               ErrorCode &first_unresolved_ec);
+    // Synchronous meta submission checks every read result and re-arms
+    // DELETING locations (CAS, Sync, physical enqueue). DELETING alone does
+    // not prove an owned physical task after a failure or restart.
+    // Async meta and location submissions retain their existing skip behavior.
+    LocationDelAdmissionResult PrepareDeleteTask(const CacheMetaDelRequest &task, bool strict_meta_delete = false);
     LocationDelAdmissionResult PrepareDeleteTask(const CacheLocationDelRequest &task);
     LocationDelAdmissionResult
     PrepareDeleteTaskImpl(const std::string &instance_id,
@@ -195,14 +239,21 @@ private:
                           const std::vector<std::vector<std::string>> *target_location_ids,
                           const std::vector<std::vector<std::string>> *expected_location_values,
                           std::chrono::microseconds delay,
-                          bool authoritative_read = false);
+                          bool authoritative_read = false,
+                          bool strict_meta_delete = false);
+    // `admission` is only ever non-null when RunDeleteAdmission is invoked
+    // inline on the submitting thread; the deferred admission path has no
+    // caller frame left to report into.
     void RunDeleteAdmission(const std::shared_ptr<PromiseCompletion> &completion,
                             std::chrono::microseconds delay,
                             const std::function<LocationDelAdmissionResult()> &prepare,
-                            ScheduleTaskClass task_class);
+                            ScheduleTaskClass task_class,
+                            LogicalDeleteAdmission *admission = nullptr);
     AsyncDeleteSubmitResult SubmitDeleteTaskAsync(std::chrono::microseconds delay,
                                                   std::function<LocationDelAdmissionResult()> prepare);
-    std::future<PlanExecuteResult> SubmitMetaDelete(const CacheMetaDelRequest &task, ScheduleTaskClass task_class);
+    std::future<PlanExecuteResult> SubmitMetaDelete(const CacheMetaDelRequest &task,
+                                                    ScheduleTaskClass task_class,
+                                                    LogicalDeleteAdmission *admission = nullptr);
     std::future<PlanExecuteResult> SubmitLocationDelete(const CacheLocationDelRequest &task,
                                                         ScheduleTaskClass task_class);
     PlanExecuteResult DoLocationDelTask(const CacheLocationDelRequest &task);

--- a/kv_cache_manager/manager/test/cache_manager_test.cc
+++ b/kv_cache_manager/manager/test/cache_manager_test.cc
@@ -199,6 +199,39 @@ public:
         control_cv_.notify_all();
     }
 
+    // Blocks *after* the location snapshot has been copied out, instead of
+    // before the read reaches the backend. A before-read gate lets a concurrent
+    // publisher finish first, so the gated reader observes the published state
+    // and the read-WRITING -> publish-SERVING -> CAS-MISMATCH race is never
+    // exercised. Only armed on the arming thread, and only on the non-RMW
+    // CacheLocationMapVector read: MetaIndexer::GetLocations holds no shard
+    // lock there, so a publisher can make progress while this one waits.
+    void BlockAfterNextLocationSnapshotOnCurrentThread() {
+        std::lock_guard<std::mutex> lock(control_mutex_);
+        block_after_next_snapshot_ = true;
+        snapshot_thread_ = std::this_thread::get_id();
+        snapshot_entered_ = false;
+        release_snapshot_ = false;
+        captured_snapshot_.clear();
+    }
+
+    bool WaitUntilLocationSnapshotEntered(std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(control_mutex_);
+        return control_cv_.wait_for(lock, timeout, [&] { return snapshot_entered_; });
+    }
+
+    void ReleaseLocationSnapshot() {
+        std::lock_guard<std::mutex> lock(control_mutex_);
+        release_snapshot_ = true;
+        control_cv_.notify_all();
+    }
+
+    // location_id -> status actually handed to the admission path.
+    std::map<std::string, CacheLocationStatus> CapturedLocationSnapshot() {
+        std::lock_guard<std::mutex> lock(control_mutex_);
+        return captured_snapshot_;
+    }
+
     void BlockNextUpsert() {
         std::lock_guard<std::mutex> lock(control_mutex_);
         block_next_upsert_ = true;
@@ -220,6 +253,11 @@ public:
     void FailKeyOnNextUpsert(int64_t key) {
         std::lock_guard<std::mutex> lock(control_mutex_);
         fail_key_on_next_upsert_ = key;
+    }
+
+    void FailKeyOnNextLocationRead(int64_t key) {
+        std::lock_guard<std::mutex> lock(control_mutex_);
+        fail_key_on_next_location_read_ = key;
     }
 
     size_t GetSyncCallCount() {
@@ -280,7 +318,19 @@ public:
                                         const KeyTypeVec &keys,
                                         CacheLocationMapVector &out_locations) noexcept override {
         MaybeBlockLocationRead();
-        return MetaLocalBackend::GetLocations(request_context, keys, out_locations);
+        auto result = MetaLocalBackend::GetLocations(request_context, keys, out_locations);
+        {
+            std::lock_guard<std::mutex> lock(control_mutex_);
+            for (size_t i = 0; i < keys.size(); ++i) {
+                if (fail_key_on_next_location_read_ == keys[i]) {
+                    result[i] = EC_ERROR;
+                    out_locations[i].clear(); // Preserve the valid result shape.
+                }
+            }
+            fail_key_on_next_location_read_.reset();
+        }
+        MaybeBlockAfterLocationSnapshot(out_locations);
+        return result;
     }
 
     std::vector<ErrorCode> GetLocationValues(RequestContext *request_context,
@@ -320,6 +370,27 @@ private:
         control_cv_.wait(lock, [&] { return release_location_read_; });
     }
 
+    void MaybeBlockAfterLocationSnapshot(const CacheLocationMapVector &out_locations) {
+        std::unique_lock<std::mutex> lock(control_mutex_);
+        if (!block_after_next_snapshot_ || snapshot_thread_ != std::this_thread::get_id()) {
+            return;
+        }
+        block_after_next_snapshot_ = false;
+        snapshot_thread_ = {};
+        captured_snapshot_.clear();
+        for (const auto &location_map : out_locations) {
+            for (const auto &location_kv : location_map) {
+                if (!location_kv.second) {
+                    continue;
+                }
+                captured_snapshot_.emplace(location_kv.second->id(), location_kv.second->status());
+            }
+        }
+        snapshot_entered_ = true;
+        control_cv_.notify_all();
+        control_cv_.wait(lock, [&] { return release_snapshot_; });
+    }
+
     void MaybeBlockUpsert() {
         std::unique_lock<std::mutex> lock(control_mutex_);
         if (!block_next_upsert_) {
@@ -340,7 +411,13 @@ private:
     std::thread::id blocked_location_read_thread_;
     bool location_read_entered_ = false;
     bool release_location_read_ = false;
+    bool block_after_next_snapshot_ = false;
+    std::thread::id snapshot_thread_;
+    bool snapshot_entered_ = false;
+    bool release_snapshot_ = false;
+    std::map<std::string, CacheLocationStatus> captured_snapshot_;
     std::optional<int64_t> fail_key_on_next_upsert_;
+    std::optional<int64_t> fail_key_on_next_location_read_;
     size_t sync_call_count_ = 0;
 };
 
@@ -385,6 +462,64 @@ public:
 private:
     std::shared_ptr<DataStorageBackend> delegate_;
     std::atomic<size_t> deleted_uri_count_{0};
+};
+
+// Occupies every SchedulePlanExecutor worker so a queued physical delete cannot
+// start. Proving "the logical ACK does not wait for physical deletion" needs a
+// gate: a sleep only shows the deletion was slow, never that it was still queued
+// when the caller was already acknowledged. Held through a shared_ptr so the
+// blocked tasks keep the gate alive past the end of the test scope.
+class SchedulerWorkerGate {
+public:
+    static void
+    Occupy(const std::shared_ptr<SchedulerWorkerGate> &gate, SchedulePlanExecutor *executor, size_t worker_count) {
+        for (size_t i = 0; i < worker_count; ++i) {
+            executor->SubmitTask([gate]() { gate->Enter(); });
+        }
+    }
+
+    void Enter() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        ++entered_;
+        cv_.notify_all();
+        cv_.wait(lock, [&] { return released_; });
+    }
+
+    bool WaitUntilOccupied(size_t worker_count, std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return cv_.wait_for(lock, timeout, [&] { return entered_ >= worker_count; });
+    }
+
+    void Release() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        released_ = true;
+        cv_.notify_all();
+    }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    size_t entered_ = 0;
+    bool released_ = false;
+};
+
+// Releases the gate on every exit path, including a failed ASSERT_*: leaving the
+// workers blocked would deadlock the executor's Stop() during fixture teardown.
+class ScopedWorkerGateRelease {
+public:
+    explicit ScopedWorkerGateRelease(std::shared_ptr<SchedulerWorkerGate> gate) : gate_(std::move(gate)) {}
+    ~ScopedWorkerGateRelease() {
+        if (gate_) {
+            gate_->Release();
+        }
+    }
+    // Hands the responsibility back to the caller: used when the gate must stay
+    // closed past this scope but every early-exit path inside it still has to
+    // release.
+    void Disarm() { gate_.reset(); }
+
+private:
+    std::shared_ptr<SchedulerWorkerGate> gate_;
 };
 
 class CacheManagerTest : public TESTBASE {
@@ -2218,6 +2353,694 @@ TEST_F(CacheManagerTest, TestRemoveCache) {
                       meta.at("status"));
         }
     }
+}
+
+TEST_F(CacheManagerTest, TestFinishWriteCacheDoesNotReviveLogicallyDeletedLocation) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    const KeyVector keys{97001};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+
+    // Submit performs the logical status transition synchronously. Keep physical
+    // deletion queued so this exercises an existing DELETING location, not NOENT.
+    CacheMetaDelRequest delete_request{"test_instance", keys, std::chrono::hours(1)};
+    auto delete_future = cache_manager_->schedule_plan_executor_->Submit(delete_request);
+    ASSERT_TRUE(delete_future.valid());
+    ASSERT_EQ(std::future_status::timeout, delete_future.wait_for(std::chrono::seconds(0)));
+    {
+        auto [meta_ec, meta_info] =
+            cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+        ASSERT_EQ(EC_OK, meta_ec);
+        ASSERT_EQ(1u, meta_info.metas().size());
+        std::map<std::string, std::string> meta;
+        ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+        ASSERT_EQ(CacheLocation::CacheLocationStatusToString(CLS_DELETING), meta.at("status"));
+    }
+
+    EXPECT_NE(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+    {
+        auto [meta_ec, meta_info] =
+            cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+        ASSERT_EQ(EC_OK, meta_ec);
+        ASSERT_EQ(1u, meta_info.metas().size());
+        std::map<std::string, std::string> meta;
+        ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+        EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_DELETING), meta.at("status"));
+    }
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), "test_instance", CacheManager::QueryType::QT_PREFIX_MATCH, keys, {}, empty_mask, 0, {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(0u, locations.cache_locations_view().size());
+    // Stop cancels the delayed physical task; teardown never waits for its delay.
+    cache_manager_->schedule_plan_executor_->Stop();
+}
+
+TEST_F(CacheManagerTest, TestRemoveCacheRejectsUnknownInstance) {
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    EXPECT_NE(
+        EC_OK,
+        cache_manager_->RemoveCache(request_context_.get(), "unknown_instance", KeyVector{97002}, {}, empty_mask));
+}
+
+TEST_F(CacheManagerTest, TestRemoveCacheRejectsStoppedExecutor) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    const KeyVector keys{97003};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    cache_manager_->schedule_plan_executor_->Stop();
+    EXPECT_NE(EC_OK, cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask));
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(1u, meta_info.metas().size());
+    std::map<std::string, std::string> meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+    EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_SERVING), meta.at("status"));
+}
+
+TEST_F(CacheManagerTest, TestRemoveCacheRejectsReadError) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    auto *backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, backend);
+    const KeyVector keys{97021};
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+    backend->FailKeyOnNextLocationRead(keys.back());
+    EXPECT_NE(EC_OK,
+              cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, BlockMask{size_t{0}}));
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(request_context_.get(),
+                                                                  "test_instance",
+                                                                  CacheManager::QueryType::QT_PREFIX_MATCH,
+                                                                  KeyVector{keys.back()},
+                                                                  {},
+                                                                  BlockMask{size_t{0}},
+                                                                  0,
+                                                                  {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(1u, locations.cache_locations_view().size());
+}
+
+TEST_F(CacheManagerTest, TestRemoveCacheRejectsPartialReadError) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    auto *backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, backend);
+    const KeyVector keys{97022, 97023};
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+    backend->FailKeyOnNextLocationRead(keys.back());
+    EXPECT_NE(EC_OK,
+              cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, BlockMask{size_t{0}}));
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(request_context_.get(),
+                                                                  "test_instance",
+                                                                  CacheManager::QueryType::QT_PREFIX_MATCH,
+                                                                  KeyVector{keys.back()},
+                                                                  {},
+                                                                  BlockMask{size_t{0}},
+                                                                  0,
+                                                                  {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(1u, locations.cache_locations_view().size());
+}
+
+TEST_F(CacheManagerTest, TestRemoveCacheReportsPartialLogicalDeleteFailure) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, meta_backend);
+    const KeyVector keys{97004, 97005};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    meta_backend->FailKeyOnNextUpsert(keys.back());
+    const auto remove_ec = cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask);
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(keys.size(), meta_info.metas().size());
+    std::map<std::string, std::string> admitted_meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], admitted_meta));
+    EXPECT_TRUE(admitted_meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_DELETING) ||
+                admitted_meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_NOT_FOUND));
+    std::map<std::string, std::string> failed_meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[1], failed_meta));
+    const bool failed_key_invalidated =
+        failed_meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_DELETING) ||
+        failed_meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_NOT_FOUND);
+    // A bounded retry may recover the injected failure. Success is honest only
+    // when every requested key is unavailable for reuse at the time of return.
+    if (remove_ec == EC_OK) {
+        EXPECT_TRUE(failed_key_invalidated);
+    } else {
+        EXPECT_TRUE(failed_key_invalidated ||
+                    failed_meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_SERVING));
+    }
+}
+
+// 逻辑失效对"本来就查不到"的 key 必须是诚实的成功：没有任何 location 需要作废，
+// 重复调用同样成功。这条守住"honest admission"不会退化成对缺失 key 报错。
+TEST_F(CacheManagerTest, TestRemoveCacheOnAbsentKeysIsIdempotent) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    const KeyVector keys{97101, 97102};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+
+    EXPECT_EQ(EC_OK, cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask));
+    EXPECT_EQ(EC_OK, cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask));
+
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(keys.size(), meta_info.metas().size());
+    for (const auto &meta_json : meta_info.metas()) {
+        std::map<std::string, std::string> meta;
+        ASSERT_TRUE(Jsonizable::FromJsonString(meta_json, meta));
+        EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_NOT_FOUND), meta.at("status"));
+    }
+}
+
+// 第二次失效落在已经 CLS_DELETING（物理回收由既有 GC 拥有）或已经消失的 location 上，
+// 属于"已经不可复用"，必须继续返回 EC_OK，而不是把既有 GC 的所有权当成失败。
+TEST_F(CacheManagerTest, TestRemoveCacheRepeatedInvalidationIsIdempotent) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    const KeyVector keys{97103};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    EXPECT_EQ(EC_OK, cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask));
+    EXPECT_EQ(EC_OK, cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask));
+
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(1u, meta_info.metas().size());
+    std::map<std::string, std::string> meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+    EXPECT_NE(CacheLocation::CacheLocationStatusToString(CLS_SERVING), meta.at("status"));
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), "test_instance", CacheManager::QueryType::QT_PREFIX_MATCH, keys, {}, empty_mask, 0, {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(0u, locations.cache_locations_view().size());
+}
+
+// 读到 CLS_WRITING 的快照后，并发 Finish 把 location 发布成 CLS_SERVING，
+// 失效的 CAS(WRITING->DELETING) 因此 per-location EC_MISMATCH。
+// BatchCASLocationStatus 的聚合 ec 在这种冲突下仍是 EC_OK，
+// 所以只看聚合值就会返回"假成功"：block 还在 SERVING、仍可被复用。
+// 允许有界重试收敛到"不再 SERVING"，但绝不允许 EC_OK + 仍然 SERVING。
+TEST_F(CacheManagerTest, TestRemoveCacheDoesNotFalselySucceedWhenPublishRacesInvalidation) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, meta_backend);
+    const KeyVector keys{97104};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+
+    // 逻辑失效的准入在调用线程上同步完成，因此把 gate 绑在当前线程；而且必须拦在
+    // GetLocations **返回之后**：拦在读之前只会让 publisher 先跑完，RemoveCache
+    // 读到的快照就是 SERVING，压根走不到 CAS(WRITING->DELETING) 的 MISMATCH。
+    meta_backend->BlockAfterNextLocationSnapshotOnCurrentThread();
+    ErrorCode finish_ec = EC_UNKNOWN;
+    std::string status_seen_by_publisher;
+    std::thread publisher([&]() {
+        EXPECT_TRUE(meta_backend->WaitUntilLocationSnapshotEntered(std::chrono::seconds(10)));
+        finish_ec = cache_manager_->FinishWriteCache(
+            request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()});
+        // 在放行 Remove 之前确认并发状态确实已经是 SERVING。
+        auto [publish_meta_ec, publish_meta_info] =
+            cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+        std::map<std::string, std::string> published_meta;
+        if (publish_meta_ec == EC_OK && publish_meta_info.metas().size() == 1 &&
+            Jsonizable::FromJsonString(publish_meta_info.metas()[0], published_meta)) {
+            status_seen_by_publisher = published_meta["status"];
+        }
+        meta_backend->ReleaseLocationSnapshot();
+    });
+    const ErrorCode remove_ec =
+        cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask);
+    publisher.join();
+    ASSERT_EQ(EC_OK, finish_ec);
+
+    // 只有这两条同时成立，本用例才真正复现了竞态：Remove 拿到的是 WRITING 快照，
+    // 而它继续做 CAS 时 location 已经被并发发布成 SERVING。
+    const auto captured = meta_backend->CapturedLocationSnapshot();
+    ASSERT_FALSE(captured.empty()) << "snapshot gate never fired: the race was not exercised";
+    for (const auto &location_kv : captured) {
+        EXPECT_EQ(CLS_WRITING, location_kv.second)
+            << "RemoveCache should have captured a WRITING snapshot, location " << location_kv.first;
+    }
+    EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_SERVING), status_seen_by_publisher);
+
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(1u, meta_info.metas().size());
+    std::map<std::string, std::string> meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+    const bool still_servable = meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_SERVING);
+    if (remove_ec == EC_OK) {
+        EXPECT_FALSE(still_servable) << "RemoveCache returned EC_OK while the location is still SERVING";
+    } else {
+        EXPECT_NE(EC_OK, remove_ec);
+    }
+}
+
+// 逻辑失效 ACK 不等物理删除：占满全部 worker 后 RemoveCache 仍必须同步返回，
+// 此时 location 已经是 CLS_DELETING（逻辑失效已持久化），而物理回收（CAD 到
+// CLS_NOT_FOUND）还排在队列里没被执行。放开 gate 后物理回收才推进。
+TEST_F(CacheManagerTest, TestRemoveCacheAcknowledgesBeforePhysicalDeletion) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    const KeyVector keys{97105};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    auto *executor = cache_manager_->schedule_plan_executor_.get();
+    ASSERT_NE(nullptr, executor);
+    const size_t worker_count = executor->workers_.size();
+    ASSERT_LT(0u, worker_count);
+    auto gate = std::make_shared<SchedulerWorkerGate>();
+    SchedulerWorkerGate::Occupy(gate, executor, worker_count);
+    {
+        ScopedWorkerGateRelease occupy_guard(gate);
+        ASSERT_TRUE(gate->WaitUntilOccupied(worker_count, std::chrono::seconds(10)));
+        occupy_guard.Disarm();
+    }
+
+    // RemoveCache 必须跑在别的线程上：一旦回归成"同步等物理删除完成"，测试线程会
+    // 永远卡死，RAII 也就没机会放开 gate。析构是声明的逆序，所以放 gate 的守卫要
+    // 声明在 future **之后** —— 任何 ASSERT 提前返回时都先放 gate、再析构（会
+    // join 的）future。
+    auto remove_context = std::make_shared<RequestContext>("remove_ack_test");
+    auto remove_future = std::async(std::launch::async, [&]() {
+        return cache_manager_->RemoveCache(remove_context.get(), "test_instance", keys, {}, empty_mask);
+    });
+    ScopedWorkerGateRelease gate_release(gate);
+
+    ASSERT_EQ(std::future_status::ready, remove_future.wait_for(std::chrono::seconds(10)))
+        << "RemoveCache did not acknowledge while every worker was blocked";
+    EXPECT_EQ(EC_OK, remove_future.get());
+    {
+        auto [meta_ec, meta_info] =
+            cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+        ASSERT_EQ(EC_OK, meta_ec);
+        ASSERT_EQ(1u, meta_info.metas().size());
+        std::map<std::string, std::string> meta;
+        ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+        // 物理回收一个 worker 都拿不到，此刻只可能停在逻辑失效状态。
+        EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_DELETING), meta.at("status"));
+    }
+    // 逻辑失效已经生效：即使物理回收还没跑，block 也不能再被复用。
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), "test_instance", CacheManager::QueryType::QT_PREFIX_MATCH, keys, {}, empty_mask, 0, {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(0u, locations.cache_locations_view().size());
+
+    gate->Release();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    bool physically_deleted = false;
+    while (!physically_deleted && std::chrono::steady_clock::now() < deadline) {
+        auto [meta_ec, meta_info] =
+            cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+        std::map<std::string, std::string> meta;
+        if (meta_ec == EC_OK && meta_info.metas().size() == 1 &&
+            Jsonizable::FromJsonString(meta_info.metas()[0], meta) &&
+            meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_NOT_FOUND)) {
+            physically_deleted = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(physically_deleted);
+}
+
+// 部分准入：一个 key 的逻辑失效写入失败，另一个成功。成功的子集必须继续被
+// 物理调度（不能因为同批的另一个 slot 失败就被搁置），同时返回值必须诚实。
+TEST_F(CacheManagerTest, TestRemoveCacheKeepsAdmittedSubsetScheduled) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    auto *meta_backend = InstallControllableMetaBackend();
+    ASSERT_NE(nullptr, meta_backend);
+    const KeyVector keys{97106, 97107};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    meta_backend->FailKeyOnNextUpsert(keys.back());
+    const ErrorCode remove_ec =
+        cache_manager_->RemoveCache(request_context_.get(), "test_instance", keys, {}, empty_mask);
+
+    // 被准入的 key 归既有物理回收管道所有，最终必须落到 CLS_NOT_FOUND。
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    bool admitted_key_reclaimed = false;
+    while (!admitted_key_reclaimed && std::chrono::steady_clock::now() < deadline) {
+        auto [meta_ec, meta_info] = cache_manager_->GetCacheMeta(
+            request_context_.get(), "test_instance", KeyVector{keys.front()}, {}, empty_mask, 0);
+        std::map<std::string, std::string> meta;
+        if (meta_ec == EC_OK && meta_info.metas().size() == 1 &&
+            Jsonizable::FromJsonString(meta_info.metas()[0], meta) &&
+            meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_NOT_FOUND)) {
+            admitted_key_reclaimed = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(admitted_key_reclaimed);
+
+    auto [meta_ec, meta_info] = cache_manager_->GetCacheMeta(
+        request_context_.get(), "test_instance", KeyVector{keys.back()}, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(1u, meta_info.metas().size());
+    std::map<std::string, std::string> failed_meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], failed_meta));
+    if (failed_meta.at("status") == CacheLocation::CacheLocationStatusToString(CLS_SERVING)) {
+        EXPECT_NE(EC_OK, remove_ec) << "unresolved key is still SERVING but RemoveCache reported success";
+    }
+}
+
+// 显式记录这条掩盖风险：per-location CAS 冲突返回 EC_MISMATCH，
+// 但 BatchCASLocationStatus 的聚合 ec 仍是 EC_OK。任何逻辑失效的准入判定
+// 都不能只看聚合值，必须逐 location 检查。
+TEST_F(CacheManagerTest, TestLocationCasAggregateOkMasksPerLocationMismatch) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    MetaSearcher *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    const KeyVector keys{97108};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+
+    // 先拿到 CLS_WRITING 的快照，再发布成 CLS_SERVING，让快照过期。
+    std::vector<CacheLocationMap> location_maps;
+    ASSERT_EQ(EC_OK, meta_searcher->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_FALSE(location_maps.front().empty());
+    std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks(1);
+    for (const auto &[location_id, location] : location_maps.front()) {
+        ASSERT_TRUE(location != nullptr);
+        ASSERT_EQ(CLS_WRITING, location->status());
+        cas_tasks[0].push_back(MetaSearcher::LocationCASTask{location_id, CLS_WRITING, CLS_DELETING});
+    }
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    std::vector<std::vector<ErrorCode>> cas_results;
+    const ErrorCode aggregate_ec =
+        meta_searcher->BatchCASLocationStatus(request_context_.get(), keys, cas_tasks, cas_results);
+    EXPECT_EQ(EC_OK, aggregate_ec) << "aggregate ec no longer masks per-location mismatch; revisit admission logic";
+    ASSERT_EQ(1u, cas_results.size());
+    ASSERT_EQ(cas_tasks[0].size(), cas_results[0].size());
+    for (const auto location_ec : cas_results[0]) {
+        EXPECT_EQ(EC_MISMATCH, location_ec);
+    }
+
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(1u, meta_info.metas().size());
+    std::map<std::string, std::string> meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+    EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_SERVING), meta.at("status"));
+}
+
+TEST_F(CacheManagerTest, TestFinishWriteCachePublishesWritingLocation) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    const KeyVector keys{97009};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+
+    ASSERT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(1u, meta_info.metas().size());
+    std::map<std::string, std::string> meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], meta));
+    EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_SERVING), meta.at("status"));
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), "test_instance", CacheManager::QueryType::QT_PREFIX_MATCH, keys, {}, empty_mask, 0, {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(1u, locations.cache_locations_view().size());
+}
+
+TEST_F(CacheManagerTest, TestFinishWriteCachePublishesOnlyLocationsStillWriting) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    MetaSearcher *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    const KeyVector keys{97006, 97007};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+
+    // 只把第二个 key 的 location 逻辑删除，模拟写入过程中该 block 被回收命中。
+    const KeyVector deleted_keys{keys.back()};
+    std::vector<CacheLocationMap> location_maps;
+    ASSERT_EQ(EC_OK, meta_searcher->BatchGetLocation(request_context_.get(), deleted_keys, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_FALSE(location_maps.front().empty());
+    std::vector<std::vector<MetaSearcher::LocationCASTask>> cas_tasks(1);
+    for (const auto &[location_id, location] : location_maps.front()) {
+        (void)location;
+        cas_tasks[0].push_back(MetaSearcher::LocationCASTask{location_id, CLS_WRITING, CLS_DELETING});
+    }
+    std::vector<std::vector<ErrorCode>> cas_results;
+    ASSERT_EQ(EC_OK,
+              meta_searcher->BatchCASLocationStatus(request_context_.get(), deleted_keys, cas_tasks, cas_results));
+    ASSERT_EQ(1u, cas_results.size());
+    ASSERT_EQ(cas_tasks[0].size(), cas_results[0].size());
+    for (const auto location_ec : cas_results[0]) {
+        ASSERT_EQ(EC_OK, location_ec);
+    }
+
+    // 一半发布成功、一半 CAS 冲突：聚合 ec 为 EC_OK，必须靠 per-location 结果才能如实上报。
+    EXPECT_EQ(EC_PARTIAL_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    auto [meta_ec, meta_info] =
+        cache_manager_->GetCacheMeta(request_context_.get(), "test_instance", keys, {}, empty_mask, 0);
+    ASSERT_EQ(EC_OK, meta_ec);
+    ASSERT_EQ(keys.size(), meta_info.metas().size());
+    std::map<std::string, std::string> published_meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[0], published_meta));
+    EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_SERVING), published_meta.at("status"));
+    std::map<std::string, std::string> deleted_meta;
+    ASSERT_TRUE(Jsonizable::FromJsonString(meta_info.metas()[1], deleted_meta));
+    EXPECT_EQ(CacheLocation::CacheLocationStatusToString(CLS_DELETING), deleted_meta.at("status"));
+
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), "test_instance", CacheManager::QueryType::QT_PREFIX_MATCH, keys, {}, empty_mask, 0, {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(1u, locations.cache_locations_view().size());
+}
+
+TEST_F(CacheManagerTest, TestFinishWriteCacheDoesNotRecreateDeletedLocation) {
+    ASSERT_EQ(EC_OK,
+              cache_manager_
+                  ->RegisterInstance(request_context_.get(),
+                                     "default",
+                                     "test_instance",
+                                     64,
+                                     createLocationSpecInfos(),
+                                     createModelDeployment(),
+                                     {})
+                  .first);
+    MetaSearcher *meta_searcher = cache_manager_->meta_searcher_manager_->GetMetaSearcher("test_instance");
+    ASSERT_NE(nullptr, meta_searcher);
+    const KeyVector keys{97008};
+    const BlockMask empty_mask = static_cast<size_t>(0);
+    auto [start_ec, write_info] =
+        cache_manager_->StartWriteCache(request_context_.get(), "test_instance", keys, {}, {}, 100000000);
+    ASSERT_EQ(EC_OK, start_ec);
+
+    // 物理回收已经把 location metadata CAD 掉，Finish 只能保持幂等，不允许重建。
+    std::vector<CacheLocationMap> location_maps;
+    ASSERT_EQ(EC_OK, meta_searcher->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_FALSE(location_maps.front().empty());
+    std::vector<std::vector<MetaSearcher::LocationCADTask>> cad_tasks(1);
+    for (const auto &[location_id, location] : location_maps.front()) {
+        (void)location;
+        cad_tasks[0].push_back(MetaSearcher::LocationCADTask{location_id, CLS_WRITING});
+    }
+    std::vector<std::vector<ErrorCode>> cad_results;
+    ASSERT_EQ(EC_OK, meta_searcher->BatchCADLocationStatus(request_context_.get(), keys, cad_tasks, cad_results));
+    location_maps.clear();
+    ASSERT_EQ(EC_OK, meta_searcher->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_TRUE(location_maps.front().empty());
+
+    EXPECT_EQ(EC_OK,
+              cache_manager_->FinishWriteCache(
+                  request_context_.get(), "test_instance", write_info.write_session_id(), BlockMask{keys.size()}));
+
+    location_maps.clear();
+    ASSERT_EQ(EC_OK, meta_searcher->BatchGetLocation(request_context_.get(), keys, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    EXPECT_TRUE(location_maps.front().empty());
+    auto [query_ec, locations] = cache_manager_->GetCacheLocation(
+        request_context_.get(), "test_instance", CacheManager::QueryType::QT_PREFIX_MATCH, keys, {}, empty_mask, 0, {});
+    ASSERT_EQ(EC_OK, query_ec);
+    EXPECT_EQ(0u, locations.cache_locations_view().size());
 }
 
 TEST_F(CacheManagerTest, TestTrimCache) {

--- a/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
+++ b/kv_cache_manager/manager/test/schedule_plan_executor_test.cc
@@ -42,6 +42,35 @@ bool MetaIndexer_Sync_stub(void *obj, const KeyVector &keys) noexcept {
     return true;
 }
 
+std::atomic<int> sync_call_count{0};
+std::atomic<int> sync_failing_calls{0};
+
+// 前 sync_failing_calls 次 Sync 失败，之后成功。用来构造"CAS 已把 location 置成
+// DELETING、但 Sync 失败因而没有排队任何物理删除"的无人认领状态，再验证重试能重新
+// 走完 re-CAS + Sync + 排队。
+bool MetaIndexer_Sync_fail_first_calls_stub(void *obj, const KeyVector &keys) noexcept {
+    (void)obj;
+    (void)keys;
+    const int call_index = sync_call_count.fetch_add(1, std::memory_order_acq_rel);
+    sync_entered.store(true, std::memory_order_release);
+    return call_index >= sync_failing_calls.load(std::memory_order_acquire);
+}
+
+std::atomic<SchedulePlanExecutor *> sync_stop_executor{nullptr};
+
+// Sync 是 prepare 的最后一步，在这里 Stop 就精确落在"逻辑失效已完成、物理任务尚未
+// 入队"的窗口里 —— 这是 SubmitRaw 唯一会拒绝一批已经 DELETING 的 location 的时机。
+bool MetaIndexer_Sync_stop_executor_stub(void *obj, const KeyVector &keys) noexcept {
+    (void)obj;
+    (void)keys;
+    sync_entered.store(true, std::memory_order_release);
+    auto *executor = sync_stop_executor.exchange(nullptr, std::memory_order_acq_rel);
+    if (executor != nullptr) {
+        executor->Stop();
+    }
+    return true;
+}
+
 std::shared_ptr<MetaIndexer> MetaIndexerManager_GetMetaIndexer_throw_stub(void *obj, const std::string &instance_id) {
     (void)obj;
     (void)instance_id;
@@ -1901,4 +1930,215 @@ TEST_F(SchedulePlanExecutorTest, TestAuthoritativeAdmissionRefreshesCachedMetada
     ASSERT_EQ(1u, persistent_results.size());
     ASSERT_EQ(1u, persistent_locations.size());
     EXPECT_TRUE(persistent_results.front() == EC_NOENT || persistent_locations.front().empty());
+}
+
+// 已经是 DELETING、却没有任何在途物理任务的 location（上一次 Sync 失败、入队被拒或
+// 进程重启都会留下这种状态，GC/LRU 只回收 orphan WRITING 与缺失 SERVING，不会认领它）。
+// 同步 meta Submit 必须重新 CAS + Sync + 排队物理删除：它交给调用方的 future 承诺的是
+// 物理完成，不能因为"看起来已经有人在删"就提前完成。
+TEST_F(SchedulePlanExecutorTest, TestSubmitMetaReinvalidatesStrandedDeletingLocation) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("stranded_deleting_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    const int64_t block_key = 920;
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/stranded_deleting?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {location}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+
+    // 直接 CAS 构造 DELETING：没有经过 Submit，所以没有任何排队中的物理删除任务。
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_EQ(1u, location_maps.front().size());
+    const auto initial_status = location_maps.front().at(location_ids.front())->status();
+    std::vector<std::vector<ErrorCode>> cas_results;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchCASLocationStatus(
+                  request_context.get(),
+                  {block_key},
+                  {{MetaSearcher::LocationCASTask{
+                      location_ids.front(), initial_status, CacheLocationStatus::CLS_DELETING, ""}}},
+                  cas_results));
+    ASSERT_EQ(1u, cas_results.size());
+    ASSERT_EQ(1u, cas_results.front().size());
+    ASSERT_EQ(ErrorCode::EC_OK, cas_results.front().front());
+
+    Stub stub;
+    sync_entered.store(false);
+    sync_completed.store(false);
+    release_sync.store(true);
+    sync_delay_ms.store(0);
+    sync_thread_hash.store(0);
+    stub.set(ADDR(MetaIndexer, Sync), MetaIndexer_Sync_stub);
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    // 占住唯一的 worker：物理删除只能排队，future 在放行之前必须保持未完成。
+    auto blocker_started = std::make_shared<std::promise<void>>();
+    std::promise<void> release_blocker;
+    auto release_blocker_future = release_blocker.get_future().share();
+    ASSERT_TRUE(executor.SubmitTask([blocker_started, release_blocker_future] {
+        blocker_started->set_value();
+        release_blocker_future.wait();
+    }));
+    ASSERT_EQ(std::future_status::ready, blocker_started->get_future().wait_for(std::chrono::seconds(1)));
+
+    CacheMetaDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {block_key},
+    };
+    LogicalDeleteAdmission admission;
+    auto future = executor.Submit(request, admission);
+
+    EXPECT_EQ(ErrorCode::EC_OK, admission.status) << admission.error_message;
+    EXPECT_EQ(ErrorCode::EC_OK, admission.LogicalStatus());
+    EXPECT_EQ(1u, admission.requested_locations);
+    EXPECT_EQ(0u, admission.unresolved_locations);
+    EXPECT_TRUE(sync_entered.load(std::memory_order_acquire))
+        << "already-DELETING location must be re-CAS'd and re-Sync'd by the synchronous meta submit";
+    EXPECT_EQ(std::future_status::timeout, future.wait_for(std::chrono::milliseconds(200)))
+        << "physical-completion future must not complete before the physical delete actually runs";
+
+    release_blocker.set_value();
+    const auto result = future.get();
+    EXPECT_TRUE(result.status == ErrorCode::EC_OK || result.status == ErrorCode::EC_PARTIAL_OK) << result.error_message;
+
+    location_maps.clear();
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    EXPECT_TRUE(location_maps.empty() || location_maps.front().empty())
+        << "physical reclamation must actually progress for a stranded DELETING location";
+
+    stub.reset(ADDR(MetaIndexer, Sync));
+}
+
+// 首次 Sync 失败：CAS 已经把 location 置成 DELETING，但没有排队任何物理任务，逻辑阶段
+// 必须报错。重试必须能重新 CAS DELETING -> DELETING、再 Sync、再排队，并真正完成物理回收。
+TEST_F(SchedulePlanExecutorTest, TestSubmitMetaRetriesAfterInitialSyncFailure) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("sync_failure_retry_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    const int64_t block_key = 921;
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/sync_failure_retry?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {location}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+
+    Stub stub;
+    sync_entered.store(false);
+    sync_call_count.store(0);
+    sync_failing_calls.store(1);
+    stub.set(ADDR(MetaIndexer, Sync), MetaIndexer_Sync_fail_first_calls_stub);
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+    CacheMetaDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {block_key},
+    };
+
+    LogicalDeleteAdmission first_admission;
+    auto first_future = executor.Submit(request, first_admission);
+    EXPECT_EQ(ErrorCode::EC_ERROR, first_admission.status);
+    EXPECT_NE(std::string::npos, first_admission.error_message.find("Sync failed")) << first_admission.error_message;
+    const auto first_result = first_future.get();
+    EXPECT_EQ(ErrorCode::EC_ERROR, first_result.status) << first_result.error_message;
+
+    // 逻辑失效已经生效但无人认领：这正是需要靠重试恢复的 stranded DELETING。
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_EQ(1u, location_maps.front().size());
+    ASSERT_EQ(CacheLocationStatus::CLS_DELETING, location_maps.front().at(location_ids.front())->status());
+
+    LogicalDeleteAdmission retry_admission;
+    auto retry_future = executor.Submit(request, retry_admission);
+    EXPECT_EQ(ErrorCode::EC_OK, retry_admission.status) << retry_admission.error_message;
+    EXPECT_EQ(ErrorCode::EC_OK, retry_admission.LogicalStatus());
+    EXPECT_EQ(1u, retry_admission.requested_locations);
+    EXPECT_EQ(0u, retry_admission.unresolved_locations);
+    EXPECT_EQ(2, sync_call_count.load(std::memory_order_acquire)) << "retry must Sync again, not skip DELETING";
+
+    const auto retry_result = retry_future.get();
+    EXPECT_TRUE(retry_result.status == ErrorCode::EC_OK || retry_result.status == ErrorCode::EC_PARTIAL_OK)
+        << retry_result.error_message;
+
+    location_maps.clear();
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    EXPECT_TRUE(location_maps.empty() || location_maps.front().empty());
+
+    stub.reset(ADDR(MetaIndexer, Sync));
+}
+
+// prepare 成功（CAS + Sync 都过了）之后、物理任务入队之前 executor 被 Stop：入队失败
+// 不能只体现在物理 future 上，逻辑准入必须一起报错，否则调用方会以为失效已被 GC 接管，
+// 而 DELETING 实际上被永久搁浅。
+TEST_F(SchedulePlanExecutorTest, TestSubmitMetaReportsAdmissionFailureWhenPhysicalEnqueueRejected) {
+    ASSERT_EQ(ErrorCode::EC_OK, CreateMetaIndexer(kTestInstanceName, "local"));
+    ASSERT_EQ(ErrorCode::EC_OK, CreateDataStorage());
+
+    auto request_context = std::make_shared<RequestContext>("enqueue_rejected_test");
+    MetaSearcher meta_searcher(meta_manager_->GetMetaIndexer(kTestInstanceName));
+    const int64_t block_key = 922;
+    auto location = SchedulePlanExecutorTestHelper::CreateCacheLocation(
+        DataStorageType::DATA_STORAGE_TYPE_NFS,
+        1,
+        {SchedulePlanExecutorTestHelper::CreateLocationSpec("test_loc", "nfs://nfs_01/enqueue_rejected?size=1")});
+    std::vector<std::string> location_ids;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              BatchAddLocationForTest(&meta_searcher, request_context.get(), {block_key}, {location}, location_ids));
+    ASSERT_EQ(1u, location_ids.size());
+
+    SchedulePlanExecutor executor(1, meta_manager_, data_storage_manager_, metrics_registry_);
+
+    Stub stub;
+    sync_entered.store(false);
+    sync_stop_executor.store(&executor, std::memory_order_release);
+    stub.set(ADDR(MetaIndexer, Sync), MetaIndexer_Sync_stop_executor_stub);
+
+    CacheMetaDelRequest request{
+        .instance_id = kTestInstanceName,
+        .block_keys = {block_key},
+    };
+    LogicalDeleteAdmission admission;
+    auto future = executor.Submit(request, admission);
+
+    EXPECT_TRUE(sync_entered.load(std::memory_order_acquire)) << "the stop must land after prepare, not before it";
+    EXPECT_EQ(ErrorCode::EC_ERROR, admission.status);
+    EXPECT_NE(std::string::npos, admission.error_message.find("submit physical delete task failed"))
+        << admission.error_message;
+    EXPECT_EQ(ErrorCode::EC_ERROR, admission.LogicalStatus());
+
+    const auto result = future.get();
+    EXPECT_EQ(ErrorCode::EC_ERROR, result.status);
+    EXPECT_NE(std::string::npos, result.error_message.find("submit physical delete task failed"))
+        << result.error_message;
+
+    // DELETING 保留下来供重试；不能回滚，也不能被当成已经完成。
+    std::vector<CacheLocationMap> location_maps;
+    BlockMask empty_mask;
+    ASSERT_EQ(ErrorCode::EC_OK,
+              meta_searcher.BatchGetLocation(request_context.get(), {block_key}, empty_mask, location_maps));
+    ASSERT_EQ(1u, location_maps.size());
+    ASSERT_EQ(1u, location_maps.front().size());
+    EXPECT_EQ(CacheLocationStatus::CLS_DELETING, location_maps.front().at(location_ids.front())->status());
+
+    sync_stop_executor.store(nullptr, std::memory_order_release);
+    stub.reset(ADDR(MetaIndexer, Sync));
 }


### PR DESCRIPTION
## Problem and change

A late FinishWriteCache can publish a location after logical deletion, and synchronous RemoveCache can report success despite failed metadata reads or deletion admission. This patch uses WRITING-to-SERVING CAS for Finish, returns per-location failures, and shares strict logical admission with the existing physical deletion machinery.

- Preserve partial successes for GC while reporting unresolved locations accurately.
- Re-arm reclamation when a retry finds DELETING metadata without a live owned task.
- Keep asynchronous/location-delete semantics and existing physical GC; add no new API.
- Cover races, read/CAS/sync/enqueue failures, and compatibility cases with regression tests.

## Validation

The patch was previously tested on base `e84c334ef601288222ca97b29b86a8be7b34ab93`: 205 related cases passed under debug/ASAN; the full open-source suite had 1708 passing cases and 5 conditional skips. Tests demonstrated failures before the fixes. A pre-existing test shard-selection issue was fixed using the actual indexer shard.

This PR has been cleanly rebased onto `0d242f742e0fab2a223f6ff5fafa446cb0d22dd2`, retaining the upstream EventReport cleanup changes. C++ review and `git diff --check` passed after the rebase. **Linux tests have not been rerun on this new base**; the repository's normal and ASAN PR workflows remain the final validation gate.

## Scope

Existing read-failure EventReport cleanup and migration-admission PRs address different paths; this change handles Finish publication and synchronous delete acknowledgement. The WARN adjustment only scopes this patch's new partial-admission message to explicit admission callers. It does not replace the broader cache GC log cleanup work.

Logical admission is separate from physical completion. This does not establish a permanent tombstone against every future writer, and does not claim multi-node deployment validation.
